### PR TITLE
fix(checkpoint): preserve concurrent persistent ref updates

### DIFF
--- a/cmd/entire/cli/checkpoint/migrate.go
+++ b/cmd/entire/cli/checkpoint/migrate.go
@@ -81,31 +81,18 @@ func MigrateBranchToRefs(ctx context.Context, repo *git.Repository, dryRun bool)
 			return fmt.Errorf("ref name for checkpoint %s: %w", cid, err)
 		}
 
-		// The existing ref drives the idempotency check and the new commit's
-		// parent. refBase separates three cases we must not conflate:
-		//   - no ref yet (nil error, zero hash): a brand-new orphan.
-		//   - ref present but its commit object is missing (corrupt or pruned):
-		//     treat as absent and re-import as an orphan rather than parenting on
-		//     a bad hash, which would corrupt the commit graph for fetch+replay.
-		//   - a genuine read failure (transient IO, a concurrent repack): do NOT
-		//     clobber a possibly-valid ref with an orphan; abort this checkpoint
-		//     so an idempotent re-run can retry once the repo is readable again.
-		parent, _, err := refsStore.refBase(cid)
-		switch {
-		case err == nil:
-			// parent is the ref tip, or zero when the ref is absent.
-		case errors.Is(err, plumbing.ErrObjectNotFound):
-			parent = plumbing.ZeroHash
-		default:
-			return fmt.Errorf("resolve existing ref for checkpoint %s: %w", cid, err)
-		}
-		// This snapshot is already imported when it appears anywhere on the
-		// ref's first-parent chain: the ref may have advanced past it through
-		// refs-store writes, and re-wrapping the old snapshot would regress the
-		// tip.
-		alreadyImported := treeInRefHistory(repo, parent, migratedTree)
-
 		if dryRun {
+			parent, _, err := refsStore.refBase(cid)
+			switch {
+			case err == nil:
+				// parent is the ref tip, or zero when the ref is absent.
+			case errors.Is(err, plumbing.ErrObjectNotFound):
+				parent = plumbing.ZeroHash
+			default:
+				return fmt.Errorf("resolve existing ref for checkpoint %s: %w", cid, err)
+			}
+			alreadyImported := treeInRefHistory(repo, parent, migratedTree)
+
 			// Report only what a real run would newly write; an already-imported
 			// checkpoint is a skip, not a would-migrate. No refs or objects are
 			// enqueued or written on this path.
@@ -117,36 +104,56 @@ func MigrateBranchToRefs(ctx context.Context, repo *git.Repository, dryRun bool)
 			return nil
 		}
 
-		if alreadyImported {
-			// The snapshot is on the ref, but a prior run may have written the
-			// ref and then failed before enqueuing it (an Enqueue error, or a
-			// crash between setRef and Enqueue), leaving it queued for a push
-			// that never comes — and every later run would skip it here. Enqueue
-			// unconditionally so the "queued for push" contract survives a
-			// partial earlier run; duplicates collapse on Drain and an
-			// already-pushed ref is a no-op on the next push.
-			if err := queue.Enqueue(refName); err != nil {
-				return fmt.Errorf("enqueue checkpoint %s for push: %w", cid, err)
+		migrated := false
+		if err := updatePersistentRef(ctx, repo, refName, func() (plumbing.Hash, plumbing.Hash, error) {
+			// Re-read the parent and idempotency state on every CAS retry so a
+			// migration commit never overwrites a concurrently advanced ref.
+			parent, _, baseErr := refsStore.refBase(cid)
+			expected := parent
+			switch {
+			case baseErr == nil:
+				// parent is the ref tip, or zero when the ref is absent.
+			case errors.Is(baseErr, plumbing.ErrObjectNotFound):
+				// Repair an unreadable ref with an orphan commit, but still CAS
+				// against the actual ref hash so a concurrent repair wins cleanly.
+				ref, refErr := repo.Reference(refName, true)
+				if refErr != nil {
+					return plumbing.ZeroHash, plumbing.ZeroHash,
+						fmt.Errorf("resolve unreadable ref %s: %w", refName, refErr)
+				}
+				expected = ref.Hash()
+				parent = plumbing.ZeroHash
+			default:
+				return plumbing.ZeroHash, plumbing.ZeroHash,
+					fmt.Errorf("resolve existing ref for checkpoint %s: %w", cid, baseErr)
 			}
-			result.Skipped++
-			return nil
-		}
+			if treeInRefHistory(repo, parent, migratedTree) {
+				migrated = false
+				return parent, expected, nil
+			}
 
-		msg := fmt.Sprintf("Import checkpoint %s (migrated from git-branch)", cid)
-		commitHash, err := CreateCommit(ctx, repo, migratedTree, parent, msg, authorName, authorEmail)
-		if err != nil {
-			return fmt.Errorf("commit checkpoint %s: %w", cid, err)
-		}
-		if err := refsStore.setRef(ctx, cid, commitHash); err != nil {
+			msg := fmt.Sprintf("Import checkpoint %s (migrated from git-branch)", cid)
+			commitHash, commitErr := CreateCommit(ctx, repo, migratedTree, parent, msg, authorName, authorEmail)
+			if commitErr != nil {
+				return plumbing.ZeroHash, plumbing.ZeroHash,
+					fmt.Errorf("commit checkpoint %s: %w", cid, commitErr)
+			}
+			migrated = true
+			return commitHash, expected, nil
+		}); err != nil {
 			return fmt.Errorf("set ref for checkpoint %s: %w", cid, err)
 		}
-		// setRef's own enqueue is best-effort (a condensation write must not
-		// fail on it); the migration's queued-for-push contract needs a
-		// guaranteed one. Duplicates collapse on Drain.
+
+		// The migration's queued-for-push contract is guaranteed for both new
+		// and already-imported refs. Duplicates collapse on Drain.
 		if err := queue.Enqueue(refName); err != nil {
 			return fmt.Errorf("enqueue checkpoint %s for push: %w", cid, err)
 		}
-		result.Migrated = append(result.Migrated, cid)
+		if migrated {
+			result.Migrated = append(result.Migrated, cid)
+		} else {
+			result.Skipped++
+		}
 		return nil
 	})
 	if walkErr != nil {

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -80,40 +80,30 @@ func (s *GitStore) writeSession(ctx context.Context, opts WriteOptions) error {
 		return fmt.Errorf("failed to ensure sessions branch: %w", err)
 	}
 
-	// Get branch ref and root tree hash (O(1), no flatten)
-	parentHash, rootTreeHash, err := s.getSessionsBranchRef()
-	if err != nil {
-		return err
-	}
+	return s.updatePrimaryRef(ctx, func(parentHash, rootTreeHash plumbing.Hash) (plumbing.Hash, error) {
+		// Build the checkpoint subtree from the fresh branch tip on every retry,
+		// then splice it back into that same root tree.
+		existing, err := s.subtreeObjAt(rootTreeHash, opts.CheckpointID.Path())
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
+		checkpointSubtree, err := s.applySessionWrite(ctx, opts, existing, opts.CheckpointID.Path()+"/")
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
 
-	// Build the new checkpoint subtree from its current state on the v1 branch,
-	// then splice it back at the shard path. basePath keeps the v1 sharded layout
-	// so stored session-file pointers stay /<shard>/<id>/<n>/... as before.
-	existing, err := s.subtreeObjAt(rootTreeHash, opts.CheckpointID.Path())
-	if err != nil {
-		return err
-	}
-	checkpointSubtree, err := s.applySessionWrite(ctx, opts, existing, opts.CheckpointID.Path()+"/")
-	if err != nil {
-		return err
-	}
+		newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, opts.CheckpointID, checkpointSubtree)
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
+		newTreeHash, err = s.maybeMergeVercelConfig(ctx, newTreeHash)
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
 
-	newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, opts.CheckpointID, checkpointSubtree)
-	if err != nil {
-		return err
-	}
-	newTreeHash, err = s.maybeMergeVercelConfig(ctx, newTreeHash)
-	if err != nil {
-		return err
-	}
-
-	commitMsg := s.buildCommitMessage(opts)
-	newCommitHash, err := CreateCommit(ctx, s.repo, newTreeHash, parentHash, commitMsg, opts.AuthorName, opts.AuthorEmail)
-	if err != nil {
-		return err
-	}
-
-	return s.setPrimaryRef(newCommitHash)
+		commitMsg := s.buildCommitMessage(opts)
+		return CreateCommit(ctx, s.repo, newTreeHash, parentHash, commitMsg, opts.AuthorName, opts.AuthorEmail)
+	})
 }
 
 // subtreeObjAt returns the tree object for one checkpoint's subtree within a root
@@ -855,33 +845,25 @@ func (s *GitStore) backfillAttribution(ctx context.Context, checkpointID id.Chec
 		return err
 	}
 
-	parentHash, rootTreeHash, err := s.getSessionsBranchRef()
-	if err != nil {
-		return err
-	}
+	return s.updatePrimaryRef(ctx, func(parentHash, rootTreeHash plumbing.Hash) (plumbing.Hash, error) {
+		existing, err := s.subtreeObjAt(rootTreeHash, checkpointID.Path())
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
+		checkpointSubtree, err := s.applyAttributionBackfill(ctx, existing, checkpointID.Path()+"/", combinedAttribution)
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
 
-	existing, err := s.subtreeObjAt(rootTreeHash, checkpointID.Path())
-	if err != nil {
-		return err
-	}
-	checkpointSubtree, err := s.applyAttributionBackfill(ctx, existing, checkpointID.Path()+"/", combinedAttribution)
-	if err != nil {
-		return err
-	}
+		newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, checkpointID, checkpointSubtree)
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
 
-	newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, checkpointID, checkpointSubtree)
-	if err != nil {
-		return err
-	}
-
-	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
-	commitMsg := fmt.Sprintf("Update checkpoint summary for %s", checkpointID)
-	newCommitHash, err := CreateCommit(ctx, s.repo, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
-	if err != nil {
-		return err
-	}
-
-	return s.setPrimaryRef(newCommitHash)
+		authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+		commitMsg := fmt.Sprintf("Update checkpoint summary for %s", checkpointID)
+		return CreateCommit(ctx, s.repo, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
+	})
 }
 
 // findSessionIndex returns the index of an existing session with the given ID,
@@ -1721,34 +1703,25 @@ func (s *GitStore) backfillSummary(ctx context.Context, checkpointID id.Checkpoi
 		return err
 	}
 
-	// Get branch ref and root tree hash (O(1), no flatten)
-	parentHash, rootTreeHash, err := s.getSessionsBranchRef()
-	if err != nil {
-		return err
-	}
+	return s.updatePrimaryRef(ctx, func(parentHash, rootTreeHash plumbing.Hash) (plumbing.Hash, error) {
+		existing, err := s.subtreeObjAt(rootTreeHash, checkpointID.Path())
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
+		checkpointSubtree, sessionID, err := s.applySummaryBackfill(ctx, existing, checkpointID.Path()+"/", summary)
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
 
-	existing, err := s.subtreeObjAt(rootTreeHash, checkpointID.Path())
-	if err != nil {
-		return err
-	}
-	checkpointSubtree, sessionID, err := s.applySummaryBackfill(ctx, existing, checkpointID.Path()+"/", summary)
-	if err != nil {
-		return err
-	}
+		newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, checkpointID, checkpointSubtree)
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
 
-	newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, checkpointID, checkpointSubtree)
-	if err != nil {
-		return err
-	}
-
-	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
-	commitMsg := fmt.Sprintf("Update summary for checkpoint %s (session: %s)", checkpointID, sessionID)
-	newCommitHash, err := CreateCommit(ctx, s.repo, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
-	if err != nil {
-		return err
-	}
-
-	return s.setPrimaryRef(newCommitHash)
+		authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+		commitMsg := fmt.Sprintf("Update summary for checkpoint %s (session: %s)", checkpointID, sessionID)
+		return CreateCommit(ctx, s.repo, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
+	})
 }
 
 // backfillTranscript replaces the transcript, prompts, and context for an existing
@@ -1772,38 +1745,29 @@ func (s *GitStore) backfillTranscript(ctx context.Context, opts UpdateOptions) e
 		return err
 	}
 
-	// Get branch ref and root tree hash (O(1), no flatten)
-	parentHash, rootTreeHash, err := s.getSessionsBranchRef()
-	if err != nil {
-		return err
-	}
+	return s.updatePrimaryRef(ctx, func(parentHash, rootTreeHash plumbing.Hash) (plumbing.Hash, error) {
+		existing, err := s.subtreeObjAt(rootTreeHash, opts.CheckpointID.Path())
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
+		checkpointSubtree, err := s.applyTranscriptBackfill(ctx, opts, existing, opts.CheckpointID.Path()+"/")
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
 
-	existing, err := s.subtreeObjAt(rootTreeHash, opts.CheckpointID.Path())
-	if err != nil {
-		return err
-	}
-	checkpointSubtree, err := s.applyTranscriptBackfill(ctx, opts, existing, opts.CheckpointID.Path()+"/")
-	if err != nil {
-		return err
-	}
+		newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, opts.CheckpointID, checkpointSubtree)
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
+		newTreeHash, err = s.maybeMergeVercelConfig(ctx, newTreeHash)
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
 
-	newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, opts.CheckpointID, checkpointSubtree)
-	if err != nil {
-		return err
-	}
-	newTreeHash, err = s.maybeMergeVercelConfig(ctx, newTreeHash)
-	if err != nil {
-		return err
-	}
-
-	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
-	commitMsg := fmt.Sprintf("Finalize transcript for Checkpoint: %s", opts.CheckpointID)
-	newCommitHash, err := CreateCommit(ctx, s.repo, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
-	if err != nil {
-		return err
-	}
-
-	return s.setPrimaryRef(newCommitHash)
+		authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+		commitMsg := fmt.Sprintf("Finalize transcript for Checkpoint: %s", opts.CheckpointID)
+		return CreateCommit(ctx, s.repo, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
+	})
 }
 
 // updateSessionMetadata reads the session metadata blob from entries, applies
@@ -2156,23 +2120,32 @@ func (s *GitStore) ensureSessionsBranch(ctx context.Context) error {
 		return fmt.Errorf("failed to check sessions branch: %w", err)
 	}
 
-	// Create orphan branch with empty tree
-	emptyTreeHash, err := BuildTreeFromEntries(ctx, s.repo, make(map[string]object.TreeEntry))
-	if err != nil {
-		return err
-	}
-	emptyTreeHash, err = s.maybeMergeVercelConfig(ctx, emptyTreeHash)
-	if err != nil {
-		return err
-	}
+	return updatePersistentRef(ctx, s.repo, s.refs.Primary, func() (plumbing.Hash, plumbing.Hash, error) {
+		// Another process may have initialized the branch before this callback
+		// acquired the ref lock or between CAS retries.
+		if ref, refErr := s.repo.Reference(s.refs.Primary, true); refErr == nil {
+			return ref.Hash(), ref.Hash(), nil
+		} else if !errors.Is(refErr, plumbing.ErrReferenceNotFound) {
+			return plumbing.ZeroHash, plumbing.ZeroHash,
+				fmt.Errorf("failed to check sessions branch: %w", refErr)
+		}
 
-	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
-	commitHash, err := CreateCommit(ctx, s.repo, emptyTreeHash, plumbing.ZeroHash, "Initialize sessions branch", authorName, authorEmail)
-	if err != nil {
-		return err
-	}
+		emptyTreeHash, buildErr := BuildTreeFromEntries(ctx, s.repo, make(map[string]object.TreeEntry))
+		if buildErr != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, buildErr
+		}
+		emptyTreeHash, buildErr = s.maybeMergeVercelConfig(ctx, emptyTreeHash)
+		if buildErr != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, buildErr
+		}
 
-	return s.setPrimaryRef(commitHash)
+		authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+		commitHash, buildErr := CreateCommit(ctx, s.repo, emptyTreeHash, plumbing.ZeroHash, "Initialize sessions branch", authorName, authorEmail)
+		if buildErr != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, buildErr
+		}
+		return commitHash, plumbing.ZeroHash, nil
+	})
 }
 
 func (s *GitStore) maybeMergeVercelConfig(ctx context.Context, rootTreeHash plumbing.Hash) (plumbing.Hash, error) {

--- a/cmd/entire/cli/checkpoint/persistent_ref_update.go
+++ b/cmd/entire/cli/checkpoint/persistent_ref_update.go
@@ -68,12 +68,12 @@ func persistentRefLockPath(commonDir string, refName plumbing.ReferenceName) (st
 	return filepath.Join(lockDir, safe+".lock"), nil
 }
 
-func withPersistentRefFlock(commonDir string, refName plumbing.ReferenceName, fn func() error) error {
+func withPersistentRefFlock(ctx context.Context, commonDir string, refName plumbing.ReferenceName, fn func() error) error {
 	path, err := persistentRefLockPath(commonDir, refName)
 	if err != nil {
 		return err
 	}
-	release, err := flock.Acquire(path)
+	release, err := flock.AcquireContext(ctx, path)
 	if err != nil {
 		return fmt.Errorf("acquire persistent ref flock %s: %w", refName, err)
 	}
@@ -90,7 +90,7 @@ func updatePersistentRef(ctx context.Context, repo *git.Repository, refName plum
 		return fmt.Errorf("resolve repository directories: %w", err)
 	}
 
-	return withPersistentRefFlock(commonDir, refName, func() error {
+	return withPersistentRefFlock(ctx, commonDir, refName, func() error {
 		for attempt := range shadowRefMaxRetries {
 			newHash, expectedHash, buildErr := build()
 			if buildErr != nil {

--- a/cmd/entire/cli/checkpoint/persistent_ref_update.go
+++ b/cmd/entire/cli/checkpoint/persistent_ref_update.go
@@ -1,0 +1,123 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+type persistentRefBuilder func() (newHash, expectedHash plumbing.Hash, err error)
+
+func repositoryDirs(ctx context.Context, repo *git.Repository) (worktreeRoot, commonDir string, err error) {
+	wt, err := repo.Worktree()
+	if err != nil {
+		return "", "", fmt.Errorf("open worktree: %w", err)
+	}
+	worktreeRoot = wt.Filesystem().Root()
+	if worktreeRoot == "" {
+		return "", "", errors.New("repository worktree filesystem has no root path")
+	}
+	commonDir, err = resolveGitCommonDir(ctx, repo)
+	if err != nil {
+		return "", "", err
+	}
+	return worktreeRoot, commonDir, nil
+}
+
+// casUpdateRef atomically updates refName through native Git's lock protocol.
+// Pass ZeroHash as expectedHash to require that the ref does not exist.
+func casUpdateRef(ctx context.Context, repoRoot string, refName plumbing.ReferenceName, newHash, expectedHash plumbing.Hash) error {
+	newValue := newHash.String()
+	oldValue := strings.Repeat("0", newHash.HexSize())
+	if expectedHash != plumbing.ZeroHash {
+		oldValue = expectedHash.String()
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "update-ref", refName.String(), newValue, oldValue)
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	out := string(output)
+	if strings.Contains(out, "cannot lock ref") || strings.Contains(out, "but expected") {
+		return ErrShadowRefBusy
+	}
+	return fmt.Errorf("git update-ref %s: %s: %w", refName, strings.TrimSpace(out), err)
+}
+
+func persistentRefLockPath(commonDir string, refName plumbing.ReferenceName) (string, error) {
+	lockDir := filepath.Join(commonDir, "entire-persistent-ref-locks")
+	if err := os.MkdirAll(lockDir, 0o750); err != nil {
+		return "", fmt.Errorf("create persistent ref lock directory: %w", err)
+	}
+	safe := strings.NewReplacer("/", "_", "\\", "_", ":", "_").Replace(refName.String())
+	return filepath.Join(lockDir, safe+".lock"), nil
+}
+
+func withPersistentRefFlock(commonDir string, refName plumbing.ReferenceName, fn func() error) error {
+	path, err := persistentRefLockPath(commonDir, refName)
+	if err != nil {
+		return err
+	}
+	release, err := flock.Acquire(path)
+	if err != nil {
+		return fmt.Errorf("acquire persistent ref flock %s: %w", refName, err)
+	}
+	defer release()
+	return fn()
+}
+
+// updatePersistentRef serializes Entire writers for one ref and retains a CAS
+// retry for native Git or other external writers. build runs again after every
+// conflict, so each retry reconstructs its tree and commit from the fresh tip.
+func updatePersistentRef(ctx context.Context, repo *git.Repository, refName plumbing.ReferenceName, build persistentRefBuilder) error {
+	repoRoot, commonDir, err := repositoryDirs(ctx, repo)
+	if err != nil {
+		return fmt.Errorf("resolve repository directories: %w", err)
+	}
+
+	return withPersistentRefFlock(commonDir, refName, func() error {
+		for attempt := range shadowRefMaxRetries {
+			newHash, expectedHash, buildErr := build()
+			if buildErr != nil {
+				return buildErr
+			}
+
+			refErr := casUpdateRef(ctx, repoRoot, refName, newHash, expectedHash)
+			if refErr == nil {
+				return nil
+			}
+			if newHash != expectedHash {
+				tryDeleteLooseObject(commonDir, newHash)
+			}
+			if !errors.Is(refErr, ErrShadowRefBusy) {
+				return fmt.Errorf("update persistent ref %s: %w", refName, refErr)
+			}
+
+			if backoffErr := shadowRefBackoff(ctx, attempt); backoffErr != nil {
+				return backoffErr
+			}
+		}
+
+		logging.Warn(logging.WithComponent(ctx, "checkpoint"),
+			"persistent ref CAS retry budget exhausted",
+			slog.String("ref", refName.String()),
+			slog.Int("retries", shadowRefMaxRetries),
+		)
+		return fmt.Errorf("failed to update persistent ref %s after %d CAS retries: %w", refName, shadowRefMaxRetries, ErrShadowRefBusy)
+	})
+}

--- a/cmd/entire/cli/checkpoint/persistent_ref_update.go
+++ b/cmd/entire/cli/checkpoint/persistent_ref_update.go
@@ -101,11 +101,11 @@ func updatePersistentRef(ctx context.Context, repo *git.Repository, refName plum
 			if refErr == nil {
 				return nil
 			}
-			if newHash != expectedHash {
-				tryDeleteLooseObject(commonDir, newHash)
-			}
 			if !errors.Is(refErr, ErrShadowRefBusy) {
 				return fmt.Errorf("update persistent ref %s: %w", refName, refErr)
+			}
+			if newHash != expectedHash {
+				tryDeleteLooseObject(commonDir, newHash)
 			}
 
 			if backoffErr := shadowRefBackoff(ctx, attempt); backoffErr != nil {

--- a/cmd/entire/cli/checkpoint/persistent_ref_update_test.go
+++ b/cmd/entire/cli/checkpoint/persistent_ref_update_test.go
@@ -4,12 +4,40 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
 )
+
+func TestUpdatePersistentRef_StopsWaitingWhenContextDeadlineExpires(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	refName := plumbing.ReferenceName("refs/entire/test-deadline")
+
+	_, commonDir, err := repositoryDirs(context.Background(), repo)
+	require.NoError(t, err)
+	lockPath, err := persistentRefLockPath(commonDir, refName)
+	require.NoError(t, err)
+	release, err := flock.Acquire(lockPath)
+	require.NoError(t, err)
+	t.Cleanup(release)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	buildCalled := false
+	err = updatePersistentRef(ctx, repo, refName, func() (plumbing.Hash, plumbing.Hash, error) {
+		buildCalled = true
+		return plumbing.ZeroHash, plumbing.ZeroHash, nil
+	})
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.False(t, buildCalled, "the ref builder must not run without the lock")
+}
 
 func TestUpdatePersistentRef_RebuildsAfterCASConflict(t *testing.T) {
 	t.Parallel()
@@ -17,13 +45,15 @@ func TestUpdatePersistentRef_RebuildsAfterCASConflict(t *testing.T) {
 	repo, initial := setupBranchTestRepo(t)
 	refName := plumbing.ReferenceName("refs/entire/test-cas")
 	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, initial)))
+	repoRoot, _, err := repositoryDirs(ctx, repo)
+	require.NoError(t, err)
 
 	var (
 		calls       int
 		seenParents []plumbing.Hash
 		externalTip plumbing.Hash
 	)
-	err := updatePersistentRef(ctx, repo, refName, func() (plumbing.Hash, plumbing.Hash, error) {
+	err = updatePersistentRef(ctx, repo, refName, func() (plumbing.Hash, plumbing.Hash, error) {
 		calls++
 		ref, err := repo.Reference(refName, true)
 		if err != nil {
@@ -57,7 +87,7 @@ func TestUpdatePersistentRef_RebuildsAfterCASConflict(t *testing.T) {
 			if err != nil {
 				return plumbing.ZeroHash, plumbing.ZeroHash, err
 			}
-			if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, externalTip)); err != nil {
+			if err := casUpdateRef(ctx, repoRoot, refName, externalTip, parent); err != nil {
 				return plumbing.ZeroHash, plumbing.ZeroHash, err
 			}
 		}
@@ -87,9 +117,11 @@ func TestUpdatePersistentRef_NoOpConflictKeepsExistingCommit(t *testing.T) {
 	repo, initial := setupBranchTestRepo(t)
 	refName := plumbing.ReferenceName("refs/entire/test-cas-noop")
 	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, initial)))
+	repoRoot, _, err := repositoryDirs(ctx, repo)
+	require.NoError(t, err)
 
 	calls := 0
-	err := updatePersistentRef(ctx, repo, refName, func() (plumbing.Hash, plumbing.Hash, error) {
+	err = updatePersistentRef(ctx, repo, refName, func() (plumbing.Hash, plumbing.Hash, error) {
 		calls++
 		ref, err := repo.Reference(refName, true)
 		if err != nil {
@@ -105,7 +137,7 @@ func TestUpdatePersistentRef_NoOpConflictKeepsExistingCommit(t *testing.T) {
 			if err != nil {
 				return plumbing.ZeroHash, plumbing.ZeroHash, err
 			}
-			if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, external)); err != nil {
+			if err := casUpdateRef(ctx, repoRoot, refName, external, current); err != nil {
 				return plumbing.ZeroHash, plumbing.ZeroHash, err
 			}
 		}

--- a/cmd/entire/cli/checkpoint/persistent_ref_update_test.go
+++ b/cmd/entire/cli/checkpoint/persistent_ref_update_test.go
@@ -1,0 +1,118 @@
+package checkpoint
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdatePersistentRef_RebuildsAfterCASConflict(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo, initial := setupBranchTestRepo(t)
+	refName := plumbing.ReferenceName("refs/entire/test-cas")
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, initial)))
+
+	var (
+		calls       int
+		seenParents []plumbing.Hash
+		externalTip plumbing.Hash
+	)
+	err := updatePersistentRef(ctx, repo, refName, func() (plumbing.Hash, plumbing.Hash, error) {
+		calls++
+		ref, err := repo.Reference(refName, true)
+		if err != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, err
+		}
+		parent := ref.Hash()
+		seenParents = append(seenParents, parent)
+		commit, err := repo.CommitObject(parent)
+		if err != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, err
+		}
+		marker := fmt.Sprintf("attempt-%d", calls)
+		blob, err := CreateBlobFromContent(repo, []byte(marker))
+		if err != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, err
+		}
+		tree, err := ApplyTreeChanges(ctx, repo, commit.TreeHash, []TreeChange{{
+			Path:  "cas-marker.txt",
+			Entry: &object.TreeEntry{Name: "cas-marker.txt", Mode: filemode.Regular, Hash: blob},
+		}})
+		if err != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, err
+		}
+		newCommit, err := CreateCommit(ctx, repo, tree, parent, marker, "Test", "test@test.com")
+		if err != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, err
+		}
+
+		if calls == 1 {
+			externalTip, err = CreateCommit(ctx, repo, commit.TreeHash, parent, "external writer", "Test", "test@test.com")
+			if err != nil {
+				return plumbing.ZeroHash, plumbing.ZeroHash, err
+			}
+			if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, externalTip)); err != nil {
+				return plumbing.ZeroHash, plumbing.ZeroHash, err
+			}
+		}
+		return newCommit, parent, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+	require.Equal(t, []plumbing.Hash{initial, externalTip}, seenParents)
+
+	ref, err := repo.Reference(refName, true)
+	require.NoError(t, err)
+	finalCommit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	require.Equal(t, externalTip, finalCommit.ParentHashes[0])
+	finalTree, err := finalCommit.Tree()
+	require.NoError(t, err)
+	file, err := finalTree.File("cas-marker.txt")
+	require.NoError(t, err)
+	contents, err := file.Contents()
+	require.NoError(t, err)
+	require.Equal(t, "attempt-2", contents)
+}
+
+func TestUpdatePersistentRef_NoOpConflictKeepsExistingCommit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo, initial := setupBranchTestRepo(t)
+	refName := plumbing.ReferenceName("refs/entire/test-cas-noop")
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, initial)))
+
+	calls := 0
+	err := updatePersistentRef(ctx, repo, refName, func() (plumbing.Hash, plumbing.Hash, error) {
+		calls++
+		ref, err := repo.Reference(refName, true)
+		if err != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, err
+		}
+		current := ref.Hash()
+		if calls == 1 {
+			commit, err := repo.CommitObject(current)
+			if err != nil {
+				return plumbing.ZeroHash, plumbing.ZeroHash, err
+			}
+			external, err := CreateCommit(ctx, repo, commit.TreeHash, current, "external writer", "Test", "test@test.com")
+			if err != nil {
+				return plumbing.ZeroHash, plumbing.ZeroHash, err
+			}
+			if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, external)); err != nil {
+				return plumbing.ZeroHash, plumbing.ZeroHash, err
+			}
+		}
+		return current, current, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+	_, err = repo.CommitObject(initial)
+	require.NoError(t, err, "CAS cleanup must not delete an existing no-op target")
+}

--- a/cmd/entire/cli/checkpoint/refs_store.go
+++ b/cmd/entire/cli/checkpoint/refs_store.go
@@ -196,28 +196,12 @@ func (s *gitRefsStore) refTip(cid id.CheckpointID, ref *plumbing.Reference) (plu
 	return ref.Hash(), tree, nil
 }
 
-// setRef points a checkpoint's ref at a new commit and records it for push.
-// Enqueue is best-effort: a write that lands locally but fails to enqueue must
-// not fail condensation. The ref is still local; only its remote sync is missed
-// until a later write to the same checkpoint re-enqueues it.
-func (s *gitRefsStore) setRef(ctx context.Context, cid id.CheckpointID, hash plumbing.Hash) error {
-	refName, err := RefName(cid)
-	if err != nil {
-		return err
-	}
-	if err := s.repo.Storer.SetReference(plumbing.NewHashReference(refName, hash)); err != nil {
-		return fmt.Errorf("set checkpoint ref %s to %s: %w", refName, hash, err)
-	}
-	s.enqueueForPush(ctx, refName)
-	return nil
-}
-
 // enqueueForPush records refName in the push-discovery queue, logging (never
 // returning) on failure so the local ref write still succeeds.
 //
 // The queue is resolved with the cancellation stripped from ctx. By the time we
-// get here the ref is already written locally (go-git ref writes don't observe
-// ctx), and the queue is the ONLY push-discovery mechanism there is — see the
+// get here the ref is already written locally, and the queue is the ONLY
+// push-discovery mechanism there is — see the
 // pushQueueFileName doc. A ref that misses the queue is never pushed, and the
 // writers above are idempotent, so a re-run skips it as already-present and
 // never re-enqueues it: it stays local-only forever. Resolving the queue shells
@@ -238,6 +222,31 @@ func (s *gitRefsStore) enqueueForPush(ctx context.Context, refName plumbing.Refe
 	}
 }
 
+func (s *gitRefsStore) updateCheckpointRef(
+	ctx context.Context,
+	cid id.CheckpointID,
+	base func() (plumbing.Hash, *object.Tree, error),
+	build func(parentHash plumbing.Hash, existing *object.Tree) (plumbing.Hash, error),
+) error {
+	refName, err := RefName(cid)
+	if err != nil {
+		return err
+	}
+	err = updatePersistentRef(ctx, s.repo, refName, func() (plumbing.Hash, plumbing.Hash, error) {
+		parentHash, existing, baseErr := base()
+		if baseErr != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, baseErr
+		}
+		newHash, buildErr := build(parentHash, existing)
+		return newHash, parentHash, buildErr
+	})
+	if err != nil {
+		return err
+	}
+	s.enqueueForPush(ctx, refName)
+	return nil
+}
+
 func (s *gitRefsStore) writeSession(ctx context.Context, opts WriteOptions) error {
 	// Parity with the backfill writers above and with GitStore.writeSession: a
 	// canceled ctx means stop doing work, and creating a checkpoint is the most
@@ -253,23 +262,19 @@ func (s *gitRefsStore) writeSession(ctx context.Context, opts WriteOptions) erro
 	if err := validation.ValidateSessionID(opts.SessionID); err != nil {
 		return fmt.Errorf("invalid checkpoint options: %w", err)
 	}
-
-	parentHash, existing, err := s.refBase(opts.CheckpointID)
-	if err != nil {
-		return err
-	}
-
-	checkpointSubtree, err := s.applySessionWrite(ctx, opts, existing, "")
-	if err != nil {
-		return err
-	}
-
-	commitMsg := s.buildCommitMessage(opts)
-	commitHash, err := CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, opts.AuthorName, opts.AuthorEmail)
-	if err != nil {
-		return err
-	}
-	return s.setRef(ctx, opts.CheckpointID, commitHash)
+	return s.updateCheckpointRef(ctx, opts.CheckpointID,
+		func() (plumbing.Hash, *object.Tree, error) {
+			return s.refBase(opts.CheckpointID)
+		},
+		func(parentHash plumbing.Hash, existing *object.Tree) (plumbing.Hash, error) {
+			checkpointSubtree, err := s.applySessionWrite(ctx, opts, existing, "")
+			if err != nil {
+				return plumbing.ZeroHash, err
+			}
+			commitMsg := s.buildCommitMessage(opts)
+			return CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, opts.AuthorName, opts.AuthorEmail)
+		},
+	)
 }
 
 func (s *gitRefsStore) backfillTranscript(ctx context.Context, opts UpdateOptions) error {
@@ -280,26 +285,20 @@ func (s *gitRefsStore) backfillTranscript(ctx context.Context, opts UpdateOption
 		return errors.New("invalid update options: checkpoint ID is required")
 	}
 
-	parentHash, existing, err := s.refBaseForBackfill(ctx, opts.CheckpointID)
-	if err != nil {
-		return err
-	}
-
-	// applyTranscriptBackfill returns ErrCheckpointNotFound when the ref has no
-	// root summary yet (existing == nil → empty entries), matching the git-branch
-	// store's behavior for backfilling an unknown checkpoint.
-	checkpointSubtree, err := s.applyTranscriptBackfill(ctx, opts, existing, "")
-	if err != nil {
-		return err
-	}
-
-	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
-	commitMsg := fmt.Sprintf("Finalize transcript for Checkpoint: %s", opts.CheckpointID)
-	commitHash, err := CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, authorName, authorEmail)
-	if err != nil {
-		return err
-	}
-	return s.setRef(ctx, opts.CheckpointID, commitHash)
+	return s.updateCheckpointRef(ctx, opts.CheckpointID,
+		func() (plumbing.Hash, *object.Tree, error) {
+			return s.refBaseForBackfill(ctx, opts.CheckpointID)
+		},
+		func(parentHash plumbing.Hash, existing *object.Tree) (plumbing.Hash, error) {
+			checkpointSubtree, err := s.applyTranscriptBackfill(ctx, opts, existing, "")
+			if err != nil {
+				return plumbing.ZeroHash, err
+			}
+			authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+			commitMsg := fmt.Sprintf("Finalize transcript for Checkpoint: %s", opts.CheckpointID)
+			return CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, authorName, authorEmail)
+		},
+	)
 }
 
 func (s *gitRefsStore) backfillSummary(ctx context.Context, checkpointID id.CheckpointID, summary *Summary) error {
@@ -307,23 +306,20 @@ func (s *gitRefsStore) backfillSummary(ctx context.Context, checkpointID id.Chec
 		return err //nolint:wrapcheck // Propagating context cancellation
 	}
 
-	parentHash, existing, err := s.refBaseForBackfill(ctx, checkpointID)
-	if err != nil {
-		return err
-	}
-
-	checkpointSubtree, sessionID, err := s.applySummaryBackfill(ctx, existing, "", summary)
-	if err != nil {
-		return err
-	}
-
-	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
-	commitMsg := fmt.Sprintf("Update summary for checkpoint %s (session: %s)", checkpointID, sessionID)
-	commitHash, err := CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, authorName, authorEmail)
-	if err != nil {
-		return err
-	}
-	return s.setRef(ctx, checkpointID, commitHash)
+	return s.updateCheckpointRef(ctx, checkpointID,
+		func() (plumbing.Hash, *object.Tree, error) {
+			return s.refBaseForBackfill(ctx, checkpointID)
+		},
+		func(parentHash plumbing.Hash, existing *object.Tree) (plumbing.Hash, error) {
+			checkpointSubtree, sessionID, err := s.applySummaryBackfill(ctx, existing, "", summary)
+			if err != nil {
+				return plumbing.ZeroHash, err
+			}
+			authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+			commitMsg := fmt.Sprintf("Update summary for checkpoint %s (session: %s)", checkpointID, sessionID)
+			return CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, authorName, authorEmail)
+		},
+	)
 }
 
 func (s *gitRefsStore) backfillAttribution(ctx context.Context, checkpointID id.CheckpointID, combinedAttribution *Attribution) error {
@@ -331,23 +327,20 @@ func (s *gitRefsStore) backfillAttribution(ctx context.Context, checkpointID id.
 		return err //nolint:wrapcheck // Propagating context cancellation
 	}
 
-	parentHash, existing, err := s.refBaseForBackfill(ctx, checkpointID)
-	if err != nil {
-		return err
-	}
-
-	checkpointSubtree, err := s.applyAttributionBackfill(ctx, existing, "", combinedAttribution)
-	if err != nil {
-		return err
-	}
-
-	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
-	commitMsg := fmt.Sprintf("Update checkpoint summary for %s", checkpointID)
-	commitHash, err := CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, authorName, authorEmail)
-	if err != nil {
-		return err
-	}
-	return s.setRef(ctx, checkpointID, commitHash)
+	return s.updateCheckpointRef(ctx, checkpointID,
+		func() (plumbing.Hash, *object.Tree, error) {
+			return s.refBaseForBackfill(ctx, checkpointID)
+		},
+		func(parentHash plumbing.Hash, existing *object.Tree) (plumbing.Hash, error) {
+			checkpointSubtree, err := s.applyAttributionBackfill(ctx, existing, "", combinedAttribution)
+			if err != nil {
+				return plumbing.ZeroHash, err
+			}
+			authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+			commitMsg := fmt.Sprintf("Update checkpoint summary for %s", checkpointID)
+			return CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, authorName, authorEmail)
+		},
+	)
 }
 
 // checkpointTree resolves a FetchingTree rooted at a checkpoint's ref commit

--- a/cmd/entire/cli/checkpoint/refs_store_test.go
+++ b/cmd/entire/cli/checkpoint/refs_store_test.go
@@ -763,26 +763,29 @@ func TestGitRefsStore_WriteRefusesCanceledContext(t *testing.T) {
 		"a write refused for cancellation must not leave a checkpoint ref behind")
 }
 
-// TestGitRefsStore_EnqueuesForPushDuringShutdown pins that a ref written during
-// shutdown is still queued for push — see enqueueForPush for why dropping the
-// record would strand the checkpoint locally forever.
-func TestGitRefsStore_EnqueuesForPushDuringShutdown(t *testing.T) {
+// TestGitRefsStore_EnqueuesAfterCancellationFollowingCAS pins that cancellation
+// after a successful ref update does not drop the push-queue record.
+func TestGitRefsStore_EnqueuesAfterCancellationFollowingCAS(t *testing.T) {
 	t.Parallel()
 	store := newRefsStore(t)
 	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	refName := mustRefName(t, cid)
 
 	head, err := store.repo.Head()
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	repoRoot, _, err := repositoryDirs(ctx, store.repo)
+	require.NoError(t, err)
+	require.NoError(t, casUpdateRef(ctx, repoRoot, refName, head.Hash(), plumbing.ZeroHash))
 
-	require.NoError(t, store.setRef(ctx, cid, head.Hash()))
+	cancel()
+	store.enqueueForPush(ctx, refName)
 
 	q, err := PushQueueForRepo(context.Background(), store.repo)
 	require.NoError(t, err)
 	refs, err := q.Drain()
 	require.NoError(t, err)
-	assert.Contains(t, refs, mustRefName(t, cid),
-		"a ref written during shutdown must still be queued for push")
+	assert.Contains(t, refs, refName,
+		"a successful CAS must still be queued when cancellation follows it")
 }

--- a/cmd/entire/cli/checkpoint/shadow_ref.go
+++ b/cmd/entire/cli/checkpoint/shadow_ref.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -36,19 +35,7 @@ const shadowRefMaxJitter = 8 * time.Millisecond
 // and the common dir to locate filesystem paths (lock files, loose objects)
 // — both without depending on the process cwd.
 func (s *ephemeralStore) repoDirs(ctx context.Context) (worktreeRoot, commonDir string, err error) {
-	wt, err := s.repo.Worktree()
-	if err != nil {
-		return "", "", fmt.Errorf("open worktree: %w", err)
-	}
-	worktreeRoot = wt.Filesystem().Root()
-	if worktreeRoot == "" {
-		return "", "", errors.New("repository worktree filesystem has no root path")
-	}
-	commonDir, err = resolveGitCommonDir(ctx, s.repo)
-	if err != nil {
-		return "", "", err
-	}
-	return worktreeRoot, commonDir, nil
+	return repositoryDirs(ctx, s.repo)
 }
 
 // casUpdateShadowBranchRef atomically updates a shadow branch ref via
@@ -67,35 +54,7 @@ func (s *ephemeralStore) repoDirs(ctx context.Context) (worktreeRoot, commonDir 
 // .lock files, and shadow branches can be touched concurrently by separate
 // `entire` hook processes.
 func casUpdateShadowBranchRef(ctx context.Context, repoRoot, branchName string, newHash, expectedHash plumbing.Hash) error {
-	refName := "refs/heads/" + branchName
-
-	// All-zeros OID with the repo's object-format width means "must not
-	// exist". SHA-1 repos want 40 zeros, SHA-256 repos want 64; mirror
-	// newHash's hex width so we pick the right one without an extra git call.
-	newValue := newHash.String()
-	oldValue := strings.Repeat("0", newHash.HexSize())
-	if expectedHash != plumbing.ZeroHash {
-		oldValue = expectedHash.String()
-	}
-
-	cmd := exec.CommandContext(ctx, "git", "update-ref", refName, newValue, oldValue)
-	cmd.Dir = repoRoot
-	// Force English diagnostics so the CAS-conflict pattern match below
-	// isn't defeated by a translated stderr message in a non-C locale.
-	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
-	output, err := cmd.CombinedOutput()
-	if err == nil {
-		return nil
-	}
-
-	out := string(output)
-	// Git's CAS-failure messages: "cannot lock ref ..." (covers both
-	// "is at X but expected Y" and "reference already exists" for the
-	// zero-OID case). Other failures propagate.
-	if strings.Contains(out, "cannot lock ref") || strings.Contains(out, "but expected") {
-		return ErrShadowRefBusy
-	}
-	return fmt.Errorf("git update-ref %s: %s: %w", refName, strings.TrimSpace(out), err)
+	return casUpdateRef(ctx, repoRoot, plumbing.NewBranchReferenceName(branchName), newHash, expectedHash)
 }
 
 // shadowRefBackoff sleeps for a small random jitter before the next CAS

--- a/cmd/entire/cli/checkpoint/store.go
+++ b/cmd/entire/cli/checkpoint/store.go
@@ -1,7 +1,7 @@
 package checkpoint
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -112,9 +112,13 @@ func (s *GitStore) PersistentReadRef() plumbing.ReferenceName {
 	return s.refs.Read
 }
 
-func (s *GitStore) setPrimaryRef(hash plumbing.Hash) error {
-	if err := s.repo.Storer.SetReference(plumbing.NewHashReference(s.refs.Primary, hash)); err != nil {
-		return fmt.Errorf("set primary metadata ref %s to %s: %w", s.refs.Primary, hash, err)
-	}
-	return nil
+func (s *GitStore) updatePrimaryRef(ctx context.Context, build func(parentHash, rootTreeHash plumbing.Hash) (plumbing.Hash, error)) error {
+	return updatePersistentRef(ctx, s.repo, s.refs.Primary, func() (plumbing.Hash, plumbing.Hash, error) {
+		parentHash, rootTreeHash, err := s.getSessionsBranchRef()
+		if err != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, err
+		}
+		newHash, buildErr := build(parentHash, rootTreeHash)
+		return newHash, parentHash, buildErr
+	})
 }

--- a/cmd/entire/cli/integration_test/concurrent_checkpoint_writers_test.go
+++ b/cmd/entire/cli/integration_test/concurrent_checkpoint_writers_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// stopHookCmd builds a Stop-hook subprocess for a session without running it,
+// so callers can start several concurrently.
+func stopHookCmd(env *TestEnv, sessionID, transcriptPath string) *exec.Cmd {
+	input, err := json.Marshal(map[string]string{
+		"session_id":      sessionID,
+		"transcript_path": transcriptPath,
+	})
+	if err != nil {
+		env.T.Fatalf("marshal stop input: %v", err)
+	}
+	cmd := exec.CommandContext(context.Background(), getTestBinary(), "hooks", agentClaudeCode, "stop")
+	cmd.Dir = env.RepoDir
+	cmd.Stdin = bytes.NewReader(input)
+	cmd.Env = append(testutil.GitIsolatedEnv(),
+		"ENTIRE_TEST_CLAUDE_PROJECT_DIR="+env.ClaudeProjectDir,
+	)
+	cmd.Env = append(cmd.Env, env.ExtraEnv...)
+	cmd.Env = append(cmd.Env, env.checkpointStoreEnv()...)
+	return cmd
+}
+
+// checkpointBlob reads a path inside a stored checkpoint, resolving the storage
+// topology per backend: a subtree of the shared v1 branch (git-branch) or the
+// root tree of the checkpoint's own ref (git-refs).
+func checkpointBlob(env *TestEnv, checkpointID, relPath string) (string, bool) {
+	env.T.Helper()
+	spec := paths.MetadataBranchName + ":" + id.CheckpointID(checkpointID).Path() + "/" + relPath
+	if env.usingGitRefs() {
+		spec = checkpointRefName(checkpointID) + ":" + relPath
+	}
+	cmd := exec.CommandContext(env.T.Context(), "git", "show", spec)
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
+}
+
+// TestConcurrent_TwoStopHooks_SameCheckpoint covers two agents working in one
+// worktree whose uncondensed work lands in a single commit. Post-commit
+// condenses both sessions into ONE checkpoint and records it as each session's
+// turn checkpoint, so when both turns end, both Stop hooks finalize the SAME
+// checkpoint's transcript.
+//
+// Each Stop hook holds only its own per-session state lock, so the persistent
+// store must serialize writers at the shared checkpoint ref. The ref update
+// must also use compare-and-swap and rebuild from a fresh tip after a conflict;
+// otherwise both hooks can build sibling commits and lose one finalize.
+//
+// The sequential subtest is the control: identical scenario, one Stop after the
+// other, both finalizes survive. Only the interleaving differs.
+func TestConcurrent_TwoStopHooks_SameCheckpoint(t *testing.T) {
+	t.Parallel()
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		t.Run("sequential", func(t *testing.T) {
+			t.Parallel()
+			runTwoStopHooksScenario(t, backend, false)
+		})
+		t.Run("concurrent", func(t *testing.T) {
+			t.Parallel()
+			runTwoStopHooksScenario(t, backend, true)
+		})
+	})
+}
+
+func runTwoStopHooksScenario(t *testing.T, backend string, concurrent bool) {
+	t.Helper()
+	const (
+		markerA = "MARKER-SESSION-A-AFTER-COMMIT"
+		markerB = "MARKER-SESSION-B-AFTER-COMMIT"
+	)
+
+	env := NewFeatureBranchEnv(t)
+	env.CheckpointStore = backend
+
+	sessA := env.NewSession()
+	sessB := env.NewSession()
+	if err := env.SimulateUserPromptSubmitWithTranscriptPath(sessA.ID, sessA.TranscriptPath); err != nil {
+		t.Fatalf("prompt A: %v", err)
+	}
+	if err := env.SimulateUserPromptSubmitWithTranscriptPath(sessB.ID, sessB.TranscriptPath); err != nil {
+		t.Fatalf("prompt B: %v", err)
+	}
+
+	// Each agent writes a file. The padding widens the finalize window
+	// (transcript redaction + blob writes) so the overlap is reliable rather
+	// than a hairline.
+	padding := strings.Repeat("// filler line to widen the write window\n", 400)
+	contentA := "package a\n" + padding
+	contentB := "package b\n" + padding
+	env.WriteFile("agent_a.go", contentA)
+	env.WriteFile("agent_b.go", contentB)
+	sessA.CreateTranscript("write file a", []FileChange{{Path: "agent_a.go", Content: contentA}})
+	sessB.CreateTranscript("write file b", []FileChange{{Path: "agent_b.go", Content: contentB}})
+
+	// One commit, condensing both sessions into a single checkpoint.
+	env.GitCommitWithShadowHooksAsAgent("add agent files", "agent_a.go", "agent_b.go")
+
+	checkpointID := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
+	if checkpointID == "" {
+		t.Fatal("commit has no Entire-Checkpoint trailer; scenario setup failed")
+	}
+
+	summaryJSON, ok := checkpointBlob(env, checkpointID, paths.MetadataFileName)
+	if !ok {
+		t.Fatalf("checkpoint %s not stored after post-commit", checkpointID)
+	}
+	var before struct {
+		Sessions []json.RawMessage `json:"sessions"`
+	}
+	if err := json.Unmarshal([]byte(summaryJSON), &before); err != nil {
+		t.Fatalf("parse checkpoint summary: %v", err)
+	}
+	t.Logf("checkpoint %s holds %d sessions after post-commit", checkpointID, len(before.Sessions))
+	if len(before.Sessions) < 2 {
+		t.Fatalf("expected a 2-session checkpoint, got %d - scenario setup failed", len(before.Sessions))
+	}
+
+	// Each agent keeps working after the commit, so each Stop-hook finalize has
+	// distinct new transcript content. The markers show which finalize landed.
+	sessA.TranscriptBuilder.AddAssistantMessage(markerA)
+	if err := sessA.TranscriptBuilder.WriteToFile(sessA.TranscriptPath); err != nil {
+		t.Fatalf("append marker A: %v", err)
+	}
+	sessB.TranscriptBuilder.AddAssistantMessage(markerB)
+	if err := sessB.TranscriptBuilder.WriteToFile(sessB.TranscriptPath); err != nil {
+		t.Fatalf("append marker B: %v", err)
+	}
+
+	cmdA := stopHookCmd(env, sessA.ID, sessA.TranscriptPath)
+	cmdB := stopHookCmd(env, sessB.ID, sessB.TranscriptPath)
+	var outA, outB []byte
+	var errA, errB error
+	if concurrent {
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		wg.Add(2)
+		go func() { defer wg.Done(); <-start; outA, errA = cmdA.CombinedOutput() }()
+		go func() { defer wg.Done(); <-start; outB, errB = cmdB.CombinedOutput() }()
+		close(start)
+		wg.Wait()
+	} else {
+		outA, errA = cmdA.CombinedOutput()
+		outB, errB = cmdB.CombinedOutput()
+	}
+	if errA != nil {
+		t.Fatalf("stop A failed: %v\n%s", errA, outA)
+	}
+	if errB != nil {
+		t.Fatalf("stop B failed: %v\n%s", errB, outB)
+	}
+
+	// Both hooks reported success, so both finalizes must be readable from the
+	// checkpoint the ref now points at.
+	var stored strings.Builder
+	for i := range before.Sessions {
+		content, found := checkpointBlob(env, checkpointID, fmt.Sprintf("%d/full.jsonl", i))
+		if !found {
+			t.Errorf("session %d transcript missing from stored checkpoint", i)
+			continue
+		}
+		stored.WriteString(content)
+	}
+	for name, marker := range map[string]string{"A": markerA, "B": markerB} {
+		if strings.Contains(stored.String(), marker) {
+			t.Logf("session %s: finalize landed", name)
+			continue
+		}
+		t.Errorf("LOST UPDATE: session %s's post-commit transcript content is absent from "+
+			"checkpoint %s - its Stop-hook finalize was silently clobbered by the concurrent one "+
+			"(both hooks exited 0)", name, checkpointID)
+	}
+}

--- a/cmd/entire/cli/integration_test/setup_test.go
+++ b/cmd/entire/cli/integration_test/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -23,6 +24,9 @@ func TestMain(m *testing.M) {
 	}
 
 	testBinaryPath = filepath.Join(tmpDir, "entire")
+	if runtime.GOOS == "windows" {
+		testBinaryPath += ".exe"
+	}
 
 	// Route every spawned CLI away from the developer's real ~/.config/entire
 	// (contexts.json, version_check.json), ~/.cache/entire (discovery caches),


### PR DESCRIPTION
## Summary

Fixes entireio/cli#1917.

Concurrent checkpoint writers could read the same persistent ref tip, build<br>independent commits, and successfully update the ref without preserving both<br>mutations. The later update made the earlier completed data unreachable.

This follows the reproduction and guidance from entireio/cli#1920.

## Changes

* Add a cross-process lock scoped to each persistent ref.
* Replace unconditional ref updates with native Git CAS using:<br>`git update-ref <ref> <new> <old>`.
* Retry from a freshly read parent after CAS conflicts.
* Rebuild the tree and commit on every retry.
* Apply the same protection to:
  * `git-branch` writes
  * `git-refs` writes
  * persistent-ref initialization
  * git-branch to git-refs migration
* Add focused CAS retry and cleanup tests.
* Add the concurrent two-Stop-hook integration regression for both backends.

## Testing

* Soph's sequential/concurrent integration test passed for both<br>`git-branch` and `git-refs`.
* Five-repeat stress run passed all 20 integration scenarios.
* Focused checkpoint, migration, dispatch, and enqueue tests passed.
* `go vet ./cmd/entire/cli/checkpoint` passed.
* `gofmt -s` and `git diff --check` passed.
* Rebased and verified against current `main`.
* Added coverage proving that cancellation before CAS prevents the ref write.
* Added coverage proving that successful CAS followed by cancellation still
  enqueues the ref for push.
* The sequential and concurrent #1920 scenarios pass for both `git-branch`
  and `git-refs`, with both session updates preserved.

The full checkpoint package was also run. Seven existing Windows tests are<br>environment-sensitive because they access the real Git configuration or<br>AppData paths; the remaining package tests passed.

## Notes

The implementation uses the same lock/CAS/retry pattern already used by the<br>shadow-branch store. The retry rebuilds from the new tip rather than reusing a<br>commit built from the stale parent.

## Behavior and scope

`casUpdateRef` uses `exec.CommandContext`, so cancellation before the CAS
prevents `git update-ref` from running and the checkpoint ref is not written.
This is intentional: no partial checkpoint is stranded, `FullyCondensed`
remains false, and PostCommit can retry the work later.

Cancellation after a successful CAS does not prevent push discovery. Enqueueing
is context-free, so a ref that was successfully written is still recorded in
the push queue.

The lock-plus-CAS guarantee in this PR covers writers in the `checkpoint`
package. Pre-existing unconditional writes to the same refs from `strategy`
remain follow-up scope.

Lock granularity differs by backend:

* `git-refs` locks each checkpoint ref independently.
* `git-branch` locks the shared v1 branch, so all checkpoint writes in a
  repository are serialized.

Note: This commit does not include an Entire-Checkpoint trailer because the implementation session was not captured by Entire.