### PR TITLE
cli: entire ci buildkite enroll/list/update/remove

### DIFF
--- a/cmd/entire/cli/ci/buildkite_internal.go
+++ b/cmd/entire/cli/ci/buildkite_internal.go
@@ -1,0 +1,391 @@
+//go:build internal
+
+package ci
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// newBuildkiteCmd is the `entire ci buildkite` subgroup: manage a repo's
+// Buildkite CI-webhook subscriptions through the core-mediated management API
+// (POST/GET/PATCH/DELETE /api/v1/repos/{repoId}/ci-webhooks). Every verb
+// addresses a repo by the same reference ResolveNativeRepo accepts (a native
+// <project>/<repo> path or a raw repo ULID) and resolves it to a ULID before
+// calling the control plane.
+func newBuildkiteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "buildkite",
+		Short: "Manage Buildkite CI webhook integrations",
+	}
+	cmd.AddCommand(newBuildkiteEnrollCmd())
+	cmd.AddCommand(newBuildkiteListCmd())
+	cmd.AddCommand(newBuildkiteUpdateCmd())
+	cmd.AddCommand(newBuildkiteRemoveCmd())
+	return cmd
+}
+
+func newBuildkiteEnrollCmd() *cobra.Command {
+	var (
+		bkOrg       string
+		bkClusterID string
+		refFilter   string
+		events      []string
+		displayName string
+	)
+	cmd := &cobra.Command{
+		Use:   "enroll <repo> [pipeline]",
+		Short: "Enroll a repo for Buildkite CI webhooks",
+		Long: "Enroll a native repo for Buildkite CI webhooks.\n\n" +
+			"<repo> is a native <project>/<repo> path or a repo ULID. [pipeline] is the\n" +
+			"Buildkite pipeline slug; omit it to let the server default to the repo name.\n\n" +
+			"The operation is idempotent: a fresh enroll returns 201, re-enrolling an\n" +
+			"existing subscription returns 200 with the current config. No Buildkite API\n" +
+			"token is passed — it is an operator-seeded, org-level credential.",
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+				repoID, err := ResolveNativeRepo(ctx, c, args[0])
+				if err != nil {
+					return err
+				}
+				body := &coreapi.CreateRepoCIWebhookInputBody{
+					Provider:       coreapi.CreateRepoCIWebhookInputBodyProviderBuildkite,
+					BkOrganization: bkOrg,
+					BkClusterID:    bkClusterID,
+				}
+				if len(args) == 2 {
+					body.BkPipeline = coreapi.NewOptString(args[1])
+				}
+				if cmd.Flags().Changed("ref-filter") {
+					body.RefFilter = coreapi.NewOptString(refFilter)
+				}
+				if len(events) > 0 {
+					body.Events = events
+				}
+				if cmd.Flags().Changed("display-name") {
+					body.DisplayName = coreapi.NewOptString(displayName)
+				}
+				res, err := c.CreateRepoCIWebhook(ctx, body, coreapi.CreateRepoCIWebhookParams{RepoId: repoID})
+				if err != nil {
+					return err
+				}
+				if jsonRequested(cmd) {
+					// Pass a pointer so the generated (*CIWebhookView).MarshalJSON
+					// is used (a value would fall back to field encoding and break
+					// on an unset $schema OptURI field).
+					return printJSON(cmd.OutOrStdout(), &res.Response)
+				}
+				verb := "Enrolled"
+				if res.StatusCode == http.StatusOK {
+					verb = "Re-enrolled"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "✓ %s %s for Buildkite (subscription %s)\n", verb, args[0], res.Response.ID)
+				return printSubscriptionFields(cmd.OutOrStdout(), res.Response)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&bkOrg, "bk-org", "", "Buildkite organization slug (required)")
+	// bk-cluster-id is required by the server (the leaf attaches the pipeline to
+	// a Buildkite cluster). It is not marked required here because a later PR
+	// resolves it via a cluster-discovery picker; until then the operator passes
+	// it and the server rejects its absence with a clear validation error.
+	cmd.Flags().StringVar(&bkClusterID, "bk-cluster-id", "", "Buildkite cluster ID to attach the pipeline to (required by the server)")
+	cmd.Flags().StringVar(&refFilter, "ref-filter", "", "Only fire for refs matching this glob (e.g. refs/heads/main)")
+	cmd.Flags().StringSliceVar(&events, "events", nil, "Ref events to subscribe to (comma-separated, e.g. create,update)")
+	cmd.Flags().StringVar(&displayName, "display-name", "", "Human-friendly name for the subscription")
+	markRequired(cmd, "bk-org")
+	addJSONFlag(cmd)
+	return cmd
+}
+
+func newBuildkiteListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list <repo>",
+		Short: "List a repo's Buildkite CI webhook subscriptions",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+				repoID, err := ResolveNativeRepo(ctx, c, args[0])
+				if err != nil {
+					return err
+				}
+				out, err := c.ListRepoCIWebhooks(ctx, coreapi.ListRepoCIWebhooksParams{RepoId: repoID})
+				if err != nil {
+					return err
+				}
+				subs := out.Subscriptions
+				if jsonRequested(cmd) {
+					if subs == nil {
+						subs = []coreapi.CIWebhookView{} // a nil slice encodes as null; scripts expect []
+					}
+					return printJSON(cmd.OutOrStdout(), subs)
+				}
+				if len(subs) == 0 {
+					fmt.Fprintln(cmd.OutOrStdout(), "No Buildkite subscriptions for this repo.")
+					return nil
+				}
+				return printSubscriptionsTable(cmd.OutOrStdout(), subs)
+			})
+		},
+	}
+	addJSONFlag(cmd)
+	return cmd
+}
+
+func newBuildkiteUpdateCmd() *cobra.Command {
+	var (
+		enabled     bool
+		refFilter   string
+		events      []string
+		displayName string
+	)
+	cmd := &cobra.Command{
+		Use:   "update <repo> <subscriptionId>",
+		Short: "Update a Buildkite CI webhook subscription",
+		Long: "Update mutable fields of a Buildkite CI webhook subscription.\n\n" +
+			"Only the flags you set are sent; the (repo, org, pipeline) key and the\n" +
+			"Buildkite token are immutable. Pass at least one field flag.",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !anyChanged(cmd, "enabled", "ref-filter", "events", "display-name") {
+				cmd.SilenceUsage = true
+				return errors.New("nothing to update: set at least one of --enabled, --ref-filter, --events, --display-name")
+			}
+			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+				repoID, err := ResolveNativeRepo(ctx, c, args[0])
+				if err != nil {
+					return err
+				}
+				body := &coreapi.PatchRepoCIWebhookInputBody{}
+				if cmd.Flags().Changed("enabled") {
+					body.Enabled = coreapi.NewOptBool(enabled)
+				}
+				if cmd.Flags().Changed("ref-filter") {
+					body.RefFilter = coreapi.NewOptString(refFilter)
+				}
+				if cmd.Flags().Changed("events") {
+					// A non-nil (possibly empty) slice is what the encoder emits,
+					// letting `--events ""` clear the subscription's events.
+					if events == nil {
+						events = []string{}
+					}
+					body.Events = events
+				}
+				if cmd.Flags().Changed("display-name") {
+					body.DisplayName = coreapi.NewOptString(displayName)
+				}
+				sub, err := c.PatchRepoCIWebhook(ctx, body, coreapi.PatchRepoCIWebhookParams{RepoId: repoID, ID: args[1]})
+				if err != nil {
+					return err
+				}
+				if jsonRequested(cmd) {
+					return printJSON(cmd.OutOrStdout(), sub)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "✓ Updated subscription %s\n", sub.ID)
+				return printSubscriptionFields(cmd.OutOrStdout(), *sub)
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&enabled, "enabled", false, "Enable (--enabled) or disable (--enabled=false) the subscription")
+	cmd.Flags().StringVar(&refFilter, "ref-filter", "", "Only fire for refs matching this glob (e.g. refs/heads/main)")
+	cmd.Flags().StringSliceVar(&events, "events", nil, "Ref events to subscribe to (comma-separated); pass an empty value to clear")
+	cmd.Flags().StringVar(&displayName, "display-name", "", "Human-friendly name for the subscription")
+	addJSONFlag(cmd)
+	return cmd
+}
+
+func newBuildkiteRemoveCmd() *cobra.Command {
+	var teardown bool
+	cmd := &cobra.Command{
+		Use:   "remove <repo> <subscriptionId>",
+		Short: "Remove a Buildkite CI webhook subscription",
+		Long: "Remove a Buildkite CI webhook subscription.\n\n" +
+			"With --teardown the service also revokes the enrollment identity (OIDC\n" +
+			"binding, repo pull grant, and dedicated service account). The Buildkite\n" +
+			"pipeline itself is always kept.",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+				repoID, err := ResolveNativeRepo(ctx, c, args[0])
+				if err != nil {
+					return err
+				}
+				err = c.DeleteRepoCIWebhook(ctx, coreapi.DeleteRepoCIWebhookParams{
+					RepoId:   repoID,
+					ID:       args[1],
+					Teardown: coreapi.NewOptBool(teardown),
+				})
+				if err != nil {
+					return err
+				}
+				msg := "✓ Removed subscription " + args[1]
+				if teardown {
+					msg += " (enrollment identity torn down)"
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), msg)
+				return nil
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&teardown, "teardown", false, "Also revoke the enrollment identity (OIDC binding, repo grant, service account); the Buildkite pipeline is kept")
+	return cmd
+}
+
+// activeCoreClient builds the control-plane client for the buildkite verbs. A
+// package-level seam (production wiring is coreapi.New) so command-level tests
+// can point the command tree at an httptest server without the auth/context/TLS
+// stack. Mirrors cli.activeCoreClient; replicated rather than imported because
+// the cli package imports this one (root.go calls ci.Register), so importing
+// cli back would form an import cycle — the same reason resolve.go replicates
+// its control-plane helpers.
+var activeCoreClient = func(context.Context) (*coreapi.Client, error) { return coreapi.New() }
+
+// runCore owns the control-plane preamble shared by every buildkite verb:
+// silence usage, opt into plain-HTTP token exchange when --insecure-http-auth
+// is set, build the client via the activeCoreClient seam, run fn, and map API
+// errors to the server's problem-detail message. Mirrors cli.runCore.
+func runCore(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client) error) error {
+	cmd.SilenceUsage = true
+	if insecureHTTPRequested(cmd) {
+		auth.EnableInsecureHTTP()
+	}
+	client, err := activeCoreClient(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("connect to Entire control plane: %w", err)
+	}
+	if err := fn(cmd.Context(), client); err != nil {
+		return renderCoreError(err)
+	}
+	return nil
+}
+
+// renderCoreError converts a Core API error into the server's problem-detail
+// message (so users see the server's reason rather than ogen's decode-wrapped
+// string), falling back to the raw error for transport/local failures. Mirrors
+// cli.renderCoreError.
+func renderCoreError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if msg := coreapi.APIError(err); msg != "" {
+		return errors.New(msg)
+	}
+	return err
+}
+
+// insecureHTTPRequested reports whether --insecure-http-auth was set on cmd or
+// an ancestor (it is a hidden persistent flag on the `ci` parent).
+func insecureHTTPRequested(cmd *cobra.Command) bool {
+	v, err := cmd.Flags().GetBool("insecure-http-auth")
+	return err == nil && v
+}
+
+// addJSONFlag registers the local --json flag on a verb that renders a wire
+// payload. Local, not persistent, so only the read/mutation verbs advertise it.
+func addJSONFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool("json", false, "Output raw JSON instead of a table")
+}
+
+// jsonRequested reports whether --json was set. A lookup error (flag undefined
+// on this command) is treated as "not requested".
+func jsonRequested(cmd *cobra.Command) bool {
+	v, err := cmd.Flags().GetBool("json")
+	return err == nil && v
+}
+
+// anyChanged reports whether the user set any of the named flags.
+func anyChanged(cmd *cobra.Command, names ...string) bool {
+	for _, name := range names {
+		if cmd.Flags().Changed(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// markRequired marks a flag required, panicking on a typo (a wiring-time bug,
+// never a runtime one). Mirrors cli.markRequired.
+func markRequired(cmd *cobra.Command, names ...string) {
+	for _, name := range names {
+		if err := cmd.MarkFlagRequired(name); err != nil {
+			panic(fmt.Sprintf("mark flag %q required: %v", name, err))
+		}
+	}
+}
+
+// printJSON writes v as indented JSON — the --json view for the buildkite verbs.
+func printJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("encode output: %w", err)
+	}
+	return nil
+}
+
+// subscriptionColumns is the human view of one CI-webhook subscription, shared
+// by the list table and the single-subscription field view so the two never
+// drift. subscriptionValues maps a view to its cells in the same order.
+var subscriptionColumns = []string{"ID", "PROVIDER", "BK_ORG", "PIPELINE", "ENABLED", "REF_FILTER", "EVENTS"}
+
+func subscriptionValues(s coreapi.CIWebhookView) []string {
+	return []string{
+		s.ID,
+		s.Provider,
+		orDash(s.BkOrganization),
+		orDash(s.BkPipeline),
+		strconv.FormatBool(s.Enabled),
+		orDash(s.RefFilter),
+		orDash(strings.Join(s.Events, ",")),
+	}
+}
+
+// printSubscriptionsTable renders the subscriptions as an aligned table with
+// subscriptionColumns as the header. Callers handle the empty case.
+func printSubscriptionsTable(w io.Writer, subs []coreapi.CIWebhookView) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, strings.Join(subscriptionColumns, "\t"))
+	for _, s := range subs {
+		fmt.Fprintln(tw, strings.Join(subscriptionValues(s), "\t"))
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("render table: %w", err)
+	}
+	return nil
+}
+
+// printSubscriptionFields renders one subscription as aligned "FIELD value"
+// lines, the single-object counterpart of the list table.
+func printSubscriptionFields(w io.Writer, s coreapi.CIWebhookView) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	vals := subscriptionValues(s)
+	for i, col := range subscriptionColumns {
+		fmt.Fprintf(tw, "%s\t%s\n", col, vals[i])
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("render fields: %w", err)
+	}
+	return nil
+}
+
+// orDash returns s, or "-" when s is empty/blank, so empty cells read clearly
+// in the human table/field views.
+func orDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/entire/cli/ci/buildkite_internal_test.go
+++ b/cmd/entire/cli/ci/buildkite_internal_test.go
@@ -1,0 +1,348 @@
+//go:build internal
+
+package ci
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// testRepoULID is a syntactically valid repo ULID (26 Crockford base32 chars,
+// no I/L/O/U) so ResolveNativeRepo short-circuits and the fake server only
+// needs to answer the ci-webhooks calls, never a project/repo name lookup.
+const (
+	testRepoULID = "0123456789ABCDEFGHJKMNPQR5"
+	testSubID    = "01HSUBBKWEBHOOK00000000001"
+)
+
+// runBuildkiteCmd points the activeCoreClient seam at srvURL and runs the ci
+// command tree with the given args (prefixed with "ci"), returning the leaf's
+// stdout and error. Building the tree via Register exercises the full cobra
+// wiring including the hidden `ci` group and its persistent flags.
+// Not parallel: the seam is package-global.
+func runBuildkiteCmd(t *testing.T, srvURL string, args ...string) (stdout string, err error) {
+	t.Helper()
+	prev := activeCoreClient
+	activeCoreClient = func(context.Context) (*coreapi.Client, error) {
+		return coreapi.NewWithBearer(srvURL, "tok")
+	}
+	t.Cleanup(func() { activeCoreClient = prev })
+
+	root := &cobra.Command{Use: "entire"}
+	Register(root)
+	var out, errW bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errW)
+	root.SetArgs(append([]string{"ci"}, args...))
+	err = root.ExecuteContext(t.Context())
+	return out.String(), err
+}
+
+// writeJSONResponse writes status + body as application/json, reporting a write
+// error without aborting the handler goroutine (a require/Goexit inside a
+// handler is a testifylint go-require violation and would surface to the client
+// as a confusing EOF).
+func writeJSONResponse(t *testing.T, w http.ResponseWriter, status int, body []byte) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(body); err != nil {
+		t.Errorf("write response: %v", err)
+	}
+}
+
+// viewJSON encodes a CIWebhookView fixture. events is always non-nil (the
+// generated response validator rejects a nil events array). It marshals via
+// pointer so the generated (*CIWebhookView).MarshalJSON is used; a value would
+// fall back to field encoding and break on the unset $schema (OptURI) field.
+func viewJSON(t *testing.T, v coreapi.CIWebhookView) []byte {
+	t.Helper()
+	if v.Events == nil {
+		v.Events = []string{}
+	}
+	b, err := json.Marshal(&v)
+	require.NoError(t, err)
+	return b
+}
+
+// listJSON encodes a ListRepoCIWebhooksOutputBody fixture with the given
+// subscriptions (non-nil so the response validator accepts it).
+func listJSON(t *testing.T, subs []coreapi.CIWebhookView) []byte {
+	t.Helper()
+	if subs == nil {
+		subs = []coreapi.CIWebhookView{}
+	}
+	out := coreapi.ListRepoCIWebhooksOutputBody{Subscriptions: subs}
+	b, err := json.Marshal(&out)
+	require.NoError(t, err)
+	return b
+}
+
+func sampleView() coreapi.CIWebhookView {
+	return coreapi.CIWebhookView{
+		ID:             testSubID,
+		RepoID:         testRepoULID,
+		Provider:       "buildkite",
+		DisplayName:    "web CI",
+		BkOrganization: "acme",
+		BkPipeline:     "web",
+		RefFilter:      "refs/heads/main",
+		Events:         []string{"create", "update"},
+		Enabled:        true,
+		CreatedAt:      time.Unix(0, 0).UTC(),
+		UpdatedAt:      time.Unix(0, 0).UTC(),
+	}
+}
+
+// decodeBody reads r's JSON body into a generic map for presence/absence
+// assertions on the fields the CLI sent.
+func decodeBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	raw, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}
+
+func TestBuildkiteEnroll_BodyAssemblyAndFreshVsReenroll(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		status   int
+		wantWord string
+	}{
+		{"fresh enroll → 201", http.StatusCreated, "✓ Enrolled"},
+		{"re-enroll → 200", http.StatusOK, "✓ Re-enrolled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod, gotPath = r.Method, r.URL.Path
+				gotBody = decodeBody(t, r)
+				writeJSONResponse(t, w, tc.status, viewJSON(t, sampleView()))
+			}))
+			t.Cleanup(srv.Close)
+
+			out, err := runBuildkiteCmd(t, srv.URL,
+				"buildkite", "enroll", testRepoULID, "web",
+				"--bk-org", "acme", "--bk-cluster-id", "cluster-1",
+				"--ref-filter", "refs/heads/main", "--events", "create,update",
+				"--display-name", "web CI")
+			require.NoError(t, err)
+
+			assert.Equal(t, http.MethodPost, gotMethod)
+			assert.Equal(t, "/api/v1/repos/"+testRepoULID+"/ci-webhooks", gotPath)
+			assert.Equal(t, "buildkite", gotBody["provider"])
+			assert.Equal(t, "acme", gotBody["bk_organization"])
+			assert.Equal(t, "cluster-1", gotBody["bk_cluster_id"])
+			assert.Equal(t, "web", gotBody["bk_pipeline"])
+			assert.Equal(t, "refs/heads/main", gotBody["ref_filter"])
+			assert.Equal(t, "web CI", gotBody["display_name"])
+			assert.Equal(t, []any{"create", "update"}, gotBody["events"])
+			assert.Contains(t, out, tc.wantWord)
+			assert.Contains(t, out, testSubID)
+		})
+	}
+}
+
+func TestBuildkiteEnroll_OmitsUnsetOptionalFields(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = decodeBody(t, r)
+		writeJSONResponse(t, w, http.StatusCreated, viewJSON(t, sampleView()))
+	}))
+	t.Cleanup(srv.Close)
+
+	// No positional pipeline, no ref-filter/events/display-name.
+	_, err := runBuildkiteCmd(t, srv.URL,
+		"buildkite", "enroll", testRepoULID, "--bk-org", "acme", "--bk-cluster-id", "cluster-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "acme", gotBody["bk_organization"])
+	assert.NotContains(t, gotBody, "bk_pipeline", "unset pipeline must be omitted so the server defaults it")
+	assert.NotContains(t, gotBody, "ref_filter")
+	assert.NotContains(t, gotBody, "events")
+	assert.NotContains(t, gotBody, "display_name")
+}
+
+func TestBuildkiteEnroll_JSONOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(t, w, http.StatusCreated, viewJSON(t, sampleView()))
+	}))
+	t.Cleanup(srv.Close)
+
+	out, err := runBuildkiteCmd(t, srv.URL,
+		"buildkite", "enroll", testRepoULID, "--bk-org", "acme", "--bk-cluster-id", "cluster-1", "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"id": "`+testSubID+`"`)
+	assert.NotContains(t, out, "✓ Enrolled", "JSON output must not carry the human confirmation line")
+}
+
+func TestBuildkiteEnroll_RequiresBkOrg(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := runBuildkiteCmd(t, srv.URL, "buildkite", "enroll", testRepoULID, "--bk-cluster-id", "cluster-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bk-org")
+	assert.False(t, called, "a missing required flag must fail before any HTTP call")
+}
+
+func TestBuildkiteList_TableAndJSON(t *testing.T) {
+	newServer := func() *httptest.Server {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/api/v1/repos/"+testRepoULID+"/ci-webhooks", r.URL.Path)
+			writeJSONResponse(t, w, http.StatusOK, listJSON(t, []coreapi.CIWebhookView{sampleView()}))
+		}))
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	t.Run("human table", func(t *testing.T) {
+		out, err := runBuildkiteCmd(t, newServer().URL, "buildkite", "list", testRepoULID)
+		require.NoError(t, err)
+		assert.Contains(t, out, "ID")
+		assert.Contains(t, out, "PROVIDER")
+		assert.Contains(t, out, "EVENTS")
+		assert.Contains(t, out, testSubID)
+		assert.Contains(t, out, "buildkite")
+		assert.Contains(t, out, "create,update")
+	})
+
+	t.Run("json", func(t *testing.T) {
+		out, err := runBuildkiteCmd(t, newServer().URL, "buildkite", "list", testRepoULID, "--json")
+		require.NoError(t, err)
+		assert.Contains(t, out, `"id": "`+testSubID+`"`)
+		assert.Contains(t, out, `"provider": "buildkite"`)
+	})
+}
+
+func TestBuildkiteList_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(t, w, http.StatusOK, listJSON(t, nil))
+	}))
+	t.Cleanup(srv.Close)
+
+	out, err := runBuildkiteCmd(t, srv.URL, "buildkite", "list", testRepoULID)
+	require.NoError(t, err)
+	assert.Contains(t, out, "No Buildkite subscriptions")
+}
+
+func TestBuildkiteUpdate_OnlySendsChangedFields(t *testing.T) {
+	t.Run("enabled only", func(t *testing.T) {
+		var gotMethod, gotPath string
+		var gotBody map[string]any
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod, gotPath = r.Method, r.URL.Path
+			gotBody = decodeBody(t, r)
+			writeJSONResponse(t, w, http.StatusOK, viewJSON(t, sampleView()))
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := runBuildkiteCmd(t, srv.URL, "buildkite", "update", testRepoULID, testSubID, "--enabled=false")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPatch, gotMethod)
+		assert.Equal(t, "/api/v1/repos/"+testRepoULID+"/ci-webhooks/"+testSubID, gotPath)
+		assert.Equal(t, false, gotBody["enabled"])
+		assert.NotContains(t, gotBody, "ref_filter")
+		assert.NotContains(t, gotBody, "events")
+		assert.NotContains(t, gotBody, "display_name")
+	})
+
+	t.Run("ref-filter only", func(t *testing.T) {
+		var gotBody map[string]any
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotBody = decodeBody(t, r)
+			writeJSONResponse(t, w, http.StatusOK, viewJSON(t, sampleView()))
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := runBuildkiteCmd(t, srv.URL, "buildkite", "update", testRepoULID, testSubID, "--ref-filter", "refs/tags/*")
+		require.NoError(t, err)
+		assert.Equal(t, "refs/tags/*", gotBody["ref_filter"])
+		assert.NotContains(t, gotBody, "enabled")
+		assert.NotContains(t, gotBody, "events")
+		assert.NotContains(t, gotBody, "display_name")
+	})
+
+	t.Run("empty events clears the list", func(t *testing.T) {
+		var gotBody map[string]any
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotBody = decodeBody(t, r)
+			writeJSONResponse(t, w, http.StatusOK, viewJSON(t, sampleView()))
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := runBuildkiteCmd(t, srv.URL, "buildkite", "update", testRepoULID, testSubID, "--events", "")
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, gotBody["events"], "an explicit empty --events must send a non-nil empty array to clear")
+	})
+}
+
+func TestBuildkiteUpdate_NothingToUpdate(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := runBuildkiteCmd(t, srv.URL, "buildkite", "update", testRepoULID, testSubID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nothing to update")
+	assert.False(t, called, "a no-op update must not issue a PATCH")
+}
+
+func TestBuildkiteRemove_TeardownQuery(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		args         []string
+		wantTeardown string
+		wantNote     bool
+	}{
+		{"default keeps identity", nil, "false", false},
+		{"teardown revokes identity", []string{"--teardown"}, "true", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath, gotTeardown string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod, gotPath = r.Method, r.URL.Path
+				gotTeardown = r.URL.Query().Get("teardown")
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			t.Cleanup(srv.Close)
+
+			args := append([]string{"buildkite", "remove", testRepoULID, testSubID}, tc.args...)
+			out, err := runBuildkiteCmd(t, srv.URL, args...)
+			require.NoError(t, err)
+			assert.Equal(t, http.MethodDelete, gotMethod)
+			assert.Equal(t, "/api/v1/repos/"+testRepoULID+"/ci-webhooks/"+testSubID, gotPath)
+			assert.Equal(t, tc.wantTeardown, gotTeardown)
+			assert.Contains(t, out, "✓ Removed subscription "+testSubID)
+			if tc.wantNote {
+				assert.Contains(t, out, "torn down")
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/ci/register_internal.go
+++ b/cmd/entire/cli/ci/register_internal.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// newBuildkiteCmd and the four Buildkite verbs it mounts live in
+// buildkite_internal.go, alongside the control-plane client seam and rendering
+// helpers they share.
+
 // Register mounts the hidden `ci` command group onto root. This variant is
 // compiled only under the `internal` build tag; the `!internal` build gets the
 // no-op twin in register_stub.go, so the public `entire` binary omits the group
@@ -32,23 +36,6 @@ func newCICmd() *cobra.Command {
 	addControlPlaneFlags(cmd)
 	cmd.AddCommand(newBuildkiteCmd())
 	return cmd
-}
-
-// newBuildkiteCmd is the placeholder `entire ci buildkite` subgroup. The
-// Buildkite verbs (list/create/…) stack onto it in later PRs; for now bare
-// invocation prints a "coming soon" notice so the wiring is exercised
-// end-to-end.
-func newBuildkiteCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "buildkite",
-		Short: "Manage Buildkite CI webhook integrations (coming soon)",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			// cobra's Print* writes to stderr in production, so use Fprintln
-			// against OutOrStdout explicitly (enforced by the forbidigo linter).
-			fmt.Fprintln(cmd.OutOrStdout(), "entire ci buildkite: coming soon")
-			return nil
-		},
-	}
 }
 
 // addControlPlaneFlags registers the persistent flags shared by the

--- a/internal/coreapi/UPSTREAM.md
+++ b/internal/coreapi/UPSTREAM.md
@@ -51,6 +51,30 @@ loosened; request-body enums stay strict. Locked in by
 `TestListProjectRepos_UnknownEnumValuesPassThrough` in `client_test.go`.
 Retire the allowlist entries as upstream loosens the corresponding fields.
 
+## 3. Idempotent CI-webhook enroll returns an undocumented 200
+
+**Symptom:** `POST /repos/{repoId}/ci-webhooks` is idempotent — it answers
+`201` on a fresh enroll and `200` on a re-enroll of an existing
+subscription, both carrying the same `CIWebhookView` body. But the huma
+operation only sets `DefaultStatus: 201`, so the OpenAPI document lists
+`201` alone. ogen's decoder then treats the `200` re-enroll as an
+unexpected status and fails to decode it (it falls through to the
+`application/problem+json` error branch and errors on the `application/json`
+content type), surfacing an idempotent success as a client error.
+
+**Fix upstream:** have huma advertise `200` as an additional response on the
+enroll operation (or document the idempotent behavior with a both-codes
+response set), so the generated client accepts the re-enroll.
+
+**Workaround:** `spec/normalize.go` (`addCreateCIWebhookReenrollStatus`)
+replaces the operation's single literal `201` with a `2XX` range (same
+`CIWebhookView` schema). ogen then decodes any 2xx into one concrete
+`*CIWebhookViewStatusCode` — declaring `200` and `201` as separate responses
+would instead force a per-status sum type, breaking the `(*T, error)`
+ergonomics the rest of the client relies on (see item 1). The wrapper's
+`StatusCode` still distinguishes a fresh enroll (201) from a re-enroll (200).
+Retire this transform once the enroll operation advertises the 200 upstream.
+
 <!-- Resolved upstream and removed:
   - Nullable arrays (`"type": ["array","null"]`) — entiredb now emits
     non-nullable arrays (`"type": "array"`, absent ⇒ `[]`), so the

--- a/internal/coreapi/oas_client_gen.go
+++ b/internal/coreapi/oas_client_gen.go
@@ -74,7 +74,7 @@ type Invoker interface {
 	// Enroll a repo into a CI webhook (Buildkite).
 	//
 	// POST /repos/{repoId}/ci-webhooks
-	CreateRepoCIWebhook(ctx context.Context, request *CreateRepoCIWebhookInputBody, params CreateRepoCIWebhookParams) (*CIWebhookView, error)
+	CreateRepoCIWebhook(ctx context.Context, request *CreateRepoCIWebhookInputBody, params CreateRepoCIWebhookParams) (*CIWebhookViewStatusCode, error)
 	// CreateServiceAccount invokes createServiceAccount operation.
 	//
 	// Create service account.
@@ -1156,12 +1156,12 @@ func (c *Client) sendCreateRepo(ctx context.Context, request *CreateRepoInputBod
 // Enroll a repo into a CI webhook (Buildkite).
 //
 // POST /repos/{repoId}/ci-webhooks
-func (c *Client) CreateRepoCIWebhook(ctx context.Context, request *CreateRepoCIWebhookInputBody, params CreateRepoCIWebhookParams) (*CIWebhookView, error) {
+func (c *Client) CreateRepoCIWebhook(ctx context.Context, request *CreateRepoCIWebhookInputBody, params CreateRepoCIWebhookParams) (*CIWebhookViewStatusCode, error) {
 	res, err := c.sendCreateRepoCIWebhook(ctx, request, params)
 	return res, err
 }
 
-func (c *Client) sendCreateRepoCIWebhook(ctx context.Context, request *CreateRepoCIWebhookInputBody, params CreateRepoCIWebhookParams) (res *CIWebhookView, err error) {
+func (c *Client) sendCreateRepoCIWebhook(ctx context.Context, request *CreateRepoCIWebhookInputBody, params CreateRepoCIWebhookParams) (res *CIWebhookViewStatusCode, err error) {
 
 	u := uri.Clone(c.requestURL(ctx))
 	var pathParts [3]string

--- a/internal/coreapi/oas_response_decoders_gen.go
+++ b/internal/coreapi/oas_response_decoders_gen.go
@@ -665,52 +665,61 @@ func decodeCreateRepoResponse(resp *http.Response) (res *Repo, _ error) {
 	return res, errors.Wrap(defRes, "error")
 }
 
-func decodeCreateRepoCIWebhookResponse(resp *http.Response) (res *CIWebhookView, _ error) {
-	switch resp.StatusCode {
-	case 201:
-		// Code 201.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
+func decodeCreateRepoCIWebhookResponse(resp *http.Response) (res *CIWebhookViewStatusCode, _ error) {
+	switch resp.StatusCode / 100 {
+	case 2:
+		// Pattern 2XX.
+		res, err := func() (res *CIWebhookViewStatusCode, err error) {
+			ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 			if err != nil {
-				return res, err
+				return res, errors.Wrap(err, "parse media type")
 			}
-			d := jx.DecodeBytes(buf)
+			switch {
+			case ct == "application/json":
+				buf, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return res, err
+				}
+				d := jx.DecodeBytes(buf)
 
-			var response CIWebhookView
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
+				var response CIWebhookView
+				if err := func() error {
+					if err := response.Decode(d); err != nil {
+						return err
+					}
+					if err := d.Skip(); err != io.EOF {
+						return errors.New("unexpected trailing data")
+					}
+					return nil
+				}(); err != nil {
+					err = &ogenerrors.DecodeBodyError{
+						ContentType: ct,
+						Body:        buf,
+						Err:         err,
+					}
+					return res, err
 				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
+				// Validate response.
+				if err := func() error {
+					if err := response.Validate(); err != nil {
+						return err
+					}
+					return nil
+				}(); err != nil {
+					return res, errors.Wrap(err, "validate")
 				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
+				return &CIWebhookViewStatusCode{
+					StatusCode: resp.StatusCode,
+					Response:   response,
+				}, nil
+			default:
+				return res, validate.InvalidContentType(ct)
 			}
-			// Validate response.
-			if err := func() error {
-				if err := response.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return res, errors.Wrap(err, "validate")
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
+		}()
+		if err != nil {
+			return res, errors.Wrapf(err, "pattern 2XX (code %d)", resp.StatusCode)
 		}
+		return res, nil
 	}
 	// Convenient error response.
 	defRes, err := func() (res *ErrorModelStatusCode, err error) {

--- a/internal/coreapi/oas_schemas_gen.go
+++ b/internal/coreapi/oas_schemas_gen.go
@@ -809,6 +809,32 @@ func (s *CIWebhookViewAdditional) init() CIWebhookViewAdditional {
 	return m
 }
 
+// CIWebhookViewStatusCode wraps CIWebhookView with StatusCode.
+type CIWebhookViewStatusCode struct {
+	StatusCode int
+	Response   CIWebhookView
+}
+
+// GetStatusCode returns the value of StatusCode.
+func (s *CIWebhookViewStatusCode) GetStatusCode() int {
+	return s.StatusCode
+}
+
+// GetResponse returns the value of Response.
+func (s *CIWebhookViewStatusCode) GetResponse() CIWebhookView {
+	return s.Response
+}
+
+// SetStatusCode sets the value of StatusCode.
+func (s *CIWebhookViewStatusCode) SetStatusCode(val int) {
+	s.StatusCode = val
+}
+
+// SetResponse sets the value of Response.
+func (s *CIWebhookViewStatusCode) SetResponse(val CIWebhookView) {
+	s.Response = val
+}
+
 // CancelDeletionOK is response for CancelDeletion operation.
 type CancelDeletionOK struct{}
 

--- a/internal/coreapi/oas_validators_gen.go
+++ b/internal/coreapi/oas_validators_gen.go
@@ -269,6 +269,29 @@ func (s *CIWebhookView) Validate() error {
 	return nil
 }
 
+func (s *CIWebhookViewStatusCode) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *CreateBindingInputBody) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer

--- a/internal/coreapi/spec/core.gen.json
+++ b/internal/coreapi/spec/core.gen.json
@@ -5191,7 +5191,7 @@
           "required": true
         },
         "responses": {
-          "201": {
+          "2XX": {
             "content": {
               "application/json": {
                 "schema": {

--- a/internal/coreapi/spec/normalize.go
+++ b/internal/coreapi/spec/normalize.go
@@ -78,6 +78,7 @@ func run() error {
 
 	ops := foldErrorResponses(doc)
 	loosened := loosenReadModelEnums(doc)
+	reenroll := addCreateCIWebhookReenrollStatus(doc)
 
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
@@ -90,8 +91,52 @@ func run() error {
 		return fmt.Errorf("write spec: %w", err)
 	}
 
-	fmt.Printf("normalize: folded error responses on %d operation(s), loosened %d read-model enum field(s) → %s\n", ops, loosened, outPath)
+	fmt.Printf("normalize: folded error responses on %d operation(s), loosened %d read-model enum field(s), added %d re-enroll status → %s\n", ops, loosened, reenroll, outPath)
 	return nil
+}
+
+// addCreateCIWebhookReenrollStatus teaches the generated client that
+// POST /repos/{repoId}/ci-webhooks can answer 200 as well as 201.
+//
+// The handler is idempotent: it returns 201 on a fresh enroll and 200 on an
+// idempotent re-enroll of an existing subscription (both carry the same
+// CIWebhookView body). huma only documents its Operation.DefaultStatus (201),
+// so the pristine spec omits the 200 — and ogen's decoder then treats a 200
+// re-enroll as an unexpected status, surfacing the idempotent success as a
+// content-type error rather than returning the subscription.
+//
+// The fix replaces the single literal 201 with a "2XX" range (same schema),
+// so ogen decodes any 2xx to one concrete *CIWebhookViewStatusCode — no
+// per-status sum type (declaring 200 and 201 separately would force one),
+// and the wrapper's StatusCode still tells fresh (201) from re-enroll (200)
+// apart. Returns 1 if applied, else 0.
+//
+// See UPSTREAM.md item 3: the real fix is huma advertising the 200 upstream,
+// after which this transform can be deleted.
+func addCreateCIWebhookReenrollStatus(doc map[string]any) int {
+	paths, ok := doc["paths"].(map[string]any)
+	if !ok {
+		return 0
+	}
+	item, ok := paths["/repos/{repoId}/ci-webhooks"].(map[string]any)
+	if !ok {
+		return 0
+	}
+	post, ok := item["post"].(map[string]any)
+	if !ok {
+		return 0
+	}
+	responses, ok := post["responses"].(map[string]any)
+	if !ok {
+		return 0
+	}
+	created, ok := responses["201"]
+	if !ok {
+		return 0
+	}
+	delete(responses, "201")
+	responses["2XX"] = created
+	return 1
 }
 
 // readModelEnumFields lists the response read-model schema fields whose


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/860
<!-- entire-trail-link-end -->

Stacks on #1754 (→ #1753). Review/merge those first.

## Why

The `entire ci buildkite` subgroup shipped as a "coming soon" placeholder in
the scaffold PR. This turns it into the real operator surface for managing a
repo's Buildkite CI-webhook subscriptions through the core-mediated
management API (the ci-webhooks routes shipped in entire-core under COR-836).

The whole `ci` group stays gated behind the `internal` build tag, so none of
this appears in released `entire` binaries.

## What

Four verbs under `entire ci buildkite`, each resolving `<repo>` to a ULID via
the inherited `ResolveNativeRepo` (native `<project>/<repo>` path or a raw repo
ULID; GitHub mirrors rejected):

- `enroll <repo> [pipeline] --bk-org <slug> --bk-cluster-id <id> [--ref-filter <glob>] [--events create,update] [--display-name <s>]`
  → `POST /api/v1/repos/{repoId}/ci-webhooks` with `provider: buildkite`. The
  optional `[pipeline]` positional is omitted to let the server default it to
  the repo name. No token field — the Buildkite credential is operator-seeded,
  org-level. `--bk-org` is required; `--bk-cluster-id` is enforced by the
  server (a later PR resolves it via cluster discovery, so it is not marked
  required client-side yet). Prints `Enrolled` on a fresh 201 and `Re-enrolled`
  on an idempotent 200.
- `list <repo>` → `GET …/ci-webhooks`, rendered as an aligned table (id,
  provider, bk_org, pipeline, enabled, ref_filter, events) or raw `--json`.
- `update <repo> <subscriptionId> [--enabled=bool] [--ref-filter <glob>] [--events …] [--display-name <s>]`
  → `PATCH …/ci-webhooks/{id}`, sending **only** the flags the user set (cobra
  `Changed` checks; unset = unchanged). An explicit empty `--events` clears the
  list. A no-op update (no field flags) is rejected before any request.
- `remove <repo> <subscriptionId> [--teardown]` → `DELETE …/ci-webhooks/{id}?teardown=<bool>`
  (204). `--teardown` also revokes the enrollment identity; the Buildkite
  pipeline is always kept.

Because the `cli` package imports this one (`root.go` calls `ci.Register`), the
verbs can't reuse `cli`'s `runCore*` helpers — the package carries a small,
clearly-commented local `runCore` preamble and rendering helpers, mirroring how
the inherited `resolve.go` already replicates its control-plane helpers to avoid
the import cycle.

### coreapi client

No hand-written client and no full regen were needed: the base branch's spec
refresh already exposes `CreateRepoCIWebhook` / `ListRepoCIWebhooks` /
`PatchRepoCIWebhook` / `DeleteRepoCIWebhook` and their DTOs in
`internal/coreapi/`.

One targeted spec workaround was added and the client regenerated via the
documented `go generate ./internal/coreapi/...` path: the enroll `POST` is
idempotent (201 fresh / 200 re-enroll, same body) but huma documents only its
`DefaultStatus` (201), so ogen treated a 200 re-enroll as an unexpected status
and failed to decode it. `spec/normalize.go` (`addCreateCIWebhookReenrollStatus`)
rewrites that operation's success response to a `2XX` range, so ogen emits one
concrete `*CIWebhookViewStatusCode` — declaring 200 and 201 separately would
force a per-status sum type and break the `(*T, error)` ergonomics the rest of
the client relies on. The wrapper's `StatusCode` still distinguishes fresh from
re-enroll. Tracked as UPSTREAM.md item 3; the real fix is huma advertising the
200. The regenerated diff is confined to the enroll operation.

## Verification

- `go build ./...` and `go build -tags internal ./...` both pass.
- `go test -tags internal ./cmd/entire/cli/ci/...` and the `!internal` variant
  pass, including `-race`. Tests fake the core client with `httptest` and cover
  flag parsing, body assembly, fresh-vs-re-enroll rendering, `--json` output,
  PATCH sending only changed fields, the empty-`--events` clear, the
  required-`--bk-org` and no-op-update guards, and the DELETE `teardown` query.
- `go test ./internal/coreapi/...` passes after the regen.
- `mise run fmt` clean; `mise run lint` and
  `golangci-lint run --build-tags internal ./cmd/entire/cli/ci/...` report 0
  issues.
- `entire ci buildkite enroll|list|update|remove --help` render correctly in an
  `-tags internal` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHPhjYDtZx71THMtVwc83E

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Internal-only CLI, but enroll/remove affect CI webhook subscriptions and optional OIDC/enrollment teardown on delete; coreapi spec normalization changes generated enroll client behavior.
> 
> **Overview**
> Replaces the internal `entire ci buildkite` placeholder with **enroll**, **list**, **update**, and **remove** verbs that call the core repo CI-webhook API after resolving `<repo>` via `ResolveNativeRepo`. Human output uses tables/field views; **list**, **enroll**, and **update** support **`--json`**. **Enroll** distinguishes fresh **201** vs idempotent **200**; **update** PATCHes only flags the user set (including clearing events with empty `--events`**); **remove** accepts **`--teardown`** for enrollment identity revocation.
> 
> The **`ci`** package adds local **`runCore`** / rendering helpers (import-cycle safe) and **`httptest`** coverage for request bodies, guards, and teardown query params.
> 
> **coreapi** gains a spec normalize step so idempotent enroll **200** decodes: enroll success is modeled as **`*CIWebhookViewStatusCode`** with a **2XX** response range instead of **201** only (**UPSTREAM.md** item 3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5be3c68596499e8a41ef433917d483e1ce54755. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->