### PR TITLE
fix: skip empty v1 orphan seed under git-refs backend

### DIFF
--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -464,6 +464,17 @@ func resolveAgentType(ctxAgentType types.AgentType, state *SessionState) types.A
 // origin holds the store — when Primary is in Push and the local ref is missing
 // or un-initialized, the local ref is created/updated from origin's
 // remote-tracking ref. Otherwise an empty orphan is created.
+// primaryIsGitRefs reports whether the configured primary checkpoint backend is
+// git-refs. Resolution is fail-soft: any config-load error is treated as the
+// default git-branch backend (returns false), preserving legacy behavior.
+func primaryIsGitRefs(ctx context.Context) bool {
+	cfg, err := settings.LoadCheckpointsConfig(ctx)
+	if err != nil {
+		return false
+	}
+	return checkpoint.PrimaryIsRefs(cfg)
+}
+
 func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 	// Rebind settings/remote resolution to the repository being modified rather
 	// than the ambient working directory, so the "is a checkpoint_remote
@@ -476,6 +487,17 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 
 	refs := checkpoint.ResolveRefs(ctx)
 	primaryName := refs.Primary.Short()
+
+	// Under the git-refs primary backend, checkpoints are written to
+	// per-checkpoint refs and nothing is ever written to the v1 metadata
+	// branch. Seeding an empty orphan v1 here would leave a vestigial,
+	// never-written branch — the surprise a user hit when `entire enable`
+	// selected git-refs yet still created entire/checkpoints/v1. We still adopt
+	// real v1 data that already exists on origin or a checkpoint_remote below
+	// (so legacy checkpoints stay readable); we only suppress the empty-orphan
+	// fallback. Resolution is fail-soft: an unreadable config keeps the legacy
+	// git-branch seeding behavior.
+	skipEmptyOrphan := primaryIsGitRefs(ctx)
 
 	localRef, localErr := repo.Reference(refs.Primary, true)
 	if localErr != nil && !errors.Is(localErr, plumbing.ErrReferenceNotFound) {
@@ -515,6 +537,9 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 		// Nothing usable on the checkpoint remote (fetch skipped/failed or the
 		// remote has no data) — create a fresh orphan that future pushes publish
 		// there. Still never origin.
+		if skipEmptyOrphan {
+			return nil
+		}
 		return createOrphanMetadataRef(ctx, repo, refs)
 	}
 
@@ -565,6 +590,9 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 	}
 
 	// No local or origin ref — create an empty orphan.
+	if skipEmptyOrphan {
+		return nil
+	}
 	return createOrphanMetadataRef(ctx, repo, refs)
 }
 

--- a/cmd/entire/cli/strategy/common_test.go
+++ b/cmd/entire/cli/strategy/common_test.go
@@ -988,6 +988,38 @@ func TestEnsurePrimaryRef(t *testing.T) {
 			t.Errorf("expected empty tree, got %d entries", len(tree.Entries))
 		}
 	})
+
+	t.Run("skips empty orphan when primary is git-refs", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		initTestRepo(t, dir)
+
+		// Select the git-refs backend for this repo. EnsurePrimaryRef rebinds
+		// the config lookup to the repo root, so a repo-local settings file is
+		// what it reads.
+		settingsDir := filepath.Join(dir, ".entire")
+		if err := os.MkdirAll(settingsDir, 0o750); err != nil {
+			t.Fatalf("failed to create .entire dir: %v", err)
+		}
+		cfg := []byte(`{"checkpoints":{"primary":{"type":"git-refs"}}}`)
+		if err := os.WriteFile(filepath.Join(settingsDir, "settings.json"), cfg, 0o600); err != nil {
+			t.Fatalf("failed to write settings: %v", err)
+		}
+
+		repo, err := git.PlainOpen(dir)
+		if err != nil {
+			t.Fatalf("failed to open repo: %v", err)
+		}
+		if err := EnsurePrimaryRef(t.Context(), repo); err != nil {
+			t.Fatalf("EnsurePrimaryRef() failed: %v", err)
+		}
+
+		// Under git-refs, checkpoints live in per-checkpoint refs and nothing
+		// is ever written to v1, so no vestigial empty orphan should be created.
+		_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+		require.ErrorIs(t, err, plumbing.ErrReferenceNotFound,
+			"expected no v1 branch under git-refs primary")
+	})
 }
 
 func TestEnsurePrimaryRef_WritesVercelConfigWhenEnabled(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/910
<!-- entire-trail-link-end -->

## Problem

Running `entire enable` and selecting the **git-refs** checkpoint backend still created an empty `entire/checkpoints/v1` branch — surprising, since git-refs writes checkpoints to per-checkpoint refs and never touches v1.

## Root cause

The enable-time seed step `EnsureSetup` → `EnsurePrimaryRef` (`cmd/entire/cli/strategy/common.go`) is backend-agnostic: it resolves the target ref via the hardcoded `checkpoint.ResolveRefs` (always `entire/checkpoints/v1`) and never consults `checkpoints.primary`. On a freshly `git init`'d folder with no origin and no `checkpoint_remote`, it falls through to `createOrphanMetadataRef`, unconditionally creating a vestigial empty orphan v1 that git-refs never writes to.

The git-refs backend selection **is** persisted correctly to `settings.json` before this runs — it's not a timing/ordering bug. The seed simply ignores the setting.

## Fix

Gate the empty-orphan fallback in `EnsurePrimaryRef` on the primary backend. Under git-refs, skip the orphan seed. Scope kept minimal:

- **Only** the empty-orphan creation is suppressed.
- Adoption of real existing v1 data from origin / a `checkpoint_remote` is **preserved**, so legacy checkpoints stay readable.
- Fail-soft: a config-load error keeps the legacy git-branch seeding behavior.
- Reuses the existing `checkpoint.PrimaryIsRefs` predicate.

## Test

New subtest `TestEnsurePrimaryRef/skips_empty_orphan_when_primary_is_git-refs`: writes a repo-local `settings.json` with git-refs primary, runs `EnsurePrimaryRef`, asserts no v1 branch is created. Red before the fix, green after.

## Verification

- `go test ./cmd/entire/cli/strategy/` — pass
- `mise run fmt` — applied
- golangci-lint v2.11.3 on the package — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized setup-path change in `EnsurePrimaryRef` with fail-soft config handling and a focused regression test; no auth or data-migration logic.
> 
> **Overview**
> **`EnsurePrimaryRef` no longer seeds an empty `entire/checkpoints/v1` orphan when checkpoints primary is git-refs**, fixing `entire enable` creating a vestigial v1 branch even though that backend only uses per-checkpoint refs.
> 
> A new **`primaryIsGitRefs`** helper reads repo-local checkpoints config (fail-soft: load errors keep legacy git-branch behavior) and gates only the **empty-orphan** fallbacks—after a failed/missing checkpoint_remote bootstrap and when there is no local or origin ref. **Adopting existing v1 data from origin or checkpoint_remote is unchanged** so legacy checkpoints stay readable.
> 
> A **`TestEnsurePrimaryRef`** subtest asserts that with `{"checkpoints":{"primary":{"type":"git-refs"}}}` in `.entire/settings.json`, no v1 branch is created on a fresh repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc8a77af75a0954ca8f04355440561087807c40. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->