### PR TITLE
repo mirror list: rename REPO column and --repo flag to NAME

### DIFF
--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -18,19 +18,34 @@ import (
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// Column header names, the single source of truth for both the table headers
-// (mirrorColumns/availableMirrorColumns) and the --sort key switches. parseSort-
-// Column returns the canonical header it matched, so the sort switches compare
-// against these constants directly. The NAME header carries an inline
-// "(owner/repo)" hint spelling out what the cell holds; parseSortColumn accepts
-// the header with that trailing parenthetical stripped, so `--sort name` works.
-const (
-	colName     = "NAME (owner/repo)"
-	colCloneURL = "CLONE URL"
-	colPrivate  = "PRIVATE"
-	colAccess   = "ACCESS"
-	colStatus   = "STATUS"
+// column is a table column with two separable identities: key is the canonical
+// name a caller types for --sort (and the value parseSortColumn returns, so the
+// sort switches compare against these constants directly); header is the text
+// shown in the table. They differ only where the header carries a display hint
+// the sort key shouldn't — e.g. NAME's inline "(owner/repo)" — which keeps
+// --sort matching a simple equality on key with no header parsing.
+type column struct {
+	key    string
+	header string
+}
+
+var (
+	colName     = column{key: "NAME", header: "NAME (owner/repo)"}
+	colCloneURL = column{key: "CLONE URL", header: "CLONE URL"}
+	colPrivate  = column{key: "PRIVATE", header: "PRIVATE"}
+	colAccess   = column{key: "ACCESS", header: "ACCESS"}
+	colStatus   = column{key: "STATUS", header: "STATUS"}
 )
+
+// columnHeaders is the display-header view of a column set, for the table/field
+// renderers (runCoreList/runCoreObject) which take plain header strings.
+func columnHeaders(cols []column) []string {
+	h := make([]string, len(cols))
+	for i, c := range cols {
+		h[i] = c.header
+	}
+	return h
+}
 
 // mirrorColumns is the human table/field view of a mirror: the scannable
 // owner/repo name, the clone URL you'd copy, and whether the upstream is
@@ -41,7 +56,7 @@ const (
 // model's internal ids are dropped. The clone URL is synthesised from the
 // mirror's coords (the form `git clone` accepts), since the list API doesn't
 // return it.
-var mirrorColumns = []string{colName, colCloneURL, colPrivate}
+var mirrorColumns = []column{colName, colCloneURL, colPrivate}
 
 // mirrorPrivate renders the PRIVATE column ("yes"/"no"), shared by the table
 // row and the --sort private key so both agree on the cell value.
@@ -58,43 +73,30 @@ func mirrorRow(m coreapi.Mirror) []string {
 	return []string{repo, cloneURL, mirrorPrivate(m)}
 }
 
-// parenHint matches a trailing " (...)" qualifier on a column header, e.g. the
-// "(owner/repo)" in "NAME (owner/repo)". Stripping it yields the friendly short
-// name a caller can type for --sort.
-var parenHint = regexp.MustCompile(`\s*\([^)]*\)$`)
-
-// sortKeyOf returns the header with its trailing parenthetical hint removed,
-// i.e. the short name accepted by --sort ("NAME (owner/repo)" -> "NAME").
-func sortKeyOf(header string) string {
-	return parenHint.ReplaceAllString(header, "")
-}
-
-// parseSortColumn resolves a --sort spec to the canonical column header it
-// names (one of the columns entries) and a direction. It trims first, then
-// reads the '-' prefix, so leading/trailing whitespace is handled identically
-// on every path (the direction and the column name never disagree). An empty
-// spec selects the first column. A spec matches a column by its full header or
-// by the header with its trailing parenthetical hint stripped, so both
-// `--sort "name (owner/repo)"` and the friendly `--sort name` resolve. An
-// unknown name errors naming the valid (short) columns. Returning the matched
-// header lets callers switch on the col* constants directly.
-func parseSortColumn(spec string, columns []string) (col string, desc bool, err error) {
+// parseSortColumn resolves a --sort spec to the column it names and a
+// direction. It trims first, then reads the '-' prefix, so leading/trailing
+// whitespace is handled identically on every path (the direction and the column
+// name never disagree). An empty spec selects the first column. A spec matches a
+// column by its key (case-insensitive) — a plain equality, since key holds no
+// display hint. An unknown name errors naming the valid keys. Returning the
+// matched column lets callers switch on the col* constants directly.
+func parseSortColumn(spec string, columns []column) (col column, desc bool, err error) {
 	spec = strings.TrimSpace(spec)
 	desc = strings.HasPrefix(spec, "-")
 	name := strings.TrimSpace(strings.TrimPrefix(spec, "-"))
 	if name == "" {
 		return columns[0], desc, nil
 	}
-	for _, h := range columns {
-		if strings.EqualFold(h, name) || strings.EqualFold(sortKeyOf(h), name) {
-			return h, desc, nil
+	for _, c := range columns {
+		if strings.EqualFold(c.key, name) {
+			return c, desc, nil
 		}
 	}
 	valid := make([]string, len(columns))
-	for i, h := range columns {
-		valid[i] = strings.ToLower(sortKeyOf(h))
+	for i, c := range columns {
+		valid[i] = strings.ToLower(c.key)
 	}
-	return "", false, fmt.Errorf("unknown sort column %q; valid columns: %s", name, strings.Join(valid, ", "))
+	return column{}, false, fmt.Errorf("unknown sort column %q; valid columns: %s", name, strings.Join(valid, ", "))
 }
 
 // sortMirrors orders mirrors in place by the --sort spec: by the named column's
@@ -196,7 +198,7 @@ func filterByName[T any](items []T, nameOf func(T) string, substr string) []T {
 // clone URL), or "owner-only" (a personal repo of another user; only its
 // owner may mirror it). No clone URL column: an un-onboarded repo doesn't
 // have one yet.
-var availableMirrorColumns = []string{colName, colAccess, colStatus}
+var availableMirrorColumns = []column{colName, colAccess, colStatus}
 
 func availableMirrorRow(m coreapi.AvailableMirror) []string {
 	return []string{m.Owner + "/" + m.Repo, string(m.Access), string(m.Status)}
@@ -521,7 +523,7 @@ func newRepoMirrorListCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if showAvailable {
-				return runCoreList(cmd, "No repos available to mirror.", availableMirrorColumns, availableMirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.AvailableMirror, error) {
+				return runCoreList(cmd, "No repos available to mirror.", columnHeaders(availableMirrorColumns), availableMirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.AvailableMirror, error) {
 					// Computed live from GitHub using your own login, so name the
 					// core being dialled (same rationale as the existing-mirror
 					// banner). --cluster/--provider don't apply here: the
@@ -544,7 +546,7 @@ func newRepoMirrorListCmd() *cobra.Command {
 					return avail, nil
 				})
 			}
-			return runCoreList(cmd, "No mirrors found.", mirrorColumns, mirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Mirror, error) {
+			return runCoreList(cmd, "No mirrors found.", columnHeaders(mirrorColumns), mirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Mirror, error) {
 				// mirror list is identity-scoped: it shows the mirrors visible
 				// from the active login's federation, so naming that login server
 				// makes a surprising empty result legible — e.g. mirrors in a
@@ -593,7 +595,7 @@ func newRepoMirrorListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&provider, "provider", "", "Filter by upstream provider (e.g. github)")
 	cmd.Flags().StringVar(&owner, "owner", "", "Filter by upstream owner login")
 	cmd.Flags().StringVar(&name, "name", "", "Filter by owner/repo substring, matching the NAME column (case-insensitive)")
-	cmd.Flags().StringVar(&sortSpec, "sort", "", "Sort by column (header name; prefix '-' for descending). Default: name ascending")
+	cmd.Flags().StringVar(&sortSpec, "sort", "", "Sort by column (column name; prefix '-' for descending). Default: name ascending")
 	cmd.Flags().BoolVar(&showAvailable, "show-available", false, "Instead of existing mirrors, list GitHub repos you could onboard as mirrors (ignores --cluster/--provider)")
 	return cmd
 }
@@ -609,7 +611,7 @@ func newRepoMirrorGetCmd() *cobra.Command {
 			"  entire repo mirror get entire://aws-us-east-2.entire.io/gh/octocat/hello-world",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoreObject(cmd, mirrorColumns, mirrorRow, func(ctx context.Context, c *coreapi.Client) (*coreapi.Mirror, error) {
+			return runCoreObject(cmd, columnHeaders(mirrorColumns), mirrorRow, func(ctx context.Context, c *coreapi.Client) (*coreapi.Mirror, error) {
 				mirrorID, err := resolveMirrorRef(ctx, c, args[0])
 				if err != nil {
 					return nil, err

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -29,12 +29,14 @@ type column struct {
 	header string
 }
 
+// Keys are lower-case, single shell tokens (kebab-case for multi-word columns)
+// so `--sort clone-url` needs no quoting; headers stay upper-case display text.
 var (
-	colName     = column{key: "NAME", header: "NAME (owner/repo)"}
-	colCloneURL = column{key: "CLONE URL", header: "CLONE URL"}
-	colPrivate  = column{key: "PRIVATE", header: "PRIVATE"}
-	colAccess   = column{key: "ACCESS", header: "ACCESS"}
-	colStatus   = column{key: "STATUS", header: "STATUS"}
+	colName     = column{key: "name", header: "NAME (owner/repo)"}
+	colCloneURL = column{key: "clone-url", header: "CLONE URL"}
+	colPrivate  = column{key: "private", header: "PRIVATE"}
+	colAccess   = column{key: "access", header: "ACCESS"}
+	colStatus   = column{key: "status", header: "STATUS"}
 )
 
 // columnHeaders is the display-header view of a column set, for the table/field
@@ -94,7 +96,7 @@ func parseSortColumn(spec string, columns []column) (col column, desc bool, err 
 	}
 	valid := make([]string, len(columns))
 	for i, c := range columns {
-		valid[i] = strings.ToLower(c.key)
+		valid[i] = c.key
 	}
 	return column{}, false, fmt.Errorf("unknown sort column %q; valid columns: %s", name, strings.Join(valid, ", "))
 }

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -21,9 +21,11 @@ import (
 // Column header names, the single source of truth for both the table headers
 // (mirrorColumns/availableMirrorColumns) and the --sort key switches. parseSort-
 // Column returns the canonical header it matched, so the sort switches compare
-// against these constants directly.
+// against these constants directly. The NAME header carries an inline
+// "(owner/repo)" hint spelling out what the cell holds; parseSortColumn accepts
+// the header with that trailing parenthetical stripped, so `--sort name` works.
 const (
-	colRepo     = "REPO"
+	colName     = "NAME (owner/repo)"
 	colCloneURL = "CLONE URL"
 	colPrivate  = "PRIVATE"
 	colAccess   = "ACCESS"
@@ -34,11 +36,12 @@ const (
 // owner/repo name, the clone URL you'd copy, and whether the upstream is
 // private. Owner, provider, and cluster aren't columns of their own — they're
 // inferable from the owner/repo pair and the clone URL
-// (entire://<cluster>/gh/<owner>/<repo>). `--repo` filters on the repo name
-// only; owner/provider/cluster stay server-side filters, and the wire model's
-// internal ids are dropped. The clone URL is synthesised from the mirror's
-// coords (the form `git clone` accepts), since the list API doesn't return it.
-var mirrorColumns = []string{colRepo, colCloneURL, colPrivate}
+// (entire://<cluster>/gh/<owner>/<repo>). `--name` filters on the owner/repo
+// name only; owner/provider/cluster stay server-side filters, and the wire
+// model's internal ids are dropped. The clone URL is synthesised from the
+// mirror's coords (the form `git clone` accepts), since the list API doesn't
+// return it.
+var mirrorColumns = []string{colName, colCloneURL, colPrivate}
 
 // mirrorPrivate renders the PRIVATE column ("yes"/"no"), shared by the table
 // row and the --sort private key so both agree on the cell value.
@@ -55,13 +58,26 @@ func mirrorRow(m coreapi.Mirror) []string {
 	return []string{repo, cloneURL, mirrorPrivate(m)}
 }
 
+// parenHint matches a trailing " (...)" qualifier on a column header, e.g. the
+// "(owner/repo)" in "NAME (owner/repo)". Stripping it yields the friendly short
+// name a caller can type for --sort.
+var parenHint = regexp.MustCompile(`\s*\([^)]*\)$`)
+
+// sortKeyOf returns the header with its trailing parenthetical hint removed,
+// i.e. the short name accepted by --sort ("NAME (owner/repo)" -> "NAME").
+func sortKeyOf(header string) string {
+	return parenHint.ReplaceAllString(header, "")
+}
+
 // parseSortColumn resolves a --sort spec to the canonical column header it
 // names (one of the columns entries) and a direction. It trims first, then
 // reads the '-' prefix, so leading/trailing whitespace is handled identically
 // on every path (the direction and the column name never disagree). An empty
-// spec selects the first column. An unknown name errors naming the valid
-// columns. Returning the matched header lets callers switch on the col*
-// constants directly.
+// spec selects the first column. A spec matches a column by its full header or
+// by the header with its trailing parenthetical hint stripped, so both
+// `--sort "name (owner/repo)"` and the friendly `--sort name` resolve. An
+// unknown name errors naming the valid (short) columns. Returning the matched
+// header lets callers switch on the col* constants directly.
 func parseSortColumn(spec string, columns []string) (col string, desc bool, err error) {
 	spec = strings.TrimSpace(spec)
 	desc = strings.HasPrefix(spec, "-")
@@ -70,18 +86,22 @@ func parseSortColumn(spec string, columns []string) (col string, desc bool, err 
 		return columns[0], desc, nil
 	}
 	for _, h := range columns {
-		if strings.EqualFold(h, name) {
+		if strings.EqualFold(h, name) || strings.EqualFold(sortKeyOf(h), name) {
 			return h, desc, nil
 		}
 	}
-	return "", false, fmt.Errorf("unknown sort column %q; valid columns: %s", name, strings.ToLower(strings.Join(columns, ", ")))
+	valid := make([]string, len(columns))
+	for i, h := range columns {
+		valid[i] = strings.ToLower(sortKeyOf(h))
+	}
+	return "", false, fmt.Errorf("unknown sort column %q; valid columns: %s", name, strings.Join(valid, ", "))
 }
 
 // sortMirrors orders mirrors in place by the --sort spec: by the named column's
 // value ascending (case-insensitive), always breaking ties by owner/repo then
 // cluster host so a repo mirrored across clusters (or rows equal on any other
 // column) has a stable, deterministic order rather than arbitrary server order.
-// A '-' prefix reverses the whole ordering. `repo`/default sorts by the
+// A '-' prefix reverses the whole ordering. `name`/default sorts by the
 // tiebreak alone.
 func sortMirrors(mirrors []coreapi.Mirror, spec string) error {
 	col, desc, err := parseSortColumn(spec, mirrorColumns)
@@ -94,7 +114,7 @@ func sortMirrors(mirrors []coreapi.Mirror, spec string) error {
 			return strings.ToLower(mirrorCloneURL(m.ClusterHost, m.Owner, m.Repo))
 		case colPrivate:
 			return mirrorPrivate(m)
-		default: // repo -> tiebreak alone
+		default: // name -> tiebreak alone
 			return ""
 		}
 	}
@@ -130,7 +150,7 @@ func sortAvailable(avail []coreapi.AvailableMirror, spec string) error {
 			return strings.ToLower(string(m.Access))
 		case colStatus:
 			return strings.ToLower(string(m.Status))
-		default: // repo -> tiebreak alone
+		default: // name -> tiebreak alone
 			return ""
 		}
 	}
@@ -147,14 +167,14 @@ func sortAvailable(avail []coreapi.AvailableMirror, spec string) error {
 	return nil
 }
 
-// filterByRepo keeps items whose repo identifier contains substr (case-
+// filterByName keeps items whose owner/repo name contains substr (case-
 // insensitive). The control plane already filters by owner/provider/cluster
-// server-side but not by repo name, so `repo mirror list --repo` narrows that
-// last dimension client-side. repoOf returns the item's displayed identifier —
-// the callers pass the owner/repo form shown in the REPO column, so a value
-// copied from the table (e.g. acme/web) matches the row it came from. An empty
-// substr returns items unchanged.
-func filterByRepo[T any](items []T, repoOf func(T) string, substr string) []T {
+// server-side but not by name, so `repo mirror list --name` narrows that last
+// dimension client-side. nameOf returns the item's displayed identifier — the
+// callers pass the owner/repo form shown in the NAME column, so a value copied
+// from the table (e.g. acme/web) matches the row it came from. An empty substr
+// returns items unchanged.
+func filterByName[T any](items []T, nameOf func(T) string, substr string) []T {
 	substr = strings.TrimSpace(substr)
 	if substr == "" {
 		return items
@@ -162,7 +182,7 @@ func filterByRepo[T any](items []T, repoOf func(T) string, substr string) []T {
 	substr = strings.ToLower(substr)
 	out := make([]T, 0, len(items))
 	for _, it := range items {
-		if strings.Contains(strings.ToLower(repoOf(it)), substr) {
+		if strings.Contains(strings.ToLower(nameOf(it)), substr) {
 			out = append(out, it)
 		}
 	}
@@ -176,7 +196,7 @@ func filterByRepo[T any](items []T, repoOf func(T) string, substr string) []T {
 // clone URL), or "owner-only" (a personal repo of another user; only its
 // owner may mirror it). No clone URL column: an un-onboarded repo doesn't
 // have one yet.
-var availableMirrorColumns = []string{colRepo, colAccess, colStatus}
+var availableMirrorColumns = []string{colName, colAccess, colStatus}
 
 func availableMirrorRow(m coreapi.AvailableMirror) []string {
 	return []string{m.Owner + "/" + m.Repo, string(m.Access), string(m.Status)}
@@ -481,7 +501,7 @@ func reportOneShotMirror(out, errW io.Writer, outcome mirrorCreateOutcome, err e
 }
 
 func newRepoMirrorListCmd() *cobra.Command {
-	var cluster, provider, owner, repo string
+	var cluster, provider, owner, name string
 	var sortSpec string
 	var showAvailable bool
 	cmd := &cobra.Command{
@@ -517,7 +537,7 @@ func newRepoMirrorListCmd() *cobra.Command {
 					if err != nil {
 						return nil, err
 					}
-					avail := filterByRepo(out.Available, func(m coreapi.AvailableMirror) string { return m.Owner + "/" + m.Repo }, repo)
+					avail := filterByName(out.Available, func(m coreapi.AvailableMirror) string { return m.Owner + "/" + m.Repo }, name)
 					if err := sortAvailable(avail, sortSpec); err != nil {
 						return nil, err
 					}
@@ -561,7 +581,7 @@ func newRepoMirrorListCmd() *cobra.Command {
 				if err != nil {
 					return nil, err
 				}
-				mirrors = filterByRepo(mirrors, func(m coreapi.Mirror) string { return m.Owner + "/" + m.Repo }, repo)
+				mirrors = filterByName(mirrors, func(m coreapi.Mirror) string { return m.Owner + "/" + m.Repo }, name)
 				if err := sortMirrors(mirrors, sortSpec); err != nil {
 					return nil, err
 				}
@@ -572,8 +592,8 @@ func newRepoMirrorListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&cluster, "cluster", "", "Filter by cluster public host")
 	cmd.Flags().StringVar(&provider, "provider", "", "Filter by upstream provider (e.g. github)")
 	cmd.Flags().StringVar(&owner, "owner", "", "Filter by upstream owner login")
-	cmd.Flags().StringVar(&repo, "repo", "", "Filter by owner/repo substring, matching the REPO column (case-insensitive)")
-	cmd.Flags().StringVar(&sortSpec, "sort", "", "Sort by column (header name; prefix '-' for descending). Default: repo name ascending")
+	cmd.Flags().StringVar(&name, "name", "", "Filter by owner/repo substring, matching the NAME column (case-insensitive)")
+	cmd.Flags().StringVar(&sortSpec, "sort", "", "Sort by column (header name; prefix '-' for descending). Default: name ascending")
 	cmd.Flags().BoolVar(&showAvailable, "show-available", false, "Instead of existing mirrors, list GitHub repos you could onboard as mirrors (ignores --cluster/--provider)")
 	return cmd
 }

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -597,7 +597,7 @@ func newRepoMirrorListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&provider, "provider", "", "Filter by upstream provider (e.g. github)")
 	cmd.Flags().StringVar(&owner, "owner", "", "Filter by upstream owner login")
 	cmd.Flags().StringVar(&name, "name", "", "Filter by owner/repo substring, matching the NAME column (case-insensitive)")
-	cmd.Flags().StringVar(&sortSpec, "sort", "", "Sort by column (column name; prefix '-' for descending). Default: name ascending")
+	cmd.Flags().StringVar(&sortSpec, "sort", "", "Sort by column key (e.g. name, clone-url; prefix '-' for descending). Default: name ascending")
 	cmd.Flags().BoolVar(&showAvailable, "show-available", false, "Instead of existing mirrors, list GitHub repos you could onboard as mirrors (ignores --cluster/--provider)")
 	return cmd
 }

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -380,7 +380,7 @@ func serveMirrorList(t *testing.T, mirrors []coreapi.Mirror, available []coreapi
 
 // execMirrorList runs `list` under a parent that carries the control-plane
 // persistent flags (--json lives there, not on the list command itself), so
-// tests can exercise --json and the client-side --repo/--sort together.
+// tests can exercise --json and the client-side --name/--sort together.
 func execMirrorList(t *testing.T, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
 	parent := &cobra.Command{Use: "mirror"}
@@ -512,7 +512,7 @@ func requireOrder(t *testing.T, s string, needles ...string) {
 	}
 }
 
-// TestRepoMirrorList_FilterSort pins the client-side --repo filter and --sort
+// TestRepoMirrorList_FilterSort pins the client-side --name filter and --sort
 // applied to `repo mirror list` before rendering (server handles
 // owner/provider/cluster), so they shape both the table and --json output and
 // work under --show-available.
@@ -525,19 +525,19 @@ func TestRepoMirrorList_FilterSort(t *testing.T) {
 		{Owner: "other", Repo: "api", ClusterHost: "eu-west-1.entire.io"},
 	}
 
-	t.Run("--repo narrows the table by repo-name substring", func(t *testing.T) {
+	t.Run("--name narrows the table by owner/repo substring", func(t *testing.T) {
 		serveMirrorList(t, mirrors, nil)
-		stdout, _ := runMirrorList(t, "--repo", "cli")
+		stdout, _ := runMirrorList(t, "--name", "cli")
 		require.Contains(t, stdout, "acme/cli")
 		require.NotContains(t, stdout, "acme/web")
 		require.NotContains(t, stdout, "other/api")
 	})
 
-	t.Run("--repo matches the owner/repo form shown in the REPO column", func(t *testing.T) {
-		// A value copied straight from the displayed REPO column must match the
+	t.Run("--name matches the owner/repo form shown in the NAME column", func(t *testing.T) {
+		// A value copied straight from the displayed NAME column must match the
 		// row it came from; filtering on the bare repo name would drop it.
 		serveMirrorList(t, mirrors, nil)
-		stdout, _ := runMirrorList(t, "--repo", "acme/web")
+		stdout, _ := runMirrorList(t, "--name", "acme/web")
 		require.Contains(t, stdout, "acme/web")
 		require.NotContains(t, stdout, "acme/cli")
 		require.NotContains(t, stdout, "other/api")
@@ -550,20 +550,30 @@ func TestRepoMirrorList_FilterSort(t *testing.T) {
 		requireOrder(t, stdout, "acme/cli", "acme/web", "other/api")
 	})
 
-	t.Run("--sort -repo reverses the order", func(t *testing.T) {
+	t.Run("--sort -name reverses the order", func(t *testing.T) {
 		serveMirrorList(t, mirrors, nil)
-		stdout, _ := runMirrorList(t, "--sort", "-repo")
+		stdout, _ := runMirrorList(t, "--sort", "-name")
 		requireOrder(t, stdout, "other/api", "acme/web", "acme/cli")
 	})
 
-	t.Run("--repo applies to --json and keeps [] not null", func(t *testing.T) {
+	t.Run("--sort name (short form) resolves the NAME column", func(t *testing.T) {
+		// The NAME header carries an inline "(owner/repo)" hint, but the friendly
+		// short "name" must still resolve (parseSortColumn strips the hint).
 		serveMirrorList(t, mirrors, nil)
-		stdout, _ := runMirrorList(t, "--repo", "cli", "--json")
+		stdout, _ := runMirrorList(t, "--sort", "name")
+		requireOrder(t, stdout, "acme/cli", "acme/web", "other/api")
+	})
+
+	t.Run("--name applies to --json and keeps [] not null", func(t *testing.T) {
+		serveMirrorList(t, mirrors, nil)
+		// The JSON keys come from the raw coreapi model, unaffected by the NAME
+		// column/flag rename — the wire field stays "repo".
+		stdout, _ := runMirrorList(t, "--name", "cli", "--json")
 		require.Contains(t, stdout, `"repo": "cli"`)
 		require.NotContains(t, stdout, `"repo": "web"`)
 
 		serveMirrorList(t, mirrors, nil)
-		stdout, _ = runMirrorList(t, "--repo", "zzz", "--json")
+		stdout, _ = runMirrorList(t, "--name", "zzz", "--json")
 		require.Contains(t, stdout, "[]")
 		require.NotContains(t, stdout, "null")
 	})
@@ -590,11 +600,11 @@ func TestRepoMirrorList_FilterSort(t *testing.T) {
 		)
 	})
 
-	t.Run("explicit --sort repo keeps the cluster tiebreak (matches default)", func(t *testing.T) {
+	t.Run("explicit --sort name keeps the cluster tiebreak (matches default)", func(t *testing.T) {
 		// A repo on two clusters plus a lexically-earlier repo. Explicit
-		// `--sort repo` must order like the default: owner/repo ascending, and
+		// `--sort name` must order like the default: owner/repo ascending, and
 		// within the duplicate tie, cluster ascending (aws before eu). Guards
-		// against `--sort repo` regressing to a plain single-key sort that would
+		// against `--sort name` regressing to a plain single-key sort that would
 		// drop the tiebreak.
 		dupes := []coreapi.Mirror{
 			{Owner: "acme", Repo: "web", ClusterHost: "eu-west-1.entire.io"},
@@ -602,7 +612,7 @@ func TestRepoMirrorList_FilterSort(t *testing.T) {
 			{Owner: "acme", Repo: "api", ClusterHost: "aws-us-east-2.entire.io"},
 		}
 		serveMirrorList(t, dupes, nil)
-		stdout, _ := runMirrorList(t, "--sort", "repo")
+		stdout, _ := runMirrorList(t, "--sort", "name")
 		// acme/api before acme/web, and within the acme/web tie aws before eu.
 		requireOrder(t, stdout,
 			"entire://aws-us-east-2.entire.io/gh/acme/api",
@@ -610,17 +620,17 @@ func TestRepoMirrorList_FilterSort(t *testing.T) {
 			"entire://eu-west-1.entire.io/gh/acme/web",
 		)
 
-		// -repo reverses the whole ordering, tiebreak included.
+		// -name reverses the whole ordering, tiebreak included.
 		serveMirrorList(t, dupes, nil)
-		stdout, _ = runMirrorList(t, "--sort", "-repo")
+		stdout, _ = runMirrorList(t, "--sort", "-name")
 		requireOrder(t, stdout,
 			"entire://eu-west-1.entire.io/gh/acme/web",
 			"entire://aws-us-east-2.entire.io/gh/acme/web",
 		)
 	})
 
-	t.Run("--repo/--sort apply under --show-available", func(t *testing.T) {
-		// --repo cli keeps two rows (so --sort is observable) and drops the
+	t.Run("--name/--sort apply under --show-available", func(t *testing.T) {
+		// --name cli keeps two rows (so --sort is observable) and drops the
 		// third, so the filter and the sort are both exercised: `access` orders
 		// read before write, i.e. cli-web before cli-api.
 		serveMirrorList(t, nil, []coreapi.AvailableMirror{
@@ -628,13 +638,13 @@ func TestRepoMirrorList_FilterSort(t *testing.T) {
 			{Owner: "acme", Repo: "cli-web", Access: "read", Status: "available"},
 			{Owner: "other", Repo: "srv", Access: "read", Status: "available"},
 		})
-		stdout, _ := runMirrorList(t, "--show-available", "--repo", "cli", "--sort", "access")
-		require.NotContains(t, stdout, "other/srv", "--repo cli must drop the non-matching row")
+		stdout, _ := runMirrorList(t, "--show-available", "--name", "cli", "--sort", "access")
+		require.NotContains(t, stdout, "other/srv", "--name cli must drop the non-matching row")
 		requireOrder(t, stdout, "acme/cli-web", "acme/cli-api")
 	})
 
 	t.Run("--sort private breaks ties deterministically by owner/repo then cluster", func(t *testing.T) {
-		// A non-repo column sort: all rows share the same private value, so the
+		// A non-name column sort: all rows share the same private value, so the
 		// order must fall back to the owner/repo + cluster tiebreak rather than
 		// the eu-first order the server delivered.
 		dupes := []coreapi.Mirror{
@@ -655,7 +665,7 @@ func TestRepoMirrorList_FilterSort(t *testing.T) {
 
 	t.Run("--sort with leading whitespace parses direction like the trimmed spec", func(t *testing.T) {
 		serveMirrorList(t, mirrors, nil)
-		stdout, _ := runMirrorList(t, "--sort", " -repo")
+		stdout, _ := runMirrorList(t, "--sort", " -name")
 		requireOrder(t, stdout, "other/api", "acme/web", "acme/cli")
 	})
 }

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -556,9 +556,9 @@ func TestRepoMirrorList_FilterSort(t *testing.T) {
 		requireOrder(t, stdout, "other/api", "acme/web", "acme/cli")
 	})
 
-	t.Run("--sort name (short form) resolves the NAME column", func(t *testing.T) {
-		// The NAME header carries an inline "(owner/repo)" hint, but the friendly
-		// short "name" must still resolve (parseSortColumn strips the hint).
+	t.Run("--sort name resolves the NAME column by its key", func(t *testing.T) {
+		// The NAME header carries an inline "(owner/repo)" display hint, but the
+		// sort key is the plain "name" — --sort matches on key, not header.
 		serveMirrorList(t, mirrors, nil)
 		stdout, _ := runMirrorList(t, "--sort", "name")
 		requireOrder(t, stdout, "acme/cli", "acme/web", "other/api")

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -1144,10 +1144,10 @@ func TestSortMirrors(t *testing.T) {
 		}, mirrorRepoHosts(m))
 	})
 
-	t.Run("-repo reverses the whole ordering, tiebreak included", func(t *testing.T) {
+	t.Run("-name reverses the whole ordering, tiebreak included", func(t *testing.T) {
 		t.Parallel()
 		m := base()
-		require.NoError(t, sortMirrors(m, "-repo"))
+		require.NoError(t, sortMirrors(m, "-name"))
 		require.Equal(t, []string{
 			"acme/web@eu-west-1.entire.io",
 			"acme/web@aws-us-east-2.entire.io",
@@ -1155,7 +1155,7 @@ func TestSortMirrors(t *testing.T) {
 		}, mirrorRepoHosts(m))
 	})
 
-	t.Run("non-repo column sorts keep the owner/repo+cluster tiebreak", func(t *testing.T) {
+	t.Run("non-name column sorts keep the owner/repo+cluster tiebreak", func(t *testing.T) {
 		t.Parallel()
 		// All three sort keys collide on "private" once acme/api and the aws web
 		// mirror are both public; the deterministic order must fall back to
@@ -1174,7 +1174,7 @@ func TestSortMirrors(t *testing.T) {
 	t.Run("whitespace spec parses direction from the trimmed spec", func(t *testing.T) {
 		t.Parallel()
 		m := base()
-		require.NoError(t, sortMirrors(m, " -repo"))
+		require.NoError(t, sortMirrors(m, " -name"))
 		require.Equal(t, []string{
 			"acme/web@eu-west-1.entire.io",
 			"acme/web@aws-us-east-2.entire.io",
@@ -1187,7 +1187,7 @@ func TestSortMirrors(t *testing.T) {
 		err := sortMirrors(base(), "nope")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unknown sort column")
-		require.Contains(t, err.Error(), "repo")
+		require.Contains(t, err.Error(), "name")
 	})
 }
 
@@ -1220,7 +1220,7 @@ func TestSortAvailable(t *testing.T) {
 	t.Run("whitespace spec parses direction from the trimmed spec", func(t *testing.T) {
 		t.Parallel()
 		a := base()
-		require.NoError(t, sortAvailable(a, " -repo"))
+		require.NoError(t, sortAvailable(a, " -name"))
 		require.Equal(t, []string{"acme/web", "acme/cli", "acme/api"}, repos(a))
 	})
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/799
<!-- entire-trail-link-end -->

## What

Under the `entire repo mirror` group, the column header **REPO** and the `--repo` filter stutter against the group noun (`entire repo mirror list --repo ...`). This renames both:

- Column `REPO` → **`NAME (owner/repo)`** — the inline hint spells out that the cell holds the composite `owner/repo`.
- Flag `--repo` → **`--name`** (hard rename, no alias — the mirror-list filter/sort landed this week, nothing depends on `--repo` yet). Filter semantics unchanged: it still matches the whole `owner/repo` string.

## Notes

- `parseSortColumn` now accepts a column header with its trailing parenthetical hint stripped, so the friendly `--sort name` resolves the NAME column alongside the full `--sort "name (owner/repo)"`.
- **`--json` is unchanged** — it serializes the raw `coreapi` model, not the column headers, so the wire field stays `"repo"` and scripts don't break. A test pins this.
- Scope is limited to `repo mirror list`. Other commands' `--repo`/`REPO` (experts, trail, dispatch, `repo list`, mirror-create wizard) are untouched.

## Verification

- Build OK; `TestRepoMirrorList*` green (added a `--sort name` short-form test).
- `golangci-lint` (pinned 2.11.3) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only rename and sort UX in a recently added command surface; no API or auth changes, with tests covering filter, sort, and JSON stability.
> 
> **Overview**
> **`entire repo mirror list`** drops the redundant **REPO** / **`--repo`** pairing in favor of **`NAME (owner/repo)`** and **`--name`**, with the same owner/repo substring filter and sort behavior (including **`--show-available`**).
> 
> **`parseSortColumn`** now matches column headers with trailing parentheticals stripped via **`sortKeyOf`**, so **`--sort name`** works alongside the full header; unknown-sort errors list the short column names. **`--json`** output is unchanged (wire field stays **`repo`**). Scope is mirror list only—other commands’ **`--repo`** flags are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 570854e73447f44da5476931e5e13e861022afac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->