### PR TITLE
Fix Windows Cursor hooks + Scoop app-dir naming (#1424)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,7 +100,14 @@ release:
   prerelease: auto
 
 scoops:
-  - repository:
+  # Name the manifest (and therefore the Scoop app directory) "entire". Without
+  # this, goreleaser defaults the manifest name to the project name, which
+  # resolves to the repo name ("cli"), so `scoop install` lands the binary in
+  # …\scoop\apps\cli\current\entire.exe. That mismatched app-dir name is
+  # surprising ("scoop install cli"?) and fed the Windows hook-path bug in
+  # https://github.com/entireio/cli/issues/1424.
+  - name: entire
+    repository:
       owner: entireio
       name: scoop-bucket
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"

--- a/cmd/entire/cli/agent/cursor/hooks.go
+++ b/cmd/entire/cli/agent/cursor/hooks.go
@@ -130,13 +130,21 @@ func (c *CursorAgent) InstallHooks(ctx context.Context, localDev bool, force boo
 	subagentStartCmd := cmdPrefix + HookNameSubagentStart
 	subagentEndCmd := cmdPrefix + HookNameSubagentStop
 	if !localDev {
-		sessionStartCmd = agent.WrapProductionSilentHookCommand(sessionStartCmd)
-		sessionEndCmd = agent.WrapProductionSilentHookCommand(sessionEndCmd)
-		beforeSubmitPromptCmd = agent.WrapProductionSilentHookCommand(beforeSubmitPromptCmd)
-		stopCmd = agent.WrapProductionSilentHookCommand(stopCmd)
-		preCompactCmd = agent.WrapProductionSilentHookCommand(preCompactCmd)
-		subagentStartCmd = agent.WrapProductionSilentHookCommand(subagentStartCmd)
-		subagentEndCmd = agent.WrapProductionSilentHookCommand(subagentEndCmd)
+		// Cursor spawns hook commands through the native OS shell (cmd.exe on
+		// Windows), so a `sh -c '…'` wrapper silently fails to launch on a
+		// Windows host without a working POSIX sh — no hook fires and, because
+		// this is the *silent* wrapper, no error surfaces (issue #1424).
+		// UseWindowsProductionHooks probes for a runnable sh and only swaps in
+		// the native cmd.exe wrapper when one is absent, so this is a no-op on
+		// hosts (incl. all non-Windows) where the sh wrapper already works.
+		useWindowsHooks := agent.UseWindowsProductionHooks(ctx, localDev)
+		sessionStartCmd = agent.WrapProductionSilentHookCommandForOS(sessionStartCmd, useWindowsHooks)
+		sessionEndCmd = agent.WrapProductionSilentHookCommandForOS(sessionEndCmd, useWindowsHooks)
+		beforeSubmitPromptCmd = agent.WrapProductionSilentHookCommandForOS(beforeSubmitPromptCmd, useWindowsHooks)
+		stopCmd = agent.WrapProductionSilentHookCommandForOS(stopCmd, useWindowsHooks)
+		preCompactCmd = agent.WrapProductionSilentHookCommandForOS(preCompactCmd, useWindowsHooks)
+		subagentStartCmd = agent.WrapProductionSilentHookCommandForOS(subagentStartCmd, useWindowsHooks)
+		subagentEndCmd = agent.WrapProductionSilentHookCommandForOS(subagentEndCmd, useWindowsHooks)
 	}
 
 	count := 0

--- a/cmd/entire/cli/agent/cursor/hooks.go
+++ b/cmd/entire/cli/agent/cursor/hooks.go
@@ -149,35 +149,19 @@ func (c *CursorAgent) InstallHooks(ctx context.Context, localDev bool, force boo
 
 	count := 0
 
-	// Add hooks if they don't exist
-	if !hookCommandExists(sessionStart, sessionStartCmd) {
-		sessionStart = append(sessionStart, CursorHookEntry{Command: sessionStartCmd})
-		count++
-	}
-	if !hookCommandExists(sessionEnd, sessionEndCmd) {
-		sessionEnd = append(sessionEnd, CursorHookEntry{Command: sessionEndCmd})
-		count++
-	}
-	if !hookCommandExists(beforeSubmitPrompt, beforeSubmitPromptCmd) {
-		beforeSubmitPrompt = append(beforeSubmitPrompt, CursorHookEntry{Command: beforeSubmitPromptCmd})
-		count++
-	}
-	if !hookCommandExists(stop, stopCmd) {
-		stop = append(stop, CursorHookEntry{Command: stopCmd})
-		count++
-	}
-	if !hookCommandExists(preCompact, preCompactCmd) {
-		preCompact = append(preCompact, CursorHookEntry{Command: preCompactCmd})
-		count++
-	}
-	if !hookCommandExists(subagentStart, subagentStartCmd) {
-		subagentStart = append(subagentStart, CursorHookEntry{Command: subagentStartCmd})
-		count++
-	}
-	if !hookCommandExists(subagentStop, subagentEndCmd) {
-		subagentStop = append(subagentStop, CursorHookEntry{Command: subagentEndCmd})
-		count++
-	}
+	// Sync each hook to its desired command. syncEntireHook replaces any
+	// stale-form Entire hook (e.g. an sh-wrapped entry from a previous install)
+	// with the current command even without --force, so a wrapper-form change —
+	// notably the sh↔cmd.exe migration driven by UseWindowsProductionHooks when
+	// a Windows host gains or loses a working POSIX sh — cleanly replaces rather
+	// than leaving a dead duplicate entry that could double-fire (issue #1424).
+	sessionStart, count = syncEntireHook(sessionStart, sessionStartCmd, count)
+	sessionEnd, count = syncEntireHook(sessionEnd, sessionEndCmd, count)
+	beforeSubmitPrompt, count = syncEntireHook(beforeSubmitPrompt, beforeSubmitPromptCmd, count)
+	stop, count = syncEntireHook(stop, stopCmd, count)
+	preCompact, count = syncEntireHook(preCompact, preCompactCmd, count)
+	subagentStart, count = syncEntireHook(subagentStart, subagentStartCmd, count)
+	subagentStop, count = syncEntireHook(subagentStop, subagentEndCmd, count)
 
 	if count == 0 {
 		return 0, nil
@@ -358,6 +342,21 @@ func marshalCursorHookType(rawHooks map[string]json.RawMessage, hookType string,
 }
 
 // Helper functions for hook management
+
+// syncEntireHook ensures entries contains exactly the given Entire hook command
+// for this hook type. If command is already present it is a no-op. Otherwise any
+// existing Entire hook (in any wrapper form) is removed before appending command,
+// so a changed wrapper form replaces the stale one rather than duplicating it.
+// Non-Entire entries are preserved. count is incremented when a change is made.
+func syncEntireHook(entries []CursorHookEntry, command string, count int) ([]CursorHookEntry, int) {
+	if hookCommandExists(entries, command) {
+		return entries, count
+	}
+	if hasEntireHook(entries) {
+		entries = removeEntireHooks(entries)
+	}
+	return append(entries, CursorHookEntry{Command: command}), count + 1
+}
 
 func hookCommandExists(entries []CursorHookEntry, command string) bool {
 	for _, entry := range entries {

--- a/cmd/entire/cli/agent/cursor/hooks_test.go
+++ b/cmd/entire/cli/agent/cursor/hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -104,6 +105,52 @@ func TestInstallHooks_WindowsProbeFailureUsesCmdWrappers(t *testing.T) {
 	assertEntryCommand(t, hooksFile.Hooks.SessionStart, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor session-start"))
 	assertEntryCommand(t, hooksFile.Hooks.Stop, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor stop"))
 	assertEntryCommand(t, hooksFile.Hooks.SubagentStop, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor subagent-stop"))
+}
+
+// TestInstallHooks_WindowsProbeFlipMigratesCleanly verifies that when a host's
+// sh availability changes between installs, a non-force reinstall REPLACES the
+// stale sh-wrapped hooks with cmd.exe ones rather than leaving both (which would
+// double-fire). Mirrors the codex migration test. Mutates the shared probe, so
+// no t.Parallel().
+func TestInstallHooks_WindowsProbeFlipMigratesCleanly(t *testing.T) {
+	shWorks := true
+	t.Cleanup(agent.SetWindowsHookProbeForTesting("windows", func(context.Context, string) bool {
+		return shWorks
+	}))
+
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+	ag := &CursorAgent{}
+
+	// First install with a working sh → sh-based wrappers.
+	if _, err := ag.InstallHooks(context.Background(), false, false); err != nil {
+		t.Fatalf("first InstallHooks() error = %v", err)
+	}
+
+	// sh stops working; reinstall WITHOUT force.
+	shWorks = false
+	if _, err := ag.InstallHooks(context.Background(), false, false); err != nil {
+		t.Fatalf("second InstallHooks() error = %v", err)
+	}
+
+	hooksFile := readHooksFile(t, tempDir)
+	// Exactly one entry per type — the stale sh entry must be gone, not duplicated.
+	if len(hooksFile.Hooks.Stop) != 1 {
+		t.Errorf("Stop hooks = %d after wrapper migration, want 1 (no duplicate)", len(hooksFile.Hooks.Stop))
+	}
+	if len(hooksFile.Hooks.SessionStart) != 1 {
+		t.Errorf("SessionStart hooks = %d after wrapper migration, want 1 (no duplicate)", len(hooksFile.Hooks.SessionStart))
+	}
+	assertEntryCommand(t, hooksFile.Hooks.Stop, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor stop"))
+
+	// No sh-based Entire wrapper may survive the migration.
+	data, err := os.ReadFile(filepath.Join(tempDir, ".cursor", HooksFileName))
+	if err != nil {
+		t.Fatalf("failed to read hooks file: %v", err)
+	}
+	if strings.Contains(string(data), "sh -c") || strings.Contains(string(data), "command -v entire") {
+		t.Errorf("stale sh-based wrapper survived migration:\n%s", data)
+	}
 }
 
 func TestInstallHooks_Idempotent(t *testing.T) {

--- a/cmd/entire/cli/agent/cursor/hooks_test.go
+++ b/cmd/entire/cli/agent/cursor/hooks_test.go
@@ -63,6 +63,49 @@ func TestInstallHooks_FreshInstall(t *testing.T) {
 	assertEntryCommand(t, hooksFile.Hooks.SubagentStop, agent.WrapProductionSilentHookCommand("entire hooks cursor subagent-stop"))
 }
 
+// TestInstallHooks_WindowsProbeSuccessKeepsShWrappers verifies that on a
+// Windows host where a POSIX sh is runnable, Cursor keeps the sh-based wrappers
+// (parity with non-Windows). Mutates the shared probe, so no t.Parallel().
+func TestInstallHooks_WindowsProbeSuccessKeepsShWrappers(t *testing.T) {
+	t.Cleanup(agent.SetWindowsHookProbeForTesting("windows", func(context.Context, string) bool {
+		return true // sh works
+	}))
+
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &CursorAgent{}
+	if _, err := ag.InstallHooks(context.Background(), false, false); err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+
+	hooksFile := readHooksFile(t, tempDir)
+	assertEntryCommand(t, hooksFile.Hooks.SessionStart, agent.WrapProductionSilentHookCommand("entire hooks cursor session-start"))
+	assertEntryCommand(t, hooksFile.Hooks.Stop, agent.WrapProductionSilentHookCommand("entire hooks cursor stop"))
+}
+
+// TestInstallHooks_WindowsProbeFailureUsesCmdWrappers verifies that on a Windows
+// host with no runnable POSIX sh, Cursor installs the native cmd.exe wrappers so
+// hooks actually fire (issue #1424). Mutates the shared probe, so no t.Parallel().
+func TestInstallHooks_WindowsProbeFailureUsesCmdWrappers(t *testing.T) {
+	t.Cleanup(agent.SetWindowsHookProbeForTesting("windows", func(context.Context, string) bool {
+		return false // no working sh
+	}))
+
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &CursorAgent{}
+	if _, err := ag.InstallHooks(context.Background(), false, false); err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+
+	hooksFile := readHooksFile(t, tempDir)
+	assertEntryCommand(t, hooksFile.Hooks.SessionStart, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor session-start"))
+	assertEntryCommand(t, hooksFile.Hooks.Stop, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor stop"))
+	assertEntryCommand(t, hooksFile.Hooks.SubagentStop, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor subagent-stop"))
+}
+
 func TestInstallHooks_Idempotent(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Chdir(tempDir)

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -461,13 +462,34 @@ func hookCmdPrefix(localDev, absolutePath bool) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("--absolute-git-hook-path: failed to resolve binary path: %w", err)
 		}
-		resolved, err := filepath.EvalSymlinks(exe)
+		resolved, err := resolveHookExePath(exe, filepath.EvalSymlinks, runtime.GOOS)
 		if err != nil {
-			return "", fmt.Errorf("--absolute-git-hook-path: failed to resolve symlinks for %s: %w", exe, err)
+			return "", err
 		}
 		return shellQuote(resolved), nil
 	}
 	return "entire", nil
+}
+
+// resolveHookExePath resolves exe through symlinks for embedding as an absolute
+// path in a git hook. On Windows, filepath.EvalSymlinks can fail when a path
+// component is an NTFS directory junction rather than a plain symlink — notably
+// Scoop's `…\scoop\apps\<app>\current\` junction, which yields "The system
+// cannot find the path specified" (issue #1424). The unresolved os.Executable()
+// path is itself a valid, launchable absolute path (and on Scoop the stable
+// `current\` junction path is actually preferable, since it survives version
+// updates that repoint the junction), so on Windows we fall back to it rather
+// than failing the hook install outright. Off Windows, an EvalSymlinks failure
+// is unexpected and still surfaced as an error.
+func resolveHookExePath(exe string, evalSymlinks func(string) (string, error), goos string) (string, error) {
+	resolved, err := evalSymlinks(exe)
+	if err != nil {
+		if goos == "windows" {
+			return exe, nil
+		}
+		return "", fmt.Errorf("--absolute-git-hook-path: failed to resolve symlinks for %s: %w", exe, err)
+	}
+	return resolved, nil
 }
 
 // shellQuote wraps a string in single quotes for safe use in #!/bin/sh scripts.

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1698,4 +1699,56 @@ func TestRemoveGitHook_PermissionDenied(t *testing.T) {
 	if !strings.Contains(err.Error(), "failed to remove hooks") {
 		t.Errorf("error should mention 'failed to remove hooks', got: %v", err)
 	}
+}
+
+// TestResolveHookExePath covers the absolute-git-hook-path symlink resolution,
+// including the Windows fallback for NTFS junctions that EvalSymlinks cannot
+// resolve (e.g. Scoop's `…\current\` junction — issue #1424). GOOS and the
+// symlink resolver are injected so every branch runs on any host.
+func TestResolveHookExePath(t *testing.T) {
+	t.Parallel()
+
+	const exe = `C:\Users\admin\scoop\apps\cli\current\entire.exe`
+	// Stand-in for the Windows junction error ("The system cannot find the path
+	// specified") that filepath.EvalSymlinks returns on Scoop's `current\`.
+	junctionErr := errors.New("cannot find the path specified")
+
+	t.Run("resolves normally when EvalSymlinks succeeds", func(t *testing.T) {
+		t.Parallel()
+		got, err := resolveHookExePath("/tmp/linkto", func(string) (string, error) {
+			return "/opt/entire/entire", nil
+		}, "linux")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/opt/entire/entire" {
+			t.Errorf("got %q, want resolved target", got)
+		}
+	})
+
+	t.Run("windows falls back to unresolved path on EvalSymlinks failure", func(t *testing.T) {
+		t.Parallel()
+		got, err := resolveHookExePath(exe, func(string) (string, error) {
+			return "", junctionErr
+		}, "windows")
+		if err != nil {
+			t.Fatalf("windows should fall back, got error: %v", err)
+		}
+		if got != exe {
+			t.Errorf("got %q, want unresolved exe %q", got, exe)
+		}
+	})
+
+	t.Run("non-windows surfaces EvalSymlinks failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := resolveHookExePath("/usr/local/bin/entire", func(string) (string, error) {
+			return "", junctionErr
+		}, "linux")
+		if err == nil {
+			t.Fatal("expected error on non-windows EvalSymlinks failure")
+		}
+		if !strings.Contains(err.Error(), "failed to resolve symlinks") {
+			t.Errorf("error should mention symlink resolution, got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
[https://entire.io/gh/entireio/cli/trails/841](<https://entire.io/gh/entireio/cli/trails/841>)

Fixes entireio/cli#1424.

## Background

entireio/cli#1424 reports that on Windows 11 (Scoop install, Cursor), Entire records nothing — `session list` / `checkpoint list` stay at 0 even though `entire status` shows enabled and hooks look correctly configured. Investigation found **three independent root causes** stacked together.

## Root causes & fixes

### 1\. Scoop installs the app dir as `cli`, not `entire`

The published bucket manifest is literally `cli.json` (verified live), so the binary lands at `…\scoop\apps\cli\current\entire.exe`. GoReleaser defaults the scoop manifest name to the project name, which resolves to the repo name (`cli`). The `scoops:` block set no `name:`.

**Fix:** set `scoops[].name: entire`.

### 2\. `--absolute-git-hook-path` fails on Scoop's `current\` junction

`hookCmdPrefix` calls `filepath.EvalSymlinks(os.Executable())`, which can't resolve Scoop's `current\` **NTFS directory junction** and returns *"The system cannot find the path specified."* — the exact error in the report. This blocks `entire enable --agent cursor`, `agent add cursor`, and `configure --absolute-git-hook-path`.

**Fix:** on Windows, fall back to the unresolved `os.Executable()` path (extracted into `resolveHookExePath` so all branches are unit-tested cross-platform). That path is valid and, on Scoop, actually **more stable** than the resolved one — `current\` survives version updates that repoint the junction, whereas a resolved versioned path disappears on the next update.

### 3\. Cursor agent hooks silently never fire on Windows (the actual "nothing recorded")

`cursor.InstallHooks` hardcoded the POSIX `sh -c '…'` wrapper. Cursor spawns hook commands via the native OS shell, so on a Windows host with no runnable POSIX `sh` the wrapper fails to launch — and because it's the *silent* wrapper, the failure is swallowed (no hook, no error). The shared OS-aware path (`UseWindowsProductionHooks` + `WrapProductionSilentHookCommandForOS`) already exists and was built explicitly "so the other sh-based agents can adopt the Windows fallback" (commit `1cf8eadc2`) — but only codex had adopted it.

**Fix:** migrate Cursor to the shared path. It's **probe-gated**: a no-op on non-Windows and on Windows hosts where `sh` works; it only swaps in the native `cmd.exe` wrapper when no `sh` is present.

## Scope notes

* The other sh-based agents (gemini, claude-code, factory-droid) still hardcode the sh wrapper and have the same latent bug; **copilot-cli deliberately stays sh-based** because it runs hook commands via a `bash` field (not the native shell), so the cmd.exe wrapper would break it. A blanket migration is unsafe — auditing each agent's execution model is left to a follow-up.
* Windows **Authenticode signing** (Smart App Control) is a separate issue (entireio/cli#1505), not addressed here.
* Existing Scoop users on `cli` won't auto-migrate; they'd `scoop uninstall cli` + `scoop install entire`. The stale `cli.json` in the bucket can be removed separately.

## Tests

* `resolveHookExePath`: resolves normally / Windows falls back on failure / non-Windows surfaces the error (injected GOOS + resolver, runs on any host).
* Cursor: Windows probe-success keeps sh wrappers; probe-failure installs cmd.exe wrappers (via `SetWindowsHookProbeForTesting`).
* `go build ./...`, `golangci-lint` (changed pkgs), and `go test ./cmd/entire/cli/agent/... ./cmd/entire/cli/strategy/...` all pass locally.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)