### PR TITLE
test(import): fully isolate git config in author fallback test

### DIFF
--- a/cmd/entire/cli/agentimport/agentimport_test.go
+++ b/cmd/entire/cli/agentimport/agentimport_test.go
@@ -438,11 +438,22 @@ func TestRun_StampsImporterGitAuthorOnCheckpointCommit(t *testing.T) {
 // same "Unknown"/"unknown@local" default checkpoint.GetGitAuthorFromRepo
 // already applies elsewhere, rather than an empty one.
 func TestRun_UnconfiguredGitIdentityFallsBackToDefaults(t *testing.T) {
-	// Cannot use t.Parallel(): isolates HOME via t.Setenv so this repo's
-	// global git config resolution can't see the developer's real ~/.gitconfig.
+	// Cannot use t.Parallel(): isolates git config resolution via t.Setenv so
+	// this repo can't see any real identity. GetGitAuthorFromRepo resolves
+	// GlobalScope through go-git's Auto loader, which reads all of git's global
+	// sources; neutralize every one or the fallback assertion is flaky wherever
+	// an identity is configured (~/.gitconfig, XDG, GIT_CONFIG_GLOBAL, or system
+	// /etc/gitconfig). Mirrors the checkpoint package's pointHomeAt helper.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	// t.Setenv registers restoration of the original value; unset it for the
+	// test since an empty GIT_CONFIG_GLOBAL disables global config entirely.
+	t.Setenv("GIT_CONFIG_GLOBAL", "")
+	if err := os.Unsetenv("GIT_CONFIG_GLOBAL"); err != nil {
+		t.Fatal(err)
+	}
 
 	repoDir := t.TempDir()
 	repo, err := git.PlainInit(repoDir, false)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/935
<!-- entire-trail-link-end -->

Stacked on #1846.

## Summary

Copilot flagged that `TestRun_UnconfiguredGitIdentityFallsBackToDefaults` (added in #1846) only overrides `HOME`/`XDG_CONFIG_HOME`. But `checkpoint.GetGitAuthorFromRepo` resolves `GlobalScope` through go-git's Auto loader, which also honors **`GIT_CONFIG_GLOBAL`** and the **system `/etc/gitconfig`**. On any dev machine or CI image where either carries a git identity (e.g. `GIT_CONFIG_GLOBAL` set by chezmoi/direnv — the same dotfile-tool setups `configloader.go` exists to handle), the `Unknown`/`unknown@local` assertion would flake.

The fix neutralizes every global source, matching the checkpoint package's own `pointHomeAt` helper (`checkpoint/configloader_test.go:52`, `checkpoint/global_test.go:39`):

- `GIT_CONFIG_NOSYSTEM=1` — skip `/etc/gitconfig`
- unset `GIT_CONFIG_GLOBAL` — fall back to XDG (empty value would disable global config entirely, so it is unset, not emptied)

Production code is unchanged; this is test-isolation hardening only. The sibling `TestRun_StampsImporterGitAuthorOnCheckpointCommit` was never at risk — it uses repo-**local** identity, which wins go-git's config merge regardless of global/system.

## Test plan
- [x] `go test ./cmd/entire/cli/agentimport/ -run 'TestRun_Unconfigured...|TestRun_Stamps...' -count=1` green
- [x] `golangci-lint` (v2.11.3) `0 issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only comment and environment setup; no runtime behavior changes.
> 
> **Overview**
> Hardens **`TestRun_UnconfiguredGitIdentityFallsBackToDefaults`** so it no longer flakes when the host has git identity outside `HOME`/`XDG_CONFIG_HOME`.
> 
> The test now sets **`GIT_CONFIG_NOSYSTEM=1`** and **unsets `GIT_CONFIG_GLOBAL`** (after `t.Setenv` for cleanup), matching the checkpoint package’s **`pointHomeAt`** helper. That blocks go-git’s global config sources (`/etc/gitconfig`, `GIT_CONFIG_GLOBAL`, etc.) so **`Unknown` / `unknown@local`** assertions stay reliable. Comments were expanded to document why full isolation is required.
> 
> **No production code changes** — test isolation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dda7eef366300a857eb9c67078e16128ea2b661. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->