### PR TITLE
Route checkpoint reads by ID kind across git backends

### DIFF
--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -78,12 +78,43 @@ func Open(ctx context.Context, repo *git.Repository, opts OpenOptions) (*Stores,
 	if err != nil {
 		return nil, err
 	}
+	writer := newFanoutStore(primary, mirrors)
+
+	// Read routing: resolve id-keyed reads by the checkpoint's format across both
+	// git backends (a ULID lives in refs, a hex ID on the branch or a migrated
+	// ref), so a coexisting / mid-migration repo reads either format without
+	// reconfiguring. Writes still go through writer (configured primary + mirrors).
+	branchStore, refsStore, err := buildKindReadStores(ctx, env, primaryType, primary)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Stores{
-		Persistent: newFanoutStore(primary, mirrors),
+		Persistent: newKindRoutingStore(writer, branchStore, refsStore, primaryType),
 		ephemeral:  newEphemeralStore(repo, refs),
 		refs:       refs,
 	}, nil
+}
+
+// buildKindReadStores returns the git-branch and git-refs read stores used for
+// id-kind read routing, reusing the already-built primary for whichever kind it
+// is and constructing the sibling. A non-branch/refs git-backed primary (not a
+// real configuration today, since buildPrimary only accepts git-backed backends)
+// yields both freshly built git stores.
+func buildKindReadStores(ctx context.Context, env OpenEnv, primaryType string, primary PersistentStore) (branch, refs PersistentStore, err error) {
+	switch primaryType {
+	case BackendTypeGitBranch:
+		branch = primary
+		refs, err = build(ctx, env, BackendTypeGitRefs, nil)
+	case BackendTypeGitRefs:
+		refs = primary
+		branch, err = build(ctx, env, BackendTypeGitBranch, nil)
+	default:
+		if branch, err = build(ctx, env, BackendTypeGitBranch, nil); err == nil {
+			refs, err = build(ctx, env, BackendTypeGitRefs, nil)
+		}
+	}
+	return branch, refs, err
 }
 
 // resolvePrimaryType returns the configured primary backend type, defaulting to

--- a/cmd/entire/cli/checkpoint/open_config_test.go
+++ b/cmd/entire/cli/checkpoint/open_config_test.go
@@ -43,8 +43,13 @@ func TestOpen_DefaultIsGitPrimaryNoMirrors(t *testing.T) {
 
 	stores, err := Open(context.Background(), repo, OpenOptions{})
 	require.NoError(t, err)
-	_, isGit := stores.Persistent.(*GitStore)
-	assert.True(t, isGit, "default persistent store should be the raw git store, not a fan-out wrapper")
+	// Persistent is always the kind-routing store now (it routes id-keyed reads
+	// across the git backends); with a git-branch primary it preserves the git
+	// AuthorReader capability.
+	_, isRouting := stores.Persistent.(*kindRoutingStoreWithAuthor)
+	assert.True(t, isRouting, "default persistent store should be the kind-routing store")
+	_, isAuthor := stores.Persistent.(AuthorReader)
+	assert.True(t, isAuthor, "routing store should preserve the git primary's AuthorReader")
 }
 
 func TestOpen_RejectsNonGitBackedPrimary(t *testing.T) {
@@ -101,12 +106,12 @@ func TestOpen_BuildsConfiguredMirror(t *testing.T) {
 	stores, err := Open(context.Background(), repo, OpenOptions{})
 	require.NoError(t, err)
 
-	// With a mirror configured the persistent store is the fan-out wrapper, not
-	// the raw git store, and it still exposes AuthorReader (git primary has it).
+	// The persistent store is the kind-routing store (never the raw git store),
+	// and it still exposes AuthorReader (git primary has it).
 	_, isGit := stores.Persistent.(*GitStore)
-	assert.False(t, isGit, "configured mirror should wrap the primary in a fan-out store")
+	assert.False(t, isGit, "configured mirror should not expose the raw git store")
 	_, isAuthor := stores.Persistent.(AuthorReader)
-	assert.True(t, isAuthor, "fan-out store should preserve the git primary's AuthorReader")
+	assert.True(t, isAuthor, "routing store should preserve the git primary's AuthorReader")
 }
 
 func TestOpen_InvalidCheckpointsBlockErrors(t *testing.T) {
@@ -129,8 +134,10 @@ func TestOpen_ToleratesUnrelatedMalformedSettings(t *testing.T) {
 
 	stores, err := Open(context.Background(), repo, OpenOptions{})
 	require.NoError(t, err)
-	_, isGit := stores.Persistent.(*GitStore)
-	assert.True(t, isGit)
+	// Fail-soft default is the git-branch backend, so the routing store still
+	// exposes the git AuthorReader capability.
+	_, isAuthor := stores.Persistent.(AuthorReader)
+	assert.True(t, isAuthor)
 }
 
 func TestOpen_ToleratesWholeFileSyntaxError(t *testing.T) {
@@ -140,6 +147,8 @@ func TestOpen_ToleratesWholeFileSyntaxError(t *testing.T) {
 
 	stores, err := Open(context.Background(), repo, OpenOptions{})
 	require.NoError(t, err)
-	_, isGit := stores.Persistent.(*GitStore)
-	assert.True(t, isGit)
+	// Fail-soft default is the git-branch backend, so the routing store still
+	// exposes the git AuthorReader capability.
+	_, isAuthor := stores.Persistent.(AuthorReader)
+	assert.True(t, isAuthor)
 }

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -1564,10 +1564,7 @@ func (s *GitStore) List(ctx context.Context) ([]CheckpointInfo, error) {
 		return nil
 	})
 
-	// Sort by time (most recent first)
-	sort.Slice(checkpoints, func(i, j int) bool {
-		return checkpoints[i].CreatedAt.After(checkpoints[j].CreatedAt)
-	})
+	sortCheckpointInfosByRecency(checkpoints) // most recent first
 
 	return checkpoints, nil
 }

--- a/cmd/entire/cli/checkpoint/refs_store.go
+++ b/cmd/entire/cli/checkpoint/refs_store.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sort"
 	"strconv"
 
 	"github.com/go-git/go-git/v6"
@@ -392,9 +391,7 @@ func (s *gitRefsStore) List(ctx context.Context) ([]CheckpointInfo, error) {
 		return nil, fmt.Errorf("iterate checkpoint refs: %w", err)
 	}
 
-	sort.Slice(checkpoints, func(i, j int) bool {
-		return checkpoints[i].CreatedAt.After(checkpoints[j].CreatedAt)
-	})
+	sortCheckpointInfosByRecency(checkpoints)
 	return checkpoints, nil
 }
 

--- a/cmd/entire/cli/checkpoint/routing_store.go
+++ b/cmd/entire/cli/checkpoint/routing_store.go
@@ -62,16 +62,19 @@ func (s *kindRoutingStore) readOrder(checkpointID id.CheckpointID) []PersistentS
 	}
 }
 
-// firstResolved calls read on each store in order and returns the first result
-// that is not "absent" (per absent). A real (non-absent) error short-circuits.
-// When every store reports absent, the last absent result is returned so callers
-// still see the backend's own not-found signal.
+// firstResolved calls read on each store in order and returns the first genuine
+// hit (a non-absent result with no error). A non-final store that reports absent
+// OR errors falls through to the next store, so a transient failure in one
+// backend (e.g. a git-refs on-demand fetch error) does not hide a checkpoint that
+// resolves in the fallback backend. The final store's result is returned as-is
+// (hit, absent, or error), so callers still see the backend's own not-found /
+// error signal when nothing resolved.
 func firstResolved[T any](stores []PersistentStore, read func(PersistentStore) (T, error), absent func(T, error) bool) (T, error) {
 	var v T
 	var err error
-	for _, st := range stores {
+	for i, st := range stores {
 		v, err = read(st)
-		if !absent(v, err) {
+		if i == len(stores)-1 || (err == nil && !absent(v, err)) {
 			return v, err
 		}
 	}
@@ -106,14 +109,33 @@ func (s *kindRoutingStore) List(ctx context.Context) ([]CheckpointInfo, error) {
 	if err != nil {
 		return nil, err //nolint:wrapcheck // in-package store error surfaced verbatim
 	}
-	// Disjoint by construction (hex on the branch, ULID in refs; a migrated hex
-	// ref would appear only in refs). Concatenate and re-sort most-recent-first to
-	// match each backend's own List ordering.
 	merged := make([]CheckpointInfo, 0, len(branchList)+len(refsList))
 	merged = append(merged, branchList...)
 	merged = append(merged, refsList...)
-	sort.Slice(merged, func(i, j int) bool { return merged[i].CreatedAt.After(merged[j].CreatedAt) })
-	return merged, nil
+	sortCheckpointInfosByRecency(merged)
+	// Dedup by ID: during coexistence/migration the same checkpoint can appear in
+	// both backends (a ULID mirrored to the branch, or a hex still on the branch
+	// and also migrated into refs). Keep the first occurrence — i.e. the most
+	// recent after the sort.
+	deduped := merged[:0]
+	seen := make(map[id.CheckpointID]struct{}, len(merged))
+	for _, info := range merged {
+		if _, dup := seen[info.CheckpointID]; dup {
+			continue
+		}
+		seen[info.CheckpointID] = struct{}{}
+		deduped = append(deduped, info)
+	}
+	return deduped, nil
+}
+
+// sortCheckpointInfosByRecency orders checkpoints most-recent-first by CreatedAt.
+// Shared by the git-branch, git-refs, and routing List implementations so they
+// present a consistent order.
+func sortCheckpointInfosByRecency(checkpoints []CheckpointInfo) {
+	sort.Slice(checkpoints, func(i, j int) bool {
+		return checkpoints[i].CreatedAt.After(checkpoints[j].CreatedAt)
+	})
 }
 
 func (s *kindRoutingStore) ReadSessionContent(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*SessionContent, error) {

--- a/cmd/entire/cli/checkpoint/routing_store.go
+++ b/cmd/entire/cli/checkpoint/routing_store.go
@@ -1,0 +1,186 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+)
+
+// kindRoutingStore resolves id-keyed reads across the two git backends so a repo
+// running git-refs and git-branch side by side (or mid-migration between them)
+// can read checkpoints of BOTH formats without reconfiguring:
+//
+//   - A ULID checkpoint only ever lives in the git-refs store, so a ULID ID is
+//     read from refs and NEVER from the branch (regardless of the active backend).
+//   - A legacy-hex ID is read from the active (configured) primary first. When the
+//     active primary is git-refs, it also falls back to the git-branch store,
+//     because a hex checkpoint may still sit on the pre-migration v1 branch. Under
+//     a git-branch primary the branch is authoritative for hex, so refs is not
+//     consulted.
+//
+// List unions both backends (disjoint ID spaces). Writes are NOT kind-routed:
+// they go to the configured primary (+ mirrors) via writer, since a new
+// checkpoint's ID is already minted to match the primary's format
+// (see checkpoint.GenerateCheckpointID).
+type kindRoutingStore struct {
+	writer      PersistentStore // configured primary + mirrors (fanout); handles Write
+	branch      PersistentStore // git-branch store; serves hex reads
+	refs        PersistentStore // git-refs store; serves ULID reads (+ hex under refs primary)
+	primaryType string
+}
+
+// newKindRoutingStore wraps the write fanout plus the two git read stores. It
+// preserves the optional AuthorReader capability (explain relies on it) when both
+// read stores provide it — the built-in git backends always do.
+func newKindRoutingStore(writer, branch, refs PersistentStore, primaryType string) PersistentStore {
+	s := &kindRoutingStore{writer: writer, branch: branch, refs: refs, primaryType: primaryType}
+	if _, ok := branch.(AuthorReader); ok {
+		if _, ok := refs.(AuthorReader); ok {
+			return &kindRoutingStoreWithAuthor{kindRoutingStore: s}
+		}
+	}
+	return s
+}
+
+// readOrder returns the stores to consult for checkpointID, in priority order,
+// per the routing rules above.
+func (s *kindRoutingStore) readOrder(checkpointID id.CheckpointID) []PersistentStore {
+	if checkpointID.Kind() == id.KindULID {
+		return []PersistentStore{s.refs} // ULIDs only ever live in refs
+	}
+	switch s.primaryType {
+	case BackendTypeGitBranch:
+		return []PersistentStore{s.branch} // branch is authoritative for hex
+	case BackendTypeGitRefs:
+		return []PersistentStore{s.refs, s.branch} // active refs, then pre-migration branch
+	default:
+		// A non-branch/refs git-backed primary is not a real configuration today;
+		// try both git stores so a hex ID still resolves wherever it landed.
+		return []PersistentStore{s.branch, s.refs}
+	}
+}
+
+// firstResolved calls read on each store in order and returns the first result
+// that is not "absent" (per absent). A real (non-absent) error short-circuits.
+// When every store reports absent, the last absent result is returned so callers
+// still see the backend's own not-found signal.
+func firstResolved[T any](stores []PersistentStore, read func(PersistentStore) (T, error), absent func(T, error) bool) (T, error) {
+	var v T
+	var err error
+	for _, st := range stores {
+		v, err = read(st)
+		if !absent(v, err) {
+			return v, err
+		}
+	}
+	return v, err
+}
+
+// checkpointNotFound reports the checkpoint-level "absent" signal: Read returns
+// (nil, nil) — not an error — when a checkpoint does not exist.
+func checkpointNotFound(v *CheckpointSummary, err error) bool {
+	return err == nil && v == nil
+}
+
+// sessionNotFound reports the session-level "absent" signal: the session readers
+// return ErrCheckpointNotFound when the checkpoint (or session) is missing.
+func sessionNotFound[T any](_ T, err error) bool {
+	return errors.Is(err, ErrCheckpointNotFound)
+}
+
+func (s *kindRoutingStore) Read(ctx context.Context, checkpointID id.CheckpointID) (*CheckpointSummary, error) {
+	return firstResolved(s.readOrder(checkpointID),
+		func(st PersistentStore) (*CheckpointSummary, error) { return st.Read(ctx, checkpointID) },
+		checkpointNotFound,
+	)
+}
+
+func (s *kindRoutingStore) List(ctx context.Context) ([]CheckpointInfo, error) {
+	branchList, err := s.branch.List(ctx)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // in-package store error surfaced verbatim
+	}
+	refsList, err := s.refs.List(ctx)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // in-package store error surfaced verbatim
+	}
+	// Disjoint by construction (hex on the branch, ULID in refs; a migrated hex
+	// ref would appear only in refs). Concatenate and re-sort most-recent-first to
+	// match each backend's own List ordering.
+	merged := make([]CheckpointInfo, 0, len(branchList)+len(refsList))
+	merged = append(merged, branchList...)
+	merged = append(merged, refsList...)
+	sort.Slice(merged, func(i, j int) bool { return merged[i].CreatedAt.After(merged[j].CreatedAt) })
+	return merged, nil
+}
+
+func (s *kindRoutingStore) ReadSessionContent(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*SessionContent, error) {
+	return firstResolved(s.readOrder(checkpointID),
+		func(st PersistentStore) (*SessionContent, error) {
+			return st.ReadSessionContent(ctx, checkpointID, sessionIndex)
+		},
+		sessionNotFound[*SessionContent],
+	)
+}
+
+func (s *kindRoutingStore) ReadSessionMetadata(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*Metadata, error) {
+	return firstResolved(s.readOrder(checkpointID),
+		func(st PersistentStore) (*Metadata, error) {
+			return st.ReadSessionMetadata(ctx, checkpointID, sessionIndex)
+		},
+		sessionNotFound[*Metadata],
+	)
+}
+
+func (s *kindRoutingStore) ReadSessionPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (string, error) {
+	return firstResolved(s.readOrder(checkpointID),
+		func(st PersistentStore) (string, error) {
+			return st.ReadSessionPrompts(ctx, checkpointID, sessionIndex)
+		},
+		sessionNotFound[string],
+	)
+}
+
+// metaAndPrompts bundles the two non-error returns of ReadSessionMetadataAndPrompts
+// so it can flow through the single-value firstResolved helper.
+type metaAndPrompts struct {
+	meta    *Metadata
+	prompts string
+}
+
+func (s *kindRoutingStore) ReadSessionMetadataAndPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*Metadata, string, error) {
+	mp, err := firstResolved(s.readOrder(checkpointID),
+		func(st PersistentStore) (metaAndPrompts, error) {
+			m, p, e := st.ReadSessionMetadataAndPrompts(ctx, checkpointID, sessionIndex)
+			return metaAndPrompts{meta: m, prompts: p}, e //nolint:wrapcheck // in-package store error surfaced verbatim
+		},
+		sessionNotFound[metaAndPrompts],
+	)
+	return mp.meta, mp.prompts, err
+}
+
+// Write is not kind-routed: it targets the configured primary (+ mirrors).
+func (s *kindRoutingStore) Write(ctx context.Context, req WriteRequest) error {
+	return s.writer.Write(ctx, req) //nolint:wrapcheck // primary error is the operation's error, surfaced verbatim
+}
+
+// kindRoutingStoreWithAuthor adds the optional AuthorReader capability, routing
+// GetCheckpointAuthor by the same rules as the reads.
+type kindRoutingStoreWithAuthor struct {
+	*kindRoutingStore
+}
+
+func (s *kindRoutingStoreWithAuthor) GetCheckpointAuthor(ctx context.Context, checkpointID id.CheckpointID) (Author, error) {
+	return firstResolved(s.readOrder(checkpointID),
+		func(st PersistentStore) (Author, error) {
+			ar, ok := st.(AuthorReader)
+			if !ok {
+				return Author{}, nil
+			}
+			return ar.GetCheckpointAuthor(ctx, checkpointID)
+		},
+		func(a Author, err error) bool { return err == nil && a == Author{} },
+	)
+}

--- a/cmd/entire/cli/checkpoint/routing_store_test.go
+++ b/cmd/entire/cli/checkpoint/routing_store_test.go
@@ -2,8 +2,10 @@ package checkpoint
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -86,6 +88,26 @@ func TestKindRoutingStore_Read(t *testing.T) {
 		require.NotNil(t, got, "a hex checkpoint migrated into refs should resolve under a git-refs primary")
 	})
 
+	t.Run("git-refs primary: a refs fetch error falls back to the branch", func(t *testing.T) {
+		t.Parallel()
+		_, repo, _ := newTestRepo(t)
+		branch := NewGitStore(repo, DefaultV1Refs())
+		refs := newGitRefsStore(repo)
+		// A missing local ref triggers an on-demand fetch; simulate that fetch
+		// failing (network down) so the refs read returns a hard error rather than
+		// ErrCheckpointNotFound.
+		refs.SetRefFetcher(func(context.Context, plumbing.ReferenceName) error {
+			return errors.New("network down")
+		})
+		writeRoutingCheckpoint(t, branch, hexID, "hex-on-branch")
+
+		router := newKindRoutingStore(refs, branch, refs, BackendTypeGitRefs)
+
+		got, err := router.Read(ctx, hexID)
+		require.NoError(t, err, "a refs fetch error must not block the branch fallback")
+		require.NotNil(t, got, "hex checkpoint on the branch should resolve even when the refs read errors")
+	})
+
 	t.Run("a ULID is never read from the branch", func(t *testing.T) {
 		t.Parallel()
 		_, repo, _ := newTestRepo(t)
@@ -144,6 +166,32 @@ func TestKindRoutingStore_ListUnionsBothBackends(t *testing.T) {
 	}
 	assert.True(t, seen[hexID.String()], "list should include the hex checkpoint from the branch")
 	assert.True(t, seen[ulidID.String()], "list should include the ULID checkpoint from refs")
+}
+
+func TestKindRoutingStore_ListDedupesAcrossBackends(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	_, repo, _ := newTestRepo(t)
+	branch := NewGitStore(repo, DefaultV1Refs())
+	refs := newGitRefsStore(repo)
+
+	// The same checkpoint present in BOTH backends (as happens for a mirrored
+	// checkpoint or a migrated one) must appear only once in the merged list.
+	dupID := id.MustCheckpointID("a1b2c3d4e5f6")
+	writeRoutingCheckpoint(t, branch, dupID, "on-branch")
+	writeRoutingCheckpoint(t, refs, dupID, "in-refs")
+
+	router := newKindRoutingStore(branch, branch, refs, BackendTypeGitRefs)
+
+	infos, err := router.List(ctx)
+	require.NoError(t, err)
+	count := 0
+	for _, info := range infos {
+		if info.CheckpointID == dupID {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "a checkpoint present in both backends should appear once")
 }
 
 func TestKindRoutingStore_GetCheckpointAuthorRoutes(t *testing.T) {

--- a/cmd/entire/cli/checkpoint/routing_store_test.go
+++ b/cmd/entire/cli/checkpoint/routing_store_test.go
@@ -1,0 +1,166 @@
+package checkpoint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/redact"
+)
+
+const routingSampleULID = "01KVBJCWYA4YW6J5M9GP655HZN"
+
+// writeRoutingCheckpoint writes a minimal one-session checkpoint to store.
+func writeRoutingCheckpoint(t *testing.T, store PersistentStore, cid id.CheckpointID, sessionID string) {
+	t.Helper()
+	require.NoError(t, store.Write(context.Background(), Session{
+		CheckpointID: cid,
+		SessionID:    sessionID,
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("transcript for " + sessionID)),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+	}))
+}
+
+func TestKindRoutingStore_Read(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	hexID := id.MustCheckpointID("a1b2c3d4e5f6")
+	ulidID := id.MustCheckpointID(routingSampleULID)
+
+	t.Run("git-branch primary: hex on branch, ULID still from refs", func(t *testing.T) {
+		t.Parallel()
+		_, repo, _ := newTestRepo(t)
+		branch := NewGitStore(repo, DefaultV1Refs())
+		refs := newGitRefsStore(repo)
+		writeRoutingCheckpoint(t, branch, hexID, "hex-on-branch")
+		writeRoutingCheckpoint(t, refs, ulidID, "ulid-in-refs")
+
+		router := newKindRoutingStore(branch, branch, refs, BackendTypeGitBranch)
+
+		got, err := router.Read(ctx, hexID)
+		require.NoError(t, err)
+		require.NotNil(t, got, "hex checkpoint should resolve from the branch")
+
+		got, err = router.Read(ctx, ulidID)
+		require.NoError(t, err)
+		require.NotNil(t, got, "ULID checkpoint should resolve from refs even under a git-branch primary")
+	})
+
+	t.Run("git-refs primary: ULID from refs, pre-migration hex from branch fallback", func(t *testing.T) {
+		t.Parallel()
+		_, repo, _ := newTestRepo(t)
+		branch := NewGitStore(repo, DefaultV1Refs())
+		refs := newGitRefsStore(repo)
+		writeRoutingCheckpoint(t, branch, hexID, "hex-on-branch")
+		writeRoutingCheckpoint(t, refs, ulidID, "ulid-in-refs")
+
+		router := newKindRoutingStore(refs, branch, refs, BackendTypeGitRefs)
+
+		got, err := router.Read(ctx, ulidID)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+
+		got, err = router.Read(ctx, hexID)
+		require.NoError(t, err)
+		require.NotNil(t, got, "hex checkpoint on the branch should resolve via fallback under a git-refs primary")
+	})
+
+	t.Run("git-refs primary: migrated hex in refs resolves from refs first", func(t *testing.T) {
+		t.Parallel()
+		_, repo, _ := newTestRepo(t)
+		branch := NewGitStore(repo, DefaultV1Refs())
+		refs := newGitRefsStore(repo)
+		migratedHex := id.MustCheckpointID("ffffffffeeee")
+		writeRoutingCheckpoint(t, refs, migratedHex, "hex-migrated-to-refs")
+
+		router := newKindRoutingStore(refs, branch, refs, BackendTypeGitRefs)
+
+		got, err := router.Read(ctx, migratedHex)
+		require.NoError(t, err)
+		require.NotNil(t, got, "a hex checkpoint migrated into refs should resolve under a git-refs primary")
+	})
+
+	t.Run("a ULID is never read from the branch", func(t *testing.T) {
+		t.Parallel()
+		_, repo, _ := newTestRepo(t)
+		branch := NewGitStore(repo, DefaultV1Refs())
+		refs := newGitRefsStore(repo)
+		// Deliberately put a ULID-named checkpoint on the branch (the wrong place)
+		// and nothing in refs; routing must not find it, proving branch is never
+		// consulted for a ULID.
+		writeRoutingCheckpoint(t, branch, ulidID, "stray-ulid-on-branch")
+
+		router := newKindRoutingStore(branch, branch, refs, BackendTypeGitBranch)
+
+		got, err := router.Read(ctx, ulidID)
+		require.NoError(t, err)
+		assert.Nil(t, got, "a ULID must be read only from refs; a stray ULID on the branch must not resolve")
+	})
+}
+
+func TestKindRoutingStore_SessionReadRoutes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	_, repo, _ := newTestRepo(t)
+	branch := NewGitStore(repo, DefaultV1Refs())
+	refs := newGitRefsStore(repo)
+
+	ulidID := id.MustCheckpointID(routingSampleULID)
+	writeRoutingCheckpoint(t, refs, ulidID, "ulid-in-refs")
+
+	router := newKindRoutingStore(branch, branch, refs, BackendTypeGitBranch)
+
+	meta, err := router.ReadSessionMetadata(ctx, ulidID, 0)
+	require.NoError(t, err)
+	require.NotNil(t, meta, "session metadata for a ULID checkpoint should route to refs")
+	assert.Equal(t, "ulid-in-refs", meta.SessionID)
+}
+
+func TestKindRoutingStore_ListUnionsBothBackends(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	_, repo, _ := newTestRepo(t)
+	branch := NewGitStore(repo, DefaultV1Refs())
+	refs := newGitRefsStore(repo)
+
+	hexID := id.MustCheckpointID("a1b2c3d4e5f6")
+	ulidID := id.MustCheckpointID(routingSampleULID)
+	writeRoutingCheckpoint(t, branch, hexID, "hex")
+	writeRoutingCheckpoint(t, refs, ulidID, "ulid")
+
+	router := newKindRoutingStore(branch, branch, refs, BackendTypeGitBranch)
+
+	infos, err := router.List(ctx)
+	require.NoError(t, err)
+	seen := make(map[string]bool, len(infos))
+	for _, info := range infos {
+		seen[info.CheckpointID.String()] = true
+	}
+	assert.True(t, seen[hexID.String()], "list should include the hex checkpoint from the branch")
+	assert.True(t, seen[ulidID.String()], "list should include the ULID checkpoint from refs")
+}
+
+func TestKindRoutingStore_GetCheckpointAuthorRoutes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	_, repo, _ := newTestRepo(t)
+	branch := NewGitStore(repo, DefaultV1Refs())
+	refs := newGitRefsStore(repo)
+
+	ulidID := id.MustCheckpointID(routingSampleULID)
+	writeRoutingCheckpoint(t, refs, ulidID, "ulid-in-refs")
+
+	router := newKindRoutingStore(branch, branch, refs, BackendTypeGitBranch)
+	author, ok := router.(AuthorReader)
+	require.True(t, ok, "routing store over git backends should expose AuthorReader")
+
+	got, err := author.GetCheckpointAuthor(ctx, ulidID)
+	require.NoError(t, err)
+	assert.Equal(t, "Test", got.Name, "author of a ULID checkpoint should route to refs")
+}

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -377,6 +377,17 @@ The checkpoint ID is the **stable identifier** that links user commits to metada
 
 Both formats are validated by `id.KindOf` / `id.Validate`; readers accept either.
 
+**Read routing (`checkpoint.Open` → `kindRoutingStore`):** id-keyed reads resolve
+across both git backends by the checkpoint's format, so a repo running git-refs
+and git-branch side by side (or mid-migration) reads either format without
+reconfiguring:
+- A **ULID** is read from the git-refs store only — never the branch.
+- A **hex** ID is read from the active (configured) primary first; when the
+  primary is git-refs it also falls back to the git-branch store (a hex checkpoint
+  may still sit on the pre-migration v1 branch, or have been migrated into refs).
+- `List` unions both backends. **Writes are not kind-routed** — they go to the
+  configured primary (+ mirrors); the minted ID already matches the primary.
+
 **Generation:**
 - Minted by `checkpoint.GenerateCheckpointID`, which picks the format from the
   configured primary store (ULID under git-refs, 12-hex otherwise). Do not call


### PR DESCRIPTION
## What

Follow-up **#1** from the ULID-emission review (#1629). Reads previously resolved only against the *configured primary* store, so after a git-branch⇄git-refs flip — or while running the two side by side — a checkpoint stored in the other backend was reported missing (and attach could even suggest an unfixable fetch). This adds **id-kind read routing** so the CLI resolves a checkpoint by its format, wherever it lives.

## Routing rules (per Stefan's spec)

- **ULID** → git-refs store only; **never** the branch (regardless of active backend).
- **hex + git-branch primary** → branch only.
- **hex + git-refs primary** → refs first, then git-branch fallback (a hex checkpoint may still sit on the pre-migration v1 branch, or have been migrated into refs).
- `List` unions both backends; `GetCheckpointAuthor` routes the same way (`AuthorReader` preserved).
- **Writes are not kind-routed** — they stay on the configured primary (+ mirrors); the minted ID already matches the primary's format.

## How

`checkpoint.Open` now returns a `kindRoutingStore` wrapping the write fanout plus the two git read stores (reusing the primary for its kind, building the sibling). Every general read path — resume, explain, attribution, blame, tokens, attach — inherits routing for free. No config knob; it's automatic.

## Tests

`routing_store_test.go` covers: ULID→refs (incl. *"a ULID never reads from the branch"*), hex→branch, hex-fallback and migrated-hex-in-refs under a refs primary, `List` union, session-read routing, author routing. `open_config_test.go` updated to the new "`Persistent` is always the routing store" invariant.

Verified: unit + integration (390) + E2E canary on **both** backends (git-branch 4/4, git-refs 58/59 +1 known skip).

## Not in scope (separate follow-up #2)

The write-boundary guard for the ULID⇒refs invariant (warn/reject when a ULID would be condensed onto a git-branch primary). Left deliberately — it needs topology-role awareness (a git-branch *mirror* of a git-refs primary legitimately receives ULIDs).

## Review updates (commit `80c7a4e`)

Addressed the Cursor Bugbot findings and a `/simplify` reuse cleanup:

- **Fetch errors no longer block the branch fallback** (Cursor, medium): `firstResolved` now falls through to the next store on a non-final store's **error** as well as on "absent". Under a git-refs primary, a hex read whose refs lookup fails on an on-demand ref fetch (network) still resolves from the git-branch store. The final store's result (hit/absent/error) is returned verbatim, and single-store orders are unchanged.
- **`List` dedups by checkpoint ID** (Cursor, low): a checkpoint present in both backends (a mirrored ULID, or a hex on the branch also migrated into refs) now appears once (most-recent kept).
- **Shared sort helper** (`/simplify` reuse): extracted `sortCheckpointInfosByRecency`, now used by the git-branch, git-refs, and routing `List` implementations.
- New tests: refs-fetch-error-falls-back-to-branch, and List-dedup across backends.

The rest of `/simplify` was judged already-clean: `firstResolved`/`readOrder` stay centralized (the fallback fix depends on it), and "routing-as-a-backend / backends-declare-their-id-kind" was deemed over-engineering for two backends. `List` querying both backends is intentional (union completeness) — a bounded per-command cost, not a hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central `checkpoint.Open` read path for resume, explain, attach, and list; behavior changes are intentional for migration but any routing bug could surface as missing checkpoints.
> 
> **Overview**
> **Checkpoint reads no longer depend on whichever git backend is configured as primary.** `checkpoint.Open` always exposes a `kindRoutingStore` around the write fanout (primary + mirrors) plus dedicated git-branch and git-refs read stores, built via `buildKindReadStores` (reusing the primary where it matches).
> 
> **Routing behavior:** ULID IDs are read only from git-refs; legacy hex IDs follow the active primary (branch-only under git-branch, refs then branch fallback under git-refs). `List` merges both backends; session reads and `GetCheckpointAuthor` use the same order; **writes** still go only through the configured primary and mirrors.
> 
> Adds `routing_store.go` with `firstResolved` fallback semantics, unit tests for migration/coexistence cases, updates `open_config_test.go` expectations, and documents read routing in `sessions-and-checkpoints.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a1f5fa174a74af3abde658cc6431d6dc653291b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
