### PR TITLE
fix(e2e): dismiss Droid trust-folder dialog on interactive start

### DIFF
--- a/e2e/agents/droid.go
+++ b/e2e/agents/droid.go
@@ -191,10 +191,33 @@ func (d *Droid) StartSession(ctx context.Context, dir string) (Session, error) {
 		return nil, err
 	}
 
-	// Wait for the interactive prompt indicator.
-	if _, err := s.WaitFor(`>`, 30*time.Second); err != nil {
+	// Dismiss startup dialogs (folder trust, etc.) then wait for the input
+	// prompt. Droid v0.178.0 added a "Trust this folder?" dialog in interactive
+	// mode for untrusted directories. Its "1. Trust this folder" option is
+	// pre-selected, so Enter confirms it. The dialog renders its selected option
+	// as "> 1. Trust this folder", so a bare ">" match cannot distinguish the
+	// dialog from the real input box — we must key off the dialog chrome (see
+	// isDroidStartupDialog) before treating ">" as ready.
+	foundPrompt := false
+	for range 5 {
+		content, err := s.WaitFor(`>`, 30*time.Second)
+		if err != nil {
+			_ = s.Close()
+			return nil, fmt.Errorf("waiting for startup prompt: %w", err)
+		}
+		if !isDroidStartupDialog(content) {
+			foundPrompt = true
+			break
+		}
+		if err := s.SendKeys("Enter"); err != nil {
+			_ = s.Close()
+			return nil, fmt.Errorf("dismissing startup dialog: %w", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if !foundPrompt {
 		_ = s.Close()
-		return nil, fmt.Errorf("waiting for startup prompt: %w", err)
+		return nil, errors.New("droid did not reach interactive prompt after dismissing startup dialogs")
 	}
 
 	// Droid auto-generates a greeting on startup which fires a Stop hook.
@@ -208,4 +231,16 @@ func (d *Droid) StartSession(ctx context.Context, dir string) (Session, error) {
 	s.stableAtSend = ""
 
 	return s, nil
+}
+
+// isDroidStartupDialog reports whether the captured pane is showing a Droid
+// startup dialog (currently the "Trust this folder?" prompt) rather than the
+// interactive input box. The dialog renders its pre-selected option as
+// "> 1. Trust this folder", so the presence of ">" alone cannot distinguish it
+// from the real prompt — we key off the dialog title and footer instead.
+// Matching is case-insensitive to stay resilient to Droid re-casing its copy.
+func isDroidStartupDialog(content string) bool {
+	lower := strings.ToLower(content)
+	return strings.Contains(lower, "trust this folder") ||
+		strings.Contains(lower, "exit without trusting")
 }

--- a/e2e/agents/droid.go
+++ b/e2e/agents/droid.go
@@ -237,7 +237,8 @@ func (d *Droid) StartSession(ctx context.Context, dir string) (Session, error) {
 // startup dialog (currently the "Trust this folder?" prompt) rather than the
 // interactive input box. The dialog renders its pre-selected option as
 // "> 1. Trust this folder", so the presence of ">" alone cannot distinguish it
-// from the real prompt — we key off the dialog title and footer instead.
+// from the real prompt — we key off the dialog title ("trust this folder") and
+// its "exit without trusting" option label instead.
 // Matching is case-insensitive to stay resilient to Droid re-casing its copy.
 func isDroidStartupDialog(content string) bool {
 	lower := strings.ToLower(content)

--- a/e2e/agents/droid_trust_test.go
+++ b/e2e/agents/droid_trust_test.go
@@ -1,0 +1,64 @@
+package agents
+
+import "testing"
+
+// droidTrustDialogPane is a trimmed capture of Droid v0.178.0's interactive
+// "Trust this folder?" startup dialog. The pre-selected option renders as
+// "> 1. Trust this folder", i.e. it uses the same ">" as the real input box —
+// the exact shape that made the old bare-">" WaitFor mistake the dialog for the
+// prompt and swallow the first real prompt.
+const droidTrustDialogPane = `│ Trust this folder?                                                           │
+│                                                                              │
+│ /tmp/e2e-repo-4116086897                                                     │
+│                                                                              │
+│ Droid will read, edit, and run files in this folder, and load any project    │
+│ configuration it defines, including hooks and MCP servers that can execute   │
+│ commands on your machine.                                                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+> 1. Trust this folder
+  2. Exit without trusting
+
+Enter to confirm · Esc to exit`
+
+// droidInteractivePromptPane is the real idle REPL after trust is granted: the
+// input box with a bare ">" and no dialog chrome. This must NOT be classified
+// as a startup dialog.
+const droidInteractivePromptPane = ` Auto (High) · allow all commands           claude-haiku-custom (High) [custom]
+╭──────────────────────────────────────────────────────────────────────────────╮
+│ >                                                                            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+? for help                                                                TMUX ⧉`
+
+// TestIsDroidStartupDialog_DetectsTrustDialog is the regression guard for the
+// Droid v0.178.0 break: the trust dialog must be recognized so StartSession
+// keeps sending Enter to confirm it instead of mistaking "> 1. Trust this
+// folder" for the interactive prompt and sending the first real prompt into a
+// dialog that swallows it.
+func TestIsDroidStartupDialog_DetectsTrustDialog(t *testing.T) {
+	t.Parallel()
+	if !isDroidStartupDialog(droidTrustDialogPane) {
+		t.Fatal("trust dialog should be detected as a startup dialog")
+	}
+}
+
+// TestIsDroidStartupDialog_DetectsByOptionLabel confirms detection keys off the
+// "exit without trusting" option too, so a title-text change in a future Droid
+// release does not silently re-break the handshake.
+func TestIsDroidStartupDialog_DetectsByOptionLabel(t *testing.T) {
+	t.Parallel()
+	const optionOnly = "> 1. Trust folder\n  2. Exit without trusting"
+	if !isDroidStartupDialog(optionOnly) {
+		t.Fatal("the trust dialog's option labels alone should be enough to detect it")
+	}
+}
+
+// TestIsDroidStartupDialog_IgnoresInteractivePrompt ensures the real prompt is
+// not classified as a dialog — otherwise StartSession would loop dismissing a
+// dialog that isn't there and never hand back a usable session.
+func TestIsDroidStartupDialog_IgnoresInteractivePrompt(t *testing.T) {
+	t.Parallel()
+	if isDroidStartupDialog(droidInteractivePromptPane) {
+		t.Fatal("bare interactive prompt should not be classified as a startup dialog")
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/928
<!-- entire-trail-link-end -->

## Why

factoryai-droid e2e was failing consistently (not flaky) — 14 failures =
7 tests × 2 (initial + re-run 1). Droid v0.178.0 added a "Trust this
folder?" startup dialog in interactive mode. Its pre-selected option
renders as `> 1. Trust this folder`, so the bare `WaitFor(">")` in
`StartSession` matched the dialog, declared the session ready, and sent the
first prompt into a dialog that swallowed it.

Only `StartSession`-based tests failed; exec-mode tests pass because
`--skip-permissions-unsafe` bypasses the dialog. All other agents green.

## What

- `StartSession` now dismisses the dialog with an Enter loop (option 1
  pre-selected = trust) before treating `>` as the prompt.
- New `isDroidStartupDialog` keys off dialog chrome so the input box isn't
  misclassified. Mirrors the existing Copilot startup-dialog handling.

## Test plan

- [x] New `isDroidStartupDialog` regression tests (fixtures from real
      v0.178.0 captures) pass
- [x] `golangci-lint` clean, `go build -tags e2e ./e2e/...` + `go vet` clean
- [ ] factoryai-droid e2e green in CI (needs live run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Droid e2e harness startup handshake and unit tests; no production auth or runtime paths.
> 
> **Overview**
> **Droid v0.178.0** shows a **“Trust this folder?”** startup dialog whose selected line also starts with `>`, so `StartSession`’s old `WaitFor(">")` treated the dialog as the REPL and the first test prompt was lost.
> 
> `StartSession` now loops (up to five times): wait for `>`, and if `isDroidStartupDialog` sees trust-dialog copy, send **Enter** (option 1 is pre-selected) before accepting the pane as ready. A clear error is returned if the real prompt never appears. **`isDroidStartupDialog`** uses case-insensitive substring checks on dialog chrome (e.g. “trust this folder”, “exit without trusting”), following the same pattern as Copilot’s `isStartupDialog`.
> 
> **`droid_trust_test.go`** adds fixture-based unit tests so the trust dialog is detected, option labels alone still match, and the idle interactive prompt is not misclassified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daf706901c4578b0ea68f91710d12da08565ceb7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->