### PR TITLE
fix(external): consult the caller's context when discovering a named agent

### DIFF
--- a/cmd/entire/cli/agent/external/discovery.go
+++ b/cmd/entire/cli/agent/external/discovery.go
@@ -58,6 +58,35 @@ func DiscoverAndRegisterNamedAlways(ctx context.Context, name types.AgentName) e
 	return discoverAndRegisterNamed(ctx, name, discoveryTimeout)
 }
 
+// discoveryCanceled reports whether either the caller's context or the derived
+// discovery-timeout context has been cancelled.
+//
+// Both must be consulted. A context closes its own Done channel *before* cancelling
+// its children, so a goroutine that has just observed the caller's cancellation can
+// run while the derived context still reports no error — and when the caller is not a
+// standard context, propagation happens in a watcher goroutine, widening the window
+// further. Checking only the derived context therefore lets a caller whose deadline
+// expired mid-operation look like it is still live.
+func discoveryCanceled(caller, derived context.Context) bool {
+	return caller.Err() != nil || derived.Err() != nil
+}
+
+// discoveryCtxErr wraps whichever of the two contexts has been cancelled, preferring
+// the caller's, and returns nil when neither has. op names the stage for the message.
+// See discoveryCanceled for why the caller's context must be consulted too: missing it
+// lets a caller whose deadline expired mid-lookup receive a nil error and a silently
+// skipped agent instead of its context error.
+func discoveryCtxErr(caller, derived context.Context, op string) error {
+	err := caller.Err()
+	if err == nil {
+		err = derived.Err()
+	}
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", op, err)
+}
+
 func discoverAndRegisterNamed(ctx context.Context, name types.AgentName, timeout time.Duration) error {
 	if name == "" {
 		return nil
@@ -69,16 +98,17 @@ func discoverAndRegisterNamed(ctx context.Context, name types.AgentName, timeout
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	callerCtx := ctx
+	ctx, cancel := context.WithTimeout(callerCtx, timeout)
 	defer cancel()
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("discovering external agent %q: %w", name, err)
+	if err := discoveryCtxErr(callerCtx, ctx, fmt.Sprintf("discovering external agent %q", name)); err != nil {
+		return err
 	}
 
 	binName := binaryPrefix + string(name)
 	binPath, err := lookPathExternalAgent(binName)
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return fmt.Errorf("looking up external agent %q binary %q: %w", name, binName, ctxErr)
+	if ctxErr := discoveryCtxErr(callerCtx, ctx, fmt.Sprintf("looking up external agent %q binary %q", name, binName)); ctxErr != nil {
+		return ctxErr
 	}
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
@@ -98,7 +128,8 @@ func discoverAndRegisterNamed(ctx context.Context, name types.AgentName, timeout
 
 // discoverAndRegister contains the shared scanning logic for external agent discovery.
 func discoverAndRegister(ctx context.Context) {
-	ctx, cancel := context.WithTimeout(ctx, discoveryTimeout)
+	callerCtx := ctx
+	ctx, cancel := context.WithTimeout(callerCtx, discoveryTimeout)
 	defer cancel()
 
 	pathEnv := os.Getenv("PATH")
@@ -114,7 +145,7 @@ func discoverAndRegister(ctx context.Context) {
 
 	seen := make(map[string]bool) // deduplicate binaries across PATH dirs
 	for _, dir := range filepath.SplitList(pathEnv) {
-		if ctx.Err() != nil {
+		if discoveryCanceled(callerCtx, ctx) {
 			logging.Debug(ctx, "external agent discovery timed out")
 			return
 		}
@@ -124,7 +155,7 @@ func discoverAndRegister(ctx context.Context) {
 			continue // skip unreadable directories
 		}
 		for _, binPath := range matches {
-			if ctx.Err() != nil {
+			if discoveryCanceled(callerCtx, ctx) {
 				logging.Debug(ctx, "external agent discovery timed out")
 				return
 			}

--- a/cmd/entire/cli/agent/external/discovery.go
+++ b/cmd/entire/cli/agent/external/discovery.go
@@ -98,16 +98,18 @@ func discoverAndRegisterNamed(ctx context.Context, name types.AgentName, timeout
 		return nil
 	}
 
-	callerCtx := ctx
-	ctx, cancel := context.WithTimeout(callerCtx, timeout)
+	// `ctx` deliberately stays the CALLER's context; the derived timeout gets its own
+	// name. Shadowing `ctx` with the derived context is what caused the bug this
+	// function is guarding against, and it left the trap in place for the next edit.
+	discoveryCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	if err := discoveryCtxErr(callerCtx, ctx, fmt.Sprintf("discovering external agent %q", name)); err != nil {
+	if err := discoveryCtxErr(ctx, discoveryCtx, fmt.Sprintf("discovering external agent %q", name)); err != nil {
 		return err
 	}
 
 	binName := binaryPrefix + string(name)
 	binPath, err := lookPathExternalAgent(binName)
-	if ctxErr := discoveryCtxErr(callerCtx, ctx, fmt.Sprintf("looking up external agent %q binary %q", name, binName)); ctxErr != nil {
+	if ctxErr := discoveryCtxErr(ctx, discoveryCtx, fmt.Sprintf("looking up external agent %q binary %q", name, binName)); ctxErr != nil {
 		return ctxErr
 	}
 	if err != nil {
@@ -116,7 +118,7 @@ func discoverAndRegisterNamed(ctx context.Context, name types.AgentName, timeout
 		}
 		return fmt.Errorf("looking up external agent %q binary %q: %w", name, binName, err)
 	}
-	registered, err := registerExternalAgent(ctx, binPath, name)
+	registered, err := registerExternalAgent(discoveryCtx, binPath, name)
 	if err != nil {
 		return err
 	}
@@ -128,8 +130,8 @@ func discoverAndRegisterNamed(ctx context.Context, name types.AgentName, timeout
 
 // discoverAndRegister contains the shared scanning logic for external agent discovery.
 func discoverAndRegister(ctx context.Context) {
-	callerCtx := ctx
-	ctx, cancel := context.WithTimeout(callerCtx, discoveryTimeout)
+	// As above: `ctx` remains the caller's, the derived timeout is named.
+	discoveryCtx, cancel := context.WithTimeout(ctx, discoveryTimeout)
 	defer cancel()
 
 	pathEnv := os.Getenv("PATH")
@@ -145,7 +147,7 @@ func discoverAndRegister(ctx context.Context) {
 
 	seen := make(map[string]bool) // deduplicate binaries across PATH dirs
 	for _, dir := range filepath.SplitList(pathEnv) {
-		if discoveryCanceled(callerCtx, ctx) {
+		if discoveryCanceled(ctx, discoveryCtx) {
 			logging.Debug(ctx, "external agent discovery timed out")
 			return
 		}
@@ -155,7 +157,7 @@ func discoverAndRegister(ctx context.Context) {
 			continue // skip unreadable directories
 		}
 		for _, binPath := range matches {
-			if discoveryCanceled(callerCtx, ctx) {
+			if discoveryCanceled(ctx, discoveryCtx) {
 				logging.Debug(ctx, "external agent discovery timed out")
 				return
 			}
@@ -177,7 +179,7 @@ func discoverAndRegister(ctx context.Context) {
 				continue
 			}
 
-			registeredAgent, err := registerExternalAgent(ctx, binPath, agentName)
+			registeredAgent, err := registerExternalAgent(discoveryCtx, binPath, agentName)
 			if err != nil {
 				logging.Debug(ctx, "skipping external agent (registration failed)",
 					slog.String("binary", binPath),

--- a/cmd/entire/cli/agent/external/discovery_test.go
+++ b/cmd/entire/cli/agent/external/discovery_test.go
@@ -651,3 +651,57 @@ func TestDiscoverAndRegisterNamedAlways_RegistersBatOnWindows(t *testing.T) {
 		t.Fatalf("agent Name() = %q, want %q", ag.Name(), name)
 	}
 }
+
+// stalledPropagationCtx is a context whose cancellation is immediately visible via
+// Done and Err, but whose propagation to derived contexts is not awaited. Because it
+// is not a standard context, context.WithTimeout watches it from a goroutine, so a
+// derived context still reports no error for a moment after this one is cancelled.
+//
+// That window is real, not contrived: even for standard contexts, cancel() closes its
+// own Done channel before cancelling children, so a goroutine woken by the parent can
+// run before the child observes anything. This type just makes the window wide enough
+// to assert on deterministically instead of relying on scheduler luck.
+type stalledPropagationCtx struct {
+	done chan struct{}
+}
+
+func (*stalledPropagationCtx) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *stalledPropagationCtx) Done() <-chan struct{}     { return c.done }
+func (*stalledPropagationCtx) Value(any) any               { return nil }
+func (c *stalledPropagationCtx) Err() error {
+	select {
+	case <-c.done:
+		return context.DeadlineExceeded
+	default:
+		return nil
+	}
+}
+
+// TestDiscoverAndRegisterNamedAlways_ReportsCallerDeadlineExpiredDuringLookup pins the
+// contract that a caller whose context expires while the helper binary is being looked
+// up gets its context error back — not a nil "no such agent" result.
+//
+// Before the fix this returned nil: the caller's context was shadowed by the derived
+// timeout context, so the post-lookup check consulted only the derived one, which had
+// not yet observed the caller's cancellation. That is the same defect that made
+// TestDiscoverAndRegisterNamedAlways_DeadlineWhileLookingUpMissingHelper flaky under
+// load, where the window had to be hit by chance.
+func TestDiscoverAndRegisterNamedAlways_ReportsCallerDeadlineExpiredDuringLookup(t *testing.T) {
+	name := types.AgentName("disc-named-caller-deadline")
+	caller := &stalledPropagationCtx{done: make(chan struct{})}
+
+	originalLookPath := lookPathExternalAgent
+	t.Cleanup(func() { lookPathExternalAgent = originalLookPath })
+	lookPathExternalAgent = func(string) (string, error) {
+		// Expire the caller mid-lookup and return straight away, before the derived
+		// context's watcher goroutine can observe it. ErrNotFound is the benign
+		// "no such helper" result the deadline must take precedence over.
+		close(caller.done)
+		return "", exec.ErrNotFound
+	}
+
+	err := DiscoverAndRegisterNamedAlways(caller, name)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want context deadline exceeded", err)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/980
<!-- entire-trail-link-end -->

## Problem

`discoverAndRegisterNamed` shadows its caller's context:

```go
ctx, cancel := context.WithTimeout(ctx, timeout)   // caller's ctx now unreachable
...
binPath, err := lookPathExternalAgent(binName)
if ctxErr := ctx.Err(); ctxErr != nil { ... }        // only sees the DERIVED context
```

A context closes its own `Done` channel **before** cancelling its children, so a goroutine woken by the caller's cancellation can run while the derived context still reports no error. When the caller isn't a standard context, propagation happens in a watcher goroutine, widening the window further.

**Consequence:** a caller whose deadline expired while the helper binary was being looked up got `nil` back instead of its context error — execution fell through to the benign `exec.ErrNotFound` branch and reported "no such agent". The deadline was silently swallowed.

## Why this matters beyond correctness

This is what made `TestDiscoverAndRegisterNamedAlways_DeadlineWhileLookingUpMissingHelper` flaky, which recently red-lit CI on an unrelated PR.

Worth stating plainly: **that test was right.** It asserts exactly the documented contract, and it was intermittently catching a real defect — not being badly written. It only failed under load because the window had to be hit by chance. The package runs ~1.3 s alone but **~14.5 s under whole-repo `-race`**, and that contention is what let the woken stub outrun the propagation.

## Fix

Keep a reference to the caller's context and consult both, preferring the caller's.

- `discoveryCtxErr(caller, derived, op)` — wraps whichever expired. Message text is unchanged.
- `discoveryCanceled(caller, derived)` — boolean form for the `$PATH`-scan loop in `discoverAndRegister`, which had the same shadowing. That site could only exit one iteration late rather than return a wrong value, so its risk profile is lower, but the pattern is identical and it now shares the helper.

## Verification

New test `TestDiscoverAndRegisterNamedAlways_ReportsCallerDeadlineExpiredDuringLookup` reproduces the window **deterministically** rather than relying on scheduler luck — a caller context whose cancellation is visible via `Done`/`Err` but whose propagation to derived contexts hasn't run yet.

- **RED without the fix**, with the same `error = <nil>, want context deadline exceeded` message seen in CI.
- GREEN with it, 5/5.

The pre-existing test is now deterministic too, because it synchronizes on the caller's context — which the code finally consults. Verified with the whole package under `-race`, 15 iterations, against 10 competing CPU hogs: **no failures** (previously reproducible under exactly that kind of contention).

`mise run fmt && mise run lint` → 0 issues. `mise run test:ci` → pass, canary green.

## Note

`golangci-lint`'s `wrapcheck` rejects returning `ctx.Err()` unwrapped from a helper, so `discoveryCtxErr` takes an `op` string and does the wrapping itself. That keeps the produced error strings byte-identical to before rather than adding a `//nolint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to external agent discovery cancellation handling with added regression tests; behavior change only surfaces when caller contexts expire mid-discovery.
> 
> **Overview**
> Fixes a bug where **named external agent discovery** could treat an expired caller context as still active because only the derived `WithTimeout` context was checked after shadowing the original `ctx`.
> 
> The change keeps **`callerCtx`** alongside the timeout context and adds **`discoveryCtxErr`** / **`discoveryCanceled`** so cancellation is detected on **either** context (caller preferred), including the race where parent cancellation is visible before it propagates to children.
> 
> **`discoverAndRegisterNamed`** now returns the caller’s context error instead of falling through to a benign “missing helper” `nil` when the deadline hits during lookup. **`discoverAndRegister`** uses the same pattern in its `$PATH` scan loop.
> 
> A new test with **`stalledPropagationCtx`** reproduces that window deterministically and locks in the expected `context.DeadlineExceeded` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f10908777fa0a475b5ea48b99933745d88f5a31. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->