### PR TITLE
Skip post-plugin version check after self-update plugin

### DIFF
--- a/cmd/entire/cli/plugin.go
+++ b/cmd/entire/cli/plugin.go
@@ -31,6 +31,14 @@ const (
 	agentPluginBinaryPrefix = "entire-agent-"
 )
 
+// selfUpdatePluginName is the plugin that replaces the entire binary on
+// disk (`entire upgrade` → entire-upgrade).
+const selfUpdatePluginName = "upgrade"
+
+// postPluginVersionCheck is a test seam for the version-check notice that
+// fires after a successful plugin run.
+var postPluginVersionCheck = versioncheck.CheckAndNotify
+
 // MaybeRunPlugin returns (true, exitCode) when an external command was
 // resolved and run. On launch failure (e.g. missing executable bit)
 // returns (true, 1) after printing to stderr. On no-match returns
@@ -49,7 +57,13 @@ func MaybeRunPlugin(ctx context.Context, rootCmd *cobra.Command, args []string) 
 		maybeTrackPluginInvocation(ctx, pluginName)
 		// Stderr, matching the built-in PersistentPostRun: the plugin's own
 		// stdout may be machine-readable and piped.
-		versioncheck.CheckAndNotify(ctx, os.Stderr, versioninfo.Version)
+		//
+		// Skipped after a self-update: this process still carries the
+		// pre-upgrade compiled-in version, so the check would see itself as
+		// outdated and prompt to redo the upgrade that just completed.
+		if pluginName != selfUpdatePluginName {
+			postPluginVersionCheck(ctx, os.Stderr, versioninfo.Version)
+		}
 	}
 	return true, exitCode
 }

--- a/cmd/entire/cli/plugin_test.go
+++ b/cmd/entire/cli/plugin_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -188,6 +189,65 @@ func TestRunPlugin_ExitCodePropagation(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(contents)); got != "a\nb" {
 		t.Errorf("argv: got %q, want %q", got, "a\nb")
+	}
+}
+
+// interceptVersionCheck swaps the post-plugin version-check seam for a
+// counter and restores it on cleanup.
+func interceptVersionCheck(t *testing.T) *int {
+	t.Helper()
+	calls := 0
+	orig := postPluginVersionCheck
+	postPluginVersionCheck = func(context.Context, io.Writer, string) { calls++ }
+	t.Cleanup(func() { postPluginVersionCheck = orig })
+	return &calls
+}
+
+func TestMaybeRunPlugin_VersionCheckAfterSuccess(t *testing.T) { //nolint:paralleltest // mutates PATH and the version-check seam
+	dir := t.TempDir()
+	writePluginBinary(t, dir, "entire-pgr", filepath.Join(dir, "args.txt"), 0)
+	withPathDir(t, dir)
+	calls := interceptVersionCheck(t)
+
+	handled, code := MaybeRunPlugin(context.Background(), newTestRoot(), []string{"pgr"})
+	if !handled || code != 0 {
+		t.Fatalf("handled=%v code=%d, want handled=true code=0", handled, code)
+	}
+	if *calls != 1 {
+		t.Errorf("version check calls: got %d, want 1", *calls)
+	}
+}
+
+// After `entire upgrade` replaces the binary on disk, this process still
+// carries the pre-upgrade compiled-in version — a post-run version check
+// would see itself as outdated and prompt to redo the finished upgrade.
+func TestMaybeRunPlugin_NoVersionCheckAfterSelfUpdate(t *testing.T) { //nolint:paralleltest // mutates PATH and the version-check seam
+	dir := t.TempDir()
+	writePluginBinary(t, dir, "entire-upgrade", filepath.Join(dir, "args.txt"), 0)
+	withPathDir(t, dir)
+	calls := interceptVersionCheck(t)
+
+	handled, code := MaybeRunPlugin(context.Background(), newTestRoot(), []string{"upgrade", "--nightly"})
+	if !handled || code != 0 {
+		t.Fatalf("handled=%v code=%d, want handled=true code=0", handled, code)
+	}
+	if *calls != 0 {
+		t.Errorf("version check calls: got %d, want 0", *calls)
+	}
+}
+
+func TestMaybeRunPlugin_NoVersionCheckAfterFailure(t *testing.T) { //nolint:paralleltest // mutates PATH and the version-check seam
+	dir := t.TempDir()
+	writePluginBinary(t, dir, "entire-pgr", filepath.Join(dir, "args.txt"), 3)
+	withPathDir(t, dir)
+	calls := interceptVersionCheck(t)
+
+	handled, code := MaybeRunPlugin(context.Background(), newTestRoot(), []string{"pgr"})
+	if !handled || code != 3 {
+		t.Fatalf("handled=%v code=%d, want handled=true code=3", handled, code)
+	}
+	if *calls != 0 {
+		t.Errorf("version check calls: got %d, want 0", *calls)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/837
<!-- entire-trail-link-end -->

## Why

Running `entire upgrade` (the entire-upgrade plugin) replaces the binary on disk, but the parent `entire` process still carries the pre-upgrade compiled-in version. The post-plugin version check (`plugin.go`) then saw itself as outdated, prompted "Update available!" again, and re-ran a no-op `brew upgrade` — right after the upgrade had just completed.

This results in shell sessions like this:

```
$ entire upgrade --nightly --yes
  Detected Entire CLI (homebrew install):
    entire            0.8.43-nightly.202607081321.e009b7501 at /opt/homebrew/bin/entire
    git-remote-entire 0.8.43-nightly.202607081321.e009b7501 at /opt/homebrew/bin/git-remote-entire
  Latest nightly build is 0.8.43-nightly.202607110651.7cd666280
  ==> Auto-updating Homebrew...
  ==> Downloading https://formulae.brew.sh/api/formula.jws.json
  [... elided ...]
  [... homebrew upgrade goes brrrrr ...]
  ==> Would upgrade 1 outdated package
  entireio/tap/entire@nightly 0.8.43-nightly.202607081321.e009b7501 -> 0.8.43-nightly.202607110651.7cd666280
  ==> Do you want to proceed with the upgrade? [y/n] y
  ==> Upgrading 1 outdated package:
  entireio/tap/entire@nightly 0.8.43-nightly.202607081321.e009b7501 -> 0.8.43-nightly.202607110651.7cd666280
  ==> Fetching downloads for: entireio/tap/entire@nightly
  ✔︎ Cask entire@nightly (0.8.43-nightly.202607110651.7cd666280)                                                                                                                                                        Downloaded   20.2MB/ 20.2MB
  ==> Upgrading entire@nightly
    0.8.43-nightly.202607081321.e009b7501 -> 0.8.43-nightly.202607110651.7cd666280
    [... elided ...]
  🍺  entire@nightly was successfully upgraded!
  ==> Upgraded 1 outdated package
  entireio/tap/entire@nightly 0.8.43-nightly.202607081321.e009b7501 -> 0.8.43-nightly.202607110651.7cd666280
  Entire CLI upgrade complete (homebrew install):
    entire            0.8.43-nightly.202607110651.7cd666280 installed to /opt/homebrew/bin/entire
    git-remote-entire 0.8.43-nightly.202607110651.7cd666280 installed to /opt/homebrew/bin/git-remote-entire
[ .. but now we get the upgrade prompt again! .. ]
  Updating Entire CLI: brew upgrade --yes entire@nightly
  ✔︎ JSON API packages.arm64_tahoe.jws.json                                                                                                                                                                             Downloaded   15.2MB/ 15.2MB
  Warning: Not upgrading entire@nightly, the latest version is already installed
  Update complete. Re-run entire to use the new version.
```

## What

- `MaybeRunPlugin` skips `versioncheck.CheckAndNotify` when the plugin that just ran is `upgrade` (new `selfUpdatePluginName` const), via a new `postPluginVersionCheck` test seam.
- Tests: check fires after a successful non-upgrade plugin, is skipped after `entire-upgrade`, and is skipped after a failing plugin (pins existing behavior).

Tradeoff: name-based coupling — any `entire-upgrade` binary on PATH suppresses the check, not just the official plugin. The name is de facto reserved for self-update, so this seems fine.

## Verification

- New unit tests pass (`go test ./cmd/entire/cli/ -run TestMaybeRunPlugin`).
- `mise run fmt && mise run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to CLI plugin post-run behavior with unit tests; no auth, data, or security surface.
> 
> **Overview**
> Fixes a false **“Update available!”** prompt immediately after a successful `entire upgrade` when the upgrade runs as the `entire-upgrade` plugin.
> 
> `MaybeRunPlugin` still runs `versioncheck.CheckAndNotify` after other successful plugins, but **skips** it when the plugin name is `upgrade`, because this process still has the pre-upgrade `versioninfo.Version` baked in even though the binary on disk was just replaced.
> 
> The direct call is routed through a `postPluginVersionCheck` variable (defaults to `CheckAndNotify`) so tests can assert: check runs after a successful non-upgrade plugin, is omitted after `upgrade`, and stays off on plugin failure (unchanged behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e12b0cac276ef7e3cb2840cd9877d39a3e7c781. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->