### PR TITLE
test: git-remote coverage (3/4) — divergence & recovery matrix

### DIFF
--- a/cmd/entire/cli/integration_test/divergence_matrix_test.go
+++ b/cmd/entire/cli/integration_test/divergence_matrix_test.go
@@ -1,0 +1,254 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// D1 -- git-branch divergence & recovery matrix
+//
+// Systematizes the local-v1 state {ahead, behind, diverged, disconnected,
+// missing} x trigger {pre-push, explain fetch-on-miss, doctor} matrix that the
+// #953/#1251/#1252/#1260 fixes patched piecemeal. The reconcile engine itself
+// (SafelyAdvanceLocalRef, ReconcileDisconnectedMetadataRef, cherryPickOnto) is
+// unit-tested exhaustively in the strategy package (safely_advance_local_ref_test.go,
+// metadata_reconcile_test.go); these tests exercise it end-to-end through the
+// real CLI triggers, where the historical regressions actually lived (wiring).
+//
+// git-branch only: assertions read the single v1 branch tree and its tip parent
+// count. The git-refs per-checkpoint-ref divergence matrix is D2/D3.
+//
+// Invariants across the matrix:
+//   - local-only commits always survive;
+//   - a diverged push replays local onto remote, preserving BOTH sides;
+//   - the replay is linear (tip has one parent), and a repeated trigger is
+//     idempotent -- the double-replay guard for #1260.
+// =============================================================================
+
+// advanceRemoteV1 clones bareDir, runs a real checkpointed session on a throwaway
+// branch, and pushes its v1 through the pre-push hook so the remote v1 branch
+// advances by one checkpoint as if another machine had pushed. Returns the new
+// remote-only checkpoint ID. The prompt is embedded in the checkpoint so callers
+// can assert on it after a fetch-on-miss read.
+func advanceRemoteV1(t *testing.T, srcEnv *TestEnv, bareDir, prompt string) string {
+	t.Helper()
+
+	other := srcEnv.CloneFrom(bareDir)
+	other.GitCheckoutNewBranch("feature/remote-advance")
+	cp := createCheckpointedCommit(t, other, prompt, "remote_adv.go", "package remoteadv", prompt)
+	require.NotEmpty(t, cp, "remote-advance clone should produce a checkpoint")
+	// Push only the checkpoint refs (not the throwaway branch) to advance remote v1.
+	other.RunPrePush("origin")
+	require.True(t, srcEnv.CheckpointExistsOnRemote(bareDir, cp),
+		"remote v1 should carry the advanced checkpoint after the clone pushed")
+	return cp
+}
+
+// forceLocalV1Orphan replaces the local entire/checkpoints/v1 branch with an
+// orphan commit (no shared history with the remote) carrying a single checkpoint
+// shard. This reproduces the empty-orphan-bug artifact: a local v1 that is
+// disconnected from the remote v1. It builds the commit with plumbing + a
+// temporary index so the working tree and current branch are untouched.
+func forceLocalV1Orphan(t *testing.T, env *TestEnv, checkpointID string) {
+	t.Helper()
+
+	metaPath := CheckpointSummaryPath(checkpointID)
+	content := `{"checkpoint_id":"` + checkpointID + `"}`
+
+	runGit := func(stdin string, args ...string) string {
+		c := exec.CommandContext(env.T.Context(), "git", args...)
+		c.Dir = env.RepoDir
+		c.Env = append(testutil.GitIsolatedEnv(), "GIT_INDEX_FILE="+env.RepoDir+"/.git/entire-orphan-index")
+		if stdin != "" {
+			c.Stdin = strings.NewReader(stdin)
+		}
+		out, err := c.CombinedOutput()
+		require.NoError(t, err, "git %v failed: %s", args, out)
+		return strings.TrimSpace(string(out))
+	}
+
+	blobSHA := runGit(content, "hash-object", "-w", "--stdin")
+	runGit("", "read-tree", "--empty")
+	runGit("", "update-index", "--add", "--cacheinfo", "100644,"+blobSHA+","+metaPath)
+	treeSHA := runGit("", "write-tree")
+	commitSHA := runGit("", "commit-tree", treeSHA, "-m", "Checkpoint: "+checkpointID)
+	runGit("", "update-ref", plumbingBranchRef(paths.MetadataBranchName), commitSHA)
+}
+
+func plumbingBranchRef(shortName string) string { return "refs/heads/" + shortName }
+
+// TestDivergedV1_PrePushMatrix drives the real pre-push hook against each local-v1
+// divergence state and asserts the invariants. It stays on the default git-branch
+// backend (D1 is git-branch).
+func TestDivergedV1_PrePushMatrix(t *testing.T) {
+	t.Parallel()
+
+	for _, state := range []string{"ahead", "behind", "diverged", "disconnected"} {
+		t.Run(state, func(t *testing.T) {
+			t.Parallel()
+
+			env := NewFeatureBranchEnv(t)
+			bareDir := env.SetupBareRemote()
+
+			// Shared base: one checkpoint pushed so local and remote v1 align.
+			baseCP := createCheckpointedCommit(t, env, "base work", "base.go", "package base", "base work")
+			require.NotEmpty(t, baseCP)
+			env.GitPush("origin", "HEAD")
+			env.RunPrePush("origin")
+			require.True(t, env.CheckpointExistsOnRemote(bareDir, baseCP), "base checkpoint should be on remote")
+
+			var localCP, remoteCP string
+			switch state {
+			case "ahead":
+				// Local v1 gains a checkpoint that is never pushed; remote stays at base.
+				localCP = createCheckpointedCommit(t, env, "local ahead", "ahead.go", "package ahead", "local ahead")
+			case "behind":
+				// Remote v1 advances independently; local stays at base with stale tracking.
+				remoteCP = advanceRemoteV1(t, env, bareDir, "remote behind work")
+			case "diverged":
+				// Both sides add a checkpoint from the shared base.
+				localCP = createCheckpointedCommit(t, env, "local diverge", "diverge.go", "package diverge", "local diverge")
+				remoteCP = advanceRemoteV1(t, env, bareDir, "remote diverge work")
+			case "disconnected":
+				// Local v1 becomes an orphan sharing no ancestry with the remote base.
+				localCP = "abcdef012345"
+				forceLocalV1Orphan(t, env, localCP)
+			}
+
+			// A plain, pushable feature commit guarantees git invokes the pre-push hook
+			// (an up-to-date push would skip it).
+			trigger := "push-trigger-" + state + ".txt"
+			env.WriteFile(trigger, "x")
+			env.GitAdd(trigger)
+			env.GitCommit("push trigger (" + state + ")")
+
+			env.GitPushWithHooks("origin", "HEAD")
+
+			// The base checkpoint survives on the remote in every state.
+			require.True(t, env.CheckpointExistsOnRemote(bareDir, baseCP),
+				"[%s] base checkpoint must always survive on the remote", state)
+
+			switch state {
+			case "ahead":
+				require.True(t, env.CheckpointExistsOnRemote(bareDir, localCP),
+					"ahead: local-only checkpoint should fast-forward onto the remote")
+			case "behind":
+				// Stale tracking makes the hook a safe no-op: the remote's own
+				// checkpoint is untouched and nothing is lost. (Local reconcile to
+				// a behind remote happens on READ triggers -- see the explain test.)
+				require.True(t, env.CheckpointExistsOnRemote(bareDir, remoteCP),
+					"behind: the remote's checkpoint must remain")
+			case "diverged":
+				require.True(t, env.CheckpointExistsOnRemote(bareDir, localCP),
+					"diverged: local checkpoint must be replayed onto the remote")
+				require.True(t, env.CheckpointExistsOnRemote(bareDir, remoteCP),
+					"diverged: remote checkpoint must be preserved (not overwritten)")
+				require.Equal(t, 1, env.GetBranchTipParentCount(paths.MetadataBranchName),
+					"diverged: local v1 tip must be linear after replay (double-replay guard, #1260)")
+			case "disconnected":
+				require.True(t, env.CheckpointExistsOnRemote(bareDir, localCP),
+					"disconnected: orphaned local checkpoint must be cherry-picked onto the remote")
+			}
+
+			// Double-replay guard (#1260): an immediately repeated pre-push must be
+			// idempotent -- the remote checkpoint state stays byte-for-byte identical.
+			before := env.RemoteCheckpointState(bareDir)
+			env.RunPrePush("origin")
+			after := env.RemoteCheckpointState(bareDir)
+			require.Equal(t, before, after,
+				"[%s] a repeated pre-push must not re-replay or otherwise mutate the remote", state)
+		})
+	}
+}
+
+// TestDivergedV1_ExplainFetchOnMiss covers the read-path (fetch-on-miss) reconcile
+// for the {behind, diverged} states, extending the existing missing/ahead coverage
+// (TestExplain_CheckpointFetchesFromRemoteWhenMissingLocally,
+// TestExplain_CheckpointFetchDoesNotRewindLocalAheadBranch). Reading a remote-only
+// checkpoint fetches and reconciles the local v1 (SafelyAdvanceLocalRef) so the
+// remote checkpoint becomes visible while any local-only checkpoint survives.
+func TestDivergedV1_ExplainFetchOnMiss(t *testing.T) {
+	t.Parallel()
+
+	for _, state := range []string{"behind", "diverged"} {
+		t.Run(state, func(t *testing.T) {
+			t.Parallel()
+
+			env := NewFeatureBranchEnv(t)
+			bareDir := env.SetupBareRemote()
+
+			baseCP := createCheckpointedCommit(t, env, "base work", "base.go", "package base", "base work")
+			require.NotEmpty(t, baseCP)
+			env.GitPush("origin", "HEAD")
+			env.RunPrePush("origin")
+
+			var localCP string
+			if state == "diverged" {
+				localCP = createCheckpointedCommit(t, env, "local diverge", "diverge.go", "package diverge", "local diverge")
+			}
+
+			remoteCP := advanceRemoteV1(t, env, bareDir, "remote read-path work")
+
+			// The remote-only checkpoint is not present locally yet.
+			require.False(t, env.FileExistsInBranch(paths.MetadataBranchName, CheckpointSummaryPath(remoteCP)),
+				"[%s] remote checkpoint should be absent locally before the fetch-on-miss read", state)
+
+			// Reading it triggers the fetch + reconcile.
+			out := env.RunCLI("checkpoint", "explain", "--checkpoint", remoteCP)
+			require.Contains(t, out, "remote read-path work",
+				"[%s] explain should fetch the remote-only checkpoint and surface its prompt", state)
+
+			// The local-only checkpoint (diverged case) must survive the reconcile.
+			if localCP != "" {
+				survived := env.RunCLI("checkpoint", "explain", "--checkpoint", localCP)
+				require.Contains(t, survived, "local diverge",
+					"diverged: local-only checkpoint must remain discoverable after fetch-on-miss reconcile")
+			}
+		})
+	}
+}
+
+// TestDivergedV1_DoctorReconcilesDisconnected exercises the doctor trigger: a
+// disconnected local v1 (orphan sharing no ancestry with the remote) is repaired
+// by `entire doctor --force`, which cherry-picks the local checkpoints onto the
+// remote tip so both sides survive. This is the CLI-level counterpart to the
+// strategy unit tests for ReconcileDisconnectedMetadataRef.
+func TestDivergedV1_DoctorReconcilesDisconnected(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	bareDir := env.SetupBareRemote()
+
+	baseCP := createCheckpointedCommit(t, env, "base work", "base.go", "package base", "base work")
+	require.NotEmpty(t, baseCP)
+	env.GitPush("origin", "HEAD")
+	env.RunPrePush("origin")
+	require.True(t, env.CheckpointExistsOnRemote(bareDir, baseCP))
+
+	// Refresh the remote-tracking ref (doctor compares local v1 against
+	// refs/remotes/origin/<v1> and does not fetch on its own), then orphan the
+	// local v1 so it is disconnected from that tracked base.
+	env.FetchMetadataBranch(bareDir)
+	orphanCP := "abcdef012345"
+	forceLocalV1Orphan(t, env, orphanCP)
+
+	out := env.RunCLI("doctor", "--force")
+	require.Contains(t, out, "reconciled", "doctor should report it reconciled the disconnected branches")
+
+	// After the fix the local v1 carries BOTH the remote base checkpoint and the
+	// orphaned local checkpoint on a single connected history.
+	require.True(t, env.FileExistsInBranch(paths.MetadataBranchName, CheckpointSummaryPath(baseCP)),
+		"doctor: remote base checkpoint must be present locally after reconcile")
+	require.True(t, env.FileExistsInBranch(paths.MetadataBranchName, CheckpointSummaryPath(orphanCP)),
+		"doctor: orphaned local checkpoint must survive the reconcile")
+	require.Equal(t, 1, env.GetBranchTipParentCount(paths.MetadataBranchName),
+		"doctor: reconciled v1 tip must be linear (cherry-pick, not merge)")
+}

--- a/cmd/entire/cli/integration_test/divergence_matrix_test.go
+++ b/cmd/entire/cli/integration_test/divergence_matrix_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -66,7 +67,7 @@ func forceLocalV1Orphan(t *testing.T, env *TestEnv, checkpointID string) {
 	runGit := func(stdin string, args ...string) string {
 		c := exec.CommandContext(env.T.Context(), "git", args...)
 		c.Dir = env.RepoDir
-		c.Env = append(testutil.GitIsolatedEnv(), "GIT_INDEX_FILE="+env.RepoDir+"/.git/entire-orphan-index")
+		c.Env = append(testutil.GitIsolatedEnv(), "GIT_INDEX_FILE="+filepath.Join(env.RepoDir, ".git", "entire-orphan-index"))
 		if stdin != "" {
 			c.Stdin = strings.NewReader(stdin)
 		}

--- a/cmd/entire/cli/integration_test/refs_divergence_test.go
+++ b/cmd/entire/cli/integration_test/refs_divergence_test.go
@@ -1,0 +1,296 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// D2 / D3 -- git-refs per-checkpoint ref divergence & recovery (integration).
+//
+// The unit-level recovery is covered in strategy/refs_push_test.go
+// (TestBatchPushRefs_RejectsNonFastForward, TestPushCheckpointRefWithRecovery_
+// MergesDivergedRef). These drive the same behaviour end-to-end through the real
+// pre-push path (drain the push queue -> batch push -> per-ref fetch+replay
+// recovery), where the checkpoint ref really lives on a bare remote.
+// =============================================================================
+
+// checkpointIdentityEnv is a git env with a committer/author identity, needed by
+// commit-tree in a bare remote (which has no repo-local user config).
+func checkpointIdentityEnv() []string {
+	return append(testutil.GitIsolatedEnv(),
+		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.com",
+	)
+}
+
+// amendCheckpointRef advances the checkpoint ref in the repo at dir to a new
+// child commit of base that adds fileName. It builds the commit with plumbing +
+// a temporary index so no working tree is required (works in a bare remote too),
+// then updates the ref. Returns the new commit hash. This models another clone
+// (or the bare's own state) advancing a per-checkpoint ref.
+func amendCheckpointRef(t *testing.T, dir, ref, base, fileName, content string) string {
+	t.Helper()
+
+	idxPath := filepath.Join(t.TempDir(), "amend-index")
+	run := func(stdin string, args ...string) string {
+		c := exec.CommandContext(t.Context(), "git", args...)
+		c.Dir = dir
+		c.Env = append(checkpointIdentityEnv(), "GIT_INDEX_FILE="+idxPath)
+		if stdin != "" {
+			c.Stdin = strings.NewReader(stdin)
+		}
+		out, err := c.CombinedOutput()
+		require.NoError(t, err, "git %v in %s failed: %s", args, dir, out)
+		return strings.TrimSpace(string(out))
+	}
+
+	run("", "read-tree", base)
+	blobSHA := run(content, "hash-object", "-w", "--stdin")
+	run("", "update-index", "--add", "--cacheinfo", "100644,"+blobSHA+","+fileName)
+	treeSHA := run("", "write-tree")
+	commitSHA := run("", "commit-tree", treeSHA, "-p", base, "-m", "amend "+fileName)
+	run("", "update-ref", ref, commitSHA)
+	return commitSHA
+}
+
+// enqueueCheckpointRef appends ref to the git-refs push queue in the repo's git
+// common dir, so the next pre-push drains and pushes it. Mirrors what a checkpoint
+// write does internally.
+func enqueueCheckpointRef(t *testing.T, env *TestEnv, ref string) {
+	t.Helper()
+
+	commonDir := gitCommonDir(t, env.RepoDir)
+	queuePath := filepath.Join(commonDir, "entire-checkpoint-push-queue.jsonl")
+	f, err := os.OpenFile(queuePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.WriteString(`{"ref":"` + ref + `"}` + "\n")
+	require.NoError(t, err)
+}
+
+// gitCommonDir resolves the git common dir for a repo/worktree dir.
+func gitCommonDir(t *testing.T, dir string) string {
+	t.Helper()
+	c := exec.CommandContext(t.Context(), "git", "rev-parse", "--git-common-dir")
+	c.Dir = dir
+	c.Env = testutil.GitIsolatedEnv()
+	out, err := c.Output()
+	require.NoError(t, err, "resolve git common dir")
+	common := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(dir, common)
+	}
+	return common
+}
+
+// refHashIn returns the commit hash a ref points at in the repo at dir.
+func refHashIn(t *testing.T, dir, ref string) string {
+	t.Helper()
+	c := exec.CommandContext(t.Context(), "git", "rev-parse", ref)
+	c.Dir = dir
+	c.Env = testutil.GitIsolatedEnv()
+	out, err := c.Output()
+	require.NoError(t, err, "rev-parse %s in %s", ref, dir)
+	return strings.TrimSpace(string(out))
+}
+
+// refTreeFilesIn lists the files in the tree a ref points at in the repo at dir.
+func refTreeFilesIn(t *testing.T, dir, ref string) string {
+	t.Helper()
+	c := exec.CommandContext(t.Context(), "git", "ls-tree", "-r", "--name-only", ref)
+	c.Dir = dir
+	c.Env = testutil.GitIsolatedEnv()
+	out, err := c.CombinedOutput()
+	require.NoError(t, err, "ls-tree %s in %s: %s", ref, dir, out)
+	return string(out)
+}
+
+// isAncestorIn reports whether ancestor is an ancestor of descendant in dir.
+func isAncestorIn(t *testing.T, dir, ancestor, descendant string) bool {
+	t.Helper()
+	c := exec.CommandContext(t.Context(), "git", "merge-base", "--is-ancestor", ancestor, descendant)
+	c.Dir = dir
+	c.Env = testutil.GitIsolatedEnv()
+	return c.Run() == nil
+}
+
+// fetchCheckpointRefLocally fetches a single checkpoint ref from origin into the
+// same ref name locally (so a clone can then amend and diverge it).
+func fetchCheckpointRefLocally(t *testing.T, env *TestEnv, ref string) {
+	t.Helper()
+	c := exec.CommandContext(t.Context(), "git", "fetch", "--no-tags", "origin", ref+":"+ref)
+	c.Dir = env.RepoDir
+	c.Env = testutil.GitIsolatedEnv()
+	out, err := c.CombinedOutput()
+	require.NoError(t, err, "fetch checkpoint ref %s: %s", ref, out)
+}
+
+// TestGitRefsDivergence_RemoteAheadRefFetchReplaysNonForce is D2's primary case:
+// the remote checkpoint ref was amended by another clone (a valid child commit).
+// A local divergent write of the SAME ref then pushes through the real pre-push
+// path: the fast-forward-only batch push is rejected, recovery fetches the remote
+// tip and replays the local-only change on top (non-force), so BOTH sides' files
+// survive and the remote's commit is preserved as an ancestor.
+func TestGitRefsDivergence_RemoteAheadRefFetchReplaysNonForce(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitRefs
+	bareDir := env.SetupBareRemote()
+
+	cp := createCheckpointedCommit(t, env, "Add module", "mod.go", "package mod", "Add module")
+	require.NotEmpty(t, cp)
+	ref := checkpointRefName(cp)
+
+	// Push the checkpoint ref to the remote (remote ref = C0).
+	env.RunPrePush("origin")
+	require.True(t, env.CheckpointExistsOnRemote(bareDir, cp))
+	c0 := refHashIn(t, bareDir, ref)
+
+	// Another clone amends the same checkpoint on the remote: remote ref -> C_remote
+	// (a child of C0 that adds remote_side.txt).
+	cRemote := amendCheckpointRef(t, bareDir, ref, c0, "remote_side.txt", "remote change")
+
+	// Locally, diverge the same ref to a sibling child of C0 (adds local_side.txt)
+	// and enqueue it for the next push.
+	amendCheckpointRef(t, env.RepoDir, ref, c0, "local_side.txt", "local change")
+	enqueueCheckpointRef(t, env, ref)
+
+	// Real pre-push path: batch push is non-fast-forward -> recovery fetch+replay.
+	env.RunPrePush("origin")
+
+	// Both sides' files survive on the remote ref.
+	files := refTreeFilesIn(t, bareDir, ref)
+	require.Contains(t, files, "remote_side.txt", "remote-only change must be preserved (non-force)")
+	require.Contains(t, files, "local_side.txt", "local-only change must be replayed on top")
+
+	// Non-force: the remote's amended commit remains an ancestor of the new tip.
+	newRemote := refHashIn(t, bareDir, ref)
+	require.True(t, isAncestorIn(t, bareDir, cRemote, newRemote),
+		"the remote's amended commit must be preserved as an ancestor, never overwritten")
+
+	// The queue was drained by the successful recovery push.
+	require.Empty(t, env.PushQueueRefs(), "push queue should be drained after the recovery push landed")
+}
+
+// TestGitRefsDivergence_RejectedRefStaysQueuedRemoteUntouched is D2's queue-safety
+// case: when the remote refuses the checkpoint ref update, the ref is left queued
+// and the remote ref is untouched (never force-overwritten); a later push, once
+// the remote accepts writes again, lands it.
+//
+// A pure content-level cherry-pick conflict is not reproducible at this layer
+// (the tree-delta apply is last-writer, not a 3-way merge), so a server-side
+// rejection (a bare pre-receive hook that declines the checkpoint namespace)
+// stands in for "the ref could not land" — exercising the same "stays queued,
+// remote untouched, retry next time" property.
+func TestGitRefsDivergence_RejectedRefStaysQueuedRemoteUntouched(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitRefs
+	bareDir := env.SetupBareRemote()
+
+	cp := createCheckpointedCommit(t, env, "Add module", "mod.go", "package mod", "Add module")
+	require.NotEmpty(t, cp)
+	ref := checkpointRefName(cp)
+
+	env.RunPrePush("origin")
+	require.True(t, env.CheckpointExistsOnRemote(bareDir, cp))
+	remoteBefore := refHashIn(t, bareDir, ref)
+
+	// Reject any update to the checkpoint ref namespace on the remote.
+	installRejectCheckpointRefsHook(t, bareDir)
+
+	// Advance the local ref (a fast-forward child) and enqueue it.
+	amendCheckpointRef(t, env.RepoDir, ref, remoteBefore, "local_side.txt", "local change")
+	enqueueCheckpointRef(t, env, ref)
+
+	// Pre-push: the push is rejected, recovery cannot make it land -> the ref is
+	// left queued and the remote ref is unchanged (never force-overwritten).
+	env.RunPrePush("origin")
+	require.Contains(t, env.PushQueueRefs(), ref, "a rejected ref must stay queued for a later push")
+	require.Equal(t, remoteBefore, refHashIn(t, bareDir, ref),
+		"a rejected push must leave the remote ref untouched (no force overwrite)")
+
+	// Once the remote accepts writes again, the next pre-push retries and lands it.
+	removeRejectCheckpointRefsHook(t, bareDir)
+	env.RunPrePush("origin")
+	require.Contains(t, refTreeFilesIn(t, bareDir, ref), "local_side.txt",
+		"the queued ref must land on the next push once the remote accepts it")
+	require.Empty(t, env.PushQueueRefs(), "queue should drain after the retry succeeds")
+}
+
+// installRejectCheckpointRefsHook writes a pre-receive hook on the bare remote
+// that declines any update to refs/entire/checkpoints/*.
+func installRejectCheckpointRefsHook(t *testing.T, bareDir string) {
+	t.Helper()
+	hooksDir := filepath.Join(bareDir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	script := "#!/bin/sh\n" +
+		"while read _old _new ref; do\n" +
+		"  case \"$ref\" in\n" +
+		"    refs/entire/checkpoints/*) echo 'rejected: checkpoint refs are protected' >&2; exit 1;;\n" +
+		"  esac\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(hooksDir, "pre-receive"), []byte(script), 0o755)) //nolint:gosec // hook must be executable
+}
+
+func removeRejectCheckpointRefsHook(t *testing.T, bareDir string) {
+	t.Helper()
+	require.NoError(t, os.Remove(filepath.Join(bareDir, "hooks", "pre-receive")))
+}
+
+// TestGitRefsConcurrentPush_SecondPusherReplaysAndRetries is D3: two clones race
+// on the SAME per-checkpoint ref (each amends it from a shared base). The first
+// push fast-forwards; the second is non-fast-forward and must fetch+replay+retry
+// (non-force), so both clones' changes survive. This is the git-refs analogue of
+// TestConcurrentPush_SecondPusherRebasesAndRetries (v1-only).
+func TestGitRefsConcurrentPush_SecondPusherReplaysAndRetries(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitRefs
+	bareDir := env.SetupBareRemote()
+
+	cp := createCheckpointedCommit(t, env, "Add shared module", "shared.go", "package shared", "Add shared module")
+	require.NotEmpty(t, cp)
+	ref := checkpointRefName(cp)
+	env.RunPrePush("origin")
+	c0 := refHashIn(t, bareDir, ref)
+
+	// Two clones both fetch the shared checkpoint ref at C0 (before either pushes).
+	cloneA := env.CloneFrom(bareDir)
+	cloneA.CheckpointStore = StoreGitRefs
+	fetchCheckpointRefLocally(t, cloneA, ref)
+
+	cloneB := env.CloneFrom(bareDir)
+	cloneB.CheckpointStore = StoreGitRefs
+	fetchCheckpointRefLocally(t, cloneB, ref)
+
+	// Each clone amends the same ref differently and enqueues it.
+	amendCheckpointRef(t, cloneA.RepoDir, ref, c0, "a_side.txt", "A change")
+	enqueueCheckpointRef(t, cloneA, ref)
+	amendCheckpointRef(t, cloneB.RepoDir, ref, c0, "b_side.txt", "B change")
+	enqueueCheckpointRef(t, cloneB, ref)
+
+	// A pushes first (fast-forward over C0).
+	cloneA.RunPrePush("origin")
+	require.Contains(t, refTreeFilesIn(t, bareDir, ref), "a_side.txt")
+
+	// B pushes second: non-fast-forward -> fetch+replay+retry, preserving both.
+	cloneB.RunPrePush("origin")
+	files := refTreeFilesIn(t, bareDir, ref)
+	require.Contains(t, files, "a_side.txt", "clone A's change must be preserved (not overwritten)")
+	require.Contains(t, files, "b_side.txt", "clone B's change must be replayed on top")
+	require.Empty(t, cloneB.PushQueueRefs(), "clone B's queue should drain after the recovery push")
+}

--- a/cmd/entire/cli/integration_test/refs_queue_semantics_test.go
+++ b/cmd/entire/cli/integration_test/refs_queue_semantics_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// D6 / D7 -- git-refs push-queue semantics (integration).
+// =============================================================================
+
+// TestGitRefsQueue_MultiWorktreeSharedQueueDrains is D6: the git-refs push queue
+// lives in the shared git common dir, so a session in a linked worktree and a
+// session in the main worktree both enqueue into ONE queue. A single pre-push
+// from the main worktree pushes BOTH worktrees' checkpoint refs, drains the queue
+// to empty, and prunes a stale entry (a queued ref that no longer exists locally),
+// exercising partitionLocalRefs.
+func TestGitRefsQueue_MultiWorktreeSharedQueueDrains(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitRefs
+	bareDir := env.SetupBareRemote()
+
+	// Session in the main worktree enqueues its checkpoint ref into the shared queue.
+	_ = createCheckpointedCommit(t, env, "main worktree work", "main_wt.go", "package mainwt", "main worktree work")
+	queueAfterMain := env.PushQueueRefs()
+	require.NotEmpty(t, queueAfterMain, "main worktree session should enqueue a checkpoint ref")
+
+	// Session in a linked worktree (shares the git common dir, so the SAME queue).
+	wt := env.AddWorktree("feature/wt-second")
+	_ = createCheckpointedCommit(t, wt, "linked worktree work", "wt.go", "package wt", "linked worktree work")
+
+	// The shared queue (read from the main worktree) now holds an additional
+	// distinct ref enqueued by the linked worktree's session.
+	realRefs := env.PushQueueRefs()
+	require.Greater(t, len(realRefs), len(queueAfterMain),
+		"the linked worktree's session should enqueue an additional ref into the shared common-dir queue")
+
+	// A stale entry (no such local ref) must be pruned, not pushed or retried forever.
+	staleRef := checkpointRefName("ffffffffffff")
+	enqueueCheckpointRef(t, env, staleRef)
+
+	// One pre-push from the main worktree drains everything pushable in the queue.
+	env.RunPrePush("origin")
+
+	for _, ref := range realRefs {
+		require.True(t, refExists(t, bareDir, ref),
+			"both worktrees' checkpoint refs must reach the remote via the shared queue: %s", ref)
+	}
+	require.False(t, refExists(t, bareDir, staleRef),
+		"a stale queue entry must not be pushed")
+	require.Empty(t, env.PushQueueRefs(),
+		"the shared queue must be drained and compacted after a successful push (stale entry pruned)")
+}
+
+// TestGitRefsQueue_TwoRemotesQueueClearedByFirstPush is D7: it PINS the known
+// two-remote queue-clearing gap (test plan decision D-2).
+//
+// KNOWN BUG / PINNED CURRENT BEHAVIOR: the push queue records only the ref, not
+// which remote it was pushed to. A successful pre-push to ANY remote drains the
+// queue, so a second remote never receives those refs. This test asserts that
+// current (buggy) behavior on purpose, so a regression is visible and so the
+// fix is a deliberate, reviewed change.
+//
+// WHEN THE FIX LANDS (per-remote push tracking, or "drain only when pushed to the
+// fetch-resolution target"): flip the final assertion — the second remote SHOULD
+// then receive the checkpoint refs.
+func TestGitRefsQueue_TwoRemotesQueueClearedByFirstPush(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitRefs
+
+	bareOrigin := env.SetupBareRemote()
+	bareSecond := env.SetupNamedBareRemote("second")
+
+	cp := createCheckpointedCommit(t, env, "Add module", "mod.go", "package mod", "Add module")
+	require.NotEmpty(t, cp)
+	require.Contains(t, env.PushQueueRefs(), checkpointRefName(cp), "checkpoint ref should be queued")
+
+	// Push to origin first — this drains the queue.
+	env.RunPrePush("origin")
+	require.True(t, env.CheckpointExistsOnRemote(bareOrigin, cp),
+		"origin should receive the checkpoint ref")
+	require.Empty(t, env.PushQueueRefs(),
+		"the queue is drained by the first push regardless of remote (root of the D-2 gap)")
+
+	// Now push to the second remote. Because the queue is already empty, nothing is
+	// sent — the second remote permanently misses the checkpoint.
+	env.RunPrePush("second")
+
+	// PINNED CURRENT BEHAVIOR (test plan D-2): the second remote never gets the ref.
+	// Flip this to require.True when per-remote queue tracking lands.
+	require.False(t, env.CheckpointExistsOnRemote(bareSecond, cp),
+		"KNOWN BUG (D-2): the second remote misses checkpoint refs the first push drained; "+
+			"flip to require.True when per-remote push tracking lands")
+}

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -310,6 +310,21 @@ func (env *TestEnv) gitConfigPath() string {
 	return filepath.Join(env.RepoDir, ".git", "config")
 }
 
+// commitMsgPath returns the COMMIT_EDITMSG scratch path inside the repo's real
+// git dir, resolved via git so it is correct in a linked worktree (where ".git"
+// is a file pointing at the common dir's worktrees/<name>, not a directory). For
+// a normal checkout this equals RepoDir/.git/COMMIT_EDITMSG.
+func (env *TestEnv) commitMsgPath() string {
+	cmd := exec.CommandContext(env.T.Context(), "git", "rev-parse", "--absolute-git-dir")
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return filepath.Join(env.RepoDir, ".git", "COMMIT_EDITMSG")
+	}
+	return filepath.Join(strings.TrimSpace(string(out)), "COMMIT_EDITMSG")
+}
+
 var gitConfigGuardRepositoryFormatVersionRE = regexp.MustCompile(`(?m)^([ \t]*)repositoryformatversion = [01]$`)
 
 var gitConfigGuardTransportPromisorRemoteRE = regexp.MustCompile(
@@ -1045,7 +1060,7 @@ func (env *TestEnv) gitCommitWithShadowHooks(message string, simulateTTY bool, f
 	}
 
 	// Create a temp file for the commit message (prepare-commit-msg hook modifies this)
-	msgFile := filepath.Join(env.RepoDir, ".git", "COMMIT_EDITMSG")
+	msgFile := env.commitMsgPath()
 	if err := os.WriteFile(msgFile, []byte(message), 0o644); err != nil {
 		env.T.Fatalf("failed to write commit message file: %v", err)
 	}
@@ -1119,7 +1134,7 @@ func (env *TestEnv) GitCommitAmendWithShadowHooks(message string, files ...strin
 	}
 
 	// Write commit message to temp file
-	msgFile := filepath.Join(env.RepoDir, ".git", "COMMIT_EDITMSG")
+	msgFile := env.commitMsgPath()
 	if err := os.WriteFile(msgFile, []byte(message), 0o644); err != nil {
 		env.T.Fatalf("failed to write commit message file: %v", err)
 	}
@@ -1206,7 +1221,7 @@ func (env *TestEnv) GitCommitWithTrailerRemoved(message string, files ...string)
 	}
 
 	// Create a temp file for the commit message (prepare-commit-msg hook modifies this)
-	msgFile := filepath.Join(env.RepoDir, ".git", "COMMIT_EDITMSG")
+	msgFile := env.commitMsgPath()
 	if err := os.WriteFile(msgFile, []byte(message), 0o644); err != nil {
 		env.T.Fatalf("failed to write commit message file: %v", err)
 	}
@@ -1303,7 +1318,7 @@ func (env *TestEnv) gitCommitStagedWithShadowHooks(message string, simulateTTY b
 	env.T.Helper()
 
 	// Create a temp file for the commit message (prepare-commit-msg hook modifies this)
-	msgFile := filepath.Join(env.RepoDir, ".git", "COMMIT_EDITMSG")
+	msgFile := env.commitMsgPath()
 	if err := os.WriteFile(msgFile, []byte(message), 0o644); err != nil {
 		env.T.Fatalf("failed to write commit message file: %v", err)
 	}
@@ -1913,6 +1928,60 @@ func (env *TestEnv) BranchExistsOnRemote(bareDir, branchName string) bool {
 	cmd.Dir = bareDir
 	cmd.Env = testutil.GitIsolatedEnv()
 	return cmd.Run() == nil
+}
+
+// AddWorktree creates a linked git worktree on a new branch and returns a
+// TestEnv pointing at it. The worktree shares the main repo's git common dir
+// (objects, refs, and the git-refs push queue live there), so sessions run in
+// either worktree enqueue into the same queue. Because .entire/ is gitignored
+// (not committed), the worktree gets its own freshly-initialized .entire/. The
+// checkpoint-store backend is inherited from the parent env.
+func (env *TestEnv) AddWorktree(branch string) *TestEnv {
+	env.T.Helper()
+
+	worktreeDir := filepath.Join(env.T.TempDir(), "worktree")
+	if resolved, err := filepath.EvalSymlinks(filepath.Dir(worktreeDir)); err == nil {
+		worktreeDir = filepath.Join(resolved, "worktree")
+	}
+
+	cmd := exec.CommandContext(env.T.Context(), "git", "worktree", "add", worktreeDir, "-b", branch)
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		env.T.Fatalf("failed to add worktree on branch %s: %v\n%s", branch, err, output)
+	}
+
+	claudeProjectDir := env.T.TempDir()
+	if resolved, err := filepath.EvalSymlinks(claudeProjectDir); err == nil {
+		claudeProjectDir = resolved
+	}
+	geminiProjectDir := env.T.TempDir()
+	if resolved, err := filepath.EvalSymlinks(geminiProjectDir); err == nil {
+		geminiProjectDir = resolved
+	}
+	openCodeProjectDir := env.T.TempDir()
+	if resolved, err := filepath.EvalSymlinks(openCodeProjectDir); err == nil {
+		openCodeProjectDir = resolved
+	}
+
+	wtEnv := &TestEnv{
+		T:                  env.T,
+		RepoDir:            worktreeDir,
+		ClaudeProjectDir:   claudeProjectDir,
+		GeminiProjectDir:   geminiProjectDir,
+		OpenCodeProjectDir: openCodeProjectDir,
+		CheckpointStore:    env.CheckpointStore,
+		// Session IDs are "test-session-<counter>" per env and the session state
+		// store is shared across worktrees (git common dir). Offset the worktree's
+		// counter so its sessions never collide with the parent worktree's.
+		SessionCounter: 500,
+	}
+	wtEnv.InitEntire()
+	// A linked worktree's ".git" is a file, not a directory, so the .git/config
+	// guard (which reads RepoDir/.git/config) cannot baseline it. The worktree
+	// shares the main repo's common config, which the parent env already guards,
+	// so intentionally skip setGitConfigBaseline here.
+	return wtEnv
 }
 
 // PatchSettings merges extra keys into .entire/settings.json.

--- a/cmd/entire/cli/strategy/replay_fidelity_test.go
+++ b/cmd/entire/cli/strategy/replay_fidelity_test.go
@@ -1,0 +1,251 @@
+package strategy
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// commitsFromHashes resolves each hash to its commit object, preserving order.
+func commitsFromHashes(t *testing.T, repo *git.Repository, hashes ...plumbing.Hash) []*object.Commit {
+	t.Helper()
+	commits := make([]*object.Commit, 0, len(hashes))
+	for _, h := range hashes {
+		c, err := repo.CommitObject(h)
+		require.NoError(t, err)
+		commits = append(commits, c)
+	}
+	return commits
+}
+
+// D4(a) — regression guard for 743c43f4c ("skip non-root no-op commits in push
+// signing"): a no-op commit (identical tree to its parent) must NOT reuse its
+// own tree when replayed onto a remote tip that has accumulated a different
+// tree. The buggy behaviour reset the tip's tree to the no-op commit's own
+// tree, silently dropping files another clone contributed to the remote.
+// cherryPickOnto skips no-op commits entirely, so the remote tip's tree is
+// preserved. This pins that behaviour on the current replay path (cherryPickOnto),
+// which is where the "same skip" the fix referenced actually lives.
+func TestCherryPickOnto_NoOpCommitDoesNotClobberRemoteTree(t *testing.T) {
+	t.Parallel()
+	repo := newSafelyAdvanceTestRepo(t)
+	ctx := context.Background()
+
+	// Remote tip carries a file contributed by another clone.
+	remoteTip := makeTreeCommit(t, repo, nil, "remote-only work", map[string]string{"remote.txt": "R"})
+
+	// Local chain: base -> c1 (adds local.txt) -> c2 (no-op: identical tree to c1).
+	base := makeTreeCommit(t, repo, nil, "base", map[string]string{"base.txt": "B"})
+	c1 := makeTreeCommit(t, repo, []plumbing.Hash{base}, "add local", map[string]string{"base.txt": "B", "local.txt": "L"})
+	c2 := makeTreeCommit(t, repo, []plumbing.Hash{c1}, "no-op child", map[string]string{"base.txt": "B", "local.txt": "L"})
+
+	newTip, err := cherryPickOnto(ctx, repo, remoteTip, commitsFromHashes(t, repo, c1, c2), nil)
+	require.NoError(t, err)
+
+	// The remote's accumulated file must survive — the core of the regression.
+	assertCommitFile(t, repo, newTip, "remote.txt", "R")
+	// c1's real change is replayed on top.
+	assertCommitFile(t, repo, newTip, "local.txt", "L")
+
+	// Only c1 produced a commit; the no-op c2 was skipped, so the new tip parents
+	// directly onto the remote tip (guards against a spurious clobbering commit).
+	newTipCommit, err := repo.CommitObject(newTip)
+	require.NoError(t, err)
+	require.Len(t, newTipCommit.ParentHashes, 1)
+	assert.Equal(t, remoteTip, newTipCommit.ParentHashes[0],
+		"no-op commit must not add a second (tree-clobbering) commit on top of the remote tip")
+}
+
+// D4(b) — root-commit replay: a local chain whose oldest commit is a true root
+// (no parents) replays cleanly onto a remote tip. The root's delta is computed
+// against the empty tree (parentTree nil in treeChangesForCherryPick), so its
+// files are added rather than diffed against a phantom parent.
+func TestCherryPickOnto_RootCommitChainReplays(t *testing.T) {
+	t.Parallel()
+	repo := newSafelyAdvanceTestRepo(t)
+	ctx := context.Background()
+
+	remoteTip := makeTreeCommit(t, repo, nil, "remote-only work", map[string]string{"remote.txt": "R"})
+
+	// Local chain rooted at a parentless commit.
+	localRoot := makeTreeCommit(t, repo, nil, "local root", map[string]string{"root.txt": "root"})
+	child := makeTreeCommit(t, repo, []plumbing.Hash{localRoot}, "local child", map[string]string{"root.txt": "root", "child.txt": "child"})
+
+	newTip, err := cherryPickOnto(ctx, repo, remoteTip, commitsFromHashes(t, repo, localRoot, child), nil)
+	require.NoError(t, err)
+
+	assertCommitFile(t, repo, newTip, "remote.txt", "R")
+	assertCommitFile(t, repo, newTip, "root.txt", "root")
+	assertCommitFile(t, repo, newTip, "child.txt", "child")
+
+	// Both local commits were applied (root produced content), so the chain above
+	// the remote tip is exactly two commits.
+	tip, err := repo.CommitObject(newTip)
+	require.NoError(t, err)
+	require.Len(t, tip.ParentHashes, 1)
+	mid, err := repo.CommitObject(tip.ParentHashes[0])
+	require.NoError(t, err)
+	require.Len(t, mid.ParentHashes, 1)
+	assert.Equal(t, remoteTip, mid.ParentHashes[0])
+}
+
+// D4(c) — KNOWN BUG PIN for 4cf01edb3 ("Drop commit-count cap when replaying
+// commits during pre-push").
+//
+// The pre-push diverged-replay path (fetchAndRebaseRefCommon -> collectCommitsSince)
+// aborts once the local-only commit set exceeds MaxCommitTraversalDepth (1000).
+// A checkpoint branch can legitimately accumulate more local-only commits than
+// that, so the cap turns a valid push into a hard failure. Commit 4cf01edb3
+// removes the cap, but it lives on the unmerged branch origin/no-limit and is NOT
+// an ancestor of this branch (verified: `git merge-base --is-ancestor 4cf01edb3
+// HEAD` -> false), so the cap is still active here.
+//
+// This test PINS the current (capped) behaviour. When the cap-removal lands,
+// flip it: replace require.Error with require.NoError and assert all commits are
+// returned. The sibling collectCommitChain cap is already pinned by
+// TestCollectCommitChain_DepthLimit.
+func TestCollectCommitsSince_CommitCapPinsCurrentBehavior(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	// A single empty tree, reused by every synthetic commit — keeps the build fast.
+	emptyTree := &object.Tree{}
+	treeObj := repo.Storer.NewEncodedObject()
+	require.NoError(t, emptyTree.Encode(treeObj))
+	treeHash, err := repo.Storer.SetEncodedObject(treeObj)
+	require.NoError(t, err)
+
+	// base (excluded) followed by MaxCommitTraversalDepth+1 single-parent commits,
+	// so rev-list base..tip yields one more entry than the cap allows.
+	var base, tip plumbing.Hash
+	for i := range MaxCommitTraversalDepth + 2 {
+		c := &object.Commit{
+			TreeHash:  treeHash,
+			Author:    object.Signature{Name: "t", Email: "t@example.com", When: time.Unix(int64(i), 0).UTC()},
+			Committer: object.Signature{Name: "t", Email: "t@example.com", When: time.Unix(int64(i), 0).UTC()},
+			Message:   "commit\n",
+		}
+		if tip != plumbing.ZeroHash {
+			c.ParentHashes = []plumbing.Hash{tip}
+		}
+		obj := repo.Storer.NewEncodedObject()
+		require.NoError(t, c.Encode(obj))
+		h, sErr := repo.Storer.SetEncodedObject(obj)
+		require.NoError(t, sErr)
+		if i == 0 {
+			base = h
+		}
+		tip = h
+	}
+
+	_, err = collectCommitsSince(context.Background(), repo, dir, tip, base)
+	require.Error(t, err, "KNOWN BUG (4cf01edb3, unmerged): >1000-commit replay is capped and errors")
+	assert.Contains(t, err.Error(), "exceeded")
+	assert.Contains(t, err.Error(), "aborting rebase")
+}
+
+// D5 — regression guard for 1e8628ade ("Use fetched ref hash instead of
+// ls-remote hash for disconnect check"). The remote may advance between an
+// earlier hash observation and the fetch; reconcile/replay must operate on the
+// hash the fetch actually landed, not a stale earlier one.
+//
+// The literal ls-remote-before-fetch seam that 1e8628ade patched no longer
+// exists in the refactored code (the fix is an ancestor of this branch:
+// `git merge-base --is-ancestor 1e8628ade HEAD` -> true; the reconcile path now
+// always reads the post-fetch remote-tracking ref). So this pins the behavioural
+// invariant end-to-end: fetchAndRebaseRefCommon replays local-only commits onto
+// the freshly fetched remote tip. We advance the remote AFTER the local repo
+// last saw it, then reconcile, and prove the new local tip descends from the
+// advanced (fetched) remote commit and carries its content — not the stale one.
+//
+// Not parallel: fetchAndRebaseRefCommon opens the repository from the working
+// directory, so the test uses t.Chdir.
+func TestFetchAndRebaseRefCommon_UsesFetchedRemoteHash(t *testing.T) {
+	ctx := context.Background()
+	v1Ref := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+
+	workDir := t.TempDir()
+	testutil.InitRepo(t, workDir)
+	testutil.WriteFile(t, workDir, "README.md", "# work")
+	testutil.GitAdd(t, workDir, "README.md")
+	testutil.GitCommit(t, workDir, "init")
+
+	runGit := func(dir string, args ...string) string {
+		t.Helper()
+		c := exec.CommandContext(ctx, "git", args...)
+		c.Dir = dir
+		c.Env = testutil.GitIsolatedEnv()
+		out, err := c.CombinedOutput()
+		require.NoError(t, err, "git %v failed: %s", args, out)
+		return strings.TrimSpace(string(out))
+	}
+
+	// Build a v1 metadata branch with a base checkpoint shard, as an orphan.
+	runGit(workDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runGit(workDir, "rm", "-rf", ".")
+	testutil.WriteFile(t, workDir, "aa/aaaaaaaaaa/metadata.json", `{"checkpoint_id":"aaaaaaaaaaaa"}`)
+	runGit(workDir, "add", ".")
+	runGit(workDir, "commit", "-m", "Checkpoint: aaaaaaaaaaaa")
+	baseHash := plumbing.NewHash(runGit(workDir, "rev-parse", "HEAD"))
+
+	// Bare remote seeded with the base v1.
+	bareDir := t.TempDir()
+	runGit(bareDir, "init", "--bare")
+	runGit(workDir, "remote", "add", "origin", bareDir)
+	runGit(workDir, "push", "origin", paths.MetadataBranchName)
+
+	// Another clone advances the remote v1 to R2 (a new checkpoint shard), so the
+	// remote tip is now ahead of anything workDir has observed.
+	scratch := t.TempDir()
+	runGit(scratch, "clone", bareDir, ".")
+	runGit(scratch, "config", "user.email", "s@example.com")
+	runGit(scratch, "config", "user.name", "Scratch")
+	runGit(scratch, "config", "commit.gpgsign", "false")
+	runGit(scratch, "checkout", paths.MetadataBranchName)
+	testutil.WriteFile(t, scratch, "bb/bbbbbbbbbb/metadata.json", `{"checkpoint_id":"bbbbbbbbbbbb"}`)
+	runGit(scratch, "add", ".")
+	runGit(scratch, "commit", "-m", "Checkpoint: bbbbbbbbbbbb")
+	runGit(scratch, "push", "origin", paths.MetadataBranchName)
+	remoteAdvancedHash := plumbing.NewHash(runGit(scratch, "rev-parse", "HEAD"))
+	require.NotEqual(t, baseHash, remoteAdvancedHash)
+
+	// workDir diverges locally from base WITHOUT fetching the advance: reset v1 to
+	// base, add a local-only checkpoint. workDir has never seen R2.
+	runGit(workDir, "checkout", paths.MetadataBranchName)
+	testutil.WriteFile(t, workDir, "cc/cccccccccc/metadata.json", `{"checkpoint_id":"cccccccccccc"}`)
+	runGit(workDir, "add", ".")
+	runGit(workDir, "commit", "-m", "Checkpoint: cccccccccccc")
+
+	t.Chdir(workDir)
+
+	require.NoError(t, fetchAndRebaseRefCommon(ctx, "origin", v1Ref))
+
+	repo, err := git.PlainOpen(workDir)
+	require.NoError(t, err)
+	localRef, err := repo.Reference(v1Ref, true)
+	require.NoError(t, err)
+
+	// The reconciled local tip must descend from the FETCHED remote tip (R2), not
+	// the stale base — proving reconcile used the fetched hash.
+	require.True(t, IsAncestorOf(ctx, repo, remoteAdvancedHash, localRef.Hash()),
+		"reconciled local v1 must build on the fetched remote tip (R2), not a stale hash")
+
+	// Both the remote-only checkpoint (from R2) and the local-only checkpoint survive.
+	assertCommitFile(t, repo, localRef.Hash(), "bb/bbbbbbbbbb/metadata.json", `{"checkpoint_id":"bbbbbbbbbbbb"}`)
+	assertCommitFile(t, repo, localRef.Hash(), "cc/cccccccccc/metadata.json", `{"checkpoint_id":"cccccccccccc"}`)
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/759
<!-- entire-trail-link-end -->

Part 3 of the stack on #1637. Systematizes the historically most re-broken area (#953, #1251, #1252, #1260: destructive local-v1-ref moves) into an explicit matrix, and covers the git-refs equivalents that only had unit coverage.

## Tests

- **D1 (git-branch)**: table-driven matrix — local v1 {ahead, behind, diverged, disconnected} × {pre-push (real hook), explain fetch-on-miss, doctor}: local-only commits always survive, behind→FF, diverged→both sides preserved with linear tip (double-replay guard), repeated pre-push leaves the remote byte-identical. Cells already covered by `safely_advance_local_ref_test.go` / `explain_test.go` are not duplicated; the resume trigger shares the `SafelyAdvanceLocalRef` engine exercised via explain.
- **D4 (replay fidelity)**: no-op commit replay must not clobber the remote tip's tree (743c43f4c had no test); root-commit replay; **>1000-commit replay pinned** — the historical cap-removal fix (4cf01edb3) was never merged (it's stranded on `origin/no-limit`), so `TestCollectCommitsSince_CommitCapPinsCurrentBehavior` pins the hard failure with a flip-when-fixed note.
- **D5 (TOCTOU)**: reconcile uses the fetched remote hash, not a stale pre-fetch observation (1e8628ade had no test) — asserted as a behavioral invariant against a bare remote that advanced mid-flight.
- **D2/D3 (git-refs)**: remote-ahead per-checkpoint ref → real-hook push does fetch+replay+non-force retry with both sides surviving; rejected refs stay queued with the remote untouched (via a bare-side `pre-receive` rejection — a content-level cherry-pick conflict isn't deterministically reproducible at this layer); concurrent pushers from two clones.
- **D6 (multi-worktree)**: two worktrees enqueue into the shared common-dir push queue; a push from worktree A also lands worktree B's refs, queue compacted. New `AddWorktree` test helper.
- **D7 (two-remote pin)**: push to remote A drains the queue so remote B never receives the refs — pins current behavior, tracked as #1635.

## Verification

- `mise run fmt && mise run lint` clean per commit
- `mise run test:integration` green (444 tests at tip)
- `go test ./cmd/entire/cli/strategy/` green
- `mise run test:e2e:canary` green under both `E2E_CHECKPOINT_STORE` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yi3hHGAGepwfrfjPETjGq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and integration helpers; no runtime checkpoint sync or push logic is modified.
> 
> **Overview**
> Adds integration and strategy tests that map **local v1 / per-checkpoint ref divergence** to real CLI paths (pre-push, `checkpoint explain`, `entire doctor`) and git-refs push-queue behavior, without changing production code.
> 
> **D1 (git-branch):** Table-driven cases for local v1 *ahead, behind, diverged, disconnected* through the pre-push hook (checkpoint survival, diverged replay keeps both sides with a linear tip, idempotent double pre-push). Separate tests cover fetch-on-miss via `checkpoint explain` (behind/diverged) and `doctor --force` on disconnected orphans.
> 
> **D2/D3 (git-refs):** End-to-end pre-push when a per-checkpoint ref is amended on the remote vs locally (fetch+replay, both file sets kept), server rejection (ref stays queued, remote unchanged, retry succeeds), and two clones racing on the same ref.
> 
> **D6/D7 (queue):** Shared common-dir queue across linked worktrees (one pre-push drains both, stale entries pruned). **D7** intentionally asserts today’s two-remote gap: first push drains the queue so a second remote never gets the refs (#1635).
> 
> **Test harness:** `commitMsgPath()` for linked worktrees; new `AddWorktree` helper.
> 
> **Strategy (`replay_fidelity_test.go`):** Guards for no-op commits not clobbering remote trees on replay, root-commit chains, reconcile using the post-fetch remote tip; pins the **>1000-commit** `collectCommitsSince` cap until the unmerged cap-removal lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93c1e3d5b7ce056daa6073fb438121ce7f3a393. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->