### PR TITLE
fix(enable): explain core.hooksPath when hooks dir is not a directory

### DIFF
--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -294,6 +294,13 @@ func InstallGitHook(ctx context.Context, silent, localDev, absolutePath bool) (i
 		return 0, err
 	}
 
+	if info, statErr := os.Stat(hooksDir); statErr == nil && !info.IsDir() {
+		return 0, fmt.Errorf("git resolves the hooks directory to %s, which is not a directory — core.hooksPath is likely set to disable git hooks\n"+
+			"Entire requires git hooks to capture sessions. See where it is set with:\n"+
+			"  git config --show-origin --get-all core.hooksPath\n"+
+			"then unset it (git config --global --unset core.hooksPath) or override for this repo (git config core.hooksPath .git/hooks) and re-run 'entire enable'", hooksDir)
+	}
+
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil { //nolint:gosec // Git hooks require executable permissions
 		return 0, fmt.Errorf("failed to create hooks directory: %w", err)
 	}

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
@@ -294,7 +295,11 @@ func InstallGitHook(ctx context.Context, silent, localDev, absolutePath bool) (i
 		return 0, err
 	}
 
-	if info, statErr := os.Stat(hooksDir); statErr == nil && !info.IsDir() {
+	info, statErr := os.Stat(hooksDir)
+	notDir := statErr == nil && !info.IsDir()
+	// ENOTDIR: a path component of hooksDir is itself a non-directory
+	// (e.g. core.hooksPath=/dev/null/hooks) — same misconfiguration.
+	if notDir || errors.Is(statErr, syscall.ENOTDIR) {
 		return 0, fmt.Errorf("git resolves the hooks directory to %s, which is not a directory — core.hooksPath is likely set to disable git hooks\n"+
 			"Entire requires git hooks to capture sessions. See where it is set with:\n"+
 			"  git config --show-origin --get-all core.hooksPath\n"+

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -314,6 +314,52 @@ func TestGetHooksDirInPath_CoreHooksPath(t *testing.T) {
 	}
 }
 
+func TestInstallGitHook_HooksPathNotADirectory(t *testing.T) {
+	// core.hooksPath pointing at a non-directory (commonly /dev/null, the
+	// "disable git hooks globally" idiom) must fail with guidance naming
+	// core.hooksPath, not a raw mkdir error.
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	cmd := exec.CommandContext(ctx, "git", "init")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+
+	hooksPath := "/dev/null"
+	if runtime.GOOS == "windows" {
+		hooksPath = filepath.Join(tmpDir, "not-a-dir")
+		if err := os.WriteFile(hooksPath, []byte("x"), 0o600); err != nil {
+			t.Fatalf("failed to create non-directory hooks path: %v", err)
+		}
+	}
+	cmd = exec.CommandContext(ctx, "git", "config", "core.hooksPath", hooksPath)
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to set core.hooksPath: %v", err)
+	}
+
+	t.Chdir(tmpDir)
+	ClearHooksDirCache()
+	paths.ClearWorktreeRootCache()
+
+	_, err := InstallGitHook(ctx, true, false, false)
+	if err == nil {
+		t.Fatal("InstallGitHook() should fail when hooks path is not a directory")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "core.hooksPath") {
+		t.Errorf("error should name core.hooksPath, got: %s", msg)
+	}
+	if !strings.Contains(msg, hooksPath) {
+		t.Errorf("error should include the resolved hooks path %s, got: %s", hooksPath, msg)
+	}
+	if !strings.Contains(msg, "git config") {
+		t.Errorf("error should tell the user how to inspect/fix the setting, got: %s", msg)
+	}
+}
+
 func TestInstallGitHook_WorktreeInstallsInCommonHooks(t *testing.T) {
 	mainRepo, worktreeDir := initHooksWorktreeRepo(t)
 	t.Chdir(worktreeDir)

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -346,6 +346,13 @@ func TestInstallGitHook_HooksPathNotADirectory(t *testing.T) {
 	ClearHooksDirCache()
 	paths.ClearWorktreeRootCache()
 
+	// Assert against the resolved hooks dir (what the error prints), not the
+	// configured value — git may normalize separators on Windows.
+	resolvedHooksDir, resolveErr := GetHooksDir(ctx)
+	if resolveErr != nil {
+		t.Fatalf("GetHooksDir() failed: %v", resolveErr)
+	}
+
 	_, err := InstallGitHook(ctx, true, false, false)
 	if err == nil {
 		t.Fatal("InstallGitHook() should fail when hooks path is not a directory")
@@ -354,8 +361,8 @@ func TestInstallGitHook_HooksPathNotADirectory(t *testing.T) {
 	if !strings.Contains(msg, "core.hooksPath") {
 		t.Errorf("error should name core.hooksPath, got: %s", msg)
 	}
-	if !strings.Contains(msg, hooksPath) {
-		t.Errorf("error should include the resolved hooks path %s, got: %s", hooksPath, msg)
+	if !strings.Contains(msg, resolvedHooksDir) {
+		t.Errorf("error should include the resolved hooks path %s, got: %s", resolvedHooksDir, msg)
 	}
 	if !strings.Contains(msg, "git config") {
 		t.Errorf("error should tell the user how to inspect/fix the setting, got: %s", msg)

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
 
+const goosWindows = "windows"
+
 // readEntireDevScript returns the contents of the committed scripts/entire-dev
 // launcher, located relative to this test file's position in the source tree.
 func readEntireDevScript(t *testing.T) string {
@@ -328,7 +330,7 @@ func TestInstallGitHook_HooksPathNotADirectory(t *testing.T) {
 	}
 
 	hooksPath := "/dev/null"
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		hooksPath = filepath.Join(tmpDir, "not-a-dir")
 		if err := os.WriteFile(hooksPath, []byte("x"), 0o600); err != nil {
 			t.Fatalf("failed to create non-directory hooks path: %v", err)
@@ -357,6 +359,80 @@ func TestInstallGitHook_HooksPathNotADirectory(t *testing.T) {
 	}
 	if !strings.Contains(msg, "git config") {
 		t.Errorf("error should tell the user how to inspect/fix the setting, got: %s", msg)
+	}
+}
+
+func TestInstallGitHook_HooksPathUnderNonDirectory(t *testing.T) {
+	// core.hooksPath pointing below a non-directory (e.g. /dev/null/hooks)
+	// makes os.Stat fail with ENOTDIR instead of succeeding on a non-dir;
+	// the guidance must fire for this variant too.
+	if runtime.GOOS == goosWindows {
+		t.Skip("ENOTDIR detection is POSIX-specific; Windows falls back to the raw mkdir error")
+	}
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	cmd := exec.CommandContext(ctx, "git", "init")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+	cmd = exec.CommandContext(ctx, "git", "config", "core.hooksPath", "/dev/null/hooks")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to set core.hooksPath: %v", err)
+	}
+
+	t.Chdir(tmpDir)
+	ClearHooksDirCache()
+	paths.ClearWorktreeRootCache()
+
+	_, err := InstallGitHook(ctx, true, false, false)
+	if err == nil {
+		t.Fatal("InstallGitHook() should fail when hooks path is under a non-directory")
+	}
+	if !strings.Contains(err.Error(), "core.hooksPath") {
+		t.Errorf("error should name core.hooksPath, got: %s", err)
+	}
+}
+
+func TestInstallGitHook_HooksPathNonexistentIsCreated(t *testing.T) {
+	// A configured-but-missing core.hooksPath is legitimate: the guard must
+	// not fire, and MkdirAll must create the directory and install hooks.
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	cmd := exec.CommandContext(ctx, "git", "init")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+	hooksPath := filepath.Join(tmpDir, "githooks-not-yet-created")
+	cmd = exec.CommandContext(ctx, "git", "config", "core.hooksPath", hooksPath)
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to set core.hooksPath: %v", err)
+	}
+
+	t.Chdir(tmpDir)
+	ClearHooksDirCache()
+	paths.ClearWorktreeRootCache()
+
+	count, err := InstallGitHook(ctx, true, false, false)
+	if err != nil {
+		t.Fatalf("InstallGitHook() should create a nonexistent hooks path: %v", err)
+	}
+	if count == 0 {
+		t.Fatal("InstallGitHook() should install hooks into the created directory")
+	}
+	for _, hook := range gitHookNames {
+		data, readErr := os.ReadFile(filepath.Join(hooksPath, hook))
+		if readErr != nil {
+			t.Fatalf("expected hook %s in created hooks dir: %v", hook, readErr)
+		}
+		if !strings.Contains(string(data), entireHookMarker) {
+			t.Errorf("hook %s should contain Entire marker", hook)
+		}
 	}
 }
 
@@ -1776,7 +1852,7 @@ func TestResolveHookExePath(t *testing.T) {
 		t.Parallel()
 		got, err := resolveHookExePath(exe, func(string) (string, error) {
 			return "", junctionErr
-		}, "windows")
+		}, goosWindows)
 		if err != nil {
 			t.Fatalf("windows should fall back, got error: %v", err)
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/937
<!-- entire-trail-link-end -->

## Problem

A user reported `entire enable` "crashing" with:

```
failed to install git hooks: failed to create hooks directory: mkdir /dev/null: not a directory
```

The cause is `core.hooksPath = /dev/null` in their git config — a common idiom for globally disabling git hooks (e.g. to neuter Husky). `GetHooksDir` resolves the hooks dir via `git rev-parse --git-path hooks`, which faithfully returns `/dev/null`, and `os.MkdirAll` then fails with a raw OS error. The message says *what* failed but never mentions `core.hooksPath`, so users can't connect it to their own config and report it as a bug.

## Fix

Before `MkdirAll`, stat the resolved hooks path; if it exists and is not a directory, fail with guidance:

```
failed to install git hooks: git resolves the hooks directory to /dev/null, which is not a directory — core.hooksPath is likely set to disable git hooks
Entire requires git hooks to capture sessions. See where it is set with:
  git config --show-origin --get-all core.hooksPath
then unset it (git config --global --unset core.hooksPath) or override for this repo (git config core.hooksPath .git/hooks) and re-run 'entire enable'
```

## Testing

- New `TestInstallGitHook_HooksPathNotADirectory` (uses `/dev/null` on Unix, a regular file on Windows); watched it fail on the old behavior first
- `mise run fmt`, `mise run lint`, `mise run test` (8302 tests) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, pre-install validation and clearer errors only; no change to successful hook installation paths.
> 
> **Overview**
> When `entire enable` installs git hooks, it now **detects a resolved hooks path that exists but is not a directory** (e.g. `core.hooksPath = /dev/null`) **before** `MkdirAll`, instead of surfacing a generic `mkdir … not a directory` error.
> 
> Users get an error that names **`core.hooksPath`**, shows the resolved path, and suggests `git config --show-origin --get-all core.hooksPath` plus unset or repo-local override before re-running `entire enable`.
> 
> Coverage is added in **`TestInstallGitHook_HooksPathNotADirectory`** (`/dev/null` on Unix, a file path on Windows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ce70c5dc35aa34a5fbb923d8a8f591427b57b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->