### PR TITLE
fix(review): pass codex skills natively instead of paraphrasing them

### DIFF
--- a/cmd/entire/cli/agent/codex/reviewer.go
+++ b/cmd/entire/cli/agent/codex/reviewer.go
@@ -32,9 +32,24 @@ func NewReviewer() *reviewtypes.ReviewerTemplate {
 
 // buildCodexReviewCmd builds the exec.Cmd for a codex review run.
 // Exposed at package level for test inspection of argv, stdin, and env.
+// buildCodexReviewCmd builds the exec.Cmd for a codex review run.
+//
+// Configured skills are passed through in codex's native $name form — NOT
+// paraphrased. Codex's skill system injects a catalog of installed skills
+// into every exec session and loads the matching SKILL.md when the prompt
+// names one, so the agent runs the real configured workflow. A previous
+// version silently REPLACED /review with a generic 28-word instruction: the
+// configured skill never ran (the codex sibling of the claude -p
+// slash-expansion bug, where the built-in /review hijacked the prompt).
+//
+// Native `codex exec review` is intentionally NOT used: it rejects an extra
+// prompt when a scope flag is set, and codex hooks don't fire during it —
+// leaving no channel for Entire's scope enumeration, per-run prompt, and
+// checkpoint context. Plain `codex exec -` with the composed prompt on stdin
+// runs the same skill while carrying our arguments.
 func buildCodexReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
 	promptCfg := cfg
-	promptCfg.Skills = expandCodexBuiltinReview(cfg.Skills)
+	promptCfg.Skills = codexNativeSkillInvocations(cfg.Skills)
 	args := []string{codexExecCommand, "--skip-git-repo-check", "--json"}
 	args = review.AppendModelFlag(args, cfg.Model)
 	args = append(args, "-")
@@ -45,19 +60,16 @@ func buildCodexReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.C
 	return cmd
 }
 
-// Codex's native `exec review --base <branch>` rejects an additional prompt,
-// so expand `/review` into text and run normal `codex exec -`. That preserves
-// Entire's scoped base clause, per-run instructions, and checkpoint context.
-const codexBuiltinReviewPrompt = "Review the current branch changes and report actionable findings. " +
-	"Prioritize correctness, regressions, security, and missing test coverage. Do not make code changes."
-
 const codexExecCommand = "exec"
 
-func expandCodexBuiltinReview(skills []string) []string {
+// codexNativeSkillInvocations rewrites slash-form skill invocations (the
+// agent-portable form profiles are configured with) into codex's native
+// $name form. Non-slash entries (plain instruction text) pass verbatim.
+func codexNativeSkillInvocations(skills []string) []string {
 	out := make([]string, 0, len(skills))
 	for _, skill := range skills {
-		if skill == "/review" {
-			out = append(out, codexBuiltinReviewPrompt)
+		if rest, ok := strings.CutPrefix(skill, "/"); ok && rest != "" {
+			out = append(out, "$"+rest)
 			continue
 		}
 		out = append(out, skill)

--- a/cmd/entire/cli/agent/codex/reviewer_test.go
+++ b/cmd/entire/cli/agent/codex/reviewer_test.go
@@ -122,10 +122,10 @@ func TestCodexReviewer_BuiltinReviewExpandsToScopedExecPrompt(t *testing.T) {
 
 	prompt := readCodexCmdStdin(t, cmd)
 	if strings.Contains(prompt, "/review") {
-		t.Fatalf("builtin review prompt should not include raw /review:\n%s", prompt)
+		t.Fatalf("slash-form skill must be rewritten to codex's $ form:\n%s", prompt)
 	}
 	for _, wantText := range []string{
-		"Review the current branch changes and report actionable findings.",
+		"$review",
 		"Focus on auth regressions.",
 		"Scope: review the commits unique to this branch vs main, plus any uncommitted changes in the working tree. Ignore code outside this scope.",
 		"Commits in scope (newest first):",
@@ -462,4 +462,50 @@ func envToMap(env []string) map[string]string {
 		m[e[:idx]] = e[idx+1:]
 	}
 	return m
+}
+
+// TestBuildCodexReviewCmd_SkillsPassNativelyNotParaphrased locks the fix for
+// codex skill invocation: configured skills reach codex in its native $name
+// form so codex's skill system loads the real SKILL.md, instead of /review
+// being silently REPLACED with a generic 28-word paraphrase (which meant the
+// configured skill never ran — the codex sibling of the claude -p
+// slash-expansion bug).
+func TestBuildCodexReviewCmd_SkillsPassNativelyNotParaphrased(t *testing.T) {
+	t.Parallel()
+	cmd := buildCodexReviewCmd(context.Background(), reviewtypes.RunConfig{
+		Skills: []string{"/review", "/pr-review-toolkit:review-pr", "plain instruction line"},
+	})
+	stdin, err := io.ReadAll(cmd.Stdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := string(stdin)
+	for _, want := range []string{"$review", "$pr-review-toolkit:review-pr", "plain instruction line"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing native skill invocation %q:\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "Review the current branch changes and report actionable findings") {
+		t.Errorf("prompt still contains the generic paraphrase:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "/review\n") || strings.HasSuffix(prompt, "/review") {
+		t.Errorf("slash-form skill leaked through untransformed:\n%s", prompt)
+	}
+}
+
+// TestBuildCodexReviewCmd_PromptOverrideVerbatim ensures the $-form transform
+// never touches a verbatim prompt override.
+func TestBuildCodexReviewCmd_PromptOverrideVerbatim(t *testing.T) {
+	t.Parallel()
+	cmd := buildCodexReviewCmd(context.Background(), reviewtypes.RunConfig{
+		Skills:         []string{"/review"},
+		PromptOverride: "/review exactly as written",
+	})
+	stdin, err := io.ReadAll(cmd.Stdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(stdin); got != "/review exactly as written" {
+		t.Errorf("PromptOverride modified: %q", got)
+	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/776
<!-- entire-trail-link-end -->

## Problem

`expandCodexBuiltinReview` silently **replaced** a configured `/review` skill with a generic 28-word instruction before composing the codex prompt — the configured skill never ran. This is the codex sibling of the claude `-p` slash-expansion bug fixed in #1647: in both cases the child executed something other than what the user configured.

## Change

Slash-form skill invocations (the agent-portable form profiles are configured with) are rewritten to codex's native `$name` form, which codex's skill system resolves against its installed-skill catalog and loads the matching SKILL.md. Non-slash entries (plain instruction text) pass verbatim; `PromptOverride` is untouched. The paraphrase constant and expansion are deleted.

With #1647 (claude Skill-tool invocation) and #1651 (skill fan-out), this completes faithful parallel skill execution for both agents: N configured skills → N parallel children, each natively running exactly its skill.

## Relationship to #1370

Extracted from #1370 (codex review correctness), which this supersedes for merge purposes:
- **skill invocation** → this PR
- **live token tailing** (claude streaming + codex rollout) → remains queued as its own follow-up
- **per-spawn `reasoning_effort`** → dropped by product decision (entire invokes skills; it does not alter how they run)
- **skilldiscovery refactor** → superseded by main's evolution

## Testing

- TDD: native-form + no-paraphrase + override-verbatim tests watched fail first; the old paraphrase-pinning assertion inverted deliberately
- `mise run test` (7,558) green, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to codex review prompt assembly; fixes incorrect behavior without touching auth, data, or shared review core beyond skill string rewriting.
> 
> **Overview**
> **Codex review** no longer substitutes configured slash skills with a generic paraphrase. Profile skills like `/review` are rewritten to codex’s native **`$name`** form so codex loads the real **SKILL.md**; plain text lines stay unchanged.
> 
> The old **`expandCodexBuiltinReview`** path and **`codexBuiltinReviewPrompt`** are removed. **`codex exec -`** with the composed prompt on stdin is unchanged (still avoids **`codex exec review`** limitations).
> 
> Tests now expect **`$review`** in the prompt and add coverage for multi-skill **`$`** rewriting and **`PromptOverride`** bypassing skill transforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c756707bc47079aaa1bfce268cb1045f1c16701. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->