### PR TITLE
feat(review): drop the default reviewer timeout — reviewers run until done

### DIFF
--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -250,7 +250,7 @@ To tag an already-finished session as a review, use
 	cmd.Flags().StringVar(&profileOverride, "profile", "", "review profile to run (default: review_default_profile or general)")
 	cmd.Flags().StringVar(&perRunPrompt, "prompt", "", "one-off instructions appended to this review run")
 	cmd.Flags().StringVar(&baseOverride, "base", "", "git ref to scope the review against (default: origin/HEAD → origin/main → origin/master → main → master)")
-	cmd.Flags().DurationVar(&reviewTimeout, "timeout", defaultReviewerTimeout, "max time each reviewer may run before it is cancelled and marked failed; also bounds the consolidating judge, whose timeout or error fails the review (0 disables both)")
+	cmd.Flags().DurationVar(&reviewTimeout, "timeout", 0, "optional hard cap per reviewer (default: none — reviewers run until they finish, like a skill invoked directly in a session). When set, it also bounds the consolidating judge; unset, the judge keeps its own 5m default")
 	// The listing modes and the action modes each select a distinct command
 	// behavior; combining them silently runs one and drops the rest, so reject
 	// the combination up front with a clear cobra error.
@@ -722,6 +722,19 @@ func resolveReviewerTimeoutArg(flagValue time.Duration) time.Duration {
 		return -1
 	}
 	return flagValue
+}
+
+// judgeTimeoutArg maps the resolved reviewer timeout to the judge's
+// ProviderTimeout three-state. The judge is a single text-generation call
+// with no event stream, so unlike reviewers it always keeps a bound: an
+// explicit --timeout governs it, otherwise the synthesis default (5m)
+// applies. The reviewer no-cap sentinel (negative) must not leak through —
+// it would disable the judge bound entirely.
+func judgeTimeoutArg(reviewerArg time.Duration) time.Duration {
+	if reviewerArg > 0 {
+		return reviewerArg
+	}
+	return 0
 }
 
 // runReview executes the main review flow.
@@ -1231,7 +1244,7 @@ func runMultiAgentPath(
 		profileName:       profileName,
 		task:              profile.Task,
 		masterName:        masterLabel,
-		judgeTimeout:      timeout,
+		judgeTimeout:      judgeTimeoutArg(timeout),
 		onSynthesisResult: func(result string) {
 			aggregateOutput = result
 		},

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -251,7 +251,7 @@ To tag an already-finished session as a review, use
 	cmd.Flags().StringVar(&profileOverride, "profile", "", "review profile to run (default: review_default_profile or general)")
 	cmd.Flags().StringVar(&perRunPrompt, "prompt", "", "one-off instructions appended to this review run")
 	cmd.Flags().StringVar(&baseOverride, "base", "", "git ref to scope the review against (default: origin/HEAD → origin/main → origin/master → main → master)")
-	cmd.Flags().DurationVar(&reviewTimeout, "timeout", 0, "optional hard cap per reviewer (default: none — reviewers run until they finish, like a skill invoked directly in a session). When set, it also bounds the consolidating judge; unset, the judge keeps its own 5m default")
+	cmd.Flags().DurationVar(&reviewTimeout, "timeout", 0, "optional hard cap per reviewer (default: none — reviewers run until they finish, like a skill invoked directly in a session). When set, it also bounds the consolidating judge; unset, the judge keeps its own 20m default")
 	// The listing modes and the action modes each select a distinct command
 	// behavior; combining them silently runs one and drops the rest, so reject
 	// the combination up front with a clear cobra error.
@@ -717,7 +717,7 @@ func reviewAgentNames(deps Deps) []string {
 // ProviderTimeout. The judge is a single text-generation call with no event
 // stream, so unlike reviewers it always keeps a bound: an explicit positive
 // --timeout governs it, anything else (unset, 0, or a negative like
-// `--timeout -5m`) maps to 0 so the synthesis default (5m) applies — a
+// `--timeout -5m`) maps to 0 so the synthesis default (20m) applies — a
 // reviewer-side "no cap" must never leak through as "judge unbounded".
 func judgeTimeoutArg(reviewerArg time.Duration) time.Duration {
 	return max(reviewerArg, 0)

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -223,13 +223,12 @@ To tag an already-finished session as a review, use
 			if findings {
 				return runReviewFindings(ctx, cmd, positionalArg, deps.NewSilentError)
 			}
-			// Map the flag to the RunConfig timeout convention: a non-positive
-			// value (the user passed --timeout 0) means "disable", encoded as the
-			// negative sentinel, which disables BOTH the per-reviewer bound and the
-			// judge's deadline. A positive value passes through and bounds both.
-			// (The flag's default is nonzero, so 0 only appears on --timeout 0.)
-			timeoutArg := resolveReviewerTimeoutArg(reviewTimeout)
-			return runReview(ctx, cmd, agentOverride, modelOverride, baseOverride, profileName, perRunPrompt, timeoutArg, deps)
+			// The flag flows through unmapped: RunConfig.ReviewerTimeout is
+			// two-state (positive = hard cap, anything else = no cap), so the
+			// default 0, an explicit --timeout 0, and a negative all mean
+			// "reviewers run until done". The judge derives its own bound via
+			// judgeTimeoutArg and is never uncapped.
+			return runReview(ctx, cmd, agentOverride, modelOverride, baseOverride, profileName, perRunPrompt, reviewTimeout, deps)
 		},
 	}
 	cmd.Flags().BoolVar(&configure, "configure", false, "set up a review profile; shows available agents and accepts --set-* flags for non-interactive config")
@@ -712,29 +711,14 @@ func reviewAgentNames(deps Deps) []string {
 	return names
 }
 
-// resolveReviewerTimeoutArg maps the --timeout flag value to the RunConfig
-// timeout convention used by reviewerTimeout and the judge's providerContext: a
-// non-positive value (the user passed --timeout 0) becomes the negative
-// "disabled" sentinel; a positive value passes through unchanged. The flag's
-// default is nonzero, so 0 only reaches here when the user explicitly set it.
-func resolveReviewerTimeoutArg(flagValue time.Duration) time.Duration {
-	if flagValue <= 0 {
-		return -1
-	}
-	return flagValue
-}
-
-// judgeTimeoutArg maps the resolved reviewer timeout to the judge's
-// ProviderTimeout three-state. The judge is a single text-generation call
-// with no event stream, so unlike reviewers it always keeps a bound: an
-// explicit --timeout governs it, otherwise the synthesis default (5m)
-// applies. The reviewer no-cap sentinel (negative) must not leak through —
-// it would disable the judge bound entirely.
+// judgeTimeoutArg maps the reviewer --timeout value to the judge's
+// ProviderTimeout. The judge is a single text-generation call with no event
+// stream, so unlike reviewers it always keeps a bound: an explicit positive
+// --timeout governs it, anything else (unset, 0, or a negative like
+// `--timeout -5m`) maps to 0 so the synthesis default (5m) applies — a
+// reviewer-side "no cap" must never leak through as "judge unbounded".
 func judgeTimeoutArg(reviewerArg time.Duration) time.Duration {
-	if reviewerArg > 0 {
-		return reviewerArg
-	}
-	return 0
+	return max(reviewerArg, 0)
 }
 
 // runReview executes the main review flow.

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -134,11 +134,13 @@ Flags:
   --models       list the models each agent advertises (optionally --agent NAME)
   --profile NAME select a profile (also accepted as positional arg)
   --prompt TEXT  add one-off per-run instructions for this invocation
-  --timeout DUR  max time each reviewer may run before it's cancelled and marked
-                 failed; also bounds the consolidating judge, whose timeout or
-                 error fails the review with no verdict (default 20m; 0 disables
-                 both bounds). A timed-out reviewer's siblings and the judge
-                 still proceed.
+  --timeout DUR  optional hard cap on each reviewer before it's cancelled and
+                 marked failed. No default — reviewers run until they finish,
+                 like a directly-invoked skill. A positive value also bounds
+                 the consolidating judge, which otherwise keeps its own 20m
+                 default (the judge is never unbounded; its timeout or error
+                 fails the review with no verdict). A timed-out reviewer's
+                 siblings and the judge still proceed.
   --base REF     scope against REF instead of mainline. Useful for stacked
                  PRs where the base is the parent feature branch, not main.
                  Default: first existing of origin/HEAD, origin/main,

--- a/cmd/entire/cli/review/run.go
+++ b/cmd/entire/cli/review/run.go
@@ -47,10 +47,7 @@ func reviewerModelName(r reviewtypes.AgentReviewer) string {
 //   - positive: hard cap.
 //   - zero or negative: no cap.
 func reviewerTimeout(cfg reviewtypes.RunConfig) time.Duration {
-	if cfg.ReviewerTimeout > 0 {
-		return cfg.ReviewerTimeout
-	}
-	return 0
+	return max(cfg.ReviewerTimeout, 0)
 }
 
 var errReviewerTimeoutCause = errors.New("reviewer timeout elapsed")

--- a/cmd/entire/cli/review/run.go
+++ b/cmd/entire/cli/review/run.go
@@ -34,29 +34,23 @@ func reviewerModelName(r reviewtypes.AgentReviewer) string {
 	return ""
 }
 
-// defaultReviewerTimeout bounds a single reviewer's run when the caller
-// doesn't set RunConfig.ReviewerTimeout. A stuck agent is cancelled (its
-// process killed) and marked failed rather than hanging the review forever.
-//
-// A full reviewer pass (read the diff, run skills, write the report) regularly
-// runs past 10m, especially for the consolidating judge, so the default is 20m;
-// override with --timeout (0 disables).
-const defaultReviewerTimeout = 20 * time.Minute
-
-// reviewerTimeout resolves the effective per-reviewer timeout, distinguishing
-// the three RunConfig.ReviewerTimeout states the zero value alone can't:
-//   - positive: use it.
-//   - zero (unset): use defaultReviewerTimeout.
-//   - negative: disabled — return 0, and callers treat 0 as "no timeout".
+// reviewerTimeout resolves the effective per-reviewer wall cap. There is
+// deliberately NO default: reviewers run until they finish, exactly like the
+// same skill invoked in a user's own session. Review time is dominated by
+// long-running subagents inside the reviewer (measured: a single legitimate
+// review subagent ran 12.6 minutes with zero parent output) — every
+// wall-clock default we shipped killed real work at some diff size, and no
+// reliable liveness signal exists for a headless child that would let a
+// watchdog distinguish "working via a quiet subagent" from "hung". A stuck
+// reviewer is Ctrl+C in interactive runs (process-group kill handles it);
+// unattended callers that need a bound pass --timeout explicitly.
+//   - positive: hard cap.
+//   - zero or negative: no cap.
 func reviewerTimeout(cfg reviewtypes.RunConfig) time.Duration {
-	switch {
-	case cfg.ReviewerTimeout > 0:
+	if cfg.ReviewerTimeout > 0 {
 		return cfg.ReviewerTimeout
-	case cfg.ReviewerTimeout < 0:
-		return 0
-	default:
-		return defaultReviewerTimeout
 	}
+	return 0
 }
 
 var errReviewerTimeoutCause = errors.New("reviewer timeout elapsed")

--- a/cmd/entire/cli/review/run_test.go
+++ b/cmd/entire/cli/review/run_test.go
@@ -996,8 +996,8 @@ func TestRun_NaturalCompletionPastDeadlineIsNotTimeout(t *testing.T) {
 
 func TestReviewerTimeout(t *testing.T) {
 	t.Parallel()
-	if got := reviewerTimeout(reviewtypes.RunConfig{}); got != defaultReviewerTimeout {
-		t.Errorf("unset = %v, want default %v", got, defaultReviewerTimeout)
+	if got := reviewerTimeout(reviewtypes.RunConfig{}); got != 0 {
+		t.Errorf("unset = %v, want 0 (no default cap)", got)
 	}
 	if got := reviewerTimeout(reviewtypes.RunConfig{ReviewerTimeout: 5 * time.Minute}); got != 5*time.Minute {
 		t.Errorf("explicit = %v, want 5m", got)
@@ -1029,13 +1029,34 @@ func TestResolveReviewerTimeoutArg(t *testing.T) {
 	}
 }
 
-// TestDefaultReviewerTimeoutValue pins the literal default so an accidental edit
-// to the constant is caught (the other timeout tests compare against the
-// constant itself and would silently follow a change).
-func TestDefaultReviewerTimeoutValue(t *testing.T) {
+// TestReviewerTimeout_NoDefaultCap pins the deliberate absence of a default
+// wall cap: an unset RunConfig.ReviewerTimeout means the reviewer runs until
+// it finishes, like a skill invoked directly in a session. Every wall-clock
+// default we shipped killed legitimate work at some diff size (reviewers
+// spend 10+ minute stretches inside subagents with zero parent output).
+func TestReviewerTimeout_NoDefaultCap(t *testing.T) {
 	t.Parallel()
-	if defaultReviewerTimeout != 20*time.Minute {
-		t.Errorf("defaultReviewerTimeout = %v, want 20m", defaultReviewerTimeout)
+	if got := reviewerTimeout(reviewtypes.RunConfig{}); got != 0 {
+		t.Errorf("reviewerTimeout(unset) = %v, want 0 (no cap)", got)
+	}
+	if got := reviewerTimeout(reviewtypes.RunConfig{ReviewerTimeout: -1}); got != 0 {
+		t.Errorf("reviewerTimeout(negative) = %v, want 0 (no cap)", got)
+	}
+	if got := reviewerTimeout(reviewtypes.RunConfig{ReviewerTimeout: 30 * time.Minute}); got != 30*time.Minute {
+		t.Errorf("reviewerTimeout(30m) = %v, want the explicit cap", got)
+	}
+}
+
+// TestJudgeTimeoutArg pins the judge mapping: the judge is one bounded API
+// call and always keeps a limit — an explicit --timeout governs it, and the
+// reviewer's no-cap sentinel must not leak through as "judge unbounded".
+func TestJudgeTimeoutArg(t *testing.T) {
+	t.Parallel()
+	if got := judgeTimeoutArg(-1); got != 0 {
+		t.Errorf("judgeTimeoutArg(no-cap sentinel) = %v, want 0 (judge default applies)", got)
+	}
+	if got := judgeTimeoutArg(30 * time.Minute); got != 30*time.Minute {
+		t.Errorf("judgeTimeoutArg(30m) = %v, want 30m", got)
 	}
 }
 
@@ -1058,15 +1079,16 @@ func TestTimeoutFlag_ResolvesThroughCommand(t *testing.T) {
 		return d
 	}
 
-	// Default (no flag) is the nonzero default and resolves to a positive bound.
-	if d := parseTimeout(nil); d != defaultReviewerTimeout {
-		t.Errorf("default --timeout = %v, want %v", d, defaultReviewerTimeout)
-	} else if got := resolveReviewerTimeoutArg(d); got != defaultReviewerTimeout {
-		t.Errorf("default resolves to %v, want %v", got, defaultReviewerTimeout)
+	// Default (no flag) is zero and resolves to the no-cap sentinel: reviewers
+	// run until they finish unless the user explicitly caps them.
+	if d := parseTimeout(nil); d != 0 {
+		t.Errorf("default --timeout = %v, want 0 (no cap)", d)
+	} else if got := resolveReviewerTimeoutArg(d); got != -1 {
+		t.Errorf("default resolves to %v, want -1 (no cap)", got)
 	}
-	// --timeout 0 resolves to the negative disable sentinel (reviewers + judge).
+	// Explicit --timeout 0 behaves the same as the default.
 	if got := resolveReviewerTimeoutArg(parseTimeout([]string{"--timeout", "0"})); got != -1 {
-		t.Errorf("--timeout 0 resolves to %v, want -1 (disabled)", got)
+		t.Errorf("--timeout 0 resolves to %v, want -1 (no cap)", got)
 	}
 	// A positive override passes through unchanged.
 	if got := resolveReviewerTimeoutArg(parseTimeout([]string{"--timeout", "30m"})); got != 30*time.Minute {

--- a/cmd/entire/cli/review/run_test.go
+++ b/cmd/entire/cli/review/run_test.go
@@ -1007,28 +1007,6 @@ func TestReviewerTimeout(t *testing.T) {
 	}
 }
 
-// TestResolveReviewerTimeoutArg pins the --timeout flag -> RunConfig sentinel
-// mapping: a non-positive flag value (the user passed --timeout 0) becomes the
-// negative "disabled" sentinel that turns off both the reviewer bound and the
-// judge's deadline; a positive value passes through unchanged.
-func TestResolveReviewerTimeoutArg(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		in   time.Duration
-		want time.Duration
-	}{
-		{"explicit zero disables", 0, -1},
-		{"negative disables", -5 * time.Minute, -1},
-		{"positive passes through", 20 * time.Minute, 20 * time.Minute},
-	}
-	for _, tc := range cases {
-		if got := resolveReviewerTimeoutArg(tc.in); got != tc.want {
-			t.Errorf("%s: resolveReviewerTimeoutArg(%v) = %v, want %v", tc.name, tc.in, got, tc.want)
-		}
-	}
-}
-
 // TestReviewerTimeout_NoDefaultCap pins the deliberate absence of a default
 // wall cap: an unset RunConfig.ReviewerTimeout means the reviewer runs until
 // it finishes, like a skill invoked directly in a session. Every wall-clock
@@ -1048,23 +1026,27 @@ func TestReviewerTimeout_NoDefaultCap(t *testing.T) {
 }
 
 // TestJudgeTimeoutArg pins the judge mapping: the judge is one bounded API
-// call and always keeps a limit — an explicit --timeout governs it, and the
-// reviewer's no-cap sentinel must not leak through as "judge unbounded".
+// call and always keeps a limit — an explicit positive --timeout governs it,
+// and a reviewer-side "no cap" (zero or negative, e.g. `--timeout -5m`) must
+// not leak through as "judge unbounded".
 func TestJudgeTimeoutArg(t *testing.T) {
 	t.Parallel()
-	if got := judgeTimeoutArg(-1); got != 0 {
-		t.Errorf("judgeTimeoutArg(no-cap sentinel) = %v, want 0 (judge default applies)", got)
+	if got := judgeTimeoutArg(0); got != 0 {
+		t.Errorf("judgeTimeoutArg(0) = %v, want 0 (judge default applies)", got)
+	}
+	if got := judgeTimeoutArg(-5 * time.Minute); got != 0 {
+		t.Errorf("judgeTimeoutArg(-5m) = %v, want 0 (judge default applies)", got)
 	}
 	if got := judgeTimeoutArg(30 * time.Minute); got != 30*time.Minute {
 		t.Errorf("judgeTimeoutArg(30m) = %v, want 30m", got)
 	}
 }
 
-// TestTimeoutFlag_ResolvesThroughCommand drives the real --timeout flag through
-// the command (parse only, no RunE) and the resolver, covering the full
-// flag -> resolveReviewerTimeoutArg chain: 0 (and the default) and a positive
-// override. Guards the documented "0 disables" contract against a regression
-// that bypasses the resolver.
+// TestTimeoutFlag_ResolvesThroughCommand drives the real --timeout flag
+// through the command (parse only, no RunE), pinning the two-state contract
+// the flag value carries directly into RunConfig.ReviewerTimeout: the default
+// and an explicit 0 both mean "no cap" (reviewerTimeout returns 0), and a
+// positive override is the hard cap.
 func TestTimeoutFlag_ResolvesThroughCommand(t *testing.T) {
 	t.Parallel()
 	parseTimeout := func(args []string) time.Duration {
@@ -1079,19 +1061,19 @@ func TestTimeoutFlag_ResolvesThroughCommand(t *testing.T) {
 		return d
 	}
 
-	// Default (no flag) is zero and resolves to the no-cap sentinel: reviewers
-	// run until they finish unless the user explicitly caps them.
+	// Default (no flag) is zero: reviewers run until they finish unless the
+	// user explicitly caps them.
 	if d := parseTimeout(nil); d != 0 {
 		t.Errorf("default --timeout = %v, want 0 (no cap)", d)
-	} else if got := resolveReviewerTimeoutArg(d); got != -1 {
-		t.Errorf("default resolves to %v, want -1 (no cap)", got)
+	} else if got := reviewerTimeout(reviewtypes.RunConfig{ReviewerTimeout: d}); got != 0 {
+		t.Errorf("default resolves to %v, want 0 (no cap)", got)
 	}
 	// Explicit --timeout 0 behaves the same as the default.
-	if got := resolveReviewerTimeoutArg(parseTimeout([]string{"--timeout", "0"})); got != -1 {
-		t.Errorf("--timeout 0 resolves to %v, want -1 (no cap)", got)
+	if got := reviewerTimeout(reviewtypes.RunConfig{ReviewerTimeout: parseTimeout([]string{"--timeout", "0"})}); got != 0 {
+		t.Errorf("--timeout 0 resolves to %v, want 0 (no cap)", got)
 	}
 	// A positive override passes through unchanged.
-	if got := resolveReviewerTimeoutArg(parseTimeout([]string{"--timeout", "30m"})); got != 30*time.Minute {
+	if got := reviewerTimeout(reviewtypes.RunConfig{ReviewerTimeout: parseTimeout([]string{"--timeout", "30m"})}); got != 30*time.Minute {
 		t.Errorf("--timeout 30m resolves to %v, want 30m", got)
 	}
 }

--- a/cmd/entire/cli/review/synthesis_sink.go
+++ b/cmd/entire/cli/review/synthesis_sink.go
@@ -90,8 +90,12 @@ var _ reviewtypes.Sink = SynthesisSink{}
 // defaultSynthesisProviderTimeout bounds the judge's single consolidation call
 // when SynthesisSink.ProviderTimeout is unset. The judge reads every reviewer's
 // report and writes the combined verdict in one text-generation call, which
-// regularly needs more than the original 2m, so the default is 5m.
-const defaultSynthesisProviderTimeout = 5 * time.Minute
+// regularly needs more than the original 2m. 20m matches the judge's previous
+// effective bound: before the reviewer default was dropped, the --timeout flag
+// default (20m) always flowed into ProviderTimeout on the no-flag path, so
+// keeping 5m here would have silently tightened the judge 4x — and a judge
+// timeout discards an entire multi-reviewer run with no verdict.
+const defaultSynthesisProviderTimeout = 20 * time.Minute
 
 // AgentEvent is a no-op; SynthesisSink only acts in RunFinished.
 func (SynthesisSink) AgentEvent(_ string, _ reviewtypes.Event) {}

--- a/cmd/entire/cli/review/synthesis_sink_test.go
+++ b/cmd/entire/cli/review/synthesis_sink_test.go
@@ -366,7 +366,7 @@ func TestSynthesisSink_ExplicitProviderTimeoutHonored(t *testing.T) {
 	if !provider.hadDeadline {
 		t.Fatal("explicit ProviderTimeout must apply a deadline")
 	}
-	// Generous slack: the deadline should be ~1h out, far above the 5m default.
+	// Generous slack: the deadline should be ~1h out, far above the 20m default.
 	if provider.remaining < 30*time.Minute {
 		t.Fatalf("deadline remaining = %v, want ~1h (explicit timeout not honored, fell back to default)", provider.remaining)
 	}

--- a/cmd/entire/cli/review/synthesis_sink_test.go
+++ b/cmd/entire/cli/review/synthesis_sink_test.go
@@ -312,7 +312,8 @@ func TestSynthesisSink_DefaultProviderTimeoutBounds(t *testing.T) {
 }
 
 // TestSynthesisSink_DefaultProviderTimeoutValue pins the judge's default
-// deadline (~5m) when ProviderTimeout is unset, so an accidental change to
+// deadline (~20m, the flag default's previous effective bound) when
+// ProviderTimeout is unset, so an accidental change to
 // defaultSynthesisProviderTimeout is caught rather than passing silently.
 func TestSynthesisSink_DefaultProviderTimeoutValue(t *testing.T) {
 	t.Parallel()
@@ -326,10 +327,10 @@ func TestSynthesisSink_DefaultProviderTimeoutValue(t *testing.T) {
 	if !provider.hadDeadline {
 		t.Fatal("unset ProviderTimeout must apply the default deadline")
 	}
-	// The default is 5m; allow generous slack for scheduling between context
+	// The default is 20m; allow generous slack for scheduling between context
 	// creation and the provider reading the deadline.
-	if provider.remaining < 4*time.Minute || provider.remaining > 5*time.Minute {
-		t.Fatalf("default deadline remaining = %v, want ~5m", provider.remaining)
+	if provider.remaining < 19*time.Minute || provider.remaining > 20*time.Minute {
+		t.Fatalf("default deadline remaining = %v, want ~20m", provider.remaining)
 	}
 }
 

--- a/cmd/entire/cli/review/types/reviewer.go
+++ b/cmd/entire/cli/review/types/reviewer.go
@@ -131,10 +131,11 @@ type RunConfig struct {
 
 	// ReviewerTimeout bounds how long a single reviewer may run before the
 	// orchestrator cancels it (its process is killed and the run is marked
-	// failed-by-timeout) so a stuck agent can't hang the review forever. Zero
-	// or negative means use the orchestrator default (defaultReviewerTimeout).
-	// Sibling reviewers and the judge are unaffected by one reviewer's
-	// timeout.
+	// failed-by-timeout). Positive is a hard cap; zero or negative means no
+	// cap — reviewers run until they finish, like a skill invoked directly
+	// in a session (there is deliberately no default: every wall-clock
+	// default shipped killed legitimate long-running work). Sibling
+	// reviewers and the judge are unaffected by one reviewer's timeout.
 	ReviewerTimeout time.Duration
 
 	// EnrichSummary optionally updates the completed run summary before sinks


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/784
<!-- entire-trail-link-end -->

## Problem

Reviewers were killed at a wall-clock default (10m, later raised to 20m) that conflates "slow because working" with "hung". Observed live: a reviewer at ~90% completion killed with everything discarded. Plain agent invocation has no such cliff — the user is the liveness check.

Two findings shaped the fix:

- **No inactivity watchdog can replace the wall clock.** Legitimate review subagents run 12+ minutes while the reviewer's parent process emits zero output (measured on a real run), so a headless child offers no liveness signal that distinguishes a quiet working subagent from a hang. Any watchdog on available signals re-creates the kill-real-work bug.
- **The duration is the task, not a hang risk.** A controlled A/B on the same branch with the same two skills: plain `claude` session 9m57s vs `entire review` 9m08s. Reviews take as long as they take, wherever they run.

## Change

- `--timeout` default: `20m` → `0` (none). Reviewers run until they finish, exactly like a directly-invoked skill. The flag remains as an explicit opt-in hard cap for CI/cost-bounded runs.
- The judge keeps its own 5m default regardless — it's a single text-generation call; a new `judgeTimeoutArg` mapping prevents the reviewer's no-cap sentinel leaking through as "judge unbounded".
- A stuck reviewer in an interactive run is Ctrl+C (process-group kill already handles it, #1625-era fix); unattended liveness is the background-mode/durable-run design's job, not a kill timer's.

## Testing

- `TestReviewerTimeout_NoDefaultCap`, `TestJudgeTimeoutArg`, and the flag-resolution test updated to pin the new contract
- `mise run test` (7,604) green, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default behavior change means long or stuck reviewer processes are no longer auto-cancelled unless users pass `--timeout`; multi-agent reviews may run much longer, though the judge consolidation step remains bounded.
> 
> **Overview**
> **`entire review` no longer applies a wall-clock cap to reviewers by default** (previously ~20m). Reviewers run until they finish, matching a skill invoked in a normal session; **`--timeout` stays an opt-in hard cap** for CI or cost limits, with updated flag help (default `0`).
> 
> **`reviewerTimeout`** drops the implicit default: only a positive `ReviewerTimeout` enables `context.WithTimeout`; unset, zero, or the no-cap sentinel means no reviewer deadline.
> 
> **The consolidating judge is handled separately** via **`judgeTimeoutArg`**: an explicit positive `--timeout` still bounds the judge; when reviewers are uncapped, the reviewer sentinel must not disable the judge—**the judge keeps its existing ~5m synthesis default**.
> 
> Tests pin the no-default-cap contract, judge mapping, and flag → resolver behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe6fe6090561768c2cc28b0f214cee29ec898ae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->