### PR TITLE
fix(e2e): select the restored Codex rollout by recency, not by path inequality

### DIFF
--- a/e2e/tests/codex_resume_test.go
+++ b/e2e/tests/codex_resume_test.go
@@ -55,7 +55,7 @@ func TestCodexResumeRestoredSessionWithSanitizedCompactedHistory(t *testing.T) {
 
 		// Prove the restored rollout actually contains the shape under test before
 		// asserting Codex tolerates it — otherwise a green run says nothing.
-		assertRestoredCompactionStripped(t, findRestoredCodexRollout(t, codexSession.Home(), rolloutPath))
+		assertRestoredCompactionStripped(t, findRestoredCodexRollout(t, codexSession.Home()))
 
 		codexAgent, ok := s.Agent.(*agents.Codex)
 		require.True(t, ok, "expected *agents.Codex agent, got %T", s.Agent)
@@ -174,30 +174,53 @@ func appendCompactedEncryptedHistory(t *testing.T, rolloutPath string) {
 	}
 }
 
-// findRestoredCodexRollout returns the rollout `entire resume` wrote. Restore does
-// not overwrite the agent's original file — it writes a fresh rollout for the same
-// session id under a new timestamped name — so the home holds both afterwards and
-// findCodexRollout's exactly-one expectation no longer applies.
-func findRestoredCodexRollout(t *testing.T, codexHome, originalPath string) string {
+// findRestoredCodexRollout returns the rollout `entire resume` wrote, which is the one
+// the subsequent `codex resume` loads.
+//
+// Restore may either overwrite the agent's original file or add a second one, and
+// which happens depends on the machine's timezone: Entire derives the restored path
+// from the session start time in UTC (codex.restoredRolloutPath), while Codex names
+// its own rollout in local time. On a UTC host (CI) the two names collide and restore
+// overwrites in place; anywhere else they differ and both files remain.
+//
+// So do not key off "the path that is not the original" — that only holds off-UTC.
+// Pick the most recently written rollout instead, which is the restored copy in both
+// layouts.
+func findRestoredCodexRollout(t *testing.T, codexHome string) string {
 	t.Helper()
 
 	matches, err := filepath.Glob(filepath.Join(codexHome, "sessions", "*", "*", "*", "rollout-*.jsonl"))
 	require.NoError(t, err)
 	require.NotEmpty(t, matches, "no Codex rollout found after resume")
 
-	var restored []string
-	for _, m := range matches {
-		if m != originalPath {
-			restored = append(restored, m)
+	newest := newestFile(t, matches)
+	t.Logf("rollouts after resume (%d): %v", len(matches), matches)
+	t.Logf("asserting on most recently written: %s", newest)
+	return newest
+}
+
+// newestFile returns the most recently modified of paths. Ties are broken by taking
+// the later entry, which keeps the choice deterministic when a filesystem reports
+// coarse timestamps.
+func newestFile(t *testing.T, paths []string) string {
+	t.Helper()
+	require.NotEmpty(t, paths)
+
+	newest := paths[0]
+	newestMod := fileModTime(t, newest)
+	for _, p := range paths[1:] {
+		if mod := fileModTime(t, p); !mod.Before(newestMod) {
+			newest, newestMod = p, mod
 		}
 	}
-	require.Len(t, restored, 1,
-		"expected exactly one restored rollout alongside the original\noriginal: %s\nall: %v",
-		originalPath, matches)
+	return newest
+}
 
-	t.Logf("original rollout: %s", originalPath)
-	t.Logf("restored rollout: %s", restored[0])
-	return restored[0]
+func fileModTime(t *testing.T, path string) time.Time {
+	t.Helper()
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	return fi.ModTime()
 }
 
 // assertRestoredCompactionStripped verifies the restored rollout carries a
@@ -257,4 +280,49 @@ func payloadKeys(payload map[string]any) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// TestFindRestoredCodexRollout_HandlesOverwriteAndSecondFile pins the selection rule
+// against both layouts `entire resume` can produce, without needing a real agent.
+//
+// This exists because the original helper assumed restore always adds a second file
+// and identified it as "the path that is not the original". That assumption is
+// timezone-dependent — Entire derives the restored path in UTC while Codex names its
+// own rollout in local time — so it held on a developer laptop and broke on CI, where
+// the names collide and restore overwrites in place.
+func TestFindRestoredCodexRollout_HandlesOverwriteAndSecondFile(t *testing.T) {
+	t.Parallel()
+
+	write := func(t *testing.T, home, name string, modAt time.Time) string {
+		t.Helper()
+		dir := filepath.Join(home, "sessions", "2026", "08", "06")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte("{}\n"), 0o644))
+		require.NoError(t, os.Chtimes(p, modAt, modAt))
+		return p
+	}
+
+	base := time.Now().Add(-time.Hour)
+
+	t.Run("overwritten in place (UTC host)", func(t *testing.T) {
+		t.Parallel()
+		home := t.TempDir()
+		only := write(t, home, "rollout-2026-08-06T10-54-17-sess.jsonl", base)
+
+		require.Equal(t, only, findRestoredCodexRollout(t, home),
+			"with a single rollout the helper must use it rather than demanding a second file")
+	})
+
+	t.Run("second file added (non-UTC host)", func(t *testing.T) {
+		t.Parallel()
+		home := t.TempDir()
+		// The agent's own file, named in local time, written first.
+		write(t, home, "rollout-2026-08-06T12-54-17-sess.jsonl", base)
+		// Restore's copy, named in UTC, written afterwards.
+		restored := write(t, home, "rollout-2026-08-06T10-54-17-sess.jsonl", base.Add(time.Minute))
+
+		require.Equal(t, restored, findRestoredCodexRollout(t, home),
+			"with two rollouts the helper must pick the one restore wrote, not the lexically first")
+	})
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/983
<!-- entire-trail-link-end -->

Fixes the **E2E Tests** failure on `main` after #1901 merged ([run](https://github.com/entireio/cli/actions/runs/31094714607/job/92593838882)). My bug, introduced in that PR's review-fix commit.

## Cause

The assertion helper I added assumed `entire resume` always writes a **second** rollout alongside the agent's own, and identified it as "the path that is not the original". That assumption is timezone-dependent:

`codex.restoredRolloutPath` derives the restored filename from the session start time in **UTC**, while Codex names its own rollout in **local** time.

| Host | Filenames | Restore behaviour | Old helper |
|---|---|---|---|
| UTC (CI) | collide | overwrites in place → **1 file** | filter yields 0 → `require.Len(…, 1)` **fails** |
| CEST (my laptop) | differ | writes a new file → **2 files** | filter yields 1 → passes |

Which is exactly what CI reported:

```
Error:    "[]" should have 1 item(s), but has 0
Messages: expected exactly one restored rollout alongside the original
original: …/rollout-2026-08-06T10-54-17-019fd6b5-….jsonl
all:      […/rollout-2026-08-06T10-54-17-019fd6b5-….jsonl]
```

## Fix

Select the **most recently written** rollout. That's the restored copy in both layouts, and it's also the file the subsequent `codex resume` actually loads — so the assertion now targets the right bytes for the right reason, rather than passing by construction on one class of machine.

## Test

`TestFindRestoredCodexRollout_HandlesOverwriteAndSecondFile` fabricates both layouts (single overwritten file; two files with distinct mtimes) and needs no agent and no API call, so the selection rule is pinned inside the existing e2e job for free.

## Verification, stated honestly

I did **not** reproduce the old failure locally. My attempt to re-instate the old rule wasn't equivalent — it filtered a hardcoded local-time filename that doesn't exist in the UTC layout, so the test passed and proved nothing. The evidence the old rule was wrong is the CI log above; the new test encodes the correct contract for both layouts.

The real `codex resume` path itself is unchanged by this PR — only which file the assertion inspects — so the remaining risk is confined to the helper, which is now directly tested. Happy to spend a real `mise run test:e2e --agent codex` run to confirm end-to-end if you'd prefer that before merging.

`mise run fmt && mise run lint` → 0 issues. `mise run test:ci` → pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to rollout file selection and new coverage; production resume behavior is unchanged.
> 
> **Overview**
> Fixes flaky **Codex resume** e2e assertions that failed on **UTC CI** because `findRestoredCodexRollout` expected exactly one rollout whose path differed from the original. When Entire’s UTC-derived restore path collides with Codex’s local-time rollout name, restore **overwrites in place** and that filter returns nothing.
> 
> The helper now picks the **most recently modified** `rollout-*.jsonl` (via `newestFile` / `fileModTime`), which matches what `codex resume` loads in both the single-file and two-file layouts. The main test drops the `originalPath` argument; logging documents which file is asserted.
> 
> Adds **`TestFindRestoredCodexRollout_HandlesOverwriteAndSecondFile`** to lock both layouts without a live agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd3cc5601e54fc5aa715c61189a3bbad8d321a92. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->