### PR TITLE
refactor(login): collapse the quit watchdog into context.AfterFunc

### DIFF
--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -62,12 +62,6 @@ type loginURLActionReadFunc func(ctx context.Context) (loginURLAction, error)
 // clipboardCopyTimeout bounds a single clipboard write. See copyLoginURL.
 const clipboardCopyTimeout = 3 * time.Second
 
-// loginURLQuitGrace bounds how long a cancelled key-reader waits for Bubble
-// Tea's graceful shutdown before being killed instead. Generous: Run's own
-// read-loop join is capped at 500ms, so a healthy program returns well inside
-// this. See readLoginURLActionFromTTY.
-const loginURLQuitGrace = 2 * time.Second
-
 // loginURLInteractor owns the side effects behind the interactive URL prompt.
 // Production uses the controlling TTY, system clipboard, and default browser;
 // tests provide deterministic functions instead. keysAvailable answers whether
@@ -723,14 +717,10 @@ func readLoginURLAction(ctx context.Context, errW io.Writer) (loginURLAction, er
 	return readLoginURLActionFromTTY(ctx, errW, tty)
 }
 
-// readLoginURLActionFromTTY takes ownership of tty and closes it on every path.
-// Bubble Tea handles raw mode, escape-sequence decoding, and terminal
-// restoration; cancellation is translated into a Quit here rather than handed to
-// Bubble Tea as a context. If the terminal cannot provide single-key input,
-// disable key actions.
+// readLoginURLActionFromTTY takes ownership of tty. Bubble Tea handles raw mode,
+// escape-sequence decoding, and terminal restoration. If the terminal cannot
+// provide single-key input, disable key actions.
 func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File) (loginURLAction, error) {
-	// Closed on every path except a killed Run — see the closeTTY assignment
-	// below, which is the only case where something may still hold the fd.
 	closeTTY := true
 	defer func() {
 		if closeTTY {
@@ -742,62 +732,31 @@ func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File
 		return loginURLNone, nil
 	}
 
-	// Nothing to read once we are already cancelled, and returning here means no
-	// program — hence no input reader — is ever started.
+	// Fast path: don't put the terminal in raw mode for a read we would abandon.
 	if err := ctx.Err(); err != nil {
 		return loginURLNone, fmt.Errorf("interrupted: %w", err)
 	}
 
-	// killCtx, not ctx, is Bubble Tea's context, and it is cancelled only as a
-	// last resort below. Handing it ctx directly makes every cancellation a
-	// *killed* Run (Run derives `killed` from externalCtx.Err() || ctx.Err() ||
-	// err != nil), and shutdown(kill=true) skips waitForReadLoop() before closing
-	// its cancelreader. That closes two descriptors under a live reader: tty, and
-	// — inside cancelreader itself — its own cancel-signal pipe, whose Fd() the
-	// reader reads on wake. Both are data races that fail the whole package under
-	// -race, and the second is upstream, so no care on this side avoids it.
-	killCtx, kill := context.WithCancel(context.Background())
-	defer kill()
-
 	program := tea.NewProgram(
 		loginURLActionModel{},
-		tea.WithContext(killCtx),
 		tea.WithInput(tty),
 		tea.WithOutput(io.Discard),
 		tea.WithoutSignalHandler(),
 	)
 
-	// Translate cancellation into Quit, which arrives as a QuitMsg that eventLoop
-	// returns with a nil error, so `killed` stays false and shutdown joins the
-	// read loop before closing anything.
-	runDone := make(chan struct{})
-	go func() {
-		select {
-		case <-runDone:
-			return
-		case <-ctx.Done():
-		}
-		// Quit sends on an unbuffered channel, so it blocks until the event loop
-		// takes it. Run it separately so a loop that never does cannot also block
-		// the fallback below; kill() releases it, since Send selects on the
-		// program's own context.
-		go program.Quit()
-		select {
-		case <-runDone:
-		case <-time.After(loginURLQuitGrace):
-			// The graceful path did not land. Kill rather than hang: a caller that
-			// has already authenticated joins this read (finishActionRead), so
-			// blocking here would strand a completed sign-in.
-			kill()
-		}
-	}()
+	// Cancellation must reach Bubble Tea as a Quit, never as its context: Run
+	// treats a cancelled context as a kill, and shutdown(kill=true) skips
+	// waitForReadLoop() before closing its cancelreader — closing tty, and
+	// cancelreader's own cancel-signal pipe, under a live reader. A QuitMsg leaves
+	// `killed` false, so the read loop is joined before anything closes.
+	stopQuit := context.AfterFunc(ctx, program.Quit)
+	defer stopQuit()
 
 	finalModel, err := program.Run()
-	close(runDone)
 	if errors.Is(err, tea.ErrProgramKilled) {
-		// Only reachable via the fallback above. A killed Run skipped
-		// waitForReadLoop, so the input reader may still be holding tty; leave the
-		// descriptor for process exit rather than race the reader for it.
+		// Bubble Tea reports any event-loop error this way, input-stream failures
+		// included, and a killed Run skipped waitForReadLoop — so the reader may
+		// still hold tty. Let process exit reclaim the fd rather than race for it.
 		closeTTY = false
 	}
 	if ctx.Err() != nil {
@@ -810,12 +769,10 @@ func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File
 		return loginURLNone, nil
 	}
 
-	// Defensive: unreachable as configured. Run() returns a nil error via a
-	// graceful QuitMsg, and both sources of one are already accounted for — the
-	// model's tea.Quit, returned only once selected is set, and the Quit sent on
-	// cancellation, which the ctx.Err() check above returns before. Degrade
-	// rather than abort anyway: a future keybinding, filter, or signal handler
-	// could arm this branch, and losing keyboard access must never kill a
+	// Defensive: unreachable as configured — a nil error means a graceful QuitMsg,
+	// and both sources are handled above (the model's tea.Quit sets selected; the
+	// cancellation Quit is caught by the ctx.Err() check). Degrade anyway: a future
+	// keybinding or filter could arm this, and losing keys must never kill a
 	// sign-in the visible URL can still complete.
 	result, ok := finalModel.(loginURLActionModel)
 	if !ok || !result.selected {

--- a/cmd/entire/cli/login_tty_test.go
+++ b/cmd/entire/cli/login_tty_test.go
@@ -191,15 +191,7 @@ func TestReadLoginURLActionFromTTY_ControlCRecordsInterrupt(t *testing.T) {
 	assertLoginPromptTTYRestored(t, observer, before)
 }
 
-// TestReadLoginURLActionFromTTY_CancelledClosesDescriptor pins that the
-// cancelled path owns and closes the descriptor like every other path.
-//
-// It used to be the one exception: cancellation reached Bubble Tea as a context,
-// which makes Run a *killed* Run, and shutdown(kill=true) skips
-// waitForReadLoop(), so the input reader could outlive Run and still be reading
-// tty.Fd(). Closing underneath it was a data race. Driving shutdown with Quit
-// instead takes the graceful path, which joins the read loop first, so there is
-// no live reader left to race and nothing to leak.
+// The cancelled path owns and closes the descriptor like every other path.
 func TestReadLoginURLActionFromTTY_CancelledClosesDescriptor(t *testing.T) {
 	t.Parallel()
 
@@ -218,12 +210,11 @@ func TestReadLoginURLActionFromTTY_CancelledClosesDescriptor(t *testing.T) {
 		t.Errorf("err = %v, want context.Canceled", err)
 	}
 
-	// Close sets Sysfd to -1 (internal/poll (*FD).destroy), so the descriptor
-	// number is the platform-independent signal that the function closed it.
-	// Terminal state is not: tcgetattr here would report EIO on Linux merely
-	// because ptmx is still open, saying nothing about ownership.
-	if int(tty.Fd()) >= 0 {
-		t.Error("cancelled path did not close the descriptor")
+	// Stat, matching the sibling test above — not terminal state, which would
+	// report EIO on Linux merely because ptmx is still open and says nothing
+	// about ownership.
+	if _, err := tty.Stat(); !errors.Is(err, os.ErrClosed) {
+		t.Errorf("cancelled path did not close the descriptor: %v", err)
 	}
 }
 


### PR DESCRIPTION
Cleanup pass over #2009 (now merged). **No behaviour change on any reachable path**, net −76/+24.

## The kill fallback is deleted, because it never worked

#2009 added a 2s fallback that killed the Bubble Tea program if a graceful `Quit` didn't land, so a wedged event loop couldn't strand a completed sign-in (`finishActionRead` is a blocking join).

Probed with a model that blocks forever inside `Update` — the only way a loop can refuse a `QuitMsg`:

```
kill() did NOT unblock Run on a wedged event loop
```

`eventLoop` observes `p.ctx.Done()` **only at its top-level select**, so a body that never returns never gets back there. `Run` never returns, `killed` is never computed, `shutdown` never runs. `program.Kill()` fails identically. The fallback bought a 2s delay before the same hang.

That also corrects the premise it was justified on: **the `tea.WithContext(ctx)` form it replaced had no hang guarantee either**, so dropping the context traded nothing away. And the fallback's one *reachable* effect was harmful — a graceful shutdown slower than 2s became a killed `Run`, precisely the racy path #2009 exists to avoid, plus a leaked fd.

## What's left is two lines

With no fallback, `killCtx` has no reason to exist (it existed only to be cancelled by it, and `Program.Kill()` is the same `shutdown(true)` regardless). `context.AfterFunc` is exactly "run this once ctx is done", so the goroutine, both channels, both selects, the nested `go program.Quit()`, `time.After`, and the grace constant collapse to:

```go
stopQuit := context.AfterFunc(ctx, program.Quit)
defer stopQuit()
```

Also cheaper: `AfterFunc` registers nothing when the parent can never be cancelled (`propagateCancel` returns early on a nil `Done`), where the old watchdog spawned a goroutine per call — and this function is re-entered after every copy action.

## `closeTTY` stays — the old comment was wrong

I'd written "only reachable via the fallback above." Wrong twice: `Run` wraps **any** event-loop error as `ErrProgramKilled`, and `readLoop` feeds input-stream failures into `p.errs`, so a tty read failure (revoked pty, SIGHUP) lands there with the read loop unjoined — exactly the condition the branch assumes. It's load-bearing and unrelated to the fallback.

## Comments

The kill-skips-the-join fact was stated three times in source plus the commit body; it now lives once, at the `closeTTY` site whose shape depends on it. The cancellation-is-a-Quit decision now lives only where it's enacted. Dropped the triage line "no care on this side avoids it" — sitting beside the code that *does* avoid it, it read as the opposite of the truth. And the doc comment no longer claims closure "on every path" while the next line documents the exception.

The test's nine-line mechanics comment described shutdown internals it never executes (the pre-cancelled context returns before any program is constructed) and duplicated the commit body. Its assertion now uses `Stat` + `os.ErrClosed`, matching the sibling test 130 lines up instead of introducing a second idiom for one question.

## Verification

3000 iterations of every TTY test under `-race`, zero races — the sweep is the meaningful one, since it includes `AuthCompletionCancelsTTYAndRestoresTerminal`, which actually exercises the graceful join. Plus full-package `-race` and `mise run lint`.

## Follow-ups this review surfaced, not addressed here

- **`review/tui_sink.go` calls `Kill()` at three sites** (`:193`, `:310`, `:316`), taking the same `shutdown(kill=true)` path. Its input is `os.Stdin` so the fd half can't bite, but the upstream cancel-pipe race applies to any `*os.File` input. Untestable as written — its tests pass `bytes.NewReader(nil)`, which routes to the no-op fallback reader.
- **Nine `tea.NewProgram` sites, five hand-rolled cancellation designs**, two worse than the one fixed here (`investigate` waits unbounded; four accept a ctx and never wire it up). A `uiform.RunProgram(ctx, model, opts...)` wrapper plus a `forbidigo` rule on `tea.WithContext` would make the hazard unreachable by construction — note `review` and `login` independently landed on the same 2s constant, which is the argument.
- **Upstream** [charmbracelet/bubbletea#1599](https://github.com/charmbracelet/bubbletea/issues/1599) fixed the sibling half of this race (ultraviolet now joins its inner reader — confirmed present in the pinned version). What remains is the `!kill` guard around `waitForReadLoop()`; `Cancel()` returning true already means the loop is waking, and the join is capped at 500ms, so dropping the guard would delete this workaround entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 59cfbdf43ee68458fe4c60fc8a6923d742d82202. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->