### PR TITLE
feat(explain): cross-repo checkpoint explain via the entire-api cell (ENT-1523)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,17 @@ the commands are always runnable in every build.
   to the adopted session from the new location.
 - `checkpoint` (aliases: `cp`, `checkpoints`): `list`, `explain`, `tokens`, `search`, plus
   the deprecated `rewind` (functional, prints a cobra deprecation message, will
-  be removed in a future release)
+  be removed in a future release).
+  `explain` also takes `--repo <owner/name>`, the drill-down for a cross-repo
+  `search` hit: it reads the checkpoint from that repo's entire-api cell over
+  HTTP (`/repos/{repo_id}/checkpoints/{id}` plus `.../transcript/raw`) rather
+  than fetching git objects, so a foreign checkpoint never enters this repo's
+  object store, ref namespace, or `tokens profile`. It needs a full checkpoint
+  ID and a pushed checkpoint; `--commit`, `--session`, `--search-all`, and
+  `--generate` are rejected with it, and naming the current repo is a no-op
+  that falls through to the local path. See `checkpoint_api_reader.go`
+  (`apiCheckpointReader`, which implements the two checkpoint reader tiers and
+  deliberately not `Writer`) and `explain_repo.go`.
 - `agent`: bare opens the interactive agent selector, plus `list`, `add`, `remove`
 - `configure`: bare prints help and a hint pointing at `entire agent`; flags
   manage non-agent settings (telemetry, git-hook installation mode, strategy

--- a/cmd/entire/cli/api_cmd.go
+++ b/cmd/entire/cli/api_cmd.go
@@ -222,7 +222,7 @@ func expandAPIPlaceholders(ctx context.Context, s string) (string, error) {
 		s = strings.ReplaceAll(s, "{repo}", repo)
 	}
 	if needRepoID {
-		id, err := resolveCurrentRepoID(ctx, forge, owner, repo)
+		id, err := resolveRepoIDFromMirror(ctx, forge, owner, repo)
 		if err != nil {
 			return "", err
 		}
@@ -231,10 +231,12 @@ func expandAPIPlaceholders(ctx context.Context, s string) (string, error) {
 	return s, nil
 }
 
-// resolveCurrentRepoID resolves a repo's Entire ULID from its mirror (the mirror
-// id, which entire-api uses as the repo_id), given its already-resolved origin
-// coordinates. Picks the first active placement.
-func resolveCurrentRepoID(ctx context.Context, forge, owner, repo string) (string, error) {
+// resolveRepoIDFromMirror resolves a repo's Entire ULID from its mirror (the
+// mirror id, which entire-api uses as the repo_id), given its already-resolved
+// coordinates. Picks the first active placement. Used for the current repo by
+// `entire api`'s {repo_id} placeholder and for a foreign repo by cross-repo
+// `checkpoint explain --repo`.
+func resolveRepoIDFromMirror(ctx context.Context, forge, owner, repo string) (string, error) {
 	if f := strings.ToLower(strings.TrimSpace(forge)); f != "gh" && f != mirrorCloneProviderGitHub {
 		return "", fmt.Errorf("{repo_id} needs a GitHub repo; origin forge is %q", forge)
 	}

--- a/cmd/entire/cli/api_cmd.go
+++ b/cmd/entire/cli/api_cmd.go
@@ -222,7 +222,7 @@ func expandAPIPlaceholders(ctx context.Context, s string) (string, error) {
 		s = strings.ReplaceAll(s, "{repo}", repo)
 	}
 	if needRepoID {
-		id, err := resolveRepoIDFromMirror(ctx, forge, owner, repo)
+		id, err := resolveCurrentRepoID(ctx, forge, owner, repo)
 		if err != nil {
 			return "", err
 		}
@@ -231,12 +231,10 @@ func expandAPIPlaceholders(ctx context.Context, s string) (string, error) {
 	return s, nil
 }
 
-// resolveRepoIDFromMirror resolves a repo's Entire ULID from its mirror (the
-// mirror id, which entire-api uses as the repo_id), given its already-resolved
-// coordinates. Picks the first active placement. Used for the current repo by
-// `entire api`'s {repo_id} placeholder and for a foreign repo by cross-repo
-// `checkpoint explain --repo`.
-func resolveRepoIDFromMirror(ctx context.Context, forge, owner, repo string) (string, error) {
+// resolveCurrentRepoID resolves a repo's Entire ULID from its mirror (the mirror
+// id, which entire-api uses as the repo_id), given its already-resolved origin
+// coordinates. Picks the first active placement.
+func resolveCurrentRepoID(ctx context.Context, forge, owner, repo string) (string, error) {
 	if f := strings.ToLower(strings.TrimSpace(forge)); f != "gh" && f != mirrorCloneProviderGitHub {
 		return "", fmt.Errorf("{repo_id} needs a GitHub repo; origin forge is %q", forge)
 	}

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -18,6 +18,20 @@ import (
 // must hold for slow cores, not just erroring ones.
 const cellResolveTimeout = 5 * time.Second
 
+// requiredCellResolveTimeout bounds the control-plane lookups a repo-scoped
+// cell read cannot proceed without (resolveRepoCellPlacement).
+//
+// Deliberately not cellResolveTimeout: that budget bounds *best-effort* lookups
+// whose failure silently degrades to home-jurisdiction routing, so it can be
+// aggressive. Here a timeout is a visible command failure, and the budget has
+// to cover two sequential control-plane round trips (the repo's mirrors, then
+// the cluster catalog), so it is more patient.
+//
+// Some deadline is required: the coreapi HTTP client sets only a dial timeout,
+// so a reachable-but-slow core is otherwise unbounded, and this runs before the
+// command's spinner starts — the user would sit in front of a silent terminal.
+const requiredCellResolveTimeout = 15 * time.Second
+
 // cellCoreClient is the control-plane surface the cell-target resolver needs.
 // An interface (with a swappable constructor) so the resolver is unit-testable
 // against a fake control plane; *coreapi.Client satisfies it.
@@ -117,13 +131,16 @@ type repoCellPlacement struct {
 // among multi-region placements and falls back to the home cell, which is
 // exactly the mismatch to avoid here.
 func resolveRepoCellPlacement(ctx context.Context, owner, repo string) (repoCellPlacement, error) {
+	ctx, cancel := context.WithTimeout(ctx, requiredCellResolveTimeout)
+	defer cancel()
+
 	c, err := newCellCoreClient()
 	if err != nil {
 		return repoCellPlacement{}, fmt.Errorf("control plane unavailable: %w", err)
 	}
 	mirrors, err := listMirrorsForRepo(ctx, c, mirrorCloneProviderGitHub, strings.ToLower(owner), strings.ToLower(repo))
 	if err != nil {
-		return repoCellPlacement{}, fmt.Errorf("list mirrors for %s/%s: %w", owner, repo, err)
+		return repoCellPlacement{}, cellPlacementError(ctx, owner, repo, fmt.Errorf("list mirrors for %s/%s: %w", owner, repo, err))
 	}
 	for i := range mirrors {
 		if !isActiveMirror(mirrors[i]) {
@@ -142,7 +159,23 @@ func resolveRepoCellPlacement(ctx context.Context, owner, repo string) (repoCell
 		}
 		return repoCellPlacement{RepoID: repoID, Target: target}, nil
 	}
-	return repoCellPlacement{}, fmt.Errorf("no reachable Entire mirror for %s/%s", owner, repo)
+	// A deadline that fired mid-loop leaves cellTargetForClusterHost returning
+	// nil for every placement, which would otherwise be reported as "no
+	// reachable mirror" — a wrong diagnosis for a slow control plane.
+	return repoCellPlacement{}, cellPlacementError(ctx, owner, repo,
+		fmt.Errorf("no reachable Entire mirror for %s/%s", owner, repo))
+}
+
+// cellPlacementError reports a timeout as a timeout. The underlying lookups
+// degrade quietly (cellTargetForClusterHost logs and returns nil), so without
+// this a fired deadline surfaces as whichever "not found" message the caller
+// reached, and the user goes looking for a missing mirror instead of a slow
+// control plane.
+func cellPlacementError(ctx context.Context, owner, repo string, fallback error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("resolving the Entire mirror for %s/%s timed out: %w", owner, repo, ctxErr)
+	}
+	return fallback
 }
 
 // resolveRepoClusterHost finds the public cluster host that owns the repo. It

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -65,6 +66,14 @@ func resolveRepoCellTarget(ctx context.Context, fullName, ulid string) *auth.Cel
 		return nil
 	}
 
+	return cellTargetForClusterHost(ctx, c, clusterHost)
+}
+
+// cellTargetForClusterHost maps a known cluster host to a cell apiUrl +
+// jurisdiction via the coreapi cluster catalog, the authoritative source for a
+// jurisdiction's cell URL. Returns nil for every unresolvable case so callers
+// fall back to home-jurisdiction routing.
+func cellTargetForClusterHost(ctx context.Context, c cellCoreClient, clusterHost string) *auth.CellTarget {
 	clusters, err := c.ListClusters(ctx)
 	if err != nil {
 		logging.Debug(ctx, "cell target: list clusters failed, using home-jurisdiction routing", "error", err.Error())
@@ -85,6 +94,55 @@ func resolveRepoCellTarget(ctx context.Context, fullName, ulid string) *auth.Cel
 		return nil
 	}
 	return &auth.CellTarget{BaseURL: apiURL, Jurisdiction: jurisdiction}
+}
+
+// repoCellPlacement is one active mirror placement: the id entire-api keys
+// repo-scoped routes on, paired with the cell that actually holds it.
+type repoCellPlacement struct {
+	// RepoID is the mirror id, which entire-api uses as its repo_id.
+	RepoID string
+	// Target is the cell hosting THIS placement.
+	Target *auth.CellTarget
+}
+
+// resolveRepoCellPlacement resolves a GitHub repo to one active placement's
+// (repo_id, cell) pair for repo-scoped cell reads.
+//
+// The pair must come from the same placement: each placement has its own mirror
+// id, and only the cell hosting that placement can resolve it. Taking the id
+// from one placement and routing to a cell chosen some other way — the caller's
+// home cell, say — asks a cell about an id it has never seen, which comes back
+// as an indistinguishable 404. That is also why this does not reuse
+// resolveRepoCellTarget's owner/repo path: that one deliberately refuses to pick
+// among multi-region placements and falls back to the home cell, which is
+// exactly the mismatch to avoid here.
+func resolveRepoCellPlacement(ctx context.Context, owner, repo string) (repoCellPlacement, error) {
+	c, err := newCellCoreClient()
+	if err != nil {
+		return repoCellPlacement{}, fmt.Errorf("control plane unavailable: %w", err)
+	}
+	mirrors, err := listMirrorsForRepo(ctx, c, mirrorCloneProviderGitHub, strings.ToLower(owner), strings.ToLower(repo))
+	if err != nil {
+		return repoCellPlacement{}, fmt.Errorf("list mirrors for %s/%s: %w", owner, repo, err)
+	}
+	for i := range mirrors {
+		if !isActiveMirror(mirrors[i]) {
+			continue
+		}
+		repoID := strings.TrimSpace(mirrors[i].MirrorId)
+		clusterHost := strings.TrimSpace(mirrors[i].ClusterHost)
+		if repoID == "" || clusterHost == "" {
+			continue
+		}
+		target := cellTargetForClusterHost(ctx, c, clusterHost)
+		if target == nil {
+			// The catalog can't place this cluster; try the next placement
+			// rather than falling back to a cell that doesn't know this id.
+			continue
+		}
+		return repoCellPlacement{RepoID: repoID, Target: target}, nil
+	}
+	return repoCellPlacement{}, fmt.Errorf("no reachable Entire mirror for %s/%s", owner, repo)
 }
 
 // resolveRepoClusterHost finds the public cluster host that owns the repo. It

--- a/cmd/entire/cli/cell_target_test.go
+++ b/cmd/entire/cli/cell_target_test.go
@@ -205,3 +205,81 @@ func TestResolveRepoCellTarget_JurisdictionLowercased(t *testing.T) {
 		t.Fatalf("target = %+v, want lowercased jurisdiction eu", target)
 	}
 }
+
+// Bugbot (PR #1942): cross-repo reads must take the repo_id and the cell from
+// the SAME placement. A mirror id is only resolvable by the cell holding that
+// placement, so pairing one placement's id with a cell picked another way (the
+// caller's home cell, which is what resolveRepoCellTarget falls back to for a
+// multi-region repo) asks a cell about an id it has never seen.
+func TestResolveRepoCellPlacement_PairsIDWithItsOwnCell(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
+		mirrors: []coreapi.Mirror{
+			{Repo: "widget", MirrorId: "mirror-eu", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
+		},
+		clusters: euClusters(),
+	})
+	got, err := resolveRepoCellPlacement(context.Background(), "acme", "widget")
+	if err != nil {
+		t.Fatalf("resolveRepoCellPlacement: %v", err)
+	}
+	if got.RepoID != "mirror-eu" {
+		t.Errorf("RepoID = %q, want mirror-eu", got.RepoID)
+	}
+	if got.Target == nil || got.Target.Jurisdiction != "eu" || got.Target.BaseURL != euCellAPIURL {
+		t.Fatalf("Target = %+v, want the eu cell that holds mirror-eu", got.Target)
+	}
+}
+
+// A multi-region repo must still resolve to a real placement's cell. This is the
+// case resolveRepoCellTarget deliberately refuses (returning nil so the auth
+// layer routes to the caller's home cell) — for a repo_id-keyed read that
+// fallback is a wrong-cell 404, so this path picks a placement instead.
+func TestResolveRepoCellPlacement_MultiRegionPicksAPlacement(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
+		mirrors: []coreapi.Mirror{
+			{Repo: "widget", MirrorId: "mirror-eu", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
+			{Repo: "widget", MirrorId: "mirror-us", ClusterHost: "us.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
+		},
+		clusters: euClusters(),
+	})
+	got, err := resolveRepoCellPlacement(context.Background(), "acme", "widget")
+	if err != nil {
+		t.Fatalf("resolveRepoCellPlacement: %v", err)
+	}
+	// Whichever placement is chosen, its id and its cell must agree.
+	wantJurisdiction := map[string]string{"mirror-eu": "eu", "mirror-us": "us"}[got.RepoID]
+	if wantJurisdiction == "" {
+		t.Fatalf("RepoID = %q, want one of the two placements", got.RepoID)
+	}
+	if got.Target == nil || got.Target.Jurisdiction != wantJurisdiction {
+		t.Fatalf("Target = %+v, want the %s cell to match %s", got.Target, wantJurisdiction, got.RepoID)
+	}
+}
+
+// An inactive placement can't serve the repo, so it must not be chosen.
+func TestResolveRepoCellPlacement_SkipsInactiveAndUnplaceable(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
+		mirrors: []coreapi.Mirror{
+			{Repo: "widget", MirrorId: "mirror-failed", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusFailed)},
+			// Not in the cluster catalog: unplaceable, so skip rather than fall
+			// back to a cell that doesn't know this id.
+			{Repo: "widget", MirrorId: "mirror-unknown", ClusterHost: "nowhere.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
+			{Repo: "widget", MirrorId: "mirror-eu", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
+		},
+		clusters: euClusters(),
+	})
+	got, err := resolveRepoCellPlacement(context.Background(), "acme", "widget")
+	if err != nil {
+		t.Fatalf("resolveRepoCellPlacement: %v", err)
+	}
+	if got.RepoID != "mirror-eu" {
+		t.Errorf("RepoID = %q, want mirror-eu (the only active, placeable mirror)", got.RepoID)
+	}
+}
+
+func TestResolveRepoCellPlacement_NoMirror(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{clusters: euClusters()})
+	if _, err := resolveRepoCellPlacement(context.Background(), "acme", "widget"); err == nil {
+		t.Fatal("expected an error when the repo has no reachable mirror")
+	}
+}

--- a/cmd/entire/cli/cell_target_test.go
+++ b/cmd/entire/cli/cell_target_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/entireio/cli/internal/coreapi"
 )
@@ -98,6 +100,19 @@ type fakeCellCore struct {
 	mirrorsErr  error
 	clusters    []coreapi.Cluster
 	clustersErr error
+	// blockUntilCtxDone makes the lookups hang until the caller's deadline
+	// fires, standing in for a reachable-but-slow control plane. Off by
+	// default, so existing tests are unaffected.
+	blockUntilCtxDone bool
+}
+
+// waitIfBlocking simulates a core that accepts the connection and then stalls.
+func (f *fakeCellCore) waitIfBlocking(ctx context.Context) error {
+	if !f.blockUntilCtxDone {
+		return nil
+	}
+	<-ctx.Done()
+	return ctx.Err()
 }
 
 func (f *fakeCellCore) GetRepo(context.Context, coreapi.GetRepoParams) (*coreapi.Repo, error) {
@@ -111,7 +126,10 @@ func (f *fakeCellCore) ListClusters(context.Context) (*coreapi.ListClustersOutpu
 	return &coreapi.ListClustersOutputBody{Clusters: f.clusters}, nil
 }
 
-func (f *fakeCellCore) ListMirrors(context.Context, coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error) {
+func (f *fakeCellCore) ListMirrors(ctx context.Context, _ coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error) {
+	if err := f.waitIfBlocking(ctx); err != nil {
+		return nil, err
+	}
 	if f.mirrorsErr != nil {
 		return nil, f.mirrorsErr
 	}
@@ -281,5 +299,46 @@ func TestResolveRepoCellPlacement_NoMirror(t *testing.T) {
 	withFakeCellCore(t, &fakeCellCore{clusters: euClusters()})
 	if _, err := resolveRepoCellPlacement(context.Background(), "acme", "widget"); err == nil {
 		t.Fatal("expected an error when the repo has no reachable mirror")
+	}
+}
+
+// Trail #1003 finding: resolveRepoCellPlacement was the one cell-resolution
+// entry point with no deadline, and the coreapi HTTP client sets only a dial
+// timeout — so a reachable-but-slow control plane stalled `explain --repo`
+// indefinitely, before its spinner had even started. The parent deadline here
+// is shorter than requiredCellResolveTimeout, which is what keeps this test
+// fast; the point is that the wait is bounded and reported as a timeout.
+func TestResolveRepoCellPlacement_BoundedByDeadline(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{blockUntilCtxDone: true, clusters: euClusters()})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := resolveRepoCellPlacement(ctx, "acme", "widget")
+	if err == nil {
+		t.Fatal("expected a timeout error from a stalled control plane")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("resolveRepoCellPlacement waited %s; the lookup is not bounded", elapsed)
+	}
+	// Reported as a timeout, not as a missing mirror — the whole point is that
+	// the user looks at the control plane rather than at their mirrors.
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %q, want it to name a timeout", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error = %q, want it to wrap context.DeadlineExceeded", err)
+	}
+}
+
+// The command cannot proceed without this lookup, so its budget is separate
+// from the best-effort one that silently degrades to home-jurisdiction routing.
+func TestRequiredCellResolveTimeoutIsItsOwnBudget(t *testing.T) {
+	t.Parallel()
+
+	if requiredCellResolveTimeout <= cellResolveTimeout {
+		t.Errorf("requiredCellResolveTimeout (%s) should be more patient than the best-effort cellResolveTimeout (%s): a timeout here fails the command instead of degrading",
+			requiredCellResolveTimeout, cellResolveTimeout)
 	}
 }

--- a/cmd/entire/cli/checkpoint_api_reader.go
+++ b/cmd/entire/cli/checkpoint_api_reader.go
@@ -1,0 +1,382 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+)
+
+// maxAPITranscriptBytes caps a single raw-transcript read from the cell. It
+// matches the 50MB blob cap the checkpoint store writes under, so any
+// transcript the store accepted is readable here; a larger response means the
+// server changed its contract and we should fail loudly rather than silently
+// truncate a transcript into the renderer.
+const maxAPITranscriptBytes = 50 << 20
+
+// apiCheckpointReader reads one repo's committed checkpoints over the
+// entire-api cell HTTP surface instead of the local git object store. It
+// implements checkpoint.CheckpointReader + checkpoint.SessionReader (plus the
+// optional checkpoint.AuthorReader), which is the whole surface explain's
+// render path needs — so cross-repo explain reuses the local renderers
+// verbatim rather than carrying a second output implementation.
+//
+// Nothing is written to the local repository: the point of reading through the
+// API is that another repo's checkpoint never enters this repo's object store,
+// ref namespace, or `entire tokens profile`.
+//
+// It deliberately does NOT implement checkpoint.Writer. A foreign repo's
+// checkpoint is read-only from here (`--generate` is rejected at the flag
+// layer), and leaving Write off the type makes that structural instead of a
+// convention this file has to remember.
+type apiCheckpointReader struct {
+	client *api.Client
+	// repoID is the repo's Entire ULID; cell checkpoint routes key on it.
+	repoID string
+	// ownerRepo is the display coordinate ("owner/name") used in errors.
+	ownerRepo string
+
+	// detail caches the checkpoint envelope. Every read tier is derived from
+	// this one response, and explain reads the summary and then each session,
+	// so caching turns an N+1 into a single request.
+	detail   *apiCheckpointInfo
+	detailID id.CheckpointID
+}
+
+// newAPICheckpointReader returns a reader for repoID's checkpoints on the cell
+// that client is already pointed at.
+func newAPICheckpointReader(client *api.Client, repoID, ownerRepo string) *apiCheckpointReader {
+	return &apiCheckpointReader{client: client, repoID: repoID, ownerRepo: ownerRepo}
+}
+
+// --- wire shapes ------------------------------------------------------
+//
+// Only the fields the CLI renders are declared. These mirror entire-api's
+// httpapi.CheckpointInfo / CheckpointSessionInfo; unknown fields are ignored so
+// a server-side addition can't break the read.
+
+type apiCheckpointEnvelope struct {
+	Checkpoint   *apiCheckpointInfo `json:"checkpoint"`
+	RepoFullName string             `json:"repo_full_name"`
+}
+
+type apiCheckpointInfo struct {
+	CheckpointID         string                 `json:"checkpointId"`
+	CommitSha            string                 `json:"commitSha"`
+	CommitSubject        string                 `json:"commitSubject"`
+	CommitDate           string                 `json:"commitDate"`
+	CommitAuthor         string                 `json:"commitAuthor"`
+	CommitAuthorUsername *string                `json:"commitAuthorUsername"`
+	CreatedAt            string                 `json:"createdAt"`
+	FilesTouched         []string               `json:"filesTouched"`
+	Sessions             []apiCheckpointSession `json:"sessions"`
+	SessionCount         int                    `json:"sessionCount"`
+	TotalSteps           int                    `json:"totalSteps"`
+	InputTokens          int64                  `json:"inputTokens"`
+	CacheCreationTokens  int64                  `json:"cacheCreationTokens"`
+	CacheReadTokens      int64                  `json:"cacheReadTokens"`
+	OutputTokens         int64                  `json:"outputTokens"`
+	APICallCount         int64                  `json:"apiCallCount"`
+}
+
+type apiCheckpointSession struct {
+	Prompt                    *string               `json:"prompt"`
+	Agent                     string                `json:"agent"`
+	Model                     string                `json:"model"`
+	Kind                      string                `json:"kind"`
+	Steps                     int                   `json:"steps"`
+	SessionID                 string                `json:"sessionId"`
+	CreatedAt                 string                `json:"createdAt"`
+	TokenUsage                *apiSessionTokenUsage `json:"tokenUsage"`
+	CheckpointTranscriptStart *int                  `json:"checkpointTranscriptStart"`
+	SkillEvents               []types.SkillEvent    `json:"skillEvents"`
+}
+
+type apiSessionTokenUsage struct {
+	InputTokens         int64 `json:"inputTokens"`
+	CacheCreationTokens int64 `json:"cacheCreationTokens"`
+	CacheReadTokens     int64 `json:"cacheReadTokens"`
+	OutputTokens        int64 `json:"outputTokens"`
+	APICallCount        int64 `json:"apiCallCount"`
+}
+
+// --- checkpoint tier --------------------------------------------------
+
+// Read fetches the checkpoint envelope and maps it onto the local
+// CheckpointSummary shape the renderers consume.
+func (r *apiCheckpointReader) Read(ctx context.Context, checkpointID id.CheckpointID) (*checkpoint.CheckpointSummary, error) {
+	info, err := r.loadDetail(ctx, checkpointID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sessions carries cardinality only: the renderers use len(Sessions) and
+	// index into it, and read the actual per-session data through
+	// SessionReader. The local shape's path fields name blobs in a git tree,
+	// which has no meaning over HTTP, so they stay empty rather than carrying
+	// invented paths a caller might try to resolve.
+	sessions := make([]checkpoint.SessionFilePaths, len(info.Sessions))
+
+	// Branch is deliberately left empty. The local shape's Branch is the branch
+	// the checkpoint was CREATED on; the cell reports the branches that
+	// currently CONTAIN the commit (a checkpoint made on a feature branch and
+	// since merged reports "main"). Those are different facts, and putting the
+	// second one behind the first one's JSON field would quietly mislead every
+	// consumer of `explain --json`.
+	return &checkpoint.CheckpointSummary{
+		CheckpointID:     checkpointID,
+		Strategy:         "manual-commit",
+		CommitSHA:        info.CommitSha,
+		CheckpointsCount: info.TotalSteps,
+		FilesTouched:     info.FilesTouched,
+		Sessions:         sessions,
+		TokenUsage: &types.TokenUsage{
+			InputTokens:         int(info.InputTokens),
+			CacheCreationTokens: int(info.CacheCreationTokens),
+			CacheReadTokens:     int(info.CacheReadTokens),
+			OutputTokens:        int(info.OutputTokens),
+			APICallCount:        int(info.APICallCount),
+		},
+	}, nil
+}
+
+// List is not supported: enumerating a foreign repo's checkpoints is a
+// different product surface (`entire search`), and cross-repo explain requires
+// a full checkpoint ID precisely so no prefix resolution — the only thing that
+// needs a listing — is involved.
+func (r *apiCheckpointReader) List(context.Context) ([]checkpoint.CheckpointInfo, error) {
+	return nil, errors.New("listing another repo's checkpoints is not supported; use `entire search`")
+}
+
+// GetCheckpointAuthor satisfies checkpoint.AuthorReader so the renderer can
+// attribute a foreign checkpoint without any local commit to read it from.
+func (r *apiCheckpointReader) GetCheckpointAuthor(ctx context.Context, checkpointID id.CheckpointID) (checkpoint.Author, error) {
+	info, err := r.loadDetail(ctx, checkpointID)
+	if err != nil {
+		return checkpoint.Author{}, err
+	}
+	name := info.CommitAuthor
+	if name == "" && info.CommitAuthorUsername != nil {
+		name = *info.CommitAuthorUsername
+	}
+	// The cell exposes the commit author's display name and forge username,
+	// never their email, so Email stays empty instead of being guessed.
+	return checkpoint.Author{Name: name}, nil
+}
+
+// checkpointCommit returns the commit the checkpoint is anchored to, as
+// reported by the cell. Cross-repo explain has no local commit to walk for
+// this, so the renderer is fed the server's view instead of an empty list —
+// which would otherwise render as "(none on this branch)" and read as if the
+// foreign checkpoint were uncommitted.
+func (r *apiCheckpointReader) checkpointCommit(ctx context.Context, checkpointID id.CheckpointID) ([]associatedCommit, error) {
+	info, err := r.loadDetail(ctx, checkpointID)
+	if err != nil {
+		return nil, err
+	}
+	sha := strings.TrimSpace(info.CommitSha)
+	if sha == "" {
+		// Genuinely uncommitted (or not yet linked) — nil omits the row rather
+		// than asserting either way.
+		return nil, nil
+	}
+	short := sha
+	if len(short) > 7 {
+		short = short[:7]
+	}
+	return []associatedCommit{{
+		SHA:      sha,
+		ShortSHA: short,
+		Message:  info.CommitSubject,
+		Author:   info.CommitAuthor,
+		Date:     parseAPITime(info.CommitDate),
+	}}, nil
+}
+
+// --- session tier -----------------------------------------------------
+
+func (r *apiCheckpointReader) ReadSessionMetadata(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*checkpoint.Metadata, error) {
+	meta, _, err := r.ReadSessionMetadataAndPrompts(ctx, checkpointID, sessionIndex)
+	return meta, err
+}
+
+func (r *apiCheckpointReader) ReadSessionPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (string, error) {
+	_, prompts, err := r.ReadSessionMetadataAndPrompts(ctx, checkpointID, sessionIndex)
+	return prompts, err
+}
+
+// ReadSessionMetadataAndPrompts maps one entry of the checkpoint envelope's
+// sessions[] onto the local session Metadata shape. Both narrower accessors
+// delegate here so there is one mapping to keep correct.
+func (r *apiCheckpointReader) ReadSessionMetadataAndPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*checkpoint.Metadata, string, error) {
+	info, err := r.loadDetail(ctx, checkpointID)
+	if err != nil {
+		return nil, "", err
+	}
+	if sessionIndex < 0 || sessionIndex >= len(info.Sessions) {
+		return nil, "", fmt.Errorf("session index %d out of range: checkpoint %s has %d session(s)", sessionIndex, checkpointID, len(info.Sessions))
+	}
+	s := info.Sessions[sessionIndex]
+
+	meta := &checkpoint.Metadata{
+		CheckpointID:     checkpointID,
+		SessionID:        s.SessionID,
+		Strategy:         "manual-commit",
+		CreatedAt:        parseAPITime(s.CreatedAt, info.CreatedAt),
+		CommitSHA:        info.CommitSha,
+		CheckpointsCount: s.Steps,
+		FilesTouched:     info.FilesTouched,
+		Agent:            types.AgentType(s.Agent),
+		Model:            s.Model,
+		Kind:             s.Kind,
+		SkillEvents:      s.SkillEvents,
+	}
+	// Absent upstream means "not recorded", which is exactly how a local
+	// checkpoint written before the field existed reads: GetTranscriptStart()
+	// falls back to 0 and the transcript renders unscoped. Don't invent an
+	// offset — a wrong one silently shows the wrong slice.
+	if s.CheckpointTranscriptStart != nil {
+		meta.CheckpointTranscriptStart = *s.CheckpointTranscriptStart
+	}
+	if s.TokenUsage != nil {
+		meta.TokenUsage = &types.TokenUsage{
+			InputTokens:         int(s.TokenUsage.InputTokens),
+			CacheCreationTokens: int(s.TokenUsage.CacheCreationTokens),
+			CacheReadTokens:     int(s.TokenUsage.CacheReadTokens),
+			OutputTokens:        int(s.TokenUsage.OutputTokens),
+			APICallCount:        int(s.TokenUsage.APICallCount),
+		}
+	}
+
+	prompts := ""
+	if s.Prompt != nil {
+		prompts = *s.Prompt
+	}
+	return meta, prompts, nil
+}
+
+// ReadSessionContent pairs the session's metadata with its stored transcript
+// bytes. The bytes come from the raw endpoint, not the parsed one: explain
+// documents --transcript as the same bytes as --raw-transcript, and the parsed
+// message-tree view is a derived shape that would quietly break that promise.
+func (r *apiCheckpointReader) ReadSessionContent(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*checkpoint.SessionContent, error) {
+	meta, prompts, err := r.ReadSessionMetadataAndPrompts(ctx, checkpointID, sessionIndex)
+	if err != nil {
+		return nil, err
+	}
+	transcript, err := r.readRawTranscript(ctx, checkpointID, sessionIndex)
+	if err != nil {
+		return nil, err
+	}
+	return &checkpoint.SessionContent{
+		Metadata:   *meta,
+		Transcript: transcript,
+		Prompts:    prompts,
+	}, nil
+}
+
+// readRawTranscript streams one session's stored transcript bytes.
+func (r *apiCheckpointReader) readRawTranscript(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) ([]byte, error) {
+	path := fmt.Sprintf("/api/v1/repos/%s/checkpoints/%s/transcript/raw?%s",
+		url.PathEscape(r.repoID), url.PathEscape(checkpointID.String()),
+		url.Values{"session": []string{strconv.Itoa(sessionIndex)}}.Encode())
+
+	resp, err := r.client.GetStream(ctx, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("read transcript for checkpoint %s from %s: %w", checkpointID, r.ownerRepo, err)
+	}
+	defer resp.Body.Close()
+
+	if err := api.CheckResponse(resp); err != nil {
+		// A missing transcript blob is a real, reportable state (the
+		// checkpoint exists but its bytes were never stored or have been
+		// pruned) — distinct from the checkpoint itself being absent, which
+		// Read already reported.
+		if api.IsHTTPErrorStatus(err, http.StatusNotFound) {
+			return nil, fmt.Errorf("checkpoint %s in %s has no stored transcript", checkpointID, r.ownerRepo)
+		}
+		return nil, fmt.Errorf("read transcript for checkpoint %s from %s: %w", checkpointID, r.ownerRepo, err)
+	}
+
+	// LimitReader+1 so a transcript exactly at the cap is not mistaken for an
+	// oversized one, and an oversized one is an error rather than a silent
+	// truncation into the renderer.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPITranscriptBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read transcript for checkpoint %s from %s: %w", checkpointID, r.ownerRepo, err)
+	}
+	if len(body) > maxAPITranscriptBytes {
+		return nil, fmt.Errorf("transcript for checkpoint %s in %s exceeds the %d MB read limit", checkpointID, r.ownerRepo, maxAPITranscriptBytes>>20)
+	}
+	return body, nil
+}
+
+// --- envelope fetch ---------------------------------------------------
+
+// loadDetail fetches (and memoizes) the checkpoint envelope.
+func (r *apiCheckpointReader) loadDetail(ctx context.Context, checkpointID id.CheckpointID) (*apiCheckpointInfo, error) {
+	if r.detail != nil && r.detailID == checkpointID {
+		return r.detail, nil
+	}
+
+	path := fmt.Sprintf("/api/v1/repos/%s/checkpoints/%s",
+		url.PathEscape(r.repoID), url.PathEscape(checkpointID.String()))
+	resp, err := r.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("read checkpoint %s from %s: %w", checkpointID, r.ownerRepo, err)
+	}
+	defer resp.Body.Close()
+
+	if err := api.CheckResponse(resp); err != nil {
+		if api.IsHTTPErrorStatus(err, http.StatusNotFound) {
+			// Lead with the cause that is overwhelmingly the common one. A
+			// checkpoint only becomes visible here once it has been pushed
+			// and ingested, and most local checkpoints in an active repo are
+			// not pushed yet.
+			return nil, fmt.Errorf("checkpoint %s is not available for %s yet: it may not have been pushed, or Entire may not have finished ingesting it. Checkpoints you have not pushed are only readable in the repo that created them", checkpointID, r.ownerRepo)
+		}
+		if api.IsHTTPErrorStatus(err, http.StatusForbidden) {
+			return nil, fmt.Errorf("your login cannot read checkpoints in %s", r.ownerRepo)
+		}
+		return nil, fmt.Errorf("read checkpoint %s from %s: %w", checkpointID, r.ownerRepo, err)
+	}
+
+	var env apiCheckpointEnvelope
+	if err := api.DecodeJSON(resp, &env); err != nil {
+		return nil, fmt.Errorf("read checkpoint %s from %s: %w", checkpointID, r.ownerRepo, err)
+	}
+	if env.Checkpoint == nil {
+		return nil, fmt.Errorf("checkpoint %s is not available for %s (the server returned no checkpoint)", checkpointID, r.ownerRepo)
+	}
+	if len(env.Checkpoint.Sessions) == 0 {
+		return nil, fmt.Errorf("checkpoint %s in %s has no sessions to explain", checkpointID, r.ownerRepo)
+	}
+
+	r.detail = env.Checkpoint
+	r.detailID = checkpointID
+	return r.detail, nil
+}
+
+// parseAPITime parses the first parseable RFC3339 timestamp from the given
+// candidates. Returns the zero time when none parse, which renders as "unknown"
+// rather than as a wrong date.
+func parseAPITime(candidates ...string) time.Time {
+	for _, c := range candidates {
+		if c = strings.TrimSpace(c); c != "" {
+			if t, err := time.Parse(time.RFC3339, c); err == nil {
+				return t
+			}
+		}
+	}
+	return time.Time{}
+}

--- a/cmd/entire/cli/checkpoint_api_reader_test.go
+++ b/cmd/entire/cli/checkpoint_api_reader_test.go
@@ -1,0 +1,356 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+)
+
+const (
+	testAPIRepoID   = "01KVBJCWYA4YW6J5M9GP655HZ9"
+	testAPIOwnerRep = "acme/widgets"
+)
+
+var testAPICheckpointID = id.CheckpointID("01KXGTTNGCEACC83QZEJ5YAF0D")
+
+// checkpointEnvelopeJSON mirrors a real cell response for
+// GET /repos/{repo_id}/checkpoints/{checkpoint_id}, trimmed to the fields the
+// CLI reads. `branches` is deliberately present and different from the
+// checkpoint's creation branch — see TestAPICheckpointReader_ReadLeavesBranchEmpty.
+const checkpointEnvelopeJSON = `{
+  "checkpoint_id": "01KXGTTNGCEACC83QZEJ5YAF0D",
+  "branches": ["main"],
+  "default_branch": "main",
+  "suggested_branch": "main",
+  "repo_full_name": "acme/widgets",
+  "checkpoint": {
+    "checkpointId": "01KXGTTNGCEACC83QZEJ5YAF0D",
+    "commitSha": "13e379e4b0000000000000000000000000000000",
+    "commitSubject": "docs(readme): document headless auth",
+    "commitDate": "2026-07-14T17:30:13.000Z",
+    "commitAuthor": "Peyton Montei",
+    "commitAuthorUsername": "peyton-alt",
+    "createdAt": "2026-07-14T17:30:22.661Z",
+    "filesTouched": ["README.md", "cmd/entire/cli/auth.go"],
+    "sessionCount": 2,
+    "totalSteps": 4,
+    "inputTokens": 468,
+    "cacheCreationTokens": 1381547,
+    "cacheReadTokens": 70839522,
+    "outputTokens": 197680,
+    "apiCallCount": 252,
+    "sessions": [
+      {
+        "prompt": "first session prompt",
+        "agent": "Claude Code",
+        "model": "claude-fable-5",
+        "steps": 1,
+        "sessionId": "session-one",
+        "createdAt": "2026-07-14T17:00:00.000Z",
+        "checkpointTranscriptStart": 7,
+        "tokenUsage": {"inputTokens": 100, "cacheCreationTokens": 2, "cacheReadTokens": 3, "outputTokens": 4, "apiCallCount": 5}
+      },
+      {
+        "prompt": "second session prompt",
+        "agent": "Claude Code",
+        "steps": 3,
+        "sessionId": "session-two",
+        "createdAt": "2026-07-14T17:30:22.661Z"
+      }
+    ]
+  }
+}`
+
+// newTestAPIReader wires an apiCheckpointReader at an httptest server. The
+// returned recorder captures every requested path so tests can assert which
+// endpoint a read actually hit.
+func newTestAPIReader(t *testing.T, handler http.HandlerFunc) (*apiCheckpointReader, *[]string) {
+	t.Helper()
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.RequestURI())
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	client := api.NewClientWithBaseURL("test-token", srv.URL)
+	return newAPICheckpointReader(client, testAPIRepoID, testAPIOwnerRep), &paths
+}
+
+// defaultAPIHandler serves the envelope and a raw transcript per session index.
+func defaultAPIHandler(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasSuffix(r.URL.Path, "/transcript/raw"):
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprintf(w, `{"type":"user","session":%q}`+"\n", r.URL.Query().Get("session"))
+	case strings.Contains(r.URL.Path, "/checkpoints/"):
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, checkpointEnvelopeJSON)
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func TestAPICheckpointReader_ReadMapsEnvelope(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, defaultAPIHandler)
+	summary, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.NoError(t, err)
+
+	assert.Equal(t, testAPICheckpointID, summary.CheckpointID)
+	assert.Equal(t, "13e379e4b0000000000000000000000000000000", summary.CommitSHA)
+	assert.Equal(t, 4, summary.CheckpointsCount, "checkpoints_count comes from totalSteps")
+	assert.Equal(t, []string{"README.md", "cmd/entire/cli/auth.go"}, summary.FilesTouched)
+	assert.Len(t, summary.Sessions, 2, "one entry per session so index-based reads and len() work")
+	require.NotNil(t, summary.TokenUsage)
+	assert.Equal(t, 468, summary.TokenUsage.InputTokens)
+	assert.Equal(t, 1381547, summary.TokenUsage.CacheCreationTokens)
+	assert.Equal(t, 70839522, summary.TokenUsage.CacheReadTokens)
+	assert.Equal(t, 197680, summary.TokenUsage.OutputTokens)
+	assert.Equal(t, 252, summary.TokenUsage.APICallCount)
+}
+
+// The cell reports branches CONTAINING the commit, which is a different fact
+// from the local Branch field's "branch the checkpoint was created on" (a
+// checkpoint made on a feature branch and since merged reports "main"). Putting
+// the former behind the latter's JSON key would mislead every consumer of
+// `explain --json`, so it stays empty.
+func TestAPICheckpointReader_ReadLeavesBranchEmpty(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, defaultAPIHandler)
+	summary, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.NoError(t, err)
+	assert.Empty(t, summary.Branch, "must not report a containing branch as the creation branch")
+
+	meta, err := reader.ReadSessionMetadata(context.Background(), testAPICheckpointID, 0)
+	require.NoError(t, err)
+	assert.Empty(t, meta.Branch)
+}
+
+func TestAPICheckpointReader_ReadSessionMetadataAndPrompts(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, defaultAPIHandler)
+
+	meta, prompts, err := reader.ReadSessionMetadataAndPrompts(context.Background(), testAPICheckpointID, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "session-one", meta.SessionID)
+	assert.Equal(t, "Claude Code", string(meta.Agent))
+	assert.Equal(t, "claude-fable-5", meta.Model)
+	assert.Equal(t, 1, meta.CheckpointsCount, "per-session count comes from steps")
+	assert.Equal(t, 7, meta.GetTranscriptStart(), "transcript scoping offset must survive the mapping")
+	assert.Equal(t, "first session prompt", prompts)
+	require.NotNil(t, meta.TokenUsage)
+	assert.Equal(t, 100, meta.TokenUsage.InputTokens)
+	assert.Equal(t, "2026-07-14T17:00:00Z", meta.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"))
+
+	// A session with no recorded offset reads unscoped (offset 0), exactly like
+	// a local checkpoint written before the field existed — not an invented one.
+	meta, prompts, err = reader.ReadSessionMetadataAndPrompts(context.Background(), testAPICheckpointID, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "session-two", meta.SessionID)
+	assert.Equal(t, 0, meta.GetTranscriptStart())
+	assert.Equal(t, "second session prompt", prompts)
+	assert.Nil(t, meta.TokenUsage)
+}
+
+func TestAPICheckpointReader_SessionIndexOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, defaultAPIHandler)
+	_, err := reader.ReadSessionMetadata(context.Background(), testAPICheckpointID, 5)
+	require.ErrorContains(t, err, "session index 5 out of range")
+	_, err = reader.ReadSessionMetadata(context.Background(), testAPICheckpointID, -1)
+	require.ErrorContains(t, err, "out of range")
+}
+
+// The transcript must come from the raw endpoint, byte-for-byte. explain
+// documents --transcript as the same bytes as --raw-transcript; sourcing it from
+// the parsed message-tree endpoint would quietly break that promise.
+func TestAPICheckpointReader_ReadSessionContentUsesRawEndpoint(t *testing.T) {
+	t.Parallel()
+
+	reader, paths := newTestAPIReader(t, defaultAPIHandler)
+	content, err := reader.ReadSessionContent(context.Background(), testAPICheckpointID, 1)
+	require.NoError(t, err)
+
+	// Compared as bytes, not JSON: byte-exactness is the contract under test.
+	assert.JSONEq(t, `{"type":"user","session":"1"}`+"\n", string(content.Transcript))
+	assert.Equal(t, "second session prompt", content.Prompts)
+	assert.Equal(t, "session-two", content.Metadata.SessionID)
+
+	joined := strings.Join(*paths, " ")
+	assert.Contains(t, joined, "/transcript/raw?session=1", "must request the raw endpoint for the asked-for session")
+	assert.NotContains(t, joined, "/transcript?", "must not read transcript bytes from the parsed endpoint")
+}
+
+// One envelope fetch backs every read tier: explain reads the summary and then
+// each session, so a per-call fetch would turn one view into an N+1.
+func TestAPICheckpointReader_CachesEnvelope(t *testing.T) {
+	t.Parallel()
+
+	reader, paths := newTestAPIReader(t, defaultAPIHandler)
+	ctx := context.Background()
+	_, err := reader.Read(ctx, testAPICheckpointID)
+	require.NoError(t, err)
+	_, err = reader.ReadSessionMetadata(ctx, testAPICheckpointID, 0)
+	require.NoError(t, err)
+	_, err = reader.ReadSessionPrompts(ctx, testAPICheckpointID, 1)
+	require.NoError(t, err)
+	_, err = reader.GetCheckpointAuthor(ctx, testAPICheckpointID)
+	require.NoError(t, err)
+
+	detailFetches := 0
+	for _, p := range *paths {
+		if !strings.Contains(p, "/transcript") {
+			detailFetches++
+		}
+	}
+	assert.Equal(t, 1, detailFetches, "envelope should be fetched once across all read tiers")
+}
+
+func TestAPICheckpointReader_AuthorAndCommit(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, defaultAPIHandler)
+	ctx := context.Background()
+
+	author, err := reader.GetCheckpointAuthor(ctx, testAPICheckpointID)
+	require.NoError(t, err)
+	assert.Equal(t, "Peyton Montei", author.Name)
+	assert.Empty(t, author.Email, "the cell never exposes the author's email; don't invent one")
+
+	commits, err := reader.checkpointCommit(ctx, testAPICheckpointID)
+	require.NoError(t, err)
+	require.Len(t, commits, 1)
+	assert.Equal(t, "13e379e", commits[0].ShortSHA)
+	assert.Equal(t, "docs(readme): document headless auth", commits[0].Message)
+	assert.Equal(t, "Peyton Montei", commits[0].Author)
+	assert.Equal(t, 2026, commits[0].Date.Year())
+}
+
+// A 404 means "not readable from here", and by far the most common reason is a
+// checkpoint that was never pushed. The message must say so rather than blaming
+// a storage backend, which sends the reader looking in the wrong place.
+func TestAPICheckpointReader_NotFoundExplainsUnpushed(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"checkpoint not found"}`)
+	})
+	_, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "may not have been pushed")
+	assert.Contains(t, err.Error(), testAPIOwnerRep)
+	assert.NotContains(t, strings.ToLower(err.Error()), "branch-based")
+}
+
+func TestAPICheckpointReader_ForbiddenNamesAccess(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	_, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.ErrorContains(t, err, "cannot read checkpoints in acme/widgets")
+}
+
+func TestAPICheckpointReader_EmptyEnvelopeIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"checkpoint": null}`)
+	})
+	_, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.ErrorContains(t, err, "not available")
+}
+
+func TestAPICheckpointReader_NoSessionsIsAnError(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"checkpoint": {"checkpointId":"01KXGTTNGCEACC83QZEJ5YAF0D","sessions":[]}}`)
+	})
+	_, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.ErrorContains(t, err, "no sessions to explain")
+}
+
+// A transcript larger than the read cap must fail loudly. Truncating it would
+// hand the renderer a silently-incomplete transcript, which reads as a real one.
+func TestAPICheckpointReader_OversizeTranscriptFailsLoudly(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/transcript/raw") {
+			chunk := strings.Repeat("x", 1<<20)
+			for range (maxAPITranscriptBytes >> 20) + 1 {
+				if _, err := w.Write([]byte(chunk)); err != nil {
+					return
+				}
+			}
+			return
+		}
+		fmt.Fprint(w, checkpointEnvelopeJSON)
+	})
+	_, err := reader.ReadSessionContent(context.Background(), testAPICheckpointID, 0)
+	require.ErrorContains(t, err, "exceeds the")
+}
+
+func TestAPICheckpointReader_MissingTranscriptBlob(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/transcript/raw") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fmt.Fprint(w, checkpointEnvelopeJSON)
+	})
+	_, err := reader.ReadSessionContent(context.Background(), testAPICheckpointID, 0)
+	require.ErrorContains(t, err, "has no stored transcript")
+}
+
+// List would mean enumerating another repo's checkpoints, which is `entire
+// search`'s job. Cross-repo explain requires a full ID so nothing needs it.
+func TestAPICheckpointReader_ListUnsupported(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, defaultAPIHandler)
+	_, err := reader.List(context.Background())
+	require.ErrorContains(t, err, "not supported")
+}
+
+// The reader must not be a Writer: a foreign repo's checkpoint is read-only
+// from here, and keeping Write off the type makes that structural rather than a
+// rule the flag layer has to remember.
+func TestAPICheckpointReader_IsNotAWriter(t *testing.T) {
+	t.Parallel()
+
+	var anyReader any = newAPICheckpointReader(nil, testAPIRepoID, testAPIOwnerRep)
+	_, isWriter := anyReader.(checkpoint.Writer)
+	assert.False(t, isWriter, "apiCheckpointReader must not implement checkpoint.Writer")
+	_, isStore := anyReader.(checkpoint.PersistentStore)
+	assert.False(t, isStore, "apiCheckpointReader must not satisfy PersistentStore")
+}
+
+func TestParseAPITime(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 2026, parseAPITime("2026-07-14T17:30:22.661Z").Year())
+	assert.Equal(t, 2026, parseAPITime("", "not-a-time", "2026-07-14T17:30:22Z").Year(),
+		"falls through to the first parseable candidate")
+	assert.True(t, parseAPITime("", "nonsense").IsZero(),
+		"an unparseable timestamp must stay zero rather than becoming a wrong date")
+}

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -2099,10 +2099,16 @@ func formatCheckpointOutput(ctx context.Context, summary *checkpoint.CheckpointS
 		}
 
 		hint := fmt.Sprintf("Not generated yet. Run `entire checkpoint explain --generate %s` to create an AI summary.", checkpointID)
-		if summary != nil && summary.Imported {
+		switch src, crossRepo := crossRepoReadSource(ctx); {
+		case summary != nil && summary.Imported:
 			// Imported history is read-only; --generate is refused for it, so
 			// don't point users at a command that will error out.
 			hint = "No summary. Imported history is read-only, so summaries cannot be generated."
+		case crossRepo:
+			// Same reasoning across repos: --generate is rejected with --repo,
+			// and a summary is stored by the repo that owns the checkpoint, so
+			// the default hint names a command that cannot succeed here.
+			hint = fmt.Sprintf("No summary stored for this checkpoint. Summaries are generated in the repo that owns it (%s).", src)
 		}
 		md := buildNoSummaryMarkdown(intent, files, hint)
 		sb.WriteString(renderExplainBody(w, md))

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -234,6 +234,8 @@ func newExplainCmd() *cobra.Command {
 	var searchAllFlag bool
 	var jsonFlag bool
 	var transcriptFlag bool
+	var repoFlag string
+	var insecureHTTPFlag bool
 	var summaryTimeoutSecondsFlag int
 	sessionIndex := -1
 	listLimit := 0 // 0 means "use default (branchCheckpointsLimit)"
@@ -253,6 +255,14 @@ Viewing specific items:
   entire checkpoint explain <id-or-sha>           Auto-detects checkpoint ID or commit SHA
   entire checkpoint explain --checkpoint <id>     Force interpretation as checkpoint ID
   entire checkpoint explain --commit <ref>        Force interpretation as commit ref
+
+Checkpoints in another repo:
+  entire checkpoint explain <id> --repo owner/name
+                 Explain a checkpoint owned by another repository — the
+                 drill-down for a cross-repo 'entire search' hit. Reads it from
+                 that repo's Entire API; nothing is written to this repo.
+                 Needs a full checkpoint ID (positional or --checkpoint) and a
+                 checkpoint that has been pushed.
 
 Filtering the list view:
   --session      Filter checkpoints by session ID (or prefix)
@@ -320,46 +330,52 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 				}
 			}
 
-			// --generate and --raw-transcript need a specific target — either the
-			// positional arg, --checkpoint/-c, or --commit (which forwards to
-			// the checkpoint path via the commit's Entire-Checkpoint trailer).
-			hasCheckpointTarget := checkpointFlag != "" || commitFlag != "" || positional != ""
-			if generateFlag && !hasCheckpointTarget {
-				return errors.New("--generate requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
+			if err := validateExplainFlagCombinations(cmd, explainFlagValues{
+				checkpoint:            checkpointFlag,
+				commit:                commitFlag,
+				repo:                  repoFlag,
+				generate:              generateFlag,
+				force:                 forceFlag,
+				rawTranscript:         rawTranscriptFlag,
+				transcript:            transcriptFlag,
+				json:                  jsonFlag,
+				sessionIndex:          sessionIndex,
+				listLimit:             listLimit,
+				summaryTimeoutSeconds: summaryTimeoutSecondsFlag,
+			}, positional); err != nil {
+				return err
 			}
-			if forceFlag && !generateFlag {
-				return errors.New("--force requires --generate flag")
-			}
-			if rawTranscriptFlag && !hasCheckpointTarget {
-				return errors.New("--raw-transcript requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
-			}
-			if transcriptFlag && !hasCheckpointTarget {
-				return errors.New("--transcript requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
-			}
-			if cmd.Flags().Changed("session-index") {
-				if !transcriptFlag && !rawTranscriptFlag {
-					return errors.New("--session-index only applies with --transcript or --raw-transcript")
+
+			// Cross-repo: read the foreign checkpoint from its repo's cell and
+			// render it with the same formatters as a local one. Routed before
+			// the local pipelines because none of their git-backed resolution
+			// (commit walks, prefix matching, blob prefetch) applies to a repo
+			// that isn't checked out here.
+			if repoFlag != "" {
+				target := positional
+				if target == "" {
+					target = checkpointFlag
 				}
-				if sessionIndex < 0 {
-					return errors.New("--session-index must be non-negative")
+				if !explainRepoTargetsCurrentRepo(cmd.Context(), repoFlag) {
+					// Past flag parsing every failure is a runtime one
+					// (network, auth, missing checkpoint), not a usage
+					// mistake — don't dump usage text on it.
+					cmd.SilenceUsage = true
+					return runCrossRepoExplain(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), crossRepoExplainOptions{
+						repoFlag:      repoFlag,
+						target:        target,
+						json:          jsonFlag,
+						transcript:    transcriptFlag,
+						rawTranscript: rawTranscriptFlag,
+						sessionIndex:  crossRepoExplainSessionIndex(cmd.Flags().Changed("session-index"), sessionIndex),
+						verbose:       !shortFlag,
+						full:          fullFlag,
+						noPager:       noPagerFlag,
+						insecureHTTP:  insecureHTTPFlag,
+					})
 				}
-			}
-			if cmd.Flags().Changed("limit") {
-				if !jsonFlag {
-					return errors.New("--limit only applies with --json")
-				}
-				if listLimit <= 0 {
-					return errors.New("--limit must be positive")
-				}
-			}
-			// --summary-timeout-seconds only makes sense with --generate.
-			if cmd.Flags().Changed("summary-timeout-seconds") {
-				if !generateFlag {
-					return errors.New("--summary-timeout-seconds only applies with --generate")
-				}
-				if summaryTimeoutSecondsFlag < 0 {
-					return errors.New("--summary-timeout-seconds must be non-negative")
-				}
+				// --repo naming the current repo is a no-op: the local path is
+				// faster and can also read checkpoints that aren't pushed yet.
 			}
 
 			// Export modes — emit machine-readable output and skip the prose pipeline.
@@ -401,10 +417,20 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 	cmd.Flags().BoolVar(&transcriptFlag, "transcript", false, "Stream stored checkpoint transcript bytes to stdout")
 	cmd.Flags().IntVar(&sessionIndex, "session-index", -1, "Session index within a multi-session checkpoint (0-based, defaults to latest)")
 	cmd.Flags().IntVar(&listLimit, "limit", 0, "Cap the list view at N checkpoints (default: 100). Only meaningful with --json.")
+	cmd.Flags().StringVar(&repoFlag, "repo", "", "Explain a checkpoint owned by another repo (owner/name or gh/owner/name), read from that repo's Entire API")
+	cmd.Flags().BoolVar(&insecureHTTPFlag, "insecure-http-auth", false, "Allow plain-HTTP auth for --repo (local dev only)")
 	cmd.Flags().IntVar(&summaryTimeoutSecondsFlag, "summary-timeout-seconds", 0, "Hard deadline in seconds for --generate summary generation; overrides summary_timeout_seconds setting. 0 = use setting; if setting is also unset or 0, no automatic deadline applies.")
 
 	// Verbosity / transcript output modes are mutually exclusive
 	cmd.MarkFlagsMutuallyExclusive("short", "full", "raw-transcript", "transcript", "json")
+	// --repo reads another repo over HTTP: --commit resolves against local
+	// history, --session filters the local list view, --search-all walks local
+	// commits, and --generate would write a summary the foreign repo never
+	// sees.
+	cmd.MarkFlagsMutuallyExclusive("repo", "commit")
+	cmd.MarkFlagsMutuallyExclusive("repo", "session")
+	cmd.MarkFlagsMutuallyExclusive("repo", "generate")
+	cmd.MarkFlagsMutuallyExclusive("repo", "search-all")
 	// --generate and --raw-transcript are incompatible (summary would be generated but not shown)
 	cmd.MarkFlagsMutuallyExclusive("generate", "raw-transcript")
 	// --generate is a write op; export modes are reader-only
@@ -412,6 +438,71 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 	cmd.MarkFlagsMutuallyExclusive("generate", "transcript")
 
 	return cmd
+}
+
+// explainFlagValues carries the explain flag values that participate in
+// combination rules, so validateExplainFlagCombinations can enforce them
+// outside the already-large newExplainCmd closure.
+type explainFlagValues struct {
+	checkpoint, commit, repo                         string
+	generate, force, rawTranscript, transcript, json bool
+	sessionIndex, listLimit, summaryTimeoutSeconds   int
+}
+
+// validateExplainFlagCombinations enforces the rules cobra's
+// MarkFlagsMutuallyExclusive cannot express: which flags need a specific target
+// and which values are in range.
+func validateExplainFlagCombinations(cmd *cobra.Command, v explainFlagValues, positional string) error {
+	// --generate and --raw-transcript need a specific target — either the
+	// positional arg, --checkpoint/-c, or --commit (which forwards to
+	// the checkpoint path via the commit's Entire-Checkpoint trailer).
+	hasCheckpointTarget := v.checkpoint != "" || v.commit != "" || positional != ""
+	if v.generate && !hasCheckpointTarget {
+		return errors.New("--generate requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
+	}
+	if v.force && !v.generate {
+		return errors.New("--force requires --generate flag")
+	}
+	// --repo needs a specific checkpoint: there is no local history to resolve a
+	// commit ref or an ID prefix against.
+	if v.repo != "" && positional == "" && v.checkpoint == "" {
+		return errors.New("--repo requires a checkpoint ID (positional or --checkpoint/-c)")
+	}
+	if cmd.Flags().Changed("insecure-http-auth") && v.repo == "" {
+		return errors.New("--insecure-http-auth only applies with --repo")
+	}
+	if v.rawTranscript && !hasCheckpointTarget {
+		return errors.New("--raw-transcript requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
+	}
+	if v.transcript && !hasCheckpointTarget {
+		return errors.New("--transcript requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
+	}
+	if cmd.Flags().Changed("session-index") {
+		if !v.transcript && !v.rawTranscript {
+			return errors.New("--session-index only applies with --transcript or --raw-transcript")
+		}
+		if v.sessionIndex < 0 {
+			return errors.New("--session-index must be non-negative")
+		}
+	}
+	if cmd.Flags().Changed("limit") {
+		if !v.json {
+			return errors.New("--limit only applies with --json")
+		}
+		if v.listLimit <= 0 {
+			return errors.New("--limit must be positive")
+		}
+	}
+	// --summary-timeout-seconds only makes sense with --generate.
+	if cmd.Flags().Changed("summary-timeout-seconds") {
+		if !v.generate {
+			return errors.New("--summary-timeout-seconds only applies with --generate")
+		}
+		if v.summaryTimeoutSeconds < 0 {
+			return errors.New("--summary-timeout-seconds must be non-negative")
+		}
+	}
+	return nil
 }
 
 // runExplain routes to the appropriate explain function based on flags and the
@@ -2140,7 +2231,14 @@ func formatCheckpointHeader(
 	writeRow("session", meta.SessionID)
 	writeRow("created", meta.CreatedAt.Format("2006-01-02 15:04:05"))
 	if author.Name != "" {
-		writeRow("author", fmt.Sprintf("%s <%s>", author.Name, author.Email))
+		// Some sources carry a display name without an email (the cell reports
+		// a commit author's name and forge username, never their address), so
+		// don't render an empty "<>".
+		authorVal := author.Name
+		if author.Email != "" {
+			authorVal = fmt.Sprintf("%s <%s>", author.Name, author.Email)
+		}
+		writeRow("author", authorVal)
 	}
 
 	tokenUsage := meta.TokenUsage

--- a/cmd/entire/cli/explain_repo.go
+++ b/cmd/entire/cli/explain_repo.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
+)
+
+// crossRepoReader is the read surface cross-repo explain needs: the two
+// checkpoint reader tiers the renderers consume, plus the two cross-repo-only
+// extras (author and anchoring commit) that normally come from local git.
+// Narrowed to an interface so tests can drive the render paths without a cell.
+type crossRepoReader interface {
+	checkpoint.CheckpointReader
+	checkpoint.SessionReader
+	GetCheckpointAuthor(ctx context.Context, checkpointID id.CheckpointID) (checkpoint.Author, error)
+	checkpointCommit(ctx context.Context, checkpointID id.CheckpointID) ([]associatedCommit, error)
+}
+
+// newCrossRepoReader builds the API-backed reader for owner/repo. Injectable so
+// tests can substitute a fake cell (see explain_repo_test.go).
+var newCrossRepoReader = func(ctx context.Context, insecureHTTP bool, owner, repo string) (crossRepoReader, error) {
+	ownerRepo := owner + "/" + repo
+	repoID, err := resolveRepoIDFromMirror(ctx, mirrorCloneProviderGitHub, owner, repo)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", ownerRepo, err)
+	}
+	client, err := NewAuthenticatedEntireAPICellClient(ctx, insecureHTTP, ownerRepo, "")
+	if err != nil {
+		// NewEntireAPICellClient already returns user-facing, context-rich
+		// errors (login hint, discovery guidance); surface them verbatim.
+		return nil, err
+	}
+	return newAPICheckpointReader(client, repoID, ownerRepo), nil
+}
+
+// crossRepoExplainOptions carries what `explain --repo` needs to render a
+// foreign repo's checkpoint.
+type crossRepoExplainOptions struct {
+	repoFlag string
+	// target is the checkpoint the user asked for, before ID validation.
+	target string
+
+	json          bool
+	transcript    bool
+	rawTranscript bool
+	// sessionIndex is -1 for "latest session".
+	sessionIndex int
+
+	verbose bool
+	full    bool
+	noPager bool
+
+	insecureHTTP bool
+}
+
+// parseExplainRepoFlag parses `--repo`. Accepted shapes are `owner/name` and
+// `gh/owner/name` (leading slash optional), matching the `repo` field of
+// `entire search` results, which is where a cross-repo checkpoint ID comes
+// from. Returns lowercased coordinates, as the control plane persists them.
+//
+// A bare repo ID is deliberately not accepted: the control plane and the search
+// index expose different identifiers for a repository, and guessing which space
+// an opaque ID belongs to would key the cell lookup off the wrong one.
+func parseExplainRepoFlag(value string) (owner, repo string, err error) {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return "", "", errors.New("--repo requires a value: owner/name or gh/owner/name")
+	}
+	if !strings.Contains(v, "/") {
+		return "", "", fmt.Errorf("invalid --repo %q: expected owner/name or gh/owner/name", value)
+	}
+	// Normalize to the gh/owner/name clone-ref shape so the mirror parser's
+	// GitHub charset validation applies to both accepted forms.
+	ref := strings.TrimPrefix(v, "/")
+	if !strings.HasPrefix(ref, "gh/") {
+		ref = "gh/" + ref
+	}
+	_, owner, repo, err = parseMirrorCloneRef(ref)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid --repo %q: expected owner/name or gh/owner/name: %w", value, err)
+	}
+	return owner, repo, nil
+}
+
+// explainRepoTargetsCurrentRepo reports whether the --repo value names the repo
+// checked out here. An unparseable value returns false so the cross-repo path
+// runs and reports the parse error, rather than silently falling through to the
+// local path.
+func explainRepoTargetsCurrentRepo(ctx context.Context, repoFlag string) bool {
+	owner, repo, err := parseExplainRepoFlag(repoFlag)
+	if err != nil {
+		return false
+	}
+	return explainRepoIsCurrent(ctx, owner, repo)
+}
+
+// explainRepoIsCurrent reports whether owner/repo names the same repository as
+// the cwd worktree's origin remote (which handles ssh, https, and entire://
+// mirror URL forms). --repo is GitHub-scoped, so a non-GitHub origin with a
+// coincidentally matching owner/name must not match. Best-effort: any lookup or
+// parse failure returns false and the cross-repo path runs.
+//
+// When it does match, explain falls through to the local path — which is both
+// faster and strictly more capable, since it can read checkpoints that have not
+// been pushed yet.
+func explainRepoIsCurrent(ctx context.Context, owner, repo string) bool {
+	curForge, curOwner, curRepo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	if err != nil || curForge != "gh" {
+		return false
+	}
+	return strings.EqualFold(curOwner, owner) && strings.EqualFold(curRepo, repo)
+}
+
+// runCrossRepoExplain explains a checkpoint owned by another repository by
+// reading it from that repo's cell over HTTP. Nothing is written to the local
+// repository: no ref, no objects, no session state — so a foreign checkpoint
+// never shows up in this repo's own checkpoint history or token profile.
+//
+// The output modes reuse the same renderers as the local path, so a foreign
+// checkpoint prints identically to a local one.
+func runCrossRepoExplain(ctx context.Context, w, errW io.Writer, opts crossRepoExplainOptions) error {
+	owner, repoName, err := parseExplainRepoFlag(opts.repoFlag)
+	if err != nil {
+		return err
+	}
+	ownerRepo := owner + "/" + repoName
+
+	// A prefix can't be resolved without listing the foreign repo's
+	// checkpoints, which is `entire search`'s job, so cross-repo needs the
+	// whole ID.
+	cid, err := id.NewCheckpointID(opts.target)
+	if err != nil {
+		return fmt.Errorf("--repo requires a full checkpoint ID (12-char hex or 26-char ULID); a prefix cannot be resolved in another repo: %w", err)
+	}
+
+	reader, err := newCrossRepoReader(ctx, opts.insecureHTTP, owner, repoName)
+	if err != nil {
+		return err
+	}
+
+	stop := startSpinner(errW, fmt.Sprintf("Reading checkpoint %s from %s", cid, ownerRepo))
+	// Read directly rather than through checkpoint.ReadCheckpoint: the helper
+	// prefixes "read persistent checkpoint:", which buries the reader's
+	// already-user-facing message (e.g. the not-pushed-yet guidance) behind
+	// storage vocabulary that means nothing for a repo read over HTTP.
+	summary, err := reader.Read(ctx, cid)
+	if err != nil {
+		stop(false)
+		return err //nolint:wrapcheck // the reader's errors already name the checkpoint and repo
+	}
+	if summary == nil {
+		stop(false)
+		return fmt.Errorf("checkpoint %s is not available for %s", cid, ownerRepo)
+	}
+
+	switch {
+	case opts.transcript || opts.rawTranscript:
+		content, contentErr := readCrossRepoSessionContent(ctx, reader, cid, summary, opts.sessionIndex)
+		stop(contentErr == nil)
+		if contentErr != nil {
+			return contentErr
+		}
+		if len(content.Transcript) == 0 {
+			return fmt.Errorf("checkpoint %s in %s has no transcript", cid, ownerRepo)
+		}
+		if _, err := w.Write(content.Transcript); err != nil {
+			return fmt.Errorf("failed to write transcript: %w", err)
+		}
+		return nil
+
+	case opts.json:
+		envelope, failed := buildCheckpointJSONEnvelope(ctx, reader, summary, cid)
+		stop(!envelope.Partial)
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(envelope); err != nil {
+			return fmt.Errorf("failed to encode checkpoint json: %w", err)
+		}
+		// Parity with the local --json path: fail hard so automation can't
+		// mistake incomplete metadata for a clean export. The envelope, with
+		// its per-session error fields, is already on stdout.
+		if envelope.Partial {
+			fmt.Fprintf(errW, "checkpoint %s: failed to read metadata for %d session(s) (indexes %v)\n", cid, len(failed), failed)
+			return NewSilentError(fmt.Errorf("checkpoint %s export incomplete: %d session(s) unreadable", cid, len(failed)))
+		}
+		return nil
+
+	default:
+		content, contentErr := readCrossRepoSessionContent(ctx, reader, cid, summary, opts.sessionIndex)
+		if contentErr != nil {
+			stop(false)
+			return contentErr
+		}
+		author, _ := reader.GetCheckpointAuthor(ctx, cid) //nolint:errcheck // author is optional
+		commits, _ := reader.checkpointCommit(ctx, cid)   //nolint:errcheck // best-effort, already-cached read
+		// Stop before the first write to w so stderr spinner frames never
+		// interleave with stdout content.
+		stop(false)
+		output := formatCheckpointOutput(ctx, summary, content, cid, commits, author, opts.verbose, opts.full, w)
+		outputExplainContent(w, output, opts.noPager)
+		return nil
+	}
+}
+
+// readCrossRepoSessionContent reads the requested session, or the latest when
+// no explicit index was given.
+func readCrossRepoSessionContent(ctx context.Context, reader crossRepoReader, cid id.CheckpointID, summary *checkpoint.CheckpointSummary, sessionIndex int) (*checkpoint.SessionContent, error) {
+	if sessionIndex < 0 {
+		content, err := checkpoint.ReadLatestSessionContent(ctx, reader, cid, summary)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read checkpoint content for %s: %w", cid, err)
+		}
+		return content, nil
+	}
+	content, err := reader.ReadSessionContent(ctx, cid, sessionIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read checkpoint content for %s: %w", cid, err)
+	}
+	return content, nil
+}
+
+// crossRepoExplainSessionIndex maps the --session-index flag to the reader's
+// convention (-1 = latest), so an unset flag reads the latest session.
+func crossRepoExplainSessionIndex(changed bool, value int) int {
+	if !changed {
+		return -1
+	}
+	return value
+}
+
+// assert the API reader satisfies the read surface the render paths need.
+var _ crossRepoReader = (*apiCheckpointReader)(nil)

--- a/cmd/entire/cli/explain_repo.go
+++ b/cmd/entire/cli/explain_repo.go
@@ -191,13 +191,18 @@ func runCrossRepoExplain(ctx context.Context, w, errW io.Writer, opts crossRepoE
 	switch {
 	case opts.transcript || opts.rawTranscript:
 		content, contentErr := readCrossRepoSessionContent(ctx, reader, cid, summary, opts.sessionIndex)
-		stop(contentErr == nil)
 		if contentErr != nil {
+			stop(false)
 			return contentErr
 		}
+		// Every failure has to land before stop(true): an empty transcript is a
+		// failure, and reporting it after a ✓ line tells the reader the read
+		// succeeded and then contradicts it.
 		if len(content.Transcript) == 0 {
+			stop(false)
 			return fmt.Errorf("checkpoint %s in %s has no transcript", cid, ownerRepo)
 		}
+		stop(true)
 		if _, err := w.Write(content.Transcript); err != nil {
 			return fmt.Errorf("failed to write transcript: %w", err)
 		}

--- a/cmd/entire/cli/explain_repo.go
+++ b/cmd/entire/cli/explain_repo.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
@@ -28,17 +29,40 @@ type crossRepoReader interface {
 // tests can substitute a fake cell (see explain_repo_test.go).
 var newCrossRepoReader = func(ctx context.Context, insecureHTTP bool, owner, repo string) (crossRepoReader, error) {
 	ownerRepo := owner + "/" + repo
-	repoID, err := resolveRepoIDFromMirror(ctx, mirrorCloneProviderGitHub, owner, repo)
+	// Resolve the repo_id and the cell together, from one placement: a mirror id
+	// is only resolvable by the cell holding that placement, so a
+	// separately-chosen cell (the caller's home cell, for a multi-region repo)
+	// would be asked about an id it has never seen and answer 404.
+	placement, err := resolveRepoCellPlacement(ctx, owner, repo)
 	if err != nil {
 		return nil, fmt.Errorf("resolve %s: %w", ownerRepo, err)
 	}
-	client, err := NewAuthenticatedEntireAPICellClient(ctx, insecureHTTP, ownerRepo, "")
+	client, err := auth.NewEntireAPICellClient(ctx, insecureHTTP, placement.Target)
 	if err != nil {
 		// NewEntireAPICellClient already returns user-facing, context-rich
 		// errors (login hint, discovery guidance); surface them verbatim.
-		return nil, err
+		return nil, err //nolint:wrapcheck // pass through contextual auth errors
 	}
-	return newAPICheckpointReader(client, repoID, ownerRepo), nil
+	return newAPICheckpointReader(client, placement.RepoID, ownerRepo), nil
+}
+
+// crossRepoReadKey marks a context as rendering a checkpoint read from another
+// repo. Context-scoped like gitrepo.WithStatusCache / checkpoint's remote-list
+// discovery, so the renderers can adjust their guidance without an extra
+// positional parameter through every formatCheckpointOutput call site.
+type crossRepoReadKey struct{}
+
+// withCrossRepoRead marks ctx as reading ownerRepo's checkpoint from that
+// repo's cell.
+func withCrossRepoRead(ctx context.Context, ownerRepo string) context.Context {
+	return context.WithValue(ctx, crossRepoReadKey{}, ownerRepo)
+}
+
+// crossRepoReadSource returns the repo a checkpoint is being read from when the
+// current render is a cross-repo one.
+func crossRepoReadSource(ctx context.Context) (string, bool) {
+	ownerRepo, ok := ctx.Value(crossRepoReadKey{}).(string)
+	return ownerRepo, ok && ownerRepo != ""
 }
 
 // crossRepoExplainOptions carries what `explain --repo` needs to render a
@@ -145,6 +169,9 @@ func runCrossRepoExplain(ctx context.Context, w, errW io.Writer, opts crossRepoE
 	if err != nil {
 		return err
 	}
+	// Marked for the renderers: a foreign checkpoint cannot be written to, so
+	// they must not offer actions that only work in the owning repo.
+	ctx = withCrossRepoRead(ctx, ownerRepo)
 
 	stop := startSpinner(errW, fmt.Sprintf("Reading checkpoint %s from %s", cid, ownerRepo))
 	// Read directly rather than through checkpoint.ReadCheckpoint: the helper

--- a/cmd/entire/cli/explain_repo_test.go
+++ b/cmd/entire/cli/explain_repo_test.go
@@ -268,6 +268,8 @@ func TestRunCrossRepoExplain_EmptyTranscriptIsAnError(t *testing.T) {
 		transcript:   true,
 	})
 	require.ErrorContains(t, err, "has no transcript")
+	// Copilot (PR #1942): a failure must not be preceded by a success marker.
+	assert.NotContains(t, errOut.String(), "✓", "an empty transcript must not report success first")
 }
 
 func TestRunCrossRepoExplain_RejectsPrefix(t *testing.T) {

--- a/cmd/entire/cli/explain_repo_test.go
+++ b/cmd/entire/cli/explain_repo_test.go
@@ -342,3 +342,53 @@ func TestExplainCmd_RepoFlagValidation(t *testing.T) {
 		})
 	}
 }
+
+// Bugbot (PR #1942): the default no-summary hint tells the reader to run
+// `explain --generate`, which is rejected with --repo and impossible against a
+// read-only reader. A foreign checkpoint must say why instead of naming a
+// command that cannot succeed.
+func TestRunCrossRepoExplain_NoDeadGenerateHint(t *testing.T) {
+	withStubCrossRepoReader(t, &stubCrossRepoReader{
+		transcript: []byte(`{"type":"user","message":{"role":"user","content":"do the foreign thing"}}` + "\n"),
+	})
+
+	var out, errOut bytes.Buffer
+	require.NoError(t, runCrossRepoExplain(context.Background(), &out, &errOut, crossRepoExplainOptions{
+		repoFlag:     "acme/widgets",
+		target:       testAPICheckpointID.String(),
+		sessionIndex: -1,
+		verbose:      true,
+		noPager:      true,
+	}))
+
+	got := out.String()
+	assert.NotContains(t, got, "--generate", "must not advertise a flag that --repo rejects")
+	assert.Contains(t, got, "repo that owns it (acme/widgets)")
+}
+
+// The local path keeps its hint: the fix must be scoped to cross-repo reads.
+func TestFormatCheckpointOutput_LocalKeepsGenerateHint(t *testing.T) {
+	t.Parallel()
+
+	summary := &checkpoint.CheckpointSummary{CheckpointID: testAPICheckpointID}
+	content := &checkpoint.SessionContent{
+		Metadata: checkpoint.Metadata{CheckpointID: testAPICheckpointID, SessionID: "s"},
+		Prompts:  "do the local thing",
+	}
+	got := formatCheckpointOutput(context.Background(), summary, content, testAPICheckpointID, nil, checkpoint.Author{}, true, false, &bytes.Buffer{})
+	assert.Contains(t, got, "--generate", "the local hint is still actionable")
+}
+
+func TestCrossRepoReadSource(t *testing.T) {
+	t.Parallel()
+
+	_, ok := crossRepoReadSource(context.Background())
+	assert.False(t, ok, "an unmarked context is a local read")
+
+	src, ok := crossRepoReadSource(withCrossRepoRead(context.Background(), "acme/widgets"))
+	assert.True(t, ok)
+	assert.Equal(t, "acme/widgets", src)
+
+	_, ok = crossRepoReadSource(withCrossRepoRead(context.Background(), ""))
+	assert.False(t, ok, "an empty repo name must not count as a cross-repo read")
+}

--- a/cmd/entire/cli/explain_repo_test.go
+++ b/cmd/entire/cli/explain_repo_test.go
@@ -1,0 +1,344 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+func TestParseExplainRepoFlag(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name, in, owner, repo, wantErr string
+	}{
+		{name: "owner/name", in: "acme/widgets", owner: "acme", repo: "widgets"},
+		{name: "gh prefixed", in: "gh/acme/widgets", owner: "acme", repo: "widgets"},
+		{name: "leading slash", in: "/gh/acme/widgets", owner: "acme", repo: "widgets"},
+		{name: "lowercased", in: "ACME/Widgets", owner: "acme", repo: "widgets"},
+		{name: "surrounding space", in: "  acme/widgets  ", owner: "acme", repo: "widgets"},
+		{name: "empty", in: "", wantErr: "--repo requires a value"},
+		{name: "bare word", in: "widgets", wantErr: "expected owner/name"},
+		// A repo ID is rejected rather than guessed at: the control plane and
+		// the search index expose different identifiers for a repository.
+		{name: "bare ulid", in: "01KVBJCWYA4YW6J5M9GP655HZ9", wantErr: "expected owner/name"},
+		{name: "clone url", in: "https://github.com/acme/widgets", wantErr: "invalid --repo"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			owner, repo, err := parseExplainRepoFlag(tc.in)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.owner, owner)
+			assert.Equal(t, tc.repo, repo)
+		})
+	}
+}
+
+// TestExplainRepoIsCurrent checks same-repo detection against the origin URL.
+// Not parallel: uses t.Chdir.
+func TestExplainRepoIsCurrent(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	setOrigin := func(t *testing.T, url string) {
+		t.Helper()
+		out, err := exec.CommandContext(t.Context(), "git", "-C", dir, "remote", "remove", "origin").CombinedOutput()
+		if err != nil && !strings.Contains(string(out), "No such remote") {
+			t.Logf("remove origin: %s", out)
+		}
+		out, err = exec.CommandContext(t.Context(), "git", "-C", dir, "remote", "add", "origin", url).CombinedOutput()
+		require.NoError(t, err, "add origin: %s", out)
+	}
+
+	ctx := context.Background()
+
+	setOrigin(t, "git@github.com:acme/widgets.git")
+	assert.True(t, explainRepoIsCurrent(ctx, "acme", "widgets"))
+	assert.True(t, explainRepoIsCurrent(ctx, "ACME", "Widgets"), "comparison is case-insensitive")
+	assert.False(t, explainRepoIsCurrent(ctx, "acme", "other"))
+
+	setOrigin(t, "https://github.com/acme/widgets")
+	assert.True(t, explainRepoIsCurrent(ctx, "acme", "widgets"))
+
+	// entire:// mirror URLs carry the forge in the path.
+	setOrigin(t, "entire://aws-us-east-2.entire.io/gh/acme/widgets")
+	assert.True(t, explainRepoIsCurrent(ctx, "acme", "widgets"))
+
+	// --repo is GitHub-scoped, so a non-GitHub origin with a coincidentally
+	// matching owner/name must not count as the current repo.
+	setOrigin(t, "git@gitlab.com:acme/widgets.git")
+	assert.False(t, explainRepoIsCurrent(ctx, "acme", "widgets"))
+}
+
+// --- render paths -----------------------------------------------------
+
+// stubCrossRepoReader serves a fixed checkpoint so the render paths can be
+// exercised without a cell.
+type stubCrossRepoReader struct {
+	transcript []byte
+	metaErr    error
+	sessions   int
+}
+
+func (s *stubCrossRepoReader) Read(context.Context, id.CheckpointID) (*checkpoint.CheckpointSummary, error) {
+	n := s.sessions
+	if n == 0 {
+		n = 1
+	}
+	return &checkpoint.CheckpointSummary{
+		CheckpointID:     testAPICheckpointID,
+		Strategy:         "manual-commit",
+		CheckpointsCount: 4,
+		FilesTouched:     []string{"README.md"},
+		Sessions:         make([]checkpoint.SessionFilePaths, n),
+		TokenUsage:       &types.TokenUsage{InputTokens: 10, OutputTokens: 20},
+	}, nil
+}
+
+func (s *stubCrossRepoReader) List(context.Context) ([]checkpoint.CheckpointInfo, error) {
+	return nil, errors.New("not supported")
+}
+
+func (s *stubCrossRepoReader) ReadSessionMetadata(_ context.Context, cid id.CheckpointID, _ int) (*checkpoint.Metadata, error) {
+	if s.metaErr != nil {
+		return nil, s.metaErr
+	}
+	return &checkpoint.Metadata{
+		CheckpointID: cid,
+		SessionID:    "stub-session",
+		Strategy:     "manual-commit",
+		CreatedAt:    time.Date(2026, 7, 14, 17, 30, 22, 0, time.UTC),
+		Agent:        types.AgentType("Claude Code"),
+	}, nil
+}
+
+func (s *stubCrossRepoReader) ReadSessionPrompts(context.Context, id.CheckpointID, int) (string, error) {
+	return "do the foreign thing", nil
+}
+
+func (s *stubCrossRepoReader) ReadSessionMetadataAndPrompts(ctx context.Context, cid id.CheckpointID, idx int) (*checkpoint.Metadata, string, error) {
+	meta, err := s.ReadSessionMetadata(ctx, cid, idx)
+	if err != nil {
+		return nil, "", err
+	}
+	return meta, "do the foreign thing", nil
+}
+
+func (s *stubCrossRepoReader) ReadSessionContent(ctx context.Context, cid id.CheckpointID, idx int) (*checkpoint.SessionContent, error) {
+	meta, prompts, err := s.ReadSessionMetadataAndPrompts(ctx, cid, idx)
+	if err != nil {
+		return nil, err
+	}
+	return &checkpoint.SessionContent{Metadata: *meta, Transcript: s.transcript, Prompts: prompts}, nil
+}
+
+func (s *stubCrossRepoReader) GetCheckpointAuthor(context.Context, id.CheckpointID) (checkpoint.Author, error) {
+	return checkpoint.Author{Name: "Foreign Author"}, nil
+}
+
+func (s *stubCrossRepoReader) checkpointCommit(context.Context, id.CheckpointID) ([]associatedCommit, error) {
+	return []associatedCommit{{SHA: "13e379e4b", ShortSHA: "13e379e", Message: "foreign commit"}}, nil
+}
+
+// withStubCrossRepoReader points the cross-repo path at stub and records the
+// coordinates it was asked to read. It swaps a package-level var, so its
+// callers must not use t.Parallel() — concurrent tests would clobber each
+// other's stub and read another test's checkpoint.
+func withStubCrossRepoReader(t *testing.T, stub crossRepoReader) *string {
+	t.Helper()
+	var asked string
+	prev := newCrossRepoReader
+	newCrossRepoReader = func(_ context.Context, _ bool, owner, repo string) (crossRepoReader, error) {
+		asked = owner + "/" + repo
+		return stub, nil
+	}
+	t.Cleanup(func() { newCrossRepoReader = prev })
+	return &asked
+}
+
+func TestRunCrossRepoExplain_Prose(t *testing.T) {
+	stub := &stubCrossRepoReader{transcript: []byte(`{"type":"user","message":{"role":"user","content":"do the foreign thing"}}` + "\n")}
+	asked := withStubCrossRepoReader(t, stub)
+
+	var out, errOut bytes.Buffer
+	require.NoError(t, runCrossRepoExplain(context.Background(), &out, &errOut, crossRepoExplainOptions{
+		repoFlag:     "acme/widgets",
+		target:       testAPICheckpointID.String(),
+		sessionIndex: -1,
+		verbose:      true,
+		noPager:      true,
+	}))
+
+	assert.Equal(t, "acme/widgets", *asked)
+	got := out.String()
+	assert.Contains(t, got, testAPICheckpointID.String())
+	assert.Contains(t, got, "Foreign Author", "the cell's author must render without a local commit")
+	assert.Contains(t, got, "13e379e", "the checkpoint's own commit must render, not '(none on this branch)'")
+	assert.NotContains(t, got, "none on this branch")
+	assert.Contains(t, got, "do the foreign thing")
+}
+
+func TestRunCrossRepoExplain_JSON(t *testing.T) {
+	asked := withStubCrossRepoReader(t, &stubCrossRepoReader{sessions: 2})
+
+	var out, errOut bytes.Buffer
+	require.NoError(t, runCrossRepoExplain(context.Background(), &out, &errOut, crossRepoExplainOptions{
+		repoFlag:     "acme/widgets",
+		target:       testAPICheckpointID.String(),
+		sessionIndex: -1,
+		json:         true,
+	}))
+	assert.Equal(t, "acme/widgets", *asked)
+
+	var envelope struct {
+		CheckpointID string `json:"checkpoint_id"`
+		SessionCount int    `json:"session_count"`
+		Partial      bool   `json:"partial"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &envelope), "stdout must be clean JSON")
+	assert.Equal(t, testAPICheckpointID.String(), envelope.CheckpointID)
+	assert.Equal(t, 2, envelope.SessionCount)
+	assert.False(t, envelope.Partial, "a complete read must not be flagged partial")
+}
+
+// A session whose metadata can't be read must produce the same partial-export
+// contract as the local path: envelope on stdout, diagnostic on stderr, non-nil
+// error so automation can't mistake it for a clean export.
+func TestRunCrossRepoExplain_JSONPartialFailsHard(t *testing.T) {
+	withStubCrossRepoReader(t, &stubCrossRepoReader{metaErr: errors.New("boom")})
+
+	var out, errOut bytes.Buffer
+	err := runCrossRepoExplain(context.Background(), &out, &errOut, crossRepoExplainOptions{
+		repoFlag:     "acme/widgets",
+		target:       testAPICheckpointID.String(),
+		sessionIndex: -1,
+		json:         true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "export incomplete")
+	assert.Contains(t, errOut.String(), "failed to read metadata")
+
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &envelope), "the envelope is still written to stdout")
+	assert.Equal(t, true, envelope["partial"])
+}
+
+func TestRunCrossRepoExplain_TranscriptWritesBytesVerbatim(t *testing.T) {
+	raw := []byte(`{"type":"user"}` + "\n" + `{"type":"assistant"}` + "\n")
+	withStubCrossRepoReader(t, &stubCrossRepoReader{transcript: raw})
+
+	var out, errOut bytes.Buffer
+	require.NoError(t, runCrossRepoExplain(context.Background(), &out, &errOut, crossRepoExplainOptions{
+		repoFlag:      "acme/widgets",
+		target:        testAPICheckpointID.String(),
+		sessionIndex:  -1,
+		rawTranscript: true,
+	}))
+	assert.Equal(t, string(raw), out.String(), "transcript bytes must pass through unmodified")
+}
+
+func TestRunCrossRepoExplain_EmptyTranscriptIsAnError(t *testing.T) {
+	withStubCrossRepoReader(t, &stubCrossRepoReader{})
+
+	var out, errOut bytes.Buffer
+	err := runCrossRepoExplain(context.Background(), &out, &errOut, crossRepoExplainOptions{
+		repoFlag:     "acme/widgets",
+		target:       testAPICheckpointID.String(),
+		sessionIndex: -1,
+		transcript:   true,
+	})
+	require.ErrorContains(t, err, "has no transcript")
+}
+
+func TestRunCrossRepoExplain_RejectsPrefix(t *testing.T) {
+	withStubCrossRepoReader(t, &stubCrossRepoReader{})
+
+	err := runCrossRepoExplain(context.Background(), io.Discard, io.Discard, crossRepoExplainOptions{
+		repoFlag:     "acme/widgets",
+		target:       "01KXGT",
+		sessionIndex: -1,
+	})
+	require.ErrorContains(t, err, "requires a full checkpoint ID")
+}
+
+func TestCrossRepoExplainSessionIndex(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, -1, crossRepoExplainSessionIndex(false, 0), "unset means latest session")
+	assert.Equal(t, 0, crossRepoExplainSessionIndex(true, 0))
+	assert.Equal(t, 3, crossRepoExplainSessionIndex(true, 3))
+}
+
+// --- flag layer -------------------------------------------------------
+
+func TestExplainCmd_RepoFlagValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "repo without a checkpoint",
+			args:    []string{"checkpoint", "explain", "--repo", "acme/widgets"},
+			wantErr: "--repo requires a checkpoint ID",
+		},
+		{
+			name:    "repo with commit",
+			args:    []string{"checkpoint", "explain", "--repo", "acme/widgets", "--commit", "HEAD"},
+			wantErr: "[repo commit]",
+		},
+		{
+			name:    "repo with generate",
+			args:    []string{"checkpoint", "explain", "abc", "--repo", "acme/widgets", "--generate"},
+			wantErr: "[repo generate]",
+		},
+		{
+			name:    "repo with session filter",
+			args:    []string{"checkpoint", "explain", "abc", "--repo", "acme/widgets", "--session", "s1"},
+			wantErr: "[repo session]",
+		},
+		{
+			name:    "repo with search-all",
+			args:    []string{"checkpoint", "explain", "abc", "--repo", "acme/widgets", "--search-all"},
+			wantErr: "[repo search-all]",
+		},
+		{
+			name:    "insecure without repo",
+			args:    []string{"checkpoint", "explain", "abc", "--insecure-http-auth"},
+			wantErr: "--insecure-http-auth only applies with --repo",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := NewRootCmd()
+			root.SetArgs(tc.args)
+			root.SetOut(io.Discard)
+			root.SetErr(io.Discard)
+			err := root.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1003
<!-- entire-trail-link-end -->

`entire checkpoint explain <id> --repo owner/name` explains a checkpoint owned by another repository, reading it from that repo's entire-api cell over HTTP.

This is an alternative to #— the `--repo` implementation on `surf-lightning` (trail 986), which fetches the checkpoint's git ref into the local repo. Same user-facing feature, different data path. Opening it as a separate PR so the two approaches can be compared directly.

## Why

`entire search` is cross-repo; `explain` was not. Search hands you an identifier the natural next command cannot resolve:

```
$ entire checkpoint explain b754d1dae6b8      # a checkpoint in entirehq/entiredb
no checkpoint or commit found matching "b754d1dae6b8"
```

The compact-search work (trail 982) makes this sharper: its per-hit shape is deliberately too thin to answer anything alone, and its skill template has to tell agents to *give up* on cross-repo hits ("summarize from the compact fields alone; `explain` cannot read them").

## Approach

The cell already serves everything explain renders — it's how the web app shows you any repo's checkpoint without cloning it:

| Endpoint | Serves |
|---|---|
| `GET /repos/{repo_id}/checkpoints/{id}` | commit, `filesTouched`, sessions + prompts, per-session and aggregate tokens |
| `GET /repos/{repo_id}/checkpoints/{id}/transcript/raw` | the stored transcript bytes |

`apiCheckpointReader` implements the two checkpoint reader tiers (`CheckpointReader` + `SessionReader`) plus the optional `AuthorReader`. That's the whole surface the render path consumes, so **every output mode reuses the existing renderers verbatim** — prose, `--short`, `--full`, `--json`, `--transcript`/`--raw-transcript`. No second output implementation.

It deliberately does **not** implement `Writer`. A foreign checkpoint is read-only from here, and leaving `Write` off the type makes that structural instead of a convention the flag layer has to remember (there's a test pinning it).

## What this buys over fetching git refs

**Nothing is written to the local repository.** Verified from a scratch repo against production, after explaining a real foreign checkpoint:

| | git-ref fetch | this PR |
|---|---|---|
| `refs/entire/*` left behind | 1 | **0** |
| `.git` size | 3.5 MB | **108 K** |
| `entire tokens profile` | 1 checkpoint, 72.4M tokens (another repo's) | **0 checkpoints** |
| cleanup path | none (`entire clean --all` doesn't touch checkpoint refs) | nothing to clean |

**No `--cluster` flag.** Cell routing is automatic via `resolveRepoCellTarget`. The ref-fetch path resolves mirror placements instead and dead-ends without it:

```
# git-ref fetch
$ entire checkpoint explain <id> --repo entireio/cli
repo is mirrored on 4 clusters; pass --cluster to choose one of: ...

# this PR
$ entire checkpoint explain <id> --repo entireio/cli
● Checkpoint 01KXGTTNGCEACC83QZEJ5YAF0D
  ...
```

**Wider coverage.** Same checkpoint ID, same repo, both binaries:

```
# git-ref fetch
checkpoint 01KZP3V62DKQBG9ZKS6T2ADR00 not found in the mirror for entireio/cli;
repos using the legacy branch-based checkpoint store ... are not supported cross-repo yet

# this PR
● Checkpoint 01KZP3V62DKQBG9ZKS6T2ADR00
  session  a78beaef-a2ab-4cad-9900-f4d3c3b51959
```

The cell resolves the storage layout itself (`checkpointlayout.RefAndFolder(id, data.RefBacked)`), so branch-backed and ref-backed repos both work — the ref-fetch path is ref-layout-only by construction.

## Fidelity decisions (both tested)

- **`Branch` is left empty**, not filled from the envelope. The cell reports branches *containing* the commit; the local field means the branch the checkpoint was *created* on. A checkpoint made on a feature branch and since merged reports `main`, so putting that behind the same JSON key would mislead every `--json` consumer.
- **Transcript bytes come from `.../transcript/raw`**, never the parsed message-tree endpoint. `explain` documents `--transcript` as the same bytes as `--raw-transcript`; sourcing them from a derived shape would quietly break that.
- **A missing `checkpointTranscriptStart` reads as 0** (unscoped) rather than an invented offset — identical to how a local checkpoint written before that field existed behaves.
- **Oversize transcripts error** instead of truncating into the renderer.

## Flag rules

`--repo` needs a full checkpoint ID (a prefix would require listing the foreign repo's checkpoints — that's `search`'s job) and is mutually exclusive with `--commit`, `--session`, `--search-all`, and `--generate`. Naming the current repo is a no-op that falls through to the local path, which is faster and can also read unpushed checkpoints.

A bare repo ID is not accepted, only `owner/name` / `gh/owner/name` — the control plane and the search index expose different identifiers for a repository, and guessing which space an opaque ID belongs to would key the lookup off the wrong one. `owner/name` is what search's `repo` field gives you.

## Error messages

A 404 leads with the cause that actually dominates:

```
checkpoint 01KV... is not available for entireio/cli yet: it may not have been
pushed, or Entire may not have finished ingesting it. Checkpoints you have not
pushed are only readable in the repo that created them
```

## Drive-bys

- Extracted `validateExplainFlagCombinations` out of `newExplainCmd` (it was over the `maintidx` limit with the new flag).
- Renamed `resolveCurrentRepoID` → `resolveRepoIDFromMirror`; it takes explicit coordinates and now serves a foreign repo too.
- Stopped rendering an empty `<>` when an author has a name but no email.

## Testing

`mise run fmt && mise run lint && mise run test:ci` all green (lint: 0 issues). 25 new tests: envelope mapping, the raw-vs-parsed endpoint assertion, envelope caching (one fetch across all read tiers), 404/403/empty/no-session paths, oversize transcript, `List` unsupported, not-a-`Writer`, flag validation, and all four render modes against a stub reader.

Manually verified end-to-end against production for prose, `--json`, `--full` (3,273 lines), and `--transcript` (3.1 MB), plus clean stdout JSON with the spinner on stderr.

## Known gap

The availability precondition is *pushed and ingested*, so a just-pushed checkpoint may briefly 404. The message above says so; if that lag turns out to be user-visible in practice, a retry hint would be the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated HTTP read path and flag surface on a heavily used command; risk is moderated by read-only semantics (no local git writes), strict flag mutual exclusion, and extensive tests.
> 
> **Overview**
> Adds **`entire checkpoint explain <id> --repo owner/name`** so cross-repo `search` hits can be drilled down without pulling foreign git objects into the local repo.
> 
> **`apiCheckpointReader`** loads checkpoint metadata and raw transcript bytes from the repo’s entire-api cell (`GET .../checkpoints/{id}` and `.../transcript/raw`), maps them into the existing checkpoint reader types, and **does not implement `Writer`**. Prose, `--json`, `--full`, and transcript modes reuse the same renderers as local explain.
> 
> **`runCrossRepoExplain`** resolves mirror `repo_id`, dials the owning cell via `NewAuthenticatedEntireAPICellClient`, and rejects incompatible flags (`--commit`, `--session`, `--search-all`, `--generate`). `--repo` on the current checkout is a no-op to the local path. Cross-repo requires a **full** checkpoint ID.
> 
> Notable fidelity choices: **`Branch` stays empty** (cell “containing branches” ≠ creation branch), transcripts always from **raw** endpoint, oversize transcripts **error** instead of truncating, and 404 messaging calls out unpushed/not-yet-ingested checkpoints.
> 
> Also extracts **`validateExplainFlagCombinations`**, renames **`resolveCurrentRepoID` → `resolveRepoIDFromMirror`** for foreign-repo use, fixes author lines when email is missing, and documents the feature in **CLAUDE.md**. Broad unit test coverage for the API reader and cross-repo explain paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346b7fb5b53078c1a8f46fdce807151a081e4dcd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->