### PR TITLE
fix(pi): model subagent runs as subagents so checkpoints keep the right transcript

### DIFF
--- a/cmd/entire/cli/agent/event.go
+++ b/cmd/entire/cli/agent/event.go
@@ -111,6 +111,14 @@ type Event struct {
 	// SubagentID identifies the subagent instance (for SubagentEnd events).
 	SubagentID string
 
+	// SubagentTranscriptPath, when set, is the path to the subagent's own
+	// transcript file (SubagentEnd events). Agents that keep subagent
+	// transcripts at a location the framework cannot reconstruct from
+	// SessionRef + SubagentID (e.g. Pi, which stores each run under a nested
+	// <parent>/<sub>/run-N/ directory) set this directly; the SubagentEnd
+	// handler prefers it over the AgentTranscriptPath naming convention.
+	SubagentTranscriptPath string
+
 	// ToolInput is the raw tool input JSON (for subagent type/description extraction).
 	// Used when both SubagentType and TaskDescription are empty (agents that don't provide
 	// these fields directly parse them from ToolInput).

--- a/cmd/entire/cli/agent/pi/lifecycle.go
+++ b/cmd/entire/cli/agent/pi/lifecycle.go
@@ -153,10 +153,15 @@ func (a *PiAgent) ParseHookEvent(ctx context.Context, hookName string, stdin io.
 	}
 	payload := *parsed
 
+	identity := parsePiSessionIdentity(payload.SessionFile)
 	sessionID := payload.SessionID
 	if sessionID == "" {
-		sessionID = extractSessionIDFromPath(payload.SessionFile)
+		sessionID = identity.SessionID
 	}
+	// subagentID is non-empty only for Pi subagent runs, whose transcript path
+	// carries <parent>/<sub>/run-N identity that filepath.Base would otherwise
+	// collapse to the role-named "session" leaf (issue #1870).
+	subagentID := identity.SubagentID
 
 	now := time.Now()
 
@@ -170,6 +175,25 @@ func (a *PiAgent) ParseHookEvent(ctx context.Context, hookName string, stdin io.
 		}, nil
 
 	case HookNameBeforeAgentStart:
+		if subagentID != "" {
+			// A Pi subagent run is starting. Route it through the subagent
+			// mechanism (issue #1870) so pre-task state is captured and the run
+			// is attributed to the parent session rather than a phantom
+			// "session"-named session. No context injection: that is for the
+			// parent turn only.
+			return &agent.Event{
+				Type:       agent.SubagentStart,
+				SessionID:  sessionID,
+				SubagentID: subagentID,
+				ToolUseID:  subagentID,
+				// SessionRef is the parent conversation on both Pi subagent
+				// events (Start/End). The Start handler only logs it and
+				// snapshots pre-task git state, so the value is informational
+				// here; keeping it identical to End avoids a confusing mismatch.
+				SessionRef: derivePiParentTranscript(payload.SessionFile),
+				Timestamp:  now,
+			}, nil
+		}
 		// Pi emits before_agent_start with a fully-populated session ID, but
 		// we cache it anyway to support the agent_end fallback below.
 		if sessionID == "" {
@@ -192,6 +216,29 @@ func (a *PiAgent) ParseHookEvent(ctx context.Context, hookName string, stdin io.
 	case HookNameAgentEnd:
 		if sessionID == "" {
 			sessionID = readCachedSessionID(ctx)
+		}
+		if subagentID != "" {
+			// A Pi subagent run ended. Stage its transcript under the run's own
+			// identity (never the shared "session.json"), attach it to the
+			// parent session as a subagent transcript, and route as SubagentEnd
+			// so distinct runs no longer overwrite one another (issue #1870).
+			subagentRef := captureTranscript(ctx, subagentID, payload.SessionFile)
+			return &agent.Event{
+				Type:       agent.SubagentEnd,
+				SessionID:  sessionID,
+				SubagentID: subagentID,
+				ToolUseID:  subagentID,
+				// SessionRef points at the raw parent transcript, not the staged
+				// .entire/tmp/pi/<parentUUID>.json copy: the parent's agent_end
+				// (which stages that copy) fires last, after every subagent run,
+				// so the staged copy does not exist yet here. The raw path still
+				// exists mid-session and is read best-effort at checkpoint-write
+				// time, so the parent content lands in the shadow tree then.
+				SessionRef:             derivePiParentTranscript(payload.SessionFile),
+				SubagentTranscriptPath: subagentRef,
+				Model:                  extractModelFromPiSessionFile(subagentRef),
+				Timestamp:              now,
+			}, nil
 		}
 		// Capture the Pi JSONL into <repo>/.entire/tmp/pi/<id>.json so the
 		// strategy has a stable transcript reference even if the user later
@@ -360,17 +407,94 @@ func captureTranscript(ctx context.Context, sessionID, piSessionFile string) str
 	return dst
 }
 
-// extractSessionIDFromPath extracts the UUID from a Pi session filename.
-// Pattern: <timestamp>_<uuid>.jsonl → returns <uuid>
-// Falls back to the basename without extension if the pattern doesn't match.
-func extractSessionIDFromPath(p string) string {
+// piSubagentLeaf is the fixed basename Pi gives every subagent run transcript.
+// The run's identity lives in the surrounding directory segments, not this
+// leaf — the bug in issue #1870 was collapsing the path to this literal.
+const piSubagentLeaf = "session.jsonl"
+
+// piSessionIdentity is the identity resolved from a Pi transcript path. For a
+// parent session, SessionID is the session UUID and SubagentID is empty. For a
+// subagent run, SessionID rolls up to the parent UUID and SubagentID names the
+// run (<sub>-run-N) so runs no longer collide on the role-named "session" leaf.
+type piSessionIdentity struct {
+	SessionID  string
+	SubagentID string
+}
+
+// parsePiSessionIdentity resolves a Pi session_file path into its identity.
+// Subagent runs live at <...>/<timestamp>_<uuid>/<sub>/run-N/session.jsonl;
+// parents at <...>/<timestamp>_<uuid>.jsonl.
+func parsePiSessionIdentity(p string) piSessionIdentity {
 	if p == "" {
-		return ""
+		return piSessionIdentity{}
 	}
-	base := filepath.Base(p)
+	if filepath.Base(p) == piSubagentLeaf {
+		if idty, ok := parsePiSubagentPath(p); ok {
+			return idty
+		}
+	}
+	return piSessionIdentity{SessionID: parsePiParentID(filepath.Base(p))}
+}
+
+// parsePiParentID extracts the UUID from a parent transcript basename
+// (<timestamp>_<uuid>.jsonl → <uuid>), falling back to the basename without
+// extension when there is no underscore to split on.
+func parsePiParentID(base string) string {
 	base = strings.TrimSuffix(base, ".jsonl")
 	if i := strings.LastIndex(base, "_"); i >= 0 {
 		return base[i+1:]
 	}
 	return base
+}
+
+// parsePiSubagentPath resolves <...>/<timestamp>_<uuid>/<sub>/run-N/session.jsonl
+// into the parent UUID and a distinct, path-safe run identity. ok is false when
+// the surrounding segments don't match that shape or yield unsafe identifiers,
+// so the caller falls back to parent-style parsing.
+func parsePiSubagentPath(p string) (piSessionIdentity, bool) {
+	runDir := filepath.Dir(p)                        // <...>/<seg>/<sub>/run-N
+	subDir := filepath.Dir(runDir)                   // <...>/<seg>/<sub>
+	parentSeg := filepath.Base(filepath.Dir(subDir)) // <timestamp>_<uuid>
+	run := filepath.Base(runDir)
+	sub := filepath.Base(subDir)
+	if run == "." || sub == "." || parentSeg == "." || parentSeg == string(filepath.Separator) {
+		return piSessionIdentity{}, false
+	}
+	parentID := parsePiParentID(parentSeg)
+	if parentID == "" || parentID == parentSeg {
+		// No <timestamp>_<uuid> underscore split — not the expected shape.
+		return piSessionIdentity{}, false
+	}
+	subagentID := sub + "-" + run
+	// subagentID feeds two consumers with different rules: the dispatcher
+	// (ValidateAgentID) and captureTranscript (the stricter ValidateSessionID,
+	// which also rejects a leading dash). Require both so an exotic <sub> dir
+	// can't parse-pass here and then silently fail to stage its transcript.
+	if validation.ValidateSessionID(parentID) != nil ||
+		validation.ValidateAgentID(subagentID) != nil ||
+		validation.ValidateSessionID(subagentID) != nil {
+		return piSessionIdentity{}, false
+	}
+	return piSessionIdentity{SessionID: parentID, SubagentID: subagentID}, true
+}
+
+// extractSessionIDFromPath returns the Pi session identity's session ID: the
+// parent UUID for both parent and subagent transcript paths.
+func extractSessionIDFromPath(p string) string {
+	return parsePiSessionIdentity(p).SessionID
+}
+
+// derivePiParentTranscript maps a subagent run path
+// <...>/<seg>/<sub>/run-N/session.jsonl to the parent transcript <...>/<seg>.jsonl,
+// so a subagent checkpoint can reference the parent conversation. Returns "" if
+// the path is not a subagent run.
+func derivePiParentTranscript(p string) string {
+	if p == "" || filepath.Base(p) != piSubagentLeaf {
+		return ""
+	}
+	parentSegDir := filepath.Dir(filepath.Dir(filepath.Dir(p))) // <...>/<seg>
+	if parentSegDir == "." || parentSegDir == string(filepath.Separator) {
+		return ""
+	}
+	return parentSegDir + ".jsonl"
 }

--- a/cmd/entire/cli/agent/pi/lifecycle_test.go
+++ b/cmd/entire/cli/agent/pi/lifecycle_test.go
@@ -181,6 +181,10 @@ func TestExtractSessionIDFromPath(t *testing.T) {
 		"abc-123.jsonl":                             "abc-123",
 		"/tmp/no-underscore-here.jsonl":             "no-underscore-here",
 		"/path/with/multiple_under_scores_id.jsonl": "id",
+		// Issue #1870: Pi subagent runs live at <ts>_<uuid>/<sub>/run-N/session.jsonl.
+		// The identity is the parent UUID, not the role-named "session" leaf.
+		"/s/slug/2026-07-29T00-36-01-991Z_019fab4c-c147-7b3a/d93a3451/run-0/session.jsonl": "019fab4c-c147-7b3a",
+		"/s/slug/2026-07-29T00-36-01-991Z_019fab4c-c147-7b3a/716671d6/run-2/session.jsonl": "019fab4c-c147-7b3a",
 	}
 	for in, want := range cases {
 		if got := extractSessionIDFromPath(in); got != want {

--- a/cmd/entire/cli/agent/pi/subagent_1870_test.go
+++ b/cmd/entire/cli/agent/pi/subagent_1870_test.go
@@ -1,0 +1,210 @@
+package pi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// Tests for issue #1870: every Pi subagent transcript is named session.jsonl,
+// so extractSessionIDFromPath collapsed each run to the literal "session".
+// That collision keyed both the staged capture and the shadow archive on one
+// ID, so runs overwrote each other and checkpoints read the wrong transcript.
+//
+// Fix direction 1: model Pi subagents as subagents — roll the session ID up to
+// the parent UUID, give each run a distinct SubagentID, and stage each run's
+// transcript at its own path (surfaced via Event.SubagentTranscriptPath).
+
+const (
+	repro1870ParentUUID = "019fab4c-c147-7b3a-8cc9-9ebd7224663b"
+	repro1870ParentSeg  = "2026-07-29T00-36-01-991Z_019fab4c-c147-7b3a-8cc9-9ebd7224663b"
+)
+
+// writePiParentFile lays down a parent transcript: <ts>_<uuid>.jsonl.
+func writePiParentFile(t *testing.T, root, body string) string {
+	t.Helper()
+	p := filepath.Join(root, "sessions", "slug", repro1870ParentSeg+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// writePiSubagentFile lays down a subagent run transcript at the real Pi shape:
+// <ts>_<uuid>/<sub>/run-<n>/session.jsonl.
+func writePiSubagentFile(t *testing.T, root, sub, run, body string) string {
+	t.Helper()
+	p := filepath.Join(root, "sessions", "slug", repro1870ParentSeg, sub, run, "session.jsonl")
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func mustParsePi(t *testing.T, hook, sessionFile string) *agent.Event {
+	t.Helper()
+	payload := `{"type":` + strconv.Quote(hook) + `,"session_file":` + strconv.Quote(sessionFile) + `}`
+	ev, err := (&PiAgent{}).ParseHookEvent(context.Background(), hook, strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("ParseHookEvent(%s): %v", hook, err)
+	}
+	if ev == nil {
+		t.Fatalf("ParseHookEvent(%s): nil event", hook)
+	}
+	return ev
+}
+
+// subagentTranscriptRef returns the reference a checkpoint would read for a
+// subagent run: the dedicated subagent transcript path when set, else the
+// generic transcript reference. Under the bug the latter is the shared
+// session.json; the fix populates the former with a distinct per-run path.
+func subagentTranscriptRef(ev *agent.Event) string {
+	if ev.SubagentTranscriptPath != "" {
+		return ev.SubagentTranscriptPath
+	}
+	return ev.SessionRef
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	if path == "" {
+		t.Fatalf("no transcript path to read (want content %q)", want)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Errorf("transcript %s = %q, want %q", path, string(got), want)
+	}
+}
+
+// T1 — the parse must not collapse subagent paths to the role-named leaf.
+// Direction 1: a subagent transcript's session ID rolls up to the parent UUID.
+func TestExtractSessionIDFromPath_SubagentRollsUpToParent(t *testing.T) {
+	t.Parallel()
+	base := "/Users/x/.pi/agent/sessions/slug"
+	parent := base + "/" + repro1870ParentSeg + ".jsonl"
+	subA := base + "/" + repro1870ParentSeg + "/d93a3451/run-0/session.jsonl"
+	subB := base + "/" + repro1870ParentSeg + "/716671d6/run-2/session.jsonl"
+
+	if got := extractSessionIDFromPath(parent); got != repro1870ParentUUID {
+		t.Fatalf("parent: got %q, want %q", got, repro1870ParentUUID)
+	}
+	for _, p := range []string{subA, subB} {
+		got := extractSessionIDFromPath(p)
+		if got == "session" {
+			t.Fatalf("subagent path %q collapsed to literal %q (issue #1870)", p, got)
+		}
+		if got != repro1870ParentUUID {
+			t.Errorf("subagent path %q: got %q, want parent UUID %q", p, got, repro1870ParentUUID)
+		}
+	}
+}
+
+// T2 — two subagent runs must be distinguishable as subagent events: same
+// (parent) session ID, distinct SubagentID, routed through the subagent
+// mechanism rather than arriving as ordinary turns.
+func TestParseHookEvent_PiSubagentRunsRouteAsSubagents(t *testing.T) {
+	// Not parallel: agent_end capture resolves the cache dir from cwd.
+	root := t.TempDir()
+	t.Chdir(root)
+
+	run0 := writePiSubagentFile(t, root, "d93a3451", "run-0", `{"run":"0"}`+"\n")
+	run2 := writePiSubagentFile(t, root, "716671d6", "run-2", `{"run":"2"}`+"\n")
+
+	startEv := mustParsePi(t, HookNameBeforeAgentStart, run0)
+	if startEv.Type != agent.SubagentStart {
+		t.Errorf("before_agent_start subagent: Type = %v, want SubagentStart", startEv.Type)
+	}
+
+	end0 := mustParsePi(t, HookNameAgentEnd, run0)
+	end2 := mustParsePi(t, HookNameAgentEnd, run2)
+
+	for _, ev := range []*agent.Event{end0, end2} {
+		if ev.Type != agent.SubagentEnd {
+			t.Errorf("agent_end subagent: Type = %v, want SubagentEnd", ev.Type)
+		}
+		if ev.SessionID != repro1870ParentUUID {
+			t.Errorf("SessionID = %q, want parent UUID %q (rolled up)", ev.SessionID, repro1870ParentUUID)
+		}
+	}
+	if end0.SubagentID == "" || end2.SubagentID == "" {
+		t.Fatalf("subagent runs must carry a SubagentID (got %q, %q)", end0.SubagentID, end2.SubagentID)
+	}
+	if end0.SubagentID == end2.SubagentID {
+		t.Fatalf("distinct subagent runs share SubagentID %q (issue #1870 collision)", end0.SubagentID)
+	}
+}
+
+// T3 — each participant (parent + every subagent run) must stage its own
+// transcript. Under the bug every run collapses onto session.json.
+func TestParseHookEvent_PiSubagentCaptureDoesNotClobber(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+
+	parentBody := `{"who":"parent"}` + "\n"
+	run0Body := `{"who":"run0"}` + "\n"
+	run2Body := `{"who":"run2"}` + "\n"
+
+	parent := writePiParentFile(t, root, parentBody)
+	run0 := writePiSubagentFile(t, root, "d93a3451", "run-0", run0Body)
+	run2 := writePiSubagentFile(t, root, "716671d6", "run-2", run2Body)
+
+	parentEv := mustParsePi(t, HookNameAgentEnd, parent)
+	end0 := mustParsePi(t, HookNameAgentEnd, run0)
+	end2 := mustParsePi(t, HookNameAgentEnd, run2)
+
+	parentRef := parentEv.SessionRef
+	ref0 := subagentTranscriptRef(end0)
+	ref2 := subagentTranscriptRef(end2)
+
+	refs := map[string]string{"parent": parentRef, "run0": ref0, "run2": ref2}
+	for name, ref := range refs {
+		if ref == "" {
+			t.Fatalf("%s: empty transcript reference", name)
+		}
+	}
+	if parentRef == ref0 || parentRef == ref2 || ref0 == ref2 {
+		t.Fatalf("transcript references collide: parent=%q run0=%q run2=%q", parentRef, ref0, ref2)
+	}
+
+	assertFileContent(t, parentRef, parentBody)
+	assertFileContent(t, ref0, run0Body)
+	assertFileContent(t, ref2, run2Body)
+}
+
+// T4 — the checkpoint for one subagent run must keep that run's transcript,
+// even after a later run ends. This is the exact corruption in #1870: two
+// commits from one session, the second condensed against the last writer.
+func TestParseHookEvent_PiSubagentTranscriptSurvivesLaterRun(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+
+	run0Body := `{"who":"run0","commit":"first"}` + "\n"
+	run2Body := `{"who":"run2","commit":"second"}` + "\n"
+
+	// Run-0 ends and its transcript is staged for the first commit.
+	run0 := writePiSubagentFile(t, root, "d93a3451", "run-0", run0Body)
+	end0 := mustParsePi(t, HookNameAgentEnd, run0)
+	ref0 := subagentTranscriptRef(end0)
+	assertFileContent(t, ref0, run0Body)
+
+	// Later, a different subagent run ends (the "last writer" in the issue).
+	run2 := writePiSubagentFile(t, root, "716671d6", "run-2", run2Body)
+	mustParsePi(t, HookNameAgentEnd, run2)
+
+	// Run-0's staged transcript must be untouched — not the later run's content.
+	assertFileContent(t, ref0, run0Body)
+}

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -1081,11 +1081,16 @@ func handleLifecycleSubagentEnd(ctx context.Context, ag agent.Agent, event *agen
 		event.SubagentType, event.TaskDescription = ParseSubagentTypeAndDescription(event.ToolInput)
 	}
 
-	// Determine subagent transcript path
-	transcriptDir := filepath.Dir(event.SessionRef)
+	// Determine subagent transcript path. An agent that stores per-subagent
+	// transcripts where the framework cannot reconstruct them from
+	// SessionRef + SubagentID (e.g. Pi's nested <parent>/<sub>/run-N layout,
+	// issue #1870) sets the path explicitly; otherwise fall back to the
+	// agent-<id>.jsonl convention beside the main transcript.
 	var subagentTranscriptPath string
-	if event.SubagentID != "" {
-		subagentTranscriptPath = AgentTranscriptPath(transcriptDir, event.SubagentID)
+	if event.SubagentTranscriptPath != "" {
+		subagentTranscriptPath = event.SubagentTranscriptPath
+	} else if event.SubagentID != "" {
+		subagentTranscriptPath = AgentTranscriptPath(filepath.Dir(event.SessionRef), event.SubagentID)
 		if !fileExists(subagentTranscriptPath) {
 			subagentTranscriptPath = ""
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/953
<!-- entire-trail-link-end -->

Fixes #1870.

## Summary

Every Pi subagent run resolved to the same session ID — the literal string `session` — because the ID was parsed from the transcript's basename, and Pi names every subagent transcript `session.jsonl`. That one ID keyed both transcript paths (the staged capture `.entire/tmp/pi/<id>.json` and the shadow archive `.entire/<id>/`), so runs overwrote each other and a checkpoint condensed whichever run wrote last — storing a *different* subagent's conversation. Reproduces with a single Pi session and one subagent; no concurrency required.

This takes **direction 1** from the issue: model Pi subagents as subagents — roll the session ID up to the parent UUID, give each run a distinct identity, and route runs through the existing subagent mechanism so each gets its own transcript.

## What Changed

- **`agent/pi/lifecycle.go`** — new `parsePiSessionIdentity` (+ `parsePiSubagentPath`, `parsePiParentID`, `derivePiParentTranscript`) resolves the path shape:
  - parent `…/<ts>_<uuid>.jsonl` → session ID = `<uuid>`
  - subagent `…/<ts>_<uuid>/<sub>/run-N/session.jsonl` → session ID rolls up to the parent `<uuid>`, plus a distinct `<sub>-run-N` id.

  `ParseHookEvent` now routes subagent `before_agent_start`/`agent_end` to `SubagentStart`/`SubagentEnd` (parent turns still emit `TurnStart`/`TurnEnd`), and stages each run's transcript under its own identity. The parse validates the derived id against **both** consumers (`ValidateAgentID` for the dispatcher and the stricter `ValidateSessionID` for the capture key) so an exotic dir name can't parse-pass then silently fail to stage.
- **`agent/event.go`** — added `Event.SubagentTranscriptPath` for agents whose per-subagent transcripts can't be reconstructed from `SessionRef` + `SubagentID` (Pi's nested `<parent>/<sub>/run-N` layout).
- **`lifecycle.go`** — `handleLifecycleSubagentEnd` prefers `event.SubagentTranscriptPath`, falling back to the existing `agent-<id>.jsonl` convention. Claude Code / Cursor are unaffected (the new field is empty for them).

Net effect: one Pi session per conversation (no phantom `session · turns N` row), a distinct staged/stored transcript per run, and task checkpoints that roll up under the parent session with uncontaminated content.

## Tests

Written test-first, all confirmed **red** before the fix, green after:

- `TestExtractSessionIDFromPath_SubagentRollsUpToParent` — subagent paths roll to the parent UUID, never `"session"`.
- `TestParseHookEvent_PiSubagentRunsRouteAsSubagents` — subagent runs emit `SubagentStart`/`SubagentEnd`, share the parent `SessionID`, carry distinct `SubagentID`s.
- `TestParseHookEvent_PiSubagentCaptureDoesNotClobber` — parent + each run stage distinct, content-correct transcripts.
- `TestParseHookEvent_PiSubagentTranscriptSurvivesLaterRun` — one run's staged transcript isn't overwritten when a later run ends (the exact corruption).
- `TestExtractSessionIDFromPath` — extended the canonical table with the nested subagent shape and dropped the case that pinned the wrong fallback.

## Verification

- `mise run fmt`, lint (golangci-lint v2.11.3, pinned) — clean.
- `mise run test:ci` (full race suite + e2e canary) — green; `pi`, `agent/*`, `checkpoint/*`, `strategy`, `cli` suites green.
- **End-to-end smoke test** with the real binary in a scratch repo, driving a parent turn + two subagent runs that each modify a file:
  - `entire session list` → one Pi session with the real parent UUID, no phantom `session` row.
  - `.entire/tmp/pi/` → three distinct captures (`019fab4c-….json`, `d93a3451-run-0.json`, `716671d6-run-1.json`), no shared `session.json`.
  - Shadow branch → task checkpoints under `…/<parentUUID>/tasks/<run>/agent-<run>.jsonl`, each storing its **own** run's content (run-0 → run0 marker, run-1 → run1 marker), zero cross-contamination.

## Deferred

The issue's optional "have `entire_extension.ts` send `session_id` explicitly" was intentionally dropped: the path parse is now correct and load-bearing, so it's unnecessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Pi hook routing and subagent checkpoint transcript resolution; mistakes could mis-attribute sessions or corrupt task checkpoints, but scope is Pi-specific with a clear fallback for other agents.
> 
> **Overview**
> Fixes **#1870**: Pi subagent hooks used to derive session ID from `session.jsonl` basenames, so every run shared the ID `session` and **staged transcripts / task checkpoints overwrote each other**.
> 
> **Pi lifecycle** now parses nested paths (`…/<ts>_<uuid>/<sub>/run-N/session.jsonl`), rolls **SessionID** up to the parent UUID, assigns a distinct **`<sub>-run-N`** subagent ID, and emits **`SubagentStart` / `SubagentEnd`** instead of normal turns. Each run is staged via `captureTranscript` under its own cache key.
> 
> **Framework**: `agent.Event` gains **`SubagentTranscriptPath`**; `handleLifecycleSubagentEnd` prefers it over the `agent-<id>.jsonl` convention beside the main transcript.
> 
> Other agents are unchanged when the new field is empty. Regression coverage lives in `subagent_1870_test.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9b8d49248cc78b2ac4ea1aecc961a711a89343e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->