### PR TITLE
fix(claudecode): extract model from transcript to fix Unknown attribution (#1804)

### DIFF
--- a/cmd/entire/cli/agent/claudecode/lifecycle.go
+++ b/cmd/entire/cli/agent/claudecode/lifecycle.go
@@ -20,6 +20,7 @@ var (
 	_ agent.TranscriptAnalyzer     = (*ClaudeCodeAgent)(nil)
 	_ agent.TranscriptPreparer     = (*ClaudeCodeAgent)(nil)
 	_ agent.TokenCalculator        = (*ClaudeCodeAgent)(nil)
+	_ agent.ModelExtractor         = (*ClaudeCodeAgent)(nil)
 	_ agent.SkillEventExtractor    = (*ClaudeCodeAgent)(nil)
 	_ agent.SubagentAwareExtractor = (*ClaudeCodeAgent)(nil)
 	_ agent.HookResponseWriter     = (*ClaudeCodeAgent)(nil)

--- a/cmd/entire/cli/agent/claudecode/model.go
+++ b/cmd/entire/cli/agent/claudecode/model.go
@@ -7,9 +7,11 @@ import (
 
 // modelScanLine captures the two places a Claude Code transcript records the
 // model: the top-level "model" on the system/init line, and "message.model" on
-// each assistant message.
+// each assistant message. Subtype distinguishes the init envelope from other
+// "system" envelopes.
 type modelScanLine struct {
 	Type    string `json:"type"`
+	Subtype string `json:"subtype"`
 	Model   string `json:"model"`
 	Message struct {
 		Model string `json:"model"`
@@ -48,7 +50,7 @@ func (c *ClaudeCodeAgent) ExtractModel(transcriptData []byte) (string, error) {
 				assistantModel = line.Message.Model
 			}
 		case "system":
-			if initModel == "" && line.Model != "" {
+			if line.Subtype == "init" && initModel == "" && line.Model != "" {
 				initModel = line.Model
 			}
 		}

--- a/cmd/entire/cli/agent/claudecode/model.go
+++ b/cmd/entire/cli/agent/claudecode/model.go
@@ -1,0 +1,60 @@
+package claudecode
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// modelScanLine captures the two places a Claude Code transcript records the
+// model: the top-level "model" on the system/init line, and "message.model" on
+// each assistant message.
+type modelScanLine struct {
+	Type    string `json:"type"`
+	Model   string `json:"model"`
+	Message struct {
+		Model string `json:"model"`
+	} `json:"message"`
+}
+
+// ExtractModel returns the model identifier from a Claude Code transcript.
+//
+// Claude Code only reports the model on the SessionStart hook payload, so when
+// SessionStart never fired for a session (hooks installed mid-session, a
+// resumed/continued session, or a cleared model hint) the model is otherwise
+// unknown and checkpoints fall back to "Unknown" attribution. The transcript,
+// however, always records it: on the system/init line ("model") and on every
+// assistant message ("message.model"). This lets condensation backfill the
+// model from the transcript, matching Pi/Copilot/Factory Droid.
+//
+// The most recent assistant "message.model" wins (reflecting a mid-session
+// model switch, and matching the clean, hook-consistent identifier). The
+// system/init "model" is a fallback for very short transcripts that have no
+// assistant message yet. Returns "" when neither source carries a model.
+func (c *ClaudeCodeAgent) ExtractModel(transcriptData []byte) (string, error) {
+	var assistantModel, initModel string
+	for raw := range bytes.SplitSeq(transcriptData, []byte("\n")) {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		var line modelScanLine
+		if err := json.Unmarshal(raw, &line); err != nil {
+			// Skip malformed lines (e.g. an incompletely-flushed transcript)
+			// rather than aborting the whole scan.
+			continue
+		}
+		switch line.Type {
+		case envelopeTypeAssistant:
+			if line.Message.Model != "" {
+				assistantModel = line.Message.Model
+			}
+		case "system":
+			if initModel == "" && line.Model != "" {
+				initModel = line.Model
+			}
+		}
+	}
+	if assistantModel != "" {
+		return assistantModel, nil
+	}
+	return initModel, nil
+}

--- a/cmd/entire/cli/agent/claudecode/model.go
+++ b/cmd/entire/cli/agent/claudecode/model.go
@@ -5,6 +5,10 @@ import (
 	"encoding/json"
 )
 
+// syntheticModel is the placeholder Claude Code writes to message.model for
+// synthetic (API-error) assistant entries; it is not a real model identifier.
+const syntheticModel = "<synthetic>"
+
 // modelScanLine captures the two places a Claude Code transcript records the
 // model: the top-level "model" on the system/init line, and "message.model" on
 // each assistant message. Subtype distinguishes the init envelope from other
@@ -46,7 +50,10 @@ func (c *ClaudeCodeAgent) ExtractModel(transcriptData []byte) (string, error) {
 		}
 		switch line.Type {
 		case envelopeTypeAssistant:
-			if line.Message.Model != "" {
+			// Claude Code sets message.model to "<synthetic>" on API-error
+			// entries; skip it so the placeholder doesn't replace the last
+			// genuine model.
+			if line.Message.Model != "" && line.Message.Model != syntheticModel {
 				assistantModel = line.Message.Model
 			}
 		case "system":

--- a/cmd/entire/cli/agent/claudecode/model.go
+++ b/cmd/entire/cli/agent/claudecode/model.go
@@ -50,6 +50,12 @@ func (c *ClaudeCodeAgent) ExtractModel(transcriptData []byte) (string, error) {
 		}
 		switch line.Type {
 		case envelopeTypeAssistant:
+			// All assistant lines are considered, including subagent
+			// (isSidechain) messages: the whole session shares one model, and
+			// on a mid-session switch the most recent line — sidechain or not —
+			// reflects the current one. This matches the rest of the package,
+			// which does not distinguish sidechains when scanning transcripts.
+			//
 			// Claude Code sets message.model to "<synthetic>" on API-error
 			// entries; skip it so the placeholder doesn't replace the last
 			// genuine model.

--- a/cmd/entire/cli/agent/claudecode/model_test.go
+++ b/cmd/entire/cli/agent/claudecode/model_test.go
@@ -20,6 +20,22 @@ func TestExtractModel_MostRecentAssistantMessageWins(t *testing.T) {
 	}
 }
 
+func TestExtractModel_SkipsSyntheticPlaceholder(t *testing.T) {
+	t.Parallel()
+	// Claude Code sets message.model to "<synthetic>" on API-error assistant
+	// entries. That placeholder must not replace the last genuine model.
+	transcript := `{"type":"assistant","message":{"model":"claude-opus-4-8","id":"m1","role":"assistant","content":[]}}
+{"type":"assistant","message":{"model":"<synthetic>","id":"m2","role":"assistant","content":[]}}`
+
+	model, err := (&ClaudeCodeAgent{}).ExtractModel([]byte(transcript))
+	if err != nil {
+		t.Fatalf("ExtractModel returned error: %v", err)
+	}
+	if model != "claude-opus-4-8" {
+		t.Errorf("expected last genuine model %q, got %q", "claude-opus-4-8", model)
+	}
+}
+
 func TestExtractModel_FallsBackToSystemInit(t *testing.T) {
 	t.Parallel()
 	// No assistant message yet (very short/early transcript): recover the model

--- a/cmd/entire/cli/agent/claudecode/model_test.go
+++ b/cmd/entire/cli/agent/claudecode/model_test.go
@@ -1,0 +1,80 @@
+package claudecode
+
+import "testing"
+
+func TestExtractModel_MostRecentAssistantMessageWins(t *testing.T) {
+	t.Parallel()
+	// message.model is the clean, hook-consistent identifier; the most recent
+	// assistant message reflects a mid-session model switch.
+	transcript := `{"type":"system","subtype":"init","session_id":"s","model":"claude-opus-4-8[1m]"}
+{"type":"assistant","message":{"model":"claude-opus-4-8","id":"m1","role":"assistant","content":[]}}
+{"type":"user","message":{"role":"user","content":"hi"}}
+{"type":"assistant","message":{"model":"claude-sonnet-5","id":"m2","role":"assistant","content":[]}}`
+
+	model, err := (&ClaudeCodeAgent{}).ExtractModel([]byte(transcript))
+	if err != nil {
+		t.Fatalf("ExtractModel returned error: %v", err)
+	}
+	if model != "claude-sonnet-5" {
+		t.Errorf("expected most recent assistant model %q, got %q", "claude-sonnet-5", model)
+	}
+}
+
+func TestExtractModel_FallsBackToSystemInit(t *testing.T) {
+	t.Parallel()
+	// No assistant message yet (very short/early transcript): recover the model
+	// from the system init line rather than reporting empty.
+	transcript := `{"type":"system","subtype":"init","session_id":"s","model":"claude-opus-4-8[1m]"}
+{"type":"user","message":{"role":"user","content":"hi"}}`
+
+	model, err := (&ClaudeCodeAgent{}).ExtractModel([]byte(transcript))
+	if err != nil {
+		t.Fatalf("ExtractModel returned error: %v", err)
+	}
+	if model != "claude-opus-4-8[1m]" {
+		t.Errorf("expected system init model %q, got %q", "claude-opus-4-8[1m]", model)
+	}
+}
+
+func TestExtractModel_EmptyTranscript(t *testing.T) {
+	t.Parallel()
+	model, err := (&ClaudeCodeAgent{}).ExtractModel(nil)
+	if err != nil {
+		t.Fatalf("ExtractModel returned error: %v", err)
+	}
+	if model != "" {
+		t.Errorf("expected empty model for empty transcript, got %q", model)
+	}
+}
+
+func TestExtractModel_NoModelField(t *testing.T) {
+	t.Parallel()
+	// Assistant messages without a model field, and no system init model.
+	transcript := `{"type":"assistant","message":{"id":"m1","role":"assistant","content":[]}}
+{"type":"user","message":{"role":"user","content":"hi"}}`
+
+	model, err := (&ClaudeCodeAgent{}).ExtractModel([]byte(transcript))
+	if err != nil {
+		t.Fatalf("ExtractModel returned error: %v", err)
+	}
+	if model != "" {
+		t.Errorf("expected empty model when none present, got %q", model)
+	}
+}
+
+func TestExtractModel_IgnoresMalformedLines(t *testing.T) {
+	t.Parallel()
+	// A corrupt/partial line (e.g. from an incompletely-flushed transcript) must
+	// not abort extraction of the surrounding valid lines.
+	transcript := `{"type":"system","subtype":"init","model":"claude-opus-4-8[1m]"}
+{not valid json
+{"type":"assistant","message":{"model":"claude-opus-4-8","id":"m1","role":"assistant","content":[]}}`
+
+	model, err := (&ClaudeCodeAgent{}).ExtractModel([]byte(transcript))
+	if err != nil {
+		t.Fatalf("ExtractModel returned error: %v", err)
+	}
+	if model != "claude-opus-4-8" {
+		t.Errorf("expected %q despite malformed line, got %q", "claude-opus-4-8", model)
+	}
+}

--- a/cmd/entire/cli/agent/claudecode/model_test.go
+++ b/cmd/entire/cli/agent/claudecode/model_test.go
@@ -62,6 +62,22 @@ func TestExtractModel_NoModelField(t *testing.T) {
 	}
 }
 
+func TestExtractModel_IgnoresNonInitSystemEnvelope(t *testing.T) {
+	t.Parallel()
+	// A "system" line that is not the init envelope must not be mistaken for the
+	// init-model fallback, even if it happens to carry a "model" field.
+	transcript := `{"type":"system","subtype":"compact_boundary","model":"stale-model"}
+{"type":"user","message":{"role":"user","content":"hi"}}`
+
+	model, err := (&ClaudeCodeAgent{}).ExtractModel([]byte(transcript))
+	if err != nil {
+		t.Fatalf("ExtractModel returned error: %v", err)
+	}
+	if model != "" {
+		t.Errorf("expected empty model for non-init system envelope, got %q", model)
+	}
+}
+
 func TestExtractModel_IgnoresMalformedLines(t *testing.T) {
 	t.Parallel()
 	// A corrupt/partial line (e.g. from an incompletely-flushed transcript) must

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -291,6 +291,26 @@ func TestSessionStateBackfillModel_PiReadsModelFromTranscript(t *testing.T) {
 	require.Equal(t, "gpt-5.5", model)
 }
 
+func TestSessionStateBackfillModel_ClaudeCodeReadsModelFromTranscript(t *testing.T) {
+	t.Parallel()
+
+	// Claude Code reports the model only on the SessionStart hook payload. When
+	// that never fired (hooks installed mid-session, a resumed session, or a
+	// cleared model hint) the model would otherwise be empty and checkpoints fall
+	// back to "Unknown" attribution (issue #1804). The transcript still records
+	// it on message.model, so backfill recovers it at condensation time.
+	transcript := []byte(strings.Join([]string{
+		`{"type":"system","subtype":"init","session_id":"cc-uuid","model":"claude-opus-4-8[1m]"}`,
+		`{"type":"assistant","message":{"model":"claude-opus-4-8","id":"m1","role":"assistant","content":[]}}`,
+	}, "\n") + "\n")
+
+	ag, err := agent.GetByAgentType(agent.AgentTypeClaudeCode)
+	require.NoError(t, err)
+
+	model := sessionStateBackfillModel(context.Background(), ag, transcript)
+	require.Equal(t, "claude-opus-4-8", model)
+}
+
 func TestSessionStateBackfillModel_EmptyTranscript(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/899
<!-- entire-trail-link-end -->

## Summary

Fixes the primary CLI-side cause of #1804 — Claude Code sessions attributed as **"Unknown"** because their checkpoints carry an empty model.

**Root cause:** Claude Code was the *only* major agent without a `ModelExtractor`. It sourced the model **solely** from the SessionStart hook payload (stored in the model-hint file, recovered on later turns). When SessionStart never delivered a model for a session — hooks installed mid-session, a resumed/`--continue` session, compaction spawning a fresh segment, or a cleared hint — `state.ModelName` stayed `""` **permanently with no fallback**. Every checkpoint then carried an empty model, and the entire.io frontend renders an empty model as the **"Unknown"** agent.

Pi, Copilot, and Factory Droid already recover the model from the transcript at condensation time via `sessionStateBackfillModel` (`manual_commit_condensation.go`). This makes Claude Code do the same. The CC transcript always records the model — on the `system`/`init` line and on every assistant `message.model` — so recovery is reliable.

## What changed

- **`ExtractModel` for `ClaudeCodeAgent`** (`agent/claudecode/model.go`): prefer the most recent assistant `message.model` (clean, hook-consistent identifier, reflects mid-session model switches), falling back to the `system`/`init` line's `model` for very short transcripts. Malformed lines (e.g. an incompletely-flushed transcript) are skipped rather than fatal.
- Registered the `agent.ModelExtractor` interface assertion, so the existing generic backfill (`AsModelExtractor`) now fires for Claude Code with no other wiring changes.

## Why this shape

Matches the existing Pi/Copilot/Droid pattern exactly (KISS/DRY) and realizes the reporter's suggestion #2 ("propagate the session-level model onto checkpoint records"). Low risk: `system.init.model` is line 1 of the transcript, present even in a partial/unflushed file.

## Not in scope (deliberately)

- **The 3s flush-sentinel timeout** (reporter's suggestion #1) is a *separate* issue and **not** the cause of the empty model — the sentinel governs transcript-flush completeness, and CC never sourced the model from the transcript before this change. `finalize` re-reads the full transcript later regardless. Worth revisiting for token-count accuracy on large transcripts, but decoupled from attribution.
- **Server/frontend hardening**: empty model → "Unknown" agent (same class as #859) would be better fixed by falling back to the checkpoint's `agent` field when model is empty. Out of scope for this CLI PR.

## Tests

- `agent/claudecode/model_test.go` — most-recent-assistant precedence, system/init fallback, empty transcript, no-model, malformed-line resilience.
- `strategy/manual_commit_condensation_test.go` — end-to-end guard that `sessionStateBackfillModel` recovers the model for Claude Code (the reporter's exact scenario).

Full unit suite green (8175 tests); `golangci-lint` v2.11.3 clean on both changed packages.

Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized attribution/backfill logic with no auth or data-path changes; behavior matches existing agents’ transcript model extraction.
> 
> **Overview**
> Fixes Claude Code checkpoints showing **Unknown** model when SessionStart never populated session state (mid-session hooks, resumed sessions, cleared hints).
> 
> **Claude Code** now implements `ModelExtractor` via `ExtractModel`, scanning the JSONL transcript: the **latest assistant `message.model`** wins (including mid-session switches), with **`system`/`init` `model`** as fallback when there are no assistant lines yet. Bad lines are skipped instead of failing the scan. A compile-time `agent.ModelExtractor` assertion wires this into the existing **`sessionStateBackfillModel`** path at condensation—same pattern as Pi, Copilot, and Factory Droid.
> 
> Tests cover precedence, fallbacks, empty/malformed transcripts, and an end-to-end **`sessionStateBackfillModel`** case for Claude Code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5dc22582fcacf320df5719cf83805e0ae258a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->