### PR TITLE
feat: select checkpoint backend via --checkpoint-backend on enable/configure

### DIFF
--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -139,12 +139,8 @@ func primaryConfig(cfg *settings.CheckpointsConfig) json.RawMessage {
 // the primary's record through the repo and its refs, so a non-git-backed
 // primary is rejected rather than silently half-supported.
 func buildPrimary(ctx context.Context, env OpenEnv, typ string, raw json.RawMessage) (PersistentStore, error) {
-	b, err := lookupBackend(typ)
-	if err != nil {
+	if err := ValidatePrimaryBackend(typ); err != nil {
 		return nil, fmt.Errorf("checkpoints.primary: %w", err)
-	}
-	if !b.gitBacked {
-		return nil, fmt.Errorf("checkpoints.primary.type %q cannot be the primary: only git-backed backends (e.g. %q) may be the primary", typ, BackendTypeGitBranch)
 	}
 	return build(ctx, env, typ, raw)
 }

--- a/cmd/entire/cli/checkpoint/registry.go
+++ b/cmd/entire/cli/checkpoint/registry.go
@@ -93,6 +93,24 @@ func lookupBackend(typ string) (registeredBackend, error) {
 	return b, nil
 }
 
+// ValidatePrimaryBackend reports an error unless typ names a registered backend
+// that may serve as the primary. Only git-backed backends qualify: a
+// non-git-backed or unknown type is rejected with a descriptive message that
+// names the valid types. This is the single source of the "primary must be
+// git-backed" rule — buildPrimary delegates here, and selection surfaces (entire
+// enable / configure --checkpoint-backend) call it to reject a bad backend
+// before writing it to settings, rather than failing later in Open.
+func ValidatePrimaryBackend(typ string) error {
+	b, err := lookupBackend(typ)
+	if err != nil {
+		return err
+	}
+	if !b.gitBacked {
+		return fmt.Errorf("checkpoint backend %q cannot be the primary: only git-backed backends (e.g. %q, %q) may be the primary", typ, BackendTypeGitBranch, BackendTypeGitRefs)
+	}
+	return nil
+}
+
 // build constructs the store for the named backend type.
 func build(ctx context.Context, env OpenEnv, typ string, cfg json.RawMessage) (PersistentStore, error) {
 	b, err := lookupBackend(typ)

--- a/cmd/entire/cli/checkpoint/registry.go
+++ b/cmd/entire/cli/checkpoint/registry.go
@@ -94,12 +94,13 @@ func lookupBackend(typ string) (registeredBackend, error) {
 }
 
 // ValidatePrimaryBackend reports an error unless typ names a registered backend
-// that may serve as the primary. Only git-backed backends qualify: a
-// non-git-backed or unknown type is rejected with a descriptive message that
-// names the valid types. This is the single source of the "primary must be
-// git-backed" rule — buildPrimary delegates here, and selection surfaces (entire
-// enable / configure --checkpoint-backend) call it to reject a bad backend
-// before writing it to settings, rather than failing later in Open.
+// that may serve as the primary. An unknown type is rejected with an error
+// listing the registered backend types; a registered but non-git-backed type is
+// rejected separately, since only git-backed backends may be the primary. This
+// is the single source of the "primary must be git-backed" rule — buildPrimary
+// delegates here, and selection surfaces (entire enable / configure
+// --checkpoint-backend) call it to reject a bad backend before writing it to
+// settings, rather than failing later in Open.
 func ValidatePrimaryBackend(typ string) error {
 	b, err := lookupBackend(typ)
 	if err != nil {

--- a/cmd/entire/cli/checkpoint/registry_test.go
+++ b/cmd/entire/cli/checkpoint/registry_test.go
@@ -37,6 +37,39 @@ func TestRegistry_UnknownType(t *testing.T) {
 	assert.Contains(t, err.Error(), BackendTypeGitBranch)
 }
 
+func TestValidatePrimaryBackend_GitBackedTypesAllowed(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidatePrimaryBackend(BackendTypeGitBranch))
+	require.NoError(t, ValidatePrimaryBackend(BackendTypeGitRefs))
+}
+
+func TestValidatePrimaryBackend_UnknownTypeRejected(t *testing.T) {
+	t.Parallel()
+
+	err := ValidatePrimaryBackend("definitely-not-a-backend")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown checkpoint backend type "definitely-not-a-backend"`)
+	// The error lists registered types so a typo is debuggable.
+	assert.Contains(t, err.Error(), BackendTypeGitBranch)
+}
+
+func TestValidatePrimaryBackend_NonGitBackedRejected(t *testing.T) {
+	t.Parallel()
+
+	// Register a mirror-only (non-git-backed) backend and confirm it cannot be the
+	// primary. The unique type name avoids colliding with the built-ins.
+	const typ = "test-mirror-only-primary-check"
+	Register(typ, func(context.Context, OpenEnv, json.RawMessage) (PersistentStore, error) {
+		return nil, nil //nolint:nilnil // never constructed; validation fails before build
+	})
+
+	err := ValidatePrimaryBackend(typ)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be the primary")
+	assert.Contains(t, err.Error(), BackendTypeGitRefs)
+}
+
 func TestRegistry_GitBranchFactoryIgnoresConfig(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/checkpoint_backend.go
+++ b/cmd/entire/cli/checkpoint_backend.go
@@ -110,10 +110,14 @@ func updateCheckpointBackend(ctx context.Context, w io.Writer, opts EnableOption
 // promptCheckpointBackend asks the user to choose a checkpoint storage backend
 // during first-time interactive setup. The default is the git-branch backend;
 // the git-refs backend is offered as the selectable alternative. It returns the
-// canonical backend type, or "" when the user kept the default so the caller can
-// skip writing a redundant config block. Callers must gate this on an
-// interactive terminal.
-func promptCheckpointBackend() (string, error) {
+// canonical backend type, or "" when the user kept the default (or cancelled) so
+// the caller can skip writing a redundant config block. Callers must gate this
+// on an interactive terminal.
+//
+// Cancellation (Ctrl+C or a cancelled ctx) is treated like keeping the default:
+// it prints a "cancelled" line and returns ("", nil) so enable continues with
+// the default backend, matching the optional-prompt behavior elsewhere in setup.
+func promptCheckpointBackend(ctx context.Context, w io.Writer) (string, error) {
 	choice := checkpoint.BackendTypeGitBranch
 	form := NewAccessibleForm(
 		huh.NewGroup(
@@ -127,8 +131,8 @@ func promptCheckpointBackend() (string, error) {
 				Value(&choice),
 		),
 	)
-	if err := form.Run(); err != nil {
-		return "", fmt.Errorf("checkpoint backend selection: %w", err)
+	if err := form.RunWithContext(ctx); err != nil {
+		return "", handleFormCancellation(w, "Checkpoint backend selection", err)
 	}
 	if choice == checkpoint.BackendTypeGitBranch {
 		return "", nil

--- a/cmd/entire/cli/checkpoint_backend.go
+++ b/cmd/entire/cli/checkpoint_backend.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"charm.land/huh/v2"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// Friendly aliases for the two selectable checkpoint backends. Users type these
+// on --checkpoint-backend; they map to the canonical backend types stored in
+// settings (checkpoint.BackendTypeGitBranch / checkpoint.BackendTypeGitRefs).
+const (
+	checkpointBackendBranchAlias = "branch"
+	checkpointBackendRefsAlias   = "refs"
+)
+
+// resolveCheckpointBackendType maps a user-facing backend name to the canonical
+// settings backend type and validates it may serve as the primary. It accepts
+// the friendly aliases "branch"/"refs" and the canonical "git-branch"/"git-refs"
+// (case-insensitive). An unknown or non-git-backed value is rejected via the
+// checkpoint registry, so the error text stays in sync with the backend list.
+func resolveCheckpointBackendType(name string) (string, error) {
+	typ := strings.ToLower(strings.TrimSpace(name))
+	switch typ {
+	case checkpointBackendBranchAlias:
+		typ = checkpoint.BackendTypeGitBranch
+	case checkpointBackendRefsAlias:
+		typ = checkpoint.BackendTypeGitRefs
+	}
+	if err := checkpoint.ValidatePrimaryBackend(typ); err != nil {
+		return "", fmt.Errorf("invalid --%s: %w", flagCheckpointBackend, err)
+	}
+	return typ, nil
+}
+
+// applyCheckpointBackend sets the primary checkpoint backend on settings,
+// preserving any existing mirrors except one whose type would collide with the
+// new primary (the one-of-each-type topology rule enforced in checkpoint.Open).
+// Switching the primary on an existing repo is safe: new checkpoints use the new
+// backend while read routing keeps prior checkpoints readable in their original
+// format.
+func applyCheckpointBackend(s *EntireSettings, typ string) {
+	cfg := s.Checkpoints
+	if cfg == nil {
+		cfg = &settings.CheckpointsConfig{}
+	}
+	cfg.Primary = settings.BackendConfig{Type: typ}
+	cfg.Mirrors = slices.DeleteFunc(cfg.Mirrors, func(m settings.BackendConfig) bool {
+		return m.Type == typ
+	})
+	s.Checkpoints = cfg
+}
+
+// applyCheckpointBackendFlag resolves and applies a --checkpoint-backend value to
+// settings when it is non-empty; a no-op otherwise. Used by the fresh-repo enable
+// paths (interactive setup and --agent), which mutate an in-memory settings
+// object before their own save. Existing-repo enable and configure use
+// updateCheckpointBackend instead.
+func applyCheckpointBackendFlag(s *EntireSettings, backend string) error {
+	if backend == "" {
+		return nil
+	}
+	typ, err := resolveCheckpointBackendType(backend)
+	if err != nil {
+		return err
+	}
+	applyCheckpointBackend(s, typ)
+	return nil
+}
+
+// updateCheckpointBackend persists opts.CheckpointBackend to the target settings
+// file. Used by `entire configure` and by `entire enable` on repos that are
+// already set up (both operate on an on-disk file rather than the in-memory
+// settings the fresh-setup flow builds).
+func updateCheckpointBackend(ctx context.Context, w io.Writer, opts EnableOptions) error {
+	typ, err := resolveCheckpointBackendType(opts.CheckpointBackend)
+	if err != nil {
+		return err
+	}
+
+	targetFile, configDisplay := settingsTargetFile(ctx, opts.UseLocalSettings, opts.UseProjectSettings)
+	targetFileAbs, err := paths.AbsPath(ctx, targetFile)
+	if err != nil {
+		targetFileAbs = targetFile
+	}
+
+	s, err := settings.LoadFromFile(targetFileAbs)
+	if err != nil {
+		return fmt.Errorf("failed to load settings: %w", err)
+	}
+
+	applyCheckpointBackend(s, typ)
+
+	if err := saveSettingsToTarget(ctx, s, targetFile); err != nil {
+		return fmt.Errorf("failed to save settings: %w", err)
+	}
+
+	fmt.Fprintf(w, "✓ Checkpoint backend set to %s (%s)\n", typ, configDisplay)
+	return nil
+}
+
+// promptCheckpointBackend asks the user to choose a checkpoint storage backend
+// during first-time interactive setup. The default is the git-branch backend;
+// the git-refs backend is offered as the selectable alternative. It returns the
+// canonical backend type, or "" when the user kept the default so the caller can
+// skip writing a redundant config block. Callers must gate this on an
+// interactive terminal.
+func promptCheckpointBackend() (string, error) {
+	choice := checkpoint.BackendTypeGitBranch
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Checkpoint storage backend").
+				Description("How Entire stores committed session checkpoints in your repo.").
+				Options(
+					huh.NewOption("Branch — one shared branch, entire/checkpoints/v1 (default)", checkpoint.BackendTypeGitBranch),
+					huh.NewOption("Refs — one git ref per checkpoint (experimental)", checkpoint.BackendTypeGitRefs),
+				).
+				Value(&choice),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return "", fmt.Errorf("checkpoint backend selection: %w", err)
+	}
+	if choice == checkpoint.BackendTypeGitBranch {
+		return "", nil
+	}
+	return choice, nil
+}

--- a/cmd/entire/cli/checkpoint_backend_test.go
+++ b/cmd/entire/cli/checkpoint_backend_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+func TestResolveCheckpointBackendType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: "branch", want: checkpoint.BackendTypeGitBranch},
+		{in: "refs", want: checkpoint.BackendTypeGitRefs},
+		{in: "git-branch", want: checkpoint.BackendTypeGitBranch},
+		{in: "git-refs", want: checkpoint.BackendTypeGitRefs},
+		{in: "  REFS  ", want: checkpoint.BackendTypeGitRefs}, // trimmed + case-insensitive
+		{in: "Branch", want: checkpoint.BackendTypeGitBranch},
+		{in: "", wantErr: true},
+		{in: "bogus", wantErr: true},
+	}
+	for _, tc := range tests {
+		got, err := resolveCheckpointBackendType(tc.in)
+		if tc.wantErr {
+			require.Error(t, err, "input %q", tc.in)
+			continue
+		}
+		require.NoError(t, err, "input %q", tc.in)
+		assert.Equal(t, tc.want, got, "input %q", tc.in)
+	}
+}
+
+func TestApplyCheckpointBackend_SetsPrimaryFromNil(t *testing.T) {
+	t.Parallel()
+
+	s := &EntireSettings{}
+	applyCheckpointBackend(s, checkpoint.BackendTypeGitRefs)
+
+	require.NotNil(t, s.Checkpoints)
+	assert.Equal(t, checkpoint.BackendTypeGitRefs, s.Checkpoints.Primary.Type)
+	assert.Empty(t, s.Checkpoints.Mirrors)
+}
+
+func TestApplyCheckpointBackend_PreservesUnrelatedMirror(t *testing.T) {
+	t.Parallel()
+
+	s := &EntireSettings{Checkpoints: &settings.CheckpointsConfig{
+		Primary: settings.BackendConfig{Type: checkpoint.BackendTypeGitBranch},
+		Mirrors: []settings.BackendConfig{{Type: "fs"}},
+	}}
+	applyCheckpointBackend(s, checkpoint.BackendTypeGitRefs)
+
+	assert.Equal(t, checkpoint.BackendTypeGitRefs, s.Checkpoints.Primary.Type)
+	require.Len(t, s.Checkpoints.Mirrors, 1)
+	assert.Equal(t, "fs", s.Checkpoints.Mirrors[0].Type)
+}
+
+func TestApplyCheckpointBackend_DropsCollidingMirror(t *testing.T) {
+	t.Parallel()
+
+	// A git-refs mirror alongside a git-branch primary is valid; promoting the
+	// primary to git-refs would collide (one-of-each-type), so the mirror is dropped.
+	s := &EntireSettings{Checkpoints: &settings.CheckpointsConfig{
+		Primary: settings.BackendConfig{Type: checkpoint.BackendTypeGitBranch},
+		Mirrors: []settings.BackendConfig{{Type: checkpoint.BackendTypeGitRefs}},
+	}}
+	applyCheckpointBackend(s, checkpoint.BackendTypeGitRefs)
+
+	assert.Equal(t, checkpoint.BackendTypeGitRefs, s.Checkpoints.Primary.Type)
+	assert.Empty(t, s.Checkpoints.Mirrors, "mirror colliding with the new primary must be dropped")
+}
+
+func TestApplyCheckpointBackendFlag_EmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	s := &EntireSettings{}
+	require.NoError(t, applyCheckpointBackendFlag(s, ""))
+	assert.Nil(t, s.Checkpoints, "empty flag must not write a checkpoints block")
+}
+
+func TestApplyCheckpointBackendFlag_Invalid(t *testing.T) {
+	t.Parallel()
+
+	s := &EntireSettings{}
+	err := applyCheckpointBackendFlag(s, "bogus")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), flagCheckpointBackend)
+	assert.Nil(t, s.Checkpoints)
+}
+
+func TestUpdateCheckpointBackend_WritesAndReloads(t *testing.T) {
+	// Uses t.Chdir (process-global cwd), so no t.Parallel.
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	ctx := context.Background()
+
+	require.NoError(t, updateCheckpointBackend(ctx, io.Discard, EnableOptions{CheckpointBackend: "refs"}))
+
+	cfg, err := settings.LoadCheckpointsConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, checkpoint.BackendTypeGitRefs, cfg.Primary.Type)
+	assert.True(t, checkpoint.PrimaryIsRefs(cfg))
+
+	// Switching back to branch overrides the prior selection.
+	require.NoError(t, updateCheckpointBackend(ctx, io.Discard, EnableOptions{CheckpointBackend: "branch"}))
+	cfg, err = settings.LoadCheckpointsConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, checkpoint.BackendTypeGitBranch, cfg.Primary.Type)
+	assert.False(t, checkpoint.PrimaryIsRefs(cfg))
+}
+
+func TestUpdateCheckpointBackend_InvalidValue(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	err := updateCheckpointBackend(context.Background(), io.Discard, EnableOptions{CheckpointBackend: "bogus"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), flagCheckpointBackend)
+}

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -37,6 +37,7 @@ const (
 const (
 	agentFlagName            = "agent"
 	flagCheckpointRemote     = "checkpoint-remote"
+	flagCheckpointBackend    = "checkpoint-backend"
 	flagSkipPushSessions     = "skip-push-sessions"
 	flagSummarizeModel       = "summarize-model"
 	flagSummarizeAgent       = "summarize-provider"
@@ -58,12 +59,16 @@ const externalAgentsAutoEnabledNotice = "Note: external agents are now enabled f
 
 // EnableOptions holds the flags for `entire enable`.
 type EnableOptions struct {
-	LocalDev            bool
-	UseLocalSettings    bool
-	UseProjectSettings  bool
-	ForceHooks          bool
-	SkipPushSessions    bool
-	CheckpointRemote    string
+	LocalDev           bool
+	UseLocalSettings   bool
+	UseProjectSettings bool
+	ForceHooks         bool
+	SkipPushSessions   bool
+	CheckpointRemote   string
+	// CheckpointBackend selects the persistent checkpoint storage backend
+	// ("branch"/"refs" or the canonical "git-branch"/"git-refs"). Empty leaves
+	// the current/default (git-branch) backend in place.
+	CheckpointBackend   string
 	Telemetry           bool
 	AbsoluteGitHookPath bool
 	// SuppressDoneMessage tells `runEnableInteractive` to skip its final
@@ -104,6 +109,10 @@ func hasStrategyFlags(cmd *cobra.Command) bool {
 	return cmd.Flags().Changed(flagCheckpointRemote) || cmd.Flags().Changed(flagSkipPushSessions)
 }
 
+func hasCheckpointBackendFlag(cmd *cobra.Command) bool {
+	return cmd.Flags().Changed(flagCheckpointBackend)
+}
+
 func hasSummaryProviderFlags(cmd *cobra.Command) bool {
 	return cmd.Flags().Changed(flagSummarizeAgent) || cmd.Flags().Changed(flagSummarizeModel)
 }
@@ -124,7 +133,7 @@ func hasGlobalSettingsFlags(cmd *cobra.Command) bool {
 // hasConfigureSettingsFlags reports whether configure was invoked with any
 // flag that mutates settings or hooks. Bare invocation prints help instead.
 func hasConfigureSettingsFlags(cmd *cobra.Command) bool {
-	return hasStrategyFlags(cmd) || hasSummaryProviderFlags(cmd) || hasSummaryTimeoutFlag(cmd) || hasGlobalSettingsFlags(cmd)
+	return hasStrategyFlags(cmd) || hasCheckpointBackendFlag(cmd) || hasSummaryProviderFlags(cmd) || hasSummaryTimeoutFlag(cmd) || hasGlobalSettingsFlags(cmd)
 }
 
 // enableUsesSetupFlow reports whether `entire enable` should delegate to the
@@ -132,7 +141,7 @@ func hasConfigureSettingsFlags(cmd *cobra.Command) bool {
 // Bare `enable` and `enable --local/--project` remain state-toggle operations;
 // any other setup-mutating flag should share configure's behavior.
 func enableUsesSetupFlow(cmd *cobra.Command, agentName string) bool {
-	if agentName != "" || hasStrategyFlags(cmd) || cmd.Flags().Changed(flagSearchSkill) || cmd.Flags().Changed(flagAgentHelpSkill) {
+	if agentName != "" || hasStrategyFlags(cmd) || hasCheckpointBackendFlag(cmd) || cmd.Flags().Changed(flagSearchSkill) || cmd.Flags().Changed(flagAgentHelpSkill) {
 		return true
 	}
 	return hasGlobalSettingsFlags(cmd) || cmd.Flags().Changed("yes")
@@ -713,6 +722,7 @@ Examples:
   entire configure --absolute-git-hook-path       # Reinstall git hook with absolute path
   entire configure --force                        # Reinstall git hook
   entire configure --checkpoint-remote github:org/checkpoints
+  entire configure --checkpoint-backend refs      # Store each checkpoint as its own git ref
   entire configure --summarize-provider claude-code
   entire configure --summarize-timeout-seconds 300   # 5m deadline for explain --generate`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -743,6 +753,11 @@ Examples:
 					return err
 				}
 			}
+			if hasCheckpointBackendFlag(cmd) {
+				if err := updateCheckpointBackend(ctx, cmd.OutOrStdout(), opts); err != nil {
+					return err
+				}
+			}
 			if hasSummaryProviderFlags(cmd) {
 				if err := updateSummaryGenerationSettings(ctx, cmd.OutOrStdout(), summarizeProvider, summarizeModel, opts); err != nil {
 					return err
@@ -769,6 +784,7 @@ Examples:
 	cmd.Flags().BoolVarP(&opts.ForceHooks, flagForce, "f", false, "Reinstall the Entire git hook")
 	cmd.Flags().BoolVar(&opts.SkipPushSessions, flagSkipPushSessions, false, "Disable automatic pushing of session logs on git push")
 	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
+	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", "Checkpoint storage backend: branch (default) or refs (one git ref per checkpoint)")
 	cmd.Flags().StringVar(&summarizeProvider, flagSummarizeAgent, "", "Set the provider used by explain --generate (e.g., claude-code, codex, gemini, pi, cursor, copilot-cli)")
 	cmd.Flags().StringVar(&summarizeModel, flagSummarizeModel, "", "Set the model hint used by explain --generate")
 	cmd.Flags().IntVar(&summarizeTimeoutSeconds, flagSummarizeTimeout, 0, "Set the hard deadline (seconds) for explain --generate summary generation. 0 clears (falls back to 5m default).")
@@ -808,6 +824,16 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 				}
 				reportRepoEnabled(ctx, insecureHTTPAuth)
 			}()
+
+			// Validate --checkpoint-backend up front so a bad value fails before we
+			// bootstrap a repo or install any hooks.
+			if hasCheckpointBackendFlag(cmd) {
+				if _, err := resolveCheckpointBackendType(opts.CheckpointBackend); err != nil {
+					cmd.SilenceUsage = true
+					return err
+				}
+			}
+
 			// Check if we're in a git repository first. If not, offer to
 			// bootstrap one (git init + optional GitHub repo). If the user
 			// declines, fall back to the legacy prerequisite error.
@@ -886,34 +912,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 			// Any setup-mutating flags should behave like `configure` on repos that
 			// are already set up. Bare `enable` remains the lightweight re-enable path.
 			if settings.IsSetUpAny(ctx) {
-				usedSetupFlow := enableUsesSetupFlow(cmd, agentName)
-				if usedSetupFlow {
-					if hasStrategyFlags(cmd) {
-						if err := updateStrategyOptions(ctx, cmd.OutOrStdout(), opts); err != nil {
-							return err
-						}
-					}
-					if enableNeedsAgentManagement(cmd) {
-						var selectFn func(available []string) ([]string, error)
-						if opts.Yes {
-							selectFn = selectAllAgents
-						}
-						if err := runManageAgents(ctx, cmd.OutOrStdout(), opts, selectFn); err != nil {
-							return err
-						}
-					}
-				}
-
-				enabled, err := IsEnabled(ctx)
-				if err == nil && enabled {
-					w := cmd.OutOrStdout()
-					if !usedSetupFlow {
-						fmt.Fprintln(w, "Entire is already enabled.")
-					}
-					printEnabledStatus(ctx, w)
-					return nil
-				}
-				return runEnable(ctx, cmd.OutOrStdout(), opts.UseProjectSettings)
+				return runEnableOnConfiguredRepo(ctx, cmd, opts)
 			}
 
 			// Fresh repo — run full setup flow
@@ -931,6 +930,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	cmd.Flags().BoolVarP(&opts.ForceHooks, flagForce, "f", false, "Force reinstall hooks (removes existing Entire hooks first)")
 	cmd.Flags().BoolVar(&opts.SkipPushSessions, flagSkipPushSessions, false, "Disable automatic pushing of session logs on git push")
 	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
+	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", "Checkpoint storage backend: branch (default) or refs (one git ref per checkpoint)")
 	cmd.Flags().BoolVar(&opts.Telemetry, flagTelemetry, true, "Enable anonymous usage analytics")
 	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
 	cmd.Flags().BoolVar(&opts.SearchSkill, flagSearchSkill, false, "Install the optional Entire search skill for selected agent(s)")
@@ -1081,6 +1081,46 @@ To completely remove Entire integrations from this repository, use --uninstall:
 
 // runEnableInteractive runs the interactive enable flow.
 // agents must be provided by the caller (via detectOrSelectAgent).
+// runEnableOnConfiguredRepo handles `entire enable` when the repo is already set
+// up. Setup-mutating flags (strategy options, checkpoint backend, agent
+// management) behave like `configure`; a bare re-enable just flips the enabled
+// flag or reports current status.
+func runEnableOnConfiguredRepo(ctx context.Context, cmd *cobra.Command, opts EnableOptions) error {
+	w := cmd.OutOrStdout()
+	usedSetupFlow := enableUsesSetupFlow(cmd, "")
+	if usedSetupFlow {
+		if hasStrategyFlags(cmd) {
+			if err := updateStrategyOptions(ctx, w, opts); err != nil {
+				return err
+			}
+		}
+		if hasCheckpointBackendFlag(cmd) {
+			if err := updateCheckpointBackend(ctx, w, opts); err != nil {
+				return err
+			}
+		}
+		if enableNeedsAgentManagement(cmd) {
+			var selectFn func(available []string) ([]string, error)
+			if opts.Yes {
+				selectFn = selectAllAgents
+			}
+			if err := runManageAgents(ctx, w, opts, selectFn); err != nil {
+				return err
+			}
+		}
+	}
+
+	enabled, err := IsEnabled(ctx)
+	if err == nil && enabled {
+		if !usedSetupFlow {
+			fmt.Fprintln(w, "Entire is already enabled.")
+		}
+		printEnabledStatus(ctx, w)
+		return nil
+	}
+	return runEnable(ctx, w, opts.UseProjectSettings)
+}
+
 func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent, opts EnableOptions) error {
 	// Capture first-run status before we write any settings: setupEntireDirectory
 	// and saveSettings below make IsSetUpAny report true. maybeOfferSessionImport
@@ -1134,6 +1174,20 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 	}
 
 	opts.applyStrategyOptions(settings)
+
+	// Checkpoint storage backend. An explicit --checkpoint-backend always wins.
+	// Otherwise, on the first interactive setup, offer a choice (default: branch).
+	// Non-interactive or --yes first runs keep the default git-branch backend.
+	if opts.CheckpointBackend == "" && firstRun && !opts.Yes && interactive.CanPromptInteractively() {
+		chosen, err := promptCheckpointBackend()
+		if err != nil {
+			return err
+		}
+		opts.CheckpointBackend = chosen // "" keeps the default backend
+	}
+	if err := applyCheckpointBackendFlag(settings, opts.CheckpointBackend); err != nil {
+		return err
+	}
 
 	// Determine which settings file to write to
 	// First run always creates settings.json (no prompt)
@@ -1632,6 +1686,11 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 	}
 
 	opts.applyStrategyOptions(settings)
+
+	// Apply an explicit --checkpoint-backend (no prompt on this non-interactive path).
+	if err := applyCheckpointBackendFlag(settings, opts.CheckpointBackend); err != nil {
+		return err
+	}
 
 	// Handle telemetry for non-interactive mode
 	// Note: if telemetry is nil (not configured), it defaults to disabled

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1179,11 +1179,11 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 	// Otherwise, on the first interactive setup, offer a choice (default: branch).
 	// Non-interactive or --yes first runs keep the default git-branch backend.
 	if opts.CheckpointBackend == "" && firstRun && !opts.Yes && interactive.CanPromptInteractively() {
-		chosen, err := promptCheckpointBackend()
+		chosen, err := promptCheckpointBackend(ctx, w)
 		if err != nil {
 			return err
 		}
-		opts.CheckpointBackend = chosen // "" keeps the default backend
+		opts.CheckpointBackend = chosen // "" keeps the default (or cancelled) backend
 	}
 	if err := applyCheckpointBackendFlag(settings, opts.CheckpointBackend); err != nil {
 		return err


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/782
<!-- entire-trail-link-end -->

## Summary

The git-refs checkpoint backend was already fully wired to *run*, but had no config **writer** — it could only be turned on via `ENTIRE_CHECKPOINTS_PRIMARY` or by hand-editing `.entire/settings.json`. This adds a simple selection path for both an existing repo and initial enable.

## What's new

- **`--checkpoint-backend branch|refs`** (also accepts canonical `git-branch`/`git-refs`) on both `entire enable` and `entire configure`.
  - Covers fresh repos, the `--agent` non-interactive path, and already-set-up repos (`enable` on a configured repo behaves like `configure`).
- **Interactive selector on first-time setup** — prompts for the backend, defaulting to **branch**. Choosing the default writes no config block, keeping `settings.json` pristine (an explicit flag always writes the block). Uses `NewAccessibleForm` so it respects `ACCESSIBLE=1`.
- **Up-front validation** — a bad value fails before any repo bootstrap / hook install, via a new `checkpoint.ValidatePrimaryBackend`, which is now the single source of the "primary must be git-backed" rule (`buildPrimary` delegates to it).
- **Safe primary switch** — preserves existing mirrors, dropping only one that would collide with the new primary (one-of-each-type rule). Existing hex-ID checkpoints stay readable via kind-routing; no migration needed.

## Verified

- Full `mise run check`: fmt clean, lint 0 issues, unit + 59 integration + 4 e2e canary tests pass.
- Exercised the real binary end-to-end: invalid value fails fast; `configure` before enable is rejected; refs written and round-tripped through `settings.json` and `--local`; downgrade back to branch overrides correctly; fresh enable without the flag writes no `checkpoints` block.

## Out of scope / follow-ups

- **Downgrade data-safety**: refs→branch mirror-push isn't implemented upstream yet, so switching *off* refs after pushing refs-format checkpoints has the known remote-visibility caveat.
- Docs (`sessions-and-checkpoints.md`) not updated — happy to add a short "selecting a backend" note if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how checkpoint data is stored for new sessions when users switch backends; validation is early but primary switches affect git checkpoint layout without automatic data migration.
> 
> **Overview**
> Adds a **config writer** for the primary checkpoint storage backend so users can pick **branch** (default) or **refs** without editing settings or env vars.
> 
> **`--checkpoint-backend branch|refs`** (and canonical `git-branch`/`git-refs`) is on **`entire enable`** and **`entire configure`**. Invalid values are rejected **before** repo bootstrap or hook install. **`checkpoint.ValidatePrimaryBackend`** is the single place that enforces “primary must be git-backed”; **`buildPrimary`** and the CLI both use it.
> 
> On **first interactive enable**, users get a backend picker (default branch leaves settings without a `checkpoints` block). Switching primary **drops only a mirror** that would collide on type; other mirrors stay. Already-configured repos use **`runEnableOnConfiguredRepo`** so enable with setup flags behaves like configure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e79baf6631e63460ca6f2d85fb5aa7260ba43de0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->