### PR TITLE
cli: register entire-ci as an official plugin

### DIFF
--- a/cmd/entire/cli/plugin_official.go
+++ b/cmd/entire/cli/plugin_official.go
@@ -11,7 +11,7 @@ import "slices"
 //nolint:gochecknoglobals // package-level allowlist; mutated by tests via snapshot/restore.
 var officialPlugins = []string{
 	// Add Entire-shipped plugin names here as they're released.
-	// e.g. "pgr"
+	"ci", // entire-ci: customer-facing CI-integration management (entireio/entire-ci)
 }
 
 func IsOfficialPlugin(name string) bool {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/888
<!-- entire-trail-link-end -->

## Why

`entire-ci` now ships as a standalone plugin ([entireio/entire-ci](https://github.com/entireio/entire-ci)), discovered as `entire ci …` on PATH — replacing the build-tagged `ci` command group that was proposed in the now-closed #1753–#1758.

## What

Add `"ci"` to `officialPlugins`. This list gates **telemetry only** — plugin discovery and execution already work without it; it just lets `entire ci` invocations be counted (third-party plugin names stay silent by design).

## Tests

`go test ./cmd/entire/cli/ -run TestIsOfficialPlugin` passes (the test snapshots the allowlist, so it's unaffected).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single allowlist entry with no auth, data, or execution-path changes; only affects optional plugin invocation telemetry.
> 
> **Overview**
> Adds **`ci`** to the `officialPlugins` telemetry allowlist in `plugin_official.go`, so `entire ci` (the standalone **entire-ci** plugin) can be counted when user telemetry is enabled. **Plugin discovery and execution are unchanged** — only `maybeTrackPluginInvocation` / `IsOfficialPlugin` behavior for that name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7421ef4d55ed500c0e05c457c9e0fd718b9dd9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->