### PR TITLE
test(e2e): bump resume checkpoint-advance timeout to 60s for CI flakiness

### DIFF
--- a/e2e/tests/resume_test.go
+++ b/e2e/tests/resume_test.go
@@ -86,7 +86,11 @@ func TestResumeSquashMergeMultipleCheckpoints(t *testing.T) {
 
 		s.Git(t, "add", ".")
 		s.Git(t, "commit", "-m", "Add red doc")
-		testutil.WaitForCheckpoint(t, s, 30*time.Second)
+		// The second checkpoint condenses onto the single git-branch v1 branch,
+		// whose advance can lag on a loaded CI runner. 30s flaked here
+		// intermittently (only on the git-branch backend); give it 60s. See #787
+		// for the same CI-slower-than-local timing class.
+		testutil.WaitForCheckpoint(t, s, 60*time.Second)
 		cp1Ref := testutil.CurrentCheckpointRef(t, s.Dir)
 
 		_, err = s.RunPrompt(t, ctx,
@@ -97,7 +101,7 @@ func TestResumeSquashMergeMultipleCheckpoints(t *testing.T) {
 
 		s.Git(t, "add", ".")
 		s.Git(t, "commit", "-m", "Add blue doc")
-		testutil.WaitForCheckpointAdvanceFrom(t, s.Dir, cp1Ref, 30*time.Second)
+		testutil.WaitForCheckpointAdvanceFrom(t, s.Dir, cp1Ref, 60*time.Second)
 
 		// Record checkpoint IDs from both feature branch commits.
 		cpID1 := testutil.GetCheckpointTrailer(t, s.Dir, "HEAD~1")


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/977
<!-- entire-trail-link-end -->

De-flakes `TestResumeSquashMergeMultipleCheckpoints` on the Vogon canary.

## Failing job
[test-canary (git-branch) — run 30997514111, attempt 1](https://github.com/entireio/cli/actions/runs/30997514111/job/92278074377)

```
resume_test.go:100: checkpoint state did not advance from 56ea54d9 within 30s
```

It surfaced on #1896's CI and **passed on attempt 2 with no code change** — a timing flake, not a regression. The `test` job failure in the same run is a cascade (`needs: test-canary`).

## Root cause
The second checkpoint condenses onto the single `entire/checkpoints/v1` branch. That advance is normally inline in the post-commit hook, but on a loaded CI runner it can lag behind the 30s poll window. `#787` already moved this class 15s→30s for the same "CI slower than local" reason; this test still occasionally exceeds 30s.

Not reproducible locally (20/20 on the git-branch backend) — the local machine is too fast to lose the race.

## Change
Bump the two checkpoint waits in this test (30s → 60s). Test-timing only; no production code touched.

## Out of scope (noted, not fixed here)
A separate latent bug: git-branch `setPrimaryRef` advances the shared v1 branch with a read-tip-then-set-ref and **no compare-and-swap** (`checkpoint/persistent.go`), so genuinely concurrent checkpoint writers could clobber v1. Not reachable in this single-session test (no concurrent writer); worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test timeout and comment changes only; no production or security impact.
> 
> **Overview**
> Addresses intermittent CI failures in **`TestResumeSquashMergeMultipleCheckpoints`** on the git-branch backend, where checkpoint state sometimes did not advance within the previous **30s** poll window on loaded runners.
> 
> **`WaitForCheckpoint`** and **`WaitForCheckpointAdvanceFrom`** in that test are increased to **60s**, with comments tying the flake to lag when the second checkpoint condenses onto the shared **`entire/checkpoints/v1`** branch (same timing class as **#787**). Test-only change; no production behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1571da8cd1043ee55e922ae7d6b492105575289c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->