### PR TITLE
test: fix red main — route corecmd stub handlers through printJSON

### DIFF
--- a/cmd/entire/cli/corecmd_list_test.go
+++ b/cmd/entire/cli/corecmd_list_test.go
@@ -18,7 +18,7 @@ func serveOrgList(t *testing.T, orgs []coreapi.Org) *httptest.Server {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		w.Header().Set("Content-Type", "application/json")
-		if err := writeJSON(w, &coreapi.ListOrgsOutputBody{Orgs: orgs}); err != nil {
+		if err := printJSON(w, &coreapi.ListOrgsOutputBody{Orgs: orgs}); err != nil {
 			t.Errorf("encode orgs: %v", err)
 		}
 	}))

--- a/cmd/entire/cli/corecmd_mutation_test.go
+++ b/cmd/entire/cli/corecmd_mutation_test.go
@@ -20,7 +20,7 @@ func newCreateOrgServer(t *testing.T) *httptest.Server {
 		assert.Equal(t, http.MethodPost, r.Method)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		if err := writeJSON(w, &coreapi.Org{ID: testDeleteULID, Name: "acme", Region: "us"}); err != nil {
+		if err := printJSON(w, &coreapi.Org{ID: testDeleteULID, Name: "acme", Region: "us"}); err != nil {
 			t.Errorf("encode org: %v", err)
 		}
 	}))
@@ -71,7 +71,7 @@ func newCreateRepoServer(t *testing.T) *httptest.Server {
 			ClusterHost:     coreapi.NewOptString("c.example.com"),
 			Path:            coreapi.NewOptString("/gh/o/web"),
 		}
-		if err := writeJSON(w, repo); err != nil {
+		if err := printJSON(w, repo); err != nil {
 			t.Errorf("encode repo: %v", err)
 		}
 	}))


### PR DESCRIPTION
## Summary

#1626 landed corecmd_list_test.go / corecmd_mutation_test.go calling a `writeJSON` helper. Its CI was legitimately green on Jul 3 — but 90 minutes later #1606 (deslop) merged, deleting `writeJSON` to standardize package `cli` on `printJSON`. #1626 then merged on Jul 5 with its stale green checks (GitHub doesn't re-run when the base moves), so main's Lint (typecheck) and Tests jobs are red and every open PR inherits the failure via the merge preview.

The fix points the three call sites at `printJSON` — the same conversion #1606 applied to the package's other stub-handler test fixtures (`repo_mirror_test.go`, `resolveref_test.go`, …) — rather than reintroducing the duplicate helper that cleanup deliberately deleted.

## Test plan

- [x] `go test ./cmd/entire/cli/` passes (was: compile failure)
- [x] `mise run fmt && mise run lint` clean (was: typecheck error)

Consider requiring branches to be up to date before merging (or a merge queue) to prevent this class of semantic conflict — this one sat undetected across a two-day merge gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)