### PR TITLE
fix: route `repo create` to the target cluster's core

### DIFF
--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -364,7 +364,25 @@ func writeTableRow(b *strings.Builder, cells []string, widths []int, styleFor fu
 // preamble as the other runCore variants: silence usage, build the client,
 // map API errors to problem-detail messages.
 func runCoreMutation(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client) (message string, wire any, err error)) error {
-	return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+	return runCore(cmd, renderCoreMutation(cmd, fn))
+}
+
+// runCoreMutationForCluster is runCoreMutation for a resource-provider command
+// (see runCoreForCluster): identical ✓-line / --json rendering, but dialing the
+// core that fronts clusterHost rather than the active context. `repo create
+// --cluster-host` uses this so a repo requested in another jurisdiction lands on
+// that cluster's own regional core (which resolves the globally-registered
+// project) instead of the active login's core rejecting it as cross-jurisdiction.
+func runCoreMutationForCluster(cmd *cobra.Command, clusterHost string, fn func(ctx context.Context, c *coreapi.Client) (message string, wire any, err error)) error {
+	return runCoreForCluster(cmd, clusterHost, renderCoreMutation(cmd, fn))
+}
+
+// renderCoreMutation builds the run-function shared by runCoreMutation and
+// runCoreMutationForCluster: run fn, then print the ✓-prefixed human line
+// (default) or the wire object (--json). Kept separate from the client-selection
+// so the two mutation variants differ only in which core they dial.
+func renderCoreMutation(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client) (message string, wire any, err error)) func(context.Context, *coreapi.Client) error {
+	return func(ctx context.Context, c *coreapi.Client) error {
 		message, wire, err := fn(ctx, c)
 		if err != nil {
 			return err
@@ -374,7 +392,7 @@ func runCoreMutation(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), message)
 		return nil
-	})
+	}
 }
 
 // activeCoreClient builds the control-plane client for active-context
@@ -382,6 +400,12 @@ func runCoreMutation(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi
 // command-level tests can point the whole command tree at an httptest server
 // without standing up the auth/context/TLS stack.
 var activeCoreClient = func(context.Context) (*coreapi.Client, error) { return coreapi.New() }
+
+// clusterCoreClient builds the control-plane client for cluster-addressed
+// commands (production wiring is coreapi.NewForCluster). A package-level seam
+// mirroring activeCoreClient so command-level tests can point the cluster path
+// at an httptest server without standing up cluster discovery.
+var clusterCoreClient = coreapi.NewForCluster
 
 // runCore is the shared base for every active-context control-plane command:
 // it owns the preamble only — silence usage, build the client, map API
@@ -403,7 +427,7 @@ func runCore(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client)
 // cluster_host". See coreapi.NewForCluster.
 func runCoreForCluster(cmd *cobra.Command, clusterHost string, fn func(ctx context.Context, c *coreapi.Client) error) error {
 	return runCoreClient(cmd, func(ctx context.Context) (*coreapi.Client, error) {
-		return coreapi.NewForCluster(ctx, clusterHost)
+		return clusterCoreClient(ctx, clusterHost)
 	}, fn)
 }
 

--- a/cmd/entire/cli/corecmd_delete_test.go
+++ b/cmd/entire/cli/corecmd_delete_test.go
@@ -32,12 +32,15 @@ func writeNotFoundProblem(t *testing.T, w http.ResponseWriter) {
 	}
 }
 
-// runCoreCmd runs any active-context control-plane command against a seamed
-// httptest core: it points the active-context client at srv via the
-// activeCoreClient seam, runs newCmd() with args, and returns its stdout,
-// stderr, and error. Commands dialing via runCoreForCluster (mirror
-// create/remove/collaborators) bypass the seam and need their own httptest
-// wiring. The caller must not be parallel: the seam is package-global.
+// runCoreCmd runs a control-plane command against a seamed httptest core: it
+// points both the active-context (activeCoreClient) and cluster-addressed
+// (clusterCoreClient) client seams at srv, runs newCmd() with args, and returns
+// its stdout, stderr, and error. Seaming both lets it drive active-context
+// commands (org/project create, delete) and cluster-addressed ones (repo
+// create, which always dials the cluster's core) through the same helper.
+// Commands dialing via runCoreForCluster directly (mirror create/remove/
+// collaborators) still need their own httptest wiring. The caller must not be
+// parallel: the seams are package-global.
 //
 // Note: cobra's cmd.Print* falls back to OutOrStderr(), which under SetOut
 // resolves to the stdout buffer — so Empty(errOut) assertions in these tests
@@ -45,11 +48,18 @@ func writeNotFoundProblem(t *testing.T, w http.ResponseWriter) {
 // are what pin the production stream.
 func runCoreCmd(t *testing.T, newCmd func() *cobra.Command, srvURL string, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
-	prev := activeCoreClient
+	prevActive := activeCoreClient
+	prevCluster := clusterCoreClient
 	activeCoreClient = func(context.Context) (*coreapi.Client, error) {
 		return coreapi.NewWithBearer(srvURL, "tok")
 	}
-	t.Cleanup(func() { activeCoreClient = prev })
+	clusterCoreClient = func(context.Context, string) (*coreapi.Client, error) {
+		return coreapi.NewWithBearer(srvURL, "tok")
+	}
+	t.Cleanup(func() {
+		activeCoreClient = prevActive
+		clusterCoreClient = prevCluster
+	})
 
 	cmd := newCmd()
 	var out, errW bytes.Buffer

--- a/cmd/entire/cli/corecmd_delete_test.go
+++ b/cmd/entire/cli/corecmd_delete_test.go
@@ -37,10 +37,10 @@ func writeNotFoundProblem(t *testing.T, w http.ResponseWriter) {
 // (clusterCoreClient) client seams at srv, runs newCmd() with args, and returns
 // its stdout, stderr, and error. Seaming both lets it drive active-context
 // commands (org/project create, delete) and cluster-addressed ones (repo
-// create, which always dials the cluster's core) through the same helper.
-// Commands dialing via runCoreForCluster directly (mirror create/remove/
-// collaborators) still need their own httptest wiring. The caller must not be
-// parallel: the seams are package-global.
+// create, which always dials the cluster's core) through the same helper —
+// runCoreForCluster now routes through the clusterCoreClient seam, so
+// cluster-addressed commands no longer need their own httptest wiring. The
+// caller must not be parallel: the seams are package-global.
 //
 // Note: cobra's cmd.Print* falls back to OutOrStderr(), which under SetOut
 // resolves to the stdout buffer — so Empty(errOut) assertions in these tests

--- a/cmd/entire/cli/corecmd_mutation_test.go
+++ b/cmd/entire/cli/corecmd_mutation_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -96,4 +98,82 @@ func TestRepoCreate_JSONOnRequest(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, out, `"remote": "entire://c.example.com/gh/o/web"`)
 	require.NotContains(t, out, "✓ Created")
+}
+
+// TestRepoCreate_ClusterHostRouting pins the routing fix: `repo create
+// --cluster-host X` must dial that cluster's own core (coreapi.NewForCluster),
+// not the active-context core, so a repo requested in another jurisdiction lands
+// on the correct regional deployment instead of being rejected as
+// cross-jurisdiction. Without --cluster-host it must keep dialing the active core.
+//
+// Not parallel: swaps the package-level activeCoreClient and clusterCoreClient seams.
+func TestRepoCreate_ClusterHostRouting(t *testing.T) {
+	newRepoServer := func(hit *bool) *httptest.Server {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			*hit = true
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/api/v1/repos", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			if err := printJSON(w, &coreapi.Repo{
+				ID:              testDeleteULID,
+				Name:            "web",
+				OwningProjectId: testRepoCreateProjectULID,
+				ClusterHost:     coreapi.NewOptString("c.example.com"),
+				Path:            coreapi.NewOptString("/gh/o/web"),
+			}); err != nil {
+				t.Errorf("encode repo: %v", err)
+			}
+		}))
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	// run points both seams at distinct fake cores, runs `repo create` with the
+	// extra args, and reports which core received the POST plus the cluster host
+	// the cluster seam was asked for.
+	run := func(t *testing.T, extra ...string) (activeHit, clusterHit bool, gotClusterHost, out string) {
+		t.Helper()
+		var aHit, cHit bool
+		var host string
+		activeSrv := newRepoServer(&aHit)
+		clusterSrv := newRepoServer(&cHit)
+
+		prevActive := activeCoreClient
+		prevCluster := clusterCoreClient
+		activeCoreClient = func(context.Context) (*coreapi.Client, error) {
+			return coreapi.NewWithBearer(activeSrv.URL, "tok")
+		}
+		clusterCoreClient = func(_ context.Context, clusterHost string) (*coreapi.Client, error) {
+			host = clusterHost
+			return coreapi.NewWithBearer(clusterSrv.URL, "tok")
+		}
+		t.Cleanup(func() {
+			activeCoreClient = prevActive
+			clusterCoreClient = prevCluster
+		})
+
+		cmd := newRepoCmd()
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs(append([]string{"create", "web", "--project", testRepoCreateProjectULID}, extra...))
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		return aHit, cHit, host, buf.String()
+	}
+
+	t.Run("--cluster-host dials the cluster core, not the active core", func(t *testing.T) {
+		activeHit, clusterHit, gotHost, out := run(t, "--cluster-host", "aws-ap-southeast-2.entire.io")
+		require.True(t, clusterHit, "the cluster core should receive the create")
+		require.False(t, activeHit, "the active core must not be dialed")
+		require.Equal(t, "aws-ap-southeast-2.entire.io", gotHost)
+		require.Contains(t, out, "✓ Created repository web")
+	})
+
+	t.Run("no --cluster-host dials the active core", func(t *testing.T) {
+		activeHit, clusterHit, _, out := run(t)
+		require.True(t, activeHit, "the active core should receive the create")
+		require.False(t, clusterHit, "the cluster core must not be dialed")
+		require.Contains(t, out, "✓ Created repository web")
+	})
 }

--- a/cmd/entire/cli/corecmd_mutation_test.go
+++ b/cmd/entire/cli/corecmd_mutation_test.go
@@ -100,11 +100,12 @@ func TestRepoCreate_JSONOnRequest(t *testing.T) {
 	require.NotContains(t, out, "✓ Created")
 }
 
-// TestRepoCreate_ClusterHostRouting pins the routing fix: `repo create
-// --cluster-host X` must dial that cluster's own core (coreapi.NewForCluster),
-// not the active-context core, so a repo requested in another jurisdiction lands
-// on the correct regional deployment instead of being rejected as
-// cross-jurisdiction. Without --cluster-host it must keep dialing the active core.
+// TestRepoCreate_ClusterHostRouting pins the routing fix: `repo create` must
+// always dial the target cluster's own core (coreapi.NewForCluster), never the
+// active-context core, so a repo lands on the correct regional deployment even
+// when the target cluster is in a different jurisdiction than the active login.
+// --cluster-host X targets cluster X; omitting it falls back to
+// defaultClusterHost. The active core seam must never be used for the create.
 //
 // Not parallel: swaps the package-level activeCoreClient and clusterCoreClient seams.
 func TestRepoCreate_ClusterHostRouting(t *testing.T) {
@@ -162,7 +163,7 @@ func TestRepoCreate_ClusterHostRouting(t *testing.T) {
 		return aHit, cHit, host, buf.String()
 	}
 
-	t.Run("--cluster-host dials the cluster core, not the active core", func(t *testing.T) {
+	t.Run("--cluster-host dials that cluster's core, not the active core", func(t *testing.T) {
 		activeHit, clusterHit, gotHost, out := run(t, "--cluster-host", "aws-ap-southeast-2.entire.io")
 		require.True(t, clusterHit, "the cluster core should receive the create")
 		require.False(t, activeHit, "the active core must not be dialed")
@@ -170,10 +171,11 @@ func TestRepoCreate_ClusterHostRouting(t *testing.T) {
 		require.Contains(t, out, "✓ Created repository web")
 	})
 
-	t.Run("no --cluster-host dials the active core", func(t *testing.T) {
-		activeHit, clusterHit, _, out := run(t)
-		require.True(t, activeHit, "the active core should receive the create")
-		require.False(t, clusterHit, "the cluster core must not be dialed")
+	t.Run("no --cluster-host falls back to the default cluster's core, not the active core", func(t *testing.T) {
+		activeHit, clusterHit, gotHost, out := run(t)
+		require.True(t, clusterHit, "the default cluster's core should receive the create")
+		require.False(t, activeHit, "the active core must not be dialed")
+		require.Equal(t, defaultClusterHost, gotHost)
 		require.Contains(t, out, "✓ Created repository web")
 	})
 }

--- a/cmd/entire/cli/corecmd_mutation_test.go
+++ b/cmd/entire/cli/corecmd_mutation_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -109,9 +110,8 @@ func TestRepoCreate_JSONOnRequest(t *testing.T) {
 //
 // Not parallel: swaps the package-level activeCoreClient and clusterCoreClient seams.
 func TestRepoCreate_ClusterHostRouting(t *testing.T) {
-	newRepoServer := func(hit *bool) *httptest.Server {
+	newRepoServer := func() *httptest.Server {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			*hit = true
 			assert.Equal(t, http.MethodPost, r.Method)
 			assert.Equal(t, "/api/v1/repos", r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
@@ -130,20 +130,23 @@ func TestRepoCreate_ClusterHostRouting(t *testing.T) {
 		return srv
 	}
 
-	// run points both seams at distinct fake cores, runs `repo create` with the
-	// extra args, and reports which core received the POST plus the cluster host
-	// the cluster seam was asked for.
-	run := func(t *testing.T, extra ...string) (activeHit, clusterHit bool, gotClusterHost, out string) {
+	// run wires the cluster seam at a fake core and makes the active-core seam
+	// fail loudly if it's ever dialed, then runs `repo create` and returns the
+	// cluster host the cluster seam was asked for plus stdout. The host is
+	// captured in the seam closure, which runs on this (test) goroutine during
+	// the synchronous ExecuteContext — no state is written by the httptest
+	// handler goroutine and read here, so there's nothing to race. A successful
+	// "✓ Created" round-trip is itself proof the cluster core served the create.
+	run := func(t *testing.T, extra ...string) (gotClusterHost, out string) {
 		t.Helper()
-		var aHit, cHit bool
 		var host string
-		activeSrv := newRepoServer(&aHit)
-		clusterSrv := newRepoServer(&cHit)
+		clusterSrv := newRepoServer()
 
 		prevActive := activeCoreClient
 		prevCluster := clusterCoreClient
 		activeCoreClient = func(context.Context) (*coreapi.Client, error) {
-			return coreapi.NewWithBearer(activeSrv.URL, "tok")
+			t.Error("active core must not be dialed for repo create")
+			return nil, errors.New("active core dialed")
 		}
 		clusterCoreClient = func(_ context.Context, clusterHost string) (*coreapi.Client, error) {
 			host = clusterHost
@@ -160,21 +163,17 @@ func TestRepoCreate_ClusterHostRouting(t *testing.T) {
 		cmd.SetErr(&buf)
 		cmd.SetArgs(append([]string{"create", "web", "--project", testRepoCreateProjectULID}, extra...))
 		require.NoError(t, cmd.ExecuteContext(t.Context()))
-		return aHit, cHit, host, buf.String()
+		return host, buf.String()
 	}
 
 	t.Run("--cluster-host dials that cluster's core, not the active core", func(t *testing.T) {
-		activeHit, clusterHit, gotHost, out := run(t, "--cluster-host", "aws-ap-southeast-2.entire.io")
-		require.True(t, clusterHit, "the cluster core should receive the create")
-		require.False(t, activeHit, "the active core must not be dialed")
+		gotHost, out := run(t, "--cluster-host", "aws-ap-southeast-2.entire.io")
 		require.Equal(t, "aws-ap-southeast-2.entire.io", gotHost)
 		require.Contains(t, out, "✓ Created repository web")
 	})
 
 	t.Run("no --cluster-host falls back to the default cluster's core, not the active core", func(t *testing.T) {
-		activeHit, clusterHit, gotHost, out := run(t)
-		require.True(t, clusterHit, "the default cluster's core should receive the create")
-		require.False(t, activeHit, "the active core must not be dialed")
+		gotHost, out := run(t)
 		require.Equal(t, defaultClusterHost, gotHost)
 		require.Contains(t, out, "✓ Created repository web")
 	})

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -162,13 +162,13 @@ func newRepoCreateCmd() *cobra.Command {
 			}
 			if err := validateClusterHost(host); err != nil {
 				cmd.SilenceUsage = true
-				return err
+				return fmt.Errorf("invalid --cluster-host: %w", err)
 			}
 			return runCoreMutationForCluster(cmd, host, mutate)
 		},
 	}
 	cmd.Flags().StringVar(&projectID, "project", "", "Owning project (name or ULID) (required)")
-	cmd.Flags().StringVar(&clusterHost, "cluster-host", "", "Public host of the cluster to pin the repo to (defaults to the jurisdiction default)")
+	cmd.Flags().StringVar(&clusterHost, "cluster-host", "", "Public host of the cluster to pin the repo to (defaults to "+defaultClusterHost+")")
 	markRequired(cmd, "project")
 	return cmd
 }

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -148,16 +148,23 @@ func newRepoCreateCmd() *cobra.Command {
 				}
 				return msg, wire, nil
 			}
-			// With --cluster-host, dial that cluster's own regional core so the
-			// create lands there (the cluster's core resolves the globally
-			// registered project). Without it, use the active context's core,
-			// which applies the jurisdiction default. Dialing the active core with
-			// a cross-jurisdiction --cluster-host is what the home core rejects
-			// with "cluster host ... is in jurisdiction ... not ...".
-			if clusterHost != "" {
-				return runCoreMutationForCluster(cmd, clusterHost, mutate)
+			// Always dial the target cluster's own regional core (never the
+			// active-context core): the cluster's core resolves the globally
+			// registered project and provisions the repo locally, so this works
+			// even when the target cluster lives in a different jurisdiction than
+			// the active login. Dialing the active core would reject a foreign
+			// cluster with "cluster host ... is in jurisdiction ... not ...".
+			// --cluster-host picks the cluster; when omitted we fall back to the
+			// same defaultClusterHost the positional-arg mirror commands use.
+			host := clusterHost
+			if host == "" {
+				host = defaultClusterHost
 			}
-			return runCoreMutation(cmd, mutate)
+			if err := validateClusterHost(host); err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
+			return runCoreMutationForCluster(cmd, host, mutate)
 		},
 	}
 	cmd.Flags().StringVar(&projectID, "project", "", "Owning project (name or ULID) (required)")

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -122,7 +122,7 @@ func newRepoCreateCmd() *cobra.Command {
 		Short: "Create a repository in a project",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoreMutation(cmd, func(ctx context.Context, c *coreapi.Client) (string, any, error) {
+			mutate := func(ctx context.Context, c *coreapi.Client) (string, any, error) {
 				projID, err := resolveProjectRef(ctx, c, projectID)
 				if err != nil {
 					return "", nil, err
@@ -147,7 +147,17 @@ func newRepoCreateCmd() *cobra.Command {
 					msg += "\n  Remote: " + remote
 				}
 				return msg, wire, nil
-			})
+			}
+			// With --cluster-host, dial that cluster's own regional core so the
+			// create lands there (the cluster's core resolves the globally
+			// registered project). Without it, use the active context's core,
+			// which applies the jurisdiction default. Dialing the active core with
+			// a cross-jurisdiction --cluster-host is what the home core rejects
+			// with "cluster host ... is in jurisdiction ... not ...".
+			if clusterHost != "" {
+				return runCoreMutationForCluster(cmd, clusterHost, mutate)
+			}
+			return runCoreMutation(cmd, mutate)
 		},
 	}
 	cmd.Flags().StringVar(&projectID, "project", "", "Owning project (name or ULID) (required)")


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/763
<!-- entire-trail-link-end -->

`entire repo create --cluster-host <host>` now routes to the correct regional core, so creating a repo in another jurisdiction (e.g. `aws-ap-southeast-2.entire.io` from an EU login) works instead of failing with `cluster host ... is in jurisdiction ... not ...`.

When `--cluster-host` is omitted it resolves to the default cluster (`aws-us-east-2.entire.io`) and dials that cluster's core, matching `repo mirror`. The create no longer depends on the active login's home core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which control-plane endpoint provisions new repos (always cluster-scoped), affecting federation/jurisdiction behavior; risk is mitigated by focused routing logic and new routing tests.
> 
> **Overview**
> **`entire repo create` no longer talks to the active login's core.** It always dials the regional core for the target cluster (`runCoreMutationForCluster` / `clusterCoreClient`), so creates with `--cluster-host` in another jurisdiction succeed instead of failing on cross-jurisdiction rejection.
> 
> When `--cluster-host` is omitted, the command uses the same **`defaultClusterHost`** as mirror commands, validates the host, then posts the create to that cluster's core—not the active context.
> 
> Supporting changes: mutation rendering is factored into **`renderCoreMutation`**; **`clusterCoreClient`** is a test seam like **`activeCoreClient`**; **`runCoreCmd`** stubs both seams; **`TestRepoCreate_ClusterHostRouting`** asserts the active core is never hit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db545e0acd571e65a242ea5b7b54b3418474b447. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->