### PR TITLE
Drop strategy name from `entire status` output

### DIFF
--- a/cmd/entire/cli/integration_test/setup_cmd_test.go
+++ b/cmd/entire/cli/integration_test/setup_cmd_test.go
@@ -209,10 +209,10 @@ func TestEnableDefaultStrategy(t *testing.T) {
 		t.Error("Expected enabled to be true")
 	}
 
-	// Verify status shows manual-commit (the only strategy)
+	// Verify status shows the enabled state
 	stdout = env.RunCLI("status")
-	if !strings.Contains(stdout, "manual-commit") {
-		t.Errorf("Expected status to show 'manual-commit', got: %s", stdout)
+	if !strings.Contains(stdout, "Enabled") {
+		t.Errorf("Expected status to show 'Enabled', got: %s", stdout)
 	}
 }
 

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -18,7 +18,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
-	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 
@@ -160,10 +159,8 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 }
 
 // formatSettingsStatusShort formats a short settings status line.
-// Output format: "● Enabled · manual-commit · branch main" or "○ Disabled"
+// Output format: "● Enabled · branch main" or "○ Disabled"
 func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statusStyles) string {
-	displayName := strategy.StrategyNameManualCommit
-
 	var b strings.Builder
 
 	if s.Enabled {
@@ -175,9 +172,6 @@ func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statu
 		b.WriteString(" ")
 		b.WriteString(sty.render(sty.bold, "Disabled"))
 	}
-
-	b.WriteString(sty.render(sty.dim, " · "))
-	b.WriteString(displayName)
 
 	// Resolve branch from repo root
 	if repoRoot, err := paths.WorktreeRoot(ctx); err == nil {
@@ -222,10 +216,8 @@ func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statu
 }
 
 // formatSettingsStatus formats a settings status line with source prefix.
-// Output format: "Project · enabled · manual-commit" or "Local · disabled"
+// Output format: "Project · enabled" or "Local · disabled"
 func formatSettingsStatus(prefix string, s *EntireSettings, sty statusStyles) string {
-	displayName := strategy.StrategyNameManualCommit
-
 	var b strings.Builder
 	b.WriteString(sty.render(sty.bold, prefix))
 	b.WriteString(sty.render(sty.dim, " · "))
@@ -235,9 +227,6 @@ func formatSettingsStatus(prefix string, s *EntireSettings, sty statusStyles) st
 	} else {
 		b.WriteString("disabled")
 	}
-
-	b.WriteString(sty.render(sty.dim, " · "))
-	b.WriteString(displayName)
 
 	return b.String()
 }

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -159,7 +159,8 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 }
 
 // formatSettingsStatusShort formats a short settings status line.
-// Output format: "● Enabled · branch main" or "○ Disabled"
+// Output format: "● Enabled · branch main" or "○ Disabled · branch main"
+// (the branch segment is appended whenever it can be resolved).
 func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statusStyles) string {
 	var b strings.Builder
 

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -324,8 +324,8 @@ func TestRunStatus_LocalSettingsOnly(t *testing.T) {
 
 func TestRunStatus_BothProjectAndLocal(t *testing.T) {
 	setupTestRepo(t)
-	// Project: enabled=true, strategy=manual-commit
-	// Local: enabled=false, strategy=manual-commit
+	// Project: enabled=true
+	// Local: enabled=false
 	// Detailed mode shows effective status first, then each file separately
 	writeSettings(t, `{"enabled": true}`)
 	writeLocalSettings(t, `{"enabled": false}`)
@@ -337,12 +337,12 @@ func TestRunStatus_BothProjectAndLocal(t *testing.T) {
 
 	output := stdout.String()
 	// Should show effective status first (local overrides project)
-	if !strings.Contains(output, "Disabled") || !strings.Contains(output, "manual-commit") {
-		t.Errorf("Expected output to show effective 'Disabled' with 'manual-commit', got: %s", output)
+	if !strings.Contains(output, "Disabled") {
+		t.Errorf("Expected output to show effective 'Disabled', got: %s", output)
 	}
 	// Should show both settings separately
-	if !strings.Contains(output, "Project") || !strings.Contains(output, "manual-commit") {
-		t.Errorf("Expected output to show Project with manual-commit, got: %s", output)
+	if !strings.Contains(output, "Project") || !strings.Contains(output, "enabled") {
+		t.Errorf("Expected output to show Project with enabled, got: %s", output)
 	}
 	if !strings.Contains(output, "Local") || !strings.Contains(output, "disabled") {
 		t.Errorf("Expected output to show Local with disabled, got: %s", output)
@@ -351,8 +351,8 @@ func TestRunStatus_BothProjectAndLocal(t *testing.T) {
 
 func TestRunStatus_BothProjectAndLocal_Short(t *testing.T) {
 	setupTestRepo(t)
-	// Project: enabled=true, strategy=manual-commit
-	// Local: enabled=false, strategy=manual-commit
+	// Project: enabled=true
+	// Local: enabled=false
 	// Short mode shows merged/effective settings
 	writeSettings(t, `{"enabled": true}`)
 	writeLocalSettings(t, `{"enabled": false}`)
@@ -364,28 +364,8 @@ func TestRunStatus_BothProjectAndLocal_Short(t *testing.T) {
 
 	output := stdout.String()
 	// Should show merged/effective state (local overrides project)
-	if !strings.Contains(output, "Disabled") || !strings.Contains(output, "manual-commit") {
-		t.Errorf("Expected output to show 'Disabled' with 'manual-commit', got: %s", output)
-	}
-}
-
-func TestRunStatus_ShowsManualCommitStrategy(t *testing.T) {
-	setupTestRepo(t)
-	writeSettings(t, `{"enabled": false}`)
-
-	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, true, false); err != nil {
-		t.Fatalf("runStatus() error = %v", err)
-	}
-
-	output := stdout.String()
-	// Should show effective status first
-	if !strings.Contains(output, "Disabled") || !strings.Contains(output, "manual-commit") {
-		t.Errorf("Expected output to show effective 'Disabled' with 'manual-commit', got: %s", output)
-	}
-	// Should show per-file details
-	if !strings.Contains(output, "Project") || !strings.Contains(output, "disabled") {
-		t.Errorf("Expected output to show 'Project' and 'disabled', got: %s", output)
+	if !strings.Contains(output, "Disabled") {
+		t.Errorf("Expected output to show 'Disabled', got: %s", output)
 	}
 }
 
@@ -1222,8 +1202,7 @@ func TestFormatSettingsStatusShort_Enabled(t *testing.T) {
 
 	sty := statusStyles{colorEnabled: false, width: 60}
 	s := &EntireSettings{
-		Enabled:  true,
-		Strategy: "manual-commit",
+		Enabled: true,
 	}
 
 	result := formatSettingsStatusShort(context.Background(), s, sty)
@@ -1234,9 +1213,6 @@ func TestFormatSettingsStatusShort_Enabled(t *testing.T) {
 	if !strings.Contains(result, "Enabled") {
 		t.Errorf("Expected 'Enabled' in output, got: %q", result)
 	}
-	if !strings.Contains(result, "manual-commit") {
-		t.Errorf("Expected strategy in output, got: %q", result)
-	}
 }
 
 func TestFormatSettingsStatusShort_Disabled(t *testing.T) {
@@ -1244,8 +1220,7 @@ func TestFormatSettingsStatusShort_Disabled(t *testing.T) {
 
 	sty := statusStyles{colorEnabled: false, width: 60}
 	s := &EntireSettings{
-		Enabled:  false,
-		Strategy: "manual-commit",
+		Enabled: false,
 	}
 
 	result := formatSettingsStatusShort(context.Background(), s, sty)
@@ -1255,9 +1230,6 @@ func TestFormatSettingsStatusShort_Disabled(t *testing.T) {
 	}
 	if !strings.Contains(result, "Disabled") {
 		t.Errorf("Expected 'Disabled' in output, got: %q", result)
-	}
-	if !strings.Contains(result, "manual-commit") {
-		t.Errorf("Expected strategy in output, got: %q", result)
 	}
 }
 
@@ -1437,8 +1409,7 @@ func TestFormatSettingsStatus_Project(t *testing.T) {
 
 	sty := statusStyles{colorEnabled: false, width: 60}
 	s := &EntireSettings{
-		Enabled:  true,
-		Strategy: "manual-commit",
+		Enabled: true,
 	}
 
 	result := formatSettingsStatus("Project", s, sty)
@@ -1449,9 +1420,6 @@ func TestFormatSettingsStatus_Project(t *testing.T) {
 	if !strings.Contains(result, "enabled") {
 		t.Errorf("Expected 'enabled' in output, got: %q", result)
 	}
-	if !strings.Contains(result, "manual-commit") {
-		t.Errorf("Expected strategy in output, got: %q", result)
-	}
 }
 
 func TestFormatSettingsStatus_LocalDisabled(t *testing.T) {
@@ -1459,8 +1427,7 @@ func TestFormatSettingsStatus_LocalDisabled(t *testing.T) {
 
 	sty := statusStyles{colorEnabled: false, width: 60}
 	s := &EntireSettings{
-		Enabled:  false,
-		Strategy: "manual-commit",
+		Enabled: false,
 	}
 
 	result := formatSettingsStatus("Local", s, sty)
@@ -1470,9 +1437,6 @@ func TestFormatSettingsStatus_LocalDisabled(t *testing.T) {
 	}
 	if !strings.Contains(result, "disabled") {
 		t.Errorf("Expected 'disabled' in output, got: %q", result)
-	}
-	if !strings.Contains(result, "manual-commit") {
-		t.Errorf("Expected strategy in output, got: %q", result)
 	}
 }
 
@@ -1702,8 +1666,7 @@ func TestFormatSettingsStatus_Separators(t *testing.T) {
 
 	sty := statusStyles{colorEnabled: false, width: 60}
 	s := &EntireSettings{
-		Enabled:  true,
-		Strategy: "manual-commit",
+		Enabled: true,
 	}
 
 	result := formatSettingsStatus("Project", s, sty)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/889
<!-- entire-trail-link-end -->

manual-commit is the only implemented strategy, so printing its name in `entire status` (`● Enabled · manual-commit · branch main`, `Project · enabled · manual-commit`) tells the user nothing. This removes it from both status lines.

Deliberately untouched: checkpoint metadata `strategy` field, `Entire-Strategy` commit trailers, and `checkpoint explain --json` — those record provenance (imports write `"import"`), not display.

**Test plan:** updated `status_test.go` + `setup_cmd_test.go` assertions; `mise run fmt`, golangci-lint, and scoped unit/integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only CLI change with no settings, hook, or checkpoint behavior changes; tests updated accordingly.
> 
> **Overview**
> **`entire status`** no longer prints the checkpoint strategy (e.g. `manual-commit`) on the short summary line or on **Project** / **Local** detailed lines, since only one strategy is implemented and the label added no signal.
> 
> Short output is now along the lines of **`● Enabled · branch main`** (branch and agents unchanged); detailed lines are **`Project · enabled`** / **`Local · disabled`**. The `strategy` package import was removed from `status.go`.
> 
> Unit and integration tests were updated to assert **Enabled** / **Disabled** (and per-scope enabled state) instead of **`manual-commit`**; the dedicated **`TestRunStatus_ShowsManualCommitStrategy`** test was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6bba294f6895109fa5de35a2676d91bc84be64d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->