### PR TITLE
build(scoop): keep pre-rename 'cli' installs updating and migrate them to entire

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -121,6 +121,33 @@ scoops:
     license: MIT
     skip_upload: auto
 
+  # Transition manifest for the pre-rename package name. Before the "entire"
+  # manifest existed, goreleaser defaulted the name to the project name, so
+  # existing Windows installs are registered as app "cli" and `scoop update`
+  # resolves their updates from cli.json — dropping it orphans those installs
+  # silently (no error, no more updates). Keep publishing it, depending on the
+  # canonical "entire" package so one `scoop update` migrates users without a
+  # forced reinstall, and nudge cleanup via post_install. Drop this entry a few
+  # releases after migration has largely completed.
+  #
+  # Note: both apps ship the same entire.exe shim; scoop lets the most recently
+  # installed app own it, and `scoop uninstall cli` can take the shared shim
+  # with it — hence the `scoop reset entire` step in the message below.
+  - name: cli
+    repository:
+      owner: entireio
+      name: scoop-bucket
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/entireio/cli"
+    description: "CLI for Entire (renamed to 'entire' — install that instead)"
+    license: MIT
+    depends:
+      - entire
+    post_install:
+      - "Write-Host \"This package was renamed to 'entire'. Finish migrating with:\" -ForegroundColor Yellow"
+      - "Write-Host '  scoop uninstall cli; scoop reset entire' -ForegroundColor Yellow"
+    skip_upload: auto
+
 homebrew_casks:
   - name: entire
     repository:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -131,11 +131,21 @@ scoops:
   # the user at the Scoop commands to move onto the renamed `entire` package
   # (see cmd/entire/cli/versioncheck). The post_install prints the same nudge.
   #
+  # Accepted cost of the transition window: `scoop search entire` lists both
+  # packages, so a new user can still install the deprecated `cli`. Scoop has no
+  # deprecation field — the description below is the only signal available.
+  #
   # No `depends: [entire]`: pulling in the `entire` package automatically would
-  # fight the CLI-driven migration and the shared-shim ownership between the two
-  # apps. The renamed `entire` package is installed only when the user runs the
-  # migration commands. Drop this entry a few releases after migration has
-  # largely completed.
+  # fight the CLI-driven migration and ownership of the shims both manifests
+  # declare (`entire.exe` and `git-remote-entire.exe`). The renamed `entire`
+  # package is installed only when the user runs the migration commands.
+  #
+  # Drop this entry (and the `scoopAppName() == "cli"` branch in
+  # cmd/entire/cli/versioncheck) no earlier than v0.12.0. There is no telemetry
+  # dimension for the install manager, so completion can't be measured — the
+  # version is a deliberate cutoff, not an observation. Dropping it orphans any
+  # remaining `cli` installs silently, so if a data-driven call is wanted
+  # instead, add the Scoop app dir as a telemetry dimension first.
   - name: cli
     repository:
       owner: entireio

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -146,7 +146,7 @@ scoops:
     license: MIT
     post_install:
       - "Write-Host \"This package was renamed to 'entire'. Migrate with (run when entire is not running):\" -ForegroundColor Yellow"
-      - "Write-Host '  scoop install entire/entire; scoop uninstall entire/cli; scoop reset entire' -ForegroundColor Yellow"
+      - "Write-Host '  cmd.exe /D /C \"scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire\"' -ForegroundColor Yellow"
     skip_upload: auto
 
 homebrew_casks:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -125,14 +125,17 @@ scoops:
   # manifest existed, goreleaser defaulted the name to the project name, so
   # existing Windows installs are registered as app "cli" and `scoop update`
   # resolves their updates from cli.json — dropping it orphans those installs
-  # silently (no error, no more updates). Keep publishing it, depending on the
-  # canonical "entire" package so one `scoop update` migrates users without a
-  # forced reinstall, and nudge cleanup via post_install. Drop this entry a few
-  # releases after migration has largely completed.
+  # silently (no error, no more updates). Keep publishing it so `scoop update
+  # cli` still delivers the latest binary. That binary carries the in-CLI
+  # migration: when it detects it is running from the `cli` app dir it points
+  # the user at the Scoop commands to move onto the renamed `entire` package
+  # (see cmd/entire/cli/versioncheck). The post_install prints the same nudge.
   #
-  # Note: both apps ship the same entire.exe shim; scoop lets the most recently
-  # installed app own it, and `scoop uninstall cli` can take the shared shim
-  # with it — hence the `scoop reset entire` step in the message below.
+  # No `depends: [entire]`: pulling in the `entire` package automatically would
+  # fight the CLI-driven migration and the shared-shim ownership between the two
+  # apps. The renamed `entire` package is installed only when the user runs the
+  # migration commands. Drop this entry a few releases after migration has
+  # largely completed.
   - name: cli
     repository:
       owner: entireio
@@ -141,11 +144,9 @@ scoops:
     homepage: "https://github.com/entireio/cli"
     description: "CLI for Entire (renamed to 'entire' — install that instead)"
     license: MIT
-    depends:
-      - entire
     post_install:
-      - "Write-Host \"This package was renamed to 'entire'. Finish migrating with:\" -ForegroundColor Yellow"
-      - "Write-Host '  scoop uninstall cli; scoop reset entire' -ForegroundColor Yellow"
+      - "Write-Host \"This package was renamed to 'entire'. Migrate with (run when entire is not running):\" -ForegroundColor Yellow"
+      - "Write-Host '  scoop install entire/entire; scoop uninstall entire/cli; scoop reset entire' -ForegroundColor Yellow"
     skip_upload: auto
 
 homebrew_casks:

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ scoop bucket add entire https://github.com/entireio/scoop-bucket.git
 scoop install entire/entire
 ```
 
-#### Upgrading to v9 (Scoop package rename)
+#### Upgrading to v0.9 (Scoop package rename)
 
-The Scoop package was renamed from `cli` to `entire` in v9. If you installed a
-v8 build (`entire/cli`), remove the old package and install the new one:
+The Scoop package was renamed from `cli` to `entire` in v0.9. If you installed a
+v0.8.x build (`entire/cli`), remove the old package and install the new one:
 
 ```powershell
 scoop uninstall entire/cli

--- a/README.md
+++ b/README.md
@@ -71,14 +71,16 @@ scoop bucket add entire https://github.com/entireio/scoop-bucket.git
 scoop install entire/entire
 ```
 
-#### Upgrading to v0.9 (Scoop package rename)
+#### Migrating an old `cli` Scoop install (package rename)
 
-The Scoop package was renamed from `cli` to `entire` in v0.9. If you installed a
-v0.8.x build (`entire/cli`), remove the old package and install the new one:
+The Scoop package was renamed from `cli` to `entire`. If your install is still
+registered as the old `cli` package, install the new one first, then remove the
+old one (`scoop reset` re-links the shared `entire.exe` shim):
 
 ```powershell
-scoop uninstall entire/cli
 scoop install entire/entire
+scoop uninstall entire/cli
+scoop reset entire
 ```
 
 ### Go (development/manual setup)

--- a/README.md
+++ b/README.md
@@ -75,14 +75,20 @@ scoop install entire/entire
 
 The Scoop package was renamed from `cli` to `entire`. If your install is still
 registered as the old `cli` package, run the migration below. It installs the
-new package before removing the old one, and only continues when each command
-succeeds (`scoop reset` re-links the shared `entire.exe` shim). Run it where
-`entire` is **not** running — a live `entire.exe` locks its own shim, so Scoop
-can't relink or uninstall it mid-run:
+new package before removing the old one, so the old install is only removed
+once the new one is in place (`scoop reset` re-links the shared `entire.exe`
+and `git-remote-entire.exe` shims). Run it where `entire` is **not** running — a
+live `entire.exe` locks its own shim, so Scoop can't relink or uninstall it
+mid-run:
 
 ```powershell
 cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"
 ```
+
+If the first step fails with "couldn't find manifest", your bucket clone
+predates the renamed package — run `scoop update` to refresh it, then retry the
+command above. Nothing is removed until the install succeeds, so a failed
+attempt leaves your existing install working.
 
 ### Go (development/manual setup)
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ scoop install entire/entire
 
 The Scoop package was renamed from `cli` to `entire`. If your install is still
 registered as the old `cli` package, install the new one first, then remove the
-old one (`scoop reset` re-links the shared `entire.exe` shim):
+old one (`scoop reset` re-links the shared `entire.exe` shim). Run these in a
+shell where `entire` is **not** running — a live `entire.exe` locks its own
+shim, so Scoop can't relink or uninstall it mid-run:
 
 ```powershell
 scoop install entire/entire

--- a/README.md
+++ b/README.md
@@ -74,15 +74,14 @@ scoop install entire/entire
 #### Migrating an old `cli` Scoop install (package rename)
 
 The Scoop package was renamed from `cli` to `entire`. If your install is still
-registered as the old `cli` package, install the new one first, then remove the
-old one (`scoop reset` re-links the shared `entire.exe` shim). Run these in a
-shell where `entire` is **not** running — a live `entire.exe` locks its own
-shim, so Scoop can't relink or uninstall it mid-run:
+registered as the old `cli` package, run the migration below. It installs the
+new package before removing the old one, and only continues when each command
+succeeds (`scoop reset` re-links the shared `entire.exe` shim). Run it where
+`entire` is **not** running — a live `entire.exe` locks its own shim, so Scoop
+can't relink or uninstall it mid-run:
 
 ```powershell
-scoop install entire/entire
-scoop uninstall entire/cli
-scoop reset entire
+cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"
 ```
 
 ### Go (development/manual setup)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,17 @@ Install with Scoop:
 
 ```powershell
 scoop bucket add entire https://github.com/entireio/scoop-bucket.git
-scoop install entire/cli
+scoop install entire/entire
+```
+
+#### Upgrading to v9 (Scoop package rename)
+
+The Scoop package was renamed from `cli` to `entire` in v9. If you installed a
+v8 build (`entire/cli`), remove the old package and install the new one:
+
+```powershell
+scoop uninstall entire/cli
+scoop install entire/entire
 ```
 
 ### Go (development/manual setup)
@@ -105,7 +115,7 @@ How to use each channel:
 - Homebrew nightly: `brew install --cask entire@nightly`
 - `install.sh` stable: `curl -fsSL https://entire.io/install.sh | bash`
 - `install.sh` nightly: `curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly`
-- Scoop: currently supports `stable` only via `scoop install entire/cli`
+- Scoop: currently supports `stable` only via `scoop install entire/entire`
 
 ## Typical Workflow
 

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 
 	"charm.land/huh/v2"
 
@@ -72,7 +73,7 @@ func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 
 	if os.Getenv(envKillSwitch) != "" || !interactive.CanPromptInteractively() || !isTerminalOut(w) {
 		printNotification(w, currentVersion, latestVersion)
-		fmt.Fprintf(w, "To update, run:\n  %s\n", cmdStr)
+		fmt.Fprintf(w, "To update, run:\n%s\n", indentCommand(cmdStr))
 		return autoUpdateActionSkip
 	}
 
@@ -84,9 +85,9 @@ func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 
 	switch action {
 	case autoUpdateActionUpdate:
-		fmt.Fprintf(w, "\nUpdating Entire CLI: %s\n", cmdStr)
+		fmt.Fprintf(w, "\nUpdating Entire CLI:\n%s\n", indentCommand(cmdStr))
 		if err := runInstaller(ctx, cmdStr); err != nil {
-			fmt.Fprintf(w, "Update failed: %v\nTry again later running:\n  %s\n", err, cmdStr)
+			fmt.Fprintf(w, "Update failed: %v\nTry again later running:\n%s\n", err, indentCommand(cmdStr))
 			return autoUpdateActionUpdate
 		}
 		fmt.Fprintln(w, "Update complete. Re-run entire to use the new version.")
@@ -125,20 +126,39 @@ func realChooseUpdate(ctx context.Context, currentVersion, latestVersion, cmdStr
 	return action, nil
 }
 
+// indentCommand indents each line of a (possibly multi-line) installer command
+// so it reads as a block under a "run:" heading.
+func indentCommand(cmdStr string) string {
+	return "  " + strings.ReplaceAll(cmdStr, "\n", "\n  ")
+}
+
 // realRunInstaller shells out to the installer command, streaming stdin/stdout/stderr
 // so password prompts and progress output reach the user.
+//
+// cmdStr may hold several newline-separated commands (e.g. the Scoop package
+// rename: install, uninstall, reset). Each line is run as its own process and
+// a failure stops the sequence, so a later step never runs after an earlier one
+// failed (the uninstall must not run if the install did not succeed). Keeping
+// the steps as separate lines — rather than a `;`/`&&` shell one-liner — lets
+// the same string be pasted into any shell the user happens to be in.
 func realRunInstaller(ctx context.Context, cmdStr string) error {
-	var c *exec.Cmd
-	if runtime.GOOS == goosWindows {
-		c = exec.CommandContext(ctx, "cmd", "/C", cmdStr)
-	} else {
-		c = exec.CommandContext(ctx, "sh", "-c", cmdStr)
-	}
-	c.Stdin = os.Stdin
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	if err := c.Run(); err != nil {
-		return fmt.Errorf("installer exited: %w", err)
+	for line := range strings.SplitSeq(cmdStr, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var c *exec.Cmd
+		if runtime.GOOS == goosWindows {
+			c = exec.CommandContext(ctx, "cmd", "/C", line)
+		} else {
+			c = exec.CommandContext(ctx, "sh", "-c", line)
+		}
+		c.Stdin = os.Stdin
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		if err := c.Run(); err != nil {
+			return fmt.Errorf("installer exited: %w", err)
+		}
 	}
 	return nil
 }

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"runtime"
 
 	"charm.land/huh/v2"
 
@@ -76,6 +75,11 @@ func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 	// mid-run (install leaves the shim on the old package, and uninstall fails
 	// with "still running"). Never auto-run on Windows — print the command(s)
 	// to run once entire has exited.
+	//
+	// This returns plain skip, not skipUntilNextVersion, so Windows users can't
+	// suppress a specific version: the nudge returns every 24h until they
+	// update. That is deliberate while the Scoop rename migration is live —
+	// there is no prompt to choose from, so there is no choice to remember.
 	if goos == goosWindows {
 		printNotification(w, currentVersion, latestVersion)
 		fmt.Fprintf(w, "To update, run the following when entire is not running:\n  %s\n", cmdStr)
@@ -138,13 +142,15 @@ func realChooseUpdate(ctx context.Context, currentVersion, latestVersion, cmdStr
 }
 
 // realRunInstaller shells out to the installer command, streaming stdin/stdout/stderr
-// so password prompts and progress output reach the user. Only ever runs
-// single-command installers (brew, mise, curl): the multi-line Scoop rename is
-// Windows-only and Windows is print-only (see MaybeAutoUpdate), so it never
-// reaches the runner.
+// so password prompts and progress output reach the user. In practice it only
+// ever runs the POSIX installers (brew, mise, curl): MaybeAutoUpdate returns
+// before reaching here on Windows, so the cmd.exe branch below is unreachable
+// today. It is kept as cover for Windows print-only being lifted later, and
+// reads the same `goos` seam MaybeAutoUpdate does so a test can drive both
+// consistently.
 func realRunInstaller(ctx context.Context, cmdStr string) error {
 	var c *exec.Cmd
-	if runtime.GOOS == goosWindows {
+	if goos == goosWindows {
 		c = exec.CommandContext(ctx, "cmd", "/C", cmdStr)
 	} else {
 		c = exec.CommandContext(ctx, "sh", "-c", cmdStr)

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -84,7 +84,7 @@ func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 
 	if os.Getenv(envKillSwitch) != "" || !interactive.CanPromptInteractively() || !isTerminalOut(w) {
 		printNotification(w, currentVersion, latestVersion)
-		fmt.Fprintf(w, "To update, run:\n%s\n", indentCommand(cmdStr))
+		fmt.Fprintf(w, "To update, run:\n  %s\n", cmdStr)
 		return autoUpdateActionSkip
 	}
 
@@ -96,9 +96,9 @@ func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 
 	switch action {
 	case autoUpdateActionUpdate:
-		fmt.Fprintf(w, "\nUpdating Entire CLI:\n%s\n", indentCommand(cmdStr))
+		fmt.Fprintf(w, "\nUpdating Entire CLI: %s\n", cmdStr)
 		if err := runInstaller(ctx, cmdStr); err != nil {
-			fmt.Fprintf(w, "Update failed: %v\nTry again later running:\n%s\n", err, indentCommand(cmdStr))
+			fmt.Fprintf(w, "Update failed: %v\nTry again later running:\n  %s\n", err, cmdStr)
 			return autoUpdateActionUpdate
 		}
 		fmt.Fprintln(w, "Update complete. Re-run entire to use the new version.")
@@ -137,8 +137,10 @@ func realChooseUpdate(ctx context.Context, currentVersion, latestVersion, cmdStr
 	return action, nil
 }
 
-// indentCommand indents each line of a (possibly multi-line) installer command
-// so it reads as a block under a "run:" heading.
+// indentCommand indents each line of a multi-line installer command so it reads
+// as a block under a "run:" heading. Only the Windows Scoop package-rename
+// migration is multi-line; every other installer is a single command printed
+// inline, so this is used only on the Windows print-only path.
 func indentCommand(cmdStr string) string {
 	return "  " + strings.ReplaceAll(cmdStr, "\n", "\n  ")
 }

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -71,6 +71,17 @@ func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 
 	cmdStr := updateCommand(currentVersion)
 
+	// Windows can't replace a running executable: the live entire.exe holds its
+	// own shim open, so scoop can't relink or uninstall it mid-run (install
+	// leaves the shim on the old package, and uninstall fails with "still
+	// running"). Never auto-run on Windows — print the command(s) to run once
+	// entire has exited.
+	if goos == goosWindows {
+		printNotification(w, currentVersion, latestVersion)
+		fmt.Fprintf(w, "To update, run the following when entire is not running:\n%s\n", indentCommand(cmdStr))
+		return autoUpdateActionSkip
+	}
+
 	if os.Getenv(envKillSwitch) != "" || !interactive.CanPromptInteractively() || !isTerminalOut(w) {
 		printNotification(w, currentVersion, latestVersion)
 		fmt.Fprintf(w, "To update, run:\n%s\n", indentCommand(cmdStr))
@@ -133,32 +144,22 @@ func indentCommand(cmdStr string) string {
 }
 
 // realRunInstaller shells out to the installer command, streaming stdin/stdout/stderr
-// so password prompts and progress output reach the user.
-//
-// cmdStr may hold several newline-separated commands (e.g. the Scoop package
-// rename: install, uninstall, reset). Each line is run as its own process and
-// a failure stops the sequence, so a later step never runs after an earlier one
-// failed (the uninstall must not run if the install did not succeed). Keeping
-// the steps as separate lines — rather than a `;`/`&&` shell one-liner — lets
-// the same string be pasted into any shell the user happens to be in.
+// so password prompts and progress output reach the user. Only ever runs
+// single-command installers (brew, mise, curl): the multi-line Scoop rename is
+// Windows-only and Windows is print-only (see MaybeAutoUpdate), so it never
+// reaches the runner.
 func realRunInstaller(ctx context.Context, cmdStr string) error {
-	for line := range strings.SplitSeq(cmdStr, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		var c *exec.Cmd
-		if runtime.GOOS == goosWindows {
-			c = exec.CommandContext(ctx, "cmd", "/C", line)
-		} else {
-			c = exec.CommandContext(ctx, "sh", "-c", line)
-		}
-		c.Stdin = os.Stdin
-		c.Stdout = os.Stdout
-		c.Stderr = os.Stderr
-		if err := c.Run(); err != nil {
-			return fmt.Errorf("installer exited: %w", err)
-		}
+	var c *exec.Cmd
+	if runtime.GOOS == goosWindows {
+		c = exec.CommandContext(ctx, "cmd", "/C", cmdStr)
+	} else {
+		c = exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	}
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("installer exited: %w", err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -70,11 +70,12 @@ func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 
 	cmdStr := updateCommand(currentVersion)
 
-	// Windows can't replace a running executable: the live entire.exe holds its
-	// own shim open, so scoop can't relink or uninstall it mid-run (install
-	// leaves the shim on the old package, and uninstall fails with "still
-	// running"). Never auto-run on Windows — print the command(s) to run once
-	// entire has exited.
+	// Windows can't replace a running executable, so no installer can update
+	// entire in place while it runs. For Scoop this is acute: the live
+	// entire.exe holds its own shim open, so scoop can't relink or uninstall it
+	// mid-run (install leaves the shim on the old package, and uninstall fails
+	// with "still running"). Never auto-run on Windows — print the command(s)
+	// to run once entire has exited.
 	if goos == goosWindows {
 		printNotification(w, currentVersion, latestVersion)
 		fmt.Fprintf(w, "To update, run the following when entire is not running:\n  %s\n", cmdStr)

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -130,10 +130,7 @@ func realChooseUpdate(ctx context.Context, currentVersion, latestVersion, cmdStr
 func realRunInstaller(ctx context.Context, cmdStr string) error {
 	var c *exec.Cmd
 	if runtime.GOOS == goosWindows {
-		// PowerShell, not cmd.exe: the Scoop install manager is a PowerShell
-		// tool and the update commands use `;` as the statement separator,
-		// which cmd.exe does not recognize.
-		c = exec.CommandContext(ctx, "powershell", "-NoProfile", "-Command", cmdStr)
+		c = exec.CommandContext(ctx, "cmd", "/C", cmdStr)
 	} else {
 		c = exec.CommandContext(ctx, "sh", "-c", cmdStr)
 	}

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 
 	"charm.land/huh/v2"
 
@@ -78,7 +77,7 @@ func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 	// entire has exited.
 	if goos == goosWindows {
 		printNotification(w, currentVersion, latestVersion)
-		fmt.Fprintf(w, "To update, run the following when entire is not running:\n%s\n", indentCommand(cmdStr))
+		fmt.Fprintf(w, "To update, run the following when entire is not running:\n  %s\n", cmdStr)
 		return autoUpdateActionSkip
 	}
 
@@ -135,14 +134,6 @@ func realChooseUpdate(ctx context.Context, currentVersion, latestVersion, cmdStr
 		return autoUpdateActionSkip, fmt.Errorf("update prompt: %w", err)
 	}
 	return action, nil
-}
-
-// indentCommand indents each line of a multi-line installer command so it reads
-// as a block under a "run:" heading. Only the Windows Scoop package-rename
-// migration is multi-line; every other installer is a single command printed
-// inline, so this is used only on the Windows print-only path.
-func indentCommand(cmdStr string) string {
-	return "  " + strings.ReplaceAll(cmdStr, "\n", "\n  ")
 }
 
 // realRunInstaller shells out to the installer command, streaming stdin/stdout/stderr

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -130,7 +130,10 @@ func realChooseUpdate(ctx context.Context, currentVersion, latestVersion, cmdStr
 func realRunInstaller(ctx context.Context, cmdStr string) error {
 	var c *exec.Cmd
 	if runtime.GOOS == goosWindows {
-		c = exec.CommandContext(ctx, "cmd", "/C", cmdStr)
+		// PowerShell, not cmd.exe: the Scoop install manager is a PowerShell
+		// tool and the update commands use `;` as the statement separator,
+		// which cmd.exe does not recognize.
+		c = exec.CommandContext(ctx, "powershell", "-NoProfile", "-Command", cmdStr)
 	} else {
 		c = exec.CommandContext(ctx, "sh", "-c", cmdStr)
 	}

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -110,9 +110,7 @@ func assertManualHint(t *testing.T, out, wantCmd string) {
 	if !strings.Contains(out, "To update, run:") {
 		t.Errorf("missing manual-update hint: %q", out)
 	}
-	// The hint prints each command line indented, so match the indented form
-	// (this also covers multi-line commands like the Scoop package rename).
-	if !strings.Contains(out, indentCommand(wantCmd)) {
+	if !strings.Contains(out, "  "+wantCmd) {
 		t.Errorf("manual hint missing installer command %q: %q", wantCmd, out)
 	}
 }
@@ -231,8 +229,8 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 	if !strings.Contains(out, "when entire is not running") {
 		t.Errorf("missing Windows manual-run hint: %q", out)
 	}
-	wantScoopCmd := "scoop install entire/entire\nscoop uninstall entire/cli\nscoop reset entire"
-	if !strings.Contains(out, indentCommand(wantScoopCmd)) {
+	wantScoopCmd := `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
+	if !strings.Contains(out, "  "+wantScoopCmd) {
 		t.Errorf("manual hint missing migration commands %q: %q", wantScoopCmd, out)
 	}
 }

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -210,28 +210,55 @@ func TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun(t *testing.T) {
 
 // TestMaybeAutoUpdate_WindowsNeverAutoRuns verifies that on Windows the update
 // is never auto-run — a running entire.exe can't replace its own shim — so the
-// migration commands are printed for the user to run once entire has exited.
+// command is printed for the user to run once entire has exited. This holds for
+// every auto-installable manager on Windows, not just Scoop: mise is covered so
+// narrowing the branch back to Scoop can't silently regress it.
 func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
-	f := newAutoUpdateFixture(t)
-	useScoopExecutable(t)
-
-	origGOOS := goos
-	goos = goosWindows
-	t.Cleanup(func() { goos = origGOOS })
-
-	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
-
-	if f.installCalls != 0 {
-		t.Fatalf("installer must not auto-run on Windows; calls=%d", f.installCalls)
+	tests := []struct {
+		name    string
+		setup   func(*testing.T)
+		wantCmd string
+	}{
+		{
+			name:    "scoop cli app prints migration command",
+			setup:   useScoopExecutable,
+			wantCmd: `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`,
+		},
+		{
+			name:    "mise prints upgrade command",
+			setup:   useMiseExecutable,
+			wantCmd: "mise upgrade entire",
+		},
 	}
-	out := buf.String()
-	if !strings.Contains(out, "when entire is not running") {
-		t.Errorf("missing Windows manual-run hint: %q", out)
-	}
-	wantScoopCmd := `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
-	if !strings.Contains(out, "  "+wantScoopCmd) {
-		t.Errorf("manual hint missing migration commands %q: %q", wantScoopCmd, out)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newAutoUpdateFixture(t)
+			tt.setup(t)
+
+			origGOOS := goos
+			goos = goosWindows
+			t.Cleanup(func() { goos = origGOOS })
+
+			var buf bytes.Buffer
+			action := MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+
+			if f.installCalls != 0 {
+				t.Fatalf("installer must not auto-run on Windows; calls=%d", f.installCalls)
+			}
+			// Plain skip, not skip-until-next-version: Windows gets no prompt,
+			// so there is no per-version choice to persist.
+			if action != autoUpdateActionSkip {
+				t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
+			}
+			out := buf.String()
+			if !strings.Contains(out, "when entire is not running") {
+				t.Errorf("missing Windows manual-run hint: %q", out)
+			}
+			if !strings.Contains(out, "  "+tt.wantCmd) {
+				t.Errorf("manual hint missing command %q: %q", tt.wantCmd, out)
+			}
+		})
 	}
 }
 

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -225,8 +225,8 @@ func TestMaybeAutoUpdate_WindowsScoopStillAutoRuns(t *testing.T) {
 	if f.installCalls != 1 {
 		t.Fatalf("scoop install should auto-run on Windows; calls=%d", f.installCalls)
 	}
-	if f.lastCommand != "scoop update entire/entire" {
-		t.Errorf("got %q, want scoop update entire/entire", f.lastCommand)
+	if f.lastCommand != "scoop uninstall entire/cli; scoop install entire/entire" {
+		t.Errorf("got %q, want scoop uninstall entire/cli; scoop install entire/entire", f.lastCommand)
 	}
 }
 
@@ -303,7 +303,7 @@ func nonWindowsAutoInstallers() []installerCase {
 	return []installerCase{
 		{name: "brew", setup: useBrewExecutable, wantCmd: brewUpgradeCmd},
 		{name: "mise", setup: useMiseExecutable, wantCmd: "mise upgrade entire"},
-		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop update entire/entire"},
+		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop uninstall entire/cli; scoop install entire/entire"},
 		{name: "unknown_curl_bash", setup: useUnknownExecutable, wantCmd: "curl -fsSL https://entire.io/install.sh | bash"},
 	}
 }

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -225,9 +225,8 @@ func TestMaybeAutoUpdate_WindowsScoopStillAutoRuns(t *testing.T) {
 	if f.installCalls != 1 {
 		t.Fatalf("scoop install should auto-run on Windows; calls=%d", f.installCalls)
 	}
-	wantScoopCmd := "scoop install entire/entire; if ($?) { scoop uninstall entire/cli; scoop reset entire }"
-	if f.lastCommand != wantScoopCmd {
-		t.Errorf("got %q, want %q", f.lastCommand, wantScoopCmd)
+	if f.lastCommand != "scoop install entire/entire" {
+		t.Errorf("got %q, want scoop install entire/entire", f.lastCommand)
 	}
 }
 
@@ -304,7 +303,7 @@ func nonWindowsAutoInstallers() []installerCase {
 	return []installerCase{
 		{name: "brew", setup: useBrewExecutable, wantCmd: brewUpgradeCmd},
 		{name: "mise", setup: useMiseExecutable, wantCmd: "mise upgrade entire"},
-		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop install entire/entire; if ($?) { scoop uninstall entire/cli; scoop reset entire }"},
+		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop install entire/entire"},
 		{name: "unknown_curl_bash", setup: useUnknownExecutable, wantCmd: "curl -fsSL https://entire.io/install.sh | bash"},
 	}
 }

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -110,7 +113,9 @@ func assertManualHint(t *testing.T, out, wantCmd string) {
 	if !strings.Contains(out, "To update, run:") {
 		t.Errorf("missing manual-update hint: %q", out)
 	}
-	if !strings.Contains(out, wantCmd) {
+	// The hint prints each command line indented, so match the indented form
+	// (this also covers multi-line commands like the Scoop package rename).
+	if !strings.Contains(out, indentCommand(wantCmd)) {
 		t.Errorf("manual hint missing installer command %q: %q", wantCmd, out)
 	}
 }
@@ -225,8 +230,9 @@ func TestMaybeAutoUpdate_WindowsScoopStillAutoRuns(t *testing.T) {
 	if f.installCalls != 1 {
 		t.Fatalf("scoop install should auto-run on Windows; calls=%d", f.installCalls)
 	}
-	if f.lastCommand != "scoop install entire/entire" {
-		t.Errorf("got %q, want scoop install entire/entire", f.lastCommand)
+	wantScoopCmd := "scoop install entire/entire\nscoop uninstall entire/cli\nscoop reset entire"
+	if f.lastCommand != wantScoopCmd {
+		t.Errorf("got %q, want %q", f.lastCommand, wantScoopCmd)
 	}
 }
 
@@ -303,7 +309,7 @@ func nonWindowsAutoInstallers() []installerCase {
 	return []installerCase{
 		{name: "brew", setup: useBrewExecutable, wantCmd: brewUpgradeCmd},
 		{name: "mise", setup: useMiseExecutable, wantCmd: "mise upgrade entire"},
-		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop install entire/entire"},
+		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop install entire/entire\nscoop uninstall entire/cli\nscoop reset entire"},
 		{name: "unknown_curl_bash", setup: useUnknownExecutable, wantCmd: "curl -fsSL https://entire.io/install.sh | bash"},
 	}
 }
@@ -400,5 +406,37 @@ func TestMaybeAutoUpdate_AllInstallers_UserSkips(t *testing.T) {
 				t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
 			}
 		})
+	}
+}
+
+// TestRealRunInstaller_SequentialStopsOnFailure verifies the multi-line
+// installer command (e.g. the Scoop package rename) runs each line as its own
+// process and stops at the first failure — so a later step never runs after an
+// earlier one failed.
+func TestRealRunInstaller_SequentialStopsOnFailure(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == goosWindows {
+		t.Skip("uses sh; POSIX only")
+	}
+	dir := t.TempDir()
+
+	// First line fails; the second must not run, so its marker must not exist.
+	marker := filepath.Join(dir, "should-not-exist")
+	if err := realRunInstaller(context.Background(), "false\ntouch "+marker); err == nil {
+		t.Fatal("expected error when the first command fails")
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("second command ran after the first failed")
+	}
+
+	// All lines succeed in order; every marker exists afterward.
+	a, b := filepath.Join(dir, "a"), filepath.Join(dir, "b")
+	if err := realRunInstaller(context.Background(), "touch "+a+"\ntouch "+b); err != nil {
+		t.Fatalf("sequential success returned error: %v", err)
+	}
+	for _, f := range []string{a, b} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("expected %q to be created", f)
+		}
 	}
 }

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -307,10 +307,13 @@ type installerCase struct {
 }
 
 func nonWindowsAutoInstallers() []installerCase {
+	// Scoop is intentionally absent: it is a Windows-only installer, and on
+	// Windows the update is print-only (never auto-run). Its command building is
+	// covered by TestUpdateCommand and its print-only path by
+	// TestMaybeAutoUpdate_WindowsNeverAutoRuns.
 	return []installerCase{
 		{name: "brew", setup: useBrewExecutable, wantCmd: brewUpgradeCmd},
 		{name: "mise", setup: useMiseExecutable, wantCmd: "mise upgrade entire"},
-		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop install entire/entire\nscoop uninstall entire/cli\nscoop reset entire"},
 		{name: "unknown_curl_bash", setup: useUnknownExecutable, wantCmd: "curl -fsSL https://entire.io/install.sh | bash"},
 	}
 }

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -225,8 +225,8 @@ func TestMaybeAutoUpdate_WindowsScoopStillAutoRuns(t *testing.T) {
 	if f.installCalls != 1 {
 		t.Fatalf("scoop install should auto-run on Windows; calls=%d", f.installCalls)
 	}
-	if f.lastCommand != "scoop update entire/cli" {
-		t.Errorf("got %q, want scoop update entire/cli", f.lastCommand)
+	if f.lastCommand != "scoop update entire/entire" {
+		t.Errorf("got %q, want scoop update entire/entire", f.lastCommand)
 	}
 }
 
@@ -303,7 +303,7 @@ func nonWindowsAutoInstallers() []installerCase {
 	return []installerCase{
 		{name: "brew", setup: useBrewExecutable, wantCmd: brewUpgradeCmd},
 		{name: "mise", setup: useMiseExecutable, wantCmd: "mise upgrade entire"},
-		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop update entire/cli"},
+		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop update entire/entire"},
 		{name: "unknown_curl_bash", setup: useUnknownExecutable, wantCmd: "curl -fsSL https://entire.io/install.sh | bash"},
 	}
 }

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -213,10 +210,10 @@ func TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun(t *testing.T) {
 	}
 }
 
-// TestMaybeAutoUpdate_WindowsScoopStillAutoRuns verifies that a Windows
-// scoop install still takes the interactive path — only unknown install
-// managers are blocked on Windows.
-func TestMaybeAutoUpdate_WindowsScoopStillAutoRuns(t *testing.T) {
+// TestMaybeAutoUpdate_WindowsNeverAutoRuns verifies that on Windows the update
+// is never auto-run — a running entire.exe can't replace its own shim — so the
+// migration commands are printed for the user to run once entire has exited.
+func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 	f := newAutoUpdateFixture(t)
 	useScoopExecutable(t)
 
@@ -227,12 +224,16 @@ func TestMaybeAutoUpdate_WindowsScoopStillAutoRuns(t *testing.T) {
 	var buf bytes.Buffer
 	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
-	if f.installCalls != 1 {
-		t.Fatalf("scoop install should auto-run on Windows; calls=%d", f.installCalls)
+	if f.installCalls != 0 {
+		t.Fatalf("installer must not auto-run on Windows; calls=%d", f.installCalls)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "when entire is not running") {
+		t.Errorf("missing Windows manual-run hint: %q", out)
 	}
 	wantScoopCmd := "scoop install entire/entire\nscoop uninstall entire/cli\nscoop reset entire"
-	if f.lastCommand != wantScoopCmd {
-		t.Errorf("got %q, want %q", f.lastCommand, wantScoopCmd)
+	if !strings.Contains(out, indentCommand(wantScoopCmd)) {
+		t.Errorf("manual hint missing migration commands %q: %q", wantScoopCmd, out)
 	}
 }
 
@@ -406,37 +407,5 @@ func TestMaybeAutoUpdate_AllInstallers_UserSkips(t *testing.T) {
 				t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
 			}
 		})
-	}
-}
-
-// TestRealRunInstaller_SequentialStopsOnFailure verifies the multi-line
-// installer command (e.g. the Scoop package rename) runs each line as its own
-// process and stops at the first failure — so a later step never runs after an
-// earlier one failed.
-func TestRealRunInstaller_SequentialStopsOnFailure(t *testing.T) {
-	t.Parallel()
-	if runtime.GOOS == goosWindows {
-		t.Skip("uses sh; POSIX only")
-	}
-	dir := t.TempDir()
-
-	// First line fails; the second must not run, so its marker must not exist.
-	marker := filepath.Join(dir, "should-not-exist")
-	if err := realRunInstaller(context.Background(), "false\ntouch "+marker); err == nil {
-		t.Fatal("expected error when the first command fails")
-	}
-	if _, err := os.Stat(marker); err == nil {
-		t.Fatal("second command ran after the first failed")
-	}
-
-	// All lines succeed in order; every marker exists afterward.
-	a, b := filepath.Join(dir, "a"), filepath.Join(dir, "b")
-	if err := realRunInstaller(context.Background(), "touch "+a+"\ntouch "+b); err != nil {
-		t.Fatalf("sequential success returned error: %v", err)
-	}
-	for _, f := range []string{a, b} {
-		if _, err := os.Stat(f); err != nil {
-			t.Errorf("expected %q to be created", f)
-		}
 	}
 }

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -225,8 +225,9 @@ func TestMaybeAutoUpdate_WindowsScoopStillAutoRuns(t *testing.T) {
 	if f.installCalls != 1 {
 		t.Fatalf("scoop install should auto-run on Windows; calls=%d", f.installCalls)
 	}
-	if f.lastCommand != "scoop uninstall entire/cli; scoop install entire/entire" {
-		t.Errorf("got %q, want scoop uninstall entire/cli; scoop install entire/entire", f.lastCommand)
+	wantScoopCmd := "scoop install entire/entire; if ($?) { scoop uninstall entire/cli; scoop reset entire }"
+	if f.lastCommand != wantScoopCmd {
+		t.Errorf("got %q, want %q", f.lastCommand, wantScoopCmd)
 	}
 }
 
@@ -303,7 +304,7 @@ func nonWindowsAutoInstallers() []installerCase {
 	return []installerCase{
 		{name: "brew", setup: useBrewExecutable, wantCmd: brewUpgradeCmd},
 		{name: "mise", setup: useMiseExecutable, wantCmd: "mise upgrade entire"},
-		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop uninstall entire/cli; scoop install entire/entire"},
+		{name: "scoop", setup: useScoopExecutable, wantCmd: "scoop install entire/entire; if ($?) { scoop uninstall entire/cli; scoop reset entire }"},
 		{name: "unknown_curl_bash", setup: useUnknownExecutable, wantCmd: "curl -fsSL https://entire.io/install.sh | bash"},
 	}
 }

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -429,18 +429,19 @@ func updateCommand(currentVersion string) string {
 	case installManagerScoop:
 		// The Scoop package was renamed from `cli` to `entire`. A binary still
 		// running from the old `cli` app dir can never cross the rename with a
-		// plain `scoop update entire/cli`, so route it through the rename.
-		// Install the new `entire` package FIRST — `scoop install`
-		// auto-refreshes the bucket when it is >3h stale (is_scoop_outdated),
-		// so the new manifest lands without an explicit refresh — and only on
-		// its success ($?) remove the old `cli` package. Sequencing install
-		// before uninstall means a stale bucket or transient failure never
-		// leaves the user without a working CLI. `scoop reset entire` re-links
-		// the shared `entire.exe` shim, which `uninstall cli` can take with it.
-		// Runs under PowerShell (see realRunInstaller). Binaries already on the
-		// `entire` app just update in place.
+		// plain `scoop update entire/cli`, so install the new `entire` package.
+		// `scoop install` auto-refreshes the bucket when it is >3h stale
+		// (is_scoop_outdated), so the new manifest lands without an explicit
+		// refresh, and the most-recent install owns the shared `entire.exe`
+		// shim — so this single command migrates the user. It is deliberately
+		// one shell-agnostic command (no `;`/`&&`/conditionals): the string is
+		// both auto-run and printed for the user to paste into any shell, and
+		// installing without removing the old package can never leave them
+		// without a working CLI. Cleanup of the leftover `cli` app is handled
+		// by the transition manifest's post_install nudge on `scoop update`.
+		// Binaries already on the `entire` app just update in place.
 		if scoopAppName() == "cli" {
-			return "scoop install entire/entire; if ($?) { scoop uninstall entire/cli; scoop reset entire }"
+			return "scoop install entire/entire"
 		}
 		return "scoop update entire/entire"
 	}

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -429,19 +429,22 @@ func updateCommand(currentVersion string) string {
 	case installManagerScoop:
 		// The Scoop package was renamed from `cli` to `entire`. A binary still
 		// running from the old `cli` app dir can never cross the rename with a
-		// plain `scoop update entire/cli`, so install the new `entire` package.
-		// `scoop install` auto-refreshes the bucket when it is >3h stale
-		// (is_scoop_outdated), so the new manifest lands without an explicit
-		// refresh, and the most-recent install owns the shared `entire.exe`
-		// shim — so this single command migrates the user. It is deliberately
-		// one shell-agnostic command (no `;`/`&&`/conditionals): the string is
-		// both auto-run and printed for the user to paste into any shell, and
-		// installing without removing the old package can never leave them
-		// without a working CLI. Cleanup of the leftover `cli` app is handled
-		// by the transition manifest's post_install nudge on `scoop update`.
-		// Binaries already on the `entire` app just update in place.
+		// plain `scoop update entire/cli`, so migrate it: install the new
+		// `entire` package, remove the old `cli` package, then reset the shared
+		// `entire.exe` shim (which uninstalling `cli` can take with it).
+		//
+		// These are three separate one-command lines, NOT a shell one-liner.
+		// The string is both auto-run and printed for the user to paste into an
+		// unknown shell (cmd, PowerShell, git-bash, WSL), so it must carry no
+		// `;`/`&&`/conditional. realRunInstaller runs each line as its own
+		// process and stops on the first failure, so the uninstall only runs
+		// once the install has succeeded — a stale bucket or transient failure
+		// never leaves the user without a working CLI. `scoop install` also
+		// auto-refreshes the bucket when >3h stale (is_scoop_outdated), so the
+		// new manifest lands without an explicit refresh. Binaries already on
+		// the `entire` app just update in place.
 		if scoopAppName() == "cli" {
-			return "scoop install entire/entire"
+			return "scoop install entire/entire\nscoop uninstall entire/cli\nscoop reset entire"
 		}
 		return "scoop update entire/entire"
 	}

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -343,6 +343,16 @@ func releaseChannel(version string) string {
 	return installChannelStable
 }
 
+// isMajorV8 reports whether currentVersion is a v8.x release. Used to route
+// Scoop users through the v9 package rename (`cli` -> `entire`) on upgrade.
+func isMajorV8(currentVersion string) bool {
+	v := currentVersion
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+	return semver.IsValid(v) && semver.Major(v) == "v8"
+}
+
 func installManagerForCurrentBinary() string {
 	execPath, err := executablePath()
 	if err != nil {
@@ -401,6 +411,16 @@ func updateCommand(currentVersion string) string {
 	case installManagerMise:
 		return "mise upgrade entire"
 	case installManagerScoop:
+		// The Scoop package was renamed from `cli` to `entire` in v9. A v8
+		// binary is installed as `entire/cli`, so a plain `scoop update
+		// entire/cli` can never cross the rename. Route v8 Scoop users through
+		// the rename: drop the old `cli` package and install the new `entire`
+		// package. `scoop install` auto-refreshes the bucket when it is >3h
+		// stale (is_scoop_outdated), so the new `entire` manifest lands without
+		// an explicit refresh step.
+		if isMajorV8(currentVersion) {
+			return "scoop uninstall entire/cli && scoop install entire/entire"
+		}
 		return "scoop update entire/cli"
 	}
 

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -429,14 +429,18 @@ func updateCommand(currentVersion string) string {
 	case installManagerScoop:
 		// The Scoop package was renamed from `cli` to `entire`. A binary still
 		// running from the old `cli` app dir can never cross the rename with a
-		// plain `scoop update entire/cli`, so route it through the rename: drop
-		// the old `cli` package and install the new `entire` package. `scoop
-		// install` auto-refreshes the bucket when it is >3h stale
-		// (is_scoop_outdated), so the new `entire` manifest lands without an
-		// explicit refresh step. Binaries already on the `entire` app just
-		// update in place.
+		// plain `scoop update entire/cli`, so route it through the rename.
+		// Install the new `entire` package FIRST — `scoop install`
+		// auto-refreshes the bucket when it is >3h stale (is_scoop_outdated),
+		// so the new manifest lands without an explicit refresh — and only on
+		// its success ($?) remove the old `cli` package. Sequencing install
+		// before uninstall means a stale bucket or transient failure never
+		// leaves the user without a working CLI. `scoop reset entire` re-links
+		// the shared `entire.exe` shim, which `uninstall cli` can take with it.
+		// Runs under PowerShell (see realRunInstaller). Binaries already on the
+		// `entire` app just update in place.
 		if scoopAppName() == "cli" {
-			return "scoop uninstall entire/cli; scoop install entire/entire"
+			return "scoop install entire/entire; if ($?) { scoop uninstall entire/cli; scoop reset entire }"
 		}
 		return "scoop update entire/entire"
 	}

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -343,15 +343,30 @@ func releaseChannel(version string) string {
 	return installChannelStable
 }
 
-// isPreRenameScoopVersion reports whether currentVersion predates the v0.9
-// Scoop package rename. Those builds are installed as the `cli` package and
-// must be routed across the rename to `entire`; v0.9+ is already on `entire`.
-func isPreRenameScoopVersion(currentVersion string) bool {
-	v := currentVersion
-	if !strings.HasPrefix(v, "v") {
-		v = "v" + v
+// scoopAppName returns the Scoop app directory the running binary lives under
+// — the path segment after `/scoop/apps/` (e.g. "cli" or "entire") — or ""
+// when the binary is not a Scoop install. This is the durable signal for the
+// pre-rename package: a binary running from the `cli` app dir must migrate to
+// `entire` regardless of its version (the fix ships in a final `cli` release,
+// so the migrating binary's version is already past the rename).
+func scoopAppName() string {
+	execPath, err := executablePath()
+	if err != nil {
+		return ""
 	}
-	return semver.IsValid(v) && semver.Compare(v, "v0.9.0") < 0
+	realPath, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		realPath = execPath
+	}
+	normalized := strings.ReplaceAll(filepath.ToSlash(realPath), "\\", "/")
+	_, rest, ok := strings.Cut(normalized, "/scoop/apps/")
+	if !ok {
+		return ""
+	}
+	if app, _, ok := strings.Cut(rest, "/"); ok {
+		return app
+	}
+	return rest
 }
 
 func installManagerForCurrentBinary() string {
@@ -412,14 +427,15 @@ func updateCommand(currentVersion string) string {
 	case installManagerMise:
 		return "mise upgrade entire"
 	case installManagerScoop:
-		// The Scoop package was renamed from `cli` to `entire` in v0.9.
-		// Pre-rename builds are installed as `entire/cli`, so a plain `scoop
-		// update entire/cli` can never cross the rename. Route those users
-		// through the rename: drop the old `cli` package and install the new
-		// `entire` package. `scoop install` auto-refreshes the bucket when it
-		// is >3h stale (is_scoop_outdated), so the new `entire` manifest lands
-		// without an explicit refresh step. v0.9+ is already on `entire`.
-		if isPreRenameScoopVersion(currentVersion) {
+		// The Scoop package was renamed from `cli` to `entire`. A binary still
+		// running from the old `cli` app dir can never cross the rename with a
+		// plain `scoop update entire/cli`, so route it through the rename: drop
+		// the old `cli` package and install the new `entire` package. `scoop
+		// install` auto-refreshes the bucket when it is >3h stale
+		// (is_scoop_outdated), so the new `entire` manifest lands without an
+		// explicit refresh step. Binaries already on the `entire` app just
+		// update in place.
+		if scoopAppName() == "cli" {
 			return "scoop uninstall entire/cli; scoop install entire/entire"
 		}
 		return "scoop update entire/entire"

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -373,10 +373,10 @@ func scoopAppName() string {
 	if !ok {
 		return ""
 	}
-	if app, _, ok := strings.Cut(rest, "/"); ok {
-		return app
-	}
-	return rest
+	// Cut returns the whole string when the separator is absent, so this covers
+	// both `.../scoop/apps/cli/current/entire.exe` and a bare app segment.
+	app, _, _ := strings.Cut(rest, "/")
+	return app
 }
 
 func installManagerForCurrentBinary() string {
@@ -435,17 +435,30 @@ func updateCommand(currentVersion string) string {
 		// running from the old `cli` app dir can never cross the rename with a
 		// plain `scoop update entire/cli`, so migrate it: install the new
 		// `entire` package, remove the old `cli` package, then reset the shared
-		// `entire.exe` shim (which uninstalling `cli` can take with it).
+		// shims. Both manifests declare `bin: [git-remote-entire.exe,
+		// entire.exe]`, so the two packages contend for the same shims. Current
+		// Scoop handles that itself: installing `entire` renames the displaced
+		// shim to `entire.shim.cli` (warn_on_overwrite) and uninstalling `cli`
+		// removes only that suffixed copy (rm_shim), leaving the active shims
+		// pointing at `entire`. The reset step is belt-and-braces for older
+		// Scoop versions that overwrote shims without that alt-file dance and
+		// would otherwise take `entire.exe` and the git remote helper with them.
 		//
 		// The Windows updater is print-only, so return a self-contained command
 		// users can paste into either cmd or PowerShell. Explicitly invoking
 		// cmd.exe makes `&&` portable across those shells and ensures uninstall
-		// only runs after install succeeds; reset likewise requires a successful
-		// uninstall. A stale bucket or transient failure therefore never removes
-		// the working CLI. `scoop install` also
-		// auto-refreshes the bucket when >3h stale (is_scoop_outdated), so the
-		// new manifest lands without an explicit refresh. Binaries already on
-		// the `entire` app just update in place.
+		// only runs after install succeeds — a stale bucket or transient failure
+		// therefore never removes the working CLI. (The uninstall→reset link is
+		// weaker: `scoop uninstall` ends in an unconditional `exit 0`, so reset
+		// runs even when the uninstall skipped its work. That is harmless, since
+		// reset is a no-op on the Scoop versions that make it unnecessary.)
+		//
+		// `scoop install` also auto-refreshes the bucket when >3h stale
+		// (is_scoop_outdated), so the new manifest usually lands
+		// without an explicit refresh; a bucket clone older than that check can
+		// still fail with "couldn't find manifest", and the README migration
+		// section names `scoop update` as the retry. Binaries already on the
+		// `entire` app just update in place.
 		if scoopAppName() == "cli" {
 			return `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
 		}

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -343,14 +343,15 @@ func releaseChannel(version string) string {
 	return installChannelStable
 }
 
-// isMajorV8 reports whether currentVersion is a v8.x release. Used to route
-// Scoop users through the v9 package rename (`cli` -> `entire`) on upgrade.
-func isMajorV8(currentVersion string) bool {
+// isPreRenameScoopVersion reports whether currentVersion predates the v0.9
+// Scoop package rename. Those builds are installed as the `cli` package and
+// must be routed across the rename to `entire`; v0.9+ is already on `entire`.
+func isPreRenameScoopVersion(currentVersion string) bool {
 	v := currentVersion
 	if !strings.HasPrefix(v, "v") {
 		v = "v" + v
 	}
-	return semver.IsValid(v) && semver.Major(v) == "v8"
+	return semver.IsValid(v) && semver.Compare(v, "v0.9.0") < 0
 }
 
 func installManagerForCurrentBinary() string {
@@ -411,17 +412,17 @@ func updateCommand(currentVersion string) string {
 	case installManagerMise:
 		return "mise upgrade entire"
 	case installManagerScoop:
-		// The Scoop package was renamed from `cli` to `entire` in v9. A v8
-		// binary is installed as `entire/cli`, so a plain `scoop update
-		// entire/cli` can never cross the rename. Route v8 Scoop users through
-		// the rename: drop the old `cli` package and install the new `entire`
-		// package. `scoop install` auto-refreshes the bucket when it is >3h
-		// stale (is_scoop_outdated), so the new `entire` manifest lands without
-		// an explicit refresh step.
-		if isMajorV8(currentVersion) {
+		// The Scoop package was renamed from `cli` to `entire` in v0.9.
+		// Pre-rename builds are installed as `entire/cli`, so a plain `scoop
+		// update entire/cli` can never cross the rename. Route those users
+		// through the rename: drop the old `cli` package and install the new
+		// `entire` package. `scoop install` auto-refreshes the bucket when it
+		// is >3h stale (is_scoop_outdated), so the new `entire` manifest lands
+		// without an explicit refresh step. v0.9+ is already on `entire`.
+		if isPreRenameScoopVersion(currentVersion) {
 			return "scoop uninstall entire/cli && scoop install entire/entire"
 		}
-		return "scoop update entire/cli"
+		return "scoop update entire/entire"
 	}
 
 	if releaseChannel(currentVersion) == installChannelNightly {

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -420,7 +420,7 @@ func updateCommand(currentVersion string) string {
 		// is >3h stale (is_scoop_outdated), so the new `entire` manifest lands
 		// without an explicit refresh step. v0.9+ is already on `entire`.
 		if isPreRenameScoopVersion(currentVersion) {
-			return "scoop uninstall entire/cli && scoop install entire/entire"
+			return "scoop uninstall entire/cli; scoop install entire/entire"
 		}
 		return "scoop update entire/entire"
 	}

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -433,18 +433,17 @@ func updateCommand(currentVersion string) string {
 		// `entire` package, remove the old `cli` package, then reset the shared
 		// `entire.exe` shim (which uninstalling `cli` can take with it).
 		//
-		// These are three separate one-command lines, NOT a shell one-liner.
-		// The string is both auto-run and printed for the user to paste into an
-		// unknown shell (cmd, PowerShell, git-bash, WSL), so it must carry no
-		// `;`/`&&`/conditional. realRunInstaller runs each line as its own
-		// process and stops on the first failure, so the uninstall only runs
-		// once the install has succeeded — a stale bucket or transient failure
-		// never leaves the user without a working CLI. `scoop install` also
+		// The Windows updater is print-only, so return a self-contained command
+		// users can paste into either cmd or PowerShell. Explicitly invoking
+		// cmd.exe makes `&&` portable across those shells and ensures uninstall
+		// only runs after install succeeds; reset likewise requires a successful
+		// uninstall. A stale bucket or transient failure therefore never removes
+		// the working CLI. `scoop install` also
 		// auto-refreshes the bucket when >3h stale (is_scoop_outdated), so the
 		// new manifest lands without an explicit refresh. Binaries already on
 		// the `entire` app just update in place.
 		if scoopAppName() == "cli" {
-			return "scoop install entire/entire\nscoop uninstall entire/cli\nscoop reset entire"
+			return `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
 		}
 		return "scoop update entire/entire"
 	}

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -343,6 +343,21 @@ func releaseChannel(version string) string {
 	return installChannelStable
 }
 
+// normalizedExecPath returns the running binary's real path with all separators
+// normalized to forward slashes (symlinks resolved, best-effort). Both the
+// install-manager detection and the Scoop app-dir lookup key off this form.
+func normalizedExecPath() (string, error) {
+	execPath, err := executablePath()
+	if err != nil {
+		return "", err
+	}
+	realPath, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		realPath = execPath
+	}
+	return strings.ReplaceAll(filepath.ToSlash(realPath), "\\", "/"), nil
+}
+
 // scoopAppName returns the Scoop app directory the running binary lives under
 // — the path segment after `/scoop/apps/` (e.g. "cli" or "entire") — or ""
 // when the binary is not a Scoop install. This is the durable signal for the
@@ -350,15 +365,10 @@ func releaseChannel(version string) string {
 // `entire` regardless of its version (the fix ships in a final `cli` release,
 // so the migrating binary's version is already past the rename).
 func scoopAppName() string {
-	execPath, err := executablePath()
+	normalized, err := normalizedExecPath()
 	if err != nil {
 		return ""
 	}
-	realPath, err := filepath.EvalSymlinks(execPath)
-	if err != nil {
-		realPath = execPath
-	}
-	normalized := strings.ReplaceAll(filepath.ToSlash(realPath), "\\", "/")
 	_, rest, ok := strings.Cut(normalized, "/scoop/apps/")
 	if !ok {
 		return ""
@@ -370,16 +380,10 @@ func scoopAppName() string {
 }
 
 func installManagerForCurrentBinary() string {
-	execPath, err := executablePath()
+	normalizedPath, err := normalizedExecPath()
 	if err != nil {
 		return installManagerUnknown
 	}
-
-	realPath, err := filepath.EvalSymlinks(execPath)
-	if err != nil {
-		realPath = execPath
-	}
-	normalizedPath := strings.ReplaceAll(filepath.ToSlash(realPath), "\\", "/")
 
 	switch {
 	case strings.Contains(normalizedPath, "/Cellar/") ||

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -400,7 +400,7 @@ func TestUpdateCommand(t *testing.T) {
 			name:           "scoop cli app routes through package rename regardless of version",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return scoopExecutablePath, nil },
-			want:           "scoop install entire/entire; if ($?) { scoop uninstall entire/cli; scoop reset entire }",
+			want:           "scoop install entire/entire",
 		},
 		{
 			name:           "unknown path stable falls back to stable curl command",

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -400,7 +400,7 @@ func TestUpdateCommand(t *testing.T) {
 			name:           "scoop cli app routes through package rename regardless of version",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return scoopExecutablePath, nil },
-			want:           "scoop uninstall entire/cli; scoop install entire/entire",
+			want:           "scoop install entire/entire; if ($?) { scoop uninstall entire/cli; scoop reset entire }",
 		},
 		{
 			name:           "unknown path stable falls back to stable curl command",

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -346,7 +346,11 @@ func TestParseGitHubRelease(t *testing.T) {
 // it without tripping goconst on repeated string literals.
 const brewUpgradeCmd = "brew upgrade --yes entire"
 
+// scoopExecutablePath is the pre-rename `cli` app dir; scoopEntireExecutablePath
+// is the renamed `entire` app dir. The Scoop update command is chosen by which
+// app dir the binary runs from, not by version.
 const scoopExecutablePath = `C:\Users\test\scoop\apps\cli\current\entire.exe`
+const scoopEntireExecutablePath = `C:\Users\test\scoop\apps\entire\current\entire.exe`
 
 func TestUpdateCommand(t *testing.T) {
 	const plainBinPath = "/usr/local/bin/entire"
@@ -387,14 +391,14 @@ func TestUpdateCommand(t *testing.T) {
 			want:           "mise upgrade entire",
 		},
 		{
-			name:           "scoop path post-rename",
+			name:           "scoop entire app updates in place",
 			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return scoopExecutablePath, nil },
+			execPath:       func() (string, error) { return scoopEntireExecutablePath, nil },
 			want:           "scoop update entire/entire",
 		},
 		{
-			name:           "scoop path pre-rename routes through package rename",
-			currentVersion: "0.8.4",
+			name:           "scoop cli app routes through package rename regardless of version",
+			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return scoopExecutablePath, nil },
 			want:           "scoop uninstall entire/cli; scoop install entire/entire",
 		},
@@ -443,7 +447,7 @@ func TestUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "known installer returns command",
 			currentVersion: "1.2.3",
 			goos:           goosWindows,
-			execPath:       func() (string, error) { return scoopExecutablePath, nil },
+			execPath:       func() (string, error) { return scoopEntireExecutablePath, nil },
 			want:           "scoop update entire/entire",
 		},
 		{

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -352,8 +352,60 @@ const brewUpgradeCmd = "brew upgrade --yes entire"
 const scoopExecutablePath = `C:\Users\test\scoop\apps\cli\current\entire.exe`
 const scoopEntireExecutablePath = `C:\Users\test\scoop\apps\entire\current\entire.exe`
 
+// plainBinPath is a POSIX install under no recognized install manager.
+const plainBinPath = "/usr/local/bin/entire"
+
+// TestScoopAppName pins the signal the rename migration keys off. The ""
+// results matter most: they are what keeps the `== "cli"` comparison in
+// updateCommand from misfiring on a non-Scoop binary that happens to live in a
+// directory named `cli`.
+func TestScoopAppName(t *testing.T) {
+	tests := []struct {
+		name     string
+		execPath func() (string, error)
+		want     string
+	}{
+		{
+			name:     "pre-rename cli app dir",
+			execPath: func() (string, error) { return scoopExecutablePath, nil },
+			want:     "cli",
+		},
+		{
+			name:     "renamed entire app dir",
+			execPath: func() (string, error) { return scoopEntireExecutablePath, nil },
+			want:     "entire",
+		},
+		{
+			name:     "non-scoop path in a cli directory",
+			execPath: func() (string, error) { return `C:\tools\cli\entire.exe`, nil },
+			want:     "",
+		},
+		{
+			name:     "posix install",
+			execPath: func() (string, error) { return plainBinPath, nil },
+			want:     "",
+		},
+		{
+			name:     "executable path unavailable",
+			execPath: func() (string, error) { return "", errors.New("not found") },
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := executablePath
+			executablePath = tt.execPath
+			t.Cleanup(func() { executablePath = original })
+
+			if got := scoopAppName(); got != tt.want {
+				t.Errorf("scoopAppName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUpdateCommand(t *testing.T) {
-	const plainBinPath = "/usr/local/bin/entire"
 	tests := []struct {
 		name           string
 		currentVersion string
@@ -461,7 +513,7 @@ func TestUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "non-windows unknown installer returns curl command",
 			currentVersion: "1.2.3",
 			goos:           "linux",
-			execPath:       func() (string, error) { return "/usr/local/bin/entire", nil },
+			execPath:       func() (string, error) { return plainBinPath, nil },
 			want:           "curl -fsSL https://entire.io/install.sh | bash",
 		},
 	}

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -400,7 +400,7 @@ func TestUpdateCommand(t *testing.T) {
 			name:           "scoop cli app routes through package rename regardless of version",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return scoopExecutablePath, nil },
-			want:           "scoop install entire/entire\nscoop uninstall entire/cli\nscoop reset entire",
+			want:           `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`,
 		},
 		{
 			name:           "unknown path stable falls back to stable curl command",

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -400,7 +400,7 @@ func TestUpdateCommand(t *testing.T) {
 			name:           "scoop cli app routes through package rename regardless of version",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return scoopExecutablePath, nil },
-			want:           "scoop install entire/entire",
+			want:           "scoop install entire/entire\nscoop uninstall entire/cli\nscoop reset entire",
 		},
 		{
 			name:           "unknown path stable falls back to stable curl command",

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -393,6 +393,12 @@ func TestUpdateCommand(t *testing.T) {
 			want:           "scoop update entire/cli",
 		},
 		{
+			name:           "scoop path v8 routes through package rename",
+			currentVersion: "8.4.1",
+			execPath:       func() (string, error) { return scoopExecutablePath, nil },
+			want:           "scoop uninstall entire/cli && scoop install entire/entire",
+		},
+		{
 			name:           "unknown path stable falls back to stable curl command",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return plainBinPath, nil },

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -387,14 +387,14 @@ func TestUpdateCommand(t *testing.T) {
 			want:           "mise upgrade entire",
 		},
 		{
-			name:           "scoop path",
+			name:           "scoop path post-rename",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return scoopExecutablePath, nil },
-			want:           "scoop update entire/cli",
+			want:           "scoop update entire/entire",
 		},
 		{
-			name:           "scoop path v8 routes through package rename",
-			currentVersion: "8.4.1",
+			name:           "scoop path pre-rename routes through package rename",
+			currentVersion: "0.8.4",
 			execPath:       func() (string, error) { return scoopExecutablePath, nil },
 			want:           "scoop uninstall entire/cli && scoop install entire/entire",
 		},
@@ -444,7 +444,7 @@ func TestUpdateCommandForCurrentBinary(t *testing.T) {
 			currentVersion: "1.2.3",
 			goos:           goosWindows,
 			execPath:       func() (string, error) { return scoopExecutablePath, nil },
-			want:           "scoop update entire/cli",
+			want:           "scoop update entire/entire",
 		},
 		{
 			name:           "windows unknown installer returns releases URL",

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -396,7 +396,7 @@ func TestUpdateCommand(t *testing.T) {
 			name:           "scoop path pre-rename routes through package rename",
 			currentVersion: "0.8.4",
 			execPath:       func() (string, error) { return scoopExecutablePath, nil },
-			want:           "scoop uninstall entire/cli && scoop install entire/entire",
+			want:           "scoop uninstall entire/cli; scoop install entire/entire",
 		},
 		{
 			name:           "unknown path stable falls back to stable curl command",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,7 +63,7 @@ detect_os() {
         mingw*|msys*|cygwin*)
             error "install.sh does not support Windows, you can install the Entire CLI using scoop:
 
-    scoop install entire/cli
+    scoop install entire/entire
 
   Or download the Windows zip from:
     https://github.com/entireio/cli/releases/latest"


### PR DESCRIPTION
## Entire trail

[#1023 — Fix Scoop cli->entire upgrade path](https://entire.io/gh/entireio/cli/trails/1023)

## Summary

Keep existing Windows Scoop installs updating after the package rename from `cli` to `entire`, then guide users through a failure-safe migration to the canonical package.

## What Changed

- Publish `cli.json` as a temporary transition manifest alongside the canonical `entire.json`, so existing `cli` installs continue receiving releases.
- Detect whether the running binary belongs to Scoop's legacy `cli` app directory or the renamed `entire` directory.
- For legacy installs, print a Windows command that installs the replacement before removing the working package:

  ```text
  cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"
  ```

  Explicit `cmd.exe` invocation makes the command pasteable from cmd or PowerShell. The `&&` chain prevents uninstall when installation fails, so a stale bucket or transient error never removes the working CLI. The uninstall→reset link is weaker — `scoop uninstall` ends in an unconditional `exit 0` — but that is harmless: reset is a no-op on the Scoop versions where it isn't needed.
- Keep Windows updates print-only because a running `entire.exe` can lock the Scoop shim that the migration must replace.
- Scope `scoop reset` correctly in the comments: current Scoop already preserves the active shims across the uninstall (installing `entire` renames the displaced shim to `entire.shim.cli` via `warn_on_overwrite`, and uninstalling `cli` removes only that suffixed copy via `rm_shim`), so reset is belt-and-braces for older Scoop rather than the step keeping `entire.exe` and the git remote helper alive.
- Update the transition manifest message, README migration instructions, and `install.sh` Windows fallback to use `entire/entire`.
- Do not add an `entire` dependency to the transition manifest; the explicit migration controls shared-shim ownership and ordering.

The transition manifest should be removed after legacy installs have had a reasonable migration window.

## Verification

- `mise run fmt`
- golangci-lint v2.11.3 config verification and full lint: 0 issues
- shellcheck, module, mise, and gofmt lint tasks
- `mise run test:ci`
  - unit and integration tests with race detection
  - Vogon deterministic E2E canary: 60 passed
  - Roger Roger deterministic E2E canary: 4 passed
- `goreleaser check .goreleaser.yaml`
- `git diff --check`

