### PR TITLE
cli: render mirror poll 404 cleanly and widen poll retry budget

### DIFF
--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -335,10 +335,13 @@ func reportOneShotMirror(out, errW io.Writer, outcome mirrorCreateOutcome, err e
 		return fmt.Errorf("initial clone of mirror %s failed", created.MirrorId)
 	case coreapi.MirrorStatusProcessing:
 		// Still processing when the poll returned: the wait timed out (or a
-		// transport error broke the poll). awaitMirrorReady's err carries which.
-		return err
+		// poll call errored). awaitMirrorReady's err carries which. Route it
+		// through renderCoreError so an API error (e.g. a 404 problem+json)
+		// renders as the server's Detail rather than ogen's raw decoded struct;
+		// a timeout error passes through unchanged.
+		return renderCoreError(err)
 	default:
-		return err
+		return renderCoreError(err)
 	}
 }
 

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -615,11 +615,16 @@ func createOneMirror(ctx context.Context, t mirrorTarget, c *coreapi.Client, cli
 
 	// nonTerminal classifies a still-processing/unknown result: the poll ended
 	// without a terminal status, so the wait timed out or a poll call errored.
+	// A poll that errored carries an ogen API error (e.g. a 404 problem+json);
+	// route it through renderCoreError so it renders as the server's Detail
+	// ("mirror not found") instead of the raw decoded struct — the same
+	// treatment the create-failure branch above gives its error. A timeout
+	// error isn't an API error, so renderCoreError passes it through unchanged.
 	nonTerminal := func() {
 		if errors.Is(err, context.DeadlineExceeded) {
 			res.status, res.err = mirrorStatusTimedOut, err
 		} else {
-			res.status, res.err = mirrorStatusError, err
+			res.status, res.err = mirrorStatusError, renderCoreError(err)
 		}
 	}
 	switch outcome.status {

--- a/cmd/entire/cli/repo_mirror_create_wizard_test.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,6 +41,59 @@ func TestCreateOneMirror_Suspended(t *testing.T) {
 	require.Equal(t, mirrorStatusSuspended, final)
 	require.False(t, finalOK)
 	require.Equal(t, []string{mirrorsAPIPath}, *paths, "suspended must not poll GetMirror")
+}
+
+// TestCreateOneMirror_PollErrorRendersCleanDetail pins the fix for a create
+// that succeeds but whose readiness poll keeps 404ing (the us-east-2 symptom:
+// CreateMirror returns a placement + clone URL, but GetMirror on it reports
+// "mirror not found"). The per-mirror error must render the server's problem
+// Detail, not ogen's raw decoded ErrorModel struct — so it goes through
+// renderCoreError like the create-failure branch, and the clone URL is still
+// captured from the successful create.
+//
+// Not parallel: shortens the package-level mirrorPollInterval.
+func TestCreateOneMirror_PollErrorRendersCleanDetail(t *testing.T) {
+	prev := mirrorPollInterval
+	mirrorPollInterval = time.Millisecond
+	t.Cleanup(func() { mirrorPollInterval = prev })
+	ctx := t.Context()
+
+	created := &coreapi.CreatedMirror{Created: true, MirrorId: "m1", MirrorUrl: "entire://c/gh/o/r"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == mirrorsAPIPath:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			if err := printJSON(w, created); err != nil {
+				t.Errorf("encode created response: %v", err)
+			}
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/mirrors/"):
+			// The status poll can't find the placement the create just returned.
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.WriteHeader(http.StatusNotFound)
+			if _, err := w.Write([]byte(`{"title":"Not Found","detail":"mirror not found","status":404}`)); err != nil {
+				t.Errorf("write problem response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := coreapi.NewWithBearer(srv.URL, "tok")
+	require.NoError(t, err)
+
+	target := mirrorTarget{owner: "o", repo: "r", region: regionChoice{host: "c"}}
+	res := createOneMirror(ctx, target, c, nil, false, time.Second, nil)
+
+	require.Equal(t, mirrorStatusError, res.status)
+	require.Equal(t, "entire://c/gh/o/r", res.cloneURL, "a successful create still yields the clone URL")
+	require.Error(t, res.err)
+	require.EqualError(t, res.err, "mirror not found", "must render the server's problem Detail")
+	// Guard against ogen's raw `code 404: {Schema:... Set:true}` struct dump leaking.
+	require.NotContains(t, res.err.Error(), "Set:", "must not leak the decoded ErrorModel struct")
+	require.NotContains(t, res.err.Error(), "decode response")
+	require.NotContains(t, res.err.Error(), "code 404")
 }
 
 func TestRunMirrorCreateWizard_RequiresTTY(t *testing.T) {

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -68,11 +68,19 @@ func parseGitHubURL(rawURL string) (owner, repo string, err error) {
 var mirrorPollInterval = 2 * time.Second
 
 // maxConsecutivePollErrors bounds how many back-to-back GetMirror failures the
-// clone wait tolerates before giving up. A brief network/API glitch during a
-// long initial clone shouldn't fail the create, but a persistent error
-// (deleted mirror, revoked auth) should surface rather than spin to the
-// deadline. The counter resets on any successful poll.
-const maxConsecutivePollErrors = 5
+// clone wait tolerates before giving up. Two failure modes share this budget: a
+// brief network/API glitch during a long clone, and — the common one — the
+// stale-read window right after create, where the control plane returns 404
+// "mirror not found" because the just-written repo#list grant / placement row
+// isn't yet visible to the region's minimize_latency + follower reads (~4.8s
+// nominal, but it spikes under concurrent multi-region creates). At the 2s
+// cadence, 15 tolerated errors ≈ 30s — enough to ride out that window, while a
+// genuinely persistent error (deleted mirror, revoked auth) still surfaces well
+// before the 30m --wait-timeout. This is a stopgap: the durable fix is
+// server-side, making GetMirror check the grant fully-consistent and read the
+// row from the CRDB leaseholder so a fresh mirror is visible on the first poll.
+// The counter resets on any successful poll.
+const maxConsecutivePollErrors = 15
 
 var (
 	// errMirrorCloneFailed reports the mirror's initial clone reached the


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/781
<!-- entire-trail-link-end -->

Creating a mirror in a region can succeed (201 + clone URL) yet have the status poll 404 for a few seconds: the just-written repo#list grant / placement row isn't yet visible to the region's minimize_latency + follower reads (~4.8s, worse under concurrent multi-region creates). The CLI surfaced that as a raw ogen ErrorModel struct dump and gave up after only ~8s.

- Route the poll-failure error through renderCoreError in both the wizard (createOneMirror) and one-shot (reportOneShotMirror) paths, so a 404 renders as the server's "mirror not found" Detail, not the struct dump.
- Raise maxConsecutivePollErrors 5 -> 15 (~8s -> ~30s at the 2s cadence) to ride out the stale-read window. Stopgap; the durable fix is server-side fresh reads on GetMirror.
- Add a regression test that a poll 404 renders the clean Detail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only error formatting and poll retry tuning for mirror create; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes mirror create flows where **CreateMirror succeeds** but **GetMirror** readiness polls briefly return **404** (stale placement/grant reads). Users no longer see ogen’s raw **ErrorModel** dump; poll failures go through **`renderCoreError`** in both **`reportOneShotMirror`** (one-shot create) and **`createOneMirror`** (wizard), so problem+json **detail** (e.g. `mirror not found`) is shown. Timeout errors are unchanged.
> 
> **`maxConsecutivePollErrors`** rises **5 → 15** (~8s → ~30s at the 2s poll interval) so transient post-create 404s can clear before the CLI gives up; documented as a client stopgap until server-side consistent reads on **GetMirror**.
> 
> Adds **`TestCreateOneMirror_PollErrorRendersCleanDetail`** to lock in clean error text and preserved clone URL after a successful create.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1b973ad9ef2b45e918d085d1d53bce72cc0155. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->