### PR TITLE
cli: scaffold internal-gated `entire ci` command group

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,6 +32,36 @@ builds:
       # builds carry no stamp and use the package default ("true" = visible).
       - -X github.com/entireio/cli/cmd/entire/cli/experimental.Visible={{ if .Prerelease }}true{{ else }}false{{ end }}
 
+  # entire-internal builds the same ./cmd/entire main with `-tags=internal`, so
+  # the internal-only command groups (e.g. `entire ci`, gated in
+  # cmd/entire/cli/ci) are compiled in. It reuses the public build's env/matrix
+  # and ldflags verbatim and only adds the tag. This variant is intentionally
+  # NOT published: the archives below allow-list only the public build ids, so
+  # the internal binary is produced under dist/ for internal distribution but
+  # never lands in the release archives, scoop manifest, or Homebrew cask. The
+  # public `entire` build stays untagged.
+  - id: entire-internal
+    main: ./cmd/entire
+    binary: entire
+    flags:
+      - -tags=internal
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/entireio/cli/cmd/entire/cli/versioninfo.Version={{.Version}}
+      - -X github.com/entireio/cli/cmd/entire/cli/versioninfo.Commit={{.ShortCommit}}
+      - -X github.com/entireio/cli/cmd/entire/cli/telemetry.PostHogAPIKey={{.Env.POSTHOG_API_KEY}}
+      - -X github.com/entireio/cli/cmd/entire/cli/telemetry.PostHogEndpoint={{.Env.POSTHOG_ENDPOINT}}
+      - -X github.com/entireio/cli/cmd/entire/cli/experimental.Visible={{ if .Prerelease }}true{{ else }}false{{ end }}
+
   # git-remote-entire is the git remote helper for entire:// URLs (see
   # cmd/git-remote-entire). A small, dedicated binary shipped alongside
   # entire so `git clone entire://…` resolves it on PATH — no telemetry,
@@ -74,7 +104,15 @@ notarize:
         wait: true # do not let an unusable binary slip into the wild
 
 archives:
-  - formats:
+  # Allow-list the published build ids explicitly. Without this, archives bundle
+  # every build for each os/arch — which would (a) collide on the duplicate
+  # `entire` binary name shared by the entire and entire-internal builds, and
+  # (b) ship the internal-tagged binary in the public release. Listing only the
+  # public ids keeps the internal build out of every published artifact.
+  - builds:
+      - entire
+      - git-remote-entire
+    formats:
       - tar.gz
     format_overrides:
       - goos: windows

--- a/cmd/entire/cli/ci/doc.go
+++ b/cmd/entire/cli/ci/doc.go
@@ -1,0 +1,9 @@
+// Package ci hosts the `entire ci` command group: internal-only tooling for
+// managing Entire's CI integrations (Buildkite, …).
+//
+// The command tree is compiled only under the `internal` build tag
+// (register_internal.go). The public, untagged build gets a no-op Register
+// (register_stub.go), so `entire ci` never appears in a released binary.
+// This doc.go carries no build tag so exactly one package comment exists
+// under either build configuration.
+package ci

--- a/cmd/entire/cli/ci/register_internal.go
+++ b/cmd/entire/cli/ci/register_internal.go
@@ -1,0 +1,64 @@
+//go:build internal
+
+package ci
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Register mounts the hidden `ci` command group onto root. This variant is
+// compiled only under the `internal` build tag; the `!internal` build gets the
+// no-op twin in register_stub.go, so the public `entire` binary omits the group
+// entirely. Both files export the same Register symbol, so root.go compiles
+// unchanged under either tag.
+func Register(root *cobra.Command) {
+	root.AddCommand(newCICmd())
+}
+
+// newCICmd is the bare `entire ci` parent: it carries the shared control-plane
+// persistent flags and mounts the CI-integration subgroups (currently just
+// `buildkite`), mirroring the control-plane groups in the cli package such as
+// newRepoCmd. It is marked Hidden as belt-and-suspenders — the build tag
+// already keeps the whole group out of the public binary, and Hidden keeps it
+// out of help within internal builds until the verbs land in later PRs.
+func newCICmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "ci",
+		Short:  "Manage Entire CI integrations (internal)",
+		Hidden: true,
+	}
+	addControlPlaneFlags(cmd)
+	cmd.AddCommand(newBuildkiteCmd())
+	return cmd
+}
+
+// newBuildkiteCmd is the placeholder `entire ci buildkite` subgroup. The
+// Buildkite verbs (list/create/…) stack onto it in later PRs; for now bare
+// invocation prints a "coming soon" notice so the wiring is exercised
+// end-to-end.
+func newBuildkiteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "buildkite",
+		Short: "Manage Buildkite CI webhook integrations (coming soon)",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// cobra's Print* writes to stderr in production, so use Fprintln
+			// against OutOrStdout explicitly (enforced by the forbidigo linter).
+			fmt.Fprintln(cmd.OutOrStdout(), "entire ci buildkite: coming soon")
+			return nil
+		},
+	}
+}
+
+// addControlPlaneFlags registers the persistent flags shared by the
+// control-plane command groups, mirroring cli.addControlPlaneFlags. It is
+// replicated here rather than imported because the cli package imports this
+// package (root.go calls ci.Register), so importing cli back would form an
+// import cycle.
+func addControlPlaneFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().Bool("insecure-http-auth", false, "Allow authentication over plain HTTP (insecure, for local development only)")
+	if err := cmd.PersistentFlags().MarkHidden("insecure-http-auth"); err != nil {
+		panic(fmt.Sprintf("hide insecure-http-auth flag: %v", err))
+	}
+}

--- a/cmd/entire/cli/ci/register_internal_test.go
+++ b/cmd/entire/cli/ci/register_internal_test.go
@@ -1,0 +1,41 @@
+//go:build internal
+
+package ci_test
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/ci"
+)
+
+// TestRegister_MountsCIGroup asserts that under the `internal` build tag the
+// `ci` group is registered, stays Hidden, and carries the `buildkite`
+// placeholder subgroup.
+func TestRegister_MountsCIGroup(t *testing.T) {
+	t.Parallel()
+
+	root := &cobra.Command{Use: "entire"}
+	ci.Register(root)
+
+	ciCmd := findCommand(root, "ci")
+	if ciCmd == nil {
+		t.Fatal("internal build: expected `ci` group to be registered on root")
+	}
+	if !ciCmd.Hidden {
+		t.Error("`ci` group should be Hidden")
+	}
+	if findCommand(ciCmd, "buildkite") == nil {
+		t.Error("internal build: expected `ci buildkite` subgroup to be present")
+	}
+}
+
+func findCommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}

--- a/cmd/entire/cli/ci/register_stub.go
+++ b/cmd/entire/cli/ci/register_stub.go
@@ -1,0 +1,11 @@
+//go:build !internal
+
+package ci
+
+import "github.com/spf13/cobra"
+
+// Register is the no-op public-build twin of the internal Register
+// (register_internal.go). Because both files export the same symbol, root.go's
+// ci.Register(cmd) call compiles under both build tags; only the internal build
+// actually mounts the `ci` group, so it is absent from released binaries.
+func Register(_ *cobra.Command) {}

--- a/cmd/entire/cli/ci/register_stub_test.go
+++ b/cmd/entire/cli/ci/register_stub_test.go
@@ -1,0 +1,26 @@
+//go:build !internal
+
+package ci_test
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/ci"
+)
+
+// TestRegister_NoopInPublicBuild asserts that without the `internal` build tag
+// Register is a no-op: the `ci` group must not appear on the public binary.
+func TestRegister_NoopInPublicBuild(t *testing.T) {
+	t.Parallel()
+
+	root := &cobra.Command{Use: "entire"}
+	ci.Register(root)
+
+	for _, c := range root.Commands() {
+		if c.Name() == "ci" {
+			t.Fatal("public build: `ci` group must not be registered")
+		}
+	}
+}

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/entireio/cli/cmd/entire/cli/ci"
 	"github.com/entireio/cli/cmd/entire/cli/experimental"
 	"github.com/entireio/cli/cmd/entire/cli/investigate"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -99,6 +100,12 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newProjectCmd())                 // 'project' — control-plane project management
 	cmd.AddCommand(newRepoCmd())                    // 'repo' — control-plane repo lifecycle
 	cmd.AddCommand(newGrantCmd())                   // 'grant' — control-plane access grants
+
+	// Internal-only CI integrations. Register mounts the hidden `ci` group only
+	// under the `internal` build tag; in the public (untagged) build it's a
+	// no-op, so the group is absent from released binaries. Later PRs stack the
+	// Buildkite verbs onto `ci buildkite`.
+	ci.Register(cmd)
 
 	// Top-level lifecycle and standalone commands.
 	experimental.Register(cmd, cliReview.NewCommand(buildReviewDeps()))        // `review` (experimental)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/858
<!-- entire-trail-link-end -->

## Why

We want an `entire ci` command group for managing CI-provider integrations (Buildkite first), but the surface is internal-only and not ready to ship to customers. This PR lays the foundation: the group skeleton plus the machinery that keeps it out of the public release, so later PRs can stack verbs onto it without re-litigating the gating.

No Buildkite verbs yet — just the group, the build-tag gating, a goreleaser internal build variant, and tests.

## What

New package `cmd/entire/cli/ci/`, split across build tags:

- `doc.go` (no build tag) — the single package doc comment, so exactly one exists under either build configuration (keeps revive/staticcheck happy regardless of which register file compiles).
- `register_internal.go` (`//go:build internal`) — exports `func Register(root *cobra.Command)`, which mounts a hidden `ci` group carrying the shared control-plane persistent flags (mirroring `newRepoCmd` / `addControlPlaneFlags`) with a placeholder `buildkite` subgroup that prints "coming soon".
- `register_stub.go` (`//go:build !internal`) — a no-op `Register(_ *cobra.Command)`. Both files export the same `Register` symbol, so `root.go` compiles unchanged under either tag; only the internal build actually mounts the group.
- `register_internal_test.go` / `register_stub_test.go` — build-tag-aware tests asserting the group is present (and `buildkite` mounted, `ci` Hidden) under `internal`, and absent otherwise.

`addControlPlaneFlags` is replicated in the `ci` package rather than imported: `cli` imports `ci` (root.go calls `ci.Register`), so importing `cli` back would be an import cycle. This mirrors the pattern the task asked for while respecting the dependency direction.

`root.go` calls `ci.Register(cmd)` near the other control-plane group registrations.

**goreleaser:** added an `entire-internal` build id that builds `./cmd/entire` with `flags: [-tags=internal]`, reusing the public build's env/matrix/ldflags verbatim. The public `entire` build stays untagged. To keep the internal binary from ever shipping publicly, the `archives` block now allow-lists only the public build ids (`entire`, `git-remote-entire`). This is also load-bearing: without the filter, both `entire` and `entire-internal` produce a binary named `entire` and would collide in the same archive. Net effect: the internal build is produced under `dist/` (proving the tagged build compiles in the release toolchain) but is excluded from the release archives, scoop manifest, and Homebrew cask.

I chose a live-but-unpublished build id (rather than a commented-out stanza) so the tagged build is exercised by the release pipeline, while the archives allow-list makes accidental public distribution structurally impossible.

Note: in the public build, `entire ci` falls through to kubectl-style external-command resolution (`entire-ci` on PATH) since no built-in `ci` group exists — expected behavior, unchanged by this PR.

## Verification

- `go build ./...` — succeeds; `entire --help` lists no built-in `ci` group (confirmed alongside `auth`/`repo`/`grant`/`org`/`project`).
- `go build -tags internal ./...` — succeeds; `entire ci buildkite` prints "coming soon" and `entire ci --help` shows the `buildkite` subgroup.
- `go test ./cmd/entire/cli/ci/...` (stub test: group absent) and `go test -tags internal ./cmd/entire/cli/ci/...` (internal test: group present) both pass.
- `golangci-lint run` clean under both the default build and `--build-tags internal`; `gofmt` clean.
- goreleaser YAML validated: build ids `[entire, entire-internal, git-remote-entire]`, `entire-internal` flags `[-tags=internal]`, archives allow-list `[entire, git-remote-entire]`. (`goreleaser check` fails only on a pre-existing Pro-only field under the OSS binary, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHPhjYDtZx71THMtVwc83E

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release packaging changes (archive allow-list plus a second `entire` build id) could mis-ship binaries if misconfigured; customer-facing CLI surface stays gated by the `internal` tag.
> 
> **Overview**
> Introduces an **internal-only** `entire ci` command tree (Buildkite placeholder first) without shipping it in public releases.
> 
> A new `cmd/entire/cli/ci` package uses the **`internal` build tag**: `register_internal.go` mounts a hidden `ci` group with control-plane persistent flags and a `buildkite` stub that prints “coming soon”; `register_stub.go` is a no-op `Register` for public builds. **`root.go`** calls `ci.Register(cmd)` next to other control-plane groups. Tag-aware tests assert the group is present under `internal` and absent otherwise.
> 
> **GoReleaser** adds an `entire-internal` build (`-tags=internal`) that still outputs `entire` under `dist/` for internal use, and **archives** now allow-list only `entire` and `git-remote-entire` so the internal binary never collides with or leaks into public tarballs, Scoop, or Homebrew.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1339cb8a737b5fe6b06bf7c6a6649b74cd076d1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->