### PR TITLE
fix(codex): close tailer emitted-flag race causing token scale flap

### DIFF
--- a/cmd/entire/cli/agent/codex/review_tokens.go
+++ b/cmd/entire/cli/agent/codex/review_tokens.go
@@ -35,9 +35,10 @@ const (
 // token_count.total_token_usage is a running SESSION total (not per-turn
 // scale like turn.completed usage), so each emission is an absolute count —
 // matching consumers' overwrite-not-sum semantics. Duplicate totals are
-// suppressed so we only emit on real movement. emitted is set after the
-// first successful send; the parser uses it to suppress its per-turn-scale
-// stdout emissions so a single source stays authoritative.
+// suppressed so we only emit on real movement. emitted is set immediately
+// before each send (never after — see drain) so it is observable no later
+// than the Tokens event itself; the parser uses it to suppress its
+// per-turn-scale stdout emissions so a single source stays authoritative.
 //
 // Returns when stop is closed (the stdout stream ended) — after one final
 // catch-up drain of the file, so the last token_count codex wrote is not
@@ -126,11 +127,19 @@ func (t *rolloutTail) drain() error {
 					continue
 				}
 				t.lastIn, t.lastOut = in, outTok
+				// Set emitted BEFORE the send: the parser suppresses its
+				// per-turn-scale turn.completed Tokens once the tailer has
+				// emitted, so the flag must be observable no later than the
+				// Tokens event itself. Storing after the send leaves a window
+				// where a consumer sees the tailer's Tokens while emitted is
+				// still false, letting a concurrent turn.completed leak a
+				// per-turn value and flap the counter between scales.
+				//
 				// Unconditional send is safe: the parser waits for the
 				// tailer before closing the channel, and the run contract
 				// guarantees the consumer drains until close.
-				t.out <- reviewtypes.Tokens{In: in, Out: outTok}
 				t.emitted.Store(true)
+				t.out <- reviewtypes.Tokens{In: in, Out: outTok}
 			}
 		}
 		if readErr != nil {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/947
<!-- entire-trail-link-end -->

## Problem

CI job `test-core` failed on `TestParseCodexOutput_TailerSuppressesPerTurnStdoutTokens` ([run 30341611180](https://github.com/entireio/cli/actions/runs/30341611180/job/90218245630)) — a timing flake exposing a real race.

In `review_tokens.go` `drain()`, the rollout tailer sent each `Tokens` event **then** set `emitted`:

```go
t.out <- reviewtypes.Tokens{...}  // send
t.emitted.Store(true)             // flag set AFTER
```

This leaves a window where a consumer observes the tailer's cumulative Tokens while `emitted` is still `false`. A concurrent `turn.completed` envelope reads `tailerEmitted.Load()` → `false` → leaks a per-turn-scale token value that should be suppressed. The live counter flaps between per-turn and session-cumulative scales; the final value is nondeterministic. Passes locally, loses the race under CI load.

## Fix

Store `emitted` **before** the send, so the flag is observable no later than the `Tokens` event itself. Updated the two doc comments that described the old order.

## Test plan
- [x] Target test: 200× pass
- [x] `-race` on tailer tests: clean
- [x] Full codex package: ok
- [x] golangci-lint v2.11.3: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single ordering change in token tailing with no auth or data-model impact; reduces nondeterministic token display under concurrency.
> 
> **Overview**
> Fixes a **timing race** in the Codex review rollout token tailer where `emitted` was set **after** each `Tokens` send on the event channel.
> 
> In `rolloutTail.drain()`, **`emitted.Store(true)` now runs immediately before** `t.out <- reviewtypes.Tokens{...}`. That way the parser’s `tailerEmitted.Load()` on concurrent `turn.completed` stdout cannot still see `false` while consumers already received the tailer’s session-cumulative totals. Previously that window allowed a per-turn-scale `Tokens` event to leak through and **flap** the live counter between per-turn and cumulative scales (the flake behind `TestParseCodexOutput_TailerSuppressesPerTurnStdoutTokens`).
> 
> Doc comments on `tailRolloutTokens` and inline notes in `drain()` were updated to describe the new ordering; behavior is otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40c09d8a26e9be7f5658808f3f2863a3abbd691b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->