### PR TITLE
fix(checkpoint): stamp adhoc checkpoint remotes at creation, not retroactively

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -11,10 +11,17 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
+
+// stampConfigTimeout bounds the local git-config reads/writes that mark a newly
+// created checkpoint remote as skipped. They run detached from the fetch's
+// context (see stampNewlyCreatedRemote), so a bound guards against a stuck
+// config lock hanging the caller.
+const stampConfigTimeout = 10 * time.Second
 
 // CheckpointTokenEnvVar is the environment variable for providing an access token
 // used to authenticate git push/fetch operations for checkpoint branches.
@@ -112,21 +119,34 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	disableTerminalPrompt(cmd)
 	out, err := cmd.CombinedOutput()
 
-	// Stamp whenever this fetch newly created the section — even on a fetch
-	// error. Git writes remote.<url>.promisor eagerly during connection setup,
-	// so a failed filtered fetch still leaves the phantom remote behind; if we
-	// only stamped on success it would linger unstamped forever (the section
-	// then exists on the next attempt, so it never looks "new" again). Checking
-	// existence after the fetch keeps us from inventing a section when the fetch
-	// died before git wrote anything.
-	if stampCandidate && !existedBefore && gitRemoteSectionExists(ctx, opts.Dir, stampURL) {
-		markRemoteSkipped(ctx, opts.Dir, stampURL)
+	if stampCandidate && !existedBefore {
+		stampNewlyCreatedRemote(ctx, opts.Dir, stampURL)
 	}
 
 	if err != nil {
 		return out, fmt.Errorf("git fetch: %w", err)
 	}
 	return out, nil
+}
+
+// stampNewlyCreatedRemote stamps a URL-keyed remote section that this fetch just
+// created. Git writes remote.<url>.promisor eagerly during connection setup, so
+// a filtered fetch that later fails still leaves the phantom remote behind;
+// stamping here — rather than only on fetch success — keeps it from lingering
+// unstamped forever (the section then exists on the next attempt, so it never
+// looks "new" again). Re-checking existence keeps us from inventing a section
+// when the fetch died before git wrote anything.
+//
+// The git-config commands run on a context detached from the fetch's deadline:
+// a filtered fetch that timed out leaves ctx already past its deadline, and
+// inheriting it would make these local commands fail immediately and leave the
+// phantom unstamped — the very miss this stamping exists to prevent.
+func stampNewlyCreatedRemote(ctx context.Context, dir, url string) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), stampConfigTimeout)
+	defer cancel()
+	if gitRemoteSectionExists(ctx, dir, url) {
+		markRemoteSkipped(ctx, dir, url)
+	}
 }
 
 // markRemoteSkipped stamps skipFetchAll/skipDefaultUpdate on a URL-keyed remote
@@ -163,7 +183,7 @@ func markRemoteSkipped(ctx context.Context, dir, url string) {
 // about to create a new URL-keyed remote, so we only stamp remotes we create and
 // never rewrite ones the user already has.
 func gitRemoteSectionExists(ctx context.Context, dir, url string) bool {
-	cmd := exec.CommandContext(ctx, "git", "config", "--local", "--list")
+	cmd := exec.CommandContext(ctx, "git", "config", "--local", "--list", "--name-only")
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -171,10 +191,21 @@ func gitRemoteSectionExists(ctx context.Context, dir, url string) bool {
 	if err != nil {
 		return false
 	}
-	// git --list preserves subsection (the URL) case, so match it verbatim.
-	prefix := "remote." + url + "."
+	// Each name is "remote.<url>.<key>". Git config keys carry no dots, so the
+	// final dotted component is the key and everything between "remote." and it
+	// is the subsection (the URL, whose case git preserves). Compare the
+	// subsection exactly so a longer URL that shares a prefix (e.g. a
+	// ".../repo.git" section vs a ".../repo" fetch) is not a false match.
 	for line := range strings.SplitSeq(string(out), "\n") {
-		if strings.HasPrefix(line, prefix) {
+		rest, ok := strings.CutPrefix(line, "remote.")
+		if !ok {
+			continue
+		}
+		lastDot := strings.LastIndexByte(rest, '.')
+		if lastDot < 0 {
+			continue
+		}
+		if rest[:lastDot] == url {
 			return true
 		}
 	}

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -96,9 +96,9 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	// (remote.<url>.*) so it can lazy-fetch filtered-out objects later. That
 	// section also turns the URL into a phantom remote that `git fetch --all`
 	// and `git remote update` keep dialing. When this fetch is the one creating
-	// the section, stamp skipFetchAll/skipDefaultUpdate so bulk fetches skip our
-	// adhoc remote. Remotes that already existed are left untouched so we never
-	// rewrite the user's config.
+	// the section, stamp skipFetchAll so bulk fetches skip our adhoc remote.
+	// Remotes that already existed are left untouched so we never rewrite the
+	// user's config.
 	var stampURL string
 	var stampCandidate, existedBefore bool
 	if filtered && IsURL(opts.Remote) {
@@ -149,32 +149,28 @@ func stampNewlyCreatedRemote(ctx context.Context, dir, url string) {
 	}
 }
 
-// markRemoteSkipped stamps skipFetchAll/skipDefaultUpdate on a URL-keyed remote
-// section so `git fetch --all` and `git remote update` skip it. Called only for
-// remotes this fetch just created, so an adhoc checkpoint URL never lingers as a
-// phantom remote that bulk fetches keep dialing.
+// markRemoteSkipped stamps skipFetchAll on a URL-keyed remote section so
+// `git fetch --all` and `git remote update` skip it. Called only for remotes
+// this fetch just created, so an adhoc checkpoint URL never lingers as a phantom
+// remote that bulk fetches keep dialing.
 // Best-effort: the git config write is not worth failing the fetch over, so
 // failures only log.
 func markRemoteSkipped(ctx context.Context, dir, url string) {
-	for _, key := range []string{"skipFetchAll", "skipDefaultUpdate"} {
-		fullKey := "remote." + url + "." + key
-		cmd := exec.CommandContext(ctx, "git", "config", "--local", fullKey, "true")
-		if dir != "" {
-			cmd.Dir = dir
-		}
-		if out, cfgErr := cmd.CombinedOutput(); cfgErr != nil {
-			redactedURL := RedactURL(url)
-			// The output can echo the key, which embeds the URL — and a URL
-			// can carry credentials. Redact before logging.
-			msg := strings.TrimSpace(strings.ReplaceAll(string(out), url, redactedURL))
-			logging.Warn(ctx, "failed to mark remote config entry as skipped for bulk fetches",
-				slog.String("url", redactedURL),
-				slog.String("key", key),
-				slog.String("output", msg),
-				slog.String("error", cfgErr.Error()),
-			)
-			return
-		}
+	fullKey := "remote." + url + ".skipFetchAll"
+	cmd := exec.CommandContext(ctx, "git", "config", "--local", fullKey, "true")
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	if out, cfgErr := cmd.CombinedOutput(); cfgErr != nil {
+		redactedURL := RedactURL(url)
+		// The output can echo the key, which embeds the URL — and a URL can
+		// carry credentials. Redact before logging.
+		msg := strings.TrimSpace(strings.ReplaceAll(string(out), url, redactedURL))
+		logging.Warn(ctx, "failed to mark remote config entry as skipped for bulk fetches",
+			slog.String("url", redactedURL),
+			slog.String("output", msg),
+			slog.String("error", cfgErr.Error()),
+		)
 	}
 }
 

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -85,6 +85,25 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	args = append(args, opts.Remote)
 	args = append(args, opts.RefSpecs...)
 
+	// A filtered fetch from a URL makes git record a URL-keyed remote section
+	// (remote.<url>.*) so it can lazy-fetch filtered-out objects later. That
+	// section also turns the URL into a phantom remote that `git fetch --all`
+	// and `git remote update` keep dialing. When this fetch is the one creating
+	// the section (it did not exist beforehand), stamp skipFetchAll/
+	// skipDefaultUpdate so bulk fetches skip our adhoc remote. Remotes that
+	// already existed are left untouched so we never rewrite the user's config.
+	var stampURL string
+	var stampNewRemote bool
+	if filtered && IsURL(opts.Remote) {
+		stampURL = opts.Remote
+		if token := strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)); token != "" && isValidToken(token) {
+			// With a checkpoint token, newCommand rewrites SSH targets to HTTPS
+			// and git records the section under the rewritten URL.
+			stampURL, _ = resolveTargetForTokenAuth(ctx, stampURL)
+		}
+		stampNewRemote = !gitRemoteSectionExists(ctx, opts.Dir, stampURL)
+	}
+
 	cmd := newCommand(ctx, args...)
 	if opts.Dir != "" {
 		cmd.Dir = opts.Dir
@@ -94,39 +113,20 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	if err != nil {
 		return out, fmt.Errorf("git fetch: %w", err)
 	}
-	if filtered && IsURL(opts.Remote) {
-		// Stamp the URL git actually fetched from: with a checkpoint token set,
-		// newCommand rewrites SSH targets to HTTPS, and git records the
-		// promisor entry under the rewritten URL.
-		target := opts.Remote
-		if token := strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)); token != "" && isValidToken(token) {
-			target, _ = resolveTargetForTokenAuth(ctx, target)
-		}
-		markPromisorEntrySkipped(ctx, opts.Dir, target)
+	if stampNewRemote {
+		markRemoteSkipped(ctx, opts.Dir, stampURL)
 	}
 	return out, nil
 }
 
-// markPromisorEntrySkipped excludes the URL-keyed config section that git
-// creates for a filtered URL fetch (remote.<url>.promisor=true) from
-// `git fetch --all` and `git remote update`. Git needs the promisor entry to
-// lazy-fetch filtered-out objects later, but the entry also makes the URL show
-// up as a fetchable remote, so without this every checkpoint URL ever fetched
-// from lingers as a phantom remote that bulk fetches keep dialing.
+// markRemoteSkipped stamps skipFetchAll/skipDefaultUpdate on a URL-keyed remote
+// section so `git fetch --all` and `git remote update` skip it. Called only for
+// remotes this fetch just created, so an adhoc checkpoint URL never lingers as a
+// phantom remote that bulk fetches keep dialing.
 // Best-effort: the fetch already succeeded, so failures only log.
-func markPromisorEntrySkipped(ctx context.Context, dir, url string) {
-	if !gitConfigBool(ctx, dir, "remote."+url+".promisor") {
-		// Git didn't record a promisor entry for this URL; don't invent a
-		// config section that wouldn't otherwise exist.
-		return
-	}
+func markRemoteSkipped(ctx context.Context, dir, url string) {
 	for _, key := range []string{"skipFetchAll", "skipDefaultUpdate"} {
 		fullKey := "remote." + url + "." + key
-		if gitConfigBool(ctx, dir, fullKey) {
-			// Checked per key so a partially-stamped entry (e.g. an earlier
-			// run failing between the two writes) still gets completed.
-			continue
-		}
 		cmd := exec.CommandContext(ctx, "git", "config", "--local", fullKey, "true")
 		if dir != "" {
 			cmd.Dir = dir
@@ -136,7 +136,7 @@ func markPromisorEntrySkipped(ctx context.Context, dir, url string) {
 			// The output can echo the key, which embeds the URL — and a URL
 			// can carry credentials. Redact before logging.
 			msg := strings.TrimSpace(strings.ReplaceAll(string(out), url, redactedURL))
-			logging.Warn(ctx, "failed to mark promisor config entry as skipped for bulk fetches",
+			logging.Warn(ctx, "failed to mark remote config entry as skipped for bulk fetches",
 				slog.String("url", redactedURL),
 				slog.String("key", key),
 				slog.String("output", msg),
@@ -147,10 +147,12 @@ func markPromisorEntrySkipped(ctx context.Context, dir, url string) {
 	}
 }
 
-// gitConfigBool reads a local git config key and reports whether it is set to
-// a true value. Missing keys and read errors report false.
-func gitConfigBool(ctx context.Context, dir, key string) bool {
-	cmd := exec.CommandContext(ctx, "git", "config", "--local", "--get", "--type=bool", key)
+// gitRemoteSectionExists reports whether a remote.<url>.* config section already
+// exists in the local git config. Used to tell whether a filtered URL fetch is
+// about to create a new URL-keyed remote, so we only stamp remotes we create and
+// never rewrite ones the user already has.
+func gitRemoteSectionExists(ctx context.Context, dir, url string) bool {
+	cmd := exec.CommandContext(ctx, "git", "config", "--local", "--list")
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -158,7 +160,14 @@ func gitConfigBool(ctx context.Context, dir, key string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.TrimSpace(string(out)) == "true"
+	// git --list preserves subsection (the URL) case, so match it verbatim.
+	prefix := "remote." + url + "."
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // FetchBlobs fetches specific objects (typically blobs) by hash from a remote.

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -89,19 +89,20 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	// (remote.<url>.*) so it can lazy-fetch filtered-out objects later. That
 	// section also turns the URL into a phantom remote that `git fetch --all`
 	// and `git remote update` keep dialing. When this fetch is the one creating
-	// the section (it did not exist beforehand), stamp skipFetchAll/
-	// skipDefaultUpdate so bulk fetches skip our adhoc remote. Remotes that
-	// already existed are left untouched so we never rewrite the user's config.
+	// the section, stamp skipFetchAll/skipDefaultUpdate so bulk fetches skip our
+	// adhoc remote. Remotes that already existed are left untouched so we never
+	// rewrite the user's config.
 	var stampURL string
-	var stampNewRemote bool
+	var stampCandidate, existedBefore bool
 	if filtered && IsURL(opts.Remote) {
+		stampCandidate = true
 		stampURL = opts.Remote
 		if token := strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)); token != "" && isValidToken(token) {
 			// With a checkpoint token, newCommand rewrites SSH targets to HTTPS
 			// and git records the section under the rewritten URL.
 			stampURL, _ = resolveTargetForTokenAuth(ctx, stampURL)
 		}
-		stampNewRemote = !gitRemoteSectionExists(ctx, opts.Dir, stampURL)
+		existedBefore = gitRemoteSectionExists(ctx, opts.Dir, stampURL)
 	}
 
 	cmd := newCommand(ctx, args...)
@@ -110,11 +111,20 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	}
 	disableTerminalPrompt(cmd)
 	out, err := cmd.CombinedOutput()
+
+	// Stamp whenever this fetch newly created the section — even on a fetch
+	// error. Git writes remote.<url>.promisor eagerly during connection setup,
+	// so a failed filtered fetch still leaves the phantom remote behind; if we
+	// only stamped on success it would linger unstamped forever (the section
+	// then exists on the next attempt, so it never looks "new" again). Checking
+	// existence after the fetch keeps us from inventing a section when the fetch
+	// died before git wrote anything.
+	if stampCandidate && !existedBefore && gitRemoteSectionExists(ctx, opts.Dir, stampURL) {
+		markRemoteSkipped(ctx, opts.Dir, stampURL)
+	}
+
 	if err != nil {
 		return out, fmt.Errorf("git fetch: %w", err)
-	}
-	if stampNewRemote {
-		markRemoteSkipped(ctx, opts.Dir, stampURL)
 	}
 	return out, nil
 }
@@ -123,7 +133,8 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 // section so `git fetch --all` and `git remote update` skip it. Called only for
 // remotes this fetch just created, so an adhoc checkpoint URL never lingers as a
 // phantom remote that bulk fetches keep dialing.
-// Best-effort: the fetch already succeeded, so failures only log.
+// Best-effort: the git config write is not worth failing the fetch over, so
+// failures only log.
 func markRemoteSkipped(ctx context.Context, dir, url string) {
 	for _, key := range []string{"skipFetchAll", "skipDefaultUpdate"} {
 		fullKey := "remote." + url + "." + key

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -874,6 +874,58 @@ func TestFetch_FilteredURLFetchMarksNewRemoteSkipped(t *testing.T) {
 	runIsolatedGit(ctx, t, cloneDir, "fetch", "--all", "--no-auto-gc")
 }
 
+// TestFetch_FailedFilteredFetchStillStampsNewRemote guards the resume
+// regression: git writes remote.<url>.promisor eagerly during connection
+// setup, so a filtered fetch that then fails (e.g. a missing ref) still leaves
+// the phantom remote behind. The stamp must land anyway — otherwise the section
+// exists on the next attempt, never looks new again, and lingers unstamped.
+func TestFetch_FailedFilteredFetchStillStampsNewRemote(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	originBare := filepath.Join(tmpDir, "origin.git")
+	checkpointBare := filepath.Join(tmpDir, "checkpoints.git")
+	seedDir := filepath.Join(tmpDir, "seed")
+	cloneDir := filepath.Join(tmpDir, "clone")
+
+	testutil.InitRepo(t, seedDir)
+	testutil.WriteFile(t, seedDir, "f.txt", "init")
+	testutil.GitAdd(t, seedDir, "f.txt")
+	testutil.GitCommit(t, seedDir, "init")
+
+	runIsolatedGit(ctx, t, "", "init", "--bare", originBare)
+	runIsolatedGit(ctx, t, "", "init", "--bare", checkpointBare)
+	runIsolatedGit(ctx, t, checkpointBare, "config", "uploadpack.allowFilter", "true")
+	runIsolatedGit(ctx, t, seedDir, "push", originBare, "HEAD:refs/heads/main")
+	runIsolatedGit(ctx, t, "", "clone", "--branch", "main", "file://"+originBare, cloneDir)
+
+	testutil.WriteFile(
+		t,
+		cloneDir,
+		".entire/settings.json",
+		`{"enabled": true, "strategy_options": {"filtered_fetches": true}}`,
+	)
+	t.Chdir(cloneDir)
+
+	fetchURL := "file://" + checkpointBare
+	// Fetch a ref that does not exist on the checkpoint remote: the command
+	// fails, but git has already recorded the URL-keyed promisor section.
+	_, err := Fetch(ctx, FetchOptions{
+		Remote:   fetchURL,
+		RefSpecs: []string{"+refs/heads/does-not-exist:refs/entire-fetch-tmp/x"},
+		NoTags:   true,
+		Dir:      cloneDir,
+	})
+	require.Error(t, err, "fetch of a missing ref should fail")
+
+	require.True(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".promisor"),
+		"git records the promisor section even when the fetch fails")
+	assert.True(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipFetchAll"),
+		"a phantom remote left by a failed fetch must still be stamped")
+	assert.True(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipDefaultUpdate"),
+		"a phantom remote left by a failed fetch must still be stamped")
+}
+
 // TestFetch_UnfilteredFetchDoesNotCreateConfigSection verifies the stamp is
 // gated on a filtered fetch: a plain (unfiltered) URL fetch records no
 // URL-keyed section, so we must not invent a remote.<url> config section.

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -1054,3 +1054,48 @@ func TestGitRemoteSectionExists(t *testing.T) {
 	runIsolatedGit(ctx, t, repoDir, "config", "--local", "remote."+url+".promisor", "true")
 	assert.True(t, gitRemoteSectionExists(ctx, repoDir, url))
 }
+
+// TestGitRemoteSectionExists_ExactSubsectionMatch verifies the check compares
+// the whole URL subsection, not a prefix: a longer URL that shares a prefix
+// (e.g. ".../repo.git") must not make a shorter one (".../repo") look present.
+func TestGitRemoteSectionExists_ExactSubsectionMatch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+
+	const longURL = "https://example.com/org/repo.git"
+	const shortURL = "https://example.com/org/repo"
+	runIsolatedGit(ctx, t, repoDir, "config", "--local", "remote."+longURL+".promisor", "true")
+
+	assert.True(t, gitRemoteSectionExists(ctx, repoDir, longURL),
+		"the exact URL section is present")
+	assert.False(t, gitRemoteSectionExists(ctx, repoDir, shortURL),
+		"a prefix of an existing URL section must not count as present")
+}
+
+// TestStampNewlyCreatedRemote_StampsUnderCancelledContext guards the timed-out
+// fetch case: git records the promisor section before the fetch times out, so
+// the stamp must still land even though the fetch context is already cancelled.
+func TestStampNewlyCreatedRemote_StampsUnderCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+
+	const url = "https://example.com/org/checkpoints.git"
+	// Simulate git having recorded the promisor section during a fetch that
+	// then timed out.
+	runIsolatedGit(context.Background(), t, repoDir, "config", "--local", "remote."+url+".promisor", "true")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // parent context already done, as after a timed-out fetch
+
+	stampNewlyCreatedRemote(ctx, repoDir, url)
+
+	assert.True(t, gitConfigBool(context.Background(), repoDir, "remote."+url+".skipFetchAll"),
+		"stamp must land even though the parent context is cancelled")
+	assert.True(t, gitConfigBool(context.Background(), repoDir, "remote."+url+".skipDefaultUpdate"),
+		"stamp must land even though the parent context is cancelled")
+}

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -792,12 +792,26 @@ func envToMap(env []string) map[string]string {
 	return m
 }
 
-// TestFetch_FilteredURLFetchMarksPromisorSkipped verifies that after a
-// filtered fetch from a URL, the URL-keyed promisor config section git creates
-// is excluded from `git fetch --all` / `git remote update` — otherwise every
+// gitConfigBool reads a local git config key and reports whether it is set to a
+// true value. Missing keys and read errors report false.
+func gitConfigBool(ctx context.Context, dir, key string) bool {
+	cmd := exec.CommandContext(ctx, "git", "config", "--local", "--get", "--type=bool", key)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
+}
+
+// TestFetch_FilteredURLFetchMarksNewRemoteSkipped verifies that when a filtered
+// fetch from a URL creates a new URL-keyed remote section, that section is
+// excluded from `git fetch --all` / `git remote update` — otherwise every
 // checkpoint URL ever fetched from lingers as a phantom remote that bulk
 // fetches keep dialing.
-func TestFetch_FilteredURLFetchMarksPromisorSkipped(t *testing.T) {
+func TestFetch_FilteredURLFetchMarksNewRemoteSkipped(t *testing.T) {
 	ctx := context.Background()
 
 	tmpDir := t.TempDir()
@@ -861,8 +875,8 @@ func TestFetch_FilteredURLFetchMarksPromisorSkipped(t *testing.T) {
 }
 
 // TestFetch_UnfilteredFetchDoesNotCreateConfigSection verifies the stamp is
-// gated on git having created a promisor entry: a plain (unfiltered) URL fetch
-// must not invent a remote.<url> config section.
+// gated on a filtered fetch: a plain (unfiltered) URL fetch records no
+// URL-keyed section, so we must not invent a remote.<url> config section.
 func TestFetch_UnfilteredFetchDoesNotCreateConfigSection(t *testing.T) {
 	ctx := context.Background()
 
@@ -904,10 +918,63 @@ func TestFetch_UnfilteredFetchDoesNotCreateConfigSection(t *testing.T) {
 	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipDefaultUpdate"))
 }
 
-// TestMarkPromisorEntrySkipped_CompletesPartialStamp verifies the keys are
-// checked independently: an entry with skipFetchAll already set (e.g. an
-// earlier run failing between the two writes) still gets skipDefaultUpdate.
-func TestMarkPromisorEntrySkipped_CompletesPartialStamp(t *testing.T) {
+// TestFetch_ExistingURLRemoteNotReStamped verifies we only stamp remotes we
+// create: a filtered fetch from a URL that already has a remote.<url> section
+// must leave that section as-is rather than rewriting the user's git config.
+func TestFetch_ExistingURLRemoteNotReStamped(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	originBare := filepath.Join(tmpDir, "origin.git")
+	checkpointBare := filepath.Join(tmpDir, "checkpoints.git")
+	seedDir := filepath.Join(tmpDir, "seed")
+	cloneDir := filepath.Join(tmpDir, "clone")
+
+	testutil.InitRepo(t, seedDir)
+	testutil.WriteFile(t, seedDir, "f.txt", "init")
+	testutil.GitAdd(t, seedDir, "f.txt")
+	testutil.GitCommit(t, seedDir, "init")
+
+	runIsolatedGit(ctx, t, "", "init", "--bare", originBare)
+	runIsolatedGit(ctx, t, "", "init", "--bare", checkpointBare)
+	runIsolatedGit(ctx, t, checkpointBare, "config", "uploadpack.allowFilter", "true")
+	runIsolatedGit(ctx, t, seedDir, "push", originBare, "HEAD:refs/heads/main")
+	runIsolatedGit(ctx, t, "", "clone", "--branch", "main", "file://"+originBare, cloneDir)
+
+	testutil.WriteFile(t, seedDir, "f.txt", "init\nnext\n")
+	testutil.GitAdd(t, seedDir, "f.txt")
+	testutil.GitCommit(t, seedDir, "next")
+	runIsolatedGit(ctx, t, seedDir, "push", checkpointBare, "HEAD:refs/heads/main")
+
+	testutil.WriteFile(
+		t,
+		cloneDir,
+		".entire/settings.json",
+		`{"enabled": true, "strategy_options": {"filtered_fetches": true}}`,
+	)
+	t.Chdir(cloneDir)
+
+	fetchURL := "file://" + checkpointBare
+	// Simulate a pre-existing URL-keyed remote (e.g. a phantom left by an older
+	// CLI). Its presence means the section already exists before our fetch.
+	runIsolatedGit(ctx, t, cloneDir, "config", "--local", "remote."+fetchURL+".promisor", "true")
+
+	out, err := Fetch(ctx, FetchOptions{
+		Remote:   fetchURL,
+		RefSpecs: []string{"+refs/heads/main:refs/entire-fetch-tmp/main"},
+		NoTags:   true,
+		Dir:      cloneDir,
+	})
+	require.NoError(t, err, "fetch output: %s", out)
+
+	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipFetchAll"),
+		"a remote that already existed must not be stamped")
+	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipDefaultUpdate"),
+		"a remote that already existed must not be stamped")
+}
+
+// TestMarkRemoteSkipped_SetsBothKeys verifies the helper stamps both skip keys.
+func TestMarkRemoteSkipped_SetsBothKeys(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
@@ -915,12 +982,23 @@ func TestMarkPromisorEntrySkipped_CompletesPartialStamp(t *testing.T) {
 	testutil.InitRepo(t, repoDir)
 
 	const url = "https://example.com/org/checkpoints.git"
-	runIsolatedGit(ctx, t, repoDir, "config", "--local", "remote."+url+".promisor", "true")
-	runIsolatedGit(ctx, t, repoDir, "config", "--local", "remote."+url+".skipFetchAll", "true")
-
-	markPromisorEntrySkipped(ctx, repoDir, url)
+	markRemoteSkipped(ctx, repoDir, url)
 
 	assert.True(t, gitConfigBool(ctx, repoDir, "remote."+url+".skipFetchAll"))
-	assert.True(t, gitConfigBool(ctx, repoDir, "remote."+url+".skipDefaultUpdate"),
-		"partially-stamped entry should be completed")
+	assert.True(t, gitConfigBool(ctx, repoDir, "remote."+url+".skipDefaultUpdate"))
+}
+
+// TestGitRemoteSectionExists reports true only once a remote.<url>.* key is set.
+func TestGitRemoteSectionExists(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+
+	const url = "https://example.com/org/checkpoints.git"
+	assert.False(t, gitRemoteSectionExists(ctx, repoDir, url))
+
+	runIsolatedGit(ctx, t, repoDir, "config", "--local", "remote."+url+".promisor", "true")
+	assert.True(t, gitRemoteSectionExists(ctx, repoDir, url))
 }

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -864,8 +864,6 @@ func TestFetch_FilteredURLFetchMarksNewRemoteSkipped(t *testing.T) {
 
 	assert.True(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipFetchAll"),
 		"URL-keyed promisor entry should be excluded from git fetch --all")
-	assert.True(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipDefaultUpdate"),
-		"URL-keyed promisor entry should be excluded from git remote update")
 
 	// git fetch --all must no longer dial the phantom entry: with the
 	// checkpoint repo gone, --all only succeeds if the URL-keyed entry is
@@ -922,8 +920,6 @@ func TestFetch_FailedFilteredFetchStillStampsNewRemote(t *testing.T) {
 		"git records the promisor section even when the fetch fails")
 	assert.True(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipFetchAll"),
 		"a phantom remote left by a failed fetch must still be stamped")
-	assert.True(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipDefaultUpdate"),
-		"a phantom remote left by a failed fetch must still be stamped")
 }
 
 // TestFetch_UnfilteredFetchDoesNotCreateConfigSection verifies the stamp is
@@ -967,7 +963,6 @@ func TestFetch_UnfilteredFetchDoesNotCreateConfigSection(t *testing.T) {
 
 	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".promisor"))
 	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipFetchAll"))
-	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipDefaultUpdate"))
 }
 
 // TestFetch_ExistingURLRemoteNotReStamped verifies we only stamp remotes we
@@ -1021,12 +1016,10 @@ func TestFetch_ExistingURLRemoteNotReStamped(t *testing.T) {
 
 	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipFetchAll"),
 		"a remote that already existed must not be stamped")
-	assert.False(t, gitConfigBool(ctx, cloneDir, "remote."+fetchURL+".skipDefaultUpdate"),
-		"a remote that already existed must not be stamped")
 }
 
-// TestMarkRemoteSkipped_SetsBothKeys verifies the helper stamps both skip keys.
-func TestMarkRemoteSkipped_SetsBothKeys(t *testing.T) {
+// TestMarkRemoteSkipped_SetsSkipFetchAll verifies the helper stamps skipFetchAll.
+func TestMarkRemoteSkipped_SetsSkipFetchAll(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
@@ -1037,7 +1030,6 @@ func TestMarkRemoteSkipped_SetsBothKeys(t *testing.T) {
 	markRemoteSkipped(ctx, repoDir, url)
 
 	assert.True(t, gitConfigBool(ctx, repoDir, "remote."+url+".skipFetchAll"))
-	assert.True(t, gitConfigBool(ctx, repoDir, "remote."+url+".skipDefaultUpdate"))
 }
 
 // TestGitRemoteSectionExists reports true only once a remote.<url>.* key is set.
@@ -1095,7 +1087,5 @@ func TestStampNewlyCreatedRemote_StampsUnderCancelledContext(t *testing.T) {
 	stampNewlyCreatedRemote(ctx, repoDir, url)
 
 	assert.True(t, gitConfigBool(context.Background(), repoDir, "remote."+url+".skipFetchAll"),
-		"stamp must land even though the parent context is cancelled")
-	assert.True(t, gitConfigBool(context.Background(), repoDir, "remote."+url+".skipDefaultUpdate"),
 		"stamp must land even though the parent context is cancelled")
 }

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -313,16 +313,15 @@ func (env *TestEnv) gitConfigPath() string {
 var gitConfigGuardRepositoryFormatVersionRE = regexp.MustCompile(`(?m)^([ \t]*)repositoryformatversion = [01]$`)
 
 var gitConfigGuardTransportPromisorRemoteRE = regexp.MustCompile(
-	`(?m)^\[remote "(?:(?:https?|ssh|file)://|/|[A-Za-z]:[\\/]|[^"\n]+@[^"\n]+:[^"\n]+).+"\]\n(?:[ \t]+(?:promisor = true|partialclonefilter = blob:none|skipFetchAll = true|skipDefaultUpdate = true)\n?){2,4}`,
+	`(?m)^\[remote "(?:(?:https?|ssh|file)://|/|[A-Za-z]:[\\/]|[^"\n]+@[^"\n]+:[^"\n]+).+"\]\n(?:[ \t]+(?:promisor = true|partialclonefilter = blob:none|skipFetchAll = true)\n?){2,3}`,
 )
 
 func normalizeGitConfigForGuard(content string) string {
 	content = gitConfigGuardRepositoryFormatVersionRE.ReplaceAllString(content, `${1}repositoryformatversion = <normalized>`)
 	// Deliberately ignore only the URL-keyed remote sections written during
 	// filtered fetches: git's promisor+partialclonefilter pair plus the
-	// skipFetchAll/skipDefaultUpdate stamp the CLI adds so bulk fetches skip
-	// the entry. A section without the full promisor pair (or with any other
-	// key) still fails loudly.
+	// skipFetchAll stamp the CLI adds so bulk fetches skip the entry. A section
+	// without the full promisor pair (or with any other key) still fails loudly.
 	content = gitConfigGuardTransportPromisorRemoteRE.ReplaceAllStringFunc(content, func(section string) string {
 		if strings.Contains(section, "promisor = true") && strings.Contains(section, "partialclonefilter = blob:none") {
 			return ""


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/852
<!-- entire-trail-link-end -->

## What

Reworks how the CLI keeps filtered checkpoint fetches from cluttering the
user's git config with phantom remotes.

When `filtered_fetches` is enabled, checkpoint fetches run
`git fetch --filter=blob:none <url>`. Git records a URL-keyed
`remote.<url>.promisor` section so it can lazy-fetch filtered-out objects
later — but that section also turns the URL into a phantom remote that
`git fetch --all` / `git remote update` keep dialing. We stamp
`skipFetchAll`/`skipDefaultUpdate` on it so bulk fetches skip it.

Previously (#1733) we re-scanned and stamped **any** URL-keyed promisor
section on **every** filtered fetch, rewriting config for remotes we
didn't create. This changes it to stamp **only the section this fetch
creates**, leaving pre-existing remotes untouched so we never rewrite the
user's own git config.

## Changes

- Drop the promisor-key read; detect "did we just create this remote" by
  comparing `remote.<url>.*` section existence **before and after** the
  fetch.
- Stamp only when the section newly appeared, so remotes the user (or an
  older CLI) already had are left alone.
- Stamp **regardless of fetch success**: git writes the promisor section
  eagerly during connection setup, so a filtered fetch that later fails
  (e.g. a missing ref during `entire resume`) still leaves a phantom
  remote. The earlier draft returned early on error before stamping, and
  its "only if new" gate then made the miss permanent — the entry looked
  pre-existing on every retry and lingered unstamped forever. The
  post-fetch existence recheck also avoids inventing a section when the
  fetch dies before git writes anything.

## Why

- Avoid mutating config for remotes we didn't create.
- Keep adhoc checkpoint URL remotes out of the user's bulk-fetch surface
  without accumulating unstamped phantoms.

## Testing

- `TestFetch_FilteredURLFetchMarksNewRemoteSkipped` — new URL remote is
  stamped and excluded from `git fetch --all`.
- `TestFetch_FailedFilteredFetchStillStampsNewRemote` — a filtered fetch
  that fails after git records the promisor still gets stamped
  (regression test; verified it fails without the fix).
- `TestFetch_ExistingURLRemoteNotReStamped` — a pre-existing remote is
  left untouched.
- `TestFetch_UnfilteredFetchDoesNotCreateConfigSection`,
  `TestMarkRemoteSkipped_SetsBothKeys`, `TestGitRemoteSectionExists`.
- `mise run fmt` / `mise run lint` clean; package + integration
  config-guard tests pass.

## Note

Promisor entries created by an **older CLI version** are not back-filled
— by design, the CLI only stamps sections it creates itself, so it never
rewrites config the user already has. Cleaning up legacy unstamped
entries would be a separate change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how the CLI mutates local git config during checkpoint fetches; behavior is narrower and best-effort, but mistakes could leave phantom remotes or skip stamping in edge cases.
> 
> **Overview**
> Reworks how filtered checkpoint URL fetches avoid **phantom remotes** in local `.git/config`. Instead of re-stamping **every** URL-keyed promisor section on each successful filtered fetch, the CLI now records whether `remote.<url>.*` existed **before** the fetch and only stamps when that section is **newly created** by this fetch—so pre-existing user (or legacy) remotes are not rewritten.
> 
> Stamping runs **after the fetch attempt regardless of success** (still gated on “was new”), fixing cases where git writes the promisor section during connection setup but the fetch then fails or times out—previously an early return on error could leave an unstamped phantom forever. Config writes use a **detached context with a 10s timeout** so a cancelled fetch deadline does not skip the stamp. The stamp is narrowed to **`skipFetchAll` only** (no longer sets `skipDefaultUpdate`), with existence detected via **`gitRemoteSectionExists`** (exact URL subsection match).
> 
> Tests cover failed fetches, existing remotes left alone, cancelled-context stamping, and integration **git config guard** regex updates for the slimmer stamped section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740b7994bedfec52834196357e178dd07c6d3a19. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->