### PR TITLE
cli: entire ci buildkite watch (live build status)

### DIFF
--- a/cmd/entire/cli/ci/buildkite_internal.go
+++ b/cmd/entire/cli/ci/buildkite_internal.go
@@ -34,6 +34,7 @@ func newBuildkiteCmd() *cobra.Command {
 	cmd.AddCommand(newBuildkiteListCmd())
 	cmd.AddCommand(newBuildkiteUpdateCmd())
 	cmd.AddCommand(newBuildkiteRemoveCmd())
+	cmd.AddCommand(newBuildkiteWatchCmd())
 	return cmd
 }
 

--- a/cmd/entire/cli/ci/buildkite_watch.go
+++ b/cmd/entire/cli/ci/buildkite_watch.go
@@ -1,0 +1,264 @@
+package ci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+)
+
+// This file is intentionally untagged (no `internal` build constraint): it is
+// the provider-neutral watch renderer, ported from entiredb's
+// cmd/entire-ci/cli/buildkite_watch.go. Keeping it out of the build tag lets the
+// normal `go test` run cover renderBuild and runWatch. The command constructor
+// and the core-backed data source that consume it live in
+// buildkite_watch_internal.go, gated on `internal` alongside the other verbs.
+
+// errNoActiveBuilds is returned by runWatch when no build number was given and
+// the source has nothing in flight to watch.
+var errNoActiveBuilds = errors.New("no active builds")
+
+// These Buildkite build/step states recur across the three state-classifier
+// funcs below (terminal, color, glyph); named so each literal has a single
+// source. Single-use states (running, scheduled, …) stay inline.
+const (
+	statePassed   = "passed"
+	stateFailed   = "failed"
+	stateCanceled = "canceled"
+	stateBlocked  = "blocked"
+)
+
+// --- neutral view model: the data-source seam ---
+//
+// stepView / buildView are deliberately provider-agnostic. The watcher's
+// renderer consumes only these, so the data source (here: the core-mediated
+// builds endpoint) can be swapped without touching the renderer.
+
+type stepView struct {
+	Label       string
+	Key         string
+	State       string
+	Exit        *int
+	Started     time.Time
+	Finished    time.Time
+	HasStarted  bool
+	HasFinished bool
+}
+
+type buildView struct {
+	Number      int
+	State       string
+	Branch      string
+	Commit      string
+	Message     string
+	URL         string
+	Started     time.Time
+	Finished    time.Time
+	HasStarted  bool
+	HasFinished bool
+	Steps       []stepView
+}
+
+// buildSource abstracts where build status comes from, so the poll loop and
+// renderer are testable against a fake and independent of the transport. The
+// only production implementation reads entire-core's mediated builds endpoint
+// (see coreBuildSource in buildkite_watch_internal.go).
+type buildSource interface {
+	// ActiveBuilds returns in-flight builds, newest first, for picking a
+	// default build when the caller didn't name one.
+	ActiveBuilds(ctx context.Context) ([]buildView, error)
+	// Build returns a single build with its steps.
+	Build(ctx context.Context, number int) (buildView, error)
+}
+
+// runWatch polls src for build `number` and renders a live step tree until the
+// build reaches a terminal state. When number <= 0 it picks the most recent
+// active build. On a TTY it redraws in place; otherwise it prints a fresh frame
+// only when build/step states change (so piped output is a clean transition
+// log, not a per-tick flood).
+func runWatch(ctx context.Context, out io.Writer, src buildSource, number int, interval time.Duration, clock func() time.Time, tty bool) error {
+	if clock == nil {
+		clock = time.Now
+	}
+	if number <= 0 {
+		active, err := src.ActiveBuilds(ctx)
+		if err != nil {
+			return fmt.Errorf("list active builds: %w", err)
+		}
+		if len(active) == 0 {
+			return errNoActiveBuilds
+		}
+		number = active[0].Number
+		if len(active) > 1 {
+			fmt.Fprintf(out, "watching the most recent of %d active builds (#%d); pass a build number to pick another\n\n", len(active), number)
+		}
+	}
+
+	var prevLines int
+	lastSig := ""
+	for {
+		v, err := src.Build(ctx, number)
+		if err != nil {
+			return fmt.Errorf("get build #%d: %w", number, err)
+		}
+		frame := renderBuild(v, clock(), tty)
+		terminal := isTerminalBuildState(v.State)
+		if tty {
+			if prevLines > 0 {
+				fmt.Fprintf(out, "\x1b[%dA\x1b[J", prevLines)
+			}
+			fmt.Fprint(out, frame)
+			prevLines = strings.Count(frame, "\n")
+		} else if sig := stateSignature(v); sig != lastSig || terminal {
+			fmt.Fprint(out, frame)
+			lastSig = stateSignature(v)
+		}
+		if terminal {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("watch interrupted: %w", ctx.Err())
+		case <-time.After(interval):
+		}
+	}
+}
+
+// renderBuild produces one frame of the watch view. Pure (no I/O, no clock) so
+// it's unit-testable; `now` supplies the reference time for in-progress
+// durations and `color` gates ANSI on the build-state word only (kept out of
+// the tabwriter block so escape codes don't break column alignment).
+func renderBuild(v buildView, now time.Time, color bool) string {
+	var b strings.Builder
+	header := fmt.Sprintf("Build #%d  %s", v.Number, colorize(strings.ToUpper(v.State), buildColor(v.State), color))
+	var meta []string
+	if v.Branch != "" {
+		meta = append(meta, v.Branch)
+	}
+	if v.Commit != "" {
+		meta = append(meta, shortCommit(v.Commit))
+	}
+	if d, ok := elapsed(v.Started, v.HasStarted, v.Finished, v.HasFinished, now); ok {
+		meta = append(meta, fmtDuration(d))
+	}
+	if len(meta) > 0 {
+		header += "  " + strings.Join(meta, " · ")
+	}
+	b.WriteString(header + "\n")
+	if v.Message != "" {
+		b.WriteString("  " + v.Message + "\n")
+	}
+	if v.URL != "" {
+		b.WriteString("  " + v.URL + "\n")
+	}
+	if len(v.Steps) == 0 {
+		b.WriteString("  (no steps yet)\n")
+		return b.String()
+	}
+	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+	for _, s := range v.Steps {
+		dur := ""
+		if d, ok := elapsed(s.Started, s.HasStarted, s.Finished, s.HasFinished, now); ok {
+			dur = fmtDuration(d)
+		}
+		exit := ""
+		if s.Exit != nil && *s.Exit != 0 {
+			exit = fmt.Sprintf("exit %d", *s.Exit)
+		}
+		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\n", stepGlyph(s.State), s.Label, s.State, dur, exit)
+	}
+	_ = tw.Flush()
+	return b.String()
+}
+
+// isTerminalBuildState reports whether a build has stopped progressing (so the
+// watcher should exit). "blocked" counts: the build is paused on a block step
+// and won't move without human action.
+func isTerminalBuildState(s string) bool {
+	switch s {
+	case statePassed, stateFailed, stateCanceled, "skipped", "not_run", stateBlocked, "finished":
+		return true
+	}
+	return false
+}
+
+func stepGlyph(state string) string {
+	switch state {
+	case statePassed:
+		return "✓"
+	case stateFailed, "timed_out", "broken":
+		return "✗"
+	case "running":
+		return "▶"
+	case stateCanceled, "canceling":
+		return "⊘"
+	case stateBlocked, "unblocked":
+		return "▮"
+	case "skipped", "not_run":
+		return "–"
+	default: // scheduled, waiting, assigned, accepted, limited, ...
+		return "·"
+	}
+}
+
+func buildColor(state string) string {
+	switch state {
+	case statePassed:
+		return "32" // green
+	case stateFailed, stateCanceled, stateBlocked:
+		return "31" // red
+	case "running", "scheduled", "failing", "canceling":
+		return "33" // yellow
+	}
+	return ""
+}
+
+func colorize(s, code string, on bool) string {
+	if !on || code == "" {
+		return s
+	}
+	return "\x1b[" + code + "m" + s + "\x1b[0m"
+}
+
+func stateSignature(v buildView) string {
+	var b strings.Builder
+	b.WriteString(v.State)
+	for _, s := range v.Steps {
+		b.WriteByte('|')
+		b.WriteString(s.State)
+	}
+	return b.String()
+}
+
+func elapsed(start time.Time, hasStart bool, end time.Time, hasEnd bool, now time.Time) (time.Duration, bool) {
+	if !hasStart {
+		return 0, false
+	}
+	stop := now
+	if hasEnd {
+		stop = end
+	}
+	if d := stop.Sub(start); d > 0 {
+		return d, true
+	}
+	return 0, true
+}
+
+func fmtDuration(d time.Duration) string {
+	secs := int(d.Round(time.Second).Seconds())
+	if secs < 60 {
+		return strconv.Itoa(secs) + "s"
+	}
+	return fmt.Sprintf("%dm%02ds", secs/60, secs%60)
+}
+
+func shortCommit(c string) string {
+	if len(c) >= 7 {
+		return c[:7]
+	}
+	return c
+}

--- a/cmd/entire/cli/ci/buildkite_watch_internal.go
+++ b/cmd/entire/cli/ci/buildkite_watch_internal.go
@@ -1,0 +1,285 @@
+//go:build internal
+
+package ci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+const (
+	// defaultWatchInterval is the poll cadence when --interval is unset.
+	defaultWatchInterval = 2 * time.Second
+	// ciBuildsLimit is how many recent builds we request per poll. The server
+	// clamps this to 1..200 (default 50); we ask for enough headroom to find a
+	// named build among recent ones and to spot in-flight builds without paging.
+	ciBuildsLimit = 100
+)
+
+// activeBuildStates are the Buildkite build states treated as "in flight" when
+// picking a default build to watch.
+var activeBuildStates = []string{"scheduled", "running", "failing", "canceling"}
+
+// newBuildkiteWatchCmd is the `entire ci buildkite watch` verb: a `gh run
+// watch`-style live view of a repo's Buildkite build, driven by the neutral
+// renderer in buildkite_watch.go over the core-mediated builds endpoint.
+func newBuildkiteWatchCmd() *cobra.Command {
+	var (
+		pipeline string
+		interval time.Duration
+	)
+	cmd := &cobra.Command{
+		Use:   "watch <repo> [build]",
+		Short: "Watch a repo's Buildkite build status live (like `gh run watch`)",
+		Long: "Watch a repo's Buildkite build progress from the terminal, like `gh run watch`.\n\n" +
+			"<repo> is a native <project>/<repo> path or a repo ULID. With no [build]\n" +
+			"number the most recent in-progress build is watched; pass a number to watch a\n" +
+			"specific one. Use --pipeline to narrow to one pipeline when a repo feeds\n" +
+			"several.\n\n" +
+			"Build status comes from entire-core's mediated builds endpoint (projected from\n" +
+			"ingested Buildkite webhook events) using your login — no Buildkite API token is\n" +
+			"needed. On a TTY the step tree redraws in place; piped output logs each state\n" +
+			"transition. The watcher exits when the build reaches a terminal state.",
+		Example: "  entire ci buildkite watch acme/web\n" +
+			"  entire ci buildkite watch acme/web 42\n" +
+			"  entire ci buildkite watch acme/web --pipeline web --interval 5s",
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			number := 0
+			if len(args) == 2 {
+				n, err := strconv.Atoi(strings.TrimSpace(args[1]))
+				if err != nil || n <= 0 {
+					cmd.SilenceUsage = true
+					return fmt.Errorf("invalid build number %q: want a positive integer", args[1])
+				}
+				number = n
+			}
+			if interval <= 0 {
+				interval = defaultWatchInterval
+			}
+			pipeline = strings.TrimSpace(pipeline)
+			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+				repoID, err := ResolveNativeRepo(ctx, c, args[0])
+				if err != nil {
+					return err
+				}
+				src := &coreBuildSource{client: c, repoID: repoID, pipeline: pipeline}
+				out := cmd.OutOrStdout()
+				err = runWatch(ctx, out, src, number, interval, time.Now, isTerminalWriter(out))
+				if errors.Is(err, errNoActiveBuilds) {
+					fmt.Fprintf(out, "no in-progress builds for %s%s; pass a build number to watch a specific build\n", args[0], pipelineSuffix(pipeline))
+					return nil
+				}
+				return err
+			})
+		},
+	}
+	cmd.Flags().StringVar(&pipeline, "pipeline", "", "Only watch builds for this Buildkite pipeline slug (default: all pipelines)")
+	cmd.Flags().DurationVar(&interval, "interval", defaultWatchInterval, "Poll interval")
+	return cmd
+}
+
+// coreBuildSource is the production buildSource. It reads build status from the
+// core-mediated builds endpoint (GET /api/v1/repos/{repoId}/ci-builds), which
+// projects the Buildkite webhook events ingested by ci-webhooks. It reuses the
+// caller's coreapi client — authenticating as the logged-in user via the same
+// bearer plumbing as the other `ci` verbs — so it needs no per-user Buildkite
+// token and no leaf ops token.
+type coreBuildSource struct {
+	client   *coreapi.Client
+	repoID   string
+	pipeline string // optional pipeline-slug filter ("" = all pipelines)
+}
+
+// ciJobDTO / ciBuildDTO / ciBuildsResponse mirror entire-core's ci-builds
+// response DTO (api/corev1: CIJobView / CIBuildView) field for field. This
+// endpoint (entiredb#2741) is not yet in this repo's generated coreapi spec, so
+// the request is hand-rolled via coreapi.Client.GetJSON and decoded here. Once
+// the spec is regenerated to include ci-builds, delete these structs and
+// coreBuildSource.fetch's GetJSON call in favour of the generated method.
+type ciJobDTO struct {
+	BKJobID    string     `json:"bk_job_id"`
+	Type       string     `json:"type"`
+	Name       string     `json:"name"`
+	StepKey    string     `json:"step_key"`
+	State      string     `json:"state"`
+	ExitStatus *int       `json:"exit_status,omitempty"`
+	StartedAt  *time.Time `json:"started_at,omitempty"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+}
+
+type ciBuildDTO struct {
+	BKBuildUUID    string     `json:"bk_build_uuid"`
+	BKOrganization string     `json:"bk_organization"`
+	BKPipeline     string     `json:"bk_pipeline"`
+	BuildNumber    int64      `json:"build_number"`
+	State          string     `json:"state"`
+	Commit         string     `json:"commit"`
+	Branch         string     `json:"branch"`
+	Message        string     `json:"message"`
+	WebURL         string     `json:"web_url"`
+	CreatedAt      *time.Time `json:"created_at,omitempty"`
+	StartedAt      *time.Time `json:"started_at,omitempty"`
+	FinishedAt     *time.Time `json:"finished_at,omitempty"`
+	LastEvent      string     `json:"last_event"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+	Jobs           []ciJobDTO `json:"jobs"`
+}
+
+type ciBuildsResponse struct {
+	Builds []ciBuildDTO `json:"builds"`
+}
+
+// fetch pulls the repo's recent builds, applying the pipeline filter and limit.
+// The commit filter the endpoint also supports is left unset — watch has no
+// commit input — so an empty commit means "all commits".
+func (s *coreBuildSource) fetch(ctx context.Context) ([]ciBuildDTO, error) {
+	q := url.Values{}
+	if s.pipeline != "" {
+		q.Set("pipeline", s.pipeline)
+	}
+	q.Set("limit", strconv.Itoa(ciBuildsLimit))
+	var resp ciBuildsResponse
+	if err := s.client.GetJSON(ctx, "repos/"+s.repoID+"/ci-builds", q, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Builds, nil
+}
+
+func (s *coreBuildSource) ActiveBuilds(ctx context.Context) ([]buildView, error) {
+	builds, err := s.fetch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	views := make([]buildView, 0, len(builds))
+	for i := range builds {
+		if !isActiveBuildState(builds[i].State) {
+			continue
+		}
+		views = append(views, buildViewFromCore(&builds[i]))
+	}
+	sort.Slice(views, func(i, j int) bool { return views[i].Number > views[j].Number })
+	return views, nil
+}
+
+func (s *coreBuildSource) Build(ctx context.Context, number int) (buildView, error) {
+	builds, err := s.fetch(ctx)
+	if err != nil {
+		return buildView{}, err
+	}
+	for i := range builds {
+		if int(builds[i].BuildNumber) == number {
+			return buildViewFromCore(&builds[i]), nil
+		}
+	}
+	return buildView{}, fmt.Errorf("build #%d not found for this repo%s (it may be older than the %d most recent builds)", number, pipelineSuffix(s.pipeline), ciBuildsLimit)
+}
+
+// buildViewFromCore projects a ci-builds DTO onto the neutral view model.
+// Waiter jobs (structural barriers with no command) are dropped — they're noise
+// in a step tree.
+func buildViewFromCore(b *ciBuildDTO) buildView {
+	v := buildView{
+		Number:  int(b.BuildNumber),
+		State:   b.State,
+		Branch:  b.Branch,
+		Commit:  b.Commit,
+		Message: firstLine(b.Message),
+		URL:     b.WebURL,
+	}
+	v.Started, v.HasStarted = fromPtrTime(b.StartedAt)
+	v.Finished, v.HasFinished = fromPtrTime(b.FinishedAt)
+	for i := range b.Jobs {
+		j := &b.Jobs[i]
+		if j.Type == "waiter" {
+			continue
+		}
+		sv := stepView{Label: stepLabel(j.Name, j.StepKey, j.Type), Key: j.StepKey, State: j.State, Exit: j.ExitStatus}
+		sv.Started, sv.HasStarted = fromPtrTime(j.StartedAt)
+		sv.Finished, sv.HasFinished = fromPtrTime(j.FinishedAt)
+		v.Steps = append(v.Steps, sv)
+	}
+	return v
+}
+
+// fromPtrTime projects an optional timestamp onto the (time, ok) pair the view
+// model uses; a nil or zero time means "not yet started/finished".
+func fromPtrTime(t *time.Time) (time.Time, bool) {
+	if t == nil || t.IsZero() {
+		return time.Time{}, false
+	}
+	return *t, true
+}
+
+func isActiveBuildState(state string) bool {
+	for _, s := range activeBuildStates {
+		if state == s {
+			return true
+		}
+	}
+	return false
+}
+
+// pipelineSuffix renders an optional " (pipeline <slug>)" qualifier for
+// user-facing messages, or "" when no pipeline filter is set.
+func pipelineSuffix(pipeline string) string {
+	if pipeline == "" {
+		return ""
+	}
+	return " (pipeline " + pipeline + ")"
+}
+
+// firstLine trims a build message to its first line, capped at 72 runes, for a
+// tidy single-line header.
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	if len([]rune(s)) > 72 {
+		s = string([]rune(s)[:71]) + "…"
+	}
+	return s
+}
+
+// stepLabel picks the best human label for a step from its (name, step_key,
+// type), falling back through them so a frame never shows a blank cell.
+func stepLabel(name, stepKey, typ string) string {
+	if s := strings.TrimSpace(name); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(stepKey); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(typ); s != "" {
+		return "(" + s + ")"
+	}
+	return "(step)"
+}
+
+// isTerminalWriter reports whether w is a character device (a TTY), so the
+// watcher can choose in-place redraw vs. plain transition logging.
+// Dependency-free: no x/term / go-isatty.
+func isTerminalWriter(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/cmd/entire/cli/ci/buildkite_watch_internal_test.go
+++ b/cmd/entire/cli/ci/buildkite_watch_internal_test.go
@@ -1,0 +1,152 @@
+//go:build internal
+
+package ci
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+func tp(t *testing.T, s string) *time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+	return &parsed
+}
+
+// buildsJSON encodes a ci-builds response fixture the way entire-core would.
+func buildsJSON(t *testing.T, builds ...ciBuildDTO) []byte {
+	t.Helper()
+	b, err := json.Marshal(ciBuildsResponse{Builds: builds})
+	require.NoError(t, err)
+	return b
+}
+
+// newCoreSource points a coreBuildSource at srvURL via the same bearer client
+// the ci verbs use, so the hand-rolled GetJSON call is exercised end to end.
+func newCoreSource(t *testing.T, srvURL, pipeline string) *coreBuildSource {
+	t.Helper()
+	c, err := coreapi.NewWithBearer(srvURL, "tok")
+	require.NoError(t, err)
+	return &coreBuildSource{client: c, repoID: testRepoULID, pipeline: pipeline}
+}
+
+func TestCoreBuildSource_BuildMapsDTO(t *testing.T) {
+	var gotPath string
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		assert.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+		writeJSONResponse(t, w, http.StatusOK, buildsJSON(t, ciBuildDTO{
+			BKBuildUUID: "uuid-1", BKOrganization: "acme", BKPipeline: "web",
+			BuildNumber: 42, State: "running", Branch: "main", Commit: "abcdef0123456",
+			Message: "fix: the thing\n\nlong body ignored", WebURL: "https://buildkite.com/acme/web/builds/42",
+			StartedAt: tp(t, "2026-06-09T12:00:00Z"),
+			Jobs: []ciJobDTO{
+				{Type: "script", Name: ":package: build", StepKey: "build", State: "passed", ExitStatus: new(0),
+					StartedAt: tp(t, "2026-06-09T12:00:00Z"), FinishedAt: tp(t, "2026-06-09T12:00:12Z")},
+				{Type: "waiter", State: "passed"},
+				{Type: "script", Name: "", StepKey: "tests", State: "running", StartedAt: tp(t, "2026-06-09T12:00:12Z")},
+			},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	v, err := newCoreSource(t, srv.URL, "web").Build(t.Context(), 42)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/v1/repos/"+testRepoULID+"/ci-builds", gotPath)
+	assert.Equal(t, "web", gotQuery.Get("pipeline"))
+	assert.Equal(t, "100", gotQuery.Get("limit"))
+
+	assert.Equal(t, 42, v.Number)
+	assert.Equal(t, "running", v.State)
+	assert.Equal(t, "main", v.Branch)
+	assert.Equal(t, "fix: the thing", v.Message, "message is trimmed to its first line")
+	assert.True(t, v.HasStarted)
+	require.Len(t, v.Steps, 2, "the waiter job must be dropped")
+	assert.Equal(t, ":package: build", v.Steps[0].Label)
+	assert.True(t, v.Steps[0].HasFinished)
+	assert.Equal(t, "tests", v.Steps[1].Label, "empty name falls back to step_key")
+}
+
+func TestCoreBuildSource_BuildNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(t, w, http.StatusOK, buildsJSON(t))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newCoreSource(t, srv.URL, "").Build(t.Context(), 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build #7 not found")
+}
+
+func TestCoreBuildSource_ActiveBuildsFiltersAndSorts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No pipeline filter set → the param is absent.
+		assert.Empty(t, r.URL.Query().Get("pipeline"))
+		writeJSONResponse(t, w, http.StatusOK, buildsJSON(t,
+			ciBuildDTO{BuildNumber: 9, State: "passed"},
+			ciBuildDTO{BuildNumber: 14, State: "running"},
+			ciBuildDTO{BuildNumber: 11, State: "scheduled"},
+		))
+	}))
+	t.Cleanup(srv.Close)
+
+	views, err := newCoreSource(t, srv.URL, "").ActiveBuilds(t.Context())
+	require.NoError(t, err)
+	require.Len(t, views, 2, "the passed build is not active")
+	assert.Equal(t, 14, views[0].Number, "newest active build first")
+	assert.Equal(t, 11, views[1].Number)
+}
+
+// TestWatchCommand_TerminalBuildExits drives the whole `ci buildkite watch`
+// verb: ResolveNativeRepo short-circuits on the ULID, the poll loop fetches a
+// terminal build on the first tick, renders it, and exits without sleeping.
+func TestWatchCommand_TerminalBuildExits(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(t, w, http.StatusOK, buildsJSON(t, ciBuildDTO{
+			BuildNumber: 42, State: "passed", Branch: "main",
+			Jobs: []ciJobDTO{{Type: "script", Name: "build", State: "passed", ExitStatus: new(0)}},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	out, err := runBuildkiteCmd(t, srv.URL, "buildkite", "watch", testRepoULID, "42")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Build #42  PASSED")
+	assert.Contains(t, out, "build")
+}
+
+func TestWatchCommand_NoActiveBuilds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(t, w, http.StatusOK, buildsJSON(t))
+	}))
+	t.Cleanup(srv.Close)
+
+	out, err := runBuildkiteCmd(t, srv.URL, "buildkite", "watch", testRepoULID, "--pipeline", "web")
+	require.NoError(t, err)
+	assert.Contains(t, out, "no in-progress builds")
+	assert.Contains(t, out, "pipeline web")
+}
+
+func TestWatchCommand_RejectsBadBuildNumber(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(t, w, http.StatusOK, buildsJSON(t))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := runBuildkiteCmd(t, srv.URL, "buildkite", "watch", testRepoULID, "notanumber")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid build number")
+}

--- a/cmd/entire/cli/ci/buildkite_watch_test.go
+++ b/cmd/entire/cli/ci/buildkite_watch_test.go
@@ -1,0 +1,153 @@
+package ci
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This test file is untagged so the provider-neutral renderer and poll loop are
+// covered by a normal `go test` run, not only the internal build.
+
+func TestIsTerminalBuildState(t *testing.T) {
+	for _, s := range []string{"passed", "failed", "canceled", "skipped", "not_run", "blocked", "finished"} {
+		if !isTerminalBuildState(s) {
+			t.Errorf("%q should be terminal", s)
+		}
+	}
+	for _, s := range []string{"running", "scheduled", "failing", "canceling"} {
+		if isTerminalBuildState(s) {
+			t.Errorf("%q should NOT be terminal", s)
+		}
+	}
+}
+
+func TestRenderBuild_StepTree(t *testing.T) {
+	start := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	now := start.Add(15 * time.Second)
+	v := buildView{
+		Number: 12, State: "running", Branch: "main", Commit: "abcdef0123456",
+		URL: "https://buildkite.com/entire/canary/builds/12", HasStarted: true, Started: start,
+		Steps: []stepView{
+			{Label: ":package: build", State: "passed", Exit: new(0), HasStarted: true, Started: start, HasFinished: true, Finished: start.Add(12 * time.Second)},
+			{Label: ":test: tests", State: "running", HasStarted: true, Started: start.Add(12 * time.Second)},
+			{Label: ":rocket: deploy", State: "scheduled"},
+		},
+	}
+	out := renderBuild(v, now, false)
+
+	for _, want := range []string{
+		"Build #12  RUNNING", "main", "abcdef0", "https://buildkite.com/entire/canary/builds/12",
+		":package: build", "passed", ":test: tests", "running", ":rocket: deploy", "scheduled",
+		"✓", "▶", "·", "15s",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("render missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderBuild_ShowsFailingExitStatus(t *testing.T) {
+	v := buildView{
+		Number: 3, State: "failed",
+		Steps: []stepView{{Label: "tests", State: "failed", Exit: new(2)}},
+	}
+	out := renderBuild(v, time.Now(), false)
+	if !strings.Contains(out, "✗") || !strings.Contains(out, "exit 2") {
+		t.Errorf("expected failure glyph + exit code in:\n%s", out)
+	}
+}
+
+func TestRenderBuild_EmptyState(t *testing.T) {
+	v := buildView{Number: 1, State: "scheduled"}
+	out := renderBuild(v, time.Now(), false)
+	if !strings.Contains(out, "(no steps yet)") {
+		t.Errorf("expected empty-state note in:\n%s", out)
+	}
+}
+
+func TestRenderBuild_ColorGatesStateWordOnly(t *testing.T) {
+	v := buildView{Number: 5, State: "passed", Steps: []stepView{{Label: "build", State: "passed"}}}
+	colored := renderBuild(v, time.Now(), true)
+	if !strings.Contains(colored, "\x1b[32mPASSED\x1b[0m") {
+		t.Errorf("expected colorized state word in:\n%q", colored)
+	}
+	plain := renderBuild(v, time.Now(), false)
+	if strings.Contains(plain, "\x1b[") {
+		t.Errorf("plain render must carry no ANSI escapes:\n%q", plain)
+	}
+}
+
+// fakeSource scripts a sequence of Build() results so we can drive runWatch
+// deterministically to a terminal state.
+type fakeSource struct {
+	active []buildView
+	seq    []buildView
+	i      int
+	calls  int
+}
+
+func (f *fakeSource) ActiveBuilds(context.Context) ([]buildView, error) { return f.active, nil }
+func (f *fakeSource) Build(context.Context, int) (buildView, error) {
+	f.calls++
+	v := f.seq[f.i]
+	if f.i < len(f.seq)-1 {
+		f.i++
+	}
+	return v, nil
+}
+
+func TestRunWatch_StopsAtTerminalAndLogsTransitions(t *testing.T) {
+	src := &fakeSource{seq: []buildView{
+		{Number: 12, State: "running", Steps: []stepView{{Label: "build", State: "running"}}},
+		{Number: 12, State: "running", Steps: []stepView{{Label: "build", State: "passed", Exit: new(0)}}},
+		{Number: 12, State: "passed", Steps: []stepView{{Label: "build", State: "passed", Exit: new(0)}}},
+	}}
+	var out strings.Builder
+	clock := func() time.Time { return time.Unix(0, 0) }
+
+	err := runWatch(context.Background(), &out, src, 12, time.Millisecond, clock, false)
+	if err != nil {
+		t.Fatalf("runWatch: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Build #12  PASSED") {
+		t.Errorf("expected terminal PASSED frame in:\n%s", got)
+	}
+	// Non-TTY prints a frame per state transition: running, build-passed, build PASSED = 3.
+	if n := strings.Count(got, "Build #12"); n != 3 {
+		t.Errorf("frame count = %d, want 3 (one per state transition)", n)
+	}
+	if src.calls != 3 {
+		t.Errorf("Build calls = %d, want 3 (stopped at terminal)", src.calls)
+	}
+}
+
+func TestRunWatch_NoActiveBuilds(t *testing.T) {
+	src := &fakeSource{active: nil}
+	var out strings.Builder
+	err := runWatch(context.Background(), &out, src, 0, time.Millisecond, nil, false)
+	if err == nil || !strings.Contains(err.Error(), "no active builds") {
+		t.Fatalf("err = %v, want errNoActiveBuilds", err)
+	}
+}
+
+func TestRunWatch_PicksMostRecentActive(t *testing.T) {
+	src := &fakeSource{
+		active: []buildView{{Number: 14, State: "running"}, {Number: 9, State: "running"}},
+		seq:    []buildView{{Number: 14, State: "passed", Steps: []stepView{{Label: "x", State: "passed"}}}},
+	}
+	var out strings.Builder
+	if err := runWatch(context.Background(), &out, src, 0, time.Millisecond, nil, false); err != nil {
+		t.Fatalf("runWatch: %v", err)
+	}
+	// With >1 active build, runWatch emits a notice naming the count and the
+	// chosen (newest, active[0]) build number.
+	if !strings.Contains(out.String(), "2 active builds") {
+		t.Errorf("expected multi-active notice in:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "#14") {
+		t.Errorf("expected to watch newest active build #14 in:\n%s", out.String())
+	}
+}

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -2,8 +2,12 @@ package coreapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -134,6 +138,59 @@ func clientForTarget(target auth.ControlPlaneTarget) (*Client, error) {
 // silently miss the ENTIRE_TOKEN and cluster cases.
 func (c *Client) CoreOrigin() string {
 	return c.serverURL.Scheme + "://" + c.serverURL.Host
+}
+
+// GetJSON issues a GET to path (relative to this client's /api/v1 base),
+// applying the same bearer auth and cross-jurisdiction transport as the
+// generated operations, and decodes a 2xx JSON body into dst. A non-2xx
+// response is returned as an *ErrorModelStatusCode, so callers get the server's
+// RFC 7807 problem detail via APIError exactly as they do for generated calls.
+//
+// It is a deliberate escape hatch for control-plane endpoints not yet present
+// in the generated spec: it reuses this client's own serverURL, SecuritySource,
+// and HTTP transport rather than opening a second auth path. Its only caller is
+// `entire ci buildkite watch`, which reads GET /repos/{repoId}/ci-builds (added
+// by entiredb#2741, not yet regenerated into this client's spec). Once the spec
+// is regenerated to include ci-builds, delete GetJSON and switch that caller to
+// the generated Invoker method.
+func (c *Client) GetJSON(ctx context.Context, path string, query url.Values, dst any) error {
+	u := c.serverURL.JoinPath(path)
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if err := c.securityBearerAuth(ctx, "GetJSON", req); err != nil {
+		return fmt.Errorf("apply bearer auth: %w", err)
+	}
+	resp, err := c.cfg.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return statusCodeError(resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+// statusCodeError turns a non-2xx response into an *ErrorModelStatusCode,
+// decoding the RFC 7807 problem body when present so APIError renders the
+// server's title/detail; a body that is absent or non-JSON still yields a
+// well-formed error carrying the status code.
+func statusCodeError(resp *http.Response) error {
+	e := &ErrorModelStatusCode{StatusCode: resp.StatusCode}
+	if body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)); err == nil && len(body) > 0 {
+		_ = json.Unmarshal(body, &e.Response) //nolint:errcheck // best-effort: a missing/non-JSON body just yields a status-only error
+	}
+	return e
 }
 
 // NewWithBearer returns a *Client targeting an explicit core origin with a

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -291,5 +292,72 @@ func TestListProjectRepos_UnknownEnumValuesPassThrough(t *testing.T) {
 	}
 	if got := repo.ObjectFormat.Or(""); got != "sha512" {
 		t.Errorf("ObjectFormat = %q, want the unknown value %q passed through verbatim", got, "sha512")
+	}
+}
+
+// TestGetJSON_SuccessDecodesAndSendsBearer covers the escape-hatch GET added for
+// endpoints not yet in the generated spec: it must resolve the path against the
+// client's /api/v1 base, apply the bearer from the SecuritySource, encode the
+// query, and decode a 2xx JSON body into dst.
+func TestGetJSON_SuccessDecodesAndSendsBearer(t *testing.T) {
+	var gotPath, gotAuth, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotAuth, gotQuery = r.URL.Path, r.Header.Get("Authorization"), r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true,"n":7}`)) //nolint:errcheck // test
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := NewWithBearer(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewWithBearer: %v", err)
+	}
+	var dst struct {
+		OK bool `json:"ok"`
+		N  int  `json:"n"`
+	}
+	if err := c.GetJSON(context.Background(), "repos/R/ci-builds", url.Values{"limit": {"100"}}, &dst); err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if gotPath != "/api/v1/repos/R/ci-builds" {
+		t.Errorf("path = %q, want /api/v1/repos/R/ci-builds", gotPath)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("auth = %q, want Bearer tok", gotAuth)
+	}
+	if gotQuery != "limit=100" {
+		t.Errorf("query = %q, want limit=100", gotQuery)
+	}
+	if !dst.OK || dst.N != 7 {
+		t.Errorf("decoded = %+v, want {OK:true N:7}", dst)
+	}
+}
+
+// TestGetJSON_Non2xxReturnsProblemDetail asserts a non-2xx response surfaces as
+// an *ErrorModelStatusCode carrying the RFC 7807 detail, so APIError renders the
+// server's message exactly as it does for generated operations.
+func TestGetJSON_Non2xxReturnsProblemDetail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"title":"Not Found","detail":"repo not found","status":404}`)) //nolint:errcheck // test
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := NewWithBearer(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewWithBearer: %v", err)
+	}
+	var dst map[string]any
+	err = c.GetJSON(context.Background(), "repos/R/ci-builds", nil, &dst)
+	if err == nil {
+		t.Fatal("GetJSON: want error on 404")
+	}
+	var se *ErrorModelStatusCode
+	if !errors.As(err, &se) || se.StatusCode != http.StatusNotFound {
+		t.Fatalf("err = %v, want *ErrorModelStatusCode with 404", err)
+	}
+	if msg := APIError(err); msg != "repo not found" {
+		t.Errorf("APIError = %q, want %q", msg, "repo not found")
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/861
<!-- entire-trail-link-end -->

## Why

The `entire ci buildkite` group can enroll/list/update/remove CI-webhook
subscriptions, but there was no way to *watch* a build progress from the
terminal. This adds a `gh run watch`-style live viewer so an operator can push
and follow the resulting Buildkite build without leaving the CLI or holding a
Buildkite token.

Stacked on the `ci buildkite` verbs: **#1755 → #1754 → #1753**.

## What

`entire ci buildkite watch <repo> [build]` (internal-gated, like the rest of the
`ci` group).

- Flags: `--pipeline <name>` (filter to one pipeline slug), `--interval <dur>`
  (poll cadence, default 2s). With no `[build]`, watches the newest in-flight
  build; pass a number to pin one. Exits when the build reaches a terminal
  state. On a TTY the step tree redraws in place; piped output logs each state
  transition only.

**Ported (provider-neutral, unchanged in spirit) from entiredb's
`cmd/entire-ci/cli/buildkite_watch.go`** into the untagged
`buildkite_watch.go` so a normal `go test` run covers it:
- the `stepView` / `buildView` view model and the `buildSource` seam,
- `runWatch` (poll loop, newest-active pick, terminal-state exit via
  `isTerminalBuildState`),
- `renderBuild` (pure, ANSI in-place redraw on a TTY; signature-gated frames
  otherwise) plus its render helpers.

The two reference data sources were **not** ported — `bkBuildSource` (personal
Buildkite token) and `entireStoreSource` (leaf ops-token) are both invalid under
a user login JWT.

**Written fresh:** `coreBuildSource`, backed by the core-mediated builds
endpoint `GET /api/v1/repos/{repoId}/ci-builds?commit=&pipeline=&limit=`
(entiredb#2741, branch `dv/ci-builds-endpoint`). Because that endpoint is **not
yet in this repo's generated `coreapi` client**, the call is a hand-rolled typed
GET: a new `coreapi.Client.GetJSON` escape hatch reuses the client's own
`serverURL`, `SecuritySource` (bearer), and cross-jurisdiction HTTP transport —
no second auth path — and decodes into local structs (`ciBuildDTO` / `ciJobDTO`)
that mirror B3's response DTO field for field. `<repo>` resolves to a ULID via
the inherited `ResolveNativeRepo`.

> **Follow-up (dependency):** once entiredb#2741 merges and this repo's `coreapi`
> spec is regenerated to include `ci-builds`, delete `GetJSON` and the local
> DTOs and switch `coreBuildSource.fetch` to the generated client method. Both
> sites carry a comment saying so.

`watch` has no commit input, so the endpoint's `commit` filter is left unset
(all commits); the query sends `pipeline` (when set) and `limit`.

## Verification

- `go build ./...` and `go build -tags internal ./...` both succeed.
- `go test` and `go test -tags internal -race` pass for
  `./cmd/entire/cli/ci/...` and `./internal/coreapi/...`:
  - untagged: `renderBuild` pure tests + a fake `buildSource` driving `runWatch`
    to a terminal state (frame-per-transition, stops at terminal, picks newest
    active, empty state);
  - internal: `coreBuildSource` DTO mapping + query/path assertions against an
    `httptest` server, the full `watch` verb driven to a terminal build, the
    no-active-builds message, and bad-build-number rejection;
  - coreapi: `GetJSON` success decode + bearer/query, and non-2xx →
    `*ErrorModelStatusCode` surfacing the RFC 7807 detail via `APIError`.
- `golangci-lint run` clean under **both** the default tags and
  `--build-tags internal` for `./cmd/entire/cli/ci/...` (CI's default-tag lint
  doesn't cover the internal files); `gofmt` clean.
- Smoke: `entire ci buildkite watch --help` renders (built with `-tags internal`).

Not verifiable locally: the live poll loop against a real entire-core with the
ci-builds endpoint deployed (endpoint PR not yet merged). Exercised end-to-end
against an `httptest` fake of B3's response shape.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New control-plane polling path and hand-rolled `GetJSON` until the OpenAPI spec catches up; behavior is well-tested but depends on the not-yet-merged ci-builds endpoint shape.
> 
> **Overview**
> Adds **`entire ci buildkite watch <repo> [build]`** (internal-gated like other `ci buildkite` verbs) so operators can follow Buildkite progress from the terminal without a Buildkite API token—status comes from the logged-in user’s core **`GET /repos/{repoId}/ci-builds`** projection.
> 
> The **poll loop and renderer** live in untagged `buildkite_watch.go` (`buildSource` seam, TTY in-place redraw vs transition-only output when piped, default to newest in-flight build, `--pipeline` / `--interval`). **`coreBuildSource`** maps core DTOs to that view (drops waiter jobs, filters active builds).
> 
> Because **ci-builds is not in the generated client yet**, **`coreapi.Client.GetJSON`** is added as a temporary escape hatch reusing the same bearer auth and transport as generated calls, with local DTO structs until spec regen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bc7ddca153fa757745b3765868b981b4f2ff703. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->