### PR TITLE
Standardize control-plane command output to CLI house style

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -107,6 +107,9 @@ linters:
         - pattern: '^.*\.Checkout$'
           msg: "go-git Checkout deletes .gitignored dirs - use CheckoutBranch() from git_operations.go"
           pkg: 'github\.com/go-git/go-git'
+        - pattern: '^.*\.(Print|Println|Printf)$'
+          msg: "cobra's Print* writes to OutOrStderr (stderr in production); use fmt.Fprint*(cmd.OutOrStdout(), ...)"
+          pkg: 'github\.com/spf13/cobra'
     govet:
       enable-all: true
       disable:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Control-plane commands (`org`, `project`, `repo`, `grant`) now print human-readable confirmations by default; the wire JSON (including `repo create`'s `entire://` remote) moved behind `--json`. Empty `--json` lists emit `[]`, and success messages moved from stderr to stdout ([#1626](https://github.com/entireio/cli/pull/1626))
+
 ## [0.7.8] - 2026-06-30
 
 ### Added

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -354,19 +354,25 @@ func writeTableRow(b *strings.Builder, cells []string, widths []int, styleFor fu
 	b.WriteByte('\n')
 }
 
-// runCoreJSON runs fn against an authenticated control-plane client and
-// prints its result as indented JSON. It owns the preamble every
-// control-plane command shares: silence usage so input errors don't spam
-// the usage block, build the client, and map an API error to a
-// problem-detail SilentError. Commands supply only the call + the value to
-// render.
-func runCoreJSON(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client) (any, error)) error {
+// runCoreMutation runs fn against the control plane and renders its outcome
+// the way the rest of the CLI renders mutations: the ✓ human confirmation on
+// stdout by default, or the wire object as JSON when --json was passed. fn
+// returns both so the human line can name the created resource while --json
+// preserves the full wire model (additive-only: synthesized fields like the
+// repo remote URL are merged in, nothing is ever omitted). It owns the same
+// preamble as the other runCore variants: silence usage, build the client,
+// map API errors to problem-detail messages.
+func runCoreMutation(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client) (message string, wire any, err error)) error {
 	return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
-		out, err := fn(ctx, c)
+		message, wire, err := fn(ctx, c)
 		if err != nil {
 			return err
 		}
-		return printJSON(cmd.OutOrStdout(), out)
+		if jsonRequested(cmd) {
+			return printJSON(cmd.OutOrStdout(), wire)
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), message)
+		return nil
 	})
 }
 

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -25,7 +25,7 @@ import (
 //     (local/dev deployments where the core isn't behind TLS). Hidden, as
 //     elsewhere in the CLI.
 func addControlPlaneFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().Bool("json", false, "output raw JSON instead of a table")
+	cmd.PersistentFlags().Bool("json", false, "Output raw JSON instead of a table")
 	cmd.PersistentFlags().Bool("insecure-http-auth", false, "Allow authentication over plain HTTP (insecure, for local development only)")
 	if err := cmd.PersistentFlags().MarkHidden("insecure-http-auth"); err != nil {
 		panic(fmt.Sprintf("hide insecure-http-auth flag: %v", err))
@@ -458,7 +458,7 @@ func renderCoreError(err error) error {
 }
 
 // printJSON writes v as indented JSON to w — the --json view for list/get
-// and the default for create commands that echo the new object.
+// and mutations.
 func printJSON(w io.Writer, v any) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -355,8 +355,9 @@ func writeTableRow(b *strings.Builder, cells []string, widths []int, styleFor fu
 }
 
 // runCoreMutation runs fn against the control plane and renders its outcome
-// the way the rest of the CLI renders mutations: the ✓ human confirmation on
-// stdout by default, or the wire object as JSON when --json was passed. fn
+// the way the rest of the CLI renders mutations: prints the caller's
+// ✓-prefixed confirmation on stdout by default, or the wire object as JSON
+// when --json was passed. fn
 // returns both so the human line can name the created resource while --json
 // preserves the full wire model (additive-only: synthesized fields like the
 // repo remote URL are merged in, nothing is ever omitted). It owns the same
@@ -382,11 +383,13 @@ func runCoreMutation(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi
 // without standing up the auth/context/TLS stack.
 var activeCoreClient = func(context.Context) (*coreapi.Client, error) { return coreapi.New() }
 
-// runCore is the variant for commands that don't render JSON (delete,
-// revoke, remove): it runs the same preamble — silence usage, build
-// client, map API errors — and leaves any success output to fn. The client
-// dials the active context's core (coreapi.New); use runCoreForCluster for
-// commands addressed at a specific cluster.
+// runCore is the shared base for every active-context control-plane command:
+// it owns the preamble only — silence usage, build the client, map API
+// errors — and leaves all rendering to fn. The delete/revoke verbs call it
+// directly and render their own output; runCoreList, runCoreObject, and
+// runCoreMutation build on it to add their table/JSON/confirmation
+// rendering. The client dials the active context's core (coreapi.New); use
+// runCoreForCluster for commands addressed at a specific cluster.
 func runCore(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client) error) error {
 	return runCoreClient(cmd, activeCoreClient, fn)
 }

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -94,12 +94,12 @@ func runControlPlaneDelete(
 			// delete call — e.g. a ULID passed straight through, or a concurrent
 			// delete) is the desired end state, not an error.
 			if isCoreNotFound(err) {
-				cmd.Printf("%s not found; nothing to delete\n", label)
+				fmt.Fprintf(cmd.OutOrStdout(), "%s not found; nothing to delete\n", label)
 				return nil
 			}
 			return err
 		}
-		cmd.Printf("Deleted %s\n", label)
+		fmt.Fprintf(cmd.OutOrStdout(), "✓ Deleted %s\n", label)
 		return nil
 	})
 }
@@ -142,36 +142,42 @@ func confirmControlPlaneDeletion(ctx context.Context, w io.Writer, label string,
 }
 
 // runCoreList fetches a slice via fn and renders it as an aligned table
-// (default) or the raw wire JSON (--json). headers names the columns; row
-// maps one item to its cells in the same order. The human view keeps the
-// output actionable — only the columns a person acts on — while --json
-// preserves the full model for scripting.
-func runCoreList[T any](cmd *cobra.Command, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) ([]T, error)) error {
-	return runCore(cmd, renderCoreList(cmd, headers, row, fn))
+// (default) or the raw wire JSON (--json). empty is the full sentence printed
+// to stdout in place of the table when there are no items (e.g. "No
+// organizations found."). headers names the columns; row maps one item to its
+// cells in the same order. The human view keeps the output actionable — only
+// the columns a person acts on — while --json preserves the full model for
+// scripting.
+func runCoreList[T any](cmd *cobra.Command, empty string, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) ([]T, error)) error {
+	return runCore(cmd, renderCoreList(cmd, empty, headers, row, fn))
 }
 
 // runCoreListForCluster is runCoreList for a resource-provider command (see
-// runCoreForCluster): identical table/JSON rendering, but dialing the core that
-// fronts clusterHost rather than the active context.
-func runCoreListForCluster[T any](cmd *cobra.Command, clusterHost string, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) ([]T, error)) error {
-	return runCoreForCluster(cmd, clusterHost, renderCoreList(cmd, headers, row, fn))
+// runCoreForCluster): identical table/JSON/empty-state rendering, but dialing
+// the core that fronts clusterHost rather than the active context.
+func runCoreListForCluster[T any](cmd *cobra.Command, clusterHost, empty string, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) ([]T, error)) error {
+	return runCoreForCluster(cmd, clusterHost, renderCoreList(cmd, empty, headers, row, fn))
 }
 
 // renderCoreList builds the run-function shared by runCoreList and
-// runCoreListForCluster: fetch via fn, then render as a table (default) or raw
-// JSON (--json). Kept separate from the client-selection so the two list
-// variants differ only in which core they dial.
-func renderCoreList[T any](cmd *cobra.Command, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) ([]T, error)) func(context.Context, *coreapi.Client) error {
+// runCoreListForCluster: fetch via fn, then render as a table (default), the
+// empty sentence (no items), or raw JSON (--json). Kept separate from the
+// client-selection so the two list variants differ only in which core they
+// dial.
+func renderCoreList[T any](cmd *cobra.Command, empty string, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) ([]T, error)) func(context.Context, *coreapi.Client) error {
 	return func(ctx context.Context, c *coreapi.Client) error {
 		items, err := fn(ctx, c)
 		if err != nil {
 			return err
 		}
 		if jsonRequested(cmd) {
+			if items == nil {
+				items = []T{} // a nil slice encodes as null; scripts expect []
+			}
 			return printJSON(cmd.OutOrStdout(), items)
 		}
 		if len(items) == 0 {
-			fmt.Fprintln(cmd.ErrOrStderr(), "(none)")
+			fmt.Fprintln(cmd.OutOrStdout(), empty)
 			return nil
 		}
 		return printTable(cmd.OutOrStdout(), headers, items, row)

--- a/cmd/entire/cli/corecmd_delete_test.go
+++ b/cmd/entire/cli/corecmd_delete_test.go
@@ -32,10 +32,17 @@ func writeNotFoundProblem(t *testing.T, w http.ResponseWriter) {
 	}
 }
 
-// runCoreCmd runs any control-plane command against a seamed httptest core:
-// it points the active-context client at srv via the activeCoreClient seam,
-// runs newCmd() with args, and returns its stdout, stderr, and error. The
-// caller must not be parallel: the seam is package-global.
+// runCoreCmd runs any active-context control-plane command against a seamed
+// httptest core: it points the active-context client at srv via the
+// activeCoreClient seam, runs newCmd() with args, and returns its stdout,
+// stderr, and error. Commands dialing via runCoreForCluster (mirror
+// create/remove/collaborators) bypass the seam and need their own httptest
+// wiring. The caller must not be parallel: the seam is package-global.
+//
+// Note: cobra's cmd.Print* falls back to OutOrStderr(), which under SetOut
+// resolves to the stdout buffer — so Empty(errOut) assertions in these tests
+// only guard explicit ErrOrStderr writes; the Contains-on-stdout assertions
+// are what pin the production stream.
 func runCoreCmd(t *testing.T, newCmd func() *cobra.Command, srvURL string, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
 	prev := activeCoreClient
@@ -85,7 +92,7 @@ func TestControlPlaneDelete_Wiring(t *testing.T) {
 			require.Equal(t, http.MethodDelete, gotMethod)
 			require.Equal(t, tc.wantPath, gotPath)
 			require.Contains(t, out, "✓ Deleted "+tc.noun+" "+testDeleteULID)
-			require.Empty(t, errOut, "success output must go to stdout, not stderr")
+			require.Empty(t, errOut, "no explicit ErrOrStderr writes expected")
 		})
 
 		t.Run(tc.noun+"/already-gone is idempotent", func(t *testing.T) {

--- a/cmd/entire/cli/corecmd_delete_test.go
+++ b/cmd/entire/cli/corecmd_delete_test.go
@@ -32,10 +32,11 @@ func writeNotFoundProblem(t *testing.T, w http.ResponseWriter) {
 	}
 }
 
-// runDeleteCmd points the active-context client at srv via the activeCoreClient
-// seam, runs newCmd() with args, and returns its stdout, stderr, and error. The
+// runCoreCmd runs any control-plane command against a seamed httptest core:
+// it points the active-context client at srv via the activeCoreClient seam,
+// runs newCmd() with args, and returns its stdout, stderr, and error. The
 // caller must not be parallel: the seam is package-global.
-func runDeleteCmd(t *testing.T, newCmd func() *cobra.Command, srvURL string, args ...string) (stdout, stderr string, err error) {
+func runCoreCmd(t *testing.T, newCmd func() *cobra.Command, srvURL string, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
 	prev := activeCoreClient
 	activeCoreClient = func(context.Context) (*coreapi.Client, error) {
@@ -79,7 +80,7 @@ func TestControlPlaneDelete_Wiring(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
-			out, errOut, err := runDeleteCmd(t, tc.newCmd, srv.URL, testDeleteULID, "--force")
+			out, errOut, err := runCoreCmd(t, tc.newCmd, srv.URL, testDeleteULID, "--force")
 			require.NoError(t, err)
 			require.Equal(t, http.MethodDelete, gotMethod)
 			require.Equal(t, tc.wantPath, gotPath)
@@ -93,7 +94,7 @@ func TestControlPlaneDelete_Wiring(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
-			out, errOut, err := runDeleteCmd(t, tc.newCmd, srv.URL, testDeleteULID, "--force")
+			out, errOut, err := runCoreCmd(t, tc.newCmd, srv.URL, testDeleteULID, "--force")
 			require.NoError(t, err)
 			require.Contains(t, out, "not found; nothing to delete")
 			require.Empty(t, errOut)
@@ -106,7 +107,7 @@ func TestControlPlaneDelete_Wiring(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
-			_, _, err := runDeleteCmd(t, tc.newCmd, srv.URL, testDeleteULID)
+			_, _, err := runCoreCmd(t, tc.newCmd, srv.URL, testDeleteULID)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "--force")
 		})

--- a/cmd/entire/cli/corecmd_delete_test.go
+++ b/cmd/entire/cli/corecmd_delete_test.go
@@ -33,9 +33,9 @@ func writeNotFoundProblem(t *testing.T, w http.ResponseWriter) {
 }
 
 // runDeleteCmd points the active-context client at srv via the activeCoreClient
-// seam, runs newCmd() with args, and returns its stdout and error. The caller
-// must not be parallel: the seam is package-global.
-func runDeleteCmd(t *testing.T, newCmd func() *cobra.Command, srvURL string, args ...string) (string, error) {
+// seam, runs newCmd() with args, and returns its stdout, stderr, and error. The
+// caller must not be parallel: the seam is package-global.
+func runDeleteCmd(t *testing.T, newCmd func() *cobra.Command, srvURL string, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
 	prev := activeCoreClient
 	activeCoreClient = func(context.Context) (*coreapi.Client, error) {
@@ -44,12 +44,12 @@ func runDeleteCmd(t *testing.T, newCmd func() *cobra.Command, srvURL string, arg
 	t.Cleanup(func() { activeCoreClient = prev })
 
 	cmd := newCmd()
-	var out bytes.Buffer
+	var out, errW bytes.Buffer
 	cmd.SetOut(&out)
-	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetErr(&errW)
 	cmd.SetArgs(args)
-	err := cmd.ExecuteContext(t.Context())
-	return out.String(), err
+	err = cmd.ExecuteContext(t.Context())
+	return out.String(), errW.String(), err
 }
 
 // TestControlPlaneDelete_Wiring exercises the org/project/repo delete commands
@@ -79,11 +79,12 @@ func TestControlPlaneDelete_Wiring(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
-			out, err := runDeleteCmd(t, tc.newCmd, srv.URL, testDeleteULID, "--force")
+			out, errOut, err := runDeleteCmd(t, tc.newCmd, srv.URL, testDeleteULID, "--force")
 			require.NoError(t, err)
 			require.Equal(t, http.MethodDelete, gotMethod)
 			require.Equal(t, tc.wantPath, gotPath)
-			require.Contains(t, out, "Deleted "+tc.noun+" "+testDeleteULID)
+			require.Contains(t, out, "✓ Deleted "+tc.noun+" "+testDeleteULID)
+			require.Empty(t, errOut, "success output must go to stdout, not stderr")
 		})
 
 		t.Run(tc.noun+"/already-gone is idempotent", func(t *testing.T) {
@@ -92,9 +93,10 @@ func TestControlPlaneDelete_Wiring(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
-			out, err := runDeleteCmd(t, tc.newCmd, srv.URL, testDeleteULID, "--force")
+			out, errOut, err := runDeleteCmd(t, tc.newCmd, srv.URL, testDeleteULID, "--force")
 			require.NoError(t, err)
 			require.Contains(t, out, "not found; nothing to delete")
+			require.Empty(t, errOut)
 		})
 
 		t.Run(tc.noun+"/refuses without --force when non-interactive", func(t *testing.T) {
@@ -104,7 +106,7 @@ func TestControlPlaneDelete_Wiring(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
-			_, err := runDeleteCmd(t, tc.newCmd, srv.URL, testDeleteULID)
+			_, _, err := runDeleteCmd(t, tc.newCmd, srv.URL, testDeleteULID)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "--force")
 		})

--- a/cmd/entire/cli/corecmd_list_test.go
+++ b/cmd/entire/cli/corecmd_list_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// listCmd builds a minimal command wired to renderCoreList via runCoreList so
+// the rendering path (table / empty state / --json) is exercised without a
+// server: fn returns items directly.
+func runListRender(t *testing.T, jsonFlag bool, items []coreapi.Org) (stdout, stderr string) {
+	t.Helper()
+	prev := activeCoreClient
+	activeCoreClient = func(context.Context) (*coreapi.Client, error) {
+		// The URL is never contacted: fn below returns items directly, so
+		// the client only needs to construct.
+		return coreapi.NewWithBearer("http://127.0.0.1:0", "tok")
+	}
+	t.Cleanup(func() { activeCoreClient = prev })
+
+	cmd := &cobra.Command{
+		Use: "list",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCoreList(cmd, "No organizations found.", orgColumns, orgRow,
+				func(context.Context, *coreapi.Client) ([]coreapi.Org, error) { return items, nil })
+		},
+	}
+	cmd.Flags().Bool("json", false, "Output raw JSON instead of a table")
+	var out, errW bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errW)
+	args := []string{}
+	if jsonFlag {
+		args = append(args, "--json")
+	}
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+	return out.String(), errW.String()
+}
+
+// Not parallel: swaps the package-level activeCoreClient seam.
+func TestRunCoreList_EmptyHumanMessageOnStdout(t *testing.T) {
+	out, errOut := runListRender(t, false, nil)
+	require.Contains(t, out, "No organizations found.")
+	require.Empty(t, errOut, "empty-state message must go to stdout")
+}
+
+// Not parallel: swaps the package-level activeCoreClient seam.
+func TestRunCoreList_EmptyJSONIsArray(t *testing.T) {
+	out, _ := runListRender(t, true, nil)
+	require.JSONEq(t, "[]", out, "empty --json list must be [], not null")
+}

--- a/cmd/entire/cli/corecmd_list_test.go
+++ b/cmd/entire/cli/corecmd_list_test.go
@@ -1,65 +1,55 @@
 package cli
 
 import (
-	"bytes"
-	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// runListRender builds a minimal command wired to renderCoreList via runCoreList so
-// the rendering path (table / empty state / --json) is exercised without a
-// server: fn returns items directly.
-func runListRender(t *testing.T, jsonFlag bool, items []coreapi.Org) (stdout, stderr string) {
+// serveOrgList answers GET /api/v1/orgs with the given orgs, standing in for
+// the control plane behind `entire org list`.
+func serveOrgList(t *testing.T, orgs []coreapi.Org) *httptest.Server {
 	t.Helper()
-	prev := activeCoreClient
-	activeCoreClient = func(context.Context) (*coreapi.Client, error) {
-		// The URL is never contacted: fn below returns items directly, so
-		// the client only needs to construct.
-		return coreapi.NewWithBearer("http://127.0.0.1:0", "tok")
-	}
-	t.Cleanup(func() { activeCoreClient = prev })
-
-	cmd := &cobra.Command{
-		Use: "list",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runCoreList(cmd, "No organizations found.", orgColumns, orgRow,
-				func(context.Context, *coreapi.Client) ([]coreapi.Org, error) { return items, nil })
-		},
-	}
-	cmd.Flags().Bool("json", false, "Output raw JSON instead of a table")
-	var out, errW bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&errW)
-	args := []string{}
-	if jsonFlag {
-		args = append(args, "--json")
-	}
-	cmd.SetArgs(args)
-	require.NoError(t, cmd.ExecuteContext(t.Context()))
-	return out.String(), errW.String()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		if err := writeJSON(w, &coreapi.ListOrgsOutputBody{Orgs: orgs}); err != nil {
+			t.Errorf("encode orgs: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
 }
 
-// Not parallel: swaps the package-level activeCoreClient seam.
+// Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestRunCoreList_EmptyHumanMessageOnStdout(t *testing.T) {
-	out, errOut := runListRender(t, false, nil)
+	srv := serveOrgList(t, nil)
+	out, errOut, err := runCoreCmd(t, newOrgListCmd, srv.URL)
+	require.NoError(t, err)
 	require.Contains(t, out, "No organizations found.")
 	require.Empty(t, errOut, "empty-state message must go to stdout")
 }
 
-// Not parallel: swaps the package-level activeCoreClient seam.
+// Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestRunCoreList_EmptyJSONIsArray(t *testing.T) {
-	out, _ := runListRender(t, true, nil)
+	srv := serveOrgList(t, nil)
+	// org list's --json is persistent on the group root, so drive the full
+	// group command with "list" as a subcommand arg.
+	out, _, err := runCoreCmd(t, newOrgCmd, srv.URL, "list", "--json")
+	require.NoError(t, err)
 	require.JSONEq(t, "[]", out, "empty --json list must be [], not null")
 }
 
-// Not parallel: swaps the package-level activeCoreClient seam.
+// Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestRunCoreList_RendersRows(t *testing.T) {
-	out, errOut := runListRender(t, false, []coreapi.Org{{ID: testDeleteULID, Name: "acme", Region: "us"}})
+	srv := serveOrgList(t, []coreapi.Org{{ID: testDeleteULID, Name: "acme", Region: "us"}})
+	out, errOut, err := runCoreCmd(t, newOrgListCmd, srv.URL)
+	require.NoError(t, err)
 	require.Contains(t, out, "NAME")
 	require.Contains(t, out, "acme")
 	require.Empty(t, errOut)

--- a/cmd/entire/cli/corecmd_list_test.go
+++ b/cmd/entire/cli/corecmd_list_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// listCmd builds a minimal command wired to renderCoreList via runCoreList so
+// runListRender builds a minimal command wired to renderCoreList via runCoreList so
 // the rendering path (table / empty state / --json) is exercised without a
 // server: fn returns items directly.
 func runListRender(t *testing.T, jsonFlag bool, items []coreapi.Org) (stdout, stderr string) {
@@ -55,4 +55,12 @@ func TestRunCoreList_EmptyHumanMessageOnStdout(t *testing.T) {
 func TestRunCoreList_EmptyJSONIsArray(t *testing.T) {
 	out, _ := runListRender(t, true, nil)
 	require.JSONEq(t, "[]", out, "empty --json list must be [], not null")
+}
+
+// Not parallel: swaps the package-level activeCoreClient seam.
+func TestRunCoreList_RendersRows(t *testing.T) {
+	out, errOut := runListRender(t, false, []coreapi.Org{{ID: testDeleteULID, Name: "acme", Region: "us"}})
+	require.Contains(t, out, "NAME")
+	require.Contains(t, out, "acme")
+	require.Empty(t, errOut)
 }

--- a/cmd/entire/cli/corecmd_mutation_test.go
+++ b/cmd/entire/cli/corecmd_mutation_test.go
@@ -31,7 +31,7 @@ func newCreateOrgServer(t *testing.T) *httptest.Server {
 // Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestOrgCreate_HumanByDefault(t *testing.T) {
 	srv := newCreateOrgServer(t)
-	out, errOut, err := runCoreCmd(t, newOrgCreateCmd, srv.URL, "acme")
+	out, errOut, err := runCoreCmd(t, newOrgCmd, srv.URL, "create", "acme")
 	require.NoError(t, err)
 	require.Contains(t, out, "✓ Created org acme ("+testDeleteULID+")")
 	require.NotContains(t, out, "{", "default output must not be JSON")
@@ -47,5 +47,53 @@ func TestOrgCreate_JSONOnRequest(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, out, `"name": "acme"`)
 	require.Contains(t, out, `"id": "`+testDeleteULID+`"`)
+	require.NotContains(t, out, "✓ Created")
+}
+
+// testRepoCreateProjectULID is the --project value for the repo-create tests
+// below: a syntactically valid ULID so resolveProjectRef skips the by-name
+// lookup and the fake server only needs to answer POST /api/v1/repos.
+const testRepoCreateProjectULID = "01HZX7QABCDEFGHJKMNPQRSTV2"
+
+// newCreateRepoServer answers POST /api/v1/repos with a created repo whose
+// clusterHost/path resolve to a clone URL. The 201 status is load-bearing,
+// same as newCreateOrgServer.
+func newCreateRepoServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		repo := &coreapi.Repo{
+			ID:              testDeleteULID,
+			Name:            "web",
+			OwningProjectId: testRepoCreateProjectULID,
+			ClusterHost:     coreapi.NewOptString("c.example.com"),
+			Path:            coreapi.NewOptString("/gh/o/web"),
+		}
+		if err := writeJSON(w, repo); err != nil {
+			t.Errorf("encode repo: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
+func TestRepoCreate_HumanByDefault(t *testing.T) {
+	srv := newCreateRepoServer(t)
+	out, errOut, err := runCoreCmd(t, newRepoCmd, srv.URL, "create", "web", "--project", testRepoCreateProjectULID)
+	require.NoError(t, err)
+	require.Contains(t, out, "✓ Created repository web ("+testDeleteULID+")")
+	require.Contains(t, out, "Remote: entire://c.example.com/gh/o/web")
+	require.Empty(t, errOut)
+}
+
+// Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
+func TestRepoCreate_JSONOnRequest(t *testing.T) {
+	srv := newCreateRepoServer(t)
+	out, _, err := runCoreCmd(t, newRepoCmd, srv.URL, "create", "web", "--project", testRepoCreateProjectULID, "--json")
+	require.NoError(t, err)
+	require.Contains(t, out, `"remote": "entire://c.example.com/gh/o/web"`)
 	require.NotContains(t, out, "✓ Created")
 }

--- a/cmd/entire/cli/corecmd_mutation_test.go
+++ b/cmd/entire/cli/corecmd_mutation_test.go
@@ -28,22 +28,22 @@ func newCreateOrgServer(t *testing.T) *httptest.Server {
 	return srv
 }
 
-// Not parallel: runDeleteCmd swaps the package-level activeCoreClient seam.
+// Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestOrgCreate_HumanByDefault(t *testing.T) {
 	srv := newCreateOrgServer(t)
-	out, errOut, err := runDeleteCmd(t, newOrgCreateCmd, srv.URL, "acme")
+	out, errOut, err := runCoreCmd(t, newOrgCreateCmd, srv.URL, "acme")
 	require.NoError(t, err)
 	require.Contains(t, out, "✓ Created org acme ("+testDeleteULID+")")
 	require.NotContains(t, out, "{", "default output must not be JSON")
 	require.Empty(t, errOut)
 }
 
-// Not parallel: runDeleteCmd swaps the package-level activeCoreClient seam.
+// Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestOrgCreate_JSONOnRequest(t *testing.T) {
 	srv := newCreateOrgServer(t)
 	// org create's --json is persistent on the group root, so drive the
 	// full group command with "create" as a subcommand arg.
-	out, _, err := runDeleteCmd(t, newOrgCmd, srv.URL, "create", "acme", "--json")
+	out, _, err := runCoreCmd(t, newOrgCmd, srv.URL, "create", "acme", "--json")
 	require.NoError(t, err)
 	require.Contains(t, out, `"name": "acme"`)
 	require.Contains(t, out, `"id": "`+testDeleteULID+`"`)

--- a/cmd/entire/cli/corecmd_mutation_test.go
+++ b/cmd/entire/cli/corecmd_mutation_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// newCreateOrgServer answers POST /api/v1/orgs with a created org. The 201
+// status is load-bearing: the generated decodeCreateOrgResponse only accepts
+// http.StatusCreated — a default 200 makes CreateOrg return an error.
+func newCreateOrgServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if err := writeJSON(w, &coreapi.Org{ID: testDeleteULID, Name: "acme", Region: "us"}); err != nil {
+			t.Errorf("encode org: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Not parallel: runDeleteCmd swaps the package-level activeCoreClient seam.
+func TestOrgCreate_HumanByDefault(t *testing.T) {
+	srv := newCreateOrgServer(t)
+	out, errOut, err := runDeleteCmd(t, newOrgCreateCmd, srv.URL, "acme")
+	require.NoError(t, err)
+	require.Contains(t, out, "✓ Created org acme ("+testDeleteULID+")")
+	require.NotContains(t, out, "{", "default output must not be JSON")
+	require.Empty(t, errOut)
+}
+
+// Not parallel: runDeleteCmd swaps the package-level activeCoreClient seam.
+func TestOrgCreate_JSONOnRequest(t *testing.T) {
+	srv := newCreateOrgServer(t)
+	// org create's --json is persistent on the group root, so drive the
+	// full group command with "create" as a subcommand arg.
+	out, _, err := runDeleteCmd(t, newOrgCmd, srv.URL, "create", "acme", "--json")
+	require.NoError(t, err)
+	require.Contains(t, out, `"name": "acme"`)
+	require.Contains(t, out, `"id": "`+testDeleteULID+`"`)
+	require.NotContains(t, out, "✓ Created")
+}

--- a/cmd/entire/cli/grant.go
+++ b/cmd/entire/cli/grant.go
@@ -151,7 +151,7 @@ func newGrantOrgListCmd() *cobra.Command {
 		Short: "List org members",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoreList(cmd, orgMemberColumns, orgMemberRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Membership, error) {
+			return runCoreList(cmd, "No members found.", orgMemberColumns, orgMemberRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Membership, error) {
 				orgID, err := resolveOrgRef(ctx, c, args[0])
 				if err != nil {
 					return nil, err
@@ -257,7 +257,7 @@ func newGrantProjectListCmd() *cobra.Command {
 		Short: "List project members",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoreList(cmd, grantColumns, projectGrantRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.ProjectGrant, error) {
+			return runCoreList(cmd, "No grants found.", grantColumns, projectGrantRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.ProjectGrant, error) {
 				projID, err := resolveProjectRef(ctx, c, args[0])
 				if err != nil {
 					return nil, err
@@ -403,7 +403,7 @@ func newGrantRepoListCmd() *cobra.Command {
 		Short: "List repo grants",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoreList(cmd, grantColumns, repoGrantRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.RepoGrant, error) {
+			return runCoreList(cmd, "No grants found.", grantColumns, repoGrantRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.RepoGrant, error) {
 				repoID, err := resolveRepoRef(ctx, c, args[0], project)
 				if err != nil {
 					return nil, err
@@ -478,11 +478,11 @@ func revokeRepoGrantee(ctx context.Context, cmd *cobra.Command, c *coreapi.Clien
 func revokeGrant(cmd *cobra.Command, verb, subject string, revoke func() error) error {
 	if err := revoke(); err != nil {
 		if isCoreNotFound(err) {
-			cmd.Printf("%s: no such grant; nothing to revoke\n", subject)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s: no such grant; nothing to revoke\n", subject)
 			return nil
 		}
 		return err
 	}
-	cmd.Printf("%s %s\n", verb, subject)
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ %s %s\n", verb, subject)
 	return nil
 }

--- a/cmd/entire/cli/grant.go
+++ b/cmd/entire/cli/grant.go
@@ -69,7 +69,7 @@ func newGrantCmd() *cobra.Command {
 // saying where the grant comes from; ID keeps the ULID for revoke.
 var (
 	orgMemberColumns = []string{"ACCOUNT", "ROLE", "STATUS"}
-	grantColumns     = []string{"GRANTEE-TYPE", "GRANTEE", "ID", "ROLE", "SOURCE"}
+	grantColumns     = []string{"GRANTEE", "ROLE", "SOURCE", "TYPE", "ID"}
 )
 
 func orgMemberRow(m coreapi.Membership) []string {
@@ -77,13 +77,13 @@ func orgMemberRow(m coreapi.Membership) []string {
 }
 
 func projectGrantRow(g coreapi.ProjectGrant) []string {
-	return []string{g.GranteeType, granteeName(g.GranteeName, g.GranteeId), g.GranteeId, g.Role, g.Source}
+	return []string{granteeName(g.GranteeName, g.GranteeId), g.Role, g.Source, g.GranteeType, g.GranteeId}
 }
 
 // repoGrantRow mirrors projectGrantRow; RepoGrant and ProjectGrant share the
 // grantee/role/source shape, so both reuse grantColumns.
 func repoGrantRow(g coreapi.RepoGrant) []string {
-	return []string{g.GranteeType, granteeName(g.GranteeName, g.GranteeId), g.GranteeId, g.Role, g.Source}
+	return []string{granteeName(g.GranteeName, g.GranteeId), g.Role, g.Source, g.GranteeType, g.GranteeId}
 }
 
 // granteeName returns the friendly name when the server resolved one, falling
@@ -145,7 +145,7 @@ func newGrantOrgAddCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().StringVar(&role, "role", "", "org role: owner, admin, or member (default member)")
+	cmd.Flags().StringVar(&role, "role", "", "Org role: owner, admin, or member (default member)")
 	return cmd
 }
 
@@ -254,7 +254,7 @@ func newGrantProjectAddCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().StringVar(&role, "role", "", "project role: reader, writer, or admin (required)")
+	cmd.Flags().StringVar(&role, "role", "", "Project role: reader, writer, or admin (required)")
 	markRequired(cmd, "role")
 	return cmd
 }
@@ -402,7 +402,7 @@ func newGrantRepoAddCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().StringVar(&role, "role", "", "repo role: reader, writer, or admin (required)")
+	cmd.Flags().StringVar(&role, "role", "", "Repo role: reader, writer, or admin (required)")
 	bindRepoProjectFlag(cmd, &project)
 	markRequired(cmd, "role")
 	return cmd

--- a/cmd/entire/cli/grant.go
+++ b/cmd/entire/cli/grant.go
@@ -117,14 +117,14 @@ func newGrantOrgAddCmd() *cobra.Command {
 		Example: "  entire grant org add acme github:alice --role admin",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoreJSON(cmd, func(ctx context.Context, c *coreapi.Client) (any, error) {
+			return runCoreMutation(cmd, func(ctx context.Context, c *coreapi.Client) (string, any, error) {
 				orgID, err := resolveOrgRef(ctx, c, args[0])
 				if err != nil {
-					return nil, err
+					return "", nil, err
 				}
 				provider, providerUserID, err := resolveGranteeProvider(ctx, c, args[1])
 				if err != nil {
-					return nil, err
+					return "", nil, err
 				}
 				body := &coreapi.AddOrgMemberInputBody{
 					Provider:       provider,
@@ -133,11 +133,15 @@ func newGrantOrgAddCmd() *cobra.Command {
 				if role != "" {
 					r, err := parseOrgRole(role)
 					if err != nil {
-						return nil, err
+						return "", nil, err
 					}
 					body.Role = coreapi.NewOptAddOrgMemberInputBodyRole(r)
 				}
-				return c.AddOrgMember(ctx, body, coreapi.AddOrgMemberParams{OrgId: orgID})
+				m, err := c.AddOrgMember(ctx, body, coreapi.AddOrgMemberParams{OrgId: orgID})
+				if err != nil {
+					return "", nil, err
+				}
+				return fmt.Sprintf("✓ Added %s to org %s as %s", args[1], args[0], m.Role), m, nil
 			})
 		},
 	}
@@ -228,21 +232,25 @@ func newGrantProjectAddCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return err
 			}
-			return runCoreJSON(cmd, func(ctx context.Context, c *coreapi.Client) (any, error) {
+			return runCoreMutation(cmd, func(ctx context.Context, c *coreapi.Client) (string, any, error) {
 				projID, err := resolveProjectRef(ctx, c, args[0])
 				if err != nil {
-					return nil, err
+					return "", nil, err
 				}
 				provider, providerUserID, err := resolveGranteeProvider(ctx, c, args[1])
 				if err != nil {
-					return nil, err
+					return "", nil, err
 				}
 				body := &coreapi.GrantProjectAccessInputBody{
 					Provider:       provider,
 					ProviderUserId: providerUserID,
 					Role:           coreapi.GrantProjectAccessInputBodyRole(role),
 				}
-				return c.GrantProjectAccess(ctx, body, coreapi.GrantProjectAccessParams{ProjectId: projID})
+				out, err := c.GrantProjectAccess(ctx, body, coreapi.GrantProjectAccessParams{ProjectId: projID})
+				if err != nil {
+					return "", nil, err
+				}
+				return fmt.Sprintf("✓ Granted %s %s access to project %s", args[1], role, args[0]), out, nil
 			})
 		},
 	}
@@ -372,21 +380,25 @@ func newGrantRepoAddCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return err
 			}
-			return runCoreJSON(cmd, func(ctx context.Context, c *coreapi.Client) (any, error) {
+			return runCoreMutation(cmd, func(ctx context.Context, c *coreapi.Client) (string, any, error) {
 				repoID, err := resolveRepoRef(ctx, c, args[0], project)
 				if err != nil {
-					return nil, err
+					return "", nil, err
 				}
 				provider, providerUserID, err := resolveGranteeProvider(ctx, c, args[1])
 				if err != nil {
-					return nil, err
+					return "", nil, err
 				}
 				body := &coreapi.GrantRepoAccessInputBody{
 					Provider:       provider,
 					ProviderUserId: providerUserID,
 					Role:           coreapi.GrantRepoAccessInputBodyRole(role),
 				}
-				return c.GrantRepoAccess(ctx, body, coreapi.GrantRepoAccessParams{RepoId: repoID})
+				out, err := c.GrantRepoAccess(ctx, body, coreapi.GrantRepoAccessParams{RepoId: repoID})
+				if err != nil {
+					return "", nil, err
+				}
+				return fmt.Sprintf("✓ Granted %s %s access to repo %s", args[1], role, args[0]), out, nil
 			})
 		},
 	}

--- a/cmd/entire/cli/grant_test.go
+++ b/cmd/entire/cli/grant_test.go
@@ -63,7 +63,7 @@ func TestGrantRows(t *testing.T) {
 			Role:        "writer",
 			Source:      "direct",
 		})
-		want := []string{"account", "github:alice", ulid, "writer", "direct"}
+		want := []string{"github:alice", "writer", "direct", "account", ulid}
 		if !slices.Equal(row, want) {
 			t.Errorf("projectGrantRow = %v, want %v", row, want)
 		}
@@ -78,7 +78,7 @@ func TestGrantRows(t *testing.T) {
 			Role:        "reader",
 			Source:      "inherited",
 		})
-		want := []string{"team", ulid, ulid, "reader", "inherited"}
+		want := []string{ulid, "reader", "inherited", "team", ulid}
 		if !slices.Equal(row, want) {
 			t.Errorf("repoGrantRow = %v, want %v", row, want)
 		}

--- a/cmd/entire/cli/grant_wiring_test.go
+++ b/cmd/entire/cli/grant_wiring_test.go
@@ -99,7 +99,7 @@ func TestGrantRemove_RouteWiring(t *testing.T) {
 			))
 			t.Cleanup(srv.Close)
 
-			_, err := runDeleteCmd(t, tc.newCmd, srv.URL, tc.args...)
+			_, _, err := runDeleteCmd(t, tc.newCmd, srv.URL, tc.args...)
 			require.NoError(t, err)
 			require.Equal(t, http.MethodDelete, gotMethod)
 			require.Equal(t, tc.wantPath, gotPath)
@@ -132,9 +132,10 @@ func TestGrantRemove_Idempotent(t *testing.T) {
 			))
 			t.Cleanup(srv.Close)
 
-			out, err := runDeleteCmd(t, tc.newCmd, srv.URL, tc.args...)
+			out, errOut, err := runDeleteCmd(t, tc.newCmd, srv.URL, tc.args...)
 			require.NoError(t, err)
 			require.Contains(t, out, "nothing to revoke")
+			require.Empty(t, errOut)
 		})
 	}
 }

--- a/cmd/entire/cli/grant_wiring_test.go
+++ b/cmd/entire/cli/grant_wiring_test.go
@@ -53,40 +53,47 @@ func grantWiringHandler(t *testing.T, record func(method, path string), deleteFn
 // Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestGrantRemove_RouteWiring(t *testing.T) {
 	cases := []struct {
-		name     string
-		newCmd   func() *cobra.Command
-		args     []string
-		wantPath string
+		name       string
+		newCmd     func() *cobra.Command
+		args       []string
+		wantPath   string
+		wantOutput string // when set, the full success line; otherwise just "✓ " is checked
 	}{
 		{
 			"repo/by-provider",
 			newGrantRepoRemoveCmd,
 			[]string{wiringRepoULID, "github:alice"},
 			"/api/v1/repos/" + wiringRepoULID + "/grants/account/github/12345",
+			"✓ Revoked github:alice from repo " + wiringRepoULID,
 		},
 		{
 			"repo/by-grantee-id",
 			newGrantRepoRemoveCmd,
 			[]string{wiringRepoULID, wiringGranteeULID},
 			"/api/v1/repos/" + wiringRepoULID + "/grants/account/" + wiringGranteeULID,
+			"",
 		},
 		{
 			"project/by-provider",
 			newGrantProjectRemoveCmd,
 			[]string{wiringProjULID, "github:alice"},
 			"/api/v1/projects/" + wiringProjULID + "/grants/account/github/12345",
+			"",
 		},
 		{
 			"project/by-grantee-id",
 			newGrantProjectRemoveCmd,
 			[]string{wiringProjULID, wiringGranteeULID},
 			"/api/v1/projects/" + wiringProjULID + "/grants/account/" + wiringGranteeULID,
+			"",
 		},
 		{
 			"org/by-provider",
 			newGrantOrgRemoveCmd,
 			[]string{wiringOrgULID, "github:alice"},
 			"/api/v1/orgs/" + wiringOrgULID + "/members/github/12345",
+			// org remove uses verb "Removed"; project/repo use "Revoked".
+			"✓ Removed github:alice from org " + wiringOrgULID,
 		},
 	}
 
@@ -99,10 +106,14 @@ func TestGrantRemove_RouteWiring(t *testing.T) {
 			))
 			t.Cleanup(srv.Close)
 
-			_, _, err := runCoreCmd(t, tc.newCmd, srv.URL, tc.args...)
+			out, _, err := runCoreCmd(t, tc.newCmd, srv.URL, tc.args...)
 			require.NoError(t, err)
 			require.Equal(t, http.MethodDelete, gotMethod)
 			require.Equal(t, tc.wantPath, gotPath)
+			require.Contains(t, out, "✓ ")
+			if tc.wantOutput != "" {
+				require.Contains(t, out, tc.wantOutput)
+			}
 		})
 	}
 }

--- a/cmd/entire/cli/grant_wiring_test.go
+++ b/cmd/entire/cli/grant_wiring_test.go
@@ -50,7 +50,7 @@ func grantWiringHandler(t *testing.T, record func(method, path string), deleteFn
 // then hits the by-provider revoke route, while an account ULID hits the
 // typed-id route directly. This locks in the grantee→route mapping.
 //
-// Not parallel: runDeleteCmd swaps the package-level activeCoreClient seam.
+// Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestGrantRemove_RouteWiring(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -99,7 +99,7 @@ func TestGrantRemove_RouteWiring(t *testing.T) {
 			))
 			t.Cleanup(srv.Close)
 
-			_, _, err := runDeleteCmd(t, tc.newCmd, srv.URL, tc.args...)
+			_, _, err := runCoreCmd(t, tc.newCmd, srv.URL, tc.args...)
 			require.NoError(t, err)
 			require.Equal(t, http.MethodDelete, gotMethod)
 			require.Equal(t, tc.wantPath, gotPath)
@@ -111,7 +111,7 @@ func TestGrantRemove_RouteWiring(t *testing.T) {
 // (the server answers 404) is a no-op success — "no such grant; nothing to
 // revoke" — rather than surfacing a raw 404, matching the typed deletes.
 //
-// Not parallel: runDeleteCmd swaps the package-level activeCoreClient seam.
+// Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestGrantRemove_Idempotent(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -132,7 +132,7 @@ func TestGrantRemove_Idempotent(t *testing.T) {
 			))
 			t.Cleanup(srv.Close)
 
-			out, errOut, err := runDeleteCmd(t, tc.newCmd, srv.URL, tc.args...)
+			out, errOut, err := runCoreCmd(t, tc.newCmd, srv.URL, tc.args...)
 			require.NoError(t, err)
 			require.Contains(t, out, "nothing to revoke")
 			require.Empty(t, errOut)

--- a/cmd/entire/cli/labs.go
+++ b/cmd/entire/cli/labs.go
@@ -43,17 +43,17 @@ var experimentalCommands = []experimentalCommandInfo{
 	{
 		CommandPath: []string{"org"},
 		Invocation:  "entire org",
-		Summary:     "Manage Entire organizations (create, list)",
+		Summary:     "Manage Entire organizations (create, list, get, delete)",
 	},
 	{
 		CommandPath: []string{"project"},
 		Invocation:  "entire project",
-		Summary:     "Manage Entire projects (create, list)",
+		Summary:     "Manage Entire projects (create, list, get, delete)",
 	},
 	{
 		CommandPath: []string{"repo"},
 		Invocation:  "entire repo",
-		Summary:     "Manage Entire repositories (create, list, get, delete)",
+		Summary:     "Manage Entire repositories (create, list, get, delete, clone, mirror, visibility)",
 	},
 	{
 		CommandPath: []string{"grant"},

--- a/cmd/entire/cli/org.go
+++ b/cmd/entire/cli/org.go
@@ -54,7 +54,7 @@ func newOrgCreateCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().StringVar(&region, "region", "", "jurisdiction slug (defaults to the server's home jurisdiction)")
+	cmd.Flags().StringVar(&region, "region", "", "Jurisdiction slug (defaults to the server's home jurisdiction)")
 	return cmd
 }
 

--- a/cmd/entire/cli/org.go
+++ b/cmd/entire/cli/org.go
@@ -59,7 +59,7 @@ func newOrgListCmd() *cobra.Command {
 		Short: "List organizations you can see",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runCoreList(cmd, orgColumns, orgRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Org, error) {
+			return runCoreList(cmd, "No organizations found.", orgColumns, orgRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Org, error) {
 				return fetchAllPages(ctx, func(ctx context.Context, cursor string) ([]coreapi.Org, string, error) {
 					params := coreapi.ListOrgsParams{}
 					if cursor != "" {

--- a/cmd/entire/cli/org.go
+++ b/cmd/entire/cli/org.go
@@ -9,9 +9,9 @@ import (
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// newOrgCmd is the hidden `entire org` command group: create and list
-// organizations on the Entire control plane. Surfaced via `entire labs`
-// while the control-plane surface matures.
+// newOrgCmd is the hidden `entire org` command group: create, list, get, and
+// delete organizations on the Entire control plane. Surfaced via `entire
+// labs` while the control-plane surface matures.
 func newOrgCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "org",

--- a/cmd/entire/cli/org.go
+++ b/cmd/entire/cli/org.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -40,12 +41,16 @@ func newOrgCreateCmd() *cobra.Command {
 		Short: "Create an organization",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoreJSON(cmd, func(ctx context.Context, c *coreapi.Client) (any, error) {
+			return runCoreMutation(cmd, func(ctx context.Context, c *coreapi.Client) (string, any, error) {
 				body := &coreapi.CreateOrgInputBody{Name: args[0]}
 				if region != "" {
 					body.Region = coreapi.NewOptString(region)
 				}
-				return c.CreateOrg(ctx, body)
+				org, err := c.CreateOrg(ctx, body)
+				if err != nil {
+					return "", nil, err
+				}
+				return fmt.Sprintf("✓ Created org %s (%s)", org.Name, org.ID), org, nil
 			})
 		},
 	}

--- a/cmd/entire/cli/project.go
+++ b/cmd/entire/cli/project.go
@@ -55,7 +55,7 @@ func newProjectCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runCoreJSON(cmd, func(ctx context.Context, c *coreapi.Client) (any, error) {
+			return runCoreMutation(cmd, func(ctx context.Context, c *coreapi.Client) (string, any, error) {
 				// Orgs are addressed by name, accounts by github:handle; both
 				// also accept a raw ULID.
 				var ownerRef string
@@ -66,7 +66,7 @@ func newProjectCreateCmd() *cobra.Command {
 					ownerRef, err = resolveAccountRef(ctx, c, ownerID)
 				}
 				if err != nil {
-					return nil, err
+					return "", nil, err
 				}
 				body := &coreapi.CreateProjectInputBody{
 					Name:      args[0],
@@ -76,7 +76,11 @@ func newProjectCreateCmd() *cobra.Command {
 				if region != "" {
 					body.Region = coreapi.NewOptString(region)
 				}
-				return c.CreateProject(ctx, body)
+				project, err := c.CreateProject(ctx, body)
+				if err != nil {
+					return "", nil, err
+				}
+				return fmt.Sprintf("✓ Created project %s (%s)", project.Name, project.ID), project, nil
 			})
 		},
 	}

--- a/cmd/entire/cli/project.go
+++ b/cmd/entire/cli/project.go
@@ -9,8 +9,9 @@ import (
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// newProjectCmd is the hidden `entire project` command group: create and
-// list projects on the Entire control plane. Surfaced via `entire labs`.
+// newProjectCmd is the hidden `entire project` command group: create, list,
+// get, and delete projects on the Entire control plane. Surfaced via `entire
+// labs`.
 func newProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "project",

--- a/cmd/entire/cli/project.go
+++ b/cmd/entire/cli/project.go
@@ -84,9 +84,9 @@ func newProjectCreateCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().StringVar(&ownerID, "owner", "", "owning org (name or ULID), or account (github:handle or ULID) (required)")
-	cmd.Flags().StringVar(&ownerType, "owner-type", "org", "owner kind: org or account")
-	cmd.Flags().StringVar(&region, "region", "", "jurisdiction slug (defaults to the server's home jurisdiction)")
+	cmd.Flags().StringVar(&ownerID, "owner", "", "Owning org (name or ULID), or account (github:handle or ULID) (required)")
+	cmd.Flags().StringVar(&ownerType, "owner-type", "org", "Owner kind: org or account")
+	cmd.Flags().StringVar(&region, "region", "", "Jurisdiction slug (defaults to the server's home jurisdiction)")
 	markRequired(cmd, "owner")
 	return cmd
 }
@@ -154,8 +154,8 @@ func newProjectListCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().StringVar(&name, "name", "", "filter by exact project name")
-	cmd.Flags().StringVar(&org, "org", "", "list projects owned by this org (name or ULID)")
+	cmd.Flags().StringVar(&name, "name", "", "Filter by exact project name")
+	cmd.Flags().StringVar(&org, "org", "", "List projects owned by this org (name or ULID)")
 	return cmd
 }
 

--- a/cmd/entire/cli/project.go
+++ b/cmd/entire/cli/project.go
@@ -94,7 +94,7 @@ func newProjectListCmd() *cobra.Command {
 		Short: "List projects you can see",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runCoreList(cmd, projectColumns, projectRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Project, error) {
+			return runCoreList(cmd, "No projects found.", projectColumns, projectRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Project, error) {
 				// Both the global and org-scoped list endpoints filter by name
 				// server-side (case-insensitive), returning the single match under
 				// the response's `project` field (or 404 → empty result, not an

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -121,10 +121,10 @@ func newRepoCreateCmd() *cobra.Command {
 		Short: "Create a repository in a project",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoreJSON(cmd, func(ctx context.Context, c *coreapi.Client) (any, error) {
+			return runCoreMutation(cmd, func(ctx context.Context, c *coreapi.Client) (string, any, error) {
 				projID, err := resolveProjectRef(ctx, c, projectID)
 				if err != nil {
-					return nil, err
+					return "", nil, err
 				}
 				body := &coreapi.CreateRepoInputBody{
 					Name:      args[0],
@@ -135,9 +135,17 @@ func newRepoCreateCmd() *cobra.Command {
 				}
 				created, err := c.CreateRepo(ctx, body)
 				if err != nil {
-					return nil, err
+					return "", nil, err
 				}
-				return repoCreateOutput(created)
+				wire, err := repoCreateOutput(created)
+				if err != nil {
+					return "", nil, err
+				}
+				msg := fmt.Sprintf("✓ Created repository %s (%s)", created.Name, created.ID)
+				if remote := repoRemoteURL(*created); remote != "" {
+					msg += "\n  Remote: " + remote
+				}
+				return msg, wire, nil
 			})
 		},
 	}

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -13,10 +13,11 @@ import (
 )
 
 // newRepoCmd is the hidden `entire repo` command group: control-plane
-// repository lifecycle (create, list within a project, get, delete) plus the
-// `clone` convenience that resolves a mirror and shells out to `git clone`.
-// Other git content operations (log, diff, …) remain intentionally out of scope
-// here. Surfaced via `entire labs`.
+// repository lifecycle (create, list within a project, get, delete), the
+// `mirror` and `visibility` subtrees, plus the `clone` convenience that
+// resolves a mirror and shells out to `git clone`. Other git content
+// operations (log, diff, …) remain intentionally out of scope here. Surfaced
+// via `entire labs`.
 func newRepoCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "repo",

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -154,7 +154,7 @@ func newRepoListCmd() *cobra.Command {
 		Long:  "List repositories in a project, addressed by name or ULID.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoreList(cmd, repoColumns, repoRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Repo, error) {
+			return runCoreList(cmd, "No repositories found in this project.", repoColumns, repoRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Repo, error) {
 				projID, err := resolveProjectRef(ctx, c, args[0])
 				if err != nil {
 					return nil, err

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -149,8 +149,8 @@ func newRepoCreateCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().StringVar(&projectID, "project", "", "owning project (name or ULID) (required)")
-	cmd.Flags().StringVar(&clusterHost, "cluster-host", "", "public host of the cluster to pin the repo to (defaults to the jurisdiction default)")
+	cmd.Flags().StringVar(&projectID, "project", "", "Owning project (name or ULID) (required)")
+	cmd.Flags().StringVar(&clusterHost, "cluster-host", "", "Public host of the cluster to pin the repo to (defaults to the jurisdiction default)")
 	markRequired(cmd, "project")
 	return cmd
 }
@@ -304,6 +304,7 @@ func newRepoVisibilitySetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			vis, err := parseVisibility(args[1])
 			if err != nil {
+				cmd.SilenceUsage = true
 				return err
 			}
 			return runCoreObject(cmd, visibilityColumns, visibilityRow, func(ctx context.Context, c *coreapi.Client) (*repoVisibility, error) {
@@ -327,5 +328,5 @@ func newRepoVisibilitySetCmd() *cobra.Command {
 // addressed by name (a repo name is unique only within its project). Ignored
 // when the repo arg is already a ULID.
 func bindRepoProjectFlag(cmd *cobra.Command, project *string) {
-	cmd.Flags().StringVar(project, "project", "", "owning project (name or ULID); required when <repo> is a name")
+	cmd.Flags().StringVar(project, "project", "", "Owning project (name or ULID); required when <repo> is a name")
 }

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -162,7 +162,7 @@ func newRepoCloneCmd() *cobra.Command {
 			return runGitClone(cmd.Context(), cmd, cloneURL, targetDir)
 		},
 	}
-	cmd.Flags().StringVar(&cluster, "cluster", "", "cluster host to clone from when the repo is mirrored on more than one (may belong to another auth context)")
+	cmd.Flags().StringVar(&cluster, "cluster", "", "Cluster host to clone from when the repo is mirrored on more than one (may belong to another auth context)")
 	return cmd
 }
 

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -291,7 +291,7 @@ func reportOneShotMirror(out, errW io.Writer, outcome mirrorCreateOutcome, err e
 		return err
 	}
 	if created.Created {
-		fmt.Fprintf(out, "\nRegistered mirror %s\n", created.MirrorId)
+		fmt.Fprintf(out, "\n✓ Registered mirror %s\n", created.MirrorId)
 	} else {
 		fmt.Fprintf(out, "\nMirror exists (%s)\n", created.MirrorId)
 	}
@@ -536,6 +536,9 @@ func newRepoMirrorRemoveCmd() *cobra.Command {
 					ClusterHost: clusterHost,
 				}); err != nil {
 					if isCoreNotFound(err) {
+						// Deliberately not %w-wrapped: renderCoreError would extract
+						// the server's generic problem detail and replace this
+						// targeted message.
 						return fmt.Errorf("no mirror of github.com/%s/%s on %s — it may be on a different cluster (run `entire repo mirror list` to see placements)", owner, repo, clusterHost)
 					}
 					return err

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -341,7 +341,7 @@ func newRepoMirrorListCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if showAvailable {
-				return runCoreList(cmd, availableMirrorColumns, availableMirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.AvailableMirror, error) {
+				return runCoreList(cmd, "No repos available to mirror.", availableMirrorColumns, availableMirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.AvailableMirror, error) {
 					// Computed live from GitHub using your own login, so name the
 					// core being dialled (same rationale as the existing-mirror
 					// banner). --cluster/--provider don't apply here: the
@@ -360,7 +360,7 @@ func newRepoMirrorListCmd() *cobra.Command {
 					return out.Available, nil
 				})
 			}
-			return runCoreList(cmd, mirrorColumns, mirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Mirror, error) {
+			return runCoreList(cmd, "No mirrors found.", mirrorColumns, mirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Mirror, error) {
 				// mirror list is identity-scoped: it shows the mirrors visible
 				// from the active login's federation, so naming that login server
 				// makes a surprising empty result legible — e.g. mirrors in a
@@ -527,17 +527,20 @@ func newRepoMirrorRemoveCmd() *cobra.Command {
 				// error here, not idempotent success: the server only
 				// answers 204 when it actually removed a placement, so a
 				// 404 ("no such mirror / not visible / different cluster")
-				// surfaces verbatim via renderCoreError rather than being
-				// reported as a successful removal.
+				// maps to a targeted "may be on a different cluster" error
+				// rather than being reported as a successful removal.
 				if err := c.DeleteMirror(ctx, coreapi.DeleteMirrorParams{
 					Provider:    coreapi.DeleteMirrorProviderGithub,
 					Owner:       owner,
 					Repo:        repo,
 					ClusterHost: clusterHost,
 				}); err != nil {
+					if isCoreNotFound(err) {
+						return fmt.Errorf("no mirror of github.com/%s/%s on %s — it may be on a different cluster (run `entire repo mirror list` to see placements)", owner, repo, clusterHost)
+					}
 					return err
 				}
-				cmd.Printf("Removed mirror github.com/%s/%s from %s\n", owner, repo, clusterHost)
+				fmt.Fprintf(cmd.OutOrStdout(), "✓ Removed mirror github.com/%s/%s from %s\n", owner, repo, clusterHost)
 				return nil
 			})
 		},

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -523,29 +523,36 @@ func newRepoMirrorRemoveCmd() *cobra.Command {
 				return fmt.Errorf("invalid [cluster-host]: %w", err)
 			}
 			return runCoreForCluster(cmd, clusterHost, func(ctx context.Context, c *coreapi.Client) error {
-				// Delete by upstream coords in one call. A 404 is a real
-				// error here, not idempotent success: the server only
-				// answers 204 when it actually removed a placement, so a
-				// 404 ("no such mirror / not visible / different cluster")
-				// maps to a targeted "may be on a different cluster" error
-				// rather than being reported as a successful removal.
-				if err := c.DeleteMirror(ctx, coreapi.DeleteMirrorParams{
-					Provider:    coreapi.DeleteMirrorProviderGithub,
-					Owner:       owner,
-					Repo:        repo,
-					ClusterHost: clusterHost,
-				}); err != nil {
-					if isCoreNotFound(err) {
-						// Deliberately not %w-wrapped: renderCoreError would extract
-						// the server's generic problem detail and replace this
-						// targeted message.
-						return fmt.Errorf("no mirror of github.com/%s/%s on %s — it may be on a different cluster (run `entire repo mirror list` to see placements)", owner, repo, clusterHost)
-					}
-					return err
-				}
-				fmt.Fprintf(cmd.OutOrStdout(), "✓ Removed mirror github.com/%s/%s from %s\n", owner, repo, clusterHost)
-				return nil
+				return removeMirror(ctx, cmd.OutOrStdout(), c, owner, repo, clusterHost)
 			})
 		},
 	}
+}
+
+// removeMirror deletes the (owner, repo) placement on clusterHost via c and
+// reports the outcome on w. A decoded 404 is a real error here (the server
+// only answers 204 when it actually removed a placement); it is rewritten
+// into a targeted message with the server's own detail appended so no
+// information is lost.
+func removeMirror(ctx context.Context, w io.Writer, c *coreapi.Client, owner, repo, clusterHost string) error {
+	if err := c.DeleteMirror(ctx, coreapi.DeleteMirrorParams{
+		Provider:    coreapi.DeleteMirrorProviderGithub,
+		Owner:       owner,
+		Repo:        repo,
+		ClusterHost: clusterHost,
+	}); err != nil {
+		if isCoreNotFound(err) {
+			// Deliberately not %w-wrapped: renderCoreError would extract the
+			// server's problem detail and replace this targeted message. The
+			// detail is appended as plain text instead, so nothing is lost.
+			msg := fmt.Sprintf("no mirror of github.com/%s/%s on %s — it may be on a different cluster (run `entire repo mirror list` to see placements)", owner, repo, clusterHost)
+			if detail := coreapi.APIError(err); detail != "" {
+				msg += " (server: " + detail + ")"
+			}
+			return errors.New(msg)
+		}
+		return err
+	}
+	fmt.Fprintf(w, "✓ Removed mirror github.com/%s/%s from %s\n", owner, repo, clusterHost)
+	return nil
 }

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -207,8 +207,8 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().BoolVar(&noWait, "no-wait", false, "return once the placement is registered, without waiting for the initial clone")
-	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Minute, "how long to wait for the initial clone to finish")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Return once the placement is registered, without waiting for the initial clone")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Minute, "How long to wait for the initial clone to finish")
 	return cmd
 }
 
@@ -397,10 +397,10 @@ func newRepoMirrorListCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().StringVar(&cluster, "cluster", "", "filter by cluster public host")
-	cmd.Flags().StringVar(&provider, "provider", "", "filter by upstream provider (e.g. github)")
-	cmd.Flags().StringVar(&owner, "owner", "", "filter by upstream owner login")
-	cmd.Flags().BoolVar(&showAvailable, "show-available", false, "instead of existing mirrors, list GitHub repos you could onboard as mirrors (ignores --cluster/--provider)")
+	cmd.Flags().StringVar(&cluster, "cluster", "", "Filter by cluster public host")
+	cmd.Flags().StringVar(&provider, "provider", "", "Filter by upstream provider (e.g. github)")
+	cmd.Flags().StringVar(&owner, "owner", "", "Filter by upstream owner login")
+	cmd.Flags().BoolVar(&showAvailable, "show-available", false, "Instead of existing mirrors, list GitHub repos you could onboard as mirrors (ignores --cluster/--provider)")
 	return cmd
 }
 

--- a/cmd/entire/cli/repo_mirror_collaborators.go
+++ b/cmd/entire/cli/repo_mirror_collaborators.go
@@ -69,7 +69,7 @@ func newRepoMirrorCollaboratorsListCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("invalid [cluster-host]: %w", err)
 			}
-			return runCoreListForCluster(cmd, clusterHost, mirrorCollaboratorColumns, mirrorCollaboratorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.MirrorCollaborator, error) {
+			return runCoreListForCluster(cmd, clusterHost, "No collaborators found.", mirrorCollaboratorColumns, mirrorCollaboratorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.MirrorCollaborator, error) {
 				out, err := c.ListMirrorCollaborators(ctx, coreapi.ListMirrorCollaboratorsParams{
 					Provider:    coreapi.ListMirrorCollaboratorsProviderGithub,
 					Owner:       owner,

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/internal/coreapi"
@@ -833,4 +834,65 @@ func TestValidateClusterHost(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRemoveMirror covers `repo mirror remove`'s DeleteMirror call:
+// removeMirror dials via runCoreForCluster, which the activeCoreClient test
+// seam does not intercept, so this drives the helper directly against an
+// httptest server the way the createAndAwaitMirror tests do.
+func TestRemoveMirror(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodDelete, r.Method)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		t.Cleanup(srv.Close)
+		c, err := coreapi.NewWithBearer(srv.URL, "tok")
+		require.NoError(t, err)
+
+		var out bytes.Buffer
+		err = removeMirror(t.Context(), &out, c, "octocat", "hello-world", "aws-us-east-2.entire.io")
+		require.NoError(t, err)
+		require.Contains(t, out.String(), "✓ Removed mirror github.com/octocat/hello-world from aws-us-east-2.entire.io")
+	})
+
+	t.Run("decoded 404 appends server detail", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			writeNotFoundProblem(t, w)
+		}))
+		t.Cleanup(srv.Close)
+		c, err := coreapi.NewWithBearer(srv.URL, "tok")
+		require.NoError(t, err)
+
+		var out bytes.Buffer
+		err = removeMirror(t.Context(), &out, c, "octocat", "hello-world", "aws-us-east-2.entire.io")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "may be on a different cluster")
+		require.ErrorContains(t, err, "(server: not found)")
+		require.Empty(t, out.String())
+	})
+
+	t.Run("non-404 server error passes through the problem detail", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.WriteHeader(http.StatusInternalServerError)
+			if _, werr := w.Write([]byte(`{"status":500,"detail":"boom"}`)); werr != nil {
+				t.Errorf("write problem: %v", werr)
+			}
+		}))
+		t.Cleanup(srv.Close)
+		c, err := coreapi.NewWithBearer(srv.URL, "tok")
+		require.NoError(t, err)
+
+		var out bytes.Buffer
+		err = removeMirror(t.Context(), &out, c, "octocat", "hello-world", "aws-us-east-2.entire.io")
+		require.Error(t, err)
+		require.Equal(t, "boom", coreapi.APIError(err))
+		require.Empty(t, out.String())
+	})
 }


### PR DESCRIPTION
## Summary

Output cleanup for the control-plane command groups (`org`, `project`, `repo`, `grant`) — no behavior changes (verbs, flags, prompts, exit codes, 404 semantics, and API calls are all identical). The `--json` payload stays a full wire passthrough (additive-only, nothing omitted) so agents/scripts keep the complete `/api/v1` object shape.

## What changed, per command

| Command | Before | After |
|---|---|---|
| `org create` / `project create` | Raw wire-JSON dump by default | `✓ Created org acme (01H…)` — JSON via `--json` |
| `repo create` | Raw wire-JSON dump by default | `✓ Created repository web (01H…)` + `  Remote: entire://…` when resolvable — JSON (incl. merged `remote`) via `--json` |
| `grant org add` | Raw wire-JSON dump | `✓ Added github:alice to org acme as member` |
| `grant project/repo add` | Raw wire-JSON dump | `✓ Granted github:alice writer access to project widgets` |
| `org/project/repo delete` | `Deleted org acme (01H…)` on **stderr** (cobra `cmd.Printf` fallback — `2>/dev/null` hid it) | `✓ Deleted org acme (01H…)` on **stdout** |
| `org/project/repo delete` (already gone) | `… not found; nothing to delete` on stderr | Same text, stdout (still exit 0) |
| `grant org/project/repo remove` | `Revoked github:alice from repo web` on **stderr** | `✓ Revoked …` / `✓ Removed …` on **stdout** |
| `repo mirror remove` | `Removed mirror …` on **stderr**; 404 surfaced the server's generic problem detail | `✓ Removed mirror …` on **stdout**; 404 → `no mirror of github.com/x/y on <cluster> — it may be on a different cluster (run 'entire repo mirror list' …) (server: <detail>)` — still exit 1 |
| `repo mirror create` | `Registered mirror 01…` | `✓ Registered mirror 01…` |
| every `list` with zero results | `(none)` on **stderr**; `--json` printed `null` | Sentence on **stdout** (`No organizations found.`, `No mirrors found.`, …); `--json` prints `[]` |
| every `list`/`get` with results | *(unchanged)* | Same lipgloss tables / field views, same `--json` |
| `grant project/repo list` | Columns `GRANTEE-TYPE  GRANTEE  ID  ROLE  SOURCE` (primary color on "account") | `GRANTEE  ROLE  SOURCE  TYPE  ID` (primary color on the handle) |
| `repo visibility set <repo> bogus` | Error + full usage dump | One-line error only |
| all flag help text | Mixed casing (`output raw JSON…`) | House-style capitalized (20 strings, first letter only) |
| `entire labs` | Stale summaries ("create, list") | Actual verb sets per group |

**Explicitly unchanged:** all verbs and flags, confirmation prompts, `--force`/`--yes`, 404-idempotency semantics (delete/revoke idempotent, mirror remove strict), exit codes, every API call, and the `--json` schema itself.

## Review hardening (last commit)

A 12-agent review pass over the PR produced one follow-up commit: the mirror-remove 404 error now appends the server's own detail (extracted to a testable `removeMirror` helper with 404/success/passthrough coverage), test gaps closed (repo-create message assembly, grant-revoke output, list harness now drives the real `org list` command), stale group doc comments fixed, a CHANGELOG entry for the new output contract, and a `forbidigo` guard banning cobra's `Print*` (stderr fallback) so the bug this PR fixes can't be reintroduced.

## Test Plan

- [x] `mise run check` (fmt, lint, unit + integration + Vogon/roger-roger canaries) green
- [x] Wiring tests pin the contracts: stream routing (`✓ …` on stdout), `[]` for empty `--json`, human-vs-JSON create paths, mirror-remove 404 message, grant-revoke output (201/204/problem-json httptest control plane)
- [x] Live smoke test against `us.auth.entire.io`: org create/get/delete round-trip, empty states, mirror-list stderr banner, validation-error probes, non-interactive delete refusal
- [x] TTY rendering verified via pty capture: lipgloss table/field styling intact; new messages plain like the existing `✓ Login complete.` convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)