### PR TITLE
fix(redact): fail closed when OPF is enabled with no categories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -692,7 +692,7 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
 - `strategy.go` - Interface definition and context structs (`StepContext`, `TaskStepContext`, `RewindPoint`, etc.)
 - `common.go` - Helpers for metadata extraction, tree building, rewind validation, `ListCheckpoints()`
 - `manual_commit*.go` - Manual-commit strategy: main impl, types, session state, condensation, rewind, git ops, logs, hook handlers (prepare-commit-msg, post-commit, post-rewrite, pre-push), reset
-- `manual_commit_opf_rewrite.go` - Pre-push OPF re-redaction: walks unpushed v1 commits, runs OPF over their blobs, rebuilds commits with `Entire-OPF-Applied: true` trailer, CAS-updates the local ref. Sentinel error types (use `errors.As`): `V1DivergedError`, `BootstrapTooLargeError`, `V1RefMovedError`, `OPFRuntimeFailedError`.
+- `manual_commit_opf_rewrite.go` - Pre-push OPF re-redaction: walks unpushed v1 commits, runs OPF over their blobs, rebuilds commits with `Entire-OPF-Applied: true` trailer, CAS-updates the local ref. Sentinel error types (use `errors.As`): `V1DivergedError`, `BootstrapTooLargeError`, `V1RefMovedError`, `OPFRuntimeFailedError`, `OPFNoCategoriesError` (OPF enabled with zero effective categories — the rewrite fails closed instead of stamping the trailer without a scan).
 - `cleanup.go` - Cleanup discovery/deletion for shadow branches, session states, and checkpoint metadata
 - `session_state.go` - Package-level session state functions
 - `hooks.go` - Git hook installation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -692,7 +692,7 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
 - `strategy.go` - Interface definition and context structs (`StepContext`, `TaskStepContext`, `RewindPoint`, etc.)
 - `common.go` - Helpers for metadata extraction, tree building, rewind validation, `ListCheckpoints()`
 - `manual_commit*.go` - Manual-commit strategy: main impl, types, session state, condensation, rewind, git ops, logs, hook handlers (prepare-commit-msg, post-commit, post-rewrite, pre-push), reset
-- `manual_commit_opf_rewrite.go` - Pre-push OPF re-redaction: walks unpushed v1 commits, runs OPF over their blobs, rebuilds commits with `Entire-OPF-Applied: true` trailer, CAS-updates the local ref. Sentinel error types (use `errors.As`): `V1DivergedError`, `BootstrapTooLargeError`, `V1RefMovedError`, `OPFRuntimeFailedError`, `OPFNoCategoriesError` (OPF enabled with zero effective categories — the rewrite fails closed instead of stamping the trailer without a scan).
+- `manual_commit_opf_rewrite.go` - Pre-push OPF re-redaction: walks unpushed v1 commits, runs OPF over their blobs, rebuilds commits with `Entire-OPF-Applied: true` trailer, CAS-updates the local ref. Sentinel error types (use `errors.As`): `V1DivergedError`, `BootstrapTooLargeError`, `V1RefMovedError`, `OPFRuntimeFailedError`, `OPFBatchTooLargeError`, `OPFRawBytesTooLargeError`, `OPFNoCategoriesError` (OPF enabled with zero effective categories — the pre-push decision and the rewrite both fail closed instead of stamping the trailer without a scan).
 - `cleanup.go` - Cleanup discovery/deletion for shadow branches, session states, and checkpoint metadata
 - `session_state.go` - Package-level session state functions
 - `hooks.go` - Git hook installation

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -2407,8 +2407,12 @@ func createRedactedBlobFromFile(ctx context.Context, repo *git.Repository, fileP
 // string leaves and applies OPF only to those, preserving the JSON
 // structure.
 //
-// Post-commit condensation uses false (fast path). The pre-push rewrite
-// (strategy/manual_commit_opf_rewrite.go) uses true.
+// Post-commit condensation uses false (fast path). The pre-push
+// rewrite does NOT come through here — it batches all blobs through
+// redact.BatchBytesWithPrivacyFilter, which fails closed on an
+// enabled-but-no-categories OPF config; the true path below silently
+// falls back to regex-only in that state, so it must not be wired
+// into any flow that stamps the Entire-OPF-Applied trailer.
 func RedactBlobBytes(ctx context.Context, content []byte, treePath string, usePrivacyFilter bool) []byte {
 	if strings.HasSuffix(treePath, ".jsonl") || strings.HasSuffix(treePath, ".json") {
 		var (

--- a/cmd/entire/cli/hooks_git_cmd.go
+++ b/cmd/entire/cli/hooks_git_cmd.go
@@ -333,7 +333,8 @@ func newHooksGitPrePushCmd() *cobra.Command {
 			// git push aborts the entire batch. PrePush itself only
 			// returns errors for privacy-critical failures (OPF rewrite —
 			// e.g., V1DivergedError, BootstrapTooLargeError,
-			// V1RefMovedError, OPFRuntimeFailedError); transient
+			// V1RefMovedError, OPFRuntimeFailedError,
+			// OPFNoCategoriesError); transient
 			// checkpoint-push failures are logged and swallowed before
 			// reaching this point. See strategy/manual_commit_push.go
 			// for the contract. We wrap with a short "pre-push:" prefix

--- a/cmd/entire/cli/strategy/manual_commit_opf_prompt.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_prompt.go
@@ -15,6 +15,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/uiform"
+	"github.com/entireio/cli/redact"
 )
 
 // OPFDecision is the resolved gate for a single pre-push OPF run.
@@ -32,12 +33,28 @@ const envOPF = "ENTIRE_OPF"
 // first): ENTIRE_OPF env var → settings.PromptDefault → interactive
 // prompt → non-TTY fallback (run).
 //
+// misconfigured is redact.OPFMisconfiguredNoCategories(): OPF enabled
+// with zero effective categories, so the model scan cannot run. Any
+// resolution that would run OPF (env yes, prompt_default always,
+// non-TTY auto-run) fails closed with OPFNoCategoriesError, and the
+// prompt is never shown — asking "Run OPF?" for a scan guaranteed to
+// abort would be noise, and answering "Always" would persist
+// prompt_default before the failure surfaces. Explicit skips (env no,
+// prompt_default never) still resolve to OPFSkip: they push regex-only
+// content without the trailer, which is an honest opt-out.
+//
 // Pure logic — prompter is only called when the user needs to decide.
 // Tests inject a fake.
-func resolveOPFDecision(env, promptDefault string, hasTTY bool, prompter func() (OPFDecision, error)) (OPFDecision, error) {
+func resolveOPFDecision(env, promptDefault string, hasTTY, misconfigured bool, prompter func() (OPFDecision, error)) (OPFDecision, error) {
+	failClosedOr := func(d OPFDecision) (OPFDecision, error) {
+		if misconfigured {
+			return OPFAbort, &OPFNoCategoriesError{}
+		}
+		return d, nil
+	}
 	switch strings.ToLower(strings.TrimSpace(env)) {
 	case "yes":
-		return OPFRun, nil
+		return failClosedOr(OPFRun)
 	case "no":
 		return OPFSkip, nil
 	}
@@ -45,13 +62,16 @@ func resolveOPFDecision(env, promptDefault string, hasTTY bool, prompter func() 
 	case settings.OPFPromptNever:
 		return OPFSkip, nil
 	case settings.OPFPromptAlways:
-		return OPFRun, nil
+		return failClosedOr(OPFRun)
 	}
 	if !hasTTY {
 		// Non-interactive context: run OPF (matches the user's "if
 		// enabled, just run" preference). The caller emits a progress
 		// line at run time so scripted output isn't silent.
-		return OPFRun, nil
+		return failClosedOr(OPFRun)
+	}
+	if misconfigured {
+		return OPFAbort, &OPFNoCategoriesError{}
 	}
 	return prompter()
 }
@@ -71,6 +91,7 @@ func resolveOPFDecisionForPrePush(ctx context.Context, opf *settings.OPFSettings
 		os.Getenv(envOPF),
 		promptDefault,
 		hasTTY,
+		redact.OPFMisconfiguredNoCategories(),
 		func() (OPFDecision, error) { return askOPFPrompt(ctx) },
 	)
 	if err != nil {

--- a/cmd/entire/cli/strategy/manual_commit_opf_prompt_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_prompt_test.go
@@ -40,6 +40,7 @@ func TestResolveOPFDecision_Precedence(t *testing.T) {
 		env            string
 		promptDefault  string
 		hasTTY         bool
+		misconfigured  bool
 		prompter       func() (OPFDecision, error)
 		want           OPFDecision
 		wantErr        bool
@@ -67,11 +68,23 @@ func TestResolveOPFDecision_Precedence(t *testing.T) {
 		// Unrecognized env values fall through to next layer
 		{name: "env_bogus_falls_through_to_setting", env: "maybe", promptDefault: settings.OPFPromptAlways, hasTTY: true, prompter: promptNever, want: OPFRun},
 		{name: "env_empty_falls_through_to_setting", env: "", promptDefault: settings.OPFPromptAlways, hasTTY: true, prompter: promptNever, want: OPFRun},
+		// Misconfigured (OPF enabled, zero effective categories): any
+		// resolution that would run OPF fails closed with
+		// OPFNoCategoriesError, and the prompt is never shown — asking
+		// would offer a scan guaranteed to abort, and "Always" would
+		// persist prompt_default before the failure surfaces. Explicit
+		// skips stay honest opt-outs (regex-only push, no trailer).
+		{name: "misconfigured_env_no_still_skips", env: "no", promptDefault: "", hasTTY: true, misconfigured: true, prompter: promptNever, want: OPFSkip},
+		{name: "misconfigured_setting_never_still_skips", env: "", promptDefault: settings.OPFPromptNever, hasTTY: true, misconfigured: true, prompter: promptNever, want: OPFSkip},
+		{name: "misconfigured_env_yes_fails_closed", env: "yes", promptDefault: "", hasTTY: true, misconfigured: true, prompter: promptNever, want: OPFAbort, wantErr: true, wantErrMessage: "no detection category"},
+		{name: "misconfigured_setting_always_fails_closed", env: "", promptDefault: settings.OPFPromptAlways, hasTTY: true, misconfigured: true, prompter: promptNever, want: OPFAbort, wantErr: true, wantErrMessage: "no detection category"},
+		{name: "misconfigured_tty_ask_fails_closed_without_prompting", env: "", promptDefault: settings.OPFPromptAsk, hasTTY: true, misconfigured: true, prompter: promptNever, want: OPFAbort, wantErr: true, wantErrMessage: "no detection category"},
+		{name: "misconfigured_no_tty_fails_closed", env: "", promptDefault: "", hasTTY: false, misconfigured: true, prompter: promptNever, want: OPFAbort, wantErr: true, wantErrMessage: "no detection category"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := resolveOPFDecision(tc.env, tc.promptDefault, tc.hasTTY, tc.prompter)
+			got, err := resolveOPFDecision(tc.env, tc.promptDefault, tc.hasTTY, tc.misconfigured, tc.prompter)
 			if tc.wantErr {
 				require.Error(t, err)
 				if tc.wantErrMessage != "" {

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -114,10 +114,14 @@ func (e *OPFRuntimeFailedError) Unwrap() error {
 // cannot run. Proceeding would stamp Entire-OPF-Applied on commits OPF
 // never saw, and later rewrites would skip them permanently — even
 // after the user fixes the config. Abort the push with remediation
-// instead. The rewrite-level gate is deliberately unconditional: it
-// aborts even a re-parent-only push (every unpushed commit already
-// tagged), keeping the invariant simple rather than poking a
-// no-new-stamping hole through it.
+// instead. Two gates enforce this: the decision gate in prePush runs
+// whenever OPF is enabled, with no knowledge of whether anything is
+// unpushed, so a misconfigured repo aborts every push — including one
+// with nothing to rewrite. The rewrite-level gate in
+// RewriteUnpushedV1WithOPF sits after the no-work early returns and
+// fires only when commits are unpushed; it deliberately aborts even a
+// re-parent-only push (every unpushed commit already tagged) rather
+// than poking a no-new-stamping hole through the invariant.
 type OPFNoCategoriesError struct{}
 
 func (e *OPFNoCategoriesError) Error() string {

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -96,6 +96,22 @@ func (e *OPFRuntimeFailedError) Error() string {
 		e.OPFCommand, e.OPFCommand)
 }
 
+// OPFNoCategoriesError: OPF is enabled but the effective category set
+// is empty (categories omitted, {}, or all-false), so the model scan
+// cannot run. Proceeding would stamp Entire-OPF-Applied on commits OPF
+// never saw, and later rewrites would skip them permanently — even
+// after the user fixes the config. Abort the push with remediation
+// instead.
+type OPFNoCategoriesError struct{}
+
+func (e *OPFNoCategoriesError) Error() string {
+	return "OpenAI Privacy Filter is enabled but no detection category is enabled, " +
+		"so the model scan cannot run; aborting push so unscanned content isn't " +
+		"tagged as OPF-applied. Enable at least one category (e.g. " +
+		`"private_person": true) under redaction.openai_privacy_filter.categories ` +
+		"in .entire/settings.json, or set enabled: false to push regex-only content."
+}
+
 const (
 	// bootstrapDefaultLimit caps first-push history rewrites. Picked
 	// to bound worst-case wall-clock at ~50min @ 30s/commit.
@@ -213,8 +229,9 @@ const rawByteCapMultiplier = 100
 //
 // Caller checks redact.OPFEnabled() and skips this when OPF is off.
 // Returns one of {V1DivergedError, BootstrapTooLargeError,
-// V1RefMovedError, OPFRuntimeFailedError} for privacy-critical
-// failures — the pre-push hook propagates these so git push aborts.
+// V1RefMovedError, OPFRuntimeFailedError, OPFNoCategoriesError} for
+// privacy-critical failures — the pre-push hook propagates these so
+// git push aborts.
 func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target string) (plumbing.Hash, error) {
 	localTip, err := readV1Tip(repo, plumbing.NewBranchReferenceName(paths.MetadataBranchName))
 	if err != nil {
@@ -249,6 +266,16 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 		if limit := resolveBootstrapLimit(); len(unpushed) > limit {
 			return plumbing.ZeroHash, &BootstrapTooLargeError{Count: len(unpushed), Limit: limit}
 		}
+	}
+
+	// Fail-closed defense: enabled-with-no-categories means the model
+	// scan can't run at all. Diagnose it here — before the breaker
+	// check and the batch call — so the user gets the config-specific
+	// remediation rather than OPFRuntimeFailedError's "verify your OPF
+	// install". BatchBytesWithPrivacyFilter rejects this state too, but
+	// its error would be wrapped as a runtime failure below.
+	if redact.OPFMisconfiguredNoCategories() {
+		return plumbing.ZeroHash, &OPFNoCategoriesError{}
 	}
 
 	// Fail-closed defense: if OPF is already broken at the start of

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -84,16 +84,29 @@ func (e *V1RefMovedError) Error() string {
 // commits as Entire-OPF-Applied would be a privacy regression (future
 // pushes would skip them while their content is regex-only). Abort
 // before CAS so the user fixes their OPF install and retries.
+//
+// Cause carries the underlying batch error when there is one (the
+// breaker-tripped-at-start construction has none) so the real failure
+// survives into the pre-push abort message and errors.Is/As chains.
 type OPFRuntimeFailedError struct {
 	OPFCommand string
+	Cause      error
 }
 
 func (e *OPFRuntimeFailedError) Error() string {
-	return fmt.Sprintf("OPF runtime failed during pre-push rewrite (command=%q); "+
+	msg := fmt.Sprintf("OPF runtime failed during pre-push rewrite (command=%q); "+
 		"aborting push so regex-only content isn't tagged as OPF-applied. "+
 		"Run `%s --help` to verify your OPF install, then retry. Or set "+
 		"ENTIRE_OPF=no on the push to skip OPF for this push only.",
 		e.OPFCommand, e.OPFCommand)
+	if e.Cause != nil {
+		msg += fmt.Sprintf(" (cause: %v)", e.Cause)
+	}
+	return msg
+}
+
+func (e *OPFRuntimeFailedError) Unwrap() error {
+	return e.Cause
 }
 
 // OPFNoCategoriesError: OPF is enabled but the effective category set
@@ -101,7 +114,10 @@ func (e *OPFRuntimeFailedError) Error() string {
 // cannot run. Proceeding would stamp Entire-OPF-Applied on commits OPF
 // never saw, and later rewrites would skip them permanently — even
 // after the user fixes the config. Abort the push with remediation
-// instead.
+// instead. The rewrite-level gate is deliberately unconditional: it
+// aborts even a re-parent-only push (every unpushed commit already
+// tagged), keeping the invariant simple rather than poking a
+// no-new-stamping hole through it.
 type OPFNoCategoriesError struct{}
 
 func (e *OPFNoCategoriesError) Error() string {
@@ -109,7 +125,9 @@ func (e *OPFNoCategoriesError) Error() string {
 		"so the model scan cannot run; aborting push so unscanned content isn't " +
 		"tagged as OPF-applied. Enable at least one category (e.g. " +
 		`"private_person": true) under redaction.openai_privacy_filter.categories ` +
-		"in .entire/settings.json, or set enabled: false to push regex-only content."
+		"in .entire/settings.json (or .entire/settings.local.json), set " +
+		"enabled: false to push regex-only content, or set ENTIRE_OPF=no on the " +
+		"push to skip OPF for this push only."
 }
 
 const (
@@ -229,7 +247,8 @@ const rawByteCapMultiplier = 100
 //
 // Caller checks redact.OPFEnabled() and skips this when OPF is off.
 // Returns one of {V1DivergedError, BootstrapTooLargeError,
-// V1RefMovedError, OPFRuntimeFailedError, OPFNoCategoriesError} for
+// V1RefMovedError, OPFRuntimeFailedError, OPFNoCategoriesError,
+// OPFBatchTooLargeError, OPFRawBytesTooLargeError} for
 // privacy-critical failures — the pre-push hook propagates these so
 // git push aborts.
 func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target string) (plumbing.Hash, error) {
@@ -269,11 +288,11 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 	}
 
 	// Fail-closed defense: enabled-with-no-categories means the model
-	// scan can't run at all. Diagnose it here — before the breaker
-	// check and the batch call — so the user gets the config-specific
-	// remediation rather than OPFRuntimeFailedError's "verify your OPF
-	// install". BatchBytesWithPrivacyFilter rejects this state too, but
-	// its error would be wrapped as a runtime failure below.
+	// scan can't run at all. The decision resolution in prePush already
+	// rejects this state before any prompt; this second gate covers
+	// direct callers and sits before the breaker check so the user gets
+	// the config-specific remediation rather than OPFRuntimeFailedError's
+	// "verify your OPF install".
 	if redact.OPFMisconfiguredNoCategories() {
 		return plumbing.ZeroHash, &OPFNoCategoriesError{}
 	}
@@ -350,7 +369,13 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 		}
 		globalRedacted, err = redact.BatchBytesWithPrivacyFilter(ctx, globalBlobs)
 		if err != nil {
-			return plumbing.ZeroHash, &OPFRuntimeFailedError{OPFCommand: redact.OPFCommand()}
+			// Converge with the up-front gate: the misconfiguration
+			// sentinel must surface config remediation, not "verify
+			// your OPF install".
+			if errors.Is(err, redact.ErrOPFNoEnabledCategories) {
+				return plumbing.ZeroHash, &OPFNoCategoriesError{}
+			}
+			return plumbing.ZeroHash, &OPFRuntimeFailedError{OPFCommand: redact.OPFCommand(), Cause: err}
 		}
 	}
 
@@ -572,10 +597,11 @@ func rebuildV1Commit(ctx context.Context, repo *git.Repository, oldCommit *objec
 // to "redact everything except the deferred file" means new types are
 // covered by default; opting out requires an explicit code change.
 //
-// RedactBlobBytes itself handles arbitrary content: .jsonl/.json go
-// through JSON-aware leaf redaction; anything else gets byte
-// redaction over the raw content. The OPF has-space gate excludes
-// binary blobs from paying inference cost.
+// The batch redactor (redact.BatchBytesWithPrivacyFilter, via
+// NamedBlob) handles arbitrary content: .jsonl/.json go through
+// JSON-aware leaf redaction; anything else gets byte redaction over
+// the raw content. The OPF has-space gate excludes binary blobs from
+// paying inference cost.
 func isRedactableBlobName(name string) bool {
 	return name != paths.ContentHashFileName
 }

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
@@ -98,11 +98,16 @@ type testOPFRuntime interface {
 // process-global OPF.
 func configureFakeOPF(t *testing.T, rt testOPFRuntime) {
 	t.Helper()
+	configureFakeOPFWithCategories(t, rt, map[string]bool{"private_person": true})
+}
+
+func configureFakeOPFWithCategories(t *testing.T, rt testOPFRuntime, cats map[string]bool) {
+	t.Helper()
 	redact.ResetOPFConfigForTest()
 	t.Cleanup(redact.ResetOPFConfigForTest)
 	redact.ConfigurePrivacyFilterWithRuntime(redact.OPFConfig{
 		Enabled:    true,
-		Categories: map[string]bool{"private_person": true},
+		Categories: cats,
 		Command:    "/tmp/test-opf",
 	}, rt)
 }
@@ -244,13 +249,7 @@ func TestRewriteUnpushedV1WithOPF_HappyPath_RewritesAndTagsApplied(t *testing.T)
 // then scan the same commits normally.
 func TestRewriteUnpushedV1WithOPF_NoEnabledCategoriesAbortsThenRepairs(t *testing.T) {
 	fake := &fakeOPFForRewrite{}
-	redact.ResetOPFConfigForTest()
-	t.Cleanup(redact.ResetOPFConfigForTest)
-	redact.ConfigurePrivacyFilterWithRuntime(redact.OPFConfig{
-		Enabled:    true,
-		Categories: map[string]bool{},
-		Command:    "/tmp/test-opf",
-	}, fake)
+	configureFakeOPFWithCategories(t, fake, map[string]bool{})
 	repo, originalTip := setupV1Repo(t)
 
 	_, err := RewriteUnpushedV1WithOPF(context.Background(), repo, "origin")
@@ -308,6 +307,70 @@ func TestPrePushFromGitHook_DeferralStillRunsOPF(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, trailers.HasOPFApplied(commit.Message))
 	require.Equal(t, 1, fake.batchCallCount())
+}
+
+// Regression: the no-categories abort must reach the git hook boundary.
+// PrePush deliberately swallows transient checkpoint-push failures, so
+// without this pin a refactor could downgrade the rewrite's fail-closed
+// errors to logged warnings and ship unscanned content off-machine.
+func TestPrePushFromGitHook_NoEnabledCategoriesAbortsPush(t *testing.T) {
+	fake := &fakeOPFForRewrite{}
+	configureFakeOPFWithCategories(t, fake, map[string]bool{})
+
+	dir, repo, originalTip := setupV1RepoInDir(t)
+	remoteDir := filepath.Join(t.TempDir(), "origin.git")
+	_, err := git.PlainInit(remoteDir, true)
+	require.NoError(t, err)
+	_, err = repo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{remoteDir}})
+	require.NoError(t, err)
+
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	err = NewManualCommitStrategy().PrePushFromGitHook(t.Context(), "origin")
+	var noCatErr *OPFNoCategoriesError
+	require.ErrorAs(t, err, &noCatErr)
+	require.Equal(t, 0, fake.batchCallCount())
+
+	ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+	require.Equal(t, originalTip, ref.Hash(), "aborted push must not move the v1 ref")
+	commit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	require.False(t, trailers.HasOPFApplied(commit.Message))
+}
+
+// Regression: ENTIRE_OPF=no must stay a working opt-out under the
+// no-categories misconfiguration — an explicit skip pushes regex-only
+// content without the trailer, so failing closed there would remove
+// the one-command unblock the abort message advertises.
+func TestPrePushFromGitHook_EnvSkipBypassesNoCategoriesAbort(t *testing.T) {
+	fake := &fakeOPFForRewrite{}
+	configureFakeOPFWithCategories(t, fake, map[string]bool{})
+
+	dir, repo, originalTip := setupV1RepoInDir(t)
+	remoteDir := filepath.Join(t.TempDir(), "origin.git")
+	_, err := git.PlainInit(remoteDir, true)
+	require.NoError(t, err)
+	_, err = repo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{remoteDir}})
+	require.NoError(t, err)
+
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Setenv("ENTIRE_OPF", "no")
+
+	require.NoError(t, NewManualCommitStrategy().PrePushFromGitHook(t.Context(), "origin"))
+	require.Equal(t, 0, fake.batchCallCount())
+
+	ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+	require.Equal(t, originalTip, ref.Hash(), "skipped OPF must leave the v1 ref as-is")
+	commit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	require.False(t, trailers.HasOPFApplied(commit.Message),
+		"opted-out push must not carry the OPF-applied trailer")
 }
 
 func TestRewriteUnpushedV1WithOPF_MultiCommitTipCarriesPriorRedactedShards(t *testing.T) {

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
@@ -236,6 +236,52 @@ func TestRewriteUnpushedV1WithOPF_HappyPath_RewritesAndTagsApplied(t *testing.T)
 	}))
 }
 
+// Regression: OPF enabled with an empty effective category set used
+// to succeed silently — the model scan
+// never ran, yet the rewrite stamped Entire-OPF-Applied: true, so later
+// rewrites skipped the commit permanently even after the user fixed the
+// config. The rewrite must abort instead, and a corrected config must
+// then scan the same commits normally.
+func TestRewriteUnpushedV1WithOPF_NoEnabledCategoriesAbortsThenRepairs(t *testing.T) {
+	fake := &fakeOPFForRewrite{}
+	redact.ResetOPFConfigForTest()
+	t.Cleanup(redact.ResetOPFConfigForTest)
+	redact.ConfigurePrivacyFilterWithRuntime(redact.OPFConfig{
+		Enabled:    true,
+		Categories: map[string]bool{},
+		Command:    "/tmp/test-opf",
+	}, fake)
+	repo, originalTip := setupV1Repo(t)
+
+	_, err := RewriteUnpushedV1WithOPF(context.Background(), repo, "origin")
+	var noCatErr *OPFNoCategoriesError
+	require.ErrorAs(t, err, &noCatErr)
+	require.Equal(t, 0, fake.batchCallCount(), "OPF must not be invoked with zero categories")
+
+	ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+	require.Equal(t, originalTip, ref.Hash(), "aborted rewrite must not move the v1 ref")
+	commit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	require.False(t, trailers.HasOPFApplied(commit.Message),
+		"no commit may carry Entire-OPF-Applied when the scan never ran")
+
+	// Fix the config: because the abort left no trailer behind, the same
+	// commits are still eligible and the next push scans them normally.
+	redact.ConfigurePrivacyFilterWithRuntime(redact.OPFConfig{
+		Enabled:    true,
+		Categories: map[string]bool{"private_person": true},
+		Command:    "/tmp/test-opf",
+	}, fake)
+	newTip, err := RewriteUnpushedV1WithOPF(context.Background(), repo, "origin")
+	require.NoError(t, err)
+	require.NotEqual(t, originalTip, newTip)
+	require.Equal(t, 1, fake.batchCallCount())
+	repaired, err := repo.CommitObject(newTip)
+	require.NoError(t, err)
+	require.True(t, trailers.HasOPFApplied(repaired.Message))
+}
+
 func TestPrePushFromGitHook_DeferralStillRunsOPF(t *testing.T) {
 	fake := &fakeOPFForRewrite{}
 	configureFakeOPF(t, fake)

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -103,6 +103,8 @@ Available categories (set to `true` to enable, `false` or omit to skip):
 
 Unknown category names are rejected at settings load time so typos surface immediately instead of silently disabling a category.
 
+Enabling the filter requires at least one enabled category. With `enabled: true` and no effective category (`categories` omitted, empty, or all-false) the model scan cannot run, so the pre-push rewrite aborts the push with a configuration error rather than tagging commits as OPF-applied without a scan. Enable a category or set `enabled: false` to proceed.
+
 Full settings reference:
 
 ```json

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -103,7 +103,7 @@ Available categories (set to `true` to enable, `false` or omit to skip):
 
 Unknown category names are rejected at settings load time so typos surface immediately instead of silently disabling a category.
 
-Enabling the filter requires at least one enabled category. With `enabled: true` and no effective category (`categories` omitted, empty, or all-false) the model scan cannot run, so the pre-push rewrite aborts the push with a configuration error rather than tagging commits as OPF-applied without a scan. Enable a category or set `enabled: false` to proceed.
+The filter needs at least one enabled category to run. This is enforced at push time, not settings load: with `enabled: true` and no effective category (`categories` omitted, empty, or all-false) the model scan cannot run, so the push aborts with a configuration error rather than tagging commits as OPF-applied without a scan. Enable a category, set `enabled: false`, or pass `ENTIRE_OPF=no` on a push to skip the filter for that push only.
 
 Full settings reference:
 

--- a/redact/batch.go
+++ b/redact/batch.go
@@ -40,18 +40,24 @@ type NamedBlob struct {
 // caller's hot-path code clean. Enabled with zero effective categories
 // is different: that returns ErrOPFNoEnabledCategories, because the
 // caller is about to stamp the Entire-OPF-Applied trailer and a silent
-// regex-only success here would make that attestation false.
+// regex-only success here would make that attestation false. The
+// zero-categories check runs BEFORE the breaker check so the guarantee
+// is unconditional — a tripped breaker must not downgrade the
+// misconfiguration back into silent regex-only success.
 func BatchBytesWithPrivacyFilter(ctx context.Context, inputs []NamedBlob) ([][]byte, error) {
 	if len(inputs) == 0 {
 		return nil, nil
 	}
 	cfg := getOPFConfig()
-	if cfg == nil || !cfg.Enabled || cfg.runtime == nil || opfBreakerTripped.Load() {
+	if cfg == nil || !cfg.Enabled || cfg.runtime == nil {
 		return applyRegexLayersToBlobs(inputs), nil
 	}
 	cats := enabledCategories(cfg)
 	if len(cats) == 0 {
 		return nil, ErrOPFNoEnabledCategories
+	}
+	if opfBreakerTripped.Load() {
+		return applyRegexLayersToBlobs(inputs), nil
 	}
 
 	// Pass 1: collect unique prose-shaped leaves across every blob.

--- a/redact/batch.go
+++ b/redact/batch.go
@@ -34,10 +34,13 @@ type NamedBlob struct {
 // (cross-blob walker) needs an explicit signal that OPF did not
 // finish.
 //
-// When OPF is unconfigured, disabled, has no enabled categories, or
-// the per-process circuit breaker has tripped, returns regex-only
-// output for every blob with no error. This matches the existing
-// non-batched paths and keeps the caller's hot-path code clean.
+// When OPF is unconfigured, disabled, or the per-process circuit
+// breaker has tripped, returns regex-only output for every blob with
+// no error. This matches the existing non-batched paths and keeps the
+// caller's hot-path code clean. Enabled with zero effective categories
+// is different: that returns ErrOPFNoEnabledCategories, because the
+// caller is about to stamp the Entire-OPF-Applied trailer and a silent
+// regex-only success here would make that attestation false.
 func BatchBytesWithPrivacyFilter(ctx context.Context, inputs []NamedBlob) ([][]byte, error) {
 	if len(inputs) == 0 {
 		return nil, nil
@@ -48,7 +51,7 @@ func BatchBytesWithPrivacyFilter(ctx context.Context, inputs []NamedBlob) ([][]b
 	}
 	cats := enabledCategories(cfg)
 	if len(cats) == 0 {
-		return applyRegexLayersToBlobs(inputs), nil
+		return nil, ErrOPFNoEnabledCategories
 	}
 
 	// Pass 1: collect unique prose-shaped leaves across every blob.

--- a/redact/batch.go
+++ b/redact/batch.go
@@ -40,21 +40,25 @@ type NamedBlob struct {
 // caller's hot-path code clean. Enabled with zero effective categories
 // is different: that returns ErrOPFNoEnabledCategories, because the
 // caller is about to stamp the Entire-OPF-Applied trailer and a silent
-// regex-only success here would make that attestation false. The
-// zero-categories check runs BEFORE the breaker check so the guarantee
-// is unconditional — a tripped breaker must not downgrade the
+// regex-only success here would make that attestation false. Enabled
+// with a nil runtime errors for the same reason. Both fail-closed
+// checks run BEFORE the breaker check so the guarantee is
+// unconditional — a tripped breaker must not downgrade a
 // misconfiguration back into silent regex-only success.
 func BatchBytesWithPrivacyFilter(ctx context.Context, inputs []NamedBlob) ([][]byte, error) {
 	if len(inputs) == 0 {
 		return nil, nil
 	}
 	cfg := getOPFConfig()
-	if cfg == nil || !cfg.Enabled || cfg.runtime == nil {
+	if cfg == nil || !cfg.Enabled {
 		return applyRegexLayersToBlobs(inputs), nil
 	}
 	cats := enabledCategories(cfg)
 	if len(cats) == 0 {
 		return nil, ErrOPFNoEnabledCategories
+	}
+	if cfg.runtime == nil {
+		return nil, errOPFNilRuntime
 	}
 	if opfBreakerTripped.Load() {
 		return applyRegexLayersToBlobs(inputs), nil

--- a/redact/batch_test.go
+++ b/redact/batch_test.go
@@ -513,6 +513,7 @@ func TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesWinsOverBreaker(t *testi
 	fake := &fakeRuntime{}
 	configureFakeOPF(t, fake, map[string]bool{})
 	opfBreakerTripped.Store(true)
+	t.Cleanup(func() { opfBreakerTripped.Store(false) })
 
 	inputs := []NamedBlob{
 		{Name: "x.jsonl", Content: []byte(`{"text":"Alice met Bob"}`)},
@@ -520,6 +521,33 @@ func TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesWinsOverBreaker(t *testi
 	out, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
 	if !errors.Is(err, ErrOPFNoEnabledCategories) {
 		t.Fatalf("want ErrOPFNoEnabledCategories despite tripped breaker, got %v", err)
+	}
+	if out != nil {
+		t.Errorf("want nil output on fail-closed error, got %d blobs", len(out))
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_NilRuntimeFailsClosed pins that an
+// enabled config with a nil runtime errors instead of silently
+// returning regex-only output — the caller stamps the
+// Entire-OPF-Applied trailer on any nil-error return. Unreachable
+// through ConfigurePrivacyFilter (it always constructs the shell-out
+// runtime), but the guarantee must hold by construction, not by that
+// property of the config lifecycle.
+func TestBatchBytesWithPrivacyFilter_NilRuntimeFailsClosed(t *testing.T) {
+	resetOPFConfig()
+	t.Cleanup(resetOPFConfig)
+	ConfigurePrivacyFilterWithRuntime(OPFConfig{
+		Enabled:    true,
+		Categories: map[string]bool{"private_person": true},
+	}, nil)
+
+	inputs := []NamedBlob{
+		{Name: "x.jsonl", Content: []byte(`{"text":"Alice met Bob"}`)},
+	}
+	out, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if !errors.Is(err, errOPFNilRuntime) {
+		t.Fatalf("want errOPFNilRuntime, got %v", err)
 	}
 	if out != nil {
 		t.Errorf("want nil output on fail-closed error, got %d blobs", len(out))

--- a/redact/batch_test.go
+++ b/redact/batch_test.go
@@ -460,24 +460,40 @@ func TestSumProseLeafBytes_CountsAcrossBlobShapes(t *testing.T) {
 	}
 }
 
-// TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesReturns7Layer
-// covers the configuration edge case where OPF is enabled but every
-// category is turned off — the model has nothing to look for, so we
-// skip the shell-out entirely and return regex-only output.
-func TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesReturns7Layer(t *testing.T) {
-	fake := &fakeRuntime{}
-	// Empty categories — Configure call still wires the runtime but
-	// enabledCategories returns nothing.
-	configureFakeOPF(t, fake, map[string]bool{})
+// TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesFailsClosed
+// covers the misconfiguration where OPF is enabled but the effective
+// category set is empty (empty map, all-false, or omitted). The model
+// scan cannot run, and the only caller stamps the Entire-OPF-Applied
+// trailer on success — so silently returning regex-only output here
+// produced a false attestation and made later rewrites skip the commit
+// permanently. Fail closed instead.
+func TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesFailsClosed(t *testing.T) {
+	cases := []struct {
+		name       string
+		categories map[string]bool
+	}{
+		{name: "empty_map", categories: map[string]bool{}},
+		{name: "nil_map", categories: nil},
+		{name: "all_false", categories: map[string]bool{"private_person": false}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeRuntime{}
+			configureFakeOPF(t, fake, tc.categories)
 
-	inputs := []NamedBlob{
-		{Name: "x.jsonl", Content: []byte(`{"text":"Alice met Bob"}`)},
-	}
-	_, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
-	if err != nil {
-		t.Fatalf("no-categories path should not error: %v", err)
-	}
-	if fake.batchCalls != 0 {
-		t.Errorf("want 0 OPF calls when no categories enabled, got %d", fake.batchCalls)
+			inputs := []NamedBlob{
+				{Name: "x.jsonl", Content: []byte(`{"text":"Alice met Bob"}`)},
+			}
+			out, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+			if !errors.Is(err, ErrOPFNoEnabledCategories) {
+				t.Fatalf("want ErrOPFNoEnabledCategories, got %v", err)
+			}
+			if out != nil {
+				t.Errorf("want nil output on fail-closed error, got %d blobs", len(out))
+			}
+			if fake.batchCalls != 0 {
+				t.Errorf("want 0 OPF calls when no categories enabled, got %d", fake.batchCalls)
+			}
+		})
 	}
 }

--- a/redact/batch_test.go
+++ b/redact/batch_test.go
@@ -475,6 +475,9 @@ func TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesFailsClosed(t *testing.T
 		{name: "empty_map", categories: map[string]bool{}},
 		{name: "nil_map", categories: nil},
 		{name: "all_false", categories: map[string]bool{"private_person": false}},
+		// Unknown keys are rejected at settings load, but OPFConfig is
+		// constructible directly; enabledCategories must filter them.
+		{name: "only_unknown_keys", categories: map[string]bool{"typo_category": true}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -495,5 +498,30 @@ func TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesFailsClosed(t *testing.T
 				t.Errorf("want 0 OPF calls when no categories enabled, got %d", fake.batchCalls)
 			}
 		})
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesWinsOverBreaker
+// pins the check ordering: a tripped circuit breaker must not
+// downgrade the no-categories misconfiguration back into silent
+// regex-only success — the caller stamps the Entire-OPF-Applied
+// trailer on any nil-error return. Unreachable through the production
+// config lifecycle today (Configure resets the breaker, and tripping
+// it requires an enabled category), but the guarantee must hold by
+// construction, not by that coincidence.
+func TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesWinsOverBreaker(t *testing.T) {
+	fake := &fakeRuntime{}
+	configureFakeOPF(t, fake, map[string]bool{})
+	opfBreakerTripped.Store(true)
+
+	inputs := []NamedBlob{
+		{Name: "x.jsonl", Content: []byte(`{"text":"Alice met Bob"}`)},
+	}
+	out, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if !errors.Is(err, ErrOPFNoEnabledCategories) {
+		t.Fatalf("want ErrOPFNoEnabledCategories despite tripped breaker, got %v", err)
+	}
+	if out != nil {
+		t.Errorf("want nil output on fail-closed error, got %d blobs", len(out))
 	}
 }

--- a/redact/opf.go
+++ b/redact/opf.go
@@ -107,9 +107,10 @@ func OPFEnabled() bool {
 // JSONLContentWithPrivacyFilter) still fall back silently in this
 // state because their callers do not attest that OPF ran.
 var ErrOPFNoEnabledCategories = errors.New(
-	"openai_privacy_filter is enabled but no detection category is enabled; " +
-		"enable at least one category (e.g. \"private_person\": true) in " +
-		"redaction.openai_privacy_filter.categories, or set enabled: false")
+	"redaction.openai_privacy_filter is enabled but no detection category is enabled; " +
+		"enable at least one category (e.g. \"private_person\": true) under " +
+		"redaction.openai_privacy_filter.categories in .entire/settings.json " +
+		"(or .entire/settings.local.json), or set enabled: false")
 
 // OPFMisconfiguredNoCategories reports whether OPF is enabled for this
 // process with an empty effective category set — the state described by

--- a/redact/opf.go
+++ b/redact/opf.go
@@ -112,6 +112,16 @@ var ErrOPFNoEnabledCategories = errors.New(
 		"redaction.openai_privacy_filter.categories in .entire/settings.json " +
 		"(or .entire/settings.local.json), or set enabled: false")
 
+// errOPFNilRuntime guards the trailer-stamping batch path against a
+// config that is enabled but carries no runtime. Unreachable through
+// ConfigurePrivacyFilter, which always constructs the shell-out
+// runtime; only ConfigurePrivacyFilterWithRuntime can produce it. The
+// no-silent-regex-only guarantee must hold by construction, not by
+// that property of the config lifecycle.
+var errOPFNilRuntime = errors.New(
+	"openai privacy filter is enabled but has no runtime; " +
+		"refusing regex-only output on the trailer-stamping path")
+
 // OPFMisconfiguredNoCategories reports whether OPF is enabled for this
 // process with an empty effective category set — the state described by
 // ErrOPFNoEnabledCategories. The pre-push flow checks this twice: when

--- a/redact/opf.go
+++ b/redact/opf.go
@@ -98,11 +98,14 @@ func OPFEnabled() bool {
 	return cfg != nil && cfg.Enabled
 }
 
-// ErrOPFNoEnabledCategories is returned by privacy-critical OPF entry
-// points when OPF is enabled but the effective category set is empty
-// (categories omitted, {}, all-false, or only unknown keys). The model
-// scan cannot run in this state; succeeding silently would let callers
-// attest OPF ran (Entire-OPF-Applied trailer) when it never did.
+// ErrOPFNoEnabledCategories is returned by BatchBytesWithPrivacyFilter
+// — the trailer-stamping path — when OPF is enabled but the effective
+// category set is empty (categories omitted, {}, all-false, or only
+// unknown keys). The model scan cannot run in this state; succeeding
+// silently would let the caller attest OPF ran (Entire-OPF-Applied
+// trailer) when it never did. The non-batched entry points (detectOPF,
+// JSONLContentWithPrivacyFilter) still fall back silently in this
+// state because their callers do not attest that OPF ran.
 var ErrOPFNoEnabledCategories = errors.New(
 	"openai_privacy_filter is enabled but no detection category is enabled; " +
 		"enable at least one category (e.g. \"private_person\": true) in " +
@@ -110,9 +113,12 @@ var ErrOPFNoEnabledCategories = errors.New(
 
 // OPFMisconfiguredNoCategories reports whether OPF is enabled for this
 // process with an empty effective category set — the state described by
-// ErrOPFNoEnabledCategories. The pre-push gate checks this before
-// prompting or rewriting so the push aborts with remediation instead of
-// stamping the Entire-OPF-Applied trailer on unscanned commits.
+// ErrOPFNoEnabledCategories. The pre-push flow checks this twice: when
+// resolving the run/skip decision (so the user is never prompted to run
+// a scan that cannot run) and again at the start of the rewrite (so
+// direct callers fail closed too). Explicit opt-outs (ENTIRE_OPF=no,
+// prompt_default: never) still resolve to skip and push regex-only
+// content without the trailer.
 func OPFMisconfiguredNoCategories() bool {
 	cfg := getOPFConfig()
 	return cfg != nil && cfg.Enabled && len(enabledCategories(cfg)) == 0

--- a/redact/opf.go
+++ b/redact/opf.go
@@ -98,6 +98,26 @@ func OPFEnabled() bool {
 	return cfg != nil && cfg.Enabled
 }
 
+// ErrOPFNoEnabledCategories is returned by privacy-critical OPF entry
+// points when OPF is enabled but the effective category set is empty
+// (categories omitted, {}, all-false, or only unknown keys). The model
+// scan cannot run in this state; succeeding silently would let callers
+// attest OPF ran (Entire-OPF-Applied trailer) when it never did.
+var ErrOPFNoEnabledCategories = errors.New(
+	"openai_privacy_filter is enabled but no detection category is enabled; " +
+		"enable at least one category (e.g. \"private_person\": true) in " +
+		"redaction.openai_privacy_filter.categories, or set enabled: false")
+
+// OPFMisconfiguredNoCategories reports whether OPF is enabled for this
+// process with an empty effective category set — the state described by
+// ErrOPFNoEnabledCategories. The pre-push gate checks this before
+// prompting or rewriting so the push aborts with remediation instead of
+// stamping the Entire-OPF-Applied trailer on unscanned commits.
+func OPFMisconfiguredNoCategories() bool {
+	cfg := getOPFConfig()
+	return cfg != nil && cfg.Enabled && len(enabledCategories(cfg)) == 0
+}
+
 // OPFBreakerTripped reports whether the per-process OPF circuit breaker
 // has been tripped — i.e. an OPF invocation failed at some point during
 // this process's lifetime. The pre-push rewrite uses this to detect


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1042
<!-- entire-trail-link-end -->

## Summary

With `openai_privacy_filter.enabled: true` but an empty effective category set (`categories` omitted, `{}`, or all-false), the model scan never ran, yet the pre-push rewrite still stamped `Entire-OPF-Applied: true` on every rebuilt commit. Later rewrites treat that trailer as proof the commit was scanned and skip it permanently, so fixing the config afterwards never repaired the affected commits, and prose PII that only the model layer detects could reach the remote.

This makes the state fail closed at two layers:

- `RewriteUnpushedV1WithOPF` aborts with a new `OPFNoCategoriesError` sentinel before any commit is rebuilt — no trailer is stamped, and a corrected config scans the same commits on the next push. The check sits before the breaker check so the user gets config-specific remediation rather than "verify your OPF install".
- `BatchBytesWithPrivacyFilter` returns `ErrOPFNoEnabledCategories` for enabled-with-zero-categories instead of silently returning regex-only output, as defense in depth for its trailer-stamping caller. Unconfigured / disabled / breaker-tripped still return regex-only output with no error, unchanged.

Rejecting the shape at settings validation was considered and deliberately not done: hooks swallow `settings.Load` errors, so a Load-time rejection would leave OPF unconfigured and let the push proceed regex-only with no message at all — a silent unprotected push instead of a loud abort. The gate only works when the config loads.

`ENTIRE_OPF=no` and `prompt_default: never` are unaffected: they skip OPF without stamping the trailer, which stays an honest opt-out.

## Test plan

- `TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesFailsClosed` (replaces the test that pinned the old silent-fallback behavior) covers empty, nil, and all-false category maps.
- `TestRewriteUnpushedV1WithOPF_NoEnabledCategoriesAbortsThenRepairs` proves the abort leaves the v1 ref unmoved with no trailer, and that enabling a category afterwards scans the same commits normally.
- `mise run fmt`, `mise run lint`, full unit suite green (8,835 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b21c91e65ef02cfb14a63d97626fb69396d53321. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->