### PR TITLE
Publish git-remote-entire per-commit to the public release bucket

### DIFF
--- a/.github/workflows/publish-git-remote-entire.yml
+++ b/.github/workflows/publish-git-remote-entire.yml
@@ -22,12 +22,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
 
@@ -38,13 +38,13 @@ jobs:
         run: git tag --force v0.0.0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: arn:aws:iam::128096325110:role/github-actions-public-release-upload
           aws-region: us-east-2
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
+        uses: goreleaser/goreleaser-action@v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/publish-git-remote-entire.yml
+++ b/.github/workflows/publish-git-remote-entire.yml
@@ -1,0 +1,53 @@
+name: publish-git-remote-entire
+
+# Publishes git-remote-entire (linux amd64/arm64 tarballs) to the public
+# release bucket on every push to main, keyed by commit sha. Consumed by
+# the entire-core-auth Buildkite plugin, whose environment hook installs
+# a pinned sha on hosted agents so `git clone entire://…` resolves.
+# See .goreleaser.nonprod.yaml for the artifact layout.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required to mint the OIDC token that assume-role exchanges for AWS
+  # credentials.
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      # GoReleaser refuses to run untagged. The tag is local to the
+      # runner, never pushed, and deliberately not stamped into the
+      # binary (see the ldflags note in .goreleaser.nonprod.yaml).
+      - name: Make a throwaway tag
+        run: git tag --force v0.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: arn:aws:iam::128096325110:role/github-actions-public-release-upload
+          aws-region: us-east-2
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: -f .goreleaser.nonprod.yaml release --clean --skip=validate
+        env:
+          GORELEASER_CURRENT_TAG: v0.0.0

--- a/.github/workflows/publish-git-remote-entire.yml
+++ b/.github/workflows/publish-git-remote-entire.yml
@@ -22,12 +22,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
@@ -38,13 +38,13 @@ jobs:
         run: git tag --force v0.0.0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.2.1
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: arn:aws:iam::128096325110:role/github-actions-public-release-upload
           aws-region: us-east-2
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7.2.3
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.goreleaser.nonprod.yaml
+++ b/.goreleaser.nonprod.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+# Per-commit publish of git-remote-entire, keyed by full commit sha, to
+# the anonymous-read public release bucket. Consumed by Buildkite Cloud
+# hosted agents (which have no AWS creds and no Homebrew) so they can
+# resolve `git clone entire://…` — see the entire-core-auth Buildkite
+# plugin's environment hook, which pins a sha from this pipeline.
+#
+# This lived in entiredb's .goreleaser.nonprod.yaml until the command
+# moved here; the bucket and IAM role are defined in
+# infra/aws/entire-nonprod/public-release-bucket/.
+#
+# Tagged releases (.goreleaser.yaml) are unaffected: this config is only
+# run by the publish-git-remote-entire workflow on pushes to main.
+
+builds:
+  - id: git-remote-entire
+    main: ./cmd/git-remote-entire
+    binary: git-remote-entire
+    env:
+      - CGO_ENABLED=0
+    # Buildkite Cloud hosted agents are always linux; nothing else
+    # consumes these artifacts.
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      # No Version stamp: the workflow's throwaway v0.0.0 tag would be
+      # stamped verbatim. versioninfo.Load() falls back to build info,
+      # so the binary still self-reports the commit it was built from.
+      - -X github.com/entireio/cli/cmd/entire/cli/versioninfo.Commit={{.ShortCommit}}
+
+archives:
+  - id: git-remote-entire
+    ids:
+      - git-remote-entire
+    formats: [tar.gz]
+    # OS and arch spelled to match `uname` output, which is how the
+    # Buildkite plugin assembles the download URL.
+    name_template: git-remote-entire_{{ .Os }}_{{ .Arch }}
+
+blobs:
+  - ids:
+      - git-remote-entire
+    provider: s3
+    bucket: entire-public-release-bucket-7f3e2a01c9b48d56
+    region: us-east-2
+    # The bucket policy only allows anonymous reads under commit/*.
+    directory: "commit/{{.FullCommit}}"
+
+release:
+  disable: true


### PR DESCRIPTION
Restores the per-commit S3 publish that was dropped when git-remote-entire moved here from entiredb (entiredb#1868) — nothing has written to the public bucket since, and the Buildkite plugin is living off the last entiredb artifact.

New workflow runs goreleaser (`.goreleaser.nonprod.yaml`) on every push to main, uploading `commit/<full-sha>/git-remote-entire_linux_{amd64,arm64}.tar.gz`.

**Merge order:** apply entirehq/infra#772 first — the workflow assumes the `github-actions-public-release-upload` role created there. After the first publish, bump `GIT_REMOTE_ENTIRE_SHA` in entire-core-auth-buildkite-plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)