### PR TITLE
fix(trail): send the pre-image anchor with --patch suggested changes

### DIFF
--- a/cmd/entire/cli/api/trail_review_types.go
+++ b/cmd/entire/cli/api/trail_review_types.go
@@ -166,6 +166,18 @@ type TrailReviewLocationCreateRequest struct {
 }
 
 // TrailReviewSuggestedChangeCreateRequest attaches a suggested fix to a new finding.
+//
+// Every change_type other than manual_instruction requires the full expected_*
+// anchor — the API rejects a patch that arrives without it. The anchor describes
+// the pre-image the patch was written against, so a later apply can tell whether
+// the file has moved on:
+//
+//   - ExpectedFileHash is the git blob OID of the whole file as it stood in the
+//     author's worktree, i.e. what `git hash-object <file>` prints in that repo.
+//     The server stores it opaquely, so this is the CLI's convention; keep
+//     producers in agreement before relying on it for staleness checks.
+//   - ExpectedLines is the byte-exact content of ExpectedStartLine..ExpectedEndLine
+//     with line endings intact — not CRLF-normalized display text.
 type TrailReviewSuggestedChangeCreateRequest struct {
 	ChangeType        string  `json:"change_type"`
 	Patch             *string `json:"patch,omitempty"`

--- a/cmd/entire/cli/trail_review_cmd.go
+++ b/cmd/entire/cli/trail_review_cmd.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -1274,21 +1273,19 @@ func combinedSafeUnifiedDiffPatch(comment api.TrailReviewComment, w io.Writer) (
 	return combined.String(), supported, nil
 }
 
+// validateUnifiedDiffPatchPaths checks every path a patch's headers name. It
+// walks headers only: diff content is not a path, and a deleted line such as
+// "-- ../legacy" serializes as "--- ../legacy", which read as a header would
+// reject a perfectly safe patch.
 func validateUnifiedDiffPatchPaths(patchText string) error {
-	scanner := bufio.NewScanner(strings.NewReader(patchText))
-	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
-	for scanner.Scan() {
-		line := scanner.Text()
+	return forEachPatchHeaderLine(patchText, func(line string) error {
 		for _, p := range patchHeaderPaths(line) {
 			if err := validatePatchPath(p); err != nil {
 				return err
 			}
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("scan patch: %w", err)
-	}
-	return nil
+		return nil
+	})
 }
 
 func patchHeaderPaths(line string) []string {
@@ -1335,7 +1332,7 @@ func cleanPatchPath(raw string) string {
 
 func validatePatchPath(raw string) error {
 	p := strings.TrimSpace(raw)
-	if p == "" || p == "/dev/null" {
+	if p == "" || p == patchDevNull {
 		return nil
 	}
 	p = cleanPatchPath(p)

--- a/cmd/entire/cli/trail_review_cmd.go
+++ b/cmd/entire/cli/trail_review_cmd.go
@@ -176,12 +176,12 @@ func newTrailFindingAddCmd(targetOpts *trailReviewTargetOptions) *cobra.Command 
 	cmd.Flags().StringVarP(&opts.Body, "body", "m", "", "Finding body")
 	cmd.Flags().StringVar(&opts.Severity, "severity", "", "Finding severity: high,medium,low")
 	cmd.Flags().Float64Var(&opts.Confidence, "confidence", -1, "Finding confidence from 0.0 to 1.0")
-	cmd.Flags().StringVar(&opts.FilePath, "file", "", "File path for the finding location")
+	cmd.Flags().StringVar(&opts.FilePath, "file", "", "File path for the finding location; defaults to the file a --patch modifies")
 	cmd.Flags().IntVar(&opts.Line, "line", 0, "Line number for the finding location")
 	cmd.Flags().IntVar(&opts.StartLine, "start-line", 0, "Start line for the finding location")
 	cmd.Flags().IntVar(&opts.EndLine, "end-line", 0, "End line for the finding location")
 	cmd.Flags().StringVar(&opts.ClientID, "client-id", "", "Client-provided idempotency key for this finding")
-	cmd.Flags().StringVar(&opts.Patch, "patch", "", "Unified-diff suggested change to attach")
+	cmd.Flags().StringVar(&opts.Patch, "patch", "", "Unified-diff suggested change to attach; must modify a single existing file in this worktree")
 	cmd.Flags().StringVar(&opts.PatchFile, "patch-file", "", "Read unified-diff suggested change from file; use '-' for stdin")
 	cmd.Flags().StringVar(&opts.Instruction, "instruction", "", "Manual suggested-change instruction to attach")
 	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output as JSON")
@@ -348,7 +348,14 @@ func runTrailReviewCommentAdd(cmd *cobra.Command, selector string, opts trailRev
 	if err != nil {
 		return err
 	}
-	input, err := buildTrailReviewCommentInput(opts)
+	// An --instruction-only finding needs no anchor; a patch always does.
+	var anchor *trailReviewPatchAnchor
+	if patch := strings.TrimSpace(opts.Patch); patch != "" {
+		if anchor, err = resolveTrailReviewPatchAnchor(cmd.Context(), patch); err != nil {
+			return err
+		}
+	}
+	input, err := buildTrailReviewCommentInput(opts, anchor)
 	if err != nil {
 		return err
 	}
@@ -735,7 +742,7 @@ func trailReviewCommentPatchHasFields(req api.TrailReviewCommentPatchRequest) bo
 	return req.Body != nil || req.Severity != nil || req.Confidence != nil || req.Status != "" || req.StatusReason != nil
 }
 
-func buildTrailReviewCommentInput(opts trailReviewCommentAddOptions) (api.TrailReviewCommentInput, error) {
+func buildTrailReviewCommentInput(opts trailReviewCommentAddOptions, anchor *trailReviewPatchAnchor) (api.TrailReviewCommentInput, error) {
 	body := strings.TrimSpace(opts.Body)
 	if body == "" {
 		return api.TrailReviewCommentInput{}, errors.New("finding body is required (pass --body)")
@@ -752,7 +759,7 @@ func buildTrailReviewCommentInput(opts trailReviewCommentAddOptions) (api.TrailR
 	if err != nil {
 		return api.TrailReviewCommentInput{}, err
 	}
-	loc, err := buildTrailReviewCommentLocation(opts)
+	loc, err := buildTrailReviewCommentLocation(opts, anchor)
 	if err != nil {
 		return api.TrailReviewCommentInput{}, err
 	}
@@ -773,10 +780,20 @@ func buildTrailReviewCommentInput(opts trailReviewCommentAddOptions) (api.TrailR
 		input.Confidence = &confidence
 	}
 	if patch := strings.TrimSpace(opts.Patch); patch != "" {
+		// The API rejects a unified_diff that carries no pre-image anchor, so a
+		// patch without one must not reach the wire.
+		if anchor == nil {
+			return api.TrailReviewCommentInput{}, errors.New("suggested-change patch has no resolved file anchor")
+		}
 		input.SuggestedChange = &api.TrailReviewSuggestedChangeCreateRequest{
-			ChangeType:  "unified_diff",
-			Patch:       stringPtr(patch),
-			Instruction: optionalStringPtr(strings.TrimSpace(opts.Instruction)),
+			ChangeType:        "unified_diff",
+			Patch:             stringPtr(patch),
+			Instruction:       optionalStringPtr(strings.TrimSpace(opts.Instruction)),
+			ExpectedFilePath:  stringPtr(anchor.FilePath),
+			ExpectedFileHash:  stringPtr(anchor.FileHash),
+			ExpectedStartLine: &anchor.StartLine,
+			ExpectedEndLine:   &anchor.EndLine,
+			ExpectedLines:     stringPtr(anchor.Lines),
 		}
 	} else if instruction := strings.TrimSpace(opts.Instruction); instruction != "" {
 		input.SuggestedChange = &api.TrailReviewSuggestedChangeCreateRequest{
@@ -803,7 +820,11 @@ func buildTrailReviewCommentConfidence(confidence float64) (float64, bool, error
 	return confidence, true, nil
 }
 
-func buildTrailReviewCommentLocation(opts trailReviewCommentAddOptions) (api.TrailReviewLocationCreateRequest, error) {
+// buildTrailReviewCommentLocation resolves where the finding sits. A patch
+// already names the file it rewrites and the lines it expects, so when the
+// caller gave no --file the anchor supplies both rather than the finding landing
+// on the trail as a whole; explicit flags always win over it.
+func buildTrailReviewCommentLocation(opts trailReviewCommentAddOptions, anchor *trailReviewPatchAnchor) (api.TrailReviewLocationCreateRequest, error) {
 	filePath := strings.TrimSpace(opts.FilePath)
 	line := opts.Line
 	if line < 0 || opts.StartLine < 0 || opts.EndLine < 0 {
@@ -827,7 +848,18 @@ func buildTrailReviewCommentLocation(opts trailReviewCommentAddOptions) (api.Tra
 
 	loc := api.TrailReviewLocationCreateRequest{Granularity: reviewTrailGranularityWholeChange}
 	if filePath == "" {
+		if anchor != nil {
+			return trailReviewLocationFromAnchor(anchor), nil
+		}
 		return loc, nil
+	}
+	// The API pins a suggested change to one file, so a --file naming a
+	// different one than the patch rewrites has no sensible reading: the finding
+	// would point at one place and its fix at another.
+	if anchor != nil && normalizeFindingPath(filePath) != normalizeFindingPath(anchor.FilePath) {
+		return api.TrailReviewLocationCreateRequest{}, fmt.Errorf(
+			"--file names %s but the patch modifies %s; a suggested change must target the file the finding is on",
+			filePath, anchor.FilePath)
 	}
 	loc.Granularity = reviewTrailGranularityFile
 	loc.FilePath = stringPtr(filePath)
@@ -842,6 +874,33 @@ func buildTrailReviewCommentLocation(opts trailReviewCommentAddOptions) (api.Tra
 		}
 	}
 	return loc, nil
+}
+
+// trailReviewLocationFromAnchor places the finding on the span the patch
+// rewrites: the whole hunk range, so a multi-hunk fix is not misreported as
+// sitting on its first line alone.
+func trailReviewLocationFromAnchor(anchor *trailReviewPatchAnchor) api.TrailReviewLocationCreateRequest {
+	// Copy rather than alias the anchor's fields; they are also handed to the
+	// suggested-change request.
+	startLine := anchor.StartLine
+	loc := api.TrailReviewLocationCreateRequest{
+		Granularity: reviewTrailGranularityLine,
+		FilePath:    stringPtr(anchor.FilePath),
+		StartLine:   &startLine,
+	}
+	if anchor.EndLine > anchor.StartLine {
+		endLine := anchor.EndLine
+		loc.Granularity = reviewTrailGranularityRange
+		loc.EndLine = &endLine
+	}
+	return loc
+}
+
+// normalizeFindingPath puts a caller-supplied path into the slash-separated,
+// cleaned form patch targets already use, so `./cmd/foo.go` and `cmd/foo.go`
+// compare equal.
+func normalizeFindingPath(p string) string {
+	return path.Clean(filepath.ToSlash(strings.TrimSpace(p)))
 }
 
 // createTrailReviewFinding posts a single finding through the current API flow:
@@ -1261,17 +1320,25 @@ func patchHeaderPath(raw string) string {
 	return raw
 }
 
-func validatePatchPath(raw string) error {
+// cleanPatchPath normalizes a diff header path to the repo-relative,
+// slash-separated form the working tree uses: quoted paths are unquoted, the a/
+// or b/ prefix git prepends is dropped, and separators are normalized.
+func cleanPatchPath(raw string) string {
 	p := strings.TrimSpace(raw)
-	if p == "" || p == "/dev/null" {
-		return nil
-	}
 	if unquoted, err := strconv.Unquote(p); err == nil {
 		p = unquoted
 	}
 	p = strings.TrimPrefix(p, "a/")
 	p = strings.TrimPrefix(p, "b/")
-	p = strings.ReplaceAll(p, "\\", "/")
+	return strings.ReplaceAll(p, "\\", "/")
+}
+
+func validatePatchPath(raw string) error {
+	p := strings.TrimSpace(raw)
+	if p == "" || p == "/dev/null" {
+		return nil
+	}
+	p = cleanPatchPath(p)
 	if strings.HasPrefix(p, "/") {
 		return fmt.Errorf("absolute path %q is not allowed", raw)
 	}

--- a/cmd/entire/cli/trail_review_cmd_test.go
+++ b/cmd/entire/cli/trail_review_cmd_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -22,6 +24,7 @@ import (
 const (
 	trailReviewApplyOriginalContent = "hello\nold\n"
 	trailReviewTestCommentID        = "cmt_1"
+	trailReviewTestFilePath         = "src/auth/session.ts"
 	trailReviewTestStartPath        = "/api/v1/trails/trl_1/reviews"
 	trailReviewTestCommentsPath     = "/api/v1/trails/trl_1/reviews/rvw_1/comments"
 )
@@ -233,12 +236,12 @@ func TestBuildTrailReviewCommentInput(t *testing.T) {
 		Body:        "Token refresh should allow clock skew.",
 		Severity:    "HIGH",
 		Confidence:  0.94,
-		FilePath:    "src/auth/session.ts",
+		FilePath:    trailReviewTestFilePath,
 		StartLine:   88,
 		EndLine:     91,
 		ClientID:    "agent-run-1:finding-7",
 		Instruction: "Allow a five minute skew.",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("buildTrailReviewCommentInput: %v", err)
 	}
@@ -254,7 +257,7 @@ func TestBuildTrailReviewCommentInput(t *testing.T) {
 	if input.ClientID != "agent-run-1:finding-7" {
 		t.Fatalf("ClientID = %q", input.ClientID)
 	}
-	if input.Location.Granularity != "range" || input.Location.FilePath == nil || *input.Location.FilePath != "src/auth/session.ts" {
+	if input.Location.Granularity != "range" || input.Location.FilePath == nil || *input.Location.FilePath != trailReviewTestFilePath {
 		t.Fatalf("Location = %#v", input.Location)
 	}
 	if input.Location.StartLine == nil || *input.Location.StartLine != 88 || input.Location.EndLine == nil || *input.Location.EndLine != 91 {
@@ -267,12 +270,224 @@ func TestBuildTrailReviewCommentInput(t *testing.T) {
 
 func TestBuildTrailReviewCommentInputGeneratesClientID(t *testing.T) {
 	t.Parallel()
-	input, err := buildTrailReviewCommentInput(trailReviewCommentAddOptions{Body: "finding body"})
+	input, err := buildTrailReviewCommentInput(trailReviewCommentAddOptions{Body: "finding body"}, nil)
 	if err != nil {
 		t.Fatalf("buildTrailReviewCommentInput: %v", err)
 	}
 	if input.ClientID == "" {
 		t.Fatal("expected a generated client_id when --client-id is omitted")
+	}
+}
+
+// TestBuildTrailReviewCommentInputSendsFullPatchAnchor guards the contract the
+// API enforces: a unified_diff is rejected unless it carries expected_file_path,
+// expected_file_hash, expected_start_line, expected_end_line and expected_lines.
+// Sending only change_type and patch is what made --patch fail with a 400.
+func TestBuildTrailReviewCommentInputSendsFullPatchAnchor(t *testing.T) {
+	t.Parallel()
+	anchor := &trailReviewPatchAnchor{
+		FilePath:  trailReviewTestFilePath,
+		FileHash:  "0cfbf08886fca9a91cb753ec8734c84fcbe52c9f",
+		StartLine: 88,
+		EndLine:   91,
+		Lines:     "old line\n",
+	}
+	patch := trailReviewPatch(trailReviewTestFilePath, "old")
+	input, err := buildTrailReviewCommentInput(trailReviewCommentAddOptions{
+		Body:  "Token refresh should allow clock skew.",
+		Patch: patch,
+	}, anchor)
+	if err != nil {
+		t.Fatalf("buildTrailReviewCommentInput: %v", err)
+	}
+	// Compare the whole request: that pins Instruction to nil too, and fails
+	// loudly if the API request struct later grows a field nothing populates.
+	trimmedPatch := strings.TrimSpace(patch)
+	want := api.TrailReviewSuggestedChangeCreateRequest{
+		ChangeType:        "unified_diff",
+		Patch:             &trimmedPatch,
+		ExpectedFilePath:  &anchor.FilePath,
+		ExpectedFileHash:  &anchor.FileHash,
+		ExpectedStartLine: &anchor.StartLine,
+		ExpectedEndLine:   &anchor.EndLine,
+		ExpectedLines:     &anchor.Lines,
+	}
+	if input.SuggestedChange == nil || !reflect.DeepEqual(*input.SuggestedChange, want) {
+		t.Fatalf("SuggestedChange = %#v, want %#v", input.SuggestedChange, want)
+	}
+}
+
+// TestBuildTrailReviewCommentInputLocatesPatchOnlyFinding covers a --patch with
+// no --file: the patch already names the file and the lines it rewrites, so the
+// finding is placed there instead of landing on the trail as a whole.
+func TestBuildTrailReviewCommentInputLocatesPatchOnlyFinding(t *testing.T) {
+	t.Parallel()
+	anchor := &trailReviewPatchAnchor{FilePath: trailReviewTestFilePath, StartLine: 40, EndLine: 98}
+	input, err := buildTrailReviewCommentInput(trailReviewCommentAddOptions{
+		Body:  "finding body",
+		Patch: trailReviewPatch(trailReviewTestFilePath, "old"),
+	}, anchor)
+	if err != nil {
+		t.Fatalf("buildTrailReviewCommentInput: %v", err)
+	}
+	loc := input.Location
+	if loc.Granularity != reviewTrailGranularityRange {
+		t.Fatalf("Granularity = %q, want range", loc.Granularity)
+	}
+	if loc.FilePath == nil || *loc.FilePath != trailReviewTestFilePath {
+		t.Fatalf("FilePath = %#v", loc.FilePath)
+	}
+	if loc.StartLine == nil || *loc.StartLine != 40 || loc.EndLine == nil || *loc.EndLine != 98 {
+		t.Fatalf("lines = %#v/%#v, want 40/98", loc.StartLine, loc.EndLine)
+	}
+}
+
+// TestBuildTrailReviewCommentInputExplicitFileWinsOverAnchor pins the precedence:
+// the anchor only fills a gap, it never overrides what the caller typed.
+func TestBuildTrailReviewCommentInputExplicitFileWinsOverAnchor(t *testing.T) {
+	t.Parallel()
+	// Same file spelled with a leading ./ — must not read as a mismatch. The
+	// caller's line stays put even though the patch spans a different range.
+	anchor := &trailReviewPatchAnchor{FilePath: trailReviewTestFilePath, StartLine: 40, EndLine: 98}
+	input, err := buildTrailReviewCommentInput(trailReviewCommentAddOptions{
+		Body:     "finding body",
+		FilePath: "./" + trailReviewTestFilePath,
+		Line:     45,
+		Patch:    trailReviewPatch(trailReviewTestFilePath, "old"),
+	}, anchor)
+	if err != nil {
+		t.Fatalf("buildTrailReviewCommentInput: %v", err)
+	}
+	if input.Location.Granularity != reviewTrailGranularityLine {
+		t.Fatalf("Granularity = %q, want line", input.Location.Granularity)
+	}
+	if input.Location.StartLine == nil || *input.Location.StartLine != 45 {
+		t.Fatalf("StartLine = %#v, want the explicit 45", input.Location.StartLine)
+	}
+}
+
+// TestBuildTrailReviewCommentInputRejectsFileAnchorMismatch refuses a finding
+// whose location and fix point at different files.
+func TestBuildTrailReviewCommentInputRejectsFileAnchorMismatch(t *testing.T) {
+	t.Parallel()
+	anchor := &trailReviewPatchAnchor{FilePath: "cmd/b.go", StartLine: 1, EndLine: 2}
+	_, err := buildTrailReviewCommentInput(trailReviewCommentAddOptions{
+		Body:     "finding body",
+		FilePath: "cmd/a.go",
+		Patch:    trailReviewPatch("cmd/b.go", "old"),
+	}, anchor)
+	if err == nil {
+		t.Fatal("expected an error when --file and the patch name different files")
+	}
+	if !strings.Contains(err.Error(), "cmd/a.go") || !strings.Contains(err.Error(), "cmd/b.go") {
+		t.Fatalf("error = %v, want it to name both paths", err)
+	}
+}
+
+// TestBuildTrailReviewCommentInputRejectsUnanchoredPatch keeps an unanchored
+// patch off the wire rather than letting the API reject it.
+func TestBuildTrailReviewCommentInputRejectsUnanchoredPatch(t *testing.T) {
+	t.Parallel()
+	_, err := buildTrailReviewCommentInput(trailReviewCommentAddOptions{
+		Body:  "finding body",
+		Patch: trailReviewPatch("file.txt", "old"),
+	}, nil)
+	if err == nil {
+		t.Fatal("expected an error when a patch has no resolved anchor")
+	}
+}
+
+func TestResolveTrailReviewPatchAnchor(t *testing.T) {
+	repo := newTrailReviewApplyRepo(t)
+	writeTrailReviewApplyFile(t, repo, "dir/file.txt")
+
+	anchor, err := resolveTrailReviewPatchAnchor(context.Background(), trailReviewPatch("dir/file.txt", "old"))
+	if err != nil {
+		t.Fatalf("resolveTrailReviewPatchAnchor: %v", err)
+	}
+	if anchor.FilePath != "dir/file.txt" {
+		t.Fatalf("FilePath = %q", anchor.FilePath)
+	}
+	if anchor.StartLine != 1 || anchor.EndLine != 2 {
+		t.Fatalf("range = %d-%d, want 1-2", anchor.StartLine, anchor.EndLine)
+	}
+	// expected_lines is the exact pre-image slice, line endings included.
+	if anchor.Lines != trailReviewApplyOriginalContent {
+		t.Fatalf("Lines = %q, want %q", anchor.Lines, trailReviewApplyOriginalContent)
+	}
+	// The hash must be the blob OID git itself would print for the file.
+	want := trailReviewGitOutput(t, repo, "hash-object", "dir/file.txt")
+	if anchor.FileHash != want {
+		t.Fatalf("FileHash = %q, want %q", anchor.FileHash, want)
+	}
+}
+
+func TestResolveTrailReviewPatchAnchorErrors(t *testing.T) {
+	repo := newTrailReviewApplyRepo(t)
+	writeTrailReviewApplyFile(t, repo, "file.txt")
+
+	tests := []struct {
+		name  string
+		patch string
+		want  string
+	}{
+		{
+			name:  "missing file",
+			patch: trailReviewPatch("absent.txt", "old"),
+			want:  "anchor the suggested change",
+		},
+		{
+			name:  "hunk past end of file",
+			patch: "--- a/file.txt\n+++ b/file.txt\n@@ -40,2 +40,2 @@\n old\n",
+			want:  "the file has 2",
+		},
+		{
+			name:  "multiple files",
+			patch: trailReviewPatch("file.txt", "old") + trailReviewPatch("other.txt", "old"),
+			want:  "multiple files",
+		},
+		{
+			name:  "file creation",
+			patch: "--- /dev/null\n+++ b/new.txt\n@@ -0,0 +1,1 @@\n+added\n",
+			want:  "must modify an existing file",
+		},
+		{
+			name:  "no hunk header",
+			patch: "--- a/file.txt\n+++ b/file.txt\n",
+			want:  "no '@@' hunk header",
+		},
+		{
+			name:  "escapes the repository",
+			patch: "--- a/../outside.txt\n+++ b/../outside.txt\n@@ -1,1 +1,1 @@\n-a\n+b\n",
+			want:  "escapes the repository",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveTrailReviewPatchAnchor(context.Background(), tc.patch)
+			if err == nil {
+				t.Fatalf("expected an error containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseTrailReviewPatchTargetSpansHunks checks that a multi-hunk patch
+// anchors to the full span it touches, not just its first hunk.
+func TestParseTrailReviewPatchTargetSpansHunks(t *testing.T) {
+	t.Parallel()
+	patch := "--- a/file.txt\n+++ b/file.txt\n" +
+		"@@ -20,3 +20,3 @@\n old\n" +
+		"@@ -5,2 +5,2 @@\n old\n"
+	target, err := parseTrailReviewPatchTarget(patch)
+	if err != nil {
+		t.Fatalf("parseTrailReviewPatchTarget: %v", err)
+	}
+	if target.StartLine != 5 || target.EndLine != 22 {
+		t.Fatalf("range = %d-%d, want 5-22", target.StartLine, target.EndLine)
 	}
 }
 
@@ -488,7 +703,7 @@ func TestPrintTrailReviewDashboard(t *testing.T) {
 	t.Parallel()
 	high := trailReviewSeverityHigh
 	medium := trailReviewSeverityMedium
-	path := "src/auth/session.ts"
+	path := trailReviewTestFilePath
 	line := 88
 	comments := []api.TrailReviewComment{
 		{
@@ -528,7 +743,7 @@ func TestPrintTrailReviewDashboard(t *testing.T) {
 		"Resolved: 1",
 		"FRESHNESS",
 		"High",
-		"src/auth/session.ts:88",
+		trailReviewTestFilePath + ":88",
 		"Missing expiry skew handling",
 		"Actions:",
 	} {
@@ -763,13 +978,25 @@ func readTrailReviewApplyFile(t *testing.T, repo, rel string) string {
 	return string(data)
 }
 
-func runTrailReviewApplyGit(t *testing.T, dir string, args ...string) {
+// trailReviewGitOutput runs git in dir and returns its trimmed stdout, failing
+// the test on error. runTrailReviewApplyGit is the same thing where the output
+// is not interesting.
+func trailReviewGitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
+	var stderr bytes.Buffer
 	cmd := exec.CommandContext(context.Background(), "git", args...)
 	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, stderr.String())
 	}
+	return strings.TrimSpace(string(out))
+}
+
+func runTrailReviewApplyGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	trailReviewGitOutput(t, dir, args...)
 }
 
 func trailReviewApplyComment(patches ...string) api.TrailReviewComment {

--- a/cmd/entire/cli/trail_review_cmd_test.go
+++ b/cmd/entire/cli/trail_review_cmd_test.go
@@ -475,13 +475,108 @@ func TestResolveTrailReviewPatchAnchorErrors(t *testing.T) {
 	}
 }
 
+// TestParseTrailReviewPatchTargetSkipsHunkBodies covers diff *content* that
+// looks like a diff *header*. Deleting a line that itself starts with "-- "
+// (SQL, Lua and Haskell comments, CLI flag docs) serializes as "--- ...", and
+// an added line starting with "++ " serializes as "+++ ...". Neither is a file
+// header, and treating them as one rejected valid single-file patches.
+func TestParseTrailReviewPatchTargetSkipsHunkBodies(t *testing.T) {
+	t.Parallel()
+	patch := "--- a/schema.sql\n+++ b/schema.sql\n" +
+		"@@ -10,4 +10,4 @@\n" +
+		" CREATE TABLE t (\n" +
+		"--- legacy column, drop after migration\n" +
+		"+++ replacement column\n" +
+		" );\n"
+	target, err := parseTrailReviewPatchTarget(patch)
+	if err != nil {
+		t.Fatalf("parseTrailReviewPatchTarget: %v", err)
+	}
+	if target.Path != "schema.sql" {
+		t.Fatalf("Path = %q, want schema.sql", target.Path)
+	}
+	if target.StartLine != 10 || target.EndLine != 13 {
+		t.Fatalf("range = %d-%d, want 10-13", target.StartLine, target.EndLine)
+	}
+}
+
+// TestParseTrailReviewPatchTargetKeepsRealPathPrefix guards a file genuinely
+// living under b/ (or a/): the diff header "--- a/b/pkg.go" must resolve to
+// b/pkg.go, not pkg.go. Stripping both prefixes in sequence read the wrong file.
+func TestParseTrailReviewPatchTargetKeepsRealPathPrefix(t *testing.T) {
+	t.Parallel()
+	for _, dir := range []string{"a", "b"} {
+		t.Run(dir, func(t *testing.T) {
+			t.Parallel()
+			want := dir + "/pkg.go"
+			patch := "--- a/" + want + "\n+++ b/" + want + "\n@@ -1,2 +1,2 @@\n-old\n+new\n"
+			target, err := parseTrailReviewPatchTarget(patch)
+			if err != nil {
+				t.Fatalf("parseTrailReviewPatchTarget: %v", err)
+			}
+			if target.Path != want {
+				t.Fatalf("Path = %q, want %q", target.Path, want)
+			}
+		})
+	}
+}
+
+// TestParseTrailReviewPatchTargetPrependToExistingFile covers "@@ -0,0 +1,N @@",
+// which `diff -u0` emits both for a brand-new file and for an insertion above
+// line 1 of an existing one. Only a /dev/null old path means creation; the
+// prepend anchors on the line it is inserted before.
+func TestParseTrailReviewPatchTargetPrependToExistingFile(t *testing.T) {
+	t.Parallel()
+	patch := "--- a/file.txt\n+++ b/file.txt\n@@ -0,0 +1,1 @@\n+added\n"
+	target, err := parseTrailReviewPatchTarget(patch)
+	if err != nil {
+		t.Fatalf("parseTrailReviewPatchTarget: %v", err)
+	}
+	if target.StartLine != 1 || target.EndLine != 1 {
+		t.Fatalf("range = %d-%d, want 1-1", target.StartLine, target.EndLine)
+	}
+}
+
+// TestParseTrailReviewPatchTargetAllowsDeletion keeps "delete this" a valid
+// suggestion: a /dev/null *new* side still has a real old file to anchor to,
+// unlike a /dev/null old side.
+func TestParseTrailReviewPatchTargetAllowsDeletion(t *testing.T) {
+	t.Parallel()
+	patch := "--- a/file.txt\n+++ /dev/null\n@@ -1,2 +0,0 @@\n-hello\n-old\n"
+	target, err := parseTrailReviewPatchTarget(patch)
+	if err != nil {
+		t.Fatalf("parseTrailReviewPatchTarget: %v", err)
+	}
+	if target.Path != "file.txt" || target.StartLine != 1 || target.EndLine != 2 {
+		t.Fatalf("target = %+v, want file.txt 1-2", target)
+	}
+}
+
+// TestParseTrailReviewPatchTargetRejectsRename gives renames an actionable
+// message: the old path is gone from the worktree, so anchoring would otherwise
+// fail with a confusing "read <old path>" error.
+func TestParseTrailReviewPatchTargetRejectsRename(t *testing.T) {
+	t.Parallel()
+	patch := "diff --git a/old.go b/new.go\nrename from old.go\nrename to new.go\n" +
+		"--- a/old.go\n+++ b/new.go\n@@ -1,2 +1,2 @@\n-old\n+new\n"
+	_, err := parseTrailReviewPatchTarget(patch)
+	if err == nil {
+		t.Fatal("expected a rename patch to be rejected")
+	}
+	if !strings.Contains(err.Error(), "renames") {
+		t.Fatalf("error = %v, want it to mention the rename", err)
+	}
+}
+
 // TestParseTrailReviewPatchTargetSpansHunks checks that a multi-hunk patch
 // anchors to the full span it touches, not just its first hunk.
 func TestParseTrailReviewPatchTargetSpansHunks(t *testing.T) {
 	t.Parallel()
+	// Hunk bodies must match the counts their headers declare, exactly as git
+	// emits them — the parser consumes bodies by those counts.
 	patch := "--- a/file.txt\n+++ b/file.txt\n" +
-		"@@ -20,3 +20,3 @@\n old\n" +
-		"@@ -5,2 +5,2 @@\n old\n"
+		"@@ -20,3 +20,3 @@\n a\n-b\n+c\n g\n" +
+		"@@ -5,2 +5,2 @@\n d\n-e\n+f\n"
 	target, err := parseTrailReviewPatchTarget(patch)
 	if err != nil {
 		t.Fatalf("parseTrailReviewPatchTarget: %v", err)

--- a/cmd/entire/cli/trail_review_patch.go
+++ b/cmd/entire/cli/trail_review_patch.go
@@ -95,10 +95,68 @@ type trailReviewPatchTarget struct {
 	EndLine   int
 }
 
-// trailReviewHunkRangePattern captures the old-side range of a unified-diff hunk
-// header: "@@ -12,7 +12,8 @@" yields start 12 and count 7, and an omitted count
-// means a single line.
-var trailReviewHunkRangePattern = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+`)
+// trailReviewHunkRangePattern captures both sides of a unified-diff hunk header:
+// "@@ -12,7 +12,8 @@" yields old 12,7 and new 12,8, and an omitted count means a
+// single line. Both sides are needed to know how long the hunk body is.
+var trailReviewHunkRangePattern = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@`)
+
+// patchDevNull is the path a unified diff uses for "this side does not exist":
+// on the old side it means the patch creates the file, on the new side that it
+// deletes it.
+const patchDevNull = "/dev/null"
+
+// unifiedDiffHunk is the line accounting from one "@@" header.
+type unifiedDiffHunk struct {
+	OldStart int
+	OldCount int
+	NewCount int
+}
+
+// forEachPatchHeaderLine calls fn for every line of a unified diff that is a
+// header rather than hunk content, skipping each hunk body by consuming exactly
+// the line counts its "@@" header declares.
+//
+// Prefix matching alone cannot tell the two apart: deleting a line that starts
+// with "-- " (a SQL, Lua or Haskell comment, a CLI flag doc) serializes as
+// "--- ...", and adding one that starts with "++ " serializes as "+++ ...".
+// Reading those as file headers rejected valid single-file patches and let diff
+// content reach path validation. Counting the body is also exactly how git
+// itself decides where a hunk ends, so this agrees with what `git apply` will do.
+func forEachPatchHeaderLine(patchText string, fn func(line string) error) error {
+	scanner := bufio.NewScanner(strings.NewReader(patchText))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	var remainingOld, remainingNew int
+	for scanner.Scan() {
+		line := scanner.Text()
+		if remainingOld > 0 || remainingNew > 0 {
+			switch {
+			case strings.HasPrefix(line, `\`): // "\ No newline at end of file"
+			case strings.HasPrefix(line, "-"):
+				remainingOld--
+			case strings.HasPrefix(line, "+"):
+				remainingNew--
+			default: // context line, present on both sides
+				if remainingOld > 0 {
+					remainingOld--
+				}
+				if remainingNew > 0 {
+					remainingNew--
+				}
+			}
+			continue
+		}
+		if hunk, ok := parseUnifiedDiffHunkRange(line); ok {
+			remainingOld, remainingNew = hunk.OldCount, hunk.NewCount
+		}
+		if err := fn(line); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan patch: %w", err)
+	}
+	return nil
+}
 
 // parseTrailReviewPatchTarget reads the file and line span a unified diff
 // targets. A suggestion anchors to exactly one file, so a multi-file patch is
@@ -111,41 +169,39 @@ func parseTrailReviewPatchTarget(patch string) (trailReviewPatchTarget, error) {
 		sawFile bool
 		sawHunk bool
 	)
-	scanner := bufio.NewScanner(strings.NewReader(patch))
-	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
-	for scanner.Scan() {
-		line := scanner.Text()
+	err := forEachPatchHeaderLine(patch, func(line string) error {
 		switch {
 		case strings.HasPrefix(line, "--- "):
 			if sawFile {
-				return target, errors.New("patch targets multiple files; attach one suggested change per file")
+				return errors.New("patch targets multiple files; attach one suggested change per file")
 			}
 			sawFile = true
-			oldPath = patchHeaderPath(line[4:])
+			oldPath = patchSidePath(line[4:], "a/")
 		case strings.HasPrefix(line, "+++ "):
-			newPath = patchHeaderPath(line[4:])
-		case strings.HasPrefix(line, "@@ "):
-			start, count, ok := parseUnifiedDiffHunkRange(line)
+			newPath = patchSidePath(line[4:], "b/")
+		default:
+			hunk, ok := parseUnifiedDiffHunkRange(line)
 			if !ok {
-				continue
+				return nil
 			}
-			end := start + count - 1
-			if count == 0 {
-				// A zero-length old range is a pure insertion (git -U0 output);
-				// it anchors on the line the new text is inserted after.
-				end = start
+			end := hunk.OldStart + hunk.OldCount - 1
+			if hunk.OldCount == 0 {
+				// A zero-length old range is a pure insertion (diff -u0 output);
+				// it anchors on the line the new text is inserted next to.
+				end = hunk.OldStart
 			}
-			if !sawHunk || start < target.StartLine {
-				target.StartLine = start
+			if !sawHunk || hunk.OldStart < target.StartLine {
+				target.StartLine = hunk.OldStart
 			}
 			if end > target.EndLine {
 				target.EndLine = end
 			}
 			sawHunk = true
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return target, fmt.Errorf("scan patch: %w", err)
+		return nil
+	})
+	if err != nil {
+		return target, err
 	}
 	if !sawFile {
 		return target, errors.New("patch has no '--- <file>' header naming the file it changes")
@@ -153,12 +209,24 @@ func parseTrailReviewPatchTarget(patch string) (trailReviewPatchTarget, error) {
 	if !sawHunk {
 		return target, errors.New("patch has no '@@' hunk header")
 	}
-	if strings.TrimSpace(oldPath) == "/dev/null" || target.StartLine < 1 {
-		// A suggestion is anchored to lines that already exist, so a patch that
-		// creates a file has nothing to pin to. Say so rather than letting the
-		// API reject expected_start_line 0.
+	// Only a /dev/null old side means creation. A zero start line does not: an
+	// insertion above line 1 of an existing file is also "@@ -0,0 +1,N @@".
+	if oldPath == patchDevNull {
 		return target, fmt.Errorf("patch creates %s; a suggested change must modify an existing file (use --instruction instead)",
-			strings.TrimSpace(cleanPatchPath(newPath)))
+			newPath)
+	}
+	if newPath != "" && newPath != patchDevNull && newPath != oldPath {
+		// The old path is gone from the worktree, so anchoring would otherwise
+		// fail with an unhelpful "read <old path>" error.
+		return target, fmt.Errorf("patch renames %s to %s; a suggested change must modify a single existing file (use --instruction instead)",
+			oldPath, newPath)
+	}
+	// A prepend anchors on the line the new text goes before.
+	if target.StartLine < 1 {
+		target.StartLine = 1
+	}
+	if target.EndLine < target.StartLine {
+		target.EndLine = target.StartLine
 	}
 	// The same whole-patch check the apply path runs, so a patch is held to one
 	// path-safety standard whether it is being written or applied: this covers
@@ -167,28 +235,58 @@ func parseTrailReviewPatchTarget(patch string) (trailReviewPatchTarget, error) {
 	if err := validateUnifiedDiffPatchPaths(patch); err != nil {
 		return target, fmt.Errorf("unsafe patch path: %w", err)
 	}
-	target.Path = path.Clean(cleanPatchPath(oldPath))
+	target.Path = path.Clean(oldPath)
 	return target, nil
 }
 
-// parseUnifiedDiffHunkRange extracts the old-side start line and line count from
-// a hunk header.
-func parseUnifiedDiffHunkRange(line string) (start, count int, ok bool) {
+// patchSidePath normalizes one side of a diff header. git prefixes the old side
+// with a/ and the new side with b/, and only that one prefix may be stripped: a
+// file genuinely living at b/pkg.go is written "--- a/b/pkg.go", so stripping
+// both in sequence resolved it to pkg.go and read the wrong file.
+func patchSidePath(raw, prefix string) string {
+	p := patchHeaderPath(raw)
+	if unquoted, err := strconv.Unquote(p); err == nil {
+		p = unquoted
+	}
+	p = strings.ReplaceAll(p, `\`, "/")
+	if p == patchDevNull {
+		return p
+	}
+	return strings.TrimPrefix(p, prefix)
+}
+
+// parseUnifiedDiffHunkRange extracts the line accounting from a hunk header.
+func parseUnifiedDiffHunkRange(line string) (unifiedDiffHunk, bool) {
 	match := trailReviewHunkRangePattern.FindStringSubmatch(line)
 	if match == nil {
-		return 0, 0, false
+		return unifiedDiffHunk{}, false
 	}
-	start, err := strconv.Atoi(match[1])
+	oldStart, err := strconv.Atoi(match[1])
 	if err != nil {
-		return 0, 0, false
+		return unifiedDiffHunk{}, false
 	}
-	count = 1
-	if match[2] != "" {
-		if count, err = strconv.Atoi(match[2]); err != nil {
-			return 0, 0, false
-		}
+	oldCount, ok := patchHunkCount(match[2])
+	if !ok {
+		return unifiedDiffHunk{}, false
 	}
-	return start, count, true
+	newCount, ok := patchHunkCount(match[4])
+	if !ok {
+		return unifiedDiffHunk{}, false
+	}
+	return unifiedDiffHunk{OldStart: oldStart, OldCount: oldCount, NewCount: newCount}, true
+}
+
+// patchHunkCount reads one side's line count, which defaults to 1 when the hunk
+// header omits it.
+func patchHunkCount(raw string) (int, bool) {
+	if raw == "" {
+		return 1, true
+	}
+	count, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false
+	}
+	return count, true
 }
 
 // patchAnchorLines returns the file's bytes for lines [start, end] with their

--- a/cmd/entire/cli/trail_review_patch.go
+++ b/cmd/entire/cli/trail_review_patch.go
@@ -1,0 +1,221 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
+)
+
+// trailReviewPatchAnchor is the pre-image a machine-applicable suggested change
+// is pinned to: which file the patch rewrites, what that file hashed to when the
+// finding was written, and the exact lines the patch expects to find there. The
+// API requires all of it for a unified_diff ("unified_diff change requires
+// expected_file_path" and four sibling checks), so these fields are mandatory
+// rather than decorative — a patch sent without them is rejected outright.
+type trailReviewPatchAnchor struct {
+	FilePath  string
+	FileHash  string
+	StartLine int
+	EndLine   int
+	Lines     string
+}
+
+// resolveTrailReviewPatchAnchor derives the anchor from the patch plus the
+// working tree: the diff headers name the file and the old-side line span, and
+// the file on disk supplies the hash and the expected lines.
+func resolveTrailReviewPatchAnchor(ctx context.Context, patch string) (*trailReviewPatchAnchor, error) {
+	target, err := parseTrailReviewPatchTarget(patch)
+	if err != nil {
+		return nil, err
+	}
+	root, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve worktree root: %w", err)
+	}
+	fullPath, ok := safeWorktreeFilePath(root, target.Path)
+	if !ok {
+		return nil, fmt.Errorf("patch path %s does not resolve inside the worktree", target.Path)
+	}
+	content, err := os.ReadFile(fullPath) //nolint:gosec // path is constrained to the current worktree root.
+	if err != nil {
+		return nil, fmt.Errorf("read %s to anchor the suggested change: %w", target.Path, err)
+	}
+	lines, err := patchAnchorLines(content, target.StartLine, target.EndLine)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", target.Path, err)
+	}
+	// Resolved only once the patch and the file have checked out, so a rejected
+	// patch does not pay for opening the repository.
+	hash, err := gitBlobHash(content, trailReviewObjectFormat(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("hash %s: %w", target.Path, err)
+	}
+	return &trailReviewPatchAnchor{
+		FilePath:  target.Path,
+		FileHash:  hash,
+		StartLine: target.StartLine,
+		EndLine:   target.EndLine,
+		Lines:     lines,
+	}, nil
+}
+
+// trailReviewObjectFormat reports the repository's git object format, so that
+// expected_file_hash is the blob OID `git hash-object` prints in this repo
+// rather than a sha1 value that a sha256 repository would never reproduce.
+func trailReviewObjectFormat(ctx context.Context) format.ObjectFormat {
+	repo, err := gitrepo.OpenCurrent(ctx)
+	if err != nil {
+		return format.SHA1
+	}
+	defer repo.Close()
+	cfg, err := repo.Config()
+	if err != nil || cfg.Extensions.ObjectFormat == format.UnsetObjectFormat {
+		return format.SHA1
+	}
+	return cfg.Extensions.ObjectFormat
+}
+
+// trailReviewPatchTarget is the single file a suggested-change patch rewrites
+// and the old-side line span it covers.
+type trailReviewPatchTarget struct {
+	Path      string
+	StartLine int
+	EndLine   int
+}
+
+// trailReviewHunkRangePattern captures the old-side range of a unified-diff hunk
+// header: "@@ -12,7 +12,8 @@" yields start 12 and count 7, and an omitted count
+// means a single line.
+var trailReviewHunkRangePattern = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+`)
+
+// parseTrailReviewPatchTarget reads the file and line span a unified diff
+// targets. A suggestion anchors to exactly one file, so a multi-file patch is
+// rejected here with an actionable message instead of as a server 400.
+func parseTrailReviewPatchTarget(patch string) (trailReviewPatchTarget, error) {
+	var (
+		target  trailReviewPatchTarget
+		oldPath string
+		newPath string
+		sawFile bool
+		sawHunk bool
+	)
+	scanner := bufio.NewScanner(strings.NewReader(patch))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "--- "):
+			if sawFile {
+				return target, errors.New("patch targets multiple files; attach one suggested change per file")
+			}
+			sawFile = true
+			oldPath = patchHeaderPath(line[4:])
+		case strings.HasPrefix(line, "+++ "):
+			newPath = patchHeaderPath(line[4:])
+		case strings.HasPrefix(line, "@@ "):
+			start, count, ok := parseUnifiedDiffHunkRange(line)
+			if !ok {
+				continue
+			}
+			end := start + count - 1
+			if count == 0 {
+				// A zero-length old range is a pure insertion (git -U0 output);
+				// it anchors on the line the new text is inserted after.
+				end = start
+			}
+			if !sawHunk || start < target.StartLine {
+				target.StartLine = start
+			}
+			if end > target.EndLine {
+				target.EndLine = end
+			}
+			sawHunk = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return target, fmt.Errorf("scan patch: %w", err)
+	}
+	if !sawFile {
+		return target, errors.New("patch has no '--- <file>' header naming the file it changes")
+	}
+	if !sawHunk {
+		return target, errors.New("patch has no '@@' hunk header")
+	}
+	if strings.TrimSpace(oldPath) == "/dev/null" || target.StartLine < 1 {
+		// A suggestion is anchored to lines that already exist, so a patch that
+		// creates a file has nothing to pin to. Say so rather than letting the
+		// API reject expected_start_line 0.
+		return target, fmt.Errorf("patch creates %s; a suggested change must modify an existing file (use --instruction instead)",
+			strings.TrimSpace(cleanPatchPath(newPath)))
+	}
+	// The same whole-patch check the apply path runs, so a patch is held to one
+	// path-safety standard whether it is being written or applied: this covers
+	// the +++ side and any rename/copy headers, not just the --- path we anchor
+	// to.
+	if err := validateUnifiedDiffPatchPaths(patch); err != nil {
+		return target, fmt.Errorf("unsafe patch path: %w", err)
+	}
+	target.Path = path.Clean(cleanPatchPath(oldPath))
+	return target, nil
+}
+
+// parseUnifiedDiffHunkRange extracts the old-side start line and line count from
+// a hunk header.
+func parseUnifiedDiffHunkRange(line string) (start, count int, ok bool) {
+	match := trailReviewHunkRangePattern.FindStringSubmatch(line)
+	if match == nil {
+		return 0, 0, false
+	}
+	start, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	count = 1
+	if match[2] != "" {
+		if count, err = strconv.Atoi(match[2]); err != nil {
+			return 0, 0, false
+		}
+	}
+	return start, count, true
+}
+
+// patchAnchorLines returns the file's bytes for lines [start, end] with their
+// line endings intact, which is what expected_lines records: the exact slice a
+// later apply compares against to tell whether the file has moved on. Unlike
+// trailReviewSelectedTextFromWorktree, it must not normalize CRLF — the value is
+// a byte-for-byte pre-image, not display text.
+func patchAnchorLines(content []byte, start, end int) (string, error) {
+	lines := strings.SplitAfter(string(content), "\n")
+	// A trailing newline leaves a final empty element that is not a line.
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1]
+	}
+	// end >= start >= 1 holds for every target the parser returns, so this one
+	// bound covers both.
+	if end > len(lines) {
+		return "", fmt.Errorf("patch expects lines %d-%d but the file has %d", start, end, len(lines))
+	}
+	return strings.Join(lines[start-1:end], ""), nil
+}
+
+// gitBlobHash computes the git blob object ID of the given content, so the value
+// stored as expected_file_hash matches `git hash-object <file>`.
+func gitBlobHash(content []byte, objectFormat format.ObjectFormat) (string, error) {
+	hasher := plumbing.NewHasher(objectFormat, plumbing.BlobObject, int64(len(content)))
+	if _, err := hasher.Write(content); err != nil {
+		return "", fmt.Errorf("write blob content to hasher: %w", err)
+	}
+	return hasher.Sum().String(), nil
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1048
<!-- entire-trail-link-end -->

## The bug

`entire trail finding add --patch/--patch-file` has **never once succeeded**. The CLI built the suggested change from `change_type` + `patch` + `instruction` and nothing else, but the API requires a full pre-image anchor for any non-`manual_instruction` change:

```go
// entire-api internal/store/suggested_changes.go (and the identical BFF check)
patch → expected_file_path → expected_file_hash
      → expected_start_line → expected_end_line → expected_lines
```

`expected_file_path` was just the first check to fail; filling only that field would have moved the error to `expected_file_hash`. Every call came back with `invalid_request: unified_diff change requires expected_file_path`, so only `--instruction` ever got through — which is why CLI-created findings carry prose instead of diffs, and why `entire trail finding apply` had no CLI-created patches to apply.

## Since when

Broken since the flags shipped.

| When | What |
|---|---|
| 2026-05-18 | Server-side requirement lands in entire.io |
| 2026-06-05 | `43067b86d` adds `--patch`/`--patch-file`, sending only `change_type` + `patch` |
| 2026-06-11 | `38e470409` fixes the endpoint and surfaces per-item errors — the failure becomes visible |

No version of `trail_review_cmd.go` has ever assigned `ExpectedFilePath` (verified across all 29 commits touching the file).

**Measured impact.** Scanning every agent transcript on one machine (954 files, 142k records): 92 real `trail finding add` invocations, 68 successful — all `-m`/`--instruction` only. 10 used `--patch`; 9 failed with this exact error across 6 review sessions on 3 separate days, and the 1 success is the verification call for this branch. Six times an agent reached for a machine-applicable fix and silently fell back to prose.

## The fix

Derive the anchor from the patch plus the worktree:

- **path + line span** — parsed from the diff headers and the old-side `@@` ranges, spanning min-start to max-end across hunks
- **`expected_lines`** — the byte-exact pre-image slice, line endings intact (deliberately *not* CRLF-normalized like `selected_text`)
- **`expected_file_hash`** — the git blob OID, so it matches `git hash-object <file>`, read through the repository's object format so a sha256 repo isn't handed a sha1 value

Cases the API would reject now fail locally with an actionable message instead of a server error: multi-file patches, file-creation patches (`--- /dev/null` has no pre-image to anchor to → use `--instruction`), hunks past EOF, missing files. Patch paths run through the same whole-patch safety check the apply path already used, so a patch is held to one standard whether it's being written or applied.

## Behavior changes

Two, both deliberate:

- **A `--patch` with no `--file` now gets a location.** It previously produced a locationless `whole_change` finding even though the patch named the file and lines exactly. It now lands on the patch's file and full hunk span (`Location: .gitignore:3-5`). An explicit `--file`/`--line` still wins — the anchor only fills a gap.
- **A `--file` naming a different file than the patch modifies is rejected**, rather than storing a finding whose location and fix point at different places. The API forces single-file patches, so there's no sensible reading of that state.

A line-range disagreement (`--line 45` with hunks at 10–20) is deliberately **not** checked: pointing at where a problem manifests while fixing elsewhere in the same file is legitimate.

## Verification

- Posted real findings with `--patch-file` to a trail: accepted, `unified_diff` with the right file, location derived correctly. Mismatch guard rejects as expected. Test findings dismissed.
- `mise run fmt && mise run lint && mise run test:ci` all clean.
- New unit tests cover the full anchor payload (via `reflect.DeepEqual` on the whole request, which caught that the stored patch is trimmed), the location defaulting and precedence, the mismatch rejection, and six parser rejection cases.

## Open questions for review

- **`expected_file_hash` has no consumer** anywhere — CLI, cell, or frontend — and no documented algorithm. I picked the git blob OID because it's repo-native and hand-verifiable, and documented the convention on the API type. Worth pinning down while there's still only one producer: a later consumer computing it differently would read every CLI-created suggestion as stale.
- **Hash source is the worktree, not the review head blob.** The worktree is consistent with the patch (both written against the same tree); the head blob would be reproducible by the server. Reasonable people differ — flagging rather than deciding unilaterally.

## Follow-ups not taken

- `gitBlobHash` is now the third "git blob hash of content" in the tree (`strategy/content_overlap.go:534`, `checkpoint/migrate.go:234`); extracting into `gitrepo` is a clean mechanical follow-up.
- The anchor parser and the apply path's `validateUnifiedDiffPatchPaths` still scan the patch separately; unifying them means touching the apply path, which deserves its own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ea829fbb1c8e77b835d86071aedd4f92123de489. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->