### PR TITLE
cli: cell-routing foundation — client factory, generic repo→cell resolver, multi-cell fan-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,6 +506,35 @@ env-token-first precedence itself — see `resolveAuthStatusTarget` /
 deliberate exception: it manages a *stored* login session, which an ephemeral
 env token has none of, so it stays on the active context.
 
+### Entire-API Cell Routing (which cell does a data-plane request go to?)
+
+The data plane (entire-api) is deployed per jurisdiction; a repo placement
+lives in exactly one cell, user `/me/*` activity is consolidated in the
+caller's home cell, and no server-side cross-cell aggregator exists. The CLI
+therefore has exactly three routing shapes, mirroring the entire.io BFF:
+
+- **Repo-scoped → one cell**: `resolveRepoCellTarget` (`cell_target.go`) maps
+  a repo (ULID or owner/repo) to the cell hosting it via mirrors + the cluster
+  catalog. Best-effort: any failure returns nil and the auth layer falls back
+  to home-jurisdiction routing. Used by experts
+  (`NewAuthenticatedEntireAPICellClient` in `api_client.go`).
+- **User-scoped `/me` → home cell, never fan out**:
+  `auth.NewEntireAPICellClient(ctx, insecure, nil)` routes by the
+  `home_jurisdiction` JWT claim; activity/recap use it with a data-API
+  fallback (`runAuthenticatedActivityAPI` in `entireapi_client.go`).
+- **Repo-set queries → fan out and merge client-side**: `cell_fanout.go` —
+  `groupReposByCell` (repo index → per-cell groups; the catalog join key is
+  `ClusterSlug`↔`Cluster.Slug`, NOT the cell name, which the catalog does not
+  expose), `resolveCellBaseURLs`, and `fanOutCells` (parallel per-cell calls,
+  per-cell timeout, partial failures isolated per slot). Merge semantics stay
+  with the command.
+
+Token rule: identity tokens are **per-jurisdiction, not per-cell**. Multi-cell
+callers must build one `auth.CellClientFactory`
+(`NewEntireAPICellClientFactory`) per operation — it resolves the login
+subject once and mints at most one token per jurisdiction. `fanOutCells` does
+this automatically; do not call `NewEntireAPICellClient` in a loop.
+
 ### Session Strategy (`cmd/entire/cli/strategy/`)
 
 The CLI uses a manual-commit strategy for managing session data and checkpoints. The strategy implements the `Strategy` interface defined in `strategy.go`.

--- a/cmd/entire/cli/api_client.go
+++ b/cmd/entire/cli/api_client.go
@@ -60,7 +60,7 @@ func NewAuthenticatedAPIClient(ctx context.Context, insecureHTTP bool) (*api.Cli
 // failure yields a nil target and NewEntireAPICellClient falls back to
 // home-jurisdiction routing, so the common same-region case never regresses.
 func NewAuthenticatedEntireAPICellClient(ctx context.Context, insecureHTTP bool, fullName, ulid string) (*api.Client, error) {
-	target := resolveExpertsCellTarget(ctx, fullName, ulid)
+	target := resolveRepoCellTarget(ctx, fullName, ulid)
 	// NewEntireAPICellClient already returns user-facing, context-rich errors
 	// (login hint, discovery-unavailable, region guidance); re-wrapping here
 	// would bury them, so surface them verbatim.

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -119,8 +119,18 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *Cell
 type CellClientFactory struct {
 	subject cellSubject
 
-	mu     sync.Mutex
-	tokens map[string]string // jurisdiction -> minted identity token
+	mu    sync.Mutex           // guards slots (map access only, never held across I/O)
+	slots map[string]*mintSlot // jurisdiction -> its token slot
+}
+
+// mintSlot single-flights one jurisdiction's token: the slot mutex is held
+// across the mint, so concurrent callers for the same jurisdiction wait for one
+// exchange instead of duplicating it, while other jurisdictions mint in
+// parallel on their own slots. A failed mint caches nothing — the next caller
+// retries.
+type mintSlot struct {
+	mu    sync.Mutex
+	token string
 }
 
 // NewEntireAPICellClientFactory resolves the exchange subject (active stored
@@ -131,7 +141,7 @@ func NewEntireAPICellClientFactory(ctx context.Context, insecureHTTP bool) (*Cel
 	if err != nil {
 		return nil, err
 	}
-	return &CellClientFactory{subject: subject, tokens: make(map[string]string)}, nil
+	return &CellClientFactory{subject: subject, slots: make(map[string]*mintSlot)}, nil
 }
 
 // ClientFor returns an authenticated client for the given cell target (nil
@@ -169,22 +179,30 @@ func (f *CellClientFactory) ClientFor(ctx context.Context, target *CellTarget) (
 }
 
 // tokenFor returns the cached identity token for jurisdiction, minting it on
-// first use. The mutex is held across the mint: concurrent callers for the
-// same jurisdiction wait for one exchange instead of duplicating it, at the
-// cost of serializing cross-jurisdiction mints (fine for the handful of
-// jurisdictions a fan-out touches).
+// first use. Locking is per jurisdiction (see mintSlot): a slow exchange for
+// one jurisdiction never blocks another jurisdiction's mint — in a fan-out,
+// healthy cells must not burn their per-cell deadline waiting on an unrelated
+// region's exchange.
 func (f *CellClientFactory) tokenFor(ctx context.Context, jurisdiction, coreURL string) (string, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
-	if token, ok := f.tokens[jurisdiction]; ok {
-		return token, nil
+	slot, ok := f.slots[jurisdiction]
+	if !ok {
+		slot = &mintSlot{}
+		f.slots[jurisdiction] = slot
+	}
+	f.mu.Unlock()
+
+	slot.mu.Lock()
+	defer slot.mu.Unlock()
+	if slot.token != "" {
+		return slot.token, nil
 	}
 	audience := jurisdictionAudience(jurisdiction, f.subject.dataOrigin, f.subject.discoveredCore)
 	token, err := exchangeJurisdictionToken(ctx, coreURL, f.subject.loginJWT, audience, f.subject.httpClient)
 	if err != nil {
 		return "", fmt.Errorf("exchange jurisdictional identity token: %w", err)
 	}
-	f.tokens[jurisdiction] = token
+	slot.token = token
 	return token, nil
 }
 

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -569,7 +569,7 @@ var ErrNoCellForJurisdiction = errors.New("no entire-api cell configured for jur
 // cluster first). It hand-parses GET /api/v1/clusters rather than reusing the
 // generated coreapi.ListClusters() because coreapi imports this (auth) package,
 // so auth cannot import coreapi without a cycle — the repo-scoped path avoids
-// this by resolving the cell in the cli layer (see resolveExpertsCellTarget).
+// this by resolving the cell in the cli layer (see resolveRepoCellTarget).
 func resolveCellAPIBaseURL(ctx context.Context, coreURL, loginJWT, jurisdiction string, httpClient *http.Client) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(coreURL, "/")+clustersAPIPath, nil)
 	if err != nil {

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -119,15 +119,17 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *Cell
 type CellClientFactory struct {
 	subject cellSubject
 
-	mu    sync.Mutex           // guards slots (map access only, never held across I/O)
+	// mu guards the slots map only and is never held across I/O; the
+	// hold-across-I/O locking is per-jurisdiction, on each mintSlot.mu.
+	mu    sync.Mutex
 	slots map[string]*mintSlot // jurisdiction -> its token slot
 }
 
-// mintSlot single-flights one jurisdiction's token: the slot mutex is held
-// across the mint, so concurrent callers for the same jurisdiction wait for one
-// exchange instead of duplicating it, while other jurisdictions mint in
-// parallel on their own slots. A failed mint caches nothing — the next caller
-// retries.
+// mintSlot single-flights one jurisdiction's token. Unlike the factory-level
+// mutex, the slot mutex IS deliberately held across the network exchange:
+// concurrent callers for the same jurisdiction wait for one mint instead of
+// duplicating it, while other jurisdictions mint in parallel on their own
+// slots. A failed mint caches nothing — the next caller retries.
 type mintSlot struct {
 	mu    sync.Mutex
 	token string

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
@@ -97,21 +98,52 @@ func SetCellExchangeTransportForTest(t interface{ Helper() }, rt http.RoundTripp
 //   - otherwise the data host is a BFF/apex: resolve the caller's home-cell
 //     apiUrl from the cluster catalog (home-jurisdiction fallback).
 func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *CellTarget) (*api.Client, error) {
-	// NewEntireAPICellClient deliberately does NOT consult ENTIRE_TOKEN: it
-	// resolves the active stored login context (like every other cell/data-API
-	// command). Only `entire auth token --jurisdiction` (JurisdictionToken) adds
-	// the env-token path.
+	factory, err := NewEntireAPICellClientFactory(ctx, insecureHTTP)
+	if err != nil {
+		return nil, err
+	}
+	return factory.ClientFor(ctx, target)
+}
+
+// CellClientFactory builds entire-api cell clients from a single resolved
+// exchange subject, minting at most one jurisdictional identity token per
+// jurisdiction. Identity tokens are per-jurisdiction, not per-cell — every cell
+// in a jurisdiction accepts the same token — so a caller dialing several cells
+// in one operation (multi-cell fan-out over the caller's repos) should build
+// one factory and reuse it for every cell, instead of paying discovery + login
+// refresh + RFC 8693 exchange once per cell via NewEntireAPICellClient.
+//
+// A factory is safe for concurrent use, and holds credentials resolved at
+// construction time — build it per operation, don't store it long-term. Like
+// NewEntireAPICellClient it deliberately does NOT consult ENTIRE_TOKEN.
+type CellClientFactory struct {
+	subject cellSubject
+
+	mu     sync.Mutex
+	tokens map[string]string // jurisdiction -> minted identity token
+}
+
+// NewEntireAPICellClientFactory resolves the exchange subject (active stored
+// login context) once, for building clients aimed at several cells. See
+// NewEntireAPICellClient for the single-cell convenience wrapper.
+func NewEntireAPICellClientFactory(ctx context.Context, insecureHTTP bool) (*CellClientFactory, error) {
 	subject, err := resolveStoredCellSubject(ctx, insecureHTTP)
 	if err != nil {
 		return nil, err
 	}
+	return &CellClientFactory{subject: subject, tokens: make(map[string]string)}, nil
+}
 
-	jurisdiction, err := targetJurisdiction(target, subject.loginJWT)
+// ClientFor returns an authenticated client for the given cell target (nil
+// falls back to home-jurisdiction routing), reusing an already-minted identity
+// token when the target's jurisdiction matches an earlier call.
+func (f *CellClientFactory) ClientFor(ctx context.Context, target *CellTarget) (*api.Client, error) {
+	jurisdiction, err := targetJurisdiction(target, f.subject.loginJWT)
 	if err != nil {
 		return nil, err
 	}
 
-	coreURL := jurisdictionCoreURL(jurisdiction, subject.dataOrigin, subject.discoveredCore)
+	coreURL := jurisdictionCoreURL(jurisdiction, f.subject.dataOrigin, f.subject.discoveredCore)
 	if err := requireSafeExchangeURL("entire-core", coreURL); err != nil {
 		return nil, err
 	}
@@ -120,7 +152,7 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *Cell
 	// which is signed by the discovered login core — so list there, not at the
 	// templated jurisdiction core (coreURL), which in a multi-core setup could
 	// differ and reject the token. coreURL still governs the token exchange below.
-	cellBaseURL, err := resolveTargetCellBaseURL(ctx, target, subject.dataOrigin, jurisdiction, subject.discoveredCore, subject.loginJWT, subject.httpClient)
+	cellBaseURL, err := resolveTargetCellBaseURL(ctx, target, f.subject.dataOrigin, jurisdiction, f.subject.discoveredCore, f.subject.loginJWT, f.subject.httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -128,13 +160,32 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *Cell
 		return nil, err
 	}
 
-	audience := jurisdictionAudience(jurisdiction, subject.dataOrigin, subject.discoveredCore)
-	token, err := exchangeJurisdictionToken(ctx, coreURL, subject.loginJWT, audience, subject.httpClient)
+	token, err := f.tokenFor(ctx, jurisdiction, coreURL)
 	if err != nil {
-		return nil, fmt.Errorf("exchange jurisdictional identity token: %w", err)
+		return nil, err
 	}
 
 	return api.NewClientWithBaseURL(token, cellBaseURL), nil
+}
+
+// tokenFor returns the cached identity token for jurisdiction, minting it on
+// first use. The mutex is held across the mint: concurrent callers for the
+// same jurisdiction wait for one exchange instead of duplicating it, at the
+// cost of serializing cross-jurisdiction mints (fine for the handful of
+// jurisdictions a fan-out touches).
+func (f *CellClientFactory) tokenFor(ctx context.Context, jurisdiction, coreURL string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if token, ok := f.tokens[jurisdiction]; ok {
+		return token, nil
+	}
+	audience := jurisdictionAudience(jurisdiction, f.subject.dataOrigin, f.subject.discoveredCore)
+	token, err := exchangeJurisdictionToken(ctx, coreURL, f.subject.loginJWT, audience, f.subject.httpClient)
+	if err != nil {
+		return "", fmt.Errorf("exchange jurisdictional identity token: %w", err)
+	}
+	f.tokens[jurisdiction] = token
+	return token, nil
 }
 
 // JurisdictionToken mints and returns a jurisdictional identity token

--- a/cmd/entire/cli/auth/cell_data_api_test.go
+++ b/cmd/entire/cli/auth/cell_data_api_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -602,5 +603,72 @@ func TestCellClientFactory_ReusesTokenPerJurisdiction(t *testing.T) {
 	}
 	if got, want := strings.Join(audiences, ","), "https://eu.entire.io,"+usEntireAudience; got != want {
 		t.Fatalf("exchange audiences = %q, want %q", got, want)
+	}
+}
+
+// TestCellClientFactory_SingleFlightsConcurrentMints pins the per-jurisdiction
+// locking: concurrent ClientFor calls for the same jurisdiction produce exactly
+// one exchange (the rest wait on the slot and reuse the result), not one each.
+// Not parallel: manipulates env + token store.
+func TestCellClientFactory_SingleFlightsConcurrentMints(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Setenv("ENTIRE_API_BASE_URL", "https://entire.io")
+	t.Setenv("ENTIRE_API_AUDIENCE_TEMPLATE", "")
+	t.Setenv("ENTIRE_CORE_BASE_URL_TEMPLATE", "")
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	var mu sync.Mutex
+	exchangeCount := 0
+	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != oauthTokenPath {
+			http.NotFound(w, r)
+			return
+		}
+		mu.Lock()
+		exchangeCount++
+		mu.Unlock()
+		time.Sleep(30 * time.Millisecond) // widen the window concurrent callers could race into
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"access_token":"identity-token","token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer coreSrv.Close()
+
+	svc := tokenstore.CoreKeyringService(coreSrv.URL)
+	loginJWT := makeJWT(t, fmt.Sprintf(`{"iss":%q,"home_jurisdiction":"us","exp":%d}`, coreSrv.URL, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "me", tokenstore.EncodeTokenWithExpiration(loginJWT, 7200)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	ctxObj := &contexts.Context{Name: "me@core", CoreURL: coreSrv.URL, Handle: "me", KeychainService: svc}
+	t.Cleanup(SetResolveContextForCellAPIForTest(t, func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+		return ctxObj, nil
+	}))
+	t.Cleanup(SetCellExchangeTransportForTest(t, coreSrv.Client().Transport))
+
+	factory, err := NewEntireAPICellClientFactory(context.Background(), false)
+	if err != nil {
+		t.Fatalf("NewEntireAPICellClientFactory: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = factory.ClientFor(context.Background(), &CellTarget{
+				BaseURL:      fmt.Sprintf("https://cell-%d.api.example", i),
+				Jurisdiction: "eu",
+			})
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("ClientFor[%d]: %v", i, err)
+		}
+	}
+	if exchangeCount != 1 {
+		t.Fatalf("exchange count = %d, want 1 (same jurisdiction single-flighted)", exchangeCount)
 	}
 }

--- a/cmd/entire/cli/auth/cell_data_api_test.go
+++ b/cmd/entire/cli/auth/cell_data_api_test.go
@@ -542,3 +542,65 @@ func TestJurisdictionToken_EnvToken(t *testing.T) {
 		t.Errorf("home-fallback audience = %q, want https://us.entire.io", got)
 	}
 }
+
+// TestCellClientFactory_ReusesTokenPerJurisdiction pins the factory's core
+// contract: identity tokens are per-jurisdiction, not per-cell, so building
+// clients for several cells must mint one token per distinct jurisdiction and
+// reuse it across cells. Not parallel: manipulates env + token store.
+func TestCellClientFactory_ReusesTokenPerJurisdiction(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Setenv("ENTIRE_API_BASE_URL", "https://entire.io")
+	t.Setenv("ENTIRE_API_AUDIENCE_TEMPLATE", "")
+	t.Setenv("ENTIRE_CORE_BASE_URL_TEMPLATE", "")
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	var exchangeCount int
+	var audiences []string
+	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != oauthTokenPath {
+			http.NotFound(w, r)
+			return
+		}
+		_ = r.ParseForm() //nolint:errcheck // test handler
+		exchangeCount++
+		audiences = append(audiences, r.FormValue("audience"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"access_token":"identity-token-%d","token_type":"Bearer","expires_in":3600}`, exchangeCount)
+	}))
+	defer coreSrv.Close()
+
+	svc := tokenstore.CoreKeyringService(coreSrv.URL)
+	loginJWT := makeJWT(t, fmt.Sprintf(`{"iss":%q,"home_jurisdiction":"us","exp":%d}`, coreSrv.URL, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "me", tokenstore.EncodeTokenWithExpiration(loginJWT, 7200)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	ctxObj := &contexts.Context{Name: "me@core", CoreURL: coreSrv.URL, Handle: "me", KeychainService: svc}
+	t.Cleanup(SetResolveContextForCellAPIForTest(t, func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+		return ctxObj, nil
+	}))
+	t.Cleanup(SetCellExchangeTransportForTest(t, coreSrv.Client().Transport))
+
+	factory, err := NewEntireAPICellClientFactory(context.Background(), false)
+	if err != nil {
+		t.Fatalf("NewEntireAPICellClientFactory: %v", err)
+	}
+
+	// Two eu cells then one us cell: two exchanges total, the eu token reused
+	// for the second eu cell.
+	for _, target := range []*CellTarget{
+		{BaseURL: "https://cell-a.api.example", Jurisdiction: "eu"},
+		{BaseURL: "https://cell-b.api.example", Jurisdiction: "eu"},
+		{BaseURL: "https://cell-c.api.example", Jurisdiction: "us"},
+	} {
+		if _, err := factory.ClientFor(context.Background(), target); err != nil {
+			t.Fatalf("ClientFor(%s): %v", target.BaseURL, err)
+		}
+	}
+	if exchangeCount != 2 {
+		t.Fatalf("exchange count = %d, want 2 (one per distinct jurisdiction)", exchangeCount)
+	}
+	if got, want := strings.Join(audiences, ","), "https://eu.entire.io,"+usEntireAudience; got != want {
+		t.Fatalf("exchange audiences = %q, want %q", got, want)
+	}
+}

--- a/cmd/entire/cli/cell_fanout.go
+++ b/cmd/entire/cli/cell_fanout.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// This file is the multi-cell counterpart to cell_target.go: where
+// resolveRepoCellTarget routes ONE repo-scoped call to the cell hosting that
+// repo, the helpers here route a query over ALL of the caller's repos — group
+// the repo index by hosting cell, then ask each cell about its own repos and
+// let the caller merge. That mirrors the entire.io BFF's fan-out
+// (code-search.ts: index → group by cell → per-cell call → merge); no
+// server-side aggregator exists, cells are strictly local.
+
+// cellGroup is one entire-api cell plus the caller's repos hosted there — the
+// unit of a multi-cell fan-out.
+type cellGroup struct {
+	// cell is the physical cell name (e.g. aws-eu-west-1), the grouping key —
+	// each repo placement lives in exactly one cell. Empty when the index did
+	// not report one (the group then routes by jurisdiction, or home).
+	cell string
+	// clusterSlug joins the group to the cluster catalog
+	// (RepoIndexEntry.ClusterSlug ↔ Cluster.Slug) to resolve baseURL. The
+	// catalog does not expose a cell field, so the slug — not the cell name —
+	// is the only reliable join key. Several clusters may share a cell; any of
+	// them reports the jurisdiction's apiUrl, so the first seen slug serves.
+	clusterSlug string
+	// jurisdiction is the lowercased jurisdiction label; it drives the identity
+	// token audience and is the routing fallback when baseURL is empty.
+	jurisdiction string
+	// baseURL is the cell's resolved apiUrl (resolveCellBaseURLs). Empty means
+	// "route by jurisdiction" — the auth layer then resolves the jurisdiction's
+	// default cell from the catalog.
+	baseURL string
+	// repoIDs are the caller's repo ULIDs placed in this cell, so the cell is
+	// only ever asked about repos it hosts.
+	repoIDs []string
+}
+
+// groupReposByCell groups a repo index by hosting cell, one group per distinct
+// cell, deterministically ordered by cell name. Entries without an ID are
+// skipped (nothing to ask the cell about).
+func groupReposByCell(repos []coreapi.RepoIndexEntry) []cellGroup {
+	byCell := make(map[string]*cellGroup)
+	for _, r := range repos {
+		id := strings.TrimSpace(r.ID)
+		if id == "" {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(r.Cell))
+		g, ok := byCell[key]
+		if !ok {
+			g = &cellGroup{
+				cell:         key,
+				clusterSlug:  strings.ToLower(strings.TrimSpace(r.ClusterSlug)),
+				jurisdiction: strings.ToLower(strings.TrimSpace(r.Jurisdiction)),
+			}
+			byCell[key] = g
+		}
+		g.repoIDs = append(g.repoIDs, id)
+	}
+	cells := make([]cellGroup, 0, len(byCell))
+	for _, g := range byCell {
+		cells = append(cells, *g)
+	}
+	sort.Slice(cells, func(i, j int) bool { return cells[i].cell < cells[j].cell })
+	return cells
+}
+
+// resolveCellBaseURLs fills each group's baseURL from the cluster catalog,
+// joining on ClusterSlug ↔ Cluster.Slug. Best-effort: on a catalog error or a
+// missing/incomplete cluster row the group keeps baseURL "" and falls back to
+// jurisdiction routing — a degraded catalog must not sink the fan-out.
+func resolveCellBaseURLs(ctx context.Context, c cellCoreClient, cells []cellGroup) {
+	clusters, err := c.ListClusters(ctx)
+	if err != nil {
+		logging.Debug(ctx, "cell fan-out: list clusters failed, using jurisdiction routing", "error", err.Error())
+		return
+	}
+	bySlug := make(map[string]coreapi.Cluster, len(clusters.Clusters))
+	for _, cl := range clusters.Clusters {
+		bySlug[strings.ToLower(strings.TrimSpace(cl.Slug))] = cl
+	}
+	for i := range cells {
+		cl, ok := bySlug[cells[i].clusterSlug]
+		if !ok {
+			logging.Debug(ctx, "cell fan-out: cluster not in catalog, using jurisdiction routing",
+				"cluster_slug", cells[i].clusterSlug, "cell", cells[i].cell)
+			continue
+		}
+		cells[i].baseURL = strings.TrimRight(strings.TrimSpace(cl.ApiUrl.Or("")), "/")
+		if j := strings.ToLower(strings.TrimSpace(cl.Jurisdiction)); j != "" {
+			cells[i].jurisdiction = j
+		}
+	}
+}
+
+// cellTarget converts the group's routing coordinates into the auth layer's
+// CellTarget: full target when the catalog resolved a baseURL,
+// jurisdiction-only when it didn't, nil (home routing) when neither is known.
+func (g cellGroup) cellTarget() *auth.CellTarget {
+	switch {
+	case g.baseURL != "":
+		return &auth.CellTarget{BaseURL: g.baseURL, Jurisdiction: g.jurisdiction}
+	case g.jurisdiction != "":
+		return &auth.CellTarget{Jurisdiction: g.jurisdiction}
+	default:
+		return nil
+	}
+}
+
+// label names the group in errors and logs: cell, else jurisdiction, else home.
+func (g cellGroup) label() string {
+	switch {
+	case g.cell != "":
+		return g.cell
+	case g.jurisdiction != "":
+		return g.jurisdiction
+	default:
+		return "home"
+	}
+}
+
+// cellClientBuilder is what fanOutCells needs from the auth layer;
+// *auth.CellClientFactory satisfies it. A seam so fan-out tests don't run the
+// real discovery/exchange stack.
+type cellClientBuilder interface {
+	ClientFor(ctx context.Context, target *auth.CellTarget) (*api.Client, error)
+}
+
+// newCellClientBuilder builds the per-operation cell client factory: the
+// subject is resolved once and identity tokens are minted once per
+// jurisdiction, however many cells the fan-out touches. Swapped in tests.
+var newCellClientBuilder = func(ctx context.Context, insecureHTTP bool) (cellClientBuilder, error) {
+	return auth.NewEntireAPICellClientFactory(ctx, insecureHTTP)
+}
+
+// cellCallResult is one cell's outcome in a fan-out: the group it was asked
+// for, and either fn's value or the error (client construction or fn itself).
+type cellCallResult[T any] struct {
+	group cellGroup
+	value T
+	err   error
+}
+
+// fanOutCells calls fn once per cell group — concurrently when there is more
+// than one — under a per-cell timeout, and returns every cell's outcome in
+// input order. One bad cell never sinks the operation: its error is recorded
+// in its slot and the other cells proceed; the caller decides how partial
+// results surface (typically: merge successes, warn about failures, error only
+// when every cell failed). The returned error is non-nil only when no per-cell
+// call could even start (factory construction failed — e.g. not logged in).
+func fanOutCells[T any](ctx context.Context, insecureHTTP bool, perCellTimeout time.Duration, cells []cellGroup, fn func(ctx context.Context, group cellGroup, client *api.Client) (T, error)) ([]cellCallResult[T], error) {
+	if len(cells) == 0 {
+		return nil, nil
+	}
+	factory, err := newCellClientBuilder(ctx, insecureHTTP)
+	if err != nil {
+		return nil, err
+	}
+
+	call := func(ctx context.Context, g cellGroup) cellCallResult[T] {
+		ctx, cancel := context.WithTimeout(ctx, perCellTimeout)
+		defer cancel()
+		res := cellCallResult[T]{group: g}
+		client, err := factory.ClientFor(ctx, g.cellTarget())
+		if err != nil {
+			res.err = err
+			return res
+		}
+		res.value, res.err = fn(ctx, g, client)
+		return res
+	}
+
+	results := make([]cellCallResult[T], len(cells))
+	if len(cells) == 1 {
+		results[0] = call(ctx, cells[0])
+		return results, nil
+	}
+	var wg sync.WaitGroup
+	for i := range cells {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i] = call(ctx, cells[i])
+		}(i)
+	}
+	wg.Wait()
+	return results, nil
+}

--- a/cmd/entire/cli/cell_fanout.go
+++ b/cmd/entire/cli/cell_fanout.go
@@ -47,8 +47,11 @@ type cellGroup struct {
 }
 
 // groupReposByCell groups a repo index by hosting cell, one group per distinct
-// cell, deterministically ordered by cell name. Entries without an ID are
-// skipped (nothing to ask the cell about).
+// cell, deterministically ordered by cell name (jurisdiction as tiebreak).
+// Entries without an ID are skipped (nothing to ask the cell about). The key
+// includes the jurisdiction so entries whose index row carries no cell don't
+// collapse across jurisdictions into one group routed by whichever repo came
+// first — they stay per-jurisdiction and route via the jurisdiction fallback.
 func groupReposByCell(repos []coreapi.RepoIndexEntry) []cellGroup {
 	byCell := make(map[string]*cellGroup)
 	for _, r := range repos {
@@ -56,13 +59,15 @@ func groupReposByCell(repos []coreapi.RepoIndexEntry) []cellGroup {
 		if id == "" {
 			continue
 		}
-		key := strings.ToLower(strings.TrimSpace(r.Cell))
+		cell := strings.ToLower(strings.TrimSpace(r.Cell))
+		jurisdiction := strings.ToLower(strings.TrimSpace(r.Jurisdiction))
+		key := cell + "\x00" + jurisdiction
 		g, ok := byCell[key]
 		if !ok {
 			g = &cellGroup{
-				cell:         key,
+				cell:         cell,
 				clusterSlug:  strings.ToLower(strings.TrimSpace(r.ClusterSlug)),
-				jurisdiction: strings.ToLower(strings.TrimSpace(r.Jurisdiction)),
+				jurisdiction: jurisdiction,
 			}
 			byCell[key] = g
 		}
@@ -72,15 +77,25 @@ func groupReposByCell(repos []coreapi.RepoIndexEntry) []cellGroup {
 	for _, g := range byCell {
 		cells = append(cells, *g)
 	}
-	sort.Slice(cells, func(i, j int) bool { return cells[i].cell < cells[j].cell })
+	sort.Slice(cells, func(i, j int) bool {
+		if cells[i].cell != cells[j].cell {
+			return cells[i].cell < cells[j].cell
+		}
+		return cells[i].jurisdiction < cells[j].jurisdiction
+	})
 	return cells
 }
 
 // resolveCellBaseURLs fills each group's baseURL from the cluster catalog,
-// joining on ClusterSlug ↔ Cluster.Slug. Best-effort: on a catalog error or a
-// missing/incomplete cluster row the group keeps baseURL "" and falls back to
-// jurisdiction routing — a degraded catalog must not sink the fan-out.
+// joining on ClusterSlug ↔ Cluster.Slug. Best-effort: on a catalog error or
+// timeout (bounded by cellResolveTimeout, like resolveRepoCellTarget — a hung
+// core must not stall the command) or a missing/incomplete cluster row, the
+// group keeps baseURL "" and falls back to jurisdiction routing — a degraded
+// catalog must not sink the fan-out.
 func resolveCellBaseURLs(ctx context.Context, c cellCoreClient, cells []cellGroup) {
+	ctx, cancel := context.WithTimeout(ctx, cellResolveTimeout)
+	defer cancel()
+
 	clusters, err := c.ListClusters(ctx)
 	if err != nil {
 		logging.Debug(ctx, "cell fan-out: list clusters failed, using jurisdiction routing", "error", err.Error())
@@ -97,10 +112,21 @@ func resolveCellBaseURLs(ctx context.Context, c cellCoreClient, cells []cellGrou
 				"cluster_slug", cells[i].clusterSlug, "cell", cells[i].cell)
 			continue
 		}
-		cells[i].baseURL = strings.TrimRight(strings.TrimSpace(cl.ApiUrl.Or("")), "/")
+		// A concrete baseURL needs a jurisdiction to mint the matching token
+		// for — mirroring resolveRepoCellTarget, which refuses a target unless
+		// both are present. Setting baseURL with an unknown jurisdiction would
+		// dial the cell with a home-jurisdiction token.
+		jurisdiction := cells[i].jurisdiction
 		if j := strings.ToLower(strings.TrimSpace(cl.Jurisdiction)); j != "" {
-			cells[i].jurisdiction = j
+			jurisdiction = j
 		}
+		if jurisdiction == "" {
+			logging.Debug(ctx, "cell fan-out: no jurisdiction for cluster, using home routing",
+				"cluster_slug", cells[i].clusterSlug, "cell", cells[i].cell)
+			continue
+		}
+		cells[i].jurisdiction = jurisdiction
+		cells[i].baseURL = strings.TrimRight(strings.TrimSpace(cl.ApiUrl.Or("")), "/")
 	}
 }
 

--- a/cmd/entire/cli/cell_fanout_test.go
+++ b/cmd/entire/cli/cell_fanout_test.go
@@ -1,0 +1,227 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+func TestGroupReposByCell(t *testing.T) {
+	t.Parallel()
+	repos := []coreapi.RepoIndexEntry{
+		{ID: "01B", Cell: "aws-us-east-2", ClusterSlug: "us-prod", Jurisdiction: "us"},
+		{ID: "01C", Cell: "AWS-US-EAST-2", ClusterSlug: "us-prod", Jurisdiction: "US"}, // case-folds into same group
+		{ID: "01A", Cell: euWestCell, ClusterSlug: "eu-prod", Jurisdiction: "eu"},
+		{ID: "", Cell: euWestCell}, // no ID → skipped
+		{ID: "01D"},                // no cell → its own "" group (home/jurisdiction routing)
+	}
+	cells := groupReposByCell(repos)
+	if len(cells) != 3 {
+		t.Fatalf("groups = %d, want 3: %+v", len(cells), cells)
+	}
+	// Deterministic order by cell name: "" < aws-eu-west-1 < aws-us-east-2.
+	if cells[0].cell != "" || cells[1].cell != euWestCell || cells[2].cell != "aws-us-east-2" {
+		t.Fatalf("group order = [%q %q %q], want [\"\" aws-eu-west-1 aws-us-east-2]", cells[0].cell, cells[1].cell, cells[2].cell)
+	}
+	us := cells[2]
+	if got := strings.Join(us.repoIDs, ","); got != "01B,01C" {
+		t.Fatalf("us repoIDs = %q, want 01B,01C", got)
+	}
+	if us.clusterSlug != "us-prod" || us.jurisdiction != "us" {
+		t.Fatalf("us group coordinates = %+v, want us-prod/us", us)
+	}
+}
+
+// TestResolveCellBaseURLs_JoinsOnClusterSlug pins the catalog join key: the
+// cluster catalog has no cell field, so groups must join on ClusterSlug —
+// joining the cell name against Cluster.Slug only works when the two happen to
+// coincide.
+func TestResolveCellBaseURLs_JoinsOnClusterSlug(t *testing.T) {
+	t.Parallel()
+	cells := []cellGroup{
+		// Slug ("eu-prod") differs from the cell name (euWestCell).
+		{cell: euWestCell, clusterSlug: "eu-prod", jurisdiction: "eu"},
+		{cell: "aws-ap-south-1", clusterSlug: "ap-prod", jurisdiction: "ap"}, // not in catalog
+	}
+	fake := &fakeCellCore{clusters: []coreapi.Cluster{
+		{Slug: "EU-Prod", Jurisdiction: "EU", ApiUrl: coreapi.NewOptString("https://aws-eu-west-1.api.entire.io/")},
+	}}
+	resolveCellBaseURLs(context.Background(), fake, cells)
+	if got := cells[0].baseURL; got != "https://aws-eu-west-1.api.entire.io" {
+		t.Fatalf("eu baseURL = %q, want the catalog apiUrl (trimmed)", got)
+	}
+	if cells[0].jurisdiction != "eu" {
+		t.Fatalf("eu jurisdiction = %q, want normalised eu", cells[0].jurisdiction)
+	}
+	if cells[1].baseURL != "" {
+		t.Fatalf("ap baseURL = %q, want empty (jurisdiction fallback)", cells[1].baseURL)
+	}
+}
+
+func TestResolveCellBaseURLs_CatalogErrorLeavesJurisdictionRouting(t *testing.T) {
+	t.Parallel()
+	cells := []cellGroup{{cell: euWestCell, clusterSlug: "eu-prod", jurisdiction: "eu"}}
+	resolveCellBaseURLs(context.Background(), &fakeCellCore{clustersErr: errors.New("boom")}, cells)
+	if cells[0].baseURL != "" {
+		t.Fatalf("baseURL = %q, want empty after catalog error", cells[0].baseURL)
+	}
+}
+
+func TestCellGroupTargetAndLabel(t *testing.T) {
+	t.Parallel()
+	full := cellGroup{cell: euWestCell, jurisdiction: "eu", baseURL: "https://aws-eu-west-1.api.entire.io"}
+	if tgt := full.cellTarget(); tgt == nil || tgt.BaseURL != full.baseURL || tgt.Jurisdiction != "eu" {
+		t.Fatalf("full target = %+v", tgt)
+	}
+	jur := cellGroup{jurisdiction: "eu"}
+	if tgt := jur.cellTarget(); tgt == nil || tgt.BaseURL != "" || tgt.Jurisdiction != "eu" {
+		t.Fatalf("jurisdiction-only target = %+v", tgt)
+	}
+	if tgt := (cellGroup{}).cellTarget(); tgt != nil {
+		t.Fatalf("empty group target = %+v, want nil (home routing)", tgt)
+	}
+	if got := full.label(); got != euWestCell {
+		t.Fatalf("label = %q", got)
+	}
+	if got := jur.label(); got != "eu" {
+		t.Fatalf("label = %q", got)
+	}
+	if got := (cellGroup{}).label(); got != "home" {
+		t.Fatalf("label = %q, want home", got)
+	}
+}
+
+// fakeCellClientBuilder hands out unauthenticated clients keyed by target and
+// records what it was asked for.
+type fakeCellClientBuilder struct {
+	mu      sync.Mutex // fanOutCells calls ClientFor from one goroutine per cell
+	targets []*auth.CellTarget
+	err     error
+}
+
+func (f *fakeCellClientBuilder) ClientFor(_ context.Context, target *auth.CellTarget) (*api.Client, error) {
+	f.mu.Lock()
+	f.targets = append(f.targets, target)
+	f.mu.Unlock()
+	if f.err != nil {
+		return nil, f.err
+	}
+	base := "https://home.api.example"
+	if target != nil && target.BaseURL != "" {
+		base = target.BaseURL
+	}
+	return api.NewClientWithBaseURL("test-token", base), nil
+}
+
+func withFakeCellClientBuilder(t *testing.T, f *fakeCellClientBuilder) {
+	t.Helper()
+	prev := newCellClientBuilder
+	newCellClientBuilder = func(context.Context, bool) (cellClientBuilder, error) { return f, nil }
+	t.Cleanup(func() { newCellClientBuilder = prev })
+}
+
+func TestFanOutCells_PartialFailureIsPerCell(t *testing.T) {
+	// Not parallel: swaps the package-level newCellClientBuilder seam.
+	withFakeCellClientBuilder(t, &fakeCellClientBuilder{})
+	cells := []cellGroup{
+		{cell: euWestCell, jurisdiction: "eu", baseURL: "https://eu.api.example", repoIDs: []string{"01A"}},
+		{cell: "aws-us-east-2", jurisdiction: "us", baseURL: "https://us.api.example", repoIDs: []string{"01B"}},
+	}
+	boom := errors.New("cell down")
+	results, err := fanOutCells(context.Background(), false, time.Second, cells,
+		func(ctx context.Context, g cellGroup, _ *api.Client) (string, error) {
+			if _, ok := ctx.Deadline(); !ok {
+				t.Error("per-cell ctx has no deadline")
+			}
+			if g.cell == euWestCell {
+				return "", boom
+			}
+			return "hits:" + strings.Join(g.repoIDs, ","), nil
+		})
+	if err != nil {
+		t.Fatalf("fanOutCells: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	// Input order preserved; the eu failure is isolated in its slot.
+	if !errors.Is(results[0].err, boom) || results[0].group.cell != euWestCell {
+		t.Fatalf("results[0] = %+v, want eu failure", results[0])
+	}
+	if results[1].err != nil || results[1].value != "hits:01B" {
+		t.Fatalf("results[1] = %+v, want us success", results[1])
+	}
+}
+
+func TestFanOutCells_SingleCellRunsSerially(t *testing.T) {
+	// Not parallel: swaps the package-level newCellClientBuilder seam.
+	builder := &fakeCellClientBuilder{}
+	withFakeCellClientBuilder(t, builder)
+	cells := []cellGroup{{jurisdiction: "eu", baseURL: "https://eu.api.example"}}
+	results, err := fanOutCells(context.Background(), false, time.Second, cells,
+		func(_ context.Context, _ cellGroup, _ *api.Client) (string, error) {
+			return "ok", nil
+		})
+	if err != nil || len(results) != 1 || results[0].err != nil || results[0].value != "ok" {
+		t.Fatalf("results = %+v, err = %v", results, err)
+	}
+	if len(builder.targets) != 1 || builder.targets[0].BaseURL != "https://eu.api.example" {
+		t.Fatalf("builder targets = %+v", builder.targets)
+	}
+}
+
+func TestFanOutCells_EmptyAndFactoryError(t *testing.T) {
+	// Not parallel: swaps the package-level newCellClientBuilder seam.
+	results, err := fanOutCells(context.Background(), false, time.Second, nil,
+		func(context.Context, cellGroup, *api.Client) (int, error) { return 0, nil })
+	if results != nil || err != nil {
+		t.Fatalf("empty fan-out = (%v, %v), want (nil, nil)", results, err)
+	}
+
+	factoryErr := errors.New("not logged in")
+	prev := newCellClientBuilder
+	newCellClientBuilder = func(context.Context, bool) (cellClientBuilder, error) { return nil, factoryErr }
+	t.Cleanup(func() { newCellClientBuilder = prev })
+	if _, err := fanOutCells(context.Background(), false, time.Second, []cellGroup{{jurisdiction: "eu"}},
+		func(context.Context, cellGroup, *api.Client) (int, error) { return 0, nil }); !errors.Is(err, factoryErr) {
+		t.Fatalf("err = %v, want factory error", err)
+	}
+}
+
+// TestFanOutCells_ClientPerCellFromOneBuilder asserts every cell's client
+// comes from the single shared builder (one subject, per-jurisdiction token
+// reuse lives behind it in auth.CellClientFactory).
+func TestFanOutCells_ClientPerCellFromOneBuilder(t *testing.T) {
+	// Not parallel: swaps the package-level newCellClientBuilder seam.
+	builder := &fakeCellClientBuilder{}
+	withFakeCellClientBuilder(t, builder)
+	var cells []cellGroup
+	for i := range 3 {
+		cells = append(cells, cellGroup{
+			cell:         fmt.Sprintf("cell-%d", i),
+			jurisdiction: "eu",
+			baseURL:      fmt.Sprintf("https://cell-%d.api.example", i),
+		})
+	}
+	results, err := fanOutCells(context.Background(), false, time.Second, cells,
+		func(_ context.Context, g cellGroup, _ *api.Client) (string, error) { return g.cell, nil })
+	if err != nil {
+		t.Fatalf("fanOutCells: %v", err)
+	}
+	for i, r := range results {
+		if r.err != nil || r.value != fmt.Sprintf("cell-%d", i) {
+			t.Fatalf("results[%d] = %+v", i, r)
+		}
+	}
+	if len(builder.targets) != 3 {
+		t.Fatalf("builder asked for %d targets, want 3", len(builder.targets))
+	}
+}

--- a/cmd/entire/cli/cell_fanout_test.go
+++ b/cmd/entire/cli/cell_fanout_test.go
@@ -21,22 +21,50 @@ func TestGroupReposByCell(t *testing.T) {
 		{ID: "01C", Cell: "AWS-US-EAST-2", ClusterSlug: "us-prod", Jurisdiction: "US"}, // case-folds into same group
 		{ID: "01A", Cell: euWestCell, ClusterSlug: "eu-prod", Jurisdiction: "eu"},
 		{ID: "", Cell: euWestCell}, // no ID → skipped
-		{ID: "01D"},                // no cell → its own "" group (home/jurisdiction routing)
+		// Blank cell in different jurisdictions must NOT collapse into one
+		// group — each routes via its own jurisdiction fallback.
+		{ID: "01D", Jurisdiction: "eu"},
+		{ID: "01E", Jurisdiction: "us"},
 	}
 	cells := groupReposByCell(repos)
-	if len(cells) != 3 {
-		t.Fatalf("groups = %d, want 3: %+v", len(cells), cells)
+	if len(cells) != 4 {
+		t.Fatalf("groups = %d, want 4: %+v", len(cells), cells)
 	}
-	// Deterministic order by cell name: "" < aws-eu-west-1 < aws-us-east-2.
-	if cells[0].cell != "" || cells[1].cell != euWestCell || cells[2].cell != "aws-us-east-2" {
-		t.Fatalf("group order = [%q %q %q], want [\"\" aws-eu-west-1 aws-us-east-2]", cells[0].cell, cells[1].cell, cells[2].cell)
+	// Deterministic order by cell name, jurisdiction tiebreak:
+	// ""/eu < ""/us < aws-eu-west-1 < aws-us-east-2.
+	order := []struct{ cell, jurisdiction string }{
+		{"", "eu"}, {"", "us"}, {euWestCell, "eu"}, {"aws-us-east-2", "us"},
 	}
-	us := cells[2]
+	for i, want := range order {
+		if cells[i].cell != want.cell || cells[i].jurisdiction != want.jurisdiction {
+			t.Fatalf("group[%d] = %q/%q, want %q/%q", i, cells[i].cell, cells[i].jurisdiction, want.cell, want.jurisdiction)
+		}
+	}
+	if got := strings.Join(cells[0].repoIDs, ","); got != "01D" {
+		t.Fatalf("blank-cell eu repoIDs = %q, want 01D", got)
+	}
+	us := cells[3]
 	if got := strings.Join(us.repoIDs, ","); got != "01B,01C" {
 		t.Fatalf("us repoIDs = %q, want 01B,01C", got)
 	}
 	if us.clusterSlug != "us-prod" || us.jurisdiction != "us" {
 		t.Fatalf("us group coordinates = %+v, want us-prod/us", us)
+	}
+}
+
+// TestResolveCellBaseURLs_RefusesBaseURLWithoutJurisdiction pins the guard: a
+// concrete baseURL is only usable together with the jurisdiction its token
+// must be minted for; a catalog row with no jurisdiction leaves the group on
+// home routing instead of dialing a foreign cell with a home token.
+func TestResolveCellBaseURLs_RefusesBaseURLWithoutJurisdiction(t *testing.T) {
+	t.Parallel()
+	cells := []cellGroup{{cell: "aws-eu-west-1", clusterSlug: "eu-prod"}} // no jurisdiction anywhere
+	fake := &fakeCellCore{clusters: []coreapi.Cluster{
+		{Slug: "eu-prod", ApiUrl: coreapi.NewOptString(euCellAPIURL)}, // row has no jurisdiction either
+	}}
+	resolveCellBaseURLs(context.Background(), fake, cells)
+	if cells[0].baseURL != "" || cells[0].jurisdiction != "" {
+		t.Fatalf("group = %+v, want untouched (home routing)", cells[0])
 	}
 }
 

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -10,31 +10,31 @@ import (
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// expertsCellResolveTimeout bounds the best-effort control-plane lookups that
+// cellResolveTimeout bounds the best-effort control-plane lookups that
 // pick a repo's cell. Without it, a reachable-but-hung control plane would block
-// the whole experts command instead of degrading to home-jurisdiction routing —
-// the "any failure falls back" contract must hold for slow cores, not just
-// erroring ones.
-const expertsCellResolveTimeout = 5 * time.Second
+// the calling command (experts, and any future cell-routed command) instead of
+// degrading to home-jurisdiction routing — the "any failure falls back" contract
+// must hold for slow cores, not just erroring ones.
+const cellResolveTimeout = 5 * time.Second
 
-// expertsCoreClient is the control-plane surface the cell-target resolver needs.
+// cellCoreClient is the control-plane surface the cell-target resolver needs.
 // An interface (with a swappable constructor) so the resolver is unit-testable
 // against a fake control plane; *coreapi.Client satisfies it.
-type expertsCoreClient interface {
+type cellCoreClient interface {
 	GetRepo(ctx context.Context, params coreapi.GetRepoParams) (*coreapi.Repo, error)
 	ListClusters(ctx context.Context) (*coreapi.ListClustersOutputBody, error)
 	ListMirrors(ctx context.Context, params coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error)
 }
 
-// newExpertsCoreClient builds the control-plane client used for cell resolution.
+// newCellCoreClient builds the control-plane client used for cell resolution.
 // Swapped in tests.
-var newExpertsCoreClient = func() (expertsCoreClient, error) { return coreapi.New() }
+var newCellCoreClient = func() (cellCoreClient, error) { return coreapi.New() }
 
-// resolveExpertsCellTarget resolves the entire-api cell that HOSTS the given
-// repo, plus that cell's jurisdiction, so a repo-scoped experts call reaches the
-// region that owns the repo — mirroring how the entire.io BFF selects a cell per
-// repo (resolve-cluster-host.ts / repos-stream.ts) rather than using the
-// caller's home cell.
+// resolveRepoCellTarget resolves the entire-api cell that HOSTS the given
+// repo, plus that cell's jurisdiction, so a repo-scoped call (experts today)
+// reaches the region that owns the repo — mirroring how the entire.io BFF
+// selects a cell per repo (resolve-cluster-host.ts / repos-stream.ts) rather
+// than using the caller's home cell.
 //
 // It is deliberately best-effort: ANY failure (not logged in, control-plane
 // error or timeout, unknown/ambiguous placement, missing apiUrl) returns nil,
@@ -50,13 +50,13 @@ var newExpertsCoreClient = func() (expertsCoreClient, error) { return coreapi.Ne
 // The cluster host is then mapped to a cell apiUrl + jurisdiction via the
 // coreapi cluster catalog (ListClusters), the authoritative source for a
 // jurisdiction's cell URL.
-func resolveExpertsCellTarget(ctx context.Context, fullName, ulid string) *auth.CellTarget {
-	ctx, cancel := context.WithTimeout(ctx, expertsCellResolveTimeout)
+func resolveRepoCellTarget(ctx context.Context, fullName, ulid string) *auth.CellTarget {
+	ctx, cancel := context.WithTimeout(ctx, cellResolveTimeout)
 	defer cancel()
 
-	c, err := newExpertsCoreClient()
+	c, err := newCellCoreClient()
 	if err != nil {
-		logging.Debug(ctx, "experts cell target: core client unavailable, using home-jurisdiction routing", "error", err.Error())
+		logging.Debug(ctx, "cell target: core client unavailable, using home-jurisdiction routing", "error", err.Error())
 		return nil
 	}
 
@@ -67,12 +67,12 @@ func resolveExpertsCellTarget(ctx context.Context, fullName, ulid string) *auth.
 
 	clusters, err := c.ListClusters(ctx)
 	if err != nil {
-		logging.Debug(ctx, "experts cell target: list clusters failed, using home-jurisdiction routing", "error", err.Error())
+		logging.Debug(ctx, "cell target: list clusters failed, using home-jurisdiction routing", "error", err.Error())
 		return nil
 	}
 	cluster, ok := matchClusterByHost(clusters.Clusters, clusterHost)
 	if !ok {
-		logging.Debug(ctx, "experts cell target: no cluster matched repo host, using home-jurisdiction routing", "cluster_host", clusterHost)
+		logging.Debug(ctx, "cell target: no cluster matched repo host, using home-jurisdiction routing", "cluster_host", clusterHost)
 		return nil
 	}
 	apiURL := strings.TrimRight(strings.TrimSpace(cluster.ApiUrl.Or("")), "/")
@@ -81,7 +81,7 @@ func resolveExpertsCellTarget(ctx context.Context, fullName, ulid string) *auth.
 	// instead of hard-failing the target path.
 	jurisdiction := strings.ToLower(strings.TrimSpace(cluster.Jurisdiction))
 	if apiURL == "" || jurisdiction == "" {
-		logging.Debug(ctx, "experts cell target: matched cluster missing apiUrl/jurisdiction, using home-jurisdiction routing", "cluster_host", clusterHost)
+		logging.Debug(ctx, "cell target: matched cluster missing apiUrl/jurisdiction, using home-jurisdiction routing", "cluster_host", clusterHost)
 		return nil
 	}
 	return &auth.CellTarget{BaseURL: apiURL, Jurisdiction: jurisdiction}
@@ -90,11 +90,11 @@ func resolveExpertsCellTarget(ctx context.Context, fullName, ulid string) *auth.
 // resolveRepoClusterHost finds the public cluster host that owns the repo. It
 // returns ok=false to signal "fall back to home-jurisdiction routing" for every
 // unresolved or ambiguous case, never an error.
-func resolveRepoClusterHost(ctx context.Context, c expertsCoreClient, fullName, ulid string) (string, bool) {
+func resolveRepoClusterHost(ctx context.Context, c cellCoreClient, fullName, ulid string) (string, bool) {
 	if strings.TrimSpace(ulid) != "" {
 		repo, err := c.GetRepo(ctx, coreapi.GetRepoParams{RepoId: ulid})
 		if err != nil {
-			logging.Debug(ctx, "experts cell target: GetRepo failed, using home-jurisdiction routing", "error", err.Error())
+			logging.Debug(ctx, "cell target: GetRepo failed, using home-jurisdiction routing", "error", err.Error())
 			return "", false
 		}
 		return strings.TrimSpace(repo.ClusterHost.Or("")), true
@@ -106,16 +106,16 @@ func resolveRepoClusterHost(ctx context.Context, c expertsCoreClient, fullName, 
 	}
 	mirrors, err := listMirrorsForRepo(ctx, c, mirrorCloneProviderGitHub, strings.ToLower(owner), strings.ToLower(repo))
 	if err != nil {
-		logging.Debug(ctx, "experts cell target: list mirrors failed, using home-jurisdiction routing", "error", err.Error())
+		logging.Debug(ctx, "cell target: list mirrors failed, using home-jurisdiction routing", "error", err.Error())
 		return "", false
 	}
 	hosts := distinctActiveClusterHosts(mirrors)
 	if len(hosts) != 1 {
 		// Zero placements (not mirrored / unknown) or multiple regions
-		// (ambiguous which cell holds the experts data): fall back rather than
+		// (ambiguous which cell holds the repo-scoped data): fall back rather than
 		// guess a region.
 		if len(hosts) > 1 {
-			logging.Debug(ctx, "experts cell target: repo mirrored in multiple regions, using home-jurisdiction routing", "count", len(hosts))
+			logging.Debug(ctx, "cell target: repo mirrored in multiple regions, using home-jurisdiction routing", "count", len(hosts))
 		}
 		return "", false
 	}
@@ -136,7 +136,7 @@ func isActiveMirror(m coreapi.Mirror) bool {
 
 // distinctActiveClusterHosts returns the set of cluster hosts a repo is actively
 // serviced on: excluding archived placements and unhealthy ones (failed /
-// suspended clone status), since those cells can't answer experts for the repo.
+// suspended clone status), since those cells can't answer for the repo.
 // A failed/suspended placement must neither manufacture false cross-region
 // ambiguity nor become a sole "active" host. Case-folded to match DNS
 // semantics; order is unimportant (callers only use a single-member set).

--- a/cmd/entire/cli/cell_target_test.go
+++ b/cmd/entire/cli/cell_target_test.go
@@ -88,8 +88,8 @@ func TestClusterHostJoin(t *testing.T) {
 	}
 }
 
-// fakeExpertsCore is a stub control plane for resolveExpertsCellTarget tests.
-type fakeExpertsCore struct {
+// fakeCellCore is a stub control plane for resolveRepoCellTarget tests.
+type fakeCellCore struct {
 	repo        *coreapi.Repo
 	repoErr     error
 	mirrors     []coreapi.Mirror
@@ -98,29 +98,29 @@ type fakeExpertsCore struct {
 	clustersErr error
 }
 
-func (f *fakeExpertsCore) GetRepo(context.Context, coreapi.GetRepoParams) (*coreapi.Repo, error) {
+func (f *fakeCellCore) GetRepo(context.Context, coreapi.GetRepoParams) (*coreapi.Repo, error) {
 	return f.repo, f.repoErr
 }
 
-func (f *fakeExpertsCore) ListClusters(context.Context) (*coreapi.ListClustersOutputBody, error) {
+func (f *fakeCellCore) ListClusters(context.Context) (*coreapi.ListClustersOutputBody, error) {
 	if f.clustersErr != nil {
 		return nil, f.clustersErr
 	}
 	return &coreapi.ListClustersOutputBody{Clusters: f.clusters}, nil
 }
 
-func (f *fakeExpertsCore) ListMirrors(context.Context, coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error) {
+func (f *fakeCellCore) ListMirrors(context.Context, coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error) {
 	if f.mirrorsErr != nil {
 		return nil, f.mirrorsErr
 	}
 	return &coreapi.ListMirrorsOutputBody{Mirrors: f.mirrors}, nil
 }
 
-func withFakeExpertsCore(t *testing.T, f *fakeExpertsCore) {
+func withFakeCellCore(t *testing.T, f *fakeCellCore) {
 	t.Helper()
-	prev := newExpertsCoreClient
-	newExpertsCoreClient = func() (expertsCoreClient, error) { return f, nil }
-	t.Cleanup(func() { newExpertsCoreClient = prev })
+	prev := newCellCoreClient
+	newCellCoreClient = func() (cellCoreClient, error) { return f, nil }
+	t.Cleanup(func() { newCellCoreClient = prev })
 }
 
 func euClusters() []coreapi.Cluster {
@@ -130,12 +130,12 @@ func euClusters() []coreapi.Cluster {
 	}
 }
 
-func TestResolveExpertsCellTarget_ULID(t *testing.T) {
-	withFakeExpertsCore(t, &fakeExpertsCore{
+func TestResolveRepoCellTarget_ULID(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
 		repo:     &coreapi.Repo{ID: "ULID", ClusterHost: coreapi.NewOptString("eu.entire.io")},
 		clusters: euClusters(),
 	})
-	target := resolveExpertsCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	target := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
 	if target == nil {
 		t.Fatal("expected a target for a resolvable ULID")
 	}
@@ -144,15 +144,15 @@ func TestResolveExpertsCellTarget_ULID(t *testing.T) {
 	}
 }
 
-func TestResolveExpertsCellTarget_ULIDError_FallsBack(t *testing.T) {
-	withFakeExpertsCore(t, &fakeExpertsCore{repoErr: errors.New("boom"), clusters: euClusters()})
-	if target := resolveExpertsCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV"); target != nil {
+func TestResolveRepoCellTarget_ULIDError_FallsBack(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{repoErr: errors.New("boom"), clusters: euClusters()})
+	if target := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV"); target != nil {
 		t.Fatalf("expected nil (fallback) on GetRepo error, got %+v", target)
 	}
 }
 
-func TestResolveExpertsCellTarget_OwnerRepoSingleRegion(t *testing.T) {
-	withFakeExpertsCore(t, &fakeExpertsCore{
+func TestResolveRepoCellTarget_OwnerRepoSingleRegion(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
 		mirrors: []coreapi.Mirror{
 			{Repo: "widget", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
 			// A failed placement in another region must be ignored, not create ambiguity.
@@ -162,43 +162,43 @@ func TestResolveExpertsCellTarget_OwnerRepoSingleRegion(t *testing.T) {
 		},
 		clusters: euClusters(),
 	})
-	target := resolveExpertsCellTarget(context.Background(), "acme/widget", "")
+	target := resolveRepoCellTarget(context.Background(), "acme/widget", "")
 	if target == nil || target.Jurisdiction != "eu" || target.BaseURL != euCellAPIURL {
 		t.Fatalf("target = %+v, want eu cell", target)
 	}
 }
 
-func TestResolveExpertsCellTarget_MultiRegion_FallsBack(t *testing.T) {
-	withFakeExpertsCore(t, &fakeExpertsCore{
+func TestResolveRepoCellTarget_MultiRegion_FallsBack(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
 		mirrors: []coreapi.Mirror{
 			{Repo: "widget", ClusterHost: "eu.entire.io"},
 			{Repo: "widget", ClusterHost: "us.entire.io"},
 		},
 		clusters: euClusters(),
 	})
-	if target := resolveExpertsCellTarget(context.Background(), "acme/widget", ""); target != nil {
+	if target := resolveRepoCellTarget(context.Background(), "acme/widget", ""); target != nil {
 		t.Fatalf("expected nil (fallback) for ambiguous multi-region repo, got %+v", target)
 	}
 }
 
-func TestResolveExpertsCellTarget_NoClusterMatch_FallsBack(t *testing.T) {
-	withFakeExpertsCore(t, &fakeExpertsCore{
+func TestResolveRepoCellTarget_NoClusterMatch_FallsBack(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
 		repo:     &coreapi.Repo{ClusterHost: coreapi.NewOptString("ap.entire.io")}, // not in catalog
 		clusters: euClusters(),
 	})
-	if target := resolveExpertsCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV"); target != nil {
+	if target := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV"); target != nil {
 		t.Fatalf("expected nil (fallback) when no cluster matches, got %+v", target)
 	}
 }
 
-func TestResolveExpertsCellTarget_JurisdictionLowercased(t *testing.T) {
-	withFakeExpertsCore(t, &fakeExpertsCore{
+func TestResolveRepoCellTarget_JurisdictionLowercased(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
 		repo: &coreapi.Repo{ClusterHost: coreapi.NewOptString("eu.entire.io")},
 		clusters: []coreapi.Cluster{
 			{PublicUrl: "https://eu.entire.io", Jurisdiction: "EU", ApiUrl: coreapi.NewOptString(euCellAPIURL)},
 		},
 	})
-	target := resolveExpertsCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	target := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
 	if target == nil || target.Jurisdiction != "eu" {
 		t.Fatalf("target = %+v, want lowercased jurisdiction eu", target)
 	}

--- a/cmd/entire/cli/cell_target_test.go
+++ b/cmd/entire/cli/cell_target_test.go
@@ -11,6 +11,8 @@ import (
 
 const euCellAPIURL = "https://eu.api.entire.io"
 
+const euWestCell = "aws-eu-west-1"
+
 func TestDistinctActiveClusterHosts(t *testing.T) {
 	t.Parallel()
 	mirrors := []coreapi.Mirror{

--- a/cmd/entire/cli/entireapi_client.go
+++ b/cmd/entire/cli/entireapi_client.go
@@ -16,8 +16,7 @@ import (
 
 // currentRepoRefTimeout bounds currentRepoRef's control-plane lookup. The
 // lookup is best-effort decoration (recap degrades to personal-only without
-// it), so a stalled core must not hang the command — mirror
-// expertsCellResolveTimeout.
+// it), so a stalled core must not hang the command — mirror cellResolveTimeout.
 const currentRepoRefTimeout = 5 * time.Second
 
 // runAuthenticatedActivityAPI runs fn with an authenticated client for the


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/762
<!-- entire-trail-link-end -->

Stacked on #1592. Extracts the CLI's cell-routing plumbing into a shared foundation so multi-cell commands (code search, #1616, and anything after it) stop growing parallel copies of it. The backend model gives the CLI exactly three routing shapes, mirroring the entire.io BFF: repo-scoped → one cell, user-scoped /me → home cell, repo-set queries → fan out and merge client-side (no server-side aggregator exists). #1592 covers the second; this PR generalizes the first and builds the third.

## Commits

- **`auth.CellClientFactory`** — `NewEntireAPICellClient` resolved the login subject (discovery + refresh) and ran the RFC 8693 exchange on every call. Identity tokens are per-jurisdiction, not per-cell, so a fan-out over N cells was about to pay N× all of it. The factory resolves the subject once and mints at most one token per jurisdiction; `NewEntireAPICellClient` stays as the single-cell wrapper, existing callers unchanged.
- **`cell_target.go`** — mechanical generalization of `experts_cell_target.go` (`resolveRepoCellTarget`, `cellCoreClient`, `cellResolveTimeout`): nothing in it was experts-specific, and it's the repo-scoped shape every cell-routed command needs. No behavior change.
- **`cell_fanout.go`** — the repo-set shape, extracted from what #1616 currently inlines into `search_cmd.go`:
  - `groupReposByCell`: repo index → per-cell groups, deterministic order.
  - `resolveCellBaseURLs`: cluster-catalog join on `ClusterSlug`↔`Cluster.Slug`. The catalog exposes **no cell field** — #1616's current join of the cell name against `Slug` only works when the two happen to coincide; a test pins the correct key.
  - `fanOutCells`: parallel per-cell calls under a per-cell timeout through **one** shared `CellClientFactory`; partial failures are isolated per result slot, merge semantics stay with the command.
- Documents the three routing shapes in CLAUDE.md.

## Intended consumer

#1616 (code search) keeps its `codesearch` client, merge/sort/dedup semantics, and output rendering, and replaces its inline `groupReposByCell`/`searchAllCells`/`searchCell` orchestration with these helpers — fixing the slug join and the per-cell token minting along the way.

## Testing

`mise run test:ci` green (unit + integration + both canary suites), `-race` on the fan-out tests. New tests: factory token reuse per jurisdiction, group determinism, slug-join pinning, per-cell failure isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication (RFC 8693 exchange caching) and cross-region API routing; behavior is largely refactored with tests, but fan-out and factory concurrency affect how multi-cell commands authenticate and fail partially.
> 
> **Overview**
> Introduces shared **entire-api cell routing** so multi-cell commands can reuse one plumbing layer instead of duplicating BFF-style routing.
> 
> **Auth:** `NewEntireAPICellClient` now delegates to **`CellClientFactory`**, which resolves the login subject once and caches **one jurisdictional identity token per jurisdiction** (not per cell). `NewEntireAPICellClient` remains the single-cell entry point; existing callers are unchanged.
> 
> **Repo-scoped routing:** Experts-style resolution is renamed and generalized to **`resolveRepoCellTarget`** (from `resolveExpertsCellTarget`), with shared **`cellCoreClient`** / **`cellResolveTimeout`** naming. Behavior is unchanged; **`NewAuthenticatedEntireAPICellClient`** calls the new resolver.
> 
> **Repo-set routing:** New **`cell_fanout.go`** provides **`groupReposByCell`**, **`resolveCellBaseURLs`** (catalog join on **`ClusterSlug` ↔ `Cluster.Slug`**, not cell name), and generic **`fanOutCells`** (parallel per-cell calls, per-cell timeout, isolated partial failures, one factory per operation).
> 
> **Docs:** `CLAUDE.md` documents the three routing shapes (repo-scoped, `/me` home cell, repo-set fan-out) and the per-jurisdiction token rule.
> 
> Minor: shared **`writeJSON`** test helper in `corecmd_test.go`; comment tweak in `entireapi_client.go` for timeout naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b1b2eb7009a6adca50a8be5a55845577259f61. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
