### PR TITLE
ENT-1064: stop hinting re-login on trail 403s; name the denying host

### DIFF
--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1762,12 +1762,25 @@ func parseTrailRepoArg(raw string) (forge, owner, repo string, err error) {
 	return info.Forge, info.Owner, info.Repo, nil
 }
 
-// checkTrailResponse checks the API response and returns user-friendly errors.
-// For auth failures, it appends a hint to re-authenticate while preserving the server's error message.
+// checkTrailResponse checks the API response and returns user-friendly errors,
+// preserving the server's error message.
+//
+// The re-login hint is reserved for 401: a 403 means the server validated the
+// credential and denied access anyway, so re-authenticating mints the same
+// authority and sends the user in circles (ENT-1064). For 403 we name the host
+// that denied us instead, so a wrong-server or wrong-account situation is
+// visible from the message alone.
 func checkTrailResponse(resp *http.Response) error {
 	if err := api.CheckResponse(resp); err != nil {
-		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		switch resp.StatusCode {
+		case http.StatusUnauthorized:
 			return fmt.Errorf("%w — run 'entire login' to re-authenticate", err)
+		case http.StatusForbidden:
+			host := "the server"
+			if resp.Request != nil && resp.Request.URL != nil && resp.Request.URL.Host != "" {
+				host = resp.Request.URL.Host
+			}
+			return fmt.Errorf("%w — %s denied access for your account (re-login won't fix a 403; check that your account has access to this repo's trails)", err, host)
 		}
 		return fmt.Errorf("trail API: %w", err)
 	}

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -1450,3 +1450,91 @@ func TestFetchCurrentUserLoginWrapsGhError(t *testing.T) {
 		t.Fatalf("error should mention the --author fallback hint, got: %v", err)
 	}
 }
+
+// checkTrailResponse must reserve the re-login hint for 401: a 403 is an
+// authorization denial for a validated credential, so telling the user to
+// re-login sends them in circles (ENT-1064). The 403 message names the host
+// that denied access and keeps the server's error body.
+func TestCheckTrailResponse(t *testing.T) {
+	t.Parallel()
+
+	respFor := func(t *testing.T, status int, body string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://entire.io/api/v1/trails/gh/acme/app", nil)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}
+	}
+
+	t.Run("2xx passes", func(t *testing.T) {
+		t.Parallel()
+		resp := respFor(t, http.StatusOK, "")
+		defer resp.Body.Close()
+		if err := checkTrailResponse(resp); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("401 hints re-login", func(t *testing.T) {
+		t.Parallel()
+		resp := respFor(t, http.StatusUnauthorized, `{"error":"Not authenticated"}`)
+		defer resp.Body.Close()
+		err := checkTrailResponse(resp)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "run 'entire login' to re-authenticate") {
+			t.Fatalf("401 must hint re-login, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "Not authenticated") {
+			t.Fatalf("401 must preserve the server message, got: %v", err)
+		}
+	})
+
+	t.Run("403 names the denying host and does not hint re-login", func(t *testing.T) {
+		t.Parallel()
+		resp := respFor(t, http.StatusForbidden, `{"error":"Forbidden"}`)
+		defer resp.Body.Close()
+		err := checkTrailResponse(resp)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if strings.Contains(err.Error(), "entire login") {
+			t.Fatalf("403 must not tell the user to re-login, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "entire.io denied access") {
+			t.Fatalf("403 must name the denying host, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "Forbidden") {
+			t.Fatalf("403 must preserve the server message, got: %v", err)
+		}
+	})
+
+	t.Run("403 without a request falls back to a generic host", func(t *testing.T) {
+		t.Parallel()
+		resp := &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"Forbidden"}`)),
+		}
+		defer resp.Body.Close()
+		err := checkTrailResponse(resp)
+		if err == nil || !strings.Contains(err.Error(), "the server denied access") {
+			t.Fatalf("expected generic-host fallback, got: %v", err)
+		}
+	})
+
+	t.Run("other statuses keep the trail API prefix", func(t *testing.T) {
+		t.Parallel()
+		resp := respFor(t, http.StatusInternalServerError, `{"error":"boom"}`)
+		defer resp.Body.Close()
+		err := checkTrailResponse(resp)
+		if err == nil || !strings.Contains(err.Error(), "trail API:") {
+			t.Fatalf("expected trail API prefix, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/798
<!-- entire-trail-link-end -->

## Why

`entire trail show`/`list` mapped both 401 and 403 to "run 'entire login' to re-authenticate" ([ENT-1064](https://linear.app/entirehq/issue/ENT-1064/entire-trail-show-returns-403-even-after-a-fresh-login-with-a)). A 403 is an authorization denial for a credential the server already validated — re-login mints the same authority, so the hint sends the user in circles.

(The actual 403 users are hitting is a BFF bug — bearer-orgs `/userinfo` misrouted to the default core, fixed in https://github.com/entirehq/entire.io/pull/2977 — but the CLI hint is wrong for any 403.)

## What

`checkTrailResponse`: the re-login hint is now 401-only. A 403 keeps the server's error body and names the host that denied access:

```
before: API error: Forbidden (status 403) — run 'entire login' to re-authenticate
after:  API error: Forbidden (status 403) — entire.io denied access for your account (re-login won't fix a 403; check that your account has access to this repo's trails)
```

## Verification

- New `TestCheckTrailResponse` covers 2xx, 401 hint, 403 host naming + no re-login hint, nil-request fallback, and the generic non-auth prefix.
- `go test ./cmd/entire/cli/ -run Trail` passes; `mise run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error text only in a shared trail API helper; no changes to authentication or request handling.
> 
> **Overview**
> Trail API failures from `checkTrailResponse` no longer tell users to run `entire login` on **403** responses—only **401** keeps that hint, since a forbidden response means the credential was already accepted and re-auth does not help.
> 
> **403** errors now keep the server message and add guidance that names the denying host (from the request URL, or a generic fallback) and points users toward account/repo trail access instead of re-login.
> 
> `TestCheckTrailResponse` exercises 2xx success, 401 re-login hint, 403 host naming without re-login, missing-request fallback, and other statuses still using the `trail API:` prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2be06923a237dd969c0f52de8c29fab8eaa06c83. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->