### PR TITLE
Make an unreachable login server say which context chose it

### DIFF
--- a/cmd/entire/cli/auth/refresh.go
+++ b/cmd/entire/cli/auth/refresh.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -149,14 +150,14 @@ type reauthError struct {
 func (e *reauthError) Error() string { return e.msg }
 func (e *reauthError) Unwrap() error { return e.sentinel }
 
-// contextReauthError maps the two re-auth sentinels a per-context manager can
-// return into a friendly message that names the context and its core (so a
-// multi-core user logs back into the right one — matching the
-// "no auth context, run `entire login`" hint style used by clusterdiscovery),
-// preserving the sentinel for errors.Is. Returns nil when err is neither
-// sentinel, leaving the caller to wrap the residual error in its own terms
-// (refresh vs exchange).
-func contextReauthError(c *contexts.Context, err error) error {
+// contextAuthError maps the per-context auth failures worth rewording into
+// messages that name the context and its core (so a multi-core user logs back
+// into the right one — matching the "no auth context, run `entire login`" hint
+// style used by clusterdiscovery): the two re-auth sentinels a per-context
+// manager can return, preserving the sentinel for errors.Is, and a core we
+// could not reach. Returns nil for everything else, leaving the caller to wrap
+// the residual error in its own terms (refresh vs exchange).
+func contextAuthError(c *contexts.Context, err error) error {
 	coreURL := strings.TrimRight(c.CoreURL, "/")
 	switch {
 	case errors.Is(err, tokenmanager.ErrReauthRequired):
@@ -170,7 +171,51 @@ func contextReauthError(c *contexts.Context, err error) error {
 			sentinel: tokenmanager.ErrNotLoggedIn,
 		}
 	}
-	return nil
+	return contextUnreachableError(c, coreURL, err)
+}
+
+// contextUnreachableError maps a transport-level failure talking to a context's
+// core (connection refused, DNS miss, TLS failure, timeout) into a message that
+// names the context and the host it chose, and offers the two ways out:
+// re-login, or switch to another saved login.
+//
+// This is the stale-context case, and it is the one an unadorned error serves
+// worst: a context left pointing at a local dev core that is no longer
+// listening surfaces as a bare `dial tcp [::1]:8180: connect: connection
+// refused`, naming neither the context that chose that host nor a command that
+// fixes it.
+//
+// Scope: the paths that MINT a token (this refresh, and the STS exchange). A
+// command holding a locally-valid access token makes no call here, so the same
+// dead core surfaces from the request instead — with the host but no context
+// name or hint (see internal/coreapi's transport). Covering that too means
+// carrying the context name on auth.ControlPlaneTarget so the coreapi client
+// can reword its own transport failures next to CoreOrigin().
+//
+// Gated on *url.Error, which the http client returns only for transport-level
+// failures — a 4xx/5xx from the token endpoint is a credential problem, not a
+// reachability one, and keeps its own text. Cancellation and deadline are
+// excluded for the same reason (the user hit Ctrl-C, or an enclosing timeout
+// fired; neither says anything about the core). DNS misses need no separate
+// tier here (cf. isRecapNetworkError in the cli package): reaching the core
+// always goes through http.Client, which wraps a *net.DNSError in a *url.Error
+// too.
+//
+// urlErr.Err is wrapped rather than urlErr itself so the message doesn't repeat
+// the core URL we already name; errors.Is against the syscall/net cause still
+// matches. http.Client always sets it.
+func contextUnreachableError(c *contexts.Context, coreURL string, err error) error {
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	return fmt.Errorf(
+		"cannot reach the login server for %q (%s): %w; run `entire login` to sign in again, or `entire auth use <context>` to switch to another login",
+		c.Name, coreURL, urlErr.Err,
+	)
 }
 
 // RefreshingLoginCredential resolves a context's login JWT and can force a
@@ -204,7 +249,7 @@ func (c *RefreshingLoginCredential) ForceRefresh(ctx context.Context, staleToken
 }
 
 func (c *RefreshingLoginCredential) result(tok string, err error) (string, error) {
-	if mapped := contextReauthError(c.context, err); mapped != nil {
+	if mapped := contextAuthError(c.context, err); mapped != nil {
 		return "", mapped
 	}
 	if err != nil {
@@ -287,7 +332,7 @@ func NewRefreshingResourceProvider(c *contexts.Context, resourceOrigin string, t
 	req := tokenmanager.TokenRequest{Resource: resourceOrigin}
 	return func(ctx context.Context) (string, error) {
 		tok, err := mgr.Token(ctx, req)
-		if mapped := contextReauthError(c, err); mapped != nil {
+		if mapped := contextAuthError(c, err); mapped != nil {
 			return "", mapped
 		}
 		if err != nil {

--- a/cmd/entire/cli/auth/refresh_test.go
+++ b/cmd/entire/cli/auth/refresh_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -204,6 +205,60 @@ func TestNewRefreshingLoginProvider_ExpiredNoRefresh(t *testing.T) {
 	}
 }
 
+// A context pointing at a core that is no longer listening (the stale
+// local-dev-context case) must say which context chose that host and how to get
+// out of it — not just "connection refused" from a port the user has to
+// recognize on their own.
+func TestNewRefreshingLoginProvider_UnreachableCore(t *testing.T) {
+	// A core nobody is listening on: start a server, take its URL, stop it.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	coreURL := srv.URL
+	srv.Close()
+
+	provider := seedExpiredLogin(t, "local", coreURL, nil)
+	_, err := provider(t.Context())
+	if err == nil {
+		t.Fatal("unreachable core: want an error")
+	}
+	got := err.Error()
+	// Phrase, context name and host pinned together, so the host can't satisfy
+	// the assertion by appearing in some unrelated segment.
+	if want := fmt.Sprintf("cannot reach the login server for %q (%s)", "local", coreURL); !strings.Contains(got, want) {
+		t.Errorf("error %q missing %q", got, want)
+	}
+	if !strings.Contains(got, "entire login") || !strings.Contains(got, "entire auth use <context>") {
+		t.Errorf("error %q missing the re-login and switch-login hints", got)
+	}
+	// The transport cause survives for callers matching on it, and the message
+	// doesn't repeat the /oauth/token URL it already names as the login server.
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		t.Errorf("error %v no longer unwraps to ECONNREFUSED", err)
+	}
+	if strings.Contains(got, "/oauth/token") {
+		t.Errorf("error %q repeats the token endpoint URL", got)
+	}
+}
+
+// A token endpoint that answers is a credential problem, not a reachability
+// one: it must keep its own wording rather than being reworded as unreachable.
+func TestNewRefreshingLoginProvider_RejectedRefreshIsNotUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprint(w, `{"error":"invalid_grant","error_description":"refresh token revoked"}`)
+	}))
+	defer srv.Close()
+
+	provider := seedExpiredLogin(t, "alice@core", srv.URL, srv.Client().Transport)
+	_, err := provider(t.Context())
+	if err == nil {
+		t.Fatal("rejected refresh token: want an error")
+	}
+	if strings.Contains(err.Error(), "cannot reach the login server") {
+		t.Errorf("rejected refresh reworded as unreachable: %v", err)
+	}
+}
+
 // The full path: an expired access token is silently re-minted from the
 // stored refresh token, and the rotated refresh token is persisted.
 func TestNewRefreshingLoginProvider_RefreshesAndRotates(t *testing.T) {
@@ -324,6 +379,32 @@ func TestContextTokenStore_SaveTokens_RefreshFirstOrdering(t *testing.T) {
 			t.Fatalf("refresh slot = %q, want entr_new persisted before the access write", r)
 		}
 	})
+}
+
+// seedExpiredLogin points the token store at a throwaway file holding an
+// already-expired login JWT for coreURL plus an "entr_old" refresh token, and
+// returns a login provider for a context named name — i.e. a login that must
+// re-mint on first use, which is what puts the refresh grant on the wire.
+// allowInsecureHTTP is always on: every caller's core is a loopback test server.
+func seedExpiredLogin(t *testing.T, name, coreURL string, transport http.RoundTripper) func(context.Context) (string, error) {
+	t.Helper()
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+
+	svc := tokenstore.CoreKeyringService(coreURL)
+	expired := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, time.Now().Add(-time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "alice", expired+tokenstore.TokenExpirationSeparator+"0"); err != nil {
+		t.Fatalf("seed access token: %v", err)
+	}
+	if err := tokenstore.Set(tokenstore.RefreshService(svc), "alice", "entr_old"); err != nil {
+		t.Fatalf("seed refresh token: %v", err)
+	}
+
+	c := &contexts.Context{Name: name, CoreURL: coreURL, Handle: "alice", KeychainService: svc}
+	provider, err := NewRefreshingLoginProvider(c, transport, true)
+	if err != nil {
+		t.Fatalf("NewRefreshingLoginProvider: %v", err)
+	}
+	return provider
 }
 
 func failRoundTripper(t *testing.T) http.RoundTripper {

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -643,7 +643,13 @@ func renderCoreError(err error) error {
 	if msg := coreapi.APIError(err); msg != "" {
 		return errors.New(msg)
 	}
-	return err
+	// A local/transport failure falls through with its own text, cleaned of the
+	// generated security scaffolding. Redundant for the commands that return
+	// this error to main.go (which cleans it again — harmless, since the strip
+	// leaves the original chain intact to unwrap), and load-bearing for the
+	// mirror-create wizard, which prints renderCoreError's result itself and
+	// returns a SilentError, so main.go never renders it.
+	return RenderUserFacingError(err)
 }
 
 // printJSON writes v as indented JSON to w — the --json view for list/get

--- a/cmd/entire/cli/errors.go
+++ b/cmd/entire/cli/errors.go
@@ -1,5 +1,24 @@
 package cli
 
+import "github.com/entireio/cli/internal/coreapi"
+
+// RenderUserFacingError cleans an error for display: it drops the
+// `security "BearerAuth": security source "BearerAuth":` segments ogen's
+// generated control-plane client wraps every auth failure in, which name the
+// OpenAPI security scheme that failed to resolve and so say nothing a user can
+// act on (see coreapi.StripSecurityWrapping).
+//
+// It exists as a named function because there is more than one place the CLI
+// turns an error into text, and they can't share one: main.go prints the error
+// a command returns, renderCoreError feeds the mirror-create wizard (which
+// prints its own errors and returns a SilentError, so main.go never sees them),
+// and the search TUI captures err.Error() into its model before the command
+// returns nil. Call this at any new site that renders an error for a user
+// rather than adding another strip.
+func RenderUserFacingError(err error) error {
+	return coreapi.StripSecurityWrapping(err)
+}
+
 // SilentError wraps an error to signal that the error message has already been
 // printed to the user. main.go checks for this type to avoid duplicate output.
 type SilentError struct {

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -332,7 +332,7 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 		m.loading = false
 		m.fetchingMore = false
 		if msg.err != nil {
-			m.searchErr = msg.err.Error()
+			m.searchErr = RenderUserFacingError(msg.err).Error()
 			m = m.refreshBrowseContent()
 			return m, nil
 		}
@@ -351,7 +351,7 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 	case searchMoreResultsMsg:
 		m.fetchingMore = false
 		if msg.err != nil {
-			m.searchErr = msg.err.Error()
+			m.searchErr = RenderUserFacingError(msg.err).Error()
 			m = m.refreshBrowseContent()
 			return m, nil
 		}
@@ -393,7 +393,7 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 		}
 		m.codeLoading = false
 		if msg.err != nil {
-			m.codeSearchErr = msg.err.Error()
+			m.codeSearchErr = RenderUserFacingError(msg.err).Error()
 		} else if msg.resp != nil {
 			m.codeResults = msg.resp.Results
 			m.codeStats = msg.resp.Stats

--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -123,7 +123,10 @@ func main() {
 			// deepest matched command, which is the one that failed.
 			showSuggestion(executed, err)
 		default:
-			fmt.Fprintln(rootCmd.OutOrStderr(), err)
+			// The choke point for everything a command returns rather than
+			// prints itself: see cli.RenderUserFacingError for what it strips
+			// and which other render sites exist.
+			fmt.Fprintln(rootCmd.OutOrStderr(), cli.RenderUserFacingError(err))
 		}
 
 		cancel()

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -213,7 +213,14 @@ func (t *crossJurisRoundTripper) send(req *http.Request, body []byte, originalAu
 
 	resp, err := t.base.RoundTrip(req)
 	if err != nil {
-		return nil, fmt.Errorf("cross-juris transport: base round trip: %w", err)
+		// Returned verbatim: http.Client wraps every RoundTripper failure in a
+		// *url.Error that already names the method and URL, so a prefix here
+		// only pads the one line a user sees when a core is unreachable
+		// ("...: cross-juris transport: base round trip: dial tcp ...: connection
+		// refused") without locating the failure any better. The other failure
+		// sites in this file keep their prefixes — they name mechanisms a bare
+		// error wouldn't reveal (body buffering, the 421/401 exchange).
+		return nil, err //nolint:wrapcheck // see above
 	}
 
 	switch resp.StatusCode {

--- a/internal/coreapi/security_wrap.go
+++ b/internal/coreapi/security_wrap.go
@@ -1,0 +1,78 @@
+package coreapi
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+// securityWrapPrefix matches the prefixes ogen's generated client adds to any
+// error a SecuritySource returns: `security "BearerAuth"` around the operation's
+// security resolution (oas_client_gen.go) and `security source "BearerAuth"`
+// around the source call itself (oas_security_gen.go). Both are generated, so
+// neither can be reworded at the source.
+var securityWrapPrefix = regexp.MustCompile(`^security (source )?"[^"]*"$`)
+
+// strippedError renders a message with the generated wrappers removed while
+// still unwrapping to the original chain, so errors.Is/As keep matching
+// whatever the caller was matching before.
+type strippedError struct {
+	msg string
+	err error
+}
+
+func (e *strippedError) Error() string { return e.msg }
+func (e *strippedError) Unwrap() error { return e.err }
+
+// StripSecurityWrapping returns err with ogen's generated security wrappers
+// removed from the rendered message, and err unchanged when it carries none.
+//
+// It exists because those wrappers turn an actionable auth failure into
+// something a user has to read past: an unreachable login server surfaces as
+//
+//	resolve mirror placements: security "BearerAuth": security source "BearerAuth": cannot reach the login server for …
+//
+// where the two middle segments say nothing a user can act on — they name the
+// OpenAPI security scheme that failed to resolve, which is an implementation
+// detail of how the client asks for a token.
+//
+// The segments are peeled structurally rather than by search-and-replace: each
+// link in the chain is decomposed into the prefix its wrapper added plus the
+// message it wrapped, and only a prefix that is itself a generated wrapper is
+// dropped. Identical text appearing inside a message (an API error detail, say)
+// is left alone, because it is not a wrapper prefix. Walking stops at the first
+// link whose message doesn't contain its cause verbatim (a message that was
+// rewritten rather than wrapped, e.g. the per-context re-login errors) — there
+// is nothing further to decompose past that point.
+func StripSecurityWrapping(err error) error {
+	if err == nil {
+		return nil
+	}
+	var kept []string
+	stripped := false
+	cur := err
+	for {
+		inner := errors.Unwrap(cur)
+		if inner == nil {
+			break
+		}
+		// Only a `<segment>: <cause>` wrapper can be recomposed by joining on
+		// ": ". Anything else (an interpolated %w, a bare "%w", a message
+		// rewritten rather than prefixed) isn't decomposable, so stop and render
+		// the rest verbatim.
+		segment, ok := strings.CutSuffix(cur.Error(), ": "+inner.Error())
+		if !ok {
+			break
+		}
+		if securityWrapPrefix.MatchString(segment) {
+			stripped = true
+		} else {
+			kept = append(kept, segment)
+		}
+		cur = inner
+	}
+	if !stripped {
+		return err
+	}
+	return &strippedError{msg: strings.Join(append(kept, cur.Error()), ": "), err: err}
+}

--- a/internal/coreapi/security_wrap_test.go
+++ b/internal/coreapi/security_wrap_test.go
@@ -1,0 +1,104 @@
+package coreapi
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// The reported shape: an unreachable login server, wrapped by the generated
+// client's two security segments, under the command's own context.
+func TestStripSecurityWrapping_RealChain(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("cannot reach the login server for \"local\" (http://localhost:8180): connect: connection refused")
+	err := fmt.Errorf("resolve mirror placements: %w",
+		fmt.Errorf("security %q: %w", "BearerAuth",
+			fmt.Errorf("security source %q: %w", "BearerAuth", cause)))
+
+	stripped := StripSecurityWrapping(err)
+	want := "resolve mirror placements: " + cause.Error()
+	if got := stripped.Error(); got != want {
+		t.Errorf("stripped message:\n got %q\nwant %q", got, want)
+	}
+	// The original chain must survive for errors.Is/As callers.
+	if !errors.Is(stripped, cause) {
+		t.Error("stripped error no longer unwraps to the cause")
+	}
+}
+
+func TestStripSecurityWrapping(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nothing to strip is returned unchanged",
+			err:  fmt.Errorf("list mirrors: %w", sentinel),
+			want: "list mirrors: boom",
+		},
+		{
+			name: "session scheme is stripped too",
+			err:  fmt.Errorf("security %q: %w", "SessionAuth", sentinel),
+			want: "boom",
+		},
+		{
+			name: "the security source form is stripped too",
+			err:  fmt.Errorf("security source %q: %w", "BearerAuth", sentinel),
+			want: "boom",
+		},
+		{
+			// Only a wrapper *prefix* is dropped. The same words inside a
+			// message (an API problem detail, say) are the message, not
+			// scaffolding, so they stay.
+			name: "matching text inside a message is preserved",
+			err:  fmt.Errorf("create org: %w", errors.New(`security "BearerAuth": rejected by policy`)),
+			want: `create org: security "BearerAuth": rejected by policy`,
+		},
+		{
+			// A message rewritten rather than prefixed (the per-context
+			// re-login errors) stops the walk: outer segments already peeled
+			// are still dropped, the rest renders verbatim.
+			name: "walk stops at a rewritten message",
+			err: fmt.Errorf("security %q: %w", "BearerAuth",
+				&rewrittenError{msg: "login session expired; run `entire login`", err: sentinel}),
+			want: "login session expired; run `entire login`",
+		},
+		{
+			name: "empty scheme name still matches",
+			err:  fmt.Errorf("security %q: %w", "", sentinel),
+			want: "boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := StripSecurityWrapping(tt.err).Error(); got != tt.want {
+				t.Errorf("stripped message:\n got %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripSecurityWrapping_Nil(t *testing.T) {
+	t.Parallel()
+	if err := StripSecurityWrapping(nil); err != nil {
+		t.Errorf("StripSecurityWrapping(nil) = %v, want nil", err)
+	}
+}
+
+// An error whose message replaces its cause's rather than prefixing it — the
+// shape auth's per-context re-login errors use.
+type rewrittenError struct {
+	msg string
+	err error
+}
+
+func (e *rewrittenError) Error() string { return e.msg }
+func (e *rewrittenError) Unwrap() error { return e.err }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1050
<!-- entire-trail-link-end -->

## Why

`entire repo clone` against a stale login context failed like this:

```
resolve mirror placements: security “BearerAuth”: security source “BearerAuth”: refresh login token: refresh token: Post “https://localhost:8180/oauth/token”: dial tcp [::1]:8180: connect: connection refused
```

`entire login` fixed it, but nothing in the message says which login context picked `localhost:8180`, and two of the five segments name an OpenAPI security scheme rather than anything a user can act on. Reproduced verbatim on `main` before changing anything.

Same command now:

```
resolve mirror placements: cannot reach the login server for "local" (https://localhost:8180): dial tcp [::1]:8180: connect: connection refused; run `entire login` to sign in again, or `entire auth use <context>` to switch to another login
```

## What changed

Three commits, each independent:

1. **`refactor(coreapi)`** — stop double-wrapping transport failures. `http.Client` already wraps RoundTripper errors in a `*url.Error` naming method and URL, so `cross-juris transport: base round trip:` located nothing.
2. **`fix(auth)`** — a transport-level failure reaching a context's core now names the context, the host it chose, and the two ways out. `contextReauthError` becomes `contextAuthError` and ends with the new mapper, so the login-JWT path and the STS exchange path share it. Gated on `*url.Error` so an answered 4xx from the token endpoint keeps its own credential-problem wording, and cancellation/deadline aren't reworded as an unreachable core.
3. **`fix(errors)`** — strip ogen's `security "BearerAuth": security source "BearerAuth":` segments. Peeled structurally (each link decomposed into wrapper prefix + wrapped message; only a prefix that *is* a generated wrapper is dropped), so identical text inside an API problem detail survives and the error still unwraps to the original chain. Applied through one named `cli.RenderUserFacingError`.

## Notes for review

- **Why not fix the noise at generation time:** the wording is hard-wired in ogen's embedded templates behind an unexported loader — no `--templates` flag, no config option, no feature toggle. Render-time is the only lever.
- **Three render sites, not one.** main.go covers what a command returns; `renderCoreError` is load-bearing for the mirror-create wizard (prints its own error, returns a `SilentError`, so main.go never sees it); the search TUI captures `err.Error()` into its model before the command returns nil — so `entire search` showed the raw chain even with main.go covered. That third site was found in review, not in the original fix.
- **Known gap, documented not fixed:** the message covers the paths that *mint* a token. A command holding a locally-valid access token makes no call there, so the same dead core still surfaces from the request with the host but no context name. The deeper fix — carry the context name on `auth.ControlPlaneTarget` so the coreapi client can reword its own transport failures next to `CoreOrigin()` — is a new field plus a RoundTripper plus a fallback label for `ENTIRE_TOKEN` clients, so it's called out in the doc comment rather than smuggled in here.
- **Deliberately not deduplicated:** the `*url.Error` gate overlaps `isRecapNetworkError` (`recap_errors.go:69`), but `auth` can't import `cli` and `coreapi` imports `auth`, so sharing it needs a new leaf package for six lines. Cross-referenced in a comment instead, including why no separate DNS tier is needed (`http.Client` wraps `*net.DNSError` in a `*url.Error` too).

## Testing

- New: unreachable core names context/host/both hints and still unwraps to `ECONNREFUSED`; an `invalid_grant` response is *not* reworded as unreachable; table over the peeler covering the real chain, passthrough, both schemes, and "matching text inside a message is preserved".
- `mise run fmt && mise run lint` clean; `mise run test:ci` green including the canary (56 + 4).
- Verified end to end with the real binary against a dead core (isolated `ENTIRE_CONFIG_DIR` + file token store), for both the expired-token and live-token paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a1d71fd8c987faa7ab26cc576a708edf1974ac78. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->