### PR TITLE
feat(doctor): add flutter-doctor-style environment sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `entire doctor` now starts with a flutter-doctor-style environment sweep: CLI version and update availability, git installation, repository/enablement, installed agent hooks and their CLIs, settings validity, and authentication status. Read-only — each finding comes with the command to fix it — followed by the existing session repair flow.
+
 ## [0.9.0] - 2026-07-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,10 @@ the commands are always runnable in every build.
   home jurisdiction so the slug is discoverable. `logout`
   takes `--everywhere` (revoke every session on the active core, not just the
   current one) and `--all-contexts` (log out of every saved login)
-- `doctor`: bare runs the scan-and-fix flow, plus `trace`, `logs`, `bundle`
+- `doctor`: bare runs a flutter-doctor-style environment/install/config sweep
+  (CLI version + update, git, repository/enablement, agent CLIs, settings,
+  authentication) followed by the scan-and-fix flow, plus `trace`, `logs`,
+  `bundle`
 - `org`: control-plane organization management — `create`, `list`, `get`, `delete`
 - `project`: control-plane project management — `create`, `list`, `get`, `delete`
 - `repo`: control-plane repository lifecycle — `create`, `list`, `get`, `delete`,

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ go test -tags=integration ./cmd/entire/cli/integration_test -run TestLogin
 | `entire agent`   | Add, remove, or list agent integrations for the current repository                                |
 | `entire configure` | Update non-agent settings (telemetry, git hook, strategy options, summary provider)            |
 | `entire disable` | Remove Entire hooks from repository                                                               |
-| `entire doctor`  | Fix or clean up stuck sessions                                                                    |
+| `entire doctor`  | Diagnose environment, installation, and config issues; fix or clean up stuck sessions                  |
 | `entire enable`  | Enable Entire in your repository                                                                  |
 | `entire checkpoint`        | List, explain, and search checkpoints                                                   |
 | `entire checkpoint explain` | Explain a session, commit, or checkpoint                                               |

--- a/cmd/entire/cli/agent/cli_binary.go
+++ b/cmd/entire/cli/agent/cli_binary.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"os/exec"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+)
+
+// cliBinaries maps agent registry keys to the CLI binary name users install
+// for that agent (e.g. "claude" for Claude Code, "agent" for Cursor's CLI,
+// "droid" for Factory AI Droid). `entire doctor` uses these to surface
+// installation issues: hooks can be installed for an agent while the agent's
+// own CLI is missing from PATH.
+var cliBinaries = map[types.AgentName]string{
+	AgentNameClaudeCode:     "claude",
+	AgentNameCodex:          "codex",
+	AgentNameCopilotCLI:     "copilot",
+	AgentNameCursor:         "agent",
+	AgentNameFactoryAIDroid: "droid",
+	AgentNameGemini:         "gemini",
+	AgentNameOpenCode:       "opencode",
+	AgentNamePi:             "pi",
+}
+
+// CLIBinaryName returns the CLI binary name users install for an agent
+// (e.g. "claude" for claude-code, "agent" for cursor). Returns "" for agents
+// without a known CLI binary.
+func CLIBinaryName(name types.AgentName) string {
+	return cliBinaries[name]
+}
+
+// IsCLIAvailable reports whether the agent's CLI binary is on PATH.
+func IsCLIAvailable(name types.AgentName) bool {
+	bin := CLIBinaryName(name)
+	if bin == "" {
+		return false
+	}
+	_, err := exec.LookPath(bin)
+	return err == nil
+}
+
+// AvailableCLIBinaries returns the binary names found on PATH for the given
+// agents, in input order.
+func AvailableCLIBinaries(names []types.AgentName) []string {
+	var found []string
+	for _, n := range names {
+		if IsCLIAvailable(n) {
+			found = append(found, CLIBinaryName(n))
+		}
+	}
+	return found
+}
+
+// MissingCLIBinaries returns agent names whose CLI binary is not on PATH,
+// in input order. Duplicates in names are collapsed.
+func MissingCLIBinaries(names []types.AgentName) []types.AgentName {
+	var missing []types.AgentName
+	seen := make(map[types.AgentName]bool)
+	for _, n := range names {
+		if seen[n] {
+			continue
+		}
+		seen[n] = true
+		if !IsCLIAvailable(n) {
+			missing = append(missing, n)
+		}
+	}
+	return missing
+}

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -27,26 +27,37 @@ func newDoctorCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "doctor",
-		Short: "Diagnose and fix session issues",
-		Long: `Scan for session issues and offer to fix them.
+		Short: "Diagnose and fix environment, configuration, and session issues",
+		Long: `Diagnose your Entire setup, then scan for session issues and offer to fix them.
 
-Checks performed:
-  1. Disconnected metadata branches: detects when local and remote
+First, a flutter-doctor-style sweep checks the environment, installation, and
+configuration:
+  1. Entire CLI version and whether an update is available
+  2. Git, the core runtime dependency
+  3. Repository state (inside a git repo? Entire enabled?)
+  4. Installed agent hooks and whether each agent's CLI is on PATH
+  5. Configuration files (.entire/settings.json, settings.local.json)
+  6. Authentication (login contexts or ENTIRE_TOKEN)
+
+The sweep is read-only; issues come with the command to fix them.
+
+Then, session repair checks run:
+  7. Disconnected metadata branches: detects when local and remote
      entire/checkpoints/v1 branches share no common ancestor (caused by a
      previous bug). Fixes by cherry-picking local checkpoints onto remote tip.
 
   When Codex hooks are installed:
-  2. Codex hook trust: warn when hooks declared in .codex/hooks.json
+  8. Codex hook trust: warn when hooks declared in .codex/hooks.json
      lack a trusted_hash entry in the user's Codex config (i.e. /hooks
      review hasn't run yet on this machine, or a newer entire release
      added a hook the user hasn't approved yet).
 
   When Claude Code hooks are installed:
-  3. Claude Code hook config: warn when the installed hooks are out of
+  9. Claude Code hook config: warn when the installed hooks are out of
      date (e.g. an older release wrote tool matchers that no longer fire).
      Fix by re-running 'entire enable --force'.
 
-  4. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
+  10. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
 
 A session is considered stuck if:
   - It is in ACTIVE phase with no interaction for over 1 hour
@@ -90,6 +101,11 @@ type stuckSession struct {
 
 func runSessionsFix(cmd *cobra.Command, force bool) error {
 	var finalErr error
+
+	// Environment / installation / configuration sweep (flutter-doctor-style,
+	// read-only). Reports issues and the commands to fix them, then the
+	// session repair checks below run as before.
+	runDoctorChecks(cmd)
 
 	// Check 1: Disconnected metadata branches
 	metadataErr := checkDisconnectedMetadata(cmd, force)

--- a/cmd/entire/cli/doctor_check.go
+++ b/cmd/entire/cli/doctor_check.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+	"github.com/spf13/cobra"
+)
+
+// doctorCheckStatus is the severity of one doctor diagnostic line.
+type doctorCheckStatus int
+
+const (
+	doctorCheckOK doctorCheckStatus = iota
+	doctorCheckWarn
+	doctorCheckError
+)
+
+// doctorPrint writes one flutter-doctor-style status line: a [✓]/[!]/[✗]
+// marker followed by the description. Plain text (no ANSI) so the output
+// stays script-grep-friendly.
+func doctorPrint(w io.Writer, status doctorCheckStatus, text string) {
+	var marker string
+	switch status {
+	case doctorCheckOK:
+		marker = "[✓]"
+	case doctorCheckWarn:
+		marker = "[!]"
+	case doctorCheckError:
+		marker = "[✗]"
+	}
+	fmt.Fprintf(w, "%s %s\n", marker, text)
+}
+
+// checkForUpdate is the version-fetch seam for the CLI-version doctor check.
+// Production wires versioncheck.CheckForUpdate; tests stub it to avoid
+// network access (and versioninfo.Version is "dev" in tests anyway, which
+// CheckForUpdate short-circuits).
+var checkForUpdate = versioncheck.CheckForUpdate
+
+// runDoctorChecks runs the environment / installation / configuration
+// diagnostics of `entire doctor` — the flutter-doctor-style sweep. It is
+// read-only and non-interactive: it reports issues and points at the command
+// that fixes them, and never prompts. Returns the number of issues found
+// (warnings + errors) so callers can fold them into the doctor summary.
+func runDoctorChecks(cmd *cobra.Command) int {
+	w := cmd.OutOrStdout()
+	issues := 0
+
+	fmt.Fprintln(w, "Entire Doctor — environment, installation, and configuration checks")
+	fmt.Fprintln(w)
+
+	// 1. CLI version and update availability.
+	version := versioninfo.Version
+	if versioncheck.IsDevBuild(version) {
+		doctorPrint(w, doctorCheckOK, fmt.Sprintf("Entire CLI: %s (dev build — update check skipped)", version))
+	} else {
+		latest, outdated, err := checkForUpdate(cmd.Context(), version)
+		switch {
+		case err != nil:
+			issues++
+			doctorPrint(w, doctorCheckWarn, fmt.Sprintf("Entire CLI: %s (could not check for updates: %v)", version, err))
+		case outdated:
+			issues++
+			doctorPrint(w, doctorCheckWarn, fmt.Sprintf("Entire CLI: %s (update available: %s — run '%s')",
+				versioncheck.DisplayVersion(version),
+				versioncheck.DisplayVersion(latest),
+				versioncheck.UpdateCommandForCurrentBinary(version)))
+		default:
+			doctorPrint(w, doctorCheckOK, fmt.Sprintf("Entire CLI: %s (up to date)", versioncheck.DisplayVersion(version)))
+		}
+	}
+
+	// 2. Git, the core runtime dependency.
+	gitBin, gitErr := exec.LookPath("git")
+	if gitErr != nil {
+		issues++
+		doctorPrint(w, doctorCheckError, "Git: not found on PATH (Entire requires git)")
+	} else if out, err := exec.CommandContext(cmd.Context(), gitBin, "--version").Output(); err != nil {
+		issues++
+		doctorPrint(w, doctorCheckError, fmt.Sprintf("Git: found at %s but could not run it: %v", gitBin, err))
+	} else {
+		doctorPrint(w, doctorCheckOK, "Git: "+strings.TrimSpace(string(out)))
+	}
+
+	// 3. Repository and enablement. Settings are loaded once here and reused
+	// by the Configuration check below.
+	s, settingsErr := LoadEntireSettings(cmd.Context())
+	root, rootErr := paths.WorktreeRoot(cmd.Context())
+	switch {
+	case rootErr != nil:
+		issues++
+		doctorPrint(w, doctorCheckWarn, "Repository: not inside a git repository (run 'entire enable' from a repo)")
+	case settingsErr != nil:
+		issues++
+		doctorPrint(w, doctorCheckError, fmt.Sprintf("Repository: %s (could not load settings: %v)", root, settingsErr))
+	case !s.Enabled:
+		issues++
+		doctorPrint(w, doctorCheckWarn, fmt.Sprintf("Repository: %s (Entire is disabled — run 'entire enable')", root))
+	default:
+		doctorPrint(w, doctorCheckOK, fmt.Sprintf("Repository: %s (Entire enabled)", root))
+	}
+
+	// 4. Agent hooks and the CLIs behind them.
+	installed := GetAgentsWithHooksInstalled(cmd.Context())
+	if len(installed) == 0 {
+		issues++
+		doctorPrint(w, doctorCheckWarn, "Agent hooks: none installed (run 'entire enable' or 'entire agent add <name>')")
+	} else {
+		ok := agent.AvailableCLIBinaries(installed)
+		missing := agent.MissingCLIBinaries(installed)
+		if len(missing) > 0 {
+			issues++
+			parts := make([]string, 0, len(missing))
+			for _, name := range missing {
+				parts = append(parts, fmt.Sprintf("%s (CLI '%s' not found on PATH)", name, agent.CLIBinaryName(name)))
+			}
+			doctorPrint(w, doctorCheckWarn, "Agent hooks installed but agent CLI missing: "+strings.Join(parts, ", "))
+		}
+		if len(ok) > 0 {
+			doctorPrint(w, doctorCheckOK, fmt.Sprintf("Agent hooks: %s (CLI found)", strings.Join(ok, ", ")))
+		}
+	}
+
+	// 5. Configuration files.
+	switch {
+	case settingsErr != nil:
+		issues++
+		doctorPrint(w, doctorCheckError, "Configuration: invalid — "+settingsErr.Error())
+		doctorPrint(w, doctorCheckError, "  Fix the JSON in .entire/settings.json or .entire/settings.local.json, then re-run 'entire doctor'.")
+	case s.LogLevel != "" && !validLogLevel(s.LogLevel):
+		issues++
+		doctorPrint(w, doctorCheckWarn, fmt.Sprintf("Configuration: log_level %q is not one of debug/info/warn/error", s.LogLevel))
+	default:
+		doctorPrint(w, doctorCheckOK, "Configuration: valid")
+	}
+
+	// 6. Authentication.
+	if _, ok := os.LookupEnv(auth.EnvTokenVar); ok {
+		doctorPrint(w, doctorCheckOK, "Authentication: "+auth.EnvTokenVar+" environment variable set")
+	} else {
+		contexts, _, err := auth.Contexts()
+		switch {
+		case err != nil:
+			issues++
+			doctorPrint(w, doctorCheckError, fmt.Sprintf("Authentication: could not read login contexts: %v", err))
+		case len(contexts) == 0:
+			issues++
+			doctorPrint(w, doctorCheckWarn, "Authentication: not logged in (run 'entire login')")
+		default:
+			doctorPrint(w, doctorCheckOK, fmt.Sprintf("Authentication: logged in (%d context(s) saved)", len(contexts)))
+		}
+	}
+
+	fmt.Fprintln(w)
+	if issues == 0 {
+		fmt.Fprintln(w, "No issues found.")
+	} else {
+		fmt.Fprintf(w, "Doctor found %d issue(s) — see the [!] and [✗] items above.\n", issues)
+	}
+	fmt.Fprintln(w)
+
+	return issues
+}
+
+// validLogLevel reports whether level is one of the supported log levels.
+func validLogLevel(level string) bool {
+	switch level {
+	case "debug", "info", "warn", "error":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/entire/cli/doctor_check_test.go
+++ b/cmd/entire/cli/doctor_check_test.go
@@ -1,0 +1,254 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setDoctorVersion overrides the package version var for the duration of a
+// test so the CLI-version doctor check exercises its non-dev-build paths
+// (the default "dev" sentinel skips the update fetch entirely).
+func setDoctorVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := versioninfo.Version
+	versioninfo.Version = v
+	t.Cleanup(func() { versioninfo.Version = orig })
+}
+
+// stubDoctorUpdateCheck overrides the version-fetch seam used by the CLI
+// version doctor check so tests don't reach the network.
+func stubDoctorUpdateCheck(t *testing.T, latest string, outdated bool, err error) {
+	t.Helper()
+	orig := checkForUpdate
+	checkForUpdate = func(context.Context, string) (string, bool, error) {
+		return latest, outdated, err
+	}
+	t.Cleanup(func() { checkForUpdate = orig })
+}
+
+func TestRunDoctorChecks_HealthyRepo(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "Entire Doctor")
+	require.Contains(t, out, "[✓] Entire CLI: dev (dev build — update check skipped)")
+	require.Contains(t, out, "[✓] Git: git version")
+	require.Contains(t, out, "[✓] Repository: ")
+	require.Contains(t, out, "(Entire enabled)")
+	require.Contains(t, out, "[!] Agent hooks: none installed (run 'entire enable' or 'entire agent add <name>')")
+	require.Contains(t, out, "[✓] Configuration: valid")
+	require.Contains(t, out, "[!] Authentication: not logged in (run 'entire login')")
+	require.Contains(t, out, "Doctor found 2 issue(s)")
+	require.Equal(t, 2, issues)
+}
+
+func TestRunDoctorChecks_NotInARepo(t *testing.T) {
+	// t.TempDir() is not a git repository.
+	t.Chdir(t.TempDir())
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "[!] Repository: not inside a git repository (run 'entire enable' from a repo)")
+	// Outside a repo, settings still load with defaults, so configuration
+	// itself stays valid.
+	require.Contains(t, out, "[✓] Configuration: valid")
+	require.Equal(t, 3, issues) // repository + agent hooks + authentication
+}
+
+func TestRunDoctorChecks_UpdateAvailable(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	setDoctorVersion(t, "0.5.0")
+	stubDoctorUpdateCheck(t, "v9.9.9", true, nil)
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "[!] Entire CLI: 0.5.0 (update available: 9.9.9")
+	require.Contains(t, out, "run '")
+	require.GreaterOrEqual(t, issues, 1)
+}
+
+func TestRunDoctorChecks_UpdateCheckError(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	setDoctorVersion(t, "0.5.0")
+	stubDoctorUpdateCheck(t, "", false, errors.New("network down"))
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "[!] Entire CLI: 0.5.0 (could not check for updates: network down)")
+	require.GreaterOrEqual(t, issues, 1)
+}
+
+func TestRunDoctorChecks_UpToDate(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	setDoctorVersion(t, "0.5.0")
+	stubDoctorUpdateCheck(t, "v0.5.0", false, nil)
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "[✓] Entire CLI: 0.5.0 (up to date)")
+	require.Equal(t, 2, issues) // repository-only issues: agent hooks + auth
+}
+
+func TestRunDoctorChecks_DisabledRepo(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".entire", "settings.json"), []byte(`{"enabled": false}`), 0o600))
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "[!] Repository: ")
+	require.Contains(t, out, "(Entire is disabled — run 'entire enable')")
+	require.Contains(t, out, "[✓] Configuration: valid")
+	require.Equal(t, 3, issues) // disabled + agent hooks + auth
+}
+
+func TestRunDoctorChecks_InvalidSettings(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".entire", "settings.json"), []byte(`{not json`), 0o600))
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "[✗] Repository: ")
+	require.Contains(t, out, "(could not load settings:")
+	require.Contains(t, out, "[✗] Configuration: invalid —")
+	require.Contains(t, out, "Fix the JSON in .entire/settings.json or .entire/settings.local.json")
+	require.Equal(t, 4, issues) // repo + config + agent hooks + auth
+}
+
+func TestRunDoctorChecks_InvalidLogLevel(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".entire", "settings.json"), []byte(`{"enabled": true, "log_level": "bogus"}`), 0o600))
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, `[!] Configuration: log_level "bogus" is not one of debug/info/warn/error`)
+	require.Equal(t, 3, issues) // log level + agent hooks + auth
+}
+
+func TestRunDoctorChecks_AgentCLIMissing(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	codexDir := filepath.Join(dir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(canonicalCodexHooksJSON()), 0o600))
+	t.Chdir(dir)
+
+	// Wipe PATH so no agent CLI resolves — the missing-binary finding is
+	// deterministic regardless of what's installed on the host.
+	t.Setenv("PATH", t.TempDir())
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "Agent hooks installed but agent CLI missing: codex (CLI 'codex' not found on PATH)")
+	require.NotContains(t, out, "CLI found")
+	require.GreaterOrEqual(t, issues, 1)
+}
+
+func TestRunDoctorChecks_AgentCLIFound(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	codexDir := filepath.Join(dir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(canonicalCodexHooksJSON()), 0o600))
+	t.Chdir(dir)
+
+	// Fake a codex binary on PATH so the CLI-presence check passes.
+	binDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "codex"), []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "[✓] Agent hooks: codex (CLI found)")
+	require.NotContains(t, out, "not found on PATH")
+	require.Equal(t, 1, issues) // agent hooks OK; auth is the remaining finding
+}
+
+func TestRunDoctorChecks_LoggedIn(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	configDir := t.TempDir()
+	contextsJSON := `{"current_context":"dev","contexts":[{"name":"dev","core_url":"https://core.example","handle":"alice","keychain_service":"entire-core:https://core.example"}]}`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "contexts.json"), []byte(contextsJSON), 0o600))
+	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "[✓] Authentication: logged in (1 context(s) saved)")
+	require.Equal(t, 1, issues) // only agent hooks
+}
+
+func TestRunDoctorChecks_EnvToken(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	t.Setenv(auth.EnvTokenVar, "not.a.real.jwt")
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "[✓] Authentication: ENTIRE_TOKEN environment variable set")
+	require.Equal(t, 1, issues) // only agent hooks
+}
+
+func TestRunDoctorChecks_CorruptContexts(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	configDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "contexts.json"), []byte(`{not json`), 0o600))
+	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+
+	cmd, stdout := newTestCmd(t)
+	issues := runDoctorChecks(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "[✗] Authentication: could not read login contexts:")
+	require.Equal(t, 2, issues) // agent hooks + corrupt contexts
+}

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -107,7 +107,7 @@ func realChooseUpdate(ctx context.Context, currentVersion, latestVersion, cmdStr
 	action := autoUpdateActionUpdate
 	sel := huh.NewSelect[AutoUpdateAction]().
 		Title(fmt.Sprintf("Update available! %s -> %s",
-			displayVersion(currentVersion), displayVersion(latestVersion))).
+			DisplayVersion(currentVersion), DisplayVersion(latestVersion))).
 		Description("Release notes: "+releaseNotesURL(latestVersion)).
 		Options(
 			huh.NewOption(fmt.Sprintf("Update now (runs `%s`)", cmdStr), autoUpdateActionUpdate),

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -35,12 +35,34 @@ const (
 	installChannelNightly = "nightly"
 )
 
+// CheckForUpdate performs an explicit, uncached version check: it fetches the
+// latest release for the channel matching currentVersion (nightly vs stable)
+// and reports whether an update is available. Unlike CheckAndNotify it always
+// fetches (no 24h cache, no notification) and is the check behind
+// `entire doctor`. Dev builds (empty, "dev", pseudo-versions) return
+// outdated=false with no error.
+func CheckForUpdate(ctx context.Context, currentVersion string) (latest string, outdated bool, err error) {
+	if IsDevBuild(currentVersion) {
+		return "", false, nil
+	}
+	var latestVersion string
+	if isNightly(currentVersion) {
+		latestVersion, err = fetchLatestNightlyVersion(ctx)
+	} else {
+		latestVersion, err = fetchLatestVersion(ctx)
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return latestVersion, isOutdated(currentVersion, latestVersion), nil
+}
+
 // CheckAndNotify performs a version check and notifies the user if a newer version is available.
 // This is the main entry point for the version check system.
 // The function is silent on all errors to avoid interrupting CLI operations.
 func CheckAndNotify(ctx context.Context, w io.Writer, currentVersion string) {
 	// Skip checks for local/unreleased builds.
-	if isDevBuild(currentVersion) {
+	if IsDevBuild(currentVersion) {
 		return
 	}
 
@@ -293,7 +315,7 @@ func isOutdated(current, latest string) bool {
 
 	// Local/unreleased builds shouldn't trigger update notifications.
 	// Normal prereleases (e.g., "1.0.0-rc1") should still be compared normally.
-	if isDevBuild(current) {
+	if IsDevBuild(current) {
 		return false
 	}
 
@@ -301,13 +323,13 @@ func isOutdated(current, latest string) bool {
 	return semver.Compare(current, latest) < 0
 }
 
-// isDevBuild reports whether v identifies a local, unreleased build that
+// IsDevBuild reports whether v identifies a local, unreleased build that
 // should not be nagged to update. This covers the "dev" sentinel and empty
 // string (an unstamped binary), a Go pseudo-version (built from a commit that
 // isn't a tagged release), and any build carrying +metadata such as "+dirty".
 // Released builds — stable tags, nightly tags, and `go install ...@<tag>` —
 // have clean semver and return false.
-func isDevBuild(v string) bool {
+func IsDevBuild(v string) bool {
 	if v == "" || v == "dev" {
 		return true
 	}
@@ -324,7 +346,9 @@ func versionCacheKey(version string) string {
 	return "v" + version
 }
 
-func displayVersion(version string) string {
+// DisplayVersion strips the leading "v" from a version tag for user-facing
+// output (e.g. "v1.2.3" -> "1.2.3").
+func DisplayVersion(version string) string {
 	return strings.TrimPrefix(version, "v")
 }
 
@@ -420,5 +444,5 @@ func UpdateCommandForCurrentBinary(currentVersion string) string {
 // printNotification prints the version update notification to the user.
 func printNotification(w io.Writer, current, latest string) {
 	fmt.Fprintf(w, "\nUpdate available! %s -> %s\nRelease notes: %s\n",
-		displayVersion(current), displayVersion(latest), releaseNotesURL(latest))
+		DisplayVersion(current), DisplayVersion(latest), releaseNotesURL(latest))
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -106,10 +106,117 @@ func TestIsDevBuild(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
 			t.Parallel()
-			if got := isDevBuild(tt.version); got != tt.want {
-				t.Errorf("isDevBuild(%q) = %v, want %v", tt.version, got, tt.want)
+			if got := IsDevBuild(tt.version); got != tt.want {
+				t.Errorf("IsDevBuild(%q) = %v, want %v", tt.version, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCheckForUpdate_DevBuildSkipsFetch(t *testing.T) {
+	server := newVersionServer(t, "v9.9.9")
+	original := githubAPIURL
+	githubAPIURL = server.URL
+	t.Cleanup(func() { githubAPIURL = original })
+
+	latest, outdated, err := CheckForUpdate(context.Background(), "dev")
+	if err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if latest != "" || outdated {
+		t.Errorf(`CheckForUpdate(dev) = (%q, %v), want ("", false)`, latest, outdated)
+	}
+}
+
+// stableLatest is the fake latest version served by newVersionServer in
+// TestCheckForUpdate_StableChannel. Hoisted to avoid tripping goconst on
+// repeated string literals.
+const stableLatest = "v2.0.0"
+
+func TestCheckForUpdate_StableChannel(t *testing.T) {
+	server := newVersionServer(t, stableLatest)
+	original := githubAPIURL
+	githubAPIURL = server.URL
+	t.Cleanup(func() { githubAPIURL = original })
+
+	latest, outdated, err := CheckForUpdate(context.Background(), "1.0.0")
+	if err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if latest != stableLatest || !outdated {
+		t.Errorf("CheckForUpdate() = (%q, %v), want (%s, true)", latest, outdated, stableLatest)
+	}
+}
+
+func TestCheckForUpdate_UpToDate(t *testing.T) {
+	server := newVersionServer(t, "v1.0.0")
+	original := githubAPIURL
+	githubAPIURL = server.URL
+	t.Cleanup(func() { githubAPIURL = original })
+
+	latest, outdated, err := CheckForUpdate(context.Background(), "1.0.0")
+	if err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if latest != "v1.0.0" || outdated {
+		t.Errorf("CheckForUpdate() = (%q, %v), want (v1.0.0, false)", latest, outdated)
+	}
+}
+
+func TestCheckForUpdate_NightlyChannel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		releases := []GitHubRelease{
+			{TagName: "v0.5.4", Prerelease: false},
+			{TagName: "v0.5.4-nightly.202604061200.abc1234", Prerelease: true},
+			{TagName: "v0.5.4-nightly.202604051159.def5678", Prerelease: true},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		//nolint:errcheck // test helper
+		json.NewEncoder(w).Encode(releases)
+	}))
+	t.Cleanup(server.Close)
+
+	original := githubReleasesURL
+	githubReleasesURL = server.URL
+	t.Cleanup(func() { githubReleasesURL = original })
+
+	latest, outdated, err := CheckForUpdate(context.Background(), "0.5.3-nightly.202604051159.abc1234")
+	if err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if latest != "v0.5.4-nightly.202604061200.abc1234" || !outdated {
+		t.Errorf("CheckForUpdate() = (%q, %v), want (v0.5.4-nightly.202604061200.abc1234, true)", latest, outdated)
+	}
+}
+
+func TestCheckForUpdate_FetchFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	original := githubAPIURL
+	githubAPIURL = server.URL
+	t.Cleanup(func() { githubAPIURL = original })
+
+	_, _, err := CheckForUpdate(context.Background(), "1.0.0")
+	if err == nil {
+		t.Fatal("CheckForUpdate() expected error on fetch failure, got nil")
+	}
+}
+
+func TestDisplayVersion(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"v1.2.3":                              "1.2.3",
+		"1.2.3":                               "1.2.3",
+		"v0.6.3-nightly.202604061200.abc1234": "0.6.3-nightly.202604061200.abc1234",
+		"":                                    "",
+	}
+	for in, want := range cases {
+		if got := DisplayVersion(in); got != want {
+			t.Errorf("DisplayVersion(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`entire doctor` now opens with a flutter-doctor-style, read-only environment/installation/configuration sweep before the existing session repair flow runs unchanged. Each finding is reported with the command to fix it.

## Checks added

1. **Entire CLI version** — current version, plus update availability for the active channel (nightly vs stable) with the exact update command (`brew upgrade`, `mise upgrade`, `scoop update`, install script). Dev builds skip the fetch.
2. **Git** — present on PATH and runnable (core runtime dependency).
3. **Repository** — inside a git repo? Entire enabled? (`entire enable` hint when disabled)
4. **Agent hooks** — which agents have hooks installed, and whether each agent's CLI (`claude`, `codex`, `gemini`, ...) is on PATH.
5. **Configuration** — `.entire/settings.json` / `settings.local.json` parse validity and `log_level` sanity.
6. **Authentication** — login contexts or `ENTIRE_TOKEN` (offline, no network/keyring).

## Changes

- `cmd/entire/cli/doctor_check.go` (new) — the sweep, wired into `runSessionsFix` in `doctor.go`; help text updated.
- `cmd/entire/cli/agent/cli_binary.go` (new) — per-agent CLI binary name + `LookPath` helpers.
- `cmd/entire/cli/versioncheck/versioncheck.go` — exported `CheckForUpdate` (uncached, channel-aware), `IsDevBuild`, `DisplayVersion`.
- Tests: `doctor_check_test.go` (13 cases) and new `CheckForUpdate`/`DisplayVersion` unit tests.
- Docs: README command table, CLAUDE.md, CHANGELOG entry.

## Verification

- `go build ./...`, `go vet`, golangci-lint (0 issues)
- doctor + versioncheck + status/root/help test suites pass
- Live smoke test of the binary: correctly reported "update available: 0.10.0" and flagged installed hooks whose CLIs were missing from PATH
- Full CI suite (`mise run check`) not run locally — Go toolchain isn't installed on this machine; verification was done in an ephemeral Docker container.