### PR TITLE
fix(strategy): warn when ambiguous worktree sessions block commit linking

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
@@ -221,9 +223,40 @@ func (s *ManualCommitStrategy) findSessionsForWorktree(ctx context.Context, work
 	}
 
 	if len(parentWorktreeMatches) > 0 {
-		return sessionsFromSingleWorktree(parentWorktreeMatches), nil
+		matches := sessionsFromSingleWorktree(parentWorktreeMatches)
+		if matches == nil {
+			warnAmbiguousWorktreeSessions(ctx, worktreePath, parentWorktreeMatches)
+		}
+		return matches, nil
 	}
-	return sessionsFromSingleWorktree(commonDirMatches), nil
+	matches := sessionsFromSingleWorktree(commonDirMatches)
+	if matches == nil && len(commonDirMatches) > 0 {
+		warnAmbiguousWorktreeSessions(ctx, worktreePath, commonDirMatches)
+	}
+	return matches, nil
+}
+
+// warnAmbiguousWorktreeSessions surfaces refused fallback matches: live
+// sessions exist in other worktrees of this repo, but they span multiple
+// worktrees so no automatic match is safe. Without this warning, commits made
+// here silently lose their Entire-Checkpoint linkage (#1852) with only a
+// DEBUG-level trace.
+func warnAmbiguousWorktreeSessions(ctx context.Context, worktreePath string, candidates []*SessionState) {
+	logCtx := logging.WithComponent(ctx, "checkpoint")
+	seen := make(map[string]struct{}, len(candidates))
+	worktrees := make([]string, 0, len(candidates))
+	for _, state := range candidates {
+		if _, ok := seen[state.WorktreePath]; ok {
+			continue
+		}
+		seen[state.WorktreePath] = struct{}{}
+		worktrees = append(worktrees, state.WorktreePath)
+	}
+	logging.Warn(logCtx, "session matching: live sessions in multiple worktrees of this repo match; refusing to guess, so commits here will not be linked — run 'entire session adopt --from <worktree>' to link one explicitly",
+		slog.String("commit_worktree", worktreePath),
+		slog.Int("candidate_sessions", len(candidates)),
+		slog.Any("candidate_worktrees", worktrees),
+	)
 }
 
 // sessionsFromSingleWorktree returns the candidates only when they were all

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -252,7 +252,7 @@ func warnAmbiguousWorktreeSessions(ctx context.Context, worktreePath string, can
 		seen[state.WorktreePath] = struct{}{}
 		worktrees = append(worktrees, state.WorktreePath)
 	}
-	logging.Warn(logCtx, "session matching: live sessions in multiple worktrees of this repo match; refusing to guess, so commits here will not be linked — run 'entire session adopt --from <worktree>' to link one explicitly",
+	logging.Warn(logCtx, "session matching: ambiguous sessions across worktrees; commit will not be linked",
 		slog.String("commit_worktree", worktreePath),
 		slog.Int("candidate_sessions", len(candidates)),
 		slog.Any("candidate_worktrees", worktrees),

--- a/cmd/entire/cli/strategy/manual_commit_worktree_session_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_worktree_session_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -321,6 +322,62 @@ func TestGitCommonDirForWorktree_IgnoresHookGitDirEnv(t *testing.T) {
 	commonDir, err := gitCommonDirForWorktree(ctx, mainDir)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(mainDir, ".git"), commonDir)
+}
+
+func TestManualCommitStrategy_FindSessionsForWorktree_WarnsOnAmbiguousSiblingSessions(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	ctx := context.Background()
+	mainDir := setupSessionMatchRepo(t)
+	firstWorktree := resolvedRemovedTempDir(t)
+	secondWorktree := resolvedRemovedTempDir(t)
+	commitWorktree := resolvedRemovedTempDir(t)
+	createSessionMatchWorktree(t, mainDir, firstWorktree, "first")
+	t.Cleanup(func() { removeSessionMatchWorktree(mainDir, firstWorktree) })
+	createSessionMatchWorktree(t, mainDir, secondWorktree, "second")
+	t.Cleanup(func() { removeSessionMatchWorktree(mainDir, secondWorktree) })
+	createSessionMatchWorktree(t, mainDir, commitWorktree, "commit")
+	t.Cleanup(func() { removeSessionMatchWorktree(mainDir, commitWorktree) })
+
+	s := &ManualCommitStrategy{}
+	saveSessionMatchState(ctx, t, s, mainDir, &SessionState{
+		SessionID:    "first-session",
+		WorktreePath: firstWorktree,
+	})
+	saveSessionMatchState(ctx, t, s, mainDir, &SessionState{
+		SessionID:    "second-session",
+		WorktreePath: secondWorktree,
+	})
+
+	t.Chdir(commitWorktree)
+	clearSessionMatchCaches()
+	require.NoError(t, logging.Init(ctx, "warn-test-session"))
+	t.Cleanup(logging.Close)
+
+	finder := &ManualCommitStrategy{}
+	matching, err := finder.findSessionsForWorktree(ctx, commitWorktree)
+	require.NoError(t, err)
+	require.Empty(t, matching)
+
+	logging.Close()
+	logs := readSessionMatchLogs(t, commitWorktree)
+	require.Contains(t, logs, `"level":"WARN"`, "ambiguous sibling sessions must be surfaced at WARN, not DEBUG")
+	require.Contains(t, logs, "refusing to guess")
+	require.Contains(t, logs, "entire session adopt")
+}
+
+func readSessionMatchLogs(t *testing.T, repoDir string) string {
+	t.Helper()
+
+	entries, err := filepath.Glob(filepath.Join(repoDir, ".entire", "logs", "*"))
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "expected a log file under .entire/logs")
+	var combined []byte
+	for _, entry := range entries {
+		content, err := os.ReadFile(entry)
+		require.NoError(t, err)
+		combined = append(combined, content...)
+	}
+	return string(combined)
 }
 
 func setupSessionMatchRepo(t *testing.T) string {

--- a/cmd/entire/cli/strategy/manual_commit_worktree_session_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_worktree_session_test.go
@@ -361,8 +361,8 @@ func TestManualCommitStrategy_FindSessionsForWorktree_WarnsOnAmbiguousSiblingSes
 	logging.Close()
 	logs := readSessionMatchLogs(t, commitWorktree)
 	require.Contains(t, logs, `"level":"WARN"`, "ambiguous sibling sessions must be surfaced at WARN, not DEBUG")
-	require.Contains(t, logs, "refusing to guess")
-	require.Contains(t, logs, "entire session adopt")
+	require.Contains(t, logs, "ambiguous sessions across worktrees")
+	require.Contains(t, logs, "candidate_worktrees")
 }
 
 func readSessionMatchLogs(t *testing.T, repoDir string) string {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/940
<!-- entire-trail-link-end -->

## Summary

Follow-up to #1440 for the last ask in #1852: when the sibling/parent worktree fallback finds live sessions but they span multiple worktrees, it refuses to guess — and until now the commit silently lost its `Entire-Checkpoint` linkage with only a DEBUG-level trace.

- Surface the refusal at WARN, listing the candidate worktrees and session count
- Message follows house style (short + factual); the candidate worktrees and session count are in structured attrs. The `entire session adopt` remedy stays in docs/issue guidance rather than log prose
- Test asserts the WARN lands in `.entire/logs` (level, message, and candidate_worktrees attr)

Terminal output was considered but the installed `prepare-commit-msg` and `post-commit` hooks intentionally redirect stderr to /dev/null, so the log-file WARN is the available surface.

## Validation

- `mise run fmt` / `mise run lint` (0 issues)
- `mise run test` — 8377 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: matching behavior is unchanged; adds structured WARN logging and test coverage for an existing refusal path.
> 
> **Overview**
> When **sibling/parent worktree fallback** finds live sessions but they span **more than one worktree**, `findSessionsForWorktree` still returns no match (no guessing). This change **emits a WARN** via the checkpoint logger instead of leaving the refusal effectively invisible.
> 
> The warning lists the commit worktree, candidate session count, and distinct candidate worktrees, and tells users to run **`entire session adopt --from <worktree>`** to link a session explicitly. That targets the case where commits in a third worktree **silently lose Entire-Checkpoint linkage** (#1852).
> 
> A new integration test initializes logging, reproduces ambiguous sibling sessions, and asserts **WARN** level plus the refusal and adopt hints appear under **`.entire/logs`** (hooks redirect stderr, so logs are the intended surface).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a19d840952eaf323bef032759ea30a186349912f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


## Before / after

Captured from a real run of the ambiguous scenario (live sessions in two worktrees, `git commit` in a third worktree of the same repo); temp paths shortened.

**Before** — the only trace, visible only with `log_level: DEBUG`:

```json
{"level":"DEBUG","msg":"prepare-commit-msg: no active sessions","component":"checkpoint","strategy":"manual-commit","source":"message"}
```

**After** — visible at the default level, names the worktrees involved:

```json
{"level":"WARN","msg":"session matching: ambiguous sessions across worktrees; commit will not be linked","component":"checkpoint","commit_worktree":"/repo/.worktrees/commit","candidate_sessions":2,"candidate_worktrees":["/repo/.worktrees/first","/repo/.worktrees/second"]}
{"level":"DEBUG","msg":"prepare-commit-msg: no active sessions","component":"checkpoint","strategy":"manual-commit","source":"message"}
```
