### PR TITLE
build(deps): raise the go-git floor to include go-git#2312

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,10 +16,15 @@ require (
 	github.com/go-faster/errors v0.8.0
 	github.com/go-faster/jx v1.2.0
 	github.com/go-git/go-billy/v6 v6.0.0-alpha.2
-	// Floor, not just a bump: go-git#2309 (per-directory ignore Scope). The
-	// root-level e2e/artifacts/ rule only prunes the status walk from this
-	// commit onward. Move to a plain tag once alpha.6 ships.
-	github.com/go-git/go-git/v6 v6.0.0-alpha.5.0.20260812095450-22b9459b2be0
+	// Floor, not just a bump, for two reasons. go-git#2309 (per-directory
+	// ignore Scope): the root-level e2e/artifacts/ rule only prunes the status
+	// walk from that commit onward. go-git#2312 (record partial clones): a
+	// go-git filtered fetch used to write no promisor bookkeeping, leaving a
+	// repository git calls corrupt and can never gc again; the same commits
+	// also fix RepackObjects/Prune failing with "object not found" on any
+	// partial clone, including one made by the git binary.
+	// Move to a plain tag once alpha.6 ships.
+	github.com/go-git/go-git/v6 v6.0.0-alpha.5.0.20260812155443-34770e01d7c2
 	github.com/go-git/x/plugin/objectsigner/auto v0.1.1-0.20260624122410-382b2905c041
 	github.com/go-git/x/plugin/objectsigner/program v0.0.0-20260624122410-382b2905c041
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/go-git/go-billy/v6 v6.0.0-alpha.2 h1:1Sv5WemXL8CxKrAx1gioJ+uHNb2bZJhi
 github.com/go-git/go-billy/v6 v6.0.0-alpha.2/go.mod h1:r/bsv9i/iDyyEU8/Z6mjC+YraOVwie1ddfUqBCElKXQ=
 github.com/go-git/go-git-fixtures/v6 v6.0.0-alpha.1 h1:gmqi2jvsreu0s8JMLylYDFq4sbjHwwlhktMw0DUg3mA=
 github.com/go-git/go-git-fixtures/v6 v6.0.0-alpha.1/go.mod h1:ECf1MqJlBdYpKggBrOXjo/0EnvRZx6D++I86UYjPgAQ=
-github.com/go-git/go-git/v6 v6.0.0-alpha.5.0.20260812095450-22b9459b2be0 h1:cNbRTih+sFXGwGYglNhkFDFiDA7ttg39+eucyC1Fx2Y=
-github.com/go-git/go-git/v6 v6.0.0-alpha.5.0.20260812095450-22b9459b2be0/go.mod h1:idGfI4Zv6CBgGaBuoNjqvKMtJAhJxFcRWSpJAs8REvk=
+github.com/go-git/go-git/v6 v6.0.0-alpha.5.0.20260812155443-34770e01d7c2 h1:E0Hy8aLMcJ6wYI7dJIZcsqusZ87Qet5kE2HKIm8NUsA=
+github.com/go-git/go-git/v6 v6.0.0-alpha.5.0.20260812155443-34770e01d7c2/go.mod h1:idGfI4Zv6CBgGaBuoNjqvKMtJAhJxFcRWSpJAs8REvk=
 github.com/go-git/x/plugin/objectsigner/auto v0.1.1-0.20260624122410-382b2905c041 h1:ATVPaVKC1wbuQdvGKfKXotuwXYeGfigyHERl7lmNG+I=
 github.com/go-git/x/plugin/objectsigner/auto v0.1.1-0.20260624122410-382b2905c041/go.mod h1:Cpmdf+1Pmw6nPWTpfBMsPmWju2Tb+qjwccWR5AvOBC4=
 github.com/go-git/x/plugin/objectsigner/gpg v0.2.1-0.20260624122410-382b2905c041 h1:Tni6GTpv/Nx4HAub64YmnxGWe99za33jfzy3GesditQ=


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1027
<!-- entire-trail-link-end -->

Bumps `github.com/go-git/go-git/v6` from `...20260812095450-22b9459b2be0` to
`...20260812155443-34770e01d7c2` so that
[go-git#2312](https://github.com/go-git/go-git/pull/2312) is in the version the
CLI builds against.

## What #2312 fixes

`FetchOptions.Filter` / `CloneOptions.Filter` performed a real partial fetch but
wrote none of the bookkeeping git uses to tell a *promised* object from a *lost*
one — no `pack-<hash>.promisor`, no `remote.<name>.promisor`, no
`partialclonefilter`. The result is a repository `git fsck` reports broken links
for and `git gc` refuses to repack, permanently. Along the way it also fixes:

- `RepackObjects` and `Prune` failing with `object not found` on **any** partial
  clone, including one the git binary made.
- `dotgit.DeleteOldObjectPackAndIndex` leaving an orphaned `.promisor` behind, or
  dropping the marker while its pack survived.
- A marker written before the already-on-disk check, so a duplicate pack could
  get marked promisor.

## Impact on this CLI

None at runtime — this is a floor raise, not a behaviour change here. Every
filtered fetch in this repo goes through our own `remote.Fetch` wrapper
(`cmd/entire/cli/checkpoint/remote/`), which shells out to the git binary and
passes `--filter=blob:none` itself; nothing sets go-git's `FetchOptions.Filter`,
so the config-recording half of #2312 never triggers from our code. The
`RepackObjects`/`Prune` half *is* relevant to repositories we create, since
`plugin_gitremote.go` does make real partial clones.

The existing guarantee in `fetch_no_config_pollution_test.go` — that a fetch
never leaves `remote.origin.promisor` on the repo — is unaffected and still
passes.

## Why a pseudo-version and not a tag

alpha.6 has not shipped. The `go.mod` comment already recorded #2309 as a floor
for the same reason; it now records both, and still says to move to a plain tag
once alpha.6 is out.

## Verification

- Delta over the previous pin is exactly #2312's sixteen commits plus the merge
  — confirmed via the upstream compare API. `go.sum` moves only the two go-git
  lines; no transitive dependency changes.
- `go build ./...`, `go vet ./...` clean.
- `mise run check` green: `fmt`, all five lint tasks, and `test:ci` (unit +
  `-race` integration + both canary E2E agents — 56 vogon tests, 4 roger-roger
  tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e125cf5988b0be5b1b9cc7afcb0a8b951d598608. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->