### PR TITLE
ci: run Windows unit tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,28 @@ jobs:
           E2E_CHECKPOINT_STORE: ${{ matrix.checkpoint_store }}
         run: mise run test:e2e:canary
 
+  test-windows:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      # Real-Windows tests must include Windows or MSYS in their top-level
+      # test name so this job selects them without running POSIX-only harnesses.
+      - name: Windows unit tests
+        run: go test ./cmd/entire/cli/... -run '(Windows|MSYS)' -count=1 -v
+
   test:
     runs-on: ubuntu-latest
     needs:
       - test-core
       - test-integration
       - test-canary
+      - test-windows
     if: ${{ always() }}
     steps:
       - name: Check dependencies
@@ -80,3 +96,4 @@ jobs:
           [ "${{ needs.test-core.result }}" = "success" ]
           [ "${{ needs.test-integration.result }}" = "success" ]
           [ "${{ needs.test-canary.result }}" = "success" ]
+          [ "${{ needs.test-windows.result }}" = "success" ]

--- a/cmd/entire/cli/agent/hook_command.go
+++ b/cmd/entire/cli/agent/hook_command.go
@@ -67,9 +67,7 @@ func WrapProductionJSONWarningHookCommand(command string, format WarningFormat) 
 	)
 }
 
-// Hook runners execute Windows command strings through cmd.exe already, so
-// these wrappers contain cmd.exe syntax directly rather than launching a
-// second nested shell. They use an `if errorlevel 1 (…) else (<command>)` form
+// The Windows wrappers use an `if errorlevel 1 (…) else (<command>)` form
 // rather than a `where … || <else> & <command>` form. This keeps the wrapped
 // command INSIDE the else branch, so there is no unconditional trailing
 // command to fall through to and correctness does NOT depend on `exit /b`
@@ -86,14 +84,16 @@ func WrapProductionJSONWarningHookCommand(command string, format WarningFormat) 
 // from native Windows shells.
 func WrapWindowsProductionSilentHookCommand(command string) string {
 	return fmt.Sprintf(
-		`where.exe entire >nul 2>nul & if errorlevel 1 (ver>nul) else (%s)`,
+		`cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 (ver>nul) else (%s)"`,
 		command,
 	)
 }
 
 // WrapWindowsProductionJSONWarningHookCommand emits a JSON hook response with a
 // systemMessage field on stdout when the Entire CLI is missing from PATH. It
-// avoids sh so Codex hooks still work from native Windows shells.
+// avoids sh so Codex hooks still work from native Windows shells. Codex already
+// runs hook commands through cmd.exe /C, so this JSON-bearing command uses that
+// shell directly instead of adding a second quote-parsing layer.
 func WrapWindowsProductionJSONWarningHookCommand(command string, format WarningFormat) string {
 	payload, err := jsonutil.MarshalWithNoHTMLEscape(struct {
 		SystemMessage string `json:"systemMessage,omitempty"`
@@ -111,8 +111,8 @@ func WrapWindowsProductionJSONWarningHookCommand(command string, format WarningF
 	)
 }
 
-// WrapWindowsProductionPlainTextWarningHookCommand emits the warning as plain
-// text to stdout when the Entire CLI is missing from PATH.
+// WrapWindowsProductionPlainTextWarningHookCommand is the direct-shell fallback
+// for WrapWindowsProductionJSONWarningHookCommand when JSON marshaling fails.
 func WrapWindowsProductionPlainTextWarningHookCommand(command string, format WarningFormat) string {
 	return fmt.Sprintf(
 		`where.exe entire >nul 2>nul & if errorlevel 1 (echo %s) else (%s)`,
@@ -133,7 +133,7 @@ func WrapProductionPlainTextWarningHookCommand(command string, format WarningFor
 
 const productionHookWrapperPrefix = `sh -c 'if ! command -v entire >/dev/null 2>&1; then `
 const windowsProductionHookWrapperPrefix = `where.exe entire >nul 2>nul & if errorlevel 1 `
-const legacyWindowsProductionHookWrapperPrefix = `cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 `
+const nestedWindowsProductionHookWrapperPrefix = `cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 `
 
 // IsManagedHookCommand reports whether command is either a direct Entire hook
 // command or one of Entire's production wrapper forms that exec that command.
@@ -150,7 +150,7 @@ func IsManagedHookCommand(command string, prefixes []string) bool {
 		return hasManagedHookPrefix(wrappedCommand, prefixes)
 	}
 	if strings.HasPrefix(command, windowsProductionHookWrapperPrefix) ||
-		strings.HasPrefix(command, legacyWindowsProductionHookWrapperPrefix) {
+		strings.HasPrefix(command, nestedWindowsProductionHookWrapperPrefix) {
 		// The wrapped command lives in the `else (<command>)` branch. Take the
 		// last ` else (` so a warning string containing the marker can't fool us.
 		const elseMarker = " else ("

--- a/cmd/entire/cli/agent/hook_command.go
+++ b/cmd/entire/cli/agent/hook_command.go
@@ -104,7 +104,7 @@ func WrapWindowsProductionJSONWarningHookCommand(command string, format WarningF
 
 	return fmt.Sprintf(
 		`cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 (echo %s) else (%s)"`,
-		escapeWindowsCMD(string(payload)),
+		escapeWindowsCMDForNestedCommand(string(payload)),
 		command,
 	)
 }
@@ -114,7 +114,7 @@ func WrapWindowsProductionJSONWarningHookCommand(command string, format WarningF
 func WrapWindowsProductionPlainTextWarningHookCommand(command string, format WarningFormat) string {
 	return fmt.Sprintf(
 		`cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 (echo %s) else (%s)"`,
-		escapeWindowsCMD(windowsPlainTextWarning(format)),
+		escapeWindowsCMDForNestedCommand(windowsPlainTextWarning(format)),
 		command,
 	)
 }
@@ -171,16 +171,13 @@ func hasManagedHookPrefix(command string, prefixes []string) bool {
 	return false
 }
 
-// escapeWindowsCMD caret-escapes the cmd.exe block metacharacters that would
-// otherwise terminate the `(echo …)` warning block or redirect its output.
+// escapeWindowsCMD caret-escapes one cmd.exe parsing layer's block
+// metacharacters so they cannot terminate the `(echo …)` warning block or
+// redirect its output.
 //
-// `%` is deliberately NOT escaped. These wrappers are a `cmd.exe /d /s /c`
-// command line, not a batch script, so batch's `%%` doubling does not apply
-// (it would print a literal `%%`), and caret-escaping `%` is not a thing cmd
-// recognizes — `^%` would leak the caret. On the command line a lone `%` is
-// literal and `%NAME%` only expands for a defined environment variable, so the
-// fixed, %-free warning constant is emitted verbatim. If the warning text ever
-// gains a `%NAME%` that collides with a real env var, revisit this.
+// `%` is deliberately NOT escaped because caret-escaping `%` is not something
+// cmd.exe recognizes — `^%` would leak the caret. The fixed warning constants
+// are %-free; if that changes, percent expansion needs separate handling.
 func escapeWindowsCMD(s string) string {
 	replacer := strings.NewReplacer(
 		`^`, `^^`,
@@ -193,6 +190,13 @@ func escapeWindowsCMD(s string) string {
 		`)`, `^)`,
 	)
 	return replacer.Replace(s)
+}
+
+// escapeWindowsCMDForNestedCommand preserves metacharacter escaping through
+// the hook runner's outer cmd.exe /c so the nested cmd.exe /d /s /c receives
+// one complete escape layer of its own.
+func escapeWindowsCMDForNestedCommand(s string) string {
+	return escapeWindowsCMD(escapeWindowsCMD(s))
 }
 
 func windowsPlainTextWarning(format WarningFormat) string {

--- a/cmd/entire/cli/agent/hook_command.go
+++ b/cmd/entire/cli/agent/hook_command.go
@@ -67,7 +67,9 @@ func WrapProductionJSONWarningHookCommand(command string, format WarningFormat) 
 	)
 }
 
-// The Windows wrappers use an `if errorlevel 1 (…) else (<command>)` form
+// Hook runners execute Windows command strings through cmd.exe already, so
+// these wrappers contain cmd.exe syntax directly rather than launching a
+// second nested shell. They use an `if errorlevel 1 (…) else (<command>)` form
 // rather than a `where … || <else> & <command>` form. This keeps the wrapped
 // command INSIDE the else branch, so there is no unconditional trailing
 // command to fall through to and correctness does NOT depend on `exit /b`
@@ -84,7 +86,7 @@ func WrapProductionJSONWarningHookCommand(command string, format WarningFormat) 
 // from native Windows shells.
 func WrapWindowsProductionSilentHookCommand(command string) string {
 	return fmt.Sprintf(
-		`cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 (ver>nul) else (%s)"`,
+		`where.exe entire >nul 2>nul & if errorlevel 1 (ver>nul) else (%s)`,
 		command,
 	)
 }
@@ -103,8 +105,8 @@ func WrapWindowsProductionJSONWarningHookCommand(command string, format WarningF
 	}
 
 	return fmt.Sprintf(
-		`cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 (echo %s) else (%s)"`,
-		escapeWindowsCMDForNestedCommand(string(payload)),
+		`where.exe entire >nul 2>nul & if errorlevel 1 (echo %s) else (%s)`,
+		escapeWindowsCMD(string(payload)),
 		command,
 	)
 }
@@ -113,8 +115,8 @@ func WrapWindowsProductionJSONWarningHookCommand(command string, format WarningF
 // text to stdout when the Entire CLI is missing from PATH.
 func WrapWindowsProductionPlainTextWarningHookCommand(command string, format WarningFormat) string {
 	return fmt.Sprintf(
-		`cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 (echo %s) else (%s)"`,
-		escapeWindowsCMDForNestedCommand(windowsPlainTextWarning(format)),
+		`where.exe entire >nul 2>nul & if errorlevel 1 (echo %s) else (%s)`,
+		escapeWindowsCMD(windowsPlainTextWarning(format)),
 		command,
 	)
 }
@@ -130,7 +132,8 @@ func WrapProductionPlainTextWarningHookCommand(command string, format WarningFor
 }
 
 const productionHookWrapperPrefix = `sh -c 'if ! command -v entire >/dev/null 2>&1; then `
-const windowsProductionHookWrapperPrefix = `cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 `
+const windowsProductionHookWrapperPrefix = `where.exe entire >nul 2>nul & if errorlevel 1 `
+const legacyWindowsProductionHookWrapperPrefix = `cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 `
 
 // IsManagedHookCommand reports whether command is either a direct Entire hook
 // command or one of Entire's production wrapper forms that exec that command.
@@ -146,7 +149,8 @@ func IsManagedHookCommand(command string, prefixes []string) bool {
 
 		return hasManagedHookPrefix(wrappedCommand, prefixes)
 	}
-	if strings.HasPrefix(command, windowsProductionHookWrapperPrefix) {
+	if strings.HasPrefix(command, windowsProductionHookWrapperPrefix) ||
+		strings.HasPrefix(command, legacyWindowsProductionHookWrapperPrefix) {
 		// The wrapped command lives in the `else (<command>)` branch. Take the
 		// last ` else (` so a warning string containing the marker can't fool us.
 		const elseMarker = " else ("
@@ -171,13 +175,13 @@ func hasManagedHookPrefix(command string, prefixes []string) bool {
 	return false
 }
 
-// escapeWindowsCMD caret-escapes one cmd.exe parsing layer's block
-// metacharacters so they cannot terminate the `(echo …)` warning block or
-// redirect its output.
+// escapeWindowsCMD caret-escapes the cmd.exe block metacharacters that would
+// otherwise terminate the `(echo …)` warning block or redirect its output.
 //
-// `%` is deliberately NOT escaped because caret-escaping `%` is not something
-// cmd.exe recognizes — `^%` would leak the caret. The fixed warning constants
-// are %-free; if that changes, percent expansion needs separate handling.
+// `%` is deliberately NOT escaped. Hook runners pass these strings to a cmd /c
+// command line, not a batch script, so batch's `%%` doubling does not apply,
+// and caret-escaping `%` would leak the caret. The fixed warning constants are
+// %-free; if that changes, percent expansion needs separate handling.
 func escapeWindowsCMD(s string) string {
 	replacer := strings.NewReplacer(
 		`^`, `^^`,
@@ -190,13 +194,6 @@ func escapeWindowsCMD(s string) string {
 		`)`, `^)`,
 	)
 	return replacer.Replace(s)
-}
-
-// escapeWindowsCMDForNestedCommand preserves metacharacter escaping through
-// the hook runner's outer cmd.exe /c so the nested cmd.exe /d /s /c receives
-// one complete escape layer of its own.
-func escapeWindowsCMDForNestedCommand(s string) string {
-	return escapeWindowsCMD(escapeWindowsCMD(s))
 }
 
 func windowsPlainTextWarning(format WarningFormat) string {

--- a/cmd/entire/cli/agent/hook_command_exec_windows_test.go
+++ b/cmd/entire/cli/agent/hook_command_exec_windows_test.go
@@ -1,22 +1,21 @@
 package agent
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 )
 
-// runWindowsWrapper executes a Windows hook wrapper string through cmd.exe and
-// returns its stdout and exit code. The wrapper is written verbatim to a .bat
-// file (rather than re-quoted into argv) so the test exercises exactly the
-// string Entire writes into hooks.json. PATH is scoped so `where.exe entire`
-// resolves only when entirePresent is true.
-func runWindowsWrapper(t *testing.T, wrapper string, entirePresent bool) (string, int) {
+// runWindowsWrapper mirrors Codex's Windows command runner: cmd.exe /C followed
+// by the raw, quoted hook command. SysProcAttr.CmdLine is required because
+// cmd.exe does not use the standard Windows argv unquoting rules.
+func runWindowsWrapper(t *testing.T, wrapper string, entirePresent bool) (string, string, int) {
 	t.Helper()
 
 	sysRoot := os.Getenv("SystemRoot")
@@ -36,23 +35,28 @@ func runWindowsWrapper(t *testing.T, wrapper string, entirePresent bool) (string
 	t.Setenv("PATH", strings.Join(pathEntries, ";"))
 
 	runDir := t.TempDir()
-	batPath := filepath.Join(runDir, "run.bat")
-	if err := os.WriteFile(batPath, []byte(wrapper+"\r\n"), 0o700); err != nil {
-		t.Fatalf("write run.bat: %v", err)
+	cmdPath, err := exec.LookPath("cmd.exe")
+	if err != nil {
+		t.Fatalf("find cmd.exe: %v", err)
 	}
 
-	// /q suppresses batch command echo so stdout contains only wrapper output.
-	cmd := exec.CommandContext(t.Context(), "cmd.exe", "/d", "/q", "/s", "/c", batPath)
+	cmd := exec.CommandContext(t.Context(), cmdPath)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CmdLine: `"` + cmdPath + `" /C "` + wrapper + `"`,
+	}
 	cmd.Dir = runDir // clean CWD so `where` can't find a stray entire next to us
-	out, err := cmd.Output()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return string(out), exitErr.ExitCode()
+			return stdout.String(), stderr.String(), exitErr.ExitCode()
 		}
 		t.Fatalf("run wrapper: %v", err)
 	}
-	return string(out), 0
+	return stdout.String(), stderr.String(), 0
 }
 
 // TestWindowsWrappers_Execution verifies the cmd.exe wrappers behave correctly
@@ -61,53 +65,50 @@ func runWindowsWrapper(t *testing.T, wrapper string, entirePresent bool) (string
 // (and propagates its exit code) when entire is present, and is skipped with a
 // 0 exit when entire is absent, for both the silent and JSON-warning forms.
 func TestWindowsWrappers_Execution(t *testing.T) {
-	if runtime.GOOS != windowsOS {
-		t.Skip("cmd.exe wrapper execution test runs only on Windows")
-	}
 	// No t.Parallel(): t.Setenv("PATH") forbids it.
 
 	const marker = "ENTIRE_HOOK_RAN"
 
 	t.Run("silent/present runs the command", func(t *testing.T) {
-		out, code := runWindowsWrapper(t, WrapWindowsProductionSilentHookCommand("echo "+marker), true)
+		out, stderr, code := runWindowsWrapper(t, WrapWindowsProductionSilentHookCommand("echo "+marker), true)
 		if !strings.Contains(out, marker) {
-			t.Fatalf("expected wrapped command to run; stdout=%q", out)
+			t.Fatalf("expected wrapped command to run; stdout=%q stderr=%q", out, stderr)
 		}
 		if code != 0 {
-			t.Fatalf("expected exit 0, got %d", code)
+			t.Fatalf("expected exit 0, got %d; stderr=%q", code, stderr)
 		}
 	})
 
 	t.Run("silent/present propagates the command exit code", func(t *testing.T) {
-		_, code := runWindowsWrapper(t, WrapWindowsProductionSilentHookCommand("cmd /c exit 7"), true)
+		_, stderr, code := runWindowsWrapper(t, WrapWindowsProductionSilentHookCommand("cmd /c exit 7"), true)
 		if code != 7 {
-			t.Fatalf("expected wrapped command exit code 7 to propagate, got %d", code)
+			t.Fatalf("expected wrapped command exit code 7 to propagate, got %d; stderr=%q", code, stderr)
 		}
 	})
 
 	t.Run("silent/absent skips the command and exits 0", func(t *testing.T) {
-		out, code := runWindowsWrapper(t, WrapWindowsProductionSilentHookCommand("echo "+marker), false)
+		out, stderr, code := runWindowsWrapper(t, WrapWindowsProductionSilentHookCommand("echo "+marker), false)
 		if strings.Contains(out, marker) {
-			t.Fatalf("wrapped command must NOT run when entire absent; stdout=%q", out)
+			t.Fatalf("wrapped command must NOT run when entire absent; stdout=%q stderr=%q", out, stderr)
 		}
 		if code != 0 {
-			t.Fatalf("expected exit 0 when entire absent, got %d", code)
+			t.Fatalf("expected exit 0 when entire absent, got %d; stderr=%q", code, stderr)
 		}
 	})
 
 	t.Run("json/absent emits valid JSON and skips the command", func(t *testing.T) {
-		out, code := runWindowsWrapper(t, WrapWindowsProductionJSONWarningHookCommand("echo "+marker, WarningFormatSingleLine), false)
+		out, stderr, code := runWindowsWrapper(t, WrapWindowsProductionJSONWarningHookCommand("echo "+marker, WarningFormatSingleLine), false)
 		if strings.Contains(out, marker) {
-			t.Fatalf("wrapped command must NOT run when entire absent; stdout=%q", out)
+			t.Fatalf("wrapped command must NOT run when entire absent; stdout=%q stderr=%q", out, stderr)
 		}
 		if code != 0 {
-			t.Fatalf("expected exit 0, got %d", code)
+			t.Fatalf("expected exit 0, got %d; stderr=%q", code, stderr)
 		}
 		var payload struct {
 			SystemMessage string `json:"systemMessage"`
 		}
 		if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &payload); err != nil {
-			t.Fatalf("expected valid JSON on stdout, got %q (err %v)", out, err)
+			t.Fatalf("expected valid JSON on stdout, got %q stderr=%q (err %v)", out, stderr, err)
 		}
 		if !strings.Contains(payload.SystemMessage, "Entire CLI") {
 			t.Fatalf("unexpected systemMessage: %q", payload.SystemMessage)
@@ -115,15 +116,15 @@ func TestWindowsWrappers_Execution(t *testing.T) {
 	})
 
 	t.Run("json/present runs the command without a warning", func(t *testing.T) {
-		out, code := runWindowsWrapper(t, WrapWindowsProductionJSONWarningHookCommand("echo "+marker, WarningFormatSingleLine), true)
+		out, stderr, code := runWindowsWrapper(t, WrapWindowsProductionJSONWarningHookCommand("echo "+marker, WarningFormatSingleLine), true)
 		if !strings.Contains(out, marker) {
-			t.Fatalf("expected wrapped command to run; stdout=%q", out)
+			t.Fatalf("expected wrapped command to run; stdout=%q stderr=%q", out, stderr)
 		}
 		if strings.Contains(out, "systemMessage") {
-			t.Fatalf("warning must NOT be emitted when entire present; stdout=%q", out)
+			t.Fatalf("warning must NOT be emitted when entire present; stdout=%q stderr=%q", out, stderr)
 		}
 		if code != 0 {
-			t.Fatalf("expected exit 0, got %d", code)
+			t.Fatalf("expected exit 0, got %d; stderr=%q", code, stderr)
 		}
 	})
 }

--- a/cmd/entire/cli/agent/hook_command_exec_windows_test.go
+++ b/cmd/entire/cli/agent/hook_command_exec_windows_test.go
@@ -127,4 +127,18 @@ func TestWindowsWrappers_Execution(t *testing.T) {
 			t.Fatalf("expected exit 0, got %d; stderr=%q", code, stderr)
 		}
 	})
+
+	t.Run("json/present propagates the command exit code", func(t *testing.T) {
+		out, stderr, code := runWindowsWrapper(
+			t,
+			WrapWindowsProductionJSONWarningHookCommand("cmd /c exit 7", WarningFormatSingleLine),
+			true,
+		)
+		if strings.Contains(out, "systemMessage") {
+			t.Fatalf("warning must NOT be emitted when entire present; stdout=%q stderr=%q", out, stderr)
+		}
+		if code != 7 {
+			t.Fatalf("expected wrapped command exit code 7 to propagate, got %d; stderr=%q", code, stderr)
+		}
+	})
 }

--- a/cmd/entire/cli/agent/hook_command_test.go
+++ b/cmd/entire/cli/agent/hook_command_test.go
@@ -90,8 +90,8 @@ func TestWrapWindowsProductionJSONWarningHookCommand(t *testing.T) {
 	if !strings.Contains(command, "where.exe entire") {
 		t.Fatalf("windows wrapper missing PATH guard, got %q", command)
 	}
-	if !strings.Contains(command, "^\"systemMessage^\"") {
-		t.Fatalf("windows wrapper missing escaped systemMessage JSON, got %q", command)
+	if !strings.Contains(command, "^^^\"systemMessage^^^\"") {
+		t.Fatalf("windows wrapper missing nested-shell escaped systemMessage JSON, got %q", command)
 	}
 	if !strings.Contains(command, "entire hooks codex session-start") {
 		t.Fatalf("windows wrapper missing hook target, got %q", command)

--- a/cmd/entire/cli/agent/hook_command_test.go
+++ b/cmd/entire/cli/agent/hook_command_test.go
@@ -87,11 +87,14 @@ func TestWrapWindowsProductionJSONWarningHookCommand(t *testing.T) {
 	if strings.Contains(command, "sh -c") {
 		t.Fatalf("windows wrapper should not use sh, got %q", command)
 	}
+	if strings.HasPrefix(command, "cmd.exe ") {
+		t.Fatalf("windows wrapper should use the hook runner's existing cmd.exe shell, got %q", command)
+	}
 	if !strings.Contains(command, "where.exe entire") {
 		t.Fatalf("windows wrapper missing PATH guard, got %q", command)
 	}
-	if !strings.Contains(command, "^^^\"systemMessage^^^\"") {
-		t.Fatalf("windows wrapper missing nested-shell escaped systemMessage JSON, got %q", command)
+	if !strings.Contains(command, "^\"systemMessage^\"") {
+		t.Fatalf("windows wrapper missing escaped systemMessage JSON, got %q", command)
 	}
 	if !strings.Contains(command, "entire hooks codex session-start") {
 		t.Fatalf("windows wrapper missing hook target, got %q", command)
@@ -109,6 +112,9 @@ func TestWrapWindowsProductionSilentHookCommand(t *testing.T) {
 	if strings.Contains(command, "sh -c") {
 		t.Fatalf("windows wrapper should not use sh, got %q", command)
 	}
+	if strings.HasPrefix(command, "cmd.exe ") {
+		t.Fatalf("windows wrapper should use the hook runner's existing cmd.exe shell, got %q", command)
+	}
 	if !strings.Contains(command, "where.exe entire") {
 		t.Fatalf("windows wrapper missing PATH guard, got %q", command)
 	}
@@ -125,6 +131,9 @@ func TestWrapWindowsProductionPlainTextWarningHookCommandUsesSingleLineWarning(t
 
 	command := WrapWindowsProductionPlainTextWarningHookCommand("entire hooks codex session-start", WarningFormatMultiLine)
 
+	if strings.HasPrefix(command, "cmd.exe ") {
+		t.Fatalf("windows wrapper should use the hook runner's existing cmd.exe shell, got %q", command)
+	}
 	if strings.Contains(command, "\n") {
 		t.Fatalf("windows wrapper should keep warning command single-line, got %q", command)
 	}
@@ -200,6 +209,10 @@ func TestIsManagedHookCommand_WrappedPrefix(t *testing.T) {
 		prefixes,
 	) {
 		t.Fatal("expected windows wrapped json warning command to match")
+	}
+	legacyWindowsWrapper := `cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 (ver>nul) else (entire hooks codex stop)"`
+	if !IsManagedHookCommand(legacyWindowsWrapper, prefixes) {
+		t.Fatal("expected legacy nested windows wrapper to remain managed for migration")
 	}
 }
 

--- a/cmd/entire/cli/agent/hook_command_test.go
+++ b/cmd/entire/cli/agent/hook_command_test.go
@@ -88,7 +88,7 @@ func TestWrapWindowsProductionJSONWarningHookCommand(t *testing.T) {
 		t.Fatalf("windows wrapper should not use sh, got %q", command)
 	}
 	if strings.HasPrefix(command, "cmd.exe ") {
-		t.Fatalf("windows wrapper should use the hook runner's existing cmd.exe shell, got %q", command)
+		t.Fatalf("windows JSON wrapper should use Codex's existing cmd.exe shell, got %q", command)
 	}
 	if !strings.Contains(command, "where.exe entire") {
 		t.Fatalf("windows wrapper missing PATH guard, got %q", command)
@@ -112,8 +112,8 @@ func TestWrapWindowsProductionSilentHookCommand(t *testing.T) {
 	if strings.Contains(command, "sh -c") {
 		t.Fatalf("windows wrapper should not use sh, got %q", command)
 	}
-	if strings.HasPrefix(command, "cmd.exe ") {
-		t.Fatalf("windows wrapper should use the hook runner's existing cmd.exe shell, got %q", command)
+	if !strings.HasPrefix(command, "cmd.exe ") {
+		t.Fatalf("silent windows wrapper should retain its explicit cmd.exe shell, got %q", command)
 	}
 	if !strings.Contains(command, "where.exe entire") {
 		t.Fatalf("windows wrapper missing PATH guard, got %q", command)
@@ -210,9 +210,9 @@ func TestIsManagedHookCommand_WrappedPrefix(t *testing.T) {
 	) {
 		t.Fatal("expected windows wrapped json warning command to match")
 	}
-	legacyWindowsWrapper := `cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 (ver>nul) else (entire hooks codex stop)"`
-	if !IsManagedHookCommand(legacyWindowsWrapper, prefixes) {
-		t.Fatal("expected legacy nested windows wrapper to remain managed for migration")
+	nestedWindowsWrapper := `cmd.exe /d /s /c "where.exe entire >nul 2>nul & if errorlevel 1 (ver>nul) else (entire hooks codex stop)"`
+	if !IsManagedHookCommand(nestedWindowsWrapper, prefixes) {
+		t.Fatal("expected nested windows wrapper to remain managed")
 	}
 }
 

--- a/cmd/entire/cli/agent/hook_command_windows_exec_test.go
+++ b/cmd/entire/cli/agent/hook_command_windows_exec_test.go
@@ -41,7 +41,8 @@ func runWindowsWrapper(t *testing.T, wrapper string, entirePresent bool) (string
 		t.Fatalf("write run.bat: %v", err)
 	}
 
-	cmd := exec.CommandContext(t.Context(), "cmd.exe", "/d", "/s", "/c", batPath)
+	// /q suppresses batch command echo so stdout contains only wrapper output.
+	cmd := exec.CommandContext(t.Context(), "cmd.exe", "/d", "/q", "/s", "/c", batPath)
 	cmd.Dir = runDir // clean CWD so `where` can't find a stray entire next to us
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/956
<!-- entire-trail-link-end -->

## Summary

- add a `windows-latest` unit-test job to the existing pull-request CI workflow
- run Windows/MSYS-named CLI tests with the Go version from `go.mod`
- wire the Windows job into the required aggregate `test` check

## Why

Windows-only unit tests currently skip in every per-PR job because all required CI jobs run on Ubuntu. Go reports those skips as successful, so regressions in `cmd.exe` wrappers, `PATHEXT` discovery, plugin paths, and MSYS path handling are invisible until someone runs them manually on Windows.

This keeps the initial scope targeted: it reuses the existing Windows-focused tests without attempting to make every POSIX-oriented test harness Windows-compatible.

Closes #1843.

## Validation

- `mise run check`
- `mise run lint`
- `go test ./cmd/entire/cli/... -run (Windows|MSYS) -count=1 -v`
- YAML parse validation and `git diff --check`

The real Windows-only test bodies will execute in the new `windows-latest` CI job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow changes only; no runtime product or security-sensitive code paths are modified.
> 
> **Overview**
> Adds a **`test-windows`** job on `windows-latest` that runs `go test ./cmd/entire/cli/...` with `-run '(Windows|MSYS)'`, so Windows/MSYS-focused CLI tests actually execute on PRs instead of being skipped on Ubuntu.
> 
> The aggregate **`test`** job now **depends on** `test-windows` and fails the required check if that job does not succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1bfe9a0ccbda1b109cbac344a30d04f9fa73060. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->