### PR TITLE
feat: track CLI installs to PostHog (curl / brew / scoop)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -120,6 +120,8 @@ scoops:
     description: "CLI for Entire"
     license: MIT
     skip_upload: auto
+    post_install:
+      - "entire __track-install --method scoop"
 
 homebrew_casks:
   - name: entire
@@ -143,6 +145,10 @@ homebrew_casks:
     conflicts:
       - cask: entire@nightly
     skip_upload: auto
+    hooks:
+      post:
+        install: |
+          system_command "#{staged_path}/entire", args: ["__track-install", "--method", "brew"]
 
   - name: entire@nightly
     repository:
@@ -165,6 +171,10 @@ homebrew_casks:
     conflicts:
       - cask: entire
     skip_upload: "{{ if not .Prerelease }}true{{ end }}"
+    hooks:
+      post:
+        install: |
+          system_command "#{staged_path}/entire", args: ["__track-install", "--method", "brew"]
 
 announce:
   discord:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -121,7 +121,10 @@ scoops:
     license: MIT
     skip_upload: auto
     post_install:
-      - "entire __track-install --method scoop"
+      # Invoke the just-installed binary directly ($dir is this version's app
+      # dir) rather than relying on PATH, which could resolve an older entire.
+      # Wrapped so a tracking failure can never fail the install (best-effort).
+      - 'try { & "$dir\entire.exe" __track-install --method scoop *> $null } catch { }'
 
 homebrew_casks:
   - name: entire

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -164,6 +164,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newHooksCmd())
 	cmd.AddCommand(newTrailCmd())
 	cmd.AddCommand(newSendAnalyticsCmd())
+	cmd.AddCommand(newTrackInstallCmd())
 	cmd.AddCommand(newCurlBashPostInstallCmd())
 	cmd.AddCommand(newRefreshTrailEnablementCmd())
 
@@ -206,4 +207,21 @@ func newSendAnalyticsCmd() *cobra.Command {
 			telemetry.SendEvent(args[0])
 		},
 	}
+}
+
+// newTrackInstallCmd creates the hidden command invoked by the brew/scoop
+// installers to record a one-time install event. Not for direct user use.
+func newTrackInstallCmd() *cobra.Command {
+	var method string
+	cmd := &cobra.Command{
+		Use:    "__track-install",
+		Hidden: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			telemetry.TrackInstallDetached(method, versioninfo.Version)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&method, "method", "", "installation method (brew|scoop)")
+	markRequired(cmd, "method")
+	return cmd
 }

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -221,7 +221,7 @@ func newTrackInstallCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&method, "method", "", "installation method (brew|scoop)")
+	cmd.Flags().StringVar(&method, "method", "", "installation method (install.sh|brew|scoop)")
 	markRequired(cmd, "method")
 	return cmd
 }

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -221,7 +221,7 @@ func newTrackInstallCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&method, "method", "", "installation method (install.sh|brew|scoop)")
+	cmd.Flags().StringVar(&method, "method", "", "installation method (bash|brew|scoop)")
 	markRequired(cmd, "method")
 	return cmd
 }

--- a/cmd/entire/cli/root_test.go
+++ b/cmd/entire/cli/root_test.go
@@ -338,6 +338,22 @@ func TestRoot_VisibleCommandsAreGrouped(t *testing.T) {
 	}
 }
 
+func TestTrackInstallCmd_RequiresMethod(t *testing.T) {
+	t.Parallel()
+	cmd := newTrackInstallCmd()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when --method is missing")
+	}
+}
+
+func TestTrackInstallCmd_Hidden(t *testing.T) {
+	t.Parallel()
+	if !newTrackInstallCmd().Hidden {
+		t.Error("__track-install must be hidden")
+	}
+}
+
 func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -21,9 +21,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
-	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/vercelconfig"
-	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 
 	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
@@ -2078,8 +2076,6 @@ func newCurlBashPostInstallCmd() *cobra.Command {
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			w := cmd.OutOrStdout()
-			// Record the install (curl|bash path). Best-effort, detached, opt-out aware.
-			telemetry.TrackInstallDetached("install.sh", versioninfo.Version)
 			if err := promptShellCompletion(w); err != nil {
 				fmt.Fprintf(w, "Note: Shell completion setup skipped: %v\n", err)
 			}

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -21,7 +21,9 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/vercelconfig"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 
 	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
@@ -2076,6 +2078,8 @@ func newCurlBashPostInstallCmd() *cobra.Command {
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			w := cmd.OutOrStdout()
+			// Record the install (curl|bash path). Best-effort, detached, opt-out aware.
+			telemetry.TrackInstallDetached("install.sh", versioninfo.Version)
 			if err := promptShellCompletion(w); err != nil {
 				fmt.Fprintf(w, "Note: Shell completion setup skipped: %v\n", err)
 			}

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -191,11 +191,17 @@ func SendEvent(payloadJSON string) {
 	// Resolve the installed git version best-effort. A missing or failing
 	// git must never block the rest of the telemetry — the property is simply
 	// omitted when it can't be determined.
-	if v := gitVersion(context.Background()); v != "" {
-		if payload.Properties == nil {
-			payload.Properties = map[string]any{}
+	//
+	// Skipped for the pre-consent cli_installed event: its disclosure
+	// enumerates an exact, fixed set of properties (method/channel/
+	// cli_version/os/arch) with no git_version. Other events are unaffected.
+	if payload.Event != "cli_installed" {
+		if v := gitVersion(context.Background()); v != "" {
+			if payload.Properties == nil {
+				payload.Properties = map[string]any{}
+			}
+			payload.Properties["git_version"] = v
 		}
-		payload.Properties["git_version"] = v
 	}
 
 	// Build properties

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/denisbrodbeck/machineid"
 	"github.com/entireio/cli/cmd/entire/cli/execx"
+	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
 	"github.com/posthog/posthog-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -210,6 +211,48 @@ func SendEvent(payloadJSON string) {
 		Properties: props,
 		Timestamp:  payload.Timestamp,
 	})
+}
+
+// BuildInstallEventPayload constructs the cli_installed event payload.
+// Exported for testing. Returns nil if the machine ID cannot be resolved.
+func BuildInstallEventPayload(method, version string) *EventPayload {
+	machineID, err := machineid.ProtectedID("entire-cli")
+	if err != nil {
+		return nil
+	}
+
+	properties := map[string]any{
+		"method":      method,
+		"channel":     versioncheck.ReleaseChannel(version),
+		"cli_version": version,
+		"os":          runtime.GOOS,
+		"arch":        runtime.GOARCH,
+	}
+
+	return &EventPayload{
+		Event:      "cli_installed",
+		DistinctID: machineID,
+		Properties: properties,
+		Timestamp:  time.Now(),
+	}
+}
+
+// TrackInstallDetached records a one-time install event by spawning a detached
+// subprocess. Fires before the in-app telemetry consent prompt, so it is gated
+// only by ENTIRE_TELEMETRY_OPTOUT (see docs/security-and-privacy.md).
+func TrackInstallDetached(method, version string) {
+	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+		return
+	}
+
+	payload := BuildInstallEventPayload(method, version)
+	if payload == nil {
+		return
+	}
+
+	if payloadJSON, err := json.Marshal(payload); err == nil {
+		spawnDetachedAnalytics(string(payloadJSON))
+	}
 }
 
 // gitVersion returns the installed git version (e.g. "2.43.0"), best-effort.

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -3,8 +3,10 @@ package telemetry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/denisbrodbeck/machineid"
 	"github.com/entireio/cli/cmd/entire/cli/execx"
 	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 	"github.com/posthog/posthog-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -219,9 +222,24 @@ func SendEvent(payloadJSON string) {
 	})
 }
 
+// validInstallMethods is the closed set of installation channels recorded on
+// the cli_installed event. Unknown methods are dropped (no event) so manual or
+// mistaken invocations can't pollute install attribution — this set matches the
+// values documented in docs/security-and-privacy.md.
+var validInstallMethods = map[string]bool{
+	"bash":  true,
+	"brew":  true,
+	"scoop": true,
+}
+
 // BuildInstallEventPayload constructs the cli_installed event payload.
-// Exported for testing. Returns nil if the machine ID cannot be resolved.
+// Exported for testing. Returns nil for an unrecognized method or if the
+// machine ID cannot be resolved.
 func BuildInstallEventPayload(method, version string) *EventPayload {
+	if !validInstallMethods[method] {
+		return nil
+	}
+
 	machineID, err := machineid.ProtectedID("entire-cli")
 	if err != nil {
 		return nil
@@ -256,9 +274,41 @@ func TrackInstallDetached(method, version string) {
 		return
 	}
 
+	// Fire at most once per machine. The brew/scoop post-install hooks also run
+	// on upgrade/reinstall, so without this gate every upgrade (especially
+	// frequent nightlies) would re-emit cli_installed and inflate install
+	// counts. The sentinel keeps the event one-time, as documented.
+	if !markFirstInstall() {
+		return
+	}
+
 	if payloadJSON, err := json.Marshal(payload); err == nil {
 		spawnDetachedAnalytics(string(payloadJSON))
 	}
+}
+
+// markFirstInstall records a one-shot sentinel in the user cache dir and
+// reports whether this is the first install-track on this machine. It returns
+// true exactly once; later calls (upgrades/reinstalls) find the sentinel and
+// return false so the cli_installed event stays one-time. Best-effort: if the
+// sentinel cannot be resolved or created for any reason other than "already
+// exists", it returns true rather than silently dropping a genuine install.
+func markFirstInstall() bool {
+	path := filepath.Join(userdirs.Cache(), "install_tracked")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return true
+	}
+	// #nosec G304 -- path is the trusted user cache dir plus a constant
+	// filename, never user input.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err == nil {
+		_ = f.Close()
+		return true
+	}
+	if errors.Is(err, os.ErrExist) {
+		return false
+	}
+	return true
 }
 
 // gitVersion returns the installed git version (e.g. "2.43.0"), best-effort.

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -3,7 +3,6 @@ package telemetry
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -233,9 +232,11 @@ var validInstallMethods = map[string]bool{
 }
 
 // BuildInstallEventPayload constructs the cli_installed event payload.
-// Exported for testing. Returns nil for an unrecognized method or if the
-// machine ID cannot be resolved.
-func BuildInstallEventPayload(method, version string) *EventPayload {
+// previousVersion is the last version recorded on this machine ("" on a first
+// install), letting analytics tell installs from upgrades. Exported for
+// testing. Returns nil for an unrecognized method or if the machine ID cannot
+// be resolved.
+func BuildInstallEventPayload(method, version, previousVersion string) *EventPayload {
 	if !validInstallMethods[method] {
 		return nil
 	}
@@ -246,11 +247,12 @@ func BuildInstallEventPayload(method, version string) *EventPayload {
 	}
 
 	properties := map[string]any{
-		"method":      method,
-		"channel":     versioncheck.ReleaseChannel(version),
-		"cli_version": version,
-		"os":          runtime.GOOS,
-		"arch":        runtime.GOARCH,
+		"method":           method,
+		"channel":          versioncheck.ReleaseChannel(version),
+		"cli_version":      version,
+		"previous_version": previousVersion,
+		"os":               runtime.GOOS,
+		"arch":             runtime.GOARCH,
 	}
 
 	return &EventPayload{
@@ -261,54 +263,73 @@ func BuildInstallEventPayload(method, version string) *EventPayload {
 	}
 }
 
-// TrackInstallDetached records a one-time install event by spawning a detached
-// subprocess. Fires before the in-app telemetry consent prompt, so it is gated
-// only by ENTIRE_TELEMETRY_OPTOUT (see docs/security-and-privacy.md).
+// TrackInstallDetached records an install-or-upgrade event by spawning a
+// detached subprocess. It fires on every install AND upgrade (brew upgrade /
+// scoop update / reinstall all re-run the post-install hooks); analytics
+// distinguishes installs from upgrades via the per-machine distinct_id
+// (first-ever event = install) and the previous_version property. Fires before
+// the in-app telemetry consent prompt, so it is gated only by
+// ENTIRE_TELEMETRY_OPTOUT (see docs/security-and-privacy.md).
 func TrackInstallDetached(method, version string) {
 	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
 		return
 	}
 
-	payload := BuildInstallEventPayload(method, version)
+	previous := readInstalledVersion()
+	payload := BuildInstallEventPayload(method, version, previous)
 	if payload == nil {
 		return
 	}
 
-	// Fire at most once per machine. The brew/scoop post-install hooks also run
-	// on upgrade/reinstall, so without this gate every upgrade (especially
-	// frequent nightlies) would re-emit cli_installed and inflate install
-	// counts. The sentinel keeps the event one-time, as documented.
-	if !markFirstInstall() {
-		return
-	}
+	// Record the current version so the next install/upgrade can report it as
+	// previous_version. Best-effort — a write failure must never drop the event.
+	writeInstalledVersion(version)
 
 	if payloadJSON, err := json.Marshal(payload); err == nil {
 		spawnDetachedAnalytics(string(payloadJSON))
 	}
 }
 
-// markFirstInstall records a one-shot sentinel in the user cache dir and
-// reports whether this is the first install-track on this machine. It returns
-// true exactly once; later calls (upgrades/reinstalls) find the sentinel and
-// return false so the cli_installed event stays one-time. Best-effort: if the
-// sentinel cannot be resolved or created for any reason other than "already
-// exists", it returns true rather than silently dropping a genuine install.
-func markFirstInstall() bool {
-	path := filepath.Join(userdirs.Cache(), "install_tracked")
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return true
-	}
-	// #nosec G304 -- path is the trusted user cache dir plus a constant
+// installState is the per-user record of the last CLI version whose
+// install/upgrade was tracked. It lives in the persistent config dir (not the
+// ephemeral cache) so it survives cache clears.
+type installState struct {
+	Version string `json:"version"`
+}
+
+func installStatePath() string {
+	return filepath.Join(userdirs.Config(), "install_state.json")
+}
+
+// readInstalledVersion returns the last recorded CLI version, or "" when none
+// is recorded yet (first install) or the record can't be read.
+func readInstalledVersion() string {
+	// #nosec G304 -- path is the trusted user config dir plus a constant
 	// filename, never user input.
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
-	if err == nil {
-		_ = f.Close()
-		return true
+	data, err := os.ReadFile(installStatePath())
+	if err != nil {
+		return ""
 	}
-	if errors.Is(err, os.ErrExist) {
-		return false
+	var st installState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return ""
 	}
-	return true
+	return st.Version
+}
+
+// writeInstalledVersion records the current CLI version. Best-effort.
+func writeInstalledVersion(version string) {
+	dir := userdirs.Config()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return
+	}
+	data, err := json.Marshal(installState{Version: version})
+	if err != nil {
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dir, "install_state.json"), data, 0o600); err != nil {
+		return
+	}
 }
 
 // gitVersion returns the installed git version (e.g. "2.43.0"), best-effort.

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -155,6 +155,38 @@ func TestSendEventHandlesInvalidJSON(_ *testing.T) {
 	SendEvent("{}")
 }
 
+func TestBuildInstallEventPayload(t *testing.T) {
+	t.Parallel()
+	p := BuildInstallEventPayload("brew", "v1.2.3-nightly.20260805")
+	if p == nil {
+		t.Fatal("BuildInstallEventPayload returned nil")
+	}
+	if p.Event != "cli_installed" {
+		t.Errorf("Event = %q, want cli_installed", p.Event)
+	}
+	if p.DistinctID == "" {
+		t.Error("DistinctID is empty")
+	}
+	if p.Properties["method"] != "brew" {
+		t.Errorf("method = %v, want brew", p.Properties["method"])
+	}
+	if p.Properties["channel"] != "nightly" {
+		t.Errorf("channel = %v, want nightly", p.Properties["channel"])
+	}
+	if p.Properties["cli_version"] != "v1.2.3-nightly.20260805" {
+		t.Errorf("cli_version = %v", p.Properties["cli_version"])
+	}
+	if p.Properties["os"] == nil || p.Properties["arch"] == nil {
+		t.Error("os/arch missing")
+	}
+}
+
+func TestTrackInstallDetachedRespectsOptOut(t *testing.T) {
+	t.Setenv("ENTIRE_TELEMETRY_OPTOUT", "1")
+	// Should not panic and should skip sending.
+	TrackInstallDetached("scoop", "v1.2.3")
+}
+
 func TestParseGitVersion(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -187,6 +187,31 @@ func TestTrackInstallDetachedRespectsOptOut(t *testing.T) {
 	TrackInstallDetached("scoop", "v1.2.3")
 }
 
+func TestBuildInstallEventPayload_MethodAllowlist(t *testing.T) {
+	t.Parallel()
+	for _, m := range []string{"bash", "brew", "scoop"} {
+		if p := BuildInstallEventPayload(m, "v1.2.3"); p == nil || p.Properties["method"] != m {
+			t.Errorf("method %q should yield a payload, got %+v", m, p)
+		}
+	}
+	for _, m := range []string{"foo", "install.sh", ""} {
+		if p := BuildInstallEventPayload(m, "v1.2.3"); p != nil {
+			t.Errorf("unknown method %q should yield nil payload, got %+v", m, p)
+		}
+	}
+}
+
+func TestMarkFirstInstall(t *testing.T) {
+	// Uses t.Setenv, so cannot run in parallel.
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	if !markFirstInstall() {
+		t.Fatal("first markFirstInstall should return true (first install)")
+	}
+	if markFirstInstall() {
+		t.Error("second markFirstInstall should return false (already tracked)")
+	}
+}
+
 func TestParseGitVersion(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -157,7 +157,7 @@ func TestSendEventHandlesInvalidJSON(_ *testing.T) {
 
 func TestBuildInstallEventPayload(t *testing.T) {
 	t.Parallel()
-	p := BuildInstallEventPayload("brew", "v1.2.3-nightly.20260805")
+	p := BuildInstallEventPayload("brew", "v1.2.3-nightly.20260805", "v1.2.2")
 	if p == nil {
 		t.Fatal("BuildInstallEventPayload returned nil")
 	}
@@ -176,8 +176,22 @@ func TestBuildInstallEventPayload(t *testing.T) {
 	if p.Properties["cli_version"] != "v1.2.3-nightly.20260805" {
 		t.Errorf("cli_version = %v", p.Properties["cli_version"])
 	}
+	if p.Properties["previous_version"] != "v1.2.2" {
+		t.Errorf("previous_version = %v, want v1.2.2", p.Properties["previous_version"])
+	}
 	if p.Properties["os"] == nil || p.Properties["arch"] == nil {
 		t.Error("os/arch missing")
+	}
+}
+
+func TestBuildInstallEventPayload_FirstInstallHasEmptyPrevious(t *testing.T) {
+	t.Parallel()
+	p := BuildInstallEventPayload("bash", "v1.2.3", "")
+	if p == nil {
+		t.Fatal("BuildInstallEventPayload returned nil")
+	}
+	if p.Properties["previous_version"] != "" {
+		t.Errorf("first install previous_version = %v, want empty", p.Properties["previous_version"])
 	}
 }
 
@@ -190,25 +204,30 @@ func TestTrackInstallDetachedRespectsOptOut(t *testing.T) {
 func TestBuildInstallEventPayload_MethodAllowlist(t *testing.T) {
 	t.Parallel()
 	for _, m := range []string{"bash", "brew", "scoop"} {
-		if p := BuildInstallEventPayload(m, "v1.2.3"); p == nil || p.Properties["method"] != m {
+		if p := BuildInstallEventPayload(m, "v1.2.3", ""); p == nil || p.Properties["method"] != m {
 			t.Errorf("method %q should yield a payload, got %+v", m, p)
 		}
 	}
 	for _, m := range []string{"foo", "install.sh", ""} {
-		if p := BuildInstallEventPayload(m, "v1.2.3"); p != nil {
+		if p := BuildInstallEventPayload(m, "v1.2.3", ""); p != nil {
 			t.Errorf("unknown method %q should yield nil payload, got %+v", m, p)
 		}
 	}
 }
 
-func TestMarkFirstInstall(t *testing.T) {
+func TestInstalledVersionRoundTrip(t *testing.T) {
 	// Uses t.Setenv, so cannot run in parallel.
-	t.Setenv("XDG_CACHE_HOME", t.TempDir())
-	if !markFirstInstall() {
-		t.Fatal("first markFirstInstall should return true (first install)")
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	if got := readInstalledVersion(); got != "" {
+		t.Errorf("no state yet: want empty, got %q", got)
 	}
-	if markFirstInstall() {
-		t.Error("second markFirstInstall should return false (already tracked)")
+	writeInstalledVersion("v1.0.0")
+	if got := readInstalledVersion(); got != "v1.0.0" {
+		t.Errorf("after first write: want v1.0.0, got %q", got)
+	}
+	writeInstalledVersion("v1.1.0")
+	if got := readInstalledVersion(); got != "v1.1.0" {
+		t.Errorf("after upgrade write: want v1.1.0, got %q", got)
 	}
 }
 

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -336,7 +336,8 @@ func releaseNotesURL(version string) string {
 // It's a variable so tests can override it.
 var executablePath = os.Executable
 
-func releaseChannel(version string) string {
+// ReleaseChannel reports whether the given version is a stable or nightly build.
+func ReleaseChannel(version string) string {
 	if isNightly(version) {
 		return installChannelNightly
 	}
@@ -394,7 +395,7 @@ const downloadsURL = "https://github.com/entireio/cli/releases"
 func updateCommand(currentVersion string) string {
 	switch installManagerForCurrentBinary() {
 	case installManagerBrew:
-		if releaseChannel(currentVersion) == installChannelNightly {
+		if ReleaseChannel(currentVersion) == installChannelNightly {
 			return "brew upgrade --yes entire@nightly"
 		}
 		return "brew upgrade --yes entire"
@@ -404,7 +405,7 @@ func updateCommand(currentVersion string) string {
 		return "scoop update entire/cli"
 	}
 
-	if releaseChannel(currentVersion) == installChannelNightly {
+	if ReleaseChannel(currentVersion) == installChannelNightly {
 		return "curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly"
 	}
 	return "curl -fsSL https://entire.io/install.sh | bash"

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -59,6 +59,16 @@ func TestIsOutdated(t *testing.T) {
 	}
 }
 
+func TestReleaseChannel(t *testing.T) {
+	t.Parallel()
+	if got := ReleaseChannel("v1.2.3"); got != "stable" {
+		t.Errorf("ReleaseChannel(stable) = %q, want stable", got)
+	}
+	if got := ReleaseChannel("v1.2.3-nightly.20260805"); got != "nightly" {
+		t.Errorf("ReleaseChannel(nightly) = %q, want nightly", got)
+	}
+}
+
 func TestIsNightly(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -393,6 +393,10 @@ Opt out via any one of:
 - `"telemetry": false` in `.entire/settings.json` or `.entire/settings.local.json`.
 - `ENTIRE_TELEMETRY_OPTOUT=1` in the environment.
 
+### Install event
+
+On installation, the CLI sends a one-time anonymous `cli_installed` event to PostHog with: `method` (`install.sh` / `brew` / `scoop`), `channel` (`stable` / `nightly`), `cli_version`, `os`, and `arch`. The identifier is the same hashed per-machine ID used for other telemetry (`machineid.ProtectedID`) — no personal data is sent. Because installation happens before the in-app telemetry prompt, this event is governed solely by the `ENTIRE_TELEMETRY_OPTOUT` environment variable: set `ENTIRE_TELEMETRY_OPTOUT=1` before installing to disable it.
+
 ## Reporting a vulnerability
 
 For vulnerability disclosure, see [SECURITY.md](../SECURITY.md) at the repo root: email `security@entire.io`, expect acknowledgment within 48 hours and resolution of criticals within 90 days.

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -395,7 +395,7 @@ Opt out via any one of:
 
 ### Install event
 
-On installation, the CLI sends a one-time anonymous `cli_installed` event to PostHog with: `method` (`bash` / `brew` / `scoop`), `channel` (`stable` / `nightly`), `cli_version`, `os`, and `arch`. The identifier is the same hashed per-machine ID used for other telemetry (`machineid.ProtectedID`) — no personal data is sent. Because installation happens before the in-app telemetry prompt, this event is governed solely by the `ENTIRE_TELEMETRY_OPTOUT` environment variable: set `ENTIRE_TELEMETRY_OPTOUT=1` before installing to disable it. The event fires at most once per machine — a local sentinel keeps `brew upgrade` / `scoop update` from re-emitting it.
+On installation **and upgrade**, the CLI sends an anonymous `cli_installed` event to PostHog with: `method` (`bash` / `brew` / `scoop`), `channel` (`stable` / `nightly`), `cli_version`, `previous_version` (the last version recorded on this machine; empty on a first install), `os`, and `arch`. The identifier is the same hashed per-machine ID used for other telemetry (`machineid.ProtectedID`) — no personal data is sent. First installs are distinguished from upgrades by `previous_version` (and by first-vs-repeat events per machine); the last version is kept in a small `install_state.json` in the config directory. Because installation happens before the in-app telemetry prompt, this event is governed solely by the `ENTIRE_TELEMETRY_OPTOUT` environment variable: set `ENTIRE_TELEMETRY_OPTOUT=1` before installing to disable it.
 
 ## Reporting a vulnerability
 

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -395,7 +395,7 @@ Opt out via any one of:
 
 ### Install event
 
-On installation, the CLI sends a one-time anonymous `cli_installed` event to PostHog with: `method` (`install.sh` / `brew` / `scoop`), `channel` (`stable` / `nightly`), `cli_version`, `os`, and `arch`. The identifier is the same hashed per-machine ID used for other telemetry (`machineid.ProtectedID`) — no personal data is sent. Because installation happens before the in-app telemetry prompt, this event is governed solely by the `ENTIRE_TELEMETRY_OPTOUT` environment variable: set `ENTIRE_TELEMETRY_OPTOUT=1` before installing to disable it.
+On installation, the CLI sends a one-time anonymous `cli_installed` event to PostHog with: `method` (`bash` / `brew` / `scoop`), `channel` (`stable` / `nightly`), `cli_version`, `os`, and `arch`. The identifier is the same hashed per-machine ID used for other telemetry (`machineid.ProtectedID`) — no personal data is sent. Because installation happens before the in-app telemetry prompt, this event is governed solely by the `ENTIRE_TELEMETRY_OPTOUT` environment variable: set `ENTIRE_TELEMETRY_OPTOUT=1` before installing to disable it. The event fires at most once per machine — a local sentinel keeps `brew upgrade` / `scoop update` from re-emitting it.
 
 ## Reporting a vulnerability
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -269,6 +269,12 @@ main() {
         error "Installation completed but the binary failed to execute. Please check the installation."
     fi
 
+    # Record the install as early as possible — before any PATH-related early
+    # exit below — so first-time installs (not yet on PATH) are still counted.
+    # Best-effort, detached, opt-out aware; uses the absolute path, not PATH.
+    info "Sending an anonymous install ping. Set ENTIRE_TELEMETRY_OPTOUT=1 (before installing) to disable."
+    "$install_path" __track-install --method install.sh || true
+
     # Check if the installed binary is the one that will be found in PATH
     local path_binary
     path_binary=$(command -v "entire" 2>/dev/null || true)
@@ -333,7 +339,6 @@ main() {
     fi
 
     info "Running post-install actions..."
-    info "Sending an anonymous install ping. Set ENTIRE_TELEMETRY_OPTOUT=1 to disable."
     "$install_path" curl-bash-post-install
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -273,7 +273,7 @@ main() {
     # exit below — so first-time installs (not yet on PATH) are still counted.
     # Best-effort, detached, opt-out aware; uses the absolute path, not PATH.
     info "Sending an anonymous install ping. Set ENTIRE_TELEMETRY_OPTOUT=1 (before installing) to disable."
-    "$install_path" __track-install --method install.sh || true
+    "$install_path" __track-install --method bash || true
 
     # Check if the installed binary is the one that will be found in PATH
     local path_binary

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -333,6 +333,7 @@ main() {
     fi
 
     info "Running post-install actions..."
+    info "Sending an anonymous install ping. Set ENTIRE_TELEMETRY_OPTOUT=1 to disable."
     "$install_path" curl-bash-post-install
 }
 


### PR DESCRIPTION
## What

Emit an anonymous `cli_installed` event to PostHog on install **and upgrade**, tagged with the installation method, so we can track adoption across our three distribution channels (curl `bash`, Homebrew cask, Scoop).

Reuses the existing detached telemetry pipeline — no second PostHog client.

## Event

```
event:       cli_installed
distinct_id: machineid.ProtectedID("entire-cli")   # existing hashed per-machine id
properties:  method            (bash | brew | scoop)
             channel           (stable | nightly, derived from version)
             cli_version
             previous_version  (last version seen on this machine; "" on first install)
             os, arch
```

Methods outside the `bash|brew|scoop` allowlist are dropped (no event), so a manual or mistaken `__track-install` run can't pollute attribution.

## Install vs upgrade

Rather than gate client-side, the event fires on every install and upgrade and the split is derived downstream — the standard telemetry pattern (this is how Homebrew's own analytics work):

- **`distinct_id`** is the hashed per-machine id, so PostHog's first-touch = install, repeats = upgrades.
- **`previous_version`** is read from a small persisted `install_state.json` in the **config** dir (empty on first install), giving an explicit, cache-clear-proof upgrade signal and version-transition history.

An earlier revision gated with a one-shot marker in the **cache** dir; that was replaced because the cache is ephemeral (a wipe re-counted the machine as new) and it threw away upgrade data.

## How it fires per channel

| Channel | Mechanism |
|---------|-----------|
| curl | `install.sh` calls `entire __track-install --method bash` **right after install verification**, before any PATH-related early exit (so first-time installs are counted) |
| brew | both casks' `hooks.post.install` → `entire __track-install --method brew` |
| scoop | manifest `post_install` → `"$dir\entire.exe" __track-install --method scoop` (app-local binary, wrapped in `try/catch` so tracking can't fail the install) |

`__track-install` is a hidden command that calls `TrackInstallDetached` (detached, non-blocking).

## Consent / privacy

The event fires **before** the in-app telemetry consent prompt, so it is gated **only** by `ENTIRE_TELEMETRY_OPTOUT`. This is disclosed in `install.sh` output and in `docs/security-and-privacy.md`, including the `install_state.json` version record. `git_version` (added to other events) is deliberately kept **off** this event so the payload matches the documented property set exactly.

## Open question for reviewers

`.goreleaser.nonprod.yaml` is intentionally **not** wired — only prod `.goreleaser.yaml` emits install events. Confirm nightly-via-nonprod not emitting is intended, or I'll follow up.

## Testing

- Unit tests for the payload builder, method allowlist, `previous_version` (populated + empty), the install-state round-trip, opt-out gate, `ReleaseChannel`, and the hidden command.
- Full unit suite green (8537 pass / 4 skip). `goreleaser check` passes; `bash -n` clean; lint clean (golangci-lint v2.11.3).
- **Not verifiable in CI:** the brew cask `#{staged_path}/entire` hook resolving at real `brew install` time — smoke-test on the next nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
