### PR TITLE
DRAFT: cli: entire ci buildkite org connect/list/cluster (M1)

### DIFF
--- a/cmd/entire/cli/ci/buildkite_internal.go
+++ b/cmd/entire/cli/ci/buildkite_internal.go
@@ -35,6 +35,7 @@ func newBuildkiteCmd() *cobra.Command {
 	cmd.AddCommand(newBuildkiteUpdateCmd())
 	cmd.AddCommand(newBuildkiteRemoveCmd())
 	cmd.AddCommand(newBuildkiteWatchCmd())
+	cmd.AddCommand(newBuildkiteOrgCmd())
 	return cmd
 }
 

--- a/cmd/entire/cli/ci/buildkite_org_internal.go
+++ b/cmd/entire/cli/ci/buildkite_org_internal.go
@@ -1,0 +1,397 @@
+//go:build internal
+
+package ci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// newBuildkiteOrgCmd is the `entire ci buildkite org` subgroup: an org/project
+// admin connects their own Buildkite organization (supplying a Buildkite API
+// token entire stores encrypted) and registers the Buildkite hosted clusters
+// their pipelines run on. Every verb addresses the entire org by an <entire-org>
+// reference (an org ULID or an org name) and resolves it to a ULID via ResolveOrg
+// before calling the control plane.
+//
+// These verbs hit the ORG-scoped CI-webhooks endpoints under
+// /api/v1/orgs/{orgId}/ci/buildkite/… added by the DRAFT entiredb#2744. They are
+// not yet in this repo's generated coreapi spec, so the requests are hand-rolled
+// via the coreapi.Client PostJSON/GetJSON/DeleteJSON escape hatch and decoded
+// into the local DTOs below. Once that spec regenerates, swap these calls for the
+// generated Invoker methods and delete the DTOs + escape-hatch helpers.
+func newBuildkiteOrgCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "org",
+		Short: "Manage an org's Buildkite credentials and clusters",
+	}
+	cmd.AddCommand(newBuildkiteOrgConnectCmd())
+	cmd.AddCommand(newBuildkiteOrgListCmd())
+	cmd.AddCommand(newBuildkiteOrgClusterCmd())
+	cmd.AddCommand(newBuildkiteOrgDisconnectCmd())
+	return cmd
+}
+
+func newBuildkiteOrgConnectCmd() *cobra.Command {
+	var (
+		bkOrg   string
+		bkToken string
+	)
+	cmd := &cobra.Command{
+		Use:   "connect <entire-org>",
+		Short: "Connect (or rotate) an org's Buildkite API credential",
+		Long: "Connect a Buildkite organization to an Entire org by storing its API token.\n\n" +
+			"<entire-org> is an Entire org name or an org ULID. --bk-org is the Buildkite\n" +
+			"organization slug. The Buildkite API token is read, in order, from --bk-token,\n" +
+			"the BUILDKITE_API_TOKEN env var, or an interactive no-echo prompt. Prefer the\n" +
+			"env var or prompt: a token passed via --bk-token lands in your shell history.\n\n" +
+			"The token is sent to the server over TLS, stored encrypted, and NEVER echoed\n" +
+			"back or logged — only its byte length is reported. Re-running with a new token\n" +
+			"rotates the stored one (the server answers 200 instead of 201).",
+		Example: "  BUILDKITE_API_TOKEN=bkua_… entire ci buildkite org connect acme --bk-org acme-inc\n" +
+			"  entire ci buildkite org connect 01J… --bk-org acme-inc",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			token, err := resolveBuildkiteToken(cmd, bkToken)
+			if err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
+			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+				orgID, err := ResolveOrg(ctx, c, args[0])
+				if err != nil {
+					return err
+				}
+				body := connectOrgCredentialRequest{BKOrganization: bkOrg, BKAPIToken: token}
+				var view orgBuildkiteCredentialView
+				status, err := c.PostJSON(ctx, orgCredentialPath(orgID), body, &view)
+				if err != nil {
+					return err
+				}
+				if jsonRequested(cmd) {
+					return printJSON(cmd.OutOrStdout(), view)
+				}
+				if status == http.StatusOK {
+					fmt.Fprintf(cmd.OutOrStdout(), "✓ Rotated Buildkite credential for %q (token_len=%d)\n", view.BKOrganization, view.TokenLen)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "✓ Connected Buildkite org %q (token_len=%d)\n", view.BKOrganization, view.TokenLen)
+				}
+				return nil
+			})
+		},
+	}
+	cmd.Flags().StringVar(&bkOrg, "bk-org", "", "Buildkite organization slug (required)")
+	cmd.Flags().StringVar(&bkToken, "bk-token", "", "Buildkite API token (insecure: lands in shell history — prefer BUILDKITE_API_TOKEN or the prompt)")
+	markRequired(cmd, "bk-org")
+	addJSONFlag(cmd)
+	return cmd
+}
+
+func newBuildkiteOrgListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list <entire-org>",
+		Short: "List an org's connected Buildkite credentials and clusters",
+		Long: "List the Buildkite organizations connected to an Entire org and the hosted\n" +
+			"clusters registered for each. No token material is shown — only each\n" +
+			"credential's byte length.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+				orgID, err := ResolveOrg(ctx, c, args[0])
+				if err != nil {
+					return err
+				}
+				var credsResp listOrgCredentialsResponse
+				if err := c.GetJSON(ctx, orgCredentialsPath(orgID), nil, &credsResp); err != nil {
+					return err
+				}
+				// Clusters are scoped to a single Buildkite org, so fan out one
+				// clusters query per connected credential to assemble the org's
+				// full view. No credentials means nothing to enumerate.
+				var clusters []orgBuildkiteClusterView
+				for _, cred := range credsResp.Credentials {
+					cls, err := fetchOrgClusters(ctx, c, orgID, cred.BKOrganization)
+					if err != nil {
+						return err
+					}
+					clusters = append(clusters, cls...)
+				}
+				if jsonRequested(cmd) {
+					return printJSON(cmd.OutOrStdout(), orgBuildkiteListView{
+						Credentials: nonNilCreds(credsResp.Credentials),
+						Clusters:    nonNilClusters(clusters),
+					})
+				}
+				return printOrgBuildkiteList(cmd.OutOrStdout(), credsResp.Credentials, clusters)
+			})
+		},
+	}
+	addJSONFlag(cmd)
+	return cmd
+}
+
+func newBuildkiteOrgClusterCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cluster",
+		Short: "Manage an org's Buildkite hosted clusters",
+	}
+	cmd.AddCommand(newBuildkiteOrgClusterAddCmd())
+	return cmd
+}
+
+func newBuildkiteOrgClusterAddCmd() *cobra.Command {
+	var (
+		bkOrg         string
+		bkClusterID   string
+		authPluginRef string
+	)
+	cmd := &cobra.Command{
+		Use:   "add <entire-org>",
+		Short: "Register (or update) a Buildkite hosted cluster for an org",
+		Long: "Register a Buildkite hosted cluster so the org's pipelines can run on it.\n\n" +
+			"<entire-org> is an Entire org name or an org ULID. The upsert key is\n" +
+			"(--bk-org, --bk-cluster-id); re-running updates the row (the server answers\n" +
+			"200 instead of 201). --auth-plugin-ref pins the entire-core-auth Buildkite\n" +
+			"plugin (org/name#version); omit it to use the server's pinned default.",
+		Example: "  entire ci buildkite org cluster add acme --bk-org acme-inc --bk-cluster-id 0195… \\\n" +
+			"    --auth-plugin-ref entire-io/entire-core-auth#v1.2.3",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+				orgID, err := ResolveOrg(ctx, c, args[0])
+				if err != nil {
+					return err
+				}
+				body := registerOrgClusterRequest{
+					BKOrganization: bkOrg,
+					BKClusterID:    bkClusterID,
+					AuthPluginRef:  authPluginRef,
+				}
+				var view orgBuildkiteClusterView
+				status, err := c.PostJSON(ctx, orgClustersPath(orgID), body, &view)
+				if err != nil {
+					return err
+				}
+				if jsonRequested(cmd) {
+					return printJSON(cmd.OutOrStdout(), view)
+				}
+				verb := "Registered"
+				if status == http.StatusOK {
+					verb = "Updated"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "✓ %s Buildkite cluster %s for org %q\n", verb, view.BKClusterID, view.BKOrganization)
+				return nil
+			})
+		},
+	}
+	cmd.Flags().StringVar(&bkOrg, "bk-org", "", "Buildkite organization slug (required)")
+	cmd.Flags().StringVar(&bkClusterID, "bk-cluster-id", "", "Buildkite hosted-cluster ID (required)")
+	cmd.Flags().StringVar(&authPluginRef, "auth-plugin-ref", "", "entire-core-auth plugin ref (org/name#version); empty uses the server default")
+	markRequired(cmd, "bk-org", "bk-cluster-id")
+	addJSONFlag(cmd)
+	return cmd
+}
+
+func newBuildkiteOrgDisconnectCmd() *cobra.Command {
+	var bkOrg string
+	cmd := &cobra.Command{
+		Use:   "disconnect <entire-org>",
+		Short: "Disconnect an org's Buildkite credential",
+		Long: "Remove the stored Buildkite API credential for --bk-org from an Entire org.\n\n" +
+			"<entire-org> is an Entire org name or an org ULID. Registered clusters are\n" +
+			"config, not secrets, and are left in place.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+				orgID, err := ResolveOrg(ctx, c, args[0])
+				if err != nil {
+					return err
+				}
+				if err := c.DeleteJSON(ctx, orgCredentialPath(orgID)+"/"+url.PathEscape(bkOrg)); err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "✓ Disconnected Buildkite org %q\n", bkOrg)
+				return nil
+			})
+		},
+	}
+	cmd.Flags().StringVar(&bkOrg, "bk-org", "", "Buildkite organization slug to disconnect (required)")
+	markRequired(cmd, "bk-org")
+	return cmd
+}
+
+// orgCredentialPath / orgCredentialsPath / orgClustersPath build the escape-hatch
+// request paths (relative to the client's /api/v1 base). Kept as helpers so the
+// route strings live in exactly one place.
+func orgCredentialPath(orgID string) string  { return "orgs/" + orgID + "/ci/buildkite/credential" }
+func orgCredentialsPath(orgID string) string { return "orgs/" + orgID + "/ci/buildkite/credentials" }
+func orgClustersPath(orgID string) string    { return "orgs/" + orgID + "/ci/buildkite/clusters" }
+
+// fetchOrgClusters lists the clusters registered for one Buildkite org under the
+// Entire org. The server requires the bk_organization query parameter — the
+// registry is always org+bk-org-scoped.
+func fetchOrgClusters(ctx context.Context, c *coreapi.Client, orgID, bkOrg string) ([]orgBuildkiteClusterView, error) {
+	q := url.Values{}
+	q.Set("bk_organization", bkOrg)
+	var resp listOrgClustersResponse
+	if err := c.GetJSON(ctx, orgClustersPath(orgID), q, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Clusters, nil
+}
+
+// resolveBuildkiteToken sources the Buildkite API token for `org connect`,
+// preferring the safest input the caller supplied. Precedence: the --bk-token
+// flag (with a one-line shell-history warning), then the BUILDKITE_API_TOKEN
+// env var, then an interactive no-echo prompt when a TTY is available. It never
+// logs or echoes the token; the returned value is sent to the server over TLS
+// and nowhere else.
+func resolveBuildkiteToken(cmd *cobra.Command, flagToken string) (string, error) {
+	if strings.TrimSpace(flagToken) != "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), "warning: --bk-token is visible in your shell history; prefer BUILDKITE_API_TOKEN or the interactive prompt")
+		return flagToken, nil
+	}
+	if env := strings.TrimSpace(os.Getenv("BUILDKITE_API_TOKEN")); env != "" {
+		return env, nil
+	}
+	if interactive.CanPromptInteractively() {
+		return promptBuildkiteToken(cmd)
+	}
+	return "", errors.New("no Buildkite API token: set BUILDKITE_API_TOKEN, pass --bk-token, or run interactively to be prompted")
+}
+
+// promptBuildkiteToken reads a Buildkite API token from the terminal without
+// echoing it. Only reached when interactive.CanPromptInteractively() is true, so
+// os.Stdin is a real terminal.
+func promptBuildkiteToken(cmd *cobra.Command) (string, error) {
+	fmt.Fprint(cmd.ErrOrStderr(), "Buildkite API token: ")
+	raw, err := term.ReadPassword(int(os.Stdin.Fd())) //nolint:gosec // G115: uintptr->int is safe for a stdin fd
+	fmt.Fprintln(cmd.ErrOrStderr())                   // terminate the (hidden) input line
+	if err != nil {
+		return "", fmt.Errorf("read Buildkite API token: %w", err)
+	}
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		return "", errors.New("no Buildkite API token entered")
+	}
+	return token, nil
+}
+
+// connectOrgCredentialRequest / registerOrgClusterRequest are the POST bodies for
+// the org connect / cluster-add verbs, mirroring entiredb#2744's
+// ConnectOrgCIBuildkiteCredentialInput.Body / RegisterOrgCIBuildkiteClusterInput.Body.
+type connectOrgCredentialRequest struct {
+	BKOrganization string `json:"bk_organization"`
+	BKAPIToken     string `json:"bk_api_token"`
+}
+
+type registerOrgClusterRequest struct {
+	BKOrganization string `json:"bk_organization"`
+	BKClusterID    string `json:"bk_cluster_id"`
+	Label          string `json:"label,omitempty"`
+	AuthPluginRef  string `json:"auth_plugin_ref,omitempty"`
+}
+
+// orgBuildkiteCredentialView / orgBuildkiteClusterView mirror entiredb#2744's
+// corev1.OrgCIBuildkiteCredentialView / OrgCIBuildkiteClusterView field for
+// field. The credential view carries no token — only token_len — matching the
+// server, which never returns token material.
+type orgBuildkiteCredentialView struct {
+	BKOrganization string    `json:"bk_organization"`
+	Owner          string    `json:"owner"`
+	CipherVersion  int       `json:"cipher_version"`
+	TokenLen       int       `json:"token_len"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type orgBuildkiteClusterView struct {
+	BKOrganization string    `json:"bk_organization"`
+	Owner          string    `json:"owner"`
+	BKClusterID    string    `json:"bk_cluster_id"`
+	Label          string    `json:"label"`
+	AuthPluginRef  string    `json:"auth_plugin_ref"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type listOrgCredentialsResponse struct {
+	Credentials []orgBuildkiteCredentialView `json:"credentials"`
+}
+
+type listOrgClustersResponse struct {
+	Clusters []orgBuildkiteClusterView `json:"clusters"`
+}
+
+// orgBuildkiteListView is the combined --json shape for `org list`: the org's
+// connected credentials plus every registered cluster across them.
+type orgBuildkiteListView struct {
+	Credentials []orgBuildkiteCredentialView `json:"credentials"`
+	Clusters    []orgBuildkiteClusterView    `json:"clusters"`
+}
+
+// printOrgBuildkiteList renders the human view of `org list`: a credentials
+// section then a clusters section, each an aligned table. No token material.
+func printOrgBuildkiteList(w io.Writer, creds []orgBuildkiteCredentialView, clusters []orgBuildkiteClusterView) error {
+	if len(creds) == 0 {
+		fmt.Fprintln(w, "No Buildkite credentials connected for this org.")
+		return nil
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "CREDENTIALS")
+	fmt.Fprintln(tw, "BK_ORG\tTOKEN_LEN\tCIPHER\tUPDATED")
+	for _, cr := range creds {
+		fmt.Fprintf(tw, "%s\t%d\t%d\t%s\n", cr.BKOrganization, cr.TokenLen, cr.CipherVersion, fmtTime(cr.UpdatedAt))
+	}
+	fmt.Fprintln(tw)
+	fmt.Fprintln(tw, "CLUSTERS")
+	fmt.Fprintln(tw, "BK_ORG\tCLUSTER_ID\tLABEL\tAUTH_PLUGIN_REF\tUPDATED")
+	if len(clusters) == 0 {
+		fmt.Fprintln(tw, "(none)")
+	}
+	for _, cl := range clusters {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", cl.BKOrganization, cl.BKClusterID, orDash(cl.Label), orDash(cl.AuthPluginRef), fmtTime(cl.UpdatedAt))
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("render table: %w", err)
+	}
+	return nil
+}
+
+// fmtTime renders a timestamp compactly in UTC for the list tables.
+func fmtTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.UTC().Format("2006-01-02 15:04Z")
+}
+
+// nonNilCreds / nonNilClusters coerce a nil slice to an empty one so the --json
+// output encodes [] rather than null (scripts expect an array).
+func nonNilCreds(s []orgBuildkiteCredentialView) []orgBuildkiteCredentialView {
+	if s == nil {
+		return []orgBuildkiteCredentialView{}
+	}
+	return s
+}
+
+func nonNilClusters(s []orgBuildkiteClusterView) []orgBuildkiteClusterView {
+	if s == nil {
+		return []orgBuildkiteClusterView{}
+	}
+	return s
+}

--- a/cmd/entire/cli/ci/buildkite_org_internal_test.go
+++ b/cmd/entire/cli/ci/buildkite_org_internal_test.go
@@ -1,0 +1,305 @@
+//go:build internal
+
+package ci
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// testOrgULID is a syntactically valid org ULID (26 Crockford base32 chars, no
+// I/L/O/U) so ResolveOrg short-circuits and the fake server only answers the
+// ci/buildkite org calls, never an org-by-name lookup.
+const testOrgULID = "0123456789ABCDEFGHJKMNPQR1"
+
+// runOrgCmd is runBuildkiteCmd's sibling that also returns stderr, so the org
+// tests can assert the shell-history warning lands on stderr and that the token
+// never appears on either stream. Not parallel: the activeCoreClient seam is
+// package-global.
+//
+//nolint:dupl // deliberately mirrors runBuildkiteCmd's seam+tree preamble but returns stderr too.
+func runOrgCmd(t *testing.T, srvURL string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	prev := activeCoreClient
+	activeCoreClient = func(context.Context) (*coreapi.Client, error) {
+		return coreapi.NewWithBearer(srvURL, "tok")
+	}
+	t.Cleanup(func() { activeCoreClient = prev })
+
+	root := &cobra.Command{Use: "entire"}
+	Register(root)
+	var out, errW bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errW)
+	root.SetArgs(append([]string{"ci"}, args...))
+	err = root.ExecuteContext(t.Context())
+	return out.String(), errW.String(), err
+}
+
+func orgCredJSON(t *testing.T, bkOrg string, tokenLen int) []byte {
+	t.Helper()
+	b, err := json.Marshal(orgBuildkiteCredentialView{
+		BKOrganization: bkOrg,
+		Owner:          testOrgULID,
+		CipherVersion:  1,
+		TokenLen:       tokenLen,
+		CreatedAt:      time.Unix(0, 0).UTC(),
+		UpdatedAt:      time.Unix(0, 0).UTC(),
+	})
+	require.NoError(t, err)
+	return b
+}
+
+func orgClusterJSON(t *testing.T, view orgBuildkiteClusterView) []byte {
+	t.Helper()
+	b, err := json.Marshal(view)
+	require.NoError(t, err)
+	return b
+}
+
+const bkCredentialPath = "/api/v1/orgs/" + testOrgULID + "/ci/buildkite/credential"
+
+func TestBuildkiteOrgConnect_BodyAssemblyAndVerb(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		status   int
+		wantWord string
+	}{
+		{"fresh connect → 201", http.StatusCreated, "✓ Connected"},
+		{"rotate → 200", http.StatusOK, "✓ Rotated"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const token = "bkua_secret_value_987654"
+			t.Setenv("BUILDKITE_API_TOKEN", token)
+
+			var gotMethod, gotPath string
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod, gotPath = r.Method, r.URL.Path
+				gotBody = decodeBody(t, r)
+				writeJSONResponse(t, w, tc.status, orgCredJSON(t, "acme-inc", len(token)))
+			}))
+			t.Cleanup(srv.Close)
+
+			stdout, stderr, err := runOrgCmd(t, srv.URL, "buildkite", "org", "connect", testOrgULID, "--bk-org", "acme-inc")
+			require.NoError(t, err)
+
+			assert.Equal(t, http.MethodPost, gotMethod)
+			assert.Equal(t, bkCredentialPath, gotPath)
+			assert.Equal(t, "acme-inc", gotBody["bk_organization"])
+			assert.Equal(t, token, gotBody["bk_api_token"], "the token must reach the server in the request body")
+			assert.Contains(t, stdout, tc.wantWord)
+			assert.Contains(t, stdout, "token_len=")
+			// The token must never surface in user-facing output.
+			assert.NotContains(t, stdout, token, "token must never appear on stdout")
+			assert.NotContains(t, stderr, token, "token must never appear on stderr")
+		})
+	}
+}
+
+func TestBuildkiteOrgConnect_FlagTokenWarnsAboutShellHistory(t *testing.T) {
+	t.Setenv("BUILDKITE_API_TOKEN", "") // force the flag path, not env
+
+	const token = "bkua_flag_token_abcdef"
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = decodeBody(t, r)
+		writeJSONResponse(t, w, http.StatusCreated, orgCredJSON(t, "acme-inc", len(token)))
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runOrgCmd(t, srv.URL, "buildkite", "org", "connect", testOrgULID, "--bk-org", "acme-inc", "--bk-token", token)
+	require.NoError(t, err)
+
+	assert.Equal(t, token, gotBody["bk_api_token"])
+	assert.Contains(t, stderr, "shell history", "using --bk-token must warn about shell history")
+	assert.NotContains(t, stdout, token, "token must never appear on stdout")
+}
+
+func TestBuildkiteOrgConnect_NoTokenSourceFails(t *testing.T) {
+	t.Setenv("BUILDKITE_API_TOKEN", "")
+
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	// Under `go test` CanPromptInteractively is false, so with no flag and no env
+	// there is no token source and connect must fail before any HTTP call.
+	_, _, err := runOrgCmd(t, srv.URL, "buildkite", "org", "connect", testOrgULID, "--bk-org", "acme-inc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Buildkite API token")
+	assert.False(t, called, "a missing token must fail before any HTTP call")
+}
+
+func TestBuildkiteOrgConnect_RequiresBkOrg(t *testing.T) {
+	t.Setenv("BUILDKITE_API_TOKEN", "tok")
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := runOrgCmd(t, srv.URL, "buildkite", "org", "connect", testOrgULID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bk-org")
+	assert.False(t, called, "a missing required flag must fail before any HTTP call")
+}
+
+func TestBuildkiteOrgList_TableAndJSON(t *testing.T) {
+	const token = "bkua_should_never_render_123456"
+	newServer := func() *httptest.Server {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/ci/buildkite/credentials"):
+				body := []byte(`{"credentials":` + string(orgCredsListJSON(t)) + `}`)
+				writeJSONResponse(t, w, http.StatusOK, body)
+			case strings.HasSuffix(r.URL.Path, "/ci/buildkite/clusters"):
+				assert.Equal(t, "acme-inc", r.URL.Query().Get("bk_organization"), "clusters must be queried per connected bk org")
+				cl := orgBuildkiteClusterView{
+					BKOrganization: "acme-inc", Owner: testOrgULID, BKClusterID: "cluster-uuid-1",
+					Label: "web", AuthPluginRef: "entire-io/entire-core-auth#v1.2.3",
+					CreatedAt: time.Unix(0, 0).UTC(), UpdatedAt: time.Unix(0, 0).UTC(),
+				}
+				body := []byte(`{"clusters":[` + string(orgClusterJSON(t, cl)) + `]}`)
+				writeJSONResponse(t, w, http.StatusOK, body)
+			default:
+				t.Errorf("unexpected path %q", r.URL.Path)
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}))
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	t.Run("human table", func(t *testing.T) {
+		stdout, _, err := runOrgCmd(t, newServer().URL, "buildkite", "org", "list", testOrgULID)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "CREDENTIALS")
+		assert.Contains(t, stdout, "CLUSTERS")
+		assert.Contains(t, stdout, "acme-inc")
+		assert.Contains(t, stdout, "cluster-uuid-1")
+		assert.Contains(t, stdout, "web")
+		assert.Contains(t, stdout, "TOKEN_LEN")
+		assert.NotContains(t, stdout, token, "no token material must ever render")
+	})
+
+	t.Run("json", func(t *testing.T) {
+		stdout, _, err := runOrgCmd(t, newServer().URL, "buildkite", "org", "list", testOrgULID, "--json")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, `"credentials"`)
+		assert.Contains(t, stdout, `"clusters"`)
+		assert.Contains(t, stdout, `"cluster-uuid-1"`)
+		assert.NotContains(t, stdout, `"bk_api_token"`, "the wire view has no token field")
+		assert.NotContains(t, stdout, token)
+	})
+}
+
+func TestBuildkiteOrgList_Empty(t *testing.T) {
+	var clustersCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/ci/buildkite/clusters") {
+			clustersCalled = true
+		}
+		writeJSONResponse(t, w, http.StatusOK, []byte(`{"credentials":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, _, err := runOrgCmd(t, srv.URL, "buildkite", "org", "list", testOrgULID)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "No Buildkite credentials connected")
+	assert.False(t, clustersCalled, "with no credentials there is nothing to query clusters for")
+}
+
+func TestBuildkiteOrgClusterAdd_BodyAndVerb(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		status   int
+		wantWord string
+	}{
+		{"insert → 201", http.StatusCreated, "✓ Registered"},
+		{"update → 200", http.StatusOK, "✓ Updated"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod, gotPath = r.Method, r.URL.Path
+				gotBody = decodeBody(t, r)
+				cl := orgBuildkiteClusterView{
+					BKOrganization: "acme-inc", Owner: testOrgULID, BKClusterID: "cluster-uuid-1",
+					AuthPluginRef: "entire-io/entire-core-auth#v1.2.3",
+					CreatedAt:     time.Unix(0, 0).UTC(), UpdatedAt: time.Unix(0, 0).UTC(),
+				}
+				writeJSONResponse(t, w, tc.status, orgClusterJSON(t, cl))
+			}))
+			t.Cleanup(srv.Close)
+
+			stdout, _, err := runOrgCmd(t, srv.URL, "buildkite", "org", "cluster", "add", testOrgULID,
+				"--bk-org", "acme-inc", "--bk-cluster-id", "cluster-uuid-1",
+				"--auth-plugin-ref", "entire-io/entire-core-auth#v1.2.3")
+			require.NoError(t, err)
+
+			assert.Equal(t, http.MethodPost, gotMethod)
+			assert.Equal(t, "/api/v1/orgs/"+testOrgULID+"/ci/buildkite/clusters", gotPath)
+			assert.Equal(t, "acme-inc", gotBody["bk_organization"])
+			assert.Equal(t, "cluster-uuid-1", gotBody["bk_cluster_id"])
+			assert.Equal(t, "entire-io/entire-core-auth#v1.2.3", gotBody["auth_plugin_ref"])
+			assert.Contains(t, stdout, tc.wantWord)
+			assert.Contains(t, stdout, "cluster-uuid-1")
+		})
+	}
+}
+
+func TestBuildkiteOrgClusterAdd_RequiresFlags(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := runOrgCmd(t, srv.URL, "buildkite", "org", "cluster", "add", testOrgULID, "--bk-org", "acme-inc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bk-cluster-id")
+	assert.False(t, called, "a missing required flag must fail before any HTTP call")
+}
+
+func TestBuildkiteOrgDisconnect_Path(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, _, err := runOrgCmd(t, srv.URL, "buildkite", "org", "disconnect", testOrgULID, "--bk-org", "acme-inc")
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, gotMethod)
+	assert.Equal(t, bkCredentialPath+"/acme-inc", gotPath)
+	assert.Contains(t, stdout, "✓ Disconnected Buildkite org")
+	assert.Contains(t, stdout, "acme-inc")
+}
+
+// orgCredsListJSON is the single-credential fixture used inside the list
+// handler's credentials envelope.
+func orgCredsListJSON(t *testing.T) []byte {
+	t.Helper()
+	return []byte("[" + string(orgCredJSON(t, "acme-inc", 24)) + "]")
+}

--- a/cmd/entire/cli/ci/resolve.go
+++ b/cmd/entire/cli/ci/resolve.go
@@ -34,7 +34,7 @@ func ResolveNativeRepo(ctx context.Context, c *coreapi.Client, ref string) (repo
 	if ref == "" {
 		return "", errors.New("repo reference is empty")
 	}
-	if looksLikeRepoULID(ref) {
+	if looksLikeULID(ref) {
 		return ref, nil
 	}
 	if looksLikeMirrorRef(ref) {
@@ -68,6 +68,38 @@ func ResolveNativeRepo(ctx context.Context, c *coreapi.Client, ref string) (repo
 		return "", noRepoNamedErr(repoName, projectName)
 	}
 	return repo.ID, nil
+}
+
+// ResolveOrg turns an org reference into its org ULID — the identifier the
+// `entire ci buildkite org` verbs address an org by. A raw 26-character ULID is
+// round-tripped unchanged after a shape check (never hitting the network); any
+// other value is treated as an org name and resolved via the control plane's
+// O(1) case-insensitive by-name filter (?name=), the same one resolveOrgRef and
+// `entire org list --name` use. It mirrors ResolveNativeRepo's ULID-or-name
+// contract and lives beside it so the two resolvers stay consistent.
+func ResolveOrg(ctx context.Context, c *coreapi.Client, ref string) (orgULID string, err error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", errors.New("org reference is empty")
+	}
+	if looksLikeULID(ref) {
+		return ref, nil
+	}
+	out, err := c.ListOrgs(ctx, coreapi.ListOrgsParams{Name: coreapi.NewOptString(ref)})
+	if err != nil {
+		if isCoreNotFound(err) {
+			return "", noOrgNamedErr(ref)
+		}
+		return "", err
+	}
+	// A name-filtered list returns the single match under the singular `org`
+	// field (the plural `orgs` is only populated for an unfiltered page), so an
+	// unset `org` means no match — same contract as the project/repo lookups.
+	org, ok := out.Response.Org.Get()
+	if !ok || org.ID == "" {
+		return "", noOrgNamedErr(ref)
+	}
+	return org.ID, nil
 }
 
 // resolveProjectByName resolves a project name to its ULID via the control
@@ -123,17 +155,18 @@ func looksLikeMirrorRef(ref string) bool {
 	return false
 }
 
-// looksLikeRepoULID reports whether s has the shape of a ULID: 26 characters
+// looksLikeULID reports whether s has the shape of a ULID: 26 characters
 // drawn from Crockford base32 (digits plus uppercase letters, excluding I, L,
 // O, U). The check is shape-only and case-insensitive on the alphabet; it never
 // hits the network. Entire ULIDs carry no type prefix, so this is the light
-// validity check a raw repo ULID passes before being round-tripped unchanged.
+// validity check a raw repo or org ULID passes before being round-tripped
+// unchanged.
 //
 // Replicated from cli.looksLikeULID rather than imported: the cli package
 // imports this package (root.go calls ci.Register), so importing cli back would
 // form an import cycle — the same reason the scaffold replicates
 // addControlPlaneFlags.
-func looksLikeRepoULID(s string) bool {
+func looksLikeULID(s string) bool {
 	if len(s) != 26 {
 		return false
 	}
@@ -154,6 +187,10 @@ func looksLikeRepoULID(s string) bool {
 func isCoreNotFound(err error) bool {
 	var se *coreapi.ErrorModelStatusCode
 	return errors.As(err, &se) && se.StatusCode == http.StatusNotFound
+}
+
+func noOrgNamedErr(name string) error {
+	return fmt.Errorf("no org named %q (run `entire org list` to see names, or pass an org ULID)", name)
 }
 
 func noProjectNamedErr(name string) error {

--- a/cmd/entire/cli/ci/resolve_test.go
+++ b/cmd/entire/cli/ci/resolve_test.go
@@ -179,6 +179,72 @@ func TestResolveNativeRepo_UnknownRepo(t *testing.T) {
 	}
 }
 
+func TestResolveOrg_ULIDPassthrough(t *testing.T) {
+	t.Parallel()
+	c, calls := resolveTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("unexpected HTTP call for a ULID org ref")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	got, err := ci.ResolveOrg(context.Background(), c, ulidOrgAcme)
+	if err != nil {
+		t.Fatalf("ResolveOrg: %v", err)
+	}
+	if got != ulidOrgAcme {
+		t.Errorf("ResolveOrg = %q, want the ULID unchanged", got)
+	}
+	if n := calls.Load(); n != 0 {
+		t.Errorf("ULID org ref made %d HTTP calls, want 0", n)
+	}
+}
+
+func TestResolveOrg_NameLookup(t *testing.T) {
+	t.Parallel()
+	var gotName string
+	c, calls := resolveTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotName = r.URL.Query().Get("name")
+		writeJSON(t, w, &coreapi.ListOrgsOutputBody{Org: coreapi.NewOptOrg(coreapi.Org{ID: ulidOrgAcme, Name: "acme"})})
+	})
+	got, err := ci.ResolveOrg(context.Background(), c, "acme")
+	if err != nil {
+		t.Fatalf("ResolveOrg: %v", err)
+	}
+	if got != ulidOrgAcme {
+		t.Errorf("ResolveOrg = %q, want %q", got, ulidOrgAcme)
+	}
+	if gotName != "acme" {
+		t.Errorf("server received name=%q, want %q (filtering must be server-side)", gotName, "acme")
+	}
+	if n := calls.Load(); n != 1 {
+		t.Errorf("name ref made %d HTTP calls, want 1", n)
+	}
+}
+
+func TestResolveOrg_UnknownName(t *testing.T) {
+	t.Parallel()
+	// An unset Org match means "no such org".
+	c, _ := resolveTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, &coreapi.ListOrgsOutputBody{})
+	})
+	_, err := ci.ResolveOrg(context.Background(), c, "ghost")
+	if err == nil || !strings.Contains(err.Error(), "no org named") {
+		t.Errorf("ResolveOrg unknown name: err = %v, want a \"no org named\" error", err)
+	}
+}
+
+func TestResolveOrg_Empty(t *testing.T) {
+	t.Parallel()
+	c, calls := resolveTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("unexpected HTTP call for an empty org ref")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	if _, err := ci.ResolveOrg(context.Background(), c, "   "); err == nil {
+		t.Error("ResolveOrg(\"   \") expected an error")
+	}
+	if n := calls.Load(); n != 0 {
+		t.Errorf("empty org ref made %d HTTP calls, want 0", n)
+	}
+}
+
 func TestResolveNativeRepo_InvalidShape(t *testing.T) {
 	t.Parallel()
 	for _, ref := range []string{"", "  ", "widgets", "widgets/", "/et/widgets"} {

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -1,6 +1,7 @@
 package coreapi
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -177,6 +178,80 @@ func (c *Client) GetJSON(ctx context.Context, path string, query url.Values, dst
 	}
 	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
 		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+// PostJSON issues a POST to path (relative to this client's /api/v1 base) with
+// a JSON-encoded body, applying the same bearer auth and cross-jurisdiction
+// transport as GetJSON, and decodes a 2xx JSON body into dst (pass nil to
+// discard the body). It returns the response status code so callers can tell a
+// 201-created from a 200-updated. A non-2xx response is returned as an
+// *ErrorModelStatusCode, so callers get the server's RFC 7807 problem detail
+// via APIError exactly as they do for generated calls.
+//
+// Same escape-hatch rationale and removal contract as GetJSON: it reuses this
+// client's serverURL, SecuritySource, and HTTP transport rather than opening a
+// second auth path. Its callers are the `entire ci buildkite org` verbs, which
+// hit the org-scoped CI-webhooks endpoints added by the DRAFT entiredb#2744,
+// not yet regenerated into this client's spec. Once that spec is regenerated,
+// delete PostJSON/DeleteJSON and switch those callers to the generated Invoker
+// methods.
+func (c *Client) PostJSON(ctx context.Context, path string, body, dst any) (int, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return 0, fmt.Errorf("encode request body: %w", err)
+	}
+	u := c.serverURL.JoinPath(path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(buf))
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if err := c.securityBearerAuth(ctx, "PostJSON", req); err != nil {
+		return 0, fmt.Errorf("apply bearer auth: %w", err)
+	}
+	resp, err := c.cfg.Client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resp.StatusCode, statusCodeError(resp)
+	}
+	if dst != nil {
+		if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+			return resp.StatusCode, fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+// DeleteJSON issues a DELETE to path (relative to this client's /api/v1 base)
+// with no body, applying the same bearer auth and transport as GetJSON. A 2xx
+// (typically 204 No Content) yields nil; a non-2xx yields an
+// *ErrorModelStatusCode. Same escape-hatch rationale and removal contract as
+// PostJSON.
+func (c *Client) DeleteJSON(ctx context.Context, path string) error {
+	u := c.serverURL.JoinPath(path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u.String(), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if err := c.securityBearerAuth(ctx, "DeleteJSON", req); err != nil {
+		return fmt.Errorf("apply bearer auth: %w", err)
+	}
+	resp, err := c.cfg.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return statusCodeError(resp)
 	}
 	return nil
 }


### PR DESCRIPTION
## Why

M1 of the customer-facing CI-webhooks surface (COR-976): an org/project admin
needs to connect their own Buildkite organization to an Entire org — supply a
Buildkite API token (stored encrypted server-side) and register the hosted
clusters their pipelines run on. This adds the CLI verbs for that flow.

The backend endpoints this drives live in the **DRAFT** backend
`entiredb#2744` (branch `dv/ci-org-credentials-m1`) and are **not yet in the
generated `coreapi` spec**. This PR is therefore also a **DRAFT** — do not
merge until `entiredb#2744` lands and passes security review.

This PR **stacks on** `#1756` → `#1755` → `#1754` → `#1753` (base branch
`dv/ci-buildkite-watch`). Review/merge those first.

## What

Mounts an `org` subgroup under `entire ci buildkite` (internal build tag only,
absent from released binaries):

- `entire ci buildkite org connect <entire-org> --bk-org <slug> [--bk-token <t>]`
  → `POST /api/v1/orgs/{orgId}/ci/buildkite/credential` with body
  `{bk_organization, bk_api_token}`. Prints `Connected` (201) / `Rotated`
  (200) plus `token_len`; the token is never echoed. `--json` supported.
- `entire ci buildkite org list <entire-org> [--json]`
  → `GET .../credentials`, then `GET .../clusters?bk_organization=<slug>` per
  connected credential. Renders a credentials table + a clusters table (no
  token material — only `token_len`).
- `entire ci buildkite org cluster add <entire-org> --bk-org <slug> --bk-cluster-id <id> [--auth-plugin-ref <s>]`
  → `POST .../clusters`. Prints `Registered` (201) / `Updated` (200).
- `entire ci buildkite org disconnect <entire-org> --bk-org <slug>`
  → `DELETE .../credential/{bkOrg}`.

**Org resolution.** `<entire-org>` accepts an org ULID (passed through after a
shape check, no network call) or an org name (resolved via the control plane's
case-insensitive `?name=` filter). New `ResolveOrg` helper next to
`ResolveNativeRepo`, mirroring its ULID-or-name contract; distinct
`no org named …` error for an unknown name.

**Token handling.** The Buildkite API token is sourced, in order, from
`--bk-token` (with a one-line warning that it lands in shell history), the
`BUILDKITE_API_TOKEN` env var, then an interactive no-echo prompt
(`term.ReadPassword`) when a TTY is available. It is sent to the server over
the existing TLS client only — never logged, never echoed, and absent from all
command output (only `token_len` surfaces).

**Calling the draft backend.** These endpoints aren't in the generated client
yet, so the requests are hand-rolled by extending the C3 escape hatch:
`PostJSON` / `DeleteJSON` added alongside `GetJSON` in
`internal/coreapi/client.go`, reusing the same `serverURL`, bearer
`SecuritySource`, and cross-jurisdiction transport (no second auth path).
`PostJSON` returns the status code so the verbs can distinguish 201-created
from 200-updated. Both carry a removal note: swap these calls for the
generated Invoker methods once `entiredb#2744` merges and the spec
regenerates, then delete the local DTOs + escape-hatch helpers.

## Verification

- `go build ./...` and `go build -tags internal ./...` both pass.
- New tests (fake core via `httptest`):
  - `resolve_test.go` (untagged): `ResolveOrg` ULID passthrough (zero HTTP
    calls), name lookup (server-side `?name=`), unknown-name error, empty ref.
  - `buildkite_org_internal_test.go` (internal-tagged): connect body assembly +
    `Connected`/`Rotated` verbs + **token never on stdout/stderr**, `--bk-token`
    shell-history warning, no-token-source failure, `--bk-org` required; list
    table + `--json` (no token material) + empty case (clusters not queried);
    cluster add body + `Registered`/`Updated` + required flags; disconnect path.
  - `go test ./cmd/entire/cli/ci/... && go test -tags internal ./cmd/entire/cli/ci/...`
    and `go test ./internal/coreapi/...` all green.
- `mise run fmt` clean; `golangci-lint run --build-tags internal ./cmd/entire/cli/ci/...`
  and full `mise run lint` report 0 issues.
- Smoke: `go build -tags internal ./cmd/entire` then
  `entire ci buildkite org {connect,list,cluster add,disconnect} --help` all
  render.

## Follow-ups

- Regenerate the `coreapi` spec once `entiredb#2744` merges, switch the four
  verbs to the generated Invoker methods, and delete `PostJSON`/`DeleteJSON`
  and the local DTOs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHPhjYDtZx71THMtVwc83E

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Handles Buildkite API tokens (collection, transport, and shell-history exposure) and depends on draft backend APIs via hand-rolled HTTP until spec regeneration; mistakes could leak credentials or misconfigure org CI auth.
> 
> **Overview**
> Adds an **internal-only** `entire ci buildkite org` command group so org admins can connect Buildkite API credentials, list credentials and registered hosted clusters, register/update clusters, and disconnect credentials against draft org-scoped `/api/v1/orgs/{orgId}/ci/buildkite/…` endpoints.
> 
> **Org targeting** introduces `ResolveOrg` (ULID passthrough or name via `?name=`) and renames the shared ULID shape helper to `looksLikeULID` for repo and org refs.
> 
> **API client** extends the `coreapi` escape hatch with `PostJSON` and `DeleteJSON` (alongside existing `GetJSON`) until the OpenAPI spec includes these routes; verbs use local DTOs and distinguish 201 vs 200 in user output.
> 
> **Token handling** for `org connect` prefers env or a no-echo prompt over `--bk-token`, warns when the flag is used, and never prints token material (only `token_len`). Tests cover HTTP wiring, validation, and secret hygiene.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4830786e08aa0471e22739e0fb27fe27f1f57eca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->