### PR TITLE
feat(release): add a dev channel that tracks main

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -58,21 +58,26 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # The commit Tests actually ran against, not main's tip: main may have
-          # moved on, and tagging an untested commit is the one thing this gate
-          # exists to prevent. Falls back to the ref for a manual dispatch.
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
-          # create-dev-tag.sh needs the full tag history for `git describe`.
+          # Hardcoded, and deliberately NOT the triggering commit. This is a
+          # workflow_run job, so it runs with secrets; checking out a ref taken
+          # from the event payload would run event-controlled code in a
+          # privileged context. The `if:` above happens to restrict that ref to
+          # commits already on main, but a gate is the fragile way to establish
+          # trust — relax one conjunct later (drop `event == 'push'`, add a
+          # second triggering workflow that runs on pull_request) and the
+          # checkout silently becomes arbitrary code execution. Not consuming
+          # the ref at all cannot regress that way.
+          #
+          # The commit to *tag* is still the triggering one; that is passed to
+          # the tag step below rather than checked out. Tagging and running are
+          # separate needs and only the second one requires a trusted tree.
+          ref: main
+          # Full history: `git describe` needs the tags, and the tag step needs
+          # the triggering commit to be present as an ancestor of main.
           fetch-depth: 0
-          # This is a workflow_run job: it holds secrets while running a script
-          # out of the checked-out tree, so it must not leave a repo-write
-          # credential in .git/config where that script could reach it. The
-          # push below passes the app token explicitly instead. No token is
-          # needed for the fetch itself — the repo is public.
-          # CodeQL flags the checkout of the triggering commit here; that part
-          # is inherent to tagging the commit Tests actually ran against, and is
-          # bounded by the head_branch/event gate above, which admits only
-          # commits already pushed to main.
+          # Leaves no repo-write credential in .git/config for the script this
+          # job runs out of the tree. The push below passes the app token
+          # explicitly; the fetch needs no token, as the repo is public.
           persist-credentials: false
 
       - name: Record the dev releases present before this run
@@ -90,8 +95,21 @@ jobs:
         id: tag
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The commit Tests actually ran against, not main's tip: main may have
+          # moved on while Tests ran, and publishing a commit whose own Tests are
+          # still in flight is the one thing this workflow's gate exists to
+          # prevent. Used only as a tag target, never as a checkout ref.
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
         run: |
-          TAG=$(scripts/create-dev-tag.sh) && EXIT_CODE=0 || EXIT_CODE=$?
+          # The tree is main's; the target must be reachable from it. This fails
+          # loudly if main was force-pushed out from under the triggering commit,
+          # rather than tagging something no longer on the branch.
+          if ! git merge-base --is-ancestor "$TARGET_SHA" HEAD; then
+            echo "::error::$TARGET_SHA is not an ancestor of main; refusing to tag it."
+            exit 1
+          fi
+
+          TAG=$(scripts/create-dev-tag.sh "$TARGET_SHA") && EXIT_CODE=0 || EXIT_CODE=$?
           if [ "$EXIT_CODE" -eq 2 ]; then
             echo "Skipping — this commit already has a dev tag."
             exit 0
@@ -99,7 +117,7 @@ jobs:
             echo "::error::Failed to generate dev tag"
             exit 1
           fi
-          git tag "$TAG"
+          git tag "$TAG" "$TARGET_SHA"
           # Explicit credential rather than `push origin`: the checkout persists
           # none. Runner logs mask the app token (create-github-app-token
           # registers it as a secret).

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,124 @@
+name: Dev Release
+
+# Publishes the dev channel: one release that tracks main, replaced on every
+# merge that passes tests. `install.sh --channel dev` therefore always fetches
+# current main, which is how this repo's own developers dogfood it now that
+# local-dev hooks are gone.
+#
+# Deliberately separate from nightly.yml. Nightly is a daily, externally consumed
+# channel and stays exactly as it is; firing it per merge would make its name a
+# lie and flood the releases list.
+#
+# Keeping only one dev release is what keeps this cheap: install.sh's nightly
+# lookup reads `releases?per_page=20` and takes the first nightly match, so a
+# channel that accumulated a release per merge (6-21/day in this repo) would push
+# the newest nightly off that page and silently break `--channel nightly`.
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dev-release
+  # Not cancel-in-progress: a run publishes a tag and then retires the previous
+  # release. Cancelling midway could leave both, or neither.
+  cancel-in-progress: false
+
+jobs:
+  publish-dev:
+    # Only green main. Tests is the gate rather than Lint as well: a lint failure
+    # does not produce a broken binary, and waiting on two independent
+    # workflow_run events would need its own coordination.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.event == 'push')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: app-token
+        # The tag push must come from an app token: a push made with the default
+        # GITHUB_TOKEN does not trigger other workflows, so release.yml would
+        # never fire and no release would be built.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: cli
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The commit Tests actually ran against, not main's tip: main may have
+          # moved on, and tagging an untested commit is the one thing this gate
+          # exists to prevent. Falls back to the ref for a manual dispatch.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          # create-dev-tag.sh needs the full tag history for `git describe`.
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Record the dev releases present before this run
+        id: existing
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Captured before the new tag exists, so the retire step below can never
+          # delete the release it just created.
+          gh release list --limit 100 --json tagName \
+            --jq '.[] | select(.tagName | test("-dev\\.")) | .tagName' > existing-dev-tags.txt || true
+          echo "count=$(wc -l < existing-dev-tags.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+
+      - name: Create dev tag
+        id: tag
+        run: |
+          TAG=$(scripts/create-dev-tag.sh) && EXIT_CODE=0 || EXIT_CODE=$?
+          if [ "$EXIT_CODE" -eq 2 ]; then
+            echo "Skipping — this commit already has a dev tag."
+            exit 0
+          elif [ "$EXIT_CODE" -ne 0 ] || [ -z "$TAG" ]; then
+            echo "::error::Failed to generate dev tag"
+            exit 1
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the release to be published
+        id: wait
+        if: steps.tag.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          # release.yml runs asynchronously off the tag push. Retire the previous
+          # release only once the new one exists, so `--channel dev` never sees
+          # zero releases. 20 minutes is well clear of a normal release build.
+          for _ in $(seq 1 80); do
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "published=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::warning::$TAG was not published within 20 minutes; keeping the previous dev release."
+          echo "published=false" >> "$GITHUB_OUTPUT"
+
+      - name: Retire superseded dev releases
+        if: steps.wait.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # --cleanup-tag removes the git tag too, so neither releases nor tags
+          # accumulate. Failing to delete one is not worth failing the run over:
+          # the next merge retries, and an extra release is harmless.
+          while read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "Retiring superseded dev release $tag"
+            gh release delete "$tag" --yes --cleanup-tag || \
+              echo "::warning::could not delete $tag"
+          done < existing-dev-tags.txt

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -19,8 +19,12 @@ on:
     types: [completed]
   workflow_dispatch:
 
+# Read-only: every write this workflow makes (the tag push, the release
+# deletes) goes through the app token below, not the job token. Combined with
+# persist-credentials:false on the checkout, no repo-write credential is
+# reachable from the checked-out tree.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: dev-release
@@ -60,7 +64,16 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           # create-dev-tag.sh needs the full tag history for `git describe`.
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
+          # This is a workflow_run job: it holds secrets while running a script
+          # out of the checked-out tree, so it must not leave a repo-write
+          # credential in .git/config where that script could reach it. The
+          # push below passes the app token explicitly instead. No token is
+          # needed for the fetch itself — the repo is public.
+          # CodeQL flags the checkout of the triggering commit here; that part
+          # is inherent to tagging the commit Tests actually ran against, and is
+          # bounded by the head_branch/event gate above, which admits only
+          # commits already pushed to main.
+          persist-credentials: false
 
       - name: Record the dev releases present before this run
         id: existing
@@ -75,6 +88,8 @@ jobs:
 
       - name: Create dev tag
         id: tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           TAG=$(scripts/create-dev-tag.sh) && EXIT_CODE=0 || EXIT_CODE=$?
           if [ "$EXIT_CODE" -eq 2 ]; then
@@ -85,7 +100,11 @@ jobs:
             exit 1
           fi
           git tag "$TAG"
-          git push origin "$TAG"
+          # Explicit credential rather than `push origin`: the checkout persists
+          # none. Runner logs mask the app token (create-github-app-token
+          # registers it as a secret).
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/tags/${TAG}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Wait for the release to be published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,12 @@ jobs:
             *-dev.*) CHANNEL_LABEL="Dev Build"; TAG_GLOB='v*-dev.*' ;;
             *)       CHANNEL_LABEL="Nightly Build"; TAG_GLOB='v*-nightly.*' ;;
           esac
-          LAST_IN_CHANNEL=$(git tag -l "$TAG_GLOB" --sort=-creatordate | grep -v "^${RELEASE_TAG}$" | head -1)
+          # `|| true`: with the runner's default `bash -eo pipefail`, grep exits 1
+          # when it filters everything out, killing the step before the fallback
+          # below. That is the normal case for the dev channel, whose superseded
+          # tags are deleted — so the tag being released is usually the only one
+          # matching the glob.
+          LAST_IN_CHANNEL=$(git tag -l "$TAG_GLOB" --sort=-creatordate | grep -v "^${RELEASE_TAG}$" | head -1 || true)
           if [ -n "$LAST_IN_CHANNEL" ]; then
             BASE_TAG="$LAST_IN_CHANNEL"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,16 +67,26 @@ jobs:
             exit 1
           fi
 
-      - name: Generate nightly release notes
+      - name: Generate prerelease notes
         if: steps.release-type.outputs.prerelease == 'true'
         run: |
-          LAST_NIGHTLY=$(git tag -l 'v*-nightly.*' --sort=-creatordate | grep -v "^${RELEASE_TAG}$" | head -1)
-          if [ -n "$LAST_NIGHTLY" ]; then
-            BASE_TAG="$LAST_NIGHTLY"
+          # Two prerelease channels share this step, so label and diff base come
+          # from the tag rather than being hardcoded: a dev release titled
+          # "Nightly Build", diffed against the last nightly, would misdescribe
+          # both what it is and what changed.
+          case "$RELEASE_TAG" in
+            *-dev.*) CHANNEL_LABEL="Dev Build"; TAG_GLOB='v*-dev.*' ;;
+            *)       CHANNEL_LABEL="Nightly Build"; TAG_GLOB='v*-nightly.*' ;;
+          esac
+          LAST_IN_CHANNEL=$(git tag -l "$TAG_GLOB" --sort=-creatordate | grep -v "^${RELEASE_TAG}$" | head -1)
+          if [ -n "$LAST_IN_CHANNEL" ]; then
+            BASE_TAG="$LAST_IN_CHANNEL"
           else
+            # First build in this channel, or — for dev, whose superseded tags are
+            # deleted — the usual case. Fall back to the latest stable tag.
             BASE_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' HEAD 2>/dev/null || echo "")
           fi
-          echo "## Nightly Build (${RELEASE_TAG})" > "$RUNNER_TEMP/release_notes.md"
+          echo "## ${CHANNEL_LABEL} (${RELEASE_TAG})" > "$RUNNER_TEMP/release_notes.md"
           echo "" >> "$RUNNER_TEMP/release_notes.md"
           if [ -n "$BASE_TAG" ]; then
             echo "Changes since ${BASE_TAG}:" >> "$RUNNER_TEMP/release_notes.md"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -202,7 +202,13 @@ homebrew_casks:
         - fish
     conflicts:
       - cask: entire
-    skip_upload: "{{ if not .Prerelease }}true{{ end }}"
+    # Nightly-tags only, not "any prerelease". `not .Prerelease` skipped just
+    # stable, so a second prerelease channel (-dev., published on every merge to
+    # main) would have overwritten this externally-consumed cask many times a day
+    # and quietly turned `brew install --cask entire@nightly` into a main tracker.
+    # Verified with goreleaser 2.17.1 that `contains` renders here and
+    # distinguishes the two tag shapes.
+    skip_upload: '{{ if not (contains .Prerelease "nightly") }}true{{ end }}'
 
 announce:
   discord:

--- a/README.md
+++ b/README.md
@@ -112,10 +112,11 @@ After the initial setup, use `entire agent` to add or remove agents, `entire con
 
 ## Release Channels
 
-Entire currently ships two release channels:
+Entire ships three release channels:
 
 - `stable`: recommended for most users. Stable releases change less often and are the default for Homebrew, Scoop, and `install.sh`.
-- `nightly`: prerelease builds for users who want the latest changes earlier. Nightlies are published more frequently and may include newer, less-proven changes than stable.
+- `nightly`: prerelease builds for users who want the latest changes earlier. Nightlies are published daily and may include newer, less-proven changes than stable.
+- `dev`: current `main`, rebuilt on every merge that passes tests. Intended for developing Entire itself — it moves many times a day and is the least proven of the three. Only one dev release exists at a time; it is replaced rather than accumulated, so you cannot install an older dev build (use `mise run dev:publish` from a checkout for that). `entire version` reports the commit a build came from.
 
 How to use each channel:
 
@@ -124,6 +125,7 @@ How to use each channel:
 - Homebrew nightly: `brew install --cask entire@nightly`
 - `install.sh` stable: `curl -fsSL https://entire.io/install.sh | bash`
 - `install.sh` nightly: `curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly`
+- `install.sh` dev: `curl -fsSL https://entire.io/install.sh | bash -s -- --channel dev` (or `mise run dev:sync` in a checkout)
 - Scoop: currently supports `stable` only via `scoop install entire/entire`
 
 ## Typical Workflow

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -169,9 +169,24 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
+// versionString reports the running build.
+//
+// The commit is included because the version alone does not always identify a
+// build: the dev channel keeps a single release that is replaced on every merge
+// to main, so every dev build would otherwise report the same string and a bug
+// report could not say which one it came from. Both goreleaser configs already
+// stamp versioninfo.Commit, and versioninfo.Load falls back to the embedded build
+// info, so this is surfacing a value we already have rather than a new one.
 func versionString() string {
+	build := versioninfo.Version
+	// Omitted rather than printed as "(unknown)": a local `go build` outside a
+	// detectable checkout has no commit to report, and noise there is worse than
+	// silence. Release builds always carry the stamp.
+	if c := versioninfo.Commit; c != "" && c != "unknown" {
+		build = fmt.Sprintf("%s (%s)", build, c)
+	}
 	return fmt.Sprintf("Entire CLI %s\nGo version: %s\nOS/Arch: %s/%s\n",
-		versioninfo.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		build, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 }
 
 func newVersionCmd() *cobra.Command {

--- a/cmd/entire/cli/root_test.go
+++ b/cmd/entire/cli/root_test.go
@@ -349,3 +349,27 @@ func containsString(values []string, want string) bool {
 	}
 	return false
 }
+
+// TestVersionString_IncludesCommitWhenStamped pins that a release build reports
+// the commit it came from. The dev channel keeps one release that is replaced on
+// every merge to main, so the version alone cannot identify a dev build and a bug
+// report against one would be untraceable without this.
+func TestVersionString_IncludesCommitWhenStamped(t *testing.T) {
+	origVersion, origCommit := versioninfo.Version, versioninfo.Commit
+	t.Cleanup(func() { versioninfo.Version, versioninfo.Commit = origVersion, origCommit })
+
+	versioninfo.Version, versioninfo.Commit = "0.5.5-dev.202608171200.abc1234", "abc1234"
+	if got := versionString(); !strings.Contains(got, "0.5.5-dev.202608171200.abc1234 (abc1234)") {
+		t.Errorf("version output should carry the commit, got:\n%s", got)
+	}
+
+	// A local build with nothing stamped must not print "(unknown)".
+	versioninfo.Version, versioninfo.Commit = "dev", "unknown"
+	got := versionString()
+	if strings.Contains(got, "unknown") || strings.Contains(got, "(") {
+		t.Errorf("unstamped build should omit the commit entirely, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Entire CLI dev") {
+		t.Errorf("unstamped build should still report its version, got:\n%s", got)
+	}
+}

--- a/mise-tasks/dev/sync
+++ b/mise-tasks/dev/sync
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#MISE description="Install the dev build (current main) to dogfood it"
+
+set -eu
+
+# The dev channel is one release that tracks main, rebuilt on every merge that
+# passes tests, so this installs current main through the same path users install
+# through — which is the point. Hooks name the `entire` binary and resolve it via
+# PATH, so whatever this installs is what your hooks run.
+#
+# Use dev:publish instead when you want to dogfood YOUR working tree rather than
+# main; that builds from source and does not touch the release channels.
+exec "$(git rev-parse --show-toplevel)"/scripts/install.sh --channel dev

--- a/scripts/create-dev-tag.sh
+++ b/scripts/create-dev-tag.sh
@@ -14,15 +14,23 @@ set -euo pipefail
 # publish as a prerelease, and goreleaser stamps experimental.Visible=true for
 # any prerelease, so dogfooders keep seeing experimental commands.
 #
-# Exit codes: 0 with the tag on stdout, 2 if HEAD already has one (nothing to
-# do), 1 on error.
+# Exit codes: 0 with the tag on stdout, 2 if the commit already has one (nothing
+# to do), 1 on error.
+#
+# The commit to tag is an argument rather than HEAD so the caller can run this
+# from a checkout of main while tagging an earlier commit on main — see
+# dev-release.yml, which must not consume the workflow_run ref as a checkout ref.
 #
 # Deliberately parallel to create-nightly-tag.sh rather than shared with it: that
 # script feeds the externally-consumed nightly channel, and this change is not the
 # place to refactor a published release path. Keep the two in step.
-# Usage: scripts/create-dev-tag.sh
+# Usage: scripts/create-dev-tag.sh [commit]   (default: HEAD)
 
-SHORT_COMMIT=$(git rev-parse --short HEAD)
+TARGET=${1:-HEAD}
+if ! SHORT_COMMIT=$(git rev-parse --short --verify "${TARGET}^{commit}" 2>/dev/null); then
+  echo "::error::Not a commit in this repository: ${TARGET}" >&2
+  exit 1
+fi
 
 # Skip if a dev tag already exists for this commit. Makes the workflow safe to
 # re-run, and to fire twice for one commit (a re-run of Tests, a manual dispatch).

--- a/scripts/create-dev-tag.sh
+++ b/scripts/create-dev-tag.sh
@@ -33,7 +33,9 @@ fi
 
 # Base the version on the latest stable tag, so a dev build sorts above the
 # current release and below the next one.
-LATEST_STABLE=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' 2>/dev/null)
+# `|| true`: under `set -e` a failing git describe would abort before the
+# explicit check below, so the error message would never be reached.
+LATEST_STABLE=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' 2>/dev/null || true)
 if [ -z "$LATEST_STABLE" ]; then
   echo "::error::No stable version tag found" >&2
   exit 1

--- a/scripts/create-dev-tag.sh
+++ b/scripts/create-dev-tag.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Calculate the dev release tag for HEAD.
+#
+# The dev channel tracks main: one release, replaced on every merge that passes
+# tests, so `install.sh --channel dev` always fetches current main. Tags are
+# created once and never moved — moving a published tag would make every plain
+# `git fetch` in every clone report "would clobber existing tag", forever. The
+# workflow deletes the superseded tag instead.
+#
+# Tag format: v<major>.<minor>.<patch+1>-dev.<YYYYMMDDhhmm>.<short-commit>
+# The -dev. prerelease suffix matters beyond naming: release.yml keys on it to
+# publish as a prerelease, and goreleaser stamps experimental.Visible=true for
+# any prerelease, so dogfooders keep seeing experimental commands.
+#
+# Exit codes: 0 with the tag on stdout, 2 if HEAD already has one (nothing to
+# do), 1 on error.
+#
+# Deliberately parallel to create-nightly-tag.sh rather than shared with it: that
+# script feeds the externally-consumed nightly channel, and this change is not the
+# place to refactor a published release path. Keep the two in step.
+# Usage: scripts/create-dev-tag.sh
+
+SHORT_COMMIT=$(git rev-parse --short HEAD)
+
+# Skip if a dev tag already exists for this commit. Makes the workflow safe to
+# re-run, and to fire twice for one commit (a re-run of Tests, a manual dispatch).
+if git tag -l "v*-dev.*.${SHORT_COMMIT}" | grep -q .; then
+  echo "Dev tag already exists for commit ${SHORT_COMMIT}, skipping." >&2
+  exit 2
+fi
+
+# Base the version on the latest stable tag, so a dev build sorts above the
+# current release and below the next one.
+LATEST_STABLE=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' 2>/dev/null)
+if [ -z "$LATEST_STABLE" ]; then
+  echo "::error::No stable version tag found" >&2
+  exit 1
+fi
+
+MAJOR=$(echo "$LATEST_STABLE" | sed 's/^v//' | cut -d. -f1)
+MINOR=$(echo "$LATEST_STABLE" | sed 's/^v//' | cut -d. -f2)
+PATCH=$(echo "$LATEST_STABLE" | sed 's/^v//' | cut -d. -f3)
+NEXT_PATCH=$((PATCH + 1))
+DEV_VERSION="v${MAJOR}.${MINOR}.${NEXT_PATCH}"
+
+DATE=$(TZ=UTC0 date +%Y%m%d%H%M)
+TAG="${DEV_VERSION}-dev.${DATE}.${SHORT_COMMIT}"
+
+# Two merges inside the same minute would otherwise collide on the timestamp.
+if git rev-parse "${TAG}" >/dev/null 2>&1; then
+  echo "Tag ${TAG} already exists, skipping." >&2
+  exit 2
+fi
+
+echo "${TAG}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -122,7 +122,10 @@ get_latest_dev_version() {
     # name, and cannot match a nightly tag.
     local url="https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100"
     local version
-    version=$(fetch_github_json "$url" | grep '"tag_name"' | grep -- '-dev\.' | head -n 1 | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
+    # `|| true`: install.sh runs with `set -euo pipefail`, so a grep that matches
+    # nothing would abort here instead of reaching the empty-version check below,
+    # replacing a clear message with a bare non-zero exit.
+    version=$(fetch_github_json "$url" | grep '"tag_name"' | grep -- '-dev\.' | head -n 1 | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/' || true)
 
     if [[ -z "$version" ]]; then
         error "Failed to fetch the latest dev version from GitHub. Please check your internet connection."
@@ -134,7 +137,10 @@ get_latest_dev_version() {
 get_latest_nightly_version() {
     local url="https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=20"
     local version
-    version=$(fetch_github_json "$url" | grep '"tag_name"' | grep 'nightly' | head -n 1 | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
+    # Same as the dev lookup: keep the pipeline non-fatal so the check below
+    # reports the failure. (Pre-existing; fixed alongside because the two
+    # channels share the shape.)
+    version=$(fetch_github_json "$url" | grep '"tag_name"' | grep 'nightly' | head -n 1 | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/' || true)
 
     if [[ -z "$version" ]]; then
         error "Failed to fetch latest nightly version from GitHub. Please check your internet connection."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,10 +42,13 @@ error() {
 
 usage() {
     cat <<EOF
-Usage: install.sh [--channel stable|nightly]
+Usage: install.sh [--channel stable|nightly|dev]
 
 Options:
   --channel   Release channel to install (default: stable)
+                stable  latest release
+                nightly latest nightly prerelease
+                dev     current main (rebuilt on every merge that passes tests)
   -h, --help  Show this help message
 EOF
 }
@@ -107,6 +110,22 @@ get_latest_stable_version() {
 
     if [[ -z "$version" ]]; then
         error "Failed to fetch latest version from GitHub. Please check your internet connection."
+    fi
+
+    echo "$version"
+}
+
+get_latest_dev_version() {
+    # The dev channel keeps exactly one release, replaced on every merge to main
+    # that passes tests, so there is nothing to disambiguate. Matching '-dev.'
+    # rather than bare 'dev' keeps this from colliding with anything else in a tag
+    # name, and cannot match a nightly tag.
+    local url="https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100"
+    local version
+    version=$(fetch_github_json "$url" | grep '"tag_name"' | grep -- '-dev\.' | head -n 1 | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
+
+    if [[ -z "$version" ]]; then
+        error "Failed to fetch the latest dev version from GitHub. Please check your internet connection."
     fi
 
     echo "$version"
@@ -178,9 +197,9 @@ main() {
     fi
 
     case "$channel" in
-        stable|nightly) ;;
+        stable|nightly|dev) ;;
         *)
-            error "Unsupported channel: ${channel}. Expected 'stable' or 'nightly'."
+            error "Unsupported channel: ${channel}. Expected 'stable', 'nightly' or 'dev'."
             ;;
     esac
 
@@ -193,11 +212,11 @@ main() {
     info "Detected platform: ${os}/${arch}"
 
     info "Fetching latest ${channel} version..."
-    if [[ "$channel" == "nightly" ]]; then
-        version=$(get_latest_nightly_version)
-    else
-        version=$(get_latest_stable_version)
-    fi
+    case "$channel" in
+        nightly) version=$(get_latest_nightly_version) ;;
+        dev)     version=$(get_latest_dev_version) ;;
+        *)       version=$(get_latest_stable_version) ;;
+    esac
     # Strip leading 'v' if present
     version="${version#v}"
     info "Installing version: ${version}"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1067
<!-- entire-trail-link-end -->

## Why

Removing local-dev mode (#1999) took away how this repo's developers ran their own code, without shipping the replacement. Hooks now name the `entire` binary and resolve it through PATH, so dogfooding means having a current build installed — and nothing built one automatically.

This adds a **`dev` channel: one release, replaced on every merge to main that passes tests.** `install.sh --channel dev` (or `mise run dev:sync`) therefore always fetches current main, through the same install path users take.

## Why not just retrigger nightly

Nightly is a daily, externally consumed channel and is **untouched here**. Firing it per merge would make its name a lie — but the reason this is structural rather than cosmetic:

`get_latest_nightly_version` reads `releases?per_page=20` and takes the first `nightly` match. main sees **6–21 merges/day** (last two weeks: 3, 3, 4, 8, 6, 5, 21, 4, 11, 9). A channel that accumulated a release per merge would push the newest nightly off that page and **silently break `--channel nightly`** — on busy days only, days after merge.

Keeping exactly one dev release sidesteps that entirely, which is why the existing nightly lookup needs no change at all.

## Why delete tags rather than move one

A force-moved tag is auto-followed by plain `git fetch`, so every clone would report `! [rejected] dev -> dev (would clobber existing tag)` on every merge, forever. Instead each dev tag is created once and never moved; the previous one is deleted **after the new release exists**, so `--channel dev` never sees zero releases. Deleted tags linger in a local clone until `git fetch --prune-tags`, which is cosmetic.

## What this touches beyond the new files

**`release.yml`** needed one change: its prerelease notes step hardcoded nightly, so a dev release would have been titled "Nightly Build" and diffed against the last *nightly*. Label and diff base now come from the tag. Everything else there already keys on prerelease-vs-stable, so a `-dev.` tag correctly:

- skips the CHANGELOG gate (prerelease)
- skips the homebrew/scoop stable path and `mirror-nightly` (both gated on `prerelease == 'false'`)
- keeps `experimental.Visible=true`, so dogfooders still see experimental commands

**`entire version` now reports the commit.** With one release per channel the tag no longer identifies a dev build, so without this every dev build reported the same string and a bug report against one couldn't say which. Both goreleaser configs already stamped `versioninfo.Commit` — it was simply never displayed. Omitted when unset, so a local build doesn't print `(unknown)`.

## Trade-off worth knowing

You can't install an older dev build to bisect a regression — there's only ever one. `mise run dev:publish` from a checkout covers that case. Given the channel's job is "am I running current main", I think that's the right trade, but it is a real cost.

## Judgment calls flagged rather than decided

- **Gated on Tests, not Tests + Lint.** A lint failure doesn't produce a broken binary, and waiting on two independent `workflow_run` events needs its own coordination.
- **Dev release failures still notify Slack** (`notify-slack` fires on `release` failure regardless of channel). A persistently broken main would ping repeatedly — but a silently broken dev channel seems worse. Easy to exclude if it turns out noisy.
- **Dev release notes diff against the last stable tag**, because the previous dev tag is deleted by design. That means notes list everything in main since the last release — informative, and grows over a release cycle.
- **`create-dev-tag.sh` deliberately duplicates ~25 lines of `create-nightly-tag.sh`** rather than sharing a helper, to avoid refactoring an externally-consumed release path in the same change. Worth unifying later; the two must be kept in step.

## Testing

`mise run fmt && mise run lint && mise run test:ci` pass; shellcheck clean on both new scripts. Both workflow YAMLs parse. `create-dev-tag.sh` produces `v0.10.1-dev.<ts>.<sha>` on this checkout and exits 2 idempotently for a commit that already has one. Verified the `dev` and `nightly` greps can't cross-match on a payload containing both, and that `install.sh` rejects an unknown channel. `entire version` covered by a unit test for both the stamped and unstamped cases.

The one thing that can only be verified after merge is the `workflow_run` trigger firing and the tag→release→retire sequence end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 60c8c38ca1171fa154c4e2d000ddbd503335d0e2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->