### PR TITLE
release: mirror stable tags to the nightly channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.release-type.outputs.prerelease }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -142,10 +144,55 @@ jobs:
           done
           exit $fail
 
-  notify-slack:
+  # A stable tag only refreshes the stable cask; the nightly channel would
+  # otherwise not catch up until the next scheduled nightly run cuts a tag from
+  # a *newer* commit (and create-nightly-tag.sh skips when HEAD already has a
+  # nightly). To ship the release on both channels immediately, cut a nightly
+  # tag from the exact stable commit and push it. That push re-triggers this
+  # workflow on the nightly-tag path, which uploads the entire@nightly cask.
+  mirror-nightly:
     runs-on: ubuntu-latest
     needs: [release]
-    if: ${{ always() && needs.release.result == 'failure' }}
+    # Only mirror stable releases. On a nightly-tag run the release job already
+    # published the nightly channel, so this would recurse — skip it there.
+    if: ${{ needs.release.result == 'success' && needs.release.outputs.prerelease == 'false' }}
+    steps:
+      # A cli-scoped GitHub App token (not the default GITHUB_TOKEN) so the tag
+      # push triggers a fresh workflow run — GITHUB_TOKEN pushes are suppressed
+      # to prevent recursion, which would leave the nightly cask un-uploaded.
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: cli
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Cut nightly tag from the stable commit
+        run: |
+          TAG=$(scripts/create-nightly-tag.sh) && EXIT_CODE=0 || EXIT_CODE=$?
+          if [ "$EXIT_CODE" -eq 2 ]; then
+            echo "Nightly already current for this commit — nothing to mirror."
+            exit 0
+          elif [ "$EXIT_CODE" -ne 0 ] || [ -z "$TAG" ]; then
+            echo "::error::Failed to generate nightly tag to mirror ${RELEASE_TAG}"
+            exit 1
+          fi
+          echo "Mirroring ${RELEASE_TAG} to nightly channel as ${TAG}"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs: [release, mirror-nightly]
+    if: ${{ always() && (needs.release.result == 'failure' || needs.mirror-nightly.result == 'failure') }}
     steps:
       - name: Notify Slack of release failure
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/785
<!-- entire-trail-link-end -->

## Problem

A stable tag only refreshes the **stable** Homebrew cask. The `entire@nightly` cask keeps pointing at the last nightly build, so after a stable release nightly users don't get the new code until the next 06:00 UTC cron run — and `create-nightly-tag.sh` *skips* when HEAD already has a nightly, so with no new commits they can sit on a build numbered *below* the just-shipped stable release indefinitely.

## Change

Adds a `mirror-nightly` job to `release.yml` that runs **only after a successful stable release** (`prerelease == 'false'`):

- Checks out the exact stable commit and runs the existing `scripts/create-nightly-tag.sh` to cut `v<next>-nightly.<date>.<stable-commit>`.
- Pushes it with a **`cli`-scoped GitHub App token** (not `GITHUB_TOKEN`) so the push re-triggers `release.yml` on the nightly-tag path, which uploads the `entire@nightly` cask built from the identical stable code.

## Flow

`push v0.5.5` → stable cask published → `mirror-nightly` pushes `v0.5.6-nightly.…<v0.5.5-commit>` → workflow re-runs (prerelease path) → `entire@nightly` cask published. Nightly users on `0.5.5-nightly.*` upgrade to `0.5.6-nightly.*` (semver-correct).

## Correctness notes

- **No recursion**: the re-triggered run is a prerelease tag, so `mirror-nightly`'s `if` is false there.
- **App token required**: a `GITHUB_TOKEN`-authored tag push is suppressed by GitHub, which would silently leave the nightly cask un-uploaded.
- **Idempotent**: if a nightly already points at the stable commit, `create-nightly-tag.sh` exits 2 and the step no-ops.
- **Clean channel identity**: the nightly binary stays `-nightly`-versioned, so `versioncheck` / `brew upgrade` keep those users on the nightly channel (avoids the pitfall of just flipping the cask's `skip_upload`).

## Tradeoff

Each stable release now runs GoReleaser twice (incl. a second macOS notarization pass) and creates one extra nightly GitHub release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and secret-scoped tag pushes; a misconfigured App token or `if` guard could leave nightly cask stale or cause extra GoReleaser/notarization runs, but stable release path logic is narrowly gated.
> 
> **Overview**
> After a **successful stable** release (`prerelease == 'false'`), a new **`mirror-nightly`** job checks out that tag, runs `scripts/create-nightly-tag.sh`, and pushes the resulting nightly tag so `release.yml` runs again on the prerelease path and refreshes **`entire@nightly`** from the same commit as stable.
> 
> The **`release`** job now exposes **`prerelease`** from the existing detect step so mirroring is skipped on nightly-tag runs (avoids recursion). Tag push uses a **`cli`-scoped GitHub App token** instead of `GITHUB_TOKEN` so GitHub actually triggers the follow-up workflow. Exit code **2** from the script is treated as idempotent no-op when a nightly already points at the commit.
> 
> **`notify-slack`** now depends on **`mirror-nightly`** and fires on failure of either **`release`** or **`mirror-nightly`** (not only release failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 187c90ec6dea2ce2c1bc58be2b16875fbe53b264. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->