### PR TITLE
fix(search): order CLI semantic results by rerank score, matching the web

### DIFF
--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -65,13 +65,20 @@ const DefaultLimit = 100
 
 // Meta contains search ranking metadata for a result.
 type Meta struct {
-	MatchType string   `json:"matchType"`
-	Score     float64  `json:"score"`
-	Tier      *int     `json:"tier,omitempty"`
-	Snippet   string   `json:"snippet,omitempty"`
-	Summary   string   `json:"summary,omitempty"`
-	BM25Score *float64 `json:"bm25Score,omitempty"`
-	ANNScore  *float64 `json:"annScore,omitempty"`
+	MatchType string  `json:"matchType"`
+	Score     float64 `json:"score"`
+	Tier      *int    `json:"tier,omitempty"`
+	Snippet   string  `json:"snippet,omitempty"`
+	Summary   string  `json:"summary,omitempty"`
+	// RerankScore is query-serve's cross-encoder (Cohere) relevance judgement,
+	// present only on results that went through reranking. Where present it is
+	// the signal the final ordering was built from and the only score
+	// comparable across repos — Score is per-namespace retrieval strength, so
+	// sorting by it undoes reranking. The cross-cell merge orders tier 0 and
+	// tier 1 by this field, matching the BFF (ENT-1425/ENT-1431).
+	RerankScore *float64 `json:"rerankScore,omitempty"`
+	BM25Score   *float64 `json:"bm25Score,omitempty"`
+	ANNScore    *float64 `json:"annScore,omitempty"`
 }
 
 // CheckpointResult represents a checkpoint returned by the search service.

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -458,6 +458,35 @@ func TestSearch_ResultJSONRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSearch_MetaDecodesRerankScore guards that query-serve's rerankScore is
+// actually parsed off the wire — the cross-cell merge orders tier 0/1 by it, so
+// a dropped field silently reverts the CLI to pre-rerank ordering.
+func TestSearch_MetaDecodesRerankScore(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"type":"commit","data":{"commitSha":"abc123","org":"o","repo":"r"},"searchMeta":{"matchType":"both","score":6,"tier":1,"rerankScore":0.42,"bm25Score":6}}`
+	var r Result
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		t.Fatal(err)
+	}
+	if r.Meta.RerankScore == nil {
+		t.Fatal("rerankScore decoded as nil, want 0.42")
+	}
+	if *r.Meta.RerankScore != 0.42 {
+		t.Errorf("decoded rerankScore = %f, want 0.42", *r.Meta.RerankScore)
+	}
+
+	// Absent rerankScore must stay nil (a cell whose rerank fell back), not 0,
+	// so rerankOf can distinguish "unscored" from a genuine 0 score.
+	var noRerank Result
+	if err := json.Unmarshal([]byte(`{"type":"commit","data":{"commitSha":"d","org":"o","repo":"r"},"searchMeta":{"score":1,"tier":1}}`), &noRerank); err != nil {
+		t.Fatal(err)
+	}
+	if noRerank.Meta.RerankScore != nil {
+		t.Errorf("absent rerankScore = %v, want nil", *noRerank.Meta.RerankScore)
+	}
+}
+
 // -- HasFilters tests --
 
 func TestConfig_HasFilters(t *testing.T) {

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -318,6 +318,16 @@ func bm25Of(r search.Result) float64 {
 	return 0
 }
 
+// rerankOf returns query-serve's cross-encoder relevance score, or 0 when the
+// row was not reranked (its cell fell back). Rows without a score sort after
+// reranked ones, matching the BFF's rerankOf.
+func rerankOf(r search.Result) float64 {
+	if r.Meta.RerankScore != nil {
+		return *r.Meta.RerankScore
+	}
+	return 0
+}
+
 // annOrScoreOf prefers the raw ANN score, falling back to the overall score —
 // the ordering key query-serve/BFF use for the tier-2 ANN fallback (for
 // tier-2 rows Score is itself ANN-derived, so lower is better in both cases).
@@ -400,13 +410,24 @@ var errNoRepoAvailable = errors.New("semantic search cannot search this repo yet
 // errNoRegionAvailable is returned when every queried cell lacks query-serve.
 var errNoRegionAvailable = errors.New("semantic search is not yet available in the region(s) hosting this search")
 
-// rankSemanticResults buckets every page's rows and applies the ordering
-// query-serve uses within a cell (and the BFF uses across cells): repos first,
-// then tier-0 by BM25 desc, tier-1 by rerank score desc, promoted tier-2 by
-// ANN asc. Tier-2 rows arriving alongside tier 0/1 from the same cell were
-// deliberately promoted by query-serve; a cell whose page is entirely tier 2
-// had nothing better — its ANN fallback, shown (uncapped here) only when tiers
-// 0/1 are empty everywhere.
+// tier0Row pairs a tier-0 result with its rank within the cell that returned
+// it — the selection order the mixed-capability fallback preserves (see
+// sortTier0Rows).
+type tier0Row struct {
+	r        search.Result
+	cellRank int
+}
+
+// rankSemanticResults buckets every page's rows and applies the SAME ordering
+// the BFF's cross-cell merge uses (searcher.go / routes/search.ts): repos
+// first, then tier 0 and tier 1 EACH by rerank score desc (ENT-1425/ENT-1431),
+// then promoted tier-2 by ANN asc. Ordering by rerank score — not BM25 or the
+// per-namespace retrieval Score — is what keeps the CLI in parity with the web:
+// query-serve documents that Score "is not the field results are ordered by …
+// sorting by it undoes reranking." Tier-2 rows arriving alongside tier 0/1 from
+// the same cell were deliberately promoted by query-serve; a cell whose page is
+// entirely tier 2 had nothing better — its ANN fallback, shown (uncapped here)
+// only when tiers 0/1 are empty everywhere.
 func rankSemanticResults(pages []semanticCellPage) (merged []search.Result, globalUpper bool) {
 	for _, p := range pages {
 		if p.hasUpper {
@@ -415,14 +436,17 @@ func rankSemanticResults(pages []semanticCellPage) (merged []search.Result, glob
 		}
 	}
 
-	var repos, tier0, tier1, promotedTier2, fallbackTier2 []search.Result
+	var repos, tier1, promotedTier2, fallbackTier2 []search.Result
+	var tier0 []tier0Row
 	for _, p := range pages {
+		cellRank := 0
 		for _, r := range p.body.Results {
 			switch {
 			case r.Type == search.TypeRepo:
 				repos = append(repos, r)
 			case tierOf(r) == 0:
-				tier0 = append(tier0, r)
+				tier0 = append(tier0, tier0Row{r: r, cellRank: cellRank})
+				cellRank++
 			case tierOf(r) == 1:
 				tier1 = append(tier1, r)
 			case p.hasUpper:
@@ -435,10 +459,19 @@ func rankSemanticResults(pages []semanticCellPage) (merged []search.Result, glob
 	sort.SliceStable(repos, func(i, j int) bool { return repos[i].Meta.Score > repos[j].Meta.Score })
 	merged = append(merged, repos...)
 	if globalUpper {
-		sort.SliceStable(tier0, func(i, j int) bool { return bm25Of(tier0[i]) > bm25Of(tier0[j]) })
-		sort.SliceStable(tier1, func(i, j int) bool { return tier1[i].Meta.Score > tier1[j].Meta.Score })
+		sortTier0Rows(tier0)
+		// Tier 1: rerank score decides, retrieval Score breaks ties. Rows whose
+		// cell fell back (no rerank score) sort last, matching the BFF.
+		sort.SliceStable(tier1, func(i, j int) bool {
+			if ri, rj := rerankOf(tier1[i]), rerankOf(tier1[j]); ri != rj {
+				return ri > rj
+			}
+			return tier1[i].Meta.Score > tier1[j].Meta.Score
+		})
 		sort.SliceStable(promotedTier2, func(i, j int) bool { return annOrScoreOf(promotedTier2[i]) < annOrScoreOf(promotedTier2[j]) })
-		merged = append(merged, tier0...)
+		for _, t := range tier0 {
+			merged = append(merged, t.r)
+		}
 		merged = append(merged, tier1...)
 		merged = append(merged, promotedTier2...)
 	} else {
@@ -446,6 +479,39 @@ func rankSemanticResults(pages []semanticCellPage) (merged []search.Result, glob
 		merged = append(merged, fallbackTier2...)
 	}
 	return merged, globalUpper
+}
+
+// sortTier0Rows orders the tier-0 band the way the BFF's sortTier0 does
+// (ENT-1431). When EVERY row was judged by the cross-encoder, rerank score
+// decides and BM25 breaks ties. When any row is missing a rerank score — its
+// cell predates tier-0 reranking — a global rerank sort would demote all of
+// that cell's full-phrase hits regardless of relevance, so instead the rows are
+// interleaved positionally (each cell's #1, then each cell's #2, …), preserving
+// every cell's own selection order, with BM25 breaking ties between same-rank
+// rows. Converges to rerank-first once every cell is current.
+func sortTier0Rows(tier0 []tier0Row) {
+	allScored := true
+	for _, t := range tier0 {
+		if t.r.Meta.RerankScore == nil {
+			allScored = false
+			break
+		}
+	}
+	if allScored {
+		sort.SliceStable(tier0, func(i, j int) bool {
+			if ri, rj := rerankOf(tier0[i].r), rerankOf(tier0[j].r); ri != rj {
+				return ri > rj
+			}
+			return bm25Of(tier0[i].r) > bm25Of(tier0[j].r)
+		})
+		return
+	}
+	sort.SliceStable(tier0, func(i, j int) bool {
+		if tier0[i].cellRank != tier0[j].cellRank {
+			return tier0[i].cellRank < tier0[j].cellRank
+		}
+		return bm25Of(tier0[i].r) > bm25Of(tier0[j].r)
+	})
 }
 
 // dedupSemanticResults removes cross-cell duplicates by type+id (a repo

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -155,6 +155,35 @@ func TestMergeSemanticV4Responses_Tier0MixedCapabilityFallback(t *testing.T) {
 	}
 }
 
+// TestMergeSemanticV4Responses_EqualRerankTieBreaks verifies the secondary keys
+// when rerank scores tie: tier 0 falls back to BM25 desc and tier 1 to retrieval
+// Score desc, matching the BFF's `|| bm25Of` / `|| scoreOf` tie-breaks.
+func TestMergeSemanticV4Responses_EqualRerankTieBreaks(t *testing.T) {
+	t.Parallel()
+
+	cell := &search.Response{Results: []search.Result{
+		// tier 0, equal rerank → BM25 desc decides: t0-hi before t0-lo.
+		v4Ckpt("t0-lo", 0, search.Meta{RerankScore: fptr(0.50), BM25Score: fptr(2.0)}),
+		v4Ckpt("t0-hi", 0, search.Meta{RerankScore: fptr(0.50), BM25Score: fptr(8.0)}),
+		// tier 1, equal rerank → Score desc decides: t1-hi before t1-lo.
+		v4Ckpt("t1-lo", 1, search.Meta{RerankScore: fptr(0.30), Score: 0.1}),
+		v4Ckpt("t1-hi", 1, search.Meta{RerankScore: fptr(0.30), Score: 0.9}),
+	}, Total: 4}
+
+	resp, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
+		v4CellOK(cell),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"t0-hi", "t0-lo", "t1-hi", "t1-lo"}
+	got := v4ResultIDs(t, resp.Results)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("merged order = %v, want %v", got, want)
+	}
+}
+
 // TestMergeSemanticV4Responses_PagePassthrough confirms the requested page is
 // reflected in the merged response (the TUI's fetch-more pages server-side).
 func TestMergeSemanticV4Responses_PagePassthrough(t *testing.T) {

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -78,22 +78,26 @@ func v4ResultIDs(t *testing.T, results []search.Result) []string {
 // --- merge: tier ordering ------------------------------------------------------
 
 // TestMergeSemanticV4Responses_TierOrdering verifies the cross-cell interleave
-// applies query-serve's own ordering: repos first, then tier-0 by BM25 desc,
-// tier-1 by rerank score desc, then promoted tier-2 by ANN asc — regardless of
-// which cell each result came from.
+// applies query-serve's own ordering: repos first, then tier 0 and tier 1 EACH
+// by rerank score desc (ENT-1425/ENT-1431), then promoted tier-2 by ANN asc —
+// regardless of which cell each result came from. The BM25/Score values are set
+// to the OPPOSITE order from the rerank scores so the assertion fails if the
+// merge ever regresses to sorting by BM25 (tier 0) or Score (tier 1).
 func TestMergeSemanticV4Responses_TierOrdering(t *testing.T) {
 	t.Parallel()
 
 	cellA := &search.Response{Results: []search.Result{
-		v4Ckpt("a-t1-low", 1, search.Meta{Score: 0.5}),
-		v4Ckpt("a-t0-high", 0, search.Meta{BM25Score: fptr(9.0)}),
+		// tier-1: high Score but LOW rerank → must sort below b-t1 (higher rerank).
+		v4Ckpt("a-t1-rr-lo", 1, search.Meta{Score: 0.9, RerankScore: fptr(0.20)}),
+		// tier-0: high BM25 but LOW rerank → must sort below b-t0 (higher rerank).
+		v4Ckpt("a-t0-rr-lo", 0, search.Meta{BM25Score: fptr(9.0), RerankScore: fptr(0.20)}),
 		// tier-2 alongside upper tiers in the same cell → promoted.
 		v4Ckpt("a-t2", 2, search.Meta{ANNScore: fptr(0.30)}),
 	}, Total: 3}
 	cellB := &search.Response{Results: []search.Result{
 		v4RepoRow(t, "repo-1", 0.9),
-		v4Ckpt("b-t0-low", 0, search.Meta{BM25Score: fptr(3.0)}),
-		v4Ckpt("b-t1-high", 1, search.Meta{Score: 0.8}),
+		v4Ckpt("b-t0-rr-hi", 0, search.Meta{BM25Score: fptr(3.0), RerankScore: fptr(0.80)}),
+		v4Ckpt("b-t1-rr-hi", 1, search.Meta{Score: 0.1, RerankScore: fptr(0.90)}),
 		v4Ckpt("b-t2", 2, search.Meta{ANNScore: fptr(0.10)}),
 	}, Total: 4}
 
@@ -104,7 +108,7 @@ func TestMergeSemanticV4Responses_TierOrdering(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"repo-1", "a-t0-high", "b-t0-low", "b-t1-high", "a-t1-low", "b-t2", "a-t2"}
+	want := []string{"repo-1", "b-t0-rr-hi", "a-t0-rr-lo", "b-t1-rr-hi", "a-t1-rr-lo", "b-t2", "a-t2"}
 	got := v4ResultIDs(t, resp.Results)
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Errorf("merged order = %v, want %v", got, want)
@@ -114,6 +118,40 @@ func TestMergeSemanticV4Responses_TierOrdering(t *testing.T) {
 	}
 	if resp.Page != 1 {
 		t.Errorf("page = %d, want 1", resp.Page)
+	}
+}
+
+// TestMergeSemanticV4Responses_Tier0MixedCapabilityFallback verifies the tier-0
+// fallback used when not every row was reranked (a cell predating tier-0
+// reranking): rows interleave positionally by their rank within their own cell
+// (each cell's #1, then each cell's #2, …), BM25 breaking ties between same-rank
+// rows — never a global rerank sort that would demote the un-scored cell's hits.
+func TestMergeSemanticV4Responses_Tier0MixedCapabilityFallback(t *testing.T) {
+	t.Parallel()
+
+	// cellA is a current cell (rows carry a rerank score); cellB predates tier-0
+	// reranking (no rerank score) — so the whole band uses the positional fallback.
+	cellA := &search.Response{Results: []search.Result{
+		v4Ckpt("a0", 0, search.Meta{BM25Score: fptr(1.0), RerankScore: fptr(0.90)}), // cellRank 0
+		v4Ckpt("a1", 0, search.Meta{BM25Score: fptr(2.0), RerankScore: fptr(0.80)}), // cellRank 1
+	}, Total: 2}
+	cellB := &search.Response{Results: []search.Result{
+		v4Ckpt("b0", 0, search.Meta{BM25Score: fptr(5.0)}), // cellRank 0, no rerank score
+		v4Ckpt("b1", 0, search.Meta{BM25Score: fptr(4.0)}), // cellRank 1, no rerank score
+	}, Total: 2}
+
+	resp, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
+		v4CellOK(cellA), v4CellOK(cellB),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// rank 0: b0 (BM25 5) before a0 (BM25 1); rank 1: b1 (BM25 4) before a1 (BM25 2).
+	want := []string{"b0", "a0", "b1", "a1"}
+	got := v4ResultIDs(t, resp.Results)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("merged order = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1032
<!-- entire-trail-link-end -->

## Problem

`entire search` (CLI) and entire.io (web) return **different results for the same query + repo + user** — different order and different totals. Root cause: the CLI's cross-cell semantic merge orders by the wrong key.

- The CLI ordered **tier 0 by BM25** and **tier 1 by the per-namespace retrieval `Score`**, and its result model had **no `rerankScore` field at all** (it silently dropped it when parsing the response).
- The shared server-side reranker (Cohere, in `entire-search` query-serve) is identical for both clients, but the **ordering that consumes the rerank score is a separate re-implementation in each client** (Go in the CLI, TS in the BFF), and the CLI's copy never got the fixes the web did.
- query-serve's own docs on the `Score` field: *"It is NOT the field results are ordered by … sorting by it undoes reranking."* The CLI was sorting by exactly that. The web BFF orders both tiers by rerank score (ENT-1425 / ENT-1431); the CLI was sitting at the pre-fix behavior.

Measured on EU prod, same user/repo:
- `"dependabot"` on `entirehq/entire.io`: **118 of 119** tier-0 positions differed between CLI and web; totals 100 vs 121.
- `"antithesis reranking"`: different #1, **15 of 18** positions differed; CLI output carried no `rerankScore`.

This is the same divergence class as the "wildly different results" reports.

## Fix

Bring the CLI merge to parity with the web:
- add `RerankScore` to the search result `Meta` so the CLI parses and surfaces query-serve's cross-encoder score;
- order **tier 0** by rerank score desc (BM25 tie-break) when every row was reranked, else the BFF's positional mixed-capability fallback (interleave by each cell's selection rank, BM25 tie-break);
- order **tier 1** by rerank score desc (retrieval `Score` tie-break);
- tests assert rerank ordering with BM25/`Score` set to the *opposite* order, so a regression to the old keys fails, plus a mixed-capability fallback test.

Repos, tier-2 promotion, dedupe, caps, and counts are unchanged.

## Verification

- `go build ./cmd/entire/...`, `go vet`, and the search test suites pass.
- End-to-end: the patched binary's top results for `"dependabot"` now match the web's `rerankScore` order **exactly** (0.6276, 0.6036, 0.5790, 0.5637, …), and `rerankScore` is now present on every reranked row.

## Follow-up (not in this PR)

- Tier-2 handling still differs (the web hard-drops tier-2; the CLI promotes/keeps it). Dormant today since query-serve no longer emits tier-2, but worth reconciling.
- The real durable fix is to stop maintaining two orderers — a single shared ordering contract, or have query-serve return final merged order so neither client re-sorts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 917583654874870e8873014db48324aa028bbf2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->