### PR TITLE
perf(gitrepo): share one process-wide go-git object cache

### DIFF
--- a/cmd/entire/cli/gitrepo/repository.go
+++ b/cmd/entire/cli/gitrepo/repository.go
@@ -20,6 +20,11 @@ import (
 
 const gitDir = ".git"
 
+// sharedObjectCache is one process-wide object cache. go-git uses the cache
+// passed to the storage as its delta-base cache, so a per-open cache makes
+// every open re-read pack data from scratch.
+var sharedObjectCache = cache.NewObjectLRUDefault()
+
 // OpenCurrent opens the current git worktree with object alternates enabled.
 // The caller owns the returned repository and must close it.
 func OpenCurrent(ctx context.Context) (*git.Repository, error) {
@@ -113,7 +118,7 @@ func openPathWithAlternates(repoRoot string) (*git.Repository, error) {
 	// an OS-rooted filesystem lets go-git follow those paths outside .git.
 	storage := gitfilesystem.NewStorageWithOptions(
 		repositoryFS,
-		cache.NewObjectLRUDefault(),
+		sharedObjectCache,
 		gitfilesystem.Options{
 			AlternatesFS: newAlternatesFilesystem(),
 		},


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1041
<!-- entire-trail-link-end -->

## Problem

go-git uses the cache passed to `NewStorageWithOptions` as its **delta-base** cache, not merely as a recently-loaded-object cache:

```go
// storage/filesystem/object.go
// objectCache is an object cache used to cache delta's bases and also recently
// loaded loose objects.
...
packfile.WithCache(s.objectCache),
```

`gitrepo` constructed a fresh `cache.NewObjectLRUDefault()` on every open, so each open started cold and re-read pack data that a warm cache would have served.

## Change

Hoist it to one shared process-wide instance. `gitrepo` is the single sanctioned place that opens a repository, so this is the only construction site and no callers change.

## Measurements

On a 447MB-pack repo, turn-start hook:

| | reads | bytes |
|---|---|---|
| per-open cache (before) | 28,378 | 12.1 MB |
| shared cache (after) | 18,075 | 8.8 MB |
| | **−36%** | **−27%** |

Memory drops as well: one 96 MiB-capacity cache for the process instead of one per open.

**Latency is a wash** — 166ms → 162ms median, interleaved A/B after warming both binaries. Those reads are page-cache-warm and therefore cheap. So this is worth having for the read-traffic and memory reduction, not as a latency fix.

Worth recording because it nearly went in as a headline number: measured *sequentially* (all of variant A, then all of variant B) it looks like 327ms → 168ms, a 49% win. That is page-cache warming leaking across the A/B boundary, not a real effect. Interleaving after warmup collapses it to 2%:

```
per-open (before): [166 164 168 165 171 168 166 164]  median=166ms
shared   (after) : [161 161 165 167 167 163 161 160]  median=162ms
```

## Why sharing is safe

Verified against the pinned go-git (`v6.0.0-alpha.5.0.20260812095450`):

- `cache.ObjectLRU` guards `Put`/`Get`/`Clear` with a `sync.Mutex`, so concurrent readers are fine.
- `Storage.Close()` / `ObjectStorage.Close()` close alternates and pack indexes but **do not** clear the object cache, so the existing `storage.Close()` calls don't defeat sharing. The only `Clear()` calls in `storage/filesystem` are on the separate `statIndexCache`.
- Objects are content-addressed, so entries stay valid even across different repositories opened in one process.

## Testing

`mise run fmt && mise run lint` clean (0 issues). `gitrepo` and `strategy` package tests pass, including the reftable and alternates paths that share this construction site.

## Context

This came out of investigating a slow-hook report. It was the change originally proposed as the fix, predicted at ~4× based on a synthetic loop re-reading 733 blobs of one tree. Against the real hook it is 2%, because the hook's access pattern is far less delta-bound than that loop. Shipping it on its own merits, separately from the diagnostics work in #1984, which is where the actual slow-hook investigation continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0c57e4e4bfca320952879ed7b68785c3e1683cfa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->