### PR TITLE
cli: route the update notice to stderr, never stdout

### DIFF
--- a/cmd/entire/cli/plugin.go
+++ b/cmd/entire/cli/plugin.go
@@ -47,7 +47,9 @@ func MaybeRunPlugin(ctx context.Context, rootCmd *cobra.Command, args []string) 
 	exitCode = runPlugin(ctx, pluginName, binPath, pluginArgs)
 	if exitCode == 0 {
 		maybeTrackPluginInvocation(ctx, pluginName)
-		versioncheck.CheckAndNotify(ctx, os.Stdout, versioninfo.Version)
+		// Stderr, matching the built-in PersistentPostRun: the plugin's own
+		// stdout may be machine-readable and piped.
+		versioncheck.CheckAndNotify(ctx, os.Stderr, versioninfo.Version)
 	}
 	return true, exitCode
 }

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -68,8 +68,11 @@ func NewRootCmd() *cobra.Command {
 			}
 
 			// Version check and notification (synchronous with 2s timeout)
-			// Runs AFTER command completes to avoid interfering with interactive modes
-			versioncheck.CheckAndNotify(cmd.Context(), cmd.OutOrStdout(), versioninfo.Version)
+			// Runs AFTER command completes to avoid interfering with interactive modes.
+			// Stderr, never stdout: this hook also fires after --json commands whose
+			// stdout is piped into jq or captured by scripts — a notice on stdout
+			// corrupts that output while staying invisible in the caller's logs.
+			versioncheck.CheckAndNotify(cmd.Context(), cmd.ErrOrStderr(), versioninfo.Version)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/777
<!-- entire-trail-link-end -->

## Why

The post-run version-check notice printed to stdout, where it lands inside `$(entire ... --json)` command substitutions and pipes — the caller's jq sees `Update available! ...` fused with the JSON it asked for, while the notice stays invisible in their logs. Found while investigating entiredb auth-smoke CI failures where `--json` output was corrupted (https://github.com/entirehq/entiredb/pull/2533).

## What

Route `versioncheck.CheckAndNotify` to stderr in both the built-in `PersistentPostRun` hook and the plugin dispatch path. Stdout stays reserved for command output.

## Verification

`go test ./cmd/entire/cli/ ./cmd/entire/cli/versioncheck/` and `mise run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small I/O routing change for a non-critical notice; no auth, data, or command logic changes.
> 
> **Overview**
> The post-run **update-available** notice from `versioncheck.CheckAndNotify` no longer goes to **stdout**. It is written to **stderr** in both the root `PersistentPostRun` hook (`cmd.ErrOrStderr()`) and after successful external plugin runs (`os.Stderr`), with comments noting that stdout must stay clean for `--json` and piped plugin output.
> 
> This prevents update text from being mixed into command substitutions and jq pipelines while keeping the notice visible on the terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b90e3677ef7dccf994b084374a6e96ea4351b082. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->