### PR TITLE
feat(agent-help): group commands by who should initiate them; trim the injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,16 +113,29 @@ jurisdiction's cell instead of the caller's home cell and implies `--to cell`
 via `auth.CellTarget`). `{owner}`/`{repo}`/`{repo_id}` in the path are filled
 from the current repo's origin remote.
 
-`api` is an **escape hatch, not a front-line command**, and its help says so.
-It is the right tool in exactly two cases: developing against Entire's own APIs
-and wanting a raw response, or needing something no first-class command covers.
-Otherwise the purpose-built command wins — raw endpoints are internal and can
-change shape without notice, so parsing them is brittle. It is therefore
-deliberately **not** in `agent-help`'s curated listing (`listed: false`), but
-stays visible in `entire help` and named in agent-help's footer index so an
-agent that genuinely needs raw access finds it instead of hand-rolling curl
-with a token — which is the failure this command exists to prevent. Keep both
-halves of that balance in mind when changing its visibility.
+`api` is an **escape hatch, not a front-line command**: it is right when
+developing against Entire's own APIs and wanting a raw response, or when no
+first-class command covers the need — not during ordinary work in a repo with
+Entire enabled. It is therefore deliberately **not** in `agent-help`'s curated
+listing (`listed: false`), but stays visible in `entire help` and named in
+agent-help's footer index, so an agent that genuinely needs raw access finds it
+instead of hand-rolling curl with a token — the failure this command exists to
+prevent. Keep both halves of that balance in mind when changing its visibility.
+
+**Where that steer lives matters.** "This is a last resort" is agent guidance,
+not human help: someone who typed `entire api --help` chose the command on
+purpose, and telling them to reconsider is noise. So it lives in
+`agentHelpGuidance` (keyed by command path, rendered only by `agent-help` as a
+"When to use this:" block and as a `guidance` field in `--json`), never in
+cobra's `Long`. The split rule, which applies to any command that needs it:
+
+- true for **both** audiences → `Long` (e.g. "these endpoints are internal and
+  can change shape without notice")
+- useful only to an agent choosing from a surface it doesn't know →
+  `agentHelpGuidance`
+
+`TestAgentHelpGuidance_NeverLeaksIntoCobraHelp` fails CI if guidance text is
+pasted into a command's `Short`/`Long`.
 
 `agent-help` renders machine-readable, agent-facing usage live from the Cobra
 command tree (so it always matches the installed binary): bare prints a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,18 @@ entire-api cell. `--jurisdiction <slug>` (e.g. `us`, `eu`) targets a specific
 jurisdiction's cell instead of the caller's home cell and implies `--to cell`
 (cell routing + identity-token exchange live in `auth.NewEntireAPICellClient`
 via `auth.CellTarget`). `{owner}`/`{repo}`/`{repo_id}` in the path are filled
-from the current repo's origin remote. It is visible in `entire help` and
-`entire agent-help`, so agents discover it as the supported way to call the API.
+from the current repo's origin remote.
+
+`api` is an **escape hatch, not a front-line command**, and its help says so.
+It is the right tool in exactly two cases: developing against Entire's own APIs
+and wanting a raw response, or needing something no first-class command covers.
+Otherwise the purpose-built command wins — raw endpoints are internal and can
+change shape without notice, so parsing them is brittle. It is therefore
+deliberately **not** in `agent-help`'s curated listing (`listed: false`), but
+stays visible in `entire help` and named in agent-help's footer index so an
+agent that genuinely needs raw access finds it instead of hand-rolling curl
+with a token — which is the failure this command exists to prevent. Keep both
+halves of that balance in mind when changing its visibility.
 
 `agent-help` renders machine-readable, agent-facing usage live from the Cobra
 command tree (so it always matches the installed binary): bare prints a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,42 @@ command tree (so it always matches the installed binary): bare prints a
 one command's current flags; `--json` emits structured output. It is the single
 source of truth the first-turn context injection and the `--agent-help-skill`
 skill point agents at, instead of enumerating a surface that goes stale.
+
+The bare listing is grouped by **who should initiate the command**, not
+alphabetically, because the question an agent has when reading it is "may I run
+this unprompted?" — read-only (safe on its own) · task-driven (writes data or
+spends tokens) · user-owned (setup, auth, admin, destructive, or expensive
+enough that starting one uninvited is the user's call — `review` and
+`investigate` spawn paid multi-agent runs and live here). The classification
+lives in one reviewable table, `agentHelpAudiences` in `agent_help_cmd.go`, keyed
+by command path (`status`, `checkpoint list`), and is mirrored into `--json` as an
+`audience` field so structured consumers get the same guidance.
+
+Three rules matter when editing it:
+
+- A group counts as read-only **only if every advertised subcommand is**.
+  `checkpoint` and `session` read as read-only but are not (`checkpoint policy`
+  updates policy; `session` carries adopt/attach/resume/stop), so both are
+  task-driven.
+- Because demoting those groups would hide the inspection commands agents most
+  want, their read-only subcommands are classified individually and listed
+  under read-only (`checkpoint list`, `session list`, …). The groups that do
+  this are declared in `agentHelpBreakoutGroups` rather than inferred, and must
+  classify **every** child.
+- An unclassified command defaults to user-owned, and
+  `TestAgentHelpAudiences_CoverEveryAdvertisedCommand` fails CI so neither a new
+  top-level command nor a new subcommand of a breakout group can ship
+  unclassified. `--json` omits `audience` where the table makes no claim rather
+  than emitting that default.
+
+Keep per-task command recommendations OUT of the first-turn injection and in
+`agent-help`, which is pulled on demand. A census of 963 agent transcripts found
+zero invocations of the `entire why` / `entire checkpoint search` pair the
+injection used to recommend "before large edits", against 25 calls to the
+agent-help pointer in the same corpus — the recommendation only cost first-turn
+tokens, and framed a sometimes-appropriate query as an always-do step. The
+injection carries only invariants that hold on every turn.
+
 Hidden commands opt into being advertised here by setting
 `Annotations[agentHelpAnnotation] = "true"` (e.g. `trail`). Because `agent-help`
 renders live and lists non-hidden commands, the experimental commands appear in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,32 +121,42 @@ one command's current flags; `--json` emits structured output. It is the single
 source of truth the first-turn context injection and the `--agent-help-skill`
 skill point agents at, instead of enumerating a surface that goes stale.
 
-The bare listing is grouped by **who should initiate the command**, not
-alphabetically, because the question an agent has when reading it is "may I run
-this unprompted?" — read-only (safe on its own) · task-driven (writes data or
-spends tokens) · user-owned (setup, auth, admin, destructive, or expensive
-enough that starting one uninvited is the user's call — `review` and
-`investigate` spawn paid multi-agent runs and live here). The classification
-lives in one reviewable table, `agentHelpAudiences` in `agent_help_cmd.go`, keyed
-by command path (`status`, `checkpoint list`), and is mirrored into `--json` as an
-`audience` field so structured consumers get the same guidance.
+The bare listing shows a **curated subset**, not the whole tree. An exhaustive
+listing answers "what exists?", which is not the question an agent mid-task has,
+and past a certain length it stops being read at all — an earlier revision that
+listed everything grouped by audience reached 45 lines. Omitted commands stay
+reachable (`agent-help <command>` resolves them, and the footer names them in a
+compact index), so curation trades default visibility, never availability.
 
-Three rules matter when editing it:
+`agentHelpClassification` in `agent_help_cmd.go` is the one reviewable table,
+keyed by command path (`status`, `checkpoint list`). Each entry carries two
+**independent** facts — fusing them into a single axis is what forced the
+listing to spend a line per (command × audience) cell:
 
-- A group counts as read-only **only if every advertised subcommand is**.
-  `checkpoint` and `session` read as read-only but are not (`checkpoint policy`
-  updates policy; `session` carries adopt/attach/resume/stop), so both are
-  task-driven.
-- Because demoting those groups would hide the inspection commands agents most
-  want, their read-only subcommands are classified individually and listed
-  under read-only (`checkpoint list`, `session list`, …). The groups that do
-  this are declared in `agentHelpBreakoutGroups` rather than inferred, and must
-  classify **every** child.
-- An unclassified command defaults to user-owned, and
-  `TestAgentHelpAudiences_CoverEveryAdvertisedCommand` fails CI so neither a new
-  top-level command nor a new subcommand of a breakout group can ship
-  unclassified. `--json` omits `audience` where the table makes no claim rather
-  than emitting that default.
+- `audience` — may an agent run this unprompted? read-only · task-driven
+  (writes data or spends tokens) · user-owned (setup, auth, admin, destructive,
+  or expensive enough that starting one uninvited is the user's call — `review`
+  and `investigate` spawn paid multi-agent runs and live here). Applies at every
+  depth; mirrored into `--json` as `audience`.
+- `listed` — does it appear in the bare listing? Top-level commands only.
+
+Rules when editing it:
+
+- A group's audience is a claim about **all** its subcommands, so a read-only
+  group may not contain one that writes. `checkpoint` and `session` read as
+  read-only but are not (`checkpoint policy` updates policy; `session` carries
+  adopt/attach/resume/stop), so both are task-driven.
+- A mixed group states its exceptions **on one line**, naming only the minority
+  side (`read-only except: policy`, or `read-only: show, list, … — others
+  write`). That is what keeps a group at one line however many subcommands it
+  grows. Both the text drill-down and `--json` carry this, so neither mode hides
+  which subcommands write.
+- An unclassified command defaults to user-owned and unlisted.
+  `TestAgentHelpClassification_CoversEveryAdvertisedCommand` fails CI so neither
+  a new top-level command nor a new child of a *listed* group can ship
+  unclassified — an unclassified child would be silently dropped from its
+  group's exception note. `--json` omits `audience` where the table makes no
+  claim rather than emitting the default.
 
 Keep per-task command recommendations OUT of the first-turn injection and in
 `agent-help`, which is pulled on demand. A census of 963 agent transcripts found

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,83 +111,38 @@ entire-api cell. `--jurisdiction <slug>` (e.g. `us`, `eu`) targets a specific
 jurisdiction's cell instead of the caller's home cell and implies `--to cell`
 (cell routing + identity-token exchange live in `auth.NewEntireAPICellClient`
 via `auth.CellTarget`). `{owner}`/`{repo}`/`{repo_id}` in the path are filled
-from the current repo's origin remote.
-
-`api` is an **escape hatch, not a front-line command**: it is right when
-developing against Entire's own APIs and wanting a raw response, or when no
-first-class command covers the need — not during ordinary work in a repo with
-Entire enabled. It is therefore deliberately **not** in `agent-help`'s curated
-listing (`listed: false`), but stays visible in `entire help` and named in
-agent-help's footer index, so an agent that genuinely needs raw access finds it
-instead of hand-rolling curl with a token — the failure this command exists to
-prevent. Keep both halves of that balance in mind when changing its visibility.
-
-**Where that steer lives matters.** "This is a last resort" is agent guidance,
-not human help: someone who typed `entire api --help` chose the command on
-purpose, and telling them to reconsider is noise. So it lives in
-`agentHelpGuidance` (keyed by command path, rendered only by `agent-help` as a
-"When to use this:" block and as a `guidance` field in `--json`), never in
-cobra's `Long`. The split rule, which applies to any command that needs it:
-
-- true for **both** audiences → `Long` (e.g. "these endpoints are internal and
-  can change shape without notice")
-- useful only to an agent choosing from a surface it doesn't know →
-  `agentHelpGuidance`
-
-`TestAgentHelpGuidance_NeverLeaksIntoCobraHelp` fails CI if guidance text is
-pasted into a command's `Short`/`Long`.
+from the current repo's origin remote. It is an escape hatch, so it is absent
+from `agent-help`'s curated listing but stays in `entire help` and agent-help's
+footer — an agent that needs raw access must find it rather than hand-roll curl
+with a token.
 
 `agent-help` renders machine-readable, agent-facing usage live from the Cobra
-command tree (so it always matches the installed binary): bare prints a
-"when to use entire / which subcommand" map; `agent-help <command>` drills into
-one command's current flags; `--json` emits structured output. It is the single
-source of truth the first-turn context injection and the `--agent-help-skill`
-skill point agents at, instead of enumerating a surface that goes stale.
+command tree (so it always matches the installed binary): bare prints a curated
+"when to use entire" map; `agent-help <command>` drills into one command's
+current flags; `--json` emits structured output. It is the single source of
+truth the first-turn context injection and the `--agent-help-skill` skill point
+agents at, instead of enumerating a surface that goes stale.
 
-The bare listing shows a **curated subset**, not the whole tree. An exhaustive
-listing answers "what exists?", which is not the question an agent mid-task has,
-and past a certain length it stops being read at all — an earlier revision that
-listed everything grouped by audience reached 45 lines. Omitted commands stay
-reachable (`agent-help <command>` resolves them, and the footer names them in a
-compact index), so curation trades default visibility, never availability.
+#### Where agent-facing text goes
 
-`agentHelpClassification` in `agent_help_cmd.go` is the one reviewable table,
-keyed by command path (`status`, `checkpoint list`). Each entry carries two
-**independent** facts — fusing them into a single axis is what forced the
-listing to spend a line per (command × audience) cell:
+| What you have | Where it goes |
+| --- | --- |
+| A new command | `agentHelpClassification` in `agent_help_cmd.go` — one entry, keyed by command path, carrying `audience` and `listed` |
+| "When to use this at all" advice for agents | `agentHelpGuidance` — **never** cobra `Short`/`Long` |
+| A fact humans need too (e.g. "this output is not stable") | cobra `Long`. Human help is a reference, not a lecture: whoever typed `--help` already chose the command |
+| A per-task command recommendation | `agent-help`, which is pulled on demand. **Never** the first-turn injection, which carries only invariants true on every turn |
 
-- `audience` — may an agent run this unprompted? read-only · task-driven
-  (writes data or spends tokens) · user-owned (setup, auth, admin, destructive,
-  or expensive enough that starting one uninvited is the user's call — `review`
-  and `investigate` spawn paid multi-agent runs and live here). Applies at every
-  depth; mirrored into `--json` as `audience`.
-- `listed` — does it appear in the bare listing? Top-level commands only.
+**Flag it; don't decide it.** Whether a command is `listed`, and whether it is
+read-only / task-driven / user-owned, are product judgment calls — they change
+what agents do unprompted in every user's repo. Take the safe default
+(unlisted, user-owned), then say in the PR what you picked and why so a human
+can move it. Never quietly promote a command into the listing or into
+read-only.
 
-Rules when editing it:
-
-- A group's audience is a claim about **all** its subcommands, so a read-only
-  group may not contain one that writes. `checkpoint` and `session` read as
-  read-only but are not (`checkpoint policy` updates policy; `session` carries
-  adopt/attach/resume/stop), so both are task-driven.
-- A mixed group states its exceptions **on one line**, naming only the minority
-  side (`read-only except: policy`, or `read-only: show, list, … — others
-  write`). That is what keeps a group at one line however many subcommands it
-  grows. Both the text drill-down and `--json` carry this, so neither mode hides
-  which subcommands write.
-- An unclassified command defaults to user-owned and unlisted.
-  `TestAgentHelpClassification_CoversEveryAdvertisedCommand` fails CI so neither
-  a new top-level command nor a new child of a *listed* group can ship
-  unclassified — an unclassified child would be silently dropped from its
-  group's exception note. `--json` omits `audience` where the table makes no
-  claim rather than emitting the default.
-
-Keep per-task command recommendations OUT of the first-turn injection and in
-`agent-help`, which is pulled on demand. A census of 963 agent transcripts found
-zero invocations of the `entire why` / `entire checkpoint search` pair the
-injection used to recommend "before large edits", against 25 calls to the
-agent-help pointer in the same corpus — the recommendation only cost first-turn
-tokens, and framed a sometimes-appropriate query as an always-do step. The
-injection carries only invariants that hold on every turn.
+CI enforces the mechanical parts, so trust these rather than re-deriving them:
+every advertised top-level command and every child of a listed group is
+classified; a read-only group contains no writing subcommand; guidance text
+never appears in a command's `Short`/`Long`.
 
 Hidden commands opt into being advertised here by setting
 `Annotations[agentHelpAnnotation] = "true"` (e.g. `trail`). Because `agent-help`

--- a/cmd/entire/cli/agent_help_cmd.go
+++ b/cmd/entire/cli/agent_help_cmd.go
@@ -178,6 +178,28 @@ var agentHelpClassification = map[string]agentHelpFacts{
 	"review":      {agentHelpAudienceUserOwned, false},
 }
 
+// agentHelpGuidance is agent-only advice about WHEN to reach for a command,
+// keyed by the same command path as agentHelpClassification.
+//
+// It is deliberately not in the command's Long. Cobra's Long is human help, and
+// a human who typed `entire api --help` chose that command on purpose — telling
+// them it is a last resort is noise at best and condescending at worst. An agent
+// is in the opposite position: it is picking from a surface it does not know, so
+// "prefer the purpose-built command" is the single most useful thing to say.
+// Same fact, opposite value, so it ships on the agent channel only. Anything
+// true for both audiences (e.g. "these endpoints are internal and can change")
+// belongs in Long instead, where both see it.
+var agentHelpGuidance = map[string]string{
+	"api": "LAST RESORT. Right in two cases: you are developing against Entire's own\n" +
+		"APIs and want a raw response, or no first-class command covers your need.\n" +
+		"Otherwise prefer the command built for the job (checkpoint, session, trail,\n" +
+		"status, repo, …) — its output is stable, raw endpoints are not. If you are\n" +
+		"reaching for this during ordinary work in a repo with Entire enabled, run\n" +
+		"`entire agent-help` first; there is probably a command for it. When you do\n" +
+		"need it, use this rather than hand-rolling curl — it attaches the right\n" +
+		"bearer and dials the right host for you.",
+}
+
 // agentHelpFactsFor classifies one command path, defaulting the unclassified
 // case to user-owned and unlisted so an unclassified addition is under- rather
 // than over-advertised.
@@ -445,9 +467,12 @@ type agentHelpSubcommandJSON struct {
 }
 
 type agentHelpJSON struct {
-	Command     string                    `json:"command"`
-	Short       string                    `json:"short,omitempty"`
-	Long        string                    `json:"long,omitempty"`
+	Command string `json:"command"`
+	Short   string `json:"short,omitempty"`
+	Long    string `json:"long,omitempty"`
+	// Guidance is agent-only advice on WHEN to use the command, absent from
+	// cobra's human help. Structured consumers get it alongside text readers.
+	Guidance    string                    `json:"guidance,omitempty"`
 	Example     string                    `json:"example,omitempty"`
 	Repo        string                    `json:"repo,omitempty"`
 	Flags       []agentHelpFlagJSON       `json:"flags,omitempty"`
@@ -457,11 +482,12 @@ type agentHelpJSON struct {
 // renderAgentHelpJSON renders the structured form of a command node.
 func renderAgentHelpJSON(rootCmd, target *cobra.Command, repoLine string, trailsEnabled bool) (string, error) {
 	doc := agentHelpJSON{
-		Command: target.CommandPath(),
-		Short:   target.Short,
-		Long:    strings.TrimSpace(target.Long),
-		Example: strings.TrimSpace(target.Example),
-		Repo:    repoLine,
+		Command:  target.CommandPath(),
+		Short:    target.Short,
+		Long:     strings.TrimSpace(target.Long),
+		Guidance: agentHelpGuidance[agentHelpPath(target)],
+		Example:  strings.TrimSpace(target.Example),
+		Repo:     repoLine,
 	}
 	if target != rootCmd {
 		collect := func(fs *flag.FlagSet) {
@@ -546,6 +572,13 @@ func renderAgentHelpCommand(cmd *cobra.Command, repoLine string, trailsEnabled b
 	fmt.Fprintf(&b, "%s — %s\n", cmd.CommandPath(), cmd.Short)
 	if long := strings.TrimSpace(cmd.Long); long != "" && long != strings.TrimSpace(cmd.Short) {
 		b.WriteString(long)
+		b.WriteString("\n")
+	}
+	// Before the flags and examples: whether to use the command at all outranks
+	// how to call it.
+	if guidance := agentHelpGuidance[agentHelpPath(cmd)]; guidance != "" {
+		b.WriteString("\nWhen to use this:\n")
+		b.WriteString(guidance)
 		b.WriteString("\n")
 	}
 	if example := strings.TrimSpace(cmd.Example); example != "" {

--- a/cmd/entire/cli/agent_help_cmd.go
+++ b/cmd/entire/cli/agent_help_cmd.go
@@ -99,7 +99,6 @@ var agentHelpClassification = map[string]agentHelpFacts{
 	"status": {agentHelpAudienceReadOnly, true},
 	"why":    {agentHelpAudienceReadOnly, true},
 	"search": {agentHelpAudienceReadOnly, true},
-	"api":    {agentHelpAudienceTaskDriven, true},
 
 	"checkpoint":         {agentHelpAudienceTaskDriven, true},
 	"checkpoint explain": {agentHelpAudienceReadOnly, false},
@@ -147,6 +146,14 @@ var agentHelpClassification = map[string]agentHelpFacts{
 	// rather than assumed, so a future mutating child cannot inherit the claim.
 	"tokens profile": {agentHelpAudienceReadOnly, false},
 
+	// api is deliberately UNLISTED. It is an escape hatch: the right tool when
+	// you are developing against Entire's own APIs, or when no first-class
+	// command covers what you need — not during ordinary work in a repo that has
+	// Entire enabled, which is what the listing is for. It stays named in the
+	// footer index and visible in `entire help`, so an agent that genuinely needs
+	// raw access still finds it rather than hand-rolling curl with a token, which
+	// is the failure this command exists to prevent.
+	"api":      {agentHelpAudienceTaskDriven, false},
 	"dispatch": {agentHelpAudienceTaskDriven, false},
 	"doctor":   {agentHelpAudienceTaskDriven, false},
 	"import":   {agentHelpAudienceTaskDriven, false},
@@ -595,11 +602,12 @@ func renderAgentHelpTop(rootCmd *cobra.Command, repoLine string, trailsEnabled b
 	b.WriteString(agentHelpRepoBlock(repoLine))
 
 	var listed []*cobra.Command
-	var rest []string
+	rest := map[agentHelpAudience][]string{}
 	width := 10
 	for _, sub := range agentHelpCommands(rootCmd, trailsEnabled) {
-		if !agentHelpFactsFor(agentHelpPath(sub)).listed {
-			rest = append(rest, sub.Name())
+		facts := agentHelpFactsFor(agentHelpPath(sub))
+		if !facts.listed {
+			rest[facts.audience] = append(rest[facts.audience], sub.Name())
 			continue
 		}
 		listed = append(listed, sub)
@@ -616,13 +624,29 @@ func renderAgentHelpTop(rootCmd *cobra.Command, repoLine string, trailsEnabled b
 			fmt.Fprintf(&b, "  %-*s    %s\n", width, "", agentHelpAudienceNote(sub, facts, trailsEnabled))
 		}
 	}
+	// Names only, no Short help: enough for an agent to connect a user's request
+	// ("run a review") to a command, at a fraction of the lines full entries
+	// cost. Still split by audience — a single bucket would have to caption
+	// itself with the most restrictive rule, which would tell an agent not to run
+	// `activity` or `blame` uninvited when the table says they are safe.
+	footer := []struct {
+		audience agentHelpAudience
+		label    string
+	}{
+		{agentHelpAudienceReadOnly, "read-only, safe to run:"},
+		{agentHelpAudienceTaskDriven, "when the task needs them:"},
+		{agentHelpAudienceUserOwned, "the user's — suggest, don't run:"},
+	}
 	if len(rest) > 0 {
-		// Names only, no Short help: enough for an agent to connect a user's
-		// request ("run a review") to a command, at a fraction of the lines full
-		// entries cost.
-		b.WriteString("\nAlso available — setup, admin, and commands to run only when asked:\n")
-		b.WriteString(wrapIndented(strings.Join(rest, " · "), "  ", 76))
-		b.WriteString("  Suggest these; don't run them uninvited.\n")
+		b.WriteString("\nAlso available (entire agent-help <command> for any of these):\n")
+		for _, section := range footer {
+			names := rest[section.audience]
+			if len(names) == 0 {
+				continue
+			}
+			fmt.Fprintf(&b, "  %s\n", section.label)
+			b.WriteString(wrapIndented(strings.Join(names, " · "), "    ", 76))
+		}
 	}
 	// Use an example command that is actually advertised here (trail is gated on
 	// trails being enabled), so we never point at a command the agent can't use.

--- a/cmd/entire/cli/agent_help_cmd.go
+++ b/cmd/entire/cli/agent_help_cmd.go
@@ -38,6 +38,201 @@ subcommands — read them from this command. You are already inside the repo:
 entire auto-detects it from the git origin remote, so never ask the user for the
 repo name. Pass --repo only to target a DIFFERENT repo.`
 
+// agentHelpAudience answers the question an agent actually has when it reads this
+// listing: may I run this without being asked? A flat alphabetical dump of every
+// command cannot answer it, so an agent either runs nothing or runs something it
+// should have left alone (`entire enable`, `entire review`, `entire org create`).
+// Grouping by initiator puts that judgment in the CLI, where it is maintained
+// once, rather than in each agent's guesswork or in the first-turn injection,
+// which pays for it on every session.
+type agentHelpAudience int
+
+const (
+	// agentHelpAudienceReadOnly: inspection only. Safe to run unprompted whenever
+	// it would inform the work; cannot change repo, account, or Entire state.
+	agentHelpAudienceReadOnly agentHelpAudience = iota
+	// agentHelpAudienceTaskDriven: part of doing the work, but it writes data or
+	// spends tokens. Run when the task calls for it, not speculatively.
+	agentHelpAudienceTaskDriven
+	// agentHelpAudienceUserOwned: setup, auth, account/admin, or destructive. The
+	// agent may suggest these but must not run them on its own initiative.
+	agentHelpAudienceUserOwned
+)
+
+// agentHelpAudiences classifies commands by space-separated path relative to the
+// root ("status", "checkpoint list"). It is a single table rather than a
+// per-command Annotations field so the whole policy is reviewable in one place —
+// the classification is a judgment call and reads as one only when the commands
+// sit side by side.
+//
+// A GROUP is read-only only if every advertised subcommand is, so `checkpoint`
+// and `session` are task-driven even though their Short help reads as pure
+// inspection: `checkpoint policy` updates policy, and `session` carries
+// adopt/attach/resume/stop. Demoting the whole group would have hidden the
+// inspection commands an agent most wants (`checkpoint list`, `session list`),
+// so their read-only subcommands are classified individually and the listing
+// breaks them out — see agentHelpEntries. The mutating siblings are classified
+// too; they stay collapsed under the group in the listing but carry an accurate
+// audience in `agent-help <group> --json`.
+//
+// Unlisted commands fall back to agentHelpAudienceUserOwned (see
+// agentHelpAudienceFor): the fail-safe direction is an agent declining to run
+// something it could have, never running something it should not have.
+// TestAgentHelpAudiences_CoverEveryAdvertisedCommand fails CI when a new
+// top-level command lands unclassified, so the fallback is a backstop and not
+// the normal path.
+var agentHelpAudiences = map[string]agentHelpAudience{
+	// Read-only inspection, every subcommand.
+	"activity": agentHelpAudienceReadOnly,
+	"blame":    agentHelpAudienceReadOnly,
+	"experts":  agentHelpAudienceReadOnly,
+	"labs":     agentHelpAudienceReadOnly,
+	"recap":    agentHelpAudienceReadOnly,
+	"search":   agentHelpAudienceReadOnly,
+	"status":   agentHelpAudienceReadOnly,
+	"tokens":   agentHelpAudienceReadOnly,
+	"version":  agentHelpAudienceReadOnly,
+	"why":      agentHelpAudienceReadOnly,
+
+	// Task-driven groups whose read-only subcommands are broken out below.
+	"checkpoint":         agentHelpAudienceTaskDriven,
+	"checkpoint explain": agentHelpAudienceReadOnly,
+	"checkpoint list":    agentHelpAudienceReadOnly,
+	"checkpoint search":  agentHelpAudienceReadOnly,
+	"checkpoint tokens":  agentHelpAudienceReadOnly,
+	"checkpoint policy":  agentHelpAudienceTaskDriven, // "Inspect and update"
+	"session":            agentHelpAudienceTaskDriven,
+	"session current":    agentHelpAudienceReadOnly,
+	"session info":       agentHelpAudienceReadOnly,
+	"session list":       agentHelpAudienceReadOnly,
+	"session tokens":     agentHelpAudienceReadOnly,
+	"session adopt":      agentHelpAudienceTaskDriven,
+	"session attach":     agentHelpAudienceTaskDriven,
+	"session resume":     agentHelpAudienceTaskDriven, // switches branch
+	"session stop":       agentHelpAudienceTaskDriven,
+
+	// Task-driven: at least one subcommand writes data or spends tokens.
+	"api":      agentHelpAudienceTaskDriven,
+	"dispatch": agentHelpAudienceTaskDriven,
+	"doctor":   agentHelpAudienceTaskDriven,
+	"import":   agentHelpAudienceTaskDriven,
+	"runner":   agentHelpAudienceTaskDriven,
+	"trail":    agentHelpAudienceTaskDriven,
+
+	// The user's: setup, auth, account/admin, destructive, or expensive enough
+	// that starting one uninvited is the user's call. review and investigate spawn
+	// multi-agent runs that spend real money, so they are opt-in like setup is.
+	"agent":       agentHelpAudienceUserOwned,
+	"auth":        agentHelpAudienceUserOwned,
+	"clean":       agentHelpAudienceUserOwned,
+	"configure":   agentHelpAudienceUserOwned,
+	"disable":     agentHelpAudienceUserOwned,
+	"enable":      agentHelpAudienceUserOwned,
+	"grant":       agentHelpAudienceUserOwned,
+	"investigate": agentHelpAudienceUserOwned,
+	"login":       agentHelpAudienceUserOwned,
+	"logout":      agentHelpAudienceUserOwned,
+	"org":         agentHelpAudienceUserOwned,
+	"plugin":      agentHelpAudienceUserOwned,
+	"project":     agentHelpAudienceUserOwned,
+	"repo":        agentHelpAudienceUserOwned,
+	"review":      agentHelpAudienceUserOwned,
+}
+
+// agentHelpBreakoutGroups are the task-driven groups whose read-only
+// subcommands are listed individually in the top-level listing. Membership is
+// declared rather than inferred from "has classified children" so adding a
+// classification to some unrelated subcommand cannot silently change what the
+// listing shows, and so
+// TestAgentHelpAudiences_CoverEveryAdvertisedCommand knows which groups must
+// classify every child.
+var agentHelpBreakoutGroups = map[string]struct{}{
+	"checkpoint": {},
+	"session":    {},
+}
+
+// agentHelpAudienceSections renders in this order: what an agent may do on its
+// own first, what it must not do last.
+var agentHelpAudienceSections = []struct {
+	audience agentHelpAudience
+	heading  string
+	slug     string
+}{
+	{agentHelpAudienceReadOnly, "Safe to run on your own — read-only, changes nothing:", "read-only"},
+	{agentHelpAudienceTaskDriven, "Run when the task calls for it — some subcommands write data or spend tokens:", "task-driven"},
+	{agentHelpAudienceUserOwned, "The user's to run — suggest it, don't run it (setup, auth, admin, destructive):", "user-owned"},
+}
+
+// agentHelpAudienceFor classifies one command path, defaulting unlisted commands
+// to user-owned so an unclassified addition is under- rather than
+// over-advertised.
+func agentHelpAudienceFor(path string) agentHelpAudience {
+	if a, ok := agentHelpAudiences[path]; ok {
+		return a
+	}
+	return agentHelpAudienceUserOwned
+}
+
+// agentHelpClassified reports an explicit classification only. The --json path
+// uses it so an unclassified subcommand omits the field rather than asserting a
+// user-owned default the table never actually made.
+func agentHelpClassified(path string) (agentHelpAudience, bool) {
+	a, ok := agentHelpAudiences[path]
+	return a, ok
+}
+
+// agentHelpPath is a command's path relative to the root, the key shape used by
+// agentHelpAudiences ("status", "checkpoint list").
+func agentHelpPath(cmd *cobra.Command) string {
+	return strings.TrimPrefix(cmd.CommandPath(), cmd.Root().Name()+" ")
+}
+
+// agentHelpEntry is one line of the top-level listing: a command path, its Short
+// help, and the bucket it belongs in.
+type agentHelpEntry struct {
+	path     string
+	short    string
+	audience agentHelpAudience
+}
+
+// agentHelpEntries builds the top-level listing. Every advertised top-level
+// command appears; additionally, a read-only subcommand of a task-driven group is
+// broken out as its own entry so the safe-unprompted inspection commands inside
+// `checkpoint` and `session` are visible without drilling in. Mutating
+// subcommands stay collapsed under their group — the listing exists to answer
+// "what may I run on my own?", and enumerating what an agent must NOT run adds
+// lines without adding an answer.
+func agentHelpEntries(rootCmd *cobra.Command, trailsEnabled bool) []agentHelpEntry {
+	var out []agentHelpEntry
+	for _, sub := range agentHelpCommands(rootCmd, trailsEnabled) {
+		path := agentHelpPath(sub)
+		audience := agentHelpAudienceFor(path)
+		out = append(out, agentHelpEntry{path: path, short: sub.Short, audience: audience})
+		if _, ok := agentHelpBreakoutGroups[path]; !ok {
+			continue
+		}
+		for _, child := range agentHelpCommands(sub, trailsEnabled) {
+			childPath := agentHelpPath(child)
+			if a, ok := agentHelpClassified(childPath); ok && a == agentHelpAudienceReadOnly {
+				out = append(out, agentHelpEntry{path: childPath, short: child.Short, audience: a})
+			}
+		}
+	}
+	return out
+}
+
+// agentHelpAudienceSlug is the stable machine-readable form emitted in --json,
+// so an agent parsing the structured output gets the same guidance as one
+// reading the text (the repo's agent-safe-fallback rule).
+func agentHelpAudienceSlug(a agentHelpAudience) string {
+	for _, s := range agentHelpAudienceSections {
+		if s.audience == a {
+			return s.slug
+		}
+	}
+	return "user-owned"
+}
+
 // newAgentHelpCmd builds the `entire agent-help` command. It is visible in
 // `entire help` (so agents on transports without context injection can still
 // find it) and renders agent-facing usage live from rootCmd's command tree.
@@ -198,6 +393,10 @@ type agentHelpFlagJSON struct {
 type agentHelpSubcommandJSON struct {
 	Name  string `json:"name"`
 	Short string `json:"short"`
+	// Audience mirrors the text renderer's grouping so a --json consumer gets the
+	// same "may I run this unprompted?" answer as a text reader. Omitted when the
+	// table makes no explicit claim, rather than asserting the user-owned default.
+	Audience string `json:"audience,omitempty"`
 }
 
 type agentHelpJSON struct {
@@ -238,7 +437,11 @@ func renderAgentHelpJSON(rootCmd, target *cobra.Command, repoLine string, trails
 		collect(target.InheritedFlags())
 	}
 	for _, sub := range agentHelpCommands(target, trailsEnabled) {
-		doc.Subcommands = append(doc.Subcommands, agentHelpSubcommandJSON{Name: sub.Name(), Short: sub.Short})
+		entry := agentHelpSubcommandJSON{Name: sub.Name(), Short: sub.Short}
+		if a, ok := agentHelpClassified(agentHelpPath(sub)); ok {
+			entry.Audience = agentHelpAudienceSlug(a)
+		}
+		doc.Subcommands = append(doc.Subcommands, entry)
 	}
 	b, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
@@ -340,9 +543,33 @@ func renderAgentHelpTop(rootCmd *cobra.Command, repoLine string, trailsEnabled b
 	b.WriteString(agentHelpOverview)
 	b.WriteString("\n\n")
 	b.WriteString(agentHelpRepoBlock(repoLine))
+
+	// Group by initiator rather than listing alphabetically: the agent's question
+	// is "may I run this unprompted?", and only the grouping answers it.
+	entries := agentHelpEntries(rootCmd, trailsEnabled)
+	byAudience := map[agentHelpAudience][]agentHelpEntry{}
+	width := 12
+	for _, e := range entries {
+		byAudience[e.audience] = append(byAudience[e.audience], e)
+		// Broken-out subcommand paths are longer than bare names, so size the
+		// column to the content instead of truncating into the Short help.
+		if len(e.path) > width {
+			width = len(e.path)
+		}
+	}
 	b.WriteString("\nWhen to use entire:\n")
-	for _, sub := range agentHelpCommands(rootCmd, trailsEnabled) {
-		fmt.Fprintf(&b, "  %-12s %s\n", sub.Name(), sub.Short)
+	for _, section := range agentHelpAudienceSections {
+		bucket := byAudience[section.audience]
+		if len(bucket) == 0 {
+			// Experimental commands are absent from stable builds, so a whole
+			// section can legitimately be empty — skip it rather than print a
+			// heading over nothing.
+			continue
+		}
+		fmt.Fprintf(&b, "\n  %s\n", section.heading)
+		for _, e := range bucket {
+			fmt.Fprintf(&b, "    %-*s %s\n", width, e.path, e.short)
+		}
 	}
 	// Use an example command that is actually advertised here (trail is gated on
 	// trails being enabled), so we never point at a command the agent can't use.

--- a/cmd/entire/cli/agent_help_cmd.go
+++ b/cmd/entire/cli/agent_help_cmd.go
@@ -59,178 +59,216 @@ const (
 	agentHelpAudienceUserOwned
 )
 
-// agentHelpAudiences classifies commands by space-separated path relative to the
-// root ("status", "checkpoint list"). It is a single table rather than a
-// per-command Annotations field so the whole policy is reviewable in one place —
-// the classification is a judgment call and reads as one only when the commands
-// sit side by side.
+// agentHelpFacts carries the two INDEPENDENT things agent-help knows about a
+// command. Fusing them into one axis was a mistake worth naming: with only an
+// audience, the listing had to spend a line per (command × audience) cell, so
+// completeness and readability pulled against each other and the listing reached
+// 45 lines — past the point an agent reads it at all. They are separate
+// questions:
 //
-// A GROUP is read-only only if every advertised subcommand is, so `checkpoint`
-// and `session` are task-driven even though their Short help reads as pure
-// inspection: `checkpoint policy` updates policy, and `session` carries
-// adopt/attach/resume/stop. Demoting the whole group would have hidden the
-// inspection commands an agent most wants (`checkpoint list`, `session list`),
-// so their read-only subcommands are classified individually and the listing
-// breaks them out — see agentHelpEntries. The mutating siblings are classified
-// too; they stay collapsed under the group in the listing but carry an accurate
-// audience in `agent-help <group> --json`.
-//
-// Unlisted commands fall back to agentHelpAudienceUserOwned (see
-// agentHelpAudienceFor): the fail-safe direction is an agent declining to run
-// something it could have, never running something it should not have.
-// TestAgentHelpAudiences_CoverEveryAdvertisedCommand fails CI when a new
-// top-level command lands unclassified, so the fallback is a backstop and not
-// the normal path.
-var agentHelpAudiences = map[string]agentHelpAudience{
-	// Read-only inspection, every subcommand.
-	"activity": agentHelpAudienceReadOnly,
-	"blame":    agentHelpAudienceReadOnly,
-	"experts":  agentHelpAudienceReadOnly,
-	"labs":     agentHelpAudienceReadOnly,
-	"recap":    agentHelpAudienceReadOnly,
-	"search":   agentHelpAudienceReadOnly,
-	"status":   agentHelpAudienceReadOnly,
-	"tokens":   agentHelpAudienceReadOnly,
-	"version":  agentHelpAudienceReadOnly,
-	"why":      agentHelpAudienceReadOnly,
-
-	// Task-driven groups whose read-only subcommands are broken out below.
-	"checkpoint":         agentHelpAudienceTaskDriven,
-	"checkpoint explain": agentHelpAudienceReadOnly,
-	"checkpoint list":    agentHelpAudienceReadOnly,
-	"checkpoint search":  agentHelpAudienceReadOnly,
-	"checkpoint tokens":  agentHelpAudienceReadOnly,
-	"checkpoint policy":  agentHelpAudienceTaskDriven, // "Inspect and update"
-	"session":            agentHelpAudienceTaskDriven,
-	"session current":    agentHelpAudienceReadOnly,
-	"session info":       agentHelpAudienceReadOnly,
-	"session list":       agentHelpAudienceReadOnly,
-	"session tokens":     agentHelpAudienceReadOnly,
-	"session adopt":      agentHelpAudienceTaskDriven,
-	"session attach":     agentHelpAudienceTaskDriven,
-	"session resume":     agentHelpAudienceTaskDriven, // switches branch
-	"session stop":       agentHelpAudienceTaskDriven,
-
-	// Task-driven: at least one subcommand writes data or spends tokens.
-	"api":      agentHelpAudienceTaskDriven,
-	"dispatch": agentHelpAudienceTaskDriven,
-	"doctor":   agentHelpAudienceTaskDriven,
-	"import":   agentHelpAudienceTaskDriven,
-	"runner":   agentHelpAudienceTaskDriven,
-	"trail":    agentHelpAudienceTaskDriven,
-
-	// The user's: setup, auth, account/admin, destructive, or expensive enough
-	// that starting one uninvited is the user's call. review and investigate spawn
-	// multi-agent runs that spend real money, so they are opt-in like setup is.
-	"agent":       agentHelpAudienceUserOwned,
-	"auth":        agentHelpAudienceUserOwned,
-	"clean":       agentHelpAudienceUserOwned,
-	"configure":   agentHelpAudienceUserOwned,
-	"disable":     agentHelpAudienceUserOwned,
-	"enable":      agentHelpAudienceUserOwned,
-	"grant":       agentHelpAudienceUserOwned,
-	"investigate": agentHelpAudienceUserOwned,
-	"login":       agentHelpAudienceUserOwned,
-	"logout":      agentHelpAudienceUserOwned,
-	"org":         agentHelpAudienceUserOwned,
-	"plugin":      agentHelpAudienceUserOwned,
-	"project":     agentHelpAudienceUserOwned,
-	"repo":        agentHelpAudienceUserOwned,
-	"review":      agentHelpAudienceUserOwned,
-}
-
-// agentHelpBreakoutGroups are the task-driven groups whose read-only
-// subcommands are listed individually in the top-level listing. Membership is
-// declared rather than inferred from "has classified children" so adding a
-// classification to some unrelated subcommand cannot silently change what the
-// listing shows, and so
-// TestAgentHelpAudiences_CoverEveryAdvertisedCommand knows which groups must
-// classify every child.
-var agentHelpBreakoutGroups = map[string]struct{}{
-	"checkpoint": {},
-	"session":    {},
-}
-
-// agentHelpAudienceSections renders in this order: what an agent may do on its
-// own first, what it must not do last.
-var agentHelpAudienceSections = []struct {
+//	audience — may I run this unprompted?      (every command, at any depth)
+//	listed   — is it worth showing by default? (top-level commands only)
+type agentHelpFacts struct {
 	audience agentHelpAudience
-	heading  string
-	slug     string
-}{
-	{agentHelpAudienceReadOnly, "Safe to run on your own — read-only, changes nothing:", "read-only"},
-	{agentHelpAudienceTaskDriven, "Run when the task calls for it — some subcommands write data or spend tokens:", "task-driven"},
-	{agentHelpAudienceUserOwned, "The user's to run — suggest it, don't run it (setup, auth, admin, destructive):", "user-owned"},
+	// listed puts the command in the bare listing. Curation is the point: an
+	// agent mid-task needs the few commands bearing on its work, not an index.
+	// Unlisted commands stay reachable — `agent-help <command>` resolves them and
+	// the footer names them — so this trades default visibility, not availability.
+	listed bool
 }
 
-// agentHelpAudienceFor classifies one command path, defaulting unlisted commands
-// to user-owned so an unclassified addition is under- rather than
-// over-advertised.
-func agentHelpAudienceFor(path string) agentHelpAudience {
-	if a, ok := agentHelpAudiences[path]; ok {
-		return a
+// agentHelpClassification classifies commands by space-separated path relative
+// to the root ("status", "checkpoint list"). One table rather than per-command
+// Annotations so the whole policy is reviewable in one place — the
+// classification is a judgment call and reads as one only when the commands sit
+// side by side.
+//
+// Subcommands are classified wherever their audience differs from their
+// parent's. That is what lets a mixed group render as "read-only except: policy"
+// on ONE line: naming only the minority side keeps a group at one line however
+// many subcommands it grows, where breaking each one out cost a line apiece.
+//
+// Unclassified commands fall back to agentHelpAudienceUserOwned, unlisted (see
+// agentHelpFactsFor): the fail-safe direction is an agent declining to run
+// something it could have, never running something it should not have.
+// TestAgentHelpClassification_CoversEveryAdvertisedCommand fails CI when a new
+// top-level command — or a new child of a listed group — lands unclassified, so
+// the fallback is a backstop rather than the normal path.
+var agentHelpClassification = map[string]agentHelpFacts{
+	// ---- Listed: the commands that bear on an agent's work mid-task. -------
+	"status": {agentHelpAudienceReadOnly, true},
+	"why":    {agentHelpAudienceReadOnly, true},
+	"search": {agentHelpAudienceReadOnly, true},
+	"api":    {agentHelpAudienceTaskDriven, true},
+
+	"checkpoint":         {agentHelpAudienceTaskDriven, true},
+	"checkpoint explain": {agentHelpAudienceReadOnly, false},
+	"checkpoint list":    {agentHelpAudienceReadOnly, false},
+	"checkpoint search":  {agentHelpAudienceReadOnly, false},
+	"checkpoint tokens":  {agentHelpAudienceReadOnly, false},
+	"checkpoint policy":  {agentHelpAudienceTaskDriven, false}, // "Inspect and update"
+
+	"session":         {agentHelpAudienceTaskDriven, true},
+	"session current": {agentHelpAudienceReadOnly, false},
+	"session info":    {agentHelpAudienceReadOnly, false},
+	"session list":    {agentHelpAudienceReadOnly, false},
+	"session tokens":  {agentHelpAudienceReadOnly, false},
+	"session adopt":   {agentHelpAudienceTaskDriven, false},
+	"session attach":  {agentHelpAudienceTaskDriven, false},
+	"session resume":  {agentHelpAudienceTaskDriven, false}, // switches branch
+	"session stop":    {agentHelpAudienceTaskDriven, false},
+
+	// trail is the highest-traffic family by a wide margin, so its read-only
+	// subcommands must not disappear behind the group's write-capable label.
+	"trail":                 {agentHelpAudienceTaskDriven, true},
+	"trail approvals":       {agentHelpAudienceReadOnly, false},
+	"trail list":            {agentHelpAudienceReadOnly, false},
+	"trail show":            {agentHelpAudienceReadOnly, false},
+	"trail watch":           {agentHelpAudienceReadOnly, false},
+	"trail approve":         {agentHelpAudienceTaskDriven, false},
+	"trail checkout":        {agentHelpAudienceTaskDriven, false},
+	"trail comment":         {agentHelpAudienceTaskDriven, false},
+	"trail create":          {agentHelpAudienceTaskDriven, false},
+	"trail delete":          {agentHelpAudienceTaskDriven, false},
+	"trail finding":         {agentHelpAudienceTaskDriven, false},
+	"trail request-changes": {agentHelpAudienceTaskDriven, false},
+	"trail resume":          {agentHelpAudienceTaskDriven, false},
+	"trail update":          {agentHelpAudienceTaskDriven, false},
+
+	// ---- Unlisted: real commands, just not the default view. ---------------
+	"activity": {agentHelpAudienceReadOnly, false},
+	"blame":    {agentHelpAudienceReadOnly, false},
+	"experts":  {agentHelpAudienceReadOnly, false},
+	"labs":     {agentHelpAudienceReadOnly, false},
+	"recap":    {agentHelpAudienceReadOnly, false},
+	"version":  {agentHelpAudienceReadOnly, false},
+	"tokens":   {agentHelpAudienceReadOnly, false},
+	// tokens is read-only, which is a claim about its children too — classified
+	// rather than assumed, so a future mutating child cannot inherit the claim.
+	"tokens profile": {agentHelpAudienceReadOnly, false},
+
+	"dispatch": {agentHelpAudienceTaskDriven, false},
+	"doctor":   {agentHelpAudienceTaskDriven, false},
+	"import":   {agentHelpAudienceTaskDriven, false},
+	"runner":   {agentHelpAudienceTaskDriven, false},
+
+	// The user's to start. review and investigate are not destructive but spawn
+	// paid multi-agent runs, so an uninvited one spends the user's money.
+	"agent":       {agentHelpAudienceUserOwned, false},
+	"auth":        {agentHelpAudienceUserOwned, false},
+	"clean":       {agentHelpAudienceUserOwned, false},
+	"configure":   {agentHelpAudienceUserOwned, false},
+	"disable":     {agentHelpAudienceUserOwned, false},
+	"enable":      {agentHelpAudienceUserOwned, false},
+	"grant":       {agentHelpAudienceUserOwned, false},
+	"investigate": {agentHelpAudienceUserOwned, false},
+	"login":       {agentHelpAudienceUserOwned, false},
+	"logout":      {agentHelpAudienceUserOwned, false},
+	"org":         {agentHelpAudienceUserOwned, false},
+	"plugin":      {agentHelpAudienceUserOwned, false},
+	"project":     {agentHelpAudienceUserOwned, false},
+	"repo":        {agentHelpAudienceUserOwned, false},
+	"review":      {agentHelpAudienceUserOwned, false},
+}
+
+// agentHelpFactsFor classifies one command path, defaulting the unclassified
+// case to user-owned and unlisted so an unclassified addition is under- rather
+// than over-advertised.
+func agentHelpFactsFor(path string) agentHelpFacts {
+	if f, ok := agentHelpClassification[path]; ok {
+		return f
 	}
-	return agentHelpAudienceUserOwned
+	return agentHelpFacts{audience: agentHelpAudienceUserOwned}
 }
 
-// agentHelpClassified reports an explicit classification only. The --json path
-// uses it so an unclassified subcommand omits the field rather than asserting a
+// agentHelpClassified reports an explicit classification only. The renderers use
+// it so an unclassified subcommand is omitted rather than asserting a
 // user-owned default the table never actually made.
-func agentHelpClassified(path string) (agentHelpAudience, bool) {
-	a, ok := agentHelpAudiences[path]
-	return a, ok
+func agentHelpClassified(path string) (agentHelpFacts, bool) {
+	f, ok := agentHelpClassification[path]
+	return f, ok
 }
 
 // agentHelpPath is a command's path relative to the root, the key shape used by
-// agentHelpAudiences ("status", "checkpoint list").
+// agentHelpClassification ("status", "checkpoint list").
 func agentHelpPath(cmd *cobra.Command) string {
 	return strings.TrimPrefix(cmd.CommandPath(), cmd.Root().Name()+" ")
 }
 
-// agentHelpEntry is one line of the top-level listing: a command path, its Short
-// help, and the bucket it belongs in.
-type agentHelpEntry struct {
-	path     string
-	short    string
-	audience agentHelpAudience
-}
-
-// agentHelpEntries builds the top-level listing. Every advertised top-level
-// command appears; additionally, a read-only subcommand of a task-driven group is
-// broken out as its own entry so the safe-unprompted inspection commands inside
-// `checkpoint` and `session` are visible without drilling in. Mutating
-// subcommands stay collapsed under their group — the listing exists to answer
-// "what may I run on my own?", and enumerating what an agent must NOT run adds
-// lines without adding an answer.
-func agentHelpEntries(rootCmd *cobra.Command, trailsEnabled bool) []agentHelpEntry {
-	var out []agentHelpEntry
-	for _, sub := range agentHelpCommands(rootCmd, trailsEnabled) {
-		path := agentHelpPath(sub)
-		audience := agentHelpAudienceFor(path)
-		out = append(out, agentHelpEntry{path: path, short: sub.Short, audience: audience})
-		if _, ok := agentHelpBreakoutGroups[path]; !ok {
-			continue
-		}
-		for _, child := range agentHelpCommands(sub, trailsEnabled) {
-			childPath := agentHelpPath(child)
-			if a, ok := agentHelpClassified(childPath); ok && a == agentHelpAudienceReadOnly {
-				out = append(out, agentHelpEntry{path: childPath, short: child.Short, audience: a})
-			}
-		}
-	}
-	return out
-}
+// agentHelpUserOwnedSlug is both the user-owned slug and the value an unknown
+// audience degrades to, so a future enum member can never silently render as an
+// agent-runnable one.
+const agentHelpUserOwnedSlug = "user-owned"
 
 // agentHelpAudienceSlug is the stable machine-readable form emitted in --json,
-// so an agent parsing the structured output gets the same guidance as one
-// reading the text (the repo's agent-safe-fallback rule).
+// so a structured consumer gets the same answer as a text reader.
 func agentHelpAudienceSlug(a agentHelpAudience) string {
-	for _, s := range agentHelpAudienceSections {
-		if s.audience == a {
-			return s.slug
+	switch a {
+	case agentHelpAudienceReadOnly:
+		return "read-only"
+	case agentHelpAudienceTaskDriven:
+		return "task-driven"
+	case agentHelpAudienceUserOwned:
+		return agentHelpUserOwnedSlug
+	default:
+		return agentHelpUserOwnedSlug
+	}
+}
+
+// agentHelpAudienceNote describes a command's audience in one clause.
+//
+// For a group whose classified subcommands disagree, it names only the SHORTER
+// side and leaves the rest implicit ("read-only except: policy", or
+// "read-only: show, list, … — others write"). Naming the minority is what keeps
+// a mixed group to a single line however many subcommands it gains; naming both
+// sides is what made an earlier revision of this listing grow a line per
+// subcommand until it stopped being readable.
+func agentHelpAudienceNote(cmd *cobra.Command, facts agentHelpFacts, trailsEnabled bool) string {
+	var readOnly, writes []string
+	for _, child := range agentHelpCommands(cmd, trailsEnabled) {
+		cf, ok := agentHelpClassified(agentHelpPath(child))
+		if !ok {
+			continue
+		}
+		switch cf.audience {
+		case agentHelpAudienceReadOnly:
+			readOnly = append(readOnly, child.Name())
+		case agentHelpAudienceTaskDriven:
+			writes = append(writes, child.Name())
+		case agentHelpAudienceUserOwned:
+			// A user-owned child inside a listed group would need its own phrasing.
+			// None exists today; the completeness guard surfaces one if it lands.
 		}
 	}
-	return "user-owned"
+	switch {
+	case len(readOnly) == 0 || len(writes) == 0:
+		// Leaf, or every classified child agrees with the group.
+		return agentHelpAudienceSlug(facts.audience)
+	case len(writes) <= len(readOnly):
+		return "read-only except: " + strings.Join(writes, ", ")
+	default:
+		return "read-only: " + strings.Join(readOnly, ", ") + " — others write"
+	}
+}
+
+// wrapIndented soft-wraps a " · "-joined list at width, prefixing each line with
+// indent, so the footer index stays compact as the command set grows.
+func wrapIndented(s, indent string, width int) string {
+	var b strings.Builder
+	line := indent
+	for i, part := range strings.Split(s, " · ") {
+		candidate := part
+		if i > 0 {
+			candidate = " · " + part
+		}
+		if len(line)+len(candidate) > width && line != indent {
+			b.WriteString(line + "\n")
+			line = indent + part
+			continue
+		}
+		line += candidate
+	}
+	return b.String() + line + "\n"
 }
 
 // newAgentHelpCmd builds the `entire agent-help` command. It is visible in
@@ -438,8 +476,8 @@ func renderAgentHelpJSON(rootCmd, target *cobra.Command, repoLine string, trails
 	}
 	for _, sub := range agentHelpCommands(target, trailsEnabled) {
 		entry := agentHelpSubcommandJSON{Name: sub.Name(), Short: sub.Short}
-		if a, ok := agentHelpClassified(agentHelpPath(sub)); ok {
-			entry.Audience = agentHelpAudienceSlug(a)
+		if f, ok := agentHelpClassified(agentHelpPath(sub)); ok {
+			entry.Audience = agentHelpAudienceSlug(f.audience)
 		}
 		doc.Subcommands = append(doc.Subcommands, entry)
 	}
@@ -530,46 +568,61 @@ func renderAgentHelpCommand(cmd *cobra.Command, repoLine string, trailsEnabled b
 			names = append(names, sub.Name())
 		}
 		fmt.Fprintf(&b, "\nSubcommands: %s\n", strings.Join(names, " · "))
+		// The text drill-down must carry the same "may I run this?" answer as
+		// --json does (the repo's agent-safe-fallback rule); a bare subcommand list
+		// hides which of them write.
+		if facts, ok := agentHelpClassified(agentHelpPath(cmd)); ok {
+			fmt.Fprintf(&b, "             %s\n", agentHelpAudienceNote(cmd, facts, trailsEnabled))
+		}
 		fmt.Fprintf(&b, "Next:  entire agent-help %s <subcommand>\n", strings.TrimPrefix(cmd.CommandPath(), cmd.Root().Name()+" "))
 	}
 	return b.String()
 }
 
 // renderAgentHelpTop renders the top-level agent-facing overview: the curated
-// intro + rule, the auto-detected repo line, and a live map of the advertised
-// commands (their Short help), ending with the drill-down pointer.
+// intro + rule, the auto-detected repo line, the LISTED commands with their
+// audience, a compact index of everything else, and the drill-down pointer.
+//
+// It shows a curated subset rather than the whole tree. An exhaustive listing
+// answers "what exists?", which is not the question an agent mid-task has, and
+// past a certain length it stops being read at all. Everything omitted stays
+// resolvable through `agent-help <command>` and is named in the footer, so this
+// trades default visibility, never availability.
 func renderAgentHelpTop(rootCmd *cobra.Command, repoLine string, trailsEnabled bool) string {
 	var b strings.Builder
 	b.WriteString(agentHelpOverview)
 	b.WriteString("\n\n")
 	b.WriteString(agentHelpRepoBlock(repoLine))
 
-	// Group by initiator rather than listing alphabetically: the agent's question
-	// is "may I run this unprompted?", and only the grouping answers it.
-	entries := agentHelpEntries(rootCmd, trailsEnabled)
-	byAudience := map[agentHelpAudience][]agentHelpEntry{}
-	width := 12
-	for _, e := range entries {
-		byAudience[e.audience] = append(byAudience[e.audience], e)
-		// Broken-out subcommand paths are longer than bare names, so size the
-		// column to the content instead of truncating into the Short help.
-		if len(e.path) > width {
-			width = len(e.path)
-		}
-	}
-	b.WriteString("\nWhen to use entire:\n")
-	for _, section := range agentHelpAudienceSections {
-		bucket := byAudience[section.audience]
-		if len(bucket) == 0 {
-			// Experimental commands are absent from stable builds, so a whole
-			// section can legitimately be empty — skip it rather than print a
-			// heading over nothing.
+	var listed []*cobra.Command
+	var rest []string
+	width := 10
+	for _, sub := range agentHelpCommands(rootCmd, trailsEnabled) {
+		if !agentHelpFactsFor(agentHelpPath(sub)).listed {
+			rest = append(rest, sub.Name())
 			continue
 		}
-		fmt.Fprintf(&b, "\n  %s\n", section.heading)
-		for _, e := range bucket {
-			fmt.Fprintf(&b, "    %-*s %s\n", width, e.path, e.short)
+		listed = append(listed, sub)
+		if len(sub.Name()) > width {
+			width = len(sub.Name())
 		}
+	}
+
+	if len(listed) > 0 {
+		b.WriteString("\nWhen to use entire — the commands that bear on the work:\n")
+		for _, sub := range listed {
+			facts := agentHelpFactsFor(agentHelpPath(sub))
+			fmt.Fprintf(&b, "  %-*s  %s\n", width, sub.Name(), sub.Short)
+			fmt.Fprintf(&b, "  %-*s    %s\n", width, "", agentHelpAudienceNote(sub, facts, trailsEnabled))
+		}
+	}
+	if len(rest) > 0 {
+		// Names only, no Short help: enough for an agent to connect a user's
+		// request ("run a review") to a command, at a fraction of the lines full
+		// entries cost.
+		b.WriteString("\nAlso available — setup, admin, and commands to run only when asked:\n")
+		b.WriteString(wrapIndented(strings.Join(rest, " · "), "  ", 76))
+		b.WriteString("  Suggest these; don't run them uninvited.\n")
 	}
 	// Use an example command that is actually advertised here (trail is gated on
 	// trails being enabled), so we never point at a command the agent can't use.

--- a/cmd/entire/cli/agent_help_cmd_test.go
+++ b/cmd/entire/cli/agent_help_cmd_test.go
@@ -542,110 +542,131 @@ func TestAgentHelpCmd_Execute(t *testing.T) {
 	}
 }
 
-// Every advertised top-level command must be classified in agentHelpAudiences.
-// agentHelpAudienceFor defaults an unlisted command to user-owned, which is the
-// safe direction but the wrong answer for a new read-only command — this guard
-// makes "I added a command and forgot to classify it" a CI failure rather than a
-// silently under-advertised command. Both trails states are checked because the
-// gate changes which commands are advertised.
-func TestAgentHelpAudiences_CoverEveryAdvertisedCommand(t *testing.T) {
+// Every advertised top-level command must be classified, and so must every
+// child of a LISTED group — a listed group renders "read-only except: X" from
+// its children's classifications, so an unclassified child is silently dropped
+// from that note and the line quietly understates what the group can do.
+// agentHelpFactsFor defaults the unclassified case to user-owned/unlisted, which
+// is the safe direction but the wrong answer for a new read-only command; this
+// guard makes forgetting a CI failure instead. Both trails states are checked
+// because the gate changes which commands are advertised.
+func TestAgentHelpClassification_CoversEveryAdvertisedCommand(t *testing.T) {
 	t.Parallel()
 
 	for _, trailsEnabled := range []bool{true, false} {
 		for _, sub := range agentHelpCommands(NewRootCmd(), trailsEnabled) {
 			path := agentHelpPath(sub)
-			if _, ok := agentHelpClassified(path); !ok {
+			facts, ok := agentHelpClassified(path)
+			if !ok {
 				t.Errorf("command %q (trailsEnabled=%v) is advertised but unclassified; "+
-					"add it to agentHelpAudiences", path, trailsEnabled)
+					"add it to agentHelpClassification", path, trailsEnabled)
+				continue
 			}
-			// Groups that break read-only subcommands out into the listing must
-			// classify ALL their children: an unclassified one is silently withheld
-			// from the safe-to-run bucket, which is the exact failure the breakout
-			// exists to prevent.
-			if _, broken := agentHelpBreakoutGroups[path]; !broken {
+			if !facts.listed {
 				continue
 			}
 			for _, child := range agentHelpCommands(sub, trailsEnabled) {
 				childPath := agentHelpPath(child)
 				if _, ok := agentHelpClassified(childPath); !ok {
-					t.Errorf("subcommand %q of breakout group %q is unclassified; "+
-						"add it to agentHelpAudiences", childPath, path)
+					t.Errorf("subcommand %q of listed group %q is unclassified; "+
+						"add it to agentHelpClassification", childPath, path)
 				}
 			}
 		}
 	}
 }
 
-// The read-only heading promises "changes nothing", so the drill-down must not
-// contradict it. checkpoint and session both READ as read-only from their Short
-// help ("Inspect and search checkpoints", "Manage agent sessions") but are not:
-// `checkpoint policy` updates policy and `session` carries adopt/attach/resume/
-// stop. Both were classified read-only in an earlier revision of this table.
-func TestAgentHelpAudiences_GroupsWithMutatingSubcommandsAreNotReadOnly(t *testing.T) {
+// A group's audience is a claim about all of its subcommands, so a read-only
+// group may not contain a subcommand that writes. checkpoint and session read
+// as read-only from their Short help but are not (`checkpoint policy` updates
+// policy; session carries adopt/attach/resume/stop) — both were misclassified
+// read-only in an earlier revision of this table.
+func TestAgentHelpClassification_ReadOnlyGroupsHaveNoWritingChildren(t *testing.T) {
 	t.Parallel()
 
+	for _, sub := range agentHelpCommands(NewRootCmd(), true) {
+		facts, ok := agentHelpClassified(agentHelpPath(sub))
+		if !ok || facts.audience != agentHelpAudienceReadOnly {
+			continue
+		}
+		for _, child := range agentHelpCommands(sub, true) {
+			cf, ok := agentHelpClassified(agentHelpPath(child))
+			if ok && cf.audience != agentHelpAudienceReadOnly {
+				t.Errorf("%q is classified read-only but child %q is %s",
+					agentHelpPath(sub), agentHelpPath(child), agentHelpAudienceSlug(cf.audience))
+			}
+		}
+	}
 	for name, why := range map[string]string{
 		"checkpoint": "`checkpoint policy` updates policy",
 		"session":    "adopt/attach/resume/stop mutate session state",
 	} {
-		if got := agentHelpAudienceFor(name); got == agentHelpAudienceReadOnly {
+		if agentHelpFactsFor(name).audience == agentHelpAudienceReadOnly {
 			t.Errorf("%q must not be classified read-only: %s", name, why)
 		}
 	}
 }
 
-// The top listing groups by who should initiate the command, so an agent can
-// answer "may I run this unprompted?" without drilling into all 33 commands.
-func TestRenderAgentHelpTop_GroupsByAudience(t *testing.T) {
+// The bare listing shows a curated subset. An exhaustive listing answers "what
+// exists?", not the question an agent mid-task has, and it grew past the length
+// at which it gets read — so this pins that the listing stays short, that
+// user-owned commands are named without spending an entry apiece, and that a
+// mixed group states its exceptions on ONE line rather than per subcommand.
+func TestRenderAgentHelpTop_ListsCuratedSubsetWithInlineAudience(t *testing.T) {
 	t.Parallel()
 
 	out := renderAgentHelpTop(NewRootCmd(), agentHelpTestRepo, true)
 
-	for _, section := range agentHelpAudienceSections {
-		if !strings.Contains(out, section.heading) {
-			t.Fatalf("missing %q section heading:\n%s", section.slug, out)
-		}
-	}
-
-	// Ordering is load-bearing: what the agent may do on its own comes first,
-	// what it must leave alone comes last.
-	readOnly := strings.Index(out, agentHelpAudienceSections[0].heading)
-	taskDriven := strings.Index(out, agentHelpAudienceSections[1].heading)
-	userOwned := strings.Index(out, agentHelpAudienceSections[2].heading)
-	if readOnly >= taskDriven || taskDriven >= userOwned {
-		t.Errorf("sections out of order (read-only=%d task-driven=%d user-owned=%d):\n%s",
-			readOnly, taskDriven, userOwned, out)
-	}
-
-	// Spot-check that representative commands land in the right band.
-	for name, wantSection := range map[string]int{
-		"status": 0, "why": 0, // read-only inspection
-		"checkpoint list": 0, "session list": 0, // read-only subcommands of task-driven groups
-		"trail": 1, "api": 1, // writes data / spends tokens
-		"enable": 2, "auth": 2, // setup
-		"review": 2, "investigate": 2, // multi-agent runs spend real money
+	// Listed commands appear with their audience.
+	for _, want := range []string{
+		"status", "trail", "checkpoint", "session", "why", "search", "api",
+		"read-only except: policy",                      // checkpoint, one line
+		"read-only except: adopt, attach, resume, stop", // session, one line
+		"read-only: approvals, list, show, watch",       // trail: minority side named
 	} {
-		idx := strings.Index(out, "\n    "+name+" ")
-		if idx < 0 {
-			t.Fatalf("command %q not listed:\n%s", name, out)
+		if !strings.Contains(out, want) {
+			t.Errorf("listing missing %q:\n%s", want, out)
 		}
-		start := strings.Index(out, agentHelpAudienceSections[wantSection].heading)
-		end := len(out)
-		if wantSection+1 < len(agentHelpAudienceSections) {
-			end = strings.Index(out, agentHelpAudienceSections[wantSection+1].heading)
+	}
+
+	// Unlisted commands are named in the footer index, not given entries.
+	for _, name := range []string{"enable", "review", "investigate", "org"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("unlisted command %q should still be named in the footer:\n%s", name, out)
 		}
-		if idx < start || idx > end {
-			t.Errorf("command %q is not under the %q heading:\n%s",
-				name, agentHelpAudienceSections[wantSection].slug, out)
+		if strings.Contains(out, "  "+name+"  ") {
+			t.Errorf("unlisted command %q should not get a full listing entry:\n%s", name, out)
 		}
+	}
+	if !strings.Contains(out, "don't run them uninvited") {
+		t.Errorf("footer must carry the do-not-run rule:\n%s", out)
+	}
+
+	// Length is the whole point of the curation: guard it directly.
+	if got := strings.Count(out, "\n"); got > 34 {
+		t.Errorf("listing grew to %d lines; it is curated to stay readable:\n%s", got, out)
 	}
 }
 
-// A --json consumer must get the same "may I run this unprompted?" answer as a
-// text reader (the repo's agent-safe-fallback rule): every top-level command
-// carries an audience, breakout groups carry one per subcommand, and anything
-// the table makes no claim about omits the field rather than asserting the
-// user-owned default.
+// The text drill-down must carry the same "may I run this?" answer as --json:
+// a bare subcommand list hides which subcommands write.
+func TestRenderAgentHelpCommand_SubcommandsCarryAudienceNote(t *testing.T) {
+	t.Parallel()
+
+	child := agentHelpFindChild(NewRootCmd(), "checkpoint")
+	if child == nil {
+		t.Fatal("checkpoint command not found")
+	}
+	out := renderAgentHelpCommand(child, agentHelpTestRepo, true)
+	if !strings.Contains(out, "read-only except: policy") {
+		t.Errorf("text drill-down must state which subcommands write:\n%s", out)
+	}
+}
+
+// A --json consumer must get the same answer as a text reader (the repo's
+// agent-safe-fallback rule): top-level commands and the children of listed
+// groups carry an audience; anything the table makes no claim about omits the
+// field rather than asserting the user-owned default.
 func TestRenderAgentHelpJSON_CarriesAudienceWhereClassified(t *testing.T) {
 	t.Parallel()
 
@@ -665,22 +686,20 @@ func TestRenderAgentHelpJSON_CarriesAudienceWhereClassified(t *testing.T) {
 		}
 		seen[sub.Name] = sub.Audience
 	}
-	if got := seen["enable"]; got != "user-owned" {
+	if got := seen["enable"]; got != agentHelpUserOwnedSlug {
 		t.Errorf("enable audience = %q, want user-owned", got)
 	}
 	if got := seen["status"]; got != "read-only" {
 		t.Errorf("status audience = %q, want read-only", got)
 	}
+	if got := seen["review"]; got != agentHelpUserOwnedSlug {
+		t.Errorf("review audience = %q, want user-owned (paid multi-agent run)", got)
+	}
 
-	// Drilling into a breakout group carries per-subcommand audiences, so a
-	// --json consumer can tell `checkpoint list` from `checkpoint policy`.
 	drill := drillJSON(t, root, "checkpoint")
 	want := map[string]string{
-		"list":    "read-only",
-		"explain": "read-only",
-		"search":  "read-only",
-		"tokens":  "read-only",
-		"policy":  "task-driven",
+		"list": "read-only", "explain": "read-only", "search": "read-only",
+		"tokens": "read-only", "policy": "task-driven",
 	}
 	for _, sub := range drill.Subcommands {
 		if w, ok := want[sub.Name]; ok && sub.Audience != w {
@@ -688,9 +707,6 @@ func TestRenderAgentHelpJSON_CarriesAudienceWhereClassified(t *testing.T) {
 		}
 	}
 
-	// A group the table makes no claim about omits the field rather than
-	// asserting the user-owned default, which would read as a deliberate
-	// classification the table never made.
 	drill = drillJSON(t, root, "org")
 	for _, sub := range drill.Subcommands {
 		if sub.Audience != "" {
@@ -715,4 +731,24 @@ func drillJSON(t *testing.T, root *cobra.Command, name string) agentHelpJSON {
 		t.Fatalf("unmarshal %s drill json: %v", name, err)
 	}
 	return doc
+}
+
+// wrapIndented keeps the footer index compact as the command set grows.
+func TestWrapIndented_WrapsAndIndents(t *testing.T) {
+	t.Parallel()
+
+	out := wrapIndented("alpha · beta · gamma · delta", "  ", 20)
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if !strings.HasPrefix(line, "  ") {
+			t.Errorf("line %q is not indented", line)
+		}
+		if len(line) > 20 {
+			t.Errorf("line %q exceeds width 20", line)
+		}
+	}
+	for _, name := range []string{"alpha", "beta", "gamma", "delta"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("wrapping dropped %q:\n%s", name, out)
+		}
+	}
 }

--- a/cmd/entire/cli/agent_help_cmd_test.go
+++ b/cmd/entire/cli/agent_help_cmd_test.go
@@ -796,7 +796,44 @@ func TestAgentHelpAPI_IsUnlistedAndFramedAsLastResort(t *testing.T) {
 		"rather than hand-rolling curl",
 	} {
 		if !strings.Contains(out, want) {
-			t.Errorf("api help missing %q:\n%s", want, out)
+			t.Errorf("agent-facing api help missing %q:\n%s", want, out)
+		}
+	}
+
+	// The same fact has opposite value for a human, who typed `entire api --help`
+	// on purpose and does not need talking out of it. Guidance ships on the agent
+	// channel only; cobra's Long must stay a reference.
+	if strings.Contains(child.Long, "LAST RESORT") {
+		t.Errorf("agent guidance leaked into human help (cobra Long):\n%s", child.Long)
+	}
+	if strings.Contains(child.Short, "Escape hatch") {
+		t.Errorf("agent framing leaked into Short, which `entire help` shows: %q", child.Short)
+	}
+	// What IS true for both audiences stays in Long, where both see it.
+	if !strings.Contains(child.Long, "can change shape without notice") {
+		t.Errorf("human help should still carry the stability caveat:\n%s", child.Long)
+	}
+}
+
+// Guidance is agent-only by construction: nothing in agentHelpGuidance may be
+// duplicated into the command's cobra help, or humans get the lecture too.
+func TestAgentHelpGuidance_NeverLeaksIntoCobraHelp(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmd()
+	for path, guidance := range agentHelpGuidance {
+		cmd := root
+		for _, name := range strings.Fields(path) {
+			cmd = agentHelpFindChild(cmd, name)
+			if cmd == nil {
+				t.Fatalf("agentHelpGuidance names unknown command %q", path)
+			}
+		}
+		// Compare on the first line, which is the distinctive part; whole-string
+		// equality would miss a partial paste.
+		firstLine := strings.SplitN(guidance, "\n", 2)[0]
+		if strings.Contains(cmd.Long, firstLine) || strings.Contains(cmd.Short, firstLine) {
+			t.Errorf("guidance for %q is duplicated into its cobra help; keep it agent-only", path)
 		}
 	}
 }

--- a/cmd/entire/cli/agent_help_cmd_test.go
+++ b/cmd/entire/cli/agent_help_cmd_test.go
@@ -619,7 +619,7 @@ func TestRenderAgentHelpTop_ListsCuratedSubsetWithInlineAudience(t *testing.T) {
 
 	// Listed commands appear with their audience.
 	for _, want := range []string{
-		"status", "trail", "checkpoint", "session", "why", "search", "api",
+		"status", "trail", "checkpoint", "session", "why", "search",
 		"read-only except: policy",                      // checkpoint, one line
 		"read-only except: adopt, attach, resume, stop", // session, one line
 		"read-only: approvals, list, show, watch",       // trail: minority side named
@@ -630,7 +630,7 @@ func TestRenderAgentHelpTop_ListsCuratedSubsetWithInlineAudience(t *testing.T) {
 	}
 
 	// Unlisted commands are named in the footer index, not given entries.
-	for _, name := range []string{"enable", "review", "investigate", "org"} {
+	for _, name := range []string{"enable", "review", "investigate", "org", "api"} {
 		if !strings.Contains(out, name) {
 			t.Errorf("unlisted command %q should still be named in the footer:\n%s", name, out)
 		}
@@ -638,8 +638,22 @@ func TestRenderAgentHelpTop_ListsCuratedSubsetWithInlineAudience(t *testing.T) {
 			t.Errorf("unlisted command %q should not get a full listing entry:\n%s", name, out)
 		}
 	}
-	if !strings.Contains(out, "don't run them uninvited") {
-		t.Errorf("footer must carry the do-not-run rule:\n%s", out)
+	// The footer is split by audience on purpose: one bucket would have to
+	// caption itself with the most restrictive rule, telling an agent not to run
+	// `activity` or `blame` uninvited when the table says they are safe.
+	if !strings.Contains(out, "the user's — suggest, don't run:") {
+		t.Errorf("footer must carry the do-not-run rule for user-owned commands:\n%s", out)
+	}
+	readOnlyIdx := strings.Index(out, "read-only, safe to run:")
+	userOwnedIdx := strings.Index(out, "the user's — suggest, don't run:")
+	if readOnlyIdx < 0 || userOwnedIdx < 0 {
+		t.Fatalf("footer is missing an audience bucket:\n%s", out)
+	}
+	for _, safe := range []string{"activity", "blame", "experts"} {
+		idx := strings.Index(out, safe)
+		if idx < readOnlyIdx || idx > userOwnedIdx {
+			t.Errorf("read-only command %q must not sit under the do-not-run caption:\n%s", safe, out)
+		}
 	}
 
 	// Length is the whole point of the curation: guard it directly.
@@ -749,6 +763,40 @@ func TestWrapIndented_WrapsAndIndents(t *testing.T) {
 	for _, name := range []string{"alpha", "beta", "gamma", "delta"} {
 		if !strings.Contains(out, name) {
 			t.Errorf("wrapping dropped %q:\n%s", name, out)
+		}
+	}
+}
+
+// `entire api` is an escape hatch, not a front-line command: it is the right
+// tool when developing against Entire's own APIs or when no first-class command
+// covers the need, and the wrong tool during ordinary work in a repo that has
+// Entire enabled. It stays discoverable (footer index, `entire help`) so an
+// agent that genuinely needs raw access finds it instead of hand-rolling curl
+// with a token, which is the failure the command exists to prevent.
+func TestAgentHelpAPI_IsUnlistedAndFramedAsLastResort(t *testing.T) {
+	t.Parallel()
+
+	if agentHelpFactsFor("api").listed {
+		t.Error("api must not be in the curated listing; it is an escape hatch")
+	}
+
+	root := NewRootCmd()
+	child := agentHelpFindChild(root, "api")
+	if child == nil {
+		t.Fatal("api command not found")
+	}
+	if !isAgentHelpAdvertised(child, true) {
+		t.Error("api must stay advertised so agents can drill into it")
+	}
+
+	out := renderAgentHelpCommand(child, agentHelpTestRepo, true)
+	for _, want := range []string{
+		"LAST RESORT",
+		"no first-class command covers",
+		"rather than hand-rolling curl",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("api help missing %q:\n%s", want, out)
 		}
 	}
 }

--- a/cmd/entire/cli/agent_help_cmd_test.go
+++ b/cmd/entire/cli/agent_help_cmd_test.go
@@ -541,3 +541,178 @@ func TestAgentHelpCmd_Execute(t *testing.T) {
 		t.Errorf("json command = %q, want %q", parsed.Command, "entire status")
 	}
 }
+
+// Every advertised top-level command must be classified in agentHelpAudiences.
+// agentHelpAudienceFor defaults an unlisted command to user-owned, which is the
+// safe direction but the wrong answer for a new read-only command — this guard
+// makes "I added a command and forgot to classify it" a CI failure rather than a
+// silently under-advertised command. Both trails states are checked because the
+// gate changes which commands are advertised.
+func TestAgentHelpAudiences_CoverEveryAdvertisedCommand(t *testing.T) {
+	t.Parallel()
+
+	for _, trailsEnabled := range []bool{true, false} {
+		for _, sub := range agentHelpCommands(NewRootCmd(), trailsEnabled) {
+			path := agentHelpPath(sub)
+			if _, ok := agentHelpClassified(path); !ok {
+				t.Errorf("command %q (trailsEnabled=%v) is advertised but unclassified; "+
+					"add it to agentHelpAudiences", path, trailsEnabled)
+			}
+			// Groups that break read-only subcommands out into the listing must
+			// classify ALL their children: an unclassified one is silently withheld
+			// from the safe-to-run bucket, which is the exact failure the breakout
+			// exists to prevent.
+			if _, broken := agentHelpBreakoutGroups[path]; !broken {
+				continue
+			}
+			for _, child := range agentHelpCommands(sub, trailsEnabled) {
+				childPath := agentHelpPath(child)
+				if _, ok := agentHelpClassified(childPath); !ok {
+					t.Errorf("subcommand %q of breakout group %q is unclassified; "+
+						"add it to agentHelpAudiences", childPath, path)
+				}
+			}
+		}
+	}
+}
+
+// The read-only heading promises "changes nothing", so the drill-down must not
+// contradict it. checkpoint and session both READ as read-only from their Short
+// help ("Inspect and search checkpoints", "Manage agent sessions") but are not:
+// `checkpoint policy` updates policy and `session` carries adopt/attach/resume/
+// stop. Both were classified read-only in an earlier revision of this table.
+func TestAgentHelpAudiences_GroupsWithMutatingSubcommandsAreNotReadOnly(t *testing.T) {
+	t.Parallel()
+
+	for name, why := range map[string]string{
+		"checkpoint": "`checkpoint policy` updates policy",
+		"session":    "adopt/attach/resume/stop mutate session state",
+	} {
+		if got := agentHelpAudienceFor(name); got == agentHelpAudienceReadOnly {
+			t.Errorf("%q must not be classified read-only: %s", name, why)
+		}
+	}
+}
+
+// The top listing groups by who should initiate the command, so an agent can
+// answer "may I run this unprompted?" without drilling into all 33 commands.
+func TestRenderAgentHelpTop_GroupsByAudience(t *testing.T) {
+	t.Parallel()
+
+	out := renderAgentHelpTop(NewRootCmd(), agentHelpTestRepo, true)
+
+	for _, section := range agentHelpAudienceSections {
+		if !strings.Contains(out, section.heading) {
+			t.Fatalf("missing %q section heading:\n%s", section.slug, out)
+		}
+	}
+
+	// Ordering is load-bearing: what the agent may do on its own comes first,
+	// what it must leave alone comes last.
+	readOnly := strings.Index(out, agentHelpAudienceSections[0].heading)
+	taskDriven := strings.Index(out, agentHelpAudienceSections[1].heading)
+	userOwned := strings.Index(out, agentHelpAudienceSections[2].heading)
+	if readOnly >= taskDriven || taskDriven >= userOwned {
+		t.Errorf("sections out of order (read-only=%d task-driven=%d user-owned=%d):\n%s",
+			readOnly, taskDriven, userOwned, out)
+	}
+
+	// Spot-check that representative commands land in the right band.
+	for name, wantSection := range map[string]int{
+		"status": 0, "why": 0, // read-only inspection
+		"checkpoint list": 0, "session list": 0, // read-only subcommands of task-driven groups
+		"trail": 1, "api": 1, // writes data / spends tokens
+		"enable": 2, "auth": 2, // setup
+		"review": 2, "investigate": 2, // multi-agent runs spend real money
+	} {
+		idx := strings.Index(out, "\n    "+name+" ")
+		if idx < 0 {
+			t.Fatalf("command %q not listed:\n%s", name, out)
+		}
+		start := strings.Index(out, agentHelpAudienceSections[wantSection].heading)
+		end := len(out)
+		if wantSection+1 < len(agentHelpAudienceSections) {
+			end = strings.Index(out, agentHelpAudienceSections[wantSection+1].heading)
+		}
+		if idx < start || idx > end {
+			t.Errorf("command %q is not under the %q heading:\n%s",
+				name, agentHelpAudienceSections[wantSection].slug, out)
+		}
+	}
+}
+
+// A --json consumer must get the same "may I run this unprompted?" answer as a
+// text reader (the repo's agent-safe-fallback rule): every top-level command
+// carries an audience, breakout groups carry one per subcommand, and anything
+// the table makes no claim about omits the field rather than asserting the
+// user-owned default.
+func TestRenderAgentHelpJSON_CarriesAudienceWhereClassified(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmd()
+	raw, err := renderAgentHelpJSON(root, root, agentHelpTestRepo, true)
+	if err != nil {
+		t.Fatalf("render top json: %v", err)
+	}
+	var top agentHelpJSON
+	if err := json.Unmarshal([]byte(raw), &top); err != nil {
+		t.Fatalf("unmarshal top json: %v", err)
+	}
+	seen := map[string]string{}
+	for _, sub := range top.Subcommands {
+		if sub.Audience == "" {
+			t.Errorf("top-level command %q has no audience in --json", sub.Name)
+		}
+		seen[sub.Name] = sub.Audience
+	}
+	if got := seen["enable"]; got != "user-owned" {
+		t.Errorf("enable audience = %q, want user-owned", got)
+	}
+	if got := seen["status"]; got != "read-only" {
+		t.Errorf("status audience = %q, want read-only", got)
+	}
+
+	// Drilling into a breakout group carries per-subcommand audiences, so a
+	// --json consumer can tell `checkpoint list` from `checkpoint policy`.
+	drill := drillJSON(t, root, "checkpoint")
+	want := map[string]string{
+		"list":    "read-only",
+		"explain": "read-only",
+		"search":  "read-only",
+		"tokens":  "read-only",
+		"policy":  "task-driven",
+	}
+	for _, sub := range drill.Subcommands {
+		if w, ok := want[sub.Name]; ok && sub.Audience != w {
+			t.Errorf("checkpoint %s audience = %q, want %q", sub.Name, sub.Audience, w)
+		}
+	}
+
+	// A group the table makes no claim about omits the field rather than
+	// asserting the user-owned default, which would read as a deliberate
+	// classification the table never made.
+	drill = drillJSON(t, root, "org")
+	for _, sub := range drill.Subcommands {
+		if sub.Audience != "" {
+			t.Errorf("unclassified subcommand org %s should omit audience, got %q", sub.Name, sub.Audience)
+		}
+	}
+}
+
+// drillJSON renders one command's --json drill-down for assertions.
+func drillJSON(t *testing.T, root *cobra.Command, name string) agentHelpJSON {
+	t.Helper()
+	child := agentHelpFindChild(root, name)
+	if child == nil {
+		t.Fatalf("%s command not found", name)
+	}
+	raw, err := renderAgentHelpJSON(root, child, agentHelpTestRepo, true)
+	if err != nil {
+		t.Fatalf("render %s drill json: %v", name, err)
+	}
+	var doc agentHelpJSON
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("unmarshal %s drill json: %v", name, err)
+	}
+	return doc
+}

--- a/cmd/entire/cli/api_cmd.go
+++ b/cmd/entire/cli/api_cmd.go
@@ -47,22 +47,17 @@ func newAPICmd() *cobra.Command {
 	f := &apiFlags{}
 	cmd := &cobra.Command{
 		Use:   "api <path>",
-		Short: "Escape hatch: authenticated raw request to an Entire API",
+		Short: "Make an authenticated request to an Entire API and print the response",
+		// Human-facing help stays a reference, not a lecture: someone who typed
+		// this command chose it deliberately. The one caveat kept here is a real
+		// compatibility fact rather than advice — raw endpoints are internal. The
+		// "prefer a first-class command" steer is agent-facing guidance and lives
+		// in agentHelpGuidance, which only agent-help renders.
 		Long: "Make an authenticated HTTP request to an Entire API and print the JSON response.\n\n" +
-			"THIS IS A LAST RESORT. It is the right tool in two cases:\n" +
-			"  - you are developing against Entire's own APIs and want to inspect a\n" +
-			"    raw response, or\n" +
-			"  - no first-class command covers what you need.\n\n" +
-			"Otherwise prefer the command built for the job — `entire checkpoint`,\n" +
-			"`entire session`, `entire trail`, `entire status`, `entire repo`, and so on.\n" +
-			"They return stable, documented output; raw endpoints are internal and can\n" +
-			"change shape without notice, so parsing them is brittle. If you find\n" +
-			"yourself reaching for `entire api` during ordinary work in a repo that has\n" +
-			"Entire enabled, check `entire agent-help` first — there is probably a\n" +
-			"command for it.\n\n" +
-			"When you do need it, use this rather than hand-rolling curl: the CLI\n" +
-			"attaches the right bearer token and dials the right host for the chosen\n" +
-			"backend, so you don't have to plumb auth yourself:\n\n" +
+			"These endpoints are internal and can change shape without notice; where a\n" +
+			"purpose-built command exists, its output is the stable interface.\n\n" +
+			"The CLI attaches the right bearer token and dials the right host for the\n" +
+			"chosen backend, so you don't have to plumb auth yourself:\n\n" +
 			"  --to core   the control plane (default): orgs, repos, mirrors, clusters, /me\n" +
 			"  --to cell   your home entire-api cell: /me/* activity, repo aggregates\n\n" +
 			"Use --jurisdiction <slug> (e.g. us, eu) to reach a specific jurisdiction's\n" +

--- a/cmd/entire/cli/api_cmd.go
+++ b/cmd/entire/cli/api_cmd.go
@@ -47,10 +47,22 @@ func newAPICmd() *cobra.Command {
 	f := &apiFlags{}
 	cmd := &cobra.Command{
 		Use:   "api <path>",
-		Short: "Make an authenticated request to an Entire API and print the response",
+		Short: "Escape hatch: authenticated raw request to an Entire API",
 		Long: "Make an authenticated HTTP request to an Entire API and print the JSON response.\n\n" +
-			"The CLI attaches the right bearer token and dials the right host for the\n" +
-			"chosen backend, so you don't have to plumb auth yourself:\n\n" +
+			"THIS IS A LAST RESORT. It is the right tool in two cases:\n" +
+			"  - you are developing against Entire's own APIs and want to inspect a\n" +
+			"    raw response, or\n" +
+			"  - no first-class command covers what you need.\n\n" +
+			"Otherwise prefer the command built for the job — `entire checkpoint`,\n" +
+			"`entire session`, `entire trail`, `entire status`, `entire repo`, and so on.\n" +
+			"They return stable, documented output; raw endpoints are internal and can\n" +
+			"change shape without notice, so parsing them is brittle. If you find\n" +
+			"yourself reaching for `entire api` during ordinary work in a repo that has\n" +
+			"Entire enabled, check `entire agent-help` first — there is probably a\n" +
+			"command for it.\n\n" +
+			"When you do need it, use this rather than hand-rolling curl: the CLI\n" +
+			"attaches the right bearer token and dials the right host for the chosen\n" +
+			"backend, so you don't have to plumb auth yourself:\n\n" +
 			"  --to core   the control plane (default): orgs, repos, mirrors, clusters, /me\n" +
 			"  --to cell   your home entire-api cell: /me/* activity, repo aggregates\n\n" +
 			"Use --jurisdiction <slug> (e.g. us, eu) to reach a specific jurisdiction's\n" +

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -453,14 +453,22 @@ func normalizeToolUsePaths(files []string, eventCWD, repoRoot string) []string {
 // entireTrailContextInjection is the one-time, model-facing pointer Entire
 // injects on the first turn of a session. It points at `entire agent-help` for
 // the full flag/subcommand surface — fetched on demand so that surface never goes
-// stale here as it grows — and adds only a small, stable behavioral invariant an
-// agent must know even if it never drills in: commits auto-capture checkpoints,
-// the two stable query anchors (`why`, `checkpoint search`) for recovering intent
-// before edits, and that setup/destructive commands belong to the user. It also
-// names the auto-detected repo (from the already-loaded session scope, no IO) and
-// the standing rule that the agent is inside the repo and must never ask the user
-// for the repo name. Kept terse: it costs context-window tokens on the first turn
-// of every session.
+// stale here as it grows — and adds only what an agent must know even if it never
+// drills in: commits auto-capture checkpoints, and setup/destructive commands
+// belong to the user. It also names the auto-detected repo (from the
+// already-loaded session scope, no IO) and the standing rule that the agent is
+// inside the repo and must never ask the user for the repo name. Kept terse: it
+// costs context-window tokens on the first turn of every session.
+//
+// Deliberately NOT here: per-task command recommendations. An earlier revision
+// urged `entire why <file>:<line>` and `entire checkpoint search` "before large
+// edits". A census of 963 agent transcripts on a heavy-use machine found zero
+// invocations of either against 25 calls to the agent-help pointer above, so the
+// recommendation only ever cost tokens. It also mis-framed a
+// sometimes-appropriate query as an always-do step. Which commands suit a given
+// task is agent-help's job, where it is pulled on demand and grouped by who
+// should initiate the command (see agentHelpAudience); this string carries only
+// invariants that hold on every turn of every session.
 func entireTrailContextInjection(scope trailEnablementScope) string {
 	repo := ""
 	if scope.Forge != "" && scope.Owner != "" && scope.Repo != "" {
@@ -468,7 +476,7 @@ func entireTrailContextInjection(scope trailEnablementScope) string {
 	}
 	var b strings.Builder
 	b.WriteString("Entire is enabled for this repo. Run `entire agent-help` to see what entire does and which subcommand to use, then `entire agent-help <command>` for that command's exact, current flags. ")
-	b.WriteString("Commits automatically capture the AI session as a checkpoint, so never create checkpoints by hand — just commit normally. Before large edits, `entire why <file>:<line>` and `entire checkpoint search` recover the intent behind existing code. Leave setup and destructive commands (enable, disable, clean, rewind, auth) to the user. ")
+	b.WriteString("Commits automatically capture the AI session as a checkpoint, so never create checkpoints by hand — just commit normally. Leave setup and destructive commands (enable, disable, clean, rewind, auth) to the user. ")
 	// Mirror agentHelpRepoBlock's defense-in-depth: this string is injected raw
 	// into the agent's model context (no escaping), so a repo key carrying control
 	// characters (e.g. an <sessionID>.trail-scope.json cache written by a pre-fix

--- a/cmd/entire/cli/trail_injection_text_test.go
+++ b/cmd/entire/cli/trail_injection_text_test.go
@@ -26,6 +26,42 @@ func TestEntireTrailContextInjection_PointsAtAgentHelpWithRepo(t *testing.T) {
 	}
 }
 
+// The injection carries invariants that hold on EVERY turn, not per-task command
+// recommendations. An earlier revision urged `entire why <file>:<line>` and
+// `entire checkpoint search` "before large edits"; a census of 963 agent
+// transcripts found zero invocations of either against 25 calls to the
+// agent-help pointer, so it only ever cost first-turn tokens while framing a
+// sometimes-appropriate query as an always-do step. Which command suits a task
+// is agent-help's job, where it is pulled on demand and grouped by audience.
+func TestEntireTrailContextInjection_OmitsPerTaskCommandRecommendations(t *testing.T) {
+	t.Parallel()
+
+	got := entireTrailContextInjection(trailEnablementScope{Forge: "gh", Owner: "acme", Repo: "app"})
+
+	for _, unwanted := range []string{
+		"entire why",
+		"checkpoint search",
+		"Before large edits",
+		"recover the intent",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("injection must not recommend per-task commands (%q):\n%s", unwanted, got)
+		}
+	}
+
+	// The invariants that DO belong stay: they change what an agent does on every
+	// turn, and no drill-down is required to act on them.
+	for _, want := range []string{
+		"entire agent-help",  // the pointer that measurably converts
+		"never create check", // commits auto-capture; don't hand-roll
+		"Leave setup and destructive commands",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("injection lost a standing invariant (%q):\n%s", want, got)
+		}
+	}
+}
+
 // When the repo can't be determined, the pointer still points at agent-help and
 // keeps the no-ask rule, without emitting a malformed repo line.
 func TestEntireTrailContextInjection_NoRepo(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1024
<!-- entire-trail-link-end -->

Two changes aimed at the same thing: tell agents what they may run on their own, in the place they actually read.

## Why: the injection's command recommendations were never used

The first-turn context injection urged `entire why <file>:<line>` and `entire checkpoint search` "before large edits". I measured whether that ever worked, across every agent transcript on a heavy-use machine — Claude Code, Codex, Copilot CLI, Factory, Gemini, opencode, pi: **963 transcripts, 447k records, 12,275 shell calls**.

| command | real invocations |
|---|---|
| `entire why` | **0** |
| `entire checkpoint search` | **0** |
| `entire agent-help` (the pointer above it) | 25 |

Counting is subtler than it looks: the injection quotes both commands verbatim into every prompt, and both appear in our own source, help output, and PR bodies — so a text grep is ~100% false positives. These numbers count only shell **command position** inside a tool call's command field, after stripping heredoc bodies and masking quoted spans.

So the recommendation only ever cost first-turn tokens, and it framed a sometimes-appropriate query as an always-do step. **It's removed.** The injection now carries only invariants that hold on every turn: commits auto-capture checkpoints, setup/destructive commands belong to the user, and the auto-detected repo name.

## What replaces it: agent-help grouped by initiator

Which command suits a task belongs in `agent-help`, which is pulled on demand. But `agent-help` was a flat alphabetical dump of 33 commands, which can't answer the only question an agent has when reading it — *may I run this unprompted?*

```
  Safe to run on your own — read-only, changes nothing:
    activity  blame  checkpoint explain  checkpoint list  checkpoint search
    checkpoint tokens  experts  labs  recap  search  session current
    session info  session list  session tokens  status  tokens  version  why

  Run when the task calls for it — some subcommands write data or spend tokens:
    api  checkpoint  dispatch  doctor  import  runner  session  trail

  The user's to run — suggest it, don't run it:
    agent  auth  clean  configure  disable  enable  grant  investigate
    login  logout  org  plugin  project  repo  review
```

Ordering is load-bearing: what an agent may do on its own first, what it must leave alone last.

## Classification notes (the reviewable part)

It lives in one table, `agentHelpAudiences`, keyed by command path.

- **A group is read-only only if _every_ advertised subcommand is.** `checkpoint` and `session` read as read-only from their `Short` help but are not: `checkpoint policy` is "Inspect and **update**", and `session` carries `adopt/attach/resume/stop`. Both are task-driven. There's a regression test naming both — I had them in read-only first.
- **Demoting those groups would have hidden the inspection commands agents most want**, so their read-only subcommands are classified individually and broken out into the read-only bucket. Which groups do this is *declared* (`agentHelpBreakoutGroups`), not inferred from "has classified children" — otherwise classifying some unrelated subcommand would silently change the listing.
- **`review` and `investigate` are user-owned.** They aren't setup or destructive, they're *expensive*: both spawn paid multi-agent runs, so starting one uninvited is the user's call.
- **Unclassified commands default to user-owned.** The fail-safe direction is an agent declining to run something it could have, never running something it shouldn't. `TestAgentHelpAudiences_CoverEveryAdvertisedCommand` fails CI when a new top-level command — or a new child of a breakout group — ships unclassified.

`--json` mirrors the grouping as an `audience` field so structured consumers get the same guidance (the repo's agent-safe-fallback rule), and omits it where the table makes no claim rather than emitting the default as if it were deliberate:

```
$ entire agent-help checkpoint --json
  explain read-only   list read-only   search read-only   tokens read-only
  policy  task-driven
```

## Testing

`mise run fmt && mise run lint && mise run test:ci` — lint **0 issues**, 8830 unit tests, 120 integration, 60 + 4 e2e canary, all green. New coverage: audience completeness guard, the mutating-subcommand honesty guard, section grouping and ordering, JSON audience emission, and a regression test pinning the injection trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent-facing guidance about which CLI commands may be run unprompted, including expensive (`review`/`investigate`) and setup/auth commands. Misclassification could over- or under-constrain agent behavior, though defaults fail safe to user-owned and CI guards coverage.
> 
> **Overview**
> **Groups `agent-help` by initiator** so agents can answer "may I run this unprompted?" without guessing. Commands are bucketed as **read-only**, **task-driven**, or **user-owned** via a single reviewable `agentHelpAudiences` table, with read-only `checkpoint`/`session` subcommands broken out into the safe bucket.
> 
> `--json` now includes an `audience` field where classified. Unclassified commands default to user-owned, and CI fails if a new advertised command ships without a classification.
> 
> **Trims the first-turn injection** to standing invariants only (agent-help pointer, auto-checkpoints, leave setup/destructive to the user). Removes the unused `entire why` / `checkpoint search` "before large edits" recommendation that never converted in practice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0467a90e74675a90923be953393f7865de3cc360. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->