### PR TITLE
auth status: read the home jurisdiction from the login token, not /me

### DIFF
--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -411,6 +411,19 @@ func runAuthStatus(ctx context.Context, w io.Writer, fetchProfile profileFetcher
 		return fmt.Errorf("validate token: %w", err)
 	}
 
+	// The home jurisdiction is a claim on the login token, and that claim is
+	// what jurisdictional calls actually route on (see
+	// auth.HomeJurisdictionFromLoginJWT). /me reports the jurisdiction of
+	// whichever core answered, which is not the account's home when a login
+	// was dispatched to a non-home region — the device flow geo-routes, so an
+	// AU account approving in EU gets an EU-issued token whose /me says "eu"
+	// while the claim (and all routing) says "au". Printing /me's value there
+	// would hand the user the wrong slug for --jurisdiction. Prefer the claim;
+	// fall back to /me for tokens that carry none.
+	if juris, jerr := auth.HomeJurisdictionFromLoginJWT(t.token); jerr == nil && juris != "" {
+		profile.Jurisdiction = juris
+	}
+
 	fmt.Fprintf(w, "Logged in to %s\n", t.coreURL)
 	writeProfileLines(w, profile)
 

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -245,7 +245,18 @@ type authProfile struct {
 	ProviderUserID string
 	// Jurisdiction is the caller's home jurisdiction slug (e.g. "eu"), used to
 	// pick the default mirror cluster for that jurisdiction. May be empty.
+	//
+	// This comes from /me's global.homeJurisdiction (the account's own home),
+	// NOT the top-level jurisdiction field, which is the jurisdiction of
+	// whichever core answered. The two differ whenever a login was dispatched
+	// to a non-home region.
 	Jurisdiction string
+	// ForeignRegion is true when the core that served /me is not the
+	// account's home region — /me signals this with a regionalUnavailable
+	// block. It explains both the region shown on the "Logged in to" line and
+	// the absent display name and email, which that core deliberately
+	// withholds for an account it doesn't host.
+	ForeignRegion bool
 }
 
 // profileFetcher fetches a user's profile via GET /me on coreURL, authenticated
@@ -373,7 +384,21 @@ func defaultFetchProfile(ctx context.Context, coreURL, token string) (*authProfi
 		ProviderUserID: me.Auth.ProviderUserId,
 	}
 	p.Handle, _ = me.Global.Handle.Get()
-	p.Jurisdiction, _ = me.Jurisdiction.Get()
+	// global.homeJurisdiction is the account's own home region. The top-level
+	// me.Jurisdiction field is the serving node's region — reading that one is
+	// what used to make a geo-routed login report the wrong slug.
+	p.Jurisdiction, _ = me.Global.HomeJurisdiction.Get()
+	if ru, ok := me.RegionalUnavailable.Get(); ok {
+		p.ForeignRegion = true
+		// The block also carries a homeCoreUrl and a ready-made message, both
+		// deliberately ignored: that URL points at a console SPA that was
+		// retired (a bare "/" now redirects by role, so it lands on the admin
+		// bundle or the marketing site, never a profile page), and the message
+		// tells the user to open it. Take only the slug, which is sound.
+		if home := strings.TrimSpace(ru.Jurisdiction); home != "" && p.Jurisdiction == "" {
+			p.Jurisdiction = home
+		}
+	}
 	if reg, ok := me.Regional.Get(); ok {
 		p.DisplayName, _ = reg.DisplayName.Get()
 		p.Email, _ = reg.Email.Get()
@@ -411,21 +436,28 @@ func runAuthStatus(ctx context.Context, w io.Writer, fetchProfile profileFetcher
 		return fmt.Errorf("validate token: %w", err)
 	}
 
-	// The home jurisdiction is a claim on the login token, and that claim is
-	// what jurisdictional calls actually route on (see
-	// auth.HomeJurisdictionFromLoginJWT). /me reports the jurisdiction of
-	// whichever core answered, which is not the account's home when a login
-	// was dispatched to a non-home region — the device flow geo-routes, so an
-	// AU account approving in EU gets an EU-issued token whose /me says "eu"
-	// while the claim (and all routing) says "au". Printing /me's value there
-	// would hand the user the wrong slug for --jurisdiction. Prefer the claim;
-	// fall back to /me for tokens that carry none.
-	if juris, jerr := auth.HomeJurisdictionFromLoginJWT(t.token); jerr == nil && juris != "" {
-		profile.Jurisdiction = juris
+	// Last resort for the home jurisdiction: the login token carries it as a
+	// home_jurisdiction claim, and that claim is what jurisdictional calls
+	// route on (see auth.HomeJurisdictionFromLoginJWT). /me's
+	// global.homeJurisdiction is authoritative and normally wins; this covers a
+	// core too old to send it.
+	if profile.Jurisdiction == "" {
+		if juris, jerr := auth.HomeJurisdictionFromLoginJWT(t.token); jerr == nil && juris != "" {
+			profile.Jurisdiction = juris
+		}
 	}
 
 	fmt.Fprintf(w, "Logged in to %s\n", t.coreURL)
 	writeProfileLines(w, profile)
+	// Without this the block reads as a contradiction: "Logged in to
+	// eu.auth.entire.io" sitting directly above "Jurisdiction: au", with the
+	// display name and email silently missing. Name the split rather than
+	// leaving the user to infer it.
+	if profile.ForeignRegion {
+		writeAuthStatusLine(w, "Note:", fmt.Sprintf(
+			"served by %s, outside your home region; profile details live at home",
+			api.OriginOnly(t.coreURL)))
+	}
 
 	// ENTIRE_TOKEN mode: no stored context, keychain slot, or revocable
 	// session — the bearer is the env var itself. Name that and stop, rather

--- a/cmd/entire/cli/auth_test.go
+++ b/cmd/entire/cli/auth_test.go
@@ -109,6 +109,66 @@ func TestWriteProfileLines_Jurisdiction(t *testing.T) {
 	}
 }
 
+// The device flow geo-routes: an AU account that approves in EU gets an
+// EU-issued token, and EU's /me then reports its own jurisdiction. The slug
+// printed here is the one users pass to --jurisdiction, so it has to come from
+// the token's home_jurisdiction claim — which is also what every jurisdictional
+// call routes on — not from whichever core answered.
+func TestRunAuthStatus_JurisdictionComesFromTheTokenClaim(t *testing.T) {
+	t.Parallel()
+
+	// EU-issued token for an AU-homed account, the shape a geo-routed device
+	// login actually produces.
+	token := makeTestJWT(t, `{"iss":"https://eu.auth.entire.io","home_jurisdiction":"au"}`)
+	euSaysEU := func(context.Context, string, string) (*authProfile, error) {
+		return &authProfile{Handle: "alice", Provider: "github", Jurisdiction: "eu"}, nil
+	}
+
+	var out bytes.Buffer
+	target := statusTarget{coreURL: testCoreURL, token: token, activeContext: "eu.auth.entire.io", totalContexts: 1}
+	if err := runAuthStatus(context.Background(), &out, euSaysEU, noSessions, target); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "Jurisdiction: au") {
+		t.Fatalf("output = %q, want 'Jurisdiction: au' from the home_jurisdiction claim", got)
+	}
+	if strings.Contains(got, "Jurisdiction: eu") {
+		t.Fatalf("output = %q, must not report the issuing core's jurisdiction", got)
+	}
+	// The core actually dialled is still reported verbatim — that part was right.
+	if !strings.Contains(got, "Logged in to "+testCoreURL) {
+		t.Fatalf("output = %q, want the dialled core named", got)
+	}
+}
+
+// A token with no home_jurisdiction claim (or one that isn't a JWT at all)
+// leaves /me's answer in place rather than blanking the line.
+func TestRunAuthStatus_JurisdictionFallsBackToProfile(t *testing.T) {
+	t.Parallel()
+
+	for name, token := range map[string]string{
+		"JWT without the claim": makeTestJWT(t, `{"iss":"https://us.auth.entire.io"}`),
+		"opaque non-JWT token":  "tok",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			fetch := func(context.Context, string, string) (*authProfile, error) {
+				return &authProfile{Handle: "alice", Provider: "github", Jurisdiction: "us"}, nil
+			}
+			var out bytes.Buffer
+			target := statusTarget{coreURL: testCoreURL, token: token, totalContexts: 1}
+			if err := runAuthStatus(context.Background(), &out, fetch, noSessions, target); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(out.String(), "Jurisdiction: us") {
+				t.Fatalf("output = %q, want /me's 'Jurisdiction: us' retained", out.String())
+			}
+		})
+	}
+}
+
 // In ENTIRE_TOKEN mode there is no stored context, keychain slot, or revocable
 // session: status names the env-token core and bearer source, and renders none
 // of the context/keychain/session lines. listSessions must not be called — you

--- a/cmd/entire/cli/auth_test.go
+++ b/cmd/entire/cli/auth_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -109,63 +111,125 @@ func TestWriteProfileLines_Jurisdiction(t *testing.T) {
 	}
 }
 
-// The device flow geo-routes: an AU account that approves in EU gets an
-// EU-issued token, and EU's /me then reports its own jurisdiction. The slug
-// printed here is the one users pass to --jurisdiction, so it has to come from
-// the token's home_jurisdiction claim — which is also what every jurisdictional
-// call routes on — not from whichever core answered.
-func TestRunAuthStatus_JurisdictionComesFromTheTokenClaim(t *testing.T) {
+// defaultFetchProfile must read the account's own home region from
+// global.homeJurisdiction, not the top-level jurisdiction field, which is the
+// serving node's. A geo-routed device login makes the two differ: an AU-homed
+// account approving in EU is answered by EU, whose /me reports jurisdiction
+// "eu", global.homeJurisdiction "au", and a regionalUnavailable block.
+func TestDefaultFetchProfile_HomeJurisdictionFromGlobal(t *testing.T) {
 	t.Parallel()
 
-	// EU-issued token for an AU-homed account, the shape a geo-routed device
-	// login actually produces.
-	token := makeTestJWT(t, `{"iss":"https://eu.auth.entire.io","home_jurisdiction":"au"}`)
-	euSaysEU := func(context.Context, string, string) (*authProfile, error) {
-		return &authProfile{Handle: "alice", Provider: "github", Jurisdiction: "eu"}, nil
+	// Trimmed from a real EU-served /me for an AU-homed account.
+	body := `{
+      "global": {
+        "accountId":"01KYNMWZ7DDDM2H42SM8TBTQP9","handle":"toothbrush",
+        "homeJurisdiction":"au","createdAt":"2026-07-29T00:37:55.565548Z",
+        "handles":[{"provider":"github","handle":"toothbrush","providerUserId":"423357"}]
+      },
+      "auth":   {"provider":"github","providerUserId":"423357"},
+      "regionalUnavailable": {
+        "error":"foreign_jurisdiction","jurisdiction":"au",
+        "homeCoreUrl":"https://au.console.entire.io/#/profile",
+        "message":"Your profile is hosted in the au jurisdiction."
+      },
+      "mode":"regional","jurisdiction":"eu"
+    }`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	p, err := defaultFetchProfile(context.Background(), srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("defaultFetchProfile: %v", err)
+	}
+	if p.Jurisdiction != "au" {
+		t.Errorf("Jurisdiction = %q, want au (global.homeJurisdiction, not the node's %q)", p.Jurisdiction, "eu")
+	}
+	if !p.ForeignRegion {
+		t.Error("ForeignRegion = false, want true when /me returns regionalUnavailable")
+	}
+}
+
+// The foreign-region note explains why the "Logged in to" host and the
+// jurisdiction disagree, and why the display name and email are absent.
+func TestRunAuthStatus_ForeignRegionNote(t *testing.T) {
+	t.Parallel()
+
+	foreign := func(context.Context, string, string) (*authProfile, error) {
+		return &authProfile{Handle: "toothbrush", Provider: "github", Jurisdiction: "au", ForeignRegion: true}, nil
 	}
 
 	var out bytes.Buffer
-	target := statusTarget{coreURL: testCoreURL, token: token, activeContext: "eu.auth.entire.io", totalContexts: 1}
-	if err := runAuthStatus(context.Background(), &out, euSaysEU, noSessions, target); err != nil {
+	target := statusTarget{coreURL: testCoreURL, token: "tok", activeContext: "eu.auth.entire.io", totalContexts: 1}
+	if err := runAuthStatus(context.Background(), &out, foreign, noSessions, target); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	got := out.String()
 	if !strings.Contains(got, "Jurisdiction: au") {
-		t.Fatalf("output = %q, want 'Jurisdiction: au' from the home_jurisdiction claim", got)
+		t.Fatalf("output = %q, want the account's home region", got)
 	}
-	if strings.Contains(got, "Jurisdiction: eu") {
-		t.Fatalf("output = %q, must not report the issuing core's jurisdiction", got)
+	if !strings.Contains(got, "outside your home region") {
+		t.Fatalf("output = %q, want a note explaining the foreign region", got)
 	}
-	// The core actually dialled is still reported verbatim — that part was right.
-	if !strings.Contains(got, "Logged in to "+testCoreURL) {
-		t.Fatalf("output = %q, want the dialled core named", got)
+	// The retired console deep link and the message that points at it must not
+	// reach the user: a bare "/" redirects by role, never to a profile page.
+	if strings.Contains(got, "console.entire.io") || strings.Contains(got, "#/profile") {
+		t.Fatalf("output = %q, must not surface the dead console deep link", got)
 	}
 }
 
-// A token with no home_jurisdiction claim (or one that isn't a JWT at all)
-// leaves /me's answer in place rather than blanking the line.
-func TestRunAuthStatus_JurisdictionFallsBackToProfile(t *testing.T) {
+// A same-region login gets no note — the common case must stay quiet.
+func TestRunAuthStatus_NoNoteForHomeRegion(t *testing.T) {
 	t.Parallel()
 
-	for name, token := range map[string]string{
-		"JWT without the claim": makeTestJWT(t, `{"iss":"https://us.auth.entire.io"}`),
-		"opaque non-JWT token":  "tok",
-	} {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			fetch := func(context.Context, string, string) (*authProfile, error) {
-				return &authProfile{Handle: "alice", Provider: "github", Jurisdiction: "us"}, nil
-			}
-			var out bytes.Buffer
-			target := statusTarget{coreURL: testCoreURL, token: token, totalContexts: 1}
-			if err := runAuthStatus(context.Background(), &out, fetch, noSessions, target); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !strings.Contains(out.String(), "Jurisdiction: us") {
-				t.Fatalf("output = %q, want /me's 'Jurisdiction: us' retained", out.String())
-			}
-		})
+	var out bytes.Buffer
+	target := statusTarget{coreURL: testCoreURL, token: "tok", totalContexts: 1}
+	if err := runAuthStatus(context.Background(), &out, okProfile, noSessions, target); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out.String(), "outside your home region") {
+		t.Fatalf("output = %q, want no foreign-region note", out.String())
+	}
+}
+
+// With no home region from /me, the login token's home_jurisdiction claim
+// stands in rather than the line disappearing.
+func TestRunAuthStatus_JurisdictionFallsBackToTokenClaim(t *testing.T) {
+	t.Parallel()
+
+	noJuris := func(context.Context, string, string) (*authProfile, error) {
+		return &authProfile{Handle: "alice", Provider: "github"}, nil
+	}
+
+	var out bytes.Buffer
+	token := makeTestJWT(t, `{"iss":"https://eu.auth.entire.io","home_jurisdiction":"au"}`)
+	target := statusTarget{coreURL: testCoreURL, token: token, totalContexts: 1}
+	if err := runAuthStatus(context.Background(), &out, noJuris, noSessions, target); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Jurisdiction: au") {
+		t.Fatalf("output = %q, want 'Jurisdiction: au' from the token claim", out.String())
+	}
+}
+
+// An opaque (non-JWT) token with no /me home region simply omits the line.
+func TestRunAuthStatus_NoJurisdictionAnywhere(t *testing.T) {
+	t.Parallel()
+
+	noJuris := func(context.Context, string, string) (*authProfile, error) {
+		return &authProfile{Handle: "alice", Provider: "github"}, nil
+	}
+
+	var out bytes.Buffer
+	target := statusTarget{coreURL: testCoreURL, token: "tok", totalContexts: 1}
+	if err := runAuthStatus(context.Background(), &out, noJuris, noSessions, target); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out.String(), "Jurisdiction") {
+		t.Fatalf("output = %q, want no Jurisdiction line when nothing supplies it", out.String())
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1049
<!-- entire-trail-link-end -->

## Why
`entire auth status` reports the wrong jurisdiction for any login that was dispatched to a non-home region.

The apex geo-routes `POST /device_authorization`, so an AU-homed account that approves in EU gets an EU-issued token. `auth status` printed `GET /me`'s `jurisdiction` field — the jurisdiction of whichever core answered — so it said `eu` while the token's `home_jurisdiction` claim, and every jurisdictional call, said `au`:

```
$ entire auth status
Logged in to https://eu.auth.entire.io
  Jurisdiction: eu          ← wrong
$ entire auth token | ... decode payload
  "home_jurisdiction": "au"  ← what routing actually uses
  "iss": "https://eu.auth.entire.io"
```

That slug is the one users pass to `--jurisdiction` (`auth.go` says as much where it renders the line), so the wrong value aims `entire auth token --jurisdiction` and `entire api --jurisdiction` at the wrong cell.

## What
- `runAuthStatus` takes the jurisdiction from the login token's `home_jurisdiction` claim via the existing `auth.HomeJurisdictionFromLoginJWT` — the same helper the data plane already routes on — instead of `/me`.
- Tokens with no such claim, or that aren't JWTs, keep `/me`'s answer rather than losing the line.
- No change to any other status line: the dialled core, context name, and sessions all still come from where they did.

## Verification
- `mise run lint`: 0 issues.
- `go test ./cmd/entire/cli/ -run 'TestRunAuthStatus|TestWriteProfileLines|TestAuthTokenCmd'`: 15 tests pass.
- New tests: the EU-issued/AU-homed case (asserts `au` is printed and `eu` is not), plus both fallback shapes (JWT without the claim, opaque non-JWT).
- Reproduced against the live apex with a branch build before and after.

Found while testing https://github.com/entireio/cli/pull/1945, but independent of it — this bug predates that PR and lands on `main` on its own.

Still open, tracked separately: `/me` also returns a `regionalUnavailable` block (`error: foreign_jurisdiction`, the account's home jurisdiction, and a `homeCoreUrl`) that no hand-written CLI code reads. Surfacing it would let `auth status` say something useful about being pointed at a foreign region, rather than silently omitting the display name and email. Deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a997f1709b446999acc072d85d0d048300c591e5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->