### PR TITLE
Reuse list-for-push advertisement in remote helper push

### DIFF
--- a/internal/remotehelper/githelper/invariants_test.go
+++ b/internal/remotehelper/githelper/invariants_test.go
@@ -323,12 +323,72 @@ func TestInvariant_HelperStatusSurfacedOnSendPackError(t *testing.T) {
 	stdin := bufio.NewReader(strings.NewReader("\n"))
 
 	var stdout bytes.Buffer
-	err := handlePush(context.Background(), ft, firstLine, &Options{}, stdin, &stdout)
+	err := handlePush(context.Background(), ft, &refAdvCache{}, firstLine, &Options{}, stdin, &stdout)
 	if err == nil {
 		t.Fatal("expected error from send-pack exit 1")
 	}
 	if !strings.Contains(stdout.String(), helperStatusLine) {
 		t.Errorf("stdout missing helper-status line; got %q, want substring %q",
 			stdout.String(), helperStatusLine)
+	}
+}
+
+// TestInvariant_PushReusesListForPushAdvertisement pins the fix for ENCLI-267.
+// Within one helper session the "push" command MUST reuse the ref
+// advertisement fetched during "list for-push" rather than re-fetching
+// info/refs. Git snapshots the remote refs from "list for-push" into its
+// remote_refs list *before* running the pre-push hook, and the hook pushes
+// per-checkpoint refs to the same remote. A fresh info/refs at push time then
+// hands send-pack a ref (the freshly-pushed checkpoint) Git never asked to
+// push; send-pack emits `error <ref> no match`, and Git — not finding it in
+// remote_refs — warns `helper reported unexpected status of <ref>`. Reusing
+// the list-for-push snapshot mirrors remote-curl.c's discovery cache and keeps
+// that phantom ref out of send-pack's view.
+func TestInvariant_PushReusesListForPushAdvertisement(t *testing.T) {
+	// No t.Parallel(): t.Setenv("PATH", ...) mutates process-global state.
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script PATH stub is POSIX-only")
+	}
+
+	ref := testRefMain
+	oldSHA := strings.Repeat("a", 40)
+
+	// Stub git send-pack: emit the empty-request terminator, drain stdin,
+	// then the trailing flush + a plain "ok" helper-status, exit 0.
+	stubDir := t.TempDir()
+	stub := "#!/bin/sh\nprintf '0000'\ncat > /dev/null\nprintf '0000ok " + ref + "\\n'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "git"), []byte(stub), 0o755); err != nil {
+		t.Fatalf("writing stub git: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// The checkpoint ref the pre-push hook would push between list-for-push
+	// and push: absent from the first advertisement, present in the second, so
+	// a re-fetch (the bug) would expose it to send-pack.
+	checkpointRef := "refs/entire/checkpoints/9H/01KX2ATMJ3FAZZFZ8CP1CA279H"
+	receivePackCalls := 0
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			receivePackCalls++
+			refLine := oldSHA + " " + ref + "\x00report-status object-format=sha1\n"
+			if receivePackCalls == 1 {
+				return stringRC(serviceAnnouncement(serviceReceivePack, refLine)), nil
+			}
+			return stringRC(serviceAnnouncement(serviceReceivePack, refLine,
+				oldSHA+" "+checkpointRef+"\n")), nil
+		},
+		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
+			return stringRC(""), nil
+		},
+	}
+
+	stdin := strings.NewReader("list for-push\npush " + oldSHA + ":" + ref + "\n\n")
+	var stdout bytes.Buffer
+	if err := Run(context.Background(), ft, 2, stdin, &stdout); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if receivePackCalls != 1 {
+		t.Fatalf("receive-pack info/refs fetched %d times; want 1 (push must reuse the list-for-push advertisement)", receivePackCalls)
 	}
 }

--- a/internal/remotehelper/githelper/list.go
+++ b/internal/remotehelper/githelper/list.go
@@ -18,12 +18,12 @@ import (
 // writes one "<value> <name>" line per ref followed by a blank-line
 // terminator. HEAD is emitted as "@<target> HEAD" when the symref
 // capability resolves; detached HEAD falls back to "<sha> HEAD".
-func handleList(ctx context.Context, t Transport, forPush bool, stdout io.Writer) error {
+func handleList(ctx context.Context, t Transport, adv *refAdvCache, forPush bool, stdout io.Writer) error {
 	service := serviceUploadPack
 	if forPush {
 		service = serviceReceivePack
 	}
-	refs, err := t.InfoRefs(ctx, service)
+	refs, err := adv.infoRefs(ctx, t, service)
 	if err != nil {
 		return fmt.Errorf("list %s info/refs: %w", service, err)
 	}

--- a/internal/remotehelper/githelper/list_test.go
+++ b/internal/remotehelper/githelper/list_test.go
@@ -107,7 +107,7 @@ func TestHandleList(t *testing.T) {
 			defer server.Close()
 
 			var out bytes.Buffer
-			if err := handleList(context.Background(), testTransport(server), tt.forPush, &out); err != nil {
+			if err := handleList(context.Background(), testTransport(server), &refAdvCache{}, tt.forPush, &out); err != nil {
 				t.Fatalf("handleList: %v", err)
 			}
 			if out.String() != tt.want {

--- a/internal/remotehelper/githelper/push.go
+++ b/internal/remotehelper/githelper/push.go
@@ -42,13 +42,17 @@ import (
 //  6. Send-pack writes a trailing flush + helper-status lines to
 //     stdout; we discard the flush and relay helper-status to git,
 //     then append the blank line that terminates the status batch.
-func handlePush(ctx context.Context, t Transport, firstLine string, opts *Options, stdin *bufio.Reader, stdout io.Writer) error {
+func handlePush(ctx context.Context, t Transport, adv *refAdvCache, firstLine string, opts *Options, stdin *bufio.Reader, stdout io.Writer) error {
 	refspecs, err := readPushBatch(firstLine, stdin)
 	if err != nil {
 		return err
 	}
 
-	refsResp, err := t.InfoRefs(ctx, serviceReceivePack)
+	// Reuse the advertisement "list for-push" already fetched. Re-fetching
+	// here would observe refs the pre-push hook pushed after Git's ref
+	// snapshot, which send-pack reports and Git flags as "unexpected status"
+	// (see refAdvCache / ENCLI-267).
+	refsResp, err := adv.infoRefs(ctx, t, serviceReceivePack)
 	if err != nil {
 		return fmt.Errorf("fetching receive-pack info/refs: %w", err)
 	}

--- a/internal/remotehelper/githelper/refadv_cache.go
+++ b/internal/remotehelper/githelper/refadv_cache.go
@@ -1,0 +1,55 @@
+package githelper
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+)
+
+// refAdvCache memoizes the receive-pack ref advertisement across a single
+// helper session so the "push" command reuses the exact ref snapshot that
+// "list for-push" fetched. This mirrors remote-curl.c's discovery cache
+// (get_refs/last_refs): Git builds its remote_refs list from the
+// "list for-push" advertisement, then runs the pre-push hook, then issues
+// "push". The Entire pre-push hook pushes per-checkpoint refs to the same
+// remote in that window, so a fresh info/refs at push time would hand
+// send-pack a ref Git never asked to push. send-pack then reports
+// `error <ref> no match` and Git — not finding it in remote_refs — warns
+// `helper reported unexpected status of <ref>` (ENCLI-267). Reusing the
+// snapshot keeps that phantom ref out of send-pack's view.
+//
+// Only the receive-pack (for-push) advertisement is cached; upload-pack and
+// v2 fetches pass straight through, matching remote-curl's per-for_push cache.
+type refAdvCache struct {
+	receivePack []byte
+	cached      bool
+}
+
+// infoRefs returns the ref advertisement for service. The receive-pack
+// advertisement is fetched from the Transport once and replayed from an
+// in-memory buffer on subsequent calls; every other service is fetched fresh.
+func (c *refAdvCache) infoRefs(ctx context.Context, t Transport, service string) (io.ReadCloser, error) {
+	if service != serviceReceivePack {
+		rc, err := t.InfoRefs(ctx, service)
+		if err != nil {
+			return nil, fmt.Errorf("fetch %s advertisement: %w", service, err)
+		}
+		return rc, nil
+	}
+	if c.cached {
+		return io.NopCloser(bytes.NewReader(c.receivePack)), nil
+	}
+	rc, err := t.InfoRefs(ctx, service)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s advertisement: %w", service, err)
+	}
+	defer rc.Close()
+	buf, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("buffer %s advertisement: %w", service, err)
+	}
+	c.receivePack = buf
+	c.cached = true
+	return io.NopCloser(bytes.NewReader(buf)), nil
+}

--- a/internal/remotehelper/githelper/run.go
+++ b/internal/remotehelper/githelper/run.go
@@ -31,6 +31,9 @@ import (
 func Run(ctx context.Context, t Transport, protocolVersion int, stdin io.Reader, stdout io.Writer) error {
 	commandReader := bufio.NewReader(stdin)
 	opts := &Options{}
+	// One advertisement snapshot per session: "push" reuses what
+	// "list for-push" fetched. See refAdvCache / ENCLI-267.
+	adv := &refAdvCache{}
 
 	for {
 		line, err := commandReader.ReadString('\n')
@@ -58,7 +61,7 @@ func Run(ctx context.Context, t Transport, protocolVersion int, stdin io.Reader,
 			fmt.Fprintln(stdout)
 
 		case line == "list" || line == "list for-push":
-			if err := handleList(ctx, t, line == "list for-push", stdout); err != nil {
+			if err := handleList(ctx, t, adv, line == "list for-push", stdout); err != nil {
 				return err
 			}
 
@@ -85,7 +88,7 @@ func Run(ctx context.Context, t Transport, protocolVersion int, stdin io.Reader,
 			return nil
 
 		case strings.HasPrefix(line, "push "):
-			if err := handlePush(ctx, t, line, opts, commandReader, stdout); err != nil {
+			if err := handlePush(ctx, t, adv, line, opts, commandReader, stdout); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/845
<!-- entire-trail-link-end -->

The `entire://` remote helper re-fetched the receive-pack ref advertisement in `handlePush` instead of reusing the one from "list for-push". Git snapshots remote refs at list-for-push, then runs the pre-push hook (which pushes per-checkpoint refs), then issues push. The fresh advertisement then included the checkpoint ref, so `git send-pack --helper-status` reported `error <ref> no match` for it, and Git — not finding it in its snapshot — warned `helper reported unexpected status of <ref>` (ENCLI-267).

Cache the receive-pack advertisement once per helper session and replay it to push, mirroring remote-curl.c's discovery cache (get_refs). Only the for-push advertisement is cached; upload-pack/v2 fetches pass through, so fetch behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes push-time ref advertisement semantics on the critical git-remote-helper path; scope is narrow (session cache for receive-pack only) and covered by a new invariant test, but incorrect caching could still affect push correctness.
> 
> **Overview**
> Fixes **ENCLI-267** by caching the receive-pack `info/refs` advertisement for one helper session and feeding that same snapshot to both **list for-push** and **push**, instead of fetching again in `handlePush`.
> 
> Git records remote refs from list-for-push, then runs the pre-push hook (which can push Entire checkpoint refs), then push. A second fetch exposed those checkpoint refs to `git send-pack`, which reported `error <ref> no match` and triggered Git’s `helper reported unexpected status` warning. Behavior aligns with **remote-curl.c**’s discovery cache; upload-pack / non–for-push paths still hit the transport on every request.
> 
> Adds `refAdvCache`, wires it through `Run`, `handleList`, and `handlePush`, and adds `TestInvariant_PushReusesListForPushAdvertisement` to assert a single receive-pack `info/refs` call across a list-for-push → push session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51367df318c6345a4f1aefdaf8c591c8da787484. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->