### PR TITLE
fix(subagent): resolve subagent transcripts in Claude Code's current layout

### DIFF
--- a/cmd/entire/cli/agent/claudecode/transcript.go
+++ b/cmd/entire/cli/agent/claudecode/transcript.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
 )
@@ -428,7 +429,7 @@ func (c *ClaudeCodeAgent) CalculateTotalTokenUsage(transcriptData []byte, startL
 	if len(agentIDs) > 0 {
 		subagentUsage := &agent.TokenUsage{}
 		for agentID := range agentIDs {
-			agentPath := filepath.Join(subagentsDir, fmt.Sprintf("agent-%s.jsonl", agentID))
+			agentPath := filepath.Join(subagentsDir, paths.AgentTranscriptFileName(agentID))
 			agentUsage, err := CalculateTokenUsageFromFile(agentPath, 0)
 			if err != nil {
 				// Agent transcript may not exist yet or may have been cleaned up
@@ -493,7 +494,7 @@ func (c *ClaudeCodeAgent) ExtractAllModifiedFiles(transcriptData []byte, startLi
 	}
 	agentIDs := ExtractSpawnedAgentIDs(fullParsed)
 	for agentID := range agentIDs {
-		agentPath := filepath.Join(subagentsDir, fmt.Sprintf("agent-%s.jsonl", agentID))
+		agentPath := filepath.Join(subagentsDir, paths.AgentTranscriptFileName(agentID))
 		agentLines, agentErr := transcript.ParseFromFileAtLine(agentPath, 0)
 		if agentErr != nil {
 			// Subagent transcript may not exist yet or may have been cleaned up

--- a/cmd/entire/cli/agent/factoryaidroid/transcript.go
+++ b/cmd/entire/cli/agent/factoryaidroid/transcript.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
 )
@@ -394,7 +395,7 @@ func CalculateTotalTokenUsageFromBytes(data []byte, startLine int, subagentsDir 
 	if len(agentIDs) > 0 {
 		subagentUsage := &agent.TokenUsage{}
 		for agentID := range agentIDs {
-			agentPath := filepath.Join(subagentsDir, fmt.Sprintf("agent-%s.jsonl", agentID))
+			agentPath := filepath.Join(subagentsDir, paths.AgentTranscriptFileName(agentID))
 			agentUsage, err := CalculateTokenUsageFromFile(agentPath, 0)
 			if err != nil {
 				continue
@@ -451,7 +452,7 @@ func ExtractAllModifiedFilesFromBytes(data []byte, startLine int, subagentsDir s
 	}
 	agentIDs := ExtractSpawnedAgentIDs(fullParsed)
 	for agentID := range agentIDs {
-		agentPath := filepath.Join(subagentsDir, fmt.Sprintf("agent-%s.jsonl", agentID))
+		agentPath := filepath.Join(subagentsDir, paths.AgentTranscriptFileName(agentID))
 		agentLines, _, agentErr := ParseDroidTranscript(agentPath, 0)
 		if agentErr != nil {
 			continue

--- a/cmd/entire/cli/agentimport/claude.go
+++ b/cmd/entire/cli/agentimport/claude.go
@@ -10,6 +10,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
 )
 
@@ -39,7 +40,7 @@ func (claudeImporter) Discover(repoRoot, overridePath string, now time.Time, ses
 // rescopeSubagentTokensToDeltas). tool_result lines (Type == "user" but no text
 // content) do not start a turn.
 func (claudeImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
-	subagentsDir := filepath.Join(filepath.Dir(sf.Path), sf.SessionID, "subagents")
+	subagentsDir := paths.SubagentsDir(filepath.Dir(sf.Path), sf.SessionID)
 	ag := &claudecode.ClaudeCodeAgent{}
 	return splitLineTurns(splitRawLines(full), isUserPromptLine,
 		func(rawLines [][]byte, start, end int, truncated []byte) (*Turn, error) {

--- a/cmd/entire/cli/agentimport/factory.go
+++ b/cmd/entire/cli/agentimport/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
 )
 
@@ -42,7 +43,7 @@ func (factoryImporter) Discover(repoRoot, overridePath string, now time.Time, se
 // time.Now() at hook time), so every turn falls back to the transcript file's
 // modtime — the same fallback the Gemini importer uses.
 func (factoryImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
-	subagentsDir := filepath.Join(filepath.Dir(sf.Path), sf.SessionID, "subagents")
+	subagentsDir := paths.SubagentsDir(filepath.Dir(sf.Path), sf.SessionID)
 	model := factoryaidroid.ExtractModelFromTranscript(sf.Path)
 	var createdAt time.Time
 	if info, statErr := os.Stat(sf.Path); statErr == nil {

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
@@ -291,6 +292,54 @@ func (s *Session) CreateTranscript(prompt string, changes []FileChange) string {
 	}
 
 	return s.TranscriptPath
+}
+
+// CreateSubagentTranscript writes a transcript for a subagent of this session,
+// where current agent versions store it: paths.SubagentsDir/agent-<agentID>.jsonl.
+// Returns the path.
+//
+// A subagent's Write/Edit tool uses appear only in its own transcript, never in the
+// main one, so tests that exercise subagent file extraction or task-checkpoint
+// storage need this rather than CreateTranscript.
+func (s *Session) CreateSubagentTranscript(agentID string, changes []FileChange) string {
+	s.env.T.Helper()
+
+	dir := paths.SubagentsDir(filepath.Dir(s.TranscriptPath), s.ID)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		s.env.T.Fatalf("failed to create subagents dir: %v", err)
+	}
+	path := filepath.Join(dir, paths.AgentTranscriptFileName(agentID))
+	s.writeSubagentTranscriptTo(path, changes)
+	return path
+}
+
+// CreateLegacySubagentTranscript writes a subagent transcript in the pre-nesting
+// layout — agent-<agentID>.jsonl as a sibling of the main transcript — for tests
+// that must keep older sessions resolving.
+func (s *Session) CreateLegacySubagentTranscript(agentID string, changes []FileChange) string {
+	s.env.T.Helper()
+
+	path := filepath.Join(filepath.Dir(s.TranscriptPath), paths.AgentTranscriptFileName(agentID))
+	s.writeSubagentTranscriptTo(path, changes)
+	return path
+}
+
+// writeSubagentTranscriptTo builds a minimal subagent transcript (its own builder,
+// so it never pollutes the main session transcript) and writes it to path.
+func (s *Session) writeSubagentTranscriptTo(path string, changes []FileChange) {
+	s.env.T.Helper()
+
+	builder := NewTranscriptBuilder()
+	builder.AddUserMessage("subagent task")
+	for _, change := range changes {
+		toolID := builder.AddToolUse("mcp__acp__Write", change.Path, change.Content)
+		builder.AddToolResult(toolID)
+	}
+	builder.AddAssistantMessage("Done!")
+
+	if err := builder.WriteToFile(path); err != nil {
+		s.env.T.Fatalf("failed to write subagent transcript %s: %v", path, err)
+	}
 }
 
 // SimulateUserPromptSubmit is a convenience method on TestEnv.

--- a/cmd/entire/cli/integration_test/subagent_transcript_layout_test.go
+++ b/cmd/entire/cli/integration_test/subagent_transcript_layout_test.go
@@ -3,177 +3,80 @@
 package integration
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v6"
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
 
-// TestSubagentCheckpoints_StoresSubagentTranscript_CurrentLayout verifies that the
-// task checkpoint captures the subagent's own transcript when it is stored the way
-// current Claude Code versions store it: <transcriptDir>/<sessionID>/subagents/.
+// TestSubagentCheckpoints_StoresSubagentTranscript asserts the task checkpoint
+// captures the subagent's own transcript, in both layouts agents have used for it —
+// see ResolveAgentTranscriptPath for which one wins and why the fallback exists.
 //
-// Resolving only the legacy sibling layout (<transcriptDir>/agent-<id>.jsonl) meant
-// the path never existed for a modern session, so the subagent transcript was never
-// committed and file extraction fell back to the main transcript — where a
-// subagent's Write/Edit calls do not appear.
-func TestSubagentCheckpoints_StoresSubagentTranscript_CurrentLayout(t *testing.T) {
+// Claude Code writes an agent-<id>.meta.json sidecar next to the nested transcript;
+// nothing in the CLI reads it, so these tests do not create one.
+func TestSubagentCheckpoints_StoresSubagentTranscript(t *testing.T) {
 	t.Parallel()
-	env := NewFeatureBranchEnv(t)
-	session := env.NewSession()
-	session.CreateTranscript("delegate red.md to a subagent", nil)
 
-	const (
-		taskToolUseID = "toolu_01LayoutABC123"
-		subagentID    = "a0123456789abcdef"
-	)
-	writeSubagentTranscript(t, session, subagentID, "docs/red.md")
+	const editedFile = "docs/red.md"
 
-	if err := env.SimulateUserPromptSubmit(session.ID); err != nil {
-		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
-	}
-	if err := env.SimulatePreTask(session.ID, session.TranscriptPath, taskToolUseID); err != nil {
-		t.Fatalf("SimulatePreTask failed: %v", err)
-	}
-
-	// The subagent edits a file; only its own transcript records the Write.
-	env.WriteFile("docs/red.md", "Red is a warm colour.\n")
-
-	if err := env.SimulatePostTask(PostTaskInput{
-		SessionID:      session.ID,
-		TranscriptPath: session.TranscriptPath,
-		ToolUseID:      taskToolUseID,
-		AgentID:        subagentID,
-	}); err != nil {
-		t.Fatalf("SimulatePostTask failed: %v", err)
+	tests := []struct {
+		name          string
+		taskToolUseID string
+		subagentID    string
+		write         func(s *Session, agentID string, changes []FileChange) string
+	}{
+		{
+			name:          "current nested layout",
+			taskToolUseID: "toolu_01LayoutABC123",
+			subagentID:    "a0123456789abcdef",
+			write:         (*Session).CreateSubagentTranscript,
+		},
+		{
+			name:          "legacy sibling layout",
+			taskToolUseID: "toolu_01LegacyABC123",
+			subagentID:    "afedcba9876543210",
+			write:         (*Session).CreateLegacySubagentTranscript,
+		},
 	}
 
-	wantPath := ".entire/metadata/" + session.ID + "/tasks/" + taskToolUseID + "/agent-" + subagentID + ".jsonl"
-	content, ok := readShadowFile(t, env, wantPath)
-	if !ok {
-		t.Fatalf("subagent transcript not stored in shadow branch at %s", wantPath)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Each subtest asserts a different on-disk layout, so they cannot share a repo.
+			env := NewFeatureBranchEnv(t)
+			session := env.NewSession()
+			session.CreateTranscript("delegate "+editedFile+" to a subagent", nil)
+			tt.write(session, tt.subagentID, []FileChange{{Path: editedFile, Content: "content"}})
+
+			if err := env.SimulateUserPromptSubmit(session.ID); err != nil {
+				t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+			}
+			if err := env.SimulatePreTask(session.ID, session.TranscriptPath, tt.taskToolUseID); err != nil {
+				t.Fatalf("SimulatePreTask failed: %v", err)
+			}
+
+			// The subagent edits a file; only its own transcript records the Write.
+			env.WriteFile(editedFile, "Red is a warm colour.\n")
+
+			if err := env.SimulatePostTask(PostTaskInput{
+				SessionID:      session.ID,
+				TranscriptPath: session.TranscriptPath,
+				ToolUseID:      tt.taskToolUseID,
+				AgentID:        tt.subagentID,
+			}); err != nil {
+				t.Fatalf("SimulatePostTask failed: %v", err)
+			}
+
+			wantPath := paths.EntireMetadataDir + "/" + session.ID +
+				"/tasks/" + tt.taskToolUseID + "/" + paths.AgentTranscriptFileName(tt.subagentID)
+			content, ok := env.ReadFileFromBranch(env.GetShadowBranchName(), wantPath)
+			if !ok {
+				t.Fatalf("subagent transcript not stored in shadow branch at %s", wantPath)
+			}
+			if !strings.Contains(content, editedFile) {
+				t.Errorf("stored subagent transcript does not reference the subagent's edit: %q", content)
+			}
+		})
 	}
-	if !strings.Contains(content, "docs/red.md") {
-		t.Errorf("stored subagent transcript does not reference the subagent's edit: %q", content)
-	}
-}
-
-// TestSubagentCheckpoints_StoresSubagentTranscript_LegacyLayout keeps the older
-// sibling layout working, so sessions recorded by earlier agent versions still get
-// their subagent transcript captured.
-func TestSubagentCheckpoints_StoresSubagentTranscript_LegacyLayout(t *testing.T) {
-	t.Parallel()
-	env := NewFeatureBranchEnv(t)
-	session := env.NewSession()
-	session.CreateTranscript("delegate blue.md to a subagent", nil)
-
-	const (
-		taskToolUseID = "toolu_01LegacyABC123"
-		subagentID    = "afedcba9876543210"
-	)
-	// Legacy: a sibling of the main transcript, with no <sessionID>/subagents/ dir.
-	legacyPath := filepath.Join(filepath.Dir(session.TranscriptPath), "agent-"+subagentID+".jsonl")
-	writeTranscriptFile(t, legacyPath, "docs/blue.md")
-
-	if err := env.SimulateUserPromptSubmit(session.ID); err != nil {
-		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
-	}
-	if err := env.SimulatePreTask(session.ID, session.TranscriptPath, taskToolUseID); err != nil {
-		t.Fatalf("SimulatePreTask failed: %v", err)
-	}
-	env.WriteFile("docs/blue.md", "Blue is a cool colour.\n")
-
-	if err := env.SimulatePostTask(PostTaskInput{
-		SessionID:      session.ID,
-		TranscriptPath: session.TranscriptPath,
-		ToolUseID:      taskToolUseID,
-		AgentID:        subagentID,
-	}); err != nil {
-		t.Fatalf("SimulatePostTask failed: %v", err)
-	}
-
-	wantPath := ".entire/metadata/" + session.ID + "/tasks/" + taskToolUseID + "/agent-" + subagentID + ".jsonl"
-	if _, ok := readShadowFile(t, env, wantPath); !ok {
-		t.Fatalf("subagent transcript not stored in shadow branch at %s", wantPath)
-	}
-}
-
-// writeSubagentTranscript writes a subagent transcript where current Claude Code
-// versions put it: <transcriptDir>/<sessionID>/subagents/agent-<id>.jsonl, next to
-// the agent-<id>.meta.json sidecar the agent also writes.
-func writeSubagentTranscript(t *testing.T, session *Session, subagentID, editedPath string) {
-	t.Helper()
-
-	dir := filepath.Join(filepath.Dir(session.TranscriptPath), session.ID, "subagents")
-	if err := os.MkdirAll(dir, 0o750); err != nil {
-		t.Fatalf("failed to create subagents dir: %v", err)
-	}
-	writeTranscriptFile(t, filepath.Join(dir, "agent-"+subagentID+".jsonl"), editedPath)
-
-	meta := `{"agentType":"dev","description":"write ` + editedPath + `","spawnDepth":1}`
-	metaPath := filepath.Join(dir, "agent-"+subagentID+".meta.json")
-	if err := os.WriteFile(metaPath, []byte(meta), 0o600); err != nil {
-		t.Fatalf("failed to write subagent meta: %v", err)
-	}
-}
-
-// writeTranscriptFile writes a minimal subagent transcript whose only tool use is a
-// Write of editedPath.
-func writeTranscriptFile(t *testing.T, path, editedPath string) {
-	t.Helper()
-
-	builder := NewTranscriptBuilder()
-	builder.AddUserMessage("create " + editedPath)
-	toolID := builder.AddToolUse("mcp__acp__Write", editedPath, "content")
-	builder.AddToolResult(toolID)
-	builder.AddAssistantMessage("Done!")
-
-	if err := builder.WriteToFile(path); err != nil {
-		t.Fatalf("failed to write transcript %s: %v", path, err)
-	}
-}
-
-// readShadowFile returns the contents of a path in the shadow branch tree.
-func readShadowFile(t *testing.T, env *TestEnv, path string) (string, bool) {
-	t.Helper()
-
-	repo, err := git.PlainOpen(env.RepoDir)
-	if err != nil {
-		t.Fatalf("failed to open repo: %v", err)
-	}
-
-	shadowBranchName := env.GetShadowBranchName()
-	shadowRef, err := repo.Reference(plumbing.NewBranchReferenceName(shadowBranchName), true)
-	if err != nil {
-		t.Fatalf("shadow branch %s not found: %v", shadowBranchName, err)
-	}
-	shadowCommit, err := repo.CommitObject(shadowRef.Hash())
-	if err != nil {
-		t.Fatalf("failed to get shadow commit: %v", err)
-	}
-	shadowTree, err := shadowCommit.Tree()
-	if err != nil {
-		t.Fatalf("failed to get shadow tree: %v", err)
-	}
-
-	var content string
-	var found bool
-	if err := shadowTree.Files().ForEach(func(f *object.File) error {
-		if f.Name != path {
-			return nil
-		}
-		c, readErr := f.Contents()
-		if readErr != nil {
-			return readErr
-		}
-		content, found = c, true
-		return nil
-	}); err != nil {
-		t.Fatalf("failed to iterate shadow tree: %v", err)
-	}
-	return content, found
 }

--- a/cmd/entire/cli/integration_test/subagent_transcript_layout_test.go
+++ b/cmd/entire/cli/integration_test/subagent_transcript_layout_test.go
@@ -1,0 +1,179 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+)
+
+// TestSubagentCheckpoints_StoresSubagentTranscript_CurrentLayout verifies that the
+// task checkpoint captures the subagent's own transcript when it is stored the way
+// current Claude Code versions store it: <transcriptDir>/<sessionID>/subagents/.
+//
+// Resolving only the legacy sibling layout (<transcriptDir>/agent-<id>.jsonl) meant
+// the path never existed for a modern session, so the subagent transcript was never
+// committed and file extraction fell back to the main transcript — where a
+// subagent's Write/Edit calls do not appear.
+func TestSubagentCheckpoints_StoresSubagentTranscript_CurrentLayout(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+	session := env.NewSession()
+	session.CreateTranscript("delegate red.md to a subagent", nil)
+
+	const (
+		taskToolUseID = "toolu_01LayoutABC123"
+		subagentID    = "a0123456789abcdef"
+	)
+	writeSubagentTranscript(t, session, subagentID, "docs/red.md")
+
+	if err := env.SimulateUserPromptSubmit(session.ID); err != nil {
+		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+	}
+	if err := env.SimulatePreTask(session.ID, session.TranscriptPath, taskToolUseID); err != nil {
+		t.Fatalf("SimulatePreTask failed: %v", err)
+	}
+
+	// The subagent edits a file; only its own transcript records the Write.
+	env.WriteFile("docs/red.md", "Red is a warm colour.\n")
+
+	if err := env.SimulatePostTask(PostTaskInput{
+		SessionID:      session.ID,
+		TranscriptPath: session.TranscriptPath,
+		ToolUseID:      taskToolUseID,
+		AgentID:        subagentID,
+	}); err != nil {
+		t.Fatalf("SimulatePostTask failed: %v", err)
+	}
+
+	wantPath := ".entire/metadata/" + session.ID + "/tasks/" + taskToolUseID + "/agent-" + subagentID + ".jsonl"
+	content, ok := readShadowFile(t, env, wantPath)
+	if !ok {
+		t.Fatalf("subagent transcript not stored in shadow branch at %s", wantPath)
+	}
+	if !strings.Contains(content, "docs/red.md") {
+		t.Errorf("stored subagent transcript does not reference the subagent's edit: %q", content)
+	}
+}
+
+// TestSubagentCheckpoints_StoresSubagentTranscript_LegacyLayout keeps the older
+// sibling layout working, so sessions recorded by earlier agent versions still get
+// their subagent transcript captured.
+func TestSubagentCheckpoints_StoresSubagentTranscript_LegacyLayout(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+	session := env.NewSession()
+	session.CreateTranscript("delegate blue.md to a subagent", nil)
+
+	const (
+		taskToolUseID = "toolu_01LegacyABC123"
+		subagentID    = "afedcba9876543210"
+	)
+	// Legacy: a sibling of the main transcript, with no <sessionID>/subagents/ dir.
+	legacyPath := filepath.Join(filepath.Dir(session.TranscriptPath), "agent-"+subagentID+".jsonl")
+	writeTranscriptFile(t, legacyPath, "docs/blue.md")
+
+	if err := env.SimulateUserPromptSubmit(session.ID); err != nil {
+		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+	}
+	if err := env.SimulatePreTask(session.ID, session.TranscriptPath, taskToolUseID); err != nil {
+		t.Fatalf("SimulatePreTask failed: %v", err)
+	}
+	env.WriteFile("docs/blue.md", "Blue is a cool colour.\n")
+
+	if err := env.SimulatePostTask(PostTaskInput{
+		SessionID:      session.ID,
+		TranscriptPath: session.TranscriptPath,
+		ToolUseID:      taskToolUseID,
+		AgentID:        subagentID,
+	}); err != nil {
+		t.Fatalf("SimulatePostTask failed: %v", err)
+	}
+
+	wantPath := ".entire/metadata/" + session.ID + "/tasks/" + taskToolUseID + "/agent-" + subagentID + ".jsonl"
+	if _, ok := readShadowFile(t, env, wantPath); !ok {
+		t.Fatalf("subagent transcript not stored in shadow branch at %s", wantPath)
+	}
+}
+
+// writeSubagentTranscript writes a subagent transcript where current Claude Code
+// versions put it: <transcriptDir>/<sessionID>/subagents/agent-<id>.jsonl, next to
+// the agent-<id>.meta.json sidecar the agent also writes.
+func writeSubagentTranscript(t *testing.T, session *Session, subagentID, editedPath string) {
+	t.Helper()
+
+	dir := filepath.Join(filepath.Dir(session.TranscriptPath), session.ID, "subagents")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("failed to create subagents dir: %v", err)
+	}
+	writeTranscriptFile(t, filepath.Join(dir, "agent-"+subagentID+".jsonl"), editedPath)
+
+	meta := `{"agentType":"dev","description":"write ` + editedPath + `","spawnDepth":1}`
+	metaPath := filepath.Join(dir, "agent-"+subagentID+".meta.json")
+	if err := os.WriteFile(metaPath, []byte(meta), 0o600); err != nil {
+		t.Fatalf("failed to write subagent meta: %v", err)
+	}
+}
+
+// writeTranscriptFile writes a minimal subagent transcript whose only tool use is a
+// Write of editedPath.
+func writeTranscriptFile(t *testing.T, path, editedPath string) {
+	t.Helper()
+
+	builder := NewTranscriptBuilder()
+	builder.AddUserMessage("create " + editedPath)
+	toolID := builder.AddToolUse("mcp__acp__Write", editedPath, "content")
+	builder.AddToolResult(toolID)
+	builder.AddAssistantMessage("Done!")
+
+	if err := builder.WriteToFile(path); err != nil {
+		t.Fatalf("failed to write transcript %s: %v", path, err)
+	}
+}
+
+// readShadowFile returns the contents of a path in the shadow branch tree.
+func readShadowFile(t *testing.T, env *TestEnv, path string) (string, bool) {
+	t.Helper()
+
+	repo, err := git.PlainOpen(env.RepoDir)
+	if err != nil {
+		t.Fatalf("failed to open repo: %v", err)
+	}
+
+	shadowBranchName := env.GetShadowBranchName()
+	shadowRef, err := repo.Reference(plumbing.NewBranchReferenceName(shadowBranchName), true)
+	if err != nil {
+		t.Fatalf("shadow branch %s not found: %v", shadowBranchName, err)
+	}
+	shadowCommit, err := repo.CommitObject(shadowRef.Hash())
+	if err != nil {
+		t.Fatalf("failed to get shadow commit: %v", err)
+	}
+	shadowTree, err := shadowCommit.Tree()
+	if err != nil {
+		t.Fatalf("failed to get shadow tree: %v", err)
+	}
+
+	var content string
+	var found bool
+	if err := shadowTree.Files().ForEach(func(f *object.File) error {
+		if f.Name != path {
+			return nil
+		}
+		c, readErr := f.Contents()
+		if readErr != nil {
+			return readErr
+		}
+		content, found = c, true
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to iterate shadow tree: %v", err)
+	}
+	return content, found
+}

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -844,8 +844,7 @@ func handleLifecycleTurnEnd(ctx context.Context, ag agent.Agent, event *agent.Ev
 	}
 
 	// Compute subagents directory for agents that support subagent extraction.
-	// Subagent transcripts live in <transcriptDir>/<modelSessionID>/subagents/
-	subagentsDir := filepath.Join(filepath.Dir(transcriptRef), event.SessionID, "subagents")
+	subagentsDir := SubagentsDir(filepath.Dir(transcriptRef), event.SessionID)
 
 	// Extract metadata via agent interface (modified files)
 	var modifiedFiles []string
@@ -1145,15 +1144,9 @@ func handleLifecycleSubagentEnd(ctx context.Context, ag agent.Agent, event *agen
 		event.SubagentType, event.TaskDescription = ParseSubagentTypeAndDescription(event.ToolInput)
 	}
 
-	// Determine subagent transcript path
+	// Determine subagent transcript path (empty when the agent stores none).
 	transcriptDir := filepath.Dir(event.SessionRef)
-	var subagentTranscriptPath string
-	if event.SubagentID != "" {
-		subagentTranscriptPath = AgentTranscriptPath(transcriptDir, event.SubagentID)
-		if !fileExists(subagentTranscriptPath) {
-			subagentTranscriptPath = ""
-		}
-	}
+	subagentTranscriptPath := ResolveAgentTranscriptPath(transcriptDir, event.SessionID, event.SubagentID)
 
 	// Log context
 	subagentEndAttrs := []any{

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -844,7 +844,7 @@ func handleLifecycleTurnEnd(ctx context.Context, ag agent.Agent, event *agent.Ev
 	}
 
 	// Compute subagents directory for agents that support subagent extraction.
-	subagentsDir := SubagentsDir(filepath.Dir(transcriptRef), event.SessionID)
+	subagentsDir := paths.SubagentsDir(filepath.Dir(transcriptRef), event.SessionID)
 
 	// Extract metadata via agent interface (modified files)
 	var modifiedFiles []string
@@ -1145,8 +1145,7 @@ func handleLifecycleSubagentEnd(ctx context.Context, ag agent.Agent, event *agen
 	}
 
 	// Determine subagent transcript path (empty when the agent stores none).
-	transcriptDir := filepath.Dir(event.SessionRef)
-	subagentTranscriptPath := ResolveAgentTranscriptPath(transcriptDir, event.SessionID, event.SubagentID)
+	subagentTranscriptPath := ResolveAgentTranscriptPath(filepath.Dir(event.SessionRef), event.SessionID, event.SubagentID)
 
 	// Log context
 	subagentEndAttrs := []any{

--- a/cmd/entire/cli/paths/paths.go
+++ b/cmd/entire/cli/paths/paths.go
@@ -244,6 +244,28 @@ func SessionMetadataDirFromSessionID(sessionID string) string {
 	return EntireMetadataDir + "/" + sessionID
 }
 
+// SubagentsDir returns the directory an agent stores a session's subagent
+// transcripts in: <transcriptDir>/<sessionID>/subagents.
+//
+// This layout lives here, in the leaf paths package, because it is needed on both
+// sides of the import graph — the lifecycle dispatcher and the strategy, review,
+// and agentimport packages all resolve it, and those cannot import each other.
+// Before it was named it existed as five copies of the same filepath.Join, which
+// is how the SubagentEnd path came to disagree with the turn-end path about where
+// subagent transcripts live.
+//
+// sessionID is the *agent's* session ID (the transcript file's own basename), not
+// the date-prefixed Entire session ID.
+func SubagentsDir(transcriptDir, sessionID string) string {
+	return filepath.Join(transcriptDir, sessionID, "subagents")
+}
+
+// AgentTranscriptFileName returns the file name an agent writes a subagent's
+// transcript under: agent-<agentID>.jsonl.
+func AgentTranscriptFileName(agentID string) string {
+	return "agent-" + agentID + ".jsonl"
+}
+
 // ExtractSessionIDFromTranscriptPath attempts to extract a session ID from a transcript path.
 // Claude transcripts are stored at ~/.claude/projects/<project>/sessions/<id>.jsonl
 // If the path doesn't match expected format, returns empty string.

--- a/cmd/entire/cli/review/manifest.go
+++ b/cmd/entire/cli/review/manifest.go
@@ -443,7 +443,7 @@ func reviewSubagentsDir(st *session.State) string {
 	if st == nil || st.TranscriptPath == "" || st.SessionID == "" {
 		return ""
 	}
-	return filepath.Join(filepath.Dir(st.TranscriptPath), st.SessionID, "subagents")
+	return paths.SubagentsDir(filepath.Dir(st.TranscriptPath), st.SessionID)
 }
 
 func reviewTokensFromTokenUsage(usage *agent.TokenUsage) reviewtypes.Tokens {

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1945,7 +1945,7 @@ func (s *ManualCommitStrategy) extractModifiedFilesFromLiveTranscript(ctx contex
 	// For Claude Code, use ExtractAllModifiedFiles which parses the main transcript
 	// AND subagent transcripts in a single pass, avoiding redundant parsing.
 	if state.AgentType == agent.AgentTypeClaudeCode {
-		subagentsDir := filepath.Join(filepath.Dir(state.TranscriptPath), state.SessionID, "subagents")
+		subagentsDir := paths.SubagentsDir(filepath.Dir(state.TranscriptPath), state.SessionID)
 		transcriptData, readErr := os.ReadFile(state.TranscriptPath)
 		if readErr != nil {
 			logging.Debug(logCtx, "extractModifiedFilesFromLiveTranscript: failed to read transcript",

--- a/cmd/entire/cli/transcript.go
+++ b/cmd/entire/cli/transcript.go
@@ -96,11 +96,48 @@ func searchTranscriptInProjectDirs(sessionID string, ag agentpkg.Agent) (string,
 	return "", errors.New("transcript not found in any project directory")
 }
 
-// AgentTranscriptPath returns the path to a subagent's transcript file.
-// Subagent transcripts are stored as agent-{agentId}.jsonl in the same directory
-// as the main transcript.
+// AgentTranscriptPath returns the legacy path to a subagent's transcript file,
+// stored as agent-{agentId}.jsonl as a sibling of the main transcript.
+//
+// Current Claude Code versions nest subagent transcripts one level deeper — see
+// SubagentsDir. Prefer ResolveAgentTranscriptPath, which handles both layouts.
 func AgentTranscriptPath(transcriptDir, agentID string) string {
 	return filepath.Join(transcriptDir, fmt.Sprintf("agent-%s.jsonl", agentID))
+}
+
+// SubagentsDir returns the directory holding a session's subagent transcripts:
+// <transcriptDir>/<sessionID>/subagents. This is where Claude Code writes them
+// today (alongside an agent-<id>.meta.json per subagent), whereas older versions
+// wrote agent-<id>.jsonl directly into transcriptDir.
+func SubagentsDir(transcriptDir, sessionID string) string {
+	return filepath.Join(transcriptDir, sessionID, "subagents")
+}
+
+// ResolveAgentTranscriptPath returns the path to an existing subagent transcript
+// for agentID, or "" when none exists.
+//
+// It prefers the current layout (<transcriptDir>/<sessionID>/subagents/) and falls
+// back to the legacy sibling layout so sessions recorded by older agent versions
+// still resolve. Checking the current layout first matters: resolving only the
+// legacy path silently yielded "" for every modern Claude Code session, which left
+// task checkpoints without a subagent transcript and made file extraction fall back
+// to scanning the main transcript, where the subagent's edits never appear.
+//
+// An empty agentID never resolves — agent-.jsonl is not a real transcript.
+func ResolveAgentTranscriptPath(transcriptDir, sessionID, agentID string) string {
+	if agentID == "" {
+		return ""
+	}
+	candidates := []string{
+		AgentTranscriptPath(SubagentsDir(transcriptDir, sessionID), agentID),
+		AgentTranscriptPath(transcriptDir, agentID),
+	}
+	for _, candidate := range candidates {
+		if fileExists(candidate) {
+			return candidate
+		}
+	}
+	return ""
 }
 
 // toolResultBlock represents a tool_result in a user message

--- a/cmd/entire/cli/transcript.go
+++ b/cmd/entire/cli/transcript.go
@@ -96,46 +96,30 @@ func searchTranscriptInProjectDirs(sessionID string, ag agentpkg.Agent) (string,
 	return "", errors.New("transcript not found in any project directory")
 }
 
-// AgentTranscriptPath returns the legacy path to a subagent's transcript file,
-// stored as agent-{agentId}.jsonl as a sibling of the main transcript.
-//
-// Current Claude Code versions nest subagent transcripts one level deeper — see
-// SubagentsDir. Prefer ResolveAgentTranscriptPath, which handles both layouts.
-func AgentTranscriptPath(transcriptDir, agentID string) string {
-	return filepath.Join(transcriptDir, fmt.Sprintf("agent-%s.jsonl", agentID))
-}
-
-// SubagentsDir returns the directory holding a session's subagent transcripts:
-// <transcriptDir>/<sessionID>/subagents. This is where Claude Code writes them
-// today (alongside an agent-<id>.meta.json per subagent), whereas older versions
-// wrote agent-<id>.jsonl directly into transcriptDir.
-func SubagentsDir(transcriptDir, sessionID string) string {
-	return filepath.Join(transcriptDir, sessionID, "subagents")
-}
-
 // ResolveAgentTranscriptPath returns the path to an existing subagent transcript
 // for agentID, or "" when none exists.
 //
-// It prefers the current layout (<transcriptDir>/<sessionID>/subagents/) and falls
-// back to the legacy sibling layout so sessions recorded by older agent versions
-// still resolve. Checking the current layout first matters: resolving only the
-// legacy path silently yielded "" for every modern Claude Code session, which left
-// task checkpoints without a subagent transcript and made file extraction fall back
-// to scanning the main transcript, where the subagent's edits never appear.
+// It prefers the current layout, paths.SubagentsDir (which is also what the
+// turn-end extractor scans), and falls back to the legacy sibling layout —
+// agent-<id>.jsonl directly beside the main transcript — so sessions recorded by
+// older agent versions still resolve.
+//
+// Order is the whole point: resolving only the legacy path silently yielded "" for
+// every modern Claude Code session, which left task checkpoints without a subagent
+// transcript and made file extraction fall back to scanning the main transcript,
+// where a subagent's edits never appear.
 //
 // An empty agentID never resolves — agent-.jsonl is not a real transcript.
 func ResolveAgentTranscriptPath(transcriptDir, sessionID, agentID string) string {
 	if agentID == "" {
 		return ""
 	}
-	candidates := []string{
-		AgentTranscriptPath(SubagentsDir(transcriptDir, sessionID), agentID),
-		AgentTranscriptPath(transcriptDir, agentID),
+	name := paths.AgentTranscriptFileName(agentID)
+	if nested := filepath.Join(paths.SubagentsDir(transcriptDir, sessionID), name); fileExists(nested) {
+		return nested
 	}
-	for _, candidate := range candidates {
-		if fileExists(candidate) {
-			return candidate
-		}
+	if legacy := filepath.Join(transcriptDir, name); fileExists(legacy) {
+		return legacy
 	}
 	return ""
 }

--- a/cmd/entire/cli/transcript_test.go
+++ b/cmd/entire/cli/transcript_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -96,6 +97,90 @@ func TestAgentTranscriptPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubagentsDir(t *testing.T) {
+	t.Parallel()
+
+	got := SubagentsDir("/home/user/.claude/projects/myproject", "sess-1")
+	want := filepath.Join("/home/user/.claude/projects/myproject", "sess-1", "subagents")
+	if got != want {
+		t.Errorf("SubagentsDir() = %q, want %q", got, want)
+	}
+}
+
+// TestResolveAgentTranscriptPath covers both subagent transcript layouts Claude
+// Code has used: the current one nests them under <dir>/<sessionID>/subagents/,
+// while older versions wrote them as siblings of the main transcript.
+func TestResolveAgentTranscriptPath(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sessionID = "11111111-2222-3333-4444-555555555555"
+		agentID   = "a0123456789abcdef"
+	)
+
+	writeFile := func(t *testing.T, path string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	t.Run("current nested layout", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		want := filepath.Join(dir, sessionID, "subagents", "agent-"+agentID+".jsonl")
+		writeFile(t, want)
+
+		if got := ResolveAgentTranscriptPath(dir, sessionID, agentID); got != want {
+			t.Errorf("ResolveAgentTranscriptPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("legacy sibling layout", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		want := filepath.Join(dir, "agent-"+agentID+".jsonl")
+		writeFile(t, want)
+
+		if got := ResolveAgentTranscriptPath(dir, sessionID, agentID); got != want {
+			t.Errorf("ResolveAgentTranscriptPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("prefers nested over legacy", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		nested := filepath.Join(dir, sessionID, "subagents", "agent-"+agentID+".jsonl")
+		writeFile(t, nested)
+		writeFile(t, filepath.Join(dir, "agent-"+agentID+".jsonl"))
+
+		if got := ResolveAgentTranscriptPath(dir, sessionID, agentID); got != nested {
+			t.Errorf("ResolveAgentTranscriptPath() = %q, want %q", got, nested)
+		}
+	})
+
+	t.Run("neither exists", func(t *testing.T) {
+		t.Parallel()
+		if got := ResolveAgentTranscriptPath(t.TempDir(), sessionID, agentID); got != "" {
+			t.Errorf("ResolveAgentTranscriptPath() = %q, want empty", got)
+		}
+	})
+
+	t.Run("empty agent ID never resolves", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		// A stray agent-.jsonl must not be mistaken for a real subagent transcript.
+		writeFile(t, filepath.Join(dir, "agent-.jsonl"))
+
+		if got := ResolveAgentTranscriptPath(dir, sessionID, ""); got != "" {
+			t.Errorf("ResolveAgentTranscriptPath() = %q, want empty", got)
+		}
+	})
 }
 
 func TestFindCheckpointUUID(t *testing.T) {

--- a/cmd/entire/cli/transcript_test.go
+++ b/cmd/entire/cli/transcript_test.go
@@ -68,47 +68,6 @@ func TestResolveTranscriptPath_AllowsLegitSessionID(t *testing.T) {
 	}
 }
 
-func TestAgentTranscriptPath(t *testing.T) {
-	tests := []struct {
-		name          string
-		transcriptDir string
-		agentID       string
-		expected      string
-	}{
-		{
-			name:          "standard path",
-			transcriptDir: "/home/user/.claude/projects/myproject",
-			agentID:       "agent_abc123",
-			expected:      "/home/user/.claude/projects/myproject/agent-agent_abc123.jsonl",
-		},
-		{
-			name:          "empty agent ID",
-			transcriptDir: "/path/to/transcripts",
-			agentID:       "",
-			expected:      "/path/to/transcripts/agent-.jsonl",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := AgentTranscriptPath(tt.transcriptDir, tt.agentID)
-			if got != tt.expected {
-				t.Errorf("AgentTranscriptPath() = %v, want %v", got, tt.expected)
-			}
-		})
-	}
-}
-
-func TestSubagentsDir(t *testing.T) {
-	t.Parallel()
-
-	got := SubagentsDir("/home/user/.claude/projects/myproject", "sess-1")
-	want := filepath.Join("/home/user/.claude/projects/myproject", "sess-1", "subagents")
-	if got != want {
-		t.Errorf("SubagentsDir() = %q, want %q", got, want)
-	}
-}
-
 // TestResolveAgentTranscriptPath covers both subagent transcript layouts Claude
 // Code has used: the current one nests them under <dir>/<sessionID>/subagents/,
 // while older versions wrote them as siblings of the main transcript.

--- a/docs/architecture/claude-hooks-integration.md
+++ b/docs/architecture/claude-hooks-integration.md
@@ -124,7 +124,8 @@ Fires when Claude finishes responding. Does **not** fire on user interrupt (Ctrl
     - Extracts token counts from assistant messages: input tokens, cache creation/read tokens, output tokens.
     - Deduplicates by message ID (streaming creates multiple rows per message; uses highest output_tokens).
     - Finds spawned subagents by scanning for `agentId:` in Task tool results.
-    - Calculates subagent token usage from their transcript files (`agent-<id>.jsonl`).
+    - Calculates subagent token usage from their transcript files
+      (`<transcript_dir>/<session_id>/subagents/agent-<id>.jsonl`).
     - Aggregates into a `TokenUsage` struct with nested `SubagentTokens`.
 
 6.  **Invoke Strategy**:
@@ -172,10 +173,17 @@ Fires after a subagent finishes its work. Creates the final checkpoint for the s
 
 1.  **Parse Input**: Extracts `tool_use_id`, `agent_id` (from `tool_response.agentId`), `session_id`, `transcript_path`, and `tool_input`.
 
-2.  **Locate Subagent Transcript**:
+2.  **Locate Subagent Transcript** (`ResolveAgentTranscriptPath`):
 
-    - Constructs path: `<transcript_dir>/agent-<agent_id>.jsonl`.
+    - Prefers the current layout: `<transcript_dir>/<session_id>/subagents/agent-<agent_id>.jsonl`
+      (Claude Code writes an `agent-<agent_id>.meta.json` sidecar there too, carrying
+      `agentType`, `description`, `toolUseId`, and `spawnDepth`).
+    - Falls back to the legacy sibling layout `<transcript_dir>/agent-<agent_id>.jsonl`
+      used by older versions.
     - If the subagent transcript exists, uses it for file extraction; otherwise falls back to main transcript.
+      Falling back matters: a subagent's Write/Edit calls appear only in its own
+      transcript, so a missed subagent transcript means those edits are invisible here
+      (they are still picked up at turn end, which is why a wrong path went unnoticed).
 
 3.  **Extract Modified Files**: Parses the transcript (subagent or main) to find Write/Edit tool invocations.
 

--- a/docs/architecture/claude-hooks-integration.md
+++ b/docs/architecture/claude-hooks-integration.md
@@ -124,8 +124,8 @@ Fires when Claude finishes responding. Does **not** fire on user interrupt (Ctrl
     - Extracts token counts from assistant messages: input tokens, cache creation/read tokens, output tokens.
     - Deduplicates by message ID (streaming creates multiple rows per message; uses highest output_tokens).
     - Finds spawned subagents by scanning for `agentId:` in Task tool results.
-    - Calculates subagent token usage from their transcript files
-      (`<transcript_dir>/<session_id>/subagents/agent-<id>.jsonl`).
+    - Calculates subagent token usage from their transcript files under
+      `paths.SubagentsDir`.
     - Aggregates into a `TokenUsage` struct with nested `SubagentTokens`.
 
 6.  **Invoke Strategy**:
@@ -173,17 +173,13 @@ Fires after a subagent finishes its work. Creates the final checkpoint for the s
 
 1.  **Parse Input**: Extracts `tool_use_id`, `agent_id` (from `tool_response.agentId`), `session_id`, `transcript_path`, and `tool_input`.
 
-2.  **Locate Subagent Transcript** (`ResolveAgentTranscriptPath`):
-
-    - Prefers the current layout: `<transcript_dir>/<session_id>/subagents/agent-<agent_id>.jsonl`
-      (Claude Code writes an `agent-<agent_id>.meta.json` sidecar there too, carrying
-      `agentType`, `description`, `toolUseId`, and `spawnDepth`).
-    - Falls back to the legacy sibling layout `<transcript_dir>/agent-<agent_id>.jsonl`
-      used by older versions.
-    - If the subagent transcript exists, uses it for file extraction; otherwise falls back to main transcript.
-      Falling back matters: a subagent's Write/Edit calls appear only in its own
-      transcript, so a missed subagent transcript means those edits are invisible here
-      (they are still picked up at turn end, which is why a wrong path went unnoticed).
+2.  **Locate Subagent Transcript** — `ResolveAgentTranscriptPath`, which prefers
+    `paths.SubagentsDir` (`<transcript_dir>/<session_id>/subagents/agent-<agent_id>.jsonl`,
+    where Claude Code writes it today, alongside an unused-by-Entire
+    `agent-<agent_id>.meta.json` sidecar) and falls back to the legacy sibling
+    `<transcript_dir>/agent-<agent_id>.jsonl`. See that function for why the order
+    matters. If it resolves, it is used for file extraction; otherwise extraction
+    falls back to the main transcript, where a subagent's Write/Edit calls do not appear.
 
 3.  **Extract Modified Files**: Parses the transcript (subagent or main) to find Write/Edit tool invocations.
 


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/997

## Problem

`handleLifecycleSubagentEnd` resolved the subagent transcript as a **sibling** of the main transcript:

```
<transcriptDir>/agent-<agentID>.jsonl
```

Claude Code (verified on 2.1.221) nests them one level deeper:

```
<transcriptDir>/<sessionID>/subagents/agent-<agentID>.jsonl
<transcriptDir>/<sessionID>/subagents/agent-<agentID>.meta.json   # agentType, description, toolUseId, spawnDepth
```

So the resolved path never existed and `SubagentTranscriptPath` was always empty in production. Evidence: across three enabled repos, **every** real `"subagent completed"` log line carries `agent_id` but never the `subagent_transcript` attribute — that attribute is only appended when the path resolves.

Two consequences:

1. The shadow-branch task checkpoint stored **no subagent transcript** — `.entire/metadata/<session>/tasks/<tool-use-id>/` held only `checkpoint.json`.
2. File extraction fell back to scanning the **main** transcript from offset 0, where a subagent's `Write`/`Edit` calls never appear.

The turn-end extractor already used the correct nested path, so a subagent's files were still picked up at Stop. That masked the bug.

## Scope — what this does and does not fix

This restores the capture at `SubagentEnd`, which is **shadow-branch (ephemeral) only**. Verified end to end on this branch:

```
# shadow branch, after post-task
.entire/metadata/<session>/full.jsonl
.entire/metadata/<session>/tasks/toolu_.../agent-<id>.jsonl   <-- restored by this PR
.entire/metadata/<session>/tasks/toolu_.../checkpoint.json

# committed checkpoint, after the user commits
0/content_hash.txt  0/full.jsonl  0/metadata.json  0/prompt.txt  0/transcript.jsonl  metadata.json
```

`extractSessionData` reads only `full.jsonl` + `prompt.txt` out of the shadow tree, so `tasks/` is dropped at condensation and the shadow branch is then deleted — after the commit the subagent transcript is reachable from no ref at all. (Consistent with the wider survey: 0 of 80 primary checkpoint refs in this repo contain a `tasks/` path.)

So what this PR buys today:

- Correct `ModifiedFiles` on the task step — extracted from the subagent's own transcript instead of the main one.
- In-session task checkpoints (`entire checkpoint list`, rewind) actually carry the subagent transcript until the next commit.
- A working resolver, which is a prerequisite for carrying subagent data into committed checkpoints.

Making subagent detail survive a commit is separate follow-up work: it needs condensation to carry `tasks/` into the committed tree (the persistent store already has the layout and an `IsTask` flag, but no production path writes it), and a decision on what the committed record should contain. Not in this PR.

## Fix

- `ResolveAgentTranscriptPath(transcriptDir, sessionID, agentID)` — prefers the nested layout, falls back to the legacy sibling layout so sessions from older agent versions keep working, returns `""` when neither exists (and never resolves an empty `agentID`).
- `SubagentsDir(transcriptDir, sessionID)` — one definition of the nested directory; the turn-end extractor now uses it too instead of inlining the join.

The `meta.json` sidecar is documented but not yet consumed — richer subagent attribution is part of the follow-up above.

## Tests

- `TestResolveAgentTranscriptPath` — nested, legacy, nested-wins-over-legacy, neither-exists, empty-agent-ID.
- `TestSubagentCheckpoints_StoresSubagentTranscript_CurrentLayout` (integration) — asserts the shadow branch contains `tasks/<tool-use-id>/agent-<id>.jsonl` and that it references the subagent's edit. **Verified RED before the fix**, green after.
- `TestSubagentCheckpoints_StoresSubagentTranscript_LegacyLayout` (integration) — regression guard for the old layout.

`mise run check` passes (fmt, lint, unit + integration + canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)