### PR TITLE
fix(lint): use the package's scheme constants instead of "http"/"https"

### DIFF
--- a/cmd/entire/cli/plugin_fetch.go
+++ b/cmd/entire/cli/plugin_fetch.go
@@ -56,9 +56,9 @@ func requireSecureAssetURL(rawURL string) error {
 		return fmt.Errorf("parse download URL %q: %w", redactURL(rawURL), err)
 	}
 	switch strings.ToLower(u.Scheme) {
-	case "https":
+	case schemeHTTPS:
 		return nil
-	case "http":
+	case schemeHTTP:
 		if isLoopbackHost(u.Hostname()) {
 			return nil
 		}
@@ -121,7 +121,7 @@ func releaseAssetBaseURL(repoURL, tag string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse repo URL: %w", err)
 	}
-	if u.Scheme != "https" && u.Scheme != "http" {
+	if u.Scheme != schemeHTTPS && u.Scheme != schemeHTTP {
 		return "", fmt.Errorf("release downloads need an http(s) repo URL, got %q (declare download_url in %s for non-HTTP remotes)", redactURL(repoURL), pluginMetadataFileName)
 	}
 	base := strings.TrimSuffix(u.String(), "/")

--- a/cmd/entire/cli/review_target.go
+++ b/cmd/entire/cli/review_target.go
@@ -139,7 +139,7 @@ func normalizeReviewTargetSelector(raw, forge, owner, repo string) (string, bool
 	if parseErr != nil || u.Scheme == "" || u.Host == "" {
 		return "", true, fmt.Errorf("invalid review target URL %q", raw)
 	}
-	if u.Scheme != "https" && u.Scheme != "http" {
+	if u.Scheme != schemeHTTPS && u.Scheme != schemeHTTP {
 		return "", true, fmt.Errorf("unsupported review target URL scheme %q", u.Scheme)
 	}
 	host := strings.ToLower(u.Hostname())


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1022
<!-- entire-trail-link-end -->

Main is red on lint: two `goconst` errors in `cmd/entire/cli/plugin_fetch.go`.

```
plugin_fetch.go:59:7: string `https` has 3 occurrences, but such constant `schemeHTTPS` already exists
plugin_fetch.go:61:7: string `http`  has 3 occurrences, but such constant `schemeHTTP`  already exists
```

`login.go:25-26` already declares `schemeHTTP` and `schemeHTTPS` for this package, so the literals just need to use them. This changes three call sites:

- `plugin_fetch.go:59,61` — `case "https":` / `case "http":`

- `plugin_fetch.go:124` — `u.Scheme != "https" && u.Scheme != "http"`

- `review_target.go:142` — the same comparison

## Why it only broke after the merge

`goconst` counts occurrences per package, with a threshold of 3. The literals were split across two files that never existed at the same time until the merge:

| Commit | plugin_fetch.go | review_target.go | occurrences of `"https"` | lint |
|---|---|---|---|---|
| main before merge (`6e7985f4e`) | 2 | absent | 2 | pass |
| trail branch head (`b989d612c`) | absent | 1 | 1 | pass |
| merge (`f6fd1159d`) | 2 | 1 | 3 | fail |

Both parents were genuinely green. The trail branch last merged main at `fbbff047` on Aug 10, 08:38; `plugin_fetch.go` landed on main at `18f9bcd9d` (PR #1422) on Aug 10, 21:42 — 13 hours later. Nothing in the two diffs overlaps, so git merged cleanly and only the merged package hit 3.

Two things worth noting for later:

1. `goconst` blamed `plugin_fetch.go`, which the merge never touched. The new code was `review_target.go`.

2. `.github/workflows/lint.yml` checks out `github.event.pull_request.head.sha`, so the merged tree is never linted before it lands. Any package-counting linter (`goconst`, `dupl`, `maintidx`) can only be caught after the fact. Checking out the PR merge commit instead would catch this class before merge, at the cost of the run depending on main moving underneath the PR.

## Verification

`mise run fmt && mise run lint` → 0 issues. `mise run test:ci` passes.

<!-- entire-shadow-pr -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure lint/refactor with no behavioral change; only substitutes existing package constants for equivalent string literals.
> 
> **Overview**
> Replaces hardcoded `"http"`/`"https"` string literals with the package's existing `schemeHTTP` and `schemeHTTPS` constants in URL scheme checks.
> 
> Touches `requireSecureAssetURL` and `releaseAssetBaseURL` in `plugin_fetch.go`, plus review-target URL validation in `review_target.go`. Behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c97b26e12777cf93855b7a598baaf440216ec1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
