### PR TITLE
perf(strategy): filter blobs on the checkpoint_remote bootstrap fetch

### DIFF
--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -132,9 +132,10 @@ func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
 //
 // When noFilter is true, --filter=blob:none is suppressed even if filtered
 // fetches are globally enabled. Use noFilter for operations that need blob
-// content (resume, explain) as opposed to sync operations (push recovery)
-// that only need tree structure.
-func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, label string, noFilter bool) error { //nolint:unparam // noFilter distinguishes blob-content fetches (true) from tree-only sync fetches (false); kept for the documented fetch-filtering contract even though current callers all need blob content
+// content (resume, explain) as opposed to ancestry- or tree-only operations
+// (push recovery, the enable-time checkpoint_remote bootstrap) where fetching
+// blobs means downloading every stored transcript for no benefit.
+func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, label string, noFilter bool) error {
 	fetchCtx, cancel := context.WithTimeout(ctx, checkpointRemoteFetchTimeout)
 	defer cancel()
 

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -1027,6 +1027,83 @@ func TestEnsurePrimaryRef_FetchesFromCheckpointRemoteInsteadOfOrphan(t *testing.
 		"the bootstrapped branch should contain the checkpoint committed on the remote")
 }
 
+// TestEnsurePrimaryRef_BootstrapFetchIsFiltered pins the enable-time bootstrap
+// fetch to --filter=blob:none when filtered_fetches is enabled.
+//
+// The bootstrap exists only to establish shared ancestry with the checkpoint
+// remote so the local ref is not a divergent orphan (#1374). Proving that needs
+// the commit graph and the trees — never blob content. Fetching blobs pulls every
+// stored transcript in the branch's history, which on a real checkpoint repo
+// overruns checkpointRemoteFetchTimeout and lands the caller in the empty orphan
+// this path was built to prevent.
+//
+// The assertion is that the metadata blob is a partial-clone placeholder while
+// the tree that names it is local: correct ancestry, no payload.
+//
+// Not parallel: uses t.Chdir().
+func TestEnsurePrimaryRef_BootstrapFetchIsFiltered(t *testing.T) {
+	ctx := context.Background()
+
+	// Checkpoint remote holding a real entire/checkpoints/v1, as device A left it.
+	remoteDir := t.TempDir()
+	testutil.InitRepo(t, remoteDir)
+	testutil.WriteFile(t, remoteDir, "f.txt", "init")
+	testutil.GitAdd(t, remoteDir, "f.txt")
+	testutil.GitCommit(t, remoteDir, "init")
+	remoteDefaultBranch := checkpointRemoteCurrentBranch(ctx, t, remoteDir)
+
+	runCheckpointRemoteGit(ctx, t, remoteDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, remoteDir, "rm", "-rf", ".")
+	commitCheckpointRemoteMetadata(ctx, t, remoteDir, "aaaaaaaaaaaa", "device-a")
+	runCheckpointRemoteGit(ctx, t, remoteDir, "checkout", remoteDefaultBranch)
+
+	// Serving a filtered fetch over file:// requires opting the source repo in;
+	// without this git quietly ignores --filter and sends every blob, which would
+	// make this test pass against the unfiltered code path too.
+	runCheckpointRemoteGit(ctx, t, remoteDir, "config", "uploadpack.allowFilter", "true")
+
+	// Local repo (device B): origin is the main repo, checkpoints live elsewhere,
+	// and the local metadata branch does not exist yet.
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+	runCheckpointRemoteGit(ctx, t, localDir, "remote", "add", "origin", "git@github.com:org/main-repo.git")
+
+	entireDir := filepath.Join(localDir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(entireDir, "settings.json"),
+		[]byte(`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}, "filtered_fetches": true}}`),
+		0o644,
+	))
+
+	redirectGitURL(t, localDir, "git@github.com:org/checkpoints.git", "file://"+remoteDir)
+
+	t.Chdir(localDir)
+	paths.ClearWorktreeRootCache()
+
+	repo, err := OpenRepository(ctx)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	require.NoError(t, EnsurePrimaryRef(WithCheckpointRemoteBootstrap(ctx), repo))
+
+	// Ancestry and trees arrived: the branch still names the remote's checkpoint.
+	metadataPath := "aa/aaaaaaaaaa/" + paths.MetadataFileName
+	files := checkpointRemoteMetadataFiles(ctx, t, localDir)
+	require.Contains(t, files, metadataPath,
+		"a filtered bootstrap must still fetch the trees naming the remote's checkpoints")
+
+	// The payload did not: its blob is a placeholder, so the fetch was filtered.
+	blobHash := checkpointRemoteRevParse(ctx, t, localDir,
+		"refs/heads/"+paths.MetadataBranchName+":"+metadataPath)
+	missing := checkpointRemoteMissingObjects(ctx, t, localDir, paths.MetadataBranchName)
+	assert.Contains(t, missing, "?"+blobHash,
+		"the enable bootstrap must fetch --filter=blob:none; pulling transcript blobs overruns the fetch timeout on a real checkpoint repo")
+}
+
 // TestEnsurePrimaryRef_ReplacesExistingEmptyOrphanFromCheckpointRemote verifies
 // that a *pre-existing* local empty orphan (the exact shape a pre-#1374
 // `entire enable` left behind) is still healed on a later run of an explicit
@@ -1442,6 +1519,23 @@ func commitCheckpointRemoteMetadata(ctx context.Context, t *testing.T, dir, chec
 	))
 	runCheckpointRemoteGit(ctx, t, dir, "add", ".")
 	runCheckpointRemoteGit(ctx, t, dir, "commit", "-m", "Checkpoint: "+checkpointID+" "+label)
+}
+
+// checkpointRemoteMissingObjects lists objects reachable from ref that are absent
+// locally — the partial-clone placeholders a --filter=blob:none fetch leaves
+// behind. `--missing=print` reports them instead of lazily fetching them, so this
+// stays a local read even with a promisor remote configured.
+//
+// Every reachable object is listed; only the absent ones carry a "?" prefix, so
+// callers must match on "?"+hash rather than the bare hash.
+func checkpointRemoteMissingObjects(ctx context.Context, t *testing.T, dir, ref string) string {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, "git", "rev-list", "--objects", "--missing=print", ref)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	return string(out)
 }
 
 func checkpointRemoteMetadataFiles(ctx context.Context, t *testing.T, dir string) string {

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -702,7 +702,13 @@ func bootstrapPrimaryFromCheckpointRemote(ctx context.Context, repo *git.Reposit
 
 	branchName := primary.Short()
 	tmpRefName := plumbing.ReferenceName(FetchTmpRefPrefix + branchName)
-	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", true); err != nil {
+	// noFilter=false: adopting the remote branch needs its commit graph and trees
+	// (SafelyAdvanceLocalRef walks commits, metadataBranchHasData reads tree
+	// entries) but never blob content. An unfiltered fetch here pulls every stored
+	// transcript in the branch's history, which on a real checkpoint repo overruns
+	// checkpointRemoteFetchTimeout and drops the caller into the empty orphan this
+	// function exists to avoid.
+	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", false); err != nil {
 		logging.Debug(ctx, "checkpoint-remote: enable bootstrap fetch failed; creating empty orphan",
 			slog.String("url", remote.RedactURL(url)),
 			slog.String("error", err.Error()),
@@ -788,7 +794,9 @@ func healEmptyOrphanFromCheckpointRemote(ctx context.Context, repo *git.Reposito
 	tmpRefName := plumbing.ReferenceName(FetchTmpRefPrefix + primary.Short())
 	defer func() { _ = repo.Storer.RemoveReference(tmpRefName) }() //nolint:errcheck // cleanup is best-effort
 
-	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", true); err != nil {
+	// noFilter=false for the same reason as the bootstrap above: the heal only
+	// inspects the fetched branch's trees before replacing the data-free orphan.
+	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", false); err != nil {
 		logging.Debug(ctx, "checkpoint-remote: empty-orphan heal fetch failed; keeping local orphan",
 			slog.String("url", remote.RedactURL(url)),
 			slog.String("error", err.Error()),


### PR DESCRIPTION
## What

`entire enable` on a fresh clone of a repo with a dedicated `checkpoint_remote` takes ~30 seconds. Measured: **31.6s wall clock for 0.6s of CPU** — it is blocked on the network, not computing.

## Why

`EnsurePrimaryRef`'s bootstrap fetches `entire/checkpoints/v1` from the checkpoint remote with `NoFilter: true`, so it pulls every stored transcript blob in that branch's history. On a real checkpoint repo that overruns `checkpointRemoteFetchTimeout` (30s) and the fetch is killed:

```
DEBUG checkpoint-remote: enable bootstrap fetch failed; creating empty orphan
  url=https://github.com/entireio/cli-checkpoints.git
  error=... git fetch: signal: killed
```

The fallback then creates exactly the divergent empty orphan that #1374 added this path to prevent — so today you pay the full timeout *and* still end up with a branch that hides existing checkpoints and gets rejected non-fast-forward on the next push. The safety net makes the regression silent.

Not an auth hang: `git ls-remote` against the same URL answers in 0.7s. The transfer itself is just large.

## The fix

The bootstrap only needs to prove ancestry — `SafelyAdvanceLocalRef` walks commits, `metadataBranchHasData` reads tree entries, and neither touches blob content. Both checkpoint_remote fetch paths now pass `noFilter=false`:

- `bootstrapPrimaryFromCheckpointRemote` (missing local ref)
- `healEmptyOrphanFromCheckpointRemote` (same problem on re-run)

## Deliberately not shallow

I considered `--depth=1`. `SafelyAdvanceLocalRef` calls `hasReachableShallowBoundary` and hard-errors when a shallow boundary blocks proving two refs are disconnected, telling the user to `git fetch --unshallow`. That would trade a slow enable for a wedged one. Blob filtering alone removes the bulk.

## Judgment call for review

Filtering stays gated on the existing `filtered_fetches` setting rather than forced on. A filtered fetch from a URL makes git record a promisor remote section, and `filtered_fetches` reads as the intended opt-in for accepting that.

Consequence: `filtered_fetches` defaults to **off**, so repos without it keep the slow path. This repo sets it true, so fresh clones of `entireio/cli` get the fix. Happy to force the filter on this path instead if reviewers prefer — it is a product call about promisor remotes, not a technical blocker.

## Testing

`TestEnsurePrimaryRef_BootstrapFetchIsFiltered` runs the real bootstrap against a `file://` checkpoint remote and asserts the tree naming the checkpoint is local while its `metadata.json` blob is still a partial-clone placeholder. Two things the test needs to be meaningful, both learned the hard way:

- `uploadpack.allowFilter=true` on the source repo, or git silently ignores `--filter` over `file://` and the test passes either way.
- Matching `?`+hash, not the bare hash. `git rev-list --objects` lists every reachable object and marks only absent ones with `?`. My first version matched the bare hash, passed against unmodified code, and was measuring nothing.

Verified it fails against the old code before making it pass.

`mise run check` clean: fmt, lint (0 issues), and `test:ci` — unit + integration under `-race`, canary vogon 56/56, canary roger-roger 4/4.

Not yet verified end-to-end against the real `entireio/cli-checkpoints` on a fresh clone; that is worth doing before this comes out of draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4643f0ebb3177d71a06567923e9e2cc59fd017e5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->