### PR TITLE
Fix three CI flakes from test helpers sharing state across parallel tests

### DIFF
--- a/internal/coreapi/cross_juris_transport_test.go
+++ b/internal/coreapi/cross_juris_transport_test.go
@@ -93,8 +93,27 @@ func writeTestFederation(w http.ResponseWriter, peers []string) {
 	w.Write([]byte(b.String())) //nolint:errcheck // test
 }
 
-func transportFor() *crossJurisRoundTripper {
-	return newCrossJurisRoundTripper(http.DefaultTransport)
+// transportFor builds a round-tripper over a connection pool private to
+// this test.
+//
+// Do not hand it http.DefaultTransport. httptest.Server.Close calls
+// http.DefaultTransport.CloseIdleConnections as a courtesy to its users
+// (net/http/httptest/server.go), so with a shared pool any parallel test
+// in this package tearing its server down closes a pooled connection
+// another test is about to reuse. net/http does not retry that one:
+// shouldRetryRequest lists errServerClosedIdle but not errCloseIdleConns,
+// so it reaches the caller as "transport connection broken: http:
+// CloseIdleConnections called". Clone keeps DefaultTransport's timeouts
+// and proxy settings; only the pool is ours.
+func transportFor(t *testing.T) *crossJurisRoundTripper {
+	t.Helper()
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Fatalf("http.DefaultTransport is %T, want *http.Transport", http.DefaultTransport)
+	}
+	tr := base.Clone()
+	t.Cleanup(tr.CloseIdleConnections)
+	return newCrossJurisRoundTripper(tr)
 }
 
 // TestRoundTripper_PassThrough: a 2xx is returned unchanged.
@@ -106,7 +125,7 @@ func TestRoundTripper_PassThrough(t *testing.T) {
 		w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test
 	})
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.srv.URL, nil) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer user-jwt")
 
@@ -138,7 +157,7 @@ func TestRoundTripper_421FollowsToHomeCore(t *testing.T) {
 	})
 	wrongCore.peers = []string{homeCore.srv.URL}
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, wrongCore.srv.URL+"/api/v1/mirrors", strings.NewReader(`{"a":1}`)) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer user-jwt")
 
@@ -191,7 +210,7 @@ func TestRoundTripper_421ThenBareUnauthorizedProactiveExchange(t *testing.T) {
 	})
 	wrongCore.peers = []string{homeCore.URL}
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, wrongCore.srv.URL+"/api/v1/mirrors/collaborators", strings.NewReader(`{}`)) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer original-eu-login-jwt")
 
@@ -231,7 +250,7 @@ func TestRoundTripper_BareUnauthorizedNoRedirectPassesThrough(t *testing.T) {
 		w.Write([]byte(`{"error":"invalid token"}`)) //nolint:errcheck // test
 	})
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.srv.URL+"/api/v1/me", nil) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer user-jwt")
 
@@ -273,7 +292,7 @@ func TestRoundTripper_401ExchangeAndRetry(t *testing.T) {
 	}))
 	t.Cleanup(apiServer.Close)
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, apiServer.URL+"/api/v1/mirrors", strings.NewReader(`{"a":1}`)) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer user-jwt")
 
@@ -310,7 +329,7 @@ func TestRoundTripper_Rejects421OffFederation(t *testing.T) {
 	})
 	// wrongCore.peers stays empty.
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, wrongCore.srv.URL+"/api/v1/mirrors", nil) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer user-jwt")
 
@@ -345,7 +364,7 @@ func TestRoundTripper_RejectsOffOrigin401ExchangeURL(t *testing.T) {
 		w.Write([]byte(`{"error":"cross_juris_token_required","token_exchange_url":"` + attacker.URL + `","audience":"https://api.test"}`)) //nolint:errcheck // test
 	})
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, api.srv.URL+"/api/v1/me", nil) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer user-jwt")
 
@@ -381,7 +400,7 @@ func TestRoundTripper_BodyReplayedOnRetry(t *testing.T) {
 	})
 	wrongCore.peers = []string{homeCore.srv.URL}
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, wrongCore.srv.URL+"/api/v1/mirrors", bytes.NewReader([]byte(payload))) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer user-jwt")
 	resp, err := client.Do(req)
@@ -447,7 +466,7 @@ func TestEffectiveTokenTTL(t *testing.T) {
 // TestStoreTokenDeclinesNonPositiveTTL: a <=0 TTL must not be cached.
 func TestStoreTokenDeclinesNonPositiveTTL(t *testing.T) {
 	t.Parallel()
-	rt := transportFor()
+	rt := transportFor(t)
 	rt.storeToken("https://example.test", "tok", 0)
 	if _, ok := rt.lookupToken("https://example.test"); ok {
 		t.Error("zero TTL must not be cached")
@@ -485,7 +504,7 @@ func TestRoundTripper_TokenCacheReusesExchanged(t *testing.T) {
 	}))
 	t.Cleanup(apiServer.Close)
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	for i := range 2 {
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, apiServer.URL+"/api/v1/me", nil) //nolint:errcheck // test
 		req.Header.Set("Authorization", "Bearer user-jwt")
@@ -526,7 +545,7 @@ func TestRoundTripper_NoInfiniteLoopOn421Chain(t *testing.T) {
 	})
 	first.peers = []string{second.srv.URL}
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, first.srv.URL+"/api/v1/mirrors", nil) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer user-jwt")
 	resp, err := client.Do(req)
@@ -560,7 +579,7 @@ func TestRoundTripper_ExchangeFailurePropagates401(t *testing.T) {
 	}))
 	t.Cleanup(api.Close)
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, api.URL+"/api/v1/me", nil) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer user-jwt")
 	resp, err := client.Do(req)
@@ -639,7 +658,7 @@ func TestRoundTripper_ExchangeAfter401Then421UsesOriginalSubjectToken(t *testing
 	}))
 	t.Cleanup(misdirected.Close)
 
-	client := &http.Client{Transport: transportFor()}
+	client := &http.Client{Transport: transportFor(t)}
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, misdirected.URL+"/api/v1/mirrors", strings.NewReader(`{}`)) //nolint:errcheck // test
 	req.Header.Set("Authorization", "Bearer "+originalLoginJWT)
 	resp, err := client.Do(req)
@@ -665,7 +684,7 @@ func TestRoundTripper_ExchangeAfter401Then421UsesOriginalSubjectToken(t *testing
 // TestCacheExpiresAfterTTL: expired entries are evicted on lookup.
 func TestCacheExpiresAfterTTL(t *testing.T) {
 	t.Parallel()
-	rt := transportFor()
+	rt := transportFor(t)
 	rt.storeToken("https://example.test", "tok", cachedTokenTTL)
 	if _, ok := rt.lookupToken("https://example.test"); !ok {
 		t.Fatal("fresh token must be a hit")

--- a/internal/entireclient/clusterdiscovery/api_discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery_test.go
@@ -80,9 +80,7 @@ func TestDiscoverAPI(t *testing.T) {
 
 	t.Run("transport error → ErrDiscoveryUnavailable", func(t *testing.T) {
 		t.Parallel()
-		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-		client := hostPinningClient(t, srv)
-		srv.Close()
+		client := deadPinningClient(t)
 
 		_, err := DiscoverAPI(t.Context(), "partial.to", client, t.Logf)
 		assert.ErrorIs(t, err, ErrDiscoveryUnavailable)
@@ -115,7 +113,7 @@ func TestDiscoverAPI(t *testing.T) {
 		// schemeRewriteClient rewrites the hard-coded https:// to http:// but
 		// leaves the host alone, so the redirect actually reaches `target`
 		// rather than being pinned back to `redirector`.
-		client := &http.Client{Transport: schemeRewriteTransport{base: http.DefaultTransport}}
+		client := &http.Client{Transport: schemeRewriteTransport{base: newTestTransport(t)}}
 		host := strings.TrimPrefix(redirector.URL, "http://")
 
 		doc, err := DiscoverAPI(t.Context(), host, client, t.Logf)

--- a/internal/entireclient/clusterdiscovery/discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/discovery_test.go
@@ -2,6 +2,7 @@ package clusterdiscovery
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -20,8 +21,59 @@ func hostPinningClient(t *testing.T, srv *httptest.Server) *http.Client {
 	srvURL, err := url.Parse(srv.URL)
 	require.NoError(t, err)
 	return &http.Client{
-		Transport: rewritingTransport{base: http.DefaultTransport, scheme: srvURL.Scheme, host: srvURL.Host},
+		Transport: rewritingTransport{base: newTestTransport(t), scheme: srvURL.Scheme, host: srvURL.Host},
 	}
+}
+
+// deadPinningClient returns a client pinned to a 127.0.0.1 address that
+// accepts connections and immediately closes them, so every request
+// through it fails. fetchWellKnownJSON wraps any transport error as
+// ErrUnreachable, so callers asserting on that keep working.
+//
+// Do not build this by starting an httptest.Server and closing it to free
+// the port. Tests here run with t.Parallel(), so another test's
+// httptest.NewServer can be handed the released port and answer a request
+// this client expects to fail — and that foreign request also trips the
+// other test's in-handler path assertion. CI hit exactly that: one event
+// failed both TestResolve_PreAudienceEntryNotUsedAsDiscoveryFallback
+// (its "unreachable" cluster answered) and TestResolveContextForAPI
+// (apiHandler saw /.well-known/entire-cluster.json). Holding the listener
+// for the test's lifetime keeps the port ours.
+func deadPinningClient(t *testing.T) *http.Client {
+	t.Helper()
+	var lc net.ListenConfig
+	l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	return &http.Client{
+		Transport: rewritingTransport{base: newTestTransport(t), scheme: "http", host: l.Addr().String()},
+	}
+}
+
+// newTestTransport gives each test its own connection pool. Sharing
+// http.DefaultTransport is unsafe here: httptest.Server.Close calls
+// http.DefaultTransport.CloseIdleConnections as a courtesy to its users
+// (net/http/httptest/server.go), so one parallel test's teardown can close
+// a pooled connection another test is about to reuse — and net/http does
+// not retry that error.
+func newTestTransport(t *testing.T) *http.Transport {
+	t.Helper()
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Fatalf("http.DefaultTransport is %T, want *http.Transport", http.DefaultTransport)
+	}
+	tr := base.Clone()
+	t.Cleanup(tr.CloseIdleConnections)
+	return tr
 }
 
 type rewritingTransport struct {
@@ -86,12 +138,10 @@ func TestDiscover(t *testing.T) {
 	})
 
 	t.Run("transport error → ErrUnreachable", func(t *testing.T) {
-		// Closed server: connection refused. From the caller's POV this
-		// is indistinguishable from a typo'd host like "foo.invalid";
+		// A host that never answers. From the caller's POV this is
+		// indistinguishable from a typo'd host like "foo.invalid";
 		// both deserve the same actionable nudge.
-		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-		client := hostPinningClient(t, srv)
-		srv.Close()
+		client := deadPinningClient(t)
 
 		_, err := Discover(t.Context(), "rc.partial.to", client, t.Logf)
 		assert.ErrorIs(t, err, ErrUnreachable)

--- a/internal/entireclient/clusterdiscovery/discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/discovery_test.go
@@ -46,6 +46,11 @@ func deadPinningClient(t *testing.T) *http.Client {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = l.Close() })
 	go func() {
+		// If Accept ever fails for a reason other than our own Close, drop the
+		// listener with it. A bound port with nobody accepting completes the
+		// handshake from the kernel backlog, so requests would hang instead of
+		// failing.
+		defer func() { _ = l.Close() }()
 		for {
 			c, err := l.Accept()
 			if err != nil {

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -204,10 +204,8 @@ func TestResolve_ClusterHostCaseInsensitive(t *testing.T) {
 // break an operation whose cores we already knew.
 func TestResolve_StaleCacheFallbackOnDiscoveryFailure(t *testing.T) {
 	t.Parallel()
-	// Server is closed immediately so any discovery attempt fails.
-	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	client := hostPinningClient(t, srv)
-	srv.Close()
+	// Pinned at a host that never answers, so any discovery attempt fails.
+	client := deadPinningClient(t)
 
 	configDir := t.TempDir()
 	cacheDir := t.TempDir()
@@ -274,9 +272,7 @@ func TestResolve_PreAudienceCacheRefetched(t *testing.T) {
 // transient discovery failure as "cluster doesn't do jurisdiction tokens".
 func TestResolve_PreAudienceEntryNotUsedAsDiscoveryFallback(t *testing.T) {
 	t.Parallel()
-	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	client := hostPinningClient(t, srv)
-	srv.Close() // discovery fails
+	client := deadPinningClient(t) // discovery fails
 
 	configDir := t.TempDir()
 	cacheDir := t.TempDir()
@@ -339,9 +335,7 @@ func TestResolve_AudienceAgnosticCallersSkipPreAudienceRefetch(t *testing.T) {
 // the "doesn't look like a cluster" message.
 func TestResolve_Unreachable(t *testing.T) {
 	t.Parallel()
-	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	client := hostPinningClient(t, srv)
-	srv.Close()
+	client := deadPinningClient(t)
 
 	configDir := t.TempDir()
 	require.NoError(t, contexts.Save(configDir, &contexts.File{

--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -867,12 +867,13 @@ func TestProxyConsumesServerHeaderFormat(t *testing.T) {
 // and immediately closes them, so every request against it fails.
 //
 // Do not build this by starting an httptest.Server and closing it: closing
-// hands the port back to the OS, and because every test in this file runs
-// with t.Parallel(), another test's httptest.NewServer can be given the same
-// port while the first test still treats it as dead. That made two tests fail
-// together — one saw its "dead" node answer 200, the other saw the first
-// test's request land in its handler. Here the listener stays bound for the
-// test's lifetime, so nothing else can take the port.
+// hands the port back to the OS, and tests in this file run with t.Parallel(),
+// so another test's httptest.NewServer can be given the same port while the
+// first test still treats it as dead. That failed
+// TestColdPathRedirectAllReplicasFail and TestServiceRPC together — one saw
+// its "dead" node answer 200, the other saw the foreign request land in its
+// handler. Here the listener stays bound for the test's lifetime, so nothing
+// else can take the port.
 func deadServerURL(t *testing.T) string {
 	t.Helper()
 	var lc net.ListenConfig
@@ -880,6 +881,11 @@ func deadServerURL(t *testing.T) string {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = l.Close() })
 	go func() {
+		// If Accept ever fails for a reason other than our own Close, drop the
+		// listener with it. A bound port with nobody accepting completes the
+		// handshake from the kernel backlog, so requests would hang instead of
+		// failing — and these callers pass no timeout.
+		defer func() { _ = l.Close() }()
 		for {
 			c, err := l.Accept()
 			if err != nil {
@@ -1427,7 +1433,7 @@ func TestColdPathDropsOutOfClusterReplicasFromHeader(t *testing.T) {
 
 func TestColdPathRefusesOutOfClusterLocationSalvage(t *testing.T) {
 	t.Parallel()
-	deadReplica := deadServerURL(t) // in-cluster (127.0.0.1) but unreachable
+	deadReplica := deadServerURL(t) // in-cluster (127.0.0.1) but never answers
 
 	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// The only replica is dead, forcing the salvage path; Location points

--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -311,8 +312,7 @@ func TestUnauthorized(t *testing.T) {
 
 func TestFailover(t *testing.T) {
 	t.Parallel()
-	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	down.Close()
+	down := deadServerURL(t)
 
 	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -320,7 +320,7 @@ func TestFailover(t *testing.T) {
 	}))
 	defer up.Close()
 
-	p := proxyWithClient([]string{down.URL, up.URL}, "/et/alice/repo", "", "", &http.Client{})
+	p := proxyWithClient([]string{down, up.URL}, "/et/alice/repo", "", "", &http.Client{})
 
 	resp, err := p.InfoRefs(context.Background(), "git-upload-pack")
 	if err != nil {
@@ -362,14 +362,13 @@ func TestFailover5xx(t *testing.T) {
 
 func TestOnNodeFailedCalledOnConnectionError(t *testing.T) {
 	t.Parallel()
-	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	down.Close()
+	down := deadServerURL(t)
 
 	var failed []string
 	p := New(Config{
 		Nodes: replicas.NodeConfig{
-			InitialNodes: []string{down.URL},
-			ClusterHost:  mustHost(t, down.URL),
+			InitialNodes: []string{down},
+			ClusterHost:  mustHost(t, down),
 		},
 		Path:         "/et/alice/repo",
 		OnNodeFailed: func(node string) { failed = append(failed, node) },
@@ -379,8 +378,8 @@ func TestOnNodeFailedCalledOnConnectionError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error with single unreachable node")
 	}
-	if len(failed) != 1 || failed[0] != down.URL {
-		t.Errorf("onNodeFailed = %v, want [%s]", failed, down.URL)
+	if len(failed) != 1 || failed[0] != down {
+		t.Errorf("onNodeFailed = %v, want [%s]", failed, down)
 	}
 }
 
@@ -864,17 +863,36 @@ func TestProxyConsumesServerHeaderFormat(t *testing.T) {
 	}
 }
 
-// closedServerURL returns the URL of an httptest.Server that has been
-// closed — a guaranteed-dead 127.0.0.1:port a request will fail to dial.
-func closedServerURL() string {
-	s := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	url := s.URL
-	s.Close()
-	return url
+// deadServerURL returns the URL of a 127.0.0.1:port that accepts connections
+// and immediately closes them, so every request against it fails.
+//
+// Do not build this by starting an httptest.Server and closing it: closing
+// hands the port back to the OS, and because every test in this file runs
+// with t.Parallel(), another test's httptest.NewServer can be given the same
+// port while the first test still treats it as dead. That made two tests fail
+// together — one saw its "dead" node answer 200, the other saw the first
+// test's request land in its handler. Here the listener stays bound for the
+// test's lifetime, so nothing else can take the port.
+func deadServerURL(t *testing.T) string {
+	t.Helper()
+	var lc net.ListenConfig
+	l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	return "http://" + l.Addr().String()
 }
 
 func TestColdPathFailoverWhenRedirectTargetUnreachable(t *testing.T) {
-	dead := closedServerURL()
+	dead := deadServerURL(t)
 
 	var aliveURL string
 	alive := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -960,8 +978,8 @@ func TestColdPathDoesNotFollowRedirectAuto(t *testing.T) {
 
 func TestColdPathRedirectAllReplicasFail(t *testing.T) {
 	t.Parallel()
-	dead1 := closedServerURL()
-	dead2 := closedServerURL()
+	dead1 := deadServerURL(t)
+	dead2 := deadServerURL(t)
 
 	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(dead1, dead2))
@@ -1003,8 +1021,8 @@ func TestColdPathRedirectMissingHeaderFollows(t *testing.T) {
 func TestColdPathRedirectFailureDoesNotPoisonCache(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
-	dead1 := closedServerURL()
-	dead2 := closedServerURL()
+	dead1 := deadServerURL(t)
+	dead2 := deadServerURL(t)
 
 	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(dead1, dead2))
@@ -1034,8 +1052,8 @@ func TestColdPathRedirectFailureDoesNotPoisonCache(t *testing.T) {
 func TestColdPathRedirectStaleHeaderFallsBackToLocation(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
-	dead1 := closedServerURL()
-	dead2 := closedServerURL()
+	dead1 := deadServerURL(t)
+	dead2 := deadServerURL(t)
 
 	var aliveURL string
 	alive := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1273,9 +1291,9 @@ func TestNoRedirectClientPrefersDiscoveryTransport(t *testing.T) {
 
 func TestInfoRefsWarmAndColdBothFailSurfacesBoth(t *testing.T) {
 	t.Parallel()
-	deadReplica1 := closedServerURL()
-	deadReplica2 := closedServerURL()
-	deadEntry := closedServerURL()
+	deadReplica1 := deadServerURL(t)
+	deadReplica2 := deadServerURL(t)
+	deadEntry := deadServerURL(t)
 
 	p := proxyWithClient([]string{deadReplica1, deadReplica2}, "/et/alice/repo", deadEntry, "127.0.0.1", &http.Client{})
 
@@ -1409,7 +1427,7 @@ func TestColdPathDropsOutOfClusterReplicasFromHeader(t *testing.T) {
 
 func TestColdPathRefusesOutOfClusterLocationSalvage(t *testing.T) {
 	t.Parallel()
-	deadReplica := closedServerURL() // in-cluster (127.0.0.1) but unreachable
+	deadReplica := deadServerURL(t) // in-cluster (127.0.0.1) but unreachable
 
 	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// The only replica is dead, forcing the salvage path; Location points


### PR DESCRIPTION
Three intermittent `test-core` failures across three packages. They share a shape — a test helper handing out state it does not own — but the causes are distinct. All test-only; no production code changes.

## 1. `internal/remotehelper/transport` — a port we gave back

`closedServerURL()` built a "guaranteed dead" node by starting an `httptest.Server` and closing it. Closing hands the port back to the OS, and tests in that file run with `t.Parallel()`, so another test's `httptest.NewServer` could be handed the same port while the first test still treated it as dead.

One event failed two tests at once:

- `TestColdPathRedirectAllReplicasFail` expects both replicas to fail. One "dead" node was alive and answered 200, so `require.Error` got nil.
- `TestServiceRPC` owned the server that inherited the port, so the other test's request landed in its handler — which is why it logged the foreign path `/et/alice/repo/info/refs` and method GET.

Neither test is wrong on its own. The helper handed out an address it did not own.

`deadServerURL(t)` replaces it: it keeps a listener bound for the test's lifetime and closes every connection it accepts. Nothing else can take the port, and requests still fail, so the existing assertions hold — "all 2 nodes failed" and "after entry-domain redirect" come from the proxy's own aggregation, not from the dial error text.

`TestFailover` and `TestOnNodeFailedCalledOnConnectionError` hand-rolled the same close-and-keep-the-URL pattern inline, so they were not among the 12 helper call sites. Left alone they would have kept firing the same flake. They use the helper now too.

## 2. `internal/coreapi` — a connection pool we shared

Undiagnosed before this change, and unrelated to the above.

`transportFor()` wrapped the process-global `http.DefaultTransport`. `httptest.Server.Close()` calls `http.DefaultTransport.CloseIdleConnections()` deliberately, as a courtesy to its users (`net/http/httptest/server.go:265-270`). Every parallel test in the package closes an httptest server, so each teardown wiped the connection pool that `TestRoundTripper_TokenCacheReusesExchanged` relies on between its two requests.

It surfaces instead of being retried because `shouldRetryRequest` (`net/http/transport.go:842-861`) lists `errServerClosedIdle` but not `errCloseIdleConns` — so it reaches the caller as `net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called`.

`transportFor(t)` now clones `DefaultTransport`: same timeouts and proxy settings, private pool. That puts the error out of reach — `errCloseIdleConns` has exactly one producer in the whole stdlib (`transport.go:907`, inside `CloseIdleConnections`), and nothing in this repo calls that on a private transport.

## 3. `internal/entireclient/clusterdiscovery` — the same port bug, third package

Found by CI on this very PR ([run 31710801422](https://github.com/entireio/cli/actions/runs/31710801422)), in a package neither earlier commit touched. Two tests, one event:

```
TestResolve_PreAudienceEntryNotUsedAsDiscoveryFallback
  "...advertises no trusted core URLs..." does not contain "unreachable"

TestResolveContextForAPI/ambiguous_eligible_contexts
  expected: "/.well-known/entire-api.json"
  actual  : "/.well-known/entire-cluster.json"
```

Five tests built a client pinned to an `httptest.Server`'s host:port and then closed the server so discovery would fail. The released port got picked up elsewhere, so the "unreachable" cluster answered — and the request landed in an api-discovery test's handler, where `apiHandler`'s in-handler path assertion reported the foreign cluster path.

That second assertion is what makes the diagnosis conclusive rather than inferred: a cluster-discovery request cannot reach an api-discovery test's server unless the two shared a port.

`deadPinningClient(t)` holds a listener for the test's lifetime and closes each connection it accepts. `fetchWellKnownJSON` wraps *any* transport error as `ErrUnreachable` (`discovery.go:101-105`), so the `ErrUnreachable` / `ErrDiscoveryUnavailable` assertions are unaffected by moving from connection-refused to connection-reset.

This package also shared `http.DefaultTransport` the way `coreapi` did, so it got the same private-pool treatment via `newTestTransport`. **That part is preventive, not diagnosed here.**

## Review findings addressed

- **The accept loops could hang instead of failing.** Both helpers returned from the accept goroutine on any `Accept` error while leaving the listener bound; a bound port with nobody accepting still completes the handshake from the kernel backlog, so a request would hang rather than fail — and these callers pass `context.Background()` with no client timeout, turning that into a package-level test timeout. Both loops now close the listener on the way out. Fd exhaustion is the realistic way in, since Go retries `EINTR`, `ECONNABORTED` and `EAGAIN` internally.
- **Two comments left wrong by the helper swap.** `deadServerURL` claimed "every test in this file runs with `t.Parallel()`" — 7 of 55 top-level tests do not, three of them `deadServerURL` callers. Go never overlaps a non-parallel top-level test with a parallel one, so those three were never exposed to the steal. The comment now names the pair that actually collided. Separately, "in-cluster (127.0.0.1) but unreachable" described the old helper, which failed at dial; the address is now reachable and simply never answers.
- **Duplication across packages, deliberately not extracted.** Two pairs of near-identical helpers now exist. Extracting them would mean standing up a new `internal/testutil` (the existing ones live under `cmd/entire/cli/` and `e2e/`), and the two listener helpers differ in return type. Recorded so a third copy triggers extraction instead of another paste.

## Verification, and its limits

- `-count=20 -race -parallel 16` green on all three packages.
- Full `mise run test:ci` green (unit + integration + canary).

None of these reproduced locally, and that is worth stating plainly rather than calling them confirmed by test. macOS cycles through the whole ephemeral port range before wrapping, so the port reuse effectively cannot happen here — 3000 interleaved open/close rounds gave zero collisions. For the pool bug, the fix was temporarily reverted and a churn test run alongside 13,692 keep-alive requests; still no failure, because the window between checking a connection out of the pool and writing to it is very narrow. Both reproductions were scratch-only and deleted.

The proof is structural rather than empirical:

- For the port bugs, the cross-test requests in the CI logs are decisive — `TestServiceRPC` expects `/et/owner/repo/git-upload-pack` but logged `/et/alice/repo/info/refs`, and `apiHandler` expects `/.well-known/entire-api.json` but logged `/.well-known/entire-cluster.json`. Requests cannot cross between two httptest servers unless they shared a port.
- For the pool bug, `errCloseIdleConns` has exactly one producer in the stdlib, and `httptest.Server.Close` is the only caller reachable from these tests.

## Worth a follow-up

Three packages have now hit the same bug, and the repo-wide sweep only happened after CI failed rather than when the first fix went in. A lint rule, or a shared "address that never answers" helper, would be worth more than three point fixes — otherwise the fourth instance gets written next month. Deliberately out of scope here.
