### PR TITLE
redact: preserve thinking-block signatures (fix omp replay 400)

### DIFF
--- a/redact/redact.go
+++ b/redact/redact.go
@@ -827,12 +827,19 @@ func collectJSONLReplacements(v any, redactor func(string) string) []jsonReplace
 }
 
 // shouldSkipJSONLField returns true if a JSON key should be excluded from scanning/redaction.
-// Skips "signature" (exact), ID fields (ending in "id"/"ids"), and common path/directory fields.
+// Skips signature fields (any key ending in "signature"), ID fields (ending in "id"/"ids"),
+// and common path/directory fields.
 func shouldSkipJSONLField(key string) bool {
-	if key == "signature" {
+	lower := strings.ToLower(key)
+
+	// Skip signature fields: cryptographic attestations, not secrets. Covers
+	// "signature" (Claude Code) and provider variants like "thinkingSignature"
+	// (Oh My Pi). Their values are high-entropy base64, so the entropy scanner
+	// would otherwise redact them — corrupting extended-thinking signatures and
+	// breaking transcript replay ("Invalid `signature` in `thinking` block").
+	if strings.HasSuffix(lower, "signature") {
 		return true
 	}
-	lower := strings.ToLower(key)
 
 	// Skip ID fields
 	if strings.HasSuffix(lower, "id") || strings.HasSuffix(lower, "ids") {

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -224,8 +224,10 @@ func TestShouldSkipJSONLField(t *testing.T) {
 		{"ids", true},
 		{"session_ids", true},
 		{"userIds", true},
-		// Exact match "signature" should be skipped.
+		// Signature fields should be skipped (any key ending in "signature").
 		{"signature", true},
+		{"thinkingSignature", true},
+		{"thinking_signature", true},
 		// Path-related fields should be skipped.
 		{"filePath", true},
 		{"file_path", true},
@@ -245,7 +247,7 @@ func TestShouldSkipJSONLField(t *testing.T) {
 		{"args", false},
 		{"video", false},      // ends in "o", not "id"
 		{"identify", false},   // ends in "ify", not "id"
-		{"signatures", false}, // not exact match "signature"
+		{"signatures", false}, // does not end in "signature"
 		{"signal_data", false},
 		{"consideration", false}, // contains "id" but doesn't end with it
 	}
@@ -289,6 +291,22 @@ func TestJSONLContent_SkippedFieldValueCollision(t *testing.T) {
 	}
 	if !strings.Contains(result, `"content":"REDACTED"`) {
 		t.Fatalf("expected content field to be redacted, got: %s", result)
+	}
+}
+
+func TestJSONLContent_PreservesThinkingSignature(t *testing.T) {
+	t.Parallel()
+	// Oh My Pi stores extended-thinking signatures under "thinkingSignature".
+	// Their base64 value is high-entropy; redacting it corrupts the signature and
+	// breaks replay with "Invalid `signature` in `thinking` block".
+	input := `{"type":"thinking","thinking":"plan","thinkingSignature":"` + highEntropySecret + `"}`
+
+	result, err := JSONLContent(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, `"thinkingSignature":"`+highEntropySecret+`"`) {
+		t.Fatalf("expected thinkingSignature to be preserved verbatim, got: %s", result)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/948
<!-- entire-trail-link-end -->

## Summary

`redact.shouldSkipJSONLField` only skipped a field named **exactly** `"signature"` (Claude Code's key). Oh My Pi stores the extended-thinking signature under **`thinkingSignature`**, which fell through to the entropy scanner. Signature values are high-entropy base64, so redaction replaced segments with `REDACTED` and corrupted them.

When such a redacted transcript is later replayed to the model, the Anthropic API rejects it — it validates the signature on **every** thinking block in the history, not just the last turn:

```
✘ 400 invalid_request_error: messages.1.content.0: Invalid `signature` in `thinking` block
```

This surfaced while testing the Oh My Pi (`omp`) external agent: after a redacted session was resumed, every `omp` turn 400'd, because the stored transcript carried 9 thinking blocks whose `thinkingSignature` had been mangled to `REDACTED/REDACTED/REDACTED/…`.

## Fix

Generalize the skip from an exact `"signature"` match to **any field whose lowercased name ends in `signature`** — covering `signature` (Claude Code) and `thinkingSignature` (Oh My Pi), plus future provider variants. Signatures are cryptographic attestations, not secrets, and must be preserved byte-for-byte for replay. `signatures` (plural) still redacts.

```go
// before
if key == "signature" { return true }
// after
lower := strings.ToLower(key)
if strings.HasSuffix(lower, "signature") { return true }
```

## Reproduction

```
{"type":"thinking","thinking":"plan","thinkingSignature":"<high-entropy base64>"}
```
Before: the `thinkingSignature` value is redacted to `REDACTED/…`; replaying that transcript 400s with "Invalid `signature` in `thinking` block".
After: the value is preserved verbatim.

## Tests

- `TestShouldSkipJSONLField`: added `thinkingSignature` / `thinking_signature` → skipped; `signatures` still redacts.
- `TestJSONLContent_PreservesThinkingSignature`: end-to-end, a `thinkingSignature` value survives `JSONLContent` unchanged.
- `go test ./redact/` — green.

## Notes

This prevents *future* corruption. Transcripts already redacted before this fix cannot be repaired (the original signatures are gone) — affected sessions must be started fresh.
