### PR TITLE
fix(login): don't close the TTY a killed Bubble Tea reader still holds

### DIFF
--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -721,7 +721,16 @@ func readLoginURLAction(ctx context.Context, errW io.Writer) (loginURLAction, er
 // escape-sequence decoding, cancellation, and terminal restoration. If the
 // terminal cannot provide single-key input, disable key actions.
 func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File) (loginURLAction, error) {
-	defer tty.Close()
+	// Normally this function owns tty and closes it on the way out. The one
+	// exception is a cancelled context — see the comment below — so the close is
+	// conditional rather than a plain defer.
+	closeTTY := true
+	defer func() {
+		if closeTTY {
+			_ = tty.Close()
+		}
+	}()
+
 	if !interactive.IsTerminalReader(tty) {
 		return loginURLNone, nil
 	}
@@ -735,6 +744,20 @@ func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File
 		tea.WithoutSignalHandler(),
 	).Run()
 	if ctx.Err() != nil {
+		// Do NOT close tty here. When the program is killed by context
+		// cancellation, Bubble Tea's shutdown(kill=true) deliberately skips
+		// waitForReadLoop(), so its input reader goroutine can still be running
+		// after Run returns. On Linux that reader is cancelreader's epoll
+		// implementation, whose wait loop reads tty.Fd() — closing the descriptor
+		// underneath it is a data race (the race detector catches it as
+		// poll.(*FD).destroy vs os.(*File).Fd), and freeing the number lets an
+		// unrelated open reuse it while a live reader still holds the File.
+		//
+		// Bubble Tea exposes nothing to join that goroutine: Program.Wait only
+		// waits on a channel Run already closed via defer. So leave the descriptor
+		// for process exit to reclaim. `entire login` is short-lived and cancels
+		// at most once per sign-in, so this is bounded to a single descriptor.
+		closeTTY = false
 		return loginURLNone, fmt.Errorf("interrupted: %w", ctx.Err())
 	}
 	if err != nil {

--- a/cmd/entire/cli/login_tty_test.go
+++ b/cmd/entire/cli/login_tty_test.go
@@ -191,6 +191,41 @@ func TestReadLoginURLActionFromTTY_ControlCRecordsInterrupt(t *testing.T) {
 	assertLoginPromptTTYRestored(t, observer, before)
 }
 
+// TestReadLoginURLActionFromTTY_CancelledLeavesDescriptorOpen pins the one
+// exception to this function owning the descriptor it is handed.
+//
+// When the program is killed by context cancellation, Bubble Tea's
+// shutdown(kill=true) skips waitForReadLoop(), so its input reader goroutine can
+// outlive Run. Closing the descriptor there races that reader (on Linux
+// cancelreader's epoll wait loop reads tty.Fd()) and frees an fd number the live
+// reader still holds, so the cancelled path must leave the descriptor alone.
+func TestReadLoginURLActionFromTTY_CancelledLeavesDescriptorOpen(t *testing.T) {
+	t.Parallel()
+
+	ptmx, tty, observer, _ := openLoginPromptPTY(t)
+	defer ptmx.Close()
+	defer observer.Close()
+	// Ownership stays with us on this path, so this close is the real one.
+	defer tty.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	action, err := readLoginURLActionFromTTY(ctx, io.Discard, tty)
+	if action != loginURLNone {
+		t.Errorf("action = %v, want loginURLNone", action)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+
+	// A closed *os.File reports Fd() as -1, so this fails if the descriptor was
+	// reclaimed while a killed reader could still be holding it.
+	if _, err := term.GetState(int(tty.Fd())); err != nil {
+		t.Errorf("descriptor was closed on the cancelled path: %v", err)
+	}
+}
+
 func openLoginPromptPTY(t *testing.T) (ptmx, tty, observer *os.File, before *term.State) {
 	t.Helper()
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1057
<!-- entire-trail-link-end -->

## Symptom

`test` and `test-core` fail intermittently on `main` and on PRs, reporting ~30 unrelated failures in the `cli` package at once — `TestMergeUnique`, `TestActivityModel_ScrollKeys`, `TestBuildRepoDir`, and so on. That breadth is misleading: one failure kills the test binary and everything in the package is reported failed.

The real failure is a **data race**, which is why only the `-race` jobs catch it:

```
Read at 0x... by goroutine 11000:
  os.(*File).Fd()
  cancelreader.(*epollCancelReader).wait()
  ultraviolet.(*TerminalReader).StreamEvents.func1()

Previous write at 0x... by goroutine 10991:
  internal/poll.(*FD).destroy()
  os.(*File).Close()
  cli.readLoginURLActionFromTTY.deferwrap1()      login.go:724
```

## Cause

`readLoginURLActionFromTTY` closed its descriptor unconditionally via `defer`. But when the program is killed by context cancellation, Bubble Tea's shutdown skips joining the input reader:

```go
// bubbletea/tea.go
func (p *Program) shutdown(kill bool) {
	...
	if p.cancelReader.Cancel() {
		if !kill {
			p.waitForReadLoop()   // ← skipped when kill == true
		}
	}
```

Context cancellation takes `p.shutdown(true)`, so `StreamEvents` can still be running when `Run` returns. On Linux that reader is cancelreader's epoll implementation, whose wait loop reads `tty.Fd()` — so our close races it. Beyond the race, freeing the descriptor number lets an unrelated `open` reuse it while a live reader still holds the `File`.

macOS uses a different cancelreader that doesn't touch `Fd()`, which is why this never reproduces locally and only ever failed on CI.

## Fix

Don't reclaim the descriptor on the cancelled path; let process exit do it. Every other path closes exactly as before.

There is no way to join that goroutine: `Program.Wait()` looks like the answer but only waits on a channel `Run` has already closed via `defer`, so it returns immediately (and would block forever on the one early return where `p.finished` is still nil). I tried that first; it does nothing.

`entire login` is short-lived and cancels at most once per sign-in, so the cost is a single descriptor.

## Testing

`TestReadLoginURLActionFromTTY_CancelledLeavesDescriptorOpen` pins the ownership rule portably — it asserts the descriptor is still usable after a cancelled read, and fails with `bad file descriptor` against the old unconditional close, so it's a real guard rather than a passing formality. Verified RED → GREEN.

The existing `TestReadLoginURLActionFromTTY_UnavailableInputContinuesAndCloses` still covers the close-on-other-paths half, so both sides of the contract are held.

`mise run fmt && lint` clean (0 issues), `mise run test:ci` green (56 unit + 4 canary). Since the race is Linux-only, this PR's own CI is the real verification.

## Upstream

Worth reporting to charmbracelet: `cancelreader`'s epoll path reads `File.Fd()` in its wait loop after `Close()`, and `shutdown(kill=true)` leaves that reader unjoined with no API to await it.

Found while diagnosing CI failures on #2002, which was blocked by this and is otherwise green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f40fd7340d6f980971cdbdea7fae400d334903d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->