### PR TITLE
fix(claude-code): target current tool matchers for subagent hooks

### DIFF
--- a/cmd/entire/cli/agent/claudecode/hooks.go
+++ b/cmd/entire/cli/agent/claudecode/hooks.go
@@ -36,17 +36,13 @@ const (
 // ,/| as exact strings, not a regex). See:
 //   - https://code.claude.com/docs/en/tools-reference.md (Agent, TodoWrite entries)
 //   - https://code.claude.com/docs/en/hooks.md (matcher evaluation rules)
+//
+// Configs written by older CLI versions used the outdated matchers "Task" and
+// "TodoWrite", where the hooks silently never fired. Those are not rewritten in
+// place on a normal `entire enable`; run with --force to strip and reinstall.
 const (
 	subagentToolMatcher = "Agent"
 	taskToolMatcher     = "TaskCreate|TaskUpdate"
-)
-
-// staleSubagentMatcher and staleTaskMatcher are the outdated matcher names that
-// older CLI versions wrote. `entire enable` migrates Entire hooks off these onto
-// the current matchers above (see migrateEntireToolMatcher).
-const (
-	staleSubagentMatcher = "Task"
-	staleTaskMatcher     = "TodoWrite"
 )
 
 // ClaudeSettingsFileName is the settings file used by Claude Code.
@@ -149,17 +145,6 @@ func (c *ClaudeCodeAgent) InstallHooks(ctx context.Context, localDev bool, force
 		postToolUse = removeEntireHooksFromMatchers(postToolUse)
 	}
 
-	// Migrate Entire hooks off the outdated tool matchers that older CLI versions
-	// wrote (Task->Agent rename; TodoWrite deprecated for TaskCreate/TaskUpdate).
-	// This runs on every enable, not just --force, so existing users self-heal by
-	// re-running `entire enable`. User-owned hooks under these matchers are kept
-	// (removal keys on the Entire command prefix, not the matcher name). Force mode
-	// already stripped all Entire hooks above, so these are no-ops there.
-	migrated := false
-	preToolUse, migrated = migrateEntireToolMatcher(preToolUse, staleSubagentMatcher, subagentToolMatcher, migrated)
-	postToolUse, migrated = migrateEntireToolMatcher(postToolUse, staleSubagentMatcher, subagentToolMatcher, migrated)
-	postToolUse, migrated = migrateEntireToolMatcher(postToolUse, staleTaskMatcher, taskToolMatcher, migrated)
-
 	// Define hook commands
 	var sessionStartCmd, sessionEndCmd, stopCmd, userPromptSubmitCmd, preTaskCmd, postTaskCmd, postTodoCmd string
 	if localDev {
@@ -230,8 +215,8 @@ func (c *ClaudeCodeAgent) InstallHooks(ctx context.Context, localDev bool, force
 		permissionsChanged = true
 	}
 
-	if count == 0 && !permissionsChanged && !migrated {
-		return 0, nil // All hooks and permissions already installed, nothing to migrate
+	if count == 0 && !permissionsChanged {
+		return 0, nil // All hooks and permissions already installed
 	}
 
 	// Marshal modified hook types back to rawHooks
@@ -537,37 +522,4 @@ func removeEntireHooks(matchers []ClaudeHookMatcher) []ClaudeHookMatcher {
 func removeEntireHooksFromMatchers(matchers []ClaudeHookMatcher) []ClaudeHookMatcher {
 	// Same logic as removeEntireHooks - both work on the same structure
 	return removeEntireHooks(matchers)
-}
-
-// migrateEntireToolMatcher removes Entire-managed hook entries that live under a
-// stale tool matcher (e.g. "Task", "TodoWrite") so InstallHooks can re-add them
-// under the current tool name. Non-Entire hooks under the stale matcher are
-// preserved. Returns the (possibly modified) matchers and changed, OR'd with the
-// incoming changed so callers can chain calls. A no-op when staleMatcher equals
-// currentMatcher (nothing to migrate).
-func migrateEntireToolMatcher(matchers []ClaudeHookMatcher, staleMatcher, currentMatcher string, changed bool) ([]ClaudeHookMatcher, bool) {
-	if staleMatcher == currentMatcher {
-		return matchers, changed
-	}
-	result := make([]ClaudeHookMatcher, 0, len(matchers))
-	for _, matcher := range matchers {
-		if matcher.Matcher != staleMatcher {
-			result = append(result, matcher)
-			continue
-		}
-		kept := make([]ClaudeHookEntry, 0, len(matcher.Hooks))
-		for _, hook := range matcher.Hooks {
-			if isEntireHook(hook.Command) {
-				changed = true
-				continue
-			}
-			kept = append(kept, hook)
-		}
-		// Only keep the matcher if user hooks remain under it.
-		if len(kept) > 0 {
-			matcher.Hooks = kept
-			result = append(result, matcher)
-		}
-	}
-	return result, changed
 }

--- a/cmd/entire/cli/agent/claudecode/hooks.go
+++ b/cmd/entire/cli/agent/claudecode/hooks.go
@@ -27,6 +27,28 @@ const (
 	HookNamePostTodo         = "post-todo"
 )
 
+// Claude Code tool-name matchers for Entire's PreToolUse/PostToolUse hooks.
+//
+// The subagent dispatch tool is "Agent" (Claude Code never exposed a tool named
+// "Task"), and the "TodoWrite" tool was disabled by default in v2.1.142 in favor
+// of the Task* tools. "TaskCreate|TaskUpdate" is a matcher list of exact tool
+// names (Claude Code treats a matcher containing only letters/digits/_/-/spaces/
+// ,/| as exact strings, not a regex). See:
+//   - https://code.claude.com/docs/en/tools-reference.md (Agent, TodoWrite entries)
+//   - https://code.claude.com/docs/en/hooks.md (matcher evaluation rules)
+const (
+	subagentToolMatcher = "Agent"
+	taskToolMatcher     = "TaskCreate|TaskUpdate"
+)
+
+// staleSubagentMatcher and staleTaskMatcher are the outdated matcher names that
+// older CLI versions wrote. `entire enable` migrates Entire hooks off these onto
+// the current matchers above (see migrateEntireToolMatcher).
+const (
+	staleSubagentMatcher = "Task"
+	staleTaskMatcher     = "TodoWrite"
+)
+
 // ClaudeSettingsFileName is the settings file used by Claude Code.
 // This is Claude-specific and not shared with other agents.
 const ClaudeSettingsFileName = "settings.json"
@@ -127,6 +149,17 @@ func (c *ClaudeCodeAgent) InstallHooks(ctx context.Context, localDev bool, force
 		postToolUse = removeEntireHooksFromMatchers(postToolUse)
 	}
 
+	// Migrate Entire hooks off the outdated tool matchers that older CLI versions
+	// wrote (Task->Agent rename; TodoWrite deprecated for TaskCreate/TaskUpdate).
+	// This runs on every enable, not just --force, so existing users self-heal by
+	// re-running `entire enable`. User-owned hooks under these matchers are kept
+	// (removal keys on the Entire command prefix, not the matcher name). Force mode
+	// already stripped all Entire hooks above, so these are no-ops there.
+	migrated := false
+	preToolUse, migrated = migrateEntireToolMatcher(preToolUse, staleSubagentMatcher, subagentToolMatcher, migrated)
+	postToolUse, migrated = migrateEntireToolMatcher(postToolUse, staleSubagentMatcher, subagentToolMatcher, migrated)
+	postToolUse, migrated = migrateEntireToolMatcher(postToolUse, staleTaskMatcher, taskToolMatcher, migrated)
+
 	// Define hook commands
 	var sessionStartCmd, sessionEndCmd, stopCmd, userPromptSubmitCmd, preTaskCmd, postTaskCmd, postTodoCmd string
 	if localDev {
@@ -166,16 +199,16 @@ func (c *ClaudeCodeAgent) InstallHooks(ctx context.Context, localDev bool, force
 		userPromptSubmit = addHookToMatcher(userPromptSubmit, "", userPromptSubmitCmd)
 		count++
 	}
-	if !hookCommandExistsWithMatcher(preToolUse, "Task", preTaskCmd) {
-		preToolUse = addHookToMatcher(preToolUse, "Task", preTaskCmd)
+	if !hookCommandExistsWithMatcher(preToolUse, subagentToolMatcher, preTaskCmd) {
+		preToolUse = addHookToMatcher(preToolUse, subagentToolMatcher, preTaskCmd)
 		count++
 	}
-	if !hookCommandExistsWithMatcher(postToolUse, "Task", postTaskCmd) {
-		postToolUse = addHookToMatcher(postToolUse, "Task", postTaskCmd)
+	if !hookCommandExistsWithMatcher(postToolUse, subagentToolMatcher, postTaskCmd) {
+		postToolUse = addHookToMatcher(postToolUse, subagentToolMatcher, postTaskCmd)
 		count++
 	}
-	if !hookCommandExistsWithMatcher(postToolUse, "TodoWrite", postTodoCmd) {
-		postToolUse = addHookToMatcher(postToolUse, "TodoWrite", postTodoCmd)
+	if !hookCommandExistsWithMatcher(postToolUse, taskToolMatcher, postTodoCmd) {
+		postToolUse = addHookToMatcher(postToolUse, taskToolMatcher, postTodoCmd)
 		count++
 	}
 
@@ -197,8 +230,8 @@ func (c *ClaudeCodeAgent) InstallHooks(ctx context.Context, localDev bool, force
 		permissionsChanged = true
 	}
 
-	if count == 0 && !permissionsChanged {
-		return 0, nil // All hooks and permissions already installed
+	if count == 0 && !permissionsChanged && !migrated {
+		return 0, nil // All hooks and permissions already installed, nothing to migrate
 	}
 
 	// Marshal modified hook types back to rawHooks
@@ -500,8 +533,41 @@ func removeEntireHooks(matchers []ClaudeHookMatcher) []ClaudeHookMatcher {
 }
 
 // removeEntireHooksFromMatchers removes Entire hooks from tool-use matchers (PreToolUse, PostToolUse)
-// This handles the nested structure where hooks are grouped by tool matcher (e.g., "Task", "TodoWrite")
+// This handles the nested structure where hooks are grouped by tool matcher (e.g., "Agent", "TaskCreate|TaskUpdate")
 func removeEntireHooksFromMatchers(matchers []ClaudeHookMatcher) []ClaudeHookMatcher {
 	// Same logic as removeEntireHooks - both work on the same structure
 	return removeEntireHooks(matchers)
+}
+
+// migrateEntireToolMatcher removes Entire-managed hook entries that live under a
+// stale tool matcher (e.g. "Task", "TodoWrite") so InstallHooks can re-add them
+// under the current tool name. Non-Entire hooks under the stale matcher are
+// preserved. Returns the (possibly modified) matchers and changed, OR'd with the
+// incoming changed so callers can chain calls. A no-op when staleMatcher equals
+// currentMatcher (nothing to migrate).
+func migrateEntireToolMatcher(matchers []ClaudeHookMatcher, staleMatcher, currentMatcher string, changed bool) ([]ClaudeHookMatcher, bool) {
+	if staleMatcher == currentMatcher {
+		return matchers, changed
+	}
+	result := make([]ClaudeHookMatcher, 0, len(matchers))
+	for _, matcher := range matchers {
+		if matcher.Matcher != staleMatcher {
+			result = append(result, matcher)
+			continue
+		}
+		kept := make([]ClaudeHookEntry, 0, len(matcher.Hooks))
+		for _, hook := range matcher.Hooks {
+			if isEntireHook(hook.Command) {
+				changed = true
+				continue
+			}
+			kept = append(kept, hook)
+		}
+		// Only keep the matcher if user hooks remain under it.
+		if len(kept) > 0 {
+			matcher.Hooks = kept
+			result = append(result, matcher)
+		}
+	}
+	return result, changed
 }

--- a/cmd/entire/cli/agent/claudecode/hooks_test.go
+++ b/cmd/entire/cli/agent/claudecode/hooks_test.go
@@ -706,20 +706,6 @@ func TestUninstallHooks_PreservesUnknownHookTypes(t *testing.T) {
 	}
 }
 
-// entireMatchersFor returns the matcher names under which an Entire-managed hook
-// with the given command appears.
-func entireMatchersFor(matchers []ClaudeHookMatcher, command string) []string {
-	var found []string
-	for _, m := range matchers {
-		for _, h := range m.Hooks {
-			if h.Command == command {
-				found = append(found, m.Matcher)
-			}
-		}
-	}
-	return found
-}
-
 // TestInstallHooks_UsesCurrentToolMatchers pins the tool-use matchers to Claude
 // Code's current tool names. The subagent tool is "Agent" (there was never a
 // "Task" tool) and "TodoWrite" was deprecated for TaskCreate/TaskUpdate; a bad
@@ -745,88 +731,45 @@ func TestInstallHooks_UsesCurrentToolMatchers(t *testing.T) {
 		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo"), "post-todo task-list hook")
 }
 
-// TestInstallHooks_MigratesStaleToolMatchers verifies that re-running enable
-// (without --force) moves Entire hooks off the outdated "Task"/"TodoWrite"
-// matchers onto the current ones, so already-configured users self-heal.
-func TestInstallHooks_MigratesStaleToolMatchers(t *testing.T) {
+// TestInstallHooks_Force_ReinstallsStaleToolMatchers verifies that `--force`
+// strips Entire hooks left under the outdated "Task"/"TodoWrite" matchers by
+// older CLI versions and reinstalls them under the current matchers. (A normal
+// enable does not rewrite existing hook config; --force is the fix path.)
+func TestInstallHooks_Force_ReinstallsStaleToolMatchers(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Chdir(tempDir)
 
-	// Simulate settings written by an older CLI version, using the production
-	// wrapper form real installs store (so migration must unwrap to detect them).
-	stalePre := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task")
+	// Settings written by an older CLI version, in the production wrapper form.
 	stalePost := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task")
 	staleTodo := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo")
 	writeSettingsFile(t, tempDir, fmt.Sprintf(`{
   "hooks": {
-    "PreToolUse": [
-      {"matcher": "Task", "hooks": [{"type": "command", "command": %q}]}
-    ],
     "PostToolUse": [
       {"matcher": "Task", "hooks": [{"type": "command", "command": %q}]},
       {"matcher": "TodoWrite", "hooks": [{"type": "command", "command": %q}]}
     ]
   }
-}`, stalePre, stalePost, staleTodo))
+}`, stalePost, staleTodo))
 
 	a := &ClaudeCodeAgent{}
-	count, err := a.InstallHooks(context.Background(), false, false)
-	if err != nil {
-		t.Fatalf("InstallHooks() error = %v", err)
-	}
-	if count == 0 {
-		t.Error("migration should have installed hooks under the current matchers")
+	if _, err := a.InstallHooks(context.Background(), false, true); err != nil {
+		t.Fatalf("InstallHooks(force) error = %v", err)
 	}
 
 	settings := readClaudeSettings(t, tempDir)
-
-	// Current matchers now carry the Entire hooks.
-	assertHookExists(t, settings.Hooks.PreToolUse, "Agent",
-		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task"), "migrated pre-task hook")
+	// Reinstalled under the current matchers.
 	assertHookExists(t, settings.Hooks.PostToolUse, "Agent",
-		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task"), "migrated post-task hook")
+		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task"), "post-task hook")
 	assertHookExists(t, settings.Hooks.PostToolUse, "TaskCreate|TaskUpdate",
-		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo"), "migrated post-todo hook")
-
-	// The Entire hooks live under exactly one (current) matcher — the stale
-	// Task/TodoWrite entries were removed, not left as dead duplicates.
-	preTaskCmd := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task")
-	if got := entireMatchersFor(settings.Hooks.PreToolUse, preTaskCmd); !slices.Equal(got, []string{"Agent"}) {
-		t.Errorf("pre-task hook matchers = %v, want [Agent]", got)
+		staleTodo, "post-todo hook")
+	// The stale matchers no longer carry an Entire hook.
+	for _, m := range settings.Hooks.PostToolUse {
+		if m.Matcher == "Task" || m.Matcher == "TodoWrite" {
+			for _, h := range m.Hooks {
+				if isEntireHook(h.Command) {
+					t.Errorf("stale matcher %q still carries an Entire hook: %q", m.Matcher, h.Command)
+				}
+			}
+		}
 	}
-	postTaskCmd := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task")
-	if got := entireMatchersFor(settings.Hooks.PostToolUse, postTaskCmd); !slices.Equal(got, []string{"Agent"}) {
-		t.Errorf("post-task hook matchers = %v, want [Agent]", got)
-	}
-}
-
-// TestInstallHooks_MigrationPreservesUserToolHooks verifies migration only
-// removes Entire-managed entries under the stale matcher, leaving a user's own
-// hook under "Task" intact.
-func TestInstallHooks_MigrationPreservesUserToolHooks(t *testing.T) {
-	tempDir := t.TempDir()
-	t.Chdir(tempDir)
-
-	writeSettingsFile(t, tempDir, `{
-  "hooks": {
-    "PreToolUse": [
-      {"matcher": "Task", "hooks": [
-        {"type": "command", "command": "echo user-task-hook"},
-        {"type": "command", "command": "entire hooks claude-code pre-task"}
-      ]}
-    ]
-  }
-}`)
-
-	a := &ClaudeCodeAgent{}
-	if _, err := a.InstallHooks(context.Background(), false, false); err != nil {
-		t.Fatalf("InstallHooks() error = %v", err)
-	}
-
-	settings := readClaudeSettings(t, tempDir)
-	// User's own Task hook survives.
-	assertHookExists(t, settings.Hooks.PreToolUse, "Task", "echo user-task-hook", "user Task hook")
-	// Ours moved to Agent.
-	assertHookExists(t, settings.Hooks.PreToolUse, "Agent",
-		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task"), "migrated pre-task hook")
 }

--- a/cmd/entire/cli/agent/claudecode/hooks_test.go
+++ b/cmd/entire/cli/agent/claudecode/hooks_test.go
@@ -3,6 +3,7 @@ package claudecode
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -546,8 +547,8 @@ func TestInstallHooks_PreservesUserHooksOnSameType(t *testing.T) {
 			t.Fatalf("failed to parse PostToolUse hooks: %v", err)
 		}
 		assertHookExists(t, matchers, "Write", "echo user wrote file", "user Write hook")
-		assertHookExists(t, matchers, "Task", agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task"), "Entire Task hook")
-		assertHookExists(t, matchers, "TodoWrite", agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo"), "Entire TodoWrite hook")
+		assertHookExists(t, matchers, "Agent", agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task"), "Entire Agent (subagent) hook")
+		assertHookExists(t, matchers, "TaskCreate|TaskUpdate", agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo"), "Entire task-list hook")
 	})
 }
 
@@ -703,4 +704,129 @@ func TestUninstallHooks_PreservesUnknownHookTypes(t *testing.T) {
 			t.Errorf("Stop hook should have been removed")
 		}
 	}
+}
+
+// entireMatchersFor returns the matcher names under which an Entire-managed hook
+// with the given command appears.
+func entireMatchersFor(matchers []ClaudeHookMatcher, command string) []string {
+	var found []string
+	for _, m := range matchers {
+		for _, h := range m.Hooks {
+			if h.Command == command {
+				found = append(found, m.Matcher)
+			}
+		}
+	}
+	return found
+}
+
+// TestInstallHooks_UsesCurrentToolMatchers pins the tool-use matchers to Claude
+// Code's current tool names. The subagent tool is "Agent" (there was never a
+// "Task" tool) and "TodoWrite" was deprecated for TaskCreate/TaskUpdate; a bad
+// matcher is a silent no-op in Claude Code, so this is the only guard against
+// the hooks silently ceasing to fire. See:
+//   - https://code.claude.com/docs/en/tools-reference.md
+//   - https://code.claude.com/docs/en/hooks.md
+func TestInstallHooks_UsesCurrentToolMatchers(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	a := &ClaudeCodeAgent{}
+	if _, err := a.InstallHooks(context.Background(), false, false); err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+
+	settings := readClaudeSettings(t, tempDir)
+	assertHookExists(t, settings.Hooks.PreToolUse, "Agent",
+		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task"), "pre-task subagent hook")
+	assertHookExists(t, settings.Hooks.PostToolUse, "Agent",
+		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task"), "post-task subagent hook")
+	assertHookExists(t, settings.Hooks.PostToolUse, "TaskCreate|TaskUpdate",
+		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo"), "post-todo task-list hook")
+}
+
+// TestInstallHooks_MigratesStaleToolMatchers verifies that re-running enable
+// (without --force) moves Entire hooks off the outdated "Task"/"TodoWrite"
+// matchers onto the current ones, so already-configured users self-heal.
+func TestInstallHooks_MigratesStaleToolMatchers(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	// Simulate settings written by an older CLI version, using the production
+	// wrapper form real installs store (so migration must unwrap to detect them).
+	stalePre := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task")
+	stalePost := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task")
+	staleTodo := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo")
+	writeSettingsFile(t, tempDir, fmt.Sprintf(`{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "Task", "hooks": [{"type": "command", "command": %q}]}
+    ],
+    "PostToolUse": [
+      {"matcher": "Task", "hooks": [{"type": "command", "command": %q}]},
+      {"matcher": "TodoWrite", "hooks": [{"type": "command", "command": %q}]}
+    ]
+  }
+}`, stalePre, stalePost, staleTodo))
+
+	a := &ClaudeCodeAgent{}
+	count, err := a.InstallHooks(context.Background(), false, false)
+	if err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+	if count == 0 {
+		t.Error("migration should have installed hooks under the current matchers")
+	}
+
+	settings := readClaudeSettings(t, tempDir)
+
+	// Current matchers now carry the Entire hooks.
+	assertHookExists(t, settings.Hooks.PreToolUse, "Agent",
+		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task"), "migrated pre-task hook")
+	assertHookExists(t, settings.Hooks.PostToolUse, "Agent",
+		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task"), "migrated post-task hook")
+	assertHookExists(t, settings.Hooks.PostToolUse, "TaskCreate|TaskUpdate",
+		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo"), "migrated post-todo hook")
+
+	// The Entire hooks live under exactly one (current) matcher — the stale
+	// Task/TodoWrite entries were removed, not left as dead duplicates.
+	preTaskCmd := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task")
+	if got := entireMatchersFor(settings.Hooks.PreToolUse, preTaskCmd); !slices.Equal(got, []string{"Agent"}) {
+		t.Errorf("pre-task hook matchers = %v, want [Agent]", got)
+	}
+	postTaskCmd := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task")
+	if got := entireMatchersFor(settings.Hooks.PostToolUse, postTaskCmd); !slices.Equal(got, []string{"Agent"}) {
+		t.Errorf("post-task hook matchers = %v, want [Agent]", got)
+	}
+}
+
+// TestInstallHooks_MigrationPreservesUserToolHooks verifies migration only
+// removes Entire-managed entries under the stale matcher, leaving a user's own
+// hook under "Task" intact.
+func TestInstallHooks_MigrationPreservesUserToolHooks(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	writeSettingsFile(t, tempDir, `{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "Task", "hooks": [
+        {"type": "command", "command": "echo user-task-hook"},
+        {"type": "command", "command": "entire hooks claude-code pre-task"}
+      ]}
+    ]
+  }
+}`)
+
+	a := &ClaudeCodeAgent{}
+	if _, err := a.InstallHooks(context.Background(), false, false); err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+
+	settings := readClaudeSettings(t, tempDir)
+	// User's own Task hook survives.
+	assertHookExists(t, settings.Hooks.PreToolUse, "Task", "echo user-task-hook", "user Task hook")
+	// Ours moved to Agent.
+	assertHookExists(t, settings.Hooks.PreToolUse, "Agent",
+		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task"), "migrated pre-task hook")
 }

--- a/cmd/entire/cli/integration_test/setup_claude_hooks_test.go
+++ b/cmd/entire/cli/integration_test/setup_claude_hooks_test.go
@@ -66,14 +66,14 @@ func TestSetupClaudeHooks_AddsAllRequiredHooks(t *testing.T) {
 	if len(settings.Hooks.UserPromptSubmit) == 0 {
 		t.Error("UserPromptSubmit hook should exist")
 	}
-	if !hasHookWithMatcher(settings.Hooks.PreToolUse, "Task") {
-		t.Error("PreToolUse[Task] hook should exist")
+	if !hasHookWithMatcher(settings.Hooks.PreToolUse, "Agent") {
+		t.Error("PreToolUse[Agent] hook should exist")
 	}
-	if !hasHookWithMatcher(settings.Hooks.PostToolUse, "Task") {
-		t.Error("PostToolUse[Task] hook should exist")
+	if !hasHookWithMatcher(settings.Hooks.PostToolUse, "Agent") {
+		t.Error("PostToolUse[Agent] hook should exist")
 	}
-	if !hasHookWithMatcher(settings.Hooks.PostToolUse, "TodoWrite") {
-		t.Error("PostToolUse[TodoWrite] hook should exist")
+	if !hasHookWithMatcher(settings.Hooks.PostToolUse, "TaskCreate|TaskUpdate") {
+		t.Error("PostToolUse[TaskCreate|TaskUpdate] hook should exist")
 	}
 
 }
@@ -146,15 +146,15 @@ func TestSetupClaudeHooks_PreservesExistingSettings(t *testing.T) {
 		t.Error("existing CustomTool hook should be preserved")
 	}
 
-	// User's Task hook should be preserved alongside our hook
+	// User's Task hook should be preserved (migration only removes Entire hooks)
 	taskHooks := getAllHookCommands(settings.Hooks.PreToolUse, "Task")
 	if !containsCommand(taskHooks, "echo user-task-hook") {
 		t.Errorf("user's Task hook should be preserved, got: %v", taskHooks)
 	}
 
-	// Our hooks should also be added
-	if !hasHookWithMatcher(settings.Hooks.PostToolUse, "Task") {
-		t.Error("PostToolUse[Task] hook should be added")
+	// Our hooks should be added under the current subagent matcher
+	if !hasHookWithMatcher(settings.Hooks.PostToolUse, "Agent") {
+		t.Error("PostToolUse[Agent] hook should be added")
 	}
 }
 

--- a/cmd/entire/cli/integration_test/setup_claude_hooks_test.go
+++ b/cmd/entire/cli/integration_test/setup_claude_hooks_test.go
@@ -146,7 +146,7 @@ func TestSetupClaudeHooks_PreservesExistingSettings(t *testing.T) {
 		t.Error("existing CustomTool hook should be preserved")
 	}
 
-	// User's Task hook should be preserved (migration only removes Entire hooks)
+	// User's own Task hook should be preserved (enable never removes non-Entire hooks)
 	taskHooks := getAllHookCommands(settings.Hooks.PreToolUse, "Task")
 	if !containsCommand(taskHooks, "echo user-task-hook") {
 		t.Errorf("user's Task hook should be preserved, got: %v", taskHooks)

--- a/docs/architecture/claude-hooks-integration.md
+++ b/docs/architecture/claude-hooks-integration.md
@@ -11,9 +11,23 @@ Entire integrates with Claude Code through six hooks that fire at different poin
 | `SessionStart`           | New chat session begins        | Generate and persist Entire session ID         |
 | `UserPromptSubmit`       | User submits a prompt          | Capture pre-prompt state, check for conflicts  |
 | `Stop`                   | Claude finishes responding     | Create checkpoint with code + metadata         |
-| `PreToolUse[Task]`       | Subagent is about to start     | Capture pre-task state for diff computation    |
-| `PostToolUse[Task]`      | Subagent finishes              | Create final checkpoint for subagent work      |
-| `PostToolUse[TodoWrite]` | Subagent updates its todo list | Create incremental checkpoint if files changed |
+| `PreToolUse[Agent]`      | Subagent is about to start     | Capture pre-task state for diff computation    |
+| `PostToolUse[Agent]`     | Subagent finishes              | Create final checkpoint for subagent work      |
+| `PostToolUse[TaskCreate\|TaskUpdate]` | Subagent updates its task list | Create incremental checkpoint if files changed |
+
+> **Tool matcher note.** Claude Code's subagent dispatch tool is `Agent` (there
+> was never a `Task` tool), and the `TodoWrite` tool was disabled by default in
+> v2.1.142 in favor of `TaskCreate`/`TaskUpdate`. Older CLI versions installed
+> these hooks under `Task`/`TodoWrite`, where they silently never fired.
+> Re-running `entire enable` migrates them onto the matchers above. See
+> [tools-reference](https://code.claude.com/docs/en/tools-reference.md) and
+> [hooks matcher rules](https://code.claude.com/docs/en/hooks.md).
+>
+> The incremental-checkpoint handler still parses the legacy `TodoWrite`
+> `tool_input` schema for its checkpoint message label; under `TaskCreate`/
+> `TaskUpdate` the checkpoint is still created (file-change detection is
+> independent) but the label falls back to `Checkpoint #N`. Richer labels from
+> the Task* payloads are a follow-up.
 
 ### Critical Capabilities
 
@@ -122,12 +136,12 @@ Fires when Claude finishes responding. Does **not** fire on user interrupt (Ctrl
 
 8.  **Cleanup**: Deletes the temporary `.entire/tmp/pre-prompt-<session-id>.json` file.
 
-### `PreToolUse[Task]`
+### `PreToolUse[Agent]`
 
 - **Command**: `entire hooks claude-code pre-task`
 - **Handler**: `handlePreTask()` in `hooks_claudecode_handlers.go:668`
 
-Fires just before a subagent (Task tool) begins execution. Captures the current state so that file changes can be computed when the task completes.
+Fires just before a subagent (Agent tool) begins execution. Captures the current state so that file changes can be computed when the task completes.
 
 **What it does:**
 
@@ -142,10 +156,10 @@ Fires just before a subagent (Task tool) begins execution. Captures the current 
 
     - Runs `git status` to get current untracked files.
     - Saves to `.entire/tmp/pre-task-<tool-use-id>.json`.
-    - This baseline is used by `PostToolUse[Task]` to determine which files the subagent created.
-    - **Note**: No checkpoint/commit is created at this stage. Commits are only created during task completion (`PostToolUse[Task]` or `PostToolUse[TodoWrite]`) and only if there are actual file changes.
+    - This baseline is used by `PostToolUse[Agent]` to determine which files the subagent created.
+    - **Note**: No checkpoint/commit is created at this stage. Commits are only created during task completion (`PostToolUse[Agent]` or `PostToolUse[TaskCreate|TaskUpdate]`) and only if there are actual file changes.
 
-### `PostToolUse[Task]`
+### `PostToolUse[Agent]`
 
 - **Command**: `entire hooks claude-code post-task`
 - **Handler**: `handlePostTask()` in `hooks_claudecode_handlers.go:770`
@@ -179,12 +193,12 @@ Fires after a subagent finishes its work. Creates the final checkpoint for the s
 
 7.  **Cleanup**: Deletes `.entire/tmp/pre-task-<tool-use-id>.json`.
 
-### `PostToolUse[TodoWrite]`
+### `PostToolUse[TaskCreate|TaskUpdate]`
 
 - **Command**: `entire hooks claude-code post-todo`
 - **Handler**: `handlePostTodo()` in `hooks_claudecode_handlers.go:550`
 
-Fires whenever a subagent updates its todo list. Enables fine-grained, incremental checkpointing _during_ subagent execution.
+Fires whenever a subagent updates its task list. Enables fine-grained, incremental checkpointing _during_ subagent execution. (The `post-todo` command name predates Claude Code's TodoWrite→Task* rename; the matcher now targets `TaskCreate`/`TaskUpdate`.)
 
 **What it does:**
 

--- a/docs/architecture/claude-hooks-integration.md
+++ b/docs/architecture/claude-hooks-integration.md
@@ -18,8 +18,10 @@ Entire integrates with Claude Code through six hooks that fire at different poin
 > **Tool matcher note.** Claude Code's subagent dispatch tool is `Agent` (there
 > was never a `Task` tool), and the `TodoWrite` tool was disabled by default in
 > v2.1.142 in favor of `TaskCreate`/`TaskUpdate`. Older CLI versions installed
-> these hooks under `Task`/`TodoWrite`, where they silently never fired.
-> Re-running `entire enable` migrates them onto the matchers above. See
+> these hooks under `Task`/`TodoWrite`, where they silently never fired. A normal
+> `entire enable` does not rewrite existing hook config in place; re-run with
+> `--force` (`entire enable --force`) to strip the stale entries and reinstall
+> under the matchers above. See
 > [tools-reference](https://code.claude.com/docs/en/tools-reference.md) and
 > [hooks matcher rules](https://code.claude.com/docs/en/hooks.md).
 >


### PR DESCRIPTION
## Problem

Our Claude Code `PreToolUse`/`PostToolUse` hooks are installed under the tool matchers `Task` and `TodoWrite`. On current Claude Code neither matches anything, so a class of checkpoints **silently never fires**:

- `pre-task` + `post-task` (matcher `Task`) → no per-subagent checkpoints
- `post-todo` (matcher `TodoWrite`) → no incremental checkpoints during subagent runs

A bad matcher in Claude Code is a silent no-op — no error, no warning, no changelog entry — which is why this went unnoticed.

**Not** data loss for the common single-worktree flow: the `Stop` hook (match-all matcher, unaffected) still checkpoints the whole worktree, so subagent edits are captured — just attributed to the main turn, and without subagent/incremental granularity or metadata.

### Source of truth (per docs)

The docs don't phrase this as a "deprecated matcher" — the underlying facts are:

- **Subagent tool is `Agent`**, not `Task` (there was never a `Task` tool): [tools-reference.md](https://code.claude.com/docs/en/tools-reference.md) (`Agent` entry), [hooks.md](https://code.claude.com/docs/en/hooks.md) (matcher tool-name list).
- **`TodoWrite` disabled by default as of v2.1.142** in favor of `TaskCreate`/`TaskGet`/`TaskList`/`TaskUpdate`: [tools-reference.md](https://code.claude.com/docs/en/tools-reference.md) (`TodoWrite` entry, `min-version: 2.1.142`).
- **Matcher evaluation**: a matcher of only letters/digits/`_`/`-`/spaces/`,`/`|` is an exact string (or `|`-list), not a regex — so `Task` does **not** match `TaskCreate`; `TaskCreate|TaskUpdate` matches either exactly: [hooks.md](https://code.claude.com/docs/en/hooks.md) (matcher patterns).

> Note: there is no dedicated Claude Code changelog/GH-issue "deprecation" entry for these — the authoritative statements are the tools-reference version notes linked above.

## Fix

- Generate matchers `Agent` (pre-task/post-task) and `TaskCreate|TaskUpdate` (post-todo). Fresh installs are correct.
- **No in-place migration.** `entire enable` deliberately does **not** rewrite existing hook config as a side effect. Configs written by older versions (stale `Task`/`TodoWrite` entries) are repaired by re-running with **`entire enable --force`**, which already strips and reinstalls Entire hooks.
- Tests: positive-spec guard pinning matchers to Claude Code's current tool names; a `--force` reinstall test proving stale matchers are stripped and reinstalled. Integration assertions updated.
- Architecture doc updated (points stale-config users at `--force`).

## Scope note (see comment)

This fix repairs the Claude Code matchers only. Whether the subagent-checkpoint **granularity** is worth keeping at all is deferred — see the follow-up comment: the product consumes session-level data only, so this output is currently unconsumed, and the machinery is shared across Claude Code / Cursor / Factory Droid / Copilot CLI. Merging keeps behavior consistent without committing to keep the granularity.

## Known follow-up (out of scope)

`post-todo`'s handler still parses the legacy `TodoWrite` `tool_input` schema for its checkpoint **message label**. Under `TaskCreate`/`TaskUpdate` the checkpoint is still created (file-change detection is independent) but the label falls back to `Checkpoint #N`.

## Test plan

- `go test ./cmd/entire/cli/agent/claudecode/` ✅
- `go test -tags integration -run TestSetupClaudeHooks ./cmd/entire/cli/integration_test/` ✅
- `golangci-lint` (v2.11.3) clean on touched packages ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
