### PR TITLE
fix: fail closed on unanswered init-repo prompt

### DIFF
--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -345,7 +345,11 @@ func confirmInitRepo(_ io.Writer, cwd string, opts GitHubBootstrapOptions) (bool
 	}
 
 	folder := filepath.Base(cwd)
-	confirmed := true
+	// Fail closed: git init mutates the user's directory, and huh's
+	// accessible mode silently resolves to the default when stdin hits
+	// EOF or a blank line — a default of "yes" turns an unanswered prompt
+	// into consent (e.g. automation with ACCESSIBLE set and piped stdin).
+	confirmed := false
 	form := NewAccessibleForm(
 		huh.NewGroup(
 			huh.NewConfirm().

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -1154,6 +1154,45 @@ func TestResolveRepoName_YesRepoExistsWithTTY_FallsBackToPrompt(t *testing.T) {
 	}
 }
 
+func TestConfirmInitRepo_AccessibleUnansweredPrompt_Declines(t *testing.T) {
+	// Regression: huh's accessible mode resolves the confirm to its default
+	// when stdin hits EOF or a blank line — no abort, no error. With a
+	// default of true, an unanswered prompt silently consented to `git init`
+	// (e.g. automation with ACCESSIBLE set and piped or closed stdin). The
+	// default must fail closed so silence means decline.
+	for name, stdin := range map[string]string{
+		"eof":        "",
+		"blank-line": "\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("ENTIRE_TEST_TTY", "1")
+			// Accessible (text-based) mode reads os.Stdin instead of
+			// opening /dev/tty via bubbletea.
+			t.Setenv("ACCESSIBLE", "1")
+			pr, pw, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { pr.Close() })
+			if stdin != "" {
+				pw.WriteString(stdin) //nolint:errcheck // test helper
+			}
+			pw.Close()
+			oldStdin := os.Stdin
+			os.Stdin = pr
+			t.Cleanup(func() { os.Stdin = oldStdin })
+
+			confirmed, err := confirmInitRepo(io.Discard, t.TempDir(), GitHubBootstrapOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if confirmed {
+				t.Error("unanswered init-repo prompt must decline, got confirmed=true")
+			}
+		})
+	}
+}
+
 func TestRunGitHubBootstrap_YesWithNoGitHub(t *testing.T) {
 	// --yes combined with --no-github should skip GitHub but still init + commit.
 	dir := t.TempDir()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/843
<!-- entire-trail-link-end -->

## What

Flips the `confirmInitRepo` confirm default from `true` to `false`, and adds a regression test. Prompt now renders `[y/N]` instead of `[Y/n]`.

## Why

`entire enable` in a non-git directory could run `git init` without anyone answering the "Initialize one here?" prompt:

- huh's accessible mode (`ACCESSIBLE` set — a supported screen-reader feature) reads `os.Stdin` and **silently resolves the confirm to its default** on EOF or a blank line — no abort, no error (`PromptString` returns the default; `runAccessible` discards field errors).
- `CanPromptInteractively()` can't guard this: it probes `/dev/tty`, a different channel than the stdin the accessible form actually consumes.
- In TUI mode on a PTY owned by automation (tmux/expect/agents not in the sentinel list), the Yes-focused confirm accepted any stray Enter.

With the default at `true`, every "form completed without a real answer" path became consent to mutate the user's directory. Fail closed: silence now means decline.

Reproduced locally (all paths verified): `ENTIRE_TEST_TTY=1 ACCESSIBLE=1 entire enable --agent claude-code --no-github --skip-initial-commit </dev/null` created `.git` with zero input before this change; declines after.

## Out of scope (follow-ups)

- Gate improvement: require stdin be a TTY when `ACCESSIBLE` is set in `CanPromptInteractively()`.
- Accessible multiselect with reject-empty validator busy-loops forever on stdin EOF (agent selection) — separate bug, also reproducible upstream in huh v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow prompt-default change with regression tests; reduces risk of unintended `git init` rather than expanding behavior.
> 
> **Overview**
> **`confirmInitRepo`** now defaults the “Initialize one here?” confirm to **no** instead of yes, so an empty or EOF stdin in huh **accessible** mode (`ACCESSIBLE=1`) no longer silently runs **`git init`**.
> 
> The confirm shows **`[y/N]`** rather than **`[Y/n]`**. Explicit flags (`--init-repo`, `--yes`, `--no-init-repo`) and non-interactive paths are unchanged.
> 
> Adds **`TestConfirmInitRepo_AccessibleUnansweredPrompt_Declines`** for EOF and blank-line stdin under accessible mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aedb49a71cc58384f229ef8523c6f061a7769f7b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->