### PR TITLE
fix(doctor): load custom redaction rules for doctor subcommands

### DIFF
--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -60,9 +60,12 @@ For each stuck session, you can choose to:
 
 Use --force to condense all fixable sessions without prompting.  Sessions that can't
 be condensed will be discarded.`,
-		// PersistentPreRun (not PreRun) so subcommands like `doctor bundle`
-		// also load user-defined redaction rules before they redact output;
-		// cobra only runs PreRun for the command it is declared on.
+		// Redaction config must be loaded for the whole doctor subtree —
+		// `doctor bundle` redacts everything it collects, and the bare scan
+		// condenses sessions. Cobra runs only the NEAREST ancestor's
+		// persistent pre-run: a subcommand that declares its own would
+		// silently drop this and ship bundles without user-defined rules
+		// (see TestDoctorSubtree_NoPersistentPreRunShadowing).
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			strategy.EnsureRedactionConfigured()
 		},

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -60,7 +60,10 @@ For each stuck session, you can choose to:
 
 Use --force to condense all fixable sessions without prompting.  Sessions that can't
 be condensed will be discarded.`,
-		PreRun: func(_ *cobra.Command, _ []string) {
+		// PersistentPreRun (not PreRun) so subcommands like `doctor bundle`
+		// also load user-defined redaction rules before they redact output;
+		// cobra only runs PreRun for the command it is declared on.
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			strategy.EnsureRedactionConfigured()
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -620,3 +620,24 @@ func TestConfirmDoctorFix_CancelledContext(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, proceed)
 }
+
+// TestDoctorSubtree_NoPersistentPreRunShadowing guards the redaction-loading
+// invariant on the doctor command tree: EnsureRedactionConfigured runs from
+// the doctor root's PersistentPreRun, and cobra executes only the NEAREST
+// ancestor's persistent pre-run. A subcommand that declares its own would
+// silently stop loading user-defined redaction rules for its process — the
+// exact leak behind the doctor-bundle support report — with no compile error
+// and no unit-test failure outside this one.
+func TestDoctorSubtree_NoPersistentPreRunShadowing(t *testing.T) {
+	t.Parallel()
+
+	root := newDoctorCmd()
+	if root.PersistentPreRun == nil && root.PersistentPreRunE == nil {
+		t.Fatal("doctor root lost its PersistentPreRun — redaction config no longer loads for any doctor subcommand")
+	}
+	for _, sub := range root.Commands() {
+		if sub.PersistentPreRun != nil || sub.PersistentPreRunE != nil {
+			t.Errorf("doctor subcommand %q declares its own persistent pre-run, shadowing the root's redaction setup; call strategy.EnsureRedactionConfigured from it or restructure", sub.Name())
+		}
+	}
+}

--- a/cmd/entire/cli/integration_test/doctor_bundle_redaction_test.go
+++ b/cmd/entire/cli/integration_test/doctor_bundle_redaction_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package integration
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDoctorBundle_AppliesCustomRedactionRules is the regression test for the
+// support report where a diagnostic bundle leaked a project identifier that a
+// user-defined redaction rule was written to catch: EnsureRedactionConfigured
+// hung on the doctor command's PreRun, which cobra does not run for
+// subcommands, so `doctor bundle` redacted with the built-in layers only and
+// silently ignored .entire/redactors/ packs and redaction.custom_redactions.
+// It must run the real binary so the cobra pre-run wiring is exercised —
+// calling writeDoctorBundle directly (like the unit tests) bypasses the bug.
+func TestDoctorBundle_AppliesCustomRedactionRules(t *testing.T) {
+	t.Parallel()
+
+	const (
+		packTarget   = "ACME_ABC123"   // matched by the pack rule below
+		inlineTarget = "INLINE_ZZ99XX" // matched by the inline custom_redactions rule
+	)
+
+	env := NewFeatureBranchEnv(t)
+
+	env.PatchSettings(map[string]any{
+		"redaction": map[string]any{
+			"custom_redactions": map[string]any{
+				"inline-acme": "INLINE_[A-Z0-9]{6}",
+			},
+		},
+	})
+	redactorsDir := filepath.Join(env.RepoDir, ".entire", "redactors")
+	if err := os.MkdirAll(redactorsDir, 0o755); err != nil {
+		t.Fatalf("mkdir redactors: %v", err)
+	}
+	packYAML := `name: acme
+version: 1.0.0
+rules:
+  - id: acme-token
+    regex: 'ACME_[A-Z0-9]{6}'
+`
+	if err := os.WriteFile(filepath.Join(redactorsDir, "acme.yaml"), []byte(packYAML), 0o644); err != nil {
+		t.Fatalf("write pack: %v", err)
+	}
+
+	// Vector 1: identifier in a collected log file.
+	logsDir := filepath.Join(env.RepoDir, ".entire", "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	logBody := "deploying " + packTarget + " with tag " + inlineTarget + "\n"
+	if err := os.WriteFile(filepath.Join(logsDir, "entire.log"), []byte(logBody), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	// Vector 2: identifier in a git commit subject, the reported leak — the
+	// built-in secret layers leave it (it is not a secret), so only the
+	// custom rule can catch it in git-log.txt.
+	env.WriteFile("feature.txt", "content\n")
+	env.GitAdd("feature.txt")
+	env.GitCommit("rollout " + packTarget)
+
+	outZip := filepath.Join(t.TempDir(), "bundle.zip")
+	out := env.RunCLI("doctor", "bundle", "--out", outZip)
+	t.Logf("doctor bundle output: %s", out)
+
+	for entry, target := range map[string]string{
+		"logs/entire.log": packTarget,
+		"git-log.txt":     packTarget,
+	} {
+		content := readBundleEntry(t, outZip, entry)
+		if strings.Contains(content, target) {
+			t.Errorf("bundle entry %s leaked custom-rule target %q:\n%s", entry, target, content)
+		}
+	}
+	if content := readBundleEntry(t, outZip, "logs/entire.log"); strings.Contains(content, inlineTarget) {
+		t.Errorf("bundle entry logs/entire.log leaked inline custom_redactions target %q:\n%s", inlineTarget, content)
+	}
+}
+
+func readBundleEntry(t *testing.T, zipPath, name string) string {
+	t.Helper()
+
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatalf("open bundle zip: %v", err)
+	}
+	defer zr.Close()
+
+	for _, f := range zr.File {
+		if f.Name != name {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open bundle entry %s: %v", name, err)
+		}
+		defer rc.Close()
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("read bundle entry %s: %v", name, err)
+		}
+		return string(data)
+	}
+	t.Fatalf("bundle entry %q not found", name)
+	return ""
+}

--- a/cmd/entire/cli/integration_test/doctor_bundle_redaction_test.go
+++ b/cmd/entire/cli/integration_test/doctor_bundle_redaction_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"archive/zip"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -13,12 +12,11 @@ import (
 
 // TestDoctorBundle_AppliesCustomRedactionRules is the regression test for the
 // support report where a diagnostic bundle leaked a project identifier that a
-// user-defined redaction rule was written to catch: EnsureRedactionConfigured
-// hung on the doctor command's PreRun, which cobra does not run for
-// subcommands, so `doctor bundle` redacted with the built-in layers only and
-// silently ignored .entire/redactors/ packs and redaction.custom_redactions.
-// It must run the real binary so the cobra pre-run wiring is exercised —
-// calling writeDoctorBundle directly (like the unit tests) bypasses the bug.
+// user-defined rule was written to catch: redaction setup lived on the doctor
+// command's PreRun, which cobra never runs for subcommands, so `doctor bundle`
+// silently skipped .entire/redactors/ packs and redaction.custom_redactions.
+// It must run the real binary — calling writeDoctorBundle directly (like the
+// unit tests) bypasses the cobra wiring where the bug lived.
 func TestDoctorBundle_AppliesCustomRedactionRules(t *testing.T) {
 	t.Parallel()
 
@@ -36,29 +34,16 @@ func TestDoctorBundle_AppliesCustomRedactionRules(t *testing.T) {
 			},
 		},
 	})
-	redactorsDir := filepath.Join(env.RepoDir, ".entire", "redactors")
-	if err := os.MkdirAll(redactorsDir, 0o755); err != nil {
-		t.Fatalf("mkdir redactors: %v", err)
-	}
-	packYAML := `name: acme
+	env.WriteFile(filepath.Join(".entire", "redactors", "acme.yaml"), `name: acme
 version: 1.0.0
 rules:
   - id: acme-token
     regex: 'ACME_[A-Z0-9]{6}'
-`
-	if err := os.WriteFile(filepath.Join(redactorsDir, "acme.yaml"), []byte(packYAML), 0o644); err != nil {
-		t.Fatalf("write pack: %v", err)
-	}
+`)
 
-	// Vector 1: identifier in a collected log file.
-	logsDir := filepath.Join(env.RepoDir, ".entire", "logs")
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		t.Fatalf("mkdir logs: %v", err)
-	}
-	logBody := "deploying " + packTarget + " with tag " + inlineTarget + "\n"
-	if err := os.WriteFile(filepath.Join(logsDir, "entire.log"), []byte(logBody), 0o600); err != nil {
-		t.Fatalf("write log: %v", err)
-	}
+	// Vector 1: identifiers in a collected log file.
+	env.WriteFile(filepath.Join(".entire", "logs", "entire.log"),
+		"deploying "+packTarget+" with tag "+inlineTarget+"\n")
 
 	// Vector 2: identifier in a git commit subject, the reported leak — the
 	// built-in secret layers leave it (it is not a secret), so only the
@@ -68,20 +53,27 @@ rules:
 	env.GitCommit("rollout " + packTarget)
 
 	outZip := filepath.Join(t.TempDir(), "bundle.zip")
-	out := env.RunCLI("doctor", "bundle", "--out", outZip)
-	t.Logf("doctor bundle output: %s", out)
+	env.RunCLI("doctor", "bundle", "--out", outZip)
 
-	for entry, target := range map[string]string{
-		"logs/entire.log": packTarget,
-		"git-log.txt":     packTarget,
+	for _, tc := range []struct {
+		entry  string
+		target string
+		rule   string
+	}{
+		{"logs/entire.log", packTarget, "pack rule"},
+		{"logs/entire.log", inlineTarget, "inline custom_redactions rule"},
+		{"git-log.txt", packTarget, "pack rule"},
 	} {
-		content := readBundleEntry(t, outZip, entry)
-		if strings.Contains(content, target) {
-			t.Errorf("bundle entry %s leaked custom-rule target %q:\n%s", entry, target, content)
+		content := readBundleEntry(t, outZip, tc.entry)
+		if strings.Contains(content, tc.target) {
+			t.Errorf("bundle entry %s leaked %s target %q:\n%s", tc.entry, tc.rule, tc.target, content)
 		}
-	}
-	if content := readBundleEntry(t, outZip, "logs/entire.log"); strings.Contains(content, inlineTarget) {
-		t.Errorf("bundle entry logs/entire.log leaked inline custom_redactions target %q:\n%s", inlineTarget, content)
+		// Positive control: the surviving text proves the entry carried the
+		// line and redaction replaced the target, so the absence checks above
+		// cannot pass vacuously on an empty or unredacted-but-missing entry.
+		if !strings.Contains(content, "REDACTED") {
+			t.Errorf("bundle entry %s missing REDACTED placeholder — redaction did not run on it:\n%s", tc.entry, content)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1028
<!-- entire-trail-link-end -->

## Problem

`EnsureRedactionConfigured` hangs on the `doctor` command's `PreRun`, which cobra only runs for the command it is declared on — never for subcommands. `doctor bundle` therefore redacted collected logs, settings, and git output with the built-in secret layers only, silently ignoring `.entire/redactors/` packs and `redaction.custom_redactions`.

Found while investigating a customer security report: their diagnostic bundle leaked a project identifier their custom rule was written to catch — it sat in a git commit subject line, which no built-in layer flags.

## Fix

Switch to `PersistentPreRun` so `bundle`/`logs`/`trace`/`migrate-checkpoints` get the same redaction configuration as the bare doctor scan.

## Test

Integration test drives the real binary (`doctor bundle`) with a rule pack and an inline rule configured, and asserts the targets are redacted in both leak vectors from the report: a collected log file and a git commit subject in `git-log.txt`. Runs through the actual cobra wiring — the existing unit tests call `writeDoctorBundle` directly, which is exactly why this was never caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1f7ebd5b5eab65b737a219dac08d7c130454dc9c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->