### PR TITLE
Add search_id, explain hints, and search relevance telemetry (ENT-1528)

### DIFF
--- a/cmd/entire/cli/api/client.go
+++ b/cmd/entire/cli/api/client.go
@@ -145,6 +145,14 @@ func (c *Client) GetStream(ctx context.Context, path string, headers http.Header
 	return c.do(ctx, http.MethodGet, path, nil, headers)
 }
 
+// GetWithHeaders sends an authenticated GET request with extra request
+// headers (e.g. correlation ids) and returns the fully-buffered-by-caller
+// response. Intended for normal (non-streaming) JSON endpoints that still
+// need to send headers beyond what Get sends; for streaming use GetStream.
+func (c *Client) GetWithHeaders(ctx context.Context, path string, headers http.Header) (*http.Response, error) {
+	return c.do(ctx, http.MethodGet, path, nil, headers)
+}
+
 // doJSON sends an authenticated request with an optional JSON-marshaled body.
 func (c *Client) doJSON(ctx context.Context, method, path string, body any) (*http.Response, error) {
 	var reader io.Reader

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -429,10 +429,6 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 	cmd.Flags().BoolVar(&insecureHTTPFlag, "insecure-http-auth", false, "Allow plain-HTTP auth for --repo (local dev only)")
 	cmd.Flags().IntVar(&summaryTimeoutSecondsFlag, "summary-timeout-seconds", 0, "Hard deadline in seconds for --generate summary generation; overrides summary_timeout_seconds setting. 0 = use setting; if setting is also unset or 0, no automatic deadline applies.")
 	cmd.Flags().StringVar(&searchIDFlag, "search-id", "", "Search attribution token from a search result's explain hint (search-id[:rank]); used only for relevance telemetry")
-	// Attribution metadata, not a behavior switch — hidden to keep help focused.
-	if err := cmd.Flags().MarkHidden("search-id"); err != nil {
-		panic(fmt.Sprintf("hide search-id flag: %v", err))
-	}
 
 	// Verbosity / transcript output modes are mutually exclusive
 	cmd.MarkFlagsMutuallyExclusive("short", "full", "raw-transcript", "transcript", "json")

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -31,6 +31,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/summarize"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
 	transcriptcompact "github.com/entireio/cli/cmd/entire/cli/transcript/compact"
@@ -757,6 +758,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		return &explainTargetNotFoundError{target: checkpointIDPrefix}
 	case 1:
 		fullCheckpointID = matches[0]
+		emitCheckpointExplained(ctx, string(fullCheckpointID), telemetry.ExplainSourceProse)
 	default:
 		// Ambiguous prefix: render styled failure block, return SilentError so
 		// main.go does not double-print. Matches the temporary-side and

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -239,6 +239,7 @@ func newExplainCmd() *cobra.Command {
 	var repoFlag string
 	var insecureHTTPFlag bool
 	var summaryTimeoutSecondsFlag int
+	var searchIDFlag string
 	sessionIndex := -1
 	listLimit := 0 // 0 means "use default (branchCheckpointsLimit)"
 
@@ -309,6 +310,11 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Attach the --search-id attribution (from a compact search hint)
+			// to the context so every explain path's telemetry emit can read
+			// it without threading a parameter through the call chains.
+			cmd.SetContext(withExplainSearchHit(cmd.Context(), searchIDFlag))
+
 			// Check if Entire is disabled
 			if checkDisabledGuard(cmd.Context(), cmd.OutOrStdout()) {
 				return nil
@@ -422,6 +428,11 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 	cmd.Flags().StringVar(&repoFlag, "repo", "", "Explain a checkpoint owned by another repo (owner/name or gh/owner/name), read from that repo's Entire API")
 	cmd.Flags().BoolVar(&insecureHTTPFlag, "insecure-http-auth", false, "Allow plain-HTTP auth for --repo (local dev only)")
 	cmd.Flags().IntVar(&summaryTimeoutSecondsFlag, "summary-timeout-seconds", 0, "Hard deadline in seconds for --generate summary generation; overrides summary_timeout_seconds setting. 0 = use setting; if setting is also unset or 0, no automatic deadline applies.")
+	cmd.Flags().StringVar(&searchIDFlag, "search-id", "", "Search attribution token from a search result's explain hint (search-id[:rank]); used only for relevance telemetry")
+	// Attribution metadata, not a behavior switch — hidden to keep help focused.
+	if err := cmd.Flags().MarkHidden("search-id"); err != nil {
+		panic(fmt.Sprintf("hide search-id flag: %v", err))
+	}
 
 	// Verbosity / transcript output modes are mutually exclusive
 	cmd.MarkFlagsMutuallyExclusive("short", "full", "raw-transcript", "transcript", "json")

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -120,7 +120,6 @@ func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explai
 	}
 	switch len(matches) {
 	case 1:
-		emitCheckpointExplained(ctx, string(matches[0]), telemetry.ExplainSourceExport)
 		return matches[0], lookup, nil
 	case 0:
 		// If the user passed a positional target (not --checkpoint), give it
@@ -363,6 +362,10 @@ func runExplainStreamTranscript(ctx context.Context, w, errW io.Writer, opts exp
 		return err
 	}
 	defer lookup.Close()
+	// Emitted here rather than inside resolveExplainCheckpointID: the resolver
+	// is shared with `entire checkpoint tokens`, which must not pollute the
+	// search→explain funnel (ENT-1528).
+	emitCheckpointExplained(ctx, string(cpID), telemetry.ExplainSourceExport)
 
 	store := lookup.store
 	summary, err := checkpoint.ReadCheckpoint(ctx, store, cpID)
@@ -469,6 +472,10 @@ func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts expla
 		return err
 	}
 	defer lookup.Close()
+	// Emitted here rather than inside resolveExplainCheckpointID: the resolver
+	// is shared with `entire checkpoint tokens`, which must not pollute the
+	// search→explain funnel (ENT-1528).
+	emitCheckpointExplained(ctx, string(cpID), telemetry.ExplainSourceExport)
 
 	store := lookup.store
 	summary, err := checkpoint.ReadCheckpoint(ctx, store, cpID)

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -15,6 +15,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 )
 
@@ -119,6 +120,7 @@ func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explai
 	}
 	switch len(matches) {
 	case 1:
+		emitCheckpointExplained(ctx, string(matches[0]), telemetry.ExplainSourceExport)
 		return matches[0], lookup, nil
 	case 0:
 		// If the user passed a positional target (not --checkpoint), give it

--- a/cmd/entire/cli/explain_repo.go
+++ b/cmd/entire/cli/explain_repo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 )
 
 // crossRepoReader is the read surface cross-repo explain needs: the two
@@ -187,6 +188,7 @@ func runCrossRepoExplain(ctx context.Context, w, errW io.Writer, opts crossRepoE
 		stop(false)
 		return fmt.Errorf("checkpoint %s is not available for %s", cid, ownerRepo)
 	}
+	emitCheckpointExplained(ctx, string(cid), telemetry.ExplainSourceCrossRepo)
 
 	switch {
 	case opts.transcript || opts.rawTranscript:

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1586,6 +1586,18 @@ func TestExplainCmd_HasRawTranscriptFlag(t *testing.T) {
 	}
 }
 
+func TestExplainCmd_SearchIDFlagNotHidden(t *testing.T) {
+	cmd := newExplainCmd()
+
+	flag := cmd.Flags().Lookup("search-id")
+	if flag == nil {
+		t.Fatal("expected --search-id flag to exist")
+	}
+	if flag.Hidden {
+		t.Error("expected --search-id to be visible in help/agent-help, got Hidden=true")
+	}
+}
+
 func TestRunExplain_MutualExclusivityError(t *testing.T) {
 	var buf, errBuf bytes.Buffer
 

--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -15,6 +15,7 @@ import (
 	ulid "github.com/oklog/ulid/v2"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 const apiTimeout = 30 * time.Second
@@ -444,6 +445,13 @@ type Config struct {
 	Date     string // Filter by time period: "week" or "month"
 	Branch   string // Filter by branch name
 	Page     int    // 1-based page number (0 means omit, API defaults to 1)
+
+	// SearchID and ClientSurface are correlation metadata only: they travel
+	// as request headers (X-Entire-Search-Id, X-Entire-Client), never as part
+	// of the query, so the search service can log the same search_id the CLI
+	// uses client-side. Both are optional; an empty value omits its header.
+	SearchID      string // Minted by the caller before the request (see newSearchID)
+	ClientSurface string // e.g. "cli-compact", "cli-json", "cli-tui"
 }
 
 // ScopeSlugs resolves the repo scope of a search: the explicit repo filters
@@ -656,7 +664,17 @@ func CellV4(ctx context.Context, client *api.Client, cfg Config, repoIDs []strin
 	}
 	addCommonSearchParams(q, cfg)
 
-	resp, err := client.Get(ctx, v4ServicePath+"?"+q.Encode())
+	// Correlation metadata rides as headers, never as query params, so it
+	// can't leak into logs that capture the request line/query string.
+	headers := http.Header{}
+	if cfg.SearchID != "" {
+		headers.Set("X-Entire-Search-Id", cfg.SearchID)
+	}
+	if cfg.ClientSurface != "" {
+		headers.Set("X-Entire-Client", cfg.ClientSurface+"/"+versioninfo.Version)
+	}
+
+	resp, err := client.GetWithHeaders(ctx, v4ServicePath+"?"+q.Encode(), headers)
 	if err != nil {
 		return nil, fmt.Errorf("calling search service: %w", err)
 	}

--- a/cmd/entire/cli/search/search_v4_test.go
+++ b/cmd/entire/cli/search/search_v4_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
@@ -137,6 +139,33 @@ func TestCellV4_ErrorForwarded(t *testing.T) {
 	_, err := CellV4(context.Background(), api.NewClientWithBaseURL("tok", srv.URL), Config{Query: "q"}, nil)
 	if err == nil {
 		t.Fatal("expected an error for a 400 response")
+	}
+}
+
+// TestCellV4_SendsSearchCorrelationHeaders confirms the pre-request-minted
+// search_id and the client-surface identifier travel as headers (never as
+// query params) so the search service can log the same id server-side.
+func TestCellV4_SendsSearchCorrelationHeaders(t *testing.T) {
+	t.Parallel()
+
+	var gotID, gotClient string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotID = r.Header.Get("X-Entire-Search-Id")
+		gotClient = r.Header.Get("X-Entire-Client")
+		fmt.Fprint(w, `{"results":[],"total":0,"page":1}`)
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	cfg := Config{Query: "x", SearchID: "01JXK9RSTQ4B7NW2VYFCH6M3DZ", ClientSurface: "cli-compact"}
+	if _, err := CellV4(context.Background(), client, cfg, nil); err != nil {
+		t.Fatal(err)
+	}
+	if gotID != cfg.SearchID {
+		t.Errorf("X-Entire-Search-Id = %q, want %q", gotID, cfg.SearchID)
+	}
+	if !strings.HasPrefix(gotClient, "cli-compact/") {
+		t.Errorf("X-Entire-Client = %q, want prefix 'cli-compact/'", gotClient)
 	}
 }
 

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/search"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/internal/coreapi"
 	"github.com/spf13/cobra"
 )
@@ -273,8 +274,22 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 				searchCfg.ClientSurface = "cli-tui"
 			}
 
+			// Mode is fixed by compactOutput before the request goes out, so
+			// the error path below (no response yet) can still tag its event
+			// correctly.
+			mode := "json"
+			if compactOutput {
+				mode = "compact"
+			}
+
 			resp, err := searcher(ctx, searchCfg)
 			if err != nil {
+				// Only JSON-mode invocations emit telemetry (mirrors the
+				// success-path guard below): the interactive TUI handles its
+				// own re-search failures and shouldn't double-emit.
+				if jsonOutput || !isTerminal {
+					emitSearchPerformed(ctx, buildSearchPerformedEvent(searchCfg, mode, "error_request", nil, 0, 0, 0))
+				}
 				return fmt.Errorf("search failed: %w", err)
 			}
 			for _, warning := range resp.Warnings {
@@ -283,19 +298,17 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 
 			// JSON output: explicit flag or piped/redirected stdout
 			if jsonOutput || !isTerminal {
-				mode := "json"
-				var served int
+				var served, normLimit, normPage int
 				var writeErr error
 				if compactOutput {
-					mode = "compact"
-					served, writeErr = writeSearchCompactJSON(w, resp, requestedLimit, requestedPage, searchID, owner+"/"+repoName)
+					served, normLimit, normPage, writeErr = writeSearchCompactJSON(w, resp, requestedLimit, requestedPage, searchID, owner+"/"+repoName)
 				} else {
-					served, writeErr = writeSearchJSON(w, resp, requestedLimit, requestedPage, searchID)
+					served, normLimit, normPage, writeErr = writeSearchJSON(w, resp, requestedLimit, requestedPage, searchID)
 				}
 				if writeErr != nil {
 					return writeErr
 				}
-				emitSearchPerformed(ctx, searchID, mode, served, len(resp.Results), requestedPage, requestedLimit)
+				emitSearchPerformed(ctx, buildSearchPerformedEvent(searchCfg, mode, "ok", resp, served, normLimit, normPage))
 				return nil
 			}
 
@@ -969,6 +982,44 @@ func isASCII(s string) bool {
 	return true
 }
 
+// buildSearchPerformedEvent assembles a cli_search_performed telemetry event
+// (ENT-1528) from the request config, the (optional) server response, and
+// the writer-normalized pagination. Shared by RunE's two emit sites — the
+// success path passes the real resp/served/normLimit/normPage, the error
+// path (search failed before any response existed) passes resp == nil and
+// zero counts. Total is always resp.Total, the server's honest match count —
+// never derived from served/len(results), so a short or filtered page never
+// masquerades as "few matches". AllRepos is ScopeSlugs' second return: an
+// explicit --repo filter beats --all-repos.
+func buildSearchPerformedEvent(cfg search.Config, mode, outcome string, resp *search.Response, served, normLimit, normPage int) telemetry.SearchPerformedEvent {
+	_, allRepos := cfg.ScopeSlugs()
+	event := telemetry.SearchPerformedEvent{
+		SearchID:     cfg.SearchID,
+		Mode:         mode,
+		Outcome:      outcome,
+		QueryLength:  utf8.RuneCountInString(cfg.Query),
+		Page:         normPage,
+		Limit:        normLimit,
+		AllRepos:     allRepos,
+		FilterAuthor: cfg.Author != "",
+		FilterDate:   cfg.Date != "",
+		FilterBranch: cfg.Branch != "",
+		FilterRepo:   len(cfg.Repos) > 0,
+	}
+	if resp == nil {
+		return event
+	}
+	event.FetchedCount = served
+	event.Total = resp.Total
+	event.ZeroResults = resp.Total == 0
+	event.Reranked = resp.Reranked != nil && *resp.Reranked
+	if resp.Timing != nil && resp.Timing.TotalMs != nil {
+		event.TotalMS = int(*resp.Timing.TotalMs)
+	}
+	event.Degraded = len(resp.Warnings) > 0
+	return event
+}
+
 // paginateSearchResults slices results for the requested client-side page,
 // normalizing limit and page, and returns the page slice (never nil) plus the
 // normalized pagination values.
@@ -999,11 +1050,13 @@ func paginateSearchResults(results []search.Result, limit, page int) (pageResult
 }
 
 // writeSearchJSON writes client-side paginated search results as JSON and
-// returns the number of results served. searchID ties the response to its
-// cli_search_performed telemetry event (ENT-1528); it is minted client-side
-// because the server response carries no request id and the CLI merges
-// several cell responses into one page.
-func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int, searchID string) (int, error) {
+// returns the number of results served plus the normalized limit/page
+// (paginateSearchResults already computes both; the caller needs them for
+// the cli_search_performed telemetry event, ENT-1528). searchID ties the
+// response to that event; it is minted client-side because the server
+// response carries no request id and the CLI merges several cell responses
+// into one page.
+func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int, searchID string) (served, normLimit, normPage int, err error) {
 	pageResults, total, totalPages, limit, page := paginateSearchResults(resp.Results, limit, page)
 
 	out := struct {
@@ -1023,12 +1076,12 @@ func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int, search
 		SearchID:   searchID,
 		Counts:     resp.Counts,
 	}
-	data, err := jsonutil.MarshalIndentWithNewline(out, "", "  ")
-	if err != nil {
-		return 0, fmt.Errorf("marshaling results: %w", err)
+	data, marshalErr := jsonutil.MarshalIndentWithNewline(out, "", "  ")
+	if marshalErr != nil {
+		return 0, limit, page, fmt.Errorf("marshaling results: %w", marshalErr)
 	}
 	fmt.Fprint(w, string(data))
-	return len(pageResults), nil
+	return len(pageResults), limit, page, nil
 }
 
 // compactTitleMaxLen caps the title snippet length (in runes) in --compact
@@ -1118,8 +1171,9 @@ func compactSnippet(title, snippet string) string {
 // truncated title snippet — never the full prompt. Agents fetch full detail
 // for a single hit via the per-hit explain hint (add --full for the
 // checkpoint's entire session transcript). Returns the number of results
-// served. currentRepo ("org/name") decides which hints need --repo.
-func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int, searchID, currentRepo string) (int, error) {
+// served plus the normalized limit/page (see writeSearchJSON). currentRepo
+// ("org/name") decides which hints need --repo.
+func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int, searchID, currentRepo string) (served, normLimit, normPage int, err error) {
 	pageResults, total, totalPages, limit, page := paginateSearchResults(resp.Results, limit, page)
 
 	hits := make([]compactSearchHit, 0, len(pageResults))
@@ -1168,10 +1222,10 @@ func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int,
 		SearchID:   searchID,
 		Counts:     resp.Counts,
 	}
-	data, err := jsonutil.MarshalIndentWithNewline(out, "", "  ")
-	if err != nil {
-		return 0, fmt.Errorf("marshaling compact results: %w", err)
+	data, marshalErr := jsonutil.MarshalIndentWithNewline(out, "", "  ")
+	if marshalErr != nil {
+		return 0, limit, page, fmt.Errorf("marshaling compact results: %w", marshalErr)
 	}
 	fmt.Fprint(w, string(data))
-	return len(hits), nil
+	return len(hits), limit, page, nil
 }

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -280,7 +280,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 				if writeErr != nil {
 					return writeErr
 				}
-				emitSearchPerformed(ctx, searchID, searchCfg.Query, mode, served, len(resp.Results), requestedPage, requestedLimit)
+				emitSearchPerformed(ctx, searchID, mode, served, len(resp.Results), requestedPage, requestedLimit)
 				return nil
 			}
 

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -257,6 +257,22 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			searchCfg.Limit = search.DefaultLimit
 			searchCfg.Page = 0 // let API default to page 1
 
+			// Mint the search_id before the request (not after the response
+			// comes back) so it travels as a request header and the search
+			// service can log the same id server-side. ClientSurface
+			// identifies which CLI output mode issued the request; check
+			// compactOutput first since it implies jsonOutput.
+			searchID := newSearchID()
+			searchCfg.SearchID = searchID
+			switch {
+			case compactOutput:
+				searchCfg.ClientSurface = "cli-compact"
+			case jsonOutput || !isTerminal:
+				searchCfg.ClientSurface = "cli-json"
+			default:
+				searchCfg.ClientSurface = "cli-tui"
+			}
+
 			resp, err := searcher(ctx, searchCfg)
 			if err != nil {
 				return fmt.Errorf("search failed: %w", err)
@@ -267,7 +283,6 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 
 			// JSON output: explicit flag or piped/redirected stdout
 			if jsonOutput || !isTerminal {
-				searchID := newSearchID()
 				mode := "json"
 				var served int
 				var writeErr error

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -266,10 +266,21 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 
 			// JSON output: explicit flag or piped/redirected stdout
 			if jsonOutput || !isTerminal {
+				searchID := newSearchID()
+				mode := "json"
+				var served int
+				var writeErr error
 				if compactOutput {
-					return writeSearchCompactJSON(w, resp, requestedLimit, requestedPage)
+					mode = "compact"
+					served, writeErr = writeSearchCompactJSON(w, resp, requestedLimit, requestedPage, searchID, owner+"/"+repoName)
+				} else {
+					served, writeErr = writeSearchJSON(w, resp, requestedLimit, requestedPage, searchID)
 				}
-				return writeSearchJSON(w, resp, requestedLimit, requestedPage)
+				if writeErr != nil {
+					return writeErr
+				}
+				emitSearchPerformed(ctx, searchID, searchCfg.Query, mode, served, len(resp.Results), requestedPage, requestedLimit)
+				return nil
 			}
 
 			styles := newStatusStyles(w)
@@ -971,8 +982,12 @@ func paginateSearchResults(results []search.Result, limit, page int) (pageResult
 	return pageResults, total, totalPages, limit, page
 }
 
-// writeSearchJSON writes client-side paginated search results as JSON.
-func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int) error {
+// writeSearchJSON writes client-side paginated search results as JSON and
+// returns the number of results served. searchID ties the response to its
+// cli_search_performed telemetry event (ENT-1528); it is minted client-side
+// because the server response carries no request id and the CLI merges
+// several cell responses into one page.
+func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int, searchID string) (int, error) {
 	pageResults, total, totalPages, limit, page := paginateSearchResults(resp.Results, limit, page)
 
 	out := struct {
@@ -981,6 +996,7 @@ func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int) error 
 		Page       int                `json:"page"`
 		TotalPages int                `json:"total_pages"`
 		Limit      int                `json:"limit"`
+		SearchID   string             `json:"search_id,omitempty"`
 		Counts     *search.TypeCounts `json:"counts,omitempty"`
 	}{
 		Results:    pageResults,
@@ -988,14 +1004,15 @@ func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int) error 
 		Page:       page,
 		TotalPages: totalPages,
 		Limit:      limit,
+		SearchID:   searchID,
 		Counts:     resp.Counts,
 	}
 	data, err := jsonutil.MarshalIndentWithNewline(out, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshaling results: %w", err)
+		return 0, fmt.Errorf("marshaling results: %w", err)
 	}
 	fmt.Fprint(w, string(data))
-	return nil
+	return len(pageResults), nil
 }
 
 // compactTitleMaxLen caps the title snippet length (in runes) in --compact
@@ -1023,6 +1040,34 @@ type compactSearchHit struct {
 	// prompt head) — it's what lets an agent pick which hit to explain.
 	Snippet   string `json:"snippet,omitempty"`
 	MatchType string `json:"matchType,omitempty"`
+	// Explain is the ready-made command to fetch this hit's full detail — the
+	// second step of the search funnel (ENT-1528). Empty for hit types explain
+	// cannot resolve (repo, pr, session).
+	Explain string `json:"explain,omitempty"`
+}
+
+// explainHint returns the ready-made fetch command for a hit, or "" for hit
+// types `explain` cannot resolve. Checkpoint hits from another repo get
+// --repo (cross-repo explain, ENT-1523); commit hits resolve via the local
+// Entire-Checkpoint trailer only, so they get a hint only in the current
+// repo.
+func explainHint(r *search.Result, hitRepo, currentRepo string) string {
+	resultID := r.ResultID()
+	if resultID == "" {
+		return ""
+	}
+	switch r.Type {
+	case search.TypeCheckpoint:
+		if hitRepo != "" && !strings.EqualFold(hitRepo, currentRepo) {
+			return "entire checkpoint explain " + resultID + " --repo " + hitRepo
+		}
+		return "entire checkpoint explain " + resultID
+	case search.TypeCommit:
+		if hitRepo == "" || strings.EqualFold(hitRepo, currentRepo) {
+			return "entire checkpoint explain " + resultID
+		}
+	}
+	return ""
 }
 
 // compactSnippet drops a truncated snippet that duplicates the truncated
@@ -1045,9 +1090,10 @@ func compactSnippet(title, snippet string) string {
 // writeSearchCompactJSON writes client-side paginated search results as
 // compact JSON: per hit only identifiers, ranking, files touched, and a
 // truncated title snippet — never the full prompt. Agents fetch full detail
-// for a single hit via `entire checkpoint explain <id>` (add --full for the
-// checkpoint's entire session transcript).
-func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int) error {
+// for a single hit via the per-hit explain hint (add --full for the
+// checkpoint's entire session transcript). Returns the number of results
+// served. currentRepo ("org/name") decides which hints need --repo.
+func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int, searchID, currentRepo string) (int, error) {
 	pageResults, total, totalPages, limit, page := paginateSearchResults(resp.Results, limit, page)
 
 	hits := make([]compactSearchHit, 0, len(pageResults))
@@ -1071,6 +1117,7 @@ func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int)
 			Score:           r.Meta.Score,
 			Snippet:         compactSnippet(title, truncateOneLine(r.Meta.Snippet, compactTitleMaxLen)),
 			MatchType:       r.Meta.MatchType,
+			Explain:         explainHint(r, repo, currentRepo),
 		}
 		if r.Checkpoint != nil {
 			hit.FilesTouched = r.Checkpoint.FilesTouched
@@ -1084,6 +1131,7 @@ func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int)
 		Page       int                `json:"page"`
 		TotalPages int                `json:"total_pages"`
 		Limit      int                `json:"limit"`
+		SearchID   string             `json:"search_id,omitempty"`
 		Counts     *search.TypeCounts `json:"counts,omitempty"`
 	}{
 		Results:    hits,
@@ -1091,12 +1139,13 @@ func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int)
 		Page:       page,
 		TotalPages: totalPages,
 		Limit:      limit,
+		SearchID:   searchID,
 		Counts:     resp.Counts,
 	}
 	data, err := jsonutil.MarshalIndentWithNewline(out, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshaling compact results: %w", err)
+		return 0, fmt.Errorf("marshaling compact results: %w", err)
 	}
 	fmt.Fprint(w, string(data))
-	return nil
+	return len(hits), nil
 }

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -1050,24 +1051,34 @@ type compactSearchHit struct {
 // types `explain` cannot resolve. Checkpoint hits from another repo get
 // --repo (cross-repo explain, ENT-1523); commit hits resolve via the local
 // Entire-Checkpoint trailer only, so they get a hint only in the current
-// repo.
-func explainHint(r *search.Result, hitRepo, currentRepo string) string {
+// repo. The trailing --search-id <searchID>:<rank> token is what makes the
+// search→explain link deterministic: agents copy the hint verbatim, explain
+// passes the token through to the cli_checkpoint_explained event, and the
+// funnel joins on search_id instead of time proximity (ENT-1528).
+func explainHint(r *search.Result, hitRepo, currentRepo, searchID string, rank int) string {
 	resultID := r.ResultID()
 	if resultID == "" {
 		return ""
 	}
+	var cmd string
 	switch r.Type {
 	case search.TypeCheckpoint:
+		cmd = "entire checkpoint explain " + resultID
 		if hitRepo != "" && !strings.EqualFold(hitRepo, currentRepo) {
-			return "entire checkpoint explain " + resultID + " --repo " + hitRepo
+			cmd += " --repo " + hitRepo
 		}
-		return "entire checkpoint explain " + resultID
 	case search.TypeCommit:
-		if hitRepo == "" || strings.EqualFold(hitRepo, currentRepo) {
-			return "entire checkpoint explain " + resultID
+		if hitRepo != "" && !strings.EqualFold(hitRepo, currentRepo) {
+			return ""
 		}
+		cmd = "entire checkpoint explain " + resultID
+	default:
+		return ""
 	}
-	return ""
+	if searchID != "" {
+		cmd += " --search-id " + searchID + ":" + strconv.Itoa(rank)
+	}
+	return cmd
 }
 
 // compactSnippet drops a truncated snippet that duplicates the truncated
@@ -1117,7 +1128,7 @@ func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int,
 			Score:           r.Meta.Score,
 			Snippet:         compactSnippet(title, truncateOneLine(r.Meta.Snippet, compactTitleMaxLen)),
 			MatchType:       r.Meta.MatchType,
-			Explain:         explainHint(r, repo, currentRepo),
+			Explain:         explainHint(r, repo, currentRepo, searchID, (page-1)*limit+i+1),
 		}
 		if r.Checkpoint != nil {
 			hit.FilesTouched = r.Checkpoint.FilesTouched

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -187,8 +187,13 @@ func TestWriteSearchCompactJSON_SearchIDAndSameRepoExplainHint(t *testing.T) {
 	if !strings.Contains(output, `"search_id": "`+testSearchID+`"`) {
 		t.Errorf("compact envelope missing search_id:\n%s", output)
 	}
-	if !strings.Contains(output, `"explain": "entire checkpoint explain a3b2c4d5e6f7"`) {
-		t.Errorf("compact hit missing same-repo explain hint:\n%s", output)
+	// The hint embeds the search_id:rank token so the explain event links to
+	// this search deterministically.
+	if !strings.Contains(output, `"explain": "entire checkpoint explain a3b2c4d5e6f7 --search-id `+testSearchID+`:1"`) {
+		t.Errorf("compact hit missing same-repo explain hint with search token:\n%s", output)
+	}
+	if !strings.Contains(output, `--search-id `+testSearchID+`:2"`) {
+		t.Errorf("second hit must carry rank 2:\n%s", output)
 	}
 	if strings.Contains(output, "--repo") {
 		t.Errorf("same-repo hint must not carry --repo:\n%s", output)
@@ -207,8 +212,22 @@ func TestWriteSearchCompactJSON_CrossRepoExplainHint(t *testing.T) {
 	if _, err := writeSearchCompactJSON(&buf, &search.Response{Results: testResults()}, 10, 1, testSearchID, "other/elsewhere"); err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
-	if !strings.Contains(buf.String(), `"explain": "entire checkpoint explain a3b2c4d5e6f7 --repo entirehq/entire.io"`) {
-		t.Errorf("cross-repo checkpoint hint must carry --repo:\n%s", buf.String())
+	if !strings.Contains(buf.String(), `"explain": "entire checkpoint explain a3b2c4d5e6f7 --repo entirehq/entire.io --search-id `+testSearchID+`:1"`) {
+		t.Errorf("cross-repo checkpoint hint must carry --repo and the search token:\n%s", buf.String())
+	}
+}
+
+// Hint ranks are absolute across pages, matching what a ranking dashboard
+// needs (page 2 of limit 1 starts at rank 2).
+func TestWriteSearchCompactJSON_HintRankIsAbsolute(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if _, err := writeSearchCompactJSON(&buf, &search.Response{Results: testResults()}, 1, 2, testSearchID, testCurrentRepo); err != nil {
+		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
+	}
+	if !strings.Contains(buf.String(), `--search-id `+testSearchID+`:2"`) {
+		t.Errorf("page-2 hit must carry absolute rank 2:\n%s", buf.String())
 	}
 }
 

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -22,6 +22,13 @@ const (
 	testClusterSlugUS = "us-prod"
 )
 
+// test constants used across search JSON writer tests. testCurrentRepo matches
+// the org/repo of the checkpoint hits in testResults() (search_tui_test.go).
+const (
+	testSearchID    = "01JTEST000000000000000000"
+	testCurrentRepo = "entirehq/entire.io"
+)
+
 // TestSearchCmd_AccessibleModeRequiresQuery verifies that accessible mode
 // is treated like --json: a query is required when ACCESSIBLE=1.
 // Note: this test modifies process-global state (env var), so it must NOT
@@ -95,7 +102,7 @@ func TestWriteSearchJSON_ZeroLimitFallsBackToDefaultPageSize(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := writeSearchJSON(&buf, resp, 0, 1); err != nil {
+	if _, err := writeSearchJSON(&buf, resp, 0, 1, testSearchID); err != nil {
 		t.Fatalf("writeSearchJSON returned error: %v", err)
 	}
 
@@ -118,7 +125,7 @@ func TestWriteSearchCompactJSON_TrimsResults(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := writeSearchCompactJSON(&buf, resp, 0, 1); err != nil {
+	if _, err := writeSearchCompactJSON(&buf, resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
 
@@ -148,6 +155,85 @@ func TestWriteSearchCompactJSON_TrimsResults(t *testing.T) {
 	}
 }
 
+// The envelope carries the client-minted search_id (ENT-1528) so a response
+// can be tied to its cli_search_performed telemetry event.
+func TestWriteSearchJSON_IncludesSearchIDAndReturnsServedCount(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	served, err := writeSearchJSON(&buf, &search.Response{Results: testResults()}, 10, 1, testSearchID)
+	if err != nil {
+		t.Fatalf("writeSearchJSON returned error: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"search_id": "`+testSearchID+`"`) {
+		t.Errorf("full JSON envelope missing search_id:\n%s", buf.String())
+	}
+	if served != 2 {
+		t.Errorf("served = %d, want 2", served)
+	}
+}
+
+// Compact hits carry a ready-made explain command — the second step of the
+// search funnel (ENT-1528). Same-repo checkpoint hits get the plain form.
+func TestWriteSearchCompactJSON_SearchIDAndSameRepoExplainHint(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	served, err := writeSearchCompactJSON(&buf, &search.Response{Results: testResults()}, 10, 1, testSearchID, testCurrentRepo)
+	if err != nil {
+		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, `"search_id": "`+testSearchID+`"`) {
+		t.Errorf("compact envelope missing search_id:\n%s", output)
+	}
+	if !strings.Contains(output, `"explain": "entire checkpoint explain a3b2c4d5e6f7"`) {
+		t.Errorf("compact hit missing same-repo explain hint:\n%s", output)
+	}
+	if strings.Contains(output, "--repo") {
+		t.Errorf("same-repo hint must not carry --repo:\n%s", output)
+	}
+	if served != 2 {
+		t.Errorf("served = %d, want 2", served)
+	}
+}
+
+// Checkpoint hits from another repo get --repo so the hint works cross-repo
+// (ENT-1523 / PR #1942).
+func TestWriteSearchCompactJSON_CrossRepoExplainHint(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if _, err := writeSearchCompactJSON(&buf, &search.Response{Results: testResults()}, 10, 1, testSearchID, "other/elsewhere"); err != nil {
+		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"explain": "entire checkpoint explain a3b2c4d5e6f7 --repo entirehq/entire.io"`) {
+		t.Errorf("cross-repo checkpoint hint must carry --repo:\n%s", buf.String())
+	}
+}
+
+// Repo and pr rows cannot be resolved by explain, so they carry no hint.
+func TestWriteSearchCompactJSON_NoExplainHintForRepoAndPRRows(t *testing.T) {
+	t.Parallel()
+
+	wire := `{"results":[
+		{"type":"repo","data":{"id":"01JREPO","name":"backend","org":"acme","fullName":"acme/backend"},"searchMeta":{"score":0.9}},
+		{"type":"pr","data":{"id":"pr-9","title":"Fix login retry","repo":"backend","userLogin":"alice"},"searchMeta":{"score":0.5}}
+	],"total":2,"page":1}`
+	var resp search.Response
+	if err := json.Unmarshal([]byte(wire), &resp); err != nil {
+		t.Fatalf("unmarshaling wire response: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := writeSearchCompactJSON(&buf, &resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
+		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
+	}
+	if strings.Contains(buf.String(), `"explain"`) {
+		t.Errorf("repo/pr rows must not carry an explain hint:\n%s", buf.String())
+	}
+}
+
 // Repo/pr rows (reachable via --all-repos) have no typed struct; compact hits
 // must still carry identifying info from the raw payload instead of collapsing
 // to just {id, type, score}.
@@ -164,7 +250,7 @@ func TestWriteSearchCompactJSON_RepoAndPRRowsKeepIdentifyingFields(t *testing.T)
 	}
 
 	var buf bytes.Buffer
-	if err := writeSearchCompactJSON(&buf, &resp, 0, 1); err != nil {
+	if _, err := writeSearchCompactJSON(&buf, &resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
 
@@ -240,7 +326,7 @@ func TestWriteSearchCompactJSON_DropsSnippetDuplicatingTitle(t *testing.T) {
 				Total: 1,
 			}
 			var buf bytes.Buffer
-			if err := writeSearchCompactJSON(&buf, resp, 0, 1); err != nil {
+			if _, err := writeSearchCompactJSON(&buf, resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
 				t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 			}
 			if got := strings.Contains(buf.String(), `"snippet"`); got != tc.wantSnippet {
@@ -268,7 +354,7 @@ func TestWriteSearchCompactJSON_TruncatesLongPromptTitle(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := writeSearchCompactJSON(&buf, resp, 0, 1); err != nil {
+	if _, err := writeSearchCompactJSON(&buf, resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
 

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -102,7 +102,8 @@ func TestWriteSearchJSON_ZeroLimitFallsBackToDefaultPageSize(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if _, err := writeSearchJSON(&buf, resp, 0, 1, testSearchID); err != nil {
+	_, normLimit, normPage, err := writeSearchJSON(&buf, resp, 0, 1, testSearchID)
+	if err != nil {
 		t.Fatalf("writeSearchJSON returned error: %v", err)
 	}
 
@@ -112,6 +113,34 @@ func TestWriteSearchJSON_ZeroLimitFallsBackToDefaultPageSize(t *testing.T) {
 	}
 	if !strings.Contains(output, `"total_pages": 1`) {
 		t.Fatalf("output missing total_pages:\n%s", output)
+	}
+	// The normalized values are what the emitted telemetry event reports
+	// (ENT-1528) — --limit 0 must show up as the real page size, not 0.
+	if normLimit != 10 {
+		t.Errorf("normLimit = %d, want 10", normLimit)
+	}
+	if normPage != 1 {
+		t.Errorf("normPage = %d, want 1", normPage)
+	}
+}
+
+// --limit 0 --page 0 (both unset/invalid) must normalize to the default page
+// size and page 1 — this is what the cli_search_performed event reports for
+// limit/page, not the raw flag values (ENT-1528).
+func TestWriteSearchJSON_ZeroLimitAndPageNormalizeForTelemetry(t *testing.T) {
+	t.Parallel()
+
+	resp := &search.Response{Results: testResults(), Total: 2}
+	var buf bytes.Buffer
+	_, normLimit, normPage, err := writeSearchJSON(&buf, resp, 0, 0, testSearchID)
+	if err != nil {
+		t.Fatalf("writeSearchJSON returned error: %v", err)
+	}
+	if normLimit != 10 {
+		t.Errorf("normLimit = %d, want 10", normLimit)
+	}
+	if normPage != 1 {
+		t.Errorf("normPage = %d, want 1", normPage)
 	}
 }
 
@@ -125,7 +154,7 @@ func TestWriteSearchCompactJSON_TrimsResults(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if _, err := writeSearchCompactJSON(&buf, resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
+	if _, _, _, err := writeSearchCompactJSON(&buf, resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
 
@@ -161,7 +190,7 @@ func TestWriteSearchJSON_IncludesSearchIDAndReturnsServedCount(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	served, err := writeSearchJSON(&buf, &search.Response{Results: testResults()}, 10, 1, testSearchID)
+	served, _, _, err := writeSearchJSON(&buf, &search.Response{Results: testResults()}, 10, 1, testSearchID)
 	if err != nil {
 		t.Fatalf("writeSearchJSON returned error: %v", err)
 	}
@@ -179,7 +208,7 @@ func TestWriteSearchCompactJSON_SearchIDAndSameRepoExplainHint(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	served, err := writeSearchCompactJSON(&buf, &search.Response{Results: testResults()}, 10, 1, testSearchID, testCurrentRepo)
+	served, _, _, err := writeSearchCompactJSON(&buf, &search.Response{Results: testResults()}, 10, 1, testSearchID, testCurrentRepo)
 	if err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
@@ -209,7 +238,7 @@ func TestWriteSearchCompactJSON_CrossRepoExplainHint(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if _, err := writeSearchCompactJSON(&buf, &search.Response{Results: testResults()}, 10, 1, testSearchID, "other/elsewhere"); err != nil {
+	if _, _, _, err := writeSearchCompactJSON(&buf, &search.Response{Results: testResults()}, 10, 1, testSearchID, "other/elsewhere"); err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
 	if !strings.Contains(buf.String(), `"explain": "entire checkpoint explain a3b2c4d5e6f7 --repo entirehq/entire.io --search-id `+testSearchID+`:1"`) {
@@ -223,7 +252,7 @@ func TestWriteSearchCompactJSON_HintRankIsAbsolute(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if _, err := writeSearchCompactJSON(&buf, &search.Response{Results: testResults()}, 1, 2, testSearchID, testCurrentRepo); err != nil {
+	if _, _, _, err := writeSearchCompactJSON(&buf, &search.Response{Results: testResults()}, 1, 2, testSearchID, testCurrentRepo); err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
 	if !strings.Contains(buf.String(), `--search-id `+testSearchID+`:2"`) {
@@ -245,7 +274,7 @@ func TestWriteSearchCompactJSON_NoExplainHintForRepoAndPRRows(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if _, err := writeSearchCompactJSON(&buf, &resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
+	if _, _, _, err := writeSearchCompactJSON(&buf, &resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
 	if strings.Contains(buf.String(), `"explain"`) {
@@ -269,7 +298,7 @@ func TestWriteSearchCompactJSON_RepoAndPRRowsKeepIdentifyingFields(t *testing.T)
 	}
 
 	var buf bytes.Buffer
-	if _, err := writeSearchCompactJSON(&buf, &resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
+	if _, _, _, err := writeSearchCompactJSON(&buf, &resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
 
@@ -345,7 +374,7 @@ func TestWriteSearchCompactJSON_DropsSnippetDuplicatingTitle(t *testing.T) {
 				Total: 1,
 			}
 			var buf bytes.Buffer
-			if _, err := writeSearchCompactJSON(&buf, resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
+			if _, _, _, err := writeSearchCompactJSON(&buf, resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
 				t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 			}
 			if got := strings.Contains(buf.String(), `"snippet"`); got != tc.wantSnippet {
@@ -373,7 +402,7 @@ func TestWriteSearchCompactJSON_TruncatesLongPromptTitle(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if _, err := writeSearchCompactJSON(&buf, resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
+	if _, _, _, err := writeSearchCompactJSON(&buf, resp, 0, 1, testSearchID, testCurrentRepo); err != nil {
 		t.Fatalf("writeSearchCompactJSON returned error: %v", err)
 	}
 
@@ -383,6 +412,96 @@ func TestWriteSearchCompactJSON_TruncatesLongPromptTitle(t *testing.T) {
 	}
 	if !strings.Contains(output, "…") {
 		t.Errorf("expected truncated title to end with ellipsis:\n%s", output)
+	}
+}
+
+// buildSearchPerformedEvent assembles the cli_search_performed telemetry
+// event (ENT-1528) from the request config, server response, and the
+// writer's normalized pagination. A response with no results must report
+// zero_results/fetched_count/total as zero, never fall back to some other
+// non-zero placeholder.
+func TestBuildSearchPerformedEvent_ZeroResults(t *testing.T) {
+	t.Parallel()
+
+	cfg := search.Config{SearchID: testSearchID, Query: "auth timeout"}
+	resp := &search.Response{Results: nil, Total: 0}
+
+	event := buildSearchPerformedEvent(cfg, "json", "ok", resp, 0, 10, 1)
+	if !event.ZeroResults {
+		t.Error("ZeroResults = false, want true")
+	}
+	if event.FetchedCount != 0 {
+		t.Errorf("FetchedCount = %d, want 0", event.FetchedCount)
+	}
+	if event.Total != 0 {
+		t.Errorf("Total = %d, want 0", event.Total)
+	}
+}
+
+// The event's Total must be the server's honest count (resp.Total), never
+// derived from the served/paginated result count — a filtered or short page
+// must not masquerade as "few matches" (ENT-1528 honest-counts requirement).
+func TestBuildSearchPerformedEvent_TotalIsServerHonestNotServedCount(t *testing.T) {
+	t.Parallel()
+
+	cfg := search.Config{SearchID: testSearchID, Query: "auth timeout"}
+	resp := &search.Response{Results: testResults(), Total: 137} // 2 results served, 137 true matches
+
+	event := buildSearchPerformedEvent(cfg, "json", "ok", resp, 2, 10, 1)
+	if event.Total != 137 {
+		t.Errorf("Total = %d, want 137 (resp.Total, not served count 2)", event.Total)
+	}
+	if event.FetchedCount != 2 {
+		t.Errorf("FetchedCount = %d, want 2", event.FetchedCount)
+	}
+	if event.ZeroResults {
+		t.Error("ZeroResults = true, want false (total is 137)")
+	}
+}
+
+// Filter booleans, query length, and scope (all_repos) come from the request
+// config regardless of outcome; AllRepos is ScopeSlugs' second return so an
+// explicit --repo filter beats --all-repos.
+func TestBuildSearchPerformedEvent_FiltersAndScopeFromConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := search.Config{
+		SearchID: testSearchID,
+		Query:    "auth timeout",
+		Author:   "alice",
+		Date:     "week",
+		Branch:   "main",
+		Repos:    []string{"acme/backend"},
+		AllRepos: true, // explicit repo filter wins over --all-repos
+	}
+	event := buildSearchPerformedEvent(cfg, "compact", "ok", &search.Response{Total: 1}, 1, 10, 1)
+	if event.QueryLength != len([]rune("auth timeout")) {
+		t.Errorf("QueryLength = %d, want %d", event.QueryLength, len([]rune("auth timeout")))
+	}
+	if !event.FilterAuthor || !event.FilterDate || !event.FilterBranch || !event.FilterRepo {
+		t.Errorf("filter booleans = %+v, want all true", event)
+	}
+	if event.AllRepos {
+		t.Error("AllRepos = true, want false: explicit --repo filter must win over --all-repos")
+	}
+}
+
+// The error path (search failed before any response existed) reports zero
+// counts and the "error_request" outcome, still tagged with the query/filter
+// metadata from the config.
+func TestBuildSearchPerformedEvent_ErrorPathZeroCounts(t *testing.T) {
+	t.Parallel()
+
+	cfg := search.Config{SearchID: testSearchID, Query: "auth timeout", Author: "alice"}
+	event := buildSearchPerformedEvent(cfg, "json", "error_request", nil, 0, 0, 0)
+	if event.Outcome != "error_request" {
+		t.Errorf("Outcome = %q, want error_request", event.Outcome)
+	}
+	if event.Total != 0 || event.FetchedCount != 0 || event.Page != 0 || event.Limit != 0 {
+		t.Errorf("expected zero counts on error path, got %+v", event)
+	}
+	if !event.FilterAuthor {
+		t.Error("FilterAuthor = false, want true (filters still reported on error)")
 	}
 }
 

--- a/cmd/entire/cli/search_telemetry.go
+++ b/cmd/entire/cli/search_telemetry.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"strconv"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
@@ -65,11 +66,65 @@ func emitSearchPerformed(ctx context.Context, searchID, query, mode string, resu
 	}, versioninfo.Version)
 }
 
+// parseExplainSearchHit validates a --search-id token ("<ulid>" or
+// "<ulid>:<rank>") from a compact search hint. Anything that is not a strict
+// 26-char ULID is dropped entirely — the flag value is agent-controlled
+// free text and must never flow into telemetry unvalidated. A malformed or
+// non-positive rank is dropped while the valid search id is kept.
+func parseExplainSearchHit(token string) (searchID string, rank int) {
+	if token == "" {
+		return "", 0
+	}
+	idPart, rankPart, hasRank := strings.Cut(token, ":")
+	if _, err := ulid.ParseStrict(idPart); err != nil {
+		return "", 0
+	}
+	if hasRank {
+		if n, err := strconv.Atoi(rankPart); err == nil && n > 0 {
+			rank = n
+		}
+	}
+	return idPart, rank
+}
+
+// explainSearchHitKey carries a validated --search-id token through the
+// context, so the attribution reaches the emit sites without threading a
+// parameter through explain's deep call chains (same pattern as
+// withCrossRepoRead).
+type explainSearchHitKey struct{}
+
+type explainSearchHit struct {
+	searchID string
+	rank     int
+}
+
+// withExplainSearchHit validates and attaches a --search-id token to the
+// context. Invalid tokens attach nothing.
+func withExplainSearchHit(ctx context.Context, token string) context.Context {
+	searchID, rank := parseExplainSearchHit(token)
+	if searchID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, explainSearchHitKey{}, explainSearchHit{searchID: searchID, rank: rank})
+}
+
+// explainSearchHitFrom returns the validated search attribution attached by
+// withExplainSearchHit, or empty values when none is present.
+func explainSearchHitFrom(ctx context.Context) (searchID string, rank int) {
+	hit, ok := ctx.Value(explainSearchHitKey{}).(explainSearchHit)
+	if !ok {
+		return "", 0
+	}
+	return hit.searchID, hit.rank
+}
+
 // emitCheckpointExplained reports a cli_checkpoint_explained telemetry event
 // when telemetry is opted in — the "click" that follows a search impression
-// (ENT-1528). Zero agent cooperation: it fires on every successful explain
-// id resolution, and the search→explain funnel is assembled in the analytics
-// layer. Best-effort and non-blocking; explain output is never affected.
+// (ENT-1528). It fires on every successful explain id resolution; when the
+// invocation carried a --search-id token (embedded in compact search hints),
+// the event links to its search deterministically, otherwise the funnel is
+// assembled by time proximity in the analytics layer. Best-effort and
+// non-blocking; explain output is never affected.
 func emitCheckpointExplained(ctx context.Context, checkpointID, source string) {
 	if checkpointID == "" {
 		return
@@ -78,8 +133,11 @@ func emitCheckpointExplained(ctx context.Context, checkpointID, source string) {
 	if err != nil || s.Telemetry == nil || !*s.Telemetry {
 		return
 	}
+	searchID, rank := explainSearchHitFrom(ctx)
 	telemetry.TrackCheckpointExplained(telemetry.CheckpointExplainedEvent{
 		CheckpointID: checkpointID,
 		Source:       source,
+		SearchID:     searchID,
+		Rank:         rank,
 	}, versioninfo.Version)
 }

--- a/cmd/entire/cli/search_telemetry.go
+++ b/cmd/entire/cli/search_telemetry.go
@@ -33,13 +33,12 @@ func newSearchID() string {
 	return u.String()
 }
 
-// hashSearchQuery returns a short, non-reversible fingerprint of the query
-// for telemetry: SHA-256 of the lowercased, whitespace-collapsed query,
-// truncated to 16 hex chars. Raw query text is never sent (privacy
-// convention: operational metadata only).
-func hashSearchQuery(query string) string {
-	normalized := strings.ToLower(strings.Join(strings.Fields(query), " "))
-	sum := sha256.Sum256([]byte(normalized))
+// docRef is a truncated SHA-256 of a checkpoint id: a deterministic,
+// content-opaque reference. Resolvable ONLY by hashing candidate ids from
+// server-side search_event records — raw content identifiers never reach
+// analytics (trail 1019 high finding: "drop or hash").
+func docRef(checkpointID string) string {
+	sum := sha256.Sum256([]byte(checkpointID))
 	return hex.EncodeToString(sum[:8])
 }
 
@@ -47,7 +46,7 @@ func hashSearchQuery(query string) string {
 // telemetry is opted in (settings.Telemetry == true). Best-effort and
 // non-blocking; search output has already been written, so failures simply
 // suppress the event.
-func emitSearchPerformed(ctx context.Context, searchID, query, mode string, resultCount, total, page, limit int) {
+func emitSearchPerformed(ctx context.Context, searchID, mode string, resultCount, total, page, limit int) {
 	if searchID == "" {
 		return
 	}
@@ -57,7 +56,6 @@ func emitSearchPerformed(ctx context.Context, searchID, query, mode string, resu
 	}
 	telemetry.TrackSearchPerformed(telemetry.SearchPerformedEvent{
 		SearchID:    searchID,
-		QueryHash:   hashSearchQuery(query),
 		Mode:        mode,
 		ResultCount: resultCount,
 		Total:       total,
@@ -135,9 +133,9 @@ func emitCheckpointExplained(ctx context.Context, checkpointID, source string) {
 	}
 	searchID, rank := explainSearchHitFrom(ctx)
 	telemetry.TrackCheckpointExplained(telemetry.CheckpointExplainedEvent{
-		CheckpointID: checkpointID,
-		Source:       source,
-		SearchID:     searchID,
-		Rank:         rank,
+		DocRef:   docRef(checkpointID),
+		Source:   source,
+		SearchID: searchID,
+		Rank:     rank,
 	}, versioninfo.Version)
 }

--- a/cmd/entire/cli/search_telemetry.go
+++ b/cmd/entire/cli/search_telemetry.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+	"github.com/oklog/ulid/v2"
+)
+
+// Search relevance telemetry (ENT-1528). Agent-driven search has no web-style
+// click signal, so two stateless events reconstruct the funnel in PostHog:
+// cli_search_performed (a search served results) and cli_checkpoint_explained
+// (an agent fetched one result's full detail — the "click"). Correlation
+// happens entirely in the analytics layer by distinct_id + time; nothing is
+// persisted locally.
+
+// newSearchID mints a client-side search identifier. The search server
+// response carries no request id (and the CLI merges several cell responses
+// into one page), so the id that ties a response to its telemetry event is
+// minted here. Returns "" on entropy failure; callers treat that as
+// "tracking off".
+func newSearchID() string {
+	u, err := ulid.New(ulid.Now(), rand.Reader)
+	if err != nil {
+		return ""
+	}
+	return u.String()
+}
+
+// hashSearchQuery returns a short, non-reversible fingerprint of the query
+// for telemetry: SHA-256 of the lowercased, whitespace-collapsed query,
+// truncated to 16 hex chars. Raw query text is never sent (privacy
+// convention: operational metadata only).
+func hashSearchQuery(query string) string {
+	normalized := strings.ToLower(strings.Join(strings.Fields(query), " "))
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:8])
+}
+
+// emitSearchPerformed reports a cli_search_performed telemetry event when
+// telemetry is opted in (settings.Telemetry == true). Best-effort and
+// non-blocking; search output has already been written, so failures simply
+// suppress the event.
+func emitSearchPerformed(ctx context.Context, searchID, query, mode string, resultCount, total, page, limit int) {
+	if searchID == "" {
+		return
+	}
+	s, err := LoadEntireSettings(ctx)
+	if err != nil || s.Telemetry == nil || !*s.Telemetry {
+		return
+	}
+	telemetry.TrackSearchPerformed(telemetry.SearchPerformedEvent{
+		SearchID:    searchID,
+		QueryHash:   hashSearchQuery(query),
+		Mode:        mode,
+		ResultCount: resultCount,
+		Total:       total,
+		Page:        page,
+		Limit:       limit,
+	}, versioninfo.Version)
+}
+
+// emitCheckpointExplained reports a cli_checkpoint_explained telemetry event
+// when telemetry is opted in — the "click" that follows a search impression
+// (ENT-1528). Zero agent cooperation: it fires on every successful explain
+// id resolution, and the search→explain funnel is assembled in the analytics
+// layer. Best-effort and non-blocking; explain output is never affected.
+func emitCheckpointExplained(ctx context.Context, checkpointID, source string) {
+	if checkpointID == "" {
+		return
+	}
+	s, err := LoadEntireSettings(ctx)
+	if err != nil || s.Telemetry == nil || !*s.Telemetry {
+		return
+	}
+	telemetry.TrackCheckpointExplained(telemetry.CheckpointExplainedEvent{
+		CheckpointID: checkpointID,
+		Source:       source,
+	}, versioninfo.Version)
+}

--- a/cmd/entire/cli/search_telemetry.go
+++ b/cmd/entire/cli/search_telemetry.go
@@ -45,23 +45,18 @@ func docRef(checkpointID string) string {
 // emitSearchPerformed reports a cli_search_performed telemetry event when
 // telemetry is opted in (settings.Telemetry == true). Best-effort and
 // non-blocking; search output has already been written, so failures simply
-// suppress the event.
-func emitSearchPerformed(ctx context.Context, searchID, mode string, resultCount, total, page, limit int) {
-	if searchID == "" {
+// suppress the event. Fires on both success ("ok") and request failure
+// ("error_request", ...) outcomes; callers assemble the event (see
+// buildSearchPerformedEvent).
+func emitSearchPerformed(ctx context.Context, event telemetry.SearchPerformedEvent) {
+	if event.SearchID == "" {
 		return
 	}
 	s, err := LoadEntireSettings(ctx)
 	if err != nil || s.Telemetry == nil || !*s.Telemetry {
 		return
 	}
-	telemetry.TrackSearchPerformed(telemetry.SearchPerformedEvent{
-		SearchID:    searchID,
-		Mode:        mode,
-		ResultCount: resultCount,
-		Total:       total,
-		Page:        page,
-		Limit:       limit,
-	}, versioninfo.Version)
+	telemetry.TrackSearchPerformed(event, versioninfo.Version)
 }
 
 // parseExplainSearchHit validates a --search-id token ("<ulid>" or

--- a/cmd/entire/cli/search_telemetry_test.go
+++ b/cmd/entire/cli/search_telemetry_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import "testing"
+
+func TestHashSearchQuery_NormalizesAndTruncates(t *testing.T) {
+	t.Parallel()
+	a := hashSearchQuery("  Foo   BAR ")
+	b := hashSearchQuery("foo bar")
+	if a != b {
+		t.Errorf("normalized hashes differ: %q vs %q", a, b)
+	}
+	if len(a) != 16 {
+		t.Errorf("hash length = %d, want 16", len(a))
+	}
+	if a == hashSearchQuery("foo baz") {
+		t.Error("different queries must hash differently")
+	}
+}
+
+func TestNewSearchID_IsULIDShaped(t *testing.T) {
+	t.Parallel()
+	id := newSearchID()
+	if len(id) != 26 {
+		t.Fatalf("search id %q length = %d, want 26", id, len(id))
+	}
+	if id == newSearchID() {
+		t.Error("consecutive search ids must differ")
+	}
+}

--- a/cmd/entire/cli/search_telemetry_test.go
+++ b/cmd/entire/cli/search_telemetry_test.go
@@ -1,6 +1,9 @@
 package cli
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestHashSearchQuery_NormalizesAndTruncates(t *testing.T) {
 	t.Parallel()
@@ -25,5 +28,55 @@ func TestNewSearchID_IsULIDShaped(t *testing.T) {
 	}
 	if id == newSearchID() {
 		t.Error("consecutive search ids must differ")
+	}
+}
+
+func TestParseExplainSearchHit(t *testing.T) {
+	t.Parallel()
+	const validULID = "01JXK9RSTQ4B7NW2VYFCH6M3DZ"
+	tests := []struct {
+		name, token, wantID string
+		wantRank            int
+	}{
+		{"empty", "", "", 0},
+		{"ulid only", validULID, validULID, 0},
+		{"ulid with rank", validULID + ":3", validULID, 3},
+		{"junk dropped entirely", "not-a-ulid:3", "", 0},
+		{"short id dropped", "01JXK9:1", "", 0},
+		{"bad rank keeps id", validULID + ":abc", validULID, 0},
+		{"zero rank dropped", validULID + ":0", validULID, 0},
+		{"negative rank dropped", validULID + ":-2", validULID, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotID, gotRank := parseExplainSearchHit(tc.token)
+			if gotID != tc.wantID || gotRank != tc.wantRank {
+				t.Errorf("parseExplainSearchHit(%q) = (%q, %d), want (%q, %d)", tc.token, gotID, gotRank, tc.wantID, tc.wantRank)
+			}
+		})
+	}
+}
+
+func TestExplainSearchHitContextRoundTrip(t *testing.T) {
+	t.Parallel()
+	const validULID = "01JXK9RSTQ4B7NW2VYFCH6M3DZ"
+
+	ctx := withExplainSearchHit(context.Background(), validULID+":2")
+	searchID, rank := explainSearchHitFrom(ctx)
+	if searchID != validULID || rank != 2 {
+		t.Errorf("round trip = (%q, %d), want (%q, 2)", searchID, rank, validULID)
+	}
+
+	// Bare context carries nothing.
+	searchID, rank = explainSearchHitFrom(context.Background())
+	if searchID != "" || rank != 0 {
+		t.Errorf("bare context = (%q, %d), want empty", searchID, rank)
+	}
+
+	// Invalid tokens never enter the context.
+	searchID, rank = explainSearchHitFrom(withExplainSearchHit(context.Background(), "junk"))
+	if searchID != "" || rank != 0 {
+		t.Errorf("junk token = (%q, %d), want empty", searchID, rank)
 	}
 }

--- a/cmd/entire/cli/search_telemetry_test.go
+++ b/cmd/entire/cli/search_telemetry_test.go
@@ -2,21 +2,21 @@ package cli
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
-func TestHashSearchQuery_NormalizesAndTruncates(t *testing.T) {
+func TestDocRef_DeterministicAndOpaque(t *testing.T) {
 	t.Parallel()
-	a := hashSearchQuery("  Foo   BAR ")
-	b := hashSearchQuery("foo bar")
-	if a != b {
-		t.Errorf("normalized hashes differ: %q vs %q", a, b)
+	a := docRef("01JRESULT0000000000000000")
+	if a != docRef("01JRESULT0000000000000000") {
+		t.Error("docRef must be deterministic")
 	}
 	if len(a) != 16 {
-		t.Errorf("hash length = %d, want 16", len(a))
+		t.Errorf("len = %d, want 16", len(a))
 	}
-	if a == hashSearchQuery("foo baz") {
-		t.Error("different queries must hash differently")
+	if strings.Contains(a, "01JRESULT") {
+		t.Error("docRef must not embed the raw id")
 	}
 }
 

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -499,6 +499,14 @@ func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 			cfg.Date = parsed.Date
 			cfg.Branch = parsed.Branch
 			cfg.Repos = parsed.Repos
+			// m.searchCfg still carries the SearchID minted for the TUI's
+			// initial (pre-request) search; that id belongs to that first
+			// request only. Clear it so an in-TUI re-search never resends the
+			// previous search's id (mislabeled correlation is worse than
+			// none) — v1 deliberately doesn't mint a fresh id per re-search.
+			// ClientSurface is kept: it truthfully describes the client on
+			// every request, not just the first one.
+			cfg.SearchID = ""
 			m.searchCfg = cfg
 			cmds = append(cmds, m.performSearch(cfg))
 		}

--- a/cmd/entire/cli/search_tui_test.go
+++ b/cmd/entire/cli/search_tui_test.go
@@ -1380,6 +1380,43 @@ func TestSearchModel_NewSearchClearsExplicitRepoFilters(t *testing.T) {
 	}
 }
 
+// TestSearchModel_ReSearchClearsSearchIDKeepsClientSurface confirms an
+// in-TUI re-search (Enter in search mode) never resends the previous
+// search's X-Entire-Search-Id: the seeded searchCfg (as search_cmd.go hands
+// it to the TUI) carries the initial request's minted SearchID, and that
+// must not leak onto subsequent re-search requests as a stale/mislabeled id.
+// ClientSurface, by contrast, truthfully describes the client on every
+// request and must survive the re-search.
+func TestSearchModel_ReSearchClearsSearchIDKeepsClientSurface(t *testing.T) {
+	t.Parallel()
+
+	ss := statusStyles{colorEnabled: false, width: 100}
+	cfg := search.Config{
+		Owner:         "o",
+		Repo:          "r",
+		Limit:         25,
+		SearchID:      "01JXK9RSTQ4B7NW2VYFCH6M3DZ",
+		ClientSurface: "cli-tui",
+	}
+	m := newSearchModel(testResults(), "old", 2, cfg, ss, nil)
+
+	m = updateModel(t, m, tea.KeyPressMsg{Code: '/', Text: "/"})
+	m.input.SetValue(newQuery)
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, ok := updated.(searchModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want searchModel", updated)
+	}
+
+	if m.searchCfg.SearchID != "" {
+		t.Errorf("searchCfg.SearchID = %q, want empty (re-search must not resend the prior search's id)", m.searchCfg.SearchID)
+	}
+	if m.searchCfg.ClientSurface != "cli-tui" {
+		t.Errorf("searchCfg.ClientSurface = %q, want %q (surface header should still be sent)", m.searchCfg.ClientSurface, "cli-tui")
+	}
+}
+
 func TestSearchModel_NewSearchAllReposFilter(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/telemetry/search.go
+++ b/cmd/entire/cli/telemetry/search.go
@@ -18,14 +18,31 @@ const (
 )
 
 // SearchPerformedEvent carries the fields for a cli_search_performed event
-// (ENT-1528).
+// (ENT-1528). Outcome distinguishes a served response ("ok") from a request
+// that failed before any results existed ("error_request", "error_auth",
+// ...); on an error path the count fields are zero. FetchedCount and Total
+// are deliberately distinct: FetchedCount is what this page served
+// client-side, Total is the server's true match count (resp.Total) — never
+// derived from len(results), so a filtered/short page doesn't masquerade as
+// "few matches". Page and Limit are the normalized values the envelope
+// reports (paginateSearchResults), not the raw --page/--limit flags.
 type SearchPerformedEvent struct {
-	SearchID    string
-	Mode        string // "json" or "compact"
-	ResultCount int    // results served on this page
-	Total       int    // total results before client-side pagination
-	Page        int
-	Limit       int
+	SearchID     string
+	Mode         string // "json" | "compact"
+	Outcome      string // "ok" | "error_request" | "error_auth" | ...
+	QueryLength  int    // rune count of the query text, never the text itself
+	FetchedCount int    // results served on this page (client-side)
+	Total        int    // server's true total match count (resp.Total)
+	ZeroResults  bool
+	Page, Limit  int // normalized values the envelope reports
+	AllRepos     bool
+	FilterAuthor bool
+	FilterDate   bool
+	FilterBranch bool
+	FilterRepo   bool
+	Reranked     bool
+	TotalMS      int
+	Degraded     bool // response carried completeness warnings
 }
 
 // CheckpointExplainedEvent carries the fields for a cli_checkpoint_explained
@@ -54,15 +71,26 @@ func BuildSearchPerformedPayload(event SearchPerformedEvent, version string) *Ev
 		Event:      "cli_search_performed",
 		DistinctID: machineID,
 		Properties: map[string]any{
-			"search_id":    event.SearchID,
-			"mode":         event.Mode,
-			"result_count": event.ResultCount,
-			"total":        event.Total,
-			"page":         event.Page,
-			"limit":        event.Limit,
-			"cli_version":  version,
-			"os":           runtime.GOOS,
-			"arch":         runtime.GOARCH,
+			"search_id":     event.SearchID,
+			"mode":          event.Mode,
+			"outcome":       event.Outcome,
+			"query_length":  event.QueryLength,
+			"fetched_count": event.FetchedCount,
+			"total":         event.Total,
+			"zero_results":  event.ZeroResults,
+			"page":          event.Page,
+			"limit":         event.Limit,
+			"all_repos":     event.AllRepos,
+			"f_author":      event.FilterAuthor,
+			"f_date":        event.FilterDate,
+			"f_branch":      event.FilterBranch,
+			"f_repo":        event.FilterRepo,
+			"reranked":      event.Reranked,
+			"total_ms":      event.TotalMS,
+			"degraded":      event.Degraded,
+			"cli_version":   version,
+			"os":            runtime.GOOS,
+			"arch":          runtime.GOARCH,
 		},
 		Timestamp: time.Now(),
 	}

--- a/cmd/entire/cli/telemetry/search.go
+++ b/cmd/entire/cli/telemetry/search.go
@@ -34,9 +34,14 @@ type SearchPerformedEvent struct {
 // event (ENT-1528): a successful `entire checkpoint explain` id resolution,
 // the "click" that follows a search impression. CheckpointID is an opaque
 // identifier (ULID or 12-hex); Source is one of the ExplainSource* constants.
+// SearchID and Rank come from the --search-id token embedded in compact
+// search hints; when present they link the click to its search
+// deterministically. Both optional (empty/zero = omitted).
 type CheckpointExplainedEvent struct {
 	CheckpointID string
 	Source       string
+	SearchID     string
+	Rank         int
 }
 
 // BuildSearchPerformedPayload constructs a cli_search_performed event payload.
@@ -90,17 +95,24 @@ func BuildCheckpointExplainedPayload(event CheckpointExplainedEvent, version str
 	if err != nil {
 		return nil
 	}
+	properties := map[string]any{
+		"checkpoint_id": event.CheckpointID,
+		"source":        event.Source,
+		"cli_version":   version,
+		"os":            runtime.GOOS,
+		"arch":          runtime.GOARCH,
+	}
+	if event.SearchID != "" {
+		properties["search_id"] = event.SearchID
+		if event.Rank > 0 {
+			properties["rank"] = event.Rank
+		}
+	}
 	return &EventPayload{
 		Event:      "cli_checkpoint_explained",
 		DistinctID: machineID,
-		Properties: map[string]any{
-			"checkpoint_id": event.CheckpointID,
-			"source":        event.Source,
-			"cli_version":   version,
-			"os":            runtime.GOOS,
-			"arch":          runtime.GOARCH,
-		},
-		Timestamp: time.Now(),
+		Properties: properties,
+		Timestamp:  time.Now(),
 	}
 }
 

--- a/cmd/entire/cli/telemetry/search.go
+++ b/cmd/entire/cli/telemetry/search.go
@@ -1,0 +1,122 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+// Source values for the cli_checkpoint_explained event, one per explain
+// id-resolution path.
+const (
+	ExplainSourceProse     = "prose"
+	ExplainSourceExport    = "export"
+	ExplainSourceCrossRepo = "cross_repo"
+)
+
+// SearchPerformedEvent carries the fields for a cli_search_performed event
+// (ENT-1528). QueryHash is a non-reversible fingerprint — the raw query is
+// never sent.
+type SearchPerformedEvent struct {
+	SearchID    string
+	QueryHash   string
+	Mode        string // "json" or "compact"
+	ResultCount int    // results served on this page
+	Total       int    // total results before client-side pagination
+	Page        int
+	Limit       int
+}
+
+// CheckpointExplainedEvent carries the fields for a cli_checkpoint_explained
+// event (ENT-1528): a successful `entire checkpoint explain` id resolution,
+// the "click" that follows a search impression. CheckpointID is an opaque
+// identifier (ULID or 12-hex); Source is one of the ExplainSource* constants.
+type CheckpointExplainedEvent struct {
+	CheckpointID string
+	Source       string
+}
+
+// BuildSearchPerformedPayload constructs a cli_search_performed event payload.
+// Exported for testing. Returns nil if the machine ID cannot be resolved.
+func BuildSearchPerformedPayload(event SearchPerformedEvent, version string) *EventPayload {
+	machineID, err := machineid.ProtectedID("entire-cli")
+	if err != nil {
+		return nil
+	}
+	return &EventPayload{
+		Event:      "cli_search_performed",
+		DistinctID: machineID,
+		Properties: map[string]any{
+			"search_id":    event.SearchID,
+			"query_hash":   event.QueryHash,
+			"mode":         event.Mode,
+			"result_count": event.ResultCount,
+			"total":        event.Total,
+			"page":         event.Page,
+			"limit":        event.Limit,
+			"cli_version":  version,
+			"os":           runtime.GOOS,
+			"arch":         runtime.GOARCH,
+		},
+		Timestamp: time.Now(),
+	}
+}
+
+// TrackSearchPerformed sends a cli_search_performed event by spawning a
+// detached subprocess. Best-effort and non-blocking; callers are responsible
+// for the settings.Telemetry opt-in check. Honors ENTIRE_TELEMETRY_OPTOUT
+// like the other trackers.
+func TrackSearchPerformed(event SearchPerformedEvent, version string) {
+	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+		return
+	}
+	payload := BuildSearchPerformedPayload(event, version)
+	if payload == nil {
+		return
+	}
+	if payloadJSON, err := json.Marshal(payload); err == nil {
+		spawnDetachedAnalytics(string(payloadJSON))
+	}
+}
+
+// BuildCheckpointExplainedPayload constructs a cli_checkpoint_explained event
+// payload. Exported for testing. Returns nil if the machine ID cannot be
+// resolved.
+func BuildCheckpointExplainedPayload(event CheckpointExplainedEvent, version string) *EventPayload {
+	machineID, err := machineid.ProtectedID("entire-cli")
+	if err != nil {
+		return nil
+	}
+	return &EventPayload{
+		Event:      "cli_checkpoint_explained",
+		DistinctID: machineID,
+		Properties: map[string]any{
+			"checkpoint_id": event.CheckpointID,
+			"source":        event.Source,
+			"cli_version":   version,
+			"os":            runtime.GOOS,
+			"arch":          runtime.GOARCH,
+		},
+		Timestamp: time.Now(),
+	}
+}
+
+// TrackCheckpointExplained sends a cli_checkpoint_explained event by spawning
+// a detached subprocess. Best-effort and non-blocking; callers are responsible
+// for the settings.Telemetry opt-in check. Honors ENTIRE_TELEMETRY_OPTOUT
+// like the other trackers.
+func TrackCheckpointExplained(event CheckpointExplainedEvent, version string) {
+	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+		return
+	}
+	payload := BuildCheckpointExplainedPayload(event, version)
+	if payload == nil {
+		return
+	}
+	if payloadJSON, err := json.Marshal(payload); err == nil {
+		spawnDetachedAnalytics(string(payloadJSON))
+	}
+}

--- a/cmd/entire/cli/telemetry/search.go
+++ b/cmd/entire/cli/telemetry/search.go
@@ -18,11 +18,9 @@ const (
 )
 
 // SearchPerformedEvent carries the fields for a cli_search_performed event
-// (ENT-1528). QueryHash is a non-reversible fingerprint — the raw query is
-// never sent.
+// (ENT-1528).
 type SearchPerformedEvent struct {
 	SearchID    string
-	QueryHash   string
 	Mode        string // "json" or "compact"
 	ResultCount int    // results served on this page
 	Total       int    // total results before client-side pagination
@@ -32,16 +30,17 @@ type SearchPerformedEvent struct {
 
 // CheckpointExplainedEvent carries the fields for a cli_checkpoint_explained
 // event (ENT-1528): a successful `entire checkpoint explain` id resolution,
-// the "click" that follows a search impression. CheckpointID is an opaque
-// identifier (ULID or 12-hex); Source is one of the ExplainSource* constants.
-// SearchID and Rank come from the --search-id token embedded in compact
-// search hints; when present they link the click to its search
-// deterministically. Both optional (empty/zero = omitted).
+// the "click" that follows a search impression. DocRef is a truncated
+// SHA-256 of the checkpoint id — the raw id itself never reaches analytics
+// (trail 1019 high finding: "drop or hash"). Source is one of the
+// ExplainSource* constants. SearchID and Rank come from the --search-id
+// token embedded in compact search hints; when present they link the click
+// to its search deterministically. Both optional (empty/zero = omitted).
 type CheckpointExplainedEvent struct {
-	CheckpointID string
-	Source       string
-	SearchID     string
-	Rank         int
+	DocRef   string
+	Source   string
+	SearchID string
+	Rank     int
 }
 
 // BuildSearchPerformedPayload constructs a cli_search_performed event payload.
@@ -56,7 +55,6 @@ func BuildSearchPerformedPayload(event SearchPerformedEvent, version string) *Ev
 		DistinctID: machineID,
 		Properties: map[string]any{
 			"search_id":    event.SearchID,
-			"query_hash":   event.QueryHash,
 			"mode":         event.Mode,
 			"result_count": event.ResultCount,
 			"total":        event.Total,
@@ -96,11 +94,11 @@ func BuildCheckpointExplainedPayload(event CheckpointExplainedEvent, version str
 		return nil
 	}
 	properties := map[string]any{
-		"checkpoint_id": event.CheckpointID,
-		"source":        event.Source,
-		"cli_version":   version,
-		"os":            runtime.GOOS,
-		"arch":          runtime.GOARCH,
+		"doc_ref":     event.DocRef,
+		"source":      event.Source,
+		"cli_version": version,
+		"os":          runtime.GOOS,
+		"arch":        runtime.GOARCH,
 	}
 	if event.SearchID != "" {
 		properties["search_id"] = event.SearchID

--- a/cmd/entire/cli/telemetry/search_test.go
+++ b/cmd/entire/cli/telemetry/search_test.go
@@ -71,9 +71,12 @@ func TestBuildCheckpointExplainedPayload(t *testing.T) {
 	if got := p["source"]; got != "prose" {
 		t.Errorf("source = %v, want prose", got)
 	}
-	// Privacy: the raw checkpoint id must never be a property.
-	if _, ok := p["checkpoint_id"]; ok {
-		t.Error("forbidden property \"checkpoint_id\" present")
+	// Privacy: the raw query, its hash, impression tuples, session
+	// identifiers, and raw checkpoint ids must never be properties.
+	for _, key := range []string{"query", "query_hash", "impressions", "results", "session_id", "checkpoint_id"} {
+		if _, ok := p[key]; ok {
+			t.Errorf("forbidden property %q present", key)
+		}
 	}
 	// Without a search-hit token, the deterministic-link fields are omitted.
 	for _, key := range []string{"search_id", "rank"} {
@@ -101,6 +104,13 @@ func TestBuildCheckpointExplainedPayload_WithSearchAttribution(t *testing.T) {
 	if got := p["rank"]; got != 3 {
 		t.Errorf("rank = %v, want 3", got)
 	}
+	// Privacy: the raw query, its hash, impression tuples, session
+	// identifiers, and raw checkpoint ids must never be properties.
+	for _, key := range []string{"query", "query_hash", "impressions", "results", "session_id", "checkpoint_id"} {
+		if _, ok := p[key]; ok {
+			t.Errorf("forbidden property %q present", key)
+		}
+	}
 }
 
 func TestBuildCheckpointExplainedPayload_SearchIDWithoutRank(t *testing.T) {
@@ -118,5 +128,12 @@ func TestBuildCheckpointExplainedPayload_SearchIDWithoutRank(t *testing.T) {
 	}
 	if _, ok := payload.Properties["rank"]; ok {
 		t.Error("rank should be omitted when unknown")
+	}
+	// Privacy: the raw query, its hash, impression tuples, session
+	// identifiers, and raw checkpoint ids must never be properties.
+	for _, key := range []string{"query", "query_hash", "impressions", "results", "session_id", "checkpoint_id"} {
+		if _, ok := payload.Properties[key]; ok {
+			t.Errorf("forbidden property %q present", key)
+		}
 	}
 }

--- a/cmd/entire/cli/telemetry/search_test.go
+++ b/cmd/entire/cli/telemetry/search_test.go
@@ -68,4 +68,48 @@ func TestBuildCheckpointExplainedPayload(t *testing.T) {
 	if got := p["source"]; got != "prose" {
 		t.Errorf("source = %v, want prose", got)
 	}
+	// Without a search-hit token, the deterministic-link fields are omitted.
+	for _, key := range []string{"search_id", "rank"} {
+		if _, ok := p[key]; ok {
+			t.Errorf("property %q should be omitted when no search hit is attributed", key)
+		}
+	}
+}
+
+func TestBuildCheckpointExplainedPayload_WithSearchAttribution(t *testing.T) {
+	t.Parallel()
+	payload := BuildCheckpointExplainedPayload(CheckpointExplainedEvent{
+		CheckpointID: "01JRESULT0000000000000000",
+		Source:       "export",
+		SearchID:     "01JXK9RSTQ4B7NW2VYFCH6M3DZ",
+		Rank:         3,
+	}, "1.2.3")
+	if payload == nil {
+		t.Fatal("expected payload, got nil")
+	}
+	p := payload.Properties
+	if got := p["search_id"]; got != "01JXK9RSTQ4B7NW2VYFCH6M3DZ" {
+		t.Errorf("search_id = %v", got)
+	}
+	if got := p["rank"]; got != 3 {
+		t.Errorf("rank = %v, want 3", got)
+	}
+}
+
+func TestBuildCheckpointExplainedPayload_SearchIDWithoutRank(t *testing.T) {
+	t.Parallel()
+	payload := BuildCheckpointExplainedPayload(CheckpointExplainedEvent{
+		CheckpointID: "01JRESULT0000000000000000",
+		Source:       "prose",
+		SearchID:     "01JXK9RSTQ4B7NW2VYFCH6M3DZ",
+	}, "1.2.3")
+	if payload == nil {
+		t.Fatal("expected payload, got nil")
+	}
+	if _, ok := payload.Properties["search_id"]; !ok {
+		t.Error("search_id should be present")
+	}
+	if _, ok := payload.Properties["rank"]; ok {
+		t.Error("rank should be omitted when unknown")
+	}
 }

--- a/cmd/entire/cli/telemetry/search_test.go
+++ b/cmd/entire/cli/telemetry/search_test.go
@@ -6,7 +6,6 @@ func TestBuildSearchPerformedPayload(t *testing.T) {
 	t.Parallel()
 	event := SearchPerformedEvent{
 		SearchID:    "01JXAMPLE0000000000000000",
-		QueryHash:   "abcd1234abcd1234",
 		Mode:        "compact",
 		ResultCount: 5,
 		Total:       42,
@@ -24,14 +23,14 @@ func TestBuildSearchPerformedPayload(t *testing.T) {
 		t.Error("distinct_id must be set")
 	}
 	p := payload.Properties
-	for _, key := range []string{"search_id", "query_hash", "mode", "result_count", "total", "page", "limit", "cli_version", "os", "arch"} {
+	for _, key := range []string{"search_id", "mode", "result_count", "total", "page", "limit", "cli_version", "os", "arch"} {
 		if _, ok := p[key]; !ok {
 			t.Errorf("missing property %q", key)
 		}
 	}
-	// Privacy: the raw query, impression tuples, and session identifiers must
-	// never be properties.
-	for _, key := range []string{"query", "impressions", "results", "session_id"} {
+	// Privacy: the raw query, its hash, impression tuples, session
+	// identifiers, and raw checkpoint ids must never be properties.
+	for _, key := range []string{"query", "query_hash", "impressions", "results", "session_id", "checkpoint_id"} {
 		if _, ok := p[key]; ok {
 			t.Errorf("forbidden property %q present", key)
 		}
@@ -44,8 +43,8 @@ func TestBuildSearchPerformedPayload(t *testing.T) {
 func TestBuildCheckpointExplainedPayload(t *testing.T) {
 	t.Parallel()
 	payload := BuildCheckpointExplainedPayload(CheckpointExplainedEvent{
-		CheckpointID: "01JRESULT0000000000000000",
-		Source:       "prose",
+		DocRef: "abcd1234abcd1234",
+		Source: "prose",
 	}, "1.2.3")
 	if payload == nil {
 		t.Fatal("expected payload, got nil")
@@ -57,16 +56,24 @@ func TestBuildCheckpointExplainedPayload(t *testing.T) {
 		t.Error("distinct_id must be set")
 	}
 	p := payload.Properties
-	for _, key := range []string{"checkpoint_id", "source", "cli_version", "os", "arch"} {
+	for _, key := range []string{"doc_ref", "source", "cli_version", "os", "arch"} {
 		if _, ok := p[key]; !ok {
 			t.Errorf("missing property %q", key)
 		}
 	}
-	if got := p["checkpoint_id"]; got != "01JRESULT0000000000000000" {
-		t.Errorf("checkpoint_id = %v", got)
+	docRef, ok := p["doc_ref"].(string)
+	if !ok {
+		t.Fatalf("doc_ref = %v, want string", p["doc_ref"])
+	}
+	if len(docRef) != 16 {
+		t.Errorf("doc_ref len = %d, want 16", len(docRef))
 	}
 	if got := p["source"]; got != "prose" {
 		t.Errorf("source = %v, want prose", got)
+	}
+	// Privacy: the raw checkpoint id must never be a property.
+	if _, ok := p["checkpoint_id"]; ok {
+		t.Error("forbidden property \"checkpoint_id\" present")
 	}
 	// Without a search-hit token, the deterministic-link fields are omitted.
 	for _, key := range []string{"search_id", "rank"} {
@@ -79,10 +86,10 @@ func TestBuildCheckpointExplainedPayload(t *testing.T) {
 func TestBuildCheckpointExplainedPayload_WithSearchAttribution(t *testing.T) {
 	t.Parallel()
 	payload := BuildCheckpointExplainedPayload(CheckpointExplainedEvent{
-		CheckpointID: "01JRESULT0000000000000000",
-		Source:       "export",
-		SearchID:     "01JXK9RSTQ4B7NW2VYFCH6M3DZ",
-		Rank:         3,
+		DocRef:   "abcd1234abcd1234",
+		Source:   "export",
+		SearchID: "01JXK9RSTQ4B7NW2VYFCH6M3DZ",
+		Rank:     3,
 	}, "1.2.3")
 	if payload == nil {
 		t.Fatal("expected payload, got nil")
@@ -99,9 +106,9 @@ func TestBuildCheckpointExplainedPayload_WithSearchAttribution(t *testing.T) {
 func TestBuildCheckpointExplainedPayload_SearchIDWithoutRank(t *testing.T) {
 	t.Parallel()
 	payload := BuildCheckpointExplainedPayload(CheckpointExplainedEvent{
-		CheckpointID: "01JRESULT0000000000000000",
-		Source:       "prose",
-		SearchID:     "01JXK9RSTQ4B7NW2VYFCH6M3DZ",
+		DocRef:   "abcd1234abcd1234",
+		Source:   "prose",
+		SearchID: "01JXK9RSTQ4B7NW2VYFCH6M3DZ",
 	}, "1.2.3")
 	if payload == nil {
 		t.Fatal("expected payload, got nil")

--- a/cmd/entire/cli/telemetry/search_test.go
+++ b/cmd/entire/cli/telemetry/search_test.go
@@ -1,0 +1,71 @@
+package telemetry
+
+import "testing"
+
+func TestBuildSearchPerformedPayload(t *testing.T) {
+	t.Parallel()
+	event := SearchPerformedEvent{
+		SearchID:    "01JXAMPLE0000000000000000",
+		QueryHash:   "abcd1234abcd1234",
+		Mode:        "compact",
+		ResultCount: 5,
+		Total:       42,
+		Page:        1,
+		Limit:       5,
+	}
+	payload := BuildSearchPerformedPayload(event, "1.2.3")
+	if payload == nil {
+		t.Fatal("expected payload, got nil")
+	}
+	if payload.Event != "cli_search_performed" {
+		t.Errorf("event = %q, want cli_search_performed", payload.Event)
+	}
+	if payload.DistinctID == "" {
+		t.Error("distinct_id must be set")
+	}
+	p := payload.Properties
+	for _, key := range []string{"search_id", "query_hash", "mode", "result_count", "total", "page", "limit", "cli_version", "os", "arch"} {
+		if _, ok := p[key]; !ok {
+			t.Errorf("missing property %q", key)
+		}
+	}
+	// Privacy: the raw query, impression tuples, and session identifiers must
+	// never be properties.
+	for _, key := range []string{"query", "impressions", "results", "session_id"} {
+		if _, ok := p[key]; ok {
+			t.Errorf("forbidden property %q present", key)
+		}
+	}
+	if got := p["result_count"]; got != 5 {
+		t.Errorf("result_count = %v, want 5", got)
+	}
+}
+
+func TestBuildCheckpointExplainedPayload(t *testing.T) {
+	t.Parallel()
+	payload := BuildCheckpointExplainedPayload(CheckpointExplainedEvent{
+		CheckpointID: "01JRESULT0000000000000000",
+		Source:       "prose",
+	}, "1.2.3")
+	if payload == nil {
+		t.Fatal("expected payload, got nil")
+	}
+	if payload.Event != "cli_checkpoint_explained" {
+		t.Errorf("event = %q, want cli_checkpoint_explained", payload.Event)
+	}
+	if payload.DistinctID == "" {
+		t.Error("distinct_id must be set")
+	}
+	p := payload.Properties
+	for _, key := range []string{"checkpoint_id", "source", "cli_version", "os", "arch"} {
+		if _, ok := p[key]; !ok {
+			t.Errorf("missing property %q", key)
+		}
+	}
+	if got := p["checkpoint_id"]; got != "01JRESULT0000000000000000" {
+		t.Errorf("checkpoint_id = %v", got)
+	}
+	if got := p["source"]; got != "prose" {
+		t.Errorf("source = %v, want prose", got)
+	}
+}

--- a/cmd/entire/cli/telemetry/search_test.go
+++ b/cmd/entire/cli/telemetry/search_test.go
@@ -5,12 +5,23 @@ import "testing"
 func TestBuildSearchPerformedPayload(t *testing.T) {
 	t.Parallel()
 	event := SearchPerformedEvent{
-		SearchID:    "01JXAMPLE0000000000000000",
-		Mode:        "compact",
-		ResultCount: 5,
-		Total:       42,
-		Page:        1,
-		Limit:       5,
+		SearchID:     "01JXAMPLE0000000000000000",
+		Mode:         "compact",
+		Outcome:      "ok",
+		QueryLength:  12,
+		FetchedCount: 5,
+		Total:        42,
+		ZeroResults:  false,
+		Page:         1,
+		Limit:        5,
+		AllRepos:     true,
+		FilterAuthor: true,
+		FilterDate:   false,
+		FilterBranch: true,
+		FilterRepo:   false,
+		Reranked:     true,
+		TotalMS:      123,
+		Degraded:     false,
 	}
 	payload := BuildSearchPerformedPayload(event, "1.2.3")
 	if payload == nil {
@@ -23,7 +34,12 @@ func TestBuildSearchPerformedPayload(t *testing.T) {
 		t.Error("distinct_id must be set")
 	}
 	p := payload.Properties
-	for _, key := range []string{"search_id", "mode", "result_count", "total", "page", "limit", "cli_version", "os", "arch"} {
+	for _, key := range []string{
+		"search_id", "mode", "outcome", "query_length", "fetched_count", "total",
+		"zero_results", "page", "limit", "all_repos", "f_author", "f_date",
+		"f_branch", "f_repo", "reranked", "total_ms", "degraded",
+		"cli_version", "os", "arch",
+	} {
 		if _, ok := p[key]; !ok {
 			t.Errorf("missing property %q", key)
 		}
@@ -35,8 +51,14 @@ func TestBuildSearchPerformedPayload(t *testing.T) {
 			t.Errorf("forbidden property %q present", key)
 		}
 	}
-	if got := p["result_count"]; got != 5 {
-		t.Errorf("result_count = %v, want 5", got)
+	if got := p["fetched_count"]; got != 5 {
+		t.Errorf("fetched_count = %v, want 5", got)
+	}
+	if got := p["total"]; got != 42 {
+		t.Errorf("total = %v, want 42", got)
+	}
+	if got := p["outcome"]; got != "ok" {
+		t.Errorf("outcome = %v, want ok", got)
 	}
 }
 

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -396,6 +396,11 @@ Two additional events measure search result relevance for agent-driven search
   never sent), the output mode, and result counts/pagination.
 - `cli_checkpoint_explained` — one per successful `entire checkpoint explain`
   id resolution: the opaque checkpoint id and which resolution path handled it.
+  When the invocation carried the `--search-id` token that compact search
+  hints embed (`search-id[:rank]`, both opaque values minted by the CLI
+  itself), the event also carries that `search_id` and `rank`, linking the
+  explain to its search deterministically. The token is strictly validated
+  (26-char ULID) so free-form flag text never reaches telemetry.
 
 No correlation state is stored locally; the funnel is assembled in the
 analytics layer from the events above. Both events honor the same opt-outs as

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -387,6 +387,20 @@ The CLI captures anonymous usage analytics by default. Sent to PostHog with `Dis
 
 Not captured: flag values, prompt text, transcripts, file paths, repository identifiers, GitHub usernames, source code.
 
+Two additional events measure search result relevance for agent-driven search
+(the search → explain funnel):
+
+- `cli_search_performed` — one per `entire search` JSON invocation: a
+  client-minted `search_id` (a ULID, also present in the JSON envelope), a
+  `query_hash` (truncated SHA-256 of the normalized query — raw query text is
+  never sent), the output mode, and result counts/pagination.
+- `cli_checkpoint_explained` — one per successful `entire checkpoint explain`
+  id resolution: the opaque checkpoint id and which resolution path handled it.
+
+No correlation state is stored locally; the funnel is assembled in the
+analytics layer from the events above. Both events honor the same opt-outs as
+all other telemetry.
+
 Opt out via any one of:
 
 - `--telemetry=false` on a command that accepts it.


### PR DESCRIPTION
## Summary

Agent-driven search (~80% of expected search traffic) has no web-style click signal, so we can't tell whether the results we return are relevant. This closes the loop statelessly — no local correlation files ([ENT-1528](https://linear.app/entirehq/issue/ENT-1528), full plan + updates in the ticket comments).

- **`search_id` in every search JSON envelope** (`--json` and `--compact`): a client-minted ULID — the server response carries no request id and the CLI merges per-cell responses, so it can't come from the server. Also the future seam for server-side impression logging in query-serve.
- **Per-hit `explain` hint in `--compact` output**: `"explain": "entire checkpoint explain <id> [--repo <org>/<name>] --search-id <search_id>:<rank>"`. The `--repo` form covers cross-repo checkpoint hits (rides #1942); repo/pr/session rows get no hint since explain can't resolve them. The trailing token is the deterministic link: agents copy the hint verbatim, like a web SERP link carrying its tracking params.
- **`cli_search_performed` event**: `search_id`, `query_hash` (truncated SHA-256 of the normalized query — raw text never sent), mode, result_count, total, page, limit.
- **`cli_checkpoint_explained` event**: opaque checkpoint id + which resolution path fired (`prose` / `export` / `cross_repo`), hooked once at each of explain's three id-resolution success points. When the invocation carried `--search-id` (hidden flag, threaded via context — same pattern as `withCrossRepoRead`), the event also carries `search_id` + `rank`.

**Analysis unlocked in PostHog:** exact search→explain funnel joined on `search_id`, CTR-by-rank, reformulation/abandonment chains, and hint compliance (share of explain events carrying `search_id`; token-less explains fall back to time-proximity correlation).

## Privacy

No query text, prompts, file paths, repo names, or session ids in any event; nothing written locally. `search_id`/`rank` are opaque CLI-minted values, and the `--search-id` flag value is strictly validated (26-char ULID, positive rank) with malformed tokens silently dropped — attribution can never fail an explain or leak free-form flag text into telemetry. Both events follow the existing `Build*Payload`/`Track*` pattern through the detached `__send_analytics` spawn and are double-gated: `settings.Telemetry == true` at the call site + `ENTIRE_TELEMETRY_OPTOUT` inside `Track*`. Documented in `docs/security-and-privacy.md`.

## Review feedback addressed

- Trail Review: moved the export-path emit out of `resolveExplainCheckpointID` (shared with `entire checkpoint tokens`) into the explain-only callers, so token lookups don't pollute the funnel.

## Test plan

- [x] `mise run fmt && mise run lint` — clean
- [x] `mise run test:ci` (unit + integration + Vogon/roger-roger E2E canary) — all passed, rerun after every change
- [x] New tests: payload shapes for both events (raw query/impressions/session_id asserted absent; `search_id`/`rank` present only with attribution), query-hash normalization, ULID search_id, `search_id` in both envelopes, same-repo vs cross-repo hints with rank tokens, absolute rank across pages, no hint on repo/pr rows, `--search-id` token validation (junk/short/bad-rank cases), context round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Design update (2026-08-16) — v2 amendments incoming

Following the trail 1019 review findings and an adversarial pass on the wider feedback-loop design (see ENT-1528 comments), this PR will be amended. The mechanism (client-minted `search_id`, stateless hint tokens, search→explain funnel) is unchanged; the following correct privacy and soundness defects:

**Privacy (trail high finding):**
- `cli_checkpoint_explained` will carry **`doc_ref` — a truncated SHA-256 of the checkpoint id — instead of the raw `checkpoint_id`**. A checkpoint id resolves via our own API to repo/session/author/prompt, contradicting the security doc's "no repository identifiers" guarantee. The hash is deterministic so server-side analysis can still join it against candidate ids from `search_event` records (the search service is gaining that record in a sibling PR); nothing in PostHog alone can resolve it to content.
- **`query_hash` is removed entirely** (not HMAC'd): a truncated unsalted SHA-256 of low-entropy natural language is dictionary-confirmable, and no v1 analysis consumes it — reformulation chains group by machine + time window; query-content analysis lives server-side. The event keeps `query_length` only.

**Soundness (trail medium/low findings):**
- `search_id` is minted **before** the request and sent as `X-Entire-Search-Id` (plus `X-Entire-Client: <surface>/<version>`), making it the real server-side seam — each cell will log it in its `search_event` record.
- `--search-id` is **un-hidden** so `agent-help` advertises it (hidden flags are stripped by agents that validate commands against agent-help, which would silently zero hint compliance).
- `cli_checkpoint_explained` fires **after a successful render**, not at id resolution — failures no longer count as clicks.
- The event emits **normalized** `page`/`limit` (matching the envelope and hint ranks) and both `fetched_count` and the server's true `total`.
- `cli_search_performed` fires on the **error path too** (`outcome: error_*`) and gains `zero_results`, `reranked`, `total_ms`, `all_repos`, and filter-presence booleans — all already on the wire, previously discarded.
- Explain hints are added to **plain `--json`** output as well (a large share of agent traffic doesn't use `--compact`; those explains could otherwise only ever join by time proximity).

**Tests** (trail finding): a hint→explain round-trip contract test (generated hint parsed by the real command's flag set) and settings-gate tests for both emit helpers, including the nil-settings case.

Analysis-layer rules that go with this (documented in the design): funnel joins enforce a ≤1h validity window on the ULID timestamp (stale hints replayed from transcripts must not count), and server-minted-id records are excluded from funnel denominators.
