### PR TITLE
git-remote-entire: migrate the ENTIRE_TOKEN (CI) path to jurisdiction tokens

### DIFF
--- a/cmd/git-remote-entire/jurisdictionauth.go
+++ b/cmd/git-remote-entire/jurisdictionauth.go
@@ -6,10 +6,12 @@ package main
 // authorizes it live against regional SpiceDB, so one token covers every
 // repo the account can reach.
 //
-// The token is persisted in the OS keychain (like the login JWT) so fresh
-// git-remote-entire processes reuse it instead of paying the exchange per
-// git command — with the server-side 8h JurisdictionAccessTokenTTL that removes the
-// exchange from the hot path entirely.
+// On the interactive path the token is persisted in the OS keychain (like
+// the login JWT) so fresh git-remote-entire processes reuse it instead of
+// paying the exchange per git command — with the server-side 8h
+// JurisdictionAccessTokenTTL that removes the exchange from the hot path
+// entirely. The ENTIRE_TOKEN (CI / workload) path skips the keychain —
+// runners are ephemeral — and memoizes in-process only.
 
 import (
 	"context"
@@ -35,11 +37,10 @@ func jurisdictionKeyringService(audience string) string {
 	return "entire-jurisdiction:" + strings.TrimRight(audience, "/")
 }
 
-// jurisdictionTokenSource satisfies the same Token(ctx, audienceSuffix, action)
-// seam as repocreds.Cache but ignores the repo/action: one jurisdiction token
-// covers every repo the account can reach. Tokens come from, in order: the
-// in-process memo, the OS keychain (persisted by an earlier invocation),
-// or a fresh /oauth/token exchange (then persisted).
+// jurisdictionTokenSource mints and reuses the jurisdiction token that
+// authenticates every git request: one token covers every repo the account
+// can reach. Tokens come from, in order: the in-process memo, the OS
+// keychain (interactive path only), or a fresh /oauth/token exchange.
 type jurisdictionTokenSource struct {
 	// homeCoreURL is the login context's core — the exchange target for the
 	// common case where the cluster's jurisdiction is the login's home.
@@ -50,10 +51,24 @@ type jurisdictionTokenSource struct {
 	// audience — the cross-jurisdiction exchange endpoint. It rides the
 	// same TLS-authenticated /.well-known trust root as the audience.
 	jurisdictionCoreURL string
+	// fixedCoreURL, when set, pins the exchange to one core and disables the
+	// home/cross-jurisdiction routing (which needs a home_jurisdiction claim
+	// the ENTIRE_TOKEN path's sa-session JWTs don't carry). Set by
+	// newEnvJurisdictionTokenSource to the env token's own trust-gated core.
+	fixedCoreURL string
+	// exchangeHint, when non-empty, is appended to exchange failures. The
+	// resolver sets it when it can already see why the exchange is doomed
+	// (an ENTIRE_TOKEN from a different jurisdiction than the cluster's),
+	// turning the core's opaque invalid_target into an actionable message.
+	exchangeHint string
 	// handle is the context's account handle — the keychain account key.
 	handle string
-	login  func(context.Context) (string, error)
-	client *http.Client
+	// persist mirrors the token through the OS keychain so later processes
+	// reuse it. Off for the ENTIRE_TOKEN path: CI runners have no keychain,
+	// so the in-process memo is the only reuse.
+	persist bool
+	login   func(context.Context) (string, error)
+	client  *http.Client
 
 	mu        sync.Mutex
 	token     string
@@ -70,36 +85,53 @@ func newJurisdictionTokenSource(homeCoreURL, audience, jurisdictionCoreURL, hand
 		audience:            audience,
 		jurisdictionCoreURL: strings.TrimRight(jurisdictionCoreURL, "/"),
 		handle:              handle,
+		persist:             true,
 		login:               login,
 		client:              client,
 	}
 }
 
+// newEnvJurisdictionTokenSource is the ENTIRE_TOKEN (CI / workload) flavour:
+// the env token is the session credential, the exchange is pinned to the
+// token's own core (the caller has trust-gated it against the cluster's
+// advertised core set), and the OS keychain is never touched. exchangeHint
+// may be empty; see the field.
+func newEnvJurisdictionTokenSource(coreURL, audience, envToken, exchangeHint string, client *http.Client) *jurisdictionTokenSource {
+	return &jurisdictionTokenSource{
+		audience:     audience,
+		fixedCoreURL: strings.TrimRight(coreURL, "/"),
+		exchangeHint: exchangeHint,
+		login:        func(context.Context) (string, error) { return envToken, nil },
+		client:       client,
+	}
+}
+
 // Token returns the jurisdiction token, minting only when neither the memo nor
 // the keychain has a fresh one.
-func (s *jurisdictionTokenSource) Token(ctx context.Context, _, _ string) (string, error) {
+func (s *jurisdictionTokenSource) Token(ctx context.Context) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.token != "" && time.Now().Before(s.expiresAt) {
 		return s.token, nil
 	}
 
-	service := jurisdictionKeyringService(s.audience)
-	if encoded, err := tokenstore.Get(service, s.handle); err == nil {
-		// The empty-token guard rejects a corrupted keychain entry that
-		// decodes to a valid timestamp but no token — otherwise it would
-		// produce bare "Bearer " headers until the entry expired.
-		//
-		// Freshness margins differ by design: cross-process reuse stops at
-		// the 5m TokenExpirationBuffer (a fresh process should not start on
-		// a nearly-dead token), while this process keeps its token until
-		// SafetyMargin before actual expiry — individual git requests are
-		// short.
-		if token, expiresAt := tokenstore.DecodeTokenWithExpiration(encoded); token != "" && !tokenstore.IsTokenExpiredOrExpiring(expiresAt) {
-			debuglog.Printf("jurisdiction token from keychain (aud=%s, expires %s)", s.audience, expiresAt.Format(time.RFC3339))
-			s.token = token
-			s.expiresAt = expiresAt.Add(-repocreds.SafetyMargin)
-			return token, nil
+	if s.persist {
+		if encoded, err := tokenstore.Get(jurisdictionKeyringService(s.audience), s.handle); err == nil {
+			// The empty-token guard rejects a corrupted keychain entry that
+			// decodes to a valid timestamp but no token — otherwise it would
+			// produce bare "Bearer " headers until the entry expired.
+			//
+			// Freshness margins differ by design: cross-process reuse stops at
+			// the 5m TokenExpirationBuffer (a fresh process should not start on
+			// a nearly-dead token), while this process keeps its token until
+			// SafetyMargin before actual expiry — individual git requests are
+			// short.
+			if token, expiresAt := tokenstore.DecodeTokenWithExpiration(encoded); token != "" && !tokenstore.IsTokenExpiredOrExpiring(expiresAt) {
+				debuglog.Printf("jurisdiction token from keychain (aud=%s, expires %s)", s.audience, expiresAt.Format(time.RFC3339))
+				s.token = token
+				s.expiresAt = expiresAt.Add(-repocreds.SafetyMargin)
+				return token, nil
+			}
 		}
 	}
 
@@ -116,10 +148,12 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context, _, _ string) (strin
 	s.token = token
 	margin := min(repocreds.SafetyMargin, ttl/2)
 	s.expiresAt = time.Now().Add(ttl - margin)
-	if err := tokenstore.Set(service, s.handle, tokenstore.EncodeTokenWithExpiration(token, int64(ttl/time.Second))); err != nil {
-		// Non-fatal: the token still serves this process; the next
-		// invocation just re-mints.
-		debuglog.Printf("jurisdiction token keychain write failed: %v", err)
+	if s.persist {
+		if err := tokenstore.Set(jurisdictionKeyringService(s.audience), s.handle, tokenstore.EncodeTokenWithExpiration(token, int64(ttl/time.Second))); err != nil {
+			// Non-fatal: the token still serves this process; the next
+			// invocation just re-mints.
+			debuglog.Printf("jurisdiction token keychain write failed: %v", err)
+		}
 	}
 	return token, nil
 }
@@ -130,21 +164,25 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context, _, _ string) (strin
 // itself (signing-key rotation, expiry skew), replaying it until its
 // recorded expiry — up to the full 8h TTL — would keep every git command
 // failing. The in-flight command still fails; the next one self-heals.
+// The env-token flavour persists nothing, so only its memo is dropped.
 func (s *jurisdictionTokenSource) Invalidate() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.token = ""
 	s.expiresAt = time.Time{}
-	if err := tokenstore.Delete(jurisdictionKeyringService(s.audience), s.handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
-		debuglog.Printf("jurisdiction token keychain delete failed: %v", err)
+	if s.persist {
+		if err := tokenstore.Delete(jurisdictionKeyringService(s.audience), s.handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
+			debuglog.Printf("jurisdiction token keychain delete failed: %v", err)
+		}
 	}
-	debuglog.Printf("jurisdiction token invalidated after 401 (aud=%s); next invocation re-mints", s.audience)
+	debuglog.Printf("jurisdiction token invalidated after 401 (aud=%s); next acquisition re-mints", s.audience)
 }
 
-// mint exchanges the login JWT for a jurisdiction token at the core owning the
-// target jurisdiction. For a same-jurisdiction login that is the login's own
-// core; for a cross-jurisdiction repo the sibling core accepts our login JWT
-// via the foreign-session path and mints the jurisdiction token in the same
+// mint exchanges the session credential (login JWT or ENTIRE_TOKEN) for a
+// jurisdiction token at the core owning the target jurisdiction. For a
+// same-jurisdiction login that is the login's own core; for a
+// cross-jurisdiction repo the sibling core accepts our login JWT via the
+// foreign-session path and mints the jurisdiction token in the same
 // single POST.
 func (s *jurisdictionTokenSource) mint(ctx context.Context) (string, time.Duration, error) {
 	loginJWT, err := s.login(ctx)
@@ -161,7 +199,7 @@ func (s *jurisdictionTokenSource) mint(ctx context.Context) (string, time.Durati
 
 	token, expiresIn, err := httputil.PostOAuthToken(ctx, s.client, coreURL, form)
 	if err != nil {
-		return "", 0, fmt.Errorf("jurisdiction token exchange (aud=%s at %s): %w", s.audience, coreURL, err)
+		return "", 0, fmt.Errorf("jurisdiction token exchange (aud=%s at %s): %w%s", s.audience, coreURL, err, s.exchangeHint)
 	}
 	if strings.TrimSpace(token) == "" {
 		return "", 0, errors.New("jurisdiction token exchange returned an empty access token")
@@ -171,13 +209,20 @@ func (s *jurisdictionTokenSource) mint(ctx context.Context) (string, time.Durati
 	return token, ttl, nil
 }
 
-// exchangeCore picks the core to exchange at: the login's own core when the
-// audience is in the login's home jurisdiction, else the cluster's
+// exchangeCore picks the core to exchange at. A pinned core (ENTIRE_TOKEN
+// path) wins outright — the trust gate in resolveEnvTokenCreds guarantees
+// it fronts the target cluster, so it owns the cluster's jurisdiction
+// audience and no routing is needed. Otherwise: the login's own core when
+// the audience is in the login's home jurisdiction, else the cluster's
 // advertised jurisdiction core. The home core is the issuer the user logged
 // in at, used verbatim (it may legitimately be loopback http in local dev);
 // the advertised core comes from a foreign cluster's /.well-known, so it
 // must be https before the login JWT is POSTed to it.
 func (s *jurisdictionTokenSource) exchangeCore(loginJWT string) (string, error) {
+	if s.fixedCoreURL != "" {
+		return s.fixedCoreURL, nil
+	}
+
 	label, err := jurisdictionLabel(s.audience)
 	if err != nil {
 		return "", err

--- a/cmd/git-remote-entire/jurisdictionauth_test.go
+++ b/cmd/git-remote-entire/jurisdictionauth_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -98,6 +99,20 @@ func TestExchangeCore(t *testing.T) {
 			t.Fatal("expected error for plaintext advertised core")
 		}
 	})
+
+	t.Run("env path pins the token's core", func(t *testing.T) {
+		t.Parallel()
+		// sa-session JWTs carry no home_jurisdiction claim; the pinned core
+		// must win without ever parsing the subject token for routing.
+		s := newEnvJurisdictionTokenSource("https://core.us.entire.io/", "https://us.entire.io", "env-jwt", "", nil)
+		core, err := s.exchangeCore("not-even-a-jwt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if core != "https://core.us.entire.io" {
+			t.Fatalf("core = %q, want pinned trimmed core", core)
+		}
+	})
 }
 
 func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
@@ -123,7 +138,7 @@ func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 	login := staticLogin(fakeLoginJWT(t, "eu"))
 	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
 
-	token, err := s.Token(context.Background(), "/et/x/y", "pull")
+	token, err := s.Token(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +150,7 @@ func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 	}
 
 	// Same source: memoized, no second exchange.
-	if _, err := s.Token(context.Background(), "/et/x/y", "push"); err != nil {
+	if _, err := s.Token(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if mints != 1 {
@@ -144,7 +159,7 @@ func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 
 	// Fresh source (new process): served from the persisted keychain entry.
 	s2 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
-	token2, err := s2.Token(context.Background(), "/et/x/y", "pull")
+	token2, err := s2.Token(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +172,7 @@ func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 
 	// A different handle must not share the token.
 	s3 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "other-account", login, core.Client())
-	if _, err := s3.Token(context.Background(), "/et/x/y", "pull"); err != nil {
+	if _, err := s3.Token(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if mints != 2 {
@@ -179,7 +194,7 @@ func TestJurisdictionToken_InvalidateDropsMemoAndKeychain(t *testing.T) {
 
 	login := staticLogin(fakeLoginJWT(t, "eu"))
 	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
-	if _, err := s.Token(context.Background(), "/et/x/y", "pull"); err != nil {
+	if _, err := s.Token(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if mints != 1 {
@@ -189,7 +204,7 @@ func TestJurisdictionToken_InvalidateDropsMemoAndKeychain(t *testing.T) {
 	s.Invalidate()
 
 	// Memo gone: this source re-mints.
-	if _, err := s.Token(context.Background(), "/et/x/y", "pull"); err != nil {
+	if _, err := s.Token(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if mints != 2 {
@@ -201,7 +216,7 @@ func TestJurisdictionToken_InvalidateDropsMemoAndKeychain(t *testing.T) {
 	// a new entry, so invalidate again to observe the delete.)
 	s.Invalidate()
 	s2 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
-	if _, err := s2.Token(context.Background(), "/et/x/y", "pull"); err != nil {
+	if _, err := s2.Token(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if mints != 3 {
@@ -231,7 +246,7 @@ func TestJurisdictionToken_EmptyPersistedTokenRemints(t *testing.T) {
 	defer core.Close()
 
 	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
-	token, err := s.Token(context.Background(), "/et/x/y", "pull")
+	token, err := s.Token(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,11 +276,99 @@ func TestJurisdictionToken_ExpiredPersistedTokenRemints(t *testing.T) {
 	defer core.Close()
 
 	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
-	token, err := s.Token(context.Background(), "/et/x/y", "pull")
+	token, err := s.Token(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if token != "fresh-jwt" || mints != 1 {
 		t.Fatalf("token = %q mints = %d, want fresh mint", token, mints)
+	}
+}
+
+func TestEnvJurisdictionToken_MintsInMemoryOnly(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	defer restore()
+
+	const audience = "https://eu.example.io"
+	const envToken = "env-sa-session-jwt"
+	mints := 0
+	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mints++
+		if got := r.FormValue("subject_token"); got != envToken {
+			t.Errorf("subject_token = %q, want the ENTIRE_TOKEN verbatim", got)
+		}
+		if got := r.FormValue("audience"); got != audience {
+			t.Errorf("audience = %q, want %q", got, audience)
+		}
+		if got := r.FormValue("scope"); got != "openid" {
+			t.Errorf("scope = %q, want openid", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"env-juri-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
+	}))
+	defer core.Close()
+
+	s := newEnvJurisdictionTokenSource(core.URL, audience, envToken, "", core.Client())
+	token, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "env-juri-jwt" || mints != 1 {
+		t.Fatalf("token = %q mints = %d, want one mint", token, mints)
+	}
+
+	// Same source: memoized, no second exchange.
+	if _, err := s.Token(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mints != 1 {
+		t.Fatalf("mints after memo hit = %d, want 1", mints)
+	}
+
+	// Invalidate (data-plane 401) drops the memo without touching the token
+	// store — the next acquisition in this process re-mints.
+	s.Invalidate()
+	if _, err := s.Token(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mints != 2 {
+		t.Fatalf("mints after invalidate = %d, want 2", mints)
+	}
+
+	// Nothing may be persisted: a fresh source (new helper process) re-mints,
+	// and the token store has no entry under the jurisdiction service.
+	s2 := newEnvJurisdictionTokenSource(core.URL, audience, envToken, "", core.Client())
+	if _, err := s2.Token(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mints != 3 {
+		t.Fatalf("mints for fresh env source = %d, want 3 (no persistence)", mints)
+	}
+	if _, err := tokenstore.Get(jurisdictionKeyringService(audience), ""); err == nil {
+		t.Fatal("env path must not write the jurisdiction token to the token store")
+	}
+}
+
+func TestEnvJurisdictionToken_ExchangeHintDecoratesFailure(t *testing.T) {
+	t.Parallel()
+
+	// A cross-jurisdiction ENTIRE_TOKEN reaches the wrong core, which
+	// refuses the audience with an opaque invalid_target. The pre-computed
+	// hint must ride the error so the CI operator learns the actual fix.
+	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_target"}`)) //nolint:errcheck // test
+	}))
+	defer core.Close()
+
+	const hint = "\nENTIRE_TOKEN was minted at X, but cluster Y's jurisdiction core is Z — point your CI auth url at Z"
+	s := newEnvJurisdictionTokenSource(core.URL, "https://au.example.io", "env-jwt", hint, core.Client())
+	_, err := s.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected the exchange to fail")
+	}
+	if !strings.HasSuffix(err.Error(), hint) {
+		t.Fatalf("error must end with the cross-jurisdiction hint, got: %v", err)
 	}
 }

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -14,8 +14,8 @@
 // Authentication resolves the login context for the target cluster from the
 // shared contexts.json: the cluster's cores come from the cluster_cores.json
 // cache (or a live /.well-known fetch on miss), then the account is selected
-// from local contexts. It then mints repo-scoped tokens by exchanging that
-// context's login JWT.
+// from local contexts. It then mints a jurisdiction access token by
+// exchanging that context's login JWT (or ENTIRE_TOKEN in CI).
 package main
 
 import (
@@ -38,7 +38,6 @@ import (
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/httpclient"
 	"github.com/entireio/cli/internal/entireclient/httputil"
-	"github.com/entireio/cli/internal/entireclient/repocreds"
 	"github.com/entireio/cli/internal/entireclient/userdirs"
 	"github.com/entireio/cli/internal/remotehelper"
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
@@ -101,11 +100,6 @@ func run(args []string) int {
 	skipTLS := os.Getenv("ENTIRE_TLS_SKIP_VERIFY") == "true"
 
 	nodeCfg := replicas.Resolve(parsedURL)
-	// The repo-scoped token's audience is <clusterBaseURL><repoSlug>. The
-	// audience pins to the cluster entry URL (not a replica node), matching
-	// what the server validates the exchanged token against.
-	clusterBaseURL := nodeCfg.EntryURL
-	repoSlug := parsedURL.Path
 
 	// This client drives the auth path only: cluster /.well-known discovery
 	// and the token exchange. Both talk to a single control-plane host with no
@@ -124,7 +118,7 @@ func run(args []string) int {
 		},
 	}
 
-	creds, err := resolveCreds(ctx, parsedURL, clusterBaseURL, skipTLS, httpClient)
+	creds, err := resolveCreds(ctx, parsedURL, skipTLS, httpClient)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 		return 128
@@ -134,14 +128,13 @@ func run(args []string) int {
 		// Refuse to attach credentials to a request we can't classify as a
 		// known git smart-HTTP endpoint. The jurisdiction token doesn't
 		// need the action, but sending a bearer to an unexpected endpoint
-		// is never right; the ENTIRE_TOKEN scoped path additionally needs
-		// pull/push to mint.
+		// is never right.
 		action := gitActionFromRequest(req)
 		if action == "" {
 			return fmt.Errorf("refusing to attach credentials: %s %s is not a recognised git smart-HTTP endpoint", req.Method, req.URL.Path)
 		}
 		start := time.Now()
-		token, err := creds.Token(req.Context(), repoSlug, action)
+		token, err := creds.Token(req.Context())
 		if err != nil {
 			return fmt.Errorf("git credential exchange: %w", err)
 		}
@@ -155,23 +148,18 @@ func run(args []string) int {
 		onNodeFailed = func(string) { replicas.Invalidate(nodeCfg.ClusterHost, nodeCfg.RepoPath) }
 	}
 
-	// A 401 means the data plane rejected the credential itself (e.g.
-	// signing-key rotation invalidated a persisted jurisdiction token) —
-	// drop it so the next invocation re-mints instead of failing until the
-	// token's recorded expiry. The env-token source has nothing persisted
-	// to drop and doesn't implement the seam.
-	var onUnauthorized func()
-	if invalidator, ok := creds.(interface{ Invalidate() }); ok {
-		onUnauthorized = invalidator.Invalidate
-	}
-
 	proxy := transport.New(transport.Config{
-		Nodes:          nodeCfg,
-		Path:           parsedURL.Path,
-		SkipTLS:        skipTLS,
-		SetAuth:        setAuth,
+		Nodes:   nodeCfg,
+		Path:    parsedURL.Path,
+		SkipTLS: skipTLS,
+		SetAuth: setAuth,
+		// A 401 means the data plane rejected the credential itself (e.g.
+		// signing-key rotation invalidated a persisted jurisdiction token) —
+		// drop it so the next invocation re-mints instead of failing until
+		// the token's recorded expiry. The env-token source persists
+		// nothing; it drops only its in-process memo.
+		OnUnauthorized: creds.Invalidate,
 		OnNodeFailed:   onNodeFailed,
-		OnUnauthorized: onUnauthorized,
 		UserAgent:      httpUserAgent,
 	})
 
@@ -275,24 +263,19 @@ func parseProtocolVersion(raw string, warn io.Writer) int {
 	return defaultVersion
 }
 
-// tokenSource is the one-method seam setAuth needs: repocreds.Cache
-// (repo-scoped tokens) and jurisdictionTokenSource (jurisdiction
-// access tokens) both satisfy it.
-type tokenSource interface {
-	Token(ctx context.Context, audienceSuffix, action string) (string, error)
-}
-
-// resolveCreds builds the git-credential source, choosing by auth model:
+// resolveCreds builds the git-credential source. Both paths mint a
+// jurisdiction access token; they differ in what session credential seeds
+// the exchange and where the token is cached:
 //
-//   - ENTIRE_TOKEN set: use the env JWT verbatim as the login token, deriving
-//     the login server URL from its aud claim. Skips contexts.json and the keyring
-//     entirely — the CI / workload-identity path, still minting per-(repo,action)
-//     scoped tokens. A non-URL aud is a hard error, never a silent fallback
-//     to context resolution.
+//   - ENTIRE_TOKEN set: use the env JWT verbatim as the session credential,
+//     exchanging it at the core derived from its aud claim. Skips
+//     contexts.json and the keyring entirely — the CI / workload path,
+//     memoized in-process only. A non-URL aud is a hard error, never a
+//     silent fallback to context resolution.
 //   - otherwise: resolve the login context for this cluster from contexts.json
 //     and mint a keychain-persisted jurisdiction access token from its
 //     stored login JWT.
-func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string, skipTLS bool, httpClient *http.Client) (tokenSource, error) {
+func resolveCreds(ctx context.Context, parsedURL *url.URL, skipTLS bool, httpClient *http.Client) (*jurisdictionTokenSource, error) {
 	// Presence of ENTIRE_TOKEN is the signal: if it's set at all (LookupEnv,
 	// not Getenv, so we can tell set-empty from unset), we commit to the
 	// env-token path and any failure to use it is fatal — never a silent
@@ -306,7 +289,7 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 		if envToken == "" {
 			return nil, fmt.Errorf("%s is set but blank", auth.EnvTokenVar)
 		}
-		return resolveEnvTokenCreds(ctx, envToken, parsedURL.Host, clusterBaseURL, userdirs.Cache(), httpClient)
+		return resolveEnvTokenCreds(ctx, envToken, parsedURL.Host, userdirs.Cache(), httpClient)
 	}
 
 	// Resolve which login context authenticates this cluster: the cluster's
@@ -323,7 +306,7 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 
 	// The login-JWT provider transparently refreshes an expired login JWT
 	// from the stored refresh token (serialised across processes, rotated
-	// tokens persisted) before repocreds exchanges it for repo-scoped tokens.
+	// tokens persisted) before the jurisdiction-token exchange consumes it.
 	loginProvider, err := auth.NewRefreshingLoginProvider(clusterCtx, httpClient.Transport, skipTLS)
 	if err != nil {
 		return nil, err //nolint:wrapcheck // NewRefreshingLoginProvider already returns a user-facing error
@@ -335,16 +318,21 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 	// audience.
 	audience := clusterAuth.JurisdictionAudience
 	if audience == "" {
-		return nil, fmt.Errorf("cluster %s advertises no jurisdiction_audience at %s; its entire-server predates jurisdiction-token git auth", parsedURL.Host, clusterdiscovery.Path)
+		return nil, missingJurisdictionAudienceErr(parsedURL.Host)
 	}
 	debuglog.Printf("auth: jurisdiction access token (aud=%s, core=%s)", audience, clusterCtx.CoreURL)
 	return newJurisdictionTokenSource(clusterCtx.CoreURL, audience, clusterAuth.JurisdictionCoreURL, clusterCtx.Handle, loginProvider, httpClient), nil
 }
 
-// resolveEnvTokenCreds builds the repo-cred cache for the ENTIRE_TOKEN path.
-// Split out of resolveCreds with explicit clusterHost/cacheDir params (no
-// os.Getenv / userdirs.Cache globals) so the trust gate below is unit-testable
-// against a fake well-known server.
+// resolveEnvTokenCreds builds the jurisdiction-token source for the
+// ENTIRE_TOKEN path. Split out of resolveCreds with explicit
+// clusterHost/cacheDir params (no os.Getenv / userdirs.Cache globals) so the
+// trust gate below is unit-testable against a fake well-known server.
+//
+// The exchange runs at the env token's own core with the cluster's advertised
+// jurisdiction audience. No home/cross-jurisdiction routing is needed: the
+// trust gate guarantees that core fronts the target cluster, so it owns the
+// cluster's jurisdiction audience.
 //
 // SECURITY: coreURL is derived from the env token's *unverified* aud claim, and
 // it becomes the host the token is POSTed to as a subject_token during
@@ -357,24 +345,56 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 // ENTIRE_TLS_SKIP_VERIFY=true (a local-dev escape hatch) the well-known fetch
 // is no longer authenticated, so a MITM could advertise an attacker host as a
 // trusted core. Do not combine ENTIRE_TOKEN with ENTIRE_TLS_SKIP_VERIFY in
-// CI / workload-identity environments.
-func resolveEnvTokenCreds(ctx context.Context, envToken, clusterHost, clusterBaseURL, cacheDir string, httpClient *http.Client) (*repocreds.Cache, error) {
+// CI / workload environments.
+func resolveEnvTokenCreds(ctx context.Context, envToken, clusterHost, cacheDir string, httpClient *http.Client) (*jurisdictionTokenSource, error) {
 	coreURL, err := auth.CoreURLFromEnvToken(envToken)
 	if err != nil {
 		return nil, err //nolint:wrapcheck // CoreURLFromEnvToken already returns a user-facing, ENTIRE_TOKEN-prefixed error
 	}
-	cores, err := clusterdiscovery.ResolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debuglog.Printf)
+	cluster, err := clusterdiscovery.ResolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debuglog.Printf)
 	if err != nil {
 		return nil, err //nolint:wrapcheck // ResolveClusterCores returns a user-facing discovery error
 	}
-	if !coreTrusted(coreURL, cores) {
+	if !coreTrusted(coreURL, cluster.CoreURLs) {
 		return nil, fmt.Errorf("%s aud %q is not a trusted login server for cluster %s (advertised: %s); the token belongs to a different cluster",
-			auth.EnvTokenVar, coreURL, clusterHost, strings.Join(cores, ", "))
+			auth.EnvTokenVar, coreURL, clusterHost, strings.Join(cluster.CoreURLs, ", "))
 	}
-	debuglog.Printf("authenticating via %s; core=%s", auth.EnvTokenVar, coreURL)
-	return repocreds.New(coreURL, clusterBaseURL, func(context.Context) (string, error) {
-		return envToken, nil
-	}, httpClient), nil
+	if cluster.JurisdictionAudience == "" {
+		return nil, missingJurisdictionAudienceErr(clusterHost)
+	}
+	hint := crossJurisdictionHint(coreURL, clusterHost, cluster.JurisdictionCoreURL)
+	if hint != "" {
+		debuglog.Printf("auth: %s core %s differs from cluster %s's jurisdiction core %s; the exchange will likely be refused", auth.EnvTokenVar, coreURL, clusterHost, cluster.JurisdictionCoreURL)
+	}
+	debuglog.Printf("auth: %s jurisdiction access token (aud=%s, core=%s)", auth.EnvTokenVar, cluster.JurisdictionAudience, coreURL)
+	return newEnvJurisdictionTokenSource(coreURL, cluster.JurisdictionAudience, envToken, hint, httpClient), nil
+}
+
+// crossJurisdictionHint pre-computes the actionable message for the one
+// misconfiguration the trust gate can't catch: an ENTIRE_TOKEN minted at a
+// core of a different jurisdiction than the cluster's. Clusters advertise
+// every jurisdiction's cores as trusted login servers, so such a token
+// passes the gate — but the exchange is doomed, because only the cluster's
+// own jurisdiction core mints for its audience, and the core-side refusal
+// is an opaque invalid_target. Returned as a suffix for that eventual
+// exchange error rather than a hard pre-flight failure: clusters may
+// advertise several same-jurisdiction core URLs, so inequality here is a
+// strong hint, not proof.
+func crossJurisdictionHint(coreURL, clusterHost, jurisdictionCoreURL string) string {
+	if jurisdictionCoreURL == "" {
+		return ""
+	}
+	if strings.EqualFold(strings.TrimRight(coreURL, "/"), strings.TrimRight(jurisdictionCoreURL, "/")) {
+		return ""
+	}
+	return fmt.Sprintf("\n%s was minted at %s, but cluster %s's jurisdiction core is %s — point your CI auth url at %s",
+		auth.EnvTokenVar, coreURL, clusterHost, jurisdictionCoreURL, jurisdictionCoreURL)
+}
+
+// missingJurisdictionAudienceErr names the one condition both auth paths
+// refuse on: a cluster that predates jurisdiction-token git auth.
+func missingJurisdictionAudienceErr(clusterHost string) error {
+	return fmt.Errorf("cluster %s advertises no jurisdiction_audience at %s; its entire-server predates jurisdiction-token git auth", clusterHost, clusterdiscovery.Path)
 }
 
 // coreTrusted reports whether coreURL is in the cluster's advertised core
@@ -390,9 +410,11 @@ func coreTrusted(coreURL string, trusted []string) bool {
 	return false
 }
 
-// gitActionFromRequest classifies a smart-HTTP request as "pull" or "push"
-// so the right repo-scoped token can be minted. Returns "" when the
-// endpoint isn't a recognised git smart-HTTP route.
+// gitActionFromRequest classifies a smart-HTTP request as "pull" or "push".
+// The jurisdiction token doesn't vary by action, but the classification
+// still gates which endpoints may carry credentials (and labels the timing
+// logs). Returns "" when the endpoint isn't a recognised git smart-HTTP
+// route.
 func gitActionFromRequest(req *http.Request) string {
 	path := req.URL.Path
 	switch req.Method {

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -216,16 +216,25 @@ func makeTestJWT(t *testing.T, aud string) string {
 	return header + "." + payload + "." + enc.EncodeToString([]byte("sig"))
 }
 
-// wellKnownServer serves /.well-known/entire-cluster.json advertising the given
-// cores over TLS, returning the server and the host:port to use as clusterHost.
-func wellKnownServer(t *testing.T, cores []string) (*httptest.Server, string) {
+// wellKnownServer serves /.well-known/entire-cluster.json advertising the
+// given cores, jurisdiction audience, and jurisdiction core over TLS,
+// returning the server and the host:port to use as clusterHost. An empty
+// audience models a cluster predating jurisdiction-token git auth.
+func wellKnownServer(t *testing.T, cores []string, jurisdictionAudience, jurisdictionCoreURL string) (*httptest.Server, string) {
 	t.Helper()
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/.well-known/entire-cluster.json" {
 			http.NotFound(w, r)
 			return
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"core_urls": cores}) //nolint:errcheck // best-effort in test stub
+		body := map[string]any{"core_urls": cores}
+		if jurisdictionAudience != "" {
+			body["jurisdiction_audience"] = jurisdictionAudience
+		}
+		if jurisdictionCoreURL != "" {
+			body["jurisdiction_core_url"] = jurisdictionCoreURL
+		}
+		_ = json.NewEncoder(w).Encode(body) //nolint:errcheck // best-effort in test stub
 	}))
 	t.Cleanup(srv.Close)
 	u, err := url.Parse(srv.URL)
@@ -238,17 +247,94 @@ func wellKnownServer(t *testing.T, cores []string) (*httptest.Server, string) {
 func TestResolveEnvTokenCreds_TrustedAudSucceeds(t *testing.T) {
 	t.Parallel()
 	const core = "https://core.us.entire.io"
-	srv, clusterHost := wellKnownServer(t, []string{core})
+	const audience = "https://us.entire.io"
+	srv, clusterHost := wellKnownServer(t, []string{core}, audience, core)
 
 	creds, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, core), clusterHost,
-		"https://cluster.example.com", t.TempDir(), srv.Client(),
+		t.Context(), makeTestJWT(t, core), clusterHost, t.TempDir(), srv.Client(),
 	)
 	if err != nil {
 		t.Fatalf("expected trusted aud to succeed, got: %v", err)
 	}
 	if creds == nil {
 		t.Fatal("expected non-nil creds for trusted aud")
+	}
+	// The exchange must be pinned to the token's own (trust-gated) core with
+	// the cluster's advertised jurisdiction audience, and must never touch
+	// the keychain — CI runners don't have one.
+	if creds.fixedCoreURL != core {
+		t.Errorf("fixedCoreURL = %q, want %q", creds.fixedCoreURL, core)
+	}
+	if creds.audience != audience {
+		t.Errorf("audience = %q, want %q", creds.audience, audience)
+	}
+	if creds.persist {
+		t.Error("env-token creds must not persist to the keychain")
+	}
+	if creds.exchangeHint != "" {
+		t.Errorf("no cross-jurisdiction hint expected when the token's core is the jurisdiction core, got %q", creds.exchangeHint)
+	}
+}
+
+func TestResolveEnvTokenCreds_CrossJurisdictionTokenGetsHint(t *testing.T) {
+	t.Parallel()
+	// Clusters advertise every jurisdiction's cores, so a token minted at a
+	// sibling core passes the trust gate — but the exchange at that core is
+	// doomed. The resolver must pre-compute the actionable hint that the
+	// eventual exchange failure surfaces.
+	const tokenCore = "https://core.eu.entire.io"
+	const jurisdictionCore = "https://core.us.entire.io"
+	srv, clusterHost := wellKnownServer(t, []string{tokenCore, jurisdictionCore}, "https://us.entire.io", jurisdictionCore)
+
+	creds, err := resolveEnvTokenCreds(
+		t.Context(), makeTestJWT(t, tokenCore), clusterHost, t.TempDir(), srv.Client(),
+	)
+	if err != nil {
+		t.Fatalf("cross-jurisdiction token must still resolve (it fails at exchange time), got: %v", err)
+	}
+	for _, want := range []string{tokenCore, clusterHost, "point your CI auth url at " + jurisdictionCore} {
+		if !strings.Contains(creds.exchangeHint, want) {
+			t.Errorf("exchangeHint missing %q, got %q", want, creds.exchangeHint)
+		}
+	}
+}
+
+func TestCrossJurisdictionHint_SameCoreVariantsStaySilent(t *testing.T) {
+	t.Parallel()
+	// Trailing-slash and case differences are the same core — a hint there
+	// would cry wolf on healthy configs. An unadvertised jurisdiction core
+	// (pre-upgrade server) also stays silent: there is nothing to point at.
+	for _, tc := range []struct{ name, coreURL, jurisdictionCoreURL string }{
+		{"exact", "https://core.us.entire.io", "https://core.us.entire.io"},
+		{"trailing slash", "https://core.us.entire.io/", "https://core.us.entire.io"},
+		{"case", "https://CORE.us.entire.io", "https://core.us.entire.io"},
+		{"unadvertised", "https://core.us.entire.io", ""},
+	} {
+		if hint := crossJurisdictionHint(tc.coreURL, "cluster.example.com", tc.jurisdictionCoreURL); hint != "" {
+			t.Errorf("%s: expected no hint, got %q", tc.name, hint)
+		}
+	}
+}
+
+func TestResolveEnvTokenCreds_MissingJurisdictionAudienceAborts(t *testing.T) {
+	t.Parallel()
+	// The cluster's core set trusts the token, but the cluster predates
+	// jurisdiction-token git auth (no jurisdiction_audience). With no
+	// repo-scoped fallback left, this must fail closed with the upgrade hint.
+	const core = "https://core.us.entire.io"
+	srv, clusterHost := wellKnownServer(t, []string{core}, "", "")
+
+	creds, err := resolveEnvTokenCreds(
+		t.Context(), makeTestJWT(t, core), clusterHost, t.TempDir(), srv.Client(),
+	)
+	if err == nil {
+		t.Fatal("expected missing jurisdiction_audience to be rejected")
+	}
+	if creds != nil {
+		t.Fatal("expected nil creds when the cluster advertises no jurisdiction_audience")
+	}
+	if !strings.Contains(err.Error(), "jurisdiction_audience") {
+		t.Fatalf("expected jurisdiction_audience error, got: %v", err)
 	}
 }
 
@@ -260,7 +346,7 @@ func TestResolveCreds_BlankEnvTokenFailsClosed(t *testing.T) {
 	dummyURL := &url.URL{Scheme: "entire", Host: "cluster.example.com"}
 	for _, blank := range []string{"", " ", "\t", "\n", " \t\n "} {
 		t.Setenv(auth.EnvTokenVar, blank)
-		creds, err := resolveCreds(t.Context(), dummyURL, "https://cluster.example.com", false, nil)
+		creds, err := resolveCreds(t.Context(), dummyURL, false, nil)
 		if err == nil {
 			t.Fatalf("blank ENTIRE_TOKEN %q should fail closed", blank)
 		}
@@ -277,11 +363,10 @@ func TestResolveEnvTokenCreds_UntrustedAudAborts(t *testing.T) {
 	t.Parallel()
 	// The cluster advertises only core.us; the token's aud points elsewhere.
 	// The gate must abort before building creds (i.e. before any exchange).
-	srv, clusterHost := wellKnownServer(t, []string{"https://core.us.entire.io"})
+	srv, clusterHost := wellKnownServer(t, []string{"https://core.us.entire.io"}, "https://us.entire.io", "https://core.us.entire.io")
 
 	creds, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, "https://attacker.example.com"), clusterHost,
-		"https://cluster.example.com", t.TempDir(), srv.Client(),
+		t.Context(), makeTestJWT(t, "https://attacker.example.com"), clusterHost, t.TempDir(), srv.Client(),
 	)
 	if err == nil {
 		t.Fatal("expected untrusted aud to be rejected")
@@ -298,11 +383,10 @@ func TestResolveEnvTokenCreds_EmptyAdvertisedCoresAborts(t *testing.T) {
 	t.Parallel()
 	// Discovery succeeds (HTTP 200) but advertises no cores. With nothing to
 	// trust, the gate must fail closed rather than trusting the token's aud.
-	srv, clusterHost := wellKnownServer(t, []string{})
+	srv, clusterHost := wellKnownServer(t, []string{}, "https://us.entire.io", "https://core.us.entire.io")
 
 	creds, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, "https://core.us.entire.io"), clusterHost,
-		"https://cluster.example.com", t.TempDir(), srv.Client(),
+		t.Context(), makeTestJWT(t, "https://core.us.entire.io"), clusterHost, t.TempDir(), srv.Client(),
 	)
 	if err == nil {
 		t.Fatal("expected empty advertised core set to be rejected")
@@ -326,8 +410,7 @@ func TestResolveEnvTokenCreds_DiscoveryFailureAborts(t *testing.T) {
 	}
 
 	creds, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, "https://core.us.entire.io"), u.Host,
-		"https://cluster.example.com", t.TempDir(), srv.Client(),
+		t.Context(), makeTestJWT(t, "https://core.us.entire.io"), u.Host, t.TempDir(), srv.Client(),
 	)
 	if err == nil {
 		t.Fatal("expected discovery failure to abort")
@@ -342,8 +425,7 @@ func TestResolveEnvTokenCreds_MalformedTokenAborts(t *testing.T) {
 	// A malformed aud must fail at the parse/validate step, before any network
 	// discovery happens — so a nil httpClient is safe here.
 	creds, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, "http://core.us.entire.io"), "cluster.example.com",
-		"https://cluster.example.com", t.TempDir(), nil,
+		t.Context(), makeTestJWT(t, "http://core.us.entire.io"), "cluster.example.com", t.TempDir(), nil,
 	)
 	if err == nil {
 		t.Fatal("expected http aud to be rejected before discovery")

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -110,22 +110,21 @@ func resolveClusterAuth(ctx context.Context, configDir, cacheDir, clusterHost st
 	}, nil
 }
 
-// ResolveClusterCores returns the trusted control-plane core URLs that
-// front clusterHost, using the same cache-then-/.well-known discovery as
-// ResolveContextForCluster (see resolveClusterCores). Exported for callers
-// that need the cluster's trusted-core set without account selection — e.g.
+// ResolveClusterCores returns the cluster's discovery entry — the trusted
+// control-plane core URLs that front clusterHost plus its advertised
+// jurisdiction audience/core — using the same cache-then-/.well-known
+// discovery as ResolveContextForCluster (see resolveClusterCores). Exported
+// for callers that need the cluster facts without account selection — e.g.
 // the ENTIRE_TOKEN path validates that the env token's audience is one of
-// these before exchanging it, so an unverified JWT can't redirect the
-// token exchange to an attacker-chosen host.
-func ResolveClusterCores(ctx context.Context, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) ([]string, error) {
+// the advertised cores before exchanging it, so an unverified JWT can't
+// redirect the token exchange to an attacker-chosen host. Its sole caller
+// mints jurisdiction tokens, so the audience-requiring cache semantics
+// apply (see resolveCachedCores).
+func ResolveClusterCores(ctx context.Context, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) (*discovery.CoresEntry, error) {
 	if debugf == nil {
 		debugf = func(string, ...any) {}
 	}
-	entry, err := resolveClusterCores(ctx, cacheDir, normalizeClusterHost(clusterHost), false, httpClient, debugf)
-	if err != nil {
-		return nil, err
-	}
-	return entry.CoreURLs, nil
+	return resolveClusterCores(ctx, cacheDir, normalizeClusterHost(clusterHost), true, httpClient, debugf)
 }
 
 // normalizeClusterHost folds a cluster host to its canonical form for use as a
@@ -146,7 +145,7 @@ func normalizeClusterHost(clusterHost string) string {
 // label names the resource in debug output ("cluster" / "api host").
 //
 // requireAudience marks callers that cannot proceed without the entry's
-// jurisdiction audience (the interactive git path). For them, an entry
+// jurisdiction audience (both git auth paths). For them, an entry
 // cached before the cluster advertised an audience is treated as stale so
 // the upgrade is picked up immediately instead of after the 24h TTL — and
 // an audience-less entry is NOT used as the discovery-failure fallback:


### PR DESCRIPTION
Stacked on #1621. Fixes COR-847.

## Why

The `ENTIRE_TOKEN` (CI / Buildkite) path was the last client of the repo-scoped exchange, paying it per (repo, action) on every git command — that's also happening in CI.

## What

- `resolveEnvTokenCreds` now mints a jurisdiction access token instead of building a `repocreds.Cache`: audience = the cluster's advertised `jurisdiction_audience`, exchanged at the core derived from the token's `aud` claim (unchanged trust gate against the cluster's advertised core set). A cluster advertising no `jurisdiction_audience` fails closed with the same upgrade hint as the interactive path (shared `missingJurisdictionAudienceErr`).
- The env flavour pins the exchange core (sa-session JWTs carry no `home_jurisdiction` claim to route by) and never touches the OS keychain — in-process memo only; `Invalidate()` (the 401 observer) drops just the memo.
- Both paths now return `*jurisdictionTokenSource`, so the `tokenSource` interface, the repocreds dependency in git-remote-entire, and the unused `clusterBaseURL` plumbing are gone. `Token()` drops its ignored (repo, action) params; the smart-HTTP endpoint classification stays as the credential-attachment gate.
- `clusterdiscovery.ResolveClusterCores` returns the full discovery entry and adopts the audience-requiring cache semantics (pre-audience entries refetched, no audience-less stale fallback) — its sole caller is now audience-requiring.

Verified server-side that the exchange gates hold for CI subjects: sa-session tokens carry `LoginScopes` ⊇ `entire:session` (passes `validateIdentityExchange`), have `aud == iss`, and are explicitly carved out of the fid-liveness gate. No entiredb change needed.

## Follow-up

- Sunset `validateRepoExchange` server-side once nothing mints repo-scoped tokens (needs a released helper + bumped Buildkite plugin pin).

## Tests

- `go test ./...` green; new tests: env source pins the token's core, mints in-memory only (no token-store writes, memo-only Invalidate), missing `jurisdiction_audience` fails closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication for all CI git operations and removes the repo-scoped fallback; clusters without jurisdiction_audience will fail until upgraded, but the existing ENTIRE_TOKEN trust gate and fail-closed behavior are preserved.
> 
> **Overview**
> **CI / `ENTIRE_TOKEN` auth now uses jurisdiction access tokens** instead of per-(repo, action) repo-scoped exchanges, so Buildkite-style runners pay one exchange per process (memoized) rather than on every git command.
> 
> `resolveEnvTokenCreds` builds `newEnvJurisdictionTokenSource`: exchange at the trust-gated core from the token’s `aud`, audience from cluster `jurisdiction_audience`, **pinned core** (no `home_jurisdiction` on sa-session JWTs), and **no OS keychain**—only in-process cache; `Invalidate` on 401 clears the memo only. Missing `jurisdiction_audience` fails closed via shared `missingJurisdictionAudienceErr` (no repo-scoped fallback).
> 
> Both interactive and env paths return `*jurisdictionTokenSource`; **`repocreds` and `tokenSource` are removed**, `Token(ctx)` no longer takes repo/action (smart-HTTP classification still gates where Bearer is attached). `ResolveClusterCores` returns the full discovery entry and uses **audience-required** cache semantics for the env path.
> 
> Tests cover pinned core routing, in-memory-only env minting, and missing-audience rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b1dcd38c83f1676725a1eb34eb2efc9e2f8bd4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->