### PR TITLE
fix(repo): resolve `mirror get` clone URLs via that cluster's login server

### DIFF
--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -215,7 +215,23 @@ func fetchAllPages[T any](ctx context.Context, fetch func(ctx context.Context, c
 // field/value list (default) or raw JSON (--json), reusing the same column
 // definition as the matching list view.
 func runCoreObject[T any](cmd *cobra.Command, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) (*T, error)) error {
-	return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+	return runCore(cmd, renderCoreObject(cmd, headers, row, fn))
+}
+
+// runCoreObjectForCluster is runCoreObject for a resource-provider command (see
+// runCoreForCluster): identical field/JSON rendering, but dialing the core that
+// fronts clusterHost rather than the active context.
+func runCoreObjectForCluster[T any](cmd *cobra.Command, clusterHost string, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) (*T, error)) error {
+	return runCoreForCluster(cmd, clusterHost, renderCoreObject(cmd, headers, row, fn))
+}
+
+// renderCoreObject builds the run-function shared by runCoreObject and
+// runCoreObjectForCluster: fetch via fn, then render as a field/value list
+// (default) or raw JSON (--json). Kept separate from the client-selection so
+// the two object variants differ only in which core they dial (mirroring
+// renderCoreList).
+func renderCoreObject[T any](cmd *cobra.Command, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) (*T, error)) func(context.Context, *coreapi.Client) error {
+	return func(ctx context.Context, c *coreapi.Client) error {
 		item, err := fn(ctx, c)
 		if err != nil {
 			return err
@@ -224,7 +240,7 @@ func runCoreObject[T any](cmd *cobra.Command, headers []string, row func(T) []st
 			return printJSON(cmd.OutOrStdout(), item)
 		}
 		return printFields(cmd.OutOrStdout(), headers, row(*item))
-	})
+	}
 }
 
 // tableStyles holds the foreground styles for the human table/field views,
@@ -384,6 +400,12 @@ func runCoreMutation(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi
 // without standing up the auth/context/TLS stack.
 var activeCoreClient = func(context.Context) (*coreapi.Client, error) { return coreapi.New() }
 
+// clusterCoreClient builds the control-plane client for cluster-addressed
+// commands (see runCoreForCluster). Same test seam as activeCoreClient —
+// production wiring is coreapi.NewForCluster, which does live /.well-known
+// discovery that command-level tests must not reach.
+var clusterCoreClient func(ctx context.Context, clusterHost string) (*coreapi.Client, error) = coreapi.NewForCluster
+
 // runCore is the shared base for every active-context control-plane command:
 // it owns the preamble only — silence usage, build the client, map API
 // errors — and leaves all rendering to fn. The delete/revoke verbs call it
@@ -404,7 +426,7 @@ func runCore(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client)
 // cluster_host". See coreapi.NewForCluster.
 func runCoreForCluster(cmd *cobra.Command, clusterHost string, fn func(ctx context.Context, c *coreapi.Client) error) error {
 	return runCoreClient(cmd, func(ctx context.Context) (*coreapi.Client, error) {
-		return coreapi.NewForCluster(ctx, clusterHost)
+		return clusterCoreClient(ctx, clusterHost)
 	}, fn)
 }
 

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -421,12 +421,12 @@ func newRepoMirrorGetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <mirror>",
 		Short: "Show a mirror by ULID or clone URL",
-		Long: "Show a mirror. <mirror> is either a mirror ULID or an entire:// clone " +
-			"URL\n(entire://<cluster>/gh/<owner>/<repo>) — the form `mirror list` " +
-			"prints and `git clone` accepts. A clone URL is looked up on the core " +
-			"fronting\nits cluster, so it resolves even when that cluster belongs to " +
-			"a federation\nother than the active auth context; a ULID is looked up " +
-			"on the active context.",
+		Long: "Show a mirror. <mirror> is either a mirror ULID or an entire:// clone URL\n" +
+			"(entire://<cluster>/gh/<owner>/<repo>) — the form `mirror list` prints and\n" +
+			"`git clone` accepts; a trailing .git, as pasted from `git remote -v`, is\n" +
+			"accepted too. A clone URL is looked up on the core fronting its cluster, so\n" +
+			"it resolves even when that cluster belongs to a federation other than the\n" +
+			"active auth context; a ULID is looked up on the active context.",
 		Example: "  entire repo mirror get 01KS6KFJR2XS6PZ188MVYE07AN\n" +
 			"  entire repo mirror get entire://aws-us-east-2.entire.io/gh/octocat/hello-world",
 		Args: cobra.ExactArgs(1),

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -424,9 +424,10 @@ func newRepoMirrorGetCmd() *cobra.Command {
 		Long: "Show a mirror. <mirror> is either a mirror ULID or an entire:// clone URL\n" +
 			"(entire://<cluster>/gh/<owner>/<repo>) — the form `mirror list` prints and\n" +
 			"`git clone` accepts; a trailing .git, as pasted from `git remote -v`, is\n" +
-			"accepted too. A clone URL is looked up on the core fronting its cluster, so\n" +
-			"it resolves even when that cluster belongs to a federation other than the\n" +
-			"active auth context; a ULID is looked up on the active context.",
+			"accepted too. A clone URL is looked up on the login server fronting its\n" +
+			"cluster, so it resolves even when that cluster belongs to a federation other\n" +
+			"than the active auth context; a ULID is looked up on the active context's\n" +
+			"login server.",
 		Example: "  entire repo mirror get 01KS6KFJR2XS6PZ188MVYE07AN\n" +
 			"  entire repo mirror get entire://aws-us-east-2.entire.io/gh/octocat/hello-world",
 		Args: cobra.ExactArgs(1),

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -423,18 +423,38 @@ func newRepoMirrorGetCmd() *cobra.Command {
 		Short: "Show a mirror by ULID or clone URL",
 		Long: "Show a mirror. <mirror> is either a mirror ULID or an entire:// clone " +
 			"URL\n(entire://<cluster>/gh/<owner>/<repo>) — the form `mirror list` " +
-			"prints and `git clone` accepts.",
+			"prints and `git clone` accepts. A clone URL is looked up on the core " +
+			"fronting\nits cluster, so it resolves even when that cluster belongs to " +
+			"a federation\nother than the active auth context; a ULID is looked up " +
+			"on the active context.",
 		Example: "  entire repo mirror get 01KS6KFJR2XS6PZ188MVYE07AN\n" +
 			"  entire repo mirror get entire://aws-us-east-2.entire.io/gh/octocat/hello-world",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoreObject(cmd, mirrorColumns, mirrorRow, func(ctx context.Context, c *coreapi.Client) (*coreapi.Mirror, error) {
-				mirrorID, err := resolveMirrorRef(ctx, c, args[0])
+			ref := args[0]
+			show := func(ctx context.Context, c *coreapi.Client) (*coreapi.Mirror, error) {
+				mirrorID, err := resolveMirrorRef(ctx, c, ref)
 				if err != nil {
 					return nil, err
 				}
 				return c.GetMirror(ctx, coreapi.GetMirrorParams{MirrorId: mirrorID})
-			})
+			}
+			// A ULID carries no cluster coordinate, so it can only be looked up
+			// on the active context's core. A clone URL names its cluster — dial
+			// the core fronting that cluster (discovered from its well-known and
+			// authenticated with the matching local context, the same path
+			// create/remove use), so the lookup works when the mirror lives in a
+			// federation other than the active login instead of failing with
+			// "no mirror matching".
+			if looksLikeULID(ref) {
+				return runCoreObject(cmd, mirrorColumns, mirrorRow, show)
+			}
+			clusterHost, _, _, _, err := parseMirrorCloneURL(ref)
+			if err != nil {
+				cmd.SilenceUsage = true
+				return badMirrorRefErr(err)
+			}
+			return runCoreObjectForCluster(cmd, clusterHost, mirrorColumns, mirrorRow, show)
 		},
 	}
 }
@@ -451,7 +471,7 @@ func resolveMirrorRef(ctx context.Context, c *coreapi.Client, ref string) (strin
 	}
 	clusterHost, provider, owner, repo, err := parseMirrorCloneURL(ref)
 	if err != nil {
-		return "", fmt.Errorf("%w; pass a mirror ULID or a clone URL (entire://<cluster>/gh/<owner>/<repo>)", err)
+		return "", badMirrorRefErr(err)
 	}
 	mirrors, err := fetchAllPages(ctx, func(ctx context.Context, cursor string) ([]coreapi.Mirror, string, error) {
 		params := coreapi.ListMirrorsParams{
@@ -512,6 +532,13 @@ func parseMirrorCloneURL(raw string) (clusterHost, provider, owner, repo string,
 
 func noMirrorErr(ref string) error {
 	return fmt.Errorf("no mirror matching %q (run `entire repo mirror list` to see clone URLs, or pass a ULID)", ref)
+}
+
+// badMirrorRefErr wraps a clone-URL parse failure with the accepted <mirror>
+// forms. Shared by the pre-dial parse in `mirror get` and resolveMirrorRef so
+// both boundaries report identically.
+func badMirrorRefErr(err error) error {
+	return fmt.Errorf("%w; pass a mirror ULID or a clone URL (entire://<cluster>/gh/<owner>/<repo>)", err)
 }
 
 func newRepoMirrorRemoveCmd() *cobra.Command {

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -665,6 +665,115 @@ func TestResolveMirrorRef(t *testing.T) {
 	})
 }
 
+// TestRepoMirrorGet_Routing pins which core `mirror get <ref>` dials. A clone
+// URL names its cluster, so it must be resolved on the core fronting that
+// cluster (clusterCoreClient), not the active context — the original bug:
+// `mirror get entire://<cluster>/…` for a cluster in a federation other than
+// the active login failed with "no mirror matching" until the user switched
+// contexts. A ULID carries no cluster coordinate and stays on the active
+// context; an unparseable ref must error before dialing anything.
+//
+// Not parallel: swaps the package-level activeCoreClient/clusterCoreClient
+// seams.
+func TestRepoMirrorGet_Routing(t *testing.T) {
+	const mirrorULID = "0123456789ABCDEFGHJKMNPQRS"
+	const clusterHost = "eukanuba.partial.to"
+	const cloneURL = "entire://" + clusterHost + "/gh/entirehq/librarian"
+
+	// mirrorServer answers both the list (clone-URL resolution) and the
+	// GetMirror-by-ULID calls for the librarian mirror.
+	mirrorServer := func(t *testing.T) *httptest.Server {
+		t.Helper()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case mirrorsAPIPath:
+				assert.NoError(t, printJSON(w, &coreapi.ListMirrorsOutputBody{Mirrors: []coreapi.Mirror{
+					{MirrorId: mirrorULID, Owner: "entirehq", Repo: "librarian", ClusterHost: clusterHost},
+				}}))
+			case mirrorsAPIPath + "/" + mirrorULID:
+				assert.NoError(t, printJSON(w, &coreapi.Mirror{
+					MirrorId: mirrorULID, Owner: "entirehq", Repo: "librarian", ClusterHost: clusterHost,
+					IsPrivate: coreapi.NewOptBool(true),
+				}))
+			default:
+				t.Errorf("unexpected request path %q", r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		t.Cleanup(srv.Close)
+		return srv
+	}
+	seamActive := func(t *testing.T, fn func(context.Context) (*coreapi.Client, error)) {
+		t.Helper()
+		prev := activeCoreClient
+		activeCoreClient = fn
+		t.Cleanup(func() { activeCoreClient = prev })
+	}
+	seamCluster := func(t *testing.T, fn func(context.Context, string) (*coreapi.Client, error)) {
+		t.Helper()
+		prev := clusterCoreClient
+		clusterCoreClient = fn
+		t.Cleanup(func() { clusterCoreClient = prev })
+	}
+	runGet := func(t *testing.T, ref string) (string, error) {
+		t.Helper()
+		cmd := newRepoCmd()
+		var out, errW bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&errW)
+		cmd.SetArgs([]string{"mirror", "get", ref})
+		err := cmd.ExecuteContext(t.Context())
+		return out.String(), err
+	}
+
+	t.Run("clone URL dials the cluster's core, not the active context", func(t *testing.T) {
+		srv := mirrorServer(t)
+		seamActive(t, func(context.Context) (*coreapi.Client, error) {
+			t.Error("clone-URL get dialed the active context's core")
+			return nil, errors.New("wrong core")
+		})
+		var gotHost string
+		seamCluster(t, func(_ context.Context, host string) (*coreapi.Client, error) {
+			gotHost = host
+			return coreapi.NewWithBearer(srv.URL, "tok")
+		})
+		out, err := runGet(t, cloneURL)
+		require.NoError(t, err)
+		require.Equal(t, clusterHost, gotHost, "must resolve on the clone URL's cluster")
+		require.Contains(t, out, "entirehq/librarian")
+		require.Contains(t, out, cloneURL)
+	})
+
+	t.Run("ULID dials the active context", func(t *testing.T) {
+		srv := mirrorServer(t)
+		seamActive(t, func(context.Context) (*coreapi.Client, error) {
+			return coreapi.NewWithBearer(srv.URL, "tok")
+		})
+		seamCluster(t, func(_ context.Context, host string) (*coreapi.Client, error) {
+			t.Errorf("ULID get dialed cluster core %q; a ULID has no cluster coordinate", host)
+			return nil, errors.New("wrong core")
+		})
+		out, err := runGet(t, mirrorULID)
+		require.NoError(t, err)
+		require.Contains(t, out, "entirehq/librarian")
+	})
+
+	t.Run("unparseable ref errors before dialing any core", func(t *testing.T) {
+		seamActive(t, func(context.Context) (*coreapi.Client, error) {
+			t.Error("unparseable ref dialed the active context's core")
+			return nil, errors.New("no dial expected")
+		})
+		seamCluster(t, func(context.Context, string) (*coreapi.Client, error) {
+			t.Error("unparseable ref dialed a cluster core")
+			return nil, errors.New("no dial expected")
+		})
+		_, err := runGet(t, "not-a-url")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "pass a mirror ULID or a clone URL")
+	})
+}
+
 func TestMirrorRow(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/796
<!-- entire-trail-link-end -->

## Why

`entire repo mirror get entire://<cluster>/gh/<owner>/<repo>` resolved the mirror on the **active context's** login server, so a clone URL for a cluster in another federation failed with `no mirror matching` until the user switched contexts with `entire auth use`. Not a regression: the clone-URL form was born with this in https://github.com/entireio/cli/pull/1531, which shipped without the cluster routing that https://github.com/entireio/cli/pull/1475 (mirror create/remove/collaborators) and https://github.com/entireio/cli/pull/1529 (repo clone --cluster) already established.

## What

- `mirror get <clone-url>` now dials the login server fronting the URL's cluster (via `coreapi.NewForCluster` — cached well-known discovery + matching local context), so it works regardless of the active context. A ULID ref has no cluster coordinate and stays on the active context; an unparseable ref errors before dialing anything.
- Adds `runCoreObjectForCluster` (mirroring `runCoreListForCluster`) and a `clusterCoreClient` test seam alongside `activeCoreClient`, making cluster-routed commands testable at command level for the first time.
- Help text: documents the routing per ref form and the trailing-`.git` tolerance; says "login server", not "core".

## Verification

- New `TestRepoMirrorGet_Routing` pins all three paths: clone URL must dial the cluster's core and must NOT touch the active context; ULID the reverse; bad ref dials nothing.
- `mise run fmt && mise run lint` clean; `go test ./cmd/entire/cli/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior fix and testable refactors in CLI mirror lookup; no auth or data-model changes beyond dialing the correct control plane for clone URLs.
> 
> **Overview**
> **`entire repo mirror get`** with an `entire://…` clone URL now talks to the login server for the URL’s cluster (`runCoreObjectForCluster` / `coreapi.NewForCluster`), matching create/remove—so mirrors in another federation no longer fail with “no mirror matching” while the wrong context is active. **ULID** refs still use the active context; **invalid** refs fail during parse with no API dial.
> 
> Shared CLI plumbing adds `renderCoreObject`, `runCoreObjectForCluster`, and a `clusterCoreClient` test seam (like list commands). Help text documents per-ref routing and trailing `.git`; `badMirrorRefErr` unifies parse errors. **`TestRepoMirrorGet_Routing`** asserts clone URL vs ULID vs bad-ref dialing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8721e8694abb7dc517eb6194ad9d40cd678e991. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->