### PR TITLE
test: git-remote coverage (2/4) — real-hook P0 tests, cross-machine fetch, explain fix

### DIFF
--- a/cmd/entire/cli/attribution.go
+++ b/cmd/entire/cli/attribution.go
@@ -571,11 +571,14 @@ func (r *attributionResolver) fetchCheckpointContext(cpID id.CheckpointID, file 
 	}
 	defer lookup.Close()
 
-	matches, fresh := matchCheckpointPrefixWithRemoteFallback(r.ctx, io.Discard, lookup, cpID.String())
+	matches, fresh, fallbackErr := matchCheckpointPrefixWithRemoteFallback(r.ctx, io.Discard, lookup, cpID.String())
 	if fresh != lookup {
 		defer fresh.Close()
 	}
 	if len(matches) != 1 {
+		if fallbackErr != nil {
+			return attributionCheckpointContext{}, fallbackErr
+		}
 		return attributionCheckpointContext{}, checkpoint.ErrCheckpointNotFound
 	}
 

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -599,7 +599,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	}()
 
 	// Match the prefix locally; on miss, fetch from remote and retry once.
-	matches, lookup := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, checkpointIDPrefix)
+	matches, lookup, fallbackErr := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, checkpointIDPrefix)
 
 	var fullCheckpointID id.CheckpointID
 	switch len(matches) {
@@ -630,6 +630,12 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 			}
 			outputExplainContent(w, output, noPager)
 			return nil
+		}
+		// The prefix matched nothing locally (including temp checkpoints) and
+		// the remote fetch failed: report the fetch failure, not "not found" —
+		// the checkpoint may well exist on a reachable remote.
+		if fallbackErr != nil {
+			return fmt.Errorf("checkpoint %s not found locally; fetching from remote failed: %w", checkpointIDPrefix, fallbackErr)
 		}
 		return fmt.Errorf("%w: %s", checkpoint.ErrCheckpointNotFound, checkpointIDPrefix)
 	case 1:

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
@@ -110,7 +111,7 @@ func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explai
 		return id.CheckpointID(""), nil, lookupErr
 	}
 
-	matches, resolvedLookup := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, prefix)
+	matches, resolvedLookup, fallbackErr := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, prefix)
 	if resolvedLookup != lookup {
 		_ = lookup.Close()
 		lookup = resolvedLookup
@@ -128,6 +129,9 @@ func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explai
 				_ = lookup.Close()
 				return cpID, freshLookup, nil
 			}
+		}
+		if fallbackErr != nil {
+			return id.CheckpointID(""), lookup, fmt.Errorf("checkpoint %s not found locally; fetching from remote failed: %w", prefix, fallbackErr)
 		}
 		return id.CheckpointID(""), lookup, fmt.Errorf("%w: %s", checkpoint.ErrCheckpointNotFound, prefix)
 	default:
@@ -166,9 +170,12 @@ func resolveCheckpointFromCommitRef(ctx context.Context, errW io.Writer, commitR
 
 	// If the trailer points at a checkpoint we don't have locally, do the
 	// same remote-fetch retry the prefix path uses; otherwise downstream
-	// metadata reads would fail with an immediate "not found".
+	// metadata reads would fail with an immediate "not found". A fetch error
+	// is deliberately ignored here: this is an opportunistic prefetch, and the
+	// downstream store read surfaces real fetch failures with the correct
+	// absent-vs-error semantics.
 	if !lookupHasCheckpoint(lookup, cpID) {
-		if matches, fresh := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, cpID.String()); len(matches) == 1 {
+		if matches, fresh, _ := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, cpID.String()); len(matches) == 1 { //nolint:errcheck // opportunistic prefetch; downstream store read surfaces real fetch failures
 			if fresh != lookup {
 				_ = lookup.Close()
 			}
@@ -192,11 +199,15 @@ func lookupHasCheckpoint(lookup *explainCheckpointLookup, cpID id.CheckpointID) 
 // matchCheckpointPrefixWithRemoteFallback returns all committed checkpoints
 // whose ID starts with prefix. On a local miss, fetches metadata from the
 // remote (treeless origin → full origin chain) and retries once with a fresh
-// lookup. The returned lookup may differ from the input on retry.
-func matchCheckpointPrefixWithRemoteFallback(ctx context.Context, errW io.Writer, lookup *explainCheckpointLookup, prefix string) ([]id.CheckpointID, *explainCheckpointLookup) {
+// lookup. The returned lookup may differ from the input on retry. A non-nil
+// error means the remote fetch (or the post-fetch re-list) failed for real —
+// callers must surface it instead of reporting "checkpoint not found", which
+// would tell the user the checkpoint doesn't exist when it may well exist on
+// a reachable remote (regression class 7bbdad09c).
+func matchCheckpointPrefixWithRemoteFallback(ctx context.Context, errW io.Writer, lookup *explainCheckpointLookup, prefix string) ([]id.CheckpointID, *explainCheckpointLookup, error) {
 	matches := matchCheckpointPrefix(lookup, prefix)
 	if len(matches) > 0 {
-		return matches, lookup
+		return matches, lookup, nil
 	}
 
 	// git-refs primary: there is no single metadata branch to fetch — each
@@ -210,21 +221,30 @@ func matchCheckpointPrefixWithRemoteFallback(ctx context.Context, errW io.Writer
 			// rather than fetch a malformed ref.
 			refName, refErr := checkpoint.RefName(cid)
 			if refErr != nil {
-				return nil, lookup
+				return nil, lookup, nil //nolint:nilerr // defensive: fall through to not-found rather than fetch a malformed ref
+			}
+			// No resolvable checkpoint source (e.g. a repo with no remote):
+			// local absence is authoritative, so report not-found rather than
+			// attempting a fetch that can only fail with a confusing error.
+			if _, urlErr := remote.FetchURL(ctx); urlErr != nil {
+				return nil, lookup, nil //nolint:nilerr // no remote to consult; local absence is authoritative
 			}
 			stop := startSpinner(errW, "Fetching checkpoint from remote")
 			fetchErr := FetchCheckpointRef(ctx, refName)
 			stop(false)
-			if fetchErr == nil {
-				if fresh, freshErr := newExplainCheckpointLookup(ctx); freshErr == nil {
-					if m := matchCheckpointPrefix(fresh, prefix); len(m) > 0 {
-						return m, fresh
-					}
-					_ = fresh.Close()
-				}
+			if fetchErr != nil {
+				return nil, lookup, fetchErr
 			}
+			fresh, freshErr := newExplainCheckpointLookup(ctx)
+			if freshErr != nil {
+				return nil, lookup, freshErr
+			}
+			if m := matchCheckpointPrefix(fresh, prefix); len(m) > 0 {
+				return m, fresh, nil
+			}
+			_ = fresh.Close()
 		}
-		return nil, lookup
+		return nil, lookup, nil
 	}
 
 	stop := startSpinner(errW, "Fetching checkpoint metadata from remote")
@@ -234,13 +254,13 @@ func matchCheckpointPrefixWithRemoteFallback(ctx context.Context, errW io.Writer
 	}
 	stop(false)
 	if v1Err != nil {
-		return nil, lookup
+		return nil, lookup, nil //nolint:nilerr // v1-branch fallback keeps its historical fail-soft behavior (see plan B-group)
 	}
 	fresh, freshErr := newExplainCheckpointLookup(ctx)
 	if freshErr != nil {
-		return nil, lookup
+		return nil, lookup, nil //nolint:nilerr // v1-branch fallback keeps its historical fail-soft behavior (see plan B-group)
 	}
-	return matchCheckpointPrefix(fresh, prefix), fresh
+	return matchCheckpointPrefix(fresh, prefix), fresh, nil
 }
 
 func matchCheckpointPrefix(lookup *explainCheckpointLookup, prefix string) []id.CheckpointID {

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -476,7 +476,8 @@ func resolveCheckpointFetchTarget(ctx context.Context) string {
 // FetchCheckpointRef fetches a single per-checkpoint ref (refs/entire/checkpoints/
 // <shard>/<id>) from the checkpoint remote into the local ref of the same name,
 // so the git-refs store can resolve a checkpoint written on another machine.
-// Best-effort: the caller treats a fetch failure as "checkpoint not found".
+// Callers must surface a fetch failure as a real error, not "checkpoint not
+// found" — the checkpoint may exist on a remote we simply could not reach.
 func FetchCheckpointRef(ctx context.Context, ref plumbing.ReferenceName) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()

--- a/cmd/entire/cli/integration_test/backend.go
+++ b/cmd/entire/cli/integration_test/backend.go
@@ -114,7 +114,9 @@ func (env *TestEnv) RemoteCheckpointState(bareDir string) string {
 	cmd.Env = testutil.GitIsolatedEnv()
 	out, err := cmd.Output()
 	if err != nil {
-		return ""
+		// Fail rather than return "": two broken invocations comparing equal
+		// would make an idempotence assertion pass vacuously.
+		env.T.Fatalf("RemoteCheckpointState: git for-each-ref %s in %s failed: %v", prefix, bareDir, err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
 	sort.Strings(lines)

--- a/cmd/entire/cli/integration_test/backend.go
+++ b/cmd/entire/cli/integration_test/backend.go
@@ -1,0 +1,144 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// Checkpoint storage backends the integration suite can run against. Selected
+// per-subtest by ForEachBackend, which sets TestEnv.CheckpointStore so every
+// spawned CLI/hook inherits ENTIRE_CHECKPOINTS_PRIMARY. The backend-aware
+// assertion helpers below mirror e2e/testutil/backend.go so the same test asserts
+// against either the single v1 branch (git-branch) or the per-checkpoint refs
+// (git-refs).
+const (
+	StoreGitBranch = "git-branch"
+	StoreGitRefs   = "git-refs"
+
+	// checkpointRefPrefix is the git-refs namespace for per-checkpoint refs.
+	checkpointRefPrefix = "refs/entire/checkpoints/"
+)
+
+// ForEachBackend runs fn as a subtest for each checkpoint backend ("git-branch"
+// and "git-refs"). Each subtest runs in parallel and receives the backend name;
+// the closure constructs its TestEnv and assigns env.CheckpointStore = backend
+// before any checkpoint-creating operation. Prefer the backend-aware assertion
+// helpers (CheckpointsPresentLocally, CheckpointsPresentOnRemote, …) inside fn so
+// the assertions hold for both topologies.
+func ForEachBackend(t *testing.T, fn func(t *testing.T, backend string)) {
+	t.Helper()
+	for _, backend := range []string{StoreGitBranch, StoreGitRefs} {
+		t.Run(backend, func(t *testing.T) {
+			t.Parallel()
+			fn(t, backend)
+		})
+	}
+}
+
+// usingGitRefs reports whether the env's selected backend is the per-checkpoint
+// git-refs store. An empty CheckpointStore is the CLI default (git-branch).
+func (env *TestEnv) usingGitRefs() bool {
+	return env.CheckpointStore == StoreGitRefs
+}
+
+// LatestCheckpointID returns the most recent checkpoint ID in a backend-aware
+// way: from the v1 branch commit message (git-branch) or from the code commit's
+// Entire-Checkpoint trailer (git-refs, where there is no v1 commit to parse).
+// The trailer is written for both backends, so the git-refs path also works for
+// git-branch — the split keeps each backend on its established reader.
+func (env *TestEnv) LatestCheckpointID() string {
+	env.T.Helper()
+	if env.usingGitRefs() {
+		return env.GetLatestCheckpointIDFromHistory()
+	}
+	return env.GetLatestCheckpointID()
+}
+
+// checkpointRefName returns refs/entire/checkpoints/<shard>/<id> for a checkpoint.
+func checkpointRefName(checkpointID string) string {
+	return checkpointRefPrefix + id.CheckpointID(checkpointID).ShardFor() + "/" + checkpointID
+}
+
+// CheckpointsPresentLocally reports whether any committed checkpoint exists in the
+// repo: the v1 branch (git-branch) or at least one per-checkpoint ref (git-refs).
+func (env *TestEnv) CheckpointsPresentLocally() bool {
+	env.T.Helper()
+	if env.usingGitRefs() {
+		return anyRefUnderPrefix(env.T, env.RepoDir, checkpointRefPrefix)
+	}
+	return env.BranchExists(paths.MetadataBranchName)
+}
+
+// CheckpointsPresentOnRemote reports whether any committed checkpoint landed on
+// the bare remote: the v1 branch (git-branch) or at least one per-checkpoint ref
+// (git-refs).
+func (env *TestEnv) CheckpointsPresentOnRemote(bareDir string) bool {
+	env.T.Helper()
+	if env.usingGitRefs() {
+		return anyRefUnderPrefix(env.T, bareDir, checkpointRefPrefix)
+	}
+	return env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName)
+}
+
+// CheckpointExistsOnRemote reports whether a specific checkpoint landed on the
+// bare remote: its metadata blob in the v1 tree (git-branch) or its per-checkpoint
+// ref (git-refs).
+func (env *TestEnv) CheckpointExistsOnRemote(bareDir, checkpointID string) bool {
+	env.T.Helper()
+	if env.usingGitRefs() {
+		return refExists(env.T, bareDir, checkpointRefName(checkpointID))
+	}
+	return fileExistsOnRemoteBranch(env.T, bareDir, CheckpointSummaryPath(checkpointID))
+}
+
+// RemoteCheckpointState returns a digest of the committed checkpoint state on the
+// bare remote that changes whenever a checkpoint is pushed. Backend-aware: the v1
+// branch tip (git-branch) or the sorted set of per-checkpoint refs and their
+// objects (git-refs). Used to assert idempotent pushes leave the remote unchanged.
+func (env *TestEnv) RemoteCheckpointState(bareDir string) string {
+	env.T.Helper()
+	prefix := "refs/heads/" + paths.MetadataBranchName
+	if env.usingGitRefs() {
+		prefix = checkpointRefPrefix
+	}
+	cmd := exec.CommandContext(env.T.Context(), "git", "for-each-ref", "--format=%(refname) %(objectname)", prefix)
+	cmd.Dir = bareDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}
+
+// anyRefUnderPrefix reports whether the repo at dir has any ref under prefix.
+func anyRefUnderPrefix(t *testing.T, dir, prefix string) bool {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "for-each-ref", "--format=%(refname)", prefix)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
+}
+
+// refExists reports whether the exact ref exists in the repo at dir.
+func refExists(t *testing.T, dir, ref string) bool {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "show-ref", "--verify", "--quiet", ref)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	return cmd.Run() == nil
+}

--- a/cmd/entire/cli/integration_test/explain_test.go
+++ b/cmd/entire/cli/integration_test/explain_test.go
@@ -202,72 +202,61 @@ func TestExplain_BranchListingShowsCheckpointsAndPrompts(t *testing.T) {
 }
 
 // TestExplain_CheckpointFetchesFromRemoteWhenMissingLocally verifies that
-// explain --checkpoint fetches metadata from the remote when the
-// entire/checkpoints/v1 branch doesn't exist locally (e.g., reviewing
-// someone else's PR).
+// explain --checkpoint fetches checkpoint data from the remote when it doesn't
+// exist locally (e.g., reviewing someone else's PR). Under git-branch this is
+// the v1 branch fetch; under git-refs it is the on-demand per-checkpoint
+// RefFetcher path.
 func TestExplain_CheckpointFetchesFromRemoteWhenMissingLocally(t *testing.T) {
 	t.Parallel()
-	env := NewFeatureBranchEnv(t)
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
 
-	// Set up bare remote
-	env.SetupBareRemote()
+		// Set up bare remote
+		env.SetupBareRemote()
 
-	// Create a session, make changes, checkpoint, and commit (triggers condensation)
-	session := env.NewSession()
-	transcriptPath := session.CreateTranscript("Add feature module", []FileChange{
-		{Path: "feature.go", Content: "package feature"},
+		// Create a session, make changes, checkpoint, and commit (triggers condensation)
+		checkpointID := createCheckpointedCommit(t, env, "Add feature module", "feature.go", "package feature", "Add feature module")
+		if checkpointID == "" {
+			t.Fatal("should have a checkpoint ID after condensation")
+		}
+
+		// Push checkpoint data to remote
+		env.RunPrePush("origin")
+
+		// Delete the local checkpoint (and remote-tracking ref, git-branch only) to
+		// simulate a collaborator's repo that has never fetched the checkpoint.
+		repo, err := git.PlainOpen(env.RepoDir)
+		require.NoError(t, err)
+		if env.usingGitRefs() {
+			ref := plumbing.ReferenceName(checkpointRefName(checkpointID))
+			_ = repo.Storer.RemoveReference(ref)
+			_, err = repo.Storer.Reference(ref)
+			require.ErrorIs(t, err, plumbing.ErrReferenceNotFound, "local checkpoint ref should be absent")
+		} else {
+			localRef := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+			remoteRef := plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName)
+			_ = repo.Storer.RemoveReference(localRef)
+			_ = repo.Storer.RemoveReference(remoteRef)
+			_, err = repo.Storer.Reference(localRef)
+			require.ErrorIs(t, err, plumbing.ErrReferenceNotFound, "local metadata ref should be absent")
+			_, err = repo.Storer.Reference(remoteRef)
+			require.ErrorIs(t, err, plumbing.ErrReferenceNotFound, "remote-tracking metadata ref should be absent")
+		}
+
+		// This should succeed by fetching the checkpoint from the remote
+		output := env.RunCLI("checkpoint", "explain", "--checkpoint", checkpointID)
+
+		// Verify the output contains checkpoint content (prompt text)
+		if !strings.Contains(output, "Add feature module") {
+			t.Errorf("expected output to contain prompt text, got:\n%s", output)
+		}
 	})
-
-	if err := env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(session.ID, "Add feature module", transcriptPath); err != nil {
-		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
-	}
-
-	env.WriteFile("feature.go", "package feature")
-	env.GitAdd("feature.go")
-
-	if err := env.SimulateStop(session.ID, transcriptPath); err != nil {
-		t.Fatalf("SimulateStop failed: %v", err)
-	}
-
-	// Commit with hooks (triggers prepare-commit-msg + post-commit = condensation)
-	env.GitCommitWithShadowHooks("Add feature module", "feature.go")
-
-	// Get the checkpoint ID before we delete the local branch
-	checkpointID := env.GetLatestCheckpointID()
-	if checkpointID == "" {
-		t.Fatal("should have a checkpoint ID after condensation")
-	}
-
-	// Push checkpoint data to remote
-	env.RunPrePush("origin")
-
-	// Delete local metadata branch and remote-tracking ref to simulate
-	// a collaborator's repo that has never fetched the metadata branch.
-	// RemoveReference may fail if the remote-tracking ref was never
-	// populated; we tolerate that but assert absence below so the test
-	// actually exercises the "fetch from remote when missing" path.
-	repo, err := git.PlainOpen(env.RepoDir)
-	require.NoError(t, err)
-
-	localRef := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
-	remoteRef := plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName)
-	_ = repo.Storer.RemoveReference(localRef)
-	_ = repo.Storer.RemoveReference(remoteRef)
-
-	_, err = repo.Storer.Reference(localRef)
-	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound, "local metadata ref should be absent")
-	_, err = repo.Storer.Reference(remoteRef)
-	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound, "remote-tracking metadata ref should be absent")
-
-	// This should succeed by fetching metadata from the remote
-	output := env.RunCLI("checkpoint", "explain", "--checkpoint", checkpointID)
-
-	// Verify the output contains checkpoint content (prompt text)
-	if !strings.Contains(output, "Add feature module") {
-		t.Errorf("expected output to contain prompt text, got:\n%s", output)
-	}
 }
 
+// git-branch only: asserts the local v1 branch tip hash is unchanged by
+// fetch-on-miss (the branch is the unit of divergence). The git-refs equivalent
+// (per-checkpoint refs never rewound) is separate future work (test plan D2).
 func TestExplain_CheckpointFetchDoesNotRewindLocalAheadBranch(t *testing.T) {
 	t.Parallel()
 	env := NewFeatureBranchEnv(t)
@@ -330,6 +319,9 @@ func TestExplain_CheckpointFetchDoesNotRewindLocalAheadBranch(t *testing.T) {
 		"locally-committed checkpoint must remain discoverable after fetch-on-miss")
 }
 
+// git-branch only: seeds a treeless clone of the v1 branch (refspec targets
+// refs/heads/entire/checkpoints/v1). The git-refs partial-clone equivalent is
+// separate future work (test plan C6).
 func TestExplain_CheckpointSucceedsAfterTreelessFetch(t *testing.T) {
 	t.Parallel()
 	env := NewFeatureBranchEnv(t)

--- a/cmd/entire/cli/integration_test/hermeticity_test.go
+++ b/cmd/entire/cli/integration_test/hermeticity_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// TestHermeticityGuard_ExternalHostFailsFast proves the TestMain hermeticity
+// tripwire fires: a git command that dials a real external host is redirected to
+// an unroutable loopback address and fails fast, without reaching the network or
+// prompting for credentials. Regression class: tests accidentally hitting live
+// github.com / the macOS keychain (#1463, 53bc37a88).
+func TestHermeticityGuard_ExternalHostFailsFast(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+
+	// ls-remote against a public-looking github URL must be refused immediately
+	// by the insteadOf redirect to 127.0.0.1:1, not hang on DNS/network or block
+	// on a credential prompt.
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "https://github.com/example/example")
+	cmd.Env = testutil.GitIsolatedEnv()
+
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected ls-remote to fail under the hermeticity guard, but it succeeded:\n%s", out)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("ls-remote did not fail fast (timed out after %s); the guard should refuse it immediately:\n%s", elapsed, out)
+	}
+	// The redirect target is the loopback refusal address, confirming the rewrite
+	// (not a real github.com dial) produced the failure.
+	if !strings.Contains(string(out), "127.0.0.1") {
+		t.Errorf("expected failure to mention the loopback redirect target 127.0.0.1, got:\n%s", out)
+	}
+}

--- a/cmd/entire/cli/integration_test/hermeticity_test.go
+++ b/cmd/entire/cli/integration_test/hermeticity_test.go
@@ -24,8 +24,9 @@ func TestHermeticityGuard_ExternalHostFailsFast(t *testing.T) {
 	defer cancel()
 
 	// ls-remote against a public-looking github URL must be refused immediately
-	// by the insteadOf redirect to 127.0.0.1:1, not hang on DNS/network or block
-	// on a credential prompt.
+	// by the per-host http.<url>.proxy entries pointing at the dead loopback
+	// address (see testutil.hermeticGitConfig), not hang on DNS/network or
+	// block on a credential prompt.
 	cmd := exec.CommandContext(ctx, "git", "ls-remote", "https://github.com/example/example")
 	cmd.Env = testutil.GitIsolatedEnv()
 

--- a/cmd/entire/cli/integration_test/http_remote_test.go
+++ b/cmd/entire/cli/integration_test/http_remote_test.go
@@ -203,42 +203,45 @@ func assertRemoteHasCheckpointCommit(t *testing.T, bareDir, checkpointID string)
 func TestHTTPS_PushCheckpointBranchToRemote(t *testing.T) {
 	t.Parallel()
 
-	srv := startGitHTTPSServer(t, "testorg/main-repo")
-	env := NewFeatureBranchEnv(t)
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		srv := startGitHTTPSServer(t, "testorg/main-repo")
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
 
-	httpsURL := srv.URL + "/testorg/main-repo.git"
-	seedBareRepo(t, env, srv.BareDirs["testorg/main-repo"], httpsURL)
+		httpsURL := srv.URL + "/testorg/main-repo.git"
+		seedBareRepo(t, env, srv.BareDirs["testorg/main-repo"], httpsURL)
 
-	env.ExtraEnv = srv.tokenEnv("test-push-token")
+		env.ExtraEnv = srv.tokenEnv("test-push-token")
 
-	_ = createCheckpointedCommit(t, env, "Add feature", "feature.go", "package feature", "Add feature")
+		checkpointID := createCheckpointedCommit(t, env, "Add feature", "feature.go", "package feature", "Add feature")
 
-	if !env.BranchExists(paths.MetadataBranchName) {
-		t.Fatal("checkpoint branch should exist locally after condensation")
-	}
+		if !env.CheckpointsPresentLocally() {
+			t.Fatal("checkpoints should exist locally after condensation")
+		}
 
-	env.RunPrePush("origin")
+		env.RunPrePush("origin")
 
-	bareDir := srv.BareDirs["testorg/main-repo"]
-	if !env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
-		t.Fatal("checkpoint branch should exist on HTTPS remote after PrePush")
-	}
+		bareDir := srv.BareDirs["testorg/main-repo"]
+		if !env.CheckpointsPresentOnRemote(bareDir) {
+			t.Fatal("checkpoints should exist on HTTPS remote after PrePush")
+		}
 
-	checkpointID := env.GetLatestCheckpointID()
-	if checkpointID == "" {
-		t.Fatal("should have a checkpoint ID after condensation")
-	}
-	summaryPath := CheckpointSummaryPath(checkpointID)
-	if !fileExistsOnRemoteBranch(t, bareDir, summaryPath) {
-		t.Errorf("checkpoint metadata should exist on remote at %s", summaryPath)
-	}
+		if checkpointID == "" {
+			t.Fatal("should have a checkpoint ID after condensation")
+		}
+		if !env.CheckpointExistsOnRemote(bareDir, checkpointID) {
+			t.Errorf("checkpoint %s should exist on HTTPS remote", checkpointID)
+		}
 
-	// 2 commits: "Initialize metadata branch" + "Checkpoint: <id>"
-	commits := listRemoteMetadataCommits(t, bareDir)
-	if len(commits) != 2 {
-		t.Fatalf("expected 2 commits on remote metadata branch, got %d: %v", len(commits), commits)
-	}
-	assertRemoteHasCheckpointCommit(t, bareDir, checkpointID)
+		if !env.usingGitRefs() {
+			// 2 commits: "Initialize metadata branch" + "Checkpoint: <id>"
+			commits := listRemoteMetadataCommits(t, bareDir)
+			if len(commits) != 2 {
+				t.Fatalf("expected 2 commits on remote metadata branch, got %d: %v", len(commits), commits)
+			}
+			assertRemoteHasCheckpointCommit(t, bareDir, checkpointID)
+		}
+	})
 }
 
 // TestHTTPS_CheckpointRemoteRoutesToSeparateRepo verifies that when
@@ -254,6 +257,10 @@ func TestHTTPS_PushCheckpointBranchToRemote(t *testing.T) {
 //   - resolvePushSettings -> PushURL -> deriveCheckpointURLFromInfo (push routing)
 //   - fetchAndRebaseRefCommon with checkpoint URL target (fetch routing)
 //   - tryPushRefCommon retry after rebase (push retry)
+//
+// git-branch only: asserts on v1 commit counts/subjects and the rebased tip's
+// parent count. checkpoint_remote routing and non-FF rebase for git-refs
+// per-checkpoint refs are separate future work (test plan B5/D2, git-refs only).
 func TestHTTPS_CheckpointRemoteRoutesToSeparateRepo(t *testing.T) {
 	t.Parallel()
 
@@ -340,6 +347,10 @@ func TestHTTPS_CheckpointRemoteRoutesToSeparateRepo(t *testing.T) {
 // TestHTTPS_OutOfSyncCheckpointBranchRebases verifies that when two clones
 // push to the same HTTPS remote, the second pusher fetches, rebases its local
 // checkpoint branch, and retries the push successfully.
+//
+// git-branch only: asserts on v1 commit counts and the rebased tip's parent
+// count. The git-refs non-FF fetch+replay+retry equivalent is separate future
+// work (test plan D2/D3, git-refs only).
 func TestHTTPS_OutOfSyncCheckpointBranchRebases(t *testing.T) {
 	t.Parallel()
 
@@ -406,43 +417,50 @@ func TestHTTPS_OutOfSyncCheckpointBranchRebases(t *testing.T) {
 func TestHTTPS_PushFailsWithoutToken(t *testing.T) {
 	t.Parallel()
 
-	srv := startGitHTTPSServer(t, "testorg/main-repo")
-	env := NewFeatureBranchEnv(t)
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		srv := startGitHTTPSServer(t, "testorg/main-repo")
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
 
-	bareDir := srv.BareDirs["testorg/main-repo"]
-	httpsURL := srv.URL + "/testorg/main-repo.git"
-	seedBareRepo(t, env, bareDir, httpsURL)
+		bareDir := srv.BareDirs["testorg/main-repo"]
+		httpsURL := srv.URL + "/testorg/main-repo.git"
+		seedBareRepo(t, env, bareDir, httpsURL)
 
-	// SSL trust only — no token.
-	env.ExtraEnv = srv.sslEnv()
+		// SSL trust only — no token.
+		env.ExtraEnv = srv.sslEnv()
 
-	_ = createCheckpointedCommit(t, env, "Add service", "service.go", "package service", "Add service")
+		checkpointID := createCheckpointedCommit(t, env, "Add service", "service.go", "package service", "Add service")
 
-	if !env.BranchExists(paths.MetadataBranchName) {
-		t.Fatal("checkpoint branch should exist locally after condensation")
-	}
+		if !env.CheckpointsPresentLocally() {
+			t.Fatal("checkpoints should exist locally after condensation")
+		}
 
-	// Push without token — the server returns 401 for receive-pack. PrePush
-	// degrades gracefully (returns nil, logs a warning).
-	env.RunPrePush("origin")
+		// Push without token — the server returns 401 for receive-pack. PrePush
+		// degrades gracefully (returns nil, logs a warning).
+		env.RunPrePush("origin")
 
-	if env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
-		t.Error("checkpoint branch should NOT be on remote without token (401 expected)")
-	}
+		if env.CheckpointsPresentOnRemote(bareDir) {
+			t.Error("checkpoints should NOT be on remote without token (401 expected)")
+		}
 
-	// Now set the token and push again — should succeed.
-	env.ExtraEnv = srv.tokenEnv("valid-token")
-	env.RunPrePush("origin")
+		// Now set the token and push again — should succeed.
+		env.ExtraEnv = srv.tokenEnv("valid-token")
+		env.RunPrePush("origin")
 
-	if !env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
-		t.Fatal("checkpoint branch should be on remote after push with token")
-	}
+		if !env.CheckpointsPresentOnRemote(bareDir) {
+			t.Fatal("checkpoints should be on remote after push with token")
+		}
+		if !env.CheckpointExistsOnRemote(bareDir, checkpointID) {
+			t.Errorf("checkpoint %s should exist on HTTPS remote after token push", checkpointID)
+		}
 
-	// 2 commits: "Initialize metadata branch" + "Checkpoint: <id>"
-	checkpointID := env.GetLatestCheckpointID()
-	commits := listRemoteMetadataCommits(t, bareDir)
-	if len(commits) != 2 {
-		t.Fatalf("expected 2 commits on remote metadata branch, got %d: %v", len(commits), commits)
-	}
-	assertRemoteHasCheckpointCommit(t, bareDir, checkpointID)
+		if !env.usingGitRefs() {
+			// 2 commits: "Initialize metadata branch" + "Checkpoint: <id>"
+			commits := listRemoteMetadataCommits(t, bareDir)
+			if len(commits) != 2 {
+				t.Fatalf("expected 2 commits on remote metadata branch, got %d: %v", len(commits), commits)
+			}
+			assertRemoteHasCheckpointCommit(t, bareDir, checkpointID)
+		}
+	})
 }

--- a/cmd/entire/cli/integration_test/http_remote_test.go
+++ b/cmd/entire/cli/integration_test/http_remote_test.go
@@ -464,3 +464,106 @@ func TestHTTPS_PushFailsWithoutToken(t *testing.T) {
 		}
 	})
 }
+
+// =============================================================================
+// C. Cross-machine clone → fetch (over HTTPS with token)
+// =============================================================================
+
+// TestHTTPS_FetchMetadataBranchIfMissingOnPrePush is test C1: the production
+// fetchMetadataBranchIfMissing path, exercised for real. A clone that lacks the
+// local v1 branch resolves its pre-push settings; because a checkpoint_remote is
+// configured, resolvePushSettings fetches the missing v1 branch from the remote
+// before pushing — so the local branch appears without any manual `git fetch`.
+//
+// It runs over HTTPS because a local-path origin can't derive a checkpoint URL
+// (ParseURL fails and derivation falls back to origin without fetching). git-branch
+// only: it asserts on the v1 branch, which git-refs has no equivalent of.
+func TestHTTPS_FetchMetadataBranchIfMissingOnPrePush(t *testing.T) {
+	t.Parallel()
+
+	srv := startGitHTTPSServer(t, "testorg/main-repo")
+	env := NewFeatureBranchEnv(t)
+
+	mainBare := srv.BareDirs["testorg/main-repo"]
+	httpsURL := srv.URL + "/testorg/main-repo.git"
+	seedBareRepo(t, env, mainBare, httpsURL)
+	env.ExtraEnv = srv.tokenEnv("c1-token")
+
+	// Repo A creates and pushes a checkpoint so the remote has a v1 branch.
+	_ = createCheckpointedCommit(t, env, "Add module", "mod.go", "package mod", "Add module")
+	env.RunPrePush("origin")
+	if !env.BranchExistsOnRemote(mainBare, paths.MetadataBranchName) {
+		t.Fatal("v1 branch should be on the remote after repo A's push")
+	}
+
+	// Clone over HTTPS. A plain clone leaves v1 only as a remote-tracking ref, not
+	// a local branch.
+	clone := cloneFromBareWithHTTPS(t, env, mainBare, httpsURL)
+	clone.ExtraEnv = srv.tokenEnv("c1-token")
+	clone.PatchSettings(map[string]any{
+		"strategy_options": map[string]any{
+			"checkpoint_remote": map[string]any{
+				"provider": "github",
+				"repo":     "testorg/main-repo",
+			},
+		},
+	})
+	if clone.BranchExists(paths.MetadataBranchName) {
+		t.Fatal("clone should not have a local v1 branch before pre-push settings resolution")
+	}
+
+	// Resolving pre-push settings triggers fetchMetadataBranchIfMissing, which
+	// fetches v1 from the checkpoint remote — no manual git fetch.
+	clone.RunPrePush("origin")
+
+	if !clone.BranchExists(paths.MetadataBranchName) {
+		t.Error("local v1 branch should appear after pre-push settings resolution fetched it (fetchMetadataBranchIfMissing)")
+	}
+}
+
+// TestHTTPS_CloneReadAutoFetchesWithToken is test C4: reading a checkpoint from a
+// fresh clone over an authenticated HTTPS remote auto-fetches the checkpoint data
+// with the token. The git-branch path fetches the v1 branch on miss; the git-refs
+// path fetches exactly the per-checkpoint ref via the on-demand RefFetcher. Both
+// require ENTIRE_CHECKPOINT_TOKEN to reach the server.
+func TestHTTPS_CloneReadAutoFetchesWithToken(t *testing.T) {
+	t.Parallel()
+
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		srv := startGitHTTPSServer(t, "testorg/main-repo")
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
+
+		mainBare := srv.BareDirs["testorg/main-repo"]
+		httpsURL := srv.URL + "/testorg/main-repo.git"
+		seedBareRepo(t, env, mainBare, httpsURL)
+		env.ExtraEnv = srv.tokenEnv("c4-token")
+
+		checkpointID := createCheckpointedCommit(t, env, "Add remote feature", "feat.go", "package feat", "Add remote feature")
+		if checkpointID == "" {
+			t.Fatal("should have a checkpoint ID after condensation")
+		}
+		// Push checkpoints into the server (token-authenticated CLI push).
+		env.RunPrePush("origin")
+		if !env.CheckpointExistsOnRemote(mainBare, checkpointID) {
+			t.Fatal("checkpoint should be on the HTTPS remote after push")
+		}
+
+		clone := cloneFromBareWithHTTPS(t, env, mainBare, httpsURL)
+		clone.ExtraEnv = srv.tokenEnv("c4-token")
+		if clone.CheckpointsPresentLocally() {
+			t.Fatalf("[%s] clone should not have the checkpoint locally before a read", backend)
+		}
+
+		// Reading the checkpoint auto-fetches it from the authenticated remote.
+		out := clone.RunCLI("checkpoint", "explain", "--checkpoint", checkpointID)
+		if !strings.Contains(out, "Add remote feature") {
+			t.Errorf("[%s] explain should surface the prompt after auto-fetch, got:\n%s", backend, out)
+		}
+
+		// git-refs lands exactly the per-checkpoint ref locally after the read.
+		if clone.usingGitRefs() && !refExists(t, clone.RepoDir, checkpointRefName(checkpointID)) {
+			t.Errorf("git-refs: checkpoint ref should be fetched locally after the authenticated read")
+		}
+	})
+}

--- a/cmd/entire/cli/integration_test/real_hook_push_test.go
+++ b/cmd/entire/cli/integration_test/real_hook_push_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+)
+
+// TestGitPushWithHooks_SyncsCheckpointsToRemote is the seed of test A1: a plain
+// `git push` of a feature branch, running the installed pre-push hook exactly as
+// git runs it (realistic stdin refspecs, remote name/URL argv), lands the
+// committed checkpoints on the bare remote WITHOUT any explicit RunPrePush or
+// PushCheckpointRefs. It runs under both checkpoint backends via ForEachBackend,
+// validating the whole I-1/I-2 enabler stack: env injection selects the store,
+// the real hook drains it, and the backend-aware assertion finds the result.
+func TestGitPushWithHooks_SyncsCheckpointsToRemote(t *testing.T) {
+	t.Parallel()
+
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
+
+		bareDir := env.SetupBareRemote()
+
+		checkpointID := createCheckpointedCommit(t, env, "Add auth module", "auth.go", "package auth", "Add auth module")
+		if checkpointID == "" {
+			t.Fatal("should have a checkpoint ID after condensation")
+		}
+
+		// Sanity: checkpoint exists locally under the selected backend.
+		if !env.CheckpointsPresentLocally() {
+			t.Fatalf("[%s] checkpoint should exist locally after condensation", backend)
+		}
+
+		// Plain push through the real hook — no explicit checkpoint push.
+		env.GitPushWithHooks("origin", "HEAD")
+
+		if !env.CheckpointsPresentOnRemote(bareDir) {
+			t.Fatalf("[%s] checkpoints should be on remote after `git push` via the real pre-push hook", backend)
+		}
+		if !env.CheckpointExistsOnRemote(bareDir, checkpointID) {
+			t.Fatalf("[%s] checkpoint %s should be on remote after `git push` via the real pre-push hook", backend, checkpointID)
+		}
+	})
+}

--- a/cmd/entire/cli/integration_test/real_hook_push_test.go
+++ b/cmd/entire/cli/integration_test/real_hook_push_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 )
 
-// TestGitPushWithHooks_SyncsCheckpointsToRemote is the seed of test A1: a plain
-// `git push` of a feature branch, running the installed pre-push hook exactly as
-// git runs it (realistic stdin refspecs, remote name/URL argv), lands the
-// committed checkpoints on the bare remote WITHOUT any explicit RunPrePush or
-// PushCheckpointRefs. It runs under both checkpoint backends via ForEachBackend,
-// validating the whole I-1/I-2 enabler stack: env injection selects the store,
-// the real hook drains it, and the backend-aware assertion finds the result.
+// TestGitPushWithHooks_SyncsCheckpointsToRemote is test A1: a plain `git push` of
+// a feature branch, running the installed pre-push hook exactly as git runs it
+// (realistic stdin refspecs, remote name/URL argv), lands the committed
+// checkpoints on the bare remote WITHOUT any explicit RunPrePush or
+// PushCheckpointRefs — and the user push itself is unaffected (the feature branch
+// arrives). It runs under both checkpoint backends via ForEachBackend, validating
+// the whole I-1/I-2 enabler stack: env injection selects the store, the real hook
+// drains it, and the backend-aware assertion finds the result.
 func TestGitPushWithHooks_SyncsCheckpointsToRemote(t *testing.T) {
 	t.Parallel()
 
@@ -41,5 +42,191 @@ func TestGitPushWithHooks_SyncsCheckpointsToRemote(t *testing.T) {
 		if !env.CheckpointExistsOnRemote(bareDir, checkpointID) {
 			t.Fatalf("[%s] checkpoint %s should be on remote after `git push` via the real pre-push hook", backend, checkpointID)
 		}
+
+		// The user's own push is unaffected: the feature branch itself arrives on
+		// the remote alongside the checkpoints.
+		if !env.BranchExistsOnRemote(bareDir, "feature/test-branch") {
+			t.Fatalf("[%s] user feature branch should arrive on remote via the same push", backend)
+		}
 	})
+}
+
+// TestGitPushWithHooks_NoNewCheckpointsIsNoOp is test A2: once checkpoints are
+// synced, a later push carrying only a plain (non-checkpointed) commit runs the
+// real hook, but with nothing new to push the remote checkpoint state is
+// byte-for-byte unchanged and the user push still succeeds.
+func TestGitPushWithHooks_NoNewCheckpointsIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
+
+		bareDir := env.SetupBareRemote()
+
+		// First push syncs the checkpoint to the remote.
+		_ = createCheckpointedCommit(t, env, "Add auth module", "auth.go", "package auth", "Add auth module")
+		env.GitPushWithHooks("origin", "HEAD")
+		if !env.CheckpointsPresentOnRemote(bareDir) {
+			t.Fatalf("[%s] checkpoints should be on remote after the first push", backend)
+		}
+
+		stateBefore := env.RemoteCheckpointState(bareDir)
+
+		// A plain commit with no session activity, then push again through the real
+		// hook. The hook runs but finds nothing new to sync.
+		env.WriteFile("README.md", "# updated")
+		env.GitAdd("README.md")
+		env.GitCommit("Docs tweak (no session)")
+		env.GitPushWithHooks("origin", "HEAD")
+
+		stateAfter := env.RemoteCheckpointState(bareDir)
+		if stateBefore != stateAfter {
+			t.Errorf("[%s] remote checkpoint state should be unchanged by a push with no new checkpoints:\nbefore=%s\nafter=%s",
+				backend, stateBefore, stateAfter)
+		}
+	})
+}
+
+// TestGitPushWithHooks_DeleteAndTagPushesAreNoOp is test A3: a branch deletion
+// (`git push --delete`, whose stdin carries a zero-sha line) and a tag-only push
+// run through the real pre-push hook without crashing and exit 0. With no local
+// checkpoints there is nothing to sync, so the remote checkpoint state stays
+// empty — the unusual push shapes don't trigger a spurious checkpoint push.
+func TestGitPushWithHooks_DeleteAndTagPushesAreNoOp(t *testing.T) {
+	t.Parallel()
+
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
+
+		bareDir := env.SetupBareRemote()
+
+		// Seed a throwaway branch and a tag on the remote (setup plumbing, hook
+		// bypassed) so we have something to delete and a tag to push.
+		env.GitCheckoutNewBranch("to-delete")
+		env.WriteFile("scratch.txt", "scratch")
+		env.GitAdd("scratch.txt")
+		env.GitCommit("scratch commit")
+		env.GitPush("origin", "to-delete")
+		env.GitCheckoutNewBranch("feature/back")
+
+		// Branch delete through the real hook — stdin carries a zero-sha refspec.
+		out, err := env.GitPushArgsWithHooks("origin", "--delete", "to-delete")
+		if err != nil {
+			t.Fatalf("[%s] `git push --delete` via the real hook should exit 0, got: %v\n%s", backend, err, out)
+		}
+
+		// Tag-only push through the real hook — stdin carries a tag refspec.
+		tagName := "v0.0.1"
+		env.GitTag(tagName)
+		out, err = env.GitPushArgsWithHooks("origin", "refs/tags/"+tagName)
+		if err != nil {
+			t.Fatalf("[%s] tag-only push via the real hook should exit 0, got: %v\n%s", backend, err, out)
+		}
+
+		// No sessions ran, so no checkpoint push should have been attempted.
+		if env.CheckpointsPresentOnRemote(bareDir) {
+			t.Errorf("[%s] no checkpoints should be on remote after delete/tag pushes (none were created)", backend)
+		}
+	})
+}
+
+// TestGitPushWithHooks_UnreachableCheckpointRemoteContinues is test A4, the
+// real-hook variant of graceful degradation: when checkpoints are routed to a
+// genuinely unreachable target, the user's push must still succeed.
+//
+// A local-path origin can't express this — checkpoint_remote URL derivation fails
+// on a file path and silently falls back to origin (which is reachable). So this
+// runs over the in-process HTTPS server: origin is the (existing) main-repo, while
+// checkpoint_remote points at a sibling repo that does NOT exist on the server.
+// The CLI's checkpoint push (token-authenticated) fails at the missing repo and
+// degrades gracefully; the user's own push, authenticated via credentials
+// embedded in the origin URL, lands the feature branch on main-repo.
+func TestGitPushWithHooks_UnreachableCheckpointRemoteContinues(t *testing.T) {
+	t.Parallel()
+
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		srv := startGitHTTPSServer(t, "testorg/main-repo")
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
+
+		mainBare := srv.BareDirs["testorg/main-repo"]
+
+		// Seed main-repo over the file path, then point origin at the plain HTTPS
+		// URL. The go-git backend requires a non-empty Authorization header for
+		// receive-pack; real git only sends one after a challenge, so set a static
+		// http.extraHeader that git sends proactively on every request.
+		httpsURL := srv.URL + "/testorg/main-repo.git"
+		seedBareRepo(t, env, mainBare, httpsURL)
+		env.SetGitConfig("http.extraHeader", "Authorization: Basic dGVzdDp0ZXN0")
+
+		// checkpoint_remote points at a repo that does not exist on the server.
+		env.PatchSettings(map[string]any{
+			"strategy_options": map[string]any{
+				"checkpoint_remote": map[string]any{
+					"provider": "github",
+					"repo":     "testorg/does-not-exist",
+				},
+			},
+		})
+		env.ExtraEnv = srv.tokenEnv("a4-token")
+
+		_ = createCheckpointedCommit(t, env, "Add module", "mod.go", "package mod", "Add module")
+		if !env.CheckpointsPresentLocally() {
+			t.Fatalf("[%s] should have local checkpoints after condensation", backend)
+		}
+
+		out, err := env.GitPushArgsWithHooks("origin", "HEAD")
+		if err != nil {
+			t.Fatalf("[%s] user push should succeed even when the checkpoint remote is unreachable, got: %v\n%s", backend, err, out)
+		}
+
+		if !env.BranchExistsOnRemote(mainBare, "feature/test-branch") {
+			t.Errorf("[%s] user feature branch should land on origin (main-repo)", backend)
+		}
+		// Checkpoints were routed to the missing sibling repo, so nothing landed
+		// on main-repo.
+		if env.CheckpointsPresentOnRemote(mainBare) {
+			t.Errorf("[%s] checkpoints should NOT land on main-repo when routed to a missing checkpoint_remote", backend)
+		}
+	})
+}
+
+// TestGitPushWithHooks_GitRefsDrainsPushQueue is the git-refs slice of A6: a real
+// `git push` drains the per-checkpoint push queue that git-refs writes on each
+// checkpoint. After the hook-driven push the ref is on the bare remote and the
+// queue file (in the git common dir) is emptied, proving the hook consumed the
+// queue rather than leaving entries to accumulate.
+//
+// The v1-branch alternates scenario (TestAlternates_RelativeObjectAlternate_
+// CheckpointSync) has no git-refs equivalent — git-refs writes independent
+// fast-forward refs with no v1 rebase reading alternate-resident commits — so
+// this asserts the queue-drain property instead of the rebase path.
+func TestGitPushWithHooks_GitRefsDrainsPushQueue(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitRefs
+
+	bareDir := env.SetupBareRemote()
+
+	checkpointID := createCheckpointedCommit(t, env, "Add service", "svc.go", "package svc", "Add service")
+	if checkpointID == "" {
+		t.Fatal("should have a checkpoint ID after condensation")
+	}
+
+	// The checkpoint write enqueued its ref for push.
+	if got := env.PushQueueRefs(); len(got) == 0 {
+		t.Fatal("git-refs: push queue should hold the new checkpoint ref before push")
+	}
+
+	env.GitPushWithHooks("origin", "HEAD")
+
+	if !env.CheckpointExistsOnRemote(bareDir, checkpointID) {
+		t.Fatalf("git-refs: checkpoint %s should be on remote after the hook-driven push", checkpointID)
+	}
+	if got := env.PushQueueRefs(); len(got) != 0 {
+		t.Errorf("git-refs: push queue should be drained after a successful push, still holds: %v", got)
+	}
 }

--- a/cmd/entire/cli/integration_test/refs_fetch_test.go
+++ b/cmd/entire/cli/integration_test/refs_fetch_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGitRefsClone_ExplainFetchesExactRef is test C2: after cloning a git-refs
+// repo without any checkpoint refs, a read command (`entire explain`) triggers the
+// on-demand RefFetcher, which fetches EXACTLY the one ref it needs — not the whole
+// namespace. The remote is seeded with two checkpoints; reading the first fetches
+// only its ref, leaving the second's ref absent until a read asks for it too.
+func TestGitRefsClone_ExplainFetchesExactRef(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitRefs
+
+	bareDir := env.SetupBareRemote()
+
+	// Two independent checkpoints on the feature branch.
+	cp1 := createCheckpointedCommit(t, env, "Add first module", "one.go", "package one", "Add first module")
+	cp2 := createCheckpointedCommit(t, env, "Add second module", "two.go", "package two", "Add second module")
+	if cp1 == "" || cp2 == "" || cp1 == cp2 {
+		t.Fatalf("expected two distinct checkpoint IDs, got %q and %q", cp1, cp2)
+	}
+
+	// Push both per-checkpoint refs to the remote via the hook path.
+	env.RunPrePush("origin")
+	if !env.CheckpointExistsOnRemote(bareDir, cp1) || !env.CheckpointExistsOnRemote(bareDir, cp2) {
+		t.Fatal("both checkpoint refs should be on the remote after push")
+	}
+
+	// A plain clone carries refs/heads/* and tags, never refs/entire/*.
+	clone := env.CloneFrom(bareDir)
+	if refExists(t, clone.RepoDir, checkpointRefName(cp1)) || refExists(t, clone.RepoDir, checkpointRefName(cp2)) {
+		t.Fatal("clone should not have any per-checkpoint refs before an on-demand read")
+	}
+
+	// Reading cp1 fetches only cp1's ref.
+	out := clone.RunCLI("checkpoint", "explain", "--checkpoint", cp1)
+	if !strings.Contains(out, "Add first module") {
+		t.Errorf("explain cp1 should surface its prompt, got:\n%s", out)
+	}
+	if !refExists(t, clone.RepoDir, checkpointRefName(cp1)) {
+		t.Errorf("cp1 ref should be fetched locally after explaining cp1")
+	}
+	if refExists(t, clone.RepoDir, checkpointRefName(cp2)) {
+		t.Errorf("cp2 ref should NOT be fetched when only cp1 was read (RefFetcher over-fetched)")
+	}
+
+	// Reading cp2 then fetches cp2's ref on demand.
+	out = clone.RunCLI("checkpoint", "explain", "--checkpoint", cp2)
+	if !strings.Contains(out, "Add second module") {
+		t.Errorf("explain cp2 should surface its prompt, got:\n%s", out)
+	}
+	if !refExists(t, clone.RepoDir, checkpointRefName(cp2)) {
+		t.Errorf("cp2 ref should be fetched locally after explaining cp2")
+	}
+}
+
+// TestGitRefsClone_UnreachableRemoteMissingRefSurfacesRealError is test C3, a
+// regression guard for 7bbdad09c: under git-refs, when a checkpoint's ref is
+// missing locally AND the remote is unreachable, the read must surface the real
+// fetch failure rather than masking it as "checkpoint not found" (which would tell
+// the user the checkpoint doesn't exist when it may well exist on a reachable
+// remote).
+func TestGitRefsClone_UnreachableRemoteMissingRefSurfacesRealError(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitRefs
+
+	bareDir := env.SetupBareRemote()
+
+	cp := createCheckpointedCommit(t, env, "Add module", "mod.go", "package mod", "Add module")
+	if cp == "" {
+		t.Fatal("should have a checkpoint ID after condensation")
+	}
+	env.RunPrePush("origin")
+
+	clone := env.CloneFrom(bareDir)
+	if refExists(t, clone.RepoDir, checkpointRefName(cp)) {
+		t.Fatal("clone should not have the per-checkpoint ref before a read")
+	}
+
+	// Point origin at a nonexistent path so the on-demand fetch fails.
+	clone.SetGitConfig("remote.origin.url", clone.RepoDir+"/nonexistent-remote.git")
+
+	out, err := clone.RunCLIWithError("checkpoint", "explain", "--checkpoint", cp)
+	if err == nil {
+		t.Fatalf("explain should fail when the ref is missing and the remote is unreachable, got success:\n%s", out)
+	}
+
+	// KNOWN BUG (regression class 7bbdad09c): the store layer preserves the real
+	// fetch error, but explain's git-refs prefix-match remote fallback discards
+	// the FetchCheckpointRef error (explain_export.go:216-227) and returns
+	// ErrCheckpointNotFound, so an unreachable remote is reported identically to a
+	// genuinely absent checkpoint. A parallel investigation owns the production
+	// fix — this test does not touch production code. It self-heals: once the
+	// fallback surfaces the fetch error, the skip stops firing and the assertions
+	// below guard against regressing back to the masked message.
+	if strings.Contains(out, "checkpoint not found") {
+		t.Skipf("KNOWN BUG (7bbdad09c): unreachable-remote fetch failure masked as 'checkpoint not found':\n%s", out)
+	}
+	// Reaching here means the fallback surfaced a real error (the bug is fixed):
+	// err != nil is already asserted above, and the message is not the masked one.
+}

--- a/cmd/entire/cli/integration_test/refs_fetch_test.go
+++ b/cmd/entire/cli/integration_test/refs_fetch_test.go
@@ -94,17 +94,14 @@ func TestGitRefsClone_UnreachableRemoteMissingRefSurfacesRealError(t *testing.T)
 		t.Fatalf("explain should fail when the ref is missing and the remote is unreachable, got success:\n%s", out)
 	}
 
-	// KNOWN BUG (regression class 7bbdad09c): the store layer preserves the real
-	// fetch error, but explain's git-refs prefix-match remote fallback discards
-	// the FetchCheckpointRef error (explain_export.go:216-227) and returns
-	// ErrCheckpointNotFound, so an unreachable remote is reported identically to a
-	// genuinely absent checkpoint. A parallel investigation owns the production
-	// fix — this test does not touch production code. It self-heals: once the
-	// fallback surfaces the fetch error, the skip stops firing and the assertions
-	// below guard against regressing back to the masked message.
-	if strings.Contains(out, "checkpoint not found") {
-		t.Skipf("KNOWN BUG (7bbdad09c): unreachable-remote fetch failure masked as 'checkpoint not found':\n%s", out)
+	// The store layer preserves the real fetch error (7bbdad09c), and explain's
+	// git-refs prefix-match remote fallback must not re-mask it as a plain
+	// "checkpoint not found" — that would report an unreachable remote
+	// identically to a genuinely absent checkpoint.
+	if strings.Contains(out, "checkpoint not found:") {
+		t.Errorf("unreachable-remote fetch failure masked as 'checkpoint not found':\n%s", out)
 	}
-	// Reaching here means the fallback surfaced a real error (the bug is fixed):
-	// err != nil is already asserted above, and the message is not the masked one.
+	if !strings.Contains(out, "fetching from remote failed") {
+		t.Errorf("explain should surface the real fetch failure, got:\n%s", out)
+	}
 }

--- a/cmd/entire/cli/integration_test/remote_operations_test.go
+++ b/cmd/entire/cli/integration_test/remote_operations_test.go
@@ -15,121 +15,96 @@ import (
 // P0 -- PrePush Basic Flow
 // =============================================================================
 
-// TestPrePush_PushesCheckpointBranchToOrigin verifies that PrePush pushes
-// the entire/checkpoints/v1 branch to a bare remote after condensation.
+// TestPrePush_PushesCheckpointBranchToOrigin verifies that PrePush pushes the
+// committed checkpoints to a bare remote after condensation, under both the
+// git-branch (v1 branch) and git-refs (per-checkpoint refs) backends.
 func TestPrePush_PushesCheckpointBranchToOrigin(t *testing.T) {
 	t.Parallel()
-	env := NewFeatureBranchEnv(t)
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
 
-	// Set up bare remote
-	bareDir := env.SetupBareRemote()
+		// Set up bare remote
+		bareDir := env.SetupBareRemote()
 
-	// Create a session, make changes, checkpoint, and commit (triggers condensation)
-	session := env.NewSession()
-	transcriptPath := session.CreateTranscript("Add auth module", []FileChange{
-		{Path: "auth.go", Content: "package auth"},
+		// Create a session, make changes, checkpoint, and commit (triggers condensation)
+		checkpointID := createCheckpointedCommit(t, env, "Add auth module", "auth.go", "package auth", "Add auth module")
+
+		// Verify condensation happened locally
+		if !env.CheckpointsPresentLocally() {
+			t.Fatal("checkpoints should exist locally after condensation")
+		}
+
+		// Run PrePush (simulates what happens during git push)
+		env.RunPrePush("origin")
+
+		// Verify the checkpoints arrived on the remote
+		if !env.CheckpointsPresentOnRemote(bareDir) {
+			t.Error("checkpoints should exist on bare remote after PrePush")
+		}
+
+		// Verify the specific checkpoint is on the remote
+		if checkpointID == "" {
+			t.Fatal("should have a checkpoint ID after condensation")
+		}
+		if !env.CheckpointExistsOnRemote(bareDir, checkpointID) {
+			t.Errorf("checkpoint %s should exist on remote", checkpointID)
+		}
 	})
-
-	if err := env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(session.ID, "Add auth module", transcriptPath); err != nil {
-		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
-	}
-
-	env.WriteFile("auth.go", "package auth")
-	env.GitAdd("auth.go")
-
-	if err := env.SimulateStop(session.ID, transcriptPath); err != nil {
-		t.Fatalf("SimulateStop failed: %v", err)
-	}
-
-	// Commit with hooks (triggers prepare-commit-msg + post-commit = condensation)
-	env.GitCommitWithShadowHooks("Add auth module", "auth.go")
-
-	// Verify condensation happened locally
-	if !env.BranchExists(paths.MetadataBranchName) {
-		t.Fatal("entire/checkpoints/v1 should exist locally after condensation")
-	}
-
-	// Run PrePush (simulates what happens during git push)
-	env.RunPrePush("origin")
-
-	// Verify the branch arrived on the remote
-	if !env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
-		t.Error("entire/checkpoints/v1 should exist on bare remote after PrePush")
-	}
-
-	// Verify checkpoint metadata is in the remote tree
-	checkpointID := env.GetLatestCheckpointID()
-	if checkpointID == "" {
-		t.Fatal("should have a checkpoint ID after condensation")
-	}
-	summaryPath := CheckpointSummaryPath(checkpointID)
-	if !fileExistsOnRemoteBranch(t, bareDir, summaryPath) {
-		t.Errorf("checkpoint metadata should exist on remote at %s", summaryPath)
-	}
 }
 
 // TestPrePush_NoOpWhenNoCheckpoints verifies that PrePush is a no-op
 // when no sessions or checkpoints exist.
 func TestPrePush_NoOpWhenNoCheckpoints(t *testing.T) {
 	t.Parallel()
-	env := NewFeatureBranchEnv(t)
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
 
-	bareDir := env.SetupBareRemote()
+		bareDir := env.SetupBareRemote()
 
-	// Run PrePush without any session activity
-	env.RunPrePush("origin")
+		// Run PrePush without any session activity
+		env.RunPrePush("origin")
 
-	// No checkpoint branches should exist on remote
-	if env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
-		t.Error("entire/checkpoints/v1 should NOT exist on remote when no checkpoints were created")
-	}
+		// No checkpoints should exist on remote
+		if env.CheckpointsPresentOnRemote(bareDir) {
+			t.Error("checkpoints should NOT exist on remote when none were created")
+		}
+	})
 }
 
 // TestPrePush_IdempotentWhenAlreadyPushed verifies that pushing twice
 // with no new checkpoints is a no-op (idempotent).
 func TestPrePush_IdempotentWhenAlreadyPushed(t *testing.T) {
 	t.Parallel()
-	env := NewFeatureBranchEnv(t)
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
 
-	bareDir := env.SetupBareRemote()
+		bareDir := env.SetupBareRemote()
 
-	// Create session, commit, push
-	session := env.NewSession()
-	transcriptPath := session.CreateTranscript("Initial work", []FileChange{
-		{Path: "main.go", Content: "package main"},
+		// Create session, commit, push
+		_ = createCheckpointedCommit(t, env, "Initial work", "main.go", "package main", "Initial work")
+
+		// First push
+		env.RunPrePush("origin")
+
+		if !env.CheckpointsPresentOnRemote(bareDir) {
+			t.Fatal("checkpoints should exist after first push")
+		}
+
+		// Get remote checkpoint state before second push
+		stateBefore := env.RemoteCheckpointState(bareDir)
+
+		// Second push (no new checkpoints)
+		env.RunPrePush("origin")
+
+		// Remote state should be unchanged
+		stateAfter := env.RemoteCheckpointState(bareDir)
+		if stateBefore != stateAfter {
+			t.Errorf("remote checkpoint state should be unchanged after idempotent push:\nbefore=%s\nafter=%s", stateBefore, stateAfter)
+		}
 	})
-
-	if err := env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(session.ID, "Initial work", transcriptPath); err != nil {
-		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
-	}
-
-	env.WriteFile("main.go", "package main")
-	env.GitAdd("main.go")
-
-	if err := env.SimulateStop(session.ID, transcriptPath); err != nil {
-		t.Fatalf("SimulateStop failed: %v", err)
-	}
-
-	env.GitCommitWithShadowHooks("Initial work", "main.go")
-
-	// First push
-	env.RunPrePush("origin")
-
-	if !env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
-		t.Fatal("checkpoint branch should exist after first push")
-	}
-
-	// Get remote ref before second push
-	refBefore := getRemoteBranchHash(t, bareDir, paths.MetadataBranchName)
-
-	// Second push (no new checkpoints)
-	env.RunPrePush("origin")
-
-	// Remote ref should be unchanged
-	refAfter := getRemoteBranchHash(t, bareDir, paths.MetadataBranchName)
-	if refBefore != refAfter {
-		t.Errorf("remote ref should be unchanged after idempotent push: before=%s, after=%s", refBefore, refAfter)
-	}
 }
 
 // =============================================================================
@@ -140,32 +115,35 @@ func TestPrePush_IdempotentWhenAlreadyPushed(t *testing.T) {
 // disables checkpoint push.
 func TestPrePush_PushDisabledSkipsCheckpoints(t *testing.T) {
 	t.Parallel()
-	env := NewFeatureBranchEnv(t)
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
 
-	bareDir := env.SetupBareRemote()
+		bareDir := env.SetupBareRemote()
 
-	// Configure push_sessions: false
-	env.PatchSettings(map[string]any{
-		"strategy_options": map[string]any{
-			"push_sessions": false,
-		},
+		// Configure push_sessions: false
+		env.PatchSettings(map[string]any{
+			"strategy_options": map[string]any{
+				"push_sessions": false,
+			},
+		})
+
+		// Create session, checkpoint, and commit
+		_ = createCheckpointedCommit(t, env, "Some work", "work.go", "package work", "Some work")
+
+		// Verify checkpoint was created locally
+		if !env.CheckpointsPresentLocally() {
+			t.Fatal("should have local checkpoints after condensation")
+		}
+
+		// PrePush should skip checkpoints when push_sessions is false
+		env.RunPrePush("origin")
+
+		// Checkpoints should NOT be on remote
+		if env.CheckpointsPresentOnRemote(bareDir) {
+			t.Error("checkpoints should NOT be on remote when push_sessions is false")
+		}
 	})
-
-	// Create session, checkpoint, and commit
-	_ = createCheckpointedCommit(t, env, "Some work", "work.go", "package work", "Some work")
-
-	// Verify checkpoint was created locally
-	if !env.BranchExists(paths.MetadataBranchName) {
-		t.Fatal("should have local checkpoint branch after condensation")
-	}
-
-	// PrePush should skip checkpoints when push_sessions is false
-	env.RunPrePush("origin")
-
-	// Checkpoints should NOT be on remote
-	if env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
-		t.Error("entire/checkpoints/v1 should NOT be on remote when push_sessions is false")
-	}
 }
 
 // TestPrePush_CheckpointRemoteRoutesToSeparateRemote verifies that checkpoint data
@@ -185,6 +163,11 @@ func TestPrePush_PushDisabledSkipsCheckpoints(t *testing.T) {
 // The pushRefIfNeeded function (which PrePush calls with the resolved target)
 // is exercised in push_common_test.go:TestPushRefIfNeeded_LocalBareRepo_PushesSuccessfully,
 // verifying it works with local bare repo paths.
+//
+// git-branch only: this test directly pushes the v1 branch via env.GitPush to
+// verify data routing. checkpoint_remote routing for git-refs per-checkpoint
+// refs is separate future work (test plan B5, "gr: N/A until checkpoint_remote
+// applies to refs"), so this stays on the default (git-branch) backend.
 func TestPrePush_CheckpointRemoteRoutesToSeparateRemote(t *testing.T) {
 	t.Parallel()
 	env := NewFeatureBranchEnv(t)
@@ -230,55 +213,48 @@ func TestPrePush_CheckpointRemoteRoutesToSeparateRemote(t *testing.T) {
 // checkpoint_remote_test.go:TestResolvePushSettings_ForkDetection.
 func TestPrePush_CheckpointURLDerivationFailureFallsBackToOrigin(t *testing.T) {
 	t.Parallel()
-	env := NewFeatureBranchEnv(t)
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
 
-	bareDir := env.SetupBareRemote()
+		bareDir := env.SetupBareRemote()
 
-	// Configure checkpoint_remote with a different owner than origin.
-	// Since our bare remote is a local path (not a URL), resolvePushSettings cannot
-	// parse it via remote.ParseURL and falls back to origin. The unit test
-	// TestResolvePushSettings_ForkDetection in checkpoint_remote_test.go validates
-	// the exact fork detection logic with real URL parsing.
-	env.PatchSettings(map[string]any{
-		"strategy_options": map[string]any{
-			"checkpoint_remote": map[string]any{
-				"provider": "github",
-				"repo":     "different-org/checkpoints",
+		// Configure checkpoint_remote with a different owner than origin.
+		// Since our bare remote is a local path (not a URL), resolvePushSettings cannot
+		// parse it via remote.ParseURL and falls back to origin. The unit test
+		// TestResolvePushSettings_ForkDetection in checkpoint_remote_test.go validates
+		// the exact fork detection logic with real URL parsing.
+		env.PatchSettings(map[string]any{
+			"strategy_options": map[string]any{
+				"checkpoint_remote": map[string]any{
+					"provider": "github",
+					"repo":     "different-org/checkpoints",
+				},
 			},
-		},
+		})
+
+		// Create session, checkpoint, and commit
+		_ = createCheckpointedCommit(t, env, "Add middleware", "middleware.go", "package middleware", "Add middleware")
+
+		// Run PrePush -- with a local path remote, checkpoint URL derivation will fail
+		// (remote.ParseURL can't parse local paths), so checkpoints fall back to origin.
+		env.RunPrePush("origin")
+
+		// Checkpoints should be on origin (fallback behavior)
+		if !env.CheckpointsPresentOnRemote(bareDir) {
+			t.Error("checkpoints should be on origin when checkpoint_remote is unavailable (fork/fallback)")
+		}
 	})
-
-	// Create session, checkpoint, and commit
-	session := env.NewSession()
-	transcriptPath := session.CreateTranscript("Add middleware", []FileChange{
-		{Path: "middleware.go", Content: "package middleware"},
-	})
-
-	if err := env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(session.ID, "Add middleware", transcriptPath); err != nil {
-		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
-	}
-
-	env.WriteFile("middleware.go", "package middleware")
-	env.GitAdd("middleware.go")
-
-	if err := env.SimulateStop(session.ID, transcriptPath); err != nil {
-		t.Fatalf("SimulateStop failed: %v", err)
-	}
-
-	env.GitCommitWithShadowHooks("Add middleware", "middleware.go")
-
-	// Run PrePush -- with a local path remote, checkpoint URL derivation will fail
-	// (remote.ParseURL can't parse local paths), so checkpoints fall back to origin.
-	env.RunPrePush("origin")
-
-	// Checkpoints should be on origin (fallback behavior)
-	if !env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
-		t.Error("entire/checkpoints/v1 should be on origin when checkpoint_remote is unavailable (fork/fallback)")
-	}
 }
 
 // =============================================================================
 // P0 -- Clone and Resume
+//
+// The clone/fetch tests below stay on the default git-branch backend: they fetch
+// and read the v1 branch tree directly (FetchMetadataBranch, FileExistsInBranch).
+// git-refs cross-machine fetch goes through the on-demand RefFetcher, a distinct
+// path covered separately (test plan C2, git-refs only) rather than by
+// parameterizing these v1-tree assertions.
 // =============================================================================
 
 // createCheckpointedCommit is a helper that creates a session with a single file change,
@@ -306,7 +282,7 @@ func createCheckpointedCommit(t *testing.T, env *TestEnv, prompt, fileName, file
 
 	env.GitCommitWithShadowHooks(commitMsg, fileName)
 
-	return env.GetLatestCheckpointID()
+	return env.LatestCheckpointID()
 }
 
 // TestCloneAndResume_FetchesCheckpointMetadata verifies that after pushing
@@ -473,6 +449,11 @@ func TestCloneAndResume_NewSessionPushAppends(t *testing.T) {
 
 // TestConcurrentPush_SecondPusherRebasesAndRetries verifies that when two clones
 // push to the same remote, the second pusher fetches, rebases, and retries.
+//
+// git-branch only: it asserts on the v1 branch tip's parent count to prove a
+// linear rebase (not a merge). The git-refs concurrent-push equivalent
+// (fetch+replay+non-force retry on per-checkpoint refs) is separate future work
+// (test plan D3, git-refs only).
 func TestConcurrentPush_SecondPusherRebasesAndRetries(t *testing.T) {
 	t.Parallel()
 	env := NewFeatureBranchEnv(t)
@@ -536,39 +517,42 @@ func TestConcurrentPush_SecondPusherRebasesAndRetries(t *testing.T) {
 //   - TestPushRefIfNeeded_UnreachableTarget_ReturnsNil
 func TestGracefulDegradation_UnreachableCheckpointRemotePushContinues(t *testing.T) {
 	t.Parallel()
-	env := NewFeatureBranchEnv(t)
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
 
-	bareOrigin := env.SetupBareRemote()
+		bareOrigin := env.SetupBareRemote()
 
-	// Configure checkpoint_remote with a nonexistent repo. Since origin is a local
-	// file path, resolvePushSettings cannot parse it as a URL and will silently fall
-	// back to pushing checkpoints to origin (the default behavior).
-	env.PatchSettings(map[string]any{
-		"strategy_options": map[string]any{
-			"checkpoint_remote": map[string]any{
-				"provider": "github",
-				"repo":     "nonexistent-org/unreachable-repo",
+		// Configure checkpoint_remote with a nonexistent repo. Since origin is a local
+		// file path, resolvePushSettings cannot parse it as a URL and will silently fall
+		// back to pushing checkpoints to origin (the default behavior).
+		env.PatchSettings(map[string]any{
+			"strategy_options": map[string]any{
+				"checkpoint_remote": map[string]any{
+					"provider": "github",
+					"repo":     "nonexistent-org/unreachable-repo",
+				},
 			},
-		},
+		})
+
+		// Create session, checkpoint, and commit
+		_ = createCheckpointedCommit(t, env, "Some work", "work.go", "package work", "Some work")
+
+		// Verify local checkpoints exist
+		if !env.CheckpointsPresentLocally() {
+			t.Fatal("should have local checkpoints after condensation")
+		}
+
+		// Run PrePush with checkpoint_remote configured. Since origin is a local path,
+		// resolvePushSettings will fail to derive a checkpoint URL and fall back to
+		// pushing checkpoints to origin.
+		env.RunPrePush("origin")
+
+		// Checkpoints should be on origin (fallback behavior when checkpoint URL derivation fails)
+		if !env.CheckpointsPresentOnRemote(bareOrigin) {
+			t.Error("checkpoints should be on origin when checkpoint_remote URL derivation fails")
+		}
 	})
-
-	// Create session, checkpoint, and commit
-	_ = createCheckpointedCommit(t, env, "Some work", "work.go", "package work", "Some work")
-
-	// Verify local checkpoint branch exists
-	if !env.BranchExists(paths.MetadataBranchName) {
-		t.Fatal("should have local checkpoint branch after condensation")
-	}
-
-	// Run PrePush with checkpoint_remote configured. Since origin is a local path,
-	// resolvePushSettings will fail to derive a checkpoint URL and fall back to
-	// pushing checkpoints to origin.
-	env.RunPrePush("origin")
-
-	// Checkpoints should be on origin (fallback behavior when checkpoint URL derivation fails)
-	if !env.BranchExistsOnRemote(bareOrigin, paths.MetadataBranchName) {
-		t.Error("entire/checkpoints/v1 should be on origin when checkpoint_remote URL derivation fails")
-	}
 }
 
 // TestGracefulDegradation_UnreachableCheckpointRemoteOnCloneIsSilent verifies that
@@ -576,57 +560,74 @@ func TestGracefulDegradation_UnreachableCheckpointRemotePushContinues(t *testing
 // a session does not error. fetchMetadataBranchIfMissing silently swallows fetch failures.
 func TestGracefulDegradation_UnreachableCheckpointRemoteOnCloneIsSilent(t *testing.T) {
 	t.Parallel()
-	env := NewFeatureBranchEnv(t)
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
 
-	bareDir := env.SetupBareRemote()
+		bareDir := env.SetupBareRemote()
 
-	// Create a session in repo A and push
-	createCheckpointedCommit(t, env, "Initial work", "init.go", "package init", "Initial work")
-	env.GitPush("origin", "HEAD")
-	env.RunPrePush("origin")
+		// Create a session in repo A and push
+		createCheckpointedCommit(t, env, "Initial work", "init.go", "package init", "Initial work")
+		env.GitPush("origin", "HEAD")
+		env.RunPrePush("origin")
 
-	// Clone from origin
-	cloneEnv := env.CloneFrom(bareDir)
+		// Clone from origin (inherits the backend via CloneFrom)
+		cloneEnv := env.CloneFrom(bareDir)
 
-	// Configure checkpoint_remote to an unreachable path in the clone.
-	// When the checkpoint_remote URL can't be reached, fetch fails silently.
-	cloneEnv.PatchSettings(map[string]any{
-		"strategy_options": map[string]any{
-			"checkpoint_remote": map[string]any{
-				"provider": "github",
-				"repo":     "nonexistent-org/nonexistent-repo",
+		// Configure checkpoint_remote to an unreachable path in the clone.
+		// When the checkpoint_remote URL can't be reached, fetch fails silently.
+		cloneEnv.PatchSettings(map[string]any{
+			"strategy_options": map[string]any{
+				"checkpoint_remote": map[string]any{
+					"provider": "github",
+					"repo":     "nonexistent-org/nonexistent-repo",
+				},
 			},
-		},
+		})
+
+		// Starting a new session should not error even though checkpoint_remote is unreachable.
+		// The session machinery itself doesn't trigger fetchMetadataBranchIfMissing (that happens
+		// in resolvePushSettings during PrePush), so this verifies the session starts cleanly.
+		session := cloneEnv.NewSession()
+		transcriptPath := session.CreateTranscript("Clone work", []FileChange{
+			{Path: "clone.go", Content: "package clone"},
+		})
+
+		if err := cloneEnv.SimulateUserPromptSubmitWithPromptAndTranscriptPath(session.ID, "Clone work", transcriptPath); err != nil {
+			t.Fatalf("session start should not fail with unreachable checkpoint_remote: %v", err)
+		}
+
+		if err := cloneEnv.SimulateStop(session.ID, transcriptPath); err != nil {
+			t.Fatalf("session stop should not fail: %v", err)
+		}
+
+		// PrePush should also not fail -- checkpoint_remote URL derivation will fail
+		// (origin is a local path, can't parse it), so it falls back to pushing to origin.
+		cloneEnv.WriteFile("clone.go", "package clone")
+		cloneEnv.GitAdd("clone.go")
+		cloneEnv.GitCommitWithShadowHooks("Clone work", "clone.go")
+		cloneEnv.RunPrePush("origin")
+
+		// Verify that the session actually created a local checkpoint despite the
+		// unreachable checkpoint_remote config.
+		//
+		// KNOWN BUG (git-refs): this test stages the session's file changes AFTER
+		// the stop hook. Under git-branch, condensation still creates the local v1
+		// checkpoint; under git-refs it creates no per-checkpoint ref (only the v1
+		// session-metadata branch is updated). A fresh git-refs repo and a git-refs
+		// clone that stages before stop both create the ref correctly (verified), so
+		// this is a real backend divergence in the write-after-stop path, not a
+		// harness artifact. The graceful-degradation path this test targets
+		// (session start/stop/pre-push do not error with an unreachable
+		// checkpoint_remote) is exercised under git-refs above; only this final
+		// local-presence check is skipped. Tracked for the section-3 follow-up.
+		if env.usingGitRefs() {
+			t.Skip("KNOWN BUG: git-refs creates no per-checkpoint ref when files are staged after the stop hook")
+		}
+		if !cloneEnv.CheckpointsPresentLocally() {
+			t.Error("checkpoints should exist locally after session + commit in clone")
+		}
 	})
-
-	// Starting a new session should not error even though checkpoint_remote is unreachable.
-	// The session machinery itself doesn't trigger fetchMetadataBranchIfMissing (that happens
-	// in resolvePushSettings during PrePush), so this verifies the session starts cleanly.
-	session := cloneEnv.NewSession()
-	transcriptPath := session.CreateTranscript("Clone work", []FileChange{
-		{Path: "clone.go", Content: "package clone"},
-	})
-
-	if err := cloneEnv.SimulateUserPromptSubmitWithPromptAndTranscriptPath(session.ID, "Clone work", transcriptPath); err != nil {
-		t.Fatalf("session start should not fail with unreachable checkpoint_remote: %v", err)
-	}
-
-	if err := cloneEnv.SimulateStop(session.ID, transcriptPath); err != nil {
-		t.Fatalf("session stop should not fail: %v", err)
-	}
-
-	// PrePush should also not fail -- checkpoint_remote URL derivation will fail
-	// (origin is a local path, can't parse it), so it falls back to pushing to origin.
-	cloneEnv.WriteFile("clone.go", "package clone")
-	cloneEnv.GitAdd("clone.go")
-	cloneEnv.GitCommitWithShadowHooks("Clone work", "clone.go")
-	cloneEnv.RunPrePush("origin")
-
-	// Verify that the session actually created a local checkpoint despite the
-	// unreachable checkpoint_remote config.
-	if !cloneEnv.BranchExists(paths.MetadataBranchName) {
-		t.Error("entire/checkpoints/v1 should exist locally after session + commit in clone")
-	}
 }
 
 // =============================================================================
@@ -646,6 +647,11 @@ func TestGracefulDegradation_UnreachableCheckpointRemoteOnCloneIsSilent(t *testi
 // to a bare remote, then clones to a fresh repo that does NOT have the
 // feature branch locally. With filtered_fetches enabled, `entire resume`
 // must still fetch the branch fully so the checked-out file has real content.
+//
+// git-branch only: the final assertion reads the transcript blob from the v1
+// branch tree (FileExistsInBranch) to prove the metadata fetch was unfiltered.
+// The git-refs equivalent (per-checkpoint ref blob availability) is separate
+// future work (test plan C2/C6).
 func TestResume_FetchesPrimaryBranchFullyWithFilteredFetches(t *testing.T) {
 	t.Parallel()
 	env := NewFeatureBranchEnv(t)

--- a/cmd/entire/cli/integration_test/remote_operations_test.go
+++ b/cmd/entire/cli/integration_test/remote_operations_test.go
@@ -567,7 +567,7 @@ func TestGracefulDegradation_UnreachableCheckpointRemoteOnCloneIsSilent(t *testi
 		bareDir := env.SetupBareRemote()
 
 		// Create a session in repo A and push
-		createCheckpointedCommit(t, env, "Initial work", "init.go", "package init", "Initial work")
+		initialID := createCheckpointedCommit(t, env, "Initial work", "init.go", "package init", "Initial work")
 		env.GitPush("origin", "HEAD")
 		env.RunPrePush("origin")
 
@@ -597,35 +597,31 @@ func TestGracefulDegradation_UnreachableCheckpointRemoteOnCloneIsSilent(t *testi
 			t.Fatalf("session start should not fail with unreachable checkpoint_remote: %v", err)
 		}
 
+		// Stage the session's changes before stop (as a real agent session would;
+		// the stop hook skips condensation entirely when no files changed on disk
+		// during the session).
+		cloneEnv.WriteFile("clone.go", "package clone")
+		cloneEnv.GitAdd("clone.go")
+
 		if err := cloneEnv.SimulateStop(session.ID, transcriptPath); err != nil {
 			t.Fatalf("session stop should not fail: %v", err)
 		}
 
 		// PrePush should also not fail -- checkpoint_remote URL derivation will fail
 		// (origin is a local path, can't parse it), so it falls back to pushing to origin.
-		cloneEnv.WriteFile("clone.go", "package clone")
-		cloneEnv.GitAdd("clone.go")
 		cloneEnv.GitCommitWithShadowHooks("Clone work", "clone.go")
 		cloneEnv.RunPrePush("origin")
 
-		// Verify that the session actually created a local checkpoint despite the
-		// unreachable checkpoint_remote config.
-		//
-		// KNOWN BUG (git-refs): this test stages the session's file changes AFTER
-		// the stop hook. Under git-branch, condensation still creates the local v1
-		// checkpoint; under git-refs it creates no per-checkpoint ref (only the v1
-		// session-metadata branch is updated). A fresh git-refs repo and a git-refs
-		// clone that stages before stop both create the ref correctly (verified), so
-		// this is a real backend divergence in the write-after-stop path, not a
-		// harness artifact. The graceful-degradation path this test targets
-		// (session start/stop/pre-push do not error with an unreachable
-		// checkpoint_remote) is exercised under git-refs above; only this final
-		// local-presence check is skipped. Tracked for the section-3 follow-up.
-		if env.usingGitRefs() {
-			t.Skip("KNOWN BUG: git-refs creates no per-checkpoint ref when files are staged after the stop hook")
-		}
+		// Verify the clone's session condensed a NEW local checkpoint despite the
+		// unreachable checkpoint_remote config. Comparing against the initial
+		// checkpoint matters under git-branch: the clone inherits repo A's v1
+		// branch from the plain clone, so mere branch presence would pass even if
+		// condensation never ran.
 		if !cloneEnv.CheckpointsPresentLocally() {
 			t.Error("checkpoints should exist locally after session + commit in clone")
+		}
+		if newID := cloneEnv.LatestCheckpointID(); newID == "" || newID == initialID {
+			t.Errorf("clone session should have condensed a new checkpoint, got %q (initial %q)", newID, initialID)
 		}
 	})
 }

--- a/cmd/entire/cli/integration_test/setup_test.go
+++ b/cmd/entire/cli/integration_test/setup_test.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
 // TestMain builds the CLI binary once before running all tests.
@@ -27,12 +29,23 @@ func TestMain(m *testing.M) {
 	// internal/testdirs fallback cannot protect it — isolation must come from
 	// the environment, which children inherit because all integration env
 	// building starts from os.Environ() (testutil.GitIsolatedEnv).
+	//
+	// GIT_TERMINAL_PROMPT=0 and ENTIRE_TEST_GIT_HERMETIC form the hermeticity
+	// tripwire: the latter makes GitIsolatedEnv's global git config route HTTPS
+	// transport to real external hosts (github.com, gitlab.com) through a dead
+	// loopback proxy, so any test whose git commands accidentally dial the network
+	// fails fast instead of reaching it or prompting for credentials (regressions
+	// #1463, 53bc37a88). The config lives in the file because GitIsolatedEnv strips
+	// inherited GIT_CONFIG_* env; it proxies transport only (not url.insteadOf, which
+	// would corrupt origin-URL forge detection) and leaves loopback servers untouched.
 	isolation := map[string]string{
 		"ENTIRE_CONFIG_DIR":           filepath.Join(tmpDir, "entire-config"),
 		"XDG_CACHE_HOME":              filepath.Join(tmpDir, "entire-cache"),
 		"ENTIRE_TOKEN_STORE":          "file",
 		"ENTIRE_TOKEN_STORE_PATH":     filepath.Join(tmpDir, "entire-tokens.json"),
 		"ENTIRE_TEST_AUTH_STORE_FILE": filepath.Join(tmpDir, "entire-auth-tokens.json"),
+		"GIT_TERMINAL_PROMPT":         "0",
+		testutil.EnvGitHermetic:       "1",
 	}
 	for k, v := range isolation {
 		if err := os.Setenv(k, v); err != nil {

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -1945,7 +1945,10 @@ func (env *TestEnv) PatchSettings(extra map[string]any) {
 	}
 }
 
-// GitPush pushes a branch to a remote. Fails the test on error.
+// GitPush pushes a branch to a remote with --no-verify, bypassing the pre-push
+// hook. Use this for setup plumbing (seeding remotes, pushing the user branch)
+// where the checkpoint sync should NOT run. To exercise the real hook, use
+// GitPushWithHooks. Fails the test on error.
 func (env *TestEnv) GitPush(remote, refSpec string) {
 	env.T.Helper()
 
@@ -1957,8 +1960,50 @@ func (env *TestEnv) GitPush(remote, refSpec string) {
 	}
 }
 
-// RunPrePush runs the pre-push hook via the CLI binary, consistent with how
-// other CLI invocations (GitCommitWithShadowHooks, RunCLI) use env.cliEnv().
+// InstallRealPrePushHook writes .git/hooks/pre-push so a plain `git push` (no
+// --no-verify) runs the checkpoint sync exactly as git runs it: git invokes the
+// hook with the remote name ($1) and URL ($2) as argv and feeds
+// "<local-ref> <local-sha> <remote-ref> <remote-sha>" lines on stdin. The hook
+// inherits the pushing process's environment, so the checkpoint-store and git
+// isolation overrides from GitPushWithHooks propagate into it.
+func (env *TestEnv) InstallRealPrePushHook() {
+	env.T.Helper()
+
+	hooksDir := filepath.Join(env.RepoDir, ".git", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		env.T.Fatalf("failed to create hooks dir: %v", err)
+	}
+	// Quote the binary path so a temp path containing spaces still execs.
+	script := fmt.Sprintf("#!/bin/sh\nexec %q hooks git pre-push \"$1\"\n", getTestBinary())
+	hookPath := filepath.Join(hooksDir, "pre-push")
+	if err := os.WriteFile(hookPath, []byte(script), 0o755); err != nil { //nolint:gosec // G306: hook scripts must be executable
+		env.T.Fatalf("failed to write pre-push hook: %v", err)
+	}
+}
+
+// GitPushWithHooks pushes a branch to a remote WITHOUT --no-verify, so the
+// installed pre-push hook (see InstallRealPrePushHook) runs as part of the push.
+// This is the real-git path: git feeds the hook realistic stdin refspec lines
+// and the remote name/URL argv, so the checkpoint sync happens without any
+// explicit RunPrePush. Fails the test on error.
+func (env *TestEnv) GitPushWithHooks(remote, refSpec string) {
+	env.T.Helper()
+
+	env.InstallRealPrePushHook()
+
+	cmd := execx.NonInteractive(env.T.Context(), "git", "push", remote, refSpec)
+	cmd.Dir = env.RepoDir
+	cmd.Env = env.cliEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		env.T.Fatalf("git push (with hooks) %s %s failed: %v\n%s", remote, refSpec, err, output)
+	}
+}
+
+// RunPrePush runs the pre-push hook via the CLI binary, feeding realistic stdin
+// refspec lines for the current branch (see defaultPrePushStdin). This is the
+// direct-invocation stand-in for GitPushWithHooks used by tests that don't push
+// the user branch. Consistent with other CLI invocations (RunCLI) it uses
+// env.cliEnv().
 func (env *TestEnv) RunPrePush(remote string) {
 	env.T.Helper()
 	if err := env.RunPrePushWithError(remote); err != nil {
@@ -1969,11 +2014,24 @@ func (env *TestEnv) RunPrePush(remote string) {
 // RunPrePushWithError runs the pre-push hook and returns any error instead of failing.
 func (env *TestEnv) RunPrePushWithError(remote string) error {
 	env.T.Helper()
+	return env.runPrePush(remote, env.defaultPrePushStdin())
+}
 
+// RunPrePushWithStdin runs the pre-push hook feeding the given stdin verbatim.
+// Pass "" to exercise the real no-op case (a `git push` with nothing new to
+// push feeds the hook empty stdin).
+func (env *TestEnv) RunPrePushWithStdin(remote, stdin string) error {
+	env.T.Helper()
+	return env.runPrePush(remote, stdin)
+}
+
+func (env *TestEnv) runPrePush(remote, stdin string) error {
 	cmd := exec.CommandContext(env.T.Context(), getTestBinary(), "hooks", "git", "pre-push", remote)
 	cmd.Dir = env.RepoDir
 	cmd.Env = env.cliEnv()
-	cmd.Stdin = nil
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
 
 	output, err := cmd.CombinedOutput()
 	env.T.Logf("pre-push output: %s", output)
@@ -1981,6 +2039,29 @@ func (env *TestEnv) RunPrePushWithError(remote string) error {
 		return fmt.Errorf("pre-push hook failed: %w", err)
 	}
 	return nil
+}
+
+// defaultPrePushStdin builds the stdin line git feeds a pre-push hook for the
+// current branch: "<local-ref> <local-sha> <remote-ref> <remote-sha>". The
+// remote sha is all-zeros (a new branch) since it doesn't change the checkpoint
+// sync behavior. Returns "" when HEAD is detached or unresolvable, so callers
+// exercise the empty-stdin (no-op) case.
+func (env *TestEnv) defaultPrePushStdin() string {
+	branch := env.GetCurrentBranch()
+	if branch == "" {
+		return ""
+	}
+	repo, err := gitrepo.OpenPath(env.RepoDir)
+	if err != nil {
+		return ""
+	}
+	defer repo.Close()
+	head, err := repo.Head()
+	if err != nil {
+		return ""
+	}
+	ref := "refs/heads/" + branch
+	return fmt.Sprintf("%s %s %s %s\n", ref, head.Hash().String(), ref, plumbing.ZeroHash.String())
 }
 
 // FetchMetadataBranch fetches the entire/checkpoints/v1 branch from a remote URL.

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -26,6 +26,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 
@@ -63,6 +64,14 @@ type TestEnv struct {
 	// invocations (RunPrePush, GitCommitWithShadowHooks, etc.). Use this to
 	// pass ENTIRE_CHECKPOINT_TOKEN, GIT_SSL_CAINFO, and similar per-test env.
 	ExtraEnv []string
+
+	// CheckpointStore, when set (via ForEachBackend), selects the checkpoint
+	// storage backend for every spawned CLI/hook by injecting
+	// ENTIRE_CHECKPOINTS_PRIMARY into their environment. Empty means the CLI
+	// default (git-branch). It must be set before the first checkpoint-creating
+	// operation; the InitRepo/InitEntire/GitCommit factory steps create no
+	// checkpoints, so setting it right after a factory call is safe.
+	CheckpointStore string
 }
 
 // NewTestEnv creates a new isolated test environment.
@@ -130,7 +139,19 @@ func (env *TestEnv) cliEnv() []string {
 		"ENTIRE_TEST_GEMINI_PROJECT_DIR="+env.GeminiProjectDir,
 		"ENTIRE_TEST_OPENCODE_PROJECT_DIR="+env.OpenCodeProjectDir,
 	)
+	base = append(base, env.checkpointStoreEnv()...)
 	return append(base, env.ExtraEnv...)
+}
+
+// checkpointStoreEnv returns the ENTIRE_CHECKPOINTS_PRIMARY override for the
+// selected backend, or nil when unset. Included in both cliEnv (RunCLI, resume,
+// pre-push) and gitHookEnv (post-commit condensation, prepare-commit-msg) so the
+// backend is consistent across every subprocess a test spawns.
+func (env *TestEnv) checkpointStoreEnv() []string {
+	if env.CheckpointStore == "" {
+		return nil
+	}
+	return []string{settings.EnvCheckpointsPrimary + "=" + env.CheckpointStore}
 }
 
 // RunCLI runs the entire CLI with the given arguments and returns stdout.
@@ -1082,6 +1103,7 @@ func (env *TestEnv) gitHookEnv(extra ...string) []string {
 		"ENTIRE_TEST_OPENCODE_PROJECT_DIR="+env.OpenCodeProjectDir,
 		"ENTIRE_TEST_OPENCODE_MOCK_EXPORT=1",
 	)
+	envVars = append(envVars, env.checkpointStoreEnv()...)
 	return append(envVars, extra...)
 }
 
@@ -1873,6 +1895,7 @@ func (env *TestEnv) CloneFrom(bareDir string) *TestEnv {
 		ClaudeProjectDir:   claudeProjectDir,
 		GeminiProjectDir:   geminiProjectDir,
 		OpenCodeProjectDir: openCodeProjectDir,
+		CheckpointStore:    env.CheckpointStore,
 	}
 
 	// Initialize Entire in the clone

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -1961,11 +1961,14 @@ func (env *TestEnv) GitPush(remote, refSpec string) {
 }
 
 // InstallRealPrePushHook writes .git/hooks/pre-push so a plain `git push` (no
-// --no-verify) runs the checkpoint sync exactly as git runs it: git invokes the
-// hook with the remote name ($1) and URL ($2) as argv and feeds
-// "<local-ref> <local-sha> <remote-ref> <remote-sha>" lines on stdin. The hook
-// inherits the pushing process's environment, so the checkpoint-store and git
-// isolation overrides from GitPushWithHooks propagate into it.
+// --no-verify) runs the checkpoint sync through a real git-invoked hook: git
+// feeds "<local-ref> <local-sha> <remote-ref> <remote-sha>" lines on stdin
+// (inherited by the exec'd binary) and passes the remote name ($1) and URL
+// ($2) as argv. Like the production hook template (strategy/hooks.go), the
+// script forwards only the remote name — `entire hooks git pre-push` does not
+// take the URL. The hook inherits the pushing process's environment, so the
+// checkpoint-store and git isolation overrides from GitPushWithHooks propagate
+// into it.
 func (env *TestEnv) InstallRealPrePushHook() {
 	env.T.Helper()
 
@@ -2031,7 +2034,17 @@ func (env *TestEnv) GitTag(name string) {
 func (env *TestEnv) PushQueueRefs() []string {
 	env.T.Helper()
 
-	queuePath := filepath.Join(env.RepoDir, ".git", "entire-checkpoint-push-queue.jsonl")
+	// Resolve the common dir like production does (checkpoint/pushqueue.go):
+	// in a linked worktree .git is a file and the queue lives in the shared
+	// common dir, not under RepoDir/.git.
+	cmd := exec.CommandContext(env.T.Context(), "git", "rev-parse", "--path-format=absolute", "--git-common-dir")
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	commonDirOut, err := cmd.Output()
+	if err != nil {
+		env.T.Fatalf("resolve git common dir: %v", err)
+	}
+	queuePath := filepath.Join(strings.TrimSpace(string(commonDirOut)), "entire-checkpoint-push-queue.jsonl")
 	data, err := os.ReadFile(queuePath) //nolint:gosec // G304: path built from test env, not user input
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -2060,7 +2073,8 @@ func (env *TestEnv) PushQueueRefs() []string {
 }
 
 // GitPushArgsWithHooks installs the pre-push hook and runs `git push <args>`
-// (WITHOUT --no-verify) so the real hook fires exactly as git runs it, then
+// (WITHOUT --no-verify) so the real git-invoked hook fires (see
+// InstallRealPrePushHook for its fidelity notes), then
 // returns the combined output and any error instead of failing the test. Use it
 // for push shapes GitPushWithHooks can't express — a `--delete` (zero-sha stdin),
 // a tag-only push, or an expected graceful-degradation exit code.

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -1999,6 +1999,83 @@ func (env *TestEnv) GitPushWithHooks(remote, refSpec string) {
 	}
 }
 
+// SetGitConfig sets a repo-local git config value and re-baselines the
+// .git/config guard so the intentional mutation isn't flagged during cleanup
+// (mirrors the set-url + setGitConfigBaseline pattern in the HTTPS helpers).
+func (env *TestEnv) SetGitConfig(key, value string) {
+	env.T.Helper()
+	cmd := exec.CommandContext(env.T.Context(), "git", "config", key, value)
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		env.T.Fatalf("git config %s failed: %v\n%s", key, err, output)
+	}
+	env.setGitConfigBaseline()
+}
+
+// GitTag creates a lightweight tag at HEAD. Fails the test on error.
+func (env *TestEnv) GitTag(name string) {
+	env.T.Helper()
+	cmd := exec.CommandContext(env.T.Context(), "git", "tag", name)
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		env.T.Fatalf("git tag %s failed: %v\n%s", name, err, output)
+	}
+}
+
+// PushQueueRefs returns the checkpoint refs currently recorded in the git-refs
+// push queue (entire-checkpoint-push-queue.jsonl in the git common dir). It reads
+// the file directly rather than draining the queue so it is a non-destructive
+// peek. Returns nil when the queue file is absent (nothing queued).
+func (env *TestEnv) PushQueueRefs() []string {
+	env.T.Helper()
+
+	queuePath := filepath.Join(env.RepoDir, ".git", "entire-checkpoint-push-queue.jsonl")
+	data, err := os.ReadFile(queuePath) //nolint:gosec // G304: path built from test env, not user input
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		env.T.Fatalf("read push queue: %v", err)
+	}
+
+	var refs []string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry struct {
+			Ref string `json:"ref"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			env.T.Fatalf("parse push queue line %q: %v", line, err)
+		}
+		if entry.Ref != "" {
+			refs = append(refs, entry.Ref)
+		}
+	}
+	return refs
+}
+
+// GitPushArgsWithHooks installs the pre-push hook and runs `git push <args>`
+// (WITHOUT --no-verify) so the real hook fires exactly as git runs it, then
+// returns the combined output and any error instead of failing the test. Use it
+// for push shapes GitPushWithHooks can't express — a `--delete` (zero-sha stdin),
+// a tag-only push, or an expected graceful-degradation exit code.
+func (env *TestEnv) GitPushArgsWithHooks(args ...string) (string, error) {
+	env.T.Helper()
+
+	env.InstallRealPrePushHook()
+
+	cmd := execx.NonInteractive(env.T.Context(), "git", append([]string{"push"}, args...)...)
+	cmd.Dir = env.RepoDir
+	cmd.Env = env.cliEnv()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 // RunPrePush runs the pre-push hook via the CLI binary, feeding realistic stdin
 // refspec lines for the current branch (see defaultPrePushStdin). This is the
 // direct-invocation stand-in for GitPushWithHooks used by tests that don't push

--- a/cmd/entire/cli/testutil/testutil.go
+++ b/cmd/entire/cli/testutil/testutil.go
@@ -222,13 +222,48 @@ func BranchExists(t *testing.T, repoDir, branchName string) bool {
 var gitEmptyConfig string
 var gitEmptyConfigOnce sync.Once
 
+// EnvGitHermetic, when set to a non-empty value, makes gitEmptyConfigPath append
+// per-host HTTP proxy config that routes git HTTPS transport to real external
+// hosts (github.com, gitlab.com) through an unroutable loopback proxy. Any test
+// whose git commands accidentally dial those hosts then fails fast (connection
+// refused at 127.0.0.1:1) instead of reaching the network or prompting for
+// credentials. It is opt-in per test process — the integration TestMain sets it
+// — so unit test packages that don't set it are unaffected. Because
+// GitIsolatedEnv strips all inherited GIT_CONFIG_* env, this config must live in
+// the file GIT_CONFIG_GLOBAL points at (this one), not in GIT_CONFIG_* env
+// entries.
+//
+// A dead proxy (not url.insteadOf) is used deliberately: insteadOf rewrites the
+// effective URL that git reports on read, which breaks production code that
+// resolves the origin URL to detect the forge (e.g. `entire trail`). The proxy
+// blocks transport only, leaving the configured URL string intact, and is scoped
+// per host so loopback (127.0.0.1) test servers are never proxied.
+//
+// Regression class: tests accidentally hitting live github.com / the macOS
+// keychain (#1463, 53bc37a88).
+const EnvGitHermetic = "ENTIRE_TEST_GIT_HERMETIC"
+
+// hermeticGitConfig routes HTTPS transport to real external hosts through a dead
+// loopback proxy. Loopback test servers (127.0.0.1) and file:// / bare-path
+// remotes are not proxied, so the in-process HTTPS git server still works. Only
+// HTTPS is covered — the accidental-dial regression class is HTTPS fetches; SSH
+// (git@…) to a real host fails on its own without credentials.
+const hermeticGitConfig = "[http \"https://github.com/\"]\n" +
+	"\tproxy = http://127.0.0.1:1\n" +
+	"[http \"https://gitlab.com/\"]\n" +
+	"\tproxy = http://127.0.0.1:1\n"
+
 func gitEmptyConfigPath() string {
 	gitEmptyConfigOnce.Do(func() {
 		f, err := os.CreateTemp("", "git-isolation-config-*")
 		if err != nil {
 			panic("create git isolation config: " + err.Error())
 		}
-		_, err = f.WriteString("[gc]\n\tauto = 0\n\tautoDetach = false\n[maintenance]\n\tauto = false\n[fetch]\n\twriteCommitGraph = false\n")
+		content := "[gc]\n\tauto = 0\n\tautoDetach = false\n[maintenance]\n\tauto = false\n[fetch]\n\twriteCommitGraph = false\n"
+		if os.Getenv(EnvGitHermetic) != "" {
+			content += hermeticGitConfig
+		}
+		_, err = f.WriteString(content)
 		if err != nil {
 			panic("write git isolation config: " + err.Error())
 		}

--- a/docs/testing/git-remote-test-plan.md
+++ b/docs/testing/git-remote-test-plan.md
@@ -1,0 +1,160 @@
+# Test Plan: Git Remote Operations & Upstream Resolution — Both Checkpoint Backends
+
+Status: proposal, 2026-07-04.
+Scope: e2e (`e2e/tests/`) + integration (`cmd/entire/cli/integration_test/`) coverage for everything that talks to a git remote — pre-push checkpoint sync, remote/upstream resolution, cross-machine fetch — for the **git-branch** (`entire/checkpoints/v1`) and **git-refs** (`refs/entire/checkpoints/<shard>/<id>`) backends.
+
+---
+
+## 1. Where we stand
+
+### What exists
+
+| Layer | Coverage |
+|---|---|
+| Integration | `remote_operations_test.go` (12 tests: pre-push to bare file remote, checkpoint_remote routing, clone+resume, concurrent push rebase-retry, graceful degradation, filtered-fetch resume), `http_remote_test.go` (4 tests: in-process smart-HTTPS server, `ENTIRE_CHECKPOINT_TOKEN` injection, URL derivation, non-FF rebase, 401 degradation), `explain_test.go` (fetch-on-miss ×3 incl. treeless), `diverged_replay_test.go` |
+| Strategy/checkpoint unit | `push_common_test.go`, `checkpoint_remote_test.go`, `refs_push_test.go` (FF-only, fetch+replay recovery), `manual_commit_opf_rewrite_test.go`, `safely_advance_local_ref_test.go`, `replay_disconnected_test.go`, `pushqueue_test.go`, `checkpoint/remote/util_test.go` |
+| E2E | `SetupBareRemote` helper (opt-in; default harness repo has **no remote**); 4 remote-flavored tests: `resume_remote_test.go` (clone+auto-fetch ×2), `explain_test.go` (explain from clone), `doctor_test.go`, `alternates_test.go` (the only pre-push-hook e2e — **skipped under git-refs**) |
+| Backend matrix | e2e only: `E2E_CHECKPOINT_STORE` → `ENTIRE_CHECKPOINTS_PRIMARY` (`e2e/testutil/backend.go`); CI canary runs both. **Integration tests have zero git-refs parameterization.** |
+
+### Structural blind spots
+
+1. **The real git-invoked pre-push hook is never asserted end-to-end.** Integration `RunPrePush` spawns `entire hooks git pre-push <remote>` with `Stdin = nil` (`testenv.go:1950`) — real git feeds `<local-ref> <sha> <remote-ref> <sha>` lines on stdin. `GitPush` always passes `--no-verify` (`testenv.go:1926`). E2E pushes *do* run the installed hook, but every remote e2e test then calls `PushCheckpointRefs` explicitly, so a completely broken hook would go unnoticed.
+2. **The read/fetch side hardcodes `origin` everywhere** (`checkpoint/remote/util.go:18`, `git_operations.go:363-443`, `strategy/common.go`, `resume.go`, `api_cmd.go:216`, …) while the push side follows the hook's `$1`. No test has a repo whose only remote is `upstream`, a multi-remote fork triangle, or a push to a non-origin remote followed by reads.
+3. **Upstream tracking config is never consulted** (`branch.<name>.remote`, `remote.pushDefault`, separate `pushurl`) — and never pinned by a test, so we don't even document the current behavior.
+4. **git-refs remote behavior is unit-tested only**: batch FF-only push, fetch+replay recovery, queue drain/compaction/stale-pruning, on-demand `RefFetcher` — nothing at integration level, and the one hook-driven e2e skips under git-refs.
+5. **OPF pre-push rewrite has zero integration/e2e coverage** (divergence abort, CAS `V1RefMovedError`, bootstrap cap — all unit-only).
+6. **No worktree+remote coverage at all** (the git-refs push queue lives in the git *common* dir, shared across worktrees — never exercised with >1 worktree).
+7. **No SSH remotes anywhere; no shallow user clones; detached HEAD only as setup plumbing.**
+
+### History says these regress (mined from PRs/commits)
+
+- **Destructive local-v1-ref moves** — the single most re-broken area: #953, `96034892c`, #1252, #1251, #1260 (ahead/behind/diverged/disconnected/shallow × resume/explain/doctor/pre-push).
+- **Cross-clone replay fidelity**: no-op commit tree clobber (`743c43f4c` — *no test*), >1000-commit replay cap (`4cf01edb3` — *no test*), stale ls-remote hash TOCTOU (`1e8628ade` — *no test*), double-replay (#1260 has a test).
+- **Remote-target precedence**: hardcoded-origin blob fetch (#976), `entire://`/`file://` non-derivable origin (#1279), token SSH→HTTPS coercion on fetch missing (`7afdaa33e`), silent origin fallback faking success (`53bc37a88`).
+- **Errors masked as not-found**: partial-clone `ErrFileNotFound` (#1069), git-refs read paths (`7bbdad09c`).
+- **Self-inflicted shallow grafts** (#1443), promisor config pollution of `[remote "origin"]` (#934), gc pack race (#1276).
+- **Hook/transport hangs**: grandchild helper holding pipes (#1282), timeout stacking (`2e2c1b73a`), protected-ref GH013 silence (#1033).
+- **Hermeticity**: tests accidentally hitting live github.com / macOS keychain (#1463, `53bc37a88`).
+
+---
+
+## 2. Infrastructure work (enablers, do first)
+
+**I-1. Integration backend matrix.** Add a `CheckpointStore` option to `TestEnv` (sets `ENTIRE_CHECKPOINTS_PRIMARY`, inherited by spawned binaries/hooks like the e2e TestMain does) plus a `ForEachBackend(t, func(t, env))` helper. Run the whole remote-touching integration surface (`remote_operations_test.go`, `http_remote_test.go`, explain fetch-on-miss, diverged replay) under both backends; use targeted skips where behavior legitimately differs (e.g. OPF is git-branch-only).
+
+**I-2. Real-hook push in tests.**
+- Integration: `GitPushWithHooks` (no `--no-verify`) so the installed pre-push script runs exactly as git runs it (stdin refspec lines, remote name + URL argv). Keep `GitPush` for setup plumbing.
+- Fix `RunPrePush` to feed realistic stdin lines instead of nil (or replace its uses with `GitPushWithHooks`).
+- E2E: assertion helper `AssertCheckpointsOnRemote(t, s, bareDir)` that checks the backend-appropriate refs (`entire/checkpoints/v1` vs `refs/entire/checkpoints/*`) landed on the remote **without** calling `PushCheckpointRefs`.
+
+**I-3. Remote-topology helpers.** On top of the existing `SetupBareRemote`/`SetupNamedBareRemote`/`CloneFrom`: `SetupUpstreamOnlyRemote` (only remote named `upstream`), `SetupForkTriangle` (origin = fork, upstream = base), `AddWorktree(t, env, branch)` returning a second working dir sharing the common git dir.
+- Reuse `startGitHTTPSServer` (`http_remote_test.go:54`) wherever URL parsing matters (fork detection, token flows) — file-path remotes can't exercise it (`remote_operations_test.go:178-187`).
+
+**I-4. Hermeticity guard.** A TestMain-level tripwire for the integration suite: fail any test whose git commands dial a non-loopback host (e.g. `GIT_CONFIG_COUNT`-injected `url.<base>.insteadOf` redirect to an invalid local address, or asserting `ENTIRE_CHECKPOINT_TOKEN` is unset unless the test sets it). Regression class: #1463, `53bc37a88`.
+
+---
+
+## 3. Test cases
+
+Legend: **[gb]** git-branch, **[gr]** git-refs, **[both]** run under the I-1 matrix. Priority P0 = past data-loss/regression or zero coverage on a core flow; P1 = important hardening; P2 = nice-to-have/pinning.
+
+### A. Real pre-push hook, end to end — P0
+
+| # | Test | Layer | Backend |
+|---|---|---|---|
+| A1 | Plain `git push` of a feature branch (real hook, stdin refspecs) lands checkpoints on the bare remote; nothing else about the user push changes | integration + e2e | both |
+| A2 | `git push` of a branch with **no** new checkpoints → hook is a fast no-op, user push succeeds | integration | both |
+| A3 | `git push --delete <branch>` and tag-only pushes through the hook (stdin shape differs — zero-sha lines) — no checkpoint push attempted, no crash | integration | both |
+| A4 | Hook failure containment: unreachable checkpoint remote → user push still succeeds with warning (today only tested via nil-stdin `RunPrePush`) | integration | both |
+| A5 | e2e: full agent session → user commits → plain `git push` → clone in fresh dir → `entire resume` works **without any explicit `PushCheckpointRefs`** (closes the masking gap) | e2e (vogon-first) | both |
+| A6 | git-refs: `TestAlternates`-equivalent pre-push coverage — hook-driven push of queued per-checkpoint refs to a seeded bare remote, asserting FF and queue emptied (replaces the git-refs skip) | e2e | gr |
+
+### B. Remote-name & upstream resolution — P0
+
+These mostly **pin current behavior first**; several will surface product decisions (see §4).
+
+| # | Test | Layer | Backend |
+|---|---|---|---|
+| B1 | Repo whose only remote is `upstream`: enable, checkpoint, `git push upstream` → checkpoints go to `upstream` (hook `$1`); then `resume`/`explain`-from-clone document the current origin-hardcoded read failure (pin, referencing decision D-1) | integration | both |
+| B2 | Fork triangle (origin = fork, upstream = base): push to origin syncs checkpoints to origin; push to upstream — where do checkpoints go, and do subsequent reads find them? (pin) | integration | both |
+| B3 | No remote at all: pre-push not applicable, but doctor/reconcile OK ("no remote to compare", regression `cac63b010`), `entire api` `{owner}` substitution errors cleanly, status/enable don't crash | integration | both |
+| B4 | `branch.<name>.remote=upstream` with both remotes present: pin that checkpoint reads still target origin; `git push` (no args, tracking-based) routes hook `$1`=upstream — assert consistent checkpoint destination | integration | both |
+| B5 | checkpoint_remote fork detection over HTTPS server: push-remote owner ≠ checkpoint_remote owner → fallback used (today unit-only; run through a real push) | integration (HTTPS) | gb (gr: N/A until checkpoint_remote applies to refs — verify and pin) |
+| B6 | `ENTIRE_CHECKPOINT_TOKEN` with SSH-shaped origin URL (`git@host:o/r.git` pointing at the HTTPS test server via insteadOf or URL rewrite): fetch **and** push both coerce to HTTPS (regression `7afdaa33e`) | integration (HTTPS) | both |
+| B7 | Local-path origin (bare dir added as `origin`): `ParseURL` fails → raw-origin fallback still pushes/fetches correctly; no crash in URL derivation (pin; latent gap `isLocalPath`) | integration | both |
+
+### C. Cross-machine: clone → fetch → resume/explain/attribution — P0
+
+| # | Test | Layer | Backend |
+|---|---|---|---|
+| C1 | Production `fetchMetadataBranchIfMissing` path exercised for real: clone without checkpoint refs, run a pre-push settings resolution (e.g. first `git push` from the clone) → v1 fetched. Today integration substitutes raw `git fetch` (`remote_operations_test.go:316`) | integration | gb |
+| C2 | git-refs on-demand `RefFetcher`: clone, `entire explain <id>` / `resume` / `tokens` fetch exactly the needed ref (assert no v1 branch fetch, no other refs) | integration | gr |
+| C3 | git-refs offline read: unreachable remote + locally-missing ref → real error, **not** "checkpoint not found" (regression `7bbdad09c`) | integration | gr |
+| C4 | Clone over HTTPS with token: resume auto-fetch works with auth (e2e today is file-path only) | integration (HTTPS) | both |
+| C5 | Shallow user clone (`git clone --depth=1`): enable, session, commit, push, resume — no `.git/shallow` self-infliction (regressions #1443, #1276), replay refuses at shallow boundary rather than corrupting | integration | both |
+| C6 | Partial clone (`--filter=blob:none`): explain/attribution lazily fetch blobs via `fetch-pack`, no promisor config stamped onto `[remote "origin"]` (regressions #1069, #934 — extend the existing config-guard) | integration | both |
+
+### D. Divergence & recovery matrix — P0 (the most re-broken area)
+
+Systematize the ahead/behind/diverged/disconnected × operation matrix that items #953/#1251/#1252/#1260 patched piecemeal:
+
+| # | Test | Layer | Backend |
+|---|---|---|---|
+| D1 | Table-driven: local v1 {ahead, behind, diverged, disconnected(no merge-base), missing} × trigger {resume, explain fetch-on-miss, pre-push, doctor} → local-only commits always survive; behind → FF; diverged → replay preserving both sides; count assertions guard double-replay | integration | gb |
+| D2 | Same matrix for git-refs per-checkpoint refs: remote-ahead ref (another clone amended) → fetch+replay+non-force retry lands both; genuine conflict → ref stays queued, remote untouched, next push retries | integration | gr |
+| D3 | Concurrent pushers from two clones (extend `TestConcurrentPush_...` to git-refs; the v1 version exists) | integration | gr |
+| D4 | Replay fidelity edges: no-op commit replay must not clobber the remote tip's tree (`743c43f4c` — currently untested); root-commit replay; >1000 local-only commits push successfully (`4cf01edb3` — currently untested) | integration or strategy unit | gb |
+| D5 | TOCTOU: remote advances between ls-remote and fetch → reconcile uses fetched hash (`1e8628ade` — currently untested; simulatable with a pre-fetch hook on the bare remote or an interposed fetch) | strategy unit/integration | gb |
+| D6 | Multi-worktree git-refs queue: two worktrees enqueue checkpoints; `git push` from worktree A drains the shared common-dir queue — worktree B's refs also pushed, queue compacted; stale refs pruned | integration | gr |
+| D7 | Pin the known two-remote queue bug: push to remote A drains the queue, so remote B never receives those refs (decision D-2 — pin now, flip assertion when fixed) | integration | gr |
+
+### E. OPF pre-push rewrite (git-branch only) — P1
+
+| # | Test | Layer |
+|---|---|---|
+| E1 | OPF enabled, happy path over a real bare remote via real hook: unpushed v1 commits rewritten with `Entire-OPF-Applied: true`, pushed; remote content is the redacted version | integration |
+| E2 | Diverged v1 during rewrite → `V1DivergedError` aborts the **user** push with the actionable message | integration |
+| E3 | CAS conflict: concurrent checkpoint write between rewrite and ref-update → `V1RefMovedError`, re-run push succeeds | integration |
+| E4 | Bootstrap cap: remote has no v1 + local history over cap → typed abort, nothing pushed | integration |
+| E5 | Non-TTY push with OPF (regression `626a0344e`): no /dev/tty writes, hook completes | integration |
+
+### F. Degraded remotes & protocol edges — P1
+
+| # | Test | Layer | Backend |
+|---|---|---|---|
+| F1 | Protected v1 branch (GH013 emulation via bare-remote `pre-receive` hook): loud banner, no retry loop, user push unaffected (regression #1033 — currently unit-only on output classification) | integration | gb |
+| F2 | Hook time bounds: unreachable/hanging remote (HTTPS server that accepts then stalls) → pre-push respects the shared push budget, no per-attempt timeout stacking (regressions #1282, `2e2c1b73a`) | integration (HTTPS) | both |
+| F3 | 401→token-retry over HTTPS for git-refs batch push (v1 version exists: `TestHTTPS_PushFailsWithoutToken`) | integration (HTTPS) | gr |
+| F4 | Checkpoint policy sync in the git-refs pre-push path (regression `7bbdad09c` — policy check was skipped): blocked policy skips checkpoint refs but not the user push | integration | gr |
+| F5 | Detached HEAD: session + checkpoint while detached; `git push origin HEAD:branch`; resume from detached clone (today detach is only setup plumbing) | integration | both |
+| F6 | `entire://` origin with checkpoint_remote configured → provider-host routing, not a push at the helper (regression #1279) — currently unit-only; needs a fake provider mapping or injectable host table | integration | gb |
+
+### G. E2E additions (real agents optional, vogon default) — P1
+
+- G1: extend `resume_remote_test.go` + `explain_test.go` clone tests to rely on the real hook (drop `PushCheckpointRefs`, see A5) and run under both `E2E_CHECKPOINT_STORE` values in the CI canary matrix.
+- G2: one e2e worktree scenario: session in a linked worktree, commit, push from the worktree, clone elsewhere, resume (covers worktree shadow-branch namespace + shared queue end-to-end).
+- G3: doctor e2e on a repo with unreachable remote (today `TestDoctorNoIssues` only covers healthy).
+
+### H. Explicit non-goals (for now)
+
+- Real SSH transport (sshd in CI) — the SSH-specific logic is URL parsing/coercion, covered at unit + B6; a real sshd adds flake for little marginal signal.
+- GitLab token semantics, GHE forge mapping — product questions before tests (see D-3 below).
+- `git-remote-entire` replica failover internals — separately tested in `internal/remotehelper`.
+
+---
+
+## 4. Product decisions the tests will force (flag before pinning)
+
+- **D-1 non-origin reads**: pushing checkpoints to `upstream` (hook `$1`) while every read path fetches from `origin` is incoherent. Decide: teach reads to use the checkpoint-bearing remote (e.g. remember last push remote, or consult `branch.<name>.remote`), or document origin-only support and warn on non-origin pushes. B1/B2/B4 pin whichever is chosen.
+- **D-2 multi-remote queue clearing** (git-refs): queue entries are deleted after a successful push to *any* remote — second remote permanently misses refs. Probably needs per-remote tracking or "delete only when pushed to the fetch-resolution target". D7 pins current behavior until then.
+- **D-3 forge map / provider table**: only `github.com`→`gh` and github/gitlab provider hosts exist; GHE/self-hosted silently degrade (`{repo_id}`, trails). Decide config story before writing tests beyond pinning.
+
+## 5. Suggested sequencing
+
+1. **PR 1 — infrastructure**: I-1 (backend matrix for integration), I-2 (real-hook push helpers + RunPrePush stdin), I-4 (hermeticity tripwire). Immediately re-run the existing remote suites under git-refs; expect it to surface real bugs the same way the e2e matrix did (`refs-v1` policy, explain-clone fetch).
+2. **PR 2 — P0 hook & cross-machine**: A1–A6, C1–C4, plus e2e G1.
+3. **PR 3 — divergence matrix**: D1–D7 (D4/D5 fill known untested regressions).
+4. **PR 4 — remote-name/upstream pinning**: B1–B7 after a decision on D-1 (or with explicit "pins current behavior" markers).
+5. **PR 5 — OPF + degraded**: E1–E5, F1–F6, G2–G3, C5–C6.
+
+Rough sizing: PRs 1–3 are the high-value core (~2/3 of the risk reduction, all P0); 4–5 can trail.

--- a/e2e/tests/explain_test.go
+++ b/e2e/tests/explain_test.go
@@ -66,8 +66,10 @@ func TestExplainCheckpointFromClonedRepo(t *testing.T) {
 		testutil.WaitForCheckpoint(t, s, 30*time.Second)
 
 		checkpointID := testutil.AssertHasCheckpointTrailer(t, s.Dir, "HEAD")
+		// Plain push runs the installed pre-push hook, which syncs checkpoints —
+		// no explicit PushCheckpointRefs. This exercises the real hook end to end.
 		s.Git(t, "push", "-u", "origin", "feature")
-		testutil.PushCheckpointRefs(t, s.Dir)
+		testutil.AssertCheckpointsOnRemote(t, s, bareDir)
 
 		cloneDir := t.TempDir()
 		if resolved, symErr := filepath.EvalSymlinks(cloneDir); symErr == nil {

--- a/e2e/tests/resume_remote_test.go
+++ b/e2e/tests/resume_remote_test.go
@@ -44,9 +44,11 @@ func TestResumeFromClonedRepo(t *testing.T) {
 		checkpointID := testutil.AssertHasCheckpointTrailer(t, s.Dir, "HEAD")
 		sessionMeta := testutil.WaitForSessionMetadata(t, s.Dir, checkpointID, 0, 30*time.Second)
 
-		// Push feature branch and checkpoint refs to the bare remote.
+		// Push the feature branch. The installed pre-push hook syncs checkpoints as
+		// part of the plain push — no explicit PushCheckpointRefs — so this covers
+		// the real hook end to end (A5/G1).
 		s.Git(t, "push", "-u", "origin", "feature")
-		testutil.PushCheckpointRefs(t, s.Dir)
+		testutil.AssertCheckpointsOnRemote(t, s, bareDir)
 
 		// Clone the repo to a new directory (simulating a teammate).
 		cloneDir := t.TempDir()

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -199,6 +199,26 @@ func PushCheckpointRefs(t *testing.T, dir string) {
 	Git(t, dir, "push", "origin", checkpointRefV1+":"+checkpointRefV1)
 }
 
+// AssertCheckpointsOnRemote asserts that the backend-appropriate committed
+// checkpoint refs are present on the bare remote at bareDir: the
+// entire/checkpoints/v1 branch (git-branch) or at least one
+// refs/entire/checkpoints/* ref (git-refs). Use it in remote e2e tests to verify
+// the real pre-push hook synced checkpoints WITHOUT an explicit PushCheckpointRefs.
+func AssertCheckpointsOnRemote(t *testing.T, _ *RepoState, bareDir string) {
+	t.Helper()
+
+	if UsingGitRefs() {
+		out := gitOutputSafe(bareDir, "for-each-ref", "--format=%(refname)", checkpointRefPrefix)
+		if strings.TrimSpace(out) == "" {
+			t.Errorf("expected at least one %s* ref on remote %s, found none", checkpointRefPrefix, bareDir)
+		}
+		return
+	}
+	if _, err := GitOutputErr(bareDir, "rev-parse", "--verify", "refs/heads/"+checkpointRefV1); err != nil {
+		t.Errorf("expected %s branch on remote %s: %v", checkpointRefV1, bareDir, err)
+	}
+}
+
 func setupGeminiTestHome(t *testing.T, repoDir string) {
 	t.Helper()
 

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -208,7 +208,11 @@ func AssertCheckpointsOnRemote(t *testing.T, _ *RepoState, bareDir string) {
 	t.Helper()
 
 	if UsingGitRefs() {
-		out := gitOutputSafe(bareDir, "for-each-ref", "--format=%(refname)", checkpointRefPrefix)
+		out, err := GitOutputErr(bareDir, "for-each-ref", "--format=%(refname)", checkpointRefPrefix)
+		if err != nil {
+			t.Errorf("listing %s* refs on remote %s failed: %v", checkpointRefPrefix, bareDir, err)
+			return
+		}
 		if strings.TrimSpace(out) == "" {
 			t.Errorf("expected at least one %s* ref on remote %s, found none", checkpointRefPrefix, bareDir)
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/758
<!-- entire-trail-link-end -->

Part 2 of the stack on #1636. The P0 test groups from the plan, plus two fixes they surfaced.

## Tests

- **A-group (real pre-push hook, both backends)**: plain-push checkpoint sync with user-push assertions (A1), no-new-checkpoints no-op via remote digest (A2), branch-delete and tag-only pushes through the hook (A3), unreachable checkpoint target degrades gracefully under the real hook (A4), git-refs queue drain via real push (A6 slice).
- **C-group (cross-machine clone flows)**: production `fetchMetadataBranchIfMissing` exercised for real over HTTPS (C1 — previous clone tests substituted a raw `git fetch`), git-refs on-demand `RefFetcher` fetches exactly the needed ref and nothing else (C2), unreachable-remote reads surface the real fetch error (C3), authenticated HTTPS clone auto-fetch under both backends (C4).
- **G1 (e2e)**: `resume_remote_test.go` / `explain_test.go` clone tests now rely on the installed hook (`AssertCheckpointsOnRemote`) instead of explicit `PushCheckpointRefs` — a broken hook can no longer pass the e2e suite.

## Fixes

- **Graceful-degradation test false-positive**: the test staged the session's files *after* the stop hook, so neither backend condensed anything; git-branch passed only because the v1 branch was inherited from the clone. Reordered to stage-before-stop and the assertion now requires a *new* checkpoint ID.
- **`fix: surface git-refs checkpoint fetch failures in explain fallback`**: `matchCheckpointPrefixWithRemoteFallback` discarded the `FetchCheckpointRef` error, reporting an unreachable remote identically to an absent checkpoint — re-masking the error class 7bbdad09c fixed at the store layer. The fallback now propagates the error (repos with no resolvable checkpoint source keep the clean not-found; the commit-ref prefetch stays best-effort; the v1-branch path keeps its historical fail-soft behavior). C3 asserts it hard.

## Verification

- `mise run fmt && mise run lint` clean per commit
- `mise run test:integration` green (430 tests, 0 skips at tip)
- `mise run test:e2e:canary` green under both `E2E_CHECKPOINT_STORE` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yi3hHGAGepwfrfjPETjGq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible error handling on checkpoint explain and attribution when remotes are unreachable; behavior is more correct but could surprise scripts that only matched on “not found”.
> 
> **Overview**
> Adds broad **integration and e2e coverage** for checkpoint sync and cross-machine reads: real `git push` through the installed pre-push hook (sync, no-op pushes, delete/tag shapes, unreachable `checkpoint_remote`, git-refs push-queue drain), HTTPS clone flows (`fetchMetadataBranchIfMissing`, tokenized auto-fetch, per-ref `RefFetcher` precision), plus e2e tests that assert checkpoints land on the remote via the hook instead of explicit `PushCheckpointRefs`.
> 
> **Fixes misleading “checkpoint not found” when the remote fetch actually failed** (regression 7bbdad09c): `matchCheckpointPrefixWithRemoteFallback` now returns a third `error` value; git-refs `FetchCheckpointRef` failures and post-fetch re-list errors propagate through `checkpoint explain`, JSON export, and attribution remote enrichment. Repos with no resolvable remote still get a clean local not-found; the v1 metadata-branch path keeps prior fail-soft behavior.
> 
> **Test harness / correctness tweaks:** `TestEnv` helpers for config, tags, push-queue peek, and hook pushes with arbitrary args; graceful-degradation clone test stages files before stop and requires a **new** checkpoint ID (fixes a false positive from inherited v1 metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f48e203a04ca51d9df3cd1c7f005a437472be8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->