### PR TITLE
Ungate code search: remove the ENTIRE_CODE_SEARCH feature flag

### DIFF
--- a/cmd/entire/cli/attribution.go
+++ b/cmd/entire/cli/attribution.go
@@ -178,9 +178,9 @@ func newWhyCmd() *cobra.Command {
 		// Hidden from `entire help` while the feature is still maturing —
 		// advertised under `entire labs`, and `entire why` / `entire why
 		// --help` keep working normally. The agent-help annotation keeps
-		// `entire agent-help why` resolving in stable builds: the first-turn
-		// injection names `entire why` as a query anchor, so the help surface
-		// it points agents at must know the command exists.
+		// `entire agent-help why` resolving in stable builds: agents that
+		// learn of `why` (labs, docs, a user's prompt) verify commands
+		// against agent-help, so it must know the command exists.
 		Annotations: map[string]string{agentHelpAnnotation: agentHelpAnnotationEnabled},
 		Hidden:      true,
 		Short:       "Show why a line exists",

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -359,11 +358,6 @@ func completeRepoFlag(cmd *cobra.Command, _ []string, _ string) ([]string, cobra
 	return suggestions, cobra.ShellCompDirectiveNoFileComp
 }
 
-// codeSearchEnabled reports whether the code search feature is gated on.
-func codeSearchEnabled() bool {
-	return os.Getenv("ENTIRE_CODE_SEARCH") == "1"
-}
-
 type codeSearchOpts struct {
 	query           string
 	repoFilters     []string
@@ -421,14 +415,10 @@ func filterRepoWildcards(repos []string) []string {
 	return out
 }
 
-// buildCodeSearchOpts returns a *codeSearchOpts pre-populated with repo filters
-// when ENTIRE_CODE_SEARCH=1 is set, or nil when the feature is off. It honors
-// --repo, --all-repos, and inline repo: filters from the command line; when none
-// are specified, it falls back to the current git origin slug.
+// buildCodeSearchOpts returns a *codeSearchOpts pre-populated with repo filters.
+// It honors --repo, --all-repos, and inline repo: filters from the command line;
+// when none are specified, it falls back to the current git origin slug.
 func buildCodeSearchOpts(ctx context.Context, owner, repoName string, repos []string, allRepos, insecureHTTP bool) *codeSearchOpts {
-	if !codeSearchEnabled() {
-		return nil
-	}
 	var repoFilters []string
 	switch {
 	case allRepos:
@@ -462,10 +452,6 @@ const codeSearchCellTimeout = 30 * time.Second
 // (mirroring the BFF's /api/v1/stream endpoint): list repos from the control
 // plane, group by cell/jurisdiction, search each cell in parallel, merge.
 func runCodeSearch(ctx context.Context, cmd *cobra.Command, opts codeSearchOpts) error {
-	if !codeSearchEnabled() {
-		return errors.New("code search is not yet available")
-	}
-
 	if opts.query == "" {
 		return errors.New("query required for code search. Usage: entire search --code <query>")
 	}

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -296,47 +296,19 @@ func TestSearchCmd_CompactWithCodeRejected(t *testing.T) {
 	}
 }
 
-func TestCodeSearchEnabled_EnvGate(t *testing.T) {
-	// Modifies process-global env, no t.Parallel().
-	for _, tc := range []struct {
-		val  string
-		want bool
-	}{
-		{"", false},
-		{"0", false},
-		{"false", false},
-		{"true", false},
-		{"1", true},
-	} {
-		t.Setenv("ENTIRE_CODE_SEARCH", tc.val)
-		if got := codeSearchEnabled(); got != tc.want {
-			t.Errorf("ENTIRE_CODE_SEARCH=%q: codeSearchEnabled() = %v, want %v", tc.val, got, tc.want)
-		}
-	}
-}
-
-func TestSearchCmd_CodeFlagGated(t *testing.T) {
-	// --code without ENTIRE_CODE_SEARCH should fail with gate message.
-	t.Setenv("ENTIRE_CODE_SEARCH", "")
-
+func TestSearchCmd_CodeFlagUngated(t *testing.T) {
+	// Code search is generally available: --code must never fail with the old
+	// feature-gate message (it may still fail later at auth/network).
 	root := NewRootCmd()
 	root.SetArgs([]string{"search", "--code", "test query"})
 
 	err := root.Execute()
-	if err == nil {
-		t.Fatal("expected error when --code used without ENTIRE_CODE_SEARCH")
-	}
-	if !strings.Contains(err.Error(), "not yet available") {
-		t.Errorf("error = %q, want containing 'not yet available'", err.Error())
-	}
-	if strings.Contains(err.Error(), "ENTIRE_CODE_SEARCH") {
-		t.Errorf("gate error should not mention env var, got: %q", err.Error())
+	if err != nil && strings.Contains(err.Error(), "not yet available") {
+		t.Errorf("--code should not be feature-gated, got: %q", err.Error())
 	}
 }
 
 func TestSearchCmd_CodeFlagRequiresQuery(t *testing.T) {
-	t.Setenv("ENTIRE_CODE_SEARCH", "1")
-
 	root := NewRootCmd()
 	root.SetArgs([]string{"search", "--code"})
 
@@ -950,8 +922,6 @@ func TestResolveRepoFilters_MultipleReposMixed(t *testing.T) {
 
 func TestSearchCmd_CaseSensitiveWithCodeFlagParsesCorrectly(t *testing.T) {
 	// --case-sensitive with --code should be accepted (fails later at auth, not at validation).
-	t.Setenv("ENTIRE_CODE_SEARCH", "1")
-
 	root := NewRootCmd()
 	root.SetArgs([]string{"search", "--code", "--case-sensitive", "HandleRequest"})
 
@@ -964,8 +934,6 @@ func TestSearchCmd_CaseSensitiveWithCodeFlagParsesCorrectly(t *testing.T) {
 
 func TestSearchCmd_LimitFlagAccepted(t *testing.T) {
 	// --limit with --code should parse correctly.
-	t.Setenv("ENTIRE_CODE_SEARCH", "1")
-
 	root := NewRootCmd()
 	root.SetArgs([]string{"search", "--code", "--limit", "50", "handleRequest"})
 
@@ -978,8 +946,6 @@ func TestSearchCmd_LimitFlagAccepted(t *testing.T) {
 
 func TestSearchCmd_InlineRepoStarTreatedAsAllRepos(t *testing.T) {
 	// repo:* inline should be treated as "all repos" (no filter).
-	t.Setenv("ENTIRE_CODE_SEARCH", "1")
-
 	root := NewRootCmd()
 	root.SetArgs([]string{"search", "--code", "auth repo:*"})
 
@@ -992,8 +958,6 @@ func TestSearchCmd_InlineRepoStarTreatedAsAllRepos(t *testing.T) {
 
 func TestSearchCmd_MultipleInlineRepoFilters(t *testing.T) {
 	// Multiple inline repo: filters should all be collected.
-	t.Setenv("ENTIRE_CODE_SEARCH", "1")
-
 	root := NewRootCmd()
 	root.SetArgs([]string{"search", "--code", "auth repo:gh/entirehq/entire.io repo:gh/entirehq/cli"})
 
@@ -1100,8 +1064,6 @@ func TestExtractInlineRepoFilters(t *testing.T) {
 
 func TestSearchCmd_CodePreservesNonRepoFiltersInQuery(t *testing.T) {
 	// Ensure author:foo is NOT consumed by code search query parsing.
-	t.Setenv("ENTIRE_CODE_SEARCH", "1")
-
 	root := NewRootCmd()
 	root.SetArgs([]string{"search", "--code", "author:foo TODO"})
 

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -161,7 +161,7 @@ type searchModel struct {
 	// loop (which would race against bubbletea's stdin reader and stall).
 	darkBg bool
 
-	// Code search state (behind ENTIRE_CODE_SEARCH=1 feature flag).
+	// Code search state.
 	codeResults    []codesearch.Result // results from peregrine
 	codeStats      codesearch.Stats    // aggregate stats
 	codeLoading    bool                // true while async code search runs
@@ -446,37 +446,35 @@ func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		// Code search uses extractInlineRepoFilters (not ParseSearchInput)
 		// so author:/date:/branch: tokens are preserved as literal search
 		// text, matching the --code CLI path.
-		if codeSearchEnabled() {
-			codeQuery, inlineRepos := extractInlineRepoFilters(raw)
-			if codeQuery != "" {
-				willFireCodeSearch = true
-				opts := m.codeSearchOpts
-				opts.query = codeQuery
-				// Always reset to the model's default repo scope, then apply
-				// inline overrides. This prevents a stale repo list from a
-				// previous query leaking into the next one.
-				opts.repoFilters = m.codeSearchOpts.repoFilters
-				if len(inlineRepos) > 0 {
-					if hasAllReposFilter(inlineRepos) {
-						opts.repoFilters = nil
-					} else {
-						opts.repoFilters = filterRepoWildcards(inlineRepos)
-					}
+		codeQuery, inlineRepos := extractInlineRepoFilters(raw)
+		if codeQuery != "" {
+			willFireCodeSearch = true
+			opts := m.codeSearchOpts
+			opts.query = codeQuery
+			// Always reset to the model's default repo scope, then apply
+			// inline overrides. This prevents a stale repo list from a
+			// previous query leaking into the next one.
+			opts.repoFilters = m.codeSearchOpts.repoFilters
+			if len(inlineRepos) > 0 {
+				if hasAllReposFilter(inlineRepos) {
+					opts.repoFilters = nil
+				} else {
+					opts.repoFilters = filterRepoWildcards(inlineRepos)
 				}
-				m.codeSearchGen++
-				m.codeLoading = true
-				m.codeResults = nil
-				m.codeSearchErr = ""
-				cmds = append(cmds, performCodeSearch(opts, m.codeSearchGen))
-			} else {
-				// No code query (e.g. repo-only input) — clear stale code
-				// results and bump the generation so any in-flight search
-				// from a prior query is discarded when it completes.
-				m.codeSearchGen++
-				m.codeLoading = false
-				m.codeResults = nil
-				m.codeSearchErr = ""
 			}
+			m.codeSearchGen++
+			m.codeLoading = true
+			m.codeResults = nil
+			m.codeSearchErr = ""
+			cmds = append(cmds, performCodeSearch(opts, m.codeSearchGen))
+		} else {
+			// No code query (e.g. repo-only input) — clear stale code
+			// results and bump the generation so any in-flight search
+			// from a prior query is discarded when it completes.
+			m.codeSearchGen++
+			m.codeLoading = false
+			m.codeResults = nil
+			m.codeSearchErr = ""
 		}
 
 		// Checkpoint search (only if repo filters are valid for the checkpoint API).
@@ -539,14 +537,12 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		m = m.refreshBrowseContent()
 		return m, nil
 	case "4":
-		if codeSearchEnabled() {
-			m.filterType = typeFilterCode
-			m.cursor = 0
-			m.page = 0
-			m.browseVP.GotoTop()
-			m = m.refreshBrowseContent()
-			return m, nil
-		}
+		m.filterType = typeFilterCode
+		m.cursor = 0
+		m.page = 0
+		m.browseVP.GotoTop()
+		m = m.refreshBrowseContent()
+		return m, nil
 	}
 
 	var pageLen int
@@ -818,9 +814,7 @@ func (m searchModel) viewTypeTabs() string {
 		renderTab("Checkpoints", typeFilterCheckpoints, cpCount, "1"),
 		renderTab("Sessions", typeFilterSessions, ssCount, "2"),
 		renderTab("Commits", typeFilterCommits, cmCount, "3"),
-	}
-	if codeSearchEnabled() {
-		tabs = append(tabs, renderTab("Code", typeFilterCode, len(m.codeResults), "4"))
+		renderTab("Code", typeFilterCode, len(m.codeResults), "4"),
 	}
 
 	return strings.Join(tabs, "  ")
@@ -840,23 +834,9 @@ func (m searchModel) viewBrowseHeader() (string, bool) {
 	b.WriteString(pad + m.styles.render(m.styles.sectionTitle, "›") + " " + m.styles.render(m.styles.bold, query))
 	b.WriteString("\n\n")
 
-	// When code search is available, always show type tabs so the user can
-	// switch to the Code tab even when checkpoint search is loading/errored/empty.
-	hasCodeTab := codeSearchEnabled()
+	// Always show type tabs so the user can switch to the Code tab even when
+	// checkpoint search is loading/errored/empty.
 	checkpointBlocked := m.loading || m.searchErr != "" || len(m.results) == 0
-
-	if checkpointBlocked && !hasCodeTab {
-		// No code tab — show the checkpoint-only loading/error/empty state.
-		switch {
-		case m.loading:
-			b.WriteString(pad + m.styles.render(m.styles.dim, "Searching..."))
-		case m.searchErr != "":
-			b.WriteString(pad + m.styles.render(m.styles.red, "Error: "+m.searchErr))
-		default:
-			b.WriteString(pad + m.styles.render(m.styles.dim, "No results found."))
-		}
-		return b.String(), false
-	}
 
 	// Type tabs
 	b.WriteString(pad + m.viewTypeTabs())
@@ -1578,11 +1558,7 @@ func (m searchModel) viewHelp() string {
 	if pages > 1 {
 		left += dot + m.styles.helpItem("n/p", "page")
 	}
-	typeHint := "1-3"
-	if codeSearchEnabled() {
-		typeHint = "1-4"
-	}
-	left += dot + m.styles.helpItem(typeHint, "type") + dot +
+	left += dot + m.styles.helpItem("1-4", "type") + dot +
 		m.styles.helpItem(keys.Quit.Help().Key, keys.Quit.Help().Desc)
 
 	// The page / results count lives on the status row beneath the list

--- a/cmd/entire/cli/search_tui_test.go
+++ b/cmd/entire/cli/search_tui_test.go
@@ -638,7 +638,7 @@ func TestSearchModel_BrowseFooterHelp(t *testing.T) {
 		"/ search",
 		"↑/↓, j/k scroll",
 		"home/end, g/G top/bottom",
-		"1-3 type",
+		"1-4 type",
 		"q quit",
 	}
 	lastIndex := -1
@@ -680,7 +680,7 @@ func TestSearchModel_BrowseFooterHelpIncludesPagingForMultiplePages(t *testing.T
 		"↑/↓, j/k scroll",
 		"home/end, g/G top/bottom",
 		"n/p page",
-		"1-3 type",
+		"1-4 type",
 		"q quit",
 	}
 	lastIndex := -1


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1031
<!-- entire-trail-link-end -->

## Summary

Code search is ready for general availability. Until now, `entire search --code` and the TUI's Code tab required `ENTIRE_CODE_SEARCH=1` and failed with "code search is not yet available" without it — while the newly promoted `search` command's help and `agent-help` advertised the `--code` flags unconditionally, so stable builds documented a flag that refused to run.

- **Remove `codeSearchEnabled()` and every branch on it** (net −76 lines): `--code` always runs, `buildCodeSearchOpts` never returns nil, and the client-side gate error is gone.
- **TUI**: the Code tab, its `4` key binding, and code-search firing on query are always active; the dead "no code tab" fallback rendering is removed; the footer type hint is always `1-4`.
- **Graceful degradation is unchanged**: cells without the search service still 404 at the route level, map to `ErrCellUnavailable`, and are skipped — per-cell availability decides, not a client-side flag.
- **Tests**: the env-gate unit test is deleted; the gate test becomes its inverse (`--code` must never fail with the old gate message); `t.Setenv("ENTIRE_CODE_SEARCH", "1")` scaffolding is removed; TUI footer tests expect `1-4`.

Also fixes a stale comment on `why`'s agent-help annotation that justified it via the injection sentence removed in #1967.

## Test plan

- `mise run check` (fmt, lint, full test:ci incl. integration + e2e canary) — green
- Verified live: `entire search --code "codeSearchOpts"` returns real backend results with no env var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a291e92b71743a8adbd30cac6032a296eecaba4a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->