### PR TITLE
don't call the ref backend experimental

### DIFF
--- a/cmd/entire/cli/checkpoint_backend.go
+++ b/cmd/entire/cli/checkpoint_backend.go
@@ -126,7 +126,7 @@ func promptCheckpointBackend(ctx context.Context, w io.Writer) (string, error) {
 				Description("How Entire stores committed session checkpoints in your repo.").
 				Options(
 					huh.NewOption("Branch — one shared branch, entire/checkpoints/v1 (default)", checkpoint.BackendTypeGitBranch),
-					huh.NewOption("Refs — one git ref per checkpoint (experimental)", checkpoint.BackendTypeGitRefs),
+					huh.NewOption("Refs — one git ref per checkpoint", checkpoint.BackendTypeGitRefs),
 				).
 				Value(&choice),
 		),


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/789
<!-- entire-trail-link-end -->

see https://github.com/entireio/cli/pull/1661

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 99ebaafe3ba01498654d80ede5f4571bd1ad12d2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->