### PR TITLE
Add worktree checkout for trails

### DIFF
--- a/cmd/entire/cli/trail_checkout_cmd_test.go
+++ b/cmd/entire/cli/trail_checkout_cmd_test.go
@@ -130,6 +130,7 @@ func TestShellQuotePath(t *testing.T) {
 }
 
 func TestCheckoutTrailWorktreeCreatesRepoLocalWorktree(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
 	paths.ClearWorktreeRootCache()
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
@@ -172,6 +173,7 @@ func TestCheckoutTrailWorktreeCreatesRepoLocalWorktree(t *testing.T) {
 }
 
 func TestEnsureTrailWorktreeLocalExcludeIsIdempotent(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
 	paths.ClearWorktreeRootCache()
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
@@ -196,6 +198,7 @@ func TestEnsureTrailWorktreeLocalExcludeIsIdempotent(t *testing.T) {
 }
 
 func TestCheckoutTrailWorktreeFetchesRemoteOnlyBranch(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
 	paths.ClearWorktreeRootCache()
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
@@ -236,6 +239,7 @@ func TestCheckoutTrailWorktreeFetchesRemoteOnlyBranch(t *testing.T) {
 }
 
 func TestCheckoutTrailWorktreeReusesExistingWorktree(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
 	paths.ClearWorktreeRootCache()
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
@@ -257,6 +261,16 @@ func TestCheckoutTrailWorktreeReusesExistingWorktree(t *testing.T) {
 	}
 	if !strings.Contains(secondOut.String(), "Worktree already exists") {
 		t.Fatalf("second output = %q, want existing worktree message", secondOut.String())
+	}
+}
+
+func TestCheckoutTrailWorktreeRejectsInvalidBranch(t *testing.T) {
+	t.Parallel()
+
+	var out, errOut bytes.Buffer
+	err := checkoutTrailWorktree(context.Background(), &out, &errOut, "-bad", true, 1)
+	if err == nil || !strings.Contains(err.Error(), "invalid branch") {
+		t.Fatalf("error = %v, want invalid branch", err)
 	}
 }
 

--- a/cmd/entire/cli/trail_checkout_cmd_test.go
+++ b/cmd/entire/cli/trail_checkout_cmd_test.go
@@ -6,10 +6,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
 func TestResolveTrailBySelector_FindsBySelector(t *testing.T) {
@@ -104,6 +109,157 @@ func TestDescribeTrailRef(t *testing.T) {
 	}
 }
 
+func TestDefaultTrailWorktreePath(t *testing.T) {
+	t.Parallel()
+
+	got := defaultTrailWorktreePath("/repo", "peter/feature.auth", 123)
+	want := filepath.Join("/repo", ".entire", "worktrees", "trail-123-peter-feature.auth")
+	if got != want {
+		t.Fatalf("defaultTrailWorktreePath() = %q, want %q", got, want)
+	}
+}
+
+func TestShellQuotePath(t *testing.T) {
+	t.Parallel()
+
+	got := shellQuotePath("/tmp/it's here")
+	want := `'/tmp/it'\''s here'`
+	if got != want {
+		t.Fatalf("shellQuotePath() = %q, want %q", got, want)
+	}
+}
+
+func TestCheckoutTrailWorktreeCreatesRepoLocalWorktree(t *testing.T) {
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "README.md", "test\n")
+	runTrailCheckoutGit(t, repoDir, "add", "README.md")
+	runTrailCheckoutGit(t, repoDir, "commit", "-m", "initial")
+	runTrailCheckoutGit(t, repoDir, "branch", "feature/test")
+	startBranch := currentBranchTrailCheckoutTest(t, repoDir)
+	t.Chdir(repoDir)
+
+	var out, errOut bytes.Buffer
+	err := checkoutTrailWorktree(context.Background(), &out, &errOut, "feature/test", true, 7)
+	if err != nil {
+		t.Fatalf("checkoutTrailWorktree: %v; stderr: %s", err, errOut.String())
+	}
+
+	wantPath := filepath.Join(repoDir, ".entire", "worktrees", "trail-7-feature-test")
+	if !strings.Contains(out.String(), wantPath) {
+		t.Fatalf("output = %q, want path %q", out.String(), wantPath)
+	}
+	if !strings.Contains(out.String(), "cd '") || !strings.Contains(out.String(), "trail-7-feature-test'") {
+		t.Fatalf("output = %q, want cd hint", out.String())
+	}
+	if got := currentBranchTrailCheckoutTest(t, repoDir); got != startBranch {
+		t.Fatalf("current branch = %q, want %s", got, startBranch)
+	}
+	if got := currentBranchTrailCheckoutTest(t, wantPath); got != "feature/test" {
+		t.Fatalf("worktree branch = %q, want feature/test", got)
+	}
+	excludeBytes, err := os.ReadFile(filepath.Join(repoDir, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	exclude := string(excludeBytes)
+	if !strings.Contains(exclude, ".entire/worktrees/") {
+		t.Fatalf("exclude = %q, want .entire/worktrees/", exclude)
+	}
+}
+
+func TestEnsureTrailWorktreeLocalExcludeIsIdempotent(t *testing.T) {
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	if err := ensureTrailWorktreeLocalExclude(context.Background()); err != nil {
+		t.Fatalf("ensureTrailWorktreeLocalExclude first: %v", err)
+	}
+	if err := ensureTrailWorktreeLocalExclude(context.Background()); err != nil {
+		t.Fatalf("ensureTrailWorktreeLocalExclude second: %v", err)
+	}
+
+	excludeBytes, err := os.ReadFile(filepath.Join(repoDir, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	if got := strings.Count(string(excludeBytes), ".entire/worktrees/"); got != 1 {
+		t.Fatalf("exclude rule count = %d, want 1; content: %q", got, string(excludeBytes))
+	}
+}
+
+func TestCheckoutTrailWorktreeFetchesRemoteOnlyBranch(t *testing.T) {
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	tmp := t.TempDir()
+	originDir := filepath.Join(tmp, "origin.git")
+	seedDir := filepath.Join(tmp, "seed")
+	repoDir := filepath.Join(tmp, "local")
+	runTrailCheckoutGit(t, tmp, "init", "--bare", originDir)
+	testutil.InitRepo(t, seedDir)
+	testutil.WriteFile(t, seedDir, "README.md", "test\n")
+	runTrailCheckoutGit(t, seedDir, "add", "README.md")
+	runTrailCheckoutGit(t, seedDir, "commit", "-m", "initial")
+	runTrailCheckoutGit(t, seedDir, "checkout", "-b", "feature/remote")
+	testutil.WriteFile(t, seedDir, "remote.txt", "remote\n")
+	runTrailCheckoutGit(t, seedDir, "add", "remote.txt")
+	runTrailCheckoutGit(t, seedDir, "commit", "-m", "remote branch")
+	runTrailCheckoutGit(t, seedDir, "remote", "add", "origin", originDir)
+	runTrailCheckoutGit(t, seedDir, "push", "origin", "master", "feature/remote")
+	runTrailCheckoutGit(t, tmp, "clone", originDir, repoDir)
+	t.Chdir(repoDir)
+	startBranch := currentBranchTrailCheckoutTest(t, repoDir)
+
+	var out, errOut bytes.Buffer
+	if err := checkoutTrailWorktree(context.Background(), &out, &errOut, "feature/remote", true, 12); err != nil {
+		t.Fatalf("checkoutTrailWorktree: %v; stderr: %s", err, errOut.String())
+	}
+
+	wantPath := filepath.Join(repoDir, ".entire", "worktrees", "trail-12-feature-remote")
+	if got := currentBranchTrailCheckoutTest(t, repoDir); got != startBranch {
+		t.Fatalf("current branch = %q, want %s", got, startBranch)
+	}
+	if got := currentBranchTrailCheckoutTest(t, wantPath); got != "feature/remote" {
+		t.Fatalf("worktree branch = %q, want feature/remote", got)
+	}
+	if _, err := os.Stat(filepath.Join(wantPath, "remote.txt")); err != nil {
+		t.Fatalf("remote branch file missing: %v", err)
+	}
+}
+
+func TestCheckoutTrailWorktreeReusesExistingWorktree(t *testing.T) {
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "README.md", "test\n")
+	runTrailCheckoutGit(t, repoDir, "add", "README.md")
+	runTrailCheckoutGit(t, repoDir, "commit", "-m", "initial")
+	runTrailCheckoutGit(t, repoDir, "branch", "feature/reuse")
+	t.Chdir(repoDir)
+
+	var firstOut, firstErr bytes.Buffer
+	if err := checkoutTrailWorktree(context.Background(), &firstOut, &firstErr, "feature/reuse", true, 9); err != nil {
+		t.Fatalf("checkoutTrailWorktree first: %v; stderr: %s", err, firstErr.String())
+	}
+	var secondOut, secondErr bytes.Buffer
+	if err := checkoutTrailWorktree(context.Background(), &secondOut, &secondErr, "feature/reuse", true, 9); err != nil {
+		t.Fatalf("checkoutTrailWorktree second: %v; stderr: %s", err, secondErr.String())
+	}
+	if !strings.Contains(secondOut.String(), "Worktree already exists") {
+		t.Fatalf("second output = %q, want existing worktree message", secondOut.String())
+	}
+}
+
 func TestTrailCheckoutRejectsArgWithTrailFlag(t *testing.T) {
 	t.Parallel()
 
@@ -119,4 +275,25 @@ func TestTrailCheckoutRejectsArgWithTrailFlag(t *testing.T) {
 	if !strings.Contains(err.Error(), "cannot combine") {
 		t.Fatalf("error = %q, want it to mention 'cannot combine'", err)
 	}
+}
+
+func runTrailCheckoutGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+}
+
+func currentBranchTrailCheckoutTest(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", "branch", "--show-current")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git branch --show-current failed: %v", err)
+	}
+	return strings.TrimSpace(string(output))
 }

--- a/cmd/entire/cli/trail_checkout_cmd_test.go
+++ b/cmd/entire/cli/trail_checkout_cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -169,6 +170,45 @@ func TestCheckoutTrailWorktreeCreatesRepoLocalWorktree(t *testing.T) {
 	exclude := string(excludeBytes)
 	if !strings.Contains(exclude, ".entire/worktrees/") {
 		t.Fatalf("exclude = %q, want .entire/worktrees/", exclude)
+	}
+}
+
+func TestCheckoutTrailWorktreeFromLinkedWorktreeCreatesSiblingUnderMainRoot(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "README.md", "test\n")
+	runTrailCheckoutGit(t, repoDir, "add", "README.md")
+	runTrailCheckoutGit(t, repoDir, "commit", "-m", "initial")
+	runTrailCheckoutGit(t, repoDir, "branch", "feature/first")
+	runTrailCheckoutGit(t, repoDir, "branch", "feature/second")
+	t.Chdir(repoDir)
+
+	var firstOut, firstErr bytes.Buffer
+	if err := checkoutTrailWorktree(context.Background(), &firstOut, &firstErr, "feature/first", true, 7); err != nil {
+		t.Fatalf("checkoutTrailWorktree first: %v; stderr: %s", err, firstErr.String())
+	}
+	firstPath := filepath.Join(repoDir, ".entire", "worktrees", "trail-7-feature-first")
+	t.Chdir(firstPath)
+
+	var secondOut, secondErr bytes.Buffer
+	if err := checkoutTrailWorktree(context.Background(), &secondOut, &secondErr, "feature/second", true, 8); err != nil {
+		t.Fatalf("checkoutTrailWorktree second: %v; stderr: %s", err, secondErr.String())
+	}
+
+	wantPath := filepath.Join(repoDir, ".entire", "worktrees", "trail-8-feature-second")
+	nestedPath := filepath.Join(firstPath, ".entire", "worktrees", "trail-8-feature-second")
+	if !strings.Contains(secondOut.String(), wantPath) {
+		t.Fatalf("output = %q, want main-root path %q", secondOut.String(), wantPath)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("sibling worktree missing: %v", err)
+	}
+	if _, err := os.Stat(nestedPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("nested worktree stat error = %v, want not exist", err)
 	}
 }
 

--- a/cmd/entire/cli/trail_checkout_cmd_test.go
+++ b/cmd/entire/cli/trail_checkout_cmd_test.go
@@ -278,6 +278,27 @@ func TestCheckoutTrailWorktreeFetchesRemoteOnlyBranch(t *testing.T) {
 	}
 }
 
+func TestFindWorktreeForBranchIgnoresMainWorktree(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "README.md", "test\n")
+	runTrailCheckoutGit(t, repoDir, "add", "README.md")
+	runTrailCheckoutGit(t, repoDir, "commit", "-m", "initial")
+	t.Chdir(repoDir)
+
+	path, ok, err := findWorktreeForBranch(context.Background(), currentBranchTrailCheckoutTest(t, repoDir))
+	if err != nil {
+		t.Fatalf("findWorktreeForBranch: %v", err)
+	}
+	if ok {
+		t.Fatalf("findWorktreeForBranch returned %q, want no managed worktree for main checkout", path)
+	}
+}
+
 func TestCheckoutTrailWorktreeReusesExistingWorktree(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	paths.ClearWorktreeRootCache()

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1472,6 +1472,12 @@ func fetchTrailWorktreeBranch(ctx context.Context, branch string) error {
 }
 
 func findWorktreeForBranch(ctx context.Context, branch string) (string, bool, error) {
+	baseRoot, err := trailWorktreeBaseRoot(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to find main worktree root: %w", err)
+	}
+	managedRoot := normalizeWorktreePath(filepath.Join(baseRoot, ".entire", "worktrees"))
+
 	cmd := exec.CommandContext(ctx, "git", "worktree", "list", "--porcelain")
 	output, err := cmd.Output()
 	if err != nil {
@@ -1480,12 +1486,19 @@ func findWorktreeForBranch(ctx context.Context, branch string) (string, bool, er
 	var currentPath string
 	for _, line := range strings.Split(string(output), "\n") {
 		line = strings.TrimSpace(line)
+		if line == "" {
+			currentPath = ""
+			continue
+		}
 		if strings.HasPrefix(line, "worktree ") {
 			currentPath = strings.TrimSpace(strings.TrimPrefix(line, "worktree "))
 			continue
 		}
 		if strings.TrimPrefix(line, "branch ") == "refs/heads/"+branch && currentPath != "" {
-			return currentPath, true, nil
+			normalizedPath := normalizeWorktreePath(currentPath)
+			if normalizedPath == managedRoot || strings.HasPrefix(normalizedPath, managedRoot+string(filepath.Separator)) {
+				return currentPath, true, nil
+			}
 		}
 	}
 	return "", false, nil

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1322,7 +1322,10 @@ func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool,
 	})
 }
 
-func checkoutTrailWorktree(ctx context.Context, w, errW io.Writer, branch string, force bool, trailNumber int) error {
+func checkoutTrailWorktree(ctx context.Context, w, _ io.Writer, branch string, force bool, trailNumber int) error {
+	if err := ValidateBranchName(ctx, branch); err != nil {
+		return err
+	}
 	if existing, ok, err := findWorktreeForBranch(ctx, branch); err != nil {
 		return err
 	} else if ok {
@@ -1331,8 +1334,13 @@ func checkoutTrailWorktree(ctx context.Context, w, errW io.Writer, branch string
 		return nil
 	}
 
-	if err := ensureTrailWorktreeBranchAvailable(ctx, w, branch, force); err != nil {
+	proceed, err := ensureTrailWorktreeBranchAvailable(ctx, w, branch, force)
+	if err != nil {
 		return err
+	}
+	if !proceed {
+		fmt.Fprintf(w, "Checkout of branch %s cancelled.\n", branch)
+		return nil
 	}
 	if err := ensureTrailWorktreeLocalExclude(ctx); err != nil {
 		return err
@@ -1349,7 +1357,6 @@ func checkoutTrailWorktree(ctx context.Context, w, errW io.Writer, branch string
 
 	cmd := exec.CommandContext(ctx, "git", "worktree", "add", worktreePath, branch)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		fmt.Fprintf(errW, "Error: failed to create worktree: %v\n", err)
 		return fmt.Errorf("failed to create worktree: %s: %w", strings.TrimSpace(string(output)), err)
 	}
 	fmt.Fprintf(w, "✓ Worktree ready at %s\n", worktreePath)
@@ -1405,37 +1412,37 @@ func gitCommonDirForTrailWorktree(ctx context.Context) (string, error) {
 	return filepath.Clean(gitDir), nil
 }
 
-func ensureTrailWorktreeBranchAvailable(ctx context.Context, w io.Writer, branch string, force bool) error {
+func ensureTrailWorktreeBranchAvailable(ctx context.Context, w io.Writer, branch string, force bool) (bool, error) {
 	exists, err := BranchExistsLocally(ctx, branch)
 	if err != nil {
-		return fmt.Errorf("failed to check branch: %w", err)
+		return false, fmt.Errorf("failed to check branch: %w", err)
 	}
 	if exists {
-		return nil
+		return true, nil
 	}
 
 	remoteExists, err := BranchExistsOnRemote(ctx, branch)
 	if err != nil {
-		return fmt.Errorf("failed to check remote branch: %w", err)
+		return false, fmt.Errorf("failed to check remote branch: %w", err)
 	}
 	if !remoteExists {
-		return fmt.Errorf("branch '%s' not found locally or on origin", branch)
+		return false, fmt.Errorf("branch '%s' not found locally or on origin", branch)
 	}
 	if !force {
 		shouldFetch, err := promptFetchFromRemote(branch)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if !shouldFetch {
-			return errors.New("checkout cancelled")
+			return false, nil
 		}
 	}
 
 	fmt.Fprintf(w, "Fetching branch '%s' from origin...\n", branch)
 	if err := fetchTrailWorktreeBranch(ctx, branch); err != nil {
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 func fetchTrailWorktreeBranch(ctx context.Context, branch string) error {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -19,7 +19,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
-	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trail"
 
@@ -1346,9 +1345,9 @@ func checkoutTrailWorktree(ctx context.Context, w, _ io.Writer, branch string, f
 		return err
 	}
 
-	repoRoot, err := paths.WorktreeRoot(ctx)
+	repoRoot, err := trailWorktreeBaseRoot(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to find worktree root: %w", err)
+		return fmt.Errorf("failed to find main worktree root: %w", err)
 	}
 	worktreePath := defaultTrailWorktreePath(repoRoot, branch, trailNumber)
 	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o750); err != nil {
@@ -1362,6 +1361,17 @@ func checkoutTrailWorktree(ctx context.Context, w, _ io.Writer, branch string, f
 	fmt.Fprintf(w, "✓ Worktree ready at %s\n", worktreePath)
 	fmt.Fprintf(w, "cd %s\n", shellQuotePath(worktreePath))
 	return nil
+}
+
+func trailWorktreeBaseRoot(ctx context.Context) (string, error) {
+	gitDir, err := gitCommonDirForTrailWorktree(ctx)
+	if err != nil {
+		return "", err
+	}
+	if filepath.Base(gitDir) != ".git" {
+		return "", fmt.Errorf("git common dir %q is not a .git directory", gitDir)
+	}
+	return filepath.Dir(gitDir), nil
 }
 
 func ensureTrailWorktreeLocalExclude(ctx context.Context) error {
@@ -1407,7 +1417,11 @@ func gitCommonDirForTrailWorktree(ctx context.Context) (string, error) {
 	}
 	gitDir := strings.TrimSpace(string(output))
 	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(".", gitDir)
+		cwd, wdErr := os.Getwd()
+		if wdErr != nil {
+			return "", fmt.Errorf("failed to get current directory: %w", wdErr)
+		}
+		gitDir = filepath.Join(cwd, gitDir)
 	}
 	return filepath.Clean(gitDir), nil
 }

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -17,6 +19,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trail"
 
@@ -1227,6 +1230,7 @@ func buildTrailUpdateRequest(current *api.TrailResource, inputs trailUpdateInput
 func newTrailCheckoutCmd() *cobra.Command {
 	var trailSelector string
 	var force bool
+	var worktree bool
 
 	cmd := &cobra.Command{
 		Use:   "checkout [<trail>]",
@@ -1236,6 +1240,9 @@ func newTrailCheckoutCmd() *cobra.Command {
 The trail may be given as the first argument or via --trail, as a number, id, or
 branch. Without one, the trail for the current branch is used. The trail's branch
 is checked out, fetching it from origin first when it only exists there.
+
+With --worktree, the branch is checked out under .entire/worktrees instead of
+switching the current checkout. The command prints a cd command for the worktree.
 
 This must be run from within a clone of the repository the trail belongs to; the
 trail is looked up against that repository's origin remote.`,
@@ -1251,17 +1258,23 @@ trail is looked up against that repository's origin remote.`,
 			if err := ensureNoTrailRepoOverride(cmd, "trail checkout"); err != nil {
 				return err
 			}
-			return runTrailCheckout(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), selector, force)
+			return runTrailCheckout(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), selector, trailCheckoutOptions{Force: force, Worktree: worktree})
 		},
 	}
 
 	cmd.Flags().StringVar(&trailSelector, "trail", "", "Trail to check out (number, id, or branch; defaults to the current branch's trail)")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip the prompt before fetching a remote-only branch")
+	cmd.Flags().BoolVar(&worktree, "worktree", false, "Check out the trail branch in .entire/worktrees instead of switching this checkout")
 
 	return cmd
 }
 
-func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector string, force bool) error {
+type trailCheckoutOptions struct {
+	Force    bool
+	Worktree bool
+}
+
+func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector string, opts trailCheckoutOptions) error {
 	// checkout rejects --repo (it operates on the local clone), so the enablement
 	// cache always tracks the local origin here.
 	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, "", func(ctx context.Context, client *api.Client) error {
@@ -1280,6 +1293,11 @@ func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool,
 			return fmt.Errorf("%s has no branch to check out", describeTrailRef(found))
 		}
 
+		if opts.Worktree {
+			fmt.Fprintf(w, "Checking out %s in a worktree\n", describeTrailRef(found))
+			return checkoutTrailWorktree(ctx, w, errW, branch, opts.Force, found.Number)
+		}
+
 		currentBranch, _ := GetCurrentBranch(ctx) //nolint:errcheck // best-effort; a detached HEAD just means "not already on the branch"
 		if currentBranch == branch {
 			fmt.Fprintf(w, "Already on branch %s for %s.\n", branch, describeTrailRef(found))
@@ -1290,7 +1308,7 @@ func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool,
 		// switchToBranchForResume handles local vs. remote-only branches, the
 		// uncommitted-changes guard, and the fetch prompt; reuse it rather than
 		// re-deriving that logic here.
-		proceed, err := switchToBranchForResume(ctx, w, errW, branch, force)
+		proceed, err := switchToBranchForResume(ctx, w, errW, branch, opts.Force)
 		if err != nil {
 			return err
 		}
@@ -1302,6 +1320,180 @@ func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool,
 		}
 		return nil
 	})
+}
+
+func checkoutTrailWorktree(ctx context.Context, w, errW io.Writer, branch string, force bool, trailNumber int) error {
+	if existing, ok, err := findWorktreeForBranch(ctx, branch); err != nil {
+		return err
+	} else if ok {
+		fmt.Fprintf(w, "✓ Worktree already exists at %s\n", existing)
+		fmt.Fprintf(w, "cd %s\n", shellQuotePath(existing))
+		return nil
+	}
+
+	if err := ensureTrailWorktreeBranchAvailable(ctx, w, branch, force); err != nil {
+		return err
+	}
+	if err := ensureTrailWorktreeLocalExclude(ctx); err != nil {
+		return err
+	}
+
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to find worktree root: %w", err)
+	}
+	worktreePath := defaultTrailWorktreePath(repoRoot, branch, trailNumber)
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o750); err != nil {
+		return fmt.Errorf("failed to create worktree parent: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "worktree", "add", worktreePath, branch)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(errW, "Error: failed to create worktree: %v\n", err)
+		return fmt.Errorf("failed to create worktree: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	fmt.Fprintf(w, "✓ Worktree ready at %s\n", worktreePath)
+	fmt.Fprintf(w, "cd %s\n", shellQuotePath(worktreePath))
+	return nil
+}
+
+func ensureTrailWorktreeLocalExclude(ctx context.Context) error {
+	gitDir, err := gitCommonDirForTrailWorktree(ctx)
+	if err != nil {
+		return err
+	}
+	excludePath := filepath.Join(gitDir, "info", "exclude")
+	const rule = ".entire/worktrees/"
+
+	content, err := os.ReadFile(excludePath) //nolint:gosec // excludePath is under git rev-parse --git-common-dir.
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to read local git exclude: %w", err)
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.TrimSpace(line) == rule {
+			return nil
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0o750); err != nil {
+		return fmt.Errorf("failed to create local git exclude dir: %w", err)
+	}
+
+	// Controversial: mutate .git/info/exclude from a checkout command. We do it
+	// local-only to prevent accidental commits of .entire/worktrees without
+	// dirtying the user's tracked .gitignore.
+	prefix := ""
+	if len(content) > 0 && !strings.HasSuffix(string(content), "\n") {
+		prefix = "\n"
+	}
+	updated := string(content) + prefix + rule + "\n"
+	if err := os.WriteFile(excludePath, []byte(updated), 0o600); err != nil { //nolint:gosec // excludePath is under git rev-parse --git-common-dir.
+		return fmt.Errorf("failed to update local git exclude: %w", err)
+	}
+	return nil
+}
+
+func gitCommonDirForTrailWorktree(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get git common dir: %w", err)
+	}
+	gitDir := strings.TrimSpace(string(output))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(".", gitDir)
+	}
+	return filepath.Clean(gitDir), nil
+}
+
+func ensureTrailWorktreeBranchAvailable(ctx context.Context, w io.Writer, branch string, force bool) error {
+	exists, err := BranchExistsLocally(ctx, branch)
+	if err != nil {
+		return fmt.Errorf("failed to check branch: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
+	remoteExists, err := BranchExistsOnRemote(ctx, branch)
+	if err != nil {
+		return fmt.Errorf("failed to check remote branch: %w", err)
+	}
+	if !remoteExists {
+		return fmt.Errorf("branch '%s' not found locally or on origin", branch)
+	}
+	if !force {
+		shouldFetch, err := promptFetchFromRemote(branch)
+		if err != nil {
+			return err
+		}
+		if !shouldFetch {
+			return errors.New("checkout cancelled")
+		}
+	}
+
+	fmt.Fprintf(w, "Fetching branch '%s' from origin...\n", branch)
+	if err := fetchTrailWorktreeBranch(ctx, branch); err != nil {
+		return err
+	}
+	return nil
+}
+
+func fetchTrailWorktreeBranch(ctx context.Context, branch string) error {
+	if err := ValidateBranchName(ctx, branch); err != nil {
+		return err
+	}
+	refSpec := fmt.Sprintf("refs/heads/%s:refs/heads/%s", branch, branch)
+	cmd := exec.CommandContext(ctx, "git", "fetch", "origin", refSpec)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to fetch branch from origin: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+func findWorktreeForBranch(ctx context.Context, branch string) (string, bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "worktree", "list", "--porcelain")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", false, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+	var currentPath string
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "worktree ") {
+			currentPath = strings.TrimSpace(strings.TrimPrefix(line, "worktree "))
+			continue
+		}
+		if strings.TrimPrefix(line, "branch ") == "refs/heads/"+branch && currentPath != "" {
+			return currentPath, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func defaultTrailWorktreePath(repoRoot, branch string, trailNumber int) string {
+	name := sanitizeTrailWorktreeName(branch)
+	if trailNumber > 0 {
+		name = fmt.Sprintf("trail-%d-%s", trailNumber, name)
+	}
+	return filepath.Join(repoRoot, ".entire", "worktrees", name)
+}
+
+func shellQuotePath(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", "'\\''") + "'"
+}
+
+func sanitizeTrailWorktreeName(branch string) string {
+	name := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			return r
+		}
+		return '-'
+	}, strings.TrimSpace(branch))
+	name = strings.Trim(name, "-.")
+	if name == "" {
+		return "branch"
+	}
+	return name
 }
 
 // describeTrailRef renders a short human reference to a trail for status


### PR DESCRIPTION
## Summary
- add `entire trail checkout --worktree` to create/reuse repo-local worktrees under `.entire/worktrees`
- print a shell-safe `cd` hint for the worktree path
- add local `.git/info/exclude` entry for `.entire/worktrees/` to avoid dirtying tracked `.gitignore`

## Testing
- `go test ./cmd/entire/cli -run 'TrailCheckout|TestResolveTrailBySelector|TestDescribeTrailRef'`
- `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The command runs `git worktree`/`fetch` and writes to `.git/info/exclude`, which affects local git state; scope is limited to trail checkout and is covered by integration tests.
> 
> **Overview**
> Adds **`entire trail checkout --worktree`** so a trail’s branch is opened in a repo-local git worktree under **`.entire/worktrees/`** (e.g. `trail-123-feature-name`) instead of switching the current checkout. Success output includes a **shell-safe `cd`** hint.
> 
> The worktree path reuses an existing worktree when that branch is already checked out elsewhere, and can **fetch from origin** when the branch exists only remotely (with the same **`--force`** / prompt behavior as normal checkout). Checkout options are grouped in **`trailCheckoutOptions`**; the default in-place checkout path is unchanged.
> 
> On first worktree use, the CLI **idempotently appends** `.entire/worktrees/` to **`.git/info/exclude`** so those directories are not accidentally committed without editing tracked `.gitignore`. Integration tests cover path naming, quoting, create/reuse, remote-only fetch, exclude idempotency, and that the main checkout branch stays put.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e34a337d52d37371fcad7ade7f3f37ba1004a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->