### PR TITLE
cli: native repo path→ULID resolver for ci commands

### DIFF
--- a/cmd/entire/cli/ci/resolve.go
+++ b/cmd/entire/cli/ci/resolve.go
@@ -1,0 +1,165 @@
+package ci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// ResolveNativeRepo turns a native repo reference into its entiredb repo ULID,
+// the identifier the `entire ci buildkite` verbs address a repo by. Accepted
+// shapes:
+//
+//   - a raw 26-character ULID — round-tripped unchanged after a shape check,
+//     never hitting the network;
+//   - `<project>/<repo>` or `/et/<project>/<repo>` — a native (entire-git) repo,
+//     resolved via the control plane: the project name → its ULID, then the repo
+//     name within that project → its ULID.
+//
+// GitHub mirrors (`gh/<owner>/<repo>`, `github.com/<owner>/<repo>`) are rejected
+// with an actionable error. The ci-webhooks backend enrolls native, org-owned
+// `/et/` repos only — a mirror authorizes via GitHub permissions, not an Entire
+// repo grant, so a CI pipeline could never clone it. We reject the shape loudly
+// here rather than enrolling a pipeline that can never run.
+//
+// Both lookups use the control plane's O(1) case-insensitive by-name filter
+// (?name=), the same one `entire project list --name` and `resolveRepoRef` use;
+// the CLI never lists everything and matches client-side.
+func ResolveNativeRepo(ctx context.Context, c *coreapi.Client, ref string) (repoULID string, err error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", errors.New("repo reference is empty")
+	}
+	if looksLikeRepoULID(ref) {
+		return ref, nil
+	}
+	if looksLikeMirrorRef(ref) {
+		return "", fmt.Errorf("%q is a GitHub mirror path: Buildkite CI supports native /et/ repos only, not GitHub mirrors — pass a native repo as <project>/<repo>", ref)
+	}
+	projectName, repoName, ok := splitNativePath(ref)
+	if !ok {
+		return "", fmt.Errorf("invalid repo reference %q: expected a native path <project>/<repo> (or /et/<project>/<repo>), or a 26-character repo ULID", ref)
+	}
+
+	projectID, err := resolveProjectByName(ctx, c, projectName)
+	if err != nil {
+		return "", err
+	}
+
+	repos, err := c.ListProjectRepos(ctx, coreapi.ListProjectReposParams{
+		ProjectId: projectID,
+		Name:      coreapi.NewOptString(repoName),
+	})
+	if err != nil {
+		if isCoreNotFound(err) {
+			return "", noRepoNamedErr(repoName, projectName)
+		}
+		return "", err
+	}
+	// A name-filtered list returns the single match under the singular `repo`
+	// field (the plural `repos` is only populated for an unfiltered page), so an
+	// unset `repo` means no match — same contract as the project/org lookups.
+	repo, ok := repos.Repo.Get()
+	if !ok || repo.ID == "" {
+		return "", noRepoNamedErr(repoName, projectName)
+	}
+	return repo.ID, nil
+}
+
+// resolveProjectByName resolves a project name to its ULID via the control
+// plane's case-insensitive by-name filter, mapping "not found" (a 404 or an
+// unset match) to a friendly error.
+func resolveProjectByName(ctx context.Context, c *coreapi.Client, name string) (string, error) {
+	projects, err := c.ListProjects(ctx, coreapi.ListProjectsParams{Name: coreapi.NewOptString(name)})
+	if err != nil {
+		if isCoreNotFound(err) {
+			return "", noProjectNamedErr(name)
+		}
+		return "", err
+	}
+	project, ok := projects.Project.Get()
+	if !ok || project.ID == "" {
+		return "", noProjectNamedErr(name)
+	}
+	return project.ID, nil
+}
+
+// splitNativePath splits a native repo path into its project and repo segments,
+// tolerating the `/et/` namespace prefix that mirrors the canonical
+// `entire://<cluster>/et/<project>/<repo>` URL form. A bare leading slash is
+// also tolerated. It reports ok=false for anything that isn't exactly
+// `<project>/<repo>` after prefix stripping.
+func splitNativePath(ref string) (project, repo string, ok bool) {
+	path := ref
+	switch {
+	case strings.HasPrefix(path, "/et/"):
+		path = strings.TrimPrefix(path, "/et/")
+	case strings.HasPrefix(path, "/"):
+		path = strings.TrimPrefix(path, "/")
+	}
+	project, repo, found := strings.Cut(path, "/")
+	if !found || project == "" || repo == "" || strings.Contains(repo, "/") {
+		return "", "", false
+	}
+	return project, repo, true
+}
+
+// looksLikeMirrorRef reports whether ref is an explicit GitHub-mirror path —
+// `gh/<…>` or `github.com/<…>`, with or without a leading slash (the
+// `entire repo clone /gh/…` form). A bare `<owner>/<repo>` is NOT a mirror ref:
+// it is ambiguous with the native `<project>/<repo>` shape, so mirrors must be
+// explicitly prefixed. Used only to reject the shape with a clear message; CI
+// does not resolve mirrors.
+func looksLikeMirrorRef(ref string) bool {
+	for _, p := range []string{"gh/", "/gh/", "github.com/", "/github.com/"} {
+		if strings.HasPrefix(ref, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// looksLikeRepoULID reports whether s has the shape of a ULID: 26 characters
+// drawn from Crockford base32 (digits plus uppercase letters, excluding I, L,
+// O, U). The check is shape-only and case-insensitive on the alphabet; it never
+// hits the network. Entire ULIDs carry no type prefix, so this is the light
+// validity check a raw repo ULID passes before being round-tripped unchanged.
+//
+// Replicated from cli.looksLikeULID rather than imported: the cli package
+// imports this package (root.go calls ci.Register), so importing cli back would
+// form an import cycle — the same reason the scaffold replicates
+// addControlPlaneFlags.
+func looksLikeRepoULID(s string) bool {
+	if len(s) != 26 {
+		return false
+	}
+	for _, r := range strings.ToUpper(s) {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'A' && r <= 'Z' && r != 'I' && r != 'L' && r != 'O' && r != 'U':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isCoreNotFound reports whether err is a control-plane 404. The by-name lookups
+// return 404 when nothing matches; callers turn that into a friendly "no X
+// named" message. Replicated from cli.isCoreNotFound to avoid the import cycle.
+func isCoreNotFound(err error) bool {
+	var se *coreapi.ErrorModelStatusCode
+	return errors.As(err, &se) && se.StatusCode == http.StatusNotFound
+}
+
+func noProjectNamedErr(name string) error {
+	return fmt.Errorf("no project named %q (run `entire project list` to see names, or pass a repo ULID)", name)
+}
+
+func noRepoNamedErr(repo, project string) error {
+	return fmt.Errorf("no repo named %q in project %q (run `entire repo list %s` to see names, or pass a repo ULID)", repo, project, project)
+}

--- a/cmd/entire/cli/ci/resolve_test.go
+++ b/cmd/entire/cli/ci/resolve_test.go
@@ -1,0 +1,199 @@
+package ci_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/ci"
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// Valid ULID-shaped fixtures (26 Crockford base32 chars, no I/L/O/U) so the
+// resolver tests exercise the ULID short-circuit instead of a name lookup.
+const (
+	ulidOrgAcme        = "0123456789ABCDEFGHJKMNPQR1"
+	ulidProjectWidgets = "0123456789ABCDEFGHJKMNPQR3"
+	ulidRepoWeb        = "0123456789ABCDEFGHJKMNPQR5"
+)
+
+// widgetsProject is the canonical project fixture. The generated response
+// validator requires OwnerType/OwnerId to be set to valid values, so a bare
+// {ID, Name} would fail decode.
+func widgetsProject() coreapi.OptProject {
+	return coreapi.NewOptProject(coreapi.Project{
+		ID:        ulidProjectWidgets,
+		Name:      "widgets",
+		OwnerId:   ulidOrgAcme,
+		OwnerType: coreapi.ProjectOwnerTypeOrg,
+	})
+}
+
+// resolveTestClient builds a coreapi client pointed at a test server whose
+// handler is h, and returns the client plus a counter of HTTP requests seen.
+// It lets the tests assert the load-bearing invariant: a ULID or mirror ref
+// makes zero network calls, a native path makes exactly the expected lookups.
+func resolveTestClient(t *testing.T, h http.HandlerFunc) (*coreapi.Client, *atomic.Int64) {
+	t.Helper()
+	var calls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		h(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	c, err := coreapi.NewWithBearer(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewWithBearer: %v", err)
+	}
+	return c, &calls
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Errorf("encode response: %v", err)
+	}
+}
+
+// nativeRepoHandler serves the two by-name lookups a native path resolution
+// makes: /projects (project by name) and /projects/{id}/repos (repo by name),
+// each returning the single match under its singular field, mirroring the real
+// server. Either fixture may be left zero to simulate "not found".
+func nativeRepoHandler(t *testing.T, project coreapi.OptProject, repo coreapi.OptRepo, gotRepoName *string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/repos"):
+			if gotRepoName != nil {
+				*gotRepoName = r.URL.Query().Get("name")
+			}
+			writeJSON(t, w, &coreapi.ListProjectReposOutputBody{Repo: repo})
+		case strings.HasSuffix(r.URL.Path, "/projects"):
+			writeJSON(t, w, &coreapi.ListProjectsOutputBody{Project: project})
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+}
+
+func TestResolveNativeRepo_ULIDPassthrough(t *testing.T) {
+	t.Parallel()
+	c, calls := resolveTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("unexpected HTTP call for a ULID ref")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	got, err := ci.ResolveNativeRepo(context.Background(), c, ulidRepoWeb)
+	if err != nil {
+		t.Fatalf("ResolveNativeRepo: %v", err)
+	}
+	if got != ulidRepoWeb {
+		t.Errorf("ResolveNativeRepo = %q, want the ULID unchanged", got)
+	}
+	if n := calls.Load(); n != 0 {
+		t.Errorf("ULID ref made %d HTTP calls, want 0", n)
+	}
+}
+
+func TestResolveNativeRepo_NativePath(t *testing.T) {
+	t.Parallel()
+	project := widgetsProject()
+	repo := coreapi.NewOptRepo(coreapi.Repo{ID: ulidRepoWeb, Name: "web"})
+
+	t.Run("plain project/repo resolves", func(t *testing.T) {
+		t.Parallel()
+		var gotRepoName string
+		c, calls := resolveTestClient(t, nativeRepoHandler(t, project, repo, &gotRepoName))
+		got, err := ci.ResolveNativeRepo(context.Background(), c, "widgets/web")
+		if err != nil {
+			t.Fatalf("ResolveNativeRepo: %v", err)
+		}
+		if got != ulidRepoWeb {
+			t.Errorf("ResolveNativeRepo = %q, want %q", got, ulidRepoWeb)
+		}
+		if gotRepoName != "web" {
+			t.Errorf("server received repo name=%q, want %q (filtering must be server-side)", gotRepoName, "web")
+		}
+		// project-by-name + repo-by-name = two lookups.
+		if n := calls.Load(); n != 2 {
+			t.Errorf("native path made %d HTTP calls, want 2", n)
+		}
+	})
+
+	t.Run("/et/ prefix is tolerated", func(t *testing.T) {
+		t.Parallel()
+		c, _ := resolveTestClient(t, nativeRepoHandler(t, project, repo, nil))
+		got, err := ci.ResolveNativeRepo(context.Background(), c, "/et/widgets/web")
+		if err != nil {
+			t.Fatalf("ResolveNativeRepo: %v", err)
+		}
+		if got != ulidRepoWeb {
+			t.Errorf("ResolveNativeRepo(/et/…) = %q, want %q", got, ulidRepoWeb)
+		}
+	})
+}
+
+func TestResolveNativeRepo_MirrorRejected(t *testing.T) {
+	t.Parallel()
+	for _, ref := range []string{"gh/acme/web", "/gh/acme/web", "github.com/acme/web"} {
+		t.Run(ref, func(t *testing.T) {
+			t.Parallel()
+			c, calls := resolveTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+				t.Error("unexpected HTTP call for a mirror ref")
+				w.WriteHeader(http.StatusInternalServerError)
+			})
+			_, err := ci.ResolveNativeRepo(context.Background(), c, ref)
+			if err == nil || !strings.Contains(err.Error(), "not GitHub mirrors") {
+				t.Errorf("ResolveNativeRepo(%q) err = %v, want a GitHub-mirror rejection", ref, err)
+			}
+			if n := calls.Load(); n != 0 {
+				t.Errorf("mirror ref made %d HTTP calls, want 0", n)
+			}
+		})
+	}
+}
+
+func TestResolveNativeRepo_UnknownProject(t *testing.T) {
+	t.Parallel()
+	// Empty project match; the repo lookup must never be reached.
+	c, _ := resolveTestClient(t, nativeRepoHandler(t, coreapi.OptProject{}, coreapi.OptRepo{}, nil))
+	_, err := ci.ResolveNativeRepo(context.Background(), c, "ghost/web")
+	if err == nil || !strings.Contains(err.Error(), "no project named") {
+		t.Errorf("ResolveNativeRepo unknown project: err = %v, want a \"no project named\" error", err)
+	}
+}
+
+func TestResolveNativeRepo_UnknownRepo(t *testing.T) {
+	t.Parallel()
+	project := widgetsProject()
+	// Project resolves, repo does not.
+	c, _ := resolveTestClient(t, nativeRepoHandler(t, project, coreapi.OptRepo{}, nil))
+	_, err := ci.ResolveNativeRepo(context.Background(), c, "widgets/ghost")
+	if err == nil || !strings.Contains(err.Error(), "no repo named") {
+		t.Errorf("ResolveNativeRepo unknown repo: err = %v, want a \"no repo named\" error", err)
+	}
+}
+
+func TestResolveNativeRepo_InvalidShape(t *testing.T) {
+	t.Parallel()
+	for _, ref := range []string{"", "  ", "widgets", "widgets/", "/et/widgets"} {
+		t.Run("ref="+ref, func(t *testing.T) {
+			t.Parallel()
+			c, calls := resolveTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+				t.Error("unexpected HTTP call for an invalid ref")
+				w.WriteHeader(http.StatusInternalServerError)
+			})
+			if _, err := ci.ResolveNativeRepo(context.Background(), c, ref); err == nil {
+				t.Errorf("ResolveNativeRepo(%q) expected an error", ref)
+			}
+			if n := calls.Load(); n != 0 {
+				t.Errorf("invalid ref %q made %d HTTP calls, want 0", ref, n)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> Stacks on #1753 (the internal-gated `entire ci` scaffold). Review/merge that first; this PR's base is `dv/ci-cmd-scaffold`, not `main`.

## Why

The `entire ci buildkite` verbs (enroll/list/update/remove/watch, landing in later PRs) address a repo by its entiredb repo ULID, but users type a native path like `widgets/web`. No `path→ULID` resolver exists in `entireio/cli` yet. This PR adds it — the one piece those verbs all depend on — as a standalone, tested unit so the verb PRs stay small.

It mirrors the entiredb reference (`cmd/entire-ci/cli/repo_resolve.go` `resolveRepoRef`) and the M2 "Repo resolution" note in the Buildkite CI CLI spec.

## What

`ResolveNativeRepo(ctx, c, ref) (repoULID string, err error)` in the internal-gated `cmd/entire/cli/ci` package. Accepted shapes:

- **raw 26-char ULID** — round-tripped unchanged after a Crockford-base32 shape check, zero network calls;
- **`<project>/<repo>`** and **`/et/<project>/<repo>`** — resolved via the control plane: project name → project ULID, then repo name within that project → repo ULID;
- **`gh/…` / `github.com/…` mirror paths** (with or without a leading slash) — rejected with an actionable error: *"Buildkite CI supports native /et/ repos only, not GitHub mirrors"*. The ci-webhooks backend enrolls native, org-owned `/et/` repos only; a mirror authorizes via GitHub perms, not an Entire grant, so a pipeline could never clone it.

Unknown project and unknown repo return distinct, friendly errors that point at `entire project list` / `entire repo list`.

Placement/wiring notes:
- The file is **untagged** (`resolve.go`), so it compiles under both `internal` and public builds and normal `go test ./...` covers it. It is referenced only by the `//go:build internal` verb code in later PRs.
- The ULID-shape check and 404→friendly-error mapping are **replicated** from the `cli` package rather than imported: `cli` imports `ci` (root.go calls `ci.Register`), so importing back would form a cycle — the same rationale the scaffold gives for replicating `addControlPlaneFlags`.

**Note on the repo-name lookup:** the task brief assumed the generated `coreapi` client had no repo-name filter and that repos would need client-side matching. In fact `ListProjectReposParams` carries a server-side `Name` (exact, case-insensitive) filter — the same one the spec's reference algorithm (`GET /projects/{id}/repos?name=`) and the sibling `resolveRepoRef` already use. This PR uses that server-side filter: one O(1) lookup per level, no client-side scan of paginated lists.

## Verification

```
go build ./...                                  # ok
go build -tags internal ./...                   # ok
go test ./cmd/entire/cli/ci/...                 # ok (untagged — normal test path)
go test -tags internal ./cmd/entire/cli/ci/...  # ok
go test -race (both tag configs)                # ok
mise run fmt                                     # no changes
mise run lint                                    # 0 issues
golangci-lint run --build-tags internal ./cmd/entire/cli/ci/...  # 0 issues
```

Unit tests (in the untagged `resolve_test.go`, via an `httptest`-backed `coreapi` client) cover: ULID passthrough with zero network calls, native `<project>/<repo>` and `/et/…` resolution, `gh/`+`/gh/`+`github.com/` mirror rejection (zero calls), unknown-project and unknown-repo distinct errors, and invalid-shape inputs rejected before any call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHPhjYDtZx71THMtVwc83E

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated resolver and tests only; no wiring to production CI flows yet, read-only control-plane lookups with explicit mirror rejection.
> 
> **Overview**
> Adds **`ResolveNativeRepo`** in `cmd/entire/cli/ci` so upcoming `entire ci buildkite` commands can turn user input into an entiredb repo ULID.
> 
> **ULIDs** pass through after a local Crockford-base32 shape check with **no** control-plane calls. **Native paths** (`<project>/<repo>` or `/et/<project>/<repo>`) resolve with two server-side `?name=` lookups: project by name, then repo by name within that project. **`gh/`** and **`github.com/`** mirror paths fail fast with a clear “native /et/ repos only” message and no API traffic.
> 
> Unknown project/repo map to friendly errors (with hints to `entire project list` / `entire repo list`). ULID validation and 404 handling are duplicated from `cli` to avoid an import cycle (`cli` already imports `ci` for registration).
> 
> **`resolve_test.go`** exercises ULID passthrough, native resolution (including `/et/`), mirror rejection, not-found cases, invalid shapes, and expected HTTP call counts via `httptest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c8aa582c3a579e6d897b0ec6403f6ec9506a7e7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->