### PR TITLE
cli: show recent sessions (not commits) in `entire activity`

### DIFF
--- a/cmd/entire/cli/activity_cmd.go
+++ b/cmd/entire/cli/activity_cmd.go
@@ -22,6 +22,9 @@ const (
 	dateUnknown       = "unknown"
 	activityTimeframe = "last-month"
 	activityLimit     = 1000
+	// sessionsOverviewLimit mirrors entire.io's USER_OVERVIEW_RECENT_SESSIONS_LIMIT
+	// so the CLI's recent-session list matches the web Overview page's window.
+	sessionsOverviewLimit = 50
 )
 
 // knownAgents maps normalized agent strings from the API to display IDs.
@@ -44,35 +47,58 @@ var knownAgents = map[string]string{
 }
 
 func newActivityCmd() *cobra.Command {
+	var showCommits bool
 	cmd := &cobra.Command{
 		Use:   "activity",
 		Short: "Show your activity overview",
-		Long:  "Display your activity overview, repository breakdown, and recent commits from entire.io",
+		Long: "Display your activity overview, repository breakdown, and recent sessions from entire.io.\n\n" +
+			"The recent list shows your sessions by default, matching the entire.io Overview page. " +
+			"Pass --commits to show recent commits instead.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runActivity(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return runActivity(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), showCommits)
 		},
 	}
+	cmd.Flags().BoolVar(&showCommits, "commits", false, "Show recent commits instead of recent sessions")
 	return cmd
 }
 
-func runActivity(ctx context.Context, w, errW io.Writer) error {
+func runActivity(ctx context.Context, w, errW io.Writer, showCommits bool) error {
 	return runAuthenticatedActivityAPI(ctx, errW, false, func(ctx context.Context, client *api.Client) error {
 		// Non-interactive fallback: piped output or accessibility mode
 		if !interactive.IsTerminalWriter(w) || IsAccessibleMode() {
-			return runActivityStatic(ctx, w, client)
+			return runActivityStatic(ctx, w, client, showCommits)
 		}
 
-		return runActivityTUI(ctx, client)
+		return runActivityTUI(ctx, client, showCommits)
 	})
 }
 
-func runActivityStatic(ctx context.Context, w io.Writer, client *api.Client) error {
-	activity, commits, err := fetchActivityData(ctx, client)
+func runActivityStatic(ctx context.Context, w io.Writer, client *api.Client, showCommits bool) error {
+	sty := newActivityStyles(w)
+
+	if showCommits {
+		activity, commits, err := fetchActivityWith(ctx, client, fetchCommits)
+		if err != nil {
+			return err
+		}
+		renderActivityHeader(w, sty, statsFromActivity(activity), activity.Repos, activity.HourlyContributions)
+		renderCommitList(w, sty, groupCommitsByDay(commits))
+		return nil
+	}
+
+	activity, sessions, err := fetchActivityWith(ctx, client, fetchSessions)
 	if err != nil {
 		return err
 	}
+	renderActivityHeader(w, sty, statsFromActivity(activity), activity.Repos, activity.HourlyContributions)
+	renderSessionList(w, sty, groupSessionsByDay(sessions))
+	return nil
+}
 
-	stats := contributionStats{
+// statsFromActivity projects the aggregated /me/activity response onto the
+// stat-card view model. Shared by the static and TUI render paths.
+func statsFromActivity(activity *userActivityResponse) contributionStats {
+	return contributionStats{
 		Tasks:         activity.Stats.Tasks,
 		Throughput:    activity.Stats.Throughput,
 		Iteration:     activity.Stats.Iteration,
@@ -80,17 +106,14 @@ func runActivityStatic(ctx context.Context, w io.Writer, client *api.Client) err
 		Streak:        activity.Stats.LifetimeStreak,
 		CurrentStreak: activity.Stats.LifetimeCurrentStreak,
 	}
-	days := groupCommitsByDay(commits)
-
-	sty := newActivityStyles(w)
-	renderActivity(w, sty, stats, activity.Repos, activity.HourlyContributions, days)
-	return nil
 }
 
-// fetchActivityData fetches aggregated activity and commits concurrently.
-func fetchActivityData(ctx context.Context, client *api.Client) (*userActivityResponse, []userCommit, error) {
+// fetchActivityWith fetches the always-needed /me/activity aggregate
+// concurrently with the caller's chosen recent-list fetch (sessions or
+// commits). Either fetch failing fails the whole call.
+func fetchActivityWith[T any](ctx context.Context, client *api.Client, fetchList func(context.Context, *api.Client) (T, error)) (*userActivityResponse, T, error) {
 	var activity *userActivityResponse
-	var commits []userCommit
+	var list T
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -100,13 +123,13 @@ func fetchActivityData(ctx context.Context, client *api.Client) (*userActivityRe
 	})
 	g.Go(func() error {
 		var err error
-		commits, err = fetchCommits(gCtx, client)
+		list, err = fetchList(gCtx, client)
 		return err
 	})
 	if err := g.Wait(); err != nil {
-		return nil, nil, fmt.Errorf("fetch activity: %w", err)
+		return nil, list, fmt.Errorf("fetch activity: %w", err)
 	}
-	return activity, commits, nil
+	return activity, list, nil
 }
 
 func fetchActivity(ctx context.Context, client *api.Client) (*userActivityResponse, error) {
@@ -150,6 +173,29 @@ func fetchCommits(ctx context.Context, client *api.Client) ([]userCommit, error)
 		return nil, fmt.Errorf("decode commits: %w", err)
 	}
 	return result.Commits, nil
+}
+
+func fetchSessions(ctx context.Context, client *api.Client) ([]userSession, error) {
+	q := url.Values{}
+	q.Set("timeframe", activityTimeframe)
+	q.Set("limit", strconv.Itoa(sessionsOverviewLimit))
+	path := "/api/v1/me/sessions?" + q.Encode()
+
+	resp, err := client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("GET sessions: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := api.CheckResponse(resp); err != nil {
+		return nil, fmt.Errorf("sessions response: %w", err)
+	}
+
+	var result userSessionsResponse
+	if err := api.DecodeJSON(resp, &result); err != nil {
+		return nil, fmt.Errorf("decode sessions: %w", err)
+	}
+	return result.Sessions, nil
 }
 
 // detectTimezone returns a best-effort timezone name for the current host.
@@ -201,37 +247,61 @@ func normalizeTimezone(raw string) string {
 	return name
 }
 
-func groupCommitsByDay(commits []userCommit) []commitDay {
-	byDate := make(map[string][]userCommit)
-	var dateOrder []string
-
-	for _, c := range commits {
-		date := dateUnknown
-		if c.CommitDate != nil {
-			if t, err := parseFlexibleTime(*c.CommitDate); err == nil {
-				date = t.Local().Format("2006-01-02")
-			}
-		}
-		if _, exists := byDate[date]; !exists {
-			dateOrder = append(dateOrder, date)
-		}
-		byDate[date] = append(byDate[date], c)
+// localDayOf returns the local "2006-01-02" day of an RFC3339 timestamp, or
+// dateUnknown when the pointer is nil/empty or the value can't be parsed.
+func localDayOf(ts *string) string {
+	if ts == nil || *ts == "" {
+		return dateUnknown
 	}
+	t, err := parseFlexibleTime(*ts)
+	if err != nil {
+		return dateUnknown
+	}
+	return t.Local().Format("2006-01-02")
+}
 
-	// Sort dates newest first, with unknown dates pushed to the end
-	sort.Slice(dateOrder, func(i, j int) bool {
-		if dateOrder[i] == dateUnknown {
+// groupItemsByDay buckets items by a local-day key, returning the distinct keys
+// ordered newest-first (with dateUnknown pushed to the end) plus the by-day map.
+// Shared by the commit and session day-grouped lists.
+func groupItemsByDay[T any](items []T, dayOf func(T) string) (order []string, byDate map[string][]T) {
+	byDate = make(map[string][]T)
+	for _, it := range items {
+		date := dayOf(it)
+		if _, exists := byDate[date]; !exists {
+			order = append(order, date)
+		}
+		byDate[date] = append(byDate[date], it)
+	}
+	sort.Slice(order, func(i, j int) bool {
+		if order[i] == dateUnknown {
 			return false
 		}
-		if dateOrder[j] == dateUnknown {
+		if order[j] == dateUnknown {
 			return true
 		}
-		return dateOrder[i] > dateOrder[j]
+		return order[i] > order[j]
 	})
+	return order, byDate
+}
 
-	result := make([]commitDay, 0, len(dateOrder))
-	for _, d := range dateOrder {
+func groupCommitsByDay(commits []userCommit) []commitDay {
+	order, byDate := groupItemsByDay(commits, func(c userCommit) string {
+		return localDayOf(c.CommitDate)
+	})
+	result := make([]commitDay, 0, len(order))
+	for _, d := range order {
 		result = append(result, commitDay{Date: d, Commits: byDate[d]})
+	}
+	return result
+}
+
+func groupSessionsByDay(sessions []userSession) []sessionDay {
+	order, byDate := groupItemsByDay(sessions, func(s userSession) string {
+		return localDayOf(&s.LastActivityAt)
+	})
+	result := make([]sessionDay, 0, len(order))
+	for _, d := range order {
+		result = append(result, sessionDay{Date: d, Sessions: byDate[d]})
 	}
 	return result
 }

--- a/cmd/entire/cli/activity_cmd_test.go
+++ b/cmd/entire/cli/activity_cmd_test.go
@@ -40,7 +40,7 @@ func TestRunActivity_SilencesContextCanceled(t *testing.T) {
 		}))
 
 	var out, errOut bytes.Buffer
-	err := runActivity(t.Context(), &out, &errOut)
+	err := runActivity(t.Context(), &out, &errOut, false)
 	if err == nil {
 		t.Fatal("expected error when STS exchange is cancelled")
 	}
@@ -74,7 +74,7 @@ func TestRunActivity_PrintsLoginHintOnNotLoggedIn(t *testing.T) {
 		}))
 
 	var out, errOut bytes.Buffer
-	err := runActivity(t.Context(), &out, &errOut)
+	err := runActivity(t.Context(), &out, &errOut, false)
 	if err == nil {
 		t.Fatal("expected error when not logged in")
 	}

--- a/cmd/entire/cli/activity_render.go
+++ b/cmd/entire/cli/activity_render.go
@@ -526,8 +526,11 @@ func renderCommitListN(w io.Writer, sty activityStyles, days []commitDay, maxDay
 	}
 }
 
-// sessionTitleMaxRunes mirrors entire.io's 120-char displayName cap on the
-// Overview row (width-based truncation may shorten it further on the terminal).
+// sessionTitleMaxRunes caps the display-name *content* at 120 runes, matching
+// entire.io's Overview row (`displayName.slice(0, 120) + "…"`): the ellipsis is
+// appended as an overflow marker on top of the 120, so the rendered title can
+// be 121 runes — this is a content cap, not a hard total-length cap. On a real
+// terminal the width-based truncation below usually shortens it further first.
 const sessionTitleMaxRunes = 120
 
 func renderSessionList(w io.Writer, sty activityStyles, days []sessionDay) {

--- a/cmd/entire/cli/activity_render.go
+++ b/cmd/entire/cli/activity_render.go
@@ -120,7 +120,10 @@ var agentOrder = []string{
 	"copilot", "pi", "cursor", "droid", "kiro", "unknown",
 }
 
-func renderActivity(w io.Writer, sty activityStyles, stats contributionStats, repos []repoContribution, hourly []hourlyPoint, days []commitDay) {
+// renderActivityHeader renders the stat cards, contribution heatmap, and repo
+// chart — the sections common to both the sessions and commits views. The
+// caller renders the recent-list section (sessions or commits) after it.
+func renderActivityHeader(w io.Writer, sty activityStyles, stats contributionStats, repos []repoContribution, hourly []hourlyPoint) {
 	fmt.Fprintln(w)
 	renderStatCards(w, sty, stats)
 	fmt.Fprintln(w)
@@ -128,7 +131,6 @@ func renderActivity(w io.Writer, sty activityStyles, stats contributionStats, re
 	fmt.Fprintln(w)
 	renderRepoChart(w, sty, repos)
 	fmt.Fprintln(w)
-	renderCommitList(w, sty, days)
 }
 
 func renderStatCards(w io.Writer, sty activityStyles, stats contributionStats) {
@@ -522,6 +524,113 @@ func renderCommitListN(w io.Writer, sty activityStyles, days []commitDay, maxDay
 		}
 		fmt.Fprintln(w)
 	}
+}
+
+// sessionTitleMaxRunes mirrors entire.io's 120-char displayName cap on the
+// Overview row (width-based truncation may shorten it further on the terminal).
+const sessionTitleMaxRunes = 120
+
+func renderSessionList(w io.Writer, sty activityStyles, days []sessionDay) {
+	renderSessionListN(w, sty, days, 3)
+}
+
+// renderSessionListN renders the recent-session feed grouped by day (newest
+// first), mirroring the entire.io Overview list: a per-day header with a
+// session count, then one row per session. maxDays <= 0 renders every day.
+func renderSessionListN(w io.Writer, sty activityStyles, days []sessionDay, maxDays int) {
+	if len(days) == 0 {
+		return
+	}
+	if maxDays <= 0 || maxDays > len(days) {
+		maxDays = len(days)
+	}
+
+	for _, day := range days[:maxDays] {
+		displayDate := formatCommitDate(day.Date)
+		sessionWord := "sessions"
+		if len(day.Sessions) == 1 {
+			sessionWord = strings.TrimSuffix(sessionWord, "s")
+		}
+
+		fmt.Fprintf(w, "%s  %s\n",
+			sty.render(sty.bold, displayDate),
+			sty.render(sty.muted, fmt.Sprintf("%d %s", len(day.Sessions), sessionWord)))
+
+		for _, s := range day.Sessions {
+			renderSessionRow(w, sty, s)
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+// renderSessionRow renders one session: title  repo  [public]  agent  …  model  checkpoints.
+// Left side is the session's display name, repo, an optional public tag, and
+// the agent badge; right side (right-aligned) is the friendly model label and
+// checkpoint count. Fields mirror the entire.io Overview row.
+func renderSessionRow(w io.Writer, sty activityStyles, s userSession) {
+	agentID := agentUnknown
+	if s.Agent != nil && *s.Agent != "" {
+		agentID = normalizeAgentString(*s.Agent)
+	}
+	agentLabel := agentDisplayMap[agentID].Label
+
+	title := strings.TrimSpace(s.DisplayName)
+	if title == "" {
+		title = "(untitled session)"
+	}
+	if runes := []rune(title); len(runes) > sessionTitleMaxRunes {
+		title = string(runes[:sessionTitleMaxRunes]) + "…"
+	}
+
+	model := ""
+	if s.Model != nil {
+		model = formatModel(*s.Model)
+	}
+
+	cpStr := fmt.Sprintf("%d checkpoints", s.CheckpointCount)
+	if s.CheckpointCount == 1 {
+		cpStr = "1 checkpoint"
+	}
+
+	// Right side: [model  ]checkpoints, right-aligned.
+	rightSide := sty.render(sty.muted, cpStr)
+	rightPlain := cpStr
+	if model != "" {
+		rightSide = sty.render(sty.muted, model) + sty.render(sty.dim, "  ") + rightSide
+		rightPlain = model + "  " + cpStr
+	}
+
+	// Public tag (rare from the entire-api cell, which reports isPublic=false).
+	publicRendered, publicPlain := "", ""
+	if s.IsPublic {
+		publicRendered = "  " + sty.render(sty.add, "public")
+		publicPlain = "  public"
+	}
+
+	buildLeft := func(t string) (rendered, plain string) {
+		rendered = sty.render(sty.commitM, t) + " " +
+			sty.render(sty.muted, s.RepoFullName) + publicRendered +
+			"  " + sty.renderAgent(agentID, agentLabel)
+		plain = t + " " + s.RepoFullName + publicPlain + "  " + agentLabel
+		return rendered, plain
+	}
+	left, leftPlain := buildLeft(title)
+
+	// Truncate the title if the row would exceed the terminal width.
+	maxTitle := sty.width - (lipgloss.Width(leftPlain) - lipgloss.Width(title)) - lipgloss.Width(rightPlain) - 2
+	if maxTitle < 10 {
+		maxTitle = 10
+	}
+	if lipgloss.Width(title) > maxTitle {
+		title = truncateDisplayWidth(title, maxTitle, "…")
+		left, leftPlain = buildLeft(title)
+	}
+
+	gap := sty.width - lipgloss.Width(leftPlain) - lipgloss.Width(rightPlain)
+	if gap < 2 {
+		gap = 2
+	}
+	fmt.Fprintf(w, "%s%s%s\n", left, strings.Repeat(" ", gap), rightSide)
 }
 
 func uniqueCommitAgents(c userCommit) []string {

--- a/cmd/entire/cli/activity_sessions_test.go
+++ b/cmd/entire/cli/activity_sessions_test.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+)
+
+func TestGroupSessionsByDay_SortsNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	at := func(year int, month time.Month, day int) string {
+		return time.Date(year, month, day, 12, 0, 0, 0, time.Local).Format(time.RFC3339)
+	}
+
+	sessions := []userSession{
+		{SessionID: "aaa", LastActivityAt: at(2026, time.January, 10)},
+		{SessionID: "bbb", LastActivityAt: at(2026, time.January, 12)},
+		{SessionID: "ccc", LastActivityAt: at(2026, time.January, 11)},
+	}
+	days := groupSessionsByDay(sessions)
+
+	if len(days) != 3 {
+		t.Fatalf("got %d day groups, want 3", len(days))
+	}
+	// Newest first: 2026-01-12, 2026-01-11, 2026-01-10.
+	if days[0].Sessions[0].SessionID != "bbb" {
+		t.Errorf("first day should contain session bbb (2026-01-12), got %q", days[0].Sessions[0].SessionID)
+	}
+	if days[1].Sessions[0].SessionID != "ccc" {
+		t.Errorf("second day should contain session ccc (2026-01-11), got %q", days[1].Sessions[0].SessionID)
+	}
+	if days[2].Sessions[0].SessionID != "aaa" {
+		t.Errorf("third day should contain session aaa (2026-01-10), got %q", days[2].Sessions[0].SessionID)
+	}
+}
+
+func TestGroupSessionsByDay_UnknownDatesLast(t *testing.T) {
+	t.Parallel()
+	sessions := []userSession{
+		{SessionID: "bad", LastActivityAt: ""},
+		{SessionID: "good", LastActivityAt: "2026-01-15T10:00:00Z"},
+	}
+	days := groupSessionsByDay(sessions)
+
+	if len(days) != 2 {
+		t.Fatalf("got %d day groups, want 2", len(days))
+	}
+	if days[0].Date == dateUnknown {
+		t.Errorf("unknown-date sessions should sort last, but appeared first")
+	}
+	if days[1].Date != dateUnknown {
+		t.Errorf("unknown-date sessions should be the last group, got %q", days[1].Date)
+	}
+}
+
+func TestFetchSessions_ParsesEnvelopeAndSendsWindow(t *testing.T) {
+	t.Parallel()
+
+	var gotPath, gotTimeframe, gotLimit string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotTimeframe = r.URL.Query().Get("timeframe")
+		gotLimit = r.URL.Query().Get("limit")
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{
+			"sessions": [
+				{"sessionId":"s1","displayName":"Add sessions list","isPublic":false,
+				 "agent":"claude","model":"claude-opus-4-6","lastActivityAt":"2026-01-15T10:00:00Z",
+				 "checkpointCount":3,"repo_full_name":"org/repo","is_private":true}
+			],
+			"timeframe":"last-month",
+			"updated_at":"2026-01-15T10:00:00.000Z"
+		}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	sessions, err := fetchSessions(t.Context(), client)
+	if err != nil {
+		t.Fatalf("fetchSessions: %v", err)
+	}
+
+	if gotPath != "/api/v1/me/sessions" {
+		t.Errorf("path = %q, want /api/v1/me/sessions", gotPath)
+	}
+	if gotTimeframe != activityTimeframe {
+		t.Errorf("timeframe = %q, want %q", gotTimeframe, activityTimeframe)
+	}
+	if gotLimit != "50" {
+		t.Errorf("limit = %q, want 50", gotLimit)
+	}
+
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	s := sessions[0]
+	if s.SessionID != "s1" || s.DisplayName != "Add sessions list" {
+		t.Errorf("unexpected session identity: %+v", s)
+	}
+	if s.Agent == nil || *s.Agent != activityTestAgentClaude {
+		t.Errorf("agent = %v, want claude", s.Agent)
+	}
+	if s.Model == nil || *s.Model != "claude-opus-4-6" {
+		t.Errorf("model = %v, want claude-opus-4-6", s.Model)
+	}
+	if s.CheckpointCount != 3 || s.RepoFullName != "org/repo" {
+		t.Errorf("checkpointCount/repo = %d/%q, want 3/org/repo", s.CheckpointCount, s.RepoFullName)
+	}
+}
+
+func TestRenderSessionList_ShowsRowFields(t *testing.T) {
+	t.Parallel()
+	agent := activityTestAgentClaude
+	model := "claude-opus-4-6"
+	days := []sessionDay{
+		{Date: "2026-01-15", Sessions: []userSession{
+			{
+				SessionID:       "s1",
+				DisplayName:     "Add sessions list to activity",
+				Agent:           &agent,
+				Model:           &model,
+				LastActivityAt:  "2026-01-15T10:00:00Z",
+				CheckpointCount: 3,
+				RepoFullName:    "org/repo",
+			},
+		}},
+	}
+
+	var buf strings.Builder
+	sty := activityStyles{width: 100}
+	renderSessionList(&buf, sty, days)
+	out := buf.String()
+
+	for _, want := range []string{
+		"Add sessions list to activity", // title
+		"org/repo",                      // repo
+		"Claude Code",                   // agent label
+		"Opus 4.6",                      // formatted model
+		"3 checkpoints",                 // checkpoint count
+		"1 session",                     // day header count (singular)
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("session row output missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderSessionList_PluralAndUntitled(t *testing.T) {
+	t.Parallel()
+	days := []sessionDay{
+		{Date: "2026-01-15", Sessions: []userSession{
+			{DisplayName: "", CheckpointCount: 1, RepoFullName: "org/repo"},
+			{DisplayName: "second", CheckpointCount: 0, RepoFullName: "org/repo"},
+		}},
+	}
+
+	var buf strings.Builder
+	sty := activityStyles{width: 100}
+	renderSessionList(&buf, sty, days)
+	out := buf.String()
+
+	if !strings.Contains(out, "2 sessions") {
+		t.Error("day header should say '2 sessions' (plural)")
+	}
+	if !strings.Contains(out, "(untitled session)") {
+		t.Error("empty display name should render as '(untitled session)'")
+	}
+	if !strings.Contains(out, "1 checkpoint") || strings.Contains(out, "1 checkpoints") {
+		t.Error("checkpoint count should be singular '1 checkpoint'")
+	}
+}

--- a/cmd/entire/cli/activity_tui.go
+++ b/cmd/entire/cli/activity_tui.go
@@ -15,12 +15,14 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 )
 
-// activityDataMsg is sent when API data has been fetched.
+// activityDataMsg is sent when API data has been fetched. Exactly one of days
+// (commits view) or sessionDays (sessions view) is populated, per showCommits.
 type activityDataMsg struct {
-	stats  contributionStats
-	repos  []repoContribution
-	hourly []hourlyPoint
-	days   []commitDay
+	stats       contributionStats
+	repos       []repoContribution
+	hourly      []hourlyPoint
+	days        []commitDay
+	sessionDays []sessionDay
 }
 
 // activityErrMsg is sent when fetching fails.
@@ -28,10 +30,14 @@ type activityErrMsg struct{ err error }
 
 type activityModel struct {
 	// Data (nil until loaded)
-	stats  *contributionStats
-	repos  []repoContribution
-	hourly []hourlyPoint
-	days   []commitDay
+	stats       *contributionStats
+	repos       []repoContribution
+	hourly      []hourlyPoint
+	days        []commitDay
+	sessionDays []sessionDay
+
+	// showCommits selects the recent-list view: commits when true, else sessions.
+	showCommits bool
 
 	// Loading state
 	loading bool
@@ -51,17 +57,18 @@ type activityModel struct {
 	ready    bool
 }
 
-func runActivityTUI(ctx context.Context, client *api.Client) error {
+func runActivityTUI(ctx context.Context, client *api.Client, showCommits bool) error {
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
 	sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 
 	m := activityModel{
-		loading:  true,
-		spinner:  sp,
-		ctx:      ctx,
-		client:   client,
-		useColor: shouldUseColor(os.Stdout),
+		loading:     true,
+		spinner:     sp,
+		ctx:         ctx,
+		client:      client,
+		useColor:    shouldUseColor(os.Stdout),
+		showCommits: showCommits,
 	}
 	p := tea.NewProgram(m)
 	if _, err := p.Run(); err != nil {
@@ -71,23 +78,28 @@ func runActivityTUI(ctx context.Context, client *api.Client) error {
 }
 
 func (m activityModel) fetchData() tea.Msg {
-	activity, commits, err := fetchActivityData(m.ctx, m.client)
+	if m.showCommits {
+		activity, commits, err := fetchActivityWith(m.ctx, m.client, fetchCommits)
+		if err != nil {
+			return activityErrMsg{err: err}
+		}
+		return activityDataMsg{
+			stats:  statsFromActivity(activity),
+			repos:  activity.Repos,
+			hourly: activity.HourlyContributions,
+			days:   groupCommitsByDay(commits),
+		}
+	}
+
+	activity, sessions, err := fetchActivityWith(m.ctx, m.client, fetchSessions)
 	if err != nil {
 		return activityErrMsg{err: err}
 	}
-
 	return activityDataMsg{
-		stats: contributionStats{
-			Tasks:         activity.Stats.Tasks,
-			Throughput:    activity.Stats.Throughput,
-			Iteration:     activity.Stats.Iteration,
-			ContinuityH:   activity.Stats.ContinuityHours,
-			Streak:        activity.Stats.LifetimeStreak,
-			CurrentStreak: activity.Stats.LifetimeCurrentStreak,
-		},
-		repos:  activity.Repos,
-		hourly: activity.HourlyContributions,
-		days:   groupCommitsByDay(commits),
+		stats:       statsFromActivity(activity),
+		repos:       activity.Repos,
+		hourly:      activity.HourlyContributions,
+		sessionDays: groupSessionsByDay(sessions),
 	}
 }
 
@@ -103,6 +115,7 @@ func (m activityModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.repos = msg.repos
 		m.hourly = msg.hourly
 		m.days = msg.days
+		m.sessionDays = msg.sessionDays
 		if m.width > 0 {
 			m = m.withViewport()
 		}
@@ -170,7 +183,7 @@ func (m activityModel) withViewport() activityModel {
 		m.viewport.SetWidth(m.width)
 		m.viewport.SetHeight(vpHeight)
 	}
-	m.viewport.SetContent(m.renderCommits())
+	m.viewport.SetContent(m.renderList())
 	return m
 }
 
@@ -218,9 +231,15 @@ func (m activityModel) headerLineCount() int {
 	return strings.Count(m.renderHeader(), "\n")
 }
 
-func (m activityModel) renderCommits() string {
+// renderList renders the scrollable recent-list section — sessions by default,
+// commits when --commits is set.
+func (m activityModel) renderList() string {
 	var buf bytes.Buffer
-	renderCommitListN(&buf, m.sty, m.days, -1)
+	if m.showCommits {
+		renderCommitListN(&buf, m.sty, m.days, -1)
+	} else {
+		renderSessionListN(&buf, m.sty, m.sessionDays, -1)
+	}
 	return buf.String()
 }
 

--- a/cmd/entire/cli/activity_types.go
+++ b/cmd/entire/cli/activity_types.go
@@ -91,3 +91,37 @@ type commitDay struct {
 	Date    string
 	Commits []userCommit
 }
+
+// userSessionsResponse is the API response for GET /api/v1/me/sessions — the
+// cross-repo recent-session feed the entire.io Overview page renders. The
+// envelope is snake_case; session-item fields are camelCase (mirrors entire-api
+// / entire.io exactly). Timeframe/UpdatedAt are unused by the CLI today.
+type userSessionsResponse struct {
+	Sessions  []userSession `json:"sessions"`
+	Timeframe string        `json:"timeframe"`
+	UpdatedAt string        `json:"updated_at"`
+}
+
+// userSession is one row of /me/sessions. Only the fields the Overview row
+// renders are kept; the wire also carries token and attribution totals, plus
+// prompt/stepCount/startedAt/customName/firstCommitAuthorUsername, which the
+// web (and so the CLI) does not display. Agent/Model are pointers because the
+// API sends null when unknown. DisplayName is already resolved server-side
+// (custom name > AI-generated name > heuristic). repo_full_name / is_private
+// are the two snake_case cross-repo fields.
+type userSession struct {
+	SessionID       string  `json:"sessionId"`
+	DisplayName     string  `json:"displayName"`
+	IsPublic        bool    `json:"isPublic"`
+	Agent           *string `json:"agent"`
+	Model           *string `json:"model"`
+	LastActivityAt  string  `json:"lastActivityAt"`
+	CheckpointCount int     `json:"checkpointCount"`
+	RepoFullName    string  `json:"repo_full_name"`
+}
+
+// sessionDay groups sessions by the local day of their last activity.
+type sessionDay struct {
+	Date     string
+	Sessions []userSession
+}

--- a/cmd/entire/cli/model_label.go
+++ b/cmd/entire/cli/model_label.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"regexp"
+	"strings"
+)
+
+// claudeModelRe matches Claude identifiers: claude-<family>-<major>[-<tail>].
+// The tail (rest) carries optional minor versions and/or a legacy date suffix.
+var claudeModelRe = regexp.MustCompile(`(?i)^claude-(opus|sonnet|haiku)-(\d+)(.*)$`)
+
+// dateSuffixRe matches a legacy date chunk (6+ digits, e.g. 20250514).
+var dateSuffixRe = regexp.MustCompile(`^\d{6,}$`)
+
+// formatModel turns a raw model identifier into a short display label, mirroring
+// entire.io's frontend formatModel (frontend/src/lib/model.ts) so the CLI's
+// session list reads identically to the web Overview page. Examples:
+//
+//	"claude-opus-4-6"          -> "Opus 4.6"
+//	"claude-sonnet-4-20250514" -> "Sonnet 4"
+//	"gpt-4o"                   -> "GPT-4o"
+//	"gemini-2.0-flash"         -> "Gemini 2.0 Flash"
+//
+// Unknown formats pass through unchanged. Empty/whitespace input returns ""
+// (the web returns null; the CLI renders nothing for it).
+func formatModel(model string) string {
+	trimmed := strings.TrimSpace(model)
+	if trimmed == "" {
+		return ""
+	}
+
+	// Claude: title-case family, then major[.minor], dropping any date suffix.
+	if m := claudeModelRe.FindStringSubmatch(trimmed); m != nil {
+		family, major, rest := m[1], m[2], m[3]
+		familyLabel := strings.ToUpper(family[:1]) + strings.ToLower(family[1:])
+		var minorParts []string
+		for _, part := range strings.Split(rest, "-") {
+			if part == "" {
+				continue
+			}
+			// A 6+ digit chunk is a date suffix — ignore it and everything after.
+			if dateSuffixRe.MatchString(part) {
+				break
+			}
+			minorParts = append(minorParts, part)
+		}
+		if minor := strings.Join(minorParts, "."); minor != "" {
+			return familyLabel + " " + major + "." + minor
+		}
+		return familyLabel + " " + major
+	}
+
+	// GPT: gpt-4o -> "GPT-4o" (case-insensitive prefix; "gpt-" is 4 ASCII bytes).
+	if len(trimmed) >= 4 && strings.EqualFold(trimmed[:4], "gpt-") {
+		return "GPT-" + trimmed[4:]
+	}
+
+	// Gemini: gemini-2.0-flash -> "Gemini 2.0 Flash" (upper-first each part).
+	if strings.HasPrefix(strings.ToLower(trimmed), "gemini-") {
+		parts := strings.Split(trimmed, "-")
+		for i, part := range parts {
+			parts[i] = upperFirst(part)
+		}
+		return strings.Join(parts, " ")
+	}
+
+	return trimmed
+}
+
+// upperFirst upper-cases the first rune of s, leaving the remainder unchanged
+// (matching the web's `part.charAt(0).toUpperCase() + part.slice(1)`).
+func upperFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	return strings.ToUpper(string(r[0])) + string(r[1:])
+}

--- a/cmd/entire/cli/model_label_test.go
+++ b/cmd/entire/cli/model_label_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import "testing"
+
+// TestFormatModel mirrors entire.io's frontend model.test.ts so the CLI's
+// friendly model labels stay identical to the web Overview page.
+func TestFormatModel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Current Claude identifiers.
+		{"claude-opus-4-6", "Opus 4.6"},
+		{"claude-sonnet-4-6", "Sonnet 4.6"},
+		{"claude-haiku-4-5", "Haiku 4.5"},
+		// Legacy date suffixes are stripped.
+		{"claude-sonnet-4-20250514", "Sonnet 4"},
+		{"claude-opus-4-1-20250805", "Opus 4.1"},
+		// Case-insensitive family, normalized to Title case.
+		{"CLAUDE-OPUS-4-6", "Opus 4.6"},
+		// GPT models.
+		{"gpt-4o", "GPT-4o"},
+		{"gpt-4-turbo", "GPT-4-turbo"},
+		{"GPT-4o", "GPT-4o"},
+		// Gemini models: upper-first each dash-part.
+		{"gemini-2.0-flash", "Gemini 2.0 Flash"},
+		// Empty / whitespace.
+		{"", ""},
+		{"   ", ""},
+		// Unknown formats pass through unchanged.
+		{"custom-model-123", "custom-model-123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			if got := formatModel(tt.input); got != tt.want {
+				t.Errorf("formatModel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/769
<!-- entire-trail-link-end -->

## Why

The entire.io Overview page renders a recent-**sessions** feed from `GET /api/v1/me/sessions`, but `entire activity` rendered a recent-**commits** feed from `/me/commits`. The two surfaces listed different things, so a session with no resulting commit never showed in the CLI, and a commit bundling several sessions showed as one row — the lists never lined up.

## What

Make sessions the default recent-list in `entire activity`, matching the web exactly. The stat cards, contribution heatmap, and repo chart (all from `/me/activity`) are unchanged; only the bottom list changes.

- **Sessions feed** — fetch `/me/sessions` at `limit=50` (mirroring the web's `USER_OVERVIEW_RECENT_SESSIONS_LIMIT`), group by the local day of `lastActivityAt` (newest first, unknown last), and render one row per session with the same fields the web row shows: display name (capped at 120), repo, a `public` tag when `isPublic`, agent badge, friendly model label, and checkpoint count.
- **Commits stay available** behind `entire activity --commits`.
- **`formatModel` ported** from `entire.io/frontend/src/lib/model.ts` to Go so labels read identically (`claude-opus-4-6` → "Opus 4.6", `gpt-4o` → "GPT-4o", `gemini-2.0-flash` → "Gemini 2.0 Flash", legacy date suffixes stripped). Same test cases as the web's `model.test.ts`.
- **Routing** — reuses the existing `runAuthenticatedActivityAPI`, so `/me/sessions` goes to the caller's home entire-api cell with the data-API fallback (the routing landed in #1641).
- **Dedup** — extracts `fetchActivityWith` (activity aggregate + chosen list, fetched concurrently) and a generic `groupItemsByDay`, so the session and commit paths don't duplicate the plumbing.

`entire agent-help activity` picks up the new `--commits` flag automatically (it renders live from the cobra tree).

### Endpoint note

`/me/sessions` reports `isPublic: false` unconditionally today (entire-api has no GitHub-login-on-session source), so the `public` tag is implemented for correctness but will rarely render from the cell — matching the repo sessions surface.

## Testing

- New unit tests: `formatModel` (mirrors the web's `model.test.ts`), `groupSessionsByDay` (ordering + unknown-date handling), `fetchSessions` (path/window/envelope parsing via httptest), and session-row rendering (fields, singular/plural, untitled fallback).
- `mise run fmt` clean, `mise run lint` 0 issues, `mise run test:ci` green (unit + integration + Vogon canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI display and read-only API calls only; commits remain available via `--commits`, with solid unit test coverage.
> 
> **Overview**
> **`entire activity` now defaults to a recent-sessions list** aligned with the entire.io Overview: it calls `GET /api/v1/me/sessions` with `limit=50`, groups by local day of `lastActivityAt`, and renders rows (title, repo, optional `public`, agent, formatted model, checkpoint count). Stat cards, heatmap, and repo chart from `/me/activity` are unchanged.
> 
> **`entire activity --commits`** restores the previous recent-commits behavior. Static and TUI paths both branch on that flag; the header vs list rendering is split (`renderActivityHeader` + session or commit list).
> 
> **Plumbing:** generic `fetchActivityWith` loads activity and the chosen list concurrently; `groupItemsByDay` / `localDayOf` dedupe day grouping for commits and sessions. **`formatModel`** is added in Go to mirror the web’s friendly model labels.
> 
> Tests cover sessions fetch/render/grouping and `formatModel`; existing `runActivity` tests pass the new `showCommits` argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 887f764057293d18909e23374921e993d9606a6c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->