### PR TITLE
refactor: gate the status cache centrally and hoist EnsureSetup

### DIFF
--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -96,6 +96,13 @@ func DispatchLifecycleEvent(ctx context.Context, ag agent.Agent, event *agent.Ev
 		}
 	}
 
+	// Memoize worktree status for the handlers whose window is provably stable.
+	// Centralized here rather than inside a handler so that no handler can opt
+	// itself in without the precondition being reviewed (see statusCacheSafe).
+	if statusCacheSafe(event.Type) {
+		ctx = gitrepo.WithStatusCache(ctx)
+	}
+
 	switch event.Type {
 	case agent.SessionStart:
 		return handleLifecycleSessionStart(ctx, ag, event)
@@ -117,6 +124,33 @@ func DispatchLifecycleEvent(ctx context.Context, ag agent.Agent, event *agent.Ev
 		return handleLifecycleToolUse(ctx, ag, event)
 	default:
 		return fmt.Errorf("unknown lifecycle event type: %d", event.Type)
+	}
+}
+
+// statusCacheSafe reports whether t's handler is guaranteed to neither write
+// tracked files nor stage anything for the duration of the handler, which is the
+// precondition for reusing one worktree status across it (see
+// gitrepo.WithStatusCache).
+//
+// This is a closed allowlist and must stay one. Post-agent handlers — TurnEnd,
+// SubagentEnd — run after the agent has edited files, and DetectFileChanges
+// there must observe those edits. Before adding an event, check that its handler
+// performs no tracked-file write between its first and last status read;
+// TurnStart only qualifies because EnsureSetup (which can rewrite the tracked
+// .entire/.gitignore) was hoisted above its first read.
+//
+// Every event is listed explicitly rather than folded into the default so the
+// exhaustive linter fails the build when a new EventType is added, forcing that
+// review to happen. The default stays as a belt-and-braces deny.
+func statusCacheSafe(t agent.EventType) bool {
+	switch t {
+	case agent.TurnStart:
+		return true
+	case agent.SessionStart, agent.TurnEnd, agent.Compaction, agent.SessionEnd,
+		agent.SubagentStart, agent.SubagentEnd, agent.ModelUpdate, agent.ToolUse:
+		return false
+	default:
+		return false
 	}
 }
 
@@ -550,16 +584,6 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 	// background lock holder can't stall the user's prompt (see the const doc).
 	ctx = strategy.WithSessionLockWait(ctx, turnStartSessionLockWait)
 
-	// Read the worktree status at most once for this hook. TurnStart runs before
-	// the agent acts, and it neither stages anything nor writes tracked files —
-	// only session metadata under .entire/ and refs under .git/ — so the status
-	// cannot change while this hook executes. Note the precondition is "no index
-	// writes and no tracked-file writes", not merely "nothing outside .git/":
-	// .git/index lives inside .git/ and staging does change reported status.
-	// Without the cache both CapturePrePromptState and the strategy's prompt
-	// attribution pay for a full go-git worktree walk.
-	ctx = gitrepo.WithStatusCache(ctx)
-
 	// Fill model from hint file if the agent didn't provide it on this hook
 	if event.Model == "" {
 		if hint := strategy.LoadModelHint(ctx, sessionID); hint != "" {
@@ -568,6 +592,20 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 				slog.String("model", hint))
 		}
 	}
+
+	// Strategy setup runs before the first worktree-status read below.
+	// EnsureEntireGitignore can append entries to .entire/.gitignore, which is
+	// tracked, and the dispatcher has already installed a status cache for this
+	// event (see statusCacheSafe). The cache fills on first read rather than at
+	// install, so doing this write first keeps every cached read consistent with
+	// the worktree. Moving this back below CapturePrePromptState would reintroduce
+	// a tracked-file write between two cached reads.
+	_, setupSpan := perf.Start(ctx, "ensure_setup")
+	if err := strategy.EnsureSetup(ctx); err != nil {
+		logging.Warn(logCtx, "failed to ensure strategy setup",
+			slog.String("error", err.Error()))
+	}
+	setupSpan.End()
 
 	// Capture pre-prompt state (including transcript position via TranscriptAnalyzer)
 	_, captureSpan := perf.Start(ctx, "capture_pre_prompt_state")
@@ -601,13 +639,8 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 		}
 	}
 
-	// Ensure strategy setup and initialize session
+	// Initialize session (setup already ran above, before the first status read)
 	_, initSpan := perf.Start(ctx, "init_session")
-	if err := strategy.EnsureSetup(ctx); err != nil {
-		logging.Warn(logCtx, "failed to ensure strategy setup",
-			slog.String("error", err.Error()))
-	}
-
 	strat := GetStrategy(ctx)
 	if err := strat.InitializeSession(ctx, sessionID, ag.Type(), event.SessionRef, event.Prompt, event.Model); err != nil {
 		logging.Warn(logCtx, "failed to initialize session state",

--- a/cmd/entire/cli/lifecycle_statuscache_test.go
+++ b/cmd/entire/cli/lifecycle_statuscache_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// TestStatusCacheSafe_ClosedAllowlist pins which lifecycle events may reuse a
+// single worktree status. Adding an event here without confirming its handler
+// performs no tracked-file write between its first and last status read produces
+// silently stale checkpoints, so this test is deliberately exhaustive: every
+// EventType is listed, and a new one fails to compile into the table unnoticed
+// only if someone also edits this test.
+func TestStatusCacheSafe_ClosedAllowlist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		event agent.EventType
+		want  bool
+		why   string
+	}{
+		{agent.TurnStart, true, "runs before the agent acts; EnsureSetup hoisted above the first status read"},
+		{agent.SessionStart, false, "no second status read to share; not reviewed for tracked-file writes"},
+		{agent.TurnEnd, false, "post-agent: DetectFileChanges must observe the agent's edits"},
+		{agent.Compaction, false, "shares TurnEnd's save path"},
+		{agent.SessionEnd, false, "post-agent"},
+		{agent.SubagentStart, false, "not reviewed for tracked-file writes"},
+		{agent.SubagentEnd, false, "post-agent: DetectFileChanges must observe the subagent's edits"},
+		{agent.ModelUpdate, false, "no status read"},
+		{agent.ToolUse, false, "mid-turn: the agent is actively editing files"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.event.String(), func(t *testing.T) {
+			t.Parallel()
+
+			if got := statusCacheSafe(tt.event); got != tt.want {
+				t.Errorf("statusCacheSafe(%s) = %v, want %v (%s)",
+					tt.event, got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestStatusCacheSafe_UnknownEventDeniedByDefault guards the default branch: an
+// EventType added to the agent package but not considered here must not silently
+// inherit caching.
+func TestStatusCacheSafe_UnknownEventDeniedByDefault(t *testing.T) {
+	t.Parallel()
+
+	// Well past the last defined constant.
+	if statusCacheSafe(agent.EventType(9999)) {
+		t.Error("statusCacheSafe(unknown) = true, want false: new events must be opt-in")
+	}
+}

--- a/cmd/entire/cli/lifecycle_statuscache_test.go
+++ b/cmd/entire/cli/lifecycle_statuscache_test.go
@@ -7,11 +7,13 @@ import (
 )
 
 // TestStatusCacheSafe_ClosedAllowlist pins which lifecycle events may reuse a
-// single worktree status. Adding an event here without confirming its handler
-// performs no tracked-file write between its first and last status read produces
-// silently stale checkpoints, so this test is deliberately exhaustive: every
-// EventType is listed, and a new one fails to compile into the table unnoticed
-// only if someone also edits this test.
+// single worktree status. Allowing an event whose handler writes a tracked file
+// between its first and last status read produces silently stale checkpoints.
+//
+// This table is a manual enumeration, not a compile-time exhaustive one: adding
+// a constant to the agent package does not break this test. The exhaustive
+// linter on statusCacheSafe's switch is what forces a new EventType to be
+// classified — update this table alongside that switch.
 func TestStatusCacheSafe_ClosedAllowlist(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/990
<!-- entire-trail-link-end -->

Follow-up to #1911, which merged before this landed. Addresses the trail finding on the cache install site, plus the review concern that `WithStatusCache` is exported with only a doc comment guarding its precondition.

## The finding is correct

Verified end to end:

- `.entire/.gitignore` **is tracked** (`git ls-files` lists it)
- `EnsureSetup` → `EnsureEntireGitignore` rewrites it via `os.WriteFile` when a required entry is missing — fresh clone, or first run after an upgrade adds one
- It ran **between** the read that populated the cache and the read that reused it: install → `CapturePrePromptState` (populate) → **`EnsureSetup` (write)** → `InitializeSession` (stale read)

That is a tracked-file write inside the window, exactly what the precondition forbids.

## It could not produce a wrong result

`.entire/.gitignore` is the only tracked file `EnsureSetup` writes — `InitSettings` is read-only, `InstallGitHook` writes `.git/hooks/*`, `EnsurePrimaryRef` writes refs. And both consumers of the cached status drop `.entire/` paths:

- `getUntrackedFilesForState` → `shouldIgnoreSessionTrackingPath(".entire/.gitignore")` returns **true** (verified by running it)
- `calculatePromptAttributionAtStart` → explicit `strings.HasPrefix(filePath, ".entire/")` skip

So it was a latent violation held harmless by a coincidence in two unrelated filter lists — not a live bug. It becomes real if a required entry outside `.entire/` is ever added, or either filter is relaxed.

## Changes

Rather than document the exception, make the invariant true.

**1. Hoist `EnsureSetup` above `CapturePrePromptState`.** The cache fills on first *read*, not at install, so doing the write before any read keeps every cached read consistent. Nothing between the two positions feeds `EnsureSetup`, and running setup before capture is the more natural order anyway. It gets its own `ensure_setup` perf span; no test asserted the old span boundary.

**2. Move the cache install into `DispatchLifecycleEvent`** behind `statusCacheSafe(event.Type)`, so no handler can opt itself in without the precondition being reviewed.

Note this makes the window *wider*, not narrower — which is precisely why change 1 is required alongside it. Centralizing alone would have left the `EnsureSetup` write inside the window.

**3. List every `EventType` explicitly** in that switch instead of folding them into `default`. The `exhaustive` linter then **fails the build** when a new event type is added, forcing the review to happen. The `default` stays as a belt-and-braces deny.

**4. Tests** pinning the allowlist (with a rationale per event) and the default-deny for unknown event types.

## Test plan

- [x] `mise run fmt && mise run lint` clean
- [x] `mise run test:ci` green — unit + integration under `-race`, canary 60 + 4
- [x] Hook unchanged at 0.90s; second status read still a 0.011s cache hit
- [x] Rebased onto current `main` and re-verified after #1911 and #1919 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0afa73622400cc8f22727c1da9492ce0e2b089c4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->