### PR TITLE
remotehelper: stop telling users to re-login on a bare 401

### DIFF
--- a/internal/remotehelper/transport/inforefs.go
+++ b/internal/remotehelper/transport/inforefs.go
@@ -199,7 +199,7 @@ func HTTPErrorMessage(statusCode int, serverMsg, baseURL string) error {
 		if serverMsg != "" {
 			return fmt.Errorf("authentication failed: %s", serverMsg)
 		}
-		return errors.New("authentication failed - please run 'entire login'")
+		return errors.New("authentication failed - the cached credential was rejected and has been discarded; retry the command (if this persists, run 'entire login')")
 	case http.StatusNotFound:
 		if serverMsg != "" {
 			return errors.New(serverMsg)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/778
<!-- entire-trail-link-end -->

## Why

A bare data-plane 401 already self-heals — telling users to re-login is misleading and trains them to run `entire login` for transient 401s (signing-key rotation, expiry skew), where it does nothing useful.

The 401 observer at `internal/remotehelper/transport/proxy.go:159-166` (`unauthorizedObserver.RoundTrip`) fires `OnUnauthorized` on every 401 response. It's wired to `creds.Invalidate` in `cmd/git-remote-entire/main.go:161`, and both the failover client and the discovery probe transports are wrapped with it (`proxy.go:132-147`). `jurisdictionTokenSource.Invalidate` (`cmd/git-remote-entire/jurisdictionauth.go:168`) drops the memoized token AND deletes the keychain entry, so the next command re-mints from the login session — no re-login needed.

Because the observer runs inside the RoundTripper, it fires during `doWithFailover` — before `httpError`/`HTTPErrorMessage` renders the message at `inforefs.go:146` (info/refs) and `inforefs.go:187` (ServiceRPC). Invalidate always happens first, on both 401 paths. No missing wiring.

## What

Change the bare-401 message (`internal/remotehelper/transport/inforefs.go:202`) from `authentication failed - please run 'entire login'` to `authentication failed - the cached credential was rejected and has been discarded; retry the command (if this persists, run 'entire login')`.

The with-server-message variant (`authentication failed: %s`) is unchanged — it surfaces an explicit server reason and doesn't misdirect.

No test asserted the old full string; existing tests assert the `authentication failed` substring, which is preserved.

## Verification

`mise run lint` — clean, 0 issues.

`go test ./internal/remotehelper/transport/...` — ok.

`go test ./cmd/entire/cli/ -run TestExplain` — ok.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error text only; no auth, transport, or invalidation behavior changes.
> 
> **Overview**
> **Bare 401 errors** from Git remote transport (`HTTPErrorMessage` in `inforefs.go`) no longer tell users to run `entire login` as the first step.
> 
> The message now explains that the **cached credential was rejected and cleared**, asks the user to **retry the command**, and only suggests `entire login` if the problem persists. The variant that includes an explicit server message (`authentication failed: %s`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaf04b0299014ed5629c6996f41dffb02f7e9905. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->