### PR TITLE
login: open the Windows browser under WSL, with device-flow fallback

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,13 +5,25 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.4.7"
+        "@opencode-ai/plugin": "1.17.11"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
       "cpu": [
         "arm64"
       ],
@@ -22,9 +34,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
       "cpu": [
         "x64"
       ],
@@ -35,9 +47,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
       "cpu": [
         "arm"
       ],
@@ -48,9 +60,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
       "cpu": [
         "arm64"
       ],
@@ -61,9 +73,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
       "cpu": [
         "x64"
       ],
@@ -74,9 +86,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
       "cpu": [
         "x64"
       ],
@@ -87,21 +99,26 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.7.tgz",
-      "integrity": "sha512-RbzMl7ILvQDHpZNvqzi6RCYaGcB3eBwNIMRZww467drLvMd1eOwr4/qAurrvYDsIIEctE6cKsrLuSGIKCW/Fxg==",
+      "version": "1.17.11",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.11.tgz",
+      "integrity": "sha512-mE6SR1tVxL98zbZrlneqF/+dpIKLeZHKzWZy35Hq54uEnuCM1gKq3LK8F2PG2zMBDKQtz2fahEIksJ7svoPLLw==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.4.7",
-        "effect": "4.0.0-beta.48",
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/sdk": "1.17.11",
+        "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.99",
-        "@opentui/solid": ">=0.1.99"
+        "@opentui/core": ">=0.3.4",
+        "@opentui/keymap": ">=0.3.4",
+        "@opentui/solid": ">=0.3.4"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
           "optional": true
         },
         "@opentui/solid": {
@@ -110,9 +127,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.7.tgz",
-      "integrity": "sha512-onEtaooQyoDP5gTShQeQSf0Sd8V7949G9pPNyIyRXnVtFqyDIhUDLGtL/a/+EIW9x5s+Y6lDy/3oVoGMvQ0rQQ==",
+      "version": "1.17.11",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.11.tgz",
+      "integrity": "sha512-UdSwnNM4/cD5rHnI8O7VaHuiwYnsEOglpRPVeeYE2S5Nm1K34ijCyZGDvBecb0ShdBQgn49XvyQWJH6cREsIPw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -149,27 +166,27 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.48",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
-      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
+      "version": "4.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.6.0",
+        "fast-check": "^4.8.0",
         "find-my-way-ts": "^0.1.6",
-        "ini": "^6.0.0",
+        "ini": "^7.0.0",
         "kubernetes-types": "^1.30.0",
-        "msgpackr": "^1.11.9",
+        "msgpackr": "^2.0.1",
         "multipasta": "^0.2.7",
         "toml": "^4.1.1",
-        "uuid": "^13.0.0",
-        "yaml": "^2.8.3"
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/fast-check": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
-      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
       "funding": [
         {
           "type": "individual",
@@ -195,12 +212,12 @@
       "license": "MIT"
     },
     "node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
       "license": "ISC",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/isexe": {
@@ -209,6 +226,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/kubernetes-types": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
@@ -216,18 +239,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
-      "integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
+        "msgpackr-extract": "^3.0.4"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -238,18 +261,18 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
       }
     },
     "node_modules/multipasta": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
-      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
       "license": "MIT"
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -277,9 +300,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
       "funding": [
         {
           "type": "individual",
@@ -314,18 +337,18 @@
       }
     },
     "node_modules/toml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
-      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.2.tgz",
+      "integrity": "sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -351,9 +374,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -330,7 +330,7 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 		fmt.Fprint(outW, "Waiting for sign-in... ")
 		code, err := flow.Wait(waitCtx)
 		if err != nil {
-			return browserWaitError(err, waitCtx, waitTimeout)
+			return browserWaitError(waitCtx, err, waitTimeout)
 		}
 		return exchangeAndPersist(ctx, outW, flow, baseURL, code)
 	}
@@ -359,7 +359,7 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 	case r := <-callbackCh:
 		cancel() // unblock the fallback waiter (closes /dev/tty)
 		if r.err != nil {
-			return browserWaitError(r.err, waitCtx, waitTimeout)
+			return browserWaitError(waitCtx, r.err, waitTimeout)
 		}
 		return exchangeAndPersist(ctx, outW, flow, baseURL, r.code)
 	case ferr := <-fallbackCh:
@@ -367,7 +367,17 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 		if ferr != nil {
 			// Not a real keypress — the waiter was cancelled (parent ctx or the
 			// backstop timeout), so surface that rather than falling back.
-			return browserWaitError(ferr, waitCtx, waitTimeout)
+			return browserWaitError(waitCtx, ferr, waitTimeout)
+		}
+		// The redirect may have already succeeded in the instant before Enter
+		// (a reflexive keypress on a working localhostForwarding setup). Prefer
+		// that buffered result over discarding a completed login.
+		select {
+		case r := <-callbackCh:
+			if r.err == nil {
+				return exchangeAndPersist(ctx, outW, flow, baseURL, r.code)
+			}
+		default:
 		}
 		fmt.Fprintln(outW)
 		return errBrowserFallbackRequested
@@ -376,7 +386,7 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 
 // browserWaitError maps a Wait/fallback error to the user-facing message,
 // distinguishing the backstop timeout from other failures.
-func browserWaitError(err error, waitCtx context.Context, waitTimeout time.Duration) error {
+func browserWaitError(waitCtx context.Context, err error, waitTimeout time.Duration) error {
 	if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
 		return fmt.Errorf("timed out waiting for sign-in after %v; run `entire login` again, or use `entire login --device`", waitTimeout)
 	}
@@ -592,8 +602,14 @@ func openBrowser(ctx context.Context, browserURL string) error {
 
 	cmd := exec.CommandContext(ctx, command, args...)
 	// dir is set only for the WSL cmd.exe fallback, to keep cmd.exe from
-	// warning about the unsupported WSL (UNC) working directory.
-	cmd.Dir = dir
+	// warning about the unsupported WSL (UNC) working directory. It's
+	// best-effort: a customized automount root means /mnt/c may not exist, and
+	// suppressing a cosmetic warning must not become a hard chdir failure.
+	if dir != "" {
+		if _, statErr := os.Stat(dir); statErr == nil {
+			cmd.Dir = dir
+		}
+	}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start browser command %q: %w", command, err)
 	}

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -100,6 +100,7 @@ func newLoginCmd() *cobra.Command {
 					useDevice:  useDevice,
 					canPrompt:  interactive.CanPromptInteractively(),
 					sshSession: isSSHSession(),
+					wsl:        isWSL(),
 				})
 		},
 	}
@@ -157,7 +158,7 @@ func requireSecureLoginServer(server string, insecureHTTPAuth bool) error {
 	return nil
 }
 
-func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc, canPrompt bool) error {
+func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc, canPrompt, autoOpen bool) error {
 	start, err := client.StartDeviceAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("start login: %w", err)
@@ -173,14 +174,20 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		// code is printed above regardless, so it's still available to confirm
 		// against the page (RFC 8628 §3.3.1) or to enter on the bare-URI fallback.
 		fmt.Fprintf(outW, "Login URL:   %s\n\n", approvalURL)
-		fmt.Fprintf(outW, "Press Enter to open in browser...")
 
-		// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
-		if err := waitForEnter(ctx); err != nil {
-			return fmt.Errorf("wait for input: %w", err)
+		// autoOpen skips the Enter prompt and opens straight away: it's set when
+		// arriving here from the WSL browser-loopback fallback, where the user
+		// has already pressed Enter to signal the redirect failed.
+		if !autoOpen {
+			fmt.Fprintf(outW, "Press Enter to open in browser...")
+
+			// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
+			if err := waitForEnter(ctx); err != nil {
+				return fmt.Errorf("wait for input: %w", err)
+			}
+			fmt.Fprintln(outW)
 		}
 
-		fmt.Fprintln(outW)
 		if err := openURL(ctx, approvalURL); err != nil {
 			fmt.Fprintf(errW, "Warning: failed to open browser: %v\n", err)
 			fmt.Fprintf(outW, "Open this URL in your browser to approve this login: %s\n", approvalURL)
@@ -206,6 +213,7 @@ type loginFlowFacts struct {
 	useDevice  bool // --device flag
 	canPrompt  bool // interactive terminal present
 	sshSession bool // running inside an SSH session
+	wsl        bool // running under WSL (Windows Subsystem for Linux)
 }
 
 // runLoginAuto picks between the browser (loopback authorization-code) and
@@ -224,9 +232,24 @@ func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient device
 			// exhausted ports); that shouldn't strand the user — warn and
 			// use the device flow instead.
 			fmt.Fprintf(errW, "Warning: could not start browser sign-in (%v); falling back to the device-code flow.\n", err)
-			return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt)
+			return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt, false)
 		}
-		return runBrowserLogin(ctx, outW, errW, flow, deviceClient.BaseURL(), openURL, browserLoginTimeout)
+		// Under WSL the Windows browser opened by openURL can't necessarily
+		// reach this WSL loopback listener (it depends on WSL2
+		// localhostForwarding), so arm the Enter-driven fallback that lets the
+		// user switch to the device-code flow when the redirect never arrives.
+		var waitFallback func(context.Context) error
+		if facts.wsl {
+			waitFallback = waitForEnter
+		}
+		err = runBrowserLogin(ctx, outW, errW, flow, deviceClient.BaseURL(), openURL, browserLoginTimeout, waitFallback)
+		if errors.Is(err, errBrowserFallbackRequested) {
+			fmt.Fprintln(errW, "Browser sign-in didn't complete; switching to code-based sign-in.")
+			// The user just signalled intent, so open the verification URL
+			// immediately instead of prompting for another Enter.
+			return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt, true)
+		}
+		return err
 	}
 	switch {
 	case facts.useDevice:
@@ -236,8 +259,13 @@ func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient device
 	case facts.sshSession:
 		fmt.Fprintln(errW, "SSH session detected; using device-code flow (a browser opened here couldn't reach this machine).")
 	}
-	return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt)
+	return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt, false)
 }
+
+// errBrowserFallbackRequested signals that the user, during the WSL
+// browser-loopback flow, pressed Enter to abandon the (unreachable) redirect
+// and switch to the device-code flow. It never escapes runLoginAuto.
+var errBrowserFallbackRequested = errors.New("browser login fallback requested")
 
 // shouldUseBrowserLogin reports whether `entire login` should use the
 // loopback authorization-code (browser) flow. The browser flow is the
@@ -264,7 +292,7 @@ func isSSHSession() bool {
 // wait up to waitTimeout for the redirect back to the local listener, then
 // exchange the code for tokens. Shares the token validation + persistence
 // tail with runLogin via persistLogin.
-func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuthFlow, baseURL string, openURL browserOpenFunc, waitTimeout time.Duration) error {
+func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuthFlow, baseURL string, openURL browserOpenFunc, waitTimeout time.Duration, waitFallback func(context.Context) error) error {
 	// Wait tears the listener down on return, but Close is idempotent and
 	// covers the error paths before Wait runs.
 	defer func() { _ = flow.Close() }()
@@ -293,26 +321,75 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 		fmt.Fprintf(outW, "Open this URL in your browser to sign in: %s\n", authURL)
 	}
 
-	fmt.Fprint(outW, "Waiting for sign-in... ")
-
 	// The clock starts here, after the Enter prompt, so time spent reading
 	// the prompt isn't counted against the sign-in itself.
 	waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
 	defer cancel()
 
-	code, err := flow.Wait(waitCtx)
-	if err != nil {
-		if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
-			return fmt.Errorf("timed out waiting for sign-in after %v; run `entire login` again, or use `entire login --device`", waitTimeout)
+	if waitFallback == nil {
+		fmt.Fprint(outW, "Waiting for sign-in... ")
+		code, err := flow.Wait(waitCtx)
+		if err != nil {
+			return browserWaitError(err, waitCtx, waitTimeout)
 		}
-		return fmt.Errorf("complete login: %w", err)
+		return exchangeAndPersist(ctx, outW, flow, baseURL, code)
 	}
 
+	// WSL: the Windows browser can't necessarily reach this WSL loopback
+	// listener (it depends on WSL2 localhostForwarding). Race the OAuth
+	// callback against an Enter keypress — the user presses Enter when the
+	// browser shows a "can't reach this page" error — and fall back to the
+	// device-code flow on Enter. Whichever fires first cancels the shared
+	// context, unblocking the loser (waitFallback closes /dev/tty on cancel).
+	fmt.Fprint(outW, "Waiting for sign-in... (press Enter if your browser shows a connection error) ")
+
+	type waitResult struct {
+		code string
+		err  error
+	}
+	callbackCh := make(chan waitResult, 1)
+	go func() {
+		code, err := flow.Wait(waitCtx)
+		callbackCh <- waitResult{code: code, err: err}
+	}()
+	fallbackCh := make(chan error, 1)
+	go func() { fallbackCh <- waitFallback(waitCtx) }()
+
+	select {
+	case r := <-callbackCh:
+		cancel() // unblock the fallback waiter (closes /dev/tty)
+		if r.err != nil {
+			return browserWaitError(r.err, waitCtx, waitTimeout)
+		}
+		return exchangeAndPersist(ctx, outW, flow, baseURL, r.code)
+	case ferr := <-fallbackCh:
+		cancel() // unblock flow.Wait
+		if ferr != nil {
+			// Not a real keypress — the waiter was cancelled (parent ctx or the
+			// backstop timeout), so surface that rather than falling back.
+			return browserWaitError(ferr, waitCtx, waitTimeout)
+		}
+		fmt.Fprintln(outW)
+		return errBrowserFallbackRequested
+	}
+}
+
+// browserWaitError maps a Wait/fallback error to the user-facing message,
+// distinguishing the backstop timeout from other failures.
+func browserWaitError(err error, waitCtx context.Context, waitTimeout time.Duration) error {
+	if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("timed out waiting for sign-in after %v; run `entire login` again, or use `entire login --device`", waitTimeout)
+	}
+	return fmt.Errorf("complete login: %w", err)
+}
+
+// exchangeAndPersist exchanges the authorization code for tokens and records
+// the login. Shared by the linear and WSL-fallback browser paths.
+func exchangeAndPersist(ctx context.Context, outW io.Writer, flow browserAuthFlow, baseURL, code string) error {
 	token, refreshToken, err := flow.Exchange(ctx, code)
 	if err != nil {
 		return fmt.Errorf("complete login: %w", err)
 	}
-
 	return persistLogin(outW, baseURL, token, refreshToken)
 }
 

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/entireio/auth-go/tokens"
@@ -507,24 +508,15 @@ func openBrowser(ctx context.Context, browserURL string) error {
 		return errors.New("browser unavailable under test")
 	}
 
-	var command string
-	var args []string
-
-	switch runtime.GOOS {
-	case "darwin":
-		command = "open"
-		args = []string{browserURL}
-	case "linux":
-		command = "xdg-open"
-		args = []string{browserURL}
-	case "windows":
-		command = "cmd"
-		args = []string{"/c", "start", "", browserURL}
-	default:
-		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	command, args, dir, err := resolveBrowserLauncher(runtime.GOOS, isWSL(), exec.LookPath, browserURL)
+	if err != nil {
+		return err
 	}
 
 	cmd := exec.CommandContext(ctx, command, args...)
+	// dir is set only for the WSL cmd.exe fallback, to keep cmd.exe from
+	// warning about the unsupported WSL (UNC) working directory.
+	cmd.Dir = dir
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start browser command %q: %w", command, err)
 	}
@@ -535,3 +527,59 @@ func openBrowser(ctx context.Context, browserURL string) error {
 
 	return nil
 }
+
+// resolveBrowserLauncher picks the command that opens browserURL, given the
+// OS, whether we're under WSL, and a PATH probe. It is pure so the platform
+// matrix is unit-testable without spawning anything; openBrowser wires in the
+// real runtime.GOOS, isWSL(), and exec.LookPath.
+//
+// Under WSL, xdg-open can't be trusted: with a Linux browser installed via
+// WSLg it resolves the https scheme handler to that Linux browser, ignoring
+// both $BROWSER and the xdg default, so the user lands in a browser with none
+// of their sessions. So on WSL we open the Windows default browser directly
+// via wslview (from wslu, preinstalled on Ubuntu-on-WSL), falling back to
+// cmd.exe on stripped-down distros without it. The cmd.exe working directory
+// is a Windows path so cmd doesn't warn about the unsupported WSL (UNC) cwd.
+func resolveBrowserLauncher(goos string, wsl bool, lookPath func(string) (string, error), browserURL string) (command string, args []string, dir string, err error) {
+	switch goos {
+	case "darwin":
+		return "open", []string{browserURL}, "", nil
+	case "windows":
+		return "cmd", []string{"/c", "start", "", browserURL}, "", nil
+	case "linux":
+		if wsl {
+			if path, lerr := lookPath("wslview"); lerr == nil {
+				return path, []string{browserURL}, "", nil
+			}
+			return "cmd.exe", []string{"/c", "start", "", browserURL}, "/mnt/c", nil
+		}
+		return "xdg-open", []string{browserURL}, "", nil
+	default:
+		return "", nil, "", fmt.Errorf("unsupported platform %s", goos)
+	}
+}
+
+// wslFromProcVersion reports whether a /proc/version string indicates WSL.
+// Both WSL1 ("...Microsoft...") and WSL2 ("...microsoft-standard-WSL2...")
+// carry the marker; the match is case-insensitive.
+func wslFromProcVersion(s string) bool {
+	return strings.Contains(strings.ToLower(s), "microsoft")
+}
+
+var wslDetect = sync.OnceValue(func() bool {
+	// Non-Linux hosts are never WSL, so /proc/version is only read on Linux.
+	// Detection keys on /proc/version rather than WSL_* env vars because those
+	// can be stripped when entire is spawned from a hook, service, or env -i —
+	// exactly the contexts the CLI must handle.
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	b, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return false
+	}
+	return wslFromProcVersion(string(b))
+})
+
+// isWSL reports whether we're running under WSL, reading /proc/version once.
+func isWSL() bool { return wslDetect() }

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -612,5 +613,75 @@ func TestRunBrowserLogin_ParentCancelNotReportedAsTimeout(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "timed out") {
 		t.Errorf("cancellation must not be reported as a timeout: %v", err)
+	}
+}
+
+func TestWSLFromProcVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"wsl2", "Linux version 6.18.33.2-microsoft-standard-WSL2 (root@f1bbfb02316b)", true},
+		{"wsl1", "Linux version 4.4.0-19041-Microsoft (build)", true},
+		{"plain-linux", "Linux version 6.8.0-generic (buildd@lcy02)", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		if got := wslFromProcVersion(tc.in); got != tc.want {
+			t.Errorf("wslFromProcVersion(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestResolveBrowserLauncher(t *testing.T) {
+	t.Parallel()
+
+	const browserURL = "https://auth.test/cli/auth?user_code=ABCD"
+	found := func(string) (string, error) { return "/usr/bin/wslview", nil }
+	missing := func(string) (string, error) { return "", errors.New("not found") }
+
+	cases := []struct {
+		name     string
+		goos     string
+		wsl      bool
+		look     func(string) (string, error)
+		wantCmd  string
+		wantArgs []string
+		wantDir  string
+		wantErr  bool
+	}{
+		{"darwin", "darwin", false, missing, "open", []string{browserURL}, "", false},
+		{"windows", "windows", false, missing, "cmd", []string{"/c", "start", "", browserURL}, "", false},
+		{"linux-non-wsl", "linux", false, found, "xdg-open", []string{browserURL}, "", false},
+		{"wsl-with-wslview", "linux", true, found, "/usr/bin/wslview", []string{browserURL}, "", false},
+		{"wsl-without-wslview", "linux", true, missing, "cmd.exe", []string{"/c", "start", "", browserURL}, "/mnt/c", false},
+		{"unsupported", "plan9", false, missing, "", nil, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd, args, dir, err := resolveBrowserLauncher(tc.goos, tc.wsl, tc.look, browserURL)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got cmd=%q", cmd)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cmd != tc.wantCmd {
+				t.Errorf("cmd = %q, want %q", cmd, tc.wantCmd)
+			}
+			if !reflect.DeepEqual(args, tc.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tc.wantArgs)
+			}
+			if dir != tc.wantDir {
+				t.Errorf("dir = %q, want %q", dir, tc.wantDir)
+			}
+		})
 	}
 }

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -508,7 +508,7 @@ func TestRunBrowserLogin_OpensAuthorizationURL(t *testing.T) {
 	// The stubbed Wait returns an error, so runBrowserLogin stops before
 	// persistLogin (which would hit the real keyring); we assert on the
 	// side effects up to that point.
-	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, flow, "https://auth.test", openURL, browserLoginTimeout); err == nil {
+	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, flow, "https://auth.test", openURL, browserLoginTimeout, nil); err == nil {
 		t.Fatal("expected error from stubbed Wait")
 	}
 
@@ -538,7 +538,7 @@ func TestRunBrowserLogin_OpenBrowserFallback(t *testing.T) {
 	failOpen := func(context.Context, string) error { return errors.New("no browser") }
 
 	var out, errW bytes.Buffer
-	if err := runBrowserLogin(context.Background(), &out, &errW, flow, "https://auth.test", failOpen, browserLoginTimeout); err == nil {
+	if err := runBrowserLogin(context.Background(), &out, &errW, flow, "https://auth.test", failOpen, browserLoginTimeout, nil); err == nil {
 		t.Fatal("expected error from stubbed Wait")
 	}
 
@@ -556,7 +556,7 @@ func TestRunBrowserLogin_WaitError(t *testing.T) {
 	denied := errors.New("access_denied")
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: denied}
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout, nil)
 	if !errors.Is(err, denied) {
 		t.Fatalf("err = %v, want wrapped %v", err, denied)
 	}
@@ -571,7 +571,7 @@ func TestRunBrowserLogin_ExchangeError(t *testing.T) {
 		exchErr:  errors.New("invalid_grant"),
 	}
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout, nil)
 	if err == nil || !strings.Contains(err.Error(), "complete login") {
 		t.Fatalf("err = %v, want complete login error", err)
 	}
@@ -587,7 +587,7 @@ func TestRunBrowserLogin_WaitTimeout(t *testing.T) {
 	// come from runBrowserLogin's own timeout, or this test would hang.
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, 50*time.Millisecond)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, 50*time.Millisecond, nil)
 	if err == nil || !strings.Contains(err.Error(), "timed out waiting for sign-in") {
 		t.Fatalf("err = %v, want sign-in timeout", err)
 	}
@@ -607,12 +607,110 @@ func TestRunBrowserLogin_ParentCancelNotReportedAsTimeout(t *testing.T) {
 
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
 
-	err := runBrowserLogin(ctx, &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, time.Minute)
+	err := runBrowserLogin(ctx, &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, time.Minute, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want wrapped context.Canceled", err)
 	}
 	if strings.Contains(err.Error(), "timed out") {
 		t.Errorf("cancellation must not be reported as a timeout: %v", err)
+	}
+}
+
+func TestRunBrowserLogin_WSLFallback_CallbackWins(t *testing.T) {
+	t.Parallel()
+
+	// Callback returns a code; Exchange errors so we stop before persistLogin
+	// (which would hit real storage). The fallback blocks until the shared
+	// context is cancelled, so the callback wins the race.
+	flow := &fakeBrowserFlow{
+		authURL:  "https://auth.test/authorize",
+		waitCode: "cb-code",
+		exchErr:  errors.New("exchange boom"),
+	}
+	blockingFallback := func(ctx context.Context) error { <-ctx.Done(); return ctx.Err() }
+
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow,
+		"https://auth.test", noopOpenURL, browserLoginTimeout, blockingFallback)
+
+	if errors.Is(err, errBrowserFallbackRequested) {
+		t.Fatalf("callback should win, got fallback: %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "complete login") {
+		t.Fatalf("err = %v, want 'complete login' from exchange error", err)
+	}
+	if flow.gotExchangeCode != "cb-code" {
+		t.Errorf("exchange code = %q, want cb-code (callback path taken)", flow.gotExchangeCode)
+	}
+	if !flow.closed {
+		t.Error("flow not closed")
+	}
+}
+
+func TestRunBrowserLogin_WSLFallback_EnterWins(t *testing.T) {
+	t.Parallel()
+
+	// flow.Wait blocks until ctx is done; the fallback returns immediately
+	// (as if the user pressed Enter), so the fallback wins.
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
+	enterNow := func(context.Context) error { return nil }
+
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow,
+		"https://auth.test", noopOpenURL, browserLoginTimeout, enterNow)
+
+	if !errors.Is(err, errBrowserFallbackRequested) {
+		t.Fatalf("err = %v, want errBrowserFallbackRequested", err)
+	}
+	if flow.gotExchangeCode != "" {
+		t.Errorf("exchange must not run on fallback, got code %q", flow.gotExchangeCode)
+	}
+	if !flow.closed {
+		t.Error("flow not closed")
+	}
+}
+
+func TestRunLoginAuto_WSL_FallbackToDevice(t *testing.T) {
+	t.Parallel()
+
+	// Under test the real waitForEnter (armed only for WSL) returns
+	// immediately, so the fallback fires and routes to the device flow. The
+	// browser flow's Wait blocks so the callback never pre-empts the fallback.
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
+	var browserCalls int
+	var errW bytes.Buffer
+
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
+		startBrowserStub(&browserCalls, flow, nil), noopOpenURL,
+		loginFlowFacts{canPrompt: true, wsl: true})
+
+	if browserCalls != 1 {
+		t.Errorf("startBrowser calls = %d, want 1 (WSL still tries the loopback flow first)", browserCalls)
+	}
+	if !strings.Contains(errW.String(), "switching to code-based sign-in") {
+		t.Errorf("stderr missing fallback message:\n%s", errW.String())
+	}
+	// mockClient.StartDeviceAuth errors — proof the device flow was attempted.
+	if err == nil || !strings.Contains(err.Error(), "not implemented in mock") {
+		t.Fatalf("err = %v, want device-flow start error from mock", err)
+	}
+	if !flow.closed {
+		t.Error("browser flow not closed before fallback")
+	}
+}
+
+func TestRunLoginAuto_NonWSL_NoFallbackArmed(t *testing.T) {
+	t.Parallel()
+
+	// Without wsl, the browser flow must NOT arm the Enter fallback: Wait's
+	// error surfaces directly as a 'complete login' failure, never a fallback.
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: errors.New("stop")}
+	var browserCalls int
+
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, &mockClient{},
+		startBrowserStub(&browserCalls, flow, nil), noopOpenURL,
+		loginFlowFacts{canPrompt: true})
+
+	if err == nil || !strings.Contains(err.Error(), "complete login") {
+		t.Fatalf("err = %v, want browser-flow 'complete login' error (no fallback)", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #1707. Makes `entire login` under WSL open the Windows browser (where users are already signed in) and recover when the OAuth redirect can't reach WSL.

- Open the Windows default browser under WSL (wslview, else cmd.exe) instead of a Linux WSLg browser
- Detect WSL from /proc/version, so detection survives hooks/services that strip WSL env vars
- On WSL, let the user fall back to device-code sign-in when the browser redirect can't reach the loopback listener (extends the #1403 `loginFlowFacts` pattern with a `wsl` fact, mirroring its SSH fallback)
- Shared launcher, so `entire experts` also opens the Windows browser
- Non-WSL platforms unchanged; launcher selection and the fallback race are unit-tested (pass under `-race`)
