### PR TITLE
fix(import): stamp importer git identity on checkpoint commits

### DIFF
--- a/cmd/entire/cli/agentimport/agentimport.go
+++ b/cmd/entire/cli/agentimport/agentimport.go
@@ -156,6 +156,12 @@ func Run(ctx context.Context, repo *git.Repository, imp Importer, opts Options) 
 	// whole import run pays for at most one history walk, not one per turn.
 	anchorResolver := newTurnAnchorResolver(repo, opts.LinkCommitSHA, opts.Now)
 
+	// Resolve the importer's git identity once per run (not per turn):
+	// checkpoint commits otherwise carry an empty author, which the
+	// GitHub->mirror ingestion path falls back to when it has no pusher
+	// identity for imported sessions, leaving them unattributed.
+	authorName, authorEmail := cp.GetGitAuthorFromRepo(repo)
+
 	for _, sf := range files {
 		res.SessionsScanned++
 		full, readErr := os.ReadFile(sf.Path)
@@ -195,7 +201,7 @@ func Run(ctx context.Context, repo *git.Repository, imp Importer, opts Options) 
 				logging.Debug(ctx, "import: turn anchor fell back",
 					"sessionID", sf.SessionID, "turnUUID", turn.UUID, "candidates", len(turn.CommitSHAs))
 			}
-			if err := writeTurn(ctx, stores, imp, cid, sf, red, turn, anchor); err != nil {
+			if err := writeTurn(ctx, stores, imp, cid, sf, red, turn, anchor, authorName, authorEmail); err != nil {
 				return res, err
 			}
 			existing[cid.String()] = true
@@ -286,7 +292,7 @@ func writeSessionState(ctx context.Context, imp Importer, sf SessionFile, turns 
 	return nil
 }
 
-func writeTurn(ctx context.Context, stores *cp.Stores, imp Importer, cid id.CheckpointID, sf SessionFile, red redact.RedactedBytes, turn Turn, anchorCommitSHA string) error {
+func writeTurn(ctx context.Context, stores *cp.Stores, imp Importer, cid id.CheckpointID, sf SessionFile, red redact.RedactedBytes, turn Turn, anchorCommitSHA, authorName, authorEmail string) error {
 	if err := stores.Persistent.Write(ctx, cp.Session(cp.WriteOptions{
 		CheckpointID:              cid,
 		SessionID:                 sf.SessionID,
@@ -301,6 +307,8 @@ func writeTurn(ctx context.Context, stores *cp.Stores, imp Importer, cid id.Chec
 		CheckpointTranscriptStart: turn.LineStart,
 		TokenUsage:                turn.Tokens,
 		CommitSHA:                 anchorCommitSHA,
+		AuthorName:                authorName,
+		AuthorEmail:               authorEmail,
 	})); err != nil {
 		return fmt.Errorf("write imported checkpoint %s: %w", cid, err)
 	}

--- a/cmd/entire/cli/agentimport/agentimport_test.go
+++ b/cmd/entire/cli/agentimport/agentimport_test.go
@@ -384,6 +384,122 @@ func TestRun_CursorImporterEndToEnd(t *testing.T) {
 	}
 }
 
+// TestRun_StampsImporterGitAuthorOnCheckpointCommit proves an imported
+// checkpoint's underlying git commit on entire/checkpoints/v1 carries the
+// importer's configured git identity (resolved once per Run via
+// checkpoint.GetGitAuthorFromRepo), not an empty signature.
+//
+// Motivation: on the GitHub->mirror ingestion path, the data plane has no
+// pusher identity for imported sessions and falls back to the checkpoint
+// commit's git author. An empty author meant imported sessions couldn't be
+// attributed to the importer.
+func TestRun_StampsImporterGitAuthorOnCheckpointCommit(t *testing.T) {
+	t.Parallel()
+	repo, repoDir := initRepoWithCommit(t)
+	claudeDir := t.TempDir()
+	writeFixtureSession(t, claudeDir, "sess-author.jsonl")
+
+	res, err := Run(context.Background(), repo, claudeImporter{}, Options{
+		RepoRoot: repoDir, OverridePath: claudeDir,
+		Now: time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.TurnsImported != 2 {
+		t.Fatalf("want 2 imported, got %+v", res)
+	}
+
+	stores, err := cp.Open(context.Background(), repo, cp.OpenOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ar, ok := stores.Persistent.(cp.AuthorReader)
+	if !ok {
+		t.Fatalf("persistent store %T does not implement AuthorReader", stores.Persistent)
+	}
+	cid := DeriveCheckpointID("sess-author", "u1")
+	author, err := ar.GetCheckpointAuthor(context.Background(), cid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// initRepoWithCommit uses testutil.InitRepo, which configures this
+	// repo-local git identity.
+	const wantName, wantEmail = "Test User", "test@example.com"
+	if author.Name != wantName || author.Email != wantEmail {
+		t.Fatalf("checkpoint commit author = %+v, want Name=%q Email=%q (the repo's configured git identity)",
+			author, wantName, wantEmail)
+	}
+}
+
+// TestRun_UnconfiguredGitIdentityFallsBackToDefaults proves that when the
+// importer's repo has no configured git user (no local or global user.name /
+// user.email), the imported checkpoint commit still gets a signature — the
+// same "Unknown"/"unknown@local" default checkpoint.GetGitAuthorFromRepo
+// already applies elsewhere, rather than an empty one.
+func TestRun_UnconfiguredGitIdentityFallsBackToDefaults(t *testing.T) {
+	// Cannot use t.Parallel(): isolates HOME via t.Setenv so this repo's
+	// global git config resolution can't see the developer's real ~/.gitconfig.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	repoDir := t.TempDir()
+	repo, err := git.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Seed one commit with a real timestamp (the anchor resolver's bounded
+	// walk stops at commits older than its date cutoff; a zero-value When
+	// would halt it immediately). The commit's own author signature is
+	// independent of GetGitAuthorFromRepo's config-based resolution under
+	// test here.
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.WriteFile(t, repoDir, "f.txt", "x")
+	if _, err := wt.Add("f.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Commit("init", &git.CommitOptions{
+		Author: &object.Signature{Name: "Seed", Email: "seed@test.com", When: time.Now()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	claudeDir := t.TempDir()
+	writeFixtureSession(t, claudeDir, "sess-noauthor.jsonl")
+
+	res, err := Run(context.Background(), repo, claudeImporter{}, Options{
+		RepoRoot: repoDir, OverridePath: claudeDir,
+		Now: time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.TurnsImported != 2 {
+		t.Fatalf("want 2 imported, got %+v", res)
+	}
+
+	stores, err := cp.Open(context.Background(), repo, cp.OpenOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ar, ok := stores.Persistent.(cp.AuthorReader)
+	if !ok {
+		t.Fatalf("persistent store %T does not implement AuthorReader", stores.Persistent)
+	}
+	cid := DeriveCheckpointID("sess-noauthor", "u1")
+	author, err := ar.GetCheckpointAuthor(context.Background(), cid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if author.Name != "Unknown" || author.Email != "unknown@local" {
+		t.Fatalf("checkpoint commit author = %+v, want the GetGitAuthorFromRepo defaults", author)
+	}
+}
+
 func TestRun_DryRunWritesNothing(t *testing.T) {
 	t.Parallel()
 	repo, repoDir := initRepoWithCommit(t)


### PR DESCRIPTION
## Summary

`entire import` writes checkpoint commits with an **empty** git author signature — `writeTurn` never set `AuthorName`/`AuthorEmail` and `CreateCommit` applies them verbatim. That breaks importer attribution on the data plane's GitHub→mirror ingestion path: mirror-sync pushes carry no pusher identity, so entire-api falls back to the checkpoint commit's git author — which is empty for imports, leaving them permanently unattributable there.

This resolves the importer's identity once per import run via the checkpoint package's `GetGitAuthorFromRepo` (the same fallback every other checkpoint write path uses) and stamps it on each import commit. The data plane's existing author machinery then attributes imports with no special casing — and it de-identifies (the email is HMAC'd, never stored).

Companion to entirehq/entire-api#405 (data-plane import ingestion) and entirehq/entire.io#3310 (BFF import ingestion); follows up entireio/cli#1825.

## Test plan
- [x] New: imported checkpoint commit carries the repo's configured git author (real import run, real repo, assertion on the actual commit signature)
- [x] New: unconfigured git identity falls back to `Unknown`/`unknown@local` (HOME/XDG isolated)
- [x] `mise run test` — 8303 tests green; `mise run test:integration` green; `mise run lint` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUDkzmpwgC4BiZ894UfnTy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to the import write path using an existing attribution helper; behavior matches other checkpoint commits, with new tests covering configured and default authors.
> 
> **Overview**
> **`entire import`** previously wrote checkpoint commits with an **empty git author** because `writeTurn` never set `AuthorName` / `AuthorEmail`. On GitHub→mirror ingestion, when there is no pusher identity, the data plane falls back to the checkpoint commit author—so imported sessions stayed unattributed.
> 
> The import run now resolves the importer’s identity **once** via `checkpoint.GetGitAuthorFromRepo` (same helper as other checkpoint writes) and passes it into each imported checkpoint write so commits carry a real signature, or `Unknown` / `unknown@local` when git user config is missing.
> 
> Tests assert the commit author matches repo-local git config and the unconfigured fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df67dc311516a593bda91450098c4dfc22d9c26. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->