### PR TITLE
fix(e2e): close original Codex session before resuming the same thread

### DIFF
--- a/e2e/agents/tmux.go
+++ b/e2e/agents/tmux.go
@@ -243,6 +243,29 @@ func (s *TmuxSession) Close() error {
 	return s.Terminate()
 }
 
+// Quit asks the foreground program to exit the way a user would — by sending
+// Ctrl+C — and waits for the process to actually exit. It sends Ctrl+C again
+// each poll because some TUIs (Codex among them) treat a single Ctrl+C as
+// "cancel the current turn" and need a second press to quit, and that gesture
+// is version-dependent. If the process has still not exited by timeout it falls
+// back to a hard kill: callers use Quit when they need the process gone (e.g.
+// to release a lock it holds) and must not hang on an agent that changed its
+// quit keybinding. Like Terminate, it does NOT run the OnClose cleanups, so a
+// caller that needs a registered resource torn down owns that itself.
+func (s *TmuxSession) Quit(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if s.IsPaneDead() {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return s.Terminate()
+		}
+		_ = s.SendKeys("C-c")
+		time.Sleep(pollInterval)
+	}
+}
+
 // Terminate kills the tmux session (and the process it runs) WITHOUT running
 // the registered OnClose cleanups. Use it when the process must die but a
 // resource it registered for teardown — e.g. an isolated HOME that a later

--- a/e2e/agents/tmux.go
+++ b/e2e/agents/tmux.go
@@ -240,6 +240,15 @@ func (s *TmuxSession) Close() error {
 	for _, fn := range s.cleanups {
 		fn()
 	}
+	return s.Terminate()
+}
+
+// Terminate kills the tmux session (and the process it runs) WITHOUT running
+// the registered OnClose cleanups. Use it when the process must die but a
+// resource it registered for teardown — e.g. an isolated HOME that a later
+// step in the same test still reads — has to outlive the process. Callers that
+// bypass Close this way own the surviving resource's cleanup themselves.
+func (s *TmuxSession) Terminate() error {
 	cmd := exec.Command("tmux", "kill-session", "-t", s.name)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/e2e/tests/codex_resume_test.go
+++ b/e2e/tests/codex_resume_test.go
@@ -47,6 +47,16 @@ func TestCodexResumeRestoredSessionWithSanitizedCompactedHistory(t *testing.T) {
 		testutil.WaitForSessionIdle(t, s.Dir, 15*time.Second)
 		testutil.WaitForCheckpoint(t, s, 30*time.Second)
 
+		// Close the original Codex process before resuming the same thread.
+		// Codex serialises writers per thread: "Only one app-server process can
+		// hold a paginated thread open for writing at a time. If another process
+		// already owns the thread, thread/resume ... fail[s] with JSON-RPC error
+		// -32600" (codex-rs/app-server/README.md). While the StartSession TUI is
+		// still alive it owns the writer, so the resume below aborts with
+		// "already has an active writer (code -32600)". Killing it releases the
+		// lock before the resume attaches.
+		require.NoError(t, codexSession.Close(), "close original Codex session before resume")
+
 		s.Git(t, "checkout", mainBranch)
 
 		out, err := entire.ResumeWithEnv(s.Dir, "feature", []string{"CODEX_HOME=" + codexSession.Home()})

--- a/e2e/tests/codex_resume_test.go
+++ b/e2e/tests/codex_resume_test.go
@@ -47,7 +47,7 @@ func TestCodexResumeRestoredSessionWithSanitizedCompactedHistory(t *testing.T) {
 		testutil.WaitForSessionIdle(t, s.Dir, 15*time.Second)
 		testutil.WaitForCheckpoint(t, s, 30*time.Second)
 
-		// Close the original Codex process before resuming the same thread.
+		// Kill the original Codex process before resuming the same thread.
 		// Codex serialises writers per thread: "Only one app-server process can
 		// hold a paginated thread open for writing at a time. If another process
 		// already owns the thread, thread/resume ... fail[s] with JSON-RPC error
@@ -55,7 +55,14 @@ func TestCodexResumeRestoredSessionWithSanitizedCompactedHistory(t *testing.T) {
 		// still alive it owns the writer, so the resume below aborts with
 		// "already has an active writer (code -32600)". Killing it releases the
 		// lock before the resume attaches.
-		require.NoError(t, codexSession.Close(), "close original Codex session before resume")
+		//
+		// Use Terminate, not Close: Close runs the OnClose cleanup that
+		// RemoveAll's this isolated CODEX_HOME, but the resume flow below still
+		// reads and restores rollouts under it. Terminate kills only the
+		// process, so we take over removing the home at test end.
+		home := codexSession.Home()
+		t.Cleanup(func() { _ = os.RemoveAll(home) })
+		require.NoError(t, codexSession.Terminate(), "terminate original Codex session before resume")
 
 		s.Git(t, "checkout", mainBranch)
 

--- a/e2e/tests/codex_resume_test.go
+++ b/e2e/tests/codex_resume_test.go
@@ -47,22 +47,22 @@ func TestCodexResumeRestoredSessionWithSanitizedCompactedHistory(t *testing.T) {
 		testutil.WaitForSessionIdle(t, s.Dir, 15*time.Second)
 		testutil.WaitForCheckpoint(t, s, 30*time.Second)
 
-		// Kill the original Codex process before resuming the same thread.
+		// Exit the original Codex session before resuming the same thread, the
+		// way a user would: send Ctrl+C and wait for the process to exit.
 		// Codex serialises writers per thread: "Only one app-server process can
 		// hold a paginated thread open for writing at a time. If another process
 		// already owns the thread, thread/resume ... fail[s] with JSON-RPC error
 		// -32600" (codex-rs/app-server/README.md). While the StartSession TUI is
 		// still alive it owns the writer, so the resume below aborts with
-		// "already has an active writer (code -32600)". Killing it releases the
-		// lock before the resume attaches.
+		// "already has an active writer (code -32600)". Quit releases the lock
+		// before the resume attaches (hard-killing only if Ctrl+C doesn't take).
 		//
-		// Use Terminate, not Close: Close runs the OnClose cleanup that
-		// RemoveAll's this isolated CODEX_HOME, but the resume flow below still
-		// reads and restores rollouts under it. Terminate kills only the
-		// process, so we take over removing the home at test end.
+		// Quit (like Terminate) skips the OnClose cleanup that RemoveAll's this
+		// isolated CODEX_HOME — the resume flow below still reads and restores
+		// rollouts under it — so we take over removing the home at test end.
 		home := codexSession.Home()
 		t.Cleanup(func() { _ = os.RemoveAll(home) })
-		require.NoError(t, codexSession.Terminate(), "terminate original Codex session before resume")
+		require.NoError(t, codexSession.Quit(15*time.Second), "quit original Codex session before resume")
 
 		s.Git(t, "checkout", mainBranch)
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/988
<!-- entire-trail-link-end -->

## Problem

`TestCodexResumeRestoredSessionWithSanitizedCompactedHistory` fails **deterministically** on `main` — not flaky. Both the initial run and the CI re-run fail, across two consecutive main runs:

- [run 31170781348 / e2e-tests (codex)](https://github.com/entireio/cli/actions/runs/31170781348/job/92841896785)
- [run 31168604362 / e2e-tests (codex)](https://github.com/entireio/cli/actions/runs/31168604362)

Error (test dies at `codex_resume_test.go:68` waiting for the `›` prompt because the codex process exited):

```
waiting for codex resumed prompt: process exited while waiting for "›"
thread/resume failed during TUI bootstrap: thread/resume failed:
thread <id> already has an active writer (code -32600)
```

## Root cause — validated, not a guess

The E2E job installs Codex **unpinned**: `npm install -g @openai/codex` (`.github/workflows/e2e.yml:84`, `e2e-isolated.yml:41`, `e2e-checkpoint-store.yml:103`, `e2e-checkpoints-v2.yml:68`). A new Codex release changed thread-resume semantics.

Recent Codex enforces a **single writer per thread**. From the OpenAI Codex app-server docs:

> "Only one app-server process can hold a paginated thread open for writing at a time. If another process already owns the thread, `thread/resume`, `thread/archive`, and `thread/delete` fail with JSON-RPC error `-32600`."

Source: https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md

The test starts a Codex TUI (`StartSession`) and **never closes it**, then resumes the **same** session id. While the original process is alive it owns the writer lock, so the resume aborts with `-32600`. The last passing codex-resume run predates the Codex release; every run since fails identically — consistent with an upstream agent change, not our code.

## Fix

Close the original Codex session after the checkpoint is captured and before the resume flow, releasing the writer lock so `codex resume` can attach. No production code change — the CLI is behaving correctly; the test just needed to stop keeping a second writer open.

## Follow-up (not in this PR)

Consider pinning `@openai/codex` to a known-good version in the E2E workflows so upstream agent releases can't silently break `main` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2e test-only change with no production code paths affected.
> 
> **Overview**
> Fixes a **deterministic** failure in `TestCodexResumeRestoredSessionWithSanitizedCompactedHistory` caused by newer Codex enforcing **one writer per thread**.
> 
> After the checkpoint is captured, the test now calls **`codexSession.Close()`** before `entire resume` and the follow-on `codex resume`. That tears down the original `StartSession` TUI so it no longer holds the thread writer lock, which otherwise makes `thread/resume` fail with **“already has an active writer (code -32600)”**. Inline comments document the Codex app-server constraint. **No production CLI changes**—only test lifecycle ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85eac74d6f7ce0420bd71fc06a000e84269991c4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->