### PR TITLE
fix(search): 1 MiB cell response cap truncated large-region results; surface per-region fan-out errors

### DIFF
--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -19,6 +19,16 @@ import (
 
 const apiTimeout = 30 * time.Second
 
+// maxResponseBytes bounds a single cell's response body. It is a DoS/runaway
+// guard, not a functional limit: a high-hit query against the largest cell
+// returns a few MB of result text (rows carry full transcript snippets), so the
+// cap sits ~30x above any legitimate page (which is itself bounded by the
+// per-request result limit). The previous 1 MiB cap silently truncated big
+// cells mid-JSON, failing the decode and dropping the whole region from a
+// cross-cell fan-out; readCappedBody now turns an over-cap body into an
+// explicit error instead of feeding truncated JSON to the decoder.
+const maxResponseBytes = 64 << 20 // 64 MiB
+
 // v4ServicePath is the per-repo v4 query-serve route exposed by the entire-api
 // cell gateway. It takes repo=<ULID>. The BFF (entire.io /api/v1/search)
 // forwards to this same path; the CLI dials the cell directly with a
@@ -662,9 +672,9 @@ func CellV4(ctx context.Context, client *api.Client, cfg Config, repoIDs []strin
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := readCappedBody(resp.Body, maxResponseBytes)
 	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
+		return nil, err
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		// The gateway has no semantic-search route (plain "404 page not
@@ -695,6 +705,23 @@ func addCommonSearchParams(q url.Values, cfg Config) {
 	if cfg.Page > 0 {
 		q.Set("page", strconv.Itoa(cfg.Page))
 	}
+}
+
+// readCappedBody reads up to maxBytes from r, returning an explicit error if
+// the body exceeds the cap rather than silently truncating it. A truncated
+// body would fail JSON decoding downstream and be misreported as a malformed
+// ("unexpected") response; making the overflow loud keeps the failure mode
+// diagnosable. Reading maxBytes+1 lets a body sitting exactly at the cap
+// succeed while anything larger is detected as over.
+func readCappedBody(r io.Reader, maxBytes int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("search service response exceeded the %d-byte read limit", maxBytes)
+	}
+	return body, nil
 }
 
 // parseSearchResponse decodes a search response body, preserving the

--- a/cmd/entire/cli/search/search_v4_test.go
+++ b/cmd/entire/cli/search/search_v4_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
@@ -120,6 +121,90 @@ func TestCellV4_ResponseDecodesLikeV3(t *testing.T) {
 	}
 	if resp.Counts == nil || resp.Counts.Commits != 1 {
 		t.Errorf("counts did not decode; got %+v", resp.Counts)
+	}
+}
+
+// TestCellV4_LargeResponseDecodesFully is the regression test for the 1 MiB
+// response cap: a busy cell returns a valid JSON body larger than the old
+// io.LimitReader(resp.Body, 1<<20) limit (rows carry full transcript text).
+// The old cap truncated the body mid-JSON, failed the decode, and dropped the
+// whole region from the cross-cell merge. The response must now decode intact.
+func TestCellV4_LargeResponseDecodesFully(t *testing.T) {
+	t.Parallel()
+
+	// A single checkpoint whose prompt alone exceeds the old 1 MiB cap.
+	bigPrompt := strings.Repeat("transcript ", (1<<20)/11+4096)
+	payload, err := json.Marshal(&Response{
+		Results: []Result{{
+			Type:       TypeCheckpoint,
+			Meta:       Meta{Score: 1.0, Tier: iptrTest(0)},
+			Checkpoint: &CheckpointResult{ID: "big", Prompt: bigPrompt},
+		}},
+		Total: 1,
+		Page:  1,
+	})
+	if err != nil {
+		t.Fatalf("building payload: %v", err)
+	}
+	if len(payload) <= 1<<20 {
+		t.Fatalf("test payload is %d bytes, must exceed the old 1 MiB cap to exercise the bug", len(payload))
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeTestJSON(w, string(payload))
+	}))
+	defer srv.Close()
+
+	resp, err := CellV4(context.Background(), api.NewClientWithBaseURL("tok", srv.URL), Config{Query: "transcript"}, nil)
+	if err != nil {
+		t.Fatalf("large response should decode, got error: %v", err)
+	}
+	if len(resp.Results) != 1 || resp.Results[0].Checkpoint == nil {
+		t.Fatalf("results did not decode: %+v", resp.Results)
+	}
+	if got := resp.Results[0].Checkpoint.Prompt; got != bigPrompt {
+		t.Errorf("prompt truncated: got %d bytes, want %d", len(got), len(bigPrompt))
+	}
+}
+
+func iptrTest(i int) *int { return &i }
+
+// TestReadCappedBody confirms the read guard: bodies at or under the cap are
+// returned intact, and an over-cap body is an explicit error rather than a
+// silently truncated slice fed to the JSON decoder.
+func TestReadCappedBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		size    int
+		cap     int64
+		wantErr bool
+	}{
+		{"under cap", 50, 100, false},
+		{"exactly at cap", 100, 100, false},
+		{"one over cap", 101, 100, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body, err := readCappedBody(strings.NewReader(strings.Repeat("a", tt.size)), tt.cap)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("size %d cap %d: want an overflow error, got nil", tt.size, tt.cap)
+				}
+				if !strings.Contains(err.Error(), "exceeded") {
+					t.Errorf("error = %q, want it to mention the exceeded read limit", err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("size %d cap %d: unexpected error: %v", tt.size, tt.cap, err)
+			}
+			if len(body) != tt.size {
+				t.Errorf("read %d bytes, want %d", len(body), tt.size)
+			}
+		})
 	}
 }
 

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -539,9 +539,16 @@ func mergeSemanticV4Responses(ctx context.Context, limit, page int, results []ce
 	pages, failed, lastErr := classifySemanticCells(ctx, results)
 	if len(pages) == 0 {
 		if lastErr != nil {
-			// Summarize before surfacing: a decode failure embeds the raw
-			// (now up to 64 MiB) response body in lastErr, and this error goes
-			// straight to the user's terminal via main.go.
+			// Preserve the error chain for a cancellation so main.go's
+			// errors.Is(err, context.Canceled) signal-exit still matches on
+			// Ctrl-C during an all-region fan-out (every cell fails with
+			// cancellation and lands here); a cancellation error carries no
+			// body to dump. Otherwise summarize: a decode failure embeds the
+			// raw (now up to 64 MiB) response body in lastErr, and this error
+			// goes straight to the user's terminal via main.go.
+			if errors.Is(lastErr, context.Canceled) {
+				return nil, fmt.Errorf("semantic search: %w", lastErr)
+			}
 			return nil, fmt.Errorf("semantic search: %s", summarizeCellError(lastErr))
 		}
 		return &search.Response{Results: []search.Result{}, Page: 1}, nil

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
@@ -392,16 +393,28 @@ type failedCell struct {
 const maxCellErrorReason = 200
 
 // summarizeCellError renders a cell's error as a short, single-line reason fit
-// for the user-facing warning. It collapses embedded whitespace/newlines and
-// truncates on a rune boundary so a multibyte character is never cut in half.
+// for the user-facing warning. A cell error can embed the raw, untrusted
+// response body verbatim (parseSearchResponse dumps string(body) on a decode
+// or non-200 failure), so this both bounds and sanitizes it: non-printable
+// runes — ANSI escape / C0 / C1 / DEL bytes that could hijack the terminal
+// when the reason is written to stderr — are replaced with spaces, then
+// whitespace is collapsed and the result truncated on a rune boundary (never
+// cutting a multibyte character in half). The body is treated as data, never
+// as terminal control.
 func summarizeCellError(err error) string {
 	if err == nil {
 		return "unknown error"
 	}
-	reason := strings.Join(strings.Fields(err.Error()), " ")
+	cleaned := strings.Map(func(r rune) rune {
+		if !unicode.IsPrint(r) {
+			return ' '
+		}
+		return r
+	}, err.Error())
+	reason := strings.Join(strings.Fields(cleaned), " ")
 	if reason == "" {
-		// An empty/whitespace-only error message would leave a dangling
-		// "label: " in the warning; fall back like the nil-error branch.
+		// An empty/whitespace-only (or all-control) error message would leave a
+		// dangling "label: " in the warning; fall back like the nil-error branch.
 		return "unknown error"
 	}
 	if runes := []rune(reason); len(runes) > maxCellErrorReason {

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -340,7 +340,7 @@ type semanticCellPage struct {
 // it can't serve the search yet: its gateway has no query-serve route, or the
 // cluster catalog doesn't expose the placement's jurisdiction at all (a cell
 // mid-onboarding). Neither is worth warning the user about on every search.
-func classifySemanticCells(ctx context.Context, results []cellCallResult[*search.Response]) (pages []semanticCellPage, failed []string, lastErr error) {
+func classifySemanticCells(ctx context.Context, results []cellCallResult[*search.Response]) (pages []semanticCellPage, failed []failedCell, lastErr error) {
 	var skipped []string
 	for _, r := range results {
 		switch {
@@ -348,7 +348,7 @@ func classifySemanticCells(ctx context.Context, results []cellCallResult[*search
 			skipped = append(skipped, r.group.label())
 		case r.err != nil:
 			lastErr = r.err
-			failed = append(failed, fmt.Sprintf("%s: %s", r.group.label(), summarizeCellError(r.err)))
+			failed = append(failed, failedCell{label: r.group.label(), reason: summarizeCellError(r.err)})
 		case r.value != nil:
 			p := semanticCellPage{body: r.value}
 			for _, res := range r.value.Results {
@@ -374,6 +374,15 @@ func classifySemanticCells(ctx context.Context, results []cellCallResult[*search
 // errNoRegionAvailable is returned when every queried cell lacks query-serve.
 var errNoRegionAvailable = errors.New("semantic search is not yet available in the region(s) hosting this search")
 
+// failedCell records one hard cell failure: its region label (operational
+// metadata, safe to log) and a summarized, user-safe reason. The two are kept
+// apart so the reason — which can contain response-body-derived content — stays
+// out of the Debug log and only ever reaches the user-facing warning.
+type failedCell struct {
+	label  string
+	reason string
+}
+
 // maxCellErrorReason bounds the per-region reason shown in the partial-failure
 // warning. A cell error can embed the raw response body — parseSearchResponse
 // dumps string(body) on a decode failure or non-200 — so the reason is
@@ -390,6 +399,11 @@ func summarizeCellError(err error) string {
 		return "unknown error"
 	}
 	reason := strings.Join(strings.Fields(err.Error()), " ")
+	if reason == "" {
+		// An empty/whitespace-only error message would leave a dangling
+		// "label: " in the warning; fall back like the nil-error branch.
+		return "unknown error"
+	}
 	if runes := []rune(reason); len(runes) > maxCellErrorReason {
 		reason = string(runes[:maxCellErrorReason]) + "…"
 	}
@@ -525,7 +539,10 @@ func mergeSemanticV4Responses(ctx context.Context, limit, page int, results []ce
 	pages, failed, lastErr := classifySemanticCells(ctx, results)
 	if len(pages) == 0 {
 		if lastErr != nil {
-			return nil, fmt.Errorf("semantic search: %w", lastErr)
+			// Summarize before surfacing: a decode failure embeds the raw
+			// (now up to 64 MiB) response body in lastErr, and this error goes
+			// straight to the user's terminal via main.go.
+			return nil, fmt.Errorf("semantic search: %s", summarizeCellError(lastErr))
 		}
 		return &search.Response{Results: []search.Result{}, Page: 1}, nil
 	}
@@ -533,13 +550,20 @@ func mergeSemanticV4Responses(ctx context.Context, limit, page int, results []ce
 	if len(failed) > 0 {
 		// Debug, not Warn: the warning below already reaches the user via
 		// Response.Warnings, and slog's default handler would print a Warn
-		// straight to stderr on commands that never ran logging.Init.
+		// straight to stderr on commands that never ran logging.Init. Log only
+		// the region labels — the reasons can carry response-body-derived
+		// content, which must not land in .entire/logs/ (privacy).
+		labels := make([]string, len(failed))
+		details := make([]string, len(failed))
+		for i, f := range failed {
+			labels[i] = f.label
+			details[i] = fmt.Sprintf("%s: %s", f.label, f.reason)
+		}
 		logging.Debug(ctx, "semantic search: partial failure; results may be incomplete",
-			"succeeded", len(pages), "total", len(results), "failed_cells", failed)
-		// Name each failed region and a concise reason (failed entries are
-		// "label: reason"), preserving the "N of M regions" prefix the
-		// user-facing contract and tests key on.
-		warnings = append(warnings, fmt.Sprintf("search failed in %d of %d regions; results may be incomplete (%s)", len(failed), len(pages)+len(failed), strings.Join(failed, "; ")))
+			"succeeded", len(pages), "total", len(results), "failed_cells", labels)
+		// Name each failed region and a concise reason, preserving the "N of M
+		// regions" prefix the user-facing contract and tests key on.
+		warnings = append(warnings, fmt.Sprintf("search failed in %d of %d regions; results may be incomplete (%s)", len(failed), len(pages)+len(failed), strings.Join(details, "; ")))
 	}
 
 	merged, globalUpper := rankSemanticResults(pages)

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -348,7 +348,7 @@ func classifySemanticCells(ctx context.Context, results []cellCallResult[*search
 			skipped = append(skipped, r.group.label())
 		case r.err != nil:
 			lastErr = r.err
-			failed = append(failed, r.group.label())
+			failed = append(failed, fmt.Sprintf("%s: %s", r.group.label(), summarizeCellError(r.err)))
 		case r.value != nil:
 			p := semanticCellPage{body: r.value}
 			for _, res := range r.value.Results {
@@ -373,6 +373,28 @@ func classifySemanticCells(ctx context.Context, results []cellCallResult[*search
 
 // errNoRegionAvailable is returned when every queried cell lacks query-serve.
 var errNoRegionAvailable = errors.New("semantic search is not yet available in the region(s) hosting this search")
+
+// maxCellErrorReason bounds the per-region reason shown in the partial-failure
+// warning. A cell error can embed the raw response body — parseSearchResponse
+// dumps string(body) on a decode failure or non-200 — so the reason is
+// collapsed to a single line and truncated: enough to name the failure mode
+// (e.g. "unexpected response from search service") without spilling a multi-MB
+// body into the user's terminal.
+const maxCellErrorReason = 200
+
+// summarizeCellError renders a cell's error as a short, single-line reason fit
+// for the user-facing warning. It collapses embedded whitespace/newlines and
+// truncates on a rune boundary so a multibyte character is never cut in half.
+func summarizeCellError(err error) string {
+	if err == nil {
+		return "unknown error"
+	}
+	reason := strings.Join(strings.Fields(err.Error()), " ")
+	if runes := []rune(reason); len(runes) > maxCellErrorReason {
+		reason = string(runes[:maxCellErrorReason]) + "…"
+	}
+	return reason
+}
 
 // rankSemanticResults buckets every page's rows and applies the ordering
 // query-serve uses within a cell (and the BFF uses across cells): repos first,
@@ -514,7 +536,10 @@ func mergeSemanticV4Responses(ctx context.Context, limit, page int, results []ce
 		// straight to stderr on commands that never ran logging.Init.
 		logging.Debug(ctx, "semantic search: partial failure; results may be incomplete",
 			"succeeded", len(pages), "total", len(results), "failed_cells", failed)
-		warnings = append(warnings, fmt.Sprintf("search failed in %d of %d regions; results may be incomplete", len(failed), len(pages)+len(failed)))
+		// Name each failed region and a concise reason (failed entries are
+		// "label: reason"), preserving the "N of M regions" prefix the
+		// user-facing contract and tests key on.
+		warnings = append(warnings, fmt.Sprintf("search failed in %d of %d regions; results may be incomplete (%s)", len(failed), len(pages)+len(failed), strings.Join(failed, "; ")))
 	}
 
 	merged, globalUpper := rankSemanticResults(pages)

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -538,6 +538,27 @@ func TestMergeSemanticV4Responses_AllCellsFailTruncatesBody(t *testing.T) {
 	}
 }
 
+// TestMergeSemanticV4Responses_AllCellsCancelledPreservesChain guards the
+// signal-exit path: on Ctrl-C during an all-region fan-out every cell fails
+// with context.Canceled and lands on the all-failed return. That error must
+// keep context.Canceled in its chain so main.go's
+// errors.Is(err, context.Canceled) quiet-exit still matches — summarizing to a
+// plain string (needed for the body-dump case) must not sever it.
+func TestMergeSemanticV4Responses_AllCellsCancelledPreservesChain(t *testing.T) {
+	t.Parallel()
+
+	_, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
+		v4CellErr(fmt.Errorf("calling search service: %w", context.Canceled)),
+		v4CellErr(fmt.Errorf("calling search service: %w", context.Canceled)),
+	})
+	if err == nil {
+		t.Fatal("expected an error when every cell was cancelled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %q, want context.Canceled preserved in the chain", err.Error())
+	}
+}
+
 func TestMergeSemanticV4Responses_NoCells(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/search"
@@ -440,6 +441,30 @@ func TestMergeSemanticV4Responses_PartialFailureNamesRegionAndReason(t *testing.
 	// The huge embedded body must be truncated out — the warning stays readable.
 	if len(w) > 500 {
 		t.Errorf("warning is %d bytes; the raw body must be truncated, not dumped in full", len(w))
+	}
+}
+
+// TestSummarizeCellError_StripsControlChars verifies the reason surfaced to the
+// terminal is sanitized: a cell error can embed the raw untrusted response body
+// (more exposed with --insecure), so ANSI escape / control bytes must be
+// stripped before the reason reaches stderr, never left to hijack the terminal.
+func TestSummarizeCellError_StripsControlChars(t *testing.T) {
+	t.Parallel()
+
+	// An injected ANSI escape + CR/BEL wrapped around real text.
+	err := errors.New("unexpected response: \x1b[31m\x1b]0;pwned\x07malicious\x1b[0m\rtext")
+	got := summarizeCellError(err)
+	for _, r := range got {
+		if !unicode.IsPrint(r) && r != ' ' {
+			t.Fatalf("summary %q still contains a non-printable rune %U", got, r)
+		}
+	}
+	if strings.ContainsRune(got, '\x1b') || strings.ContainsRune(got, '\x07') || strings.ContainsRune(got, '\r') {
+		t.Errorf("summary %q retained a control byte", got)
+	}
+	// The printable text survives.
+	if !strings.Contains(got, "malicious") || !strings.Contains(got, "text") {
+		t.Errorf("summary %q dropped printable content", got)
 	}
 }
 

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -516,6 +516,28 @@ func TestMergeSemanticV4Responses_AllCellsFail(t *testing.T) {
 	}
 }
 
+// TestMergeSemanticV4Responses_AllCellsFailTruncatesBody guards the all-failed
+// path: the returned error goes straight to the user's terminal, so a decode
+// failure that embeds the raw (multi-MB) response body must be summarized, not
+// dumped in full — the same guarantee the partial-failure warning gives.
+func TestMergeSemanticV4Responses_AllCellsFailTruncatesBody(t *testing.T) {
+	t.Parallel()
+
+	hugeBody := strings.Repeat("x", 2<<20)
+	_, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
+		v4CellErrLabeled("aws-us-east-2", fmt.Errorf("unexpected response from search service: %s", hugeBody)),
+	})
+	if err == nil {
+		t.Fatal("expected an error when the only cell failed")
+	}
+	if !strings.Contains(err.Error(), "unexpected response from search service") {
+		t.Errorf("error = %q, want the concise failure reason", err.Error())
+	}
+	if len(err.Error()) > 500 {
+		t.Errorf("error is %d bytes; the raw body must be truncated, not dumped in full", len(err.Error()))
+	}
+}
+
 func TestMergeSemanticV4Responses_NoCells(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -66,6 +66,10 @@ func v4CellErr(err error) cellCallResult[*search.Response] {
 	return cellCallResult[*search.Response]{err: err}
 }
 
+func v4CellErrLabeled(cell string, err error) cellCallResult[*search.Response] {
+	return cellCallResult[*search.Response]{group: cellGroup{cell: cell}, err: err}
+}
+
 func v4ResultIDs(t *testing.T, results []search.Result) []string {
 	t.Helper()
 	ids := make([]string, len(results))
@@ -395,6 +399,47 @@ func TestMergeSemanticV4Responses_PartialFailureMergesSurvivorsWithWarning(t *te
 	}
 	if len(resp.Warnings) != 1 || !strings.Contains(resp.Warnings[0], "1 of 2 regions") {
 		t.Errorf("warnings = %v, want a visible partial-failure warning naming 1 of 2 regions", resp.Warnings)
+	}
+}
+
+// TestMergeSemanticV4Responses_PartialFailureNamesRegionAndReason verifies the
+// warning surfaces which region failed and why (Bug 3): the count-only warning
+// hid the region + reason in a discarded Debug log, making the underlying 1 MiB
+// truncation undiagnosable. A cell error can embed the raw response body, so
+// the surfaced reason must be a short single line, not a multi-MB blob.
+func TestMergeSemanticV4Responses_PartialFailureNamesRegionAndReason(t *testing.T) {
+	t.Parallel()
+
+	// Simulate parseSearchResponse's decode-failure error, which dumps the raw
+	// (here multi-MB) body into the error string.
+	hugeBody := strings.Repeat("x", 2<<20)
+	cellErr := fmt.Errorf("unexpected response from search service: %s", hugeBody)
+
+	resp, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
+		v4CellErrLabeled("aws-us-east-2", cellErr),
+		v4CellOK(&search.Response{Results: []search.Result{
+			v4Ckpt("ok", 1, search.Meta{Score: 0.5}),
+		}, Total: 1}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Warnings) != 1 {
+		t.Fatalf("warnings = %v, want exactly one", resp.Warnings)
+	}
+	w := resp.Warnings[0]
+	if !strings.Contains(w, "1 of 2 regions") {
+		t.Errorf("warning = %q, want the preserved '1 of 2 regions' prefix", w)
+	}
+	if !strings.Contains(w, "aws-us-east-2") {
+		t.Errorf("warning = %q, want it to name the failed region", w)
+	}
+	if !strings.Contains(w, "unexpected response from search service") {
+		t.Errorf("warning = %q, want a concise reason for the failure", w)
+	}
+	// The huge embedded body must be truncated out — the warning stays readable.
+	if len(w) > 500 {
+		t.Errorf("warning is %d bytes; the raw body must be truncated, not dumped in full", len(w))
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1005
<!-- entire-trail-link-end -->

## Problem

`entire search --all-repos` (or `repo:*`) fans out to every regional query-serve cell in parallel and merges the results. On high-hit queries (e.g. `transcript`, `backfill`, `indexer`), the busiest cell silently dropped out of the results and the CLI printed only `search failed in 1 of 4 regions; results may be incomplete` — with no way to tell which region or why. **Silent, incomplete cross-region results.**

## Root cause

**Bug 2 — the defect.** `search.CellV4` read each cell's response body with `io.ReadAll(io.LimitReader(resp.Body, 1<<20))` — a hard **1 MiB** cap. The largest cell returns 2+ MB on high-hit queries (result rows carry full transcript text). `LimitReader` truncated the body mid-JSON, `json.Unmarshal` failed, `CellV4` returned `unexpected response from search service`, and that cell was classified *failed* — dropping its whole region from the merge. Volume-dependent, not region health / version skew / latency.

**Bug 3 — why it was undiagnosable.** The partial-failure warning printed only a **count**; the per-cell label + error went to `logging.Debug`, which the `search` command discards (it never calls `logging.Init`, so the default logger sits at INFO and Debug is dropped). The operator could not see which region failed or why.

## Fix

**Bug 2 — bounded read with explicit overflow, not a silent raised cap.** Reads go through a new `readCappedBody` helper with a **64 MiB** guard (~30× real payloads; a DoS/runaway bound, not a functional limit — the page is already bounded by the per-request result limit). On overflow it returns an explicit `exceeded the N-byte read limit` error instead of feeding truncated JSON to the decoder, so the silent-truncation failure class is gone.

**Bug 3 — name the region and reason.** The warning now lists each failed region with a concise reason. Since a cell error can embed the raw response body, `summarizeCellError` collapses it to a single, rune-safe, truncated line — the terminal never gets a multi-MB blob. The `N of M regions` prefix and the machine-readable `Response.Warnings` contract are preserved.

### Design decision: cap vs. stream

I kept a **buffered read with a bounded cap + explicit overflow error** rather than switching `CellV4` to `json.NewDecoder(resp.Body)`. Streaming would remove the magic number, but:

- both the non-200 path and the decode-error path dump `string(body)` for diagnostics — streaming loses the raw body;
- a raw `json.NewDecoder` over `resp.Body` has **no memory bound** (DoS); wrapping it back in a `LimitReader` just turns an over-cap payload into `unexpected EOF` — silent-ish again, and still no raw body.

Buffered + `maxBytes+1` overflow detection keeps a hard memory bound **and** makes overflow loud **and** preserves the raw-body diagnostics — strictly better here.

## Tests

- `TestCellV4_LargeResponseDecodesFully` — a valid JSON body **> 1 MiB** now decodes intact (regression for Bug 2).
- `TestReadCappedBody` — at/under cap returns intact; one byte over is an explicit error, not a truncated slice.
- `TestMergeSemanticV4Responses_PartialFailureNamesRegionAndReason` — the warning names the region + a concise reason, truncates an embedded multi-MB body, and keeps the `1 of 2 regions` prefix (Bug 3). Existing `1 of N regions` assertions stay green.

`gofmt`, `go vet ./...`, `mise run lint` (0 issues), and the search suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VccsQTwYMBjeTC8aJQ3wTP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-region search merge behavior and user-visible errors for a core CLI path; bounded reads and sanitization reduce DoS/terminal risks from large or untrusted bodies.
> 
> **Overview**
> Fixes **cross-region semantic search** dropping busy cells when responses exceed the old **1 MiB** body cap. `CellV4` now reads via `readCappedBody` with a **64 MiB** guard; bodies over the cap return an explicit limit error instead of silent truncation that broke JSON decode and removed whole regions from the merge.
> 
> **Partial and total failures** are easier to diagnose: `mergeSemanticV4Responses` warnings name each failed region plus a short reason (still using the `N of M regions` prefix). `summarizeCellError` strips non-printable runes and truncates reasons so embedded response bodies cannot flood the terminal or debug logs; all-cells-failed errors use the same summarization except **`context.Canceled`** stays wrapped for Ctrl-C handling.
> 
> Regression tests cover large JSON decode, read-cap behavior, warning content, error truncation, and cancellation chaining.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb983446380db12d116bf443fc7bf0327dcdce8e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->