### PR TITLE
fix(trail): surface message IDs in comment show

### DIFF
--- a/cmd/entire/cli/trail_collaboration_cmd_test.go
+++ b/cmd/entire/cli/trail_collaboration_cmd_test.go
@@ -1,9 +1,42 @@
 package cli
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
 )
+
+func TestPrintTrailThreadDetail_ShowsMessageIDs(t *testing.T) {
+	t.Parallel()
+	// edit/delete take <thread-id> <message-id>; the text output must surface
+	// the message and reply IDs so they are discoverable without --json.
+	out := api.TrailThreadDetailResponse{
+		Thread: api.TrailThreadSummary{ID: "th1", Title: "Design"},
+		Messages: []api.TrailThreadMessage{{
+			ID:     "msg-abc",
+			Author: "alice",
+			Body:   "top message",
+			Replies: []api.TrailThreadReply{{
+				ID:     "rep-xyz",
+				Author: "bob",
+				Body:   "a reply",
+			}},
+		}},
+	}
+	var buf bytes.Buffer
+	if err := printTrailThreadDetail(&buf, out, false); err != nil {
+		t.Fatalf("printTrailThreadDetail: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "msg-abc") {
+		t.Errorf("output missing message ID %q:\n%s", "msg-abc", got)
+	}
+	if !strings.Contains(got, "rep-xyz") {
+		t.Errorf("output missing reply ID %q:\n%s", "rep-xyz", got)
+	}
+}
 
 func TestTrailThreadPathBuilders(t *testing.T) {
 	t.Parallel()

--- a/cmd/entire/cli/trail_comment_cmd.go
+++ b/cmd/entire/cli/trail_comment_cmd.go
@@ -195,9 +195,11 @@ func printTrailThreadDetail(w io.Writer, out api.TrailThreadDetailResponse, json
 	}
 	fmt.Fprintf(w, "Thread %s [%s]: %s\n\n", t.ID, marker, t.Title)
 	for _, m := range out.Messages {
-		fmt.Fprintf(w, "%s  %s\n%s\n", m.Author, m.CreatedAt.Format(time.RFC3339), m.Body)
+		// The message ID is the argument `comment edit`/`delete` take, so it
+		// must be visible here (the only plain-text read that shows messages).
+		fmt.Fprintf(w, "%s  %s  %s\n%s\n", m.ID, m.Author, m.CreatedAt.Format(time.RFC3339), m.Body)
 		for _, r := range m.Replies {
-			fmt.Fprintf(w, "  ↳ %s  %s\n  %s\n", r.Author, r.CreatedAt.Format(time.RFC3339), r.Body)
+			fmt.Fprintf(w, "  ↳ %s  %s  %s\n  %s\n", r.ID, r.Author, r.CreatedAt.Format(time.RFC3339), r.Body)
 		}
 		fmt.Fprintln(w)
 	}
@@ -284,6 +286,7 @@ func newTrailCommentEditCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit <thread-id> <message-id>",
 		Short: "Edit a message in a discussion thread",
+		Long:  "Edit a message in a discussion thread.\n\nFind <thread-id> with 'entire trail comment list' and <message-id> with 'entire trail comment show <thread-id>'.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			threadID, messageID := args[0], args[1]
@@ -318,6 +321,7 @@ func newTrailCommentDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <thread-id> <message-id>",
 		Short: "Delete a message from a discussion thread",
+		Long:  "Delete a message from a discussion thread.\n\nFind <thread-id> with 'entire trail comment list' and <message-id> with 'entire trail comment show <thread-id>'.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			threadID, messageID := args[0], args[1]


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/923
<!-- entire-trail-link-end -->

## Problem

`entire trail comment edit`/`delete` take `<thread-id> <message-id>`, but the message ID was reachable only via `comment show --json` or a write command's echo. The default text output of `comment show` printed author/time/body and **omitted the message/reply IDs**, so an agent on a non-interactive terminal could not discover the ID needed to edit or delete a comment.

## Fix

- Print the message and reply IDs in the `comment show` text output.
- Point `comment edit`/`delete` help at `comment list` (thread ID) and `comment show` (message ID) for discovery.

## Tests

- `TestPrintTrailThreadDetail_ShowsMessageIDs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display and help-only changes with no API or auth impact; JSON output is unchanged.
> 
> **Overview**
> **`entire trail comment show`** now prints **message and reply IDs** in the default text output (alongside author and timestamp), so `<message-id>` for `comment edit` / `delete` can be discovered without `--json`.
> 
> **`comment edit`** and **`comment delete`** long help text now points users to **`comment list`** for thread IDs and **`comment show`** for message IDs.
> 
> Adds **`TestPrintTrailThreadDetail_ShowsMessageIDs`** to lock in the new formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d966d3f98409e1f9e5a1a2f54d851a9afa0e300d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->