### PR TITLE
Route remaining huh forms through the base16 palette theme

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_opf_prompt.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_prompt.go
@@ -14,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/uiform"
 )
 
 // OPFDecision is the resolved gate for a single pre-push OPF run.
@@ -70,7 +71,7 @@ func resolveOPFDecisionForPrePush(ctx context.Context, opf *settings.OPFSettings
 		os.Getenv(envOPF),
 		promptDefault,
 		hasTTY,
-		func() (OPFDecision, error) { return askOPFPrompt(ctx, isAccessibleMode()) },
+		func() (OPFDecision, error) { return askOPFPrompt(ctx) },
 	)
 	if err != nil {
 		return OPFAbort, err
@@ -85,18 +86,18 @@ func resolveOPFDecisionForPrePush(ctx context.Context, opf *settings.OPFSettings
 // OPFAbort. Selecting "Always" persists prompt_default=always to
 // .entire/settings.local.json so future pushes don't ask.
 //
-// Style matches other entire CLI prompts: Dracula theme via
-// huh.ThemeDracula (the same theme cli.NewAccessibleForm applies for
-// callers in the cli package). Strategy can't import cli (cycle), so
-// we apply the theme inline.
-func askOPFPrompt(ctx context.Context, accessible bool) (OPFDecision, error) {
+// Style matches other entire CLI prompts via uiform.New, which applies the
+// shared base16 palette theme and accessibility handling (the same wiring
+// cli.NewAccessibleForm uses). uiform is a leaf package, so strategy can
+// import it without the cycle that importing cli would create.
+func askOPFPrompt(ctx context.Context) (OPFDecision, error) {
 	const (
 		choiceYes    = "yes"
 		choiceNo     = "no"
 		choiceAlways = "always"
 	)
 	choice := choiceYes
-	form := huh.NewForm(
+	form := uiform.New(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Run OpenAI Privacy Filter on these checkpoints?").
@@ -108,10 +109,7 @@ func askOPFPrompt(ctx context.Context, accessible bool) (OPFDecision, error) {
 				).
 				Value(&choice),
 		),
-	).WithTheme(huh.ThemeFunc(huh.ThemeDracula))
-	if accessible {
-		form = form.WithAccessible(true)
-	}
+	)
 	if err := form.RunWithContext(ctx); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return OPFAbort, nil

--- a/cmd/entire/cli/strategy/manual_commit_reset.go
+++ b/cmd/entire/cli/strategy/manual_commit_reset.go
@@ -4,18 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 
 	"github.com/go-git/go-git/v6/plumbing"
 )
-
-// isAccessibleMode returns true if accessibility mode should be enabled.
-// This checks the ACCESSIBLE environment variable.
-func isAccessibleMode() bool {
-	return os.Getenv("ACCESSIBLE") != ""
-}
 
 // Reset deletes the shadow branch and session state for the current HEAD.
 // This allows starting fresh without existing checkpoints.

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -20,6 +20,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
+	"github.com/entireio/cli/cmd/entire/cli/uiform"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
 
 	"charm.land/huh/v2"
@@ -1062,16 +1063,13 @@ func PromptOverwriteNewerLogs(errW io.Writer, sessions []SessionRestoreInfo) (bo
 	fmt.Fprintf(errW, "\nOverwriting will lose the newer local entries.\n\n")
 
 	var confirmed bool
-	form := huh.NewForm(
+	form := uiform.New(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title("Overwrite local session logs with checkpoint versions?").
 				Value(&confirmed),
 		),
 	)
-	if isAccessibleMode() {
-		form = form.WithAccessible(true)
-	}
 
 	if err := form.Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/uiform"
 )
 
 // envKillSwitch disables the interactive update prompt regardless of TTY.
@@ -114,10 +115,7 @@ func realChooseUpdate(ctx context.Context, currentVersion, latestVersion, cmdStr
 			huh.NewOption("Skip until next version", autoUpdateActionSkipUntilNextVersion),
 		).
 		Value(&action)
-	form := huh.NewForm(huh.NewGroup(sel)).WithTheme(huh.ThemeFunc(huh.ThemeDracula))
-	if os.Getenv("ACCESSIBLE") != "" {
-		form = form.WithAccessible(true)
-	}
+	form := uiform.New(huh.NewGroup(sel))
 	if err := form.RunWithContext(ctx); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) || errors.Is(err, huh.ErrTimeout) {
 			return autoUpdateActionSkip, nil


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/805
<!-- entire-trail-link-end -->

## What

Follow-up to #1542 (base16 palette migration). Three `huh` forms still bypassed the shared `uiform.Theme()`, so they rendered off-palette:

- **Auto-update prompt** (`versioncheck/autoupdate.go`) — pinned `huh.ThemeDracula`
- **OPF pre-push prompt** (`strategy/manual_commit_opf_prompt.go`) — pinned `huh.ThemeDracula`, with a now-stale comment claiming it matched `cli.NewAccessibleForm`
- **Rewind overwrite confirm** (`strategy/manual_commit_rewind.go`) — no theme at all, so it fell back to huh's default (Charm) theme

## How

- Switched all three to `uiform.New(...)`, which applies the base16 palette theme and `ACCESSIBLE` handling. `uiform` is a leaf package (imports only `palette` + huh/lipgloss), so `strategy` and `versioncheck` can import it without the cycle that importing `cli` would create.
- Dropped the now-derivable `accessible` param from `askOPFPrompt` (and updated its one caller); `uiform.New` derives it internally.
- Removed the orphaned `isAccessibleMode` helper (and its `os` import) from `manual_commit_reset.go` — the rewind form was its last caller.

After this, every `huh` form in the CLI routes through the palette theme. The only remaining non-palette colors are the two documented #1542 exceptions (per-agent brand hexes in `activity_render.go`, chroma syntax hexes in `mdrender.go`).

## Verification

- `mise run fmt` — clean
- `go build ./...` — passes
- `mise run lint` — 0 issues
- `go test ./cmd/entire/cli/strategy/... ./cmd/entire/cli/versioncheck/... ./cmd/entire/cli/uiform/...` — pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to interactive prompts; prompt behavior and business logic are unchanged.
> 
> **Overview**
> Completes the base16 palette follow-up by moving the last three interactive **huh** prompts onto **`uiform.New`**, so they share the same theme and **`ACCESSIBLE`** handling as the rest of the CLI instead of **Dracula**, default Charm styling, or ad-hoc env checks.
> 
> **Auto-update** (`versioncheck/autoupdate.go`), the **OPF pre-push** select (`strategy/manual_commit_opf_prompt.go`), and the **rewind overwrite** confirm (`strategy/manual_commit_rewind.go`) now all build forms via **`uiform`** (importable from `strategy` / `versioncheck` without a **`cli`** import cycle).
> 
> **OPF** drops the **`accessible`** argument on **`askOPFPrompt`**; accessibility is derived inside **`uiform`**. The unused **`isAccessibleMode`** helper (and **`os`** import) is removed from **`manual_commit_reset.go`** after the rewind prompt stopped calling it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08f4ce6effaee6119855a368c5ace2b0c574d93. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->