### PR TITLE
Add hidden `doctor rewrite-checkpoints` test tooling (git-branch → git-refs)

### DIFF
--- a/cmd/entire/cli/checkpoint/rewrite.go
+++ b/cmd/entire/cli/checkpoint/rewrite.go
@@ -55,7 +55,8 @@ func RewriteBranchToRefs(ctx context.Context, repo *git.Repository, dryRun, forc
 	}
 
 	authors := branchSessionAuthors(ctx, repo)
-	fallbackName, fallbackEmail := GetGitAuthorFromRepo(repo)
+	fbName, fbEmail := GetGitAuthorFromRepo(repo)
+	fallback := commitAuthor{Name: fbName, Email: fbEmail}
 	refsStore := newGitRefsStore(repo)
 
 	walkErr := WalkCheckpointShards(ctx, repo, tree, func(cid id.CheckpointID, cpTreeHash plumbing.Hash) error {
@@ -80,7 +81,7 @@ func RewriteBranchToRefs(ctx context.Context, repo *git.Repository, dryRun, forc
 			return nil
 		}
 
-		if err := rewriteCheckpoint(ctx, branch, refsStore, repo, cid, cpTreeHash, authors, fallbackName, fallbackEmail); err != nil {
+		if err := rewriteCheckpoint(ctx, branch, refsStore, repo, cid, refName, cpTreeHash, authors, fallback, force); err != nil {
 			return fmt.Errorf("rewrite checkpoint %s: %w", cid, err)
 		}
 		result.Rewritten = append(result.Rewritten, cid)
@@ -92,10 +93,22 @@ func RewriteBranchToRefs(ctx context.Context, repo *git.Repository, dryRun, forc
 	return result, nil
 }
 
+// tasksDirName is the checkpoint subtree that holds subagent task steps.
+const tasksDirName = "tasks"
+
 // commitAuthor is a git author identity.
 type commitAuthor struct {
 	Name  string
 	Email string
+}
+
+// resolveAuthor returns the recorded author for a session, or the fallback when
+// the session has no mapped commit author.
+func resolveAuthor(sessionID string, authors map[string]commitAuthor, fallback commitAuthor) commitAuthor {
+	if a, ok := authors[sessionID]; ok && a.Name != "" {
+		return a
+	}
+	return fallback
 }
 
 // branchSessionAuthors maps each session id to the author of the earliest
@@ -137,9 +150,11 @@ func rewriteCheckpoint(
 	refsStore *gitRefsStore,
 	repo *git.Repository,
 	cid id.CheckpointID,
+	refName plumbing.ReferenceName,
 	cpTreeHash plumbing.Hash,
 	authors map[string]commitAuthor,
-	fallbackName, fallbackEmail string,
+	fallback commitAuthor,
+	force bool,
 ) error {
 	summary, err := branch.Read(ctx, cid)
 	if err != nil {
@@ -149,33 +164,29 @@ func rewriteCheckpoint(
 		return errors.New("checkpoint summary not found on branch")
 	}
 
-	// Start clean: drop any existing ref so the replay builds a fresh history
-	// rooted at an orphan commit rather than parenting on stale content.
-	refName, err := RefName(cid)
-	if err != nil {
-		return err
-	}
-	if _, err := repo.Reference(refName, true); err == nil {
-		if err := repo.Storer.RemoveReference(refName); err != nil {
-			return fmt.Errorf("reset existing ref: %w", err)
+	// Under --force, drop the existing ref so the replay builds a fresh history
+	// rooted at an orphan commit. Without --force the caller already skipped an
+	// existing ref, so there's nothing to reset.
+	if force {
+		if _, err := repo.Reference(refName, true); err == nil {
+			if err := repo.Storer.RemoveReference(refName); err != nil {
+				return fmt.Errorf("reset existing ref: %w", err)
+			}
 		}
 	}
 
 	// Replay each session in order. Writing session N then its summary keeps
 	// SessionSummary (which targets the latest session) pointed at the right one.
-	firstAuthor := commitAuthor{Name: fallbackName, Email: fallbackEmail}
+	firstAuthor := fallback
 	for idx := range summary.Sessions {
 		content, err := branch.ReadSessionContent(ctx, cid, idx)
 		if err != nil {
 			return fmt.Errorf("read session %d: %w", idx, err)
 		}
 		m := content.Metadata
-		name, email := fallbackName, fallbackEmail
-		if a, ok := authors[m.SessionID]; ok && a.Name != "" {
-			name, email = a.Name, a.Email
-		}
+		author := resolveAuthor(m.SessionID, authors, fallback)
 		if idx == 0 {
-			firstAuthor = commitAuthor{Name: name, Email: email}
+			firstAuthor = author
 		}
 
 		if err := refsStore.Write(ctx, Session(WriteOptions{
@@ -189,8 +200,8 @@ func rewriteCheckpoint(
 			FilesTouched:                m.FilesTouched,
 			CheckpointsCount:            m.CheckpointsCount,
 			SaveStepCount:               m.SaveStepCount,
-			AuthorName:                  name,
-			AuthorEmail:                 email,
+			AuthorName:                  author.Name,
+			AuthorEmail:                 author.Email,
 			Agent:                       m.Agent,
 			Model:                       m.Model,
 			TurnID:                      m.TurnID,
@@ -230,8 +241,8 @@ func rewriteCheckpoint(
 	// Graft the tasks/ subtree unchanged if the checkpoint has one — task steps
 	// aren't reconstructable through the write union, so the existing tree is
 	// carried over verbatim.
-	if tasksHash, ok := subtreeEntryHash(repo, cpTreeHash, "tasks"); ok {
-		if err := graftTasksSubtree(ctx, repo, refsStore, cid, tasksHash, firstAuthor); err != nil {
+	if tasksHash, ok := subtreeEntryHash(repo, cpTreeHash, tasksDirName); ok {
+		if err := graftTasksSubtree(ctx, repo, refsStore, cid, refName, tasksHash, firstAuthor); err != nil {
 			return fmt.Errorf("graft tasks: %w", err)
 		}
 	}
@@ -253,12 +264,10 @@ func subtreeEntryHash(repo *git.Repository, treeHash plumbing.Hash, name string)
 }
 
 // graftTasksSubtree adds the tasks/ subtree to the checkpoint's current ref tree
-// via one commit on top, reusing the existing task objects unchanged.
-func graftTasksSubtree(ctx context.Context, repo *git.Repository, refsStore *gitRefsStore, cid id.CheckpointID, tasksHash plumbing.Hash, author commitAuthor) error {
-	refName, err := RefName(cid)
-	if err != nil {
-		return err
-	}
+// via one commit on top, reusing the existing task objects unchanged. The tasks/
+// entry is spliced into the root tree with UpdateSubtree, so every sibling
+// session subtree keeps its hash — no whole-tree rebuild.
+func graftTasksSubtree(ctx context.Context, repo *git.Repository, refsStore *gitRefsStore, cid id.CheckpointID, refName plumbing.ReferenceName, tasksHash plumbing.Hash, author commitAuthor) error {
 	ref, err := repo.Reference(refName, true)
 	if err != nil {
 		return fmt.Errorf("resolve ref: %w", err)
@@ -267,25 +276,11 @@ func graftTasksSubtree(ctx context.Context, repo *git.Repository, refsStore *git
 	if err != nil {
 		return fmt.Errorf("read ref commit: %w", err)
 	}
-	rootTree, err := commit.Tree()
+	newTree, err := UpdateSubtree(repo, commit.TreeHash, nil,
+		[]object.TreeEntry{{Name: tasksDirName, Mode: filemode.Dir, Hash: tasksHash}},
+		UpdateSubtreeOptions{MergeMode: MergeKeepExisting})
 	if err != nil {
-		return fmt.Errorf("read ref tree: %w", err)
-	}
-	tasksTree, err := repo.TreeObject(tasksHash)
-	if err != nil {
-		return fmt.Errorf("read tasks subtree: %w", err)
-	}
-
-	entries := make(map[string]object.TreeEntry)
-	if err := FlattenTree(repo, rootTree, "", entries); err != nil {
-		return fmt.Errorf("flatten ref tree: %w", err)
-	}
-	if err := FlattenTree(repo, tasksTree, "tasks", entries); err != nil {
-		return fmt.Errorf("flatten tasks subtree: %w", err)
-	}
-	newTree, err := BuildTreeFromEntries(ctx, repo, entries)
-	if err != nil {
-		return fmt.Errorf("build grafted tree: %w", err)
+		return fmt.Errorf("graft tasks subtree: %w", err)
 	}
 	if newTree == commit.TreeHash {
 		return nil // tasks already present, nothing to graft

--- a/cmd/entire/cli/checkpoint/rewrite.go
+++ b/cmd/entire/cli/checkpoint/rewrite.go
@@ -185,7 +185,7 @@ func rewriteCheckpoint(
 			Strategy:                    m.Strategy,
 			Branch:                      m.Branch,
 			Transcript:                  redact.AlreadyRedacted(content.Transcript),
-			Prompts:                     []string{content.Prompts},
+			Prompts:                     SplitPromptContent(content.Prompts),
 			FilesTouched:                m.FilesTouched,
 			CheckpointsCount:            m.CheckpointsCount,
 			SaveStepCount:               m.SaveStepCount,
@@ -198,6 +198,18 @@ func rewriteCheckpoint(
 			CheckpointTranscriptStart:   m.CheckpointTranscriptStart,
 			TokenUsage:                  m.TokenUsage,
 			SkillEvents:                 m.SkillEvents,
+			// Forward the remaining session-level fields so a rewritten ref
+			// matches the branch checkpoint the tool is meant to evaluate.
+			Attribution:            m.Attribution,
+			PromptAttributionsJSON: m.PromptAttributions,
+			SessionMetrics:         m.SessionMetrics,
+			Kind:                   m.Kind,
+			ReviewPrompt:           m.ReviewPrompt,
+			ReviewSkills:           m.ReviewSkills,
+			InvestigateRunID:       m.InvestigateRunID,
+			InvestigateTopic:       m.InvestigateTopic,
+			HasReview:              summary.HasReview,
+			HasInvestigation:       summary.HasInvestigation,
 		})); err != nil {
 			return fmt.Errorf("write session %d: %w", idx, err)
 		}

--- a/cmd/entire/cli/checkpoint/rewrite.go
+++ b/cmd/entire/cli/checkpoint/rewrite.go
@@ -1,0 +1,287 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+	"github.com/entireio/cli/redact"
+)
+
+// RewriteResult summarizes a git-branch → git-refs checkpoint rewrite.
+type RewriteResult struct {
+	// Total is the number of checkpoints found on the v1 branch.
+	Total int
+	// Rewritten lists the checkpoints re-materialized as refs.
+	Rewritten []id.CheckpointID
+	// Skipped counts checkpoints left alone because their ref already exists.
+	Skipped int
+}
+
+// RewriteBranchToRefs re-materializes every checkpoint on the git-branch v1
+// branch as a per-checkpoint ref by re-driving the git-refs store's write path.
+//
+// Unlike a byte-identical copy, this reads each checkpoint's data and writes it
+// fresh: for every session it replays the transcript (so the compact
+// transcript.jsonl is regenerated), prompts, and metadata at the ref's tree root
+// (no shard folders), then replays the per-session summaries and the combined
+// attribution. Any tasks/ subtree is grafted in unchanged. The checkpoint id is
+// preserved, and each commit keeps the original author — read from the v1-branch
+// commit that wrote the session (metadata carries no author), falling back to
+// the repo's git author.
+//
+// Idempotent: a checkpoint whose ref already exists is skipped unless force is
+// set (which re-materializes it from scratch). When dryRun is true it reports
+// what would be rewritten without writing anything.
+func RewriteBranchToRefs(ctx context.Context, repo *git.Repository, dryRun, force bool) (RewriteResult, error) {
+	var result RewriteResult
+
+	branch := NewGitStore(repo, DefaultV1Refs())
+	tree, err := branch.getSessionsBranchTree()
+	if err != nil {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return result, nil // no v1 branch → nothing to rewrite
+		}
+		return result, fmt.Errorf("read v1 checkpoint branch: %w", err)
+	}
+
+	authors := branchSessionAuthors(ctx, repo)
+	fallbackName, fallbackEmail := GetGitAuthorFromRepo(repo)
+	refsStore := newGitRefsStore(repo)
+
+	walkErr := WalkCheckpointShards(ctx, repo, tree, func(cid id.CheckpointID, cpTreeHash plumbing.Hash) error {
+		if err := ctx.Err(); err != nil {
+			return err //nolint:wrapcheck // propagate context cancellation
+		}
+		result.Total++
+
+		refName, err := RefName(cid)
+		if err != nil {
+			logging.Warn(ctx, "rewrite: skipping checkpoint with unmappable id",
+				slog.String("id", cid.String()), slog.String("error", err.Error()))
+			return nil
+		}
+		if _, err := repo.Reference(refName, true); err == nil && !force {
+			result.Skipped++
+			return nil
+		}
+
+		if dryRun {
+			result.Rewritten = append(result.Rewritten, cid)
+			return nil
+		}
+
+		if err := rewriteCheckpoint(ctx, branch, refsStore, repo, cid, cpTreeHash, authors, fallbackName, fallbackEmail); err != nil {
+			return fmt.Errorf("rewrite checkpoint %s: %w", cid, err)
+		}
+		result.Rewritten = append(result.Rewritten, cid)
+		return nil
+	})
+	if walkErr != nil {
+		return result, fmt.Errorf("walk v1 checkpoints: %w", walkErr)
+	}
+	return result, nil
+}
+
+// commitAuthor is a git author identity.
+type commitAuthor struct {
+	Name  string
+	Email string
+}
+
+// branchSessionAuthors maps each session id to the author of the earliest
+// v1-branch commit that wrote it, so a rewrite can preserve the original author.
+// The map is best-effort: a session with no resolvable commit falls back to the
+// repo author at the call site.
+func branchSessionAuthors(ctx context.Context, repo *git.Repository) map[string]commitAuthor {
+	authors := make(map[string]commitAuthor)
+	ref, err := repo.Reference(DefaultV1Refs().Read, true)
+	if err != nil {
+		return authors
+	}
+	iter, err := repo.Log(&git.LogOptions{From: ref.Hash()})
+	if err != nil {
+		return authors
+	}
+	defer iter.Close()
+	// Walk tip → root and overwrite, so the root-most (earliest) commit for a
+	// session — its original write — wins over later backfill commits. The map is
+	// best-effort: a cancellation mid-walk just yields a partial map, and callers
+	// fall back to the repo author for any unmapped session.
+	_ = iter.ForEach(func(c *object.Commit) error { //nolint:errcheck // best-effort; partial map is acceptable
+		if err := ctx.Err(); err != nil {
+			return err //nolint:wrapcheck // stop the walk on cancellation
+		}
+		if sessionID, ok := trailers.ParseSession(c.Message); ok {
+			authors[sessionID] = commitAuthor{Name: c.Author.Name, Email: c.Author.Email}
+		}
+		return nil
+	})
+	return authors
+}
+
+// rewriteCheckpoint re-materializes one checkpoint as a ref by replaying its
+// sessions, summaries, attribution, and tasks through the git-refs write path.
+func rewriteCheckpoint(
+	ctx context.Context,
+	branch *GitStore,
+	refsStore *gitRefsStore,
+	repo *git.Repository,
+	cid id.CheckpointID,
+	cpTreeHash plumbing.Hash,
+	authors map[string]commitAuthor,
+	fallbackName, fallbackEmail string,
+) error {
+	summary, err := branch.Read(ctx, cid)
+	if err != nil {
+		return fmt.Errorf("read checkpoint summary: %w", err)
+	}
+	if summary == nil {
+		return errors.New("checkpoint summary not found on branch")
+	}
+
+	// Start clean: drop any existing ref so the replay builds a fresh history
+	// rooted at an orphan commit rather than parenting on stale content.
+	refName, err := RefName(cid)
+	if err != nil {
+		return err
+	}
+	if _, err := repo.Reference(refName, true); err == nil {
+		if err := repo.Storer.RemoveReference(refName); err != nil {
+			return fmt.Errorf("reset existing ref: %w", err)
+		}
+	}
+
+	// Replay each session in order. Writing session N then its summary keeps
+	// SessionSummary (which targets the latest session) pointed at the right one.
+	firstAuthor := commitAuthor{Name: fallbackName, Email: fallbackEmail}
+	for idx := range summary.Sessions {
+		content, err := branch.ReadSessionContent(ctx, cid, idx)
+		if err != nil {
+			return fmt.Errorf("read session %d: %w", idx, err)
+		}
+		m := content.Metadata
+		name, email := fallbackName, fallbackEmail
+		if a, ok := authors[m.SessionID]; ok && a.Name != "" {
+			name, email = a.Name, a.Email
+		}
+		if idx == 0 {
+			firstAuthor = commitAuthor{Name: name, Email: email}
+		}
+
+		if err := refsStore.Write(ctx, Session(WriteOptions{
+			CheckpointID:                cid,
+			SessionID:                   m.SessionID,
+			CreatedAt:                   m.CreatedAt,
+			Strategy:                    m.Strategy,
+			Branch:                      m.Branch,
+			Transcript:                  redact.AlreadyRedacted(content.Transcript),
+			Prompts:                     []string{content.Prompts},
+			FilesTouched:                m.FilesTouched,
+			CheckpointsCount:            m.CheckpointsCount,
+			SaveStepCount:               m.SaveStepCount,
+			AuthorName:                  name,
+			AuthorEmail:                 email,
+			Agent:                       m.Agent,
+			Model:                       m.Model,
+			TurnID:                      m.TurnID,
+			TranscriptIdentifierAtStart: m.TranscriptIdentifierAtStart,
+			CheckpointTranscriptStart:   m.CheckpointTranscriptStart,
+			TokenUsage:                  m.TokenUsage,
+			SkillEvents:                 m.SkillEvents,
+		})); err != nil {
+			return fmt.Errorf("write session %d: %w", idx, err)
+		}
+
+		if m.Summary != nil {
+			if err := refsStore.Write(ctx, SessionSummary{CheckpointID: cid, Summary: m.Summary}); err != nil {
+				return fmt.Errorf("write session %d summary: %w", idx, err)
+			}
+		}
+	}
+
+	if summary.CombinedAttribution != nil {
+		if err := refsStore.Write(ctx, CheckpointAttribution{CheckpointID: cid, Attribution: summary.CombinedAttribution}); err != nil {
+			return fmt.Errorf("write combined attribution: %w", err)
+		}
+	}
+
+	// Graft the tasks/ subtree unchanged if the checkpoint has one — task steps
+	// aren't reconstructable through the write union, so the existing tree is
+	// carried over verbatim.
+	if tasksHash, ok := subtreeEntryHash(repo, cpTreeHash, "tasks"); ok {
+		if err := graftTasksSubtree(ctx, repo, refsStore, cid, tasksHash, firstAuthor); err != nil {
+			return fmt.Errorf("graft tasks: %w", err)
+		}
+	}
+	return nil
+}
+
+// subtreeEntryHash returns the hash of a named directory entry in a tree.
+func subtreeEntryHash(repo *git.Repository, treeHash plumbing.Hash, name string) (plumbing.Hash, bool) {
+	tree, err := repo.TreeObject(treeHash)
+	if err != nil {
+		return plumbing.ZeroHash, false
+	}
+	for _, e := range tree.Entries {
+		if e.Name == name && e.Mode == filemode.Dir {
+			return e.Hash, true
+		}
+	}
+	return plumbing.ZeroHash, false
+}
+
+// graftTasksSubtree adds the tasks/ subtree to the checkpoint's current ref tree
+// via one commit on top, reusing the existing task objects unchanged.
+func graftTasksSubtree(ctx context.Context, repo *git.Repository, refsStore *gitRefsStore, cid id.CheckpointID, tasksHash plumbing.Hash, author commitAuthor) error {
+	refName, err := RefName(cid)
+	if err != nil {
+		return err
+	}
+	ref, err := repo.Reference(refName, true)
+	if err != nil {
+		return fmt.Errorf("resolve ref: %w", err)
+	}
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		return fmt.Errorf("read ref commit: %w", err)
+	}
+	rootTree, err := commit.Tree()
+	if err != nil {
+		return fmt.Errorf("read ref tree: %w", err)
+	}
+	tasksTree, err := repo.TreeObject(tasksHash)
+	if err != nil {
+		return fmt.Errorf("read tasks subtree: %w", err)
+	}
+
+	entries := make(map[string]object.TreeEntry)
+	if err := FlattenTree(repo, rootTree, "", entries); err != nil {
+		return fmt.Errorf("flatten ref tree: %w", err)
+	}
+	if err := FlattenTree(repo, tasksTree, "tasks", entries); err != nil {
+		return fmt.Errorf("flatten tasks subtree: %w", err)
+	}
+	newTree, err := BuildTreeFromEntries(ctx, repo, entries)
+	if err != nil {
+		return fmt.Errorf("build grafted tree: %w", err)
+	}
+	if newTree == commit.TreeHash {
+		return nil // tasks already present, nothing to graft
+	}
+	msg := fmt.Sprintf("Graft tasks for checkpoint %s (migrated from git-branch)", cid)
+	graftCommit, err := CreateCommit(ctx, repo, newTree, ref.Hash(), msg, author.Name, author.Email)
+	if err != nil {
+		return fmt.Errorf("commit grafted tasks: %w", err)
+	}
+	return refsStore.setRef(ctx, cid, graftCommit)
+}

--- a/cmd/entire/cli/checkpoint/rewrite_test.go
+++ b/cmd/entire/cli/checkpoint/rewrite_test.go
@@ -1,0 +1,165 @@
+package checkpoint
+
+import (
+	"context"
+	"testing"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/redact"
+)
+
+// seedBranchCheckpoint writes one checkpoint to the git-branch v1 store,
+// authored by Test <test@test.com>.
+func seedBranchCheckpoint(t *testing.T, store *GitStore, cid id.CheckpointID, sessionID string) {
+	t.Helper()
+	require.NoError(t, store.Write(context.Background(), Session{
+		CheckpointID: cid,
+		SessionID:    sessionID,
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("transcript for " + sessionID + "\n")),
+		Prompts:      []string{"do the thing"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	}))
+}
+
+// refHash returns the commit hash a checkpoint's ref points at (fatal if absent).
+func refHash(t *testing.T, repo *git.Repository, cid id.CheckpointID) plumbing.Hash {
+	t.Helper()
+	refName, err := RefName(cid)
+	require.NoError(t, err)
+	ref, err := repo.Reference(refName, true)
+	require.NoError(t, err)
+	return ref.Hash()
+}
+
+// rootTreeEntryNames returns the top-level entry names of a checkpoint ref's tree.
+func rootTreeEntryNames(t *testing.T, repo *git.Repository, cid id.CheckpointID) map[string]bool {
+	t.Helper()
+	commit, err := repo.CommitObject(refHash(t, repo, cid))
+	require.NoError(t, err)
+	tree, err := commit.Tree()
+	require.NoError(t, err)
+	names := make(map[string]bool, len(tree.Entries))
+	for _, e := range tree.Entries {
+		names[e.Name] = true
+	}
+	return names
+}
+
+func TestRewriteBranchToRefs(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	ctx := context.Background()
+	branch := NewGitStore(repo, DefaultV1Refs())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	seedBranchCheckpoint(t, branch, cid, "s1") // authored by Test <test@test.com>
+
+	result, err := RewriteBranchToRefs(ctx, repo, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Total)
+	assert.Len(t, result.Rewritten, 1)
+	assert.Equal(t, 0, result.Skipped)
+
+	// Reads back through the git-refs store.
+	refsStore := newGitRefsStore(repo)
+	summary, err := refsStore.Read(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, cid, summary.CheckpointID)
+	require.Len(t, summary.Sessions, 1)
+
+	// Root-flat: checkpoint files sit at the tree root (no <shard>/<id> nesting).
+	names := rootTreeEntryNames(t, repo, cid)
+	assert.True(t, names["metadata.json"], "checkpoint metadata should be at the ref tree root")
+	assert.True(t, names["0"], "session 0 should be at the ref tree root")
+	assert.False(t, names["a1"], "there must be no shard folder in the ref tree")
+
+	// The commit keeps the original author (read from the branch commit).
+	commit, err := repo.CommitObject(refHash(t, repo, cid))
+	require.NoError(t, err)
+	assert.Equal(t, "Test", commit.Author.Name)
+	assert.Equal(t, "test@test.com", commit.Author.Email)
+}
+
+func TestRewriteBranchToRefs_IdempotentAndForce(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	ctx := context.Background()
+	branch := NewGitStore(repo, DefaultV1Refs())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	seedBranchCheckpoint(t, branch, cid, "s1")
+
+	_, err := RewriteBranchToRefs(ctx, repo, false, false)
+	require.NoError(t, err)
+	before := refHash(t, repo, cid)
+
+	// Re-run without force: the existing ref is skipped and left untouched.
+	again, err := RewriteBranchToRefs(ctx, repo, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, again.Rewritten, "existing ref should be skipped")
+	assert.Equal(t, 1, again.Skipped)
+	assert.Equal(t, before, refHash(t, repo, cid), "skipped run must not move the ref")
+
+	// Re-run with force: the checkpoint is re-materialized and still reads back.
+	forced, err := RewriteBranchToRefs(ctx, repo, false, true)
+	require.NoError(t, err)
+	assert.Len(t, forced.Rewritten, 1, "force re-materializes the checkpoint")
+	refsStore := newGitRefsStore(repo)
+	summary, err := refsStore.Read(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, cid, summary.CheckpointID)
+}
+
+func TestRewriteBranchToRefs_MultipleSessions(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	ctx := context.Background()
+	branch := NewGitStore(repo, DefaultV1Refs())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	seedBranchCheckpoint(t, branch, cid, "sess-1")
+	seedBranchCheckpoint(t, branch, cid, "sess-2")
+
+	result, err := RewriteBranchToRefs(ctx, repo, false, false)
+	require.NoError(t, err)
+	assert.Len(t, result.Rewritten, 1)
+
+	refsStore := newGitRefsStore(repo)
+	summary, err := refsStore.Read(ctx, cid)
+	require.NoError(t, err)
+	require.Len(t, summary.Sessions, 2, "both sessions replayed into the ref checkpoint")
+
+	names := rootTreeEntryNames(t, repo, cid)
+	assert.True(t, names["0"] && names["1"], "both session dirs at root")
+}
+
+func TestRewriteBranchToRefs_DryRunAndNoBranch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// No v1 branch → no-op.
+	emptyRepo, _ := setupBranchTestRepo(t)
+	res, err := RewriteBranchToRefs(ctx, emptyRepo, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.Total)
+
+	// Dry run reports without writing.
+	repo, _ := setupBranchTestRepo(t)
+	branch := NewGitStore(repo, DefaultV1Refs())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	seedBranchCheckpoint(t, branch, cid, "s1")
+
+	dry, err := RewriteBranchToRefs(ctx, repo, true, false)
+	require.NoError(t, err)
+	assert.Len(t, dry.Rewritten, 1)
+	refName, err := RefName(cid)
+	require.NoError(t, err)
+	_, err = repo.Reference(refName, true)
+	assert.Error(t, err, "dry-run must not write a ref")
+}

--- a/cmd/entire/cli/checkpoint/rewrite_test.go
+++ b/cmd/entire/cli/checkpoint/rewrite_test.go
@@ -6,6 +6,8 @@ import (
 
 	git "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -137,6 +139,42 @@ func TestRewriteBranchToRefs_MultipleSessions(t *testing.T) {
 
 	names := rootTreeEntryNames(t, repo, cid)
 	assert.True(t, names["0"] && names["1"], "both session dirs at root")
+}
+
+func TestRewrite_GraftsTasksSubtree(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	ctx := context.Background()
+	branch := NewGitStore(repo, DefaultV1Refs())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	seedBranchCheckpoint(t, branch, cid, "s1")
+
+	_, err := RewriteBranchToRefs(ctx, repo, false, false)
+	require.NoError(t, err)
+	require.False(t, rootTreeEntryNames(t, repo, cid)["tasks"], "no tasks before graft")
+
+	// Build a standalone tasks/ subtree object and graft it onto the ref.
+	blob, err := CreateBlobFromContent(repo, []byte("task data"))
+	require.NoError(t, err)
+	tasksTree, err := BuildTreeFromEntries(ctx, repo, map[string]object.TreeEntry{
+		"tool-1/checkpoint.json": {Name: "checkpoint.json", Mode: filemode.Regular, Hash: blob},
+	})
+	require.NoError(t, err)
+	refName, err := RefName(cid)
+	require.NoError(t, err)
+	require.NoError(t, graftTasksSubtree(ctx, repo, newGitRefsStore(repo), cid, refName, tasksTree,
+		commitAuthor{Name: "Test", Email: "test@test.com"}))
+
+	// tasks/ is spliced in while the existing entries keep their place.
+	after := rootTreeEntryNames(t, repo, cid)
+	assert.True(t, after["tasks"], "tasks grafted at the ref tree root")
+	assert.True(t, after["metadata.json"], "existing metadata preserved")
+	assert.True(t, after["0"], "existing session preserved")
+
+	// The checkpoint still reads back through the git-refs store.
+	summary, err := newGitRefsStore(repo).Read(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
 }
 
 func TestRewriteBranchToRefs_DryRunAndNoBranch(t *testing.T) {

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -67,6 +67,7 @@ be condensed will be discarded.`,
 	cmd.AddCommand(newTraceCmd())
 	cmd.AddCommand(newDoctorLogsCmd())
 	cmd.AddCommand(newDoctorBundleCmd())
+	cmd.AddCommand(newDoctorRewriteCheckpointsCmd())
 
 	return cmd
 }

--- a/cmd/entire/cli/doctor_rewrite.go
+++ b/cmd/entire/cli/doctor_rewrite.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+)
+
+func newDoctorRewriteCheckpointsCmd() *cobra.Command {
+	var dryRun bool
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "rewrite-checkpoints",
+		Short: "Re-materialize git-branch checkpoints as per-checkpoint git refs (test tooling)",
+		Long: `Rewrite the checkpoints stored on the entire/checkpoints/v1 branch into
+per-checkpoint refs under refs/entire/checkpoints/<shard>/<id>, the layout the
+git-refs checkpoint store uses.
+
+Each checkpoint is written fresh through the git-refs store: the transcript is
+replayed (regenerating the compact transcript.jsonl), everything is rooted at
+the checkpoint (no shard folders), and per-session summaries and combined
+attribution are replayed. The checkpoint id is preserved and each commit keeps
+the original author. Any subagent tasks/ subtree is grafted in unchanged.
+
+This is test tooling for evaluating the git-refs store against real branch data:
+it writes refs locally and does not push them. Idempotent — checkpoints that
+already have a ref are skipped (use --force to re-materialize from scratch).`,
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			out := cmd.OutOrStdout()
+
+			repo, err := strategy.OpenRepository(ctx)
+			if err != nil {
+				return fmt.Errorf("open repository: %w", err)
+			}
+			defer repo.Close()
+
+			result, err := checkpoint.RewriteBranchToRefs(ctx, repo, dryRun, force)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return NewSilentError(err)
+				}
+				return fmt.Errorf("rewrite checkpoints: %w", err)
+			}
+
+			if result.Total == 0 {
+				fmt.Fprintln(out, "No checkpoints found on the v1 branch — nothing to rewrite.")
+				return nil
+			}
+
+			verb := "Rewrote"
+			if dryRun {
+				verb = "Would rewrite"
+			}
+			fmt.Fprintf(out, "%s %d checkpoint(s) to refs (%d already present, %d total).\n",
+				verb, len(result.Rewritten), result.Skipped, result.Total)
+			if !dryRun && len(result.Rewritten) > 0 {
+				fmt.Fprintln(out, "Refs written locally under refs/entire/checkpoints/ — not pushed.")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report what would be rewritten without writing refs")
+	cmd.Flags().BoolVar(&force, "force", false, "Re-materialize checkpoints whose ref already exists")
+	return cmd
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/752
<!-- entire-trail-link-end -->

Hidden test tooling for evaluating the **git-refs** checkpoint store against real branch data: it re-materializes every checkpoint on the `entire/checkpoints/v1` branch as a per-checkpoint ref by re-driving the git-refs store's write path. Independent of the (still-undecided) byte-identical migration — standalone off `main`.

## What it does
`entire doctor rewrite-checkpoints` (hidden). For each checkpoint on the v1 branch:
- Replays each session's transcript through `Write`, so the compact `transcript.jsonl` is **regenerated**, the tree is **rooted at the checkpoint** (no shard folders), and `SessionFilePaths`/`CompactTranscriptStart` are correct by construction.
- Replays per-session summaries and combined attribution; grafts any `tasks/` subtree in unchanged.
- **Preserves the checkpoint id**, and **each commit keeps the original author** — read from the v1-branch commit that wrote the session (metadata carries no author), falling back to the repo git author.
- Fresh commits copy the data; the branch's own commits are not reused.

It writes refs **locally and does not push** (test tooling for now). Idempotent: existing refs are skipped unless `--force`; `--dry-run` reports without writing.

## Testing
`rewrite_test.go` (self-contained): root-flat layout + reads back via the git-refs store, author preserved from the branch commit, idempotency + `--force`, multi-session replay, dry-run/no-branch. Build clean, lint 0, checkpoint + cli suites pass.

## Notes
- Hidden from help — it's evaluation tooling, not a supported migration, while the migration approach is still being decided.
- Summary/attribution *backfill* commits use the repo author (consistent with the branch store's own backfills); only the session commits carry the original author.
- `transcript.jsonl` regeneration is best-effort (same as native git-refs writes) — produced when the transcript is compactable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rewrites local git refs and checkpoint object graphs; mistakes could corrupt local checkpoint data, but the command is hidden, local-only, and positioned as evaluation tooling rather than a supported migration.
> 
> **Overview**
> Introduces **hidden test tooling** to copy checkpoints from the legacy `entire/checkpoints/v1` **git-branch** layout into **per-checkpoint refs** (`refs/entire/checkpoints/...`) by replaying the git-refs store’s write path—not a byte copy.
> 
> **`checkpoint.RewriteBranchToRefs`** walks v1 shard trees, skips checkpoints that already have a ref (unless `--force`), and for each checkpoint replays sessions (regenerating compact `transcript.jsonl`), summaries, and combined attribution at a **root-flat** ref tree, preserves checkpoint IDs, and restores session commit authors from v1 branch history (with repo author fallback). Existing refs are removed before replay when rewriting; any `tasks/` subtree is **grafted** unchanged. Supports **dry-run** and returns counts of total, rewritten, and skipped.
> 
> **`entire doctor rewrite-checkpoints`** wires this up (hidden from help), opens the repo, prints a short summary, and notes refs are written **locally only**. **`rewrite_test.go`** covers happy path, idempotency/force, multi-session, dry-run, and missing v1 branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07aac087bd570c8f8621fdbbc355b2735014aa48. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->