### PR TITLE
chore(deps): group codeql-action bumps into one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
+    groups:
+      # CodeQL subactions (init, analyze, ...) share one monorepo release and
+      # must move together — a version mismatch fails the CodeQL job with
+      # "Loaded a configuration file for version X, but running version Y".
+      # Grouping bundles every github/codeql-action/* bump into one PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/926
<!-- entire-trail-link-end -->

## Problem

`github/codeql-action` is a monorepo: `init` and `analyze` share a single release SHA and **must run the same version**. Dependabot bumps each subaction in its own PR, so whichever lags fails the CodeQL job:

```
Loaded a configuration file for version '4.37.0', but running version '4.37.3'
```

This has broken CI on multiple codeql dependabot PRs (most recently #1834).

## Fix

Add a `github-actions` dependabot group matching `github/codeql-action*` so every subaction bump lands in a single PR — versions stay in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes Dependabot grouping for GitHub Actions; no runtime or application code is affected.
> 
> **Overview**
> Adds a **Dependabot group** on the `github-actions` ecosystem so all `github/codeql-action*` dependency updates land in **one PR** instead of separate bumps per subaction (`init`, `analyze`, etc.).
> 
> This keeps CodeQL workflow steps on the **same monorepo release**, avoiding CI failures from mismatched versions (e.g. config loaded for one version while the runner uses another).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db46b2530390b6e6d8f16fc557f0825e2df05d7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->