### PR TITLE
fix(redact): reconcile layer-count vocabulary and pin provider-token boundaries

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint_test.go
+++ b/cmd/entire/cli/checkpoint/checkpoint_test.go
@@ -4695,7 +4695,7 @@ func TestCheckpointSummary_HasReview(t *testing.T) {
 // Summary.Intent and ReviewPrompt that previously bypassed redaction because
 // the dispatcher only matched .jsonl. The PR 1236 fix extended the JSON-aware
 // branch to .json. We assert via a low-entropy AWS-key shaped secret (catches
-// the 7-layer pipeline) so the test stays deterministic without the OPF binary.
+// the regex-only pipeline) so the test stays deterministic without the OPF binary.
 func TestRedactBlobBytes_JSONMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -448,7 +448,7 @@ func (s *treeWriter) applyTranscriptBackfill(ctx context.Context, opts UpdateOpt
 		}
 	}
 
-	// Replace prompts with 7-layer-redacted content.
+	// Replace prompts with regex-only-redacted content.
 	if len(opts.Prompts) > 0 {
 		promptContent := RedactedJoinedPrompts(opts.Prompts)
 		blobHash, err := CreateBlobFromContent(s.repo, []byte(promptContent))
@@ -715,7 +715,7 @@ func (s *treeWriter) writeSessionToSubdirectory(ctx context.Context, opts WriteO
 	}
 	filePaths.AssetsManifest = manifestPath
 
-	// Write prompts via the 7-layer pipeline. OPF runs only in the
+	// Write prompts via the regex-only pipeline. OPF runs only in the
 	// pre-push rewrite path (manual_commit_opf_rewrite.go).
 	if len(opts.Prompts) > 0 {
 		promptContent := RedactedJoinedPrompts(opts.Prompts)
@@ -2254,12 +2254,13 @@ func (s *treeWriter) copyMetadataDir(ctx context.Context, metadataDir, sessionDi
 			return fmt.Errorf("path traversal detected: %s", relPath)
 		}
 
-		// Create blob from file with 7-layer secrets redaction.
-		// Post-commit emits 7-layer-only blobs; the pre-push rewrite
+		// Create blob from file with regex-only secrets redaction (the
+		// eight always-on/opt-in layers).
+		// Post-commit emits regex-only blobs; the pre-push rewrite
 		// (strategy/manual_commit_opf_rewrite.go) walks the resulting
 		// tree, re-redacts these blobs with OPF when enabled, and
-		// rewrites entire/checkpoints/v1 into 8-layer commits before
-		// they leave the local machine.
+		// rewrites entire/checkpoints/v1 into OPF-applied (9-layer)
+		// commits before they leave the local machine.
 		blobHash, mode, err := createRedactedBlobFromFile(ctx, s.repo, path, relPath)
 		if err != nil {
 			return fmt.Errorf("failed to create blob for %s: %w", path, err)
@@ -2281,12 +2282,13 @@ func (s *treeWriter) copyMetadataDir(ctx context.Context, metadataDir, sessionDi
 	return nil
 }
 
-// createRedactedBlobFromFile reads a file, applies the 7-layer redaction
-// pipeline, and creates a git blob. Used by committed-checkpoint writes
-// at post-commit time. The OpenAI Privacy Filter is intentionally NOT
-// run here — OPF lives in the pre-push rewrite path
-// (strategy/manual_commit_opf_rewrite.go), which re-redacts the 7-layer
-// blobs into 8-layer commits before they leave the local machine.
+// createRedactedBlobFromFile reads a file, applies the regex-only redaction
+// pipeline (the eight always-on/opt-in layers), and creates a git blob. Used
+// by committed-checkpoint writes at post-commit time. The OpenAI Privacy
+// Filter is intentionally NOT run here — OPF lives in the pre-push rewrite
+// path (strategy/manual_commit_opf_rewrite.go), which re-redacts the
+// regex-only blobs into OPF-applied (9-layer) commits before they leave the
+// local machine.
 // JSONL files get JSONL-aware redaction; all other files get plain byte redaction.
 func createRedactedBlobFromFile(ctx context.Context, repo *git.Repository, filePath, treePath string) (plumbing.Hash, filemode.FileMode, error) {
 	info, err := os.Stat(filePath)
@@ -2328,8 +2330,8 @@ func createRedactedBlobFromFile(ctx context.Context, repo *git.Repository, fileP
 // JSON-shaped files (.jsonl or .json) get JSON-aware redaction (falling
 // back to plain bytes on parse failure so regex/credential layers
 // still apply); other files get plain byte redaction. When
-// usePrivacyFilter is true the full 8-layer pipeline (including OPF)
-// runs; otherwise the 7-layer pipeline.
+// usePrivacyFilter is true the full 9-layer pipeline (the eight regex
+// layers plus OPF) runs; otherwise just the eight regex layers.
 //
 // .json is handled alongside .jsonl because checkpoint metadata files
 // (metadata.json, per-session metadata.json) carry free-form fields

--- a/cmd/entire/cli/checkpoint/persistent_opf_trailer_test.go
+++ b/cmd/entire/cli/checkpoint/persistent_opf_trailer_test.go
@@ -18,12 +18,12 @@ import (
 
 // TestWriteCommitted_DoesNotEmitOPFAppliedTrailer is the regression guard
 // for the architectural promise: standard post-commit condensation writes
-// 7-layer-only blobs and MUST NOT mark them with the Entire-OPF-Applied
+// regex-only blobs and MUST NOT mark them with the Entire-OPF-Applied
 // trailer. The trailer is emitted exclusively by the pre-push rewrite
 // path; if a future change accidentally added it to the standard writer,
 // the pre-push rewrite would skip those commits (HasOPFApplied true →
-// reparent-only, no actual OPF run) and ship 7-layer content as if it
-// were 8-layer. This test pins down that contract.
+// reparent-only, no actual OPF run) and ship regex-only content as if it
+// were OPF-applied. This test pins down that contract.
 func TestWriteCommitted_DoesNotEmitOPFAppliedTrailer(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/checkpoint/prompts.go
+++ b/cmd/entire/cli/checkpoint/prompts.go
@@ -23,8 +23,9 @@ func SplitPromptContent(content string) []string {
 	return prompts
 }
 
-// RedactedJoinedPrompts joins prompts and runs the 7-layer redaction
-// pipeline. OPF runs exclusively in the pre-push rewrite (not here),
+// RedactedJoinedPrompts joins prompts and runs the regex-only redaction
+// pipeline (the eight always-on/opt-in layers). OPF runs exclusively in
+// the pre-push rewrite (not here),
 // so the writer's hot path stays predictable. Exported so alternate
 // persistent backends produce identically-redacted prompt blobs.
 func RedactedJoinedPrompts(prompts []string) string {

--- a/cmd/entire/cli/checkpoint/prompts_test.go
+++ b/cmd/entire/cli/checkpoint/prompts_test.go
@@ -28,8 +28,9 @@ func TestSplitPromptContent_EmptyContent(t *testing.T) {
 }
 
 // TestRedactedJoinedPrompts_AppliesSafetyNet verifies the helper joins
-// prompts with the canonical separator and runs them through the 7-layer
-// pipeline. OPF runs only in the pre-push rewrite path, never here.
+// prompts with the canonical separator and runs them through the
+// regex-only pipeline. OPF runs only in the pre-push rewrite path, never
+// here.
 func TestRedactedJoinedPrompts_AppliesSafetyNet(t *testing.T) {
 	t.Parallel()
 	got := RedactedJoinedPrompts([]string{"hello", "world"})

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -284,7 +284,7 @@ type OPFSettings struct {
 
 	// PromptDefault controls whether the pre-push hook asks the user
 	// before running OPF. "" (default) and "ask" both surface the
-	// interactive prompt; "never" skips OPF and pushes 7-layer content;
+	// interactive prompt; "never" skips OPF and pushes regex-only content;
 	// "always" runs without asking. ENTIRE_OPF=yes|no on the push
 	// invocation overrides this setting per-push.
 	PromptDefault string `json:"prompt_default,omitempty"`

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -442,7 +442,7 @@ func EnsureRedactionConfigured() {
 			})
 		}
 
-		// OpenAI Privacy Filter (opt-in 8th layer).
+		// OpenAI Privacy Filter (opt-in 9th layer).
 		if s.Redaction != nil && s.Redaction.OpenAIPrivacyFilter != nil {
 			opf := s.Redaction.OpenAIPrivacyFilter
 			redact.ConfigurePrivacyFilter(redact.OPFConfig{

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -105,11 +105,13 @@ type condenseOpts struct {
 	allAgentFiles    map[string]struct{} // Union of all sessions' FilesTouched for cross-session exclusion (nil = single-session)
 }
 
-// redactSessionJSONLBytes runs the 7-layer redaction pipeline over a
-// session transcript at post-commit condensation. OPF is intentionally
-// NOT included here — it runs exclusively in the pre-push rewrite path
+// redactSessionJSONLBytes runs the regex-only redaction pipeline (the
+// eight always-on/opt-in layers) over a session transcript at
+// post-commit condensation. OPF is intentionally NOT included here —
+// it runs exclusively in the pre-push rewrite path
 // (strategy/manual_commit_opf_rewrite.go), which re-redacts the
-// 7-layer blobs and produces 8-layer commits before the push.
+// regex-only blobs and produces OPF-applied (9-layer) commits before
+// the push.
 //
 // Exposed as a var so tests can inject deterministic success/error
 // returns. The signature still takes a context so the var can be
@@ -355,7 +357,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		summary = generateSummary(ctx, redactedTranscript, sessionData.FilesTouched, state)
 	}
 
-	// Post-commit emits 7-layer-only blobs. OPF runs later in the
+	// Post-commit emits regex-only blobs. OPF runs later in the
 	// pre-push rewrite path, never here.
 	skillEvents := mergeSkillEvents(state.SkillEvents, withSkillEventTurnID(sessionData.SkillEvents, state.TurnID))
 

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -2842,9 +2842,9 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 	// (attribution, files touched, prompts). Hooks run without user interaction
 	// so there is no retry path — preserving partial metadata is better than
 	// losing everything. Persisting an unredacted transcript would be worse.
-	// Run the 7-layer pipeline over the transcript — OPF runs later in
-	// the pre-push rewrite path, which re-redacts these 7-layer blobs
-	// and produces 8-layer commits before the push goes out.
+	// Run the regex-only pipeline over the transcript — OPF runs later in
+	// the pre-push rewrite path, which re-redacts these regex-only blobs
+	// and produces OPF-applied (9-layer) commits before the push goes out.
 	// Externalize inline images BEFORE redaction, mirroring CondenseSession, so the
 	// finalized (authoritative, full-session) transcript keeps its placeholders and
 	// matching assets instead of re-inlining what condensation lifted out. Opt-in;
@@ -2895,7 +2895,7 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 		redactedTranscript = redact.RedactedBytes{}
 	}
 
-	// Post-commit emits 7-layer-only blobs; the writer joins + redacts
+	// Post-commit emits regex-only blobs; the writer joins + redacts
 	// via checkpoint.redactedJoinedPrompts. OPF runs later, once per
 	// push, in the pre-push rewrite path.
 	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})

--- a/cmd/entire/cli/strategy/manual_commit_opf_prompt.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_prompt.go
@@ -21,8 +21,8 @@ import (
 type OPFDecision int
 
 const (
-	OPFRun   OPFDecision = iota // run the rewrite, push 8-layer
-	OPFSkip                     // skip the rewrite, push 7-layer
+	OPFRun   OPFDecision = iota // run the rewrite, push OPF-applied (9-layer)
+	OPFSkip                     // skip the rewrite, push regex-only (8-layer)
 	OPFAbort                    // cancel the push entirely (Ctrl-C / non-TTY abort)
 )
 

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -1,9 +1,9 @@
 // Pre-push OPF rewrite for entire/checkpoints/v1.
 //
 // This is the ONLY production code path that runs the OPF-augmented
-// redaction entry points. Post-commit condensation stays on 7-layer
-// for predictable latency; OPF runs here, once per push, after the
-// user opted in via settings.
+// redaction entry points. Post-commit condensation stays on the
+// regex-only pipeline for predictable latency; OPF runs here, once per
+// push, after the user opted in via settings.
 package strategy
 
 import (
@@ -80,17 +80,17 @@ func (e *V1RefMovedError) Error() string {
 }
 
 // OPFRuntimeFailedError: the OPF circuit breaker tripped mid-rewrite.
-// Some blobs were silently downgraded to 7-layer; tagging those commits
-// as Entire-OPF-Applied would be a privacy regression (future pushes
-// would skip them while their content is 7-layer-only). Abort before
-// CAS so the user fixes their OPF install and retries.
+// Some blobs were silently downgraded to regex-only; tagging those
+// commits as Entire-OPF-Applied would be a privacy regression (future
+// pushes would skip them while their content is regex-only). Abort
+// before CAS so the user fixes their OPF install and retries.
 type OPFRuntimeFailedError struct {
 	OPFCommand string
 }
 
 func (e *OPFRuntimeFailedError) Error() string {
 	return fmt.Sprintf("OPF runtime failed during pre-push rewrite (command=%q); "+
-		"aborting push so 7-layer content isn't tagged as 8-layer-applied. "+
+		"aborting push so regex-only content isn't tagged as OPF-applied. "+
 		"Run `%s --help` to verify your OPF install, then retry. Or set "+
 		"ENTIRE_OPF=no on the push to skip OPF for this push only.",
 		e.OPFCommand, e.OPFCommand)
@@ -255,7 +255,7 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 	// this push (an earlier process step tripped the breaker), abort
 	// before tagging any commits as OPF-applied. Without this, the
 	// per-blob fallback inside the no-OPF cases of BatchBytesWithPrivacyFilter
-	// could let 7-layer content slip out with the trailer attached.
+	// could let regex-only content slip out with the trailer attached.
 	if redact.OPFBreakerTripped() {
 		return plumbing.ZeroHash, &OPFRuntimeFailedError{OPFCommand: redact.OPFCommand()}
 	}
@@ -293,7 +293,7 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 			}
 			pc.startIdx = len(globalBlobs)
 			// Whole-tree redaction: each v1 commit tree is cumulative, so the
-			// newest commit can still carry older shards that were 7-layer-only
+			// newest commit can still carry older shards that were regex-only
 			// before this rewrite. Redacting the whole tree for every unapplied
 			// commit keeps the final rewritten tip from reintroducing an
 			// un-OPF-redacted older shard. collect and apply walk the tree the
@@ -487,7 +487,7 @@ func listUnpushedV1Commits(repo *git.Repository, localTip, remoteTip plumbing.Ha
 //
 // Correctness note: each v1 commit tree is cumulative. During a multi-commit
 // rewrite, the newest original commit can still contain older shards that were
-// 7-layer-only before this rewrite. The collect/apply walkers redact the whole
+// regex-only before this rewrite. The collect/apply walkers redact the whole
 // tree for every unapplied commit so the final rewritten tip cannot
 // reintroduce an older un-OPF-redacted shard.
 func rebuildV1Commit(ctx context.Context, repo *git.Repository, oldCommit *object.Commit, parent plumbing.Hash, redactedByPath map[string][]byte) (plumbing.Hash, error) {

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
@@ -656,8 +656,8 @@ func TestOPFRewrite_PreservesAssetsSubtreeVerbatim(t *testing.T) {
 
 // Fail-closed regression: when the OPF runtime fails and the breaker
 // trips, the rewrite must NOT CAS the ref. Otherwise the new commits
-// would carry Entire-OPF-Applied: true while their content is 7-layer
-// only, and future pushes would skip them — silently shipping unredacted
+// would carry Entire-OPF-Applied: true while their content is regex-only,
+// and future pushes would skip them — silently shipping unredacted
 // content to the remote.
 func TestRewriteUnpushedV1WithOPF_BreakerTrippedMidRewrite_AbortsBeforeCAS(t *testing.T) {
 	configureFakeOPF(t, &fakeRuntimeAlwaysFails{})

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -71,9 +71,9 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 
 	// OPF pre-push rewrite: if OPF is configured, resolve the user's
 	// decision (env > settings > prompt > non-TTY auto-run), then
-	// re-redact unpushed v1 commits with the 8-layer pipeline before
-	// pushing. Skipped entirely when OPF is off, so the common-case
-	// fast path is unchanged.
+	// re-redact unpushed v1 commits with OPF (producing the OPF-applied,
+	// 9-layer pipeline) before pushing. Skipped entirely when OPF is off,
+	// so the common-case fast path is unchanged.
 	if redact.OPFEnabled() {
 		cfg, _ := settings.Load(ctx) //nolint:errcheck // Load already failed at hook init; fall back to nil
 		var opfCfg *settings.OPFSettings
@@ -92,7 +92,7 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 			return errOPFAbortedByUser
 		case OPFSkip:
 			// User opted out for this push (or settings/env say
-			// "never"). Push 7-layer content as-is.
+			// "never"). Push regex-only (8-layer) content as-is.
 			logging.Info(ctx, "OPF skipped for this push (user choice or settings)")
 		case OPFRun:
 			_, opfSpan := perf.Start(ctx, "opf_pre_push_rewrite")

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -51,7 +51,8 @@ const (
 	AgentTrailerKey = "Entire-Agent"
 
 	// OPFAppliedTrailerKey marks an entire/checkpoints/v1 commit whose blobs
-	// have been redacted by the OpenAI Privacy Filter (8-layer pipeline).
+	// have been redacted by the OpenAI Privacy Filter (the opt-in 9th,
+	// network-backed layer, applied on top of the 8 regex layers).
 	// Format: literal "true"; the trailer is omitted entirely when OPF was
 	// not applied. The pre-push rewrite path treats commits lacking this
 	// trailer as candidates to OPF-redact before they reach the remote.

--- a/cmd/entire/cli/trailers/trailers_test.go
+++ b/cmd/entire/cli/trailers/trailers_test.go
@@ -351,8 +351,9 @@ func TestParseCheckpoint(t *testing.T) {
 
 // TestHasOPFApplied covers the Entire-OPF-Applied trailer reader. The
 // trailer marks a v1 commit whose blobs have been redacted by the
-// OpenAI Privacy Filter (8-layer); commits without it carry 7-layer
-// content and are eligible for the pre-push rewrite to add OPF.
+// OpenAI Privacy Filter (OPF-applied, 9-layer); commits without it carry
+// regex-only (8-layer) content and are eligible for the pre-push rewrite
+// to add OPF.
 func TestHasOPFApplied(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/redact/batch.go
+++ b/redact/batch.go
@@ -28,13 +28,14 @@ type NamedBlob struct {
 // returns a non-nil error. Callers running this for privacy-critical
 // operations (e.g. the pre-push rewrite) must abort rather than
 // proceed with partially-redacted content. The per-blob
-// JSONLContentWithPrivacyFilter falls back to 7-layer on batch
-// failure; this batched variant intentionally does not, because the
-// only caller (cross-blob walker) needs an explicit signal that OPF
-// did not finish.
+// JSONLContentWithPrivacyFilter falls back to the regex-only pipeline
+// (the eight always-on/opt-in layers, no OPF) on batch failure; this
+// batched variant intentionally does not, because the only caller
+// (cross-blob walker) needs an explicit signal that OPF did not
+// finish.
 //
 // When OPF is unconfigured, disabled, has no enabled categories, or
-// the per-process circuit breaker has tripped, returns 7-layer-only
+// the per-process circuit breaker has tripped, returns regex-only
 // output for every blob with no error. This matches the existing
 // non-batched paths and keeps the caller's hot-path code clean.
 func BatchBytesWithPrivacyFilter(ctx context.Context, inputs []NamedBlob) ([][]byte, error) {
@@ -43,11 +44,11 @@ func BatchBytesWithPrivacyFilter(ctx context.Context, inputs []NamedBlob) ([][]b
 	}
 	cfg := getOPFConfig()
 	if cfg == nil || !cfg.Enabled || cfg.runtime == nil || opfBreakerTripped.Load() {
-		return apply7LayerToBlobs(inputs), nil
+		return applyRegexLayersToBlobs(inputs), nil
 	}
 	cats := enabledCategories(cfg)
 	if len(cats) == 0 {
-		return apply7LayerToBlobs(inputs), nil
+		return applyRegexLayersToBlobs(inputs), nil
 	}
 
 	// Pass 1: collect unique prose-shaped leaves across every blob.
@@ -114,7 +115,7 @@ func BatchBytesWithPrivacyFilter(ctx context.Context, inputs []NamedBlob) ([][]b
 //
 // JSON parse failures fall back to whole-content treatment, matching
 // RedactBlobBytes's behavior: a malformed JSON blob still gets the
-// 7-layer pipeline applied, just without leaf-by-leaf precision.
+// regex-only pipeline applied, just without leaf-by-leaf precision.
 func collectLeaves(in NamedBlob, add func(string)) {
 	if isJSONLikeName(in.Name) {
 		if _, err := jsonlContentImpl(string(in.Content), func(v string) string {
@@ -129,7 +130,7 @@ func collectLeaves(in NamedBlob, add func(string)) {
 }
 
 // applyToBlob produces the redacted bytes for a single blob, combining
-// the 7 regex layers with the cached OPF spans for each leaf. The
+// the always-on/opt-in regex layers with the cached OPF spans for each leaf. The
 // per-leaf closure mirrors JSONLContentWithPrivacyFilter's Pass 3.
 func applyToBlob(in NamedBlob, spansByInput map[string][]Span, cfg *OPFConfig) []byte {
 	applier := func(v string) string {
@@ -145,10 +146,10 @@ func applyToBlob(in NamedBlob, spansByInput map[string][]Span, cfg *OPFConfig) [
 	return []byte(applier(string(in.Content)))
 }
 
-// apply7LayerToBlobs is the OPF-disabled fast path: each blob gets
+// applyRegexLayersToBlobs is the OPF-disabled fast path: each blob gets
 // regex-only redaction with no shell-out. Returned slice is index-aligned
 // with inputs.
-func apply7LayerToBlobs(inputs []NamedBlob) [][]byte {
+func applyRegexLayersToBlobs(inputs []NamedBlob) [][]byte {
 	out := make([][]byte, len(inputs))
 	for i, in := range inputs {
 		if isJSONLikeName(in.Name) {

--- a/redact/batch_test.go
+++ b/redact/batch_test.go
@@ -202,7 +202,7 @@ func TestBatchBytesWithPrivacyFilter_EmptyInputs(t *testing.T) {
 
 // TestBatchBytesWithPrivacyFilter_FailsClosedOnBatchError is the
 // fail-closed contract: when the OPF runtime errors, callers must see
-// the error rather than silently get 7-layer-only output tagged as if
+// the error rather than silently get regex-only output tagged as if
 // OPF ran. This is the privacy-critical difference vs
 // JSONLContentWithPrivacyFilter (which silently falls back).
 func TestBatchBytesWithPrivacyFilter_FailsClosedOnBatchError(t *testing.T) {
@@ -277,12 +277,12 @@ func TestBatchBytesWithPrivacyFilter_ShortReturnFailsClosed(t *testing.T) {
 	}
 }
 
-// TestBatchBytesWithPrivacyFilter_OPFDisabledReturns7Layer covers the
+// TestBatchBytesWithPrivacyFilter_OPFDisabledReturnsRegexOnly covers the
 // "OPF turned off in settings" path: every blob gets regex-only
 // redaction, no shell-out happens, no error. Without this, a user with
 // OPF disabled would get a hard error from the new API instead of the
-// fast 7-layer path they expect.
-func TestBatchBytesWithPrivacyFilter_OPFDisabledReturns7Layer(t *testing.T) {
+// fast regex-only path they expect.
+func TestBatchBytesWithPrivacyFilter_OPFDisabledReturnsRegexOnly(t *testing.T) {
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
 	// No ConfigurePrivacyFilter call → cfg == nil
@@ -295,16 +295,16 @@ func TestBatchBytesWithPrivacyFilter_OPFDisabledReturns7Layer(t *testing.T) {
 		t.Fatalf("OPF-disabled path should not error: %v", err)
 	}
 	if !strings.Contains(string(got[0]), "REDACTED") {
-		t.Errorf("7-layer fallback should still redact AWS key, got %q", string(got[0]))
+		t.Errorf("regex-only fallback should still redact AWS key, got %q", string(got[0]))
 	}
 }
 
-// TestBatchBytesWithPrivacyFilter_BreakerTrippedReturns7Layer ensures
+// TestBatchBytesWithPrivacyFilter_BreakerTrippedReturnsRegexOnly ensures
 // that once the circuit breaker has tripped (e.g. an earlier batch
 // failed and the strategy aborted), subsequent calls in the same
 // process don't pay another shell-out cost. They short-circuit to
 // regex-only with no error.
-func TestBatchBytesWithPrivacyFilter_BreakerTrippedReturns7Layer(t *testing.T) {
+func TestBatchBytesWithPrivacyFilter_BreakerTrippedReturnsRegexOnly(t *testing.T) {
 	fake := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
 	configureFakeOPF(t, fake, map[string]bool{"private_person": true})
 	opfBreakerTripped.Store(true)

--- a/redact/opf.go
+++ b/redact/opf.go
@@ -88,7 +88,7 @@ func getOPFConfig() *OPFConfig {
 
 // OPFEnabled reports whether the OpenAI Privacy Filter is configured
 // and turned on for this process. Callers gate pre-push rewrite work
-// on this: when false, the pre-push hook pushes the local 7-layer
+// on this: when false, the pre-push hook pushes the local regex-only
 // checkpoint branch verbatim with no extra processing. Independent of
 // the circuit breaker — a tripped breaker still reports Enabled=true
 // because the runtime config didn't change; the rewrite logic itself
@@ -101,9 +101,9 @@ func OPFEnabled() bool {
 // OPFBreakerTripped reports whether the per-process OPF circuit breaker
 // has been tripped — i.e. an OPF invocation failed at some point during
 // this process's lifetime. The pre-push rewrite uses this to detect
-// when OPF silently fell back to 7-layer mid-rewrite and abort before
+// when OPF silently fell back to regex-only mid-rewrite and abort before
 // CAS-ing the new ref; otherwise the rewritten commits would carry the
-// Entire-OPF-Applied: true trailer despite containing only 7-layer
+// Entire-OPF-Applied: true trailer despite containing only regex-only
 // content, and the next push would skip them.
 func OPFBreakerTripped() bool {
 	return opfBreakerTripped.Load()
@@ -185,7 +185,7 @@ func enabledCategories(cfg *OPFConfig) []string {
 // in the pre-push rewrite path (strategy/manual_commit_opf_rewrite.go),
 // whose hook is installed without a `2>/dev/null` redirect, so plain
 // stderr reaches the user's terminal during `git push`. Post-commit
-// condensation never invokes OPF (it calls the 7-layer functions
+// condensation never invokes OPF (it calls the regex-layer functions
 // directly via RedactBlobBytes(..., usePrivacyFilter=false)), so the
 // historical `/dev/tty` routing that survived the post-commit hook's
 // stderr redirect is no longer needed. Tests override this directly.

--- a/redact/opf_test.go
+++ b/redact/opf_test.go
@@ -608,7 +608,7 @@ func (r *shortReturnRuntime) RedactBatch(_ context.Context, inputs []string, _ [
 
 // TestJSONLContentWithPrivacyFilter_ShortReturnTripsBreaker pins the
 // privacy contract: if the OPF runtime returns fewer span slices than
-// inputs, we treat it as a runtime failure (trip the breaker + 7-layer
+// inputs, we treat it as a runtime failure (trip the breaker + regex-only
 // fallback) rather than silently produce under-redacted output. The
 // per-blob caller in the pre-push rewrite then catches the tripped
 // breaker via OPFBreakerTripped() and aborts before CAS.
@@ -626,7 +626,7 @@ func TestJSONLContentWithPrivacyFilter_ShortReturnTripsBreaker(t *testing.T) {
 	content := `{"a":"Alice met Bob","b":"Charlie sat down","c":"Eve walked home"}`
 	_, err := JSONLContentWithPrivacyFilter(context.Background(), content)
 	if err != nil {
-		t.Fatalf("short return should fall back to 7-layer (no error), got %v", err)
+		t.Fatalf("short return should fall back to regex-only (no error), got %v", err)
 	}
 	if !opfBreakerTripped.Load() {
 		t.Error("short return must trip the OPF breaker so the rewrite's post-loop check aborts the push")

--- a/redact/providers.go
+++ b/redact/providers.go
@@ -8,11 +8,19 @@ import "regexp"
 // entropy or the surrounding key name, so it catches low-entropy
 // credential formats the other secret layers don't reliably flag.
 //
-// The betterleaks layer misses these in isolation: its Supabase
-// secret-key rule is a *composite* rule (RequiredRules:
-// supabase-project-url) that only fires when a matching "*.supabase.co"
-// URL is present in the same content, plus an entropy filter. A secret
-// captured on its own therefore passes straight through.
+// The betterleaks layer's coverage of these differs per prefix (verified
+// against the vendored betterleaks v1.5.0 rule source):
+//   - sb_secret_: the supabase-project-api-key rule is a *composite* rule
+//     (RequiredRules: supabase-project-url) that only fires when a matching
+//     "*.supabase.co" URL is present in the same content, on top of an
+//     entropy<=4.0 filter. A secret captured on its own therefore passes
+//     straight through regardless of entropy.
+//   - sbp_: the supabase-management-token rule fires standalone (no
+//     RequiredRules), but only matches an exact 40-character lowercase body
+//     and is further filtered by entropy<=3.5 and a two-digit minimum. A
+//     high-entropy 40-char sbp_ token captured alone IS caught by
+//     betterleaks; what this layer adds for sbp_ is coverage of bodies at
+//     other lengths, lower entropy, or without two digits.
 //
 // Supabase (https://supabase.com/docs/guides/getting-started/api-keys):
 //   - sb_secret_...      secret API key (replaces the legacy service_role
@@ -38,7 +46,8 @@ import "regexp"
 // the {20,} length check is open-ended, sufficiently long snake_case
 // identifiers that merely start with a provider prefix are redacted even
 // though they aren't secrets — e.g. `sb_secret_key_rotation_handler`, or
-// mid-word inside a longer identifier like `libsbp_something_long`. This is
+// mid-word inside a longer identifier like
+// `libsbp_something_long_enough_value`. This is
 // accepted: over-redaction is the safe direction here (see
 // TestString_SupabaseProviderTokenLongIdentifierOverRedaction), and adding
 // anchors or capping the body length to eliminate it would reopen the

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -346,16 +346,29 @@ func supabasePublishablePrefix() string { return "sb" + "_publishable_" }
 
 // TestString_SupabaseProviderTokens covers issue #1716: Supabase sb_secret_
 // API keys and sbp_ personal access tokens are low-entropy and, captured in
-// isolation, are missed by the entropy layer (threshold 4.5) and by the
-// betterleaks Supabase rule (a composite rule that only fires when a
-// *.supabase.co URL is co-present). The deterministic provider-prefix layer
-// must catch them regardless of entropy or the surrounding variable name.
+// isolation, are missed by the entropy layer (threshold 4.5). betterleaks
+// coverage differs per prefix: its sb_secret_ rule is a composite rule that
+// only fires when a *.supabase.co URL is co-present, so a bare sb_secret_
+// value never reaches its filter at all; its sbp_ rule fires standalone but
+// requires an exact 40-character lowercase body, so bodies of another length
+// (like the probe values below) never match its regex regardless of entropy.
+// The deterministic provider-prefix layer must catch both regardless of
+// entropy, body length, or the surrounding variable name.
 func TestString_SupabaseProviderTokens(t *testing.T) {
 	t.Parallel()
 
 	secret := supabaseSecretPrefix() + "probe_20260710_7f91c2d8e4a6b3f0" // entropy 4.199
 	realSecret := supabaseSecretPrefix() + "9uM4GhB0STF5R4K3HxQtlg_bzWW6DRj"
 	sbpToken := supabasePersonalPrefix() + "test_probe_20260710_test_probe_2026071"
+	// Real Supabase key bodies are base64url, which includes '-'. No other
+	// fixture in this test contains a hyphen, so the charset's '-' member is
+	// otherwise unpinned: narrowing [A-Za-z0-9_-] / [a-z0-9_-] to drop the
+	// hyphen would still pass every other case here while silently truncating
+	// (not merely shrinking) the match at the first hyphen in a real key,
+	// leaking the remainder raw — the #1716 failure mode recurring via an
+	// innocent charset "tidy-up".
+	secretWithHyphen := supabaseSecretPrefix() + "probe-20260710-7f91c2d8e4a6b3f0"
+	sbpTokenWithHyphen := supabasePersonalPrefix() + "probe-20260710-7f91c2d8e4a6b3f0"
 
 	// Both probe values sit below the entropy threshold, proving entropy-only
 	// detection would miss them (the issue reports entropy 4.199 for sb_secret_).
@@ -406,9 +419,67 @@ func TestString_SupabaseProviderTokens(t *testing.T) {
 			want:  `SUPABASE_SERVICE_ROLE_KEY="REDACTED"`,
 		},
 		{
-			name:  "sbp_ personal access token (low entropy, betterleaks misses)",
+			name:  "sbp_ personal access token (38-char body, betterleaks' rule requires exactly 40)",
 			input: "SUPABASE_ACCESS_TOKEN=" + sbpToken,
 			want:  "SUPABASE_ACCESS_TOKEN=REDACTED",
+		},
+		{
+			name:  "sb_secret_ body with an early hyphen (real base64url shape)",
+			input: secretWithHyphen,
+			want:  "REDACTED",
+		},
+		{
+			name:  "sbp_ body with an early hyphen (real base64url shape)",
+			input: sbpTokenWithHyphen,
+			want:  "REDACTED",
+		},
+	})
+}
+
+// TestString_SupabaseProviderTokenLengthBoundaries pins the {20,} body-length
+// floor shared by both provider patterns as an explicit boundary rather than
+// an emergent property of an unrelated fixture: a body of exactly 20 chars
+// must redact, and a body of exactly 19 chars must be preserved. Before this
+// test, the floor was pinned only accidentally — via key_rotation_handler
+// (sb_secret_) happening to have a 20-char body, with no equivalent coverage
+// for sbp_ at all. Each case fails if either pattern's minimum is tightened
+// to {21,}.
+func TestString_SupabaseProviderTokenLengthBoundaries(t *testing.T) {
+	t.Parallel()
+
+	const (
+		body20 = "boundary_probe_2026x" // exactly 20 chars
+		body19 = "boundary_probe_2026"  // exactly 19 chars
+	)
+	if len(body20) != 20 || len(body19) != 19 {
+		t.Fatalf("fixture bodies are %d/%d chars, want 20/19", len(body20), len(body19))
+	}
+
+	secret20 := supabaseSecretPrefix() + body20
+	secret19 := supabaseSecretPrefix() + body19
+	sbp20 := supabasePersonalPrefix() + body20
+	sbp19 := supabasePersonalPrefix() + body19
+
+	assertStringRedactionCases(t, []stringRedactionCase{
+		{
+			name:  "sb_secret_ with exactly 20-char body redacts",
+			input: secret20,
+			want:  "REDACTED",
+		},
+		{
+			name:  "sb_secret_ with exactly 19-char body is preserved",
+			input: secret19,
+			want:  secret19,
+		},
+		{
+			name:  "sbp_ with exactly 20-char body redacts",
+			input: sbp20,
+			want:  "REDACTED",
+		},
+		{
+			name:  "sbp_ with exactly 19-char body is preserved",
+			input: sbp19,
+			want:  sbp19,
 		},
 	})
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/856
<!-- entire-trail-link-end -->

Follow-up to #1726 (merged), addressing post-merge review findings on trail 833.

## What
- **Vocabulary reconcile** (`2d5279794`): the provider-prefix layer added in #1726 renumbered redact.go + docs, but ~25 sibling references across the tree still said `7-layer`/`8-layer` (including a runtime error string in `manual_commit_opf_rewrite.go` and a misnamed `apply7LayerToBlobs` that applied 8). Reconciled all to the true counts (8 regex layers, OPF 9th), grounded in redact.go.
- **Boundary + hyphen pins** (`0f6e21b38`): the `{20,}` length floors were only accidentally pinned, and the base64url hyphen in the body charset was unpinned — a "tidy the regex" refactor could drop it and silently truncate real Supabase keys before position 20, reintroducing #1716. Added explicit boundary tests (body exactly 20 redacts, 19 preserved) and hyphen-in-body fixtures for both prefixes. Mutation-verified: dropping the hyphen from the charset now fails a test.
- **Comment accuracy**: corrected the betterleaks attribution in `providers.go` against the vendored v1.5.0 source (the `sbp_` supabase-management-token rule fires standalone; only `sb_secret_` is composite).

## Why
Post-merge re-review of the redact code (trail 833). No behavior change to the redaction logic itself — the fixes are vocabulary, test pinning, and comment accuracy. The hyphen pin is the security-relevant one: it locks in base64url support so #1716 can't silently regress.

## Testing
`mise run check` green (fmt, lint, test:ci -race + canary, exit 0). New boundary/hyphen tests mutation-verified.

Refs #1726.