### PR TITLE
fix: SessionEnd hooks were cancelled on every exit — sessions never marked ended

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,8 +132,9 @@ Deprecated top-level commands (functional, print a cobra deprecation message):
 deprecation as `checkpoint rewind`).
 
 Hidden infrastructure commands: `hooks`, `trail`,
-`curl-bash-post-install`, `__send_analytics`, `mcp` (MCP stdio server for
-MCP-host agents).
+`curl-bash-post-install`, `__send_analytics`, `__refresh_trail_enablement`,
+`__condense_session` (detached session-end condense child), `mcp` (MCP stdio
+server for MCP-host agents).
 
 The `hideAsAlias(cmd, canonical)` helper in `cmd/entire/cli/aliascmd.go`
 marks a command Hidden and sets cobra's `Deprecated` field so the hint

--- a/cmd/entire/cli/checkpoint_policy_warning.go
+++ b/cmd/entire/cli/checkpoint_policy_warning.go
@@ -25,7 +25,7 @@ func ShouldCheckCheckpointPolicyWarning(cmd *cobra.Command) bool {
 
 func isCheckpointPolicyWarningExcludedCommand(name string) bool {
 	switch name {
-	case "hooks", "__send_analytics", "__refresh_trail_enablement", "curl-bash-post-install":
+	case "hooks", "__send_analytics", "__refresh_trail_enablement", "__condense_session", "curl-bash-post-install":
 		return true
 	default:
 		return false

--- a/cmd/entire/cli/checkpoint_policy_warning_test.go
+++ b/cmd/entire/cli/checkpoint_policy_warning_test.go
@@ -50,9 +50,13 @@ func TestShouldCheckCheckpointPolicyWarning(t *testing.T) {
 	refreshTrailEnablement := &cobra.Command{Use: "__refresh_trail_enablement", Hidden: true}
 	root.AddCommand(refreshTrailEnablement)
 
+	condenseSession := &cobra.Command{Use: "__condense_session", Hidden: true}
+	root.AddCommand(condenseSession)
+
 	require.True(t, ShouldCheckCheckpointPolicyWarning(visible))
 	require.True(t, ShouldCheckCheckpointPolicyWarning(hiddenAlias))
 	require.False(t, ShouldCheckCheckpointPolicyWarning(gitHook))
 	require.False(t, ShouldCheckCheckpointPolicyWarning(sendAnalytics))
 	require.False(t, ShouldCheckCheckpointPolicyWarning(refreshTrailEnablement))
+	require.False(t, ShouldCheckCheckpointPolicyWarning(condenseSession))
 }

--- a/cmd/entire/cli/execx/spawn_detached.go
+++ b/cmd/entire/cli/execx/spawn_detached.go
@@ -2,6 +2,7 @@ package execx
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -13,19 +14,22 @@ import (
 // CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS on Windows, via detachFromTTY).
 // The child runs in dir (os.TempDir() when empty, so the child never holds the
 // parent's working directory), inherits the parent's environment, and has its
-// stdout/stderr discarded. Best-effort: every error is swallowed — callers
-// treat the spawn as advisory background work.
+// stdout/stderr discarded. Best-effort: the spawn is advisory background work
+// and the returned error exists only so callers can log that the child never
+// started (e.g. the running executable was deleted out from under us) — the
+// parent is the last process with working logging, so discarding it leaves no
+// evidence at all.
 //
 // In-process `go test` runs are a no-op: the current executable is the test
 // binary, and re-execing it would fork the whole suite. Tests exercise the
 // call sites through their spawn seams instead.
-func SpawnDetached(dir string, args ...string) {
+func SpawnDetached(dir string, args ...string) error {
 	if testing.Testing() {
-		return
+		return nil
 	}
 	executable, err := os.Executable()
 	if err != nil {
-		return
+		return fmt.Errorf("resolve current executable: %w", err)
 	}
 
 	// context.Background(): the child must outlive the parent, so it is never
@@ -41,9 +45,10 @@ func SpawnDetached(dir string, args ...string) {
 	cmd.Stderr = io.Discard
 
 	if err := cmd.Start(); err != nil {
-		return
+		return fmt.Errorf("start detached child (%v): %w", args, err)
 	}
 	// Release the process so it can run independently of the parent.
 	//nolint:errcheck // best effort — the child continues regardless
 	_ = cmd.Process.Release()
+	return nil
 }

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -229,8 +229,9 @@ func (r *HookRunner) runHookInRepoDir(hookName string, inputJSON []byte) error {
 }
 
 // runHookInRepoDirWithExtraEnv is like runHookInRepoDir but appends additional
-// env vars to the subprocess environment. Used by review-env adoption tests that
-// need ENTIRE_REVIEW_* vars present in the hook child process.
+// env vars to the subprocess environment, for tests that need extra or
+// overriding env vars in the hook child process (exec.Cmd keeps the last
+// value for a duplicated key, so appending overrides).
 func (r *HookRunner) runHookInRepoDirWithExtraEnv(hookName string, inputJSON []byte, extraEnv []string) error {
 	// Run using the shared test binary
 	// Command structure: entire hooks claude-code <hook-name>

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -115,6 +115,10 @@ func (r *HookRunner) SimulateStop(sessionID, transcriptPath string) error {
 
 // SimulateSessionEnd simulates the Claude Code session-end hook.
 // This transitions a session from IDLE (or ACTIVE) to ENDED phase.
+// The eager condense runs inline (TestMain sets ENTIRE_SESSION_END_SYNC
+// process-wide) so assertions that follow are deterministic; use
+// SimulateSessionEndDetached to exercise the production detached-condense
+// flow.
 func (r *HookRunner) SimulateSessionEnd(sessionID string) error {
 	r.T.Helper()
 
@@ -124,6 +128,27 @@ func (r *HookRunner) SimulateSessionEnd(sessionID string) error {
 	}
 
 	return r.runHookWithInput("session-end", input)
+}
+
+// SimulateSessionEndDetached simulates the Claude Code session-end hook with
+// the production behavior: the ENDED mark happens inline and the eager
+// condense is handed to a detached __condense_session child. Callers must
+// poll for the condense outcome.
+func (r *HookRunner) SimulateSessionEndDetached(sessionID string) error {
+	r.T.Helper()
+
+	input := map[string]string{
+		"session_id":      sessionID,
+		"transcript_path": "",
+	}
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return fmt.Errorf("failed to marshal hook input: %w", err)
+	}
+
+	// Override TestMain's process-wide sync forcing back to empty; exec.Cmd
+	// deduplicates the env slice keeping the last value for each key.
+	return r.runHookInRepoDirWithExtraEnv("session-end", inputJSON, []string{"ENTIRE_SESSION_END_SYNC="})
 }
 
 // PreTaskInput contains the input for PreToolUse[Task] hook.
@@ -348,6 +373,13 @@ func (env *TestEnv) SimulateSessionEnd(sessionID string) error {
 	env.T.Helper()
 	runner := NewHookRunner(env.RepoDir, env.ClaudeProjectDir, env.T)
 	return runner.SimulateSessionEnd(sessionID)
+}
+
+// SimulateSessionEndDetached is a convenience method on TestEnv.
+func (env *TestEnv) SimulateSessionEndDetached(sessionID string) error {
+	env.T.Helper()
+	runner := NewHookRunner(env.RepoDir, env.ClaudeProjectDir, env.T)
+	return runner.SimulateSessionEndDetached(sessionID)
 }
 
 // SimulatePreTask is a convenience method on TestEnv.

--- a/cmd/entire/cli/integration_test/session_end_detached_test.go
+++ b/cmd/entire/cli/integration_test/session_end_detached_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/session"
+)
+
+// TestSessionEnd_DetachedCondense exercises the production SessionEnd flow:
+// the hook marks the session ENDED inline (fast enough for agents' short
+// SessionEnd budgets — Claude Code cancels the hook after ~1.5s) and hands
+// the eager condense to a detached __condense_session child that survives
+// the hook process being killed. The ENDED mark must be observable as soon
+// as the hook returns; the condense lands asynchronously.
+func TestSessionEnd_DetachedCondense(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	sess := env.NewSession()
+
+	if err := env.SimulateUserPromptSubmit(sess.ID); err != nil {
+		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+	}
+
+	env.WriteFile("detached.go", "package main\n\nfunc Detached() {}\n")
+	sess.CreateTranscript("Create detached.go", []FileChange{
+		{Path: "detached.go", Content: "package main\n\nfunc Detached() {}\n"},
+	})
+
+	// Commit the file BEFORE stopping so FilesTouched is empty at session end
+	// and the eager condense actually runs (sessions with FilesTouched defer
+	// to PostCommit for carry-forward tracking).
+	env.GitAdd("detached.go")
+	env.GitCommitWithShadowHooks("Add detached.go", "detached.go")
+
+	if err := env.SimulateStop(sess.ID, sess.TranscriptPath); err != nil {
+		t.Fatalf("SimulateStop failed: %v", err)
+	}
+
+	if err := env.SimulateSessionEndDetached(sess.ID); err != nil {
+		t.Fatalf("SimulateSessionEndDetached failed: %v", err)
+	}
+
+	// The ENDED mark is synchronous — it must hold the moment the hook returns.
+	state, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if state == nil {
+		t.Fatal("session state missing after session-end")
+	}
+	if state.Phase != session.PhaseEnded {
+		t.Fatalf("phase = %s immediately after session-end, want ended", state.Phase)
+	}
+	if state.EndedAt == nil {
+		t.Fatal("EndedAt should be set immediately after session-end")
+	}
+
+	// The condense is detached — poll until the child lands it.
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		state, err = env.GetSessionState(sess.ID)
+		if err != nil {
+			t.Fatalf("GetSessionState failed while polling: %v", err)
+		}
+		if state != nil && state.FullyCondensed {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("detached condense did not mark session FullyCondensed within 15s (phase=%s)", state.Phase)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/cmd/entire/cli/integration_test/session_end_detached_test.go
+++ b/cmd/entire/cli/integration_test/session_end_detached_test.go
@@ -11,10 +11,10 @@ import (
 
 // TestSessionEnd_DetachedCondense exercises the production SessionEnd flow:
 // the hook marks the session ENDED inline (fast enough for agents' short
-// SessionEnd budgets — Claude Code cancels the hook after ~1.5s) and hands
-// the eager condense to a detached __condense_session child that survives
-// the hook process being killed. The ENDED mark must be observable as soon
-// as the hook returns; the condense lands asynchronously.
+// SessionEnd budgets — see spawnDetachedSessionEndCondense) and hands the
+// eager condense to a detached __condense_session child that survives the
+// hook process being killed. The ENDED mark must be observable as soon as
+// the hook returns; the condense lands asynchronously.
 func TestSessionEnd_DetachedCondense(t *testing.T) {
 	t.Parallel()
 
@@ -70,6 +70,9 @@ func TestSessionEnd_DetachedCondense(t *testing.T) {
 			break
 		}
 		if time.Now().After(deadline) {
+			if state == nil {
+				t.Fatal("detached condense did not complete within 15s and session state vanished")
+			}
 			t.Fatalf("detached condense did not mark session FullyCondensed within 15s (phase=%s)", state.Phase)
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/cmd/entire/cli/integration_test/setup_test.go
+++ b/cmd/entire/cli/integration_test/setup_test.go
@@ -46,6 +46,12 @@ func TestMain(m *testing.M) {
 		"ENTIRE_TEST_AUTH_STORE_FILE": filepath.Join(tmpDir, "entire-auth-tokens.json"),
 		"GIT_TERMINAL_PROMPT":         "0",
 		testutil.EnvGitHermetic:       "1",
+		// Keep session-end deterministic: the hook normally hands the eager
+		// condense to a detached child (so agents' short SessionEnd budgets
+		// can't kill it), which would race the assertions that follow
+		// SimulateSessionEnd in these tests. The detached flow has its own
+		// dedicated test that overrides this back to empty.
+		"ENTIRE_SESSION_END_SYNC": "1",
 	}
 	for k, v := range isolation {
 		if err := os.Setenv(k, v); err != nil {

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -1020,43 +1020,62 @@ func handleLifecycleSessionEnd(ctx context.Context, ag agent.Agent, event *agent
 	// the transcript to extract file changes. Cleanup is handled by
 	// `entire clean` or when the session state is fully removed.
 
-	// Agents give SessionEnd hooks a short budget and never wait for them on
-	// exit (Claude Code cancels after ~1.5s), so only the fast ENDED mark runs
-	// inline; the eager condense — transcript reads plus git tree building —
-	// is handed to a detached child that survives the hook being killed.
-	// ENTIRE_SESSION_END_SYNC keeps the inline sequence (integration tests
-	// use it for determinism), as does a worktree root that can't be resolved
-	// (nowhere to run the child; dropping the condense would regress #591).
-	worktreeRoot, rootErr := paths.WorktreeRoot(ctx)
+	// Agents give SessionEnd hooks a short budget and do not wait for them on
+	// exit (see spawnDetachedSessionEndCondense for the observed figure), so
+	// only the fast ENDED mark runs inline; the eager condense — transcript
+	// reads plus git tree building — is handed to a detached child that
+	// survives the hook being killed. ENTIRE_SESSION_END_SYNC keeps the
+	// inline sequence (integration tests use it for determinism), as does a
+	// worktree root that can't be resolved (nowhere to run the child;
+	// dropping the condense would regress #591).
+	//
+	// The graceful half of that cancellation is a SIGTERM, which cancels the
+	// root context (see main.go) — the very signal this teardown must
+	// survive. Run the short, bounded finalization on a cancellation-immune
+	// context so the ENDED mark can't be aborted mid-write; a force-quit
+	// (second signal → SIGKILL) still terminates the process outright.
+	endCtx := context.WithoutCancel(ctx)
+	worktreeRoot, rootErr := paths.WorktreeRoot(endCtx)
 	if os.Getenv(envSessionEndSyncCondense) != "" || rootErr != nil {
-		if _, err := endSessionNow(ctx, event, event.SessionID, nil); err != nil {
+		if _, err := endSessionNow(endCtx, event, event.SessionID, nil); err != nil {
 			logging.Warn(logCtx, "failed to mark session ended",
 				slog.String("error", err.Error()))
 		}
 		return nil
 	}
 
-	ended, err := markSessionEnded(ctx, event, event.SessionID, nil)
+	ended, err := markSessionEnded(endCtx, event, event.SessionID, nil)
 	if err != nil {
 		logging.Warn(logCtx, "failed to mark session ended",
 			slog.String("error", err.Error()))
 		return nil
 	}
 	if ended {
-		sessionEndCondenseSpawn(worktreeRoot, event.SessionID)
+		logging.Info(logCtx, "handing session-end condense to detached child",
+			slog.String("session_id", event.SessionID))
+		if spawnErr := sessionEndCondenseSpawn(worktreeRoot, event.SessionID); spawnErr != nil {
+			// Fail-open, but never silent: the session is ENDED with its
+			// condense outstanding, and PostCommit (next commit) or `entire
+			// doctor` are the remaining retry surfaces.
+			logging.Warn(logCtx, "failed to spawn detached session-end condense",
+				slog.String("session_id", event.SessionID),
+				slog.String("error", spawnErr.Error()))
+		}
 	}
 
 	return nil
 }
 
-// endSessionNow runs the canonical "this session is over" sequence: it marks the
-// session ended (firing the SessionStop transition → PhaseEnded + EndedAt) and
-// eagerly condenses its pending work so PostCommit need not. This prevents
+// endSessionNow runs the synchronous "this session is over" sequence: it marks
+// the session ended (firing the SessionStop transition → PhaseEnded + EndedAt)
+// and eagerly condenses its pending work so PostCommit need not. This prevents
 // zombie ENDED sessions from accumulating and causing O(N) overhead on every
-// future commit (GitHub issue #591). It is used by the exited-session sweep
-// (finalizeExitedSessions) and by the SessionEnd hook's synchronous fallback
-// (handleLifecycleSessionEnd, which normally detaches the condense instead),
-// so the two stay in lockstep.
+// future commit (GitHub issue #591). Callers: the exited-session sweep
+// (finalizeExitedSessions — status/doctor have no hook budget, so condensing
+// inline is fine there) and the SessionEnd hook's rarely-taken sync fallback.
+// The normal hook path deliberately does NOT use this sequence: it calls
+// markSessionEnded inline and hands the condense to a detached child — see
+// handleLifecycleSessionEnd.
 //
 // The condense is fail-open (PostCommit retries on the next commit); an error
 // marking the session ended is returned so callers can react, and skips the

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -1020,9 +1020,30 @@ func handleLifecycleSessionEnd(ctx context.Context, ag agent.Agent, event *agent
 	// the transcript to extract file changes. Cleanup is handled by
 	// `entire clean` or when the session state is fully removed.
 
-	if _, err := endSessionNow(ctx, event, event.SessionID, nil); err != nil {
+	// Agents give SessionEnd hooks a short budget and never wait for them on
+	// exit (Claude Code cancels after ~1.5s), so only the fast ENDED mark runs
+	// inline; the eager condense — transcript reads plus git tree building —
+	// is handed to a detached child that survives the hook being killed.
+	// ENTIRE_SESSION_END_SYNC keeps the inline sequence (integration tests
+	// use it for determinism), as does a worktree root that can't be resolved
+	// (nowhere to run the child; dropping the condense would regress #591).
+	worktreeRoot, rootErr := paths.WorktreeRoot(ctx)
+	if os.Getenv(envSessionEndSyncCondense) != "" || rootErr != nil {
+		if _, err := endSessionNow(ctx, event, event.SessionID, nil); err != nil {
+			logging.Warn(logCtx, "failed to mark session ended",
+				slog.String("error", err.Error()))
+		}
+		return nil
+	}
+
+	ended, err := markSessionEnded(ctx, event, event.SessionID, nil)
+	if err != nil {
 		logging.Warn(logCtx, "failed to mark session ended",
 			slog.String("error", err.Error()))
+		return nil
+	}
+	if ended {
+		sessionEndCondenseSpawn(worktreeRoot, event.SessionID)
 	}
 
 	return nil
@@ -1032,9 +1053,10 @@ func handleLifecycleSessionEnd(ctx context.Context, ag agent.Agent, event *agent
 // session ended (firing the SessionStop transition → PhaseEnded + EndedAt) and
 // eagerly condenses its pending work so PostCommit need not. This prevents
 // zombie ENDED sessions from accumulating and causing O(N) overhead on every
-// future commit (GitHub issue #591). It is shared by the SessionStop hook
-// (handleLifecycleSessionEnd) and the exited-session sweep
-// (finalizeExitedSessions), so the two stay in lockstep.
+// future commit (GitHub issue #591). It is used by the exited-session sweep
+// (finalizeExitedSessions) and by the SessionEnd hook's synchronous fallback
+// (handleLifecycleSessionEnd, which normally detaches the condense instead),
+// so the two stay in lockstep.
 //
 // The condense is fail-open (PostCommit retries on the next commit); an error
 // marking the session ended is returned so callers can react, and skips the

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -166,6 +166,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newSendAnalyticsCmd())
 	cmd.AddCommand(newCurlBashPostInstallCmd())
 	cmd.AddCommand(newRefreshTrailEnablementCmd())
+	cmd.AddCommand(newCondenseSessionCmd())
 
 	// Experimental command (developer-only visibility; setup/tune runners).
 	experimental.Register(cmd, newRunnerCmd()) // 'runner' (experimental)

--- a/cmd/entire/cli/session_end_condense.go
+++ b/cmd/entire/cli/session_end_condense.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/entireio/cli/cmd/entire/cli/execx"
@@ -11,26 +12,36 @@ import (
 )
 
 // envSessionEndSyncCondense forces the SessionEnd hook to run the eager
-// condense inline instead of handing it to a detached child. Integration
-// tests set it for determinism; it also serves as an escape hatch when the
-// detached child is undesirable (e.g. debugging).
+// condense inline instead of handing it to a detached child. Any non-empty
+// value enables it (including "0"/"false", matching the ACCESSIBLE
+// convention). Integration tests set it for determinism; it also serves as
+// an escape hatch when the detached child is undesirable (e.g. debugging).
 const envSessionEndSyncCondense = "ENTIRE_SESSION_END_SYNC"
 
 // sessionEndCondenseSpawn is the process-spawn seam used by
-// handleLifecycleSessionEnd. Swapped in tests so they can assert the hook
-// requests a detached condense without forking a real subprocess (a real
-// `go test` binary doesn't understand `__condense_session` as an argument).
-// Production code always uses spawnDetachedSessionEndCondense.
+// handleLifecycleSessionEnd. SpawnDetached is already a no-op under `go test`
+// (see execx.SpawnDetached); this seam exists so unit tests can record that a
+// detached condense was requested, and with which arguments. Production code
+// always uses spawnDetachedSessionEndCondense.
 var sessionEndCondenseSpawn = spawnDetachedSessionEndCondense
 
 // spawnDetachedSessionEndCondense starts `entire __condense_session <id>` as
 // a detached child so the eager condense survives the SessionEnd hook being
-// cancelled (agents give these hooks a short budget — Claude Code cancels
-// after ~1.5s — and never wait for them on exit). The child runs from the
-// worktree root because the strategy resolves the repo and session store
-// from its working directory.
-func spawnDetachedSessionEndCondense(worktreeRoot, sessionID string) {
-	execx.SpawnDetached(worktreeRoot, "__condense_session", sessionID)
+// cancelled. Agents give SessionEnd hooks a short budget and do not wait for
+// them on exit — empirically ~1.5s for Claude Code (v2.1.x, observed 2026-07;
+// undocumented, so treat the figure as approximate). Other comments reference
+// this one rather than restating the number. The child runs from the worktree
+// root because the strategy resolves the repo and session store from its
+// working directory.
+//
+// The returned error means the child never started (e.g. the local-dev cache
+// binary was deleted between exec and spawn); callers stay fail-open but must
+// log it — the parent is the last process with working logging.
+func spawnDetachedSessionEndCondense(worktreeRoot, sessionID string) error {
+	if err := execx.SpawnDetached(worktreeRoot, "__condense_session", sessionID); err != nil {
+		return fmt.Errorf("spawn detached session-end condense: %w", err)
+	}
+	return nil
 }
 
 // newCondenseSessionCmd creates the hidden command that runs the eager
@@ -49,7 +60,8 @@ func newCondenseSessionCmd() *cobra.Command {
 			// .entire/logs/entire.log rather than vanishing. Guard on
 			// WorktreeRoot first — matching __refresh_trail_enablement — so a
 			// child whose worktree was removed between spawn and exec doesn't
-			// create a stray .entire/logs/ in an arbitrary directory.
+			// create a stray .entire/logs/ in an arbitrary directory
+			// (logging.Init falls back to cwd when WorktreeRoot fails).
 			if _, err := paths.WorktreeRoot(ctx); err == nil {
 				logging.SetLogLevelGetter(GetLogLevel)
 				if err := logging.Init(ctx, ""); err == nil {
@@ -59,8 +71,11 @@ func newCondenseSessionCmd() *cobra.Command {
 			sessionID := args[0]
 			if err := GetStrategy(ctx).CondenseAndMarkFullyCondensed(ctx, sessionID); err != nil {
 				// Fail-open, like the inline condense it replaces: PostCommit
-				// retries on the next commit and the exited-session sweep
-				// retries from status/doctor.
+				// retries on the next commit, and `entire doctor` detects and
+				// offers to condense stuck ended sessions. (The exited-session
+				// sweep does NOT cover this — it only finalizes ACTIVE
+				// sessions whose owner died, and this session is already
+				// ENDED.)
 				logging.Warn(logging.WithComponent(ctx, "lifecycle"),
 					"detached session-end condense failed",
 					slog.String("session_id", sessionID),

--- a/cmd/entire/cli/session_end_condense.go
+++ b/cmd/entire/cli/session_end_condense.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"log/slog"
+
+	"github.com/entireio/cli/cmd/entire/cli/execx"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+
+	"github.com/spf13/cobra"
+)
+
+// envSessionEndSyncCondense forces the SessionEnd hook to run the eager
+// condense inline instead of handing it to a detached child. Integration
+// tests set it for determinism; it also serves as an escape hatch when the
+// detached child is undesirable (e.g. debugging).
+const envSessionEndSyncCondense = "ENTIRE_SESSION_END_SYNC"
+
+// sessionEndCondenseSpawn is the process-spawn seam used by
+// handleLifecycleSessionEnd. Swapped in tests so they can assert the hook
+// requests a detached condense without forking a real subprocess (a real
+// `go test` binary doesn't understand `__condense_session` as an argument).
+// Production code always uses spawnDetachedSessionEndCondense.
+var sessionEndCondenseSpawn = spawnDetachedSessionEndCondense
+
+// spawnDetachedSessionEndCondense starts `entire __condense_session <id>` as
+// a detached child so the eager condense survives the SessionEnd hook being
+// cancelled (agents give these hooks a short budget — Claude Code cancels
+// after ~1.5s — and never wait for them on exit). The child runs from the
+// worktree root because the strategy resolves the repo and session store
+// from its working directory.
+func spawnDetachedSessionEndCondense(worktreeRoot, sessionID string) {
+	execx.SpawnDetached(worktreeRoot, "__condense_session", sessionID)
+}
+
+// newCondenseSessionCmd creates the hidden command that runs the eager
+// session-end condense out of band. It is invoked by
+// spawnDetachedSessionEndCondense from a detached subprocess and should not
+// be called directly.
+func newCondenseSessionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "__condense_session <session-id>",
+		Hidden: true,
+		Args:   cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			// Detached child with discarded stdout/stderr: initialize file
+			// logging so a failing condense is diagnosable in
+			// .entire/logs/entire.log rather than vanishing. Guard on
+			// WorktreeRoot first — matching __refresh_trail_enablement — so a
+			// child whose worktree was removed between spawn and exec doesn't
+			// create a stray .entire/logs/ in an arbitrary directory.
+			if _, err := paths.WorktreeRoot(ctx); err == nil {
+				logging.SetLogLevelGetter(GetLogLevel)
+				if err := logging.Init(ctx, ""); err == nil {
+					defer logging.Close()
+				}
+			}
+			sessionID := args[0]
+			if err := GetStrategy(ctx).CondenseAndMarkFullyCondensed(ctx, sessionID); err != nil {
+				// Fail-open, like the inline condense it replaces: PostCommit
+				// retries on the next commit and the exited-session sweep
+				// retries from status/doctor.
+				logging.Warn(logging.WithComponent(ctx, "lifecycle"),
+					"detached session-end condense failed",
+					slog.String("session_id", sessionID),
+					slog.String("error", err.Error()))
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/entire/cli/session_end_condense_test.go
+++ b/cmd/entire/cli/session_end_condense_test.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// swapSessionEndCondenseSpawn replaces the detached-condense spawn seam with a
+// recorder and restores it on cleanup. Tests using it must not run in parallel
+// (package-level seam).
+func swapSessionEndCondenseSpawn(t *testing.T) *[]string {
+	t.Helper()
+	var spawned []string
+	orig := sessionEndCondenseSpawn
+	sessionEndCondenseSpawn = func(_, sessionID string) {
+		spawned = append(spawned, sessionID)
+	}
+	t.Cleanup(func() { sessionEndCondenseSpawn = orig })
+	return &spawned
+}
+
+func saveIdleSessionForEndTest(t *testing.T, sessionID string) {
+	t.Helper()
+	state := &strategy.SessionState{
+		SessionID:  sessionID,
+		BaseCommit: "abc123",
+		StartedAt:  time.Now(),
+		Phase:      session.PhaseIdle,
+	}
+	require.NoError(t, strategy.SaveSessionState(context.Background(), state))
+}
+
+// TestHandleLifecycleSessionEnd_SpawnsDetachedCondense verifies the SessionEnd
+// hook path marks the session ended in-process (fast, within the agent's hook
+// budget) and defers the eager condense to a detached child instead of running
+// it inline.
+func TestHandleLifecycleSessionEnd_SpawnsDetachedCondense(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	const sessionID = "test-session-end-detach"
+	saveIdleSessionForEndTest(t, sessionID)
+	spawned := swapSessionEndCondenseSpawn(t)
+
+	event := &agent.Event{Type: agent.SessionEnd, SessionID: sessionID}
+	require.NoError(t, handleLifecycleSessionEnd(context.Background(), newMockAgent(), event))
+
+	loaded, err := strategy.LoadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, session.PhaseEnded, loaded.Phase,
+		"session must be marked ENDED synchronously")
+	assert.False(t, loaded.FullyCondensed,
+		"condense must not run inline on the hook path")
+	assert.Equal(t, []string{sessionID}, *spawned,
+		"exactly one detached condense must be requested for the ended session")
+}
+
+// TestHandleLifecycleSessionEnd_SyncEnvCondensesInline verifies the
+// ENTIRE_SESSION_END_SYNC escape hatch keeps the pre-detach synchronous
+// behavior (used by integration tests for determinism).
+func TestHandleLifecycleSessionEnd_SyncEnvCondensesInline(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	t.Setenv(envSessionEndSyncCondense, "1")
+
+	const sessionID = "test-session-end-sync"
+	saveIdleSessionForEndTest(t, sessionID)
+	spawned := swapSessionEndCondenseSpawn(t)
+
+	event := &agent.Event{Type: agent.SessionEnd, SessionID: sessionID}
+	require.NoError(t, handleLifecycleSessionEnd(context.Background(), newMockAgent(), event))
+
+	loaded, err := strategy.LoadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, session.PhaseEnded, loaded.Phase)
+	assert.True(t, loaded.FullyCondensed,
+		"sync mode must condense inline (StepCount 0 → marked fully condensed)")
+	assert.Empty(t, *spawned, "sync mode must not spawn a detached condense")
+}
+
+// TestHandleLifecycleSessionEnd_NoSpawnWhenSessionMissing verifies no detached
+// child is forked when there is no session to condense.
+func TestHandleLifecycleSessionEnd_NoSpawnWhenSessionMissing(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	spawned := swapSessionEndCondenseSpawn(t)
+
+	event := &agent.Event{Type: agent.SessionEnd, SessionID: "no-such-session"}
+	require.NoError(t, handleLifecycleSessionEnd(context.Background(), newMockAgent(), event))
+
+	assert.Empty(t, *spawned, "no detached condense for a session that was never tracked")
+}
+
+// TestCondenseSessionCmd_MarksFullyCondensed verifies the hidden
+// __condense_session command runs the eager condense for an ended session.
+func TestCondenseSessionCmd_MarksFullyCondensed(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	const sessionID = "test-condense-session-cmd"
+	now := time.Now()
+	state := &strategy.SessionState{
+		SessionID:  sessionID,
+		BaseCommit: "abc123",
+		StartedAt:  now,
+		Phase:      session.PhaseEnded,
+		EndedAt:    &now,
+	}
+	require.NoError(t, strategy.SaveSessionState(context.Background(), state))
+
+	cmd := newCondenseSessionCmd()
+	cmd.SetArgs([]string{sessionID})
+	require.NoError(t, cmd.ExecuteContext(context.Background()))
+
+	loaded, err := strategy.LoadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.True(t, loaded.FullyCondensed,
+		"__condense_session must condense the ended session (StepCount 0 → fully condensed)")
+}
+
+// TestCondenseSessionCmd_MissingSessionIsFailOpen verifies the detached child
+// never errors on a session that disappeared between spawn and exec.
+func TestCondenseSessionCmd_MissingSessionIsFailOpen(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	cmd := newCondenseSessionCmd()
+	cmd.SetArgs([]string{"gone-session"})
+	assert.NoError(t, cmd.ExecuteContext(context.Background()))
+}

--- a/cmd/entire/cli/session_end_condense_test.go
+++ b/cmd/entire/cli/session_end_condense_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -13,15 +14,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// spawnCall records one request to the detached-condense spawn seam.
+type spawnCall struct {
+	worktreeRoot string
+	sessionID    string
+}
+
 // swapSessionEndCondenseSpawn replaces the detached-condense spawn seam with a
 // recorder and restores it on cleanup. Tests using it must not run in parallel
 // (package-level seam).
-func swapSessionEndCondenseSpawn(t *testing.T) *[]string {
+func swapSessionEndCondenseSpawn(t *testing.T) *[]spawnCall {
 	t.Helper()
-	var spawned []string
+	var spawned []spawnCall
 	orig := sessionEndCondenseSpawn
-	sessionEndCondenseSpawn = func(_, sessionID string) {
-		spawned = append(spawned, sessionID)
+	sessionEndCondenseSpawn = func(worktreeRoot, sessionID string) error {
+		spawned = append(spawned, spawnCall{worktreeRoot: worktreeRoot, sessionID: sessionID})
+		return nil
 	}
 	t.Cleanup(func() { sessionEndCondenseSpawn = orig })
 	return &spawned
@@ -60,8 +68,32 @@ func TestHandleLifecycleSessionEnd_SpawnsDetachedCondense(t *testing.T) {
 		"session must be marked ENDED synchronously")
 	assert.False(t, loaded.FullyCondensed,
 		"condense must not run inline on the hook path")
-	assert.Equal(t, []string{sessionID}, *spawned,
+	require.Len(t, *spawned, 1,
 		"exactly one detached condense must be requested for the ended session")
+	assert.Equal(t, sessionID, (*spawned)[0].sessionID)
+	// The child resolves the repo and session store from its working
+	// directory, so spawning anywhere but the worktree root would make the
+	// condense a silent no-op in the wrong place.
+	wantRoot, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	gotRoot, err := filepath.EvalSymlinks((*spawned)[0].worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantRoot, gotRoot, "child must be spawned from the worktree root")
+}
+
+// TestHandleLifecycleSessionEnd_NoRepoFallsBackToSync verifies that when the
+// worktree root can't be resolved there is nowhere to run the child, so the
+// handler takes the synchronous endSessionNow path instead of spawning —
+// dropping the condense silently would regress #591.
+func TestHandleLifecycleSessionEnd_NoRepoFallsBackToSync(t *testing.T) {
+	t.Chdir(t.TempDir()) // plain directory, not a git repo
+
+	spawned := swapSessionEndCondenseSpawn(t)
+
+	event := &agent.Event{Type: agent.SessionEnd, SessionID: "some-session"}
+	require.NoError(t, handleLifecycleSessionEnd(context.Background(), newMockAgent(), event))
+
+	assert.Empty(t, *spawned, "no detached condense without a resolvable worktree root")
 }
 
 // TestHandleLifecycleSessionEnd_SyncEnvCondensesInline verifies the

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -750,6 +750,82 @@ func TestEntireDevScript_ExitsZeroWhenNothingAvailable(t *testing.T) {
 	}
 }
 
+// TestEntireDevScript_RunsCachedBinaryAndPassesExitStatus verifies the launch
+// contract of the cached-binary flow: the CLI's own exit status and output
+// pass through verbatim (the script must not mask failures as its own or
+// swallow successes into a fallback), on repeat invocations too. (The speed
+// property — rebuilding onto the same output path skips the full relink — is
+// a go toolchain behavior we don't assert on; go rewrites the output file
+// even when nothing changed, so file metadata can't witness the reuse.)
+func TestEntireDevScript_RunsCachedBinaryAndPassesExitStatus(t *testing.T) {
+	t.Parallel()
+
+	shPath := requireShell(t)
+
+	root := t.TempDir()
+	scriptPath := filepath.Join(root, "scripts", "entire-dev")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatalf("failed to create scripts dir: %v", err)
+	}
+	if err := os.WriteFile(scriptPath, []byte(readEntireDevScript(t)), 0o755); err != nil {
+		t.Fatalf("failed to write script: %v", err)
+	}
+
+	// Buildable fake CLI: echoes its args and exits 3, so both the output and
+	// the non-zero status must survive the launcher.
+	mainDir := filepath.Join(root, "cmd", "entire")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatalf("failed to create cmd/entire: %v", err)
+	}
+	mainGo := "package main\n\nimport (\n\t\"fmt\"\n\t\"os\"\n\t\"strings\"\n)\n\nfunc main() {\n\tfmt.Println(strings.Join(os.Args[1:], \" \"))\n\tos.Exit(3)\n}\n"
+	if err := os.WriteFile(filepath.Join(mainDir, "main.go"), []byte(mainGo), 0o644); err != nil {
+		t.Fatalf("failed to write main.go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module fake\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+	// Pre-create the cache dir so the test doesn't depend on mkdir being on
+	// the deliberately minimal PATH.
+	if err := os.MkdirAll(filepath.Join(root, ".entire", "tmp"), 0o755); err != nil {
+		t.Fatalf("failed to create cache dir: %v", err)
+	}
+
+	run := func() (string, int) {
+		t.Helper()
+		cmd := exec.CommandContext(context.Background(), shPath, scriptPath, "hooks", "git", "post-commit")
+		cmd.Env = envWithPath(goBinDir(t))
+		out, err := cmd.CombinedOutput()
+		var exitErr *exec.ExitError
+		switch {
+		case err == nil:
+			return string(out), 0
+		case errors.As(err, &exitErr):
+			return string(out), exitErr.ExitCode()
+		default:
+			t.Fatalf("script failed to run: %v\n%s", err, out)
+			return "", 0
+		}
+	}
+
+	out, code := run()
+	if code != 3 {
+		t.Fatalf("exit status must pass through verbatim, want 3 got %d\noutput:\n%s", code, out)
+	}
+	if !strings.Contains(out, "hooks git post-commit") {
+		t.Fatalf("args must be forwarded to the cached binary verbatim, got:\n%s", out)
+	}
+
+	bin := filepath.Join(root, ".entire", "tmp", "entire-dev-bin")
+	if _, err := os.Stat(bin); err != nil {
+		t.Fatalf("cached binary missing after first run: %v", err)
+	}
+
+	out, code = run()
+	if code != 3 || !strings.Contains(out, "hooks git post-commit") {
+		t.Fatalf("second run must behave identically, got status %d output:\n%s", code, out)
+	}
+}
+
 func TestInstallGitHook_AbsoluteGitHookPath(t *testing.T) {
 	_, hooksDir := initHooksTestRepo(t)
 

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1301,6 +1301,21 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 	var shadowBranchName string
 	var didCondense bool
 	mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+		// Only ENDED sessions are eligible. The detached session-end child can
+		// lose a race with a same-ID resume (ENDED → IDLE/ACTIVE revival is a
+		// legal transition), and condensing a revived session would wipe its
+		// in-flight prompt attribution, reset the checkpoint window mid-turn,
+		// and leave a stale FullyCondensed=true that makes PostCommit skip the
+		// session's next end. Re-checking under the state lock closes that
+		// window for every caller.
+		if state.Phase != session.PhaseEnded {
+			logging.Info(logCtx, "eager condense: session no longer ended, skipping",
+				slog.String("session_id", sessionID),
+				slog.String("phase", string(state.Phase)),
+			)
+			return ErrMutationSkip
+		}
+
 		// Sessions with FilesTouched must be processed by PostCommit for
 		// carry-forward tracking — each user commit that overlaps with
 		// tracked files gets its own checkpoint. Eagerly condensing here

--- a/cmd/entire/cli/strategy/phase_wiring_test.go
+++ b/cmd/entire/cli/strategy/phase_wiring_test.go
@@ -403,6 +403,35 @@ func TestCondenseAndMarkFullyCondensed_Guards(t *testing.T) {
 		assert.Equal(t, session.PhaseEnded, state.Phase)
 	})
 
+	t.Run("reactivated session is a no-op", func(t *testing.T) {
+		// The detached session-end child can lose a race with a same-ID
+		// resume; condensing a revived session would wipe its in-flight
+		// attribution and leave a sticky FullyCondensed=true that makes
+		// PostCommit skip the session's next end.
+		dir := setupGitRepo(t)
+		t.Chdir(dir)
+
+		s := &ManualCommitStrategy{}
+		require.NoError(t, s.InitializeSession(context.Background(), "test-session", "Claude Code", "", "", ""))
+
+		state, err := s.loadSessionState(context.Background(), "test-session")
+		require.NoError(t, err)
+		state.Phase = session.PhaseActive // revived after the ENDED mark
+		state.StepCount = 3
+		state.FilesTouched = nil
+		require.NoError(t, s.saveSessionState(context.Background(), state))
+
+		require.NoError(t, s.CondenseAndMarkFullyCondensed(context.Background(), "test-session"))
+
+		state, err = s.loadSessionState(context.Background(), "test-session")
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		assert.False(t, state.FullyCondensed,
+			"a session that is no longer ENDED must not be condensed")
+		assert.Equal(t, 3, state.StepCount, "pending steps must be left for PostCommit")
+		assert.Equal(t, session.PhaseActive, state.Phase)
+	})
+
 	t.Run("with FilesTouched is a no-op", func(t *testing.T) {
 		dir := setupGitRepo(t)
 		t.Chdir(dir)

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -90,7 +90,8 @@ func BuildEventPayload(cmd *cobra.Command, agent string, isEntireEnabled bool, v
 // __send_analytics` child so the network call never blocks the CLI. The empty
 // dir keeps the child out of the parent's working directory.
 func spawnDetachedAnalytics(payloadJSON string) {
-	execx.SpawnDetached("", "__send_analytics", payloadJSON)
+	// Analytics are strictly best-effort; a lost event is not worth logging.
+	_ = execx.SpawnDetached("", "__send_analytics", payloadJSON) //nolint:errcheck // fire-and-forget analytics
 }
 
 // TrackCommandDetached tracks a command execution by spawning a detached subprocess.

--- a/cmd/entire/cli/trail_context_cache.go
+++ b/cmd/entire/cli/trail_context_cache.go
@@ -325,7 +325,9 @@ var trailRefreshSpawn = spawnDetachedTrailRefreshProcess
 // worktree root because the refresh resolves the origin remote and
 // git-common-dir for cache storage from its working directory.
 func spawnDetachedTrailRefreshProcess(worktreeRoot string) {
-	execx.SpawnDetached(worktreeRoot, "__refresh_trail_enablement")
+	// A failed spawn just means the cache stays unknown and the next
+	// SessionStart tries again — nothing here to react to.
+	_ = execx.SpawnDetached(worktreeRoot, "__refresh_trail_enablement") //nolint:errcheck // advisory refresh, retried next SessionStart
 }
 
 // trailRefreshSpawnThrottle bounds how often SessionStart forks a detached

--- a/scripts/entire-dev
+++ b/scripts/entire-dev
@@ -1,18 +1,23 @@
 #!/bin/sh
 # Entire CLI local-development hook launcher.
 #
-# In local-dev mode, Entire hooks invoke the CLI straight from source via
-# "go run", which recompiles on demand. When the tree does not compile (for
-# example while an agent is resolving a merge conflict) "go run" fails and the
-# hook would silently do nothing. This launcher first checks that the tree
-# builds; if it does it runs the freshly compiled CLI, otherwise it falls back
-# to an "entire" binary on PATH. If neither is available it exits 0 so it never
-# blocks the surrounding git or agent operation.
+# In local-dev mode, Entire hooks invoke the CLI built straight from source.
+# The binary is cached under .entire/tmp/ (ignored via the committed
+# .entire/.gitignore) and "go build" only relinks it when the source changed,
+# so an up-to-date tree costs one staleness check instead of a full link.
+# This matters for hooks with a tight deadline — Claude Code gives SessionEnd
+# hooks only ~1.5s before cancelling them, which the previous
+# probe-then-"go run" flow (a full link per invocation) could not meet.
+#
+# When the tree does not compile (for example while an agent is resolving a
+# merge conflict) the build fails and this launcher falls back to an "entire"
+# binary on PATH. If neither is available it exits 0 so it never blocks the
+# surrounding git or agent operation.
 #
 # Usage: scripts/entire-dev <entire args...>
 #
-# All local-dev hooks delegate here so the build-probe-and-fallback logic lives
-# in one place rather than being duplicated across generated hook commands.
+# All local-dev hooks delegate here so the build-and-fallback logic lives in
+# one place rather than being duplicated across generated hook commands.
 
 set -eu
 
@@ -31,16 +36,21 @@ case "$0" in
 	*) script_dir=. ;;
 esac
 root=$(CDPATH= cd -- "$script_dir/.." && pwd)
-# Build/run the whole cmd/entire package, not just main.go: package main is
+# Build the whole cmd/entire package, not just main.go: package main is
 # split across multiple files (e.g. the git-remote-entire dispatch in
 # remotehelper.go), and naming a single file would leave the others out and
 # fail to compile.
 pkg="$root/cmd/entire"
 
-# Run freshly compiled code when the tree builds. The build probe populates the
-# build cache, so the subsequent "go run" does not recompile from scratch.
-if command -v go >/dev/null 2>&1 && go build -o /dev/null "$pkg" >/dev/null 2>&1; then
-	exec go run "$pkg" "$@"
+# Build (incrementally) into the per-worktree cache and run the result.
+# "entire clean" may remove .entire/tmp/, which just costs one rebuild.
+# Concurrent hook invocations can race the rebuild of a stale binary; a
+# failed build here simply falls through to the PATH binary.
+bin="$root/.entire/tmp/entire-dev-bin"
+if command -v go >/dev/null 2>&1 &&
+	mkdir -p "${bin%/*}" 2>/dev/null &&
+	go build -o "$bin" "$pkg" >/dev/null 2>&1; then
+	exec "$bin" "$@"
 fi
 
 # The tree does not build (or Go is unavailable): fall back to the installed

--- a/scripts/entire-dev
+++ b/scripts/entire-dev
@@ -3,11 +3,13 @@
 #
 # In local-dev mode, Entire hooks invoke the CLI built straight from source.
 # The binary is cached under .entire/tmp/ (ignored via the committed
-# .entire/.gitignore) and "go build" only relinks it when the source changed,
-# so an up-to-date tree costs one staleness check instead of a full link.
-# This matters for hooks with a tight deadline — Claude Code gives SessionEnd
-# hooks only ~1.5s before cancelling them, which the previous
-# probe-then-"go run" flow (a full link per invocation) could not meet.
+# .entire/.gitignore): rebuilding onto the same output path lets go skip the
+# full relink when the source is unchanged (measured ~0.5s vs ~1.3s — note
+# go still rewrites the output file either way). This matters for hooks with
+# a tight deadline — agents cancel SessionEnd hooks after a short (~1-2s)
+# budget (see spawnDetachedSessionEndCondense in
+# cmd/entire/cli/session_end_condense.go), which the previous
+# probe-then-"go run" flow (two full links per invocation) could not meet.
 #
 # When the tree does not compile (for example while an agent is resolving a
 # merge conflict) the build fails and this launcher falls back to an "entire"
@@ -39,27 +41,56 @@ root=$(CDPATH= cd -- "$script_dir/.." && pwd)
 # Build the whole cmd/entire package, not just main.go: package main is
 # split across multiple files (e.g. the git-remote-entire dispatch in
 # remotehelper.go), and naming a single file would leave the others out and
-# fail to compile.
-pkg="$root/cmd/entire"
+# fail to compile. The path is relative and paired with "go build -C $root":
+# an absolute package path would be resolved against the *caller's* module
+# (go interprets directory arguments relative to the current module), which
+# breaks when the hook is invoked from outside this repo.
+pkg="./cmd/entire"
 
 # Build (incrementally) into the per-worktree cache and run the result.
 # "entire clean" may remove .entire/tmp/, which just costs one rebuild.
-# Concurrent hook invocations can race the rebuild of a stale binary; a
-# failed build here simply falls through to the PATH binary.
+# Because go rewrites the output in place on every build, a concurrent
+# invocation can be mid-rewrite while this one launches (handled below via
+# the 126/127 fallback), and a still-running detached child of a previous
+# hook can be killed on macOS when its executable is rewritten under it —
+# fail-open either way (PostCommit retries any lost condense).
+# Build stderr goes to a log file, not the hook's stderr: compiler spew would
+# pollute agent-visible output, but discarding it entirely would leave
+# "build failed" undiagnosable.
 bin="$root/.entire/tmp/entire-dev-bin"
-if command -v go >/dev/null 2>&1 &&
-	mkdir -p "${bin%/*}" 2>/dev/null &&
-	go build -o "$bin" "$pkg" >/dev/null 2>&1; then
-	exec "$bin" "$@"
+if command -v go >/dev/null 2>&1; then
+	# mkdir may be absent from a minimal hook PATH; if the cache dir can't be
+	# created, go build fails to write its output and we fall back below.
+	mkdir -p "${bin%/*}" 2>/dev/null || true
+	buildlog="${bin%/*}/entire-dev-build.log"
+	[ -d "${bin%/*}" ] || buildlog=/dev/null
+	if go build -C "$root" -o "$bin" "$pkg" >/dev/null 2>"$buildlog"; then
+		# Run without exec: a concurrent invocation can be rewriting $bin
+		# (go's output install is not atomic on every filesystem), and a
+		# failed exec would abort this shell without reaching the fallbacks
+		# below, breaking the never-block contract. Launch failures surface
+		# as 126/127; anything else is the CLI's own exit status and is
+		# passed through.
+		status=0
+		"$bin" "$@" || status=$?
+		if [ "$status" -ne 126 ] && [ "$status" -ne 127 ]; then
+			exit "$status"
+		fi
+		log "cached binary failed to launch (status $status, concurrent rebuild?)"
+	else
+		log "go build failed (details: $buildlog)"
+	fi
+else
+	log "go not found on PATH"
 fi
 
-# The tree does not build (or Go is unavailable): fall back to the installed
-# binary so hooks keep working while the source is broken.
+# The tree does not build (or the cached binary couldn't run): fall back to
+# the installed binary so hooks keep working while the source is broken.
 if command -v entire >/dev/null 2>&1; then
-	log "project isn't compiling; falling back to the entire binary on PATH"
+	log "falling back to the entire binary on PATH ($(command -v entire))"
 	exec entire "$@"
 fi
 
 # Nothing to run: do not block the surrounding operation.
-log "project isn't compiling and no entire binary on PATH; skipping hook"
+log "no entire binary on PATH; skipping hook"
 exit 0


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/931
<!-- entire-trail-link-end -->

## Why

Claude Code gives SessionEnd hooks a short budget (~1.5s) and never waits for them on exit. Our hook blew that budget two ways at once, so **every session exit since 2026-05-29 printed `SessionEnd hook failed: Hook cancelled` and no session was ever marked ended**:

- `.entire` logs: 117 successful `session-end` events Feb–May, zero after May 29
- Real sessions sat `idle` with `ended_at: null` for days (e.g. the "45 hours" / "177 hours" durations on entire.io session pages), then got silently deleted by the 7-day stale sweep without ever reporting an end
- Timing lined up with 0ef509db (2026-05-27), which added a `go build -o /dev/null` probe to `scripts/entire-dev` — that output path defeats go's up-to-date short-circuit, forcing a **full link on every hook invocation** (~1.3s warm) before `go run` linked again

## What

**Commit 1 — `scripts/entire-dev`: cache the local-dev binary.** Build into `.entire/tmp/entire-dev-bin` (ignored via the committed `.entire/.gitignore`) and run it. Reusing the same output path lets go skip the full relink when the source is unchanged (~0.5s vs ~1.3s — note go still rewrites the output file every build; VCS stamping defeats the full up-to-date skip); the fake session-end round trip drops 1.66s → 0.91s. Stop/turn-end hooks re-warm the cache during the session, so SessionEnd almost always hits the warm path. Fallback semantics unchanged: broken tree → PATH binary → exit 0.

**Commit 2 — lifecycle: split the SessionEnd handler along its natural line.** The ENDED mark (a locked state-file write carrying hook event metadata, milliseconds) stays inline; the eager condense (transcript reads + git tree building, seconds) moves to a detached `__condense_session` child spawned via `execx.SpawnDetached` — the existing `__refresh_trail_enablement` pattern — which survives the hook process being killed.

The condense itself is unchanged: same `CondenseAndMarkFullyCondensed`, same fail-open + retry semantics (PostCommit on the next commit; `entire doctor` detects stuck ended sessions), same backend routing (git-branch or git-refs primary + mirrors), run from the worktree root so config resolution matches the inline call. The #591 protection (eager condense on end) is preserved — just relocated. The sweep keeps its synchronous condense.

`ENTIRE_SESSION_END_SYNC` forces the old inline sequence; the integration TestMain sets it process-wide so existing session-end assertions stay deterministic, and a dedicated integration test exercises the real detached flow by overriding it back to empty.

**Commit 3 — review findings** (four specialized review agents + Copilot + Cursor Bugbot; all findings addressed):

- `CondenseAndMarkFullyCondensed` re-checks `Phase == ENDED` under the state lock — the detached child can lose a race with a same-ID resume, and condensing a revived session would wipe in-flight attribution and leave a sticky `FullyCondensed=true` (flagged independently by three reviewers + Bugbot; guarded by a new subtest that fails without the fix)
- SessionEnd teardown runs on `context.WithoutCancel` — the graceful half of hook cancellation is a SIGTERM, which cancels the root context; the ENDED mark must survive it (Copilot)
- `scripts/entire-dev` runs the cached binary without `exec` and falls back to the PATH binary on launch failure (126/127) — go rewrites the output in place on every build, and a failed `exec` previously aborted the shell before any fallback, breaking the never-block contract. Also: `go build -C` (an absolute package path resolves against the *caller's* module — latent pre-existing bug), per-cause fallback messages, and build stderr captured to `.entire/tmp/entire-dev-build.log` instead of discarded
- `execx.SpawnDetached` returns the start error and the hook logs the handoff + any spawn failure — a silently failed spawn previously left zero evidence a condense was ever requested
- Comment/doc corrections (the exited-session sweep cannot retry ENDED sessions; single-sourced the observed ~1.5s budget; corrected the binary-reuse mechanism) and test additions (launcher exit-status passthrough contract, rootErr sync fallback, seam records the worktree root, `__condense_session` in the policy-warning table)

## Verification

- 8,309 unit / 438 integration (incl. #591 regression test) / 63 e2e canary — all green, re-run after the review round
- Live end-to-end: real headless Claude session in the worktree → no warning, `phase: ended`, real `ended_at`, `fully_condensed: true` via the detached child — the first real session-end to complete in this repo since May 29
- Interactive end-to-end: fresh `claude` session, `/exit` → clean exit (no cancelled-hook warning), session marked ended at the actual exit moment; condense correctly deferred to commit-time because the session had touched files

## Notes / follow-ups (not in this PR)

- Ctrl-C double-tap force-quit still cancels SessionEnd hooks regardless of speed — upstream Claude Code regression (anthropics/claude-code#32712)
- Crash/kill paths (no hook fires) leave IDLE sessions the sweep is blind to (`OwnerExited` is ACTIVE-only) and the 7-day stale cleanup deletes them silently instead of finalizing — worth a separate issue
- Session "duration" on entire.io is wall-clock span (start → last activity); this fix makes `ended_at` real but doesn't change that metric's definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session lifecycle and subprocess spawning on every agent exit; behavior is well-tested but incorrect detach or mark ordering could leave sessions un-ended or un-condensed until PostCommit/sweep retries.
> 
> **Overview**
> Fixes **SessionEnd hooks being cancelled** (~1.5s on Claude Code) so sessions were often never marked **ended**.
> 
> **`scripts/entire-dev`** now **incrementally builds** into `.entire/tmp/entire-dev-bin` and **execs** it instead of probe + `go run` (full link every invocation). Same fallback: broken tree → PATH `entire` → exit 0.
> 
> **Session end lifecycle** splits work: the hook **only marks the session ENDED inline** (`markSessionEnded`); the **eager condense** moves to a **detached** `entire __condense_session <id>` child (`execx.SpawnDetached`, same idea as `__refresh_trail_enablement`). Condense logic and fail-open retries are unchanged. **`ENTIRE_SESSION_END_SYNC`** (integration **TestMain**) or an **unresolvable worktree** still run the old synchronous **`endSessionNow`** path.
> 
> Adds hidden **`__condense_session`**, excludes it from checkpoint-policy warnings, and extends integration/unit tests for sync vs detached condense.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540f83e091a2306f5559b69f69846042cc2b12db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
