### PR TITLE
build: bump Go to 1.26.5 to fix -race fork-child crashes on darwin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/entireio/cli
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.1

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Please also keep the version aligned in the go.mod file
-go = { version = '1.26.4', postinstall = "go install github.com/go-delve/delve/cmd/dlv@latest && go install gotest.tools/gotestsum@latest" }
+go = { version = '1.26.5', postinstall = "go install github.com/go-delve/delve/cmd/dlv@latest && go install gotest.tools/gotestsum@latest" }
 golangci-lint = '2.11.3'
 shellcheck = 'latest'
 tmux = 'latest'


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/978
<!-- entire-trail-link-end -->

## What

Bumps the Go pin from 1.26.4 to **1.26.5** in `mise.toml` and `go.mod`. 1.26.5 is the current stable release, and it fixes a Go bug that made `go test -race` intermittently fail on darwin with `signal: segmentation fault` from a spawned subprocess.

## The bug it fixes

The child of `fork()` crashed **before it could exec**, so the target binary (`git`, or the built `entire` CLI) never ran and produced no output. No Go panic, no race report — a different test hit each run, indistinguishable from a real regression in whatever you were working on.

Go 1.26 turned darwin's `syscall.rawSyscall` from a bodiless runtime/assembly declaration into an ordinary Go function, without adding `//go:norace`. `syscall.forkAndExecInChild` is `//go:norace` and justified calling `rawSyscall` from the fork child on the grounds that *"they are assembly functions"* — true on darwin until 1.26. So under `-race` the child ran TSan instrumentation and faulted:

```
os/exec.(*Cmd).CombinedOutput → Run → Start → os.StartProcess → os.startProcess
  → syscall.forkExec → syscall.forkAndExecInChild → syscall.rawSyscall
    → __tsan::TraceSwitchPartImpl(__tsan::ThreadState*)   ← SIGSEGV at 0x8
```

macOS crash reports confirm it directly: `asi: ["crashed on child side of fork pre-exec"]`, `EXC_BAD_ACCESS`, single-threaded child.

Upstream: [golang/go#79804](https://github.com/golang/go/issues/79804), 1.26 backport [#79806](https://github.com/golang/go/issues/79806). 1.26.5 adds `//go:norace` to `rawSyscall`, `rawSyscall6`, `rawSyscall9` and the `errno`/`errnoX`/`errnoPtr` helpers, and corrects the stale comment. Verifiable without leaving your machine:

```bash
diff $(mise where go@1.26.4)/src/syscall/syscall_darwin.go \
     $(mise where go@1.26.5)/src/syscall/syscall_darwin.go
```

## Scope

Affected range is **go1.26.0 – 1.26.4**, so this repo was exposed from the 1.26 bump (`b58ccebae`, 2026-02-22) until now. **darwin only**: Linux's `RawSyscall` has carried `//go:norace` all along (with a comment naming this exact hazard), and the other libc-based platforms (aix, solaris) still declare their `raw*` helpers without Go bodies, so nothing there is instrumentable. CI runs `ubuntu-latest` and was never affected.

## Test plan

| | go1.26.4 | go1.26.5 |
|---|---|---|
| `go test -tags=integration -race -count=1 ./...` | **1 crash / 4 runs** | **0 crashes / 5 runs** |

- `mise run check` green on 1.26.5 — with the **unmodified** `-race ./...` `test:ci` command, i.e. exactly the command that was crashing.
- `mise run lint` clean (`lint:go` 0 issues, `lint:gomod` clean after `go mod tidy` — no `go.sum` change).
- Canary 59 + 4 tests pass.

## Supersedes #1899

#1899 disabled `-race` for the integration package on darwin as a workaround. This makes that unnecessary, and is strictly better: the workaround permanently gave up race coverage that the toolchain bump restores. I'll close #1899 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain version pin only; no application logic changes, with the change reducing flaky test failures on macOS.
> 
> **Overview**
> Pins the Go toolchain from **1.26.4** to **1.26.5** in `go.mod` and `mise.toml` (mise stays aligned with the module directive).
> 
> This targets a **darwin-only** Go 1.26 regression where `go test -race` could SIGSEGV in fork children before `exec`, breaking integration tests that shell out. **1.26.5** restores safe `//go:norace` on Darwin `rawSyscall` helpers, so local **`mise run check`** / **`test:ci`** can keep **`-race ./...`** without the workaround that disabled race on macOS integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773db0d34bed40f3753f4dbd5ccf47dd0ef721be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->