### PR TITLE
enable: pre-select detected agents instead of skipping the picker

### DIFF
--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1462,13 +1462,15 @@ func setupAgentHooks(ctx context.Context, ag agent.Agent, localDev, forceHooks b
 // Returns the detected/selected agents and any error.
 //
 // On first run (no hooks installed):
-//   - Single detected built-in agent: used automatically
-//   - Single detected external agent: interactive multi-select prompt
-//   - Multiple/no detected agents: interactive multi-select prompt
+//   - Always shows the interactive multi-select (when a TTY is available)
+//   - Pre-selects detected built-in agents so the user can confirm with enter
+//     or add more; detected external agents are shown but not pre-selected
+//   - Non-interactive (no TTY): uses detected agents, else the default agent
 //
 // On re-run (hooks already installed):
-//   - Always shows the interactive multi-select
+//   - Shows the interactive multi-select (when a TTY is available)
 //   - Pre-selects only agents that have hooks installed (respects prior deselection)
+//   - Non-interactive (no TTY): keeps the currently installed agents
 //
 // selectFn overrides the interactive prompt for testing. When nil, the real form is used.
 // It receives available agent names and returns the selected names.
@@ -1484,13 +1486,12 @@ func detectOrSelectAgent(ctx context.Context, w io.Writer, selectFn func(availab
 	if !hasInstalledHooks {
 		switch {
 		case len(detected) == 1:
-			if isBuiltInAgent(detected[0]) {
-				// When a selectFn is provided (e.g. --yes), skip the single-agent
-				// shortcut so the caller's selection logic runs instead.
-				if selectFn == nil {
-					fmt.Fprintf(w, "Detected agent: %s\n\n", detected[0].Type())
-					return detected, nil
-				}
+			// Announce the single detected built-in agent; it is pre-selected
+			// in the multi-select form below so the user can confirm it or add
+			// more. --yes (selectFn != nil) uses the caller's selection and
+			// skips the announcement.
+			if selectFn == nil && isBuiltInAgent(detected[0]) {
+				fmt.Fprintf(w, "Detected agent: %s\n\n", detected[0].Type())
 			}
 
 		case len(detected) > 1:

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1458,22 +1458,49 @@ func setupAgentHooks(ctx context.Context, ag agent.Agent, localDev, forceHooks b
 	return count, nil
 }
 
+// promptAgentSelection shows the interactive multi-select agent picker and
+// returns the chosen agent names. It is a package-level var so tests can
+// substitute it — no real TTY/form is available under `go test`.
+var promptAgentSelection = func(options []huh.Option[string]) ([]string, error) {
+	var selected []string
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Select the agents you want to use").
+				Description("Use space to select, enter to confirm.").
+				Options(options...).
+				Validate(func(sel []string) error {
+					if len(sel) == 0 {
+						return errors.New("please select at least one agent")
+					}
+					return nil
+				}).
+				Value(&selected),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return nil, fmt.Errorf("agent selection cancelled: %w", err)
+	}
+	return selected, nil
+}
+
 // detectOrSelectAgent tries to auto-detect agents, or prompts the user to select.
 // Returns the detected/selected agents and any error.
 //
 // On first run (no hooks installed):
-//   - Always shows the interactive multi-select (when a TTY is available)
+//   - Shows the interactive multi-select (TTY available and no selectFn override)
 //   - Pre-selects detected built-in agents so the user can confirm with enter
 //     or add more; detected external agents are shown but not pre-selected
 //   - Non-interactive (no TTY): uses detected agents, else the default agent
 //
 // On re-run (hooks already installed):
-//   - Shows the interactive multi-select (when a TTY is available)
+//   - Shows the interactive multi-select (TTY available and no selectFn override)
 //   - Pre-selects only agents that have hooks installed (respects prior deselection)
 //   - Non-interactive (no TTY): keeps the currently installed agents
 //
-// selectFn overrides the interactive prompt for testing. When nil, the real form is used.
-// It receives available agent names and returns the selected names.
+// selectFn overrides the prompt with a caller-supplied selection (--yes uses
+// selectAllAgents; tests inject their own), bypassing the form even on a TTY.
+// When nil, the real multi-select form is shown.
 func detectOrSelectAgent(ctx context.Context, w io.Writer, selectFn func(available []string) ([]string, error)) ([]agent.Agent, error) {
 	// Check for agents with hooks already installed (re-run detection)
 	installedAgentNames := GetAgentsWithHooksInstalled(ctx)
@@ -1557,35 +1584,21 @@ func detectOrSelectAgent(ctx context.Context, w io.Writer, selectFn func(availab
 		availableNames = append(availableNames, opt.Value)
 	}
 
-	var selectedAgentNames []string
-	if selectFn != nil {
-		var err error
-		selectedAgentNames, err = selectFn(availableNames)
-		if err != nil {
-			return nil, err
+	// selectFn overrides the prompt with a caller-supplied selection (--yes,
+	// tests). When nil, show the real interactive multi-select. Routing both
+	// through selectFn keeps a single selection step, so there is no "skip the
+	// picker" path a lone detected agent can slip back into.
+	if selectFn == nil {
+		selectFn = func([]string) ([]string, error) {
+			return promptAgentSelection(options)
 		}
-		if len(selectedAgentNames) == 0 {
-			return nil, errors.New("no agents selected")
-		}
-	} else {
-		form := NewAccessibleForm(
-			huh.NewGroup(
-				huh.NewMultiSelect[string]().
-					Title("Select the agents you want to use").
-					Description("Use space to select, enter to confirm.").
-					Options(options...).
-					Validate(func(selected []string) error {
-						if len(selected) == 0 {
-							return errors.New("please select at least one agent")
-						}
-						return nil
-					}).
-					Value(&selectedAgentNames),
-			),
-		)
-		if err := form.Run(); err != nil {
-			return nil, fmt.Errorf("agent selection cancelled: %w", err)
-		}
+	}
+	selectedAgentNames, err := selectFn(availableNames)
+	if err != nil {
+		return nil, err
+	}
+	if len(selectedAgentNames) == 0 {
+		return nil, errors.New("no agents selected")
 	}
 
 	selectedAgents := make([]agent.Agent, 0, len(selectedAgentNames))

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -1175,6 +1175,9 @@ func TestDetectOrSelectAgent_AgentDetected(t *testing.T) {
 		t.Fatalf("Failed to create .claude directory: %v", err)
 	}
 
+	// No TTY here, so this exercises the non-interactive fallback: the single
+	// detected agent is used without a picker. The interactive path pre-selects
+	// it in the multi-select instead (see FirstRun_SingleBuiltIn test below).
 	var buf bytes.Buffer
 	agents, err := detectOrSelectAgent(context.Background(), &buf, nil)
 	if err != nil {
@@ -1224,6 +1227,48 @@ func TestDetectOrSelectAgent_GeminiDetected(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "Detected agent:") {
 		t.Errorf("Expected output to contain 'Detected agent:', got: %s", output)
+	}
+}
+
+func TestDetectOrSelectAgent_FirstRun_SingleBuiltIn_PromptsWithDetectedPreSelected(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+
+	// Create .claude directory so exactly one built-in agent (Claude Code) is detected.
+	if err := os.MkdirAll(".claude", 0o755); err != nil {
+		t.Fatalf("Failed to create .claude directory: %v", err)
+	}
+
+	// First run: no hooks installed yet.
+	if installed := GetAgentsWithHooksInstalled(context.Background()); len(installed) != 0 {
+		t.Fatalf("Expected no installed hooks on first run, got %v", installed)
+	}
+
+	// selectFn stands in for the interactive form. The detected agent is
+	// pre-selected in the real form; here the user keeps it and adds a second.
+	var receivedAvailable []string
+	selectFn := func(available []string) ([]string, error) {
+		receivedAvailable = available
+		return []string{string(agent.AgentNameClaudeCode), string(agent.AgentNameGemini)}, nil
+	}
+
+	var buf bytes.Buffer
+	agents, err := detectOrSelectAgent(context.Background(), &buf, selectFn)
+	if err != nil {
+		t.Fatalf("detectOrSelectAgent() error = %v", err)
+	}
+
+	// A lone detected built-in agent must no longer be auto-used; the selection
+	// path runs so the user can confirm it or add more agents.
+	if len(receivedAvailable) == 0 {
+		t.Fatal("Expected the agent selection prompt for a single detected agent, but selectFn was not called")
+	}
+	if !slices.Contains(receivedAvailable, string(agent.AgentNameClaudeCode)) {
+		t.Errorf("Expected the detected agent to be offered, got %v", receivedAvailable)
+	}
+	if len(agents) != 2 {
+		t.Fatalf("Expected the user's selection of 2 agents to be honored, got %d", len(agents))
 	}
 }
 

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/huh/v2"
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
@@ -1230,8 +1231,9 @@ func TestDetectOrSelectAgent_GeminiDetected(t *testing.T) {
 	}
 }
 
-func TestDetectOrSelectAgent_FirstRun_SingleBuiltIn_PromptsWithDetectedPreSelected(t *testing.T) {
-	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+func TestDetectOrSelectAgent_FirstRun_SingleBuiltIn_ShowsPickerPreSelected(t *testing.T) {
+	// Not parallel: uses t.Chdir/t.Setenv and swaps the package-level
+	// promptAgentSelection seam.
 	setupTestRepo(t)
 	t.Setenv("ENTIRE_TEST_TTY", "1")
 
@@ -1245,30 +1247,39 @@ func TestDetectOrSelectAgent_FirstRun_SingleBuiltIn_PromptsWithDetectedPreSelect
 		t.Fatalf("Expected no installed hooks on first run, got %v", installed)
 	}
 
-	// selectFn stands in for the interactive form. The detected agent is
-	// pre-selected in the real form; here the user keeps it and adds a second.
-	var receivedAvailable []string
-	selectFn := func(available []string) ([]string, error) {
-		receivedAvailable = available
-		return []string{string(agent.AgentNameClaudeCode), string(agent.AgentNameGemini)}, nil
+	// Stub the real picker so we can assert it is shown (rather than the agent
+	// being auto-used) and inspect which options it was given. Driving the
+	// selectFn == nil path is what makes this a real regression guard: the old
+	// shortcut returned early precisely when selectFn == nil, so a test that
+	// injected a selectFn would have passed even before the fix.
+	prev := promptAgentSelection
+	t.Cleanup(func() { promptAgentSelection = prev })
+	var offered []string
+	var shown bool
+	promptAgentSelection = func(options []huh.Option[string]) ([]string, error) {
+		shown = true
+		for _, o := range options {
+			offered = append(offered, o.Value)
+		}
+		return []string{string(agent.AgentNameClaudeCode)}, nil
 	}
 
 	var buf bytes.Buffer
-	agents, err := detectOrSelectAgent(context.Background(), &buf, selectFn)
+	agents, err := detectOrSelectAgent(context.Background(), &buf, nil)
 	if err != nil {
 		t.Fatalf("detectOrSelectAgent() error = %v", err)
 	}
 
-	// A lone detected built-in agent must no longer be auto-used; the selection
-	// path runs so the user can confirm it or add more agents.
-	if len(receivedAvailable) == 0 {
-		t.Fatal("Expected the agent selection prompt for a single detected agent, but selectFn was not called")
+	// A lone detected built-in agent must no longer be auto-used: the picker
+	// must be shown so the user can confirm it or add more.
+	if !shown {
+		t.Fatal("Expected the picker to be shown for a single detected agent, but it was auto-used")
 	}
-	if !slices.Contains(receivedAvailable, string(agent.AgentNameClaudeCode)) {
-		t.Errorf("Expected the detected agent to be offered, got %v", receivedAvailable)
+	if !slices.Contains(offered, string(agent.AgentNameClaudeCode)) {
+		t.Errorf("Expected the detected agent among the picker options, got %v", offered)
 	}
-	if len(agents) != 2 {
-		t.Fatalf("Expected the user's selection of 2 agents to be honored, got %d", len(agents))
+	if len(agents) != 1 || agents[0].Name() != agent.AgentNameClaudeCode {
+		t.Fatalf("Expected the picked agent [claude-code] to be returned, got %v", agents)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/800
<!-- entire-trail-link-end -->

## What

On first run, `entire enable` auto-detects coding agents. When exactly **one built-in agent** was detected, the CLI used it automatically and **skipped the multi-select picker entirely** — so you couldn't add more agents without re-running the command.

This routes the single-detected-agent case through the same multi-select picker already used by the multi-agent and re-run paths. Detected built-in agents are pre-selected (via the existing `preSelectedSet` → `hookAgentOptions` → `opt.Selected(true)` machinery), so you can just hit **enter** to accept, or tick more agents first.

## Behavior

- **Interactive (TTY), single detected built-in agent:** now shows the picker with the detected agent pre-checked (was: auto-used, no picker).
- **Non-interactive (no TTY):** unchanged — still uses the detected agent(s) without prompting.
- **`--yes`:** unchanged — still uses the caller's selection logic.
- **Detected external agents:** unchanged — shown but not pre-selected (existing, tested policy).

## Changes

- `cmd/entire/cli/setup.go` — `detectOrSelectAgent`: the single-detected-agent case now only announces the agent and falls through to the shared picker instead of returning early; doc comment updated to describe the generalized behavior (incl. TTY caveats).
- `cmd/entire/cli/setup_test.go` — added `TestDetectOrSelectAgent_FirstRun_SingleBuiltIn_PromptsWithDetectedPreSelected` (guards against re-introducing an unconditional skip-the-picker shortcut); clarifying comment on the existing non-TTY test.

## Testing

`mise run check` passes (fmt, lint, unit + integration + E2E canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI setup UX only; non-interactive and `--yes` paths are unchanged and covered by tests.
> 
> **Overview**
> **Interactive first-run enable** no longer skips the agent multi-select when exactly one built-in agent is auto-detected. `detectOrSelectAgent` drops the early return that auto-installed that agent; it still prints **Detected agent:** when appropriate, then uses the same picker as other paths, with detected built-ins **pre-checked** via the existing `preSelectedSet` → `hookAgentOptions` flow so Enter confirms or you can add more agents.
> 
> **Unchanged:** no-TTY still uses detected agents (or default); `--yes` / injected `selectFn` still bypasses the form; external-only detection behavior stays the same.
> 
> **Tests:** new `TestDetectOrSelectAgent_FirstRun_SingleBuiltIn_PromptsWithDetectedPreSelected` plus a comment on the non-TTY single-detection test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44e02205ca374b0766e1048418f70dd518fdae00. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->