### PR TITLE
Make git-refs the sole enable default; drop backend picker

### DIFF
--- a/cmd/entire/cli/checkpoint_backend.go
+++ b/cmd/entire/cli/checkpoint_backend.go
@@ -7,8 +7,6 @@ import (
 	"slices"
 	"strings"
 
-	"charm.land/huh/v2"
-
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -74,46 +72,6 @@ func applyCheckpointBackendFlag(s *EntireSettings, backend string) error {
 	}
 	applyCheckpointBackend(s, typ)
 	return nil
-}
-
-// checkpointBackendChoices returns the storage picker's options — git-refs
-// first, labeled recommended — and the recommended value the caller
-// pre-selects.
-// Split from promptCheckpointBackend so the ordering/labeling contract is
-// unit-testable without a TTY.
-func checkpointBackendChoices() (opts []huh.Option[string], recommended string) {
-	return []huh.Option[string]{
-		huh.NewOption("Refs — one git ref per checkpoint (recommended)", checkpoint.BackendTypeGitRefs),
-		huh.NewOption("Branch — one shared branch, entire/checkpoints/v1", checkpoint.BackendTypeGitBranch),
-	}, checkpoint.BackendTypeGitRefs
-}
-
-// promptCheckpointBackend asks the user to choose a checkpoint storage backend
-// during first-time interactive setup, with the git-refs backend pre-selected
-// as the recommendation — most users should just press Enter. It returns the
-// chosen canonical backend type; cancellation (Ctrl+C or a cancelled ctx)
-// prints a cancellation note and returns "" (a soft skip, nil error, like
-// other setup prompts) so the caller falls through to the recommended
-// default. Callers must gate this on
-// an interactive terminal (and skip it when ENTIRE_CHECKPOINTS_PRIMARY is
-// active — the env fully replaces settings, so an answer could not take
-// effect and would only write diverging config).
-func promptCheckpointBackend(ctx context.Context, w io.Writer) (string, error) {
-	opts, recommended := checkpointBackendChoices()
-	choice := recommended
-	form := NewAccessibleForm(
-		huh.NewGroup(
-			huh.NewSelect[string]().
-				Title("Checkpoint storage").
-				Description("How Entire stores committed session checkpoints in your repo.").
-				Options(opts...).
-				Value(&choice),
-		),
-	)
-	if err := form.RunWithContext(ctx); err != nil {
-		return "", handleFormCancellation(w, "Checkpoint storage selection", err)
-	}
-	return choice, nil
 }
 
 // updateCheckpointBackend persists opts.CheckpointBackend to the target settings

--- a/cmd/entire/cli/checkpoint_backend_test.go
+++ b/cmd/entire/cli/checkpoint_backend_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"io"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -129,24 +128,4 @@ func TestUpdateCheckpointBackend_InvalidValue(t *testing.T) {
 	err := updateCheckpointBackend(context.Background(), io.Discard, EnableOptions{CheckpointBackend: "bogus"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), flagCheckpointBackend)
-}
-
-// The storage picker's contract from the team decision: the question stays,
-// but git-refs is listed first and pre-selected as the recommendation —
-// "default" wording is gone, one Enter accepts refs.
-func TestCheckpointBackendChoices_RefsRecommendedFirst(t *testing.T) {
-	t.Parallel()
-	opts, recommended := checkpointBackendChoices()
-	if recommended != checkpoint.BackendTypeGitRefs {
-		t.Errorf("recommended = %q, want git-refs pre-selected", recommended)
-	}
-	if len(opts) != 2 || opts[0].Value != checkpoint.BackendTypeGitRefs {
-		t.Fatalf("options = %+v, want refs listed first", opts)
-	}
-	if !strings.Contains(opts[0].Key, "(recommended)") {
-		t.Errorf("refs label = %q, want '(recommended)' suffix", opts[0].Key)
-	}
-	if strings.Contains(opts[0].Key+opts[1].Key, "default") {
-		t.Errorf("labels must not say 'default' (team decision: recommended, not default): %q / %q", opts[0].Key, opts[1].Key)
-	}
 }

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1239,10 +1239,7 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 
 	opts.applyStrategyOptions(settings)
 
-	backend, err := resolveFirstRunCheckpointBackend(ctx, w, opts, firstRun)
-	if err != nil {
-		return err
-	}
+	backend := resolveFirstRunCheckpointBackend(opts, firstRun)
 	if err := applyCheckpointBackendFlag(settings, backend); err != nil {
 		return err
 	}
@@ -1356,43 +1353,22 @@ func printEnabledStatus(ctx context.Context, w io.Writer) {
 }
 
 // resolveFirstRunCheckpointBackend decides the checkpoint storage backend
-// the setup flow writes. An explicit --checkpoint-backend always wins.
-// Otherwise a first interactive setup asks, with git-refs pre-selected as
-// the recommendation (one Enter for most users); non-interactive/--yes
-// first runs take the recommendation silently, and a cancelled prompt takes
-// it with an explicit note (unless the command context itself was cancelled
-// — then enable stops). Either way the choice is written explicitly into
-// the new settings file, and the config-less runtime fallback stays
-// git-branch so existing repos are untouched. The prompt is skipped while
-// ENTIRE_CHECKPOINTS_PRIMARY is active (firstRunCheckpointBackendDefault
-// returns ""): the env fully replaces settings, so an answer could not take
-// effect and would only write diverging config.
-func resolveFirstRunCheckpointBackend(ctx context.Context, w io.Writer, opts EnableOptions, firstRun bool) (string, error) {
-	backend := opts.CheckpointBackend
-	if backend == "" && firstRun && !opts.Yes &&
-		firstRunCheckpointBackendDefault() != "" && interactive.CanPromptInteractively() {
-		chosen, err := promptCheckpointBackend(ctx, w)
-		if err != nil {
-			return "", err
-		}
-		if ctx.Err() != nil {
-			// A cancelled command context (SIGINT/SIGTERM) surfaces as a
-			// form cancellation, but the user asked to stop: setup must not
-			// adopt a default and keep mutating the repo.
-			return "", fmt.Errorf("checkpoint storage selection: %w", ctx.Err())
-		}
-		if chosen == "" {
-			// Cancelled prompt: the recommendation is adopted, but never
-			// silently — every other cancelled setup prompt skips its
-			// action, so persisting a choice here must be disclosed.
-			fmt.Fprintln(w, "Using the recommended git-refs checkpoint storage.")
-		}
-		backend = chosen // "" (cancelled) falls through to the recommendation
+// the setup flow writes. An explicit --checkpoint-backend always wins;
+// otherwise a first run takes the git-refs default silently (branch remains
+// selectable via --checkpoint-backend branch). The choice is written
+// explicitly into the new settings file, and the config-less runtime
+// fallback stays git-branch so existing repos are untouched. The default is
+// empty — write nothing — while ENTIRE_CHECKPOINTS_PRIMARY is active
+// (firstRunCheckpointBackendDefault returns ""): the env fully replaces
+// settings, so persisting a default would only write diverging config.
+func resolveFirstRunCheckpointBackend(opts EnableOptions, firstRun bool) string {
+	if opts.CheckpointBackend != "" {
+		return opts.CheckpointBackend
 	}
-	if backend == "" && firstRun {
-		backend = firstRunCheckpointBackendDefault()
+	if firstRun {
+		return firstRunCheckpointBackendDefault()
 	}
-	return backend, nil
+	return ""
 }
 
 // firstRunCheckpointBackendDefault is the backend written on first-time

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -3929,20 +3929,6 @@ func TestRunEnableInteractive_FirstRunDefaultsToGitRefs(t *testing.T) {
 		}
 	})
 
-	t.Run("non-interactive first run without --yes takes the recommendation", func(t *testing.T) {
-		// The most common real path: a headless first run without --yes
-		// (go test => CanPromptInteractively false). The storage prompt must
-		// be skipped and the recommendation written — every other first-run
-		// subtest passes Yes: true, so this is the only coverage of the
-		// !opts.Yes non-TTY branch. Telemetry: false dodges the telemetry
-		// prompt, which (pre-existing) has no headless guard.
-		setupTestRepo(t)
-		cfg := enable(t, EnableOptions{Telemetry: false})
-		if cfg == nil || cfg.Primary.Type != checkpoint.BackendTypeGitRefs {
-			t.Errorf("Checkpoints = %+v, want the git-refs recommendation", cfg)
-		}
-	})
-
 	t.Run("re-run of an existing config-less repo stays config-less", func(t *testing.T) {
 		setupTestRepo(t)
 		// A repo set up before this change: settings.json exists, no


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/975
<!-- entire-trail-link-end -->

## Summary
- `entire enable` no longer prompts new users to choose between the git-refs and branch checkpoint backends — a storage-topology decision they can't meaningfully answer during first-run setup.
- git-refs (already the recommendation) is now written silently on first run.
- The branch backend stays fully reachable non-interactively via `--checkpoint-backend branch`.

## Changes
- Removed `promptCheckpointBackend` / `checkpointBackendChoices` and the `huh` picker from `checkpoint_backend.go`.
- Simplified `resolveFirstRunCheckpointBackend`: flag wins, else git-refs default on first run.
- `ENTIRE_CHECKPOINTS_PRIMARY` env override and the config-less git-branch runtime fallback are unchanged, so existing repos are untouched.
- Dropped the picker unit test and the redundant "without --yes" subtest (only covered the deleted prompt branch).

## Test plan
- `go build ./cmd/...`
- `go test ./cmd/entire/cli/ -run 'TestRunEnableInteractive_FirstRunDefaultsToGitRefs|TestResolveCheckpointBackendType|TestApplyCheckpointBackend|TestUpdateCheckpointBackend'` — pass
- golangci-lint v2.11.3 on `cmd/entire/cli/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Setup UX and default-selection logic only; env override, configure path, and legacy config-less behavior are explicitly preserved.
> 
> **Overview**
> First-time **`entire enable`** no longer asks users to pick checkpoint storage in an interactive form. **`git-refs`** is applied silently on first run (same as the former recommendation), while **`--checkpoint-backend branch`** still selects the shared branch backend.
> 
> The **`huh`** picker (`promptCheckpointBackend` / `checkpointBackendChoices`) is removed from `checkpoint_backend.go`, and **`resolveFirstRunCheckpointBackend`** is reduced to: explicit flag wins, else first-run default via **`firstRunCheckpointBackendDefault()`** (still empty when **`ENTIRE_CHECKPOINTS_PRIMARY`** is set so settings are not written). Config-less repos keep the **git-branch** runtime fallback; **`entire configure --checkpoint-backend`** is unchanged.
> 
> Tests for the picker contract and the headless “without `--yes`” branch that only exercised the deleted prompt are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408435dab32e88a8fc13cb721bfa79748f481fd1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->