### PR TITLE
fix(copilot-cli): accept float timestamps in hook payloads

### DIFF
--- a/cmd/entire/cli/agent/copilotcli/compat.go
+++ b/cmd/entire/cli/agent/copilotcli/compat.go
@@ -127,20 +127,22 @@ func firstString(raw map[string]json.RawMessage, keys ...string) string {
 }
 
 // ParseTimestamp decodes a Copilot event timestamp, which may be either numeric
-// epoch-millis or an RFC3339(Nano) string. A null/zero value returns the zero
-// time (callers treat that as "missing"). Exported so transcript importers can
-// decode the same dual-format field without re-implementing the logic.
+// epoch-millis or an RFC3339(Nano) string. The numeric form may carry a
+// fractional part (Copilot CLI 1.0.71 emits e.g. 1784283185447.0). A null/zero
+// value returns the zero time (callers treat that as "missing"). Exported so
+// transcript importers can decode the same dual-format field without
+// re-implementing the logic.
 func ParseTimestamp(raw json.RawMessage) (time.Time, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return time.Time{}, nil
 	}
 
-	var millis int64
+	var millis float64
 	if err := json.Unmarshal(raw, &millis); err == nil {
 		if millis == 0 {
 			return time.Time{}, nil // Treat epoch as missing — triggers time.Now() fallback.
 		}
-		return time.UnixMilli(millis), nil
+		return time.UnixMilli(int64(millis)), nil
 	}
 
 	var ts string
@@ -167,7 +169,7 @@ func isJSONNumber(raw json.RawMessage) bool {
 	if len(raw) == 0 || raw[0] == 'n' {
 		return false
 	}
-	var n int64
+	var n float64
 	return json.Unmarshal(raw, &n) == nil
 }
 

--- a/cmd/entire/cli/agent/copilotcli/compat.go
+++ b/cmd/entire/cli/agent/copilotcli/compat.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"time"
 )
@@ -128,10 +129,10 @@ func firstString(raw map[string]json.RawMessage, keys ...string) string {
 
 // ParseTimestamp decodes a Copilot event timestamp, which may be either numeric
 // epoch-millis or an RFC3339(Nano) string. The numeric form may carry a
-// fractional part (Copilot CLI 1.0.71 emits e.g. 1784283185447.0). A null/zero
-// value returns the zero time (callers treat that as "missing"). Exported so
-// transcript importers can decode the same dual-format field without
-// re-implementing the logic.
+// fractional part (Copilot CLI 1.0.71 emits e.g. 1784283185447.0); sub-millisecond
+// precision is truncated. A null/zero value returns the zero time (callers treat
+// that as "missing"). Exported so transcript importers can decode the same
+// dual-format field without re-implementing the logic.
 func ParseTimestamp(raw json.RawMessage) (time.Time, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return time.Time{}, nil
@@ -139,10 +140,16 @@ func ParseTimestamp(raw json.RawMessage) (time.Time, error) {
 
 	var millis float64
 	if err := json.Unmarshal(raw, &millis); err == nil {
-		if millis == 0 {
+		// Guard the float→int64 conversion: out-of-range values are
+		// implementation-defined in Go, so reject them instead.
+		if millis >= float64(math.MaxInt64) || millis <= float64(math.MinInt64) {
+			return time.Time{}, fmt.Errorf("timestamp %v out of range", millis)
+		}
+		ms := int64(millis) // truncates any fractional milliseconds
+		if ms == 0 {
 			return time.Time{}, nil // Treat epoch as missing — triggers time.Now() fallback.
 		}
-		return time.UnixMilli(int64(millis)), nil
+		return time.UnixMilli(ms), nil
 	}
 
 	var ts string

--- a/cmd/entire/cli/agent/copilotcli/compat_test.go
+++ b/cmd/entire/cli/agent/copilotcli/compat_test.go
@@ -148,6 +148,81 @@ func TestParseHookEnvelope_AcceptsAlternateTranscriptPathAndTimestampFormats(t *
 	}
 }
 
+// Copilot CLI 1.0.71 started emitting timestamp as float epoch-millis
+// (e.g. 1784283185447.0). The strict int64 parse rejected it, so every
+// lifecycle hook (session-start, user-prompt-submitted, agent-stop,
+// session-end) failed and no Entire session was ever created.
+func TestParseHookEnvelope_AcceptsFloatTimestamp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "sessionStart",
+			raw:  `{"sessionId":"sess-123","timestamp":1784283185447.0,"cwd":"/tmp/repo","source":"new","initialPrompt":"hi"}`,
+		},
+		{
+			name: "userPromptSubmitted",
+			raw:  `{"sessionId":"sess-123","timestamp":1784283185370.0,"cwd":"/tmp/repo","prompt":"hi"}`,
+		},
+		{
+			name: "agentStop",
+			raw:  `{"sessionId":"sess-123","timestamp":1784283190710.0,"cwd":"/tmp/repo","transcriptPath":"/tmp/events.jsonl","stopReason":"end_turn"}`,
+		},
+		{
+			name: "sessionEnd",
+			raw:  `{"sessionId":"sess-123","timestamp":1784283190784.0,"cwd":"/tmp/repo","reason":"complete"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env, err := parseHookEnvelope([]byte(tt.raw))
+			if err != nil {
+				t.Fatalf("parseHookEnvelope() error = %v", err)
+			}
+			if env.Host != HostCopilotCLI {
+				t.Fatalf("Host = %q, want %q", env.Host, HostCopilotCLI)
+			}
+			if got := env.Timestamp.UnixMilli(); got < 1784283185000 || got > 1784283191000 {
+				t.Fatalf("Timestamp.UnixMilli() = %d, want the payload's epoch-millis value", got)
+			}
+			if env.SessionID != "sess-123" {
+				t.Fatalf("SessionID = %q, want %q", env.SessionID, "sess-123")
+			}
+		})
+	}
+}
+
+func TestParseTimestamp_FloatMillis(t *testing.T) {
+	t.Parallel()
+
+	ts, err := ParseTimestamp(json.RawMessage(`1784283185447.0`))
+	if err != nil {
+		t.Fatalf("ParseTimestamp() error = %v", err)
+	}
+	if got := ts.UnixMilli(); got != 1784283185447 {
+		t.Fatalf("UnixMilli() = %d, want 1784283185447", got)
+	}
+}
+
+func TestDetectHookHost_FloatTimestampIsCopilotCLI(t *testing.T) {
+	t.Parallel()
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(`{"timestamp":1784283185447.0,"sessionId":"s","prompt":"hi"}`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got := detectHookHost(raw); got != HostCopilotCLI {
+		t.Fatalf("detectHookHost() = %q, want %q", got, HostCopilotCLI)
+	}
+}
+
 func TestParseHookEnvelope_AcceptsSnakeCaseSessionID(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/copilotcli/compat_test.go
+++ b/cmd/entire/cli/agent/copilotcli/compat_test.go
@@ -156,24 +156,29 @@ func TestParseHookEnvelope_AcceptsFloatTimestamp(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		raw  string
+		name       string
+		raw        string
+		wantMillis int64
 	}{
 		{
-			name: "sessionStart",
-			raw:  `{"sessionId":"sess-123","timestamp":1784283185447.0,"cwd":"/tmp/repo","source":"new","initialPrompt":"hi"}`,
+			name:       "sessionStart",
+			raw:        `{"sessionId":"sess-123","timestamp":1784283185447.0,"cwd":"/tmp/repo","source":"new","initialPrompt":"hi"}`,
+			wantMillis: 1784283185447,
 		},
 		{
-			name: "userPromptSubmitted",
-			raw:  `{"sessionId":"sess-123","timestamp":1784283185370.0,"cwd":"/tmp/repo","prompt":"hi"}`,
+			name:       "userPromptSubmitted",
+			raw:        `{"sessionId":"sess-123","timestamp":1784283185370.0,"cwd":"/tmp/repo","prompt":"hi"}`,
+			wantMillis: 1784283185370,
 		},
 		{
-			name: "agentStop",
-			raw:  `{"sessionId":"sess-123","timestamp":1784283190710.0,"cwd":"/tmp/repo","transcriptPath":"/tmp/events.jsonl","stopReason":"end_turn"}`,
+			name:       "agentStop",
+			raw:        `{"sessionId":"sess-123","timestamp":1784283190710.0,"cwd":"/tmp/repo","transcriptPath":"/tmp/events.jsonl","stopReason":"end_turn"}`,
+			wantMillis: 1784283190710,
 		},
 		{
-			name: "sessionEnd",
-			raw:  `{"sessionId":"sess-123","timestamp":1784283190784.0,"cwd":"/tmp/repo","reason":"complete"}`,
+			name:       "sessionEnd",
+			raw:        `{"sessionId":"sess-123","timestamp":1784283190784.0,"cwd":"/tmp/repo","reason":"complete"}`,
+			wantMillis: 1784283190784,
 		},
 	}
 
@@ -188,8 +193,8 @@ func TestParseHookEnvelope_AcceptsFloatTimestamp(t *testing.T) {
 			if env.Host != HostCopilotCLI {
 				t.Fatalf("Host = %q, want %q", env.Host, HostCopilotCLI)
 			}
-			if got := env.Timestamp.UnixMilli(); got < 1784283185000 || got > 1784283191000 {
-				t.Fatalf("Timestamp.UnixMilli() = %d, want the payload's epoch-millis value", got)
+			if got := env.Timestamp.UnixMilli(); got != tt.wantMillis {
+				t.Fatalf("Timestamp.UnixMilli() = %d, want %d", got, tt.wantMillis)
 			}
 			if env.SessionID != "sess-123" {
 				t.Fatalf("SessionID = %q, want %q", env.SessionID, "sess-123")
@@ -207,6 +212,30 @@ func TestParseTimestamp_FloatMillis(t *testing.T) {
 	}
 	if got := ts.UnixMilli(); got != 1784283185447 {
 		t.Fatalf("UnixMilli() = %d, want 1784283185447", got)
+	}
+}
+
+func TestParseTimestamp_SubMillisecondFloatIsMissing(t *testing.T) {
+	t.Parallel()
+
+	// 0.4 truncates to 0 ms — must be treated as "missing" (zero time),
+	// not as the Unix epoch.
+	ts, err := ParseTimestamp(json.RawMessage(`0.4`))
+	if err != nil {
+		t.Fatalf("ParseTimestamp() error = %v", err)
+	}
+	if !ts.IsZero() {
+		t.Fatalf("ParseTimestamp(0.4) = %v, want zero time", ts)
+	}
+}
+
+func TestParseTimestamp_OutOfRangeFloatErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{`1e300`, `-1e300`} {
+		if _, err := ParseTimestamp(json.RawMessage(raw)); err == nil {
+			t.Fatalf("ParseTimestamp(%s) expected out-of-range error, got nil", raw)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/893
<!-- entire-trail-link-end -->

## Problem

Since 2026-07-16 every copilot-cli E2E run on main fails 46/59 tests, all with `checkpoint state did not advance within 30s` (e.g. [run 29565960444](https://github.com/entireio/cli/actions/runs/29565960444)).

## Root cause

Copilot CLI **1.0.71** (published 2026-07-16 01:53 UTC; CI installs unpinned latest) changed hook payload timestamps from integer to **float** epoch-millis:

```json
{"sessionId":"…","timestamp":1784283185447.0,"cwd":"…","source":"new","initialPrompt":"…"}
```

`ParseTimestamp` in `cmd/entire/cli/agent/copilotcli/compat.go` unmarshals into `int64`, which Go rejects for `…447.0`, then falls back to the string branch and errors:

```
failed to parse hook event: failed to parse hook input: unmarshal timestamp string: json: cannot unmarshal number into Go value of type string
```

Every lifecycle hook (session-start, user-prompt-submitted, agent-stop, session-end) parses the envelope, so all of them exited 1 → no Entire session ever started → no checkpoints → tests time out. `preToolUse`/`postToolUse` are pass-through hooks that never read stdin, which is why only tool hooks appeared in CI logs and masked the failure. `isJSONNumber` had the same `int64` strictness, breaking host detection for float-timestamp payloads without `transcriptPath`.

(The failures were invisible in `entire.log` because cobra skips `PersistentPostRunE` when `RunE` errors, so the hook-log buffer is never flushed — possible follow-up hardening, kept out of this PR.)

## Fix

Parse numeric timestamps as `float64` (truncated to millis) in `ParseTimestamp` and `isJSONNumber`. Integer and RFC3339-string forms keep working. No version pinning — we keep testing against latest Copilot.

## Verification

- New unit tests use the live payloads captured from Copilot 1.0.71 (red before the fix, green after).
- End-to-end, local: `mise run test:e2e --agent copilot-cli TestSingleSessionManualCommit`
  - copilot 1.0.71 + old code: **FAIL** (checkpoint state did not advance)
  - copilot 1.0.70 + old code: PASS (regression bracket)
  - copilot 1.0.71 + this fix: **PASS**, all lifecycle hooks fire (session-start / user-prompt-submitted / agent-stop / session-end present in `entire.log`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized JSON timestamp parsing change in copilot-cli compat with new unit tests; no auth or data-model changes.
> 
> **Overview**
> Copilot CLI **1.0.71** started sending hook `timestamp` values as **float** epoch-millis (e.g. `1784283185447.0`). Numeric parsing in `ParseTimestamp` and `isJSONNumber` used `int64`, so unmarshaling failed, lifecycle hooks exited with parse errors, and Entire sessions never started.
> 
> The change unmarshals numeric timestamps as `float64` and converts to millis via `int64` truncation. **Integer** millis and **RFC3339** string timestamps behave as before. Tests cover real 1.0.71 lifecycle payloads and host detection for float timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a28de714d03e47be60f0c1408689246fb66d419. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->