### PR TITLE
git-remote-entire: actionable hint when the cluster host is missing

### DIFF
--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -216,33 +216,32 @@ func fatalMessage(err error, parsedURL *url.URL) string {
 // missingClusterHostMessage renders the stderr "fatal: …" line for an entire://
 // URL that omits its cluster host. Two shapes reach here: a forge id typed
 // where the host belongs (entire://gh/owner/repo, Host="gh") and an empty host
-// (entire:///gh/owner/repo, Host=""). When the intended repo shorthand is
-// recoverable — the host slot, or the path's leading segment, is a known forge
-// id — it points at the interactive picker (`entire repo clone <shorthand>`),
-// which resolves the mirror and clones a fully-qualified URL. Anything else
-// (bare entire://, a non-forge leading segment) falls back to the plain
-// missing-host error. Kept pure so it's unit-testable.
+// (entire:///gh/owner/repo, Host=""). When the reconstructed shorthand is a
+// complete forge/owner/repo triple that `entire repo clone` can resolve, it
+// points at the interactive picker; a partial path (entire://gh,
+// entire://gh/owner) or a non-forge segment falls back to the plain
+// missing-host error rather than suggesting a clone command that would reject
+// the ref. Kept pure so it's unit-testable.
 func missingClusterHostMessage(parsedURL *url.URL, rawURL string) string {
-	// Forge id in the host slot: the shorthand is /<host><path>.
-	if gitremote.IsSupportedForge(parsedURL.Host) {
-		return clusterHostHint(parsedURL.Host, "/"+parsedURL.Host+parsedURL.Path)
+	// Reconstruct the forge/owner/repo shorthand the user likely intended: a
+	// forge id in the host slot sits in front of the path; an empty host
+	// already has it there.
+	shorthand := strings.TrimPrefix(parsedURL.Path, "/")
+	if parsedURL.Host != "" {
+		shorthand = parsedURL.Host + "/" + shorthand
 	}
-	// Empty host with a forge-led path: the path is already the shorthand.
-	if forge, _, ok := strings.Cut(strings.TrimPrefix(parsedURL.Path, "/"), "/"); ok && gitremote.IsSupportedForge(forge) {
-		return clusterHostHint(forge, parsedURL.Path)
+	// Only point at `entire repo clone` for a complete forge/owner/repo triple
+	// (the shape parseMirrorCloneRef accepts); anything shorter would relocate
+	// the failure into a clone command that rejects the ref.
+	seg := strings.Split(strings.Trim(shorthand, "/"), "/")
+	if len(seg) != 3 || seg[0] == "" || seg[1] == "" || seg[2] == "" || !gitremote.IsSupportedForge(seg[0]) {
+		return fmt.Sprintf("fatal: missing host in URL %q\n", rawURL)
 	}
-	return fmt.Sprintf("fatal: missing host in URL %q\n", rawURL)
-}
-
-// clusterHostHint is the actionable message pointing a host-less entire:// URL
-// at the `entire repo clone` picker, which resolves the mirror for the given
-// forge shorthand.
-func clusterHostHint(forge, shorthand string) string {
 	return fmt.Sprintf(
 		"fatal: entire:// URL is missing its cluster host (%q is a forge id, not a host).\n"+
 			"The full form is entire://<cluster-host>/%s/<owner>/<repo>.\n"+
-			"To pick a mirror interactively, run:\n\n    entire repo clone %s\n",
-		forge, forge, shorthand)
+			"To pick a mirror interactively, run:\n\n    entire repo clone /%s\n",
+		seg[0], seg[0], strings.Join(seg, "/"))
 }
 
 // loadedVersion populates the build info and returns the resolved version.

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/httpclient"
@@ -89,8 +90,10 @@ func run(args []string) int {
 	case parsedURL.Scheme != "entire":
 		fmt.Fprintf(os.Stderr, "fatal: unsupported URL scheme %q (expected 'entire')\n", parsedURL.Scheme)
 		return 128
-	case parsedURL.Host == "":
-		fmt.Fprintf(os.Stderr, "fatal: missing host in URL %q\n", rawURL)
+	case parsedURL.Host == "" || gitremote.IsSupportedForge(parsedURL.Host):
+		// Cluster host absent (empty, or a forge id in its slot);
+		// missingClusterHostMessage renders the actionable hint.
+		fmt.Fprint(os.Stderr, missingClusterHostMessage(parsedURL, rawURL))
 		return 128
 	}
 
@@ -208,6 +211,38 @@ func fatalMessage(err error, parsedURL *url.URL) string {
 		}
 	}
 	return fmt.Sprintf("fatal: %v\n", err)
+}
+
+// missingClusterHostMessage renders the stderr "fatal: …" line for an entire://
+// URL that omits its cluster host. Two shapes reach here: a forge id typed
+// where the host belongs (entire://gh/owner/repo, Host="gh") and an empty host
+// (entire:///gh/owner/repo, Host=""). When the intended repo shorthand is
+// recoverable — the host slot, or the path's leading segment, is a known forge
+// id — it points at the interactive picker (`entire repo clone <shorthand>`),
+// which resolves the mirror and clones a fully-qualified URL. Anything else
+// (bare entire://, a non-forge leading segment) falls back to the plain
+// missing-host error. Kept pure so it's unit-testable.
+func missingClusterHostMessage(parsedURL *url.URL, rawURL string) string {
+	// Forge id in the host slot: the shorthand is /<host><path>.
+	if gitremote.IsSupportedForge(parsedURL.Host) {
+		return clusterHostHint(parsedURL.Host, "/"+parsedURL.Host+parsedURL.Path)
+	}
+	// Empty host with a forge-led path: the path is already the shorthand.
+	if forge, _, ok := strings.Cut(strings.TrimPrefix(parsedURL.Path, "/"), "/"); ok && gitremote.IsSupportedForge(forge) {
+		return clusterHostHint(forge, parsedURL.Path)
+	}
+	return fmt.Sprintf("fatal: missing host in URL %q\n", rawURL)
+}
+
+// clusterHostHint is the actionable message pointing a host-less entire:// URL
+// at the `entire repo clone` picker, which resolves the mirror for the given
+// forge shorthand.
+func clusterHostHint(forge, shorthand string) string {
+	return fmt.Sprintf(
+		"fatal: entire:// URL is missing its cluster host (%q is a forge id, not a host).\n"+
+			"The full form is entire://<cluster-host>/%s/<owner>/<repo>.\n"+
+			"To pick a mirror interactively, run:\n\n    entire repo clone %s\n",
+		forge, forge, shorthand)
 }
 
 // loadedVersion populates the build info and returns the resolved version.

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -173,6 +173,69 @@ func TestFatalMessage(t *testing.T) {
 	}
 }
 
+func TestMissingClusterHostMessage(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		rawURL      string
+		contains    []string
+		notContains []string
+	}{
+		{
+			// The motivating case: forge id typed where the cluster host belongs.
+			name:     "forge id in host slot points at repo clone",
+			rawURL:   "entire://gh/entire.io/cli",
+			contains: []string{"missing its cluster host", `"gh" is a forge id`, "entire repo clone /gh/entire.io/cli"},
+		},
+		{
+			// Empty host but the path already reads as a forge shorthand.
+			name:     "empty host with forge path points at repo clone",
+			rawURL:   "entire:///gh/entire.io/cli",
+			contains: []string{"missing its cluster host", "entire repo clone /gh/entire.io/cli"},
+		},
+		{
+			// Empty host, leading segment is not a known forge → generic error.
+			name:        "empty host with non-forge path falls back",
+			rawURL:      "entire:///not-a-forge/owner/repo",
+			contains:    []string{`fatal: missing host in URL "entire:///not-a-forge/owner/repo"`},
+			notContains: []string{"entire repo clone"},
+		},
+		{
+			name:        "bare scheme falls back",
+			rawURL:      "entire://",
+			contains:    []string{`fatal: missing host in URL "entire://"`},
+			notContains: []string{"entire repo clone"},
+		},
+		{
+			// Not enough path to form owner/repo → not worth pointing at clone.
+			name:        "empty host single-segment path falls back",
+			rawURL:      "entire:///gh",
+			contains:    []string{`fatal: missing host in URL "entire:///gh"`},
+			notContains: []string{"entire repo clone"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			parsed, err := url.Parse(tc.rawURL)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.rawURL, err)
+			}
+			got := missingClusterHostMessage(parsed, tc.rawURL)
+			for _, sub := range tc.contains {
+				if !strings.Contains(got, sub) {
+					t.Errorf("missingClusterHostMessage(%q) = %q, missing %q", tc.rawURL, got, sub)
+				}
+			}
+			for _, sub := range tc.notContains {
+				if strings.Contains(got, sub) {
+					t.Errorf("missingClusterHostMessage(%q) = %q, should not contain %q", tc.rawURL, got, sub)
+				}
+			}
+		})
+	}
+}
+
 func TestCoreTrusted(t *testing.T) {
 	t.Parallel()
 	trusted := []string{"https://core.us.entire.io", "https://core.eu.entire.io/"}

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -213,6 +213,35 @@ func TestMissingClusterHostMessage(t *testing.T) {
 			contains:    []string{`fatal: missing host in URL "entire:///gh"`},
 			notContains: []string{"entire repo clone"},
 		},
+		{
+			// Forge in host slot but no owner/repo — the shorthand `/gh` would be
+			// rejected by `entire repo clone`, so fall back rather than suggest it.
+			name:        "forge in host slot without path falls back",
+			rawURL:      "entire://gh",
+			contains:    []string{`fatal: missing host in URL "entire://gh"`},
+			notContains: []string{"entire repo clone"},
+		},
+		{
+			// Forge in host slot with owner but no repo — incomplete triple.
+			name:        "forge in host slot with owner only falls back",
+			rawURL:      "entire://gh/owner",
+			contains:    []string{`fatal: missing host in URL "entire://gh/owner"`},
+			notContains: []string{"entire repo clone"},
+		},
+		{
+			// Empty host, forge + owner but no repo — incomplete triple.
+			name:        "empty host forge and owner only falls back",
+			rawURL:      "entire:///gh/owner",
+			contains:    []string{`fatal: missing host in URL "entire:///gh/owner"`},
+			notContains: []string{"entire repo clone"},
+		},
+		{
+			// Too many segments — not the gh/<owner>/<repo> shape either.
+			name:        "forge in host slot with extra path segment falls back",
+			rawURL:      "entire://gh/owner/repo/extra",
+			contains:    []string{`fatal: missing host in URL "entire://gh/owner/repo/extra"`},
+			notContains: []string{"entire repo clone"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/768
<!-- entire-trail-link-end -->

## Problem

`git clone entire://gh/entire.io/cli` parses `gh` into the **host** slot (`net/url` gives `Host="gh"`, `Path="/entire.io/cli"`), so the git remote helper sailed past URL validation and later died at cluster discovery with an opaque `https://gh/.well-known/entire-cluster.json` error. The empty-host form (`entire:///gh/...`) hit only a bare `fatal: missing host in URL` message.

In both cases the user simply omitted the cluster host — and the CLI already has an interactive mirror picker for exactly this (`entire repo clone /gh/entire.io/cli`), but nothing pointed them at it.

## Change

Extend the URL-validation switch in `cmd/git-remote-entire/main.go`: when the host is empty **or** is a known forge id (`gitremote.IsSupportedForge`), print an actionable message that names the problem and points at the picker:

```
fatal: entire:// URL is missing its cluster host ("gh" is a forge id, not a host).
The full form is entire://<cluster-host>/gh/<owner>/<repo>.
To pick a mirror interactively, run:

    entire repo clone /gh/entire.io/cli
```

When the shorthand isn't recoverable (bare `entire://`, non-forge leading segment), it falls back to the original `missing host` error.

## Why this layer

`git clone entire://...` invokes the helper directly via git's remote-helper protocol — it never routes through `entire repo clone`, so the helper is the *only* place that sees this input. A picker can't live in the helper itself: stdin/stdout are reserved for git's pkt-line stream, and the helper can't rewrite the stored remote URL, so it would re-prompt on every future fetch. `entire repo clone` resolves the mirror once and clones a fully-qualified URL — the right home for the picker. This reuses the existing actionable-error idiom (`fatalMessage`) and stays a dumb transport: stderr line + exit 128, safe in CI, no hang.

Detection keys off the shared `gitremote.IsSupportedForge` predicate (today only `gh`), so a future forge (e.g. `et`) picks up the hint automatically once it's in the forge map.

## Testing

- New `TestMissingClusterHostMessage` table test: forge-in-host, empty-host-with-forge-path, and three fall-back cases.
- `mise run check` green (fmt + lint + unit + integration + e2e canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to URL validation stderr messaging and exit 128; no auth, transport, or git helper protocol behavior is altered.
> 
> **Overview**
> **`git-remote-entire` now fails fast** when an `entire://` URL has no cluster host, including the case where a **forge id** (e.g. `gh`) lands in the host slot because of URL parsing (`entire://gh/owner/repo`).
> 
> Instead of a generic missing-host line or a later opaque discovery error against `https://gh/...`, stderr explains that the cluster host is missing, shows the full URL shape, and—when a forge shorthand can be recovered—suggests **`entire repo clone <shorthand>`** for the interactive mirror picker. Unrecoverable inputs (bare `entire://`, unknown leading path segment, incomplete path) keep the original missing-host message.
> 
> Detection reuses **`gitremote.IsSupportedForge`**. **`TestMissingClusterHostMessage`** covers forge-in-host, empty-host-with-forge path, and fallback cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 317808c18b86e1ab81034cbcdbe0853c3402097d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->