### PR TITLE
fix(subagent): skip the task checkpoint when the subagent already committed

### DIFF
--- a/cmd/entire/cli/integration_test/subagent_commit_in_turn_test.go
+++ b/cmd/entire/cli/integration_test/subagent_commit_in_turn_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// TestSubagentCheckpoints_CommittedMidTurn_LeavesNoShadowBranch reproduces the
+// orphaned shadow branch behind the e2e failure of
+// TestSingleSessionSubagentCommitInTurn.
+//
+// The subagent writes a file and commits it itself, mid-turn. That commit condenses
+// the session and deletes the shadow branch. post-task then fires with nothing left
+// to snapshot — the file is already in HEAD — so it must skip the task checkpoint.
+// Creating one instead mints a *new* shadow branch after condensation has already
+// run, and nothing ever condenses it away: turn-end sees no file modifications and
+// skips, so the branch outlives the session.
+//
+// The trap is that the subagent's transcript still records the Write. Deciding from
+// the transcript alone conflates "the subagent wrote this at some point" with "there
+// is an uncommitted change here" — see filterToUncommittedFiles, which the turn-end
+// path already applies for exactly this reason.
+func TestSubagentCheckpoints_CommittedMidTurn_LeavesNoShadowBranch(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+	session := env.NewSession()
+	session.CreateTranscript("use a subagent to write docs/red.md and commit it", nil)
+
+	const (
+		taskToolUseID = "toolu_01CommitInTurn"
+		subagentID    = "a0011223344556677"
+		editedFile    = "docs/red.md"
+	)
+	// The subagent's own transcript records the Write; the main transcript does not.
+	session.CreateSubagentTranscript(subagentID, []FileChange{{Path: editedFile, Content: "Red is warm.\n"}})
+
+	if err := env.SimulateUserPromptSubmit(session.ID); err != nil {
+		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+	}
+	if err := env.SimulatePreTask(session.ID, session.TranscriptPath, taskToolUseID); err != nil {
+		t.Fatalf("SimulatePreTask failed: %v", err)
+	}
+
+	// The subagent writes the file and commits it itself, still inside the turn.
+	env.WriteFile(editedFile, "Red is a warm colour.\n")
+	env.GitCommitWithShadowHooksAsAgent("Add red.md", editedFile)
+
+	// Condensation ran on that commit and cleaned up the shadow branch.
+	if got := shadowBranches(env); len(got) != 0 {
+		t.Fatalf("precondition: shadow branch should be gone after the mid-turn commit, got %v", got)
+	}
+
+	if err := env.SimulatePostTask(PostTaskInput{
+		SessionID:      session.ID,
+		TranscriptPath: session.TranscriptPath,
+		ToolUseID:      taskToolUseID,
+		AgentID:        subagentID,
+	}); err != nil {
+		t.Fatalf("SimulatePostTask failed: %v", err)
+	}
+
+	if got := shadowBranches(env); len(got) != 0 {
+		t.Errorf("post-task created a shadow branch for already-committed work: %v\n"+
+			"nothing will condense it away — turn-end skips when no files changed", got)
+	}
+}
+
+// TestSubagentCheckpoints_UncommittedWork_StillCheckpoints is the companion guard:
+// filtering already-committed paths must not stop a subagent whose work is still
+// uncommitted from getting its task checkpoint.
+func TestSubagentCheckpoints_UncommittedWork_StillCheckpoints(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+	session := env.NewSession()
+	session.CreateTranscript("use a subagent to write docs/blue.md", nil)
+
+	const (
+		taskToolUseID = "toolu_01UncommittedWork"
+		subagentID    = "a7766554433221100"
+		editedFile    = "docs/blue.md"
+	)
+	session.CreateSubagentTranscript(subagentID, []FileChange{{Path: editedFile, Content: "Blue is cool.\n"}})
+
+	if err := env.SimulateUserPromptSubmit(session.ID); err != nil {
+		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+	}
+	if err := env.SimulatePreTask(session.ID, session.TranscriptPath, taskToolUseID); err != nil {
+		t.Fatalf("SimulatePreTask failed: %v", err)
+	}
+
+	// Left uncommitted, unlike the test above.
+	env.WriteFile(editedFile, "Blue is a cool colour.\n")
+
+	if err := env.SimulatePostTask(PostTaskInput{
+		SessionID:      session.ID,
+		TranscriptPath: session.TranscriptPath,
+		ToolUseID:      taskToolUseID,
+		AgentID:        subagentID,
+	}); err != nil {
+		t.Fatalf("SimulatePostTask failed: %v", err)
+	}
+
+	wantPath := ".entire/metadata/" + session.ID + "/tasks/" + taskToolUseID + "/checkpoint.json"
+	if !env.FileExistsInBranch(env.GetShadowBranchName(), wantPath) {
+		t.Errorf("task checkpoint missing for uncommitted subagent work (%s)", wantPath)
+	}
+}
+
+// shadowBranches returns the per-base-commit shadow branches, excluding the
+// permanent committed-checkpoint branch which is not session-scoped.
+func shadowBranches(env *TestEnv) []string {
+	var out []string
+	for _, b := range env.ListBranchesWithPrefix("entire/") {
+		if b == paths.MetadataBranchName {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
+}

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -1203,9 +1203,22 @@ func handleLifecycleSubagentEnd(ctx context.Context, ag agent.Agent, event *agen
 		return fmt.Errorf("failed to get worktree root: %w", err)
 	}
 
-	relModifiedFiles := FilterAndNormalizePaths(modifiedFiles, repoRoot)
+	// The transcript records what the subagent wrote at some point in its run, not
+	// what is still uncommitted. When the subagent committed its own work mid-turn
+	// (the scenario TestSingleSessionSubagentCommitInTurn covers), that commit has
+	// already condensed the session and deleted the shadow branch, so there is
+	// nothing left to snapshot. Keeping those paths defeats the "no changes, skip"
+	// gate below and mints a *new* shadow branch after condensation — which nothing
+	// then condenses away, because turn-end skips when no files changed, so it
+	// outlives the session.
+	//
+	// filterToUncommittedFiles is the same guard the turn-end path already applies
+	// for this exact reason; it fails open, so a git error keeps the list as-is
+	// rather than silently dropping a real checkpoint.
+	relModifiedFiles := filterToUncommittedFiles(ctx, FilterAndNormalizePaths(modifiedFiles, repoRoot), repoRoot)
 	var relNewFiles, relDeletedFiles []string
 	if changes != nil {
+		// changes come from git status, so they are uncommitted by construction.
 		relNewFiles = FilterAndNormalizePaths(changes.New, repoRoot)
 		relDeletedFiles = FilterAndNormalizePaths(changes.Deleted, repoRoot)
 		relModifiedFiles = mergeUnique(relModifiedFiles, FilterAndNormalizePaths(changes.Modified, repoRoot))


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1009
<!-- entire-trail-link-end -->

## main is red

[Run 31493707365](https://github.com/entireio/cli/actions/runs/31493707365) — `TestSingleSessionSubagentCommitInTurn/claude-code` fails on **both** linux and windows (56/60 passed; every other test and agent is green):

```
shadow branches should be cleaned up within 10s after commit,
found: [entire/695dbd1-e3b0c4]
```

## Cause: #1935, via a latent flaw it exposed

Lifecycle logs from the failing run vs. the last green run on main — same test, same agent — differ in exactly one line, and in what follows from it:

```
before: subagent completed  subagent_transcript=None
        no file changes detected, skipping task checkpoint     ← skipped
after:  subagent completed  subagent_transcript=/tmp/…/subagents/agent-ae63b3ba….jsonl
        created shadow branch and committed task checkpoint    ← no longer skipped
```

That first line is the fingerprint of 35e9b8939 (#1935), which taught `SubagentEnd` to resolve the subagent transcript. **The checkpoint logic did not change** — #1935 supplied a correct input, and that exposed a flaw already sitting in the skip gate.

Sequence in the failing run:

1. `13:04:00` — the subagent commits its own work mid-turn. That commit condenses the session and **deletes** the shadow branch.
2. `13:04:02` — `post-task` fires. The gate is `len(relModifiedFiles) == 0 && len(relNewFiles) == 0 && len(relDeletedFiles) == 0`. The new/deleted lists come from git status and are empty (already committed). `relModifiedFiles` came from scanning a **transcript**: pre-#1935 that was the *main* transcript, which never records a subagent's `Write`, so the list was empty and the checkpoint skipped **by accident**. Now it reads the subagent's own transcript, finds the `Write`, and creates a task checkpoint — minting a **new shadow branch after condensation already ran**.
3. `13:04:04` — turn-end sees no file modifications and skips. Nothing ever condenses that branch, so it outlives the session and trips the 10s assertion.

The gate conflated a **historical** signal ("the subagent wrote this at some point") with **current** worktree state ("this differs from HEAD").

## Fix

Run the transcript-derived paths through `filterToUncommittedFiles` before the gate. That helper already exists and is already applied on the turn-end path (`lifecycle.go:946`) for precisely this case — its doc says it "prevents re-adding files that an agent committed mid-turn (already condensed by PostCommit)". The subagent path simply never got the same treatment; this PR removes that asymmetry rather than adding a new mechanism.

It fails open, so a git error keeps the list as-is rather than silently dropping a real checkpoint. Paths from `git status` need no filtering — they are uncommitted by construction.

## Why nothing caught it

- **#1935's own CI run was cancelled**, superseded by the next push 90 seconds later, so it landed unobserved and surfaced on #1938's run. #1938 is innocent.
- **The canary can't catch it**: Vogon fires no subagent hooks at all, so `test:e2e:canary` never exercises this path (noted in the earlier subagent-tracking review as a coverage gap).

## Tests

- `TestSubagentCheckpoints_CommittedMidTurn_LeavesNoShadowBranch` — drives pre-task → mid-turn commit → post-task in-process and asserts no shadow branch survives. **Verified RED** on this branch before the fix, reproducing the CI failure exactly:
  ```
  post-task created a shadow branch for already-committed work: [entire/a844937-e3b0c4]
  ```
  This closes the coverage gap: the failure is now reachable without a real agent.
- `TestSubagentCheckpoints_UncommittedWork_StillCheckpoints` — companion guard that filtering already-committed paths does not stop a subagent whose work is still uncommitted from getting its task checkpoint.

`mise run check` passes (fmt, lint, unit + integration + canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subagent checkpoint lifecycle and shadow-branch behavior; change is localized and mirrors an existing turn-end path with fail-open semantics.
> 
> **Overview**
> Fixes **orphaned shadow branches** when a subagent commits its own work mid-turn and `post-task` still sees `Write` paths in the subagent transcript.
> 
> **`handleLifecycleSubagentEnd`** now runs transcript-derived modified paths through **`filterToUncommittedFiles`** before the “no changes → skip checkpoint” gate—the same guard **turn-end** already uses. That stops treating historical transcript writes as uncommitted work after condensation removed the shadow branch; git-status new/deleted lists are unchanged (already uncommitted).
> 
> Adds integration coverage: **`TestSubagentCheckpoints_CommittedMidTurn_LeavesNoShadowBranch`** (no shadow branch after post-task) and **`TestSubagentCheckpoints_UncommittedWork_StillCheckpoints`** (task checkpoint still created when work is left uncommitted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5a26a85c9cd7b063b7d625cfcd73c0b3cfba382. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->