### PR TITLE
Don't prompt from git hooks when a TUI owns the terminal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,12 @@ Tests that spawn the real `entire` or `git` binary need the child to be non-inte
 2. `testing.Testing()` → false. In-process `go test` runs are non-interactive by default; no per-test `t.Setenv("ENTIRE_TEST_TTY", "0")` is needed.
 3. Agent sentinels (`GEMINI_CLI`, `COPILOT_CLI`, `PI_CODING_AGENT`, `GIT_TERMINAL_PROMPT=0`) → false.
 4. `CI=<non-empty-non-false>` → false.
-5. `/dev/tty` probe.
+5. `/dev/tty` probe, plus its terminal mode → a terminal held in raw mode
+   (canonical input off) belongs to a full-screen TUI that spawned us, not to a
+   shell we can prompt: TUI git clients (lazygit, gitui, tig) run `git commit`
+   as a child while owning the screen, so the hook inherits a `/dev/tty` it
+   must not prompt on. Fails open when the mode can't be read. See
+   `interactive/rawmode_unix.go` for the rationale.
 
 For subprocesses spawning the real `entire` binary (e2e, integration tests, `entire` calling itself from a hook), prefer `execx.NonInteractive` over env-var plumbing:
 

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -30,7 +30,9 @@ const EnvTestTTY = "ENTIRE_TEST_TTY"
 //     Subprocess tests must spawn via execx.NonInteractive (or set EnvTestTTY).
 //  3. Agent sentinels — vendor-set by agent subprocesses.
 //  4. CI=<non-empty-non-false> — de-facto CI convention.
-//  5. /dev/tty probe.
+//  5. /dev/tty probe, plus its terminal mode: a controlling terminal held in
+//     raw mode belongs to a full-screen TUI (lazygit, gitui, tig, …) that
+//     spawned us, not to a shell we can prompt. See rawmode_unix.go.
 func CanPromptInteractively() bool {
 	if v := os.Getenv(EnvTestTTY); v != "" {
 		return v == "1"
@@ -54,8 +56,11 @@ func CanPromptInteractively() bool {
 	if err != nil {
 		return false
 	}
-	_ = tty.Close()
-	return true
+	defer tty.Close()
+	// Having a controlling terminal isn't enough — a TUI that spawned us holds
+	// that same terminal in raw mode for its own screen and keys. See
+	// rawmode_unix.go.
+	return !ttyInRawMode(tty)
 }
 
 // UnderTest reports whether the process is running in a test context — either

--- a/cmd/entire/cli/interactive/rawmode_darwin.go
+++ b/cmd/entire/cli/interactive/rawmode_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package interactive
+
+import "golang.org/x/sys/unix"
+
+// rawModeIoctl is the BSD/darwin termios read ioctl. See rawmode_unix.go.
+const rawModeIoctl = unix.TIOCGETA

--- a/cmd/entire/cli/interactive/rawmode_linux.go
+++ b/cmd/entire/cli/interactive/rawmode_linux.go
@@ -1,0 +1,8 @@
+//go:build linux
+
+package interactive
+
+import "golang.org/x/sys/unix"
+
+// rawModeIoctl is the Linux termios read ioctl. See rawmode_unix.go.
+const rawModeIoctl = unix.TCGETS

--- a/cmd/entire/cli/interactive/rawmode_other.go
+++ b/cmd/entire/cli/interactive/rawmode_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin && !linux
+
+package interactive
+
+import "os"
+
+// ttyInRawMode cannot inspect terminal modes on platforms without the unix
+// termios ioctls, so it reports false (fail open — see rawmode_unix.go). Those
+// platforms don't have a /dev/tty for CanPromptInteractively to open either, so
+// this path is not reached in practice.
+func ttyInRawMode(_ *os.File) bool {
+	return false
+}

--- a/cmd/entire/cli/interactive/rawmode_pty_test.go
+++ b/cmd/entire/cli/interactive/rawmode_pty_test.go
@@ -1,0 +1,44 @@
+//go:build darwin || linux
+
+package interactive
+
+import (
+	"testing"
+
+	"github.com/creack/pty"
+	"golang.org/x/term"
+)
+
+// TestTTYInRawMode_PTY exercises the real signal on a real terminal: a freshly
+// opened pty is in canonical mode (the shape a shell leaves the terminal in
+// while a foreground `git commit` runs), and putting it in raw mode (the shape a
+// TUI git client like lazygit holds it in) must flip detection.
+func TestTTYInRawMode_PTY(t *testing.T) {
+	t.Parallel()
+
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Skipf("cannot open a pty here: %v", err)
+	}
+	defer ptmx.Close()
+	defer tty.Close()
+
+	if ttyInRawMode(tty) {
+		t.Error("ttyInRawMode(fresh pty) = true; want false (canonical mode)")
+	}
+
+	state, err := term.MakeRaw(int(tty.Fd()))
+	if err != nil {
+		t.Fatalf("MakeRaw: %v", err)
+	}
+	if !ttyInRawMode(tty) {
+		t.Error("ttyInRawMode(raw pty) = false; want true (a TUI owns the terminal)")
+	}
+
+	if err := term.Restore(int(tty.Fd()), state); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if ttyInRawMode(tty) {
+		t.Error("ttyInRawMode(restored pty) = true; want false (back to canonical mode)")
+	}
+}

--- a/cmd/entire/cli/interactive/rawmode_test.go
+++ b/cmd/entire/cli/interactive/rawmode_test.go
@@ -1,0 +1,25 @@
+package interactive
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A non-terminal file has no terminal mode to read, so detection must fail open
+// (report "not raw"): the raw-mode check may only ever suppress prompts we
+// positively know are unusable.
+func TestTTYInRawMode_NonTerminalFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "not-a-tty")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer f.Close()
+
+	if ttyInRawMode(f) {
+		t.Error("ttyInRawMode(regular file) = true; want false (fail open)")
+	}
+}

--- a/cmd/entire/cli/interactive/rawmode_unix.go
+++ b/cmd/entire/cli/interactive/rawmode_unix.go
@@ -1,0 +1,51 @@
+//go:build darwin || linux
+
+package interactive
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// ttyInRawMode reports whether the terminal behind f has canonical (line) input
+// disabled — i.e. a full-screen program owns the screen rather than a shell we
+// can prompt.
+//
+// Terminal-UI git clients (lazygit, gitui, tig, …) run git as a child process
+// while keeping the controlling terminal in raw mode for their own screen and
+// key handling. Such a child — including a git hook, and therefore `entire` —
+// still inherits that controlling terminal, so it can open /dev/tty
+// successfully. The /dev/tty probe alone therefore cannot tell a TUI apart from
+// a shell, and prompting there is broken in both directions: our output paints
+// over the TUI's screen, and our line read races the TUI's key reader for the
+// user's keystrokes, so the answer may never arrive and the git command appears
+// to hang (the reported symptom was lazygit freezing on the "Link this commit
+// to session context?" prompt).
+//
+// Canonical input mode (ICANON) is the signal that separates the two: a shell
+// restores the terminal to canonical mode before running a foreground command,
+// while a TUI holds it in raw mode for as long as it owns the screen. That is
+// also exactly the distinction the TUIs themselves draw — lazygit restores
+// cooked mode when it deliberately hands the terminal to a child (editor,
+// interactive rebase, custom subprocess commands), which is when prompting does
+// work and should happen.
+//
+// Checking the terminal mode rather than the hook's file descriptors is
+// deliberate: git's hook stdio plumbing varies by git version (stdin is
+// /dev/null, and stdout/stderr may be inherited or captured), so an isatty
+// check on those descriptors is not a stable signal, while terminal ownership
+// is.
+//
+// rawModeIoctl is the platform's termios read ioctl (rawmode_darwin.go,
+// rawmode_linux.go); rawmode_other.go covers platforms without termios.
+func ttyInRawMode(f *os.File) bool {
+	termios, err := unix.IoctlGetTermios(int(f.Fd()), rawModeIoctl) //nolint:gosec // G115: uintptr->int is safe for fd
+	if err != nil {
+		// Can't tell — fail open so an unexpected ioctl failure never silently
+		// disables prompting. This check may only ever suppress prompts we
+		// positively know are unusable.
+		return false
+	}
+	return termios.Lflag&unix.ICANON == 0
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/betterleaks/betterleaks v1.5.0
 	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/entireio/auth-go v0.5.2
 	github.com/go-faster/errors v0.8.0


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/981
<!-- entire-trail-link-end -->

## Problem

A user reported that committing through **lazygit** froze on the interactive "Link this commit to session context?" question, hit the first time Entire ran in a new repo.

lazygit (like gitui, tig) runs `git commit` as a captured child while holding the controlling terminal in raw mode for its own screen and keys. The hook inherits that terminal, so `/dev/tty` opens fine — but it must not be used: our write paints over lazygit's UI, and our line read races lazygit's key reader for the keystroke, so the answer never arrives and the commit appears to hang.

## Fix

`interactive.CanPromptInteractively()` now also checks the *mode* of the `/dev/tty` it already opens. Canonical input off (`ICANON`) means a full-screen program owns the screen, not a shell we can prompt. Suppressed prompts fall through to the existing non-interactive path, so the hook auto-links the commit rather than blocking.

Why this signal:

- **No env sentinel exists.** lazygit runs git with the plain inherited environment plus `GIT_OPTIONAL_LOCKS=0`; its only `GIT_TERMINAL_PROMPT=0` (which we already detect) is on the `reset`/`branch` paths, not commit. There is nothing lazygit-specific to key off.
- **Generic, not a name list.** Terminal mode catches any TUI parent, and it tracks the distinction the TUIs themselves draw — lazygit restores cooked mode whenever it deliberately hands the terminal to a child (editor, interactive rebase, custom commands), which is exactly when prompting works and should still happen.
- **Not an isatty check on the hook's descriptors.** git's hook stdio plumbing varies by version (stdin is `/dev/null`; stdout/stderr may be inherited or captured), while terminal ownership does not.
- **Fails open.** If the mode can't be read, prompting stays enabled, so the check can only ever suppress prompts we positively know are unusable.

## Verification

Probe hook on git 2.54 (macOS), measuring what a real hook sees:

| hook context | `/dev/tty` opens | terminal mode | prompts? |
|---|---|---|---|
| human shell running `git commit -m` | yes | `icanon echo` | yes (unchanged) |
| TUI owning the terminal (lazygit shape) | yes | `-icanon -echo` | no (was: hang) |
| agent / CI | no | — | no (unchanged) |

- End-to-end: a binary calling the real predicate returns `true` under a cooked pty, `false` under a raw pty, `false` with no tty.
- New pty-based unit test covers cooked → raw → cooked on a real terminal; a second test pins the fail-open path.
- `ENTIRE_TEST_TTY=1` is still checked first, so existing tests that force the interactive commit path are unaffected.
- 8532 unit, 448 integration, and both canary suites pass; `golangci-lint` clean.

Windows has no `/dev/tty`, so this prompt never fired there either way.

## Note for reviewers

`github.com/creack/pty` moves from the module graph into `go.mod` as a direct (test-only) dependency for the pty test.

One known follow-up, deliberately out of scope: `strategy/checkpoint_policy.go` and `hooks_git_cmd.go` use this same predicate to decide *print-vs-log* for one-shot stderr warnings, so those warnings now downgrade to log-only under a TUI. Swapping them to a writer-scoped check wouldn't help (lazygit pipes git's stderr, so that's false too); restoring visibility means printing unconditionally, as `warnIfAttributionDiverged` already does. That's a per-site design call better made on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to interactive detection with fail-open behavior; main effect is fewer prompts in TUI git contexts, with normal shell commits unchanged.
> 
> **Overview**
> Fixes commits **freezing** when Entire tries to prompt (e.g. “Link this commit to session context?”) from a **git hook** while the user is in a TUI such as **lazygit**. Those clients keep the controlling terminal in **raw mode**; `/dev/tty` still opens, but prompting corrupts the UI and races for input.
> 
> **`interactive.CanPromptInteractively()`** still follows the existing precedence (`ENTIRE_TEST_TTY`, tests, agent env, CI), but step 5 no longer stops at “`/dev/tty` opens.” It reads the terminal **termios** and returns **false** when **canonical input is off** (`ICANON` clear), treating that as “a full-screen program owns the terminal.” Hooks then use the existing **non-interactive** path (e.g. auto-link) instead of blocking.
> 
> Implementation is split across **`ttyInRawMode`** on darwin/linux (`TIOCGETA` / `TCGETS`), **fail-open** on ioctl failure or non-Unix builds, plus **pty-based tests** and **CLAUDE.md** documentation. **`github.com/creack/pty`** is added as a direct test dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508c438e3b65c13027544f60db7f646ea1339fce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->