### PR TITLE
Emit ULID checkpoint IDs under the git-refs store

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -22,6 +22,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	cliReview "github.com/entireio/cli/cmd/entire/cli/review"
 	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
@@ -500,21 +501,27 @@ func getHeadCommit(repo *git.Repository) (*object.Commit, error) {
 // would create a fresh session 0 under the same ID and overwrite the original
 // session data on push.
 //
-// Only the local branch counts — remote-tracking presence is not enough.
-// If only the remote-tracking ref exists, a subsequent WriteCommitted creates
-// a brand-new orphan local branch with an empty tree, which would clobber
-// the remote on push.
+// Only local presence counts — remote-tracking presence is not enough. For the
+// git-branch backend, if only the remote-tracking ref exists, a subsequent
+// WriteCommitted creates a brand-new orphan local branch with an empty tree,
+// which would clobber the remote on push.
 //
-// Fast path: check local refs directly — no network. If missing, trigger the
-// metadata fetch fallback chain used by `entire resume` (which advances the
-// local ref on success) and re-check. Returns a possibly-freshly-opened repo
-// handle so go-git sees any newly fetched packfiles.
+// Fast path: check local storage directly — no network. If missing, fetch from
+// the remote (the whole v1 branch for git-branch, or just this checkpoint's ref
+// for git-refs) and re-check. Returns a possibly-freshly-opened repo handle so
+// go-git sees any newly fetched refs/packfiles.
 func ensureCheckpointAvailable(ctx, logCtx context.Context, repo *git.Repository, refs cpkg.PersistentRefs, checkpointID id.CheckpointID, isExistingCheckpoint bool) (*git.Repository, error) {
 	if !isExistingCheckpoint {
 		return repo, nil
 	}
 
-	present, readErr := checkpointPresentLocally(ctx, repo, refs, checkpointID)
+	cfg, err := settings.LoadCheckpointsConfig(ctx)
+	if err != nil {
+		return repo, fmt.Errorf("resolve checkpoints config: %w", err)
+	}
+	primaryIsRefs := cpkg.PrimaryIsRefs(cfg)
+
+	present, readErr := checkpointPresentLocally(ctx, repo, refs, checkpointID, primaryIsRefs)
 	if readErr != nil {
 		return repo, fmt.Errorf("failed to read checkpoint %s: %w", checkpointID, readErr)
 	}
@@ -522,15 +529,14 @@ func ensureCheckpointAvailable(ctx, logCtx context.Context, repo *git.Repository
 		return repo, nil
 	}
 
-	// Missing locally — try to refresh, then re-check. Use the same fetch
-	// chain `entire resume` uses for the primary metadata ref.
-	freshRepo, fetchErr := refreshCheckpointRefs(ctx)
+	// Missing locally — fetch from the remote, then re-check.
+	freshRepo, fetchErr := refreshCheckpoint(ctx, checkpointID, primaryIsRefs)
 	if fetchErr != nil {
-		logging.Warn(logCtx, "failed to refresh metadata branch before attach; proceeding with local state",
+		logging.Warn(logCtx, "failed to refresh checkpoint metadata before attach; proceeding with local state",
 			slog.String("error", fetchErr.Error()))
 	} else {
 		repo = freshRepo
-		present, readErr = checkpointPresentLocally(ctx, repo, refs, checkpointID)
+		present, readErr = checkpointPresentLocally(ctx, repo, refs, checkpointID, primaryIsRefs)
 		if readErr != nil {
 			return repo, fmt.Errorf("failed to read checkpoint %s after refresh: %w", checkpointID, readErr)
 		}
@@ -539,28 +545,49 @@ func ensureCheckpointAvailable(ctx, logCtx context.Context, repo *git.Repository
 		}
 	}
 
-	branchDescription := "entire/checkpoints/v1 branch"
-	return repo, fmt.Errorf(
-		"checkpoint %s referenced by HEAD is missing from the local %s after a refresh attempt. Creating a fresh checkpoint here would overwrite the original session data on push. Run:\n\n    %s\n\nthen re-run attach. If the colleague who made this commit hasn't pushed their checkpoint metadata yet, ask them to do so first",
-		checkpointID.String(), branchDescription, suggestCheckpointFetchCommand(logCtx),
-	)
+	return repo, missingCheckpointError(logCtx, checkpointID, primaryIsRefs)
 }
 
-// refreshCheckpointRefs runs the resume-equivalent fetch chain for the v1
-// metadata branch. Returns a freshly-opened repo so go-git sees any
-// newly-fetched packfiles and ref updates.
-func refreshCheckpointRefs(ctx context.Context) (*git.Repository, error) {
-	_, repo, err := getMetadataTree(ctx)
-	return repo, err
+// refreshCheckpoint fetches the checkpoint referenced by HEAD from the remote and
+// returns a freshly-opened repo so go-git sees the newly-fetched refs/packfiles.
+// The fetch is backend-aware: git-refs fetches just this checkpoint's ref, while
+// git-branch fetches the whole v1 metadata branch (the resume-equivalent chain).
+func refreshCheckpoint(ctx context.Context, checkpointID id.CheckpointID, primaryIsRefs bool) (*git.Repository, error) {
+	if !primaryIsRefs {
+		_, repo, err := getMetadataTree(ctx)
+		return repo, err
+	}
+	refName, err := cpkg.RefName(checkpointID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve checkpoint ref for %s: %w", checkpointID, err)
+	}
+	if err := FetchCheckpointRef(ctx, refName); err != nil {
+		return nil, err
+	}
+	repo, err := openRepository(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reopen repository after checkpoint ref fetch: %w", err)
+	}
+	return repo, nil
 }
 
-// checkpointPresentLocally reports whether the checkpoint already exists at
-// Primary locally. Reads target Primary directly, not refs.Read, because this
-// asks what the next write would find, not what readers see. A missing local
-// ref is reported as absent; the caller is responsible for any remote refresh.
-func checkpointPresentLocally(ctx context.Context, repo *git.Repository, refs cpkg.PersistentRefs, checkpointID id.CheckpointID) (bool, error) {
-	if _, err := repo.Reference(refs.Primary, true); err != nil {
-		return false, nil //nolint:nilerr // Missing ref is the "absent" signal, not an error.
+// checkpointPresentLocally reports whether the checkpoint already exists locally
+// under the configured primary store. It reads local-only; the caller's refresh
+// path is responsible for any remote fetch.
+//
+// For the git-branch backend the checkpoint lives in the v1 branch tree, and the
+// store would bootstrap a missing local branch from origin's remote-tracking ref
+// (PrimaryAsRead makes reads origin-bootstrappable). Counting that would let a
+// WriteCommitted create a fresh orphan local branch and clobber the remote on
+// push, so gate on the local Primary ref existing first. For the git-refs backend
+// the checkpoint lives at its own ref (the v1 branch is irrelevant) and the store
+// read here is already local-only — attach wires no ref fetcher — so read it
+// directly.
+func checkpointPresentLocally(ctx context.Context, repo *git.Repository, refs cpkg.PersistentRefs, checkpointID id.CheckpointID, primaryIsRefs bool) (bool, error) {
+	if !primaryIsRefs {
+		if _, err := repo.Reference(refs.Primary, true); err != nil {
+			return false, nil //nolint:nilerr // Missing local branch is the "absent" signal, not an error.
+		}
 	}
 	store, err := openAttachStore(ctx, repo, refs.PrimaryAsRead())
 	if err != nil {
@@ -573,16 +600,48 @@ func checkpointPresentLocally(ctx context.Context, repo *git.Repository, refs cp
 	return summary != nil, nil
 }
 
-// suggestCheckpointFetchCommand returns a git fetch command the user can
-// paste to pull the missing v1 metadata branch.
+// missingCheckpointError builds the refuse error shown when a HEAD-referenced
+// checkpoint is still absent locally after a refresh attempt. The storage it
+// names and the fetch command it suggests are backend-aware.
+func missingCheckpointError(ctx context.Context, checkpointID id.CheckpointID, primaryIsRefs bool) error {
+	location := "entire/checkpoints/v1 branch"
+	fetchCmd := suggestCheckpointFetchCommand(ctx)
+	if primaryIsRefs {
+		location = "checkpoint refs"
+		fetchCmd = suggestCheckpointRefFetchCommand(ctx, checkpointID)
+	}
+	return fmt.Errorf(
+		"checkpoint %s referenced by HEAD is missing from the local %s after a refresh attempt. Creating a fresh checkpoint here would overwrite the original session data on push. Run:\n\n    %s\n\nthen re-run attach. If the colleague who made this commit hasn't pushed their checkpoint metadata yet, ask them to do so first",
+		checkpointID.String(), location, fetchCmd,
+	)
+}
+
+// suggestCheckpointFetchCommand returns a git fetch command the user can paste to
+// pull the missing v1 metadata branch (git-branch backend).
 func suggestCheckpointFetchCommand(ctx context.Context) string {
-	ref := "entire/checkpoints/v1:entire/checkpoints/v1"
+	return suggestFetchCommand(ctx, "entire/checkpoints/v1:entire/checkpoints/v1")
+}
+
+// suggestCheckpointRefFetchCommand returns a git fetch command the user can paste
+// to pull one missing checkpoint ref (git-refs backend), falling back to the v1
+// branch form when the ID cannot be turned into a ref.
+func suggestCheckpointRefFetchCommand(ctx context.Context, checkpointID id.CheckpointID) string {
+	refName, err := cpkg.RefName(checkpointID)
+	if err != nil {
+		return suggestCheckpointFetchCommand(ctx)
+	}
+	return suggestFetchCommand(ctx, refName.String()+":"+refName.String())
+}
+
+// suggestFetchCommand builds a "git fetch <target> <refspec>" hint, preferring
+// the configured checkpoint remote URL when available and falling back to origin.
+func suggestFetchCommand(ctx context.Context, refspec string) string {
 	if remote.Configured(ctx) {
 		if url, err := remote.FetchURL(ctx); err == nil && url != "" {
-			return fmt.Sprintf("git fetch %s %s", url, ref)
+			return fmt.Sprintf("git fetch %s %s", url, refspec)
 		}
 	}
-	return "git fetch origin " + ref
+	return "git fetch origin " + refspec
 }
 
 func resolveCheckpointID(ctx context.Context, headCommit *object.Commit) (id.CheckpointID, bool) {

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -17,7 +17,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
-	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	cliReview "github.com/entireio/cli/cmd/entire/cli/review"
@@ -633,15 +632,13 @@ func suggestCheckpointRefFetchCommand(ctx context.Context, checkpointID id.Check
 	return suggestFetchCommand(ctx, refName.String()+":"+refName.String())
 }
 
-// suggestFetchCommand builds a "git fetch <target> <refspec>" hint, preferring
-// the configured checkpoint remote URL when available and falling back to origin.
+// suggestFetchCommand builds a "git fetch <target> <refspec>" hint. It resolves
+// the target the same way attach's own fetch does (resolveCheckpointFetchTarget:
+// the checkpoint-remote/token URL if any, else origin) so the pasteable command
+// points at the remote the fetch actually used — not a bare "origin" that fails
+// in a token-only environment with an SSH origin.
 func suggestFetchCommand(ctx context.Context, refspec string) string {
-	if remote.Configured(ctx) {
-		if url, err := remote.FetchURL(ctx); err == nil && url != "" {
-			return fmt.Sprintf("git fetch %s %s", url, refspec)
-		}
-	}
-	return "git fetch origin " + refspec
+	return fmt.Sprintf("git fetch %s %s", resolveCheckpointFetchTarget(ctx), refspec)
 }
 
 func resolveCheckpointID(ctx context.Context, headCommit *object.Commit) (id.CheckpointID, bool) {

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -289,7 +289,7 @@ func runAttach(ctx context.Context, w, errW io.Writer, sessionID string, agentNa
 	warnEmptyTranscriptMetadata(errW, ag.Name(), meta, opts)
 
 	// Determine checkpoint ID: reuse from HEAD if one exists, otherwise generate new.
-	checkpointID, isExistingCheckpoint := resolveCheckpointID(headCommit)
+	checkpointID, isExistingCheckpoint := resolveCheckpointID(ctx, headCommit)
 
 	// If HEAD references an existing checkpoint, make sure we have it locally
 	// before writing — otherwise we'd create a fresh session 0 under the same
@@ -585,13 +585,13 @@ func suggestCheckpointFetchCommand(ctx context.Context) string {
 	return "git fetch origin " + ref
 }
 
-func resolveCheckpointID(headCommit *object.Commit) (id.CheckpointID, bool) {
+func resolveCheckpointID(ctx context.Context, headCommit *object.Commit) (id.CheckpointID, bool) {
 	existing := trailers.ParseAllCheckpoints(headCommit.Message)
 	if len(existing) > 0 {
 		return existing[len(existing)-1], true
 	}
 
-	cpID, err := id.Generate()
+	cpID, err := cpkg.GenerateCheckpointID(ctx)
 	if err != nil {
 		// Generation only fails if crypto/rand fails — extremely unlikely.
 		// Fall back to empty which will cause WriteCommitted to fail with a clear error.

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -406,6 +406,83 @@ func TestAttach_AppendsAsAdditionalSessionWhenIDDiffers(t *testing.T) {
 	}
 }
 
+// Regression: under the git-refs backend a checkpoint lives at its own ref, not
+// on the v1 branch. Attaching a second session to a commit that already carries
+// a git-refs (ULID) checkpoint must find it present locally and append — the
+// earlier v1-branch presence gate wrongly refused it as "missing from the local
+// entire/checkpoints/v1 branch" (which does not exist in a refs-only repo).
+func TestAttach_GitRefsBackend_AppendsToExistingCheckpoint(t *testing.T) {
+	t.Setenv("ENTIRE_CHECKPOINTS_PRIMARY", "git-refs")
+	setupAttachTestRepo(t)
+
+	firstSessionID := "refs-first-session-original"
+	setupClaudeTranscript(t, firstSessionID, `{"type":"user","message":{"role":"user","content":"first"},"uuid":"u1"}
+`)
+	var out bytes.Buffer
+	if err := runAttach(context.Background(), &out, &out, firstSessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}); err != nil {
+		t.Fatalf("first attach failed: %v", err)
+	}
+
+	repoRoot := mustGetwd(t)
+	repo, err := git.PlainOpen(repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	headRef, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	headCommit, err := repo.CommitObject(headRef.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	existing := trailers.ParseAllCheckpoints(headCommit.Message)
+	if len(existing) != 1 {
+		t.Fatalf("expected one Entire-Checkpoint trailer after first attach; got %v", existing)
+	}
+	checkpointID := existing[0]
+	if checkpointID.Kind() != id.KindULID {
+		t.Fatalf("git-refs backend should mint a ULID checkpoint id; got %q (kind %v)", checkpointID, checkpointID.Kind())
+	}
+
+	// The checkpoint must live at its per-checkpoint ref, and no v1 branch should exist.
+	refName, err := cpkg.RefName(checkpointID)
+	if err != nil {
+		t.Fatalf("RefName(%s): %v", checkpointID, err)
+	}
+	if _, err := repo.Reference(refName, true); err != nil {
+		t.Fatalf("checkpoint ref %s should exist after attach: %v", refName, err)
+	}
+	if _, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true); err == nil {
+		t.Fatal("git-refs backend must not create the entire/checkpoints/v1 branch")
+	}
+
+	// Second attach on the same HEAD (now carrying the ULID trailer) must see the
+	// checkpoint at its ref as present and append, not refuse it as missing.
+	secondSessionID := "refs-second-session-append"
+	setupClaudeTranscript(t, secondSessionID, `{"type":"user","message":{"role":"user","content":"second"},"uuid":"u1"}
+`)
+	out.Reset()
+	if err := runAttach(context.Background(), &out, &out, secondSessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}); err != nil {
+		t.Fatalf("second attach failed (checkpoint at its ref must be seen as present): %v", err)
+	}
+
+	stores, err := cpkg.Open(context.Background(), repo, cpkg.OpenOptions{})
+	if err != nil {
+		t.Fatalf("open git-refs store: %v", err)
+	}
+	summary, err := stores.Persistent.Read(context.Background(), checkpointID)
+	if err != nil {
+		t.Fatalf("Read(%s): %v", checkpointID, err)
+	}
+	if summary == nil {
+		t.Fatalf("checkpoint %s summary nil after two attaches", checkpointID)
+	}
+	if len(summary.Sessions) != 2 {
+		t.Fatalf("checkpoint has %d sessions, want 2", len(summary.Sessions))
+	}
+}
+
 func TestAttach_RefusesWhenCheckpointMissingFromLocalBranch(t *testing.T) {
 	setupAttachTestRepo(t)
 

--- a/cmd/entire/cli/attribution.go
+++ b/cmd/entire/cli/attribution.go
@@ -1012,26 +1012,43 @@ func renderAttributionBlameCompact(w io.Writer, result *fileAttributionResult, l
 func renderAttributionBlameLong(w io.Writer, result *fileAttributionResult, lineFlag string) {
 	renderAttributionBlameTable(w, result, lineFlag, func(sty statusStyles) {
 		lineWidth := attributionLineColumnWidth(result.Lines)
-		const checkpointColumnWidth = 21
-		fmt.Fprintf(w, "  %*s  Tag   %-12s  %-18s  %-16s  %-21s    Content\n",
-			lineWidth, "Line", "Agent", "Model", "Author", "Checkpoint/Session")
-		fmt.Fprintf(w, "  %s\n", sty.render(sty.dim, strings.Repeat("─", lineWidth+92)))
+		// Size the Checkpoint/Session column to its content so a ULID checkpoint
+		// (26 chars, vs a 12-hex ID) is not front-truncated into an unresolvable,
+		// session-less prefix. The other columns sum to 71 alongside these two.
+		cpWidth := attributionCheckpointColumnWidth(result.Lines)
+		ruleWidth := lineWidth + cpWidth + 71
+		fmt.Fprintf(w, "  %*s  Tag   %-12s  %-18s  %-16s  %-*s    Content\n",
+			lineWidth, "Line", "Agent", "Model", "Author", cpWidth, "Checkpoint/Session")
+		fmt.Fprintf(w, "  %s\n", sty.render(sty.dim, strings.Repeat("─", ruleWidth)))
 
 		for _, line := range result.Lines {
-			fmt.Fprintf(w, "  %s  %s  %-12s  %-18s  %-16s  %-21s  %s %s\n",
+			fmt.Fprintf(w, "  %s  %s  %-12s  %-18s  %-16s  %-*s  %s %s\n",
 				sty.render(sty.dim, fmt.Sprintf("%*d", lineWidth, line.LineNumber)),
 				renderAttributionTag(sty, line.Authorship),
 				stringutil.TruncateRunes(line.Agent, 12, ""),
 				stringutil.TruncateRunes(line.Model, 18, ""),
 				stringutil.TruncateRunes(shortAuthorName(line.Author), 16, ""),
-				stringutil.TruncateRunes(shortCheckpointSession(line), checkpointColumnWidth, ""),
+				cpWidth, shortCheckpointSession(line),
 				sty.render(sty.dim, attributionLineMarker(line)),
 				renderAttributionContent(sty, line),
 			)
 		}
 
-		fmt.Fprintf(w, "  %s\n", sty.render(sty.dim, strings.Repeat("─", lineWidth+92)))
+		fmt.Fprintf(w, "  %s\n", sty.render(sty.dim, strings.Repeat("─", ruleWidth)))
 	})
+}
+
+// attributionCheckpointColumnWidth sizes the Checkpoint/Session column to the
+// widest value it must show (header label or any rendered checkpoint/session),
+// so ULID checkpoints render in full rather than being clipped to a 12-hex width.
+func attributionCheckpointColumnWidth(lines []attributionLine) int {
+	w := len("Checkpoint/Session")
+	for i := range lines {
+		if n := len(shortCheckpointSession(lines[i])); n > w {
+			w = n
+		}
+	}
+	return w
 }
 
 func renderAttributionSummary(w io.Writer, sty statusStyles, summary attributionSummary, lineFlag string) {

--- a/cmd/entire/cli/attribution_test.go
+++ b/cmd/entire/cli/attribution_test.go
@@ -822,3 +822,31 @@ func firstNonSpaceIndex(s string, start, end int) int {
 	}
 	return -1
 }
+
+func TestAttributionCheckpointColumnWidth(t *testing.T) {
+	t.Parallel()
+	const headerWidth = 18 // len("Checkpoint/Session")
+
+	t.Run("no lines falls back to the header width", func(t *testing.T) {
+		t.Parallel()
+		if got := attributionCheckpointColumnWidth(nil); got != headerWidth {
+			t.Errorf("got %d, want %d", got, headerWidth)
+		}
+	})
+
+	t.Run("legacy hex keeps the historical 21-char column", func(t *testing.T) {
+		t.Parallel()
+		lines := []attributionLine{{CheckpointID: "a1b2c3d4e5f6", SessionID: "session-1234567890"}}
+		if got := attributionCheckpointColumnWidth(lines); got != 21 { // 12 + "/" + 8
+			t.Errorf("got %d, want 21", got)
+		}
+	})
+
+	t.Run("ULID widens the column so it is not clipped", func(t *testing.T) {
+		t.Parallel()
+		lines := []attributionLine{{CheckpointID: "01KVBJCWYA4YW6J5M9GP655HZN", SessionID: "session-1234567890"}}
+		if got := attributionCheckpointColumnWidth(lines); got != 35 { // 26 + "/" + 8
+			t.Errorf("got %d, want 35", got)
+		}
+	})
+}

--- a/cmd/entire/cli/checkpoint/generate.go
+++ b/cmd/entire/cli/checkpoint/generate.go
@@ -1,0 +1,26 @@
+package checkpoint
+
+import (
+	"context"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// GenerateCheckpointID mints a new checkpoint ID in the format the configured
+// primary store uses: a ULID under the git-refs store, a legacy 12-hex ID
+// otherwise. It is the single place the backend-coupled ID format is decided —
+// generation sites call it instead of id.Generate() so a git-refs checkpoint is
+// always a ULID, which lets reads route by ID kind (ULID ⟹ ref).
+//
+// Fail-soft: a missing or malformed checkpoints config resolves to the default
+// hex format rather than blocking ID generation (a bad block already surfaces
+// through checkpoint.Open).
+func GenerateCheckpointID(ctx context.Context) (id.CheckpointID, error) {
+	// A malformed/missing config resolves to a nil cfg here; PrimaryIsRefs(nil)
+	// is false, so we fall through to the default hex format (fail-soft).
+	if cfg, err := settings.LoadCheckpointsConfig(ctx); err == nil && PrimaryIsRefs(cfg) {
+		return id.GenerateULID() //nolint:wrapcheck // dispatcher; id.GenerateULID already returns a descriptive error
+	}
+	return id.Generate() //nolint:wrapcheck // dispatcher; id.Generate already returns a descriptive error
+}

--- a/cmd/entire/cli/checkpoint/generate_test.go
+++ b/cmd/entire/cli/checkpoint/generate_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
 // Not parallel: uses t.Setenv to drive the checkpoints-config env override.
@@ -22,8 +23,12 @@ func TestGenerateCheckpointID(t *testing.T) {
 	})
 
 	t.Run("default primary mints legacy hex", func(t *testing.T) {
-		t.Setenv("ENTIRE_CHECKPOINTS_PRIMARY", "") // unset → default git-branch
-		cid, err := GenerateCheckpointID(ctx)
+		t.Setenv("ENTIRE_CHECKPOINTS_PRIMARY", "") // unset → resolve from settings file
+		// Resolve config from an empty worktree so a developer dogfooding git-refs
+		// in their real .entire/settings.json can't turn this default case into a
+		// ULID (empty env falls through to the settings file, keyed off cwd).
+		isolated := settings.WithWorktreeRoot(context.Background(), t.TempDir())
+		cid, err := GenerateCheckpointID(isolated)
 		require.NoError(t, err)
 		assert.Equal(t, id.KindLegacy, cid.Kind(), "default primary should mint a 12-hex id")
 	})

--- a/cmd/entire/cli/checkpoint/generate_test.go
+++ b/cmd/entire/cli/checkpoint/generate_test.go
@@ -1,0 +1,37 @@
+package checkpoint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+)
+
+// Not parallel: uses t.Setenv to drive the checkpoints-config env override.
+func TestGenerateCheckpointID(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("git-refs primary mints a ULID", func(t *testing.T) {
+		t.Setenv("ENTIRE_CHECKPOINTS_PRIMARY", "git-refs")
+		cid, err := GenerateCheckpointID(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, id.KindULID, cid.Kind(), "git-refs primary should mint a ULID")
+	})
+
+	t.Run("default primary mints legacy hex", func(t *testing.T) {
+		t.Setenv("ENTIRE_CHECKPOINTS_PRIMARY", "") // unset → default git-branch
+		cid, err := GenerateCheckpointID(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, id.KindLegacy, cid.Kind(), "default primary should mint a 12-hex id")
+	})
+
+	t.Run("git-branch primary mints legacy hex", func(t *testing.T) {
+		t.Setenv("ENTIRE_CHECKPOINTS_PRIMARY", "git-branch")
+		cid, err := GenerateCheckpointID(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, id.KindLegacy, cid.Kind())
+	})
+}

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -50,8 +50,10 @@ const ShortIDLength = 12
 
 // MaxIDLength is the longest a valid checkpoint ID can be — a 26-character ULID.
 // Use it (not ShortIDLength) when reasoning about whether a string could be a
-// checkpoint ID or a prefix of one, since IDs are no longer fixed-width.
-const MaxIDLength = 26
+// checkpoint ID or a prefix of one, since IDs are no longer fixed-width. Tied to
+// oklog/ulid's own encoded-size constant so the three ULID-width sites (this,
+// ulidPattern's {26}, and the library) cannot drift apart.
+const MaxIDLength = ulid.EncodedSize
 
 // checkpointIDRegex validates the legacy format: exactly 12 lowercase hex characters.
 var checkpointIDRegex = regexp.MustCompile(`^` + Pattern + `$`)
@@ -182,6 +184,24 @@ func Validate(s string) error {
 // String returns the checkpoint ID as a string.
 func (id CheckpointID) String() string {
 	return string(id)
+}
+
+// DisplayShort returns the checkpoint ID trimmed for compact display. A legacy
+// hex ID is random throughout, so its ShortIDLength-char prefix identifies it and
+// resolves as a prefix. A ULID encodes a millisecond timestamp in its leading
+// characters (near-identical for checkpoints minted close in time) with entropy
+// only in the tail, so a front-truncated ULID is both ambiguous and misleading —
+// it looks like a complete ID but won't resolve — so a ULID is returned in full.
+// Non-ID strings (e.g. "temporary") are trimmed like the legacy case.
+func (id CheckpointID) DisplayShort() string {
+	s := string(id)
+	if KindOf(s) == KindULID {
+		return s
+	}
+	if len(s) > ShortIDLength {
+		return s[:ShortIDLength]
+	}
+	return s
 }
 
 // IsEmpty returns true if the checkpoint ID is empty or unset.

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"time"
 
 	ulid "github.com/oklog/ulid/v2"
 )
@@ -159,8 +158,11 @@ func Generate() (CheckpointID, error) {
 // and lexicographically time-sortable. It is the format the git-refs store uses
 // (chosen by checkpoint.GenerateCheckpointID); the value is canonical and passes
 // KindOf/Validate as KindULID.
+//
+// The timestamp is Unix epoch milliseconds (via ulid.Now), so it is inherently
+// timezone-independent — the machine's local zone does not affect the ID.
 func GenerateULID() (CheckpointID, error) {
-	u, err := ulid.New(ulid.Timestamp(time.Now()), rand.Reader)
+	u, err := ulid.New(ulid.Now(), rand.Reader)
 	if err != nil {
 		return EmptyCheckpointID, fmt.Errorf("failed to generate ULID checkpoint ID: %w", err)
 	}

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"time"
 
 	ulid "github.com/oklog/ulid/v2"
 )
@@ -47,6 +48,11 @@ const CheckpointPattern = `(?:` + Pattern + `|` + ulidPattern + `)`
 // ShortIDLength is the standard length for truncating IDs for display purposes.
 // Used for tool use IDs, session IDs, and commit hashes in logs and messages.
 const ShortIDLength = 12
+
+// MaxIDLength is the longest a valid checkpoint ID can be — a 26-character ULID.
+// Use it (not ShortIDLength) when reasoning about whether a string could be a
+// checkpoint ID or a prefix of one, since IDs are no longer fixed-width.
+const MaxIDLength = 26
 
 // checkpointIDRegex validates the legacy format: exactly 12 lowercase hex characters.
 var checkpointIDRegex = regexp.MustCompile(`^` + Pattern + `$`)
@@ -146,6 +152,19 @@ func Generate() (CheckpointID, error) {
 		return EmptyCheckpointID, fmt.Errorf("failed to generate random checkpoint ID: %w", err)
 	}
 	return CheckpointID(hex.EncodeToString(bytes)), nil
+}
+
+// GenerateULID creates a new 26-character Crockford base32 ULID checkpoint ID:
+// a millisecond timestamp prefix plus crypto-random entropy, so IDs are unique
+// and lexicographically time-sortable. It is the format the git-refs store uses
+// (chosen by checkpoint.GenerateCheckpointID); the value is canonical and passes
+// KindOf/Validate as KindULID.
+func GenerateULID() (CheckpointID, error) {
+	u, err := ulid.New(ulid.Timestamp(time.Now()), rand.Reader)
+	if err != nil {
+		return EmptyCheckpointID, fmt.Errorf("failed to generate ULID checkpoint ID: %w", err)
+	}
+	return CheckpointID(u.String()), nil
 }
 
 // Validate checks if a string is a valid checkpoint ID format: either a legacy

--- a/cmd/entire/cli/checkpoint/id/id_test.go
+++ b/cmd/entire/cli/checkpoint/id/id_test.go
@@ -32,6 +32,33 @@ func TestGenerateULID(t *testing.T) {
 	}
 }
 
+func TestCheckpointID_DisplayShort(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// Legacy hex is random throughout: its 12-char form is shown whole.
+		{"legacy hex", "a1b2c3d4e5f6", "a1b2c3d4e5f6"},
+		// A ULID is shown in full — front-truncating drops its entropy tail and
+		// would render an ambiguous, unresolvable prefix.
+		{"ulid shown in full", sampleULID, sampleULID},
+		// Non-ID sentinels trim like the legacy case (here: unchanged, under width).
+		{"temporary sentinel", "temporary", "temporary"},
+		// An over-width unknown string is trimmed to ShortIDLength.
+		{"overlong unknown", "0123456789abcdef", "0123456789ab"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := CheckpointID(tt.input).DisplayShort(); got != tt.want {
+				t.Errorf("CheckpointID(%q).DisplayShort() = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckpointID_Methods(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
 		id := CheckpointID("a1b2c3d4e5f6")

--- a/cmd/entire/cli/checkpoint/id/id_test.go
+++ b/cmd/entire/cli/checkpoint/id/id_test.go
@@ -8,6 +8,30 @@ import (
 // A representative ULID (Crockford base32, 26 chars) used across tests.
 const sampleULID = "01KVBJCWYA4YW6J5M9GP655HZN"
 
+func TestGenerateULID(t *testing.T) {
+	t.Parallel()
+	a, err := GenerateULID()
+	if err != nil {
+		t.Fatalf("GenerateULID() error = %v", err)
+	}
+	if err := Validate(string(a)); err != nil {
+		t.Errorf("generated ULID %q failed Validate: %v", a, err)
+	}
+	if a.Kind() != KindULID {
+		t.Errorf("Kind() = %v, want KindULID for %q", a.Kind(), a)
+	}
+	if len(string(a)) != 26 {
+		t.Errorf("len = %d, want 26 for %q", len(string(a)), a)
+	}
+	b, err := GenerateULID()
+	if err != nil {
+		t.Fatalf("GenerateULID() error = %v", err)
+	}
+	if a == b {
+		t.Errorf("two GenerateULID() calls returned the same id %q", a)
+	}
+}
+
 func TestCheckpointID_Methods(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
 		id := CheckpointID("a1b2c3d4e5f6")

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -2553,8 +2553,6 @@ const (
 	maxMessageDisplayLength = 80
 	// maxPromptDisplayLength is the maximum length for session prompts before truncation
 	maxPromptDisplayLength = 60
-	// checkpointIDDisplayLength is the number of characters to show from checkpoint IDs
-	checkpointIDDisplayLength = 12
 )
 
 // formatBranchCheckpoints formats checkpoint information for a branch.
@@ -2715,10 +2713,9 @@ func groupByCheckpointID(points []strategy.RewindPoint) []checkpointGroup {
 // followed by indicators and the prompt — which cascades from
 // SessionPrompt → latest commit message → dimmed `(no prompt recorded)`.
 func formatCheckpointGroup(sb *strings.Builder, group checkpointGroup, styles statusStyles) {
-	cpID := group.checkpointID
-	if len(cpID) > checkpointIDDisplayLength {
-		cpID = cpID[:checkpointIDDisplayLength]
-	}
+	// Kind-aware trim: a legacy hex ID shows its 12-char prefix; a ULID is shown
+	// in full (front-truncating a ULID drops its entropy tail and won't resolve).
+	cpID := id.CheckpointID(group.checkpointID).DisplayShort()
 
 	// Indicators (Task / temporary). Skip [temporary] when cpID already says so.
 	var indicators []string

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -530,10 +530,9 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 // Best-effort: on repo/list failures we return nil so the main flow
 // surfaces the real error instead of double-reporting.
 func runExplainAutoAmbiguityGuard(ctx context.Context, target string, lookup *explainCheckpointLookup, lookupErr error) error {
-	// Targets longer than a checkpoint ID can't prefix-match one.
-	// This is coupled to checkpoint IDs being fixed-width; longer targets
-	// cannot be prefixes of committed checkpoint IDs.
-	if len(target) > id.ShortIDLength {
+	// Targets longer than the longest possible checkpoint ID (a 26-char ULID)
+	// can't be a prefix of one, so they can't be an ambiguous checkpoint target.
+	if len(target) > id.MaxIDLength {
 		return nil
 	}
 	if lookupErr != nil {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1172,14 +1172,6 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 	}
 	defer repo.Close()
 
-	checkpointID, err := cpkg.GenerateCheckpointID(logCtx)
-	if err != nil {
-		logging.Warn(logCtx, "eager condense: failed to generate checkpoint ID",
-			slog.String("error", err.Error()),
-		)
-		return nil // fail-open
-	}
-
 	var shadowBranchName string
 	var didCondense bool
 	mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
@@ -1209,6 +1201,18 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 			state.StepCount = 0
 			state.FullyCondensed = true
 			return nil
+		}
+
+		// Mint the checkpoint ID only now that condensation is actually going to
+		// run — the skip paths above (files-touched, no steps, no shadow branch)
+		// return before this, so a no-op session stop no longer pays the ID mint
+		// (and its checkpoints-config load).
+		checkpointID, genErr := cpkg.GenerateCheckpointID(logCtx)
+		if genErr != nil {
+			logging.Warn(logCtx, "eager condense: failed to generate checkpoint ID",
+				slog.String("error", genErr.Error()),
+			)
+			return ErrMutationSkip // fail-open; PostCommit retries
 		}
 
 		result, condErr := s.CondenseSession(ctx, repo, checkpointID, state, nil)

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1072,7 +1072,7 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 	}
 	defer repo.Close()
 
-	checkpointID, err := id.Generate()
+	checkpointID, err := cpkg.GenerateCheckpointID(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to generate checkpoint ID: %w", err)
 	}
@@ -1172,7 +1172,7 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 	}
 	defer repo.Close()
 
-	checkpointID, err := id.Generate()
+	checkpointID, err := cpkg.GenerateCheckpointID(logCtx)
 	if err != nil {
 		logging.Warn(logCtx, "eager condense: failed to generate checkpoint ID",
 			slog.String("error", err.Error()),

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -465,7 +465,7 @@ func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFi
 
 	// Generate a fresh checkpoint ID and resolve session metadata
 	_, resolveMetadataSpan := perf.Start(ctx, "resolve_session_metadata")
-	checkpointID, err := id.Generate()
+	checkpointID, err := checkpoint.GenerateCheckpointID(ctx)
 	if err != nil {
 		resolveMetadataSpan.RecordError(err)
 		resolveMetadataSpan.End()
@@ -2111,7 +2111,7 @@ func (s *ManualCommitStrategy) tryAgentCommitFastPath(ctx context.Context, commi
 // (ACTIVE session + no TTY). Generates a checkpoint ID and adds the trailer
 // directly, bypassing content detection and interactive prompts.
 func (s *ManualCommitStrategy) addTrailerForAgentCommit(logCtx context.Context, commitMsgFile string, state *SessionState, source string) error { //nolint:unparam // kept for signature stability
-	cpID, err := id.Generate()
+	cpID, err := checkpoint.GenerateCheckpointID(logCtx)
 	if err != nil {
 		return nil //nolint:nilerr // Hook must be silent on failure
 	}

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -26,7 +26,7 @@ A **Checkpoint** captures a point-in-time within a session. Defined in `strategy
 
 ```go
 type Checkpoint struct {
-    CheckpointID     id.CheckpointID // Stable 12-hex-char identifier
+    CheckpointID     id.CheckpointID // Stable identifier (12-hex or ULID; see Checkpoint ID Linking)
     Message          string          // Commit message or checkpoint description
     Timestamp        time.Time
     IsTaskCheckpoint bool            // Task checkpoint (subagent) vs session checkpoint
@@ -366,9 +366,21 @@ the local policy cannot be satisfied.
 
 The checkpoint ID is the **stable identifier** that links user commits to metadata across branches.
 
-**Format:** 12-hex-character random ID (e.g., `a3b2c4d5e6f7`)
+**Format:** one of two shapes — do **not** assume a fixed width:
+- **Legacy 12-hex** random ID (e.g., `a3b2c4d5e6f7`) — the git-branch store's format.
+- **26-char ULID** (Crockford base32, e.g., `01KVBJCWYA4YW6J5M9GP655HZN`) — minted only
+  under the git-refs checkpoint store. A ULID's leading chars encode a millisecond
+  timestamp (so it is lexicographically time-sortable) and its tail is random; front
+  prefixes are therefore ambiguous — trim ULIDs from nowhere / show them in full for
+  display (see `id.CheckpointID.DisplayShort`), and use `id.MaxIDLength`, not a
+  hardcoded 12, when reasoning about maximum width.
+
+Both formats are validated by `id.KindOf` / `id.Validate`; readers accept either.
 
 **Generation:**
+- Minted by `checkpoint.GenerateCheckpointID`, which picks the format from the
+  configured primary store (ULID under git-refs, 12-hex otherwise). Do not call
+  `id.Generate()` / `id.GenerateULID()` directly from a checkpoint write path.
 - Generated during condensation (post-commit hook)
 
 **Usage:**


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/753
<!-- entire-trail-link-end -->

New checkpoints written under the **git-refs** primary now get a 26-char **ULID** instead of a 12-hex id. This makes a checkpoint's id encode its storage backend — **ULID ⟹ ref**, legacy hex ⟹ branch — which is the missing piece for id-kind-aware read routing (a follow-up): reads can decide where a checkpoint lives from the id alone, no config, no guessing.

## What changed
- **`id.GenerateULID()`** — timestamp + crypto-random ULID via `oklog/ulid` (already a dependency, previously import-for-parsing-only). Canonical, passes `KindOf`/`Validate` as `KindULID`. `id.Generate()` (12-hex) is unchanged.
- **`checkpoint.GenerateCheckpointID(ctx)`** — the single place the format is decided: ULID when the primary is git-refs, else 12-hex. Fail-soft to hex on a missing/malformed checkpoints config. Layering stays clean (`checkpoint` already imports `id` + `settings`; `settings` doesn't import `checkpoint`).
- **Routed the checkpoint-id generation sites** through it: `attach`, both manual-commit hook paths, both condensation paths. **Turn ids and the investigate run id stay hex** — they're format-agnostic correlation tokens, not stored checkpoints.
- **`explain` guard fix** — its auto-ambiguity guard assumed a fixed 12-char id width; it now uses `id.MaxIDLength` (26) so a ULID target isn't wrongly treated as un-prefixable.

## Why no store changes
Read/write already handled both formats: `ShardFor` shards ULIDs on the last two chars, and `RefName`/`ParseRef`/`Validate` accept them. Only *emission* was missing (the deferred "Layer B" from the git-refs store PR).

## Testing
- `id.GenerateULID` unit test (valid, KindULID, 26 chars, unique); `GenerateCheckpointID` test (git-refs → ULID, default/git-branch → hex).
- Build clean, lint 0, checkpoint + strategy + cli suites pass, integration **390**.
- **git-refs canary passes with ULID emission** (58/58 +1 skip) — proves ULID checkpoints work end-to-end (minting → last-2-char shard ref names → reads → e2e assertions). git-branch canary unchanged (hex, 59/59).

## Follow-up
The id-kind read routing (git-refs primary reading old branch-only checkpoints, and vice-versa) builds on this — now that ULID ⟹ ref holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how new checkpoint IDs are created across attach, hooks, and condensation; mis-routing format vs primary could affect metadata writes, though tests and fail-soft hex fallback limit blast radius.
> 
> **Overview**
> New committed checkpoints now get a **26-character ULID** when the checkpoints primary is **git-refs**, and keep the legacy **12-hex** ID for **git-branch** (and the default). The goal is to tie ID shape to storage (**ULID → ref**, hex → branch) so later read routing can pick the backend from the ID alone.
> 
> **`checkpoint.GenerateCheckpointID(ctx)`** is the single dispatcher: it reads checkpoints config and calls **`id.GenerateULID()`** or **`id.Generate()`**, failing soft to hex if config is missing or bad. **Attach**, **manual-commit** hook paths, and **condensation** (doctor / eager stop) now call this instead of **`id.Generate()`** directly; **`resolveCheckpointID`** takes **`context`** for that.
> 
> **`explain --generate`** ambiguity handling no longer assumes a 12-character checkpoint width; it uses **`id.MaxIDLength` (26)** so ULID targets are not skipped incorrectly.
> 
> Tests cover ULID generation and config-driven **`GenerateCheckpointID`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc294a037d783480d6afe2cecdc7a34d6909a6b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->