### PR TITLE
fix(remotehelper): skip receive-pack POST when send-pack emits no request

### DIFF
--- a/internal/remotehelper/githelper/consts_test.go
+++ b/internal/remotehelper/githelper/consts_test.go
@@ -6,4 +6,5 @@ const (
 	testRefMain          = "refs/heads/main"
 	testRefFeatureBranch = "refs/heads/feature-branch"
 	testHeadSHA          = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	goosWindows          = "windows"
 )

--- a/internal/remotehelper/githelper/invariants_test.go
+++ b/internal/remotehelper/githelper/invariants_test.go
@@ -21,13 +21,43 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 )
+
+// wrappedSendPackRequest returns the stateless-rpc outer framing
+// `git send-pack --stateless-rpc` emits for a minimal one-command
+// receive-pack request: one outer packet wrapping the inner pkt-line
+// stream, then the outer flush. The command line omits the
+// NUL-separated capability list a real send-pack appends so the
+// result stays shell-safe for printf stubs; handlePush only relays
+// the body, and AppendAgentToReceivePackRequest leaves lines without
+// a NUL unchanged.
+func wrappedSendPackRequest(oldSHA, newSHA, ref string) string {
+	inner := pktLine(oldSHA+" "+newSHA+" "+ref+" report-status\n") + "0000"
+	return fmt.Sprintf("%04x%s0000", len(inner)+4, inner)
+}
+
+// pushFakeTransport returns a fakeTransport advertising oldSHA at
+// testRefMain for receive-pack and answering any service RPC with an
+// empty body.
+func pushFakeTransport(oldSHA string) *fakeTransport {
+	return &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			return stringRC(serviceAnnouncement(serviceReceivePack,
+				oldSHA+" "+testRefMain+"\x00 report-status\n")), nil
+		},
+		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
+			return stringRC(""), nil
+		},
+	}
+}
 
 // TestInvariant_NoSpuriousAckOnTransportError: the server's POST
 // fails before any response body is written. Helper output MUST
@@ -186,18 +216,10 @@ func TestInvariant_AckOnlyAfterFullResponse(t *testing.T) {
 	newSHA := strings.Repeat("b", 40)
 	ref := testRefMain
 
-	ft := &fakeTransport{
-		infoRefsResp: func() (io.ReadCloser, error) {
-			return stringRC(serviceAnnouncement(serviceReceivePack,
-				oldSHA+" "+ref+"\x00 report-status\n")), nil
-		},
-		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
-			// Empty response body — server processed the push but
-			// returned no report-status. Helper must surface this
-			// as "no acknowledgement" rather than synthesise one.
-			return stringRC(""), nil
-		},
-	}
+	// The empty ServiceRPC response body means the server processed the
+	// push but returned no report-status. Helper must surface this as
+	// "no acknowledgement" rather than synthesise one.
+	ft := pushFakeTransport(oldSHA)
 
 	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
 	var stdin bytes.Buffer
@@ -276,26 +298,28 @@ func TestInvariant_PartialRefBatchAllOrNothing(t *testing.T) {
 // reason and leaves the user with bare "send-pack exited with error".
 //
 // A shell stub on PATH plays the role of `git send-pack`: it emits the
-// minimal wire shape handlePush expects (empty wrapped request, then
-// trailing flush + helper-status), and exits 1.
+// wire shape of a server-side rejection (a request WAS sent, so the
+// wrapped request and the cmds_sent-guarded trailing flush are both
+// present before the helper-status), and exits 1.
 func TestInvariant_HelperStatusSurfacedOnSendPackError(t *testing.T) {
 	// No t.Parallel(): t.Setenv("PATH", ...) mutates process-global state.
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip("shell-script PATH stub is POSIX-only")
 	}
 
 	ref := testRefMain
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
 	helperStatusLine := "error " + ref + " remote rejected: branch protection violation\n"
 
-	// Stub git: emits the outer flush that terminates an empty
-	// send-pack request, drains stdin (refspecs + advertisement +
-	// receive-pack response), then emits the trailing flush +
-	// helper-status line, then exits 1. The exit code mirrors
-	// send-pack's behaviour on per-ref rejection.
+	// Stub git: emits a wrapped one-command request + outer flush,
+	// drains stdin (refspecs + advertisement + receive-pack response),
+	// then emits the trailing flush + helper-status line, then exits 1.
+	// The exit code mirrors send-pack's behaviour on per-ref rejection.
 	stubDir := t.TempDir()
 	stubPath := filepath.Join(stubDir, "git")
 	stub := "#!/bin/sh\n" +
-		"printf '0000'\n" +
+		"printf '%s' '" + wrappedSendPackRequest(oldSHA, newSHA, ref) + "'\n" +
 		"cat > /dev/null\n" +
 		"printf '0000" + helperStatusLine + "'\n" +
 		"exit 1\n"
@@ -304,17 +328,7 @@ func TestInvariant_HelperStatusSurfacedOnSendPackError(t *testing.T) {
 	}
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	oldSHA := strings.Repeat("a", 40)
-
-	ft := &fakeTransport{
-		infoRefsResp: func() (io.ReadCloser, error) {
-			return stringRC(serviceAnnouncement(serviceReceivePack,
-				oldSHA+" "+ref+"\x00 report-status\n")), nil
-		},
-		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
-			return stringRC(""), nil
-		},
-	}
+	ft := pushFakeTransport(oldSHA)
 
 	// handlePush takes the first "push" line plus a bufio.Reader for
 	// the rest of the batch; readPushBatch terminates on the blank
@@ -346,17 +360,20 @@ func TestInvariant_HelperStatusSurfacedOnSendPackError(t *testing.T) {
 // that phantom ref out of send-pack's view.
 func TestInvariant_PushReusesListForPushAdvertisement(t *testing.T) {
 	// No t.Parallel(): t.Setenv("PATH", ...) mutates process-global state.
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip("shell-script PATH stub is POSIX-only")
 	}
 
 	ref := testRefMain
 	oldSHA := strings.Repeat("a", 40)
 
-	// Stub git send-pack: emit the empty-request terminator, drain stdin,
-	// then the trailing flush + a plain "ok" helper-status, exit 0.
+	// Stub git send-pack: emit a wrapped one-command request + outer
+	// flush, drain stdin, then the trailing flush + a plain "ok"
+	// helper-status, exit 0.
 	stubDir := t.TempDir()
-	stub := "#!/bin/sh\nprintf '0000'\ncat > /dev/null\nprintf '0000ok " + ref + "\\n'\nexit 0\n"
+	stub := "#!/bin/sh\n" +
+		"printf '%s' '" + wrappedSendPackRequest(oldSHA, strings.Repeat("b", 40), ref) + "'\n" +
+		"cat > /dev/null\nprintf '0000ok " + ref + "\\n'\nexit 0\n"
 	if err := os.WriteFile(filepath.Join(stubDir, "git"), []byte(stub), 0o755); err != nil {
 		t.Fatalf("writing stub git: %v", err)
 	}
@@ -390,5 +407,147 @@ func TestInvariant_PushReusesListForPushAdvertisement(t *testing.T) {
 
 	if receivePackCalls != 1 {
 		t.Fatalf("receive-pack info/refs fetched %d times; want 1 (push must reuse the list-for-push advertisement)", receivePackCalls)
+	}
+}
+
+// TestInvariant_DryRunPushSkipsReceivePackPOST pins the fix for ENT-1199.
+// On `git push --dry-run`, stateless-rpc send-pack emits no receive-pack
+// request at all — the whole request emission is guarded by !args->dry_run,
+// so its stdout is just the outer flush followed directly by helper-status
+// lines (the trailing flush at send-pack.c:759 is guarded by cmds_sent).
+// The helper must mirror remote-curl.c:rpc_service, which breaks without
+// calling post_rpc when the first packet is a flush: no POST (the server
+// deliberately 400s zero-byte receive-pack bodies), no trailing-flush
+// drain (reading 4 more bytes would eat "ok r" from the status line).
+func TestInvariant_DryRunPushSkipsReceivePackPOST(t *testing.T) {
+	// No t.Parallel(): t.Setenv("PATH", ...) mutates process-global state.
+	if runtime.GOOS == goosWindows {
+		t.Skip("shell-script PATH stub is POSIX-only")
+	}
+
+	ref := testRefMain
+	oldSHA := strings.Repeat("a", 40)
+
+	// Stub git send-pack in dry-run shape: outer flush terminating the
+	// (empty) request, drain stdin, then helper-status with NO trailing
+	// flush, exit 0.
+	stubDir := t.TempDir()
+	stub := "#!/bin/sh\n" +
+		"printf '0000'\n" +
+		"cat > /dev/null\n" +
+		"printf 'ok " + ref + "\\n'\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "git"), []byte(stub), 0o755); err != nil {
+		t.Fatalf("writing stub git: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ft := pushFakeTransport(oldSHA)
+
+	firstLine := "push " + oldSHA + ":" + ref
+	stdin := bufio.NewReader(strings.NewReader("\n"))
+
+	var stdout bytes.Buffer
+	err := handlePush(context.Background(), ft, &refAdvCache{}, firstLine, &Options{dryRun: true}, stdin, &stdout)
+	if err != nil {
+		t.Fatalf("handlePush: %v", err)
+	}
+	if len(ft.rpcCalls) != 0 {
+		t.Errorf("expected no receive-pack POST on dry run, got %d", len(ft.rpcCalls))
+	}
+	if want := "ok " + ref + "\n\n"; stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+// TestInvariant_DryRunPushRealSendPack drives handlePush with the REAL
+// git binary — no shell stub — so the wire-shape assumption behind the
+// dry-run skip (send-pack emits no request and no trailing flush when
+// cmds_sent is 0) is pinned against the installed git, not our model
+// of it. A fast-forward update refs/heads/<old> → HEAD is pushed with
+// --dry-run; the helper must complete without POSTing and relay the
+// "ok" helper-status line.
+func TestInvariant_DryRunPushRealSendPack(t *testing.T) {
+	// No t.Parallel(): t.Chdir mutates process-global state (send-pack
+	// resolves the repo from CWD).
+	repo := t.TempDir()
+	gitRun := func(args ...string) string {
+		t.Helper()
+		base := []string{"-C", repo,
+			"-c", "user.name=test", "-c", "user.email=test@example.com",
+			"-c", "commit.gpgsign=false", "-c", "init.defaultBranch=main"}
+		out, err := exec.CommandContext(context.Background(), "git", append(base, args...)...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	gitRun("init", "-q")
+	gitRun("commit", "--allow-empty", "-m", "one")
+	oldSHA := gitRun("rev-parse", "HEAD")
+	gitRun("commit", "--allow-empty", "-m", "two")
+	t.Chdir(repo)
+
+	ft := pushFakeTransport(oldSHA)
+
+	firstLine := "push " + testRefMain + ":" + testRefMain
+	stdin := bufio.NewReader(strings.NewReader("\n"))
+
+	var stdout bytes.Buffer
+	err := handlePush(context.Background(), ft, &refAdvCache{}, firstLine, &Options{dryRun: true}, stdin, &stdout)
+	if err != nil {
+		t.Fatalf("handlePush: %v", err)
+	}
+	if len(ft.rpcCalls) != 0 {
+		t.Errorf("expected no receive-pack POST on dry run, got %d", len(ft.rpcCalls))
+	}
+	if want := "ok " + testRefMain + "\n\n"; stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+// TestInvariant_AllRejectedPushSkipsReceivePackPOST: same empty-request
+// wire shape as a dry run, but produced by a batch where send-pack
+// rejected every update client-side (e.g. non-fast-forward without
+// force) — cmds_sent stays 0, nothing is emitted, and the helper-status
+// `error` lines follow the outer flush directly. The helper must skip
+// the POST, relay the error lines, and surface send-pack's exit error.
+func TestInvariant_AllRejectedPushSkipsReceivePackPOST(t *testing.T) {
+	// No t.Parallel(): t.Setenv("PATH", ...) mutates process-global state.
+	if runtime.GOOS == goosWindows {
+		t.Skip("shell-script PATH stub is POSIX-only")
+	}
+
+	ref := testRefMain
+	oldSHA := strings.Repeat("a", 40)
+	helperStatusLine := "error " + ref + " non-fast-forward\n"
+
+	stubDir := t.TempDir()
+	stub := "#!/bin/sh\n" +
+		"printf '0000'\n" +
+		"cat > /dev/null\n" +
+		"printf '" + helperStatusLine + "'\n" +
+		"exit 1\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "git"), []byte(stub), 0o755); err != nil {
+		t.Fatalf("writing stub git: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ft := pushFakeTransport(oldSHA)
+
+	firstLine := "push " + oldSHA + ":" + ref
+	stdin := bufio.NewReader(strings.NewReader("\n"))
+
+	var stdout bytes.Buffer
+	err := handlePush(context.Background(), ft, &refAdvCache{}, firstLine, &Options{}, stdin, &stdout)
+	if err == nil {
+		t.Fatal("expected error from send-pack exit 1")
+	}
+	if len(ft.rpcCalls) != 0 {
+		t.Errorf("expected no receive-pack POST for all-rejected batch, got %d", len(ft.rpcCalls))
+	}
+	if !strings.Contains(stdout.String(), helperStatusLine) {
+		t.Errorf("stdout missing helper-status line; got %q, want substring %q",
+			stdout.String(), helperStatusLine)
 	}
 }

--- a/internal/remotehelper/githelper/push.go
+++ b/internal/remotehelper/githelper/push.go
@@ -38,10 +38,15 @@ import (
 //  4. Read send-pack stdout as a receive-pack request body (refs +
 //     capabilities + flush, then PACK data for non-delete updates).
 //  5. POST it to /git-receive-pack, stream response back into
-//     send-pack stdin.
+//     send-pack stdin. On --dry-run (or an all-rejected batch)
+//     send-pack emits no request at all — like remote-curl's
+//     rpc_service we skip the POST entirely.
 //  6. Send-pack writes a trailing flush + helper-status lines to
 //     stdout; we discard the flush and relay helper-status to git,
 //     then append the blank line that terminates the status batch.
+//     When no request was sent there is no trailing flush either
+//     (send-pack guards it with cmds_sent) — stdout continues
+//     straight into the status lines.
 func handlePush(ctx context.Context, t Transport, adv *refAdvCache, firstLine string, opts *Options, stdin *bufio.Reader, stdout io.Writer) error {
 	refspecs, err := readPushBatch(firstLine, stdin)
 	if err != nil {
@@ -123,39 +128,54 @@ func handlePush(ctx context.Context, t Transport, adv *refAdvCache, firstLine st
 		killAndWaitSendPack(sp, "after reading send-pack request failed")
 		return fmt.Errorf("reading send-pack request: %w", err)
 	}
-	amendedBody, err := gitproto.AppendAgentToReceivePackRequest(requestBody.Bytes(), Agent)
-	if err != nil {
-		close(respCh)
-		killAndWaitSendPack(sp, "after amending receive-pack agent failed")
-		return fmt.Errorf("amending receive-pack agent: %w", err)
-	}
+	// A dry-run push — or a batch where send-pack rejected every update
+	// client-side — produces no receive-pack request: send-pack guards
+	// the entire request emission with !args->dry_run / cmds_sent, so
+	// the outer flush ReadSendPackRequest just consumed is the ONLY
+	// flush on its stdout, and the next bytes are the helper-status
+	// lines themselves. Mirror remote-curl.c:rpc_service, which breaks
+	// without calling post_rpc when the first packet is a flush: skip
+	// the POST (the server deliberately 400s zero-byte receive-pack
+	// bodies) and skip the trailing-flush drain (the flush at
+	// send-pack.c:759 is guarded by cmds_sent; reading 4 more bytes
+	// here would eat "ok r" from the first status line).
+	if requestBody.Len() == 0 {
+		close(respCh) // feeder sees closed channel, reports nil, closes spIn
+	} else {
+		amendedBody, err := gitproto.AppendAgentToReceivePackRequest(requestBody.Bytes(), Agent)
+		if err != nil {
+			close(respCh)
+			killAndWaitSendPack(sp, "after amending receive-pack agent failed")
+			return fmt.Errorf("amending receive-pack agent: %w", err)
+		}
 
-	resp, err := t.ServiceRPC(ctx, serviceReceivePack, bytes.NewReader(amendedBody))
-	if err != nil {
+		resp, err := t.ServiceRPC(ctx, serviceReceivePack, bytes.NewReader(amendedBody))
+		if err != nil {
+			close(respCh)
+			killAndWaitSendPack(sp, "after posting receive-pack failed")
+			return fmt.Errorf("posting receive-pack: %w", err)
+		}
+		respCh <- resp
 		close(respCh)
-		killAndWaitSendPack(sp, "after posting receive-pack failed")
-		return fmt.Errorf("posting receive-pack: %w", err)
-	}
-	respCh <- resp
-	close(respCh)
 
-	// Send-pack's stdout sequence after we write the response:
-	//   <0000>                       <- packet_flush(out) at send-pack.c:759
-	//   ok refs/heads/...            <- print_helper_status (plain text)
-	//   error refs/...
-	// Drain the trailing flush so git sees only the newline-delimited
-	// status lines that transport-helper.c:push_update_refs_status
-	// expects.
-	//
-	// resp is closed by the feeder goroutine (above), not here — closing
-	// while io.Copy is mid-read aborts the body Read with "use of closed
-	// network connection" and turns successful pushes into fatal errors.
-	flushBuf := make([]byte, 4)
-	if _, err := io.ReadFull(spOutReader, flushBuf); err != nil {
-		return fmt.Errorf("reading send-pack trailing flush: %w", err)
-	}
-	if string(flushBuf) != "0000" {
-		return fmt.Errorf("expected trailing flush from send-pack, got %q", flushBuf)
+		// Send-pack's stdout sequence after we write the response:
+		//   <0000>                       <- packet_flush(out) at send-pack.c:759
+		//   ok refs/heads/...            <- print_helper_status (plain text)
+		//   error refs/...
+		// Drain the trailing flush so git sees only the newline-delimited
+		// status lines that transport-helper.c:push_update_refs_status
+		// expects.
+		//
+		// resp is closed by the feeder goroutine (above), not here — closing
+		// while io.Copy is mid-read aborts the body Read with "use of closed
+		// network connection" and turns successful pushes into fatal errors.
+		flushBuf := make([]byte, 4)
+		if _, err := io.ReadFull(spOutReader, flushBuf); err != nil {
+			return fmt.Errorf("reading send-pack trailing flush: %w", err)
+		}
+		if string(flushBuf) != "0000" {
+			return fmt.Errorf("expected trailing flush from send-pack, got %q", flushBuf)
+		}
 	}
 
 	helperStatus, err := io.ReadAll(spOutReader)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/892
<!-- entire-trail-link-end -->

On `git push --dry-run` (and batches where every update is rejected client-side), stateless-rpc send-pack guards the entire request emission with !args->dry_run / cmds_sent: its stdout is just the outer flush followed directly by helper-status lines — no request body and no trailing flush. handlePush unconditionally POSTed the empty body, which the server deliberately rejects with HTTP 400, and then tried to drain a trailing flush that doesn't exist.

Mirror remote-curl.c:rpc_service, which breaks without calling post_rpc when the first packet is a flush: when the wrapped request is empty, skip the POST and the trailing-flush drain and relay the helper-status lines directly.

The two existing send-pack shell stubs emitted an empty request plus a trailing flush — a wire shape real send-pack never produces; they now emit a wrapped one-command request. New invariant tests cover the dry-run and all-rejected shapes via stubs, plus one driving handlePush against the real git binary to pin the wire-shape assumption.

#### Before
```
$ git push --dry-run origin :cli-test
fatal: posting receive-pack: server error (HTTP 400): empty request body
error: failed to push some refs to 'entire://aws-eu-central-1.entire.io/gh/<handle>/test'
```

#### After
```
$ git push --dry-run origin :cli-test
To entire://aws-eu-central-1.entire.io/gh/<handle>/test
 - [deleted]         cli-test
```

Fixes [ENT-1199](https://linear.app/entirehq/issue/ENT-1199).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core remote push protocol handling in `handlePush`; behavior is well-tested but mistakes could affect all pushes through the Entire remote helper.
> 
> **Overview**
> Fixes **`git push --dry-run`** (and pushes where send-pack rejects every ref client-side) failing with HTTP 400 on an empty receive-pack POST and corrupting helper-status by draining a non-existent trailing flush.
> 
> **`handlePush`** now treats an empty wrapped send-pack request like **`remote-curl`’s `rpc_service`**: skip the **`/git-receive-pack`** POST and the trailing-flush read, close the response feeder without posting, and relay helper-status lines directly.
> 
> Tests add shared **`pushFakeTransport`** / **`wrappedSendPackRequest`** helpers, update send-pack shell stubs to match real wire shapes, and add invariant coverage for dry-run, all-rejected batches, and a real-**`git`** dry-run integration test (**ENT-1199**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f93cfcc0f499e8d6f358bce0db00fa8fb8a81f1a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->