### PR TITLE
fix(login): shut the key reader down gracefully so nothing races its fd

### DIFF
--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -62,6 +62,12 @@ type loginURLActionReadFunc func(ctx context.Context) (loginURLAction, error)
 // clipboardCopyTimeout bounds a single clipboard write. See copyLoginURL.
 const clipboardCopyTimeout = 3 * time.Second
 
+// loginURLQuitGrace bounds how long a cancelled key-reader waits for Bubble
+// Tea's graceful shutdown before being killed instead. Generous: Run's own
+// read-loop join is capped at 500ms, so a healthy program returns well inside
+// this. See readLoginURLActionFromTTY.
+const loginURLQuitGrace = 2 * time.Second
+
 // loginURLInteractor owns the side effects behind the interactive URL prompt.
 // Production uses the controlling TTY, system clipboard, and default browser;
 // tests provide deterministic functions instead. keysAvailable answers whether
@@ -717,13 +723,14 @@ func readLoginURLAction(ctx context.Context, errW io.Writer) (loginURLAction, er
 	return readLoginURLActionFromTTY(ctx, errW, tty)
 }
 
-// readLoginURLActionFromTTY takes ownership of tty. Bubble Tea handles raw mode,
-// escape-sequence decoding, cancellation, and terminal restoration. If the
-// terminal cannot provide single-key input, disable key actions.
+// readLoginURLActionFromTTY takes ownership of tty and closes it on every path.
+// Bubble Tea handles raw mode, escape-sequence decoding, and terminal
+// restoration; cancellation is translated into a Quit here rather than handed to
+// Bubble Tea as a context. If the terminal cannot provide single-key input,
+// disable key actions.
 func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File) (loginURLAction, error) {
-	// Normally this function owns tty and closes it on the way out. The one
-	// exception is a cancelled context — see the comment below — so the close is
-	// conditional rather than a plain defer.
+	// Closed on every path except a killed Run — see the closeTTY assignment
+	// below, which is the only case where something may still hold the fd.
 	closeTTY := true
 	defer func() {
 		if closeTTY {
@@ -735,29 +742,65 @@ func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File
 		return loginURLNone, nil
 	}
 
-	model := loginURLActionModel{}
-	finalModel, err := tea.NewProgram(
-		model,
-		tea.WithContext(ctx),
+	// Nothing to read once we are already cancelled, and returning here means no
+	// program — hence no input reader — is ever started.
+	if err := ctx.Err(); err != nil {
+		return loginURLNone, fmt.Errorf("interrupted: %w", err)
+	}
+
+	// killCtx, not ctx, is Bubble Tea's context, and it is cancelled only as a
+	// last resort below. Handing it ctx directly makes every cancellation a
+	// *killed* Run (Run derives `killed` from externalCtx.Err() || ctx.Err() ||
+	// err != nil), and shutdown(kill=true) skips waitForReadLoop() before closing
+	// its cancelreader. That closes two descriptors under a live reader: tty, and
+	// — inside cancelreader itself — its own cancel-signal pipe, whose Fd() the
+	// reader reads on wake. Both are data races that fail the whole package under
+	// -race, and the second is upstream, so no care on this side avoids it.
+	killCtx, kill := context.WithCancel(context.Background())
+	defer kill()
+
+	program := tea.NewProgram(
+		loginURLActionModel{},
+		tea.WithContext(killCtx),
 		tea.WithInput(tty),
 		tea.WithOutput(io.Discard),
 		tea.WithoutSignalHandler(),
-	).Run()
-	if ctx.Err() != nil {
-		// Do NOT close tty here. When the program is killed by context
-		// cancellation, Bubble Tea's shutdown(kill=true) deliberately skips
-		// waitForReadLoop(), so its input reader goroutine can still be running
-		// after Run returns. On Linux that reader is cancelreader's epoll
-		// implementation, whose wait loop reads tty.Fd() — closing the descriptor
-		// underneath it is a data race (the race detector catches it as
-		// poll.(*FD).destroy vs os.(*File).Fd), and freeing the number lets an
-		// unrelated open reuse it while a live reader still holds the File.
-		//
-		// Bubble Tea exposes nothing to join that goroutine: Program.Wait only
-		// waits on a channel Run already closed via defer. So leave the descriptor
-		// for process exit to reclaim. `entire login` is short-lived and cancels
-		// at most once per sign-in, so this is bounded to a single descriptor.
+	)
+
+	// Translate cancellation into Quit, which arrives as a QuitMsg that eventLoop
+	// returns with a nil error, so `killed` stays false and shutdown joins the
+	// read loop before closing anything.
+	runDone := make(chan struct{})
+	go func() {
+		select {
+		case <-runDone:
+			return
+		case <-ctx.Done():
+		}
+		// Quit sends on an unbuffered channel, so it blocks until the event loop
+		// takes it. Run it separately so a loop that never does cannot also block
+		// the fallback below; kill() releases it, since Send selects on the
+		// program's own context.
+		go program.Quit()
+		select {
+		case <-runDone:
+		case <-time.After(loginURLQuitGrace):
+			// The graceful path did not land. Kill rather than hang: a caller that
+			// has already authenticated joins this read (finishActionRead), so
+			// blocking here would strand a completed sign-in.
+			kill()
+		}
+	}()
+
+	finalModel, err := program.Run()
+	close(runDone)
+	if errors.Is(err, tea.ErrProgramKilled) {
+		// Only reachable via the fallback above. A killed Run skipped
+		// waitForReadLoop, so the input reader may still be holding tty; leave the
+		// descriptor for process exit rather than race the reader for it.
 		closeTTY = false
+	}
+	if ctx.Err() != nil {
 		return loginURLNone, fmt.Errorf("interrupted: %w", ctx.Err())
 	}
 	if err != nil {
@@ -767,14 +810,13 @@ func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File
 		return loginURLNone, nil
 	}
 
-	// Defensive: unreachable as configured. Run() only returns a nil error via a
-	// graceful QuitMsg, whose sole source here is the tea.Quit below — returned
-	// only once selected is set — because WithoutSignalHandler removes
-	// InterruptMsg and eventLoop's other nil returns imply a cancelled context,
-	// which the check above already caught. Degrade rather than abort anyway: a
-	// future keybinding, filter, or signal handler could arm this branch, and
-	// losing keyboard access must never kill a sign-in the visible URL can still
-	// complete.
+	// Defensive: unreachable as configured. Run() returns a nil error via a
+	// graceful QuitMsg, and both sources of one are already accounted for — the
+	// model's tea.Quit, returned only once selected is set, and the Quit sent on
+	// cancellation, which the ctx.Err() check above returns before. Degrade
+	// rather than abort anyway: a future keybinding, filter, or signal handler
+	// could arm this branch, and losing keyboard access must never kill a
+	// sign-in the visible URL can still complete.
 	result, ok := finalModel.(loginURLActionModel)
 	if !ok || !result.selected {
 		fmt.Fprintln(errW, "Warning: keyboard actions unavailable; open the login URL above to continue.")

--- a/cmd/entire/cli/login_tty_test.go
+++ b/cmd/entire/cli/login_tty_test.go
@@ -196,17 +196,33 @@ func TestReadLoginURLActionFromTTY_ControlCRecordsInterrupt(t *testing.T) {
 //
 // When the program is killed by context cancellation, Bubble Tea's
 // shutdown(kill=true) skips waitForReadLoop(), so its input reader goroutine can
-// outlive Run. Closing the descriptor there races that reader (on Linux
-// cancelreader's epoll wait loop reads tty.Fd()) and frees an fd number the live
-// reader still holds, so the cancelled path must leave the descriptor alone.
+// outlive Run. Closing the descriptor there races that reader (cancelreader
+// reads tty.Fd() after each wake — epoll on Linux, kqueue on darwin) and frees
+// an fd number the live reader still holds, so neither the cancelled path nor
+// this test's own teardown may close it.
 func TestReadLoginURLActionFromTTY_CancelledLeavesDescriptorOpen(t *testing.T) {
 	t.Parallel()
 
 	ptmx, tty, observer, _ := openLoginPromptPTY(t)
 	defer ptmx.Close()
 	defer observer.Close()
-	// Ownership stays with us on this path, so this close is the real one.
-	defer tty.Close()
+
+	// There is deliberately no `defer tty.Close()`: teardown is not late enough,
+	// because the killed reader can still be in its wait on this descriptor.
+	// t.Cleanup runs after the deferred closes above, so this fails — on every
+	// platform, rather than whenever the race detector happens to catch it — if
+	// anyone adds one back.
+	//
+	// It checks the descriptor number, not the terminal state: Close sets Sysfd
+	// to -1 in shared code (internal/poll (*FD).destroy), whereas tcgetattr on
+	// the slave reports EIO on Linux once the deferred ptmx.Close above has
+	// revoked the pty — an open descriptor that a terminal-state probe would
+	// report as closed.
+	t.Cleanup(func() {
+		if int(tty.Fd()) < 0 {
+			t.Error("tty was closed during teardown")
+		}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/cmd/entire/cli/login_tty_test.go
+++ b/cmd/entire/cli/login_tty_test.go
@@ -191,38 +191,21 @@ func TestReadLoginURLActionFromTTY_ControlCRecordsInterrupt(t *testing.T) {
 	assertLoginPromptTTYRestored(t, observer, before)
 }
 
-// TestReadLoginURLActionFromTTY_CancelledLeavesDescriptorOpen pins the one
-// exception to this function owning the descriptor it is handed.
+// TestReadLoginURLActionFromTTY_CancelledClosesDescriptor pins that the
+// cancelled path owns and closes the descriptor like every other path.
 //
-// When the program is killed by context cancellation, Bubble Tea's
-// shutdown(kill=true) skips waitForReadLoop(), so its input reader goroutine can
-// outlive Run. Closing the descriptor there races that reader (cancelreader
-// reads tty.Fd() after each wake — epoll on Linux, kqueue on darwin) and frees
-// an fd number the live reader still holds, so neither the cancelled path nor
-// this test's own teardown may close it.
-func TestReadLoginURLActionFromTTY_CancelledLeavesDescriptorOpen(t *testing.T) {
+// It used to be the one exception: cancellation reached Bubble Tea as a context,
+// which makes Run a *killed* Run, and shutdown(kill=true) skips
+// waitForReadLoop(), so the input reader could outlive Run and still be reading
+// tty.Fd(). Closing underneath it was a data race. Driving shutdown with Quit
+// instead takes the graceful path, which joins the read loop first, so there is
+// no live reader left to race and nothing to leak.
+func TestReadLoginURLActionFromTTY_CancelledClosesDescriptor(t *testing.T) {
 	t.Parallel()
 
 	ptmx, tty, observer, _ := openLoginPromptPTY(t)
 	defer ptmx.Close()
 	defer observer.Close()
-
-	// There is deliberately no `defer tty.Close()`: teardown is not late enough,
-	// because the killed reader can still be in its wait on this descriptor.
-	// t.Cleanup runs after the deferred closes above, so this fails — on every
-	// platform, rather than whenever the race detector happens to catch it — if
-	// anyone adds one back.
-	//
-	// It checks the descriptor number, not the terminal state: Close sets Sysfd
-	// to -1 in shared code (internal/poll (*FD).destroy), whereas tcgetattr on
-	// the slave reports EIO on Linux once the deferred ptmx.Close above has
-	// revoked the pty — an open descriptor that a terminal-state probe would
-	// report as closed.
-	t.Cleanup(func() {
-		if int(tty.Fd()) < 0 {
-			t.Error("tty was closed during teardown")
-		}
-	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -235,10 +218,12 @@ func TestReadLoginURLActionFromTTY_CancelledLeavesDescriptorOpen(t *testing.T) {
 		t.Errorf("err = %v, want context.Canceled", err)
 	}
 
-	// A closed *os.File reports Fd() as -1, so this fails if the descriptor was
-	// reclaimed while a killed reader could still be holding it.
-	if _, err := term.GetState(int(tty.Fd())); err != nil {
-		t.Errorf("descriptor was closed on the cancelled path: %v", err)
+	// Close sets Sysfd to -1 (internal/poll (*FD).destroy), so the descriptor
+	// number is the platform-independent signal that the function closed it.
+	// Terminal state is not: tcgetattr here would report EIO on Linux merely
+	// because ptmx is still open, saying nothing about ownership.
+	if int(tty.Fd()) >= 0 {
+		t.Error("cancelled path did not close the descriptor")
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1058
<!-- entire-trail-link-end -->

## The flake

`test-core` fails intermittently with a data race, and because the race detector fails the whole package, one landing takes ~20 unrelated parallel tests down with it — each reporting only `race detected during execution of test`, which hides the single real cause.

It has hit main twice: on the merge run of #2006 (`31836107297`, Aug 14) and again three days later on an unrelated PR (#1981), with green main runs in between.

## One cause, two racing pairs

bubbletea's `shutdown` does this:

```go
if p.cancelReader.Cancel() {
	if !kill {
		p.waitForReadLoop()
	}
}
_ = p.cancelReader.Close()
```

On a **killed** `Run` it skips the join, so `Close` lands while the input reader may still be inside `wait()`. That reader reads two descriptors on wake:

1. **`tty.Fd()`** — ours. This is the pair #2006 designed around by leaking the descriptor, and the pair its regression test then re-created by closing that descriptor in teardown.
2. **`cancelSignalReader.Fd()`** — cancelreader's own cancel-signal pipe, which `Close()` closes (`cancelreader_bsd.go:109`, `cancelreader_linux.go:118`) while `wait()` reads it (`:141`, `:150`). Entirely upstream; nothing on our side can avoid it.

And `Run` treats a cancelled context as killed:

```go
killed := p.externalCtx.Err() != nil || p.ctx.Err() != nil || err != nil
```

So passing `ctx` to `tea.WithContext` made **every** cancellation take the racy path. That matters more than it sounds: cancellation is the *normal* path here, not an edge case — `waitForLoginURLResult` cancels the reader as soon as authentication completes, so every sign-in where the user doesn't press a key went through it.

## The fix: stop cancelling, start quitting

`Quit` delivers a `QuitMsg`, which `eventLoop` returns with a **nil** error, so `killed` stays false and `shutdown` joins the read loop before closing anything. Nothing holds either descriptor by the time they're closed — which kills **both** pairs, including the upstream one, without patching upstream.

It also means `tty` can simply be closed on the cancelled path rather than leaked, so the conditional close, the long comment, the teardown tripwire, and the leak all go away.

**Not a bare swap.** `Quit` sends on an unbuffered channel, so an event loop that never takes it would block `Quit` forever — and `finishActionRead` (`login.go:615`) joins this read once authentication completes, so a hang there would strand a *completed* sign-in. That's a worse failure than the leak being removed. bubbletea therefore keeps its own context, cancelled only if the graceful path doesn't land within `loginURLQuitGrace`, and the descriptor is left alone in exactly that case — keyed on `tea.ErrProgramKilled`, the upstream signal, rather than on a proxy for it.

## Verification

On darwin under `-race`:

| Load | Races before | Races after |
|---|---|---|
| 2000× the cancelled test | reproduced the cancelreader pair | **0** |
| 2×1500× every TTY test | — | **0** |

Plus `go test -race ./cmd/entire/cli/`, `mise run test:ci`, and `mise run lint` all green.

The before/after comparison is the load-bearing evidence here: the same 2000-iteration run that reliably surfaced the upstream pair on the previous commit is now clean, which is what distinguishes this from the partial fix.

## Test change

`TestReadLoginURLActionFromTTY_CancelledLeavesDescriptorOpen` becomes `_CancelledClosesDescriptor`. Its premise inverted — the cancelled path now owns the descriptor like every other path. It asserts on the descriptor *number* (`Close` sets `Sysfd` to -1 in `internal/poll.(*FD).destroy`, so it's platform-independent) rather than terminal state, which would report EIO on Linux merely because `ptmx` is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
