### PR TITLE
fix(login): headless keyring hint, real-backend provenance, loose-permissions warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ With Entire, you can:
 - [Key Concepts](#key-concepts)
   - [How It Works](#how-it-works)
   - [Strategy](#strategy)
+- [Headless & CI Authentication](#headless--ci-authentication)
 - [Local Device Auth Testing](#local-device-auth-testing)
 - [Commands Reference](#commands-reference)
 - [Configuration](#configuration)
@@ -205,6 +206,44 @@ Entire works seamlessly with [git worktrees](https://git-scm.com/docs/git-worktr
 ### Concurrent Sessions
 
 Multiple AI sessions can run on the same commit. If you start a second session while another has uncommitted work, Entire warns you and tracks them separately. Both sessions' checkpoints are preserved and can be rewound independently.
+
+## Headless & CI Authentication
+
+By default `entire login` stores tokens in the OS keyring (macOS Keychain,
+Linux Secret Service, Windows Credential Manager). Machines without a usable
+keyring — headless servers, containers, minimal VMs, CI runners — have two
+supported paths:
+
+### Interactive login on a headless machine
+
+Use the file-backed token store. The device-auth flow already works without a
+local browser (the CLI prints an approval URL you can open on any machine);
+only token storage needs the override:
+
+```bash
+ENTIRE_TOKEN_STORE=file entire login
+```
+
+Tokens are written with `0600` permissions to `tokens.json` in your Entire
+config directory (`~/.config/entire` by default). Override the location with
+`ENTIRE_TOKEN_STORE_PATH`. Set `ENTIRE_TOKEN_STORE=file` persistently (e.g. in
+your shell profile) so later commands read from the same store.
+
+### Non-interactive automation (CI, workload identity)
+
+Skip login and storage entirely by injecting a token per invocation:
+
+```bash
+ENTIRE_TOKEN=<login-or-sa-session-JWT> entire ...
+```
+
+`ENTIRE_TOKEN` bypasses stored credentials; the CLI derives the control-plane
+endpoint from the token itself. Nothing is written to disk. This is the right
+path for CI pipelines and service accounts.
+
+> **Seeing `save login` / `failed to unlock correct collection` errors from
+> `entire login`?** That's the OS keyring being unavailable — use one of the
+> two paths above.
 
 ## Local Device Auth Testing
 

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/palette"
 	"github.com/entireio/cli/internal/coreapi"
 	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
 	"github.com/spf13/cobra"
 )
 
@@ -417,7 +418,7 @@ func runAuthStatus(ctx context.Context, w io.Writer, fetchProfile profileFetcher
 	if t.activeContext != "" {
 		writeAuthStatusLine(w, "Context:", t.activeContext)
 	}
-	writeAuthStatusLine(w, "Token:", "stored in OS keychain")
+	writeAuthStatusLine(w, "Token:", "stored in "+tokenstore.BackendDescription())
 
 	// Active sessions on this core. The token is already known good, so a
 	// listing failure is non-fatal — note it and carry on.

--- a/cmd/entire/cli/auth/contexts.go
+++ b/cmd/entire/cli/auth/contexts.go
@@ -20,6 +20,20 @@ import (
 // so a conservative non-zero value is enough to keep the entry usable.
 const defaultContextTokenTTL = time.Hour
 
+// ErrCredentialStoreWrite marks a failure writing tokens to the configured
+// credential backend (OS keyring or file store), as opposed to claim
+// validation or contexts.json failures. Login UX branches on it via
+// errors.Is to decide whether pointing the user at the file token store
+// would actually help.
+var ErrCredentialStoreWrite = errors.New("credential store write failed")
+
+// credStoreWriteError tags an underlying store error with
+// ErrCredentialStoreWrite without changing its message.
+type credStoreWriteError struct{ inner error }
+
+func (e *credStoreWriteError) Error() string   { return e.inner.Error() }
+func (e *credStoreWriteError) Unwrap() []error { return []error{e.inner, ErrCredentialStoreWrite} }
+
 // RecordLoginContext records a freshly obtained login token in the
 // shared contexts.json credential model: it derives the issuer (core
 // URL), handle, and expiry from the token's own claims, stores the token
@@ -82,7 +96,7 @@ func RecordLoginContext(rawToken, refreshToken string, activate bool) (string, e
 	refreshSlot := tokenstore.RefreshService(keychainService)
 	if refreshToken != "" {
 		if err := tokenstore.Set(refreshSlot, handle, refreshToken); err != nil {
-			return "", fmt.Errorf("store refresh token in keyring: %w", err)
+			return "", fmt.Errorf("store refresh token in credential store: %w", &credStoreWriteError{err})
 		}
 	} else {
 		_ = tokenstore.Delete(refreshSlot, handle) //nolint:errcheck // best-effort cleanup of a stale refresh token
@@ -90,7 +104,7 @@ func RecordLoginContext(rawToken, refreshToken string, activate bool) (string, e
 
 	encoded := tokenstore.EncodeTokenWithExpiration(rawToken, expiresIn)
 	if err := tokenstore.Set(keychainService, handle, encoded); err != nil {
-		return "", fmt.Errorf("store login token in keyring: %w", err)
+		return "", fmt.Errorf("store login token in credential store: %w", &credStoreWriteError{err})
 	}
 
 	var name string

--- a/cmd/entire/cli/auth_test.go
+++ b/cmd/entire/cli/auth_test.go
@@ -431,3 +431,28 @@ func TestAuthCmd_TopLevelLoginAndLogoutStillRegistered(t *testing.T) {
 		}
 	}
 }
+
+// The Token: provenance line must reflect the configured credential backend:
+// with ENTIRE_TOKEN_STORE=file the token lives in a JSON file, not the OS
+// keychain, and claiming otherwise misleads exactly the headless users the
+// file backend exists for (#1036).
+func TestRunAuthStatus_FileTokenStoreProvenance(t *testing.T) {
+	// Not parallel: t.Setenv.
+	t.Setenv("ENTIRE_TOKEN_STORE", "file")
+	t.Setenv("ENTIRE_TOKEN_STORE_PATH", "/ci/secrets/tokens.json")
+
+	target := statusTarget{coreURL: testCoreURL, token: "tok", activeContext: "core"}
+	listSessions := func(context.Context, string, string) ([]api.AuthSession, error) { return nil, nil }
+
+	var out bytes.Buffer
+	if err := runAuthStatus(context.Background(), &out, okProfile, listSessions, target); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "stored in file /ci/secrets/tokens.json") {
+		t.Fatalf("output = %q, want the file-backend provenance line", got)
+	}
+	if strings.Contains(got, "OS keychain") {
+		t.Fatalf("output = %q, must not claim the OS keychain when the file backend is configured", got)
+	}
+}

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -17,6 +17,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
 	"github.com/spf13/cobra"
 )
 
@@ -327,11 +328,26 @@ func persistLogin(outW io.Writer, baseURL, token, refreshToken string) error {
 	// single store every consumer (control plane, data API, git remote
 	// helper, entiredb's CLIs) resolves against.
 	if _, err := auth.RecordLoginContext(token, refreshToken, true); err != nil {
-		return fmt.Errorf("save login: %w", err)
+		return fmt.Errorf("save login: %w", withHeadlessStoreHint(err))
 	}
 
 	fmt.Fprintln(outW, "✓ Login complete.")
 	return nil
+}
+
+// withHeadlessStoreHint appends file-token-store guidance to a credential
+// store write failure. The default backend is the OS keyring, which locked
+// or keyring-less machines (CI, containers, minimal server VMs) can't use —
+// the raw store error gives those users no way forward (#1036). The hint is
+// skipped when ENTIRE_TOKEN_STORE=file is already set (suggesting it again
+// would be nonsense) and for failures the file store wouldn't help with.
+func withHeadlessStoreHint(err error) error {
+	if !errors.Is(err, auth.ErrCredentialStoreWrite) || tokenstore.FileBackendSelected() {
+		return err
+	}
+
+	return fmt.Errorf("%w\n\nIf this machine has no usable OS keyring (headless server, container, CI), store tokens in a file instead:\n\n  %s=file entire login\n\nTokens are then written with 0600 permissions to %s (override the location with %s)",
+		err, tokenstore.BackendEnvVar, tokenstore.FileBackendPath(), tokenstore.PathEnvVar)
 }
 
 // validateReceivedToken runs minimum-trust checks on the access token

--- a/cmd/entire/cli/login_headless_hint_test.go
+++ b/cmd/entire/cli/login_headless_hint_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+// failingTokenStore installs a backend whose Set always fails, standing in
+// for the locked/absent OS keyring a headless machine hits (#1036). Fault
+// injection (rather than filesystem permissions) keeps the failure
+// deterministic even when tests run as root, where permission bits don't
+// block writes.
+func failingTokenStore(t *testing.T) {
+	t.Helper()
+	restore := tokenstore.UseFailingBackendForTesting(
+		filepath.Join(t.TempDir(), "tokens.json"),
+		func(string, string) bool { return true },
+	)
+	t.Cleanup(restore)
+}
+
+// loginTestJWT builds a token that passes validateReceivedToken and carries
+// the iss/handle claims RecordLoginContext keys on.
+func loginTestJWT(t *testing.T, issuer string) string {
+	t.Helper()
+	exp := time.Now().Add(time.Hour).Unix()
+	return makeJWT(t, `{"alg":"RS256"}`, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, issuer, exp))
+}
+
+// A login that reaches token persistence and fails there must tell headless
+// users about the file token store: the default backend is the OS keyring,
+// and on keyring-less machines (CI, containers, minimal server VMs) the raw
+// store error gives no way forward (#1036). Both store-write sites are
+// covered: the refresh-token write (refreshToken != "") fails first when a
+// refresh token is present, and the login-token write is the first store
+// write when there is none.
+func TestPersistLogin_StoreWriteFailureIncludesHeadlessHint(t *testing.T) {
+	for name, refreshToken := range map[string]string{
+		"refresh-token write fails": "refresh-token",
+		"login-token write fails":   "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			// Not parallel: mutates the process-global tokenstore backend and
+			// env. TestMain sets ENTIRE_TOKEN_STORE=file process-wide for
+			// spawned-binary isolation; blank it so this test sees the
+			// default-keyring condition a real user hits.
+			t.Setenv("ENTIRE_TOKEN_STORE", "")
+			failingTokenStore(t)
+
+			var out bytes.Buffer
+			err := persistLogin(&out, "https://example.test", loginTestJWT(t, "https://example.test"), refreshToken)
+			if err == nil {
+				t.Fatal("persistLogin should fail when the token store rejects writes")
+			}
+			if !strings.Contains(err.Error(), "ENTIRE_TOKEN_STORE=file") {
+				t.Fatalf("store-write failure should point headless users at the file token store, got:\n%v", err)
+			}
+			if !strings.Contains(err.Error(), "ENTIRE_TOKEN_STORE_PATH") {
+				t.Fatalf("hint should mention the path override, got:\n%v", err)
+			}
+		})
+	}
+}
+
+// When the user is already on the file backend, suggesting
+// ENTIRE_TOKEN_STORE=file would be nonsense — the raw error must pass
+// through without the headless hint.
+func TestPersistLogin_StoreWriteFailureOnFileBackend_NoHint(t *testing.T) {
+	// Not parallel: mutates the process-global tokenstore backend and env.
+	t.Setenv("ENTIRE_TOKEN_STORE", "file")
+	failingTokenStore(t)
+
+	var out bytes.Buffer
+	err := persistLogin(&out, "https://example.test", loginTestJWT(t, "https://example.test"), "refresh-token")
+	if err == nil {
+		t.Fatal("persistLogin should fail when the token store rejects writes")
+	}
+	// Assert on the hint's structural markers, not its prose: the underlying
+	// store error can never contain these, so the assertion stays meaningful
+	// if the hint wording changes.
+	if strings.Contains(err.Error(), "=file entire login") || strings.Contains(err.Error(), "ENTIRE_TOKEN_STORE_PATH") {
+		t.Fatalf("hint must not appear when the file backend is already configured, got:\n%v", err)
+	}
+	if !strings.Contains(err.Error(), "save login") {
+		t.Fatalf("underlying save failure should still surface, got:\n%v", err)
+	}
+}
+
+// Failures unrelated to the credential store (here: a token whose issuer
+// doesn't match the login server) must not carry the keyring hint — the
+// file store wouldn't help.
+func TestPersistLogin_NonStoreFailure_NoHint(t *testing.T) {
+	// Not parallel: mutates process-global env.
+	t.Setenv("ENTIRE_TOKEN_STORE", "")
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(time.Hour).Unix()
+	// iss mismatch with baseURL fails validateReceivedToken before any store write.
+	token := makeJWT(t, `{"alg":"RS256"}`, fmt.Sprintf(`{"iss":"https://other.test","handle":"alice","exp":%d}`, exp))
+
+	var out bytes.Buffer
+	err := persistLogin(&out, "https://example.test", token, "refresh-token")
+	if err == nil {
+		t.Fatal("persistLogin should reject a token from the wrong issuer")
+	}
+	if strings.Contains(err.Error(), "ENTIRE_TOKEN_STORE") {
+		t.Fatalf("non-store failure must not carry the token-store hint, got:\n%v", err)
+	}
+}

--- a/internal/entireclient/tokenstore/file.go
+++ b/internal/entireclient/tokenstore/file.go
@@ -30,9 +30,11 @@ type fileStore struct {
 	path string
 	mu   sync.Mutex
 	// warnedLoosePerms dedupes the loose-permissions warning to once per
-	// store instance. Like the rest of the store's state it relies on mu,
-	// which every production caller of load (Get/Set/Delete) holds; tests
-	// that call load directly are single-goroutine.
+	// store instance — effectively once per CLI invocation, since
+	// currentBackend caches a single fileStore for the process. Like the
+	// rest of the store's state it relies on mu, which every production
+	// caller of load (Get/Set/Delete) holds; tests that call load directly
+	// are single-goroutine.
 	warnedLoosePerms bool
 }
 

--- a/internal/entireclient/tokenstore/file.go
+++ b/internal/entireclient/tokenstore/file.go
@@ -30,7 +30,9 @@ type fileStore struct {
 	path string
 	mu   sync.Mutex
 	// warnedLoosePerms dedupes the loose-permissions warning to once per
-	// store instance (guarded by mu, which every caller of load holds).
+	// store instance. Like the rest of the store's state it relies on mu,
+	// which every production caller of load (Get/Set/Delete) holds; tests
+	// that call load directly are single-goroutine.
 	warnedLoosePerms bool
 }
 

--- a/internal/entireclient/tokenstore/file.go
+++ b/internal/entireclient/tokenstore/file.go
@@ -5,19 +5,33 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
 	"github.com/gofrs/flock"
 )
 
+// goosWindows is runtime.GOOS on Windows, where unix permission bits don't
+// exist (Go reports synthetic modes) so permission checks are skipped.
+const goosWindows = "windows"
+
+// loosePermsWarnW receives the loose-permissions warning. Package-level so
+// tests can capture it; production always writes to stderr (matching the
+// unlock warning in withFileLock).
+var loosePermsWarnW io.Writer = os.Stderr
+
 // fileStore persists credentials as a JSON file on disk.
 // The file format is: { "service": { "user": "password" } }
 type fileStore struct {
 	path string
 	mu   sync.Mutex
+	// warnedLoosePerms dedupes the loose-permissions warning to once per
+	// store instance (guarded by mu, which every caller of load holds).
+	warnedLoosePerms bool
 }
 
 // withFileLock runs fn while holding an exclusive flock on f.path + ".lock".
@@ -48,6 +62,21 @@ func (f *fileStore) withFileLock(fn func() error) error {
 }
 
 func (f *fileStore) load() (map[string]map[string]string, error) {
+	// The file holds bearer tokens; warn (once per store) when it is
+	// readable or writable by group/others. Deliberately a warning, not a
+	// refusal: externally provisioned files (CI secret mounts, read-only
+	// volumes) often carry modes the user cannot change, a hard refusal
+	// would also block the login rewrite that restores 0600, and diagnostic
+	// commands must keep working so the user can see their auth state.
+	// Files written by save() are always 0600, so this only fires on files
+	// created or chmod-ed outside this store. Windows has no unix permission
+	// bits — Go reports synthetic modes there — so the check is unix-only.
+	if runtime.GOOS != goosWindows && !f.warnedLoosePerms {
+		if info, statErr := os.Stat(f.path); statErr == nil && info.Mode().Perm()&0o077 != 0 {
+			f.warnedLoosePerms = true
+			fmt.Fprintf(loosePermsWarnW, "Warning: token store %s is accessible by group/others (mode %04o) and holds bearer tokens; run: chmod 0600 %s\n", f.path, info.Mode().Perm(), f.path)
+		}
+	}
 	data, err := os.ReadFile(f.path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/entireclient/tokenstore/file_test.go
+++ b/internal/entireclient/tokenstore/file_test.go
@@ -398,3 +398,14 @@ func TestFileBackendPath_DefaultsToConfigDirTokensJSON(t *testing.T) {
 		t.Fatalf("FileBackendPath() = %q, want %q", got, want)
 	}
 }
+
+// The warning's production destination is stderr. Pinned because every other
+// warning test swaps the writer via captureLoosePermsWarnings — without this,
+// changing the default to io.Discard would silently delete the feature in
+// production while the whole suite stays green (verified by mutation).
+// Not parallel: reads the package-global writer that other tests swap.
+func TestLoosePermsWarnWriter_DefaultsToStderr(t *testing.T) {
+	if loosePermsWarnW != os.Stderr {
+		t.Fatalf("loosePermsWarnW default = %T, want os.Stderr", loosePermsWarnW)
+	}
+}

--- a/internal/entireclient/tokenstore/file_test.go
+++ b/internal/entireclient/tokenstore/file_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -235,5 +237,164 @@ func TestFileStore_FilePermissions(t *testing.T) {
 	perm := info.Mode().Perm()
 	if perm != 0600 {
 		t.Fatalf("file permissions = %o, want 0600", perm)
+	}
+}
+
+// looseStoreFile creates a store file and then chmods it explicitly —
+// os.WriteFile's mode is masked by the process umask (a hardened umask like
+// 077 would silently produce 0600), while chmod is not.
+func looseStoreFile(t *testing.T, s *fileStore, perm os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(s.path, []byte(`{"svc":{"alice":"tokval"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(s.path, perm); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// captureLoosePermsWarnings redirects the loose-permissions warning writer
+// to a buffer for the duration of the test. Tests using it must not be
+// parallel (package-global writer).
+func captureLoosePermsWarnings(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	prev := loosePermsWarnW
+	loosePermsWarnW = &buf
+	t.Cleanup(func() { loosePermsWarnW = prev })
+	return &buf
+}
+
+// The store file holds bearer tokens: a group/other-accessible file draws a
+// warning naming the file and the chmod remediation, but operations still
+// work. Deliberately not a refusal — externally provisioned files (CI secret
+// mounts, read-only volumes) can carry modes the user cannot change, and a
+// hard failure would also block the login rewrite that restores 0600.
+func TestFileStore_WarnsOnLoosePermissionsButWorks(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("unix permission semantics")
+	}
+	for name, perm := range map[string]os.FileMode{
+		"group-readable": 0o640,
+		"world-readable": 0o604,
+		"group-writable": 0o620,
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := newTestStore(t)
+			looseStoreFile(t, s, perm)
+			warnings := captureLoosePermsWarnings(t)
+
+			got, err := s.Get("svc", "alice")
+			if err != nil {
+				t.Fatalf("Get on a %s file must still work, got error: %v", name, err)
+			}
+			if got != "tokval" {
+				t.Fatalf("Get = %q, want %q", got, "tokval")
+			}
+			warned := warnings.String()
+			if !strings.Contains(warned, "chmod 0600") || !strings.Contains(warned, s.path) {
+				t.Fatalf("warning should name the file and the chmod remediation, got: %q", warned)
+			}
+		})
+	}
+}
+
+// Set must also warn on (and still repair) a loose file: login's rewrite is
+// exactly how a loose store gets restored to 0600.
+func TestFileStore_SetOnLooseFileWarnsAndRestores0600(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("unix permission semantics")
+	}
+	s := newTestStore(t)
+	looseStoreFile(t, s, 0o644)
+	warnings := captureLoosePermsWarnings(t)
+
+	if err := s.Set("svc", "alice", "fresh"); err != nil {
+		t.Fatalf("Set on a loose file must still work, got: %v", err)
+	}
+	if !strings.Contains(warnings.String(), "chmod 0600") {
+		t.Fatalf("Set should emit the loose-permissions warning, got: %q", warnings.String())
+	}
+	info, err := os.Stat(s.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("save must restore 0600 on rewrite, got %04o", perm)
+	}
+}
+
+// The warning is emitted once per store instance, not once per operation.
+func TestFileStore_LoosePermissionWarningIsDeduped(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("unix permission semantics")
+	}
+	s := newTestStore(t)
+	looseStoreFile(t, s, 0o640)
+	warnings := captureLoosePermsWarnings(t)
+
+	for range 3 {
+		if _, err := s.Get("svc", "alice"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if n := strings.Count(warnings.String(), "chmod 0600"); n != 1 {
+		t.Fatalf("warning should be emitted once, got %d occurrences:\n%s", n, warnings.String())
+	}
+}
+
+// A correctly-permissioned file draws no warning.
+func TestFileStore_Reads0600FileWithoutWarning(t *testing.T) {
+	s := newTestStore(t)
+	if err := os.WriteFile(s.path, []byte(`{"svc":{"alice":"tokval"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(s.path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	warnings := captureLoosePermsWarnings(t)
+	got, err := s.Get("svc", "alice")
+	if err != nil {
+		t.Fatalf("Get on a 0600 file should succeed, got: %v", err)
+	}
+	if got != "tokval" {
+		t.Fatalf("Get = %q, want %q", got, "tokval")
+	}
+	if warnings.Len() != 0 {
+		t.Fatalf("no warning expected for a 0600 file, got: %q", warnings.String())
+	}
+}
+
+// BackendDescription pins: user-facing provenance wording must track the env
+// the way resolveBackendLocked does. Not parallel: t.Setenv.
+func TestBackendDescription_Keyring(t *testing.T) {
+	t.Setenv(BackendEnvVar, "")
+	got := BackendDescription()
+	if got != keyringProviderName() {
+		t.Fatalf("BackendDescription() = %q, want the per-OS keyring name %q", got, keyringProviderName())
+	}
+	if strings.HasPrefix(got, "file ") {
+		t.Fatalf("BackendDescription() = %q, must not claim the file backend when env is unset", got)
+	}
+}
+
+func TestBackendDescription_FileWithExplicitPath(t *testing.T) {
+	t.Setenv(BackendEnvVar, "file")
+	t.Setenv(PathEnvVar, "/ci/secrets/tokens.json")
+	if got := BackendDescription(); got != "file /ci/secrets/tokens.json" {
+		t.Fatalf("BackendDescription() = %q, want %q", got, "file /ci/secrets/tokens.json")
+	}
+}
+
+// The default file location is tokens.json in the per-user config dir — this
+// is production routing (resolveBackendLocked uses the same helper), so a
+// typo'd default would relocate real users' token files.
+func TestFileBackendPath_DefaultsToConfigDirTokensJSON(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv(PathEnvVar, "")
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	want := filepath.Join(cfgDir, "tokens.json")
+	if got := FileBackendPath(); got != want {
+		t.Fatalf("FileBackendPath() = %q, want %q", got, want)
 	}
 }

--- a/internal/entireclient/tokenstore/keyring_timeout.go
+++ b/internal/entireclient/tokenstore/keyring_timeout.go
@@ -117,7 +117,7 @@ func keyringProviderName() string {
 	switch runtime.GOOS {
 	case "darwin":
 		return "macOS Keychain"
-	case "windows":
+	case goosWindows:
 		return "Windows Credential Manager"
 	case "linux", "freebsd", "openbsd", "netbsd", "dragonfly":
 		return "Secret Service (D-Bus)"

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -100,13 +100,48 @@ func currentBackend() store {
 	return backend
 }
 
+// BackendEnvVar selects the credential backend: set to "file" to use the
+// JSON file store instead of the OS keyring. PathEnvVar overrides where the
+// file store lives (default: tokens.json in the per-user config directory).
+// Exported so user-facing guidance (e.g. login's headless hint) names the
+// same variables this package actually reads.
+const (
+	BackendEnvVar = "ENTIRE_TOKEN_STORE"
+	PathEnvVar    = "ENTIRE_TOKEN_STORE_PATH"
+)
+
+// FileBackendSelected reports whether the environment selects the file
+// backend — the single predicate shared by backend resolution, provenance
+// wording, and login's headless hint, so they can never disagree.
+func FileBackendSelected() bool {
+	return os.Getenv(BackendEnvVar) == "file"
+}
+
+// BackendDescription names the credential backend the current environment
+// resolves to, for user-facing provenance lines (e.g. `entire auth status`).
+// It mirrors resolveBackendLocked's env semantics — the production resolution
+// — rather than introspecting the live backend, so test-only overrides don't
+// leak into user-facing wording.
+func BackendDescription() string {
+	if FileBackendSelected() {
+		return "file " + FileBackendPath()
+	}
+	return keyringProviderName()
+}
+
+// FileBackendPath resolves where the file backend stores (or would store)
+// tokens: PathEnvVar when set, else tokens.json in the per-user config
+// directory. Exported so user-facing guidance can name the concrete path.
+func FileBackendPath() string {
+	if path := os.Getenv(PathEnvVar); path != "" {
+		return path
+	}
+	return filepath.Join(userdirs.Config(), "tokens.json")
+}
+
 func resolveBackendLocked() store {
-	if os.Getenv("ENTIRE_TOKEN_STORE") == "file" {
-		path := os.Getenv("ENTIRE_TOKEN_STORE_PATH")
-		if path == "" {
-			path = filepath.Join(userdirs.Config(), "tokens.json")
-		}
-		return &fileStore{path: path}
+	if FileBackendSelected() {
+		return &fileStore{path: FileBackendPath()}
 	}
 	// Under `go test`, never fall through to the real OS keyring: a test
 	// that forgets tokenstore.UseFileBackendForTesting would otherwise write


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/855
<!-- entire-trail-link-end -->

## What

Closes the residual gap in #1036. The headless-auth mechanisms (`ENTIRE_TOKEN_STORE=file`, `ENTIRE_TOKEN`) already exist on main — but they were undiscoverable exactly when needed:

- **`entire login` on a keyring-less machine** (headless server, container, CI) failed with a raw store error and no way forward. It now appends guidance naming `ENTIRE_TOKEN_STORE=file` and the concrete token path. Detection is sentinel-based (`auth.ErrCredentialStoreWrite` tagged at the two `tokenstore.Set` sites in `RecordLoginContext`), never error-string matching, and the hint is suppressed when the file backend is already selected or the failure isn't store-related.
- **`entire auth status`** hardcoded "stored in OS keychain" regardless of backend. It now reports the resolved backend via `tokenstore.BackendDescription()` — the file path, or the per-OS keyring name.
- **The file token store warns** (once per process, stderr) when the store file is group/other-accessible, naming the file, mode, and the `chmod 0600` remediation.
- **README**: new "Headless & CI Authentication" section documenting both supported paths — file-backed interactive login and `ENTIRE_TOKEN` injection for CI/workload identity — previously documented only in an `internal/` package comment.

## Design decision: warn, don't refuse

The permission check was first implemented as a hard refusal (SSH-style). Adversarial review confirmed three breakages: externally provisioned files with unfixable modes (CI secret mounts, read-only volumes) would lock the CLI out entirely, a refusal blocks the login rewrite that restores 0600, and `git-remote-entire` would silently degrade. As a warning, every flow keeps working, the exposure is surfaced on any command touching the store, and a fresh `entire login` self-heals the file back to 0600 — verified end-to-end with a real device-flow login through the file backend over a deliberately loose 0644 file.

## User-visible changes to be aware of

- New stderr warning per invocation while a store file stays loose (by design — actionable and persistent).
- Error wording `store ... token in keyring` → `in credential store` (the failing backend may be the file store); external scripts matching the old phrase would need updating. The inner keyring error text is unchanged.
- `auth status` Token line wording changed as above.

## Testing

- TDD throughout: every behavior red-first. Fault injection uses the existing `UseFailingBackendForTesting` (deterministic under root); loose-permission fixtures chmod explicitly (immune to hardened umask).
- Mutation-hardened after review: both store-write sites, both `BackendDescription` branches, the default token path, the `0o077` write-bit half, `Set`-on-loose-file warn-and-repair, and warning dedup are all pinned.
- `mise run test:ci` (unit + integration + canary) green; lint clean.
- Live validation: real device-flow login through the file backend — warning fired mid-flow on the 0644 file, login succeeded, file self-healed to 0600, `auth status` showed the file provenance.

Fixes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX, documentation, and non-blocking security warnings on credential storage; no changes to auth protocol or token validation logic.
> 
> **Overview**
> Improves **discoverability and honesty** for headless/CI auth (#1036): mechanisms like `ENTIRE_TOKEN_STORE=file` and `ENTIRE_TOKEN` already existed but were easy to miss when login or status failed.
> 
> **`entire login`** now appends actionable guidance when token persistence fails on the default OS keyring—naming `ENTIRE_TOKEN_STORE=file`, the default `tokens.json` path, and `ENTIRE_TOKEN_STORE_PATH`. Detection uses `auth.ErrCredentialStoreWrite` at the two `tokenstore.Set` sites in `RecordLoginContext`, not string matching; the hint is skipped when the file backend is already selected or the error isn’t a store write.
> 
> **`entire auth status`** no longer hardcodes “stored in OS keychain”; the Token line uses `tokenstore.BackendDescription()` (per-OS keyring name or `file <path>`).
> 
> The **file token store** emits a **once-per-process** stderr warning when `tokens.json` is group/other-accessible (unix only), with `chmod 0600` remediation; operations still succeed so CI mounts and login rewrites can restore `0600`.
> 
> **README** adds a **Headless & CI Authentication** section (file-backed login vs `ENTIRE_TOKEN`). User-facing store errors say “credential store” instead of “keyring.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13e379e4b655b361ca6428dccc76e27b64e9d7a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->