### PR TITLE
fix(dispatch): make `dispatch --local` surface recent merged work (ENT-1188)

### DIFF
--- a/cmd/entire/cli/dispatch/mode_local.go
+++ b/cmd/entire/cli/dispatch/mode_local.go
@@ -168,7 +168,7 @@ func enumerateRepoCandidates(ctx context.Context, repoRoot string, opts Options,
 		if len(branches) > 0 {
 			currentBranch = branches[0]
 		}
-		reachableCheckpointIDs, err = reachableCheckpointIDsInRange(ctx, repoRoot, branchLocalRevRange(ctx, repoRoot, currentBranch), since)
+		reachableCheckpointIDs, err = reachableCheckpointIDsInRange(ctx, repoRoot, branchLocalRevRange(ctx, repoRoot, currentBranch), since, until)
 		if err != nil {
 			return nil, err
 		}
@@ -295,11 +295,18 @@ func readLocalSummaryTitle(ctx context.Context, store checkpoint.PersistentStore
 }
 
 // reachableCheckpointIDsInRange maps each checkpoint ID referenced by a commit
-// trailer in revRange (since <cutoff>) to the most recent commit time that
-// references it. The commit time is the "landed on this branch" timestamp,
-// used both for membership checks and to window checkpoints that are fetched
-// on demand by ID (whose CheckpointSummary carries no CreatedAt of its own).
-func reachableCheckpointIDsInRange(ctx context.Context, repoRoot, revRange string, since time.Time) (map[string]time.Time, error) {
+// trailer in revRange, within the window [since, until), to the most recent
+// referencing commit time *that falls inside the window*. The commit time is
+// the "landed on this branch" timestamp, used both for membership checks and to
+// window checkpoints that are fetched on demand by ID (whose CheckpointSummary
+// carries no CreatedAt of its own).
+//
+// Commits outside the window are ignored entirely, so a checkpoint referenced
+// by both an in-window commit and a later out-of-window commit still records
+// its in-window time (and is therefore not dropped by the caller's window
+// check). git's --since/--until only bound the scan; the explicit in-loop check
+// is authoritative for the half-open [since, until) boundary.
+func reachableCheckpointIDsInRange(ctx context.Context, repoRoot, revRange string, since, until time.Time) (map[string]time.Time, error) {
 	cmd := exec.CommandContext(
 		ctx,
 		"git",
@@ -308,6 +315,7 @@ func reachableCheckpointIDsInRange(ctx context.Context, repoRoot, revRange strin
 		"log",
 		revRange,
 		"--since="+since.UTC().Format(time.RFC3339),
+		"--until="+until.UTC().Format(time.RFC3339),
 		"--grep",
 		"Entire-Checkpoint:",
 		"--format=%cI%x00%B%x00%x00",
@@ -326,6 +334,9 @@ func reachableCheckpointIDsInRange(ctx context.Context, repoRoot, revRange strin
 		}
 		commitTime, parseErr := time.Parse(time.RFC3339, strings.TrimSpace(parts[0]))
 		if parseErr != nil {
+			continue
+		}
+		if commitTime.Before(since) || !commitTime.Before(until) {
 			continue
 		}
 		for _, checkpointID := range trailers.ParseAllCheckpoints(parts[1]) {

--- a/cmd/entire/cli/dispatch/mode_local.go
+++ b/cmd/entire/cli/dispatch/mode_local.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	checkpointid "github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -161,9 +162,13 @@ func enumerateRepoCandidates(ctx context.Context, repoRoot string, opts Options,
 	for _, branch := range branches {
 		branchSet[branch] = struct{}{}
 	}
-	reachableCheckpointIDs := map[string]struct{}{}
+	reachableCheckpointIDs := map[string]time.Time{}
 	if opts.ImplicitCurrentBranch && !opts.AllBranches {
-		reachableCheckpointIDs, err = reachableCheckpointIDsInRange(ctx, repoRoot, branchLocalRevRange(ctx, repoRoot), since)
+		currentBranch := ""
+		if len(branches) > 0 {
+			currentBranch = branches[0]
+		}
+		reachableCheckpointIDs, err = reachableCheckpointIDsInRange(ctx, repoRoot, branchLocalRevRange(ctx, repoRoot, currentBranch), since)
 		if err != nil {
 			return nil, err
 		}
@@ -187,6 +192,7 @@ func enumerateRepoCandidates(ctx context.Context, repoRoot string, opts Options,
 	}
 
 	candidates := make([]candidate, 0, len(infos))
+	seen := make(map[string]struct{}, len(infos))
 	for _, info := range infos {
 		if info.CreatedAt.Before(since) || !info.CreatedAt.Before(until) {
 			continue
@@ -209,17 +215,6 @@ func enumerateRepoCandidates(ctx context.Context, repoRoot string, opts Options,
 			}
 		}
 
-		localSummary := ""
-		if len(summary.Sessions) > 0 {
-			latestIndex := len(summary.Sessions) - 1
-			if metadata, err := store.ReadSessionMetadata(ctx, info.CheckpointID, latestIndex); err == nil && metadata != nil && metadata.Summary != nil {
-				localSummary = strings.TrimSpace(metadata.Summary.Outcome)
-				if localSummary == "" {
-					localSummary = strings.TrimSpace(metadata.Summary.Intent)
-				}
-			}
-		}
-
 		commitSubject := commitSubjectsByCheckpoint[info.CheckpointID.String()]
 		candidates = append(candidates, candidate{
 			CheckpointID:      info.CheckpointID.String(),
@@ -227,14 +222,84 @@ func enumerateRepoCandidates(ctx context.Context, repoRoot string, opts Options,
 			Branch:            summary.Branch,
 			CreatedAt:         info.CreatedAt,
 			CommitSubject:     commitSubject,
+			LocalSummaryTitle: readLocalSummaryTitle(ctx, store, info.CheckpointID, summary),
+		})
+		seen[info.CheckpointID.String()] = struct{}{}
+	}
+
+	// Second pass: checkpoints referenced by branch commit trailers in the
+	// window that store.List did not surface. store.List only enumerates
+	// checkpoints present in the local checkout, but on a checkout that has not
+	// fetched recent checkpoints (the common case — checkpoints are pushed to
+	// the remote from other worktrees) the recent work is missing locally even
+	// though it is reachable from HEAD. The commit subject is always available
+	// from git log, so we can summarize that work from the trailer + subject
+	// without a (slow) per-checkpoint network fetch; when the checkpoint does
+	// happen to be local we still prefer its richer session summary. Windowed
+	// by commit ("landed on branch") time, since a CheckpointSummary carries no
+	// CreatedAt of its own.
+	for idStr, commitTime := range reachableCheckpointIDs {
+		if _, ok := seen[idStr]; ok {
+			continue
+		}
+		if commitTime.Before(since) || !commitTime.Before(until) {
+			continue
+		}
+		commitSubject := commitSubjectsByCheckpoint[idStr]
+
+		// Opportunistic local read for a richer title/branch — no fetcher is
+		// wired, so this never touches the network; a checkpoint absent locally
+		// resolves to nil and we fall back to the commit subject.
+		branch := ""
+		localSummary := ""
+		if cid, cidErr := checkpointid.NewCheckpointID(idStr); cidErr == nil {
+			if summary, readErr := store.Read(ctx, cid); readErr == nil && summary != nil {
+				branch = summary.Branch
+				localSummary = readLocalSummaryTitle(ctx, store, cid, summary)
+			}
+		}
+
+		if strings.TrimSpace(localSummary) == "" && strings.TrimSpace(commitSubject) == "" {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			CheckpointID:      idStr,
+			RepoFullName:      repoFullName,
+			Branch:            branch,
+			CreatedAt:         commitTime,
+			CommitSubject:     commitSubject,
 			LocalSummaryTitle: localSummary,
 		})
+		seen[idStr] = struct{}{}
 	}
 
 	return candidates, nil
 }
 
-func reachableCheckpointIDsInRange(ctx context.Context, repoRoot, revRange string, since time.Time) (map[string]struct{}, error) {
+// readLocalSummaryTitle returns the latest session's outcome (falling back to
+// its intent) for use as a bullet title, or "" when no session summary is
+// available.
+func readLocalSummaryTitle(ctx context.Context, store checkpoint.PersistentStore, cid checkpointid.CheckpointID, summary *checkpoint.CheckpointSummary) string {
+	if summary == nil || len(summary.Sessions) == 0 {
+		return ""
+	}
+	latestIndex := len(summary.Sessions) - 1
+	metadata, err := store.ReadSessionMetadata(ctx, cid, latestIndex)
+	if err != nil || metadata == nil || metadata.Summary == nil {
+		return ""
+	}
+	if outcome := strings.TrimSpace(metadata.Summary.Outcome); outcome != "" {
+		return outcome
+	}
+	return strings.TrimSpace(metadata.Summary.Intent)
+}
+
+// reachableCheckpointIDsInRange maps each checkpoint ID referenced by a commit
+// trailer in revRange (since <cutoff>) to the most recent commit time that
+// references it. The commit time is the "landed on this branch" timestamp,
+// used both for membership checks and to window checkpoints that are fetched
+// on demand by ID (whose CheckpointSummary carries no CreatedAt of its own).
+func reachableCheckpointIDsInRange(ctx context.Context, repoRoot, revRange string, since time.Time) (map[string]time.Time, error) {
 	cmd := exec.CommandContext(
 		ctx,
 		"git",
@@ -245,17 +310,29 @@ func reachableCheckpointIDsInRange(ctx context.Context, repoRoot, revRange strin
 		"--since="+since.UTC().Format(time.RFC3339),
 		"--grep",
 		"Entire-Checkpoint:",
-		"--format=%B%x00",
+		"--format=%cI%x00%B%x00%x00",
 	)
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("list HEAD checkpoint trailers: %w", err)
 	}
 
-	reachable := make(map[string]struct{})
-	for _, message := range strings.Split(string(output), "\x00") {
-		for _, checkpointID := range trailers.ParseAllCheckpoints(message) {
-			reachable[checkpointID.String()] = struct{}{}
+	reachable := make(map[string]time.Time)
+	for _, record := range strings.Split(string(output), "\x00\x00") {
+		record = strings.TrimLeft(record, "\n")
+		parts := strings.SplitN(record, "\x00", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		commitTime, parseErr := time.Parse(time.RFC3339, strings.TrimSpace(parts[0]))
+		if parseErr != nil {
+			continue
+		}
+		for _, checkpointID := range trailers.ParseAllCheckpoints(parts[1]) {
+			idStr := checkpointID.String()
+			if existing, ok := reachable[idStr]; !ok || commitTime.After(existing) {
+				reachable[idStr] = commitTime
+			}
 		}
 	}
 	return reachable, nil
@@ -265,9 +342,19 @@ func reachableCheckpointIDsInRange(ctx context.Context, repoRoot, revRange strin
 // those unique to the current branch — reachable from HEAD but not from the
 // repository's default branch. Falls back to "HEAD" when no default branch
 // can be resolved (e.g. a fresh repo with no main/master ref).
-func branchLocalRevRange(ctx context.Context, repoRoot string) string {
+//
+// When the current branch IS the default branch there is no parent history to
+// exclude: base..HEAD is empty on an up-to-date default branch, which would
+// drop every checkpoint whose summary.Branch is a (now-merged) feature branch
+// and leave the dispatch effectively empty. In that case we summarize
+// everything reachable from HEAD in the window, matching the server-side
+// dispatch. The base..HEAD exclusion only applies to feature branches.
+func branchLocalRevRange(ctx context.Context, repoRoot, currentBranch string) string {
 	base := defaultBranchRef(ctx, repoRoot)
 	if base == "" {
+		return "HEAD"
+	}
+	if currentBranch != "" && strings.TrimPrefix(base, "origin/") == currentBranch {
 		return "HEAD"
 	}
 	return base + "..HEAD"

--- a/cmd/entire/cli/dispatch/mode_local.go
+++ b/cmd/entire/cli/dispatch/mode_local.go
@@ -273,7 +273,23 @@ func enumerateRepoCandidates(ctx context.Context, repoRoot string, opts Options,
 		seen[idStr] = struct{}{}
 	}
 
+	// The second pass ranges over a map (randomized iteration order), so sort
+	// before returning to keep bullet order — and therefore the LLM-authored
+	// summary — stable across runs. Newest first, with the checkpoint ID as a
+	// deterministic tiebreak for equal timestamps.
+	sortCandidatesByRecency(candidates)
 	return candidates, nil
+}
+
+// sortCandidatesByRecency orders candidates most-recent-first by CreatedAt,
+// breaking ties by checkpoint ID so the order is fully deterministic.
+func sortCandidatesByRecency(candidates []candidate) {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if !candidates[i].CreatedAt.Equal(candidates[j].CreatedAt) {
+			return candidates[i].CreatedAt.After(candidates[j].CreatedAt)
+		}
+		return candidates[i].CheckpointID < candidates[j].CheckpointID
+	})
 }
 
 // readLocalSummaryTitle returns the latest session's outcome (falling back to

--- a/cmd/entire/cli/dispatch/mode_local_test.go
+++ b/cmd/entire/cli/dispatch/mode_local_test.go
@@ -880,6 +880,33 @@ func TestReachableCheckpointIDsInRange_KeepsInWindowTimeDespiteLaterCommit(t *te
 	}
 }
 
+// TestSortCandidatesByRecency covers the trail-review finding: because the
+// trailer fallback pass ranges over a map, candidates must be sorted before
+// returning so dispatch output is stable across runs. Newest first, ties broken
+// by checkpoint ID.
+func TestSortCandidatesByRecency(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	candidates := []candidate{
+		{CheckpointID: "ccc", CreatedAt: base},
+		{CheckpointID: "aaa", CreatedAt: base.Add(2 * time.Hour)},
+		{CheckpointID: "bbb", CreatedAt: base}, // same time as ccc → tiebreak by ID
+		{CheckpointID: "zzz", CreatedAt: base.Add(time.Hour)},
+	}
+	sortCandidatesByRecency(candidates)
+
+	got := make([]string, len(candidates))
+	for i, c := range candidates {
+		got[i] = c.CheckpointID
+	}
+	want := []string{"aaa", "zzz", "bbb", "ccc"} // newest first; bbb < ccc for the tie
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sortCandidatesByRecency order = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestLoadCommitSubjectsByCheckpoint_UsesSingleWindowedLogScan(t *testing.T) {
 	tmpDir := t.TempDir()
 	argsFile := filepath.Join(tmpDir, "git-args.txt")

--- a/cmd/entire/cli/dispatch/mode_local_test.go
+++ b/cmd/entire/cli/dispatch/mode_local_test.go
@@ -538,6 +538,122 @@ func TestLocalMode_ImplicitCurrentBranchExcludesDefaultBranchHistory(t *testing.
 	}
 }
 
+// TestLocalMode_ImplicitCurrentBranchOnDefaultBranchIncludesMergedWork is the
+// regression test for ENT-1188: on the default branch there is no parent
+// history to exclude, so work done on feature branches and merged into it
+// (summary.Branch is the feature branch, but the checkpoint trailer is
+// reachable from the default branch's HEAD) must appear in the dispatch.
+// Before the fix, branchLocalRevRange returned <default>..HEAD, which is empty
+// on an up-to-date default branch, so every such checkpoint was dropped and
+// the dispatch came back empty.
+func TestLocalMode_ImplicitCurrentBranchOnDefaultBranchIncludesMergedWork(t *testing.T) {
+	dir := t.TempDir()
+	stubGeneratedLocalDispatch(t)
+	testutil.InitRepo(t, dir)
+	addOriginRemote(t, dir)
+
+	// A single commit on the default branch carrying a checkpoint trailer,
+	// simulating merged feature-branch work now reachable from HEAD.
+	testutil.WriteFile(t, dir, "feature.md", "ship it")
+	testutil.GitAdd(t, dir, "feature.md")
+	commitWithMessage(t, dir, trailers.FormatCheckpoint("feature work", mustCheckpointID(t, testCheckpointID)))
+
+	createdAt := time.Now().UTC()
+	seedCommittedCheckpoint(t, dir, seededCheckpoint{
+		id:           testCheckpointID,
+		branch:       "my-feature",
+		createdAt:    createdAt,
+		filesTouched: []string{"feature.md"},
+		outcome:      testLocalFallbackText,
+	})
+
+	// Resolve the actual default branch name (go-git's PlainInit default) so
+	// the test does not hard-code master vs main.
+	repo, err := git.PlainOpenWithOptions(dir, &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultBranch := head.Name().Short()
+
+	oldNow := nowUTC
+	nowUTC = func() time.Time { return createdAt.Add(time.Hour) }
+	t.Cleanup(func() { nowUTC = oldNow })
+
+	t.Chdir(dir)
+
+	got, err := Run(context.Background(), Options{
+		Mode:                  ModeLocal,
+		Since:                 "7d",
+		Branches:              []string{defaultBranch},
+		ImplicitCurrentBranch: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Repos) != 1 || len(got.Repos[0].Sections) == 0 || len(got.Repos[0].Sections[0].Bullets) == 0 ||
+		got.Repos[0].Sections[0].Bullets[0].Text != testLocalFallbackText {
+		t.Fatalf("merged feature-branch work missing from default-branch dispatch: %+v", got)
+	}
+}
+
+// TestLocalMode_IncludesReachableCheckpointMissingFromLocalStore is the other
+// half of the ENT-1188 fix: dispatch --local must summarize work reachable from
+// HEAD by commit trailer even when the checkpoint itself is absent from the
+// local checkout (the common case — checkpoints are pushed to the remote from
+// other worktrees and never fetched into this checkout). The commit subject is
+// always available from git log, so the bullet falls back to it without any
+// (slow) per-checkpoint network fetch. Before the fix, enumeration relied on
+// store.List, which only sees local checkpoints, so this work was invisible.
+func TestLocalMode_IncludesReachableCheckpointMissingFromLocalStore(t *testing.T) {
+	dir := t.TempDir()
+	stubGeneratedLocalDispatch(t)
+	testutil.InitRepo(t, dir)
+	addOriginRemote(t, dir)
+
+	// A commit on the default branch carrying a checkpoint trailer, but the
+	// checkpoint is intentionally NOT seeded into the local store.
+	const subject = "landed remote work"
+	testutil.WriteFile(t, dir, "feature.md", "ship it")
+	testutil.GitAdd(t, dir, "feature.md")
+	commitWithMessage(t, dir, trailers.FormatCheckpoint(subject, mustCheckpointID(t, testCheckpointID)))
+
+	repo, err := git.PlainOpenWithOptions(dir, &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultBranch := head.Name().Short()
+
+	oldNow := nowUTC
+	nowUTC = func() time.Time { return time.Now().UTC().Add(time.Hour) }
+	t.Cleanup(func() { nowUTC = oldNow })
+
+	t.Chdir(dir)
+
+	got, err := Run(context.Background(), Options{
+		Mode:                  ModeLocal,
+		Since:                 "7d",
+		Branches:              []string{defaultBranch},
+		ImplicitCurrentBranch: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Repos) != 1 || len(got.Repos[0].Sections) == 0 || len(got.Repos[0].Sections[0].Bullets) == 0 {
+		t.Fatalf("reachable-but-unfetched checkpoint missing from dispatch: %+v", got)
+	}
+	if got.Repos[0].Sections[0].Bullets[0].Text != subject {
+		t.Fatalf("expected bullet from commit subject %q, got %q", subject, got.Repos[0].Sections[0].Bullets[0].Text)
+	}
+}
+
 func TestLocalMode_AllBranchesRestrictsToLocalBranches(t *testing.T) {
 	dir := t.TempDir()
 	stubGeneratedLocalDispatch(t)
@@ -685,7 +801,7 @@ func TestReachableCheckpointIDsInRange_LimitsLogToWindowAndCheckpointTrailers(t 
 	script := "#!/bin/sh\n" +
 		"if [ \"$3\" = \"log\" ]; then\n" +
 		"  printf '%s\\n' \"$@\" > \"$TEST_GIT_ARGS_FILE\"\n" +
-		"  printf 'subject\\n\\nEntire-Checkpoint: " + testCheckpointID + "\\000'\n" +
+		"  printf '2026-04-02T10:00:00Z\\000subject\\n\\nEntire-Checkpoint: " + testCheckpointID + "\\000\\000'\n" +
 		"  exit 0\n" +
 		"fi\n" +
 		"exit 1\n"

--- a/cmd/entire/cli/dispatch/mode_local_test.go
+++ b/cmd/entire/cli/dispatch/mode_local_test.go
@@ -813,7 +813,8 @@ func TestReachableCheckpointIDsInRange_LimitsLogToWindowAndCheckpointTrailers(t 
 	t.Setenv("TEST_GIT_ARGS_FILE", argsFile)
 
 	since := time.Date(2026, 4, 1, 12, 30, 0, 0, time.UTC)
-	reachable, err := reachableCheckpointIDsInRange(context.Background(), "/tmp/repo", "origin/main..HEAD", since)
+	until := time.Date(2026, 5, 1, 12, 30, 0, 0, time.UTC)
+	reachable, err := reachableCheckpointIDsInRange(context.Background(), "/tmp/repo", "origin/main..HEAD", since, until)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -832,8 +833,50 @@ func TestReachableCheckpointIDsInRange_LimitsLogToWindowAndCheckpointTrailers(t 
 	if !strings.Contains(args, "--since=2026-04-01T12:30:00Z") {
 		t.Fatalf("expected git log to bound history by since window, got args %q", args)
 	}
+	if !strings.Contains(args, "--until=2026-05-01T12:30:00Z") {
+		t.Fatalf("expected git log to bound history by until window, got args %q", args)
+	}
 	if !strings.Contains(args, "origin/main..HEAD") {
 		t.Fatalf("expected git log to use the supplied rev range, got args %q", args)
+	}
+}
+
+// TestReachableCheckpointIDsInRange_KeepsInWindowTimeDespiteLaterCommit is the
+// regression test for the bugbot finding: a checkpoint referenced by both an
+// in-window commit and a later out-of-window commit must record its in-window
+// time so the caller's [since, until) check does not drop it.
+func TestReachableCheckpointIDsInRange_KeepsInWindowTimeDespiteLaterCommit(t *testing.T) {
+	tmpDir := t.TempDir()
+	gitPath := filepath.Join(tmpDir, "git")
+
+	// git log emits newest-first: the out-of-window commit (after until) comes
+	// before the in-window commit, both referencing the same checkpoint. Only
+	// the in-window one should be recorded.
+	script := "#!/bin/sh\n" +
+		"if [ \"$3\" = \"log\" ]; then\n" +
+		"  printf '2026-06-15T10:00:00Z\\000later subject\\n\\nEntire-Checkpoint: " + testCheckpointID + "\\000\\000'\n" +
+		"  printf '2026-04-10T10:00:00Z\\000in-window subject\\n\\nEntire-Checkpoint: " + testCheckpointID + "\\000\\000'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	since := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	reachable, err := reachableCheckpointIDsInRange(context.Background(), "/tmp/repo", "HEAD", since, until)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := reachable[testCheckpointID]
+	if !ok {
+		t.Fatalf("expected checkpoint %s to be reachable via its in-window commit, got %v", testCheckpointID, reachable)
+	}
+	want := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("expected in-window commit time %s, got %s (later out-of-window commit leaked)", want, got)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/885
<!-- entire-trail-link-end -->

## Summary

`entire dispatch --local` returned an empty / near-empty dispatch for everyone, while the server-side dispatch on entire.io worked. Fixes ENT-1188.

## Root cause

Two independent bugs in `cmd/entire/cli/dispatch/mode_local.go`:

1. **Branch scoping.** `branchLocalRevRange` always used `<default>..HEAD`, which is empty on an up-to-date default branch. So the reachable-trailer set was empty and only checkpoints whose `summary.Branch` equalled the current branch survived — rare, since work happens on feature branches merged into `main`.
2. **Stale local store (dominant).** Enumeration used `store.List`, which only sees checkpoints present in the local checkout. Recent checkpoints live in the sharded `git-refs` backend on the checkpoint remote and are never fetched locally — a plain `git pull` only syncs `refs/heads/*`, not `refs/entire/checkpoints/*`. So recent windows came up empty even though the work was reachable from `HEAD` by commit trailer.

## Fix

- `branchLocalRevRange` returns `HEAD` when the current branch **is** the default branch (nothing to exclude); the `base..HEAD` exclusion still applies to feature branches.
- Enumeration now also includes checkpoints reachable by **commit trailer** in the window, using the commit subject as the bullet (always available locally from `git log`) and preferring the richer local session summary when the checkpoint is already present locally. Windowed by commit ("landed on branch") time. No per-checkpoint network fetch, so it stays fast (~20s, dominated by the LLM step).

## Testing

- New regression tests: `TestLocalMode_ImplicitCurrentBranchOnDefaultBranchIncludesMergedWork` and `TestLocalMode_IncludesReachableCheckpointMissingFromLocalStore`.
- Existing `TestLocalMode_ImplicitCurrentBranchExcludesDefaultBranchHistory` still passes (feature-branch scoping preserved).
- Verified end-to-end on a real checkout: `dispatch --local --since 7d` now produces a full dispatch of the week's merged work (was empty before).

## Notes

- The `--all-branches` path still enumerates via `store.List` (local only) — reasonable follow-up if broader coverage is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local dispatch candidate selection and git log parsing; behavior is well covered by new tests but affects what users see in `dispatch --local` windows.
> 
> **Overview**
> Fixes **ENT-1188**: `entire dispatch --local` often returned empty output while server dispatch worked.
> 
> **Default-branch scoping:** When the current branch is the default branch, `branchLocalRevRange` now scans **`HEAD`** instead of `<default>..HEAD`, so merged feature work reachable from default-branch HEAD is included. Feature branches still use the `base..HEAD` exclusion.
> 
> **Enumeration beyond local store:** After `store.List`, a second pass adds checkpoint IDs from **commit trailers** in the time window that are not present locally. Bullets use commit subjects from `git log` (no per-checkpoint network fetch), with optional richer local session titles when a checkpoint exists locally. Trailer reachability is keyed by **in-window commit time** (`reachableCheckpointIDsInRange` now returns `map[string]time.Time` with `--until` and explicit `[since, until)` filtering, keeping in-window times when a later out-of-window commit also references the same ID).
> 
> **Refactor:** Local summary title logic moved to `readLocalSummaryTitle`.
> 
> Regression tests cover default-branch merged work, trailer-only checkpoints missing from the local store, and in-window commit time when newer out-of-window commits exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf509f7e48e3733fe1bb56b80c73ae24b77e478f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->