### PR TITLE
Exclude URL-keyed promisor entries from git fetch --all

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -95,7 +95,14 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 		return out, fmt.Errorf("git fetch: %w", err)
 	}
 	if filtered && IsURL(opts.Remote) {
-		markPromisorEntrySkipped(ctx, opts.Dir, opts.Remote)
+		// Stamp the URL git actually fetched from: with a checkpoint token set,
+		// newCommand rewrites SSH targets to HTTPS, and git records the
+		// promisor entry under the rewritten URL.
+		target := opts.Remote
+		if token := strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)); token != "" && isValidToken(token) {
+			target, _ = resolveTargetForTokenAuth(ctx, target)
+		}
+		markPromisorEntrySkipped(ctx, opts.Dir, target)
 	}
 	return out, nil
 }
@@ -113,19 +120,26 @@ func markPromisorEntrySkipped(ctx context.Context, dir, url string) {
 		// config section that wouldn't otherwise exist.
 		return
 	}
-	if gitConfigBool(ctx, dir, "remote."+url+".skipFetchAll") {
-		return
-	}
 	for _, key := range []string{"skipFetchAll", "skipDefaultUpdate"} {
-		cmd := exec.CommandContext(ctx, "git", "config", "--local", "remote."+url+"."+key, "true")
+		fullKey := "remote." + url + "." + key
+		if gitConfigBool(ctx, dir, fullKey) {
+			// Checked per key so a partially-stamped entry (e.g. an earlier
+			// run failing between the two writes) still gets completed.
+			continue
+		}
+		cmd := exec.CommandContext(ctx, "git", "config", "--local", fullKey, "true")
 		if dir != "" {
 			cmd.Dir = dir
 		}
 		if out, cfgErr := cmd.CombinedOutput(); cfgErr != nil {
+			redactedURL := RedactURL(url)
+			// The output can echo the key, which embeds the URL — and a URL
+			// can carry credentials. Redact before logging.
+			msg := strings.TrimSpace(strings.ReplaceAll(string(out), url, redactedURL))
 			logging.Warn(ctx, "failed to mark promisor config entry as skipped for bulk fetches",
-				slog.String("url", RedactURL(url)),
+				slog.String("url", redactedURL),
 				slog.String("key", key),
-				slog.String("output", strings.TrimSpace(string(out))),
+				slog.String("output", msg),
 				slog.String("error", cfgErr.Error()),
 			)
 			return

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
@@ -76,7 +78,8 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	case opts.Unshallow && isShallowRepository(ctx, opts.Dir):
 		args = append(args, "--unshallow")
 	}
-	if !opts.NoFilter && settings.IsFilteredFetchesEnabled(ctx) {
+	filtered := !opts.NoFilter && settings.IsFilteredFetchesEnabled(ctx)
+	if filtered {
 		args = append(args, "--filter=blob:none")
 	}
 	args = append(args, opts.Remote)
@@ -91,7 +94,57 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	if err != nil {
 		return out, fmt.Errorf("git fetch: %w", err)
 	}
+	if filtered && IsURL(opts.Remote) {
+		markPromisorEntrySkipped(ctx, opts.Dir, opts.Remote)
+	}
 	return out, nil
+}
+
+// markPromisorEntrySkipped excludes the URL-keyed config section that git
+// creates for a filtered URL fetch (remote.<url>.promisor=true) from
+// `git fetch --all` and `git remote update`. Git needs the promisor entry to
+// lazy-fetch filtered-out objects later, but the entry also makes the URL show
+// up as a fetchable remote, so without this every checkpoint URL ever fetched
+// from lingers as a phantom remote that bulk fetches keep dialing.
+// Best-effort: the fetch already succeeded, so failures only log.
+func markPromisorEntrySkipped(ctx context.Context, dir, url string) {
+	if !gitConfigBool(ctx, dir, "remote."+url+".promisor") {
+		// Git didn't record a promisor entry for this URL; don't invent a
+		// config section that wouldn't otherwise exist.
+		return
+	}
+	if gitConfigBool(ctx, dir, "remote."+url+".skipFetchAll") {
+		return
+	}
+	for _, key := range []string{"skipFetchAll", "skipDefaultUpdate"} {
+		cmd := exec.CommandContext(ctx, "git", "config", "--local", "remote."+url+"."+key, "true")
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		if out, cfgErr := cmd.CombinedOutput(); cfgErr != nil {
+			logging.Warn(ctx, "failed to mark promisor config entry as skipped for bulk fetches",
+				slog.String("url", RedactURL(url)),
+				slog.String("key", key),
+				slog.String("output", strings.TrimSpace(string(out))),
+				slog.String("error", cfgErr.Error()),
+			)
+			return
+		}
+	}
+}
+
+// gitConfigBool reads a local git config key and reports whether it is set to
+// a true value. Missing keys and read errors report false.
+func gitConfigBool(ctx context.Context, dir, key string) bool {
+	cmd := exec.CommandContext(ctx, "git", "config", "--local", "--get", "--type=bool", key)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
 }
 
 // FetchBlobs fetches specific objects (typically blobs) by hash from a remote.

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -903,3 +903,24 @@ func TestFetch_UnfilteredFetchDoesNotCreateConfigSection(t *testing.T) {
 	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipFetchAll"))
 	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipDefaultUpdate"))
 }
+
+// TestMarkPromisorEntrySkipped_CompletesPartialStamp verifies the keys are
+// checked independently: an entry with skipFetchAll already set (e.g. an
+// earlier run failing between the two writes) still gets skipDefaultUpdate.
+func TestMarkPromisorEntrySkipped_CompletesPartialStamp(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+
+	const url = "https://example.com/org/checkpoints.git"
+	runIsolatedGit(ctx, t, repoDir, "config", "--local", "remote."+url+".promisor", "true")
+	runIsolatedGit(ctx, t, repoDir, "config", "--local", "remote."+url+".skipFetchAll", "true")
+
+	markPromisorEntrySkipped(ctx, repoDir, url)
+
+	assert.True(t, gitConfigBool(ctx, repoDir, "remote."+url+".skipFetchAll"))
+	assert.True(t, gitConfigBool(ctx, repoDir, "remote."+url+".skipDefaultUpdate"),
+		"partially-stamped entry should be completed")
+}

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -791,3 +791,115 @@ func envToMap(env []string) map[string]string {
 	}
 	return m
 }
+
+// TestFetch_FilteredURLFetchMarksPromisorSkipped verifies that after a
+// filtered fetch from a URL, the URL-keyed promisor config section git creates
+// is excluded from `git fetch --all` / `git remote update` — otherwise every
+// checkpoint URL ever fetched from lingers as a phantom remote that bulk
+// fetches keep dialing.
+func TestFetch_FilteredURLFetchMarksPromisorSkipped(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	originBare := filepath.Join(tmpDir, "origin.git")
+	checkpointBare := filepath.Join(tmpDir, "checkpoints.git")
+	seedDir := filepath.Join(tmpDir, "seed")
+	cloneDir := filepath.Join(tmpDir, "clone")
+
+	testutil.InitRepo(t, seedDir)
+	testutil.WriteFile(t, seedDir, "f.txt", "init")
+	testutil.GitAdd(t, seedDir, "f.txt")
+	testutil.GitCommit(t, seedDir, "init")
+
+	// Separate origin and checkpoint repos, mirroring the real setup where
+	// checkpoints are fetched by URL from a repo that is not origin.
+	runIsolatedGit(ctx, t, "", "init", "--bare", originBare)
+	runIsolatedGit(ctx, t, "", "init", "--bare", checkpointBare)
+	runIsolatedGit(ctx, t, checkpointBare, "config", "uploadpack.allowFilter", "true")
+	runIsolatedGit(ctx, t, seedDir, "push", originBare, "HEAD:refs/heads/main")
+	runIsolatedGit(ctx, t, "", "clone", "--branch", "main", "file://"+originBare, cloneDir)
+
+	// A commit only in the checkpoint repo so the filtered fetch has
+	// something to transfer.
+	testutil.WriteFile(t, seedDir, "f.txt", "init\nnext\n")
+	testutil.GitAdd(t, seedDir, "f.txt")
+	testutil.GitCommit(t, seedDir, "next")
+	runIsolatedGit(ctx, t, seedDir, "push", checkpointBare, "HEAD:refs/heads/main")
+
+	// Filtered fetches read .entire settings from the CWD repo.
+	testutil.WriteFile(
+		t,
+		cloneDir,
+		".entire/settings.json",
+		`{"enabled": true, "strategy_options": {"filtered_fetches": true}}`,
+	)
+	t.Chdir(cloneDir)
+
+	fetchURL := "file://" + checkpointBare
+	out, err := Fetch(ctx, FetchOptions{
+		Remote:   fetchURL,
+		RefSpecs: []string{"+refs/heads/main:refs/entire-fetch-tmp/main"},
+		NoTags:   true,
+		Dir:      cloneDir,
+	})
+	require.NoError(t, err, "fetch output: %s", out)
+
+	// Sanity: git recorded the URL-keyed promisor entry for the filtered fetch.
+	require.True(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".promisor"),
+		"expected git to record a promisor entry for the filtered URL fetch")
+
+	assert.True(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipFetchAll"),
+		"URL-keyed promisor entry should be excluded from git fetch --all")
+	assert.True(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipDefaultUpdate"),
+		"URL-keyed promisor entry should be excluded from git remote update")
+
+	// git fetch --all must no longer dial the phantom entry: with the
+	// checkpoint repo gone, --all only succeeds if the URL-keyed entry is
+	// skipped (origin is still reachable).
+	require.NoError(t, os.RemoveAll(checkpointBare))
+	runIsolatedGit(ctx, t, cloneDir, "fetch", "--all", "--no-auto-gc")
+}
+
+// TestFetch_UnfilteredFetchDoesNotCreateConfigSection verifies the stamp is
+// gated on git having created a promisor entry: a plain (unfiltered) URL fetch
+// must not invent a remote.<url> config section.
+func TestFetch_UnfilteredFetchDoesNotCreateConfigSection(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	bareDir := filepath.Join(tmpDir, "bare.git")
+	seedDir := filepath.Join(tmpDir, "seed")
+	cloneDir := filepath.Join(tmpDir, "clone")
+
+	testutil.InitRepo(t, seedDir)
+	testutil.WriteFile(t, seedDir, "f.txt", "init")
+	testutil.GitAdd(t, seedDir, "f.txt")
+	testutil.GitCommit(t, seedDir, "init")
+
+	runIsolatedGit(ctx, t, "", "init", "--bare", bareDir)
+	runIsolatedGit(ctx, t, seedDir, "remote", "add", "origin", bareDir)
+	runIsolatedGit(ctx, t, seedDir, "push", "origin", "HEAD:refs/heads/main")
+	runIsolatedGit(ctx, t, "", "clone", "--branch", "main", "file://"+bareDir, cloneDir)
+
+	testutil.WriteFile(
+		t,
+		cloneDir,
+		".entire/settings.json",
+		`{"enabled": true, "strategy_options": {"filtered_fetches": true}}`,
+	)
+	t.Chdir(cloneDir)
+
+	fetchURL := "file://" + bareDir
+	out, err := Fetch(ctx, FetchOptions{
+		Remote:   fetchURL,
+		RefSpecs: []string{"+refs/heads/main:refs/remotes/origin/main"},
+		NoTags:   true,
+		NoFilter: true,
+		Dir:      cloneDir,
+	})
+	require.NoError(t, err, "fetch output: %s", out)
+
+	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".promisor"))
+	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipFetchAll"))
+	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipDefaultUpdate"))
+}

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -313,15 +313,22 @@ func (env *TestEnv) gitConfigPath() string {
 var gitConfigGuardRepositoryFormatVersionRE = regexp.MustCompile(`(?m)^([ \t]*)repositoryformatversion = [01]$`)
 
 var gitConfigGuardTransportPromisorRemoteRE = regexp.MustCompile(
-	`(?m)^\[remote "(?:(?:https?|ssh|file)://|/|[A-Za-z]:[\\/]|[^"\n]+@[^"\n]+:[^"\n]+).+"\]\n(?:[ \t]+promisor = true\n[ \t]+partialclonefilter = blob:none\n?|[ \t]+partialclonefilter = blob:none\n[ \t]+promisor = true\n?)`,
+	`(?m)^\[remote "(?:(?:https?|ssh|file)://|/|[A-Za-z]:[\\/]|[^"\n]+@[^"\n]+:[^"\n]+).+"\]\n(?:[ \t]+(?:promisor = true|partialclonefilter = blob:none|skipFetchAll = true|skipDefaultUpdate = true)\n?){2,4}`,
 )
 
 func normalizeGitConfigForGuard(content string) string {
 	content = gitConfigGuardRepositoryFormatVersionRE.ReplaceAllString(content, `${1}repositoryformatversion = <normalized>`)
-	// Deliberately ignore only the full promisor+partialclonefilter pair that
-	// git writes for transport-keyed remotes during filtered fetches. If git ever
-	// writes a partial section, the guard should still fail loudly.
-	content = gitConfigGuardTransportPromisorRemoteRE.ReplaceAllString(content, "")
+	// Deliberately ignore only the URL-keyed remote sections written during
+	// filtered fetches: git's promisor+partialclonefilter pair plus the
+	// skipFetchAll/skipDefaultUpdate stamp the CLI adds so bulk fetches skip
+	// the entry. A section without the full promisor pair (or with any other
+	// key) still fails loudly.
+	content = gitConfigGuardTransportPromisorRemoteRE.ReplaceAllStringFunc(content, func(section string) string {
+		if strings.Contains(section, "promisor = true") && strings.Contains(section, "partialclonefilter = blob:none") {
+			return ""
+		}
+		return section
+	})
 	return content
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/839
<!-- entire-trail-link-end -->

## Why

Filtered checkpoint fetches deliberately target URLs (not `origin`) so promisor settings don't land on named remotes. Side effect: git records a `remote.<url>` promisor section per URL, and treats each as a fetchable remote — so `git fetch --all` / `git remote update` dial every checkpoint URL ever fetched from, including dead mirror hosts and SSH github URLs (Secretive/agent prompts).

## What

After a successful filtered URL fetch, stamp `skipFetchAll` + `skipDefaultUpdate` on the URL-keyed section. Bulk fetches skip it; lazy object fetches still use it. Gated on git having actually written the promisor entry, so unfiltered fetches don't invent config sections.

Existing stale entries aren't migrated — they get stamped the next time that URL is fetched from; never-again-fetched ones (e.g. dead hosts) can be removed manually with `git config --remove-section 'remote.<url>'`.

## Verification

See PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local git config is updated post-fetch in a gated, best-effort path; behavior is covered by unit and integration tests with no auth or data-model changes.
> 
> **Overview**
> Filtered checkpoint fetches against URLs leave git `remote.<url>` promisor sections that **`git fetch --all`** and **`git remote update`** treat as extra remotes. This change **stamps** `skipFetchAll` and `skipDefaultUpdate` on those sections **after a successful filtered URL fetch**, so bulk updates skip them while lazy promisor fetches still work.
> 
> Stamping runs only when git already set `remote.<url>.promisor` (unfiltered fetches do not get new config). The URL used matches what git recorded, including SSH→HTTPS rewrites when `ENTIRE_CHECKPOINT_TOKEN` is set. Config writes are best-effort with redacted warnings on failure. Integration **`.git/config` guard** normalization now ignores the CLI skip keys alongside git’s promisor pair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fbe9c645a6f22526671e1c4781c5f26a968945c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->