### PR TITLE
test(canary): fire subagent hooks in Vogon so the canary can see that path

### DIFF
--- a/cmd/entire/cli/agent/vogon/hooks.go
+++ b/cmd/entire/cli/agent/vogon/hooks.go
@@ -21,6 +21,8 @@ const (
 	HookNameSessionEnd       = "session-end"
 	HookNameStop             = "stop"
 	HookNameUserPromptSubmit = "user-prompt-submit"
+	HookNamePreTask          = "pre-task"
+	HookNamePostTask         = "post-task"
 )
 
 // HookNames returns the hooks the vogon agent supports.
@@ -30,6 +32,8 @@ func (v *Agent) HookNames() []string {
 		HookNameSessionEnd,
 		HookNameStop,
 		HookNameUserPromptSubmit,
+		HookNamePreTask,
+		HookNamePostTask,
 	}
 }
 
@@ -58,6 +62,37 @@ func (v *Agent) ParseHookEvent(_ context.Context, hookName string, stdin io.Read
 
 	case HookNameSessionEnd:
 		return parseSessionInfoEvent(stdin, agent.SessionEnd)
+
+	case HookNamePreTask:
+		raw, err := agent.ReadAndParseHookInput[taskRaw](stdin)
+		if err != nil {
+			return nil, err
+		}
+		return &agent.Event{
+			Type:            agent.SubagentStart,
+			SessionID:       raw.SessionID,
+			SessionRef:      raw.TranscriptPath,
+			ToolUseID:       raw.ToolUseID,
+			SubagentType:    raw.SubagentType,
+			TaskDescription: raw.Description,
+			Timestamp:       time.Now(),
+		}, nil
+
+	case HookNamePostTask:
+		raw, err := agent.ReadAndParseHookInput[taskRaw](stdin)
+		if err != nil {
+			return nil, err
+		}
+		return &agent.Event{
+			Type:            agent.SubagentEnd,
+			SessionID:       raw.SessionID,
+			SessionRef:      raw.TranscriptPath,
+			ToolUseID:       raw.ToolUseID,
+			SubagentID:      raw.AgentID,
+			SubagentType:    raw.SubagentType,
+			TaskDescription: raw.Description,
+			Timestamp:       time.Now(),
+		}, nil
 
 	default:
 		return nil, nil //nolint:nilnil // Unknown hooks have no lifecycle action
@@ -108,6 +143,19 @@ type sessionInfoRaw struct {
 	SessionID      string `json:"session_id"`
 	TranscriptPath string `json:"transcript_path"`
 	Model          string `json:"model,omitempty"`
+}
+
+// taskRaw is the payload for pre-task / post-task. Unlike Claude Code, vogon
+// passes the subagent type, description and agent ID as flat fields rather than
+// nested under tool_input/tool_response — the dispatcher accepts either, and flat
+// fields keep the fake agent's payload readable.
+type taskRaw struct {
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+	ToolUseID      string `json:"tool_use_id"`
+	AgentID        string `json:"agent_id,omitempty"`
+	SubagentType   string `json:"subagent_type,omitempty"`
+	Description    string `json:"description,omitempty"`
 }
 
 type userPromptSubmitRaw struct {

--- a/cmd/entire/cli/agent/vogon/transcript.go
+++ b/cmd/entire/cli/agent/vogon/transcript.go
@@ -1,0 +1,97 @@
+package vogon
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// Compile-time assertion that vogon can report transcript-derived file lists.
+var _ agent.TranscriptAnalyzer = (*Agent)(nil)
+
+// transcriptLine is the subset of the vogon binary's JSONL the analyzer reads.
+// Keep the `files` field in step with e2e/vogon/main.go's transcriptEntry.
+type transcriptLine struct {
+	Type  string   `json:"type"`
+	Files []string `json:"files,omitempty"`
+}
+
+// GetTranscriptPosition returns the transcript's line count, or 0 when it does not
+// exist yet.
+func (v *Agent) GetTranscriptPosition(path string) (int, error) {
+	lines, err := readTranscriptLines(path)
+	if err != nil {
+		return 0, err
+	}
+	return len(lines), nil
+}
+
+// ExtractModifiedFilesFromOffset returns the files recorded by tool-use entries at
+// or after startOffset, plus the transcript's current line count.
+//
+// Vogon implements this so the canary exercises the *transcript-derived* file path
+// that real agents take — in particular the subagent case, where a subagent's writes
+// appear only in its own transcript. Without it, `entire hooks vogon post-task`
+// would fall back to worktree state alone and the canary could not see regressions
+// in subagent transcript resolution or file attribution.
+func (v *Agent) ExtractModifiedFilesFromOffset(path string, startOffset int) ([]string, int, error) {
+	lines, err := readTranscriptLines(path)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	seen := make(map[string]struct{})
+	var files []string
+	for i, raw := range lines {
+		if i < startOffset {
+			continue
+		}
+		var entry transcriptLine
+		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+			continue // a malformed line is not fatal; the real agents skip too
+		}
+		for _, f := range entry.Files {
+			if f == "" {
+				continue
+			}
+			if _, dup := seen[f]; dup {
+				continue
+			}
+			seen[f] = struct{}{}
+			files = append(files, f)
+		}
+	}
+	return files, len(lines), nil
+}
+
+// readTranscriptLines returns the transcript's non-empty lines. A missing file is
+// not an error — it just has no content yet.
+func readTranscriptLines(path string) ([]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+	f, err := os.Open(path) //nolint:gosec // path comes from the hook payload
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open transcript: %w", err)
+	}
+	defer f.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for scanner.Scan() {
+		if line := scanner.Text(); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read transcript: %w", err)
+	}
+	return lines, nil
+}

--- a/cmd/entire/cli/agent/vogon/transcript.go
+++ b/cmd/entire/cli/agent/vogon/transcript.go
@@ -12,6 +12,10 @@ import (
 // Compile-time assertion that vogon can report transcript-derived file lists.
 var _ agent.TranscriptAnalyzer = (*Agent)(nil)
 
+// transcriptTypeToolUse is the entry type the vogon binary writes for file
+// writes. Keep in step with appendToolUse in e2e/vogon/main.go.
+const transcriptTypeToolUse = "tool_use"
+
 // transcriptLine is the subset of the vogon binary's JSONL the analyzer reads.
 // Keep the `files` field in step with e2e/vogon/main.go's transcriptEntry.
 type transcriptLine struct {
@@ -52,6 +56,12 @@ func (v *Agent) ExtractModifiedFilesFromOffset(path string, startOffset int) ([]
 		var entry transcriptLine
 		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
 			continue // a malformed line is not fatal; the real agents skip too
+		}
+		// Only tool-use entries report file writes. Accepting a `files` field on
+		// any line would misattribute files if the transcript format grows another
+		// entry type that happens to carry paths.
+		if entry.Type != transcriptTypeToolUse {
+			continue
 		}
 		for _, f := range entry.Files {
 			if f == "" {

--- a/cmd/entire/cli/agent/vogon/transcript_test.go
+++ b/cmd/entire/cli/agent/vogon/transcript_test.go
@@ -1,0 +1,74 @@
+package vogon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExtractModifiedFilesFromOffset_OnlyToolUseEntries pins the analyzer to its
+// contract: file paths come from tool-use entries only. Reading `files` off any
+// line would misattribute paths the moment the transcript format grows another
+// entry type carrying them.
+func TestExtractModifiedFilesFromOffset_OnlyToolUseEntries(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	lines := `{"type":"user","message":"write two files"}
+{"type":"tool_use","message":"wrote a.go","files":["a.go"]}
+{"type":"summary","message":"touched b.go","files":["b.go"]}
+{"type":"assistant","message":"done"}
+`
+	if err := os.WriteFile(path, []byte(lines), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	files, pos, err := (&Agent{}).ExtractModifiedFilesFromOffset(path, 0)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFilesFromOffset: %v", err)
+	}
+	if pos != 4 {
+		t.Errorf("position = %d, want 4", pos)
+	}
+	if len(files) != 1 || files[0] != "a.go" {
+		t.Errorf("files = %v, want [a.go] — a non-tool_use entry must not contribute paths", files)
+	}
+}
+
+// TestExtractModifiedFilesFromOffset_HonoursOffsetAndDedupes covers the two other
+// properties the framework relies on: entries before the offset are excluded (turn
+// scoping), and a file written twice is reported once.
+func TestExtractModifiedFilesFromOffset_HonoursOffsetAndDedupes(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	lines := `{"type":"tool_use","message":"wrote old.go","files":["old.go"]}
+{"type":"tool_use","message":"wrote new.go","files":["new.go"]}
+{"type":"tool_use","message":"wrote new.go again","files":["new.go"]}
+`
+	if err := os.WriteFile(path, []byte(lines), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	files, _, err := (&Agent{}).ExtractModifiedFilesFromOffset(path, 1)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFilesFromOffset: %v", err)
+	}
+	if len(files) != 1 || files[0] != "new.go" {
+		t.Errorf("files = %v, want [new.go] (old.go is before the offset, new.go deduped)", files)
+	}
+}
+
+// TestGetTranscriptPosition_MissingFile documents that an absent transcript is not
+// an error — the framework asks for a position before the agent has written one.
+func TestGetTranscriptPosition_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	pos, err := (&Agent{}).GetTranscriptPosition(filepath.Join(t.TempDir(), "absent.jsonl"))
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition on a missing file: %v", err)
+	}
+	if pos != 0 {
+		t.Errorf("position = %d, want 0", pos)
+	}
+}

--- a/e2e/tests/subagent_commit_flow_test.go
+++ b/e2e/tests/subagent_commit_flow_test.go
@@ -42,6 +42,14 @@ func TestSubagentCommitFlow(t *testing.T) {
 		sm := testutil.ReadSessionMetadata(t, s.Dir, cpID, 0)
 		assert.NotEmpty(t, sm.Agent, "session agent field should be populated")
 		assert.NotEmpty(t, sm.SessionID, "session_id should be set")
+
+		// The subagent's work must be attributed to the checkpoint. Only the
+		// subagent's own transcript records its Write, so this is what fails when
+		// subagent transcript resolution or file attribution breaks — the test
+		// previously passed on file existence alone and could not see that.
+		assert.Contains(t, meta.FilesTouched, "docs/red.md",
+			"the file the subagent created must be attributed to the checkpoint")
+
 		testutil.WaitForNoShadowBranches(t, s.Dir, 10*time.Second)
 	})
 }

--- a/e2e/vogon/main.go
+++ b/e2e/vogon/main.go
@@ -24,7 +24,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -191,9 +190,26 @@ func delegatesToSubagent(prompt string) bool {
 // is the real thing being modelled: a subagent's edits are invisible in the main
 // transcript, which is what made a wrong subagent-transcript path silently fall
 // back to scanning the main one.
+// subagentSeq numbers delegations within this process so each task gets its own
+// tool-use and agent ID.
+//
+// Deriving them from the prompt or action count instead would collide: a vogon
+// process handles every prompt of a session (see the multi-prompt loop in main),
+// and two delegated prompts that happen to produce the same action count — the
+// common case, one file each — would share an agent ID. The framework keys
+// pre-task state on the tool-use ID (pre-task-<id>.json) and the subagent
+// transcript on the agent ID, so a collision silently overwrites the first task's
+// state and transcript, corrupting attribution. A counter keeps vogon
+// deterministic, which a UUID would not.
+var subagentSeq int
+
+func nextSubagentIDs() (toolUseID, agentID string) {
+	subagentSeq++
+	return fmt.Sprintf("toolu_vogon%03d", subagentSeq), fmt.Sprintf("avogon%03d", subagentSeq)
+}
+
 func runSubagentTask(dir, sessionID, transcriptPath, prompt string, actions []action) {
-	toolUseID := "toolu_vogon" + strconv.FormatInt(int64(len(prompt)), 16)
-	agentID := "avogon" + strconv.FormatInt(int64(len(actions)), 16)
+	toolUseID, agentID := nextSubagentIDs()
 
 	fireHook(dir, "pre-task", map[string]string{
 		"session_id":      sessionID,

--- a/e2e/vogon/main.go
+++ b/e2e/vogon/main.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -153,7 +154,11 @@ func runTurn(dir, sessionID, transcriptPath, prompt string) {
 	appendTranscript(transcriptPath, "user", prompt)
 
 	actions := parsePrompt(prompt)
-	executeActions(dir, actions)
+	if delegatesToSubagent(prompt) {
+		runSubagentTask(dir, sessionID, transcriptPath, prompt, actions)
+	} else {
+		appendToolUse(transcriptPath, executeActions(dir, actions))
+	}
 
 	appendTranscript(transcriptPath, "assistant", fmt.Sprintf("Done. Executed %d actions.", len(actions)))
 	fmt.Fprintf(os.Stdout, "Done. Executed %d actions.\n", len(actions))
@@ -163,6 +168,69 @@ func runTurn(dir, sessionID, transcriptPath, prompt string) {
 		"transcript_path": transcriptPath,
 		"model":           "vogon-llm-42",
 	})
+}
+
+// subagentPromptRe matches the delegation phrasing the e2e prompts use ("use a
+// subagent: …", "using a subagent", "delegate to a subagent"). Vogon has no real
+// subagents; it simulates one so the pre-task/post-task hooks, the task
+// checkpoint, and the shadow-branch lifecycle around them are exercised on every
+// canary run. Before this, the canary fired no subagent hooks at all, so a whole
+// class of regression was invisible to it (see TestSubagentCommitFlow).
+var subagentPromptRe = regexp.MustCompile(`(?i)\b(use|using|via|with|delegate to)\s+(a\s+)?sub-?agent`)
+
+func delegatesToSubagent(prompt string) bool {
+	return subagentPromptRe.MatchString(prompt)
+}
+
+// runSubagentTask performs the actions as a simulated subagent: pre-task, then the
+// work recorded in a *separate* subagent transcript, then post-task.
+//
+// The subagent transcript deliberately lives at the layout the framework resolves
+// (paths.SubagentsDir: <transcriptDir>/<sessionID>/subagents/agent-<id>.jsonl), and
+// the writes are recorded ONLY there — never in the main transcript. That asymmetry
+// is the real thing being modelled: a subagent's edits are invisible in the main
+// transcript, which is what made a wrong subagent-transcript path silently fall
+// back to scanning the main one.
+func runSubagentTask(dir, sessionID, transcriptPath, prompt string, actions []action) {
+	toolUseID := "toolu_vogon" + strconv.FormatInt(int64(len(prompt)), 16)
+	agentID := "avogon" + strconv.FormatInt(int64(len(actions)), 16)
+
+	fireHook(dir, "pre-task", map[string]string{
+		"session_id":      sessionID,
+		"transcript_path": transcriptPath,
+		"tool_use_id":     toolUseID,
+		"subagent_type":   "vogon-worker",
+		"description":     "vogon delegated task",
+	})
+
+	subagentTranscript := setupSubagentTranscript(transcriptPath, sessionID, agentID)
+	appendTranscript(subagentTranscript, "user", prompt)
+	touched := executeActions(dir, actions)
+	appendToolUse(subagentTranscript, touched)
+	appendTranscript(subagentTranscript, "assistant", "Subagent done.")
+
+	fireHook(dir, "post-task", map[string]string{
+		"session_id":      sessionID,
+		"transcript_path": transcriptPath,
+		"tool_use_id":     toolUseID,
+		"agent_id":        agentID,
+		"subagent_type":   "vogon-worker",
+		"description":     "vogon delegated task",
+	})
+}
+
+// setupSubagentTranscript creates the subagent transcript where the framework
+// looks for it — keep in step with paths.SubagentsDir.
+func setupSubagentTranscript(mainTranscriptPath, sessionID, agentID string) string {
+	dir := filepath.Join(filepath.Dir(mainTranscriptPath), sessionID, "subagents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fatal("mkdir subagents dir: %v", err)
+	}
+	path := filepath.Join(dir, "agent-"+agentID+".jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		fatal("create subagent transcript: %v", err)
+	}
+	return path
 }
 
 // --- Prompt Parsing ---
@@ -467,24 +535,28 @@ func extractTopic(prompt string) string {
 	return "the topic"
 }
 
-func executeActions(dir string, actions []action) {
-	var pendingFiles []string
+func executeActions(dir string, actions []action) []string {
+	var touched, pendingFiles []string
 	for _, a := range actions {
 		switch a.kind {
 		case "create":
 			createFile(dir, a.path, a.content)
 			pendingFiles = append(pendingFiles, a.path)
+			touched = append(touched, a.path)
 		case "modify":
 			modifyFile(dir, a.path, a.content)
 			pendingFiles = append(pendingFiles, a.path)
+			touched = append(touched, a.path)
 		case "delete":
 			deleteFile(dir, a.path)
 			pendingFiles = append(pendingFiles, a.path)
+			touched = append(touched, a.path)
 		case "commit":
 			gitCommit(dir, pendingFiles)
 			pendingFiles = nil
 		}
 	}
+	return touched
 }
 
 func createFile(dir, path, content string) {
@@ -580,14 +652,36 @@ type transcriptEntry struct {
 	Type      string `json:"type"`
 	Timestamp string `json:"timestamp"`
 	Message   string `json:"message"`
+	// Files records the paths a tool-use entry touched. The vogon Agent's
+	// TranscriptAnalyzer reads these back, which is what lets the canary cover
+	// transcript-derived file extraction — the path a real agent takes and the
+	// one where a subagent's writes are only ever visible in its own transcript.
+	Files []string `json:"files,omitempty"`
 }
 
 func appendTranscript(path, role, content string) {
-	entry := transcriptEntry{
+	appendTranscriptEntry(path, transcriptEntry{
 		Type:      role,
 		Timestamp: time.Now().Format(time.RFC3339),
 		Message:   content,
+	})
+}
+
+// appendToolUse records the files a (sub)agent wrote, mirroring how a real agent's
+// transcript carries Write/Edit tool calls.
+func appendToolUse(path string, files []string) {
+	if len(files) == 0 {
+		return
 	}
+	appendTranscriptEntry(path, transcriptEntry{
+		Type:      "tool_use",
+		Timestamp: time.Now().Format(time.RFC3339),
+		Message:   "wrote " + strings.Join(files, ", "),
+		Files:     files,
+	})
+}
+
+func appendTranscriptEntry(path string, entry transcriptEntry) {
 	data, _ := json.Marshal(entry) //nolint:errchkjson // transcriptEntry has no unsafe types
 	data = append(data, '\n')
 

--- a/e2e/vogon/main_test.go
+++ b/e2e/vogon/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import "testing"
+
+// TestNextSubagentIDsAreUniquePerTask guards the per-task uniqueness the framework
+// depends on. A vogon process handles every prompt of a session, so two delegated
+// prompts must not share IDs: pre-task state is keyed on the tool-use ID
+// (pre-task-<id>.json) and the subagent transcript on the agent ID, so a collision
+// silently overwrites the first task's state and transcript.
+//
+// Deriving them from prompt length or action count did collide — the common case is
+// one file per prompt, so every delegation produced the same agent ID.
+func TestNextSubagentIDsAreUniquePerTask(t *testing.T) {
+	subagentSeq = 0
+	t.Cleanup(func() { subagentSeq = 0 })
+
+	seenTool := map[string]bool{}
+	seenAgent := map[string]bool{}
+	for i := range 5 {
+		toolUseID, agentID := nextSubagentIDs()
+		if toolUseID == "" || agentID == "" {
+			t.Fatalf("call %d returned an empty ID (%q, %q)", i, toolUseID, agentID)
+		}
+		if seenTool[toolUseID] {
+			t.Errorf("duplicate tool-use ID %q on call %d", toolUseID, i)
+		}
+		if seenAgent[agentID] {
+			t.Errorf("duplicate agent ID %q on call %d", agentID, i)
+		}
+		seenTool[toolUseID] = true
+		seenAgent[agentID] = true
+	}
+}
+
+// TestDelegatesToSubagent covers the phrasings the e2e prompts use, and that an
+// ordinary prompt is not mistaken for a delegation.
+func TestDelegatesToSubagent(t *testing.T) {
+	t.Parallel()
+
+	delegating := []string{
+		"use a subagent: create docs/red.md",
+		"Using a sub-agent, create a file",
+		"delegate to a subagent and commit",
+		"do it with a subagent",
+	}
+	for _, p := range delegating {
+		if !delegatesToSubagent(p) {
+			t.Errorf("delegatesToSubagent(%q) = false, want true", p)
+		}
+	}
+
+	direct := []string{
+		"create a markdown file at docs/red.md",
+		"commit the changes",
+		"modify two existing files",
+	}
+	for _, p := range direct {
+		if delegatesToSubagent(p) {
+			t.Errorf("delegatesToSubagent(%q) = true, want false", p)
+		}
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1011
<!-- entire-trail-link-end -->

> **Stacked on #1950** (base is `soph/fix-subagent-orphan-shadow-branch`). It has to be: with this coverage in place and #1950's fix absent, the canary correctly fails — that's the whole point. Rebase onto main once #1950 lands.

## Why

The canary fired **no subagent hooks at all**. Vogon parsed `"use a subagent: create docs/red.md"` and just did the work itself, so `TestSubagentCommitFlow` passed on file existence alone — `pre-task`/`post-task`, the task checkpoint, and the shadow branch around them were never exercised.

That blind spot has a price attached now: the #1935 regression reached main and was caught only by a **paid real-agent E2E run, one merge later**, after #1935's own run had been cancelled by the next push.

## What changed

Vogon simulates a delegation when the prompt asks for one: `pre-task` → work → `post-task` with an agent ID. Two details carry the weight:

1. **The subagent transcript lives where the framework resolves it** (`paths.SubagentsDir`), and the file writes are recorded **only there — never in the main transcript**. That asymmetry is the thing worth modelling: a subagent's edits are invisible in the main transcript, which is exactly what let a wrong subagent-transcript path silently fall back to scanning the main one.
2. **Vogon gains a `TranscriptAnalyzer`**, so those records are read back through the same transcript-derived extraction real agents use. Without it the hooks would fire but every file list would come from worktree state alone — and the regression class this is meant to catch would still be invisible. This is the difference between "the canary calls the hooks" and "the canary can catch #1950".

## Proof it catches the real thing

With #1950's fix reverted on this branch:

```
✗ TestSingleSessionSubagentCommitInTurn (vogon, 12.1s)
    shadow branches should be cleaned up within 10s after commit,
    found: [entire/ad2f010-e3b0c4]
```

That is the same symptom CI produced on main — reproduced with **no API calls**. Restore the fix and it passes.

Also: `TestSubagentCommitFlow` now asserts the subagent's file is attributed to the checkpoint (`meta.FilesTouched` contains it), rather than only that the file exists and some checkpoint happened.

## Results

- Default canary: **60/60 vogon**, both subagent tests exercising the hooks (verified in the artifacts: `subagent started` → `subagent completed` with `agent_id` → `created shadow branch and committed task checkpoint` → `session condensed` → `shadow branch deleted`).
- `mise run check` green.

**Pre-existing, untouched:** roger-roger fails `TestSingleSessionSubagentCommitInTurn` both before and after this change — verified by running it against a clean tree. That is why the test is not in its default `TestExternalAgent` filter, and it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the fake vogon agent and e2e canary coverage; no production agent or checkpoint logic is modified.
> 
> **Overview**
> Makes the vogon canary exercise the real **subagent lifecycle** instead of doing delegated work inline. Prompts that ask for a subagent now fire `pre-task`/`post-task`, write tool-use file records only into a separate subagent transcript under `paths.SubagentsDir`, and use unique per-task IDs so state is not overwritten across turns.
> 
> Vogon also implements `TranscriptAnalyzer` so post-task file lists come from those transcript records (tool-use entries only), matching how real agents attribute subagent writes. `TestSubagentCommitFlow` now asserts `docs/red.md` appears in checkpoint `FilesTouched`, so broken subagent transcript resolution fails the canary instead of passing on file existence alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e375b84f012f0e8458b0545eab8bc863494c872. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->