### PR TITLE
cli: group root help output by user journey

### DIFF
--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -31,6 +31,23 @@ Environment Variables:
                 TUI elements, which works better with screen readers.
 `
 
+// Help groups for the root command. AddGroup order is display order.
+// Visible commands without a GroupID render under "Additional Commands"
+// (version, labs, agent-help, help) — that placement is intentional.
+const (
+	groupSetup        = "setup"
+	groupSessions     = "sessions"
+	groupAccount      = "account"
+	groupControlPlane = "controlplane"
+)
+
+// inGroup assigns a help group to a command at registration time so all
+// grouping stays visible in NewRootCmd rather than spread across constructors.
+func inGroup(c *cobra.Command, groupID string) *cobra.Command {
+	c.GroupID = groupID
+	return c
+}
+
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "entire",
@@ -84,39 +101,47 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
+	// Help groups; AddGroup order is display order in `entire --help`.
+	cmd.AddGroup(
+		&cobra.Group{ID: groupSetup, Title: "Entire Setup:"},
+		&cobra.Group{ID: groupSessions, Title: "Sessions & Checkpoints:"},
+		&cobra.Group{ID: groupAccount, Title: "Account:"},
+		&cobra.Group{ID: groupControlPlane, Title: "Control Plane:"},
+	)
+
 	// Noun groups (canonical homes for subcommands).
-	cmd.AddCommand(newSessionsCmd())        // 'session' (with 'sessions' as Cobra alias)
-	cmd.AddCommand(newCheckpointGroupCmd()) // 'checkpoint' / 'cp' / 'checkpoints'
-	cmd.AddCommand(newTokensGroupCmd())     // 'tokens'
-	cmd.AddCommand(newAgentGroupCmd())      // 'agent'
-	cmd.AddCommand(newAuthCmd())            // 'auth'
-	cmd.AddCommand(newDoctorCmd())          // 'doctor' (group: trace/logs/bundle)
-	cmd.AddCommand(newLabsCmd())            // 'labs' (experimental workflow discovery)
-	cmd.AddCommand(newPluginGroupCmd())     // 'plugin' (managed install/list/remove)
-	cmd.AddCommand(newImportCmd())          // 'import' (hidden; import pre-existing agent history)
-	cmd.AddCommand(newOrgCmd())             // 'org' — control-plane org management
-	cmd.AddCommand(newProjectCmd())         // 'project' — control-plane project management
-	cmd.AddCommand(newRepoCmd())            // 'repo' — control-plane repo lifecycle
-	cmd.AddCommand(newGrantCmd())           // 'grant' — control-plane access grants
+	cmd.AddCommand(inGroup(newSessionsCmd(), groupSessions))        // 'session' (with 'sessions' as Cobra alias)
+	cmd.AddCommand(inGroup(newCheckpointGroupCmd(), groupSessions)) // 'checkpoint' / 'cp' / 'checkpoints'
+	cmd.AddCommand(newTokensGroupCmd())                             // 'tokens'
+	cmd.AddCommand(inGroup(newAgentGroupCmd(), groupSetup))         // 'agent'
+	cmd.AddCommand(inGroup(newAuthCmd(), groupAccount))             // 'auth'
+	cmd.AddCommand(inGroup(newDoctorCmd(), groupSetup))             // 'doctor' (group: trace/logs/bundle)
+	cmd.AddCommand(newLabsCmd())                                    // 'labs' (experimental workflow discovery)
+	cmd.AddCommand(inGroup(newPluginGroupCmd(), groupSetup))        // 'plugin' (managed install/list/remove)
+	cmd.AddCommand(newImportCmd())                                  // 'import' (hidden; import pre-existing agent history)
+	cmd.AddCommand(inGroup(newOrgCmd(), groupControlPlane))         // 'org' — control-plane org management
+	cmd.AddCommand(inGroup(newProjectCmd(), groupControlPlane))     // 'project' — control-plane project management
+	cmd.AddCommand(inGroup(newRepoCmd(), groupControlPlane))        // 'repo' — control-plane repo lifecycle
+	cmd.AddCommand(inGroup(newGrantCmd(), groupControlPlane))       // 'grant' — control-plane access grants
 
 	// Top-level lifecycle and standalone commands.
 	cmd.AddCommand(cliReview.NewCommand(buildReviewDeps()))        // `review`; hidden during maturation
 	cmd.AddCommand(investigate.NewCommand(buildInvestigateDeps())) // hidden during maturation; runs a multi-agent investigation
-	cmd.AddCommand(newCleanCmd())
-	cmd.AddCommand(newSetupCmd()) // 'configure' — non-agent settings; agent CRUD lives under 'agent'
-	cmd.AddCommand(newEnableCmd())
-	cmd.AddCommand(newDisableCmd())
-	cmd.AddCommand(newStatusCmd())
+	cmd.AddCommand(inGroup(newCleanCmd(), groupSetup))
+	cmd.AddCommand(inGroup(newSetupCmd(), groupSetup)) // 'configure' — non-agent settings; agent CRUD lives under 'agent'
+	cmd.AddCommand(inGroup(newEnableCmd(), groupSetup))
+	cmd.AddCommand(inGroup(newDisableCmd(), groupSetup))
+	cmd.AddCommand(inGroup(newStatusCmd(), groupSetup))
 	cmd.AddCommand(newBlameCmd())
 	cmd.AddCommand(newWhyCmd())
-	cmd.AddCommand(newLoginCmd())
-	cmd.AddCommand(newLogoutCmd())
+	cmd.AddCommand(inGroup(newLoginCmd(), groupAccount))
+	cmd.AddCommand(inGroup(newLogoutCmd(), groupAccount))
 	cmd.AddCommand(newVersionCmd())
-	cmd.AddCommand(newDispatchCmd())
-	cmd.AddCommand(newActivityCmd())
-	cmd.AddCommand(newRecapCmd())
-	cmd.AddCommand(newAPICmd())          // authenticated passthrough to core/cell APIs
-	cmd.AddCommand(newAgentHelpCmd(cmd)) // visible: agents on transports without context injection discover it via `entire help`
+	cmd.AddCommand(inGroup(newDispatchCmd(), groupSessions))
+	cmd.AddCommand(inGroup(newActivityCmd(), groupSessions))
+	cmd.AddCommand(inGroup(newRecapCmd(), groupSessions))
+	cmd.AddCommand(inGroup(newAPICmd(), groupControlPlane)) // authenticated passthrough to core/cell APIs
+	cmd.AddCommand(newAgentHelpCmd(cmd))                    // visible: agents on transports without context injection discover it via `entire help`
 
 	// Hidden top-level shortcuts. Functional but print a deprecation hint.
 	cmd.AddCommand(hideAsAlias(newResumeCmd(), "entire session resume"))

--- a/cmd/entire/cli/root_test.go
+++ b/cmd/entire/cli/root_test.go
@@ -256,6 +256,75 @@ func TestCheckpointPolicyCommandIsHiddenDuringDevelopment(t *testing.T) {
 	}
 }
 
+func TestRoot_VisibleCommandsAreGrouped(t *testing.T) {
+	t.Parallel()
+
+	// Commands intentionally left out of any group; cobra renders them
+	// under "Additional Commands".
+	ungrouped := map[string]bool{
+		"version":    true,
+		"labs":       true,
+		"agent-help": true,
+		"help":       true,
+		"completion": true,
+	}
+
+	wantGroups := map[string]string{
+		"enable":     groupSetup,
+		"disable":    groupSetup,
+		"configure":  groupSetup,
+		"agent":      groupSetup,
+		"plugin":     groupSetup,
+		"status":     groupSetup,
+		"doctor":     groupSetup,
+		"clean":      groupSetup,
+		"session":    groupSessions,
+		"checkpoint": groupSessions,
+		"recap":      groupSessions,
+		"activity":   groupSessions,
+		"dispatch":   groupSessions,
+		"login":      groupAccount,
+		"logout":     groupAccount,
+		"auth":       groupAccount,
+		"org":        groupControlPlane,
+		"project":    groupControlPlane,
+		"repo":       groupControlPlane,
+		"grant":      groupControlPlane,
+		"api":        groupControlPlane,
+	}
+
+	root := NewRootCmd()
+
+	registered := make(map[string]bool)
+	for _, g := range root.Groups() {
+		registered[g.ID] = true
+	}
+
+	for _, c := range root.Commands() {
+		if c.Hidden || c.Deprecated != "" {
+			continue
+		}
+		name := c.Name()
+		if ungrouped[name] {
+			if c.GroupID != "" {
+				t.Errorf("%q should stay ungrouped, got GroupID %q", name, c.GroupID)
+			}
+			continue
+		}
+		want, ok := wantGroups[name]
+		if !ok {
+			t.Errorf("visible command %q missing from group table; assign it a group or add it to the ungrouped allowlist", name)
+			continue
+		}
+		if c.GroupID != want {
+			t.Errorf("%q GroupID = %q, want %q", name, c.GroupID, want)
+		}
+		if !registered[want] {
+			t.Errorf("group %q used by %q is not registered on root (cobra panics at Execute)", want, name)
+		}
+	}
+}
+
 func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/862
<!-- entire-trail-link-end -->

## Summary
- `entire --help` rendered 26 visible commands as one flat alphabetical list; users scanned everything to find anything
- Add cobra `Group`s so root help renders four titled sections: **Entire Setup** (enable, disable, configure, agent, plugin, status, doctor, clean), **Sessions & Checkpoints** (session, checkpoint, recap, activity, dispatch), **Account** (login, logout, auth), **Control Plane** (org, project, repo, grant, api)
- `version`, `labs`, `agent-help`, `help` stay ungrouped under cobra's "Additional Commands" on purpose (meta/discovery commands)
- Pure help-presentation change: no command names, paths, flags, or behavior change; `agent-help` output (text + JSON) unaffected

<img width="738" height="1001" alt="image" src="https://github.com/user-attachments/assets/976947ca-6630-4b92-a67d-3092b2d76445" />


## Test plan
- New `TestRoot_VisibleCommandsAreGrouped` asserts exact group membership, registered group IDs, and that new visible root commands fail the test until assigned a group or allowlisted
- `mise run test:ci` green (unit + integration + canary); golangci-lint 2.11.3 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help layout and documentation only; no changes to command execution, auth, or data paths.
> 
> **Overview**
> **`entire --help`** now lists visible root commands under four Cobra help sections instead of one flat alphabetical list: **Entire Setup**, **Sessions & Checkpoints**, **Account**, and **Control Plane**.
> 
> `NewRootCmd` registers those groups and uses a small **`inGroup`** helper to set **`GroupID`** when commands are added (setup, session/checkpoint workflows, login/auth, control-plane APIs, etc.). **`version`**, **`labs`**, **`agent-help`**, and **`help`** stay ungrouped so they appear under Cobra’s **Additional Commands**. Command names, flags, and runtime behavior are unchanged—this is help presentation only.
> 
> **`TestRoot_VisibleCommandsAreGrouped`** locks in expected group membership, verifies group IDs are registered on the root, and fails if a new visible command is added without a group or allowlist entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2311c8734a0d79efbc2b61174a51ff5745caf934. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->