### PR TITLE
fix(checkpoint): stop entire enable from cloning the whole checkpoint archive

### DIFF
--- a/cmd/entire/cli/checkpoint/fetching_tree.go
+++ b/cmd/entire/cli/checkpoint/fetching_tree.go
@@ -23,6 +23,24 @@ type BlobFetchFunc func(ctx context.Context, hashes []plumbing.Hash) error
 // package cannot resolve the remote target itself, so the CLI layer injects it.
 type RefFetchFunc func(ctx context.Context, ref plumbing.ReferenceName) error
 
+// MetadataBranchFetchFunc fetches the v1 metadata branch from the configured
+// checkpoint remote into the local ref. It is the git-branch store's counterpart
+// to RefFetchFunc: the git-refs store resolves one missing per-checkpoint ref,
+// while the git-branch store's whole record lives on a single branch, so a
+// missing local branch is resolved by fetching that branch.
+//
+// Without it, a clone whose checkpoints live on a dedicated checkpoint_remote
+// cannot read any committed checkpoint until something else happens to populate
+// the branch: the store falls back to origin's remote-tracking ref, which a
+// checkpoint_remote setup does not have. The checkpoint package cannot resolve
+// the remote target itself, so the CLI layer injects it.
+//
+// Only wire it on foreground, user-initiated read paths. It fires only when the
+// branch is missing both locally and on origin — i.e. when the read would
+// otherwise fail outright — but it is still a network call, and hook paths must
+// stay network-free.
+type MetadataBranchFetchFunc func(ctx context.Context) error
+
 // RemoteRefListFunc enumerates the per-checkpoint refs present on the configured
 // checkpoint remote (names only, via `ls-remote refs/entire/checkpoints/*` — no
 // object transfer), returning their full ref names. The git-refs store uses it

--- a/cmd/entire/cli/checkpoint/migrate.go
+++ b/cmd/entire/cli/checkpoint/migrate.go
@@ -49,7 +49,7 @@ func MigrateBranchToRefs(ctx context.Context, repo *git.Repository, dryRun bool)
 	var result MigrateResult
 
 	branch := NewGitStore(repo, DefaultV1Refs())
-	tree, err := branch.getSessionsBranchTree()
+	tree, err := branch.getSessionsBranchTree(ctx)
 	if err != nil {
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {
 			// No v1 branch locally or on origin → nothing to migrate.

--- a/cmd/entire/cli/checkpoint/migrate_test.go
+++ b/cmd/entire/cli/checkpoint/migrate_test.go
@@ -131,7 +131,7 @@ func TestMigrateBranchToRefs(t *testing.T) {
 
 	// Each ref carries the branch subtree with a normalized root metadata.json
 	// and reads back through the git-refs store.
-	branchTree, err := branch.getSessionsBranchTree()
+	branchTree, err := branch.getSessionsBranchTree(t.Context())
 	require.NoError(t, err)
 	refsStore := newGitRefsStore(repo)
 	for _, cid := range []id.CheckpointID{cid1, cid2} {

--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -24,6 +24,13 @@ type OpenOptions struct {
 	// reads local-only; ignored by the git-branch backend.
 	RefFetcher RefFetchFunc
 
+	// MetadataBranchFetcher is the CLI-level v1-metadata-branch fetcher, used by
+	// the git-branch backend to resolve a metadata branch missing both locally
+	// and on origin (the shape a fresh clone with a dedicated checkpoint_remote
+	// has). nil leaves reads local-only; ignored by the git-refs backend. Wire it
+	// only on foreground read paths — see MetadataBranchFetchFunc.
+	MetadataBranchFetcher MetadataBranchFetchFunc
+
 	// RemoteRefLister is the CLI-level checkpoint-ref enumerator, used by the
 	// git-refs backend's List to discover checkpoints present on the checkpoint
 	// remote but not yet local (see RemoteRefListFunc). It only fires on a
@@ -69,7 +76,7 @@ type Stores struct {
 // default git-branch backend with no mirrors, preserving default behavior.
 func Open(ctx context.Context, repo *git.Repository, opts OpenOptions) (*Stores, error) {
 	refs := resolveOpenRefs(ctx, opts)
-	env := OpenEnv{Repo: repo, BlobFetcher: opts.BlobFetcher, RefFetcher: opts.RefFetcher, RemoteRefLister: opts.RemoteRefLister, Refs: refs}
+	env := OpenEnv{Repo: repo, BlobFetcher: opts.BlobFetcher, RefFetcher: opts.RefFetcher, RemoteRefLister: opts.RemoteRefLister, MetadataBranchFetcher: opts.MetadataBranchFetcher, Refs: refs}
 
 	cfg, err := settings.LoadCheckpointsConfig(ctx)
 	if err != nil {

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -2232,29 +2232,61 @@ func (s *GitStore) getFetchingTree(ctx context.Context) (*FetchingTree, error) {
 // dedicated checkpoint_remote: the branch is absent locally, and origin does not
 // carry it either (checkpoints were never pushed there), so without the fetch
 // every committed checkpoint reads as "not found" with no way to recover.
+//
+// Recovery triggers on a data-free branch as well as a missing one. A local
+// orphan carrying nothing but initialization artifacts is, to a reader,
+// indistinguishable from no branch at all — but it makes the ref resolve, which
+// would otherwise mask the miss and leave the real checkpoints on the remote
+// permanently unreachable.
 func (s *GitStore) getSessionsBranchTree(ctx context.Context) (*object.Tree, error) {
-	ref, err := s.resolveSessionsBranchRef()
-	if err != nil && s.tryFetchMetadataBranch(ctx) {
-		// Recovered: re-resolve. On failure keep the original not-found error —
-		// callers such as List treat not-found as an empty result, so surfacing a
-		// transport error here would turn an offline read into a hard failure.
-		ref, err = s.resolveSessionsBranchRef()
+	tree, err := s.resolveSessionsBranchTree()
+	if err != nil || !treeHasCheckpointData(tree) {
+		if s.tryFetchMetadataBranch(ctx) {
+			if fetched, fetchedErr := s.resolveSessionsBranchTree(); fetchedErr == nil {
+				return fetched, nil
+			}
+		}
 	}
+	// Unrecovered: return what we resolved locally. Keeping the original error
+	// matters — callers such as List treat not-found as an empty result, so
+	// surfacing a transport error here would turn an offline read into a hard
+	// failure — and so does keeping a data-free tree, which reads as empty.
+	return tree, err
+}
+
+// resolveSessionsBranchTree resolves the read ref and loads its root tree.
+// Purely local: no network.
+func (s *GitStore) resolveSessionsBranchTree() (*object.Tree, error) {
+	ref, err := s.resolveSessionsBranchRef()
 	if err != nil {
 		return nil, err
 	}
-
 	commit, err := s.repo.CommitObject(ref.Hash())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit object: %w", err)
 	}
-
 	tree, err := commit.Tree()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit tree: %w", err)
 	}
-
 	return tree, nil
+}
+
+// treeHasCheckpointData reports whether a metadata branch root tree holds
+// anything beyond orphan-initialization artifacts. It mirrors
+// strategy.metadataBranchHasData, which decides the same question when healing
+// an un-initialized orphan; the two must agree on what "un-initialized" means or
+// enable and read disagree about whether a branch is worth recovering.
+func treeHasCheckpointData(tree *object.Tree) bool {
+	if tree == nil {
+		return false
+	}
+	for _, entry := range tree.Entries {
+		if entry.Name != vercelconfig.FileName {
+			return true
+		}
+	}
+	return false
 }
 
 // tryFetchMetadataBranch runs the injected metadata-branch fetcher at most once

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -1624,7 +1624,7 @@ func (s *GitStore) List(ctx context.Context) ([]CheckpointInfo, error) {
 		return nil, err //nolint:wrapcheck // Propagating context cancellation
 	}
 
-	tree, err := s.getSessionsBranchTree()
+	tree, err := s.getSessionsBranchTree(ctx)
 	if err != nil {
 		return []CheckpointInfo{}, nil //nolint:nilerr // No sessions branch means empty list
 	}
@@ -2216,7 +2216,7 @@ func (s *GitStore) maybeMergeVercelConfig(ctx context.Context, rootTreeHash plum
 // If a blob fetcher is configured on the store, File() calls on the returned
 // tree will automatically fetch missing blobs from the remote.
 func (s *GitStore) getFetchingTree(ctx context.Context) (*FetchingTree, error) {
-	tree, err := s.getSessionsBranchTree()
+	tree, err := s.getSessionsBranchTree(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2225,17 +2225,29 @@ func (s *GitStore) getFetchingTree(ctx context.Context) (*FetchingTree, error) {
 
 // getSessionsBranchTree returns the tree object at refs.Read. Falls back to
 // origin's remote-tracking ref for Primary when ReadBootstrappableFromOrigin
-// is true.
-func (s *GitStore) getSessionsBranchTree() (*object.Tree, error) {
-	ref, err := s.repo.Reference(s.refs.Read, true)
+// is true, then — if a metadata branch fetcher is wired — to fetching the branch
+// from the configured checkpoint remote.
+//
+// That last tier matters for a fresh clone of a repo whose checkpoints live on a
+// dedicated checkpoint_remote: the branch is absent locally, and origin does not
+// carry it either (checkpoints were never pushed there), so without the fetch
+// every committed checkpoint reads as "not found" with no way to recover.
+func (s *GitStore) getSessionsBranchTree(ctx context.Context) (*object.Tree, error) {
+	ref, err := s.resolveSessionsBranchRef()
 	if err != nil {
-		if !s.refs.ReadBootstrappableFromOrigin() {
-			return nil, fmt.Errorf("sessions ref %s not found: %w", s.refs.Read, err)
+		if s.metadataBranchFetcher == nil {
+			return nil, err
 		}
-		remoteRefName := plumbing.NewRemoteReferenceName("origin", s.refs.Primary.Short())
-		ref, err = s.repo.Reference(remoteRefName, true)
+		if fetchErr := s.metadataBranchFetcher(ctx); fetchErr != nil {
+			logging.Debug(ctx, "sessions branch: checkpoint remote fetch failed",
+				slog.String("ref", s.refs.Read.String()),
+				slog.String("error", fetchErr.Error()),
+			)
+			return nil, err
+		}
+		ref, err = s.resolveSessionsBranchRef()
 		if err != nil {
-			return nil, fmt.Errorf("sessions branch not found: %w", err)
+			return nil, err
 		}
 	}
 
@@ -2250,6 +2262,25 @@ func (s *GitStore) getSessionsBranchTree() (*object.Tree, error) {
 	}
 
 	return tree, nil
+}
+
+// resolveSessionsBranchRef resolves refs.Read, falling back to origin's
+// remote-tracking ref for Primary when ReadBootstrappableFromOrigin is true.
+// Purely local: no network.
+func (s *GitStore) resolveSessionsBranchRef() (*plumbing.Reference, error) {
+	ref, err := s.repo.Reference(s.refs.Read, true)
+	if err == nil {
+		return ref, nil
+	}
+	if !s.refs.ReadBootstrappableFromOrigin() {
+		return nil, fmt.Errorf("sessions ref %s not found: %w", s.refs.Read, err)
+	}
+	remoteRefName := plumbing.NewRemoteReferenceName("origin", s.refs.Primary.Short())
+	ref, err = s.repo.Reference(remoteRefName, true)
+	if err != nil {
+		return nil, fmt.Errorf("sessions branch not found: %w", err)
+	}
+	return ref, nil
 }
 
 // CreateBlobFromContent creates a blob object from in-memory content.

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -2234,21 +2234,14 @@ func (s *GitStore) getFetchingTree(ctx context.Context) (*FetchingTree, error) {
 // every committed checkpoint reads as "not found" with no way to recover.
 func (s *GitStore) getSessionsBranchTree(ctx context.Context) (*object.Tree, error) {
 	ref, err := s.resolveSessionsBranchRef()
-	if err != nil {
-		if s.metadataBranchFetcher == nil {
-			return nil, err
-		}
-		if fetchErr := s.metadataBranchFetcher(ctx); fetchErr != nil {
-			logging.Debug(ctx, "sessions branch: checkpoint remote fetch failed",
-				slog.String("ref", s.refs.Read.String()),
-				slog.String("error", fetchErr.Error()),
-			)
-			return nil, err
-		}
+	if err != nil && s.tryFetchMetadataBranch(ctx) {
+		// Recovered: re-resolve. On failure keep the original not-found error —
+		// callers such as List treat not-found as an empty result, so surfacing a
+		// transport error here would turn an offline read into a hard failure.
 		ref, err = s.resolveSessionsBranchRef()
-		if err != nil {
-			return nil, err
-		}
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	commit, err := s.repo.CommitObject(ref.Hash())
@@ -2262,6 +2255,27 @@ func (s *GitStore) getSessionsBranchTree(ctx context.Context) (*object.Tree, err
 	}
 
 	return tree, nil
+}
+
+// tryFetchMetadataBranch runs the injected metadata-branch fetcher at most once
+// per store, reporting whether it succeeded. The once-per-store latch matters:
+// a single command re-enters getSessionsBranchTree several times (List, then
+// getFetchingTree for each read), so without it a repo the fetch cannot recover
+// — remote has no v1, is unreachable, or refuses auth — would re-pay the whole
+// fetch budget on every entry.
+func (s *GitStore) tryFetchMetadataBranch(ctx context.Context) bool {
+	if s.metadataBranchFetcher == nil || s.metadataBranchFetchTried {
+		return false
+	}
+	s.metadataBranchFetchTried = true
+	if err := s.metadataBranchFetcher(ctx); err != nil {
+		logging.Debug(ctx, "sessions branch: checkpoint remote fetch failed",
+			slog.String("ref", s.refs.Read.String()),
+			slog.String("error", err.Error()),
+		)
+		return false
+	}
+	return true
 }
 
 // resolveSessionsBranchRef resolves refs.Read, falling back to origin's

--- a/cmd/entire/cli/checkpoint/persistent_compact_transcript_test.go
+++ b/cmd/entire/cli/checkpoint/persistent_compact_transcript_test.go
@@ -27,7 +27,7 @@ func claudeStyleTranscript() []byte {
 // Returns ("", false) when the file does not exist.
 func readBranchFile(t *testing.T, store *GitStore, path string) (string, bool) {
 	t.Helper()
-	tree, err := store.getSessionsBranchTree()
+	tree, err := store.getSessionsBranchTree(t.Context())
 	if err != nil {
 		t.Fatalf("getSessionsBranchTree() error = %v", err)
 	}

--- a/cmd/entire/cli/checkpoint/persistent_metadata_branch_fetch_test.go
+++ b/cmd/entire/cli/checkpoint/persistent_metadata_branch_fetch_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/vercelconfig"
 )
 
 // dropV1Branch removes the local v1 ref after capturing its hash, modelling a
@@ -129,4 +133,83 @@ func TestGetSessionsBranchTree_FetchFailureKeepsOriginalError(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, wantErr.Error(), err.Error(),
 		"a failed fetch should leave the original not-found error intact")
+}
+
+// TestGetSessionsBranchTree_RecoversFromDataFreeOrphan pins that a branch which
+// resolves but carries no checkpoint data triggers recovery just like a missing
+// one.
+//
+// This is the case a ref-missing trigger cannot see. A repo left holding an
+// un-initialized v1 orphan — created before the primary was switched to
+// git-refs, where enable no longer heals it — resolves the ref cleanly, so
+// without this the miss is masked and the real checkpoints on the checkpoint
+// remote stay permanently unreachable.
+func TestGetSessionsBranchTree_RecoversFromDataFreeOrphan(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo, DefaultV1Refs())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	seedBranchCheckpoint(t, store, cid, "s1")
+	realHash := dropV1Branch(t, repo)
+
+	// Stand up an orphan carrying nothing but init artifacts, the shape enable
+	// used to leave behind, and point v1 at it.
+	orphan := emptyOrphanCommit(t, repo)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(DefaultV1Refs().Primary, orphan)))
+
+	// It resolves, so the ref-missing trigger stays silent...
+	tree, err := store.getSessionsBranchTree(t.Context())
+	require.NoError(t, err, "a data-free orphan still resolves")
+	assert.False(t, treeHasCheckpointData(tree), "precondition: the orphan carries no checkpoint data")
+
+	// ...but with a fetcher wired, the data-free branch is treated as a miss.
+	store.metadataBranchFetchTried = false
+	calls := 0
+	store.SetMetadataBranchFetcher(func(_ context.Context) error {
+		calls++
+		return repo.Storer.SetReference(plumbing.NewHashReference(DefaultV1Refs().Primary, realHash))
+	})
+
+	recovered, err := store.getSessionsBranchTree(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "a data-free branch should trigger recovery")
+	_, err = recovered.Tree(cid.Path())
+	require.NoError(t, err, "recovered tree should carry the real checkpoint")
+}
+
+// emptyOrphanCommit creates a commit whose tree holds only the vercel.json init
+// artifact — the "un-initialized orphan" shape strategy.metadataBranchHasData
+// treats as data-free.
+func emptyOrphanCommit(t *testing.T, repo *git.Repository) plumbing.Hash {
+	t.Helper()
+	blob := repo.Storer.NewEncodedObject()
+	blob.SetType(plumbing.BlobObject)
+	w, err := blob.Writer()
+	require.NoError(t, err)
+	_, err = w.Write([]byte("{}\n"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	blobHash, err := repo.Storer.SetEncodedObject(blob)
+	require.NoError(t, err)
+
+	tree := &object.Tree{Entries: []object.TreeEntry{
+		{Name: vercelconfig.FileName, Mode: filemode.Regular, Hash: blobHash},
+	}}
+	treeObj := repo.Storer.NewEncodedObject()
+	require.NoError(t, tree.Encode(treeObj))
+	treeHash, err := repo.Storer.SetEncodedObject(treeObj)
+	require.NoError(t, err)
+
+	when := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	commit := &object.Commit{
+		Message:   "init orphan",
+		TreeHash:  treeHash,
+		Author:    object.Signature{Name: "t", Email: "t@example.com", When: when},
+		Committer: object.Signature{Name: "t", Email: "t@example.com", When: when},
+	}
+	commitObj := repo.Storer.NewEncodedObject()
+	require.NoError(t, commit.Encode(commitObj))
+	commitHash, err := repo.Storer.SetEncodedObject(commitObj)
+	require.NoError(t, err)
+	return commitHash
 }

--- a/cmd/entire/cli/checkpoint/persistent_metadata_branch_fetch_test.go
+++ b/cmd/entire/cli/checkpoint/persistent_metadata_branch_fetch_test.go
@@ -80,6 +80,32 @@ func TestGetSessionsBranchTree_SkipsFetchWhenBranchPresent(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestGetSessionsBranchTree_FetchesAtMostOncePerStore pins the recovery latch.
+// A single command re-enters getSessionsBranchTree several times — List, then
+// getFetchingTree for each read — so a repo the fetch cannot recover (remote has
+// no v1, unreachable, or refusing auth) would otherwise re-pay the whole fetch
+// budget on every entry, multiplying one command's worst case by the number of
+// reads it performs.
+func TestGetSessionsBranchTree_FetchesAtMostOncePerStore(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo, DefaultV1Refs())
+	seedBranchCheckpoint(t, store, id.MustCheckpointID("a1b2c3d4e5f6"), "s1")
+	dropV1Branch(t, repo)
+
+	calls := 0
+	store.SetMetadataBranchFetcher(func(_ context.Context) error {
+		calls++
+		return errors.New("remote unreachable")
+	})
+
+	for range 3 {
+		_, err := store.getSessionsBranchTree(t.Context())
+		require.Error(t, err)
+	}
+	assert.Equal(t, 1, calls, "an unrecoverable branch must not re-fetch on every read")
+}
+
 // TestGetSessionsBranchTree_FetchFailureKeepsOriginalError pins that a failing
 // fetch degrades to the pre-existing "not found" error rather than replacing it
 // with a transport error. Callers such as List treat not-found as an empty

--- a/cmd/entire/cli/checkpoint/persistent_metadata_branch_fetch_test.go
+++ b/cmd/entire/cli/checkpoint/persistent_metadata_branch_fetch_test.go
@@ -1,0 +1,106 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+)
+
+// dropV1Branch removes the local v1 ref after capturing its hash, modelling a
+// fresh clone: the checkpoints exist on the checkpoint remote, but no local ref
+// points at them and origin never carried the branch either.
+func dropV1Branch(t *testing.T, repo *git.Repository) plumbing.Hash {
+	t.Helper()
+	primary := DefaultV1Refs().Primary
+	ref, err := repo.Reference(primary, true)
+	require.NoError(t, err)
+	hash := ref.Hash()
+	require.NoError(t, repo.Storer.RemoveReference(primary))
+	return hash
+}
+
+// TestGetSessionsBranchTree_FetchesMetadataBranchWhenMissing pins the recovery
+// tier that makes a dedicated checkpoint_remote readable from a fresh clone.
+//
+// The git-branch store previously resolved reads from the local ref, then from
+// origin's remote-tracking ref, and gave up. A repo whose checkpoints live on a
+// separate checkpoint_remote has neither — origin never received the branch — so
+// every committed checkpoint read as "not found" with no path to recovery.
+func TestGetSessionsBranchTree_FetchesMetadataBranchWhenMissing(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo, DefaultV1Refs())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	seedBranchCheckpoint(t, store, cid, "s1")
+
+	hash := dropV1Branch(t, repo)
+
+	// Without a fetcher the read still fails, exactly as before.
+	_, err := store.getSessionsBranchTree(t.Context())
+	require.Error(t, err, "a missing branch with no fetcher must still fail")
+
+	calls := 0
+	store.SetMetadataBranchFetcher(func(_ context.Context) error {
+		calls++
+		return repo.Storer.SetReference(plumbing.NewHashReference(DefaultV1Refs().Primary, hash))
+	})
+
+	tree, err := store.getSessionsBranchTree(t.Context())
+	require.NoError(t, err, "the fetcher should have made the branch readable")
+	assert.Equal(t, 1, calls, "fetcher should be called exactly once")
+
+	// The recovered tree is the real one: it carries the seeded checkpoint.
+	_, err = tree.Tree(cid.Path())
+	require.NoError(t, err, "recovered tree should contain the seeded checkpoint")
+}
+
+// TestGetSessionsBranchTree_SkipsFetchWhenBranchPresent pins that the fetcher is
+// a recovery tier, not a refresh: a branch that resolves locally must never
+// trigger a network call. Reads run on hot paths where an unconditional fetch
+// would be a per-read stall.
+func TestGetSessionsBranchTree_SkipsFetchWhenBranchPresent(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo, DefaultV1Refs())
+	seedBranchCheckpoint(t, store, id.MustCheckpointID("a1b2c3d4e5f6"), "s1")
+
+	store.SetMetadataBranchFetcher(func(_ context.Context) error {
+		t.Error("fetcher must not run when the branch resolves locally")
+		return nil
+	})
+
+	_, err := store.getSessionsBranchTree(t.Context())
+	require.NoError(t, err)
+}
+
+// TestGetSessionsBranchTree_FetchFailureKeepsOriginalError pins that a failing
+// fetch degrades to the pre-existing "not found" error rather than replacing it
+// with a transport error. Callers such as List treat not-found as an empty
+// result, so surfacing the fetch failure here would turn an offline read into a
+// hard error.
+func TestGetSessionsBranchTree_FetchFailureKeepsOriginalError(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo, DefaultV1Refs())
+	seedBranchCheckpoint(t, store, id.MustCheckpointID("a1b2c3d4e5f6"), "s1")
+	dropV1Branch(t, repo)
+
+	_, wantErr := store.getSessionsBranchTree(t.Context())
+	require.Error(t, wantErr)
+
+	store.SetMetadataBranchFetcher(func(_ context.Context) error {
+		return errors.New("no checkpoint_remote configured")
+	})
+
+	_, err := store.getSessionsBranchTree(t.Context())
+	require.Error(t, err)
+	assert.Equal(t, wantErr.Error(), err.Error(),
+		"a failed fetch should leave the original not-found error intact")
+}

--- a/cmd/entire/cli/checkpoint/registry.go
+++ b/cmd/entire/cli/checkpoint/registry.go
@@ -31,11 +31,12 @@ const BackendTypeGitRefs = "git-refs"
 // RemoteRefLister; other backends ignore the git-shaped fields and read their
 // own configuration from cfg.
 type OpenEnv struct {
-	Repo            *git.Repository
-	BlobFetcher     BlobFetchFunc
-	RefFetcher      RefFetchFunc
-	RemoteRefLister RemoteRefListFunc
-	Refs            PersistentRefs
+	Repo                  *git.Repository
+	BlobFetcher           BlobFetchFunc
+	RefFetcher            RefFetchFunc
+	RemoteRefLister       RemoteRefListFunc
+	MetadataBranchFetcher MetadataBranchFetchFunc
+	Refs                  PersistentRefs
 }
 
 // Factory constructs a persistent store for one backend type. cfg is the
@@ -147,6 +148,9 @@ func gitBranchBackendFactory(_ context.Context, env OpenEnv, _ json.RawMessage) 
 	store := NewGitStore(env.Repo, env.Refs)
 	if env.BlobFetcher != nil {
 		store.SetBlobFetcher(env.BlobFetcher)
+	}
+	if env.MetadataBranchFetcher != nil {
+		store.SetMetadataBranchFetcher(env.MetadataBranchFetcher)
 	}
 	return store, nil
 }

--- a/cmd/entire/cli/checkpoint/store.go
+++ b/cmd/entire/cli/checkpoint/store.go
@@ -33,8 +33,9 @@ type treeWriter struct {
 type GitStore struct {
 	*treeWriter
 
-	refs        PersistentRefs
-	blobFetcher BlobFetchFunc
+	refs                  PersistentRefs
+	blobFetcher           BlobFetchFunc
+	metadataBranchFetcher MetadataBranchFetchFunc
 }
 
 // ephemeralStore is the git shadow-branch (temporary) checkpoint store. It is
@@ -70,6 +71,13 @@ func NewGitStore(repo *git.Repository, refs PersistentRefs) *GitStore {
 // on demand when reading from metadata trees.
 func (s *GitStore) SetBlobFetcher(f BlobFetchFunc) {
 	s.blobFetcher = f
+}
+
+// SetMetadataBranchFetcher configures the store to fetch the metadata branch
+// from the checkpoint remote when it is missing both locally and on origin.
+// See MetadataBranchFetchFunc for when it is appropriate to wire this.
+func (s *GitStore) SetMetadataBranchFetcher(f MetadataBranchFetchFunc) {
+	s.metadataBranchFetcher = f
 }
 
 // Repository returns the underlying git repository.

--- a/cmd/entire/cli/checkpoint/store.go
+++ b/cmd/entire/cli/checkpoint/store.go
@@ -36,6 +36,9 @@ type GitStore struct {
 	refs                  PersistentRefs
 	blobFetcher           BlobFetchFunc
 	metadataBranchFetcher MetadataBranchFetchFunc
+	// metadataBranchFetchTried latches the one recovery attempt per store; see
+	// tryFetchMetadataBranch.
+	metadataBranchFetchTried bool
 }
 
 // ephemeralStore is the git shadow-branch (temporary) checkpoint store. It is

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -822,7 +822,11 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		}
 		// Reload to get the updated summary.
 		stopLoad = startSpinner(errW, fmt.Sprintf("Reloading checkpoint %s", fullCheckpointID))
-		reopened, openErr := checkpoint.Open(ctx, lookup.repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash, RefFetcher: FetchCheckpointRef})
+		reopened, openErr := checkpoint.Open(ctx, lookup.repo, checkpoint.OpenOptions{
+			BlobFetcher:           FetchBlobsByHash,
+			RefFetcher:            FetchCheckpointRef,
+			MetadataBranchFetcher: FetchMetadataFromCheckpointRemote,
+		})
 		if openErr != nil {
 			stopLoad(false)
 			return fmt.Errorf("open checkpoint store: %w", openErr)
@@ -998,7 +1002,15 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 	// `git fetch` fails against partial-clone repos with "did not send all
 	// necessary objects"). Falls back to a full metadata-branch fetch if
 	// fetch-pack also can't reach the blobs.
-	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash, RefFetcher: FetchCheckpointRef})
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{
+		BlobFetcher: FetchBlobsByHash,
+		RefFetcher:  FetchCheckpointRef,
+		// Legacy hex-ID checkpoints live on the v1 branch, which a fresh clone
+		// with a dedicated checkpoint_remote does not have — and cannot get from
+		// origin, which never received it. Without this, explain reports every
+		// such checkpoint as unreadable.
+		MetadataBranchFetcher: FetchMetadataFromCheckpointRemote,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("open checkpoint store: %w", err)
 	}
@@ -2502,9 +2514,10 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	// fetchers hydrate each on read. WithRemoteListDiscovery keeps this off the
 	// per-turn hook hot path.
 	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{
-		BlobFetcher:     FetchBlobsByHash,
-		RefFetcher:      FetchCheckpointRef,
-		RemoteRefLister: ListCheckpointRefsOnRemote,
+		BlobFetcher:           FetchBlobsByHash,
+		RefFetcher:            FetchCheckpointRef,
+		RemoteRefLister:       ListCheckpointRefsOnRemote,
+		MetadataBranchFetcher: FetchMetadataFromCheckpointRemote,
 	})
 	if err != nil {
 		return nil, false, fmt.Errorf("open checkpoint store: %w", err)

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -2513,11 +2513,16 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	// surface refs-native checkpoints written on another machine, and the
 	// fetchers hydrate each on read. WithRemoteListDiscovery keeps this off the
 	// per-turn hook hot path.
+	//
+	// Deliberately no MetadataBranchFetcher: that tier transfers the whole v1
+	// branch, and enumeration must stay proportionate to rendering a list — the
+	// refs side next to it discovers by name only for the same reason. A repo
+	// with no local v1 lists what it has; naming a specific checkpoint
+	// (explain --checkpoint) is what earns the fetch.
 	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{
-		BlobFetcher:           FetchBlobsByHash,
-		RefFetcher:            FetchCheckpointRef,
-		RemoteRefLister:       ListCheckpointRefsOnRemote,
-		MetadataBranchFetcher: FetchMetadataFromCheckpointRemote,
+		BlobFetcher:     FetchBlobsByHash,
+		RefFetcher:      FetchCheckpointRef,
+		RemoteRefLister: ListCheckpointRefsOnRemote,
 	})
 	if err != nil {
 		return nil, false, fmt.Errorf("open checkpoint store: %w", err)

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -250,12 +250,16 @@ func matchCheckpointPrefixWithRemoteFallback(ctx context.Context, errW io.Writer
 		return matches, lookup
 	}
 
-	// git-refs primary: there is no single metadata branch to fetch — each
-	// checkpoint is its own ref. When the prefix is a full checkpoint ID (the
+	// git-refs primary: refs-native checkpoints have no single metadata branch to
+	// fetch — each is its own ref. When the prefix is a full checkpoint ID (the
 	// Entire-Checkpoint commit trailer always is), fetch that one ref directly,
-	// then re-list. A shorter prefix cannot be fetched per-ref, and under a
-	// refs primary there is no v1 metadata branch to fetch either, so a
-	// short-prefix miss stays local-only.
+	// then re-list. A shorter prefix cannot be fetched per-ref, so a short-prefix
+	// miss stays local-only for refs-native checkpoints.
+	//
+	// Legacy hex-ID checkpoints on the v1 branch are already covered before we
+	// get here, at any prefix length: matchCheckpointPrefix reads lookup.committed,
+	// which the store's List populates, and the git-branch read store recovers a
+	// missing v1 branch from the checkpoint remote itself (MetadataBranchFetchFunc).
 	if cpCfg, _ := settings.LoadCheckpointsConfig(ctx); checkpoint.PrimaryIsRefs(cpCfg) { //nolint:errcheck // fail-soft: bad config surfaces via Open elsewhere
 		if cid, err := id.NewCheckpointID(prefix); err != nil {
 			logging.Debug(ctx, "explain: prefix is not a full checkpoint ID; refs-primary store cannot fetch by prefix, treating as no match",

--- a/cmd/entire/cli/integration_test/enable_checkpoint_remote_test.go
+++ b/cmd/entire/cli/integration_test/enable_checkpoint_remote_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/entireio/cli/cmd/entire/cli/execx"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -59,7 +58,9 @@ func TestEnable_GitRefsPrimaryDoesNotPullCheckpointBranch(t *testing.T) {
 	// The settings that drive this must have survived enable, or the assertion
 	// above would pass for the wrong reason (a repo that silently fell back to
 	// the git-branch primary has no v1 branch yet either).
-	settings := readFileInDir(t, consumerDir, filepath.Join(".entire", paths.SettingsFileName))
+	settingsBytes, err := os.ReadFile(filepath.Join(consumerDir, ".entire", paths.SettingsFileName))
+	require.NoError(t, err)
+	settings := string(settingsBytes)
 	assert.Contains(t, settings, `"git-refs"`, "enable must preserve the committed git-refs primary")
 	assert.Contains(t, settings, checkpointRemoteRepoSlug, "enable must preserve the committed checkpoint_remote")
 
@@ -70,7 +71,7 @@ func TestEnable_GitRefsPrimaryDoesNotPullCheckpointBranch(t *testing.T) {
 
 	// Prove the read did the recovery rather than finding data that was already
 	// there: the branch is local only now, after explain.
-	requireMetadataBranchPresent(t, consumerDir,
+	require.True(t, testutil.BranchExists(t, consumerDir, paths.MetadataBranchName),
 		"explain should have fetched v1 from the checkpoint remote")
 }
 
@@ -149,46 +150,24 @@ func setupGitRefsCheckpointRemoteRepo(t *testing.T, checkpointBareDir string) st
 // origin remote-tracking ref.
 func requireNoMetadataBranch(t *testing.T, dir, msg string) {
 	t.Helper()
+	require.False(t, testutil.BranchExists(t, dir, paths.MetadataBranchName), msg)
+
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
 	defer repo.Close()
-
-	_, err = repo.Storer.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName))
-	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound, msg)
 	_, err = repo.Storer.Reference(plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName))
 	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound, msg)
 }
 
-// requireMetadataBranchPresent asserts the v1 branch resolves locally.
-func requireMetadataBranchPresent(t *testing.T, dir, msg string) {
-	t.Helper()
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	defer repo.Close()
-
-	_, err = repo.Storer.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName))
-	require.NoError(t, err, msg)
-}
-
-func readFileInDir(t *testing.T, dir, rel string) string {
-	t.Helper()
-	data, err := os.ReadFile(filepath.Join(dir, rel))
-	require.NoError(t, err)
-	return string(data)
-}
-
-// runEntireInDir runs the entire binary in dir and returns combined output,
-// failing the test if the command errors. Uses execx.NonInteractive (project
-// rule for spawning the entire binary in tests) so the child has no controlling
-// terminal and never blocks on a prompt.
+// runEntireInDir runs the entire binary in dir under git-isolated env and
+// returns its combined output, failing the test if the command errors. Thin
+// wrapper over runEntire, which owns the execx.NonInteractive spawn (project
+// rule: the child gets no controlling terminal, so it never blocks on a prompt).
 func runEntireInDir(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := execx.NonInteractive(t.Context(), getTestBinary(), args...)
-	cmd.Dir = dir
-	cmd.Env = testutil.GitIsolatedEnv()
-	out, err := cmd.CombinedOutput()
+	stdout, stderr, err := runEntire(t, testutil.GitIsolatedEnv(), dir, args...)
 	if err != nil {
-		t.Fatalf("entire %v failed: %v\n%s", args, err, out)
+		t.Fatalf("entire %v failed: %v\n%s%s", args, err, stdout, stderr)
 	}
-	return string(out)
+	return stdout + stderr
 }

--- a/cmd/entire/cli/integration_test/enable_checkpoint_remote_test.go
+++ b/cmd/entire/cli/integration_test/enable_checkpoint_remote_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/execx"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// TestEnable_GitRefsPrimaryDoesNotPullCheckpointBranch is the end-to-end
+// acceptance test for the shape the CLI repo itself ships: committed settings
+// that pair the git-refs primary with a dedicated checkpoint_remote whose v1
+// branch carries the repo's legacy checkpoint history.
+//
+// Before the fix, `entire enable` on a fresh clone of such a repo eagerly cloned
+// that branch — every blob of every transcript ever committed — under a 30s
+// deadline. On a real checkpoint remote the transfer cannot finish in time, and
+// because the git-refs path deliberately creates no orphan when the fetch fails,
+// the next run found identical state and started over. It never converged, and
+// the failure was logged at Debug so the command just looked slow.
+//
+// The two halves are a pair, and testing either alone would miss the point:
+// enable must not pull the branch, AND a checkpoint that exists only on that
+// branch must still be readable. The branch is not vestigial under git-refs —
+// legacy hex-ID checkpoints live there and reads route to it by ID format — so
+// "don't fetch it" is only correct because reads recover it on demand.
+func TestEnable_GitRefsPrimaryDoesNotPullCheckpointBranch(t *testing.T) {
+	t.Parallel()
+
+	// Producer: a git-branch repo that condenses a checkpoint onto v1 and pushes
+	// it to a bare repo, which then plays the consumer's checkpoint_remote. This
+	// models history written before the repo moved to the git-refs backend.
+	producer := NewFeatureBranchEnv(t)
+	bareDir := producer.SetupBareRemote()
+	const prompt = "Add rate limiting to the API gateway"
+	checkpointID := createAndPushCheckpoint(t, producer, "limiter.go", prompt)
+
+	// Consumer: a fresh-clone-shaped repo carrying the committed settings.
+	consumerDir := setupGitRefsCheckpointRemoteRepo(t, bareDir)
+	requireNoMetadataBranch(t, consumerDir, "precondition: the fresh repo has no v1 branch")
+
+	// --- enable must not pull the branch ---
+	runEntireInDir(t, consumerDir, "enable", "--agent", agentClaudeCode, "--telemetry=false")
+
+	requireNoMetadataBranch(t, consumerDir,
+		"enable must not fetch v1 under the git-refs primary: the branch is never written or pushed by that backend, so there is no divergence to prevent and the fetch only costs the full transcript history")
+
+	// The settings that drive this must have survived enable, or the assertion
+	// above would pass for the wrong reason (a repo that silently fell back to
+	// the git-branch primary has no v1 branch yet either).
+	settings := readFileInDir(t, consumerDir, filepath.Join(".entire", paths.SettingsFileName))
+	assert.Contains(t, settings, `"git-refs"`, "enable must preserve the committed git-refs primary")
+	assert.Contains(t, settings, checkpointRemoteRepoSlug, "enable must preserve the committed checkpoint_remote")
+
+	// --- and a checkpoint that exists only on that branch must still read ---
+	output := runExplainInDir(t, consumerDir, checkpointID)
+	require.Contains(t, output, prompt,
+		"explain must recover the v1 branch from the checkpoint remote on demand; without that tier a legacy hex-ID checkpoint is unreadable, since the branch is absent locally and origin never carried it")
+
+	// Prove the read did the recovery rather than finding data that was already
+	// there: the branch is local only now, after explain.
+	requireMetadataBranchPresent(t, consumerDir,
+		"explain should have fetched v1 from the checkpoint remote")
+}
+
+// checkpointRemoteRepoSlug is the owner/repo the consumer's checkpoint_remote
+// names. The derived URL is redirected at the local bare via insteadOf, so
+// nothing in this test dials the network.
+const checkpointRemoteRepoSlug = "org/checkpoints"
+
+// setupGitRefsCheckpointRemoteRepo creates a repo shaped like a fresh clone of a
+// project whose committed settings select the git-refs primary and point
+// checkpoints at a dedicated checkpoint_remote — the CLI repo's own shape.
+//
+// origin is a separate empty bare holding no checkpoint data, which is the point:
+// the v1 branch exists only on the checkpoint remote, so origin's remote-tracking
+// ref can never satisfy a read. checkpoint_remote must be a real provider/repo
+// pair (settings.GetCheckpointRemote rejects anything else, and a rejected config
+// reads as "not configured"), so the derived URL is redirected at the bare with
+// git's insteadOf rather than by naming a path directly.
+func setupGitRefsCheckpointRemoteRepo(t *testing.T, checkpointBareDir string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	testutil.InitRepo(t, dir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".entire/\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# consumer\n"), 0o644))
+
+	entireDir := filepath.Join(dir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	settings := map[string]any{
+		"enabled":   true,
+		"local_dev": true,
+		"strategy":  "manual-commit",
+		"strategy_options": map[string]any{
+			"filtered_fetches": true,
+			"checkpoint_remote": map[string]any{
+				"provider": "github",
+				"repo":     checkpointRemoteRepoSlug,
+			},
+		},
+		"checkpoints": map[string]any{
+			"primary": map[string]any{"type": "git-refs"},
+		},
+	}
+	data, err := jsonutil.MarshalIndentWithNewline(settings, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, paths.SettingsFileName), data, 0o644))
+
+	gitOutput(t, dir, "add", ".gitignore", "README.md")
+	gitOutput(t, dir, "commit", "-m", "initial commit")
+
+	// origin: a real but empty bare, so URL derivation has a remote to read and
+	// nothing ever dials the network. It must be a file:// URL, not a bare path —
+	// remote.FetchURL parses origin to derive the checkpoint URL, and a path with
+	// no protocol makes it give up and fall back to origin itself.
+	originBare := t.TempDir()
+	gitOutput(t, originBare, "init", "--bare")
+	gitOutput(t, dir, "remote", "add", "origin", "file://"+originBare)
+
+	// Redirect both URL shapes the checkpoint_remote can derive to (HTTPS from
+	// the provider's canonical host, or SSH) at the local bare.
+	fileURL := "file://" + checkpointBareDir
+	for _, derived := range []string{
+		"https://github.com/" + checkpointRemoteRepoSlug + ".git",
+		"git@github.com:" + checkpointRemoteRepoSlug + ".git",
+	} {
+		gitOutput(t, dir, "config", "--add", "url."+fileURL+".insteadOf", derived)
+	}
+
+	return dir
+}
+
+// requireNoMetadataBranch asserts the v1 branch is absent both locally and as an
+// origin remote-tracking ref.
+func requireNoMetadataBranch(t *testing.T, dir, msg string) {
+	t.Helper()
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	_, err = repo.Storer.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName))
+	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound, msg)
+	_, err = repo.Storer.Reference(plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName))
+	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound, msg)
+}
+
+// requireMetadataBranchPresent asserts the v1 branch resolves locally.
+func requireMetadataBranchPresent(t *testing.T, dir, msg string) {
+	t.Helper()
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	_, err = repo.Storer.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName))
+	require.NoError(t, err, msg)
+}
+
+func readFileInDir(t *testing.T, dir, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, rel))
+	require.NoError(t, err)
+	return string(data)
+}
+
+// runEntireInDir runs the entire binary in dir and returns combined output,
+// failing the test if the command errors. Uses execx.NonInteractive (project
+// rule for spawning the entire binary in tests) so the child has no controlling
+// terminal and never blocks on a prompt.
+func runEntireInDir(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := execx.NonInteractive(t.Context(), getTestBinary(), args...)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("entire %v failed: %v\n%s", args, err, out)
+	}
+	return string(out)
+}

--- a/cmd/entire/cli/integration_test/explain_test.go
+++ b/cmd/entire/cli/integration_test/explain_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/entireio/cli/cmd/entire/cli/execx"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -434,20 +433,11 @@ func writeMinimalEntireSettings(dir, bareURL string) error {
 	return os.WriteFile(filepath.Join(entireDir, paths.SettingsFileName), data, 0o644)
 }
 
-// runExplainInDir runs `entire explain --checkpoint <id>` in dir and
-// returns combined output. Fails the test if the command errors. Uses
-// execx.NonInteractive (project rule for spawning the entire binary in
-// tests) so the child has no controlling terminal.
+// runExplainInDir runs `entire checkpoint explain --checkpoint <id>` in dir and
+// returns combined output. Fails the test if the command errors.
 func runExplainInDir(t *testing.T, dir, checkpointID string) string {
 	t.Helper()
-	cmd := execx.NonInteractive(t.Context(), getTestBinary(), "checkpoint", "explain", "--checkpoint", checkpointID)
-	cmd.Dir = dir
-	cmd.Env = testutil.GitIsolatedEnv()
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("explain failed: %v\n%s", err, out)
-	}
-	return string(out)
+	return runEntireInDir(t, dir, "checkpoint", "explain", "--checkpoint", checkpointID)
 }
 
 // requireBlobMissing asserts that at least one metadata blob for the

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -165,12 +166,19 @@ func fetchMetadataBranchWithin(ctx context.Context, remoteURL string, timeout ti
 // leaking into logs.
 //
 // When noFilter is true, --filter=blob:none is suppressed even if filtered
-// fetches are globally enabled. Use noFilter for operations that need blob
-// content (resume, explain) as opposed to operations that only need the ref
-// and its tree structure (enable bootstrap/heal, push recovery). The
-// distinction matters: v1's blobs are the full transcript archive, so an
-// unfiltered fetch costs the whole history where a filtered one costs the
-// commit graph.
+// fetches are globally enabled. The distinction matters: v1's blobs are the full
+// transcript archive, so an unfiltered fetch costs the whole history where a
+// filtered one costs the commit graph.
+//
+// Filtered is only correct where nothing downstream reads blob content from the
+// local branch. That holds for the enable bootstrap/heal, which exist solely to
+// land the ref at the remote tip so a later orphan cannot diverge from it. It
+// does NOT hold once the branch is the repo's checkpoint store: GitStore.List
+// reads each checkpoint's metadata.json through a plain tree with no blob
+// fetcher attached, so on a blob-filtered branch every entry silently degrades
+// to an ID with no prompt, date, or counts. Paths that leave the branch in place
+// for reading — FetchMetadataBranch, and the push-path fetch that lands the
+// store a git-branch repo then reads — therefore pass noFilter.
 // timeout bounds the fetch: pass checkpointRemoteFetchTimeout on the push hot
 // path and checkpointRemoteForegroundFetchTimeout from user-initiated commands.
 func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, label string, noFilter bool, timeout time.Duration) error {
@@ -223,10 +231,16 @@ func fetchMetadataBranchIfMissing(ctx context.Context, remoteURL string) error {
 	}
 	defer repo.Close()
 
-	// Check if branch already exists locally - if so, nothing to do
+	// Check if branch already exists locally - if so, nothing to do. Only a
+	// genuinely-absent ref means "missing": any other read failure (corrupt or
+	// unreadable ref storage) is surfaced rather than masked as absence, which
+	// would send us to the network to fix a local problem.
 	refs := checkpoint.ResolveRefs(ctx)
-	if _, err := repo.Reference(refs.Primary, true); err == nil {
+	switch _, err := repo.Reference(refs.Primary, true); {
+	case err == nil:
 		return nil // Branch exists locally, skip fetch
+	case !errors.Is(err, plumbing.ErrReferenceNotFound):
+		return fmt.Errorf("read local ref %s: %w", refs.Primary, err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, checkpointRemoteFetchTimeout)

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -41,6 +41,11 @@ type pushSettings struct {
 	checkpointURL string
 	// pushDisabled is true if push_sessions is explicitly set to false.
 	pushDisabled bool
+	// primaryIsRefs records whether the git-refs backend is the configured
+	// primary, resolved once here so the pre-push path does not re-read the
+	// checkpoints config (LoadCheckpointsConfig is uncached: two whole-file
+	// reads and JSON parses per call).
+	primaryIsRefs bool
 }
 
 // pushTarget returns the target to use for git push/fetch commands for checkpoint branches.
@@ -75,8 +80,9 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 	}
 
 	ps := pushSettings{
-		remote:       pushRemoteName,
-		pushDisabled: s.IsPushSessionsDisabled(),
+		remote:        pushRemoteName,
+		pushDisabled:  s.IsPushSessionsDisabled(),
+		primaryIsRefs: primaryIsGitRefs(ctx),
 	}
 
 	config := s.GetCheckpointRemote()
@@ -109,7 +115,7 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 	// forever and every single push would re-pay the fetch. On a large checkpoint
 	// remote that is a multi-second stall on each `git push` for a branch this
 	// push will not touch.
-	if !primaryIsGitRefs(ctx) {
+	if !ps.primaryIsRefs {
 		if err := fetchMetadataBranchIfMissing(ctx, checkpointURL); err != nil {
 			logging.Warn(ctx, "checkpoint-remote: failed to fetch metadata branch",
 				slog.String("error", err.Error()),
@@ -206,6 +212,10 @@ func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, lab
 // established by probing with ls-remote first — positive evidence, matching
 // remote.FetchCheckpointRef's absence-vs-failure contract — rather than by
 // treating every fetch error as absence.
+//
+// The probe and the fetch share one deadline, so the budget the caller sees is
+// the constant's value rather than twice it: per-call timeouts do not compose
+// when applied at two nesting levels.
 func fetchMetadataBranchIfMissing(ctx context.Context, remoteURL string) error {
 	repo, err := OpenRepository(ctx)
 	if err != nil {
@@ -219,9 +229,10 @@ func fetchMetadataBranchIfMissing(ctx context.Context, remoteURL string) error {
 		return nil // Branch exists locally, skip fetch
 	}
 
-	probeCtx, cancel := context.WithTimeout(ctx, checkpointRemoteFetchTimeout)
+	ctx, cancel := context.WithTimeout(ctx, checkpointRemoteFetchTimeout)
 	defer cancel()
-	out, probeErr := remote.LsRemoteInDir(probeCtx, "", remoteURL, refs.Primary.String())
+
+	out, probeErr := remote.LsRemoteInDir(ctx, "", remoteURL, refs.Primary.String())
 	if probeErr != nil {
 		return fmt.Errorf("probe %s on %s: %w", refs.Primary, remote.RedactURL(remoteURL), probeErr)
 	}

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -1,6 +1,7 @@
 package strategy
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -15,8 +16,20 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
-// checkpointRemoteFetchTimeout is the timeout for fetching branches from the checkpoint URL.
+// checkpointRemoteFetchTimeout bounds checkpoint-remote fetches made from the
+// push hot path, where the user's own `git push` is blocked for the duration.
 const checkpointRemoteFetchTimeout = 30 * time.Second
+
+// checkpointRemoteForegroundFetchTimeout bounds checkpoint-remote fetches made
+// by user-initiated foreground commands (enable, resume, explain). It matches
+// the origin-side metadata fetch budget in the cli package.
+//
+// Splitting the two fixes a backwards asymmetry: origin-side fetches already had
+// two minutes while the checkpoint remote — which by definition holds strictly
+// more checkpoint history than origin does — was held to the push hot path's 30
+// seconds. A checkpoint archive too large to transfer in 30s was therefore
+// unreadable, and each attempt failed the same way with nothing to show for it.
+const checkpointRemoteForegroundFetchTimeout = 2 * time.Minute
 
 // pushSettings holds the resolved push configuration from a single settings load.
 type pushSettings struct {
@@ -113,8 +126,14 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 // where the local branch may be stale).
 //
 // The fetch is unfiltered (NoFilter: true) because resume needs blob content
-// (transcripts, metadata JSON) — not just tree objects.
+// (transcripts, metadata JSON) — not just tree objects, and it runs on the
+// foreground budget for the same reason: it is the call that actually moves the
+// transcript archive.
 func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
+	return fetchMetadataBranchWithin(ctx, remoteURL, checkpointRemoteForegroundFetchTimeout)
+}
+
+func fetchMetadataBranchWithin(ctx context.Context, remoteURL string, timeout time.Duration) error {
 	refs := checkpoint.ResolveRefs(ctx)
 	if !refs.Primary.IsBranch() {
 		return fmt.Errorf("primary metadata ref %s is not a branch", refs.Primary)
@@ -123,7 +142,7 @@ func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
 	tmpRef := FetchTmpRefPrefix + branchName
 	srcRef := refs.Primary.String()
 
-	if err := fetchURLIntoTmpRef(ctx, "", remoteURL, srcRef, tmpRef, "metadata branch", true); err != nil {
+	if err := fetchURLIntoTmpRef(ctx, "", remoteURL, srcRef, tmpRef, "metadata branch", true, timeout); err != nil {
 		return err
 	}
 	if err := PromoteTmpRefSafely(ctx, plumbing.ReferenceName(tmpRef), refs.Primary, branchName); err != nil {
@@ -146,8 +165,10 @@ func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
 // distinction matters: v1's blobs are the full transcript archive, so an
 // unfiltered fetch costs the whole history where a filtered one costs the
 // commit graph.
-func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, label string, noFilter bool) error {
-	fetchCtx, cancel := context.WithTimeout(ctx, checkpointRemoteFetchTimeout)
+// timeout bounds the fetch: pass checkpointRemoteFetchTimeout on the push hot
+// path and checkpointRemoteForegroundFetchTimeout from user-initiated commands.
+func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, label string, noFilter bool, timeout time.Duration) error {
+	fetchCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	refSpec := fmt.Sprintf("+%s:%s", srcRef, tmpRef)
@@ -172,8 +193,19 @@ func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, lab
 
 // fetchMetadataBranchIfMissing fetches the primary metadata ref from a URL only if it doesn't exist locally.
 // This avoids network calls on every push — once the branch exists locally, this is a no-op.
-// Fetch failures are silently swallowed (returns nil): the push will handle creating the
-// branch on the remote. Only fatal errors (opening repo, creating local branch) are returned.
+// It runs on the push hot path, so it uses the short fetch budget.
+//
+// A fetch failure is not fatal — the push will create the branch on the remote
+// when it succeeds — but it is returned rather than swallowed so the caller can
+// log it. Returning nil unconditionally meant a checkpoint remote that was
+// unreachable, too slow, or refusing auth looked identical to one that was never
+// contacted, and resolvePushSettings' warning could never fire.
+//
+// A remote that simply does not carry the branch yet (the normal state of a
+// brand-new checkpoint repo) is not a failure and stays quiet. That case is
+// established by probing with ls-remote first — positive evidence, matching
+// remote.FetchCheckpointRef's absence-vs-failure contract — rather than by
+// treating every fetch error as absence.
 func fetchMetadataBranchIfMissing(ctx context.Context, remoteURL string) error {
 	repo, err := OpenRepository(ctx)
 	if err != nil {
@@ -187,10 +219,19 @@ func fetchMetadataBranchIfMissing(ctx context.Context, remoteURL string) error {
 		return nil // Branch exists locally, skip fetch
 	}
 
-	// Branch doesn't exist locally - try to fetch it from the URL.
-	// Fetch failures are not fatal: push will create it on the remote when it succeeds.
-	if err := FetchMetadataBranch(ctx, remoteURL); err != nil {
+	probeCtx, cancel := context.WithTimeout(ctx, checkpointRemoteFetchTimeout)
+	defer cancel()
+	out, probeErr := remote.LsRemoteInDir(probeCtx, "", remoteURL, refs.Primary.String())
+	if probeErr != nil {
+		return fmt.Errorf("probe %s on %s: %w", refs.Primary, remote.RedactURL(remoteURL), probeErr)
+	}
+	if len(bytes.TrimSpace(out)) == 0 {
+		// Remote reachable, branch not there yet. The first push creates it.
 		return nil
+	}
+
+	if err := fetchMetadataBranchWithin(ctx, remoteURL, checkpointRemoteFetchTimeout); err != nil {
+		return err
 	}
 
 	logging.Info(ctx, "checkpoint-remote: fetched metadata branch from URL")

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -89,10 +89,19 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 	// This is a one-time operation — once the branch exists locally, subsequent pushes
 	// skip the fetch entirely. Only fetch the metadata branch; trails are always pushed
 	// to the user's push remote, not the checkpoint remote.
-	if err := fetchMetadataBranchIfMissing(ctx, checkpointURL); err != nil {
-		logging.Warn(ctx, "checkpoint-remote: failed to fetch metadata branch",
-			slog.String("error", err.Error()),
-		)
+	//
+	// Skipped entirely under the git-refs primary backend, where the "one-time"
+	// framing does not hold: that backend pushes per-checkpoint refs and never
+	// writes the local v1 branch (see prePush), so the branch stays missing
+	// forever and every single push would re-pay the fetch. On a large checkpoint
+	// remote that is a multi-second stall on each `git push` for a branch this
+	// push will not touch.
+	if !primaryIsGitRefs(ctx) {
+		if err := fetchMetadataBranchIfMissing(ctx, checkpointURL); err != nil {
+			logging.Warn(ctx, "checkpoint-remote: failed to fetch metadata branch",
+				slog.String("error", err.Error()),
+			)
+		}
 	}
 
 	return ps

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -166,22 +166,25 @@ func fetchMetadataBranchWithin(ctx context.Context, remoteURL string, timeout ti
 // leaking into logs.
 //
 // When noFilter is true, --filter=blob:none is suppressed even if filtered
-// fetches are globally enabled. The distinction matters: v1's blobs are the full
-// transcript archive, so an unfiltered fetch costs the whole history where a
-// filtered one costs the commit graph.
+// fetches are globally enabled. v1's blobs are the full transcript archive, so
+// an unfiltered fetch costs the whole history where a filtered one costs only
+// the commit graph — but every caller here passes true, and the reason is worth
+// stating because the cheaper option looks safe and is not.
 //
-// Filtered is only correct where nothing downstream reads blob content from the
-// local branch. That holds for the enable bootstrap/heal, which exist solely to
-// land the ref at the remote tip so a later orphan cannot diverge from it. It
-// does NOT hold once the branch is the repo's checkpoint store: GitStore.List
-// reads each checkpoint's metadata.json through a plain tree with no blob
-// fetcher attached, so on a blob-filtered branch every entry silently degrades
-// to an ID with no prompt, date, or counts. Paths that leave the branch in place
-// for reading — FetchMetadataBranch, and the push-path fetch that lands the
-// store a git-branch repo then reads — therefore pass noFilter.
+// Filtering would be correct only where nothing downstream reads blob content
+// from the local branch. No caller meets that bar: each one lands v1 as the
+// repo's checkpoint store, and GitStore.List reads each checkpoint's
+// metadata.json through a plain tree with no blob fetcher attached. Worse, the
+// read path's recovery tier is keyed on the *ref* being missing, so once a
+// filtered fetch lands the ref it never fires again — leaving `checkpoint list`
+// permanently showing bare IDs with no prompt, date, or counts, recoverable only
+// by explaining each checkpoint by ID.
+//
+// The parameter is kept rather than inlined so the contract stays explicit at
+// each call site.
 // timeout bounds the fetch: pass checkpointRemoteFetchTimeout on the push hot
 // path and checkpointRemoteForegroundFetchTimeout from user-initiated commands.
-func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, label string, noFilter bool, timeout time.Duration) error {
+func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, label string, noFilter bool, timeout time.Duration) error { //nolint:unparam // every caller needs blob content today; see the doc above for why the filtered variant is unsafe here
 	fetchCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -141,9 +141,12 @@ func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
 //
 // When noFilter is true, --filter=blob:none is suppressed even if filtered
 // fetches are globally enabled. Use noFilter for operations that need blob
-// content (resume, explain) as opposed to sync operations (push recovery)
-// that only need tree structure.
-func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, label string, noFilter bool) error { //nolint:unparam // noFilter distinguishes blob-content fetches (true) from tree-only sync fetches (false); kept for the documented fetch-filtering contract even though current callers all need blob content
+// content (resume, explain) as opposed to operations that only need the ref
+// and its tree structure (enable bootstrap/heal, push recovery). The
+// distinction matters: v1's blobs are the full transcript archive, so an
+// unfiltered fetch costs the whole history where a filtered one costs the
+// commit graph.
+func fetchURLIntoTmpRef(ctx context.Context, dir, remoteURL, srcRef, tmpRef, label string, noFilter bool) error {
 	fetchCtx, cancel := context.WithTimeout(ctx, checkpointRemoteFetchTimeout)
 	defer cancel()
 

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -1453,3 +1453,112 @@ func checkpointRemoteMetadataFiles(ctx context.Context, t *testing.T, dir string
 	require.NoError(t, err)
 	return string(out)
 }
+
+// checkpointRemoteWithV1 builds a checkpoint remote holding entire/checkpoints/v1
+// with one real checkpoint, and returns its directory. Used by the git-refs
+// bootstrap-skip tests, where the remote must be genuinely fetchable so a
+// passing assertion proves the fetch was skipped rather than that it failed.
+func checkpointRemoteWithV1(ctx context.Context, t *testing.T) string {
+	t.Helper()
+	remoteDir := t.TempDir()
+	testutil.InitRepo(t, remoteDir)
+	testutil.WriteFile(t, remoteDir, "f.txt", "init")
+	testutil.GitAdd(t, remoteDir, "f.txt")
+	testutil.GitCommit(t, remoteDir, "init")
+	defaultBranch := checkpointRemoteCurrentBranch(ctx, t, remoteDir)
+
+	runCheckpointRemoteGit(ctx, t, remoteDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, remoteDir, "rm", "-rf", ".")
+	commitCheckpointRemoteMetadata(ctx, t, remoteDir, "aaaaaaaaaaaa", "device-a")
+	runCheckpointRemoteGit(ctx, t, remoteDir, "checkout", defaultBranch)
+	return remoteDir
+}
+
+// gitRefsPrimaryLocalRepo builds a local repo configured with a github
+// checkpoint_remote and the git-refs primary backend, with the derived
+// checkpoint URL redirected at remoteDir so any fetch would succeed.
+func gitRefsPrimaryLocalRepo(ctx context.Context, t *testing.T, remoteDir string) string {
+	t.Helper()
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+	runCheckpointRemoteGit(ctx, t, localDir, "remote", "add", "origin", "git@github.com:org/main-repo.git")
+
+	entireDir := filepath.Join(localDir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(entireDir, "settings.json"),
+		[]byte(`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}, "checkpoints": {"primary": {"type": "git-refs"}}}`),
+		0o644,
+	))
+
+	// A hermetic redirect that WOULD serve the branch: a passing test therefore
+	// proves the fetch never ran, not that it ran and failed.
+	redirectGitURL(t, localDir, "git@github.com:org/checkpoints.git", "file://"+remoteDir)
+	return localDir
+}
+
+// TestEnsurePrimaryRef_SkipsCheckpointRemoteBootstrapUnderGitRefsPrimary pins that
+// `entire enable` does not eagerly clone the v1 metadata branch when the git-refs
+// backend is primary. That backend never writes v1, so there is no local orphan
+// that could diverge from the remote — the only thing the bootstrap exists to
+// prevent — while v1 carries the full legacy transcript history, making the fetch
+// arbitrarily expensive on a real checkpoint remote.
+//
+// Note this is an explicit enable flow (WithCheckpointRemoteBootstrap), unlike
+// TestEnsurePrimaryRef_SkipsCheckpointRemoteBootstrapOutsideEnableFlow: the
+// backend, not the calling context, is what suppresses the fetch here.
+func TestEnsurePrimaryRef_SkipsCheckpointRemoteBootstrapUnderGitRefsPrimary(t *testing.T) {
+	ctx := context.Background()
+
+	remoteDir := checkpointRemoteWithV1(ctx, t)
+	localDir := gitRefsPrimaryLocalRepo(ctx, t, remoteDir)
+
+	t.Chdir(localDir)
+	paths.ClearWorktreeRootCache()
+
+	repo, err := OpenRepository(ctx)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	require.NoError(t, EnsurePrimaryRef(WithCheckpointRemoteBootstrap(ctx), repo))
+
+	// A bootstrap fetch would have created the local v1 ref at the remote's tip.
+	// Under git-refs no v1 ref should exist at all: not fetched, and not seeded
+	// as an empty orphan either.
+	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound,
+		"EnsurePrimaryRef must not fetch or seed v1 under the git-refs primary backend")
+}
+
+// TestResolvePushSettings_SkipsMetadataFetchUnderGitRefsPrimary pins that the
+// pre-push path does not fetch the v1 metadata branch under the git-refs primary
+// backend. fetchMetadataBranchIfMissing is written as a one-time cost that stops
+// once the branch exists locally, but git-refs pushes per-checkpoint refs and
+// never creates v1 locally — so without this gate the "one-time" fetch would run
+// on every single `git push`.
+func TestResolvePushSettings_SkipsMetadataFetchUnderGitRefsPrimary(t *testing.T) {
+	ctx := context.Background()
+
+	remoteDir := checkpointRemoteWithV1(ctx, t)
+	localDir := gitRefsPrimaryLocalRepo(ctx, t, remoteDir)
+
+	t.Chdir(localDir)
+	paths.ClearWorktreeRootCache()
+
+	ps := resolvePushSettings(ctx, "origin")
+
+	// The checkpoint URL still resolves — only the eager fetch is suppressed.
+	assert.True(t, ps.hasCheckpointURL(), "checkpoint_remote should still resolve under git-refs")
+	assert.Equal(t, "git@github.com:org/checkpoints.git", ps.pushTarget())
+
+	repo, err := OpenRepository(ctx)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound,
+		"resolvePushSettings must not fetch v1 under the git-refs primary backend")
+}

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -1413,22 +1413,12 @@ func runCheckpointRemoteGit(ctx context.Context, t *testing.T, dir string, args 
 
 func checkpointRemoteCurrentBranch(ctx context.Context, t *testing.T, dir string) string {
 	t.Helper()
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
-	cmd.Dir = dir
-	cmd.Env = testutil.GitIsolatedEnv()
-	out, err := cmd.Output()
-	require.NoError(t, err)
-	return strings.TrimSpace(string(out))
+	return checkpointRemoteGitOutput(ctx, t, dir, "rev-parse", "--abbrev-ref", "HEAD")
 }
 
 func checkpointRemoteRevParse(ctx context.Context, t *testing.T, dir, rev string) string {
 	t.Helper()
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", rev)
-	cmd.Dir = dir
-	cmd.Env = testutil.GitIsolatedEnv()
-	out, err := cmd.Output()
-	require.NoError(t, err)
-	return strings.TrimSpace(string(out))
+	return checkpointRemoteGitOutput(ctx, t, dir, "rev-parse", rev)
 }
 
 func commitCheckpointRemoteMetadata(ctx context.Context, t *testing.T, dir, checkpointID, label string) {
@@ -1477,7 +1467,7 @@ func checkpointRemoteWithV1(ctx context.Context, t *testing.T) string {
 // gitRefsPrimaryLocalRepo builds a local repo configured with a github
 // checkpoint_remote and the git-refs primary backend, with the derived
 // checkpoint URL redirected at remoteDir so any fetch would succeed.
-func gitRefsPrimaryLocalRepo(ctx context.Context, t *testing.T, remoteDir string) string {
+func checkpointRemoteLocalRepo(ctx context.Context, t *testing.T, remoteDir, settingsJSON string) string {
 	t.Helper()
 	localDir := t.TempDir()
 	testutil.InitRepo(t, localDir)
@@ -1488,16 +1478,21 @@ func gitRefsPrimaryLocalRepo(ctx context.Context, t *testing.T, remoteDir string
 
 	entireDir := filepath.Join(localDir, ".entire")
 	require.NoError(t, os.MkdirAll(entireDir, 0o755))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(entireDir, "settings.json"),
-		[]byte(`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}, "checkpoints": {"primary": {"type": "git-refs"}}}`),
-		0o644,
-	))
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644))
 
-	// A hermetic redirect that WOULD serve the branch: a passing test therefore
-	// proves the fetch never ran, not that it ran and failed.
+	// A hermetic redirect that WOULD serve the branch: a test asserting the
+	// branch is absent therefore proves the fetch never ran, not that it ran
+	// and failed.
 	redirectGitURL(t, localDir, "git@github.com:org/checkpoints.git", "file://"+remoteDir)
 	return localDir
+}
+
+// gitRefsPrimaryLocalRepo is checkpointRemoteLocalRepo with the git-refs primary
+// selected in settings.
+func gitRefsPrimaryLocalRepo(ctx context.Context, t *testing.T, remoteDir string) string {
+	t.Helper()
+	return checkpointRemoteLocalRepo(ctx, t, remoteDir,
+		`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}, "checkpoints": {"primary": {"type": "git-refs"}}}`)
 }
 
 // TestEnsurePrimaryRef_SkipsCheckpointRemoteBootstrapUnderGitRefsPrimary pins that
@@ -1591,24 +1586,12 @@ func TestEnsurePrimaryRef_BootstrapFetchIsBlobFiltered(t *testing.T) {
 	runCheckpointRemoteGit(ctx, t, remoteDir, "config", "uploadpack.allowFilter", "true")
 
 	remoteTip := checkpointRemoteRevParse(ctx, t, remoteDir, paths.MetadataBranchName)
-	metadataBlob := checkpointRemoteGitOutput(ctx, t, remoteDir,
-		"rev-parse", "refs/heads/"+paths.MetadataBranchName+":aa/aaaaaaaaaa/"+paths.MetadataFileName)
+	metadataBlob := checkpointRemoteRevParse(ctx, t, remoteDir,
+		"refs/heads/"+paths.MetadataBranchName+":aa/aaaaaaaaaa/"+paths.MetadataFileName)
 
-	localDir := t.TempDir()
-	testutil.InitRepo(t, localDir)
-	testutil.WriteFile(t, localDir, "f.txt", "init")
-	testutil.GitAdd(t, localDir, "f.txt")
-	testutil.GitCommit(t, localDir, "init")
-	runCheckpointRemoteGit(ctx, t, localDir, "remote", "add", "origin", "git@github.com:org/main-repo.git")
-
-	entireDir := filepath.Join(localDir, ".entire")
-	require.NoError(t, os.MkdirAll(entireDir, 0o755))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(entireDir, "settings.json"),
-		[]byte(`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}, "filtered_fetches": true}}`),
-		0o644,
-	))
-	redirectGitURL(t, localDir, "git@github.com:org/checkpoints.git", "file://"+remoteDir)
+	// git-branch primary (no checkpoints block) so the bootstrap actually runs.
+	localDir := checkpointRemoteLocalRepo(ctx, t, remoteDir,
+		`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}, "filtered_fetches": true}}`)
 
 	t.Chdir(localDir)
 	paths.ClearWorktreeRootCache()

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -1631,3 +1631,32 @@ func TestEnsurePrimaryRef_BootstrapFetchIsBlobFiltered(t *testing.T) {
 	assert.Contains(t, missing, "?"+metadataBlob,
 		"bootstrap must fetch the commit graph blob-filtered, not the full transcript history")
 }
+
+// TestFetchBranchIfMissing_ReportsUnreachableRemote pins that a checkpoint remote
+// we could not talk to is reported to the caller rather than swallowed. It used
+// to return nil on every fetch failure, which made an unreachable, timing-out, or
+// auth-refusing remote indistinguishable from one that was never contacted — so
+// resolvePushSettings' warning could never fire and the failure left no trace.
+//
+// Contrast TestFetchBranchIfMissing_NoOpWhenBranchNotOnRemote: a reachable remote
+// that simply lacks the branch is still a quiet no-op.
+func TestFetchBranchIfMissing_ReportsUnreachableRemote(t *testing.T) {
+	ctx := context.Background()
+
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+
+	t.Chdir(localDir)
+
+	// A path that is not a git repository at all: git fails to connect rather
+	// than reporting the ref as absent.
+	err := fetchMetadataBranchIfMissing(ctx, filepath.Join(t.TempDir(), "nonexistent"))
+	require.Error(t, err, "an unreachable checkpoint remote must surface to the caller")
+
+	// The branch must still not exist locally — reporting the failure does not
+	// change the fail-soft outcome, only its visibility.
+	assert.False(t, testutil.BranchExists(t, localDir, paths.MetadataBranchName))
+}

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -1650,3 +1650,43 @@ func TestFetchBranchIfMissing_ReportsUnreachableRemote(t *testing.T) {
 	// change the fail-soft outcome, only its visibility.
 	assert.False(t, testutil.BranchExists(t, localDir, paths.MetadataBranchName))
 }
+
+// TestEnsurePrimaryRef_SkipsEmptyOrphanHealUnderGitRefsPrimary pins the third
+// checkpoint-remote fetch path against the same rule as the other two.
+//
+// healPrimaryFromCheckpointRemote runs whenever a local v1 ref already exists and
+// carries no data — the shape a repo enabled before the git-refs switch is left
+// in. It was the one fetch path not gated on the backend, so `entire enable` on
+// such a repo still pulled the whole transcript archive, on the raised foreground
+// budget, for a branch git-refs never writes.
+//
+// Reads are unaffected: a data-free branch is treated as a miss by the read path,
+// which recovers it on demand (checkpoint.TestGetSessionsBranchTree_RecoversFromDataFreeOrphan).
+func TestEnsurePrimaryRef_SkipsEmptyOrphanHealUnderGitRefsPrimary(t *testing.T) {
+	ctx := context.Background()
+
+	remoteDir := checkpointRemoteWithV1(ctx, t)
+	localDir := gitRefsPrimaryLocalRepo(ctx, t, remoteDir)
+
+	t.Chdir(localDir)
+	paths.ClearWorktreeRootCache()
+
+	// Stand up the data-free orphan the heal exists to replace.
+	workBranch := checkpointRemoteCurrentBranch(ctx, t, localDir)
+	runCheckpointRemoteGit(ctx, t, localDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, localDir, "rm", "-rf", ".")
+	runCheckpointRemoteGit(ctx, t, localDir, "commit", "--allow-empty", "-m", "init orphan")
+	orphanTip := checkpointRemoteRevParse(ctx, t, localDir, paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, localDir, "checkout", workBranch)
+
+	repo, err := OpenRepository(ctx)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	require.NoError(t, EnsurePrimaryRef(WithCheckpointRemoteBootstrap(ctx), repo))
+
+	// The redirect would have served the branch, so an unchanged tip proves the
+	// heal fetch was skipped rather than attempted and failed.
+	assert.Equal(t, orphanTip, checkpointRemoteRevParse(ctx, t, localDir, paths.MetadataBranchName),
+		"enable must not heal the v1 orphan from the checkpoint remote under git-refs primary")
+}

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -1562,3 +1562,72 @@ func TestResolvePushSettings_SkipsMetadataFetchUnderGitRefsPrimary(t *testing.T)
 	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound,
 		"resolvePushSettings must not fetch v1 under the git-refs primary backend")
 }
+
+// checkpointRemoteGitOutput runs a git command in dir and returns trimmed stdout.
+func checkpointRemoteGitOutput(ctx context.Context, t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	return strings.TrimSpace(string(out))
+}
+
+// TestEnsurePrimaryRef_BootstrapFetchIsBlobFiltered pins that the enable-time
+// bootstrap fetches the commit graph but not v1's blobs. The bootstrap only has
+// to land the ref so a later orphan cannot diverge from it; v1's blobs are the
+// full transcript archive, so fetching them makes `entire enable` on a fresh
+// clone pay for the entire checkpoint history before doing anything else.
+//
+// Uses the git-branch primary backend: under git-refs the bootstrap is skipped
+// outright (see TestEnsurePrimaryRef_SkipsCheckpointRemoteBootstrapUnderGitRefsPrimary).
+func TestEnsurePrimaryRef_BootstrapFetchIsBlobFiltered(t *testing.T) {
+	ctx := context.Background()
+
+	remoteDir := checkpointRemoteWithV1(ctx, t)
+	// --filter is only honored over the smart protocol with allowFilter set
+	// server-side; the redirect below already makes this a file:// URL.
+	runCheckpointRemoteGit(ctx, t, remoteDir, "config", "uploadpack.allowFilter", "true")
+
+	remoteTip := checkpointRemoteRevParse(ctx, t, remoteDir, paths.MetadataBranchName)
+	metadataBlob := checkpointRemoteGitOutput(ctx, t, remoteDir,
+		"rev-parse", "refs/heads/"+paths.MetadataBranchName+":aa/aaaaaaaaaa/"+paths.MetadataFileName)
+
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+	runCheckpointRemoteGit(ctx, t, localDir, "remote", "add", "origin", "git@github.com:org/main-repo.git")
+
+	entireDir := filepath.Join(localDir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(entireDir, "settings.json"),
+		[]byte(`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}, "filtered_fetches": true}}`),
+		0o644,
+	))
+	redirectGitURL(t, localDir, "git@github.com:org/checkpoints.git", "file://"+remoteDir)
+
+	t.Chdir(localDir)
+	paths.ClearWorktreeRootCache()
+
+	repo, err := OpenRepository(ctx)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	require.NoError(t, EnsurePrimaryRef(WithCheckpointRemoteBootstrap(ctx), repo))
+
+	// The bootstrap still did its job: the local ref tracks the remote tip, so
+	// no divergent orphan can be created on top of it.
+	assert.Equal(t, remoteTip, checkpointRemoteRevParse(ctx, t, localDir, paths.MetadataBranchName),
+		"bootstrap must still land the local ref at the checkpoint remote's tip")
+
+	// ...but the transcript blobs were not downloaded. rev-list --missing=print
+	// reports them without triggering the lazy fetch that `git cat-file` would.
+	missing := checkpointRemoteGitOutput(ctx, t, localDir,
+		"rev-list", "--objects", "--missing=print", "refs/heads/"+paths.MetadataBranchName)
+	assert.Contains(t, missing, "?"+metadataBlob,
+		"bootstrap must fetch the commit graph blob-filtered, not the full transcript history")
+}

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -1569,15 +1569,21 @@ func checkpointRemoteGitOutput(ctx context.Context, t *testing.T, dir string, ar
 	return strings.TrimSpace(string(out))
 }
 
-// TestEnsurePrimaryRef_BootstrapFetchIsBlobFiltered pins that the enable-time
-// bootstrap fetches the commit graph but not v1's blobs. The bootstrap only has
-// to land the ref so a later orphan cannot diverge from it; v1's blobs are the
-// full transcript archive, so fetching them makes `entire enable` on a fresh
-// clone pay for the entire checkpoint history before doing anything else.
+// TestEnsurePrimaryRef_BootstrapLandsReadableBranch pins that after the
+// enable-time bootstrap, the branch it landed is actually readable — not just
+// present as a ref.
 //
-// Uses the git-branch primary backend: under git-refs the bootstrap is skipped
-// outright (see TestEnsurePrimaryRef_SkipsCheckpointRemoteBootstrapUnderGitRefsPrimary).
-func TestEnsurePrimaryRef_BootstrapFetchIsBlobFiltered(t *testing.T) {
+// A blob-filtered bootstrap looks safe (the bootstrap itself only needs the ref
+// to stop a later orphan diverging) and is not. The bootstrap is only ever
+// reached under the git-branch primary, where the branch it lands IS the repo's
+// checkpoint store: GitStore.List reads each checkpoint's metadata.json through
+// a plain tree with no blob fetcher, and the read path's recovery tier is keyed
+// on the ref being missing — so once the filtered fetch lands the ref, nothing
+// ever backfills the blobs and `checkpoint list` shows bare IDs forever.
+//
+// Asserting on the blob rather than on fetch flags is deliberate: it pins the
+// property that matters (the store is readable) rather than the mechanism.
+func TestEnsurePrimaryRef_BootstrapLandsReadableBranch(t *testing.T) {
 	ctx := context.Background()
 
 	remoteDir := checkpointRemoteWithV1(ctx, t)
@@ -1607,12 +1613,13 @@ func TestEnsurePrimaryRef_BootstrapFetchIsBlobFiltered(t *testing.T) {
 	assert.Equal(t, remoteTip, checkpointRemoteRevParse(ctx, t, localDir, paths.MetadataBranchName),
 		"bootstrap must still land the local ref at the checkpoint remote's tip")
 
-	// ...but the transcript blobs were not downloaded. rev-list --missing=print
-	// reports them without triggering the lazy fetch that `git cat-file` would.
+	// ...and the checkpoint's metadata blob came with it. rev-list --missing=print
+	// reports absent objects with a "?" prefix without triggering the lazy fetch
+	// that `git cat-file` would, so this distinguishes "present" from "promised".
 	missing := checkpointRemoteGitOutput(ctx, t, localDir,
 		"rev-list", "--objects", "--missing=print", "refs/heads/"+paths.MetadataBranchName)
-	assert.Contains(t, missing, "?"+metadataBlob,
-		"bootstrap must fetch the commit graph blob-filtered, not the full transcript history")
+	assert.NotContains(t, missing, "?"+metadataBlob,
+		"bootstrap must land a readable branch: without metadata.json, checkpoint list shows a bare ID with no prompt, date, or counts")
 }
 
 // TestFetchBranchIfMissing_ReportsUnreachableRemote pins that a checkpoint remote

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -720,13 +720,15 @@ func bootstrapPrimaryFromCheckpointRemote(ctx context.Context, repo *git.Reposit
 
 	branchName := primary.Short()
 	tmpRefName := plumbing.ReferenceName(FetchTmpRefPrefix + branchName)
-	// Blob-filtered: this bootstrap only has to land the ref at the remote's tip
-	// so a later orphan cannot diverge from it. Nothing here reads blob content
-	// (SafelyAdvanceLocalRef takes the ref-not-found path and just sets the
-	// hash), while v1's blobs are the entire transcript archive — fetching them
-	// would make `entire enable` on a fresh clone pay for the full history up
-	// front. Reads pull the blobs they need on demand via BlobFetcher.
-	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", false, checkpointRemoteForegroundFetchTimeout); err != nil {
+	// Unfiltered. The bootstrap itself only needs the ref, but it is only ever
+	// reached under the git-branch primary (git-refs returns above), and there
+	// the branch it lands IS the repo's checkpoint store — refs.Read and
+	// refs.Primary are the same v1 branch. GitStore.List reads each checkpoint's
+	// metadata.json through a plain tree with no blob fetcher, and once this ref
+	// resolves the recovery tier never fires again, so a blob-filtered bootstrap
+	// would leave `checkpoint list` permanently showing bare IDs with no prompt,
+	// date, or counts.
+	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", true, checkpointRemoteForegroundFetchTimeout); err != nil {
 		// Warn, not Debug: `entire enable` is an explicit user action, and this
 		// failure means existing checkpoints stay unreachable until a read
 		// re-fetches them. At Debug the command looked like it had simply
@@ -818,10 +820,10 @@ func healEmptyOrphanFromCheckpointRemote(ctx context.Context, repo *git.Reposito
 	tmpRefName := plumbing.ReferenceName(FetchTmpRefPrefix + primary.Short())
 	defer func() { _ = repo.Storer.RemoveReference(tmpRefName) }() //nolint:errcheck // cleanup is best-effort
 
-	// Blob-filtered, for the same reason as the bootstrap fetch above: this heal
-	// replaces a data-free orphan with the real branch tip, and the only content
-	// it inspects is metadataBranchHasData's walk of the root tree's entry names.
-	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", false, checkpointRemoteForegroundFetchTimeout); err != nil {
+	// Unfiltered, for the same reason as the bootstrap fetch above: this heal
+	// replaces a data-free orphan with the real branch, which readers then treat
+	// as the checkpoint store.
+	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", true, checkpointRemoteForegroundFetchTimeout); err != nil {
 		// Warn for the same reason as the bootstrap fetch: this only runs from an
 		// explicit setup flow, and failing leaves the repo on a data-free orphan.
 		logging.Warn(ctx, "checkpoint-remote: empty-orphan heal fetch failed; keeping local orphan",

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -788,6 +788,19 @@ func healPrimaryFromCheckpointRemote(ctx context.Context, repo *git.Repository, 
 		logging.Debug(ctx, "checkpoint-remote: skipping empty-orphan heal outside explicit enable flow")
 		return false, nil
 	}
+	if primaryIsGitRefs(ctx) {
+		// Same reasoning as the bootstrap: under git-refs nothing writes v1, so a
+		// data-free orphan cannot diverge from the remote and there is nothing to
+		// protect at enable time. Healing it here would make `entire enable` pull
+		// the whole transcript archive — the exact cost this backend's gating
+		// exists to avoid — for a branch only legacy reads consult.
+		//
+		// The orphan does hide those legacy reads (it makes the ref resolve), so
+		// the read path treats a data-free branch as a miss and recovers it on
+		// demand; see checkpoint.getSessionsBranchTree.
+		logging.Debug(ctx, "checkpoint-remote: skipping empty-orphan heal under git-refs primary")
+		return false, nil
+	}
 	return healEmptyOrphanFromCheckpointRemote(ctx, repo, primary)
 }
 

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -725,11 +725,17 @@ func bootstrapPrimaryFromCheckpointRemote(ctx context.Context, repo *git.Reposit
 	// hash), while v1's blobs are the entire transcript archive — fetching them
 	// would make `entire enable` on a fresh clone pay for the full history up
 	// front. Reads pull the blobs they need on demand via BlobFetcher.
-	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", false); err != nil {
-		logging.Debug(ctx, "checkpoint-remote: enable bootstrap fetch failed; creating empty orphan",
+	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", false, checkpointRemoteForegroundFetchTimeout); err != nil {
+		// Warn, not Debug: `entire enable` is an explicit user action, and this
+		// failure means existing checkpoints stay unreachable until a read
+		// re-fetches them. At Debug the command looked like it had simply
+		// paused, then succeeded.
+		logging.Warn(ctx, "checkpoint-remote: enable bootstrap fetch failed; creating empty orphan",
 			slog.String("url", remote.RedactURL(url)),
 			slog.String("error", err.Error()),
 		)
+		fmt.Fprintf(os.Stderr, "  ! Could not fetch existing checkpoints from %s\n", remote.RedactURL(url))
+		fmt.Fprintln(os.Stderr, "    Continuing — they will be fetched on demand when a command needs them.")
 		return false
 	}
 	defer func() { _ = repo.Storer.RemoveReference(tmpRefName) }() //nolint:errcheck // cleanup is best-effort
@@ -814,8 +820,10 @@ func healEmptyOrphanFromCheckpointRemote(ctx context.Context, repo *git.Reposito
 	// Blob-filtered, for the same reason as the bootstrap fetch above: this heal
 	// replaces a data-free orphan with the real branch tip, and the only content
 	// it inspects is metadataBranchHasData's walk of the root tree's entry names.
-	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", false); err != nil {
-		logging.Debug(ctx, "checkpoint-remote: empty-orphan heal fetch failed; keeping local orphan",
+	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", false, checkpointRemoteForegroundFetchTimeout); err != nil {
+		// Warn for the same reason as the bootstrap fetch: this only runs from an
+		// explicit setup flow, and failing leaves the repo on a data-free orphan.
+		logging.Warn(ctx, "checkpoint-remote: empty-orphan heal fetch failed; keeping local orphan",
 			slog.String("url", remote.RedactURL(url)),
 			slog.String("error", err.Error()),
 		)

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -681,6 +681,23 @@ func bootstrapPrimaryFromCheckpointRemote(ctx context.Context, repo *git.Reposit
 		return false
 	}
 
+	if primaryIsGitRefs(ctx) {
+		// The whole point of this bootstrap is to stop a fresh local orphan from
+		// diverging from the real v1 branch. Under the git-refs primary backend
+		// no orphan is ever created (see skipEmptyOrphan in EnsurePrimaryRef) and
+		// nothing is ever written to v1, so there is no divergence to prevent and
+		// the fetch buys nothing at enable time.
+		//
+		// It is not free, either: v1 holds the full legacy transcript history, so
+		// this would make every `entire enable` on a fresh clone download the
+		// entire checkpoint archive before doing anything else. Legacy hex-ID
+		// checkpoints stay readable — the read paths fetch v1 from the checkpoint
+		// remote when a read actually needs it, and fetch individual blobs by
+		// hash rather than the whole branch.
+		logging.Debug(ctx, "checkpoint-remote: skipping bootstrap fetch under git-refs primary")
+		return false
+	}
+
 	worktreeRoot, err := getRepoPath(repo)
 	if err != nil {
 		logging.Debug(ctx, "checkpoint-remote: cannot resolve worktree root for enable bootstrap",

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -493,10 +493,12 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 	// branch. Seeding an empty orphan v1 here would leave a vestigial,
 	// never-written branch — the surprise a user hit when `entire enable`
 	// selected git-refs yet still created entire/checkpoints/v1. We still adopt
-	// real v1 data that already exists on origin or a checkpoint_remote below
-	// (so legacy checkpoints stay readable); we only suppress the empty-orphan
-	// fallback. Resolution is fail-soft: an unreadable config keeps the legacy
-	// git-branch seeding behavior.
+	// real v1 data that already exists on origin below; we suppress the
+	// empty-orphan fallback and, since there is no orphan that could diverge,
+	// the checkpoint-remote bootstrap fetch too. Legacy checkpoints stay
+	// readable either way — the read path recovers the branch on demand (see
+	// checkpoint.MetadataBranchFetchFunc). Resolution is fail-soft: an
+	// unreadable config keeps the legacy git-branch seeding behavior.
 	skipEmptyOrphan := primaryIsGitRefs(ctx)
 
 	localRef, localErr := repo.Reference(refs.Primary, true)
@@ -530,7 +532,7 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 		// Local ref missing — fetch the real branch before creating a fresh
 		// orphan: an orphan would diverge from it, hide existing checkpoints, and
 		// be rejected non-fast-forward on later syncs.
-		if bootstrapPrimaryFromCheckpointRemote(ctx, repo, refs.Primary) {
+		if bootstrapPrimaryFromCheckpointRemote(ctx, repo, refs.Primary, skipEmptyOrphan) {
 			fmt.Fprintf(os.Stderr, "✓ Created local ref '%s' from checkpoint remote\n", primaryName)
 			return nil
 		}
@@ -671,7 +673,7 @@ func createOrphanMetadataRef(ctx context.Context, repo *git.Repository, refs che
 // points at the remote branch. Every failure is non-fatal and returns false so
 // the caller creates the empty orphan: `entire enable` must never break on a
 // missing checkpoint remote, an unresolvable URL, or a network/auth error.
-func bootstrapPrimaryFromCheckpointRemote(ctx context.Context, repo *git.Repository, primary plumbing.ReferenceName) bool {
+func bootstrapPrimaryFromCheckpointRemote(ctx context.Context, repo *git.Repository, primary plumbing.ReferenceName, primaryIsRefs bool) bool {
 	if !checkpointRemoteBootstrapAllowed(ctx) {
 		// Not an explicit setup flow (e.g. the per-turn hook hot path via
 		// EnsureSetup). Never fetch here: hook execution has a hard timeout,
@@ -681,19 +683,18 @@ func bootstrapPrimaryFromCheckpointRemote(ctx context.Context, repo *git.Reposit
 		return false
 	}
 
-	if primaryIsGitRefs(ctx) {
+	if primaryIsRefs {
 		// The whole point of this bootstrap is to stop a fresh local orphan from
 		// diverging from the real v1 branch. Under the git-refs primary backend
-		// no orphan is ever created (see skipEmptyOrphan in EnsurePrimaryRef) and
-		// nothing is ever written to v1, so there is no divergence to prevent and
-		// the fetch buys nothing at enable time.
+		// no orphan is ever created and nothing is ever written to v1, so there
+		// is no divergence to prevent and the fetch buys nothing at enable time.
 		//
 		// It is not free, either: v1 holds the full legacy transcript history, so
 		// this would make every `entire enable` on a fresh clone download the
 		// entire checkpoint archive before doing anything else. Legacy hex-ID
-		// checkpoints stay readable — the read paths fetch v1 from the checkpoint
-		// remote when a read actually needs it, and fetch individual blobs by
-		// hash rather than the whole branch.
+		// checkpoints stay readable — the read path recovers the branch on demand
+		// (checkpoint.MetadataBranchFetchFunc), fetching individual blobs by hash
+		// rather than the whole archive.
 		logging.Debug(ctx, "checkpoint-remote: skipping bootstrap fetch under git-refs primary")
 		return false
 	}

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -719,7 +719,13 @@ func bootstrapPrimaryFromCheckpointRemote(ctx context.Context, repo *git.Reposit
 
 	branchName := primary.Short()
 	tmpRefName := plumbing.ReferenceName(FetchTmpRefPrefix + branchName)
-	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", true); err != nil {
+	// Blob-filtered: this bootstrap only has to land the ref at the remote's tip
+	// so a later orphan cannot diverge from it. Nothing here reads blob content
+	// (SafelyAdvanceLocalRef takes the ref-not-found path and just sets the
+	// hash), while v1's blobs are the entire transcript archive — fetching them
+	// would make `entire enable` on a fresh clone pay for the full history up
+	// front. Reads pull the blobs they need on demand via BlobFetcher.
+	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", false); err != nil {
 		logging.Debug(ctx, "checkpoint-remote: enable bootstrap fetch failed; creating empty orphan",
 			slog.String("url", remote.RedactURL(url)),
 			slog.String("error", err.Error()),
@@ -805,7 +811,10 @@ func healEmptyOrphanFromCheckpointRemote(ctx context.Context, repo *git.Reposito
 	tmpRefName := plumbing.ReferenceName(FetchTmpRefPrefix + primary.Short())
 	defer func() { _ = repo.Storer.RemoveReference(tmpRefName) }() //nolint:errcheck // cleanup is best-effort
 
-	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", true); err != nil {
+	// Blob-filtered, for the same reason as the bootstrap fetch above: this heal
+	// replaces a data-free orphan with the real branch tip, and the only content
+	// it inspects is metadataBranchHasData's walk of the root tree's entry names.
+	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, url, primary.String(), tmpRefName.String(), "metadata branch", false); err != nil {
 		logging.Debug(ctx, "checkpoint-remote: empty-orphan heal fetch failed; keeping local orphan",
 			slog.String("url", remote.RedactURL(url)),
 			slog.String("error", err.Error()),

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -388,7 +388,7 @@ func resolveRemoteV1Tip(ctx context.Context, repo *git.Repository, target string
 	if wt, wtErr := repo.Worktree(); wtErr == nil {
 		worktreeRoot = wt.Filesystem().Root()
 	}
-	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, target, srcRef, opfRewriteFetchTmpRef, "v1 for OPF rewrite", true); err != nil {
+	if err := fetchURLIntoTmpRef(ctx, worktreeRoot, target, srcRef, opfRewriteFetchTmpRef, "v1 for OPF rewrite", true, checkpointRemoteFetchTimeout); err != nil {
 		if !remote.IsURL(target) {
 			logging.Warn(ctx, "OPF rewrite: failed to fetch remote v1; using local remote-tracking ref",
 				slog.String("remote", target),

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -91,7 +91,7 @@ func (s *ManualCommitStrategy) prePush(ctx context.Context, remote string, prote
 	// branch — the empty-remote guard below is unnecessary for this backend.
 	// (A configured git-branch mirror's v1 ref is not pushed here yet — mirror
 	// push for downgrade safety is a later step.)
-	if cpCfg, _ := settings.LoadCheckpointsConfig(ctx); checkpoint.PrimaryIsRefs(cpCfg) { //nolint:errcheck // fail-soft: a bad checkpoints block already surfaces via Open; default to no refs push
+	if ps.primaryIsRefs {
 		return s.prePushCheckpointRefs(ctx, ps)
 	}
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1047
<!-- entire-trail-link-end -->

## Problem

A fresh clone of this repo stalls on `entire enable` — and on every `git push` — while it silently downloads the entire checkpoint archive and gives up.

Reproduced on an identical repo, same command:

| | `entire enable` |
| --- | --- |
| before | **31.0s**, then **30.2s** again on the second run |
| after | **0.9s** |

Both pre-fix runs print the same cheerful `Ready.` with no indication that anything was attempted, let alone killed.

The repo's committed `.entire/settings.json` pairs `checkpoints.primary = git-refs` with `checkpoint_remote = entireio/cli-checkpoints`. On a fresh clone the local `entire/checkpoints/v1` ref is missing, so `EnsurePrimaryRef` runs the enable bootstrap, which fetches that branch **unfiltered** under a 30s deadline. Measured against the real remote:

```
Receiving objects: 100% (104083/104083), 1.53 GiB | 19.15 MiB/s, done.
```

~82s of transfer on a fast link, so the deadline can never be met. Four separate defects compound:

1. **It never converges.** Because the git-refs path deliberately creates no orphan when the fetch fails (`skipEmptyOrphan`), the next `entire enable` finds byte-identical state and starts over. Unbounded retry, 30s each time.
2. **`git push` pays the same tax.** `resolvePushSettings` calls `fetchMetadataBranchIfMissing` unconditionally, as the first thing `prePush` does. Its comment claims the cost is one-time, amortised by the branch existing locally afterwards — but git-refs pushes per-checkpoint refs and never creates v1 locally, so the branch stays missing forever and the "one-time" fetch recurs on every push. It sits outside the 2-minute `checkpointPushBudget`.
3. **The failure is invisible.** The bootstrap logged at Debug, and `fetchMetadataBranchIfMissing` returned `nil` on every error — making `resolvePushSettings`' warning unreachable code.
4. **The timeout was backwards.** Origin-side metadata fetches already had two minutes; the checkpoint remote — which by definition holds strictly more checkpoint history than origin — was held to the push hot path's 30 seconds.

## Fix

**Don't eagerly fetch v1 under the git-refs backend** (`ae4db84`). Both call sites fetch for reasons that do not apply to that backend: the bootstrap exists to stop a freshly seeded orphan from diverging (git-refs seeds no orphan, and never writes v1), and the pre-push fetch's amortisation assumption is false there. Gated both on the backend rather than removing them — dropping the bootstrap outright would regress #1374 for git-branch repos, where a fresh clone would seed an orphan that diverges from the remote and gets rejected non-fast-forward.

**Fetch the bootstrap blob-filtered** (`9291c58`). For git-branch repos, where the bootstrap *is* load-bearing, it still only needs the ref: `SafelyAdvanceLocalRef` takes the ref-not-found path, and the heal only reads root-tree entry names. Dropped `NoFilter` so both honor `filtered_fetches` instead of pulling the transcript archive. This respects the setting rather than forcing it, so a repo that opted out of partial clones doesn't silently get a promisor remote.

**Split the fetch budget and report failures** (`d46dfcc`). Hot path keeps 30s; user-initiated commands get the same two minutes origin already had. Debug → Warn on both enable-side fetches, a stderr line on enable saying checkpoints will be fetched on demand, and `fetchMetadataBranchIfMissing` now returns its error. Absence stays quiet: a reachable remote that simply lacks the branch is the normal state of a new checkpoint repo, so it is established by an ls-remote probe (positive evidence, as in `FetchCheckpointRef`) rather than by treating every fetch error as absence.

**Recover v1 from the checkpoint remote on read** (`06cf994`). The branch is *not* vestigial under git-refs — it holds **5,390** legacy hex-ID checkpoints against **721** refs-native ones, and reads route to it by ID format — so "don't fetch it at enable" is only correct because reads can recover it. They previously could not: `GitStore.getSessionsBranchTree` resolved from the local ref, then origin's remote-tracking ref, then gave up, and a `checkpoint_remote` setup has neither. New `MetadataBranchFetchFunc` seam, the git-branch counterpart to the git-refs store's `RefFetchFunc` — where that resolves one missing per-checkpoint ref, this resolves the single branch the whole record lives on. Injected from the CLI layer like the other fetchers, so the checkpoint package still resolves no remotes itself.

The tier is recovery, not refresh: it fires only when the branch resolves neither locally nor from origin, so normal reads stay local and hook paths — which wire no fetcher at all — stay network-free. A failed fetch leaves the original not-found error intact, preserving `List`'s offline-reads-as-empty behavior. Wired into explain's read paths only; `resume` already self-heals through its own fetch ladder, and the remaining callers are hooks and background paths where a network call on read would be wrong.

## Verification

`mise run check` green — unit, 473 integration tests, and both E2E canary suites.

**Every new unit test was verified to fail against the unfixed source first**, not just to pass after.

`TestEnable_GitRefsPrimaryDoesNotPullCheckpointBranch` (`55b00ce`) is the end-to-end acceptance test: a producer repo condenses a checkpoint onto v1 and pushes it to a bare that then plays a consumer's `checkpoint_remote`; the consumer is fresh-clone-shaped with git-refs primary. It asserts `enable` leaves no local or remote-tracking v1 ref, that the settings driving that survived `enable` (otherwise the assertion could pass because the repo silently fell back to git-branch), that `explain` on a branch-only checkpoint surfaces its prompt, and that the branch is present locally *only afterwards* — proving the read did the recovery. Confirmed to fail in both directions: disabling the enable-side gate fails the first half, removing explain's `MetadataBranchFetcher` fails the second.

Writing that test corrected an assumption. `matchCheckpointPrefixWithRemoteFallback` takes a refs-specific branch under a git-refs primary whose comment asserted "under a refs primary there is no v1 metadata branch to fetch either". Recovery does work, but earlier than expected — `matchCheckpointPrefix` reads `lookup.committed`, which `store.List` populates, and the kind-routing `List` consults the branch store, so it fires at any prefix length before that fallback is reached. `6dc4ab5` corrects the now-inaccurate comment.

## Notes for review

- Two fixture traps worth knowing about, both of which cost a debugging round-trip. `checkpoint_remote` must be a real `provider`/`repo` pair — `settings.GetCheckpointRemote` rejects anything else and returns `nil`, indistinguishable from "not configured". (Consequence: the existing `writeMinimalEntireSettings` helper's `{"provider":"url","url":...}` checkpoint_remote is inert, and its test passes for unrelated reasons.) And `origin` must be a `file://` URL, not a bare path, because `remote.FetchURL` parses origin to derive the checkpoint URL and falls back to origin itself on a path with no protocol.
- A git-branch repo that has *not* opted into `filtered_fetches`, with a large checkpoint remote, still pays a slow bootstrap — now with a workable budget and a visible failure instead of a silent 30s stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6dc4ab53b3a6cea92fbf1e711638df337acdb699. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->