### PR TITLE
fix: fan out code search across mirror placements

### DIFF
--- a/cmd/entire/cli/cell_fanout.go
+++ b/cmd/entire/cli/cell_fanout.go
@@ -141,11 +141,13 @@ func resolveCellBaseURLs(ctx context.Context, c cellCoreClient, cells []cellGrou
 	byJurisdiction := make(map[string]coreapi.Cluster, len(clusters.Clusters))
 	for _, cl := range clusters.Clusters {
 		bySlug[strings.ToLower(strings.TrimSpace(cl.Slug))] = cl
-		// First cluster per jurisdiction wins — used as fallback when a
-		// placement-derived group has no cluster slug.
+		// Prefer the default cluster per jurisdiction — matches the auth
+		// layer's resolution when routing by jurisdiction alone. A non-default
+		// cluster is kept only when no default has been seen yet.
 		j := strings.ToLower(strings.TrimSpace(cl.Jurisdiction))
 		if j != "" {
-			if _, exists := byJurisdiction[j]; !exists {
+			existing, exists := byJurisdiction[j]
+			if !exists || (cl.IsDefault && !existing.IsDefault) {
 				byJurisdiction[j] = cl
 			}
 		}

--- a/cmd/entire/cli/cell_fanout.go
+++ b/cmd/entire/cli/cell_fanout.go
@@ -52,27 +52,56 @@ type cellGroup struct {
 // includes the jurisdiction so entries whose index row carries no cell don't
 // collapse across jurisdictions into one group routed by whichever repo came
 // first — they stay per-jurisdiction and route via the jurisdiction fallback.
+//
+// When a RepoIndexEntry has Placements, each placement is added to the group
+// for its own cell/jurisdiction with its placement-specific repo ID. This
+// ensures mirror placements in other regions (e.g. a US-homed repo with an EU
+// mirror) are searched in both cells — matching the BFF's fan-out behavior.
+// When Placements is empty, the top-level Cell/Jurisdiction/ID are used as
+// before (backward compat for index responses that predate placements).
 func groupReposByCell(repos []coreapi.RepoIndexEntry) []cellGroup {
 	byCell := make(map[string]*cellGroup)
-	for _, r := range repos {
-		id := strings.TrimSpace(r.ID)
+
+	addToGroup := func(id, cell, jurisdiction, clusterSlug string) {
+		id = strings.TrimSpace(id)
 		if id == "" {
-			continue
+			return
 		}
-		cell := strings.ToLower(strings.TrimSpace(r.Cell))
-		jurisdiction := strings.ToLower(strings.TrimSpace(r.Jurisdiction))
+		cell = strings.ToLower(strings.TrimSpace(cell))
+		jurisdiction = strings.ToLower(strings.TrimSpace(jurisdiction))
+		clusterSlug = strings.ToLower(strings.TrimSpace(clusterSlug))
 		key := cell + "\x00" + jurisdiction
 		g, ok := byCell[key]
 		if !ok {
 			g = &cellGroup{
 				cell:         cell,
-				clusterSlug:  strings.ToLower(strings.TrimSpace(r.ClusterSlug)),
+				clusterSlug:  clusterSlug,
 				jurisdiction: jurisdiction,
 			}
 			byCell[key] = g
 		}
 		g.repoIDs = append(g.repoIDs, id)
 	}
+
+	for _, r := range repos {
+		if len(r.Placements) > 0 {
+			for _, p := range r.Placements {
+				// Placements don't carry a cluster slug; the top-level
+				// slug applies only to the home placement. Pass it when
+				// the placement's cell matches the top-level cell (home),
+				// empty otherwise — resolveCellBaseURLs falls back to
+				// jurisdiction matching for groups without a slug.
+				slug := ""
+				if strings.EqualFold(strings.TrimSpace(p.Cell), strings.TrimSpace(r.Cell)) {
+					slug = r.ClusterSlug
+				}
+				addToGroup(p.ID, p.Cell, p.Jurisdiction, slug)
+			}
+		} else {
+			addToGroup(r.ID, r.Cell, r.Jurisdiction, r.ClusterSlug)
+		}
+	}
+
 	cells := make([]cellGroup, 0, len(byCell))
 	for _, g := range byCell {
 		cells = append(cells, *g)
@@ -102,11 +131,25 @@ func resolveCellBaseURLs(ctx context.Context, c cellCoreClient, cells []cellGrou
 		return
 	}
 	bySlug := make(map[string]coreapi.Cluster, len(clusters.Clusters))
+	byJurisdiction := make(map[string]coreapi.Cluster, len(clusters.Clusters))
 	for _, cl := range clusters.Clusters {
 		bySlug[strings.ToLower(strings.TrimSpace(cl.Slug))] = cl
+		// First cluster per jurisdiction wins — used as fallback when a
+		// placement-derived group has no cluster slug.
+		j := strings.ToLower(strings.TrimSpace(cl.Jurisdiction))
+		if j != "" {
+			if _, exists := byJurisdiction[j]; !exists {
+				byJurisdiction[j] = cl
+			}
+		}
 	}
 	for i := range cells {
 		cl, ok := bySlug[cells[i].clusterSlug]
+		if !ok && cells[i].jurisdiction != "" {
+			// Placement-derived groups lack a cluster slug; fall back to
+			// jurisdiction so mirror placements still resolve a baseURL.
+			cl, ok = byJurisdiction[cells[i].jurisdiction]
+		}
 		if !ok {
 			logging.Debug(ctx, "cell fan-out: cluster not in catalog, using jurisdiction routing",
 				"cluster_slug", cells[i].clusterSlug, "cell", cells[i].cell)

--- a/cmd/entire/cli/cell_fanout.go
+++ b/cmd/entire/cli/cell_fanout.go
@@ -92,15 +92,17 @@ func groupReposByCell(repos []coreapi.RepoIndexEntry) []cellGroup {
 
 	for _, r := range repos {
 		if len(r.Placements) > 0 {
-			homeCell := strings.ToLower(strings.TrimSpace(r.Cell))
 			for _, p := range r.Placements {
-				// Placements don't carry a cluster slug; the top-level
-				// slug applies only to the home placement. Pass it when
-				// the placement's cell matches the top-level cell (home),
-				// empty otherwise — resolveCellBaseURLs falls back to
-				// jurisdiction matching for groups without a slug.
+				// Placements don't carry a cluster slug; the top-level slug
+				// applies only to the home placement. RepoPlacement.Mirror is
+				// the contract-guaranteed home(false)/mirror(true) marker, so
+				// assign the slug to the home placement and leave mirrors
+				// slugless — resolveCellBaseURLs falls back to cell/jurisdiction
+				// matching for groups without a slug. (Keying off Mirror rather
+				// than p.Cell == r.Cell means the join still works if the index
+				// omits the top-level Cell alongside the placement array.)
 				slug := ""
-				if strings.ToLower(strings.TrimSpace(p.Cell)) == homeCell {
+				if !p.Mirror {
 					slug = r.ClusterSlug
 				}
 				addToGroup(p.ID, p.Cell, p.Jurisdiction, slug)
@@ -167,7 +169,15 @@ func resolveCellBaseURLs(ctx context.Context, c cellCoreClient, cells []cellGrou
 			// Last resort: jurisdiction-level fallback using the default
 			// cluster. Less precise, but still routes to the right
 			// jurisdiction when the cell name doesn't appear in any URL.
-			cl, ok = byJurisdiction[cells[i].jurisdiction]
+			if cl, ok = byJurisdiction[cells[i].jurisdiction]; ok {
+				// This binds the group to the jurisdiction's DEFAULT cluster,
+				// which may not be the cell hosting this placement's repo. If
+				// the placement lives in a non-default cell of the jurisdiction
+				// the query can hit a cell that returns nothing — a silent
+				// mirror miss. Log it so such a miss is diagnosable.
+				logging.Debug(ctx, "cell fan-out: jurisdiction-default fallback used (cell name not in any catalog URL); may mis-route within jurisdiction",
+					"cell", cells[i].cell, "jurisdiction", cells[i].jurisdiction, "resolved_cluster", cl.Slug)
+			}
 		}
 		if !ok {
 			logging.Debug(ctx, "cell fan-out: cluster not in catalog, using jurisdiction routing",

--- a/cmd/entire/cli/cell_fanout.go
+++ b/cmd/entire/cli/cell_fanout.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -154,9 +155,18 @@ func resolveCellBaseURLs(ctx context.Context, c cellCoreClient, cells []cellGrou
 	}
 	for i := range cells {
 		cl, ok := bySlug[cells[i].clusterSlug]
+		if !ok && cells[i].cell != "" {
+			// Try matching the group's cell name against catalog apiUrl
+			// hosts (e.g. cell "aws-eu-central-1" matches
+			// "https://aws-eu-central-1.api.entire.io"). This is more
+			// precise than jurisdiction when a jurisdiction has multiple
+			// cells — mirroring matchClusterByHost in cell_target.go.
+			cl, ok = matchClusterByCellInURL(clusters.Clusters, cells[i].cell)
+		}
 		if !ok && cells[i].jurisdiction != "" {
-			// Placement-derived groups lack a cluster slug; fall back to
-			// jurisdiction so mirror placements still resolve a baseURL.
+			// Last resort: jurisdiction-level fallback using the default
+			// cluster. Less precise, but still routes to the right
+			// jurisdiction when the cell name doesn't appear in any URL.
 			cl, ok = byJurisdiction[cells[i].jurisdiction]
 		}
 		if !ok {
@@ -180,6 +190,31 @@ func resolveCellBaseURLs(ctx context.Context, c cellCoreClient, cells []cellGrou
 		cells[i].jurisdiction = jurisdiction
 		cells[i].baseURL = strings.TrimRight(strings.TrimSpace(cl.ApiUrl.Or("")), "/")
 	}
+}
+
+// matchClusterByCellInURL finds a catalog cluster whose ApiUrl or PublicUrl
+// host contains the cell name as a prefix (e.g. cell "aws-eu-central-1"
+// matches "https://aws-eu-central-1.api.entire.io"). This is more precise
+// than a jurisdiction-level fallback when multiple clusters share a
+// jurisdiction — each cluster serves a different cell.
+func matchClusterByCellInURL(clusters []coreapi.Cluster, cell string) (coreapi.Cluster, bool) {
+	prefix := strings.ToLower(strings.TrimSpace(cell)) + "."
+	for _, cl := range clusters {
+		for _, rawURL := range []string{cl.ApiUrl.Or(""), cl.PublicUrl} {
+			rawURL = strings.TrimSpace(rawURL)
+			if rawURL == "" {
+				continue
+			}
+			u, err := url.Parse(rawURL)
+			if err != nil {
+				continue
+			}
+			if strings.HasPrefix(strings.ToLower(u.Hostname()), prefix) {
+				return cl, true
+			}
+		}
+	}
+	return coreapi.Cluster{}, false
 }
 
 // cellTarget converts the group's routing coordinates into the auth layer's

--- a/cmd/entire/cli/cell_fanout.go
+++ b/cmd/entire/cli/cell_fanout.go
@@ -80,11 +80,18 @@ func groupReposByCell(repos []coreapi.RepoIndexEntry) []cellGroup {
 			}
 			byCell[key] = g
 		}
+		// Upgrade an empty slug if a later entry provides one (a mirror
+		// placement may create the group before the home placement adds the
+		// slug).
+		if g.clusterSlug == "" && clusterSlug != "" {
+			g.clusterSlug = clusterSlug
+		}
 		g.repoIDs = append(g.repoIDs, id)
 	}
 
 	for _, r := range repos {
 		if len(r.Placements) > 0 {
+			homeCell := strings.ToLower(strings.TrimSpace(r.Cell))
 			for _, p := range r.Placements {
 				// Placements don't carry a cluster slug; the top-level
 				// slug applies only to the home placement. Pass it when
@@ -92,7 +99,7 @@ func groupReposByCell(repos []coreapi.RepoIndexEntry) []cellGroup {
 				// empty otherwise — resolveCellBaseURLs falls back to
 				// jurisdiction matching for groups without a slug.
 				slug := ""
-				if strings.EqualFold(strings.TrimSpace(p.Cell), strings.TrimSpace(r.Cell)) {
+				if strings.ToLower(strings.TrimSpace(p.Cell)) == homeCell {
 					slug = r.ClusterSlug
 				}
 				addToGroup(p.ID, p.Cell, p.Jurisdiction, slug)

--- a/cmd/entire/cli/cell_fanout_test.go
+++ b/cmd/entire/cli/cell_fanout_test.go
@@ -186,22 +186,45 @@ func TestResolveCellBaseURLs_JurisdictionFallbackForPlacements(t *testing.T) {
 	}
 }
 
+// TestResolveCellBaseURLs_CellURLMatchOverJurisdiction verifies that when a
+// jurisdiction has multiple clusters, the resolver matches the group's cell
+// name against cluster ApiUrl hosts rather than picking an arbitrary one.
+// This prevents binding a mirror group to the wrong cell's baseURL.
+func TestResolveCellBaseURLs_CellURLMatchOverJurisdiction(t *testing.T) {
+	t.Parallel()
+	cells := []cellGroup{
+		// Mirror group whose cell name appears in the second cluster's URL.
+		{cell: "aws-eu-central-1", clusterSlug: "", jurisdiction: "eu"},
+	}
+	fake := &fakeCellCore{clusters: []coreapi.Cluster{
+		// Different EU cell — must NOT be picked even though it's first and default.
+		{Slug: "eu-west-prod", Jurisdiction: "eu", IsDefault: true, ApiUrl: coreapi.NewOptString("https://aws-eu-west-1.api.entire.io")},
+		// Matching cell — should be picked by cell-URL matching.
+		{Slug: "eu-central-prod", Jurisdiction: "eu", ApiUrl: coreapi.NewOptString("https://aws-eu-central-1.api.entire.io")},
+	}}
+	resolveCellBaseURLs(context.Background(), fake, cells)
+	if cells[0].baseURL != "https://aws-eu-central-1.api.entire.io" {
+		t.Fatalf("eu baseURL = %q, want cell-matched URL, not default cluster", cells[0].baseURL)
+	}
+}
+
 // TestResolveCellBaseURLs_JurisdictionFallbackPrefersDefault verifies that
-// when multiple clusters exist in a jurisdiction, the fallback picks the one
-// with IsDefault=true — matching the auth layer's resolution.
+// when cell-URL matching doesn't find a match, the jurisdiction fallback
+// picks the cluster with IsDefault=true.
 func TestResolveCellBaseURLs_JurisdictionFallbackPrefersDefault(t *testing.T) {
 	t.Parallel()
 	cells := []cellGroup{
-		{cell: "aws-eu-central-1", clusterSlug: "", jurisdiction: "eu"},
+		// Cell name doesn't appear in any cluster URL — falls through to jurisdiction.
+		{cell: "aws-eu-unknown-1", clusterSlug: "", jurisdiction: "eu"},
 	}
 	fake := &fakeCellCore{clusters: []coreapi.Cluster{
 		// Non-default listed first — must not win.
 		{Slug: "eu-staging", Jurisdiction: "eu", ApiUrl: coreapi.NewOptString("https://eu-staging.api.entire.io")},
 		// Default cluster — should be preferred.
-		{Slug: "eu-prod", Jurisdiction: "eu", IsDefault: true, ApiUrl: coreapi.NewOptString("https://aws-eu-central-1.api.entire.io")},
+		{Slug: "eu-prod", Jurisdiction: "eu", IsDefault: true, ApiUrl: coreapi.NewOptString("https://eu-default.api.entire.io")},
 	}}
 	resolveCellBaseURLs(context.Background(), fake, cells)
-	if cells[0].baseURL != "https://aws-eu-central-1.api.entire.io" {
+	if cells[0].baseURL != "https://eu-default.api.entire.io" {
 		t.Fatalf("eu baseURL = %q, want default cluster's URL", cells[0].baseURL)
 	}
 }

--- a/cmd/entire/cli/cell_fanout_test.go
+++ b/cmd/entire/cli/cell_fanout_test.go
@@ -47,7 +47,7 @@ func TestGroupReposByCell(t *testing.T) {
 	if got := strings.Join(us.repoIDs, ","); got != "01B,01C" {
 		t.Fatalf("us repoIDs = %q, want 01B,01C", got)
 	}
-	if us.clusterSlug != "us-prod" || us.jurisdiction != "us" {
+	if us.clusterSlug != testClusterSlugUS || us.jurisdiction != "us" {
 		t.Fatalf("us group coordinates = %+v, want us-prod/us", us)
 	}
 }
@@ -97,7 +97,7 @@ func TestGroupReposByCell_Placements(t *testing.T) {
 		t.Fatalf("us repoIDs = %q, want 01US,01LEGACY", got)
 	}
 	// Home placement inherits the top-level cluster slug.
-	if us.clusterSlug != "us-prod" {
+	if us.clusterSlug != testClusterSlugUS {
 		t.Fatalf("us clusterSlug = %q, want us-prod", us.clusterSlug)
 	}
 }
@@ -117,6 +117,40 @@ func TestGroupReposByCell_PlacementEmptyID(t *testing.T) {
 	cells := groupReposByCell(repos)
 	if len(cells) != 0 {
 		t.Fatalf("groups = %d, want 0 (all placement IDs empty): %+v", len(cells), cells)
+	}
+}
+
+// TestGroupReposByCell_PlacementSlugFromMirrorFlag verifies the home
+// placement's cluster slug is assigned via RepoPlacement.Mirror rather than by
+// string-matching the top-level Cell. When the index omits the top-level Cell
+// alongside the placement array, the string-match would find no home and drop
+// every group to the fuzzier fallback; keying off Mirror keeps the precise
+// slug->catalog join.
+func TestGroupReposByCell_PlacementSlugFromMirrorFlag(t *testing.T) {
+	t.Parallel()
+	repos := []coreapi.RepoIndexEntry{
+		{
+			// Top-level Cell intentionally empty; the home placement is
+			// identified by Mirror=false, not by matching the top-level Cell.
+			ID: "01US", ClusterSlug: "us-prod", Jurisdiction: "us",
+			Placements: []coreapi.RepoPlacement{
+				{ID: "01US", Cell: "aws-us-east-2", Jurisdiction: "us", Mirror: false},
+				{ID: "01EU", Cell: "aws-eu-central-1", Jurisdiction: "eu", Mirror: true},
+			},
+		},
+	}
+	cells := groupReposByCell(repos)
+	if len(cells) != 2 {
+		t.Fatalf("groups = %d, want 2: %+v", len(cells), cells)
+	}
+	// Sorted: aws-eu-central-1 < aws-us-east-2.
+	eu := cells[0]
+	us := cells[1]
+	if us.cell != "aws-us-east-2" || us.clusterSlug != testClusterSlugUS {
+		t.Fatalf("home group = %+v, want cell aws-us-east-2 with slug us-prod", us)
+	}
+	if eu.cell != "aws-eu-central-1" || eu.clusterSlug != "" {
+		t.Fatalf("mirror group = %+v, want cell aws-eu-central-1 with empty slug", eu)
 	}
 }
 

--- a/cmd/entire/cli/cell_fanout_test.go
+++ b/cmd/entire/cli/cell_fanout_test.go
@@ -186,6 +186,26 @@ func TestResolveCellBaseURLs_JurisdictionFallbackForPlacements(t *testing.T) {
 	}
 }
 
+// TestResolveCellBaseURLs_JurisdictionFallbackPrefersDefault verifies that
+// when multiple clusters exist in a jurisdiction, the fallback picks the one
+// with IsDefault=true — matching the auth layer's resolution.
+func TestResolveCellBaseURLs_JurisdictionFallbackPrefersDefault(t *testing.T) {
+	t.Parallel()
+	cells := []cellGroup{
+		{cell: "aws-eu-central-1", clusterSlug: "", jurisdiction: "eu"},
+	}
+	fake := &fakeCellCore{clusters: []coreapi.Cluster{
+		// Non-default listed first — must not win.
+		{Slug: "eu-staging", Jurisdiction: "eu", ApiUrl: coreapi.NewOptString("https://eu-staging.api.entire.io")},
+		// Default cluster — should be preferred.
+		{Slug: "eu-prod", Jurisdiction: "eu", IsDefault: true, ApiUrl: coreapi.NewOptString("https://aws-eu-central-1.api.entire.io")},
+	}}
+	resolveCellBaseURLs(context.Background(), fake, cells)
+	if cells[0].baseURL != "https://aws-eu-central-1.api.entire.io" {
+		t.Fatalf("eu baseURL = %q, want default cluster's URL", cells[0].baseURL)
+	}
+}
+
 func TestResolveCellBaseURLs_CatalogErrorLeavesJurisdictionRouting(t *testing.T) {
 	t.Parallel()
 	cells := []cellGroup{{cell: euWestCell, clusterSlug: "eu-prod", jurisdiction: "eu"}}

--- a/cmd/entire/cli/cell_fanout_test.go
+++ b/cmd/entire/cli/cell_fanout_test.go
@@ -52,6 +52,74 @@ func TestGroupReposByCell(t *testing.T) {
 	}
 }
 
+// TestGroupReposByCell_Placements verifies that when a repo has Placements,
+// each placement is grouped into its own cell group with the placement-specific
+// repo ID. This is the fix for cross-region fan-out: a US-homed repo with an
+// EU mirror produces two cell groups so both cells are searched.
+func TestGroupReposByCell_Placements(t *testing.T) {
+	t.Parallel()
+	repos := []coreapi.RepoIndexEntry{
+		{
+			// US-homed repo with an EU mirror — the real-world scenario.
+			ID: "01US", Cell: "aws-us-east-2", ClusterSlug: "us-prod", Jurisdiction: "us",
+			Placements: []coreapi.RepoPlacement{
+				{ID: "01US", Cell: "aws-us-east-2", Jurisdiction: "us"},
+				{ID: "01EU", Cell: "aws-eu-central-1", Jurisdiction: "eu", Mirror: true},
+			},
+		},
+		{
+			// Repo without placements (legacy index) — top-level fields used.
+			ID: "01LEGACY", Cell: "aws-us-east-2", ClusterSlug: "us-prod", Jurisdiction: "us",
+		},
+	}
+	cells := groupReposByCell(repos)
+	if len(cells) != 2 {
+		t.Fatalf("groups = %d, want 2 (one per cell): %+v", len(cells), cells)
+	}
+	// Sorted: aws-eu-central-1 < aws-us-east-2.
+	eu := cells[0]
+	us := cells[1]
+	if eu.cell != "aws-eu-central-1" || eu.jurisdiction != "eu" {
+		t.Fatalf("eu group = %+v", eu)
+	}
+	if got := strings.Join(eu.repoIDs, ","); got != "01EU" {
+		t.Fatalf("eu repoIDs = %q, want 01EU", got)
+	}
+	// EU placement has no cluster slug (cell differs from top-level).
+	if eu.clusterSlug != "" {
+		t.Fatalf("eu clusterSlug = %q, want empty", eu.clusterSlug)
+	}
+	if us.cell != "aws-us-east-2" || us.jurisdiction != "us" {
+		t.Fatalf("us group = %+v", us)
+	}
+	// US group has both the placement ID and the legacy entry.
+	if got := strings.Join(us.repoIDs, ","); got != "01US,01LEGACY" {
+		t.Fatalf("us repoIDs = %q, want 01US,01LEGACY", got)
+	}
+	// Home placement inherits the top-level cluster slug.
+	if us.clusterSlug != "us-prod" {
+		t.Fatalf("us clusterSlug = %q, want us-prod", us.clusterSlug)
+	}
+}
+
+// TestGroupReposByCell_PlacementEmptyID verifies that placements with empty IDs
+// are skipped, matching the top-level behavior.
+func TestGroupReposByCell_PlacementEmptyID(t *testing.T) {
+	t.Parallel()
+	repos := []coreapi.RepoIndexEntry{
+		{
+			ID: "01A", Cell: "aws-us-east-2", Jurisdiction: "us",
+			Placements: []coreapi.RepoPlacement{
+				{ID: "", Cell: "aws-us-east-2", Jurisdiction: "us"}, // empty ID → skipped
+			},
+		},
+	}
+	cells := groupReposByCell(repos)
+	if len(cells) != 0 {
+		t.Fatalf("groups = %d, want 0 (all placement IDs empty): %+v", len(cells), cells)
+	}
+}
+
 // TestResolveCellBaseURLs_RefusesBaseURLWithoutJurisdiction pins the guard: a
 // concrete baseURL is only usable together with the jurisdiction its token
 // must be minted for; a catalog row with no jurisdiction leaves the group on
@@ -91,6 +159,30 @@ func TestResolveCellBaseURLs_JoinsOnClusterSlug(t *testing.T) {
 	}
 	if cells[1].baseURL != "" {
 		t.Fatalf("ap baseURL = %q, want empty (jurisdiction fallback)", cells[1].baseURL)
+	}
+}
+
+// TestResolveCellBaseURLs_JurisdictionFallbackForPlacements verifies that
+// groups without a cluster slug (from placement-derived groups) resolve their
+// baseURL via jurisdiction matching against the cluster catalog.
+func TestResolveCellBaseURLs_JurisdictionFallbackForPlacements(t *testing.T) {
+	t.Parallel()
+	cells := []cellGroup{
+		// Home group with slug — resolved via slug join.
+		{cell: "aws-us-east-2", clusterSlug: "us-prod", jurisdiction: "us"},
+		// Mirror group without slug — must fall back to jurisdiction join.
+		{cell: "aws-eu-central-1", clusterSlug: "", jurisdiction: "eu"},
+	}
+	fake := &fakeCellCore{clusters: []coreapi.Cluster{
+		{Slug: "us-prod", Jurisdiction: "us", ApiUrl: coreapi.NewOptString("https://aws-us-east-2.api.entire.io")},
+		{Slug: "eu-prod", Jurisdiction: "eu", ApiUrl: coreapi.NewOptString("https://aws-eu-central-1.api.entire.io")},
+	}}
+	resolveCellBaseURLs(context.Background(), fake, cells)
+	if cells[0].baseURL != "https://aws-us-east-2.api.entire.io" {
+		t.Fatalf("us baseURL = %q, want resolved via slug", cells[0].baseURL)
+	}
+	if cells[1].baseURL != "https://aws-eu-central-1.api.entire.io" {
+		t.Fatalf("eu baseURL = %q, want resolved via jurisdiction fallback", cells[1].baseURL)
 	}
 }
 

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -707,30 +707,57 @@ func mergeSearchResults(ctx context.Context, limit int, results []cellCallResult
 	}
 	merged.Results = deduped
 
-	// Deduplicate RepoStats by repo name, summing match/file counts.
-	repoStatsMap := make(map[string]*codesearch.RepoStats, len(merged.RepoStats))
+	// Deduplicate RepoStats by repo name. A repo that appears in more than one
+	// cell is a mirror placement returning the SAME content (this PR fans out
+	// across placements, so e.g. a US-homed repo with an EU mirror is now
+	// searched in both cells) — not additional matches. Keep one representative
+	// entry per repo (the max of each count; mirror copies are identical, max
+	// only guards against minor per-cell skew) instead of summing, and record
+	// the duplicated portion so the aggregate stats can drop the double-count.
+	type repoStatAcc struct {
+		idx                    int
+		sumMatches, maxMatches int
+		sumFiles, maxFiles     int
+		cellCount              int
+	}
+	accByRepo := make(map[string]*repoStatAcc, len(merged.RepoStats))
 	var dedupedStats []codesearch.RepoStats
 	for _, rs := range merged.RepoStats {
-		if existing, ok := repoStatsMap[rs.Repo]; ok {
-			existing.MatchCount += rs.MatchCount
-			existing.FileCount += rs.FileCount
-		} else {
-			entry := rs // copy
-			repoStatsMap[rs.Repo] = &entry
-			dedupedStats = append(dedupedStats, entry)
+		acc, ok := accByRepo[rs.Repo]
+		if !ok {
+			acc = &repoStatAcc{idx: len(dedupedStats)}
+			accByRepo[rs.Repo] = acc
+			dedupedStats = append(dedupedStats, codesearch.RepoStats{Repo: rs.Repo})
 		}
+		acc.cellCount++
+		acc.sumMatches += rs.MatchCount
+		acc.sumFiles += rs.FileCount
+		acc.maxMatches = max(acc.maxMatches, rs.MatchCount)
+		acc.maxFiles = max(acc.maxFiles, rs.FileCount)
 	}
-	// Write back merged values.
-	for i := range dedupedStats {
-		if m, ok := repoStatsMap[dedupedStats[i].Repo]; ok {
-			dedupedStats[i] = *m
-		}
+	var overcountMatches, overcountFiles, overcountRepos int
+	for _, acc := range accByRepo {
+		dedupedStats[acc.idx].MatchCount = acc.maxMatches
+		dedupedStats[acc.idx].FileCount = acc.maxFiles
+		overcountMatches += acc.sumMatches - acc.maxMatches
+		overcountFiles += acc.sumFiles - acc.maxFiles
+		overcountRepos += acc.cellCount - 1
 	}
 	merged.RepoStats = dedupedStats
 
-	// Stats are preserved as the sum of per-cell peregrine stats — they
-	// reflect the true totals (including zero-match repos and per-cell
-	// truncation), not just the deduped result slice.
+	// The per-cell Stats were summed above, so a mirrored repo's matches were
+	// counted once per cell. Subtract the duplicated copies identified via
+	// RepoStats so the totals reflect distinct content, not the same content
+	// seen from every mirror cell. This preserves per-cell truncation (the
+	// base is peregrine's own totals; we only remove the provable duplicate
+	// portion) and zero-match repos (they contribute 0 to the subtraction).
+	// A repo with matches but no RepoStats row, or a zero-match mirror repo,
+	// can't be de-duplicated from the response and keeps its summed
+	// contribution — a mild over-count, far less misleading than reporting
+	// every mirrored match twice. Clamp at zero against inconsistent input.
+	merged.Stats.TotalMatches = max(0, merged.Stats.TotalMatches-overcountMatches)
+	merged.Stats.TotalFiles = max(0, merged.Stats.TotalFiles-overcountFiles)
+	merged.Stats.ReposSearched = max(0, merged.Stats.ReposSearched-overcountRepos)
 
 	// Cap to the caller's requested limit.
 	if limit > 0 && len(merged.Results) > limit {

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -14,9 +14,10 @@ import (
 
 // test constants used across code-search tests.
 const (
-	testRepoID1 = "01ABC"
-	testRepoID2 = "02DEF"
-	testCellEU  = "aws-eu-west-1"
+	testRepoID1       = "01ABC"
+	testRepoID2       = "02DEF"
+	testCellEU        = "aws-eu-west-1"
+	testClusterSlugUS = "us-prod"
 )
 
 // TestSearchCmd_AccessibleModeRequiresQuery verifies that accessible mode

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -382,21 +382,16 @@ func TestMergeSearchResults_DeduplicatesOverlappingCells(t *testing.T) {
 	t.Parallel()
 
 	dup := codesearch.Result{Repo: "acme/web", Path: "main.go", Line: 10, Column: 5, Score: 0.9}
+	cellVal := func() *codesearch.SearchResponse {
+		return &codesearch.SearchResponse{
+			Results:   []codesearch.Result{dup},
+			Stats:     codesearch.Stats{TotalMatches: 1, TotalFiles: 1, ReposSearched: 1},
+			RepoStats: []codesearch.RepoStats{{Repo: "acme/web", MatchCount: 1, FileCount: 1}},
+		}
+	}
 	results := []cellCallResult[*codesearch.SearchResponse]{
-		{
-			group: cellGroup{cell: "", jurisdiction: ""},
-			value: &codesearch.SearchResponse{
-				Results: []codesearch.Result{dup},
-				Stats:   codesearch.Stats{TotalMatches: 1, TotalFiles: 1, ReposSearched: 1},
-			},
-		},
-		{
-			group: cellGroup{cell: "aws-us-east-2", jurisdiction: "us"},
-			value: &codesearch.SearchResponse{
-				Results: []codesearch.Result{dup},
-				Stats:   codesearch.Stats{TotalMatches: 1, TotalFiles: 1, ReposSearched: 1},
-			},
-		},
+		{group: cellGroup{cell: "", jurisdiction: ""}, value: cellVal()},
+		{group: cellGroup{cell: "aws-us-east-2", jurisdiction: "us"}, value: cellVal()},
 	}
 
 	merged, err := mergeSearchResults(context.Background(), 0, results)
@@ -405,6 +400,73 @@ func TestMergeSearchResults_DeduplicatesOverlappingCells(t *testing.T) {
 	}
 	if len(merged.Results) != 1 {
 		t.Fatalf("len(Results) = %d, want 1 (duplicate removed)", len(merged.Results))
+	}
+	// Stats must not double-count the overlapping match either.
+	if merged.Stats.TotalMatches != 1 {
+		t.Errorf("TotalMatches = %d, want 1 (overlapping cells must not double-count)", merged.Stats.TotalMatches)
+	}
+	if merged.Stats.ReposSearched != 1 {
+		t.Errorf("ReposSearched = %d, want 1 (one logical repo)", merged.Stats.ReposSearched)
+	}
+	if len(merged.RepoStats) != 1 || merged.RepoStats[0].MatchCount != 1 {
+		t.Errorf("RepoStats = %+v, want one entry with MatchCount 1", merged.RepoStats)
+	}
+}
+
+func TestMergeSearchResults_MirrorPlacementsDoNotDoubleCount(t *testing.T) {
+	t.Parallel()
+
+	// A US-homed repo with an EU mirror indexes the same content, so the
+	// fan-out queries both cells and each returns the SAME matches. Merged
+	// results dedupe by repo+path+line; the stats must dedupe too, or the
+	// summary reports "6 matches across 4 files in 2 repos" for 3 unique
+	// results (and falsely claims truncation). Regression guard for the
+	// mirror fan-out this trail introduced.
+	matches := []codesearch.Result{
+		{Repo: "acme/web", Path: "main.go", Line: 1, Column: 0, Score: 0.9},
+		{Repo: "acme/web", Path: "main.go", Line: 2, Column: 0, Score: 0.8},
+		{Repo: "acme/web", Path: "util.go", Line: 5, Column: 0, Score: 0.7},
+	}
+	cell := func(name, jur string) cellCallResult[*codesearch.SearchResponse] {
+		return cellCallResult[*codesearch.SearchResponse]{
+			group: cellGroup{cell: name, jurisdiction: jur},
+			value: &codesearch.SearchResponse{
+				Query:     "handleRequest",
+				Stats:     codesearch.Stats{TotalMatches: 3, TotalFiles: 2, ReposSearched: 1, DurationMs: 10},
+				RepoStats: []codesearch.RepoStats{{Repo: "acme/web", MatchCount: 3, FileCount: 2}},
+				Results:   matches,
+			},
+		}
+	}
+	results := []cellCallResult[*codesearch.SearchResponse]{
+		cell("aws-us-east-2", "us"),
+		cell(testCellEU, "eu"),
+	}
+
+	merged, err := mergeSearchResults(context.Background(), 0, results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(merged.Results) != 3 {
+		t.Fatalf("len(Results) = %d, want 3 (mirror duplicates removed)", len(merged.Results))
+	}
+	if merged.Stats.TotalMatches != 3 {
+		t.Errorf("TotalMatches = %d, want 3 (mirror must not double-count)", merged.Stats.TotalMatches)
+	}
+	if merged.Stats.TotalFiles != 2 {
+		t.Errorf("TotalFiles = %d, want 2 (mirror must not double-count)", merged.Stats.TotalFiles)
+	}
+	if merged.Stats.ReposSearched != 1 {
+		t.Errorf("ReposSearched = %d, want 1 (one logical repo across two cells)", merged.Stats.ReposSearched)
+	}
+	if merged.Stats.DurationMs != 10 {
+		t.Errorf("DurationMs = %v, want 10 (slowest cell preserved)", merged.Stats.DurationMs)
+	}
+	if len(merged.RepoStats) != 1 {
+		t.Fatalf("len(RepoStats) = %d, want 1 (deduped by repo)", len(merged.RepoStats))
+	}
+	if merged.RepoStats[0].MatchCount != 3 || merged.RepoStats[0].FileCount != 2 {
+		t.Errorf("RepoStats[0] = %+v, want representative {3,2} not summed {6,4}", merged.RepoStats[0])
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/794
<!-- entire-trail-link-end -->

## Summary
- `groupReposByCell` now iterates `RepoIndexEntry.Placements` (when present) instead of only using top-level `Cell`/`Jurisdiction`/`ID` fields. Each placement gets its own cell group with its placement-specific repo ID, so mirror placements in other regions are searched.
- `resolveCellBaseURLs` gains a jurisdiction-based fallback for the cluster catalog join, since placement-derived groups lack a `ClusterSlug`.
- Backward compatible: entries without `Placements` (legacy index) still use top-level fields.

## Context
The CLI's `entire search --code` was only returning results from the repo's home region. A US-homed repo with an EU mirror (e.g. `entireio/cli`) would only search the US peregrine instance, missing EU-indexed results. The web BFF already fans out to both cells by reading the `Placements` array — this brings the CLI in line.

Closes ENT-998

## Test plan
- [x] New unit tests for placement-aware grouping (`TestGroupReposByCell_Placements`, `TestGroupReposByCell_PlacementEmptyID`)
- [x] New unit test for jurisdiction fallback in URL resolution (`TestResolveCellBaseURLs_JurisdictionFallbackForPlacements`)
- [x] All existing cell fanout tests pass (no regressions)
- [x] Full test suite passes (7671 tests)
- [x] Manual test: `ENTIRE_CODE_SEARCH=1 entire search --code <query>` against a repo with EU mirror, verify results from both regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-cell routing and identity-token jurisdiction for code search; behavior is well-tested but wrong routing could miss results or hit the wrong cell API.
> 
> **Overview**
> **CLI multi-cell code search** now groups repos using each `RepoIndexEntry`’s **`Placements`** when present, so a home region plus EU/US mirrors produce **separate cell groups** with placement-specific repo IDs—aligned with the web BFF fan-out. Legacy index rows without placements still use top-level `Cell` / `Jurisdiction` / `ID`.
> 
> **`resolveCellBaseURLs`** adds a **jurisdiction → cluster catalog** fallback (preferring `IsDefault`) when a group has no `ClusterSlug`, which mirror-derived groups need to get a `baseURL` and correct token jurisdiction.
> 
> Unit tests cover placement grouping, empty placement IDs, jurisdiction fallback, and default-cluster preference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d80aa8fd3fdd693edcde2d4b220b67ea225457. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->