### PR TITLE
Detect hook-config drift for every agent, not just Claude Code

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -120,6 +120,42 @@ type HookSupport interface {
 	AreHooksInstalled(ctx context.Context) bool
 }
 
+// HookConfigState describes how an agent's installed Entire hook config
+// compares to what InstallHooks would write today.
+type HookConfigState int
+
+const (
+	// HooksAbsent means Entire hooks are not installed for this agent here.
+	HooksAbsent HookConfigState = iota
+	// HooksCurrent means the installed hooks match what would be written today.
+	HooksCurrent
+	// HooksOutdated means Entire hooks are installed but stale — an older CLI
+	// wrote a config that no longer matches the current one. Fix:
+	// `entire enable --force`.
+	HooksOutdated
+)
+
+// HookFreshness is implemented by hook-supporting agents that can report
+// whether their installed config has drifted from the current one.
+//
+// AreHooksInstalled answers "is Entire wired up here at all?" — for agents
+// whose hook config is a generated file checked into the repo, that stays true
+// forever even after the generated content goes stale, because the file is
+// still present and still recognisably Entire's. CheckHookConfig answers the
+// separate question "is what's installed still what we'd write today?", so
+// `entire status` and `entire doctor` can flag a stale config instead of
+// reporting it healthy while its hooks silently no-op.
+//
+// Implementations must be read-only: they are diagnostics and must never
+// modify the agent's config.
+type HookFreshness interface {
+	Agent
+
+	// CheckHookConfig reports whether this agent's Entire hook config is
+	// absent, current, or outdated in the current repo.
+	CheckHookConfig(ctx context.Context) HookConfigState
+}
+
 // FileWatcher is implemented by agents that use file-based detection.
 // Agents like Aider that don't support hooks can use file watching
 // to detect session activity.

--- a/cmd/entire/cli/agent/capabilities.go
+++ b/cmd/entire/cli/agent/capabilities.go
@@ -66,6 +66,15 @@ func AsHookSupport(ag Agent) (HookSupport, bool) {
 	return declaredCapability[HookSupport](ag, func(c DeclaredCaps) bool { return c.Hooks })
 }
 
+// AsHookFreshness returns the agent as HookFreshness if it implements the
+// interface. No capability declaration is needed: hook-config drift detection
+// is built-in only, since it compares against a template the CLI itself
+// embeds. External agents own their hook config and report installation state
+// through their own protocol.
+func AsHookFreshness(ag Agent) (HookFreshness, bool) {
+	return builtinCapability[HookFreshness](ag)
+}
+
 // AsTranscriptAnalyzer returns the agent as TranscriptAnalyzer if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
 func AsTranscriptAnalyzer(ag Agent) (TranscriptAnalyzer, bool) {

--- a/cmd/entire/cli/agent/claudecode/hooks.go
+++ b/cmd/entire/cli/agent/claudecode/hooks.go
@@ -15,7 +15,10 @@ import (
 )
 
 // Ensure ClaudeCodeAgent implements HookSupport
-var _ agent.HookSupport = (*ClaudeCodeAgent)(nil)
+var (
+	_ agent.HookSupport   = (*ClaudeCodeAgent)(nil)
+	_ agent.HookFreshness = (*ClaudeCodeAgent)(nil)
+)
 
 // Claude Code hook names - these become subcommands under `entire hooks claude-code`
 const (
@@ -448,19 +451,31 @@ func (c *ClaudeCodeAgent) AreHooksInstalled(ctx context.Context) bool {
 }
 
 // HookConfigState describes how Entire's Claude Code hooks compare to what
-// InstallHooks would write today.
-type HookConfigState int
+// InstallHooks would write today. Aliased to the shared agent-package type so
+// `entire status` and `entire doctor` can treat every agent's drift check
+// uniformly; the names stay exported here for existing call sites.
+//
+// For Claude Code, HooksOutdated means Entire hooks are installed but the
+// current tool-use matchers no longer carry them (e.g. an older CLI wrote them
+// under the now non-firing "Task"/"TodoWrite" matchers).
+type HookConfigState = agent.HookConfigState
 
 const (
 	// HooksAbsent means Entire hooks are not installed in this repo.
-	HooksAbsent HookConfigState = iota
+	HooksAbsent = agent.HooksAbsent
 	// HooksCurrent means the installed hooks match the current config.
-	HooksCurrent
-	// HooksOutdated means Entire hooks are installed but the current tool-use
-	// matchers no longer carry them (e.g. an older CLI wrote them under the now
-	// non-firing "Task"/"TodoWrite" matchers). Fix: `entire enable --force`.
-	HooksOutdated
+	HooksCurrent = agent.HooksCurrent
+	// HooksOutdated means the installed hooks are stale.
+	// Fix: `entire enable --force`.
+	HooksOutdated = agent.HooksOutdated
 )
+
+// CheckHookConfig satisfies agent.HookFreshness by delegating to the
+// package-level check, which predates the interface and is still called
+// directly by tests.
+func (c *ClaudeCodeAgent) CheckHookConfig(ctx context.Context) agent.HookConfigState {
+	return CheckHookConfig(ctx)
+}
 
 // CheckHookConfig reports whether Entire's Claude Code hooks are absent,
 // current, or outdated. It is a read-only diagnostic used by `entire status`

--- a/cmd/entire/cli/agent/hook_command.go
+++ b/cmd/entire/cli/agent/hook_command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -11,6 +12,39 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 )
+
+// GeneratedHookFileState reports hook-config drift for agents whose entire
+// Entire integration is one generated file in the repo (Pi's extension,
+// OpenCode's plugin), for use by HookFreshness implementations.
+//
+// The file counts as ours only if it contains marker, and as current only if
+// it byte-matches one of renders — the outputs InstallHooks could have
+// written. Pass both the production and local-dev renders: they differ only in
+// the substituted entire command, and CheckHookConfig cannot know which mode
+// installed the file. Matching on exact content rather than a stamped version
+// keeps this honest for free — any edit to the embedded template makes
+// installed copies read as outdated without anyone remembering to bump
+// anything.
+//
+// A file that exists but lacks marker reads as HooksAbsent, not HooksOutdated:
+// InstallHooks refuses to overwrite a foreign file at our path, so there is no
+// Entire config there for us to call stale.
+func GeneratedHookFileState(path, marker string, renders ...string) HookConfigState {
+	data, err := os.ReadFile(path) //nolint:gosec // path constructed from validated repo root
+	if err != nil {
+		return HooksAbsent
+	}
+	content := string(data)
+	if !strings.Contains(content, marker) {
+		return HooksAbsent
+	}
+	for _, render := range renders {
+		if content == render {
+			return HooksCurrent
+		}
+	}
+	return HooksOutdated
+}
 
 type WarningFormat int
 

--- a/cmd/entire/cli/agent/hook_command.go
+++ b/cmd/entire/cli/agent/hook_command.go
@@ -18,13 +18,18 @@ import (
 // OpenCode's plugin), for use by HookFreshness implementations.
 //
 // The file counts as ours only if it contains marker, and as current only if
-// it byte-matches one of renders — the outputs InstallHooks could have
-// written. Pass both the production and local-dev renders: they differ only in
-// the substituted entire command, and CheckHookConfig cannot know which mode
-// installed the file. Matching on exact content rather than a stamped version
-// keeps this honest for free — any edit to the embedded template makes
-// installed copies read as outdated without anyone remembering to bump
-// anything.
+// it matches one of renders — the outputs InstallHooks could have written.
+// Pass both the production and local-dev renders: they differ only in the
+// substituted entire command, and CheckHookConfig cannot know which mode
+// installed the file. Matching on content rather than a stamped version keeps
+// this honest for free — any edit to the embedded template makes installed
+// copies read as outdated without anyone remembering to bump anything.
+//
+// Line endings are normalized before comparing. These files are generated with
+// LF but are typically committed, so on Windows a checkout under the default
+// core.autocrlf=true hands us CRLF and byte equality never holds. That would
+// report permanent drift the user cannot clear: InstallHooks writes LF back,
+// and the next checkout converts it to CRLF again.
 //
 // A file that exists but lacks marker reads as HooksAbsent, not HooksOutdated:
 // InstallHooks refuses to overwrite a foreign file at our path, so there is no
@@ -38,12 +43,23 @@ func GeneratedHookFileState(path, marker string, renders ...string) HookConfigSt
 	if !strings.Contains(content, marker) {
 		return HooksAbsent
 	}
+	normalized := normalizeLineEndings(content)
 	for _, render := range renders {
-		if content == render {
+		if normalized == normalizeLineEndings(render) {
 			return HooksCurrent
 		}
 	}
 	return HooksOutdated
+}
+
+// normalizeLineEndings rewrites CRLF to LF so content comparison survives a
+// Windows checkout. Lone CR is left alone: no generator here emits it, and
+// touching it would rewrite content that is genuinely different.
+func normalizeLineEndings(s string) string {
+	if !strings.Contains(s, "\r\n") {
+		return s
+	}
+	return strings.ReplaceAll(s, "\r\n", "\n")
 }
 
 type WarningFormat int

--- a/cmd/entire/cli/agent/opencode/hooks.go
+++ b/cmd/entire/cli/agent/opencode/hooks.go
@@ -11,8 +11,11 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
 
-// Compile-time interface assertion
-var _ agent.HookSupport = (*OpenCodeAgent)(nil)
+// Compile-time interface assertions
+var (
+	_ agent.HookSupport   = (*OpenCodeAgent)(nil)
+	_ agent.HookFreshness = (*OpenCodeAgent)(nil)
+)
 
 const (
 	// pluginFileName is the name of the plugin file written to .opencode/plugins/
@@ -39,6 +42,16 @@ func getPluginPath(ctx context.Context) (string, error) {
 	return filepath.Join(repoRoot, ".opencode", pluginDirName, pluginFileName), nil
 }
 
+// renderPlugin returns the plugin file content for the given install mode,
+// substituting the entire command the hooks shell out to.
+func renderPlugin(localDev bool) string {
+	cmdPrefix := "entire"
+	if localDev {
+		cmdPrefix = agent.LocalDevHookScript
+	}
+	return strings.ReplaceAll(pluginTemplate, entireCmdPlaceholder, cmdPrefix)
+}
+
 // InstallHooks writes the Entire plugin file to .opencode/plugins/entire.ts.
 // Returns 1 if the plugin was written, 0 if already up-to-date (idempotent).
 // If the file exists but content differs (e.g., localDev vs production), it is rewritten.
@@ -48,16 +61,7 @@ func (a *OpenCodeAgent) InstallHooks(ctx context.Context, localDev bool, force b
 		return 0, err
 	}
 
-	// Build the command prefix
-	var cmdPrefix string
-	if localDev {
-		cmdPrefix = agent.LocalDevHookScript
-	} else {
-		cmdPrefix = "entire"
-	}
-
-	// Generate plugin content from template
-	content := strings.ReplaceAll(pluginTemplate, entireCmdPlaceholder, cmdPrefix)
+	content := renderPlugin(localDev)
 
 	// Check if already installed with identical content (idempotent) unless force
 	if !force {
@@ -111,6 +115,19 @@ func (a *OpenCodeAgent) AreHooksInstalled(ctx context.Context) bool {
 	}
 
 	return strings.Contains(string(data), entireMarker)
+}
+
+// CheckHookConfig reports whether the installed plugin matches what
+// InstallHooks would write today. Read-only diagnostic for `entire status` and
+// `entire doctor`; same committed-and-stale exposure as Pi's extension, since
+// .opencode/plugins/entire.ts is likewise a generated file repos commit so
+// every clone is covered.
+func (a *OpenCodeAgent) CheckHookConfig(ctx context.Context) agent.HookConfigState {
+	pluginPath, err := getPluginPath(ctx)
+	if err != nil {
+		return agent.HooksAbsent
+	}
+	return agent.GeneratedHookFileState(pluginPath, entireMarker, renderPlugin(false), renderPlugin(true))
 }
 
 // GetSupportedHooks returns the normalized lifecycle events this agent supports.

--- a/cmd/entire/cli/agent/opencode/hooks_test.go
+++ b/cmd/entire/cli/agent/opencode/hooks_test.go
@@ -384,3 +384,53 @@ func TestAreHooksInstalled(t *testing.T) {
 		t.Error("hooks should not be installed after UninstallHooks")
 	}
 }
+
+// TestCheckHookConfig covers the drift states for the generated plugin file.
+// Same exposure as Pi's extension: .opencode/plugins/entire.ts is a generated
+// file repos commit so every clone is covered, and a committed copy goes stale
+// as the template evolves while AreHooksInstalled keeps returning true.
+func TestCheckHookConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	ctx := context.Background()
+	a := &OpenCodeAgent{}
+
+	if got := a.CheckHookConfig(ctx); got != agent.HooksAbsent {
+		t.Errorf("no plugin: CheckHookConfig = %v, want HooksAbsent", got)
+	}
+
+	if _, err := a.InstallHooks(ctx, false, false); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+	if got := a.CheckHookConfig(ctx); got != agent.HooksCurrent {
+		t.Errorf("fresh install: CheckHookConfig = %v, want HooksCurrent", got)
+	}
+
+	// A local-dev install differs only in the substituted entire command and
+	// must not read as drift.
+	if _, err := a.InstallHooks(ctx, true, false); err != nil {
+		t.Fatalf("InstallHooks localDev: %v", err)
+	}
+	if got := a.CheckHookConfig(ctx); got != agent.HooksCurrent {
+		t.Errorf("local-dev install: CheckHookConfig = %v, want HooksCurrent", got)
+	}
+
+	path := filepath.Join(dir, ".opencode", pluginDirName, pluginFileName)
+	stale := "// " + entireMarker + "\n// an older release wrote this\n"
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !a.AreHooksInstalled(ctx) {
+		t.Error("AreHooksInstalled = false; a stale-but-marked plugin is still installed")
+	}
+	if got := a.CheckHookConfig(ctx); got != agent.HooksOutdated {
+		t.Errorf("stale plugin: CheckHookConfig = %v, want HooksOutdated", got)
+	}
+
+	if err := os.WriteFile(path, []byte("// someone else's plugin\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := a.CheckHookConfig(ctx); got != agent.HooksAbsent {
+		t.Errorf("foreign file: CheckHookConfig = %v, want HooksAbsent", got)
+	}
+}

--- a/cmd/entire/cli/agent/pi/hooks.go
+++ b/cmd/entire/cli/agent/pi/hooks.go
@@ -12,8 +12,11 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
 
-// Compile-time interface assertion
-var _ agent.HookSupport = (*PiAgent)(nil)
+// Compile-time interface assertions
+var (
+	_ agent.HookSupport   = (*PiAgent)(nil)
+	_ agent.HookFreshness = (*PiAgent)(nil)
+)
 
 //go:embed entire_extension.ts
 var extensionTemplate string
@@ -121,4 +124,23 @@ func (a *PiAgent) AreHooksInstalled(ctx context.Context) bool {
 		return false
 	}
 	return strings.Contains(string(data), entireMarker)
+}
+
+// CheckHookConfig reports whether the installed extension matches what
+// InstallHooks would write today. Read-only diagnostic for `entire status` and
+// `entire doctor`.
+//
+// This matters more for pi than for agents that configure hooks in a local
+// settings file: repos commonly commit .pi/extensions/entire/index.ts so every
+// clone gets checkpointing without each person enabling it by hand. A committed
+// extension goes stale as the template evolves, and AreHooksInstalled keeps
+// returning true because the marker is still there — while the extension's own
+// fireHook swallows every error by design, so broken hooks are silent. Without
+// this check a stale committed extension reads as healthy forever.
+func (a *PiAgent) CheckHookConfig(ctx context.Context) agent.HookConfigState {
+	path, err := extensionPath(ctx)
+	if err != nil {
+		return agent.HooksAbsent
+	}
+	return agent.GeneratedHookFileState(path, entireMarker, renderExtension(false), renderExtension(true))
 }

--- a/cmd/entire/cli/agent/pi/hooks_test.go
+++ b/cmd/entire/cli/agent/pi/hooks_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 )
 
 // Note: t.Parallel is incompatible with t.Chdir.
@@ -174,5 +176,84 @@ func TestInstallHooks_RefusesForeignFileWithoutForce(t *testing.T) {
 	}
 	if !strings.Contains(string(got), entireMarker) {
 		t.Error("force install should write Entire-owned file")
+	}
+}
+
+// TestCheckHookConfig_CommittedExtensionGoesStale is the case this check
+// exists for. Repos commonly commit .pi/extensions/entire/index.ts so every
+// clone gets checkpointing without each person running `entire agent add pi`.
+// The committed copy then goes stale as the template evolves, while
+// AreHooksInstalled keeps reporting it installed (the marker is still there)
+// and the extension's own fireHook swallows every error — so without a drift
+// check the repo reads as healthy while its hooks silently no-op.
+func TestCheckHookConfig_CommittedExtensionGoesStale(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	ctx := context.Background()
+	a := &PiAgent{}
+
+	if _, err := a.InstallHooks(ctx, false, false); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+	if got := a.CheckHookConfig(ctx); got != agent.HooksCurrent {
+		t.Fatalf("fresh install: CheckHookConfig = %v, want HooksCurrent", got)
+	}
+
+	// Simulate the template moving on under a committed extension: keep the
+	// marker (so it is still recognisably ours) but change the body.
+	path := filepath.Join(dir, ".pi", "extensions", "entire", "index.ts")
+	stale := "// " + entireMarker + "\n// an older release wrote this\n"
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !a.AreHooksInstalled(ctx) {
+		t.Error("AreHooksInstalled = false; a stale-but-marked extension is still installed")
+	}
+	if got := a.CheckHookConfig(ctx); got != agent.HooksOutdated {
+		t.Errorf("stale extension: CheckHookConfig = %v, want HooksOutdated", got)
+	}
+}
+
+// TestCheckHookConfig_LocalDevIsNotDrift guards the false positive that would
+// make this check useless in practice: a developer who enabled with --local-dev
+// has a legitimately different file (the entire command is substituted), and
+// must not be nagged that their hooks are out of date.
+func TestCheckHookConfig_LocalDevIsNotDrift(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	ctx := context.Background()
+	a := &PiAgent{}
+
+	if _, err := a.InstallHooks(ctx, true, false); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+	if got := a.CheckHookConfig(ctx); got != agent.HooksCurrent {
+		t.Errorf("local-dev install: CheckHookConfig = %v, want HooksCurrent", got)
+	}
+}
+
+func TestCheckHookConfig_AbsentAndForeign(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	ctx := context.Background()
+	a := &PiAgent{}
+
+	if got := a.CheckHookConfig(ctx); got != agent.HooksAbsent {
+		t.Errorf("no extension: CheckHookConfig = %v, want HooksAbsent", got)
+	}
+
+	// A foreign file at our path is not ours to call stale: InstallHooks
+	// refuses to overwrite it, so reporting drift would nag about a file the
+	// CLI will not touch.
+	path := filepath.Join(dir, ".pi", "extensions", "entire", "index.ts")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("// someone else's extension\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := a.CheckHookConfig(ctx); got != agent.HooksAbsent {
+		t.Errorf("foreign file: CheckHookConfig = %v, want HooksAbsent", got)
 	}
 }

--- a/cmd/entire/cli/agent/pi/hooks_test.go
+++ b/cmd/entire/cli/agent/pi/hooks_test.go
@@ -215,6 +215,35 @@ func TestCheckHookConfig_CommittedExtensionGoesStale(t *testing.T) {
 	}
 }
 
+// TestCheckHookConfig_CRLFCheckoutIsNotDrift guards the Windows false
+// positive. The extension is generated with LF but is typically committed, so
+// a checkout under git's default core.autocrlf=true on Windows hands us CRLF.
+// Byte equality never holds there, and the user cannot clear the warning:
+// InstallHooks writes LF back and the next checkout re-converts it.
+func TestCheckHookConfig_CRLFCheckoutIsNotDrift(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	ctx := context.Background()
+	a := &PiAgent{}
+
+	if _, err := a.InstallHooks(ctx, false, false); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+	path := filepath.Join(dir, ".pi", "extensions", "entire", "index.ts")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crlf := strings.ReplaceAll(string(data), "\n", "\r\n")
+	if err := os.WriteFile(path, []byte(crlf), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := a.CheckHookConfig(ctx); got != agent.HooksCurrent {
+		t.Errorf("CRLF checkout: CheckHookConfig = %v, want HooksCurrent", got)
+	}
+}
+
 // TestCheckHookConfig_LocalDevIsNotDrift guards the false positive that would
 // make this check useless in practice: a developer who enabled with --local-dev
 // has a legitimately different file (the entire command is substituted), and

--- a/cmd/entire/cli/config.go
+++ b/cmd/entire/cli/config.go
@@ -108,8 +108,12 @@ func InstalledAgentDisplayNames(ctx context.Context) []string {
 // are skipped: absence of a drift check reads as "nothing to report", never as
 // a warning.
 //
-// Scoped to agents that are actually installed here, so an agent whose config
-// exists in the repo but that nobody enabled stays quiet.
+// Scoped to agents AreHooksInstalled reports as installed here. Note what that
+// means for generated-file agents (Pi, OpenCode): the committed file *is* the
+// installation, so a repo that ships one gets drift warnings even where nobody
+// ran `entire agent add`. That is the intent — such a repo is relying on the
+// committed file to work — but it does mean this is not scoped to people who
+// opted in on this machine.
 func OutdatedHookAgents(ctx context.Context) []types.AgentName {
 	var outdated []types.AgentName
 	for _, name := range GetAgentsWithHooksInstalled(ctx) {

--- a/cmd/entire/cli/config.go
+++ b/cmd/entire/cli/config.go
@@ -102,6 +102,34 @@ func InstalledAgentDisplayNames(ctx context.Context) []string {
 	return agentDisplayNames(GetAgentsWithHooksInstalled(ctx))
 }
 
+// OutdatedHookAgents returns installed agents whose Entire hook config has
+// drifted from what the CLI would write today, for `entire status` and
+// `entire doctor` to surface. Agents that don't implement agent.HookFreshness
+// are skipped: absence of a drift check reads as "nothing to report", never as
+// a warning.
+//
+// Scoped to agents that are actually installed here, so an agent whose config
+// exists in the repo but that nobody enabled stays quiet.
+func OutdatedHookAgents(ctx context.Context) []types.AgentName {
+	var outdated []types.AgentName
+	for _, name := range GetAgentsWithHooksInstalled(ctx) {
+		ag, err := agent.Get(name)
+		if err != nil {
+			continue
+		}
+		if hf, ok := agent.AsHookFreshness(ag); ok && hf.CheckHookConfig(ctx) == agent.HooksOutdated {
+			outdated = append(outdated, name)
+		}
+	}
+	return outdated
+}
+
+// OutdatedHookAgentDisplayNames returns user-facing display names for agents
+// whose hook config is out of date.
+func OutdatedHookAgentDisplayNames(ctx context.Context) []string {
+	return agentDisplayNames(OutdatedHookAgents(ctx))
+}
+
 // agentDisplayNames maps agent names to their user-facing display names,
 // skipping names that aren't registered.
 func agentDisplayNames(names []types.AgentName) []string {

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"charm.land/huh/v2"
-	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -41,9 +41,10 @@ Checks performed:
      review hasn't run yet on this machine, or a newer entire release
      added a hook the user hasn't approved yet).
 
-  When Claude Code hooks are installed:
-  3. Claude Code hook config: warn when the installed hooks are out of
-     date (e.g. an older release wrote tool matchers that no longer fire).
+  For each installed agent that reports hook-config drift:
+  3. Hook config: warn when the installed hooks no longer match what this
+     CLI writes (e.g. an older release wrote Claude Code tool matchers that
+     no longer fire, or a committed Pi/OpenCode extension has gone stale).
      Fix by re-running 'entire enable --force'.
 
   4. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
@@ -106,7 +107,7 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 	checkCodexHookTrust(cmd)
 
 	// Agent-specific: Claude Code hook config drift.
-	checkClaudeCodeHookDrift(cmd)
+	checkHookDrift(cmd)
 
 	// Where checkpoints land, when the repo's remotes make that ambiguous.
 	printCheckpointDestinationNote(ctx, cmd.OutOrStdout(), "Checkpoint destination: REVIEW")
@@ -435,21 +436,35 @@ func confirmDoctorFix(ctx context.Context, w io.Writer, title string) (bool, err
 	return confirmed, nil
 }
 
-// checkClaudeCodeHookDrift warns when Entire's Claude Code hooks are installed
-// but out of date — e.g. an older release wrote tool matchers that no longer
-// fire on current Claude Code. Read-only; the fix is `entire enable --force`.
-// Stays silent when Claude Code hooks aren't installed here.
-func checkClaudeCodeHookDrift(cmd *cobra.Command) {
+// checkHookDrift warns when an installed agent's Entire hook config is out of
+// date — an older release wrote Claude Code tool matchers that no longer fire,
+// or a repo committed a Pi/OpenCode extension that the template has since moved
+// past. Read-only; the fix is `entire enable --force`. Stays silent for agents
+// that aren't installed here or don't implement a drift check.
+func checkHookDrift(cmd *cobra.Command) {
+	ctx := cmd.Context()
 	w := cmd.OutOrStdout()
-	switch claudecode.CheckHookConfig(cmd.Context()) {
-	case claudecode.HooksAbsent:
-		// Not installed in this repo — nothing to report.
-	case claudecode.HooksCurrent:
-		fmt.Fprintln(w, "✓ Claude Code hook config: OK")
-	case claudecode.HooksOutdated:
-		fmt.Fprintln(w, "Claude Code hooks: OUT OF DATE")
-		fmt.Fprintln(w, "  The installed hooks use outdated tool matchers and no longer fire.")
-		fmt.Fprintln(w, "  Run `entire enable --force` to update the hooks file.")
+	for _, name := range GetAgentsWithHooksInstalled(ctx) {
+		ag, err := agent.Get(name)
+		if err != nil {
+			continue
+		}
+		hf, ok := agent.AsHookFreshness(ag)
+		if !ok {
+			continue
+		}
+		displayName := string(ag.Type())
+		switch hf.CheckHookConfig(ctx) {
+		case agent.HooksAbsent:
+			// Not installed in this repo — nothing to report.
+		case agent.HooksCurrent:
+			fmt.Fprintf(w, "✓ %s hook config: OK\n", displayName)
+		case agent.HooksOutdated:
+			fmt.Fprintf(w, "%s hooks: OUT OF DATE\n", displayName)
+			fmt.Fprintln(w, "  The installed hook config no longer matches what this CLI writes,")
+			fmt.Fprintln(w, "  so some or all hooks may silently not fire.")
+			fmt.Fprintln(w, "  Run `entire enable --force` to update it.")
+		}
 	}
 }
 

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -514,7 +514,7 @@ func TestCheckClaudeCodeHookDrift_SilentWhenNotInstalled(t *testing.T) {
 	t.Chdir(dir)
 
 	cmd, stdout := newTestCmd(t)
-	checkClaudeCodeHookDrift(cmd)
+	checkHookDrift(cmd)
 	require.NotContains(t, stdout.String(), "Claude Code hook")
 }
 
@@ -529,7 +529,7 @@ func TestCheckClaudeCodeHookDrift_OKWhenCurrent(t *testing.T) {
 	}
 
 	cmd, stdout := newTestCmd(t)
-	checkClaudeCodeHookDrift(cmd)
+	checkHookDrift(cmd)
 	require.Contains(t, stdout.String(), "✓ Claude Code hook config: OK")
 }
 
@@ -555,7 +555,7 @@ func TestCheckClaudeCodeHookDrift_WarnsWhenOutdated(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, claudecode.ClaudeSettingsFileName), []byte(stale), 0o600))
 
 	cmd, stdout := newTestCmd(t)
-	checkClaudeCodeHookDrift(cmd)
+	checkHookDrift(cmd)
 
 	out := stdout.String()
 	require.Contains(t, out, "Claude Code hooks: OUT OF DATE")

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -507,9 +507,10 @@ trusted_hash = "sha256:ccc"
 	require.Contains(t, out, "Open /hooks inside Codex")
 }
 
-// TestCheckClaudeCodeHookDrift_SilentWhenNotInstalled — doctor prints nothing
-// Claude-Code-related when this repo has no Entire hooks installed.
-func TestCheckClaudeCodeHookDrift_SilentWhenNotInstalled(t *testing.T) {
+// TestCheckHookDrift_SilentWhenNotInstalled — the generalized drift check
+// prints nothing Claude-Code-related when this repo has no Entire hooks
+// installed.
+func TestCheckHookDrift_SilentWhenNotInstalled(t *testing.T) {
 	dir := setupGitRepoForPhaseTest(t)
 	t.Chdir(dir)
 
@@ -518,9 +519,9 @@ func TestCheckClaudeCodeHookDrift_SilentWhenNotInstalled(t *testing.T) {
 	require.NotContains(t, stdout.String(), "Claude Code hook")
 }
 
-// TestCheckClaudeCodeHookDrift_OKWhenCurrent — a fresh install writes the
-// current matchers, so doctor reports OK.
-func TestCheckClaudeCodeHookDrift_OKWhenCurrent(t *testing.T) {
+// TestCheckHookDrift_ClaudeCodeOKWhenCurrent — a fresh Claude Code install
+// writes the current matchers, so the drift check reports OK.
+func TestCheckHookDrift_ClaudeCodeOKWhenCurrent(t *testing.T) {
 	dir := setupGitRepoForPhaseTest(t)
 	t.Chdir(dir)
 
@@ -533,10 +534,10 @@ func TestCheckClaudeCodeHookDrift_OKWhenCurrent(t *testing.T) {
 	require.Contains(t, stdout.String(), "✓ Claude Code hook config: OK")
 }
 
-// TestCheckClaudeCodeHookDrift_WarnsWhenOutdated — a config left by an older CLI
-// (hooks under the stale Task/TodoWrite matchers) is reported OUT OF DATE with
-// the --force fix hint.
-func TestCheckClaudeCodeHookDrift_WarnsWhenOutdated(t *testing.T) {
+// TestCheckHookDrift_ClaudeCodeWarnsWhenOutdated — a Claude Code config left by
+// an older CLI (hooks under the stale Task/TodoWrite matchers) is reported OUT
+// OF DATE with the --force fix hint.
+func TestCheckHookDrift_ClaudeCodeWarnsWhenOutdated(t *testing.T) {
 	dir := setupGitRepoForPhaseTest(t)
 	t.Chdir(dir)
 

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	checkpointremote "github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
@@ -199,9 +198,9 @@ func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statu
 		}
 
 		// Warn when installed hooks are out of date (read-only; fix is manual).
-		if claudecode.CheckHookConfig(ctx) == claudecode.HooksOutdated {
+		for _, displayName := range OutdatedHookAgentDisplayNames(ctx) {
 			b.WriteString("\n")
-			b.WriteString(sty.render(sty.yellow, "  ! Claude Code hooks out of date"))
+			b.WriteString(sty.render(sty.yellow, "  ! "+displayName+" hooks out of date"))
 			b.WriteString(sty.render(sty.dim, " · run 'entire enable --force'"))
 		}
 	}
@@ -803,8 +802,8 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 			result.Agents = names
 		}
 
-		if claudecode.CheckHookConfig(ctx) == claudecode.HooksOutdated {
-			result.HooksOutdated = append(result.HooksOutdated, "claude-code")
+		for _, name := range OutdatedHookAgents(ctx) {
+			result.HooksOutdated = append(result.HooksOutdated, string(name))
 		}
 
 		// Same computation as the text path (writeCheckpointSyncLines);


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1000
<!-- entire-trail-link-end -->

## Why

`entire agent add pi` in a repo with a committed extension failed with:

```
failed to setup pi hooks: refusing to overwrite foreign file at
  .pi/extensions/entire/index.ts; remove it or pass --force
```

That refusal was correct — the file predated the `Auto-generated by ...` header, so the installer couldn't recognise it as Entire's. But chasing it surfaced a real gap behind it.

Repos commonly **commit** `.pi/extensions/entire/index.ts` and `.opencode/plugins/entire.ts`, so every clone gets checkpointing without each person enabling it by hand — forgetting to enable means losing sessions. The committed copy then goes stale as the template evolves, and nothing notices:

- `AreHooksInstalled` only checks for the marker substring, so a stale-but-marked file reads as installed forever.
- The extension's own `fireHook` swallows every error by design, so broken hooks are silent.

Result: the repo reports healthy while its hooks no-op. Claude Code was the only agent with a drift check (`CheckHookConfig`), and `status`/`doctor` hardcoded it by name, so no other agent could ever report drift regardless of what it implemented.

## What changed

- **`agent.HookFreshness`** — optional capability answering "is what's installed still what we'd write today?", distinct from `AreHooksInstalled`'s "is Entire wired up here at all?".
- **`agent.GeneratedHookFileState`** — shared implementation for agents whose whole integration is one generated file.
- **pi + opencode** implement it; **claudecode**'s enum becomes an alias of the shared type (no behaviour change, existing call sites untouched).
- **`status` + `doctor`** iterate installed agents via `AsHookFreshness` instead of naming claude-code. `status --json`'s `hooks_outdated` was already a list of agent names, so no schema change.

### Design note

Drift is detected by comparing **exact content against every render `InstallHooks` could have written**, not a stamped template version. Any edit to an embedded template then makes installed copies read as outdated automatically, with no version constant anyone can forget to bump. Matching both the production and local-dev renders is what keeps a `--local-dev` install from reading as permanent drift (`LocalDevHookScript` is a fixed const, so this is exact and machine-independent).

A **foreign** file reads as `HooksAbsent`, not `HooksOutdated` — `InstallHooks` refuses to overwrite it, so warning would nag about a file the CLI won't fix.

## Verification

`mise run check` passes (lint 0 issues; unit + integration + canary E2E green). Each of the four commits builds independently, so bisect stays clean.

It found genuine drift on first run against a real repo:

```
  Agents · Claude Code, Codex, OpenCode, Pi
  ! Claude Code hooks out of date · run 'entire enable --force'
  ! OpenCode hooks out of date · run 'entire enable --force'
  ! Pi hooks out of date · run 'entire enable --force'
```

The pi entry was a committed extension written before ed42608db (`ENTIRE_CMD` double-quoted instead of single-quoted) — exactly the silent-breakage class this is meant to catch.

## Trade-off worth a reviewer's eye

Drift is measured against **the checking binary's** template. With a committed extension and a team on mixed CLI versions, whoever runs the newest CLI sees the warning until someone re-runs `--force` and commits. That's the intended signal for a committed generated file, but it does mean a yellow status line during version skew rather than silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only diagnostics and additive agent interfaces; behavior change is surfacing warnings users were missing when committed Pi/OpenCode extensions or Claude matchers were stale.
> 
> **Overview**
> Introduces **`HookFreshness`** and shared **`HookConfigState`** so diagnostics can tell whether installed hooks still match what **`InstallHooks`** would write today—separate from **`AreHooksInstalled`**, which can stay true for committed generated files that have gone stale.
> 
> **Pi** and **OpenCode** implement drift checks via **`GeneratedHookFileState`**, comparing on-disk plugin/extension bytes to current production and local-dev renders (foreign files at the path count as absent, not outdated). **Claude Code** keeps its matcher-based logic but aliases the shared enum and wires **`CheckHookConfig`** through the interface.
> 
> **`OutdatedHookAgents`** drives **`entire status`** (text warnings per agent; **`--json`** **`hooks_outdated`** lists all outdated agents) and **`entire doctor`**’s generalized **`checkHookDrift`**, replacing the Claude-only hardcoded path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 834bfc7f28f7a70fb38b56696144b0a3621d6640. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->