### PR TITLE
fix(opencode): clear pending injection on session change

### DIFF
--- a/cmd/entire/cli/agent/opencode/entire_plugin.ts
+++ b/cmd/entire/cli/agent/opencode/entire_plugin.ts
@@ -117,6 +117,9 @@ export const EntirePlugin: Plugin = async ({ directory }) => {
     messageStore.clear()
     currentModel = null
     currentSessionID = sessionID
+    // Drop any turn-start injection captured for the prior session so it
+    // can't leak into the new session's system prompt.
+    pendingInjection = null
     return true
   }
 
@@ -236,6 +239,7 @@ export const EntirePlugin: Plugin = async ({ directory }) => {
             seenUserMessages.clear()
             messageStore.clear()
             currentSessionID = null
+            pendingInjection = null
             // Use sync variant: session-end may fire during shutdown.
             callHookSync("session-end", {
               session_id: session.id,
@@ -252,6 +256,7 @@ export const EntirePlugin: Plugin = async ({ directory }) => {
             seenUserMessages.clear()
             messageStore.clear()
             currentSessionID = null
+            pendingInjection = null
             // Use sync variant: this is the last event before process exit.
             callHookSync("session-end", {
               session_id: sessionID,

--- a/cmd/entire/cli/agent/opencode/hooks_test.go
+++ b/cmd/entire/cli/agent/opencode/hooks_test.go
@@ -195,6 +195,13 @@ func TestInstallHooks_AppliesContextInjection(t *testing.T) {
 	if !strings.Contains(content, `output.system.push(pendingInjection)`) {
 		t.Fatal("plugin file should push the injection onto the system prompt")
 	}
+	// resetSessionTracking must clear the stashed injection so a session change
+	// cannot leak the prior session's context into the next session.
+	_, afterReset, _ := strings.Cut(content, "function resetSessionTracking")
+	resetBody, _, _ := strings.Cut(afterReset, "return true")
+	if !strings.Contains(resetBody, `pendingInjection = null`) {
+		t.Fatal("resetSessionTracking should clear pendingInjection on session change")
+	}
 }
 
 func TestInstallHooks_MessageUpdatedFallsBackToSessionStart(t *testing.T) {

--- a/cmd/entire/cli/agent/opencode/hooks_test.go
+++ b/cmd/entire/cli/agent/opencode/hooks_test.go
@@ -195,12 +195,22 @@ func TestInstallHooks_AppliesContextInjection(t *testing.T) {
 	if !strings.Contains(content, `output.system.push(pendingInjection)`) {
 		t.Fatal("plugin file should push the injection onto the system prompt")
 	}
-	// resetSessionTracking must clear the stashed injection so a session change
-	// cannot leak the prior session's context into the next session.
-	_, afterReset, _ := strings.Cut(content, "function resetSessionTracking")
-	resetBody, _, _ := strings.Cut(afterReset, "return true")
-	if !strings.Contains(resetBody, `pendingInjection = null`) {
-		t.Fatal("resetSessionTracking should clear pendingInjection on session change")
+	// Every session-reset site must clear the stashed injection so a session
+	// change cannot leak the prior session's context into the next session.
+	resetSites := []struct{ name, start, end string }{
+		{"resetSessionTracking", "function resetSessionTracking", "return true"},
+		{"session.deleted", `case "session.deleted"`, `callHookSync("session-end"`},
+		{"server.instance.disposed", `case "server.instance.disposed"`, `callHookSync("session-end"`},
+	}
+	for _, site := range resetSites {
+		_, after, found := strings.Cut(content, site.start)
+		if !found {
+			t.Fatalf("plugin file missing reset site %q", site.name)
+		}
+		body, _, _ := strings.Cut(after, site.end)
+		if !strings.Contains(body, `pendingInjection = null`) {
+			t.Fatalf("%s should clear pendingInjection to avoid cross-session leakage", site.name)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/921
<!-- entire-trail-link-end -->

## Problem

The generated OpenCode plugin (`.opencode/plugins/entire.ts`, produced from this CLI's embedded template) had a stale-injection leak.

The plugin stashes Entire's turn-start context injection in `pendingInjection` and applies it later in `experimental.chat.system.transform`. `resetSessionTracking`, `session.deleted`, and `server.instance.disposed` cleared the other per-session tracking fields but left `pendingInjection` set. A session change between the turn-start stash and the transform could leak the prior session's injected system context into the next session.

## Fix

Clear `pendingInjection` at all three reset sites in `cmd/entire/cli/agent/opencode/entire_plugin.ts`:
- `resetSessionTracking` (session switch)
- `session.deleted`
- `server.instance.disposed`

Added a regression assertion in `hooks_test.go` covering all three reset sites.

## Verification

- `go test ./cmd/entire/cli/agent/opencode/` — pass
- `golangci-lint run ./cmd/entire/cli/agent/opencode/` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted state-reset fix in the OpenCode plugin template with a string-based regression test; no auth or data-path changes.
> 
> **Overview**
> Fixes a **stale context leak** in the embedded OpenCode plugin: \`pendingInjection\` (Entire turn-start context applied via \`experimental.chat.system.transform\`) was not cleared when sessions ended or switched, so a prior session's injected system text could appear on the next session's LLM call.
> 
> The plugin now sets **\`pendingInjection = null\`** in **\`resetSessionTracking\`**, **\`session.deleted\`**, and **\`server.instance.disposed\`**, alongside the existing per-session resets. **\`hooks_test.go\`** adds a regression check that the generated plugin's \`resetSessionTracking\` body clears \`pendingInjection\`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 972501d7d8c6e7b00d0be348e764560f1809d1f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->