### PR TITLE
trail show: add --json

### DIFF
--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -149,6 +149,7 @@ type trailListOptions struct {
 
 func newTrailShowCmd() *cobra.Command {
 	var branch string
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "show [<trail>]",
 		Short: "Show a trail",
@@ -168,15 +169,16 @@ Otherwise, <trail> may be a trail number, id, or branch in the target repo.`,
 			if err := ensureTrailRepoHasTarget(cmd, selector != "" || trailBranchFlag(cmd) != "", "pass a trail selector or --branch"); err != nil {
 				return err
 			}
-			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), selector, trailRepoFlag(cmd), trailBranchFlag(cmd))
+			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), selector, trailRepoFlag(cmd), trailBranchFlag(cmd), jsonOut)
 		},
 	}
 	cmd.Flags().StringVar(&branch, "branch", "", "Show the trail for this branch instead of the current branch; cannot be combined with a trail selector")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the trail as JSON, including the description")
 	return cmd
 }
 
 // runTrailShow shows one trail, defaulting to the current branch's trail.
-func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector, repoOverride, branchOverride string) error {
+func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector, repoOverride, branchOverride string, jsonOut bool) error {
 	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, repoOverride, func(ctx context.Context, client *api.Client) error {
 		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
 		if err != nil {
@@ -217,9 +219,28 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, sel
 				fmt.Fprintf(errW, "Warning: could not load trail description: %v\n", derr)
 			}
 		}
+		if jsonOut {
+			return encodeTrailShowJSON(w, *found, webURL, bodyText)
+		}
 		printTrailDetails(w, m, webURL, trailDescriptionForDisplay(bodyText, descriptionLoaded))
 		return nil
 	})
+}
+
+// encodeTrailShowJSON emits the resolved trail as JSON, with the body carrying
+// the resolved description text and the URL carrying the browser link the
+// human output surfaces.
+func encodeTrailShowJSON(w io.Writer, found api.TrailResource, webURL, bodyText string) error {
+	found.Body = bodyText
+	if strings.TrimSpace(webURL) != "" {
+		found.URL = webURL
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(found); err != nil {
+		return fmt.Errorf("encode trail JSON: %w", err)
+	}
+	return nil
 }
 
 // resolveTrailBySelector resolves a trail by an optional selector (trail

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -220,7 +220,7 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, sel
 			}
 		}
 		if jsonOut {
-			return encodeTrailShowJSON(w, *found, webURL, bodyText)
+			return encodeTrailShowJSON(w, *found, webURL, bodyText, descriptionLoaded)
 		}
 		printTrailDetails(w, m, webURL, trailDescriptionForDisplay(bodyText, descriptionLoaded))
 		return nil
@@ -229,16 +229,23 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, sel
 
 // encodeTrailShowJSON emits the resolved trail as JSON, with the body carrying
 // the resolved description text and the URL carrying the browser link the
-// human output surfaces.
-func encodeTrailShowJSON(w io.Writer, found api.TrailResource, webURL, bodyText string) error {
+// human output surfaces. description_loaded distinguishes a genuinely empty
+// description (true, body "") from a failed description fetch (false) —
+// the same distinction the text path draws via trailDescriptionForDisplay.
+func encodeTrailShowJSON(w io.Writer, found api.TrailResource, webURL, bodyText string, descriptionLoaded bool) error {
 	found.Body = bodyText
 	if strings.TrimSpace(webURL) != "" {
 		found.URL = webURL
 	}
+	payload := struct {
+		api.TrailResource
+
+		DescriptionLoaded bool `json:"description_loaded"`
+	}{TrailResource: found, DescriptionLoaded: descriptionLoaded}
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(found); err != nil {
+	if err := enc.Encode(payload); err != nil {
 		return fmt.Errorf("encode trail JSON: %w", err)
 	}
 	return nil

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -236,6 +236,7 @@ func encodeTrailShowJSON(w io.Writer, found api.TrailResource, webURL, bodyText 
 		found.URL = webURL
 	}
 	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(found); err != nil {
 		return fmt.Errorf("encode trail JSON: %w", err)

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trail"
 
@@ -173,7 +174,7 @@ Otherwise, <trail> may be a trail number, id, or branch in the target repo.`,
 		},
 	}
 	cmd.Flags().StringVar(&branch, "branch", "", "Show the trail for this branch instead of the current branch; cannot be combined with a trail selector")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the trail as JSON, including the description")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 	return cmd
 }
 
@@ -227,26 +228,29 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, sel
 	})
 }
 
-// encodeTrailShowJSON emits the resolved trail as JSON, with the body carrying
-// the resolved description text and the URL carrying the browser link the
-// human output surfaces. description_loaded distinguishes a genuinely empty
-// description (true, body "") from a failed description fetch (false) —
-// the same distinction the text path draws via trailDescriptionForDisplay.
+// encodeTrailShowJSON emits the resolved trail in the same wire shape as
+// `trail list --json` (trail.Metadata: trail_id key, normalized slices), with
+// the body carrying the resolved description text and the URL carrying the
+// browser link. description_loaded reports whether the description was
+// authoritatively consulted; false means the detail fetch failed (or never
+// ran) and no list body was available either.
 func encodeTrailShowJSON(w io.Writer, found api.TrailResource, webURL, bodyText string, descriptionLoaded bool) error {
-	found.Body = bodyText
+	m := found.ToMetadata()
+	m.Body = bodyText
 	if strings.TrimSpace(webURL) != "" {
-		found.URL = webURL
+		m.URL = webURL
 	}
 	payload := struct {
-		api.TrailResource
+		*trail.Metadata
 
 		DescriptionLoaded bool `json:"description_loaded"`
-	}{TrailResource: found, DescriptionLoaded: descriptionLoaded}
-	enc := json.NewEncoder(w)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(payload); err != nil {
+	}{Metadata: m, DescriptionLoaded: descriptionLoaded}
+	data, err := jsonutil.MarshalIndentWithNewline(payload, "", "  ")
+	if err != nil {
 		return fmt.Errorf("encode trail JSON: %w", err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("write trail JSON: %w", err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/trail_show_json_test.go
+++ b/cmd/entire/cli/trail_show_json_test.go
@@ -25,7 +25,7 @@ func TestEncodeTrailShowJSON(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := encodeTrailShowJSON(&out, found, "https://app.entire.io/t/42", "Long form description with <code> & links")
+	err := encodeTrailShowJSON(&out, found, "https://app.entire.io/t/42", "Long form description with <code> & links", true)
 	if err != nil {
 		t.Fatalf("encodeTrailShowJSON() error = %v", err)
 	}
@@ -41,16 +41,41 @@ func TestEncodeTrailShowJSON(t *testing.T) {
 		t.Fatalf("output is not valid JSON: %v\n%s", unmarshalErr, out.String())
 	}
 	for key, want := range map[string]any{
-		"number": float64(42),
-		"branch": "trail-resume",
-		"title":  "Improve trail resume",
-		"body":   "Long form description with <code> & links",
-		"url":    "https://app.entire.io/t/42",
-		"status": "open",
+		"number":             float64(42),
+		"branch":             "trail-resume",
+		"title":              "Improve trail resume",
+		"body":               "Long form description with <code> & links",
+		"url":                "https://app.entire.io/t/42",
+		"status":             "open",
+		"description_loaded": true,
 	} {
 		if payload[key] != want {
 			t.Errorf("payload[%q] = %v, want %v", key, payload[key], want)
 		}
+	}
+}
+
+// TestEncodeTrailShowJSONMarksUnloadedDescription pins the failed-fetch
+// distinction: an empty body with description_loaded=false means the
+// description could not be fetched, not that the trail has none — mirroring
+// the text path's trailDescriptionForDisplay behavior.
+func TestEncodeTrailShowJSONMarksUnloadedDescription(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := encodeTrailShowJSON(&out, api.TrailResource{Number: 7, Branch: "feat"}, "", "", false)
+	if err != nil {
+		t.Fatalf("encodeTrailShowJSON() error = %v", err)
+	}
+	var payload map[string]any
+	if unmarshalErr := json.Unmarshal(out.Bytes(), &payload); unmarshalErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", unmarshalErr, out.String())
+	}
+	if payload["description_loaded"] != false {
+		t.Errorf("payload[description_loaded] = %v, want false", payload["description_loaded"])
+	}
+	if payload["body"] != "" {
+		t.Errorf("payload[body] = %v, want empty", payload["body"])
 	}
 }
 

--- a/cmd/entire/cli/trail_show_json_test.go
+++ b/cmd/entire/cli/trail_show_json_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+)
+
+// TestEncodeTrailShowJSON pins the trail show --json payload: the resolved
+// TrailResource with the detail-endpoint description and the browser URL the
+// human output already surfaces.
+func TestEncodeTrailShowJSON(t *testing.T) {
+	t.Parallel()
+
+	found := api.TrailResource{
+		ID:     "tr_1",
+		Number: 42,
+		Title:  "Improve trail resume",
+		Branch: "trail-resume",
+		Base:   "main",
+		Status: "open",
+	}
+
+	var out bytes.Buffer
+	err := encodeTrailShowJSON(&out, found, "https://app.entire.io/t/42", "Long form description")
+	if err != nil {
+		t.Fatalf("encodeTrailShowJSON() error = %v", err)
+	}
+
+	var payload map[string]any
+	if unmarshalErr := json.Unmarshal(out.Bytes(), &payload); unmarshalErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", unmarshalErr, out.String())
+	}
+	for key, want := range map[string]any{
+		"number": float64(42),
+		"branch": "trail-resume",
+		"title":  "Improve trail resume",
+		"body":   "Long form description",
+		"url":    "https://app.entire.io/t/42",
+		"status": "open",
+	} {
+		if payload[key] != want {
+			t.Errorf("payload[%q] = %v, want %v", key, payload[key], want)
+		}
+	}
+}
+
+// TestTrailShowCmdRegistersJSONFlag closes the one read-command gap in the
+// trail group: show must accept --json like list, watch, and finding do.
+func TestTrailShowCmdRegistersJSONFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := newTrailShowCmd()
+	flag := cmd.Flags().Lookup("json")
+	if flag == nil {
+		t.Fatal("trail show has no --json flag")
+	}
+	if !strings.Contains(strings.ToLower(flag.Usage), "json") {
+		t.Errorf("--json usage = %q, want a JSON description", flag.Usage)
+	}
+}

--- a/cmd/entire/cli/trail_show_json_test.go
+++ b/cmd/entire/cli/trail_show_json_test.go
@@ -2,16 +2,29 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+
+	"github.com/stretchr/testify/require"
 )
 
-// TestEncodeTrailShowJSON pins the trail show --json payload: the resolved
-// TrailResource with the detail-endpoint description and the browser URL the
-// human output already surfaces.
+// TestEncodeTrailShowJSON pins the trail show --json payload: the list-parity
+// wire shape (trail_id key, normalized slices) with the detail-endpoint
+// description and the browser URL the human output already surfaces.
 func TestEncodeTrailShowJSON(t *testing.T) {
 	t.Parallel()
 
@@ -41,6 +54,7 @@ func TestEncodeTrailShowJSON(t *testing.T) {
 		t.Fatalf("output is not valid JSON: %v\n%s", unmarshalErr, out.String())
 	}
 	for key, want := range map[string]any{
+		"trail_id":           "tr_1",
 		"number":             float64(42),
 		"branch":             "trail-resume",
 		"title":              "Improve trail resume",
@@ -52,6 +66,14 @@ func TestEncodeTrailShowJSON(t *testing.T) {
 		if payload[key] != want {
 			t.Errorf("payload[%q] = %v, want %v", key, payload[key], want)
 		}
+	}
+	// list-parity shape: nil slices normalize to [], and the resource "id"
+	// key must not appear alongside trail_id.
+	if assignees, ok := payload["assignees"].([]any); !ok || assignees == nil {
+		t.Errorf("payload[assignees] = %v, want []", payload["assignees"])
+	}
+	if _, hasID := payload["id"]; hasID {
+		t.Errorf("payload carries both id and trail_id: %s", out.String())
 	}
 }
 
@@ -77,6 +99,11 @@ func TestEncodeTrailShowJSONMarksUnloadedDescription(t *testing.T) {
 	if payload["body"] != "" {
 		t.Errorf("payload[body] = %v, want empty", payload["body"])
 	}
+	// url is omitempty: with no web URL resolvable, consumers see key
+	// absence, not "".
+	if _, hasURL := payload["url"]; hasURL {
+		t.Errorf("payload[url] present = %v, want omitted", payload["url"])
+	}
 }
 
 // TestTrailShowCmdRegistersJSONFlag closes the one read-command gap in the
@@ -92,4 +119,94 @@ func TestTrailShowCmdRegistersJSONFlag(t *testing.T) {
 	if !strings.Contains(strings.ToLower(flag.Usage), "json") {
 		t.Errorf("--json usage = %q, want a JSON description", flag.Usage)
 	}
+}
+
+// TestRunTrailShowJSON_WiresCommandToEncoder executes `trail show 42 --json`
+// end to end against a fake control plane: the happy path must put the
+// detail-endpoint description (not the list body) on stdout as parseable
+// JSON, and a failed detail fetch must keep stdout pure JSON with
+// description_loaded=false while the warning goes to stderr.
+func TestRunTrailShowJSON_WiresCommandToEncoder(t *testing.T) {
+	// No t.Parallel: uses t.Chdir plus auth/tokenstore package-level test seams.
+	detailFails := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/oauth/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"access_token":"exchanged-token","token_type":"Bearer","expires_in":3600}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/trails/gh/acme/repo/42":
+			if detailFails {
+				http.Error(w, "boom", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]api.TrailResource{"trail": {
+				ID: "trl_show", Number: 42, Title: "Show me", Branch: "feat/show", Status: "open",
+				BodyDocument: &api.TrailBodyDocument{TextSnapshot: "Detail description"},
+			}}); err != nil {
+				t.Errorf("encode detail response: %v", err)
+			}
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/trails/gh/acme/repo":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{Trails: []api.TrailResource{{
+				ID: "trl_show", Number: 42, Title: "Show me", Branch: "feat/show", Status: "open",
+			}}, Total: 1}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv(api.BaseURLEnvVar, srv.URL)
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+	service := tokenstore.CoreKeyringService(srv.URL)
+	jwt := makeContextJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"me","exp":%d}`, srv.URL, time.Now().Add(2*time.Hour).Unix()))
+	require.NoError(t, tokenstore.Set(service, "me", tokenstore.EncodeTokenWithExpiration(jwt, 7200)))
+	ctxObj := &contexts.Context{Name: "me@core", CoreURL: srv.URL, Handle: "me", KeychainService: service}
+	t.Cleanup(auth.SetResolveContextForAPIForTest(t,
+		func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+			return ctxObj, nil
+		}))
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	runGitTrailTest(t, repoDir, "remote", "add", "origin", "https://github.com/acme/repo.git")
+	t.Chdir(repoDir)
+
+	runShow := func() (string, string, error) {
+		cmd := newTrailShowCmd()
+		cmd.SetContext(context.Background())
+		cmd.Flags().Bool("insecure-http-auth", true, "")
+		require.NoError(t, cmd.Flags().Set("insecure-http-auth", "true"))
+		cmd.SetArgs([]string{"42", "--json"})
+		var out, errOut bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&errOut)
+		err := cmd.Execute()
+		return out.String(), errOut.String(), err
+	}
+
+	// Happy path: detail body supersedes the (empty) list body.
+	out, errOut, err := runShow()
+	require.NoError(t, err, "stderr: %s", errOut)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &payload), "stdout must be pure JSON: %s", out)
+	require.Equal(t, "trl_show", payload["trail_id"])
+	require.Equal(t, "Detail description", payload["body"])
+	require.Equal(t, true, payload["description_loaded"])
+
+	// Detail fetch failure: warning on stderr, stdout still pure JSON, and
+	// with no list body the description is marked unloaded.
+	detailFails = true
+	out, errOut, err = runShow()
+	require.NoError(t, err, "stderr: %s", errOut)
+	payload = map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(out), &payload), "stdout must be pure JSON: %s", out)
+	require.Empty(t, payload["body"])
+	require.Equal(t, false, payload["description_loaded"])
+	require.Contains(t, errOut, "could not load trail description")
 }

--- a/cmd/entire/cli/trail_show_json_test.go
+++ b/cmd/entire/cli/trail_show_json_test.go
@@ -25,9 +25,15 @@ func TestEncodeTrailShowJSON(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := encodeTrailShowJSON(&out, found, "https://app.entire.io/t/42", "Long form description")
+	err := encodeTrailShowJSON(&out, found, "https://app.entire.io/t/42", "Long form description with <code> & links")
 	if err != nil {
 		t.Fatalf("encodeTrailShowJSON() error = %v", err)
+	}
+
+	// User-authored description text must not be HTML-escaped (jsonutil
+	// convention): agents should read `<code> &` literally, not <.
+	if !strings.Contains(out.String(), "<code> & links") {
+		t.Errorf("output HTML-escapes the description: %s", out.String())
 	}
 
 	var payload map[string]any
@@ -38,7 +44,7 @@ func TestEncodeTrailShowJSON(t *testing.T) {
 		"number": float64(42),
 		"branch": "trail-resume",
 		"title":  "Improve trail resume",
-		"body":   "Long form description",
+		"body":   "Long form description with <code> & links",
 		"url":    "https://app.entire.io/t/42",
 		"status": "open",
 	} {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/962
<!-- entire-trail-link-end -->

Every read command in the trail group (`list`, `watch`, `finding` and its subcommands) offers `--json` except `show` — the natural "give me the trail as data" call for agents. This closes that gap: `trail show --json` emits the resolved `TrailResource`, with the body carrying the detail-endpoint description text and the URL carrying the browser link the human output already surfaces. The description fetch stays best-effort with its warning on stderr.

Independent of (not stacked on) the trail resume non-interactive contract PR (#1884); both branch off main.

Note: `TestRunExplainAuto_GeneratePersistsHexOnBranchUnderRefsPrimary` fails on this main snapshot with the change stashed too — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an optional CLI output mode with no changes to auth, persistence, or API contracts beyond reusing existing trail resolution and description loading.
> 
> **Overview**
> **`entire trail show`** now accepts **`--json`**, matching other trail read commands (`list`, `watch`, `finding`).
> 
> With the flag set, the command prints a single indented **`TrailResource`** JSON object instead of the human-readable view. The payload uses the same resolved **description** text and **browser URL** that normal output already derives (detail fetch still best-effort; failures keep the list body and warn on stderr).
> 
> A small **`encodeTrailShowJSON`** helper performs the serialization; tests cover the JSON shape and that the **`--json`** flag is registered on the show subcommand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1025968689320f58c8fdee5a233fadc42fa3a12. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->