### PR TITLE
test: stop running the integration package under -race on darwin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,9 @@ mise run test:integration
 mise run test:ci
 ```
 
-This runs unit tests, integration tests, and the E2E canary (Vogon agent) in sequence. Integration tests use the `//go:build integration` build tag and are located in `cmd/entire/cli/integration_test/`.
+This runs unit tests, integration tests, and the E2E canary (Vogon agent) in sequence. Integration tests use the `//go:build integration` build tag and are located in `cmd/entire/cli/integration_test/`. It delegates to the same tasks CI runs (`test:ci:core`, then integration shards `a`/`b`/`c`, then the canary), so a local pass matches CI.
+
+**`-race` is deliberately off for the integration package on darwin.** ThreadSanitizer is not fork-safe there: `syscall.rawSyscall` on darwin is a Go function lacking `//go:norace` (Linux's `RawSyscall` carries it precisely "to avoid race instrumentation if RawSyscall is called after fork"), so under `-race` the instrumentation runs in the child of `fork()` before `exec` and intermittently segfaults it. It surfaces as `signal: segmentation fault` from a spawned subprocess, on a random test, roughly one run in three — indistinguishable from a real regression until you read `~/Library/Logs/DiagnosticReports/integration_test.test-*.ips`. See golang/go#49138. The gate lives in `mise-tasks/test/ci/integration/shard`; do not re-add `-race` there. CI runs Linux, where the pragma exists, so its race coverage is unchanged. Note also that this package is overwhelmingly subprocess-driven — the spawned binary is built without `-race`, so `-race` here can only ever instrument the test harness, not the CLI under test.
 
 ### Running E2E Canary Tests (Vogon Agent)
 

--- a/mise-tasks/test/ci/_default
+++ b/mise-tasks/test/ci/_default
@@ -1,0 +1,20 @@
+#!/bin/sh
+#MISE description="Run all tests (unit + integration + E2E canary) with race detection (integration: no -race on darwin)"
+
+# Runs the same tasks CI runs, so a local pass matches CI and the integration
+# package's race handling is decided in exactly one place — see the comment in
+# mise-tasks/test/ci/integration/shard (ThreadSanitizer is not fork-safe on
+# darwin, and nearly every test in that package spawns a subprocess).
+#
+# Shards a, b and c partition the integration package exactly, so running all
+# three covers every test in it.
+
+set -eu
+
+mise run test:ci:core
+
+for shard in a b c; do
+  mise run test:ci:integration:shard -- "$shard"
+done
+
+mise run test:e2e:canary

--- a/mise-tasks/test/ci/integration/shard
+++ b/mise-tasks/test/ci/integration/shard
@@ -85,5 +85,26 @@ run_regex="$(
     paste -sd'|' -
 )"
 
-go test -tags=integration -race -count=1 -parallel="$parallel" \
+# ThreadSanitizer is not fork-safe, and this package spawns a subprocess in
+# nearly every test. On darwin, syscall.rawSyscall is a Go function that lacks
+# //go:norace — Linux's RawSyscall carries it precisely "to avoid race
+# instrumentation if RawSyscall is called after fork" — so under -race the
+# instrumentation runs in the child of fork() before exec and intermittently
+# faults it (__tsan::TraceSwitchPartImpl, SIGSEGV, "crashed on child side of
+# fork pre-exec"). It lands on a random test, roughly one run in three, and is
+# indistinguishable from a real regression until you read the crash report.
+# See golang/go#49138 and #50172.
+#
+# CI runs Linux, where the pragma exists, so race coverage there is unchanged.
+# Note this package is overwhelmingly subprocess-driven (272 of 294 tests drive
+# the spawned binary, which TestMain builds WITHOUT -race), so -race can only
+# ever see the harness here — not the CLI under test.
+race="-race"
+if [ "$(uname -s)" = "Darwin" ]; then
+  race=""
+  echo "integration shard $shard: -race disabled (ThreadSanitizer is not fork-safe on darwin; see comment in $0)"
+fi
+
+# shellcheck disable=SC2086 # $race is one optional flag; intentionally unquoted so empty means "omit"
+go test -tags=integration $race -count=1 -parallel="$parallel" \
   "$pkg" -run "^(${run_regex})$"

--- a/mise.toml
+++ b/mise.toml
@@ -19,13 +19,6 @@ run = "gotestsum --format pkgname --format-icons text --format-hide-empty-pkg --
 description = "Run integration tests"
 run = "gotestsum --format testname --format-icons text --hide-summary skipped -- -tags=integration ./cmd/entire/cli/integration_test/... ./cmd/entire/cli/auth/..."
 
-[tasks."test:ci"]
-description = "Run all tests (unit + integration + E2E canary) with race detection"
-run = """
-go test -tags=integration -race ./...
-mise run test:e2e:canary
-"""
-
 [tasks.check]
 description = "Run formatting, linting, and CI tests"
 depends = ["fmt", "lint", "test:ci"]


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/974
<!-- entire-trail-link-end -->

## The bug

`go test -tags=integration -race ./...` intermittently fails on macOS with `signal: segmentation fault` from a spawned subprocess — a **different test each run**, with no output and no Go panic. It looks exactly like a real regression in whatever change you happen to be working on.

It isn't. It's the Go toolchain on darwin.

The macOS crash report (`~/Library/Logs/DiagnosticReports/integration_test.test-*.ips`) says `crashed on child side of fork pre-exec` — `EXC_BAD_ACCESS` / SIGSEGV at `0x8`, single-threaded child. Symbolized:

```
os/exec.(*Cmd).CombinedOutput → Run → Start → os.StartProcess → os.startProcess
  → syscall.forkExec → syscall.forkAndExecInChild
    → syscall.rawSyscall
      → __tsan::TraceSwitchPartImpl(__tsan::ThreadState*)   ← SIGSEGV
```

The forked child reaches the ThreadSanitizer runtime before it execs. TSan is not fork-safe — its trace buffer and locks were copied mid-flight from the multithreaded parent — so the child dies before the target binary (`entire`, `git`) ever runs. That's why there's no output.

`syscall.forkAndExecInChild` is `//go:norace`, and its comment justifies calling `rawSyscall` on the grounds that "they are assembly functions that do not grow the stack". True on Linux; **false on darwin**, where `rawSyscall`/`rawSyscall6`/`rawSyscall9` are ordinary Go functions wrapping libc trampolines, carrying `//go:nosplit` and `//go:uintptrkeepalive` but **not `//go:norace`**. Linux's `RawSyscall` has it, for exactly this reason:

> `//go:norace`, on RawSyscall, to avoid race instrumentation **if RawSyscall is called after fork**, or from a signal handler.

Known upstream: [golang/go#49138](https://github.com/golang/go/issues/49138), [#50172](https://github.com/golang/go/issues/50172), [#50323](https://github.com/golang/go/issues/50323). Reproduced on go1.26.4 / macOS 26.6 / arm64.

Why it's rare and load-dependent: `TraceSwitchPartImpl` only runs when TSan's trace-buffer part boundary is hit, so it needs that boundary to land inside the child's handful of instrumented events.

## The fix

Skip `-race` for `cmd/entire/cli/integration_test` **on darwin only**.

**This costs no CI coverage.** CI runs `ubuntu-latest`, where the pragma exists and the crash cannot occur. The gate is `uname -s = Darwin`.

**And little local coverage**, because the package is overwhelmingly subprocess-driven: 272 of its 294 tests drive the spawned `entire` binary, which `TestMain` builds with a plain `go build` — no `-race`. So `-race` there can only instrument the *test harness*, never the CLI under test. Of the 22 in-process tests, most are harness self-tests (`TestTranscriptBuilder_*`, `TestNormalizeGitConfigForGuard_*`, `resolveHookCommandWithBinary`); the few that call production code directly (`agent.Get(...)` methods, `strategy.GetGitAuthorFromRepo`, the `TestLogin_*` flows) keep full race coverage on Linux, and their own packages are race-tested in `test:ci:core`.

## Shape of the change

- `mise-tasks/test/ci/integration/shard` — the one place the integration package's `go test` is invoked. Adds the darwin guard, with the full explanation and issue links in a comment, plus a line of output so it's visible when it applies.
- `test:ci` now delegates to the tasks CI actually runs (`test:ci:core` → integration shards `a`/`b`/`c` → canary) instead of its own `go test ./...`. This keeps the race decision in exactly one place and makes a local pass match CI. The shards partition the package exactly — 79 + 50 + 165 = 294, the full test count — so nothing is dropped.
- Extracted to `mise-tasks/test/ci/_default` (mirroring `mise-tasks/test/e2e/_default`) because `mise-tasks/lint/mise` rejects inline `run = """…"""` blocks of 3+ lines.
- `CLAUDE.md` documents why, so `-race` doesn't get helpfully re-added.

## Test plan

- `mise run test:ci` green end-to-end (core with `-race`, three shards, canary 59 + 4 tests).
- `mise run lint` clean, including `lint:mise` and `shellcheck`.
- Shard arithmetic verified against `go test -list`: a=79, b=50, c=165, total=294.
- Stability: three consecutive full passes over all three shards, **zero segfaults**.

### Measured rates (quiet machine, macOS 26.6, go1.26.4)

| Command | Crash rate |
|---|---|
| single package `-race` (`./cmd/entire/cli/integration_test/`) | 0 / 8 runs |
| `go test -tags=integration -race ./...` (what `test:ci` used to run) | 1 / 4 runs |

Running many race-instrumented package binaries concurrently is the amplifier, which is why the old `./...`-shaped `test:ci` was the command that surfaced it.

### Two caveats a reviewer should know

**It is often silent.** A fork-child crash only fails the suite when it lands on a subprocess call whose error is checked; best-effort paths swallow it. One crash report here belongs to a `./...` run that exited 0 with no "segmentation fault" text anywhere. So this has plausibly been happening since the repo moved to Go 1.26 (`b58ccebae`, 2026-02-22) while only rarely being *visible* — which is why it was never reported.

**This PR is not a complete darwin fix.** The same crash reproduced in `cmd/entire/cli/strategy` (`TestReconcileDisconnected_ModifiedEntries`, on a `git commit` fork) — that package has ~153 exec call sites. Any fork-heavy race-instrumented package is exposed on darwin. I am deliberately *not* disabling `-race` there: unlike the integration package, `strategy` has real in-process concurrency worth race-testing. This PR takes the case where `-race` is pure cost (the spawned binary isn't instrumented, so only the harness ever was) and leaves the rest to the upstream fix.
- Confirmed the guard is darwin-only — Linux still resolves to `go test -tags=integration -race …`.

## Follow-up worth considering

The real fix is upstream and tiny: add `//go:norace` to darwin's `rawSyscall`, `rawSyscall6`, `rawSyscall9` in `syscall/syscall_darwin.go`, matching Linux. Happy to file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness and developer-docs only; no production CLI behavior changes, and Linux CI race coverage is unchanged.
> 
> **Overview**
> **Fixes flaky macOS integration runs** by omitting `-race` when `mise-tasks/test/ci/integration/shard` runs on Darwin. ThreadSanitizer is not fork-safe there (subprocess-heavy package + darwin `rawSyscall` without `//go:norace`), which caused intermittent child segfaults; Linux CI keeps `-race`.
> 
> **`mise run test:ci` now matches CI**: the inline `go test -race ./...` task in `mise.toml` is replaced by `mise-tasks/test/ci/_default`, which runs `test:ci:core`, integration shards `a`/`b`/`c`, then the E2E canary so the race decision lives in one place.
> 
> **`CLAUDE.md`** documents the darwin gate so `-race` is not re-added to the integration shard script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a00db5b45c8ef5e51050093cf9a57378e9c378. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
