### PR TITLE
fix(checkpoint): fall back to v1-branch store when no checkpoint remote is configured

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -39,18 +40,35 @@ func CheckpointFetchTarget(ctx context.Context) string {
 //     non-authoritative: they exist so a fetch can still be attempted, not to
 //     certify where checkpoint refs live.
 //   - resolved: whether a concrete fetch URL/remote was resolved at all. It is
-//     false ONLY when URL resolution produced nothing (no origin remote, no
-//     configured checkpoint_remote, unreadable settings) and we fell back to
-//     the bare "origin" name. That literal "origin" is not guaranteed to be a
-//     real git remote, so a probe failure against it says only "there is
-//     nowhere to fetch from", not "the checkpoint is missing on a real remote".
+//     false ONLY when no checkpoint remote is configured (no origin remote and
+//     no configured checkpoint_remote) and we fell back to the bare "origin"
+//     name. That literal "origin" is not guaranteed to be a real git remote, so
+//     a probe failure against it says only "there is nowhere to fetch from". If
+//     a checkpoint_remote IS configured but its URL can't be derived this call,
+//     resolved is true so a probe failure surfaces as a real error, not absence.
 func checkpointFetchTarget(ctx context.Context) (target string, authoritative, resolved bool) {
 	url, auth, err := fetchURLAuthoritative(ctx)
 	if err == nil && url != "" {
 		return url, auth, true
 	}
-	return "origin", false, false
+	if errors.Is(err, errNoCheckpointRemoteConfigured) {
+		// Genuinely no checkpoint remote configured: a probe failure against the
+		// bare "origin" fallback proves only "nowhere to fetch from", so callers
+		// classify it as checkpoint absence and fall back to the v1-branch store.
+		return "origin", false, false
+	}
+	// A checkpoint remote IS configured but its URL could not be derived this
+	// call (transient GetRemoteURL error, provider-host derivation failure). Mark
+	// resolved so a probe failure surfaces as a real error rather than being
+	// silently reclassified as checkpoint absence.
+	return "origin", false, true
 }
+
+// errNoCheckpointRemoteConfigured marks the "no checkpoint remote configured at
+// all" case (no origin remote and no configured checkpoint_remote) — the only
+// situation in which a probe failure against the bare "origin" fallback is
+// classified as checkpoint absence rather than surfaced as a real error.
+var errNoCheckpointRemoteConfigured = errors.New("no checkpoint remote configured")
 
 // FetchCheckpointRef fetches a single per-checkpoint ref
 // (refs/entire/checkpoints/<shard>/<id>) from the checkpoint remote into the

--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref.go
@@ -28,20 +28,28 @@ const readFetchTimeout = 2 * time.Minute
 // resolution fails, it falls back to the origin remote name so callers can
 // still attempt a fetch.
 func CheckpointFetchTarget(ctx context.Context) string {
-	target, _ := checkpointFetchTarget(ctx)
+	target, _, _ := checkpointFetchTarget(ctx)
 	return target
 }
 
-// checkpointFetchTarget is CheckpointFetchTarget plus whether the target is
-// authoritative for checkpoint refs (see fetchURLAuthoritative). The bare
-// "origin" fallbacks are non-authoritative: they exist so a fetch can still
-// be attempted, not to certify where checkpoint refs live.
-func checkpointFetchTarget(ctx context.Context) (string, bool) {
-	url, authoritative, err := fetchURLAuthoritative(ctx)
+// checkpointFetchTarget is CheckpointFetchTarget plus two facts about the
+// returned target:
+//   - authoritative: whether the target is certified as the host of checkpoint
+//     refs (see fetchURLAuthoritative). The bare "origin" fallbacks are
+//     non-authoritative: they exist so a fetch can still be attempted, not to
+//     certify where checkpoint refs live.
+//   - resolved: whether a concrete fetch URL/remote was resolved at all. It is
+//     false ONLY when URL resolution produced nothing (no origin remote, no
+//     configured checkpoint_remote, unreadable settings) and we fell back to
+//     the bare "origin" name. That literal "origin" is not guaranteed to be a
+//     real git remote, so a probe failure against it says only "there is
+//     nowhere to fetch from", not "the checkpoint is missing on a real remote".
+func checkpointFetchTarget(ctx context.Context) (target string, authoritative, resolved bool) {
+	url, auth, err := fetchURLAuthoritative(ctx)
 	if err == nil && url != "" {
-		return url, authoritative
+		return url, auth, true
 	}
-	return "origin", false
+	return "origin", false, false
 }
 
 // FetchCheckpointRef fetches a single per-checkpoint ref
@@ -62,10 +70,24 @@ func FetchCheckpointRef(ctx context.Context, ref plumbing.ReferenceName) error {
 	ctx, cancel := context.WithTimeout(ctx, readFetchTimeout)
 	defer cancel()
 
-	fetchTarget, authoritative := checkpointFetchTarget(ctx)
+	fetchTarget, authoritative, resolved := checkpointFetchTarget(ctx)
 
 	out, err := LsRemoteInDir(ctx, "", fetchTarget, ref.String())
 	if err != nil {
+		if !resolved {
+			// No checkpoint remote is configured or reachable — resolution fell
+			// back to the bare "origin" name, which need not be a real git
+			// remote (the local repo may have no origin at all). A probe failure
+			// here proves only that there is nowhere to fetch from, not that the
+			// checkpoint is missing on a real remote. Classify as absence so the
+			// git-refs store maps it to ErrCheckpointNotFound and write routing
+			// falls back to the v1-branch store, mirroring the branch-existence
+			// path (BranchExistsOnRemote treats an ls-remote failure as "not
+			// found"). A genuine transport failure against a *resolved* remote
+			// still propagates below, so real offline/network loss is never
+			// silently swallowed as absence.
+			return fmt.Errorf("probe checkpoint ref %s: no checkpoint remote configured: %w", ref, plumbing.ErrReferenceNotFound)
+		}
 		// Redact: fetchTarget can be a remote URL with embedded credentials
 		// (CI origin URLs), and this error is logged and shown to users.
 		return fmt.Errorf("probe checkpoint ref %s on %s: %w", ref, RedactURL(fetchTarget), err)

--- a/cmd/entire/cli/checkpoint/remote/checkpoint_ref_test.go
+++ b/cmd/entire/cli/checkpoint/remote/checkpoint_ref_test.go
@@ -94,3 +94,31 @@ func TestFetchCheckpointRef_UnreachableRemoteIsFailure(t *testing.T) {
 	require.NotErrorIs(t, err, plumbing.ErrReferenceNotFound,
 		"a transport failure must stay distinguishable from absence")
 }
+
+// TestFetchCheckpointRef_NoConfiguredRemoteIsAbsence: with no origin remote and
+// no configured checkpoint_remote, fetch-target resolution can resolve NOTHING
+// and falls back to the bare "origin" name, which is not a real git remote. The
+// ls-remote probe then fails — but that failure means only "there is nowhere to
+// fetch from", not "the checkpoint is missing on a real remote". It must
+// classify as absence (wrap plumbing.ErrReferenceNotFound) so the git-refs
+// store maps it to ErrCheckpointNotFound and write routing falls back to the
+// v1-branch store, instead of hard-erroring the whole save (the refs-primary
+// regression this fixes). This is the mirror of
+// TestFetchCheckpointRef_UnreachableRemoteIsFailure, where origin IS configured
+// (a real, resolved remote) and the same probe failure must propagate.
+func TestFetchCheckpointRef_NoConfiguredRemoteIsAbsence(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+
+	workDir := t.TempDir()
+	testutil.InitRepo(t, workDir) // no origin remote, no checkpoint_remote
+	testutil.WriteFile(t, workDir, "f.txt", "content")
+	testutil.GitAdd(t, workDir, "f.txt")
+	testutil.GitCommit(t, workDir, "init")
+	t.Chdir(workDir)
+
+	ref := plumbing.ReferenceName("refs/entire/checkpoints/Z9/01KVBJCWYA4YW6J5M9GP655HZ9")
+	err := FetchCheckpointRef(context.Background(), ref)
+	require.Error(t, err)
+	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound,
+		"a probe failure with no configured/reachable checkpoint remote must classify as absence so callers fall back")
+}

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -95,7 +95,7 @@ func fetchURLAuthoritative(ctx context.Context, opts ...FetchURLOptions) (string
 			// Genuinely no remote to fetch checkpoints from: no origin remote and
 			// no configured checkpoint_remote. Tagged with the sentinel so callers
 			// classify a probe failure as absence rather than a real error.
-			return "", false, fmt.Errorf("no checkpoint remote configured (no fetch URL: %w): %w", originErr, errNoCheckpointRemoteConfigured)
+			return "", false, fmt.Errorf("no fetch URL found: %w: %w", originErr, errNoCheckpointRemoteConfigured)
 		}
 		// No checkpoint_remote configured: origin IS the checkpoint host.
 		return originURL, true, nil

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -92,7 +92,10 @@ func fetchURLAuthoritative(ctx context.Context, opts ...FetchURLOptions) (string
 	config := s.GetCheckpointRemote()
 	if config == nil {
 		if originURL == "" {
-			return "", false, fmt.Errorf("no fetch URL found: %w", originErr)
+			// Genuinely no remote to fetch checkpoints from: no origin remote and
+			// no configured checkpoint_remote. Tagged with the sentinel so callers
+			// classify a probe failure as absence rather than a real error.
+			return "", false, fmt.Errorf("no checkpoint remote configured (no fetch URL: %w): %w", originErr, errNoCheckpointRemoteConfigured)
 		}
 		// No checkpoint_remote configured: origin IS the checkpoint host.
 		return originURL, true, nil


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/964
<!-- entire-trail-link-end -->

## What

Restores the git-refs-primary → v1-branch checkpoint fallback that is currently RED on `main` (blocks every PR):

`TestRunExplainAuto_GeneratePersistsHexOnBranchUnderRefsPrimary` fails with
`failed to save summary: fetch checkpoint ref ...: probe checkpoint ref ... on ://origin: git ls-remote: exit status 128`.

## Why

Under a git-refs primary, saving a summary for a pre-migration checkpoint that lives only on the v1 branch resolves the checkpoint through the git-refs store, which triggers an on-demand fetch of the missing ref. When the repo has **no origin remote and no configured `checkpoint_remote`**, fetch-target resolution falls back to the bare `"origin"` name, `git ls-remote origin` fails (exit 128), and `FetchCheckpointRef` returned that as a **hard error**.

Commit `7bbdad09c` ("git-refs: don't mask real errors as not-found") made `resolveRefMaybeFetch` propagate fetch failures instead of masking them as not-found — correct for genuine offline/network loss, but it also turned the no-remote probe failure into a hard error. That aborts the kind-routing `Write` backfill at the `ErrCheckpointNotFound` check (routing_store.go) instead of falling through to the v1-branch store, so the summary is discarded.

## How

The fix is localized to the fetch boundary and preserves `7bbdad09c`'s intent by distinguishing **no-remote** from **genuine-error**:

- `checkpointFetchTarget` now also reports `resolved` — whether a concrete fetch URL/remote was resolved at all. It is `false` **only** when URL resolution produced nothing (no origin, no `checkpoint_remote`, unreadable settings) and we fell back to the bare `"origin"` name.
- `FetchCheckpointRef`: when the ls-remote probe fails **and the target was that unresolved fallback**, it wraps `plumbing.ErrReferenceNotFound`. The git-refs store maps that to `ErrCheckpointNotFound`, and routing falls back to the v1-branch store — mirroring `BranchExistsOnRemote`, which already treats an ls-remote failure as "not found".
- A genuine transport failure against a **resolved** remote (real origin URL or configured checkpoint remote) still propagates unchanged, and genuine absence still reads not-found.

## Tests

- `TestRunExplainAuto_GeneratePersistsHexOnBranchUnderRefsPrimary` now passes.
- The `7bbdad09c` failure-propagation tests stay green: `TestFetchCheckpointRef_UnreachableRemoteIsFailure` (origin configured but unreachable → propagates), `TestFetchCheckpointRef_FallbackTargetNeverClassifiesAbsence`, and `TestGitRefsStore_OnDemandRefFetch_FailurePropagates` / `..._BackfillFetchFailureAborts`.
- New: `TestFetchCheckpointRef_NoConfiguredRemoteIsAbsence` pins the "no configured remote → not-found → fallback" classification (the mirror of the unreachable-remote case).
- Full `./cmd/entire/cli/ ./cmd/entire/cli/checkpoint/...` suite: 3365 passed. `fmt` clean, `lint` 0 issues. No existing test changed.