### PR TITLE
login: simplify WSL browser fallback to explorer.exe (alternative to part of #1708)

### DIFF
--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -595,21 +595,12 @@ func openBrowser(ctx context.Context, browserURL string) error {
 		return errors.New("browser unavailable under test")
 	}
 
-	command, args, dir, err := resolveBrowserLauncher(runtime.GOOS, isWSL(), exec.LookPath, browserURL)
+	command, args, err := resolveBrowserLauncher(runtime.GOOS, isWSL(), exec.LookPath, browserURL)
 	if err != nil {
 		return err
 	}
 
 	cmd := exec.CommandContext(ctx, command, args...)
-	// dir is set only for the WSL cmd.exe fallback, to keep cmd.exe from
-	// warning about the unsupported WSL (UNC) working directory. It's
-	// best-effort: a customized automount root means /mnt/c may not exist, and
-	// suppressing a cosmetic warning must not become a hard chdir failure.
-	if dir != "" {
-		if _, statErr := os.Stat(dir); statErr == nil {
-			cmd.Dir = dir
-		}
-	}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start browser command %q: %w", command, err)
 	}
@@ -631,24 +622,28 @@ func openBrowser(ctx context.Context, browserURL string) error {
 // both $BROWSER and the xdg default, so the user lands in a browser with none
 // of their sessions. So on WSL we open the Windows default browser directly
 // via wslview (from wslu, preinstalled on Ubuntu-on-WSL), falling back to
-// cmd.exe on stripped-down distros without it. The cmd.exe working directory
-// is a Windows path so cmd doesn't warn about the unsupported WSL (UNC) cwd.
-func resolveBrowserLauncher(goos string, wsl bool, lookPath func(string) (string, error), browserURL string) (command string, args []string, dir string, err error) {
+// explorer.exe on stripped-down distros without it. explorer.exe takes the
+// URL as a plain argument and hands it to the shell URL handler, so unlike
+// cmd.exe `start` it never reparses the command line (`&` in OAuth query
+// strings would split a cmd.exe line) and doesn't warn about the WSL (UNC)
+// working directory. Its exit code is meaningless (1 even on success), which
+// is fine here: openBrowser only checks that the process starts.
+func resolveBrowserLauncher(goos string, wsl bool, lookPath func(string) (string, error), browserURL string) (command string, args []string, err error) {
 	switch goos {
 	case "darwin":
-		return "open", []string{browserURL}, "", nil
+		return "open", []string{browserURL}, nil
 	case "windows":
-		return "cmd", []string{"/c", "start", "", browserURL}, "", nil
+		return "cmd", []string{"/c", "start", "", browserURL}, nil
 	case "linux":
 		if wsl {
 			if path, lerr := lookPath("wslview"); lerr == nil {
-				return path, []string{browserURL}, "", nil
+				return path, []string{browserURL}, nil
 			}
-			return "cmd.exe", []string{"/c", "start", "", browserURL}, "/mnt/c", nil
+			return "explorer.exe", []string{browserURL}, nil
 		}
-		return "xdg-open", []string{browserURL}, "", nil
+		return "xdg-open", []string{browserURL}, nil
 	default:
-		return "", nil, "", fmt.Errorf("unsupported platform %s", goos)
+		return "", nil, fmt.Errorf("unsupported platform %s", goos)
 	}
 }
 

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -330,7 +330,7 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 		fmt.Fprint(outW, "Waiting for sign-in... ")
 		code, err := flow.Wait(waitCtx)
 		if err != nil {
-			return browserWaitError(err, waitCtx, waitTimeout)
+			return browserWaitError(waitCtx, err, waitTimeout)
 		}
 		return exchangeAndPersist(ctx, outW, flow, baseURL, code)
 	}
@@ -359,7 +359,7 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 	case r := <-callbackCh:
 		cancel() // unblock the fallback waiter (closes /dev/tty)
 		if r.err != nil {
-			return browserWaitError(r.err, waitCtx, waitTimeout)
+			return browserWaitError(waitCtx, r.err, waitTimeout)
 		}
 		return exchangeAndPersist(ctx, outW, flow, baseURL, r.code)
 	case ferr := <-fallbackCh:
@@ -367,7 +367,17 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 		if ferr != nil {
 			// Not a real keypress — the waiter was cancelled (parent ctx or the
 			// backstop timeout), so surface that rather than falling back.
-			return browserWaitError(ferr, waitCtx, waitTimeout)
+			return browserWaitError(waitCtx, ferr, waitTimeout)
+		}
+		// The redirect may have already succeeded in the instant before Enter
+		// (a reflexive keypress on a working localhostForwarding setup). Prefer
+		// that buffered result over discarding a completed login.
+		select {
+		case r := <-callbackCh:
+			if r.err == nil {
+				return exchangeAndPersist(ctx, outW, flow, baseURL, r.code)
+			}
+		default:
 		}
 		fmt.Fprintln(outW)
 		return errBrowserFallbackRequested
@@ -376,7 +386,7 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 
 // browserWaitError maps a Wait/fallback error to the user-facing message,
 // distinguishing the backstop timeout from other failures.
-func browserWaitError(err error, waitCtx context.Context, waitTimeout time.Duration) error {
+func browserWaitError(waitCtx context.Context, err error, waitTimeout time.Duration) error {
 	if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
 		return fmt.Errorf("timed out waiting for sign-in after %v; run `entire login` again, or use `entire login --device`", waitTimeout)
 	}
@@ -592,8 +602,14 @@ func openBrowser(ctx context.Context, browserURL string) error {
 
 	cmd := exec.CommandContext(ctx, command, args...)
 	// dir is set only for the WSL cmd.exe fallback, to keep cmd.exe from
-	// warning about the unsupported WSL (UNC) working directory.
-	cmd.Dir = dir
+	// warning about the unsupported WSL (UNC) working directory. It's
+	// best-effort: a customized automount root means /mnt/c may not exist, and
+	// suppressing a cosmetic warning must not become a hard chdir failure.
+	if dir != "" {
+		if _, statErr := os.Stat(dir); statErr == nil {
+			cmd.Dir = dir
+		}
+	}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start browser command %q: %w", command, err)
 	}

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -100,6 +100,7 @@ func newLoginCmd() *cobra.Command {
 					useDevice:  useDevice,
 					canPrompt:  interactive.CanPromptInteractively(),
 					sshSession: isSSHSession(),
+					wsl:        isWSL(),
 				})
 		},
 	}
@@ -157,7 +158,7 @@ func requireSecureLoginServer(server string, insecureHTTPAuth bool) error {
 	return nil
 }
 
-func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc, canPrompt bool) error {
+func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc, canPrompt, autoOpen bool) error {
 	start, err := client.StartDeviceAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("start login: %w", err)
@@ -173,14 +174,20 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		// code is printed above regardless, so it's still available to confirm
 		// against the page (RFC 8628 §3.3.1) or to enter on the bare-URI fallback.
 		fmt.Fprintf(outW, "Login URL:   %s\n\n", approvalURL)
-		fmt.Fprintf(outW, "Press Enter to open in browser...")
 
-		// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
-		if err := waitForEnter(ctx); err != nil {
-			return fmt.Errorf("wait for input: %w", err)
+		// autoOpen skips the Enter prompt and opens straight away: it's set when
+		// arriving here from the WSL browser-loopback fallback, where the user
+		// has already pressed Enter to signal the redirect failed.
+		if !autoOpen {
+			fmt.Fprintf(outW, "Press Enter to open in browser...")
+
+			// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
+			if err := waitForEnter(ctx); err != nil {
+				return fmt.Errorf("wait for input: %w", err)
+			}
+			fmt.Fprintln(outW)
 		}
 
-		fmt.Fprintln(outW)
 		if err := openURL(ctx, approvalURL); err != nil {
 			fmt.Fprintf(errW, "Warning: failed to open browser: %v\n", err)
 			fmt.Fprintf(outW, "Open this URL in your browser to approve this login: %s\n", approvalURL)
@@ -206,6 +213,7 @@ type loginFlowFacts struct {
 	useDevice  bool // --device flag
 	canPrompt  bool // interactive terminal present
 	sshSession bool // running inside an SSH session
+	wsl        bool // running under WSL (Windows Subsystem for Linux)
 }
 
 // runLoginAuto picks between the browser (loopback authorization-code) and
@@ -224,9 +232,24 @@ func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient device
 			// exhausted ports); that shouldn't strand the user — warn and
 			// use the device flow instead.
 			fmt.Fprintf(errW, "Warning: could not start browser sign-in (%v); falling back to the device-code flow.\n", err)
-			return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt)
+			return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt, false)
 		}
-		return runBrowserLogin(ctx, outW, errW, flow, deviceClient.BaseURL(), openURL, browserLoginTimeout)
+		// Under WSL the Windows browser opened by openURL can't necessarily
+		// reach this WSL loopback listener (it depends on WSL2
+		// localhostForwarding), so arm the Enter-driven fallback that lets the
+		// user switch to the device-code flow when the redirect never arrives.
+		var waitFallback func(context.Context) error
+		if facts.wsl {
+			waitFallback = waitForEnter
+		}
+		err = runBrowserLogin(ctx, outW, errW, flow, deviceClient.BaseURL(), openURL, browserLoginTimeout, waitFallback)
+		if errors.Is(err, errBrowserFallbackRequested) {
+			fmt.Fprintln(errW, "Browser sign-in didn't complete; switching to code-based sign-in.")
+			// The user just signalled intent, so open the verification URL
+			// immediately instead of prompting for another Enter.
+			return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt, true)
+		}
+		return err
 	}
 	switch {
 	case facts.useDevice:
@@ -236,8 +259,13 @@ func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient device
 	case facts.sshSession:
 		fmt.Fprintln(errW, "SSH session detected; using device-code flow (a browser opened here couldn't reach this machine).")
 	}
-	return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt)
+	return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt, false)
 }
+
+// errBrowserFallbackRequested signals that the user, during the WSL
+// browser-loopback flow, pressed Enter to abandon the (unreachable) redirect
+// and switch to the device-code flow. It never escapes runLoginAuto.
+var errBrowserFallbackRequested = errors.New("browser login fallback requested")
 
 // shouldUseBrowserLogin reports whether `entire login` should use the
 // loopback authorization-code (browser) flow. The browser flow is the
@@ -264,7 +292,7 @@ func isSSHSession() bool {
 // wait up to waitTimeout for the redirect back to the local listener, then
 // exchange the code for tokens. Shares the token validation + persistence
 // tail with runLogin via persistLogin.
-func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuthFlow, baseURL string, openURL browserOpenFunc, waitTimeout time.Duration) error {
+func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuthFlow, baseURL string, openURL browserOpenFunc, waitTimeout time.Duration, waitFallback func(context.Context) error) error {
 	// Wait tears the listener down on return, but Close is idempotent and
 	// covers the error paths before Wait runs.
 	defer func() { _ = flow.Close() }()
@@ -293,26 +321,75 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 		fmt.Fprintf(outW, "Open this URL in your browser to sign in: %s\n", authURL)
 	}
 
-	fmt.Fprint(outW, "Waiting for sign-in... ")
-
 	// The clock starts here, after the Enter prompt, so time spent reading
 	// the prompt isn't counted against the sign-in itself.
 	waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
 	defer cancel()
 
-	code, err := flow.Wait(waitCtx)
-	if err != nil {
-		if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
-			return fmt.Errorf("timed out waiting for sign-in after %v; run `entire login` again, or use `entire login --device`", waitTimeout)
+	if waitFallback == nil {
+		fmt.Fprint(outW, "Waiting for sign-in... ")
+		code, err := flow.Wait(waitCtx)
+		if err != nil {
+			return browserWaitError(err, waitCtx, waitTimeout)
 		}
-		return fmt.Errorf("complete login: %w", err)
+		return exchangeAndPersist(ctx, outW, flow, baseURL, code)
 	}
 
+	// WSL: the Windows browser can't necessarily reach this WSL loopback
+	// listener (it depends on WSL2 localhostForwarding). Race the OAuth
+	// callback against an Enter keypress — the user presses Enter when the
+	// browser shows a "can't reach this page" error — and fall back to the
+	// device-code flow on Enter. Whichever fires first cancels the shared
+	// context, unblocking the loser (waitFallback closes /dev/tty on cancel).
+	fmt.Fprint(outW, "Waiting for sign-in... (press Enter if your browser shows a connection error) ")
+
+	type waitResult struct {
+		code string
+		err  error
+	}
+	callbackCh := make(chan waitResult, 1)
+	go func() {
+		code, err := flow.Wait(waitCtx)
+		callbackCh <- waitResult{code: code, err: err}
+	}()
+	fallbackCh := make(chan error, 1)
+	go func() { fallbackCh <- waitFallback(waitCtx) }()
+
+	select {
+	case r := <-callbackCh:
+		cancel() // unblock the fallback waiter (closes /dev/tty)
+		if r.err != nil {
+			return browserWaitError(r.err, waitCtx, waitTimeout)
+		}
+		return exchangeAndPersist(ctx, outW, flow, baseURL, r.code)
+	case ferr := <-fallbackCh:
+		cancel() // unblock flow.Wait
+		if ferr != nil {
+			// Not a real keypress — the waiter was cancelled (parent ctx or the
+			// backstop timeout), so surface that rather than falling back.
+			return browserWaitError(ferr, waitCtx, waitTimeout)
+		}
+		fmt.Fprintln(outW)
+		return errBrowserFallbackRequested
+	}
+}
+
+// browserWaitError maps a Wait/fallback error to the user-facing message,
+// distinguishing the backstop timeout from other failures.
+func browserWaitError(err error, waitCtx context.Context, waitTimeout time.Duration) error {
+	if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("timed out waiting for sign-in after %v; run `entire login` again, or use `entire login --device`", waitTimeout)
+	}
+	return fmt.Errorf("complete login: %w", err)
+}
+
+// exchangeAndPersist exchanges the authorization code for tokens and records
+// the login. Shared by the linear and WSL-fallback browser paths.
+func exchangeAndPersist(ctx context.Context, outW io.Writer, flow browserAuthFlow, baseURL, code string) error {
 	token, refreshToken, err := flow.Exchange(ctx, code)
 	if err != nil {
 		return fmt.Errorf("complete login: %w", err)
 	}
-
 	return persistLogin(outW, baseURL, token, refreshToken)
 }
 

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/entireio/auth-go/tokens"
@@ -507,24 +508,15 @@ func openBrowser(ctx context.Context, browserURL string) error {
 		return errors.New("browser unavailable under test")
 	}
 
-	var command string
-	var args []string
-
-	switch runtime.GOOS {
-	case "darwin":
-		command = "open"
-		args = []string{browserURL}
-	case "linux":
-		command = "xdg-open"
-		args = []string{browserURL}
-	case "windows":
-		command = "cmd"
-		args = []string{"/c", "start", "", browserURL}
-	default:
-		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	command, args, dir, err := resolveBrowserLauncher(runtime.GOOS, isWSL(), exec.LookPath, browserURL)
+	if err != nil {
+		return err
 	}
 
 	cmd := exec.CommandContext(ctx, command, args...)
+	// dir is set only for the WSL cmd.exe fallback, to keep cmd.exe from
+	// warning about the unsupported WSL (UNC) working directory.
+	cmd.Dir = dir
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start browser command %q: %w", command, err)
 	}
@@ -535,3 +527,59 @@ func openBrowser(ctx context.Context, browserURL string) error {
 
 	return nil
 }
+
+// resolveBrowserLauncher picks the command that opens browserURL, given the
+// OS, whether we're under WSL, and a PATH probe. It is pure so the platform
+// matrix is unit-testable without spawning anything; openBrowser wires in the
+// real runtime.GOOS, isWSL(), and exec.LookPath.
+//
+// Under WSL, xdg-open can't be trusted: with a Linux browser installed via
+// WSLg it resolves the https scheme handler to that Linux browser, ignoring
+// both $BROWSER and the xdg default, so the user lands in a browser with none
+// of their sessions. So on WSL we open the Windows default browser directly
+// via wslview (from wslu, preinstalled on Ubuntu-on-WSL), falling back to
+// cmd.exe on stripped-down distros without it. The cmd.exe working directory
+// is a Windows path so cmd doesn't warn about the unsupported WSL (UNC) cwd.
+func resolveBrowserLauncher(goos string, wsl bool, lookPath func(string) (string, error), browserURL string) (command string, args []string, dir string, err error) {
+	switch goos {
+	case "darwin":
+		return "open", []string{browserURL}, "", nil
+	case "windows":
+		return "cmd", []string{"/c", "start", "", browserURL}, "", nil
+	case "linux":
+		if wsl {
+			if path, lerr := lookPath("wslview"); lerr == nil {
+				return path, []string{browserURL}, "", nil
+			}
+			return "cmd.exe", []string{"/c", "start", "", browserURL}, "/mnt/c", nil
+		}
+		return "xdg-open", []string{browserURL}, "", nil
+	default:
+		return "", nil, "", fmt.Errorf("unsupported platform %s", goos)
+	}
+}
+
+// wslFromProcVersion reports whether a /proc/version string indicates WSL.
+// Both WSL1 ("...Microsoft...") and WSL2 ("...microsoft-standard-WSL2...")
+// carry the marker; the match is case-insensitive.
+func wslFromProcVersion(s string) bool {
+	return strings.Contains(strings.ToLower(s), "microsoft")
+}
+
+var wslDetect = sync.OnceValue(func() bool {
+	// Non-Linux hosts are never WSL, so /proc/version is only read on Linux.
+	// Detection keys on /proc/version rather than WSL_* env vars because those
+	// can be stripped when entire is spawned from a hook, service, or env -i —
+	// exactly the contexts the CLI must handle.
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	b, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return false
+	}
+	return wslFromProcVersion(string(b))
+})
+
+// isWSL reports whether we're running under WSL, reading /proc/version once.
+func isWSL() bool { return wslDetect() }

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -612,5 +613,75 @@ func TestRunBrowserLogin_ParentCancelNotReportedAsTimeout(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "timed out") {
 		t.Errorf("cancellation must not be reported as a timeout: %v", err)
+	}
+}
+
+func TestWSLFromProcVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"wsl2", "Linux version 6.18.33.2-microsoft-standard-WSL2 (root@f1bbfb02316b)", true},
+		{"wsl1", "Linux version 4.4.0-19041-Microsoft (build)", true},
+		{"plain-linux", "Linux version 6.8.0-generic (buildd@lcy02)", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		if got := wslFromProcVersion(tc.in); got != tc.want {
+			t.Errorf("wslFromProcVersion(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestResolveBrowserLauncher(t *testing.T) {
+	t.Parallel()
+
+	const browserURL = "https://auth.test/cli/auth?user_code=ABCD"
+	found := func(string) (string, error) { return "/usr/bin/wslview", nil }
+	missing := func(string) (string, error) { return "", errors.New("not found") }
+
+	cases := []struct {
+		name     string
+		goos     string
+		wsl      bool
+		look     func(string) (string, error)
+		wantCmd  string
+		wantArgs []string
+		wantDir  string
+		wantErr  bool
+	}{
+		{"darwin", "darwin", false, missing, "open", []string{browserURL}, "", false},
+		{"windows", "windows", false, missing, "cmd", []string{"/c", "start", "", browserURL}, "", false},
+		{"linux-non-wsl", "linux", false, found, "xdg-open", []string{browserURL}, "", false},
+		{"wsl-with-wslview", "linux", true, found, "/usr/bin/wslview", []string{browserURL}, "", false},
+		{"wsl-without-wslview", "linux", true, missing, "cmd.exe", []string{"/c", "start", "", browserURL}, "/mnt/c", false},
+		{"unsupported", "plan9", false, missing, "", nil, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd, args, dir, err := resolveBrowserLauncher(tc.goos, tc.wsl, tc.look, browserURL)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got cmd=%q", cmd)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cmd != tc.wantCmd {
+				t.Errorf("cmd = %q, want %q", cmd, tc.wantCmd)
+			}
+			if !reflect.DeepEqual(args, tc.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tc.wantArgs)
+			}
+			if dir != tc.wantDir {
+				t.Errorf("dir = %q, want %q", dir, tc.wantDir)
+			}
+		})
 	}
 }

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -508,7 +508,7 @@ func TestRunBrowserLogin_OpensAuthorizationURL(t *testing.T) {
 	// The stubbed Wait returns an error, so runBrowserLogin stops before
 	// persistLogin (which would hit the real keyring); we assert on the
 	// side effects up to that point.
-	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, flow, "https://auth.test", openURL, browserLoginTimeout); err == nil {
+	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, flow, "https://auth.test", openURL, browserLoginTimeout, nil); err == nil {
 		t.Fatal("expected error from stubbed Wait")
 	}
 
@@ -538,7 +538,7 @@ func TestRunBrowserLogin_OpenBrowserFallback(t *testing.T) {
 	failOpen := func(context.Context, string) error { return errors.New("no browser") }
 
 	var out, errW bytes.Buffer
-	if err := runBrowserLogin(context.Background(), &out, &errW, flow, "https://auth.test", failOpen, browserLoginTimeout); err == nil {
+	if err := runBrowserLogin(context.Background(), &out, &errW, flow, "https://auth.test", failOpen, browserLoginTimeout, nil); err == nil {
 		t.Fatal("expected error from stubbed Wait")
 	}
 
@@ -556,7 +556,7 @@ func TestRunBrowserLogin_WaitError(t *testing.T) {
 	denied := errors.New("access_denied")
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: denied}
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout, nil)
 	if !errors.Is(err, denied) {
 		t.Fatalf("err = %v, want wrapped %v", err, denied)
 	}
@@ -571,7 +571,7 @@ func TestRunBrowserLogin_ExchangeError(t *testing.T) {
 		exchErr:  errors.New("invalid_grant"),
 	}
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout, nil)
 	if err == nil || !strings.Contains(err.Error(), "complete login") {
 		t.Fatalf("err = %v, want complete login error", err)
 	}
@@ -587,7 +587,7 @@ func TestRunBrowserLogin_WaitTimeout(t *testing.T) {
 	// come from runBrowserLogin's own timeout, or this test would hang.
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, 50*time.Millisecond)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, 50*time.Millisecond, nil)
 	if err == nil || !strings.Contains(err.Error(), "timed out waiting for sign-in") {
 		t.Fatalf("err = %v, want sign-in timeout", err)
 	}
@@ -607,12 +607,110 @@ func TestRunBrowserLogin_ParentCancelNotReportedAsTimeout(t *testing.T) {
 
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
 
-	err := runBrowserLogin(ctx, &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, time.Minute)
+	err := runBrowserLogin(ctx, &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, time.Minute, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want wrapped context.Canceled", err)
 	}
 	if strings.Contains(err.Error(), "timed out") {
 		t.Errorf("cancellation must not be reported as a timeout: %v", err)
+	}
+}
+
+func TestRunBrowserLogin_WSLFallback_CallbackWins(t *testing.T) {
+	t.Parallel()
+
+	// Callback returns a code; Exchange errors so we stop before persistLogin
+	// (which would hit real storage). The fallback blocks until the shared
+	// context is cancelled, so the callback wins the race.
+	flow := &fakeBrowserFlow{
+		authURL:  "https://auth.test/authorize",
+		waitCode: "cb-code",
+		exchErr:  errors.New("exchange boom"),
+	}
+	blockingFallback := func(ctx context.Context) error { <-ctx.Done(); return ctx.Err() }
+
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow,
+		"https://auth.test", noopOpenURL, browserLoginTimeout, blockingFallback)
+
+	if errors.Is(err, errBrowserFallbackRequested) {
+		t.Fatalf("callback should win, got fallback: %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "complete login") {
+		t.Fatalf("err = %v, want 'complete login' from exchange error", err)
+	}
+	if flow.gotExchangeCode != "cb-code" {
+		t.Errorf("exchange code = %q, want cb-code (callback path taken)", flow.gotExchangeCode)
+	}
+	if !flow.closed {
+		t.Error("flow not closed")
+	}
+}
+
+func TestRunBrowserLogin_WSLFallback_EnterWins(t *testing.T) {
+	t.Parallel()
+
+	// flow.Wait blocks until ctx is done; the fallback returns immediately
+	// (as if the user pressed Enter), so the fallback wins.
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
+	enterNow := func(context.Context) error { return nil }
+
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow,
+		"https://auth.test", noopOpenURL, browserLoginTimeout, enterNow)
+
+	if !errors.Is(err, errBrowserFallbackRequested) {
+		t.Fatalf("err = %v, want errBrowserFallbackRequested", err)
+	}
+	if flow.gotExchangeCode != "" {
+		t.Errorf("exchange must not run on fallback, got code %q", flow.gotExchangeCode)
+	}
+	if !flow.closed {
+		t.Error("flow not closed")
+	}
+}
+
+func TestRunLoginAuto_WSL_FallbackToDevice(t *testing.T) {
+	t.Parallel()
+
+	// Under test the real waitForEnter (armed only for WSL) returns
+	// immediately, so the fallback fires and routes to the device flow. The
+	// browser flow's Wait blocks so the callback never pre-empts the fallback.
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
+	var browserCalls int
+	var errW bytes.Buffer
+
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
+		startBrowserStub(&browserCalls, flow, nil), noopOpenURL,
+		loginFlowFacts{canPrompt: true, wsl: true})
+
+	if browserCalls != 1 {
+		t.Errorf("startBrowser calls = %d, want 1 (WSL still tries the loopback flow first)", browserCalls)
+	}
+	if !strings.Contains(errW.String(), "switching to code-based sign-in") {
+		t.Errorf("stderr missing fallback message:\n%s", errW.String())
+	}
+	// mockClient.StartDeviceAuth errors — proof the device flow was attempted.
+	if err == nil || !strings.Contains(err.Error(), "not implemented in mock") {
+		t.Fatalf("err = %v, want device-flow start error from mock", err)
+	}
+	if !flow.closed {
+		t.Error("browser flow not closed before fallback")
+	}
+}
+
+func TestRunLoginAuto_NonWSL_NoFallbackArmed(t *testing.T) {
+	t.Parallel()
+
+	// Without wsl, the browser flow must NOT arm the Enter fallback: Wait's
+	// error surfaces directly as a 'complete login' failure, never a fallback.
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: errors.New("stop")}
+	var browserCalls int
+
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, &mockClient{},
+		startBrowserStub(&browserCalls, flow, nil), noopOpenURL,
+		loginFlowFacts{canPrompt: true})
+
+	if err == nil || !strings.Contains(err.Error(), "complete login") {
+		t.Fatalf("err = %v, want browser-flow 'complete login' error (no fallback)", err)
 	}
 }
 

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -748,20 +748,19 @@ func TestResolveBrowserLauncher(t *testing.T) {
 		look     func(string) (string, error)
 		wantCmd  string
 		wantArgs []string
-		wantDir  string
 		wantErr  bool
 	}{
-		{"darwin", "darwin", false, missing, "open", []string{browserURL}, "", false},
-		{"windows", "windows", false, missing, "cmd", []string{"/c", "start", "", browserURL}, "", false},
-		{"linux-non-wsl", "linux", false, found, "xdg-open", []string{browserURL}, "", false},
-		{"wsl-with-wslview", "linux", true, found, "/usr/bin/wslview", []string{browserURL}, "", false},
-		{"wsl-without-wslview", "linux", true, missing, "cmd.exe", []string{"/c", "start", "", browserURL}, "/mnt/c", false},
-		{"unsupported", "plan9", false, missing, "", nil, "", true},
+		{"darwin", "darwin", false, missing, "open", []string{browserURL}, false},
+		{"windows", "windows", false, missing, "cmd", []string{"/c", "start", "", browserURL}, false},
+		{"linux-non-wsl", "linux", false, found, "xdg-open", []string{browserURL}, false},
+		{"wsl-with-wslview", "linux", true, found, "/usr/bin/wslview", []string{browserURL}, false},
+		{"wsl-without-wslview", "linux", true, missing, "explorer.exe", []string{browserURL}, false},
+		{"unsupported", "plan9", false, missing, "", nil, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			cmd, args, dir, err := resolveBrowserLauncher(tc.goos, tc.wsl, tc.look, browserURL)
+			cmd, args, err := resolveBrowserLauncher(tc.goos, tc.wsl, tc.look, browserURL)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got cmd=%q", cmd)
@@ -776,9 +775,6 @@ func TestResolveBrowserLauncher(t *testing.T) {
 			}
 			if !reflect.DeepEqual(args, tc.wantArgs) {
 				t.Errorf("args = %v, want %v", args, tc.wantArgs)
-			}
-			if dir != tc.wantDir {
-				t.Errorf("dir = %q, want %q", dir, tc.wantDir)
 			}
 		})
 	}


### PR DESCRIPTION
**Draft proposal on top of #1708** — includes its commits (fork branch, so it can't be stacked as a base) plus one simplification commit: [`2c5b529`](https://github.com/entireio/cli/commit/2c5b529b1). Review only that last commit; the rest is #1708 unchanged.

## What

Replaces #1708's `cmd.exe /c start` + `/mnt/c` working-directory fallback (used on WSL when `wslview` is missing) with a bare `explorer.exe <url>`.

## Why

- **Fixes the `&` bug at the root.** `cmd.exe` reparses its command line, so the `&` separators in an OAuth authorization URL split it into multiple commands and open a truncated URL — WSL interop only quotes argv entries containing whitespace. `explorer.exe` takes the URL as a plain argument and hands it to the shell URL handler: no reparsing, no `^&` escaping.
- **Removes the `/mnt/c` workaround.** The UNC-cwd warning is cmd.exe-specific, so the `dir` return value, the `os.Stat` best-effort chdir, and the test-table column all go away (net −9 lines on top of #1708).
- **Same availability.** `explorer.exe` ships with every Windows install and is reached through the same PATH interop as `cmd.exe` — no new failure mode.

## Caveat

`explorer.exe` exits 1 even on success. Irrelevant today — `openBrowser` only checks `cmd.Start()` + `Process.Release()`, never the exit code — and the doc comment now records that invariant so a future `Wait` doesn't "fix" a phantom failure.

The native `windows` branch (`cmd /c start`) has the same latent `&` issue for multi-param URLs; left untouched here since it predates #1708 — separate PR if we want the same cure there.

## Testing

- `go test ./cmd/entire/cli/ -race` (login tests incl. launcher matrix, WSL fallback race) — pass
- `golangci-lint run ./cmd/entire/cli/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interactive auth flows and process spawning on WSL; mistakes could break login or open truncated OAuth URLs, though behavior is heavily unit-tested and non-WSL paths are largely unchanged.
> 
> **Overview**
> Improves **`entire login`** on WSL by detecting the environment via **`/proc/version`**, opening auth URLs in the **Windows** browser (`wslview` or **`explorer.exe`** instead of `xdg-open`), and adding an **Enter** escape hatch when the loopback redirect never reaches WSL.
> 
> When WSL is detected, browser sign-in **races** the OAuth callback against a second Enter press; abandoning the redirect switches to **device-code** sign-in and **auto-opens** the verification URL (no second prompt). Browser wait/exchange logic is refactored into **`browserWaitError`** and **`exchangeAndPersist`**.
> 
> **`resolveBrowserLauncher`** centralizes the OS matrix; without `wslview`, **`explorer.exe <url>`** replaces `cmd.exe /c start` so OAuth query strings with **`&`** are not reparsed and UNC-cwd workarounds are unnecessary. Tests cover WSL detection, launcher choice, and the callback-vs-Enter race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c5b529b10d91eb99f102e6d4efed8da590cf7c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->