### PR TITLE
remote: classify a remoteless repo as checkpoint-ref absence, not outage

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
@@ -70,11 +72,16 @@ func FetchCheckpointRef(ctx context.Context, ref plumbing.ReferenceName) error {
 	// fallback below probes a remote git cannot resolve ("'origin' does not
 	// appear to be a git repository", exit 128) and a remoteless repo is
 	// misreported as a transport outage. The guard is deliberately narrow:
-	// when a checkpoint_remote IS configured (even unresolvable), the
-	// fallback-emptiness refusal below still applies.
-	if fetchTarget == originRemote && !authoritative && !Configured(ctx) {
-		if _, urlErr := GetRemoteURL(ctx, originRemote); urlErr != nil {
-			return fmt.Errorf("checkpoint ref %s: repository has no remote to fetch from: %w", ref, plumbing.ErrReferenceNotFound)
+	// it requires a SUCCESSFUL settings load showing no checkpoint_remote —
+	// an unreadable configuration is undeterminable, not "not configured"
+	// (Configured() conflates the two) — and when a checkpoint_remote IS
+	// configured (even unresolvable), the fallback-emptiness refusal below
+	// still applies.
+	if fetchTarget == originRemote && !authoritative {
+		if s, loadErr := settings.Load(ctx); loadErr == nil && s.GetCheckpointRemote() == nil {
+			if _, urlErr := GetRemoteURL(ctx, originRemote); urlErr != nil {
+				return fmt.Errorf("checkpoint ref %s: repository has no remote to fetch from: %w", ref, plumbing.ErrReferenceNotFound)
+			}
 		}
 	}
 

--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
@@ -72,13 +72,15 @@ func FetchCheckpointRef(ctx context.Context, ref plumbing.ReferenceName) error {
 	// fallback below probes a remote git cannot resolve ("'origin' does not
 	// appear to be a git repository", exit 128) and a remoteless repo is
 	// misreported as a transport outage. The guard is deliberately narrow:
-	// it requires a SUCCESSFUL settings load showing no checkpoint_remote —
-	// an unreadable configuration is undeterminable, not "not configured"
-	// (Configured() conflates the two) — and when a checkpoint_remote IS
-	// configured (even unresolvable), the fallback-emptiness refusal below
-	// still applies.
+	// it requires a SUCCESSFUL settings load whose strategy options carry no
+	// checkpoint_remote entry AT ALL. An unreadable configuration is
+	// undeterminable, and a present-but-malformed entry means the user
+	// configured a checkpoint remote and botched it (GetCheckpointRemote
+	// collapses both to nil) — neither may classify as absence. When a
+	// checkpoint_remote IS configured (even unresolvable), the
+	// fallback-emptiness refusal below still applies.
 	if fetchTarget == originRemote && !authoritative {
-		if s, loadErr := settings.Load(ctx); loadErr == nil && s.GetCheckpointRemote() == nil {
+		if s, loadErr := settings.Load(ctx); loadErr == nil && !checkpointRemoteKeyPresent(s) {
 			if _, urlErr := GetRemoteURL(ctx, originRemote); urlErr != nil {
 				return fmt.Errorf("checkpoint ref %s: repository has no remote to fetch from: %w", ref, plumbing.ErrReferenceNotFound)
 			}
@@ -119,6 +121,19 @@ func FetchCheckpointRef(ctx context.Context, ref plumbing.ReferenceName) error {
 		return fmt.Errorf("fetch checkpoint ref %s from %s: %w", ref, RedactURL(fetchTarget), err)
 	}
 	return nil
+}
+
+// checkpointRemoteKeyPresent reports whether a checkpoint_remote entry exists
+// in the strategy options at all — including a malformed one that
+// GetCheckpointRemote would reject. Presence in any form means the user
+// intends a checkpoint remote, so the no-remotes absence shortcut must not
+// apply.
+func checkpointRemoteKeyPresent(s *settings.EntireSettings) bool {
+	if s == nil || s.StrategyOptions == nil {
+		return false
+	}
+	_, ok := s.StrategyOptions["checkpoint_remote"]
+	return ok
 }
 
 // HookCheckpointRefFetcher returns the write-probe fetcher for git-hook

--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
@@ -64,6 +64,20 @@ func FetchCheckpointRef(ctx context.Context, ref plumbing.ReferenceName) error {
 
 	fetchTarget, authoritative := checkpointFetchTarget(ctx)
 
+	// A fully local repository — no checkpoint_remote configured and no origin
+	// remote — has no remote that could host checkpoint refs, so the ref's
+	// local absence is the final verdict. Without this, the origin-name
+	// fallback below probes a remote git cannot resolve ("'origin' does not
+	// appear to be a git repository", exit 128) and a remoteless repo is
+	// misreported as a transport outage. The guard is deliberately narrow:
+	// when a checkpoint_remote IS configured (even unresolvable), the
+	// fallback-emptiness refusal below still applies.
+	if fetchTarget == originRemote && !authoritative && !Configured(ctx) {
+		if _, urlErr := GetRemoteURL(ctx, originRemote); urlErr != nil {
+			return fmt.Errorf("checkpoint ref %s: repository has no remote to fetch from: %w", ref, plumbing.ErrReferenceNotFound)
+		}
+	}
+
 	out, err := LsRemoteInDir(ctx, "", fetchTarget, ref.String())
 	if err != nil {
 		// Redact: fetchTarget can be a remote URL with embedded credentials

--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
+	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -60,30 +63,47 @@ func checkpointFetchTarget(ctx context.Context) (string, bool) {
 //   - Any transport-level failure (probe or fetch) is surfaced as a real
 //     error, never mapped to absence — a false "absent" would misdirect a
 //     backfill onto another backend instead of retrying.
+//   - A repository with no git remotes at all and no checkpoint_remote
+//     configured also returns an error wrapping plumbing.ErrReferenceNotFound
+//     without probing: there is no remote that could host the ref.
 func FetchCheckpointRef(ctx context.Context, ref plumbing.ReferenceName) error {
 	ctx, cancel := context.WithTimeout(ctx, readFetchTimeout)
 	defer cancel()
 
 	fetchTarget, authoritative := checkpointFetchTarget(ctx)
 
-	// A fully local repository — no checkpoint_remote configured and no origin
-	// remote — has no remote that could host checkpoint refs, so the ref's
-	// local absence is the final verdict. Without this, the origin-name
-	// fallback below probes a remote git cannot resolve ("'origin' does not
-	// appear to be a git repository", exit 128) and a remoteless repo is
-	// misreported as a transport outage. The guard is deliberately narrow:
-	// it requires a SUCCESSFUL settings load whose strategy options carry no
-	// checkpoint_remote entry AT ALL. An unreadable configuration is
-	// undeterminable, and a present-but-malformed entry means the user
-	// configured a checkpoint remote and botched it (GetCheckpointRemote
-	// collapses both to nil) — neither may classify as absence. When a
-	// checkpoint_remote IS configured (even unresolvable), the
-	// fallback-emptiness refusal below still applies.
-	if fetchTarget == originRemote && !authoritative {
-		if s, loadErr := settings.Load(ctx); loadErr == nil && !checkpointRemoteKeyPresent(s) {
-			if _, urlErr := GetRemoteURL(ctx, originRemote); urlErr != nil {
-				return fmt.Errorf("checkpoint ref %s: repository has no remote to fetch from: %w", ref, plumbing.ErrReferenceNotFound)
-			}
+	// A fully local repository — no git remotes at all and no
+	// checkpoint_remote configured — has no remote that could host checkpoint
+	// refs, so the ref's local absence is the final verdict. Without this,
+	// the origin-name fallback below probes a remote git cannot resolve
+	// ("'origin' does not appear to be a git repository", exit 128) and a
+	// remoteless repo is misreported as a transport outage. Absence is only
+	// ever classified on positive evidence; each escape below keeps today's
+	// hard-failure probe:
+	//   - dead caller context: every subprocess fails for reasons that say
+	//     nothing about the repository
+	//   - unreadable settings: a configured checkpoint remote cannot be
+	//     ruled out
+	//   - checkpoint_remote key present in any form, valid or malformed
+	//     (see settings.HasCheckpointRemoteKey for why key presence, not
+	//     GetCheckpointRemote, is the signal)
+	//   - any remote listed, or the listing itself failing: checkpoint refs
+	//     are pushed to whatever remote the pre-push hook fires for, so a
+	//     repo with only non-origin remotes is NOT remoteless
+	// The skipped-guard cases surface through the ordinary probe paths: a
+	// missing origin fails the ls-remote probe as a transport error, and an
+	// origin that merely lacks the ref hits the fallback-emptiness refusal
+	// below — neither classifies as absence.
+	if fetchTarget == originRemote && !authoritative && ctx.Err() == nil {
+		s, loadErr := settings.Load(ctx)
+		switch {
+		case loadErr != nil:
+			logging.Warn(ctx, "checkpoint probe: settings unreadable; cannot rule out a configured checkpoint remote, probing anyway",
+				slog.String("error", loadErr.Error()))
+		case !s.HasCheckpointRemoteKey() && repoHasNoRemotes(ctx):
+			logging.Debug(ctx, "checkpoint probe: repository has no git remotes; classifying ref as absent",
+				slog.String("ref", ref.String()))
+			return fmt.Errorf("checkpoint ref %s: repository has no git remotes to fetch from: %w", ref, plumbing.ErrReferenceNotFound)
 		}
 	}
 
@@ -123,17 +143,14 @@ func FetchCheckpointRef(ctx context.Context, ref plumbing.ReferenceName) error {
 	return nil
 }
 
-// checkpointRemoteKeyPresent reports whether a checkpoint_remote entry exists
-// in the strategy options at all — including a malformed one that
-// GetCheckpointRemote would reject. Presence in any form means the user
-// intends a checkpoint remote, so the no-remotes absence shortcut must not
-// apply.
-func checkpointRemoteKeyPresent(s *settings.EntireSettings) bool {
-	if s == nil || s.StrategyOptions == nil {
-		return false
-	}
-	_, ok := s.StrategyOptions["checkpoint_remote"]
-	return ok
+// repoHasNoRemotes reports whether the repository at the current directory
+// definitively has no git remotes configured. Only a successful, empty
+// `git remote` listing counts as proof; any error (dead context, missing git
+// binary, not a repository) returns false so the caller falls through to the
+// probe instead of classifying absence off an undifferentiated failure.
+func repoHasNoRemotes(ctx context.Context) bool {
+	out, err := exec.CommandContext(ctx, "git", "remote").Output()
+	return err == nil && len(bytes.TrimSpace(out)) == 0
 }
 
 // HookCheckpointRefFetcher returns the write-probe fetcher for git-hook

--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref_test.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref_test.go
@@ -119,10 +119,10 @@ func TestFetchCheckpointRef_NoRemoteAtAllIsAbsence(t *testing.T) {
 
 // TestFetchCheckpointRef_UnreadableSettingsNeverClassifiesAbsence: when the
 // checkpoint_remote configuration CANNOT BE READ (corrupt settings), whether a
-// checkpoint remote exists is undeterminable — the same case the fallback
-// emptiness path refuses to classify. The no-remotes absence shortcut must not
-// fire on a load error, only on a successful load that shows no
-// checkpoint_remote configured.
+// checkpoint remote exists is undeterminable. The no-remotes absence shortcut
+// must not fire on a load error — the run falls through to the ls-remote
+// probe, which surfaces the missing origin as a transport error, never as
+// absence.
 func TestFetchCheckpointRef_UnreadableSettingsNeverClassifiesAbsence(t *testing.T) {
 	workDir := t.TempDir()
 	testutil.InitRepo(t, workDir)
@@ -160,4 +160,49 @@ func TestFetchCheckpointRef_MalformedCheckpointRemoteNeverClassifiesAbsence(t *t
 	require.Error(t, err)
 	require.NotErrorIs(t, err, plumbing.ErrReferenceNotFound,
 		"a present-but-malformed checkpoint_remote must not classify as absence")
+}
+
+// TestFetchCheckpointRef_NonOriginRemoteNeverClassifiesAbsence: a repo whose
+// only remote is not named origin (git clone -o upstream is a common shape)
+// is NOT remoteless — checkpoint refs are pushed to whatever remote the
+// pre-push hook fires for, so they can legitimately live on a non-origin
+// remote. Classifying this repo as absence would misroute backfills; it must
+// stay a failure.
+func TestFetchCheckpointRef_NonOriginRemoteNeverClassifiesAbsence(t *testing.T) {
+	bareDir := t.TempDir()
+	out, err := exec.CommandContext(t.Context(), "git", "init", "--bare", bareDir).CombinedOutput()
+	require.NoError(t, err, "git init --bare: %s", out)
+
+	workDir := t.TempDir()
+	testutil.InitRepo(t, workDir)
+	testutil.WriteFile(t, workDir, "f.txt", "content")
+	testutil.GitAdd(t, workDir, "f.txt")
+	testutil.GitCommit(t, workDir, "init")
+	out, err = exec.CommandContext(t.Context(), "git", "-C", workDir, "remote", "add", "upstream", bareDir).CombinedOutput()
+	require.NoError(t, err, "git remote add upstream: %s", out)
+	t.Chdir(workDir)
+
+	ref := plumbing.ReferenceName("refs/entire/checkpoints/Z9/01KVBJCWYA4YW6J5M9GP655HZ9")
+	err = FetchCheckpointRef(context.Background(), ref)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, plumbing.ErrReferenceNotFound,
+		"a repo with a non-origin remote must not classify as absence")
+}
+
+// TestFetchCheckpointRef_CanceledContextNeverClassifiesAbsence: a dead caller
+// context makes every git subprocess fail, which must surface as a transport
+// failure — never as absence. Regression: the no-remotes guard once inferred
+// "no origin" from a GetRemoteURL failure, which a canceled context also
+// produces, converting Ctrl-C in a healthy repo into a false "checkpoint does
+// not exist" verdict that write routing acts on.
+func TestFetchCheckpointRef_CanceledContextNeverClassifiesAbsence(t *testing.T) {
+	_, ref := checkpointRefFixture(t, true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := FetchCheckpointRef(ctx, ref)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, plumbing.ErrReferenceNotFound,
+		"a canceled context must stay a failure, never absence")
 }

--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref_test.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref_test.go
@@ -138,3 +138,26 @@ func TestFetchCheckpointRef_UnreadableSettingsNeverClassifiesAbsence(t *testing.
 	require.NotErrorIs(t, err, plumbing.ErrReferenceNotFound,
 		"an unreadable checkpoint_remote configuration must not classify as absence")
 }
+
+// TestFetchCheckpointRef_MalformedCheckpointRemoteNeverClassifiesAbsence: a
+// checkpoint_remote entry that is present but malformed (here: missing the
+// required repo field) means the user configured a checkpoint remote and
+// botched it. Combined with a missing origin, that must stay a failure —
+// classifying it as absence would misroute backfills for checkpoints that
+// live on the remote the user intended.
+func TestFetchCheckpointRef_MalformedCheckpointRemoteNeverClassifiesAbsence(t *testing.T) {
+	workDir := t.TempDir()
+	testutil.InitRepo(t, workDir)
+	testutil.WriteFile(t, workDir, "f.txt", "content")
+	testutil.GitAdd(t, workDir, "f.txt")
+	testutil.GitCommit(t, workDir, "init")
+	testutil.WriteFile(t, workDir, ".entire/settings.json",
+		`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github"}}}`)
+	t.Chdir(workDir)
+
+	ref := plumbing.ReferenceName("refs/entire/checkpoints/Z9/01KVBJCWYA4YW6J5M9GP655HZ9")
+	err := FetchCheckpointRef(context.Background(), ref)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, plumbing.ErrReferenceNotFound,
+		"a present-but-malformed checkpoint_remote must not classify as absence")
+}

--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref_test.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref_test.go
@@ -116,3 +116,25 @@ func TestFetchCheckpointRef_NoRemoteAtAllIsAbsence(t *testing.T) {
 	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound,
 		"a repo with no remotes must classify a locally absent ref as absence")
 }
+
+// TestFetchCheckpointRef_UnreadableSettingsNeverClassifiesAbsence: when the
+// checkpoint_remote configuration CANNOT BE READ (corrupt settings), whether a
+// checkpoint remote exists is undeterminable — the same case the fallback
+// emptiness path refuses to classify. The no-remotes absence shortcut must not
+// fire on a load error, only on a successful load that shows no
+// checkpoint_remote configured.
+func TestFetchCheckpointRef_UnreadableSettingsNeverClassifiesAbsence(t *testing.T) {
+	workDir := t.TempDir()
+	testutil.InitRepo(t, workDir)
+	testutil.WriteFile(t, workDir, "f.txt", "content")
+	testutil.GitAdd(t, workDir, "f.txt")
+	testutil.GitCommit(t, workDir, "init")
+	testutil.WriteFile(t, workDir, ".entire/settings.json", "{not valid json")
+	t.Chdir(workDir)
+
+	ref := plumbing.ReferenceName("refs/entire/checkpoints/Z9/01KVBJCWYA4YW6J5M9GP655HZ9")
+	err := FetchCheckpointRef(context.Background(), ref)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, plumbing.ErrReferenceNotFound,
+		"an unreadable checkpoint_remote configuration must not classify as absence")
+}

--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref_test.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref_test.go
@@ -94,3 +94,25 @@ func TestFetchCheckpointRef_UnreachableRemoteIsFailure(t *testing.T) {
 	require.NotErrorIs(t, err, plumbing.ErrReferenceNotFound,
 		"a transport failure must stay distinguishable from absence")
 }
+
+// TestFetchCheckpointRef_NoRemoteAtAllIsAbsence: a fully local repository —
+// no origin remote and no checkpoint_remote configured — has no remote that
+// could host checkpoint refs, so the ref's local absence is the final
+// verdict, not a transport failure. Regression: the origin-name fallback
+// probe used to run `git ls-remote origin` in a remoteless repo and surface
+// exit 128, which broke backfill routing (and `explain --generate`) in fully
+// local repos.
+func TestFetchCheckpointRef_NoRemoteAtAllIsAbsence(t *testing.T) {
+	workDir := t.TempDir()
+	testutil.InitRepo(t, workDir)
+	testutil.WriteFile(t, workDir, "f.txt", "content")
+	testutil.GitAdd(t, workDir, "f.txt")
+	testutil.GitCommit(t, workDir, "init")
+	t.Chdir(workDir)
+
+	ref := plumbing.ReferenceName("refs/entire/checkpoints/Z9/01KVBJCWYA4YW6J5M9GP655HZ9")
+	err := FetchCheckpointRef(context.Background(), ref)
+	require.Error(t, err)
+	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound,
+		"a repo with no remotes must classify a locally absent ref as absence")
+}

--- a/cmd/entire/cli/checkpoint/routing_store.go
+++ b/cmd/entire/cli/checkpoint/routing_store.go
@@ -199,9 +199,10 @@ func (s *kindRoutingStore) ReadSessionMetadataAndPrompts(ctx context.Context, ch
 // (which falls through on absent OR any error): only the not-found sentinel
 // falls through here. Redirecting a write to another backend after a transient
 // primary failure could fork the data, so a hard error aborts and surfaces.
-// Note the stores' backfill absence probes are local-only (the refs store's
-// refBase does not on-demand fetch like its read path does); a checkpoint
-// whose ref exists only remotely backfills to the fallback store.
+// Note the refs store's backfill absence probe fetches a locally-missing ref
+// on demand when a fetcher is wired (refBaseForBackfill), so a checkpoint
+// whose ref exists only remotely is fetched and backfilled in place rather
+// than falling through to the fallback store.
 func (s *kindRoutingStore) Write(ctx context.Context, req WriteRequest) error {
 	checkpointID, isBackfill := backfillTarget(req)
 	if !isBackfill {

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -1407,6 +1407,19 @@ func (c *CheckpointRemoteConfig) Owner() string {
 	return parts[0]
 }
 
+// HasCheckpointRemoteKey reports whether a checkpoint_remote entry exists in
+// strategy options at all — deliberately including malformed entries that
+// GetCheckpointRemote rejects (it returns nil for absent AND malformed, so it
+// cannot distinguish "no intent" from "botched intent"). Presence in any form
+// means the user intends a checkpoint remote.
+func (s *EntireSettings) HasCheckpointRemoteKey() bool {
+	if s.StrategyOptions == nil {
+		return false
+	}
+	_, ok := s.StrategyOptions["checkpoint_remote"]
+	return ok
+}
+
 // GetCheckpointRemote returns the configured checkpoint remote.
 // Expects a structured object: {"provider": "github", "repo": "org/repo"}.
 // Returns nil if not configured, wrong type, or missing required fields.

--- a/cmd/entire/cli/settings/settings_checkpoint_remote_test.go
+++ b/cmd/entire/cli/settings/settings_checkpoint_remote_test.go
@@ -171,3 +171,21 @@ func TestCheckpointRemoteConfig_Owner(t *testing.T) {
 		})
 	}
 }
+
+func TestHasCheckpointRemoteKey(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, (&EntireSettings{}).HasCheckpointRemoteKey(), "nil strategy options")
+	assert.False(t, (&EntireSettings{StrategyOptions: map[string]any{}}).HasCheckpointRemoteKey(), "empty strategy options")
+	assert.True(t, (&EntireSettings{StrategyOptions: map[string]any{
+		"checkpoint_remote": map[string]any{"provider": "github", "repo": "org/repo"},
+	}}).HasCheckpointRemoteKey(), "well-formed entry")
+	// The reason this method exists: a malformed entry still counts as
+	// present even though GetCheckpointRemote rejects it.
+	assert.True(t, (&EntireSettings{StrategyOptions: map[string]any{
+		"checkpoint_remote": map[string]any{"provider": "github"},
+	}}).HasCheckpointRemoteKey(), "malformed entry still counts as present")
+	assert.True(t, (&EntireSettings{StrategyOptions: map[string]any{
+		"checkpoint_remote": nil,
+	}}).HasCheckpointRemoteKey(), "null entry still counts as present")
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/963
<!-- entire-trail-link-end -->

Main is currently red: `TestRunExplainAuto_GeneratePersistsHexOnBranchUnderRefsPrimary` fails on the tip (see #1885's test-core run — that PR only touches `trail show`, and the failure reproduces on pristine main with its diff stashed).

## Root cause

A semantic conflict between the last two merges — each green alone:

- #1811 routes backfill writes (e.g. `explain --generate` summary persistence) through the git-refs store.
- #1824's on-demand fetch probes the remote when the local ref is missing, with the (correct) contract that transport failure is never mapped to absence.

In a **fully local repository** — no origin remote, no checkpoint_remote — the probe's origin-name fallback runs `git ls-remote origin`, gets exit 128 (`'origin' does not appear to be a git repository`), and the contract turns "this repo has no remotes" into a hard error. Backfill routing then fails instead of falling through to the branch store.

## Fix

Before probing: if the fetch target is the non-authoritative origin fallback, no checkpoint_remote is configured, and origin has no URL, return the ref's absence (`plumbing.ErrReferenceNotFound`) — a repo with no remotes has no remote that could host checkpoint refs. Deliberately narrow:

- checkpoint_remote configured but unresolvable → unchanged (fallback emptiness still refuses to classify as absence)
- genuine transport failures → unchanged (still never absence)

New regression test `TestFetchCheckpointRef_NoRemoteAtAllIsAbsence` alongside the existing probe-contract tests, all green; the failing explain test passes with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped change to checkpoint ref fetch error classification with a regression test; does not relax transport-vs-absence rules for configured or reachable remotes.
> 
> **Overview**
> Fixes **backfill / `explain --generate` routing** in fully local repos where on-demand checkpoint ref probing would hit the non-authoritative `origin` fallback and surface `git ls-remote` exit 128 as a transport error instead of “ref not found.”
> 
> **`FetchCheckpointRef`** adds a narrow pre-probe guard: when the target is the `origin` fallback, `checkpoint_remote` is not configured, and `origin` has no URL, it returns **`plumbing.ErrReferenceNotFound`** (wrapped) without calling `ls-remote`. Behavior is unchanged when `checkpoint_remote` is set (including unresolvable) or when a real remote exists but is unreachable.
> 
> Adds regression test **`TestFetchCheckpointRef_NoRemoteAtAllIsAbsence`** for a repo with no remotes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66c06c5b561dd982012268c675bea67ecc5a1a4a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->