### PR TITLE
feat(telemetry): emit skill invocations as cli_skill_invoked events

### DIFF
--- a/cmd/entire/cli/checkpoint_policy_telemetry.go
+++ b/cmd/entire/cli/checkpoint_policy_telemetry.go
@@ -12,7 +12,7 @@ import (
 // and non-blocking; failures to load settings simply suppress the event.
 func emitCheckpointPolicyBlocked(ctx context.Context, event telemetry.CheckpointPolicyBlockedEvent) {
 	s, err := LoadEntireSettings(ctx)
-	if err != nil || s.Telemetry == nil || !*s.Telemetry {
+	if err != nil || !s.IsTelemetryEnabled() {
 		return
 	}
 	telemetry.TrackCheckpointPolicyBlocked(event, versioninfo.Version)

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -29,7 +29,9 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/review"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/perf"
 )
 
@@ -249,7 +251,7 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 				slog.String("adopted_into_worktree", state.AdoptedIntoWorktreePath))
 			return strategy.ErrMutationSkip
 		}
-		persistEventMetadataToState(event, state)
+		persistEventMetadataToState(ctx, event, state)
 		if transErr := strategy.TransitionAndLog(ctx, state, session.EventSessionStart, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
 			logging.Warn(logCtx, "session start transition failed",
 				slog.String("error", transErr.Error()))
@@ -647,7 +649,9 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 				event.Timestamp,
 			)
 		}
-		skillEventsChanged := appendEventSkillEventsToState(&skillEventSource, state)
+		appendedSkillEvents := appendEventSkillEventsToState(&skillEventSource, state)
+		trackSkillInvocations(ctx, appendedSkillEvents)
+		skillEventsChanged := len(appendedSkillEvents) > 0
 		if state.Kind == before.Kind &&
 			state.ReviewPrompt == before.ReviewPrompt &&
 			slices.Equal(state.ReviewSkills, before.ReviewSkills) &&
@@ -1061,7 +1065,7 @@ func handleLifecycleCompaction(ctx context.Context, ag agent.Agent, event *agent
 
 	// Fire EventCompaction to trigger ActionCondenseIfFilesTouched (stays in ACTIVE)
 	mutErr := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
-		persistEventMetadataToState(event, state)
+		persistEventMetadataToState(ctx, event, state)
 		if transErr := strategy.TransitionAndLog(ctx, state, session.EventCompaction, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
 			logging.Warn(logCtx, "compaction transition failed",
 				slog.String("error", transErr.Error()))
@@ -1900,7 +1904,7 @@ func recordCaptureDegraded(ctx context.Context, sessionID string, degraded bool)
 func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agent.Event) {
 	logCtx := logging.WithComponent(ctx, "lifecycle")
 	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
-		persistEventMetadataToState(event, state)
+		persistEventMetadataToState(ctx, event, state)
 		if err := strategy.TransitionAndLog(ctx, state, session.EventTurnEnd, session.TransitionContext{}, session.NoOpActionHandler{}); err != nil {
 			logging.Warn(logCtx, "turn-end transition failed",
 				slog.String("error", err.Error()))
@@ -1974,7 +1978,7 @@ func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string,
 			return strategy.ErrMutationSkip
 		}
 		if event != nil {
-			persistEventMetadataToState(event, state)
+			persistEventMetadataToState(ctx, event, state)
 		}
 		// Resolved before the transition, which is not a read-only step: the
 		// SessionStop edge carries ActionUpdateLastInteraction and stamps
@@ -2012,12 +2016,12 @@ func logFileChanges(ctx context.Context, modified, newFiles, deleted []string) {
 		slog.Int("deleted", len(deleted)))
 }
 
-func persistEventMetadataToState(event *agent.Event, state *strategy.SessionState) {
+func persistEventMetadataToState(ctx context.Context, event *agent.Event, state *strategy.SessionState) {
 	// Update ModelName if provided (model is known by turn-end even on first turn)
 	if event.Model != "" {
 		state.ModelName = event.Model
 	}
-	appendEventSkillEventsToState(event, state)
+	trackSkillInvocations(ctx, appendEventSkillEventsToState(event, state))
 
 	// Persist hook-provided session metrics (e.g., from Cursor hooks)
 	if event.DurationMs > 0 {
@@ -2052,11 +2056,15 @@ func persistEventMetadataToState(event *agent.Event, state *strategy.SessionStat
 	}
 }
 
-func appendEventSkillEventsToState(event *agent.Event, state *strategy.SessionState) bool {
+// appendEventSkillEventsToState appends the event's skill events to state,
+// deduping against events already recorded, and returns the events that were
+// actually appended (nil when nothing changed) so callers can forward exactly
+// the new ones to telemetry.
+func appendEventSkillEventsToState(event *agent.Event, state *strategy.SessionState) []agent.SkillEvent {
 	if event == nil || state == nil || len(event.SkillEvents) == 0 {
-		return false
+		return nil
 	}
-	changed := false
+	var appended []agent.SkillEvent
 	for _, skillEvent := range event.SkillEvents {
 		if skillEvent.TurnID == "" {
 			skillEvent.TurnID = state.TurnID
@@ -2065,9 +2073,35 @@ func appendEventSkillEventsToState(event *agent.Event, state *strategy.SessionSt
 			continue
 		}
 		state.SkillEvents = append(state.SkillEvents, skillEvent)
-		changed = true
+		appended = append(appended, skillEvent)
 	}
-	return changed
+	return appended
+}
+
+// trackSkillInvocations forwards newly-recorded skill events to telemetry.
+// Gated on the same opt-in telemetry setting as command tracking (root.go's
+// PersistentPostRun). Hook-driven lifecycle paths never produce
+// cli_command_executed events — the hooks tree is hidden — so this is the only
+// telemetry signal that a skill fired. Skill names and signal kinds only,
+// never prompt text or transcript content.
+func trackSkillInvocations(ctx context.Context, appended []agent.SkillEvent) {
+	if len(appended) == 0 {
+		return
+	}
+	s, err := LoadEntireSettings(ctx)
+	if err != nil || s.Telemetry == nil || !*s.Telemetry {
+		return
+	}
+	invocations := make([]telemetry.SkillInvocation, 0, len(appended))
+	for _, ev := range appended {
+		invocations = append(invocations, telemetry.SkillInvocation{
+			Skill:     ev.Skill.Name,
+			Agent:     ev.Source.Agent,
+			Signal:    ev.Source.Signal,
+			EventType: ev.EventType,
+		})
+	}
+	telemetry.TrackSkillInvocationsDetached(invocations, s.Enabled, versioninfo.Version)
 }
 
 func skillEventExists(events []agent.SkillEvent, candidate agent.SkillEvent) bool {

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -245,13 +245,14 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 	// SessionStart can fire before InitializeSession creates the state file,
 	// so ErrStateNotFound is the normal first-session path — only warn on
 	// genuinely unexpected errors, matching the rest of this file.
+	var appendedSkillEvents []agent.SkillEvent
 	mutErr := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
 		if state.AdoptedIntoWorktreePath != "" {
 			logging.Info(logCtx, "skipping adopted-away source session start",
 				slog.String("adopted_into_worktree", state.AdoptedIntoWorktreePath))
 			return strategy.ErrMutationSkip
 		}
-		persistEventMetadataToState(ctx, event, state)
+		appendedSkillEvents = persistEventMetadataToState(event, state)
 		if transErr := strategy.TransitionAndLog(ctx, state, session.EventSessionStart, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
 			logging.Warn(logCtx, "session start transition failed",
 				slog.String("error", transErr.Error()))
@@ -261,6 +262,9 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to update session state on start",
 			slog.String("error", mutErr.Error()))
+	}
+	if mutErr == nil {
+		trackSkillInvocations(ctx, appendedSkillEvents)
 	}
 
 	return nil
@@ -628,7 +632,8 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 	// spawning each per-turn investigate agent process so this conflict cannot
 	// happen for fresh investigate spawns. Both functions short-circuit on
 	// state.Kind != "" to keep the conflict harmless if it ever arises.
-	if mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+	var appendedSkillEvents []agent.SkillEvent
+	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
 		before := *state
 		// Slice fields share their backing array under struct copy. If
 		// adoptReviewEnv ever mutates ReviewSkills in place, the diff check
@@ -649,21 +654,26 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 				event.Timestamp,
 			)
 		}
-		appendedSkillEvents := appendEventSkillEventsToState(&skillEventSource, state)
-		trackSkillInvocations(ctx, appendedSkillEvents)
-		skillEventsChanged := len(appendedSkillEvents) > 0
+		appendedSkillEvents = appendEventSkillEventsToState(&skillEventSource, state)
 		if state.Kind == before.Kind &&
 			state.ReviewPrompt == before.ReviewPrompt &&
 			slices.Equal(state.ReviewSkills, before.ReviewSkills) &&
 			state.InvestigateRunID == before.InvestigateRunID &&
 			state.InvestigateTopic == before.InvestigateTopic &&
-			!skillEventsChanged {
+			len(appendedSkillEvents) == 0 {
 			return strategy.ErrMutationSkip
 		}
 		return nil
-	}); mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
+	})
+	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to save session state after review/investigate env adoption",
 			slog.String("error", mutErr.Error()))
+	}
+	// Telemetry runs after the session gate is released — settings load and
+	// process spawn must not extend the lock hold (and only after a successful
+	// save, so we never report events that weren't persisted).
+	if mutErr == nil {
+		trackSkillInvocations(ctx, appendedSkillEvents)
 	}
 	initSpan.End()
 
@@ -1064,8 +1074,9 @@ func handleLifecycleCompaction(ctx context.Context, ag agent.Agent, event *agent
 	)
 
 	// Fire EventCompaction to trigger ActionCondenseIfFilesTouched (stays in ACTIVE)
+	var appendedSkillEvents []agent.SkillEvent
 	mutErr := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
-		persistEventMetadataToState(ctx, event, state)
+		appendedSkillEvents = persistEventMetadataToState(event, state)
 		if transErr := strategy.TransitionAndLog(ctx, state, session.EventCompaction, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
 			logging.Warn(logCtx, "compaction transition failed",
 				slog.String("error", transErr.Error()))
@@ -1075,6 +1086,9 @@ func handleLifecycleCompaction(ctx context.Context, ag agent.Agent, event *agent
 	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to save session state after compaction",
 			slog.String("error", mutErr.Error()))
+	}
+	if mutErr == nil {
+		trackSkillInvocations(ctx, appendedSkillEvents)
 	}
 
 	logging.Info(logCtx, "context compaction detected")
@@ -1903,8 +1917,9 @@ func recordCaptureDegraded(ctx context.Context, sessionID string, degraded bool)
 // transitionSessionTurnEnd transitions the session phase to IDLE and dispatches turn-end actions.
 func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agent.Event) {
 	logCtx := logging.WithComponent(ctx, "lifecycle")
+	var appendedSkillEvents []agent.SkillEvent
 	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
-		persistEventMetadataToState(ctx, event, state)
+		appendedSkillEvents = persistEventMetadataToState(event, state)
 		if err := strategy.TransitionAndLog(ctx, state, session.EventTurnEnd, session.TransitionContext{}, session.NoOpActionHandler{}); err != nil {
 			logging.Warn(logCtx, "turn-end transition failed",
 				slog.String("error", err.Error()))
@@ -1922,6 +1937,9 @@ func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agen
 	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to update session phase on turn end",
 			slog.String("error", mutErr.Error()))
+	}
+	if mutErr == nil {
+		trackSkillInvocations(ctx, appendedSkillEvents)
 	}
 }
 
@@ -1973,12 +1991,13 @@ const (
 // session a concurrent turn just revived). It reports whether the session was
 // actually ended.
 func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string, guard func(*strategy.SessionState) bool, when endedAtPolicy) (ended bool, err error) {
+	var appendedSkillEvents []agent.SkillEvent
 	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
 		if guard != nil && !guard(state) {
 			return strategy.ErrMutationSkip
 		}
 		if event != nil {
-			persistEventMetadataToState(ctx, event, state)
+			appendedSkillEvents = persistEventMetadataToState(event, state)
 		}
 		// Resolved before the transition, which is not a read-only step: the
 		// SessionStop edge carries ActionUpdateLastInteraction and stamps
@@ -2004,6 +2023,7 @@ func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string,
 	if mutErr != nil {
 		return false, fmt.Errorf("failed to save session state: %w", mutErr)
 	}
+	trackSkillInvocations(ctx, appendedSkillEvents)
 	return ended, nil
 }
 
@@ -2016,12 +2036,16 @@ func logFileChanges(ctx context.Context, modified, newFiles, deleted []string) {
 		slog.Int("deleted", len(deleted)))
 }
 
-func persistEventMetadataToState(ctx context.Context, event *agent.Event, state *strategy.SessionState) {
+// persistEventMetadataToState returns the skill events newly appended to
+// state so callers can forward them to telemetry AFTER their surrounding
+// MutateSessionState closure releases the session gate — settings load and
+// detached-process spawn must never run while the lock is held.
+func persistEventMetadataToState(event *agent.Event, state *strategy.SessionState) []agent.SkillEvent {
 	// Update ModelName if provided (model is known by turn-end even on first turn)
 	if event.Model != "" {
 		state.ModelName = event.Model
 	}
-	trackSkillInvocations(ctx, appendEventSkillEventsToState(event, state))
+	appendedSkillEvents := appendEventSkillEventsToState(event, state)
 
 	// Persist hook-provided session metrics (e.g., from Cursor hooks)
 	if event.DurationMs > 0 {
@@ -2054,6 +2078,7 @@ func persistEventMetadataToState(ctx context.Context, event *agent.Event, state 
 	if event.ContextWindowSize > 0 {
 		state.ContextWindowSize = event.ContextWindowSize
 	}
+	return appendedSkillEvents
 }
 
 // appendEventSkillEventsToState appends the event's skill events to state,
@@ -2084,6 +2109,10 @@ func appendEventSkillEventsToState(event *agent.Event, state *strategy.SessionSt
 // cli_command_executed events — the hooks tree is hidden — so this is the only
 // telemetry signal that a skill fired. Skill names and signal kinds only,
 // never prompt text or transcript content.
+//
+// Call this AFTER the surrounding MutateSessionState returns, never inside its
+// closure: the settings load (disk I/O) and detached-process spawn must not
+// extend the session gate hold time and block concurrent hooks.
 func trackSkillInvocations(ctx context.Context, appended []agent.SkillEvent) {
 	if len(appended) == 0 {
 		return

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -244,7 +244,7 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 	// so ErrStateNotFound is the normal first-session path — only warn on
 	// genuinely unexpected errors, matching the rest of this file.
 	var appendedSkillEvents []agent.SkillEvent
-	mutErr := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
+	stateSaved, mutErr := strategy.MutateSessionStateSaved(ctx, event.SessionID, func(state *strategy.SessionState) error {
 		if state.AdoptedIntoWorktreePath != "" {
 			logging.Info(logCtx, "skipping adopted-away source session start",
 				slog.String("adopted_into_worktree", state.AdoptedIntoWorktreePath))
@@ -261,8 +261,8 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 		logging.Warn(logCtx, "failed to update session state on start",
 			slog.String("error", mutErr.Error()))
 	}
-	if mutErr == nil {
-		trackSkillInvocations(ctx, appendedSkillEvents)
+	if stateSaved {
+		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	}
 
 	return nil
@@ -631,7 +631,7 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 	// happen for fresh investigate spawns. Both functions short-circuit on
 	// state.Kind != "" to keep the conflict harmless if it ever arises.
 	var appendedSkillEvents []agent.SkillEvent
-	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+	stateSaved, mutErr := strategy.MutateSessionStateSaved(ctx, sessionID, func(state *strategy.SessionState) error {
 		before := *state
 		// Slice fields share their backing array under struct copy. If
 		// adoptReviewEnv ever mutates ReviewSkills in place, the diff check
@@ -670,8 +670,8 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 	// Telemetry runs after the session gate is released — settings load and
 	// process spawn must not extend the lock hold (and only after a successful
 	// save, so we never report events that weren't persisted).
-	if mutErr == nil {
-		trackSkillInvocations(ctx, appendedSkillEvents)
+	if stateSaved {
+		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	}
 	initSpan.End()
 
@@ -1073,7 +1073,7 @@ func handleLifecycleCompaction(ctx context.Context, ag agent.Agent, event *agent
 
 	// Fire EventCompaction to trigger ActionCondenseIfFilesTouched (stays in ACTIVE)
 	var appendedSkillEvents []agent.SkillEvent
-	mutErr := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
+	stateSaved, mutErr := strategy.MutateSessionStateSaved(ctx, event.SessionID, func(state *strategy.SessionState) error {
 		appendedSkillEvents = persistEventMetadataToState(event, state)
 		if transErr := strategy.TransitionAndLog(ctx, state, session.EventCompaction, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
 			logging.Warn(logCtx, "compaction transition failed",
@@ -1085,8 +1085,8 @@ func handleLifecycleCompaction(ctx context.Context, ag agent.Agent, event *agent
 		logging.Warn(logCtx, "failed to save session state after compaction",
 			slog.String("error", mutErr.Error()))
 	}
-	if mutErr == nil {
-		trackSkillInvocations(ctx, appendedSkillEvents)
+	if stateSaved {
+		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	}
 
 	logging.Info(logCtx, "context compaction detected")
@@ -1916,7 +1916,7 @@ func recordCaptureDegraded(ctx context.Context, sessionID string, degraded bool)
 func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agent.Event) {
 	logCtx := logging.WithComponent(ctx, "lifecycle")
 	var appendedSkillEvents []agent.SkillEvent
-	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+	stateSaved, mutErr := strategy.MutateSessionStateSaved(ctx, sessionID, func(state *strategy.SessionState) error {
 		appendedSkillEvents = persistEventMetadataToState(event, state)
 		if err := strategy.TransitionAndLog(ctx, state, session.EventTurnEnd, session.TransitionContext{}, session.NoOpActionHandler{}); err != nil {
 			logging.Warn(logCtx, "turn-end transition failed",
@@ -1934,15 +1934,20 @@ func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agen
 			logging.Warn(logCtx, "turn-end action dispatch failed",
 				slog.String("error", err.Error()))
 		}
-		appendedSkillEvents = append(appendedSkillEvents, state.SkillEvents[skillEventsBefore:]...)
+		// Guarded rather than sliced blind: nothing shortens SkillEvents today,
+		// but a future path that rewrote or trimmed the list would turn this
+		// into a panic in a hook.
+		if len(state.SkillEvents) > skillEventsBefore {
+			appendedSkillEvents = append(appendedSkillEvents, state.SkillEvents[skillEventsBefore:]...)
+		}
 		return nil
 	})
 	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to update session phase on turn end",
 			slog.String("error", mutErr.Error()))
 	}
-	if mutErr == nil {
-		trackSkillInvocations(ctx, appendedSkillEvents)
+	if stateSaved {
+		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	}
 }
 
@@ -1995,7 +2000,7 @@ const (
 // actually ended.
 func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string, guard func(*strategy.SessionState) bool, when endedAtPolicy) (ended bool, err error) {
 	var appendedSkillEvents []agent.SkillEvent
-	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+	stateSaved, mutErr := strategy.MutateSessionStateSaved(ctx, sessionID, func(state *strategy.SessionState) error {
 		if guard != nil && !guard(state) {
 			return strategy.ErrMutationSkip
 		}
@@ -2026,7 +2031,9 @@ func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string,
 	if mutErr != nil {
 		return false, fmt.Errorf("failed to save session state: %w", mutErr)
 	}
-	trackSkillInvocations(ctx, appendedSkillEvents)
+	if stateSaved {
+		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
+	}
 	return ended, nil
 }
 
@@ -2084,55 +2091,17 @@ func persistEventMetadataToState(event *agent.Event, state *strategy.SessionStat
 	return appendedSkillEvents
 }
 
-// appendEventSkillEventsToState appends the event's skill events to state,
-// deduping against events already recorded, and returns the events that were
-// actually appended (nil when nothing changed) so callers can forward exactly
-// the new ones to telemetry.
+// appendEventSkillEventsToState appends the event's hook-provided skill events
+// to state and returns those that were actually appended (nil when nothing
+// changed) so callers can forward exactly the new ones to telemetry. Dedupe
+// lives in strategy.AppendNewSkillEvents, shared with the transcript-extraction
+// paths — hook-driven and extracted events land in one list, so they must agree
+// on what counts as already recorded.
 func appendEventSkillEventsToState(event *agent.Event, state *strategy.SessionState) []agent.SkillEvent {
-	if event == nil || state == nil || len(event.SkillEvents) == 0 {
+	if event == nil {
 		return nil
 	}
-	var appended []agent.SkillEvent
-	for _, skillEvent := range event.SkillEvents {
-		if skillEvent.TurnID == "" {
-			skillEvent.TurnID = state.TurnID
-		}
-		if skillEventExists(state.SkillEvents, skillEvent) {
-			continue
-		}
-		state.SkillEvents = append(state.SkillEvents, skillEvent)
-		appended = append(appended, skillEvent)
-	}
-	return appended
-}
-
-// trackSkillInvocations forwards newly-recorded skill events to telemetry.
-// Hook-driven lifecycle paths never produce cli_command_executed events — the
-// hooks tree is hidden — so this and the strategy-side condensation emission
-// are the only telemetry signals that a skill fired. See
-// strategy.EmitSkillInvocationTelemetry for the gating and the
-// after-the-session-gate calling contract.
-func trackSkillInvocations(ctx context.Context, appended []agent.SkillEvent) {
-	strategy.EmitSkillInvocationTelemetry(ctx, appended)
-}
-
-func skillEventExists(events []agent.SkillEvent, candidate agent.SkillEvent) bool {
-	for _, existing := range events {
-		if existing.ID != "" && candidate.ID != "" {
-			if existing.ID == candidate.ID {
-				return true
-			}
-			continue
-		}
-		if existing.EventType == candidate.EventType &&
-			existing.Skill.Name == candidate.Skill.Name &&
-			existing.Source.Agent == candidate.Source.Agent &&
-			existing.Source.Signal == candidate.Source.Signal &&
-			existing.TurnID == candidate.TurnID {
-			return true
-		}
-	}
-	return false
+	return strategy.AppendNewSkillEvents(state, event.SkillEvents)
 }
 
 // envAdoptionSpec carries the kind-specific bits of env-driven session

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -29,9 +29,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/review"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
-	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
-	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/perf"
 )
 
@@ -1928,10 +1926,15 @@ func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agen
 		// save flushes those changes. Any reentrant MutateSessionState calls
 		// it makes on this session ID share this state pointer via the gate.
 		strat := GetStrategy(ctx)
+		// The turn-end finalize extracts skill events from the full transcript
+		// and appends the new ones to state.SkillEvents — snapshot its growth
+		// so those events reach telemetry alongside the hook-provided ones.
+		skillEventsBefore := len(state.SkillEvents)
 		if err := strat.HandleTurnEnd(ctx, state); err != nil {
 			logging.Warn(logCtx, "turn-end action dispatch failed",
 				slog.String("error", err.Error()))
 		}
+		appendedSkillEvents = append(appendedSkillEvents, state.SkillEvents[skillEventsBefore:]...)
 		return nil
 	})
 	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
@@ -2104,33 +2107,13 @@ func appendEventSkillEventsToState(event *agent.Event, state *strategy.SessionSt
 }
 
 // trackSkillInvocations forwards newly-recorded skill events to telemetry.
-// Gated on the same opt-in telemetry setting as command tracking (root.go's
-// PersistentPostRun). Hook-driven lifecycle paths never produce
-// cli_command_executed events — the hooks tree is hidden — so this is the only
-// telemetry signal that a skill fired. Skill names and signal kinds only,
-// never prompt text or transcript content.
-//
-// Call this AFTER the surrounding MutateSessionState returns, never inside its
-// closure: the settings load (disk I/O) and detached-process spawn must not
-// extend the session gate hold time and block concurrent hooks.
+// Hook-driven lifecycle paths never produce cli_command_executed events — the
+// hooks tree is hidden — so this and the strategy-side condensation emission
+// are the only telemetry signals that a skill fired. See
+// strategy.EmitSkillInvocationTelemetry for the gating and the
+// after-the-session-gate calling contract.
 func trackSkillInvocations(ctx context.Context, appended []agent.SkillEvent) {
-	if len(appended) == 0 {
-		return
-	}
-	s, err := LoadEntireSettings(ctx)
-	if err != nil || s.Telemetry == nil || !*s.Telemetry {
-		return
-	}
-	invocations := make([]telemetry.SkillInvocation, 0, len(appended))
-	for _, ev := range appended {
-		invocations = append(invocations, telemetry.SkillInvocation{
-			Skill:     ev.Skill.Name,
-			Agent:     ev.Source.Agent,
-			Signal:    ev.Source.Signal,
-			EventType: ev.EventType,
-		})
-	}
-	telemetry.TrackSkillInvocationsDetached(invocations, s.Enabled, versioninfo.Version)
+	strategy.EmitSkillInvocationTelemetry(ctx, appended)
 }
 
 func skillEventExists(events []agent.SkillEvent, candidate agent.SkillEvent) bool {

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -2537,7 +2537,7 @@ func writeCheckpoint(s *strategy.SessionState) int {
 // in between report the same count (deferred reset).
 func TestPromptWindowDeferredReset(t *testing.T) {
 	turn := func(s *strategy.SessionState) {
-		persistEventMetadataToState(&agent.Event{Type: agent.TurnEnd}, s)
+		persistEventMetadataToState(t.Context(), &agent.Event{Type: agent.TurnEnd}, s)
 	}
 
 	s := &strategy.SessionState{}
@@ -2575,7 +2575,7 @@ func TestPromptWindowDeferredReset(t *testing.T) {
 // TurnEnd increments.
 func TestPromptWindowExecModeCumulativeTurnCount(t *testing.T) {
 	exec := func(s *strategy.SessionState, cumulative int) {
-		persistEventMetadataToState(&agent.Event{Type: agent.TurnEnd, TurnCount: cumulative}, s)
+		persistEventMetadataToState(t.Context(), &agent.Event{Type: agent.TurnEnd, TurnCount: cumulative}, s)
 	}
 
 	s := &strategy.SessionState{}
@@ -2600,7 +2600,7 @@ func TestPromptWindowExecModeCumulativeTurnCount(t *testing.T) {
 // instead of matching the prior checkpoint's count.
 func TestPromptWindowStaleHookDoesNotResetEarly(t *testing.T) {
 	exec := func(s *strategy.SessionState, cumulative int) {
-		persistEventMetadataToState(&agent.Event{Type: agent.TurnEnd, TurnCount: cumulative}, s)
+		persistEventMetadataToState(t.Context(), &agent.Event{Type: agent.TurnEnd, TurnCount: cumulative}, s)
 	}
 
 	s := &strategy.SessionState{}
@@ -3899,4 +3899,37 @@ func TestCompleteLiveTaskRecords_CompletesEveryRecord(t *testing.T) {
 	require.NotNil(t, state)
 	require.Len(t, state.TaskRecords, taskCount, "records must persist after completion — the materializer reads them at condensation")
 	assert.Empty(t, state.LiveTaskRecords(), "the SessionEnd sweep must complete every record")
+}
+
+func TestAppendEventSkillEventsToState_ReturnsOnlyNewlyAppended(t *testing.T) {
+	t.Parallel()
+
+	first := agent.SkillEvent{
+		ID:        "evt-1",
+		EventType: agent.SkillEventTypePromptInvocation,
+		Skill:     agent.SkillEventSkill{Name: "search"},
+		Source:    agent.SkillEventSource{Agent: "claude-code", Signal: agent.SkillSignalPromptSlashCommand},
+	}
+	second := agent.SkillEvent{
+		ID:        "evt-2",
+		EventType: agent.SkillEventTypeToolInvocation,
+		Skill:     agent.SkillEventSkill{Name: "review"},
+		Source:    agent.SkillEventSource{Agent: "claude-code", Signal: agent.SkillSignalClaudeSkillToolUse},
+	}
+
+	state := &strategy.SessionState{TurnID: "turn-1"}
+
+	appended := appendEventSkillEventsToState(&agent.Event{SkillEvents: []agent.SkillEvent{first}}, state)
+	require.Len(t, appended, 1)
+	require.Equal(t, "search", appended[0].Skill.Name)
+	require.Equal(t, "turn-1", appended[0].TurnID, "TurnID should be backfilled before append")
+
+	// Re-delivering the first event appends nothing; only the new one comes back.
+	appended = appendEventSkillEventsToState(&agent.Event{SkillEvents: []agent.SkillEvent{first, second}}, state)
+	require.Len(t, appended, 1)
+	require.Equal(t, "review", appended[0].Skill.Name)
+	require.Len(t, state.SkillEvents, 2)
+
+	// Full re-delivery is a no-op.
+	require.Nil(t, appendEventSkillEventsToState(&agent.Event{SkillEvents: []agent.SkillEvent{first, second}}, state))
 }

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -2537,7 +2537,7 @@ func writeCheckpoint(s *strategy.SessionState) int {
 // in between report the same count (deferred reset).
 func TestPromptWindowDeferredReset(t *testing.T) {
 	turn := func(s *strategy.SessionState) {
-		persistEventMetadataToState(t.Context(), &agent.Event{Type: agent.TurnEnd}, s)
+		persistEventMetadataToState(&agent.Event{Type: agent.TurnEnd}, s)
 	}
 
 	s := &strategy.SessionState{}
@@ -2575,7 +2575,7 @@ func TestPromptWindowDeferredReset(t *testing.T) {
 // TurnEnd increments.
 func TestPromptWindowExecModeCumulativeTurnCount(t *testing.T) {
 	exec := func(s *strategy.SessionState, cumulative int) {
-		persistEventMetadataToState(t.Context(), &agent.Event{Type: agent.TurnEnd, TurnCount: cumulative}, s)
+		persistEventMetadataToState(&agent.Event{Type: agent.TurnEnd, TurnCount: cumulative}, s)
 	}
 
 	s := &strategy.SessionState{}
@@ -2600,7 +2600,7 @@ func TestPromptWindowExecModeCumulativeTurnCount(t *testing.T) {
 // instead of matching the prior checkpoint's count.
 func TestPromptWindowStaleHookDoesNotResetEarly(t *testing.T) {
 	exec := func(s *strategy.SessionState, cumulative int) {
-		persistEventMetadataToState(t.Context(), &agent.Event{Type: agent.TurnEnd, TurnCount: cumulative}, s)
+		persistEventMetadataToState(&agent.Event{Type: agent.TurnEnd, TurnCount: cumulative}, s)
 	}
 
 	s := &strategy.SessionState{}

--- a/cmd/entire/cli/plugin.go
+++ b/cmd/entire/cli/plugin.go
@@ -79,7 +79,7 @@ func maybeTrackPluginInvocation(ctx context.Context, pluginName string) {
 	if err != nil {
 		return
 	}
-	if s.Telemetry == nil || !*s.Telemetry {
+	if !s.IsTelemetryEnabled() {
 		return
 	}
 	telemetry.TrackPluginDetached(pluginName, s.Enabled, versioninfo.Version)

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -238,7 +238,7 @@ func newSendAnalyticsCmd() *cobra.Command {
 		Hidden: true,
 		Args:   cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			telemetry.SendEvent(args[0])
+			telemetry.SendEvents(args[0])
 		},
 	}
 }

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -1481,6 +1481,25 @@ func IsFilteredFetchesEnabled(ctx context.Context) bool {
 	return s.IsFilteredFetchesEnabled()
 }
 
+// IsTelemetryEnabled reports whether the user opted in to anonymous usage
+// analytics. Telemetry is opt-in: an absent key means no, so every tracker
+// call site must gate on this rather than on Telemetry being non-nil. Does not
+// consider ENTIRE_TELEMETRY_OPTOUT — the trackers honor that env opt-out
+// themselves (telemetry.IsEnvOptedOut).
+func (s *EntireSettings) IsTelemetryEnabled() bool {
+	return s != nil && s.Telemetry != nil && *s.Telemetry
+}
+
+// IsTelemetryEnabled loads settings and reports the telemetry opt-in. Returns
+// false when settings cannot be loaded — telemetry never fails open.
+func IsTelemetryEnabled(ctx context.Context) bool {
+	s, err := Load(ctx)
+	if err != nil {
+		return false
+	}
+	return s.IsTelemetryEnabled()
+}
+
 // IsSummarizeEnabled checks if auto-summarize is enabled in settings.
 // Returns false by default if settings cannot be loaded or the key is missing.
 func IsSummarizeEnabled(ctx context.Context) bool {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1640,7 +1640,7 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 	var shadowBranchName string
 	var clearAfter bool
 	var newSkillEvents []agent.SkillEvent
-	mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+	stateSaved, mutErr := MutateSessionStateSaved(ctx, sessionID, func(state *SessionState) error {
 		if state.PendingCondensationID() != checkpointID {
 			return ErrMutationSkip
 		}
@@ -1698,7 +1698,9 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 	if mutErr != nil {
 		return mutErr
 	}
-	EmitSkillInvocationTelemetry(ctx, newSkillEvents)
+	if stateSaved {
+		EmitSkillInvocationTelemetry(ctx, newSkillEvents)
+	}
 
 	if clearAfter {
 		if err := s.clearSessionState(ctx, sessionID); err != nil {
@@ -1817,7 +1819,7 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 
 	var didCondense bool
 	var newSkillEvents []agent.SkillEvent
-	mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+	stateSaved, mutErr := MutateSessionStateSaved(ctx, sessionID, func(state *SessionState) error {
 		var preflightErr error
 		shadowBranchName, shouldCondense, preflightErr = prepareEagerCondensation(logCtx, repo, state)
 		if preflightErr != nil || !shouldCondense {
@@ -1871,7 +1873,9 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 	if mutErr != nil {
 		return fmt.Errorf("failed to save session state: %w", mutErr)
 	}
-	EmitSkillInvocationTelemetry(ctx, newSkillEvents)
+	if stateSaved {
+		EmitSkillInvocationTelemetry(ctx, newSkillEvents)
+	}
 
 	if didCondense && shadowBranchName != "" {
 		if err := s.cleanupShadowBranchIfUnused(ctx, repo, shadowBranchName, sessionID); err != nil {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -604,7 +604,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		return recovery.result, recovery.err
 	}
 
-	writeOpts, attributionDuration := buildCondensationWriteOptions(
+	writeOpts, attributionDuration, newSkillEvents := buildCondensationWriteOptions(
 		ctx, repo, ref, state, sessionData, redactedTranscript, extractedAssets,
 		taskPayloads, checkpointID, shadowBranchName, o,
 	)
@@ -646,6 +646,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		Prompts:                sessionData.Prompts,
 		TotalTranscriptLines:   sessionData.FullTranscriptLines,
 		TranscriptSizeBaseline: transcriptSizeBaseline,
+		NewSkillEvents:         newSkillEvents,
 	}, nil
 }
 
@@ -691,7 +692,7 @@ func buildCondensationWriteOptions(
 	checkpointID id.CheckpointID,
 	shadowBranchName string,
 	o condenseOpts,
-) (cpkg.WriteOptions, time.Duration) {
+) (cpkg.WriteOptions, time.Duration, []agent.SkillEvent) {
 	authorName, authorEmail := GetGitAuthorFromRepo(repo)
 	attrBase := state.AttributionBaseCommit
 	if attrBase == "" {
@@ -719,7 +720,7 @@ func buildCondensationWriteOptions(
 
 	// Post-commit emits regex-only blobs. OPF runs later in the
 	// pre-push rewrite path, never here.
-	skillEvents := mergeSkillEvents(state.SkillEvents, withSkillEventTurnID(sessionData.SkillEvents, state.TurnID))
+	newSkillEvents, skillEvents := persistNewSkillEvents(state, sessionData.SkillEvents)
 	return cpkg.WriteOptions{
 		CheckpointID:                checkpointID,
 		SessionID:                   state.SessionID,
@@ -753,7 +754,7 @@ func buildCondensationWriteOptions(
 		HasInvestigation:            state.Kind.IsInvestigate(),
 		InvestigateRunID:            state.InvestigateRunID,
 		InvestigateTopic:            state.InvestigateTopic,
-	}, attributionDuration
+	}, attributionDuration, newSkillEvents
 }
 
 // redactOrDrop runs redactSessionTranscript and, on failure, logs a warning
@@ -1638,6 +1639,7 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 
 	var shadowBranchName string
 	var clearAfter bool
+	var newSkillEvents []agent.SkillEvent
 	mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
 		if state.PendingCondensationID() != checkpointID {
 			return ErrMutationSkip
@@ -1662,6 +1664,7 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 		if err != nil {
 			return fmt.Errorf("failed to condense session: %w", err)
 		}
+		newSkillEvents = result.NewSkillEvents
 
 		if result.Skipped {
 			logging.Info(logCtx, "session condensation skipped (no transcript or files), marking fully condensed",
@@ -1695,6 +1698,7 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 	if mutErr != nil {
 		return mutErr
 	}
+	EmitSkillInvocationTelemetry(ctx, newSkillEvents)
 
 	if clearAfter {
 		if err := s.clearSessionState(ctx, sessionID); err != nil {
@@ -1812,6 +1816,7 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 	}
 
 	var didCondense bool
+	var newSkillEvents []agent.SkillEvent
 	mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
 		var preflightErr error
 		shadowBranchName, shouldCondense, preflightErr = prepareEagerCondensation(logCtx, repo, state)
@@ -1832,6 +1837,7 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 			)
 			return ErrMutationSkip // fail-open
 		}
+		newSkillEvents = result.NewSkillEvents
 
 		if result.Skipped {
 			logging.Info(logCtx, "eager condense skipped (no transcript or files), marking fully condensed",
@@ -1865,6 +1871,7 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 	if mutErr != nil {
 		return fmt.Errorf("failed to save session state: %w", mutErr)
 	}
+	EmitSkillInvocationTelemetry(ctx, newSkillEvents)
 
 	if didCondense && shadowBranchName != "" {
 		if err := s.cleanupShadowBranchIfUnused(ctx, repo, shadowBranchName, sessionID); err != nil {

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -684,6 +684,10 @@ type postCommitActionHandler struct {
 	// Both failures and skips (no transcript/files) leave condensed=false, which
 	// correctly preserves shadow branches and defers FullyCondensed marking.
 	condensed bool
+	// newSkillEvents are the skill events condensation appended to session
+	// state; the PostCommit loop forwards them to telemetry after the
+	// session's MutateSessionState saves.
+	newSkillEvents []agent.SkillEvent
 }
 
 // parentCommitHash returns the first parent's hash as a string, or empty for initial commits.
@@ -707,7 +711,7 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 	)
 
 	if shouldCondense {
-		h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
+		h.condensed, h.newSkillEvents = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
 			shadowRef:        h.shadowRef,
 			headTree:         h.headTree,
 			parentTree:       h.parentTree,
@@ -736,7 +740,7 @@ func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.St
 	)
 
 	if shouldCondense {
-		h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
+		h.condensed, h.newSkillEvents = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
 			shadowRef:        h.shadowRef,
 			headTree:         h.headTree,
 			parentTree:       h.parentTree,
@@ -1001,8 +1005,9 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		}
 		sessionID := sess.SessionID
 		iterCtx, iterSpan := processSessionsLoop.Iteration(loopCtx)
+		var newSkillEvents []agent.SkillEvent
 		mutErr := MutateSessionState(iterCtx, sessionID, func(state *SessionState) error {
-			s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
+			newSkillEvents = s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
 				head, commit, newHead, worktreePath, headTree, parentTree,
 				committedFileSet, shadowBranchesToDelete, uncondensedActiveOnBranch, allAgentFiles,
 				sessionsWithCommittedFiles)
@@ -1012,6 +1017,9 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 			logging.Warn(logCtx, "post-commit: session mutation failed",
 				slog.String("session_id", sessionID),
 				slog.String("error", mutErr.Error()))
+		}
+		if mutErr == nil {
+			EmitSkillInvocationTelemetry(iterCtx, newSkillEvents)
 		}
 		iterSpan.End()
 	}
@@ -1198,7 +1206,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 	uncondensedActiveOnBranch map[string]bool,
 	allAgentFiles map[string]struct{},
 	sessionsWithCommittedFiles int,
-) {
+) (newSkillEvents []agent.SkillEvent) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	shadowBranchName := getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
 	reservedCheckpointID := state.PendingCondensationID()
@@ -1384,10 +1392,13 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 	if state.Phase.IsActive() && !handler.condensed {
 		uncondensedActiveOnBranch[shadowBranchName] = true
 	}
+
+	return handler.newSkillEvents
 }
 
 // condenseAndUpdateState runs condensation for a session and updates state afterward.
-// Returns true if condensation succeeded.
+// Returns whether condensation succeeded, plus the skill events it appended to
+// session state (for telemetry after the surrounding session gate releases).
 func (s *ManualCommitStrategy) condenseAndUpdateState(
 	ctx context.Context,
 	repo *git.Repository,
@@ -1398,7 +1409,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 	shadowBranchesToDelete map[string]struct{},
 	committedFiles map[string]struct{},
 	opts ...condenseOpts,
-) bool {
+) (condensed bool, newSkillEvents []agent.SkillEvent) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	result, err := s.CondenseSession(ctx, repo, checkpointID, state, committedFiles, opts...)
 	if err != nil {
@@ -1406,7 +1417,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 			slog.String("session_id", state.SessionID),
 			slog.String("error", err.Error()),
 		)
-		return false
+		return false, nil
 	}
 
 	if result.Skipped {
@@ -1414,7 +1425,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 			slog.String("session_id", state.SessionID),
 			slog.String("checkpoint_id", checkpointID.String()),
 		)
-		return false
+		return false, nil
 	}
 
 	// Track this shadow branch for cleanup
@@ -1451,7 +1462,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 		slog.Int("transcript_lines", result.TotalTranscriptLines),
 	)
 
-	return true
+	return true, result.NewSkillEvents
 }
 
 // updateBaseCommitIfChanged updates BaseCommit to newHead if it changed.
@@ -2889,7 +2900,10 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 	}
 
 	ag, _ := agent.GetByAgentType(state.AgentType) //nolint:errcheck // ag may be nil for unknown agent types; ExtractSkillEvents handles nil
-	skillEvents := mergeSkillEvents(state.SkillEvents, withSkillEventTurnID(agent.ExtractSkillEvents(ctx, ag, fullTranscript, 0), state.TurnID))
+	// Persist newly extracted events into state (the caller's MutateSessionState
+	// saves them); telemetry for them is emitted by the lifecycle turn-end
+	// handler, which snapshots state.SkillEvents growth around HandleTurnEnd.
+	_, skillEvents := persistNewSkillEvents(state, agent.ExtractSkillEvents(ctx, ag, fullTranscript, 0))
 
 	// Sanitize before externalizing and redacting, matching CondenseSession's
 	// sanitize -> externalize -> redact order. Skill events above are extracted from

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1006,7 +1006,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		sessionID := sess.SessionID
 		iterCtx, iterSpan := processSessionsLoop.Iteration(loopCtx)
 		var newSkillEvents []agent.SkillEvent
-		mutErr := MutateSessionState(iterCtx, sessionID, func(state *SessionState) error {
+		stateSaved, mutErr := MutateSessionStateSaved(iterCtx, sessionID, func(state *SessionState) error {
 			newSkillEvents = s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
 				head, commit, newHead, worktreePath, headTree, parentTree,
 				committedFileSet, shadowBranchesToDelete, uncondensedActiveOnBranch, allAgentFiles,
@@ -1018,7 +1018,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 				slog.String("session_id", sessionID),
 				slog.String("error", mutErr.Error()))
 		}
-		if mutErr == nil {
+		if stateSaved {
 			EmitSkillInvocationTelemetry(iterCtx, newSkillEvents)
 		}
 		iterSpan.End()
@@ -1216,7 +1216,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 			slog.String("reserved_checkpoint_id", reservedCheckpointID.String()),
 			slog.String("commit_checkpoint_id", checkpointID.String()))
 		uncondensedActiveOnBranch[shadowBranchName] = true
-		return
+		return newSkillEvents
 	}
 
 	// Pre-resolve shadow branch ref and tree for this session.

--- a/cmd/entire/cli/strategy/manual_commit_types.go
+++ b/cmd/entire/cli/strategy/manual_commit_types.go
@@ -62,6 +62,14 @@ type CondenseResult struct {
 	// a TranscriptSanitizer, so the session silently stops condensing after its
 	// first commit.
 	TranscriptSizeBaseline int64
+
+	// NewSkillEvents are the transcript-extracted skill events this
+	// condensation appended to session state (already deduped against
+	// everything previously recorded). Callers forward them to
+	// EmitSkillInvocationTelemetry after their MutateSessionState saves — an
+	// unsaved append is re-derived by the next extraction pass, so emitting
+	// early would double-report.
+	NewSkillEvents []agent.SkillEvent
 }
 
 // ExtractedSessionData contains data extracted from a shadow branch.

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -523,12 +523,27 @@ func goroutineID() int64 {
 // PostToolUse hook cannot revert fields written by lifecycle handlers
 // (TurnEnd, PostCommit, ModelUpdate) that ran between our load and our save.
 func MutateSessionState(ctx context.Context, sessionID string, fn func(*SessionState) error) error {
+	_, err := MutateSessionStateSaved(ctx, sessionID, fn)
+	return err
+}
+
+// MutateSessionStateSaved is MutateSessionState plus whether the mutation was
+// actually persisted. A nil error is NOT proof of a save: ErrMutationSkip
+// reports success without writing, so callers with side effects that must only
+// follow a durable write (telemetry that would otherwise double-report a
+// re-derived event) have to distinguish the two.
+//
+// saved is true for a nested call whose fn succeeded, because the outer frame
+// flushes those mutations; if that outer frame then skips or fails, the caller
+// has acted on an unsaved change — the same exposure the plain error return
+// always had, and self-correcting for events that later re-derive.
+func MutateSessionStateSaved(ctx context.Context, sessionID string, fn func(*SessionState) error) (saved bool, err error) {
 	if sessionID == "" {
-		return ErrStateNotFound
+		return false, ErrStateNotFound
 	}
 	gate, isOuter, release, err := acquireSessionGate(ctx, sessionID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer release()
 
@@ -536,34 +551,37 @@ func MutateSessionState(ctx context.Context, sessionID string, fn func(*SessionS
 		// Nested call: reuse the outer's state pointer. The outer save will
 		// flush our mutations; we don't load or save here.
 		if gate.activeState == nil {
-			return ErrStateNotFound
+			return false, ErrStateNotFound
 		}
-		if err := fn(gate.activeState); err != nil && !errors.Is(err, ErrMutationSkip) {
-			return err
+		if err := fn(gate.activeState); err != nil {
+			if errors.Is(err, ErrMutationSkip) {
+				return false, nil
+			}
+			return false, err
 		}
-		return nil
+		return true, nil
 	}
 
 	state, err := LoadSessionState(ctx, sessionID)
 	if err != nil {
-		return fmt.Errorf("load session state: %w", err)
+		return false, fmt.Errorf("load session state: %w", err)
 	}
 	if state == nil {
-		return ErrStateNotFound
+		return false, ErrStateNotFound
 	}
 	gate.activeState = state
 	defer func() { gate.activeState = nil }()
 
 	if err := fn(state); err != nil {
 		if errors.Is(err, ErrMutationSkip) {
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
 	if err := SaveSessionState(ctx, state); err != nil {
-		return fmt.Errorf("save session state: %w", err)
+		return false, fmt.Errorf("save session state: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 // acquireSessionGate takes the per-process gate (in-memory) and, on the

--- a/cmd/entire/cli/strategy/skill_events.go
+++ b/cmd/entire/cli/strategy/skill_events.go
@@ -61,6 +61,21 @@ func appendNewSkillEvents(state *SessionState, candidates []agent.SkillEvent) []
 	return appended
 }
 
+// AppendNewSkillEvents records candidates into state.SkillEvents, stamping the
+// session's TurnID on events that lack one, and returns those that were not
+// already recorded. It is the single dedupe used by every path that adds skill
+// events — hook-provided (lifecycle) and transcript-extracted (condensation and
+// turn-end finalize) alike — so "already recorded" means the same thing
+// everywhere. Exactly-once telemetry rests on that agreement: two paths with
+// different notions of duplicate would let one re-report what the other
+// recorded.
+func AppendNewSkillEvents(state *SessionState, candidates []agent.SkillEvent) []agent.SkillEvent {
+	if state == nil || len(candidates) == 0 {
+		return nil
+	}
+	return appendNewSkillEvents(state, withSkillEventTurnID(candidates, state.TurnID))
+}
+
 // persistNewSkillEvents records extracted transcript skill events into session
 // state and returns both the newly appended events (for telemetry — see
 // appendNewSkillEvents for the exactly-once contract) and the full deduped
@@ -70,7 +85,7 @@ func appendNewSkillEvents(state *SessionState, candidates []agent.SkillEvent) []
 // — hooks never carry them — which is why persistence lives here rather than
 // in the lifecycle handlers.
 func persistNewSkillEvents(state *SessionState, extracted []agent.SkillEvent) (newEvents, checkpointView []agent.SkillEvent) {
-	newEvents = appendNewSkillEvents(state, withSkillEventTurnID(extracted, state.TurnID))
+	newEvents = AppendNewSkillEvents(state, extracted)
 	return newEvents, mergeSkillEvents(state.SkillEvents)
 }
 

--- a/cmd/entire/cli/strategy/skill_events.go
+++ b/cmd/entire/cli/strategy/skill_events.go
@@ -32,6 +32,48 @@ func skillEventKey(ev agent.SkillEvent) string {
 	return key
 }
 
+// appendNewSkillEvents merges candidates into state.SkillEvents and returns
+// the events that were not already recorded. Persisting the merged set into
+// session state is what keeps telemetry exactly-once: condensation and the
+// turn-end finalize both re-extract skill events from the full transcript
+// (offset 0) on every run, so without a durable record each pass would
+// re-surface the same events. Callers forward the returned slice to telemetry
+// only after their surrounding MutateSessionState saves the state — an
+// unsaved append is re-derived (and re-returned) by the next pass.
+func appendNewSkillEvents(state *SessionState, candidates []agent.SkillEvent) []agent.SkillEvent {
+	if len(candidates) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(state.SkillEvents))
+	for _, ev := range state.SkillEvents {
+		seen[skillEventKey(ev)] = struct{}{}
+	}
+	var appended []agent.SkillEvent
+	for _, ev := range candidates {
+		key := skillEventKey(ev)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		state.SkillEvents = append(state.SkillEvents, ev)
+		appended = append(appended, ev)
+	}
+	return appended
+}
+
+// persistNewSkillEvents records extracted transcript skill events into session
+// state and returns both the newly appended events (for telemetry — see
+// appendNewSkillEvents for the exactly-once contract) and the full deduped
+// checkpoint view (state events first, extracted additions after, matching the
+// order mergeSkillEvents always produced here). Transcript-extracted events
+// (e.g. Claude Code's Skill tool) only surface on the condense/finalize paths
+// — hooks never carry them — which is why persistence lives here rather than
+// in the lifecycle handlers.
+func persistNewSkillEvents(state *SessionState, extracted []agent.SkillEvent) (newEvents, checkpointView []agent.SkillEvent) {
+	newEvents = appendNewSkillEvents(state, withSkillEventTurnID(extracted, state.TurnID))
+	return newEvents, mergeSkillEvents(state.SkillEvents)
+}
+
 func withSkillEventTurnID(events []agent.SkillEvent, turnID string) []agent.SkillEvent {
 	if len(events) == 0 || turnID == "" {
 		return events

--- a/cmd/entire/cli/strategy/skill_events_test.go
+++ b/cmd/entire/cli/strategy/skill_events_test.go
@@ -1,0 +1,75 @@
+package strategy
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+func toolSkillEvent(id, name string) agent.SkillEvent {
+	return agent.SkillEvent{
+		ID:        id,
+		EventType: agent.SkillEventTypeToolInvocation,
+		Skill:     agent.SkillEventSkill{Name: name},
+		Source: agent.SkillEventSource{
+			Agent:      "claude-code",
+			Signal:     agent.SkillSignalClaudeSkillToolUse,
+			Confidence: agent.SkillConfidenceExplicit,
+		},
+	}
+}
+
+func TestAppendNewSkillEvents_ReturnsOnlyUnrecordedEvents(t *testing.T) {
+	t.Parallel()
+
+	existing := toolSkillEvent("claude-skill-tu-1", "entire")
+	state := &SessionState{SkillEvents: []agent.SkillEvent{existing}}
+
+	fresh := toolSkillEvent("claude-skill-tu-2", "review")
+	appended := appendNewSkillEvents(state, []agent.SkillEvent{existing, fresh})
+
+	if len(appended) != 1 || appended[0].ID != fresh.ID {
+		t.Fatalf("appended = %+v, want only %q", appended, fresh.ID)
+	}
+	if len(state.SkillEvents) != 2 {
+		t.Fatalf("state.SkillEvents has %d events, want 2", len(state.SkillEvents))
+	}
+}
+
+func TestAppendNewSkillEvents_SecondPassIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Condensation and turn-end finalize re-extract from the full transcript
+	// (offset 0) on every run, so a second pass over the same events must
+	// append and report nothing — that is what keeps telemetry exactly-once.
+	state := &SessionState{}
+	events := []agent.SkillEvent{
+		toolSkillEvent("claude-skill-tu-1", "entire"),
+		toolSkillEvent("claude-skill-tu-2", "review"),
+	}
+
+	if first := appendNewSkillEvents(state, events); len(first) != 2 {
+		t.Fatalf("first pass appended %d events, want 2", len(first))
+	}
+	if second := appendNewSkillEvents(state, events); len(second) != 0 {
+		t.Fatalf("second pass appended %d events, want 0", len(second))
+	}
+	if len(state.SkillEvents) != 2 {
+		t.Fatalf("state.SkillEvents has %d events, want 2", len(state.SkillEvents))
+	}
+}
+
+func TestAppendNewSkillEvents_DedupesWithinCandidates(t *testing.T) {
+	t.Parallel()
+
+	state := &SessionState{}
+	ev := toolSkillEvent("claude-skill-tu-1", "entire")
+	appended := appendNewSkillEvents(state, []agent.SkillEvent{ev, ev})
+
+	if len(appended) != 1 {
+		t.Fatalf("appended %d events, want 1", len(appended))
+	}
+	if len(state.SkillEvents) != 1 {
+		t.Fatalf("state.SkillEvents has %d events, want 1", len(state.SkillEvents))
+	}
+}

--- a/cmd/entire/cli/strategy/skill_telemetry.go
+++ b/cmd/entire/cli/strategy/skill_telemetry.go
@@ -1,0 +1,41 @@
+package strategy
+
+import (
+	"context"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+)
+
+// EmitSkillInvocationTelemetry forwards newly recorded skill events to
+// telemetry. Gated on the same opt-in telemetry setting as command tracking;
+// skill names are additionally allowlisted inside the telemetry package, so
+// custom names never leave the machine verbatim. Skill names and signal kinds
+// only, never prompt text or transcript content.
+//
+// Call this AFTER the surrounding MutateSessionState returns, never inside its
+// closure: the settings load (disk I/O) and detached-process spawn must not
+// extend the session gate hold time and block concurrent hooks. Emitting only
+// after a successful save also keeps reporting exactly-once — events whose
+// append was never persisted are re-derived by the next extraction pass.
+func EmitSkillInvocationTelemetry(ctx context.Context, events []agent.SkillEvent) {
+	if len(events) == 0 {
+		return
+	}
+	s, err := settings.Load(ctx)
+	if err != nil || s.Telemetry == nil || !*s.Telemetry {
+		return
+	}
+	invocations := make([]telemetry.SkillInvocation, 0, len(events))
+	for _, ev := range events {
+		invocations = append(invocations, telemetry.SkillInvocation{
+			Skill:     ev.Skill.Name,
+			Agent:     ev.Source.Agent,
+			Signal:    ev.Source.Signal,
+			EventType: ev.EventType,
+		})
+	}
+	telemetry.TrackSkillInvocationsDetached(invocations, s.Enabled, versioninfo.Version)
+}

--- a/cmd/entire/cli/strategy/skill_telemetry.go
+++ b/cmd/entire/cli/strategy/skill_telemetry.go
@@ -25,9 +25,20 @@ func EmitSkillInvocationTelemetry(ctx context.Context, events []agent.SkillEvent
 		return
 	}
 	s, err := settings.Load(ctx)
-	if err != nil || s.Telemetry == nil || !*s.Telemetry {
+	if err != nil || !s.IsTelemetryEnabled() {
 		return
 	}
+	emitSkillTelemetry(events, s.Enabled, versioninfo.Version)
+}
+
+// emitSkillTelemetry is the send step, separated from the gating above so tests
+// can assert what the gate lets through — and that emission happens outside the
+// session gate — without a PostHog client.
+//
+//nolint:gochecknoglobals // test seam, set and restored by in-package tests.
+var emitSkillTelemetry = trackSkillInvocations
+
+func trackSkillInvocations(events []agent.SkillEvent, isEntireEnabled bool, version string) {
 	invocations := make([]telemetry.SkillInvocation, 0, len(events))
 	for _, ev := range events {
 		invocations = append(invocations, telemetry.SkillInvocation{
@@ -37,5 +48,5 @@ func EmitSkillInvocationTelemetry(ctx context.Context, events []agent.SkillEvent
 			EventType: ev.EventType,
 		})
 	}
-	telemetry.TrackSkillInvocationsDetached(invocations, s.Enabled, versioninfo.Version)
+	telemetry.TrackSkillInvocationsDetached(invocations, isEntireEnabled, version)
 }

--- a/cmd/entire/cli/strategy/skill_telemetry_test.go
+++ b/cmd/entire/cli/strategy/skill_telemetry_test.go
@@ -1,0 +1,171 @@
+package strategy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTelemetrySettings puts a repo with a known telemetry opt-in state on
+// disk and points settings resolution at it.
+func writeTelemetrySettings(t *testing.T, telemetry string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	// InitializeSession resolves HEAD, so the repo needs a commit.
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, paths.EntireDir), 0o755))
+	body := `{"enabled": true`
+	if telemetry != "" {
+		body += `, "telemetry": ` + telemetry
+	}
+	body += `}`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, paths.EntireDir, "settings.json"), []byte(body), 0o644))
+	t.Chdir(tmpDir)
+}
+
+func telemetrySkillEvent(id string) agent.SkillEvent {
+	return agent.SkillEvent{
+		ID:        id,
+		EventType: agent.SkillEventTypeToolInvocation,
+		Skill:     agent.SkillEventSkill{Name: "entire:search"},
+		Source: agent.SkillEventSource{
+			Agent:  "claude-code",
+			Signal: agent.SkillSignalClaudeSkillToolUse,
+		},
+	}
+}
+
+// captureSkillEmissions swaps the emitter seam and returns what each call
+// forwarded, so tests can assert the gate and the call ordering without a
+// PostHog client.
+func captureSkillEmissions(t *testing.T) *[][]agent.SkillEvent {
+	t.Helper()
+	calls := [][]agent.SkillEvent{}
+	prev := emitSkillTelemetry
+	emitSkillTelemetry = func(events []agent.SkillEvent, _ bool, _ string) {
+		calls = append(calls, events)
+	}
+	t.Cleanup(func() { emitSkillTelemetry = prev })
+	return &calls
+}
+
+func TestEmitSkillInvocationTelemetry_RequiresOptIn(t *testing.T) {
+	tests := []struct {
+		name      string
+		telemetry string
+		wantCalls int
+	}{
+		{"opted in", "true", 1},
+		{"opted out", "false", 0},
+		// Telemetry is opt-in: an absent key must not send.
+		{"unset", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeTelemetrySettings(t, tt.telemetry)
+			calls := captureSkillEmissions(t)
+
+			EmitSkillInvocationTelemetry(t.Context(), []agent.SkillEvent{telemetrySkillEvent("a")})
+
+			if len(*calls) != tt.wantCalls {
+				t.Errorf("emitted %d times, want %d", len(*calls), tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestEmitSkillInvocationTelemetry_NoEventsNoLoad(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+	calls := captureSkillEmissions(t)
+
+	EmitSkillInvocationTelemetry(t.Context(), nil)
+
+	if len(*calls) != 0 {
+		t.Errorf("emitted %d times for zero events, want 0", len(*calls))
+	}
+}
+
+// The emitter must run after MutateSessionState releases the session gate:
+// settings I/O and a process spawn under the lock block concurrent hooks.
+//
+// The discriminator is durability, not visibility. From inside the emitter we
+// mutate the session and immediately re-read it from disk. Called after the
+// gate is released, that mutation is an OUTER one and saves, so the re-read
+// sees it. Called from inside the closure it would be a NESTED one, which by
+// contract defers its write to the outer frame's save — so the re-read would
+// still show the old value. (Comparing in-memory state would prove nothing:
+// the nested call shares the outer's state pointer.)
+func TestEmitSkillInvocationTelemetry_RunsOutsideTheSessionGate(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+
+	sessionID := "sess-gate-scope"
+	require.NoError(t, (&ManualCommitStrategy{}).InitializeSession(
+		t.Context(), sessionID, agent.AgentTypeClaudeCode, "", "prompt", ""))
+
+	const emitterMark = "written-by-emitter"
+	var emitterWritePersisted bool
+	prev := emitSkillTelemetry
+	emitSkillTelemetry = func(_ []agent.SkillEvent, _ bool, _ string) {
+		mutErr := MutateSessionState(t.Context(), sessionID, func(state *SessionState) error {
+			state.LastPrompt = emitterMark
+			return nil
+		})
+		if mutErr != nil {
+			t.Errorf("emitter mutation failed: %v", mutErr)
+			return
+		}
+		reloaded, err := LoadSessionState(t.Context(), sessionID)
+		emitterWritePersisted = err == nil && reloaded != nil && reloaded.LastPrompt == emitterMark
+	}
+	t.Cleanup(func() { emitSkillTelemetry = prev })
+
+	var appended []agent.SkillEvent
+	saved, err := MutateSessionStateSaved(t.Context(), sessionID, func(state *SessionState) error {
+		appended = AppendNewSkillEvents(state, []agent.SkillEvent{telemetrySkillEvent("a")})
+		return nil
+	})
+	require.NoError(t, err)
+	require.True(t, saved)
+	require.Len(t, appended, 1)
+
+	EmitSkillInvocationTelemetry(t.Context(), appended)
+
+	require.True(t, emitterWritePersisted,
+		"the emitter's mutation did not persist, so it ran nested inside the session gate")
+}
+
+// The "emit only after a durable save" contract: a skipped mutation reports no
+// save, so callers never announce events the next extraction pass will re-derive.
+func TestMutateSessionStateSaved_ReportsSkipAsUnsaved(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+
+	sessionID := "sess-skip-report"
+	require.NoError(t, (&ManualCommitStrategy{}).InitializeSession(
+		t.Context(), sessionID, agent.AgentTypeClaudeCode, "", "prompt", ""))
+
+	saved, err := MutateSessionStateSaved(t.Context(), sessionID, func(state *SessionState) error {
+		state.LastPrompt = "not-persisted"
+		return ErrMutationSkip
+	})
+	require.NoError(t, err, "ErrMutationSkip is not an error")
+	require.False(t, saved, "a skipped mutation must not report itself as saved")
+
+	reloaded, err := LoadSessionState(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotEqual(t, "not-persisted", reloaded.LastPrompt, "skip must not have written")
+
+	saved, err = MutateSessionStateSaved(t.Context(), sessionID, func(state *SessionState) error {
+		state.LastPrompt = "persisted"
+		return nil
+	})
+	require.NoError(t, err)
+	require.True(t, saved)
+}

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -167,10 +167,12 @@ func TrackPluginDetached(pluginName string, isEntireEnabled bool, version string
 
 // SkillInvocation is the content-free view of one recorded skill event: which
 // skill fired, on which agent, and how it was detected. Deliberately no prompt
-// text, arguments, or transcript content — mirroring BuildPluginEventPayload's
-// name-only rule.
+// text, arguments, or transcript content — and the skill name itself is only
+// sent verbatim when allowlisted (see skillNameForTelemetry), because custom
+// slash-command names are user content too.
 type SkillInvocation struct {
-	// Skill is the invoked skill's name (e.g. "search").
+	// Skill is the invoked skill's name (e.g. "entire"). Names outside the
+	// official allowlist are reported as "custom".
 	Skill string
 	// Agent is the agent that surfaced the signal (e.g. "claude-code").
 	Agent string
@@ -202,7 +204,7 @@ func BuildSkillEventPayload(inv SkillInvocation, isEntireEnabled bool, version s
 	}
 
 	properties := map[string]any{
-		"skill":           inv.Skill,
+		"skill":           skillNameForTelemetry(inv.Skill),
 		"agent":           agentName,
 		"signal":          inv.Signal,
 		"event_type":      inv.EventType,

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -86,11 +86,77 @@ func BuildEventPayload(cmd *cobra.Command, agent string, isEntireEnabled bool, v
 	}
 }
 
+// spawnAnalyticsHook replaces the detached spawn when non-nil so tests can
+// assert how many sends a call performs and what each carries. Production
+// leaves it nil. execx.SpawnDetached itself no-ops under `go test`, so counting
+// sends needs a seam here rather than a spy on the child.
+//
+//nolint:gochecknoglobals // test seam, set and restored by in-package tests.
+var spawnAnalyticsHook func(payloadJSON string)
+
 // spawnDetachedAnalytics sends the payload from a detached `entire
 // __send_analytics` child so the network call never blocks the CLI. The empty
-// dir keeps the child out of the parent's working directory.
+// dir keeps the child out of the parent's working directory. payloadJSON is
+// one event object or an array of them — see SendEvents.
 func spawnDetachedAnalytics(payloadJSON string) {
+	if spawnAnalyticsHook != nil {
+		spawnAnalyticsHook(payloadJSON)
+		return
+	}
 	execx.SpawnDetached("", "__send_analytics", payloadJSON)
+}
+
+// maxDetachedPayloadBytes bounds the JSON handed to one child. The payload
+// travels as an argv element and argv limits are per-platform and modest
+// (macOS caps the whole vector near 256KB), so an oversized batch is split
+// across children rather than risking a spawn that fails wholesale. Far above
+// any realistic batch: one event payload runs a few hundred bytes.
+const maxDetachedPayloadBytes = 96 * 1024
+
+// spawnDetachedAnalyticsBatch sends every payload using as few detached
+// children as the size budget allows — normally exactly one.
+//
+// Nothing is dropped: a batch too large for one argv is split, so an unusually
+// long backlog costs an extra process instead of lost events. Batching also
+// means the child resolves the git version once per send rather than once per
+// event.
+func spawnDetachedAnalyticsBatch(payloads []*EventPayload) {
+	const (
+		bracketsBytes = 2 // "[" and "]"
+		commaBytes    = 1
+	)
+	batch := make([]json.RawMessage, 0, len(payloads))
+	size := bracketsBytes
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		if batchJSON, err := json.Marshal(batch); err == nil {
+			spawnDetachedAnalytics(string(batchJSON))
+		}
+		batch = batch[:0]
+		size = bracketsBytes
+	}
+
+	for _, payload := range payloads {
+		if payload == nil {
+			continue
+		}
+		payloadJSON, err := json.Marshal(payload)
+		if err != nil {
+			continue
+		}
+		// Flush before appending so the batch stays within budget. A single
+		// payload over the budget still goes out alone: dropping it would be
+		// the silent loss this batching exists to remove.
+		if len(batch) > 0 && size+len(payloadJSON)+commaBytes > maxDetachedPayloadBytes {
+			flush()
+		}
+		batch = append(batch, payloadJSON)
+		size += len(payloadJSON) + commaBytes
+	}
+	flush()
 }
 
 // TrackCommandDetached tracks a command execution by spawning a detached subprocess.
@@ -222,40 +288,41 @@ func BuildSkillEventPayload(inv SkillInvocation, isEntireEnabled bool, version s
 	}
 }
 
-// maxSkillInvocationsPerTrack caps how many detached senders one call can
-// spawn. Real turns carry at most a few skill events; the cap only guards
-// against a pathological transcript producing a process storm.
-const maxSkillInvocationsPerTrack = 10
-
-// TrackSkillInvocationsDetached records skill invocations surfaced by agent
-// hooks, one event per invocation (capped at maxSkillInvocationsPerTrack per
-// call; excess events are dropped). Like TrackPluginDetached, it only honors
-// the env opt-out itself — call sites must gate on the user's opt-in telemetry
-// setting.
+// TrackSkillInvocationsDetached records skill invocations, batching every
+// event into a single detached send (split only if it would exceed
+// maxDetachedPayloadBytes). Like TrackPluginDetached, it only honors the env
+// opt-out itself — call sites must gate on the user's opt-in telemetry setting.
+//
+// No per-call cap: an earlier version truncated to 10 events, which silently
+// dropped real invocations once condensation began extracting from transcript
+// offset 0 — the first condensation of a session drains its whole skill-event
+// backlog in one call, and a dropped event is never re-reported because the
+// dedupe in session state has already recorded it.
 func TrackSkillInvocationsDetached(invocations []SkillInvocation, isEntireEnabled bool, version string) {
 	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
 		return
 	}
 
-	if len(invocations) > maxSkillInvocationsPerTrack {
-		invocations = invocations[:maxSkillInvocationsPerTrack]
-	}
+	payloads := make([]*EventPayload, 0, len(invocations))
 	for _, inv := range invocations {
-		payload := BuildSkillEventPayload(inv, isEntireEnabled, version)
-		if payload == nil {
-			continue
-		}
-		if payloadJSON, err := json.Marshal(payload); err == nil {
-			spawnDetachedAnalytics(string(payloadJSON))
+		if payload := BuildSkillEventPayload(inv, isEntireEnabled, version); payload != nil {
+			payloads = append(payloads, payload)
 		}
 	}
+	spawnDetachedAnalyticsBatch(payloads)
 }
 
-// SendEvent processes an event payload in the detached subprocess.
+// SendEvents processes one or more event payloads in the detached subprocess.
 // This is called by the hidden __send_analytics command.
-func SendEvent(payloadJSON string) {
-	var payload EventPayload
-	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+//
+// The argv carries either a single event object or an array of them; both
+// shapes are accepted. Leniency matters beyond convenience: the child is
+// re-executed from os.Executable(), so a self-update that replaces the binary
+// between spawn and exec can hand a payload to a build other than the one that
+// wrote it.
+func SendEvents(payloadJSON string) {
+	payloads := decodeEventPayloads(payloadJSON)
+	if len(payloads) == 0 {
 		return
 	}
 
@@ -273,29 +340,47 @@ func SendEvent(payloadJSON string) {
 		_ = client.Close()
 	}()
 
-	// Resolve the installed git version best-effort. A missing or failing
-	// git must never block the rest of the telemetry — the property is simply
-	// omitted when it can't be determined.
-	if v := gitVersion(context.Background()); v != "" {
-		if payload.Properties == nil {
-			payload.Properties = map[string]any{}
+	// Resolve the installed git version best-effort, once for the whole batch.
+	// A missing or failing git must never block the rest of the telemetry — the
+	// property is simply omitted when it can't be determined.
+	gitVer := gitVersion(context.Background())
+
+	for _, payload := range payloads {
+		props := posthog.NewProperties()
+		for k, v := range payload.Properties {
+			props.Set(k, v)
 		}
-		payload.Properties["git_version"] = v
-	}
+		if gitVer != "" {
+			props.Set("git_version", gitVer)
+		}
 
-	// Build properties
-	props := posthog.NewProperties()
-	for k, v := range payload.Properties {
-		props.Set(k, v)
+		//nolint:errcheck // Best effort telemetry - don't block on result
+		_ = client.Enqueue(posthog.Capture{
+			DistinctId: payload.DistinctID,
+			Event:      payload.Event,
+			Properties: props,
+			Timestamp:  payload.Timestamp,
+		})
 	}
+}
 
-	//nolint:errcheck // Best effort telemetry - don't block on result
-	_ = client.Enqueue(posthog.Capture{
-		DistinctId: payload.DistinctID,
-		Event:      payload.Event,
-		Properties: props,
-		Timestamp:  payload.Timestamp,
-	})
+// decodeEventPayloads parses the argv payload as either an array of events or a
+// single event. Malformed input yields no payloads: telemetry is best-effort and
+// the detached child has nowhere to report a parse failure.
+func decodeEventPayloads(payloadJSON string) []EventPayload {
+	trimmed := strings.TrimSpace(payloadJSON)
+	if strings.HasPrefix(trimmed, "[") {
+		var batch []EventPayload
+		if err := json.Unmarshal([]byte(trimmed), &batch); err != nil {
+			return nil
+		}
+		return batch
+	}
+	var single EventPayload
+	if err := json.Unmarshal([]byte(trimmed), &single); err != nil {
+		return nil
+	}
+	return []EventPayload{single}
 }
 
 // gitVersion returns the installed git version (e.g. "2.43.0"), best-effort.

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -165,6 +165,74 @@ func TrackPluginDetached(pluginName string, isEntireEnabled bool, version string
 	}
 }
 
+// SkillInvocation is the content-free view of one recorded skill event: which
+// skill fired, on which agent, and how it was detected. Deliberately no prompt
+// text, arguments, or transcript content — mirroring BuildPluginEventPayload's
+// name-only rule.
+type SkillInvocation struct {
+	// Skill is the invoked skill's name (e.g. "search").
+	Skill string
+	// Agent is the agent that surfaced the signal (e.g. "claude-code").
+	Agent string
+	// Signal is the detection signal (e.g. "prompt_slash_command",
+	// "skill_tool_use").
+	Signal string
+	// EventType is the skill event type ("prompt_invocation" or
+	// "tool_invocation").
+	EventType string
+}
+
+// BuildSkillEventPayload constructs the telemetry payload for one skill
+// invocation. Exported for testing. Returns nil if the payload cannot be built.
+func BuildSkillEventPayload(inv SkillInvocation, isEntireEnabled bool, version string) *EventPayload {
+	if inv.Skill == "" {
+		return nil
+	}
+
+	machineID, err := machineid.ProtectedID("entire-cli")
+	if err != nil {
+		return nil
+	}
+
+	properties := map[string]any{
+		"skill":           inv.Skill,
+		"agent":           inv.Agent,
+		"signal":          inv.Signal,
+		"event_type":      inv.EventType,
+		"isEntireEnabled": isEntireEnabled,
+		"cli_version":     version,
+		"os":              runtime.GOOS,
+		"arch":            runtime.GOARCH,
+	}
+
+	return &EventPayload{
+		Event:      "cli_skill_invoked",
+		DistinctID: machineID,
+		Properties: properties,
+		Timestamp:  time.Now(),
+	}
+}
+
+// TrackSkillInvocationsDetached records skill invocations surfaced by agent
+// hooks, one event per invocation. Like TrackPluginDetached, it only honors
+// the env opt-out itself — call sites must gate on the user's opt-in telemetry
+// setting.
+func TrackSkillInvocationsDetached(invocations []SkillInvocation, isEntireEnabled bool, version string) {
+	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+		return
+	}
+
+	for _, inv := range invocations {
+		payload := BuildSkillEventPayload(inv, isEntireEnabled, version)
+		if payload == nil {
+			continue
+		}
+		if payloadJSON, err := json.Marshal(payload); err == nil {
+			spawnDetachedAnalytics(string(payloadJSON))
+		}
+	}
+}
+
 // SendEvent processes an event payload in the detached subprocess.
 // This is called by the hidden __send_analytics command.
 func SendEvent(payloadJSON string) {

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -194,9 +194,16 @@ func BuildSkillEventPayload(inv SkillInvocation, isEntireEnabled bool, version s
 		return nil
 	}
 
+	// Match BuildEventPayload's defaulting so the agent property is always a
+	// non-empty, queryable value.
+	agentName := inv.Agent
+	if agentName == "" {
+		agentName = "auto"
+	}
+
 	properties := map[string]any{
 		"skill":           inv.Skill,
-		"agent":           inv.Agent,
+		"agent":           agentName,
 		"signal":          inv.Signal,
 		"event_type":      inv.EventType,
 		"isEntireEnabled": isEntireEnabled,
@@ -213,8 +220,14 @@ func BuildSkillEventPayload(inv SkillInvocation, isEntireEnabled bool, version s
 	}
 }
 
+// maxSkillInvocationsPerTrack caps how many detached senders one call can
+// spawn. Real turns carry at most a few skill events; the cap only guards
+// against a pathological transcript producing a process storm.
+const maxSkillInvocationsPerTrack = 10
+
 // TrackSkillInvocationsDetached records skill invocations surfaced by agent
-// hooks, one event per invocation. Like TrackPluginDetached, it only honors
+// hooks, one event per invocation (capped at maxSkillInvocationsPerTrack per
+// call; excess events are dropped). Like TrackPluginDetached, it only honors
 // the env opt-out itself — call sites must gate on the user's opt-in telemetry
 // setting.
 func TrackSkillInvocationsDetached(invocations []SkillInvocation, isEntireEnabled bool, version string) {
@@ -222,6 +235,9 @@ func TrackSkillInvocationsDetached(invocations []SkillInvocation, isEntireEnable
 		return
 	}
 
+	if len(invocations) > maxSkillInvocationsPerTrack {
+		invocations = invocations[:maxSkillInvocationsPerTrack]
+	}
 	for _, inv := range invocations {
 		payload := BuildSkillEventPayload(inv, isEntireEnabled, version)
 		if payload == nil {

--- a/cmd/entire/cli/telemetry/detached_batch_test.go
+++ b/cmd/entire/cli/telemetry/detached_batch_test.go
@@ -1,0 +1,148 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// captureSends swaps in the spawn seam and returns the payloads each detached
+// send would have carried.
+func captureSends(t *testing.T) *[]string {
+	t.Helper()
+	sends := []string{}
+	prev := spawnAnalyticsHook
+	spawnAnalyticsHook = func(payloadJSON string) { sends = append(sends, payloadJSON) }
+	t.Cleanup(func() { spawnAnalyticsHook = prev })
+	return &sends
+}
+
+func skillInvocations(n int) []SkillInvocation {
+	out := make([]SkillInvocation, 0, n)
+	for range n {
+		out = append(out, SkillInvocation{
+			Skill:     "entire:search",
+			Agent:     "claude-code",
+			Signal:    "skill_tool_use",
+			EventType: "tool_invocation",
+		})
+	}
+	return out
+}
+
+// eventsIn counts the events across every send, asserting each is a JSON array.
+func eventsIn(t *testing.T, sends []string) int {
+	t.Helper()
+	total := 0
+	for _, send := range sends {
+		var batch []EventPayload
+		if err := json.Unmarshal([]byte(send), &batch); err != nil {
+			t.Fatalf("send is not a JSON array of events: %v", err)
+		}
+		total += len(batch)
+	}
+	return total
+}
+
+func TestTrackSkillInvocationsDetached_BatchesIntoOneSend(t *testing.T) {
+	sends := captureSends(t)
+
+	TrackSkillInvocationsDetached(skillInvocations(5), true, "1.2.3")
+
+	if len(*sends) != 1 {
+		t.Fatalf("spawned %d detached sends, want 1", len(*sends))
+	}
+	if got := eventsIn(t, *sends); got != 5 {
+		t.Errorf("sent %d events, want 5", got)
+	}
+}
+
+// The 10-event cap used to truncate here. Since condensation extracts from
+// transcript offset 0, the first condensation of a session drains its whole
+// backlog in one call, and a dropped event is never re-reported — session
+// state has already recorded it.
+func TestTrackSkillInvocationsDetached_DropsNothingAboveTheOldCap(t *testing.T) {
+	sends := captureSends(t)
+
+	const count = 25
+	TrackSkillInvocationsDetached(skillInvocations(count), true, "1.2.3")
+
+	if got := eventsIn(t, *sends); got != count {
+		t.Errorf("sent %d events, want all %d", got, count)
+	}
+}
+
+func TestTrackSkillInvocationsDetached_SplitsOversizedBatchInsteadOfDropping(t *testing.T) {
+	sends := captureSends(t)
+
+	// Enough events that the JSON exceeds one argv budget.
+	const count = 600
+	TrackSkillInvocationsDetached(skillInvocations(count), true, "1.2.3")
+
+	if len(*sends) < 2 {
+		t.Fatalf("expected the batch to split across sends, got %d send(s)", len(*sends))
+	}
+	for i, send := range *sends {
+		if len(send) > maxDetachedPayloadBytes {
+			t.Errorf("send %d is %d bytes, over the %d budget", i, len(send), maxDetachedPayloadBytes)
+		}
+	}
+	if got := eventsIn(t, *sends); got != count {
+		t.Errorf("sent %d events across %d sends, want all %d", got, len(*sends), count)
+	}
+}
+
+func TestTrackSkillInvocationsDetached_EnvOptOutSendsNothing(t *testing.T) {
+	t.Setenv("ENTIRE_TELEMETRY_OPTOUT", "1")
+	sends := captureSends(t)
+
+	TrackSkillInvocationsDetached(skillInvocations(3), true, "1.2.3")
+
+	if len(*sends) != 0 {
+		t.Errorf("spawned %d sends despite the env opt-out, want 0", len(*sends))
+	}
+}
+
+func TestTrackSkillInvocationsDetached_NoInvocationsNoSend(t *testing.T) {
+	sends := captureSends(t)
+
+	TrackSkillInvocationsDetached(nil, true, "1.2.3")
+
+	if len(*sends) != 0 {
+		t.Errorf("spawned %d sends for zero invocations, want 0", len(*sends))
+	}
+}
+
+func TestDecodeEventPayloads(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"array", `[{"event":"a"},{"event":"b"}]`, 2},
+		{"empty array", `[]`, 0},
+		// A self-update can replace the binary between spawn and exec, so the
+		// child must still read a payload written by a single-event build.
+		{"single object", `{"event":"a"}`, 1},
+		{"leading whitespace", "  \n[{\"event\":\"a\"}]", 1},
+		{"malformed", `{"event":`, 0},
+		{"empty", ``, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := len(decodeEventPayloads(tt.input)); got != tt.want {
+				t.Errorf("decodeEventPayloads(%q) returned %d payloads, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSendEventsAcceptsBothShapes(_ *testing.T) {
+	// No network in tests; this only asserts neither shape panics.
+	SendEvents(`[{"event":"a","distinct_id":"x"}]`)
+	SendEvents(`{"event":"a","distinct_id":"x"}`)
+	SendEvents(strings.Repeat("x", 10))
+}

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -150,9 +150,9 @@ func TestBuildEventPayloadAgent(t *testing.T) {
 
 func TestSendEventHandlesInvalidJSON(_ *testing.T) {
 	// Should not panic with invalid JSON
-	SendEvent("invalid json")
-	SendEvent("")
-	SendEvent("{}")
+	SendEvents("invalid json")
+	SendEvents("")
+	SendEvents("{}")
 }
 
 func TestParseGitVersion(t *testing.T) {

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -183,7 +183,7 @@ func TestParseGitVersion(t *testing.T) {
 func TestBuildSkillEventPayload(t *testing.T) {
 	t.Parallel()
 	payload := BuildSkillEventPayload(SkillInvocation{
-		Skill:     "search",
+		Skill:     "entire",
 		Agent:     "claude-code",
 		Signal:    "prompt_slash_command",
 		EventType: "prompt_invocation",
@@ -195,8 +195,8 @@ func TestBuildSkillEventPayload(t *testing.T) {
 	if payload.Event != "cli_skill_invoked" {
 		t.Errorf("Event = %q, want %q", payload.Event, "cli_skill_invoked")
 	}
-	if got := payload.Properties["skill"]; got != "search" {
-		t.Errorf("skill property = %v, want %q", got, "search")
+	if got := payload.Properties["skill"]; got != "entire" {
+		t.Errorf("skill property = %v, want %q", got, "entire")
 	}
 	if got := payload.Properties["agent"]; got != "claude-code" {
 		t.Errorf("agent property = %v, want %q", got, "claude-code")
@@ -226,5 +226,30 @@ func TestBuildSkillEventPayload_EmptySkill(t *testing.T) {
 	t.Parallel()
 	if got := BuildSkillEventPayload(SkillInvocation{Agent: "claude-code"}, true, "1.0.0"); got != nil {
 		t.Errorf("expected nil for empty skill name, got %+v", got)
+	}
+}
+
+func TestBuildSkillEventPayload_UnlistedSkillNameIsNotSent(t *testing.T) {
+	t.Parallel()
+	// Skill names are user-defined tokens: a custom slash command like
+	// /customer-acme-incident-123 can carry sensitive identifiers, so only
+	// allowlisted names pass through verbatim.
+	payload := BuildSkillEventPayload(SkillInvocation{
+		Skill:     "customer-acme-incident-123",
+		Agent:     "claude-code",
+		Signal:    "prompt_slash_command",
+		EventType: "prompt_invocation",
+	}, true, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildSkillEventPayload returned nil")
+		return
+	}
+	if got := payload.Properties["skill"]; got != "custom" {
+		t.Errorf("skill property = %v, want %q", got, "custom")
+	}
+	for _, v := range payload.Properties {
+		if s, ok := v.(string); ok && s == "customer-acme-incident-123" {
+			t.Errorf("raw skill name leaked into payload property %v", v)
+		}
 	}
 }

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -179,3 +179,52 @@ func TestParseGitVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildSkillEventPayload(t *testing.T) {
+	t.Parallel()
+	payload := BuildSkillEventPayload(SkillInvocation{
+		Skill:     "search",
+		Agent:     "claude-code",
+		Signal:    "prompt_slash_command",
+		EventType: "prompt_invocation",
+	}, true, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildSkillEventPayload returned nil")
+		return
+	}
+	if payload.Event != "cli_skill_invoked" {
+		t.Errorf("Event = %q, want %q", payload.Event, "cli_skill_invoked")
+	}
+	if got := payload.Properties["skill"]; got != "search" {
+		t.Errorf("skill property = %v, want %q", got, "search")
+	}
+	if got := payload.Properties["agent"]; got != "claude-code" {
+		t.Errorf("agent property = %v, want %q", got, "claude-code")
+	}
+	if got := payload.Properties["signal"]; got != "prompt_slash_command" {
+		t.Errorf("signal property = %v, want %q", got, "prompt_slash_command")
+	}
+	if got := payload.Properties["event_type"]; got != "prompt_invocation" {
+		t.Errorf("event_type property = %v, want %q", got, "prompt_invocation")
+	}
+	if got := payload.Properties["cli_version"]; got != "1.2.3" {
+		t.Errorf("cli_version property = %v, want %q", got, "1.2.3")
+	}
+	if got := payload.Properties["isEntireEnabled"]; got != true {
+		t.Errorf("isEntireEnabled property = %v, want true", got)
+	}
+	// The payload must stay content-free: skill/plugin names only, never
+	// prompt text, arguments, or flags.
+	for _, forbidden := range []string{"prompt", "args", "flags"} {
+		if _, ok := payload.Properties[forbidden]; ok {
+			t.Errorf("skill payload must not include %q", forbidden)
+		}
+	}
+}
+
+func TestBuildSkillEventPayload_EmptySkill(t *testing.T) {
+	t.Parallel()
+	if got := BuildSkillEventPayload(SkillInvocation{Agent: "claude-code"}, true, "1.0.0"); got != nil {
+		t.Errorf("expected nil for empty skill name, got %+v", got)
+	}
+}

--- a/cmd/entire/cli/telemetry/skill_official.go
+++ b/cmd/entire/cli/telemetry/skill_official.go
@@ -1,0 +1,30 @@
+package telemetry
+
+// Skill telemetry is recorded verbatim only for skill names listed here.
+// Skill names are arbitrary user tokens — a custom slash command or
+// third-party skill name can carry sensitive identifiers (project, vendor,
+// customer), exactly like third-party plugin names (see the cli package's
+// IsOfficialPlugin). Unlike plugins, the event itself is still worth counting
+// — the metric this feeds compares skill adoption volume against agent-help —
+// so unknown names are reported under the fixed "custom" category instead of
+// being dropped. Match is case-sensitive and exact.
+//
+//nolint:gochecknoglobals // package-level allowlist, mirroring officialPlugins.
+var officialSkillNames = map[string]struct{}{
+	// Entire-shipped skills. The agent-help skill is scaffolded as "entire"
+	// across claude/codex/gemini (see agentHelpSkillTemplate).
+	"entire": {},
+}
+
+// customSkillCategory is the fixed value reported in place of any skill name
+// not on the allowlist.
+const customSkillCategory = "custom"
+
+// skillNameForTelemetry maps a raw skill name to the value safe to send:
+// allowlisted names pass through, everything else collapses to "custom".
+func skillNameForTelemetry(name string) string {
+	if _, ok := officialSkillNames[name]; ok {
+		return name
+	}
+	return customSkillCategory
+}

--- a/cmd/entire/cli/telemetry/skill_official.go
+++ b/cmd/entire/cli/telemetry/skill_official.go
@@ -1,30 +1,90 @@
 package telemetry
 
-// Skill telemetry is recorded verbatim only for skill names listed here.
-// Skill names are arbitrary user tokens — a custom slash command or
-// third-party skill name can carry sensitive identifiers (project, vendor,
-// customer), exactly like third-party plugin names (see the cli package's
-// IsOfficialPlugin). Unlike plugins, the event itself is still worth counting
-// — the metric this feeds compares skill adoption volume against agent-help —
-// so unknown names are reported under the fixed "custom" category instead of
-// being dropped. Match is case-sensitive and exact.
+import "strings"
+
+// Skill telemetry never sends a raw skill name unless it is recognized as one
+// of Entire's own. Skill names are arbitrary user tokens — a custom slash
+// command or third-party skill name can carry sensitive identifiers (project,
+// vendor, customer), exactly like third-party plugin names (see the cli
+// package's IsOfficialPlugin). Unlike plugins, the event itself is still worth
+// counting — the metric this feeds compares skill adoption against agent-help —
+// so unrecognized names are reported under a fixed category instead of being
+// dropped.
+//
+// The emitted vocabulary is therefore closed: an allowlisted name, one of the
+// two fixed categories below, and nothing else.
+
+// entireSkillNamespace is the plugin name Entire publishes its skills under
+// (entireio/skills and entireio/claude-plugins both ship a plugin named
+// "entire"). Claude Code invokes a plugin skill as "<plugin>:<skill>", so its
+// skills arrive namespaced: "entire:search".
+//
+// The namespace alone is NOT proof of provenance — it comes from whatever
+// plugin the user installed or authored locally — so the leaf name is still
+// matched against entireSkillNames before being sent. Everything after the
+// colon is otherwise arbitrary user text.
+const entireSkillNamespace = "entire:"
+
+// scaffoldedAgentHelpSkill is the skill `entire enable --agent-help-skill`
+// writes (.claude/skills/entire/SKILL.md and the codex/gemini equivalents).
+// It is installed unnamespaced, under Entire's own name.
+const scaffoldedAgentHelpSkill = "entire"
+
+// entireSkillNames are the leaf names shipped by the "entire" plugin.
+//
+// Upstream is entireio/skills (marketplace plugin "entire"); entireio/
+// claude-plugins ships an "explain" command under the same namespace. This
+// list is hand-maintained across repositories, so a skill released upstream
+// before this list is updated reports as unlistedEntireSkill rather than
+// vanishing into customSkillCategory — see skillNameForTelemetry.
 //
 //nolint:gochecknoglobals // package-level allowlist, mirroring officialPlugins.
-var officialSkillNames = map[string]struct{}{
-	// Entire-shipped skills. The agent-help skill is scaffolded as "entire"
-	// across claude/codex/gemini (see agentHelpSkillTemplate).
-	"entire": {},
+var entireSkillNames = map[string]struct{}{
+	"address-findings":  {},
+	"explain":           {},
+	"recall":            {},
+	"replay":            {},
+	"review":            {},
+	"search":            {},
+	"session-crosslink": {},
+	"session-handoff":   {},
+	"session-to-skill":  {},
+	"teach":             {},
+	"using-entire":      {},
+	"what-happened":     {},
 }
 
-// customSkillCategory is the fixed value reported in place of any skill name
-// not on the allowlist.
-const customSkillCategory = "custom"
+const (
+	// customSkillCategory is reported for any name not recognized as Entire's.
+	customSkillCategory = "custom"
+	// unlistedEntireSkill is reported for a skill invoked under Entire's
+	// namespace whose leaf name this build does not know. It keeps adoption
+	// volume correct across releases without sending the unrecognized name.
+	unlistedEntireSkill = "entire:unlisted"
+)
 
-// skillNameForTelemetry maps a raw skill name to the value safe to send:
-// allowlisted names pass through, everything else collapses to "custom".
+// skillNameForTelemetry maps a raw skill name to the value safe to send.
+//
+// Only the namespaced form is matched. Entire's skills are advertised as
+// cross-agent and can be installed unnamespaced (Pi normalizes
+// "/skill:<name>" to a bare name, and a hand-copied SKILL.md has no
+// namespace), so those invocations report as custom. Matching bare leaf names
+// would fold Claude Code's built-in /review and any user's local /search into
+// Entire's numbers — an overcount that is invisible in the data, where this
+// undercount at least has a known cause.
 func skillNameForTelemetry(name string) string {
-	if _, ok := officialSkillNames[name]; ok {
+	if name == scaffoldedAgentHelpSkill {
 		return name
 	}
-	return customSkillCategory
+	leaf, namespaced := strings.CutPrefix(name, entireSkillNamespace)
+	if !namespaced || leaf == "" {
+		return customSkillCategory
+	}
+	if _, ok := entireSkillNames[leaf]; ok {
+		// Sent verbatim (e.g. "entire:search") so the namespace is preserved
+		// and a plugin invocation stays distinguishable from the scaffolded
+		// skill above.
+		return name
+	}
+	return unlistedEntireSkill
 }

--- a/cmd/entire/cli/telemetry/skill_official_test.go
+++ b/cmd/entire/cli/telemetry/skill_official_test.go
@@ -1,0 +1,71 @@
+package telemetry
+
+import "testing"
+
+func TestSkillNameForTelemetry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		skill string
+		want  string
+	}{
+		{"scaffolded agent-help skill", "entire", "entire"},
+		{"entire plugin skill", "entire:search", "entire:search"},
+		{"entire plugin command", "entire:explain", "entire:explain"},
+		{"hyphenated entire plugin skill", "entire:what-happened", "entire:what-happened"},
+		// A skill released upstream before this build's list was updated: the
+		// invocation still counts as Entire adoption, without sending a name
+		// the namespace does not vouch for.
+		{"unknown skill under entire namespace", "entire:brand-new-skill", "entire:unlisted"},
+		// The namespace comes from whatever plugin the user installed or
+		// authored, so the leaf is arbitrary user text.
+		{"customer identifier under entire namespace", "entire:customer-acme-incident-123", "entire:unlisted"},
+		{"degenerate empty leaf", "entire:", "custom"},
+		// Bare leaf names are deliberately NOT matched: /review is also a
+		// Claude Code built-in and /search could be any local skill, so
+		// matching them would overcount Entire adoption.
+		{"bare name colliding with a built-in", "review", "custom"},
+		{"bare name colliding with a local skill", "search", "custom"},
+		{"third-party namespaced skill", "pr-review-toolkit:review-pr", "custom"},
+		{"custom slash command", "customer-acme-incident-123", "custom"},
+		{"lookalike prefix is not the namespace", "entire-internal:search", "custom"},
+		{"case-sensitive namespace", "Entire:search", "custom"},
+		{"empty", "", "custom"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := skillNameForTelemetry(tt.skill); got != tt.want {
+				t.Errorf("skillNameForTelemetry(%q) = %q, want %q", tt.skill, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSkillNameForTelemetry_NeverEmitsAnUnrecognizedName(t *testing.T) {
+	t.Parallel()
+
+	// Whatever the input, the emitted value comes from a closed vocabulary:
+	// an allowlisted Entire skill name or one of the two fixed categories.
+	allowed := map[string]struct{}{
+		scaffoldedAgentHelpSkill: {},
+		customSkillCategory:      {},
+		unlistedEntireSkill:      {},
+	}
+	for leaf := range entireSkillNames {
+		allowed[entireSkillNamespace+leaf] = struct{}{}
+	}
+
+	inputs := []string{
+		"", "entire", "entire:", "entire:search", "entire:secret-client-name",
+		"secret-client-name", "review", "Entire:search", "entire:entire:search",
+		"../../etc/passwd", "entire:../../etc/passwd", "skill:entire:search",
+	}
+	for _, in := range inputs {
+		got := skillNameForTelemetry(in)
+		if _, ok := allowed[got]; !ok {
+			t.Errorf("skillNameForTelemetry(%q) = %q, which is outside the closed vocabulary", in, got)
+		}
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1070
<!-- entire-trail-link-end -->

Skill events are already extracted per agent and recorded in session state (`SkillEventExtractor`, `appendEventSkillEventsToState`), so internal skill usage is measurable from checkpoint refs — but nothing reached PostHog, leaving external skill adoption invisible while agent-help usage is tracked. That asymmetry biases any skills-vs-agent-help comparison toward the instrumented side.

This PR forwards exactly the newly-appended (deduped) skill events to a detached `cli_skill_invoked` event: skill name, agent, detection signal, event type.

- **Content-free by construction** — no prompt text, arguments, or transcript content, mirroring the plugin-name-only rule in `BuildPluginEventPayload`.
- **Gated** on the same opt-in telemetry setting as command tracking, plus the `ENTIRE_TELEMETRY_OPTOUT` env opt-out.
- Hook lifecycle paths never produce `cli_command_executed` (the hooks tree is hidden), so this is the only telemetry signal that a skill fired.

`appendEventSkillEventsToState` now returns the appended events instead of a bool so both call sites (TurnStart slash-command path and `persistEventMetadataToState`) forward exactly what was new.

Tests: payload shape + content-free assertions in `telemetry`, append/dedup semantics in `lifecycle_test`. Full suite: 9,170 unit / 492 integration / canary green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Which skill names are sent

Skill names are arbitrary user tokens, so the emitted `skill` property comes
from a closed vocabulary: a recognized Entire skill name, or one of two fixed
categories (`custom`, `entire:unlisted`). Recognition matches the leaf name
after stripping Entire's plugin namespace — not the `entire:` prefix itself,
which comes from whatever plugin the user installed or authored and so vouches
for nothing.

Two scoping choices, both taking the direction whose error is visible:

- **Unlisted Entire skills still count.** The leaf list lives in this repo
  while the skills ship from `entireio/skills`, so a skill released upstream
  before the list is updated reports as `entire:unlisted` — a lagging list
  undercounts the per-skill breakdown but never adoption volume.
- **Unnamespaced installs are not matched.** Entire's skills are advertised as
  cross-agent and can arrive without a namespace (Pi normalizes
  `/skill:<name>` to a bare name; a hand-copied `SKILL.md` has none), and
  those report as `custom`. Matching bare leaves would fold Claude Code's
  built-in `/review` and any local `/search` into Entire's numbers — an
  overcount invisible in the data, where this undercount has a known cause.
  Worth revisiting if cross-agent installs become a meaningful share.

`entireio/pr-review-toolkit` skills are deliberately out of scope: the CLI's
install hints for it are still placeholders (`skilldiscovery/registry.go`), so
nothing ships under that namespace yet.


## Counting caveats

**Which paths actually emit.** The condense path (commit and session-end) is
where transcript-extracted events reach telemetry in practice. The turn-end
snapshot around `HandleTurnEnd` only yields events when the turn had mid-turn
commits — `finalizeAllTurnCheckpoints` early-returns on an empty
`TurnCheckpointIDs` — so in an ordinary turn it is a no-op and the condense
path provides the coverage. Two gaps stay open by design: sessions the
exited-owner sweep marks ENDED without condensing (when `sweepCondenseBudget`
is exhausted) never emit their tool-based events, and `claudeSkillEventID`
falls back to a transcript-relative id when `tool_use_id` is absent, which
shadow-vs-live extraction could double-count — pre-existing, and now costing a
telemetry event rather than a duplicate metadata row.

**One action could emit twice.** A typed `/entire:review` can produce a
`prompt_slash_command` event from the hook path and a `skill_tool_use` event
from the transcript extractor; the ids differ, so both are legitimately new and
both emit. `event_type` disambiguates, so **count by `event_type`, or count
distinct actions rather than raw `cli_skill_invoked` volume** — a raw count
would inflate. Deliberately not deduped across signals: the two events are
distinct records the session UI relies on for its collapse behavior, so
collapsing them in telemetry would mean either dropping a recorded event or
adding a correlation identifier to the payload.

Measured rather than assumed: across 72 real Claude Code transcripts on this
machine, 8 contain `Skill` tool invocations and none pairs one with a literal
`/<name>` user message, so in practice the tool signal is what appears. The
inflation is a real possibility to guard the insight against, not something
observed.
