### PR TITLE
fix(attach): title Codex sessions from the genuine prompt, not the injected preamble

### DIFF
--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,8 +14,9 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
-	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode"     // register agent
-	_ "github.com/entireio/cli/cmd/entire/cli/agent/codex"          // register agent
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode" // register agent
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/codex"      // register agent
+	codexagent "github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/cursor"         // register agent
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid" // register agent
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"      // register agent
@@ -780,6 +782,89 @@ func TestExtractTranscriptMetadataForAgent_Pi(t *testing.T) {
 	}
 	if got.Model != "gpt-5.6-sol" {
 		t.Errorf("Model = %q, want gpt-5.6-sol", got.Model)
+	}
+}
+
+// TestExtractTranscriptMetadataForAgent_CodexSkipsEnvironmentContext: Codex
+// review sessions (and any session where the agent injects an instruction
+// preamble) record the <environment_context> block as the first user message.
+// Attach must use the first genuine user prompt as the checkpoint title — the
+// same filter the rewind display path applies (strategy.FirstDisplayPrompt).
+func TestExtractTranscriptMetadataForAgent_CodexSkipsEnvironmentContext(t *testing.T) {
+	t.Parallel()
+
+	// Single-line form: JSONL test fixtures can't embed raw newlines in a
+	// string literal without escaping, and the filter only needs the prefix.
+	envContext := "<environment_context><cwd>/Users/soph/Work/repo</cwd><shell>zsh</shell><current_date>2026-08-15</current_date></environment_context>"
+	data := []byte(`{"timestamp":"2026-08-15T10:00:00.000Z","type":"session_meta","payload":{"id":"019d6c43-1537-7343-9691-1f8cee04fe59","timestamp":"2026-08-15T10:00:00.000Z"}}
+{"timestamp":"2026-08-15T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"` + envContext + `"}]}}
+{"timestamp":"2026-08-15T10:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Review this trail for correctness"}]}}
+{"timestamp":"2026-08-15T10:00:03.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Reviewing"}]}}
+`)
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := extractTranscriptMetadataForAgent(codexagent.NewCodexAgent(), path, data)
+	if got.FirstPrompt != "Review this trail for correctness" {
+		t.Errorf("FirstPrompt = %q, want the genuine user prompt, not the injected environment context", got.FirstPrompt)
+	}
+	if got.TurnCount != 2 {
+		t.Errorf("TurnCount = %d, want 2", got.TurnCount)
+	}
+}
+
+// TestExtractTranscriptMetadata_CodexOnlyEnvironmentContext guards the
+// degenerate case: a transcript whose only user content is the injected
+// preamble must still yield a title (the raw preamble) rather than an empty
+// prompt — an attach checkpoint with no prompt at all is worse than a
+// noisy-but-present one.
+func TestExtractTranscriptMetadata_CodexOnlyEnvironmentContext(t *testing.T) {
+	t.Parallel()
+
+	envContext := "<environment_context><cwd>/repo</cwd></environment_context>"
+	data := []byte(`{"timestamp":"2026-08-15T10:00:00.000Z","type":"session_meta","payload":{"id":"019d6c43-1537-7343-9691-1f8cee04fe59","timestamp":"2026-08-15T10:00:00.000Z"}}
+{"timestamp":"2026-08-15T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"` + envContext + `"}]}}
+`)
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := extractTranscriptMetadataForAgent(codexagent.NewCodexAgent(), path, data)
+	if got.FirstPrompt != envContext {
+		t.Errorf("FirstPrompt = %q, want the raw environment context as fallback", got.FirstPrompt)
+	}
+}
+
+// TestExtractTranscriptMetadata_JSONLSkipsInjectedPreamble covers the generic
+// JSONL path (agents without a native prompt extractor): an injected
+// AGENTS.md instruction message must not become the first prompt.
+func TestExtractTranscriptMetadata_JSONLSkipsInjectedPreamble(t *testing.T) {
+	t.Parallel()
+
+	preamble := `# AGENTS.md instructions for /repo
+
+<INSTRUCTIONS>
+follow the repo conventions
+</INSTRUCTIONS>`
+	// JSON-escape the preamble so the fixture is valid JSONL (raw newlines in a
+	// string literal would break every line parse).
+	preambleJSON, err := json.Marshal(preamble)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := []byte(`{"type":"user","message":{"role":"user","content":` + string(preambleJSON) + `},"uuid":"u1"}
+{"type":"user","message":{"role":"user","content":"fix the crash"},"uuid":"u2"}
+`)
+
+	got := extractTranscriptMetadata(data)
+	if got.FirstPrompt != "fix the crash" {
+		t.Errorf("FirstPrompt = %q, want %q", got.FirstPrompt, "fix the crash")
+	}
+	if got.TurnCount != 2 {
+		t.Errorf("TurnCount = %d, want 2", got.TurnCount)
 	}
 }
 

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode" // register agent
-	_ "github.com/entireio/cli/cmd/entire/cli/agent/codex"      // register agent
 	codexagent "github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/cursor"         // register agent
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid" // register agent
@@ -810,8 +809,9 @@ func TestExtractTranscriptMetadataForAgent_CodexSkipsEnvironmentContext(t *testi
 	if got.FirstPrompt != "Review this trail for correctness" {
 		t.Errorf("FirstPrompt = %q, want the genuine user prompt, not the injected environment context", got.FirstPrompt)
 	}
-	if got.TurnCount != 2 {
-		t.Errorf("TurnCount = %d, want 2", got.TurnCount)
+	// One genuine prompt, so one step: the injected preamble is not a user turn.
+	if got.TurnCount != 1 {
+		t.Errorf("TurnCount = %d, want 1 (injected preamble is not a user turn)", got.TurnCount)
 	}
 }
 
@@ -863,8 +863,31 @@ follow the repo conventions
 	if got.FirstPrompt != "fix the crash" {
 		t.Errorf("FirstPrompt = %q, want %q", got.FirstPrompt, "fix the crash")
 	}
-	if got.TurnCount != 2 {
-		t.Errorf("TurnCount = %d, want 2", got.TurnCount)
+	if got.TurnCount != 1 {
+		t.Errorf("TurnCount = %d, want 1 (injected preamble is not a user turn)", got.TurnCount)
+	}
+}
+
+// TestExtractTranscriptMetadata_JSONLOnlyInjectedPreamble is the generic-JSONL
+// twin of TestExtractTranscriptMetadata_CodexOnlyEnvironmentContext: when every
+// user message is injected, the raw preamble must still be recorded as the
+// title. Returning an empty FirstPrompt here would write a checkpoint with no
+// prompt.txt at all, and — because TurnCount would also be non-zero —
+// warnEmptyTranscriptMetadata would stay silent about it.
+func TestExtractTranscriptMetadata_JSONLOnlyInjectedPreamble(t *testing.T) {
+	t.Parallel()
+
+	preamble := "# AGENTS.md instructions for /repo\n\nfollow the repo conventions"
+	preambleJSON, err := json.Marshal(preamble)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := []byte(`{"type":"user","message":{"role":"user","content":` + string(preambleJSON) + `},"uuid":"u1"}
+`)
+
+	got := extractTranscriptMetadata(data)
+	if got.FirstPrompt != preamble {
+		t.Errorf("FirstPrompt = %q, want the raw preamble as fallback", got.FirstPrompt)
 	}
 }
 

--- a/cmd/entire/cli/attach_transcript.go
+++ b/cmd/entire/cli/attach_transcript.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/textutil"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
 )
 
@@ -22,14 +24,26 @@ type transcriptMetadata struct {
 func extractTranscriptMetadata(data []byte) transcriptMetadata {
 	var meta transcriptMetadata
 
+	// firstUserPrompt is the unfiltered first prompt, kept as a last-resort title
+	// for a transcript whose every user message is agent-injected.
+	var firstUserPrompt string
+
 	// Try JSONL format first (Claude Code, Cursor, OpenCode, etc.)
 	lines, err := transcript.ParseFromBytes(data)
 	if err == nil {
 		for _, line := range lines {
 			if line.Type == transcript.TypeUser {
 				if prompt := transcript.ExtractUserContent(line.Message); prompt != "" {
+					if firstUserPrompt == "" {
+						firstUserPrompt = prompt
+					}
+					// An injected preamble is not a user turn: counting it
+					// inflates the step count attach reports.
+					if textutil.IsInjectedPrompt(prompt) {
+						continue
+					}
 					meta.TurnCount++
-					if meta.FirstPrompt == "" && !strategy.IsInjectedInstructionPrompt(prompt) {
+					if meta.FirstPrompt == "" {
 						meta.FirstPrompt = prompt
 					}
 				}
@@ -43,18 +57,43 @@ func extractTranscriptMetadata(data []byte) transcriptMetadata {
 				}
 			}
 		}
-		if meta.TurnCount > 0 || meta.Model != "" {
+		// A checkpoint with no prompt at all is worse than one titled with a
+		// noisy-but-present preamble, and an empty FirstPrompt alongside a
+		// non-zero TurnCount would also suppress warnEmptyTranscriptMetadata.
+		if meta.FirstPrompt == "" {
+			meta.FirstPrompt = firstUserPrompt
+		}
+		if meta.TurnCount > 0 || meta.Model != "" || meta.FirstPrompt != "" {
 			return meta
 		}
 	}
 
 	// Fallback: try Gemini JSON format {"messages": [...]}
 	if prompts, gemErr := geminicli.ExtractAllUserPrompts(data); gemErr == nil && len(prompts) > 0 {
-		meta.FirstPrompt = prompts[0]
-		meta.TurnCount = len(prompts)
+		if first := strategy.FirstDisplayPrompt(prompts); first != "" {
+			meta.FirstPrompt = first
+		} else {
+			meta.FirstPrompt = prompts[0]
+		}
+		meta.TurnCount = countUserTurns(prompts)
 	}
 
 	return meta
+}
+
+// countUserTurns counts the prompts that represent an actual user turn, skipping
+// agent-injected preambles and notifications. Once a prompt is deemed not to be
+// user-authored it must not be counted as a user turn either, or attach reports
+// more steps than the session had.
+func countUserTurns(prompts []string) int {
+	turns := 0
+	for _, prompt := range prompts {
+		if strings.TrimSpace(prompt) == "" || textutil.IsInjectedPrompt(prompt) {
+			continue
+		}
+		turns++
+	}
+	return turns
 }
 
 // extractTranscriptMetadataForAgent augments the generic attach parser with
@@ -67,16 +106,17 @@ func extractTranscriptMetadataForAgent(ag agent.Agent, sessionRef string, data [
 
 	if extractor, ok := agent.AsPromptExtractor(ag); ok {
 		if prompts, err := extractor.ExtractPrompts(sessionRef, 0); err == nil && len(prompts) > 0 {
-			// Native extractors return prompts in transcript order; agents that
-			// inject an instruction preamble (Codex's environment context) put it
-			// first, so use the first genuine user prompt for the title — the
-			// same filter the rewind display path applies.
+			// Native extractors return every user-role item in transcript order,
+			// including the agent's own injected preambles (Codex leads with an
+			// AGENTS.md dump and/or <environment_context>). Title from the first
+			// genuine prompt, falling back to the raw first one so the checkpoint
+			// is never left untitled.
 			if first := strategy.FirstDisplayPrompt(prompts); first != "" {
 				meta.FirstPrompt = first
 			} else {
 				meta.FirstPrompt = prompts[0]
 			}
-			meta.TurnCount = len(prompts)
+			meta.TurnCount = countUserTurns(prompts)
 		}
 	}
 	if extractor, ok := agent.AsModelExtractor(ag); ok {

--- a/cmd/entire/cli/attach_transcript.go
+++ b/cmd/entire/cli/attach_transcript.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
 )
 
@@ -28,7 +29,7 @@ func extractTranscriptMetadata(data []byte) transcriptMetadata {
 			if line.Type == transcript.TypeUser {
 				if prompt := transcript.ExtractUserContent(line.Message); prompt != "" {
 					meta.TurnCount++
-					if meta.FirstPrompt == "" {
+					if meta.FirstPrompt == "" && !strategy.IsInjectedInstructionPrompt(prompt) {
 						meta.FirstPrompt = prompt
 					}
 				}
@@ -66,7 +67,15 @@ func extractTranscriptMetadataForAgent(ag agent.Agent, sessionRef string, data [
 
 	if extractor, ok := agent.AsPromptExtractor(ag); ok {
 		if prompts, err := extractor.ExtractPrompts(sessionRef, 0); err == nil && len(prompts) > 0 {
-			meta.FirstPrompt = prompts[0]
+			// Native extractors return prompts in transcript order; agents that
+			// inject an instruction preamble (Codex's environment context) put it
+			// first, so use the first genuine user prompt for the title — the
+			// same filter the rewind display path applies.
+			if first := strategy.FirstDisplayPrompt(prompts); first != "" {
+				meta.FirstPrompt = first
+			} else {
+				meta.FirstPrompt = prompts[0]
+			}
 			meta.TurnCount = len(prompts)
 		}
 	}

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -18,6 +18,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/textutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
 
@@ -823,35 +824,22 @@ func restoredPromptPreview(sessionAgent agent.Agent, promptContent string, trans
 }
 
 // FirstDisplayPrompt returns the first prompt in the list worth showing as a
-// title/preview: the first entry that is non-empty, not separator-only, and
-// not an agent-injected instruction preamble (Codex's environment context,
-// AGENTS.md injection blocks). Returns "" if none qualifies. Exported so
-// import paths that select a prompt from a transcript (attach) apply the same
-// filter as the rewind display path.
+// title/preview: the first entry that is non-empty, not separator-only, and not
+// agent-injected (runtime preambles, AGENTS.md dumps — see
+// textutil.IsInjectedPrompt). Returns "" if none qualifies, which callers that
+// must show something should treat as "fall back to the raw first prompt".
+//
+// The returned text is not truncated; callers that render it into a fixed-width
+// display are responsible for that (see restoredPromptPreview).
 func FirstDisplayPrompt(prompts []string) string {
 	for _, prompt := range prompts {
 		cleaned := strings.TrimSpace(prompt)
-		if cleaned == "" || isOnlySeparators(cleaned) || isInjectedInstructionPrompt(cleaned) {
+		if cleaned == "" || isOnlySeparators(cleaned) || textutil.IsInjectedPrompt(cleaned) {
 			continue
 		}
 		return cleaned
 	}
 	return ""
-}
-
-// IsInjectedInstructionPrompt reports whether prompt is an agent-injected
-// instruction preamble (AGENTS.md injection, Codex's environment context) rather
-// than a genuine user prompt. Display paths that pick a prompt to show as a
-// title/preview skip these (see FirstDisplayPrompt).
-func IsInjectedInstructionPrompt(prompt string) bool {
-	return isInjectedInstructionPrompt(prompt)
-}
-
-func isInjectedInstructionPrompt(prompt string) bool {
-	trimmed := strings.TrimSpace(prompt)
-	return strings.HasPrefix(trimmed, "# AGENTS.md instructions for ") ||
-		strings.HasPrefix(trimmed, "<environment_context>") ||
-		(strings.Contains(trimmed, "<INSTRUCTIONS>") && strings.Contains(trimmed, "AGENTS.md instructions"))
 }
 
 func extractPromptsFromTranscriptBytes(extractor agent.PromptExtractor, transcript []byte) ([]string, error) {

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -816,18 +816,35 @@ func restoredPromptPreview(sessionAgent agent.Agent, promptContent string, trans
 	if err != nil || len(prompts) == 0 {
 		return ""
 	}
-	return firstRestoredDisplayPrompt(prompts)
+	if first := FirstDisplayPrompt(prompts); first != "" {
+		return TruncateDescription(first, MaxDescriptionLength)
+	}
+	return ""
 }
 
-func firstRestoredDisplayPrompt(prompts []string) string {
+// FirstDisplayPrompt returns the first prompt in the list worth showing as a
+// title/preview: the first entry that is non-empty, not separator-only, and
+// not an agent-injected instruction preamble (Codex's environment context,
+// AGENTS.md injection blocks). Returns "" if none qualifies. Exported so
+// import paths that select a prompt from a transcript (attach) apply the same
+// filter as the rewind display path.
+func FirstDisplayPrompt(prompts []string) string {
 	for _, prompt := range prompts {
 		cleaned := strings.TrimSpace(prompt)
 		if cleaned == "" || isOnlySeparators(cleaned) || isInjectedInstructionPrompt(cleaned) {
 			continue
 		}
-		return TruncateDescription(cleaned, MaxDescriptionLength)
+		return cleaned
 	}
 	return ""
+}
+
+// IsInjectedInstructionPrompt reports whether prompt is an agent-injected
+// instruction preamble (AGENTS.md injection, Codex's environment context) rather
+// than a genuine user prompt. Display paths that pick a prompt to show as a
+// title/preview skip these (see FirstDisplayPrompt).
+func IsInjectedInstructionPrompt(prompt string) bool {
+	return isInjectedInstructionPrompt(prompt)
 }
 
 func isInjectedInstructionPrompt(prompt string) bool {

--- a/cmd/entire/cli/strategy/rewind_test.go
+++ b/cmd/entire/cli/strategy/rewind_test.go
@@ -283,6 +283,58 @@ func TestRestoredPromptPreviewFallsBackInOrder(t *testing.T) {
 	}
 }
 
+func TestFirstDisplayPrompt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		prompts []string
+		want    string
+	}{
+		{
+			name:    "first prompt is genuine",
+			prompts: []string{"fix the login bug", "second prompt"},
+			want:    "fix the login bug",
+		},
+		{
+			name: "skips codex environment context prefix",
+			prompts: []string{
+				"<environment_context>\n  <cwd>/repo</cwd>\n  <shell>zsh</shell>\n</environment_context>",
+				"investigate the flaky test",
+			},
+			want: "investigate the flaky test",
+		},
+		{
+			name: "skips AGENTS.md instruction prefix",
+			prompts: []string{
+				"# AGENTS.md instructions for /repo\n\n<INSTRUCTIONS>\nread the docs\n</INSTRUCTIONS>",
+				"add error handling",
+			},
+			want: "add error handling",
+		},
+		{
+			name:    "skips empty and separator-only entries",
+			prompts: []string{"   ", "---", "apply the fixes"},
+			want:    "apply the fixes",
+		},
+		{
+			name:    "only injected prompts yields empty",
+			prompts: []string{"<environment_context>\n  <cwd>/repo</cwd>\n</environment_context>"},
+			want:    "",
+		},
+		{name: "empty list yields empty", prompts: nil, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := FirstDisplayPrompt(tt.prompts); got != tt.want {
+				t.Errorf("FirstDisplayPrompt(%v) = %q, want %q", tt.prompts, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveAgentForRewind(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/textutil/injected_prompt.go
+++ b/cmd/entire/cli/textutil/injected_prompt.go
@@ -1,0 +1,50 @@
+package textutil
+
+import "strings"
+
+// injectedPromptPrefixes are the leading markers of content an agent injects
+// into the user side of a transcript: runtime preambles, instruction-file dumps,
+// and tool/notification results replayed as user turns. None of it is
+// user-authored, so display paths skip it when picking a title and turn counts
+// exclude it.
+//
+// The list is anchored (prefix-only) on purpose: a genuine prompt that merely
+// mentions one of these tags must not be misclassified.
+//
+// Derived from 164 real Codex rollouts: the first user-role item is an AGENTS.md
+// dump (107) or <environment_context> (46) in 153 of them, with
+// <recommended_plugins> (8), <user_action> (2), and <turn_aborted> (1) making up
+// the remainder. The developer-role markers (<permissions instructions>,
+// <skills_instructions>, <collaboration_mode>, <apps_instructions>,
+// <plugins_instructions>) never reach the prompt path — Codex's ExtractPrompts
+// filters by role — but transcript compaction sees them, so they belong here too.
+var injectedPromptPrefixes = []string{
+	"# AGENTS.md",             // instruction-file dump: bare, or "…instructions for <path>"
+	"<environment_context>",   // runtime preamble: cwd, shell, sandbox
+	"<permissions",            // "<permissions instructions>"
+	"<collaboration_mode>",    //
+	"<skills_instructions>",   //
+	"<apps_instructions>",     //
+	"<plugins_instructions>",  //
+	"<recommended_plugins>",   // catalog of uninstalled plugins
+	"<user_action>",           // review/tool output replayed as a user turn
+	"<subagent_notification>", // subagent lifecycle notice
+	"<turn_aborted>",          // interrupted-turn notice
+}
+
+// IsInjectedPrompt reports whether text is agent-injected rather than
+// user-authored. It is the single source of truth for that question: callers
+// that pick a session title, count user turns, or compact a transcript all use
+// it so the classification cannot drift between them.
+func IsInjectedPrompt(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	for _, prefix := range injectedPromptPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	// Some instruction injections lead with the wrapper tag rather than the
+	// heading. Require the AGENTS.md marker as well, and keep the tag check
+	// anchored, so a genuine prompt asking about <INSTRUCTIONS> stays a prompt.
+	return strings.HasPrefix(trimmed, "<INSTRUCTIONS>") && strings.Contains(trimmed, "AGENTS.md instructions")
+}

--- a/cmd/entire/cli/textutil/injected_prompt_test.go
+++ b/cmd/entire/cli/textutil/injected_prompt_test.go
@@ -1,0 +1,58 @@
+package textutil
+
+import "testing"
+
+// TestIsInjectedPrompt_RealRolloutShapes covers every first-user-item shape
+// observed across 164 real Codex rollouts. The two dominant shapes (an AGENTS.md
+// dump and <environment_context>) account for 153 of them; the remaining 11 are
+// <recommended_plugins>, <user_action>, and <turn_aborted>, each of which would
+// otherwise become a session title.
+func TestIsInjectedPrompt_RealRolloutShapes(t *testing.T) {
+	t.Parallel()
+
+	injected := map[string]string{
+		"AGENTS.md dump with path":  "# AGENTS.md instructions for /Users/soph/Work/repo\n\n<INSTRUCTIONS>\nfollow them\n</INSTRUCTIONS>",
+		"AGENTS.md dump bare":       "# AGENTS.md\nThese are the project instructions.",
+		"environment context":       "<environment_context>\n  <cwd>/repo</cwd>\n  <shell>zsh</shell>\n</environment_context>",
+		"recommended plugins":       "<recommended_plugins>\nHere is a list of plugins that are available but not installed.\n\n- Airtable\n",
+		"user action review result": "<user_action>\n  <context>User initiated a review task.</context>\n  <action>review</action>\n</user_action>",
+		"turn aborted":              "<turn_aborted>\nThe user interrupted the previous turn on purpose.\n</turn_aborted>",
+		"subagent notification":     "<subagent_notification>\n{\"agent_path\":\"0\"}\n</subagent_notification>",
+		"permissions instructions":  "<permissions instructions>\nYou are sandboxed.\n</permissions instructions>",
+		"skills instructions":       "<skills_instructions>\nuse them\n</skills_instructions>",
+		"collaboration mode":        "<collaboration_mode>\npair\n</collaboration_mode>",
+		"apps instructions":         "<apps_instructions>\napps\n</apps_instructions>",
+		"plugins instructions":      "<plugins_instructions>\nplugins\n</plugins_instructions>",
+		"instructions tag first":    "<INSTRUCTIONS>\nAGENTS.md instructions follow\n</INSTRUCTIONS>",
+		"leading whitespace":        "\n  <environment_context>\n  <cwd>/repo</cwd>\n</environment_context>",
+	}
+	for name, text := range injected {
+		t.Run("injected/"+name, func(t *testing.T) {
+			t.Parallel()
+			if !IsInjectedPrompt(text) {
+				t.Errorf("IsInjectedPrompt(%q) = false, want true", text)
+			}
+		})
+	}
+
+	// Genuine prompts, including ones that discuss the injected markers. The
+	// match is anchored precisely so these stay prompts: misclassifying one
+	// costs the checkpoint its title.
+	genuine := map[string]string{
+		"plain":                      "fix the login bug",
+		"mentions INSTRUCTIONS tag":  "why does the AGENTS.md instructions block get wrapped in <INSTRUCTIONS> tags?",
+		"mentions environment tag":   "the <environment_context> block is leaking into titles — can you fix that?",
+		"mentions AGENTS.md midway":  "please update AGENTS.md to document the new flag",
+		"mentions turn_aborted":      "what emits <turn_aborted> and should we count it as a turn?",
+		"code fence with the marker": "```\n<environment_context>\n```\nwhat is this?",
+		"empty":                      "",
+	}
+	for name, text := range genuine {
+		t.Run("genuine/"+name, func(t *testing.T) {
+			t.Parallel()
+			if IsInjectedPrompt(text) {
+				t.Errorf("IsInjectedPrompt(%q) = true, want false", text)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/transcript/compact/codex.go
+++ b/cmd/entire/cli/transcript/compact/codex.go
@@ -275,22 +275,10 @@ func codexUserText(raw json.RawMessage) string {
 }
 
 // isCodexSystemContent returns true for content blocks that are system-injected
-// rather than user-authored.
+// rather than user-authored. The prefix list is shared with the session-title and
+// turn-counting paths (textutil.IsInjectedPrompt) so the two cannot drift.
 func isCodexSystemContent(text string) bool {
-	prefixes := []string{
-		"<permissions",
-		"<collaboration_mode>",
-		"<skills_instructions>",
-		"<environment_context>",
-		"<turn_aborted>",
-		"# AGENTS.md",
-	}
-	for _, p := range prefixes {
-		if len(text) >= len(p) && text[:len(p)] == p {
-			return true
-		}
-	}
-	return false
+	return textutil.IsInjectedPrompt(text)
 }
 
 // codexAssistantText extracts text from a Codex assistant message content array.


### PR DESCRIPTION
Fixes the CLI half of [ENT-1653](https://linear.app/entirehq/issue/ENT-1653/codex-agent-review-sessions-are-titled-environment-context-instead-of): Codex `agent_review` sessions are titled `<environment_context>` instead of the review ask.

Codex emits its runtime preamble as separate synthetic user messages, with the real ask in a later one. `entire attach --review` recorded `prompts[0]`, so `prompt.txt` and `review_prompt` captured pure boilerplate.

## The measurement

The first commit skipped two prefixes. To check that against reality I surveyed 164 real Codex rollouts in `~/.codex/sessions`. The first user-role item is injected in **all 164**, in five shapes:

| First user item | Count | Matched by the initial fix? |
|---|---|---|
| `# AGENTS.md …` | 107 | yes |
| `<environment_context>` | 46 | yes |
| `<recommended_plugins>` | 8 | no |
| `<user_action>` | 2 | no |
| `<turn_aborted>` | 1 | no |

So 12 of 164 sessions were still titled with boilerplate. `<user_action>` matters most: its content begins *"User initiated a review task. Here's the full review output from reviewer model"* — exactly the `agent_review` flow the issue reports.

The prefix list also existed twice — `compact.isCodexSystemContent` had six prefixes, the strategy predicate three. **That drift was the bug.**

## Changes

**One classifier.** New `textutil.IsInjectedPrompt` (leaf package) is the single source of truth; `strategy.FirstDisplayPrompt` and `compact.isCodexSystemContent` both delegate. Prefixes are the union of the old lists plus the three newly observed shapes.

**A fallback on the generic JSONL path**, matching the native-extractor path. Filtering without one turned an all-injected transcript into an empty `FirstPrompt`: no `prompt.txt`, no title, and — because `TurnCount` stayed non-zero — `warnEmptyTranscriptMetadata` never fired. Same for `--review`'s prompt and its warning.

**Turn counts exclude injected items** via a shared `countUserTurns`, on all three paths (JSONL, native extractor, Gemini), which previously disagreed. Two tests asserting the inflated count are corrected.

**The `<INSTRUCTIONS>` clause is anchored.** Two unanchored `Contains` calls matched a genuine prompt merely discussing the markers (`"why does the AGENTS.md instructions block get wrapped in <INSTRUCTIONS> tags?"`); via the attach path that cost the checkpoint its title, not just a preview line. Kept the original intent, anchored the match, added a test.

Also: dropped a pass-through wrapper, dropped a duplicate blank `codex` import in the test file, replaced a comment claiming filter parity that did not hold, and documented that `FirstDisplayPrompt` does not truncate.

## Result

Over the same 164 rollouts, sessions titled with injected content:

| | Count |
|---|---|
| `main` (no filter) | 164 / 164 |
| first commit on this branch | 12 |
| **this PR** | **4** |

The remaining 4 contain no genuine user prompt anywhere (preamble + abort, or a review-tool result only), so the raw-preamble fallback is the intended behaviour rather than a leak.

## Tests

`mise run fmt && mise run lint && mise run test:ci` green — 0 lint issues, unit + integration + both E2E canaries (56 vogon, 4 roger-roger) passing.

New coverage: `textutil` exercises every real rollout shape plus six genuine prompts that mention the markers; `TestExtractTranscriptMetadata_JSONLOnlyInjectedPreamble` covers the JSONL degenerate case that had none.

## Scope

CLI only, as agreed. Still open elsewhere, per the issue: the ingest `firstMeaningfulLine` literal-first-line fallback (entire-api), the namer's empty-name decline, and the backfill for already-affected sessions, which have burned their refinement attempts and keep their poisoned preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3001c07bf65d206b2d8cb3e008d2c3879ce1b4ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->