### PR TITLE
Support updating trails by number

### DIFF
--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1068,7 +1068,7 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, i
 			return err
 		}
 
-		branch := inputs.Branch
+		branch := strings.TrimSpace(inputs.Branch)
 		var found *api.TrailResource
 		if inputs.Number > 0 {
 			found, err = fetchTrailByNumber(ctx, client, forge, owner, repoName, inputs.Number)
@@ -1198,7 +1198,7 @@ func fetchTrailByNumber(ctx context.Context, client *api.Client, forge, owner, r
 	}
 	defer resp.Body.Close()
 	if err := checkTrailResponse(resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to fetch trail %d: %w", number, err)
 	}
 	var detail struct {
 		Trail api.TrailResource `json:"trail"`

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1002,6 +1002,7 @@ func newTrailCreateRequest(title, body, branch, base, statusStr string) api.Trai
 
 func newTrailUpdateCmd() *cobra.Command {
 	var statusStr, title, body, branch string
+	var number int
 	var labelAdd, labelRemove []string
 
 	cmd := &cobra.Command{
@@ -1009,7 +1010,14 @@ func newTrailUpdateCmd() *cobra.Command {
 		Short: "Update trail metadata",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := ensureTrailRepoHasTarget(cmd, strings.TrimSpace(branch) != "", "pass --branch"); err != nil {
+			numberChanged := cmd.Flags().Changed("number")
+			if numberChanged && number <= 0 {
+				return errors.New("--number must be greater than 0")
+			}
+			if numberChanged && strings.TrimSpace(branch) != "" {
+				return errors.New("cannot combine --number with --branch")
+			}
+			if err := ensureTrailRepoHasTarget(cmd, numberChanged || strings.TrimSpace(branch) != "", "pass --number or --branch"); err != nil {
 				return err
 			}
 			return runTrailUpdate(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), trailUpdateInputs{
@@ -1020,6 +1028,7 @@ func newTrailUpdateCmd() *cobra.Command {
 				Body:          body,
 				BodyChanged:   cmd.Flags().Changed("body"),
 				Branch:        branch,
+				Number:        number,
 				Repo:          trailRepoFlag(cmd),
 				LabelAdd:      labelAdd,
 				LabelRemove:   labelRemove,
@@ -1031,6 +1040,7 @@ func newTrailUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&title, "title", "", "Update title")
 	cmd.Flags().StringVar(&body, "body", "", "Update body")
 	cmd.Flags().StringVar(&branch, "branch", "", "Branch to update trail for (defaults to current)")
+	cmd.Flags().IntVar(&number, "number", 0, "Trail number to update")
 	cmd.Flags().StringSliceVar(&labelAdd, "add-label", nil, "Add label(s)")
 	cmd.Flags().StringSliceVar(&labelRemove, "remove-label", nil, "Remove label(s)")
 
@@ -1045,6 +1055,7 @@ type trailUpdateInputs struct {
 	Body          string
 	BodyChanged   bool
 	Branch        string
+	Number        int
 	Repo          string
 	LabelAdd      []string
 	LabelRemove   []string
@@ -1057,22 +1068,28 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, i
 			return err
 		}
 
-		// Determine branch.
 		branch := inputs.Branch
-		if branch == "" {
-			branch, err = GetCurrentBranch(ctx)
+		var found *api.TrailResource
+		if inputs.Number > 0 {
+			found, err = fetchTrailByNumber(ctx, client, forge, owner, repoName, inputs.Number)
 			if err != nil {
-				return fmt.Errorf("failed to determine current branch: %w", err)
+				return err
 			}
-		}
+		} else {
+			if branch == "" {
+				branch, err = GetCurrentBranch(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to determine current branch: %w", err)
+				}
+			}
 
-		// Find the trail by branch.
-		found, err := findTrailByBranch(ctx, client, forge, owner, repoName, branch)
-		if err != nil {
-			return err
-		}
-		if found == nil {
-			return fmt.Errorf("no trail found for branch %q", branch)
+			found, err = findTrailByBranch(ctx, client, forge, owner, repoName, branch)
+			if err != nil {
+				return err
+			}
+			if found == nil {
+				return fmt.Errorf("no trail found for branch %q", branch)
+			}
 		}
 
 		// Interactive mode when no update flags are provided.
@@ -1146,7 +1163,7 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, i
 		// The single-trail endpoint is keyed by trail number, not id; the server
 		// rejects an id here with "Invalid trail number format".
 		if found.Number <= 0 {
-			return fmt.Errorf("trail for branch %q has no number yet; cannot update", branch)
+			return fmt.Errorf("trail %q has no number yet; cannot update", describeTrailRef(found))
 		}
 		resp, err := client.Patch(ctx, trailNumberPath(forge, owner, repoName, found.Number), updateReq)
 		if err != nil {
@@ -1162,9 +1179,37 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, i
 			return fmt.Errorf("failed to decode update response: %w", err)
 		}
 
-		fmt.Fprintf(w, "Updated trail for branch %s\n", branch)
+		if strings.TrimSpace(found.Branch) != "" {
+			fmt.Fprintf(w, "Updated trail for branch %s\n", found.Branch)
+		} else {
+			fmt.Fprintf(w, "Updated trail %d\n", found.Number)
+		}
 		return nil
 	})
+}
+
+func fetchTrailByNumber(ctx context.Context, client *api.Client, forge, owner, repo string, number int) (*api.TrailResource, error) {
+	if number <= 0 {
+		return nil, errors.New("trail number must be greater than 0")
+	}
+	resp, err := client.Get(ctx, trailNumberPath(forge, owner, repo, number))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch trail %d: %w", number, err)
+	}
+	defer resp.Body.Close()
+	if err := checkTrailResponse(resp); err != nil {
+		return nil, err
+	}
+	var detail struct {
+		Trail api.TrailResource `json:"trail"`
+	}
+	if err := api.DecodeJSON(resp, &detail); err != nil {
+		return nil, fmt.Errorf("failed to decode trail %d: %w", number, err)
+	}
+	if detail.Trail.Number == 0 {
+		detail.Trail.Number = number
+	}
+	return &detail.Trail, nil
 }
 
 func validateTrailUpdateFields(inputs trailUpdateInputs) error {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -1099,6 +1099,8 @@ func TestTrailCreateAndUpdateRejectUnexpectedArgs(t *testing.T) {
 func TestTrailUpdateRejectsNonPositiveNumber(t *testing.T) {
 	t.Parallel()
 	cmd := newTrailUpdateCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"--number", "0", "--title", "New"})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "--number must be greater than 0") {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -263,6 +263,71 @@ func TestRunTrailCreateBranchlessHappyPath(t *testing.T) {
 	require.Empty(t, errOut.String())
 }
 
+func TestRunTrailUpdateNumberBranchlessHappyPath(t *testing.T) {
+	// No t.Parallel: uses t.Chdir plus auth/tokenstore package-level test seams.
+	const trailNumberPath = "/api/v1/trails/gh/acme/repo/123"
+	var gotPatch map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/oauth/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"access_token":"exchanged-token","token_type":"Bearer","expires_in":3600}`)
+		case r.Method == http.MethodGet && r.URL.Path == trailNumberPath:
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(struct {
+				Trail api.TrailResource `json:"trail"`
+			}{Trail: api.TrailResource{ID: "trl_branchless", Number: 123, Title: "Old", Status: string(trail.StatusOpen)}}); err != nil {
+				t.Errorf("encode detail response: %v", err)
+			}
+		case r.Method == http.MethodPatch && r.URL.Path == trailNumberPath:
+			if err := json.NewDecoder(r.Body).Decode(&gotPatch); err != nil {
+				t.Errorf("decode patch request: %v", err)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailUpdateResponse{Trail: api.TrailResource{ID: "trl_branchless", Number: 123, Title: "New"}}); err != nil {
+				t.Errorf("encode update response: %v", err)
+			}
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv(api.BaseURLEnvVar, srv.URL)
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+	service := tokenstore.CoreKeyringService(srv.URL)
+	jwt := makeContextJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"me","exp":%d}`, srv.URL, time.Now().Add(2*time.Hour).Unix()))
+	require.NoError(t, tokenstore.Set(service, "me", tokenstore.EncodeTokenWithExpiration(jwt, 7200)))
+	ctxObj := &contexts.Context{Name: "me@core", CoreURL: srv.URL, Handle: "me", KeychainService: service}
+	t.Cleanup(auth.SetResolveContextForAPIForTest(t,
+		func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+			return ctxObj, nil
+		}))
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	runGitTrailTest(t, repoDir, "remote", "add", "origin", "https://github.com/acme/repo.git")
+	t.Chdir(repoDir)
+
+	cmd := newTrailCmd()
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"--insecure-http-auth", "update", "--number", "123", "--title", "New", "--body", "", "--status", string(trail.StatusClosed)})
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	require.Equal(t, "New", gotPatch["title"])
+	require.Empty(t, gotPatch["body"])
+	require.Equal(t, string(trail.StatusClosed), gotPatch["status"])
+	require.Contains(t, out.String(), "Updated trail 123")
+	require.Empty(t, errOut.String())
+}
+
 func TestCleanupCreatedTrailBranch(t *testing.T) {
 	cases := []struct {
 		name             string
@@ -1028,6 +1093,56 @@ func TestTrailCreateAndUpdateRejectUnexpectedArgs(t *testing.T) {
 		if err := cmd.Args(cmd, []string{"unexpected"}); err == nil {
 			t.Fatalf("%s accepted an unexpected positional arg", cmd.Name())
 		}
+	}
+}
+
+func TestTrailUpdateRejectsNonPositiveNumber(t *testing.T) {
+	t.Parallel()
+	cmd := newTrailUpdateCmd()
+	cmd.SetArgs([]string{"--number", "0", "--title", "New"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--number must be greater than 0") {
+		t.Fatalf("err = %v, want --number validation", err)
+	}
+}
+
+func TestTrailUpdateHelpMentionsNumber(t *testing.T) {
+	t.Parallel()
+	cmd := newTrailUpdateCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	if !strings.Contains(out.String(), "--number") {
+		t.Fatalf("help output missing --number flag:\n%s", out.String())
+	}
+}
+
+func TestFetchTrailByNumberDefaultsMissingNumber(t *testing.T) {
+	t.Parallel()
+	const trailNumberPath = "/api/v1/trails/gh/acme/repo/123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != trailNumberPath {
+			t.Fatalf("path = %q, want trail number path", r.URL.Path)
+		}
+		if err := json.NewEncoder(w).Encode(struct {
+			Trail api.TrailResource `json:"trail"`
+		}{Trail: api.TrailResource{ID: "trl_123", Title: "Branchless"}}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	found, err := fetchTrailByNumber(context.Background(), client, "gh", "acme", "repo", 123)
+	if err != nil {
+		t.Fatalf("fetchTrailByNumber: %v", err)
+	}
+	if found.Number != 123 {
+		t.Fatalf("Number = %d, want 123", found.Number)
 	}
 }
 

--- a/cmd/entire/cli/trail_repo_flag_test.go
+++ b/cmd/entire/cli/trail_repo_flag_test.go
@@ -124,6 +124,7 @@ func TestTrailSelectorAndBranchAreMutuallyExclusive(t *testing.T) {
 		{name: "watch", args: []string{"watch", "5", "--branch", "foo"}, wantSub: "not both"},
 		{name: "finding list positional", args: []string{"finding", "list", "123", "--branch", "foo"}, wantSub: "not both"},
 		{name: "finding list --trail", args: []string{"finding", "list", "--trail", "123", "--branch", "foo"}, wantSub: "not both"},
+		{name: "update number", args: []string{"update", "--number", "123", "--branch", "foo"}, wantSub: "cannot combine --number with --branch"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `entire trail update --number` for branchless trails
- fetch trail details by number before patching metadata and labels
- keep branch-based update behavior unchanged

## Tests
- `go test ./cmd/entire/cli`
- `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only extension of an existing update command; branch-based updates are unchanged and the change is covered by new tests.
> 
> **Overview**
> **`entire trail update`** can target a trail by **`--number`** (in addition to **`--branch`** / current branch), so branchless trails can be updated without a branch lookup.
> 
> When **`--number`** is set, the command loads the trail via a **GET** on the per-number API path (`fetchTrailByNumber`), then applies the same PATCH metadata/label flow as before. **`--number`** must be &gt; 0, cannot be combined with **`--branch`**, and with **`--repo`** you must pass **`--number`** or **`--branch`**. Success output uses the branch line when the trail has a branch, otherwise **`Updated trail &lt;n&gt;`**.
> 
> Tests cover the branchless update happy path, flag validation, help text, and **`--number`** + **`--branch`** mutual exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a7957186c47b00c358e2e10bf9b90b415fa6187. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->