### PR TITLE
Fix Fish installer setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ curl -fsSL https://entire.io/install.sh | bash                          # stable
 # curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly  # or nightly
 ```
 
+The installer is a Bash script. Fish users should run the command unchanged,
+including the trailing `| bash`; the installer will provide Fish-specific PATH
+setup when needed.
+
 ### Windows
 
 Install with Scoop:

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -2090,7 +2090,10 @@ const shellCompletionComment = "# Entire CLI shell completion"
 // errUnsupportedShell is returned when the user's shell is not supported for completion.
 var errUnsupportedShell = errors.New("unsupported shell")
 
-const installerShellEnv = "ENTIRE_INSTALLER_SHELL"
+const (
+	installerShellEnv   = "ENTIRE_INSTALLER_SHELL"
+	installerPathDirEnv = "ENTIRE_INSTALLER_PATH_DIR"
+)
 
 // shellCompletionTarget returns the rc file path and completion lines for the
 // user's current shell.
@@ -2104,11 +2107,21 @@ func shellCompletionTarget() (shellName, rcFile, completionLine string, err erro
 	if shell == "" {
 		shell = os.Getenv("SHELL")
 	}
+
+	completionCommand := "entire"
+	if installDir := os.Getenv(installerPathDirEnv); installDir != "" {
+		// The first shell startup can encounter the completion line before the
+		// user-added PATH line. Keep their existing PATH and prepend the install
+		// directory only for completion generation. This syntax works in Bash,
+		// Zsh, and Fish.
+		completionCommand = fmt.Sprintf("env PATH=%s:\"$PATH\" entire", quoteShellWord(installDir))
+	}
+
 	switch {
 	case strings.Contains(shell, "zsh"):
 		return "Zsh",
 			filepath.Join(home, ".zshrc"),
-			"autoload -Uz compinit && compinit && source <(entire completion zsh)",
+			fmt.Sprintf("autoload -Uz compinit && compinit && source <(%s completion zsh)", completionCommand),
 			nil
 	case strings.Contains(shell, "bash"):
 		bashRC := filepath.Join(home, ".bashrc")
@@ -2117,7 +2130,7 @@ func shellCompletionTarget() (shellName, rcFile, completionLine string, err erro
 		}
 		return "Bash",
 			bashRC,
-			"source <(entire completion bash)",
+			fmt.Sprintf("source <(%s completion bash)", completionCommand),
 			nil
 	case strings.Contains(shell, "fish"):
 		configHome := os.Getenv("XDG_CONFIG_HOME")
@@ -2126,11 +2139,16 @@ func shellCompletionTarget() (shellName, rcFile, completionLine string, err erro
 		}
 		return "Fish",
 			filepath.Join(configHome, "fish", "config.fish"),
-			"entire completion fish | source",
+			completionCommand + " completion fish | source",
 			nil
 	default:
 		return "", "", "", errUnsupportedShell
 	}
+}
+
+// quoteShellWord returns a single shell word that is safe in Bash, Zsh, and Fish.
+func quoteShellWord(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 // promptShellCompletion offers to add shell completion to the user's rc file.
@@ -2177,7 +2195,11 @@ func promptShellCompletion(w io.Writer) error {
 	}
 
 	fmt.Fprintf(w, "✓ Shell completion added to %s\n", rcFile)
-	fmt.Fprintln(w, "  Restart your shell to activate")
+	if os.Getenv(installerPathDirEnv) != "" {
+		fmt.Fprintln(w, "  Complete the installer's PATH setup, then restart your shell to activate")
+	} else {
+		fmt.Fprintln(w, "  Restart your shell to activate")
+	}
 
 	return nil
 }

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -2090,6 +2090,8 @@ const shellCompletionComment = "# Entire CLI shell completion"
 // errUnsupportedShell is returned when the user's shell is not supported for completion.
 var errUnsupportedShell = errors.New("unsupported shell")
 
+const installerShellEnv = "ENTIRE_INSTALLER_SHELL"
+
 // shellCompletionTarget returns the rc file path and completion lines for the
 // user's current shell.
 func shellCompletionTarget() (shellName, rcFile, completionLine string, err error) {
@@ -2098,7 +2100,10 @@ func shellCompletionTarget() (shellName, rcFile, completionLine string, err erro
 		return "", "", "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
 
-	shell := os.Getenv("SHELL")
+	shell := os.Getenv(installerShellEnv)
+	if shell == "" {
+		shell = os.Getenv("SHELL")
+	}
 	switch {
 	case strings.Contains(shell, "zsh"):
 		return "Zsh",
@@ -2115,8 +2120,12 @@ func shellCompletionTarget() (shellName, rcFile, completionLine string, err erro
 			"source <(entire completion bash)",
 			nil
 	case strings.Contains(shell, "fish"):
+		configHome := os.Getenv("XDG_CONFIG_HOME")
+		if configHome == "" {
+			configHome = filepath.Join(home, ".config")
+		}
 		return "Fish",
-			filepath.Join(home, ".config", "fish", "config.fish"),
+			filepath.Join(configHome, "fish", "config.fish"),
 			"entire completion fish | source",
 			nil
 	default:

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -1365,7 +1365,9 @@ func TestShellCompletionTarget(t *testing.T) {
 	tests := []struct {
 		name             string
 		shell            string
+		installerShell   string
 		createBashProf   bool
+		useXDGConfigHome bool
 		wantShell        string
 		wantRCBase       string // basename of rc file
 		wantCompletion   string
@@ -1401,6 +1403,22 @@ func TestShellCompletionTarget(t *testing.T) {
 			wantCompletion: "entire completion fish | source",
 		},
 		{
+			name:             "fish_xdg_config_home",
+			shell:            "/usr/bin/fish",
+			useXDGConfigHome: true,
+			wantShell:        "Fish",
+			wantRCBase:       filepath.Join("fish", "config.fish"),
+			wantCompletion:   "entire completion fish | source",
+		},
+		{
+			name:           "installer_shell_overrides_login_shell",
+			shell:          "/bin/zsh",
+			installerShell: "fish",
+			wantShell:      "Fish",
+			wantRCBase:     filepath.Join(".config", "fish", "config.fish"),
+			wantCompletion: "entire completion fish | source",
+		},
+		{
 			name:             "empty_shell",
 			shell:            "",
 			wantErrUnsupport: true,
@@ -1412,6 +1430,14 @@ func TestShellCompletionTarget(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("HOME", home)
 			t.Setenv("SHELL", tt.shell)
+			t.Setenv(installerShellEnv, tt.installerShell)
+			t.Setenv("XDG_CONFIG_HOME", "")
+
+			configRoot := home
+			if tt.useXDGConfigHome {
+				configRoot = filepath.Join(home, "xdg-config")
+				t.Setenv("XDG_CONFIG_HOME", configRoot)
+			}
 
 			if tt.createBashProf {
 				if err := os.WriteFile(filepath.Join(home, ".bash_profile"), []byte(""), 0o644); err != nil {
@@ -1433,7 +1459,7 @@ func TestShellCompletionTarget(t *testing.T) {
 			if shellName != tt.wantShell {
 				t.Errorf("shellName = %q, want %q", shellName, tt.wantShell)
 			}
-			wantRC := filepath.Join(home, tt.wantRCBase)
+			wantRC := filepath.Join(configRoot, tt.wantRCBase)
 			if rcFile != wantRC {
 				t.Errorf("rcFile = %q, want %q", rcFile, wantRC)
 			}

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -1366,6 +1366,7 @@ func TestShellCompletionTarget(t *testing.T) {
 		name             string
 		shell            string
 		installerShell   string
+		installerPathDir string
 		createBashProf   bool
 		useXDGConfigHome bool
 		wantShell        string
@@ -1411,12 +1412,13 @@ func TestShellCompletionTarget(t *testing.T) {
 			wantCompletion:   "entire completion fish | source",
 		},
 		{
-			name:           "installer_shell_overrides_login_shell",
-			shell:          "/bin/zsh",
-			installerShell: "fish",
-			wantShell:      "Fish",
-			wantRCBase:     filepath.Join(".config", "fish", "config.fish"),
-			wantCompletion: "entire completion fish | source",
+			name:             "installer_shell_overrides_login_shell",
+			shell:            "/bin/zsh",
+			installerShell:   "fish",
+			installerPathDir: "/Users/Example User/.local/bin",
+			wantShell:        "Fish",
+			wantRCBase:       filepath.Join(".config", "fish", "config.fish"),
+			wantCompletion:   `env PATH='/Users/Example User/.local/bin':"$PATH" entire completion fish | source`,
 		},
 		{
 			name:             "empty_shell",
@@ -1431,6 +1433,7 @@ func TestShellCompletionTarget(t *testing.T) {
 			t.Setenv("HOME", home)
 			t.Setenv("SHELL", tt.shell)
 			t.Setenv(installerShellEnv, tt.installerShell)
+			t.Setenv(installerPathDirEnv, tt.installerPathDir)
 			t.Setenv("XDG_CONFIG_HOME", "")
 
 			configRoot := home
@@ -1465,6 +1468,28 @@ func TestShellCompletionTarget(t *testing.T) {
 			}
 			if completion != tt.wantCompletion {
 				t.Errorf("completion = %q, want %q", completion, tt.wantCompletion)
+			}
+		})
+	}
+}
+
+func TestQuoteShellWord(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "spaces", value: "/Users/Example User/.local/bin", want: "'/Users/Example User/.local/bin'"},
+		{name: "single_quote", value: "/Users/O'Brien/.local/bin", want: "'/Users/O'\\''Brien/.local/bin'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := quoteShellWord(tt.value); got != tt.want {
+				t.Fatalf("quoteShellWord(%q) = %q, want %q", tt.value, got, tt.want)
 			}
 		})
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,7 +92,16 @@ detect_user_shell() {
 show_path_setup() {
     local shell_name="$1"
     local install_dir="$2"
+    local install_dir_display="$install_dir"
     local shell_config=""
+
+    # Keep copy-paste instructions portable when installing under the user's
+    # home directory, while still honoring any other install directory.
+    if [[ "$install_dir" == "$HOME" ]]; then
+        install_dir_display="\$HOME"
+    elif [[ "$install_dir" == "$HOME/"* ]]; then
+        install_dir_display="\$HOME/${install_dir#"$HOME/"}"
+    fi
 
     echo ""
     echo -e "  Add ${BOLD}entire${NC} to your PATH:"
@@ -102,14 +111,14 @@ show_path_setup() {
         fish)
             # fish_add_path updates this Fish session and persists the path for
             # future sessions, so no config-file edit or restart is required.
-            echo -e "    ${BOLD}fish_add_path \"\$HOME/.local/bin\"${NC}"
+            echo -e "    ${BOLD}fish_add_path \"${install_dir_display}\"${NC}"
             echo ""
             echo -e "  Then run ${BOLD}entire${NC} to get started."
             ;;
         zsh)
             # shellcheck disable=SC2088
             shell_config="~/.zshrc"
-            echo -e "    ${BOLD}echo 'export PATH=\"${install_dir}:\$PATH\"' >> ${shell_config}${NC}"
+            echo -e "    ${BOLD}echo 'export PATH=\"${install_dir_display}:\$PATH\"' >> ${shell_config}${NC}"
             echo ""
             echo -e "  Restart your terminal, then run ${BOLD}entire${NC} to get started."
             ;;
@@ -121,16 +130,16 @@ show_path_setup() {
                 # shellcheck disable=SC2088
                 shell_config="~/.bashrc"
             fi
-            echo -e "    ${BOLD}echo 'export PATH=\"${install_dir}:\$PATH\"' >> ${shell_config}${NC}"
+            echo -e "    ${BOLD}echo 'export PATH=\"${install_dir_display}:\$PATH\"' >> ${shell_config}${NC}"
             echo ""
             echo -e "  Restart your terminal, then run ${BOLD}entire${NC} to get started."
             ;;
         *)
             echo "  Fish:"
-            echo -e "    ${BOLD}fish_add_path \"\$HOME/.local/bin\"${NC}"
+            echo -e "    ${BOLD}fish_add_path \"${install_dir_display}\"${NC}"
             echo ""
             echo "  Bash, Zsh, and other POSIX-compatible shells:"
-            echo -e "    ${BOLD}export PATH=\"${install_dir}:\$PATH\"${NC}"
+            echo -e "    ${BOLD}export PATH=\"${install_dir_display}:\$PATH\"${NC}"
             echo ""
             echo -e "  Then run ${BOLD}entire${NC} to get started."
             ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This installer requires Bash. It can be launched from Fish, Zsh, or Bash with:
+#   curl -fsSL https://entire.io/install.sh | bash
+
 set -euo pipefail
 
 GITHUB_REPO="entireio/cli"
@@ -48,6 +51,84 @@ Options:
   --channel   Release channel to install (default: stable)
   -h, --help  Show this help message
 EOF
+}
+
+normalize_shell_name() {
+    local shell_name="${1##*/}"
+    shell_name="${shell_name#-}"
+
+    case "$shell_name" in
+        bash|fish|zsh)
+            echo "$shell_name"
+            ;;
+    esac
+}
+
+detect_user_shell() {
+    local parent_command=""
+    local shell_name=""
+
+    # The installer itself runs under Bash, so inspect its parent first to find
+    # the shell the user actually launched it from. $SHELL is only a fallback:
+    # it commonly names the login shell rather than the current shell.
+    if command -v ps &> /dev/null; then
+        parent_command="$(ps -p "$PPID" -o comm= 2>/dev/null || true)"
+        shell_name="$(normalize_shell_name "$parent_command")"
+    fi
+
+    if [[ -z "$shell_name" ]]; then
+        shell_name="$(normalize_shell_name "${SHELL:-}")"
+    fi
+
+    echo "$shell_name"
+}
+
+show_path_setup() {
+    local shell_name="$1"
+    local install_dir="$2"
+    local shell_config=""
+
+    echo ""
+    echo -e "  Add ${BOLD}entire${NC} to your PATH:"
+    echo ""
+
+    case "$shell_name" in
+        fish)
+            # fish_add_path updates this Fish session and persists the path for
+            # future sessions, so no config-file edit or restart is required.
+            echo -e "    ${BOLD}fish_add_path \"\$HOME/.local/bin\"${NC}"
+            echo ""
+            echo -e "  Then run ${BOLD}entire${NC} to get started."
+            ;;
+        zsh)
+            # shellcheck disable=SC2088
+            shell_config="~/.zshrc"
+            echo -e "    ${BOLD}echo 'export PATH=\"${install_dir}:\$PATH\"' >> ${shell_config}${NC}"
+            echo ""
+            echo -e "  Restart your terminal, then run ${BOLD}entire${NC} to get started."
+            ;;
+        bash)
+            if [[ -f "$HOME/.bash_profile" ]]; then
+                # shellcheck disable=SC2088
+                shell_config="~/.bash_profile"
+            else
+                # shellcheck disable=SC2088
+                shell_config="~/.bashrc"
+            fi
+            echo -e "    ${BOLD}echo 'export PATH=\"${install_dir}:\$PATH\"' >> ${shell_config}${NC}"
+            echo ""
+            echo -e "  Restart your terminal, then run ${BOLD}entire${NC} to get started."
+            ;;
+        *)
+            echo "  Fish:"
+            echo -e "    ${BOLD}fish_add_path \"\$HOME/.local/bin\"${NC}"
+            echo ""
+            echo "  Bash, Zsh, and other POSIX-compatible shells:"
+            echo -e "    ${BOLD}export PATH=\"${install_dir}:\$PATH\"${NC}"
+            echo ""
+            echo -e "  Then run ${BOLD}entire${NC} to get started."
+            ;;
+    esac
 }
 
 detect_os() {
@@ -269,6 +350,11 @@ main() {
         error "Installation completed but the binary failed to execute. Please check the installation."
     fi
 
+    # Detect the invoking shell before checking PATH. This process is Bash even
+    # when the user launched it from Fish or Zsh.
+    local shell_name
+    shell_name="$(detect_user_shell)"
+
     # Check if the installed binary is the one that will be found in PATH
     local path_binary
     path_binary=$(command -v "entire" 2>/dev/null || true)
@@ -286,54 +372,20 @@ main() {
         echo -e "${YELLOW}!${NC}   2. Adjust your PATH to prioritize ${install_dir}"
         echo ""
         error "Installation completed but PATH needs adjustment. Then, rerun the installation."
-    elif [[ -z "$path_binary" ]]; then
-        # First-time install: ~/.local/bin likely isn't on their PATH yet.
-        # Detect their shell and show the right config file.
-        local shell_name shell_config
-        shell_name="$(basename "${SHELL:-}")"
-        case "$shell_name" in
-            zsh)
-                # shellcheck disable=SC2088
-                shell_config="~/.zshrc" ;;
-            bash)
-                if [[ -f "$HOME/.bash_profile" ]]; then
-                    # shellcheck disable=SC2088
-                    shell_config="~/.bash_profile"
-                else
-                    # shellcheck disable=SC2088
-                    shell_config="~/.bashrc"
-                fi
-                ;;
-            fish)
-                # shellcheck disable=SC2088
-                shell_config="~/.config/fish/config.fish" ;;
-            *)
-                shell_config="" ;;
-        esac
-
-        echo ""
-        echo -e "  Add ${BOLD}entire${NC} to your PATH:"
-        echo ""
-        if [[ "$shell_name" == "fish" ]]; then
-            echo -e "    ${BOLD}mkdir -p ~/.config/fish${NC}"
-            echo -e "    ${BOLD}echo 'fish_add_path ${install_dir}' >> \$HOME/.config/fish/config.fish${NC}"
-        elif [[ -n "$shell_config" ]]; then
-            echo -e "    ${BOLD}echo 'export PATH=\"${install_dir}:\$PATH\"' >> ${shell_config}${NC}"
-        else
-            echo -e "  Add this to your shell config:"
-            echo ""
-            echo -e "    ${BOLD}export PATH=\"${install_dir}:\$PATH\"${NC}"
-            echo ""
-            echo -e "  Restart your terminal, then run ${BOLD}entire${NC} to get started."
-            exit 0
-        fi
-        echo ""
-        echo -e "  Restart your terminal, then run ${BOLD}entire${NC} to get started."
-        exit 0
     fi
 
+    # Use the absolute binary path so first-time installs can run post-install
+    # actions before ~/.local/bin has been added to PATH.
     info "Running post-install actions..."
-    "$install_path" curl-bash-post-install
+    ENTIRE_INSTALLER_SHELL="$shell_name" "$install_path" curl-bash-post-install
+
+    if [[ -z "$path_binary" ]]; then
+        # First-time install: ~/.local/bin likely isn't on their PATH yet.
+        show_path_setup "$shell_name" "$install_dir"
+        exit 0
+    fi
 }
 
-main "$@"
+if [[ -z "${BASH_SOURCE[0]:-}" || "${BASH_SOURCE[0]:-}" == "$0" ]]; then
+    main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -397,8 +397,13 @@ main() {
     if [[ -z "$path_binary" ]]; then
         installer_path_dir="$install_dir"
     fi
+    local post_install_shell="${shell_name:-${SHELL:-}}"
     info "Running post-install actions..."
-    ENTIRE_INSTALLER_SHELL="$shell_name" \
+    # Released binaries that predate ENTIRE_INSTALLER_SHELL only inspect
+    # SHELL. Override it for this child process so the updated installer still
+    # targets the invoking shell while a compatible binary is rolling out.
+    SHELL="$post_install_shell" \
+        ENTIRE_INSTALLER_SHELL="$shell_name" \
         ENTIRE_INSTALLER_PATH_DIR="$installer_path_dir" \
         "$install_path" curl-bash-post-install
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,7 +54,13 @@ EOF
 }
 
 normalize_shell_name() {
-    local shell_name="${1##*/}"
+    local shell_name="$1"
+
+    # ps implementations may pad `comm` output. Trim it before extracting the
+    # executable name so the exact-match below still recognizes the shell.
+    shell_name="${shell_name#"${shell_name%%[![:space:]]*}"}"
+    shell_name="${shell_name%"${shell_name##*[![:space:]]}"}"
+    shell_name="${shell_name##*/}"
     shell_name="${shell_name#-}"
 
     case "$shell_name" in
@@ -375,9 +381,17 @@ main() {
     fi
 
     # Use the absolute binary path so first-time installs can run post-install
-    # actions before ~/.local/bin has been added to PATH.
+    # actions before ~/.local/bin has been added to PATH. Tell post-install
+    # where the binary lives so any completion command it writes can use that
+    # directory as a PATH fallback until the user's shell setup is complete.
+    local installer_path_dir=""
+    if [[ -z "$path_binary" ]]; then
+        installer_path_dir="$install_dir"
+    fi
     info "Running post-install actions..."
-    ENTIRE_INSTALLER_SHELL="$shell_name" "$install_path" curl-bash-post-install
+    ENTIRE_INSTALLER_SHELL="$shell_name" \
+        ENTIRE_INSTALLER_PATH_DIR="$installer_path_dir" \
+        "$install_path" curl-bash-post-install
 
     if [[ -z "$path_binary" ]]; then
         # First-time install: ~/.local/bin likely isn't on their PATH yet.

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -29,8 +29,8 @@ case "$1" in
         exit 0
         ;;
     curl-bash-post-install)
-        printf 'shell=%s\nxdg=%s\npath_dir=%s\n' \
-            "$ENTIRE_INSTALLER_SHELL" "$XDG_CONFIG_HOME" "$ENTIRE_INSTALLER_PATH_DIR" \
+        printf 'shell=%s\nlegacy_shell=%s\nxdg=%s\npath_dir=%s\n' \
+            "$ENTIRE_INSTALLER_SHELL" "$SHELL" "$XDG_CONFIG_HOME" "$ENTIRE_INSTALLER_PATH_DIR" \
             > "$HOME/post-install-env"
         ;;
 esac
@@ -118,7 +118,7 @@ esac
 	if err != nil {
 		t.Fatalf("post-install marker: %v", err)
 	}
-	wantPostInstallEnv := "shell=fish\nxdg=" + xdgConfigHome + "\npath_dir=" + filepath.Join(home, ".local", "bin") + "\n"
+	wantPostInstallEnv := "shell=fish\nlegacy_shell=fish\nxdg=" + xdgConfigHome + "\npath_dir=" + filepath.Join(home, ".local", "bin") + "\n"
 	if string(postInstallEnv) != wantPostInstallEnv {
 		t.Fatalf("post-install environment = %q, want %q", postInstallEnv, wantPostInstallEnv)
 	}

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -29,7 +29,9 @@ case "$1" in
         exit 0
         ;;
     curl-bash-post-install)
-        printf 'shell=%s\nxdg=%s\n' "$ENTIRE_INSTALLER_SHELL" "$XDG_CONFIG_HOME" > "$HOME/post-install-env"
+        printf 'shell=%s\nxdg=%s\npath_dir=%s\n' \
+            "$ENTIRE_INSTALLER_SHELL" "$XDG_CONFIG_HOME" "$ENTIRE_INSTALLER_PATH_DIR" \
+            > "$HOME/post-install-env"
         ;;
 esac
 `,
@@ -116,7 +118,7 @@ esac
 	if err != nil {
 		t.Fatalf("post-install marker: %v", err)
 	}
-	wantPostInstallEnv := "shell=fish\nxdg=" + xdgConfigHome + "\n"
+	wantPostInstallEnv := "shell=fish\nxdg=" + xdgConfigHome + "\npath_dir=" + filepath.Join(home, ".local", "bin") + "\n"
 	if string(postInstallEnv) != wantPostInstallEnv {
 		t.Fatalf("post-install environment = %q, want %q", postInstallEnv, wantPostInstallEnv)
 	}
@@ -164,6 +166,12 @@ func TestDetectUserShell(t *testing.T) {
 		{
 			name:       "parent_fish_overrides_login_zsh",
 			parent:     "/opt/homebrew/bin/fish",
+			loginShell: "/bin/zsh",
+			want:       "fish",
+		},
+		{
+			name:       "padded_parent_fish_overrides_login_zsh",
+			parent:     "   /opt/homebrew/bin/fish   ",
 			loginShell: "/bin/zsh",
 			want:       "fish",
 		},

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -1,0 +1,306 @@
+//go:build !windows
+
+package scripts_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestInstallFromFishWithMissingPathRunsPostInstallAndShowsFishSetup(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	fixtureDir := t.TempDir()
+	archivePath := filepath.Join(fixtureDir, "entire_darwin_arm64.tar.gz")
+	writeInstallerArchive(t, archivePath, map[string]string{
+		"entire": `#!/bin/sh
+case "$1" in
+    version)
+        exit 0
+        ;;
+    curl-bash-post-install)
+        printf 'shell=%s\nxdg=%s\n' "$ENTIRE_INSTALLER_SHELL" "$XDG_CONFIG_HOME" > "$HOME/post-install-env"
+        ;;
+esac
+`,
+		"git-remote-entire": "#!/bin/sh\nexit 0\n",
+	})
+
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read installer archive: %v", err)
+	}
+	checksumPath := filepath.Join(fixtureDir, "checksums.txt")
+	checksum := sha256.Sum256(archiveData)
+	if err := os.WriteFile(
+		checksumPath,
+		[]byte(fmt.Sprintf("%x  entire_darwin_arm64.tar.gz\n", checksum)),
+		0o644,
+	); err != nil {
+		t.Fatalf("write checksums: %v", err)
+	}
+
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "uname"), `#!/bin/sh
+case "$1" in
+    -s) printf '%s\n' Darwin ;;
+    -m) printf '%s\n' arm64 ;;
+esac
+`)
+	writeExecutable(t, filepath.Join(binDir, "ps"), "#!/bin/sh\nprintf '%s\\n' /opt/homebrew/bin/fish\n")
+	writeExecutable(t, filepath.Join(binDir, "curl"), `#!/bin/bash
+output=""
+url=""
+while (($# > 0)); do
+    case "$1" in
+        -o)
+            output="$2"
+            shift 2
+            ;;
+        -H)
+            shift 2
+            ;;
+        *)
+            url="$1"
+            shift
+            ;;
+    esac
+done
+
+case "$url" in
+    */releases/latest)
+        printf '%s\n' '{"tag_name":"v1.2.3"}'
+        ;;
+    */checksums.txt)
+        cp "$FIXTURE_CHECKSUM" "$output"
+        ;;
+    *.tar.gz)
+        cp "$FIXTURE_ARCHIVE" "$output"
+        ;;
+    *)
+        printf 'unexpected URL: %s\n' "$url" >&2
+        exit 1
+        ;;
+esac
+`)
+
+	xdgConfigHome := filepath.Join(home, "xdg-config")
+	cmd := exec.CommandContext(t.Context(), "/bin/bash", installerPath(t))
+	cmd.Env = []string{
+		"FIXTURE_ARCHIVE=" + archivePath,
+		"FIXTURE_CHECKSUM=" + checksumPath,
+		"HOME=" + home,
+		"PATH=" + binDir + ":/usr/bin:/bin",
+		"SHELL=/bin/zsh",
+		"XDG_CONFIG_HOME=" + xdgConfigHome,
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run installer: %v\n%s", err, out)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, ".local", "bin", "entire")); err != nil {
+		t.Fatalf("installed binary: %v", err)
+	}
+	postInstallEnv, err := os.ReadFile(filepath.Join(home, "post-install-env"))
+	if err != nil {
+		t.Fatalf("post-install marker: %v", err)
+	}
+	wantPostInstallEnv := "shell=fish\nxdg=" + xdgConfigHome + "\n"
+	if string(postInstallEnv) != wantPostInstallEnv {
+		t.Fatalf("post-install environment = %q, want %q", postInstallEnv, wantPostInstallEnv)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, `fish_add_path "$HOME/.local/bin"`) {
+		t.Fatalf("installer did not show Fish PATH setup:\n%s", output)
+	}
+	if strings.Contains(output, "config.fish") {
+		t.Fatalf("installer should not tell Fish users to edit config.fish:\n%s", output)
+	}
+}
+
+func TestInstallerRunsWhenPipedToBash(t *testing.T) {
+	t.Parallel()
+
+	script, err := os.ReadFile(installerPath(t))
+	if err != nil {
+		t.Fatalf("read installer: %v", err)
+	}
+	cmd := exec.CommandContext(t.Context(), "/bin/bash", "-s", "--", "--help")
+	cmd.Env = []string{
+		"HOME=" + t.TempDir(),
+		"PATH=/usr/bin:/bin",
+	}
+	cmd.Stdin = bytes.NewReader(script)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("pipe installer to Bash: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Usage: install.sh") {
+		t.Fatalf("piped installer did not run main:\n%s", out)
+	}
+}
+
+func TestDetectUserShell(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		parent     string
+		loginShell string
+		want       string
+	}{
+		{
+			name:       "parent_fish_overrides_login_zsh",
+			parent:     "/opt/homebrew/bin/fish",
+			loginShell: "/bin/zsh",
+			want:       "fish",
+		},
+		{
+			name:       "login_shell_fallback",
+			loginShell: "/usr/bin/fish",
+			want:       "fish",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			binDir := t.TempDir()
+			psBody := "#!/bin/sh\nexit 1\n"
+			if tt.parent != "" {
+				psBody = "#!/bin/sh\nprintf '%s\\n' '" + tt.parent + "'\n"
+			}
+			writeExecutable(t, filepath.Join(binDir, "ps"), psBody)
+
+			got := runInstallerHelper(t, map[string]string{
+				"HOME":  t.TempDir(),
+				"PATH":  binDir,
+				"SHELL": tt.loginShell,
+			}, "detect_user_shell")
+
+			if got != tt.want+"\n" {
+				t.Fatalf("detect_user_shell output = %q, want %q", got, tt.want+"\n")
+			}
+		})
+	}
+}
+
+func TestShowPathSetup_FishUsesNativePersistentCommand(t *testing.T) {
+	t.Parallel()
+
+	out := runInstallerHelper(t, map[string]string{
+		"HOME":  "/Users/Example User",
+		"PATH":  "/usr/bin:/bin",
+		"SHELL": "/usr/bin/fish",
+	}, "show_path_setup", "fish", "/Users/Example User/.local/bin")
+
+	if !strings.Contains(out, `fish_add_path "$HOME/.local/bin"`) {
+		t.Fatalf("Fish PATH instructions do not use fish_add_path:\n%s", out)
+	}
+	if strings.Contains(out, "config.fish") {
+		t.Fatalf("Fish PATH instructions should not edit config.fish:\n%s", out)
+	}
+	if strings.Contains(out, "Restart your terminal") {
+		t.Fatalf("fish_add_path should not require a restart:\n%s", out)
+	}
+}
+
+func TestShowPathSetup_UnknownShellShowsFishAndPOSIXOptions(t *testing.T) {
+	t.Parallel()
+
+	out := runInstallerHelper(t, map[string]string{
+		"HOME":  "/home/example",
+		"PATH":  "/usr/bin:/bin",
+		"SHELL": "/usr/bin/elvish",
+	}, "show_path_setup", "", "/home/example/.local/bin")
+
+	for _, want := range []string{
+		"Fish:",
+		`fish_add_path "$HOME/.local/bin"`,
+		"Bash, Zsh, and other POSIX-compatible shells:",
+		`export PATH="/home/example/.local/bin:$PATH"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("PATH instructions missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func runInstallerHelper(t *testing.T, env map[string]string, function string, args ...string) string {
+	t.Helper()
+
+	commandArgs := []string{"-c", `source "$1"; shift; "$@"`, "bash", installerPath(t), function}
+	commandArgs = append(commandArgs, args...)
+	cmd := exec.CommandContext(t.Context(), "/bin/bash", commandArgs...)
+	cmd.Env = make([]string, 0, len(env))
+	for key, value := range env {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run %s: %v\n%s", function, err, out)
+	}
+	return string(out)
+}
+
+func installerPath(t *testing.T) string {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate installer test file")
+	}
+	return filepath.Join(filepath.Dir(filename), "install.sh")
+}
+
+func writeInstallerArchive(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+
+	var archive bytes.Buffer
+	gzipWriter := gzip.NewWriter(&archive)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for name, content := range files {
+		header := &tar.Header{
+			Name: name,
+			Mode: 0o755,
+			Size: int64(len(content)),
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatalf("write %s header: %v", name, err)
+		}
+		if _, err := tarWriter.Write([]byte(content)); err != nil {
+			t.Fatalf("write %s content: %v", name, err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close tar archive: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("close gzip archive: %v", err)
+	}
+	if err := os.WriteFile(path, archive.Bytes(), 0o644); err != nil {
+		t.Fatalf("write installer archive: %v", err)
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+}

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -226,6 +226,23 @@ func TestShowPathSetup_FishUsesNativePersistentCommand(t *testing.T) {
 	}
 }
 
+func TestShowPathSetup_FishUsesProvidedInstallDir(t *testing.T) {
+	t.Parallel()
+
+	out := runInstallerHelper(t, map[string]string{
+		"HOME":  "/Users/Example User",
+		"PATH":  "/usr/bin:/bin",
+		"SHELL": "/usr/bin/fish",
+	}, "show_path_setup", "fish", "/opt/entire/bin")
+
+	if !strings.Contains(out, `fish_add_path "/opt/entire/bin"`) {
+		t.Fatalf("Fish PATH instructions do not use the provided install directory:\n%s", out)
+	}
+	if strings.Contains(out, `$HOME/.local/bin`) {
+		t.Fatalf("Fish PATH instructions should not hard-code the default install directory:\n%s", out)
+	}
+}
+
 func TestShowPathSetup_UnknownShellShowsFishAndPOSIXOptions(t *testing.T) {
 	t.Parallel()
 
@@ -239,7 +256,7 @@ func TestShowPathSetup_UnknownShellShowsFishAndPOSIXOptions(t *testing.T) {
 		"Fish:",
 		`fish_add_path "$HOME/.local/bin"`,
 		"Bash, Zsh, and other POSIX-compatible shells:",
-		`export PATH="/home/example/.local/bin:$PATH"`,
+		`export PATH="$HOME/.local/bin:$PATH"`,
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("PATH instructions missing %q:\n%s", want, out)


### PR DESCRIPTION
## Summary

- detect the invoking shell before falling back to `$SHELL`
- use the Fish-native `fish_add_path` flow and preserve XDG-aware completion config
- run post-install actions on first-time installs and add installer regression coverage
- clarify that Fish users should still pipe the Bash installer to `bash`

## Root cause

The installer was Bash-only, but its Fish handoff relied solely on `$SHELL` and appended `fish_add_path` to a hard-coded `~/.config/fish/config.fish`. That could select the wrong shell, ignore `XDG_CONFIG_HOME`, leave the current Fish session without the new path, and skip post-install actions during the normal first install.

## User impact

Fish users now receive a command that updates the current session and persists for future sessions. Completion setup follows the XDG config location, while Bash and Zsh behavior remains unchanged.

## Validation

- `mise run check`
  - lint: 0 issues
  - race-enabled unit and integration tests
  - Vogon E2E canary: 59 passed
  - Roger Roger E2E canary: 4 passed
- manual Fish 4.8.1 end-to-end install of stable 0.9.0 in an isolated temporary home

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to install scripting, post-install shell completion targeting, and tests; no auth or runtime CLI behavior for existing installs.
> 
> **Overview**
> **Fish and first-time installs** no longer rely on login `$SHELL` or editing `config.fish`. The Bash installer infers the parent shell (`ps` on `PPID`, then `$SHELL`), passes it as `ENTIRE_INSTALLER_SHELL` into `entire curl-bash-post-install`, and shows Fish-specific PATH help via **`fish_add_path`** (no restart). Zsh/Bash PATH messaging is unchanged; unknown shells get both Fish and POSIX instructions.
> 
> **CLI post-install** (`shellCompletionTarget`) prefers `ENTIRE_INSTALLER_SHELL` over `$SHELL` and resolves Fish’s rc file under **`XDG_CONFIG_HOME`** when set.
> 
> **Flow change:** post-install runs even when `~/.local/bin` is not on PATH yet (absolute binary path), then PATH setup is shown and the script exits—so shell completion can run on first install.
> 
> **Docs** note that Fish users should still pipe the installer to `bash`. **Tests** cover installer helpers, piped-to-bash execution, Fish end-to-end, and expanded `TestShellCompletionTarget`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a2f774813e7f4e418ac6b9ada42128e56d0787. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->