### PR TITLE
docs: split Quick Start install instructions by operating system

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,34 +43,45 @@ With Entire, you can:
 
 ## Quick Start
 
+### macOS and Linux
+
+Install with Homebrew:
+
 ```bash
-# To use Homebrew, first tap:
 brew tap entireio/tap
 brew trust entireio/tap
+brew install --cask entire            # stable
+# brew install --cask entire@nightly  # or nightly
+```
 
-# Install stable via Homebrew
-brew install --cask entire
+Or with the install script:
 
-# Or install nightly via Homebrew
-brew install --cask entire@nightly
+```bash
+curl -fsSL https://entire.io/install.sh | bash                          # stable
+# curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly  # or nightly
+```
 
-# Or install stable via install.sh
-curl -fsSL https://entire.io/install.sh | bash
+### Windows
 
-# Or install nightly via install.sh
-curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly
+Install with Scoop:
 
-# Or install stable via Scoop (Windows)
+```powershell
 scoop bucket add entire https://github.com/entireio/scoop-bucket.git
 scoop install entire/cli
+```
 
-# Or install via Go (development/manual setup)
+### Go (development/manual setup)
+
+```bash
 go install github.com/entireio/cli/cmd/entire@latest
 
-# Linux: Add Go binaries to PATH (add to ~/.zshrc or ~/.bashrc if not already configured)
+# Add Go binaries to PATH (add to ~/.zshrc or ~/.bashrc if not already configured)
 export PATH="$HOME/go/bin:$PATH"
+```
 
-# Enable in your project
+### Enable in your project
+
+```bash
 cd your-project && entire enable
 
 # Check status


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/913
<!-- entire-trail-link-end -->

## Summary

The Quick Start section of the README mixed Homebrew, install.sh, Scoop, and Go install instructions in a single code block, so it couldn't be copy-pasted as a whole. This splits it into per-OS subsections so each block is independently runnable:

- **macOS and Linux** — Homebrew (tap + install) and the install script, with nightly variants as commented alternatives
- **Windows** — Scoop, in a `powershell` fenced block
- **Go (development/manual setup)** — `go install` plus the PATH export
- **Enable in your project** — `entire enable` and `entire status`

No content was added or removed — only reorganized. The `#quick-start` TOC anchor is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gzkLpcpzFxDMT1EEWajg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only reorganization with no runtime, auth, or data-handling changes.
> 
> **Overview**
> The **Quick Start** section is reorganized so install steps are grouped by platform instead of one mixed code block.
> 
> **macOS and Linux** get separate fenced blocks for Homebrew (tap, trust, stable install with commented nightly) and `install.sh` (stable with commented nightly). **Windows** uses a `powershell` block for Scoop. **Go (development/manual setup)** and **Enable in your project** (`entire enable`, `entire status`) each have their own bash blocks.
> 
> No install commands were added or removed—only structure and headings changed. The `#quick-start` TOC anchor is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba4bb2a467df6f4fe21bd258c5fe957af5af57cc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->