### PR TITLE
fix(explain): don't mask post-resolution failures as 'no checkpoint or commit found'

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -452,8 +452,8 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 	return runExplainBranchWithFilter(ctx, w, errW, noPager, sessionID)
 }
 
-// explainTargetNotFoundError reports that the positional target matched no
-// committed or temporary checkpoint. It unwraps to
+// explainTargetNotFoundError reports that the requested checkpoint target
+// matched no committed or temporary checkpoint. It unwraps to
 // checkpoint.ErrCheckpointNotFound so callers' errors.Is contracts keep
 // working, while runExplainAuto can distinguish this resolution miss from a
 // failure AFTER a successful match that happens to wrap the same sentinel
@@ -548,7 +548,12 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 		slog.String("target", target),
 		slog.String("commit", abbreviateCommitHash(lookup.repo, hash)),
 		slog.String("checkpoint_id", cpID.String()))
-	return runExplainCheckpointWithLookup(ctx, w, errW, cpID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll, lookup, nil, summaryTimeoutSeconds)
+	if err := runExplainCheckpointWithLookup(ctx, w, errW, cpID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll, lookup, nil, summaryTimeoutSeconds); err != nil {
+		// The user typed a commit, not this checkpoint ID — without the
+		// trailer linkage the error reads as if they asked for an unknown ID.
+		return fmt.Errorf("commit %s references checkpoint %s via its Entire-Checkpoint trailer: %w", abbreviateCommitHash(lookup.repo, hash), cpID, err)
+	}
+	return nil
 }
 
 // runExplainAutoAmbiguityGuard refuses --generate when the positional
@@ -685,7 +690,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	if generate {
 		summary, summaryErr := checkpoint.ReadCheckpoint(ctx, lookup.store, fullCheckpointID)
 		if summaryErr != nil {
-			return fmt.Errorf("failed to read checkpoint: %w", summaryErr)
+			return fmt.Errorf("failed to read checkpoint %s: %w", fullCheckpointID, summaryErr)
 		}
 		if summary.Imported {
 			return fmt.Errorf("cannot generate a summary for imported checkpoint %s: imported history is read-only", fullCheckpointID)
@@ -732,7 +737,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		content, err = checkpoint.ReadLatestSessionContent(ctx, lookup.store, fullCheckpointID, summary)
 		if err != nil {
 			stopLoad(false)
-			return fmt.Errorf("failed to reload checkpoint: %w", err)
+			return fmt.Errorf("failed to reload checkpoint %s: %w", fullCheckpointID, err)
 		}
 	}
 
@@ -784,11 +789,11 @@ func loadCheckpointForExplain(ctx context.Context, lookup *explainCheckpointLook
 	store := lookup.store
 	summary, err := checkpoint.ReadCheckpoint(ctx, store, cpID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read checkpoint: %w", err)
+		return nil, nil, fmt.Errorf("failed to read checkpoint %s: %w", cpID, err)
 	}
 	content, contentErr := checkpoint.ReadLatestSessionContent(ctx, store, cpID, summary)
 	if contentErr != nil {
-		return nil, nil, fmt.Errorf("failed to read checkpoint content: %w", contentErr)
+		return nil, nil, fmt.Errorf("failed to read checkpoint content for %s: %w", cpID, contentErr)
 	}
 	return summary, content, nil
 }
@@ -1236,7 +1241,9 @@ func explainTemporaryCheckpoint(ctx context.Context, w, errW io.Writer, repo *gi
 	// This ensures we find checkpoints even if HEAD has advanced since the session started
 	tempCheckpoints, err := store.ListAllCheckpoints(ctx, "", branchCheckpointsLimit)
 	if err != nil {
-		return "", false, nil //nolint:nilerr // best-effort: caller falls back to ErrCheckpointNotFound when no temp checkpoint is found
+		logging.Debug(ctx, "explain: listing temporary checkpoints failed; treating as no temp match",
+			slog.String("error", err.Error()))
+		return "", false, nil
 	}
 
 	// Find checkpoints matching the SHA prefix - check for ambiguity
@@ -1274,12 +1281,20 @@ func explainTemporaryCheckpoint(ctx context.Context, w, errW io.Writer, repo *gi
 	// Get shadow commit and tree to read metadata
 	shadowCommit, commitErr := repo.CommitObject(tc.CommitHash)
 	if commitErr != nil {
-		return "", false, nil //nolint:nilerr // best-effort: missing shadow commit is treated as not-found
+		// The prefix DID match this temp checkpoint; record why it still
+		// reads as not-found (pruned/gc'd shadow objects, IO errors).
+		logging.Debug(ctx, "explain: temp checkpoint matched but shadow commit unreadable; treating as not-found",
+			slog.String("commit", tc.CommitHash.String()),
+			slog.String("error", commitErr.Error()))
+		return "", false, nil
 	}
 
 	shadowTree, treeErr := shadowCommit.Tree()
 	if treeErr != nil {
-		return "", false, nil //nolint:nilerr // best-effort: missing shadow tree is treated as not-found
+		logging.Debug(ctx, "explain: temp checkpoint matched but shadow tree unreadable; treating as not-found",
+			slog.String("commit", tc.CommitHash.String()),
+			slog.String("error", treeErr.Error()))
+		return "", false, nil
 	}
 
 	// Read agent type from shadow branch metadata (stored during checkpoint creation)

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -452,12 +452,36 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 	return runExplainBranchWithFilter(ctx, w, errW, noPager, sessionID)
 }
 
+// explainTargetNotFoundError reports that the positional target matched no
+// committed or temporary checkpoint. It unwraps to
+// checkpoint.ErrCheckpointNotFound so callers' errors.Is contracts keep
+// working, while runExplainAuto can distinguish this resolution miss from a
+// failure AFTER a successful match that happens to wrap the same sentinel
+// (e.g. "failed to save summary: checkpoint not found" from a backfill
+// against a backend missing the checkpoint) — those must surface verbatim,
+// not be masked by the commit fallback's "no checkpoint or commit found".
+type explainTargetNotFoundError struct{ target string }
+
+func (e *explainTargetNotFoundError) Error() string {
+	return fmt.Sprintf("%s: %s", checkpoint.ErrCheckpointNotFound, e.target)
+}
+
+func (e *explainTargetNotFoundError) Unwrap() error { return checkpoint.ErrCheckpointNotFound }
+
+// shouldFallBackToCommitResolution reports whether the checkpoint path's error
+// means "the target matched nothing", the only outcome that may fall through
+// to git commit resolution.
+func shouldFallBackToCommitResolution(err error) bool {
+	var targetMiss *explainTargetNotFoundError
+	return errors.As(err, &targetMiss)
+}
+
 // runExplainAuto resolves a positional target as either a checkpoint ID
 // (or prefix) or a git commit ref. Ordering: checkpoint path first (which
 // also handles shadow-branch temp checkpoints), falling back to commit
-// resolution only on checkpoint.ErrCheckpointNotFound. --generate runs
-// an ambiguity pre-check to avoid writing a summary to the wrong
-// checkpoint on short-prefix collisions.
+// resolution only on the target-miss error (explainTargetNotFoundError).
+// --generate runs an ambiguity pre-check to avoid writing a summary to the
+// wrong checkpoint on short-prefix collisions.
 func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool, summaryTimeoutSeconds int) error {
 	stop := startSpinner(errW, "Loading checkpoints")
 	lookup, lookupErr := newExplainCheckpointLookup(ctx)
@@ -475,11 +499,15 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 		return nil
 	}
 	// Fall back to commit resolution ONLY when nothing (committed or temp)
-	// matched the target. errCannotGenerateTemporaryCheckpoint signals that
-	// we DID match a temp checkpoint but --generate is unsupported for it;
-	// falling back to commit in that case would produce a misleading
+	// matched the target. Errors from steps AFTER a successful match — even
+	// ones wrapping checkpoint.ErrCheckpointNotFound, like a summary backfill
+	// failing against a backend missing the checkpoint — surface verbatim;
+	// falling back would misreport them as "no checkpoint or commit found"
+	// for a target that DID resolve. errCannotGenerateTemporaryCheckpoint
+	// likewise signals we matched a temp checkpoint but --generate is
+	// unsupported for it; a commit fallback there would produce a misleading
 	// "no trailer" error for the shadow-branch commit.
-	if !errors.Is(checkpointErr, checkpoint.ErrCheckpointNotFound) {
+	if !shouldFallBackToCommitResolution(checkpointErr) {
 		return checkpointErr
 	}
 	logging.Debug(ctx, "explain auto: checkpoint lookup failed, trying commit fallback",
@@ -608,7 +636,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		// Check temp checkpoints BEFORE returning errCannotGenerateTemporaryCheckpoint
 		// so runExplainAuto can distinguish:
 		//   - target matched a real temp checkpoint (sentinel returned, no fallback)
-		//   - target matched nothing (ErrCheckpointNotFound, safe to fall back to commit)
+		//   - target matched nothing (explainTargetNotFoundError, safe to fall back to commit)
 		// Previously the --generate path bailed before checking temp checkpoints,
 		// which made runExplainAuto fall back to commit resolution for temp
 		// checkpoint SHAs and produce a misleading "no trailer" error.
@@ -632,7 +660,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 			outputExplainContent(w, output, noPager)
 			return nil
 		}
-		return fmt.Errorf("%w: %s", checkpoint.ErrCheckpointNotFound, checkpointIDPrefix)
+		return &explainTargetNotFoundError{target: checkpointIDPrefix}
 	case 1:
 		fullCheckpointID = matches[0]
 	default:

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -506,32 +506,77 @@ func TestShouldFallBackToCommitResolution(t *testing.T) {
 }
 
 // TestRunExplainAuto_PostResolutionErrorSurfacesVerbatim guards the adjacent
-// contract end-to-end: when the target RESOLVES via the committed-checkpoint
-// prefix match but a later read step fails hard (here: the git-refs on-demand
-// ref fetch failing in a repo with no reachable remote), runExplainAuto must
-// surface that failure instead of running the commit fallback.
+// contract end-to-end, for both the read-only and --generate entry points:
+// when the target RESOLVES via the committed-checkpoint prefix match but a
+// later read step fails hard, runExplainAuto must surface that failure —
+// naming the resolved checkpoint — instead of running the commit fallback.
+// The fault injector is the pinned "a ULID is never read from the branch"
+// routing contract: the checkpoint is listed (List unions both backends) but
+// its read routes to refs only, where the on-demand ref fetch fails hard in a
+// repo with no reachable remote.
 func TestRunExplainAuto_PostResolutionErrorSurfacesVerbatim(t *testing.T) {
+	for _, generate := range []bool{false, true} {
+		t.Run(fmt.Sprintf("generate=%v", generate), func(t *testing.T) {
+			repo, _ := runExplainAutoTestRepo(t)
+			ctx := context.Background()
+
+			ulidID := id.MustCheckpointID("01KVBJCWYA4YW6J5M9GP655HZN")
+			require.NoError(t, checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs()).Write(ctx, checkpoint.Session{
+				CheckpointID: ulidID,
+				SessionID:    "session-stray-ulid",
+				Strategy:     "manual-commit",
+				Transcript:   redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hello"}]}}` + "\n")),
+				AuthorName:   "Test",
+				AuthorEmail:  "test@example.com",
+			}))
+
+			var out, errOut bytes.Buffer
+			err := runExplainAuto(ctx, &out, &errOut, ulidID.String(), true, false, false, false, generate, false, false, 0)
+
+			require.Error(t, err)
+			require.ErrorContains(t, err, "failed to read checkpoint",
+				"the post-resolution failure must surface as-is")
+			require.ErrorContains(t, err, ulidID.String(),
+				"the error must name the checkpoint the target resolved to")
+			require.NotContains(t, err.Error(), "no checkpoint or commit found",
+				"a post-resolution failure must not be masked by the commit fallback")
+			require.False(t, shouldFallBackToCommitResolution(err),
+				"a post-resolution failure must not classify as a target miss")
+		})
+	}
+}
+
+// TestRunExplainAuto_TrailerReferencedCheckpointMissing: when the positional
+// target is a commit whose Entire-Checkpoint trailer references a checkpoint
+// that no longer resolves, the error must name the commit and the trailer
+// linkage — the user typed a commit SHA and would otherwise see "checkpoint
+// not found: <id>" for an ID they never entered.
+func TestRunExplainAuto_TrailerReferencedCheckpointMissing(t *testing.T) {
 	repo, _ := runExplainAutoTestRepo(t)
 	ctx := context.Background()
 
-	ulidID := id.MustCheckpointID("01KVBJCWYA4YW6J5M9GP655HZN")
-	require.NoError(t, checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs()).Write(ctx, checkpoint.Session{
-		CheckpointID: ulidID,
-		SessionID:    "session-stray-ulid",
-		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hello"}]}}` + "\n")),
-		AuthorName:   "Test",
-		AuthorEmail:  "test@example.com",
-	}))
+	cpID := id.MustCheckpointID("deadbeefcafe")
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	tmpDir := wt.Filesystem().Root()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "feature.txt"), []byte("feature"), 0o644))
+	_, err = wt.Add("feature.txt")
+	require.NoError(t, err)
+	commitHash, err := wt.Commit(trailers.AppendCheckpointTrailer("Implement feature", cpID.String()), &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
 
 	var out, errOut bytes.Buffer
-	err := runExplainAuto(ctx, &out, &errOut, ulidID.String(), true, false, false, false, true, false, false, 0)
+	err = runExplainAuto(ctx, &out, &errOut, commitHash.String(), true, false, false, false, false, false, false, 0)
 
 	require.Error(t, err)
-	require.ErrorContains(t, err, "failed to read checkpoint",
-		"the post-resolution failure must surface as-is")
-	require.NotContains(t, err.Error(), "no checkpoint or commit found",
-		"a post-resolution failure must not be masked by the commit fallback")
+	require.ErrorIs(t, err, checkpoint.ErrCheckpointNotFound)
+	require.ErrorContains(t, err, cpID.String())
+	require.ErrorContains(t, err, commitHash.String()[:7],
+		"the error must name the commit the user actually typed")
+	require.ErrorContains(t, err, "Entire-Checkpoint trailer",
+		"the error must explain how the commit led to the checkpoint")
 }
 
 // TestRunExplainCheckpoint_NotFoundSentinels verifies the typed-error

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -476,6 +476,64 @@ func TestRunExplainAuto_CommitWithoutTrailer(t *testing.T) {
 	}
 }
 
+// TestShouldFallBackToCommitResolution pins runExplainAuto's fallback
+// decision: commit resolution may run ONLY when the positional target matched
+// no committed or temporary checkpoint. A failure from a step AFTER a
+// successful match that merely wraps checkpoint.ErrCheckpointNotFound (in the
+// field: "failed to save summary: checkpoint not found", from a summary
+// backfill against a backend missing the checkpoint) must NOT trigger the
+// fallback — it was masked as `no checkpoint or commit found matching ...`
+// for a checkpoint the same command had just resolved.
+func TestShouldFallBackToCommitResolution(t *testing.T) {
+	runExplainAutoTestRepo(t)
+
+	// A genuine target miss, produced by the real checkpoint path.
+	var out, errOut bytes.Buffer
+	missErr := runExplainCheckpoint(context.Background(), &out, &errOut, "abababababab", false, false, false, false, false, false, false, 0)
+	require.Error(t, missErr)
+	require.True(t, shouldFallBackToCommitResolution(missErr),
+		"a genuine target miss must fall back to commit resolution")
+	require.ErrorIs(t, missErr, checkpoint.ErrCheckpointNotFound,
+		"the target-miss error must keep wrapping the public sentinel")
+
+	// A post-resolution failure that wraps the same sentinel must not.
+	saveErr := fmt.Errorf("failed to save summary: %w", checkpoint.ErrCheckpointNotFound)
+	require.False(t, shouldFallBackToCommitResolution(saveErr),
+		"a post-resolution failure wrapping ErrCheckpointNotFound must surface verbatim, not be masked by the commit fallback")
+
+	require.False(t, shouldFallBackToCommitResolution(errors.New("network down")),
+		"unrelated errors never fall back")
+}
+
+// TestRunExplainAuto_PostResolutionErrorSurfacesVerbatim guards the adjacent
+// contract end-to-end: when the target RESOLVES via the committed-checkpoint
+// prefix match but a later read step fails hard (here: the git-refs on-demand
+// ref fetch failing in a repo with no reachable remote), runExplainAuto must
+// surface that failure instead of running the commit fallback.
+func TestRunExplainAuto_PostResolutionErrorSurfacesVerbatim(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+
+	ulidID := id.MustCheckpointID("01KVBJCWYA4YW6J5M9GP655HZN")
+	require.NoError(t, checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs()).Write(ctx, checkpoint.Session{
+		CheckpointID: ulidID,
+		SessionID:    "session-stray-ulid",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hello"}]}}` + "\n")),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+	}))
+
+	var out, errOut bytes.Buffer
+	err := runExplainAuto(ctx, &out, &errOut, ulidID.String(), true, false, false, false, true, false, false, 0)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to read checkpoint",
+		"the post-resolution failure must surface as-is")
+	require.NotContains(t, err.Error(), "no checkpoint or commit found",
+		"a post-resolution failure must not be masked by the commit fallback")
+}
+
 // TestRunExplainCheckpoint_NotFoundSentinels verifies the typed-error
 // contract runExplainAuto depends on: non-matching targets return an error
 // wrapping checkpoint.ErrCheckpointNotFound (for errors.Is detection),


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/906
<!-- entire-trail-link-end -->

## Problem

`entire checkpoint explain --generate <id>` could resolve and display a checkpoint, generate its AI summary, fail to save it — and then report `no checkpoint or commit found matching "<id>"`.

`runExplainAuto` decides whether to fall back to git commit resolution with `errors.Is(err, checkpoint.ErrCheckpointNotFound)`. But that sentinel also leaks out of steps that run **after** the target successfully resolved (in the field: `failed to save summary: checkpoint not found` from a summary backfill against a backend missing the checkpoint — see #1811 for that underlying bug). The fallback then ran, failed to parse the ID as a git rev, and replaced the real error with the misleading composite message.

## Fix

The genuine "target matched nothing" outcome now returns a dedicated `explainTargetNotFoundError` — which still unwraps to `checkpoint.ErrCheckpointNotFound`, so existing `errors.Is` contracts are unchanged — and the commit fallback triggers only on that type. Any post-resolution failure surfaces verbatim.

Before/after on the original repro (branch without #1811):
```
- no checkpoint or commit found matching "2cb795c79075"
+ failed to save summary: checkpoint not found
```

## Verification

- TDD: `TestShouldFallBackToCommitResolution` pins the decision (genuine miss → fallback; sentinel-wrapping save failure → surface verbatim); `TestRunExplainAuto_PostResolutionErrorSurfacesVerbatim` guards it end-to-end
- All existing explain tests pass unchanged (including `TestRunExplainCheckpoint_NotFoundSentinels`, which pins the public `errors.Is` contract)
- Full unit suite green (8117 tests), `mise run fmt` + `mise run lint` clean
- Field-verified against the real repro in this repo

Independent of #1811 (not stacked); the two compose — with both, the save succeeds outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI error-routing change in `explain`; behavior improves for `--generate` without touching auth, storage contracts, or checkpoint persistence.
> 
> **Overview**
> **`runExplainAuto` no longer treats every `checkpoint.ErrCheckpointNotFound` as “target not found.”** Commit resolution runs only when the checkpoint path returns a dedicated `explainTargetNotFoundError` (still unwraps to the public sentinel so existing `errors.Is` checks keep working).
> 
> When a positional target **did** resolve but a later step fails—e.g. `failed to save summary: checkpoint not found` during `--generate`—that error is returned as-is instead of falling through to git and ending up as `no checkpoint or commit found matching …`.
> 
> The “no committed or temp match” path in `runExplainCheckpointWithLookup` now returns `explainTargetNotFoundError` instead of a bare wrapped sentinel. Tests lock in `shouldFallBackToCommitResolution` and an end-to-end `runExplainAuto` case for post-resolution failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070f1f6386828f3a814c9178f74446b785873f25. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->