### PR TITLE
fix(trail): preserve body on interactive update

### DIFF
--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1101,18 +1101,26 @@ func newTrailCreateRequest(title, body, branch, base, statusStr, typeStr, priori
 
 // resolveTrailUpdateBody returns the body text to seed the interactive update
 // form with. The list resource omits the description (it lives in
-// body_document, detail-endpoint only), so update must fetch the detail body
-// or it would seed an empty field and PATCH a full-body wipe. Best-effort:
-// a failed or empty detail fetch falls back to the list body, mirroring
-// runTrailShow.
-func resolveTrailUpdateBody(ctx context.Context, client *api.Client, forge, owner, repo string, found *api.TrailResource) string {
+// body_document, served only by the detail endpoint), so update must fetch the
+// detail body — otherwise the form prefills from the empty list body and a
+// user edit against that blank baseline can overwrite a description they never
+// saw. Best-effort: on a failed detail fetch it returns the list body plus the
+// error so the caller can warn (mirroring runTrailShow); an empty detail body
+// (older/partial server) falls back to the list body with no error.
+func resolveTrailUpdateBody(ctx context.Context, client *api.Client, forge, owner, repo string, found *api.TrailResource) (string, error) {
 	body := found.Body
 	if found.Number > 0 {
-		if bt, err := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number); err == nil && strings.TrimSpace(bt) != "" {
+		bt, err := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number)
+		if err != nil {
+			return body, err
+		}
+		// fetchTrailDescription already trims; a non-empty result supersedes
+		// the list body, an empty one (older/partial server) leaves it intact.
+		if bt != "" {
 			body = bt
 		}
 	}
-	return body
+	return body, nil
 }
 
 func newTrailUpdateCmd() *cobra.Command {
@@ -1238,9 +1246,14 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, i
 			statusStr = string(metadata.Status)
 			title = metadata.Title
 			// The list resource omits the description; fetch the detail body so
-			// the form is prefilled with the current text instead of blank
-			// (blank + BodyChanged would PATCH a full-body wipe).
-			body = resolveTrailUpdateBody(ctx, client, forge, owner, repoName, found)
+			// the form prefills with the current text and change detection below
+			// compares against the real server value. Warn on a fetch failure so
+			// a blank baseline doesn't silently overwrite an unseen description.
+			seedBody, bodyErr := resolveTrailUpdateBody(ctx, client, forge, owner, repoName, found)
+			if bodyErr != nil {
+				fmt.Fprintf(errW, "Warning: could not load current trail body: %v\n", bodyErr)
+			}
+			body = seedBody
 			origStatus, origTitle, origBody := statusStr, title, body
 
 			form := NewAccessibleForm(

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1099,6 +1099,22 @@ func newTrailCreateRequest(title, body, branch, base, statusStr, typeStr, priori
 	return req
 }
 
+// resolveTrailUpdateBody returns the body text to seed the interactive update
+// form with. The list resource omits the description (it lives in
+// body_document, detail-endpoint only), so update must fetch the detail body
+// or it would seed an empty field and PATCH a full-body wipe. Best-effort:
+// a failed or empty detail fetch falls back to the list body, mirroring
+// runTrailShow.
+func resolveTrailUpdateBody(ctx context.Context, client *api.Client, forge, owner, repo string, found *api.TrailResource) string {
+	body := found.Body
+	if found.Number > 0 {
+		if bt, err := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number); err == nil && strings.TrimSpace(bt) != "" {
+			body = bt
+		}
+	}
+	return body
+}
+
 func newTrailUpdateCmd() *cobra.Command {
 	var statusStr, title, body, branch, typeStr, priorityStr string
 	var labelAdd, labelRemove, assigneeAdd, assigneeRemove, reviewerAdd, reviewerRemove []string
@@ -1221,7 +1237,11 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, i
 			}
 			statusStr = string(metadata.Status)
 			title = metadata.Title
-			body = metadata.Body
+			// The list resource omits the description; fetch the detail body so
+			// the form is prefilled with the current text instead of blank
+			// (blank + BodyChanged would PATCH a full-body wipe).
+			body = resolveTrailUpdateBody(ctx, client, forge, owner, repoName, found)
+			origStatus, origTitle, origBody := statusStr, title, body
 
 			form := NewAccessibleForm(
 				huh.NewGroup(
@@ -1240,9 +1260,12 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, i
 			if formErr := form.Run(); formErr != nil {
 				return handleFormCancellation(w, "Trail update", formErr)
 			}
-			inputs.StatusChanged = true
-			inputs.TitleChanged = true
-			inputs.BodyChanged = true
+			// Only mark a field changed when the user actually edited it, so an
+			// untouched body/title/status isn't needlessly PATCHed (a no-op body
+			// PATCH would otherwise rewrite the description on every update).
+			inputs.StatusChanged = statusStr != origStatus
+			inputs.TitleChanged = title != origTitle
+			inputs.BodyChanged = body != origBody
 		}
 
 		statusStr = strings.TrimSpace(statusStr)

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -591,6 +591,44 @@ func TestFetchTrailDescription_ReadsNestedBodyDocument(t *testing.T) {
 	}
 }
 
+func TestResolveTrailUpdateBody_PrefersDetailSnapshot(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := io.WriteString(w, `{"trail":{"number":42,"body_document":{"text_snapshot":"the real body"}},"checkpoints":[],"has_write_permission":true}`); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	// The list resource omits the description, so found.Body is empty. The
+	// seed must come from the detail endpoint, not the empty list body.
+	found := &api.TrailResource{Number: 42, Body: ""}
+	body := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	if body != "the real body" {
+		t.Fatalf("body = %q, want %q", body, "the real body")
+	}
+}
+
+func TestResolveTrailUpdateBody_FallsBackToListBody(t *testing.T) {
+	t.Parallel()
+	// Older/partial server: detail omits body_document (text_snapshot empty).
+	// The seed must fall back to the list body rather than blanking it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := io.WriteString(w, `{"trail":{"number":42},"checkpoints":[],"has_write_permission":true}`); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	found := &api.TrailResource{Number: 42, Body: "list body"}
+	body := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	if body != "list body" {
+		t.Fatalf("body = %q, want %q", body, "list body")
+	}
+}
+
 func TestResolveCreateBranch(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -604,7 +604,10 @@ func TestResolveTrailUpdateBody_PrefersDetailSnapshot(t *testing.T) {
 	// The list resource omits the description, so found.Body is empty. The
 	// seed must come from the detail endpoint, not the empty list body.
 	found := &api.TrailResource{Number: 42, Body: ""}
-	body := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	body, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	if err != nil {
+		t.Fatalf("resolveTrailUpdateBody: %v", err)
+	}
 	if body != "the real body" {
 		t.Fatalf("body = %q, want %q", body, "the real body")
 	}
@@ -623,9 +626,32 @@ func TestResolveTrailUpdateBody_FallsBackToListBody(t *testing.T) {
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
 	found := &api.TrailResource{Number: 42, Body: "list body"}
-	body := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	body, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	if err != nil {
+		t.Fatalf("resolveTrailUpdateBody: %v", err)
+	}
 	if body != "list body" {
 		t.Fatalf("body = %q, want %q", body, "list body")
+	}
+}
+
+func TestResolveTrailUpdateBody_ReturnsErrorOnFetchFailure(t *testing.T) {
+	t.Parallel()
+	// A detail-fetch failure must be surfaced (not swallowed) so the caller can
+	// warn: a blank baseline could otherwise silently overwrite an unseen body.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	found := &api.TrailResource{Number: 42, Body: "list body"}
+	body, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	if err == nil {
+		t.Fatal("expected error on fetch failure, got nil")
+	}
+	if body != "list body" {
+		t.Fatalf("body = %q, want fallback %q", body, "list body")
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/924
<!-- entire-trail-link-end -->

## Problem

`entire trail update` (interactive, no flags) came up with the **Body** field blank while Title/Status prefilled correctly. The interactive path unconditionally set `BodyChanged=true`, so submitting PATCHed an empty body and **wiped the trail's description**.

Root cause: the form seeded body from the *list* resource, which omits the description — it lives in `body_document`, served only by the *detail* endpoint (`trail_types.go:50-52`).

## Fix

- Add `resolveTrailUpdateBody`, which fetches the detail body via the existing `fetchTrailDescription` helper (best-effort: falls back to the list body on empty/failed fetch, mirroring `runTrailShow`).
- Set `StatusChanged`/`TitleChanged`/`BodyChanged` only when the user actually edited the field, so an untouched body isn't needlessly re-PATCHed.

## Tests

- `TestResolveTrailUpdateBody_PrefersDetailSnapshot`
- `TestResolveTrailUpdateBody_FallsBackToListBody`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only fix to interactive update prefilling and change detection; reduces risk of accidental description wipes with no server or auth changes.
> 
> **Overview**
> Fixes a data-loss bug in **interactive** `entire trail update`: the Body field was blank because list responses omit description text, and the flow always set `BodyChanged`, so submit could PATCH an empty body and wipe the trail.
> 
> Adds **`resolveTrailUpdateBody`**, which best-effort loads `body_document.text_snapshot` via `fetchTrailDescription` (same pattern as `trail show`), falling back to the list body when detail is missing or empty.
> 
> After the form, **`StatusChanged` / `TitleChanged` / `BodyChanged`** are set only when values differ from the prefilled originals, so unchanged fields are not sent on PATCH.
> 
> Tests cover detail snapshot preference and list-body fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e41e4136bc3797a7ee120bf7881cf65c5106c6a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->