### PR TITLE
feat(enable): collapse the non-git bootstrap into one setup question

### DIFF
--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -104,9 +104,19 @@ var ghRepoNameRe = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 // allowed visibility values.
 const (
-	visibilityPublic   = "public"
-	visibilityPrivate  = "private"
-	visibilityInternal = "internal"
+	visibilityPublic            = "public"
+	visibilityPrivate           = "private"
+	visibilityInternal          = "internal"
+	defaultInitialCommitMessage = "Initial commit"
+)
+
+type bootstrapSetupChoice string
+
+const (
+	bootstrapSetupLocal   bootstrapSetupChoice = "local"
+	bootstrapSetupGitHub  bootstrapSetupChoice = "github"
+	bootstrapSetupCustom  bootstrapSetupChoice = "custom"
+	bootstrapSetupDecline bootstrapSetupChoice = "decline"
 )
 
 // bootstrapState carries pre-setup decisions into the post-setup finalize
@@ -146,13 +156,29 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
 
-	// Step 1: confirm we should git init here.
-	proceed, err := confirmInitRepo(w, cwd, opts)
-	if err != nil {
-		return nil, err
-	}
-	if !proceed {
-		return nil, errBootstrapDeclined
+	// Step 1: decide whether to init here — and, on the bare interactive
+	// path, how: one select carries both the init consent and the setup
+	// preset, so the common flow costs a single answer. Explicit flags,
+	// --yes, and non-interactive runs keep the granular confirm + resolver
+	// contracts unchanged.
+	setupChoice := bootstrapSetupCustom
+	if shouldPromptBootstrapSetupChoice(opts) {
+		githubReady := ghAvailable(ctx, runner) && ghAuthenticated(ctx, runner)
+		setupChoice, err = promptBootstrapSetupChoice(w, cwd, githubReady)
+		if err != nil {
+			return nil, err
+		}
+		if setupChoice == bootstrapSetupDecline {
+			return nil, errBootstrapDeclined
+		}
+	} else {
+		proceed, confirmErr := confirmInitRepo(w, cwd, opts)
+		if confirmErr != nil {
+			return nil, confirmErr
+		}
+		if !proceed {
+			return nil, errBootstrapDeclined
+		}
 	}
 
 	// Step 2: git init.
@@ -165,13 +191,12 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 	paths.ClearWorktreeRootCache()
 	fmt.Fprintln(w, "  ✓ Initialized empty git repository")
 
-	// Step 3: decide whether to create a GitHub repo. Creating a remote is an
-	// explicit opt-in: it happens only on an explicit signal (repo flags,
-	// --push, or --yes) or an interactive "yes". A non-interactive run with no
-	// such signal stays local-only — we never create a repo on the user's
-	// behalf. --no-github always wins.
-	useGitHub := false
-	if !opts.NoGitHub {
+	// Creating a remote remains an explicit opt-in. Choosing the GitHub preset
+	// is that consent: its label states that the private repository will be
+	// created and the initial commit pushed. The local preset never creates or
+	// pushes a remote.
+	useGitHub := setupChoice == bootstrapSetupGitHub
+	if setupChoice == bootstrapSetupCustom && !opts.NoGitHub {
 		explicit := ghCreateRequested(opts)
 		// Only probe gh (and warn about a missing/unauthenticated CLI) when the
 		// user actually wants a GitHub repo — explicitly, or via the confirm
@@ -187,7 +212,6 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 			case explicit:
 				useGitHub = true
 			default:
-				// Interactive with no explicit signal: prompt, defaulting to No.
 				confirmed, err := confirmCreateGitHubRepo(cwd)
 				if err != nil {
 					return nil, err
@@ -201,7 +225,13 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 	// contiguous.
 	var fullName, visibility string
 	if useGitHub {
-		owner, name, vis, err := selectGitHubRepo(ctx, w, errW, runner, cwd, opts)
+		repoOpts := opts
+		if setupChoice == bootstrapSetupGitHub {
+			// The GitHub preset resolves the current user, folder-derived name,
+			// and private visibility without reopening the granular prompts.
+			repoOpts.Yes = true
+		}
+		owner, name, vis, err := selectGitHubRepo(ctx, w, errW, runner, cwd, repoOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -216,9 +246,12 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 	// because gh may read local config; but we can skip the identity
 	// check when the user is fully opting out of both commit and
 	// remote to keep the flow minimal.
-	message, commit, err := resolveCommitMessage(opts)
-	if err != nil {
-		return nil, err
+	message, commit := defaultInitialCommitMessage, true
+	if setupChoice == bootstrapSetupCustom {
+		message, commit, err = resolveCommitMessage(opts)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if commit {
 		if err := ensureGitIdentity(ctx, w, errW, runner, cwd); err != nil {
@@ -234,6 +267,9 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 	push := false
 	if useGitHub && commit {
 		switch {
+		case setupChoice == bootstrapSetupGitHub:
+			// The preset label explicitly includes pushing the initial commit.
+			push = true
 		case opts.Yes || opts.Push:
 			push = true
 		case interactive.CanPromptInteractively():
@@ -427,6 +463,65 @@ func confirmInitRepo(_ io.Writer, cwd string, opts GitHubBootstrapOptions) (bool
 		return false, fmt.Errorf("init-repo prompt: %w", err)
 	}
 	return confirmed, nil
+}
+
+// shouldPromptBootstrapSetupChoice reports whether this is the bare
+// interactive bootstrap path. Any option that expresses a granular choice —
+// including --init-repo / --no-init-repo, which answer the init consent the
+// merged select carries — keeps the established flag behavior instead of
+// being overwritten by a preset.
+func shouldPromptBootstrapSetupChoice(opts GitHubBootstrapOptions) bool {
+	return interactive.CanPromptInteractively() &&
+		!opts.Yes &&
+		!opts.InitRepo &&
+		!opts.NoInitRepo &&
+		!opts.NoGitHub &&
+		!ghFlagsProvided(opts) &&
+		!opts.Push &&
+		opts.InitialCommitMessage == "" &&
+		!opts.SkipInitialCommit
+}
+
+// promptBootstrapSetupChoice merges the init consent and the common
+// bootstrap decisions into one select, so the bare interactive path costs a
+// single answer. It runs _before_ `git init`: declining — including Ctrl-C —
+// leaves the folder untouched. The selected commit is still deferred until
+// Entire has written its settings and agent configuration.
+//
+// The wrong-directory guard from the granular confirm (issue #1717) carries
+// over: the absolute path stays in the title (the accessible renderer drops
+// descriptions), and the menu makes the choice visible before Enter lands on
+// the recommended preset.
+func promptBootstrapSetupChoice(w io.Writer, cwd string, githubReady bool) (bootstrapSetupChoice, error) {
+	options := []huh.Option[bootstrapSetupChoice]{
+		huh.NewOption("Yes, with one initial commit (recommended)", bootstrapSetupLocal),
+	}
+	if githubReady {
+		options = append(options,
+			huh.NewOption("Yes, plus a private GitHub repository (pushed)", bootstrapSetupGitHub),
+		)
+	}
+	options = append(options,
+		huh.NewOption("Yes, customize...", bootstrapSetupCustom),
+		huh.NewOption("No", bootstrapSetupDecline),
+	)
+
+	choice := bootstrapSetupLocal
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewSelect[bootstrapSetupChoice]().
+				Title(fmt.Sprintf("No git repository in %q. Set one up?", cwd)).
+				Options(options...).
+				Value(&choice),
+		),
+	).WithOutput(w)
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return bootstrapSetupDecline, nil
+		}
+		return "", fmt.Errorf("git setup prompt: %w", err)
+	}
+	return choice, nil
 }
 
 // selectGitHubRepo gathers owner, repo name, and visibility, respecting
@@ -633,8 +728,6 @@ func resolveVisibility(owner, currentUser string, opts GitHubBootstrapOptions) (
 // the initial commit entirely; callers must skip `doInitialCommit` and
 // any subsequent push.
 func resolveCommitMessage(opts GitHubBootstrapOptions) (string, bool, error) {
-	const defaultMsg = "Initial commit"
-
 	if opts.SkipInitialCommit {
 		return "", false, nil
 	}
@@ -642,7 +735,7 @@ func resolveCommitMessage(opts GitHubBootstrapOptions) (string, bool, error) {
 		return opts.InitialCommitMessage, true, nil
 	}
 	if opts.Yes || !interactive.CanPromptInteractively() {
-		return defaultMsg, true, nil
+		return defaultInitialCommitMessage, true, nil
 	}
 
 	const (
@@ -674,7 +767,7 @@ func resolveCommitMessage(opts GitHubBootstrapOptions) (string, bool, error) {
 	case choiceSkip:
 		return "", false, nil
 	case choiceCustomize:
-		input := defaultMsg
+		input := defaultInitialCommitMessage
 		custom := NewAccessibleForm(
 			huh.NewGroup(
 				huh.NewInput().
@@ -689,11 +782,11 @@ func resolveCommitMessage(opts GitHubBootstrapOptions) (string, bool, error) {
 			return "", false, fmt.Errorf("commit message prompt: %w", err)
 		}
 		if strings.TrimSpace(input) == "" {
-			return defaultMsg, true, nil
+			return defaultInitialCommitMessage, true, nil
 		}
 		return input, true, nil
 	default:
-		return defaultMsg, true, nil
+		return defaultInitialCommitMessage, true, nil
 	}
 }
 

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -520,7 +520,7 @@ func TestResolveCommitMessage_NonInteractiveDefault(t *testing.T) {
 	if !commit {
 		t.Fatal("commit should default to true non-interactively")
 	}
-	if msg != "Initial commit" {
+	if msg != defaultInitialCommitMessage {
 		t.Fatalf("message = %q, want Initial commit", msg)
 	}
 }
@@ -1143,6 +1143,155 @@ func TestConfirmInitRepo_ExplicitYesProceeds(t *testing.T) {
 	}
 }
 
+func TestPromptBootstrapSetupChoice_DefaultsToLocalInitialCommit(t *testing.T) {
+	withInteractivePromptStdin(t, "\n")
+
+	var out bytes.Buffer
+	choice, err := promptBootstrapSetupChoice(&out, "/tmp/example", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if choice != bootstrapSetupLocal {
+		t.Fatalf("choice = %q, want %q", choice, bootstrapSetupLocal)
+	}
+	if !strings.Contains(out.String(), "Set one up?") {
+		t.Fatalf("expected merged init+setup prompt, got: %s", out.String())
+	}
+	// The wrong-directory guard: the prompt must show where the repo would
+	// be created (issue #1717's concern, carried over from the confirm).
+	if !strings.Contains(out.String(), "/tmp/example") {
+		t.Fatalf("expected prompt to show the target directory, got: %s", out.String())
+	}
+}
+
+func TestPromptBootstrapSetupChoice_SelectsGitHubPreset(t *testing.T) {
+	withInteractivePromptStdin(t, "2\n")
+
+	choice, err := promptBootstrapSetupChoice(io.Discard, "/tmp/example", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if choice != bootstrapSetupGitHub {
+		t.Fatalf("choice = %q, want %q", choice, bootstrapSetupGitHub)
+	}
+}
+
+func TestPromptBootstrapSetupChoice_WithoutGitHubOffersCustomizeSecond(t *testing.T) {
+	withInteractivePromptStdin(t, "2\n")
+
+	choice, err := promptBootstrapSetupChoice(io.Discard, "/tmp/example", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if choice != bootstrapSetupCustom {
+		t.Fatalf("choice = %q, want %q", choice, bootstrapSetupCustom)
+	}
+}
+
+func TestPromptBootstrapSetupChoice_OffersDecline(t *testing.T) {
+	withInteractivePromptStdin(t, "4\n")
+
+	choice, err := promptBootstrapSetupChoice(io.Discard, "/tmp/example", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if choice != bootstrapSetupDecline {
+		t.Fatalf("choice = %q, want %q", choice, bootstrapSetupDecline)
+	}
+}
+
+func TestRunGitHubBootstrapInit_InteractiveLocalPresetUsesOneSetupAnswer(t *testing.T) {
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+	withInteractivePromptStdin(t, "\n")
+
+	r := newFakeRunner()
+	r.setIdentityConfigured()
+	r.set("git", []string{"init"}, "", nil)
+	r.set("gh", []string{"--version"}, "gh 2.81.0", nil)
+	r.set("gh", []string{"auth", "status"}, "Logged in", nil)
+
+	var out bytes.Buffer
+	state, err := runGitHubBootstrapInitWith(
+		context.Background(), &out, io.Discard,
+		GitHubBootstrapOptions{}, r,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.useGitHub {
+		t.Fatal("local preset should not create a GitHub repository")
+	}
+	if !state.commit || state.message != defaultInitialCommitMessage {
+		t.Fatalf("local preset commit = %v, message = %q", state.commit, state.message)
+	}
+	if state.push {
+		t.Fatal("local preset should not push")
+	}
+	if !strings.Contains(out.String(), "Set one up?") {
+		t.Fatalf("expected merged init+setup prompt, got: %s", out.String())
+	}
+}
+
+func TestRunGitHubBootstrapInit_InteractiveGitHubPresetUsesOneSetupAnswer(t *testing.T) {
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+	withInteractivePromptStdin(t, "2\n")
+
+	r := newFakeRunner()
+	r.setIdentityConfigured()
+	r.set("git", []string{"init"}, "", nil)
+	r.set("gh", []string{"--version"}, "gh 2.81.0", nil)
+	r.set("gh", []string{"auth", "status"}, "Logged in", nil)
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "octocat\n", nil)
+	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "", nil)
+	repoName := filepath.Base(dir)
+	r.set("gh", []string{"repo", "view", "octocat/" + repoName, "--json", "name"}, "", errors.New("not found"))
+
+	state, err := runGitHubBootstrapInitWith(
+		context.Background(), io.Discard, io.Discard,
+		GitHubBootstrapOptions{}, r,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !state.useGitHub || state.fullName != "octocat/"+repoName {
+		t.Fatalf("GitHub preset repository = %q, useGitHub = %v", state.fullName, state.useGitHub)
+	}
+	if state.visibility != visibilityPrivate {
+		t.Fatalf("visibility = %q, want %q", state.visibility, visibilityPrivate)
+	}
+	if !state.commit || state.message != defaultInitialCommitMessage {
+		t.Fatalf("GitHub preset commit = %v, message = %q", state.commit, state.message)
+	}
+	if !state.push {
+		t.Fatal("GitHub preset should push")
+	}
+}
+
+// TestRunGitHubBootstrapInit_InteractiveDeclineRunsNoGit verifies that
+// declining the merged prompt leaves the folder untouched: the select runs
+// before `git init`, so "No" must not create a repository.
+func TestRunGitHubBootstrapInit_InteractiveDeclineRunsNoGit(t *testing.T) {
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+	// gh is not stubbed: ghAvailable reports false, so the option list is
+	// local(1) / customize(2) / No(3).
+	withInteractivePromptStdin(t, "3\n")
+
+	r := newFakeRunner()
+	_, err := runGitHubBootstrapInitWith(
+		context.Background(), io.Discard, io.Discard,
+		GitHubBootstrapOptions{}, r,
+	)
+	if !errors.Is(err, errBootstrapDeclined) {
+		t.Fatalf("err = %v, want errBootstrapDeclined", err)
+	}
+	if r.hasCall(argsMatch("git", []string{"init"})) {
+		t.Fatal("declining the merged prompt must not run git init")
+	}
+}
+
 // TestConfirmCreateGitHubRepo_DefaultsToNo verifies that pressing Enter at
 // the GitHub-repo prompt declines. Creating and pushing a remote repository
 // publishes the directory's contents, so it must never happen just because
@@ -1251,7 +1400,7 @@ func TestRunGitHubBootstrap_YesAcceptsAllDefaults(t *testing.T) {
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
 	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
-	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Initial commit"}, "", nil)
+	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", defaultInitialCommitMessage}, "", nil)
 
 	// Expect repo created under the user's account (not org), private
 	repoName := filepath.Base(dir)
@@ -1277,7 +1426,7 @@ func TestRunGitHubBootstrap_YesAcceptsAllDefaults(t *testing.T) {
 		t.Errorf("expected owner to be user's account, got: %s", output)
 	}
 	// Should have committed with default message
-	if !r.hasCall(argsMatch("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Initial commit"})) {
+	if !r.hasCall(argsMatch("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", defaultInitialCommitMessage})) {
 		t.Error("expected commit with default 'Initial commit' message")
 	}
 	// Should have created the repo
@@ -1362,7 +1511,7 @@ func TestRunGitHubBootstrap_YesWithNoGitHub(t *testing.T) {
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
 	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
-	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Initial commit"}, "", nil)
+	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", defaultInitialCommitMessage}, "", nil)
 
 	opts := GitHubBootstrapOptions{Yes: true, NoGitHub: true}
 	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, opts, r)
@@ -1375,7 +1524,7 @@ func TestRunGitHubBootstrap_YesWithNoGitHub(t *testing.T) {
 		t.Error("expected no gh calls with --no-github")
 	}
 	// Should have committed
-	if !r.hasCall(argsMatch("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Initial commit"})) {
+	if !r.hasCall(argsMatch("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", defaultInitialCommitMessage})) {
 		t.Error("expected commit with default message")
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/909
<!-- entire-trail-link-end -->

## What

Enabling Entire in a folder that is not yet a git repository walked the user through up to seven prompts: init confirm, create-GitHub confirm, owner, name, visibility, commit message, and push. The bare interactive path now asks **one question** — a single select that carries both the init consent and a setup preset:

```
No git repository in "/Users/you/my-project". Set one up?
  > Yes, with one initial commit (recommended)
    Yes, plus a private GitHub repository (pushed)   ← only when gh is installed + authenticated
    Yes, customize...
    No
```

- **Local preset** (default): git init + one deferred initial commit ("Initial commit") that includes the `.entire/` config setup writes — no remote.
- **GitHub preset**: additionally creates a private repo under the current gh user with the folder-derived name and pushes the initial commit. The label spells out the private repo and the push, so choosing it is the explicit consent for both.
- **Customize**: the unchanged granular flow (GitHub? → owner → name → visibility → commit message → push?).
- **No**: same decline path as before.

## Behavior notes

- The select runs **before** `git init` — declining (including Ctrl-C) leaves the folder untouched. Previously an abort mid-flow could strand a half-initialized repo.
- The wrong-directory guard from the granular confirm (issue #1717) carries over: the absolute path stays in the title, and the menu makes every option visible. Note the deliberate trade-off: Enter now selects the recommended local preset rather than declining.
- Every explicit flag (`--yes`, `--init-repo`, `--no-init-repo`, `--no-github`, `--push`, repo/commit-message flags) and every non-interactive run keeps the existing granular contract — the merged prompt only appears on the bare interactive path.

## Tests

- Preset selection (default/GitHub/customize), decline option, and decline-runs-no-`git init` coverage.
- Prompt pins the absolute target path (the #1717 guard).
- `mise run fmt && mise run lint && mise run test` green (8,144 tests).

Part of the onboarding consolidation track (follow-up to #1618's ladder work, independent of it — merges cleanly either order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding consent defaults (Enter now starts local init) and can auto-create and push a private GitHub repo from one menu choice, though flags and the customize path preserve prior opt-in rules.
> 
> **Overview**
> **Bare interactive** `entire enable` in a non-git folder no longer chains up to seven prompts. A single select asks whether to set up git and picks a preset: **local** (default Enter) = `git init` + deferred **Initial commit** only; **GitHub** (when `gh` is ready) = private repo under the current user, folder name, and push; **customize** = the previous step-by-step flow; **No** = decline **before** `git init`.
> 
> Explicit flags (`--yes`, `--init-repo`, `--no-init-repo`, `--no-github`, repo flags, `--push`, commit flags) and non-interactive runs still use `confirmInitRepo` and the granular resolvers unchanged. Presets skip commit-message prompts and wire GitHub/push from the menu label (GitHub preset sets `repoOpts.Yes` and `push = true`). `defaultInitialCommitMessage` is shared as a package constant. Tests cover the merged prompt, presets, decline-without-`git init`, and path-in-title guard (#1717).
> 
> **UX trade-off:** on the merged prompt, Enter opts into the recommended local setup instead of declining (unlike the old init confirm defaulting to No).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18a104de8497310fd26a2c2c7b919d80899a3e2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->