### PR TITLE
feat(ticket): entire ticket — link external tickets to branches, checkpoints & reviews

### DIFF
--- a/api/checkpoint/metadata.go
+++ b/api/checkpoint/metadata.go
@@ -165,6 +165,10 @@ type WriteOptions struct {
 	// (e.g. via session.Kind.IsInvestigate) because checkpoint can't import
 	// session — the session package imports checkpoint, creating a cycle.
 	HasInvestigation bool
+
+	// Ticket is the external tracker ticket linked to the branch at condense
+	// time, captured for durable provenance. Nil when nothing is linked.
+	Ticket *TicketRef
 }
 
 // UpdateOptions contains options for updating an existing persistent checkpoint.
@@ -382,6 +386,11 @@ type Metadata struct {
 	// InvestigateTopic is the human-readable topic the investigation was
 	// asked to investigate. Only set when Kind is an investigate kind.
 	InvestigateTopic string `json:"investigate_topic,omitempty"`
+
+	// Ticket is the external tracker ticket (Linear, …) linked to this branch
+	// when the checkpoint was condensed — durable provenance of the intent the
+	// work was grounded in. Omitted when no ticket was linked.
+	Ticket *TicketRef `json:"ticket,omitempty"`
 }
 
 // GetTranscriptStart returns the transcript line offset at which this checkpoint's data begins.
@@ -404,6 +413,21 @@ func (m Metadata) GetCompactTranscriptStart() (offset int, ok bool) {
 		return 0, false
 	}
 	return *m.CompactTranscriptStart, true
+}
+
+// TicketRef is a snapshot of the external tracker ticket linked to a branch when
+// a checkpoint was condensed. It is captured for durable provenance so the
+// checkpoint history carries the intent the work was grounded in. Kept as plain
+// data (no dependency on the ticket package) so api/checkpoint stays a leaf; the
+// strategy layer maps ticket.Link → TicketRef at condense time.
+type TicketRef struct {
+	Platform  string `json:"platform,omitempty"`
+	ID        string `json:"id,omitempty"`
+	Title     string `json:"title,omitempty"`
+	State     string `json:"state,omitempty"`
+	URL       string `json:"url,omitempty"`
+	Digest    string `json:"digest,omitempty"`
+	FetchedAt string `json:"fetched_at,omitempty"`
 }
 
 // SessionFilePaths contains the absolute paths to session files from the git tree root.

--- a/cmd/entire/cli/checkpoint/aliases.go
+++ b/cmd/entire/cli/checkpoint/aliases.go
@@ -27,6 +27,7 @@ type (
 	LearningsSummary = apicheckpoint.LearningsSummary
 	CodeLearning     = apicheckpoint.CodeLearning
 	Attribution      = apicheckpoint.Attribution
+	TicketRef        = apicheckpoint.TicketRef
 
 	// Operation option types.
 	WriteOptions               = apicheckpoint.WriteOptions

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -736,6 +736,7 @@ func (s *treeWriter) writeSessionToSubdirectory(ctx context.Context, opts WriteO
 		ReviewPrompt:                opts.ReviewPrompt,
 		InvestigateRunID:            opts.InvestigateRunID,
 		InvestigateTopic:            opts.InvestigateTopic,
+		Ticket:                      opts.Ticket,
 	}
 
 	metadataJSON, err := jsonutil.MarshalIndentWithNewline(sessionMetadata, "", "  ")

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1792,6 +1792,17 @@ func formatCheckpointHeader(
 		writeRow("author", fmt.Sprintf("%s <%s>", author.Name, author.Email))
 	}
 
+	// The linked ticket frozen at condense time — the intent this work was
+	// grounded in. Shown when the branch had a ticket linked.
+	if t := meta.Ticket; t != nil {
+		writeRow("ticket", formatTicketRefLine(t))
+		if t.URL != "" {
+			// Align the URL under the value column (11-space indent), same as
+			// the multi-commit continuation lines below.
+			fmt.Fprintf(&sb, "           %s\n", t.URL)
+		}
+	}
+
 	tokenUsage := meta.TokenUsage
 	if tokenUsage == nil && summary != nil {
 		tokenUsage = summary.TokenUsage

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -351,6 +351,10 @@ type checkpointSessionJSON struct {
 	InvestigateRunID string `json:"investigate_run_id,omitempty"`
 	InvestigateTopic string `json:"investigate_topic,omitempty"`
 
+	// Ticket is the external tracker ticket frozen into this session's
+	// checkpoint at condense time. Omitted when nothing was linked.
+	Ticket *checkpoint.TicketRef `json:"ticket,omitempty"`
+
 	// Error is set when this session's metadata could not be read. The Index
 	// field remains valid; all other content fields are zero. Consumers can
 	// detect this by checking for a non-empty Error.
@@ -484,6 +488,7 @@ func sessionMetadataToJSON(idx int, meta *checkpoint.Metadata) checkpointSession
 		FilesTouched:     meta.FilesTouched,
 		InvestigateRunID: meta.InvestigateRunID,
 		InvestigateTopic: meta.InvestigateTopic,
+		Ticket:           meta.Ticket,
 	}
 	if !meta.CreatedAt.IsZero() {
 		ts := meta.CreatedAt

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -736,6 +736,47 @@ func TestSessionMetadataToJSON_CopiesInvestigateFields(t *testing.T) {
 	require.Equal(t, "topic from metadata.json", got.InvestigateTopic)
 }
 
+func TestSessionMetadataToJSON_CopiesTicket(t *testing.T) {
+	t.Parallel()
+
+	meta := &checkpoint.Metadata{
+		SessionID: "ticketed-session",
+		Ticket: &checkpoint.TicketRef{
+			Platform: "linear",
+			ID:       "LIN-123",
+			Title:    "Fix login redirect loop",
+			State:    "in_progress",
+			URL:      "https://linear.app/acme/issue/LIN-123",
+		},
+	}
+
+	got := sessionMetadataToJSON(0, meta)
+	require.NotNil(t, got.Ticket)
+	require.Equal(t, "LIN-123", got.Ticket.ID)
+	require.Equal(t, "linear", got.Ticket.Platform)
+
+	// The ticket key serializes under "ticket" with its snapshot fields.
+	raw, err := json.Marshal(got)
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	ticketField, ok := decoded["ticket"].(map[string]any)
+	require.True(t, ok, "expected a ticket object in JSON, got: %s", raw)
+	require.Equal(t, "Fix login redirect loop", ticketField["title"])
+	require.Equal(t, "in_progress", ticketField["state"])
+}
+
+func TestSessionMetadataToJSON_NoTicketStaysClean(t *testing.T) {
+	t.Parallel()
+
+	got := sessionMetadataToJSON(0, &checkpoint.Metadata{SessionID: "untracked"})
+	require.Nil(t, got.Ticket)
+
+	raw, err := json.Marshal(got)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), `"ticket"`, "ticket key must be omitted when nil")
+}
+
 // TestSessionMetadataToJSON_FullSummary pins that the export carries the whole
 // persisted summary — friction, open_items, and categorized learnings — not
 // just intent/outcome. The prose view already renders these; --json previously

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -2903,6 +2903,53 @@ func TestFormatCheckpointHeader_FullMetadataPlain(t *testing.T) {
 	}
 }
 
+func TestFormatCheckpointHeader_WithTicket(t *testing.T) {
+	t.Parallel()
+
+	cpID := id.MustCheckpointID("a3b2c4d5e6f7")
+	meta := checkpoint.Metadata{
+		SessionID: "s",
+		CreatedAt: time.Date(2026, 4, 29, 14, 22, 8, 0, time.UTC),
+		Ticket: &checkpoint.TicketRef{
+			Platform: "linear",
+			ID:       "LIN-123",
+			Title:    "Fix login redirect loop",
+			State:    "in_progress",
+			URL:      "https://linear.app/acme/issue/LIN-123",
+		},
+	}
+	styles := statusStyles{colorEnabled: false, width: 80}
+
+	got := formatCheckpointHeader(nil, meta, cpID, nil, checkpoint.Author{}, styles)
+
+	wantLines := []string{
+		"  ticket   LIN-123 — Fix login redirect loop (in progress)",
+		"           https://linear.app/acme/issue/LIN-123",
+	}
+	for _, line := range wantLines {
+		if !strings.Contains(got, line) {
+			t.Errorf("expected line %q in header, got:\n%s", line, got)
+		}
+	}
+}
+
+func TestFormatCheckpointHeader_NoTicket(t *testing.T) {
+	t.Parallel()
+
+	cpID := id.MustCheckpointID("a3b2c4d5e6f7")
+	meta := checkpoint.Metadata{
+		SessionID: "s",
+		CreatedAt: time.Date(2026, 4, 29, 14, 22, 8, 0, time.UTC),
+	}
+	styles := statusStyles{colorEnabled: false, width: 60}
+
+	got := formatCheckpointHeader(nil, meta, cpID, nil, checkpoint.Author{}, styles)
+
+	if strings.Contains(got, "  ticket") {
+		t.Errorf("did not expect ticket row when Ticket nil, got:\n%s", got)
+	}
+}
+
 func TestFormatCheckpointHeader_NoAuthor(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/integration_test/manual_commit_workflow_test.go
+++ b/cmd/entire/cli/integration_test/manual_commit_workflow_test.go
@@ -704,6 +704,61 @@ func TestShadow_TranscriptCondensation(t *testing.T) {
 	}
 }
 
+// TestShadow_TicketProvenance verifies that a ticket linked to the branch is
+// captured into the committed checkpoint metadata — durable provenance of the
+// intent on entire/checkpoints/v1.
+func TestShadow_TicketProvenance(t *testing.T) {
+	t.Parallel()
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	env.InitRepo()
+	env.WriteFile("README.md", "# Test Repository")
+	env.GitAdd("README.md")
+	env.GitCommit("Initial commit")
+	env.GitCheckoutNewBranch("feature/ticketed")
+	env.InitEntire()
+
+	// Configure a tracker and link a ticket to this branch. Neither command
+	// hits the network; the link + snapshot persist in the git common dir.
+	env.RunCLI("ticket", "setup", "--platform", "linear", "--team", "MOH", "--token", "test-token")
+	env.RunCLI("ticket", "link", "MOH-57")
+
+	// Run a session that produces a checkpoint.
+	session := env.NewSession()
+	if err := env.SimulateUserPromptSubmitWithPrompt(session.ID, "Fix the greeting trim bug"); err != nil {
+		t.Fatalf("SimulateUserPromptSubmitWithPrompt failed: %v", err)
+	}
+	content := "package main\n\nfunc main() { println(\"hi\") }\n"
+	env.WriteFile("main.go", content)
+	session.CreateTranscript("Fix the greeting trim bug", []FileChange{{Path: "main.go", Content: content}})
+	if err := env.SimulateStop(session.ID, session.TranscriptPath); err != nil {
+		t.Fatalf("SimulateStop failed: %v", err)
+	}
+
+	// Commit triggers condensation, which captures the linked ticket.
+	env.GitCommitWithShadowHooks("Add main.go", "main.go")
+
+	checkpointID := env.GetLatestCheckpointID()
+	sessionMetadataPath := SessionFilePath(checkpointID, paths.MetadataFileName)
+	metadataContent, found := env.ReadFileFromBranch(paths.MetadataBranchName, sessionMetadataPath)
+	if !found {
+		t.Fatal("session metadata.json should be readable")
+	}
+	var md checkpoint.Metadata
+	if err := json.Unmarshal([]byte(metadataContent), &md); err != nil {
+		t.Fatalf("failed to parse session metadata.json: %v", err)
+	}
+	if md.Ticket == nil {
+		t.Fatal("expected committed metadata to carry the linked ticket, got nil")
+	}
+	if md.Ticket.Platform != "linear" || md.Ticket.ID != "MOH-57" {
+		t.Errorf("ticket = %+v, want platform=linear id=MOH-57", md.Ticket)
+	} else {
+		t.Logf("✓ ticket captured into checkpoint provenance: %s %s", md.Ticket.Platform, md.Ticket.ID)
+	}
+}
+
 // TestShadow_FullTranscriptContext verifies that each checkpoint includes
 // only the prompts from its checkpoint portion, not the entire session.
 //

--- a/cmd/entire/cli/review_context.go
+++ b/cmd/entire/cli/review_context.go
@@ -18,6 +18,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
+	"github.com/entireio/cli/cmd/entire/cli/ticket"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 )
 
@@ -33,9 +34,55 @@ type reviewContextSessionMetadataReader interface {
 }
 
 func reviewCheckpointContext(ctx context.Context, worktreeRoot string, scopeBaseRef string) string {
+	ticketIntent := reviewTicketContext(ctx)
 	committed := reviewCommittedCheckpointContext(ctx, worktreeRoot, scopeBaseRef)
 	inProgress := reviewSessionContextForCurrentHead(ctx, worktreeRoot)
-	return joinReviewContextSections(committed, inProgress)
+	// Ticket first: it is the original intent the reviewer should ground the
+	// diff against, ahead of the checkpoint/session narrative of how it got done.
+	return joinReviewContextSections(ticketIntent, committed, inProgress)
+}
+
+// reviewTicketContext renders the branch's linked ticket as the reviewer's
+// grounding intent, e.g.
+//
+//	Linked ticket (original intent the change should satisfy):
+//	- LIN-123 (in progress): Fix login redirect loop
+//	  https://linear.app/acme/issue/LIN-123
+//
+// Best-effort and local only: no link (or any lookup error) yields an empty
+// section, which ComposeReviewPrompt skips.
+func reviewTicketContext(ctx context.Context) string {
+	link, ok, err := ticket.LinkForBranch(ctx, "")
+	if err != nil || !ok {
+		return ""
+	}
+	label := link.ID
+	if label == "" {
+		label = link.Platform
+	}
+	var state, title, url string
+	if link.Snapshot != nil {
+		state = formatTicketState(link.Snapshot.State)
+		title = link.Snapshot.Title
+		url = link.Snapshot.URL
+	}
+
+	var b strings.Builder
+	b.WriteString("Linked ticket (original intent the change should satisfy):\n")
+	b.WriteString("- ")
+	b.WriteString(label)
+	if state != "" {
+		fmt.Fprintf(&b, " (%s)", state)
+	}
+	if title != "" {
+		b.WriteString(": ")
+		b.WriteString(title)
+	}
+	if url != "" {
+		b.WriteString("\n  ")
+		b.WriteString(url)
+	}
+	return b.String()
 }
 
 // joinReviewContextSections concatenates non-empty review-context sections

--- a/cmd/entire/cli/review_context_test.go
+++ b/cmd/entire/cli/review_context_test.go
@@ -620,3 +620,75 @@ func writeReviewContextSessionPrompt(t *testing.T, repoRoot, sessionID, content 
 		t.Fatalf("write %s: %v", path, err)
 	}
 }
+
+// TestReviewTicketContext_RendersLinkedTicket seeds a branch→ticket link and
+// asserts reviewTicketContext surfaces it as the reviewer's grounding intent.
+// Uses t.Chdir (not parallel) because the ticket link store resolves the git
+// common dir from the current working directory.
+func TestReviewTicketContext_RendersLinkedTicket(t *testing.T) {
+	repo := t.TempDir()
+	testutil.InitRepo(t, repo)
+	testutil.WriteFile(t, repo, "f.txt", "init")
+	testutil.GitAdd(t, repo, "f.txt")
+	testutil.GitCommit(t, repo, "init")
+
+	// Resolve the current branch so we seed the link under the right key.
+	branchOut, err := exec.CommandContext(context.Background(), "git", "-C", repo, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("resolve branch: %v", err)
+	}
+	branch := strings.TrimSpace(string(branchOut))
+
+	// Seed the link store the same way the ticket package persists it.
+	linksDir := filepath.Join(repo, ".git", "entire-tickets")
+	if err := os.MkdirAll(linksDir, 0o755); err != nil {
+		t.Fatalf("mkdir links dir: %v", err)
+	}
+	links := map[string]any{
+		branch: map[string]any{
+			"platform": "linear",
+			"id":       "LIN-123",
+			"snapshot": map[string]any{
+				"title": "Fix login redirect loop",
+				"state": "in_progress",
+				"url":   "https://linear.app/acme/issue/LIN-123",
+			},
+		},
+	}
+	raw, err := json.Marshal(links)
+	if err != nil {
+		t.Fatalf("marshal links: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(linksDir, "links.json"), raw, 0o644); err != nil {
+		t.Fatalf("write links.json: %v", err)
+	}
+
+	t.Chdir(repo)
+
+	got := reviewTicketContext(context.Background())
+	for _, want := range []string{
+		"Linked ticket (original intent the change should satisfy):",
+		"LIN-123 (in progress): Fix login redirect loop",
+		"https://linear.app/acme/issue/LIN-123",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in ticket context, got:\n%s", want, got)
+		}
+	}
+}
+
+// TestReviewTicketContext_NoLinkIsEmpty confirms the section is omitted when the
+// branch has no linked ticket.
+func TestReviewTicketContext_NoLinkIsEmpty(t *testing.T) {
+	repo := t.TempDir()
+	testutil.InitRepo(t, repo)
+	testutil.WriteFile(t, repo, "f.txt", "init")
+	testutil.GitAdd(t, repo, "f.txt")
+	testutil.GitCommit(t, repo, "init")
+
+	t.Chdir(repo)
+
+	if got := reviewTicketContext(context.Background()); got != "" {
+		t.Errorf("expected empty ticket context with no link, got:\n%s", got)
+	}
+}

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -100,7 +100,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newProjectCmd())                                // hidden during maturation; control-plane project management
 	cmd.AddCommand(newRepoCmd())                                   // hidden during maturation; control-plane repo lifecycle
 	cmd.AddCommand(newGrantCmd())                                  // hidden during maturation; control-plane access grants
-	cmd.AddCommand(ticket.NewCommand())                            // hidden during maturation; link work to external tickets
+	cmd.AddCommand(ticket.NewCommand(buildTicketDeps()))           // hidden during maturation; link work to external tickets
 	cmd.AddCommand(newCleanCmd())
 	cmd.AddCommand(newSetupCmd()) // 'configure' — non-agent settings; agent CRUD lives under 'agent'
 	cmd.AddCommand(newEnableCmd())

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -9,6 +9,7 @@ import (
 	cliReview "github.com/entireio/cli/cmd/entire/cli/review"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
+	"github.com/entireio/cli/cmd/entire/cli/ticket"
 	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/spf13/cobra"
@@ -99,6 +100,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newProjectCmd())                                // hidden during maturation; control-plane project management
 	cmd.AddCommand(newRepoCmd())                                   // hidden during maturation; control-plane repo lifecycle
 	cmd.AddCommand(newGrantCmd())                                  // hidden during maturation; control-plane access grants
+	cmd.AddCommand(ticket.NewCommand())                            // hidden during maturation; link work to external tickets
 	cmd.AddCommand(newCleanCmd())
 	cmd.AddCommand(newSetupCmd()) // 'configure' — non-agent settings; agent CRUD lives under 'agent'
 	cmd.AddCommand(newEnableCmd())

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -21,6 +21,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
+	"github.com/entireio/cli/cmd/entire/cli/ticket"
 	"github.com/spf13/cobra"
 )
 
@@ -526,16 +527,35 @@ func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, m
 
 	status := sessionPhaseLabel(state)
 
+	// Resolve the branch's linked ticket (best-effort, local only) so the detail
+	// view shows the intent this session was grounded in. Uses the session's
+	// recorded branch, so it works for ended sessions inspected after the fact.
+	link := sessionTicketLink(ctx, state.Branch)
+
 	switch mode {
 	case sessionOutputTranscript:
 		return writeSessionTranscript(ctx, cmd, state)
 	case sessionOutputJSON:
-		return writeSessionInfoJSON(cmd.OutOrStdout(), state, status)
+		return writeSessionInfoJSON(cmd.OutOrStdout(), state, status, link)
 	case sessionOutputText:
-		return writeSessionInfoText(cmd.OutOrStdout(), state, status)
+		return writeSessionInfoText(cmd.OutOrStdout(), state, status, link)
 	default:
 		return fmt.Errorf("unknown session output mode: %d", mode)
 	}
+}
+
+// sessionTicketLink resolves the ticket linked to branch, returning nil when the
+// branch is empty, nothing is linked, or the lookup fails. Never blocks the
+// session view on ticket state.
+func sessionTicketLink(ctx context.Context, branch string) *ticket.Link {
+	if branch == "" {
+		return nil
+	}
+	link, ok, err := ticket.LinkForBranch(ctx, branch)
+	if err != nil || !ok {
+		return nil
+	}
+	return &link
 }
 
 // writeSessionTranscript streams the live raw agent transcript for a session
@@ -582,6 +602,8 @@ type sessionInfoJSON struct {
 	Tokens         *tokenInfoJSON `json:"tokens,omitempty"`
 	LastPrompt     string         `json:"last_prompt,omitempty"`
 	FilesTouched   []string       `json:"files_touched,omitempty"`
+	// Ticket is the tracker ticket linked to this session's branch, if any.
+	Ticket *ticketBriefJSON `json:"ticket,omitempty"`
 }
 
 type tokenInfoJSON struct {
@@ -628,16 +650,20 @@ func buildSessionInfoJSON(state *strategy.SessionState, status string) sessionIn
 	return info
 }
 
-func writeSessionInfoJSON(w io.Writer, state *strategy.SessionState, status string) error {
+func writeSessionInfoJSON(w io.Writer, state *strategy.SessionState, status string, link *ticket.Link) error {
+	info := buildSessionInfoJSON(state, status)
+	if link != nil {
+		info.Ticket = ticketBriefFromLink(*link)
+	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(buildSessionInfoJSON(state, status)); err != nil {
+	if err := enc.Encode(info); err != nil {
 		return fmt.Errorf("failed to encode session info: %w", err)
 	}
 	return nil
 }
 
-func writeSessionInfoText(w io.Writer, state *strategy.SessionState, status string) error {
+func writeSessionInfoText(w io.Writer, state *strategy.SessionState, status string, link *ticket.Link) error {
 	fmt.Fprintf(w, "Session %s\n\n", state.SessionID)
 
 	agentLabel := string(state.AgentType)
@@ -676,6 +702,13 @@ func writeSessionInfoText(w io.Writer, state *strategy.SessionState, status stri
 
 	if state.LastCheckpointID != "" {
 		fmt.Fprintf(w, "Checkpoint:  %s\n", state.LastCheckpointID)
+	}
+
+	if link != nil {
+		fmt.Fprintf(w, "Ticket:      %s\n", formatTicketLinkLine(*link))
+		if link.Snapshot != nil && link.Snapshot.URL != "" {
+			fmt.Fprintf(w, "             %s\n", link.Snapshot.URL)
+		}
 	}
 
 	if t := totalTokens(state.TokenUsage); t > 0 {

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/cmd/entire/cli/ticket"
 	"github.com/entireio/cli/redact"
 )
 
@@ -3301,5 +3302,71 @@ func TestSessionPhaseLabel(t *testing.T) {
 				t.Errorf("sessionPhaseLabel() = %q, want %q", got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestWriteSessionInfoText_WithTicket(t *testing.T) {
+	t.Parallel()
+
+	state := &strategy.SessionState{SessionID: "s1", Branch: "feat/login", StartedAt: time.Now()}
+	link := &ticket.Link{
+		Platform: "linear",
+		ID:       "LIN-123",
+		Snapshot: &ticket.Snapshot{
+			Title: "Fix login redirect loop",
+			State: "in_progress",
+			URL:   "https://linear.app/acme/issue/LIN-123",
+		},
+	}
+
+	var out bytes.Buffer
+	if err := writeSessionInfoText(&out, state, "active", link); err != nil {
+		t.Fatalf("writeSessionInfoText: %v", err)
+	}
+	for _, want := range []string{
+		"Ticket:      LIN-123 — Fix login redirect loop (in progress)",
+		"             https://linear.app/acme/issue/LIN-123",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestWriteSessionInfoText_NoTicket(t *testing.T) {
+	t.Parallel()
+
+	state := &strategy.SessionState{SessionID: "s1", Branch: "feat/login", StartedAt: time.Now()}
+
+	var out bytes.Buffer
+	if err := writeSessionInfoText(&out, state, "active", nil); err != nil {
+		t.Fatalf("writeSessionInfoText: %v", err)
+	}
+	if strings.Contains(out.String(), "Ticket:") {
+		t.Errorf("did not expect a Ticket row with nil link, got:\n%s", out.String())
+	}
+}
+
+func TestWriteSessionInfoJSON_WithTicket(t *testing.T) {
+	t.Parallel()
+
+	state := &strategy.SessionState{SessionID: "s1", Branch: "feat/login", StartedAt: time.Now()}
+	link := &ticket.Link{Platform: "linear", ID: "LIN-123", Snapshot: &ticket.Snapshot{Title: "Fix login", State: "in_progress"}}
+
+	var out bytes.Buffer
+	if err := writeSessionInfoJSON(&out, state, "active", link); err != nil {
+		t.Fatalf("writeSessionInfoJSON: %v", err)
+	}
+	var decoded struct {
+		Ticket *ticketBriefJSON `json:"ticket"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Ticket == nil {
+		t.Fatalf("expected ticket in JSON, got:\n%s", out.String())
+	}
+	if decoded.Ticket.ID != "LIN-123" || decoded.Ticket.Title != "Fix login" {
+		t.Errorf("unexpected ticket: %+v", decoded.Ticket)
 	}
 }

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -115,6 +115,11 @@ type EntireSettings struct {
 	// `entire investigate` triggers the first-run picker.
 	Investigate *InvestigateConfig `json:"investigate,omitempty"`
 
+	// Ticket holds configuration for `entire ticket` — the active ticket
+	// platform and team/workspace key. The API credential is stored in the
+	// OS credential store, never here.
+	Ticket *TicketConfig `json:"ticket,omitempty"`
+
 	// CommitLinking controls how commits are linked to agent sessions.
 	// "always" = auto-link without prompting, "prompt" = ask on each commit.
 	// Defaults to "prompt" (preserves existing user behavior).
@@ -426,6 +431,34 @@ func (s *EntireSettings) InvestigateConfig() *InvestigateConfig {
 		return nil
 	}
 	return s.Investigate
+}
+
+// TicketConfig holds the non-secret configuration for `entire ticket`: the
+// selected ticket platform and the team/workspace key on it. The API
+// credential is stored in the OS credential store, never in settings.
+type TicketConfig struct {
+	// Platform is the ticket-platform identifier, e.g. "linear".
+	Platform string `json:"platform,omitempty"`
+
+	// Team is the team, project, or workspace key on the platform.
+	Team string `json:"team,omitempty"`
+}
+
+// IsZero reports whether the config is effectively unset.
+func (c *TicketConfig) IsZero() bool {
+	if c == nil {
+		return true
+	}
+	return c.Platform == "" && c.Team == ""
+}
+
+// TicketConfig returns the configured ticket config. Returns nil when no
+// configuration is present; callers should check IsZero (or guard for nil).
+func (s *EntireSettings) TicketConfig() *TicketConfig {
+	if s == nil {
+		return nil
+	}
+	return s.Ticket
 }
 
 // Load loads the Entire settings from .entire/settings.json, then applies

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -20,6 +20,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
+	"github.com/entireio/cli/cmd/entire/cli/ticket"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 
 	"github.com/spf13/cobra"
@@ -180,11 +181,22 @@ func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statu
 	b.WriteString(displayName)
 
 	// Resolve branch from repo root
+	var branch string
 	if repoRoot, err := paths.WorktreeRoot(ctx); err == nil {
-		if branch := resolveWorktreeBranch(ctx, repoRoot); branch != "" {
+		if branch = resolveWorktreeBranch(ctx, repoRoot); branch != "" {
 			b.WriteString(sty.render(sty.dim, " · "))
 			b.WriteString("branch ")
 			b.WriteString(sty.render(sty.cyan, branch))
+		}
+	}
+
+	// Show the linked ticket for this branch, if any. Best-effort and local
+	// only (no network); a missing link or lookup error simply omits the line.
+	if branch != "" {
+		if link, ok, err := ticket.LinkForBranch(ctx, branch); err == nil && ok {
+			b.WriteString("\n")
+			b.WriteString(sty.render(sty.dim, "  Ticket · "))
+			b.WriteString(formatTicketLinkLine(link))
 		}
 	}
 
@@ -599,7 +611,9 @@ type statusJSON struct {
 	// `entire status --json` instead of the human footer. Set only on the
 	// success path (mirrors writeAgentHelpHint, which only renders when set up).
 	AgentHelp string `json:"agent_help,omitempty"`
-	Error     string `json:"error,omitempty"`
+	// Ticket is the tracker ticket linked to the current branch, if any.
+	Ticket *ticketBriefJSON `json:"ticket,omitempty"`
+	Error  string           `json:"error,omitempty"`
 }
 
 type sessionBriefJSON struct {
@@ -700,6 +714,15 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 				sort.Slice(result.ActiveSessions, func(i, j int) bool {
 					return result.ActiveSessions[i].Agent < result.ActiveSessions[j].Agent
 				})
+			}
+		}
+	}
+
+	// Linked ticket for the current branch (best-effort, local only).
+	if repoRoot, err := paths.WorktreeRoot(ctx); err == nil {
+		if branch := resolveWorktreeBranch(ctx, repoRoot); branch != "" {
+			if link, ok, err := ticket.LinkForBranch(ctx, branch); err == nil && ok {
+				result.Ticket = ticketBriefFromLink(link)
 			}
 		}
 	}

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -297,6 +297,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		HasInvestigation:            state.Kind.IsInvestigate(),
 		InvestigateRunID:            state.InvestigateRunID,
 		InvestigateTopic:            state.InvestigateTopic,
+		Ticket:                      ticketRefForBranch(ctx, branchName),
 	}
 
 	writeV1Start := time.Now()

--- a/cmd/entire/cli/strategy/manual_commit_ticket.go
+++ b/cmd/entire/cli/strategy/manual_commit_ticket.go
@@ -1,0 +1,37 @@
+package strategy
+
+import (
+	"context"
+	"log/slog"
+
+	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/ticket"
+)
+
+// ticketRefForBranch captures the external tracker ticket linked to branch (if
+// any) as durable checkpoint provenance. It reads only the locally stored link
+// and snapshot (no network fetch), so it adds no latency to condensation.
+//
+// Best-effort: any error or missing link yields nil, so a checkpoint is never
+// blocked by ticket state. The strategy layer owns this ticket.Link → TicketRef
+// mapping so api/checkpoint stays free of a ticket-package dependency.
+func ticketRefForBranch(ctx context.Context, branch string) *cpkg.TicketRef {
+	link, ok, err := ticket.LinkForBranch(ctx, branch)
+	if err != nil || !ok {
+		return nil
+	}
+	ref := &cpkg.TicketRef{Platform: link.Platform, ID: link.ID}
+	if link.Snapshot != nil {
+		ref.Title = link.Snapshot.Title
+		ref.State = link.Snapshot.State
+		ref.URL = link.Snapshot.URL
+		ref.Digest = link.Snapshot.Digest
+		ref.FetchedAt = link.Snapshot.FetchedAt
+	}
+	logging.Debug(ctx, "ticket captured into checkpoint provenance",
+		slog.String("platform", ref.Platform),
+		slog.String("ticket", ref.ID),
+		slog.String("branch", branch))
+	return ref
+}

--- a/cmd/entire/cli/ticket/branch.go
+++ b/cmd/entire/cli/ticket/branch.go
@@ -1,0 +1,107 @@
+package ticket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"charm.land/huh/v2"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitexec"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/uiform"
+)
+
+// nonSlugChars matches runs of characters that are not lowercase-alphanumeric.
+var nonSlugChars = regexp.MustCompile(`[^a-z0-9]+`)
+
+// slugify lowercases s and collapses non-alphanumeric runs into single dashes.
+func slugify(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = nonSlugChars.ReplaceAllString(s, "-")
+	return strings.Trim(s, "-")
+}
+
+// defaultBranchName suggests a branch for a ticket: the platform's own
+// suggestion when available (Linear's issue.branchName), else a
+// "<gituser>/<ticket-id>-<title>" slug.
+func defaultBranchName(ctx context.Context, task *Task, link Link) string {
+	if task != nil && strings.TrimSpace(task.BranchName) != "" {
+		return task.BranchName
+	}
+	slug := slugify(link.ID)
+	if task != nil && task.Title != "" {
+		if titleSlug := slugify(task.Title); titleSlug != "" {
+			slug += "-" + titleSlug
+		}
+	}
+	if user := gitUserSlug(ctx); user != "" {
+		return user + "/" + slug
+	}
+	return slug
+}
+
+// gitUserSlug returns a slug of the git user.name's first token, or "".
+func gitUserSlug(ctx context.Context) string {
+	root, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return ""
+	}
+	out, err := gitexec.Run(ctx, root, "config", "user.name")
+	if err != nil {
+		return ""
+	}
+	name := strings.TrimSpace(out)
+	if i := strings.IndexAny(name, " \t"); i > 0 {
+		name = name[:i]
+	}
+	return slugify(name)
+}
+
+// promptBranchName asks for a branch name, pre-filled with def.
+func promptBranchName(ctx context.Context, def string) (string, error) {
+	name := def
+	form := uiform.New(huh.NewGroup(
+		huh.NewInput().
+			Title("Branch name").
+			Description("New branch for this ticket. Edit or accept the default.").
+			Value(&name),
+	))
+	if err := form.RunWithContext(ctx); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return "", errors.New("ticket start canceled")
+		}
+		return "", fmt.Errorf("branch name prompt: %w", err)
+	}
+	return strings.TrimSpace(name), nil
+}
+
+// createOrSwitchBranch switches to name, creating it if it does not exist.
+func createOrSwitchBranch(ctx context.Context, name string) error {
+	root, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve repo root: %w", err)
+	}
+	if branchExists(ctx, root, name) {
+		if _, err := gitexec.Run(ctx, root, "switch", name); err != nil {
+			return fmt.Errorf("switch to branch %s: %w", name, err)
+		}
+		logging.Debug(ctx, "ticket branch switched", slog.String("branch", name))
+		return nil
+	}
+	if _, err := gitexec.Run(ctx, root, "switch", "-c", name); err != nil {
+		return fmt.Errorf("create branch %s: %w", name, err)
+	}
+	logging.Debug(ctx, "ticket branch created", slog.String("branch", name))
+	return nil
+}
+
+// branchExists reports whether a local branch named name exists.
+func branchExists(ctx context.Context, root, name string) bool {
+	_, err := gitexec.Run(ctx, root, "show-ref", "--verify", "--quiet", "refs/heads/"+name)
+	return err == nil
+}

--- a/cmd/entire/cli/ticket/branch_test.go
+++ b/cmd/entire/cli/ticket/branch_test.go
@@ -1,0 +1,29 @@
+package ticket
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlugify(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "add-rate-limiting", slugify("Add Rate Limiting!"))
+	assert.Equal(t, "eng-142", slugify("ENG-142"))
+	assert.Empty(t, slugify("  --  "))
+}
+
+func TestDefaultBranchName_UsesProviderSuggestion(t *testing.T) {
+	t.Parallel()
+
+	// When the provider supplies a branch name, it is used verbatim (no git
+	// calls needed), so this is deterministic.
+	name := defaultBranchName(
+		context.Background(),
+		&Task{BranchName: "amy/eng-142-rate-limit"},
+		Link{ID: "ENG-142"},
+	)
+	assert.Equal(t, "amy/eng-142-rate-limit", name)
+}

--- a/cmd/entire/cli/ticket/cmd.go
+++ b/cmd/entire/cli/ticket/cmd.go
@@ -48,6 +48,8 @@ Linear or Jira, so agents and reviews carry the ticket as grounding context.`,
 	}
 
 	cmd.AddCommand(newSetupCmd())
+	cmd.AddCommand(newLinkCmd())
+	cmd.AddCommand(newUnlinkCmd())
 
 	return cmd
 }

--- a/cmd/entire/cli/ticket/cmd.go
+++ b/cmd/entire/cli/ticket/cmd.go
@@ -47,5 +47,7 @@ Linear or Jira, so agents and reviews carry the ticket as grounding context.`,
 		},
 	}
 
+	cmd.AddCommand(newSetupCmd())
+
 	return cmd
 }

--- a/cmd/entire/cli/ticket/cmd.go
+++ b/cmd/entire/cli/ticket/cmd.go
@@ -8,6 +8,7 @@
 package ticket
 
 import (
+	"context"
 	"errors"
 
 	"github.com/spf13/cobra"
@@ -16,9 +17,18 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
 
+// Deps collects runtime-injectable hooks NewCommand needs from the cli package
+// (wired by buildTicketDeps). Keeping them here avoids an import cycle between
+// this package and the per-agent packages.
+type Deps struct {
+	// LaunchFix launches a coding agent with the given prompt. Production wires
+	// this to agentlaunch.LaunchFixAgent.
+	LaunchFix func(ctx context.Context, agentName, prompt string) error
+}
+
 // NewCommand returns the `entire ticket` cobra group. It is hidden from
 // `entire help` while the feature matures; direct invocation still works.
-func NewCommand() *cobra.Command {
+func NewCommand(deps Deps) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ticket",
 		Short: "Link work to tickets on Linear, Jira, and other platforms",
@@ -50,6 +60,7 @@ Linear or Jira, so agents and reviews carry the ticket as grounding context.`,
 	cmd.AddCommand(newSetupCmd())
 	cmd.AddCommand(newLinkCmd())
 	cmd.AddCommand(newUnlinkCmd())
+	cmd.AddCommand(newStartCmd(deps))
 
 	return cmd
 }

--- a/cmd/entire/cli/ticket/cmd.go
+++ b/cmd/entire/cli/ticket/cmd.go
@@ -1,0 +1,51 @@
+// Package ticket implements `entire ticket`, the platform-agnostic surface for
+// linking work in a repository to tickets on external trackers such as Linear
+// and Jira.
+//
+// The command layer depends only on the canonical Task type and the Provider
+// interface; concrete trackers implement Provider in their own files so the
+// surface never depends on a specific platform.
+package ticket
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// NewCommand returns the `entire ticket` cobra group. It is hidden from
+// `entire help` while the feature matures; direct invocation still works.
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ticket",
+		Short: "Link work to tickets on Linear, Jira, and other platforms",
+		// Hidden from `entire help` while the feature is still maturing;
+		// directly invoking it still works.
+		Hidden: true,
+		Long: `Link work in this repository to tickets on an external tracker such as
+Linear or Jira, so agents and reviews carry the ticket as grounding context.`,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := paths.WorktreeRoot(cmd.Context()); err != nil {
+				return errors.New("not a git repository")
+			}
+			// Best-effort: route ticket-command debug logs to .entire/logs/
+			// (matches how other standalone commands initialize logging). A
+			// failure just means no file logging; the command still runs.
+			logging.Init(cmd.Context(), "") //nolint:errcheck,gosec // best-effort logging init
+			return nil
+		},
+		// Flush the buffered log on the way out. Hidden commands skip root's
+		// PersistentPostRun, so the group flushes its own logs.
+		PersistentPostRun: func(_ *cobra.Command, _ []string) {
+			logging.Close()
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+
+	return cmd
+}

--- a/cmd/entire/cli/ticket/cmd.go
+++ b/cmd/entire/cli/ticket/cmd.go
@@ -62,6 +62,7 @@ Linear or Jira, so agents and reviews carry the ticket as grounding context.`,
 	cmd.AddCommand(newLinkCmd())
 	cmd.AddCommand(newUnlinkCmd())
 	cmd.AddCommand(newStartCmd(deps))
+	cmd.AddCommand(newRevokeTokenCmd())
 
 	return cmd
 }

--- a/cmd/entire/cli/ticket/cmd.go
+++ b/cmd/entire/cli/ticket/cmd.go
@@ -58,6 +58,7 @@ Linear or Jira, so agents and reviews carry the ticket as grounding context.`,
 	}
 
 	cmd.AddCommand(newSetupCmd())
+	cmd.AddCommand(newStatusCmd())
 	cmd.AddCommand(newLinkCmd())
 	cmd.AddCommand(newUnlinkCmd())
 	cmd.AddCommand(newStartCmd(deps))

--- a/cmd/entire/cli/ticket/cmd_test.go
+++ b/cmd/entire/cli/ticket/cmd_test.go
@@ -1,0 +1,19 @@
+package ticket
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCommand_Shape(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewCommand(Deps{})
+	require.NotNil(t, cmd)
+	assert.Equal(t, "ticket", cmd.Use)
+	assert.True(t, cmd.Hidden, "ticket group is hidden while the feature matures")
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotNil(t, cmd.PersistentPreRunE, "group gates on a git repository")
+}

--- a/cmd/entire/cli/ticket/creds.go
+++ b/cmd/entire/cli/ticket/creds.go
@@ -1,0 +1,44 @@
+package ticket
+
+import (
+	"fmt"
+
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+// credUser is the fixed username slot for ticket-platform API credentials in
+// the token store; the platform is encoded in the service name.
+const credUser = "token"
+
+// credService returns the token-store service name for a platform's API
+// credential, e.g. "entire-ticket:linear".
+func credService(p Platform) string {
+	return "entire-ticket:" + string(p)
+}
+
+// SaveToken stores the API credential for the given platform in the OS
+// credential store (never in settings).
+func SaveToken(p Platform, token string) error {
+	if err := tokenstore.Set(credService(p), credUser, token); err != nil {
+		return fmt.Errorf("store %s credential: %w", p.DisplayName(), err)
+	}
+	return nil
+}
+
+// LoadToken returns the stored API credential for the platform, or an error
+// when none is present.
+func LoadToken(p Platform) (string, error) {
+	tok, err := tokenstore.Get(credService(p), credUser)
+	if err != nil {
+		return "", fmt.Errorf("read %s credential (run `entire ticket setup`): %w", p.DisplayName(), err)
+	}
+	return tok, nil
+}
+
+// DeleteToken removes the stored API credential for the platform.
+func DeleteToken(p Platform) error {
+	if err := tokenstore.Delete(credService(p), credUser); err != nil {
+		return fmt.Errorf("remove %s credential: %w", p.DisplayName(), err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/ticket/creds_test.go
+++ b/cmd/entire/cli/ticket/creds_test.go
@@ -1,0 +1,42 @@
+package ticket
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+func TestCredService(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "entire-ticket:linear", credService(PlatformLinear))
+}
+
+// TestSaveLoadToken_RoundTrip uses the file-backed token store (never the real
+// OS keychain) so it is hermetic and CI-safe. It cannot run in parallel because
+// UseFileBackendForTesting swaps the package-global backend.
+func TestSaveLoadToken_RoundTrip(t *testing.T) {
+	cleanup := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	defer cleanup()
+
+	require.NoError(t, SaveToken(PlatformLinear, "lin_api_test"))
+
+	got, err := LoadToken(PlatformLinear)
+	require.NoError(t, err)
+	assert.Equal(t, "lin_api_test", got)
+}
+
+func TestDeleteToken(t *testing.T) {
+	cleanup := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	defer cleanup()
+
+	require.NoError(t, SaveToken(PlatformLinear, "lin_api_test"))
+	require.NoError(t, DeleteToken(PlatformLinear))
+
+	_, err := LoadToken(PlatformLinear)
+	require.Error(t, err, "credential should be gone after DeleteToken")
+}

--- a/cmd/entire/cli/ticket/linear.go
+++ b/cmd/entire/cli/ticket/linear.go
@@ -1,0 +1,366 @@
+package ticket
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+)
+
+// linearAPIURL is the Linear GraphQL endpoint.
+const linearAPIURL = "https://api.linear.app/graphql"
+
+// issueIDPattern matches a Linear issue identifier such as "ENG-142", including
+// when embedded in a branch name like "amy/eng-142-title".
+var issueIDPattern = regexp.MustCompile(`([A-Za-z][A-Za-z0-9]*)-(\d+)`)
+
+// httpDoer is the subset of *http.Client the Linear provider needs; injectable
+// so tests can stub responses without network access.
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// linearProvider implements Provider against Linear's GraphQL API. The team is
+// the workspace team key (e.g. "ENG"), used when resolving workflow states.
+type linearProvider struct {
+	token string
+	team  string
+	url   string
+	http  httpDoer
+}
+
+// newLinearProvider builds a Linear provider with a real HTTP client.
+func newLinearProvider(token, team string) *linearProvider {
+	return &linearProvider{
+		token: token,
+		team:  team,
+		url:   linearAPIURL,
+		http:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Name implements Provider.
+func (p *linearProvider) Name() string { return string(PlatformLinear) }
+
+// ResolveFromBranch implements Provider, extracting a "TEAM-123" identifier
+// from a branch name (Linear's branch format embeds one).
+func (p *linearProvider) ResolveFromBranch(branch string) (string, bool) {
+	m := issueIDPattern.FindString(branch)
+	if m == "" {
+		return "", false
+	}
+	return strings.ToUpper(m), true
+}
+
+// Fetch implements Provider.
+func (p *linearProvider) Fetch(ctx context.Context, id string) (Task, error) {
+	start := time.Now()
+	iss, err := p.fetchIssue(ctx, id)
+	if err != nil {
+		logging.Debug(ctx, "ticket fetch failed",
+			slog.String("platform", p.Name()),
+			slog.String("ticket", id),
+			slog.String("error", err.Error()))
+		return Task{}, err
+	}
+	logging.Debug(ctx, "ticket fetched",
+		slog.String("platform", p.Name()),
+		slog.String("ticket", id),
+		slog.Duration("duration", time.Since(start)))
+
+	labels := make([]string, 0, len(iss.Labels.Nodes))
+	for _, l := range iss.Labels.Nodes {
+		labels = append(labels, l.Name)
+	}
+	comments := make([]Comment, 0, len(iss.Comments.Nodes))
+	for _, c := range iss.Comments.Nodes {
+		comments = append(comments, Comment{Author: c.User.Name, Body: c.Body})
+	}
+	return Task{
+		ID:         iss.Identifier,
+		Title:      iss.Title,
+		Intent:     iss.Description,
+		State:      normalizeLinearState(iss.State.Type),
+		URL:        iss.URL,
+		BranchName: iss.BranchName,
+		Labels:     labels,
+		Comments:   comments,
+	}, nil
+}
+
+// Comment implements Provider.
+func (p *linearProvider) Comment(ctx context.Context, id, body string) error {
+	iss, err := p.fetchIssue(ctx, id)
+	if err != nil {
+		return err
+	}
+	const mutation = `mutation($issueId: String!, $body: String!) {
+  commentCreate(input: {issueId: $issueId, body: $body}) { success }
+}`
+	var out struct {
+		CommentCreate struct {
+			Success bool `json:"success"`
+		} `json:"commentCreate"`
+	}
+	if err := p.do(ctx, mutation, map[string]any{"issueId": iss.ID, "body": body}, &out); err != nil {
+		return err
+	}
+	if !out.CommentCreate.Success {
+		return fmt.Errorf("linear did not accept the comment on %s", id)
+	}
+	return nil
+}
+
+// SetState implements Provider by resolving a workflow state on the issue's
+// team and updating the issue.
+func (p *linearProvider) SetState(ctx context.Context, id string, state State) error {
+	iss, err := p.fetchIssue(ctx, id)
+	if err != nil {
+		return err
+	}
+	teamKey, _, err := parseIssueID(id)
+	if err != nil {
+		return err
+	}
+	stateID, err := p.resolveWorkflowStateID(ctx, teamKey, state)
+	if err != nil {
+		return err
+	}
+	const mutation = `mutation($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: {stateId: $stateId}) { success }
+}`
+	var out struct {
+		IssueUpdate struct {
+			Success bool `json:"success"`
+		} `json:"issueUpdate"`
+	}
+	if err := p.do(ctx, mutation, map[string]any{"id": iss.ID, "stateId": stateID}, &out); err != nil {
+		return err
+	}
+	if !out.IssueUpdate.Success {
+		return fmt.Errorf("linear did not accept the state change on %s", id)
+	}
+	return nil
+}
+
+// linearIssue is the subset of a Linear issue this provider reads.
+type linearIssue struct {
+	ID          string `json:"id"`
+	Identifier  string `json:"identifier"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	BranchName  string `json:"branchName"`
+	State       struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	} `json:"state"`
+	Labels struct {
+		Nodes []struct {
+			Name string `json:"name"`
+		} `json:"nodes"`
+	} `json:"labels"`
+	Comments struct {
+		Nodes []struct {
+			Body string `json:"body"`
+			User struct {
+				Name string `json:"name"`
+			} `json:"user"`
+		} `json:"nodes"`
+	} `json:"comments"`
+}
+
+// fetchIssue resolves a "TEAM-123" identifier to a Linear issue.
+func (p *linearProvider) fetchIssue(ctx context.Context, id string) (linearIssue, error) {
+	teamKey, number, err := parseIssueID(id)
+	if err != nil {
+		return linearIssue{}, err
+	}
+	const query = `query($team: String!, $number: Float!) {
+  issues(filter: {team: {key: {eq: $team}}, number: {eq: $number}}, first: 1) {
+    nodes {
+      id identifier title description url branchName
+      state { name type }
+      labels { nodes { name } }
+      comments(first: 50) { nodes { body user { name } } }
+    }
+  }
+}`
+	var out struct {
+		Issues struct {
+			Nodes []linearIssue `json:"nodes"`
+		} `json:"issues"`
+	}
+	if err := p.do(ctx, query, map[string]any{"team": teamKey, "number": float64(number)}, &out); err != nil {
+		return linearIssue{}, err
+	}
+	if len(out.Issues.Nodes) == 0 {
+		return linearIssue{}, fmt.Errorf("linear issue %s not found", id)
+	}
+	return out.Issues.Nodes[0], nil
+}
+
+// resolveWorkflowStateID finds the workflow-state UUID on a team that best
+// matches the normalized target state: a name match first, then a type match.
+func (p *linearProvider) resolveWorkflowStateID(ctx context.Context, teamKey string, target State) (string, error) {
+	const query = `query($team: String!) {
+  workflowStates(filter: {team: {key: {eq: $team}}}, first: 50) {
+    nodes { id name type }
+  }
+}`
+	var out struct {
+		WorkflowStates struct {
+			Nodes []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+				Type string `json:"type"`
+			} `json:"nodes"`
+		} `json:"workflowStates"`
+	}
+	if err := p.do(ctx, query, map[string]any{"team": teamKey}, &out); err != nil {
+		return "", err
+	}
+
+	wantName := stateDisplayName(target)
+	for _, n := range out.WorkflowStates.Nodes {
+		if strings.EqualFold(n.Name, wantName) {
+			return n.ID, nil
+		}
+	}
+	wantType := stateLinearType(target)
+	for _, n := range out.WorkflowStates.Nodes {
+		if n.Type == wantType {
+			return n.ID, nil
+		}
+	}
+	return "", fmt.Errorf("no linear workflow state found for %q on team %s", target, teamKey)
+}
+
+// do executes a GraphQL request and unmarshals the "data" field into out.
+func (p *linearProvider) do(ctx context.Context, query string, vars map[string]any, out any) error {
+	payload, err := json.Marshal(map[string]any{"query": query, "variables": vars})
+	if err != nil {
+		return fmt.Errorf("encode linear request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build linear request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", p.token)
+
+	resp, err := p.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("linear request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read linear response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("linear API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("decode linear response: %w", err)
+	}
+	if len(envelope.Errors) > 0 {
+		return fmt.Errorf("linear API error: %s", envelope.Errors[0].Message)
+	}
+	if out != nil {
+		if err := json.Unmarshal(envelope.Data, out); err != nil {
+			return fmt.Errorf("decode linear data: %w", err)
+		}
+	}
+	return nil
+}
+
+// CanonicalID implements Provider, normalizing a Linear issue URL or a
+// "team-142" identifier into the canonical "TEAM-142" form. It parses locally
+// and makes no API call.
+func (p *linearProvider) CanonicalID(raw string) (string, bool) {
+	teamKey, number, err := parseIssueID(raw)
+	if err != nil {
+		return "", false
+	}
+	return fmt.Sprintf("%s-%d", teamKey, number), true
+}
+
+// parseIssueID splits a Linear identifier like "ENG-142" into an uppercased
+// team key and issue number.
+func parseIssueID(id string) (teamKey string, number int, err error) {
+	m := issueIDPattern.FindStringSubmatch(strings.TrimSpace(id))
+	if m == nil {
+		return "", 0, fmt.Errorf("invalid Linear issue id %q (expected e.g. ENG-142)", id)
+	}
+	n, err := strconv.Atoi(m[2])
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid Linear issue number in %q: %w", id, err)
+	}
+	return strings.ToUpper(m[1]), n, nil
+}
+
+// normalizeLinearState maps a Linear workflow-state type to a normalized State.
+func normalizeLinearState(linearType string) State {
+	switch linearType {
+	case "completed", "canceled":
+		return StateDone
+	case "started":
+		return StateInProgress
+	case "unstarted", "backlog", "triage":
+		return StateTodo
+	default:
+		return StateUnknown
+	}
+}
+
+// stateDisplayName is the workflow-state name typically used for a State.
+func stateDisplayName(s State) string {
+	switch s {
+	case StateTodo:
+		return "Todo"
+	case StateInProgress:
+		return "In Progress"
+	case StateInReview:
+		return "In Review"
+	case StateDone:
+		return "Done"
+	case StateUnknown:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// stateLinearType is the Linear workflow-state type a State maps onto.
+func stateLinearType(s State) string {
+	switch s {
+	case StateTodo:
+		return "unstarted"
+	case StateInProgress, StateInReview:
+		return "started"
+	case StateDone:
+		return "completed"
+	case StateUnknown:
+		return ""
+	default:
+		return ""
+	}
+}

--- a/cmd/entire/cli/ticket/linear_test.go
+++ b/cmd/entire/cli/ticket/linear_test.go
@@ -1,0 +1,124 @@
+package ticket
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDoer returns a canned HTTP response for the Linear provider tests.
+type fakeDoer struct {
+	status int
+	body   string
+}
+
+func (f fakeDoer) Do(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: f.status,
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestParseIssueID(t *testing.T) {
+	t.Parallel()
+
+	team, num, err := parseIssueID("ENG-142")
+	require.NoError(t, err)
+	assert.Equal(t, "ENG", team)
+	assert.Equal(t, 142, num)
+
+	team, num, err = parseIssueID("eng-7")
+	require.NoError(t, err)
+	assert.Equal(t, "ENG", team)
+	assert.Equal(t, 7, num)
+
+	_, _, err = parseIssueID("nope")
+	require.Error(t, err)
+}
+
+func TestLinearResolveFromBranch(t *testing.T) {
+	t.Parallel()
+
+	p := newLinearProvider("t", "ENG")
+
+	id, ok := p.ResolveFromBranch("amy/eng-142-add-rate-limiting")
+	assert.True(t, ok)
+	assert.Equal(t, "ENG-142", id)
+
+	_, ok = p.ResolveFromBranch("main")
+	assert.False(t, ok)
+}
+
+func TestLinearCanonicalID(t *testing.T) {
+	t.Parallel()
+
+	p := newLinearProvider("t", "MOH")
+
+	cases := map[string]struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		"bare id":   {"MOH-57", "MOH-57", true},
+		"lowercase": {"moh-57", "MOH-57", true},
+		"full url":  {"https://linear.app/mohit-personal/issue/MOH-57/print-hello-world", "MOH-57", true},
+		"no id":     {"just some words", "", false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := p.CanonicalID(tc.in)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNormalizeLinearState(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, StateDone, normalizeLinearState("completed"))
+	assert.Equal(t, StateInProgress, normalizeLinearState("started"))
+	assert.Equal(t, StateTodo, normalizeLinearState("backlog"))
+	assert.Equal(t, StateUnknown, normalizeLinearState("mystery"))
+}
+
+func TestLinearFetch(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"data":{"issues":{"nodes":[{
+	  "id":"uuid-1","identifier":"ENG-142","title":"Add rate limiting",
+	  "description":"throttle /export","url":"https://linear.app/x/ENG-142",
+	  "state":{"name":"In Progress","type":"started"},
+	  "labels":{"nodes":[{"name":"backend"}]},
+	  "comments":{"nodes":[{"body":"looks good","user":{"name":"amy"}}]}
+	}]}}}`
+
+	p := &linearProvider{token: "t", team: "ENG", url: "https://example.test", http: fakeDoer{status: http.StatusOK, body: body}}
+
+	task, err := p.Fetch(context.Background(), "ENG-142")
+	require.NoError(t, err)
+	assert.Equal(t, "ENG-142", task.ID)
+	assert.Equal(t, "Add rate limiting", task.Title)
+	assert.Equal(t, "throttle /export", task.Intent)
+	assert.Equal(t, StateInProgress, task.State)
+	assert.Equal(t, []string{"backend"}, task.Labels)
+	require.Len(t, task.Comments, 1)
+	assert.Equal(t, "amy", task.Comments[0].Author)
+}
+
+func TestLinearFetch_NotFound(t *testing.T) {
+	t.Parallel()
+
+	p := &linearProvider{token: "t", team: "ENG", url: "https://example.test", http: fakeDoer{status: http.StatusOK, body: `{"data":{"issues":{"nodes":[]}}}`}}
+
+	_, err := p.Fetch(context.Background(), "ENG-999")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/cmd/entire/cli/ticket/link.go
+++ b/cmd/entire/cli/ticket/link.go
@@ -118,6 +118,11 @@ func storeLink(ctx context.Context, branch string, link Link, force bool) error 
 	if ok && !force && (existing.ID != link.ID || existing.Platform != link.Platform) {
 		return fmt.Errorf("branch %q is already linked to %s (%s); pass --force to overwrite", branch, existing.ID, existing.Platform)
 	}
+	// Preserve an existing snapshot when re-linking the same ticket without a
+	// fresh one, so start/status can still detect drift.
+	if link.Snapshot == nil && ok && existing.ID == link.ID && existing.Platform == link.Platform {
+		link.Snapshot = existing.Snapshot
+	}
 	logging.Debug(ctx, "ticket linked",
 		slog.String("platform", link.Platform),
 		slog.String("ticket", link.ID),

--- a/cmd/entire/cli/ticket/link.go
+++ b/cmd/entire/cli/ticket/link.go
@@ -169,6 +169,21 @@ func CurrentLink(ctx context.Context) (Link, bool, error) {
 	return store.get(branch)
 }
 
+// LinkForBranch returns the ticket linked to the given branch, if any. When
+// branch is empty it falls back to the current branch. Used by the checkpoint
+// strategy to capture ticket provenance at condense time (by the branch the
+// session recorded), independent of where HEAD currently points.
+func LinkForBranch(ctx context.Context, branch string) (Link, bool, error) {
+	if strings.TrimSpace(branch) == "" {
+		return CurrentLink(ctx)
+	}
+	store, err := newLinkStore(ctx)
+	if err != nil {
+		return Link{}, false, err
+	}
+	return store.get(branch)
+}
+
 // currentBranch resolves the current git branch name, erroring on a detached
 // HEAD.
 func currentBranch(ctx context.Context) (string, error) {

--- a/cmd/entire/cli/ticket/link.go
+++ b/cmd/entire/cli/ticket/link.go
@@ -97,6 +97,10 @@ func linkCurrentBranch(ctx context.Context, id string, force bool) (Link, string
 		id = detected
 	}
 
+	// Normalize a pasted URL or differently-cased id to its canonical form
+	// (e.g. "MOH-57") so status/prompt render it cleanly. Best-effort.
+	id = canonicalID(ctx, id)
+
 	link := Link{Platform: tc.Platform, ID: id}
 	if err := storeLink(ctx, branch, link, force); err != nil {
 		return Link{}, "", err

--- a/cmd/entire/cli/ticket/link.go
+++ b/cmd/entire/cli/ticket/link.go
@@ -1,0 +1,179 @@
+package ticket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitexec"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// newLinkCmd builds `entire ticket link`.
+func newLinkCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "link <ticket-id>",
+		Short: "Link a ticket to the current branch",
+		Long: `Link a ticket to the current git branch so agents and reviews carry it as
+grounding context. Run it from the branch you are working on.
+
+The link is stored per branch (in the git common dir) and persists across
+sessions, so you can link a ticket before, during, or after doing the work —
+Entire captures the session either way.
+
+Examples:
+  entire ticket link ENG-142`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := ""
+			if len(args) == 1 {
+				id = args[0]
+			}
+			return runLink(cmd.Context(), cmd.OutOrStdout(), id, force)
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing link on this branch")
+	return cmd
+}
+
+// newUnlinkCmd builds `entire ticket unlink`.
+func newUnlinkCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unlink",
+		Short: "Remove the ticket link from the current branch",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runUnlink(cmd.Context(), cmd.OutOrStdout())
+		},
+	}
+}
+
+func runLink(ctx context.Context, out io.Writer, id string, force bool) error {
+	link, branch, err := linkCurrentBranch(ctx, id, force)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "✓ Linked %s to branch %q.\n", link.ID, branch)
+	return nil
+}
+
+// linkCurrentBranch validates configuration, resolves the current branch, and
+// records the ticket link (honoring force). Shared by `ticket link` and
+// `ticket start`. Returns the stored link and the branch name.
+func linkCurrentBranch(ctx context.Context, id string, force bool) (Link, string, error) {
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return Link{}, "", fmt.Errorf("load settings: %w", err)
+	}
+	tc := s.TicketConfig()
+	if tc.IsZero() {
+		return Link{}, "", errors.New("no ticket platform configured — run `entire ticket setup` first")
+	}
+
+	branch, err := currentBranch(ctx)
+	if err != nil {
+		return Link{}, "", err
+	}
+
+	id = strings.TrimSpace(id)
+	if id == "" {
+		// Infer the ticket from the branch name via the active provider.
+		prov, perr := activeProvider(ctx)
+		if perr != nil {
+			return Link{}, "", fmt.Errorf("specify a ticket ID (auto-detect unavailable: %w)", perr)
+		}
+		detected, ok := prov.ResolveFromBranch(branch)
+		if !ok {
+			return Link{}, "", fmt.Errorf("could not infer a ticket ID from branch %q; specify one, e.g. `entire ticket link ENG-142`", branch)
+		}
+		id = detected
+	}
+
+	link := Link{Platform: tc.Platform, ID: id}
+	if err := storeLink(ctx, branch, link, force); err != nil {
+		return Link{}, "", err
+	}
+	return link, branch, nil
+}
+
+// storeLink records link on branch, honoring force when a different ticket is
+// already linked. Shared by `ticket link` and `ticket start`.
+func storeLink(ctx context.Context, branch string, link Link, force bool) error {
+	store, err := newLinkStore(ctx)
+	if err != nil {
+		return err
+	}
+	existing, ok, err := store.get(branch)
+	if err != nil {
+		return err
+	}
+	if ok && !force && (existing.ID != link.ID || existing.Platform != link.Platform) {
+		return fmt.Errorf("branch %q is already linked to %s (%s); pass --force to overwrite", branch, existing.ID, existing.Platform)
+	}
+	logging.Debug(ctx, "ticket linked",
+		slog.String("platform", link.Platform),
+		slog.String("ticket", link.ID),
+		slog.String("branch", branch))
+	return store.set(branch, link)
+}
+
+func runUnlink(ctx context.Context, out io.Writer) error {
+	branch, err := currentBranch(ctx)
+	if err != nil {
+		return err
+	}
+	store, err := newLinkStore(ctx)
+	if err != nil {
+		return err
+	}
+	removed, err := store.del(branch)
+	if err != nil {
+		return err
+	}
+	if !removed {
+		fmt.Fprintf(out, "Branch %q has no ticket link.\n", branch)
+		return nil
+	}
+	fmt.Fprintf(out, "✓ Unlinked ticket from branch %q.\n", branch)
+	return nil
+}
+
+// CurrentLink returns the ticket linked to the current branch, if any. It is
+// used by `ticket start` and, later, the review integration.
+func CurrentLink(ctx context.Context) (Link, bool, error) {
+	branch, err := currentBranch(ctx)
+	if err != nil {
+		return Link{}, false, err
+	}
+	store, err := newLinkStore(ctx)
+	if err != nil {
+		return Link{}, false, err
+	}
+	return store.get(branch)
+}
+
+// currentBranch resolves the current git branch name, erroring on a detached
+// HEAD.
+func currentBranch(ctx context.Context) (string, error) {
+	root, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve repo root: %w", err)
+	}
+	out, err := gitexec.Run(ctx, root, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("resolve current branch: %w", err)
+	}
+	branch := strings.TrimSpace(out)
+	if branch == "" || branch == "HEAD" {
+		return "", errors.New("not on a branch (detached HEAD)")
+	}
+	return branch, nil
+}

--- a/cmd/entire/cli/ticket/linkstore.go
+++ b/cmd/entire/cli/ticket/linkstore.go
@@ -1,0 +1,132 @@
+package ticket
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/entireio/cli/cmd/entire/cli/session"
+)
+
+const (
+	// ticketStateDirName is the directory (within the git common dir) that
+	// holds ticket-link state, shared across worktrees like entire-sessions.
+	ticketStateDirName = "entire-tickets"
+	// linksFileName holds the branch → link mapping.
+	linksFileName = "links.json"
+)
+
+// Link records which ticket a branch is associated with. It is stored per
+// branch so a ticket can be linked before, during, or after the work — the
+// session capture happens continuously regardless.
+type Link struct {
+	Platform string `json:"platform"`
+	ID       string `json:"id"`
+}
+
+// linkStore persists branch → Link mappings as a single JSON file in the git
+// common dir.
+type linkStore struct {
+	dir string
+}
+
+// newLinkStore resolves the ticket-state directory from the git common dir.
+func newLinkStore(ctx context.Context) (*linkStore, error) {
+	commonDir, err := session.GetGitCommonDir(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve git common dir: %w", err)
+	}
+	return &linkStore{dir: filepath.Join(commonDir, ticketStateDirName)}, nil
+}
+
+// newLinkStoreWithDir builds a store rooted at an explicit directory, for tests.
+func newLinkStoreWithDir(dir string) *linkStore {
+	return &linkStore{dir: dir}
+}
+
+func (s *linkStore) path() string {
+	return filepath.Join(s.dir, linksFileName)
+}
+
+// all returns the full branch → Link map, or an empty map when no state exists.
+func (s *linkStore) all() (map[string]Link, error) {
+	data, err := os.ReadFile(s.path())
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]Link{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read ticket links: %w", err)
+	}
+	links := map[string]Link{}
+	if len(data) == 0 {
+		return links, nil
+	}
+	if err := json.Unmarshal(data, &links); err != nil {
+		return nil, fmt.Errorf("parse ticket links: %w", err)
+	}
+	return links, nil
+}
+
+// get returns the link for branch, if any.
+func (s *linkStore) get(branch string) (Link, bool, error) {
+	links, err := s.all()
+	if err != nil {
+		return Link{}, false, err
+	}
+	l, ok := links[branch]
+	return l, ok, nil
+}
+
+// set records the link for branch, replacing any existing one.
+func (s *linkStore) set(branch string, l Link) error {
+	links, err := s.all()
+	if err != nil {
+		return err
+	}
+	links[branch] = l
+	return s.write(links)
+}
+
+// del removes the link for branch, reporting whether one existed.
+func (s *linkStore) del(branch string) (bool, error) {
+	links, err := s.all()
+	if err != nil {
+		return false, err
+	}
+	if _, ok := links[branch]; !ok {
+		return false, nil
+	}
+	delete(links, branch)
+	return true, s.write(links)
+}
+
+// write atomically persists the full map (temp file + rename).
+func (s *linkStore) write(links map[string]Link) error {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("create ticket state dir: %w", err)
+	}
+	data, err := json.MarshalIndent(links, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode ticket links: %w", err)
+	}
+	tmp, err := os.CreateTemp(s.dir, "links-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp ticket links: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp ticket links: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp ticket links: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path()); err != nil {
+		return fmt.Errorf("commit ticket links: %w", err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/ticket/linkstore.go
+++ b/cmd/entire/cli/ticket/linkstore.go
@@ -25,6 +25,9 @@ const (
 type Link struct {
 	Platform string `json:"platform"`
 	ID       string `json:"id"`
+	// Snapshot is the last-seen ticket state, refreshed on each fetch so drift
+	// can be detected. Nil until the ticket has been fetched at least once.
+	Snapshot *Snapshot `json:"snapshot,omitempty"`
 }
 
 // linkStore persists branch → Link mappings as a single JSON file in the git

--- a/cmd/entire/cli/ticket/linkstore_test.go
+++ b/cmd/entire/cli/ticket/linkstore_test.go
@@ -1,0 +1,45 @@
+package ticket
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkStore_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := newLinkStoreWithDir(t.TempDir())
+
+	_, ok, err := store.get("main")
+	require.NoError(t, err)
+	assert.False(t, ok, "no link before any is set")
+
+	require.NoError(t, store.set("feature/x", Link{Platform: "linear", ID: "ENG-1"}))
+	got, ok, err := store.get("feature/x")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "ENG-1", got.ID)
+	assert.Equal(t, "linear", got.Platform)
+
+	// A second branch does not disturb the first.
+	require.NoError(t, store.set("feature/y", Link{Platform: "linear", ID: "ENG-2"}))
+	got, ok, err = store.get("feature/x")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "ENG-1", got.ID)
+
+	removed, err := store.del("feature/x")
+	require.NoError(t, err)
+	assert.True(t, removed)
+
+	_, ok, err = store.get("feature/x")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// Deleting an absent branch reports false, not an error.
+	removed, err = store.del("feature/x")
+	require.NoError(t, err)
+	assert.False(t, removed)
+}

--- a/cmd/entire/cli/ticket/platform.go
+++ b/cmd/entire/cli/ticket/platform.go
@@ -1,0 +1,47 @@
+package ticket
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Platform identifies a supported ticket platform.
+type Platform string
+
+const (
+	// PlatformLinear is Linear (linear.app).
+	PlatformLinear Platform = "linear"
+)
+
+// SupportedPlatforms lists the platforms `entire ticket setup` can configure,
+// in display order. Only Linear is supported today.
+var SupportedPlatforms = []Platform{PlatformLinear}
+
+// DisplayName returns the human-facing name for the platform.
+func (p Platform) DisplayName() string {
+	switch p {
+	case PlatformLinear:
+		return "Linear"
+	default:
+		return string(p)
+	}
+}
+
+// ParsePlatform validates s against the supported platforms.
+func ParsePlatform(s string) (Platform, error) {
+	for _, p := range SupportedPlatforms {
+		if string(p) == s {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("unsupported ticket platform %q (supported: %s)", s, supportedList())
+}
+
+// supportedList renders the supported platform identifiers for error messages.
+func supportedList() string {
+	names := make([]string, len(SupportedPlatforms))
+	for i, p := range SupportedPlatforms {
+		names[i] = string(p)
+	}
+	return strings.Join(names, ", ")
+}

--- a/cmd/entire/cli/ticket/platform_test.go
+++ b/cmd/entire/cli/ticket/platform_test.go
@@ -1,0 +1,27 @@
+package ticket
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePlatform(t *testing.T) {
+	t.Parallel()
+
+	got, err := ParsePlatform("linear")
+	require.NoError(t, err)
+	assert.Equal(t, PlatformLinear, got)
+
+	_, err = ParsePlatform("jira")
+	require.Error(t, err, "jira is not supported yet")
+	assert.Contains(t, err.Error(), "linear", "error lists supported platforms")
+}
+
+func TestPlatform_DisplayName(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "Linear", PlatformLinear.DisplayName())
+	assert.Equal(t, "acme", Platform("acme").DisplayName())
+}

--- a/cmd/entire/cli/ticket/provider.go
+++ b/cmd/entire/cli/ticket/provider.go
@@ -1,0 +1,35 @@
+package ticket
+
+import "context"
+
+// Provider abstracts a ticket platform such as Linear or Jira. Implementations
+// live in their own files and are wired into the command through the deps
+// bridge in the cli package, keeping the command surface platform-agnostic.
+//
+// Providers are wired explicitly rather than self-registering via init, per the
+// repository's gochecknoinits convention.
+type Provider interface {
+	// Name is the stable identifier used in settings, e.g. "linear".
+	Name() string
+
+	// Fetch resolves a provider-native ticket ID into a canonical Task.
+	Fetch(ctx context.Context, id string) (Task, error)
+
+	// Comment posts a comment on the ticket.
+	Comment(ctx context.Context, id, body string) error
+
+	// SetState transitions the ticket to the given normalized state. Providers
+	// map State onto their own workflow states.
+	SetState(ctx context.Context, id string, state State) error
+
+	// ResolveFromBranch extracts a ticket ID from a git branch name when the
+	// platform encodes one (e.g. Linear's "user/eng-142-title"). ok is false
+	// when no ID can be inferred.
+	ResolveFromBranch(branch string) (id string, ok bool)
+
+	// CanonicalID normalizes a user-supplied identifier (which may be a full
+	// ticket URL or a differently-cased id) into the provider's canonical form,
+	// e.g. "MOH-57". ok is false when raw contains no recognizable identifier.
+	// It performs no network I/O.
+	CanonicalID(raw string) (id string, ok bool)
+}

--- a/cmd/entire/cli/ticket/provider_resolve.go
+++ b/cmd/entire/cli/ticket/provider_resolve.go
@@ -1,0 +1,34 @@
+package ticket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// activeProvider builds the Provider for the repository's configured platform,
+// loading its stored credential. Returns an error when nothing is configured,
+// the credential is missing, or no concrete provider is implemented yet for the
+// platform. Concrete providers are wired in by their own files (see linear.go).
+//
+//nolint:unparam // result is always nil until a concrete provider lands (see linear.go); wired now so link/status can resolve it.
+func activeProvider(ctx context.Context) (Provider, error) {
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load settings: %w", err)
+	}
+	tc := s.TicketConfig()
+	if tc.IsZero() {
+		return nil, errors.New("no ticket platform configured — run `entire ticket setup` first")
+	}
+	platform, err := ParsePlatform(tc.Platform)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := LoadToken(platform); err != nil {
+		return nil, err
+	}
+	return nil, fmt.Errorf("no provider implemented for platform %q", platform)
+}

--- a/cmd/entire/cli/ticket/provider_resolve.go
+++ b/cmd/entire/cli/ticket/provider_resolve.go
@@ -9,11 +9,8 @@ import (
 )
 
 // activeProvider builds the Provider for the repository's configured platform,
-// loading its stored credential. Returns an error when nothing is configured,
-// the credential is missing, or no concrete provider is implemented yet for the
-// platform. Concrete providers are wired in by their own files (see linear.go).
-//
-//nolint:unparam // result is always nil until a concrete provider lands (see linear.go); wired now so link/status can resolve it.
+// loading its stored credential. Returns an error when nothing is configured or
+// the credential is missing.
 func activeProvider(ctx context.Context) (Provider, error) {
 	s, err := settings.Load(ctx)
 	if err != nil {
@@ -27,8 +24,47 @@ func activeProvider(ctx context.Context) (Provider, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := LoadToken(platform); err != nil {
+	token, err := LoadToken(platform)
+	if err != nil {
 		return nil, err
 	}
-	return nil, fmt.Errorf("no provider implemented for platform %q", platform)
+	return buildProvider(platform, token, tc.Team)
+}
+
+// buildProvider constructs the Provider implementation for a platform.
+func buildProvider(platform Platform, token, team string) (Provider, error) {
+	switch platform {
+	case PlatformLinear:
+		return newLinearProvider(token, team), nil
+	default:
+		return nil, fmt.Errorf("no provider implemented for platform %q", platform)
+	}
+}
+
+// canonicalID best-effort normalizes a user-supplied ticket identifier (a full
+// URL or a differently-cased id) into the configured provider's canonical form
+// (e.g. "MOH-57"). Normalization is pure string parsing, so it works without a
+// stored credential; it returns id unchanged when no platform is configured or
+// the id cannot be parsed, keeping link/start usable offline.
+func canonicalID(ctx context.Context, id string) string {
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return id
+	}
+	tc := s.TicketConfig()
+	if tc.IsZero() {
+		return id
+	}
+	platform, err := ParsePlatform(tc.Platform)
+	if err != nil {
+		return id
+	}
+	prov, err := buildProvider(platform, "", tc.Team)
+	if err != nil {
+		return id
+	}
+	if canonical, ok := prov.CanonicalID(id); ok {
+		return canonical
+	}
+	return id
 }

--- a/cmd/entire/cli/ticket/revoke.go
+++ b/cmd/entire/cli/ticket/revoke.go
@@ -1,0 +1,50 @@
+package ticket
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// newRevokeTokenCmd builds `entire ticket revoke-token`.
+func newRevokeTokenCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke-token",
+		Short: "Remove the stored ticket-platform credential from this machine",
+		Long: `Remove the API credential for the configured ticket platform from this
+machine's credential store. The platform/team configuration is left in place;
+run ` + "`entire ticket setup`" + ` to store a new credential (e.g. after rotating a key).
+
+This only deletes the local copy. To fully invalidate a Linear personal key,
+also revoke it in Linear (Settings → Security & access → API keys).`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRevokeToken(cmd.Context(), cmd.OutOrStdout())
+		},
+	}
+}
+
+func runRevokeToken(ctx context.Context, out io.Writer) error {
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return fmt.Errorf("load settings: %w", err)
+	}
+	tc := s.TicketConfig()
+	if tc.IsZero() {
+		fmt.Fprintln(out, "No ticket platform configured.")
+		return nil
+	}
+	platform, err := ParsePlatform(tc.Platform)
+	if err != nil {
+		return err
+	}
+	if err := DeleteToken(platform); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "✓ Removed the stored %s credential from this machine.\n", platform.DisplayName())
+	return nil
+}

--- a/cmd/entire/cli/ticket/setup.go
+++ b/cmd/entire/cli/ticket/setup.go
@@ -1,0 +1,172 @@
+package ticket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"charm.land/huh/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/uiform"
+)
+
+// setupFlags collects the non-interactive flag values for `ticket setup`.
+type setupFlags struct {
+	platform string
+	team     string
+	token    string
+}
+
+// newSetupCmd builds `entire ticket setup`.
+func newSetupCmd() *cobra.Command {
+	flags := setupFlags{}
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Choose a ticket platform and store credentials",
+		Long: `Configure the ticket platform for this repository.
+
+Runs an interactive prompt to pick a platform (Linear today), the team or
+workspace key, and an API token. The platform and team are saved to
+.entire/settings.json; the token is stored in your OS credential store, never
+in settings.
+
+Non-interactive:
+  entire ticket setup --platform linear --team ENG --token <api-key>`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSetup(cmd.Context(), cmd.OutOrStdout(), flags)
+		},
+	}
+	cmd.Flags().StringVar(&flags.platform, "platform", "", "ticket platform (linear)")
+	cmd.Flags().StringVar(&flags.team, "team", "", "team/workspace key on the platform")
+	cmd.Flags().StringVar(&flags.token, "token", "", "API token (stored in the OS credential store)")
+	return cmd
+}
+
+// runSetup resolves the platform/team/token either from flags or an
+// interactive prompt, then persists them.
+func runSetup(ctx context.Context, out io.Writer, flags setupFlags) error {
+	// Non-interactive path: all required values supplied via flags.
+	if flags.platform != "" && flags.team != "" && flags.token != "" {
+		return applySetup(ctx, out, flags.platform, flags.team, flags.token)
+	}
+
+	if !interactive.CanPromptInteractively() {
+		return errors.New("ticket setup needs an interactive terminal, or pass --platform, --team, and --token")
+	}
+
+	return runSetupInteractive(ctx, out, flags)
+}
+
+// runSetupInteractive drives the huh form, pre-filling from flags and any
+// existing configuration.
+func runSetupInteractive(ctx context.Context, out io.Writer, flags setupFlags) error {
+	platform := flags.platform
+	team := flags.team
+	token := flags.token
+
+	if platform == "" {
+		if s, err := settings.Load(ctx); err == nil {
+			if tc := s.TicketConfig(); !tc.IsZero() {
+				platform = tc.Platform
+				if team == "" {
+					team = tc.Team
+				}
+			}
+		}
+	}
+	if platform == "" {
+		platform = string(SupportedPlatforms[0])
+	}
+
+	options := make([]huh.Option[string], 0, len(SupportedPlatforms))
+	for _, p := range SupportedPlatforms {
+		options = append(options, huh.NewOption(p.DisplayName(), string(p)))
+	}
+
+	form := uiform.New(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Ticket platform").
+			Description("Only Linear is supported today.").
+			Options(options...).
+			Value(&platform),
+		huh.NewInput().
+			Title("Team / workspace key").
+			Description("e.g. ENG").
+			Value(&team),
+		huh.NewInput().
+			Title("API token").
+			Description("Stored in your OS credential store.").
+			EchoMode(huh.EchoModePassword).
+			Value(&token),
+	))
+	if err := form.RunWithContext(ctx); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return errors.New("ticket setup canceled")
+		}
+		return fmt.Errorf("ticket setup form: %w", err)
+	}
+
+	return applySetup(ctx, out, platform, strings.TrimSpace(team), token)
+}
+
+// applySetup validates the inputs and persists the platform/team to settings
+// and the token to the credential store.
+func applySetup(ctx context.Context, out io.Writer, platformStr, team, token string) error {
+	platform, err := ParsePlatform(platformStr)
+	if err != nil {
+		return err
+	}
+	if team == "" {
+		return errors.New("team/workspace key is required")
+	}
+	if strings.TrimSpace(token) == "" {
+		return errors.New("API token is required")
+	}
+
+	if err := saveTicketConfig(ctx, &settings.TicketConfig{Platform: string(platform), Team: team}); err != nil {
+		return err
+	}
+	if err := SaveToken(platform, token); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "✓ Ticket platform configured: %s (team %s)\n", platform.DisplayName(), team)
+	return nil
+}
+
+// saveTicketConfig writes the ticket section into .entire/settings.json. It
+// reads the committed file directly (not the merged view) so clone-local
+// preferences and local overrides are never baked into the committed file —
+// mirroring how `entire investigate` persists its config section.
+func saveTicketConfig(ctx context.Context, cfg *settings.TicketConfig) error {
+	basePath, err := paths.AbsPath(ctx, settings.EntireSettingsFile)
+	if err != nil {
+		basePath = settings.EntireSettingsFile
+	}
+
+	base := &settings.EntireSettings{}
+	data, readErr := os.ReadFile(basePath) //nolint:gosec // path is from AbsPath
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return fmt.Errorf("read settings: %w", readErr)
+	}
+	if len(data) > 0 {
+		base, err = settings.LoadFromBytes(data)
+		if err != nil {
+			return fmt.Errorf("parse settings: %w", err)
+		}
+	}
+
+	base.Ticket = cfg
+	if err := settings.Save(ctx, base); err != nil {
+		return fmt.Errorf("save settings: %w", err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/ticket/snapshot.go
+++ b/cmd/entire/cli/ticket/snapshot.go
@@ -1,0 +1,109 @@
+package ticket
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+)
+
+// Snapshot is the last-seen state of a linked ticket, persisted next to
+// the link so drift can be detected on the next fetch. It is the "working
+// copy" — always refreshed to the latest, never the frozen history.
+type Snapshot struct {
+	Title     string `json:"title,omitempty"`
+	State     string `json:"state,omitempty"`
+	URL       string `json:"url,omitempty"`
+	Digest    string `json:"digest,omitempty"`
+	FetchedAt string `json:"fetched_at,omitempty"`
+}
+
+// snapshotOf captures task as a Snapshot, or nil for a nil task.
+func snapshotOf(task *Task) *Snapshot {
+	if task == nil {
+		return nil
+	}
+	return &Snapshot{
+		Title:     task.Title,
+		State:     string(task.State),
+		URL:       task.URL,
+		Digest:    taskDigest(task),
+		FetchedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// taskDigest is a content hash over the fields that define the ticket's intent,
+// used to detect any change cheaply.
+func taskDigest(task *Task) string {
+	data := strings.Join([]string{task.Title, string(task.State), task.Intent, task.Acceptance}, "\x00")
+	sum := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(sum[:])
+}
+
+// diffSnapshot lists human-readable changes from a prior snapshot to task.
+// It returns nil when there is no prior snapshot or nothing changed.
+func diffSnapshot(prior *Snapshot, task *Task) []string {
+	if prior == nil || task == nil {
+		return nil
+	}
+	next := snapshotOf(task)
+	if prior.Digest == next.Digest {
+		return nil
+	}
+	var changes []string
+	if prior.State != next.State {
+		changes = append(changes, fmt.Sprintf("state: %s → %s", displayState(prior.State), displayState(next.State)))
+	}
+	if prior.Title != next.Title {
+		changes = append(changes, "title changed")
+	}
+	if len(changes) == 0 {
+		changes = append(changes, "details updated")
+	}
+	return changes
+}
+
+// displayState renders a normalized state for humans.
+func displayState(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return strings.ReplaceAll(s, "_", " ")
+}
+
+// refreshSnapshot compares the linked branch's stored snapshot to task, updates
+// it to the latest, and returns what changed. It returns nil changes when there
+// is no prior snapshot, nothing changed, or the branch has no link.
+func refreshSnapshot(ctx context.Context, branch string, task *Task) ([]string, error) {
+	if task == nil {
+		return nil, nil
+	}
+	store, err := newLinkStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	link, ok, err := store.get(branch)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	changes := diffSnapshot(link.Snapshot, task)
+	if len(changes) > 0 {
+		logging.Debug(ctx, "ticket drift detected",
+			slog.String("branch", branch),
+			slog.String("ticket", link.ID),
+			slog.Int("changes", len(changes)))
+	}
+	link.Snapshot = snapshotOf(task)
+	if err := store.set(branch, link); err != nil {
+		return nil, err
+	}
+	return changes, nil
+}

--- a/cmd/entire/cli/ticket/snapshot_test.go
+++ b/cmd/entire/cli/ticket/snapshot_test.go
@@ -1,0 +1,35 @@
+package ticket
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffSnapshot(t *testing.T) {
+	t.Parallel()
+
+	base := &Task{Title: "Rate limit /export", State: StateTodo, Intent: "body", Acceptance: "429"}
+	prior := snapshotOf(base)
+
+	// No prior snapshot → no changes.
+	assert.Nil(t, diffSnapshot(nil, base))
+
+	// Identical → no changes.
+	assert.Nil(t, diffSnapshot(prior, base))
+
+	// State change is reported specifically.
+	ch := diffSnapshot(prior, &Task{Title: "Rate limit /export", State: StateInReview, Intent: "body", Acceptance: "429"})
+	require.NotEmpty(t, ch)
+	assert.Contains(t, strings.Join(ch, "; "), "state")
+
+	// Title change.
+	ch = diffSnapshot(prior, &Task{Title: "New title", State: StateTodo, Intent: "body", Acceptance: "429"})
+	assert.Contains(t, strings.Join(ch, "; "), "title")
+
+	// Body-only change falls back to "details updated".
+	ch = diffSnapshot(prior, &Task{Title: "Rate limit /export", State: StateTodo, Intent: "different body", Acceptance: "429"})
+	assert.Contains(t, strings.Join(ch, "; "), "details")
+}

--- a/cmd/entire/cli/ticket/start.go
+++ b/cmd/entire/cli/ticket/start.go
@@ -109,6 +109,12 @@ func runStart(ctx context.Context, out io.Writer, deps Deps, opts startOptions) 
 		return err
 	}
 
+	// Refresh the stored snapshot to the latest ticket and note any drift since
+	// it was last seen (best-effort).
+	if changes, cerr := refreshSnapshot(ctx, branch, task); cerr == nil && len(changes) > 0 {
+		fmt.Fprintf(out, "⚠️  Ticket %s changed since last sync: %s\n", link.ID, strings.Join(changes, "; "))
+	}
+
 	// Launching the coding agent is temporarily disabled — spinning up an agent
 	// per start is expensive. start prepares the branch, link, and prompt; the
 	// launcher (deps.LaunchFix, verified above) stays wired for when launch is

--- a/cmd/entire/cli/ticket/start.go
+++ b/cmd/entire/cli/ticket/start.go
@@ -1,0 +1,212 @@
+package ticket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// startOptions collects the inputs to a start run.
+type startOptions struct {
+	id         string
+	agentName  string
+	branchName string
+	noBranch   bool
+	force      bool
+}
+
+// newStartCmd builds `entire ticket start`.
+func newStartCmd(deps Deps) *cobra.Command {
+	var agentName, branchName string
+	var force, noBranch bool
+	cmd := &cobra.Command{
+		Use:   "start <ticket-id>",
+		Short: "Create a branch, link a ticket, and launch an agent to work it",
+		Long: `Link a ticket to a branch and launch a coding agent with the ticket's details
+as context.
+
+By default this creates (or switches to) a branch for the ticket, prompting for
+the name with a suggested default (the platform's own branch name when it has
+one). Use --branch to name it non-interactively, or --no-branch to stay on the
+current branch.
+
+Agent launch is temporarily disabled: start prepares the branch, link, and
+prompt, and prints the prompt instead of spawning an agent.
+
+Examples:
+  entire ticket start ENG-142
+  entire ticket start ENG-142 --branch amy/eng-142
+  entire ticket start ENG-142 --no-branch`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if branchName != "" && noBranch {
+				return errors.New("--branch and --no-branch are mutually exclusive")
+			}
+			id := ""
+			if len(args) == 1 {
+				id = args[0]
+			}
+			return runStart(cmd.Context(), cmd.OutOrStdout(), deps, startOptions{
+				id:         id,
+				agentName:  agentName,
+				branchName: branchName,
+				noBranch:   noBranch,
+				force:      force,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&agentName, "agent", "", "agent to launch (default claude-code)")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing link on this branch")
+	cmd.Flags().StringVar(&branchName, "branch", "", "name of the branch to create/switch to for this ticket")
+	cmd.Flags().BoolVar(&noBranch, "no-branch", false, "stay on the current branch instead of creating one")
+	return cmd
+}
+
+func runStart(ctx context.Context, out io.Writer, deps Deps, opts startOptions) error {
+	if deps.LaunchFix == nil {
+		return errors.New("ticket start is unavailable: no agent launcher configured")
+	}
+
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return fmt.Errorf("load settings: %w", err)
+	}
+	tc := s.TicketConfig()
+	if tc.IsZero() {
+		return errors.New("no ticket platform configured — run `entire ticket setup` first")
+	}
+
+	id, err := resolveStartID(ctx, opts.id)
+	if err != nil {
+		return err
+	}
+	link := Link{Platform: tc.Platform, ID: id}
+
+	// Best-effort fetch for the prompt and the suggested branch name.
+	var task *Task
+	if fetched, ferr := fetchTaskForStart(ctx, link); ferr == nil {
+		task = fetched
+	}
+
+	if !opts.noBranch {
+		if err := startBranch(ctx, task, link, opts.branchName); err != nil {
+			return err
+		}
+	}
+
+	branch, err := currentBranch(ctx)
+	if err != nil {
+		return err
+	}
+	if err := storeLink(ctx, branch, link, opts.force); err != nil {
+		return err
+	}
+
+	// Launching the coding agent is temporarily disabled — spinning up an agent
+	// per start is expensive. start prepares the branch, link, and prompt; the
+	// launcher (deps.LaunchFix, verified above) stays wired for when launch is
+	// re-enabled.
+	fmt.Fprintf(out, "✓ Prepared %s on branch %q (agent launch disabled for now).\n\n", link.ID, branch)
+	fmt.Fprintln(out, "Prompt prepared for the agent:")
+	fmt.Fprintln(out)
+	fmt.Fprint(out, composeStartPrompt(link, task))
+	return nil
+}
+
+// resolveStartID returns the explicit id, or infers one from the current branch.
+func resolveStartID(ctx context.Context, id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id != "" {
+		return id, nil
+	}
+	cur, err := currentBranch(ctx)
+	if err != nil {
+		return "", err
+	}
+	prov, err := activeProvider(ctx)
+	if err != nil {
+		return "", fmt.Errorf("specify a ticket ID (auto-detect unavailable: %w)", err)
+	}
+	det, ok := prov.ResolveFromBranch(cur)
+	if !ok {
+		return "", fmt.Errorf("could not infer a ticket ID from branch %q; specify one, e.g. `entire ticket start ENG-142`", cur)
+	}
+	return det, nil
+}
+
+// startBranch resolves the branch name (flag, prompt, or default) and switches
+// to it, creating it when needed.
+func startBranch(ctx context.Context, task *Task, link Link, explicit string) error {
+	name := strings.TrimSpace(explicit)
+	if name == "" {
+		name = defaultBranchName(ctx, task, link)
+		if interactive.CanPromptInteractively() {
+			prompted, err := promptBranchName(ctx, name)
+			if err != nil {
+				return err
+			}
+			name = prompted
+		}
+	}
+	if name == "" {
+		return errors.New("branch name is empty (use --no-branch to stay on the current branch)")
+	}
+	return createOrSwitchBranch(ctx, name)
+}
+
+// fetchTaskForStart resolves the linked ticket via the active provider,
+// returning a nil task (and the error) when it cannot be fetched.
+func fetchTaskForStart(ctx context.Context, link Link) (*Task, error) {
+	prov, err := activeProvider(ctx)
+	if err != nil {
+		return nil, err
+	}
+	task, err := prov.Fetch(ctx, link.ID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch ticket %s: %w", link.ID, err)
+	}
+	return &task, nil
+}
+
+// composeStartPrompt renders the ticket as the agent's context. When the ticket
+// could not be fetched it falls back to the ticket reference.
+func composeStartPrompt(link Link, task *Task) string {
+	if task == nil || task.Title == "" {
+		return fmt.Sprintf("Ticket %s (%s)\n", link.ID, link.Platform)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Ticket %s: %s\n", link.ID, task.Title)
+	if task.URL != "" {
+		b.WriteString(task.URL)
+		b.WriteString("\n")
+	}
+	if body := strings.TrimSpace(task.Intent); body != "" {
+		b.WriteString("\n")
+		b.WriteString(body)
+		b.WriteString("\n")
+	}
+	if acc := strings.TrimSpace(task.Acceptance); acc != "" {
+		b.WriteString("\nAcceptance criteria:\n")
+		b.WriteString(acc)
+		b.WriteString("\n")
+	}
+	if len(task.Comments) > 0 {
+		b.WriteString("\nDiscussion:\n")
+		for _, c := range task.Comments {
+			author := c.Author
+			if author == "" {
+				author = "unknown"
+			}
+			fmt.Fprintf(&b, "- %s: %s\n", author, strings.TrimSpace(c.Body))
+		}
+	}
+	return b.String()
+}

--- a/cmd/entire/cli/ticket/start.go
+++ b/cmd/entire/cli/ticket/start.go
@@ -130,7 +130,7 @@ func runStart(ctx context.Context, out io.Writer, deps Deps, opts startOptions) 
 func resolveStartID(ctx context.Context, id string) (string, error) {
 	id = strings.TrimSpace(id)
 	if id != "" {
-		return id, nil
+		return canonicalID(ctx, id), nil
 	}
 	cur, err := currentBranch(ctx)
 	if err != nil {
@@ -144,7 +144,7 @@ func resolveStartID(ctx context.Context, id string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("could not infer a ticket ID from branch %q; specify one, e.g. `entire ticket start ENG-142`", cur)
 	}
-	return det, nil
+	return canonicalID(ctx, det), nil
 }
 
 // startBranch resolves the branch name (flag, prompt, or default) and switches

--- a/cmd/entire/cli/ticket/start_test.go
+++ b/cmd/entire/cli/ticket/start_test.go
@@ -1,0 +1,44 @@
+package ticket
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComposeStartPrompt(t *testing.T) {
+	t.Parallel()
+
+	prompt := composeStartPrompt(Link{Platform: "linear", ID: "ENG-142"}, nil)
+	assert.Contains(t, prompt, "ENG-142")
+	assert.Contains(t, prompt, "linear")
+	assert.True(t, strings.HasPrefix(prompt, "Ticket ENG-142"))
+
+	withTask := composeStartPrompt(
+		Link{Platform: "linear", ID: "ENG-142"},
+		&Task{
+			Title:      "Add rate limiting",
+			Intent:     "throttle /export",
+			Acceptance: "429 over limit",
+			URL:        "https://linear.app/x/ENG-142",
+			Comments:   []Comment{{Author: "amy", Body: "cap at 100 rps"}},
+		},
+	)
+	assert.Contains(t, withTask, "Add rate limiting")
+	assert.Contains(t, withTask, "throttle /export")
+	assert.Contains(t, withTask, "429 over limit")
+	assert.Contains(t, withTask, "amy: cap at 100 rps")
+	assert.Contains(t, withTask, "https://linear.app/x/ENG-142")
+}
+
+func TestNewStartCmd_Flags(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStartCmd(Deps{})
+	assert.Equal(t, "start <ticket-id>", cmd.Use)
+	assert.NotNil(t, cmd.Flags().Lookup("agent"))
+	assert.NotNil(t, cmd.Flags().Lookup("force"))
+	assert.NotNil(t, cmd.Flags().Lookup("branch"))
+	assert.NotNil(t, cmd.Flags().Lookup("no-branch"))
+}

--- a/cmd/entire/cli/ticket/status.go
+++ b/cmd/entire/cli/ticket/status.go
@@ -1,0 +1,139 @@
+package ticket
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// newStatusCmd builds `entire ticket status`.
+func newStatusCmd() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show the ticket platform and the current branch's linked ticket",
+		Long: `Show what Entire has configured and linked for tickets:
+the active platform and team, whether a credential is stored, and the ticket
+linked to the current branch (with its live title and state when reachable).`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runStatus(cmd.Context(), cmd.OutOrStdout(), asJSON)
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	return cmd
+}
+
+// statusReport is the machine-readable form of `ticket status`.
+type statusReport struct {
+	Configured  bool     `json:"configured"`
+	Platform    string   `json:"platform,omitempty"`
+	Team        string   `json:"team,omitempty"`
+	Credential  bool     `json:"credential"`
+	Branch      string   `json:"branch,omitempty"`
+	TicketID    string   `json:"ticket_id,omitempty"`
+	TicketTitle string   `json:"ticket_title,omitempty"`
+	TicketState string   `json:"ticket_state,omitempty"`
+	TicketURL   string   `json:"ticket_url,omitempty"`
+	Changes     []string `json:"changes,omitempty"`
+}
+
+func runStatus(ctx context.Context, out io.Writer, asJSON bool) error {
+	rep := gatherStatus(ctx)
+	if asJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rep); err != nil {
+			return fmt.Errorf("encode status: %w", err)
+		}
+		return nil
+	}
+	printStatus(out, rep)
+	return nil
+}
+
+// gatherStatus reads local config and link state, then best-effort fetches the
+// linked ticket for its live title/state. Network or credential failures leave
+// the live fields empty rather than erroring.
+func gatherStatus(ctx context.Context) statusReport {
+	var rep statusReport
+
+	if s, err := settings.Load(ctx); err == nil {
+		if tc := s.TicketConfig(); !tc.IsZero() {
+			rep.Configured = true
+			rep.Platform = tc.Platform
+			rep.Team = tc.Team
+			if platform, perr := ParsePlatform(tc.Platform); perr == nil {
+				if _, terr := LoadToken(platform); terr == nil {
+					rep.Credential = true
+				}
+			}
+		}
+	}
+
+	branch, err := currentBranch(ctx)
+	if err != nil {
+		return rep
+	}
+	rep.Branch = branch
+
+	link, ok, err := CurrentLink(ctx)
+	if err != nil || !ok {
+		return rep
+	}
+	rep.TicketID = link.ID
+
+	if prov, perr := activeProvider(ctx); perr == nil {
+		if task, ferr := prov.Fetch(ctx, link.ID); ferr == nil {
+			rep.TicketTitle = task.Title
+			rep.TicketState = string(task.State)
+			rep.TicketURL = task.URL
+			if changes, cerr := refreshSnapshot(ctx, branch, &task); cerr == nil {
+				rep.Changes = changes
+			}
+		}
+	}
+	return rep
+}
+
+func printStatus(out io.Writer, rep statusReport) {
+	if !rep.Configured {
+		fmt.Fprintln(out, "Ticket platform: not configured (run `entire ticket setup`)")
+		return
+	}
+
+	fmt.Fprintf(out, "Ticket platform: %s (team %s)\n", rep.Platform, rep.Team)
+	if rep.Credential {
+		fmt.Fprintln(out, "Credential:      present")
+	} else {
+		fmt.Fprintln(out, "Credential:      missing (run `entire ticket setup`)")
+	}
+	if rep.Branch != "" {
+		fmt.Fprintf(out, "Branch:          %s\n", rep.Branch)
+	}
+
+	if rep.TicketID == "" {
+		fmt.Fprintln(out, "Linked ticket:   (none — run `entire ticket link <id>`)")
+		return
+	}
+	fmt.Fprintf(out, "Linked ticket:   %s\n", rep.TicketID)
+	if rep.TicketTitle != "" {
+		state := ""
+		if rep.TicketState != "" {
+			state = " [" + rep.TicketState + "]"
+		}
+		fmt.Fprintf(out, "                 %s%s\n", rep.TicketTitle, state)
+	}
+	if rep.TicketURL != "" {
+		fmt.Fprintf(out, "                 %s\n", rep.TicketURL)
+	}
+	if len(rep.Changes) > 0 {
+		fmt.Fprintf(out, "⚠️  Changed since last sync: %s\n", strings.Join(rep.Changes, "; "))
+	}
+}

--- a/cmd/entire/cli/ticket/status_test.go
+++ b/cmd/entire/cli/ticket/status_test.go
@@ -1,0 +1,56 @@
+package ticket
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintStatus_NotConfigured(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	printStatus(&buf, statusReport{Configured: false})
+	assert.Contains(t, buf.String(), "not configured")
+}
+
+func TestPrintStatus_ConfiguredWithLink(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	printStatus(&buf, statusReport{
+		Configured:  true,
+		Platform:    "linear",
+		Team:        "ENG",
+		Credential:  true,
+		Branch:      "amy/eng-142",
+		TicketID:    "ENG-142",
+		TicketTitle: "Add rate limiting",
+		TicketState: "in_progress",
+		TicketURL:   "https://linear.app/x/ENG-142",
+	})
+	out := buf.String()
+	assert.Contains(t, out, "linear (team ENG)")
+	assert.Contains(t, out, "present")
+	assert.Contains(t, out, "ENG-142")
+	assert.Contains(t, out, "Add rate limiting")
+	assert.Contains(t, out, "in_progress")
+}
+
+func TestPrintStatus_ConfiguredNoLink(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	printStatus(&buf, statusReport{Configured: true, Platform: "linear", Team: "ENG", Credential: true, Branch: "main"})
+	assert.Contains(t, buf.String(), "(none")
+}
+
+func TestNewStatusCmd_JSONFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStatusCmd()
+	require.Equal(t, "status", cmd.Use)
+	assert.NotNil(t, cmd.Flags().Lookup("json"))
+}

--- a/cmd/entire/cli/ticket/task.go
+++ b/cmd/entire/cli/ticket/task.go
@@ -1,0 +1,52 @@
+package ticket
+
+// State is a normalized ticket lifecycle state. Providers map their
+// platform-specific workflow states onto these values so callers stay
+// platform-agnostic.
+type State string
+
+const (
+	// StateUnknown is the zero value, used when a state cannot be mapped.
+	StateUnknown State = ""
+	// StateTodo is an unstarted ticket.
+	StateTodo State = "todo"
+	// StateInProgress is a ticket actively being worked.
+	StateInProgress State = "in_progress"
+	// StateInReview is a ticket whose work is awaiting review.
+	StateInReview State = "in_review"
+	// StateDone is a completed ticket.
+	StateDone State = "done"
+)
+
+// Comment is a single comment on a ticket.
+type Comment struct {
+	Author string
+	Body   string
+}
+
+// Task is the platform-agnostic representation of a ticket. Providers map their
+// native issue/story/work-item shape into this canonical form so the rest of
+// the CLI never depends on a specific tracker.
+type Task struct {
+	// ID is the provider-native identifier, e.g. "ENG-142".
+	ID string
+	// Title is the one-line summary.
+	Title string
+	// Intent is the ticket body/description — the "what was asked" that grounds
+	// agent work and review.
+	Intent string
+	// Acceptance holds acceptance criteria when the provider exposes them
+	// separately from the body; empty otherwise.
+	Acceptance string
+	// State is the normalized lifecycle state.
+	State State
+	// URL is the canonical web URL of the ticket.
+	URL string
+	// BranchName is the platform's suggested git branch name for this ticket
+	// (e.g. Linear's issue.branchName); empty when the platform has none.
+	BranchName string
+	// Labels are the ticket's labels or tags.
+	Labels []string
+	// Comments are the ticket's comments, oldest first.
+	Comments []Comment
+}

--- a/cmd/entire/cli/ticket_bridge.go
+++ b/cmd/entire/cli/ticket_bridge.go
@@ -1,0 +1,17 @@
+package cli
+
+// ticket_bridge.go wires cli-package implementations into the ticket
+// subpackage's NewCommand Deps struct. The bridge lives in the cli package so
+// the ticket subpackage does not import the per-agent packages (import cycle).
+
+import (
+	"github.com/entireio/cli/cmd/entire/cli/agentlaunch"
+	"github.com/entireio/cli/cmd/entire/cli/ticket"
+)
+
+// buildTicketDeps builds the ticket.Deps used by ticket.NewCommand.
+func buildTicketDeps() ticket.Deps {
+	return ticket.Deps{
+		LaunchFix: agentlaunch.LaunchFixAgent,
+	}
+}

--- a/cmd/entire/cli/ticket_display.go
+++ b/cmd/entire/cli/ticket_display.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/ticket"
+)
+
+// Shared rendering for the external-tracker ticket linked to a branch. Two
+// input shapes exist: the live ticket.Link (from ticket.LinkForBranch, used by
+// status/session-info/review) and the frozen checkpoint.TicketRef (captured
+// into per-session metadata, used by explain). Both collapse to a single-line
+// display, e.g. "LIN-123 — Fix login redirect (in progress)".
+
+// formatTicketState humanizes a raw tracker state value ("in_progress" →
+// "in progress"); an empty state yields an empty string so callers can omit the
+// parenthetical entirely. (The ticket package's own displayState renders empty
+// as "unknown", which is the wrong default for these compact one-liners.)
+func formatTicketState(state string) string {
+	if state == "" {
+		return ""
+	}
+	return strings.ReplaceAll(state, "_", " ")
+}
+
+// formatTicketRefLine renders a frozen checkpoint.TicketRef for single-line
+// display, e.g. "LIN-123 — Fix login redirect (in progress)". Title and state
+// are omitted when the snapshot never recorded them; the URL is rendered
+// separately by the caller as a continuation line.
+func formatTicketRefLine(t *checkpoint.TicketRef) string {
+	label := t.ID
+	if label == "" {
+		label = t.Platform
+	}
+	if t.Title != "" {
+		label += " — " + t.Title
+	}
+	if state := formatTicketState(t.State); state != "" {
+		label += fmt.Sprintf(" (%s)", state)
+	}
+	return label
+}
+
+// formatTicketLinkLine renders a live ticket.Link for single-line display, e.g.
+// "LIN-123 — Fix login redirect (in progress)". The ID is always present; title
+// and state come from the last-fetched snapshot and are omitted when it has
+// none.
+func formatTicketLinkLine(link ticket.Link) string {
+	label := link.ID
+	if label == "" {
+		label = link.Platform
+	}
+	if link.Snapshot != nil {
+		if link.Snapshot.Title != "" {
+			label += " — " + link.Snapshot.Title
+		}
+		if state := formatTicketState(link.Snapshot.State); state != "" {
+			label += fmt.Sprintf(" (%s)", state)
+		}
+	}
+	return label
+}
+
+// ticketBriefJSON is the structured ticket shape shared by the `--json` output
+// of the CLI surfaces (status, session info). It projects a live ticket.Link
+// onto plain fields; the digest is intentionally omitted as an internal detail.
+type ticketBriefJSON struct {
+	Platform string `json:"platform,omitempty"`
+	ID       string `json:"id"`
+	Title    string `json:"title,omitempty"`
+	State    string `json:"state,omitempty"`
+	URL      string `json:"url,omitempty"`
+}
+
+// ticketBriefFromLink projects a live ticket.Link onto the JSON brief.
+func ticketBriefFromLink(link ticket.Link) *ticketBriefJSON {
+	brief := &ticketBriefJSON{Platform: link.Platform, ID: link.ID}
+	if link.Snapshot != nil {
+		brief.Title = link.Snapshot.Title
+		brief.State = link.Snapshot.State
+		brief.URL = link.Snapshot.URL
+	}
+	return brief
+}

--- a/cmd/entire/cli/ticket_display_test.go
+++ b/cmd/entire/cli/ticket_display_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/ticket"
+)
+
+func TestFormatTicketState(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"":            "",
+		"in_progress": "in progress",
+		"done":        "done",
+		"in_review":   "in review",
+	}
+	for in, want := range cases {
+		if got := formatTicketState(in); got != want {
+			t.Errorf("formatTicketState(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFormatTicketRefLine(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ref  *checkpoint.TicketRef
+		want string
+	}{
+		{
+			name: "full",
+			ref:  &checkpoint.TicketRef{ID: "LIN-9", Title: "Ship it", State: "in_progress"},
+			want: "LIN-9 — Ship it (in progress)",
+		},
+		{
+			name: "id only",
+			ref:  &checkpoint.TicketRef{ID: "LIN-9"},
+			want: "LIN-9",
+		},
+		{
+			name: "no id falls back to platform",
+			ref:  &checkpoint.TicketRef{Platform: "linear", Title: "Ship it"},
+			want: "linear — Ship it",
+		},
+		{
+			name: "title without state",
+			ref:  &checkpoint.TicketRef{ID: "LIN-9", Title: "Ship it"},
+			want: "LIN-9 — Ship it",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := formatTicketRefLine(tc.ref); got != tc.want {
+				t.Errorf("formatTicketRefLine() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTicketBriefFromLink(t *testing.T) {
+	t.Parallel()
+
+	got := ticketBriefFromLink(ticket.Link{
+		Platform: "linear",
+		ID:       "LIN-123",
+		Snapshot: &ticket.Snapshot{Title: "Fix login", State: "in_progress", URL: "https://example.com/LIN-123"},
+	})
+	if got.ID != "LIN-123" || got.Platform != "linear" || got.Title != "Fix login" ||
+		got.State != "in_progress" || got.URL != "https://example.com/LIN-123" {
+		t.Errorf("unexpected brief: %+v", got)
+	}
+
+	// A link without a fetched snapshot carries only identity.
+	bare := ticketBriefFromLink(ticket.Link{Platform: "linear", ID: "LIN-9"})
+	if bare.ID != "LIN-9" || bare.Title != "" || bare.State != "" || bare.URL != "" {
+		t.Errorf("expected identity-only brief, got: %+v", bare)
+	}
+}
+
+func TestFormatTicketLinkLine(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		link ticket.Link
+		want string
+	}{
+		{
+			name: "full snapshot",
+			link: ticket.Link{ID: "LIN-123", Snapshot: &ticket.Snapshot{Title: "Fix login", State: "in_progress"}},
+			want: "LIN-123 — Fix login (in progress)",
+		},
+		{
+			name: "no snapshot yet",
+			link: ticket.Link{ID: "LIN-123"},
+			want: "LIN-123",
+		},
+		{
+			name: "snapshot without title",
+			link: ticket.Link{ID: "LIN-123", Snapshot: &ticket.Snapshot{State: "done"}},
+			want: "LIN-123 (done)",
+		},
+		{
+			name: "no id falls back to platform",
+			link: ticket.Link{Platform: "linear", Snapshot: &ticket.Snapshot{Title: "Fix login"}},
+			want: "linear — Fix login",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := formatTicketLinkLine(tc.link); got != tc.want {
+				t.Errorf("formatTicketLinkLine() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -287,9 +287,28 @@ failed or skipped regeneration **drops** the prior `transcript.jsonl` and clears
   "branch": "main",
   "checkpoints_count": 3,
   "save_step_count": 3,
-  "files_touched": ["file1.txt", "file2.txt"]
+  "files_touched": ["file1.txt", "file2.txt"],
+  "ticket": {
+    "platform": "linear",
+    "id": "ENG-142",
+    "title": "Fix greeting trim bug",
+    "state": "in_progress",
+    "url": "https://linear.app/acme/issue/ENG-142",
+    "digest": "…",
+    "fetched_at": "2025-12-01T12:30:00Z"
+  }
 }
 ```
+
+The optional `ticket` field (`checkpoint.TicketRef`) is the external tracker
+ticket linked to the branch when the checkpoint was condensed — durable
+provenance of the intent the work was grounded in. It is populated at condense
+time by `ticketRefForBranch` (strategy) reading the branch's locally stored
+`entire ticket` link + snapshot (no network fetch), so the checkpoint history on
+`entire/checkpoints/v1` becomes the ticket's timeline. Omitted when the branch
+has no linked ticket. `api/checkpoint` holds the field as plain data so it never
+depends on the `ticket` package; the `strategy` layer maps `ticket.Link` →
+`TicketRef`.
 
 In session metadata, `checkpoints_count` is the displayed prompt-window count for that session. `save_step_count` records SaveStep-created shadow-branch commits and is the conservative "real checkpoint work happened" signal; it is omitted when zero (for example, commit-only/fallback sessions). `save_step_count` is not aggregated into the root `CheckpointSummary`.
 

--- a/docs/architecture/ticket-command-overview.md
+++ b/docs/architecture/ticket-command-overview.md
@@ -1,0 +1,134 @@
+# `entire ticket` — Overview
+
+*A plain-language companion to the [design spec](./ticket-command.md), for
+reviewers and engineering managers. The spec has the low-level detail; this is
+the "what, why, and where it's going."*
+
+---
+
+## TL;DR
+
+`entire ticket` connects a repository to a ticket tracker (Linear today) so the
+work an engineer does is grounded in the ticket's real requirements — and so
+Entire captures those requirements as first-class context.
+
+**Status:** the command surface is built, tested, and behind a hidden flag while
+it matures. Agent launch is intentionally off (cost). Write-back to the tracker
+and deep provenance capture are the next phases.
+
+---
+
+## Why we're building it
+
+An AI agent is only as good as the intent it's given — and that intent lives in
+the tracker, not the code. Today it's copy-pasted by hand or lost. Capturing it
+unlocks a ladder of value:
+
+1. **Now — better context.** Every task starts from its actual requirements.
+2. **Next — straight-through delivery.** A ticket becomes a branch, a change, a
+   reviewed PR, and a status update, with a human approving the result.
+3. **Later — leverage.** Many tickets progressed in parallel ("streaming
+   engineering hours"), and the captured *requirement → change → outcome* data
+   becomes exactly what makes future models better.
+
+This fits Entire's core thesis: as writing code becomes a commodity, the value
+moves to the **edges** — getting the task *right* going in, and *trusting and
+tracing* it coming out. `entire ticket` owns the "going in" edge and sets up the
+"coming out" edge.
+
+## What it does today
+
+| Command | What it does |
+|---|---|
+| `entire ticket setup` | pick a platform + team, store an API key securely |
+| `entire ticket status` | show config, credential, and the linked ticket (live) |
+| `entire ticket link <id>` | attach a ticket to the current branch (any time) |
+| `entire ticket unlink` | detach it |
+| `entire ticket start <id>` | make a branch, link the ticket, prepare the agent prompt |
+| `entire ticket revoke-token` | remove the stored credential |
+
+**A typical flow:**
+
+```
+entire ticket setup                 # once per repo
+entire ticket start ENG-142         # → new branch "eng-142", ticket linked,
+                                    #   prompt built from the ticket's details
+entire ticket status                # → shows the ticket + flags if it changed
+```
+
+You can link a ticket **before, during, or after** doing the work — the pointer
+is stored per branch, so it works even if you forgot to link up front.
+
+## How it works (at a glance)
+
+```
+  you ──▶ entire ticket ──┬─▶ settings.json   (platform + team)
+                          ├─▶ OS keychain     (the API key — never in git)
+                          ├─▶ .git/…          (branch → ticket link + snapshot)
+                          └─▶ Linear API      (fetch the ticket, live)
+```
+
+- The **link** is just a pointer (branch → ticket). The ticket's *content* is
+  fetched **live** each time, so it's always current.
+- A **snapshot** of the last-seen ticket is kept so we can tell you when the
+  ticket **changed mid-work** — you update to the new version, and get a
+  heads-up in case a scope change invalidated code you already wrote.
+- It's **tracker-agnostic** behind one interface; Linear is the first provider,
+  others (Jira, GitHub) are adapters.
+
+## Status: done vs. deferred
+
+**Done:** all six commands, the Linear integration, secure credential storage,
+live fetch, snapshot + change-detection, `--json` output, full test coverage.
+
+**Deferred (on purpose):**
+- **Agent launch** — a full agent per `start` is expensive; `start` prepares
+  everything and prints the prompt instead.
+- **Write-back** — posting results and moving the ticket (the API calls exist,
+  they're just not wired to a command yet).
+- **Deep provenance** — freezing the ticket into Entire's checkpoint history so
+  reviews and `why` can use it. This is the phase that makes linking *durable*.
+
+## Key decisions (and why)
+
+- **Local-first.** Config and links live in the repo, not a backend — it works
+  offline with no server dependency. Trade-off: not shared across machines yet.
+- **Snapshot + always-update.** We keep the working copy current *and* detect
+  change, rather than a full version history (the tracker already has that).
+- **Personal API key first.** Simple to set up; the richer "Entire-as-an-agent"
+  Linear integration comes later.
+- **Reuses Entire's patterns, doesn't reinvent.** New code is limited to what's
+  genuinely ticket-specific; everything else follows existing conventions.
+
+## Risks & how we handle them
+
+| Risk | Mitigation |
+|---|---|
+| **Credential leakage** | stored in the OS keychain, never in settings/logs/git; `revoke-token` + rotation |
+| **Untrusted ticket text** | ticket bodies are attacker-influenceable; launch is off today, and will adopt the same guardrails as issue-seeded investigations when it returns |
+| **Cost** | agent launch deferred; fetch/keychain costs are negligible |
+| **Tracker/network down** | best-effort: commands still complete with a fallback |
+| **Headless Linux (no keychain)** | falls back to a file-backed store via env var |
+
+## Roadmap
+
+1. **Ship the command surface** *(done)* — link, context, status.
+2. **Capture into checkpoint context** *(next)* — makes linking durable
+   provenance; gives ticket "versioning" for free via the checkpoint timeline.
+3. **Write-back** — post the review verdict, move the ticket to In Review / Done.
+4. **More providers** — Jira, GitHub Issues, etc.
+5. **Linear Agent Sessions** — Entire appears as a first-class agent in Linear.
+6. **Re-enable agent launch** behind cost controls.
+
+## Engineering notes
+
+- Shipped as **13 commits across a stack of small PRs** (one per capability),
+  each independently building, testing, and passing lint.
+- **Tested hermetically** — no network or real keychain in unit tests; the real
+  keychain is verified by running the binary (with `revoke-token` for cleanup).
+- **Convention-aligned** — reuses the noun-group + deps-bridge shape, the
+  settings/token/UI/git helpers, and the error/output conventions already in the
+  codebase.
+
+*For interfaces, data models, failure cases, and security detail, see the
+[full design spec](./ticket-command.md).*

--- a/docs/architecture/ticket-command.md
+++ b/docs/architecture/ticket-command.md
@@ -1,0 +1,390 @@
+# `entire ticket` — Tech Spec
+
+## Summary
+
+`entire ticket` links work in a repository to tickets on an external tracker
+(Linear today) and carries the ticket's content into the agent's context. The
+link lives per branch, the ticket is fetched live, and a snapshot is kept so we
+can flag when the ticket changes mid-work.
+
+---
+
+## Problem & motivation
+
+**Immediate:** an agent working a task is only as good as the intent it's given.
+That intent lives in the tracker (Linear/Jira/…), not in the codebase. Today
+it's copy-pasted by hand, or lost. We want to **capture ticket context** and put
+it where agents, reviews, and provenance can use it.
+
+**Long-term unlock:** if the ticket is a first-class, captured input, the loop
+from **ticket → production** can be increasingly automated and trustworthy:
+
+- **Straight-through delivery** — a ticket becomes a branch, a change, a
+  reviewed PR, and a status update, with a human gate for trust.
+- **Improving models over time** — captured `(raw requirement → change →
+  outcome)` triples are exactly the data that makes future agents better.
+
+---
+
+## The commands
+
+```bash
+# One-time, per repo: choose a tracker + team and store its API key securely.
+entire ticket setup   [--platform linear --team ENG --token <key>]
+
+# Link a ticket to the current branch. Auto-detects the id from the branch name
+# when omitted. Works before, during, or after the work — the pointer is durable.
+entire ticket link    [<id>] [--force]
+
+# Remove the link from the current branch.
+entire ticket unlink
+
+# Link + create/switch a branch + prepare the agent prompt from the ticket.
+# Creates a branch by default (Linear's suggested name, or <user>/<id>-<title>).
+entire ticket start   [<id>] [--branch <name> | --no-branch] [--force] [--agent <name>]
+
+# Show config, whether a credential is present, the linked ticket (live), + drift.
+entire ticket status  [--json]
+
+# Remove the stored credential (rotation / cleanup). Local only.
+entire ticket revoke-token
+```
+
+**Flags at a glance:**
+
+- `--force` — overwrite an existing link when the branch is already linked to a
+  *different* ticket (otherwise the command refuses, to avoid clobbering).
+- `--branch <name>` / `--no-branch` — name the new branch non-interactively, or
+  stay on the current branch. Default is create-and-prompt.
+- `--agent <name>` — which agent `start` will launch (default `claude-code`). A
+  no-op while launch is disabled; kept for when launch returns.
+- `--platform` / `--team` / `--token` — non-interactive `setup`.
+- `--json` — machine-readable `status`.
+
+---
+
+## Goals & non-goals
+
+**Goals**
+
+- Configure a tracker per repo and store its credential securely.
+- Link a ticket to a branch — anytime (before, during, after work).
+- Fetch the ticket live and render it as agent context.
+- Keep a working snapshot current and surface mid-work changes (drift).
+- Be tracker-agnostic behind one interface.
+- **Launch a coding agent on the ticket** — an intended feature, temporarily
+  disabled during testing because a full agent per `start` is expensive.
+
+**Non-goals (now)**
+
+- Being a tracker (creating/managing tickets in Entire).
+- Real-time push sync (webhooks / Linear Agent Sessions).
+- Automatic write-back to the tracker.
+- Team-shared link state across machines.
+
+---
+
+## Technical requirements
+
+- **Latency** — one Linear round-trip on `start` / `status` (~100–500 ms).
+  Best-effort: failure never blocks the command. `http.Client` timeout 30s;
+  keyring reads guarded by a timeout (`tokenstore/keyring_timeout.go`).
+- **Availability** — degrades gracefully: no network/credential → `start` falls
+  back to an id-only prompt; `status` shows stored state. No hard dependency on
+  a backend (local-first).
+- **Consistency** — the local link/snapshot store is read-your-writes (atomic
+  temp+rename). Ticket content is *eventually consistent* with Linear: re-fetched
+  on demand (update-always), with drift surfaced on the next sync. No background
+  reconciliation.
+
+---
+
+## APIs
+
+### Internal — `Provider`
+
+```go
+Name() string
+Fetch(ctx, id) (Task, error)            // read the ticket
+Comment(ctx, id, body) error            // post a comment on the ticket (write-back)
+SetState(ctx, id, state State) error    // move the ticket (e.g. → In Review) (write-back)
+ResolveFromBranch(branch) (id, ok)      // infer the ticket id from a branch name
+```
+
+### External — Linear GraphQL
+
+`https://api.linear.app/graphql`, `Authorization: <personal key>`:
+
+- `issues(filter:{team.key, number})` — fetch by `TEAM-123`.
+- `workflowStates(filter:{team.key})` — resolve target state for `SetState`.
+- `commentCreate` / `issueUpdate` — write-back (not yet invoked).
+- reads `issue.branchName` for the default branch.
+
+---
+
+## Data models
+
+| Model | Stored in | Shape |
+|---|---|---|
+| `settings.TicketConfig` | `.entire/settings.json` | `{Platform, Team}` |
+| `ticket.Task` | in-memory (fetched) | `{ID, Title, Intent, Acceptance, State, URL, BranchName, Labels, Comments}` |
+| `ticket.Link` | `.git/entire-tickets/links.json` | `{Platform, ID, Snapshot}` |
+| `ticket.Snapshot` | (nested in `Link`) | `{Title, State, URL, Digest, FetchedAt}` |
+| `ticket.State` | — | normalized enum: todo / in_progress / in_review / done / unknown |
+| `ticket.statusReport` | `--json` output | machine-readable status |
+| `checkpoint.TicketRef` | `entire/checkpoints/v1` (per-session `metadata.json` `ticket`) | `{Platform, ID, Title, State, URL, Digest, FetchedAt}` — durable provenance |
+
+---
+
+## HLD
+
+`entire ticket` is a thin, provider-agnostic command layer over three local
+stores and one remote:
+
+- **`settings.json`** — platform + team (per repo).
+- **OS keychain** — the API credential.
+- **`links.json`** (git common dir) — branch → link + snapshot.
+- **Linear API** — the live ticket, reached only through the `Provider`
+  interface, so the surface never depends on a specific tracker.
+
+The commands compose those pieces: `setup` writes config + credential;
+`link` / `start` associate a ticket with a branch (`start` also creates the
+branch and prepares the prompt); `status` reads config + the live ticket;
+`revoke-token` clears the credential. Only the provider behind `setup` is
+platform-specific.
+
+`start` is the path that exercises everything, and every remote step is
+best-effort — a fetch failure degrades to an id-only prompt rather than blocking:
+
+```mermaid
+sequenceDiagram
+    actor Eng as Engineer
+    participant CLI as entire ticket start
+    participant Key as OS keychain
+    participant Linear as Linear API
+    participant Store as links.json
+
+    Eng->>CLI: start ENG-142
+    CLI->>Key: load credential
+    CLI->>Linear: Fetch(ENG-142)  (best-effort)
+    Linear-->>CLI: Task {title, state, branchName, …}
+    CLI->>CLI: create / switch branch
+    CLI->>Store: storeLink + refreshSnapshot (detect drift)
+    CLI-->>Eng: prompt built from the ticket (launch deferred)
+```
+
+---
+
+## Design principle: reuse, don't reinvent
+
+New surface is limited to what's genuinely ticket-specific — the `Provider`
+interface and the Linear client. **Everything else reuses existing Entire
+conventions**, so this feature stays in-pattern with the rest of the CLI:
+
+- the hidden noun-group + deps bridge (as `review` / `investigate`),
+- the `settings` package (with `investigate`'s clobber-safe persistence),
+- `tokenstore` for credentials,
+- `uiform` for accessible prompts,
+- `gitexec` / `paths` for git,
+- the git-common-dir state layout,
+- the `SilentError` / `cmd.OutOrStdout()` conventions.
+
+### Package layout
+
+Package `cmd/entire/cli/ticket/` (hidden noun group, `investigate`-style deps
+bridge to avoid an import cycle with per-agent packages):
+
+| File | Responsibility |
+|---|---|
+| `cmd.go` | group + `Deps{LaunchFix}` (bridge: `ticket_bridge.go`) |
+| `provider.go` / `task.go` | `Provider` interface + `Task` / `State` / `Comment` |
+| `platform.go` | `Platform` enum + `SupportedPlatforms` + parse |
+| `creds.go` | `SaveToken` / `LoadToken` / `DeleteToken` via `tokenstore` |
+| `setup.go` | interactive (`uiform`/huh) + flag paths; clobber-safe settings write |
+| `link.go` | `link` / `unlink`, `linkCurrentBranch`, `storeLink`, `currentBranch` |
+| `linkstore.go` | per-branch JSON store (atomic temp+rename) in the git common dir |
+| `branch.go` | default branch name (Linear `branchName` or `<user>/<id>-<title>` slug), `createOrSwitchBranch` |
+| `start.go` | orchestration; ticket-only prompt |
+| `snapshot.go` | `Snapshot`, `taskDigest` (sha256), `diffSnapshot`, `refreshSnapshot` |
+| `status.go` | `statusReport` (+ `--json`) |
+| `linear.go` | `Provider` impl; injectable `httpDoer` |
+
+### Key files
+
+`cmd/entire/cli/ticket/*` · `cmd/entire/cli/ticket_bridge.go` ·
+`settings.TicketConfig` · `internal/entireclient/tokenstore`.
+
+---
+
+## Read surfaces (observe-only)
+
+Once a ticket is captured, it is surfaced across the CLI's read paths so the
+intent the work was grounded in travels with the work. **This is deliberately
+observe-only** — nothing here mutates the tracker (see [Write-back](#roadmap),
+which is intentionally the next step, not part of this slice).
+
+Two shapes feed the surfaces, resolved through shared helpers in
+`cmd/entire/cli/ticket_display.go` (`formatTicketLinkLine` /
+`formatTicketRefLine` / `ticketBriefFromLink`), so every surface renders the
+same and none re-implements formatting:
+
+| Surface | Source | Shows |
+| --- | --- | --- |
+| `checkpoint explain` | frozen `Metadata.Ticket` (per-checkpoint) | a `ticket` header row + URL; `--json` gains a `ticket` object per session |
+| `entire status` | live `LinkForBranch` (current branch) | a `Ticket ·` line under the branch; `--json` gains a top-level `ticket` |
+| `entire session info` | live `LinkForBranch` (session's recorded branch) | a `Ticket:` row + `--json` field; `session current` inherits it |
+| `entire review` | live `LinkForBranch` (current branch) | prepends a "Linked ticket (original intent…)" block to the reviewer's context |
+
+Design rules shared by all four:
+
+- **Frozen vs. live is intentional.** `explain` reads the *captured* snapshot
+  (durable provenance of what the ticket looked like at condense time); the
+  live-branch surfaces read the *current* link so they reflect present state.
+- **Best-effort, never blocking.** A missing link or lookup error omits the
+  line; no surface fails or slows because of ticket state. Reads are local
+  (link store), so there is no network round-trip on these paths.
+- **`session list` is deliberately excluded** — a branch-scoped ticket would
+  repeat per row; it stays a compact one-card-per-session view.
+
+---
+
+## Testing
+
+- **Unit (hermetic, mostly parallel):** parsing, slugify, state mapping, prompt
+  composition, snapshot diff; `Fetch` via an injectable `httpDoer`; credential
+  round-trip via `tokenstore.UseFileBackendForTesting` (never the real keychain).
+- **Real keychain:** in-process `go test` deliberately cannot reach it (test
+  safety), so it is verified by running the **binary** without the file backend;
+  `revoke-token` gives a clean teardown:
+
+  ```bash
+  entire ticket setup --platform linear --team ENG --token <key>   # → keychain
+  entire ticket status                                             # Credential: present
+  entire ticket revoke-token                                       # remove it
+  ```
+
+> **TODO — not yet covered:** e2e against a live tracker; write-back paths.
+
+---
+
+## Failure cases
+
+| Case | Behavior |
+|---|---|
+| No platform configured | error → "run `entire ticket setup`" |
+| Missing/invalid credential | fetch fails → best-effort fallback (id-only prompt / stored status) |
+| Ticket not found | `Fetch` errors; `start`/`status` degrade |
+| Detached HEAD | `currentBranch` errors clearly |
+| Branch already exists | `start` switches to it |
+| Network down / Linear outage | best-effort; command still completes |
+| Keychain unavailable (headless Linux) | `setup`/load fails → use `ENTIRE_TOKEN_STORE=file` |
+| Linear schema/permission change | fetch errors surface the API message |
+
+---
+
+## Security
+
+- **Credential** in the OS keychain (macOS / Windows / Linux Secret Service) via
+  `tokenstore`; **never** in settings, logs, or git. The `file` backend is
+  plaintext — test/headless only.
+- Personal API keys are powerful (they act as the user); `revoke-token` removes
+  the local copy — rotate in Linear on exposure.
+- **Untrusted content — bounded risk.** A ticket body is technically
+  attacker-influenceable external input, but the blast radius is small here: the
+  user supplies their *own* API key for their *own* tracker, and agent launch is
+  off, so no untrusted text reaches an agent today. When launch ships, ticket
+  content should still be treated as untrusted and run under the same guardrails
+  as issue-seeded `investigate` runs.
+- **Branch names** derived from ticket/user input are passed to `git switch`;
+  the slug path sanitizes, but provider-supplied names should be validated.
+
+---
+
+## Observability
+
+**Logging (done).** `logging.Debug` is emitted on ticket link, fetch (success +
+duration and failure), drift detection, and branch create/switch — operational
+metadata only (platform, ticket id, branch, counts, duration), never ticket
+content, per the logging privacy rule. Written to `.entire/logs/`.
+
+**Telemetry — none today, *because the command is hidden*.** The CLI already
+emits command-usage telemetry from `root.go`'s post-run for every **visible**
+command (gated on the user's telemetry setting), but it **deliberately skips
+hidden commands** (it walks the parent chain and returns if any ancestor sets
+`Hidden`). Since `entire ticket` is `Hidden: true` while it matures, it emits
+**no telemetry yet** — and it will start automatically, with no extra code, the
+moment the command is unhidden. A bespoke per-action event (e.g. "ticket
+linked") is only worth adding once the feature is public and we know which
+metrics matter.
+
+---
+
+## Rollout & compatibility
+
+Hidden during maturation. **In plain terms: nothing old breaks.** Every new
+settings/link field is optional, so files written by an older CLI still load;
+and the credential is stored under a new, dedicated name (`entire-ticket:…`), so
+it can't collide with any credential the CLI already stores.
+
+---
+
+## Alternatives considered
+
+- **Ship as an external plugin** — deferred; native fits a maturing feature and
+  reuses `LaunchFix`/checkpoints directly.
+- **Store ticket content in settings** — rejected (secret/size/committed).
+- **Always live, never persist** — rejected (no drift detection, worse offline).
+
+---
+
+## Current state
+
+**Hidden during maturation** — like `review` and `investigate`, the whole
+`ticket` family is `Hidden: true`, so it doesn't appear in `entire help` yet.
+Every command still runs when invoked directly. Unhiding is a one-line change
+once the surface is stable; command-usage telemetry then turns on automatically
+(see [Observability](#observability)).
+
+**Built:** `setup`, `status`, `link` / `unlink`, `start` (branch creation +
+prompt), `revoke-token`, the Linear provider, snapshot + drift detection,
+`--json` status, **checkpoint-level capture** (the linked ticket is frozen
+into each committed checkpoint's metadata on `entire/checkpoints/v1`), and the
+**observe-only read surfaces** that display it (`checkpoint explain`,
+`entire status`, `session info`, and `review` grounding — see
+[Read surfaces](#read-surfaces-observe-only)) — all unit- and
+integration-tested and lint-clean.
+
+**Not built (deliberate):** write-back. The provider's `Comment` / `SetState`
+mutations are implemented but unwired — no lifecycle trigger calls them yet, so
+the tracker is never mutated. Closing the loop is the next slice, not this one.
+
+---
+
+## Open questions
+
+- Drift refresh cadence (every fetch vs. an explicit `sync`).
+- Team-shared vs. local link state.
+- Write-back triggers & safety: which lifecycle events fire `Comment` /
+  `SetState` (PR open / review pass / merge), how state names map per team, and
+  how drift (ticket changed since capture) gates a status move.
+
+---
+
+## Roadmap
+
+1. **Ship the command surface** *(done)* — link, context, status.
+2. **Capture into checkpoint context** *(done)* — the ticket snapshot is frozen
+   into each committed checkpoint's metadata on `entire/checkpoints/v1`, giving
+   **ticket versioning for free** (checkpoint chain = ticket timeline).
+3. **Surface it (read side)** *(done)* — observe-only display across
+   `checkpoint explain`, `entire status`, `session info`, and review grounding
+   (see [Read surfaces](#read-surfaces-observe-only)).
+4. **Write-back** *(next)* — wire the already-implemented `Comment` / `SetState`
+   into a lifecycle trigger. Sequenced low-risk first: (a) idempotent
+   comment-back on PR open (post PR link + grounded checkpoint ids), then
+   (b) gated status transitions (→ In Review / Done) behind explicit config, a
+   per-team state map, and a drift guard that refuses to clobber a ticket that
+   changed since capture.
+5. **More providers** — Jira, GitHub Issues, Asana, ClickUp, Azure Boards via
+   the `Provider` interface (each ~an adapter).
+6. **GitHub-like connection** — deeper PR ↔ ticket wiring, status automation.

--- a/docs/architecture/ticket.md
+++ b/docs/architecture/ticket.md
@@ -1,0 +1,87 @@
+# `entire ticket`
+
+Experimental command for linking a repository branch to a tracker ticket
+(Linear today) and carrying the ticket's intent into agent context, reviews, and
+checkpoint provenance.
+
+> Hidden while it matures — every subcommand still runs when invoked directly.
+
+## Basic use
+
+```sh
+entire ticket setup            # pick a platform + team, store an API key securely
+entire ticket start <id>       # make a branch, link the ticket, prep the prompt
+entire ticket link [<id>]      # link a ticket to the current branch (any time)
+entire ticket unlink           # remove the link from the current branch
+entire ticket status           # show config, credential, linked ticket + drift
+entire ticket revoke-token     # remove the stored credential
+```
+
+Useful flags:
+
+```sh
+entire ticket setup --platform linear --team ENG --token <key>   # non-interactive
+entire ticket start ENG-142 --branch feature/eng-142             # name the branch
+entire ticket start ENG-142 --no-branch                          # stay on current branch
+entire ticket link ENG-142 --force                               # relink to a different ticket
+entire ticket status --json                                      # machine-readable
+```
+
+`id` is auto-detected from the branch name when omitted. You can link a ticket
+**before, during, or after** the work — the pointer is durable.
+
+## Storage
+
+A ticket link is a per-branch pointer; the ticket content is fetched live each
+time. Three local stores plus one remote:
+
+- `.entire/settings.json` — platform + team (per repo, committed).
+- **OS keychain** — the API credential (via `tokenstore`; never in settings,
+  logs, or git). Headless/CI can fall back with `ENTIRE_TOKEN_STORE=file`.
+- `.git/entire-tickets/links.json` — branch → link + last-seen snapshot (in the
+  git common dir, shared across worktrees).
+- **Linear API** — the live ticket, reached only through the `Provider`
+  interface so the surface stays tracker-agnostic.
+
+## Behavior
+
+- **Best-effort, never blocking.** Every remote step degrades gracefully — a
+  fetch failure falls back to an id-only prompt (`start`) or stored state
+  (`status`); the command still completes.
+- **Live + snapshot.** Content is re-fetched on demand and compared against the
+  last-seen snapshot, so `status` flags **drift** when the ticket changed
+  mid-work.
+- **Observe-only reads.** Once captured, the ticket surfaces (read-only) across
+  the CLI — it never mutates the tracker:
+
+  | Surface | Source | Shows |
+  | --- | --- | --- |
+  | `checkpoint explain` | frozen `Metadata.Ticket` | `ticket` header row + URL (`--json` gains a `ticket` object) |
+  | `entire status` | live link (current branch) | a `Ticket ·` line under the branch (`--json` field) |
+  | `entire session info` | live link (session's branch) | a `Ticket:` row (`--json` field) |
+  | `entire review` | live link (current branch) | prepends the linked ticket as reviewer grounding |
+
+  `explain` reads the *captured* snapshot (durable provenance); the other three
+  read the *current* link. `session list` is excluded (one card per session).
+
+- **Checkpoint capture.** On commit, the linked ticket is frozen into each
+  committed checkpoint's `metadata.json` on `entire/checkpoints/v1`, so the
+  checkpoint chain doubles as the ticket's timeline.
+
+## Not built (deliberate)
+
+- **Write-back** — `Comment` / `SetState` are implemented on the provider but
+  unwired; no lifecycle event mutates the tracker yet. This is the next slice.
+- **Agent launch on `start`** — prepared but off (cost); `start` prints the
+  prompt instead.
+
+## Key files
+
+- `cmd/entire/cli/ticket/` — command group (`setup`, `link`, `start`, `status`,
+  `revoke-token`), the `Provider` interface, the Linear client, link store, and
+  snapshot/drift logic.
+- `cmd/entire/cli/ticket_bridge.go` — deps bridge (avoids an import cycle).
+- `cmd/entire/cli/ticket_display.go` — shared render helpers for the read
+  surfaces (`formatTicketRefLine` / `formatTicketLinkLine` / `ticketBriefFromLink`).
+- `api/checkpoint/metadata.go` — `TicketRef` frozen into checkpoint metadata.
+- `settings.TicketConfig` · `internal/entireclient/tokenstore`.


### PR DESCRIPTION
## Overview

`entire ticket` links an external tracker ticket (Linear today, Jira-ready) to a branch and session, so work stays grounded in its original intent — and freezes that ticket into checkpoint provenance so the checkpoint chain becomes the ticket's timeline, surfaced across `status`, `session info`, `explain`, and `review`.

The command group is platform-agnostic: every tracker implements one `Provider` interface and registers with a single `switch` case, so adding Jira later never touches the command surface.

## What's in it

- **Commands:** `entire ticket setup` (store platform + team + API token in the OS keychain), `link` / `unlink`, `start` (ticket → new branch + grounding prompt), `status` (live title/state + drift since last sync), `revoke-token`.
- **Provider:** a Linear implementation (GraphQL) behind the shared `Provider` seam.
- **Provenance:** at condensation the branch's linked ticket (id + snapshot) is frozen into per-session checkpoint metadata on `entire/checkpoints/v1` — best-effort and offline, so a checkpoint is never blocked by ticket state.
- **Read surfaces:** the linked/frozen ticket is rendered in `entire status`, `session info`, `checkpoint explain`, and prepended to the reviewer's context in `entire review` (grounding the review against the original intent).
- **Docs:** a user-facing command reference plus the tech spec.

## How to review — this is a 14-part stack

I don't have push access to `entireio/cli`, so the stacked branches can't live here; this is the whole feature as **one PR (14 clean commits, each an additive slice)**. It's split into 14 stacked PRs on my fork for per-slice review — same commits, reviewable one at a time:

- [#1] feat(ticket): base entire ticket command group [1/14] — https://github.com/Mohit-Katyal/cli/pull/1
- [#2] feat(ticket): entire ticket setup [2/14] — https://github.com/Mohit-Katyal/cli/pull/2
- [#3] feat(ticket): entire ticket link and unlink [3/14] — https://github.com/Mohit-Katyal/cli/pull/3
- [#4] feat(ticket): entire ticket start — scaffold + branch creation [4/14] — https://github.com/Mohit-Katyal/cli/pull/4
- [#5] feat(ticket): entire ticket status with snapshot drift [5/14] — https://github.com/Mohit-Katyal/cli/pull/5
- [#6] feat(ticket): entire ticket revoke-token [6/14] — https://github.com/Mohit-Katyal/cli/pull/6
- [#7] feat(ticket): Linear provider — additive leaf [7/14] — https://github.com/Mohit-Katyal/cli/pull/7
- [#9] feat(ticket): capture linked ticket into checkpoint provenance [8/14] — https://github.com/Mohit-Katyal/cli/pull/9
- [#10] feat(ticket): ticket-display helpers for CLI surfaces [9/14] — https://github.com/Mohit-Katyal/cli/pull/10
- [#11] feat(ticket): surface captured ticket in checkpoint explain [10/14] — https://github.com/Mohit-Katyal/cli/pull/11
- [#12] feat(ticket): surface linked ticket in entire status [11/14] — https://github.com/Mohit-Katyal/cli/pull/12
- [#13] feat(ticket): surface linked ticket in session info [12/14] — https://github.com/Mohit-Katyal/cli/pull/13
- [#14] feat(ticket): ground review context in linked ticket [13/14] — https://github.com/Mohit-Katyal/cli/pull/14
- [#16] docs(ticket): concise entire ticket command reference [14/14] — https://github.com/Mohit-Katyal/cli/pull/16

Each commit here maps 1:1 to a fork PR. Happy to push the branches as a real stack if a maintainer would rather review/merge that way (or grant access).

## Testing

- `go build ./...` clean; `mise run lint` 0 issues.
- `ticket`, `cli`, and `strategy` unit suites pass; integration `TestShadow_TicketProvenance` proves the ticket lands in committed checkpoint metadata end-to-end.
- Rebased cleanly onto current `main` and re-verified.

## Scope / notes

- Agent launch from `start` is deferred (prints the grounding prompt; launcher stays wired via `Deps.LaunchFix`).
- The credential is stored only in the OS keychain, never in settings; `revoke-token` is local-only (Linear keys are revoked in Linear).

🤖 Generated with Claude Code
