### PR TITLE
test(checkpoint): failing repro for concurrent checkpoint-write lost update (#1917)

### DIFF
--- a/cmd/entire/cli/integration_test/concurrent_checkpoint_writers_test.go
+++ b/cmd/entire/cli/integration_test/concurrent_checkpoint_writers_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// stopHookCmd builds a Stop-hook subprocess for a session without running it,
+// so callers can start several concurrently.
+func stopHookCmd(env *TestEnv, sessionID, transcriptPath string) *exec.Cmd {
+	input, err := json.Marshal(map[string]string{
+		"session_id":      sessionID,
+		"transcript_path": transcriptPath,
+	})
+	if err != nil {
+		env.T.Fatalf("marshal stop input: %v", err)
+	}
+	cmd := exec.CommandContext(context.Background(), getTestBinary(), "hooks", agentClaudeCode, "stop")
+	cmd.Dir = env.RepoDir
+	cmd.Stdin = bytes.NewReader(input)
+	cmd.Env = append(testutil.GitIsolatedEnv(),
+		"ENTIRE_TEST_CLAUDE_PROJECT_DIR="+env.ClaudeProjectDir,
+	)
+	cmd.Env = append(cmd.Env, env.ExtraEnv...)
+	cmd.Env = append(cmd.Env, env.checkpointStoreEnv()...)
+	return cmd
+}
+
+// checkpointBlob reads a path inside a stored checkpoint, resolving the storage
+// topology per backend: a subtree of the shared v1 branch (git-branch) or the
+// root tree of the checkpoint's own ref (git-refs).
+func checkpointBlob(env *TestEnv, checkpointID, relPath string) (string, bool) {
+	env.T.Helper()
+	spec := paths.MetadataBranchName + ":" + id.CheckpointID(checkpointID).Path() + "/" + relPath
+	if env.usingGitRefs() {
+		spec = checkpointRefName(checkpointID) + ":" + relPath
+	}
+	cmd := exec.CommandContext(env.T.Context(), "git", "show", spec)
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
+}
+
+// TestConcurrent_TwoStopHooks_SameCheckpoint covers two agents working in one
+// worktree whose uncondensed work lands in a single commit. Post-commit
+// condenses both sessions into ONE checkpoint and records it as each session's
+// turn checkpoint, so when both turns end, both Stop hooks finalize the SAME
+// checkpoint's transcript.
+//
+// Nothing serializes them: each Stop hook holds only its own per-session flock
+// (stateLockPath is keyed by session ID), and the persistent store advances the
+// checkpoint ref with an unconditional SetReference — no compare-and-swap. Both
+// hooks read the same tip, build sibling commits, and the loser's finalize
+// becomes unreachable.
+//
+// The sequential subtest is the control: identical scenario, one Stop after the
+// other, both finalizes survive. Only the interleaving differs.
+func TestConcurrent_TwoStopHooks_SameCheckpoint(t *testing.T) {
+	t.Parallel()
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		t.Run("sequential", func(t *testing.T) {
+			t.Parallel()
+			runTwoStopHooksScenario(t, backend, false)
+		})
+		t.Run("concurrent", func(t *testing.T) {
+			t.Parallel()
+			runTwoStopHooksScenario(t, backend, true)
+		})
+	})
+}
+
+func runTwoStopHooksScenario(t *testing.T, backend string, concurrent bool) {
+	t.Helper()
+	const (
+		markerA = "MARKER-SESSION-A-AFTER-COMMIT"
+		markerB = "MARKER-SESSION-B-AFTER-COMMIT"
+	)
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = backend
+
+	sessA := env.NewSession()
+	sessB := env.NewSession()
+	if err := env.SimulateUserPromptSubmitWithTranscriptPath(sessA.ID, sessA.TranscriptPath); err != nil {
+		t.Fatalf("prompt A: %v", err)
+	}
+	if err := env.SimulateUserPromptSubmitWithTranscriptPath(sessB.ID, sessB.TranscriptPath); err != nil {
+		t.Fatalf("prompt B: %v", err)
+	}
+
+	// Each agent writes a file. The padding widens the finalize window
+	// (transcript redaction + blob writes) so the overlap is reliable rather
+	// than a hairline.
+	padding := strings.Repeat("// filler line to widen the write window\n", 400)
+	contentA := "package a\n" + padding
+	contentB := "package b\n" + padding
+	env.WriteFile("agent_a.go", contentA)
+	env.WriteFile("agent_b.go", contentB)
+	sessA.CreateTranscript("write file a", []FileChange{{Path: "agent_a.go", Content: contentA}})
+	sessB.CreateTranscript("write file b", []FileChange{{Path: "agent_b.go", Content: contentB}})
+
+	// One commit, condensing both sessions into a single checkpoint.
+	env.GitCommitWithShadowHooksAsAgent("add agent files", "agent_a.go", "agent_b.go")
+
+	checkpointID := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
+	if checkpointID == "" {
+		t.Fatal("commit has no Entire-Checkpoint trailer; scenario setup failed")
+	}
+
+	summaryJSON, ok := checkpointBlob(env, checkpointID, paths.MetadataFileName)
+	if !ok {
+		t.Fatalf("checkpoint %s not stored after post-commit", checkpointID)
+	}
+	var before struct {
+		Sessions []json.RawMessage `json:"sessions"`
+	}
+	if err := json.Unmarshal([]byte(summaryJSON), &before); err != nil {
+		t.Fatalf("parse checkpoint summary: %v", err)
+	}
+	t.Logf("checkpoint %s holds %d sessions after post-commit", checkpointID, len(before.Sessions))
+	if len(before.Sessions) < 2 {
+		t.Fatalf("expected a 2-session checkpoint, got %d — scenario setup failed", len(before.Sessions))
+	}
+
+	// Each agent keeps working after the commit, so each Stop-hook finalize has
+	// distinct new transcript content. The markers show which finalize landed.
+	sessA.TranscriptBuilder.AddAssistantMessage(markerA)
+	if err := sessA.TranscriptBuilder.WriteToFile(sessA.TranscriptPath); err != nil {
+		t.Fatalf("append marker A: %v", err)
+	}
+	sessB.TranscriptBuilder.AddAssistantMessage(markerB)
+	if err := sessB.TranscriptBuilder.WriteToFile(sessB.TranscriptPath); err != nil {
+		t.Fatalf("append marker B: %v", err)
+	}
+
+	cmdA := stopHookCmd(env, sessA.ID, sessA.TranscriptPath)
+	cmdB := stopHookCmd(env, sessB.ID, sessB.TranscriptPath)
+	var outA, outB []byte
+	var errA, errB error
+	if concurrent {
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		wg.Add(2)
+		go func() { defer wg.Done(); <-start; outA, errA = cmdA.CombinedOutput() }()
+		go func() { defer wg.Done(); <-start; outB, errB = cmdB.CombinedOutput() }()
+		close(start)
+		wg.Wait()
+	} else {
+		outA, errA = cmdA.CombinedOutput()
+		outB, errB = cmdB.CombinedOutput()
+	}
+	if errA != nil {
+		t.Fatalf("stop A failed: %v\n%s", errA, outA)
+	}
+	if errB != nil {
+		t.Fatalf("stop B failed: %v\n%s", errB, outB)
+	}
+
+	// Both hooks reported success, so both finalizes must be readable from the
+	// checkpoint the ref now points at.
+	var stored strings.Builder
+	for i := range before.Sessions {
+		content, found := checkpointBlob(env, checkpointID, fmt.Sprintf("%d/full.jsonl", i))
+		if !found {
+			t.Errorf("session %d transcript missing from stored checkpoint", i)
+			continue
+		}
+		stored.WriteString(content)
+	}
+	for name, marker := range map[string]string{"A": markerA, "B": markerB} {
+		if strings.Contains(stored.String(), marker) {
+			t.Logf("session %s: finalize landed", name)
+			continue
+		}
+		t.Errorf("LOST UPDATE: session %s's post-commit transcript content is absent from "+
+			"checkpoint %s — its Stop-hook finalize was silently clobbered by the concurrent one "+
+			"(both hooks exited 0)", name, checkpointID)
+	}
+}


### PR DESCRIPTION
Draft — **this PR is a reproduction, not a fix.** The concurrent subtests are
red on purpose, so CI will fail. It exists to make #1917 concrete and to pin
down which scenario is actually reachable.

## What it reproduces

Two agents working in one worktree, whose uncondensed work lands in a **single
commit**, end up sharing **one** checkpoint: post-commit condenses both
sessions into it and records it in each session's `TurnCheckpointIDs`. When
both turns end, both Stop hooks run `finalizeAllTurnCheckpoints` over that same
checkpoint.

Nothing serializes them:

- each Stop hook holds only its own per-session flock — `stateLockPath` is
  keyed by session ID, and these are legitimately *different* sessions;
- both persistent stores advance the checkpoint ref with an unconditional
  `Storer.SetReference` (`checkpoint/refs_store.go:206` for git-refs,
  `checkpoint/store.go:91` for git-branch) with no compare-and-swap against the
  tip they read.

Both hooks read the same tip, build sibling commits, and the last ref write
makes the other's finalize unreachable. Both hooks exit 0; nothing is logged.

## Results

Real hook subprocesses, `ForEachBackend` × sequential/concurrent. The two arms
run the identical scenario — only whether the Stop hooks start together differs.

| | concurrent | sequential (control) |
|---|---|---|
| `git-branch` | **FAIL 5/5** | PASS 5/5 |
| `git-refs` | **FAIL 5/5** | PASS 5/5 |

```
go test -tags integration ./cmd/entire/cli/integration_test \
  -run '^TestConcurrent_TwoStopHooks_SameCheckpoint$' -count=5 -v
```

## Caveats, stated plainly

- The 5/5 is **conditional on both hooks starting at the same instant**, which
  the test forces with a barrier. Real turn ends are independent, so the field
  rate is roughly *finalize duration ÷ spread between the two turn ends*. The
  test pads the transcript (400 filler lines) to widen the finalize window;
  real transcripts are larger, so the real window is wider than the tested one,
  not narrower.
- What this does establish: the scenario is built from ordinary operations, not
  a hand-authored interleave, and the loss is silent.
- The losing commit is unreachable **and un-reflogged** (go-git's
  `SetReference` writes no reflog), so it is gc-able garbage. The v1 reconcile
  path can't recover it either: `ReconcileDisconnectedMetadataRef` walks back
  from the local ref tip (`strategy/metadata_reconcile.go:170`). Per-checkpoint
  directories guarantee cherry-picks apply cleanly; they don't guarantee the
  commit still exists to cherry-pick. Reconcile handles divergence between two
  *reachable* tips — this destroys reachability inside one clone before any
  reconcile can observe it.

## Note on #1917 as filed

The reporter's scenario — a summary backfill racing an attribution backfill on
one checkpoint — is essentially unreachable in practice: those writers are
sequenced by the session lifecycle, and the only unscheduled one is
user-invoked `entire checkpoint explain --generate`, which runs after the fact.
The defect is real; the reachable path is this one.

Their proposed regression test also asserts the *buggy* behavior (it passes by
observing the loss). This one asserts the correct behavior, so it goes green
when fixed.

## Fix direction (not in this PR)

The ephemeral shadow-branch store already solved this exact shape:
`withShadowBranchFlock` + `casUpdateShadowBranchRef` + retry-from-a-fresh-parent
with jitter backoff and dangling-object cleanup (`checkpoint/shadow_ref.go`,
driven from `checkpoint/ephemeral.go:112`). The persistent stores never got the
same treatment. Two things worth stating for whoever picks it up:

- retry must **rebuild** the tree from the new tip, not re-point the commit it
  already built — re-pointing reintroduces the lost update;
- don't use go-git's `CheckAndSetReference` — see the rationale at
  `shadow_ref.go:65`: it doesn't interoperate with native git's `.lock` files,
  and these refs are touched by concurrent hook processes and the user's own git.

Tightening lock scoping alone cannot fix this instance, since the two writers
are legitimately different sessions touching one checkpoint.

Refs #1917

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; concurrent subtests are intentionally red and document expected failure until a store-level CAS fix lands.
> 
> **Overview**
> Adds integration coverage for **#1917**: two sessions sharing one post-commit checkpoint, each running a real Claude **Stop** hook subprocess when their turn ends.
> 
> The scenario builds a single commit that condenses both agents, then appends distinct post-commit transcript markers and runs Stop hooks **sequentially** (control) or **concurrently** (barrier-started). Helpers `stopHookCmd` and `checkpointBlob` support parallel subprocesses and both `git-branch` / `git-refs` backends via `ForEachBackend`.
> 
> Assertions require both markers in stored checkpoint transcripts after both hooks exit 0. The **concurrent** subtests are expected to **fail** today (silent lost update); sequential should pass. This is a reproduction PR, not a fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af59539f48227a0e91eaa31a34e2eaaf06dbb3df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->