### PR TITLE
feat(mirror): cluster picker for interactive one-shot mirror create

### DIFF
--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -49,9 +49,11 @@ func availableMirrorRow(m coreapi.AvailableMirror) []string {
 
 // defaultClusterHost is the cluster the positional-arg mirror commands target
 // when the caller omits the <cluster-host> argument. The no-arg create wizard
-// instead enumerates real clusters from the catalog (GET /api/v1/clusters, see
-// availableRegions in repo_mirror_create_wizard.go); this stays as the
-// single-region fallback for the explicit `create <github-url>` form.
+// and the interactive one-shot `create <github-url>` instead enumerate real
+// clusters from the catalog (GET /api/v1/clusters, see availableRegions and
+// resolveOneShotClusterHost in repo_mirror_create_wizard.go); this stays as
+// the fixed fallback for non-interactive invocations, so scripts keep a
+// stable, offline-resolvable default.
 const defaultClusterHost = "aws-us-east-2.entire.io"
 
 // clusterArg returns the cluster host from the optional second positional
@@ -144,9 +146,9 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 			"the target cluster, then waits for the initial GitHub→EntireDB clone " +
 			"to finish so `git clone` works on return. Pass --no-wait to return " +
 			"as soon as the placement is registered. Idempotent on " +
-			"(upstream, cluster). The cluster-host defaults to " +
-			defaultClusterHost + " when omitted (the interactive wizard, with " +
-			"no args, instead lets you pick clusters).",
+			"(upstream, cluster). When the cluster-host is omitted, an " +
+			"interactive terminal offers the available clusters as a picker; " +
+			"non-interactive runs default to " + defaultClusterHost + ".",
 		Example: "  entire repo mirror create\n" +
 			"  entire repo mirror create github.com/octocat/hello-world\n" +
 			"  entire repo mirror create github.com/octocat/hello-world aws-us-east-2.entire.io",
@@ -160,11 +162,19 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("invalid <github-url>: %w", err)
 			}
-			// The non-interactive one-shot keeps a fixed default cluster
-			// (defaultClusterHost) when [cluster-host] is omitted — catalog-based
-			// cluster guessing is intentionally limited to the interactive
-			// wizard (the no-args path above), so scripts get stable behavior.
-			clusterHost := clusterArg(args)
+			// [cluster-host] omitted: on an interactive terminal, offer the
+			// catalog's clusters as a picker (the same prompt-only-when-there-
+			// is-a-choice shape as `repo clone`); non-interactive invocations
+			// keep the fixed defaultClusterHost so scripts get stable behavior.
+			var clusterHost string
+			if len(args) > 1 {
+				clusterHost = args[1]
+			} else {
+				var rerr error
+				if clusterHost, rerr = resolveOneShotClusterHost(cmd); rerr != nil {
+					return rerr
+				}
+			}
 			if err := validateClusterHost(clusterHost); err != nil {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("invalid [cluster-host]: %w", err)

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -195,6 +195,77 @@ func regionLabel(r regionChoice) string {
 	}
 }
 
+// resolveOneShotClusterHost picks the cluster `repo mirror create
+// <github-url>` targets when [cluster-host] is omitted. Non-interactive
+// callers keep the fixed defaultClusterHost so scripts stay stable and
+// offline-resolvable; on a terminal the control plane's cluster catalog is
+// offered as a single-select (skipped when only one cluster exists),
+// pre-selecting the caller's jurisdiction default — the same
+// prompt-only-when-there-is-a-choice shape `repo clone` uses for
+// multi-cluster placements.
+func resolveOneShotClusterHost(cmd *cobra.Command) (string, error) {
+	if !interactive.CanPromptInteractively() {
+		return defaultClusterHost, nil
+	}
+	errW := cmd.ErrOrStderr()
+	var (
+		regions      []regionChoice
+		jurisdiction string
+	)
+	if err := runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+		stop := startSpinner(errW, "Fetching clusters")
+		var err error
+		if regions, err = availableRegions(ctx, c); err != nil {
+			stop(false)
+			return err
+		}
+		// The jurisdiction only pre-selects the picker's default; a /me
+		// hiccup shouldn't sink the create, so fall back to no pre-selection.
+		if me, merr := c.GetMe(ctx); merr == nil {
+			jurisdiction, _ = me.Jurisdiction.Get()
+		}
+		stop(true)
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	if len(regions) == 0 {
+		return "", errors.New("no clusters available to mirror into; pass [cluster-host] explicitly")
+	}
+	if len(regions) == 1 {
+		fmt.Fprintf(errW, "Using cluster %s\n", regions[0].host)
+		return regions[0].host, nil
+	}
+	return pickOneCluster(cmd.Context(), errW, regions, jurisdiction)
+}
+
+// pickOneCluster runs the one-shot create's cluster single-select,
+// pre-selecting the default cluster for the caller's jurisdiction. A clean
+// cancel (Ctrl+C / cancelled ctx) surfaces as a SilentError so the create
+// stops instead of falling through to a cluster the user didn't choose.
+func pickOneCluster(ctx context.Context, w io.Writer, regions []regionChoice, jurisdiction string) (string, error) {
+	opts, defaults := clusterChoices(regions, jurisdiction)
+	var selected string
+	if len(defaults) > 0 {
+		selected = defaults[0]
+	}
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Select the cluster to mirror into").
+				Options(opts...).
+				Value(&selected),
+		),
+	)
+	if err := form.RunWithContext(ctx); err != nil {
+		if cerr := handleFormCancellation(w, "Mirror create", err); cerr != nil {
+			return "", cerr
+		}
+		return "", NewSilentError(errors.New("mirror create cancelled"))
+	}
+	return selected, nil
+}
+
 // mirrorTarget is one unit of work: a selected repo to be mirrored into a
 // selected region. The wizard creates the cross-product of repos × regions.
 type mirrorTarget struct {

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -263,7 +263,15 @@ func pickOneCluster(ctx context.Context, w io.Writer, regions []regionChoice, ju
 		}
 		return "", NewSilentError(errors.New("mirror create cancelled"))
 	}
-	return selected, nil
+	// Guard the selection against the offered hosts (like repo clone's
+	// picker) so a zero-value fall-through can't reach the caller as a
+	// misleading "invalid [cluster-host]" error.
+	for _, r := range regions {
+		if r.host == selected {
+			return selected, nil
+		}
+	}
+	return "", NewSilentError(errors.New("mirror create cancelled"))
 }
 
 // mirrorTarget is one unit of work: a selected repo to be mirrored into a

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -744,6 +745,24 @@ func TestClusterArg(t *testing.T) {
 	}
 	if got := clusterArg([]string{"github.com/o/r"}); got != defaultClusterHost {
 		t.Errorf("omitted cluster = %q, want default %q", got, defaultClusterHost)
+	}
+}
+
+// TestResolveOneShotClusterHost_NonInteractive locks in that a non-interactive
+// `repo mirror create <github-url>` keeps the fixed defaultClusterHost without
+// dialing the control plane — scripts must get a stable, offline default. Under
+// `go test`, CanPromptInteractively() is false, so this exercises exactly the
+// script path; no server is running, so any catalog fetch would error.
+func TestResolveOneShotClusterHost_NonInteractive(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	got, err := resolveOneShotClusterHost(cmd)
+	if err != nil {
+		t.Fatalf("resolveOneShotClusterHost() error = %v", err)
+	}
+	if got != defaultClusterHost {
+		t.Errorf("resolveOneShotClusterHost() = %q, want default %q", got, defaultClusterHost)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/764
<!-- entire-trail-link-end -->

`entire repo mirror create owner/repo` on a terminal now offers the available clusters as a picker when `[cluster-host]` is omitted — pre-selecting your jurisdiction's default, and skipping the prompt when only one cluster exists (same shape as `entire repo clone`).

Non-interactive runs are unchanged: fixed default `aws-us-east-2.entire.io`, no network lookup, so scripts stay stable.

Restores the interactive half of what #1519 walked back, without reintroducing catalog guessing for scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and cluster selection only; explicit cluster args and non-interactive defaults are preserved, with no auth or mirror API behavior changes.
> 
> **Overview**
> When **`entire repo mirror create <github-url>`** runs without **`[cluster-host]`**, an interactive terminal now loads clusters from the control plane and picks one (single-select, jurisdiction default pre-selected, prompt skipped if only one cluster)—aligned with **`entire repo clone`**.
> 
> **Non-interactive** use is unchanged: **`aws-us-east-2.entire.io`** with no catalog fetch. Explicit **`[cluster-host]`** still wins. **`resolveOneShotClusterHost`** / **`pickOneCluster`** handle fetch, auto-pick, and cancel guards; a test locks the script path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbffb79e54c497d738f9c18cec4cfbc8215a477b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->