### PR TITLE
fix(trail): decode an approval's author as the login string the API sends

### DIFF
--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -138,13 +138,20 @@ type TrailDeleteResponse struct {
 }
 
 // TrailApproval is a single approval decision on a trail.
+//
+// Author is a GitHub login string, not a *trail.Author object — the approvals
+// endpoint sends `"author":"nodo"` where the trail resource sends
+// `"author":{"id":…,"login":…}`. Matching TrailThread/TrailMessage, which use the
+// same string shape. Declaring an object here made every populated response fail
+// to decode, so `entire trail approvals` worked only while there was nothing to
+// show (see TestTrailApprovalDecodesStringAuthor).
 type TrailApproval struct {
-	ID        string        `json:"id"`
-	Author    *trail.Author `json:"author"`
-	Event     string        `json:"event"` // "approved" | "changes_requested"
-	Body      string        `json:"body,omitempty"`
-	CommitSHA string        `json:"commit_sha,omitempty"`
-	CreatedAt time.Time     `json:"created_at"`
+	ID        string    `json:"id"`
+	Author    string    `json:"author"` // GitHub login
+	Event     string    `json:"event"`  // "approved" | "changes_requested"
+	Body      string    `json:"body,omitempty"`
+	CommitSHA string    `json:"commit_sha,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // TrailApprovalRequest is the body for POST .../:number/approvals.

--- a/cmd/entire/cli/api/trail_types_test.go
+++ b/cmd/entire/cli/api/trail_types_test.go
@@ -82,3 +82,72 @@ func TestToMetadataMapsTypePriorityReviewers(t *testing.T) {
 		t.Errorf("Reviewers = %#v, want one rev1", m.Reviewers)
 	}
 }
+
+// TestTrailApprovalDecodesStringAuthor pins the wire shape of an approval's
+// author. GET .../trails/{forge}/{owner}/{repo}/{number}/approvals sends it as a
+// plain GitHub login string:
+//
+//	{"approvals":[{"id":"59ef5b87","event":"approved","author":"nodo",…}]}
+//
+// This is deliberately unlike TrailResource.author, which is an
+// {"id":…,"login":…} object — so the two cannot share a type. Declaring the
+// approval's author as *trail.Author made every populated response fail to
+// decode with "cannot unmarshal string into Go struct field
+// TrailApproval.approvals.author", which meant `entire trail approvals` could
+// only ever print approvals it did not have: an empty list decodes fine, so a
+// trail with no approvals looked healthy while an approved trail errored out.
+func TestTrailApprovalDecodesStringAuthor(t *testing.T) {
+	t.Parallel()
+
+	// Verbatim response body from the production API.
+	const body = `{"approvals":[{"id":"59ef5b87","body":null,"event":"approved",` +
+		`"author":"nodo","commit_sha":"e9a9dcbf1fbc55580e7212096824a01e1691853d",` +
+		`"created_at":"2026-08-11T09:35:11.714Z"}]}`
+
+	var got TrailApprovalsResponse
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("decoding a real approvals response failed: %v", err)
+	}
+	if len(got.Approvals) != 1 {
+		t.Fatalf("Approvals len = %d, want 1", len(got.Approvals))
+	}
+
+	a := got.Approvals[0]
+	if a.Author != "nodo" {
+		t.Errorf("Author = %q, want %q", a.Author, "nodo")
+	}
+	if a.Event != "approved" {
+		t.Errorf("Event = %q, want approved", a.Event)
+	}
+	if a.CommitSHA != "e9a9dcbf1fbc55580e7212096824a01e1691853d" {
+		t.Errorf("CommitSHA = %q", a.CommitSHA)
+	}
+	// body:null must not become the string "null".
+	if a.Body != "" {
+		t.Errorf("Body = %q, want empty for a null body", a.Body)
+	}
+	if a.CreatedAt.IsZero() {
+		t.Error("CreatedAt did not decode")
+	}
+}
+
+// TestTrailApprovalResponseDecodesStringAuthor covers the POST path. It embeds the
+// same struct, so `entire trail approve` reported a decode failure *after* the
+// server had already recorded the approval.
+func TestTrailApprovalResponseDecodesStringAuthor(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"ok":true,"approval":{"id":"9f65e574","event":"approved",` +
+		`"author":"nodo","created_at":"2026-08-11T09:35:34.998Z"}}`
+
+	var got TrailApprovalResponse
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("decoding a real approve response failed: %v", err)
+	}
+	if !got.OK {
+		t.Error("OK = false, want true")
+	}
+	if got.Approval.Author != "nodo" {
+		t.Errorf("Approval.Author = %q, want nodo", got.Approval.Author)
+	}
+}

--- a/cmd/entire/cli/trail_approval_cmd.go
+++ b/cmd/entire/cli/trail_approval_cmd.go
@@ -183,20 +183,24 @@ func runTrailApprovals(ctx context.Context, w, errW io.Writer, insecureHTTP bool
 			fmt.Fprintf(w, "No approvals on trail #%d\n", found.Number)
 			return nil
 		}
-		for _, a := range out.Approvals {
-			login := ""
-			if a.Author != nil && a.Author.Login != nil {
-				login = *a.Author.Login
-			}
-			sha := a.CommitSHA
-			if len(sha) > 7 {
-				sha = sha[:7]
-			}
-			fmt.Fprintf(w, "%s  %s  %s  %s\n", a.Event, login, sha, a.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-			if strings.TrimSpace(a.Body) != "" {
-				fmt.Fprintf(w, "    %s\n", a.Body)
-			}
-		}
+		renderTrailApprovals(w, out.Approvals)
 		return nil
 	})
+}
+
+// renderTrailApprovals prints one line per approval decision, plus an indented
+// body when the reviewer left one. Split out so the render path is covered without
+// a live API — the decode bug it exercises could only be seen against a trail that
+// actually had approvals.
+func renderTrailApprovals(w io.Writer, approvals []api.TrailApproval) {
+	for _, a := range approvals {
+		sha := a.CommitSHA
+		if len(sha) > 7 {
+			sha = sha[:7]
+		}
+		fmt.Fprintf(w, "%s  %s  %s  %s\n", a.Event, a.Author, sha, a.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
+		if strings.TrimSpace(a.Body) != "" {
+			fmt.Fprintf(w, "    %s\n", a.Body)
+		}
+	}
 }

--- a/cmd/entire/cli/trail_approval_cmd_test.go
+++ b/cmd/entire/cli/trail_approval_cmd_test.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
 )
 
 func TestBuildApprovalRequestRequiresMessageForRequestChanges(t *testing.T) {
@@ -48,5 +52,49 @@ func TestTrailApprovalCmdsHaveExpectedFlags(t *testing.T) {
 	}
 	if newTrailApprovalsCmd().Flags().Lookup("json") == nil {
 		t.Error("approvals missing --json")
+	}
+}
+
+// TestRenderTrailApprovalsShowsAuthorLogin covers the render path that the
+// author-shape mismatch broke. The approvals endpoint sends `"author":"nodo"`, so
+// the login must reach the output; when this was decoded as a *trail.Author the
+// whole response failed before rendering and the command printed only an error.
+func TestRenderTrailApprovalsShowsAuthorLogin(t *testing.T) {
+	t.Parallel()
+
+	created, err := time.Parse(time.RFC3339, "2026-08-11T09:35:11Z")
+	if err != nil {
+		t.Fatalf("parse time: %v", err)
+	}
+	approvals := []api.TrailApproval{
+		{
+			ID:        "59ef5b87",
+			Author:    "nodo",
+			Event:     "approved",
+			CommitSHA: "e9a9dcbf1fbc55580e7212096824a01e1691853d",
+			CreatedAt: created,
+		},
+		{
+			ID:        "9f65e574",
+			Author:    "reviewer2",
+			Event:     "changes_requested",
+			Body:      "needs a test",
+			CommitSHA: "d55dfa6",
+			CreatedAt: created,
+		},
+	}
+
+	var buf bytes.Buffer
+	renderTrailApprovals(&buf, approvals)
+	out := buf.String()
+
+	for _, want := range []string{"approved", "nodo", "e9a9dcb", "changes_requested", "reviewer2", "needs a test"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// The 40-char SHA is abbreviated, so the full hash must not appear.
+	if strings.Contains(out, "e9a9dcbf1fbc55580e7212096824a01e1691853d") {
+		t.Errorf("commit SHA should be abbreviated:\n%s", out)
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1007
<!-- entire-trail-link-end -->

## Problem

`entire trail approvals` fails on **every trail that has an approval**:

```
failed to decode approvals response: decode JSON response: json: cannot unmarshal
string into Go struct field TrailApproval.approvals.author of type trail.Author
```

The approvals endpoint sends the author as a plain GitHub login; `TrailApproval` declared it as an object. Both shapes verified against production:

```jsonc
// GET /api/v1/trails/gh/{owner}/{repo}/{n}          → author is an OBJECT
"author": {"id": "e45976d7-…", "login": "Soph"}

// GET /api/v1/trails/gh/{owner}/{repo}/{n}/approvals → author is a STRING
"author": "nodo"
```

`TrailThread` and `TrailMessage` already use `Author string // GitHub login` for this field (`trail_thread_types.go:13,21`), so the approval type was the one that diverged.

**The failure mode hid itself.** An empty array decodes fine, so a trail with *no* approvals printed a healthy `No approvals on trail #N`, while an approved trail errored out. The CLI could only display approval state when there was none to display. I hit this while checking whether three of my own PRs had been approved — the CLI said one had none and two were broken; the API showed all three approved.

**`entire trail approve` is affected too, and worse.** `TrailApprovalResponse` embeds the same struct, and `submitTrailApproval` decodes into it *after* `POST .../approvals` has already succeeded — so approving reported `failed to decode approval response` for an operation that had actually gone through. Same for `request-changes`.

## Fix

`TrailApproval.Author` becomes `string`, matching the wire format and the sibling thread types. `TrailResource.Author` stays `*trail.Author` — that endpoint really does send an object.

## Verification

Live, against all three of my open trails — before (binary from `main`) and after:

```
BEFORE  trail 997: failed to decode approvals response: … of type trail.Author
        trail 998: failed to decode approvals response: … of type trail.Author
        trail 999: failed to decode approvals response: … of type trail.Author

AFTER   trail 997: approved  nodo  e9a9dcb  2026-08-11T09:35:11Z
        trail 998: approved  nodo  d55dfa6  2026-08-11T09:35:34Z
        trail 999: approved  nodo  80094e5  2026-08-11T09:37:35Z
```

`--json` output verified as well.

## Tests

- `TestTrailApprovalDecodesStringAuthor` / `TestTrailApprovalResponseDecodesStringAuthor` — decode the **verbatim production response bodies** for the GET collection and the POST result, so the wire contract is pinned rather than paraphrased. Both also assert `body:null` does not become `"null"`. **Verified RED** (compile error against the old type, which is the strongest form here).
- `TestRenderTrailApprovalsShowsAuthorLogin` — the render path, extracted as `renderTrailApprovals` so it is testable without a live API. It covers both `approved` and `changes_requested`, the indented review body, and SHA abbreviation. This matters because the bug was only reachable through a trail that actually had approvals; no existing test could see it.

`mise run check` passes (fmt, lint, unit + integration + canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI JSON decoding and display only; no auth or server behavior changes, with regression tests on production-shaped payloads.
> 
> **Overview**
> Fixes **`entire trail approvals`**, **`approve`**, and **`request-changes`** when the API returns real approval data. The approvals endpoints send **`author` as a plain login string** (like thread messages), but **`TrailApproval`** modeled it as **`*trail.Author`**, so JSON decode failed on any non-empty list—and empty lists still looked fine.
> 
> **`TrailApproval.Author`** is now a **`string`**, aligned with **`TrailThread` / `TrailMessage`**. **`TrailResource.Author`** stays an object for the trail detail shape. Listing output goes through **`renderTrailApprovals`**, which prints the login directly. Tests pin **verbatim production GET/POST bodies** and cover the text render path (author, abbreviated SHA, review body).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c809390a20ffc8d3ebf32236be017ac39ae1deba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->