### PR TITLE
deps: bump auth-go to v0.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/entireio/auth-go v0.5.0
+	github.com/entireio/auth-go v0.5.1
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
 	github.com/go-git/go-billy/v6 v6.0.0-alpha.1.0.20260519112248-0095b064a6c6

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/entireio/auth-go v0.5.0 h1:omda1kFqyxrxxzDHtb9HH2ObgCaDUz8P2HQK+3g1QLg=
-github.com/entireio/auth-go v0.5.0/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
+github.com/entireio/auth-go v0.5.1 h1:V72PnApZRGtg5+691YcaokNR7Jpda7OrBEL8g9ge2XY=
+github.com/entireio/auth-go v0.5.1/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/fatih/semgroup v1.2.0 h1:h/OLXwEM+3NNyAdZEpMiH1OzfplU09i2qXPVThGZvyg=


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/780
<!-- entire-trail-link-end -->

## Why
v0.5.1 fixes a lost-rotation failure mode: tokenmanager now retries persisting rotated credentials after a successful refresh grant instead of discarding them on the first keyring failure (https://github.com/entireio/auth-go/pull/17). Previously the OS keychain could keep a consumed refresh token, and the server's reuse detection would later revoke the whole session — forcing an `entire login` the next morning. `git-remote-entire` and `entire` pick the fix up via this bump.

## What
- `go get github.com/entireio/auth-go@v0.5.1` + `go mod tidy` (go.mod/go.sum only)

## Verification
- `go test ./cmd/entire/cli/auth/... ./internal/entireclient/... ./cmd/git-remote-entire/...` — all pass
- `mise run lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only go.mod/go.sum change; behavior change is confined to the auth-go library’s token refresh/keyring retry logic, with tests already run per the PR description.
> 
> **Overview**
> Bumps **`github.com/entireio/auth-go`** from **v0.5.0** to **v0.5.1** in `go.mod` / `go.sum` only—no application code changes in this repo.
> 
> That release fixes a **lost-rotation** path in token refresh: after a successful refresh grant, rotated credentials are **retried on keyring persist** instead of being dropped on the first failure. Without it, the OS keychain could keep a consumed refresh token while the server had already rotated, which could trigger reuse detection, revoke the session, and force **`entire login`** again. **`entire`** and **`git-remote-entire`** pick up the fix transitively through this dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906086cd1b0c6bdaae3485ad7d119c54cab75b4d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->