### PR TITLE
remotehelper: re-mint and retry once on 401 instead of failing the command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/entireio/auth-go v0.5.0
+	github.com/entireio/auth-go v0.5.1
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
 	github.com/go-git/go-billy/v6 v6.0.0-alpha.1.0.20260519112248-0095b064a6c6

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/entireio/auth-go v0.5.1
+	github.com/entireio/auth-go v0.5.2
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
 	github.com/go-git/go-billy/v6 v6.0.0-alpha.1.0.20260519112248-0095b064a6c6

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/entireio/auth-go v0.5.1 h1:V72PnApZRGtg5+691YcaokNR7Jpda7OrBEL8g9ge2XY=
-github.com/entireio/auth-go v0.5.1/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
+github.com/entireio/auth-go v0.5.2 h1:z0deFLJiBQH3ROMo/Z/YE2HcJ6W2SxZO5RVn2feQIPM=
+github.com/entireio/auth-go v0.5.2/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/fatih/semgroup v1.2.0 h1:h/OLXwEM+3NNyAdZEpMiH1OzfplU09i2qXPVThGZvyg=

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/entireio/auth-go v0.5.0 h1:omda1kFqyxrxxzDHtb9HH2ObgCaDUz8P2HQK+3g1QLg=
-github.com/entireio/auth-go v0.5.0/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
+github.com/entireio/auth-go v0.5.1 h1:V72PnApZRGtg5+691YcaokNR7Jpda7OrBEL8g9ge2XY=
+github.com/entireio/auth-go v0.5.1/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/fatih/semgroup v1.2.0 h1:h/OLXwEM+3NNyAdZEpMiH1OzfplU09i2qXPVThGZvyg=

--- a/internal/remotehelper/transport/inforefs.go
+++ b/internal/remotehelper/transport/inforefs.go
@@ -199,7 +199,9 @@ func HTTPErrorMessage(statusCode int, serverMsg, baseURL string) error {
 		if serverMsg != "" {
 			return fmt.Errorf("authentication failed: %s", serverMsg)
 		}
-		return errors.New("authentication failed - please run 'entire login'")
+		// Reaching here means the transport already re-minted and retried once
+		// (see retryOn401) and the fresh credential was still rejected.
+		return errors.New("authentication failed even after refreshing credentials - run 'entire login' if this persists")
 	case http.StatusNotFound:
 		if serverMsg != "" {
 			return errors.New(serverMsg)

--- a/internal/remotehelper/transport/proxy.go
+++ b/internal/remotehelper/transport/proxy.go
@@ -297,22 +297,66 @@ func (p *Proxy) setAuthOrError(req *http.Request) error {
 // request body — the cold-path probe (no-redirect client), the
 // missing-replicas fallback, and the Location salvage all share this
 // shape.
+//
+// On a 401 it retries once with a freshly minted token: see retryOn401.
 func (p *Proxy) doGet(ctx context.Context, urlStr string, client *http.Client, setHeaders func(*http.Request)) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	build := func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		if err := p.setAuthOrError(req); err != nil {
+			return nil, err
+		}
+		if setHeaders != nil {
+			setHeaders(req)
+		}
+		return req, nil
+	}
+	req, err := build()
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	if err := p.setAuthOrError(req); err != nil {
 		return nil, err
-	}
-	if setHeaders != nil {
-		setHeaders(req)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("doing request: %w", err)
 	}
+	resp, err = p.retryOn401(client, resp, build)
+	if err != nil {
+		return nil, fmt.Errorf("doing request: %w", err)
+	}
 	return resp, nil
+}
+
+// retryOn401 resends the request once, with a freshly minted credential,
+// when resp is an HTTP 401; otherwise it returns resp untouched.
+//
+// A 401 means the data plane rejected the credential itself (a signing-key
+// rotation or clock skew invalidating a still-mid-TTL persisted token). The
+// unauthorizedObserver has already fired creds.Invalidate by the time this
+// runs — synchronously, inside the RoundTrip that produced this response — so
+// build's setAuthOrError re-resolves the Authorization header from the token
+// source, which now re-mints rather than replaying the dead credential. build
+// also rewinds any request body, so this is safe for POSTs. We deliberately
+// re-run build rather than replaying the original *http.Request: that yields a
+// fresh header (not a captured stale one) and a rewound body.
+//
+// Exactly one retry. If the resend also 401s, the caller renders the error;
+// there is no loop. A build error on the resend (e.g. the re-mint failing) is
+// surfaced verbatim, so the mint error reaches the user rather than a
+// nil-token retry.
+func (p *Proxy) retryOn401(client *http.Client, resp *http.Response, build func() (*http.Request, error)) (*http.Response, error) {
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	_ = resp.Body.Close()
+	debuglog.Printf("data plane returned 401; credential invalidated, retrying once with a freshly minted token")
+	req, err := build()
+	if err != nil {
+		return nil, err
+	}
+	//nolint:wrapcheck // caller adds context; keeping the raw error preserves failover classification
+	return client.Do(req)
 }
 
 // doWithFailover tries an HTTP request against each node, starting
@@ -332,28 +376,43 @@ func (p *Proxy) doWithFailover(ctx context.Context, makeSuffix string, method st
 		}
 	}
 	var lastErr error
+	// One auth retry per logical operation, not per replica: a 401 doesn't
+	// trigger failover, so the loop returns the first 401 to the retry — this
+	// flag stops a second node (or a re-entry) from re-minting again.
+	authRetried := false
 
 	for i := range nodes {
 		node := nodes[(start+i)%len(nodes)]
 		reqURL := p.nodeURL(node, makeSuffix)
 
-		var bodyReader io.Reader
-		if body != nil {
-			if _, err := body.Seek(0, io.SeekStart); err != nil {
-				return nil, fmt.Errorf("resetting request body: %w", err)
+		// build (re)constructs the request: rewind the body, mint/attach the
+		// Authorization header, and stamp the caller's headers. Reused by the
+		// 401 retry so the resend carries a rewound body and a fresh token
+		// rather than a replayed stale header.
+		build := func() (*http.Request, error) {
+			var bodyReader io.Reader
+			if body != nil {
+				if _, err := body.Seek(0, io.SeekStart); err != nil {
+					return nil, fmt.Errorf("resetting request body: %w", err)
+				}
+				bodyReader = body
 			}
-			bodyReader = body
+			req, err := http.NewRequestWithContext(ctx, method, reqURL, bodyReader)
+			if err != nil {
+				return nil, fmt.Errorf("creating request: %w", err)
+			}
+			if err := p.setAuthOrError(req); err != nil {
+				return nil, err
+			}
+			if setHeaders != nil {
+				setHeaders(req)
+			}
+			return req, nil
 		}
 
-		req, err := http.NewRequestWithContext(ctx, method, reqURL, bodyReader)
+		req, err := build()
 		if err != nil {
-			return nil, fmt.Errorf("creating request: %w", err)
-		}
-		if err := p.setAuthOrError(req); err != nil {
 			return nil, err
-		}
-		if setHeaders != nil {
-			setHeaders(req)
 		}
 
 		resp, err := p.client.Do(req)
@@ -362,6 +421,20 @@ func (p *Proxy) doWithFailover(ctx context.Context, makeSuffix string, method st
 			lastErr = err
 			p.markNodeFailed(node)
 			continue
+		}
+
+		if resp.StatusCode == http.StatusUnauthorized && !authRetried {
+			authRetried = true
+			debuglog.Printf("node %s returned HTTP 401; retrying once with a freshly minted token", node)
+			// The retry hits the same node it 401'd on. Surface any error
+			// directly (a re-mint failure or a transient connect on the
+			// resend) rather than failing over across healthy nodes — a
+			// blanket failover would churn the replica cache on a transient
+			// auth-provider outage, and the 401 already told us the node is up.
+			resp, err = p.retryOn401(p.client, resp, build)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if shouldFailover(resp.StatusCode) {

--- a/internal/remotehelper/transport/proxy.go
+++ b/internal/remotehelper/transport/proxy.go
@@ -349,6 +349,10 @@ func (p *Proxy) retryOn401(client *http.Client, resp *http.Response, build func(
 	if resp.StatusCode != http.StatusUnauthorized {
 		return resp, nil
 	}
+	// Drain (bounded, like httpError and the 5xx failover path) before Close
+	// so net/http can reuse the connection for the immediate retry instead of
+	// paying a fresh TCP+TLS handshake.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024)) //nolint:errcheck // best-effort drain for connection reuse
 	_ = resp.Body.Close()
 	debuglog.Printf("data plane returned 401; credential invalidated, retrying once with a freshly minted token")
 	req, err := build()

--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -1458,3 +1459,183 @@ func TestUnauthorizedObserver(t *testing.T) {
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// fakeTokenSource models the jurisdiction token source the remote helper
+// wires into the proxy: Token memoizes a minted token, Invalidate drops the
+// memo so the next Token re-mints a distinct one. mintErrs[n], when non-nil,
+// makes the (n+1)th mint fail — used to exercise re-mint failure on a retry.
+type fakeTokenSource struct {
+	mu       sync.Mutex
+	token    string
+	mints    int
+	mintErrs []error
+}
+
+func (s *fakeTokenSource) Token() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.token != "" {
+		return s.token, nil
+	}
+	if s.mints < len(s.mintErrs) && s.mintErrs[s.mints] != nil {
+		err := s.mintErrs[s.mints]
+		s.mints++
+		return "", err
+	}
+	s.mints++
+	s.token = fmt.Sprintf("token-%d", s.mints)
+	return s.token, nil
+}
+
+func (s *fakeTokenSource) Invalidate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token = ""
+}
+
+// authRetryProxy builds a single-node Proxy wired the way git-remote-entire's
+// main wires production: SetAuth stamps a Bearer from src, and OnUnauthorized
+// invalidates src so the next mint is fresh.
+func authRetryProxy(t *testing.T, serverURL string, src *fakeTokenSource) *Proxy {
+	t.Helper()
+	return New(Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: []string{serverURL},
+			ClusterHost:  mustHost(t, serverURL),
+		},
+		Path: "/et/alice/repo",
+		SetAuth: func(req *http.Request) error {
+			tok, err := src.Token()
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Authorization", "Bearer "+tok)
+			return nil
+		},
+		OnUnauthorized: src.Invalidate,
+	})
+}
+
+// TestServiceRPCRetriesOnceOn401: a POST that 401s once then succeeds must be
+// retried in-process — exactly two attempts, the body replayed verbatim on the
+// retry, and the retry carrying a freshly minted Authorization header.
+func TestServiceRPCRetriesOnceOn401(t *testing.T) {
+	t.Parallel()
+	const reqBody = "0032want 1234567890123456789012345678901234567890\n0000"
+
+	type attempt struct{ auth, body string }
+	var mu sync.Mutex
+	var attempts []attempt
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body) //nolint:errcheck // test
+		mu.Lock()
+		n := len(attempts)
+		attempts = append(attempts, attempt{auth: r.Header.Get("Authorization"), body: string(b)})
+		mu.Unlock()
+		if n == 0 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "pack-data")
+	}))
+	defer server.Close()
+
+	src := &fakeTokenSource{}
+	p := authRetryProxy(t, server.URL, src)
+
+	body, err := p.ServiceRPC(context.Background(), "git-upload-pack", strings.NewReader(reqBody))
+	require.NoError(t, err)
+	defer body.Close()
+	got, _ := io.ReadAll(body) //nolint:errcheck // test
+	assert.Equal(t, "pack-data", string(got))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, attempts, 2, "expected exactly one in-process retry (two attempts total)")
+	assert.Equal(t, reqBody, attempts[0].body, "first attempt body")
+	assert.Equal(t, reqBody, attempts[1].body, "POST body must be fully replayed on the retry")
+	assert.Equal(t, "Bearer token-1", attempts[0].auth)
+	assert.Equal(t, "Bearer token-2", attempts[1].auth, "retry must carry a freshly minted token, not the replayed stale header")
+	assert.NotEqual(t, attempts[0].auth, attempts[1].auth)
+}
+
+// TestServiceRPCRetriesOnceThenFailsOnPersistent401: when the fresh token is
+// also rejected, we stop after exactly one retry and surface the refreshed
+// message — no retry loop.
+func TestServiceRPCRetriesOnceThenFailsOnPersistent401(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	src := &fakeTokenSource{}
+	p := authRetryProxy(t, server.URL, src)
+
+	_, err := p.ServiceRPC(context.Background(), "git-upload-pack", strings.NewReader("body"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed even after refreshing credentials")
+	assert.Equal(t, int32(2), calls.Load(), "exactly two attempts: original + one retry")
+}
+
+// TestServiceRPCRetryReMintFailureSurfaces: if re-minting the token for the
+// retry fails, the mint error must reach the caller — not a nil-token retry —
+// and we must not have dialled the server a second time.
+func TestServiceRPCRetryReMintFailureSurfaces(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	// First mint succeeds (token-1, gets the 401); the retry's re-mint fails.
+	src := &fakeTokenSource{mintErrs: []error{nil, errors.New("core unreachable: exchange failed")}}
+	p := authRetryProxy(t, server.URL, src)
+
+	_, err := p.ServiceRPC(context.Background(), "git-upload-pack", strings.NewReader("body"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "core unreachable: exchange failed")
+	assert.Equal(t, int32(1), calls.Load(), "retry must abort at re-mint, before a second dial")
+}
+
+// TestInfoRefsRetriesOnceOn401: the GET info/refs path self-heals on a 401 the
+// same way, re-minting and retrying once.
+func TestInfoRefsRetriesOnceOn401(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	var auths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		n := len(auths)
+		auths = append(auths, r.Header.Get("Authorization"))
+		mu.Unlock()
+		if n == 0 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "refs")
+	}))
+	defer server.Close()
+
+	src := &fakeTokenSource{}
+	p := authRetryProxy(t, server.URL, src)
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err)
+	defer body.Close()
+	got, _ := io.ReadAll(body) //nolint:errcheck // test
+	assert.Equal(t, "refs", string(got))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, auths, 2, "expected exactly one in-process retry")
+	assert.Equal(t, "Bearer token-1", auths[0])
+	assert.Equal(t, "Bearer token-2", auths[1], "retry must carry a freshly minted token")
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/779
<!-- entire-trail-link-end -->

## Why

git-remote-entire authenticates git smart-HTTP with an 8h keychain-persisted jurisdiction token. On a data-plane 401 the transport's `unauthorizedObserver` invalidates the memoized token (and deletes the keychain entry) so the *next* command re-mints — but the in-flight command still failed by design (`jurisdictionauth.go`). That forces the user to re-run after a legitimate mid-TTL 401 (core signing-key rotation, clock skew) — needless friction, since the fix is already in hand by the time the error is rendered.

## What

- On a 401, retry the request exactly once in-process with a freshly minted credential (`internal/remotehelper/transport/proxy.go`). The retry re-runs the request-build seam — `Seek(0)` to rewind the body, `setAuthOrError` to re-resolve the `Authorization` header from the token source (which re-mints, since the observer already invalidated) — rather than replaying the captured stale header.
  - The seam is the request-construction closure in `doWithFailover` (warm info/refs GET + all ServiceRPC POSTs) and in `doGet` (cold info/refs GET), factored into a shared `retryOn401` helper.
  - Bounded to **one auth retry per logical operation** via an `authRetried` flag in `doWithFailover`: a 401 doesn't trigger failover, so the loop hands the first 401 to the retry and never re-mints per replica.
  - Re-mint failure on the retry surfaces the mint error directly (no nil-token retry, no failover churn across healthy nodes that would poison the replica cache on a transient auth-provider outage).
  - `ENTIRE_TOKEN` path works unchanged: `Invalidate` drops its in-process memo and the retry re-mints via the same fixed exchange — no special-casing.
  - The 401 body is drained (bounded, 1024 bytes) before close so the retry reuses the keep-alive connection.
- Update the bare-401 message: reaching it now means the automatic refresh-and-retry already failed, so it reads `authentication failed even after refreshing credentials - run 'entire login' if this persists` (`inforefs.go`).
- Bump auth-go to v0.5.2, picking up the tokenmanager persist-retry fix (https://github.com/entireio/auth-go/pull/17); v0.5.2 additionally carries `ForceRefresh` (https://github.com/entireio/auth-go/pull/19), unused here: rotated refresh tokens are no longer discarded on a transient keyring write failure, which was the lost-rotation mode behind the forced morning re-logins. Folded in here (replacing https://github.com/entireio/cli/pull/1659) so git-remote-entire ships both halves of the 401/refresh hardening together.

## Verification

- `go test ./internal/remotehelper/... ./cmd/git-remote-entire/... ./cmd/entire/cli/auth/...` — all pass on the bumped module.
- New tests in `internal/remotehelper/transport`: 401-once-then-success (exactly two attempts, POST body replayed verbatim, retry carries a fresh token); persistent 401 (exactly two attempts, then the refreshed-credentials error); re-mint failure (mint error surfaced, no second dial); plus an info/refs GET variant.
- `mise run lint` — 0 issues.

## Note on #1657

https://github.com/entireio/cli/pull/1657 reworded the same bare-401 line; it has been closed as superseded by this PR (the automatic retry makes its "retry the command" phrasing obsolete).

