### PR TITLE
test(e2e): cover git-refs backend on push + assert no v1 branch

### DIFF
--- a/.github/workflows/e2e-checkpoint-store.yml
+++ b/.github/workflows/e2e-checkpoint-store.yml
@@ -26,6 +26,25 @@ on:
         options:
           - git-branch
           - git-refs
+  # Reusable entry point so e2e.yml can run a fixed agent/backend leg (e.g.
+  # claude-code against git-refs) as part of the on-push matrix. The `inputs`
+  # context is shared by workflow_dispatch and workflow_call, so the jobs below
+  # read `inputs.*` for both triggers.
+  workflow_call:
+    inputs:
+      agent:
+        # Fixed to claude-code by default: the on-push leg in e2e.yml relies on
+        # this and passes no agent, so that leg always covers exactly one agent.
+        # A future caller may still override it explicitly.
+        description: "Agent to run"
+        required: false
+        type: string
+        default: "claude-code"
+      checkpoint_store:
+        description: "Checkpoint storage backend to run the suite against"
+        required: false
+        type: string
+        default: "git-refs"
 
 jobs:
   # Build the agent matrix dynamically: a single selected agent, or all of them
@@ -38,9 +57,10 @@ jobs:
       - id: set
         # Pass the input through env rather than interpolating it into the script:
         # `type: choice` only constrains the UI, so a REST-API dispatch could inject
-        # shell metacharacters here otherwise.
+        # shell metacharacters here otherwise. `inputs.agent` covers both the
+        # workflow_dispatch and workflow_call triggers.
         env:
-          AGENT_INPUT: ${{ github.event.inputs.agent }}
+          AGENT_INPUT: ${{ inputs.agent }}
         run: |
           input="$AGENT_INPUT"
           if [ -n "$input" ]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,10 +143,22 @@ jobs:
     uses: ./.github/workflows/e2e-windows.yml
     secrets: inherit
 
+  # Cover the git-refs checkpoint backend — the default for fresh `entire enable`
+  # setups — which the matrix above does not exercise (it pins git-branch). Agent
+  # (claude-code) and backend (git-refs) are fixed by the reusable workflow's
+  # input defaults, so this leg always covers exactly one agent on one backend.
+  e2e-git-refs:
+    uses: ./.github/workflows/e2e-checkpoint-store.yml
+    permissions:
+      actions: read
+      contents: read
+      copilot-requests: write
+    secrets: inherit
+
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [e2e-tests, e2e-windows]
-    if: ${{ always() && (needs.e2e-tests.result == 'failure' || needs.e2e-windows.result == 'failure') && github.event_name == 'push' }}
+    needs: [e2e-tests, e2e-windows, e2e-git-refs]
+    if: ${{ always() && (needs.e2e-tests.result == 'failure' || needs.e2e-windows.result == 'failure' || needs.e2e-git-refs.result == 'failure') && github.event_name == 'push' }}
     steps:
       # Classify the failed jobs into two severities:
       #   RED    — a "reliable" agent (or Windows) failed. These pass on every

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -169,7 +169,27 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 		}
 	})
 
+	// Under the git-refs backend, checkpoints live in per-checkpoint refs and
+	// nothing should ever create the entire/checkpoints/v1 metadata branch. A v1
+	// branch appearing means some flow seeded it despite git-refs being primary
+	// (the enable-time regression this guards against). Registered last so it
+	// runs before the repo dir is removed (cleanups are LIFO).
+	if UsingGitRefs() {
+		t.Cleanup(func() { assertNoCheckpointV1Branch(t, dir) })
+	}
+
 	return state
+}
+
+// assertNoCheckpointV1Branch fails the test if a local entire/checkpoints/v1
+// branch exists in dir. Only meaningful under the git-refs backend; git-branch
+// legitimately creates v1.
+func assertNoCheckpointV1Branch(t *testing.T, dir string) {
+	t.Helper()
+	hash := strings.TrimSpace(gitOutputSafe(dir, "rev-parse", "--verify", "--quiet", "refs/heads/"+checkpointRefV1))
+	if hash != "" {
+		t.Errorf("git-refs backend: unexpected %s branch was created (%s); no flow should seed v1 under git-refs", checkpointRefV1, hash)
+	}
 }
 
 func checkpointReadRef() string {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/911
<!-- entire-trail-link-end -->

## Why this matters

Fresh `entire enable` now defaults to the **git-refs** backend — but every automatic E2E run pins **git-branch**. The backend real users get on day one had **zero E2E coverage**, and that gap is exactly how the v1-orphan bug (#1819) shipped unnoticed.

## What this does

1. **Standing guard** (`repo.go`): every git-refs E2E test now fails if an `entire/checkpoints/v1` branch appears. Under git-refs, nothing should ever create v1 — so this catches any future flow that regresses like #1819 did.
2. **Runs the default backend in CI** (`e2e.yml` + `e2e-checkpoint-store.yml`): a `claude-code` × `git-refs` leg on every push to `main`, in Slack notify. Agent and backend are fixed by the reusable workflow's defaults (caller passes nothing) — one agent, to bound cost.

## Verified
`go vet -tags e2e` (testutil + tests), `gofmt`, YAML parse, `actionlint` (only pre-existing findings). Real E2E not run locally (API cost); it runs in the new CI leg.