### PR TITLE
checkpoint/remote: remove dead entiredb-original-url read path

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -115,7 +115,7 @@ func FetchURL(ctx context.Context, opts ...FetchURLOptions) (string, error) {
 		// Origin's protocol can't be mapped to a git transport (e.g. entire://,
 		// file://). Honor the configured checkpoint_remote by targeting the
 		// provider's canonical host over HTTPS rather than falling back to origin.
-		if providerURL, ok := resolveProviderCheckpointURL(config, originRemote, opt.WorktreeRoot); ok {
+		if providerURL, ok := resolveProviderCheckpointURL(config, opt.WorktreeRoot); ok {
 			return providerURL, nil
 		}
 		logFallback(ctx, "fetch", originURL, "derive checkpoint remote URL", err)
@@ -223,7 +223,7 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 		// (e.g. entire://, file://). Honor the configured checkpoint_remote by
 		// targeting the provider's canonical host over HTTPS rather than
 		// misrouting checkpoints to the origin remote.
-		if providerURL, ok := resolveProviderCheckpointURL(config, pushRemoteName, ""); ok {
+		if providerURL, ok := resolveProviderCheckpointURL(config, ""); ok {
 			return providerURL, true, nil
 		}
 		fallbackURL, fallbackErr := resolvePushFallbackURL(ctx, pushRemoteName, originURL)
@@ -309,13 +309,6 @@ func deriveCheckpointURLFromInfo(info *Info, config *settings.CheckpointRemoteCo
 	}
 }
 
-// originalURLConfigKey is the git config option, under remote.<name>., where
-// the retired entiredb `mirror use` verb recorded the URL a remote had before
-// it was switched to entire://. The verb is gone (no CLI writes the key today)
-// but clones that ran it still carry the value — the most faithful record of
-// the endpoint and auth method the user had for that remote.
-const originalURLConfigKey = "entiredb-original-url"
-
 // resolveProviderCheckpointURL builds the checkpoint URL for the configured
 // provider, choosing the transport from what's already configured for that
 // endpoint. It is the fallback used when the push/origin remote's protocol can't
@@ -324,25 +317,21 @@ const originalURLConfigKey = "entiredb-original-url"
 // than being misrouted to the origin remote.
 //
 // Transport precedence:
-//  1. The remote's pre-mirror URL (remote.<name>.entiredb-original-url) — the
-//     endpoint and scheme the remote used before the retired entiredb
-//     `mirror use` verb switched it to entire://. Reused verbatim (host +
-//     scheme + port).
-//  2. ENTIRE_CHECKPOINT_TOKEN set -> HTTPS on the provider host (the token is
+//  1. ENTIRE_CHECKPOINT_TOKEN set -> HTTPS on the provider host (the token is
 //     the credential).
-//  3. An existing remote already targets the provider host -> reuse its scheme,
+//  2. An existing remote already targets the provider host -> reuse its scheme,
 //     so checkpoints use the same auth the user already has for that endpoint.
-//  4. Otherwise SSH on the provider host.
+//  3. Otherwise SSH on the provider host.
 //
 // Returns ok=false when no transport can be determined (unknown provider with no
 // usable signal), in which case the caller falls back to the origin remote.
-func resolveProviderCheckpointURL(config *settings.CheckpointRemoteConfig, remoteName, dir string) (string, bool) {
+func resolveProviderCheckpointURL(config *settings.CheckpointRemoteConfig, dir string) (string, bool) {
 	repo, err := openRepoAt(dir)
 	if err != nil {
 		repo = nil // Fall back to env/provider-only signals.
 	}
 
-	info, ok := pickProviderTransport(repo, config, remoteName)
+	info, ok := pickProviderTransport(repo, config)
 	if !ok {
 		return "", false
 	}
@@ -356,31 +345,22 @@ func resolveProviderCheckpointURL(config *settings.CheckpointRemoteConfig, remot
 // pickProviderTransport returns the protocol/host/port to use when deriving a
 // checkpoint URL, following the precedence documented on
 // resolveProviderCheckpointURL.
-func pickProviderTransport(repo *git.Repository, config *settings.CheckpointRemoteConfig, remoteName string) (*Info, bool) {
-	// 1. The remote's saved pre-mirror URL: the endpoint and auth the user had.
-	if repo != nil {
-		if original := originalRemoteURL(repo, remoteName); original != "" {
-			if info, err := gitremote.ParseURL(original); err == nil && isDerivableProtocol(info.Protocol) {
-				return info, true
-			}
-		}
-	}
-
+func pickProviderTransport(repo *git.Repository, config *settings.CheckpointRemoteConfig) (*Info, bool) {
 	host, hostOK := providerHost(config.Provider)
 
-	// 2. Explicit token -> HTTPS on the provider host.
+	// 1. Explicit token -> HTTPS on the provider host.
 	if hostOK && strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != "" {
 		return &Info{Protocol: ProtocolHTTPS, Host: host}, true
 	}
 
-	// 3. An existing remote already targeting the provider host -> reuse scheme.
+	// 2. An existing remote already targeting the provider host -> reuse scheme.
 	if hostOK && repo != nil {
 		if info, ok := findRemoteInfoForHost(repo, host); ok {
 			return &Info{Protocol: info.Protocol, Host: info.Host, Port: info.Port}, true
 		}
 	}
 
-	// 4. Default to SSH on the provider host.
+	// 3. Default to SSH on the provider host.
 	if hostOK {
 		return &Info{Protocol: ProtocolSSH, Host: host}, true
 	}
@@ -399,16 +379,6 @@ func openRepoAt(dir string) (*git.Repository, error) {
 		return nil, fmt.Errorf("open git repository: %w", err)
 	}
 	return repo, nil
-}
-
-// originalRemoteURL returns the pre-mirror URL saved by the retired entiredb
-// `mirror use` verb in remote.<name>.entiredb-original-url, or "" when absent.
-func originalRemoteURL(repo *git.Repository, remoteName string) string {
-	cfg, err := repo.Config()
-	if err != nil {
-		return ""
-	}
-	return cfg.Raw.Section("remote").Subsection(remoteName).Option(originalURLConfigKey)
 }
 
 // findRemoteInfoForHost returns the parsed Info of the first configured git

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -310,9 +310,10 @@ func deriveCheckpointURLFromInfo(info *Info, config *settings.CheckpointRemoteCo
 }
 
 // originalURLConfigKey is the git config option, under remote.<name>., where
-// entiredb's `entire-repo mirror use` records the URL a remote had before it was
-// switched to entire://. It is the most faithful record of the endpoint and auth
-// method the user had for that remote.
+// the retired entiredb `mirror use` verb recorded the URL a remote had before
+// it was switched to entire://. The verb is gone (no CLI writes the key today)
+// but clones that ran it still carry the value — the most faithful record of
+// the endpoint and auth method the user had for that remote.
 const originalURLConfigKey = "entiredb-original-url"
 
 // resolveProviderCheckpointURL builds the checkpoint URL for the configured
@@ -324,8 +325,9 @@ const originalURLConfigKey = "entiredb-original-url"
 //
 // Transport precedence:
 //  1. The remote's pre-mirror URL (remote.<name>.entiredb-original-url) — the
-//     endpoint and scheme the remote used before `entire-repo mirror use`
-//     switched it to entire://. Reused verbatim (host + scheme + port).
+//     endpoint and scheme the remote used before the retired entiredb
+//     `mirror use` verb switched it to entire://. Reused verbatim (host +
+//     scheme + port).
 //  2. ENTIRE_CHECKPOINT_TOKEN set -> HTTPS on the provider host (the token is
 //     the credential).
 //  3. An existing remote already targets the provider host -> reuse its scheme,
@@ -399,8 +401,8 @@ func openRepoAt(dir string) (*git.Repository, error) {
 	return repo, nil
 }
 
-// originalRemoteURL returns the pre-mirror URL saved by `entire-repo mirror use`
-// in remote.<name>.entiredb-original-url, or "" when absent.
+// originalRemoteURL returns the pre-mirror URL saved by the retired entiredb
+// `mirror use` verb in remote.<name>.entiredb-original-url, or "" when absent.
 func originalRemoteURL(repo *git.Repository, remoteName string) string {
 	cfg, err := repo.Config()
 	if err != nil {

--- a/cmd/entire/cli/checkpoint/remote/util_test.go
+++ b/cmd/entire/cli/checkpoint/remote/util_test.go
@@ -401,38 +401,17 @@ func TestPushURL(t *testing.T) {
 // setup: origin migrated to an entire:// URL (forge-prefixed /gh/owner/repo)
 // with a github checkpoint_remote. The checkpoint URL must route to github
 // rather than fall back to the entire:// origin, reusing the auth/scheme the
-// repo had for that endpoint — first from the pre-mirror URL the retired
-// entiredb `mirror use` verb saved (remote.origin.entiredb-original-url), then
-// an existing remote on the provider host, then defaulting to SSH.
+// repo had for that endpoint — a token forces HTTPS, then an existing remote
+// on the provider host, then defaulting to SSH.
 func TestPushURL_EntireOriginReusesProviderRemoteScheme(t *testing.T) {
 	const entireOrigin = "entire://aws-eu-central-1.entire.io/gh/entireio/cli"
 	tests := []struct {
 		name        string
 		githubURL   string
-		savedURL    string
 		token       string
 		wantURL     string
 		wantEnabled bool
 	}{
-		{
-			name:        "pre-mirror ssh url yields ssh checkpoint url",
-			savedURL:    "git@github.com:entireio/cli.git",
-			wantURL:     "git@github.com:entireio/cli-checkpoints.git",
-			wantEnabled: true,
-		},
-		{
-			name:        "pre-mirror https url yields https checkpoint url",
-			savedURL:    "https://github.com/entireio/cli.git",
-			wantURL:     "https://github.com/entireio/cli-checkpoints.git",
-			wantEnabled: true,
-		},
-		{
-			name:        "pre-mirror url wins over token",
-			savedURL:    "git@github.com:entireio/cli.git",
-			token:       "ci-token",
-			wantURL:     "git@github.com:entireio/cli-checkpoints.git",
-			wantEnabled: true,
-		},
 		{
 			name:        "ssh github remote yields ssh checkpoint url",
 			githubURL:   "git@github.com:entireio/cli.git",
@@ -451,7 +430,7 @@ func TestPushURL_EntireOriginReusesProviderRemoteScheme(t *testing.T) {
 			wantEnabled: true,
 		},
 		{
-			name:        "token forces https when no pre-mirror url",
+			name:        "token forces https over existing ssh remote",
 			githubURL:   "git@github.com:entireio/cli.git",
 			token:       "ci-token",
 			wantURL:     "https://github.com/entireio/cli-checkpoints.git",
@@ -466,9 +445,6 @@ func TestPushURL_EntireOriginReusesProviderRemoteScheme(t *testing.T) {
 			runGit(t, repoDir, "remote", "add", "origin", entireOrigin)
 			if tt.githubURL != "" {
 				runGit(t, repoDir, "remote", "add", "github", tt.githubURL)
-			}
-			if tt.savedURL != "" {
-				runGit(t, repoDir, "config", "remote.origin.entiredb-original-url", tt.savedURL)
 			}
 			writeSettings(t, repoDir, `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"entireio/cli-checkpoints"}}}`)
 			t.Chdir(repoDir)

--- a/cmd/entire/cli/checkpoint/remote/util_test.go
+++ b/cmd/entire/cli/checkpoint/remote/util_test.go
@@ -401,9 +401,9 @@ func TestPushURL(t *testing.T) {
 // setup: origin migrated to an entire:// URL (forge-prefixed /gh/owner/repo)
 // with a github checkpoint_remote. The checkpoint URL must route to github
 // rather than fall back to the entire:// origin, reusing the auth/scheme the
-// repo had for that endpoint — first from the pre-mirror URL that
-// `entire-repo mirror use` saves (remote.origin.entiredb-original-url), then an
-// existing remote on the provider host, then defaulting to SSH.
+// repo had for that endpoint — first from the pre-mirror URL the retired
+// entiredb `mirror use` verb saved (remote.origin.entiredb-original-url), then
+// an existing remote on the provider host, then defaulting to SSH.
 func TestPushURL_EntireOriginReusesProviderRemoteScheme(t *testing.T) {
 	const entireOrigin = "entire://aws-eu-central-1.entire.io/gh/entireio/cli"
 	tests := []struct {


### PR DESCRIPTION
## Why

`remote.<name>.entiredb-original-url` was written by entiredb's `mirror use` verb, retired long ago — nothing writes the key anymore, so the pre-mirror-URL branch of the checkpoint transport fallback was dead weight (and its comments pointed at a command that no longer exists).

## What

- Drop the key constant, `originalRemoteURL`, and the pre-mirror precedence step in `pickProviderTransport`; remaining precedence (token → HTTPS, existing provider-host remote, SSH default) unchanged.
- Drop the unused `remoteName` threading and the pre-mirror test cases.

## Verification

`go test ./cmd/entire/cli/checkpoint/remote/` passes; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal in checkpoint remote URL resolution; behavior only changes for repos that still had the obsolete config key set, which is no longer written.
> 
> **Overview**
> Removes checkpoint URL transport logic that read `remote.<name>.entiredb-original-url` (a key nothing writes anymore after the retired `mirror use` flow).
> 
> **`resolveProviderCheckpointURL` / `pickProviderTransport`** no longer take a remote name or consult pre-mirror URLs. When origin/push uses a non-derivable protocol (`entire://`, `file://`), transport is chosen only by: **`ENTIRE_CHECKPOINT_TOKEN` → HTTPS**, **existing remote on the provider host → reuse scheme**, **else SSH** on the provider host.
> 
> Call sites in **`FetchURL`** and **`PushURL`** are updated accordingly. Tests drop pre-mirror cases and align expectations (e.g. token wins over an SSH `github` remote).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de68c54dc89f40596e050eb232a9fc9f38f62927. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->