### PR TITLE
test: pin down checkpoint push behavior for multi-push-URL remotes

### DIFF
--- a/cmd/entire/cli/integration_test/multi_pushurl.go
+++ b/cmd/entire/cli/integration_test/multi_pushurl.go
@@ -1,0 +1,277 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/execx"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// Helpers for the multi-push-URL scenario: ONE git remote that carries several
+// push URLs (remote.<name>.pushurl, which git allows to repeat). git pushes to
+// every push URL and — this is the part that matters for checkpoint sync —
+// invokes the pre-push hook ONCE PER PUSH URL, passing the same remote NAME as
+// $1 each time and the individual URL as $2. Our installed hook forwards only
+// $1 (see strategy/hooks.go), so the CLI cannot tell the invocations apart and
+// hands `git push <name>` the remote name, letting git fan out again.
+//
+// See multi_pushurl_test.go for what that means per checkpoint backend.
+
+// pushQueueFileName mirrors the unexported constant in the checkpoint package.
+// Duplicated rather than exported: the queue file name is part of the on-disk
+// layout these tests deliberately inspect from the outside.
+const pushQueueFileName = "entire-checkpoint-push-queue.jsonl"
+
+// AddSecondPushURL creates a second bare repository and configures remoteName so
+// pushes fan out to BOTH the remote's original URL and the new bare repo. It
+// returns the new bare repo path.
+//
+// Note the git subtlety this encodes: configuring ANY pushurl replaces the
+// remote's url for push purposes, so the original URL has to be re-added as an
+// explicit pushurl. Adding only the new one would silently redirect pushes to
+// the new repo instead of fanning out.
+//
+// The new bare repo is deliberately NOT added as a named remote — the whole
+// point is that it is reachable only as a push URL of an existing remote.
+func (env *TestEnv) AddSecondPushURL(remoteName string) string {
+	env.T.Helper()
+
+	ctx := env.T.Context()
+
+	secondBare := env.T.TempDir()
+	if resolved, err := filepath.EvalSymlinks(secondBare); err == nil {
+		secondBare = resolved
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "init", "--bare")
+	cmd.Dir = secondBare
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		env.T.Fatalf("failed to init second bare repo: %v\n%s", err, output)
+	}
+
+	originalURL := env.RemoteURL(remoteName)
+
+	// Re-add the original URL as an explicit push URL first, then the new one,
+	// so push fans out to both in that order.
+	for _, url := range []string{originalURL, secondBare} {
+		cmd = exec.CommandContext(ctx, "git", "remote", "set-url", "--add", "--push", remoteName, url)
+		cmd.Dir = env.RepoDir
+		cmd.Env = testutil.GitIsolatedEnv()
+		if output, err := cmd.CombinedOutput(); err != nil {
+			env.T.Fatalf("failed to add push URL %s to remote %s: %v\n%s", url, remoteName, err, output)
+		}
+	}
+
+	// Guard the setup itself: a helper that quietly configured one push URL
+	// would make every fan-out assertion below vacuous.
+	if got := env.PushURLs(remoteName); len(got) != 2 {
+		env.T.Fatalf("expected 2 push URLs on remote %s, got %d: %v", remoteName, len(got), got)
+	}
+
+	// Re-baseline the .git/config guard: adding push URLs is a deliberate
+	// change, so it must not read as unexpected drift at cleanup.
+	env.setGitConfigBaseline()
+
+	return secondBare
+}
+
+// AddUnreachableSecondPushURL configures remoteName to fan out to its original
+// URL plus a path that does not exist, so every push to that remote partially
+// fails: the real URL receives the refs, the bogus one errors, and git exits
+// non-zero. Models a mirror that is down or whose credentials have expired.
+// Returns the unreachable path.
+func (env *TestEnv) AddUnreachableSecondPushURL(remoteName string) string {
+	env.T.Helper()
+
+	ctx := env.T.Context()
+	missing := filepath.Join(env.T.TempDir(), "does-not-exist.git")
+	originalURL := env.RemoteURL(remoteName)
+
+	for _, url := range []string{originalURL, missing} {
+		cmd := exec.CommandContext(ctx, "git", "remote", "set-url", "--add", "--push", remoteName, url)
+		cmd.Dir = env.RepoDir
+		cmd.Env = testutil.GitIsolatedEnv()
+		if output, err := cmd.CombinedOutput(); err != nil {
+			env.T.Fatalf("failed to add push URL %s to remote %s: %v\n%s", url, remoteName, err, output)
+		}
+	}
+
+	env.setGitConfigBaseline()
+
+	return missing
+}
+
+// GitPushWithHooksAllowError is GitPushWithHooks without the fatal-on-error
+// behavior: it returns git's error instead of failing, so a test can exercise a
+// push that partially fails (e.g. one of several push URLs is unreachable, which
+// makes git exit non-zero even though the reachable URL received everything).
+// git's combined output — including the hook's stderr — is logged either way.
+func (env *TestEnv) GitPushWithHooksAllowError(remote, refSpec string) error {
+	env.T.Helper()
+
+	env.InstallRealPrePushHook()
+
+	cmd := execx.NonInteractive(env.T.Context(), "git", "push", remote, refSpec)
+	cmd.Dir = env.RepoDir
+	cmd.Env = env.cliEnv()
+	output, err := cmd.CombinedOutput()
+	env.T.Logf("git push (with hooks, error allowed) %s %s output: %s", remote, refSpec, output)
+	return err //nolint:wrapcheck // test helper: the caller asserts on presence/absence, not identity
+}
+
+// RemoteURL returns the fetch URL configured for remoteName.
+func (env *TestEnv) RemoteURL(remoteName string) string {
+	env.T.Helper()
+
+	cmd := exec.CommandContext(env.T.Context(), "git", "remote", "get-url", remoteName)
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		env.T.Fatalf("failed to read URL of remote %s: %v", remoteName, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// PushURLs returns every push URL configured for remoteName, in config order.
+func (env *TestEnv) PushURLs(remoteName string) []string {
+	env.T.Helper()
+
+	cmd := exec.CommandContext(env.T.Context(), "git", "remote", "get-url", "--push", "--all", remoteName)
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		env.T.Fatalf("failed to read push URLs of remote %s: %v", remoteName, err)
+	}
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
+}
+
+// DivergeRemoteRef moves ref forward in the bare repo at bareDir by one commit
+// that keeps the existing tree, so the ref is no longer an ancestor of the local
+// one and the next local push to it is rejected as non-fast-forward. label makes
+// the synthetic commit (and therefore the resulting hash) distinct, so two bare
+// repos can be diverged independently and never accidentally converge.
+//
+// Returns the new hash of the ref.
+func (env *TestEnv) DivergeRemoteRef(bareDir, ref, label string) string {
+	env.T.Helper()
+
+	tip := env.refHash(bareDir, ref)
+	if tip == "" {
+		env.T.Fatalf("cannot diverge %s in %s: ref does not exist", ref, bareDir)
+	}
+	tree := env.gitOutput(bareDir, "rev-parse", ref+"^{tree}")
+
+	newHash := env.gitOutput(bareDir, "commit-tree", tree, "-p", tip, "-m", "diverged: "+label)
+	env.gitOutput(bareDir, "update-ref", ref, newHash)
+
+	if got := env.refHash(bareDir, ref); got != newHash {
+		env.T.Fatalf("diverge %s in %s: ref is %s, expected %s", ref, bareDir, got, newHash)
+	}
+	return newHash
+}
+
+// RefHashOnRemote returns the hash ref points at in the bare repo at bareDir, or
+// "" when the ref does not exist.
+func (env *TestEnv) RefHashOnRemote(bareDir, ref string) string {
+	env.T.Helper()
+	return env.refHash(bareDir, ref)
+}
+
+// QueuedCheckpointRefs returns the checkpoint refs currently sitting in the
+// git-refs push-discovery queue, de-duplicated, in first-seen order. An empty
+// result means every write has been confirmed pushed (or nothing was queued).
+func (env *TestEnv) QueuedCheckpointRefs() []string {
+	env.T.Helper()
+
+	data, err := os.ReadFile(filepath.Join(env.RepoDir, ".git", pushQueueFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		env.T.Fatalf("failed to read push queue: %v", err)
+	}
+
+	seen := make(map[string]bool)
+	var refs []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry struct {
+			Ref string `json:"ref"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			env.T.Fatalf("failed to parse push queue line %q: %v", line, err)
+		}
+		if entry.Ref == "" || seen[entry.Ref] {
+			continue
+		}
+		seen[entry.Ref] = true
+		refs = append(refs, entry.Ref)
+	}
+	return refs
+}
+
+// refHash resolves ref in the repo at dir, returning "" when it does not exist.
+func (env *TestEnv) refHash(dir, ref string) string {
+	env.T.Helper()
+
+	cmd := exec.CommandContext(env.T.Context(), "git", "rev-parse", "--verify", "--quiet", ref)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// IsAncestor reports whether the commit ancestor is an ancestor of ref in the
+// repo at dir.
+func (env *TestEnv) IsAncestor(dir, ancestor, ref string) bool {
+	env.T.Helper()
+	return env.gitSucceeds(dir, "merge-base", "--is-ancestor", ancestor, ref)
+}
+
+// gitSucceeds reports whether a git command in dir exits zero. Used for
+// predicate-style plumbing calls (e.g. merge-base --is-ancestor) where a
+// non-zero exit is an answer, not a failure.
+func (env *TestEnv) gitSucceeds(dir string, args ...string) bool {
+	env.T.Helper()
+
+	cmd := exec.CommandContext(env.T.Context(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	return cmd.Run() == nil
+}
+
+// gitOutput runs a git command in dir and fails the test on error.
+func (env *TestEnv) gitOutput(dir string, args ...string) string {
+	env.T.Helper()
+
+	cmd := exec.CommandContext(env.T.Context(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(testutil.GitIsolatedEnv(),
+		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		env.T.Fatalf("git %s in %s failed: %v", strings.Join(args, " "), dir, err)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cmd/entire/cli/integration_test/multi_pushurl_test.go
+++ b/cmd/entire/cli/integration_test/multi_pushurl_test.go
@@ -1,0 +1,332 @@
+//go:build integration
+
+package integration
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// Multi-push-URL characterization tests: ONE git remote carrying several push
+// URLs (`git remote set-url --add --push origin <url>`, which git allows to
+// repeat). This is the "mirror to two forges in one push" / backup-remote setup.
+//
+// Two git facts drive everything here:
+//
+//  1. `git push origin` fans out to EVERY push URL.
+//  2. git invokes the pre-push hook ONCE PER PUSH URL, passing the same remote
+//     NAME as $1 every time and the individual URL as $2. Our hook forwards only
+//     $1, so the CLI sees N identical invocations and hands `git push <name>` the
+//     name — letting git fan out a second time.
+//
+// The CLI therefore has no per-URL control at all: it can only decide whether to
+// push checkpoints for a given hook invocation, not where they land. These tests
+// pin down what that means for each backend, including the places where today's
+// behavior is wrong.
+//
+// The backends are covered by separate tests rather than ForEachBackend because
+// the interesting failure modes differ: the git-branch v1 branch is a single
+// shared ref that can diverge per URL, while git-refs' per-checkpoint refs
+// normally only ever fast-forward.
+
+// v1Ref is the fully-qualified git-branch metadata ref.
+const v1Ref = "refs/heads/" + paths.MetadataBranchName
+
+// TestMultiPushURL_Branch_FanOutToBothPushURLs establishes the baseline: with two
+// push URLs on one remote, a plain `git push` through the real hook lands the v1
+// metadata branch on BOTH URLs. Nothing in the CLI arranges this — git's own
+// fan-out does it, because the CLI pushes to the remote name.
+func TestMultiPushURL_Branch_FanOutToBothPushURLs(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitBranch
+
+	bareA := env.SetupBareRemote()
+	bareB := env.AddSecondPushURL("origin")
+
+	checkpointID := createCheckpointedCommit(t, env, "Add auth module", "auth.go", "package auth", "Add auth module")
+	if checkpointID == "" {
+		t.Fatal("should have a checkpoint ID after condensation")
+	}
+
+	env.GitPushWithHooks("origin", "HEAD")
+
+	if !env.CheckpointExistsOnRemote(bareA, checkpointID) {
+		t.Errorf("checkpoint %s should be on the first push URL", checkpointID)
+	}
+	if !env.CheckpointExistsOnRemote(bareB, checkpointID) {
+		t.Errorf("checkpoint %s should be on the second push URL (git fans out to every push URL)", checkpointID)
+	}
+}
+
+// TestMultiPushURL_Branch_RepeatedPushesKeepBothURLsInSync guards the property a
+// mirror user actually depends on: over a normal sequence of checkpoints, every
+// push URL stays in sync. Each push fast-forwards all of them, so this works
+// today purely because checkpoints are pushed to the remote NAME and git fans
+// out.
+//
+// It exists to fail loudly if checkpoint pushes are ever retargeted at a single
+// resolved URL. That looks like a tidy way to give a user who does not want
+// checkpoints mirrored what they asked for, but it silently breaks the user who
+// configured several push URLs precisely because they DO want everything
+// mirrored. A single destination must come from explicit configuration
+// (checkpoint_remote), never be inferred from topology.
+func TestMultiPushURL_Branch_RepeatedPushesKeepBothURLsInSync(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitBranch
+
+	bareA := env.SetupBareRemote()
+	bareB := env.AddSecondPushURL("origin")
+
+	files := []struct{ prompt, file, content, msg string }{
+		{"Add auth module", "auth.go", "package auth", "Add auth module"},
+		{"Add login handler", "login.go", "package login", "Add login handler"},
+		{"Add session store", "session.go", "package session", "Add session store"},
+	}
+
+	var checkpointIDs []string
+	for _, f := range files {
+		id := createCheckpointedCommit(t, env, f.prompt, f.file, f.content, f.msg)
+		if id == "" {
+			t.Fatalf("no checkpoint ID after committing %s", f.file)
+		}
+		checkpointIDs = append(checkpointIDs, id)
+		env.GitPushWithHooks("origin", "HEAD")
+	}
+
+	for i, id := range checkpointIDs {
+		if !env.CheckpointExistsOnRemote(bareA, id) {
+			t.Errorf("checkpoint %d (%s) missing from the first push URL", i+1, id)
+		}
+		if !env.CheckpointExistsOnRemote(bareB, id) {
+			t.Errorf("checkpoint %d (%s) missing from the second push URL", i+1, id)
+		}
+	}
+	if a, b := env.RefHashOnRemote(bareA, v1Ref), env.RefHashOnRemote(bareB, v1Ref); a != b {
+		t.Errorf("both push URLs should hold the same v1 tip; first=%s second=%s", a, b)
+	}
+}
+
+// TestMultiPushURL_Branch_SecondPushURLDivergedDifferently is the scenario that
+// motivated these tests, and it documents a real gap.
+//
+// Both push URLs hold v1, then each moves independently (two machines pushing
+// checkpoints to two mirrors is enough to cause this). The next local push is
+// rejected by both, so the CLI runs its fetch+rebase recovery — but recovery
+// fetches from the remote NAME, and `git fetch origin` reads only the remote's
+// FETCH url. So the local branch is reconciled against the first URL only, the
+// retry lands there, and the second URL is left rejected with its divergence
+// never merged. Because checkpoint push failures are deliberately swallowed so
+// they cannot break the user's push, this is silent: the user's `git push`
+// succeeds and the second mirror simply stops receiving checkpoints.
+//
+// The assertions after the t.Skip below state the DESIRED behavior — both push
+// URLs converge — so implementing per-URL reconciliation turns this into an
+// enforcing test by deleting one line. Everything before the skip asserts what
+// already works today.
+func TestMultiPushURL_Branch_SecondPushURLDivergedDifferently(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitBranch
+
+	bareA := env.SetupBareRemote()
+	bareB := env.AddSecondPushURL("origin")
+
+	// Round 1: both URLs receive the same v1.
+	first := createCheckpointedCommit(t, env, "Add auth module", "auth.go", "package auth", "Add auth module")
+	env.GitPushWithHooks("origin", "HEAD")
+	if !env.CheckpointExistsOnRemote(bareA, first) || !env.CheckpointExistsOnRemote(bareB, first) {
+		t.Fatalf("setup: checkpoint %s should be on both push URLs before diverging", first)
+	}
+
+	// Both remotes move, differently — distinct labels give distinct hashes, so
+	// the two mirrors can never accidentally converge.
+	divergedA := env.DivergeRemoteRef(bareA, v1Ref, "on-A")
+	divergedB := env.DivergeRemoteRef(bareB, v1Ref, "on-B")
+	if divergedA == divergedB {
+		t.Fatal("setup: the two push URLs must diverge to different commits")
+	}
+
+	// Round 2: a new checkpoint, pushed into that divergence.
+	second := createCheckpointedCommit(t, env, "Add login handler", "login.go", "package login", "Add login handler")
+
+	// The user's own push succeeds: checkpoint push failures are swallowed by
+	// design so they cannot break it. That is what makes the divergence below
+	// silent — the only trace is a "failed to push ... after sync" warning on
+	// stderr that does not name the URL that rejected it.
+	if err := env.GitPushWithHooksAllowError("origin", "HEAD"); err != nil {
+		t.Fatalf("the user's push should succeed even though a checkpoint push failed: %v", err)
+	}
+
+	// The first push URL converges: recovery fetched from it, replayed the local
+	// commits on top, and the retry was a fast-forward.
+	if !env.CheckpointExistsOnRemote(bareA, second) {
+		t.Errorf("checkpoint %s should be on the first push URL after fetch+rebase recovery", second)
+	}
+	if !env.IsAncestor(bareA, divergedA, v1Ref) {
+		t.Errorf("first push URL's own divergent commit %s should be preserved as an ancestor of v1", divergedA)
+	}
+
+	// Diagnostics for why the second URL cannot self-heal within this push: there
+	// is ONE remote-tracking ref per remote NAME, and git advanced it to the hash
+	// the successful URL accepted. So pushRefIfNeeded's "does this ref have
+	// unpushed changes?" check reports "in sync with origin" while one of origin's
+	// URLs is still on its old divergent commit, and the second hook invocation
+	// (git runs one per push URL) short-circuits without attempting anything.
+	// Logged rather than asserted: this is the mechanism of the bug, not behavior
+	// worth locking in.
+	t.Logf("local v1=%s  refs/remotes/origin/%s=%s  urlA v1=%s  urlB v1=%s (still at its divergence %s)",
+		env.RefHashOnRemote(env.RepoDir, v1Ref),
+		paths.MetadataBranchName,
+		env.RefHashOnRemote(env.RepoDir, "refs/remotes/origin/"+paths.MetadataBranchName),
+		env.RefHashOnRemote(bareA, v1Ref),
+		env.RefHashOnRemote(bareB, v1Ref),
+		divergedB)
+
+	t.Skip("KNOWN BUG: fetch+rebase recovery reconciles only the remote's fetch URL, so a second push URL that diverged independently never converges and is never retried")
+
+	// DESIRED: every push URL of the remote converges, each reconciled against
+	// its own divergence. Delete the t.Skip above once that is implemented.
+	if !env.CheckpointExistsOnRemote(bareB, second) {
+		t.Errorf("checkpoint %s should also reach the second push URL", second)
+	}
+	if got := env.RefHashOnRemote(bareB, v1Ref); got == divergedB {
+		t.Errorf("second push URL's v1 should have advanced past its divergence %s", divergedB)
+	}
+	if !env.IsAncestor(bareB, divergedB, v1Ref) {
+		t.Errorf("second push URL's own divergent commit %s should be preserved as an ancestor of v1", divergedB)
+	}
+}
+
+// TestMultiPushURL_Branch_DoesNotPublishV1ToEmptySecondPushURL shows that adding
+// a push URL defeats the empty-remote guard.
+//
+// deferCheckpointPushOnEmptyRemote exists because entire/checkpoints/v1 is a real
+// refs/heads branch, so a forge would make it the default branch of an empty
+// repository. The guard asks whether the remote NAME has any local
+// remote-tracking refs — which it does, thanks to the established first URL — so
+// it permits the push, and the fan-out then publishes v1 into the brand-new
+// second URL that has no branches at all. The hook runs before git transfers the
+// user's branch, so v1 gets there first and becomes that repo's default branch.
+//
+// The assertion after the t.Skip states the desired behavior: a push URL with no
+// branches should get the same deferral an empty remote gets.
+func TestMultiPushURL_Branch_DoesNotPublishV1ToEmptySecondPushURL(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitBranch
+
+	env.SetupBareRemote()
+	bareB := env.AddSecondPushURL("origin")
+
+	createCheckpointedCommit(t, env, "Add auth module", "auth.go", "package auth", "Add auth module")
+
+	// Run only the hook — exactly the point in a real `git push` at which the
+	// user's own branch has not been transferred yet.
+	env.RunPrePush("origin")
+
+	if env.BranchExistsOnRemote(bareB, env.GetCurrentBranch()) {
+		t.Fatalf("setup: the user branch should not be on the second push URL yet")
+	}
+
+	t.Skip("KNOWN BUG: the empty-remote guard checks remote-tracking refs per remote NAME, so a brand-new second push URL receives v1 before the user's first branch and would adopt it as the default branch")
+
+	// DESIRED: v1 is withheld from a push URL that has no branches yet, exactly
+	// as it is withheld from an empty remote. Delete the t.Skip above once the
+	// guard is URL-aware.
+	if env.BranchExistsOnRemote(bareB, paths.MetadataBranchName) {
+		t.Errorf("v1 should not be the first branch published to a fresh push URL")
+	}
+}
+
+// TestMultiPushURL_Refs_FanOutToBothPushURLs is the git-refs baseline, and it
+// pins down a property the backend gets for free but does not enforce: the queue
+// is drained by the FIRST hook invocation and its refs removed after that push
+// succeeds, so the remaining invocations are no-ops. Both URLs still receive the
+// refs — again only because the CLI pushes to the remote name and git fans out.
+//
+// This is worth locking down because it is exactly what would break if
+// checkpoint pushes were ever retargeted at a single resolved URL (as a
+// configured checkpoint_remote already does): the queue would be emptied by the
+// first invocation and the second URL would silently never receive anything.
+func TestMultiPushURL_Refs_FanOutToBothPushURLs(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitRefs
+
+	bareA := env.SetupBareRemote()
+	bareB := env.AddSecondPushURL("origin")
+
+	checkpointID := createCheckpointedCommit(t, env, "Add auth module", "auth.go", "package auth", "Add auth module")
+	if checkpointID == "" {
+		t.Fatal("should have a checkpoint ID after condensation")
+	}
+	if len(env.QueuedCheckpointRefs()) == 0 {
+		t.Fatal("setup: the checkpoint write should have enqueued a ref for push")
+	}
+
+	env.GitPushWithHooks("origin", "HEAD")
+
+	if !env.CheckpointExistsOnRemote(bareA, checkpointID) {
+		t.Errorf("checkpoint ref for %s should be on the first push URL", checkpointID)
+	}
+	if !env.CheckpointExistsOnRemote(bareB, checkpointID) {
+		t.Errorf("checkpoint ref for %s should be on the second push URL (git fans out to every push URL)", checkpointID)
+	}
+	if queued := env.QueuedCheckpointRefs(); len(queued) != 0 {
+		t.Errorf("queue should be empty after a confirmed push, still holds %v", queued)
+	}
+}
+
+// TestMultiPushURL_Refs_UnreachableSecondPushURL_RefsStayQueued covers the
+// git-refs failure mode. Per-checkpoint refs normally only fast-forward (each
+// write parents on the prior tip) and a checkpoint ID is minted once, so the
+// same-ref divergence that plagues the shared v1 branch is not reachable here
+// without a backfill or migration rewriting an existing checkpoint. The
+// realistic partial failure is instead a mirror that cannot be reached at all.
+//
+// The refs still land on the reachable URL, and — the property that matters —
+// they stay queued, so every later push retries them. That is the backend
+// degrading toward "will retry" rather than toward silent loss, and it is the
+// concrete behavioral difference from the git-branch path above, which drops the
+// failure on the floor. The flip side is that the retry can never succeed while
+// the second URL is unreachable, so the queue never drains: a persistent
+// partial failure is invisible outside stderr.
+func TestMultiPushURL_Refs_UnreachableSecondPushURL_RefsStayQueued(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = StoreGitRefs
+
+	bareA := env.SetupBareRemote()
+	env.AddUnreachableSecondPushURL("origin")
+
+	checkpointID := createCheckpointedCommit(t, env, "Add auth module", "auth.go", "package auth", "Add auth module")
+	queuedBefore := env.QueuedCheckpointRefs()
+	if len(queuedBefore) == 0 {
+		t.Fatal("setup: the checkpoint write should have enqueued a ref for push")
+	}
+
+	// git exits non-zero because one push URL is unreachable; the user's push
+	// fails as a whole, which is git's behavior and not something the CLI can
+	// or should mask.
+	if err := env.GitPushWithHooksAllowError("origin", "HEAD"); err == nil {
+		t.Fatal("setup: git push should fail when one of the push URLs is unreachable")
+	}
+
+	if !env.CheckpointExistsOnRemote(bareA, checkpointID) {
+		t.Errorf("checkpoint ref for %s should still reach the reachable push URL", checkpointID)
+	}
+	wantRef := checkpointRefName(checkpointID)
+	if queued := env.QueuedCheckpointRefs(); !slices.Contains(queued, wantRef) {
+		t.Errorf("ref %s should stay queued after a partially failed push so the next push retries it; queue holds %v", wantRef, queued)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/970
<!-- entire-trail-link-end -->

## What

A single git remote can carry several push URLs — `remote.<name>.pushurl` may repeat, and a repeated `remote.<name>.url` has the same effect. It's how people mirror to two forges in one push, or keep a backup remote. Verified behavior:

| Config | Fetch | Push |
|---|---|---|
| `remote.origin.url` ×2 | uses only the **first** | goes to **both** |
| `remote.origin.pushurl` ×2 | uses `url` | goes to **both** pushurls |

Two git facts drive everything here:

1. `git push origin` fans out to **every** push URL.
2. git invokes the pre-push hook **once per push URL**, passing the same remote *name* as `$1` each time and the individual URL as `$2`.

Our installed hook forwards only `$1` (`strategy/hooks.go`), so the CLI sees N identical invocations and hands `git push <name>` the name — letting git fan out a second time. It has no per-URL control at all: it can decide *whether* to push checkpoints for an invocation, not *where* they land.

This PR adds integration coverage for what that means, and is **tests only** — no production change.

## Bugs documented

Both use the existing `t.Skip("KNOWN BUG: …")` convention (see `remote_operations_test.go:625`), placed so everything above the skip still enforces what works today, and the assertions *after* it state the desired behavior. Fixing either is a one-line deletion.

**1. Divergence recovery only ever reconciles the fetch URL.** When push URLs diverge independently, the rejected push triggers fetch+rebase recovery — but `git fetch <remote>` reads only the remote's fetch URL. URL A converges; URL B is left rejected with its divergence unmergeable. Captured hook output:

```
[entire] Pushing entire/checkpoints/v1 to origin...          ← rejected by both
[entire] Syncing entire/checkpoints/v1 with remote... done    ← fetched from URL A only
[entire] Pushing entire/checkpoints/v1 to origin...           ← retry
[entire] Warning: failed to push entire/checkpoints/v1 after sync: non-fast-forward
```

`git push` exits **0**, so this is silent: the second mirror just stops receiving checkpoints, and the only trace is a warning that doesn't name the URL that rejected it. It also can't self-heal within the push — there is one remote-tracking ref per remote *name*, and git advances it to the hash the *successful* URL accepted, so `pushRefIfNeeded`'s up-to-date check reports "in sync with origin" and the second hook invocation short-circuits. That mechanism is logged rather than asserted.

**2. Adding a push URL defeats the empty-remote guard.** `deferCheckpointPushOnEmptyRemote` exists because `entire/checkpoints/v1` is a real `refs/heads` branch a forge would adopt as the default branch of an empty repo. The guard asks whether the remote *name* has local remote-tracking refs — it does, thanks to the established first URL — so it permits the push, and the fan-out publishes v1 into a brand-new second URL that has no branches. The hook runs before git transfers the user's branch, so v1 gets there first.

## Passing coverage

- `..._Branch_FanOutToBothPushURLs` / `..._Refs_FanOutToBothPushURLs` — both URLs receive checkpoints, on both backends.
- `..._Branch_RepeatedPushesKeepBothURLsInSync` — three sequential checkpoints, both URLs in sync with identical v1 tips. This is the property a mirror user depends on, and exists to fail loudly if checkpoint pushes are ever retargeted at a single resolved URL. That looks like a tidy way to serve a user who *doesn't* want checkpoints mirrored, but it silently breaks the user who configured several push URLs precisely because they do. A single destination must come from explicit config, never be inferred from topology.
- `..._Refs_UnreachableSecondPushURL_RefsStayQueued` — git-refs leaves refs queued after a partially failed push instead of dropping them, so later pushes retry. This is the concrete behavioral difference from the git-branch path, which drops the failure on the floor.

An unreachable URL rather than divergence is used for the git-refs failure case on purpose: per-checkpoint refs only fast-forward and an ID is minted once, so same-ref divergence isn't reachable without a backfill or migration rewriting an existing checkpoint.

## Notes for reviewers

- `AddSecondPushURL` re-adds the remote's original URL as an explicit `pushurl` before adding the new one. Configuring *any* `pushurl` replaces `url` for push purposes, so adding only the new one silently redirects instead of fanning out. The helper asserts it ended up with two.
- Both fan-out helpers re-baseline the `.git/config` guard, since changing push URLs is deliberate.
- The negative assertions aren't vacuous — the fan-out baselines prove the second URL *does* receive checkpoints on the happy path.

## Test plan

- `go test -tags=integration -run TestMultiPushURL ./cmd/entire/cli/integration_test/` — 4 pass, 2 skip
- Full integration package green; `mise run fmt && mise run lint` clean
- Unrelated pre-existing flake seen while validating: a spawned subprocess intermittently segfaults under `-race` (~1 in 3 full-package runs), hitting a different test each time. Reproduced with these files removed from the tree, so it predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code; risk is limited to CI runtime and future behavior contracts when bugs are fixed.
> 
> **Overview**
> Adds **integration-only** coverage for remotes with multiple push URLs (mirror/backup setups): new `TestEnv` helpers (`AddSecondPushURL`, push-queue inspection, diverged refs, `GitPushWithHooksAllowError`) and six `TestMultiPushURL_*` cases for **git-branch** and **git-refs** backends.
> 
> **Passing tests** lock in that checkpoint pushes go to the remote *name* so git fans out to every push URL, repeated pushes keep mirrors aligned, and git-refs leaves refs **queued** when one push URL is unreachable so later pushes retry.
> 
> **Two skipped `KNOWN BUG` tests** document desired behavior without changing production code: fetch+rebase recovery only reconciles the fetch URL when push URLs diverge independently (second mirror can stop getting checkpoints silently), and the empty-remote deferral for `entire/checkpoints/v1` is bypassed when a second push URL is still empty because the guard keys off remote *name* tracking refs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbcee407d2a3b5d2afaa4a28348d10f3d36ef40d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->