### PR TITLE
Require an explicitly selected login, with --context / ENTIRE_CONTEXT for one-offs

### DIFF
--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -328,6 +328,13 @@ func resolveEnvTokenStatusTarget(raw string) (statusTarget, error) {
 func resolveStatusTarget(ctx context.Context, listContexts contextsProvider, resolveLogin loginTokenResolver) (statusTarget, error) {
 	all, current, err := listContexts()
 	if err != nil {
+		// A bad --context/$ENTIRE_CONTEXT is not a load failure, and prefixing it
+		// with one ("load contexts: --context selected …") describes the wrong
+		// problem. Its own message is already complete.
+		var unknown *contexts.UnknownContextError
+		if errors.As(err, &unknown) {
+			return statusTarget{}, err
+		}
 		return statusTarget{}, fmt.Errorf("load contexts: %w", err)
 	}
 	total := len(all)

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -208,14 +208,16 @@ type cellSubject struct {
 // ENTIRE_TOKEN when set (exclusive, fail-closed), otherwise the ACTIVE stored
 // login context.
 //
-// It deliberately uses the active context — the same login `entire auth token`
-// (no flag) prints a bearer for — rather than resolveStoredCellSubject's
-// data-host discovery. `--jurisdiction` mints a token for the caller's SELECTED
-// environment, so with (say) a partial.to context active it must mint a
-// partial.to token even though the data host defaults to entire.io. Discovery
-// keys off api.BaseURL() and would pick whichever context that host trusts,
-// silently ignoring the selection. NewEntireAPICellClient is a different case —
-// it dials the data plane — so it keeps calling resolveStoredCellSubject.
+// It deliberately skips resolveStoredCellSubject's data-host discovery.
+// `--jurisdiction` mints a token for the caller's SELECTED environment, so with
+// (say) a partial.to context active it must mint a partial.to token even though
+// the data host defaults to entire.io. Discovery keys off api.BaseURL(), so it
+// would fail outright — clusterdiscovery.requireActiveContext validates the
+// active context against *that* host's trusted issuers and errors when they
+// don't match, which for this command is the wrong question to ask: the target
+// jurisdiction comes from the flag, not from the default data host.
+// NewEntireAPICellClient is a different case — it dials the data plane — so it
+// keeps calling resolveStoredCellSubject.
 func resolveCellSubject(ctx context.Context, insecureHTTP bool) (cellSubject, error) {
 	if raw, ok := os.LookupEnv(EnvTokenVar); ok {
 		return resolveEnvTokenCellSubject(raw, insecureHTTP)

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -181,3 +181,20 @@ func Contexts() ([]*contexts.Context, string, error) {
 	}
 	return f.Contexts, sel.Context.Name, nil
 }
+
+// StoredContexts returns all stored login contexts and the STORED
+// current_context, ignoring any `--context`/$ENTIRE_CONTEXT override.
+//
+// Use this for questions about what is *persisted* — does a default exist, what
+// should become the new default — as opposed to which identity is *acting*,
+// which is Contexts. Resolving the acting identity here would answer the wrong
+// question: after `logout --context staging` the override names a context that
+// no longer exists, so Active fails and a caller asking "is a default still
+// set?" would silently get an error instead of "no".
+func StoredContexts() ([]*contexts.Context, string, error) {
+	f, err := contexts.Load(userdirs.Config())
+	if err != nil {
+		return nil, "", fmt.Errorf("load contexts: %w", err)
+	}
+	return f.Contexts, f.CurrentContext, nil
+}

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -11,12 +11,24 @@ import (
 	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
 
-// RemoveCurrentContext deletes the active context's keyring tokens and its
-// contexts.json entry, clearing current_context. It is a no-op (returns nil)
-// when there is no current context. Used by logout.
+// RemoveCurrentContext deletes the acting context's keyring tokens and its
+// contexts.json entry, clearing current_context when it pointed there. It is a
+// no-op (returns nil) when there is no acting context. Used by logout.
+//
+// It resolves through File.Active, so `entire logout --context staging` removes
+// the login it just revoked. Resolving the removal target differently from the
+// revocation target (which comes from resolveStatusTarget, also via Active)
+// would end one session server-side while deleting a different login's
+// credentials locally.
 func RemoveCurrentContext() error {
 	if err := removeContextLocked(func(f *contexts.File) *contexts.Context {
-		return f.Find(f.CurrentContext)
+		sel, err := f.Active()
+		if err != nil {
+			// Unresolvable explicit selection: remove nothing rather than
+			// falling back to current_context, which is not what was asked for.
+			return nil
+		}
+		return sel.Context
 	}); err != nil {
 		return fmt.Errorf("remove current context: %w", err)
 	}
@@ -147,12 +159,25 @@ func SetCurrentContext(name string) error {
 	return nil
 }
 
-// Contexts returns all stored login contexts and the current context name,
-// for listing/switching. Order matches on-disk order.
+// Contexts returns all stored login contexts and the name of the one currently
+// acting, for listing/switching and for the status/logout targets. Order matches
+// on-disk order.
+//
+// The second return is the EFFECTIVE active name, so a `--context`/
+// $ENTIRE_CONTEXT selection is what `auth status` reports, what `auth contexts`
+// marks, and what `logout` revokes — the alternative is status describing one
+// identity while every other command uses another.
 func Contexts() ([]*contexts.Context, string, error) {
 	f, err := contexts.Load(userdirs.Config())
 	if err != nil {
 		return nil, "", fmt.Errorf("load contexts: %w", err)
 	}
-	return f.Contexts, f.CurrentContext, nil
+	sel, err := f.Active()
+	if err != nil {
+		return nil, "", err //nolint:wrapcheck // UnknownContextError is already a complete operator message
+	}
+	if sel.Context == nil {
+		return f.Contexts, "", nil
+	}
+	return f.Contexts, sel.Context.Name, nil
 }

--- a/cmd/entire/cli/auth/context_store_test.go
+++ b/cmd/entire/cli/auth/context_store_test.go
@@ -297,3 +297,56 @@ func TestRecordLoginContext_ReloginKeepsJurisdictionAudiences(t *testing.T) {
 		t.Fatalf("recorded audiences after re-login = %v, want [%s]", got, audience)
 	}
 }
+
+// Contexts reports the ACTING identity (honouring --context/$ENTIRE_CONTEXT) while
+// StoredContexts reports the PERSISTED default. Conflating them made
+// `entire logout --context X` and a plain `entire logout` leave different state
+// for the same target: promoteNextLogin asked for the acting identity, which by
+// then named the just-deleted context, so Active failed and the promotion was
+// silently skipped.
+//
+// Mutates the process-wide override and env, so no t.Parallel.
+func TestContextsVsStoredContexts_OverrideScope(t *testing.T) {
+	const (
+		defaultCtx  = "prod"    // the stored current_context
+		overrideCtx = "staging" // selected for one invocation
+	)
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+	t.Setenv(contexts.EnvContextVar, "")
+
+	if err := contexts.Save(cfgDir, &contexts.File{
+		CurrentContext: defaultCtx,
+		Contexts: []*contexts.Context{
+			{Name: defaultCtx, CoreURL: testCoreURL, Handle: "me", KeychainService: "kc:prod"},
+			{Name: overrideCtx, CoreURL: "https://staging.example.com", Handle: "me", KeychainService: "kc:staging"},
+		},
+	}); err != nil {
+		t.Fatalf("seed contexts: %v", err)
+	}
+
+	contexts.SetFlagOverrideForTest(t, overrideCtx)
+
+	if _, acting, err := Contexts(); err != nil || acting != overrideCtx {
+		t.Fatalf("Contexts() acting = %q, %v; want staging (the override)", acting, err)
+	}
+	all, stored, err := StoredContexts()
+	if err != nil || stored != defaultCtx {
+		t.Fatalf("StoredContexts() stored = %q, %v; want prod (the persisted default)", stored, err)
+	}
+	// promoteNextLogin picks all[0] as the next default, so the list matters too.
+	if len(all) != 2 || all[0].Name != defaultCtx {
+		t.Fatalf("StoredContexts() list = %v, want the saved contexts in on-disk order", all)
+	}
+
+	// The regression: an override naming a context that no longer exists must not
+	// stop StoredContexts from answering "is a default still set?".
+	contexts.SetFlagOverrideForTest(t, "deleted-by-logout")
+	if _, _, err := Contexts(); err == nil {
+		t.Fatal("Contexts() should fail on an override naming no saved context")
+	}
+	if got, stored, err := StoredContexts(); err != nil || stored != defaultCtx || len(got) != 2 {
+		t.Fatalf("StoredContexts() = %v/%q, %v; must ignore the override entirely", got, stored, err)
+	}
+}

--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -105,14 +105,23 @@ func targetForContext(c *contexts.Context) (ControlPlaneTarget, error) {
 // ok=false when there is no current context or it carries no CoreURL (an
 // unusable pointer we treat as "no active context" rather than dialing an
 // empty host).
+//
+// A `--context`/$ENTIRE_CONTEXT selection is honoured here too, so the identity
+// the control plane acts as is the same one git and the data API use. An
+// explicit selection naming no saved context is a hard error rather than
+// ok=false: "you asked for a context that doesn't exist" must not degrade into
+// the `entire login` hint.
 func activeContext() (c *contexts.Context, ok bool, err error) {
 	f, err := contexts.Load(userdirs.Config())
 	if err != nil {
 		return nil, false, fmt.Errorf("load contexts: %w", err)
 	}
-	c = f.Find(f.CurrentContext)
-	if c == nil || c.CoreURL == "" {
+	sel, err := f.Active()
+	if err != nil {
+		return nil, false, err //nolint:wrapcheck // UnknownContextError is already a complete operator message
+	}
+	if sel.Context == nil || sel.Context.CoreURL == "" {
 		return nil, false, nil
 	}
-	return c, true, nil
+	return sel.Context, true, nil
 }

--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -68,16 +68,15 @@ func ResolveControlPlaneTarget() (ControlPlaneTarget, error) {
 // context: a cluster's mirror lives in the federation that fronts that cluster,
 // which may differ from the active login (e.g. a partial.to context acting on a
 // prod entire.io cluster). We discover the cluster's trusted cores from its
-// /.well-known/entire-cluster.json and pick the local context eligible for one
-// of them — active-wins-if-eligible, else the sole eligible context, else an
-// explicit-choice / login hint — exactly as git and data-API resolution do
-// (see ResolveDataAPIToken). The bearer is that context's
-// refreshing login provider (silent JWT re-mint from its stored refresh token).
+// /.well-known/entire-cluster.json and require the ACTIVE context to be issued
+// by one of them — exactly as git and data-API resolution do (see
+// ResolveDataAPIToken). The bearer is that context's refreshing login provider
+// (silent JWT re-mint from its stored refresh token).
 //
-// With no eligible local context the discovery resolver returns its login hint
-// naming the cluster's cores, so the user logs in to the right federation
-// rather than seeing an opaque "unknown cluster_host" 400 from the active
-// context's core.
+// When the active context isn't trusted by the cluster the discovery resolver
+// says so and names the saved logins that are (or, when none is, the cluster's
+// cores), so the user switches with `entire auth use` or logs in to the right
+// federation rather than seeing an opaque "unknown cluster_host" 400.
 func ResolveControlPlaneTargetForCluster(ctx context.Context, clusterHost string) (ControlPlaneTarget, error) {
 	if clusterHost == "" {
 		return ControlPlaneTarget{}, errors.New("cluster-addressed control-plane command requires a target cluster host")

--- a/cmd/entire/cli/auth/control_plane_test.go
+++ b/cmd/entire/cli/auth/control_plane_test.go
@@ -97,7 +97,7 @@ func TestResolveControlPlaneTargetForCluster_DialsClusterCoreNotActive(t *testin
 	}
 
 	// Stub cluster discovery so the test doesn't hit the network: the cluster
-	// resolves to the prod context (what /.well-known + selectContext would
+	// resolves to the prod context (what /.well-known + requireActiveContext would
 	// yield), NOT the active partial context.
 	prev := resolveContextForCluster
 	resolveContextForCluster = func(_ context.Context, _, _, host string, _ *http.Client, _ clusterdiscovery.DebugFunc) (*contexts.Context, error) {

--- a/cmd/entire/cli/auth/data_api.go
+++ b/cmd/entire/cli/auth/data_api.go
@@ -43,15 +43,21 @@ func SetResolveContextForAPIForTest(t interface{ Helper() }, fn resolveContextFu
 // ResolveDataAPIToken returns a bearer for the data API at dataBaseURL.
 //
 // It dials the API's /.well-known/entire-api.json to learn which login
-// server(s) the API trusts and which audience to exchange for, picks the
-// matching local auth context (active-wins-if-eligible → sole → explicit
-// choice), and exchanges that context's login JWT for the advertised audience
-// at that context's core. This is what makes
+// server(s) the API trusts and which audience to exchange for, requires the
+// ACTIVE auth context to be issued by one of those servers, and exchanges that
+// context's login JWT for the advertised audience at that context's core.
 //
+// Pointing the CLI at another environment therefore takes two steps, because
+// the acting identity is never inferred from the target host:
+//
+//	entire auth use staging
 //	ENTIRE_API_BASE_URL=https://partial.to entire activity
 //
-// authenticate as the partial.to login even while the active context is a
-// prod entire.io login — with no per-command override needed.
+// An earlier revision skipped the first line by falling back to whichever saved
+// login the host happened to trust. That made an env var silently change which
+// account a command ran as, which is exactly the ambiguity the single active
+// context exists to remove; a wrong-context run now fails with a message naming
+// the logins that would work (see clusterdiscovery.requireActiveContext).
 //
 // Discovery is the only path: an API host that doesn't advertise
 // /.well-known/entire-api.json (unreachable / 404 / 503 / malformed) is an

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -27,6 +27,12 @@ func newAuthUseCmd() *cobra.Command {
 			"`git clone entire://…`, the control-plane commands (auth status,\n" +
 			"org/project/repo/grant), and the data-API commands (activity, search,\n" +
 			"trail, dispatch). The switch takes effect on the next operation.\n\n" +
+			"This is persistent and machine-wide — it changes the identity for every\n" +
+			"shell, worktree, and background git hook until you switch back. To act as\n" +
+			"another login for a single command instead, pass --context, or set\n" +
+			"ENTIRE_CONTEXT for one shell or one git operation:\n\n" +
+			"  entire --context staging activity\n" +
+			"  ENTIRE_CONTEXT=staging git push\n\n" +
 			"Data-API commands still take their HOST from ENTIRE_API_BASE_URL; the\n" +
 			"context supplies the identity, and the host must trust its login server.",
 		Args:              cobra.ExactArgs(1),

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -15,18 +15,20 @@ import (
 // (it authenticates any cluster fronted by its login server) and the
 // control-plane commands (auth status, org/project/repo/grant), which dial the
 // context's core. Switching takes effect on the next operation; resolution
-// recomputes every time. Data-API commands (activity/search/trail/dispatch)
-// still target ENTIRE_API_BASE_URL and do not follow the active context yet.
+// recomputes every time. Data-API commands (activity/search/trail/dispatch) take
+// their HOST from ENTIRE_API_BASE_URL, but their identity from the active context
+// like everything else.
 func newAuthUseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "use <context>",
 		Short: "Switch the active login context",
 		Long: "Switch the active login context.\n\n" +
-			"The active context is the preferred identity for `git clone entire://…` and\n" +
-			"the control-plane commands (auth status, org/project/repo/grant), which dial\n" +
-			"the context's login server. The switch takes effect on the next operation.\n\n" +
-			"Data-API commands (activity/search/trail/dispatch) still target\n" +
-			"ENTIRE_API_BASE_URL and do not follow the active context yet.",
+			"The active context is the identity for every authenticated operation:\n" +
+			"`git clone entire://…`, the control-plane commands (auth status,\n" +
+			"org/project/repo/grant), and the data-API commands (activity, search,\n" +
+			"trail, dispatch). The switch takes effect on the next operation.\n\n" +
+			"Data-API commands still take their HOST from ENTIRE_API_BASE_URL; the\n" +
+			"context supplies the identity, and the host must trust its login server.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completeContextNames,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/entire/cli/context_flag.go
+++ b/cmd/entire/cli/context_flag.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/spf13/cobra"
+)
+
+// contextFlagValue applies --context to the process-wide selection as pflag
+// parses it.
+//
+// Binding through a pflag.Value rather than a PersistentPreRun is deliberate:
+// Cobra runs only the CLOSEST PersistentPreRun in the chain, and subtrees here
+// define their own (agent_group.go, the per-agent hooks commands), so a root hook
+// would be silently skipped for exactly the commands that inherited the flag.
+// Set() runs during flag parsing — before any PreRun, before RunE, and before
+// anything resolves a token — so there is no ordering to get wrong.
+type contextFlagValue struct{ name string }
+
+func (v *contextFlagValue) String() string { return v.name }
+func (v *contextFlagValue) Type() string   { return "string" }
+
+func (v *contextFlagValue) Set(name string) error {
+	v.name = name
+	contexts.SetFlagOverride(name)
+	return nil
+}
+
+// addContextFlag registers --context as a persistent flag on the root command,
+// so every subcommand that authenticates inherits it without per-command
+// plumbing.
+//
+// It is global rather than per-command because it selects an identity, and every
+// path that resolves one honours it (git, control plane, data API, cell routing,
+// status, logout). Registering it only on the commands we think authenticate
+// today is how it would drift out of sync: a new authenticating command would
+// silently ignore it. The cost is that it also parses on commands with no
+// identity to select, like `version` — harmless, and the same tradeoff kubectl
+// makes with its own global --context.
+func addContextFlag(cmd *cobra.Command) {
+	// The back-quoted word is pflag's value placeholder, so this renders as
+	// `--context name`. Any other back-quoted span here (e.g. around a command to
+	// run) would be silently hijacked as the placeholder instead.
+	cmd.PersistentFlags().Var(&contextFlagValue{}, "context",
+		"Act as this saved login `name` for this command only, instead of the active context (entire auth contexts lists them)")
+	if err := cmd.RegisterFlagCompletionFunc("context", completeContextFlag); err != nil {
+		panic("register --context completion: " + err.Error())
+	}
+}
+
+// completeContextFlag completes saved context names for --context. It reuses the
+// same listing `auth use` completes against, so both offer the same names with
+// the same descriptions.
+func completeContextFlag(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// completeContextNames takes the positional args of `auth use <context>`; pass
+	// none so it treats this as completing the first (and only) value.
+	return completeContextNames(cmd, nil, toComplete)
+}

--- a/cmd/entire/cli/logout.go
+++ b/cmd/entire/cli/logout.go
@@ -100,8 +100,14 @@ func newLogoutCmd() *cobra.Command {
 // every login when run repeatedly: each call ends the active login and
 // promotes the next, until none remain. Best-effort and informational —
 // logout already succeeded by the time we get here.
+//
+// It reads the STORED current_context (auth.StoredContexts), not the acting
+// identity: after `entire logout --context staging` the override still names
+// staging, which no longer exists, so resolving the acting identity would fail
+// and skip the promotion — leaving `logout --context X` and a plain `logout`
+// with different end states for the very same target.
 func promoteNextLogin(outW, errW io.Writer) {
-	all, current, err := auth.Contexts()
+	all, current, err := auth.StoredContexts()
 	if err != nil || current != "" || len(all) == 0 {
 		return
 	}

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -102,6 +102,8 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
+	addContextFlag(cmd)
+
 	// Help groups; AddGroup order is display order in `entire --help`.
 	cmd.AddGroup(
 		&cobra.Group{ID: groupSetup, Title: "Entire Setup:"},

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -372,9 +372,9 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, skipTLS bool, httpCli
 
 	// Resolve which login context authenticates this cluster: the cluster's
 	// login servers are taken from the cluster_cores.json cache (or a live
-	// /.well-known fetch on miss/expiry), then the account is selected from
-	// local contexts — active context if eligible, else the sole eligible
-	// one, else an explicit-choice error.
+	// /.well-known fetch on miss/expiry), and the ACTIVE context must be issued
+	// by one of them. No other saved login is substituted, so which identity
+	// pushed or fetched is always readable from current_context.
 	cfgDir := userdirs.Config()
 	clusterAuth, err := clusterdiscovery.ResolveClusterAuth(ctx, cfgDir, userdirs.Cache(), parsedURL.Host, httpClient, debuglog.Printf)
 	if err != nil {

--- a/docs/architecture/upstream-host-resolution.md
+++ b/docs/architecture/upstream-host-resolution.md
@@ -32,10 +32,10 @@ token. `entire auth use <ctx>` flips `CurrentContext`.
 ### Git cluster (done — `internal/entireclient/clusterdiscovery`)
 
 `ResolveContextForCluster(host)` fetches+caches the cluster's
-`/.well-known/entire-cluster.json`, reads `core_urls`, then selects the
-context: active-context-wins if its `CoreURL` is among the cores, else the
-sole eligible context, else an error (zero → login hint; ambiguous → asks for
-`auth use`). The token is then exchanged for the cluster.
+`/.well-known/entire-cluster.json`, reads `core_urls`, then requires the
+**active context** to be issued by one of them. There is no implicit
+selection — see [Account selection](#account-selection) below. The token is
+then exchanged for the cluster.
 
 ### Control plane (done — this slice)
 
@@ -101,11 +101,11 @@ Resolution (`auth.ResolveDataAPIToken`):
    a live `/.well-known/entire-api.json` fetch (TLS-authenticated — it's a trust
    root; redirects refused), cached with a 24h TTL and stale-fallback on a failed
    re-fetch. Same `resolveClusterCores` shape the git path uses.
-2. Pick the context with the **same cluster semantics** as the git path:
-   active-context-wins-if-eligible → sole eligible → explicit-choice error.
-   This is the lever that makes `ENTIRE_API_BASE_URL=https://partial.to entire
-   activity` authenticate as the partial.to login even while the active context
-   is a prod entire.io login.
+2. Require the **active context** with the same semantics as the git path: it is
+   used when its `CoreURL` is among the trusted issuers, and anything else is an
+   error. So `ENTIRE_API_BASE_URL=https://partial.to entire activity` needs
+   `entire auth use staging` first — the target host never selects the identity
+   for you.
 3. Exchange that context's login JWT at **its** core for the data host origin
    (`auth.NewRefreshingResourceProvider`, keyed on `c.CoreURL` like the
    control-plane provider; the token manager sets `aud` = that origin).
@@ -115,16 +115,63 @@ Resolution (`auth.ResolveDataAPIToken`):
    host whose context selection fails surfaces that error — the user must log
    in or pick one. (A transient outage with a warm cache uses the stale entry.)
 
-The selection rule differs from the control plane (where the active context
-*always* wins because there's no host to match): here a host **is** matched, so
-the active context wins only when eligible.
+The selection rule differs from the control plane (where the active context is
+*always* used because there's no host to match): here a host **is** matched, so
+the active context is used only when the host trusts its core.
 
 Key files: `cmd/entire/cli/auth/data_api.go` (`ResolveDataAPIToken`),
 `cmd/entire/cli/auth/refresh.go` (`NewRefreshingResourceProvider`),
 `internal/entireclient/clusterdiscovery/api_discovery.go` (`DiscoverAPI`,
-`ResolveContextForAPI`, sharing `selectContext` *and* the cores cache with the
-cluster path), `internal/entireclient/discovery/cluster_cores.go`
+`ResolveContextForAPI`, sharing `requireActiveContext` *and* the cores cache with
+the cluster path), `internal/entireclient/discovery/cluster_cores.go`
 (`LoadAPICores`/`ModifyAPICores`). Seams:
 `NewAuthenticatedAPIClient` (activity/trail/search-completion),
 `dispatch/mode_local.go` `lookupResourceToken` (dispatch),
 `search_cmd.go` `resolveSearchToken` (search).
+
+## Account selection
+
+One rule, everywhere a host is matched — git clusters, the data API,
+cluster-addressed control-plane commands, and entire-api cell routing
+(`auth/cell_data_api.go`'s `resolveStoredCellSubject`): **the active context is
+the identity, or the command fails.** `entire auth use <ctx>` is the only lever;
+`/.well-known` decides only whether that identity is *accepted*, never which one
+is *chosen*.
+
+Two implicit tiers used to sit underneath — "the sole eligible context", and an
+ambiguity error when several were eligible. Both are gone. They made the acting
+identity depend on what else happened to be stored, so adding a second login
+could silently change which account a command ran as, and the same command could
+act as different identities on two machines. For "whose credentials is this
+running under?", a predictable error beats a convenient guess.
+
+Multiple saved logins are still fully supported — `auth contexts`, `auth use`,
+and `logout --all-contexts` are unchanged. What changed is that switching is
+always explicit.
+
+Because "not logged in" is actively misleading for a user who *is* logged in,
+just to another federation, the error distinguishes what the user can do about
+it. Two independent facts pick the message
+(`clusterdiscovery.renderUnusableActiveContext`): whether an active context
+exists, and whether any saved login is eligible.
+
+| Active context | A saved login is eligible | Message |
+| --- | --- | --- |
+| yes | yes | names the active login, lists the eligible ones (sorted), points at `entire auth use` |
+| yes | no | names the active login, adds "no other saved login does either", then the trusted servers and `entire login --server <url>` |
+| no | yes | "no active auth context for …", lists the eligible ones, points at `entire auth use` |
+| no | no | the login hint, plus the trusted servers and `entire login --server <url>` |
+
+The two no-active-context rows must not use the "does not accept your active
+login" phrasing — there is no active login to reject, and a dangling
+`current_context` lands there.
+
+The advertised servers are named whenever no saved login fits, because they are
+then the only actionable detail: bare `entire login` re-authenticates against the
+default server, which for a resource in another federation reproduces the same
+failure.
+
+Key file: `internal/entireclient/clusterdiscovery/resolve.go`
+(`requireActiveContext` — the single home for this policy, plus
+`contextEligible`, the one eligibility predicate shared by the accept decision
+and the candidate list).

--- a/docs/architecture/upstream-host-resolution.md
+++ b/docs/architecture/upstream-host-resolution.md
@@ -133,10 +133,34 @@ the cluster path), `internal/entireclient/discovery/cluster_cores.go`
 
 One rule, everywhere a host is matched — git clusters, the data API,
 cluster-addressed control-plane commands, and entire-api cell routing
-(`auth/cell_data_api.go`'s `resolveStoredCellSubject`): **the active context is
-the identity, or the command fails.** `entire auth use <ctx>` is the only lever;
-`/.well-known` decides only whether that identity is *accepted*, never which one
-is *chosen*.
+(`auth/cell_data_api.go`'s `resolveStoredCellSubject`): **the identity is the one
+the user selected, or the command fails.** `/.well-known` decides only whether
+that identity is *accepted*, never which one is *chosen*.
+
+Selection resolves in one place, `contexts.File.Active`, with this precedence:
+
+| Source | Scope | Use it for |
+| --- | --- | --- |
+| `--context <name>` | one command | a single cross-federation command |
+| `$ENTIRE_CONTEXT` | one process/shell | git operations, hooks, a whole shell session |
+| `current_context` (`entire auth use`) | persistent, machine-wide | your normal default |
+
+The two overrides exist because `auth use` is the wrong tool for a one-off: it
+mutates state shared by every shell, worktree, and background git hook on the
+machine, so forgetting to switch back silently retargets the next `git push`. And
+a flag alone is not enough — git invokes `git-remote-entire` itself, so
+`ENTIRE_CONTEXT=staging git push` is the *only* way to scope a git operation.
+
+An override naming no saved context is a hard error
+(`contexts.UnknownContextError`), never a fall-through to `current_context`:
+running as an identity other than the one asked for would succeed silently as the
+wrong account. It is reported before any trust check, because "that context
+doesn't exist" and "that context isn't trusted here" are different mistakes.
+
+Every consumer resolves through `Active`, so the selection is coherent: `auth
+status` reports it, `auth contexts` marks it, and `logout` revokes and deletes
+*that* login. Resolving the removal target separately from the revocation target
+would end one session server-side while deleting another's local credentials.
 
 Two implicit tiers used to sit underneath — "the sole eligible context", and an
 ambiguity error when several were eligible. Both are gone. They made the acting
@@ -155,16 +179,20 @@ it. Two independent facts pick the message
 (`clusterdiscovery.renderUnusableActiveContext`): whether an active context
 exists, and whether any saved login is eligible.
 
-| Active context | A saved login is eligible | Message |
+| Identity resolved | A saved login is eligible | Message |
 | --- | --- | --- |
-| yes | yes | names the active login, lists the eligible ones (sorted), points at `entire auth use` |
-| yes | no | names the active login, adds "no other saved login does either", then the trusted servers and `entire login --server <url>` |
-| no | yes | "no active auth context for …", lists the eligible ones, points at `entire auth use` |
+| yes | yes | names the rejected login, lists the eligible ones (sorted), points at the switch |
+| yes | no | names the rejected login, adds "no other saved login does either", then the trusted servers and `entire login --server <url>` |
+| no | yes | "no active auth context for …", lists the eligible ones, points at the switch |
 | no | no | the login hint, plus the trusted servers and `entire login --server <url>` |
 
-The two no-active-context rows must not use the "does not accept your active
-login" phrasing — there is no active login to reject, and a dangling
-`current_context` lands there.
+The two no-identity rows must not use the "does not accept your active login"
+phrasing — there is no active login to reject, and a dangling `current_context`
+lands there.
+
+"Points at the switch" also tracks the source: an identity that came from
+`--context` is fixed by changing that argument, not by `entire auth use`, which
+the flag would keep overriding on the next run.
 
 The advertised servers are named whenever no saved login fits, because they are
 then the only actionable detail: bare `entire login` re-authenticates against the

--- a/internal/entireclient/clusterdiscovery/api_discovery.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery.go
@@ -86,14 +86,13 @@ func resolveAPICores(ctx context.Context, cacheDir, apiHost string, httpClient *
 // ResolveContextForAPI picks the local login context to authenticate data-API
 // calls against apiHost.
 //
-// It mirrors ResolveContextForCluster: active context wins when its CoreURL is
-// among the API's trusted issuers, else the sole eligible context, else an
-// explicit-choice / login error — sourcing the trusted issuers from
+// It mirrors ResolveContextForCluster, sharing requireActiveContext: the active
+// context is used when its CoreURL is among the API's trusted issuers, and
+// anything else is an error. It sources those issuers from
 // /.well-known/entire-api.json (cached in api_discovery.json, long TTL,
 // re-fetched on expiry with stale fallback) instead of entire-cluster.json.
-// Account selection is recomputed every call from the live contexts, never
-// persisted. The caller exchanges the chosen context's token for the data host
-// origin (which is the audience the API requires); no audience is read here.
+// The caller exchanges the active context's token for the data host origin
+// (which is the audience the API requires); no audience is read here.
 //
 // When the API doesn't advertise discovery (404 / unreachable / 503 /
 // malformed) and no cache entry exists, the returned error wraps
@@ -115,5 +114,5 @@ func ResolveContextForAPI(ctx context.Context, configDir, cacheDir, apiHost stri
 	if err != nil {
 		return nil, fmt.Errorf("load contexts: %w", err)
 	}
-	return selectContext(f, "API host "+apiHost, trustedIssuers, debugf)
+	return requireActiveContext(f, "API host "+apiHost, trustedIssuers, debugf)
 }

--- a/internal/entireclient/clusterdiscovery/api_discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery_test.go
@@ -170,10 +170,11 @@ func TestResolveContextForAPI(t *testing.T) {
 		assert.Equal(t, "me@us-partial", c.Name)
 	})
 
-	// The cross-core case the slice exists to fix: the active context is a prod
-	// login, but the only context eligible for the partial.to API is the
-	// staging one — pick it without any operator-side configuration.
-	t.Run("sole eligible context used despite unrelated active", func(t *testing.T) {
+	// The `ENTIRE_API_BASE_URL=https://partial.to entire activity` case. It used
+	// to resolve silently to the sole eligible staging login; an env var
+	// changing which account a command runs as is the ambiguity the active
+	// context exists to remove, so it is now an error that names the switch.
+	t.Run("unrelated active context errors naming the eligible login", func(t *testing.T) {
 		t.Parallel()
 		srv := httptest.NewServer(apiHandler(t, "https://us.auth.partial.to", "https://eu.auth.partial.to"))
 		defer srv.Close()
@@ -187,12 +188,14 @@ func TestResolveContextForAPI(t *testing.T) {
 			},
 		}))
 
-		c, err := ResolveContextForAPI(t.Context(), configDir, t.TempDir(), "partial.to", hostPinningClient(t, srv), t.Logf)
-		require.NoError(t, err)
-		assert.Equal(t, "me@staging", c.Name)
+		_, err := ResolveContextForAPI(t.Context(), configDir, t.TempDir(), "partial.to", hostPinningClient(t, srv), t.Logf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "API host partial.to does not accept your active login")
+		assert.Contains(t, err.Error(), "me@staging", "name the login that would work")
+		assert.Contains(t, err.Error(), "entire auth use")
 	})
 
-	t.Run("no eligible context → login hint naming the API host", func(t *testing.T) {
+	t.Run("no eligible context → login hint naming the API host's servers", func(t *testing.T) {
 		t.Parallel()
 		srv := httptest.NewServer(apiHandler(t, "https://us.auth.partial.to"))
 		defer srv.Close()
@@ -206,10 +209,15 @@ func TestResolveContextForAPI(t *testing.T) {
 		_, err := ResolveContextForAPI(t.Context(), configDir, t.TempDir(), "partial.to", hostPinningClient(t, srv), t.Logf)
 		require.Error(t, err)
 		require.NotErrorIs(t, err, ErrDiscoveryUnavailable, "a reachable-but-unmatched API is a real login error, not a fallback case")
-		assert.Contains(t, err.Error(), "no auth context for API host partial.to")
+		assert.Contains(t, err.Error(), "API host partial.to does not accept your active login")
+		assert.Contains(t, err.Error(), "no other saved login does either")
+		assert.Contains(t, err.Error(), "https://us.auth.partial.to", "name the server that would work")
+		assert.Contains(t, err.Error(), "entire login --server")
 	})
 
-	t.Run("ambiguous eligible contexts → explicit-choice error", func(t *testing.T) {
+	// Two eligible contexts are no longer "ambiguous" — the resolver never
+	// picks, so both are simply offered, sorted.
+	t.Run("several eligible contexts are all offered", func(t *testing.T) {
 		t.Parallel()
 		srv := httptest.NewServer(apiHandler(t, "https://us.auth.partial.to"))
 		defer srv.Close()
@@ -219,15 +227,15 @@ func TestResolveContextForAPI(t *testing.T) {
 			CurrentContext: "me@prod",
 			Contexts: []*contexts.Context{
 				{Name: "me@prod", CoreURL: "https://us.auth.entire.io", Handle: "me", KeychainService: "kc:prod"},
-				{Name: "alice@partial", CoreURL: "https://us.auth.partial.to", Handle: "alice", KeychainService: "kc:a"},
 				{Name: "bob@partial", CoreURL: "https://us.auth.partial.to", Handle: "bob", KeychainService: "kc:b"},
+				{Name: "alice@partial", CoreURL: "https://us.auth.partial.to", Handle: "alice", KeychainService: "kc:a"},
 			},
 		}))
 
 		_, err := ResolveContextForAPI(t.Context(), configDir, t.TempDir(), "partial.to", hostPinningClient(t, srv), t.Logf)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "multiple login contexts")
 		assert.Contains(t, err.Error(), "API host partial.to")
+		assert.Contains(t, err.Error(), "alice@partial, bob@partial", "sorted, not in stored order")
 	})
 
 	t.Run("unadvertised → ErrDiscoveryUnavailable for fallback", func(t *testing.T) {

--- a/internal/entireclient/clusterdiscovery/discovery.go
+++ b/internal/entireclient/clusterdiscovery/discovery.go
@@ -146,14 +146,55 @@ func Discover(ctx context.Context, clusterHost string, c *http.Client, debugf De
 }
 
 // renderLoginHint formats a fatal-ready "no auth context for <subject>"
-// message telling the operator to run `entire login`. subject is a noun
-// phrase like "cluster nyc.entire.io" or "API host partial.to" so the same
-// hint serves both the git-cluster and data-API resolvers.
+// message telling the operator how to get one. subject is a noun phrase like
+// "cluster nyc.entire.io" or "API host partial.to" so the same hint serves both
+// the git-cluster and data-API resolvers.
 //
-// We'll display coreURLs (2nd param) to the user as a hint at a later stage.
-func renderLoginHint(subject string, _ []string) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "no auth context for %s.\n", subject)
-	fmt.Fprint(&b, "Log in with `entire login`, then re-run your command.")
-	return b.String()
+// The advertised login servers are named because for anything outside the
+// default federation they are the only actionable part: bare `entire login`
+// re-authenticates against api.DefaultAuthBaseURL, which for a resource that
+// doesn't trust that server reproduces the very failure being reported. Callers
+// reach this with no active login, or with one no saved login can replace, and
+// in both cases the remedy is a login against one of these servers.
+//
+// The instruction half is shared with the "active login rejected and nothing
+// saved fits" error, which supplies its own first line — see
+// renderLoginInstruction.
+func renderLoginHint(subject string, coreURLs []string) string {
+	return fmt.Sprintf("no auth context for %s.\n%s", subject, renderLoginInstruction(coreURLs))
+}
+
+// renderLoginInstruction is the actionable tail of a login hint: the servers the
+// resource trusts, and the command to obtain a login from one of them. Split out
+// so callers that have already explained the situation in their own words can
+// append the remedy without repeating "no auth context for <subject>".
+//
+// coreURLs is normalised and de-duplicated so a resource advertising the same
+// core twice (or with an inconsistent trailing slash) doesn't repeat itself, and
+// the order is the resource's own — its preferred core first.
+func renderLoginInstruction(coreURLs []string) string {
+	servers := trustedLoginServers(coreURLs)
+	if len(servers) == 0 {
+		return "Log in with `entire login`, then re-run your command."
+	}
+	return fmt.Sprintf("It trusts these login servers: %s\nLog in with `entire login --server <url>`, then re-run your command.",
+		strings.Join(servers, ", "))
+}
+
+// trustedLoginServers normalises a resource's advertised cores for display
+// through normalizeCoreURL — the same folding the eligibility check uses, so a
+// server echoed back as trusted is one that would actually be accepted — then
+// drops blanks and duplicates while preserving the advertised order.
+func trustedLoginServers(coreURLs []string) []string {
+	seen := make(map[string]bool, len(coreURLs))
+	out := make([]string, 0, len(coreURLs))
+	for _, coreURL := range coreURLs {
+		normalized := normalizeCoreURL(coreURL)
+		if normalized == "" || seen[normalized] {
+			continue
+		}
+		seen[normalized] = true
+		out = append(out, normalized)
+	}
+	return out
 }

--- a/internal/entireclient/clusterdiscovery/discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/discovery_test.go
@@ -122,3 +122,12 @@ func TestDiscover(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+// TestTrustedLoginServers normalises the advertised cores for display: whitespace
+// and trailing slashes trimmed, blanks dropped, duplicates collapsed, advertised
+// order kept (the resource lists its preferred core first).
+func TestTrustedLoginServers(t *testing.T) {
+	t.Parallel()
+	got := trustedLoginServers([]string{"https://us.entire.io/", " ", " https://eu.entire.io ", "https://us.entire.io", ""})
+	assert.Equal(t, []string{"https://us.entire.io", "https://eu.entire.io"}, got)
+}

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -25,10 +25,11 @@ import (
 //     miss or expiry we re-fetch; if the re-fetch fails we fall back to
 //     the stale cached cores rather than break the op.
 //
-//   - Which of the user's accounts to use — the active context
-//     (current_context), and nothing else. The cluster's cores only decide
-//     whether that identity is accepted; see requireActiveContext for the
-//     policy and why it has no fallback tiers.
+//   - Which of the user's accounts to use — whichever the user selected, via
+//     `--context`/$ENTIRE_CONTEXT for one invocation or the stored
+//     current_context otherwise, and nothing else. The cluster's cores only
+//     decide whether that identity is accepted; see requireActiveContext for
+//     the policy and why it has no fallback tiers.
 //
 // In particular we never fall back to an active context whose core does NOT
 // front the cluster: the cluster would reject the exchanged token as "unknown
@@ -213,10 +214,11 @@ func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, requ
 // "API host partial.to") used in messages, so the same rule serves the
 // git-cluster, data-API, and cell resolvers.
 //
-// The policy: `entire auth use <name>` is the only thing that decides which
-// identity acts; a resource's advertised issuers decide only whether that
-// identity is *accepted*, never which one is *chosen*. So this validates, it
-// does not choose — hence the name.
+// The policy: the user decides which identity acts — `--context` or
+// $ENTIRE_CONTEXT for one invocation, else `entire auth use` for the stored
+// default. A resource's advertised issuers decide only whether that identity is
+// *accepted*, never which one is *chosen*. So this validates, it does not
+// choose — hence the name.
 //
 // Two implicit tiers used to sit underneath: "the sole eligible context", and an
 // ambiguity error when several were eligible. Both are gone, because they made
@@ -228,15 +230,31 @@ func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, requ
 //
 // See docs/architecture/upstream-host-resolution.md#account-selection.
 func requireActiveContext(f *contexts.File, subject string, coreURLs []string, debugf DebugFunc) (*contexts.Context, error) {
-	current := f.Find(f.CurrentContext)
-	if current != nil && contextEligible(current, coreURLs) {
-		debugf("%s -> active context %s", subject, current.Name)
-		return current, nil
+	// An explicit --context/$ENTIRE_CONTEXT naming no saved login fails here,
+	// before any eligibility talk: "that context doesn't exist" and "that context
+	// isn't trusted here" are different mistakes with different fixes.
+	sel, err := f.Active()
+	if err != nil {
+		return nil, err //nolint:wrapcheck // UnknownContextError is already a complete operator message
 	}
-	if current != nil {
-		debugf("%s -> active context %s (%s) is not trusted here", subject, current.Name, current.CoreURL)
+	if sel.Context != nil && contextEligible(sel.Context, coreURLs) {
+		debugf("%s -> %s", subject, describeSelection(sel))
+		return sel.Context, nil
 	}
-	return nil, errors.New(renderUnusableActiveContext(subject, current, eligibleContexts(f, coreURLs), coreURLs))
+	if sel.Context != nil {
+		debugf("%s -> %s (%s) is not trusted here", subject, describeSelection(sel), sel.Context.CoreURL)
+	}
+	return nil, errors.New(renderUnusableActiveContext(subject, sel, eligibleContexts(f, coreURLs), coreURLs))
+}
+
+// describeSelection labels a resolved identity for debug output, naming the
+// mechanism that chose it so a trace answers "why this login?" and not just
+// "which login?".
+func describeSelection(sel contexts.Selection) string {
+	if sel.Explicit() {
+		return fmt.Sprintf("context %s (from %s)", sel.Context.Name, sel.Source)
+	}
+	return "active context " + sel.Context.Name
 }
 
 // contextEligible reports whether c's core is among the resource's advertised
@@ -295,36 +313,51 @@ func eligibleContexts(f *contexts.File, coreURLs []string) []*contexts.Context {
 // no-identity cases must NOT use that phrasing, which is why they get their own
 // first lines rather than an interpolated-away clause.
 //
+// The remedy also tracks where the identity came from: someone who passed
+// `--context` needs to change that argument, not run `auth use`, which would
+// leave the flag still overriding it on the next run.
+//
 // Returns a string, matching renderLoginHint and leaving the single errors.New
 // to the caller.
-func renderUnusableActiveContext(subject string, current *contexts.Context, eligible []*contexts.Context, coreURLs []string) string {
-	const switchHint = "Switch with `entire auth use <context>`, then re-run your command."
+func renderUnusableActiveContext(subject string, sel contexts.Selection, eligible []*contexts.Context, coreURLs []string) string {
 	names := strings.Join(contextNames(eligible), ", ")
+	switchHint := "Switch with `entire auth use <context>`, then re-run your command."
+	if sel.Explicit() {
+		switchHint = fmt.Sprintf("Name one with `--context <context>` (or %s), then re-run your command.", contexts.EnvContextVar)
+	}
 	switch {
-	case current == nil && len(eligible) > 0:
-		// current_context unset or dangling, but a saved login would work.
+	case sel.Context == nil && len(eligible) > 0:
+		// current_context unset or dangling, but a saved login would work. An
+		// explicit selection can't land here: it either matched or already errored.
 		return fmt.Sprintf("no active auth context for %s.\nThese saved logins can authenticate it: %s\n%s",
 			subject, names, switchHint)
-	case current == nil:
+	case sel.Context == nil:
 		return renderLoginHint(subject, coreURLs)
 	case len(eligible) > 0:
-		return fmt.Sprintf("%s does not accept your active login %s.\nThese saved logins can authenticate it: %s\n%s",
-			subject, activeLoginLabel(current), names, switchHint)
+		return fmt.Sprintf("%s does not accept %s.\nThese saved logins can authenticate it: %s\n%s",
+			subject, loginLabel(sel), names, switchHint)
 	default:
-		return fmt.Sprintf("%s does not accept your active login %s, and no other saved login does either.\n%s",
-			subject, activeLoginLabel(current), renderLoginInstruction(coreURLs))
+		return fmt.Sprintf("%s does not accept %s, and no other saved login does either.\n%s",
+			subject, loginLabel(sel), renderLoginInstruction(coreURLs))
 	}
 }
 
-// activeLoginLabel renders `"name" (core)` for a context known to be non-nil,
-// degrading to `"name"` when its metadata carries no core URL rather than
+// loginLabel names the rejected login and how it was chosen — "your active
+// login" reads as a mistake in stored state, which is wrong when the user named
+// the context on this very command line.
+//
+// The core URL degrades away when the metadata carries none, rather than
 // emitting a dangling `()`. A core-less context is never eligible, so it always
 // arrives here.
-func activeLoginLabel(c *contexts.Context) string {
-	if core := normalizeCoreURL(c.CoreURL); core != "" {
-		return fmt.Sprintf("%q (%s)", c.Name, core)
+func loginLabel(sel contexts.Selection) string {
+	role := "your active login"
+	if sel.Explicit() {
+		role = "the login selected by " + sel.Source
 	}
-	return fmt.Sprintf("%q", c.Name)
+	if core := normalizeCoreURL(sel.Context.CoreURL); core != "" {
+		return fmt.Sprintf("%s %q (%s)", role, sel.Context.Name, core)
+	}
+	return fmt.Sprintf("%s %q", role, sel.Context.Name)
 }
 
 // contextNames returns the contexts' names, sorted so error messages are stable

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -268,6 +268,14 @@ func describeSelection(sel contexts.Selection) string {
 // with no CoreURL is never eligible: it names no issuer to match, and without
 // this guard a resource advertising a blank core would match it.
 func contextEligible(c *contexts.Context, coreURLs []string) bool {
+	// A nil entry comes from a hand-edited or truncated contexts.json (`[null]`),
+	// the same trust boundary deleteContextKeychain's blank-audience guard
+	// contemplates. It is never eligible, and must not panic: eligibleContexts
+	// walks every stored entry on the failure path, and that path runs inside
+	// git-remote-entire during `git push`.
+	if c == nil {
+		return false
+	}
 	want := normalizeCoreURL(c.CoreURL)
 	if want == "" {
 		return false

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/entireio/cli/internal/entireclient/contexts"
@@ -25,25 +25,13 @@ import (
 //     miss or expiry we re-fetch; if the re-fetch fails we fall back to
 //     the stale cached cores rather than break the op.
 //
-//   - Which of the user's accounts to use — recomputed every call from the
-//     live contexts, never persisted. So a user with several accounts is
-//     never silently pinned to one identity.
+//   - Which of the user's accounts to use — the active context
+//     (current_context), and nothing else. The cluster's cores only decide
+//     whether that identity is accepted; see requireActiveContext for the
+//     policy and why it has no fallback tiers.
 //
-// Account selection (selectContext):
-//
-//  1. If the active context (current_context) is issued by one of the
-//     cluster's cores, use it. This is the explicit lever: `entire auth
-//     use <name>` chooses the identity for every cluster that context's
-//     core fronts.
-//  2. Otherwise gather every local context eligible for the cluster (its
-//     CoreURL is among the advertised cores):
-//     - exactly one  → use it (the common single-account case);
-//     - none         → error with the login hint listing the cluster's cores;
-//     - more than one → error asking the user to pick with `entire auth use`,
-//     rather than silently guessing an account.
-//
-// We never fall back to an active context whose core does NOT front the
-// cluster: the cluster would reject the exchanged token as "unknown
+// In particular we never fall back to an active context whose core does NOT
+// front the cluster: the cluster would reject the exchanged token as "unknown
 // cluster_host", and silently authenticating a staging identity against a
 // prod cluster (or vice versa) is exactly the confusion the /.well-known
 // lookup exists to prevent.
@@ -99,7 +87,7 @@ func resolveClusterAuth(ctx context.Context, configDir, cacheDir, clusterHost st
 		return nil, err
 	}
 
-	selected, err := selectContext(f, "cluster "+clusterHost, entry.CoreURLs, debugf)
+	selected, err := requireActiveContext(f, "cluster "+clusterHost, entry.CoreURLs, debugf)
 	if err != nil {
 		return nil, err
 	}
@@ -219,64 +207,135 @@ func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, requ
 		}, debugf)
 }
 
-// selectContext applies the account-selection rules over a resource's
-// advertised trusted issuers. subject is a noun phrase identifying the
-// resource ("cluster nyc.entire.io" / "API host partial.to") used in
-// messages, so the same rules serve both the git-cluster and data-API
-// resolvers. See ResolveContextForCluster for the rationale.
-func selectContext(f *contexts.File, subject string, coreURLs []string, debugf DebugFunc) (*contexts.Context, error) {
-	eligible := eligibleContexts(f, coreURLs)
-
-	// 1. Active context wins when it's eligible for this resource.
-	if current := f.Find(f.CurrentContext); current != nil {
-		for _, c := range eligible {
-			if c.Name == current.Name {
-				debugf("%s -> active context %s", subject, current.Name)
-				return current, nil
-			}
-		}
+// requireActiveContext resolves the login context for a resource from the ACTIVE
+// context alone, and is the one place the CLI's account-selection policy lives.
+// subject is a noun phrase identifying the resource ("cluster nyc.entire.io" /
+// "API host partial.to") used in messages, so the same rule serves the
+// git-cluster, data-API, and cell resolvers.
+//
+// The policy: `entire auth use <name>` is the only thing that decides which
+// identity acts; a resource's advertised issuers decide only whether that
+// identity is *accepted*, never which one is *chosen*. So this validates, it
+// does not choose — hence the name.
+//
+// Two implicit tiers used to sit underneath: "the sole eligible context", and an
+// ambiguity error when several were eligible. Both are gone, because they made
+// the acting identity depend on what *else* happened to be stored — adding a
+// second login could silently change which account a command ran as, and the
+// same command could act as different identities on two machines. For a question
+// as consequential as "whose credentials is this running under?", a predictable
+// error beats a convenient guess.
+//
+// See docs/architecture/upstream-host-resolution.md#account-selection.
+func requireActiveContext(f *contexts.File, subject string, coreURLs []string, debugf DebugFunc) (*contexts.Context, error) {
+	current := f.Find(f.CurrentContext)
+	if current != nil && contextEligible(current, coreURLs) {
+		debugf("%s -> active context %s", subject, current.Name)
+		return current, nil
 	}
-
-	// 2. Otherwise the eligible set decides.
-	switch len(eligible) {
-	case 0:
-		return nil, errors.New(renderLoginHint(subject, coreURLs))
-	case 1:
-		debugf("%s -> sole eligible context %s", subject, eligible[0].Name)
-		return eligible[0], nil
-	default:
-		return nil, ambiguousContextError(subject, eligible)
+	if current != nil {
+		debugf("%s -> active context %s (%s) is not trusted here", subject, current.Name, current.CoreURL)
 	}
+	return nil, errors.New(renderUnusableActiveContext(subject, current, eligibleContexts(f, coreURLs), coreURLs))
 }
 
-// eligibleContexts returns the local contexts whose core is among coreURLs,
-// de-duplicated by name. Order is unspecified — callers either use the sole
-// element or report the whole set, never index [0] as a silent winner.
+// contextEligible reports whether c's core is among the resource's advertised
+// trusted issuers. It is the single eligibility predicate: both the accept
+// decision and the candidate list reported on failure go through it, so the two
+// can never disagree about what "eligible" means.
+//
+// Comparison is trailing-slash- and whitespace-insensitive, matching
+// trustedLoginServers' normalisation of the same URLs — a core advertised with
+// padding must not be rejected here and then echoed back as trusted. A context
+// with no CoreURL is never eligible: it names no issuer to match, and without
+// this guard a resource advertising a blank core would match it.
+func contextEligible(c *contexts.Context, coreURLs []string) bool {
+	want := normalizeCoreURL(c.CoreURL)
+	if want == "" {
+		return false
+	}
+	return slices.ContainsFunc(coreURLs, func(coreURL string) bool {
+		return normalizeCoreURL(coreURL) == want
+	})
+}
+
+// normalizeCoreURL folds a core URL to the form core URLs are compared and
+// displayed in: whitespace and trailing slashes are insignificant, so
+// `https://core.example/ ` and `https://core.example` are the same issuer. The
+// single normaliser behind contextEligible, activeLoginLabel, and
+// trustedLoginServers, so the accept decision and every message agree.
+func normalizeCoreURL(coreURL string) string {
+	return strings.TrimRight(strings.TrimSpace(coreURL), "/")
+}
+
+// eligibleContexts returns the saved contexts this resource would accept, for
+// reporting only — requireActiveContext never picks from it. Filtering f.Contexts
+// once (rather than iterating coreURLs and collecting per-issuer matches) makes
+// duplicates structurally impossible, so no de-duplication is needed even when a
+// resource advertises the same core twice.
 func eligibleContexts(f *contexts.File, coreURLs []string) []*contexts.Context {
-	seen := make(map[string]bool)
 	var out []*contexts.Context
-	for _, coreURL := range coreURLs {
-		for _, c := range f.ContextsForIssuer(coreURL) {
-			if !seen[c.Name] {
-				seen[c.Name] = true
-				out = append(out, c)
-			}
+	for _, c := range f.Contexts {
+		if contextEligible(c, coreURLs) {
+			out = append(out, c)
 		}
 	}
 	return out
 }
 
-// ambiguousContextError is returned when more than one local context could
-// authenticate against the resource and none is active. We refuse to guess —
-// the user picks explicitly. Names are sorted so the message is stable.
-func ambiguousContextError(subject string, eligible []*contexts.Context) error {
-	names := make([]string, len(eligible))
-	for i, c := range eligible {
+// renderUnusableActiveContext explains why no identity is available, in the
+// terms of what the user can actually do about it — a wrong remedy here is a
+// dead end. Two independent facts pick the message: whether an identity resolved
+// at all (is there a login to report as rejected?) and whether any saved login
+// is eligible (is the fix a local switch, or a new login?).
+//
+// Naming the login matters because "not logged in" is actively misleading for
+// someone who IS logged in, just to a federation this resource doesn't trust; it
+// sends them to `entire login`, which reproduces the same failure. The
+// no-identity cases must NOT use that phrasing, which is why they get their own
+// first lines rather than an interpolated-away clause.
+//
+// Returns a string, matching renderLoginHint and leaving the single errors.New
+// to the caller.
+func renderUnusableActiveContext(subject string, current *contexts.Context, eligible []*contexts.Context, coreURLs []string) string {
+	const switchHint = "Switch with `entire auth use <context>`, then re-run your command."
+	names := strings.Join(contextNames(eligible), ", ")
+	switch {
+	case current == nil && len(eligible) > 0:
+		// current_context unset or dangling, but a saved login would work.
+		return fmt.Sprintf("no active auth context for %s.\nThese saved logins can authenticate it: %s\n%s",
+			subject, names, switchHint)
+	case current == nil:
+		return renderLoginHint(subject, coreURLs)
+	case len(eligible) > 0:
+		return fmt.Sprintf("%s does not accept your active login %s.\nThese saved logins can authenticate it: %s\n%s",
+			subject, activeLoginLabel(current), names, switchHint)
+	default:
+		return fmt.Sprintf("%s does not accept your active login %s, and no other saved login does either.\n%s",
+			subject, activeLoginLabel(current), renderLoginInstruction(coreURLs))
+	}
+}
+
+// activeLoginLabel renders `"name" (core)` for a context known to be non-nil,
+// degrading to `"name"` when its metadata carries no core URL rather than
+// emitting a dangling `()`. A core-less context is never eligible, so it always
+// arrives here.
+func activeLoginLabel(c *contexts.Context) string {
+	if core := normalizeCoreURL(c.CoreURL); core != "" {
+		return fmt.Sprintf("%q (%s)", c.Name, core)
+	}
+	return fmt.Sprintf("%q", c.Name)
+}
+
+// contextNames returns the contexts' names, sorted so error messages are stable
+// across saves and across runs.
+func contextNames(cs []*contexts.Context) []string {
+	names := make([]string, len(cs))
+	for i, c := range cs {
 		names[i] = c.Name
 	}
-	sort.Strings(names)
-	return fmt.Errorf("multiple login contexts can authenticate against %s (%s); choose one with `entire auth use <context>` and re-run",
-		subject, strings.Join(names, ", "))
+	slices.Sort(names)
+	return names
 }
 
 // formatDiscoveryError turns a Discover error into the message

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -55,10 +55,12 @@ func TestResolve_ActiveContextWinsWhenEligible(t *testing.T) {
 	assert.Equal(t, "bob@eu", c.Name, "active eligible context must win over other same-core accounts")
 }
 
-// TestResolve_SoleEligibleContextUsedDespiteUnrelatedActive: the active
-// context is on an unrelated core, but the user has exactly one context
-// eligible for the cluster — use it (the 99% single-account case).
-func TestResolve_SoleEligibleContextUsedDespiteUnrelatedActive(t *testing.T) {
+// TestResolve_UnrelatedActiveContextErrorsNamingEligibleLogin: the active
+// context is on an unrelated core while exactly one saved context is eligible.
+// The old resolver silently used that sole eligible context; we now refuse to
+// substitute an identity the user didn't select, and name it instead so the
+// switch is one obvious command.
+func TestResolve_UnrelatedActiveContextErrorsNamingEligibleLogin(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
 	defer srv.Close()
@@ -72,15 +74,22 @@ func TestResolve_SoleEligibleContextUsedDespiteUnrelatedActive(t *testing.T) {
 		},
 	}))
 
-	c, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
-	require.NoError(t, err)
-	assert.Equal(t, "prod-eu", c.Name)
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not accept your active login")
+	assert.Contains(t, err.Error(), `"paul@unrelated"`, "the message must name the active login, or the mismatch is invisible")
+	assert.Contains(t, err.Error(), "https://eu.auth.partial.to", "and the core it belongs to")
+	assert.Contains(t, err.Error(), "prod-eu", "and the saved login that would work")
+	assert.Contains(t, err.Error(), "entire auth use")
+	// A local switch is the fix here, so don't send the user through a login flow.
+	assert.NotContains(t, err.Error(), "entire login")
 }
 
-// TestResolve_AmbiguousMultipleEligibleErrors: two same-core accounts are
-// eligible and neither is active — refuse to guess, list both, and tell the
-// user to pick. This is the footgun this redesign closes.
-func TestResolve_AmbiguousMultipleEligibleErrors(t *testing.T) {
+// TestResolve_UnrelatedActiveContextNamesAllEligibleLogins: what used to be the
+// "ambiguous" case is now the same case as a single candidate — the resolver
+// never picks, so two eligible contexts are simply two names to offer. Sorted,
+// so the message is stable across saves.
+func TestResolve_UnrelatedActiveContextNamesAllEligibleLogins(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(coresHandler(t, nil, "https://core-us.entire.io"))
 	defer srv.Close()
@@ -97,15 +106,16 @@ func TestResolve_AmbiguousMultipleEligibleErrors(t *testing.T) {
 
 	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "cluster1.entire.io", hostPinningClient(t, srv), t.Logf)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "multiple login contexts")
-	assert.Contains(t, err.Error(), "admin@core-us")
-	assert.Contains(t, err.Error(), "alice@core-us")
+	assert.Contains(t, err.Error(), "admin@core-us, alice@core-us", "candidates must be listed in sorted order")
 	assert.Contains(t, err.Error(), "entire auth use")
 }
 
-// TestResolve_NoEligibleContextReturnsLoginHint: discovery succeeds but the
-// user has no context for any advertised core.
-func TestResolve_NoEligibleContextReturnsLoginHint(t *testing.T) {
+// TestResolve_ActiveContextIneligibleAndNothingElseFits: an active context that
+// the cluster doesn't trust, with no saved alternative. The user needs a new
+// login, so the hint must name the servers the cluster actually trusts —
+// otherwise bare `entire login` re-authenticates against the default server and
+// reproduces this same error.
+func TestResolve_ActiveContextIneligibleAndNothingElseFits(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
 	defer srv.Close()
@@ -120,12 +130,90 @@ func TestResolve_NoEligibleContextReturnsLoginHint(t *testing.T) {
 
 	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no auth context for cluster aws-eu-central-1.entire.io")
-	assert.Contains(t, err.Error(), "entire login")
-	// Advertised login servers + the `entire auth use` hint are intentionally
-	// squashed for now (see renderLoginHint).
-	assert.NotContains(t, err.Error(), "https://eu.auth.entire.io")
+	assert.Contains(t, err.Error(), `"staging"`, "name the active login that was rejected")
+	assert.Contains(t, err.Error(), "no other saved login does either")
+	assert.Contains(t, err.Error(), "https://eu.auth.entire.io", "the trusted server is the only actionable detail")
+	// The situation is already explained in the first line; don't also assert
+	// "no auth context for <cluster>", which reads as logged-out.
+	assert.NotContains(t, err.Error(), "no auth context for")
+	assert.Contains(t, err.Error(), "entire login --server")
+	// Nothing local to switch to, so offering `auth use` would be a dead end.
 	assert.NotContains(t, err.Error(), "entire auth use")
+}
+
+// TestResolve_NoActiveContextReturnsLoginHint: genuinely logged out (no
+// current_context) — the plain login hint, still naming the cluster's servers.
+func TestResolve_NoActiveContextReturnsLoginHint(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	_, err := ResolveContextForCluster(t.Context(), t.TempDir(), t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no auth context for cluster aws-eu-central-1.entire.io")
+	assert.Contains(t, err.Error(), "https://eu.auth.entire.io")
+	assert.Contains(t, err.Error(), "entire login --server")
+	// With no active login there is nothing to report as rejected.
+	assert.NotContains(t, err.Error(), "does not accept your active login")
+}
+
+// TestResolve_DanglingCurrentContextIsNotAnIdentity: current_context naming a
+// context that no longer exists must not resolve to some other saved login. The
+// saved login is offered, not used.
+func TestResolve_DanglingCurrentContextIsNotAnIdentity(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "deleted-long-ago",
+		Contexts: []*contexts.Context{
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}))
+
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prod-eu", "offer the eligible login")
+	assert.Contains(t, err.Error(), "entire auth use")
+}
+
+// TestResolve_ContextWithoutCoreURLIsNeverEligible: a context carrying no
+// issuer matches nothing, even against a resource advertising an empty core URL.
+// Without the guard, normalizeCoreURL("") == normalizeCoreURL("") would make a
+// blank context authenticate anything.
+//
+// It must also not be OFFERED as a candidate. The accept check and the candidate
+// list are one predicate for this reason: when they were two, this input
+// produced "does not accept your active login \"blank\". These saved logins can
+// authenticate it: blank" — telling the user to switch to the login they were
+// already on.
+func TestResolve_ContextWithoutCoreURLIsNeverEligible(t *testing.T) {
+	t.Parallel()
+	f := &contexts.File{
+		CurrentContext: "blank",
+		Contexts:       []*contexts.Context{{Name: "blank", Handle: "paul", KeychainService: "kc:blank"}},
+	}
+	_, err := requireActiveContext(f, "cluster c.entire.io", []string{""}, t.Logf)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "These saved logins can authenticate it",
+		"a context rejected by the accept check must not be offered as a candidate")
+	assert.NotContains(t, err.Error(), "entire auth use")
+}
+
+// TestResolve_EligibilityIgnoresWhitespaceAndTrailingSlash: the accept check and
+// the trusted-server list share one normaliser, so a padded advertised core is
+// accepted rather than rejected-then-echoed-back-as-trusted.
+func TestResolve_EligibilityIgnoresWhitespaceAndTrailingSlash(t *testing.T) {
+	t.Parallel()
+	f := &contexts.File{
+		CurrentContext: "eu",
+		Contexts:       []*contexts.Context{{Name: "eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:eu"}},
+	}
+	c, err := requireActiveContext(f, "cluster c.entire.io", []string{" https://eu.auth.entire.io/ "}, t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "eu", c.Name)
 }
 
 // TestResolve_CoresCachedAcrossCalls: the first call hits /.well-known and

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -546,3 +546,49 @@ func TestResolve_UnknownOverrideFailsBeforeEligibility(t *testing.T) {
 	assert.Contains(t, err.Error(), "prod-eu", "list what is actually saved")
 	assert.NotContains(t, err.Error(), "does not accept")
 }
+
+// TestResolve_NilStoredContextDoesNotPanic: a hand-edited or truncated
+// contexts.json can contain `{"contexts":[null]}`. Every reader of f.Contexts
+// must skip it rather than dereference it — this path runs inside
+// git-remote-entire during `git push`, where a panic is the worst outcome
+// available.
+//
+// The failure path is the exposed one: eligibleContexts walks every stored entry
+// to build the candidate list, so the nil is reached even though no context can
+// possibly match.
+func TestResolve_NilStoredContextDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	f := &contexts.File{
+		CurrentContext: "gone",
+		Contexts: []*contexts.Context{
+			nil,
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}
+
+	// Empty coreURLs is the case the old loop shape never dereferenced at all.
+	_, err := requireActiveContext(f, "cluster c.entire.io", nil, t.Logf)
+	require.Error(t, err)
+
+	// And with a matching core, the nil entry must be skipped while the real one
+	// is still offered.
+	_, err = requireActiveContext(f, "cluster c.entire.io", []string{"https://eu.auth.entire.io"}, t.Logf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prod-eu", "the valid entry is still a candidate")
+}
+
+// A nil entry must also not panic the selection itself, which resolves through
+// contexts.File.Find before any eligibility check.
+func TestResolve_NilStoredContextIsSelectable(t *testing.T) {
+	t.Parallel()
+	f := &contexts.File{
+		CurrentContext: "prod-eu",
+		Contexts: []*contexts.Context{
+			nil,
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}
+	c, err := requireActiveContext(f, "cluster c.entire.io", []string{"https://eu.auth.entire.io"}, t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c.Name)
+}

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -463,3 +463,86 @@ func TestResolve_503(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not advertise any trusted login servers")
 	assert.Contains(t, err.Error(), "cluster administrator")
 }
+
+// TestResolve_ContextOverrideSelectsWithoutMutatingState: --context acts as a
+// saved login for one invocation. This is what makes cross-federation work
+// possible without `entire auth use`, whose effect is global and sticky — it
+// would retarget every other terminal, worktree, and background git hook on the
+// machine until switched back.
+//
+// Mutates the process-wide override, so no t.Parallel.
+func TestResolve_ContextOverrideSelectsWithoutMutatingState(t *testing.T) {
+	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	stored := &contexts.File{
+		CurrentContext: "paul@unrelated",
+		Contexts: []*contexts.Context{
+			{Name: "paul@unrelated", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:unrelated"},
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}
+	require.NoError(t, contexts.Save(configDir, stored))
+
+	contexts.SetFlagOverrideForTest(t, "prod-eu")
+	c, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c.Name)
+
+	// The whole point: the stored default is untouched, so the next command in
+	// another shell still acts as the login the user actually selected.
+	reloaded, err := contexts.Load(configDir)
+	require.NoError(t, err)
+	assert.Equal(t, "paul@unrelated", reloaded.CurrentContext,
+		"an override must not persist; that is what distinguishes it from `auth use`")
+}
+
+// TestResolve_IneligibleOverrideBlamesTheFlagNotTheStoredDefault: when the
+// explicitly named context isn't trusted, telling the user to run `auth use`
+// sends them to change the wrong thing — the flag would still override it.
+func TestResolve_IneligibleOverrideBlamesTheFlagNotTheStoredDefault(t *testing.T) {
+	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod-eu",
+		Contexts: []*contexts.Context{
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+			{Name: "staging", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:staging"},
+		},
+	}))
+
+	contexts.SetFlagOverrideForTest(t, "staging")
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "the login selected by --context")
+	assert.Contains(t, err.Error(), "prod-eu", "offer the login that would work")
+	assert.Contains(t, err.Error(), "--context <context>")
+	assert.NotContains(t, err.Error(), "entire auth use",
+		"`auth use` cannot fix a run whose identity comes from the flag")
+}
+
+// TestResolve_UnknownOverrideFailsBeforeEligibility: "that context doesn't exist"
+// and "that context isn't trusted here" are different mistakes. Reporting the
+// second for the first would send the user hunting a trust problem over a typo,
+// and must never silently fall back to current_context.
+func TestResolve_UnknownOverrideFailsBeforeEligibility(t *testing.T) {
+	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod-eu",
+		Contexts:       []*contexts.Context{{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"}},
+	}))
+
+	contexts.SetFlagOverrideForTest(t, "prod-eü")
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	var unknown *contexts.UnknownContextError
+	require.ErrorAs(t, err, &unknown, "callers must be able to tell a bad name from a trust failure")
+	assert.Contains(t, err.Error(), "prod-eu", "list what is actually saved")
+	assert.NotContains(t, err.Error(), "does not accept")
+}

--- a/internal/entireclient/contexts/active.go
+++ b/internal/entireclient/contexts/active.go
@@ -1,0 +1,146 @@
+package contexts
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+)
+
+// EnvContextVar selects the acting login context for one process — the
+// environment counterpart to `--context`.
+//
+// Both exist because they reach different entry points. A flag can't reach git
+// operations at all: git invokes the `git-remote-entire` helper itself, so
+// `ENTIRE_CONTEXT=staging git push` is the only way to scope a push or fetch to
+// a login other than the active one. The env var also survives into hooks and
+// subprocesses, which is what makes a whole shell session scopable without
+// mutating shared state.
+const EnvContextVar = "ENTIRE_CONTEXT"
+
+// flagOverride records an explicit `--context` selection for this process. It is
+// process-global for the same reason auth's insecure-HTTP opt-in is: the flag is
+// parsed at the CLI edge but consumed deep inside resolution, and threading it
+// through every resolver signature would touch every command that authenticates.
+// One CLI invocation acts as one identity, so a process-wide value is the honest
+// scope.
+var flagOverride atomic.Pointer[string]
+
+// SetFlagOverride records the `--context` value for this process. Call it once,
+// during flag handling, before anything resolves a token. An empty or
+// whitespace-only name clears the override rather than selecting a nameless
+// context.
+func SetFlagOverride(name string) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		flagOverride.Store(nil)
+		return
+	}
+	flagOverride.Store(&trimmed)
+}
+
+// SetFlagOverrideForTest sets the override for one test and restores the previous
+// value when it ends.
+//
+// Tests using it MUST NOT call t.Parallel(): the override is process-wide, so a
+// parallel test would resolve against another test's selection. That is also why
+// this restores the prior value rather than clearing — nesting stays honest.
+func SetFlagOverrideForTest(t interface {
+	Helper()
+	Cleanup(restore func())
+}, name string,
+) {
+	t.Helper()
+	prev := flagOverride.Load()
+	SetFlagOverride(name)
+	t.Cleanup(func() { flagOverride.Store(prev) })
+}
+
+// requestedContext returns the explicitly requested context name and the source
+// to name in errors, or ("", "") when nothing was requested. The flag wins over
+// the environment so an explicit argument always beats inherited state.
+func requestedContext() (name, source string) {
+	if override := flagOverride.Load(); override != nil {
+		return *override, "--context"
+	}
+	if env := strings.TrimSpace(os.Getenv(EnvContextVar)); env != "" {
+		return env, "$" + EnvContextVar
+	}
+	return "", ""
+}
+
+// Selection is a resolved acting identity plus where the choice came from.
+//
+// Source is what lets callers name the right remedy, which differs by origin: a
+// wrong `--context` is fixed by correcting the argument, a wrong
+// current_context by `entire auth use`. Telling someone to run `auth use` when
+// they passed an explicit flag sends them to change the wrong thing.
+type Selection struct {
+	// Context is the login to act as, or nil when there is none (logged out, or
+	// current_context unset/dangling). Never nil when Source is non-empty: an
+	// unmatched explicit request is an error instead.
+	Context *Context
+	// Source names the mechanism that chose it: "--context", "$ENTIRE_CONTEXT",
+	// or "" for the stored current_context.
+	Source string
+}
+
+// Explicit reports whether the identity was requested for this invocation
+// rather than inherited from current_context.
+func (s Selection) Explicit() bool { return s.Source != "" }
+
+// Active resolves which stored login this process should act as: an explicit
+// `--context`, else $ENTIRE_CONTEXT, else the stored current_context.
+//
+// An explicit request naming no stored context is an error, never a silent
+// fallback to current_context. Acting as an identity other than the one asked
+// for is precisely the failure the explicit selection exists to prevent, and it
+// would be invisible — the command would succeed as the wrong account.
+//
+// A missing current_context is NOT an error: that is just "logged out", and the
+// caller renders its own hint. So a nil Context with a nil error means no
+// identity is available, and callers must handle it.
+func (f *File) Active() (Selection, error) {
+	name, source := requestedContext()
+	if source == "" {
+		return Selection{Context: f.Find(f.CurrentContext)}, nil
+	}
+	if c := f.Find(name); c != nil {
+		return Selection{Context: c, Source: source}, nil
+	}
+	return Selection{}, &UnknownContextError{Name: name, Source: source, Available: f.Names()}
+}
+
+// UnknownContextError reports an explicit context selection that names no stored
+// login. It carries the available names so the caller can print them without
+// re-reading the store, and is a distinct type so callers can tell "you asked
+// for something that doesn't exist" from "this login isn't trusted here" —
+// different mistakes with different fixes.
+type UnknownContextError struct {
+	Name      string
+	Source    string
+	Available []string
+}
+
+func (e *UnknownContextError) Error() string {
+	if len(e.Available) == 0 {
+		return fmt.Sprintf("%s selected login context %q, but no logins are saved; run `entire login` first", e.Source, e.Name)
+	}
+	return fmt.Sprintf("%s selected login context %q, which is not saved.\nSaved contexts: %s\nRun `entire auth contexts` to list them.",
+		e.Source, e.Name, strings.Join(e.Available, ", "))
+}
+
+// Names returns the stored context names in on-disk order, for listing in
+// messages. On-disk order is stable across saves, so the output is too.
+func (f *File) Names() []string {
+	if f == nil {
+		return nil
+	}
+	out := make([]string, 0, len(f.Contexts))
+	for _, c := range f.Contexts {
+		if c != nil && c.Name != "" {
+			out = append(out, c.Name)
+		}
+	}
+	return out
+}

--- a/internal/entireclient/contexts/active_test.go
+++ b/internal/entireclient/contexts/active_test.go
@@ -1,0 +1,120 @@
+package contexts_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/internal/entireclient/contexts"
+)
+
+// The two saved logins these tests resolve between.
+const (
+	ctxProd    = "prod"
+	ctxStaging = "staging"
+)
+
+// storeFile is a two-login store: ctxProd is the stored current_context.
+func storeFile() *contexts.File {
+	return &contexts.File{
+		CurrentContext: ctxProd,
+		Contexts: []*contexts.Context{
+			{Name: ctxProd, CoreURL: "https://core.entire.io", Handle: "me", KeychainService: "kc:prod"},
+			{Name: ctxStaging, CoreURL: "https://core.partial.to", Handle: "me", KeychainService: "kc:staging"},
+		},
+	}
+}
+
+// Mutates the process-wide flag override, so these cannot run in parallel with
+// each other; t.Setenv already forbids it too.
+func TestActive_PrecedenceFlagOverEnvOverCurrent(t *testing.T) {
+	f := storeFile()
+
+	t.Run("current_context when nothing is requested", func(t *testing.T) {
+		contexts.SetFlagOverrideForTest(t, "")
+		t.Setenv(contexts.EnvContextVar, "")
+		sel, err := f.Active()
+		if err != nil {
+			t.Fatalf("Active: %v", err)
+		}
+		if sel.Context.Name != ctxProd || sel.Explicit() {
+			t.Fatalf("got %q explicit=%v, want prod explicit=false", sel.Context.Name, sel.Explicit())
+		}
+	})
+
+	t.Run("env overrides current_context", func(t *testing.T) {
+		contexts.SetFlagOverrideForTest(t, "")
+		t.Setenv(contexts.EnvContextVar, ctxStaging)
+		sel, err := f.Active()
+		if err != nil {
+			t.Fatalf("Active: %v", err)
+		}
+		if sel.Context.Name != ctxStaging || sel.Source != "$"+contexts.EnvContextVar {
+			t.Fatalf("got %q from %q, want staging from the env var", sel.Context.Name, sel.Source)
+		}
+	})
+
+	t.Run("flag beats env", func(t *testing.T) {
+		t.Setenv(contexts.EnvContextVar, ctxStaging)
+		contexts.SetFlagOverrideForTest(t, ctxProd)
+		sel, err := f.Active()
+		if err != nil {
+			t.Fatalf("Active: %v", err)
+		}
+		if sel.Context.Name != ctxProd || sel.Source != "--context" {
+			t.Fatalf("got %q from %q, want prod from --context", sel.Context.Name, sel.Source)
+		}
+	})
+
+	t.Run("blank env is not a selection", func(t *testing.T) {
+		contexts.SetFlagOverrideForTest(t, "")
+		t.Setenv(contexts.EnvContextVar, "   ")
+		sel, err := f.Active()
+		if err != nil {
+			t.Fatalf("Active: %v", err)
+		}
+		if sel.Context.Name != ctxProd || sel.Explicit() {
+			t.Fatalf("blank env should fall through to current_context, got %q", sel.Context.Name)
+		}
+	})
+}
+
+// An explicit request naming nothing must fail loudly. Falling back to
+// current_context would run the command as a different identity than the one
+// asked for, and succeed while doing it.
+func TestActive_UnknownExplicitSelectionErrors(t *testing.T) {
+	t.Setenv(contexts.EnvContextVar, "")
+	contexts.SetFlagOverrideForTest(t, "typo")
+
+	sel, err := storeFile().Active()
+	if err == nil {
+		t.Fatalf("want an error for an unknown --context, got selection %+v", sel)
+	}
+	var unknown *contexts.UnknownContextError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("want UnknownContextError so callers can tell it from a trust failure, got %T", err)
+	}
+	if unknown.Name != "typo" || unknown.Source != "--context" {
+		t.Fatalf("got name=%q source=%q", unknown.Name, unknown.Source)
+	}
+	for _, want := range []string{"typo", ctxProd, ctxStaging} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("message %q should name %q", err.Error(), want)
+		}
+	}
+}
+
+func TestActive_NoCurrentContextIsNotAnError(t *testing.T) {
+	contexts.SetFlagOverrideForTest(t, "")
+	t.Setenv(contexts.EnvContextVar, "")
+
+	f := storeFile()
+	f.CurrentContext = ""
+	sel, err := f.Active()
+	if err != nil {
+		t.Fatalf("logged out is not an error condition: %v", err)
+	}
+	if sel.Context != nil {
+		t.Fatalf("want no context, got %q", sel.Context.Name)
+	}
+}

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -110,7 +110,7 @@ func (f *File) ContextsForIssuer(issuer string) []*Context {
 	want := trimURL(issuer)
 	var out []*Context
 	for _, c := range f.Contexts {
-		if trimURL(c.CoreURL) == want {
+		if c != nil && trimURL(c.CoreURL) == want {
 			out = append(out, c)
 		}
 	}
@@ -130,7 +130,7 @@ func (f *File) Find(name string) *Context {
 		return nil
 	}
 	for _, c := range f.Contexts {
-		if c.Name == name {
+		if c != nil && c.Name == name {
 			return c
 		}
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1038
<!-- entire-trail-link-end -->

An alternative to #1978. Same diagnosis — implicit login selection is a footgun — but it drops **only the auto-selection**, and keeps multiple saved logins.

## The problem both PRs are solving

Account selection had three tiers: the active context when the resource trusted its core, else *"the sole eligible context"*, else an ambiguity error. The implicit tiers made the acting identity depend on what **else** happened to be stored.

Concretely: log into prod as `alice`, add a staging login as `admin` for one task, and `git push` to a staging-fronted cluster authenticates as `admin` — an elevated account you never selected for that operation, with the server-side audit trail recording it, and nothing in the output saying so. Adding a login could change what an existing command did, and the same command could act as different identities on two machines.

## What this does differently from #1978

#1978 bundles three separable decisions: (1) drop auto-selection, (2) drop multi-login, (3) move metadata into the keychain. None implies the next, and the confusion is evidence for (1) — the cheapest of the three.

This PR does (1) only. `auth contexts`, `auth use`, `logout --all-contexts`, and `contexts.json` are unchanged, so no migration, no downgrade cliff, and dual-account workflows (personal + elevated, staging + prod) keep working.

## Two commits

**1. `refactor(auth)` — require the active context.** `selectContext` becomes `requireActiveContext`: it validates, it no longer selects. Failures now distinguish what you can *do* about it, because a wrong remedy is a dead end and "not logged in" is actively misleading for someone who is logged in, just to another federation:

```
API host partial.to does not accept your active login "me@prod" (https://us.auth.entire.io).
These saved logins can authenticate it: me@staging
Switch with `entire auth use <context>`, then re-run your command.
```
```
cluster aws-eu-central-1.entire.io does not accept your active login "staging" (https://eu.auth.partial.to), and no other saved login does either.
It trusts these login servers: https://eu.auth.entire.io
Log in with `entire login --server <url>`, then re-run your command.
```

That second one cashes in `renderLoginHint`'s dead `_ []string` parameter and its *"display coreURLs at a later stage"* TODO. Naming the servers is the only actionable part — bare `entire login` re-authenticates against the default server and reproduces the same failure.

This commit also fixes a latent inconsistency: eligibility was answered by two different mechanisms in one function (`contextEligible` for the accept decision, `ContextsForIssuer` for the candidate list), which disagreed on blank `CoreURL` and on whitespace. They produced `does not accept your active login "blank". These saved logins can authenticate it: blank` — telling you to switch to the login you were already on. Both paths now share one predicate and one URL normaliser.

**2. `feat(auth)` — `--context` and `ENTIRE_CONTEXT`.** Requiring the active context sends every cross-federation operation through `auth use`, which is persistent and machine-wide. That's a bad trade for a one-off, and in one respect worse than the tier it replaced: the old fallback was scoped to a single command and left no residue, where a forgotten `auth use` silently retargets your next `git push`.

```sh
entire --context staging activity     # one command
ENTIRE_CONTEXT=staging git push       # one git operation
entire auth use staging               # your default, when you mean it
```

Both are needed because they reach different entry points — **git invokes `git-remote-entire` itself, so a flag can never reach a git operation.**

Resolution moves into one owner, `contexts.File.Active`. Seven sites resolved the active context independently; overriding only some would have had `logout` revoking one identity's session server-side while deleting another's credentials locally.

## Notes for review

- An override naming no saved context is a **hard error**, reported before any trust check. "That context doesn't exist" and "that context isn't trusted here" are different mistakes, and falling through to `current_context` would succeed as the wrong account.
- Trust failures name their source: an identity from `--context` is fixed by changing that argument, not by `auth use`, which the flag would keep overriding.
- `--context` binds through a `pflag.Value`, not a `PersistentPreRun` — Cobra runs only the closest one in the chain, and the agent and hooks subtrees define their own, so a root hook would be silently skipped for exactly the commands that inherited the flag.
- **Behaviour change worth a decision:** `ENTIRE_API_BASE_URL=https://partial.to entire activity` no longer silently picks your staging login. It now needs `--context staging` (or `ENTIRE_CONTEXT`). That was auto-selection wearing a feature's clothes — an env var quietly changing which account a command ran as — so removing it is the point, but it is a documented workflow changing shape.
- Each commit builds and passes tests on its own.

## Out of scope, surfaced while working

- The **data-API path has no `ENTIRE_TOKEN` bypass** (`ResolveDataAPIToken` never consults it), unlike git and the control plane. Pre-existing, but it is the path with the least escape hatch.
- The repo has **four hand-rolled issuer comparisons** (`contexts.trimURL`, `auth.sameIssuer`, `coreTrusted`, `contextEligible`). This unifies the two inside `clusterdiscovery`; consolidating the rest means touching `git-remote-entire` and `auth`.
- **Nobody has measured** whether auto-selection ever misfired, or how many installs hold >1 context. Two telemetry queries would turn the #1978-vs-this argument from taste into evidence.
- `CLAUDE.md` claims *"Normal lint includes dupl at threshold 75"*, but `dupl` isn't in `.golangci.yaml`'s `enable:` list — only `mise run dup` runs it. Stale, unrelated to this work.

## Verification

`mise run fmt && mise run lint` clean (0 issues). `mise run test:ci` green — unit, integration, and both canary agents (56 + 4). Behaviour also checked against the built binary: `--context staging auth contexts` marks staging active while `current_context` in `contexts.json` stays `prod`, confirming the override does not persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 02f0a7c2443ab7ae599f824f513c5e2d4f00afa7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->