### PR TITLE
Promote org/project/repo/grant out of labs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ This repo contains the CLI for Entire.
 
 ### Command Layout
 
-The visible CLI is organized around five noun groups plus a small set of
+The visible CLI is organized around a set of noun groups plus a small set of
 top-level verbs. The groups are the canonical home for each verb; legacy
 top-level shortcuts remain functional but hidden, and emit a deprecation hint
 pointing at the canonical group form. Newer experimental command families are
@@ -58,6 +58,13 @@ their canonical paths are still runnable.
   takes `--everywhere` (revoke every session on the active core, not just the
   current one) and `--all-contexts` (log out of every saved login)
 - `doctor`: bare runs the scan-and-fix flow, plus `trace`, `logs`, `bundle`
+- `org`: control-plane organization management — `create`, `list`, `get`, `delete`
+- `project`: control-plane project management — `create`, `list`, `get`, `delete`
+- `repo`: control-plane repository lifecycle — `create`, `list`, `get`, `delete`,
+  `clone`, plus the `mirror` and `visibility` subtrees. Git content operations
+  (log, diff, …) are intentionally out of scope.
+- `grant`: manage access grants and org membership — `org`, `project`, and `repo`
+  each support `add` / `list` / `remove`
 
 Experimental command families advertised through `entire labs`:
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ go test -tags=integration ./cmd/entire/cli/integration_test -run TestLogin
 | `entire checkpoint explain` | Explain a session, commit, or checkpoint                                               |
 | `entire checkpoint rewind` | Rewind to a previous checkpoint (deprecated, will be removed in a future release)       |
 | `entire login`   | Authenticate the CLI with Entire device auth                                                      |
+| `entire org`     | Manage Entire organizations (create, list, get, delete)                                           |
+| `entire project` | Manage Entire projects (create, list, get, delete)                                                |
+| `entire repo`    | Manage Entire repositories (create, list, get, delete, clone, mirror, visibility)                 |
+| `entire grant`   | Manage access grants and org membership (org, project, repo)                                      |
 | `entire session` | View and manage agent sessions tracked by Entire                                                  |
 | `entire session resume`    | Switch to a branch, restore latest checkpointed session metadata, and show command(s) |
 | `entire session attach`    | Attach to a previously detached session                                                |

--- a/cmd/entire/cli/grant.go
+++ b/cmd/entire/cli/grant.go
@@ -42,9 +42,9 @@ func validateGrantRole(role string) error {
 	}
 }
 
-// newGrantCmd is the hidden `entire grant` command group: manage access
+// newGrantCmd is the `entire grant` command group: manage access
 // grants and org membership on the Entire control plane. Org, project, and
-// repo each support add / list / remove. Surfaced via `entire labs`.
+// repo each support add / list / remove.
 //
 // Grantees are addressed by a provider-qualified handle (e.g. github:alice),
 // which the CLI resolves to the provider account behind the scenes. `remove`
@@ -52,9 +52,8 @@ func validateGrantRole(role string) error {
 // repo) are addressed by name or ULID.
 func newGrantCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "grant",
-		Short:  "Manage Entire access grants and org membership",
-		Hidden: true,
+		Use:   "grant",
+		Short: "Manage Entire access grants and org membership",
 	}
 	addControlPlaneFlags(cmd)
 	cmd.AddCommand(newGrantOrgCmd())

--- a/cmd/entire/cli/labs.go
+++ b/cmd/entire/cli/labs.go
@@ -46,26 +46,6 @@ var experimentalCommands = []experimentalCommandInfo{
 		Summary:     "Show token usage and recommendations for a session",
 	},
 	{
-		CommandPath: []string{"org"},
-		Invocation:  "entire org",
-		Summary:     "Manage Entire organizations (create, list, get, delete)",
-	},
-	{
-		CommandPath: []string{"project"},
-		Invocation:  "entire project",
-		Summary:     "Manage Entire projects (create, list, get, delete)",
-	},
-	{
-		CommandPath: []string{"repo"},
-		Invocation:  "entire repo",
-		Summary:     "Manage Entire repositories (create, list, get, delete, clone, mirror, visibility)",
-	},
-	{
-		CommandPath: []string{"grant"},
-		Invocation:  "entire grant",
-		Summary:     "Manage access grants and org membership (org, project, repo)",
-	},
-	{
 		CommandPath: []string{"blame"},
 		Invocation:  "entire blame",
 		Summary:     "Show which lines came from Entire checkpoints",
@@ -125,10 +105,6 @@ Try:
   entire tokens --help
   entire tokens profile --help
   entire session tokens --help
-  entire org --help
-  entire project --help
-  entire repo --help
-  entire grant --help
   entire blame --help
   entire why --help
   entire experts --help

--- a/cmd/entire/cli/org.go
+++ b/cmd/entire/cli/org.go
@@ -9,14 +9,12 @@ import (
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// newOrgCmd is the hidden `entire org` command group: create, list, get, and
-// delete organizations on the Entire control plane. Surfaced via `entire
-// labs` while the control-plane surface matures.
+// newOrgCmd is the `entire org` command group: create, list, get, and
+// delete organizations on the Entire control plane.
 func newOrgCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "org",
-		Short:  "Manage Entire organizations",
-		Hidden: true,
+		Use:   "org",
+		Short: "Manage Entire organizations",
 	}
 	addControlPlaneFlags(cmd)
 	cmd.AddCommand(newOrgCreateCmd())

--- a/cmd/entire/cli/project.go
+++ b/cmd/entire/cli/project.go
@@ -9,14 +9,12 @@ import (
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// newProjectCmd is the hidden `entire project` command group: create, list,
-// get, and delete projects on the Entire control plane. Surfaced via `entire
-// labs`.
+// newProjectCmd is the `entire project` command group: create, list,
+// get, and delete projects on the Entire control plane.
 func newProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "project",
-		Short:  "Manage Entire projects",
-		Hidden: true,
+		Use:   "project",
+		Short: "Manage Entire projects",
 	}
 	addControlPlaneFlags(cmd)
 	cmd.AddCommand(newProjectCreateCmd())

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -12,17 +12,15 @@ import (
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// newRepoCmd is the hidden `entire repo` command group: control-plane
+// newRepoCmd is the `entire repo` command group: control-plane
 // repository lifecycle (create, list within a project, get, delete), the
 // `mirror` and `visibility` subtrees, plus the `clone` convenience that
 // resolves a mirror and shells out to `git clone`. Other git content
-// operations (log, diff, …) remain intentionally out of scope here. Surfaced
-// via `entire labs`.
+// operations (log, diff, …) remain intentionally out of scope here.
 func newRepoCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "repo",
-		Short:  "Manage Entire repositories",
-		Hidden: true,
+		Use:   "repo",
+		Short: "Manage Entire repositories",
 	}
 	addControlPlaneFlags(cmd)
 	cmd.AddCommand(newRepoCreateCmd())

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -98,10 +98,10 @@ func NewRootCmd() *cobra.Command {
 	// Top-level lifecycle and standalone commands.
 	cmd.AddCommand(cliReview.NewCommand(buildReviewDeps()))        // `review`; hidden during maturation
 	cmd.AddCommand(investigate.NewCommand(buildInvestigateDeps())) // hidden during maturation; runs a multi-agent investigation
-	cmd.AddCommand(newOrgCmd())                                    // hidden during maturation; control-plane org management
-	cmd.AddCommand(newProjectCmd())                                // hidden during maturation; control-plane project management
-	cmd.AddCommand(newRepoCmd())                                   // hidden during maturation; control-plane repo lifecycle
-	cmd.AddCommand(newGrantCmd())                                  // hidden during maturation; control-plane access grants
+	cmd.AddCommand(newOrgCmd())                                    // control-plane org management
+	cmd.AddCommand(newProjectCmd())                                // control-plane project management
+	cmd.AddCommand(newRepoCmd())                                   // control-plane repo lifecycle
+	cmd.AddCommand(newGrantCmd())                                  // control-plane access grants
 	cmd.AddCommand(newCleanCmd())
 	cmd.AddCommand(newSetupCmd()) // 'configure' — non-agent settings; agent CRUD lives under 'agent'
 	cmd.AddCommand(newEnableCmd())

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -94,14 +94,14 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newLabsCmd())            // 'labs' (experimental workflow discovery)
 	cmd.AddCommand(newPluginGroupCmd())     // 'plugin' (managed install/list/remove)
 	cmd.AddCommand(newImportCmd())          // 'import' (hidden; import pre-existing agent history)
+	cmd.AddCommand(newOrgCmd())             // 'org' — control-plane org management
+	cmd.AddCommand(newProjectCmd())         // 'project' — control-plane project management
+	cmd.AddCommand(newRepoCmd())            // 'repo' — control-plane repo lifecycle
+	cmd.AddCommand(newGrantCmd())           // 'grant' — control-plane access grants
 
 	// Top-level lifecycle and standalone commands.
 	cmd.AddCommand(cliReview.NewCommand(buildReviewDeps()))        // `review`; hidden during maturation
 	cmd.AddCommand(investigate.NewCommand(buildInvestigateDeps())) // hidden during maturation; runs a multi-agent investigation
-	cmd.AddCommand(newOrgCmd())                                    // control-plane org management
-	cmd.AddCommand(newProjectCmd())                                // control-plane project management
-	cmd.AddCommand(newRepoCmd())                                   // control-plane repo lifecycle
-	cmd.AddCommand(newGrantCmd())                                  // control-plane access grants
 	cmd.AddCommand(newCleanCmd())
 	cmd.AddCommand(newSetupCmd()) // 'configure' — non-agent settings; agent CRUD lives under 'agent'
 	cmd.AddCommand(newEnableCmd())


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/795
<!-- entire-trail-link-end -->

## What

Promotes the four control-plane command groups — `org`, `project`, `repo`, and `grant` — out of `entire labs` and into the visible top-level command surface.

## Changes

- **Unhide the groups**: dropped `Hidden: true` from `newOrgCmd`, `newProjectCmd`, `newRepoCmd`, and `newGrantCmd`, and refreshed their doc comments (no longer "surfaced via `entire labs`").
- **Remove from labs**: dropped the four `experimentalCommandInfo` entries and their `--help` lines from the labs registry in `labs.go`.
- **Docs & comments**: updated the registration comments in `root.go`, documented the four groups in the CLAUDE.md / AGENTS.md command-layout section, and added them to the README Commands Reference table.

Commands work exactly as before at their canonical paths — they're just discoverable in `entire --help` now instead of only via `entire labs`.

## Verification

- `go build ./...` passes
- Targeted tests pass (`TestLabs*`, `TestRootHelp*`, `TestRender*`, plus org/project/repo/grant)
- `entire --help` now lists all four groups
- `mise run fmt && mise run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Discoverability and docs only—no changes to control-plane API calls or command logic.
> 
> **Overview**
> **Promotes the four control-plane command groups** (`org`, `project`, `repo`, `grant`) from experimental-only discovery to the normal CLI surface. Behavior and canonical paths are unchanged; only visibility and documentation move.
> 
> Each group drops Cobra **`Hidden: true`** and comments no longer say they are surfaced via **`entire labs`**. **`labs.go`** removes their **`experimentalCommandInfo`** entries and the corresponding “Try:” help lines. **`root.go`** registration comments and **`CLAUDE.md`** command layout now list these groups alongside **`session`**, **`auth`**, etc., instead of under labs-only experimental families.
> 
> Users see **`org`**, **`project`**, **`repo`**, and **`grant`** in **`entire --help`**; **`entire labs`** continues to advertise other experimental workflows (e.g. **`review`**, **`tokens`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d5cc06076c4bb65ee0ba96a8a8b674a5bb1c5fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
