### PR TITLE
fix(auth): delete jurisdiction tokens on logout

### DIFF
--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
@@ -34,6 +36,34 @@ func RemoveContext(name string) error {
 	return nil
 }
 
+// RememberJurisdictionAudience adds audience to context `name`'s
+// JurisdictionAudiences, so logout can find the matching keyring slot.
+// Idempotent: an already-recorded audience rewrites nothing.
+//
+// Callers MUST record before writing the token to the credential store — a
+// persisted-but-unrecorded token is a bearer logout can't find, whereas a
+// failed record that aborts the write costs only one token exchange.
+func RememberJurisdictionAudience(name, audience string) error {
+	aud := strings.TrimRight(strings.TrimSpace(audience), "/")
+	if name == "" || aud == "" {
+		return errors.New("context name and jurisdiction audience are both required")
+	}
+	if err := contexts.Modify(userdirs.Config(), func(f *contexts.File) (bool, error) {
+		c := f.Find(name)
+		if c == nil {
+			return false, fmt.Errorf("no login context named %q", name)
+		}
+		if slices.Contains(c.JurisdictionAudiences, aud) {
+			return false, nil
+		}
+		c.JurisdictionAudiences = append(c.JurisdictionAudiences, aud)
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("record jurisdiction audience %q for context %q: %w", aud, name, err)
+	}
+	return nil
+}
+
 // removeContextLocked deletes the context selected by pick — keyring slots
 // first, then the contexts.json entry — inside a single locked Modify, so
 // selection, credential deletion, and entry removal can't interleave with a
@@ -53,7 +83,7 @@ func removeContextLocked(pick func(*contexts.File) *contexts.Context) error {
 		if c == nil {
 			return false, nil
 		}
-		if err := deleteContextKeychain(c.KeychainService, c.Handle); err != nil {
+		if err := deleteContextKeychain(c); err != nil {
 			return false, fmt.Errorf("remove credentials for %q: %w", c.Name, err)
 		}
 		f.Delete(c.Name)
@@ -61,20 +91,34 @@ func removeContextLocked(pick func(*contexts.File) *contexts.Context) error {
 	})
 }
 
-// deleteContextKeychain removes a context's keyring slots. A missing entry
-// is fine; any other failure surfaces so logout doesn't claim success over
-// surviving credentials. The refresh slot goes first — it's the long-lived
-// credential, and if the second delete then fails, the leftover access
-// token at least expires on its own.
-func deleteContextKeychain(svc, handle string) error {
-	if svc == "" || handle == "" {
+// deleteContextKeychain removes every keyring slot a context owns: the paired
+// refresh + access tokens, plus one jurisdiction (data-plane) access token per
+// recorded audience — each of those authorizes git against every repo the
+// account can reach. A missing entry is fine; any other failure surfaces so
+// logout doesn't claim success over surviving credentials.
+//
+// Deletion runs longest-lived-first — refresh (indefinite), jurisdiction (8h),
+// access (an hour at most) — so a mid-sequence failure leaves behind only the
+// shorter-lived credential. Unrecorded jurisdiction slots are unreachable (no
+// enumeration API) and left to expire.
+func deleteContextKeychain(c *contexts.Context) error {
+	if c == nil || c.Handle == "" {
 		return nil
 	}
-	if err := tokenstore.Delete(tokenstore.RefreshService(svc), handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
-		return fmt.Errorf("delete refresh token: %w", err)
+	if c.KeychainService != "" {
+		if err := tokenstore.Delete(tokenstore.RefreshService(c.KeychainService), c.Handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
+			return fmt.Errorf("delete refresh token: %w", err)
+		}
 	}
-	if err := tokenstore.Delete(svc, handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
-		return fmt.Errorf("delete access token: %w", err)
+	for _, audience := range c.JurisdictionAudiences {
+		if err := tokenstore.Delete(tokenstore.JurisdictionService(audience), c.Handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
+			return fmt.Errorf("delete jurisdiction token for %s: %w", audience, err)
+		}
+	}
+	if c.KeychainService != "" {
+		if err := tokenstore.Delete(c.KeychainService, c.Handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
+			return fmt.Errorf("delete access token: %w", err)
+		}
 	}
 	return nil
 }

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -111,6 +111,12 @@ func deleteContextKeychain(c *contexts.Context) error {
 		}
 	}
 	for _, audience := range c.JurisdictionAudiences {
+		// A blank entry can only come from a hand-edited or corrupted
+		// contexts.json, and would resolve to the bare service prefix — no
+		// token lives there, so skip rather than round-trip the keyring.
+		if strings.TrimSpace(audience) == "" {
+			continue
+		}
 		if err := tokenstore.Delete(tokenstore.JurisdictionService(audience), c.Handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
 			return fmt.Errorf("delete jurisdiction token for %s: %w", audience, err)
 		}

--- a/cmd/entire/cli/auth/context_store_test.go
+++ b/cmd/entire/cli/auth/context_store_test.go
@@ -1,0 +1,261 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+// testCoreURL is the login server every context in this file is recorded
+// against; seedLoginWithJurisdictionTokens keys its keyring slots off it.
+const testCoreURL = "https://core.example.com"
+
+// seedAccountWithJurisdictionTokens records a login context for `handle`
+// against testCoreURL, notes `audiences` on it, and files a jurisdiction access
+// token in each of those keyring slots under that handle — the state
+// git-remote-entire leaves behind after a few git operations. Returns the
+// context name and the core keyring service its login tokens live in.
+func seedAccountWithJurisdictionTokens(t *testing.T, handle string, audiences ...string) (name, coreService string) {
+	t.Helper()
+
+	exp := time.Now().Add(time.Hour).Unix()
+	token := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":%q,"exp":%d}`, testCoreURL, handle, exp))
+	name, err := RecordLoginContext(token, testRefreshToken, true)
+	if err != nil {
+		t.Fatalf("RecordLoginContext(%s): %v", handle, err)
+	}
+
+	for _, audience := range audiences {
+		if err := RememberJurisdictionAudience(name, audience); err != nil {
+			t.Fatalf("RememberJurisdictionAudience(%q): %v", audience, err)
+		}
+		if err := tokenstore.Set(tokenstore.JurisdictionService(audience), handle, "juri-jwt"); err != nil {
+			t.Fatalf("seed jurisdiction token for %q: %v", audience, err)
+		}
+	}
+	return name, tokenstore.CoreKeyringService(testCoreURL)
+}
+
+// seedLoginWithJurisdictionTokens is seedAccountWithJurisdictionTokens for the
+// single-account tests, which all use handle "alice".
+func seedLoginWithJurisdictionTokens(t *testing.T, audiences ...string) (name, coreService string) {
+	t.Helper()
+	return seedAccountWithJurisdictionTokens(t, "alice", audiences...)
+}
+
+// TestRemoveContext_DeletesJurisdictionTokens pins the logout contract for
+// data-plane credentials: the jurisdiction access tokens git-remote-entire
+// filed are bearers for every repo the account can reach, with an 8h
+// server-side TTL, so logout must delete them alongside the login slots rather
+// than leave them usable on the machine.
+func TestRemoveContext_DeletesJurisdictionTokens(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+
+	name, coreService := seedLoginWithJurisdictionTokens(t,
+		"https://eu.example.io", "https://au.example.io/")
+
+	if err := RemoveContext(name); err != nil {
+		t.Fatalf("RemoveContext: %v", err)
+	}
+
+	for _, audience := range []string{"https://eu.example.io", "https://au.example.io/"} {
+		svc := tokenstore.JurisdictionService(audience)
+		if v, err := tokenstore.Get(svc, "alice"); !errors.Is(err, tokenstore.ErrNotFound) {
+			t.Fatalf("jurisdiction token for %q survived logout: value=%q err=%v", audience, v, err)
+		}
+	}
+	if v, err := tokenstore.Get(coreService, "alice"); !errors.Is(err, tokenstore.ErrNotFound) {
+		t.Fatalf("access slot survived logout: value=%q err=%v", v, err)
+	}
+	if v, err := tokenstore.Get(tokenstore.RefreshService(coreService), "alice"); !errors.Is(err, tokenstore.ErrNotFound) {
+		t.Fatalf("refresh slot survived logout: value=%q err=%v", v, err)
+	}
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load contexts: %v", err)
+	}
+	if f.Find(name) != nil {
+		t.Fatalf("context %q should have been removed", name)
+	}
+}
+
+// TestRemoveContext_LeavesOtherAccountsJurisdictionTokens pins the scope of the
+// sweep: jurisdiction slots are keyed by (audience, handle), and logout only
+// deletes the audiences recorded on the context it is removing, under that
+// context's own handle. Two accounts sharing a jurisdiction have separate slots,
+// so logging one out must leave the other's data-plane token — and its
+// bookkeeping — intact.
+func TestRemoveContext_LeavesOtherAccountsJurisdictionTokens(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+
+	// Both accounts have a token for the same jurisdiction, plus one audience
+	// only bob ever reached.
+	const shared = "https://eu.example.io"
+	const bobOnly = "https://au.example.io"
+	aliceName, _ := seedAccountWithJurisdictionTokens(t, "alice", shared)
+	bobName, _ := seedAccountWithJurisdictionTokens(t, "bob", shared, bobOnly)
+
+	if err := RemoveContext(aliceName); err != nil {
+		t.Fatalf("RemoveContext(%s): %v", aliceName, err)
+	}
+
+	if v, err := tokenstore.Get(tokenstore.JurisdictionService(shared), "alice"); !errors.Is(err, tokenstore.ErrNotFound) {
+		t.Fatalf("alice's jurisdiction token survived her logout: value=%q err=%v", v, err)
+	}
+	for _, audience := range []string{shared, bobOnly} {
+		if _, err := tokenstore.Get(tokenstore.JurisdictionService(audience), "bob"); err != nil {
+			t.Fatalf("bob's jurisdiction token for %q was deleted by alice's logout: %v", audience, err)
+		}
+	}
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load contexts: %v", err)
+	}
+	bob := f.Find(bobName)
+	if bob == nil {
+		t.Fatalf("context %q was removed by alice's logout", bobName)
+	}
+	if !slices.Equal(bob.JurisdictionAudiences, []string{shared, bobOnly}) {
+		t.Fatalf("bob's recorded audiences = %v, want [%s %s]", bob.JurisdictionAudiences, shared, bobOnly)
+	}
+}
+
+// TestRemoveCurrentContext_DeletesJurisdictionTokens covers the default
+// `entire logout` path (active context, not selected by name).
+func TestRemoveCurrentContext_DeletesJurisdictionTokens(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+
+	const audience = "https://eu.example.io"
+	seedLoginWithJurisdictionTokens(t, audience)
+
+	if err := RemoveCurrentContext(); err != nil {
+		t.Fatalf("RemoveCurrentContext: %v", err)
+	}
+	if v, err := tokenstore.Get(tokenstore.JurisdictionService(audience), "alice"); !errors.Is(err, tokenstore.ErrNotFound) {
+		t.Fatalf("jurisdiction token survived logout: value=%q err=%v", v, err)
+	}
+}
+
+// TestRemoveContext_JurisdictionDeleteFailureAbortsLogout extends the existing
+// keychain-delete contract to the jurisdiction slots: a failed delete must
+// surface and leave the context entry in place for a retry, never report
+// success over a surviving data-plane bearer.
+func TestRemoveContext_JurisdictionDeleteFailureAbortsLogout(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	seedRestore := tokenstore.UseFileBackendForTesting(path)
+
+	const audience = "https://eu.example.io"
+	name, coreService := seedLoginWithJurisdictionTokens(t, audience)
+	seedRestore()
+
+	jurisdictionSvc := tokenstore.JurisdictionService(audience)
+	failJurisdictionDelete := func(service, _ string) bool { return service == jurisdictionSvc }
+	t.Cleanup(tokenstore.UseFailingDeleteBackendForTesting(path, failJurisdictionDelete))
+
+	if err := RemoveContext(name); err == nil {
+		t.Fatal("RemoveContext: want error when the jurisdiction-slot delete fails")
+	}
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load contexts: %v", err)
+	}
+	c := f.Find(name)
+	if c == nil {
+		t.Fatal("context entry was removed despite the failed credential delete")
+	}
+	if !slices.Contains(c.JurisdictionAudiences, audience) {
+		t.Fatalf("recorded audiences = %v, want %q retained for the retry", c.JurisdictionAudiences, audience)
+	}
+	// The access slot is deleted after the jurisdiction slots, so the abort
+	// must have left it alone.
+	if _, err := tokenstore.Get(coreService, "alice"); err != nil {
+		t.Fatalf("access slot should be untouched by the aborted logout: %v", err)
+	}
+}
+
+func TestRememberJurisdictionAudience(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+
+	exp := time.Now().Add(time.Hour).Unix()
+	name, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, testCoreURL, exp)), testRefreshToken, true)
+	if err != nil {
+		t.Fatalf("RecordLoginContext: %v", err)
+	}
+
+	// Recorded once, trailing slash trimmed so the audience matches the
+	// keyring service name the writer and logout both derive.
+	if err := RememberJurisdictionAudience(name, "https://eu.example.io/"); err != nil {
+		t.Fatalf("first record: %v", err)
+	}
+	// Idempotent: the same audience (in either spelling) doesn't duplicate.
+	if err := RememberJurisdictionAudience(name, "https://eu.example.io"); err != nil {
+		t.Fatalf("duplicate record: %v", err)
+	}
+	if err := RememberJurisdictionAudience(name, "https://au.example.io"); err != nil {
+		t.Fatalf("second audience: %v", err)
+	}
+
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load contexts: %v", err)
+	}
+	got := f.Find(name).JurisdictionAudiences
+	want := []string{"https://eu.example.io", "https://au.example.io"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("recorded audiences = %v, want %v", got, want)
+	}
+
+	// A context that isn't there can't be recorded against — the caller must
+	// not then persist a token no logout could find.
+	if err := RememberJurisdictionAudience("nope", "https://eu.example.io"); err == nil {
+		t.Fatal("want error for an unknown context")
+	}
+	if err := RememberJurisdictionAudience(name, "  "); err == nil {
+		t.Fatal("want error for a blank audience")
+	}
+}
+
+// TestRecordLoginContext_ReloginKeepsJurisdictionAudiences guards the upsert:
+// re-logging in replaces the context entry, but the jurisdiction tokens in the
+// keychain (keyed by audience + handle, not by login session) survive it — so
+// dropping the list would strand them beyond any future logout.
+func TestRecordLoginContext_ReloginKeepsJurisdictionAudiences(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+
+	const audience = "https://eu.example.io"
+	name, _ := seedLoginWithJurisdictionTokens(t, audience)
+
+	exp := time.Now().Add(2 * time.Hour).Unix()
+	again, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, testCoreURL, exp)), testRefreshToken, true)
+	if err != nil {
+		t.Fatalf("re-login: %v", err)
+	}
+	if again != name {
+		t.Fatalf("re-login produced context %q, want %q", again, name)
+	}
+
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load contexts: %v", err)
+	}
+	if got := f.Find(name).JurisdictionAudiences; !slices.Equal(got, []string{audience}) {
+		t.Fatalf("recorded audiences after re-login = %v, want [%s]", got, audience)
+	}
+}

--- a/cmd/entire/cli/auth/context_store_test.go
+++ b/cmd/entire/cli/auth/context_store_test.go
@@ -147,6 +147,44 @@ func TestRemoveCurrentContext_DeletesJurisdictionTokens(t *testing.T) {
 	}
 }
 
+// TestRemoveContext_SkipsBlankRecordedAudience covers a hand-edited or
+// corrupted contexts.json: a blank audience would resolve to the bare service
+// prefix, so it must be skipped rather than looked up, and it must not stop the
+// real slots from being deleted.
+func TestRemoveContext_SkipsBlankRecordedAudience(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	seedRestore := tokenstore.UseFileBackendForTesting(path)
+
+	const audience = "https://eu.example.io"
+	name, _ := seedLoginWithJurisdictionTokens(t, audience)
+
+	// Corrupt the record the way only an editor could.
+	if err := contexts.Modify(cfgDir, func(f *contexts.File) (bool, error) {
+		f.Find(name).JurisdictionAudiences = []string{"", "  ", audience}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("seed blank audiences: %v", err)
+	}
+	seedRestore()
+
+	// Any lookup of the bare prefix is the bug this guards against.
+	blank := tokenstore.JurisdictionService("")
+	t.Cleanup(tokenstore.UseObservingBackendForTesting(path, func(op, service, _ string) {
+		if service == blank {
+			t.Errorf("%s on the bare jurisdiction prefix %q", op, service)
+		}
+	}))
+
+	if err := RemoveContext(name); err != nil {
+		t.Fatalf("RemoveContext: %v", err)
+	}
+	if v, err := tokenstore.Get(tokenstore.JurisdictionService(audience), "alice"); !errors.Is(err, tokenstore.ErrNotFound) {
+		t.Fatalf("real jurisdiction token survived logout: value=%q err=%v", v, err)
+	}
+}
+
 // TestRemoveContext_JurisdictionDeleteFailureAbortsLogout extends the existing
 // keychain-delete contract to the jurisdiction slots: a failed delete must
 // surface and leave the context entry in place for a retry, never report

--- a/cmd/entire/cli/auth/contexts.go
+++ b/cmd/entire/cli/auth/contexts.go
@@ -111,12 +111,19 @@ func RecordLoginContext(rawToken, refreshToken string, activate bool) (string, e
 	cfgDir := userdirs.Config()
 	if modErr := contexts.Modify(cfgDir, func(f *contexts.File) (bool, error) {
 		name = pickContextName(f, coreURL, handle)
-		f.Upsert(&contexts.Context{
+		next := &contexts.Context{
 			Name:            name,
 			CoreURL:         coreURL,
 			Handle:          handle,
 			KeychainService: keychainService,
-		})
+		}
+		// Upsert replaces the whole entry, so carry the audiences over: the
+		// jurisdiction tokens are keyed by audience + handle, not by login
+		// session, so they survive this re-login and must stay findable.
+		if prev := f.Find(name); prev != nil {
+			next.JurisdictionAudiences = prev.JurisdictionAudiences
+		}
+		f.Upsert(next)
 		if activate || f.CurrentContext == "" {
 			f.CurrentContext = name
 		}

--- a/cmd/git-remote-entire/jurisdictionauth.go
+++ b/cmd/git-remote-entire/jurisdictionauth.go
@@ -36,13 +36,6 @@ import (
 // semantics.
 const tokenSafetyMargin = time.Minute
 
-// jurisdictionKeyringService is the keychain service name for jurisdiction
-// tokens, keyed by audience so tokens for different jurisdictions
-// (and prod vs staging) can't be confused. The account is the context handle.
-func jurisdictionKeyringService(audience string) string {
-	return "entire-jurisdiction:" + strings.TrimRight(audience, "/")
-}
-
 // jurisdictionTokenSource mints and reuses the jurisdiction token that
 // authenticates every git request: one token covers every repo the account
 // can reach. Tokens come from, in order: the in-process memo, the OS
@@ -69,19 +62,20 @@ type jurisdictionTokenSource struct {
 	exchangeHint string
 	// handle is the context's account handle — the keychain account key.
 	handle string
-	// persist mirrors the token through the OS keychain so later processes
-	// reuse it. Off for the ENTIRE_TOKEN path: CI runners have no keychain,
-	// so the in-process memo is the only reuse.
-	persist bool
-	login   func(context.Context) (string, error)
-	client  *http.Client
+	// recordAudience notes s.audience on the login context so `entire logout`
+	// can find the keychain slot. Non-nil also selects the persisted flavour:
+	// nil means in-process memo only (the ENTIRE_TOKEN path — CI runners are
+	// ephemeral), so "persists" and "is recordable" can't disagree.
+	recordAudience func(audience string) error
+	login          func(context.Context) (string, error)
+	client         *http.Client
 
 	mu        sync.Mutex
 	token     string
 	expiresAt time.Time
 }
 
-func newJurisdictionTokenSource(homeCoreURL, audience, jurisdictionCoreURL, handle string, login func(context.Context) (string, error), client *http.Client) *jurisdictionTokenSource {
+func newJurisdictionTokenSource(homeCoreURL, audience, jurisdictionCoreURL, handle string, login func(context.Context) (string, error), recordAudience func(audience string) error, client *http.Client) *jurisdictionTokenSource {
 	return &jurisdictionTokenSource{
 		// Both core URLs feed httputil.PostOAuthToken, which appends
 		// "/oauth/token" to the base verbatim — trim so a trailing slash
@@ -91,7 +85,7 @@ func newJurisdictionTokenSource(homeCoreURL, audience, jurisdictionCoreURL, hand
 		audience:            audience,
 		jurisdictionCoreURL: strings.TrimRight(jurisdictionCoreURL, "/"),
 		handle:              handle,
-		persist:             true,
+		recordAudience:      recordAudience,
 		login:               login,
 		client:              client,
 	}
@@ -121,8 +115,8 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context) (string, error) {
 		return s.token, nil
 	}
 
-	if s.persist {
-		if encoded, err := tokenstore.Get(jurisdictionKeyringService(s.audience), s.handle); err == nil {
+	if s.persists() {
+		if encoded, err := tokenstore.Get(tokenstore.JurisdictionService(s.audience), s.handle); err == nil {
 			// The empty-token guard rejects a corrupted keychain entry that
 			// decodes to a valid timestamp but no token — otherwise it would
 			// produce bare "Bearer " headers until the entry expired.
@@ -154,14 +148,32 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context) (string, error) {
 	s.token = token
 	margin := min(tokenSafetyMargin, ttl/2)
 	s.expiresAt = time.Now().Add(ttl - margin)
-	if s.persist {
-		if err := tokenstore.Set(jurisdictionKeyringService(s.audience), s.handle, tokenstore.EncodeTokenWithExpiration(token, int64(ttl/time.Second))); err != nil {
-			// Non-fatal: the token still serves this process; the next
-			// invocation just re-mints.
-			debuglog.Printf("jurisdiction token keychain write failed: %v", err)
-		}
+	if s.persists() {
+		s.persistToken(token, ttl)
 	}
 	return token, nil
+}
+
+// persists reports whether this source caches through the OS keychain; see the
+// recordAudience field.
+func (s *jurisdictionTokenSource) persists() bool { return s.recordAudience != nil }
+
+// persistToken mirrors a freshly minted token into the OS keychain so later
+// helper processes reuse it instead of paying the exchange per git command.
+//
+// The audience is recorded FIRST and a failed record skips the write: a
+// persisted-but-unrecorded token is a bearer `entire logout` can't find, while
+// skipping the write only costs one exchange per process. Both failures are
+// non-fatal — the minted token still serves this process.
+func (s *jurisdictionTokenSource) persistToken(token string, ttl time.Duration) {
+	if err := s.recordAudience(s.audience); err != nil {
+		debuglog.Printf("jurisdiction token not cached (aud=%s): recording the audience failed: %v", s.audience, err)
+		return
+	}
+	encoded := tokenstore.EncodeTokenWithExpiration(token, int64(ttl/time.Second))
+	if err := tokenstore.Set(tokenstore.JurisdictionService(s.audience), s.handle, encoded); err != nil {
+		debuglog.Printf("jurisdiction token keychain write failed: %v", err)
+	}
 }
 
 // Invalidate drops the memoized token and the persisted keychain entry, so
@@ -171,13 +183,16 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context) (string, error) {
 // recorded expiry — up to the full 8h TTL — would keep every git command
 // failing. The in-flight command still fails; the next one self-heals.
 // The env-token flavour persists nothing, so only its memo is dropped.
+//
+// The recorded audience stays on the context: deleting an already-gone slot is
+// a no-op, and the next mint re-records it idempotently.
 func (s *jurisdictionTokenSource) Invalidate() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.token = ""
 	s.expiresAt = time.Time{}
-	if s.persist {
-		if err := tokenstore.Delete(jurisdictionKeyringService(s.audience), s.handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
+	if s.persists() {
+		if err := tokenstore.Delete(tokenstore.JurisdictionService(s.audience), s.handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
 			debuglog.Printf("jurisdiction token keychain delete failed: %v", err)
 		}
 	}

--- a/cmd/git-remote-entire/jurisdictionauth_test.go
+++ b/cmd/git-remote-entire/jurisdictionauth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -28,9 +29,17 @@ func fakeLoginJWT(t *testing.T, homeJurisdiction string) string {
 	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
 }
 
+// mintedJurisdictionToken is the access_token every fake core in this file
+// returns, so tests can assert they were served the minted value.
+const mintedJurisdictionToken = "juri-jwt"
+
 func staticLogin(jwt string) func(context.Context) (string, error) {
 	return func(context.Context) (string, error) { return jwt, nil }
 }
+
+// noopRecord selects the keychain-persisted flavour for tests that care only
+// about the caching itself, without touching contexts.json.
+func noopRecord(string) error { return nil }
 
 func TestExchangeCore(t *testing.T) {
 	t.Parallel()
@@ -38,7 +47,7 @@ func TestExchangeCore(t *testing.T) {
 
 	t.Run("same jurisdiction uses home core", func(t *testing.T) {
 		t.Parallel()
-		s := newJurisdictionTokenSource(auCore, "https://au.example.io", auCore, "h", nil, nil)
+		s := newJurisdictionTokenSource(auCore, "https://au.example.io", auCore, "h", nil, nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "au"))
 		if err != nil {
 			t.Fatal(err)
@@ -50,7 +59,7 @@ func TestExchangeCore(t *testing.T) {
 
 	t.Run("home core trailing slash is trimmed", func(t *testing.T) {
 		t.Parallel()
-		s := newJurisdictionTokenSource(auCore+"/", "https://au.example.io", "", "h", nil, nil)
+		s := newJurisdictionTokenSource(auCore+"/", "https://au.example.io", "", "h", nil, nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "au"))
 		if err != nil {
 			t.Fatal(err)
@@ -62,7 +71,7 @@ func TestExchangeCore(t *testing.T) {
 
 	t.Run("home jurisdiction claim casing is folded", func(t *testing.T) {
 		t.Parallel()
-		s := newJurisdictionTokenSource(auCore, "https://au.example.io", "", "h", nil, nil)
+		s := newJurisdictionTokenSource(auCore, "https://au.example.io", "", "h", nil, nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "AU"))
 		if err != nil {
 			t.Fatal(err)
@@ -74,7 +83,7 @@ func TestExchangeCore(t *testing.T) {
 
 	t.Run("cross jurisdiction uses advertised jurisdiction core", func(t *testing.T) {
 		t.Parallel()
-		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", auCore+"/", "h", nil, nil)
+		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", auCore+"/", "h", nil, nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
 		if err != nil {
 			t.Fatal(err)
@@ -86,7 +95,7 @@ func TestExchangeCore(t *testing.T) {
 
 	t.Run("cross jurisdiction without advertised core is refused", func(t *testing.T) {
 		t.Parallel()
-		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "", "h", nil, nil)
+		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "", "h", nil, nil, nil)
 		if _, err := s.exchangeCore(fakeLoginJWT(t, "eu")); err == nil {
 			t.Fatal("expected error when no jurisdiction core is advertised")
 		}
@@ -94,7 +103,7 @@ func TestExchangeCore(t *testing.T) {
 
 	t.Run("non-https advertised core is refused", func(t *testing.T) {
 		t.Parallel()
-		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "http://au.auth.example.io", "h", nil, nil)
+		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "http://au.auth.example.io", "h", nil, nil, nil)
 		if _, err := s.exchangeCore(fakeLoginJWT(t, "eu")); err == nil {
 			t.Fatal("expected error for plaintext advertised core")
 		}
@@ -136,13 +145,13 @@ func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 	// Same-jurisdiction routing: home_jurisdiction "eu" matches the audience
 	// label, so the exchange goes to homeCoreURL — the fake core.
 	login := staticLogin(fakeLoginJWT(t, "eu"))
-	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
+	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, noopRecord, core.Client())
 
 	token, err := s.Token(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if token != "juri-jwt" {
+	if token != mintedJurisdictionToken {
 		t.Fatalf("token = %q", token)
 	}
 	if mints != 1 {
@@ -158,12 +167,12 @@ func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 	}
 
 	// Fresh source (new process): served from the persisted keychain entry.
-	s2 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
+	s2 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, noopRecord, core.Client())
 	token2, err := s2.Token(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if token2 != "juri-jwt" {
+	if token2 != mintedJurisdictionToken {
 		t.Fatalf("token2 = %q", token2)
 	}
 	if mints != 1 {
@@ -171,12 +180,99 @@ func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 	}
 
 	// A different handle must not share the token.
-	s3 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "other-account", login, core.Client())
+	s3 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "other-account", login, noopRecord, core.Client())
 	if _, err := s3.Token(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if mints != 2 {
 		t.Fatalf("mints for different handle = %d, want 2", mints)
+	}
+}
+
+// TestJurisdictionToken_RecordsAudienceBeforePersisting pins the ordering
+// logout depends on: the audience is recorded before the token reaches the
+// credential store, so there is never a window where a persisted data-plane
+// bearer is invisible to `entire logout`.
+func TestJurisdictionToken_RecordsAudienceBeforePersisting(t *testing.T) {
+	const audience = "https://eu.example.io"
+	service := tokenstore.JurisdictionService(audience)
+
+	var events []string
+	restore := tokenstore.UseObservingBackendForTesting(
+		filepath.Join(t.TempDir(), "tokens.json"),
+		func(op, svc, _ string) {
+			if op == "set" && svc == service {
+				events = append(events, "set")
+			}
+		})
+	defer restore()
+
+	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"juri-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
+	}))
+	defer core.Close()
+
+	var recorded []string
+	record := func(aud string) error {
+		events = append(events, "record")
+		recorded = append(recorded, aud)
+		return nil
+	}
+
+	s := newJurisdictionTokenSource(core.URL, audience, "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), record, core.Client())
+	if _, err := s.Token(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(recorded) != 1 || recorded[0] != audience {
+		t.Fatalf("recorded audiences = %v, want [%s]", recorded, audience)
+	}
+	if got := strings.Join(events, ","); got != "record,set" {
+		t.Fatalf("event order = %q, want the audience recorded before the keychain write", got)
+	}
+}
+
+// TestJurisdictionToken_UnrecordableAudienceIsNotPersisted covers the other
+// half of that contract: if the audience can't be recorded, the token must not
+// be cached at all — a token logout cannot find is worse than an extra
+// exchange. The mint itself still succeeds and serves the request.
+func TestJurisdictionToken_UnrecordableAudienceIsNotPersisted(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	defer restore()
+
+	const audience = "https://eu.example.io"
+	mints := 0
+	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mints++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"juri-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
+	}))
+	defer core.Close()
+
+	failRecord := func(string) error { return errors.New("contexts.json is read-only") }
+	login := staticLogin(fakeLoginJWT(t, "eu"))
+
+	s := newJurisdictionTokenSource(core.URL, audience, "", "toothbrush", login, failRecord, core.Client())
+	token, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatalf("mint must still serve this process: %v", err)
+	}
+	if token != mintedJurisdictionToken {
+		t.Fatalf("token = %q", token)
+	}
+	if _, err := tokenstore.Get(tokenstore.JurisdictionService(audience), "toothbrush"); err == nil {
+		t.Fatal("token was persisted despite the audience record failing")
+	}
+
+	// The memo still holds within the process, but a fresh source (next git
+	// command) finds nothing cached and re-mints.
+	s2 := newJurisdictionTokenSource(core.URL, audience, "", "toothbrush", login, failRecord, core.Client())
+	if _, err := s2.Token(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mints != 2 {
+		t.Fatalf("mints = %d, want 2 (nothing was cached for the second source)", mints)
 	}
 }
 
@@ -193,7 +289,7 @@ func TestJurisdictionToken_InvalidateDropsMemoAndKeychain(t *testing.T) {
 	defer core.Close()
 
 	login := staticLogin(fakeLoginJWT(t, "eu"))
-	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
+	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, noopRecord, core.Client())
 	if _, err := s.Token(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +311,7 @@ func TestJurisdictionToken_InvalidateDropsMemoAndKeychain(t *testing.T) {
 	// rather than reading a stale persisted copy. (The re-mint above stored
 	// a new entry, so invalidate again to observe the delete.)
 	s.Invalidate()
-	s2 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
+	s2 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, noopRecord, core.Client())
 	if _, err := s2.Token(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +326,7 @@ func TestJurisdictionToken_EmptyPersistedTokenRemints(t *testing.T) {
 
 	// A corrupted entry: valid future timestamp, empty token. Must not be
 	// served as a bare "Bearer " header.
-	service := jurisdictionKeyringService("https://eu.example.io")
+	service := tokenstore.JurisdictionService("https://eu.example.io")
 	corrupted := tokenstore.TokenExpirationSeparator +
 		strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10)
 	if err := tokenstore.Set(service, "toothbrush", corrupted); err != nil {
@@ -245,7 +341,7 @@ func TestJurisdictionToken_EmptyPersistedTokenRemints(t *testing.T) {
 	}))
 	defer core.Close()
 
-	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
+	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), noopRecord, core.Client())
 	token, err := s.Token(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -260,7 +356,7 @@ func TestJurisdictionToken_ExpiredPersistedTokenRemints(t *testing.T) {
 	defer restore()
 
 	// Seed a token 1 minute from expiry — inside the 5m refresh buffer.
-	service := jurisdictionKeyringService("https://eu.example.io")
+	service := tokenstore.JurisdictionService("https://eu.example.io")
 	expiring := "stale-jwt" + tokenstore.TokenExpirationSeparator +
 		strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10)
 	if err := tokenstore.Set(service, "toothbrush", expiring); err != nil {
@@ -275,7 +371,7 @@ func TestJurisdictionToken_ExpiredPersistedTokenRemints(t *testing.T) {
 	}))
 	defer core.Close()
 
-	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
+	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), noopRecord, core.Client())
 	token, err := s.Token(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -344,7 +440,7 @@ func TestEnvJurisdictionToken_MintsInMemoryOnly(t *testing.T) {
 	if mints != 3 {
 		t.Fatalf("mints for fresh env source = %d, want 3 (no persistence)", mints)
 	}
-	if _, err := tokenstore.Get(jurisdictionKeyringService(audience), ""); err == nil {
+	if _, err := tokenstore.Get(tokenstore.JurisdictionService(audience), ""); err == nil {
 		t.Fatal("env path must not write the jurisdiction token to the token store")
 	}
 }

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -355,7 +355,12 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, skipTLS bool, httpCli
 		return nil, missingJurisdictionAudienceErr(parsedURL.Host)
 	}
 	debuglog.Printf("auth: jurisdiction access token (aud=%s, core=%s)", audience, clusterCtx.CoreURL)
-	return newJurisdictionTokenSource(clusterCtx.CoreURL, audience, clusterAuth.JurisdictionCoreURL, clusterCtx.Handle, loginProvider, httpClient), nil
+	// Passing a recorder is what selects the keychain-persisted flavour; it
+	// keeps this context's audience list current so logout can clean up.
+	recordAudience := func(aud string) error {
+		return auth.RememberJurisdictionAudience(clusterCtx.Name, aud)
+	}
+	return newJurisdictionTokenSource(clusterCtx.CoreURL, audience, clusterAuth.JurisdictionCoreURL, clusterCtx.Handle, loginProvider, recordAudience, httpClient), nil
 }
 
 // resolveEnvTokenCreds builds the jurisdiction-token source for the

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -360,7 +360,7 @@ func TestResolveEnvTokenCreds_TrustedAudSucceeds(t *testing.T) {
 	if creds.audience != audience {
 		t.Errorf("audience = %q, want %q", creds.audience, audience)
 	}
-	if creds.persist {
+	if creds.persists() {
 		t.Error("env-token creds must not persist to the keychain")
 	}
 	if creds.exchangeHint != "" {

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -41,6 +41,10 @@ type Context struct {
 	// KeychainService is the OS-keyring slot where the access token is
 	// filed; the refresh token lives at KeychainService+":refresh".
 	KeychainService string `json:"keychain_service"`
+	// JurisdictionAudiences lists the audiences this context has a jurisdiction
+	// (data-plane) access token filed for, trailing-slash-trimmed; each lives at
+	// tokenstore.JurisdictionService(audience), also keyed by Handle.
+	JurisdictionAudiences []string `json:"jurisdiction_audiences,omitempty"`
 }
 
 // File is the on-disk shape of contexts.json.

--- a/internal/entireclient/tokenstore/testing.go
+++ b/internal/entireclient/tokenstore/testing.go
@@ -51,6 +51,14 @@ func UseFailingDeleteBackendForTesting(path string, failDelete func(service, use
 	return installFaultStore(faultStore{inner: &fileStore{path: path}, failDelete: failDelete})
 }
 
+// UseObservingBackendForTesting wraps a file backend so observe is called with
+// the operation ("get", "set" or "delete") and the (service, user) pair before
+// each call is applied; operations otherwise behave normally. Lets tests assert
+// ordering between a credential write and other bookkeeping around it.
+func UseObservingBackendForTesting(path string, observe func(op, service, user string)) func() {
+	return installFaultStore(faultStore{inner: &fileStore{path: path}, observe: observe})
+}
+
 func installFaultStore(fs faultStore) func() {
 	backendMu.Lock()
 	prevBackend := backend
@@ -72,9 +80,17 @@ type faultStore struct {
 	failSet    func(service, user string) bool
 	failGet    func(service, user string) bool
 	failDelete func(service, user string) bool
+	observe    func(op, service, user string)
+}
+
+func (f faultStore) note(op, service, user string) {
+	if f.observe != nil {
+		f.observe(op, service, user)
+	}
 }
 
 func (f faultStore) Get(service, user string) (string, error) {
+	f.note("get", service, user)
 	if f.failGet != nil && f.failGet(service, user) {
 		return "", fmt.Errorf("injected Get failure for %s/%s", service, user)
 	}
@@ -83,6 +99,7 @@ func (f faultStore) Get(service, user string) (string, error) {
 }
 
 func (f faultStore) Set(service, user, password string) error {
+	f.note("set", service, user)
 	if f.failSet != nil && f.failSet(service, user) {
 		return fmt.Errorf("injected Set failure for %s/%s", service, user)
 	}
@@ -91,6 +108,7 @@ func (f faultStore) Set(service, user, password string) error {
 }
 
 func (f faultStore) Delete(service, user string) error {
+	f.note("delete", service, user)
 	if f.failDelete != nil && f.failDelete(service, user) {
 		return fmt.Errorf("injected Delete failure for %s/%s", service, user)
 	}

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -10,9 +10,11 @@
 // directory — see internal/entireclient/userdirs).
 //
 // Service-name conventions:
-//   - "entire:<cluster-host>"        — entiredb cluster login tokens
-//   - "entire-core:<core-base-url>"  — entire-core control-plane tokens
-//   - "<service>:refresh"            — refresh-token entry paired with the
+//   - "entire:<cluster-host>"          — entiredb cluster login tokens
+//   - "entire-core:<core-base-url>"    — entire-core control-plane tokens
+//   - "entire-jurisdiction:<audience>" — jurisdiction (data-plane) access
+//     tokens, keyed by jurisdiction audience
+//   - "<service>:refresh"              — refresh-token entry paired with the
 //     corresponding access-token service
 package tokenstore
 
@@ -36,8 +38,9 @@ var ErrNotFound = keyring.ErrNotFound
 // at "entire-core:<base-url>" regardless of which CLI wrote it. Two CLIs
 // sharing this prefix on the same machine read each other's writes.
 const (
-	ClusterKeyringPrefix = "entire:"      // entiredb cluster-issued tokens
-	CoreKeyringPrefix    = "entire-core:" // entire-core control-plane tokens
+	ClusterKeyringPrefix = "entire:"              // entiredb cluster-issued tokens
+	CoreKeyringPrefix    = "entire-core:"         // entire-core control-plane tokens
+	JurisdictionPrefix   = "entire-jurisdiction:" // jurisdiction (data-plane) access tokens
 )
 
 // CoreKeyringService returns the service name for tokens issued by
@@ -45,6 +48,15 @@ const (
 // are normalized away so callers don't have to.
 func CoreKeyringService(coreURL string) string {
 	return CoreKeyringPrefix + strings.TrimRight(coreURL, "/")
+}
+
+// JurisdictionService returns the service name for a jurisdiction (data-plane)
+// access token, keyed by the jurisdiction audience so tokens for different
+// jurisdictions — and for prod vs staging — can't be confused. The account key
+// is the login context's handle. Trailing slashes are normalized away so
+// callers don't have to.
+func JurisdictionService(audience string) string {
+	return JurisdictionPrefix + strings.TrimRight(audience, "/")
 }
 
 // RefreshService returns the paired refresh-token service name for an

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -38,9 +38,9 @@ var ErrNotFound = keyring.ErrNotFound
 // at "entire-core:<base-url>" regardless of which CLI wrote it. Two CLIs
 // sharing this prefix on the same machine read each other's writes.
 const (
-	ClusterKeyringPrefix = "entire:"              // entiredb cluster-issued tokens
-	CoreKeyringPrefix    = "entire-core:"         // entire-core control-plane tokens
-	JurisdictionPrefix   = "entire-jurisdiction:" // jurisdiction (data-plane) access tokens
+	ClusterKeyringPrefix      = "entire:"              // entiredb cluster-issued tokens
+	CoreKeyringPrefix         = "entire-core:"         // entire-core control-plane tokens
+	JurisdictionKeyringPrefix = "entire-jurisdiction:" // jurisdiction (data-plane) access tokens
 )
 
 // CoreKeyringService returns the service name for tokens issued by
@@ -56,7 +56,7 @@ func CoreKeyringService(coreURL string) string {
 // is the login context's handle. Trailing slashes are normalized away so
 // callers don't have to.
 func JurisdictionService(audience string) string {
-	return JurisdictionPrefix + strings.TrimRight(audience, "/")
+	return JurisdictionKeyringPrefix + strings.TrimRight(audience, "/")
 }
 
 // RefreshService returns the paired refresh-token service name for an


### PR DESCRIPTION
I saw today the jurisdiction tokens survive a logout.  That was unexpected.  Track them in the context file so they can be cleared on logout.