### PR TITLE
fix(opencode): report transcript export failures during attach

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -197,7 +197,8 @@ type TranscriptFetcher interface {
 	Agent
 
 	// FetchTranscript writes the session's transcript to the agent's cache
-	// location and returns its path.
+	// location and returns its path. Errors may be shown to users after other
+	// transcript sources fail, so they must be concise and safe to display.
 	FetchTranscript(ctx context.Context, sessionID string) (string, error)
 }
 

--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -188,6 +188,19 @@ type TranscriptPreparer interface {
 	PrepareTranscript(ctx context.Context, sessionRef string) error
 }
 
+// TranscriptFetcher is implemented by agents that can materialize a session
+// transcript on demand (e.g. OpenCode via `opencode export`), including for
+// sessions Entire never tracked — where no hook-cached transcript file exists
+// (e.g. sessions spawned by an external host rather than a hooked terminal).
+// TranscriptPreparer, by contrast, only refreshes an already-existing file.
+type TranscriptFetcher interface {
+	Agent
+
+	// FetchTranscript writes the session's transcript to the agent's cache
+	// location and returns its path.
+	FetchTranscript(ctx context.Context, sessionID string) (string, error)
+}
+
 // SidecarImageProvider is implemented by agents that keep images OUTSIDE the
 // transcript Entire condenses — e.g. Cursor stores pasted images in a per-session
 // SQLite blob store, not the JSONL transcript. The strategy layer calls this

--- a/cmd/entire/cli/agent/capabilities.go
+++ b/cmd/entire/cli/agent/capabilities.go
@@ -89,6 +89,18 @@ func AsSidecarImageProvider(ag Agent) (SidecarImageProvider, bool) {
 	return p, ok
 }
 
+// AsTranscriptFetcher returns the agent as TranscriptFetcher if it implements
+// the interface. This is an optional capability (materializing a transcript on
+// demand for sessions with no hook-cached file), so it resolves by type
+// assertion alone with no DeclaredCaps gate.
+func AsTranscriptFetcher(ag Agent) (TranscriptFetcher, bool) {
+	if ag == nil {
+		return nil, false
+	}
+	f, ok := ag.(TranscriptFetcher)
+	return f, ok
+}
+
 // AsTokenCalculator returns the agent as TokenCalculator if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
 func AsTokenCalculator(ag Agent) (TokenCalculator, bool) {

--- a/cmd/entire/cli/agent/opencode/cli_commands.go
+++ b/cmd/entire/cli/agent/opencode/cli_commands.go
@@ -3,15 +3,31 @@ package opencode
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
+	"unicode"
+
+	"github.com/entireio/cli/redact"
+
+	"github.com/charmbracelet/x/ansi"
 )
 
 // openCodeCommandTimeout is the maximum time to wait for opencode CLI commands.
 const openCodeCommandTimeout = 30 * time.Second
+
+const openCodeErrorDetailMaxRunes = 300
+
+type openCodeExportError struct {
+	message string
+	cause   error
+}
+
+func (e *openCodeExportError) Error() string { return e.message }
+func (e *openCodeExportError) Unwrap() error { return e.cause }
 
 // runOpenCodeExportToFile runs `opencode export <sessionID>` and redirects stdout
 // to outputPath. This avoids pipe/stdout capture truncation bugs in some opencode versions.
@@ -34,15 +50,84 @@ func runOpenCodeExportToFile(ctx context.Context, sessionID, outputPath string) 
 	cmd.Stdout = file
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
+	if runErr := cmd.Run(); runErr != nil {
 		_ = os.Remove(outputPath)
-		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("opencode export timed out after %s", openCodeCommandTimeout)
-		}
-		return fmt.Errorf("opencode export failed: %w (stderr: %s)", err, strings.TrimSpace(stderr.String()))
+		return classifyOpenCodeExportError(ctx, runErr, stderr.String(), sessionID)
 	}
 
 	return nil
+}
+
+func classifyOpenCodeExportError(ctx context.Context, err error, stderr, sessionID string) error {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return context.Canceled
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return &openCodeExportError{
+			message: fmt.Sprintf("OpenCode export timed out after %s. Try again.", openCodeCommandTimeout),
+			cause:   context.DeadlineExceeded,
+		}
+	}
+
+	var execErr *exec.Error
+	if errors.As(err, &execErr) && errors.Is(execErr.Err, exec.ErrNotFound) {
+		return &openCodeExportError{
+			message: "OpenCode is not installed or is not available in PATH.",
+			cause:   err,
+		}
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return &openCodeExportError{
+			message: "OpenCode could not be started because of insufficient permissions.",
+			cause:   err,
+		}
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		detail := formatOpenCodeErrorDetail(stderr)
+		if strings.HasPrefix(strings.ToLower(detail), "session not found") {
+			return &openCodeExportError{
+				message: fmt.Sprintf("OpenCode session %q was not found. Check the session ID and try again.", sessionID),
+				cause:   err,
+			}
+		}
+		if detail != "" {
+			return &openCodeExportError{
+				message: fmt.Sprintf("OpenCode could not export session %q: %s", sessionID, detail),
+				cause:   err,
+			}
+		}
+		return &openCodeExportError{
+			message: fmt.Sprintf("OpenCode could not export session %q.", sessionID),
+			cause:   err,
+		}
+	}
+
+	return &openCodeExportError{message: "OpenCode export could not be started.", cause: err}
+}
+
+func formatOpenCodeErrorDetail(stderr string) string {
+	for _, rawLine := range strings.Split(stderr, "\n") {
+		line := strings.Map(func(r rune) rune {
+			if unicode.IsControl(r) {
+				return -1
+			}
+			return r
+		}, ansi.Strip(rawLine))
+		line = strings.TrimSpace(line)
+		if len(line) < len("error:") || !strings.EqualFold(line[:len("error:")], "error:") {
+			continue
+		}
+
+		detail := strings.Join(strings.Fields(redact.String(line[len("error:"):])), " ")
+		runes := []rune(detail)
+		if len(runes) > openCodeErrorDetailMaxRunes {
+			return string(runes[:openCodeErrorDetailMaxRunes]) + "…"
+		}
+		return detail
+	}
+	return ""
 }
 
 // runOpenCodeSessionDelete runs `opencode session delete <sessionID>` to remove

--- a/cmd/entire/cli/agent/opencode/cli_commands_test.go
+++ b/cmd/entire/cli/agent/opencode/cli_commands_test.go
@@ -1,0 +1,97 @@
+package opencode
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestClassifyOpenCodeExportError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		err       error
+		stderr    string
+		sessionID string
+		want      string
+	}{
+		{
+			name:      "missing executable",
+			err:       &exec.Error{Name: "opencode", Err: exec.ErrNotFound},
+			sessionID: "ses_missing_binary",
+			want:      "OpenCode is not installed or is not available in PATH.",
+		},
+		{
+			name:      "permission denied",
+			err:       &os.PathError{Op: "fork/exec", Path: "/private/opencode", Err: os.ErrPermission},
+			sessionID: "ses_denied",
+			want:      "OpenCode could not be started because of insufficient permissions.",
+		},
+		{
+			name:      "missing session",
+			err:       &exec.ExitError{},
+			stderr:    "Exporting session: ses_missing\nError: Session not found: ses_missing\n",
+			sessionID: "ses_missing",
+			want:      `OpenCode session "ses_missing" was not found. Check the session ID and try again.`,
+		},
+		{
+			name:      "useful stderr",
+			err:       &exec.ExitError{},
+			stderr:    "Exporting session\n\x1b[31mError: Export was rejected by OpenCode\x1b[0m\nDB_PASSWORD=not-a-real-secret\n",
+			sessionID: "ses_rejected",
+			want:      `OpenCode could not export session "ses_rejected": Export was rejected by OpenCode`,
+		},
+		{
+			name:      "unstructured stderr",
+			err:       &exec.ExitError{},
+			stderr:    "internal stack trace\nDB_PASSWORD=not-a-real-secret\n",
+			sessionID: "ses_opaque",
+			want:      `OpenCode could not export session "ses_opaque".`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyOpenCodeExportError(context.Background(), tt.err, tt.stderr, tt.sessionID)
+			if got.Error() != tt.want {
+				t.Fatalf("classifyOpenCodeExportError error = %q, want %q", got, tt.want)
+			}
+			if !errors.Is(got, tt.err) {
+				t.Fatal("classified error does not retain its cause")
+			}
+		})
+	}
+}
+
+func TestClassifyOpenCodeExportError_Timeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	<-ctx.Done()
+
+	err := classifyOpenCodeExportError(ctx, errors.New("signal: killed"), "", "ses_timeout")
+	want := "OpenCode export timed out after 30s. Try again."
+	if err.Error() != want {
+		t.Fatalf("classifyOpenCodeExportError error = %q, want %q", err, want)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("timeout error does not retain context.DeadlineExceeded")
+	}
+}
+
+func TestFormatOpenCodeErrorDetail_Truncates(t *testing.T) {
+	t.Parallel()
+
+	detail := formatOpenCodeErrorDetail("Error: " + strings.Repeat("a", openCodeErrorDetailMaxRunes+1))
+	want := strings.Repeat("a", openCodeErrorDetailMaxRunes) + "…"
+	if detail != want {
+		t.Fatalf("formatOpenCodeErrorDetail = %q, want %q", detail, want)
+	}
+}

--- a/cmd/entire/cli/agent/opencode/lifecycle.go
+++ b/cmd/entire/cli/agent/opencode/lifecycle.go
@@ -224,7 +224,7 @@ func (a *OpenCodeAgent) fetchAndCacheExport(ctx context.Context, sessionID strin
 	}
 
 	if err := runOpenCodeExportToFileFn(ctx, sessionID, tmpFile); err != nil {
-		return "", fmt.Errorf("opencode export failed: %w", err)
+		return "", err
 	}
 
 	//nolint:gosec // tmpFile is constructed from validated session ID under repo .entire/tmp
@@ -239,7 +239,9 @@ func (a *OpenCodeAgent) fetchAndCacheExport(ctx context.Context, sessionID strin
 			slog.Int("bytes", len(data)),
 			slog.String("path", tmpFile),
 		)
-		return "", fmt.Errorf("opencode export returned invalid JSON (%d bytes)", len(data))
+		return "", &openCodeExportError{
+			message: fmt.Sprintf("OpenCode returned invalid transcript data for session %q. Try updating OpenCode and running the command again.", sessionID),
+		}
 	}
 
 	return tmpFile, nil

--- a/cmd/entire/cli/agent/opencode/lifecycle.go
+++ b/cmd/entire/cli/agent/opencode/lifecycle.go
@@ -168,6 +168,14 @@ func (a *OpenCodeAgent) PrepareTranscript(ctx context.Context, sessionRef string
 	return err
 }
 
+// FetchTranscript materializes the session's transcript via `opencode export`
+// and returns the cached path. Unlike PrepareTranscript (which only refreshes
+// an existing file), this works for sessions Entire never tracked — e.g.
+// sessions spawned by an external host, where no hook ever cached an export.
+func (a *OpenCodeAgent) FetchTranscript(ctx context.Context, sessionID string) (string, error) {
+	return a.fetchAndCacheExport(ctx, sessionID)
+}
+
 // sessionTranscriptPath validates the session ID and returns the expected transcript path.
 func sessionTranscriptPath(ctx context.Context, sessionID string) (string, error) {
 	if err := validation.ValidateSessionID(sessionID); err != nil {

--- a/cmd/entire/cli/agent/opencode/lifecycle_test.go
+++ b/cmd/entire/cli/agent/opencode/lifecycle_test.go
@@ -389,3 +389,29 @@ func TestFetchAndCacheExport_WritesAndValidatesExportFile(t *testing.T) {
 	require.True(t, json.Valid(content), "expected cached transcript to be valid JSON")
 	require.Contains(t, string(content), "\"ses_abc123\"")
 }
+
+func TestFetchTranscript_ValidatesSessionID(t *testing.T) {
+	t.Parallel()
+
+	ag := &OpenCodeAgent{}
+	if _, err := ag.FetchTranscript(context.Background(), "bad/session-id"); err == nil {
+		t.Fatal("expected error for session ID with path separator, got nil")
+	}
+}
+
+func TestFetchTranscript_AttemptsExport(t *testing.T) {
+	t.Parallel()
+
+	// Without mock-export mode, FetchTranscript must attempt `opencode export`
+	// — proving it tries to materialize the transcript for sessions with no
+	// hook-cached file rather than stat-checking an existing one. Without a
+	// usable session the export fails, wrapped as "opencode export failed".
+	ag := &OpenCodeAgent{}
+	_, err := ag.FetchTranscript(context.Background(), "test-fetch-transcript-no-such-session")
+	if err == nil {
+		t.Fatal("expected error for nonexistent session, got nil")
+	}
+	if !strings.Contains(err.Error(), "opencode export failed") {
+		t.Errorf("expected 'opencode export failed' error, got: %v", err)
+	}
+}

--- a/cmd/entire/cli/agent/opencode/lifecycle_test.go
+++ b/cmd/entire/cli/agent/opencode/lifecycle_test.go
@@ -3,6 +3,7 @@ package opencode
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -254,11 +255,6 @@ func TestHookNames(t *testing.T) {
 }
 
 func TestPrepareTranscript_AlwaysRefreshesTranscript(t *testing.T) {
-	t.Parallel()
-
-	// PrepareTranscript should always attempt to refresh via fetchAndCacheExport,
-	// even when the file already exists. Without opencode CLI or mock mode,
-	// this means it must return an error (proving it tried to refresh).
 	tmpDir := t.TempDir()
 	transcriptPath := filepath.Join(tmpDir, "sess-123.json")
 
@@ -267,16 +263,14 @@ func TestPrepareTranscript_AlwaysRefreshesTranscript(t *testing.T) {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
-	ag := &OpenCodeAgent{}
-	err := ag.PrepareTranscript(context.Background(), transcriptPath)
+	wantErr := errors.New("refresh attempted")
+	original := runOpenCodeExportToFileFn
+	runOpenCodeExportToFileFn = func(context.Context, string, string) error { return wantErr }
+	t.Cleanup(func() { runOpenCodeExportToFileFn = original })
 
-	// Without opencode CLI, fetchAndCacheExport must fail — proving it attempted a refresh
-	// rather than short-circuiting because the file exists.
-	if err == nil {
-		t.Fatal("expected error (refresh attempt should fail without opencode CLI), got nil")
-	}
-	if !strings.Contains(err.Error(), "opencode export failed") {
-		t.Errorf("expected 'opencode export failed' error, got: %v", err)
+	err := (&OpenCodeAgent{}).PrepareTranscript(context.Background(), transcriptPath)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("PrepareTranscript error = %v, want %v", err, wantErr)
 	}
 }
 
@@ -400,18 +394,37 @@ func TestFetchTranscript_ValidatesSessionID(t *testing.T) {
 }
 
 func TestFetchTranscript_AttemptsExport(t *testing.T) {
-	t.Parallel()
+	t.Chdir(t.TempDir())
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
 
-	// Without mock-export mode, FetchTranscript must attempt `opencode export`
-	// — proving it tries to materialize the transcript for sessions with no
-	// hook-cached file rather than stat-checking an existing one. Without a
-	// usable session the export fails, wrapped as "opencode export failed".
+	wantErr := errors.New("export attempted")
+	original := runOpenCodeExportToFileFn
+	runOpenCodeExportToFileFn = func(context.Context, string, string) error { return wantErr }
+	t.Cleanup(func() { runOpenCodeExportToFileFn = original })
+
 	ag := &OpenCodeAgent{}
 	_, err := ag.FetchTranscript(context.Background(), "test-fetch-transcript-no-such-session")
-	if err == nil {
-		t.Fatal("expected error for nonexistent session, got nil")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("FetchTranscript error = %v, want %v", err, wantErr)
 	}
-	if !strings.Contains(err.Error(), "opencode export failed") {
-		t.Errorf("expected 'opencode export failed' error, got: %v", err)
+}
+
+func TestFetchTranscript_ReportsInvalidJSON(t *testing.T) {
+	t.Chdir(t.TempDir())
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	original := runOpenCodeExportToFileFn
+	runOpenCodeExportToFileFn = func(_ context.Context, _, outputPath string) error {
+		return os.WriteFile(outputPath, []byte("not json"), 0o600)
+	}
+	t.Cleanup(func() { runOpenCodeExportToFileFn = original })
+
+	const sessionID = "test-invalid-json"
+	_, err := (&OpenCodeAgent{}).FetchTranscript(context.Background(), sessionID)
+	want := `OpenCode returned invalid transcript data for session "test-invalid-json". Try updating OpenCode and running the command again.`
+	if err == nil || err.Error() != want {
+		t.Fatalf("FetchTranscript error = %v, want %q", err, want)
 	}
 }

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -810,6 +810,16 @@ func resolveAndValidateTranscript(ctx context.Context, sessionID string, ag agen
 		}
 		return transcriptPath, nil
 	}
+	// Agents that can materialize a transcript on demand (e.g. OpenCode via
+	// `opencode export`) can conjure one even when no hook-cached file exists,
+	// e.g. sessions spawned by an external host rather than a hooked terminal.
+	if fetcher, ok := agent.AsTranscriptFetcher(ag); ok {
+		fetched, fetchErr := fetcher.FetchTranscript(ctx, sessionID)
+		if fetchErr == nil {
+			return fetched, nil
+		}
+		logging.Debug(ctx, "FetchTranscript failed, falling back to project-dir search", "error", fetchErr)
+	}
 	found, searchErr := searchTranscriptInProjectDirs(sessionID, ag)
 	if searchErr == nil {
 		logging.Info(ctx, "found transcript in alternative project directory", "path", found)

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -761,8 +761,13 @@ func resolveAgentAndTranscript(ctx context.Context, w io.Writer, sessionID strin
 	transcriptPath, err := resolveAndValidateTranscript(ctx, sessionID, ag)
 	if err != nil {
 		// Auto-detect: try all other agents.
-		detectedAg, detectedPath, detectErr := detectAgentByTranscript(ctx, sessionID, agentName)
+		detectedAg, detectedPath, detectErr := detectAgentByTranscript(ctx, sessionID, ag.Name())
 		if detectErr != nil {
+			var fetchFailure *transcriptFetchError
+			if errors.As(err, &fetchFailure) {
+				logging.Debug(ctx, "auto-detection also failed after transcript fetch", "error", detectErr)
+				return nil, "", err
+			}
 			return nil, "", fmt.Errorf("%w (also tried auto-detecting other agents: %w)", err, detectErr)
 		}
 		ag = detectedAg
@@ -773,6 +778,15 @@ func resolveAgentAndTranscript(ctx context.Context, w io.Writer, sessionID strin
 
 	return ag, transcriptPath, nil
 }
+
+// transcriptFetchError keeps secondary auto-detection failures from obscuring
+// the fetch failure that the selected agent can explain.
+type transcriptFetchError struct {
+	cause error
+}
+
+func (e *transcriptFetchError) Error() string { return e.cause.Error() }
+func (e *transcriptFetchError) Unwrap() error { return e.cause }
 
 // resolveAgent resolves the agent to use. For existing sessions with an AgentType,
 // uses agent.GetByAgentType. Otherwise falls back to the --agent flag.
@@ -813,10 +827,15 @@ func resolveAndValidateTranscript(ctx context.Context, sessionID string, ag agen
 	// Agents that can materialize a transcript on demand (e.g. OpenCode via
 	// `opencode export`) can conjure one even when no hook-cached file exists,
 	// e.g. sessions spawned by an external host rather than a hooked terminal.
+	var fetchErr error
 	if fetcher, ok := agent.AsTranscriptFetcher(ag); ok {
-		fetched, fetchErr := fetcher.FetchTranscript(ctx, sessionID)
+		var fetched string
+		fetched, fetchErr = fetcher.FetchTranscript(ctx, sessionID)
 		if fetchErr == nil {
 			return fetched, nil
+		}
+		if errors.Is(fetchErr, context.Canceled) {
+			return "", fmt.Errorf("fetch transcript: %w", fetchErr)
 		}
 		logging.Debug(ctx, "FetchTranscript failed, falling back to project-dir search", "error", fetchErr)
 	}
@@ -826,6 +845,9 @@ func resolveAndValidateTranscript(ctx context.Context, sessionID string, ag agen
 		return found, nil
 	}
 	logging.Debug(ctx, "fallback transcript search failed", "error", searchErr)
+	if fetchErr != nil {
+		return "", &transcriptFetchError{cause: fetchErr}
+	}
 	return "", fmt.Errorf("transcript not found for agent %q with session %s; is the session ID correct?", ag.Name(), sessionID)
 }
 

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -66,6 +67,101 @@ func TestAttach_TranscriptNotFound(t *testing.T) {
 	err := runAttach(context.Background(), &out, &out, "nonexistent-session-id", agent.AgentNameClaudeCode, attachOptions{Force: true})
 	if err == nil {
 		t.Fatal("expected error for missing transcript")
+	}
+	if !strings.Contains(err.Error(), `transcript not found for agent "claude-code"`) {
+		t.Fatalf("runAttach error = %v, want existing transcript-not-found error", err)
+	}
+}
+
+type failingTranscriptFetcher struct {
+	agent.Agent
+
+	baseDir    string
+	baseDirErr error
+	err        error
+}
+
+func (a *failingTranscriptFetcher) FetchTranscript(context.Context, string) (string, error) {
+	return "", a.err
+}
+
+func (a *failingTranscriptFetcher) GetSessionBaseDir() (string, error) {
+	return a.baseDir, a.baseDirErr
+}
+
+func TestResolveAndValidateTranscript_PreservesFetchFailureAfterFallback(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	baseAgent, err := agent.Get(agent.AgentNameClaudeCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("opencode export timed out")
+	ag := &failingTranscriptFetcher{
+		Agent:      baseAgent,
+		baseDirErr: errors.New("fallback unavailable"),
+		err:        wantErr,
+	}
+
+	_, err = resolveAndValidateTranscript(context.Background(), "test-fetch-failure", ag)
+	if err == nil || err.Error() != wantErr.Error() {
+		t.Fatalf("resolveAndValidateTranscript error = %v, want %q", err, wantErr)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatal("final error does not retain the fetch failure")
+	}
+}
+
+func TestResolveAndValidateTranscript_FallbackWinsAfterFetchFailure(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	const sessionID = "test-fetch-fallback"
+	baseAgent, err := agent.Get(agent.AgentNameClaudeCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseDir := t.TempDir()
+	fallbackDir := filepath.Join(baseDir, "project")
+	if err := os.MkdirAll(fallbackDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	fallbackPath := baseAgent.ResolveSessionFile(fallbackDir, sessionID)
+	if err := os.WriteFile(fallbackPath, []byte("transcript"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ag := &failingTranscriptFetcher{
+		Agent:   baseAgent,
+		baseDir: baseDir,
+		err:     errors.New("fetch failed"),
+	}
+
+	got, err := resolveAndValidateTranscript(context.Background(), sessionID, ag)
+	if err != nil {
+		t.Fatalf("expected fallback transcript to win, got: %v", err)
+	}
+	if got != fallbackPath {
+		t.Fatalf("resolved path = %q, want %q", got, fallbackPath)
+	}
+}
+
+func TestResolveAgentAndTranscript_HidesFailedAutoDetectionAfterFetchFailure(t *testing.T) {
+	setupAttachTestRepo(t)
+	t.Setenv("ENTIRE_TEST_OPENCODE_MOCK_EXPORT", "1")
+	t.Setenv("HOME", t.TempDir())
+
+	var out bytes.Buffer
+	_, _, err := resolveAgentAndTranscript(
+		context.Background(),
+		&out,
+		"test-fetch-failure-autodetect",
+		agent.AgentNameOpenCode,
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "mock export file not found") {
+		t.Fatalf("resolveAgentAndTranscript error = %v, want fetch failure", err)
+	}
+	if strings.Contains(err.Error(), "also tried auto-detecting") {
+		t.Fatalf("error contains noisy auto-detection failure: %v", err)
 	}
 }
 

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -1903,3 +1903,78 @@ func runGitInDir(t *testing.T, dir string, args ...string) {
 		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
 	}
 }
+
+// TestAttach_OpenCodeFetchesTranscriptForUntrackedSession is a regression test
+// for sessions spawned outside a hooked terminal (e.g. by an external session
+// host): no hook ever cached an export under .entire/tmp, and
+// resolveAndValidateTranscript used to give up because PrepareTranscript was
+// only called when the file already existed. OpenCode can materialize the
+// transcript via `opencode export`, so attach now consults the
+// TranscriptFetcher capability before failing.
+func TestAttach_OpenCodeFetchesTranscriptForUntrackedSession(t *testing.T) {
+	setupAttachTestRepo(t)
+	// Mock-export mode: fetchAndCacheExport returns the pre-written file
+	// instead of invoking the opencode CLI.
+	t.Setenv("ENTIRE_TEST_OPENCODE_MOCK_EXPORT", "1")
+
+	sessionID := "test-attach-opencode-untracked"
+	repoRoot := mustGetwd(t)
+	tmpDir := filepath.Join(repoRoot, ".entire", "tmp")
+	if err := os.MkdirAll(tmpDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	export := `{
+  "info": {"id": "test-attach-opencode-untracked", "title": "docs: example"},
+  "messages": [
+    {
+      "info": {"id": "msg_u1", "role": "user", "time": {"created": 1767225600000}},
+      "parts": [{"type": "text", "text": "Update the example doc"}]
+    },
+    {
+      "info": {
+        "id": "msg_a1", "role": "assistant",
+        "providerID": "fireworks-ai", "modelID": "accounts/fireworks/routers/kimi-k3-fast",
+        "time": {"created": 1767225660000, "completed": 1767225700000},
+        "tokens": {"total": 100, "input": 90, "output": 10, "reasoning": 0, "cache": {"write": 0, "read": 0}}
+      },
+      "parts": [
+        {"type": "tool", "tool": "bash", "callID": "bash_0",
+         "state": {"status": "completed", "input": {"command": "git commit -m \"docs: example\""}, "output": "ok"}}
+      ]
+    }
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(tmpDir, sessionID+".json"), []byte(export), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := runAttach(context.Background(), &out, &out, sessionID, agent.AgentNameOpenCode, attachOptions{Force: true})
+	if err != nil {
+		t.Fatalf("runAttach failed: %v", err)
+	}
+
+	store, err := session.NewStateStore(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil {
+		t.Fatal("expected session state to be created")
+		return
+	}
+	if state.LastCheckpointID.IsEmpty() {
+		t.Error("expected LastCheckpointID to be set after attach")
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Attached session") {
+		t.Errorf("expected 'Attached session' in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Created checkpoint") {
+		t.Errorf("expected 'Created checkpoint' in output, got: %s", output)
+	}
+}


### PR DESCRIPTION
Stacked on #1877. Refs #1876.

## Problem

#1877 lets `entire session attach <session-id> --agent opencode` run `opencode export` when Entire does not already have the transcript. If that export fails, the error is written only to debug logs. Attach continues through its fallback paths and can eventually report:

```text
transcript not found for agent "opencode" with session ses_missing; is the session ID correct?
```

That message loses the real failure. A missing OpenCode executable, a timeout, invalid JSON, insufficient permissions, and an OpenCode rejection can all look like an incorrect session ID.

## Change

The attach resolver now remembers an error returned by `TranscriptFetcher` while it tries the existing project-directory fallback. If the fallback finds a transcript, attach succeeds and the fetch error is ignored. If the fallback also fails, attach returns the fetch error instead of replacing it with the generic transcript-not-found message.

The resolver remains agent-agnostic. It does not inspect OpenCode errors or branch on the agent name. Each `TranscriptFetcher` owns the errors produced by its fetch mechanism. OpenCode is currently the only implementation, so its export runner now translates the common failures:

| Failure | Terminal message |
| --- | --- |
| OpenCode is missing | `OpenCode is not installed or is not available in PATH.` |
| Export times out | `OpenCode export timed out after 30s. Try again.` |
| OpenCode rejects the export | `OpenCode could not export session "ses_123": <OpenCode error>` |
| OpenCode cannot be executed | `OpenCode could not be started because of insufficient permissions.` |
| Export contains invalid JSON | `OpenCode returned invalid transcript data for session "ses_123". Try updating OpenCode and running the command again.` |
| Session does not exist | `OpenCode session "ses_missing" was not found. Check the session ID and try again.` |

OpenCode stderr can contain progress output, internal diagnostics, terminal escapes, or sensitive values. Arbitrary stderr is not copied into the terminal error. Only a line beginning with `Error:` is eligible for display. That line is stripped of terminal control sequences, passed through Entire’s redaction, collapsed to one line, and limited to 300 runes. If OpenCode exits without a structured error line, attach reports:

```text
OpenCode could not export session "ses_123".
```

When agent auto-detection also fails, that secondary failure stays in debug logs instead of adding the noisy `(also tried auto-detecting other agents: ...)` suffix. Auto-detection also skips the agent that was resolved from existing session state, rather than relying only on the CLI flag.

## Compatibility

Agents without `TranscriptFetcher` keep their existing explicit-session-ID behavior. A valid fallback transcript still wins after a fetch failure, and cancellation remains distinguishable through error unwrapping.

This PR does not include cache staging, cache-preservation changes, full transcript-shape validation, OpenCode session enumeration, the attach picker, or historical import. Cache integrity and bounded subprocess capture can be reviewed separately without blocking this error-reporting fix.

## Merge order

The preferred path is to include this follow-up in #1877 before that PR merges, so the new fetch capability lands with its user-facing failure handling.

If the changes remain in separate PRs, #1877 must merge first. This draft targets `main` from the start, so no base change is needed afterward. Once #1877 is on `main`, GitHub will remove its shared commit from this PR’s diff.

## Testing

The regression was reproduced on #1877 before the fix: a failed fetch followed by no fallback lost the fetch cause and returned the generic transcript-not-found error.

Focused tests cover fetch failure retention, successful fallback, agents without `TranscriptFetcher`, missing executables, timeouts, permission failures, useful and unstructured stderr, invalid JSON, and failed secondary auto-detection.

`mise run check` passed. This includes formatting, lint with zero issues, race-enabled unit and integration tests, all 59 deterministic Vogon scenarios, and all 4 Roger scenarios.

The current binary was also exercised with real OpenCode inside an isolated temporary Git repository. A nonexistent session produced:

```text
OpenCode could not export session "ses_nonexistent_ux_test": Unexpected error
```

<img width="1104" height="133" alt="Screenshot 2026-08-14 at 5 25 24 PM" src="https://github.com/user-attachments/assets/cd7d1813-baae-40b8-b717-90fb11731755" />

