### PR TITLE
fix(strategy): warn when a commit is left unlinked with a live sibling-worktree session

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -354,6 +354,80 @@ func isGitSequenceOperation(ctx context.Context) bool {
 //   - "commit": amend operation - preserves existing trailer or restores from LastCheckpointID
 //
 
+// warnIfUnlinkedWithLiveSibling handles the #1852 case where the current commit
+// could not be linked to any session in this worktree, yet a live agent session
+// is running in another worktree of the same repo — the silent-unlink scenario.
+// It logs a WARN (with the offending worktrees and the adopt remedy) and returns
+// true when such a session exists, false otherwise. Split out of PrepareCommitMsg
+// to keep that hook entrypoint within the maintainability budget.
+func (s *ManualCommitStrategy) warnIfUnlinkedWithLiveSibling(logCtx context.Context, worktreePath, source string) bool {
+	elsewhere := s.liveSessionsInOtherWorktrees(logCtx, worktreePath)
+	if len(elsewhere) == 0 {
+		return false
+	}
+	worktrees := uniqueWorktreePaths(elsewhere)
+	// Name a concrete session in the remedy. The bare `adopt --from <path>` form
+	// relies on adoption's auto-detect, which only considers sessions within
+	// adoptRecentWindow (12h) — narrower than this warning's 24h liveness window
+	// — and also fails when a worktree has multiple sessions. Passing the exact
+	// session ID bypasses auto-detect entirely, so the suggested command always
+	// runs. Pick the most-recently-active session, matching what auto-detect
+	// would have chosen.
+	primary := mostRecentlyActiveSession(elsewhere)
+
+	// Structured record for the .entire/logs file (diagnostics / grep).
+	logging.Warn(logCtx, "prepare-commit-msg: commit left unlinked; live agent session(s) exist in other worktree(s) of this repo",
+		slog.String("strategy", "manual-commit"),
+		slog.String("source", source),
+		slog.String("worktree", worktreePath),
+		slog.Int("live_sessions_elsewhere", len(elsewhere)),
+		slog.String("session_worktrees", strings.Join(worktrees, ", ")),
+		slog.String("suggested_session", primary.SessionID),
+	)
+
+	// logging.Warn only reaches the internal log file, so on its own it leaves
+	// the #1852 silent-unlink case silent to the person running `git commit`.
+	// Surface a concise notice on stderrWriter too — the same user-facing hook
+	// channel warnIfAttributionDiverged and warnStaleEndedSessions use.
+	fmt.Fprint(stderrWriter, formatUnlinkedCommitNotice(worktrees, primary.SessionID, primary.WorktreePath))
+	return true
+}
+
+// mostRecentlyActiveSession returns the session with the newest last-seen time
+// (LastInteractionTime, falling back to StartedAt), matching how adoption
+// auto-selects a source session. Returns nil for an empty slice.
+func mostRecentlyActiveSession(states []*SessionState) *SessionState {
+	var best *SessionState
+	for _, st := range states {
+		if best == nil || sessionLastSeen(st).After(sessionLastSeen(best)) {
+			best = st
+		}
+	}
+	return best
+}
+
+func sessionLastSeen(state *SessionState) time.Time {
+	if state.LastInteractionTime != nil {
+		return *state.LastInteractionTime
+	}
+	return state.StartedAt
+}
+
+// formatUnlinkedCommitNotice builds the user-facing stderr message for the
+// #1852 silent-unlink case, naming a concrete session so the suggested command
+// is directly runnable. Returns "" when any component is missing, so a misuse
+// degrades to no output rather than emitting a broken command.
+func formatUnlinkedCommitNotice(worktrees []string, sessionID, sessionWorktree string) string {
+	if len(worktrees) == 0 || sessionID == "" || sessionWorktree == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"entire: this commit was not linked to a checkpoint (live agent session in %s).\n"+
+			"  run 'entire session adopt %s --from %s --yes' to link this worktree.\n",
+		strings.Join(worktrees, ", "), sessionID, sessionWorktree,
+	)
+}
+
 func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFile string, source string) error {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 
@@ -408,6 +482,16 @@ func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFi
 	if err != nil || len(sessions) == 0 {
 		findSessionsSpan.RecordError(err)
 		findSessionsSpan.End()
+
+		// #1852: When no session matches this worktree but a live agent session
+		// exists in another worktree of the same repo, the commit is left
+		// silently unlinked (94% of commits in one reported case). Surface that
+		// specific, actionable case at WARN instead of swallowing it at DEBUG.
+		// Skipped when listing errored, since we cannot trust the session view.
+		if err == nil && s.warnIfUnlinkedWithLiveSibling(logCtx, worktreePath, source) {
+			return nil
+		}
+
 		// No active sessions or error listing - silently skip (hooks must be resilient)
 		logging.Debug(logCtx, "prepare-commit-msg: no active sessions",
 			slog.String("strategy", "manual-commit"),

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -176,6 +176,68 @@ func exactWorktreeMatches(states []*SessionState, worktreePath string) []*Sessio
 	return exact
 }
 
+// liveSessionsInOtherWorktrees returns non-ended sessions that were recorded in
+// a worktree other than worktreePath. The session store is already scoped to
+// this repository's git common dir, so every candidate belongs to the same
+// repo. This detects the silent no-trailer case in #1852: a commit here that
+// cannot be linked even though an agent session is live in a sibling worktree.
+// It is best-effort context for a warning, so a listing error yields nil rather
+// than propagating — the hook must stay resilient.
+func (s *ManualCommitStrategy) liveSessionsInOtherWorktrees(ctx context.Context, worktreePath string) []*SessionState {
+	allStates, err := s.listAllSessionStates(ctx)
+	if err != nil {
+		return nil
+	}
+	var live []*SessionState
+	for _, state := range allStates {
+		if isLiveSessionInOtherWorktree(state, worktreePath) {
+			live = append(live, state)
+		}
+	}
+	return live
+}
+
+// isLiveSessionInOtherWorktree reports whether state is a still-open session
+// bound to a worktree other than worktreePath, i.e. one that would plausibly
+// have owned the current commit's checkpoint had matching succeeded.
+func isLiveSessionInOtherWorktree(state *SessionState, worktreePath string) bool {
+	if state == nil || state.WorktreePath == "" || state.WorktreePath == worktreePath {
+		return false
+	}
+	// Adopted-away tombstones and read-only imported sessions never produce
+	// trailers, so they are not evidence of a missed link.
+	if state.AdoptedIntoWorktreePath != "" || state.Kind.IsImported() {
+		return false
+	}
+	// Must be adoptable, mirroring isAdoptableSourceSession in session_adopt.go:
+	// not ended and not fully condensed. This keeps the warning consistent with
+	// the `entire session adopt` remedy it prints — we only flag sessions the
+	// user could actually adopt.
+	if state.Phase == session.PhaseEnded || state.EndedAt != nil || state.FullyCondensed {
+		return false
+	}
+	// And recently interacted with. A crashed agent can leave an ACTIVE/IDLE
+	// session that never transitions to ENDED; without the recency guard it
+	// would trigger this warning on every commit indefinitely. Mirrors the
+	// staleness guard used for active-session detection elsewhere in this file.
+	return isRecentInteraction(state.LastInteractionTime)
+}
+
+// uniqueWorktreePaths returns the distinct WorktreePath values of states, in
+// first-seen order, for compact logging.
+func uniqueWorktreePaths(states []*SessionState) []string {
+	seen := make(map[string]struct{}, len(states))
+	var paths []string
+	for _, state := range states {
+		if _, ok := seen[state.WorktreePath]; ok {
+			continue
+		}
+		seen[state.WorktreePath] = struct{}{}
+		paths = append(paths, state.WorktreePath)
+	}
+	return paths
+}
+
 // findSessionsForWorktree finds all sessions for the given worktree path.
 // Exact WorktreePath matches win; otherwise sessions recorded in another
 // worktree of the same repository (shared git common dir) are matched, as long

--- a/cmd/entire/cli/strategy/manual_commit_session_warn_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_session_warn_test.go
@@ -1,0 +1,129 @@
+package strategy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsLiveSessionInOtherWorktree covers the decision that gates the #1852
+// warning: a commit with no matching session should only warn when a still-open,
+// adoptable, recently-active agent session lives in a *different* worktree of the
+// same repo.
+func TestIsLiveSessionInOtherWorktree(t *testing.T) {
+	t.Parallel()
+
+	const here = "/repo/main"
+	const sibling = "/repo/feature"
+
+	recent := time.Now().Add(-1 * time.Minute)
+	// Older than activeSessionInteractionThreshold (24h): a crashed/abandoned
+	// session that never reached ENDED.
+	stale := time.Now().Add(-72 * time.Hour)
+	ended := time.Now().Add(-2 * time.Minute)
+
+	tests := []struct {
+		name  string
+		state *SessionState
+		want  bool
+	}{
+		{name: "nil state", state: nil, want: false},
+		{name: "no worktree path", state: &SessionState{Phase: session.PhaseActive, LastInteractionTime: &recent}, want: false},
+		{name: "same worktree", state: &SessionState{WorktreePath: here, Phase: session.PhaseActive, LastInteractionTime: &recent}, want: false},
+		{name: "sibling active and recent", state: &SessionState{WorktreePath: sibling, Phase: session.PhaseActive, LastInteractionTime: &recent}, want: true},
+		{name: "sibling idle and recent is still live", state: &SessionState{WorktreePath: sibling, Phase: session.PhaseIdle, LastInteractionTime: &recent}, want: true},
+		{name: "sibling active but stale", state: &SessionState{WorktreePath: sibling, Phase: session.PhaseActive, LastInteractionTime: &stale}, want: false},
+		{name: "sibling active but never interacted", state: &SessionState{WorktreePath: sibling, Phase: session.PhaseActive}, want: false},
+		{name: "sibling ended by phase", state: &SessionState{WorktreePath: sibling, Phase: session.PhaseEnded, LastInteractionTime: &recent}, want: false},
+		{name: "sibling ended by EndedAt", state: &SessionState{WorktreePath: sibling, Phase: session.PhaseActive, LastInteractionTime: &recent, EndedAt: &ended}, want: false},
+		{name: "sibling fully condensed", state: &SessionState{WorktreePath: sibling, Phase: session.PhaseActive, LastInteractionTime: &recent, FullyCondensed: true}, want: false},
+		{
+			name:  "sibling adopted-away tombstone",
+			state: &SessionState{WorktreePath: sibling, Phase: session.PhaseActive, LastInteractionTime: &recent, AdoptedIntoWorktreePath: here},
+			want:  false,
+		},
+		{
+			name:  "sibling imported session",
+			state: &SessionState{WorktreePath: sibling, Phase: session.PhaseActive, LastInteractionTime: &recent, Kind: session.KindImported},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isLiveSessionInOtherWorktree(tt.state, here))
+		})
+	}
+}
+
+// TestMostRecentlyActiveSession verifies the source session named in the remedy
+// is the newest by last-seen time (so it matches adoption's own auto-selection).
+func TestMostRecentlyActiveSession(t *testing.T) {
+	t.Parallel()
+
+	older := time.Now().Add(-30 * time.Minute)
+	newer := time.Now().Add(-1 * time.Minute)
+
+	states := []*SessionState{
+		{SessionID: "old", LastInteractionTime: &older},
+		{SessionID: "new", LastInteractionTime: &newer},
+	}
+
+	require.Equal(t, "new", mostRecentlyActiveSession(states).SessionID)
+	require.Nil(t, mostRecentlyActiveSession(nil))
+}
+
+// TestUniqueWorktreePaths verifies distinct paths are returned in first-seen
+// order for compact warning output.
+func TestUniqueWorktreePaths(t *testing.T) {
+	t.Parallel()
+
+	states := []*SessionState{
+		{WorktreePath: "/repo/a"},
+		{WorktreePath: "/repo/b"},
+		{WorktreePath: "/repo/a"},
+		{WorktreePath: "/repo/c"},
+		{WorktreePath: "/repo/b"},
+	}
+
+	require.Equal(t, []string{"/repo/a", "/repo/b", "/repo/c"}, uniqueWorktreePaths(states))
+}
+
+// TestUniqueWorktreePaths_Empty ensures no paths are returned for no input.
+func TestUniqueWorktreePaths_Empty(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, uniqueWorktreePaths(nil))
+}
+
+// TestFormatUnlinkedCommitNotice verifies the user-facing stderr message names
+// the worktree(s) and emits a directly-runnable adopt command: the concrete
+// session ID (so it doesn't depend on adoption's 12h auto-detect window) plus
+// --yes (required for same-repo adoption).
+func TestFormatUnlinkedCommitNotice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("names the session and worktree", func(t *testing.T) {
+		t.Parallel()
+		got := formatUnlinkedCommitNotice([]string{"/repo/feature"}, "sess-123", "/repo/feature")
+		require.Contains(t, got, "not linked to a checkpoint")
+		require.Contains(t, got, "entire session adopt sess-123 --from /repo/feature --yes")
+	})
+
+	t.Run("lists multiple worktrees for context", func(t *testing.T) {
+		t.Parallel()
+		got := formatUnlinkedCommitNotice([]string{"/repo/a", "/repo/b"}, "sess-9", "/repo/a")
+		require.Contains(t, got, "/repo/a, /repo/b")
+		require.Contains(t, got, "adopt sess-9 --from /repo/a --yes")
+	})
+
+	t.Run("missing components yield no message", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, formatUnlinkedCommitNotice(nil, "sess-1", "/repo/a"))
+		require.Empty(t, formatUnlinkedCommitNotice([]string{"/repo/a"}, "", "/repo/a"))
+		require.Empty(t, formatUnlinkedCommitNotice([]string{"/repo/a"}, "sess-1", ""))
+	})
+}


### PR DESCRIPTION
## What & why

Fixes the silent no-trailer case in #1852. Commits made in a worktree with no matching session were silently left without an `Entire-Checkpoint` trailer — even when a live agent session ran in another worktree of the same repo. In one reported case this unlinked 101 of 108 commits (94%). The miss was logged at DEBUG, so nothing surfaced it to the person running `git commit`.

## Change

On the no-session path in `prepare-commit-msg`, the hook now checks whether a *live* agent session exists in a different worktree of the same repo. When one does, it (1) prints a notice to stderr during the commit — the same channel `warnIfAttributionDiverged` uses, so the failure is actually visible — and (2) keeps a structured `WARN` in `.entire/logs` for diagnostics. The stderr notice reads:

    entire: this commit was not linked to a checkpoint (live agent session in ../feature).
      run 'entire session adopt --from ../feature --yes' to link this worktree.

Sessionless commits — the common case — stay quiet; the check is skipped when listing errored. Underlying matching is unchanged — this makes the residual silent case visible, it doesn't change what gets linked.

## Notes / decisions

- "Live" = non-ended AND recently interacted (24h `activeSessionInteractionThreshold`), mirroring the staleness guard used elsewhere in this file — a crashed session that never reaches ENDED won't nag forever. ENDED / stale / adopted-away / imported don't count.
- `--yes` is required in the hint: same-repo adoption routes through `adoptFromSameSessionStore`, which needs it even on first adoption — the bare command would always error.

## ⚠️ Tradeoff — maintainer call before merge

1. Overlaps in-flight matching work (#1/#2 in the issue). That fix will shrink when this warning fires, possibly to just the ambiguous multi-worktree case it can't resolve. Whoever owns matching should confirm they want the interim warning now vs. folding it in later.
2. Prints on every affected commit (each is a real, separate miss). Repo has throttle mechanisms — happy to rate-limit / show-once-per-session if preferred.

## Tests

- Table-driven unit tests (`t.Parallel()`): `isLiveSessionInOtherWorktree` (same-worktree / sibling-active / sibling-idle / stale / never-interacted / ended / adopted-away / imported), `uniqueWorktreePaths`, `formatUnlinkedCommitNotice`.
- Full `strategy` suite passes; `maintidx` + `golangci-lint` v2.11.3 clean on changed files; `go build ./...`, `go vet`, `gofmt` clean.

Refs #1852

