### PR TITLE
Move control-plane --json off the shared persistent flag

### DIFF
--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -21,16 +21,30 @@ import (
 // addControlPlaneFlags registers the persistent flags shared by every
 // control-plane command group. Persistent so they're inherited by nested
 // subcommands (e.g. `entire repo mirror list`):
-//   - --json: emit the raw wire JSON instead of the default human table.
 //   - --insecure-http-auth: permit the token exchange over plain http://
 //     (local/dev deployments where the core isn't behind TLS). Hidden, as
-//     elsewhere in the CLI.
+//     elsewhere in the CLI. Applies to every subcommand because they all build
+//     a control-plane client.
+//
+// --json is deliberately NOT persistent here: it only makes sense on the read
+// and mutation verbs that render a wire payload, so it's registered per-command
+// with addJSONFlag. A persistent --json was inherited by side-effect verbs
+// (delete, clone, mirror create/remove, grant remove) that silently ignored it;
+// cobra can't hide a persistent flag from a subset of children, so the flag
+// lives on exactly the commands that honor it.
 func addControlPlaneFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().Bool("json", false, "Output raw JSON instead of a table")
 	cmd.PersistentFlags().Bool("insecure-http-auth", false, "Allow authentication over plain HTTP (insecure, for local development only)")
 	if err := cmd.PersistentFlags().MarkHidden("insecure-http-auth"); err != nil {
 		panic(fmt.Sprintf("hide insecure-http-auth flag: %v", err))
 	}
+}
+
+// addJSONFlag registers the local --json flag on a command that renders a wire
+// payload (list/get/create/mutation verbs routed through the runCore* helpers).
+// Local, not persistent, so only these commands advertise and accept it — see
+// addControlPlaneFlags for why. Read it with jsonRequested.
+func addJSONFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool("json", false, "Output raw JSON instead of a table")
 }
 
 // jsonRequested reports whether --json was set on cmd or an ancestor. A

--- a/cmd/entire/cli/corecmd_json_flag_test.go
+++ b/cmd/entire/cli/corecmd_json_flag_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestControlPlaneJSONFlag_OnlyOnHonoringCommands pins the structural fix that
+// moved --json off the shared control-plane persistent flag and onto a local
+// flag registered only where the command actually renders JSON.
+//
+// The old design registered --json persistently on each group root, so it was
+// inherited by every subcommand — including side-effect verbs (delete, clone,
+// mirror create/remove, grant remove) that ignored it, silently accepting a
+// no-op flag. Now the flag exists exactly on the commands that honor it, so the
+// non-honoring commands reject --json with "unknown flag" and their help never
+// advertises it.
+func TestControlPlaneJSONFlag_OnlyOnHonoringCommands(t *testing.T) {
+	t.Parallel()
+
+	// path (relative to the group root) -> honors --json.
+	want := map[string]bool{
+		// org
+		"org create": true,
+		"org list":   true,
+		"org get":    true,
+		"org delete": false,
+		// project
+		"project create": true,
+		"project list":   true,
+		"project get":    true,
+		"project delete": false,
+		// repo
+		"repo create":                    true,
+		"repo list":                      true,
+		"repo get":                       true,
+		"repo delete":                    false,
+		"repo clone":                     false,
+		"repo mirror create":             false,
+		"repo mirror list":               true,
+		"repo mirror get":                true,
+		"repo mirror remove":             false,
+		"repo mirror collaborators list": true,
+		"repo visibility get":            true,
+		"repo visibility set":            true,
+		// grant
+		"grant org add":        true,
+		"grant org list":       true,
+		"grant org remove":     false,
+		"grant project add":    true,
+		"grant project list":   true,
+		"grant project remove": false,
+		"grant repo add":       true,
+		"grant repo list":      true,
+		"grant repo remove":    false,
+	}
+
+	got := map[string]bool{}
+	for _, root := range []*cobra.Command{newOrgCmd(), newProjectCmd(), newRepoCmd(), newGrantCmd()} {
+		collectJSONFlag(t, root, root.Name(), got)
+	}
+
+	// Every command we expect an answer for must exist in the tree, and vice
+	// versa — a drift in either direction (renamed/removed command, or a new
+	// leaf we forgot to classify) should fail loudly.
+	require.Equal(t, sortedKeys(want), sortedKeys(got), "command tree drifted from the expected --json map")
+	for path, expected := range want {
+		require.Equal(t, expected, got[path], "command %q: --json presence mismatch", path)
+	}
+}
+
+// collectJSONFlag walks the command tree rooted at cmd, recording for each leaf
+// command whether --json is visible on it (local flags merged with inherited).
+func collectJSONFlag(t *testing.T, cmd *cobra.Command, path string, out map[string]bool) {
+	t.Helper()
+	children := cmd.Commands()
+	if len(children) == 0 {
+		// Merge parent persistent flags so an accidentally-inherited --json is
+		// still caught here, not just a locally-registered one.
+		out[path] = cmd.Flags().Lookup("json") != nil || cmd.InheritedFlags().Lookup("json") != nil
+		return
+	}
+	for _, child := range children {
+		collectJSONFlag(t, child, path+" "+child.Name(), out)
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/entire/cli/corecmd_list_test.go
+++ b/cmd/entire/cli/corecmd_list_test.go
@@ -38,8 +38,8 @@ func TestRunCoreList_EmptyHumanMessageOnStdout(t *testing.T) {
 // Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestRunCoreList_EmptyJSONIsArray(t *testing.T) {
 	srv := serveOrgList(t, nil)
-	// org list's --json is persistent on the group root, so drive the full
-	// group command with "list" as a subcommand arg.
+	// Drive the full group command so the test covers Cobra's command-tree
+	// wiring as well as the leaf's local --json flag.
 	out, _, err := runCoreCmd(t, newOrgCmd, srv.URL, "list", "--json")
 	require.NoError(t, err)
 	require.JSONEq(t, "[]", out, "empty --json list must be [], not null")

--- a/cmd/entire/cli/corecmd_mutation_test.go
+++ b/cmd/entire/cli/corecmd_mutation_test.go
@@ -41,8 +41,8 @@ func TestOrgCreate_HumanByDefault(t *testing.T) {
 // Not parallel: runCoreCmd swaps the package-level activeCoreClient seam.
 func TestOrgCreate_JSONOnRequest(t *testing.T) {
 	srv := newCreateOrgServer(t)
-	// org create's --json is persistent on the group root, so drive the
-	// full group command with "create" as a subcommand arg.
+	// Drive the full group command so the test covers Cobra's command-tree
+	// wiring as well as the leaf's local --json flag.
 	out, _, err := runCoreCmd(t, newOrgCmd, srv.URL, "create", "acme", "--json")
 	require.NoError(t, err)
 	require.Contains(t, out, `"name": "acme"`)

--- a/cmd/entire/cli/grant.go
+++ b/cmd/entire/cli/grant.go
@@ -145,11 +145,12 @@ func newGrantOrgAddCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&role, "role", "", "Org role: owner, admin, or member (default member)")
+	addJSONFlag(cmd)
 	return cmd
 }
 
 func newGrantOrgListCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "list <org>",
 		Short: "List org members",
 		Args:  cobra.ExactArgs(1),
@@ -173,6 +174,8 @@ func newGrantOrgListCmd() *cobra.Command {
 			})
 		},
 	}
+	addJSONFlag(cmd)
+	return cmd
 }
 
 func newGrantOrgRemoveCmd() *cobra.Command {
@@ -255,11 +258,12 @@ func newGrantProjectAddCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&role, "role", "", "Project role: reader, writer, or admin (required)")
 	markRequired(cmd, "role")
+	addJSONFlag(cmd)
 	return cmd
 }
 
 func newGrantProjectListCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "list <project>",
 		Short: "List project members",
 		Args:  cobra.ExactArgs(1),
@@ -283,6 +287,8 @@ func newGrantProjectListCmd() *cobra.Command {
 			})
 		},
 	}
+	addJSONFlag(cmd)
+	return cmd
 }
 
 func newGrantProjectRemoveCmd() *cobra.Command {
@@ -404,6 +410,7 @@ func newGrantRepoAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&role, "role", "", "Repo role: reader, writer, or admin (required)")
 	bindRepoProjectFlag(cmd, &project)
 	markRequired(cmd, "role")
+	addJSONFlag(cmd)
 	return cmd
 }
 
@@ -434,6 +441,7 @@ func newGrantRepoListCmd() *cobra.Command {
 		},
 	}
 	bindRepoProjectFlag(cmd, &project)
+	addJSONFlag(cmd)
 	return cmd
 }
 

--- a/cmd/entire/cli/org.go
+++ b/cmd/entire/cli/org.go
@@ -53,11 +53,12 @@ func newOrgCreateCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&region, "region", "", "Jurisdiction slug (defaults to the server's home jurisdiction)")
+	addJSONFlag(cmd)
 	return cmd
 }
 
 func newOrgListCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List organizations you can see",
 		Args:  cobra.NoArgs,
@@ -77,10 +78,12 @@ func newOrgListCmd() *cobra.Command {
 			})
 		},
 	}
+	addJSONFlag(cmd)
+	return cmd
 }
 
 func newOrgGetCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "get <org>",
 		Short: "Show an organization by name or ULID",
 		Args:  cobra.ExactArgs(1),
@@ -94,6 +97,8 @@ func newOrgGetCmd() *cobra.Command {
 			})
 		},
 	}
+	addJSONFlag(cmd)
+	return cmd
 }
 
 func newOrgDeleteCmd() *cobra.Command {

--- a/cmd/entire/cli/project.go
+++ b/cmd/entire/cli/project.go
@@ -87,6 +87,7 @@ func newProjectCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&ownerType, "owner-type", "org", "Owner kind: org or account")
 	cmd.Flags().StringVar(&region, "region", "", "Jurisdiction slug (defaults to the server's home jurisdiction)")
 	markRequired(cmd, "owner")
+	addJSONFlag(cmd)
 	return cmd
 }
 
@@ -155,11 +156,12 @@ func newProjectListCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&name, "name", "", "Filter by exact project name")
 	cmd.Flags().StringVar(&org, "org", "", "List projects owned by this org (name or ULID)")
+	addJSONFlag(cmd)
 	return cmd
 }
 
 func newProjectGetCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "get <project>",
 		Short: "Show a project by name or ULID",
 		Args:  cobra.ExactArgs(1),
@@ -173,6 +175,8 @@ func newProjectGetCmd() *cobra.Command {
 			})
 		},
 	}
+	addJSONFlag(cmd)
+	return cmd
 }
 
 func newProjectDeleteCmd() *cobra.Command {

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -151,11 +151,12 @@ func newRepoCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&projectID, "project", "", "Owning project (name or ULID) (required)")
 	cmd.Flags().StringVar(&clusterHost, "cluster-host", "", "Public host of the cluster to pin the repo to (defaults to the jurisdiction default)")
 	markRequired(cmd, "project")
+	addJSONFlag(cmd)
 	return cmd
 }
 
 func newRepoListCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "list <project>",
 		Short: "List repositories in a project",
 		Long:  "List repositories in a project, addressed by name or ULID.",
@@ -180,6 +181,8 @@ func newRepoListCmd() *cobra.Command {
 			})
 		},
 	}
+	addJSONFlag(cmd)
+	return cmd
 }
 
 func newRepoGetCmd() *cobra.Command {
@@ -199,6 +202,7 @@ func newRepoGetCmd() *cobra.Command {
 		},
 	}
 	bindRepoProjectFlag(cmd, &project)
+	addJSONFlag(cmd)
 	return cmd
 }
 
@@ -287,6 +291,7 @@ func newRepoVisibilityGetCmd() *cobra.Command {
 		},
 	}
 	bindRepoProjectFlag(cmd, &project)
+	addJSONFlag(cmd)
 	return cmd
 }
 
@@ -320,6 +325,7 @@ func newRepoVisibilitySetCmd() *cobra.Command {
 		},
 	}
 	bindRepoProjectFlag(cmd, &project)
+	addJSONFlag(cmd)
 	return cmd
 }
 

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -575,11 +575,12 @@ func newRepoMirrorListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&repo, "repo", "", "Filter by owner/repo substring, matching the REPO column (case-insensitive)")
 	cmd.Flags().StringVar(&sortSpec, "sort", "", "Sort by column (header name; prefix '-' for descending). Default: repo name ascending")
 	cmd.Flags().BoolVar(&showAvailable, "show-available", false, "Instead of existing mirrors, list GitHub repos you could onboard as mirrors (ignores --cluster/--provider)")
+	addJSONFlag(cmd)
 	return cmd
 }
 
 func newRepoMirrorGetCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "get <mirror>",
 		Short: "Show a mirror by ULID or clone URL",
 		Long: "Show a mirror. <mirror> is either a mirror ULID or an entire:// clone URL\n" +
@@ -619,6 +620,8 @@ func newRepoMirrorGetCmd() *cobra.Command {
 			return runCoreObjectForCluster(cmd, clusterHost, mirrorColumns, mirrorRow, show)
 		},
 	}
+	addJSONFlag(cmd)
+	return cmd
 }
 
 // resolveMirrorRef turns a mirror reference into its ULID. A ULID passes

--- a/cmd/entire/cli/repo_mirror_collaborators.go
+++ b/cmd/entire/cli/repo_mirror_collaborators.go
@@ -48,7 +48,7 @@ func newRepoMirrorCollaboratorsCmd() *cobra.Command {
 }
 
 func newRepoMirrorCollaboratorsListCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "list <github-url> [cluster-host]",
 		Short: "List the users with access to a mirror",
 		Long: "Lists the principals that can pull the mirror of <github-url> on " +
@@ -83,4 +83,6 @@ func newRepoMirrorCollaboratorsListCmd() *cobra.Command {
 			})
 		},
 	}
+	addJSONFlag(cmd)
+	return cmd
 }

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -379,8 +379,9 @@ func serveMirrorList(t *testing.T, mirrors []coreapi.Mirror, available []coreapi
 }
 
 // execMirrorList runs `list` under a parent that carries the control-plane
-// persistent flags (--json lives there, not on the list command itself), so
-// tests can exercise --json and the client-side --repo/--sort together.
+// persistent flags (--insecure-http-auth); --json is a local flag on the list
+// command itself, so tests can exercise --json and the client-side --repo/--sort
+// together.
 func execMirrorList(t *testing.T, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
 	parent := &cobra.Command{Use: "mirror"}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/806
<!-- entire-trail-link-end -->

## Why
`--json` was registered as a **persistent** flag on the `repo`/`org`/`project`/`grant`
group roots, so every subcommand inherited it — including side-effect verbs
(`delete`, `clone`, `mirror create/remove`, `grant remove`) that never render a
wire payload and **silently accepted `--json` as a no-op**. Help advertised the
flag on commands that ignored it.

Cobra can't hide a persistent flag from a subset of children, so the fix is
structural: register `--json` locally on exactly the commands that honor it.

## What changed
- Dropped `--json` from persistent `addControlPlaneFlags`; kept
  `--insecure-http-auth` persistent (all commands build a client).
- Added `addJSONFlag(cmd)` helper; wired onto the **20 commands** that render via
  the `runCore*` helpers (list/get/create/mutation verbs).
- `jsonRequested()` unchanged.

## Result
- `entire repo clone --json` → `Error: Invalid usage: unknown flag: --json`
  (loud, no longer a silent no-op).
- `repo clone --help` no longer lists `--json`; `repo mirror list --help` still does.
- Honoring commands behave identically.

## Test plan
- New `TestControlPlaneJSONFlag_OnlyOnHonoringCommands` walks all 4 group trees and
  locks the full command→`--json` matrix (drift in either direction fails).
- `cmd/entire/cli` package tests pass; `golangci-lint` v2.11.3 clean.
- Live binary confirms the reject + help behavior above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI flag wiring and UX only; JSON output on honoring commands is unchanged, though scripts that passed `--json` to delete/clone-style verbs will now fail loudly.
> 
> **Overview**
> **`--json` is no longer a persistent flag** on org/project/repo/grant group roots. It is registered locally via **`addJSONFlag`** only on commands that actually render wire JSON through the `runCore*` helpers (list/get/create and similar mutations). **`--insecure-http-auth` stays persistent** on those groups.
> 
> Side-effect commands (**delete**, **clone**, **mirror create/remove**, **grant remove**, etc.) **no longer accept or advertise `--json`**; Cobra returns **unknown flag** instead of silently ignoring it. Help on those verbs no longer lists `--json`. Commands that already honored `--json` behave the same.
> 
> **`TestControlPlaneJSONFlag_OnlyOnHonoringCommands`** walks the four command trees and locks the expected per-leaf `--json` presence so new or renamed commands cannot drift unnoticed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9369605adda556dfe55b88053c7f5c09268e90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->