### PR TITLE
chore(pi): regenerate the stale committed dogfood extension

### DIFF
--- a/.pi/extensions/entire/index.ts
+++ b/.pi/extensions/entire/index.ts
@@ -11,6 +11,17 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { execFile } from "node:child_process";
 
 export default function (pi: ExtensionAPI) {
+  // A Pi subagent is a nested `pi` process (subagent extensions spawn one per task
+  // with cwd inside the project, where Pi auto-discovers this same project-local
+  // extension), so it would otherwise forward its own lifecycle as the user's
+  // session. Mark this process so any Pi it spawns knows it is nested.
+  //
+  // WARNING: Entire's own hook subprocesses inherit this marker from the parent, so
+  // the CLI side must never treat it as a skip signal — it would disable tracking
+  // for everyone. See docs/architecture/agent-guide.md.
+  const nested = Boolean(process.env.ENTIRE_PI_NESTED);
+  process.env.ENTIRE_PI_NESTED = "1";
+
   const ENTIRE_CMD = '"$(git rev-parse --show-toplevel)"/scripts/entire-dev';
   let pendingSkillEvents: Array<{ skill_name: string; invocation: string; timestamp: string }> = [];
 
@@ -60,17 +71,14 @@ export default function (pi: ExtensionAPI) {
     return { skill_name: match[1], invocation };
   }
 
-  pi.on("input", async (event) => {
-    const skill = parseSkillInvocation(event.text);
-    if (skill) {
-      pendingSkillEvents.push({ ...skill, timestamp: new Date().toISOString() });
-    }
-    return { action: "continue" };
-  });
-
   // Agent-driven bash subprocesses inherit a real TTY but cannot answer
   // hook prompts. Disable git/Entire terminal prompts for bash calls so
   // Entire treats agent-driven commits as non-interactive.
+  //
+  // Registered even when nested: a nested Pi is non-interactive by construction
+  // while still inheriting the parent's TTY, and Entire's git hooks live in
+  // .git/hooks independently of this extension, so a nested subagent that commits
+  // needs this hardening at least as much as the parent does.
   pi.on("tool_call", async (event) => {
     if (event.toolName !== "bash") return;
     const input = event.input as { command?: string };
@@ -78,6 +86,18 @@ export default function (pi: ExtensionAPI) {
       return;
     }
     input.command = "export GIT_TERMINAL_PROMPT=0\n" + input.command;
+  });
+
+  // Everything below forwards session lifecycle to Entire, which only the
+  // top-level Pi may do.
+  if (nested) return;
+
+  pi.on("input", async (event) => {
+    const skill = parseSkillInvocation(event.text);
+    if (skill) {
+      pendingSkillEvents.push({ ...skill, timestamp: new Date().toISOString() });
+    }
+    return { action: "continue" };
   });
 
   pi.on("session_start", async (_event, ctx) => {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1045
<!-- entire-trail-link-end -->

## TL;DR

`entire doctor` reports `Pi hooks: OUT OF DATE` in this repo because the committed dogfood extension drifted from the embedded template. Regenerated it.

## Problem

This repo commits `.pi/extensions/entire/index.ts` (rendered in `--local-dev` mode) so the dogfood setup works out of the box. The embedded template moved on; the committed copy didn't.

| File | Last touched |
| --- | --- |
| `cmd/entire/cli/agent/pi/entire_extension.ts` (template) | `d55dfa643` — 2026-08-10 |
| `.pi/extensions/entire/index.ts` (committed copy) | `ed42608db` — 2026-07-24 |

Two commits landed in between — `840aee7ce` ("stop nested subagent processes from claiming the parent session") and `d55dfa643` — and the committed copy was never regenerated.

The drift is invisible to `AreHooksInstalled`, which only greps for the ownership marker, and the extension's `fireHook` swallows errors by design. Only `doctor`'s content comparison catches it. Practical impact for anyone dogfooding Pi here: no `ENTIRE_PI_NESTED` guard, so a Pi subagent forwards its own lifecycle as if it were the user's session.

## Solution

Regenerated with `entire agent add pi --local-dev --force`, scoped to Pi. The result is byte-identical to the template with `__ENTIRE_CMD__` substituted for the local-dev script.

Note for anyone hitting this locally: `doctor`'s suggested `entire enable --force` is right for users but wrong for this repo — without `--local-dev` it rewrites `ENTIRE_CMD` to `'entire'` and breaks the dogfood setup.

## Test plan

- `entire doctor` → `✓ Pi hook config: OK` (was `Pi hooks: OUT OF DATE`)
- `go test ./cmd/entire/cli/agent/pi/...` passes
- `diff <(sed 's|__ENTIRE_CMD__|...|' cmd/entire/cli/agent/pi/entire_extension.ts) .pi/extensions/entire/index.ts` is empty

## Follow-up worth considering

Nothing enforces that the committed copy tracks the template, so this will silently rot again. A CI check comparing the two would have caught it on `840aee7ce`. Not included here to keep the fix reviewable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 64bc658c6a987a4f043e5981a14577b2cf277831. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->