### PR TITLE
Support plugin-style hook payloads for Codex and Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ Each agent stores its hook configuration in its own directory. When you run `ent
 
 You can enable multiple agents at the same time — each agent's hooks are independent. Entire detects which agents are active by checking for installed hooks, not by a setting in `settings.json`.
 
+For Claude Code and Codex, Entire accepts both native CLI hook payloads and plugin-style payloads that use camelCase field names such as `sessionId`, `transcriptPath`, and `hookEventName`. This improves compatibility with VS Code/plugin-style hosts when those hosts invoke the same `entire hooks ...` commands. Desktop apps or plugins that do not invoke hooks and do not expose readable transcript files cannot be captured live by the CLI alone; use `entire import` or `entire session attach` when transcripts are available after the fact.
+
 ### Checkpoint Remote
 
 By default, Entire pushes `entire/checkpoints/v1` to the same remote as your code. If you want to push checkpoint data to a separate repo (e.g., a private repo for public projects), configure `checkpoint_remote` with a structured provider and repo:
@@ -453,6 +455,7 @@ Local settings override project settings field-by-field. When you run `entire st
 ### Agent-Specific Steps & Limitations
 
 - When enabling Entire for Codex, the command will also create or update `.codex/config.toml` with `hooks = true` to enable Codex hooks. If you configure Codex manually, make sure this flag is set in your `.codex/config.toml`. Or select Codex from the interactive agent picker when running `entire enable`.
+- Codex and Claude Code CLI hooks are fully supported. VS Code/plugin hosts are supported when they call compatible Entire hook commands or provide standard transcript paths. Desktop hosts without hooks or transcript export cannot be live-captured by CLI-only integration.
 - Entire supports Cursor IDE and Cursor Agent CLI tool, but `entire rewind` is not available at this time. Other commands (`doctor`, `status` etc.) work the same as all other agents.
 - Entire supports Copilot CLI, but not Copilot in VS Code, in other IDEs, or on github.com.
 - Entire supports Pi coding agent (Preview). Pi uses a TypeScript extension instead of a JSON hook config. Subagent capture is not currently available.

--- a/cmd/entire/cli/agent/architecture_test.go
+++ b/cmd/entire/cli/agent/architecture_test.go
@@ -43,18 +43,19 @@ func TestAgentPackages_NoForbiddenImports(t *testing.T) {
 
 	// Packages within the repo that agents ARE allowed to import.
 	allowedPrefixes := []string{
-		repoPrefix + "agent",      // agent contract + sub-packages
-		repoPrefix + "logging",    // logging utilities
-		repoPrefix + "paths",      // path utilities
-		repoPrefix + "jsonutil",   // JSON utilities
-		repoPrefix + "textutil",   // text utilities
-		repoPrefix + "transcript", // transcript utilities
-		repoPrefix + "trailers",   // git trailer utilities
-		repoPrefix + "stringutil", // string utilities
-		repoPrefix + "telemetry",  // telemetry
-		repoPrefix + "validation", // validation utilities
-		repoPrefix + "settings",   // settings (read-only access)
-		repoPrefix + "review",     // review env contract + AgentReviewer types (used by per-agent reviewer.go files)
+		repoPrefix + "agent",               // agent contract + sub-packages
+		repoPrefix + "logging",             // logging utilities
+		repoPrefix + "paths",               // path utilities
+		repoPrefix + "jsonutil",            // JSON utilities
+		repoPrefix + "textutil",            // text utilities
+		repoPrefix + "transcript",          // transcript utilities
+		repoPrefix + "trailers",            // git trailer utilities
+		repoPrefix + "stringutil",          // string utilities
+		repoPrefix + "telemetry",           // telemetry
+		repoPrefix + "validation",          // validation utilities
+		repoPrefix + "settings",            // settings (read-only access)
+		repoPrefix + "review",              // review env contract + AgentReviewer types (used by per-agent reviewer.go files)
+		repoPrefix + "internal/hookcompat", // hook payload compatibility helpers
 	}
 
 	agentDir := findAgentDir(t)

--- a/cmd/entire/cli/agent/claudecode/lifecycle.go
+++ b/cmd/entire/cli/agent/claudecode/lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/internal/hookcompat"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
 
@@ -70,13 +71,13 @@ func (c *ClaudeCodeAgent) HookNames() []string {
 func (c *ClaudeCodeAgent) ParseHookEvent(_ context.Context, hookName string, stdin io.Reader) (*agent.Event, error) {
 	switch hookName {
 	case HookNameSessionStart:
-		return c.parseSessionInfoEvent(stdin, agent.SessionStart)
+		return c.parseSessionInfoEvent(stdin, hookName, agent.SessionStart)
 	case HookNameUserPromptSubmit:
-		return c.parseTurnStart(stdin)
+		return c.parseTurnStart(stdin, hookName)
 	case HookNameStop:
-		return c.parseSessionInfoEvent(stdin, agent.TurnEnd)
+		return c.parseSessionInfoEvent(stdin, hookName, agent.TurnEnd)
 	case HookNameSessionEnd:
-		return c.parseSessionInfoEvent(stdin, agent.SessionEnd)
+		return c.parseSessionInfoEvent(stdin, hookName, agent.SessionEnd)
 	case HookNamePreTask:
 		return c.parseSubagentStart(stdin)
 	case HookNamePostTask:
@@ -87,6 +88,15 @@ func (c *ClaudeCodeAgent) ParseHookEvent(_ context.Context, hookName string, std
 	default:
 		return nil, nil //nolint:nilnil // Unknown hooks have no lifecycle action
 	}
+}
+
+var claudeHookEventToHookNames = map[string][]string{
+	"SessionStart":     {HookNameSessionStart},
+	"SessionEnd":       {HookNameSessionEnd},
+	"Stop":             {HookNameStop},
+	"UserPromptSubmit": {HookNameUserPromptSubmit},
+	"PreToolUse":       {HookNamePreTask},
+	"PostToolUse":      {HookNamePostTask, HookNamePostTodo},
 }
 
 // ReadTranscript reads the raw JSONL transcript bytes for a session.
@@ -114,32 +124,50 @@ func (c *ClaudeCodeAgent) CalculateTokenUsage(transcriptData []byte, fromOffset 
 
 // parseSessionInfoEvent parses the hooks whose payload is sessionInfoRaw —
 // SessionStart, Stop, and SessionEnd differ only in the resulting event type.
-func (c *ClaudeCodeAgent) parseSessionInfoEvent(stdin io.Reader, eventType agent.EventType) (*agent.Event, error) {
-	raw, err := agent.ReadAndParseHookInput[sessionInfoRaw](stdin)
+func (c *ClaudeCodeAgent) parseSessionInfoEvent(stdin io.Reader, hookName string, eventType agent.EventType) (*agent.Event, error) {
+	env, ok, err := readCompatEnvelope(stdin, hookName)
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return nil, nil //nolint:nilnil // Mismatched plugin event — skip silently.
 	}
 	return &agent.Event{
 		Type:       eventType,
-		SessionID:  raw.SessionID,
-		SessionRef: raw.TranscriptPath,
-		Model:      raw.Model,
-		Timestamp:  time.Now(),
+		SessionID:  env.SessionID,
+		SessionRef: env.TranscriptPath,
+		Model:      env.Model,
+		Timestamp:  env.Timestamp,
 	}, nil
 }
 
-func (c *ClaudeCodeAgent) parseTurnStart(stdin io.Reader) (*agent.Event, error) {
-	raw, err := agent.ReadAndParseHookInput[userPromptSubmitRaw](stdin)
+func (c *ClaudeCodeAgent) parseTurnStart(stdin io.Reader, hookName string) (*agent.Event, error) {
+	env, ok, err := readCompatEnvelope(stdin, hookName)
 	if err != nil {
 		return nil, err
 	}
+	if !ok {
+		return nil, nil //nolint:nilnil // Mismatched plugin event — skip silently.
+	}
 	return &agent.Event{
 		Type:       agent.TurnStart,
-		SessionID:  raw.SessionID,
-		SessionRef: raw.TranscriptPath,
-		Prompt:     raw.Prompt,
-		Timestamp:  time.Now(),
+		SessionID:  env.SessionID,
+		SessionRef: env.TranscriptPath,
+		Prompt:     env.Prompt,
+		Model:      env.Model,
+		Timestamp:  env.Timestamp,
 	}, nil
+}
+
+func readCompatEnvelope(stdin io.Reader, hookName string) (*hookcompat.Envelope, bool, error) {
+	env, err := hookcompat.ReadEnvelope(stdin)
+	if err != nil {
+		return nil, false, err
+	}
+	if !hookcompat.HookEventMatches(env.HookEventName, hookName, claudeHookEventToHookNames) {
+		return env, false, nil
+	}
+	return env, true, nil
 }
 
 func (c *ClaudeCodeAgent) parseSubagentStart(stdin io.Reader) (*agent.Event, error) {

--- a/cmd/entire/cli/agent/claudecode/lifecycle_test.go
+++ b/cmd/entire/cli/agent/claudecode/lifecycle_test.go
@@ -76,6 +76,23 @@ func TestParseHookEvent_SessionStart_EmptyModel(t *testing.T) {
 	}
 }
 
+func TestParseHookEvent_SessionStart_PluginPayload(t *testing.T) {
+	t.Parallel()
+
+	ag := &ClaudeCodeAgent{}
+	input := `{"sessionId":"plugin-session","transcriptPath":"/tmp/plugin.jsonl","hookEventName":"SessionStart","timestamp":"2026-02-09T10:30:00.000Z","model":"claude-sonnet-4-20250514"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameSessionStart, strings.NewReader(input))
+
+	require.NoError(t, err)
+	require.NotNil(t, event, "expected event, got nil")
+	require.Equal(t, agent.SessionStart, event.Type)
+	require.Equal(t, "plugin-session", event.SessionID)
+	require.Equal(t, "/tmp/plugin.jsonl", event.SessionRef)
+	require.Equal(t, "claude-sonnet-4-20250514", event.Model)
+	require.Equal(t, 2026, event.Timestamp.Year())
+}
+
 func TestParseHookEvent_TurnStart(t *testing.T) {
 	t.Parallel()
 
@@ -99,6 +116,24 @@ func TestParseHookEvent_TurnStart(t *testing.T) {
 	}
 }
 
+func TestParseHookEvent_TurnStart_PluginPayload(t *testing.T) {
+	t.Parallel()
+
+	ag := &ClaudeCodeAgent{}
+	input := `{"sessionId":"plugin-session","transcript_path":"/tmp/plugin.jsonl","hookEventName":"UserPromptSubmit","timestamp":1770633000000,"model":"claude-sonnet-4-20250514","prompt":"Hello from plugin"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameUserPromptSubmit, strings.NewReader(input))
+
+	require.NoError(t, err)
+	require.NotNil(t, event, "expected event, got nil")
+	require.Equal(t, agent.TurnStart, event.Type)
+	require.Equal(t, "plugin-session", event.SessionID)
+	require.Equal(t, "/tmp/plugin.jsonl", event.SessionRef)
+	require.Equal(t, "Hello from plugin", event.Prompt)
+	require.Equal(t, "claude-sonnet-4-20250514", event.Model)
+	require.False(t, event.Timestamp.IsZero())
+}
+
 func TestParseHookEvent_TurnEnd(t *testing.T) {
 	t.Parallel()
 
@@ -117,6 +152,22 @@ func TestParseHookEvent_TurnEnd(t *testing.T) {
 	if event.SessionID != "sess-789" {
 		t.Errorf("expected session_id 'sess-789', got %q", event.SessionID)
 	}
+}
+
+func TestParseHookEvent_TurnEnd_PluginPayload(t *testing.T) {
+	t.Parallel()
+
+	ag := &ClaudeCodeAgent{}
+	input := `{"sessionId":"plugin-session","transcriptPath":"/tmp/plugin.jsonl","hookEventName":"Stop","timestamp":"2026-02-09T10:30:00.000Z","model":"claude-opus-4-6"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameStop, strings.NewReader(input))
+
+	require.NoError(t, err)
+	require.NotNil(t, event, "expected event, got nil")
+	require.Equal(t, agent.TurnEnd, event.Type)
+	require.Equal(t, "plugin-session", event.SessionID)
+	require.Equal(t, "/tmp/plugin.jsonl", event.SessionRef)
+	require.Equal(t, "claude-opus-4-6", event.Model)
 }
 
 func TestParseHookEvent_TurnEnd_IncludesModel(t *testing.T) {
@@ -154,6 +205,34 @@ func TestParseHookEvent_SessionEnd(t *testing.T) {
 	if event.SessionID != "ending-session" {
 		t.Errorf("expected session_id 'ending-session', got %q", event.SessionID)
 	}
+}
+
+func TestParseHookEvent_SessionEnd_PluginPayload(t *testing.T) {
+	t.Parallel()
+
+	ag := &ClaudeCodeAgent{}
+	input := `{"sessionId":"plugin-session","transcriptPath":"/tmp/plugin.jsonl","hookEventName":"SessionEnd","timestamp":"2026-02-09T10:30:00.000Z","model":"claude-sonnet-4-20250514"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameSessionEnd, strings.NewReader(input))
+
+	require.NoError(t, err)
+	require.NotNil(t, event, "expected event, got nil")
+	require.Equal(t, agent.SessionEnd, event.Type)
+	require.Equal(t, "plugin-session", event.SessionID)
+	require.Equal(t, "/tmp/plugin.jsonl", event.SessionRef)
+	require.Equal(t, "claude-sonnet-4-20250514", event.Model)
+}
+
+func TestParseHookEvent_PluginPayloadMismatchedHookEventName_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	ag := &ClaudeCodeAgent{}
+	input := `{"sessionId":"plugin-session","hookEventName":"SessionStart","timestamp":"2026-02-09T10:30:00.000Z"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameStop, strings.NewReader(input))
+
+	require.NoError(t, err)
+	require.Nil(t, event)
 }
 
 func TestParseHookEvent_SessionEnd_IncludesModel(t *testing.T) {

--- a/cmd/entire/cli/agent/codex/lifecycle.go
+++ b/cmd/entire/cli/agent/codex/lifecycle.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/internal/hookcompat"
 )
 
 // Compile-time interface assertions.
@@ -54,6 +54,14 @@ const (
 	HookNamePostToolUse      = "post-tool-use"
 )
 
+var codexHookEventToHookNames = map[string][]string{
+	"SessionStart":     {HookNameSessionStart},
+	"UserPromptSubmit": {HookNameUserPromptSubmit},
+	"Stop":             {HookNameStop},
+	"PreToolUse":       {HookNamePreToolUse},
+	"PostToolUse":      {HookNamePostToolUse},
+}
+
 // HookNames returns the hook verbs Codex supports.
 func (c *CodexAgent) HookNames() []string {
 	return []string{
@@ -70,47 +78,53 @@ func (c *CodexAgent) HookNames() []string {
 func (c *CodexAgent) ParseHookEvent(_ context.Context, hookName string, stdin io.Reader) (*agent.Event, error) {
 	switch hookName {
 	case HookNameSessionStart:
-		return c.parseSessionStart(stdin)
+		return c.parseSessionStart(stdin, hookName)
 	case HookNameUserPromptSubmit:
-		return c.parseTurnStart(stdin)
+		return c.parseTurnStart(stdin, hookName)
 	case HookNameStop:
-		return c.parseTurnEnd(stdin)
+		return c.parseTurnEnd(stdin, hookName)
 	case HookNamePreToolUse:
 		// PreToolUse has no lifecycle significance — pass through
 		return nil, nil //nolint:nilnil // nil event = no lifecycle action
 	case HookNamePostToolUse:
-		return c.parsePostToolUse(stdin)
+		return c.parsePostToolUse(stdin, hookName)
 	default:
 		return nil, nil //nolint:nilnil // Unknown hooks have no lifecycle action
 	}
 }
 
-func (c *CodexAgent) parseSessionStart(stdin io.Reader) (*agent.Event, error) {
-	raw, err := agent.ReadAndParseHookInput[sessionStartRaw](stdin)
+func (c *CodexAgent) parseSessionStart(stdin io.Reader, hookName string) (*agent.Event, error) {
+	env, ok, err := readCompatEnvelope(stdin, hookName)
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return nil, nil //nolint:nilnil // Mismatched plugin event — skip silently.
 	}
 	return &agent.Event{
 		Type:       agent.SessionStart,
-		SessionID:  raw.SessionID,
-		SessionRef: derefString(raw.TranscriptPath),
-		Model:      raw.Model,
-		Timestamp:  time.Now(),
+		SessionID:  env.SessionID,
+		SessionRef: env.TranscriptPath,
+		Model:      env.Model,
+		Timestamp:  env.Timestamp,
 	}, nil
 }
 
-func (c *CodexAgent) parseTurnStart(stdin io.Reader) (*agent.Event, error) {
-	raw, err := agent.ReadAndParseHookInput[userPromptSubmitRaw](stdin)
+func (c *CodexAgent) parseTurnStart(stdin io.Reader, hookName string) (*agent.Event, error) {
+	env, ok, err := readCompatEnvelope(stdin, hookName)
 	if err != nil {
 		return nil, err
 	}
+	if !ok {
+		return nil, nil //nolint:nilnil // Mismatched plugin event — skip silently.
+	}
 	return &agent.Event{
 		Type:       agent.TurnStart,
-		SessionID:  raw.SessionID,
-		SessionRef: derefString(raw.TranscriptPath),
-		Prompt:     raw.Prompt,
-		Model:      raw.Model,
-		Timestamp:  time.Now(),
+		SessionID:  env.SessionID,
+		SessionRef: env.TranscriptPath,
+		Prompt:     env.Prompt,
+		Model:      env.Model,
+		Timestamp:  env.Timestamp,
 	}, nil
 }
 
@@ -127,20 +141,28 @@ const (
 // parsePostToolUse turns a Codex PostToolUse hook into a ToolUse lifecycle event.
 // Non-mutating tools (shell, MCP) produce a nil event so the dispatcher skips
 // them — extracting files from arbitrary shell commands would be unreliable.
-func (c *CodexAgent) parsePostToolUse(stdin io.Reader) (*agent.Event, error) {
-	raw, err := agent.ReadAndParseHookInput[postToolUseRaw](stdin)
+func (c *CodexAgent) parsePostToolUse(stdin io.Reader, hookName string) (*agent.Event, error) {
+	raw, err := hookcompat.ReadRaw(stdin)
 	if err != nil {
 		return nil, err
 	}
+	env, err := hookcompat.EnvelopeFromRaw(raw)
+	if err != nil {
+		return nil, err
+	}
+	if !hookcompat.HookEventMatches(env.HookEventName, hookName, codexHookEventToHookNames) {
+		return nil, nil //nolint:nilnil // Mismatched plugin event — skip silently.
+	}
 
-	if !isApplyPatchTool(raw.ToolName) {
+	toolName := hookcompat.FirstString(raw, "tool_name", "toolName")
+	if !isApplyPatchTool(toolName) {
 		return nil, nil //nolint:nilnil // non-mutating tools have no lifecycle action
 	}
 
 	var input applyPatchToolInput
 	// Best-effort: an unparseable tool_input means we can't extract files, but
 	// we shouldn't fail the hook (which would block the agent's tool call).
-	_ = json.Unmarshal(raw.ToolInput, &input) //nolint:errcheck // input.Command stays empty on failure
+	_ = json.Unmarshal(hookcompat.FirstRaw(raw, "tool_input", "toolInput"), &input) //nolint:errcheck // input.Command stays empty on failure
 
 	added, modified, deleted := classifyApplyPatchPaths(input.Command)
 	if len(added) == 0 && len(modified) == 0 && len(deleted) == 0 {
@@ -149,15 +171,15 @@ func (c *CodexAgent) parsePostToolUse(stdin io.Reader) (*agent.Event, error) {
 
 	return &agent.Event{
 		Type:          agent.ToolUse,
-		SessionID:     raw.SessionID,
-		SessionRef:    derefString(raw.TranscriptPath),
-		Model:         raw.Model,
-		ToolUseID:     raw.ToolUseID,
-		CWD:           raw.CWD,
+		SessionID:     env.SessionID,
+		SessionRef:    env.TranscriptPath,
+		Model:         env.Model,
+		ToolUseID:     hookcompat.FirstString(raw, "tool_use_id", "toolUseId", "toolUseID"),
+		CWD:           env.CWD,
 		ModifiedFiles: modified,
 		NewFiles:      added,
 		DeletedFiles:  deleted,
-		Timestamp:     time.Now(),
+		Timestamp:     env.Timestamp,
 	}, nil
 }
 
@@ -170,16 +192,30 @@ func isApplyPatchTool(name string) bool {
 	}
 }
 
-func (c *CodexAgent) parseTurnEnd(stdin io.Reader) (*agent.Event, error) {
-	raw, err := agent.ReadAndParseHookInput[stopRaw](stdin)
+func (c *CodexAgent) parseTurnEnd(stdin io.Reader, hookName string) (*agent.Event, error) {
+	env, ok, err := readCompatEnvelope(stdin, hookName)
 	if err != nil {
 		return nil, err
 	}
+	if !ok {
+		return nil, nil //nolint:nilnil // Mismatched plugin event — skip silently.
+	}
 	return &agent.Event{
 		Type:       agent.TurnEnd,
-		SessionID:  raw.SessionID,
-		SessionRef: derefString(raw.TranscriptPath),
-		Model:      raw.Model,
-		Timestamp:  time.Now(),
+		SessionID:  env.SessionID,
+		SessionRef: env.TranscriptPath,
+		Model:      env.Model,
+		Timestamp:  env.Timestamp,
 	}, nil
+}
+
+func readCompatEnvelope(stdin io.Reader, hookName string) (*hookcompat.Envelope, bool, error) {
+	env, err := hookcompat.ReadEnvelope(stdin)
+	if err != nil {
+		return nil, false, err
+	}
+	if !hookcompat.HookEventMatches(env.HookEventName, hookName, codexHookEventToHookNames) {
+		return env, false, nil
+	}
+	return env, true, nil
 }

--- a/cmd/entire/cli/agent/codex/lifecycle_test.go
+++ b/cmd/entire/cli/agent/codex/lifecycle_test.go
@@ -52,6 +52,28 @@ func TestParseHookEvent_SessionStartNullTranscript(t *testing.T) {
 	require.Empty(t, event.SessionRef)
 }
 
+func TestParseHookEvent_SessionStart_PluginPayload(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+	input := `{
+		"sessionId": "plugin-session",
+		"transcriptPath": "/tmp/plugin-rollout.jsonl",
+		"cwd": "/tmp/testrepo",
+		"hookEventName": "SessionStart",
+		"timestamp": "2026-02-09T10:30:00.000Z",
+		"model": "gpt-5.2-codex"
+	}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameSessionStart, strings.NewReader(input))
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	require.Equal(t, agent.SessionStart, event.Type)
+	require.Equal(t, "plugin-session", event.SessionID)
+	require.Equal(t, "/tmp/plugin-rollout.jsonl", event.SessionRef)
+	require.Equal(t, "gpt-5.2-codex", event.Model)
+	require.Equal(t, 2026, event.Timestamp.Year())
+}
+
 func TestParseHookEvent_UserPromptSubmit(t *testing.T) {
 	t.Parallel()
 	ag := &CodexAgent{}
@@ -76,6 +98,30 @@ func TestParseHookEvent_UserPromptSubmit(t *testing.T) {
 	require.Equal(t, "gpt-4.1", event.Model)
 }
 
+func TestParseHookEvent_UserPromptSubmit_PluginPayload(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+	input := `{
+		"sessionId": "plugin-session",
+		"transcript_path": "/tmp/plugin-rollout.jsonl",
+		"cwd": "/tmp/testrepo",
+		"hookEventName": "UserPromptSubmit",
+		"timestamp": 1770633000000,
+		"model": "gpt-5.2-codex",
+		"prompt": "Create a hello.txt file"
+	}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameUserPromptSubmit, strings.NewReader(input))
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	require.Equal(t, agent.TurnStart, event.Type)
+	require.Equal(t, "plugin-session", event.SessionID)
+	require.Equal(t, "/tmp/plugin-rollout.jsonl", event.SessionRef)
+	require.Equal(t, "Create a hello.txt file", event.Prompt)
+	require.Equal(t, "gpt-5.2-codex", event.Model)
+	require.False(t, event.Timestamp.IsZero())
+}
+
 func TestParseHookEvent_Stop(t *testing.T) {
 	t.Parallel()
 	ag := &CodexAgent{}
@@ -98,6 +144,41 @@ func TestParseHookEvent_Stop(t *testing.T) {
 	require.Equal(t, "test-uuid", event.SessionID)
 	require.Equal(t, "/tmp/rollout.jsonl", event.SessionRef)
 	require.Equal(t, "gpt-4.1", event.Model)
+}
+
+func TestParseHookEvent_Stop_PluginPayload(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+	input := `{
+		"sessionId": "plugin-session",
+		"transcriptPath": "/tmp/plugin-rollout.jsonl",
+		"cwd": "/tmp/testrepo",
+		"hookEventName": "Stop",
+		"timestamp": "2026-02-09T10:30:00.000Z",
+		"model": "gpt-5.2-codex"
+	}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameStop, strings.NewReader(input))
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	require.Equal(t, agent.TurnEnd, event.Type)
+	require.Equal(t, "plugin-session", event.SessionID)
+	require.Equal(t, "/tmp/plugin-rollout.jsonl", event.SessionRef)
+	require.Equal(t, "gpt-5.2-codex", event.Model)
+}
+
+func TestParseHookEvent_PluginPayloadMismatchedHookEventName_ReturnsNil(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+	input := `{
+		"sessionId": "plugin-session",
+		"hookEventName": "SessionStart",
+		"timestamp": "2026-02-09T10:30:00.000Z"
+	}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameStop, strings.NewReader(input))
+	require.NoError(t, err)
+	require.Nil(t, event)
 }
 
 func TestParseHookEvent_PreToolUse_ReturnsNil(t *testing.T) {
@@ -139,6 +220,34 @@ func TestParseHookEvent_PostToolUse_ApplyPatch(t *testing.T) {
 	require.Equal(t, []string{"a.txt"}, event.NewFiles)
 	require.Equal(t, []string{"b.txt"}, event.ModifiedFiles)
 	require.Equal(t, []string{"c.txt"}, event.DeletedFiles)
+}
+
+func TestParseHookEvent_PostToolUse_PluginPayload(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+	input := `{
+		"sessionId": "plugin-session",
+		"transcriptPath": "/tmp/plugin-rollout.jsonl",
+		"cwd": "/tmp/testrepo",
+		"hookEventName": "PostToolUse",
+		"timestamp": "2026-02-09T10:30:00.000Z",
+		"model": "gpt-5.2-codex",
+		"toolName": "apply_patch",
+		"toolUseId": "call-plugin",
+		"toolInput": {"command": "*** Begin Patch\n*** Add File: plugin.txt\n+hi\n*** End Patch\n"}
+	}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	require.Equal(t, agent.ToolUse, event.Type)
+	require.Equal(t, "plugin-session", event.SessionID)
+	require.Equal(t, "/tmp/plugin-rollout.jsonl", event.SessionRef)
+	require.Equal(t, "/tmp/testrepo", event.CWD)
+	require.Equal(t, "call-plugin", event.ToolUseID)
+	require.Equal(t, "gpt-5.2-codex", event.Model)
+	require.Equal(t, []string{"plugin.txt"}, event.NewFiles)
+	require.Equal(t, 2026, event.Timestamp.Year())
 }
 
 func TestParseHookEvent_PostToolUse_AcceptsClaudeAliases(t *testing.T) {

--- a/cmd/entire/cli/internal/hookcompat/envelope.go
+++ b/cmd/entire/cli/internal/hookcompat/envelope.go
@@ -1,0 +1,127 @@
+package hookcompat
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"time"
+)
+
+// Envelope contains the common hook fields shared by CLI and plugin-style hosts.
+type Envelope struct {
+	SessionID      string
+	Prompt         string
+	TranscriptPath string
+	HookEventName  string
+	Model          string
+	CWD            string
+	Timestamp      time.Time
+}
+
+// ReadRaw reads a hook JSON payload into a raw object map.
+func ReadRaw(stdin io.Reader) (map[string]json.RawMessage, error) {
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read hook input: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, errors.New("empty hook input")
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse hook input: %w", err)
+	}
+	return raw, nil
+}
+
+// EnvelopeFromRaw extracts common fields from either snake_case or camelCase payloads.
+func EnvelopeFromRaw(raw map[string]json.RawMessage) (*Envelope, error) {
+	ts, err := ParseTimestamp(raw["timestamp"])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse hook input: %w", err)
+	}
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+
+	return &Envelope{
+		SessionID:      FirstString(raw, "session_id", "sessionId"),
+		Prompt:         FirstString(raw, "prompt"),
+		TranscriptPath: FirstString(raw, "transcript_path", "transcriptPath"),
+		HookEventName:  FirstString(raw, "hook_event_name", "hookEventName"),
+		Model:          FirstString(raw, "model"),
+		CWD:            FirstString(raw, "cwd"),
+		Timestamp:      ts,
+	}, nil
+}
+
+// ReadEnvelope reads and extracts common hook fields.
+func ReadEnvelope(stdin io.Reader) (*Envelope, error) {
+	raw, err := ReadRaw(stdin)
+	if err != nil {
+		return nil, err
+	}
+	return EnvelopeFromRaw(raw)
+}
+
+// FirstString returns the first JSON string found under keys.
+func FirstString(raw map[string]json.RawMessage, keys ...string) string {
+	for _, key := range keys {
+		value, ok := raw[key]
+		if !ok || len(value) == 0 || string(value) == "null" {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(value, &s); err == nil {
+			return s
+		}
+	}
+	return ""
+}
+
+// FirstRaw returns the first present raw JSON value under keys.
+func FirstRaw(raw map[string]json.RawMessage, keys ...string) json.RawMessage {
+	for _, key := range keys {
+		if value, ok := raw[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+// ParseTimestamp decodes epoch-millis or RFC3339Nano hook timestamps.
+func ParseTimestamp(raw json.RawMessage) (time.Time, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return time.Time{}, nil
+	}
+
+	var millis int64
+	if err := json.Unmarshal(raw, &millis); err == nil {
+		if millis == 0 {
+			return time.Time{}, nil
+		}
+		return time.UnixMilli(millis), nil
+	}
+
+	var ts string
+	if err := json.Unmarshal(raw, &ts); err != nil {
+		return time.Time{}, fmt.Errorf("unmarshal timestamp string: %w", err)
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse timestamp %q: %w", ts, err)
+	}
+	return parsed, nil
+}
+
+// HookEventMatches validates optional hookEventName/hook_event_name fields.
+func HookEventMatches(hookEventName, hookName string, allowed map[string][]string) bool {
+	if hookEventName == "" {
+		return true
+	}
+	allowedHooks, ok := allowed[hookEventName]
+	return ok && slices.Contains(allowedHooks, hookName)
+}

--- a/cmd/entire/cli/internal/hookcompat/envelope_test.go
+++ b/cmd/entire/cli/internal/hookcompat/envelope_test.go
@@ -1,0 +1,62 @@
+package hookcompat
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadEnvelope_PluginCamelCasePayload(t *testing.T) {
+	t.Parallel()
+
+	env, err := ReadEnvelope(strings.NewReader(`{
+		"sessionId": "plugin-session",
+		"transcriptPath": "/tmp/session.jsonl",
+		"hookEventName": "SessionStart",
+		"prompt": "hello",
+		"model": "gpt-5",
+		"cwd": "/tmp/repo",
+		"timestamp": "2026-02-09T10:30:00.000Z"
+	}`))
+
+	require.NoError(t, err)
+	require.Equal(t, "plugin-session", env.SessionID)
+	require.Equal(t, "/tmp/session.jsonl", env.TranscriptPath)
+	require.Equal(t, "SessionStart", env.HookEventName)
+	require.Equal(t, "hello", env.Prompt)
+	require.Equal(t, "gpt-5", env.Model)
+	require.Equal(t, "/tmp/repo", env.CWD)
+	require.Equal(t, time.Date(2026, 2, 9, 10, 30, 0, 0, time.UTC), env.Timestamp)
+}
+
+func TestReadEnvelope_NativeSnakeCasePayloadWithEpochMillis(t *testing.T) {
+	t.Parallel()
+
+	env, err := ReadEnvelope(strings.NewReader(`{
+		"session_id": "native-session",
+		"transcript_path": "/tmp/session.jsonl",
+		"hook_event_name": "UserPromptSubmit",
+		"timestamp": 1770633000000
+	}`))
+
+	require.NoError(t, err)
+	require.Equal(t, "native-session", env.SessionID)
+	require.Equal(t, "/tmp/session.jsonl", env.TranscriptPath)
+	require.Equal(t, "UserPromptSubmit", env.HookEventName)
+	require.Equal(t, time.UnixMilli(1770633000000), env.Timestamp)
+}
+
+func TestHookEventMatches(t *testing.T) {
+	t.Parallel()
+
+	allowed := map[string][]string{
+		"SessionStart": {"session-start"},
+	}
+
+	require.True(t, HookEventMatches("", "stop", allowed))
+	require.True(t, HookEventMatches("SessionStart", "session-start", allowed))
+	require.False(t, HookEventMatches("SessionStart", "stop", allowed))
+	require.False(t, HookEventMatches("Unknown", "session-start", allowed))
+}


### PR DESCRIPTION
## Summary
- Accept plugin-style camelCase hook payload fields for Codex and Claude Code lifecycle hooks (`sessionId`, `transcriptPath`, `hookEventName`, etc.).
- Add shared hook payload compatibility helpers for snake_case/camelCase field extraction, RFC3339/epoch-millis timestamps, and hook event validation.
- Document VS Code/plugin compatibility boundaries and the Desktop limitation when no hook or transcript export exists.

## Behavior
- Existing native CLI hook payloads continue to work unchanged.
- VS Code/plugin-style hosts work when they invoke compatible `entire hooks ...` commands or provide standard transcript paths.
- This does not add Desktop live capture for hosts that do not expose hooks or readable transcripts; `entire import` / `entire session attach` remain the fallback.

## Test Plan
- `mise exec -- go test ./cmd/entire/cli/agent/codex ./cmd/entire/cli/agent/claudecode ./cmd/entire/cli/agent/copilotcli ./cmd/entire/cli/internal/hookcompat`
- `mise exec -- go test ./cmd/entire/cli/agent/... ./cmd/entire/cli/internal/hookcompat`
- `mise run test` was attempted; unrelated existing `cmd/entire/cli` explain transcript tests failed while the targeted agent/hook packages passed.
