### PR TITLE
feat(checkpoint): make the local metadata-ref replay visible

### DIFF
--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -357,6 +357,46 @@ func discardSession(ctx context.Context, ss stuckSession, _ *git.Repository, err
 	return nil
 }
 
+// reportMetadataDivergence prints the metadata-branch verdict for a comparison
+// that is not disconnected: either plain OK, or DIVERGED when both sides advanced
+// since their merge base.
+//
+// Divergence needs saying because it is the one state whose resolution rewrites
+// the local ref: the next fetch from the elected sync remote replays the local
+// commits onto the fetched tip (SafelyAdvanceLocalRef), which loses no
+// checkpoints but does move the ref and re-hash those commits. Nothing else
+// surfaces that — the replay itself only logs.
+//
+// Takes the already-computed comparison rather than re-deriving it: the verdict
+// costs a merge-base subprocess, and the caller has one in hand.
+func reportMetadataDivergence(ctx context.Context, w io.Writer, comparison strategy.MetadataComparison, remoteName string, primary plumbing.ReferenceName) {
+	if comparison.Relation != strategy.MetadataRelationDiverged {
+		fmt.Fprintln(w, "✓ Metadata branches: OK")
+		return
+	}
+
+	fmt.Fprintln(w, "Metadata branches: DIVERGED")
+	fmt.Fprintf(w, "  Local and remote %s have both advanced since they last agreed.\n", primary.Short())
+	// Labels are fixed-width and the remote name trails the hash: padding it
+	// into the label misaligns the pair for every remote name that is not
+	// exactly as long as "origin".
+	fmt.Fprintf(w, "    local:  %s\n", comparison.Local.String()[:12])
+	fmt.Fprintf(w, "    remote: %s  (%s)\n", comparison.Remote.String()[:12], remoteName)
+
+	// Whether the divergence resolves itself depends on the confinement rule:
+	// only the elected sync remote may advance the local ref, so a diverged
+	// legacy-tier ref sits there indefinitely and says nothing about local state.
+	elected, electErr := strategy.ResolveCheckpointSyncRemote(ctx)
+	if electErr == nil && elected.Name == remoteName {
+		fmt.Fprintln(w, "  No action needed: the next fetch from this remote replays your local")
+		fmt.Fprintln(w, "  checkpoints onto its tip. No checkpoints are lost, but the local ref moves")
+		fmt.Fprintln(w, "  and the replayed commits get new hashes.")
+		return
+	}
+	fmt.Fprintf(w, "  %q is the legacy read tier, not the elected checkpoint sync remote, so it\n", remoteName)
+	fmt.Fprintln(w, "  never advances the local ref. Nothing will reconcile this on its own.")
+}
+
 // checkDisconnectedMetadata detects and optionally repairs disconnected
 // local/remote metadata branches (the "empty-orphan bug").
 func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
@@ -381,13 +421,16 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 		fmt.Fprintln(w, "✓ Metadata branches: OK (no remote-tracking metadata ref found)")
 		return nil
 	}
-	disconnected, err := strategy.IsMetadataDisconnected(ctx, repo, remoteRefName)
+	// One classification for both verdicts: disconnected and diverged are two
+	// answers from the same merge base, and computing them separately meant two
+	// merge-base subprocesses that could disagree.
+	comparison, err := strategy.CompareMetadataWithRemote(ctx, repo, remoteRefName)
 	if err != nil {
 		return fmt.Errorf("could not check metadata branch state: %w", err)
 	}
 
-	if !disconnected {
-		fmt.Fprintln(w, "✓ Metadata branches: OK")
+	if comparison.Relation != strategy.MetadataRelationDisconnected {
+		reportMetadataDivergence(ctx, w, comparison, remoteName, refs.Primary)
 		return nil
 	}
 

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -308,7 +308,11 @@ func TestClassifySession_WorktreeIDInShadowBranch(t *testing.T) {
 }
 
 // Distinct parentless commits have no common ancestor.
-func writeRootlessMetadataCommit(t *testing.T, repo *git.Repository, message string) plumbing.Hash {
+// writeRootlessMetadataCommit builds a metadata commit with an empty tree.
+// parents is variadic so a test can build connected history (shared base, two
+// children) without a second copy of the go-git plumbing dance; passing none
+// yields the rootless commit the disconnection tests want.
+func writeRootlessMetadataCommit(t *testing.T, repo *git.Repository, message string, parents ...plumbing.Hash) plumbing.Hash {
 	t.Helper()
 	emptyTree := &object.Tree{Entries: []object.TreeEntry{}}
 	treeObj := repo.Storer.NewEncodedObject()
@@ -321,6 +325,8 @@ func writeRootlessMetadataCommit(t *testing.T, repo *git.Repository, message str
 		Committer: object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
 		Message:   message,
 		TreeHash:  treeHash,
+
+		ParentHashes: parents,
 	}
 	enc := repo.Storer.NewEncodedObject()
 	require.NoError(t, commitObj.Encode(enc))
@@ -678,4 +684,105 @@ func TestConfirmDoctorFix_CancelledContext(t *testing.T) {
 	proceed, err := confirmDoctorFix(ctx, &out, "Apply fix?")
 	require.NoError(t, err)
 	assert.False(t, proceed)
+}
+
+// setupDivergedMetadata points local v1 and origin's tracking ref at two
+// different children of one base commit, and returns both tips.
+func setupDivergedMetadata(t *testing.T, repo *git.Repository) (local, remote plumbing.Hash) {
+	t.Helper()
+	base := writeRootlessMetadataCommit(t, repo, "shared base")
+	local = writeRootlessMetadataCommit(t, repo, "local checkpoint", base)
+	remote = writeRootlessMetadataCommit(t, repo, "remote checkpoint", base)
+
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(
+		plumbing.NewBranchReferenceName(paths.MetadataBranchName), local)))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(
+		plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName), remote)))
+	return local, remote
+}
+
+func runCheckDisconnectedMetadata(t *testing.T) string {
+	t.Helper()
+	cmd, stdout := newTestCmd(t)
+	require.NoError(t, checkDisconnectedMetadata(cmd, true))
+	return stdout.String()
+}
+
+// TestCheckDisconnectedMetadata_Diverged_ReportedAsSelfHealing covers the state
+// that previously printed a bare "OK": local and remote both advanced, so the
+// next fetch rewrites the local ref by replaying local commits. Nothing else
+// surfaces that, since the replay itself only logs.
+func TestCheckDisconnectedMetadata_Diverged_ReportedAsSelfHealing(t *testing.T) {
+	// Cannot use t.Parallel(): t.Chdir and IsolateGitConfigEnv modify globals.
+	testutil.IsolateGitConfigEnv(t)
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	local, remote := setupDivergedMetadata(t, repo)
+
+	// origin is the elected remote here, so the replay really will happen.
+	testutil.AddRemote(t, dir, "origin", "https://example.com/origin.git")
+
+	output := runCheckDisconnectedMetadata(t)
+
+	assert.Contains(t, output, "Metadata branches: DIVERGED")
+	assert.NotContains(t, output, "DISCONNECTED", "shared ancestry is not a disconnection")
+	assert.Contains(t, output, local.String()[:12], "the local tip must be shown")
+	assert.Contains(t, output, remote.String()[:12], "the remote tip must be shown")
+	assert.Contains(t, output, "No action needed", "divergence against the elected remote self-heals")
+	assert.Contains(t, output, "new hashes", "the user must learn the replayed commits are re-hashed")
+
+	localRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+	assert.Equal(t, local, localRef.Hash(), "reporting must not move any ref")
+}
+
+// TestCheckDisconnectedMetadata_Diverged_LegacyTierWontReconcile is the other
+// half: the confinement rule means a diverged legacy-tier ref never advances the
+// local ref, so promising self-healing there would be a lie.
+func TestCheckDisconnectedMetadata_Diverged_LegacyTierWontReconcile(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	setupDivergedMetadata(t, repo)
+
+	// Election picks upstream; origin carries the diverged tracking ref.
+	testutil.AddRemote(t, dir, "origin", "https://example.com/origin.git")
+	testutil.AddRemote(t, dir, "upstream", "https://example.com/upstream.git")
+	testutil.WriteCheckpointPushRemoteSetting(t, dir, "upstream")
+
+	output := runCheckDisconnectedMetadata(t)
+
+	assert.Contains(t, output, "Metadata branches: DIVERGED")
+	assert.Contains(t, output, "legacy read tier")
+	assert.Contains(t, output, "Nothing will reconcile this on its own.")
+	assert.NotContains(t, output, "No action needed",
+		"a legacy-tier divergence does not self-heal; saying so would be wrong")
+}
+
+// TestCheckDisconnectedMetadata_Aligned_StaysQuiet pins that the common case is
+// unchanged — the divergence check must not add noise to a healthy repo.
+func TestCheckDisconnectedMetadata_Aligned_StaysQuiet(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	tip := writeRootlessMetadataCommit(t, repo, "agreed metadata")
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(
+		plumbing.NewBranchReferenceName(paths.MetadataBranchName), tip)))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(
+		plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName), tip)))
+	testutil.AddRemote(t, dir, "origin", "https://example.com/origin.git")
+
+	output := runCheckDisconnectedMetadata(t)
+
+	assert.Contains(t, output, "✓ Metadata branches: OK")
+	assert.NotContains(t, output, "DIVERGED")
 }

--- a/cmd/entire/cli/strategy/checkpoint_read_confinement_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_read_confinement_test.go
@@ -25,13 +25,15 @@ func initRemoteElectionRepo(t *testing.T) string {
 	return tmpDir
 }
 
-func electionRevParse(t *testing.T, dir, ref string) string {
+// electionHeadHash returns dir's HEAD commit hash. Every caller wanted HEAD, so
+// the ref is not a parameter.
+func electionHeadHash(t *testing.T, dir string) string {
 	t.Helper()
-	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", ref)
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "HEAD")
 	cmd.Dir = dir
 	cmd.Env = testutil.GitIsolatedEnv()
 	out, err := cmd.Output()
-	require.NoError(t, err, "git rev-parse %s", ref)
+	require.NoError(t, err, "git rev-parse HEAD")
 	return strings.TrimSpace(string(out))
 }
 
@@ -64,7 +66,7 @@ func TestEnsurePrimaryRef_NonElectedOriginNeverSeedsLocal(t *testing.T) {
 			testutil.AddRemote(t, tmpDir, "origin", "https://example.com/origin.git")
 			tt.configure(t, tmpDir)
 
-			staleHash := electionRevParse(t, tmpDir, "HEAD")
+			staleHash := electionHeadHash(t, tmpDir)
 			testutil.GitUpdateRef(t, tmpDir, "refs/remotes/origin/"+paths.MetadataBranchName, staleHash)
 
 			t.Chdir(tmpDir)
@@ -89,7 +91,7 @@ func TestEnsurePrimaryRef_ElectedUpstreamTrackingSeedsLocal(t *testing.T) {
 	testutil.AddRemote(t, tmpDir, "upstream", "https://example.com/upstream.git")
 	testutil.WriteCheckpointPushRemoteSetting(t, tmpDir, "upstream")
 
-	headHash := electionRevParse(t, tmpDir, "HEAD")
+	headHash := electionHeadHash(t, tmpDir)
 	testutil.GitUpdateRef(t, tmpDir, "refs/remotes/upstream/"+paths.MetadataBranchName, headHash)
 
 	t.Chdir(tmpDir)

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -207,7 +207,7 @@ func replayLocalRefFromBase(ctx context.Context, repo *git.Repository, repoPath 
 	if err != nil {
 		return fmt.Errorf("failed to load shallow boundaries for %s: %w", localRefName, err)
 	}
-	return replayLocalCommits(ctx, repo, localRefName, targetHash, localCommits, shallow)
+	return replayLocalCommits(ctx, repo, "diverged", localRefName, localHash, targetHash, localCommits, shallow)
 }
 
 func replayDisconnectedLocalRef(ctx context.Context, repo *git.Repository, repoPath string, localRefName plumbing.ReferenceName, localHash, targetHash plumbing.Hash) error {
@@ -219,10 +219,30 @@ func replayDisconnectedLocalRef(ctx context.Context, repo *git.Repository, repoP
 	if err != nil {
 		return fmt.Errorf("failed to collect disconnected local commits for %s: %w", localRefName, err)
 	}
-	return replayLocalCommits(ctx, repo, localRefName, targetHash, localCommits, shallow)
+	return replayLocalCommits(ctx, repo, "disconnected", localRefName, localHash, targetHash, localCommits, shallow)
 }
 
-func replayLocalCommits(ctx context.Context, repo *git.Repository, localRefName plumbing.ReferenceName, targetHash plumbing.Hash, localCommits []*object.Commit, shallow map[plumbing.Hash]bool) error {
+func replayLocalCommits(ctx context.Context, repo *git.Repository, reason string, localRefName plumbing.ReferenceName, localHash, targetHash plumbing.Hash, localCommits []*object.Commit, shallow map[plumbing.Hash]bool) error {
+	// Logged here rather than in each caller: this is the function that performs
+	// the rewrite, so a future third caller cannot silently skip the trace.
+	//
+	// A replay rewrites the local ref to the fetched remote tip with the local
+	// commits re-applied on top: no checkpoint is lost, but the ref no longer
+	// points where it did and the local commits have new hashes. That is the one
+	// place a fetch reaches past remote-tracking refs into local state, so it must
+	// leave a trace — the whole advance/replay chain was previously silent, which
+	// made an invisible rewrite impossible to reconstruct afterwards from
+	// .entire/logs/. Info rather than Debug: the default log level has to carry it
+	// for a post-hoc investigation to find it.
+	//
+	// Metadata only (ref names, hashes, counts) per the logging privacy rule.
+	logging.Info(ctx, "replaying local commits onto fetched tip; local ref will be rewritten",
+		slog.String("reason", reason),
+		slog.String("ref", localRefName.String()),
+		slog.String("local_tip", localHash.String()),
+		slog.String("target_tip", targetHash.String()),
+		slog.Int("commits_replayed", len(localCommits)))
+
 	if len(localCommits) == 0 {
 		return setRefHash(repo, localRefName, targetHash)
 	}

--- a/cmd/entire/cli/strategy/common_test.go
+++ b/cmd/entire/cli/strategy/common_test.go
@@ -1099,13 +1099,20 @@ func TestEnsurePrimaryRef_SeedsV1FromRemote(t *testing.T) {
 func cloneWithConfig(t *testing.T, bareDir string) (string, func(args ...string)) {
 	t.Helper()
 	cloneDir := filepath.Join(t.TempDir(), "clone")
+	// GitIsolatedEnv on every invocation, matching initBareWithMetadataBranch:
+	// without it these commands inherit the developer's or CI's global git
+	// config, and a global gc.autoDetach=true lets a background `git gc` write
+	// .git/objects after the test returns and race t.TempDir() cleanup. Per-command
+	// env rather than t.Setenv, so callers can still use t.Parallel().
 	cmd := exec.CommandContext(context.Background(), "git", "clone", bareDir, cloneDir)
+	cmd.Env = testutil.GitIsolatedEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clone failed: %v\n%s", err, out)
 	}
 	run := func(args ...string) {
 		cmd := exec.CommandContext(context.Background(), "git", args...)
 		cmd.Dir = cloneDir
+		cmd.Env = testutil.GitIsolatedEnv()
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("git %v failed: %v\n%s", args, err, out)
 		}

--- a/cmd/entire/cli/strategy/metadata_divergence_test.go
+++ b/cmd/entire/cli/strategy/metadata_divergence_test.go
@@ -1,0 +1,222 @@
+package strategy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// divergenceRepo returns a clone whose local primary metadata ref and origin's
+// remote-tracking ref both exist and agree, ready for a test to move either
+// side. run executes git in the clone.
+func divergenceRepo(t *testing.T) (string, func(args ...string)) {
+	t.Helper()
+
+	bareDir := initBareWithMetadataBranch(t)
+	cloneDir, run := cloneWithConfig(t, bareDir)
+
+	repo, err := git.PlainOpen(cloneDir)
+	require.NoError(t, err)
+	require.NoError(t, EnsurePrimaryRef(t.Context(), repo))
+
+	return cloneDir, run
+}
+
+// commitOnMetadataBranch adds one commit to the checked-out metadata branch and
+// returns nothing — callers read the resulting hashes off the refs.
+func commitOnMetadataBranch(t *testing.T, cloneDir string, run func(...string), dir, content string) {
+	t.Helper()
+
+	path := filepath.Join(cloneDir, dir)
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(path, "metadata.json"), []byte(content), 0o644))
+	run("add", ".")
+	run("commit", "-m", "checkpoint "+dir)
+}
+
+func divergence(t *testing.T, cloneDir string) MetadataComparison {
+	t.Helper()
+
+	repo, err := git.PlainOpen(cloneDir)
+	require.NoError(t, err)
+	c, err := CompareMetadataWithRemote(context.Background(), repo, metadataOriginRemoteRef())
+	require.NoError(t, err)
+	return c
+}
+
+// diverged is the assertion these tests are about; the other relations are
+// asserted by name where they matter.
+func diverged(c MetadataComparison) bool { return c.Relation == MetadataRelationDiverged }
+
+// TestMetadataDivergence_BothAdvanced is the case no existing check reported:
+// local and remote each gained a commit since their merge base, so the next
+// fetch rewrites the local ref by replaying local commits onto the remote tip.
+func TestMetadataDivergence_BothAdvanced(t *testing.T) {
+	t.Parallel()
+
+	cloneDir, run := divergenceRepo(t)
+
+	// Remember the agreed tip, add a local commit, then build a DIFFERENT
+	// commit on the same base and point origin's tracking ref at it.
+	run("checkout", paths.MetadataBranchName)
+	base := electionHeadHash(t, cloneDir)
+
+	commitOnMetadataBranch(t, cloneDir, run, filepath.Join("aa", "1111111111"), `{"side":"local"}`)
+	localTip := electionHeadHash(t, cloneDir)
+
+	run("checkout", "-b", "remote-side", base)
+	commitOnMetadataBranch(t, cloneDir, run, filepath.Join("bb", "2222222222"), `{"side":"remote"}`)
+	remoteTip := electionHeadHash(t, cloneDir)
+	run("update-ref", metadataOriginRemoteRef().String(), remoteTip)
+	run("checkout", "main")
+
+	require.NotEqual(t, localTip, remoteTip, "setup: the two sides must differ")
+
+	c := divergence(t, cloneDir)
+	assert.True(t, diverged(c), "both sides advanced past the merge base; that is a divergence")
+	assert.Equal(t, localTip, c.Local.String())
+	assert.Equal(t, remoteTip, c.Remote.String())
+}
+
+// TestMetadataDivergence_LocalAhead: a fast-forward is not a divergence — the
+// fetch advances the ref without replaying anything, so there is nothing to say.
+func TestMetadataDivergence_LocalAhead(t *testing.T) {
+	t.Parallel()
+
+	cloneDir, run := divergenceRepo(t)
+	run("checkout", paths.MetadataBranchName)
+	commitOnMetadataBranch(t, cloneDir, run, filepath.Join("cc", "3333333333"), `{"side":"local"}`)
+	run("checkout", "main")
+
+	assert.False(t, diverged(divergence(t, cloneDir)),
+		"local strictly ahead of the tracking ref is a fast-forward, not a divergence")
+}
+
+// TestMetadataDivergence_RemoteAhead is the mirror image.
+func TestMetadataDivergence_RemoteAhead(t *testing.T) {
+	t.Parallel()
+
+	cloneDir, run := divergenceRepo(t)
+	run("checkout", paths.MetadataBranchName)
+	base := electionHeadHash(t, cloneDir)
+	commitOnMetadataBranch(t, cloneDir, run, filepath.Join("dd", "4444444444"), `{"side":"remote"}`)
+	aheadTip := electionHeadHash(t, cloneDir)
+
+	// Local back to the base, tracking ref left ahead.
+	run("update-ref", "refs/heads/"+paths.MetadataBranchName, base)
+	run("update-ref", metadataOriginRemoteRef().String(), aheadTip)
+	run("checkout", "main")
+
+	assert.False(t, diverged(divergence(t, cloneDir)),
+		"remote strictly ahead is a fast-forward, not a divergence")
+}
+
+func TestMetadataDivergence_SameTip(t *testing.T) {
+	t.Parallel()
+
+	cloneDir, _ := divergenceRepo(t)
+	assert.False(t, diverged(divergence(t, cloneDir)), "identical tips cannot diverge")
+}
+
+// TestMetadataDivergence_DisconnectedIsNotDiverged keeps the two classifications
+// disjoint: no merge base at all is IsMetadataDisconnected's case, and doctor
+// reports it separately with a repair. Reporting it here too would double up.
+func TestMetadataDivergence_DisconnectedIsNotDiverged(t *testing.T) {
+	t.Parallel()
+
+	cloneDir, run := divergenceRepo(t)
+
+	run("checkout", "--orphan", "orphan-side")
+	run("rm", "-rf", ".")
+	commitOnMetadataBranch(t, cloneDir, run, filepath.Join("ee", "5555555555"), `{"side":"orphan"}`)
+	orphanTip := electionHeadHash(t, cloneDir)
+	run("update-ref", "refs/heads/"+paths.MetadataBranchName, orphanTip)
+	run("checkout", "main")
+
+	repo, err := git.PlainOpen(cloneDir)
+	require.NoError(t, err)
+	disconnected, err := IsMetadataDisconnected(context.Background(), repo, metadataOriginRemoteRef())
+	require.NoError(t, err)
+	require.True(t, disconnected, "setup: the orphan branch must be disconnected")
+
+	assert.False(t, diverged(divergence(t, cloneDir)),
+		"disconnected is reported by IsMetadataDisconnected, not as a divergence")
+}
+
+func TestMetadataDivergence_MissingRefs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no remote-tracking ref", func(t *testing.T) {
+		t.Parallel()
+		cloneDir, run := divergenceRepo(t)
+		run("update-ref", "-d", metadataOriginRemoteRef().String())
+		assert.False(t, diverged(divergence(t, cloneDir)), "nothing to diverge from")
+	})
+
+	t.Run("no local ref", func(t *testing.T) {
+		t.Parallel()
+		cloneDir, run := divergenceRepo(t)
+		run("update-ref", "-d", "refs/heads/"+paths.MetadataBranchName)
+		assert.False(t, diverged(divergence(t, cloneDir)), "nothing to diverge")
+	})
+}
+
+// TestSafelyAdvanceLocalRef_LogsTheReplay pins the trace on the one path where a
+// fetch reaches past remote-tracking refs and rewrites local state. The whole
+// advance/replay chain used to be silent, which made an after-the-fact
+// investigation impossible: the ref had moved, the local commits had new hashes,
+// and .entire/logs/ said nothing about it.
+//
+// Not parallel: t.Chdir plus the process-global logger.
+func TestSafelyAdvanceLocalRef_LogsTheReplay(t *testing.T) {
+	cloneDir, run := divergenceRepo(t)
+
+	run("checkout", paths.MetadataBranchName)
+	base := electionHeadHash(t, cloneDir)
+	commitOnMetadataBranch(t, cloneDir, run, filepath.Join("aa", "6666666666"), `{"side":"local"}`)
+	localTip := electionHeadHash(t, cloneDir)
+	run("checkout", "-b", "remote-side", base)
+	commitOnMetadataBranch(t, cloneDir, run, filepath.Join("bb", "7777777777"), `{"side":"remote"}`)
+	remoteTip := electionHeadHash(t, cloneDir)
+	run("update-ref", "refs/heads/"+paths.MetadataBranchName, localTip)
+	run("checkout", "main")
+
+	t.Chdir(cloneDir)
+	require.NoError(t, logging.Init(t.Context(), ""))
+	// Registered immediately: an assertion failing before the explicit flush below
+	// would otherwise leave the process-global logger holding the file handle.
+	// Close is safe to call twice.
+	t.Cleanup(logging.Close)
+
+	repo, err := git.PlainOpen(cloneDir)
+	require.NoError(t, err)
+	localRefName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+	require.NoError(t, SafelyAdvanceLocalRef(t.Context(), repo, localRefName, plumbing.NewHash(remoteTip)))
+	logging.Close() // flush the buffered writer
+
+	data, err := os.ReadFile(filepath.Join(cloneDir, logging.LogsDir, "entire.log"))
+	require.NoError(t, err)
+	logged := string(data)
+
+	assert.Contains(t, logged, "local ref will be rewritten", "the rewrite must be announced in the log")
+	assert.Contains(t, logged, "diverged", "the reason must distinguish diverged from disconnected")
+	assert.Contains(t, logged, localTip, "the pre-rewrite local tip must be recoverable from the log")
+	assert.Contains(t, logged, remoteTip, "the target tip must be recorded")
+	assert.Contains(t, logged, "commits_replayed", "the replayed-commit count must be recorded")
+
+	// The replay itself must still preserve the local checkpoint.
+	after, err := repo.Reference(localRefName, true)
+	require.NoError(t, err)
+	assert.NotEqual(t, plumbing.NewHash(remoteTip), after.Hash(),
+		"the local commit is replayed on top, so the ref is not merely reset to the remote tip")
+}

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -25,37 +25,94 @@ import (
 // disconnectedOnce ensures the disconnection warning runs at most once per process.
 var disconnectedOnce sync.Once //nolint:gochecknoglobals // intentional per-process gate
 
-// IsMetadataDisconnected checks whether the local primary metadata ref and
-// the provided fetched or remote-tracking ref exist but share no common
-// ancestor.
-func IsMetadataDisconnected(ctx context.Context, repo *git.Repository, remoteRefName plumbing.ReferenceName) (bool, error) {
+// MetadataRelation classifies how the local primary metadata ref stands relative
+// to a remote-tracking ref. Derived from a single `git merge-base`, so the
+// disconnected, fast-forward and diverged verdicts can never disagree — they used
+// to be computed by two functions that each shelled out for the same pair.
+type MetadataRelation int
+
+const (
+	// MetadataRelationAbsent: one of the two refs does not exist, so there is
+	// nothing to relate.
+	MetadataRelationAbsent MetadataRelation = iota
+	// MetadataRelationAligned: identical tips.
+	MetadataRelationAligned
+	// MetadataRelationLocalAhead: the remote tip is an ancestor of local.
+	MetadataRelationLocalAhead
+	// MetadataRelationRemoteAhead: local is an ancestor of the remote tip, so a
+	// fetch fast-forwards.
+	MetadataRelationRemoteAhead
+	// MetadataRelationDiverged: both sides advanced past their merge base, so a
+	// fetch from the elected remote replays the local commits onto the remote tip.
+	MetadataRelationDiverged
+	// MetadataRelationDisconnected: no merge base at all (the "empty-orphan bug").
+	MetadataRelationDisconnected
+)
+
+// MetadataComparison is a MetadataRelation together with the tips it was derived
+// from. Local and Remote are zero when Relation is MetadataRelationAbsent.
+type MetadataComparison struct {
+	Relation MetadataRelation
+	Local    plumbing.Hash
+	Remote   plumbing.Hash
+}
+
+// CompareMetadataWithRemote classifies the local primary metadata ref against
+// remoteRefName. Pure read — it never writes a ref, and it runs exactly one
+// merge-base subprocess.
+func CompareMetadataWithRemote(ctx context.Context, repo *git.Repository, remoteRefName plumbing.ReferenceName) (MetadataComparison, error) {
+	var c MetadataComparison
+
 	refs := checkpoint.ResolveRefs(ctx)
 	localRef, err := repo.Reference(refs.Primary, true)
 	if errors.Is(err, plumbing.ErrReferenceNotFound) {
-		return false, nil
+		return c, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("failed to check local primary metadata ref: %w", err)
+		return c, fmt.Errorf("failed to check local primary metadata ref: %w", err)
 	}
-
 	remoteRef, err := repo.Reference(remoteRefName, true)
 	if errors.Is(err, plumbing.ErrReferenceNotFound) {
-		return false, nil
+		return c, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("failed to check remote metadata ref: %w", err)
+		return c, fmt.Errorf("failed to check remote metadata ref: %w", err)
 	}
 
-	if localRef.Hash() == remoteRef.Hash() {
-		return false, nil
+	c.Local, c.Remote = localRef.Hash(), remoteRef.Hash()
+	if c.Local == c.Remote {
+		c.Relation = MetadataRelationAligned
+		return c, nil
 	}
 
 	repoPath, err := getRepoPath(repo)
 	if err != nil {
+		return c, err
+	}
+	mergeBase, err := getMergeBase(ctx, repoPath, c.Local.String(), c.Remote.String())
+	switch {
+	case errors.Is(err, errNoMergeBase):
+		c.Relation = MetadataRelationDisconnected
+	case err != nil:
+		return c, fmt.Errorf("failed to find merge base for %s: %w", refs.Primary, err)
+	case mergeBase == c.Local:
+		c.Relation = MetadataRelationRemoteAhead
+	case mergeBase == c.Remote:
+		c.Relation = MetadataRelationLocalAhead
+	default:
+		c.Relation = MetadataRelationDiverged
+	}
+	return c, nil
+}
+
+// IsMetadataDisconnected reports whether the local primary metadata ref and the
+// provided fetched or remote-tracking ref exist but share no common ancestor.
+func IsMetadataDisconnected(ctx context.Context, repo *git.Repository, remoteRefName plumbing.ReferenceName) (bool, error) {
+	c, err := CompareMetadataWithRemote(ctx, repo, remoteRefName)
+	if err != nil {
 		return false, err
 	}
-
-	return isDisconnected(ctx, repoPath, localRef.Hash().String(), remoteRef.Hash().String())
+	return c.Relation == MetadataRelationDisconnected, nil
 }
 
 // FirstReadCandidateTrackingRef returns the remote name and remote-tracking


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1054
<!-- entire-trail-link-end -->

Stacked on #1951 — base retargets to `main` automatically when that merges.

## Problem

A force-fetched metadata branch can rewrite the local primary ref: `SafelyAdvanceLocalRef` replays local commits onto the fetched tip when the two sides diverged. No checkpoint is lost, but the ref moves and the replayed commits get new hashes — and nothing said so anywhere. The whole advance/replay chain (`SafelyAdvanceLocalRef`, `replayLocalRefFromBase`, `replayDisconnectedLocalRef`, `replayLocalCommits`, `setRefHash`) had **zero** logging calls, so an after-the-fact investigation had no trace to follow.

This came out of asking why the metadata fetch refspec is force (`+refs/heads/…`). The force itself is correct and load-bearing — v1 diverges by design (OPF rewrite, condensation, reconciliation), and without `+` a diverged tracking ref cannot be fetched at all, so divergence detection would never see the remote tip. The gap was that the *consequence* was invisible.

## Change

**The replay leaves a trace.** `replayLocalCommits` records ref, pre-rewrite local tip, target tip, replayed-commit count and a `diverged`/`disconnected` reason before rewriting. Logged in the function that performs the rewrite, not in its callers, so a future third caller cannot silently skip it. `Info`, not `Debug` — the default level has to carry it to be findable in `.entire/logs/`. Metadata only, per the logging privacy rule.

**`entire doctor` reports DIVERGED** with both tips instead of a bare `OK`:

```
Metadata branches: DIVERGED
  Local and remote entire/checkpoints/v1 have both advanced since they last agreed.
    local:  8415df1ee184
    remote: 7c46565c7e7c  (origin)
  No action needed: the next fetch from this remote replays your local
  checkpoints onto its tip. No checkpoints are lost, but the local ref moves
  and the replayed commits get new hashes.
```

Divergence is the one state whose resolution rewrites the local ref, and no existing check reported it — `IsMetadataDisconnected` covers only the no-merge-base case, and ahead/behind needs no comment. The message respects #1951's confinement rule: against the elected sync remote it self-heals, but a diverged legacy-tier ref never advances the local ref, so it says so instead of promising a fix that will not come.

**Both verdicts from one classifier.** `CompareMetadataWithRemote` derives absent / aligned / local-ahead / remote-ahead / diverged / disconnected from a single `git merge-base`, and `IsMetadataDisconnected` becomes a wrapper. Computing them separately meant `entire doctor` read four refs and spawned two `merge-base` subprocesses on the same hash pair to answer one question, from two bodies that could drift apart. Measured: 2 → 1.

## Notes for reviewers

- Report-only. Nothing here moves a ref; the disconnected case keeps its existing repair path untouched.
- `isDisconnected` stays — `ReconcileDisconnectedMetadataRef` still uses it, and collapsing that too would reach into the repair path.
- Verified: `mise run lint` clean, `mise run test:ci` green (Vogon 56/56, roger-roger 4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 679c864d16dbbb0f9e0bd3fadbdd9ad79a2b8d1f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->