### PR TITLE
feat: add provider-aware summary error handling

### DIFF
--- a/cmd/entire/cli/agent/codex/generate.go
+++ b/cmd/entire/cli/agent/codex/generate.go
@@ -15,13 +15,9 @@ func (c *CodexAgent) GenerateText(ctx context.Context, prompt string, model stri
 	}
 	args = append(args, "-")
 
-	result, capturedStderr, stdoutBytes, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, "codex", "codex", args, prompt)
+	result, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, agent.AgentNameCodex, args, prompt)
 	if err != nil {
-		return "", &agent.TextGenerationError{
-			Err:         fmt.Errorf("codex text generation failed: %w", err),
-			Stderr:      capturedStderr,
-			StdoutBytes: stdoutBytes,
-		}
+		return "", fmt.Errorf("codex text generation failed: %w", err)
 	}
 	return result, nil
 }

--- a/cmd/entire/cli/agent/copilotcli/generate.go
+++ b/cmd/entire/cli/agent/copilotcli/generate.go
@@ -19,13 +19,9 @@ func (c *CopilotCLIAgent) GenerateText(ctx context.Context, prompt string, model
 		args = append(args, "--model", model)
 	}
 
-	result, capturedStderr, stdoutBytes, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, "copilot", "copilot", args, prompt)
+	result, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, agent.AgentNameCopilotCLI, args, prompt)
 	if err != nil {
-		return "", &agent.TextGenerationError{
-			Err:         fmt.Errorf("copilot text generation failed: %w", err),
-			Stderr:      capturedStderr,
-			StdoutBytes: stdoutBytes,
-		}
+		return "", fmt.Errorf("copilot text generation failed: %w", err)
 	}
 	return result, nil
 }

--- a/cmd/entire/cli/agent/cursor/generate.go
+++ b/cmd/entire/cli/agent/cursor/generate.go
@@ -19,13 +19,9 @@ func (c *CursorAgent) GenerateText(ctx context.Context, prompt string, model str
 		args = append(args, "--model", model)
 	}
 
-	result, capturedStderr, stdoutBytes, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, "agent", "cursor", args, prompt)
+	result, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, agent.AgentNameCursor, args, prompt)
 	if err != nil {
-		return "", &agent.TextGenerationError{
-			Err:         fmt.Errorf("cursor text generation failed: %w", err),
-			Stderr:      capturedStderr,
-			StdoutBytes: stdoutBytes,
-		}
+		return "", fmt.Errorf("cursor text generation failed: %w", err)
 	}
 	return result, nil
 }

--- a/cmd/entire/cli/agent/geminicli/generate.go
+++ b/cmd/entire/cli/agent/geminicli/generate.go
@@ -19,13 +19,9 @@ func (g *GeminiCLIAgent) GenerateText(ctx context.Context, prompt string, model 
 		args = append(args, "--model", model)
 	}
 
-	result, capturedStderr, stdoutBytes, err := agent.RunIsolatedTextGeneratorCLI(ctx, g.CommandRunner, "gemini", "gemini", args, prompt)
+	result, err := agent.RunIsolatedTextGeneratorCLI(ctx, g.CommandRunner, agent.AgentNameGemini, args, prompt)
 	if err != nil {
-		return "", &agent.TextGenerationError{
-			Err:         fmt.Errorf("gemini text generation failed: %w", err),
-			Stderr:      capturedStderr,
-			StdoutBytes: stdoutBytes,
-		}
+		return "", fmt.Errorf("gemini text generation failed: %w", err)
 	}
 	return result, nil
 }

--- a/cmd/entire/cli/agent/hook_command_test.go
+++ b/cmd/entire/cli/agent/hook_command_test.go
@@ -20,9 +20,9 @@ func TestUseWindowsProductionHooks(t *testing.T) {
 		want     bool
 	}{
 		{"non-windows never uses windows wrappers", "linux", false, shBroken, false},
-		{"localDev never uses windows wrappers", windowsOS, true, shBroken, false},
-		{"windows with working sh keeps sh wrappers", windowsOS, false, shWorks, false},
-		{"windows without working sh uses windows wrappers", windowsOS, false, shBroken, true},
+		{"localDev never uses windows wrappers", hookWrapperOSWindows, true, shBroken, false},
+		{"windows with working sh keeps sh wrappers", hookWrapperOSWindows, false, shWorks, false},
+		{"windows without working sh uses windows wrappers", hookWrapperOSWindows, false, shBroken, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/entire/cli/agent/hook_command_windows_exec_test.go
+++ b/cmd/entire/cli/agent/hook_command_windows_exec_test.go
@@ -60,7 +60,7 @@ func runWindowsWrapper(t *testing.T, wrapper string, entirePresent bool) (string
 // (and propagates its exit code) when entire is present, and is skipped with a
 // 0 exit when entire is absent, for both the silent and JSON-warning forms.
 func TestWindowsWrappers_Execution(t *testing.T) {
-	if runtime.GOOS != windowsOS {
+	if runtime.GOOS != hookWrapperOSWindows {
 		t.Skip("cmd.exe wrapper execution test runs only on Windows")
 	}
 	// No t.Parallel(): t.Setenv("PATH") forbids it.

--- a/cmd/entire/cli/agent/pi/generate.go
+++ b/cmd/entire/cli/agent/pi/generate.go
@@ -17,7 +17,7 @@ func (a *PiAgent) GenerateText(ctx context.Context, prompt string, model string)
 	}
 	args = append(args, prompt)
 
-	result, _, _, err := agent.RunIsolatedTextGeneratorCLI(ctx, nil, "pi", "pi", args, "")
+	result, err := agent.RunIsolatedTextGeneratorCLI(ctx, a.CommandRunner, agent.AgentNamePi, args, "")
 	if err != nil {
 		return "", fmt.Errorf("pi text generation failed: %w", err)
 	}

--- a/cmd/entire/cli/agent/pi/generate_test.go
+++ b/cmd/entire/cli/agent/pi/generate_test.go
@@ -1,0 +1,120 @@
+package pi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+const piGenerateHelperTest = "TestPiGenerateTextHelperProcess"
+const piGenerateHelperMarker = "__entire_pi_generate_helper__"
+
+// TestPiGenerateTextHelperProcess is a subprocess entrypoint. It cannot call
+// t.Parallel because its helper modes call os.Exit.
+func TestPiGenerateTextHelperProcess(_ *testing.T) {
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 {
+		return
+	}
+
+	args := os.Args[separator+1:]
+	if len(args) == 0 || args[0] != piGenerateHelperMarker {
+		return
+	}
+	args = args[1:]
+	if len(args) == 0 {
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "auth":
+		_, _ = fmt.Fprint(os.Stderr, "HTTP 401 Unauthorized")
+		os.Exit(17)
+	case "empty":
+		_, _ = fmt.Fprint(os.Stderr, "diagnostic detail")
+		os.Exit(0)
+	default:
+		os.Exit(2)
+	}
+}
+
+func piHelperRunner(mode string) agent.TextCommandRunner {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, os.Args[0], "-test.run=^"+piGenerateHelperTest+"$", "--", piGenerateHelperMarker, mode)
+	}
+}
+
+func TestPiAgentGenerateText_ClassifiesFallbackFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		runner agent.TextCommandRunner
+		kind   agent.TextGenerationErrorKind
+	}{
+		{
+			name: "missing CLI",
+			runner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "definitely-not-installed-pi-binary")
+			},
+			kind: agent.TextGenerationErrorCLIMissing,
+		},
+		{name: "auth stderr", runner: piHelperRunner("auth"), kind: agent.TextGenerationErrorAuth},
+		{name: "empty stdout with stderr", runner: piHelperRunner("empty"), kind: agent.TextGenerationErrorUnknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			piAgent := &PiAgent{CommandRunner: test.runner}
+			_, err := piAgent.GenerateText(context.Background(), "prompt", "")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			var failure *agent.TextGenerationError
+			if !errors.As(err, &failure) {
+				t.Fatalf("err = %T %v, want *TextGenerationError", err, err)
+			}
+			if failure.Kind != test.kind {
+				t.Errorf("Kind = %v, want %v", failure.Kind, test.kind)
+			}
+			if failure.Provider != agent.AgentNamePi {
+				t.Errorf("Provider = %q, want %q", failure.Provider, agent.AgentNamePi)
+			}
+			if test.name == "empty stdout with stderr" {
+				if failure.Stderr != "diagnostic detail" {
+					t.Errorf("Stderr = %q, want retained diagnostic", failure.Stderr)
+				}
+				if !strings.Contains(failure.Message, "diagnostic detail") {
+					t.Errorf("Message = %q, want retained diagnostic", failure.Message)
+				}
+			}
+			if count := countPiTextGenerationErrors(err); count != 1 {
+				t.Errorf("TextGenerationError count = %d, want 1 (chain: %v)", count, err)
+			}
+		})
+	}
+}
+
+func countPiTextGenerationErrors(err error) int {
+	count := 0
+	for err != nil {
+		textGenerationError := &agent.TextGenerationError{}
+		if errors.As(err, &textGenerationError) {
+			count++
+		}
+		err = errors.Unwrap(err)
+	}
+	return count
+}

--- a/cmd/entire/cli/agent/pi/generate_test.go
+++ b/cmd/entire/cli/agent/pi/generate_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -109,9 +110,9 @@ func TestPiAgentGenerateText_ClassifiesFallbackFailures(t *testing.T) {
 
 func countPiTextGenerationErrors(err error) int {
 	count := 0
+	targetType := reflect.TypeFor[*agent.TextGenerationError]()
 	for err != nil {
-		textGenerationError := &agent.TextGenerationError{}
-		if errors.As(err, &textGenerationError) {
+		if reflect.TypeOf(err) == targetType {
 			count++
 		}
 		err = errors.Unwrap(err)

--- a/cmd/entire/cli/agent/pi/models.go
+++ b/cmd/entire/cli/agent/pi/models.go
@@ -16,7 +16,7 @@ var _ agent.ModelLister = (*PiAgent)(nil)
 // Pi has a real enumeration command spanning every configured provider, so the
 // result reflects what this machine/account can actually use.
 func (a *PiAgent) ListModels(ctx context.Context) ([]agent.ModelInfo, error) {
-	out, _, _, err := agent.RunIsolatedTextGeneratorCLI(ctx, nil, "pi", "pi", []string{"--list-models"}, "")
+	out, err := agent.RunIsolatedTextGeneratorCLI(ctx, nil, agent.AgentNamePi, []string{"--list-models"}, "")
 	if err != nil {
 		return nil, fmt.Errorf("pi --list-models: %w", err)
 	}

--- a/cmd/entire/cli/agent/pi/pi.go
+++ b/cmd/entire/cli/agent/pi/pi.go
@@ -43,7 +43,9 @@ func init() {
 // PiAgent implements agent.Agent for the pi coding agent.
 //
 //nolint:revive // PiAgent is clearer than Agent in this context
-type PiAgent struct{}
+type PiAgent struct {
+	CommandRunner agent.TextCommandRunner
+}
 
 // NewPiAgent returns a new Pi agent instance.
 func NewPiAgent() agent.Agent {

--- a/cmd/entire/cli/agent/streaming_template.go
+++ b/cmd/entire/cli/agent/streaming_template.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
 
@@ -66,9 +67,10 @@ func (e *providerStreamError) Error() string { return e.err.Error() }
 func (e *providerStreamError) Unwrap() error { return e.err }
 
 // MarkProviderStreamError marks an error decoded from an explicit provider
-// stream event. It lets the subprocess template preserve that error when the
-// context completes concurrently, without mistaking EOF/parser failures
-// caused by killing the subprocess for provider failures.
+// stream event. It lets the subprocess template distinguish decoded provider
+// failures from EOF/parser failures caused by killing the subprocess. A
+// semantically specific provider failure can then outrank a concurrent context
+// error while an unclassified provider failure preserves both causes.
 func MarkProviderStreamError(err error) error {
 	if err == nil {
 		return nil
@@ -86,8 +88,8 @@ func isProviderStreamError(err error) bool {
 // Error shapes by failure point:
 //   - Pre-subprocess (StdoutPipe failure): plain wrapped error, since no
 //     stderr/stdout exists yet to diagnose with.
-//   - cmd.Start failure: wrapped error, or *TextGenerationError when ctx is
-//     already cancelled at that point.
+//   - cmd.Start failure: *TextGenerationError with provider metadata, including
+//     CLIMissing classification when the executable cannot be found.
 //   - Anything after Start (parse error, non-zero exit, ctx cancellation):
 //     *TextGenerationError carrying captured stderr and the stdout byte
 //     count from countingReader, matching RunIsolatedTextGeneratorCLI's
@@ -115,14 +117,20 @@ func (t *StreamingGeneratorTemplate) Generate(
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {
-		if ctx.Err() != nil {
-			return "", &TextGenerationError{
-				Err:         ctx.Err(),
-				Stderr:      strings.TrimSpace(stderr.String()),
-				StdoutBytes: 0,
-			}
+		provider := types.AgentName(t.AgentName)
+		capturedStderr := strings.TrimSpace(stderr.String())
+		kind := TextGenerationErrorUnknown
+		message := fmt.Sprintf("%s stream start: %v", t.AgentName, err)
+		var execErr *exec.Error
+		if errors.As(err, &execErr) {
+			kind = TextGenerationErrorCLIMissing
+			message = fmt.Sprintf("%s not found: %v", streamingProviderLabel(provider, t.AgentName), err)
 		}
-		return "", fmt.Errorf("%s stream start: %w", t.AgentName, err)
+		cause := err
+		if kind == TextGenerationErrorUnknown && ctx.Err() != nil {
+			cause = errors.Join(err, ctx.Err())
+		}
+		return "", newTextGenerationError(provider, kind, message, cause, capturedStderr, 0, -1)
 	}
 
 	counter := &countingReader{r: stdout}
@@ -150,32 +158,7 @@ func (t *StreamingGeneratorTemplate) Generate(
 	}
 	waitErr := cmd.Wait()
 	stderrStr := strings.TrimSpace(stderr.String())
-
-	// An explicit provider error decoded from stdout is authoritative even if
-	// the context completes concurrently. Unmarked parser failures can be a
-	// consequence of killing the subprocess, so context still wins for those.
-	if isProviderStreamError(parseErr) {
-		return "", &TextGenerationError{
-			Err:         fmt.Errorf("%s stream failed: %w", t.AgentName, parseErr),
-			Stderr:      stderrStr,
-			StdoutBytes: counter.n,
-		}
-	}
-
-	if ctx.Err() != nil {
-		return "", &TextGenerationError{
-			Err:         ctx.Err(),
-			Stderr:      stderrStr,
-			StdoutBytes: counter.n,
-		}
-	}
-
-	if parseErr == nil && waitErr == nil {
-		if doneProgress != nil {
-			progress(*doneProgress)
-		}
-		return result, nil
-	}
+	provider := types.AgentName(t.AgentName)
 
 	if waitErr != nil && t.LooksLikeUnrecognizedFlag != nil && t.LooksLikeUnrecognizedFlag(stderrStr) {
 		attrs := streamingFallbackLogAttrs(t.AgentName, stderrStr)
@@ -184,15 +167,88 @@ func (t *StreamingGeneratorTemplate) Generate(
 		return "", ErrUnrecognizedStreamingFlag
 	}
 
-	wrappedErr := waitErr
-	if wrappedErr == nil {
-		wrappedErr = parseErr
+	if parseErr == nil && waitErr == nil {
+		if doneProgress != nil {
+			progress(*doneProgress)
+		}
+		return result, nil
 	}
-	return "", &TextGenerationError{
-		Err:         fmt.Errorf("%s stream failed: %w", t.AgentName, wrappedErr),
-		Stderr:      stderrStr,
-		StdoutBytes: counter.n,
+	cause := streamingFailureCause(parseErr, waitErr)
+
+	// A semantically specific provider error decoded from stdout is authoritative
+	// even if the context completes concurrently. Unknown provider/parser errors
+	// can be consequences of a killed subprocess, so context remains discoverable.
+	if isProviderStreamError(parseErr) {
+		kind := classifyStreamingFailure(provider, stderrStr, parseErr)
+		if kind != TextGenerationErrorUnknown || ctx.Err() == nil {
+			message := parseErr.Error()
+			return "", newTextGenerationError(
+				provider, kind, message, fmt.Errorf("%s stream failed: %w", t.AgentName, cause),
+				stderrStr, counter.n, streamingExitCode(waitErr),
+			)
+		}
 	}
+
+	kind := classifyStreamingFailure(provider, stderrStr, cause)
+	if kind == TextGenerationErrorUnknown && ctx.Err() != nil {
+		cause = errors.Join(cause, ctx.Err())
+	}
+	message := streamingFailureMessage(provider, t.AgentName, stderrStr, cause)
+	return "", newTextGenerationError(
+		provider, kind, message, fmt.Errorf("%s stream failed: %w", t.AgentName, cause),
+		stderrStr, counter.n, streamingExitCode(waitErr),
+	)
+}
+
+func streamingFailureMessage(
+	provider types.AgentName,
+	fallback string,
+	stderr string,
+	cause error,
+) string {
+	if stderr != "" {
+		return stderr
+	}
+	return fmt.Sprintf("%s stream failed: %v", streamingProviderLabel(provider, fallback), cause)
+}
+
+func streamingFailureCause(parseErr, waitErr error) error {
+	if parseErr == nil {
+		return waitErr
+	}
+	if waitErr == nil {
+		return parseErr
+	}
+	return errors.Join(parseErr, waitErr)
+}
+
+func classifyStreamingFailure(provider types.AgentName, stderr string, cause error) TextGenerationErrorKind {
+	detail := stderr
+	if cause != nil {
+		if detail != "" {
+			detail += "\n"
+		}
+		detail += cause.Error()
+	}
+	return classifyTextGenerationFailure(provider, detail)
+}
+
+func streamingExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+func streamingProviderLabel(provider types.AgentName, fallback string) string {
+	if label := SummaryProviderErrorLabel(provider); label != "" {
+		return label
+	}
+	return fallback
 }
 
 func streamingFallbackLogAttrs(agentName, stderr string) []slog.Attr {

--- a/cmd/entire/cli/agent/streaming_template_test.go
+++ b/cmd/entire/cli/agent/streaming_template_test.go
@@ -3,25 +3,82 @@ package agent_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
-	"github.com/entireio/cli/cmd/entire/cli/agent/testutil"
 )
+
+const streamingTemplateHelperMarker = "__entire_streaming_template_helper__"
+
+// TestStreamingGeneratorTemplateHelperProcess is the subprocess entrypoint
+// used by this file. It must not call t.Parallel because it calls os.Exit.
+func TestStreamingGeneratorTemplateHelperProcess(_ *testing.T) {
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 {
+		return
+	}
+
+	args := os.Args[separator+1:]
+	if len(args) < 2 || args[0] != streamingTemplateHelperMarker {
+		return
+	}
+
+	switch args[1] {
+	case "output":
+		_, _ = fmt.Fprint(os.Stdout, streamingTemplateHelperArg(args, 2))
+		_, _ = fmt.Fprint(os.Stderr, streamingTemplateHelperArg(args, 3))
+		exitCode, err := strconv.Atoi(streamingTemplateHelperArg(args, 4))
+		if err != nil {
+			os.Exit(2)
+		}
+		os.Exit(exitCode)
+	case "blocking":
+		time.Sleep(time.Hour)
+	default:
+		os.Exit(2)
+	}
+}
+
+func streamingTemplateHelperArg(args []string, index int) string {
+	if index >= len(args) {
+		return ""
+	}
+	return args[index]
+}
+
+func streamingTemplateCmd(ctx context.Context, stdout, stderr string, exitCode int) *exec.Cmd {
+	return exec.CommandContext(ctx, os.Args[0],
+		"-test.run=^TestStreamingGeneratorTemplateHelperProcess$", "--",
+		streamingTemplateHelperMarker, "output", stdout, stderr, strconv.Itoa(exitCode))
+}
+
+func detachedStreamingTemplateCmd(stdout, stderr string, exitCode int) *exec.Cmd {
+	return streamingTemplateCmd(context.Background(), stdout, stderr, exitCode)
+}
 
 func TestStreamingGeneratorTemplate_Generate_Success(t *testing.T) {
 	t.Parallel()
 
 	parsed := false
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.FakeStreamCmd("hello\nworld\n", "", 0)(ctx, "fake", []string{}...)
+			return streamingTemplateCmd(ctx, "hello\nworld\n", "", 0)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			b, err := io.ReadAll(stdout)
@@ -59,9 +116,9 @@ func TestStreamingGeneratorTemplate_Generate_UnrecognizedFlagFallback(t *testing
 	t.Parallel()
 
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.FakeStreamCmd("", "error: unknown flag: --stream-json", 1)(ctx, "fake", []string{}...)
+			return streamingTemplateCmd(ctx, "", "error: unknown flag: --stream-json", 1)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // best-effort drain in test fake; failure here is irrelevant
@@ -82,9 +139,9 @@ func TestStreamingGeneratorTemplate_Generate_NonZeroExitWrapsError(t *testing.T)
 	t.Parallel()
 
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.FakeStreamCmd("partial\n", "boom\n", 1)(ctx, "fake", []string{}...)
+			return streamingTemplateCmd(ctx, "partial\n", "boom\n", 1)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // best-effort drain in test fake; failure here is irrelevant
@@ -122,7 +179,7 @@ func TestStreamingGeneratorTemplate_Generate_DoneRequiresSuccessfulProcessExit(t
 			tmpl := &agent.StreamingGeneratorTemplate{
 				AgentName: string(agent.AgentNameCodex),
 				BuildCmd: func(context.Context, string, string) *exec.Cmd {
-					return testutil.FakeStreamCmd("complete", "", test.exitCode)(context.Background(), "fake")
+					return detachedStreamingTemplateCmd("complete", "", test.exitCode)
 				},
 				Parser: func(stdout io.Reader, progress agent.ProgressFn) (string, error) {
 					result, err := io.ReadAll(stdout)
@@ -154,9 +211,9 @@ func TestStreamingGeneratorTemplate_Generate_ContextCancelled(t *testing.T) {
 	cancel()
 
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.FakeStreamCmd("ok\n", "", 0)(ctx, "fake", []string{}...)
+			return streamingTemplateCmd(ctx, "ok\n", "", 0)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // best-effort drain in test fake; failure here is irrelevant
@@ -174,16 +231,42 @@ func TestStreamingGeneratorTemplate_Generate_ContextCancelled(t *testing.T) {
 	}
 }
 
-func TestStreamingGeneratorTemplate_Generate_ProviderErrorOutranksConcurrentCancellation(t *testing.T) {
+func TestStreamingGeneratorTemplate_Generate_SuccessOutranksLateCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: string(agent.AgentNameCodex),
+		BuildCmd: func(context.Context, string, string) *exec.Cmd {
+			return detachedStreamingTemplateCmd("complete", "", 0)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			result, err := io.ReadAll(stdout)
+			cancel()
+			return string(result), err
+		},
+	}
+
+	result, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	if err != nil {
+		t.Fatalf("Generate() error = %v, want success", err)
+	}
+	if result != "complete" {
+		t.Errorf("result = %q, want complete", result)
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_UnknownProviderErrorPreservesConcurrentCancellation(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	providerErr := errors.New("provider rejected the request")
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.FakeStreamCmd("provider error event\n", "", 0)(ctx, "fake", []string{}...)
+			return streamingTemplateCmd(ctx, "provider error event\n", "", 0)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // parser result is the behavior under test
@@ -193,11 +276,15 @@ func TestStreamingGeneratorTemplate_Generate_ProviderErrorOutranksConcurrentCanc
 	}
 
 	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	failure := requireStreamingTextGenerationError(t, err)
+	if failure.Kind != agent.TextGenerationErrorUnknown {
+		t.Errorf("Kind = %v, want Unknown", failure.Kind)
+	}
 	if !errors.Is(err, providerErr) {
 		t.Fatalf("err = %v, want provider error", err)
 	}
-	if errors.Is(err, context.Canceled) {
-		t.Fatalf("err = %v, provider error must outrank concurrent cancellation", err)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want concurrent cancellation preserved", err)
 	}
 }
 
@@ -207,9 +294,11 @@ func TestStreamingGeneratorTemplate_Generate_KillInducedParserFailureUsesContext
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.BlockingCmd(ctx)
+			return exec.CommandContext(ctx, os.Args[0],
+				"-test.run=^TestStreamingGeneratorTemplateHelperProcess$", "--",
+				streamingTemplateHelperMarker, "blocking")
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // cancellation closes the subprocess pipe
@@ -220,5 +309,188 @@ func TestStreamingGeneratorTemplate_Generate_KillInducedParserFailureUsesContext
 	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err = %v, want context deadline sentinel", err)
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_MissingCLIIsClassified(t *testing.T) {
+	t.Parallel()
+
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: string(agent.AgentNameCodex),
+		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
+			return exec.CommandContext(ctx, "definitely-not-installed-streaming-summary-cli")
+		},
+		Parser: drainStreamingTemplateOutput,
+	}
+
+	_, err := tmpl.Generate(context.Background(), "prompt", "model", nil)
+	failure := requireStreamingTextGenerationError(t, err)
+	if failure.Kind != agent.TextGenerationErrorCLIMissing {
+		t.Errorf("Kind = %v, want CLIMissing", failure.Kind)
+	}
+	if failure.Provider != agent.AgentNameCodex {
+		t.Errorf("Provider = %q, want %q", failure.Provider, agent.AgentNameCodex)
+	}
+	assertOneStreamingTextGenerationError(t, err)
+}
+
+func TestStreamingGeneratorTemplate_Generate_ClassifiesExitStderr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		stderr string
+		kind   agent.TextGenerationErrorKind
+	}{
+		{name: "auth", stderr: "unexpected status 401", kind: agent.TextGenerationErrorAuth},
+		{name: "bare worker number", stderr: "worker 404 failed to start", kind: agent.TextGenerationErrorUnknown},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpl := &agent.StreamingGeneratorTemplate{
+				AgentName: string(agent.AgentNameCodex),
+				BuildCmd: func(context.Context, string, string) *exec.Cmd {
+					return detachedStreamingTemplateCmd("partial", test.stderr, 23)
+				},
+				Parser: drainStreamingTemplateOutput,
+			}
+
+			_, err := tmpl.Generate(context.Background(), "prompt", "model", nil)
+			failure := requireStreamingTextGenerationError(t, err)
+			if failure.Kind != test.kind {
+				t.Errorf("Kind = %v, want %v", failure.Kind, test.kind)
+			}
+			if failure.Stderr != test.stderr {
+				t.Errorf("Stderr = %q, want %q", failure.Stderr, test.stderr)
+			}
+			if failure.Message != test.stderr {
+				t.Errorf("Message = %q, want provider detail %q", failure.Message, test.stderr)
+			}
+			if failure.ExitCode != 23 {
+				t.Errorf("ExitCode = %d, want 23", failure.ExitCode)
+			}
+			assertOneStreamingTextGenerationError(t, err)
+		})
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_UnknownFailurePreservesDeadlineAndCause(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	t.Cleanup(cancel)
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: string(agent.AgentNameCodex),
+		BuildCmd: func(context.Context, string, string) *exec.Cmd {
+			return detachedStreamingTemplateCmd("", "provider exploded", 23)
+		},
+		Parser: drainStreamingTemplateOutput,
+	}
+
+	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	failure := requireStreamingTextGenerationError(t, err)
+	if failure.Kind != agent.TextGenerationErrorUnknown {
+		t.Errorf("Kind = %v, want Unknown", failure.Kind)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want context.DeadlineExceeded in chain", err)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("err = %v, want subprocess cause preserved", err)
+	}
+	assertOneStreamingTextGenerationError(t, err)
+}
+
+func TestStreamingGeneratorTemplate_Generate_PreservesParserAndProcessFailures(t *testing.T) {
+	t.Parallel()
+
+	parserErr := errors.New("parser rejected terminal event")
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: string(agent.AgentNameCodex),
+		BuildCmd: func(context.Context, string, string) *exec.Cmd {
+			return detachedStreamingTemplateCmd("partial", "transport closed", 23)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // parser error is the behavior under test
+			return "", parserErr
+		},
+	}
+
+	_, err := tmpl.Generate(context.Background(), "prompt", "model", nil)
+	if !errors.Is(err, parserErr) {
+		t.Errorf("err = %v, want parser cause", err)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("err = %v, want process cause", err)
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_SpecificProviderErrorOutranksDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	t.Cleanup(cancel)
+	providerErr := errors.New("unexpected status 401")
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: string(agent.AgentNameCodex),
+		BuildCmd: func(context.Context, string, string) *exec.Cmd {
+			return detachedStreamingTemplateCmd("provider error event", "transport closed", 23)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // parser result is the behavior under test
+			return "", agent.MarkProviderStreamError(providerErr)
+		},
+	}
+
+	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	failure := requireStreamingTextGenerationError(t, err)
+	if failure.Kind != agent.TextGenerationErrorAuth {
+		t.Errorf("Kind = %v, want Auth", failure.Kind)
+	}
+	if failure.Message != providerErr.Error() {
+		t.Errorf("Message = %q, want decoded provider detail %q", failure.Message, providerErr)
+	}
+	if !errors.Is(err, providerErr) {
+		t.Errorf("err = %v, want provider error in chain", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("specific provider error should outrank deadline: %v", err)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("err = %v, want process cause preserved", err)
+	}
+	assertOneStreamingTextGenerationError(t, err)
+}
+
+func drainStreamingTemplateOutput(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+	_, err := io.Copy(io.Discard, stdout)
+	return "", err
+}
+
+func requireStreamingTextGenerationError(t *testing.T, err error) *agent.TextGenerationError {
+	t.Helper()
+	var failure *agent.TextGenerationError
+	if !errors.As(err, &failure) {
+		t.Fatalf("err = %v, want *TextGenerationError", err)
+	}
+	return failure
+}
+
+func assertOneStreamingTextGenerationError(t *testing.T, err error) {
+	t.Helper()
+	count := 0
+	targetType := reflect.TypeFor[*agent.TextGenerationError]()
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		if reflect.TypeOf(current) == targetType {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("TextGenerationError count = %d, want 1 (chain: %v)", count, err)
 	}
 }

--- a/cmd/entire/cli/agent/text_generator_cli.go
+++ b/cmd/entire/cli/agent/text_generator_cli.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
@@ -21,10 +22,42 @@ type TextGenerationError struct {
 	Err         error
 	Stderr      string
 	StdoutBytes int
+	Provider    types.AgentName
+	Kind        TextGenerationErrorKind
+	Message     string
+	ExitCode    int
 }
 
-func (e *TextGenerationError) Error() string { return e.Err.Error() }
-func (e *TextGenerationError) Unwrap() error { return e.Err }
+func (e *TextGenerationError) Error() string {
+	if e == nil {
+		return "text generation failed"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "text generation failed"
+}
+
+func (e *TextGenerationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// TextGenerationErrorKind identifies actionable summary-provider failures.
+type TextGenerationErrorKind int
+
+const (
+	TextGenerationErrorUnknown TextGenerationErrorKind = iota
+	TextGenerationErrorAuth
+	TextGenerationErrorRateLimit
+	TextGenerationErrorConfig
+	TextGenerationErrorCLIMissing
+)
 
 // TextCommandRunner matches exec.CommandContext and allows tests to inject a runner.
 type TextCommandRunner func(ctx context.Context, name string, args ...string) *exec.Cmd
@@ -32,14 +65,18 @@ type TextCommandRunner func(ctx context.Context, name string, args ...string) *e
 // RunIsolatedTextGeneratorCLI executes a text-generation CLI in an isolated temp
 // directory with all GIT_* environment variables removed. This avoids recursive
 // hook triggers and repo side effects while preserving provider-specific flags.
-//
-// Returns (result, capturedStderr, stdoutByteCount, err). capturedStderr and
-// stdoutByteCount are populated even on error so callers can wrap them into a
-// *agent.TextGenerationError for timeout diagnostics.
-func RunIsolatedTextGeneratorCLI(ctx context.Context, runner TextCommandRunner, binary, displayName string, args []string, stdin string) (string, string, int, error) { //nolint:unparam // capturedStderr (result 1) is used by sub-package callers (codex, geminicli, etc.) even though intra-package tests blank it
+func RunIsolatedTextGeneratorCLI(
+	ctx context.Context,
+	runner TextCommandRunner,
+	provider types.AgentName,
+	args []string,
+	stdin string,
+) (string, error) {
 	if runner == nil {
 		runner = exec.CommandContext
 	}
+	binary := SummaryCLIBinaryName(provider)
+	displayName := SummaryProviderErrorLabel(provider)
 
 	cmd := runner(ctx, binary, args...)
 	cmd.Dir = os.TempDir()
@@ -55,38 +92,97 @@ func RunIsolatedTextGeneratorCLI(ctx context.Context, runner TextCommandRunner, 
 	if err := cmd.Run(); err != nil {
 		capturedStderr := strings.TrimSpace(stderr.String())
 		stdoutBytes := stdout.Len()
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return "", capturedStderr, stdoutBytes, context.DeadlineExceeded
-		}
-		if errors.Is(ctx.Err(), context.Canceled) {
-			return "", capturedStderr, stdoutBytes, context.Canceled
-		}
 		var execErr *exec.Error
 		if errors.As(err, &execErr) {
-			return "", capturedStderr, stdoutBytes, fmt.Errorf("%s CLI not found: %w", displayName, err)
+			message := fmt.Sprintf("%s not found: %v", displayName, err)
+			return "", newTextGenerationError(provider, TextGenerationErrorCLIMissing, message, err, capturedStderr, stdoutBytes, -1)
 		}
+
+		detail := capturedStderr
+		if detail == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
+		kind := classifyTextGenerationFailure(provider, detail)
+		underlying := err
+		if kind == TextGenerationErrorUnknown && ctx.Err() != nil {
+			underlying = errors.Join(err, ctx.Err())
+		}
+
+		exitCode := -1
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			detail := capturedStderr
-			if detail == "" {
-				detail = strings.TrimSpace(stdout.String())
-			}
+			exitCode = exitErr.ExitCode()
 			if detail == "" {
 				detail = err.Error()
 			}
-			return "", capturedStderr, stdoutBytes, fmt.Errorf("%s CLI failed (exit %d): %s: %w", displayName, exitErr.ExitCode(), detail, err)
+			message := fmt.Sprintf("%s failed (exit %d): %s", displayName, exitCode, detail)
+			return "", newTextGenerationError(provider, kind, message, underlying, capturedStderr, stdoutBytes, exitCode)
 		}
-		return "", capturedStderr, stdoutBytes, fmt.Errorf("failed to run %s CLI: %w", displayName, err)
+
+		message := fmt.Sprintf("failed to run %s: %v", displayName, err)
+		return "", newTextGenerationError(provider, kind, message, underlying, capturedStderr, stdoutBytes, exitCode)
 	}
 
 	result := strings.TrimSpace(stdout.String())
 	if result == "" {
-		return "", "", 0, fmt.Errorf("%s CLI returned empty output", displayName)
+		capturedStderr := strings.TrimSpace(stderr.String())
+		kind := classifyTextGenerationFailure(provider, capturedStderr)
+		message := displayName + " returned empty output"
+		if capturedStderr != "" {
+			message += ": " + capturedStderr
+		}
+		underlying := errors.New(message)
+		if kind == TextGenerationErrorUnknown && ctx.Err() != nil {
+			underlying = errors.Join(underlying, ctx.Err())
+		}
+		return "", newTextGenerationError(provider, kind, message, underlying, capturedStderr, stdout.Len(), 0)
 	}
-	return result, "", stdout.Len(), nil
+	return result, nil
 }
 
-// summaryProviderBinaries maps agent names to the CLI binary that
+func newTextGenerationError(
+	provider types.AgentName,
+	kind TextGenerationErrorKind,
+	message string,
+	err error,
+	stderr string,
+	stdoutBytes int,
+	exitCode int,
+) *TextGenerationError {
+	if err == nil {
+		err = errors.New(message)
+	}
+	return &TextGenerationError{
+		Err: err, Stderr: stderr, StdoutBytes: stdoutBytes,
+		Provider: provider, Kind: kind, Message: message, ExitCode: exitCode,
+	}
+}
+
+var contextualHTTPStatus = regexp.MustCompile(
+	`(?i)\b(?:http(?:\s+status(?:\s+code)?|\s+response\s+status)?|(?:api|provider)\s+response\s+status|unexpected\s+status|status\s+code)\s*:?\s*(400|401|403|404|429)\b`,
+)
+
+func classifyTextGenerationFailure(provider types.AgentName, message string) TextGenerationErrorKind {
+	if provider == AgentNameGemini && strings.Contains(strings.ToLower(message), "please set an auth method") {
+		return TextGenerationErrorAuth
+	}
+	match := contextualHTTPStatus.FindStringSubmatch(message)
+	if len(match) != 2 {
+		return TextGenerationErrorUnknown
+	}
+	switch match[1] {
+	case "401", "403":
+		return TextGenerationErrorAuth
+	case "429":
+		return TextGenerationErrorRateLimit
+	case "400", "404":
+		return TextGenerationErrorConfig
+	default:
+		return TextGenerationErrorUnknown
+	}
+}
+
+// summaryProviders maps agent names to summary CLI metadata. The binary is what
 // RunIsolatedTextGeneratorCLI will exec. Used by IsSummaryCLIAvailable to
 // check PATH instead of repo-level DetectPresence, because a repo can use
 // one agent for development while a different agent generates summaries.
@@ -95,13 +191,18 @@ func RunIsolatedTextGeneratorCLI(ctx context.Context, runner TextCommandRunner, 
 // Callers outside this package that need the binary name (e.g., the explain
 // diagnostic's "run `claude` directly" suggestion) should use
 // SummaryCLIBinaryName rather than duplicating the mapping.
-var summaryProviderBinaries = map[types.AgentName]string{
-	AgentNameClaudeCode: "claude",
-	AgentNameCodex:      "codex",
-	AgentNameCopilotCLI: "copilot",
-	AgentNameCursor:     "agent",
-	AgentNameGemini:     "gemini",
-	AgentNamePi:         "pi",
+type summaryProviderMetadata struct {
+	binary string
+	label  string
+}
+
+var summaryProviders = map[types.AgentName]summaryProviderMetadata{
+	AgentNameClaudeCode: {binary: "claude", label: "Claude"},
+	AgentNameCodex:      {binary: "codex", label: "Codex"},
+	AgentNameCopilotCLI: {binary: "copilot", label: "Copilot CLI"},
+	AgentNameCursor:     {binary: "agent", label: "Cursor"},
+	AgentNameGemini:     {binary: "gemini", label: "Gemini"},
+	AgentNamePi:         {binary: "pi", label: "Pi"},
 }
 
 // SummaryCLIBinaryName returns the CLI binary name for a summary-capable
@@ -109,7 +210,12 @@ var summaryProviderBinaries = map[types.AgentName]string{
 // agents that are not summary-capable; callers should treat that as "we
 // don't know" rather than guessing.
 func SummaryCLIBinaryName(name types.AgentName) string {
-	return summaryProviderBinaries[name]
+	return summaryProviders[name].binary
+}
+
+// SummaryProviderErrorLabel returns a user-facing provider name.
+func SummaryProviderErrorLabel(name types.AgentName) string {
+	return summaryProviders[name].label
 }
 
 // IsSummaryCLIAvailable reports whether the CLI binary for a summary-capable

--- a/cmd/entire/cli/agent/text_generator_cli_test.go
+++ b/cmd/entire/cli/agent/text_generator_cli_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -475,9 +476,9 @@ func requireTextGenerationError(t *testing.T, err error) *agent.TextGenerationEr
 
 func countConcreteTextGenerationErrors(err error) int {
 	count := 0
+	targetType := reflect.TypeFor[*agent.TextGenerationError]()
 	for err != nil {
-		textGenerationError := &agent.TextGenerationError{}
-		if errors.As(err, &textGenerationError) {
+		if reflect.TypeOf(err) == targetType {
 			count++
 		}
 		err = errors.Unwrap(err)

--- a/cmd/entire/cli/agent/text_generator_cli_test.go
+++ b/cmd/entire/cli/agent/text_generator_cli_test.go
@@ -1,120 +1,507 @@
-package agent
+package agent_test
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
+	"github.com/entireio/cli/cmd/entire/cli/agent/copilotcli"
+	"github.com/entireio/cli/cmd/entire/cli/agent/cursor"
+	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 )
 
-const windowsOS = "windows"
+const textGeneratorHelperTest = "TestTextGeneratorCLIHelperProcess"
+const textGeneratorHelperMarker = "__entire_text_generator_helper__"
 
-func TestRunIsolatedTextGeneratorCLI_EmptyOutput(t *testing.T) {
-	t.Parallel()
-
-	runner := func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "echo", "-n", "")
-	}
-	// On some systems echo -n "" still prints a newline; use printf for reliable empty output
-	if runtime.GOOS != windowsOS {
-		runner = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			return exec.CommandContext(ctx, "printf", "")
+// TestTextGeneratorCLIHelperProcess is the subprocess entrypoint used by this
+// file's tests. It must not call t.Parallel because helper modes call os.Exit.
+func TestTextGeneratorCLIHelperProcess(_ *testing.T) {
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
 		}
 	}
-	_, _, _, err := RunIsolatedTextGeneratorCLI(context.Background(), runner, "test", "test-agent", nil, "")
-	if err == nil {
-		t.Fatal("expected error for empty output")
+	if separator == -1 {
+		return
 	}
-	if !strings.Contains(err.Error(), "test-agent CLI returned empty output") {
-		t.Fatalf("error = %q, want it to contain %q", err.Error(), "test-agent CLI returned empty output")
+
+	args := os.Args[separator+1:]
+	if len(args) == 0 || args[0] != textGeneratorHelperMarker {
+		return
+	}
+	args = args[1:]
+	if len(args) == 0 {
+		os.Exit(2)
+	}
+
+	switch args[0] {
+	case "success":
+		if _, err := io.Copy(os.Stdout, os.Stdin); err != nil {
+			os.Exit(3)
+		}
+		os.Exit(0)
+	case "empty-stderr":
+		_, _ = fmt.Fprint(os.Stderr, helperArg(args, 1))
+		os.Exit(0)
+	case "stderr-failure":
+		_, _ = fmt.Fprint(os.Stderr, helperArg(args, 1))
+		os.Exit(23)
+	case "stdout-failure":
+		_, _ = fmt.Fprint(os.Stdout, helperArg(args, 1))
+		os.Exit(23)
+	case "blocking":
+		time.Sleep(time.Hour)
+	default:
+		os.Exit(2)
 	}
 }
 
-func TestRunIsolatedTextGeneratorCLI_NonZeroExit(t *testing.T) {
-	t.Parallel()
+func helperArg(args []string, index int) string {
+	if index >= len(args) {
+		return ""
+	}
+	return args[index]
+}
 
-	runner := func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "sh", "-c", "echo 'some error' >&2; exit 1")
-	}
-	_, _, _, err := RunIsolatedTextGeneratorCLI(context.Background(), runner, "test", "myagent", nil, "")
-	if err == nil {
-		t.Fatal("expected error for non-zero exit")
-	}
-	errMsg := err.Error()
-	if !strings.Contains(errMsg, "myagent CLI failed (exit 1)") {
-		t.Fatalf("error = %q, want it to contain exit code info", errMsg)
-	}
-	if !strings.Contains(errMsg, "some error") {
-		t.Fatalf("error = %q, want it to contain stderr detail", errMsg)
+func helperRunner(mode string, details ...string) agent.TextCommandRunner {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		args := []string{"-test.run=^" + textGeneratorHelperTest + "$", "--", textGeneratorHelperMarker, mode}
+		args = append(args, details...)
+		return exec.CommandContext(ctx, os.Args[0], args...)
 	}
 }
 
-func TestRunIsolatedTextGeneratorCLI_NonZeroExitFallsBackToStdout(t *testing.T) {
-	t.Parallel()
-
-	runner := func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "sh", "-c", "echo 'stdout detail'; exit 1")
-	}
-	_, _, _, err := RunIsolatedTextGeneratorCLI(context.Background(), runner, "test", "myagent", nil, "")
-	if err == nil {
-		t.Fatal("expected error for non-zero exit")
-	}
-	if !strings.Contains(err.Error(), "stdout detail") {
-		t.Fatalf("error = %q, want it to contain stdout as fallback detail", err.Error())
+func detachedHelperRunner(mode string, details ...string) agent.TextCommandRunner {
+	return func(context.Context, string, ...string) *exec.Cmd {
+		args := []string{"-test.run=^" + textGeneratorHelperTest + "$", "--", textGeneratorHelperMarker, mode}
+		args = append(args, details...)
+		return exec.CommandContext(context.Background(), os.Args[0], args...)
 	}
 }
 
-func TestRunIsolatedTextGeneratorCLI_BinaryNotFound(t *testing.T) {
+func TestSummaryProviderMetadata(t *testing.T) {
 	t.Parallel()
 
-	_, _, _, err := RunIsolatedTextGeneratorCLI(context.Background(), nil, "nonexistent-binary-12345", "myagent", nil, "")
-	if err == nil {
-		t.Fatal("expected error for missing binary")
+	tests := []struct {
+		provider types.AgentName
+		binary   string
+		label    string
+	}{
+		{provider: agent.AgentNameClaudeCode, binary: "claude", label: "Claude"},
+		{provider: agent.AgentNameCodex, binary: "codex", label: "Codex"},
+		{provider: agent.AgentNameCopilotCLI, binary: "copilot", label: "Copilot CLI"},
+		{provider: agent.AgentNameCursor, binary: "agent", label: "Cursor"},
+		{provider: agent.AgentNameGemini, binary: "gemini", label: "Gemini"},
+		{provider: agent.AgentNamePi, binary: "pi", label: "Pi"},
 	}
-	if !strings.Contains(err.Error(), "myagent CLI not found") {
-		t.Fatalf("error = %q, want it to contain 'not found'", err.Error())
+
+	for _, test := range tests {
+		t.Run(string(test.provider), func(t *testing.T) {
+			t.Parallel()
+			if got := agent.SummaryCLIBinaryName(test.provider); got != test.binary {
+				t.Errorf("SummaryCLIBinaryName(%q) = %q, want %q", test.provider, got, test.binary)
+			}
+			if got := agent.SummaryProviderErrorLabel(test.provider); got != test.label {
+				t.Errorf("SummaryProviderErrorLabel(%q) = %q, want %q", test.provider, got, test.label)
+			}
+		})
 	}
 }
 
-func TestRunIsolatedTextGeneratorCLI_NilRunnerDefaultsToExec(t *testing.T) {
+func TestRunIsolatedTextGeneratorCLI_ClassifiesContextualHTTPStatus(t *testing.T) {
 	t.Parallel()
 
-	// With nil runner, it defaults to exec.CommandContext, so "echo" should work
-	result, _, _, err := RunIsolatedTextGeneratorCLI(context.Background(), nil, "echo", "echo", []string{"hello"}, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		message string
+		kind    agent.TextGenerationErrorKind
+	}{
+		{message: "HTTP 401 Unauthorized", kind: agent.TextGenerationErrorAuth},
+		{message: "HTTP status 403", kind: agent.TextGenerationErrorAuth},
+		{message: "HTTP status code 429", kind: agent.TextGenerationErrorRateLimit},
+		{message: "status code 400", kind: agent.TextGenerationErrorConfig},
+		{message: "unexpected status 401 Unauthorized", kind: agent.TextGenerationErrorAuth},
+		{message: "provider response status 404", kind: agent.TextGenerationErrorConfig},
+		{message: "API response status: 429", kind: agent.TextGenerationErrorRateLimit},
 	}
-	if result != "hello" {
-		t.Fatalf("result = %q, want %q", result, "hello")
+
+	for _, test := range tests {
+		t.Run(test.message, func(t *testing.T) {
+			t.Parallel()
+			_, err := agent.RunIsolatedTextGeneratorCLI(
+				context.Background(), helperRunner("stderr-failure", test.message), agent.AgentNameCodex, nil, "",
+			)
+			failure := requireTextGenerationError(t, err)
+			if failure.Kind != test.kind {
+				t.Errorf("Kind = %v, want %v (error: %v)", failure.Kind, test.kind, err)
+			}
+		})
 	}
 }
 
-func TestRunIsolatedTextGeneratorCLI_CanceledContextPreservesSentinel(t *testing.T) {
+func TestRunIsolatedTextGeneratorCLI_DoesNotClassifyBareNumbers(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == windowsOS {
-		t.Skip("uses POSIX shell command")
+	tests := []string{
+		"bare 404",
+		"worker 404 failed to start",
+		"exit status 404",
+		"port 14010",
+		"took 429ms",
+		"request-id=abc-401-def",
 	}
 
-	runner := func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "sh", "-c", "sleep 10")
+	for _, message := range tests {
+		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+			_, err := agent.RunIsolatedTextGeneratorCLI(
+				context.Background(), helperRunner("stderr-failure", message), agent.AgentNameCodex, nil, "",
+			)
+			failure := requireTextGenerationError(t, err)
+			if failure.Kind != agent.TextGenerationErrorUnknown {
+				t.Errorf("Kind = %v, want Unknown (error: %v)", failure.Kind, err)
+			}
+		})
+	}
+}
+
+func TestRunIsolatedTextGeneratorCLI_FallbackContract(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing binary", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "definitely-not-installed-summary-cli")
+			}, agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorCLIMissing {
+			t.Errorf("Kind = %v, want CLIMissing", failure.Kind)
+		}
+		if failure.Provider != agent.AgentNameCodex {
+			t.Errorf("Provider = %q, want %q", failure.Provider, agent.AgentNameCodex)
+		}
+	})
+
+	t.Run("provider label is not duplicated", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "definitely-not-installed-summary-cli")
+			}, agent.AgentNameCopilotCLI, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if strings.Contains(failure.Message, "CLI CLI") {
+			t.Errorf("Message = %q, contains duplicated CLI label", failure.Message)
+		}
+	})
+
+	t.Run("auth stderr", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("stderr-failure", "HTTP 401 Unauthorized"), agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorAuth {
+			t.Errorf("Kind = %v, want Auth", failure.Kind)
+		}
+		if failure.ExitCode != 23 {
+			t.Errorf("ExitCode = %d, want 23", failure.ExitCode)
+		}
+		if failure.Stderr != "HTTP 401 Unauthorized" {
+			t.Errorf("Stderr = %q, want captured auth stderr", failure.Stderr)
+		}
+	})
+
+	t.Run("generic nonzero", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("stderr-failure", "provider exploded"), agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorUnknown {
+			t.Errorf("Kind = %v, want Unknown", failure.Kind)
+		}
+		if !strings.Contains(failure.Message, "provider exploded") {
+			t.Errorf("Message = %q, want stderr detail", failure.Message)
+		}
+	})
+
+	t.Run("stdout fallback", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("stdout-failure", "stdout detail"), agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.StdoutBytes != len("stdout detail") {
+			t.Errorf("StdoutBytes = %d, want %d", failure.StdoutBytes, len("stdout detail"))
+		}
+		if !strings.Contains(failure.Message, "stdout detail") {
+			t.Errorf("Message = %q, want stdout fallback detail", failure.Message)
+		}
+	})
+
+	t.Run("cancellation", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+		}()
+		_, err := agent.RunIsolatedTextGeneratorCLI(ctx, helperRunner("blocking"), agent.AgentNameCodex, nil, "")
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorUnknown {
+			t.Errorf("Kind = %v, want Unknown", failure.Kind)
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled in chain", err)
+		}
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		t.Cleanup(cancel)
+		_, err := agent.RunIsolatedTextGeneratorCLI(ctx, helperRunner("blocking"), agent.AgentNameCodex, nil, "")
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorUnknown {
+			t.Errorf("Kind = %v, want Unknown", failure.Kind)
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("err = %v, want context.DeadlineExceeded in chain", err)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		result, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("success"), agent.AgentNameCodex, nil, "generated summary\n",
+		)
+		if err != nil {
+			t.Fatalf("RunIsolatedTextGeneratorCLI() error = %v", err)
+		}
+		if result != "generated summary" {
+			t.Errorf("result = %q, want %q", result, "generated summary")
+		}
+	})
+
+	t.Run("empty stdout with recognized auth stderr", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("empty-stderr", "HTTP status 401"), agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorAuth {
+			t.Errorf("Kind = %v, want Auth", failure.Kind)
+		}
+		if failure.Stderr != "HTTP status 401" {
+			t.Errorf("Stderr = %q, want retained stderr", failure.Stderr)
+		}
+	})
+
+	t.Run("empty stdout with generic stderr", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("empty-stderr", "diagnostic detail"), agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorUnknown {
+			t.Errorf("Kind = %v, want Unknown", failure.Kind)
+		}
+		if failure.Stderr != "diagnostic detail" {
+			t.Errorf("Stderr = %q, want retained stderr", failure.Stderr)
+		}
+		if !strings.Contains(failure.Message, "diagnostic detail") {
+			t.Errorf("Message = %q, want retained stderr detail", failure.Message)
+		}
+	})
+}
+
+func TestRunIsolatedTextGeneratorCLI_SpecificProviderSignalOutranksContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		newCtx   func(t *testing.T) context.Context
+		sentinel error
+	}{
+		{
+			name: "cancellation",
+			newCtx: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithCancel(context.Background())
+				t.Cleanup(cancel)
+				cancel()
+				return ctx
+			},
+			sentinel: context.Canceled,
+		},
+		{
+			name: "deadline",
+			newCtx: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+				t.Cleanup(cancel)
+				return ctx
+			},
+			sentinel: context.DeadlineExceeded,
+		},
 	}
 
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := test.newCtx(t)
+			_, err := agent.RunIsolatedTextGeneratorCLI(
+				ctx, detachedHelperRunner("stderr-failure", "HTTP 401 Unauthorized"), agent.AgentNameCodex, nil, "",
+			)
+			failure := requireTextGenerationError(t, err)
+			if failure.Kind != agent.TextGenerationErrorAuth {
+				t.Errorf("Kind = %v, want Auth (error: %v)", failure.Kind, err)
+			}
+			if errors.Is(err, test.sentinel) {
+				t.Errorf("specific provider error should outrank %v: %v", test.sentinel, err)
+			}
+		})
+	}
+}
+
+func TestRunIsolatedTextGeneratorCLI_UnknownFailurePreservesCompletedContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		sentinel error
+	}{
+		{name: "cancellation", ctx: canceledContext(), sentinel: context.Canceled},
+		{name: "deadline", ctx: expiredContext(), sentinel: context.DeadlineExceeded},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := agent.RunIsolatedTextGeneratorCLI(
+				test.ctx, detachedHelperRunner("stderr-failure", "provider exploded"), agent.AgentNameCodex, nil, "",
+			)
+			failure := requireTextGenerationError(t, err)
+			if failure.Kind != agent.TextGenerationErrorUnknown {
+				t.Errorf("Kind = %v, want Unknown", failure.Kind)
+			}
+			if !errors.Is(err, test.sentinel) {
+				t.Errorf("err = %v, want %v in chain", err, test.sentinel)
+			}
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Errorf("err = %v, want subprocess cause preserved", err)
+			}
+		})
+	}
+}
+
+func canceledContext() context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		cancel()
-	}()
+	cancel()
+	return ctx
+}
 
-	_, _, _, err := RunIsolatedTextGeneratorCLI(ctx, runner, "test", "test", nil, "")
-	if err == nil {
-		t.Fatal("expected cancellation error")
+func expiredContext() context.Context {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	cancel()
+	return ctx
+}
+
+func TestRunIsolatedTextGeneratorCLI_GeminiAuthPhrase(t *testing.T) {
+	t.Parallel()
+
+	_, err := agent.RunIsolatedTextGeneratorCLI(
+		context.Background(), helperRunner("stderr-failure", "Please set an Auth method"), agent.AgentNameGemini, nil, "",
+	)
+	failure := requireTextGenerationError(t, err)
+	if failure.Kind != agent.TextGenerationErrorAuth {
+		t.Errorf("Kind = %v, want Auth", failure.Kind)
 	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context.Canceled, got %v", err)
+}
+
+func TestFallbackGeneratorsContainExactlyOneTextGenerationError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		generator agent.TextGenerator
+	}{
+		{name: "codex", generator: &codex.CodexAgent{CommandRunner: helperRunner("stderr-failure", "HTTP 401 Unauthorized")}},
+		{name: "copilot", generator: &copilotcli.CopilotCLIAgent{CommandRunner: helperRunner("stderr-failure", "HTTP 401 Unauthorized")}},
+		{name: "cursor", generator: &cursor.CursorAgent{CommandRunner: helperRunner("stderr-failure", "HTTP 401 Unauthorized")}},
+		{name: "gemini", generator: &geminicli.GeminiCLIAgent{CommandRunner: helperRunner("stderr-failure", "HTTP 401 Unauthorized")}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := test.generator.GenerateText(context.Background(), "prompt", "")
+			if count := countConcreteTextGenerationErrors(err); count != 1 {
+				t.Fatalf("TextGenerationError count = %d, want 1 (chain: %v)", count, err)
+			}
+		})
+	}
+}
+
+func requireTextGenerationError(t *testing.T, err error) *agent.TextGenerationError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var failure *agent.TextGenerationError
+	if !errors.As(err, &failure) {
+		t.Fatalf("err = %T %v, want *TextGenerationError", err, err)
+	}
+	if failure.Err == nil {
+		t.Fatal("TextGenerationError.Err must be non-nil")
+	}
+	return failure
+}
+
+func countConcreteTextGenerationErrors(err error) int {
+	count := 0
+	for err != nil {
+		textGenerationError := &agent.TextGenerationError{}
+		if errors.As(err, &textGenerationError) {
+			count++
+		}
+		err = errors.Unwrap(err)
+	}
+	return count
+}
+
+func TestTextGenerationError_DefensiveNilReceiverAndErr(t *testing.T) {
+	t.Parallel()
+
+	var nilFailure *agent.TextGenerationError
+	if got := nilFailure.Error(); got == "" {
+		t.Error("nil receiver Error() returned an empty message")
+	}
+	if err := nilFailure.Unwrap(); err != nil {
+		t.Errorf("nil receiver Unwrap() = %v, want nil", err)
+	}
+
+	failure := &agent.TextGenerationError{Message: "fallback message"}
+	if got := failure.Error(); got != "fallback message" {
+		t.Errorf("Error() = %q, want %q", got, "fallback message")
+	}
+	if err := failure.Unwrap(); err != nil {
+		t.Errorf("Unwrap() = %v, want nil", err)
 	}
 }
 
@@ -128,11 +515,11 @@ func TestStripGitEnv(t *testing.T) {
 		"GIT_WORK_TREE=/some/tree",
 		"EDITOR=vim",
 	}
-	filtered := StripGitEnv(env)
+	filtered := agent.StripGitEnv(env)
 
-	for _, e := range filtered {
-		if strings.HasPrefix(e, "GIT_") {
-			t.Fatalf("GIT_ variable not stripped: %s", e)
+	for _, entry := range filtered {
+		if strings.HasPrefix(entry, "GIT_") {
+			t.Fatalf("GIT_ variable not stripped: %s", entry)
 		}
 	}
 	if len(filtered) != 3 {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1161,13 +1161,13 @@ func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, [
 		return formatProviderSummaryError(providerErr, attempt)
 	case errors.Is(err, context.DeadlineExceeded):
 		label, rows := timeoutDiagnostic(err, attempt)
-		structured := errors.New("summary generation timed out")
+		message := "summary generation timed out"
 		if attempt.deadline > 0 {
-			structured = fmt.Errorf("summary generation did not return within the %s safety deadline", formatSummaryTimeout(attempt.deadline))
+			message = fmt.Sprintf("summary generation did not return within the %s safety deadline", formatSummaryTimeout(attempt.deadline))
 		}
-		return label, rows, structured
+		return label, rows, newFormattedProviderError(message, err)
 	case errors.Is(err, context.Canceled):
-		return "Summary generation canceled", nil, errors.New("summary generation canceled")
+		return "Summary generation canceled", nil, newFormattedProviderError("summary generation canceled", err)
 	case providerErr != nil:
 		return formatProviderSummaryError(providerErr, attempt)
 	default:

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -919,6 +919,12 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store che
 	}
 	provider, err := resolveCheckpointSummaryProvider(ctx, w)
 	if err != nil {
+		var providerFailure *agent.TextGenerationError
+		if errors.As(err, &providerFailure) {
+			attempt := newSummaryAttempt(providerFailure.Provider, 0)
+			label, rows, structured := formatCheckpointSummaryError(err, attempt)
+			return renderExplainFailure(errW, label, rows, structured)
+		}
 		return fmt.Errorf("failed to resolve summary provider: %w", err)
 	}
 	scopedTranscript = maybeCompactExternalTranscript(ctx, scopedTranscript, content.Metadata.Agent)
@@ -944,9 +950,7 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store che
 	if err != nil {
 		progressWriter.Flush()
 		label, rows, structured := formatCheckpointSummaryError(err, attempt)
-		styles := newStatusStyles(errW)
-		fmt.Fprint(errW, styles.renderFailure(label, rows))
-		return NewSilentError(structured)
+		return renderExplainFailure(errW, label, rows, structured)
 	}
 	elapsed := time.Since(start)
 
@@ -1111,6 +1115,7 @@ func generateCheckpointAISummary(ctx context.Context, scopedTranscript []byte, f
 // letting the caller still return a *SilentError for main.go's exit handling.
 func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, []explainRow, error) {
 	var claudeErr *claudecode.ClaudeError
+	var providerErr *agent.TextGenerationError
 	switch {
 	case errors.As(err, &claudeErr):
 		switch claudeErr.Kind { //nolint:exhaustive // ClaudeErrorUnknown handled by default
@@ -1152,6 +1157,8 @@ func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, [
 			}
 			return label, rows, fmt.Errorf("Claude failed to generate the summary%s", suffix) //nolint:staticcheck // ST1005
 		}
+	case errors.As(err, &providerErr) && providerErr.Kind != agent.TextGenerationErrorUnknown:
+		return formatProviderSummaryError(providerErr, attempt)
 	case errors.Is(err, context.DeadlineExceeded):
 		label, rows := timeoutDiagnostic(err, attempt)
 		structured := errors.New("summary generation timed out")
@@ -1161,8 +1168,87 @@ func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, [
 		return label, rows, structured
 	case errors.Is(err, context.Canceled):
 		return "Summary generation canceled", nil, errors.New("summary generation canceled")
+	case providerErr != nil:
+		return formatProviderSummaryError(providerErr, attempt)
 	default:
 		return "Failed to generate summary", []explainRow{{Label: "detail", Value: err.Error()}}, fmt.Errorf("failed to generate summary: %w", err)
+	}
+}
+
+func formatProviderSummaryError(failure *agent.TextGenerationError, attempt *summaryAttempt) (string, []explainRow, error) {
+	displayName := summaryProviderErrorLabel(failure.Provider, attempt)
+	if failure.Kind == agent.TextGenerationErrorCLIMissing {
+		label := displayName + " CLI is not installed or not on PATH"
+		if strings.HasSuffix(displayName, " CLI") {
+			label = displayName + " is not installed or not on PATH"
+		}
+		return label, nil, newFormattedProviderError(label, failure)
+	}
+
+	label := displayName + " failed to generate the summary"
+	switch failure.Kind { //nolint:exhaustive // Unknown and future kinds use the generic provider label.
+	case agent.TextGenerationErrorAuth:
+		label = displayName + " authentication failed"
+	case agent.TextGenerationErrorRateLimit:
+		label = displayName + " rejected the summary request due to rate limits or quota"
+	case agent.TextGenerationErrorConfig:
+		label = displayName + " rejected the summary request"
+	}
+
+	if failure.Kind != agent.TextGenerationErrorUnknown {
+		if failure.Message == "" {
+			return label, nil, newFormattedProviderError(label, failure)
+		}
+		return label,
+			[]explainRow{{Label: "message", Value: failure.Message}},
+			newFormattedProviderError(fmt.Sprintf("%s: %s", label, failure.Message), failure)
+	}
+
+	detail := providerFailureDetail(failure, displayName)
+	return label,
+		[]explainRow{{Label: "detail", Value: detail}},
+		newFormattedProviderError(fmt.Sprintf("%s: %s", label, detail), failure)
+}
+
+type formattedProviderError struct {
+	message string
+	cause   error
+}
+
+func (e *formattedProviderError) Error() string { return e.message }
+func (e *formattedProviderError) Unwrap() error { return e.cause }
+
+func newFormattedProviderError(message string, cause error) error {
+	return &formattedProviderError{message: message, cause: cause}
+}
+
+func summaryProviderErrorLabel(provider types.AgentName, attempt *summaryAttempt) string {
+	if provider == "" && attempt != nil {
+		provider = attempt.provider
+	}
+	if label := agent.SummaryProviderErrorLabel(provider); label != "" {
+		return label
+	}
+	if provider != "" {
+		return string(provider)
+	}
+	return "Provider"
+}
+
+func providerFailureDetail(failure *agent.TextGenerationError, displayName string) string {
+	switch {
+	case failure.Message != "":
+		return failure.Message
+	case strings.TrimSpace(failure.Stderr) != "":
+		return strings.TrimSpace(failure.Stderr)
+	case failure.Err != nil:
+		return failure.Err.Error()
+	case failure.ExitCode > 0:
+		return fmt.Sprintf("%s CLI exited with code %d", displayName, failure.ExitCode)
+	case failure.ExitCode < 0:
+		return displayName + " CLI terminated abnormally — no exit code captured"
+	default:
+		return "no diagnostic detail available from " + displayName + " CLI"
 	}
 }
 

--- a/cmd/entire/cli/explain_summary_provider.go
+++ b/cmd/entire/cli/explain_summary_provider.go
@@ -204,7 +204,13 @@ func ensureSummaryProviderPresent(_ context.Context, name types.AgentName) error
 		return fmt.Errorf("agent %s does not support summary generation", name)
 	}
 	if !isSummaryProviderAvailable(name, ag) {
-		return fmt.Errorf("summary provider %q is configured but its CLI binary is not on PATH; install it or update summary_generation.provider in settings", name)
+		cause := fmt.Errorf("summary provider %q is configured but its CLI binary is not on PATH", name)
+		return &agent.TextGenerationError{
+			Err:      cause,
+			Provider: name,
+			Kind:     agent.TextGenerationErrorCLIMissing,
+			Message:  cause.Error(),
+		}
 	}
 	return nil
 }

--- a/cmd/entire/cli/explain_summary_provider_test.go
+++ b/cmd/entire/cli/explain_summary_provider_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/summarize"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 func rowsContain(rows []explainRow, label, value string) bool {
@@ -303,6 +304,31 @@ func TestResolveCheckpointSummaryProvider_ConfiguredProviderNotInstalledReturnsE
 	if !strings.Contains(err.Error(), "not on PATH") {
 		t.Fatalf("unexpected error text: %v", err)
 	}
+}
+
+func TestEnsureSummaryProviderPresent_MissingCLIIsTyped(t *testing.T) {
+	// Cannot use t.Parallel() because package-level lookup functions are stubbed.
+	originalGet := getSummaryAgent
+	originalCLI := isSummaryCLIAvailable
+	t.Cleanup(func() {
+		getSummaryAgent = originalGet
+		isSummaryCLIAvailable = originalCLI
+	})
+
+	getSummaryAgent = func(name types.AgentName) (agent.Agent, error) {
+		return &stubTextAgent{name: name, kind: agent.AgentTypeCodex}, nil
+	}
+	isSummaryCLIAvailable = func(types.AgentName) bool { return false }
+
+	err := ensureSummaryProviderPresent(context.Background(), agent.AgentNameCodex)
+	var failure *agent.TextGenerationError
+	require.ErrorAs(t, err, &failure)
+	require.Equal(t, agent.AgentNameCodex, failure.Provider)
+	require.Equal(t, agent.TextGenerationErrorCLIMissing, failure.Kind)
+	require.Error(t, failure.Err)
+	require.Empty(t, failure.Stderr)
+	require.Zero(t, failure.StdoutBytes)
+	require.Zero(t, failure.ExitCode)
 }
 
 func TestResolveCheckpointSummaryProvider_ConfiguredExternalProvider(t *testing.T) {

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -267,9 +267,14 @@ func TestFormatCheckpointSummaryError_TextGenerationErrorPrecedence(t *testing.T
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			label, _, err := formatCheckpointSummaryError(test.failure, newSummaryAttempt(agent.AgentNameCodex, 5*time.Minute))
+			label, rows, structured := formatCheckpointSummaryError(test.failure, newSummaryAttempt(agent.AgentNameCodex, 5*time.Minute))
 			require.Equal(t, test.wantLabel, label)
-			require.Error(t, err)
+			var output bytes.Buffer
+			err := renderExplainFailure(&output, label, rows, structured)
+			require.ErrorIs(t, err, test.failure.Err)
+			var got *agent.TextGenerationError
+			require.ErrorAs(t, err, &got)
+			require.Same(t, test.failure, got)
 		})
 	}
 }
@@ -1182,7 +1187,7 @@ func TestGenerateCheckpointAISummary_FallbackTimeoutUsesNonStreamingDiagnostic(t
 		CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			calls++
 			if calls == 1 {
-				return streamCall(ctx, name, args...)
+				return streamCall(context.Background(), name, args...)
 			}
 			return agenttestutil.BlockingCmd(ctx)
 		},

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -140,6 +140,213 @@ func TestFormatCheckpointSummaryError_CLIMissing(t *testing.T) {
 	}
 }
 
+func TestFormatCheckpointSummaryError_NonClaudeProviderMatrix(t *testing.T) {
+	t.Parallel()
+
+	providers := []struct {
+		name  types.AgentName
+		label string
+	}{
+		{name: agent.AgentNameCodex, label: "Codex"},
+		{name: agent.AgentNameGemini, label: "Gemini"},
+		{name: agent.AgentNameCursor, label: "Cursor"},
+		{name: agent.AgentNameCopilotCLI, label: "Copilot CLI"},
+		{name: agent.AgentNamePi, label: "Pi"},
+	}
+	kinds := []struct {
+		name      string
+		kind      agent.TextGenerationErrorKind
+		label     string
+		rows      []explainRow
+		errSuffix string
+	}{
+		{
+			name:      "auth",
+			kind:      agent.TextGenerationErrorAuth,
+			label:     " authentication failed",
+			rows:      []explainRow{{Label: "message", Value: "provider detail"}},
+			errSuffix: " authentication failed: provider detail",
+		},
+		{
+			name:      "rate limit",
+			kind:      agent.TextGenerationErrorRateLimit,
+			label:     " rejected the summary request due to rate limits or quota",
+			rows:      []explainRow{{Label: "message", Value: "provider detail"}},
+			errSuffix: " rejected the summary request due to rate limits or quota: provider detail",
+		},
+		{
+			name:      "config",
+			kind:      agent.TextGenerationErrorConfig,
+			label:     " rejected the summary request",
+			rows:      []explainRow{{Label: "message", Value: "provider detail"}},
+			errSuffix: " rejected the summary request: provider detail",
+		},
+		{
+			name:      "CLI missing",
+			kind:      agent.TextGenerationErrorCLIMissing,
+			label:     " CLI is not installed or not on PATH",
+			errSuffix: " CLI is not installed or not on PATH",
+		},
+		{
+			name:      "unknown",
+			kind:      agent.TextGenerationErrorUnknown,
+			label:     " failed to generate the summary",
+			rows:      []explainRow{{Label: "detail", Value: "provider detail"}},
+			errSuffix: " failed to generate the summary: provider detail",
+		},
+	}
+
+	for _, provider := range providers {
+		for _, kind := range kinds {
+			t.Run(string(provider.name)+"/"+kind.name, func(t *testing.T) {
+				t.Parallel()
+
+				message := "provider detail"
+				if kind.kind == agent.TextGenerationErrorCLIMissing {
+					message = ""
+				}
+				failure := &agent.TextGenerationError{
+					Err:      errors.New("provider cause"),
+					Provider: provider.name,
+					Kind:     kind.kind,
+					Message:  message,
+				}
+				wantLabel := provider.label + kind.label
+				wantErr := provider.label + kind.errSuffix
+				if kind.kind == agent.TextGenerationErrorCLIMissing && strings.HasSuffix(provider.label, " CLI") {
+					wantLabel = provider.label + " is not installed or not on PATH"
+					wantErr = wantLabel
+				}
+				label, rows, err := formatCheckpointSummaryError(failure, newSummaryAttempt(provider.name, 0))
+				require.Equal(t, wantLabel, label)
+				require.Equal(t, kind.rows, rows)
+				require.EqualError(t, err, wantErr)
+			})
+		}
+	}
+}
+
+func TestFormatCheckpointSummaryError_TextGenerationErrorPrecedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		failure   *agent.TextGenerationError
+		wantLabel string
+	}{
+		{
+			name: "specific auth outranks wrapped deadline",
+			failure: &agent.TextGenerationError{
+				Err:      context.DeadlineExceeded,
+				Provider: agent.AgentNameCodex,
+				Kind:     agent.TextGenerationErrorAuth,
+				Message:  "HTTP 401 Unauthorized",
+			},
+			wantLabel: "Codex authentication failed",
+		},
+		{
+			name: "unknown wrapped deadline uses timeout",
+			failure: &agent.TextGenerationError{
+				Err:      context.DeadlineExceeded,
+				Provider: agent.AgentNameCodex,
+				Kind:     agent.TextGenerationErrorUnknown,
+			},
+			wantLabel: "Timed out after 5m0s: provider produced no output",
+		},
+		{
+			name: "unknown wrapped cancellation uses cancellation",
+			failure: &agent.TextGenerationError{
+				Err:      context.Canceled,
+				Provider: agent.AgentNameCodex,
+				Kind:     agent.TextGenerationErrorUnknown,
+			},
+			wantLabel: "Summary generation canceled",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			label, _, err := formatCheckpointSummaryError(test.failure, newSummaryAttempt(agent.AgentNameCodex, 5*time.Minute))
+			require.Equal(t, test.wantLabel, label)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestFormatCheckpointSummaryError_PreservesProviderCause(t *testing.T) {
+	t.Parallel()
+
+	failure := &agent.TextGenerationError{
+		Err:      context.DeadlineExceeded,
+		Provider: agent.AgentNameCodex,
+		Kind:     agent.TextGenerationErrorAuth,
+		Message:  "HTTP 401 Unauthorized",
+	}
+	_, _, err := formatCheckpointSummaryError(failure, newSummaryAttempt(agent.AgentNameCodex, 0))
+
+	var got *agent.TextGenerationError
+	require.ErrorAs(t, err, &got)
+	require.Same(t, failure, got)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestFormatCheckpointSummaryError_UnknownProviderDetails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		failure  *agent.TextGenerationError
+		attempt  *summaryAttempt
+		wantRows []explainRow
+		wantErr  string
+	}{
+		{
+			name: "exit code only",
+			failure: &agent.TextGenerationError{
+				Provider: agent.AgentNameCodex,
+				Kind:     agent.TextGenerationErrorUnknown,
+				ExitCode: 17,
+			},
+			attempt:  newSummaryAttempt(agent.AgentNameCodex, 0),
+			wantRows: []explainRow{{Label: "detail", Value: "Codex CLI exited with code 17"}},
+			wantErr:  "Codex failed to generate the summary: Codex CLI exited with code 17",
+		},
+		{
+			name: "original cause only",
+			failure: &agent.TextGenerationError{
+				Err:      errors.New("transport exploded"),
+				Provider: agent.AgentNameCodex,
+				Kind:     agent.TextGenerationErrorUnknown,
+			},
+			attempt:  newSummaryAttempt(agent.AgentNameCodex, 0),
+			wantRows: []explainRow{{Label: "detail", Value: "transport exploded"}},
+			wantErr:  "Codex failed to generate the summary: transport exploded",
+		},
+		{
+			name: "legacy empty provider falls back to attempt",
+			failure: &agent.TextGenerationError{
+				Err:     errors.New("legacy failure"),
+				Kind:    agent.TextGenerationErrorUnknown,
+				Message: "legacy failure",
+			},
+			attempt:  newSummaryAttempt(agent.AgentNamePi, 0),
+			wantRows: []explainRow{{Label: "detail", Value: "legacy failure"}},
+			wantErr:  "Pi failed to generate the summary: legacy failure",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			label, rows, err := formatCheckpointSummaryError(test.failure, test.attempt)
+			require.Equal(t, strings.Split(test.wantErr, ":")[0], label)
+			require.Equal(t, test.wantRows, rows)
+			require.EqualError(t, err, test.wantErr)
+		})
+	}
+}
+
 // TestFormatCheckpointSummaryError_TypedBranchesHandleEmptyMessage guards against
 // the null-result-envelope regression: Claude can emit is_error:true with a real
 // HTTP status (401/429/4xx) but result:null, producing a ClaudeError with Message="".
@@ -1141,6 +1348,52 @@ func TestGenerateCheckpointSummary_AdvancesV1Metadata(t *testing.T) {
 	v1After, err := fixture.repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.NoError(t, err)
 	require.NotEqual(t, fixture.v1Hash, v1After.Hash(), "v1 metadata branch must advance after UpdateSummary")
+}
+
+func TestGenerateCheckpointSummary_MissingConfiguredProvider(t *testing.T) {
+	fixture := setupGenerateSummaryFixture(t)
+
+	originalLoad := loadSummarySettings
+	originalGet := getSummaryAgent
+	originalCLI := isSummaryCLIAvailable
+	t.Cleanup(func() {
+		loadSummarySettings = originalLoad
+		getSummaryAgent = originalGet
+		isSummaryCLIAvailable = originalCLI
+	})
+	loadSummarySettings = func(context.Context) (*settings.EntireSettings, error) {
+		return &settings.EntireSettings{
+			Enabled: true,
+			SummaryGeneration: &settings.SummaryGenerationSettings{
+				Provider: string(agent.AgentNameCodex),
+			},
+		}, nil
+	}
+	getSummaryAgent = func(name types.AgentName) (agent.Agent, error) {
+		return &stubTextAgent{name: name, kind: agent.AgentTypeCodex}, nil
+	}
+	isSummaryCLIAvailable = func(types.AgentName) bool { return false }
+
+	var stdout, stderr bytes.Buffer
+	err := generateCheckpointSummary(
+		fixture.ctx,
+		&stdout,
+		&stderr,
+		fixture.store,
+		fixture.cpID,
+		fixture.cpSummary,
+		fixture.content,
+		false,
+		0,
+	)
+	var silentErr *SilentError
+	require.ErrorAs(t, err, &silentErr)
+	var providerFailure *agent.TextGenerationError
+	require.ErrorAs(t, err, &providerFailure)
+	require.Equal(t, agent.AgentNameCodex, providerFailure.Provider)
+	require.Equal(t, agent.TextGenerationErrorCLIMissing, providerFailure.Kind)
+	require.Contains(t, stderr.String(), "Codex CLI is not installed or not on PATH")
+	require.NotContains(t, stderr.String(), "failed to resolve summary provider:")
 }
 
 func TestRunExplainGenerateBlocksWhenPolicyWriteUnsupported(t *testing.T) {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -625,14 +625,45 @@ func generateSummary(ctx context.Context, redactedTranscript redact.RedactedByte
 	// scopedTranscript is sliced from redactedTranscript, which was redacted earlier in CondenseSession.
 	summary, err := summarize.GenerateFromTranscript(summarizeCtx, redact.AlreadyRedacted(scopedTranscript), filesTouched, state.AgentType, generator, nil) // no progress in the auto-summary hot path
 	if err != nil {
-		logging.Warn(summarizeCtx, "summary generation failed",
-			slog.String("session_id", state.SessionID),
-			slog.String("error", err.Error()))
+		attrs := []any{slog.String("session_id", state.SessionID)}
+		attrs = append(attrs, summaryGenerationFailureLogAttrs(err)...)
+		logging.Warn(summarizeCtx, "summary generation failed", attrs...)
 		return nil
 	}
 	logging.Info(summarizeCtx, "summary generated",
 		slog.String("session_id", state.SessionID))
 	return summary
+}
+
+func summaryGenerationFailureLogAttrs(err error) []any {
+	var failure *agent.TextGenerationError
+	if errors.As(err, &failure) {
+		kind := "unknown"
+		switch failure.Kind { //nolint:exhaustive // Unknown is the safe default.
+		case agent.TextGenerationErrorAuth:
+			kind = "auth"
+		case agent.TextGenerationErrorRateLimit:
+			kind = "rate_limit"
+		case agent.TextGenerationErrorConfig:
+			kind = "config"
+		case agent.TextGenerationErrorCLIMissing:
+			kind = "cli_missing"
+		}
+		return []any{
+			slog.String("failure_kind", kind),
+			slog.String("provider", string(failure.Provider)),
+			slog.Int("exit_code", failure.ExitCode),
+			slog.Int("stdout_bytes", failure.StdoutBytes),
+			slog.Int("stderr_bytes", len(failure.Stderr)),
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return []any{slog.String("failure_kind", "deadline")}
+	}
+	if errors.Is(err, context.Canceled) {
+		return []any{slog.String("failure_kind", "canceled")}
+	}
+	return []any{slog.String("failure_kind", "other")}
 }
 
 // buildSummaryGenerator returns a Generator based on the configured summary provider.

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -3,6 +3,8 @@ package strategy
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,6 +30,26 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/pi"
 )
+
+func TestSummaryGenerationFailureLogAttrsExcludeProviderContent(t *testing.T) {
+	t.Parallel()
+
+	const secret = "user prompt must not enter persistent logs"
+	failure := &agent.TextGenerationError{
+		Err:         errors.New(secret),
+		Stderr:      secret,
+		StdoutBytes: 42,
+		Provider:    agent.AgentNameCodex,
+		Kind:        agent.TextGenerationErrorAuth,
+		Message:     secret,
+		ExitCode:    7,
+	}
+
+	attrs := fmt.Sprint(summaryGenerationFailureLogAttrs(failure))
+	require.NotContains(t, attrs, secret)
+	require.Contains(t, attrs, "codex")
+	require.Contains(t, attrs, "auth")
+}
 
 // calculateTokenUsage is a test helper that looks up an agent by type and
 // calculates token usage from pre-loaded transcript bytes.


### PR DESCRIPTION
## Summary

- normalize summary-provider failures across Codex, Gemini CLI, Copilot CLI, Cursor, and Pi
- preserve decoded provider errors and cancellation/deadline causes through streaming and explain rendering
- classify authentication, rate-limit, configuration, and missing-CLI failures into actionable guidance
- keep automatic-summary failure logs privacy-safe by recording only structured metadata

## Stack

This PR is stacked on #1230, which is stacked on #964. Merge in that order.

It supersedes the older implementation in #1005 and carries forward the intent reviewed in Entire trail 193 without adding that old branch directly to the active stack.

## Verification

- `mise run check` — lint, race-enabled unit/integration suite, Vogon 59/59, Roger-Roger 4/4
- race-only fallback-timeout regression repeated 50 times
- isolated black-box failures: missing CLI, 401, 429, 400/404, generic exit, empty output, worker 404, partial timeout, and Pi auth/empty output
- real Codex native streaming and compatibility fallback both completed successfully

Native Pi calls were attempted but could not complete because the available OpenAI credential was quota-limited and the Google credential was invalid; Pi's deterministic error-path coverage passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core summary generation, streaming fallback, and user-visible explain errors across multiple providers; behavior changes are well-tested but affect failure UX and error precedence on timeouts/cancellation.
> 
> **Overview**
> Summary generation failures from external CLIs are now normalized into a shared **`TextGenerationError`** with provider identity, failure **kind** (auth, rate limit, config, missing CLI), message, stderr, exit code, and stdout byte counts.
> 
> **`RunIsolatedTextGeneratorCLI`** takes a provider enum instead of separate binary/display strings, returns `(string, error)` only, and builds typed errors via **`classifyTextGenerationFailure`** (contextual HTTP status patterns, Gemini auth phrase). Codex, Copilot, Cursor, Gemini, and Pi **`GenerateText`** paths wrap those errors instead of assembling their own envelopes. Pi gains injectable **`CommandRunner`** for tests.
> 
> **`StreamingGeneratorTemplate`** uses the same **`newTextGenerationError`** shape, classifies start/exit failures, and refines precedence: specific decoded provider errors beat concurrent deadlines; unknown provider/parser failures still join context cancellation/deadline with subprocess causes.
> 
> **Explain** and **`ensureSummaryProviderPresent`** surface missing or misconfigured providers as typed failures with user-facing labels via **`formatProviderSummaryError`**. Auto-summary condensation logs only structured metadata (no stderr/message content). Tests expand across isolated CLI helpers, streaming template subprocess fakes, and provider error matrices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee08c3d89c7322b19e54b4300ba0cc25c40aecd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->