### PR TITLE
Don't prompt from git hooks on a capturing client's own pty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,12 +299,27 @@ Tests that spawn the real `entire` or `git` binary need the child to be non-inte
 2. `testing.Testing()` → false. In-process `go test` runs are non-interactive by default; no per-test `t.Setenv("ENTIRE_TEST_TTY", "0")` is needed.
 3. Agent sentinels (`GEMINI_CLI`, `COPILOT_CLI`, `PI_CODING_AGENT`, `GIT_TERMINAL_PROMPT=0`) → false.
 4. `CI=<non-empty-non-false>` → false.
-5. `/dev/tty` probe, plus its terminal mode → a terminal held in raw mode
-   (canonical input off) belongs to a full-screen TUI that spawned us, not to a
-   shell we can prompt: TUI git clients (lazygit, gitui, tig) run `git commit`
-   as a child while owning the screen, so the hook inherits a `/dev/tty` it
-   must not prompt on. Fails open when the mode can't be read. See
+5. Git-hook context with a private terminal session → false. TUI git clients run
+   `git commit` on a pty of their own (lazygit does) and only render what comes
+   back, so the hook inherits a `/dev/tty` that opens, sits in canonical mode,
+   and that nothing forwards keystrokes to — prompting there hangs the commit and
+   freezes the client. Job control is the tell: a shell gives each foreground
+   command its own process group (`sid != pgrp`), while a private session makes
+   the command its own session leader (`sid == pgrp`). Only applied when
+   `interactive.MarkGitHookContext()` was called (the `entire hooks git` tree), so
+   one-shot interactive invocations that share the shape but do forward input
+   (`ssh -t host entire enable`, `docker run -it … entire enable`) keep prompting.
+   See `interactive/jobcontrol_unix.go`.
+6. `/dev/tty` probe, plus its terminal mode → a terminal held in raw mode
+   (canonical input off) belongs to a full-screen TUI that spawned us and reuses
+   the user's terminal rather than allocating its own (gitui, tig), so it must
+   not be prompted on. Fails open when the mode can't be read. See
    `interactive/rawmode_unix.go` for the rationale.
+
+Both terminal checks fail open, so they can only suppress prompts we positively
+know are unusable. When adding a prompt reachable from a git hook, gate it on
+`CanPromptInteractively()` and make the non-interactive branch a sensible default
+(the commit-linking prompt auto-links, which is its default answer).
 
 For subprocesses spawning the real `entire` binary (e2e, integration tests, `entire` calling itself from a hook), prefer `execx.NonInteractive` over env-var plumbing:
 

--- a/cmd/entire/cli/hooks_git_cmd.go
+++ b/cmd/entire/cli/hooks_git_cmd.go
@@ -162,6 +162,11 @@ func newHooksGitCmd() *cobra.Command {
 		Hidden: true, // Internal command, not for direct user use
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
+			// Tell the prompt gate we're a git hook: the terminal we inherit
+			// belongs to whatever ran git, which for a TUI client is a private pty
+			// it only renders. Set unconditionally and before any early return so
+			// every prompt in this process sees it.
+			interactive.MarkGitHookContext()
 			// Check if Entire is set up and enabled before doing any work.
 			// This prevents global git hooks from doing anything in repos where
 			// Entire was never enabled or has been disabled.

--- a/cmd/entire/cli/interactive/githookcontext.go
+++ b/cmd/entire/cli/interactive/githookcontext.go
@@ -1,0 +1,23 @@
+package interactive
+
+import "sync/atomic"
+
+// gitHookContext records that this process was invoked as a git hook. It is a
+// one-way latch set once during command setup, so reads are cheap and cannot
+// race with a later change.
+var gitHookContext atomic.Bool
+
+// MarkGitHookContext declares that this process is running as a git hook, which
+// changes what a controlling terminal implies: git was run by something else —
+// possibly a TUI client that gave us a private terminal it only reads from — so
+// a terminal we can open is not necessarily one a user can answer on. See
+// jobcontrol_unix.go for the check this enables and why it is scoped here rather
+// than applied to every `entire` invocation.
+//
+// Called from the `entire hooks git` command tree, which every git hook funnels
+// through. Direct CLI invocations never set it and keep the plain terminal
+// detection.
+func MarkGitHookContext() { gitHookContext.Store(true) }
+
+// inGitHookContext reports whether MarkGitHookContext was called.
+func inGitHookContext() bool { return gitHookContext.Load() }

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -30,9 +30,14 @@ const EnvTestTTY = "ENTIRE_TEST_TTY"
 //     Subprocess tests must spawn via execx.NonInteractive (or set EnvTestTTY).
 //  3. Agent sentinels — vendor-set by agent subprocesses.
 //  4. CI=<non-empty-non-false> — de-facto CI convention.
-//  5. /dev/tty probe, plus its terminal mode: a controlling terminal held in
-//     raw mode belongs to a full-screen TUI (lazygit, gitui, tig, …) that
-//     spawned us, not to a shell we can prompt. See rawmode_unix.go.
+//  5. Git-hook context with a private session — when we run as a git hook (see
+//     MarkGitHookContext) and our terminal session was created for this command
+//     alone, git was run by a client capturing our output: lazygit gives `git
+//     commit` its own pty and only renders what comes back, so a prompt there is
+//     never answered and the commit hangs. See jobcontrol_unix.go.
+//  6. /dev/tty probe, plus its terminal mode: a controlling terminal held in raw
+//     mode belongs to a full-screen TUI (gitui, tig, …) that spawned us, not to
+//     a shell we can prompt. See rawmode_unix.go.
 func CanPromptInteractively() bool {
 	if v := os.Getenv(EnvTestTTY); v != "" {
 		return v == "1"
@@ -49,6 +54,15 @@ func CanPromptInteractively() bool {
 	// CI=false is the `is-ci` escape hatch for developers who need to override
 	// an inherited value.
 	if v := os.Getenv("CI"); v != "" && v != "false" {
+		return false
+	}
+
+	// A git hook inherits whatever terminal the client that ran git left it, and
+	// a TUI client hands us a private one it only reads from. This is scoped to
+	// hook context because one-shot interactive invocations (`ssh -t host entire
+	// enable`, `docker run -it … entire enable`) have the same private-session
+	// shape but do forward the user's keystrokes.
+	if inGitHookContext() && ttyIsPrivateSession() {
 		return false
 	}
 

--- a/cmd/entire/cli/interactive/jobcontrol_other.go
+++ b/cmd/entire/cli/interactive/jobcontrol_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux
+
+package interactive
+
+// ttyIsPrivateSession needs POSIX sessions and process groups to say anything,
+// so it reports false (fail open — see jobcontrol_unix.go). Those platforms have
+// no /dev/tty for CanPromptInteractively to open, so this check is not reached
+// in practice.
+func ttyIsPrivateSession() bool {
+	return false
+}

--- a/cmd/entire/cli/interactive/jobcontrol_unix.go
+++ b/cmd/entire/cli/interactive/jobcontrol_unix.go
@@ -1,0 +1,44 @@
+//go:build darwin || linux
+
+package interactive
+
+import "golang.org/x/sys/unix"
+
+// ttyIsPrivateSession reports whether our controlling terminal was created for
+// this command alone, rather than handed to us by a user's interactive shell.
+//
+// Output-capturing git clients don't merely inherit the user's terminal: lazygit
+// runs `git commit` on a *fresh pty*, and making a pty into a controlling
+// terminal requires setsid + TIOCSCTTY. The git process therefore becomes a
+// session leader on a private terminal — one that opens cleanly and sits in
+// canonical mode, so neither the /dev/tty probe nor the raw-mode check
+// (rawmode_unix.go) can tell that nobody is reading it. lazygit only renders
+// that pty's output; it does not forward keystrokes to it, so a prompt there
+// never receives an answer: the commit blocks and the UI appears frozen.
+//
+// Job control is the discriminator. An interactive shell puts every foreground
+// command in its own process group, distinct from the session leader's own, so a
+// human's `git commit` always runs with pgrp != sid. A command handed a private
+// session is both session and process-group leader, so every process in it (git,
+// the hook script, us) sees pgrp == sid.
+//
+// Measured on Linux against lazygit 0.48 (sid == pgrp == the git pid, on a
+// second pty distinct from lazygit's own) and against interactive bash and
+// busybox sh (sid = the shell, pgrp = the git job). This shape follows from the
+// setsid a private controlling terminal requires, so unlike the pty's window
+// size — which lazygit presets to 80x24 in current master — it does not drift
+// with a client's rendering details.
+//
+// The known trade-off is `ssh -t host git commit` and `script -c`, which also
+// setsid onto a fresh pty but do forward input: those lose the prompt and fall
+// back to the non-interactive path (for commit linking, that means auto-link —
+// the prompt's own default).
+func ttyIsPrivateSession() bool {
+	sid, err := unix.Getsid(0)
+	if err != nil {
+		// Can't tell — fail open. This check may only ever suppress prompts we
+		// positively know are unusable.
+		return false
+	}
+	return sid == unix.Getpgrp()
+}

--- a/cmd/entire/cli/interactive/jobcontrol_unix_test.go
+++ b/cmd/entire/cli/interactive/jobcontrol_unix_test.go
@@ -1,0 +1,72 @@
+//go:build darwin || linux
+
+package interactive
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// envJobControlHelper makes the test binary re-exec itself as a helper that
+// reports ttyIsPrivateSession() from a process whose session/process-group shape
+// this test controls. The shapes are what matters, and a test can only set them
+// on a child, not on itself.
+const envJobControlHelper = "ENTIRE_TEST_JOBCONTROL_HELPER"
+
+// TestMain serves the helper mode described above before handing off to the
+// normal test run.
+func TestMain(m *testing.M) {
+	if os.Getenv(envJobControlHelper) != "" {
+		if ttyIsPrivateSession() {
+			os.Stdout.WriteString("true\n")
+		} else {
+			os.Stdout.WriteString("false\n")
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// runHelper re-execs the test binary with attr applied and returns what
+// ttyIsPrivateSession() reported there.
+func runHelper(t *testing.T, attr *syscall.SysProcAttr) string {
+	t.Helper()
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := exec.CommandContext(t.Context(), self)
+	cmd.Env = append(os.Environ(), envJobControlHelper+"=1")
+	cmd.SysProcAttr = attr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("helper: %v (output %q)", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// A process given its own session (what setsid + a fresh pty does, and what
+// lazygit's output-capturing `git commit` runs inside) is both session and
+// process-group leader, so it must report a private session.
+func TestTTYIsPrivateSession_OwnSessionIsPrivate(t *testing.T) {
+	t.Parallel()
+
+	if got := runHelper(t, &syscall.SysProcAttr{Setsid: true}); got != "true" {
+		t.Errorf("ttyIsPrivateSession() in a new session = %s; want true", got)
+	}
+}
+
+// A shell's job control puts each foreground command in its own process group
+// while the session leader stays the shell, so sid != pgrp. That is the shape a
+// human's `git commit` has, and it must stay promptable.
+func TestTTYIsPrivateSession_ShellJobShapeIsNotPrivate(t *testing.T) {
+	t.Parallel()
+
+	if got := runHelper(t, &syscall.SysProcAttr{Setpgid: true}); got != "false" {
+		t.Errorf("ttyIsPrivateSession() in a new process group = %s; want false", got)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/987
<!-- entire-trail-link-end -->

The raw-mode check in 508c438e3 assumed a TUI git client keeps the user's
terminal while running `git commit`. lazygit doesn't: it gives the command a
fresh pty in a new session and only renders what comes back. That pty opens
cleanly and sits in canonical mode, so the hook concluded it could prompt,
painted "Link this commit to session context?" into a terminal nobody reads,
and blocked the commit — lazygit froze. Reproduced with real lazygit 0.48 on
Linux driven through a pty, which is where the report came from.

Job control is the discriminator. An interactive shell puts each foreground
command in its own process group and stays session leader (sid != pgrp), while
a command handed a private session leads that session itself (sid == pgrp).
Measured against real lazygit (sid == pgrp == the git pid, on a pty distinct
from lazygit's own) and against interactive bash and busybox sh.

Scoped to git-hook context via MarkGitHookContext: one-shot invocations like
`ssh -t host entire enable` and `docker run -it … entire enable` share the
private-session shape but do forward keystrokes, so they keep prompting.

The pty's window size looked like an easier signal — 0x0 under lazygit 0.48 —
but lazygit master presets 80x24 to "avoid a zero-size pty", so it would have
broken on the next release. Session shape follows from the setsid a private
controlling terminal requires, so it doesn't drift with rendering details. The
raw-mode check stays as the layer for clients that reuse the user's terminal
rather than allocating one (gitui, tig).

End-to-end with a live agent session, real hooks and real lazygit: before, the
prompt painted into lazygit's pty and no commit was created; after, the commit
lands with its Entire-Checkpoint trailer auto-linked, while a human committing
in a real terminal still gets the prompt and can answer it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Entire-Checkpoint: 01KZBGWJP37Z5JFDH5W1HKH1JA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when commit-linking and other hook prompts run; misclassification could suppress prompts on ssh -t/script-style sessions (documented trade-off: auto-link default).
> 
> **Overview**
> Fixes **commits hanging in lazygit** (and similar clients) when Entire tried to prompt during git hooks on a **private PTY** the UI only displays—it never forwards keystrokes.
> 
> **`CanPromptInteractively()`** gains a new step (before the raw-mode `/dev/tty` check): when **`MarkGitHookContext()`** was set on the `entire hooks git` tree and **`ttyIsPrivateSession()`** reports `sid == pgrp` (Unix), prompting is disabled so hooks follow the **non-interactive default** (e.g. auto-link commits). Shell-driven `git commit` keeps `sid != pgrp` and still prompts. Direct CLI use is unchanged because hook context is not marked.
> 
> Adds **`githookcontext.go`**, **`jobcontrol_unix.go`** / stub for other OSes, re-exec tests for session shapes, and **CLAUDE.md** documentation for the updated precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a636839a22e24c9d727eb396c857d35712984a14. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->