### PR TITLE
investigate: fix flaky picker tests racing on global override

### DIFF
--- a/cmd/entire/cli/investigate/picker_test.go
+++ b/cmd/entire/cli/investigate/picker_test.go
@@ -33,8 +33,11 @@ func TestRunInvestigateConfigPicker_NoEligibleAgents(t *testing.T) {
 
 // TestRunInvestigateConfigPicker_FiltersNonInstalled verifies that an
 // agent with a spawner but no hooks installed is filtered out.
+// Not parallel: installs a process-global picker-form override
+// (SetPickerFormFnForTest). Running it in parallel with another override-
+// installing test lets one clobber the other's override mid-run — see the
+// contract on pickerFormOverride in picker.go.
 func TestRunInvestigateConfigPicker_FiltersNonInstalled(t *testing.T) {
-	t.Parallel()
 	cleanup := investigate.SetPickerFormFnForTest(func(_ context.Context, eligible []investigate.AgentChoice, picks *[]string, maxTurns, quorum *int) error {
 		// Capture eligible into picks for assertion via the cfg.Agents.
 		names := make([]string, 0, len(eligible))
@@ -81,8 +84,11 @@ func TestRunInvestigateConfigPicker_NoSpawnerForReturnsError(t *testing.T) {
 	}
 }
 
+// Not parallel: installs a process-global picker-form override
+// (SetPickerFormFnForTest), which must not run concurrently with another
+// override-installing test — see the contract on pickerFormOverride in
+// picker.go.
 func TestRunInvestigateConfigPicker_QuorumExceedsAgents(t *testing.T) {
-	t.Parallel()
 	cleanup := investigate.SetPickerFormFnForTest(func(_ context.Context, eligible []investigate.AgentChoice, picks *[]string, maxTurns, quorum *int) error {
 		_ = eligible
 		*picks = []string{"agent-a"}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/807
<!-- entire-trail-link-end -->

## Why
`test-core` intermittently fails on `TestRunInvestigateConfigPicker_QuorumExceedsAgents`
with `expected error when quorum exceeds agent count`.

Surfaced by the `test-core` job on PR #1680's CI:
https://github.com/entireio/cli/actions/runs/29005711348/job/86076676995
(the failure is unrelated to that PR's changes — it's a pre-existing flake in this package).

Two tests in `investigate/picker_test.go` both install a **process-global**
picker-form override via `SetPickerFormFnForTest` **and** call `t.Parallel()`:

- `TestRunInvestigateConfigPicker_FiltersNonInstalled` sets `quorum = 0` (valid)
- `TestRunInvestigateConfigPicker_QuorumExceedsAgents` sets `quorum = 5` (expects an error)

The override is an `atomic.Pointer`, which prevents a *data* race but not the
*logical* clobber: when the two run concurrently, one test's `Store` replaces the
other's mid-run. `QuorumExceedsAgents` then reads the sibling's `quorum=0` override,
gets a valid config, and never sees the error it asserts → `t.Fatal`.

`picker.go` already documents the constraint:
> tests that install conflicting overrides must not run in parallel with each other

…but both tests were left parallel.

## What changed
- Drop `t.Parallel()` from the two override-installing tests, with a comment
  pointing back to the `pickerFormOverride` contract.

## Test plan
- `go test ./cmd/entire/cli/investigate/` passes; stressed 15× at `-parallel 8`.
- The other picker tests (which don't install overrides) stay parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production behavior or runtime paths affected.
> 
> **Overview**
> Fixes intermittent **`test-core`** failures in `TestRunInvestigateConfigPicker_QuorumExceedsAgents` caused by two tests both calling **`SetPickerFormFnForTest`** while also using **`t.Parallel()`**. The override is process-global (`pickerFormOverride` in `picker.go`); concurrent installs can replace each other's stub mid-run so the quorum test sometimes sees a sibling's `quorum=0` and never hits the expected error.
> 
> **Removes `t.Parallel()`** from `TestRunInvestigateConfigPicker_FiltersNonInstalled` and `TestRunInvestigateConfigPicker_QuorumExceedsAgents`, with comments pointing at the documented contract that override-installing tests must not run in parallel with each other. Other picker tests that do not touch the override stay parallel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 113bbd7d579ee6a35fb5462d0a947d335425b32d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->