### PR TITLE
fix(search): dedupe folded legacy sessions by checkpointId (ENT-1595)

### DIFF
--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -120,8 +120,10 @@ type SessionResult struct {
 	SessionID string `json:"sessionId"`
 	// CheckpointID identifies a server-folded legacy session (ENT-1595) whose
 	// sessionId is empty (the checkpoint predates the sessionId attribute). The
-	// cross-cell dedupe (ResultID) falls back to it so distinct legacy rows are
-	// not collapsed by matching empty sessionIds — matching the BFF's merge.
+	// cross-cell dedupe (DedupID, not ResultID — which stays the raw display id)
+	// falls back to a repo-qualified form of it, so a repo mirrored across cells
+	// reports each legacy session once instead of twice. Drill-down is
+	// `entire checkpoint explain <checkpointId>`, not `entire session info`.
 	CheckpointID   string  `json:"checkpointId,omitempty"`
 	DisplayName    string  `json:"displayName"`
 	Prompt         *string `json:"prompt"`
@@ -380,17 +382,32 @@ func (r *Result) ResultID() string {
 }
 
 // DedupID is the identity used to collapse cross-cell duplicates. It matches
-// ResultID except for a server-folded legacy session (ENT-1595), whose only id
-// is its checkpoint id — unique only WITHIN a repo. That raw id is repo-qualified
-// here (mirroring the search service's synthetic session key) so two repos'
-// legacy rows sharing a checkpoint id don't collide in the deduper and drop a
-// valid result. ResultID stays the raw, machine-lookup id used for display/JSON.
+// ResultID except for the two id types that are unique only WITHIN a repo — a
+// raw checkpoint id, and the checkpoint id a server-folded legacy session
+// (ENT-1595) falls back to when its sessionId is empty. Both are repo-qualified
+// here so two repos' rows sharing a checkpoint id don't collide in the deduper
+// and drop a valid result. (Commit SHAs and session/repo ids are already global,
+// so they pass through.) ResultID stays the raw, machine-lookup id for display.
 func (r *Result) DedupID() string {
-	if r.Type == TypeSession && r.Session != nil &&
-		r.Session.SessionID == "" && r.Session.CheckpointID != "" {
-		return r.Session.Org + "\x00" + r.Session.Repo + "\x00" + r.Session.CheckpointID
+	switch r.Type {
+	case TypeCheckpoint:
+		if r.Checkpoint != nil && r.Checkpoint.ID != "" {
+			return repoQualifiedCheckpointKey(r.Checkpoint.Org, r.Checkpoint.Repo, r.Checkpoint.ID)
+		}
+	case TypeSession:
+		if r.Session != nil && r.Session.SessionID == "" && r.Session.CheckpointID != "" {
+			return repoQualifiedCheckpointKey(r.Session.Org, r.Session.Repo, r.Session.CheckpointID)
+		}
 	}
 	return r.ResultID()
+}
+
+// repoQualifiedCheckpointKey namespaces a repo-scoped checkpoint id by its repo.
+// org/repo are lowercased because the same repo can reach different cells under
+// different casing (git remote entireio/CLI vs repo index entireio/cli — see
+// resolveRepoFilters), and a casing skew would otherwise leak a duplicate.
+func repoQualifiedCheckpointKey(org, repo, checkpointID string) string {
+	return strings.ToLower(org) + "\x00" + strings.ToLower(repo) + "\x00" + checkpointID
 }
 
 // ResultTitle returns the primary display text for any result type. Repo/PR

--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -379,6 +379,20 @@ func (r *Result) ResultID() string {
 	return r.rawString("id")
 }
 
+// DedupID is the identity used to collapse cross-cell duplicates. It matches
+// ResultID except for a server-folded legacy session (ENT-1595), whose only id
+// is its checkpoint id — unique only WITHIN a repo. That raw id is repo-qualified
+// here (mirroring the search service's synthetic session key) so two repos'
+// legacy rows sharing a checkpoint id don't collide in the deduper and drop a
+// valid result. ResultID stays the raw, machine-lookup id used for display/JSON.
+func (r *Result) DedupID() string {
+	if r.Type == TypeSession && r.Session != nil &&
+		r.Session.SessionID == "" && r.Session.CheckpointID != "" {
+		return r.Session.Org + "\x00" + r.Session.Repo + "\x00" + r.Session.CheckpointID
+	}
+	return r.ResultID()
+}
+
 // ResultTitle returns the primary display text for any result type. Repo/PR
 // raw payloads identify themselves via "title", "name", or "fullName".
 func (r *Result) ResultTitle() string {

--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -118,23 +118,24 @@ type CommitResult struct {
 // SessionResult represents a session returned by the search service.
 type SessionResult struct {
 	SessionID string `json:"sessionId"`
-	// CheckpointID identifies a server-folded legacy session (ENT-1595) whose
-	// sessionId is empty (the checkpoint predates the sessionId attribute). The
-	// cross-cell dedupe (DedupID, not ResultID — which stays the raw display id)
-	// falls back to a repo-qualified form of it, so a repo mirrored across cells
-	// reports each legacy session once instead of twice. Drill-down is
-	// `entire checkpoint explain <checkpointId>`, not `entire session info`.
-	CheckpointID   string  `json:"checkpointId,omitempty"`
-	DisplayName    string  `json:"displayName"`
-	Prompt         *string `json:"prompt"`
-	Agent          *string `json:"agent"`
-	Model          *string `json:"model"`
-	StepCount      int     `json:"stepCount"`
-	Org            string  `json:"org"`
-	Repo           string  `json:"repo"`
-	Branch         *string `json:"branch"`
-	AuthorUsername *string `json:"authorUsername"`
-	CreatedAt      string  `json:"createdAt"`
+	// MatchedCheckpointID is the carrier checkpoint the search service anchors a
+	// session row to — present on every session row. For a server-folded legacy
+	// session (ENT-1595) the sessionId is empty and this IS the row's identity
+	// (the checkpoint predates the sessionId attribute), so ResultID and the
+	// cross-cell dedupe (DedupID) fall back to it, repo-qualified, and a mirrored
+	// repo reports the row once instead of twice. Drill-down is
+	// `entire checkpoint explain <id>`, not `entire session info`.
+	MatchedCheckpointID string  `json:"matchedCheckpointId,omitempty"`
+	DisplayName         string  `json:"displayName"`
+	Prompt              *string `json:"prompt"`
+	Agent               *string `json:"agent"`
+	Model               *string `json:"model"`
+	StepCount           int     `json:"stepCount"`
+	Org                 string  `json:"org"`
+	Repo                string  `json:"repo"`
+	Branch              *string `json:"branch"`
+	AuthorUsername      *string `json:"authorUsername"`
+	CreatedAt           string  `json:"createdAt"`
 }
 
 // Result wraps a search result with its type and ranking metadata.
@@ -374,7 +375,7 @@ func (r *Result) ResultID() string {
 			if s.SessionID != "" {
 				return s.SessionID
 			}
-			return s.CheckpointID // server-folded legacy session (ENT-1595)
+			return s.MatchedCheckpointID // server-folded legacy session (ENT-1595)
 		}); id != "" {
 		return id
 	}
@@ -386,7 +387,9 @@ func (r *Result) ResultID() string {
 // repo-qualifies so two repos' rows sharing an id don't collide in the deduper
 // and drop a valid result:
 //   - a raw checkpoint id, and the checkpoint id a server-folded legacy session
-//     (ENT-1595) falls back to — checkpoint ids are unique only within a repo;
+//     (ENT-1595) falls back to — checkpoint ids are a mixed space (legacy 12-hex
+//     ids repeat across repos; newer ULIDs are global), so qualifying by repo is
+//     safe for both and necessary for the legacy half;
 //   - a commit SHA — globally unique as a content address, but the SAME commit
 //     legitimately lives in many repos (a fork and its upstream), so a bare SHA
 //     would drop one repo's hit for every shared commit.
@@ -405,8 +408,8 @@ func (r *Result) DedupID() string {
 			return repoQualifiedKey(r.Commit.Org, r.Commit.Repo, r.Commit.CommitSHA)
 		}
 	case TypeSession:
-		if r.Session != nil && r.Session.SessionID == "" && r.Session.CheckpointID != "" {
-			return repoQualifiedKey(r.Session.Org, r.Session.Repo, r.Session.CheckpointID)
+		if r.Session != nil && r.Session.SessionID == "" && r.Session.MatchedCheckpointID != "" {
+			return repoQualifiedKey(r.Session.Org, r.Session.Repo, r.Session.MatchedCheckpointID)
 		}
 	}
 	return r.ResultID()

--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -382,32 +382,42 @@ func (r *Result) ResultID() string {
 }
 
 // DedupID is the identity used to collapse cross-cell duplicates. It matches
-// ResultID except for the two id types that are unique only WITHIN a repo — a
-// raw checkpoint id, and the checkpoint id a server-folded legacy session
-// (ENT-1595) falls back to when its sessionId is empty. Both are repo-qualified
-// here so two repos' rows sharing a checkpoint id don't collide in the deduper
-// and drop a valid result. (Commit SHAs and session/repo ids are already global,
-// so they pass through.) ResultID stays the raw, machine-lookup id for display.
+// ResultID except for the id types that can REPEAT across repos, which it
+// repo-qualifies so two repos' rows sharing an id don't collide in the deduper
+// and drop a valid result:
+//   - a raw checkpoint id, and the checkpoint id a server-folded legacy session
+//     (ENT-1595) falls back to — checkpoint ids are unique only within a repo;
+//   - a commit SHA — globally unique as a content address, but the SAME commit
+//     legitimately lives in many repos (a fork and its upstream), so a bare SHA
+//     would drop one repo's hit for every shared commit.
+//
+// Repo ULIDs and real session ids are globally unique, so they pass through.
+// Mirrors of the SAME repo still carry the same org/repo and collapse correctly.
+// ResultID stays the raw, machine-lookup id for display.
 func (r *Result) DedupID() string {
 	switch r.Type {
 	case TypeCheckpoint:
 		if r.Checkpoint != nil && r.Checkpoint.ID != "" {
-			return repoQualifiedCheckpointKey(r.Checkpoint.Org, r.Checkpoint.Repo, r.Checkpoint.ID)
+			return repoQualifiedKey(r.Checkpoint.Org, r.Checkpoint.Repo, r.Checkpoint.ID)
+		}
+	case TypeCommit:
+		if r.Commit != nil && r.Commit.CommitSHA != "" {
+			return repoQualifiedKey(r.Commit.Org, r.Commit.Repo, r.Commit.CommitSHA)
 		}
 	case TypeSession:
 		if r.Session != nil && r.Session.SessionID == "" && r.Session.CheckpointID != "" {
-			return repoQualifiedCheckpointKey(r.Session.Org, r.Session.Repo, r.Session.CheckpointID)
+			return repoQualifiedKey(r.Session.Org, r.Session.Repo, r.Session.CheckpointID)
 		}
 	}
 	return r.ResultID()
 }
 
-// repoQualifiedCheckpointKey namespaces a repo-scoped checkpoint id by its repo.
+// repoQualifiedKey namespaces a repo-scoped (or repo-shared) id by its repo.
 // org/repo are lowercased because the same repo can reach different cells under
 // different casing (git remote entireio/CLI vs repo index entireio/cli — see
 // resolveRepoFilters), and a casing skew would otherwise leak a duplicate.
-func repoQualifiedCheckpointKey(org, repo, checkpointID string) string {
-	return strings.ToLower(org) + "\x00" + strings.ToLower(repo) + "\x00" + checkpointID
+func repoQualifiedKey(org, repo, id string) string {
+	return strings.ToLower(org) + "\x00" + strings.ToLower(repo) + "\x00" + id
 }
 
 // ResultTitle returns the primary display text for any result type. Repo/PR

--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -117,7 +117,12 @@ type CommitResult struct {
 
 // SessionResult represents a session returned by the search service.
 type SessionResult struct {
-	SessionID      string  `json:"sessionId"`
+	SessionID string `json:"sessionId"`
+	// CheckpointID identifies a server-folded legacy session (ENT-1595) whose
+	// sessionId is empty (the checkpoint predates the sessionId attribute). The
+	// cross-cell dedupe (ResultID) falls back to it so distinct legacy rows are
+	// not collapsed by matching empty sessionIds — matching the BFF's merge.
+	CheckpointID   string  `json:"checkpointId,omitempty"`
 	DisplayName    string  `json:"displayName"`
 	Prompt         *string `json:"prompt"`
 	Agent          *string `json:"agent"`
@@ -363,7 +368,12 @@ func (r *Result) ResultID() string {
 	if id := resultField(r,
 		func(c *CheckpointResult) string { return c.ID },
 		func(c *CommitResult) string { return c.CommitSHA },
-		func(s *SessionResult) string { return s.SessionID }); id != "" {
+		func(s *SessionResult) string {
+			if s.SessionID != "" {
+				return s.SessionID
+			}
+			return s.CheckpointID // server-folded legacy session (ENT-1595)
+		}); id != "" {
 		return id
 	}
 	return r.rawString("id")

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -426,6 +426,28 @@ func TestResultID_SessionFallsBackToCheckpointID(t *testing.T) {
 	}
 }
 
+// TestDedupID_LegacySessionRepoQualified pins the fix for the repo-scoped
+// checkpoint-id collision: checkpoint ids are unique only within a repo, so the
+// legacy-session dedupe key is repo-qualified. Two repos' legacy rows sharing a
+// checkpoint id must NOT collapse, while ResultID stays the raw id for display.
+func TestDedupID_LegacySessionRepoQualified(t *testing.T) {
+	t.Parallel()
+	a := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-dup", Org: "acme", Repo: "backend"}}
+	b := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-dup", Org: "acme", Repo: "frontend"}}
+	if a.DedupID() == b.DedupID() {
+		t.Errorf("same checkpointId in different repos collide: %q", a.DedupID())
+	}
+	// Display id stays the raw checkpoint id (machine-lookup), unqualified.
+	if got := a.ResultID(); got != "cp-dup" {
+		t.Errorf("ResultID = %q, want raw cp-dup", got)
+	}
+	// A real session's DedupID is just its sessionId (no repo qualification).
+	normal := Result{Type: TypeSession, Session: &SessionResult{SessionID: "sess-1", Org: "acme", Repo: "backend"}}
+	if got := normal.DedupID(); got != "sess-1" {
+		t.Errorf("real session DedupID = %q, want sess-1", got)
+	}
+}
+
 func TestSearch_ResultJSONRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -448,6 +448,12 @@ func TestDedupID_RepoQualifiesCheckpointScopedIDs(t *testing.T) {
 	if ca.DedupID() == cb.DedupID() {
 		t.Errorf("checkpoints with same id in different repos collide: %q", ca.DedupID())
 	}
+	// Commit rows too: the same SHA lives in a fork and its upstream (two repos).
+	ma := Result{Type: TypeCommit, Commit: &CommitResult{CommitSHA: "sha-dup", Org: "acme", Repo: "backend"}}
+	mb := Result{Type: TypeCommit, Commit: &CommitResult{CommitSHA: "sha-dup", Org: "acme", Repo: "fork"}}
+	if ma.DedupID() == mb.DedupID() {
+		t.Errorf("same commit SHA in a fork and its upstream collide: %q", ma.DedupID())
+	}
 	// Casing skew across cells (git remote vs repo index) must still dedupe.
 	cUpper := Result{Type: TypeCheckpoint, Checkpoint: &CheckpointResult{ID: "cp-dup", Org: "acme", Repo: "Backend"}}
 	if ca.DedupID() != cUpper.DedupID() {

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -409,10 +409,10 @@ func TestSearch_ResultAccessors(t *testing.T) {
 	}
 }
 
-// TestResultID_SessionFallsBackToCheckpointID pins the ENT-1595 dedupe identity:
+// TestResultID_SessionFallsBackToCheckpointID pins the ENT-1595 display id:
 // a server-folded legacy session has no sessionId, so ResultID falls back to its
-// checkpointId — the cross-cell dedupe then keys on a real identity and distinct
-// legacy rows aren't collapsed, matching the BFF's session merge.
+// checkpointId — giving the row a real id in the TUI and compact JSON instead of
+// a blank one. (Cross-cell dedupe uses DedupID, not ResultID; see below.)
 func TestResultID_SessionFallsBackToCheckpointID(t *testing.T) {
 	t.Parallel()
 	legacy := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-9"}}
@@ -426,20 +426,32 @@ func TestResultID_SessionFallsBackToCheckpointID(t *testing.T) {
 	}
 }
 
-// TestDedupID_LegacySessionRepoQualified pins the fix for the repo-scoped
-// checkpoint-id collision: checkpoint ids are unique only within a repo, so the
-// legacy-session dedupe key is repo-qualified. Two repos' legacy rows sharing a
-// checkpoint id must NOT collapse, while ResultID stays the raw id for display.
-func TestDedupID_LegacySessionRepoQualified(t *testing.T) {
+// TestDedupID_RepoQualifiesCheckpointScopedIDs pins the fix for the repo-scoped
+// checkpoint-id collision: checkpoint ids are unique only within a repo, so both
+// a raw checkpoint row and a folded legacy session's checkpoint fallback are
+// repo-qualified (and lowercased) in the dedupe key. Two repos' rows sharing a
+// checkpoint id must NOT collapse; ResultID stays the raw id for display.
+func TestDedupID_RepoQualifiesCheckpointScopedIDs(t *testing.T) {
 	t.Parallel()
-	a := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-dup", Org: "acme", Repo: "backend"}}
-	b := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-dup", Org: "acme", Repo: "frontend"}}
-	if a.DedupID() == b.DedupID() {
-		t.Errorf("same checkpointId in different repos collide: %q", a.DedupID())
+	// Legacy session: same checkpoint id, different repos → distinct dedupe keys.
+	sa := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-dup", Org: "acme", Repo: "backend"}}
+	sb := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-dup", Org: "acme", Repo: "frontend"}}
+	if sa.DedupID() == sb.DedupID() {
+		t.Errorf("legacy sessions with same checkpointId in different repos collide: %q", sa.DedupID())
 	}
-	// Display id stays the raw checkpoint id (machine-lookup), unqualified.
-	if got := a.ResultID(); got != "cp-dup" {
-		t.Errorf("ResultID = %q, want raw cp-dup", got)
+	if got := sa.ResultID(); got != "cp-dup" {
+		t.Errorf("ResultID = %q, want raw cp-dup for display", got)
+	}
+	// Checkpoint rows get the same treatment (they key on a raw, repo-scoped id).
+	ca := Result{Type: TypeCheckpoint, Checkpoint: &CheckpointResult{ID: "cp-dup", Org: "acme", Repo: "backend"}}
+	cb := Result{Type: TypeCheckpoint, Checkpoint: &CheckpointResult{ID: "cp-dup", Org: "acme", Repo: "frontend"}}
+	if ca.DedupID() == cb.DedupID() {
+		t.Errorf("checkpoints with same id in different repos collide: %q", ca.DedupID())
+	}
+	// Casing skew across cells (git remote vs repo index) must still dedupe.
+	cUpper := Result{Type: TypeCheckpoint, Checkpoint: &CheckpointResult{ID: "cp-dup", Org: "acme", Repo: "Backend"}}
+	if ca.DedupID() != cUpper.DedupID() {
+		t.Errorf("casing skew leaks a duplicate: %q vs %q", ca.DedupID(), cUpper.DedupID())
 	}
 	// A real session's DedupID is just its sessionId (no repo qualification).
 	normal := Result{Type: TypeSession, Session: &SessionResult{SessionID: "sess-1", Org: "acme", Repo: "backend"}}

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -415,12 +415,12 @@ func TestSearch_ResultAccessors(t *testing.T) {
 // a blank one. (Cross-cell dedupe uses DedupID, not ResultID; see below.)
 func TestResultID_SessionFallsBackToCheckpointID(t *testing.T) {
 	t.Parallel()
-	legacy := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-9"}}
+	legacy := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", MatchedCheckpointID: "cp-9"}}
 	if got := legacy.ResultID(); got != "cp-9" {
 		t.Errorf("legacy session ResultID = %q, want checkpointId cp-9", got)
 	}
 	// A real session still keys on its sessionId even with a checkpoint anchor.
-	normal := Result{Type: TypeSession, Session: &SessionResult{SessionID: "sess-1", CheckpointID: "cp-1"}}
+	normal := Result{Type: TypeSession, Session: &SessionResult{SessionID: "sess-1", MatchedCheckpointID: "cp-1"}}
 	if got := normal.ResultID(); got != "sess-1" {
 		t.Errorf("real session ResultID = %q, want sess-1", got)
 	}
@@ -434,8 +434,8 @@ func TestResultID_SessionFallsBackToCheckpointID(t *testing.T) {
 func TestDedupID_RepoQualifiesCheckpointScopedIDs(t *testing.T) {
 	t.Parallel()
 	// Legacy session: same checkpoint id, different repos → distinct dedupe keys.
-	sa := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-dup", Org: "acme", Repo: "backend"}}
-	sb := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-dup", Org: "acme", Repo: "frontend"}}
+	sa := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", MatchedCheckpointID: "cp-dup", Org: "acme", Repo: "backend"}}
+	sb := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", MatchedCheckpointID: "cp-dup", Org: "acme", Repo: "frontend"}}
 	if sa.DedupID() == sb.DedupID() {
 		t.Errorf("legacy sessions with same checkpointId in different repos collide: %q", sa.DedupID())
 	}

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -409,6 +409,23 @@ func TestSearch_ResultAccessors(t *testing.T) {
 	}
 }
 
+// TestResultID_SessionFallsBackToCheckpointID pins the ENT-1595 dedupe identity:
+// a server-folded legacy session has no sessionId, so ResultID falls back to its
+// checkpointId — the cross-cell dedupe then keys on a real identity and distinct
+// legacy rows aren't collapsed, matching the BFF's session merge.
+func TestResultID_SessionFallsBackToCheckpointID(t *testing.T) {
+	t.Parallel()
+	legacy := Result{Type: TypeSession, Session: &SessionResult{SessionID: "", CheckpointID: "cp-9"}}
+	if got := legacy.ResultID(); got != "cp-9" {
+		t.Errorf("legacy session ResultID = %q, want checkpointId cp-9", got)
+	}
+	// A real session still keys on its sessionId even with a checkpoint anchor.
+	normal := Result{Type: TypeSession, Session: &SessionResult{SessionID: "sess-1", CheckpointID: "cp-1"}}
+	if got := normal.ResultID(); got != "sess-1" {
+		t.Errorf("real session ResultID = %q, want sess-1", got)
+	}
+}
+
 func TestSearch_ResultJSONRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -523,7 +523,7 @@ func dedupSemanticResults(merged []search.Result) ([]search.Result, map[string]i
 	dupesByType := make(map[string]int)
 	deduped := merged[:0]
 	for _, r := range merged {
-		id := r.ResultID()
+		id := r.DedupID()
 		if id == "" {
 			deduped = append(deduped, r)
 			continue

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -12,6 +12,53 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/search"
 )
 
+// --- dedup ------------------------------------------------------------------
+
+// TestDedupSemanticResults_LegacySessions exercises the deduper itself (not just
+// DedupID in isolation) over server-folded legacy sessions (ENT-1595) — the
+// behavior that actually matters. On main these rows had an empty ResultID and
+// so were never deduped at all: a repo mirrored across cells double-reported
+// each one. DedupID now gives them a repo-qualified identity.
+func TestDedupSemanticResults_LegacySessions(t *testing.T) {
+	t.Parallel()
+
+	// Distinct legacy sessions (different checkpoints) must all survive.
+	if out, _ := dedupSemanticResults([]search.Result{
+		v4LegacySession("cp-a", "backend", 0.9),
+		v4LegacySession("cp-b", "backend", 0.8),
+	}); len(out) != 2 {
+		t.Errorf("distinct legacy rows collapsed: in=2 out=%d", len(out))
+	}
+
+	// The SAME legacy session mirrored across cells collapses to one.
+	out, dupes := dedupSemanticResults([]search.Result{
+		v4LegacySession("cp-x", "backend", 0.9),
+		v4LegacySession("cp-x", "backend", 0.8),
+	})
+	if len(out) != 1 {
+		t.Errorf("mirrored legacy row not deduped: in=2 out=%d", len(out))
+	}
+	if dupes[search.TypeSession] != 1 {
+		t.Errorf("dupe tally = %v, want session:1", dupes)
+	}
+
+	// Repo casing skew across cells (git remote vs repo index) still dedupes.
+	if out, _ := dedupSemanticResults([]search.Result{
+		v4LegacySession("cp-x", "backend", 0.9),
+		v4LegacySession("cp-x", "Backend", 0.8),
+	}); len(out) != 1 {
+		t.Errorf("casing skew leaked a duplicate: in=2 out=%d", len(out))
+	}
+
+	// Two repos sharing a checkpoint id are distinct sessions — must NOT collapse.
+	if out, _ := dedupSemanticResults([]search.Result{
+		v4LegacySession("cp-dup", "backend", 0.9),
+		v4LegacySession("cp-dup", "frontend", 0.8),
+	}); len(out) != 2 {
+		t.Errorf("cross-repo same-checkpointId collapsed: in=2 out=%d", len(out))
+	}
+}
+
 // --- helpers -----------------------------------------------------------------
 
 func fptr(f float64) *float64 { return &f }
@@ -38,6 +85,16 @@ func v4Commit(sha string, tier int, meta search.Meta) search.Result {
 		Type:   search.TypeCommit,
 		Meta:   meta,
 		Commit: &search.CommitResult{CommitSHA: sha},
+	}
+}
+
+// v4LegacySession builds a server-folded legacy session row (ENT-1595): empty
+// sessionId, its identity carried by a repo-scoped checkpoint id under org acme.
+func v4LegacySession(checkpointID, repo string, score float64) search.Result {
+	return search.Result{
+		Type:    search.TypeSession,
+		Meta:    search.Meta{Score: score},
+		Session: &search.SessionResult{SessionID: "", CheckpointID: checkpointID, Org: "acme", Repo: repo},
 	}
 }
 

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -105,7 +105,7 @@ func v4RepoScopedRow(typ, id, repo string, score float64) search.Result {
 	r := search.Result{Type: typ, Meta: search.Meta{Score: score}}
 	switch typ {
 	case search.TypeSession:
-		r.Session = &search.SessionResult{SessionID: "", CheckpointID: id, Org: "acme", Repo: repo}
+		r.Session = &search.SessionResult{SessionID: "", MatchedCheckpointID: id, Org: "acme", Repo: repo}
 	case search.TypeCheckpoint:
 		r.Checkpoint = &search.CheckpointResult{ID: id, Org: "acme", Repo: repo}
 	case search.TypeCommit:

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -14,48 +14,57 @@ import (
 
 // --- dedup ------------------------------------------------------------------
 
-// TestDedupSemanticResults_LegacySessions exercises the deduper itself (not just
-// DedupID in isolation) over server-folded legacy sessions (ENT-1595) — the
-// behavior that actually matters. On main these rows had an empty ResultID and
-// so were never deduped at all: a repo mirrored across cells double-reported
-// each one. DedupID now gives them a repo-qualified identity.
-func TestDedupSemanticResults_LegacySessions(t *testing.T) {
+// TestDedupSemanticResults_RepoScopedIDs exercises the deduper itself (not just
+// DedupID in isolation) over every id type that can repeat across repos:
+// server-folded legacy sessions (ENT-1595), raw checkpoints, and commits (the
+// same SHA lives in a fork and its upstream). On main these rows either had an
+// empty ResultID (legacy sessions, never deduped) or a bare repo-scoped/shared
+// id (checkpoints/commits, collapsed across repos). DedupID now repo-qualifies
+// all three, so the same four cases must hold for each.
+func TestDedupSemanticResults_RepoScopedIDs(t *testing.T) {
 	t.Parallel()
 
-	// Distinct legacy sessions (different checkpoints) must all survive.
-	if out, _ := dedupSemanticResults([]search.Result{
-		v4LegacySession("cp-a", "backend", 0.9),
-		v4LegacySession("cp-b", "backend", 0.8),
-	}); len(out) != 2 {
-		t.Errorf("distinct legacy rows collapsed: in=2 out=%d", len(out))
-	}
+	for _, typ := range []string{search.TypeSession, search.TypeCheckpoint, search.TypeCommit} {
+		t.Run(typ, func(t *testing.T) {
+			t.Parallel()
 
-	// The SAME legacy session mirrored across cells collapses to one.
-	out, dupes := dedupSemanticResults([]search.Result{
-		v4LegacySession("cp-x", "backend", 0.9),
-		v4LegacySession("cp-x", "backend", 0.8),
-	})
-	if len(out) != 1 {
-		t.Errorf("mirrored legacy row not deduped: in=2 out=%d", len(out))
-	}
-	if dupes[search.TypeSession] != 1 {
-		t.Errorf("dupe tally = %v, want session:1", dupes)
-	}
+			// Distinct ids in the same repo must all survive.
+			if out, _ := dedupSemanticResults([]search.Result{
+				v4RepoScopedRow(typ, "id-a", "backend", 0.9),
+				v4RepoScopedRow(typ, "id-b", "backend", 0.8),
+			}); len(out) != 2 {
+				t.Errorf("distinct ids collapsed: in=2 out=%d", len(out))
+			}
 
-	// Repo casing skew across cells (git remote vs repo index) still dedupes.
-	if out, _ := dedupSemanticResults([]search.Result{
-		v4LegacySession("cp-x", "backend", 0.9),
-		v4LegacySession("cp-x", "Backend", 0.8),
-	}); len(out) != 1 {
-		t.Errorf("casing skew leaked a duplicate: in=2 out=%d", len(out))
-	}
+			// The SAME row from a repo mirrored across cells collapses to one.
+			out, dupes := dedupSemanticResults([]search.Result{
+				v4RepoScopedRow(typ, "id-x", "backend", 0.9),
+				v4RepoScopedRow(typ, "id-x", "backend", 0.8),
+			})
+			if len(out) != 1 {
+				t.Errorf("mirrored row not deduped: in=2 out=%d", len(out))
+			}
+			if dupes[typ] != 1 {
+				t.Errorf("dupe tally = %v, want %s:1", dupes, typ)
+			}
 
-	// Two repos sharing a checkpoint id are distinct sessions — must NOT collapse.
-	if out, _ := dedupSemanticResults([]search.Result{
-		v4LegacySession("cp-dup", "backend", 0.9),
-		v4LegacySession("cp-dup", "frontend", 0.8),
-	}); len(out) != 2 {
-		t.Errorf("cross-repo same-checkpointId collapsed: in=2 out=%d", len(out))
+			// Repo casing skew across cells (git remote vs repo index) still dedupes.
+			if out, _ := dedupSemanticResults([]search.Result{
+				v4RepoScopedRow(typ, "id-x", "backend", 0.9),
+				v4RepoScopedRow(typ, "id-x", "Backend", 0.8),
+			}); len(out) != 1 {
+				t.Errorf("casing skew leaked a duplicate: in=2 out=%d", len(out))
+			}
+
+			// The same id in DIFFERENT repos (a fork/upstream, or two legacy repos)
+			// is a distinct result — it must NOT collapse.
+			if out, _ := dedupSemanticResults([]search.Result{
+				v4RepoScopedRow(typ, "id-dup", "backend", 0.9),
+				v4RepoScopedRow(typ, "id-dup", "frontend", 0.8),
+			}); len(out) != 2 {
+				t.Errorf("cross-repo same id collapsed: in=2 out=%d", len(out))
+			}
+		})
 	}
 }
 
@@ -88,14 +97,21 @@ func v4Commit(sha string, tier int, meta search.Meta) search.Result {
 	}
 }
 
-// v4LegacySession builds a server-folded legacy session row (ENT-1595): empty
-// sessionId, its identity carried by a repo-scoped checkpoint id under org acme.
-func v4LegacySession(checkpointID, repo string, score float64) search.Result {
-	return search.Result{
-		Type:    search.TypeSession,
-		Meta:    search.Meta{Score: score},
-		Session: &search.SessionResult{SessionID: "", CheckpointID: checkpointID, Org: "acme", Repo: repo},
+// v4RepoScopedRow builds a result whose dedup identity is repo-qualified: a
+// server-folded legacy session (ENT-1595, empty sessionId), a raw checkpoint, or
+// a commit — all under org acme, with the given repo. id is the checkpoint id /
+// commit SHA the row carries.
+func v4RepoScopedRow(typ, id, repo string, score float64) search.Result {
+	r := search.Result{Type: typ, Meta: search.Meta{Score: score}}
+	switch typ {
+	case search.TypeSession:
+		r.Session = &search.SessionResult{SessionID: "", CheckpointID: id, Org: "acme", Repo: repo}
+	case search.TypeCheckpoint:
+		r.Checkpoint = &search.CheckpointResult{ID: id, Org: "acme", Repo: repo}
+	case search.TypeCommit:
+		r.Commit = &search.CommitResult{CommitSHA: id, Org: "acme", Repo: repo}
 	}
+	return r
 }
 
 // v4RepoRow builds a repo-type result via the wire format, since repo rows


### PR DESCRIPTION
## What was broken

When the search service folds legacy checkpoints into sessions (ENT-1595), those rows arrive with an **empty sessionId**. In the CLI that caused two problems:

1. The cross-cell deduper skips rows with an empty id, so it never deduped legacy sessions at all — a repo mirrored across cells reported each legacy session **twice**.
2. Those rows showed a **blank id** in results (the TUI id column and the agent-facing compact JSON).

(Note: unlike the web BFF — whose deduper keyed empty sessionIds on `""` and genuinely collapsed legacy rows — the CLI deduper short-circuits on an empty id, so its bug was the opposite: a duplicate leak, not a collapse.)

## Why

Legacy checkpoints predate the sessionId attribute, so their only stable identity is their checkpoint id — which the CLI wasn't using for dedup or display.

## The fix

1. Give a legacy folded session a real display id by falling back to its checkpoint id (no more blank id column / JSON field).
2. Dedupe on a repo-qualified key: checkpoint ids are unique only within a repo, so the key qualifies by org/repo (lowercased, to survive casing skew across cells). Genuinely duplicated legacy rows now collapse across cells; two repos' rows that happen to share a checkpoint id stay distinct. The same qualification is applied to raw checkpoint rows, which had the identical hazard.
3. `ResultID` stays the raw, machine-lookup id for display; a separate `DedupID` carries the repo-qualified identity.

## Verified

Unit tests plus a deduper-level test over legacy rows: distinct rows kept, mirrored rows collapsed, casing skew handled, cross-repo rows not collapsed.
