### PR TITLE
fix(checkpoint): skip .git path components when building trees

### DIFF
--- a/cmd/entire/cli/checkpoint/parse_tree.go
+++ b/cmd/entire/cli/checkpoint/parse_tree.go
@@ -406,9 +406,29 @@ func normalizeGitTreePath(path string) (string, error) {
 		if part == "." || part == ".." {
 			return "", fmt.Errorf("path contains invalid segment %q", part)
 		}
+		if isDotGitComponent(part) {
+			return "", fmt.Errorf("path contains reserved segment %q", part)
+		}
 	}
 
 	return path, nil
+}
+
+// isDotGitComponent reports whether a single path component refers to a
+// repository's own `.git` metadata, matching go-git's IsDotGitName: the
+// literal ".git" and its case-insensitive forms, plus the NTFS 8.3
+// short-name alias "git~1". Git forbids these as tree path components
+// (fsck_tree), and go-git's Tree.Encode rejects them outright, so a file
+// whose path carries such a component must be skipped rather than allowed
+// to fail the whole checkpoint. This is a pre-filter, not the authority.
+// go-git's encoder remains the backstop for exotic HFS+/NTFS disguises we
+// deliberately do not reimplement here.
+func isDotGitComponent(part string) bool {
+	switch strings.ToLower(part) {
+	case ".git", "git~1":
+		return true
+	}
+	return false
 }
 
 func isAbsoluteGitTreePath(path string) bool {

--- a/cmd/entire/cli/checkpoint/parse_tree_test.go
+++ b/cmd/entire/cli/checkpoint/parse_tree_test.go
@@ -190,6 +190,26 @@ func TestApplyTreeChanges_SkipsInvalidPaths(t *testing.T) {
 			path:        "../dir/file.txt",
 			wantPresent: "valid.txt",
 		},
+		{
+			name:        "dot git file at root",
+			path:        ".git",
+			wantPresent: "valid.txt",
+		},
+		{
+			name:        "dot git directory component",
+			path:        "sub/.git/config",
+			wantPresent: "valid.txt",
+		},
+		{
+			name:        "dot git uppercase component",
+			path:        ".GIT/config",
+			wantPresent: "valid.txt",
+		},
+		{
+			name:        "ntfs short name alias",
+			path:        "git~1/config",
+			wantPresent: "valid.txt",
+		},
 	}
 
 	for _, tt := range tests {
@@ -244,6 +264,10 @@ func TestBuildTreeFromEntries_SkipsInvalidPaths(t *testing.T) {
 		{name: "empty segment", path: "dir//file.txt"},
 		{name: "dot segment", path: "./file.txt"},
 		{name: "dot dot segment", path: "../file.txt"},
+		{name: "dot git file at root", path: ".git"},
+		{name: "dot git directory component", path: "sub/.git/config"},
+		{name: "dot git uppercase component", path: ".GIT/config"},
+		{name: "ntfs short name alias", path: "git~1/config"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/946
<!-- entire-trail-link-end -->

go-git v6's Tree.Encode runs fsck-style validation (ValidTreePath) and rejects any tree entry named ".git" (plus ".", "..", and the NTFS short-name alias git~1), matching upstream Git's fsck_tree rules. A captured file path carrying a ".git" component reached tree construction and failed the whole checkpoint at encode time:

  failed to encode tree: invalid tree: invalid path component: ".git"

normalizeGitTreePath already rejected "." and ".."; callers log-and-skip those files. Add ".git"/"git~1" (case-insensitive) to the same gate so the offending file is dropped before the tree is built, rather than aborting the checkpoint at go-git's encoder. This is the single chokepoint for both ApplyTreeChanges (shadow-branch trees) and BuildTreeFromEntries (metadata trees); go-git's encoder stays the authoritative backstop for exotic HFS+/NTFS disguises.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation change that drops invalid paths instead of failing; aligns with existing skip behavior for `.` and `..`, with go-git still enforcing exotic cases.
> 
> **Overview**
> **Checkpoint tree building** now treats paths with forbidden Git metadata segments the same as other invalid paths: they are skipped with a warning instead of failing the whole checkpoint at `Tree.Encode`.
> 
> `normalizeGitTreePath` rejects any path component matching `.git` (case-insensitive) or the NTFS alias `git~1`, via new helper `isDotGitComponent`. That gate feeds both `ApplyTreeChanges` and `BuildTreeFromEntries`, so a captured path like `sub/.git/config` no longer aborts encoding with go-git’s fsck-style “invalid path component” error.
> 
> Tests cover root `.git`, nested `.git`, uppercase `.GIT`, and `git~1` for both apply-changes and build-from-entries flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725ef0df00f7d5f399cce9a799e46e16fdae521a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->