### PR TITLE
fix(clone): never fail on a missing session — log in to the correct region

### DIFF
--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -90,6 +90,27 @@ func ResolveControlPlaneTargetForCluster(ctx context.Context, clusterHost string
 	return targetForContext(c)
 }
 
+// ClusterLoginServers returns the core origins a user may pass to
+// `entire login --server` to become eligible for clusterHost — the cluster's
+// advertised core_urls. Cache-first (a prior ResolveControlPlaneTargetForCluster
+// in the same run warms cluster_cores.json), one /.well-known GET otherwise.
+func ClusterLoginServers(ctx context.Context, clusterHost string) ([]string, error) {
+	httpClient := &http.Client{Timeout: controlPlaneClusterDiscoveryTimeout}
+	entry, err := clusterdiscovery.ResolveClusterCores(ctx, userdirs.Cache(), clusterHost, httpClient, nil)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // ResolveClusterCores already returns a user-facing discovery message
+	}
+	return entry.CoreURLs, nil
+}
+
+// ErrNoEligibleContext and ErrAmbiguousContext re-export the clusterdiscovery
+// classification sentinels so cli callers can errors.Is a cluster session probe
+// without importing clusterdiscovery directly.
+var (
+	ErrNoEligibleContext = clusterdiscovery.ErrNoEligibleContext
+	ErrAmbiguousContext  = clusterdiscovery.ErrAmbiguousContext
+)
+
 // targetForContext builds the ControlPlaneTarget for an already-chosen context:
 // a refreshing login provider (silent JWT re-mint from the stored refresh
 // token) bound to that context's core. Shared by the active-context and

--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -90,15 +90,23 @@ func ResolveControlPlaneTargetForCluster(ctx context.Context, clusterHost string
 	return targetForContext(c)
 }
 
-// ClusterLoginServers returns the core origins a user may pass to
-// `entire login --server` to become eligible for clusterHost — the cluster's
-// advertised core_urls. Cache-first (a prior ResolveControlPlaneTargetForCluster
-// in the same run warms cluster_cores.json), one /.well-known GET otherwise.
+// ClusterLoginServers returns the origin(s) a user may pass to
+// `entire login --server` to become eligible for clusterHost. It prefers the
+// cluster's own jurisdiction core (jurisdiction_core_url) — the single OAuth
+// server for the cluster's region, i.e. exactly where the user should log in —
+// so a repo on an EU cluster sends them to the EU login server rather than the
+// whole federation trust list. It falls back to the full core_urls only when
+// the cluster advertises no jurisdiction core. Cache-first (a prior
+// ResolveControlPlaneTargetForCluster in the same run warms cluster_cores.json),
+// one /.well-known GET otherwise.
 func ClusterLoginServers(ctx context.Context, clusterHost string) ([]string, error) {
 	httpClient := &http.Client{Timeout: controlPlaneClusterDiscoveryTimeout}
 	entry, err := clusterdiscovery.ResolveClusterCores(ctx, userdirs.Cache(), clusterHost, httpClient, nil)
 	if err != nil {
 		return nil, err //nolint:wrapcheck // ResolveClusterCores already returns a user-facing discovery message
+	}
+	if region := strings.TrimSpace(entry.JurisdictionCoreURL); region != "" {
+		return []string{region}, nil
 	}
 	return entry.CoreURLs, nil
 }

--- a/cmd/entire/cli/auth/reauth_message_test.go
+++ b/cmd/entire/cli/auth/reauth_message_test.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/entireio/auth-go/tokenmanager"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/entireclient/contexts"
+)
+
+// TestReauthMessage verifies the cross-package accessor extracts the clean,
+// context-named re-login message from a *reauthError anywhere in the chain
+// (both sentinels) and reports ok=false for anything else — the behaviour
+// renderCoreError and the clone precondition rely on to strip the noisy ogen
+// wrappers off the reported `entire repo clone` failure.
+func TestReauthMessage(t *testing.T) {
+	t.Parallel()
+
+	c := &contexts.Context{Name: "us", CoreURL: "https://us.auth.entire.io"}
+	expired := contextReauthError(c, tokenmanager.ErrReauthRequired)
+	notLoggedIn := contextReauthError(c, tokenmanager.ErrNotLoggedIn)
+	require.Error(t, expired)
+	require.Error(t, notLoggedIn)
+
+	t.Run("expired sentinel", func(t *testing.T) {
+		t.Parallel()
+		msg, ok := ReauthMessage(expired)
+		require.True(t, ok)
+		require.Equal(t, expired.Error(), msg)
+		require.Contains(t, msg, "expired")
+		require.Contains(t, msg, "entire login")
+	})
+
+	t.Run("not-logged-in sentinel", func(t *testing.T) {
+		t.Parallel()
+		msg, ok := ReauthMessage(notLoggedIn)
+		require.True(t, ok)
+		require.Equal(t, notLoggedIn.Error(), msg)
+		require.Contains(t, msg, "no usable login")
+	})
+
+	t.Run("deep-wrapped chain keeps the clean message", func(t *testing.T) {
+		t.Parallel()
+		// Reproduce the reported chain: command prefix + ogen security wrappers.
+		chain := fmt.Errorf("resolve mirror placements: %w",
+			fmt.Errorf("security \"BearerAuth\": %w",
+				fmt.Errorf("security source \"BearerAuth\": %w", expired)))
+		msg, ok := ReauthMessage(chain)
+		require.True(t, ok)
+		require.Equal(t, expired.Error(), msg)
+		require.NotContains(t, msg, "resolve mirror placements")
+		require.NotContains(t, msg, "BearerAuth")
+	})
+
+	t.Run("non-reauth error is not matched", func(t *testing.T) {
+		t.Parallel()
+		_, ok := ReauthMessage(errors.New("dial tcp: connection refused"))
+		require.False(t, ok)
+	})
+
+	t.Run("nil is not matched", func(t *testing.T) {
+		t.Parallel()
+		_, ok := ReauthMessage(nil)
+		require.False(t, ok)
+	})
+}

--- a/cmd/entire/cli/auth/reauth_message_test.go
+++ b/cmd/entire/cli/auth/reauth_message_test.go
@@ -67,3 +67,46 @@ func TestReauthMessage(t *testing.T) {
 		require.False(t, ok)
 	})
 }
+
+// TestReauthError verifies the accessor used at the control-plane choke points
+// (runCoreClient/renderCoreError) returns an error that displays the clean,
+// wrapper-stripped message while still errors.Is-matching the underlying
+// sentinel — so a re-auth failure stays machine-classifiable instead of
+// collapsing into a flat string.
+func TestReauthError(t *testing.T) {
+	t.Parallel()
+
+	c := &contexts.Context{Name: "us", CoreURL: "https://us.auth.entire.io"}
+	expired := contextReauthError(c, tokenmanager.ErrReauthRequired)
+	notLoggedIn := contextReauthError(c, tokenmanager.ErrNotLoggedIn)
+
+	t.Run("deep-wrapped chain yields a clean, still-classifiable error", func(t *testing.T) {
+		t.Parallel()
+		chain := fmt.Errorf("resolve mirror placements: %w",
+			fmt.Errorf("security \"BearerAuth\": %w", expired))
+		got := ReauthError(chain)
+		require.Error(t, got)
+		// Clean display: only the friendly message, none of the wrapper noise.
+		require.Equal(t, expired.Error(), got.Error())
+		require.NotContains(t, got.Error(), "resolve mirror placements")
+		require.NotContains(t, got.Error(), "BearerAuth")
+		// Chain preserved: the sentinel is still reachable.
+		require.ErrorIs(t, got, tokenmanager.ErrReauthRequired)
+	})
+
+	t.Run("not-logged-in sentinel is preserved", func(t *testing.T) {
+		t.Parallel()
+		got := ReauthError(notLoggedIn)
+		require.ErrorIs(t, got, tokenmanager.ErrNotLoggedIn)
+	})
+
+	t.Run("non-reauth error is not matched", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ReauthError(errors.New("dial tcp: connection refused")))
+	})
+
+	t.Run("nil is not matched", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ReauthError(nil))
+	})
+}

--- a/cmd/entire/cli/auth/refresh.go
+++ b/cmd/entire/cli/auth/refresh.go
@@ -149,6 +149,23 @@ type reauthError struct {
 func (e *reauthError) Error() string { return e.msg }
 func (e *reauthError) Unwrap() error { return e.sentinel }
 
+// ReauthMessage returns the friendly, context-named re-login message carried by
+// a *reauthError anywhere in err's chain (expired session or no usable login),
+// with ok=false when err is not a re-auth error. It is the cross-package
+// accessor for the unexported reauthError: callers in the cli package can't
+// errors.As the type themselves, and matching err's top-level string is wrong
+// because two noise layers (the ogen `security "BearerAuth"` wrappers and the
+// command's own `%w` prefix) sit on top of it. Both re-auth sentinels surface
+// as a *reauthError, so this single check covers ErrReauthRequired and
+// ErrNotLoggedIn.
+func ReauthMessage(err error) (string, bool) {
+	var re *reauthError
+	if errors.As(err, &re) {
+		return re.Error(), true
+	}
+	return "", false
+}
+
 // contextReauthError maps the two re-auth sentinels a per-context manager can
 // return into a friendly message that names the context and its core (so a
 // multi-core user logs back into the right one — matching the

--- a/cmd/entire/cli/auth/refresh.go
+++ b/cmd/entire/cli/auth/refresh.go
@@ -166,6 +166,22 @@ func ReauthMessage(err error) (string, bool) {
 	return "", false
 }
 
+// ReauthError returns the *reauthError carried anywhere in err's chain as an
+// error whose Error() is the clean, context-named re-login message (stripped of
+// the ogen `security "BearerAuth"` and command `%w` wrappers that sit on top of
+// it) while still errors.Is-matching the underlying sentinel (ErrReauthRequired
+// or ErrNotLoggedIn); nil when err is not a re-auth error. Prefer this over
+// ReauthMessage at choke points that must both display cleanly and preserve the
+// chain, so callers can still classify (and, e.g., retry-after-login) the
+// failure rather than receiving a flat string.
+func ReauthError(err error) error {
+	var re *reauthError
+	if errors.As(err, &re) {
+		return re
+	}
+	return nil
+}
+
 // contextReauthError maps the two re-auth sentinels a per-context manager can
 // return into a friendly message that names the context and its core (so a
 // multi-core user logs back into the right one — matching the

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -608,6 +608,13 @@ func runCoreClient(cmd *cobra.Command, newClient func(context.Context) (*coreapi
 	}
 	client, err := newClient(cmd.Context())
 	if err != nil {
+		// Client construction resolves the active login (coreapi.New →
+		// ResolveControlPlaneTarget), so a not-logged-in/expired session fails
+		// here — before any API call reaches renderCoreError. Surface the same
+		// clean re-login hint rather than the wrapper-prefixed chain.
+		if msg, ok := auth.ReauthMessage(err); ok {
+			return errors.New(msg)
+		}
 		return fmt.Errorf("connect to Entire control plane: %w", err)
 	}
 	if err := fn(cmd.Context(), client); err != nil {

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -64,6 +64,14 @@ func insecureHTTPRequested(cmd *cobra.Command) bool {
 	return err == nil && v
 }
 
+// deviceLoginRequested reports whether --device was set on cmd or an ancestor,
+// so an inline re-login (e.g. the repo clone precondition) honors the same
+// device-code preference `entire login --device` offers. Absent flag → false.
+func deviceLoginRequested(cmd *cobra.Command) bool {
+	v, err := cmd.Flags().GetBool("device")
+	return err == nil && v
+}
+
 // addForceFlag registers the standard confirmation bypass on a destructive
 // control-plane command: --force/-f, with --yes/-y as an alias. Either skips
 // the prompt. Read the combined value with forceRequested.
@@ -611,9 +619,10 @@ func runCoreClient(cmd *cobra.Command, newClient func(context.Context) (*coreapi
 		// Client construction resolves the active login (coreapi.New →
 		// ResolveControlPlaneTarget), so a not-logged-in/expired session fails
 		// here — before any API call reaches renderCoreError. Surface the same
-		// clean re-login hint rather than the wrapper-prefixed chain.
-		if msg, ok := auth.ReauthMessage(err); ok {
-			return errors.New(msg)
+		// clean re-login hint rather than the wrapper-prefixed chain, keeping the
+		// *reauthError chain intact so callers can still errors.Is the sentinel.
+		if reErr := auth.ReauthError(err); reErr != nil {
+			return reErr //nolint:wrapcheck // deliberately surface auth's clean, sentinel-preserving reauth error verbatim
 		}
 		return fmt.Errorf("connect to Entire control plane: %w", err)
 	}
@@ -653,10 +662,11 @@ func renderCoreError(err error) error {
 	// An expired/absent login surfaces as a *reauthError buried under ogen's
 	// `security "BearerAuth"` wrappers and the command's own `%w` prefix. Surface
 	// just its clean, context-named "run `entire login`" hint instead of the
-	// full noisy chain (the reported `entire repo clone` failure). Covers every
-	// control-plane command, since they all funnel through here.
-	if msg, ok := auth.ReauthMessage(err); ok {
-		return errors.New(msg)
+	// full noisy chain (the reported `entire repo clone` failure), keeping the
+	// *reauthError chain intact so callers can still errors.Is the sentinel.
+	// Covers every control-plane command, since they all funnel through here.
+	if reErr := auth.ReauthError(err); reErr != nil {
+		return reErr //nolint:wrapcheck // deliberately surface auth's clean, sentinel-preserving reauth error verbatim
 	}
 	return err
 }

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -643,6 +643,14 @@ func renderCoreError(err error) error {
 	if msg := coreapi.APIError(err); msg != "" {
 		return errors.New(msg)
 	}
+	// An expired/absent login surfaces as a *reauthError buried under ogen's
+	// `security "BearerAuth"` wrappers and the command's own `%w` prefix. Surface
+	// just its clean, context-named "run `entire login`" hint instead of the
+	// full noisy chain (the reported `entire repo clone` failure). Covers every
+	// control-plane command, since they all funnel through here.
+	if msg, ok := auth.ReauthMessage(err); ok {
+		return errors.New(msg)
+	}
 	return err
 }
 

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -80,27 +80,8 @@ func newLoginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Log in to Entire",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			loginServer, err := parseLoginServer(server)
-			if err != nil {
-				return fmt.Errorf("invalid --server: %w", err)
-			}
-			if err := requireSecureLoginServer(loginServer, insecureHTTPAuth); err != nil {
-				return err
-			}
-			client := auth.NewClient(loginServer, nil, insecureHTTPAuth)
-			// Closure adapts the concrete *auth.BrowserAuthFlow result to the
-			// browserAuthFlow interface (func types are invariant, so the
-			// method value alone won't do). On error the flow is a typed nil,
-			// which is fine — runLoginAuto checks err before touching it.
-			startBrowser := func(ctx context.Context) (browserAuthFlow, error) {
-				return client.StartBrowserAuth(ctx)
-			}
-			return runLoginAuto(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				client, startBrowser, openBrowser, loginFlowFacts{
-					useDevice:  useDevice,
-					canPrompt:  interactive.CanPromptInteractively(),
-					sshSession: isSSHSession(),
-				})
+			return runLoginToServer(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
+				server, insecureHTTPAuth, useDevice)
 		},
 	}
 	cmd.Flags().StringVar(&server, "server", api.DefaultAuthBaseURL,
@@ -108,6 +89,37 @@ func newLoginCmd() *cobra.Command {
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
 	cmd.Flags().BoolVar(&useDevice, "device", false, "Use the device-code flow (enter a code in your browser) instead of the default browser redirect")
 	return cmd
+}
+
+// runLoginToServer performs the interactive login against the given login
+// server, factored out of newLoginCmd's RunE so other commands (e.g. the
+// `repo clone` re-auth precondition in ensureCloneSession) can log in
+// in-process without duplicating the flow-selection logic. On success it
+// persists and activates the new context; a fresh coreapi client built
+// afterward re-reads the stored token, so callers may proceed in the same
+// process.
+func runLoginToServer(ctx context.Context, outW, errW io.Writer, server string, insecureHTTPAuth, useDevice bool) error {
+	loginServer, err := parseLoginServer(server)
+	if err != nil {
+		return fmt.Errorf("invalid login server: %w", err)
+	}
+	if err := requireSecureLoginServer(loginServer, insecureHTTPAuth); err != nil {
+		return err
+	}
+	client := auth.NewClient(loginServer, nil, insecureHTTPAuth)
+	// Closure adapts the concrete *auth.BrowserAuthFlow result to the
+	// browserAuthFlow interface (func types are invariant, so the
+	// method value alone won't do). On error the flow is a typed nil,
+	// which is fine — runLoginAuto checks err before touching it.
+	startBrowser := func(ctx context.Context) (browserAuthFlow, error) {
+		return client.StartBrowserAuth(ctx)
+	}
+	return runLoginAuto(ctx, outW, errW,
+		client, startBrowser, openBrowser, loginFlowFacts{
+			useDevice:  useDevice,
+			canPrompt:  interactive.CanPromptInteractively(),
+			sshSession: isSSHSession(),
+		})
 }
 
 // parseLoginServer validates and canonicalises the --server value: an

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -531,9 +531,60 @@ type placementPicker struct {
 	action string
 }
 
+// cloneHomeJurisdiction reports the caller's home jurisdiction for narrowing the
+// placement picker. A package seam so tests can drive the filter without the
+// real auth stack.
+var cloneHomeJurisdiction = defaultCloneHomeJurisdiction
+
+// defaultCloneHomeJurisdiction reads the home_jurisdiction claim off the active
+// login (best-effort — the placements lookup just ran on this same context, so
+// the token is warm). Returns "" on any uncertainty so the picker falls back to
+// showing every placement rather than hiding one.
+func defaultCloneHomeJurisdiction(ctx context.Context) string {
+	target, err := auth.ResolveControlPlaneTarget()
+	if err != nil {
+		return ""
+	}
+	jwt, err := target.TokenSource(ctx)
+	if err != nil {
+		return ""
+	}
+	jur, err := auth.HomeJurisdictionFromLoginJWT(jwt)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(jur)
+}
+
+// preferHomeJurisdiction narrows placements to those in the caller's home
+// jurisdiction, so the picker isn't cluttered with regions the user doesn't
+// belong to (and auto-selects when that leaves exactly one). Best-effort: an
+// unknown home, or a home that matches no placement, returns the input
+// unchanged so a clonable target is never silently hidden.
+func preferHomeJurisdiction(placements []coreapi.ResolvedPlacement, home string) []coreapi.ResolvedPlacement {
+	if home == "" || len(placements) < 2 {
+		return placements
+	}
+	kept := make([]coreapi.ResolvedPlacement, 0, len(placements))
+	for _, p := range placements {
+		if strings.EqualFold(strings.TrimSpace(p.Jurisdiction.Or("")), home) {
+			kept = append(kept, p)
+		}
+	}
+	if len(kept) == 0 {
+		return placements
+	}
+	return kept
+}
+
 // selectCloneTarget resolves which mirror placement to clone from, with the
-// clone verb's wording. See selectPlacement for the selection rules.
+// clone verb's wording. See selectPlacement for the selection rules. With no
+// explicit --cluster it first narrows to the caller's home jurisdiction so a
+// repo mirrored across many regions defaults to the user's own.
 func selectCloneTarget(cmd *cobra.Command, placements []coreapi.ResolvedPlacement, clusterFlag string) (coreapi.ResolvedPlacement, error) {
+	if clusterFlag == "" {
+		placements = preferHomeJurisdiction(placements, cloneHomeJurisdiction(cmd.Context()))
+	}
 	return selectPlacement(cmd, placements, clusterFlag, placementPicker{
 		selector: "--cluster",
 		title:    "This repo is mirrored on more than one cluster — pick one to clone from",

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -265,11 +265,11 @@ func defaultInteractiveReauthLogin(cmd *cobra.Command, loginServer, hint string)
 // prompt. A fresh coreapi client built afterward re-reads the newly stored
 // token, so the clone proceeds in the same process.
 func ensureCloneSession(cmd *cobra.Command) error {
-	// A non-empty ENTIRE_TOKEN supplies a verbatim bearer with no refreshable
-	// session to probe; leave any failure to the normal flow (renderCoreError
-	// still cleans the message). Such runs are non-interactive CI anyway. An
-	// empty value is treated as unset, matching coreapi's env-token path.
-	if os.Getenv(auth.EnvTokenVar) != "" {
+	// ENTIRE_TOKEN supplies a verbatim bearer with no refreshable session to
+	// probe; leave any failure, including a blank token, to the normal flow
+	// (renderCoreError still cleans the message). Match coreapi's presence-based
+	// env-token precedence so this precondition never probes a stored session.
+	if _, ok := os.LookupEnv(auth.EnvTokenVar); ok {
 		return nil
 	}
 	if insecureHTTPRequested(cmd) {
@@ -293,7 +293,7 @@ func ensureCloneSession(cmd *cobra.Command) error {
 		return err
 	}
 	if !loggedIn {
-		return errors.New(msg)
+		return NewSilentError(errors.New(msg))
 	}
 	return nil
 }

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"sort"
@@ -11,6 +13,8 @@ import (
 	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
 
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/internal/coreapi"
 )
@@ -124,6 +128,17 @@ func newRepoCloneCmd() *cobra.Command {
 				return fmt.Errorf("invalid <repo>: %w", err)
 			}
 
+			// Make a usable active-context login a precondition: fail fast with a
+			// clean re-login hint (never the noisy wrapped auth chain), and
+			// interactively offer to log in and continue, before diving into the
+			// mirror lookup. Scoped to the active-context path; --cluster dials a
+			// different context and relies on renderCoreError's clean fallback.
+			if cluster == "" {
+				if err := ensureCloneSession(cmd); err != nil {
+					return err
+				}
+			}
+
 			var placements []coreapi.ResolvedPlacement
 			lister := func(ctx context.Context, c *coreapi.Client) error {
 				ps, err := resolvePullablePlacements(ctx, c, owner, repo)
@@ -176,6 +191,111 @@ func newRepoCloneCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&cluster, "cluster", "", "Cluster host to clone from when the repo is mirrored on more than one (may belong to another auth context)")
 	return cmd
+}
+
+// Seams so ensureCloneSession is testable without the real keychain, network,
+// or a TTY (mirrors the activeCoreClient seam in corecmd.go). Tests swap these.
+var (
+	// probeCloneSession resolves the active control-plane target and checks its
+	// login by minting a token. It returns the login server to re-authenticate
+	// against (the context's core, or the default when there is no context) and
+	// the probe result: nil when the session is usable, a *reauthError (via the
+	// token source) when re-login is needed, or a transient error otherwise.
+	probeCloneSession = defaultProbeCloneSession
+	// interactiveReauthLogin prompts the user to re-authenticate and, on
+	// confirmation, logs in against loginServer. It reports whether a login was
+	// performed (false when the user declines).
+	interactiveReauthLogin = defaultInteractiveReauthLogin
+)
+
+func defaultProbeCloneSession(ctx context.Context) (loginServer string, err error) {
+	target, err := auth.ResolveControlPlaneTarget()
+	if err != nil {
+		// No active context surfaces as a *reauthError wrapping ErrNotLoggedIn;
+		// re-login against the default login server. Wrapped with %w so the
+		// caller's auth.ReauthMessage (errors.As) still finds it.
+		return api.DefaultAuthBaseURL, fmt.Errorf("resolve control-plane target: %w", err)
+	}
+	// Client construction does no network I/O — the bearer is lazy per-request —
+	// so mint a token explicitly to detect an expired/absent session up front.
+	if _, err := target.TokenSource(ctx); err != nil {
+		return target.CoreURL, fmt.Errorf("mint login token: %w", err)
+	}
+	return target.CoreURL, nil
+}
+
+func defaultInteractiveReauthLogin(cmd *cobra.Command, loginServer, hint string) (bool, error) {
+	ctx := cmd.Context()
+	// huh opens the TTY during form startup regardless of context state, so
+	// guard explicitly to honor an already-cancelled command context.
+	if ctx.Err() != nil {
+		return false, nil //nolint:nilerr // cancelled context is a clean decline, not an error
+	}
+	// Show why we're prompting (the hint names the context and its core), then
+	// offer to fix it in-process.
+	fmt.Fprintln(cmd.ErrOrStderr(), hint)
+	confirmed := false
+	form := NewAccessibleForm(
+		huh.NewGroup(huh.NewConfirm().
+			Title("Log in now and continue the clone?").
+			Value(&confirmed)),
+	)
+	if err := form.RunWithContext(ctx); err != nil {
+		// A user abort (Esc) or context cancel (Ctrl+C) is a clean decline, not
+		// an error — mirror confirmControlPlaneDeletion.
+		if errors.Is(err, huh.ErrUserAborted) || errors.Is(err, context.Canceled) {
+			return false, nil
+		}
+		return false, fmt.Errorf("login prompt: %w", err)
+	}
+	if !confirmed {
+		return false, nil
+	}
+	if err := runLoginToServer(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), loginServer, insecureHTTPRequested(cmd), false); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ensureCloneSession makes a usable active-context login a precondition of the
+// clone. On a missing/expired session it surfaces the clean, context-named
+// re-login hint (never the noisy wrapped chain); interactively it also offers
+// to run the login flow in-process and continue. Non-interactive callers
+// (agents, CI) get the hint and a non-zero exit without ever blocking on a
+// prompt. A fresh coreapi client built afterward re-reads the newly stored
+// token, so the clone proceeds in the same process.
+func ensureCloneSession(cmd *cobra.Command) error {
+	// A non-empty ENTIRE_TOKEN supplies a verbatim bearer with no refreshable
+	// session to probe; leave any failure to the normal flow (renderCoreError
+	// still cleans the message). Such runs are non-interactive CI anyway. An
+	// empty value is treated as unset, matching coreapi's env-token path.
+	if os.Getenv(auth.EnvTokenVar) != "" {
+		return nil
+	}
+	if insecureHTTPRequested(cmd) {
+		auth.EnableInsecureHTTP()
+	}
+	loginServer, probeErr := probeCloneSession(cmd.Context())
+	if probeErr == nil {
+		return nil // session usable
+	}
+	msg, isReauth := auth.ReauthMessage(probeErr)
+	if !isReauth {
+		// Transient (network/STS) failure — not a re-auth prompt. Let the normal
+		// command flow surface it in its own terms.
+		return probeErr
+	}
+	if !interactive.CanPromptInteractively() {
+		return errors.New(msg)
+	}
+	loggedIn, err := interactiveReauthLogin(cmd, loginServer, msg)
+	if err != nil {
+		return err
+	}
+	if !loggedIn {
+		return errors.New(msg)
+	}
+	return nil
 }
 
 // mirrorLister is the subset of the control-plane client listMirrorsForRepo

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -213,6 +213,7 @@ func newRepoCloneCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&cluster, "cluster", "", "Cluster host to clone from when the repo is mirrored on more than one (may belong to another auth context)")
+	cmd.Flags().Bool("device", false, "Use the device-code flow (enter a code in your browser) for any inline re-login this clone prompts for, instead of the browser redirect")
 	return cmd
 }
 
@@ -315,7 +316,7 @@ func defaultInteractiveClusterLogin(cmd *cobra.Command, servers []string, hint s
 	if !confirmed {
 		return false, nil
 	}
-	if err := runLoginToServer(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), server, insecureHTTPRequested(cmd), false); err != nil {
+	if err := runLoginToServer(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), server, insecureHTTPRequested(cmd), deviceLoginRequested(cmd)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -422,7 +423,13 @@ func ensureClusterCloneSession(cmd *cobra.Command, clusterHost string) error {
 		return probeErr
 	}
 
-	if !interactive.CanPromptInteractively() {
+	if !interactive.CanPromptInteractively() || len(servers) == 0 {
+		// No TTY, or no advertised region to log into in-process (the servers==0
+		// ErrNoEligibleContext case — the cluster names no core to authenticate
+		// against): surface the friendly hint (which already says "log in with
+		// `entire login`") rather than falling into interactiveClusterLogin, whose
+		// empty-slice guard would leak the raw "no login server" internal error.
+		// main.go prints it; nothing has echoed it yet on this path.
 		return errors.New(hint)
 	}
 	loggedIn, err := interactiveClusterLogin(cmd, servers, hint)
@@ -541,6 +548,21 @@ var cloneHomeJurisdiction = defaultCloneHomeJurisdiction
 // the token is warm). Returns "" on any uncertainty so the picker falls back to
 // showing every placement rather than hiding one.
 func defaultCloneHomeJurisdiction(ctx context.Context) string {
+	// Match coreapi's presence-based env-token precedence: when ENTIRE_TOKEN is
+	// set it is the bearer the placement lookup actually used, so derive the
+	// home jurisdiction from it, not from the stored active context.
+	if raw, ok := os.LookupEnv(auth.EnvTokenVar); ok {
+		_, token, err := auth.ParseEnvToken(raw)
+		if err != nil {
+			return ""
+		}
+		jur, err := auth.HomeJurisdictionFromLoginJWT(token)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(jur)
+	}
+
 	target, err := auth.ResolveControlPlaneTarget()
 	if err != nil {
 		return ""
@@ -582,7 +604,12 @@ func preferHomeJurisdiction(placements []coreapi.ResolvedPlacement, home string)
 // explicit --cluster it first narrows to the caller's home jurisdiction so a
 // repo mirrored across many regions defaults to the user's own.
 func selectCloneTarget(cmd *cobra.Command, placements []coreapi.ResolvedPlacement, clusterFlag string) (coreapi.ResolvedPlacement, error) {
-	if clusterFlag == "" {
+	// Only resolve the home jurisdiction when it can actually narrow the choice:
+	// with 0-1 placements there's nothing to filter (preferHomeJurisdiction would
+	// return the input unchanged), so skip the extra control-plane target
+	// resolution + login-token read on the common single-mirror clone. An
+	// explicit --cluster bypasses the filter entirely.
+	if clusterFlag == "" && len(placements) >= 2 {
 		placements = preferHomeJurisdiction(placements, cloneHomeJurisdiction(cmd.Context()))
 	}
 	return selectPlacement(cmd, placements, clusterFlag, placementPicker{

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -118,6 +118,15 @@ func newRepoCloneCmd() *cobra.Command {
 			// where we *synthesize* the URL from a --cluster flag or an API-supplied
 			// host — values that flow into the STS audience under our own construction.
 			if isEntireCloneURL(ref) {
+				// Ensure a session for the cluster named in the URL before handing
+				// off to git-remote-entire (which can't prompt). Only when the URL
+				// parses cleanly — otherwise preserve the verbatim-forward contract
+				// and let git surface its own error.
+				if host, _, _, _, perr := parseMirrorCloneURL(ref); perr == nil {
+					if err := ensureClusterCloneSession(cmd, host); err != nil {
+						return err
+					}
+				}
 				return runGitClone(cmd.Context(), cmd, ref, targetDir)
 			}
 
@@ -161,6 +170,11 @@ func newRepoCloneCmd() *cobra.Command {
 				if err := validateClusterHost(cluster); err != nil {
 					return fmt.Errorf("invalid --cluster: %w", err)
 				}
+				// The lookup dials this cluster's core and the clone targets it too,
+				// so one cluster-session precondition covers both.
+				if err := ensureClusterCloneSession(cmd, cluster); err != nil {
+					return err
+				}
 				runWithCore = func(cmd *cobra.Command, fn func(context.Context, *coreapi.Client) error) error {
 					return runCoreForCluster(cmd, cluster, fn)
 				}
@@ -185,6 +199,15 @@ func newRepoCloneCmd() *cobra.Command {
 			if err := validateClusterHost(chosen.ClusterHost); err != nil {
 				return fmt.Errorf("mirror has an invalid cluster host %q: %w", chosen.ClusterHost, err)
 			}
+			// Ensure a session for the cluster the placement resolved to (may be a
+			// different federation than the active login used for the lookup above).
+			// The --cluster path already ran this on its flag host, which equals the
+			// chosen host, so only the no-flag path needs it here.
+			if cluster == "" {
+				if err := ensureClusterCloneSession(cmd, chosen.ClusterHost); err != nil {
+					return err
+				}
+			}
 			cloneURL := mirrorCloneURL(chosen.ClusterHost, owner, repo)
 			return runGitClone(cmd.Context(), cmd, cloneURL, targetDir)
 		},
@@ -206,6 +229,16 @@ var (
 	// confirmation, logs in against loginServer. It reports whether a login was
 	// performed (false when the user declines).
 	interactiveReauthLogin = defaultInteractiveReauthLogin
+	// probeClusterCloneSession checks whether a login eligible for the TARGET
+	// cluster exists. It returns the candidate login servers (the cluster's
+	// core_urls, or the single eligible context's core) and the probe result:
+	// nil when a usable session exists, a *reauthError when an eligible context's
+	// token is expired, an auth.ErrNoEligibleContext error when none is eligible,
+	// or an ambiguous/discovery error otherwise.
+	probeClusterCloneSession = defaultProbeClusterCloneSession
+	// interactiveClusterLogin prompts (optionally picking among regions) and, on
+	// confirmation, logs in against one of servers. Reports whether a login ran.
+	interactiveClusterLogin = defaultInteractiveClusterLogin
 )
 
 func defaultProbeCloneSession(ctx context.Context) (loginServer string, err error) {
@@ -224,16 +257,47 @@ func defaultProbeCloneSession(ctx context.Context) (loginServer string, err erro
 	return target.CoreURL, nil
 }
 
+// defaultInteractiveReauthLogin adapts the single-server active-context path
+// onto the shared cluster-login flow.
 func defaultInteractiveReauthLogin(cmd *cobra.Command, loginServer, hint string) (bool, error) {
+	return defaultInteractiveClusterLogin(cmd, []string{loginServer}, hint)
+}
+
+// defaultInteractiveClusterLogin prints the hint, lets the user pick a region
+// when the cluster trusts more than one core, confirms, and logs in in-process.
+// Reports whether a login was performed (false when the user declines/aborts).
+func defaultInteractiveClusterLogin(cmd *cobra.Command, servers []string, hint string) (bool, error) {
+	if len(servers) == 0 {
+		return false, errors.New("no login server to authenticate against")
+	}
 	ctx := cmd.Context()
 	// huh opens the TTY during form startup regardless of context state, so
 	// guard explicitly to honor an already-cancelled command context.
 	if ctx.Err() != nil {
 		return false, nil //nolint:nilerr // cancelled context is a clean decline, not an error
 	}
-	// Show why we're prompting (the hint names the context and its core), then
-	// offer to fix it in-process.
+	// Show why we're prompting (the hint names the cluster/context), then offer
+	// to fix it in-process.
 	fmt.Fprintln(cmd.ErrOrStderr(), hint)
+
+	server := servers[0]
+	if len(servers) > 1 {
+		// A cluster that trusts several cores — let the user pick which region's
+		// login to establish.
+		pick := NewAccessibleForm(
+			huh.NewGroup(huh.NewSelect[string]().
+				Title("Pick the region to log in to:").
+				Options(huh.NewOptions(servers...)...).
+				Value(&server)),
+		)
+		if err := pick.RunWithContext(ctx); err != nil {
+			if errors.Is(err, huh.ErrUserAborted) || errors.Is(err, context.Canceled) {
+				return false, nil
+			}
+			return false, fmt.Errorf("region prompt: %w", err)
+		}
+	}
+
 	confirmed := false
 	form := NewAccessibleForm(
 		huh.NewGroup(huh.NewConfirm().
@@ -251,7 +315,7 @@ func defaultInteractiveReauthLogin(cmd *cobra.Command, loginServer, hint string)
 	if !confirmed {
 		return false, nil
 	}
-	if err := runLoginToServer(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), loginServer, insecureHTTPRequested(cmd), false); err != nil {
+	if err := runLoginToServer(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), server, insecureHTTPRequested(cmd), false); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -296,6 +360,96 @@ func ensureCloneSession(cmd *cobra.Command) error {
 		return NewSilentError(errors.New(msg))
 	}
 	return nil
+}
+
+// defaultProbeClusterCloneSession deliberately propagates the resolver's errors
+// unwrapped: ensureClusterCloneSession classifies them (errors.Is / ReauthMessage)
+// and surfaces the discovery/ambiguous ones verbatim (they are already
+// user-facing), so wrapping would corrupt the classification and prefix the
+// message. Hence the nolint:wrapcheck on the return sites below.
+func defaultProbeClusterCloneSession(ctx context.Context, clusterHost string) (servers []string, err error) {
+	target, terr := auth.ResolveControlPlaneTargetForCluster(ctx, clusterHost)
+	if terr == nil {
+		// An eligible context exists; mint a token to detect an expired session.
+		if _, tkErr := target.TokenSource(ctx); tkErr != nil {
+			return []string{target.CoreURL}, tkErr //nolint:wrapcheck // *reauthError (expired)/transient, classified by caller
+		}
+		return nil, nil // usable — the clone's helper will authenticate the same way
+	}
+	if errors.Is(terr, auth.ErrNoEligibleContext) {
+		// Discovery succeeded but no local login is eligible; surface the cluster's
+		// trusted cores as the login targets (cache hit — the resolve above warmed
+		// cluster_cores.json).
+		cores, cerr := auth.ClusterLoginServers(ctx, clusterHost)
+		if cerr != nil {
+			return nil, cerr //nolint:wrapcheck // already a user-facing discovery message
+		}
+		return cores, terr //nolint:wrapcheck // terr carries auth.ErrNoEligibleContext for the caller
+	}
+	// Ambiguous (needs `entire auth use`) or a discovery/transient failure —
+	// surface verbatim; not something a fresh login fixes.
+	return nil, terr //nolint:wrapcheck // already user-facing / classified by caller
+}
+
+// ensureClusterCloneSession makes a login eligible for the TARGET cluster a
+// precondition of the clone: it never lets `git clone` reach git-remote-entire
+// (which cannot prompt) without a usable session. Missing/expired + interactive
+// → offer to log in to the cluster's region and continue; non-interactive →
+// clean hint + non-zero exit. Ambiguous and discovery failures are surfaced
+// as-is (a fresh login wouldn't fix them).
+func ensureClusterCloneSession(cmd *cobra.Command, clusterHost string) error {
+	// A present ENTIRE_TOKEN is a verbatim bearer git-remote-entire validates
+	// itself (and can't prompt for); match coreapi's presence-based precedence.
+	if _, ok := os.LookupEnv(auth.EnvTokenVar); ok {
+		return nil
+	}
+	if insecureHTTPRequested(cmd) {
+		auth.EnableInsecureHTTP()
+	}
+	servers, probeErr := probeClusterCloneSession(cmd.Context(), clusterHost)
+	if probeErr == nil {
+		return nil // a usable, cluster-eligible session exists
+	}
+
+	var hint string
+	switch msg, isReauth := auth.ReauthMessage(probeErr); {
+	case isReauth:
+		hint = msg // expired eligible context; servers == [that context's core]
+	case errors.Is(probeErr, auth.ErrNoEligibleContext):
+		hint = noEligibleClusterHint(clusterHost, servers)
+	default:
+		// Ambiguous (`entire auth use`) or discovery/transient — already friendly.
+		return probeErr
+	}
+
+	if !interactive.CanPromptInteractively() {
+		return errors.New(hint)
+	}
+	loggedIn, err := interactiveClusterLogin(cmd, servers, hint)
+	if err != nil {
+		return err
+	}
+	if !loggedIn {
+		return NewSilentError(errors.New(hint))
+	}
+	return nil
+}
+
+// noEligibleClusterHint composes the "log in to the cluster's region" message,
+// naming the cluster's advertised cores as the `entire login --server` targets
+// (which is exactly what makes a context eligible for the cluster).
+func noEligibleClusterHint(clusterHost string, servers []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "no auth context for cluster %s.\n", clusterHost)
+	switch len(servers) {
+	case 0:
+		b.WriteString("Log in with `entire login`, then re-run.")
+	case 1:
+		fmt.Fprintf(&b, "Log in to its region with `entire login --server %s`, then re-run.", servers[0])
+	default:
+		fmt.Fprintf(&b, "Log in to one of its regions, e.g. `entire login --server %s`, then re-run.", servers[0])
+	}
+	return b.String()
 }
 
 // mirrorLister is the subset of the control-plane client listMirrorsForRepo

--- a/cmd/entire/cli/repo_clone_cluster_login_test.go
+++ b/cmd/entire/cli/repo_clone_cluster_login_test.go
@@ -1,0 +1,222 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+)
+
+const testClusterHost = "aws-eu-central-1.entire.io"
+
+func swapProbeClusterCloneSession(t *testing.T, fn func(context.Context, string) ([]string, error)) {
+	t.Helper()
+	orig := probeClusterCloneSession
+	probeClusterCloneSession = fn
+	t.Cleanup(func() { probeClusterCloneSession = orig })
+}
+
+func swapInteractiveClusterLogin(t *testing.T, fn func(*cobra.Command, []string, string) (bool, error)) {
+	t.Helper()
+	orig := interactiveClusterLogin
+	interactiveClusterLogin = fn
+	t.Cleanup(func() { interactiveClusterLogin = orig })
+}
+
+func TestEnsureClusterCloneSession(t *testing.T) {
+	newCmd := func(t *testing.T) *cobra.Command {
+		cmd := newCloneTestCmd()
+		cmd.SetContext(t.Context())
+		return cmd
+	}
+
+	t.Run("usable cluster session proceeds without prompting", func(t *testing.T) {
+		unsetCloneEnvToken(t)
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			return nil, nil
+		})
+		swapInteractiveClusterLogin(t, func(*cobra.Command, []string, string) (bool, error) {
+			t.Fatal("interactiveClusterLogin must not run for a usable session")
+			return false, nil
+		})
+		require.NoError(t, ensureClusterCloneSession(newCmd(t), testClusterHost))
+	})
+
+	t.Run("expired eligible context offers login to its core", func(t *testing.T) {
+		unsetCloneEnvToken(t)
+		t.Setenv(interactive.EnvTestTTY, "1")
+		re := notLoggedInReauthErr(t)
+		msg, _ := auth.ReauthMessage(re)
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			return []string{testCloneLoginServer}, re
+		})
+		var gotServers []string
+		var gotHint string
+		swapInteractiveClusterLogin(t, func(_ *cobra.Command, servers []string, hint string) (bool, error) {
+			gotServers, gotHint = servers, hint
+			return true, nil
+		})
+		require.NoError(t, ensureClusterCloneSession(newCmd(t), testClusterHost))
+		require.Equal(t, []string{testCloneLoginServer}, gotServers)
+		require.Equal(t, msg, gotHint)
+	})
+
+	t.Run("no eligible context, non-interactive, names the cores", func(t *testing.T) {
+		unsetCloneEnvToken(t)
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			return []string{testCloneLoginServer}, auth.ErrNoEligibleContext
+		})
+		swapInteractiveClusterLogin(t, func(*cobra.Command, []string, string) (bool, error) {
+			t.Fatal("interactiveClusterLogin must not run without a TTY")
+			return false, nil
+		})
+		err := ensureClusterCloneSession(newCmd(t), testClusterHost)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no auth context for cluster "+testClusterHost)
+		require.Contains(t, err.Error(), testCloneLoginServer)
+	})
+
+	t.Run("no eligible context, interactive single core, logs in", func(t *testing.T) {
+		unsetCloneEnvToken(t)
+		t.Setenv(interactive.EnvTestTTY, "1")
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			return []string{testCloneLoginServer}, auth.ErrNoEligibleContext
+		})
+		var gotServers []string
+		swapInteractiveClusterLogin(t, func(_ *cobra.Command, servers []string, _ string) (bool, error) {
+			gotServers = servers
+			return true, nil
+		})
+		require.NoError(t, ensureClusterCloneSession(newCmd(t), testClusterHost))
+		require.Equal(t, []string{testCloneLoginServer}, gotServers)
+	})
+
+	t.Run("no eligible context, interactive multi core, passes all servers", func(t *testing.T) {
+		unsetCloneEnvToken(t)
+		t.Setenv(interactive.EnvTestTTY, "1")
+		cores := []string{testCloneLoginServer, "https://eu.auth.entire.io"}
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			return cores, auth.ErrNoEligibleContext
+		})
+		var gotServers []string
+		swapInteractiveClusterLogin(t, func(_ *cobra.Command, servers []string, _ string) (bool, error) {
+			gotServers = servers
+			return true, nil
+		})
+		require.NoError(t, ensureClusterCloneSession(newCmd(t), testClusterHost))
+		require.Equal(t, cores, gotServers)
+	})
+
+	t.Run("ambiguous context is surfaced, never auto-logs-in", func(t *testing.T) {
+		unsetCloneEnvToken(t)
+		t.Setenv(interactive.EnvTestTTY, "1")
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			return nil, auth.ErrAmbiguousContext
+		})
+		swapInteractiveClusterLogin(t, func(*cobra.Command, []string, string) (bool, error) {
+			t.Fatal("interactiveClusterLogin must not run for the ambiguous case")
+			return false, nil
+		})
+		err := ensureClusterCloneSession(newCmd(t), testClusterHost)
+		require.ErrorIs(t, err, auth.ErrAmbiguousContext)
+	})
+
+	t.Run("discovery error is surfaced, never prompts", func(t *testing.T) {
+		unsetCloneEnvToken(t)
+		t.Setenv(interactive.EnvTestTTY, "1")
+		discErr := errors.New("aws-eu-central-1.entire.io doesn't look like a cluster, or it is unreachable")
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			return nil, discErr
+		})
+		swapInteractiveClusterLogin(t, func(*cobra.Command, []string, string) (bool, error) {
+			t.Fatal("interactiveClusterLogin must not run for a discovery error")
+			return false, nil
+		})
+		err := ensureClusterCloneSession(newCmd(t), testClusterHost)
+		require.ErrorIs(t, err, discErr)
+	})
+
+	t.Run("interactive decline returns a silent clean hint", func(t *testing.T) {
+		unsetCloneEnvToken(t)
+		t.Setenv(interactive.EnvTestTTY, "1")
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			return []string{testCloneLoginServer}, auth.ErrNoEligibleContext
+		})
+		swapInteractiveClusterLogin(t, func(*cobra.Command, []string, string) (bool, error) {
+			return false, nil // declined
+		})
+		err := ensureClusterCloneSession(newCmd(t), testClusterHost)
+		require.Error(t, err)
+		var silentErr *SilentError
+		require.ErrorAs(t, err, &silentErr)
+		require.Contains(t, err.Error(), "no auth context for cluster "+testClusterHost)
+	})
+
+	t.Run("interactive login error propagates", func(t *testing.T) {
+		unsetCloneEnvToken(t)
+		t.Setenv(interactive.EnvTestTTY, "1")
+		loginErr := errors.New("login failed")
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			return []string{testCloneLoginServer}, auth.ErrNoEligibleContext
+		})
+		swapInteractiveClusterLogin(t, func(*cobra.Command, []string, string) (bool, error) {
+			return false, loginErr
+		})
+		err := ensureClusterCloneSession(newCmd(t), testClusterHost)
+		require.ErrorIs(t, err, loginErr)
+	})
+
+	t.Run("non-empty ENTIRE_TOKEN skips the probe", func(t *testing.T) {
+		t.Setenv(auth.EnvTokenVar, "tok")
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			t.Fatal("probe must not run when ENTIRE_TOKEN is set")
+			return nil, nil
+		})
+		require.NoError(t, ensureClusterCloneSession(newCmd(t), testClusterHost))
+	})
+
+	t.Run("empty ENTIRE_TOKEN skips the probe", func(t *testing.T) {
+		t.Setenv(auth.EnvTokenVar, "")
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			t.Fatal("probe must not run when ENTIRE_TOKEN is present but empty")
+			return nil, nil
+		})
+		require.NoError(t, ensureClusterCloneSession(newCmd(t), testClusterHost))
+	})
+}
+
+// TestRepoClone_ClusterSessionWiring asserts each URL form probes the correct
+// target cluster before touching git. The probe returns a stub error so RunE
+// stops before the real placements lookup / git clone; we only assert the host.
+func TestRepoClone_ClusterSessionWiring(t *testing.T) {
+	stop := errors.New("stop before clone")
+
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		unsetCloneEnvToken(t)
+		var gotHost string
+		swapProbeClusterCloneSession(t, func(_ context.Context, host string) ([]string, error) {
+			gotHost = host
+			return nil, stop // surfaced verbatim; halts RunE before lookup/git
+		})
+		cmd := newCloneTestCmd()
+		cmd.SetArgs(args)
+		require.ErrorIs(t, cmd.ExecuteContext(t.Context()), stop)
+		return gotHost
+	}
+
+	t.Run("full entire:// URL probes the URL's cluster", func(t *testing.T) {
+		got := run(t, "entire://"+testClusterHost+"/gh/gtrrz-victor/testing-rift")
+		require.Equal(t, testClusterHost, got)
+	})
+
+	t.Run("--cluster probes the flag's cluster", func(t *testing.T) {
+		got := run(t, "/gh/gtrrz-victor/testing-rift", "--cluster", testClusterHost)
+		require.Equal(t, testClusterHost, got)
+	})
+}

--- a/cmd/entire/cli/repo_clone_cluster_login_test.go
+++ b/cmd/entire/cli/repo_clone_cluster_login_test.go
@@ -96,6 +96,25 @@ func TestEnsureClusterCloneSession(t *testing.T) {
 		require.Equal(t, []string{testCloneLoginServer}, gotServers)
 	})
 
+	t.Run("no eligible context, interactive but no advertised cores, surfaces the friendly hint", func(t *testing.T) {
+		unsetCloneEnvToken(t)
+		t.Setenv(interactive.EnvTestTTY, "1")
+		swapProbeClusterCloneSession(t, func(context.Context, string) ([]string, error) {
+			return nil, auth.ErrNoEligibleContext // no cores to log into in-process
+		})
+		swapInteractiveClusterLogin(t, func(*cobra.Command, []string, string) (bool, error) {
+			t.Fatal("interactiveClusterLogin must not run with no advertised cores")
+			return false, nil
+		})
+		err := ensureClusterCloneSession(newCmd(t), testClusterHost)
+		require.Error(t, err)
+		// The composed friendly hint (not the raw "no login server" internal error).
+		require.Contains(t, err.Error(), "no auth context for cluster "+testClusterHost)
+		require.Contains(t, err.Error(), "Log in with `entire login`")
+		var silentErr *SilentError
+		require.NotErrorAs(t, err, &silentErr) // non-silent: main.go prints it
+	})
+
 	t.Run("no eligible context, interactive multi core, passes all servers", func(t *testing.T) {
 		unsetCloneEnvToken(t)
 		t.Setenv(interactive.EnvTestTTY, "1")

--- a/cmd/entire/cli/repo_clone_jurisdiction_test.go
+++ b/cmd/entire/cli/repo_clone_jurisdiction_test.go
@@ -57,6 +57,21 @@ func TestPreferHomeJurisdiction(t *testing.T) {
 	})
 }
 
+func TestDefaultCloneHomeJurisdiction_EnvTokenWins(t *testing.T) {
+	// Sets ENTIRE_TOKEN, so no t.Parallel().
+	t.Run("env token drives the default, not the stored context", func(t *testing.T) {
+		t.Setenv("ENTIRE_TOKEN", makeTestJWT(t, `{"sub":"ci-runner","aud":"https://core.eu.entire.io","home_jurisdiction":"eu"}`))
+		// A stored US context could exist, but the env token is the bearer the
+		// placement lookup actually used, so its "eu" claim must win.
+		require.Equal(t, "eu", defaultCloneHomeJurisdiction(context.Background()))
+	})
+
+	t.Run("blank env token is best-effort empty", func(t *testing.T) {
+		t.Setenv("ENTIRE_TOKEN", "  ")
+		require.Empty(t, defaultCloneHomeJurisdiction(context.Background()))
+	})
+}
+
 func swapCloneHomeJurisdiction(t *testing.T, fn func(context.Context) string) {
 	t.Helper()
 	orig := cloneHomeJurisdiction
@@ -86,5 +101,17 @@ func TestSelectCloneTarget_HomeJurisdictionDefault(t *testing.T) {
 		got, err := selectCloneTarget(newCloneTestCmd(), []coreapi.ResolvedPlacement{us, eu, usWest}, "aws-us-west-1.entire.io")
 		require.NoError(t, err)
 		require.Equal(t, "aws-us-west-1.entire.io", got.ClusterHost)
+	})
+
+	t.Run("single placement never resolves the home jurisdiction", func(t *testing.T) {
+		// With nothing to narrow, the home-region lookup (a control-plane target
+		// resolution + login-token read) is pure waste, so it must be skipped.
+		swapCloneHomeJurisdiction(t, func(context.Context) string {
+			t.Fatal("home jurisdiction must not be consulted for a single placement")
+			return ""
+		})
+		got, err := selectCloneTarget(newCloneTestCmd(), []coreapi.ResolvedPlacement{us}, "")
+		require.NoError(t, err)
+		require.Equal(t, "aws-us-east-2.entire.io", got.ClusterHost)
 	})
 }

--- a/cmd/entire/cli/repo_clone_jurisdiction_test.go
+++ b/cmd/entire/cli/repo_clone_jurisdiction_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+func placementIn(host, jurisdiction string) coreapi.ResolvedPlacement {
+	return coreapi.ResolvedPlacement{ClusterHost: host, Jurisdiction: coreapi.NewOptString(jurisdiction)}
+}
+
+func TestPreferHomeJurisdiction(t *testing.T) {
+	t.Parallel()
+
+	us1 := placementIn("aws-us-east-2.entire.io", "us")
+	us2 := placementIn("aws-us-west-1.entire.io", "us")
+	eu1 := placementIn("aws-eu-central-1.entire.io", "eu")
+
+	t.Run("narrows to the home jurisdiction", func(t *testing.T) {
+		t.Parallel()
+		got := preferHomeJurisdiction([]coreapi.ResolvedPlacement{us1, eu1, us2}, "eu")
+		require.Equal(t, []coreapi.ResolvedPlacement{eu1}, got)
+	})
+
+	t.Run("matches case-insensitively", func(t *testing.T) {
+		t.Parallel()
+		got := preferHomeJurisdiction([]coreapi.ResolvedPlacement{us1, eu1}, "EU")
+		require.Equal(t, []coreapi.ResolvedPlacement{eu1}, got)
+	})
+
+	t.Run("keeps every home-region placement", func(t *testing.T) {
+		t.Parallel()
+		got := preferHomeJurisdiction([]coreapi.ResolvedPlacement{us1, placementIn("aws-eu-west-1.entire.io", "eu"), eu1}, "eu")
+		require.Len(t, got, 2)
+	})
+
+	t.Run("unknown home leaves the list unchanged", func(t *testing.T) {
+		t.Parallel()
+		in := []coreapi.ResolvedPlacement{us1, eu1}
+		require.Equal(t, in, preferHomeJurisdiction(in, ""))
+	})
+
+	t.Run("no home-region match leaves the list unchanged", func(t *testing.T) {
+		t.Parallel()
+		in := []coreapi.ResolvedPlacement{us1, us2}
+		require.Equal(t, in, preferHomeJurisdiction(in, "eu"))
+	})
+
+	t.Run("single placement is untouched", func(t *testing.T) {
+		t.Parallel()
+		in := []coreapi.ResolvedPlacement{us1}
+		require.Equal(t, in, preferHomeJurisdiction(in, "eu"))
+	})
+}
+
+func swapCloneHomeJurisdiction(t *testing.T, fn func(context.Context) string) {
+	t.Helper()
+	orig := cloneHomeJurisdiction
+	cloneHomeJurisdiction = fn
+	t.Cleanup(func() { cloneHomeJurisdiction = orig })
+}
+
+func TestSelectCloneTarget_HomeJurisdictionDefault(t *testing.T) {
+	us := placementIn("aws-us-east-2.entire.io", "us")
+	eu := placementIn("aws-eu-central-1.entire.io", "eu")
+	usWest := placementIn("aws-us-west-1.entire.io", "us")
+
+	t.Run("no --cluster auto-selects the home-region placement", func(t *testing.T) {
+		swapCloneHomeJurisdiction(t, func(context.Context) string { return "eu" })
+		// Three clusters across two regions; home filter leaves one, so the picker
+		// is skipped (works even non-interactively) and eu is chosen.
+		got, err := selectCloneTarget(newCloneTestCmd(), []coreapi.ResolvedPlacement{us, eu, usWest}, "")
+		require.NoError(t, err)
+		require.Equal(t, "aws-eu-central-1.entire.io", got.ClusterHost)
+	})
+
+	t.Run("--cluster bypasses the home filter", func(t *testing.T) {
+		swapCloneHomeJurisdiction(t, func(context.Context) string {
+			t.Fatal("home jurisdiction must not be consulted when --cluster is set")
+			return ""
+		})
+		got, err := selectCloneTarget(newCloneTestCmd(), []coreapi.ResolvedPlacement{us, eu, usWest}, "aws-us-west-1.entire.io")
+		require.NoError(t, err)
+		require.Equal(t, "aws-us-west-1.entire.io", got.ClusterHost)
+	})
+}

--- a/cmd/entire/cli/repo_clone_login_test.go
+++ b/cmd/entire/cli/repo_clone_login_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+)
+
+const testCloneLoginServer = "https://us.auth.entire.io"
+
+// notLoggedInReauthErr returns a genuine *reauthError (as an opaque error) by
+// resolving the control-plane target under an isolated, empty config dir — the
+// only public path to the unexported type. Not parallel-safe (sets an env var).
+func notLoggedInReauthErr(t *testing.T) error {
+	t.Helper()
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	_, err := auth.ResolveControlPlaneTarget()
+	require.Error(t, err)
+	_, ok := auth.ReauthMessage(err)
+	require.True(t, ok, "expected a reauth error from an empty config dir")
+	return err
+}
+
+func swapProbeCloneSession(t *testing.T, fn func(context.Context) (string, error)) {
+	t.Helper()
+	orig := probeCloneSession
+	probeCloneSession = fn
+	t.Cleanup(func() { probeCloneSession = orig })
+}
+
+func swapInteractiveReauthLogin(t *testing.T, fn func(*cobra.Command, string, string) (bool, error)) {
+	t.Helper()
+	orig := interactiveReauthLogin
+	interactiveReauthLogin = fn
+	t.Cleanup(func() { interactiveReauthLogin = orig })
+}
+
+// TestRenderCoreError_StripsReauthNoise verifies the shared choke point surfaces
+// only the clean re-login hint, not the ogen/command wrapper noise from the
+// reported `entire repo clone` failure.
+func TestRenderCoreError_StripsReauthNoise(t *testing.T) {
+	re := notLoggedInReauthErr(t)
+	msg, ok := auth.ReauthMessage(re)
+	require.True(t, ok)
+
+	chain := fmt.Errorf("resolve mirror placements: %w",
+		fmt.Errorf("security \"BearerAuth\": %w", re))
+
+	got := renderCoreError(chain)
+	require.Error(t, got)
+	require.Equal(t, msg, got.Error())
+	require.NotContains(t, got.Error(), "resolve mirror placements")
+	require.NotContains(t, got.Error(), "BearerAuth")
+}
+
+func TestEnsureCloneSession(t *testing.T) {
+	newCmd := func(t *testing.T) *cobra.Command {
+		cmd := newCloneTestCmd()
+		cmd.SetContext(t.Context())
+		return cmd
+	}
+
+	t.Run("healthy session proceeds without prompting", func(t *testing.T) {
+		t.Setenv(auth.EnvTokenVar, "")
+		swapProbeCloneSession(t, func(context.Context) (string, error) {
+			return testCloneLoginServer, nil
+		})
+		swapInteractiveReauthLogin(t, func(*cobra.Command, string, string) (bool, error) {
+			t.Fatal("interactiveReauthLogin must not run for a healthy session")
+			return false, nil
+		})
+		require.NoError(t, ensureCloneSession(newCmd(t)))
+	})
+
+	t.Run("non-interactive reauth returns the clean hint, no login", func(t *testing.T) {
+		t.Setenv(auth.EnvTokenVar, "")
+		re := notLoggedInReauthErr(t)
+		msg, _ := auth.ReauthMessage(re)
+		swapProbeCloneSession(t, func(context.Context) (string, error) {
+			return testCloneLoginServer, re
+		})
+		swapInteractiveReauthLogin(t, func(*cobra.Command, string, string) (bool, error) {
+			t.Fatal("interactiveReauthLogin must not run without a TTY")
+			return false, nil
+		})
+		// Default go test is non-interactive, so no prompt is attempted.
+		err := ensureCloneSession(newCmd(t))
+		require.Error(t, err)
+		require.Equal(t, msg, err.Error())
+		require.NotContains(t, err.Error(), "BearerAuth")
+	})
+
+	t.Run("transient probe error passes through unchanged", func(t *testing.T) {
+		t.Setenv(auth.EnvTokenVar, "")
+		transient := errors.New("dial tcp: connection refused")
+		swapProbeCloneSession(t, func(context.Context) (string, error) {
+			return testCloneLoginServer, transient
+		})
+		swapInteractiveReauthLogin(t, func(*cobra.Command, string, string) (bool, error) {
+			t.Fatal("interactiveReauthLogin must not run for a transient error")
+			return false, nil
+		})
+		err := ensureCloneSession(newCmd(t))
+		require.ErrorIs(t, err, transient)
+	})
+
+	t.Run("non-empty ENTIRE_TOKEN skips the probe", func(t *testing.T) {
+		t.Setenv(auth.EnvTokenVar, "tok")
+		swapProbeCloneSession(t, func(context.Context) (string, error) {
+			t.Fatal("probe must not run when ENTIRE_TOKEN is set")
+			return "", nil
+		})
+		require.NoError(t, ensureCloneSession(newCmd(t)))
+	})
+
+	t.Run("interactive reauth logs in and continues", func(t *testing.T) {
+		t.Setenv(auth.EnvTokenVar, "")
+		t.Setenv(interactive.EnvTestTTY, "1")
+		re := notLoggedInReauthErr(t)
+		msg, _ := auth.ReauthMessage(re)
+		swapProbeCloneSession(t, func(context.Context) (string, error) {
+			return testCloneLoginServer, re
+		})
+		var gotServer, gotHint string
+		called := false
+		swapInteractiveReauthLogin(t, func(_ *cobra.Command, server, hint string) (bool, error) {
+			called = true
+			gotServer, gotHint = server, hint
+			return true, nil // logged in
+		})
+		require.NoError(t, ensureCloneSession(newCmd(t)))
+		require.True(t, called)
+		require.Equal(t, testCloneLoginServer, gotServer)
+		require.Equal(t, msg, gotHint)
+	})
+
+	t.Run("interactive decline returns the clean hint", func(t *testing.T) {
+		t.Setenv(auth.EnvTokenVar, "")
+		t.Setenv(interactive.EnvTestTTY, "1")
+		re := notLoggedInReauthErr(t)
+		msg, _ := auth.ReauthMessage(re)
+		swapProbeCloneSession(t, func(context.Context) (string, error) {
+			return testCloneLoginServer, re
+		})
+		swapInteractiveReauthLogin(t, func(*cobra.Command, string, string) (bool, error) {
+			return false, nil // user declined
+		})
+		err := ensureCloneSession(newCmd(t))
+		require.Error(t, err)
+		require.Equal(t, msg, err.Error())
+	})
+
+	t.Run("interactive login error propagates", func(t *testing.T) {
+		t.Setenv(auth.EnvTokenVar, "")
+		t.Setenv(interactive.EnvTestTTY, "1")
+		re := notLoggedInReauthErr(t)
+		loginErr := errors.New("login failed")
+		swapProbeCloneSession(t, func(context.Context) (string, error) {
+			return testCloneLoginServer, re
+		})
+		swapInteractiveReauthLogin(t, func(*cobra.Command, string, string) (bool, error) {
+			return false, loginErr
+		})
+		err := ensureCloneSession(newCmd(t))
+		require.ErrorIs(t, err, loginErr)
+	})
+}

--- a/cmd/entire/cli/repo_clone_login_test.go
+++ b/cmd/entire/cli/repo_clone_login_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -42,6 +43,19 @@ func swapInteractiveReauthLogin(t *testing.T, fn func(*cobra.Command, string, st
 	t.Cleanup(func() { interactiveReauthLogin = orig })
 }
 
+func unsetCloneEnvToken(t *testing.T) {
+	t.Helper()
+	value, present := os.LookupEnv(auth.EnvTokenVar)
+	require.NoError(t, os.Unsetenv(auth.EnvTokenVar))
+	t.Cleanup(func() {
+		if present {
+			require.NoError(t, os.Setenv(auth.EnvTokenVar, value)) //nolint:usetesting // restore captured presence and value
+		} else {
+			require.NoError(t, os.Unsetenv(auth.EnvTokenVar))
+		}
+	})
+}
+
 // TestRenderCoreError_StripsReauthNoise verifies the shared choke point surfaces
 // only the clean re-login hint, not the ogen/command wrapper noise from the
 // reported `entire repo clone` failure.
@@ -68,7 +82,7 @@ func TestEnsureCloneSession(t *testing.T) {
 	}
 
 	t.Run("healthy session proceeds without prompting", func(t *testing.T) {
-		t.Setenv(auth.EnvTokenVar, "")
+		unsetCloneEnvToken(t)
 		swapProbeCloneSession(t, func(context.Context) (string, error) {
 			return testCloneLoginServer, nil
 		})
@@ -80,7 +94,7 @@ func TestEnsureCloneSession(t *testing.T) {
 	})
 
 	t.Run("non-interactive reauth returns the clean hint, no login", func(t *testing.T) {
-		t.Setenv(auth.EnvTokenVar, "")
+		unsetCloneEnvToken(t)
 		re := notLoggedInReauthErr(t)
 		msg, _ := auth.ReauthMessage(re)
 		swapProbeCloneSession(t, func(context.Context) (string, error) {
@@ -98,7 +112,7 @@ func TestEnsureCloneSession(t *testing.T) {
 	})
 
 	t.Run("transient probe error passes through unchanged", func(t *testing.T) {
-		t.Setenv(auth.EnvTokenVar, "")
+		unsetCloneEnvToken(t)
 		transient := errors.New("dial tcp: connection refused")
 		swapProbeCloneSession(t, func(context.Context) (string, error) {
 			return testCloneLoginServer, transient
@@ -120,8 +134,17 @@ func TestEnsureCloneSession(t *testing.T) {
 		require.NoError(t, ensureCloneSession(newCmd(t)))
 	})
 
-	t.Run("interactive reauth logs in and continues", func(t *testing.T) {
+	t.Run("empty ENTIRE_TOKEN skips the probe", func(t *testing.T) {
 		t.Setenv(auth.EnvTokenVar, "")
+		swapProbeCloneSession(t, func(context.Context) (string, error) {
+			t.Fatal("probe must not run when ENTIRE_TOKEN is present but empty")
+			return "", nil
+		})
+		require.NoError(t, ensureCloneSession(newCmd(t)))
+	})
+
+	t.Run("interactive reauth logs in and continues", func(t *testing.T) {
+		unsetCloneEnvToken(t)
 		t.Setenv(interactive.EnvTestTTY, "1")
 		re := notLoggedInReauthErr(t)
 		msg, _ := auth.ReauthMessage(re)
@@ -142,7 +165,7 @@ func TestEnsureCloneSession(t *testing.T) {
 	})
 
 	t.Run("interactive decline returns the clean hint", func(t *testing.T) {
-		t.Setenv(auth.EnvTokenVar, "")
+		unsetCloneEnvToken(t)
 		t.Setenv(interactive.EnvTestTTY, "1")
 		re := notLoggedInReauthErr(t)
 		msg, _ := auth.ReauthMessage(re)
@@ -155,10 +178,12 @@ func TestEnsureCloneSession(t *testing.T) {
 		err := ensureCloneSession(newCmd(t))
 		require.Error(t, err)
 		require.Equal(t, msg, err.Error())
+		var silentErr *SilentError
+		require.ErrorAs(t, err, &silentErr)
 	})
 
 	t.Run("interactive login error propagates", func(t *testing.T) {
-		t.Setenv(auth.EnvTokenVar, "")
+		unsetCloneEnvToken(t)
 		t.Setenv(interactive.EnvTestTTY, "1")
 		re := notLoggedInReauthErr(t)
 		loginErr := errors.New("login failed")

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -132,6 +132,25 @@ func newCloneTestCmd() *cobra.Command {
 	return cmd
 }
 
+// TestCloneDeviceFlagWiring verifies the clone command exposes --device and that
+// deviceLoginRequested reflects it, so an inline re-login can honor the
+// device-code flow instead of being pinned to the browser redirect.
+func TestCloneDeviceFlagWiring(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default is browser redirect (device off)", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, deviceLoginRequested(newCloneTestCmd()))
+	})
+
+	t.Run("--device flips deviceLoginRequested on", func(t *testing.T) {
+		t.Parallel()
+		cmd := newCloneTestCmd()
+		require.NoError(t, cmd.Flags().Set("device", "true"))
+		require.True(t, deviceLoginRequested(cmd))
+	})
+}
+
 type nopWriter struct{}
 
 func (*nopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -219,6 +219,30 @@ func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, requ
 		}, debugf)
 }
 
+// ErrNoEligibleContext and ErrAmbiguousContext classify the two
+// account-selection failure modes so callers can branch on the cause
+// (errors.Is) instead of parsing the localized message. ErrNoEligibleContext
+// means no stored login is eligible for the resource — the caller can offer to
+// log in to one of the advertised cores. ErrAmbiguousContext means several
+// eligible logins exist and none is active — the fix is `entire auth use`, not
+// a fresh login.
+var (
+	ErrNoEligibleContext = errors.New("no eligible login context")
+	ErrAmbiguousContext  = errors.New("ambiguous login context")
+)
+
+// classifiedError carries a user-facing message while unwrapping to a
+// classification sentinel, so callers can errors.Is the failure mode without
+// parsing the message. Error() returns only msg, so the rendered text is
+// byte-identical to before these sentinels existed.
+type classifiedError struct {
+	msg      string
+	sentinel error
+}
+
+func (e *classifiedError) Error() string { return e.msg }
+func (e *classifiedError) Unwrap() error { return e.sentinel }
+
 // selectContext applies the account-selection rules over a resource's
 // advertised trusted issuers. subject is a noun phrase identifying the
 // resource ("cluster nyc.entire.io" / "API host partial.to") used in
@@ -240,12 +264,12 @@ func selectContext(f *contexts.File, subject string, coreURLs []string, debugf D
 	// 2. Otherwise the eligible set decides.
 	switch len(eligible) {
 	case 0:
-		return nil, errors.New(renderLoginHint(subject, coreURLs))
+		return nil, &classifiedError{msg: renderLoginHint(subject, coreURLs), sentinel: ErrNoEligibleContext}
 	case 1:
 		debugf("%s -> sole eligible context %s", subject, eligible[0].Name)
 		return eligible[0], nil
 	default:
-		return nil, ambiguousContextError(subject, eligible)
+		return nil, &classifiedError{msg: ambiguousContextError(subject, eligible).Error(), sentinel: ErrAmbiguousContext}
 	}
 }
 

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -97,6 +97,7 @@ func TestResolve_AmbiguousMultipleEligibleErrors(t *testing.T) {
 
 	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "cluster1.entire.io", hostPinningClient(t, srv), t.Logf)
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrAmbiguousContext)
 	assert.Contains(t, err.Error(), "multiple login contexts")
 	assert.Contains(t, err.Error(), "admin@core-us")
 	assert.Contains(t, err.Error(), "alice@core-us")
@@ -120,6 +121,7 @@ func TestResolve_NoEligibleContextReturnsLoginHint(t *testing.T) {
 
 	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNoEligibleContext)
 	assert.Contains(t, err.Error(), "no auth context for cluster aws-eu-central-1.entire.io")
 	assert.Contains(t, err.Error(), "entire login")
 	// Advertised login servers + the `entire auth use` hint are intentionally


### PR DESCRIPTION
## Problem
`entire repo clone` failed hard when the caller lacked a usable session. Two shapes:
- Any control-plane path dumped the raw ogen-wrapped chain (`resolve mirror placements: security "BearerAuth": … expired; run entire login`).
- A repo on **another region's cluster** failed with `fatal: no auth context for cluster <host>` from `git-remote-entire` (which can't prompt), because clone auth is **cluster-scoped** — the helper needs a local context whose `CoreURL` is in the target cluster's advertised `core_urls`, not just any active login.

## What changed
1. **Clean re-auth message (every control-plane command).** `auth.ReauthMessage` + `renderCoreError`/`runCoreClient` surface only the actionable `run entire login` hint instead of the wrapper-prefixed chain.
2. **Active-context precondition** for the `/gh/` placements lookup: prompt inline login when interactive, clean hint + non-zero exit otherwise.
3. **Cluster-aware precondition** (the fix for the cross-region case), wired into all three URL forms — full `entire://`, `--cluster`, and shorthand after placement selection. Probes the **target cluster** via `ResolveControlPlaneTargetForCluster`; when no eligible session exists, offers to `entire login --server <core>` for that cluster's region (a picker when several cores are trusted) and continues in-process. Non-interactive → clean hint naming the region. Ambiguous-context (`entire auth use`) and discovery failures are surfaced verbatim. Adds `clusterdiscovery.ErrNoEligibleContext`/`ErrAmbiguousContext` sentinels for clean classification.
4. **Home-region default in the placement picker.** A repo mirrored across many clusters no longer lists all of them: `selectCloneTarget` narrows placements to the caller's home jurisdiction (read locally from the login JWT's `home_jurisdiction` claim) before prompting, so a single home-region placement auto-selects. Best-effort — unknown/unmatched home shows all as before; `--cluster` bypasses the filter.

## Not doing
No central main.go catch / re-exec (that's #1794's `cli_upgrade_required` shape). `ENTIRE_TOKEN` runs skip the precondition (the helper validates the bearer itself).

## Testing
`ReauthMessage`, `renderCoreError` noise-strip, `ensureCloneSession` (7 cases), `ensureClusterCloneSession` (11 cases: usable / expired / no-eligible ×TTY×single/multi / ambiguous / discovery / decline / login-error / env-token), `preferHomeJurisdiction` + `selectCloneTarget` home-region default, RunE wiring (full-URL + `--cluster` forward the right host), clusterdiscovery sentinels. Full `cli` + `auth` + `clusterdiscovery` suites, `golangci-lint`, `gofmt` all green. Manual: cross-region `entire://` clone offers region login → continues; piped → clean hint, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
