### PR TITLE
fix(factoryai-droid): attribute Worker sessions to their parent task

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -451,6 +451,51 @@ type SessionBaseDirProvider interface {
 	GetSessionBaseDir() (string, error)
 }
 
+// SubagentSessionLink identifies the parent task invocation that spawned a
+// subagent session. It is resolved from the subagent's own transcript, so it
+// stays valid regardless of when the parent's tool hooks fire.
+type SubagentSessionLink struct {
+	// ParentSessionID is the session that invoked the task tool.
+	ParentSessionID string
+
+	// ToolUseID is the parent's tool-use ID for this invocation. It keys the
+	// task checkpoint's metadata directory, so it must be stable across hooks.
+	ToolUseID string
+
+	// ParentTranscriptPath locates the parent session's transcript, which the
+	// task checkpoint stores alongside the subagent's own. Empty when the agent
+	// cannot resolve it; the checkpoint is then written without it.
+	ParentTranscriptPath string
+
+	// SubagentType is the kind of subagent (e.g. "worker"); may be empty.
+	SubagentType string
+
+	// TaskDescription is a short human-readable task label; may be empty.
+	TaskDescription string
+}
+
+// SubagentSessionResolver is implemented by agents that run subagents as
+// full sessions of their own — with their own SessionStart/UserPromptSubmit/Stop
+// hooks — rather than as a blocking tool call inside the parent's turn.
+//
+// For such agents the parent's post-tool hook cannot delimit the subagent's
+// work: it fires when the task is *dispatched*, not when it completes, so the
+// worktree is still untouched at that point. Turn-end consults this instead, to
+// recognize a subagent session and attribute its work to the parent as a task
+// checkpoint rather than minting an unrelated top-level session checkpoint.
+//
+// Agents whose subagents block the parent turn (Claude Code's Task tool) must
+// NOT implement this — their SubagentEnd path already bounds the work correctly.
+type SubagentSessionResolver interface {
+	Agent
+
+	// ResolveSubagentSession reports whether the session behind sessionRef was
+	// spawned by a parent task invocation, and if so identifies the parent.
+	// Returns false for ordinary top-level sessions and whenever the link
+	// cannot be read — callers treat a failure as "not a subagent session".
+	ResolveSubagentSession(sessionRef string) (SubagentSessionLink, bool)
+}
+
 // SubagentAwareExtractor provides methods for extracting files and tokens including subagents.
 // Agents that support spawning subagents (like Claude Code's Task tool) should implement this
 // to ensure subagent contributions are included in checkpoints.

--- a/cmd/entire/cli/agent/capabilities.go
+++ b/cmd/entire/cli/agent/capabilities.go
@@ -183,6 +183,15 @@ func AsSubagentAwareExtractor(ag Agent) (SubagentAwareExtractor, bool) {
 	return declaredCapability[SubagentAwareExtractor](ag, func(c DeclaredCaps) bool { return c.SubagentAwareExtractor })
 }
 
+// AsSubagentSessionResolver returns the agent as SubagentSessionResolver if it
+// implements the interface. No capability declaration is needed: whether an
+// agent's subagents run as sessions of their own is a property of the agent's
+// own hook protocol, which only built-in agents model. External agents report
+// subagent boundaries through their own hooks.
+func AsSubagentSessionResolver(ag Agent) (SubagentSessionResolver, bool) {
+	return builtinCapability[SubagentSessionResolver](ag)
+}
+
 // AsSessionBaseDirProvider returns the agent as SessionBaseDirProvider if it implements
 // the interface. No capability declaration is needed since this is a built-in-only feature
 // (external agents use the agent binary's own session resolution).

--- a/cmd/entire/cli/agent/factoryaidroid/lifecycle.go
+++ b/cmd/entire/cli/agent/factoryaidroid/lifecycle.go
@@ -17,11 +17,12 @@ import (
 
 // Compile-time interface assertions.
 var (
-	_ agent.TranscriptAnalyzer     = (*FactoryAIDroidAgent)(nil)
-	_ agent.TokenCalculator        = (*FactoryAIDroidAgent)(nil)
-	_ agent.SubagentAwareExtractor = (*FactoryAIDroidAgent)(nil)
-	_ agent.HookResponseWriter     = (*FactoryAIDroidAgent)(nil)
-	_ agent.PromptExtractor        = (*FactoryAIDroidAgent)(nil)
+	_ agent.TranscriptAnalyzer      = (*FactoryAIDroidAgent)(nil)
+	_ agent.TokenCalculator         = (*FactoryAIDroidAgent)(nil)
+	_ agent.SubagentAwareExtractor  = (*FactoryAIDroidAgent)(nil)
+	_ agent.SubagentSessionResolver = (*FactoryAIDroidAgent)(nil)
+	_ agent.HookResponseWriter      = (*FactoryAIDroidAgent)(nil)
+	_ agent.PromptExtractor         = (*FactoryAIDroidAgent)(nil)
 )
 
 // WriteHookResponse outputs the hook response as plain text to stdout.

--- a/cmd/entire/cli/agent/factoryaidroid/subagent_session.go
+++ b/cmd/entire/cli/agent/factoryaidroid/subagent_session.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/validation"
 )
 
 // droidSessionStart is the first line of a Droid session transcript. A session
@@ -49,6 +50,17 @@ func (f *FactoryAIDroidAgent) ResolveSubagentSession(sessionRef string) (agent.S
 		return agent.SubagentSessionLink{}, false
 	}
 
+	// Both IDs become path segments — of the sibling transcript we stat below and
+	// of the checkpoint's metadata directory. Validate before either is joined
+	// into a path: the transcript is a file on disk, so its contents are an
+	// untrusted input even though Droid is the one that writes it.
+	if err := validation.ValidateAgentSessionID(start.CallingSessionID); err != nil {
+		return agent.SubagentSessionLink{}, false
+	}
+	if err := validation.ValidateToolUseID(start.CallingToolUseID); err != nil {
+		return agent.SubagentSessionLink{}, false
+	}
+
 	subagentType, description := parseDroidSessionTitle(start.SessionTitle)
 	return agent.SubagentSessionLink{
 		ParentSessionID:      start.CallingSessionID,
@@ -62,8 +74,11 @@ func (f *FactoryAIDroidAgent) ResolveSubagentSession(sessionRef string) (agent.S
 // droidSiblingTranscriptPath locates another session's transcript. Droid keeps
 // every session for a working directory as <session-id>.jsonl in one directory,
 // so a Worker's parent is always its sibling. Returns "" when absent.
+//
+// Callers must validate sessionID first; the guard here is belt-and-braces so
+// the function cannot be repurposed into statting an arbitrary path.
 func droidSiblingTranscriptPath(sessionRef, sessionID string) string {
-	if sessionID == "" {
+	if validation.ValidateAgentSessionID(sessionID) != nil {
 		return ""
 	}
 	path := filepath.Join(filepath.Dir(sessionRef), sessionID+".jsonl")

--- a/cmd/entire/cli/agent/factoryaidroid/subagent_session.go
+++ b/cmd/entire/cli/agent/factoryaidroid/subagent_session.go
@@ -1,0 +1,123 @@
+package factoryaidroid
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// droidSessionStart is the first line of a Droid session transcript. A session
+// spawned by the Task tool records the invoking session and tool-use ID here;
+// a top-level session leaves both empty.
+type droidSessionStart struct {
+	Type             string `json:"type"`
+	CallingSessionID string `json:"callingSessionId"`
+	CallingToolUseID string `json:"callingToolUseId"`
+	SessionTitle     string `json:"sessionTitle"`
+}
+
+// sessionStartScanLimit bounds how far into a transcript we look for the
+// session_start entry. Droid writes it first; the allowance only covers a
+// future format that prepends a line or two, and keeps a large rollout from
+// being read end-to-end on every turn.
+const sessionStartScanLimit = 8
+
+// ResolveSubagentSession reports whether this transcript belongs to a Worker
+// session spawned by a parent task invocation.
+//
+// Droid runs Workers as detached sessions: the parent's PostToolUse hook fires
+// when the Worker is dispatched, before it has touched the worktree, so only
+// the Worker's own session boundary can delimit its work. Its transcript's
+// session_start line carries callingSessionId/callingToolUseId, which survives
+// independently of hook ordering and of the synthetic tool-use IDs the CLI mints
+// when Droid's tool hooks omit one.
+func (f *FactoryAIDroidAgent) ResolveSubagentSession(sessionRef string) (agent.SubagentSessionLink, bool) {
+	start, ok := readDroidSessionStart(sessionRef)
+	if !ok {
+		return agent.SubagentSessionLink{}, false
+	}
+
+	// Both IDs are required: the parent session names the metadata directory and
+	// the tool-use ID names the task within it. A half-populated link would
+	// attribute the work to the wrong place, so treat it as a top-level session.
+	if start.CallingSessionID == "" || start.CallingToolUseID == "" {
+		return agent.SubagentSessionLink{}, false
+	}
+
+	subagentType, description := parseDroidSessionTitle(start.SessionTitle)
+	return agent.SubagentSessionLink{
+		ParentSessionID:      start.CallingSessionID,
+		ToolUseID:            start.CallingToolUseID,
+		ParentTranscriptPath: droidSiblingTranscriptPath(sessionRef, start.CallingSessionID),
+		SubagentType:         subagentType,
+		TaskDescription:      description,
+	}, true
+}
+
+// droidSiblingTranscriptPath locates another session's transcript. Droid keeps
+// every session for a working directory as <session-id>.jsonl in one directory,
+// so a Worker's parent is always its sibling. Returns "" when absent.
+func droidSiblingTranscriptPath(sessionRef, sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	path := filepath.Join(filepath.Dir(sessionRef), sessionID+".jsonl")
+	if info, err := os.Stat(path); err != nil || info.IsDir() {
+		return ""
+	}
+	return path
+}
+
+// readDroidSessionStart returns the session_start entry from a Droid transcript.
+func readDroidSessionStart(path string) (droidSessionStart, bool) {
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return droidSessionStart{}, false
+	}
+	defer func() { _ = file.Close() }()
+
+	// ReadBytes rather than bufio.Scanner: session_start embeds the full task
+	// prompt in its title, which routinely exceeds Scanner's default line cap.
+	reader := bufio.NewReader(file)
+	for range sessionStartScanLimit {
+		lineBytes, err := reader.ReadBytes('\n')
+		if len(lineBytes) > 0 {
+			var start droidSessionStart
+			if jsonErr := json.Unmarshal(bytes.TrimSpace(lineBytes), &start); jsonErr == nil &&
+				start.Type == "session_start" {
+				return start, true
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	return droidSessionStart{}, false
+}
+
+// parseDroidSessionTitle splits a Worker session title into subagent type and
+// task description. Droid formats it as "<type>: <description>"; anything else
+// is returned as a bare description.
+func parseDroidSessionTitle(title string) (subagentType, description string) {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return "", ""
+	}
+	prefix, rest, found := strings.Cut(title, ":")
+	if !found {
+		return "", title
+	}
+	prefix = strings.TrimSpace(prefix)
+	rest = strings.TrimSpace(rest)
+	// A colon inside a plain sentence is not a type prefix; require a short,
+	// single-token prefix ("worker", "reviewer") to read it as one.
+	if prefix == "" || rest == "" || strings.ContainsAny(prefix, " \t") {
+		return "", title
+	}
+	return prefix, rest
+}

--- a/cmd/entire/cli/agent/factoryaidroid/subagent_session_test.go
+++ b/cmd/entire/cli/agent/factoryaidroid/subagent_session_test.go
@@ -1,6 +1,7 @@
 package factoryaidroid
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,6 +79,45 @@ func TestResolveSubagentSession_RejectsPartialLink(t *testing.T) {
 			_, ok := (&FactoryAIDroidAgent{}).ResolveSubagentSession(path)
 
 			assert.False(t, ok)
+		})
+	}
+}
+
+func TestResolveSubagentSession_RejectsPathUnsafeIDs(t *testing.T) {
+	t.Parallel()
+
+	// Both IDs become path segments of the checkpoint's metadata directory, and
+	// the parent ID also names a file we stat. A transcript is a file on disk, so
+	// treat its contents as untrusted and fail closed rather than traversing.
+	tests := map[string]struct{ parent, toolUse string }{
+		"parent traverses":        {"../../etc", "toolu_1"},
+		"parent has separator":    {"a/b", "toolu_1"},
+		"parent is dot dot":       {"..", "toolu_1"},
+		"parent has glob":         {"sess*", "toolu_1"},
+		"parent has volume":       {"C:sess", "toolu_1"},
+		"parent starts with dash": {"-sess", "toolu_1"},
+		"tool use traverses":      {"parent-1", "../../etc"},
+		"tool use has separator":  {"parent-1", "a/b"},
+		"tool use has glob":       {"parent-1", "toolu_*"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			line, err := json.Marshal(map[string]any{
+				"type":             "session_start",
+				"id":               "w",
+				"sessionTitle":     "worker: x",
+				"callingSessionId": tt.parent,
+				"callingToolUseId": tt.toolUse,
+			})
+			require.NoError(t, err)
+			path := writeTranscript(t, dir, "w", string(line), messageLine)
+
+			_, ok := (&FactoryAIDroidAgent{}).ResolveSubagentSession(path)
+
+			assert.False(t, ok, "a path-unsafe ID must not produce a subagent link")
 		})
 	}
 }

--- a/cmd/entire/cli/agent/factoryaidroid/subagent_session_test.go
+++ b/cmd/entire/cli/agent/factoryaidroid/subagent_session_test.go
@@ -1,0 +1,150 @@
+package factoryaidroid
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// workerSessionStart is a verbatim session_start line from a Droid Worker
+// transcript. Droid records the invoking session and tool-use ID here, which is
+// the only subagent boundary that survives its detached Worker dispatch.
+const workerSessionStart = `{"type":"session_start","id":"30b34828-e462-45c9-b63c-bfefb6bd178f","title":"# Task Tool Invocation Subagent type: worker Task description: Create red.md and commit ## Context You are a specialized subagent invoked by another a...","sessionTitle":"worker: Create red.md and commit","isSessionTitleManuallySet":true,"owner":"soph","callingSessionId":"0b34cbcb-108c-4800-b68e-af7093c8cae9","callingToolUseId":"toolu_01SC9sRHSef1vtNFtMrX9w6T","version":2,"cwd":"/tmp/e2e-repo-948994727"}`
+
+// topLevelSessionStart is a verbatim session_start line from the parent session
+// that spawned the Worker above. It carries no calling IDs.
+const topLevelSessionStart = `{"type":"session_start","id":"0b34cbcb-108c-4800-b68e-af7093c8cae9","title":"use a subagent: create a markdown file at docs/red.md","sessionTitle":"use a subagent: create a markdown file at docs/red.md","owner":"soph","version":2,"cwd":"/tmp/e2e-repo-948994727"}`
+
+const messageLine = `{"type":"message","id":"a7727545-a952-4c56-b581-db72279007c7","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}`
+
+// writeTranscript writes a transcript into dir and returns its path.
+func writeTranscript(t *testing.T, dir, sessionID string, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(dir, sessionID+".jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600))
+	return path
+}
+
+func TestResolveSubagentSession_WorkerSessionLinksToParent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	parent := writeTranscript(t, dir, "0b34cbcb-108c-4800-b68e-af7093c8cae9", topLevelSessionStart, messageLine)
+	worker := writeTranscript(t, dir, "30b34828-e462-45c9-b63c-bfefb6bd178f", workerSessionStart, messageLine)
+
+	link, ok := (&FactoryAIDroidAgent{}).ResolveSubagentSession(worker)
+
+	require.True(t, ok, "a Worker session must be recognized as a subagent session")
+	assert.Equal(t, "0b34cbcb-108c-4800-b68e-af7093c8cae9", link.ParentSessionID)
+	assert.Equal(t, "toolu_01SC9sRHSef1vtNFtMrX9w6T", link.ToolUseID)
+	assert.Equal(t, parent, link.ParentTranscriptPath)
+	assert.Equal(t, "worker", link.SubagentType)
+	assert.Equal(t, "Create red.md and commit", link.TaskDescription)
+}
+
+func TestResolveSubagentSession_TopLevelSessionIsNotSubagent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	parent := writeTranscript(t, dir, "0b34cbcb-108c-4800-b68e-af7093c8cae9", topLevelSessionStart, messageLine)
+
+	_, ok := (&FactoryAIDroidAgent{}).ResolveSubagentSession(parent)
+
+	assert.False(t, ok, "a session with no calling IDs is a top-level session")
+}
+
+func TestResolveSubagentSession_RejectsPartialLink(t *testing.T) {
+	t.Parallel()
+
+	// A link naming a parent session but no tool use (or vice versa) cannot key
+	// a task checkpoint; attributing it anyway would file the work in the wrong
+	// place, so it must fall back to the top-level session path.
+	tests := map[string]string{
+		"missing tool use id":    `{"type":"session_start","id":"w","callingSessionId":"p","sessionTitle":"worker: x"}`,
+		"missing parent id":      `{"type":"session_start","id":"w","callingToolUseId":"toolu_1","sessionTitle":"worker: x"}`,
+		"both present but empty": `{"type":"session_start","id":"w","callingSessionId":"","callingToolUseId":"","sessionTitle":"worker: x"}`,
+	}
+
+	for name, line := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			path := writeTranscript(t, dir, "w", line, messageLine)
+
+			_, ok := (&FactoryAIDroidAgent{}).ResolveSubagentSession(path)
+
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestResolveSubagentSession_MissingParentTranscriptStillLinks(t *testing.T) {
+	t.Parallel()
+
+	// The parent transcript is optional context for the checkpoint. Losing it
+	// must not cost us the attribution itself.
+	dir := t.TempDir()
+	worker := writeTranscript(t, dir, "30b34828-e462-45c9-b63c-bfefb6bd178f", workerSessionStart, messageLine)
+
+	link, ok := (&FactoryAIDroidAgent{}).ResolveSubagentSession(worker)
+
+	require.True(t, ok)
+	assert.Equal(t, "0b34cbcb-108c-4800-b68e-af7093c8cae9", link.ParentSessionID)
+	assert.Empty(t, link.ParentTranscriptPath)
+}
+
+func TestResolveSubagentSession_LongTitleLineIsParsed(t *testing.T) {
+	t.Parallel()
+
+	// Droid embeds the whole task prompt in `title`, which routinely exceeds
+	// bufio.Scanner's default 64KB line cap. Reading must not depend on it.
+	dir := t.TempDir()
+	huge := strings.Repeat("x", 300*1024)
+	line := `{"type":"session_start","id":"w","title":"` + huge +
+		`","sessionTitle":"worker: big","callingSessionId":"p","callingToolUseId":"toolu_big"}`
+	worker := writeTranscript(t, dir, "w", line, messageLine)
+
+	link, ok := (&FactoryAIDroidAgent{}).ResolveSubagentSession(worker)
+
+	require.True(t, ok, "a multi-hundred-KB session_start line must still parse")
+	assert.Equal(t, "p", link.ParentSessionID)
+	assert.Equal(t, "toolu_big", link.ToolUseID)
+}
+
+func TestResolveSubagentSession_MissingTranscript(t *testing.T) {
+	t.Parallel()
+
+	_, ok := (&FactoryAIDroidAgent{}).ResolveSubagentSession(filepath.Join(t.TempDir(), "absent.jsonl"))
+
+	assert.False(t, ok, "an unreadable transcript must not be treated as a subagent session")
+}
+
+func TestParseDroidSessionTitle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		title           string
+		wantType        string
+		wantDescription string
+	}{
+		{"type and description", "worker: Create red.md", "worker", "Create red.md"},
+		{"empty title", "", "", ""},
+		{"no separator", "Create red.md", "", "Create red.md"},
+		{"sentence with colon is not a type", "fix the bug: it crashes", "", "fix the bug: it crashes"},
+		{"empty description", "worker:", "", "worker:"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotType, gotDescription := parseDroidSessionTitle(tt.title)
+			assert.Equal(t, tt.wantType, gotType)
+			assert.Equal(t, tt.wantDescription, gotDescription)
+		})
+	}
+}

--- a/cmd/entire/cli/integration_test/factoryai_worker_session_test.go
+++ b/cmd/entire/cli/integration_test/factoryai_worker_session_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// Factory AI Droid dispatches Workers as detached sessions: the parent's
+// PostToolUse hook fires when the Worker is launched, before it has touched the
+// worktree, and the Worker then runs its own SessionStart/UserPromptSubmit/Stop
+// cycle. These tests pin the resulting attribution — a Worker's turn must land
+// as a task checkpoint on the parent, not as an unrelated top-level session.
+
+// TestFactoryDroidWorkerSessionBecomesTaskCheckpoint covers the regression that
+// broke TestFactoryTaskCheckpointExistsBeforeCommit: a Worker's work reached the
+// shadow branch, but under its own session ID, so no task checkpoint existed.
+func TestFactoryDroidWorkerSessionBecomesTaskCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	env := NewTestEnv(t)
+	env.InitRepo()
+	env.InitEntire()
+	env.WriteFile(".gitignore", ".entire/\n")
+	env.WriteFile("README.md", "# Test Repository")
+	env.GitAdd(".gitignore")
+	env.GitAdd("README.md")
+	env.GitCommit("Initial commit")
+
+	// The parent turn: the user asks for a Worker, and Droid dispatches one.
+	parent := env.NewFactoryDroidSession()
+	parent.CreateDroidTranscript("Run a Worker that writes docs/summary.md", nil)
+	if err := env.SimulateFactoryDroidUserPromptSubmit(parent.ID); err != nil {
+		t.Fatalf("parent UserPromptSubmit failed: %v", err)
+	}
+
+	// The Worker turn: its own session, writing the file the parent asked for.
+	const toolUseID = "toolu_worker_01"
+	worker := env.NewFactoryDroidSession()
+	if err := env.SimulateFactoryDroidUserPromptSubmit(worker.ID); err != nil {
+		t.Fatalf("worker UserPromptSubmit failed: %v", err)
+	}
+	env.WriteFile("docs/summary.md", "A short summary.\n")
+	worker.CreateDroidTranscript("# Task Tool Invocation", []FileChange{
+		{Path: "docs/summary.md", Content: "A short summary.\n"},
+	})
+	worker.MarkAsWorkerSession(parent.ID, toolUseID, "worker: Summarize the repo")
+
+	if err := env.SimulateFactoryDroidStop(worker.ID, worker.TranscriptPath); err != nil {
+		t.Fatalf("worker Stop failed: %v", err)
+	}
+
+	shadowBranch := env.GetShadowBranchName()
+	if !env.BranchExists(shadowBranch) {
+		t.Fatalf("shadow branch %s should exist after the Worker's turn", shadowBranch)
+	}
+
+	// The work belongs to the parent's task, not to the Worker's own session.
+	taskCheckpoint := ".entire/metadata/" + parent.ID + "/tasks/" + toolUseID + "/" + paths.CheckpointFileName
+	if !env.FileExistsInBranch(shadowBranch, taskCheckpoint) {
+		t.Errorf("expected task checkpoint %s on shadow branch %s", taskCheckpoint, shadowBranch)
+	}
+
+	// A top-level checkpoint for the Worker session would misattribute the work
+	// to a session the user never drove — the exact shape of the regression.
+	// A session checkpoint is what writes the session's own transcript.
+	workerSessionCheckpoint := ".entire/metadata/" + worker.ID + "/" + paths.TranscriptFileName
+	if env.FileExistsInBranch(shadowBranch, workerSessionCheckpoint) {
+		t.Errorf("Worker session must not produce its own session checkpoint at %s", workerSessionCheckpoint)
+	}
+
+	// The parent's transcript rides along, so the task reads back in context.
+	parentTranscript := ".entire/metadata/" + parent.ID + "/" + paths.TranscriptFileName
+	if !env.FileExistsInBranch(shadowBranch, parentTranscript) {
+		t.Errorf("expected the parent transcript at %s", parentTranscript)
+	}
+
+	// The Worker's transcript is preserved under the task, keyed by its session ID.
+	workerTranscript := ".entire/metadata/" + parent.ID + "/tasks/" + toolUseID + "/" +
+		paths.AgentTranscriptFileName(worker.ID)
+	if !env.FileExistsInBranch(shadowBranch, workerTranscript) {
+		t.Errorf("expected the Worker transcript at %s", workerTranscript)
+	}
+}
+
+// TestFactoryDroidTopLevelSessionStillCheckpoints guards the fallback: an
+// ordinary Droid session has no calling IDs and must keep its own checkpoint.
+func TestFactoryDroidTopLevelSessionStillCheckpoints(t *testing.T) {
+	t.Parallel()
+
+	env := NewTestEnv(t)
+	env.InitRepo()
+	env.InitEntire()
+	env.WriteFile(".gitignore", ".entire/\n")
+	env.WriteFile("README.md", "# Test Repository")
+	env.GitAdd(".gitignore")
+	env.GitAdd("README.md")
+	env.GitCommit("Initial commit")
+
+	session := env.NewFactoryDroidSession()
+	if err := env.SimulateFactoryDroidUserPromptSubmit(session.ID); err != nil {
+		t.Fatalf("UserPromptSubmit failed: %v", err)
+	}
+	env.WriteFile("feature.go", "package main\n")
+	session.CreateDroidTranscript("Add a feature", []FileChange{
+		{Path: "feature.go", Content: "package main\n"},
+	})
+
+	if err := env.SimulateFactoryDroidStop(session.ID, session.TranscriptPath); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+
+	shadowBranch := env.GetShadowBranchName()
+	sessionCheckpoint := ".entire/metadata/" + session.ID + "/" + paths.TranscriptFileName
+	if !env.FileExistsInBranch(shadowBranch, sessionCheckpoint) {
+		t.Errorf("expected an ordinary session checkpoint at %s", sessionCheckpoint)
+	}
+
+	// It must not be diverted into a task checkpoint under some other session.
+	if env.FileExistsInBranch(shadowBranch, ".entire/metadata/"+session.ID+"/tasks") {
+		t.Errorf("a top-level session must not be recorded as a task")
+	}
+}

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -849,6 +849,39 @@ func (s *FactoryDroidSession) CreateDroidTranscript(prompt string, changes []Fil
 	}
 }
 
+// MarkAsWorkerSession prepends the session_start entry Droid writes at the head
+// of a Worker transcript, naming the session and tool use that spawned it.
+// Droid dispatches Workers as detached sessions, so this line is what ties the
+// Worker's work back to its parent turn.
+//
+// Call after CreateDroidTranscript — it rewrites the file in place.
+func (s *FactoryDroidSession) MarkAsWorkerSession(parentSessionID, toolUseID, sessionTitle string) {
+	s.env.T.Helper()
+
+	existing, err := os.ReadFile(s.TranscriptPath)
+	if err != nil {
+		s.env.T.Fatalf("failed to read transcript to mark as worker: %v", err)
+	}
+
+	sessionStart, err := json.Marshal(map[string]interface{}{
+		"type":             "session_start",
+		"id":               s.ID,
+		"title":            "# Task Tool Invocation Subagent type: worker",
+		"sessionTitle":     sessionTitle,
+		"callingSessionId": parentSessionID,
+		"callingToolUseId": toolUseID,
+		"version":          2,
+	})
+	if err != nil {
+		s.env.T.Fatalf("failed to encode session_start: %v", err)
+	}
+
+	updated := append(append(sessionStart, '\n'), existing...)
+	if err := os.WriteFile(s.TranscriptPath, updated, 0o600); err != nil {
+		s.env.T.Fatalf("failed to write worker transcript: %v", err)
+	}
+}
+
 // SimulateFactoryDroidUserPromptSubmit is a convenience method on TestEnv.
 func (env *TestEnv) SimulateFactoryDroidUserPromptSubmit(sessionID string) error {
 	env.T.Helper()

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -940,6 +940,25 @@ func handleLifecycleTurnEnd(ctx context.Context, ag agent.Agent, event *agent.Ev
 	strat := GetStrategy(ctx)
 	agentType := ag.Type()
 
+	// Agents that run subagents as sessions of their own (Factory AI Droid's
+	// Workers) reach turn-end here for the subagent's own turn. Attribute that
+	// work to the parent task invocation instead of minting a top-level session
+	// checkpoint unrelated to the session the user is actually driving.
+	if link, isSubagent := resolveSubagentSessionLink(ctx, ag, transcriptRef); isSubagent {
+		return saveSubagentSessionTaskStep(ctx, subagentSessionStep{
+			link:          link,
+			sessionID:     sessionID,
+			event:         event,
+			transcriptRef: transcriptRef,
+			modifiedFiles: relModifiedFiles,
+			newFiles:      relNewFiles,
+			deletedFiles:  relDeletedFiles,
+			author:        author,
+			agentType:     agentType,
+			strat:         strat,
+		})
+	}
+
 	// Get transcript position/identifier from pre-prompt state
 	var transcriptIdentifierAtStart string
 	var transcriptLinesAtStart int
@@ -1240,6 +1259,92 @@ func handleLifecycleSubagentEnd(ctx context.Context, ag agent.Agent, event *agen
 	}
 
 	_ = CleanupPreTaskState(ctx, event.ToolUseID) //nolint:errcheck // best-effort cleanup
+	return nil
+}
+
+// resolveSubagentSessionLink reports whether this turn belongs to a subagent
+// session spawned by a parent task invocation. It fails closed: an agent that
+// does not model detached subagent sessions, or a link that cannot be read,
+// leaves the turn on the ordinary session-checkpoint path.
+func resolveSubagentSessionLink(
+	ctx context.Context,
+	ag agent.Agent,
+	transcriptRef string,
+) (agent.SubagentSessionLink, bool) {
+	resolver, ok := agent.AsSubagentSessionResolver(ag)
+	if !ok {
+		return agent.SubagentSessionLink{}, false
+	}
+	link, isSubagent := resolver.ResolveSubagentSession(transcriptRef)
+	if !isSubagent {
+		return agent.SubagentSessionLink{}, false
+	}
+	logging.Debug(logging.WithComponent(ctx, "lifecycle"), "resolved subagent session",
+		slog.String("parent_session_id", link.ParentSessionID),
+		slog.String("tool_use_id", link.ToolUseID),
+		slog.String("subagent_type", link.SubagentType))
+	return link, true
+}
+
+// subagentSessionStep carries the turn-end inputs needed to record a detached
+// subagent session as a task checkpoint on its parent.
+type subagentSessionStep struct {
+	link          agent.SubagentSessionLink
+	sessionID     string
+	event         *agent.Event
+	transcriptRef string
+	modifiedFiles []string
+	newFiles      []string
+	deletedFiles  []string
+	author        *GitAuthor
+	agentType     types.AgentType
+	strat         *strategy.ManualCommitStrategy
+}
+
+// saveSubagentSessionTaskStep writes a subagent session's turn as a task
+// checkpoint under its parent session.
+//
+// The checkpoint is keyed by the parent's session and tool-use ID, so the
+// subagent's files land in the parent's FilesTouched and its work condenses with
+// the parent's next commit. The subagent's own session ID doubles as the agent
+// ID, which is what stores its transcript beside the parent's in the checkpoint.
+func saveSubagentSessionTaskStep(ctx context.Context, step subagentSessionStep) error {
+	logCtx := logging.WithComponent(ctx, "lifecycle")
+	logging.Info(logCtx, "recording subagent session as task checkpoint",
+		slog.String("subagent_session_id", step.sessionID),
+		slog.String("parent_session_id", step.link.ParentSessionID),
+		slog.String("tool_use_id", step.link.ToolUseID),
+		slog.Int("modified_files", len(step.modifiedFiles)),
+		slog.Int("new_files", len(step.newFiles)),
+		slog.Int("deleted_files", len(step.deletedFiles)))
+
+	taskStepCtx := strategy.TaskStepContext{
+		SessionID:              step.link.ParentSessionID,
+		ToolUseID:              step.link.ToolUseID,
+		AgentID:                step.sessionID,
+		ModifiedFiles:          step.modifiedFiles,
+		NewFiles:               step.newFiles,
+		DeletedFiles:           step.deletedFiles,
+		TranscriptPath:         step.link.ParentTranscriptPath,
+		SubagentTranscriptPath: step.transcriptRef,
+		AuthorName:             step.author.Name,
+		AuthorEmail:            step.author.Email,
+		SubagentType:           step.link.SubagentType,
+		TaskDescription:        step.link.TaskDescription,
+		AgentType:              step.agentType,
+	}
+
+	if err := step.strat.SaveTaskStep(ctx, taskStepCtx); err != nil {
+		return fmt.Errorf("failed to save subagent session task step: %w", err)
+	}
+
+	// Retire the subagent's own session the same way an ordinary turn-end does,
+	// so its phase and pre-prompt state do not linger as an active session.
+	transitionSessionTurnEnd(ctx, step.sessionID, step.event)
+	if cleanupErr := CleanupPrePromptState(ctx, step.sessionID); cleanupErr != nil {
+		logging.Warn(logCtx, "failed to cleanup pre-prompt state",
+			slog.String("error", cleanupErr.Error()))
+	}
 	return nil
 }
 

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -1279,7 +1279,30 @@ func resolveSubagentSessionLink(
 	if !isSubagent {
 		return agent.SubagentSessionLink{}, false
 	}
-	logging.Debug(logging.WithComponent(ctx, "lifecycle"), "resolved subagent session",
+	// Both IDs are interpolated into metadata paths by
+	// SessionMetadataDirFromSessionID and TaskMetadataDir, neither of which
+	// sanitizes. Enforce it here rather than trusting each implementation: this
+	// is the one choke point every SubagentSessionResolver passes through, and
+	// it mirrors the ValidateSessionID checks the hook dispatcher already
+	// applies to IDs arriving from an agent.
+	logCtx := logging.WithComponent(ctx, "lifecycle")
+	if err := validation.ValidateAgentSessionID(link.ParentSessionID); err != nil {
+		logging.Warn(logCtx, "ignoring subagent session link with invalid parent session ID",
+			slog.String("error", err.Error()))
+		return agent.SubagentSessionLink{}, false
+	}
+	if err := validation.ValidateToolUseID(link.ToolUseID); err != nil {
+		logging.Warn(logCtx, "ignoring subagent session link with invalid tool use ID",
+			slog.String("error", err.Error()))
+		return agent.SubagentSessionLink{}, false
+	}
+	// An empty tool-use ID passes ValidateToolUseID (the field is optional
+	// elsewhere) but cannot name a task directory here.
+	if link.ToolUseID == "" {
+		logging.Warn(logCtx, "ignoring subagent session link with empty tool use ID")
+		return agent.SubagentSessionLink{}, false
+	}
+	logging.Debug(logCtx, "resolved subagent session",
 		slog.String("parent_session_id", link.ParentSessionID),
 		slog.String("tool_use_id", link.ToolUseID),
 		slog.String("subagent_type", link.SubagentType))

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -2471,3 +2471,84 @@ func TestSpawnDetachedTrailEnablementRefresh_CollapsesBurst(t *testing.T) {
 		t.Fatalf("expected the burst to collapse to a single detached spawn, got %d", got)
 	}
 }
+
+// resolvingSubagentAgent is a mockLifecycleAgent that also reports a subagent
+// session link, standing in for an agent whose subagents run as their own
+// sessions (Factory AI Droid's Workers).
+type resolvingSubagentAgent struct {
+	mockLifecycleAgent
+
+	link agent.SubagentSessionLink
+	ok   bool
+}
+
+var _ agent.SubagentSessionResolver = (*resolvingSubagentAgent)(nil)
+
+func (r *resolvingSubagentAgent) ResolveSubagentSession(_ string) (agent.SubagentSessionLink, bool) {
+	return r.link, r.ok
+}
+
+// TestResolveSubagentSessionLink_RejectsPathUnsafeIDs pins the choke point every
+// SubagentSessionResolver passes through. The IDs it returns are interpolated
+// into metadata paths by SessionMetadataDirFromSessionID and TaskMetadataDir,
+// neither of which sanitizes, so validation cannot be left to implementations.
+func TestResolveSubagentSessionLink_RejectsPathUnsafeIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]agent.SubagentSessionLink{
+		"parent traverses":   {ParentSessionID: "../../etc", ToolUseID: "toolu_1"},
+		"parent separator":   {ParentSessionID: "a/b", ToolUseID: "toolu_1"},
+		"tool use traverses": {ParentSessionID: "parent-1", ToolUseID: "../../etc"},
+		"tool use separator": {ParentSessionID: "parent-1", ToolUseID: "a/b"},
+		"empty parent":       {ParentSessionID: "", ToolUseID: "toolu_1"},
+		"empty tool use":     {ParentSessionID: "parent-1", ToolUseID: ""},
+	}
+
+	for name, link := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ag := &resolvingSubagentAgent{link: link, ok: true}
+
+			_, ok := resolveSubagentSessionLink(context.Background(), ag, "transcript.jsonl")
+
+			if ok {
+				t.Errorf("link %+v must be rejected, not used to build a metadata path", link)
+			}
+		})
+	}
+}
+
+// TestResolveSubagentSessionLink_AcceptsValidLink guards against the validation
+// above rejecting everything, which would silently restore the original bug.
+func TestResolveSubagentSessionLink_AcceptsValidLink(t *testing.T) {
+	t.Parallel()
+
+	want := agent.SubagentSessionLink{
+		ParentSessionID: "0b34cbcb-108c-4800-b68e-af7093c8cae9",
+		ToolUseID:       "toolu_01SC9sRHSef1vtNFtMrX9w6T",
+		SubagentType:    "worker",
+	}
+	ag := &resolvingSubagentAgent{link: want, ok: true}
+
+	got, ok := resolveSubagentSessionLink(context.Background(), ag, "transcript.jsonl")
+
+	if !ok {
+		t.Fatal("a well-formed link must be accepted")
+	}
+	if got.ParentSessionID != want.ParentSessionID || got.ToolUseID != want.ToolUseID {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+// TestResolveSubagentSessionLink_AgentWithoutCapability confirms the default
+// path: an agent whose subagents block the parent turn (Claude Code) is left on
+// the ordinary session-checkpoint path.
+func TestResolveSubagentSessionLink_AgentWithoutCapability(t *testing.T) {
+	t.Parallel()
+
+	ag := &mockLifecycleAgent{name: "mock", agentType: "mock"}
+
+	if _, ok := resolveSubagentSessionLink(context.Background(), ag, "transcript.jsonl"); ok {
+		t.Error("an agent without the capability must never resolve a subagent link")
+	}
+}

--- a/docs/architecture/agent-guide.md
+++ b/docs/architecture/agent-guide.md
@@ -50,6 +50,7 @@ Every agent must implement all 19 methods on the `Agent` interface:
 | `TranscriptPreparer` | `PrepareTranscript` | Agent writes transcripts asynchronously and needs a flush/sync step |
 | `TokenCalculator` | `CalculateTokenUsage` | Agent's transcript contains token usage data |
 | `SubagentAwareExtractor` | `ExtractAllModifiedFiles`, `CalculateTotalTokenUsage` | Agent spawns subagents (like Claude Code's Task tool) |
+| `SubagentSessionResolver` | `ResolveSubagentSession` | Agent runs subagents as **detached sessions of their own** rather than as a blocking tool call (Factory AI Droid's Workers) |
 | `HookResponseWriter` | `WriteHookResponse` | Agent can display messages from hook responses (e.g., session start banner). Claude Code uses JSON `systemMessage` on stdout; Factory AI Droid uses plain text on stdout. |
 | `ContextInjector` | `InjectionEvent`, `RenderContextInjection` | Agent can inject text into the **model's** context window (distinct from `HookResponseWriter`, which targets the *user*). The agent declares which lifecycle event it injects at and renders a native stdout payload. The dispatcher (`emitContextInjection`) emits it once per normal session via `session.State.ContextInjectionDecided`, skipping review/investigate sessions, and only when fresh clone-local preferences say trails are enabled for the current repo/API/auth target. The API check happens before the prompt path (`entire enable`, successful `entire trail ...` commands, and stale/missing cache refresh on SessionStart all refresh `ClonePreferences.TrailsEnabled` using `api.Client.TrailsEnabled`); TurnStart performs no auth/network work and leaves unknown/stale caches undecided so a later refresh can still inject. Claude Code / Codex / Gemini inject at `TurnStart` using `hookSpecificOutput.additionalContext` (UserPromptSubmit / BeforeAgent); Pi and OpenCode emit a `{"inject_context":...}` envelope that their embedded extension applies (Pi via a `before_agent_start` message, OpenCode via `experimental.chat.system.transform`). |
 | `FileWatcher` | `GetWatchPaths`, `OnFileChange` | Agent doesn't support hooks; uses file-based detection instead |
@@ -498,6 +499,34 @@ The framework dispatcher (`DispatchLifecycleEvent` in `lifecycle.go`) handles ea
 **Methods:**
 - `ExtractAllModifiedFiles(sessionRef, fromOffset, subagentsDir) ([]string, error)` - Deduplicated file list from main + subagent transcripts.
 - `CalculateTotalTokenUsage(sessionRef, fromOffset, subagentsDir) (*TokenUsage, error)` - Aggregated usage including subagents.
+
+### `SubagentSessionResolver`
+
+**What it enables:** Attributing a detached subagent session's turn to the parent
+task invocation, as a task checkpoint under `.entire/metadata/<parent>/tasks/<tool-use-id>/`.
+
+**Without it:** Turn-end treats the subagent's session as an ordinary top-level
+session and mints a session checkpoint for it — the subagent's files land on the
+shadow branch under a session the user never drove, and no task checkpoint exists.
+
+**Implement when:** Your agent dispatches subagents as sessions of their own,
+firing a full SessionStart/UserPromptSubmit/Stop cycle for each. Factory AI
+Droid does this for Workers: its `PostToolUse` fires when the Worker is
+*dispatched*, not when it finishes, so the worktree is still untouched at
+`SubagentEnd` and only the Worker's own session boundary delimits its work.
+
+**Do NOT implement** when subagents block the parent's turn (Claude Code's Task
+tool) — the `SubagentEnd` path already bounds that work correctly.
+
+**Method:**
+- `ResolveSubagentSession(sessionRef) (SubagentSessionLink, bool)` — returns the
+  parent session ID, the parent's tool-use ID, and (optionally) the parent's
+  transcript path. Must return `false` for ordinary sessions and whenever the
+  link cannot be read; the caller then keeps the session on the normal path.
+
+Resolve the link from data the agent itself persists (Droid records
+`callingSessionId`/`callingToolUseId` on its transcript's `session_start` line)
+rather than from hook ordering, so it survives asynchronous dispatch.
 
 ### `HookSupport`
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1052
<!-- entire-trail-link-end -->

## Problem

`TestFactoryTaskCheckpointExistsBeforeCommit` and
`TestFactoryCommittedCheckpointExcludesPreExistingUntrackedFiles` have failed in
**every** E2E run since 2026-08-12 05:47 (last green: 2026-08-10 21:43), both on
first run and on retry. Both fail at `waitForTaskCheckpoint` — "expected task
checkpoint within 30s".

Nothing in this repo caused it: **Droid changed Worker dispatch from blocking to
background.** Comparing `entire.log` from the last green run against a failing one:

| | Aug 10 (pass) | Aug 14 (fail) |
|---|---|---|
| `pre-tool-use` → SubagentStart | 21:47:11.176 | 15:28:31.989 |
| `post-tool-use` → SubagentEnd | 21:47:38.963 (**+27.8s**) → `new_files=1` → task checkpoint saved | 15:28:35.166 (**+3.2s**) → 0 changes → *"no file changes detected, skipping task checkpoint"* |
| Worker's own `stop` | 21:47:37.493 (before SubagentEnd) | 15:28:54.370 (**19s after** SubagentEnd) |

The tmux panes confirm the behaviour change directly:

- Aug 10: `Worker "Inspect code and write summary"` — a synchronous tool block
- Aug 14: `Worker launched … It will complete in the background and notify automatically.`

`PostToolUse` now fires when the Worker is *dispatched*, not when it *finishes*,
so `handleLifecycleSubagentEnd` sees an untouched worktree and skips.

**The work was not lost — it was misattributed.** A Droid Worker runs as a full
session of its own (its own SessionStart/UserPromptSubmit/Stop), so its file
write was picked up by the ordinary turn-end path and committed under the
*Worker's* session ID:

```
commit 3a5ca02 (entire/775fb1a-e3b0c4)
    # Task Tool Invocation Subagent type: worker …
    Entire-Metadata: .entire/metadata/398f4162-…      ← Worker's own session
```

That is `.entire/metadata/<worker-session>/`, not
`.entire/metadata/<parent>/tasks/<tool-use-id>/`. Subagent work surfaced as an
unrelated top-level session the user never drove, and no task checkpoint existed.
So this is a real attribution regression, not just a stale test.

## Fix

Key the attribution off data Droid persists rather than off hook ordering. A
Worker's transcript records its parent on its `session_start` line:

```json
{"type":"session_start","id":"30b34828…",
 "callingSessionId":"0b34cbcb…",          ← parent session
 "callingToolUseId":"toolu_01SC9sRH…"}    ← parent's tool_use_id
```

- New optional agent capability `SubagentSessionResolver`, implemented only by
  Factory AI Droid. Claude Code deliberately does **not** implement it — its
  subagents block the parent turn, so the existing `SubagentEnd` path already
  bounds them correctly.
- `handleLifecycleTurnEnd` consults it and, for a subagent session, writes a
  **task checkpoint on the parent** instead of a session checkpoint of its own.

This holds whether dispatch is synchronous or asynchronous, and sidesteps the
synthetic `factorytask_*` IDs the CLI mints when Droid's tool hooks omit a
`tool_use_id` — the transcript carries the real `toolu_*` ID.

Resulting shadow tree for a Worker turn (from the new integration test):

```
.entire/metadata/<parent>/full.jsonl
.entire/metadata/<parent>/tasks/toolu_worker_01/agent-<worker>.jsonl
.entire/metadata/<parent>/tasks/toolu_worker_01/checkpoint.json
```

No `.entire/metadata/<worker>/` entry — the Worker mints no top-level checkpoint.

It also fails closed: an agent without the capability, or a link that is
unreadable or half-populated (parent ID but no tool-use ID, or vice versa),
stays on the ordinary session-checkpoint path.

## Verification

- The new integration test **fails without the fix**, reproducing the exact CI
  symptom (no task checkpoint + a stray top-level Worker session checkpoint), and
  passes with it.
- `TestFactoryDroidTopLevelSessionStillCheckpoints` guards the fallback and passes
  both with and without the fix — a real control, not a mirror of the change.
- Unit tests for the resolver use a **verbatim** `session_start` line captured
  from a real Droid Worker transcript, plus a 300KB-title case: Droid embeds the
  whole task prompt in `title`, which exceeds `bufio.Scanner`'s default line cap,
  so the reader uses `ReadBytes`.
- `mise run check` green (fmt, lint, unit + integration, Vogon canary).

The Droid E2E tests themselves need CI — I have no local `FACTORY_API_KEY`, so
those two tests are verified by this PR's E2E run rather than locally.

## Note on the other failure in that run

`e2e-tests (opencode)` failed in the same run for an unrelated and transient
reason: the installer resolves its version through an unauthenticated
`api.github.com` call, which gets rate-limited on shared Actions runner IPs
("Failed to fetch version information"). It passed in all 8 prior runs and the
endpoint is healthy. Not addressed here; if it recurs, the installer honours a
`VERSION` env var, which skips the API call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 466c06e057dac856882b77e2fdb3fc6ee58a43ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->