### PR TITLE
feat(doctor,status): warn when Claude Code hook config is outdated

### DIFF
--- a/cmd/entire/cli/agent/claudecode/hooks.go
+++ b/cmd/entire/cli/agent/claudecode/hooks.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
@@ -456,9 +457,11 @@ func CheckHookConfig(ctx context.Context) HookConfigState {
 	if !ok || !hasEntireHook(settings.Hooks.Stop) {
 		return HooksAbsent
 	}
-	if !hasEntireHookUnderMatcher(settings.Hooks.PreToolUse, subagentToolMatcher) ||
-		!hasEntireHookUnderMatcher(settings.Hooks.PostToolUse, subagentToolMatcher) ||
-		!hasEntireHookUnderMatcher(settings.Hooks.PostToolUse, taskToolMatcher) {
+	subagentTools := splitMatcherTools(subagentToolMatcher)
+	taskTools := splitMatcherTools(taskToolMatcher)
+	if !hasEntireHookCoveringTools(settings.Hooks.PreToolUse, subagentTools) ||
+		!hasEntireHookCoveringTools(settings.Hooks.PostToolUse, subagentTools) ||
+		!hasEntireHookCoveringTools(settings.Hooks.PostToolUse, taskTools) {
 		return HooksOutdated
 	}
 	return HooksCurrent
@@ -488,11 +491,36 @@ func hasEntireHook(matchers []ClaudeHookMatcher) bool {
 	return false
 }
 
-// hasEntireHookUnderMatcher reports whether an Entire hook is installed under a
-// matcher with the exact given name.
-func hasEntireHookUnderMatcher(matchers []ClaudeHookMatcher, matcherName string) bool {
+// splitMatcherTools splits a Claude Code tool matcher into its exact tool
+// names. Matchers that InstallHooks writes are `|`-separated lists (Claude Code
+// also accepts `,`); whitespace around separators is ignored. Returns the tools
+// in order, dropping empties.
+func splitMatcherTools(matcher string) []string {
+	parts := strings.FieldsFunc(matcher, func(r rune) bool { return r == '|' || r == ',' })
+	tools := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			tools = append(tools, t)
+		}
+	}
+	return tools
+}
+
+// hasEntireHookCoveringTools reports whether an Entire hook is installed under a
+// matcher that covers every tool in want. A widened matcher still counts: a
+// matcher of "TaskCreate|TaskUpdate|TaskGet" covers {TaskCreate, TaskUpdate},
+// so users who broaden a matcher aren't falsely flagged as outdated.
+func hasEntireHookCoveringTools(matchers []ClaudeHookMatcher, want []string) bool {
 	for _, matcher := range matchers {
-		if matcher.Matcher != matcherName {
+		have := splitMatcherTools(matcher.Matcher)
+		coversAll := true
+		for _, w := range want {
+			if !slices.Contains(have, w) {
+				coversAll = false
+				break
+			}
+		}
+		if !coversAll {
 			continue
 		}
 		for _, hook := range matcher.Hooks {

--- a/cmd/entire/cli/agent/claudecode/hooks.go
+++ b/cmd/entire/cli/agent/claudecode/hooks.go
@@ -400,8 +400,9 @@ func (c *ClaudeCodeAgent) UninstallHooks(ctx context.Context) error {
 	return nil
 }
 
-// AreHooksInstalled checks if Entire hooks are installed.
-func (c *ClaudeCodeAgent) AreHooksInstalled(ctx context.Context) bool {
+// loadClaudeSettings reads and parses .claude/settings.json from the repo root.
+// Returns ok=false when the file is missing or unparseable.
+func loadClaudeSettings(ctx context.Context) (ClaudeSettings, bool) {
 	// Use repo root to find .claude directory when run from a subdirectory
 	repoRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
@@ -410,16 +411,57 @@ func (c *ClaudeCodeAgent) AreHooksInstalled(ctx context.Context) bool {
 	settingsPath := filepath.Join(repoRoot, ".claude", ClaudeSettingsFileName)
 	data, err := os.ReadFile(settingsPath) //nolint:gosec // path is constructed from repo root + fixed path
 	if err != nil {
-		return false
+		return ClaudeSettings{}, false
 	}
 
 	var settings ClaudeSettings
 	if err := json.Unmarshal(data, &settings); err != nil {
+		return ClaudeSettings{}, false
+	}
+	return settings, true
+}
+
+// AreHooksInstalled checks if Entire hooks are installed.
+func (c *ClaudeCodeAgent) AreHooksInstalled(ctx context.Context) bool {
+	settings, ok := loadClaudeSettings(ctx)
+	if !ok {
 		return false
 	}
-
 	// Check for at least one of our hooks (new, wrapped, or legacy format)
 	return hasEntireHook(settings.Hooks.Stop)
+}
+
+// HookConfigState describes how Entire's Claude Code hooks compare to what
+// InstallHooks would write today.
+type HookConfigState int
+
+const (
+	// HooksAbsent means Entire hooks are not installed in this repo.
+	HooksAbsent HookConfigState = iota
+	// HooksCurrent means the installed hooks match the current config.
+	HooksCurrent
+	// HooksOutdated means Entire hooks are installed but the current tool-use
+	// matchers no longer carry them (e.g. an older CLI wrote them under the now
+	// non-firing "Task"/"TodoWrite" matchers). Fix: `entire enable --force`.
+	HooksOutdated
+)
+
+// CheckHookConfig reports whether Entire's Claude Code hooks are absent,
+// current, or outdated. It is a read-only diagnostic used by `entire status`
+// and `entire doctor`; it never modifies settings. Outdated is detected on the
+// positive spec: Entire is installed (Stop hook present) yet one of the current
+// tool-use matchers does not carry its Entire hook.
+func CheckHookConfig(ctx context.Context) HookConfigState {
+	settings, ok := loadClaudeSettings(ctx)
+	if !ok || !hasEntireHook(settings.Hooks.Stop) {
+		return HooksAbsent
+	}
+	if !hasEntireHookUnderMatcher(settings.Hooks.PreToolUse, subagentToolMatcher) ||
+		!hasEntireHookUnderMatcher(settings.Hooks.PostToolUse, subagentToolMatcher) ||
+		!hasEntireHookUnderMatcher(settings.Hooks.PostToolUse, taskToolMatcher) {
+		return HooksOutdated
+	}
+	return HooksCurrent
 }
 
 // Helper functions for hook management
@@ -437,6 +479,22 @@ func hookCommandExists(matchers []ClaudeHookMatcher, command string) bool {
 
 func hasEntireHook(matchers []ClaudeHookMatcher) bool {
 	for _, matcher := range matchers {
+		for _, hook := range matcher.Hooks {
+			if isEntireHook(hook.Command) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasEntireHookUnderMatcher reports whether an Entire hook is installed under a
+// matcher with the exact given name.
+func hasEntireHookUnderMatcher(matchers []ClaudeHookMatcher, matcherName string) bool {
+	for _, matcher := range matchers {
+		if matcher.Matcher != matcherName {
+			continue
+		}
 		for _, hook := range matcher.Hooks {
 			if isEntireHook(hook.Command) {
 				return true

--- a/cmd/entire/cli/agent/claudecode/hooks_test.go
+++ b/cmd/entire/cli/agent/claudecode/hooks_test.go
@@ -731,6 +731,52 @@ func TestInstallHooks_UsesCurrentToolMatchers(t *testing.T) {
 		agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo"), "post-todo task-list hook")
 }
 
+func TestCheckHookConfig_Absent(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+	if got := CheckHookConfig(context.Background()); got != HooksAbsent {
+		t.Errorf("CheckHookConfig() = %v, want HooksAbsent", got)
+	}
+}
+
+func TestCheckHookConfig_Current(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+	a := &ClaudeCodeAgent{}
+	if _, err := a.InstallHooks(context.Background(), false, false); err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+	if got := CheckHookConfig(context.Background()); got != HooksCurrent {
+		t.Errorf("CheckHookConfig() = %v, want HooksCurrent", got)
+	}
+}
+
+func TestCheckHookConfig_Outdated(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	// Config from an older CLI version: Entire installed (Stop present) but the
+	// tool-use hooks sit under the outdated Task/TodoWrite matchers.
+	stop := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code stop")
+	pre := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task")
+	post := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task")
+	todo := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo")
+	writeSettingsFile(t, tempDir, fmt.Sprintf(`{
+  "hooks": {
+    "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": %q}]}],
+    "PreToolUse": [{"matcher": "Task", "hooks": [{"type": "command", "command": %q}]}],
+    "PostToolUse": [
+      {"matcher": "Task", "hooks": [{"type": "command", "command": %q}]},
+      {"matcher": "TodoWrite", "hooks": [{"type": "command", "command": %q}]}
+    ]
+  }
+}`, stop, pre, post, todo))
+
+	if got := CheckHookConfig(context.Background()); got != HooksOutdated {
+		t.Errorf("CheckHookConfig() = %v, want HooksOutdated", got)
+	}
+}
+
 // TestInstallHooks_Force_ReinstallsStaleToolMatchers verifies that `--force`
 // strips Entire hooks left under the outdated "Task"/"TodoWrite" matchers by
 // older CLI versions and reinstalls them under the current matchers. (A normal

--- a/cmd/entire/cli/agent/claudecode/hooks_test.go
+++ b/cmd/entire/cli/agent/claudecode/hooks_test.go
@@ -777,6 +777,36 @@ func TestCheckHookConfig_Outdated(t *testing.T) {
 	}
 }
 
+// TestCheckHookConfig_SupersetMatchersAreCurrent verifies that widening a
+// matcher beyond what we install (still covering the required tools) is not
+// flagged as drift — matchers are |-lists of exact tool names, so a superset
+// still fires for the required tools.
+func TestCheckHookConfig_SupersetMatchersAreCurrent(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	stop := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code stop")
+	pre := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code pre-task")
+	post := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-task")
+	todo := agentpkg.WrapProductionSilentHookCommand("entire hooks claude-code post-todo")
+	// "Agent|Foo" still covers Agent; "TaskCreate|TaskUpdate|TaskGet" still
+	// covers TaskCreate and TaskUpdate.
+	writeSettingsFile(t, tempDir, fmt.Sprintf(`{
+  "hooks": {
+    "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": %q}]}],
+    "PreToolUse": [{"matcher": "Agent|Foo", "hooks": [{"type": "command", "command": %q}]}],
+    "PostToolUse": [
+      {"matcher": "Agent|Foo", "hooks": [{"type": "command", "command": %q}]},
+      {"matcher": "TaskCreate|TaskUpdate|TaskGet", "hooks": [{"type": "command", "command": %q}]}
+    ]
+  }
+}`, stop, pre, post, todo))
+
+	if got := CheckHookConfig(context.Background()); got != HooksCurrent {
+		t.Errorf("CheckHookConfig() = %v, want HooksCurrent (superset matcher)", got)
+	}
+}
+
 // TestInstallHooks_Force_ReinstallsStaleToolMatchers verifies that `--force`
 // strips Entire hooks left under the outdated "Task"/"TodoWrite" matchers by
 // older CLI versions and reinstalls them under the current matchers. (A normal

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"charm.land/huh/v2"
+	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -40,7 +41,12 @@ Checks performed:
      review hasn't run yet on this machine, or a newer entire release
      added a hook the user hasn't approved yet).
 
-  3. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
+  When Claude Code hooks are installed:
+  3. Claude Code hook config: warn when the installed hooks are out of
+     date (e.g. an older release wrote tool matchers that no longer fire).
+     Fix by re-running 'entire enable --force'.
+
+  4. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
 
 A session is considered stuck if:
   - It is in ACTIVE phase with no interaction for over 1 hour
@@ -98,6 +104,9 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 
 	// Agent-specific: Codex hook trust state.
 	checkCodexHookTrust(cmd)
+
+	// Agent-specific: Claude Code hook config drift.
+	checkClaudeCodeHookDrift(cmd)
 
 	// Stuck sessions
 	// Load all session states
@@ -437,6 +446,24 @@ func confirmDoctorFix(ctx context.Context, w io.Writer, title string) (bool, err
 // Both checks are structural (file/key presence). Stays silent when
 // this repo doesn't have codex hooks installed or when we can't
 // resolve the worktree root. Warn-only.
+// checkClaudeCodeHookDrift warns when Entire's Claude Code hooks are installed
+// but out of date — e.g. an older release wrote tool matchers that no longer
+// fire on current Claude Code. Read-only; the fix is `entire enable --force`.
+// Stays silent when Claude Code hooks aren't installed here.
+func checkClaudeCodeHookDrift(cmd *cobra.Command) {
+	w := cmd.OutOrStdout()
+	switch claudecode.CheckHookConfig(cmd.Context()) {
+	case claudecode.HooksAbsent:
+		// Not installed in this repo — nothing to report.
+	case claudecode.HooksCurrent:
+		fmt.Fprintln(w, "✓ Claude Code hook config: OK")
+	case claudecode.HooksOutdated:
+		fmt.Fprintln(w, "Claude Code hooks: OUT OF DATE")
+		fmt.Fprintln(w, "  The installed hooks use outdated tool matchers and no longer fire.")
+		fmt.Fprintln(w, "  Run `entire enable --force` to update the hooks file.")
+	}
+}
+
 func checkCodexHookTrust(cmd *cobra.Command) {
 	repoRoot, err := paths.WorktreeRoot(cmd.Context())
 	if err != nil {

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -504,6 +505,61 @@ trusted_hash = "sha256:ccc"
 	require.Contains(t, out, "1 hook(s) declared")
 	require.Contains(t, out, "- post_tool_use")
 	require.Contains(t, out, "Open /hooks inside Codex")
+}
+
+// TestCheckClaudeCodeHookDrift_SilentWhenNotInstalled — doctor prints nothing
+// Claude-Code-related when this repo has no Entire hooks installed.
+func TestCheckClaudeCodeHookDrift_SilentWhenNotInstalled(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	cmd, stdout := newTestCmd(t)
+	checkClaudeCodeHookDrift(cmd)
+	require.NotContains(t, stdout.String(), "Claude Code hook")
+}
+
+// TestCheckClaudeCodeHookDrift_OKWhenCurrent — a fresh install writes the
+// current matchers, so doctor reports OK.
+func TestCheckClaudeCodeHookDrift_OKWhenCurrent(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	if _, err := (&claudecode.ClaudeCodeAgent{}).InstallHooks(context.Background(), false, false); err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+
+	cmd, stdout := newTestCmd(t)
+	checkClaudeCodeHookDrift(cmd)
+	require.Contains(t, stdout.String(), "✓ Claude Code hook config: OK")
+}
+
+// TestCheckClaudeCodeHookDrift_WarnsWhenOutdated — a config left by an older CLI
+// (hooks under the stale Task/TodoWrite matchers) is reported OUT OF DATE with
+// the --force fix hint.
+func TestCheckClaudeCodeHookDrift_WarnsWhenOutdated(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o750))
+	stale := `{
+  "hooks": {
+    "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "entire hooks claude-code stop"}]}],
+    "PreToolUse": [{"matcher": "Task", "hooks": [{"type": "command", "command": "entire hooks claude-code pre-task"}]}],
+    "PostToolUse": [
+      {"matcher": "Task", "hooks": [{"type": "command", "command": "entire hooks claude-code post-task"}]},
+      {"matcher": "TodoWrite", "hooks": [{"type": "command", "command": "entire hooks claude-code post-todo"}]}
+    ]
+  }
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, claudecode.ClaudeSettingsFileName), []byte(stale), 0o600))
+
+	cmd, stdout := newTestCmd(t)
+	checkClaudeCodeHookDrift(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "Claude Code hooks: OUT OF DATE")
+	require.Contains(t, out, "entire enable --force")
 }
 
 // TestCheckCodexHookTrust_FlagsStaleHooksFile — user enabled Codex on

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -190,6 +191,13 @@ func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statu
 			b.WriteString(sty.render(sty.dim, "  Agents · "))
 
 			b.WriteString(strings.Join(displayNames, ", "))
+		}
+
+		// Warn when installed hooks are out of date (read-only; fix is manual).
+		if claudecode.CheckHookConfig(ctx) == claudecode.HooksOutdated {
+			b.WriteString("\n")
+			b.WriteString(sty.render(sty.yellow, "  ! Claude Code hooks out of date"))
+			b.WriteString(sty.render(sty.dim, " · run 'entire enable --force'"))
 		}
 	}
 
@@ -589,7 +597,10 @@ type statusJSON struct {
 	// `entire status --json` instead of the human footer. Set only on the
 	// success path (mirrors writeAgentHelpHint, which only renders when set up).
 	AgentHelp string `json:"agent_help,omitempty"`
-	Error     string `json:"error,omitempty"`
+	// HooksOutdated lists agents whose installed hook config is out of date and
+	// should be refreshed with `entire enable --force`.
+	HooksOutdated []string `json:"hooks_outdated,omitempty"`
+	Error         string   `json:"error,omitempty"`
 }
 
 type sessionBriefJSON struct {
@@ -644,6 +655,10 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 	if s.Enabled {
 		if names := InstalledAgentDisplayNames(ctx); len(names) > 0 {
 			result.Agents = names
+		}
+
+		if claudecode.CheckHookConfig(ctx) == claudecode.HooksOutdated {
+			result.HooksOutdated = append(result.HooksOutdated, "claude-code")
 		}
 
 		if store, err := session.NewStateStore(ctx); err == nil {

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1712,6 +1713,44 @@ func TestRunStatusJSON_Enabled(t *testing.T) {
 	// footer, so the agent-help pointer must be present once entire is set up.
 	if result.AgentHelp != agentHelpCommand {
 		t.Errorf("Expected agent_help='entire agent-help', got %q", result.AgentHelp)
+	}
+}
+
+// TestRunStatusJSON_HooksOutdated — when Claude Code hooks are installed under
+// the outdated Task/TodoWrite matchers, `entire status --json` reports the agent
+// under hooks_outdated so scripts/agents can detect the drift.
+func TestRunStatusJSON_HooksOutdated(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+
+	if err := os.MkdirAll(".claude", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	stale := `{
+  "hooks": {
+    "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "entire hooks claude-code stop"}]}],
+    "PreToolUse": [{"matcher": "Task", "hooks": [{"type": "command", "command": "entire hooks claude-code pre-task"}]}],
+    "PostToolUse": [
+      {"matcher": "Task", "hooks": [{"type": "command", "command": "entire hooks claude-code post-task"}]},
+      {"matcher": "TodoWrite", "hooks": [{"type": "command", "command": "entire hooks claude-code post-todo"}]}
+    ]
+  }
+}`
+	if err := os.WriteFile(".claude/settings.json", []byte(stale), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, false, true); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	var result statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !slices.Contains(result.HooksOutdated, "claude-code") {
+		t.Errorf("Expected hooks_outdated to contain 'claude-code', got %v", result.HooksOutdated)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/902
<!-- entire-trail-link-end -->

Stacked on #1806 (uses its corrected `Agent` / `TaskCreate|TaskUpdate` matchers as the "expected" config). Review/merge after #1806.

## Why

#1806 stopped rewriting stale hook config during `entire enable` (no side-effect mutation). Existing users with outdated configs (`Task`/`TodoWrite` matchers that silently never fire) need a nudge to run `entire enable --force`. This adds that nudge — **detect + warn only, never mutates**.

## What

- **Detector** — `claudecode.CheckHookConfig(ctx)` returns `HooksAbsent` / `HooksCurrent` / `HooksOutdated`. Read-only. "Outdated" = Entire installed (Stop hook present) but a current tool-use matcher (`Agent`, `TaskCreate|TaskUpdate`) doesn't carry its Entire hook. Positive-spec, so it also catches future matcher drift, not just today's `Task`/`TodoWrite`. Factors a shared `loadClaudeSettings` helper (reused by `AreHooksInstalled`).
- **`entire doctor`** — `checkClaudeCodeHookDrift`, a sibling of the existing `checkCodexHookTrust`:
  - current → `✓ Claude Code hook config: OK`
  - outdated → `Claude Code hooks: OUT OF DATE` + `Run 'entire enable --force' to update the hooks file.`
  - absent → silent
- **`entire status`** — human: yellow `! Claude Code hooks out of date · run 'entire enable --force'`; `--json`: new `hooks_outdated: ["claude-code"]` field (agent-native, script/agent-detectable).

## Design notes

- Mirrors the established Codex drift-check precedent (`checkCodexHookTrust` → `codex.MissingEntireHooks`).
- No auto-fix: consistent with #1806's decision that `enable` must not rewrite hook config as a side effect. `--force` remains the fix path.

## Test plan

- `go test ./cmd/entire/cli/agent/claudecode/` ✅ (Absent/Current/Outdated detector states)
- `go test ./cmd/entire/cli/ -run 'TestCheckClaudeCodeHookDrift|TestRunStatusJSON'` ✅ (doctor: silent/OK/outdated; status `--json` hooks_outdated)
- `golangci-lint` (v2.11.3) clean on touched packages ✅
- Full `cli` package: only pre-existing `TestExplainCmd_*` failures (present on `main`, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only diagnostics and user-facing warnings only; hook files are not modified unless the user runs `entire enable --force`.
> 
> **Overview**
> Adds **read-only detection** for stale Entire Claude Code hook layouts (e.g. hooks still under legacy `Task` / `TodoWrite` matchers that no longer fire) and surfaces a fix path via `entire enable --force`, without changing `.claude/settings.json` on normal commands.
> 
> **`claudecode.CheckHookConfig`** returns `HooksAbsent`, `HooksCurrent`, or `HooksOutdated` by checking that Entire is present (Stop hook) and that current matchers (`Agent`, `TaskCreate|TaskUpdate`) carry the expected Entire hooks. Settings loading is factored into **`loadClaudeSettings`**, reused by **`AreHooksInstalled`**.
> 
> **`entire doctor`** runs **`checkClaudeCodeHookDrift`** (OK / OUT OF DATE / silent when not installed). **`entire status`** shows a yellow out-of-date line when enabled; **`entire status --json`** adds **`hooks_outdated: ["claude-code"]`** for scripts and agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48844a7ed9d951376429ac5b721e4ba995bfc59f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->