### PR TITLE
Improve readability of code search results in the terminal

### DIFF
--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -125,6 +125,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 					query:         codeQuery,
 					repoFilters:   codeRepos,
 					limit:         limitFlag,
+					limitExplicit: cmd.Flags().Changed("limit"),
 					caseSensitive: caseSensitive,
 					jsonOutput:    jsonOutput,
 					insecureHTTP:  insecureHTTPAuth,
@@ -375,6 +376,7 @@ type codeSearchOpts struct {
 	repoFilters     []string
 	resolvedRepoIDs []string // ULIDs resolved from repoFilters via repo index
 	limit           int
+	limitExplicit   bool // user passed --limit; don't override for text display
 	caseSensitive   bool
 	jsonOutput      bool
 	insecureHTTP    bool
@@ -476,6 +478,14 @@ func runCodeSearch(ctx context.Context, cmd *cobra.Command, opts codeSearchOpts)
 	}
 
 	w := cmd.OutOrStdout()
+	textOutput := !opts.jsonOutput && interactive.IsTerminalWriter(w)
+
+	// Text output shows up to maxCodeSearchFiles files with a few matches
+	// each, so fetch a deeper result set than the default --limit (which is
+	// tuned for flat JSON output) unless the user asked for a specific limit.
+	if textOutput && !opts.limitExplicit {
+		opts.limit = codeSearchTextFetchLimit
+	}
 
 	// Always fan out via searchAllCells — it fetches the repo index,
 	// resolves slugs to ULIDs, and handles single- vs multi-jurisdiction.
@@ -484,8 +494,7 @@ func runCodeSearch(ctx context.Context, cmd *cobra.Command, opts codeSearchOpts)
 		return err
 	}
 
-	isTerminal := interactive.IsTerminalWriter(w)
-	if opts.jsonOutput || !isTerminal {
+	if !textOutput {
 		return writeCodeSearchJSON(w, resp)
 	}
 
@@ -803,6 +812,15 @@ func writeCodeSearchJSON(w io.Writer, resp *codesearch.SearchResponse) error {
 // with an ellipsis so that JSONL/minified files don't blow up the terminal.
 const maxContextLineLen = 200
 
+// Text output display caps: show breadth (files) over depth (in-file matches).
+// The fetch limit leaves headroom beyond files×matches so per-file overflow
+// ("+ N matches") counts have data to count.
+const (
+	maxCodeSearchFiles       = 10  // files shown in text output
+	maxCodeSearchFileMatches = 3   // matches shown per file
+	codeSearchTextFetchLimit = 100 // results fetched for text display
+)
+
 // writeCodeSearchText renders code search results grouped by file (ripgrep
 // style): a colored "repo:path" header per file, indented line-numbered
 // matches beneath it, and a dimmed stats footer. Colors are applied only when
@@ -837,12 +855,17 @@ func writeCodeSearchText(w io.Writer, resp *codesearch.SearchResponse, styles st
 		groups[i].results = append(groups[i].results, r)
 	}
 
+	shown := 0
 	for gi, g := range groups {
-		if gi > 0 {
-			fmt.Fprintln(w)
+		if gi == maxCodeSearchFiles {
+			break
 		}
+		fmt.Fprintln(w)
 		fmt.Fprintln(w, styles.render(styles.cyan, g.key))
-		for _, r := range g.results {
+		for mi, r := range g.results {
+			if mi == maxCodeSearchFileMatches {
+				break
+			}
 			line := r.ContextLine
 			runes := []rune(line)
 			if len(runes) > maxContextLineLen {
@@ -850,10 +873,19 @@ func writeCodeSearchText(w io.Writer, resp *codesearch.SearchResponse, styles st
 			}
 			lineNo := styles.render(styles.dim, fmt.Sprintf("%d:", r.Line))
 			fmt.Fprintf(w, "  %s %s\n", lineNo, highlightCodeMatches(line, resp.Query, styles))
+			shown++
+		}
+		// ponytail: overflow counts only what this page fetched (peregrine
+		// has no per-file totals); a hot file shows "+ 97 matches" at most.
+		if extra := len(g.results) - maxCodeSearchFileMatches; extra > 0 {
+			label := "matches"
+			if extra == 1 {
+				label = "match"
+			}
+			fmt.Fprintln(w, styles.render(styles.dim, fmt.Sprintf("  + %d %s", extra, label)))
 		}
 	}
 
-	shown := len(resp.Results)
 	var summary string
 	if resp.Stats.TotalMatches > shown {
 		summary = fmt.Sprintf("Showing %d of %d matches across %d files in %d repos (%.0fms)",

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/entireio/cli/cmd/entire/cli/api"
@@ -498,7 +499,7 @@ func runCodeSearch(ctx context.Context, cmd *cobra.Command, opts codeSearchOpts)
 		return writeCodeSearchJSON(w, resp)
 	}
 
-	writeCodeSearchText(w, resp, newStatusStyles(w))
+	writeCodeSearchText(w, resp, newStatusStyles(w), opts.caseSensitive)
 	return nil
 }
 
@@ -825,7 +826,7 @@ const (
 // style): a colored "repo:path" header per file, indented line-numbered
 // matches beneath it, and a dimmed stats footer. Colors are applied only when
 // the writer supports them (styles.colorEnabled); piped output stays plain.
-func writeCodeSearchText(w io.Writer, resp *codesearch.SearchResponse, styles statusStyles) {
+func writeCodeSearchText(w io.Writer, resp *codesearch.SearchResponse, styles statusStyles, caseSensitive bool) {
 	if len(resp.Results) == 0 {
 		if len(resp.FailedJurisdictions) > 0 {
 			fmt.Fprintf(w, "No code search results found (some regions failed: %s)\n",
@@ -872,7 +873,7 @@ func writeCodeSearchText(w io.Writer, resp *codesearch.SearchResponse, styles st
 				line = string(runes[:maxContextLineLen]) + "…"
 			}
 			lineNo := styles.render(styles.dim, fmt.Sprintf("%d:", r.Line))
-			fmt.Fprintf(w, "  %s %s\n", lineNo, highlightCodeMatches(line, resp.Query, styles))
+			fmt.Fprintf(w, "  %s %s\n", lineNo, highlightCodeMatches(line, resp.Query, styles, caseSensitive))
 			shown++
 		}
 		// ponytail: overflow counts only what this page fetched (peregrine
@@ -903,17 +904,19 @@ func writeCodeSearchText(w io.Writer, resp *codesearch.SearchResponse, styles st
 }
 
 // highlightCodeMatches bold-red highlights occurrences of query in line
-// (grep convention). Matching is case-insensitive when lowercasing doesn't
-// change byte lengths (it can for some Unicode); otherwise it falls back to
-// exact matching so byte offsets stay aligned. Returns line unchanged when
-// color is disabled or there's nothing to highlight.
-func highlightCodeMatches(line, query string, styles statusStyles) string {
+// (grep convention). Matching mirrors the search: case-insensitive unless
+// caseSensitive is set. Case folding is only applied when both strings are
+// pure ASCII, since Unicode case mappings can change byte widths and
+// misalign offsets against the original line; non-ASCII input falls back to
+// exact matching. Returns line unchanged when color is disabled or there's
+// nothing to highlight.
+func highlightCodeMatches(line, query string, styles statusStyles, caseSensitive bool) string {
 	if !styles.colorEnabled || query == "" {
 		return line
 	}
 	haystack, needle := line, query
-	if l, q := strings.ToLower(line), strings.ToLower(query); len(l) == len(line) && len(q) == len(query) {
-		haystack, needle = l, q
+	if !caseSensitive && isASCII(line) && isASCII(query) {
+		haystack, needle = strings.ToLower(line), strings.ToLower(query)
 	}
 	matchStyle := styles.red.Bold(true)
 	var b strings.Builder
@@ -933,6 +936,16 @@ func highlightCodeMatches(line, query string, styles statusStyles) string {
 	}
 	b.WriteString(line[i:])
 	return b.String()
+}
+
+// isASCII reports whether s contains only ASCII bytes.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
 }
 
 // writeSearchJSON writes client-side paginated search results as JSON.

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -940,7 +940,7 @@ func highlightCodeMatches(line, query string, styles statusStyles, caseSensitive
 
 // isASCII reports whether s contains only ASCII bytes.
 func isASCII(s string) bool {
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		if s[i] >= utf8.RuneSelf {
 			return false
 		}

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -867,13 +867,17 @@ func writeCodeSearchText(w io.Writer, resp *codesearch.SearchResponse, styles st
 			if mi == maxCodeSearchFileMatches {
 				break
 			}
+			// Truncate before highlighting but append the ellipsis after,
+			// so the non-ASCII "…" doesn't disable case-insensitive
+			// highlighting (isASCII) for the rest of the line.
 			line := r.ContextLine
-			runes := []rune(line)
-			if len(runes) > maxContextLineLen {
-				line = string(runes[:maxContextLineLen]) + "…"
+			ellipsis := ""
+			if runes := []rune(line); len(runes) > maxContextLineLen {
+				line = string(runes[:maxContextLineLen])
+				ellipsis = "…"
 			}
 			lineNo := styles.render(styles.dim, fmt.Sprintf("%d:", r.Line))
-			fmt.Fprintf(w, "  %s %s\n", lineNo, highlightCodeMatches(line, resp.Query, styles, caseSensitive))
+			fmt.Fprintf(w, "  %s %s%s\n", lineNo, highlightCodeMatches(line, resp.Query, styles, caseSensitive), ellipsis)
 			shown++
 		}
 		// ponytail: overflow counts only what this page fetched (peregrine

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -489,7 +489,7 @@ func runCodeSearch(ctx context.Context, cmd *cobra.Command, opts codeSearchOpts)
 		return writeCodeSearchJSON(w, resp)
 	}
 
-	writeCodeSearchText(w, resp)
+	writeCodeSearchText(w, resp, newStatusStyles(w))
 	return nil
 }
 
@@ -803,8 +803,11 @@ func writeCodeSearchJSON(w io.Writer, resp *codesearch.SearchResponse) error {
 // with an ellipsis so that JSONL/minified files don't blow up the terminal.
 const maxContextLineLen = 200
 
-// writeCodeSearchText renders code search results in grep-style format.
-func writeCodeSearchText(w io.Writer, resp *codesearch.SearchResponse) {
+// writeCodeSearchText renders code search results grouped by file (ripgrep
+// style): a colored "repo:path" header per file, indented line-numbered
+// matches beneath it, and a dimmed stats footer. Colors are applied only when
+// the writer supports them (styles.colorEnabled); piped output stays plain.
+func writeCodeSearchText(w io.Writer, resp *codesearch.SearchResponse, styles statusStyles) {
 	if len(resp.Results) == 0 {
 		if len(resp.FailedJurisdictions) > 0 {
 			fmt.Fprintf(w, "No code search results found (some regions failed: %s)\n",
@@ -814,26 +817,90 @@ func writeCodeSearchText(w io.Writer, resp *codesearch.SearchResponse) {
 		}
 		return
 	}
-	for _, r := range resp.Results {
-		line := r.ContextLine
-		runes := []rune(line)
-		if len(runes) > maxContextLineLen {
-			line = string(runes[:maxContextLineLen]) + "…"
-		}
-		fmt.Fprintf(w, "%s:%s:%d: %s\n", r.Repo, r.Path, r.Line, line)
+
+	// Group results by repo:path, preserving first-appearance order so the
+	// best-scored file stays on top (results arrive globally score-sorted).
+	type fileGroup struct {
+		key     string
+		results []codesearch.Result
 	}
+	var groups []fileGroup
+	idx := make(map[string]int, len(resp.Results))
+	for _, r := range resp.Results {
+		key := r.Repo + ":" + r.Path
+		i, ok := idx[key]
+		if !ok {
+			i = len(groups)
+			idx[key] = i
+			groups = append(groups, fileGroup{key: key})
+		}
+		groups[i].results = append(groups[i].results, r)
+	}
+
+	for gi, g := range groups {
+		if gi > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, styles.render(styles.cyan, g.key))
+		for _, r := range g.results {
+			line := r.ContextLine
+			runes := []rune(line)
+			if len(runes) > maxContextLineLen {
+				line = string(runes[:maxContextLineLen]) + "…"
+			}
+			lineNo := styles.render(styles.dim, fmt.Sprintf("%d:", r.Line))
+			fmt.Fprintf(w, "  %s %s\n", lineNo, highlightCodeMatches(line, resp.Query, styles))
+		}
+	}
+
 	shown := len(resp.Results)
+	var summary string
 	if resp.Stats.TotalMatches > shown {
-		fmt.Fprintf(w, "\nShowing %d of %d matches across %d files in %d repos (%.0fms)\n",
+		summary = fmt.Sprintf("Showing %d of %d matches across %d files in %d repos (%.0fms)",
 			shown, resp.Stats.TotalMatches, resp.Stats.TotalFiles, resp.Stats.ReposSearched, resp.Stats.DurationMs)
 	} else {
-		fmt.Fprintf(w, "\n%d matches across %d files in %d repos (%.0fms)\n",
+		summary = fmt.Sprintf("%d matches across %d files in %d repos (%.0fms)",
 			resp.Stats.TotalMatches, resp.Stats.TotalFiles, resp.Stats.ReposSearched, resp.Stats.DurationMs)
 	}
+	fmt.Fprintf(w, "\n%s\n", styles.render(styles.dim, summary))
 	if len(resp.FailedJurisdictions) > 0 {
-		fmt.Fprintf(w, "Warning: results may be incomplete (failed jurisdictions: %s)\n",
+		warning := fmt.Sprintf("Warning: results may be incomplete (failed jurisdictions: %s)",
 			strings.Join(resp.FailedJurisdictions, ", "))
+		fmt.Fprintln(w, styles.render(styles.yellow, warning))
 	}
+}
+
+// highlightCodeMatches bold-red highlights occurrences of query in line
+// (grep convention). Matching is case-insensitive when lowercasing doesn't
+// change byte lengths (it can for some Unicode); otherwise it falls back to
+// exact matching so byte offsets stay aligned. Returns line unchanged when
+// color is disabled or there's nothing to highlight.
+func highlightCodeMatches(line, query string, styles statusStyles) string {
+	if !styles.colorEnabled || query == "" {
+		return line
+	}
+	haystack, needle := line, query
+	if l, q := strings.ToLower(line), strings.ToLower(query); len(l) == len(line) && len(q) == len(query) {
+		haystack, needle = l, q
+	}
+	matchStyle := styles.red.Bold(true)
+	var b strings.Builder
+	i := 0
+	for {
+		j := strings.Index(haystack[i:], needle)
+		if j < 0 {
+			break
+		}
+		j += i
+		b.WriteString(line[i:j])
+		b.WriteString(matchStyle.Render(line[j : j+len(needle)]))
+		i = j + len(needle)
+	}
+	if i == 0 {
+		return line // no matches; skip the builder copy
+	}
+	b.WriteString(line[i:])
+	return b.String()
 }
 
 // writeSearchJSON writes client-side paginated search results as JSON.

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -223,7 +223,7 @@ func TestWriteCodeSearchText_CapsFilesAndMatchesPerFile(t *testing.T) {
 		results = append(results, codesearch.Result{Repo: "r", Path: "hot.go", Line: line, ContextLine: "x"})
 	}
 	// More files than the file cap.
-	for f := 0; f < maxCodeSearchFiles+3; f++ {
+	for f := range maxCodeSearchFiles + 3 {
 		results = append(results, codesearch.Result{Repo: "r", Path: fmt.Sprintf("f%02d.go", f), Line: 1, ContextLine: "y"})
 	}
 	resp := &codesearch.SearchResponse{

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -167,14 +167,72 @@ func TestWriteCodeSearchText(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeCodeSearchText(&buf, resp)
+	writeCodeSearchText(&buf, resp, newStatusStyles(&buf))
 
 	output := buf.String()
-	if !strings.Contains(output, "entireio/cli:main.go:10: func main() {") {
+	if !strings.Contains(output, "entireio/cli:main.go\n") {
+		t.Errorf("output missing file header:\n%s", output)
+	}
+	if !strings.Contains(output, "  10: func main() {") {
 		t.Errorf("output missing first result:\n%s", output)
+	}
+	if !strings.Contains(output, "  42: \tfmt.Println(\"hello\")") {
+		t.Errorf("output missing second result:\n%s", output)
 	}
 	if !strings.Contains(output, "2 matches across 1 files") {
 		t.Errorf("output missing summary line:\n%s", output)
+	}
+	if strings.Contains(output, "\x1b[") {
+		t.Errorf("expected no ANSI codes for non-terminal writer:\n%s", output)
+	}
+}
+
+func TestWriteCodeSearchText_GroupsByFile(t *testing.T) {
+	t.Parallel()
+
+	// Interleaved files (score-sorted input) should collapse into one header
+	// per file, in first-appearance order.
+	resp := &codesearch.SearchResponse{
+		Stats: codesearch.Stats{TotalMatches: 3, TotalFiles: 2, ReposSearched: 1, DurationMs: 1},
+		Results: []codesearch.Result{
+			{Repo: "r", Path: "a.go", Line: 1, ContextLine: "one"},
+			{Repo: "r", Path: "b.go", Line: 2, ContextLine: "two"},
+			{Repo: "r", Path: "a.go", Line: 3, ContextLine: "three"},
+		},
+	}
+
+	var buf bytes.Buffer
+	writeCodeSearchText(&buf, resp, newStatusStyles(&buf))
+
+	output := buf.String()
+	if got := strings.Count(output, "r:a.go\n"); got != 1 {
+		t.Errorf("expected exactly 1 header for a.go, got %d:\n%s", got, output)
+	}
+	if aIdx, bIdx := strings.Index(output, "r:a.go"), strings.Index(output, "r:b.go"); aIdx > bIdx {
+		t.Errorf("expected a.go header before b.go:\n%s", output)
+	}
+}
+
+func TestHighlightCodeMatches(t *testing.T) {
+	t.Parallel()
+
+	styles := statusStyles{colorEnabled: true}
+
+	out := highlightCodeMatches("func HandleRequest(w)", "handlerequest", styles)
+	if !strings.Contains(out, "\x1b[") {
+		t.Errorf("expected ANSI codes in highlighted output, got %q", out)
+	}
+	if !strings.HasPrefix(out, "func ") || !strings.HasSuffix(out, "(w)") {
+		t.Errorf("expected unmatched text preserved around highlight, got %q", out)
+	}
+
+	if out := highlightCodeMatches("no match here", "zzz", styles); out != "no match here" {
+		t.Errorf("expected unchanged line when no match, got %q", out)
+	}
+
+	plain := statusStyles{colorEnabled: false}
+	if out := highlightCodeMatches("func main()", "main", plain); out != "func main()" {
+		t.Errorf("expected unchanged line when color disabled, got %q", out)
 	}
 }
 
@@ -218,7 +276,7 @@ func TestWriteCodeSearchText_TruncatesLongLines(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeCodeSearchText(&buf, resp)
+	writeCodeSearchText(&buf, resp, newStatusStyles(&buf))
 
 	output := buf.String()
 	if strings.Contains(output, longLine) {
@@ -242,7 +300,7 @@ func TestWriteCodeSearchText_Empty(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeCodeSearchText(&buf, resp)
+	writeCodeSearchText(&buf, resp, newStatusStyles(&buf))
 
 	if !strings.Contains(buf.String(), "No code search results found") {
 		t.Errorf("expected empty results message, got:\n%s", buf.String())

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -210,6 +211,39 @@ func TestWriteCodeSearchText_GroupsByFile(t *testing.T) {
 	}
 	if aIdx, bIdx := strings.Index(output, "r:a.go"), strings.Index(output, "r:b.go"); aIdx > bIdx {
 		t.Errorf("expected a.go header before b.go:\n%s", output)
+	}
+}
+
+func TestWriteCodeSearchText_CapsFilesAndMatchesPerFile(t *testing.T) {
+	t.Parallel()
+
+	var results []codesearch.Result
+	// First file has 5 matches — 2 over the per-file cap.
+	for line := 1; line <= maxCodeSearchFileMatches+2; line++ {
+		results = append(results, codesearch.Result{Repo: "r", Path: "hot.go", Line: line, ContextLine: "x"})
+	}
+	// More files than the file cap.
+	for f := 0; f < maxCodeSearchFiles+3; f++ {
+		results = append(results, codesearch.Result{Repo: "r", Path: fmt.Sprintf("f%02d.go", f), Line: 1, ContextLine: "y"})
+	}
+	resp := &codesearch.SearchResponse{
+		Stats:   codesearch.Stats{TotalMatches: len(results), TotalFiles: maxCodeSearchFiles + 4, ReposSearched: 1},
+		Results: results,
+	}
+
+	var buf bytes.Buffer
+	writeCodeSearchText(&buf, resp, newStatusStyles(&buf))
+	output := buf.String()
+
+	if got := strings.Count(output, "r:"); got != maxCodeSearchFiles {
+		t.Errorf("expected %d file headers, got %d:\n%s", maxCodeSearchFiles, got, output)
+	}
+	if !strings.Contains(output, "+ 2 matches") {
+		t.Errorf("expected '+ 2 matches' overflow for hot.go:\n%s", output)
+	}
+	// hot.go shows only the per-file cap: lines 1..3, not 4/5.
+	if strings.Contains(output, fmt.Sprintf("  %d: x", maxCodeSearchFileMatches+1)) {
+		t.Errorf("expected at most %d matches for hot.go:\n%s", maxCodeSearchFileMatches, output)
 	}
 }
 

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -339,6 +339,30 @@ func TestWriteCodeSearchText_TruncatesLongLines(t *testing.T) {
 	}
 }
 
+func TestWriteCodeSearchText_HighlightsTruncatedLines(t *testing.T) {
+	t.Parallel()
+
+	// The appended "…" is non-ASCII; it must not disable case-insensitive
+	// highlighting for an otherwise ASCII line.
+	longLine := "FooBar " + strings.Repeat("x", 300)
+	resp := &codesearch.SearchResponse{
+		Query:   "foobar",
+		Stats:   codesearch.Stats{TotalMatches: 1, TotalFiles: 1, ReposSearched: 1, DurationMs: 1},
+		Results: []codesearch.Result{{Repo: "r", Path: "f.go", Line: 1, ContextLine: longLine}},
+	}
+
+	var buf bytes.Buffer
+	writeCodeSearchText(&buf, resp, statusStyles{colorEnabled: true}, false)
+
+	output := buf.String()
+	if !strings.Contains(output, "…") {
+		t.Errorf("expected truncated line to end with ellipsis:\n%s", output)
+	}
+	if !strings.Contains(output, "\x1b[") {
+		t.Errorf("expected case-insensitive highlight on truncated line:\n%s", output)
+	}
+}
+
 func TestWriteCodeSearchText_Empty(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -168,7 +168,7 @@ func TestWriteCodeSearchText(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeCodeSearchText(&buf, resp, newStatusStyles(&buf))
+	writeCodeSearchText(&buf, resp, newStatusStyles(&buf), false)
 
 	output := buf.String()
 	if !strings.Contains(output, "entireio/cli:main.go\n") {
@@ -203,7 +203,7 @@ func TestWriteCodeSearchText_GroupsByFile(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeCodeSearchText(&buf, resp, newStatusStyles(&buf))
+	writeCodeSearchText(&buf, resp, newStatusStyles(&buf), false)
 
 	output := buf.String()
 	if got := strings.Count(output, "r:a.go\n"); got != 1 {
@@ -232,7 +232,7 @@ func TestWriteCodeSearchText_CapsFilesAndMatchesPerFile(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeCodeSearchText(&buf, resp, newStatusStyles(&buf))
+	writeCodeSearchText(&buf, resp, newStatusStyles(&buf), false)
 	output := buf.String()
 
 	if got := strings.Count(output, "r:"); got != maxCodeSearchFiles {
@@ -252,7 +252,7 @@ func TestHighlightCodeMatches(t *testing.T) {
 
 	styles := statusStyles{colorEnabled: true}
 
-	out := highlightCodeMatches("func HandleRequest(w)", "handlerequest", styles)
+	out := highlightCodeMatches("func HandleRequest(w)", "handlerequest", styles, false)
 	if !strings.Contains(out, "\x1b[") {
 		t.Errorf("expected ANSI codes in highlighted output, got %q", out)
 	}
@@ -260,12 +260,25 @@ func TestHighlightCodeMatches(t *testing.T) {
 		t.Errorf("expected unmatched text preserved around highlight, got %q", out)
 	}
 
-	if out := highlightCodeMatches("no match here", "zzz", styles); out != "no match here" {
+	if out := highlightCodeMatches("no match here", "zzz", styles, false); out != "no match here" {
 		t.Errorf("expected unchanged line when no match, got %q", out)
 	}
 
+	// Case-sensitive search must not highlight case variants.
+	if out := highlightCodeMatches("func HandleRequest(w)", "handlerequest", styles, true); out != "func HandleRequest(w)" {
+		t.Errorf("expected no highlight for case mismatch with caseSensitive, got %q", out)
+	}
+
+	// Non-ASCII input falls back to exact matching (no case folding).
+	if out := highlightCodeMatches("comment ÉTÉ ici", "été", styles, false); out != "comment ÉTÉ ici" {
+		t.Errorf("expected no case-folded highlight for non-ASCII input, got %q", out)
+	}
+	if out := highlightCodeMatches("comment été ici", "été", styles, false); !strings.Contains(out, "\x1b[") {
+		t.Errorf("expected exact non-ASCII match highlighted, got %q", out)
+	}
+
 	plain := statusStyles{colorEnabled: false}
-	if out := highlightCodeMatches("func main()", "main", plain); out != "func main()" {
+	if out := highlightCodeMatches("func main()", "main", plain, false); out != "func main()" {
 		t.Errorf("expected unchanged line when color disabled, got %q", out)
 	}
 }
@@ -310,7 +323,7 @@ func TestWriteCodeSearchText_TruncatesLongLines(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeCodeSearchText(&buf, resp, newStatusStyles(&buf))
+	writeCodeSearchText(&buf, resp, newStatusStyles(&buf), false)
 
 	output := buf.String()
 	if strings.Contains(output, longLine) {
@@ -334,7 +347,7 @@ func TestWriteCodeSearchText_Empty(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeCodeSearchText(&buf, resp, newStatusStyles(&buf))
+	writeCodeSearchText(&buf, resp, newStatusStyles(&buf), false)
 
 	if !strings.Contains(buf.String(), "No code search results found") {
 		t.Errorf("expected empty results message, got:\n%s", buf.String())


### PR DESCRIPTION
## Summary

Fixes [ENT-1130](https://linear.app/entirehq/issue/ENT-1130): `entire search --code` output was plain unstyled text — every match on one `repo:path:line: text` line with no color, so results ran together and were hard to scan.

- Group matches by file (ripgrep style): one cyan `repo:path` header per file, blank line between files (and before the first result), first-appearance order so score ranking is preserved
- Favor breadth over depth: show up to 10 files with the first 3 matches each, then a dim `+ N matches` overflow line per file
- Dim line numbers, bold-red highlighting of the query within each match line (case-insensitive, with an exact-match fallback when lowercasing would shift byte offsets)
- Dim stats footer, yellow partial-failure warning
- Terminal text output fetches a deeper page (100 results) so file variety can fill the display, unless `--limit` is passed explicitly
- Reuses the existing `statusStyles`/palette infra used by `entire why`/`status`; the `colorEnabled` gate means piped output stays plain, and `--json` behavior (including its default limit) is untouched

Example:

```
gh/entireio/cli:cmd/entire/cli/auth.go
  16:   "github.com/entireio/cli/cmd/entire/cli/auth"
  28: const coreAuthSessionsPath = "/api/auth/tokens"
  239: type authProfile struct {
  + 14 matches

Showing 30 of 5491 matches across 370 files in 1 repos (109ms)
```

## Test plan

- [x] `go test ./cmd/entire/cli/ -run 'TestSearch|TestWrite|TestMerge|HighlightCodeMatches'`
- [x] Existing `writeCodeSearchText` tests updated for grouped layout; new tests for file grouping, per-file/file-count caps, overflow line, and match highlighting
- [x] Manual: `ENTIRE_CODE_SEARCH=1 entire search --code auth` in a terminal — verified colors, grouping, and caps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only presentation and fetch-limit tuning for terminal text mode; JSON and piped output paths are unchanged aside from shared merge logic already in place.
> 
> **Overview**
> **Terminal `--code` results** are no longer one flat `repo:path:line:` line per hit. They’re grouped **by file** (ripgrep-style): cyan `repo:path` headers, indented dim line numbers, and **bold-red query highlighting** (case-insensitive for ASCII; exact match when Unicode would break byte offsets). Display favors breadth: up to **10 files**, **3 matches per file**, with a dim `+ N matches` overflow line; stats and partial-failure warnings use the existing `statusStyles` palette (plain when piped).
> 
> When stdout is an interactive terminal and the user did **not** pass `--limit`, the command now fetches **100** results so the grouped view can show more files; explicit `--limit` and **`--json`** behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2168e71039435d3855ba877cc57849e8702147. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->