### PR TITLE
Switching writes to new ref store

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -8,5 +8,8 @@
     },
     "filtered_fetches": true
   },
-  "strategy": "manual-commit"
+  "strategy": "manual-commit",
+  "checkpoints": {
+    "primary": { "type": "git-refs" }
+  }
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/767
<!-- entire-trail-link-end -->

Let's enable the new ref backend. All new writes will go there, all reads go to where the checkpoint is (easy check by different checkpoint format)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where and how new checkpoints are persisted for anyone using this settings file; existing hex/git-branch checkpoints should still read via ID routing, but mixed backends increase operational surface during the migration.
> 
> **Overview**
> **Turns on the git-refs primary checkpoint backend** for this repo’s checked-in Entire local settings by adding `checkpoints.primary.type: "git-refs"`. With that primary, **new checkpoint writes** go to the per-checkpoint git-ref store (ULID IDs) instead of the default `git-branch` / v1 layout; **reads** continue to resolve the correct backend from each checkpoint’s ID shape.
> 
> Also fixes JSON formatting (trailing comma after `strategy`) in the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74b8eea3f4ab698eb3d4c8051a6e58c736075907. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->