### PR TITLE
perf(codex): stop unmarshalling the whole rollout to compute token usage

### DIFF
--- a/cmd/entire/cli/agent/codex/review_tokens.go
+++ b/cmd/entire/cli/agent/codex/review_tokens.go
@@ -183,22 +183,34 @@ func pollForRollout(ctx context.Context, sessionDir, threadID string, stop <-cha
 	}
 }
 
-// parseRolloutTokenCount extracts cumulative input/output token totals from one
-// rollout JSONL line. ok is false for any line that isn't a token_count event
-// carrying total_token_usage. Reuses the rolloutLine/eventMsgPayload/
-// tokenCountInfo shapes from transcript.go so the two readers can't drift.
-func parseRolloutTokenCount(data []byte) (in, out int, ok bool) {
+// parseRolloutTokenUsage extracts the cumulative token totals from one rollout
+// JSONL line. ok is false for any line that isn't a token_count event carrying
+// total_token_usage. Uses the rolloutLine/eventMsgPayload/tokenCountInfo shapes
+// from transcript.go, and is the only reader of that envelope — both this
+// file's stream tailer and the turn-end token calculation go through it, so
+// they can't drift.
+func parseRolloutTokenUsage(data []byte) (*tokenUsageData, bool) {
 	var line rolloutLine
 	if json.Unmarshal(data, &line) != nil || line.Type != "event_msg" {
-		return 0, 0, false
+		return nil, false
 	}
 	var evt eventMsgPayload
 	if json.Unmarshal(line.Payload, &evt) != nil || evt.Type != "token_count" || len(evt.Info) == 0 {
-		return 0, 0, false
+		return nil, false
 	}
 	var info tokenCountInfo
 	if json.Unmarshal(evt.Info, &info) != nil || info.TotalTokenUsage == nil {
+		return nil, false
+	}
+	return info.TotalTokenUsage, true
+}
+
+// parseRolloutTokenCount reports just the input/output totals the review stream
+// tailer needs.
+func parseRolloutTokenCount(data []byte) (in, out int, ok bool) {
+	usage, ok := parseRolloutTokenUsage(data)
+	if !ok {
 		return 0, 0, false
 	}
-	return info.TotalTokenUsage.InputTokens, info.TotalTokenUsage.OutputTokens, true
+	return usage.InputTokens, usage.OutputTokens, true
 }

--- a/cmd/entire/cli/agent/codex/review_tokens_test.go
+++ b/cmd/entire/cli/agent/codex/review_tokens_test.go
@@ -39,6 +39,46 @@ func TestParseRolloutTokenCount(t *testing.T) {
 	}
 }
 
+// TestParseRolloutTokenUsage_AgreesWithTokenCount pins the wrapper to the
+// general parser: parseRolloutTokenCount must report exactly what
+// parseRolloutTokenUsage found, and the general form must additionally surface
+// cached_input_tokens, which the in/out wrapper drops.
+func TestParseRolloutTokenUsage_AgreesWithTokenCount(t *testing.T) {
+	t.Parallel()
+
+	line := []byte(`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":` +
+		`{"input_tokens":10000,"cached_input_tokens":8000,"output_tokens":200,"total_tokens":10200}}}}`)
+
+	usage, ok := parseRolloutTokenUsage(line)
+	if !ok {
+		t.Fatal("parseRolloutTokenUsage: got ok=false, want true")
+	}
+	if usage.CachedInputTokens != 8000 {
+		t.Errorf("cached_input_tokens: got %d, want 8000", usage.CachedInputTokens)
+	}
+
+	in, out, ok := parseRolloutTokenCount(line)
+	if !ok || in != usage.InputTokens || out != usage.OutputTokens {
+		t.Errorf("wrapper diverged: got in=%d out=%d ok=%v, want %d/%d/true",
+			in, out, ok, usage.InputTokens, usage.OutputTokens)
+	}
+
+	// Both forms must reject the same lines.
+	for _, bad := range []string{
+		`{"type":"response_item","payload":{"type":"reasoning"}}`,
+		`{"type":"event_msg","payload":{"type":"agent_message","message":"token_count"}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{}}}`,
+		`not json`,
+		``,
+	} {
+		_, usageOK := parseRolloutTokenUsage([]byte(bad))
+		_, _, countOK := parseRolloutTokenCount([]byte(bad))
+		if usageOK || countOK {
+			t.Errorf("expected both to reject %q, got usage=%v count=%v", bad, usageOK, countOK)
+		}
+	}
+}
+
 // TestTailRolloutTokens_TailsAppendedLines is the core behavior: the tailer
 // must emit Tokens for token_count lines that codex appends *after* the tailer
 // has already caught up to EOF (a plain bufio.Reader would miss these).

--- a/cmd/entire/cli/agent/codex/transcript.go
+++ b/cmd/entire/cli/agent/codex/transcript.go
@@ -263,41 +263,76 @@ func classifyApplyPatchPaths(input string) (added, modified, deleted []string) {
 	return added, modified, deleted
 }
 
+// tokenCountMarker is the byte prefilter for the token-usage walk. Every
+// token_count event contains it, because it is the value of the event's own type
+// field, so a line without it can never be one.
+var tokenCountMarker = []byte("token_count")
+
 // CalculateTokenUsage computes token usage from the transcript starting at the given line offset.
 // Codex reports cumulative total_token_usage, so we compute the delta between the last
 // token_count at/before the offset and the last token_count after the offset.
 func (c *CodexAgent) CalculateTokenUsage(transcriptData []byte, fromOffset int) (*agent.TokenUsage, error) {
+	return calculateTokenUsage(transcriptData, fromOffset, nil)
+}
+
+// calculateTokenUsage walks the rollout once and unmarshals only the lines that
+// can carry a token_count event.
+//
+// PERF: the turn-end hook calls this with the whole cumulative rollout on every
+// turn, so anything done per line is paid again every turn. Unmarshalling each
+// line just to read its envelope type made that quadratic over a session:
+// rollouts embed large encrypted_content reasoning blobs, and
+// json.RawMessage.UnmarshalJSON copies every payload it decodes, so each hook
+// scanned, validated and heap-copied every blob in the session to throw it away
+// unread. Measured on a synthetic 500-turn rollout, that was ~59ms per hook
+// against ~2ms for the walk below.
+//
+// The byte prefilter cannot miss an event (see tokenCountMarker), and every line
+// it admits still goes through the full envelope check, so per-line decisions —
+// and therefore the numbers — are identical to unmarshalling everything. Lines
+// that merely mention token_count in their text are rejected there, exactly as
+// before; nothing is trusted on the strength of the byte match alone.
+//
+// onParse, when non-nil, is called once per line that reaches the unmarshal.
+// Tests use it to assert that work tracks the number of token_count events
+// rather than the size of the transcript.
+func calculateTokenUsage(transcriptData []byte, fromOffset int, onParse func()) (*agent.TokenUsage, error) {
 	var baselineUsage *tokenUsageData // last token_count at or before offset
 	var lastUsage *tokenUsageData     // last token_count after offset
 	apiCalls := 0
 	lineNum := 0
 
-	for _, lineData := range splitJSONL(transcriptData) {
+	for rest := transcriptData; len(rest) > 0; {
+		lineData := rest
+		if idx := bytes.IndexByte(rest, '\n'); idx >= 0 {
+			lineData, rest = rest[:idx], rest[idx+1:]
+		} else {
+			rest = nil
+		}
+
+		// splitJSONL skips whitespace-only lines, and the offsets handed to this
+		// function are in its coordinates, so the same lines must not be counted.
+		lineData = bytes.TrimSpace(lineData)
+		if len(lineData) == 0 {
+			continue
+		}
 		lineNum++
 
-		var line rolloutLine
-		if json.Unmarshal(lineData, &line) != nil {
+		if !bytes.Contains(lineData, tokenCountMarker) {
 			continue
 		}
-		if line.Type != "event_msg" {
-			continue
+		if onParse != nil {
+			onParse()
 		}
-		var evt eventMsgPayload
-		if json.Unmarshal(line.Payload, &evt) != nil {
-			continue
-		}
-		if evt.Type != "token_count" || len(evt.Info) == 0 {
-			continue
-		}
-		var info tokenCountInfo
-		if json.Unmarshal(evt.Info, &info) != nil || info.TotalTokenUsage == nil {
+		usage, ok := parseRolloutTokenUsage(lineData)
+		if !ok {
 			continue
 		}
 
 		if lineNum <= fromOffset {
-			baselineUsage = info.TotalTokenUsage
+			baselineUsage = usage
 		} else {
-			lastUsage = info.TotalTokenUsage
+			lastUsage = usage
 			apiCalls++
 		}
 	}

--- a/cmd/entire/cli/agent/codex/transcript_tokens_test.go
+++ b/cmd/entire/cli/agent/codex/transcript_tokens_test.go
@@ -1,0 +1,253 @@
+package codex
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin CalculateTokenUsage's observable behaviour so the byte-prefilter
+// rewrite can be proven to change only how much work happens, never the numbers.
+// They were written against the pre-rewrite implementation and pass unchanged
+// against both.
+
+const (
+	tokenCountA = `{"timestamp":"t","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":5000,"cached_input_tokens":4000,"output_tokens":100,"total_tokens":5100}}}}`
+	tokenCountB = `{"timestamp":"t","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10000,"cached_input_tokens":8000,"output_tokens":200,"total_tokens":10200}}}}`
+	sessionMeta = `{"timestamp":"t","type":"session_meta","payload":{"id":"x","cwd":"/tmp/repo"}}`
+	userMessage = `{"timestamp":"t","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}`
+
+	// A real event_msg of another type whose text merely mentions token_count.
+	// Any session discussing token accounting emits one of these.
+	decoyMentioningTokenCount = `{"timestamp":"t","type":"event_msg","payload":{"type":"agent_message","message":"the token_count event carries cumulative totals"}}`
+
+	// A reasoning blob. Codex writes encrypted_content as URL-safe base64, whose
+	// alphabet includes '_', so the literal token_count can appear inside one.
+	blobMentioningTokenCount = `{"timestamp":"t","type":"response_item","payload":{"type":"reasoning","encrypted_content":"QUJDRA_token_count_RUZHSA"}}`
+)
+
+func rollout(lines ...string) []byte {
+	return []byte(strings.Join(lines, "\n") + "\n")
+}
+
+// syntheticRollout builds a rollout of the given number of turns. Each turn is a
+// user message, blobsPerTurn reasoning lines carrying a blobKB payload, and one
+// cumulative token_count — the shape that made the old whole-file unmarshal
+// expensive.
+func syntheticRollout(turns, blobsPerTurn, blobKB int) []byte {
+	blob := strings.Repeat("QUJDRE_VGdoSWpLbE1uT3BRclN0VXZXeFla", blobKB*1024/35)
+	var b strings.Builder
+	b.WriteString(sessionMeta + "\n")
+	for i := 1; i <= turns; i++ {
+		b.WriteString(userMessage + "\n")
+		for range blobsPerTurn {
+			fmt.Fprintf(&b, `{"timestamp":"t","type":"response_item","payload":{"type":"reasoning","encrypted_content":%q}}`+"\n", blob)
+		}
+		fmt.Fprintf(&b,
+			`{"timestamp":"t","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":%d,"cached_input_tokens":%d,"output_tokens":%d,"total_tokens":%d}}}}`+"\n",
+			i*5000, i*4000, i*100, i*5100)
+	}
+	return []byte(b.String())
+}
+
+// TestCalculateTokenUsage_ParseWorkTracksEventsNotTranscriptSize is the
+// regression gate for the performance fix. It counts unmarshals rather than
+// wall-clock, so it is deterministic and safe in CI.
+//
+// The bound has to be tight enough to distinguish "skipped the blob lines" from
+// "parsed everything": with several lines per turn, a whole-file parser is also
+// linear in turns, so a loose ratio between two session lengths would pass for
+// both. Pinning parses at one per token_count event, and asserting the fixture
+// holds several times more lines than that, is what makes the gate meaningful.
+func TestCalculateTokenUsage_ParseWorkTracksEventsNotTranscriptSize(t *testing.T) {
+	t.Parallel()
+
+	for _, turns := range []int{10, 100, 1000} {
+		t.Run(fmt.Sprintf("turns_%d", turns), func(t *testing.T) {
+			t.Parallel()
+			data := syntheticRollout(turns, 3, 1)
+			totalLines := len(splitJSONL(data))
+
+			parses := 0
+			usage, err := calculateTokenUsage(data, totalLines-3, func() { parses++ })
+			require.NoError(t, err)
+			require.NotNil(t, usage)
+
+			// One token_count per turn, plus slack for the marker appearing anywhere else.
+			require.LessOrEqualf(t, parses, turns+2,
+				"parsed %d lines for %d turns — blob lines are reaching the unmarshal", parses, turns)
+			// Without this the bound above would also hold for a parser that read
+			// every line, since the fixture's line count is itself linear in turns.
+			require.Greaterf(t, totalLines, 3*(turns+2),
+				"fixture too thin to prove anything: %d lines for a bound of %d", totalLines, turns+2)
+		})
+	}
+}
+
+// BenchmarkCalculateTokenUsage measures a single turn-end hook against sessions
+// of growing length — the shape of the original complaint, where late-turn hooks
+// felt like a hang. Reported for the record; the assertion above is the gate.
+func BenchmarkCalculateTokenUsage(b *testing.B) {
+	for _, turns := range []int{50, 200, 500} {
+		b.Run(fmt.Sprintf("turns_%d", turns), func(b *testing.B) {
+			ag := &CodexAgent{}
+			data := syntheticRollout(turns, 4, 8)
+			from := len(splitJSONL(data)) - 4
+			b.SetBytes(int64(len(data)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if _, err := ag.CalculateTokenUsage(data, from); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// TestCalculateTokenUsage_EveryOffset pins the full offset sweep over the shared
+// sampleRollout fixture, including both ends and past EOF. sampleRollout has 12
+// non-empty lines with token_count events on lines 4, 8 and 11.
+func TestCalculateTokenUsage_EveryOffset(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+
+	type want struct {
+		fresh, cache, out, calls int
+		nilUsage                 bool
+	}
+	// Offsets 0-3 precede every token_count, so they share the no-baseline result;
+	// 4-7 baseline on line 4; 8-10 baseline on line 8; from 11 on there is no
+	// token_count after the offset at all, so the nil, nil contract applies.
+	cases := map[int]want{
+		0:  {fresh: 3000, cache: 12000, out: 300, calls: 3},
+		1:  {fresh: 3000, cache: 12000, out: 300, calls: 3},
+		3:  {fresh: 3000, cache: 12000, out: 300, calls: 3},
+		4:  {fresh: 2000, cache: 8000, out: 200, calls: 2},
+		7:  {fresh: 2000, cache: 8000, out: 200, calls: 2},
+		8:  {fresh: 1000, cache: 4000, out: 100, calls: 1},
+		10: {fresh: 1000, cache: 4000, out: 100, calls: 1},
+		11: {nilUsage: true},
+		12: {nilUsage: true},
+		99: {nilUsage: true}, // past EOF
+	}
+
+	for offset, exp := range cases {
+		t.Run(fmt.Sprintf("offset_%d", offset), func(t *testing.T) {
+			t.Parallel()
+			usage, err := ag.CalculateTokenUsage([]byte(sampleRollout), offset)
+			require.NoError(t, err)
+			if exp.nilUsage {
+				require.Nil(t, usage)
+				return
+			}
+			require.NotNil(t, usage)
+			require.Equal(t, exp.fresh, usage.InputTokens, "fresh input")
+			require.Equal(t, exp.cache, usage.CacheReadTokens, "cache read")
+			require.Equal(t, exp.out, usage.OutputTokens, "output")
+			require.Equal(t, exp.calls, usage.APICallCount, "api calls")
+		})
+	}
+}
+
+// TestCalculateTokenUsage_BlankLinesDoNotShiftNumbering is the line-numbering
+// parity test. Offsets are in splitJSONL coordinates, which count only non-empty
+// lines, so padding the transcript with blank and whitespace-only lines must not
+// move the boundary. A rewrite that counted physical newlines instead would
+// silently pick the wrong baseline.
+func TestCalculateTokenUsage_BlankLinesDoNotShiftNumbering(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+
+	dense := rollout(sessionMeta, tokenCountA, userMessage, tokenCountB)
+	padded := rollout(sessionMeta, "", tokenCountA, "   ", "\t", userMessage, "", tokenCountB)
+
+	for offset := range 6 {
+		denseUsage, err := ag.CalculateTokenUsage(dense, offset)
+		require.NoError(t, err)
+		paddedUsage, err := ag.CalculateTokenUsage(padded, offset)
+		require.NoError(t, err)
+		require.Equal(t, denseUsage, paddedUsage, "offset %d: blank lines shifted the boundary", offset)
+	}
+}
+
+// TestCalculateTokenUsage_DecoyDoesNotDisplaceBaseline guards the byte prefilter.
+// Lines that merely contain the literal token_count must be rejected by the
+// envelope type check, not mistaken for the baseline. Getting this wrong loses
+// the baseline entirely and silently doubles the reported numbers.
+func TestCalculateTokenUsage_DecoyDoesNotDisplaceBaseline(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+
+	for name, decoy := range map[string]string{
+		"event_msg_of_another_type": decoyMentioningTokenCount,
+		"reasoning_blob":            blobMentioningTokenCount,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// Boundary at line 3, so the baseline is tokenCountA on line 2 and the
+			// decoy on line 3 sits between it and the boundary.
+			data := rollout(sessionMeta, tokenCountA, decoy, tokenCountB)
+
+			usage, err := ag.CalculateTokenUsage(data, 3)
+			require.NoError(t, err)
+			require.NotNil(t, usage)
+
+			// B - A = {in 5000, cache 4000, out 100} → fresh 1000.
+			require.Equal(t, 1000, usage.InputTokens, "baseline was displaced")
+			require.Equal(t, 4000, usage.CacheReadTokens)
+			require.Equal(t, 100, usage.OutputTokens)
+			require.Equal(t, 1, usage.APICallCount, "decoy counted as an API call")
+		})
+	}
+}
+
+// TestCalculateTokenUsage_MalformedLinesIgnored pins tolerance: a truncated or
+// non-JSON line is skipped rather than failing the hook.
+func TestCalculateTokenUsage_MalformedLinesIgnored(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+
+	data := rollout(
+		sessionMeta,
+		tokenCountA,
+		`{"type":"event_msg","payload":{"type":"token_`, // truncated mid-token
+		`not json at all`,
+		tokenCountB,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":`, // truncated tail
+	)
+
+	usage, err := ag.CalculateTokenUsage(data, 2)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.Equal(t, 1000, usage.InputTokens)
+	require.Equal(t, 4000, usage.CacheReadTokens)
+	require.Equal(t, 100, usage.OutputTokens)
+	require.Equal(t, 1, usage.APICallCount)
+}
+
+// TestCalculateTokenUsage_BaselineAboveLastStaysUnclamped documents a deliberate
+// asymmetry in the current accounting: only fresh input tokens are floored at
+// zero. When cumulative totals go backwards — a session reset or compaction —
+// cache-read and output deltas stay negative. The rewrite must not start
+// clamping them.
+func TestCalculateTokenUsage_BaselineAboveLastStaysUnclamped(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+
+	// Baseline is the larger B on line 2; the last value is the smaller A.
+	data := rollout(sessionMeta, tokenCountB, userMessage, tokenCountA)
+
+	usage, err := ag.CalculateTokenUsage(data, 2)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+
+	// in = 5000-10000 = -5000, cache = 4000-8000 = -4000,
+	// fresh = -5000 - (-4000) = -1000 → floored to 0. out = 100-200 = -100.
+	require.Equal(t, 0, usage.InputTokens, "fresh input must be floored at zero")
+	require.Equal(t, -4000, usage.CacheReadTokens, "cache read must stay unclamped")
+	require.Equal(t, -100, usage.OutputTokens, "output must stay unclamped")
+	require.Equal(t, 1, usage.APICallCount)
+}


### PR DESCRIPTION
Fixes #1836.

Per @gtrrz-victor's direction on the issue, this reevaluates the Codex token-usage path rather than porting Claude's slice-first pattern. Scope held to Codex-only, token-usage calculation only, same numbers out.

## Where the cost was

Not the whole-file split — `splitJSONL`'s `bytes.Split`/`TrimSpace` return subslices and copy nothing. It's `json.RawMessage.UnmarshalJSON`, which is `*m = append((*m)[0:0], data...)`: it **copies**. So every `response_item` line's `encrypted_content` reasoning blob was scanned, validated and heap-copied on every hook, then thrown away unread. The old path measured ~280 MB/s — unmarshal-bound.

`CalculateTokenUsage` needs three things from all that work: the last cumulative `total_token_usage` at or before the boundary, the last one after it, and how many `token_count` events followed. Everything else parsed was waste.

## What changed

Walk the rollout with a `bytes.IndexByte` cursor and unmarshal only lines containing the literal `token_count`.

The filter cannot miss an event: that string is the value of the event's own `type` field, so any line the envelope check would accept contains it. Every admitted line still goes through the full three-step envelope check, so per-line decisions — and therefore the numbers — are unchanged. Lines that merely *mention* `token_count` in their text are rejected there, exactly as before; nothing is trusted on the strength of the byte match alone.

Two tempting shortcuts were tried and rejected because they silently corrupt token counts:

- **Defer the baseline parse** (remember the last line containing `token_count`, unmarshal once after the walk). ~3× faster again, and wrong: a plain `event_msg` of another type whose text mentions `token_count` — an agent discussing this issue emits one — overwrites the real baseline candidate, the deferred parse fails, the baseline goes nil, and nothing is subtracted. On a fixture, truth `{fresh 1000, cache 3000, out 200}` reported as `{2000, 7000, 300}`. Both decoy shapes are now regression tests.
- **Persist a cumulative baseline in `SessionState` + reverse-scan from EOF.** `fromOffset` is a line number, so locating its byte boundary needs the forward walk anyway, and `apiCalls` still needs the delta span. What's left is invalidation surface across resume/`adopt`/import/compaction that fails silently when stale.

## Measured

`BenchmarkCalculateTokenUsage`, synthetic rollout with 4 reasoning blobs per turn at 8 KB each, boundary one turn back from EOF:

| session length | before | after |
|---|---|---|
| 50 turns | 6.03 ms/hook | 0.216 ms |
| 200 turns | 23.9 ms/hook | 0.843 ms |
| 500 turns | 59.4 ms/hook | 2.11 ms |

Allocation at 500 turns: 20.7 MB / 33.5k allocs → 0.64 MB / 13k allocs.

**This is a constant-factor fix, not a complexity-class one, and it does not satisfy the issue's acceptance criterion as literally worded.** Being explicit since the issue asked for parses "bounded by the lines added that turn (plus O(1) baseline lookup)":

- The byte scan is still linear in transcript size, so a session still costs O(N²) bytes *scanned* — what's removed is unmarshalling and copying them.
- Parses per hook are one per `token_count` event, i.e. O(turns since session start), not O(delta). Total parse work over a session drops from O(N²) to O(N).
- The only designs that hit the literal wording are the two rejected above. Happy to build the persisted-baseline version instead if you'd rather have the bound and accept its invalidation surface — that's your call, not mine.

## Verification

Tests were written against the **pre-change** implementation and pass unchanged against both, which is what makes "same numbers out" a measurement rather than a claim:

- full offset sweep over the shared fixture, including both ends and past EOF (the `nil, nil` contract)
- blank- and whitespace-only-line numbering parity — offsets are in `splitJSONL` coordinates, which count only non-empty lines
- both decoy shapes: an `event_msg` of another type mentioning `token_count`, and the substring inside a base64 `encrypted_content` blob (URL-safe base64 includes `_`)
- malformed and truncated lines
- `baseline > last` (session reset/compaction), pinning that `CacheReadTokens`/`OutputTokens` stay **unclamped** while only `InputTokens` is floored at zero — deliberate existing asymmetry this change must not alter
- a CI-gated assertion that parse count tracks `token_count` events rather than transcript size, counting unmarshals rather than wall-clock so it's deterministic

Additionally, a throwaway differential harness ran the old and new implementations over every real Codex rollout on my machine — **481 files, 609 MB, 80,410 lines, 19,742 real `token_count` events, 7,696 comparisons at both ends, past EOF and 11 interior offsets per file: 0 mismatches and 0 false negatives.** Every real event contained the byte marker, which is the empirical form of the safety argument above. That harness read local session data and is not part of this PR.

`mise run check` green (fmt, lint 0 issues, unit + integration), e2e canary 59/59 and 4/4.

## Out of scope

Left alone deliberately, per your comment narrowing scope to token-usage only:

- **The modified-files second full-file read.** The issue's AC list includes a bytes-based `SubagentAwareExtractor` for Codex so turn-end extraction stops re-reading the rollout from disk. It's a real cost worth fixing, but it's a different interface with a different risk surface. Say the word and I'll file it as a follow-up.
- **A pre-existing line-numbering skew**, unrelated to this change but worth knowing: `GetTranscriptPosition` — which *produces* the stored offset — counts every line including blanks, while the token calculation counts only non-empty ones. Blank-free rollouts are unaffected, so nothing is broken today. Happy to fix separately. It's also why porting the Claude slice-first pattern verbatim would have misfired: `transcript.SliceFromLine` counts physical newlines, so it would shift the baseline.

Also unchanged: the shared pipeline's whole-file transcript copy, `encrypted_content` in stored checkpoints, Claude and other agents, the shared `transcript` package, and accounting semantics or reported fields.

## Commits

- `refactor(codex): one reader for the token_count envelope` — `review_tokens.go` already had this three-step unmarshal for the `entire review` stream tailer, but dropped `cached_input_tokens`. Extracted `parseRolloutTokenUsage`; the tailer's `parseRolloutTokenCount` is now a wrapper over it. Separate commit because it touches a working, unrelated feature.
- `perf(codex): stop unmarshalling the whole rollout to read two numbers` — the walk, the prefilter, and the tests.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
