### PR TITLE
Route checkpoints through entire:// push-through mirrors

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -18,8 +18,9 @@ import (
 const originRemote = "origin"
 
 const (
-	ProtocolSSH   = gitremote.ProtocolSSH
-	ProtocolHTTPS = gitremote.ProtocolHTTPS
+	ProtocolSSH    = gitremote.ProtocolSSH
+	ProtocolHTTPS  = gitremote.ProtocolHTTPS
+	ProtocolEntire = gitremote.ProtocolEntire
 )
 
 // Info is an alias for gitremote.Info.
@@ -112,8 +113,9 @@ func FetchURL(ctx context.Context, opts ...FetchURLOptions) (string, error) {
 
 	checkpointURL, err := deriveCheckpointURLFromInfo(info, config)
 	if err != nil {
-		// Origin's protocol can't be mapped to a git transport (e.g. entire://,
-		// file://). Honor the configured checkpoint_remote by targeting the
+		// Origin's protocol can't be mapped to a checkpoint URL (e.g. file://,
+		// or an entire:// mirror of a different forge than the configured
+		// provider). Honor the configured checkpoint_remote by targeting the
 		// provider's canonical host over HTTPS rather than falling back to origin.
 		if providerURL, ok := resolveProviderCheckpointURL(config, opt.WorktreeRoot); ok {
 			return providerURL, nil
@@ -186,12 +188,12 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 		}
 		return "", true, fmt.Errorf("no push URL found: %w", err)
 	}
-	if strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != "" && isDerivableProtocol(pushInfo.Protocol) {
-		// Coerce a derivable (ssh/https) remote to HTTPS so the token applies,
+	withToken := strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != ""
+	if withToken && isDirectGitTransport(pushInfo.Protocol) {
+		// Coerce a direct (ssh/https) remote to HTTPS so the token applies,
 		// keeping the host so enterprise installations stay on their own host.
-		// A non-derivable protocol (e.g. entire://) carries a host that isn't a
-		// usable HTTPS host, so it's left untouched and falls through to the
-		// providerCheckpointURL fallback below.
+		// An entire:// remote carries a cluster host that isn't a usable HTTPS
+		// host, so it's handled separately after the owner check below.
 		//
 		// Keep the port only when the source was already HTTPS. SSH ports
 		// (e.g., :2222) don't map to HTTPS ports on the same host.
@@ -217,10 +219,20 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 		return fallbackURL, false, nil
 	}
 
+	if withToken && pushInfo.Protocol == ProtocolEntire {
+		// The checkpoint token is an HTTPS credential for the provider host;
+		// it can't ride through the entire:// helper (which does its own
+		// auth). Route to the provider over HTTPS instead of the mirror.
+		if providerURL, ok := resolveProviderCheckpointURL(config, ""); ok {
+			return providerURL, true, nil
+		}
+	}
+
 	pushURL, err := deriveCheckpointURLFromInfo(pushInfo, config)
 	if err != nil {
-		// The push remote's protocol can't be mapped to a git transport
-		// (e.g. entire://, file://). Honor the configured checkpoint_remote by
+		// The push remote's protocol can't be mapped to a checkpoint URL
+		// (e.g. file://, or an entire:// mirror of a different forge than the
+		// configured provider). Honor the configured checkpoint_remote by
 		// targeting the provider's canonical host over HTTPS rather than
 		// misrouting checkpoints to the origin remote.
 		if providerURL, ok := resolveProviderCheckpointURL(config, ""); ok {
@@ -278,10 +290,11 @@ func ParseURL(rawURL string) (*Info, error) {
 	return info, nil
 }
 
-// isDerivableProtocol reports whether deriveCheckpointURLFromInfo can map the
-// protocol to a checkpoint URL (i.e. it's a real git transport, not a remote
-// helper scheme like entire:// or a local file://).
-func isDerivableProtocol(protocol string) bool {
+// isDirectGitTransport reports whether the protocol talks to the git host
+// directly over ssh/https (where the host is a usable HTTPS host for token
+// auth), as opposed to a remote helper scheme like entire:// or a local
+// file://.
+func isDirectGitTransport(protocol string) bool {
 	return protocol == ProtocolSSH || protocol == ProtocolHTTPS
 }
 
@@ -296,6 +309,16 @@ func deriveCheckpointURLFromInfo(info *Info, config *settings.CheckpointRemoteCo
 		return fmt.Sprintf("git@%s:%s.git", info.Host, config.Repo), nil
 	case ProtocolHTTPS:
 		return fmt.Sprintf("https://%s/%s.git", info.HostPort(), config.Repo), nil
+	case ProtocolEntire:
+		// entire:// push-through mirrors are cluster-scoped: keep the cluster
+		// host and forge segment, swap in the checkpoint repo. Only derivable
+		// when the forge maps back to the configured provider's host, so a
+		// github checkpoint_remote never routes through another forge's mirror.
+		host, ok := providerHost(config.Provider)
+		if !ok || !strings.EqualFold(info.CanonicalHost(), host) {
+			return "", fmt.Errorf("entire:// remote forge %q does not match checkpoint provider %q", info.Forge, config.Provider)
+		}
+		return fmt.Sprintf("entire://%s/%s/%s", info.HostPort(), info.Forge, config.Repo), nil
 	default:
 		return "", fmt.Errorf("unsupported protocol %q in origin remote", info.Protocol)
 	}
@@ -393,7 +416,7 @@ func findRemoteInfoForHost(repo *git.Repository, host string) (*Info, bool) {
 			if err != nil {
 				continue
 			}
-			if strings.EqualFold(info.Host, host) && isDerivableProtocol(info.Protocol) {
+			if strings.EqualFold(info.Host, host) && isDirectGitTransport(info.Protocol) {
 				return info, true
 			}
 		}

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -320,7 +320,7 @@ func deriveCheckpointURLFromInfo(info *Info, config *settings.CheckpointRemoteCo
 		}
 		return fmt.Sprintf("entire://%s/%s/%s", info.HostPort(), info.Forge, config.Repo), nil
 	default:
-		return "", fmt.Errorf("unsupported protocol %q in origin remote", info.Protocol)
+		return "", fmt.Errorf("unsupported protocol %q in remote URL", info.Protocol)
 	}
 }
 

--- a/cmd/entire/cli/checkpoint/remote/util_test.go
+++ b/cmd/entire/cli/checkpoint/remote/util_test.go
@@ -131,8 +131,14 @@ func TestFetchURL_EdgeCases(t *testing.T) {
 			wantURL:      "git@github.com:acme/checkpoints.git",
 		},
 		{
-			name:         "entire:// origin without token routes to provider checkpoint url (ssh default)",
+			name:         "entire:// origin without token derives mirror checkpoint url on same cluster",
 			originURL:    "entire://app.entire.io/gh/acme/app",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			wantURL:      "entire://app.entire.io/gh/acme/checkpoints",
+		},
+		{
+			name:         "entire:// origin with forge not matching provider routes to provider checkpoint url (ssh default)",
+			originURL:    "entire://app.entire.io/et/acme/app",
 			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
 			wantURL:      "git@github.com:acme/checkpoints.git",
 		},
@@ -312,12 +318,28 @@ func TestPushURL(t *testing.T) {
 			wantEnabled:  false,
 		},
 		{
-			name:         "entire:// origin routes to provider checkpoint url (ssh default)",
+			name:         "entire:// origin derives mirror checkpoint url on same cluster",
 			originURL:    "entire://app.entire.io/gh/acme/app",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			wantURL:      "entire://app.entire.io/gh/acme/checkpoints",
+			wantEnabled:  true,
+		},
+		{
+			name:         "entire:// origin with forge not matching provider routes to provider checkpoint url (ssh default)",
+			originURL:    "entire://app.entire.io/et/acme/app",
 			pushRemote:   "origin",
 			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
 			wantURL:      "git@github.com:acme/checkpoints.git",
 			wantEnabled:  true,
+		},
+		{
+			name:         "entire:// origin with different owner disables checkpoint push url",
+			originURL:    "entire://app.entire.io/gh/fork/app",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			wantURL:      "entire://app.entire.io/gh/fork/app",
+			wantEnabled:  false,
 		},
 		{
 			name:         "file:// origin routes to provider checkpoint url (ssh default)",
@@ -398,14 +420,16 @@ func TestPushURL(t *testing.T) {
 	}
 }
 
-// TestPushURL_EntireOriginReusesProviderRemoteScheme reproduces the real-world
-// setup: origin migrated to an entire:// URL (forge-prefixed /gh/owner/repo)
-// with a github checkpoint_remote. The checkpoint URL must route to github
-// rather than fall back to the entire:// origin, reusing the auth/scheme the
-// repo had for that endpoint — a token forces HTTPS, then an existing remote
-// on the provider host, then defaulting to SSH.
-func TestPushURL_EntireOriginReusesProviderRemoteScheme(t *testing.T) {
-	const entireOrigin = "entire://aws-eu-central-1.entire.io/gh/entireio/cli"
+// TestPushURL_EntireOriginDerivesMirrorURL reproduces the real-world setup:
+// origin migrated to an entire:// URL (forge-prefixed /gh/owner/repo) with a
+// github checkpoint_remote. Checkpoints must follow origin through the
+// push-through mirror on the same cluster — even when leftover direct github
+// remotes (e.g. URL-named promisor entries from filtered fetches) exist. The
+// exception is a checkpoint token, which is an HTTPS credential for the
+// provider host and therefore forces direct provider HTTPS.
+func TestPushURL_EntireOriginDerivesMirrorURL(t *testing.T) {
+	const entireOrigin = "entire://aws-ap-southeast-2.entire.io/gh/entireio/cli"
+	const mirrorCheckpointURL = "entire://aws-ap-southeast-2.entire.io/gh/entireio/cli-checkpoints"
 	tests := []struct {
 		name        string
 		githubURL   string
@@ -414,24 +438,24 @@ func TestPushURL_EntireOriginReusesProviderRemoteScheme(t *testing.T) {
 		wantEnabled bool
 	}{
 		{
-			name:        "ssh github remote yields ssh checkpoint url",
+			name:        "existing ssh github remote does not divert checkpoints off the mirror",
 			githubURL:   "git@github.com:entireio/cli.git",
-			wantURL:     "git@github.com:entireio/cli-checkpoints.git",
+			wantURL:     mirrorCheckpointURL,
 			wantEnabled: true,
 		},
 		{
-			name:        "https github remote yields https checkpoint url",
+			name:        "existing https github remote does not divert checkpoints off the mirror",
 			githubURL:   "https://github.com/entireio/cli.git",
-			wantURL:     "https://github.com/entireio/cli-checkpoints.git",
+			wantURL:     mirrorCheckpointURL,
 			wantEnabled: true,
 		},
 		{
-			name:        "no signal defaults to ssh",
-			wantURL:     "git@github.com:entireio/cli-checkpoints.git",
+			name:        "entire origin alone derives mirror checkpoint url",
+			wantURL:     mirrorCheckpointURL,
 			wantEnabled: true,
 		},
 		{
-			name:        "token forces https over existing ssh remote",
+			name:        "token forces https on the provider host",
 			githubURL:   "git@github.com:entireio/cli.git",
 			token:       "ci-token",
 			wantURL:     "https://github.com/entireio/cli-checkpoints.git",
@@ -581,6 +605,24 @@ func TestDeriveCheckpointURLFromInfo(t *testing.T) {
 			pushRemoteURL:  "ssh://git@git.example.com:2222/org/main-repo.git",
 			checkpointRepo: "org/checkpoints",
 			want:           "ssh://git@git.example.com:2222/org/checkpoints.git",
+		},
+		{
+			name:           "entire push remote keeps cluster and forge",
+			pushRemoteURL:  "entire://aws-ap-southeast-2.entire.io/gh/org/main-repo",
+			checkpointRepo: "org/checkpoints",
+			want:           "entire://aws-ap-southeast-2.entire.io/gh/org/checkpoints",
+		},
+		{
+			name:           "entire push remote with non-standard port",
+			pushRemoteURL:  "entire://cluster.example.com:8443/gh/org/main-repo",
+			checkpointRepo: "org/checkpoints",
+			want:           "entire://cluster.example.com:8443/gh/org/checkpoints",
+		},
+		{
+			name:           "entire push remote with forge not matching provider",
+			pushRemoteURL:  "entire://aws-ap-southeast-2.entire.io/et/org/main-repo",
+			checkpointRepo: "org/checkpoints",
+			wantDeriveErr:  true,
 		},
 		{
 			name:          "invalid push remote",

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -337,6 +337,88 @@ func TestResolvePushSettings_ForkDetection(t *testing.T) {
 }
 
 // Not parallel: uses t.Chdir()
+//
+// When origin is an entire:// push-through mirror whose forge (gh) matches the
+// configured checkpoint provider (github), checkpoints route through the same
+// cluster mirror instead of falling back to a direct github.com URL.
+func TestResolvePushSettings_WithCheckpointRemote_EntireMirror(t *testing.T) {
+	ctx := context.Background()
+
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+
+	// Origin is an entire:// mirror on cluster app.entire.io for forge gh.
+	cmd := exec.CommandContext(ctx, "git", "remote", "add", "origin", "entire://app.entire.io/gh/org/main-repo")
+	cmd.Dir = localDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	require.NoError(t, cmd.Run())
+
+	entireDir := filepath.Join(localDir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(entireDir, "settings.json"),
+		[]byte(`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`),
+		0o644,
+	))
+
+	// Seed the local v1 metadata branch so resolvePushSettings finds it and
+	// skips fetchMetadataBranchIfMissing — which would otherwise invoke the
+	// entire:// remote helper against a live cluster.
+	runCheckpointRemoteGit(ctx, t, localDir, "branch", paths.MetadataBranchName)
+
+	t.Chdir(localDir)
+
+	ps := resolvePushSettings(ctx, "origin")
+	assert.True(t, ps.hasCheckpointURL())
+	// Keeps the cluster host and forge segment, swaps in the checkpoint repo.
+	assert.Equal(t, "entire://app.entire.io/gh/org/checkpoints", ps.pushTarget())
+	assert.False(t, ps.pushDisabled)
+}
+
+// Not parallel: uses t.Chdir()
+//
+// When origin is an entire:// mirror of a different forge (et) than the
+// configured checkpoint provider (github), it must not route through the
+// mirror; it falls back to the provider's canonical host.
+func TestResolvePushSettings_EntireMirrorForgeMismatchFallsBackToProvider(t *testing.T) {
+	ctx := context.Background()
+
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+
+	cmd := exec.CommandContext(ctx, "git", "remote", "add", "origin", "entire://app.entire.io/et/org/main-repo")
+	cmd.Dir = localDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	require.NoError(t, cmd.Run())
+
+	entireDir := filepath.Join(localDir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(entireDir, "settings.json"),
+		[]byte(`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`),
+		0o644,
+	))
+
+	// Seed the local v1 branch so the provider-host fallback URL isn't fetched
+	// from github.com for real.
+	runCheckpointRemoteGit(ctx, t, localDir, "branch", paths.MetadataBranchName)
+
+	t.Chdir(localDir)
+
+	ps := resolvePushSettings(ctx, "origin")
+	assert.True(t, ps.hasCheckpointURL())
+	// Provider host over SSH (default transport), not the non-matching mirror.
+	assert.Equal(t, "git@github.com:org/checkpoints.git", ps.pushTarget())
+	assert.False(t, ps.pushDisabled)
+}
+
+// Not parallel: uses t.Chdir()
 func TestResolvePushSettings_CheckpointURLDoesNotAffectRemoteField(t *testing.T) {
 	ctx := context.Background()
 

--- a/docs/testing/git-remote-test-plan.md
+++ b/docs/testing/git-remote-test-plan.md
@@ -30,7 +30,7 @@ Scope: e2e (`e2e/tests/`) + integration (`cmd/entire/cli/integration_test/`) cov
 
 - **Destructive local-v1-ref moves** — the single most re-broken area: #953, `96034892c`, #1252, #1251, #1260 (ahead/behind/diverged/disconnected/shallow × resume/explain/doctor/pre-push).
 - **Cross-clone replay fidelity**: no-op commit tree clobber (`743c43f4c` — *no test*), >1000-commit replay cap (`4cf01edb3` — *no test*), stale ls-remote hash TOCTOU (`1e8628ade` — *no test*), double-replay (#1260 has a test).
-- **Remote-target precedence**: hardcoded-origin blob fetch (#976), `entire://`/`file://` non-derivable origin (#1279), token SSH→HTTPS coercion on fetch missing (`7afdaa33e`), silent origin fallback faking success (`53bc37a88`).
+- **Remote-target precedence**: hardcoded-origin blob fetch (#976), `entire://`/`file://` non-derivable origin (#1279 — since superseded: a forge-matching `entire://` origin now derives a mirror checkpoint URL on the same cluster; the provider-host fallback remains for `file://` and forge-mismatched mirrors), token SSH→HTTPS coercion on fetch missing (`7afdaa33e`), silent origin fallback faking success (`53bc37a88`).
 - **Errors masked as not-found**: partial-clone `ErrFileNotFound` (#1069), git-refs read paths (`7bbdad09c`).
 - **Self-inflicted shallow grafts** (#1443), promisor config pollution of `[remote "origin"]` (#934), gc pack race (#1276).
 - **Hook/transport hangs**: grandchild helper holding pipes (#1282), timeout stacking (`2e2c1b73a`), protected-ref GH013 silence (#1033).
@@ -127,7 +127,7 @@ Systematize the ahead/behind/diverged/disconnected × operation matrix that item
 | F3 | 401→token-retry over HTTPS for git-refs batch push (v1 version exists: `TestHTTPS_PushFailsWithoutToken`) | integration (HTTPS) | gr |
 | F4 | Checkpoint policy sync in the git-refs pre-push path (regression `7bbdad09c` — policy check was skipped): blocked policy skips checkpoint refs but not the user push | integration | gr |
 | F5 | Detached HEAD: session + checkpoint while detached; `git push origin HEAD:branch`; resume from detached clone (today detach is only setup plumbing) | integration | both |
-| F6 | `entire://` origin with checkpoint_remote configured → provider-host routing, not a push at the helper (regression #1279) — currently unit-only; needs a fake provider mapping or injectable host table | integration | gb |
+| F6 | `entire://` origin with checkpoint_remote configured → checkpoints follow the mirror on the same cluster when the forge matches the provider; provider-host routing only for forge-mismatched mirrors and `file://` (supersedes the #1279 behavior) — currently unit-only; needs a fake provider mapping or injectable host table | integration | gb |
 
 ### G. E2E additions (real agents optional, vogon default) — P1
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/838
<!-- entire-trail-link-end -->

## Why

With origin on an `entire://` mirror, checkpoint pushes still went to `git@github.com:entireio/cli-checkpoints.git` over SSH: the resolver could only emit SSH/HTTPS URLs, so an `entire://` origin fell into the provider-host fallback (github.com, defaulting to SSH).

## What

- `deriveCheckpointURLFromInfo` learns the `entire` protocol: keep the cluster host and forge, swap in the checkpoint repo — `entire://<cluster>/gh/<owner>/<checkpoint-repo>`. So checkpoints follow origin through the push-through mirror; no settings change needed.
- Guarded: the forge must map to the configured provider (`gh` ↔ github). Forge-mismatched mirrors and `file://` keep the provider-host fallback; fork-owner detection unchanged.
- `ENTIRE_CHECKPOINT_TOKEN` still forces provider HTTPS (the token is an HTTPS credential and can't ride through the helper).

Users on SSH/HTTPS origins are unaffected.

## Verification

See PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 855b8cdab64147eb73fa6ac805ded1a9391a92ac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->