### PR TITLE
trail show --json, and pin the title+body update split

### DIFF
--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -165,6 +165,10 @@ type trailShowOptions struct {
 
 func newTrailShowCmd() *cobra.Command {
 	var opts trailShowOptions
+	// branchFlag is bound only so cobra has somewhere to write --branch; RunE
+	// reads it back through trailBranchFlag (which trims) along with every other
+	// field, so a value reaches opts exactly one way.
+	var branchFlag string
 	cmd := &cobra.Command{
 		Use:   "show [<trail>]",
 		Short: "Show a trail",
@@ -191,7 +195,7 @@ Otherwise, <trail> may be a trail number, id, or branch in the target repo.`,
 			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts)
 		},
 	}
-	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Show the trail for this branch instead of the current branch; cannot be combined with a trail selector")
+	cmd.Flags().StringVar(&branchFlag, "branch", "", "Show the trail for this branch instead of the current branch; cannot be combined with a trail selector")
 	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output the trail as JSON (same object shape as one entry of 'trail list --json')")
 	return cmd
 }
@@ -1380,6 +1384,13 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 	// caller knows the metadata already applied and only the body needs a
 	// retry, rather than assuming nothing changed.
 	meta, hasMeta, bodyReq := splitTrailUpdate(updateReq)
+	if !hasMeta && bodyReq == nil {
+		// Nothing changed — most often the interactive form opened and closed
+		// untouched. Say so instead of printing the success line: no PATCH went
+		// out, and agents read that line as confirmation the write landed.
+		fmt.Fprintf(w, "No changes to apply to the trail for branch %s\n", branch)
+		return nil
+	}
 	if hasMeta {
 		if err := sendTrailPatch(ctx, client, path, meta); err != nil {
 			return err
@@ -1531,6 +1542,13 @@ func splitTrailUpdate(full api.TrailUpdateRequest) (meta api.TrailUpdateRequest,
 // without anyone having to remember to extend this check. Forgetting to would
 // make splitTrailUpdate return hasMeta=false and drop that change silently: the
 // PATCH is never sent, yet the command still reports success.
+//
+// The reflective default is only right for fields the server treats as
+// metadata. A field that has to travel *with* the body instead — a hypothetical
+// body_format or body_version — would be routed into the metadata PATCH here
+// and rejected under the very "Body updates cannot be combined with metadata
+// updates" rule the split exists to satisfy. Adding one means deciding
+// explicitly where it belongs in splitTrailUpdate; it is not handled for free.
 func trailUpdateRequestHasFields(req api.TrailUpdateRequest) bool {
 	v := reflect.ValueOf(req)
 	for i := range v.NumField() {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os/exec"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -147,8 +148,23 @@ type trailListOptions struct {
 	Repo string
 }
 
+// trailShowOptions are the inputs to runTrailShow. Keeping them on a struct
+// avoids a long positional argument list, matching trailListOptions.
+type trailShowOptions struct {
+	// Selector picks the trail by number, id, or branch. Empty means "the trail
+	// for Branch", and an empty Branch in turn means the current branch.
+	Selector string
+	// Branch shows the trail for this branch instead of the current branch.
+	Branch string
+	// Repo is an optional --repo override (forge/owner/repo or a clone URL);
+	// empty means derive the repo from the origin remote.
+	Repo         string
+	JSON         bool
+	InsecureHTTP bool
+}
+
 func newTrailShowCmd() *cobra.Command {
-	var branch string
+	var opts trailShowOptions
 	cmd := &cobra.Command{
 		Use:   "show [<trail>]",
 		Short: "Show a trail",
@@ -168,58 +184,85 @@ Otherwise, <trail> may be a trail number, id, or branch in the target repo.`,
 			if err := ensureTrailRepoHasTarget(cmd, selector != "" || trailBranchFlag(cmd) != "", "pass a trail selector or --branch"); err != nil {
 				return err
 			}
-			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), selector, trailRepoFlag(cmd), trailBranchFlag(cmd))
+			opts.Selector = selector
+			opts.Branch = trailBranchFlag(cmd)
+			opts.Repo = trailRepoFlag(cmd)
+			opts.InsecureHTTP = trailInsecureHTTP(cmd)
+			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts)
 		},
 	}
-	cmd.Flags().StringVar(&branch, "branch", "", "Show the trail for this branch instead of the current branch; cannot be combined with a trail selector")
+	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Show the trail for this branch instead of the current branch; cannot be combined with a trail selector")
+	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output the trail as JSON (same object shape as one entry of 'trail list --json')")
 	return cmd
 }
 
 // runTrailShow shows one trail, defaulting to the current branch's trail.
-func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector, repoOverride, branchOverride string) error {
-	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, repoOverride, func(ctx context.Context, client *api.Client) error {
-		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
+func runTrailShow(ctx context.Context, w, errW io.Writer, opts trailShowOptions) error {
+	return runAuthenticatedTrailAPI(ctx, errW, opts.InsecureHTTP, opts.Repo, func(ctx context.Context, client *api.Client) error {
+		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, opts.Repo)
 		if err != nil {
 			return err
 		}
-
-		found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, selector, branchOverride)
-		if err != nil {
-			return err
-		}
-
-		// Enrich the list result with the detail endpoint, which carries the
-		// rendered description (trail.body_document.text_snapshot) the list
-		// omits, and surface a browser URL. The detail fetch is best-effort:
-		// the core metadata already came from the list, so a detail failure
-		// falls back to the list body with a warning rather than failing.
-		m := found.ToMetadata()
-		webURL := trailDisplayURL(*found, forge, owner, repo)
-		// Seed the description from the list body so a failed (or skipped)
-		// detail fetch still shows something; a successful detail fetch
-		// supersedes it with the richer body_document text below.
-		bodyText := found.Body
-		descriptionLoaded := strings.TrimSpace(found.Body) != ""
-		if found.Number > 0 {
-			if bt, derr := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number); derr == nil {
-				// A successful fetch means we authoritatively consulted the
-				// description, but it only supersedes the seeded list body when
-				// it actually carries text: an older/partial server that omits
-				// body_document returns "" here and must not blank out a list
-				// body that is present.
-				descriptionLoaded = true
-				if strings.TrimSpace(bt) != "" {
-					bodyText = bt
-				}
-			} else {
-				// Best-effort: warn but still render metadata + URL (and the
-				// list body) rather than failing the whole command.
-				fmt.Fprintf(errW, "Warning: could not load trail description: %v\n", derr)
-			}
-		}
-		printTrailDetails(w, m, webURL, trailDescriptionForDisplay(bodyText, descriptionLoaded))
-		return nil
+		return runTrailShowWithClient(ctx, w, errW, client, forge, owner, repo, opts)
 	})
+}
+
+// runTrailShowWithClient renders one trail once the repo and API client are
+// resolved. Warnings go to errW, so --json keeps stdout parseable even when the
+// best-effort description fetch fails.
+func runTrailShowWithClient(ctx context.Context, w, errW io.Writer, client *api.Client, forge, owner, repo string, opts trailShowOptions) error {
+	found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, opts.Selector, opts.Branch)
+	if err != nil {
+		return err
+	}
+
+	// Enrich the list result with the detail endpoint, which carries the
+	// rendered description (trail.body_document.text_snapshot) the list
+	// omits, and surface a browser URL. The detail fetch is best-effort:
+	// the core metadata already came from the list, so a detail failure
+	// falls back to the list body with a warning rather than failing.
+	m := found.ToMetadata()
+	m.URL = trailDisplayURL(*found, forge, owner, repo)
+	// Seed the description from the list body so a failed (or skipped)
+	// detail fetch still shows something; a successful detail fetch
+	// supersedes it with the richer body_document text below.
+	bodyText := found.Body
+	descriptionLoaded := strings.TrimSpace(found.Body) != ""
+	if found.Number > 0 {
+		if bt, derr := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number); derr == nil {
+			// A successful fetch means we authoritatively consulted the
+			// description, but it only supersedes the seeded list body when
+			// it actually carries text: an older/partial server that omits
+			// body_document returns "" here and must not blank out a list
+			// body that is present.
+			descriptionLoaded = true
+			if strings.TrimSpace(bt) != "" {
+				bodyText = bt
+			}
+		} else {
+			// Best-effort: warn but still render metadata + URL (and the
+			// list body) rather than failing the whole command.
+			fmt.Fprintf(errW, "Warning: could not load trail description: %v\n", derr)
+		}
+	}
+	// The list body is the weaker source; carry the resolved description on the
+	// metadata so JSON callers read the same text the human view renders.
+	m.Body = bodyText
+
+	if opts.JSON {
+		// Emit the raw body — never the "no description" placeholder, which is
+		// display text, not data. A single object mirrors one entry of
+		// `trail list --json` so both can feed the same parser.
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(m); err != nil {
+			return fmt.Errorf("failed to encode JSON: %w", err)
+		}
+		return nil
+	}
+
+	printTrailDetails(w, m, m.URL, trailDescriptionForDisplay(bodyText, descriptionLoaded))
+	return nil
 }
 
 // resolveTrailBySelector resolves a trail by an optional selector (trail
@@ -1201,152 +1244,158 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, i
 		if err != nil {
 			return err
 		}
-
-		// Determine branch.
-		branch := inputs.Branch
-		if branch == "" {
-			branch, err = GetCurrentBranch(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to determine current branch: %w", err)
-			}
-		}
-
-		// Find the trail by branch.
-		found, err := findTrailByBranch(ctx, client, forge, owner, repoName, branch)
-		if err != nil {
-			return err
-		}
-		if found == nil {
-			return fmt.Errorf("no trail found for branch %q", branch)
-		}
-
-		// Interactive mode when no update flags are provided.
-		statusStr := inputs.Status
-		title := inputs.Title
-		body := inputs.Body
-		noFlags := !inputs.StatusChanged && !inputs.TitleChanged && !inputs.BodyChanged &&
-			inputs.LabelAdd == nil && inputs.LabelRemove == nil &&
-			inputs.AssigneeAdd == nil && inputs.AssigneeRemove == nil &&
-			inputs.ReviewerAdd == nil && inputs.ReviewerRemove == nil &&
-			!inputs.TypeChanged && !inputs.PriorityChanged
-		if noFlags {
-			metadata := found.ToMetadata()
-			// Build status options with current value as default.
-			var statusOptions []huh.Option[string]
-			for _, s := range trail.ValidStatuses() {
-				if (s == trail.StatusMerged || s == trail.StatusClosed) && s != metadata.Status {
-					continue
-				}
-				label := string(s)
-				if s == metadata.Status {
-					label += " (current)"
-				}
-				statusOptions = append(statusOptions, huh.NewOption(label, string(s)))
-			}
-			statusStr = string(metadata.Status)
-			title = metadata.Title
-			// The list resource omits the description; fetch the detail body so
-			// the form prefills with the current text and change detection below
-			// compares against the real server value. Warn on a fetch failure so
-			// a blank baseline doesn't silently overwrite an unseen description.
-			seedBody, bodyErr := resolveTrailUpdateBody(ctx, client, forge, owner, repoName, found)
-			if bodyErr != nil {
-				fmt.Fprintf(errW, "Warning: could not load current trail body: %v\n", bodyErr)
-			}
-			body = seedBody
-			origStatus, origTitle, origBody := statusStr, title, body
-
-			form := NewAccessibleForm(
-				huh.NewGroup(
-					huh.NewSelect[string]().
-						Title("Status").
-						Options(statusOptions...).
-						Value(&statusStr),
-					huh.NewInput().
-						Title("Title").
-						Value(&title),
-					huh.NewText().
-						Title("Body").
-						Value(&body),
-				),
-			)
-			if formErr := form.Run(); formErr != nil {
-				return handleFormCancellation(w, "Trail update", formErr)
-			}
-			// Only mark a field changed when the user actually edited it, so an
-			// untouched body/title/status isn't needlessly PATCHed (a no-op body
-			// PATCH would otherwise rewrite the description on every update).
-			inputs.StatusChanged = statusStr != origStatus
-			inputs.TitleChanged = title != origTitle
-			inputs.BodyChanged = body != origBody
-		}
-
-		statusStr = strings.TrimSpace(statusStr)
-		title = strings.TrimSpace(title)
-		if err := validateTrailUpdateFields(trailUpdateInputs{
-			Status:          statusStr,
-			StatusChanged:   inputs.StatusChanged,
-			Title:           title,
-			TitleChanged:    inputs.TitleChanged,
-			Type:            inputs.Type,
-			TypeChanged:     inputs.TypeChanged,
-			Priority:        inputs.Priority,
-			PriorityChanged: inputs.PriorityChanged,
-		}); err != nil {
-			return err
-		}
-
-		// Build update request with only changed fields.
-		updateReq := buildTrailUpdateRequest(found, trailUpdateInputs{
-			Status:          statusStr,
-			StatusChanged:   inputs.StatusChanged,
-			Title:           title,
-			TitleChanged:    inputs.TitleChanged,
-			Body:            body,
-			BodyChanged:     inputs.BodyChanged,
-			LabelAdd:        inputs.LabelAdd,
-			LabelRemove:     inputs.LabelRemove,
-			AssigneeAdd:     inputs.AssigneeAdd,
-			AssigneeRemove:  inputs.AssigneeRemove,
-			ReviewerAdd:     inputs.ReviewerAdd,
-			ReviewerRemove:  inputs.ReviewerRemove,
-			Type:            inputs.Type,
-			TypeChanged:     inputs.TypeChanged,
-			Priority:        inputs.Priority,
-			PriorityChanged: inputs.PriorityChanged,
-		})
-
-		// The single-trail endpoint is keyed by trail number, not id; the server
-		// rejects an id here with "Invalid trail number format".
-		if found.Number <= 0 {
-			return fmt.Errorf("trail for branch %q has no number yet; cannot update", branch)
-		}
-		path := trailNumberPath(forge, owner, repoName, found.Number)
-
-		// The server rejects body + metadata in one PATCH, so send them as
-		// separate requests when both are present. These two calls are not
-		// atomic: if the metadata PATCH lands and the body PATCH then fails, the
-		// metadata change persists. Report that partial state explicitly so the
-		// caller knows the metadata already applied and only the body needs a
-		// retry, rather than assuming nothing changed.
-		meta, hasMeta, bodyReq := splitTrailUpdate(updateReq)
-		if hasMeta {
-			if err := sendTrailPatch(ctx, client, path, meta); err != nil {
-				return err
-			}
-		}
-		if bodyReq != nil {
-			if err := sendTrailPatch(ctx, client, path, *bodyReq); err != nil {
-				if hasMeta {
-					return fmt.Errorf("trail metadata was updated, but the body update failed (the metadata change already applied; retry only the --body change): %w", err)
-				}
-				return err
-			}
-		}
-
-		fmt.Fprintf(w, "Updated trail for branch %s\n", branch)
-		return nil
+		return runTrailUpdateWithClient(ctx, w, errW, client, forge, owner, repoName, inputs)
 	})
+}
+
+// runTrailUpdateWithClient applies a trail update once the repo and API client
+// are resolved.
+func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *api.Client, forge, owner, repoName string, inputs trailUpdateInputs) error {
+	// Determine branch.
+	branch := inputs.Branch
+	if branch == "" {
+		current, err := GetCurrentBranch(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to determine current branch: %w", err)
+		}
+		branch = current
+	}
+
+	// Find the trail by branch.
+	found, err := findTrailByBranch(ctx, client, forge, owner, repoName, branch)
+	if err != nil {
+		return err
+	}
+	if found == nil {
+		return fmt.Errorf("no trail found for branch %q", branch)
+	}
+
+	// Interactive mode when no update flags are provided.
+	statusStr := inputs.Status
+	title := inputs.Title
+	body := inputs.Body
+	noFlags := !inputs.StatusChanged && !inputs.TitleChanged && !inputs.BodyChanged &&
+		inputs.LabelAdd == nil && inputs.LabelRemove == nil &&
+		inputs.AssigneeAdd == nil && inputs.AssigneeRemove == nil &&
+		inputs.ReviewerAdd == nil && inputs.ReviewerRemove == nil &&
+		!inputs.TypeChanged && !inputs.PriorityChanged
+	if noFlags {
+		metadata := found.ToMetadata()
+		// Build status options with current value as default.
+		var statusOptions []huh.Option[string]
+		for _, s := range trail.ValidStatuses() {
+			if (s == trail.StatusMerged || s == trail.StatusClosed) && s != metadata.Status {
+				continue
+			}
+			label := string(s)
+			if s == metadata.Status {
+				label += " (current)"
+			}
+			statusOptions = append(statusOptions, huh.NewOption(label, string(s)))
+		}
+		statusStr = string(metadata.Status)
+		title = metadata.Title
+		// The list resource omits the description; fetch the detail body so
+		// the form prefills with the current text and change detection below
+		// compares against the real server value. Warn on a fetch failure so
+		// a blank baseline doesn't silently overwrite an unseen description.
+		seedBody, bodyErr := resolveTrailUpdateBody(ctx, client, forge, owner, repoName, found)
+		if bodyErr != nil {
+			fmt.Fprintf(errW, "Warning: could not load current trail body: %v\n", bodyErr)
+		}
+		body = seedBody
+		origStatus, origTitle, origBody := statusStr, title, body
+
+		form := NewAccessibleForm(
+			huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Status").
+					Options(statusOptions...).
+					Value(&statusStr),
+				huh.NewInput().
+					Title("Title").
+					Value(&title),
+				huh.NewText().
+					Title("Body").
+					Value(&body),
+			),
+		)
+		if formErr := form.Run(); formErr != nil {
+			return handleFormCancellation(w, "Trail update", formErr)
+		}
+		// Only mark a field changed when the user actually edited it, so an
+		// untouched body/title/status isn't needlessly PATCHed (a no-op body
+		// PATCH would otherwise rewrite the description on every update).
+		inputs.StatusChanged = statusStr != origStatus
+		inputs.TitleChanged = title != origTitle
+		inputs.BodyChanged = body != origBody
+	}
+
+	statusStr = strings.TrimSpace(statusStr)
+	title = strings.TrimSpace(title)
+	if err := validateTrailUpdateFields(trailUpdateInputs{
+		Status:          statusStr,
+		StatusChanged:   inputs.StatusChanged,
+		Title:           title,
+		TitleChanged:    inputs.TitleChanged,
+		Type:            inputs.Type,
+		TypeChanged:     inputs.TypeChanged,
+		Priority:        inputs.Priority,
+		PriorityChanged: inputs.PriorityChanged,
+	}); err != nil {
+		return err
+	}
+
+	// Build update request with only changed fields.
+	updateReq := buildTrailUpdateRequest(found, trailUpdateInputs{
+		Status:          statusStr,
+		StatusChanged:   inputs.StatusChanged,
+		Title:           title,
+		TitleChanged:    inputs.TitleChanged,
+		Body:            body,
+		BodyChanged:     inputs.BodyChanged,
+		LabelAdd:        inputs.LabelAdd,
+		LabelRemove:     inputs.LabelRemove,
+		AssigneeAdd:     inputs.AssigneeAdd,
+		AssigneeRemove:  inputs.AssigneeRemove,
+		ReviewerAdd:     inputs.ReviewerAdd,
+		ReviewerRemove:  inputs.ReviewerRemove,
+		Type:            inputs.Type,
+		TypeChanged:     inputs.TypeChanged,
+		Priority:        inputs.Priority,
+		PriorityChanged: inputs.PriorityChanged,
+	})
+
+	// The single-trail endpoint is keyed by trail number, not id; the server
+	// rejects an id here with "Invalid trail number format".
+	if found.Number <= 0 {
+		return fmt.Errorf("trail for branch %q has no number yet; cannot update", branch)
+	}
+	path := trailNumberPath(forge, owner, repoName, found.Number)
+
+	// The server rejects body + metadata in one PATCH, so send them as
+	// separate requests when both are present. These two calls are not
+	// atomic: if the metadata PATCH lands and the body PATCH then fails, the
+	// metadata change persists. Report that partial state explicitly so the
+	// caller knows the metadata already applied and only the body needs a
+	// retry, rather than assuming nothing changed.
+	meta, hasMeta, bodyReq := splitTrailUpdate(updateReq)
+	if hasMeta {
+		if err := sendTrailPatch(ctx, client, path, meta); err != nil {
+			return err
+		}
+	}
+	if bodyReq != nil {
+		if err := sendTrailPatch(ctx, client, path, *bodyReq); err != nil {
+			if hasMeta {
+				return fmt.Errorf("trail metadata was updated, but the body update failed (the metadata change already applied; retry only the --body change): %w", err)
+			}
+			return err
+		}
+	}
+
+	fmt.Fprintf(w, "Updated trail for branch %s\n", branch)
+	return nil
 }
 
 func validateTrailUpdateFields(inputs trailUpdateInputs) error {
@@ -1459,8 +1508,10 @@ func buildTrailUpdateRequest(current *api.TrailResource, inputs trailUpdateInput
 
 // splitTrailUpdate separates a full update into a metadata request and an
 // optional body request. The server rejects a body update combined with
-// status/title/assignees/reviewers/type/priority (trails.ts:4384), so the two
-// must be sent as separate PATCH calls. Labels are exempt server-side, but for
+// status/title/branch/base/assignees/reviewers/type/priority ("Body updates
+// cannot be combined with metadata updates"), so the two must be sent as
+// separate PATCH calls — that split is what makes `trail update --title X
+// --body Y` work in one command. Labels are exempt server-side, but for
 // simplicity they travel in the metadata request too; the only cost is one
 // extra PATCH in the rare body+labels-only update, which is harmless. hasMeta
 // reports whether the metadata request has any field set.
@@ -1471,10 +1522,25 @@ func splitTrailUpdate(full api.TrailUpdateRequest) (meta api.TrailUpdateRequest,
 	}
 	meta = full
 	meta.Body = nil
-	hasMeta = meta.Status != nil || meta.Title != nil || meta.Labels != nil ||
-		meta.Assignees != nil || meta.RequestedReviewers != nil ||
-		meta.Type != nil || meta.Priority != nil
-	return meta, hasMeta, bodyReq
+	return meta, trailUpdateRequestHasFields(meta), bodyReq
+}
+
+// trailUpdateRequestHasFields reports whether req sets any field at all. It
+// walks the struct reflectively rather than naming each field, so a field added
+// to TrailUpdateRequest later — a branch rename, say — counts as metadata
+// without anyone having to remember to extend this check. Forgetting to would
+// make splitTrailUpdate return hasMeta=false and drop that change silently: the
+// PATCH is never sent, yet the command still reports success.
+func trailUpdateRequestHasFields(req api.TrailUpdateRequest) bool {
+	v := reflect.ValueOf(req)
+	for i := range v.NumField() {
+		// Every field is a pointer today (nil means "not provided"), but IsZero
+		// also covers a plain string or slice field added later.
+		if !v.Field(i).IsZero() {
+			return true
+		}
+	}
+	return false
 }
 
 // sendTrailPatch issues a single trail PATCH and validates the response.

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1773,9 +1774,11 @@ func TestSplitTrailUpdateCountsEveryNonBodyFieldAsMetadata(t *testing.T) {
 		}
 		t.Run(field.Name, func(t *testing.T) {
 			t.Parallel()
-			if field.Type.Kind() != reflect.Ptr {
-				t.Skipf("field %s is not a pointer; extend this test for its zero/set semantics", field.Name)
-			}
+			// Fail rather than skip: a skipped subtest passes quietly, so a
+			// non-pointer field would silently retire the guarantee this test
+			// exists to provide, exactly when it starts mattering.
+			require.Equalf(t, reflect.Ptr, field.Type.Kind(),
+				"field %s is not a pointer; decide its zero/set semantics and extend this test before adding it", field.Name)
 			var req api.TrailUpdateRequest
 			// A pointer to the zero value is still "provided" — that is how a
 			// field is cleared (e.g. an empty title, an emptied assignee list).
@@ -1795,6 +1798,10 @@ func TestSplitTrailUpdateCountsEveryNonBodyFieldAsMetadata(t *testing.T) {
 func TestRunTrailUpdateSendsTitleAndBodyAsSeparatePatches(t *testing.T) {
 	t.Parallel()
 
+	// patches is written from the handler goroutine and read from the test
+	// goroutine, so it is guarded — the counter-based tests in this file use
+	// sync/atomic for the same reason; a slice needs a mutex instead.
+	var mu sync.Mutex
 	var patches []map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -1812,7 +1819,9 @@ func TestRunTrailUpdateSendsTitleAndBodyAsSeparatePatches(t *testing.T) {
 				t.Errorf("decode patch request: %v", err)
 				return
 			}
+			mu.Lock()
 			patches = append(patches, got)
+			mu.Unlock()
 			// Mirror the server's own rule ("Body updates cannot be combined
 			// with metadata updates").
 			_, hasBody := got[trailBodyField]
@@ -1849,11 +1858,51 @@ func TestRunTrailUpdateSendsTitleAndBodyAsSeparatePatches(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	mu.Lock()
+	defer mu.Unlock()
 	require.Len(t, patches, 2, "title and body must go out as two PATCHes")
 	require.Equal(t, map[string]any{"title": "new title"}, patches[0])
 	require.Equal(t, map[string]any{trailBodyField: "new body"}, patches[1])
 	require.Contains(t, out.String(), "Updated trail for branch feature/x")
 	require.Empty(t, errOut.String())
+}
+
+// TestRunTrailUpdateReportsNoChangesWhenNothingWasSent pins that an update
+// which sends no PATCH does not claim success — agents read the success line as
+// confirmation the write landed.
+func TestRunTrailUpdateReportsNoChangesWhenNothingWasSent(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != trailTestBasePath {
+			t.Errorf("no PATCH should be sent, got: %s %s", r.Method, r.URL.Path)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(api.TrailListResponse{
+			Trails: []api.TrailResource{{ID: "trl_1", Number: 7, Branch: "feature/x", Status: string(trail.StatusOpen)}},
+			Total:  1,
+		}); err != nil {
+			t.Errorf("encode list response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	// The real source of an empty update is the interactive form closing
+	// untouched, which leaves every *Changed flag false. That exact input would
+	// re-open the form here (noFlags), so stand in with a non-nil but empty
+	// label slice: it clears noFlags, and buildTrailUpdateRequest still returns
+	// an empty request — the same state the split has to refuse to report as a
+	// success.
+	err := runTrailUpdateWithClient(t.Context(), &out, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+		Branch:   "feature/x",
+		LabelAdd: []string{},
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "No changes to apply")
+	require.NotContains(t, out.String(), "Updated trail")
 }
 
 // TestRunTrailUpdateReportsAppliedMetadataWhenBodyPatchFails covers the

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -35,6 +36,10 @@ import (
 const (
 	trailListTestAuthorAlice = "alice"
 	trailListTestAuthorBob   = "bob"
+	// trailTestBasePath is the trails endpoint for the gh/acme/repo fixture.
+	trailTestBasePath = "/api/v1/trails/gh/acme/repo"
+	// trailBodyField is the PATCH field name carrying a trail's description.
+	trailBodyField = "body"
 )
 
 func TestNewTrailCreateRequestUsesLinkBranchAction(t *testing.T) {
@@ -1326,6 +1331,155 @@ func TestPrintTrailDetailsRendersURLAndDescription(t *testing.T) {
 	}
 }
 
+// trailShowTestServer serves the two endpoints `trail show` reads: the list
+// (which resolves the selector and omits the description) and the detail (which
+// carries body_document). detailStatus > 0 makes the detail fetch fail so the
+// best-effort path can be exercised.
+func trailShowTestServer(t *testing.T, resource api.TrailResource, detailSnapshot string, detailStatus int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath:
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{Trails: []api.TrailResource{resource}, Total: 1}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath+"/"+strconv.Itoa(resource.Number):
+			if detailStatus > 0 {
+				w.WriteHeader(detailStatus)
+				if err := json.NewEncoder(w).Encode(map[string]string{"error": "boom"}); err != nil {
+					t.Errorf("encode detail error: %v", err)
+				}
+				return
+			}
+			detail := resource
+			detail.BodyDocument = &api.TrailBodyDocument{TextSnapshot: detailSnapshot}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{"trail": detail}); err != nil {
+				t.Errorf("encode detail response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestRunTrailShowJSONEmitsOneTrailObject(t *testing.T) {
+	t.Parallel()
+
+	alice := trailListTestAuthorAlice
+	created := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	resource := api.TrailResource{
+		ID:        "trl_1",
+		Number:    7,
+		URL:       "https://entire.io/gh/acme/repo/trails/7",
+		Branch:    "feature/x",
+		Base:      "main",
+		Title:     "Shown trail",
+		Status:    string(trail.StatusOpen),
+		Phase:     "building",
+		Author:    &trail.Author{ID: "u1", Login: &alice},
+		Assignees: []string{"bob"},
+		Labels:    []string{"cli"},
+		Type:      string(trail.TypeBug),
+		Priority:  string(trail.PriorityHigh),
+		Reviewers: []trail.Reviewer{{Login: "rev1", Status: trail.ReviewerApproved}},
+		CreatedAt: created,
+		UpdatedAt: created,
+	}
+	srv := trailShowTestServer(t, resource, "detail body", 0)
+
+	var out, errOut bytes.Buffer
+	err := runTrailShowWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
+
+	require.NoError(t, err)
+	require.Empty(t, errOut.String())
+
+	var got trail.Metadata
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got), "output must be a single JSON object: %s", out.String())
+	require.Equal(t, 7, got.Number)
+	require.Equal(t, trail.ID("trl_1"), got.TrailID)
+	require.Equal(t, "https://entire.io/gh/acme/repo/trails/7", got.URL)
+	require.Equal(t, "feature/x", got.Branch)
+	require.Equal(t, "main", got.Base)
+	require.Equal(t, "Shown trail", got.Title)
+	require.Equal(t, trail.StatusOpen, got.Status)
+	require.Equal(t, "building", got.Phase)
+	require.Equal(t, alice, got.AuthorLogin())
+	require.Equal(t, []string{"bob"}, got.Assignees)
+	require.Equal(t, []string{"cli"}, got.Labels)
+	require.Equal(t, trail.TypeBug, got.Type)
+	require.Equal(t, trail.PriorityHigh, got.Priority)
+	require.Equal(t, []trail.Reviewer{{Login: "rev1", Status: trail.ReviewerApproved}}, got.Reviewers)
+	// The description lives on the detail endpoint only; JSON must carry it, not
+	// the empty list body.
+	require.Equal(t, "detail body", got.Body)
+	// Human-only decoration must not leak into the data.
+	require.NotContains(t, out.String(), noTrailDescription)
+	require.NotContains(t, out.String(), "Trail: ")
+}
+
+func TestRunTrailShowJSONLeavesBodyEmptyWithoutDescription(t *testing.T) {
+	t.Parallel()
+
+	srv := trailShowTestServer(t, api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x", Status: string(trail.StatusOpen)}, "", 0)
+
+	var out, errOut bytes.Buffer
+	err := runTrailShowWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
+
+	require.NoError(t, err)
+	require.Empty(t, errOut.String())
+
+	var got trail.Metadata
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Empty(t, got.Body, "an empty description must stay empty in JSON, not become the display placeholder")
+	require.NotContains(t, out.String(), noTrailDescription)
+}
+
+// A failed description fetch is best-effort: the warning belongs on stderr so
+// stdout stays parseable.
+func TestRunTrailShowJSONKeepsStdoutParseableWhenDescriptionFetchFails(t *testing.T) {
+	t.Parallel()
+
+	srv := trailShowTestServer(t, api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x", Title: "T", Body: "list body", Status: string(trail.StatusOpen)}, "", http.StatusInternalServerError)
+
+	var out, errOut bytes.Buffer
+	err := runTrailShowWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
+
+	require.NoError(t, err)
+	require.Contains(t, errOut.String(), "could not load trail description")
+
+	var got trail.Metadata
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got), "stdout must stay valid JSON: %s", out.String())
+	require.Equal(t, "list body", got.Body, "the list body is the fallback when the detail fetch fails")
+}
+
+func TestRunTrailShowTextStillRendersTheHumanView(t *testing.T) {
+	t.Parallel()
+
+	srv := trailShowTestServer(t, api.TrailResource{
+		ID: "trl_1", Number: 7, URL: "https://entire.io/gh/acme/repo/trails/7",
+		Branch: "feature/x", Base: "main", Title: "Shown trail", Status: string(trail.StatusOpen),
+	}, "detail body", 0)
+
+	var out, errOut bytes.Buffer
+	err := runTrailShowWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailShowOptions{Selector: "7"})
+
+	require.NoError(t, err)
+	require.Empty(t, errOut.String())
+	text := out.String()
+	for _, want := range []string{"Trail: Shown trail", "Number:", "feature/x", "https://entire.io/gh/acme/repo/trails/7", "Description:", "detail body"} {
+		require.Containsf(t, text, want, "text output missing %q:\n%s", want, text)
+	}
+}
+
+func TestTrailShowCmdHasJSONFlag(t *testing.T) {
+	t.Parallel()
+	require.NotNil(t, newTrailShowCmd().Flags().Lookup("json"), "trail show must offer --json so agents can read it non-interactively")
+}
+
 func TestPrintTrailListShowsPhaseWhenPresent(t *testing.T) {
 	t.Parallel()
 	alice := trailListTestAuthorAlice
@@ -1602,6 +1756,154 @@ func TestSplitTrailUpdateSeparatesBodyFromMetadata(t *testing.T) {
 	if bodyReq2 == nil {
 		t.Error("body-only update must produce a body request")
 	}
+}
+
+// TestSplitTrailUpdateCountsEveryNonBodyFieldAsMetadata pins the structural
+// rule splitTrailUpdate relies on: any field other than Body makes a metadata
+// PATCH. Naming the fields by hand is how a later addition (a branch rename,
+// say) gets dropped silently — hasMeta stays false, no PATCH is sent, and the
+// command still reports success. This test grows with the struct instead.
+func TestSplitTrailUpdateCountsEveryNonBodyFieldAsMetadata(t *testing.T) {
+	t.Parallel()
+	typ := reflect.TypeOf(api.TrailUpdateRequest{})
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		if field.Name == "Body" {
+			continue
+		}
+		t.Run(field.Name, func(t *testing.T) {
+			t.Parallel()
+			if field.Type.Kind() != reflect.Ptr {
+				t.Skipf("field %s is not a pointer; extend this test for its zero/set semantics", field.Name)
+			}
+			var req api.TrailUpdateRequest
+			// A pointer to the zero value is still "provided" — that is how a
+			// field is cleared (e.g. an empty title, an emptied assignee list).
+			reflect.ValueOf(&req).Elem().Field(i).Set(reflect.New(field.Type.Elem()))
+
+			_, hasMeta, _ := splitTrailUpdate(req)
+
+			require.Truef(t, hasMeta, "field %s must count as metadata, otherwise splitTrailUpdate drops it without sending a PATCH", field.Name)
+		})
+	}
+}
+
+// TestRunTrailUpdateSendsTitleAndBodyAsSeparatePatches drives the whole update
+// path against a server that rejects body+metadata in one PATCH exactly as
+// production does, so `trail update --title X --body Y` stays working end to
+// end and not just in splitTrailUpdate's unit test.
+func TestRunTrailUpdateSendsTitleAndBodyAsSeparatePatches(t *testing.T) {
+	t.Parallel()
+
+	var patches []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath:
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{
+				Trails: []api.TrailResource{{ID: "trl_1", Number: 7, Branch: "feature/x", Title: "old title", Status: string(trail.StatusOpen)}},
+				Total:  1,
+			}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
+		case r.Method == http.MethodPatch && r.URL.Path == trailTestBasePath+"/7":
+			var got map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode patch request: %v", err)
+				return
+			}
+			patches = append(patches, got)
+			// Mirror the server's own rule ("Body updates cannot be combined
+			// with metadata updates").
+			_, hasBody := got[trailBodyField]
+			hasMeta := false
+			for key := range got {
+				if key != trailBodyField {
+					hasMeta = true
+				}
+			}
+			if hasBody && hasMeta {
+				w.WriteHeader(http.StatusBadRequest)
+				if err := json.NewEncoder(w).Encode(map[string]string{"error": "Body updates cannot be combined with metadata updates"}); err != nil {
+					t.Errorf("encode rejection: %v", err)
+				}
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailUpdateResponse{Trail: api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x"}}); err != nil {
+				t.Errorf("encode update response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	var out, errOut bytes.Buffer
+	err := runTrailUpdateWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+		Branch:       "feature/x",
+		Title:        "new title",
+		TitleChanged: true,
+		Body:         "new body",
+		BodyChanged:  true,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, patches, 2, "title and body must go out as two PATCHes")
+	require.Equal(t, map[string]any{"title": "new title"}, patches[0])
+	require.Equal(t, map[string]any{trailBodyField: "new body"}, patches[1])
+	require.Contains(t, out.String(), "Updated trail for branch feature/x")
+	require.Empty(t, errOut.String())
+}
+
+// TestRunTrailUpdateReportsAppliedMetadataWhenBodyPatchFails covers the
+// non-atomic half of the two-PATCH split: the metadata already landed, so the
+// error has to say so rather than reading as "nothing changed".
+func TestRunTrailUpdateReportsAppliedMetadataWhenBodyPatchFails(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath:
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{
+				Trails: []api.TrailResource{{ID: "trl_1", Number: 7, Branch: "feature/x", Status: string(trail.StatusOpen)}},
+				Total:  1,
+			}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
+		case r.Method == http.MethodPatch:
+			var got map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode patch request: %v", err)
+				return
+			}
+			if _, hasBody := got[trailBodyField]; hasBody {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				if err := json.NewEncoder(w).Encode(map[string]string{"error": "Editor collaboration not configured"}); err != nil {
+					t.Errorf("encode rejection: %v", err)
+				}
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailUpdateResponse{Trail: api.TrailResource{ID: "trl_1", Number: 7}}); err != nil {
+				t.Errorf("encode update response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	err := runTrailUpdateWithClient(t.Context(), io.Discard, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+		Branch:       "feature/x",
+		Title:        "new title",
+		TitleChanged: true,
+		Body:         "new body",
+		BodyChanged:  true,
+	})
+
+	require.ErrorContains(t, err, "trail metadata was updated, but the body update failed")
 }
 
 func TestTrailUpdateCmdHasCollaborationFlags(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1026
<!-- entire-trail-link-end -->

Two small `entire trail` gaps. In short:

```
❯ entire trail update --title "hello" --body "happy trails"
Updated trail for branch something-fun

❯ entire trail show --json
{
  "number": 2,
  "trail_id": "019ffb13-d6ea-767a-b9dc-e8d5d49d50f7",
  "url": "https://entire.io/gh/entirehq/matthiaswenz-testing/trails/2",
  "branch": "something-fun",
  "base": "main",
  "title": "hello",
  "body": "happy trails",
  "status": "open",
  "phase": "building",
  "author": {
    "id": "62fdc0c7-3013-4661-8701-acbb98f6a9a3",
    "login": "matthiaswenz"
  },
  "assignees": [
    "matthiaswenz"
  ],
  "labels": [],
  "type": "task",
  "priority": "none",
  "created_at": "2026-08-13T12:23:29.229Z",
  "updated_at": "2026-08-13T12:24:29.934Z",
  "merged_at": null
}
```

## 1. `entire trail show` had no JSON output

An agent could only read a trail through the human view. `trail show` now takes
`--json` and prints one trail object — the same shape as an entry of
`trail list --json`, so both feed the same parser.

Details that matter:

- The description comes from the detail endpoint (`body_document.text_snapshot`)
  the same way the text view resolves it, with the list body as fallback.
- The `-- no description provided --` placeholder is display text, not data, so
  it never reaches the JSON: an empty description is an empty string.
- A failed description fetch still only warns, and the warning goes to stderr,
  so stdout stays parseable.

## 2. `trail update --title X --body Y` in one call

This already worked on main. The server rejects body and metadata in one PATCH
("Body updates cannot be combined with metadata updates"), and
`splitTrailUpdate` has been sending them as two PATCHes since c74ff3cc9
(2026-07-10). If you hit a rejection, you were on a build older than that —
`entire version` reports `dev` for a local build, so it is easy to miss.

What was actually missing was protection. Two things:

- Nothing tested the split end to end. There is now a test that drives the whole
  update path against a server reproducing the real rejection rule, so the
  two-PATCH behaviour is pinned, plus one covering the non-atomic half (the
  metadata PATCH lands, the body PATCH fails, and the error says the metadata
  already applied).
- `splitTrailUpdate` decided "this is metadata" by listing the field names by
  hand. Add a metadata field and forget that list, and the whole update
  vanishes: `hasMeta` stays false, no PATCH is sent, and the command still
  prints success. It now walks `TrailUpdateRequest` reflectively, and a test
  iterates the struct so every non-body field has to count as metadata.

## Also

Extracts `runTrailShowWithClient` and `runTrailUpdateWithClient` so both paths
can be driven against a test server, matching the existing
`runTrailListAllWithClient`.

`mise run check` passes.
