### PR TITLE
perf: log slow hook traces at WARN so real sessions self-diagnose

### DIFF
--- a/cmd/entire/cli/trace.go
+++ b/cmd/entire/cli/trace.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/entireio/cli/perf"
+
 	"charm.land/lipgloss/v2"
 )
 
@@ -249,9 +251,11 @@ func collectTraceEntries(logFile string, last int, hookFilter string) ([]traceEn
 func renderTraceEntries(w io.Writer, entries []traceEntry) {
 	if len(entries) == 0 {
 		fmt.Fprintln(w, "No trace entries found.")
-		fmt.Fprintln(w, `Slow hooks are always traced. Every hook is traced at DEBUG level: set`)
-		fmt.Fprintln(w, `ENTIRE_LOG_LEVEL=DEBUG in your shell profile, or log_level to "DEBUG" in`)
-		fmt.Fprintln(w, `.entire/settings.json.`)
+		fmt.Fprintf(w, "By default, hooks taking %s or longer are traced at WARN; set %s=0\n",
+			perf.DefaultSlowSpanThreshold, perf.SlowSpanEnvVar)
+		fmt.Fprintln(w, `to turn that off, and note that a log_level above WARN hides them too.`)
+		fmt.Fprintln(w, `To trace every hook, set ENTIRE_LOG_LEVEL=DEBUG in your shell profile,`)
+		fmt.Fprintln(w, `or log_level to "DEBUG" in .entire/settings.json.`)
 		return
 	}
 

--- a/cmd/entire/cli/trace.go
+++ b/cmd/entire/cli/trace.go
@@ -249,8 +249,9 @@ func collectTraceEntries(logFile string, last int, hookFilter string) ([]traceEn
 func renderTraceEntries(w io.Writer, entries []traceEntry) {
 	if len(entries) == 0 {
 		fmt.Fprintln(w, "No trace entries found.")
-		fmt.Fprintln(w, `Traces are logged at DEBUG level. Make sure ENTIRE_LOG_LEVEL=DEBUG is set`)
-		fmt.Fprintln(w, `in your shell profile, or set log_level to "DEBUG" in .entire/settings.json.`)
+		fmt.Fprintln(w, `Slow hooks are always traced. Every hook is traced at DEBUG level: set`)
+		fmt.Fprintln(w, `ENTIRE_LOG_LEVEL=DEBUG in your shell profile, or log_level to "DEBUG" in`)
+		fmt.Fprintln(w, `.entire/settings.json.`)
 		return
 	}
 

--- a/docs/architecture/commit-hook-perf-analysis.md
+++ b/docs/architecture/commit-hook-perf-analysis.md
@@ -146,3 +146,32 @@ go test -v -run TestCommitHookPerformance -tags hookperf -timeout 15m ./cmd/enti
 ```
 
 Requires GitHub access for cloning. Sessions are generated from repo commit history (no external templates needed).
+
+## Measuring a real hook instead of a synthetic one
+
+The synthetic harness above took several iterations to match production (see
+"Impact of test methodology"), which is the usual failure mode: a hook that is slow
+in a real repo often is not slow in a reconstructed one. Prefer reading production
+timings first.
+
+Every hook is wrapped in a root `perf` span (`perf/span.go`), so each invocation
+emits one log line carrying the full per-step tree. Root spans that take at least
+1.5s log at WARN with `slow=true`, so a slow hook records its own breakdown in a
+default (INFO-level) session — no DEBUG, no reproduction:
+
+```bash
+grep '"slow":true' .entire/logs/entire.log   # slow hooks, with steps.*_ms
+entire doctor trace --last 5                 # rendered as a step table
+```
+
+Set `ENTIRE_PERF_SLOW_MS` to change the threshold (`0` disables escalation). Every
+hook — fast ones included — is traced at DEBUG.
+
+Two traps worth avoiding when benchmarking hooks by hand:
+
+- **Do not benchmark in this repo.** Its hooks run through `scripts/entire-dev`,
+  which builds and `go run`s the CLI on every invocation — a fixed cost no other
+  repo and no user pays. Use a compiled binary in a different repo.
+- **`git clone` does not copy `refs/entire/*`.** A clone silently has no checkpoint
+  history, so it cannot reproduce costs that scale with accumulated sessions or
+  refs. Copy the repo (`cp -Rc` on APFS) instead.

--- a/perf/span.go
+++ b/perf/span.go
@@ -16,7 +16,7 @@ import (
 // root span logs at DEBUG as it did before.
 const SlowSpanEnvVar = "ENTIRE_PERF_SLOW_MS"
 
-// defaultSlowSpanThreshold is how long a root span must take before its timing
+// DefaultSlowSpanThreshold is how long a root span must take before its timing
 // tree is logged at WARN instead of DEBUG.
 //
 // Root spans carry the only per-step breakdown of a hook, and they used to log
@@ -27,7 +27,7 @@ const SlowSpanEnvVar = "ENTIRE_PERF_SLOW_MS"
 //
 // 1.5s sits above what a healthy hook costs and below the observed slow cluster,
 // so fast turns stay silent instead of logging a WARN every turn.
-const defaultSlowSpanThreshold = 1500 * time.Millisecond
+const DefaultSlowSpanThreshold = 1500 * time.Millisecond
 
 // slowSpanThreshold reports the duration above which a root span is considered
 // slow. Invalid values fall back to the default rather than disabling
@@ -35,11 +35,11 @@ const defaultSlowSpanThreshold = 1500 * time.Millisecond
 func slowSpanThreshold() time.Duration {
 	raw, ok := os.LookupEnv(SlowSpanEnvVar)
 	if !ok {
-		return defaultSlowSpanThreshold
+		return DefaultSlowSpanThreshold
 	}
 	ms, err := strconv.Atoi(raw)
 	if err != nil {
-		return defaultSlowSpanThreshold
+		return DefaultSlowSpanThreshold
 	}
 	if ms <= 0 {
 		// Explicit opt-out: never escalate.

--- a/perf/span.go
+++ b/perf/span.go
@@ -4,10 +4,56 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
+
+// SlowSpanEnvVar overrides the slow-root-span threshold, in milliseconds.
+// A value of 0 (or a negative one) disables level escalation entirely, so every
+// root span logs at DEBUG as it did before.
+const SlowSpanEnvVar = "ENTIRE_PERF_SLOW_MS"
+
+// defaultSlowSpanThreshold is how long a root span must take before its timing
+// tree is logged at WARN instead of DEBUG.
+//
+// Root spans carry the only per-step breakdown of a hook, and they used to log
+// exclusively at DEBUG. Real sessions run at INFO, so a hook that took seconds
+// left behind no record of *which* step took them — the one case anybody needs
+// the breakdown for. Escalating slow spans means a real session captures its own
+// diagnosis without the user reproducing anything or turning on DEBUG.
+//
+// 1.5s sits above what a healthy hook costs and below the observed slow cluster,
+// so fast turns stay silent instead of logging a WARN every turn.
+const defaultSlowSpanThreshold = 1500 * time.Millisecond
+
+// slowSpanThreshold reports the duration above which a root span is considered
+// slow. Invalid values fall back to the default rather than disabling
+// escalation, so a typo does not silently switch the diagnostics off.
+func slowSpanThreshold() time.Duration {
+	raw, ok := os.LookupEnv(SlowSpanEnvVar)
+	if !ok {
+		return defaultSlowSpanThreshold
+	}
+	ms, err := strconv.Atoi(raw)
+	if err != nil {
+		return defaultSlowSpanThreshold
+	}
+	if ms <= 0 {
+		// Explicit opt-out: never escalate.
+		return 0
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// isSlowSpan reports whether d is long enough to warrant escalating a root
+// span's log line from DEBUG to WARN.
+func isSlowSpan(d time.Duration) bool {
+	threshold := slowSpanThreshold()
+	return threshold > 0 && d >= threshold
+}
 
 // Span tracks timing for an operation and its substeps.
 // A Span is not safe for concurrent use from multiple goroutines.
@@ -50,8 +96,10 @@ func (s *Span) RecordError(err error) {
 	s.err = err
 }
 
-// End completes the span. For root spans, emits a single DEBUG log line
-// with the full timing tree. For child spans, records the duration only.
+// End completes the span. For root spans, emits a single log line with the full
+// timing tree -- at DEBUG normally, or at WARN with slow=true when the span
+// exceeded slowSpanThreshold so the breakdown survives a default-level session.
+// For child spans, records the duration only.
 // Safe to call multiple times -- subsequent calls are no-ops.
 func (s *Span) End() {
 	if s.ended {
@@ -73,12 +121,23 @@ func (s *Span) End() {
 		attrs = append(attrs, slog.Bool("error", true))
 	}
 
+	// Decide the level before appending the step tree so "slow" sits next to
+	// duration_ms rather than after a long tail of step attrs.
+	slow := isSlowSpan(s.duration)
+	if slow {
+		attrs = append(attrs, slog.Bool("slow", true))
+	}
+
 	attrs = appendChildStepAttrs(attrs, s, "")
 
 	for _, a := range s.attrs {
 		attrs = append(attrs, a)
 	}
 
+	if slow {
+		logging.Warn(logCtx, "perf", attrs...)
+		return
+	}
 	logging.Debug(logCtx, "perf", attrs...)
 }
 

--- a/perf/span_test.go
+++ b/perf/span_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -469,4 +470,65 @@ func TestEnd_NoErrorFlagByDefault(t *testing.T) {
 	if parent.err != nil {
 		t.Errorf("parent span should have nil error, got %v", parent.err)
 	}
+}
+
+// Env-var tests cannot use t.Parallel(): t.Setenv panics if the test is parallel.
+
+func TestSlowSpanThreshold_DefaultWhenUnset(t *testing.T) {
+	t.Setenv(SlowSpanEnvVar, "")
+	os.Unsetenv(SlowSpanEnvVar)
+	require.Equal(t, defaultSlowSpanThreshold, slowSpanThreshold())
+}
+
+func TestSlowSpanThreshold_HonorsOverride(t *testing.T) {
+	t.Setenv(SlowSpanEnvVar, "250")
+	require.Equal(t, 250*time.Millisecond, slowSpanThreshold())
+}
+
+func TestSlowSpanThreshold_InvalidFallsBackToDefault(t *testing.T) {
+	// A typo must not silently disable slow-hook diagnostics.
+	t.Setenv(SlowSpanEnvVar, "not-a-number")
+	require.Equal(t, defaultSlowSpanThreshold, slowSpanThreshold())
+}
+
+func TestSlowSpanThreshold_ZeroOptsOut(t *testing.T) {
+	t.Setenv(SlowSpanEnvVar, "0")
+	require.Zero(t, slowSpanThreshold())
+}
+
+func TestIsSlowSpan_BoundaryIsInclusive(t *testing.T) {
+	t.Setenv(SlowSpanEnvVar, "100")
+	require.False(t, isSlowSpan(99*time.Millisecond))
+	require.True(t, isSlowSpan(100*time.Millisecond))
+	require.True(t, isSlowSpan(101*time.Millisecond))
+}
+
+func TestIsSlowSpan_OptOutNeverEscalates(t *testing.T) {
+	t.Setenv(SlowSpanEnvVar, "0")
+	require.False(t, isSlowSpan(time.Hour))
+}
+
+func TestEnd_SlowRootSpanCarriesSlowAttr(t *testing.T) {
+	t.Setenv(SlowSpanEnvVar, "10")
+
+	root := testEndedSpan("stop", 0)
+	root.ended = false
+	root.start = time.Now().Add(-50 * time.Millisecond)
+	root.ctx = context.Background()
+	root.End()
+
+	require.True(t, isSlowSpan(root.duration),
+		"a 50ms span must count as slow at a 10ms threshold")
+}
+
+func TestEnd_FastRootSpanIsNotSlow(t *testing.T) {
+	t.Setenv(SlowSpanEnvVar, "5000")
+
+	root := testEndedSpan("stop", 0)
+	root.ended = false
+	root.start = time.Now()
+	root.ctx = context.Background()
+	root.End()
+
+	require.False(t, isSlowSpan(root.duration))
 }

--- a/perf/span_test.go
+++ b/perf/span_test.go
@@ -477,7 +477,7 @@ func TestEnd_NoErrorFlagByDefault(t *testing.T) {
 func TestSlowSpanThreshold_DefaultWhenUnset(t *testing.T) {
 	t.Setenv(SlowSpanEnvVar, "")
 	os.Unsetenv(SlowSpanEnvVar)
-	require.Equal(t, defaultSlowSpanThreshold, slowSpanThreshold())
+	require.Equal(t, DefaultSlowSpanThreshold, slowSpanThreshold())
 }
 
 func TestSlowSpanThreshold_HonorsOverride(t *testing.T) {
@@ -488,7 +488,7 @@ func TestSlowSpanThreshold_HonorsOverride(t *testing.T) {
 func TestSlowSpanThreshold_InvalidFallsBackToDefault(t *testing.T) {
 	// A typo must not silently disable slow-hook diagnostics.
 	t.Setenv(SlowSpanEnvVar, "not-a-number")
-	require.Equal(t, defaultSlowSpanThreshold, slowSpanThreshold())
+	require.Equal(t, DefaultSlowSpanThreshold, slowSpanThreshold())
 }
 
 func TestSlowSpanThreshold_ZeroOptsOut(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1040
<!-- entire-trail-link-end -->

## Problem

Root `perf` spans carry the only per-step breakdown of a hook, and they logged exclusively at DEBUG. Real sessions run at INFO, so **a hook that took seconds left behind no record of which step took them** — the one case the breakdown exists for.

Diagnosing a slow hook therefore meant asking the user to set DEBUG and reproduce, or rebuilding a synthetic harness. `docs/architecture/commit-hook-perf-analysis.md` shows how unreliable that second path is: its harness took four iterations before it matched production (`~18ms` → `~73-103ms` per session).

This came out of investigating a "~1.76s slow hook" report. Mining `stop_hook_summary.hookInfos[].durationMs` from real transcripts (477 samples) and Entire's own INFO logs (1363 samples) put the real median at **~3.4s** for `turn-end` → shadow-commit, bimodally distributed with a hard ~3s floor on roughly half of invocations. No synthetic reproduction got past ~1.1s, i.e. only ever the fast mode. The step that owns the ~3s is still unidentified — precisely because the breakdown was never recorded in the sessions where it happens.

## Change

Escalate root spans at or above **1.5s** to WARN with `slow=true`. Fast turns stay silent, so this adds no per-turn noise; slow ones now record their own breakdown at the default log level, with no configuration and no reproduction.

1.5s sits above what a healthy hook costs and below the slow cluster observed in real logs.

`ENTIRE_PERF_SLOW_MS` overrides the threshold; `0` opts out. An unparseable value falls back to the default rather than silently disabling the diagnostics.

No new instrumentation was added — every hook is already wrapped in a root span (`hook_registry.go:140`, `hooks_git_cmd.go:43`) with the step tree serialized as `steps.<name>_ms`. Only the level was wrong.

## Verification

At **default** log level (no DEBUG, no env vars beyond the forced threshold), the emitted line names the dominant step:

```
level=WARN  op=stop  duration_ms=696  slow=True
   prepare_and_validate_transcript     512 ms
   write_temporary_checkpoint          109 ms
   detect_file_changes                  15 ms
   filter_and_normalize_paths            2 ms
```

`entire doctor trace` renders these unchanged. Confirmed a sub-threshold hook emits nothing.

- 8 new tests: env parsing, default fallback on invalid input, inclusive boundary, opt-out. Non-parallel, since `t.Setenv` panics under `t.Parallel()`.
- `mise run fmt && mise run lint` clean (0 issues); `mise run test:ci` green including the Vogon canary.

## Docs

- `doctor trace`'s empty-state help no longer claims traces are DEBUG-only.
- The perf-analysis doc gains a section on reading production timings before reaching for a synthetic harness, recording two traps found the hard way during this investigation:
  - **Don't benchmark in this repo** — its hooks run through `scripts/entire-dev`, which `go build`s and `go run`s the CLI on every invocation (~1.5s warm). No other repo and no user pays that, and it silently dominates any measurement taken here.
  - **`git clone` does not copy `refs/entire/*`** — a clone has no checkpoint history at all, so it cannot reproduce costs that scale with accumulated sessions or refs. Copy the repo instead (`cp -Rc` on APFS).

## Follow-up

This is a diagnostic, not a fix. Once slow traces accumulate, `grep '"slow":true'` across repos should name the step owning the ~3s. One caveat: if the time is spent *between* instrumented spans, the total will exceed the sum of its steps — still diagnostic, but it would mean a second pass to add spans in the uncovered region.

Separately found and not included here: `waitForTranscriptFlush` waits for a `hook_progress` transcript entry that Claude Code no longer writes (0 occurrences across 40 real transcripts), so it always falls through to a fixed ~520ms quiet window. That's the `prepare_and_validate_transcript` line above. Real but ~15% of the 3.4s median, and fixing it trades against reading a truncated transcript, so it needs its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only logging and documentation; hook behavior is unchanged aside from WARN lines for slow root spans.
> 
> **Overview**
> Root hook **perf** spans used to emit their full step tree only at **DEBUG**, so typical **INFO** sessions left no breakdown when a hook ran slow. Spans at or above **1.5s** (override via **`ENTIRE_PERF_SLOW_MS`**, **`0`** to disable, invalid values fall back to the default) now log at **WARN** with **`slow=true`** and the same **`steps.*_ms`** tree, so slow hooks self-diagnose without DEBUG or reproduction.
> 
> **`entire doctor trace`** empty-state help and the commit-hook perf doc were updated to describe **`grep '"slow":true'`**, **`entire doctor trace`**, and manual benchmarking pitfalls (dev wrapper rebuild cost, **`git clone`** missing **`refs/entire/*`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83fa172b2594cddb950665b0a68ea0dfe01d2daf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->