### PR TITLE
docs(security): qualify phone PII redaction as NANP-only

### DIFF
--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -36,7 +36,7 @@ Built-in categories (when `enabled` is `true`):
 | Category | Default | Replacement token |
 |---|---|---|
 | `email` | on | `[REDACTED_EMAIL]` |
-| `phone` | on | `[REDACTED_PHONE]` |
+| `phone` (North American / NANP formats) | on | `[REDACTED_PHONE]` |
 | `address` (US street addresses) | off (more false-positive prone) | `[REDACTED_ADDRESS]` |
 
 Common bot/CI email addresses are not redacted (`noreply@*`, `actions@*`, `*@users.noreply.github.com`, `*@noreply.github.com`).
@@ -378,6 +378,7 @@ File an issue when the rule would benefit every Entire user (e.g., a major SaaS 
 - **Best-effort.** Novel or low-entropy secrets (short passwords, predictable tokens) may not be caught.
 - **Filenames and binary data.** Secrets in filenames, binary files, or deeply nested structures may not be detected.
 - **JSONL skip rules.** Entire skips scanning fields named `signature`, fields ending in `id`/`ids`, structural-path fields (`filepath`, `file_path`, `cwd`, `root`, `directory`, `dir`, `path`), and objects whose `type` starts with `image` or equals `base64` — all to avoid false positives.
+- **Built-in PII patterns are US-centric.** `phone` matches North American (NANP) formats only — international formats, including E.164 numbers outside `+1`, are not detected. `address` matches the street line only; city, state, and ZIP/postcode are preserved. If you handle personal data from other regions, add `custom_patterns` for your locale rather than relying on the built-in categories alone.
 - **Custom PII patterns are user-authored.** Teams own the correctness of their `custom_patterns`. An invalid regex is logged and skipped, not enforced.
 - **Users are ultimately responsible** for reviewing what they commit and push. Redaction is a safety net, not a guarantee.
 


### PR DESCRIPTION
Closes part of entireio/cli#1909.

`phone` PII redaction is on by default whenever PII redaction is enabled, but only matches North American (NANP) formats. The docs gave it no locale qualifier, while `address` right below it is already qualified as "US street addresses". A non-US user reading `phone: true` / `[REDACTED_PHONE]` reasonably concludes phone numbers are stripped, when for their own country's numbers nothing happens at all.

## Changes

Two edits to `docs/security-and-privacy.md`:

1. Qualify the table row — `` `phone` (North American / NANP formats) ``. Kept the qualifier inside the Category cell to match how `address` already does it, rather than adding the extra "Notes" column the issue suggests. Happy to switch to the column if you'd prefer it.
2. New bullet under **Limitations**:

   > **Built-in PII patterns are US-centric.** `phone` matches North American (NANP) formats only — international formats, including E.164 numbers outside `+1`, are not detected. `address` matches the street line only; city, state, and ZIP/postcode are preserved. If you handle personal data from other regions, add `custom_patterns` for your locale rather than relying on the built-in categories alone.

Docs only. No change to the matchers.

## Verified against source

* `redact/pii.go:84-92` — `phoneRegex` has three branches, all 3-3-4 NANP. Only the first carries an international prefix, and it is hardcoded `\+1`, so E.164 numbers outside `+1` are not matched.
* `redact/pii.go:93` — `addressRegex` terminates at the street suffix (`St`, `Ave`, `Rd`, …), so anything after it survives.
* `redact/pii.go:79` — `emailRegex` is locale-independent, consistent with the issue reporting email as fine.

## Not covered here

* `/guides/configuration/privacy-and-redaction` (the issue's smaller point 1) has no in-repo equivalent — it looks like it lives on the docs site. If that content is maintained elsewhere, the same qualifier is worth repeating there, since it is the page you land on to turn the feature on.
* **International phone coverage** is explicitly out of scope per the issue and the reporter's follow-up; that stays a backlog item.

## Note on process

I picked this up after commenting on the issue; @jasonmx confirmed the scope ("the primary ask is to clarify the features' scope in the docs"), but no maintainer has replied or assigned it yet. First contribution here, so happy to close this if it is already in flight or if you'd rather the docs change land somewhere else.