### PR TITLE
git-refs pre-push: show push progress instead of a silent stall

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -190,9 +191,18 @@ func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pus
 	pushCtx, pushSpan := perf.Start(ctx, "push_checkpoint_refs")
 	defer pushSpan.End()
 
+	// Progress: pushing many refs over the network can take tens of seconds, so
+	// surface it (matching the v1 path's "[entire] Pushing ..." line) instead of
+	// leaving the user's git push apparently hung. Written to stderr, which git
+	// shows during the pre-push hook.
+	displayTarget := displayPushTarget(ps.pushTarget())
+	fmt.Fprintf(os.Stderr, "[entire] Pushing %d checkpoint ref(s) to %s...", len(existing), displayTarget)
+	stop := startProgressDots(os.Stderr)
+
 	// Fast path: push all refs in one round-trip (fast-forward-only). If every
 	// ref was up to date or fast-forwarded, we're done.
 	if err := batchPushRefs(pushCtx, ps.pushTarget(), existing); err == nil {
+		stop(" done")
 		if removeErr := queue.Remove(existing); removeErr != nil {
 			logging.Warn(ctx, "git-refs pre-push: clear pushed refs from queue failed",
 				slog.String("error", removeErr.Error()))
@@ -200,12 +210,15 @@ func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pus
 		cleanupPushedShadowBranches(ctx)
 		return nil
 	}
+	stop("")
 
 	// At least one ref was rejected — typically a non-fast-forward divergence
 	// (the same checkpoint re-written on another machine). Retry per ref with
 	// fetch+replay recovery, and remove from the queue only the refs that land
 	// (a genuine cherry-pick conflict leaves that ref queued for a later push,
 	// never force-overwriting the remote).
+	fmt.Fprintf(os.Stderr, "[entire] Some checkpoint refs diverged; syncing %d ref(s) individually...", len(existing))
+	stop = startProgressDots(os.Stderr)
 	pushed := make([]plumbing.ReferenceName, 0, len(existing))
 	for _, ref := range existing {
 		if err := pushCheckpointRefWithRecovery(pushCtx, ps.pushTarget(), ref); err != nil {
@@ -215,6 +228,7 @@ func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pus
 		}
 		pushed = append(pushed, ref)
 	}
+	stop(fmt.Sprintf(" pushed %d of %d", len(pushed), len(existing)))
 	if err := queue.Remove(pushed); err != nil {
 		logging.Warn(ctx, "git-refs pre-push: clear pushed refs from queue failed",
 			slog.String("error", err.Error()))


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/756
<!-- entire-trail-link-end -->

## What

The git-refs pre-push path pushed the queued per-checkpoint refs via `batchPushRefs` with **no output**. Pushing a large backlog (e.g. after a bulk import/migration) looked like `git push` had hung for 30+ seconds, while git itself only reported `Everything up-to-date` for the branch.

## Change

Mirror the v1-branch path's existing progress line in `prePushCheckpointRefs`:

```
[entire] Pushing 381 checkpoint ref(s) to origin......... done
```

- Uses the same `startProgressDots` ticker the v1 path (`doPushRef`) already uses, written to stderr (which git surfaces during the pre-push hook).
- The fast batch path prints `... done`; if some refs need the per-ref fetch+replay recovery, that path gets its own line ending in `pushed X of N`.
- No behavior change to the push itself — purely user-facing progress.

## Why it's safe / scoped

- 14 lines, one file (`manual_commit_push.go`); the git-refs push machinery it wraps is already on main.
- Matches the established v1 progress pattern exactly (same helper, same unconditional-to-stderr behavior).
- `mise run lint` clean; strategy suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing stderr output only; no changes to push, queue, or recovery behavior.
> 
> **Overview**
> **Adds user-visible progress** to the git-refs pre-push path in `prePushCheckpointRefs`, which previously pushed queued checkpoint refs with no output during long batch operations.
> 
> Before the batch fast-forward push, it prints `[entire] Pushing N checkpoint ref(s) to <target>...` on **stderr** and runs the same **`startProgressDots`** helper the v1 `doPushRef` path already uses, finishing with ` done` on success. If batch push fails and the code falls back to per-ref fetch+replay recovery, it prints a second line and ends with `pushed X of N`.
> 
> Push behavior, queue handling, and recovery logic are unchanged—**display only** (`fmt` import added for this).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b3f756ffc59f63534c513b10850345cd21b5ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->