### PR TITLE
feat(telemetry): missed-opportunity signal at checkpoint condensation

### DIFF
--- a/cmd/entire/cli/agent/capabilities.go
+++ b/cmd/entire/cli/agent/capabilities.go
@@ -222,6 +222,14 @@ func AsSkillEventExtractor(ag Agent) (SkillEventExtractor, bool) {
 	return builtinCapability[SkillEventExtractor](ag)
 }
 
+// AsToolInvocationScanner returns the agent as ToolInvocationScanner if it
+// implements the interface. Built-in only: reading tool calls out of a
+// transcript needs knowledge of that transcript's shape, which an external
+// agent's parse-hook does not convey.
+func AsToolInvocationScanner(ag Agent) (ToolInvocationScanner, bool) {
+	return builtinCapability[ToolInvocationScanner](ag)
+}
+
 // AsSessionEndBudgeter returns the agent as SessionEndBudgeter if it implements
 // the interface. Built-in only because no external agent needs it yet — not
 // because external agents could enforce a budget themselves: a plugin supplies

--- a/cmd/entire/cli/agent/claudecode/lifecycle.go
+++ b/cmd/entire/cli/agent/claudecode/lifecycle.go
@@ -24,6 +24,7 @@ var (
 	_ agent.ModelExtractor         = (*ClaudeCodeAgent)(nil)
 	_ agent.SkillEventExtractor    = (*ClaudeCodeAgent)(nil)
 	_ agent.SubagentAwareExtractor = (*ClaudeCodeAgent)(nil)
+	_ agent.ToolInvocationScanner  = (*ClaudeCodeAgent)(nil)
 	_ agent.HookResponseWriter     = (*ClaudeCodeAgent)(nil)
 	_ agent.ContextInjector        = (*ClaudeCodeAgent)(nil)
 )

--- a/cmd/entire/cli/agent/claudecode/tool_invocations.go
+++ b/cmd/entire/cli/agent/claudecode/tool_invocations.go
@@ -73,6 +73,14 @@ func scanLineInvocations(line []byte, visit func(agent.ToolInvocation) bool) boo
 	if err := json.Unmarshal(line, &parsed); err != nil || len(parsed.Message) == 0 {
 		return false
 	}
+	// Only assistant envelopes carry live tool calls — the same gate every
+	// other tool_use consumer in this package applies (ExtractModifiedFiles,
+	// ExtractSkillEvents, ExtractAllModifiedFiles). Without it, a non-assistant
+	// envelope whose message happens to decode into tool_use-shaped content
+	// (replayed/sidechain or summary lines) would count as a real invocation.
+	if parsed.Type != envelopeTypeAssistant {
+		return false
+	}
 	var msg assistantMessage
 	if err := json.Unmarshal(parsed.Message, &msg); err != nil {
 		return false

--- a/cmd/entire/cli/agent/claudecode/tool_invocations.go
+++ b/cmd/entire/cli/agent/claudecode/tool_invocations.go
@@ -1,0 +1,97 @@
+package claudecode
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/transcript"
+)
+
+// toolUseToken is the literal that must appear in a raw transcript line for it
+// to carry a tool_use content block. Both quotes are part of the token on
+// purpose: it makes the check exact without whitespace normalization, and it is
+// what keeps `"tool_use_id"` — which appears on every tool_result line, the
+// single largest false-positive class for any substring probe — from matching.
+var toolUseToken = []byte(`"tool_use"`)
+
+// ScanToolInvocations walks the Bash/Task-style tool calls recorded in a Claude
+// Code JSONL transcript. See agent.ToolInvocationScanner for the contract,
+// including that hints is a performance filter and not a semantic one.
+//
+// Lines are split by hand with bytes.IndexByte rather than with bufio.Scanner:
+// a single Claude Code transcript line routinely carries a multi-megabyte tool
+// result, so Scanner's 64KiB default token limit would silently truncate the
+// walk. Two byte-level prefilters run before any JSON work, so a transcript
+// with no candidate line costs one pass and zero allocations — the same order
+// as the substring probe this replaces, on the miss path that dominates.
+func (c *ClaudeCodeAgent) ScanToolInvocations(transcriptData []byte, hints [][]byte, visit func(agent.ToolInvocation) bool) bool {
+	for rest := transcriptData; len(rest) > 0; {
+		line := rest
+		if idx := bytes.IndexByte(rest, '\n'); idx >= 0 {
+			line, rest = rest[:idx], rest[idx+1:]
+		} else {
+			rest = nil
+		}
+		if !lineMayCarryInvocation(line, hints) {
+			continue
+		}
+		if scanLineInvocations(line, visit) {
+			return true
+		}
+	}
+	return false
+}
+
+// lineMayCarryInvocation applies the two prefilters: the caller's hints (nil
+// means visit every line) and the tool_use token. Hints are checked first
+// because they are the selective half — a transcript typically has thousands of
+// tool_use lines and a handful mentioning whatever the caller is looking for.
+func lineMayCarryInvocation(line []byte, hints [][]byte) bool {
+	if hints != nil && !containsAny(line, hints) {
+		return false
+	}
+	return bytes.Contains(line, toolUseToken)
+}
+
+// containsAny reports whether line contains at least one of needles.
+func containsAny(line []byte, needles [][]byte) bool {
+	for _, needle := range needles {
+		if bytes.Contains(line, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// scanLineInvocations decodes one candidate line and offers each of its
+// tool_use blocks to visit. Malformed lines are skipped rather than reported:
+// the transcript is written by another process and may be mid-write, and this
+// is a telemetry read, never a correctness one.
+func scanLineInvocations(line []byte, visit func(agent.ToolInvocation) bool) bool {
+	var parsed transcript.Line
+	if err := json.Unmarshal(line, &parsed); err != nil || len(parsed.Message) == 0 {
+		return false
+	}
+	var msg assistantMessage
+	if err := json.Unmarshal(parsed.Message, &msg); err != nil {
+		return false
+	}
+	for _, block := range msg.Content {
+		if block.Type != transcript.ContentTypeToolUse || len(block.Input) == 0 {
+			continue
+		}
+		var input toolInput
+		if err := json.Unmarshal(block.Input, &input); err != nil {
+			continue
+		}
+		if visit(agent.ToolInvocation{
+			Tool:         block.Name,
+			Command:      input.Command,
+			SubagentType: input.SubagentType,
+		}) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/agent/claudecode/tool_invocations_test.go
+++ b/cmd/entire/cli/agent/claudecode/tool_invocations_test.go
@@ -127,3 +127,17 @@ func TestScanToolInvocations_EmptyTranscript(t *testing.T) {
 		t.Errorf("got %d invocations from an empty transcript, want 0", len(got))
 	}
 }
+
+// TestScanToolInvocations_SkipsNonAssistantEnvelopes pins the envelope gate:
+// only assistant envelopes carry live tool calls, matching every other
+// tool_use consumer in this package. A non-assistant envelope whose message
+// decodes into tool_use-shaped content must not be visited.
+func TestScanToolInvocations_SkipsNonAssistantEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	data := `{"type":"summary","uuid":"s1","message":{"content":[{"type":"tool_use","id":"tx","name":"Bash","input":{"command":"entire search foo"}}]}}
+`
+	if got := collectInvocations(t, data, nil); len(got) != 0 {
+		t.Errorf("got %d invocations from a non-assistant envelope, want 0: %+v", len(got), got)
+	}
+}

--- a/cmd/entire/cli/agent/claudecode/tool_invocations_test.go
+++ b/cmd/entire/cli/agent/claudecode/tool_invocations_test.go
@@ -1,0 +1,129 @@
+package claudecode
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// collectInvocations walks every invocation, so it also asserts the scanner
+// keeps going when visit declines.
+func collectInvocations(t *testing.T, data string, hints [][]byte) []agent.ToolInvocation {
+	t.Helper()
+	var got []agent.ToolInvocation
+	if found := (&ClaudeCodeAgent{}).ScanToolInvocations([]byte(data), hints, func(inv agent.ToolInvocation) bool {
+		got = append(got, inv)
+		return false
+	}); found {
+		t.Fatalf("ScanToolInvocations returned true although visit never accepted")
+	}
+	return got
+}
+
+func TestScanToolInvocations_BashAndSubagent(t *testing.T) {
+	t.Parallel()
+
+	data := `{"type":"assistant","uuid":"a1","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"entire search foo --json"}}]}}
+{"type":"assistant","uuid":"a2","message":{"content":[{"type":"tool_use","id":"t2","name":"Agent","input":{"subagent_type":"entire-search","prompt":"look"}}]}}
+`
+	got := collectInvocations(t, data, nil)
+	if len(got) != 2 {
+		t.Fatalf("got %d invocations, want 2: %+v", len(got), got)
+	}
+	if got[0].Tool != "Bash" || got[0].Command != "entire search foo --json" {
+		t.Errorf("first invocation = %+v", got[0])
+	}
+	if got[1].Tool != "Agent" || got[1].SubagentType != "entire-search" {
+		t.Errorf("second invocation = %+v", got[1])
+	}
+}
+
+// TestScanToolInvocations_SkipsToolResultLines pins the prefilter detail that
+// removes the largest false-positive class: a tool_result line carries
+// "tool_use_id", which must not read as a tool_use block.
+func TestScanToolInvocations_SkipsToolResultLines(t *testing.T) {
+	t.Parallel()
+
+	data := `{"type":"user","uuid":"u1","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"entire search foo"}]}}
+`
+	if got := collectInvocations(t, data, nil); len(got) != 0 {
+		t.Errorf("got %d invocations from a tool_result line, want 0: %+v", len(got), got)
+	}
+}
+
+// TestScanToolInvocations_HonorsHints pins the documented contract that hints
+// are a performance filter: a line the caller's hints exclude is never parsed,
+// which is exactly why a caller must pass hints its own matcher implies.
+func TestScanToolInvocations_HonorsHints(t *testing.T) {
+	t.Parallel()
+
+	data := `{"type":"assistant","uuid":"a1","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"entire search foo"}}]}}
+`
+	if got := collectInvocations(t, data, [][]byte{[]byte("entire search")}); len(got) != 1 {
+		t.Errorf("matching hint: got %d invocations, want 1", len(got))
+	}
+	if got := collectInvocations(t, data, [][]byte{[]byte("nonexistent-hint")}); len(got) != 0 {
+		t.Errorf("non-matching hint: got %d invocations, want 0 (line must not be parsed)", len(got))
+	}
+}
+
+func TestScanToolInvocations_StopsOnFirstAccept(t *testing.T) {
+	t.Parallel()
+
+	data := `{"type":"assistant","uuid":"a1","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"first"}}]}}
+{"type":"assistant","uuid":"a2","message":{"content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"second"}}]}}
+`
+	seen := 0
+	found := (&ClaudeCodeAgent{}).ScanToolInvocations([]byte(data), nil, func(agent.ToolInvocation) bool {
+		seen++
+		return true
+	})
+	if !found {
+		t.Error("ScanToolInvocations returned false although visit accepted")
+	}
+	if seen != 1 {
+		t.Errorf("visit called %d times, want 1 (walk must stop on first accept)", seen)
+	}
+}
+
+// TestScanToolInvocations_MalformedLinesAreSkipped covers a transcript read
+// mid-write, which is a normal condition rather than an error: the agent owns
+// the file and this is a telemetry read.
+func TestScanToolInvocations_MalformedLinesAreSkipped(t *testing.T) {
+	t.Parallel()
+
+	data := `not json at all
+{"type":"assistant","uuid":"a1","message":{"content":[{"type":"tool_use"
+{"type":"assistant"}
+
+{"type":"assistant","uuid":"a2","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"entire search ok"}}]}}
+`
+	got := collectInvocations(t, data, nil)
+	if len(got) != 1 {
+		t.Fatalf("got %d invocations, want 1: %+v", len(got), got)
+	}
+	if got[0].Command != "entire search ok" {
+		t.Errorf("Command = %q", got[0].Command)
+	}
+}
+
+// TestScanToolInvocations_FinalLineWithoutNewline covers the hand-rolled line
+// split: a transcript whose last line has no trailing newline must still be
+// visited.
+func TestScanToolInvocations_FinalLineWithoutNewline(t *testing.T) {
+	t.Parallel()
+
+	data := `{"type":"assistant","uuid":"a1","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"entire search tail"}}]}}`
+	got := collectInvocations(t, data, nil)
+	if len(got) != 1 {
+		t.Fatalf("got %d invocations, want 1: %+v", len(got), got)
+	}
+}
+
+func TestScanToolInvocations_EmptyTranscript(t *testing.T) {
+	t.Parallel()
+
+	if got := collectInvocations(t, "", nil); len(got) != 0 {
+		t.Errorf("got %d invocations from an empty transcript, want 0", len(got))
+	}
+}

--- a/cmd/entire/cli/agent/cursor/transcript_test.go
+++ b/cmd/entire/cli/agent/cursor/transcript_test.go
@@ -211,16 +211,22 @@ func TestCursorAgent_ExtractModifiedFilesFromOffset_EmptyPath(t *testing.T) {
 	}
 }
 
-// TestCursorAgent_MustNotImplementToolInvocationScanner pins the reason Cursor
-// is permanently outside the tool-invocation probe rather than merely
-// unimplemented: its transcripts contain no tool_use blocks at all (see
-// ExtractModifiedFilesFromOffset), so a walker cannot be written. Implementing
-// the interface would report "did not run" for every Cursor session, which is
-// indistinguishable in aggregate from a real negative.
+// TestCursorAgent_MustNotImplementToolInvocationScanner pins that Cursor stays
+// out of the tool-invocation probe until its shell-command input key is
+// confirmed.
+//
+// Not because Cursor is unprobeable. It shares this JSONL shape and does record
+// tool_use blocks; the "contains no tool_use blocks" claims elsewhere in this
+// package date to 2026-03, are pinned by no test, and are stale — they also
+// make ExtractModifiedFilesFromOffset give up entirely, which deserves its own
+// look. The narrow blocker is that ToolInvocation.Command assumes Claude's
+// `command` input key; guessing it for Cursor would produce the silent false
+// negative the interface exists to prevent. Confirm the mapping, implement the
+// scanner, and delete this test.
 func TestCursorAgent_MustNotImplementToolInvocationScanner(t *testing.T) {
 	t.Parallel()
 	if _, ok := agent.AsToolInvocationScanner(&CursorAgent{}); ok {
-		t.Fatal("CursorAgent must not implement ToolInvocationScanner: Cursor transcripts contain " +
-			"no tool_use blocks, so every answer would be a fabricated negative")
+		t.Fatal("CursorAgent must not implement ToolInvocationScanner until its shell-command " +
+			"input key is confirmed: reusing Claude's `command` key would fabricate negatives")
 	}
 }

--- a/cmd/entire/cli/agent/cursor/transcript_test.go
+++ b/cmd/entire/cli/agent/cursor/transcript_test.go
@@ -210,3 +210,17 @@ func TestCursorAgent_ExtractModifiedFilesFromOffset_EmptyPath(t *testing.T) {
 		t.Errorf("ExtractModifiedFilesFromOffset() pos = %d, want 0", pos)
 	}
 }
+
+// TestCursorAgent_MustNotImplementToolInvocationScanner pins the reason Cursor
+// is permanently outside the tool-invocation probe rather than merely
+// unimplemented: its transcripts contain no tool_use blocks at all (see
+// ExtractModifiedFilesFromOffset), so a walker cannot be written. Implementing
+// the interface would report "did not run" for every Cursor session, which is
+// indistinguishable in aggregate from a real negative.
+func TestCursorAgent_MustNotImplementToolInvocationScanner(t *testing.T) {
+	t.Parallel()
+	if _, ok := agent.AsToolInvocationScanner(&CursorAgent{}); ok {
+		t.Fatal("CursorAgent must not implement ToolInvocationScanner: Cursor transcripts contain " +
+			"no tool_use blocks, so every answer would be a fabricated negative")
+	}
+}

--- a/cmd/entire/cli/agent/pi/lifecycle_test.go
+++ b/cmd/entire/cli/agent/pi/lifecycle_test.go
@@ -106,6 +106,19 @@ func TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction(t *testing.T) {
 	}
 }
 
+// TestPiAgent_MustNotImplementToolInvocationScanner keeps Pi out of the
+// tool-invocation probe. Pi's transcript has no walker here, so implementing
+// the interface would turn "cannot tell" into a fabricated "did not run" —
+// indistinguishable in aggregate from a real one (see
+// agent.ToolInvocationScanner).
+func TestPiAgent_MustNotImplementToolInvocationScanner(t *testing.T) {
+	t.Parallel()
+	if _, ok := agent.AsToolInvocationScanner(NewPiAgent()); ok {
+		t.Fatal("PiAgent must not implement ToolInvocationScanner: no walker exists for Pi's " +
+			"transcript, and reporting a fabricated negative is worse than reporting unsupported")
+	}
+}
+
 func TestParseHookEvent_SessionShutdown_NoLifecycleEvent(t *testing.T) {
 	t.Parallel()
 	a := &PiAgent{}

--- a/cmd/entire/cli/agent/tool_invocations.go
+++ b/cmd/entire/cli/agent/tool_invocations.go
@@ -19,13 +19,20 @@ type ToolInvocation struct {
 // calls structurally, so a caller can ask "did this session invoke X" instead
 // of substring-probing the transcript and matching every mention of X.
 //
-// Agents whose transcripts carry no tool-call view MUST NOT implement this.
-// That includes Cursor, whose transcripts contain no tool_use blocks at all
-// (see cursor.CursorAgent.ExtractModifiedFilesFromOffset), and every format
-// that simply has no walker yet. Not implementing it is the honest answer, and
-// the dispatcher below turns it into a reportable "cannot tell": callers are
-// required to distinguish that from "did not run", because a fabricated "did
-// not run" is indistinguishable from a real one in aggregate.
+// An agent with no walker here MUST NOT implement this. Not implementing it is
+// the honest answer, and the dispatcher below turns it into a reportable
+// "cannot tell": callers are required to distinguish that from "did not run",
+// because a fabricated "did not run" is indistinguishable from a real one in
+// aggregate.
+//
+// "No walker yet" is the only reason any agent is absent — do not read it as
+// "impossible". Cursor in particular shares this JSONL shape (see the
+// transcript package doc) and does record tool_use blocks; the "contains no
+// tool_use blocks" comments in cmd/entire/cli/agent/cursor date to 2026-03,
+// are pinned by no test, and are stale. What blocks a Cursor implementation is
+// narrower: its input key for a shell command is unconfirmed, so reusing
+// ToolInvocation.Command would risk the very false negative this interface
+// exists to prevent. A name-based matcher (subagent dispatch) would work today.
 type ToolInvocationScanner interface {
 	// ScanToolInvocations calls visit for each recorded tool invocation and
 	// returns true as soon as visit does, stopping the walk.

--- a/cmd/entire/cli/agent/tool_invocations.go
+++ b/cmd/entire/cli/agent/tool_invocations.go
@@ -1,0 +1,61 @@
+package agent
+
+// ToolInvocation is one tool call recorded in a transcript, reduced to the
+// fields callers ask operational questions about ("did this session run X?").
+// Content-free by construction: no prompts, no file contents, no tool output.
+// Command is the raw shell command, which is user content — callers must treat
+// it as something to match against, never as something to store or transmit.
+type ToolInvocation struct {
+	// Tool is the agent-native tool name, e.g. "Bash", "Agent", "Task".
+	Tool string
+	// Command is the shell command for shell tools, empty otherwise.
+	Command string
+	// SubagentType is the dispatched subagent's name for subagent-spawning
+	// tools, empty otherwise.
+	SubagentType string
+}
+
+// ToolInvocationScanner is implemented by agents whose transcript records tool
+// calls structurally, so a caller can ask "did this session invoke X" instead
+// of substring-probing the transcript and matching every mention of X.
+//
+// Agents whose transcripts carry no tool-call view MUST NOT implement this.
+// That includes Cursor, whose transcripts contain no tool_use blocks at all
+// (see cursor.CursorAgent.ExtractModifiedFilesFromOffset), and every format
+// that simply has no walker yet. Not implementing it is the honest answer, and
+// the dispatcher below turns it into a reportable "cannot tell": callers are
+// required to distinguish that from "did not run", because a fabricated "did
+// not run" is indistinguishable from a real one in aggregate.
+type ToolInvocationScanner interface {
+	// ScanToolInvocations calls visit for each recorded tool invocation and
+	// returns true as soon as visit does, stopping the walk.
+	//
+	// hints is a PERFORMANCE contract, not a semantic filter: an implementation
+	// may skip parsing any transcript line whose raw bytes contain none of the
+	// hints. A caller must therefore pass hints that every invocation it can
+	// possibly match is guaranteed to contain literally, or pass nil to visit
+	// everything. Passing a hint that its own matcher can accept without is a
+	// silent false negative, so callers should pin the relationship with a test.
+	ScanToolInvocations(transcriptData []byte, hints [][]byte, visit func(ToolInvocation) bool) bool
+}
+
+// ScanToolInvocations walks ag's recorded tool invocations, returning whether
+// visit accepted one and whether the agent's transcript format can be walked
+// at all.
+//
+// supported is false when ag is nil, the transcript is empty, or the agent does
+// not implement ToolInvocationScanner. Callers MUST NOT collapse
+// (found=false, supported=false) into "did not invoke" — seeing nothing because
+// there was nothing to see is a different fact from seeing nothing because we
+// cannot look, and a metric that conflates them reports a confident number over
+// a population it silently cannot measure.
+func ScanToolInvocations(ag Agent, transcriptData []byte, hints [][]byte, visit func(ToolInvocation) bool) (found, supported bool) {
+	if ag == nil || len(transcriptData) == 0 {
+		return false, false
+	}
+	scanner, ok := AsToolInvocationScanner(ag)
+	if !ok {
+		return false, false
+	}
+	return scanner.ScanToolInvocations(transcriptData, hints, visit), true
+}

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -334,6 +334,26 @@ type State struct {
 	// SkillEvents records explicit native skill signals observed during this session.
 	// Stored as sidecar metadata so consumers can collapse skill-related transcript events
 	// without mutating the raw agent transcript.
+	//
+	// This grows for the life of the session and is deliberately uncapped. It is
+	// also the durable half of the exactly-once contract for skill telemetry:
+	// extraction re-derives events from transcript offset 0 on every pass and
+	// dedupes against this ledger (strategy.appendNewSkillEvents), so an event
+	// whose entry never reached disk is announced twice. Trimming it therefore
+	// re-enables double-reporting for exactly the long sessions a cap would
+	// target.
+	//
+	// The cost is real but bounded, and it is paid on EVERY MutateSessionState —
+	// i.e. every hook, including PostToolUse — because state is read and written
+	// whole. Measured JSON round-trip: 0 events / 106 B / 1.6us; 10 / 6.0 KB /
+	// 42us; 50 / 29.7 KB / 201us; 200 / 119 KB / 785us, i.e. ~594 B per event
+	// and sub-millisecond at any realistic N. The steady-state dedupe rebuild is
+	// cheap by comparison: 13us at 200 existing events.
+	//
+	// So a 100 KB session state is expected, not a leak. If the envelope ever
+	// does need shrinking, the move is a narrower ledger — persist only the
+	// dedupe keys (~40 B/event) and keep the full events transient — not a
+	// truncation, which would break exactly-once.
 	SkillEvents []agent.SkillEvent `json:"skill_events,omitempty"`
 
 	// Hook-provided session metrics (for agents like Cursor that report via hooks)

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -356,6 +356,17 @@ type State struct {
 	// truncation, which would break exactly-once.
 	SkillEvents []agent.SkillEvent `json:"skill_events,omitempty"`
 
+	// CommitCondensedSignalCheckpointID is the checkpoint ID of the last
+	// cli_commit_condensed telemetry signal this session snapshotted, the
+	// durable half of that signal's at-most-once contract. A `git commit
+	// --amend` re-runs PostCommit with the SAME trailer checkpoint ID (an
+	// ACTIVE session re-condenses unconditionally), so without this ledger one
+	// logical commit is counted twice in both halves of the miss-rate ratio.
+	// Persisted by the same state save that gates the emit, so a failed save
+	// retries cleanly; a crash between save and emit loses the row, which is
+	// the signal's accepted best-effort posture.
+	CommitCondensedSignalCheckpointID string `json:"commit_condensed_signal_checkpoint_id,omitempty"`
+
 	// Hook-provided session metrics (for agents like Cursor that report via hooks)
 	SessionDurationMs int64 `json:"session_duration_ms,omitempty"`
 	SessionTurnCount  int   `json:"session_turn_count,omitempty"`

--- a/cmd/entire/cli/setup_search_skill.go
+++ b/cmd/entire/cli/setup_search_skill.go
@@ -12,6 +12,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
 )
 
 const (
@@ -77,14 +78,20 @@ func reportSearchSkillScaffold(w io.Writer, ag agent.Agent, result managedScaffo
 	}
 }
 
+// searchSkillTemplate names the scaffolded files after
+// strategy.EntireSearchSubagentName — the value the commit-condensed telemetry
+// probe matches subagent dispatches against. The template bodies below must
+// declare the same name; TestSearchSkillTemplates_NameMatchesTelemetryProbe
+// pins that, so renaming the subagent without updating the probe fails a test
+// instead of silently zeroing the used_search=subagent signal.
 func searchSkillTemplate(agentName types.AgentName) (string, []byte, bool) {
 	switch agentName {
 	case agent.AgentNameClaudeCode:
-		return filepath.Join(".claude", "agents", "entire-search.md"), []byte(strings.TrimSpace(claudeSearchSkillTemplate) + "\n"), true
+		return filepath.Join(".claude", "agents", strategy.EntireSearchSubagentName+".md"), []byte(strings.TrimSpace(claudeSearchSkillTemplate) + "\n"), true
 	case agent.AgentNameCodex:
-		return filepath.Join(".codex", "agents", "entire-search.toml"), []byte(strings.TrimSpace(codexSearchSkillTemplate) + "\n"), true
+		return filepath.Join(".codex", "agents", strategy.EntireSearchSubagentName+".toml"), []byte(strings.TrimSpace(codexSearchSkillTemplate) + "\n"), true
 	case agent.AgentNameGemini:
-		return filepath.Join(".gemini", "agents", "entire-search.md"), []byte(strings.TrimSpace(geminiSearchSkillTemplate) + "\n"), true
+		return filepath.Join(".gemini", "agents", strategy.EntireSearchSubagentName+".md"), []byte(strings.TrimSpace(geminiSearchSkillTemplate) + "\n"), true
 	default:
 		return "", nil, false
 	}

--- a/cmd/entire/cli/setup_search_skill_test.go
+++ b/cmd/entire/cli/setup_search_skill_test.go
@@ -9,9 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
@@ -251,5 +254,45 @@ func assertStrictJSONSearchInstructions(t *testing.T, content string) {
 	}
 	if !strings.Contains(content, "summarize from the compact fields alone") {
 		t.Fatal("scaffolded file should tell agents repo/pr and cross-repo hits aren't explainable")
+	}
+}
+
+// TestSearchSkillTemplates_NameMatchesTelemetryProbe pins the scaffolded
+// subagent name to strategy.EntireSearchSubagentName, the value the
+// commit-condensed telemetry probe matches Task/Agent dispatches against.
+// Without this pin, renaming the subagent in the templates compiles and passes
+// every template test while silently zeroing used_search_source="subagent" —
+// the probe's primary path.
+func TestSearchSkillTemplates_NameMatchesTelemetryProbe(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		template string
+		// nameDecl is how the template's frontmatter/config declares the
+		// subagent name for its agent's format.
+		nameDecl string
+	}{
+		{"claude", claudeSearchSkillTemplate, "name: " + strategy.EntireSearchSubagentName + "\n"},
+		{"gemini", geminiSearchSkillTemplate, "name: " + strategy.EntireSearchSubagentName + "\n"},
+		{"codex", codexSearchSkillTemplate, "name = \"" + strategy.EntireSearchSubagentName + "\"\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if !strings.Contains(tc.template, tc.nameDecl) {
+				t.Errorf("template does not declare the subagent name the telemetry probe matches: want %q", tc.nameDecl)
+			}
+		})
+	}
+
+	for _, agentName := range []types.AgentName{agent.AgentNameClaudeCode, agent.AgentNameCodex, agent.AgentNameGemini} {
+		relPath, _, ok := searchSkillTemplate(agentName)
+		if !ok {
+			t.Fatalf("searchSkillTemplate(%s) unexpectedly unsupported", agentName)
+		}
+		base := filepath.Base(relPath)
+		if got := strings.TrimSuffix(base, filepath.Ext(base)); got != strategy.EntireSearchSubagentName {
+			t.Errorf("scaffold path for %s names %q, probe matches %q", agentName, got, strategy.EntireSearchSubagentName)
+		}
 	}
 }

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -649,6 +649,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		TotalTranscriptLines:   sessionData.FullTranscriptLines,
 		TranscriptSizeBaseline: transcriptSizeBaseline,
 		NewSkillEvents:         newSkillEvents,
+		UsedSearch:             transcriptMentionsEntireSearch(sessionData.Transcript),
 	}, nil
 }
 

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -649,7 +649,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		TotalTranscriptLines:   sessionData.FullTranscriptLines,
 		TranscriptSizeBaseline: transcriptSizeBaseline,
 		NewSkillEvents:         newSkillEvents,
-		UsedSearch:             transcriptMentionsEntireSearch(sessionData.Transcript),
+		SearchProbe:            sessionData.SearchProbe,
 	}, nil
 }
 
@@ -1447,6 +1447,7 @@ func (s *ManualCommitStrategy) extractSessionData(ctx context.Context, repo *git
 		// see withSubagentTokensFrom.
 		data.TokenUsage = agent.CalculateTokenUsage(ctx, ag, data.Transcript, checkpointTranscriptStart, "")
 		data.SkillEvents = agent.ExtractSkillEvents(ctx, ag, data.Transcript, 0)
+		data.SearchProbe = detectSearchUsage(ag, data.Transcript)
 	}
 
 	return data, nil
@@ -1493,6 +1494,7 @@ func (s *ManualCommitStrategy) extractSessionDataFromLiveTranscript(ctx context.
 		// withSubagentTokensFrom could be closed by reading them.
 		data.TokenUsage = agent.CalculateTokenUsage(ctx, ag, data.Transcript, state.CheckpointTranscriptStart, "")
 		data.SkillEvents = agent.ExtractSkillEvents(ctx, ag, data.Transcript, 0)
+		data.SearchProbe = detectSearchUsage(ag, data.Transcript)
 	}
 
 	return data, nil

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -116,6 +116,16 @@ type condenseOpts struct {
 	// and updateCombinedAttributionForCheckpoint writing attribution under the
 	// same non-existent ID.
 	reconcileInterrupted bool
+
+	// searchProbeAllowed gates the telemetry-only search-usage transcript scan
+	// (detectSearchUsage). nil or false means don't scan: the probe then stays
+	// its zero value, which the payload layer refuses to present as a
+	// measurement (searchProbe.measured). Only PostCommit — the sole path that
+	// emits the commit-condensed signal — passes a gate; the doctor and
+	// session-end condensation paths never scan because nothing would read the
+	// result. The gate is memoized per commit by commitCondensedEmitter, so the
+	// settings load behind it runs at most once per PostCommit.
+	searchProbeAllowed func() bool
 }
 
 // redactSessionJSONLBytes runs the regex-only redaction pipeline (the
@@ -584,6 +594,18 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		return skipped, nil
 	}
 
+	// Telemetry-only search probe, computed exactly once for every result this
+	// function can return (the recovery result below included) so no
+	// construction site can ship the zero value by omission — the fabricated
+	// negative searchProbe.measured exists to catch. Gated: the scan is a
+	// full-transcript pass, and only the PostCommit path, with telemetry
+	// enabled, has a reader for it. detectSearchUsage maps a nil agent or
+	// empty transcript to unsupported, which is the honest answer for the
+	// no-transcript extraction branch.
+	if o.searchProbeAllowed != nil && o.searchProbeAllowed() {
+		sessionData.SearchProbe = detectSearchUsage(ag, sessionData.Transcript)
+	}
+
 	// Capture agent sidecar images (e.g. Cursor's SQLite store) after the skip
 	// check, so the sqlite3 shell-out is avoided when the checkpoint is discarded.
 	extractedAssets = append(extractedAssets, sidecarSessionImages(ctx, logCtx, ag, state)...)
@@ -951,11 +973,6 @@ func (s *ManualCommitStrategy) extractOrCreateSessionData(ctx context.Context, r
 		)
 		return &ExtractedSessionData{
 			FilesTouched: state.FilesTouched,
-			// There is no transcript to look at, and this session can still
-			// condense on FilesTouched or task records alone, so the probe must
-			// say so explicitly. Leaving the zero value here shipped
-			// used_search=false with a blank source.
-			SearchProbe: searchProbe{source: searchSourceUnsupported},
 		}, nil
 	}
 }
@@ -1453,11 +1470,6 @@ func (s *ManualCommitStrategy) extractSessionData(ctx context.Context, repo *git
 		data.TokenUsage = agent.CalculateTokenUsage(ctx, ag, data.Transcript, checkpointTranscriptStart, "")
 		data.SkillEvents = agent.ExtractSkillEvents(ctx, ag, data.Transcript, 0)
 	}
-	// Unconditional: detectSearchUsage maps an empty transcript to unsupported,
-	// which is the honest answer. Gating it on len(Transcript) > 0 instead left
-	// the zero value ("" source) on every no-transcript condensation, which the
-	// payload then read as a measured false.
-	data.SearchProbe = detectSearchUsage(ag, data.Transcript)
 
 	return data, nil
 }
@@ -1504,11 +1516,6 @@ func (s *ManualCommitStrategy) extractSessionDataFromLiveTranscript(ctx context.
 		data.TokenUsage = agent.CalculateTokenUsage(ctx, ag, data.Transcript, state.CheckpointTranscriptStart, "")
 		data.SkillEvents = agent.ExtractSkillEvents(ctx, ag, data.Transcript, 0)
 	}
-	// Unconditional: detectSearchUsage maps an empty transcript to unsupported,
-	// which is the honest answer. Gating it on len(Transcript) > 0 instead left
-	// the zero value ("" source) on every no-transcript condensation, which the
-	// payload then read as a measured false.
-	data.SearchProbe = detectSearchUsage(ag, data.Transcript)
 
 	return data, nil
 }

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1714,6 +1714,13 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 		return mutErr
 	}
 	if stateSaved {
+		// Skill telemetry only. commitCondensedEmitter.emit is deliberately NOT
+		// called here: its payload is commit-scoped (files_committed counts a
+		// commit's files, and prior_ai_history's git-log probe uses --skip=1 to
+		// exclude the commit just made). This path condenses without a commit —
+		// doctor repairing an uncondensed session — so those fields would be
+		// meaningless and --skip=1 would exclude an unrelated HEAD. See
+		// newCommitCondensedSignal.
 		EmitSkillInvocationTelemetry(ctx, newSkillEvents)
 	}
 
@@ -1889,6 +1896,9 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 		return fmt.Errorf("failed to save session state: %w", mutErr)
 	}
 	if stateSaved {
+		// Skill telemetry only — same reason as CondenseSessionByID: this
+		// condenses the work left over after the last commit, so there is no
+		// commit for the commit-condensed signal to describe.
 		EmitSkillInvocationTelemetry(ctx, newSkillEvents)
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -951,6 +951,11 @@ func (s *ManualCommitStrategy) extractOrCreateSessionData(ctx context.Context, r
 		)
 		return &ExtractedSessionData{
 			FilesTouched: state.FilesTouched,
+			// There is no transcript to look at, and this session can still
+			// condense on FilesTouched or task records alone, so the probe must
+			// say so explicitly. Leaving the zero value here shipped
+			// used_search=false with a blank source.
+			SearchProbe: searchProbe{source: searchSourceUnsupported},
 		}, nil
 	}
 }
@@ -1447,8 +1452,12 @@ func (s *ManualCommitStrategy) extractSessionData(ctx context.Context, repo *git
 		// see withSubagentTokensFrom.
 		data.TokenUsage = agent.CalculateTokenUsage(ctx, ag, data.Transcript, checkpointTranscriptStart, "")
 		data.SkillEvents = agent.ExtractSkillEvents(ctx, ag, data.Transcript, 0)
-		data.SearchProbe = detectSearchUsage(ag, data.Transcript)
 	}
+	// Unconditional: detectSearchUsage maps an empty transcript to unsupported,
+	// which is the honest answer. Gating it on len(Transcript) > 0 instead left
+	// the zero value ("" source) on every no-transcript condensation, which the
+	// payload then read as a measured false.
+	data.SearchProbe = detectSearchUsage(ag, data.Transcript)
 
 	return data, nil
 }
@@ -1494,8 +1503,12 @@ func (s *ManualCommitStrategy) extractSessionDataFromLiveTranscript(ctx context.
 		// withSubagentTokensFrom could be closed by reading them.
 		data.TokenUsage = agent.CalculateTokenUsage(ctx, ag, data.Transcript, state.CheckpointTranscriptStart, "")
 		data.SkillEvents = agent.ExtractSkillEvents(ctx, ag, data.Transcript, 0)
-		data.SearchProbe = detectSearchUsage(ag, data.Transcript)
 	}
+	// Unconditional: detectSearchUsage maps an empty transcript to unsupported,
+	// which is the honest answer. Gating it on len(Transcript) > 0 instead left
+	// the zero value ("" source) on every no-transcript condensation, which the
+	// payload then read as a measured false.
+	data.SearchProbe = detectSearchUsage(ag, data.Transcript)
 
 	return data, nil
 }

--- a/cmd/entire/cli/strategy/manual_commit_condensation_recovery.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_recovery.go
@@ -157,6 +157,12 @@ func recoverInterruptedCondensation(
 			Prompts:                sessionData.Prompts,
 			TotalTranscriptLines:   sessionData.FullTranscriptLines,
 			TranscriptSizeBaseline: transcriptSizeBaseline,
+			// Set once in CondenseSession before recovery runs, so this result
+			// carries the same probe as the normal path. Recovery is reachable
+			// only from the non-emitting condensation paths today, but a
+			// CondenseResult that silently drops the field is the trap
+			// searchProbe.measured exists to catch — keep it carried.
+			SearchProbe: sessionData.SearchProbe,
 		},
 		done: true,
 	}

--- a/cmd/entire/cli/strategy/manual_commit_condensation_recovery_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_recovery_test.go
@@ -144,7 +144,7 @@ func TestPostCommitProcessSessionLocked_PreservesDifferentReservedAttempt(t *tes
 
 	(&ManualCommitStrategy{}).postCommitProcessSessionLocked(
 		context.Background(), nil, state, nil, commitID, nil, nil, "", "",
-		nil, nil, nil, nil, preservedBranches, nil, 0,
+		nil, nil, nil, nil, preservedBranches, nil, 0, nil,
 	)
 
 	require.Equal(t, reservedID, state.PendingCondensationID())

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -690,6 +690,10 @@ type postCommitActionHandler struct {
 	// state; the PostCommit loop forwards them to telemetry after the
 	// session's MutateSessionState saves.
 	newSkillEvents []agent.SkillEvent
+	// condensedSignal is the missed-opportunity adoption signal snapshotted
+	// by condensation; emitted by the PostCommit loop after the session's
+	// MutateSessionState saves.
+	condensedSignal *condensedTelemetrySignal
 }
 
 // parentCommitHash returns the first parent's hash as a string, or empty for initial commits.
@@ -716,7 +720,7 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 	)
 
 	if shouldCondense {
-		h.condensed, h.newSkillEvents = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
+		h.condensed, h.newSkillEvents, h.condensedSignal = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
 			shadowRef:        h.shadowRef,
 			headTree:         h.headTree,
 			parentTree:       h.parentTree,
@@ -745,7 +749,7 @@ func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.St
 	)
 
 	if shouldCondense {
-		h.condensed, h.newSkillEvents = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
+		h.condensed, h.newSkillEvents, h.condensedSignal = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
 			shadowRef:        h.shadowRef,
 			headTree:         h.headTree,
 			parentTree:       h.parentTree,
@@ -1034,8 +1038,9 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		sessionID := sess.SessionID
 		iterCtx, iterSpan := processSessionsLoop.Iteration(loopCtx)
 		var newSkillEvents []agent.SkillEvent
+		var condensedSignal *condensedTelemetrySignal
 		stateSaved, mutErr := MutateSessionStateSaved(iterCtx, sessionID, func(state *SessionState) error {
-			newSkillEvents = s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
+			newSkillEvents, condensedSignal = s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
 				head, commit, newHead, worktreePath, headTree, parentTree,
 				committedFileSet, shadowBranchesToDelete, uncondensedActiveOnBranch, allAgentFiles,
 				sessionsWithCommittedFiles)
@@ -1048,6 +1053,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		}
 		if stateSaved {
 			EmitSkillInvocationTelemetry(iterCtx, newSkillEvents)
+			emitCheckpointCondensedTelemetry(iterCtx, condensedSignal)
 		}
 		iterSpan.End()
 	}
@@ -1234,7 +1240,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 	uncondensedActiveOnBranch map[string]bool,
 	allAgentFiles map[string]struct{},
 	sessionsWithCommittedFiles int,
-) (newSkillEvents []agent.SkillEvent) {
+) (newSkillEvents []agent.SkillEvent, condensedSignal *condensedTelemetrySignal) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	shadowBranchName := getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
 	reservedCheckpointID := state.PendingCondensationID()
@@ -1244,7 +1250,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 			slog.String("reserved_checkpoint_id", reservedCheckpointID.String()),
 			slog.String("commit_checkpoint_id", checkpointID.String()))
 		uncondensedActiveOnBranch[shadowBranchName] = true
-		return newSkillEvents
+		return newSkillEvents, condensedSignal
 	}
 
 	// Pre-resolve shadow branch ref and tree for this session.
@@ -1425,7 +1431,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 		uncondensedActiveOnBranch[shadowBranchName] = true
 	}
 
-	return handler.newSkillEvents
+	return handler.newSkillEvents, handler.condensedSignal
 }
 
 // condenseAndUpdateState runs condensation for a session and updates state afterward.
@@ -1441,7 +1447,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 	shadowBranchesToDelete map[string]struct{},
 	committedFiles map[string]struct{},
 	opts condenseOpts,
-) (condensed bool, newSkillEvents []agent.SkillEvent) {
+) (condensed bool, newSkillEvents []agent.SkillEvent, condensedSignal *condensedTelemetrySignal) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	result, err := s.CondenseSession(ctx, repo, checkpointID, state, committedFiles, opts)
 	if err != nil {
@@ -1449,7 +1455,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 			slog.String("session_id", state.SessionID),
 			slog.String("error", err.Error()),
 		)
-		return false, nil
+		return false, nil, nil
 	}
 
 	if result.Skipped {
@@ -1457,15 +1463,19 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 			slog.String("session_id", state.SessionID),
 			slog.String("checkpoint_id", checkpointID.String()),
 		)
-		return false, nil
+		return false, nil, nil
 	}
 
-	// Content-free adoption signal (opt-in telemetry gated inside). Emitted
-	// before the guest-worktree branch below: a guest-linked commit is still a
-	// commit — the transcript was condensed and the trailer stamped — so the
-	// payload describes something real, and skipping it would under-count
-	// exactly the cross-worktree sessions.
-	emitCheckpointCondensedTelemetry(ctx, state, result)
+	// Snapshot the content-free adoption signal now (cheap, I/O-free); the
+	// PostCommit loop emits it after this session's gate releases, alongside
+	// the skill events — settings load, git-log probe, and detached spawn
+	// must not extend the lock hold.
+	//
+	// Snapshotted before the guest-worktree branch below: a guest-linked
+	// commit is still a commit — the transcript was condensed and the trailer
+	// stamped — so the payload describes something real, and skipping it would
+	// under-count exactly the cross-worktree sessions.
+	condensedSignal = newCondensedTelemetrySignal(state, result)
 
 	// Guest-linked commit (identity-matched from a sibling worktree): the
 	// transcript is condensed and the trailer stamped, but every mutation of
@@ -1494,7 +1504,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 			slog.String("checkpoint_id", result.CheckpointID.String()),
 			slog.String("home_worktree", state.WorktreePath),
 		)
-		return true, result.NewSkillEvents
+		return true, result.NewSkillEvents, condensedSignal
 	}
 
 	// Track this shadow branch for cleanup
@@ -1531,7 +1541,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 		slog.Int("transcript_lines", result.TotalTranscriptLines),
 	)
 
-	return true, result.NewSkillEvents
+	return true, result.NewSkillEvents, condensedSignal
 }
 
 // updateBaseCommitIfChanged updates BaseCommit to newHead if it changed.

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -694,6 +694,20 @@ type postCommitActionHandler struct {
 	// by condensation; emitted by the PostCommit loop after the session's
 	// MutateSessionState saves.
 	condensedSignal *commitCondensedSignal
+	// condensedTelemetry is the commit-scoped emitter; the handler passes its
+	// memoized gate into condensation so the search-usage transcript scan is
+	// skipped entirely when telemetry is opted out or not opted in.
+	condensedTelemetry *commitCondensedEmitter
+}
+
+// searchProbeGate adapts the emitter's memoized telemetry gate to the
+// condenseOpts shape; nil when no emitter was wired (defensive — PostCommit
+// always wires one), which condensation reads as "don't scan".
+func (h *postCommitActionHandler) searchProbeGate() func() bool {
+	if h.condensedTelemetry == nil {
+		return nil
+	}
+	return func() bool { return h.condensedTelemetry.searchProbeAllowed(h.ctx) }
 }
 
 // parentCommitHash returns the first parent's hash as a string, or empty for initial commits.
@@ -721,13 +735,14 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 
 	if shouldCondense {
 		h.condensed, h.newSkillEvents, h.condensedSignal = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
-			shadowRef:        h.shadowRef,
-			headTree:         h.headTree,
-			parentTree:       h.parentTree,
-			repoDir:          h.repoDir,
-			parentCommitHash: h.parentCommitHash(),
-			headCommitHash:   h.newHead,
-			allAgentFiles:    h.allAgentFiles,
+			shadowRef:          h.shadowRef,
+			headTree:           h.headTree,
+			parentTree:         h.parentTree,
+			repoDir:            h.repoDir,
+			parentCommitHash:   h.parentCommitHash(),
+			headCommitHash:     h.newHead,
+			allAgentFiles:      h.allAgentFiles,
+			searchProbeAllowed: h.searchProbeGate(),
 		})
 	} else {
 		h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead, h.repoDir)
@@ -750,13 +765,14 @@ func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.St
 
 	if shouldCondense {
 		h.condensed, h.newSkillEvents, h.condensedSignal = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
-			shadowRef:        h.shadowRef,
-			headTree:         h.headTree,
-			parentTree:       h.parentTree,
-			repoDir:          h.repoDir,
-			parentCommitHash: h.parentCommitHash(),
-			headCommitHash:   h.newHead,
-			allAgentFiles:    h.allAgentFiles,
+			shadowRef:          h.shadowRef,
+			headTree:           h.headTree,
+			parentTree:         h.parentTree,
+			repoDir:            h.repoDir,
+			parentCommitHash:   h.parentCommitHash(),
+			headCommitHash:     h.newHead,
+			allAgentFiles:      h.allAgentFiles,
+			searchProbeAllowed: h.searchProbeGate(),
 		})
 	} else {
 		h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead, h.repoDir)
@@ -1032,8 +1048,10 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 
 	// One emitter per commit: the prior-history git-log scan and the settings
 	// load are commit-scoped, not session-scoped. Nothing resolves until a
-	// session actually emits, so a commit that condenses nothing costs nothing.
-	condensedTelemetry := newCommitCondensedEmitter(worktreePath)
+	// session actually condenses, so a commit that condenses nothing costs
+	// nothing. newHead pins the probe to this commit — HEAD may have moved by
+	// the time it runs.
+	condensedTelemetry := newCommitCondensedEmitter(worktreePath, newHead)
 
 	loopCtx, processSessionsLoop := perf.StartLoop(ctx, "process_sessions")
 	for _, sess := range sessions {
@@ -1048,7 +1066,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 			newSkillEvents, condensedSignal = s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
 				head, commit, newHead, worktreePath, headTree, parentTree,
 				committedFileSet, shadowBranchesToDelete, uncondensedActiveOnBranch, allAgentFiles,
-				sessionsWithCommittedFiles)
+				sessionsWithCommittedFiles, condensedTelemetry)
 			return nil
 		})
 		if mutErr != nil && !errors.Is(mutErr, ErrStateNotFound) {
@@ -1229,6 +1247,26 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 // MUST be called from inside MutateSessionState. Mutations to state are persisted
 // by the caller's outer save — calling this function standalone silently loses
 // every field change (StepCount, FilesTouched, CheckpointTranscriptStart, …).
+// resolveShadowRefAndTree pre-resolves a session's shadow branch ref and tree.
+// These are read 4+ times across sessionHasNewContent, filesOverlapWithContent,
+// CondenseSession, filesWithRemainingAgentChanges, and
+// calculateSessionAttributions. Both are nil when the branch does not exist.
+func resolveShadowRefAndTree(ctx context.Context, repo *git.Repository, shadowBranchName string) (*plumbing.Reference, *object.Tree) {
+	_, span := perf.Start(ctx, "resolve_shadow_branch")
+	defer span.End()
+	var shadowRef *plumbing.Reference
+	var shadowTree *object.Tree
+	if ref, refErr := repo.Reference(plumbing.NewBranchReferenceName(shadowBranchName), true); refErr == nil {
+		shadowRef = ref
+		if sc, scErr := repo.CommitObject(ref.Hash()); scErr == nil {
+			if st, stErr := sc.Tree(); stErr == nil {
+				shadowTree = st
+			}
+		}
+	}
+	return shadowRef, shadowTree
+}
+
 func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 	ctx context.Context,
 	repo *git.Repository,
@@ -1245,6 +1283,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 	uncondensedActiveOnBranch map[string]bool,
 	allAgentFiles map[string]struct{},
 	sessionsWithCommittedFiles int,
+	condensedTelemetry *commitCondensedEmitter,
 ) (newSkillEvents []agent.SkillEvent, condensedSignal *commitCondensedSignal) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	shadowBranchName := getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
@@ -1258,21 +1297,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 		return newSkillEvents, condensedSignal
 	}
 
-	// Pre-resolve shadow branch ref and tree for this session.
-	// These are read 4+ times across sessionHasNewContent, filesOverlapWithContent,
-	// CondenseSession, filesWithRemainingAgentChanges, and calculateSessionAttributions.
-	_, resolveShadowBranchSpan := perf.Start(ctx, "resolve_shadow_branch")
-	var shadowRef *plumbing.Reference
-	var shadowTree *object.Tree
-	if ref, refErr := repo.Reference(plumbing.NewBranchReferenceName(shadowBranchName), true); refErr == nil {
-		shadowRef = ref
-		if sc, scErr := repo.CommitObject(ref.Hash()); scErr == nil {
-			if st, stErr := sc.Tree(); stErr == nil {
-				shadowTree = st
-			}
-		}
-	}
-	resolveShadowBranchSpan.End()
+	shadowRef, shadowTree := resolveShadowRefAndTree(ctx, repo, shadowBranchName)
 
 	// Check for new content (needed for TransitionContext and condensation).
 	// Fail-open: if content check errors, assume new content exists so we
@@ -1346,6 +1371,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 		shadowTree:                 shadowTree,
 		allAgentFiles:              allAgentFiles,
 		sessionsWithCommittedFiles: sessionsWithCommittedFiles,
+		condensedTelemetry:         condensedTelemetry,
 	}
 
 	if err := TransitionAndLog(ctx, state, session.EventGitCommit, *transitionCtx, handler); err != nil {
@@ -1480,7 +1506,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 	// commit is still a commit — the transcript was condensed and the trailer
 	// stamped — so the payload describes something real, and skipping it would
 	// under-count exactly the cross-worktree sessions.
-	condensedSignal = newCommitCondensedSignal(state, result)
+	condensedSignal = newCommitCondensedSignal(state, result, committedFiles)
 
 	// Guest-linked commit (identity-matched from a sibling worktree): the
 	// transcript is condensed and the trailer stamped, but every mutation of

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -693,7 +693,7 @@ type postCommitActionHandler struct {
 	// condensedSignal is the missed-opportunity adoption signal snapshotted
 	// by condensation; emitted by the PostCommit loop after the session's
 	// MutateSessionState saves.
-	condensedSignal *condensedTelemetrySignal
+	condensedSignal *commitCondensedSignal
 }
 
 // parentCommitHash returns the first parent's hash as a string, or empty for initial commits.
@@ -1038,7 +1038,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		sessionID := sess.SessionID
 		iterCtx, iterSpan := processSessionsLoop.Iteration(loopCtx)
 		var newSkillEvents []agent.SkillEvent
-		var condensedSignal *condensedTelemetrySignal
+		var condensedSignal *commitCondensedSignal
 		stateSaved, mutErr := MutateSessionStateSaved(iterCtx, sessionID, func(state *SessionState) error {
 			newSkillEvents, condensedSignal = s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
 				head, commit, newHead, worktreePath, headTree, parentTree,
@@ -1053,7 +1053,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		}
 		if stateSaved {
 			EmitSkillInvocationTelemetry(iterCtx, newSkillEvents)
-			emitCheckpointCondensedTelemetry(iterCtx, condensedSignal)
+			emitCommitCondensedTelemetry(iterCtx, condensedSignal)
 		}
 		iterSpan.End()
 	}
@@ -1240,7 +1240,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 	uncondensedActiveOnBranch map[string]bool,
 	allAgentFiles map[string]struct{},
 	sessionsWithCommittedFiles int,
-) (newSkillEvents []agent.SkillEvent, condensedSignal *condensedTelemetrySignal) {
+) (newSkillEvents []agent.SkillEvent, condensedSignal *commitCondensedSignal) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	shadowBranchName := getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
 	reservedCheckpointID := state.PendingCondensationID()
@@ -1447,7 +1447,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 	shadowBranchesToDelete map[string]struct{},
 	committedFiles map[string]struct{},
 	opts condenseOpts,
-) (condensed bool, newSkillEvents []agent.SkillEvent, condensedSignal *condensedTelemetrySignal) {
+) (condensed bool, newSkillEvents []agent.SkillEvent, condensedSignal *commitCondensedSignal) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	result, err := s.CondenseSession(ctx, repo, checkpointID, state, committedFiles, opts)
 	if err != nil {
@@ -1475,7 +1475,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 	// commit is still a commit — the transcript was condensed and the trailer
 	// stamped — so the payload describes something real, and skipping it would
 	// under-count exactly the cross-worktree sessions.
-	condensedSignal = newCondensedTelemetrySignal(state, result)
+	condensedSignal = newCommitCondensedSignal(state, result)
 
 	// Guest-linked commit (identity-matched from a sibling worktree): the
 	// transcript is condensed and the trailer stamped, but every mutation of

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1460,6 +1460,13 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 		return false, nil
 	}
 
+	// Content-free adoption signal (opt-in telemetry gated inside). Emitted
+	// before the guest-worktree branch below: a guest-linked commit is still a
+	// commit — the transcript was condensed and the trailer stamped — so the
+	// payload describes something real, and skipping it would under-count
+	// exactly the cross-worktree sessions.
+	emitCheckpointCondensedTelemetry(ctx, state, result)
+
 	// Guest-linked commit (identity-matched from a sibling worktree): the
 	// transcript is condensed and the trailer stamped, but every mutation of
 	// worktree-coupled state below is skipped. The session's BaseCommit

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1030,6 +1030,11 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		}
 	}
 
+	// One emitter per commit: the prior-history git-log scan and the settings
+	// load are commit-scoped, not session-scoped. Nothing resolves until a
+	// session actually emits, so a commit that condenses nothing costs nothing.
+	condensedTelemetry := newCommitCondensedEmitter(worktreePath)
+
 	loopCtx, processSessionsLoop := perf.StartLoop(ctx, "process_sessions")
 	for _, sess := range sessions {
 		if sess.FullyCondensed && sess.Phase == session.PhaseEnded {
@@ -1053,7 +1058,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		}
 		if stateSaved {
 			EmitSkillInvocationTelemetry(iterCtx, newSkillEvents)
-			emitCommitCondensedTelemetry(iterCtx, condensedSignal)
+			condensedTelemetry.emit(iterCtx, condensedSignal)
 		}
 		iterSpan.End()
 	}

--- a/cmd/entire/cli/strategy/manual_commit_types.go
+++ b/cmd/entire/cli/strategy/manual_commit_types.go
@@ -53,7 +53,11 @@ type CondenseResult struct {
 	Prompts              []string // User prompts from the condensed session
 	TotalTranscriptLines int      // Total transcript units after this condensation (JSONL line count or message count by agent format)
 	Skipped              bool     // True if condensation was skipped (no transcript or files to condense)
-	UsedSearch           bool     // True if the session transcript shows an `entire search` invocation (telemetry signal)
+
+	// SearchProbe records whether the session invoked Entire's history search
+	// and how that was determined. Telemetry only; see detectSearchUsage for why
+	// "could not tell" is a distinct state from "did not search".
+	SearchProbe searchProbe
 
 	// TranscriptSizeBaseline is the byte size to record as
 	// SessionState.CheckpointTranscriptSize. It must be measured on the SANITIZED,
@@ -81,4 +85,5 @@ type ExtractedSessionData struct {
 	FilesTouched        []string
 	TokenUsage          *agent.TokenUsage  // Token usage calculated from transcript (since CheckpointTranscriptStart)
 	SkillEvents         []agent.SkillEvent // Skill events detected from transcript data
+	SearchProbe         searchProbe        // `entire search` usage; see detectSearchUsage
 }

--- a/cmd/entire/cli/strategy/manual_commit_types.go
+++ b/cmd/entire/cli/strategy/manual_commit_types.go
@@ -53,6 +53,7 @@ type CondenseResult struct {
 	Prompts              []string // User prompts from the condensed session
 	TotalTranscriptLines int      // Total transcript units after this condensation (JSONL line count or message count by agent format)
 	Skipped              bool     // True if condensation was skipped (no transcript or files to condense)
+	UsedSearch           bool     // True if the session transcript shows an `entire search` invocation (telemetry signal)
 
 	// TranscriptSizeBaseline is the byte size to record as
 	// SessionState.CheckpointTranscriptSize. It must be measured on the SANITIZED,

--- a/cmd/entire/cli/strategy/manual_commit_types.go
+++ b/cmd/entire/cli/strategy/manual_commit_types.go
@@ -83,7 +83,10 @@ type ExtractedSessionData struct {
 	FullTranscriptLines int      // Total line count in full transcript
 	Prompts             []string // User prompts from the current checkpoint portion
 	FilesTouched        []string
-	TokenUsage          *agent.TokenUsage  // Token usage calculated from transcript (since CheckpointTranscriptStart)
-	SkillEvents         []agent.SkillEvent // Skill events detected from transcript data
-	SearchProbe         searchProbe        // `entire search` usage; see detectSearchUsage
+	TokenUsage          *agent.TokenUsage // Token usage calculated from transcript (since CheckpointTranscriptStart)
+	// SkillEvents are this condensation's extracted events. Transient — the
+	// durable ledger, and the per-hook cost of carrying it, is
+	// session.SessionState.SkillEvents; see its size note.
+	SkillEvents []agent.SkillEvent
+	SearchProbe searchProbe // `entire search` usage; see detectSearchUsage
 }

--- a/cmd/entire/cli/strategy/manual_commit_types.go
+++ b/cmd/entire/cli/strategy/manual_commit_types.go
@@ -88,5 +88,9 @@ type ExtractedSessionData struct {
 	// durable ledger, and the per-hook cost of carrying it, is
 	// session.SessionState.SkillEvents; see its size note.
 	SkillEvents []agent.SkillEvent
-	SearchProbe searchProbe // `entire search` usage; see detectSearchUsage
+	// SearchProbe is `entire search` usage; see detectSearchUsage. Not set by
+	// the extractors: CondenseSession assigns it exactly once, gated on
+	// condenseOpts.searchProbeAllowed, so every result path carries the same
+	// value and ungated paths never pay the scan.
+	SearchProbe searchProbe
 }

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
@@ -95,8 +96,16 @@ func emitCheckpointCondensedTelemetry(ctx context.Context, state *SessionState, 
 	if root, rootErr := paths.WorktreeRoot(ctx); rootErr == nil {
 		priorAIHistory = priorAICommitTouchedFiles(ctx, root, result.FilesTouched)
 	}
+	// Report the registry key ("claude-code"), not the display name stored in
+	// state.AgentType ("Claude Code"), so the agent property lines up with the
+	// skill and command events. Unknown agent types fall back to the stored
+	// string rather than dropping the signal.
+	agentName := string(state.AgentType)
+	if ag, agErr := agent.GetByAgentType(state.AgentType); agErr == nil && ag != nil {
+		agentName = string(ag.Name())
+	}
 	telemetry.TrackCheckpointCondensedDetached(telemetry.CheckpointCondensedSignal{
-		Agent:          string(state.AgentType),
+		Agent:          agentName,
 		UsedSearch:     result.UsedSearch,
 		PriorAIHistory: priorAIHistory,
 		FilesCommitted: len(result.FilesTouched),

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -1,0 +1,104 @@
+package strategy
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+)
+
+// priorAICheckpointsLookback bounds how many commits back the
+// missed-opportunity signal scans for AI checkpoint history. One bounded git
+// subprocess regardless of repo size.
+const priorAICheckpointsLookback = 50
+
+// transcriptMentionsEntireSearch reports whether the raw transcript contains
+// an `entire search` (or legacy `entire checkpoint search`) invocation. A
+// substring probe over agent-native JSONL is deliberately loose — a prompt
+// merely *mentioning* the command also matches — which is acceptable for an
+// aggregate telemetry boolean and never used for behavior.
+func transcriptMentionsEntireSearch(transcript []byte) bool {
+	return bytes.Contains(transcript, []byte("entire search")) ||
+		bytes.Contains(transcript, []byte("entire checkpoint search"))
+}
+
+// priorAICommitTouchedFiles reports whether any of files was touched by a
+// recent commit carrying an Entire checkpoint trailer, excluding the commit
+// that was just created (--skip=1). files must be repo-root-relative, matching
+// git log --name-only output. Best-effort: any failure reports false.
+//
+// Paths git quotes in --name-only output (e.g. non-ASCII names) won't match
+// their unquoted FilesTouched form; that false-negative is acceptable for a
+// telemetry boolean.
+func priorAICommitTouchedFiles(ctx context.Context, repoRoot string, files []string) bool {
+	if len(files) == 0 {
+		return false
+	}
+	// \x1e separates commits; \x1f separates each commit's message from the
+	// --name-only file list git appends after the format block.
+	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "log",
+		"--skip=1", "-n", strconv.Itoa(priorAICheckpointsLookback),
+		"--name-only", "--format=%x1e%B%x1f").Output()
+	if err != nil {
+		return false
+	}
+	fileSet := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		fileSet[f] = struct{}{}
+	}
+	for _, record := range strings.Split(string(out), "\x1e") {
+		message, fileList, found := strings.Cut(record, "\x1f")
+		if !found {
+			continue
+		}
+		if _, isCheckpoint := trailers.ParseCheckpoint(message); !isCheckpoint {
+			continue
+		}
+		for _, line := range strings.Split(fileList, "\n") {
+			name := strings.TrimSpace(line)
+			if name == "" {
+				continue
+			}
+			if _, hit := fileSet[name]; hit {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// emitCheckpointCondensedTelemetry sends the content-free adoption signal for
+// one condensed checkpoint: did the session consult search, and did the files
+// it committed already carry AI checkpoint history? Together these give the
+// "sessions that edited history-dense files without searching" denominator
+// that raw command counts cannot.
+//
+// Gated on the opt-in telemetry setting before any work happens — the git-log
+// density probe only runs when telemetry is on — and best-effort throughout:
+// the PostHog call happens in a detached child and never blocks the hook.
+func emitCheckpointCondensedTelemetry(ctx context.Context, state *SessionState, result *CondenseResult) {
+	if result == nil || result.Skipped || state == nil {
+		return
+	}
+	s, err := settings.Load(ctx)
+	if err != nil || s.Telemetry == nil || !*s.Telemetry {
+		return
+	}
+	priorAIHistory := false
+	if root, rootErr := paths.WorktreeRoot(ctx); rootErr == nil {
+		priorAIHistory = priorAICommitTouchedFiles(ctx, root, result.FilesTouched)
+	}
+	telemetry.TrackCheckpointCondensedDetached(telemetry.CheckpointCondensedSignal{
+		Agent:          string(state.AgentType),
+		UsedSearch:     result.UsedSearch,
+		PriorAIHistory: priorAIHistory,
+		FilesCommitted: len(result.FilesTouched),
+	}, s.Enabled, versioninfo.Version)
+}

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -107,7 +107,12 @@ const entireSearchSubagent = "entire-search"
 func detectSearchUsage(ag agent.Agent, transcriptData []byte) searchProbe {
 	source := searchSourceNone
 	found, supported := agent.ScanToolInvocations(ag, transcriptData, entireSearchHints, func(inv agent.ToolInvocation) bool {
-		if strings.EqualFold(strings.TrimSpace(inv.SubagentType), entireSearchSubagent) {
+		// Exact, not EqualFold: the hint prefilter that decides whether this
+		// line is parsed at all is case-sensitive bytes.Contains, so a
+		// case-insensitive matcher here would accept a spelling the prefilter
+		// already discarded — a silent false negative, which is exactly the
+		// hazard ToolInvocationScanner's doc warns callers about.
+		if strings.TrimSpace(inv.SubagentType) == entireSearchSubagent {
 			source = searchSourceSubagent
 			return true
 		}

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -31,6 +31,34 @@ type searchProbe struct {
 	source string
 }
 
+// measured reports whether used is a real measurement rather than "we could not
+// look".
+//
+// Deliberately an allowlist over the known-measured sources, not `source !=
+// searchSourceUnsupported`. The zero value of searchProbe has source "", which a
+// denylist admits — so any path that condenses without ever running the probe
+// would ship used_search=false with a blank label: the fabricated negative this
+// whole tri-state exists to prevent, wearing no label to reveal itself. An
+// allowlist makes forgetting to set the probe fail safe instead.
+func (p searchProbe) measured() bool {
+	switch p.source {
+	case searchSourceNone, searchSourceCommand, searchSourceSubagent:
+		return true
+	default:
+		return false
+	}
+}
+
+// label is the value sent as used_search_source. It maps the zero value onto
+// unsupported so the property honours its documented contract of always being
+// one of the four named sources.
+func (p searchProbe) label() string {
+	if p.source == "" {
+		return searchSourceUnsupported
+	}
+	return p.source
+}
+
 // Sources for searchProbe.source. Low cardinality on purpose — this is a
 // PostHog property, and a new probe method should get a new label rather than
 // being folded into an existing one.
@@ -321,14 +349,14 @@ func (e *commitCondensedEmitter) emit(ctx context.Context, sig *commitCondensedS
 	// filter excludes those rows instead of counting them as "did not search" —
 	// a missing PostHog property is not false.
 	var usedSearch *bool
-	if sig.searchProbe.source != searchSourceUnsupported {
+	if sig.searchProbe.measured() {
 		used := sig.searchProbe.used
 		usedSearch = &used
 	}
 	emitCommitCondensed(telemetry.CommitCondensedSignal{
 		Agent:            agentName,
 		UsedSearch:       usedSearch,
-		UsedSearchSource: sig.searchProbe.source,
+		UsedSearchSource: sig.searchProbe.label(),
 		PriorAIHistory:   priorAIHistory,
 		FilesCommitted:   len(sig.filesTouched),
 	}, s.Enabled, versioninfo.Version)

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -1,9 +1,9 @@
 package strategy
 
 import (
-	"bytes"
 	"context"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -21,14 +21,107 @@ import (
 // subprocess regardless of repo size.
 const priorAICheckpointsLookback = 50
 
-// transcriptMentionsEntireSearch reports whether the raw transcript contains
-// an `entire search` (or legacy `entire checkpoint search`) invocation. A
-// substring probe over agent-native JSONL is deliberately loose — a prompt
-// merely *mentioning* the command also matches — which is acceptable for an
-// aggregate telemetry boolean and never used for behavior.
-func transcriptMentionsEntireSearch(transcript []byte) bool {
-	return bytes.Contains(transcript, []byte("entire search")) ||
-		bytes.Contains(transcript, []byte("entire checkpoint search"))
+// searchProbe records whether the session consulted Entire's history search
+// AND how that answer was obtained. The source travels with the boolean all the
+// way to the payload because the two carry different information: "we looked and
+// found nothing" and "we cannot look at this transcript" are both `used=false`,
+// and a ratio computed over their union is a confident number over a population
+// it silently cannot measure.
+type searchProbe struct {
+	used   bool
+	source string
+}
+
+// Sources for searchProbe.source. Low cardinality on purpose — this is a
+// PostHog property, and a new probe method should get a new label rather than
+// being folded into an existing one.
+const (
+	// searchSourceUnsupported: this agent's transcript has no tool-call view,
+	// so the question is unanswerable. used is false, and MUST NOT be read as
+	// "did not search".
+	searchSourceUnsupported = "unsupported"
+	// searchSourceNone: the transcript was walked and no invocation was found.
+	// This is the only trustworthy false.
+	searchSourceNone = "none"
+	// searchSourceCommand: a shell tool ran the command directly.
+	searchSourceCommand = "command"
+	// searchSourceSubagent: the entire-search subagent was dispatched.
+	searchSourceSubagent = "subagent"
+)
+
+// entireSearchHints is the byte-level prefilter handed to the scanner. It is a
+// performance filter, so every string entireSearchCommandPattern or the
+// subagent check can accept must contain one of these LITERALLY — which is why
+// the pattern below spells the internal separators as single spaces instead of
+// \s+. TestSearchHintsCoverPattern pins the relationship; loosening the pattern
+// without extending the hints is a silent false negative, not a slow path.
+//
+//nolint:gochecknoglobals // immutable lookup table, built once.
+var entireSearchHints = [][]byte{
+	[]byte("entire search"),
+	[]byte("entire checkpoint search"),
+	[]byte("entire-search"),
+}
+
+// entireSearchCommandPattern matches `entire search` / `entire checkpoint
+// search` in COMMAND position — at the start of a command, or after a shell
+// separator, tolerating leading env assignments and a path prefix. Position is
+// the whole point: it accepts `cd sub && entire search "x" --json` and
+// `/usr/local/bin/entire search x`, while rejecting the mentions that made the
+// old substring probe ~18x false-positive, because in every one of them the
+// phrase sits inside an argument rather than at a command boundary —
+// `grep -rn "entire search" cmd/`, `git commit -m "... entire search ..."`.
+//
+// Known residual false negatives, and they are the safer direction: `xargs
+// entire search`, `for f in …; do entire search; done` reached through a loop
+// variable, and anything behind a wrapper script. They report `none`, so the
+// missed-opportunity rate reads as an upper bound.
+//
+//nolint:gochecknoglobals // compiled once, read-only.
+var entireSearchCommandPattern = regexp.MustCompile(
+	`(?:^|[;&|(\n])\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:[\w./-]*/)?entire (?:checkpoint )?search(?:\s|$)`)
+
+// entireSearchSubagent is the subagent name setup_search_skill.go scaffolds
+// into .claude/agents/entire-search.md (and the Codex/Gemini equivalents).
+//
+// Matching the dispatch is not a nicety, it is the primary path. A session that
+// consults search the way Entire ships it dispatches this subagent, and the
+// subagent's own `entire search` Bash call is written to a SEPARATE transcript
+// file that condensation never reads. Match only shell commands and the probe
+// reports "did not search" for exactly the sessions that adopted the feature —
+// a false negative aimed at the users we most want to count.
+const entireSearchSubagent = "entire-search"
+
+// detectSearchUsage reports whether the session consulted Entire's history
+// search, and how it knows.
+//
+// Structural by construction: it asks the agent for recorded tool invocations
+// rather than scanning bytes, so a transcript that merely *mentions* the command
+// no longer counts. Entire installs the artifacts that made that distinction
+// urgent — setup_search_skill.go embeds `entire search --json` in the search
+// skill's own body, and investigate/prompt.go injects it into every investigate
+// prompt — so the old probe fired on sessions that had only read Entire's own
+// text.
+//
+// An empty transcript reports unsupported, not none: seeing nothing because
+// there is nothing to see is not evidence that the session did not search.
+func detectSearchUsage(ag agent.Agent, transcriptData []byte) searchProbe {
+	source := searchSourceNone
+	found, supported := agent.ScanToolInvocations(ag, transcriptData, entireSearchHints, func(inv agent.ToolInvocation) bool {
+		if strings.EqualFold(strings.TrimSpace(inv.SubagentType), entireSearchSubagent) {
+			source = searchSourceSubagent
+			return true
+		}
+		if inv.Command != "" && entireSearchCommandPattern.MatchString(inv.Command) {
+			source = searchSourceCommand
+			return true
+		}
+		return false
+	})
+	if !supported {
+		return searchProbe{used: false, source: searchSourceUnsupported}
+	}
+	return searchProbe{used: found, source: source}
 }
 
 // priorAICommitTouchedFiles reports whether any of files was touched by a
@@ -86,7 +179,7 @@ func priorAICommitTouchedFiles(ctx context.Context, repoRoot string, files []str
 // gate, matching the skill-event telemetry pattern.
 type commitCondensedSignal struct {
 	agentType    types.AgentType
-	usedSearch   bool
+	searchProbe  searchProbe
 	filesTouched []string
 }
 
@@ -116,7 +209,7 @@ func newCommitCondensedSignal(state *SessionState, result *CondenseResult) *comm
 	copy(files, result.FilesTouched)
 	return &commitCondensedSignal{
 		agentType:    state.AgentType,
-		usedSearch:   result.UsedSearch,
+		searchProbe:  result.SearchProbe,
 		filesTouched: files,
 	}
 }
@@ -155,10 +248,20 @@ func emitCommitCondensedTelemetry(ctx context.Context, sig *commitCondensedSigna
 	if ag, agErr := agent.GetByAgentType(sig.agentType); agErr == nil && ag != nil {
 		agentName = string(ag.Name())
 	}
+	// Send used_search only when it was actually measurable. An unsupported
+	// transcript sends the source alone, so a consumer's `used_search = false`
+	// filter excludes those rows instead of counting them as "did not search" —
+	// a missing PostHog property is not false.
+	var usedSearch *bool
+	if sig.searchProbe.source != searchSourceUnsupported {
+		used := sig.searchProbe.used
+		usedSearch = &used
+	}
 	telemetry.TrackCommitCondensedDetached(telemetry.CommitCondensedSignal{
-		Agent:          agentName,
-		UsedSearch:     sig.usedSearch,
-		PriorAIHistory: priorAIHistory,
-		FilesCommitted: len(sig.filesTouched),
+		Agent:            agentName,
+		UsedSearch:       usedSearch,
+		UsedSearchSource: sig.searchProbe.source,
+		PriorAIHistory:   priorAIHistory,
+		FilesCommitted:   len(sig.filesTouched),
 	}, s.Enabled, versioninfo.Version)
 }

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -87,7 +87,7 @@ const (
 var entireSearchHints = [][]byte{
 	[]byte("entire search"),
 	[]byte("entire checkpoint search"),
-	[]byte("entire-search"),
+	[]byte(EntireSearchSubagentName),
 }
 
 // entireSearchCommandPattern matches `entire search` / `entire checkpoint
@@ -99,17 +99,179 @@ var entireSearchHints = [][]byte{
 // phrase sits inside an argument rather than at a command boundary —
 // `grep -rn "entire search" cmd/`, `git commit -m "... entire search ..."`.
 //
+// The regex itself is quote-blind, so it MUST only ever see commands that have
+// been through sanitizeShellCommandForMatching: without that, a separator
+// inside a quoted argument reads as a command boundary and the phrase after it
+// as a command — `git commit -m "wip; entire search notes"`,
+// `rg "foo|entire search bar" .`, and a heredoc writing the search skill's own
+// body all matched. detectSearchUsage is the only caller and applies it.
+//
 // Known residual false negatives, and they are the safer direction: `xargs
 // entire search`, `for f in …; do entire search; done` reached through a loop
-// variable, and anything behind a wrapper script. They report `none`, so the
-// missed-opportunity rate reads as an upper bound.
+// variable, an invocation inside backticks or a quoted `$(…)` (the sanitizer
+// strips quoted spans whole), and anything behind a wrapper script. They report
+// `none`, so the missed-opportunity rate reads as an upper bound.
 //
 //nolint:gochecknoglobals // compiled once, read-only.
 var entireSearchCommandPattern = regexp.MustCompile(
 	`(?:^|[;&|(\n])\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:[\w./-]*/)?entire (?:checkpoint )?search(?:\s|$)`)
 
-// entireSearchSubagent is the subagent name setup_search_skill.go scaffolds
-// into .claude/agents/entire-search.md (and the Codex/Gemini equivalents).
+// commandInvokesEntireSearch is THE command matcher: sanitize, then match.
+// detectSearchUsage and the pinning tests both go through it so the sanitizer
+// cannot be bypassed on one side and not the other.
+func commandInvokesEntireSearch(cmd string) bool {
+	return entireSearchCommandPattern.MatchString(sanitizeShellCommandForMatching(cmd))
+}
+
+// sanitizeShellCommandForMatching prepares a raw shell command for
+// entireSearchCommandPattern by blanking the spans whose content must not be
+// read as shell structure: single-quoted strings, double-quoted strings, and
+// heredoc bodies. Each blanked span becomes a single NUL byte — NUL is in
+// neither the pattern's separator class nor any of its literals, so a
+// replacement can neither fabricate a command boundary nor join two fragments
+// into a phrase that was never contiguous in the input. Every non-NUL byte of
+// the output is copied verbatim, in order, from the input, which is what keeps
+// the hint-prefilter contract intact: any match found in the sanitized text
+// exists literally in the raw command.
+//
+// This is a matcher aid, not a shell parser. It understands just enough —
+// backslash escapes outside quotes, `\"` inside double quotes, `<<`/`<<-`
+// heredocs with optionally quoted delimiters (which must start with a letter
+// or underscore, so `$((1<<2))` is not misread as one) — to kill the
+// false-positive classes review actually measured. Where it errs, it errs
+// toward blanking too much, which is a false NEGATIVE for the probe: the safer
+// direction, per entireSearchCommandPattern's doc.
+func sanitizeShellCommandForMatching(cmd string) string {
+	var b strings.Builder
+	b.Grow(len(cmd))
+	var pendingHeredocs []string
+	for i := 0; i < len(cmd); {
+		switch c := cmd[i]; c {
+		case '\\':
+			// An escaped character is literal text; copy the pair so the
+			// escaped byte can't be read as a quote or separator opener.
+			b.WriteByte(c)
+			if i+1 < len(cmd) {
+				b.WriteByte(cmd[i+1])
+				i += 2
+			} else {
+				i++
+			}
+		case '\'':
+			if end := strings.IndexByte(cmd[i+1:], '\''); end >= 0 {
+				i += end + 2
+			} else {
+				i = len(cmd) // unterminated: blank to end
+			}
+			b.WriteByte(0)
+		case '"':
+			j := i + 1
+			for j < len(cmd) && cmd[j] != '"' {
+				if cmd[j] == '\\' {
+					j++ // skip the escaped byte too
+				}
+				j++
+			}
+			if j < len(cmd) {
+				i = j + 1
+			} else {
+				i = len(cmd) // unterminated: blank to end
+			}
+			b.WriteByte(0)
+		case '<':
+			if delim, next, ok := parseHeredocStart(cmd, i); ok {
+				pendingHeredocs = append(pendingHeredocs, delim)
+				b.WriteString(cmd[i:next])
+				i = next
+			} else {
+				b.WriteByte(c)
+				i++
+			}
+		case '\n':
+			b.WriteByte(c)
+			i++
+			// The lines that follow are heredoc bodies, not commands. Blank
+			// each pending body through its delimiter line, keeping a newline
+			// in its place so a real command on the line AFTER the body still
+			// sits on a command boundary.
+			for _, delim := range pendingHeredocs {
+				i = skipHeredocBody(cmd, i, delim)
+				b.WriteByte(0)
+				b.WriteByte('\n')
+			}
+			pendingHeredocs = pendingHeredocs[:0]
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
+}
+
+// parseHeredocStart reports whether cmd[i:] opens a heredoc (`<<` or `<<-`,
+// not the `<<<` here-string), returning the delimiter word and the offset just
+// past it. The delimiter must start with a letter or underscore so arithmetic
+// like `$((1<<2))` is not misread as a heredoc.
+func parseHeredocStart(cmd string, i int) (delim string, next int, ok bool) {
+	if i+1 >= len(cmd) || cmd[i+1] != '<' || (i+2 < len(cmd) && cmd[i+2] == '<') {
+		return "", 0, false
+	}
+	j := i + 2
+	if j < len(cmd) && cmd[j] == '-' {
+		j++
+	}
+	for j < len(cmd) && (cmd[j] == ' ' || cmd[j] == '\t') {
+		j++
+	}
+	var quote byte
+	if j < len(cmd) && (cmd[j] == '\'' || cmd[j] == '"') {
+		quote = cmd[j]
+		j++
+	}
+	start := j
+	for j < len(cmd) && (isShellWordByte(cmd[j]) || (j > start && cmd[j] >= '0' && cmd[j] <= '9')) {
+		j++
+	}
+	delim = cmd[start:j]
+	if delim == "" || !isShellWordByte(delim[0]) {
+		return "", 0, false
+	}
+	if quote != 0 && j < len(cmd) && cmd[j] == quote {
+		j++
+	}
+	return delim, j, true
+}
+
+func isShellWordByte(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// skipHeredocBody returns the offset just past the line matching delim
+// (tolerating the leading tabs `<<-` allows), or len(cmd) when the body is
+// unterminated.
+func skipHeredocBody(cmd string, i int, delim string) int {
+	for i < len(cmd) {
+		line := cmd[i:]
+		next := len(cmd)
+		if eol := strings.IndexByte(line, '\n'); eol >= 0 {
+			line = line[:eol]
+			next = i + eol + 1
+		}
+		i = next
+		if strings.TrimLeft(line, "\t") == delim {
+			return i
+		}
+	}
+	return i
+}
+
+// EntireSearchSubagentName is the subagent name setup_search_skill.go (package
+// cli) scaffolds into .claude/agents/entire-search.md (and the Codex/Gemini
+// equivalents). Exported so the installer and its tests pin their scaffolded
+// paths and template bodies against the value this probe matches — strategy
+// cannot import cli, so the constant lives here and cli reaches down. Renaming
+// the scaffolded subagent without updating this constant silently makes the
+// probe report "did not search" for every session that adopted the feature.
 //
 // Matching the dispatch is not a nicety, it is the primary path. A session that
 // consults search the way Entire ships it dispatches this subagent, and the
@@ -117,7 +279,7 @@ var entireSearchCommandPattern = regexp.MustCompile(
 // file that condensation never reads. Match only shell commands and the probe
 // reports "did not search" for exactly the sessions that adopted the feature —
 // a false negative aimed at the users we most want to count.
-const entireSearchSubagent = "entire-search"
+const EntireSearchSubagentName = "entire-search"
 
 // detectSearchUsage reports whether the session consulted Entire's history
 // search, and how it knows.
@@ -140,11 +302,11 @@ func detectSearchUsage(ag agent.Agent, transcriptData []byte) searchProbe {
 		// case-insensitive matcher here would accept a spelling the prefilter
 		// already discarded — a silent false negative, which is exactly the
 		// hazard ToolInvocationScanner's doc warns callers about.
-		if strings.TrimSpace(inv.SubagentType) == entireSearchSubagent {
+		if strings.TrimSpace(inv.SubagentType) == EntireSearchSubagentName {
 			source = searchSourceSubagent
 			return true
 		}
-		if inv.Command != "" && entireSearchCommandPattern.MatchString(inv.Command) {
+		if inv.Command != "" && commandInvokesEntireSearch(inv.Command) {
 			source = searchSourceCommand
 			return true
 		}
@@ -157,11 +319,16 @@ func detectSearchUsage(ag agent.Agent, transcriptData []byte) searchProbe {
 }
 
 // priorAICommitFiles returns the repo-root-relative paths touched by recent
-// commits carrying an Entire checkpoint trailer, excluding the commit that was
-// just created (--skip=1 — the commit being reported on is not its own prior
-// history). Paths match git log --name-only output, i.e. the same form as
-// SessionState.FilesTouched. Best-effort: any failure yields nil, read as "no
-// prior history".
+// commits carrying an Entire checkpoint trailer, walking history from commit —
+// the commit being reported on — and excluding that commit itself (--skip=1: it
+// is not its own prior history). Anchoring on the explicit hash rather than
+// ambient HEAD matters twice over: the probe runs after the session gate
+// releases, so HEAD may have moved (a chained hook amending, a concurrent
+// commit), and hooks inherit git's exported GIT_DIR/GIT_WORK_TREE, which
+// override -C's repo selection — gitEnvWithoutRepoOverrides scrubs those, same
+// as this package's other `git -C` call site. Paths match git log --name-only
+// output, i.e. the same form as SessionState.FilesTouched. Best-effort: any
+// failure yields nil, read as "no prior history".
 //
 // A set rather than a predicate because the answer is commit-scoped and
 // identical for every session in the commit — only the intersection differs —
@@ -178,7 +345,7 @@ func detectSearchUsage(ag agent.Agent, transcriptData []byte) searchProbe {
 // the miss rate. A merge's content is already attributed to the individual
 // trailer-carrying commits it brings in, which sit in this window on their own
 // account. Squash merges are single-parent, so their files do appear.
-func priorAICommitFiles(ctx context.Context, repoRoot string) map[string]struct{} {
+func priorAICommitFiles(ctx context.Context, repoRoot, commit string) map[string]struct{} {
 	// Each record starts with an empty field: -z NUL-terminates the format
 	// output, and %x00 prefixes it, so splitting the whole output on NUL yields
 	// ["", "<hash>\n<body>", "\n<file>", "<file>", …] per commit. A commit
@@ -188,9 +355,11 @@ func priorAICommitFiles(ctx context.Context, repoRoot string) map[string]struct{
 	// a real trailer. %H guarantees the post-marker field is non-empty, so an
 	// empty-message commit cannot produce two adjacent markers and mis-frame
 	// the next record.
-	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "log", "-z",
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "log", "-z",
 		"--skip=1", "-n", strconv.Itoa(priorAICheckpointsLookback),
-		"--name-only", "--format=%x00%H%n%B").Output()
+		"--name-only", "--format=%x00%H%n%B", commit)
+	cmd.Env = gitEnvWithoutRepoOverrides()
+	out, err := cmd.Output()
 	if err != nil {
 		return nil
 	}
@@ -244,9 +413,16 @@ type commitCondensedSignal struct {
 
 // newCommitCondensedSignal snapshots the signal inputs for a successful
 // condensation, or nil when there is nothing to report. Cheap and I/O-free by
-// design — it is the only part of this signal that runs under the session
-// gate. FilesTouched is copied because the caller mutates state after
-// condensing.
+// design — it and the gated search probe are the only parts of this signal
+// that run under the session gate.
+//
+// filesTouched is re-intersected against committedFiles rather than trusting
+// result.FilesTouched: filterFilesTouched deliberately leaves the session's
+// list whole when the commit changed no files (--allow-empty, or file
+// detection failing upstream), which is correct for checkpoint metadata but
+// would make files_committed count files the commit never landed — and
+// prior_ai_history intersect on them. The intersection is also what copies the
+// slice out from under the caller's later state mutations.
 //
 // Commit-scoped by construction: the sole caller is condenseAndUpdateState,
 // reached only from postCommitProcessSessionLocked. That is a scoping decision,
@@ -260,12 +436,16 @@ type commitCondensedSignal struct {
 // genuine misses, inflating the denominator instead of completing it. Covering
 // them means a trigger discriminator plus nullable commit-scoped fields — a
 // change to what the metric means, not a bug fix.
-func newCommitCondensedSignal(state *SessionState, result *CondenseResult) *commitCondensedSignal {
+func newCommitCondensedSignal(state *SessionState, result *CondenseResult, committedFiles map[string]struct{}) *commitCondensedSignal {
 	if result == nil || result.Skipped || state == nil {
 		return nil
 	}
-	files := make([]string, len(result.FilesTouched))
-	copy(files, result.FilesTouched)
+	files := make([]string, 0, len(result.FilesTouched))
+	for _, f := range result.FilesTouched {
+		if _, ok := committedFiles[f]; ok {
+			files = append(files, f)
+		}
+	}
 	return &commitCondensedSignal{
 		agentType:    state.AgentType,
 		searchProbe:  result.SearchProbe,
@@ -284,15 +464,21 @@ func newCommitCondensedSignal(state *SessionState, result *CondenseResult) *comm
 // commit — only the per-session intersection differs — so paying it per session
 // was paying for spawns, not work.
 //
-// Everything resolves on FIRST USE, and the order in emit is the promise: a
-// commit where no session condenses runs neither settings.Load nor git log, and
-// an opted-out user never reaches the probe. Laziness comes from where emit is
-// called, not from this type — do not front-run the gate by resolving anything
-// in the constructor.
+// Everything resolves on FIRST USE: a commit where no session condenses runs
+// neither settings.Load nor git log, and an opted-out user never reaches the
+// probe. The gate has two resolution points sharing one memo — searchProbeAllowed,
+// called during condensation so a closed gate skips the transcript scan
+// entirely, and emit, for the send decision — so whichever runs first pays the
+// single settings load. Do not front-run the gate by resolving anything in the
+// constructor.
 //
 // Not safe for concurrent use: PostCommit's session loop is sequential.
 type commitCondensedEmitter struct {
 	repoRoot string
+	// commit is the hash of the commit PostCommit is reporting on; the
+	// prior-history probe walks from it explicitly rather than from ambient
+	// HEAD. See priorAICommitFiles.
+	commit string
 
 	gateResolved bool
 	// settings is non-nil only when the gate is open; s.Enabled is needed at
@@ -305,14 +491,28 @@ type commitCondensedEmitter struct {
 
 	// probeFn is a test seam, like emitSkillTelemetry, so tests can count probe
 	// invocations without spawning git.
-	probeFn func(ctx context.Context, repoRoot string) map[string]struct{}
+	probeFn func(ctx context.Context, repoRoot, commit string) map[string]struct{}
 }
 
 // newCommitCondensedEmitter returns an emitter for one commit. repoRoot is the
 // worktree root PostCommit already resolved, which is what the per-session emit
-// used to recompute.
-func newCommitCondensedEmitter(repoRoot string) *commitCondensedEmitter {
-	return &commitCondensedEmitter{repoRoot: repoRoot, probeFn: priorAICommitFiles}
+// used to recompute; commit is the hash of the commit being reported on.
+func newCommitCondensedEmitter(repoRoot, commit string) *commitCondensedEmitter {
+	return &commitCondensedEmitter{repoRoot: repoRoot, commit: commit, probeFn: priorAICommitFiles}
+}
+
+// searchProbeAllowed reports whether the search-usage transcript scan should
+// run at all, resolving the same memoized gate emit uses. Condensation calls
+// this (through condenseOpts.searchProbeAllowed) BEFORE scanning, so an
+// opted-out or not-opted-in user never pays a full-transcript pass for a
+// payload that would be dropped at emit — and the two non-emitting condensation
+// paths (doctor repair, session-end leftovers), which pass no gate, never scan.
+func (e *commitCondensedEmitter) searchProbeAllowed(ctx context.Context) bool {
+	if e == nil || telemetry.IsEnvOptedOut() {
+		return false
+	}
+	_, ok := e.allowed(ctx)
+	return ok
 }
 
 // emit sends the content-free adoption signal for one condensed checkpoint: did
@@ -384,7 +584,7 @@ func (e *commitCondensedEmitter) priorAITouched(ctx context.Context, files []str
 	}
 	if !e.probed {
 		e.probed = true
-		e.priorFiles = e.probeFn(ctx, e.repoRoot)
+		e.priorFiles = e.probeFn(ctx, e.repoRoot, e.commit)
 	}
 	for _, f := range files {
 		if _, hit := e.priorFiles[f]; hit {

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
-	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
@@ -124,59 +123,86 @@ func detectSearchUsage(ag agent.Agent, transcriptData []byte) searchProbe {
 	return searchProbe{used: found, source: source}
 }
 
-// priorAICommitTouchedFiles reports whether any of files was touched by a
-// recent commit carrying an Entire checkpoint trailer, excluding the commit
-// that was just created (--skip=1). files must be repo-root-relative, matching
-// git log --name-only output. Best-effort: any failure reports false.
+// priorAICommitFiles returns the repo-root-relative paths touched by recent
+// commits carrying an Entire checkpoint trailer, excluding the commit that was
+// just created (--skip=1 — the commit being reported on is not its own prior
+// history). Paths match git log --name-only output, i.e. the same form as
+// SessionState.FilesTouched. Best-effort: any failure yields nil, read as "no
+// prior history".
+//
+// A set rather than a predicate because the answer is commit-scoped and
+// identical for every session in the commit — only the intersection differs —
+// which is what lets commitCondensedEmitter run the subprocess once.
 //
 // -z keeps names unquoted and NUL-terminated, so non-ASCII paths (which git
 // would otherwise emit quoted, e.g. "caf\303\251.go") still match their
 // FilesTouched form, and names containing newlines survive parsing.
-func priorAICommitTouchedFiles(ctx context.Context, repoRoot string, files []string) bool {
-	if len(files) == 0 {
-		return false
-	}
-	// \x1e separates commits; \x1f separates each commit's message from the
-	// --name-only file list git appends after the format block.
+//
+// Merge commits contribute nothing, and that is deliberate rather than a gap.
+// --name-only emits no names for a merge, and the obvious fix
+// (--diff-merges=first-parent) would make a "Merge origin/main into X" commit
+// attribute every file it merged in, inflating prior_ai_history and therefore
+// the miss rate. A merge's content is already attributed to the individual
+// trailer-carrying commits it brings in, which sit in this window on their own
+// account. Squash merges are single-parent, so their files do appear.
+func priorAICommitFiles(ctx context.Context, repoRoot string) map[string]struct{} {
+	// Each record starts with an empty field: -z NUL-terminates the format
+	// output, and %x00 prefixes it, so splitting the whole output on NUL yields
+	// ["", "<hash>\n<body>", "\n<file>", "<file>", …] per commit. A commit
+	// message cannot contain NUL, so the record marker rests on nothing about
+	// message content — the defect in the %x1e/%x1f framing this replaces,
+	// where either control character in a body split a record early and dropped
+	// a real trailer. %H guarantees the post-marker field is non-empty, so an
+	// empty-message commit cannot produce two adjacent markers and mis-frame
+	// the next record.
 	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "log", "-z",
 		"--skip=1", "-n", strconv.Itoa(priorAICheckpointsLookback),
-		"--name-only", "--format=%x1e%B%x1f").Output()
+		"--name-only", "--format=%x00%H%n%B").Output()
 	if err != nil {
-		return false
+		return nil
 	}
-	fileSet := make(map[string]struct{}, len(files))
-	for _, f := range files {
-		fileSet[f] = struct{}{}
-	}
-	for _, record := range strings.Split(string(out), "\x1e") {
-		message, fileList, found := strings.Cut(record, "\x1f")
-		if !found {
-			continue
+	var files map[string]struct{}
+	fields := strings.Split(string(out), "\x00")
+	for i := 0; i < len(fields); i++ {
+		if fields[i] != "" {
+			continue // not a record marker; consumed below
 		}
-		if _, isCheckpoint := trailers.ParseCheckpoint(message); !isCheckpoint {
-			continue
+		i++
+		if i >= len(fields) {
+			break
 		}
-		for _, name := range strings.Split(fileList, "\x00") {
-			// The diff section still opens with the newline separating it
-			// from the format block; strip it from the segment carrying it.
-			name = strings.TrimPrefix(name, "\n")
+		isCheckpoint := false
+		if _, ok := trailers.ParseCheckpoint(fields[i]); ok {
+			isCheckpoint = true
+		}
+		// Consume this record's file list, whether or not we want it, so the
+		// outer loop resumes on the next marker rather than mid-record.
+		for i+1 < len(fields) && fields[i+1] != "" {
+			i++
+			if !isCheckpoint {
+				continue
+			}
+			// The diff section opens with the newline separating it from the
+			// format block; strip it from the segment carrying it.
+			name := strings.TrimPrefix(fields[i], "\n")
 			if name == "" {
 				continue
 			}
-			if _, hit := fileSet[name]; hit {
-				return true
+			if files == nil {
+				files = make(map[string]struct{})
 			}
+			files[name] = struct{}{}
 		}
 	}
-	return false
+	return files
 }
 
 // commitCondensedSignal captures, while the session gate is held, the few
 // state/result fields the condensed-checkpoint signal needs. Everything
 // expensive — the env/settings gates, the git-log density probe, machine-ID
 // lookup, and the detached-process spawn — runs later in
-// emitCommitCondensedTelemetry, after MutateSessionState has released the
-// gate, matching the skill-event telemetry pattern.
+// commitCondensedEmitter.emit, after MutateSessionState has released the gate,
+// matching the skill-event telemetry pattern.
 type commitCondensedSignal struct {
 	agentType    types.AgentType
 	searchProbe  searchProbe
@@ -214,32 +240,69 @@ func newCommitCondensedSignal(state *SessionState, result *CondenseResult) *comm
 	}
 }
 
-// emitCommitCondensedTelemetry sends the content-free adoption signal for
-// one condensed checkpoint: did the session consult search, and did the files
-// it committed already carry AI checkpoint history? Together these give the
-// "sessions that edited history-dense files without searching" denominator
-// that raw command counts cannot.
+// commitCondensedEmitter emits the cli_commit_condensed signal for each session
+// of one commit, memoizing everything that is commit-scoped rather than
+// session-scoped: the telemetry gate (settings load) and the git-log scan of
+// prior AI checkpoint history.
 //
-// Gated on both the env opt-out and the opt-in telemetry setting before any
-// work happens — an opted-out user never pays for the git-log density probe —
-// and best-effort throughout: the PostHog call happens in a detached child and
-// never blocks the hook. Call it AFTER the surrounding MutateSessionState
-// returns, never inside its closure.
-func emitCommitCondensedTelemetry(ctx context.Context, sig *commitCondensedSignal) {
-	if sig == nil {
+// The scan was per session, and its cost is almost entirely process spawn:
+// measured 13.8ms p50, flat across a 60x range of output size, against 8.7ms
+// for `git --version` alone. Its output is identical for every session in the
+// commit — only the per-session intersection differs — so paying it per session
+// was paying for spawns, not work.
+//
+// Everything resolves on FIRST USE, and the order in emit is the promise: a
+// commit where no session condenses runs neither settings.Load nor git log, and
+// an opted-out user never reaches the probe. Laziness comes from where emit is
+// called, not from this type — do not front-run the gate by resolving anything
+// in the constructor.
+//
+// Not safe for concurrent use: PostCommit's session loop is sequential.
+type commitCondensedEmitter struct {
+	repoRoot string
+
+	gateResolved bool
+	// settings is non-nil only when the gate is open; s.Enabled is needed at
+	// send time, which is why the loaded value is retained rather than reduced
+	// to a bool.
+	settings *settings.EntireSettings
+
+	probed     bool
+	priorFiles map[string]struct{}
+
+	// probeFn is a test seam, like emitSkillTelemetry, so tests can count probe
+	// invocations without spawning git.
+	probeFn func(ctx context.Context, repoRoot string) map[string]struct{}
+}
+
+// newCommitCondensedEmitter returns an emitter for one commit. repoRoot is the
+// worktree root PostCommit already resolved, which is what the per-session emit
+// used to recompute.
+func newCommitCondensedEmitter(repoRoot string) *commitCondensedEmitter {
+	return &commitCondensedEmitter{repoRoot: repoRoot, probeFn: priorAICommitFiles}
+}
+
+// emit sends the content-free adoption signal for one condensed checkpoint: did
+// the session consult search, and did the files it committed already carry AI
+// checkpoint history? Together these give the "commits that landed AI-dense
+// files without consulting search" ratio that raw command counts cannot.
+//
+// Gated on the env opt-out and then the opt-in telemetry setting before any
+// probe work, and best-effort throughout: the PostHog call happens in a
+// detached child and never blocks the hook. Call it AFTER the surrounding
+// MutateSessionState returns, never inside its closure.
+func (e *commitCondensedEmitter) emit(ctx context.Context, sig *commitCondensedSignal) {
+	if e == nil || sig == nil {
 		return
 	}
 	if telemetry.IsEnvOptedOut() {
 		return
 	}
-	s, err := settings.Load(ctx)
-	if err != nil || s.Telemetry == nil || !*s.Telemetry {
+	s, ok := e.allowed(ctx)
+	if !ok {
 		return
 	}
-	priorAIHistory := false
-	if root, rootErr := paths.WorktreeRoot(ctx); rootErr == nil {
-		priorAIHistory = priorAICommitTouchedFiles(ctx, root, sig.filesTouched)
-	}
+	priorAIHistory := e.priorAITouched(ctx, sig.filesTouched)
 	// Report the registry key ("claude-code"), not the display name stored in
 	// state.AgentType ("Claude Code"), so the agent property lines up with the
 	// skill and command events. Unknown agent types fall back to the stored
@@ -257,7 +320,7 @@ func emitCommitCondensedTelemetry(ctx context.Context, sig *commitCondensedSigna
 		used := sig.searchProbe.used
 		usedSearch = &used
 	}
-	telemetry.TrackCommitCondensedDetached(telemetry.CommitCondensedSignal{
+	emitCommitCondensed(telemetry.CommitCondensedSignal{
 		Agent:            agentName,
 		UsedSearch:       usedSearch,
 		UsedSearchSource: sig.searchProbe.source,
@@ -265,3 +328,41 @@ func emitCommitCondensedTelemetry(ctx context.Context, sig *commitCondensedSigna
 		FilesCommitted:   len(sig.filesTouched),
 	}, s.Enabled, versioninfo.Version)
 }
+
+// allowed resolves the opt-in telemetry gate at most once per commit.
+//
+// IsTelemetryEnabled is #2023's helper, extracted precisely to stop the
+// hand-rolled `s.Telemetry == nil || !*s.Telemetry` being copied a fourth time.
+func (e *commitCondensedEmitter) allowed(ctx context.Context) (*settings.EntireSettings, bool) {
+	if !e.gateResolved {
+		e.gateResolved = true
+		if s, err := settings.Load(ctx); err == nil && s.IsTelemetryEnabled() {
+			e.settings = s
+		}
+	}
+	return e.settings, e.settings != nil
+}
+
+// priorAITouched intersects one session's committed files against the commit's
+// prior-history set, running the git-log scan at most once.
+func (e *commitCondensedEmitter) priorAITouched(ctx context.Context, files []string) bool {
+	if len(files) == 0 {
+		return false
+	}
+	if !e.probed {
+		e.probed = true
+		e.priorFiles = e.probeFn(ctx, e.repoRoot)
+	}
+	for _, f := range files {
+		if _, hit := e.priorFiles[f]; hit {
+			return true
+		}
+	}
+	return false
+}
+
+// emitCommitCondensed is the send step, separated from the gating above so
+// tests can assert what the gate lets through without a PostHog client.
+//
+//nolint:gochecknoglobals // test seam, set and restored by in-package tests.
+var emitCommitCondensed = telemetry.TrackCommitCondensedDetached

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
@@ -35,16 +36,16 @@ func transcriptMentionsEntireSearch(transcript []byte) bool {
 // that was just created (--skip=1). files must be repo-root-relative, matching
 // git log --name-only output. Best-effort: any failure reports false.
 //
-// Paths git quotes in --name-only output (e.g. non-ASCII names) won't match
-// their unquoted FilesTouched form; that false-negative is acceptable for a
-// telemetry boolean.
+// -z keeps names unquoted and NUL-terminated, so non-ASCII paths (which git
+// would otherwise emit quoted, e.g. "caf\303\251.go") still match their
+// FilesTouched form, and names containing newlines survive parsing.
 func priorAICommitTouchedFiles(ctx context.Context, repoRoot string, files []string) bool {
 	if len(files) == 0 {
 		return false
 	}
 	// \x1e separates commits; \x1f separates each commit's message from the
 	// --name-only file list git appends after the format block.
-	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "log",
+	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "log", "-z",
 		"--skip=1", "-n", strconv.Itoa(priorAICheckpointsLookback),
 		"--name-only", "--format=%x1e%B%x1f").Output()
 	if err != nil {
@@ -62,8 +63,10 @@ func priorAICommitTouchedFiles(ctx context.Context, repoRoot string, files []str
 		if _, isCheckpoint := trailers.ParseCheckpoint(message); !isCheckpoint {
 			continue
 		}
-		for _, line := range strings.Split(fileList, "\n") {
-			name := strings.TrimSpace(line)
+		for _, name := range strings.Split(fileList, "\x00") {
+			// The diff section still opens with the newline separating it
+			// from the format block; strip it from the segment carrying it.
+			name = strings.TrimPrefix(name, "\n")
 			if name == "" {
 				continue
 			}
@@ -75,17 +78,52 @@ func priorAICommitTouchedFiles(ctx context.Context, repoRoot string, files []str
 	return false
 }
 
+// condensedTelemetrySignal captures, while the session gate is held, the few
+// state/result fields the condensed-checkpoint signal needs. Everything
+// expensive — the env/settings gates, the git-log density probe, machine-ID
+// lookup, and the detached-process spawn — runs later in
+// emitCheckpointCondensedTelemetry, after MutateSessionState has released the
+// gate, matching the skill-event telemetry pattern.
+type condensedTelemetrySignal struct {
+	agentType    types.AgentType
+	usedSearch   bool
+	filesTouched []string
+}
+
+// newCondensedTelemetrySignal snapshots the signal inputs for a successful
+// condensation, or nil when there is nothing to report. Cheap and I/O-free by
+// design — it is the only part of this signal that runs under the session
+// gate. FilesTouched is copied because the caller mutates state after
+// condensing.
+func newCondensedTelemetrySignal(state *SessionState, result *CondenseResult) *condensedTelemetrySignal {
+	if result == nil || result.Skipped || state == nil {
+		return nil
+	}
+	files := make([]string, len(result.FilesTouched))
+	copy(files, result.FilesTouched)
+	return &condensedTelemetrySignal{
+		agentType:    state.AgentType,
+		usedSearch:   result.UsedSearch,
+		filesTouched: files,
+	}
+}
+
 // emitCheckpointCondensedTelemetry sends the content-free adoption signal for
 // one condensed checkpoint: did the session consult search, and did the files
 // it committed already carry AI checkpoint history? Together these give the
 // "sessions that edited history-dense files without searching" denominator
 // that raw command counts cannot.
 //
-// Gated on the opt-in telemetry setting before any work happens — the git-log
-// density probe only runs when telemetry is on — and best-effort throughout:
-// the PostHog call happens in a detached child and never blocks the hook.
-func emitCheckpointCondensedTelemetry(ctx context.Context, state *SessionState, result *CondenseResult) {
-	if result == nil || result.Skipped || state == nil {
+// Gated on both the env opt-out and the opt-in telemetry setting before any
+// work happens — an opted-out user never pays for the git-log density probe —
+// and best-effort throughout: the PostHog call happens in a detached child and
+// never blocks the hook. Call it AFTER the surrounding MutateSessionState
+// returns, never inside its closure.
+func emitCheckpointCondensedTelemetry(ctx context.Context, sig *condensedTelemetrySignal) {
+	if sig == nil {
+		return
+	}
+	if telemetry.IsEnvOptedOut() {
 		return
 	}
 	s, err := settings.Load(ctx)
@@ -94,20 +132,20 @@ func emitCheckpointCondensedTelemetry(ctx context.Context, state *SessionState, 
 	}
 	priorAIHistory := false
 	if root, rootErr := paths.WorktreeRoot(ctx); rootErr == nil {
-		priorAIHistory = priorAICommitTouchedFiles(ctx, root, result.FilesTouched)
+		priorAIHistory = priorAICommitTouchedFiles(ctx, root, sig.filesTouched)
 	}
 	// Report the registry key ("claude-code"), not the display name stored in
 	// state.AgentType ("Claude Code"), so the agent property lines up with the
 	// skill and command events. Unknown agent types fall back to the stored
 	// string rather than dropping the signal.
-	agentName := string(state.AgentType)
-	if ag, agErr := agent.GetByAgentType(state.AgentType); agErr == nil && ag != nil {
+	agentName := string(sig.agentType)
+	if ag, agErr := agent.GetByAgentType(sig.agentType); agErr == nil && ag != nil {
 		agentName = string(ag.Name())
 	}
 	telemetry.TrackCheckpointCondensedDetached(telemetry.CheckpointCondensedSignal{
 		Agent:          agentName,
-		UsedSearch:     result.UsedSearch,
+		UsedSearch:     sig.usedSearch,
 		PriorAIHistory: priorAIHistory,
-		FilesCommitted: len(result.FilesTouched),
+		FilesCommitted: len(sig.filesTouched),
 	}, s.Enabled, versioninfo.Version)
 }

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -78,37 +78,50 @@ func priorAICommitTouchedFiles(ctx context.Context, repoRoot string, files []str
 	return false
 }
 
-// condensedTelemetrySignal captures, while the session gate is held, the few
+// commitCondensedSignal captures, while the session gate is held, the few
 // state/result fields the condensed-checkpoint signal needs. Everything
 // expensive — the env/settings gates, the git-log density probe, machine-ID
 // lookup, and the detached-process spawn — runs later in
-// emitCheckpointCondensedTelemetry, after MutateSessionState has released the
+// emitCommitCondensedTelemetry, after MutateSessionState has released the
 // gate, matching the skill-event telemetry pattern.
-type condensedTelemetrySignal struct {
+type commitCondensedSignal struct {
 	agentType    types.AgentType
 	usedSearch   bool
 	filesTouched []string
 }
 
-// newCondensedTelemetrySignal snapshots the signal inputs for a successful
+// newCommitCondensedSignal snapshots the signal inputs for a successful
 // condensation, or nil when there is nothing to report. Cheap and I/O-free by
 // design — it is the only part of this signal that runs under the session
 // gate. FilesTouched is copied because the caller mutates state after
 // condensing.
-func newCondensedTelemetrySignal(state *SessionState, result *CondenseResult) *condensedTelemetrySignal {
+//
+// Commit-scoped by construction: the sole caller is condenseAndUpdateState,
+// reached only from postCommitProcessSessionLocked. That is a scoping decision,
+// not an oversight. The payload describes a commit — files_committed counts its
+// files, and prior_ai_history's git-log probe passes --skip=1 precisely to
+// exclude the commit just made — and it feeds the ratio "commits that landed
+// AI-dense files without consulting search". The other condensation paths
+// (CondenseSessionByID via doctor, CondenseAndMarkFullyCondensed at session
+// end) condense real checkpoints but have no commit: --skip=1 would exclude an
+// unrelated HEAD, and the resulting rows would be indistinguishable from
+// genuine misses, inflating the denominator instead of completing it. Covering
+// them means a trigger discriminator plus nullable commit-scoped fields — a
+// change to what the metric means, not a bug fix.
+func newCommitCondensedSignal(state *SessionState, result *CondenseResult) *commitCondensedSignal {
 	if result == nil || result.Skipped || state == nil {
 		return nil
 	}
 	files := make([]string, len(result.FilesTouched))
 	copy(files, result.FilesTouched)
-	return &condensedTelemetrySignal{
+	return &commitCondensedSignal{
 		agentType:    state.AgentType,
 		usedSearch:   result.UsedSearch,
 		filesTouched: files,
 	}
 }
 
-// emitCheckpointCondensedTelemetry sends the content-free adoption signal for
+// emitCommitCondensedTelemetry sends the content-free adoption signal for
 // one condensed checkpoint: did the session consult search, and did the files
 // it committed already carry AI checkpoint history? Together these give the
 // "sessions that edited history-dense files without searching" denominator
@@ -119,7 +132,7 @@ func newCondensedTelemetrySignal(state *SessionState, result *CondenseResult) *c
 // and best-effort throughout: the PostHog call happens in a detached child and
 // never blocks the hook. Call it AFTER the surrounding MutateSessionState
 // returns, never inside its closure.
-func emitCheckpointCondensedTelemetry(ctx context.Context, sig *condensedTelemetrySignal) {
+func emitCommitCondensedTelemetry(ctx context.Context, sig *commitCondensedSignal) {
 	if sig == nil {
 		return
 	}
@@ -142,7 +155,7 @@ func emitCheckpointCondensedTelemetry(ctx context.Context, sig *condensedTelemet
 	if ag, agErr := agent.GetByAgentType(sig.agentType); agErr == nil && ag != nil {
 		agentName = string(ag.Name())
 	}
-	telemetry.TrackCheckpointCondensedDetached(telemetry.CheckpointCondensedSignal{
+	telemetry.TrackCommitCondensedDetached(telemetry.CommitCondensedSignal{
 		Agent:          agentName,
 		UsedSearch:     sig.usedSearch,
 		PriorAIHistory: priorAIHistory,

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
@@ -327,8 +328,13 @@ func detectSearchUsage(ag agent.Agent, transcriptData []byte) searchProbe {
 // commit), and hooks inherit git's exported GIT_DIR/GIT_WORK_TREE, which
 // override -C's repo selection — gitEnvWithoutRepoOverrides scrubs those, same
 // as this package's other `git -C` call site. Paths match git log --name-only
-// output, i.e. the same form as SessionState.FilesTouched. Best-effort: any
-// failure yields nil, read as "no prior history".
+// output, i.e. the same form as SessionState.FilesTouched.
+//
+// ok=false means the probe COULD NOT run (git unavailable, cancelled ctx, a
+// log invocation that errors) — the caller must treat that as unmeasured, not
+// as "no prior history": a fabricated false here deflates the very miss rate
+// the event exists to measure, the same conflation the used_search tri-state
+// prevents. ok=true with a nil set is the measured "no prior history".
 //
 // A set rather than a predicate because the answer is commit-scoped and
 // identical for every session in the commit — only the intersection differs —
@@ -345,7 +351,7 @@ func detectSearchUsage(ag agent.Agent, transcriptData []byte) searchProbe {
 // the miss rate. A merge's content is already attributed to the individual
 // trailer-carrying commits it brings in, which sit in this window on their own
 // account. Squash merges are single-parent, so their files do appear.
-func priorAICommitFiles(ctx context.Context, repoRoot, commit string) map[string]struct{} {
+func priorAICommitFiles(ctx context.Context, repoRoot, commit string) (result map[string]struct{}, ok bool) {
 	// Each record starts with an empty field: -z NUL-terminates the format
 	// output, and %x00 prefixes it, so splitting the whole output on NUL yields
 	// ["", "<hash>\n<body>", "\n<file>", "<file>", …] per commit. A commit
@@ -361,7 +367,7 @@ func priorAICommitFiles(ctx context.Context, repoRoot, commit string) map[string
 	cmd.Env = gitEnvWithoutRepoOverrides()
 	out, err := cmd.Output()
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	var files map[string]struct{}
 	fields := strings.Split(string(out), "\x00")
@@ -396,7 +402,7 @@ func priorAICommitFiles(ctx context.Context, repoRoot, commit string) map[string
 			files[name] = struct{}{}
 		}
 	}
-	return files
+	return files, true
 }
 
 // commitCondensedSignal captures, while the session gate is held, the few
@@ -439,6 +445,18 @@ type commitCondensedSignal struct {
 func newCommitCondensedSignal(state *SessionState, result *CondenseResult, committedFiles map[string]struct{}) *commitCondensedSignal {
 	if result == nil || result.Skipped || state == nil {
 		return nil
+	}
+	// At-most-once per checkpoint: an amend re-condenses the same trailer
+	// checkpoint ID, and emitting again would count one logical commit twice.
+	// The ledger write rides the session-state save that already gates the
+	// emit. Guarded on a real ID so unit fixtures with a zero result don't
+	// dedupe against the field's zero value.
+	if result.CheckpointID != id.EmptyCheckpointID {
+		ckpt := result.CheckpointID.String()
+		if state.CommitCondensedSignalCheckpointID == ckpt {
+			return nil
+		}
+		state.CommitCondensedSignalCheckpointID = ckpt
 	}
 	files := make([]string, 0, len(result.FilesTouched))
 	for _, f := range result.FilesTouched {
@@ -488,10 +506,14 @@ type commitCondensedEmitter struct {
 
 	probed     bool
 	priorFiles map[string]struct{}
+	// probeOK records whether the memoized probe run actually measured
+	// anything; false makes every session's prior_ai_history unmeasured
+	// (omitted) rather than a fabricated false.
+	probeOK bool
 
 	// probeFn is a test seam, like emitSkillTelemetry, so tests can count probe
 	// invocations without spawning git.
-	probeFn func(ctx context.Context, repoRoot, commit string) map[string]struct{}
+	probeFn func(ctx context.Context, repoRoot, commit string) (map[string]struct{}, bool)
 }
 
 // newCommitCondensedEmitter returns an emitter for one commit. repoRoot is the
@@ -577,21 +599,27 @@ func (e *commitCondensedEmitter) allowed(ctx context.Context) (*settings.EntireS
 }
 
 // priorAITouched intersects one session's committed files against the commit's
-// prior-history set, running the git-log scan at most once.
-func (e *commitCondensedEmitter) priorAITouched(ctx context.Context, files []string) bool {
+// prior-history set, running the git-log scan at most once. Nil means the
+// probe could not run and the payload must omit the property; a commit that
+// landed no files is a measured false without probing at all.
+func (e *commitCondensedEmitter) priorAITouched(ctx context.Context, files []string) *bool {
+	measured := func(v bool) *bool { return &v }
 	if len(files) == 0 {
-		return false
+		return measured(false)
 	}
 	if !e.probed {
 		e.probed = true
-		e.priorFiles = e.probeFn(ctx, e.repoRoot, e.commit)
+		e.priorFiles, e.probeOK = e.probeFn(ctx, e.repoRoot, e.commit)
+	}
+	if !e.probeOK {
+		return nil
 	}
 	for _, f := range files {
 		if _, hit := e.priorFiles[f]; hit {
-			return true
+			return measured(true)
 		}
 	}
-	return false
+	return measured(false)
 }
 
 // emitCommitCondensed is the send step, separated from the gating above so

--- a/cmd/entire/cli/strategy/telemetry_signals_test.go
+++ b/cmd/entire/cli/strategy/telemetry_signals_test.go
@@ -515,3 +515,70 @@ func TestCommitCondensedEmitter_OmitsUsedSearchWhenUnsupported(t *testing.T) {
 		t.Errorf("UsedSearchSource = %q, want %q", got.UsedSearchSource, searchSourceUnsupported)
 	}
 }
+
+// TestSearchProbe_ZeroValueIsNotAMeasurement is the regression test for the
+// fabricated negative: a probe that was never run must never present itself as
+// a measured "did not search", and must still carry one of the four documented
+// source labels.
+func TestSearchProbe_ZeroValueIsNotAMeasurement(t *testing.T) {
+	t.Parallel()
+
+	var zero searchProbe
+	if zero.measured() {
+		t.Error("the zero-value probe reports itself as measured; used_search would ship a fabricated false")
+	}
+	if zero.label() != searchSourceUnsupported {
+		t.Errorf("zero-value label = %q, want %q — used_search_source must always be one of the four sources",
+			zero.label(), searchSourceUnsupported)
+	}
+
+	// An unrecognised source is treated the same way. measured() is an
+	// allowlist precisely so a future source added without updating it fails
+	// safe rather than leaking a measured false.
+	unknown := searchProbe{used: true, source: "some-future-source"}
+	if unknown.measured() {
+		t.Error("an unrecognised source reports as measured; measured() must be an allowlist")
+	}
+
+	for _, p := range []searchProbe{
+		{source: searchSourceNone},
+		{used: true, source: searchSourceCommand},
+		{used: true, source: searchSourceSubagent},
+	} {
+		if !p.measured() {
+			t.Errorf("source %q must count as measured", p.source)
+		}
+		if p.label() != p.source {
+			t.Errorf("label() = %q, want %q", p.label(), p.source)
+		}
+	}
+}
+
+// TestCommitCondensedEmitter_ZeroProbeOmitsUsedSearch covers the path the
+// finding named: a session with no readable transcript still condenses on
+// FilesTouched or task records alone, so the signal it carries must not read as
+// a measured negative.
+func TestCommitCondensedEmitter_ZeroProbeOmitsUsedSearch(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+
+	var got telemetry.CommitCondensedSignal
+	restore := emitCommitCondensed
+	emitCommitCondensed = func(sig telemetry.CommitCondensedSignal, _ bool, _ string) { got = sig }
+	t.Cleanup(func() { emitCommitCondensed = restore })
+
+	e := newCommitCondensedEmitter(t.TempDir())
+	e.probeFn = func(context.Context, string) map[string]struct{} { return nil }
+	// searchProbe left at its zero value, as a no-transcript condensation
+	// produced before the probe was made unconditional.
+	e.emit(t.Context(), &commitCondensedSignal{
+		agentType:    agent.AgentTypeClaudeCode,
+		filesTouched: []string{"a.go"},
+	})
+
+	if got.UsedSearch != nil {
+		t.Errorf("UsedSearch = %v, want nil so the property is omitted rather than a fabricated false", *got.UsedSearch)
+	}
+	if got.UsedSearchSource != searchSourceUnsupported {
+		t.Errorf("UsedSearchSource = %q, want %q — never the empty string", got.UsedSearchSource, searchSourceUnsupported)
+	}
+}

--- a/cmd/entire/cli/strategy/telemetry_signals_test.go
+++ b/cmd/entire/cli/strategy/telemetry_signals_test.go
@@ -72,3 +72,27 @@ func TestPriorAICommitTouchedFiles(t *testing.T) {
 		t.Error("not a git repository; want best-effort false")
 	}
 }
+
+func TestPriorAICommitTouchedFiles_NonASCIIPath(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+
+	// Without -z git quotes non-ASCII names in --name-only output
+	// ("caf\303\251.go"), which can never match the unquoted FilesTouched
+	// form — a systematic false negative this test pins down.
+	testutil.WriteFile(t, tmpDir, "café.go", "package main")
+	testutil.GitAdd(t, tmpDir, "café.go")
+	cpID := id.MustCheckpointID("abcdef123456")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("ai change", cpID))
+
+	// HEAD commit that --skip=1 excludes.
+	testutil.WriteFile(t, tmpDir, "head.txt", "head content")
+	testutil.GitAdd(t, tmpDir, "head.txt")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
+
+	if !priorAICommitTouchedFiles(t.Context(), tmpDir, []string{"café.go"}) {
+		t.Error("café.go was touched by a prior checkpoint commit; want true")
+	}
+}

--- a/cmd/entire/cli/strategy/telemetry_signals_test.go
+++ b/cmd/entire/cli/strategy/telemetry_signals_test.go
@@ -1,33 +1,218 @@
 package strategy
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 )
 
-func TestTranscriptMentionsEntireSearch(t *testing.T) {
+// Real Claude Code JSONL lines. The shapes matter: the old substring probe was
+// tested against invented ones ({"tool":"Bash","command":...}) that no agent
+// writes, which is part of how an 18-to-1 false-positive rate went unnoticed.
+const (
+	fixtureBashSearch = `{"type":"assistant","uuid":"a1","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"entire search \"retry backoff\" --json"}}]}}
+`
+	fixtureBashCheckpointSearch = `{"type":"assistant","uuid":"a2","message":{"content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"entire checkpoint search foo"}}]}}
+`
+	fixtureBashChainedSearch = `{"type":"assistant","uuid":"a3","message":{"content":[{"type":"tool_use","id":"t3","name":"Bash","input":{"command":"cd sub && entire search foo --json"}}]}}
+`
+	fixtureSubagentDispatch = `{"type":"assistant","uuid":"a4","message":{"content":[{"type":"tool_use","id":"t4","name":"Agent","input":{"subagent_type":"entire-search","prompt":"find prior work on retries"}}]}}
+`
+	fixtureBashGrepMention = `{"type":"assistant","uuid":"a5","message":{"content":[{"type":"tool_use","id":"t5","name":"Bash","input":{"command":"grep -rn \"entire search\" cmd/"}}]}}
+`
+	fixtureBashCommitMessage = `{"type":"assistant","uuid":"a6","message":{"content":[{"type":"tool_use","id":"t6","name":"Bash","input":{"command":"git commit -m \"mention entire search here\""}}]}}
+`
+	fixtureToolResultOutput = `{"type":"user","uuid":"u1","message":{"content":[{"type":"tool_result","tool_use_id":"t9","content":"$ entire search foo\nno results"}]}}
+`
+	fixtureAssistantTextMention = `{"type":"assistant","uuid":"a7","message":{"content":[{"type":"text","text":"You could run entire search to find that."}]}}
+`
+	fixtureWriteSkillBody = `{"type":"assistant","uuid":"a8","message":{"content":[{"type":"tool_use","id":"t8","name":"Write","input":{"file_path":".claude/agents/entire-search.md","content":"Your only history-search mechanism is the entire search --json command."}}]}}
+`
+	fixtureInvestigatePrompt = `{"type":"user","uuid":"u2","message":{"content":"Run entire search \"<phrase from the symptom>\" --json to find prior work."}}
+`
+	fixtureUnrelatedBash = `{"type":"assistant","uuid":"a9","message":{"content":[{"type":"tool_use","id":"t7","name":"Bash","input":{"command":"entire status"}}]}}
+`
+)
+
+func TestDetectSearchUsage_ClaudeCode(t *testing.T) {
 	t.Parallel()
+
+	ag, err := agent.GetByAgentType(agent.AgentTypeClaudeCode)
+	if err != nil {
+		t.Fatalf("GetByAgentType(ClaudeCode) error: %v", err)
+	}
 
 	tests := []struct {
 		name       string
 		transcript string
-		want       bool
+		want       searchProbe
 	}{
-		{"canonical form", `{"tool":"Bash","command":"entire search \"retry backoff\" --json"}`, true},
-		{"legacy checkpoint form", `{"tool":"Bash","command":"entire checkpoint search foo"}`, true},
-		{"no search", `{"tool":"Bash","command":"entire status"}`, false},
-		{"empty", "", false},
+		{"bash invocation", fixtureBashSearch, searchProbe{used: true, source: searchSourceCommand}},
+		{"checkpoint search alias", fixtureBashCheckpointSearch, searchProbe{used: true, source: searchSourceCommand}},
+		{"after a shell separator", fixtureBashChainedSearch, searchProbe{used: true, source: searchSourceCommand}},
+		{"entire-search subagent dispatch", fixtureSubagentDispatch, searchProbe{used: true, source: searchSourceSubagent}},
+
+		// The false-positive classes the substring probe could not tell apart
+		// from a real invocation. Each of these is a documented source: Entire's
+		// own search skill body, the investigate prompt, or a session reading
+		// this repository.
+		{"grep for the phrase", fixtureBashGrepMention, searchProbe{used: false, source: searchSourceNone}},
+		{"phrase inside a commit message", fixtureBashCommitMessage, searchProbe{used: false, source: searchSourceNone}},
+		{"phrase in command output", fixtureToolResultOutput, searchProbe{used: false, source: searchSourceNone}},
+		{"phrase in assistant prose", fixtureAssistantTextMention, searchProbe{used: false, source: searchSourceNone}},
+		{"scaffolded skill body being written", fixtureWriteSkillBody, searchProbe{used: false, source: searchSourceNone}},
+		{"injected investigate prompt", fixtureInvestigatePrompt, searchProbe{used: false, source: searchSourceNone}},
+
+		{"unrelated entire command", fixtureUnrelatedBash, searchProbe{used: false, source: searchSourceNone}},
+		{"phrase absent", `{"type":"assistant","uuid":"a0","message":{"content":[]}}`, searchProbe{used: false, source: searchSourceNone}},
+
+		// Not "none": seeing nothing because there is nothing to see is a
+		// different fact from having looked.
+		{"empty transcript", "", searchProbe{used: false, source: searchSourceUnsupported}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := transcriptMentionsEntireSearch([]byte(tt.transcript)); got != tt.want {
-				t.Errorf("transcriptMentionsEntireSearch(%q) = %v, want %v", tt.transcript, got, tt.want)
+			if got := detectSearchUsage(ag, []byte(tt.transcript)); got != tt.want {
+				t.Errorf("detectSearchUsage() = %+v, want %+v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestDetectSearchUsage_MixedTranscriptFindsTheInvocation guards the walk
+// itself: the accepting line must be found among rejected ones, in either
+// order, so a prefilter miss cannot masquerade as "did not search".
+func TestDetectSearchUsage_MixedTranscriptFindsTheInvocation(t *testing.T) {
+	t.Parallel()
+
+	ag, err := agent.GetByAgentType(agent.AgentTypeClaudeCode)
+	if err != nil {
+		t.Fatalf("GetByAgentType(ClaudeCode) error: %v", err)
+	}
+	noise := fixtureToolResultOutput + fixtureAssistantTextMention + fixtureWriteSkillBody
+	for _, tt := range []struct {
+		name       string
+		transcript string
+	}{
+		{"invocation last", noise + fixtureBashSearch},
+		{"invocation first", fixtureBashSearch + noise},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			want := searchProbe{used: true, source: searchSourceCommand}
+			if got := detectSearchUsage(ag, []byte(tt.transcript)); got != want {
+				t.Errorf("detectSearchUsage() = %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+// TestDetectSearchUsage_UnprobeableAgentsReportUnsupported is the test that
+// keeps the metric honest, and it is the case the review finding's suggested
+// fix would have gotten wrong. These agents are fed a transcript that DOES
+// contain a real invocation: reporting used=false with source=none would be a
+// fabricated data point indistinguishable in aggregate from a real miss.
+//
+// Cursor is not merely unimplemented — its transcripts carry no tool_use blocks
+// at all, so it can never be probed this way.
+func TestDetectSearchUsage_UnprobeableAgentsReportUnsupported(t *testing.T) {
+	t.Parallel()
+
+	for _, agentType := range []types.AgentType{agent.AgentTypeCursor, agent.AgentTypePi, agent.AgentTypeCopilotCLI} {
+		t.Run(string(agentType), func(t *testing.T) {
+			t.Parallel()
+			ag, err := agent.GetByAgentType(agentType)
+			if err != nil {
+				t.Fatalf("GetByAgentType(%s) error: %v", agentType, err)
+			}
+			want := searchProbe{used: false, source: searchSourceUnsupported}
+			if got := detectSearchUsage(ag, []byte(fixtureBashSearch)); got != want {
+				t.Errorf("detectSearchUsage(%s) = %+v, want %+v", agentType, got, want)
+			}
+		})
+	}
+}
+
+func TestDetectSearchUsage_NilAgentReportsUnsupported(t *testing.T) {
+	t.Parallel()
+	want := searchProbe{used: false, source: searchSourceUnsupported}
+	if got := detectSearchUsage(nil, []byte(fixtureBashSearch)); got != want {
+		t.Errorf("detectSearchUsage(nil) = %+v, want %+v", got, want)
+	}
+}
+
+// TestSearchHintsCoverPattern pins the contract that makes the scanner's byte
+// prefilter a performance filter rather than a correctness one: every string
+// the matchers accept must contain one of the hints literally. Loosen the
+// pattern's internal spacing to \s+ and this fails — which is the point, since
+// the failure mode is otherwise a silent false negative.
+func TestSearchHintsCoverPattern(t *testing.T) {
+	t.Parallel()
+
+	accepted := []string{
+		"entire search foo",
+		"entire checkpoint search foo",
+		"cd sub && entire search foo",
+		"ENTIRE_X=1 entire search foo",
+		"/usr/local/bin/entire search foo",
+		"echo hi; entire search foo",
+		"$(entire search foo)",
+	}
+	for _, cmd := range accepted {
+		if !entireSearchCommandPattern.MatchString(cmd) {
+			t.Errorf("entireSearchCommandPattern must accept %q", cmd)
+			continue
+		}
+		if !hintedBySearchHints(cmd) {
+			t.Errorf("accepted command %q contains no entireSearchHints literal; the scanner would never parse its line", cmd)
+		}
+	}
+	if !hintedBySearchHints(entireSearchSubagent) {
+		t.Errorf("subagent name %q contains no entireSearchHints literal", entireSearchSubagent)
+	}
+
+	rejected := []string{
+		"grep -rn \"entire search\" cmd/",
+		"git commit -m \"mention entire search here\"",
+		"entire status",
+		"entire searchfoo",
+	}
+	for _, cmd := range rejected {
+		if entireSearchCommandPattern.MatchString(cmd) {
+			t.Errorf("entireSearchCommandPattern must reject %q", cmd)
+		}
+	}
+}
+
+func hintedBySearchHints(s string) bool {
+	for _, hint := range entireSearchHints {
+		if bytes.Contains([]byte(s), hint) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNewCommitCondensedSignal_CarriesSearchProbe(t *testing.T) {
+	t.Parallel()
+
+	probe := searchProbe{used: true, source: searchSourceSubagent}
+	sig := newCommitCondensedSignal(
+		&SessionState{AgentType: agent.AgentTypeClaudeCode},
+		&CondenseResult{SearchProbe: probe, FilesTouched: []string{"a.go"}},
+	)
+	if sig == nil {
+		t.Fatal("newCommitCondensedSignal returned nil")
+	}
+	if sig.searchProbe != probe {
+		t.Errorf("searchProbe = %+v, want %+v", sig.searchProbe, probe)
 	}
 }
 

--- a/cmd/entire/cli/strategy/telemetry_signals_test.go
+++ b/cmd/entire/cli/strategy/telemetry_signals_test.go
@@ -42,6 +42,11 @@ const (
 `
 	fixtureUnrelatedBash = `{"type":"assistant","uuid":"a9","message":{"content":[{"type":"tool_use","id":"t7","name":"Bash","input":{"command":"entire status"}}]}}
 `
+	// A non-assistant envelope whose message decodes into tool_use-shaped
+	// content. Only assistant envelopes carry live tool calls; the walker must
+	// apply the same gate as the package's other tool_use consumers.
+	fixtureNonAssistantToolUse = `{"type":"summary","uuid":"s1","message":{"content":[{"type":"tool_use","id":"tx","name":"Bash","input":{"command":"entire search foo"}}]}}
+`
 )
 
 func TestDetectSearchUsage_ClaudeCode(t *testing.T) {
@@ -74,6 +79,7 @@ func TestDetectSearchUsage_ClaudeCode(t *testing.T) {
 		{"injected investigate prompt", fixtureInvestigatePrompt, searchProbe{used: false, source: searchSourceNone}},
 
 		{"unrelated entire command", fixtureUnrelatedBash, searchProbe{used: false, source: searchSourceNone}},
+		{"tool_use outside an assistant envelope", fixtureNonAssistantToolUse, searchProbe{used: false, source: searchSourceNone}},
 		{"phrase absent", `{"type":"assistant","uuid":"a0","message":{"content":[]}}`, searchProbe{used: false, source: searchSourceNone}},
 
 		// Not "none": seeing nothing because there is nothing to see is a
@@ -296,6 +302,17 @@ func hasFile(files map[string]struct{}, name string) bool {
 	return ok
 }
 
+// probeOrFail runs priorAICommitFiles and fails the test if the probe itself
+// could not run — these tests assert the measured result, not measurability.
+func probeOrFail(t *testing.T, repoRoot, commit string) map[string]struct{} {
+	t.Helper()
+	files, ok := priorAICommitFiles(t.Context(), repoRoot, commit)
+	if !ok {
+		t.Fatal("priorAICommitFiles reported the probe could not run")
+	}
+	return files
+}
+
 func TestPriorAICommitFiles(t *testing.T) {
 	t.Parallel()
 
@@ -319,7 +336,7 @@ func TestPriorAICommitFiles(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	files := priorAICommitFiles(t.Context(), tmpDir, "HEAD")
+	files := probeOrFail(t, tmpDir, "HEAD")
 
 	if !hasFile(files, "ai.txt") {
 		t.Error("ai.txt was touched by a prior checkpoint commit; want present")
@@ -330,8 +347,8 @@ func TestPriorAICommitFiles(t *testing.T) {
 	if hasFile(files, "head.txt") {
 		t.Error("head.txt was only touched by the just-created HEAD commit; want absent")
 	}
-	if got := priorAICommitFiles(t.Context(), t.TempDir(), "HEAD"); got != nil {
-		t.Errorf("not a git repository; want best-effort nil, got %v", got)
+	if files, ok := priorAICommitFiles(t.Context(), t.TempDir(), "HEAD"); ok {
+		t.Errorf("not a git repository; the probe must report itself unmeasured, got ok=true with %v", files)
 	}
 }
 
@@ -375,7 +392,7 @@ func TestPriorAICommitFiles_AnchorsOnExplicitCommit(t *testing.T) {
 	t.Setenv("GIT_DIR", filepath.Join(otherRepo, ".git"))
 	t.Setenv("GIT_WORK_TREE", otherRepo)
 
-	files := priorAICommitFiles(t.Context(), tmpDir, reported)
+	files := probeOrFail(t, tmpDir, reported)
 	if !hasFile(files, "ai.txt") {
 		t.Error("ai.txt precedes the reported commit and carries a trailer; want present")
 	}
@@ -406,7 +423,7 @@ func TestPriorAICommitFiles_NonASCIIPath(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	if !hasFile(priorAICommitFiles(t.Context(), tmpDir, "HEAD"), "café.go") {
+	if !hasFile(probeOrFail(t, tmpDir, "HEAD"), "café.go") {
 		t.Error("café.go was touched by a prior checkpoint commit; want present")
 	}
 }
@@ -435,7 +452,7 @@ func TestPriorAICommitFiles_ControlCharsInBody(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	if !hasFile(priorAICommitFiles(t.Context(), tmpDir, "HEAD"), "hostile.txt") {
+	if !hasFile(probeOrFail(t, tmpDir, "HEAD"), "hostile.txt") {
 		t.Error("a commit body containing \\x1e/\\x1f must not hide its checkpoint trailer")
 	}
 }
@@ -463,7 +480,7 @@ func TestPriorAICommitFiles_EmptyMessageCommit(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	files := priorAICommitFiles(t.Context(), tmpDir, "HEAD")
+	files := probeOrFail(t, tmpDir, "HEAD")
 	if !hasFile(files, "ai.txt") {
 		t.Error("an empty-message commit must not mis-frame the records after it")
 	}
@@ -503,10 +520,86 @@ func TestPriorAICommitFiles_MergeCommitContributesNothing(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	if hasFile(priorAICommitFiles(t.Context(), tmpDir, "HEAD"), "side.txt") {
+	if hasFile(probeOrFail(t, tmpDir, "HEAD"), "side.txt") {
 		t.Error("a merge commit must contribute no files: its content is already " +
 			"attributed to the commits it brings in, and first-parent diffs would " +
 			"inflate prior_ai_history")
+	}
+}
+
+// TestCommitCondensedEmitter_ProbeFailureOmitsPriorAIHistory pins the
+// unmeasured half of prior_ai_history: when the git-log probe cannot run,
+// the payload omits the property (nil) instead of fabricating a measured
+// false — the same treatment used_search gets, applied to the other half of
+// the same ratio. A commit that landed no files, by contrast, is a measured
+// false and never even probes.
+func TestCommitCondensedEmitter_ProbeFailureOmitsPriorAIHistory(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+
+	var got []telemetry.CommitCondensedSignal
+	restore := emitCommitCondensed
+	emitCommitCondensed = func(sig telemetry.CommitCondensedSignal, _ bool, _ string) { got = append(got, sig) }
+	t.Cleanup(func() { emitCommitCondensed = restore })
+
+	probeCalls := 0
+	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
+	e.probeFn = func(context.Context, string, string) (map[string]struct{}, bool) {
+		probeCalls++
+		return nil, false // the probe itself failed
+	}
+
+	e.emit(t.Context(), &commitCondensedSignal{
+		agentType:    agent.AgentTypeClaudeCode,
+		searchProbe:  searchProbe{used: false, source: searchSourceNone},
+		filesTouched: []string{"a.go"},
+	})
+	e.emit(t.Context(), &commitCondensedSignal{
+		agentType:   agent.AgentTypeClaudeCode,
+		searchProbe: searchProbe{used: false, source: searchSourceNone},
+		// No files: measured false, no probe needed.
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("sent %d events, want 2 — a failed probe withholds the property, not the event", len(got))
+	}
+	if got[0].PriorAIHistory != nil {
+		t.Errorf("PriorAIHistory = %v, want nil when the probe could not run", *got[0].PriorAIHistory)
+	}
+	if got[1].PriorAIHistory == nil || *got[1].PriorAIHistory {
+		t.Errorf("PriorAIHistory = %v, want measured false for a commit that landed no files", got[1].PriorAIHistory)
+	}
+	if probeCalls != 1 {
+		t.Errorf("probe ran %d times, want 1 — the failure is memoized and the no-files session never probes", probeCalls)
+	}
+}
+
+// TestNewCommitCondensedSignal_DedupesAmendRecondensation pins the at-most-once
+// ledger: `git commit --amend` re-runs PostCommit with the same trailer
+// checkpoint ID and an ACTIVE session re-condenses unconditionally, so without
+// the ledger one logical commit is emitted (and counted) twice.
+func TestNewCommitCondensedSignal_DedupesAmendRecondensation(t *testing.T) {
+	t.Parallel()
+
+	state := &SessionState{AgentType: agent.AgentTypeClaudeCode}
+	committed := map[string]struct{}{"a.go": {}}
+	result := &CondenseResult{
+		CheckpointID: id.MustCheckpointID("abcdef123456"),
+		FilesTouched: []string{"a.go"},
+	}
+
+	if sig := newCommitCondensedSignal(state, result, committed); sig == nil {
+		t.Fatal("first condensation of a checkpoint must produce a signal")
+	}
+	if sig := newCommitCondensedSignal(state, result, committed); sig != nil {
+		t.Error("re-condensing the same checkpoint (amend) must not produce a second signal")
+	}
+
+	next := &CondenseResult{
+		CheckpointID: id.MustCheckpointID("fedcba654321"),
+		FilesTouched: []string{"a.go"},
+	}
+	if sig := newCommitCondensedSignal(state, next, committed); sig == nil {
+		t.Error("a new checkpoint ID is a new commit and must produce a signal")
 	}
 }
 
@@ -545,9 +638,9 @@ func TestCommitCondensedEmitter_ProbesAndGatesOnce(t *testing.T) {
 	t.Cleanup(func() { emitCommitCondensed = restore })
 
 	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
-	e.probeFn = func(context.Context, string, string) map[string]struct{} {
+	e.probeFn = func(context.Context, string, string) (map[string]struct{}, bool) {
 		probeCalls++
-		return map[string]struct{}{"shared.go": {}}
+		return map[string]struct{}{"shared.go": {}}, true
 	}
 
 	for _, files := range [][]string{{"shared.go"}, {"other.go"}, {"shared.go", "other.go"}} {
@@ -573,9 +666,9 @@ func TestCommitCondensedEmitter_NilSignalCostsNothing(t *testing.T) {
 
 	probeCalls := 0
 	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
-	e.probeFn = func(context.Context, string, string) map[string]struct{} {
+	e.probeFn = func(context.Context, string, string) (map[string]struct{}, bool) {
 		probeCalls++
-		return nil
+		return nil, true
 	}
 	e.emit(t.Context(), nil)
 
@@ -607,9 +700,9 @@ func TestCommitCondensedEmitter_OptedOutNeverProbes(t *testing.T) {
 			t.Cleanup(func() { emitCommitCondensed = restore })
 
 			e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
-			e.probeFn = func(context.Context, string, string) map[string]struct{} {
+			e.probeFn = func(context.Context, string, string) (map[string]struct{}, bool) {
 				probeCalls++
-				return nil
+				return nil, true
 			}
 			e.emit(t.Context(), &commitCondensedSignal{
 				agentType:    agent.AgentTypeClaudeCode,
@@ -637,7 +730,7 @@ func TestCommitCondensedEmitter_OmitsUsedSearchWhenUnsupported(t *testing.T) {
 	t.Cleanup(func() { emitCommitCondensed = restore })
 
 	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
-	e.probeFn = func(context.Context, string, string) map[string]struct{} { return nil }
+	e.probeFn = func(context.Context, string, string) (map[string]struct{}, bool) { return nil, true }
 	e.emit(t.Context(), &commitCondensedSignal{
 		agentType:    agent.AgentTypeClaudeCode,
 		searchProbe:  searchProbe{used: false, source: searchSourceUnsupported},
@@ -703,7 +796,7 @@ func TestCommitCondensedEmitter_ZeroProbeOmitsUsedSearch(t *testing.T) {
 	t.Cleanup(func() { emitCommitCondensed = restore })
 
 	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
-	e.probeFn = func(context.Context, string, string) map[string]struct{} { return nil }
+	e.probeFn = func(context.Context, string, string) (map[string]struct{}, bool) { return nil, true }
 	// searchProbe left at its zero value, as a no-transcript condensation
 	// produced before the probe was made unconditional.
 	e.emit(t.Context(), &commitCondensedSignal{

--- a/cmd/entire/cli/strategy/telemetry_signals_test.go
+++ b/cmd/entire/cli/strategy/telemetry_signals_test.go
@@ -1,0 +1,74 @@
+package strategy
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+)
+
+func TestTranscriptMentionsEntireSearch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		transcript string
+		want       bool
+	}{
+		{"canonical form", `{"tool":"Bash","command":"entire search \"retry backoff\" --json"}`, true},
+		{"legacy checkpoint form", `{"tool":"Bash","command":"entire checkpoint search foo"}`, true},
+		{"no search", `{"tool":"Bash","command":"entire status"}`, false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := transcriptMentionsEntireSearch([]byte(tt.transcript)); got != tt.want {
+				t.Errorf("transcriptMentionsEntireSearch(%q) = %v, want %v", tt.transcript, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPriorAICommitTouchedFiles(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+
+	// Commit 1: an AI checkpoint commit touching ai.txt.
+	testutil.WriteFile(t, tmpDir, "ai.txt", "ai content")
+	testutil.GitAdd(t, tmpDir, "ai.txt")
+	cpID := id.MustCheckpointID("abcdef123456")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("ai change", cpID))
+
+	// Commit 2: a plain human commit touching human.txt.
+	testutil.WriteFile(t, tmpDir, "human.txt", "human content")
+	testutil.GitAdd(t, tmpDir, "human.txt")
+	testutil.GitCommit(t, tmpDir, "human change")
+
+	// Commit 3: HEAD — the commit that was "just created"; --skip=1 must
+	// exclude it, so its files never count as prior history.
+	testutil.WriteFile(t, tmpDir, "head.txt", "head content")
+	testutil.GitAdd(t, tmpDir, "head.txt")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
+
+	ctx := t.Context()
+
+	if !priorAICommitTouchedFiles(ctx, tmpDir, []string{"ai.txt"}) {
+		t.Error("ai.txt was touched by a prior checkpoint commit; want true")
+	}
+	if priorAICommitTouchedFiles(ctx, tmpDir, []string{"human.txt"}) {
+		t.Error("human.txt was only touched by a human commit; want false")
+	}
+	if priorAICommitTouchedFiles(ctx, tmpDir, []string{"head.txt"}) {
+		t.Error("head.txt was only touched by the just-created HEAD commit; want false")
+	}
+	if priorAICommitTouchedFiles(ctx, tmpDir, nil) {
+		t.Error("no committed files; want false")
+	}
+	if priorAICommitTouchedFiles(ctx, t.TempDir(), []string{"ai.txt"}) {
+		t.Error("not a git repository; want best-effort false")
+	}
+}

--- a/cmd/entire/cli/strategy/telemetry_signals_test.go
+++ b/cmd/entire/cli/strategy/telemetry_signals_test.go
@@ -180,6 +180,17 @@ func TestSearchHintsCoverPattern(t *testing.T) {
 	if !hintedBySearchHints(entireSearchSubagent) {
 		t.Errorf("subagent name %q contains no entireSearchHints literal", entireSearchSubagent)
 	}
+	// The prefilter is case-sensitive bytes.Contains, so the subagent matcher
+	// must be case-sensitive too. A case-insensitive matcher would accept
+	// spellings the prefilter discards before the line is ever parsed.
+	for _, variant := range []string{"Entire-Search", "ENTIRE-SEARCH", "Entire-search"} {
+		if hintedBySearchHints(variant) {
+			t.Errorf("hint list unexpectedly covers %q; the case-sensitivity test below is moot", variant)
+		}
+		if strings.TrimSpace(variant) == entireSearchSubagent {
+			t.Errorf("subagent matcher accepts %q, which the case-sensitive hint prefilter would discard first", variant)
+		}
+	}
 
 	rejected := []string{
 		"grep -rn \"entire search\" cmd/",

--- a/cmd/entire/cli/strategy/telemetry_signals_test.go
+++ b/cmd/entire/cli/strategy/telemetry_signals_test.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"bytes"
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -123,8 +124,10 @@ func TestDetectSearchUsage_MixedTranscriptFindsTheInvocation(t *testing.T) {
 // contain a real invocation: reporting used=false with source=none would be a
 // fabricated data point indistinguishable in aggregate from a real miss.
 //
-// Cursor is not merely unimplemented — its transcripts carry no tool_use blocks
-// at all, so it can never be probed this way.
+// These agents are unprobeable because no ToolInvocationScanner walker exists
+// for them yet — not because one is impossible. Cursor in particular shares
+// the tool_use JSONL shape and could implement one; see the interface doc in
+// agent/tool_invocations.go for what blocks it.
 func TestDetectSearchUsage_UnprobeableAgentsReportUnsupported(t *testing.T) {
 	t.Parallel()
 
@@ -167,18 +170,19 @@ func TestSearchHintsCoverPattern(t *testing.T) {
 		"/usr/local/bin/entire search foo",
 		"echo hi; entire search foo",
 		"$(entire search foo)",
+		`entire search "two words"`,
 	}
 	for _, cmd := range accepted {
-		if !entireSearchCommandPattern.MatchString(cmd) {
-			t.Errorf("entireSearchCommandPattern must accept %q", cmd)
+		if !commandInvokesEntireSearch(cmd) {
+			t.Errorf("commandInvokesEntireSearch must accept %q", cmd)
 			continue
 		}
 		if !hintedBySearchHints(cmd) {
 			t.Errorf("accepted command %q contains no entireSearchHints literal; the scanner would never parse its line", cmd)
 		}
 	}
-	if !hintedBySearchHints(entireSearchSubagent) {
-		t.Errorf("subagent name %q contains no entireSearchHints literal", entireSearchSubagent)
+	if !hintedBySearchHints(EntireSearchSubagentName) {
+		t.Errorf("subagent name %q contains no entireSearchHints literal", EntireSearchSubagentName)
 	}
 	// The prefilter is case-sensitive bytes.Contains, so the subagent matcher
 	// must be case-sensitive too. A case-insensitive matcher would accept
@@ -187,7 +191,7 @@ func TestSearchHintsCoverPattern(t *testing.T) {
 		if hintedBySearchHints(variant) {
 			t.Errorf("hint list unexpectedly covers %q; the case-sensitivity test below is moot", variant)
 		}
-		if strings.TrimSpace(variant) == entireSearchSubagent {
+		if strings.TrimSpace(variant) == EntireSearchSubagentName {
 			t.Errorf("subagent matcher accepts %q, which the case-sensitive hint prefilter would discard first", variant)
 		}
 	}
@@ -197,11 +201,35 @@ func TestSearchHintsCoverPattern(t *testing.T) {
 		"git commit -m \"mention entire search here\"",
 		"entire status",
 		"entire searchfoo",
+		// Separators inside quoted arguments are text, not command
+		// boundaries. Each of these matched before sanitization was added —
+		// the quote-blind regex read the `;`/`|`/newline inside the argument
+		// as a boundary and the phrase after it as a command.
+		`git commit -m "wip; entire search notes"`,
+		`rg "foo|entire search bar" .`,
+		"echo \"a\nentire search b\"",
+		`git commit -m 'wip; entire search notes'`,
+		// A heredoc body is data — this is an agent WRITING the search skill
+		// (whose body contains the command at line start) via cat, the
+		// scaffolded-artifact false-positive class review measured.
+		"cat > .claude/agents/entire-search.md <<'EOF'\nentire search --json \"x\"\nEOF",
+		"cat > notes.md <<DOC\nentire search --json\nDOC\necho done",
 	}
 	for _, cmd := range rejected {
-		if entireSearchCommandPattern.MatchString(cmd) {
-			t.Errorf("entireSearchCommandPattern must reject %q", cmd)
+		if commandInvokesEntireSearch(cmd) {
+			t.Errorf("commandInvokesEntireSearch must reject %q", cmd)
 		}
+	}
+
+	// The sanitizer must not eat commands AFTER a heredoc: the body ends at
+	// its delimiter line, and what follows is live shell again.
+	if !commandInvokesEntireSearch("cat > notes.md <<DOC\nsome text\nDOC\nentire search foo") {
+		t.Error("commandInvokesEntireSearch must accept an invocation on the line after a heredoc body ends")
+	}
+	// Arithmetic << must not be misread as a heredoc opener that swallows the
+	// rest of the command.
+	if !commandInvokesEntireSearch("echo $((1<<2))\nentire search foo") {
+		t.Error("commandInvokesEntireSearch must accept an invocation after arithmetic <<")
 	}
 }
 
@@ -221,12 +249,43 @@ func TestNewCommitCondensedSignal_CarriesSearchProbe(t *testing.T) {
 	sig := newCommitCondensedSignal(
 		&SessionState{AgentType: agent.AgentTypeClaudeCode},
 		&CondenseResult{SearchProbe: probe, FilesTouched: []string{"a.go"}},
+		map[string]struct{}{"a.go": {}},
 	)
 	if sig == nil {
 		t.Fatal("newCommitCondensedSignal returned nil")
 	}
 	if sig.searchProbe != probe {
 		t.Errorf("searchProbe = %+v, want %+v", sig.searchProbe, probe)
+	}
+	if len(sig.filesTouched) != 1 || sig.filesTouched[0] != "a.go" {
+		t.Errorf("filesTouched = %v, want [a.go]", sig.filesTouched)
+	}
+}
+
+// TestNewCommitCondensedSignal_ScopesFilesToCommit pins the payload's
+// commit-scoping against the one upstream path that deliberately does not
+// narrow: filterFilesTouched leaves the session's whole FilesTouched list when
+// the commit changed no files (--allow-empty, or file detection failing).
+// files_committed and the prior_ai_history intersection must never count files
+// the commit did not land.
+func TestNewCommitCondensedSignal_ScopesFilesToCommit(t *testing.T) {
+	t.Parallel()
+
+	state := &SessionState{AgentType: agent.AgentTypeClaudeCode}
+	result := &CondenseResult{FilesTouched: []string{"a.go", "b.go", "c.go"}}
+
+	if sig := newCommitCondensedSignal(state, result, nil); sig == nil {
+		t.Fatal("newCommitCondensedSignal returned nil")
+	} else if len(sig.filesTouched) != 0 {
+		t.Errorf("empty commit: filesTouched = %v, want none — the commit landed no files", sig.filesTouched)
+	}
+
+	sig := newCommitCondensedSignal(state, result, map[string]struct{}{"b.go": {}, "unrelated.go": {}})
+	if sig == nil {
+		t.Fatal("newCommitCondensedSignal returned nil")
+	}
+	if len(sig.filesTouched) != 1 || sig.filesTouched[0] != "b.go" {
+		t.Errorf("filesTouched = %v, want [b.go]", sig.filesTouched)
 	}
 }
 
@@ -260,7 +319,7 @@ func TestPriorAICommitFiles(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	files := priorAICommitFiles(t.Context(), tmpDir)
+	files := priorAICommitFiles(t.Context(), tmpDir, "HEAD")
 
 	if !hasFile(files, "ai.txt") {
 		t.Error("ai.txt was touched by a prior checkpoint commit; want present")
@@ -271,8 +330,60 @@ func TestPriorAICommitFiles(t *testing.T) {
 	if hasFile(files, "head.txt") {
 		t.Error("head.txt was only touched by the just-created HEAD commit; want absent")
 	}
-	if got := priorAICommitFiles(t.Context(), t.TempDir()); got != nil {
+	if got := priorAICommitFiles(t.Context(), t.TempDir(), "HEAD"); got != nil {
 		t.Errorf("not a git repository; want best-effort nil, got %v", got)
+	}
+}
+
+// TestPriorAICommitFiles_AnchorsOnExplicitCommit pins the two properties that
+// keep the probe describing the commit PostCommit is reporting on rather than
+// whatever the process environment says HEAD is:
+//   - the walk starts at the explicit hash, so a HEAD that moved between the
+//     commit and the (post-gate) probe changes nothing;
+//   - GIT_DIR/GIT_WORK_TREE exported to hooks are scrubbed, so -C selects the
+//     repo — an inherited GIT_DIR would override it and walk another repo.
+func TestPriorAICommitFiles_AnchorsOnExplicitCommit(t *testing.T) {
+	// t.Setenv forbids t.Parallel.
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+
+	testutil.WriteFile(t, tmpDir, "ai.txt", "ai content")
+	testutil.GitAdd(t, tmpDir, "ai.txt")
+	cpID := id.MustCheckpointID("abcdef123456")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("ai change", cpID))
+
+	// The commit being reported on.
+	testutil.WriteFile(t, tmpDir, "reported.txt", "reported")
+	testutil.GitAdd(t, tmpDir, "reported.txt")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("reported change", cpID))
+	reported := strings.TrimSpace(testutil.RunGit(t, tmpDir, "rev-parse", "HEAD"))
+
+	// HEAD moves on before the probe runs (it fires after the session gate
+	// releases): a later checkpoint commit that must count neither itself nor
+	// shift --skip=1 onto the wrong commit.
+	testutil.WriteFile(t, tmpDir, "later.txt", "later")
+	testutil.GitAdd(t, tmpDir, "later.txt")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("later change", cpID))
+
+	// A hook environment pointing git somewhere else entirely; the scrub must
+	// keep -C authoritative.
+	otherRepo := t.TempDir()
+	testutil.InitRepo(t, otherRepo)
+	testutil.WriteFile(t, otherRepo, "other.txt", "other")
+	testutil.GitAdd(t, otherRepo, "other.txt")
+	testutil.GitCommit(t, otherRepo, "other")
+	t.Setenv("GIT_DIR", filepath.Join(otherRepo, ".git"))
+	t.Setenv("GIT_WORK_TREE", otherRepo)
+
+	files := priorAICommitFiles(t.Context(), tmpDir, reported)
+	if !hasFile(files, "ai.txt") {
+		t.Error("ai.txt precedes the reported commit and carries a trailer; want present")
+	}
+	if hasFile(files, "reported.txt") {
+		t.Error("the reported commit is not its own prior history; want absent")
+	}
+	if hasFile(files, "later.txt") {
+		t.Error("a commit made after the reported one (HEAD moved on) must not count; want absent")
 	}
 }
 
@@ -295,7 +406,7 @@ func TestPriorAICommitFiles_NonASCIIPath(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	if !hasFile(priorAICommitFiles(t.Context(), tmpDir), "café.go") {
+	if !hasFile(priorAICommitFiles(t.Context(), tmpDir, "HEAD"), "café.go") {
 		t.Error("café.go was touched by a prior checkpoint commit; want present")
 	}
 }
@@ -324,7 +435,7 @@ func TestPriorAICommitFiles_ControlCharsInBody(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	if !hasFile(priorAICommitFiles(t.Context(), tmpDir), "hostile.txt") {
+	if !hasFile(priorAICommitFiles(t.Context(), tmpDir, "HEAD"), "hostile.txt") {
 		t.Error("a commit body containing \\x1e/\\x1f must not hide its checkpoint trailer")
 	}
 }
@@ -352,7 +463,7 @@ func TestPriorAICommitFiles_EmptyMessageCommit(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	files := priorAICommitFiles(t.Context(), tmpDir)
+	files := priorAICommitFiles(t.Context(), tmpDir, "HEAD")
 	if !hasFile(files, "ai.txt") {
 		t.Error("an empty-message commit must not mis-frame the records after it")
 	}
@@ -392,10 +503,35 @@ func TestPriorAICommitFiles_MergeCommitContributesNothing(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	if hasFile(priorAICommitFiles(t.Context(), tmpDir), "side.txt") {
+	if hasFile(priorAICommitFiles(t.Context(), tmpDir, "HEAD"), "side.txt") {
 		t.Error("a merge commit must contribute no files: its content is already " +
 			"attributed to the commits it brings in, and first-parent diffs would " +
 			"inflate prior_ai_history")
+	}
+}
+
+// TestCommitCondensedEmitter_SearchProbeGate pins the gate condensation
+// consults before scanning a transcript: open only when telemetry is opted in,
+// closed for disabled settings and for a nil emitter (the ungated condensation
+// paths). This is what keeps the full-transcript search probe off every path
+// whose result would be discarded.
+func TestCommitCondensedEmitter_SearchProbeGate(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
+	if !e.searchProbeAllowed(t.Context()) {
+		t.Error("gate must open when telemetry is enabled")
+	}
+}
+
+func TestCommitCondensedEmitter_SearchProbeGateClosed(t *testing.T) {
+	writeTelemetrySettings(t, "false")
+	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
+	if e.searchProbeAllowed(t.Context()) {
+		t.Error("gate must stay closed when telemetry is disabled")
+	}
+	var nilEmitter *commitCondensedEmitter
+	if nilEmitter.searchProbeAllowed(t.Context()) {
+		t.Error("a nil emitter must report the gate closed")
 	}
 }
 
@@ -408,8 +544,8 @@ func TestCommitCondensedEmitter_ProbesAndGatesOnce(t *testing.T) {
 	emitCommitCondensed = func(telemetry.CommitCondensedSignal, bool, string) { sends++ }
 	t.Cleanup(func() { emitCommitCondensed = restore })
 
-	e := newCommitCondensedEmitter(t.TempDir())
-	e.probeFn = func(context.Context, string) map[string]struct{} {
+	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
+	e.probeFn = func(context.Context, string, string) map[string]struct{} {
 		probeCalls++
 		return map[string]struct{}{"shared.go": {}}
 	}
@@ -436,8 +572,8 @@ func TestCommitCondensedEmitter_NilSignalCostsNothing(t *testing.T) {
 	t.Parallel()
 
 	probeCalls := 0
-	e := newCommitCondensedEmitter(t.TempDir())
-	e.probeFn = func(context.Context, string) map[string]struct{} {
+	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
+	e.probeFn = func(context.Context, string, string) map[string]struct{} {
 		probeCalls++
 		return nil
 	}
@@ -470,8 +606,8 @@ func TestCommitCondensedEmitter_OptedOutNeverProbes(t *testing.T) {
 			emitCommitCondensed = func(telemetry.CommitCondensedSignal, bool, string) { sends++ }
 			t.Cleanup(func() { emitCommitCondensed = restore })
 
-			e := newCommitCondensedEmitter(t.TempDir())
-			e.probeFn = func(context.Context, string) map[string]struct{} {
+			e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
+			e.probeFn = func(context.Context, string, string) map[string]struct{} {
 				probeCalls++
 				return nil
 			}
@@ -500,8 +636,8 @@ func TestCommitCondensedEmitter_OmitsUsedSearchWhenUnsupported(t *testing.T) {
 	emitCommitCondensed = func(sig telemetry.CommitCondensedSignal, _ bool, _ string) { got = sig }
 	t.Cleanup(func() { emitCommitCondensed = restore })
 
-	e := newCommitCondensedEmitter(t.TempDir())
-	e.probeFn = func(context.Context, string) map[string]struct{} { return nil }
+	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
+	e.probeFn = func(context.Context, string, string) map[string]struct{} { return nil }
 	e.emit(t.Context(), &commitCondensedSignal{
 		agentType:    agent.AgentTypeClaudeCode,
 		searchProbe:  searchProbe{used: false, source: searchSourceUnsupported},
@@ -566,8 +702,8 @@ func TestCommitCondensedEmitter_ZeroProbeOmitsUsedSearch(t *testing.T) {
 	emitCommitCondensed = func(sig telemetry.CommitCondensedSignal, _ bool, _ string) { got = sig }
 	t.Cleanup(func() { emitCommitCondensed = restore })
 
-	e := newCommitCondensedEmitter(t.TempDir())
-	e.probeFn = func(context.Context, string) map[string]struct{} { return nil }
+	e := newCommitCondensedEmitter(t.TempDir(), "HEAD")
+	e.probeFn = func(context.Context, string, string) map[string]struct{} { return nil }
 	// searchProbe left at its zero value, as a no-transcript condensation
 	// produced before the probe was made unconditional.
 	e.emit(t.Context(), &commitCondensedSignal{

--- a/cmd/entire/cli/strategy/telemetry_signals_test.go
+++ b/cmd/entire/cli/strategy/telemetry_signals_test.go
@@ -2,12 +2,15 @@ package strategy
 
 import (
 	"bytes"
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 )
@@ -216,7 +219,14 @@ func TestNewCommitCondensedSignal_CarriesSearchProbe(t *testing.T) {
 	}
 }
 
-func TestPriorAICommitTouchedFiles(t *testing.T) {
+// hasFile is the intersection the emitter performs per session, spelled out so
+// the set-returning probe can be asserted directly.
+func hasFile(files map[string]struct{}, name string) bool {
+	_, ok := files[name]
+	return ok
+}
+
+func TestPriorAICommitFiles(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -239,26 +249,23 @@ func TestPriorAICommitTouchedFiles(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	ctx := t.Context()
+	files := priorAICommitFiles(t.Context(), tmpDir)
 
-	if !priorAICommitTouchedFiles(ctx, tmpDir, []string{"ai.txt"}) {
-		t.Error("ai.txt was touched by a prior checkpoint commit; want true")
+	if !hasFile(files, "ai.txt") {
+		t.Error("ai.txt was touched by a prior checkpoint commit; want present")
 	}
-	if priorAICommitTouchedFiles(ctx, tmpDir, []string{"human.txt"}) {
-		t.Error("human.txt was only touched by a human commit; want false")
+	if hasFile(files, "human.txt") {
+		t.Error("human.txt was only touched by a human commit; want absent")
 	}
-	if priorAICommitTouchedFiles(ctx, tmpDir, []string{"head.txt"}) {
-		t.Error("head.txt was only touched by the just-created HEAD commit; want false")
+	if hasFile(files, "head.txt") {
+		t.Error("head.txt was only touched by the just-created HEAD commit; want absent")
 	}
-	if priorAICommitTouchedFiles(ctx, tmpDir, nil) {
-		t.Error("no committed files; want false")
-	}
-	if priorAICommitTouchedFiles(ctx, t.TempDir(), []string{"ai.txt"}) {
-		t.Error("not a git repository; want best-effort false")
+	if got := priorAICommitFiles(t.Context(), t.TempDir()); got != nil {
+		t.Errorf("not a git repository; want best-effort nil, got %v", got)
 	}
 }
 
-func TestPriorAICommitTouchedFiles_NonASCIIPath(t *testing.T) {
+func TestPriorAICommitFiles_NonASCIIPath(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -277,7 +284,223 @@ func TestPriorAICommitTouchedFiles_NonASCIIPath(t *testing.T) {
 	testutil.GitAdd(t, tmpDir, "head.txt")
 	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
 
-	if !priorAICommitTouchedFiles(t.Context(), tmpDir, []string{"café.go"}) {
-		t.Error("café.go was touched by a prior checkpoint commit; want true")
+	if !hasFile(priorAICommitFiles(t.Context(), tmpDir), "café.go") {
+		t.Error("café.go was touched by a prior checkpoint commit; want present")
+	}
+}
+
+// TestPriorAICommitFiles_ControlCharsInBody is the regression test for the
+// %x1e/%x1f framing: those delimiters came out of the raw %B, so either
+// character in a commit body split a record early and dropped the real
+// Entire-Checkpoint trailer with it — making prior_ai_history read false and
+// suppressing a genuine miss. The NUL-anchored framing cannot be broken by
+// message content, because a commit message cannot contain NUL.
+func TestPriorAICommitFiles_ControlCharsInBody(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+
+	testutil.WriteFile(t, tmpDir, "hostile.txt", "content")
+	testutil.GitAdd(t, tmpDir, "hostile.txt")
+	cpID := id.MustCheckpointID("abcdef123456")
+	// Both delimiters, plus a trailer-lookalike line placed before the real
+	// trailer, so an early split would look plausible rather than empty.
+	body := "subject\n\nbody with \x1e and \x1f inside\nEntire-Checkpoint: not-an-id\n"
+	testutil.GitCommit(t, tmpDir, body+"\n"+trailers.FormatCheckpoint("", cpID))
+
+	testutil.WriteFile(t, tmpDir, "head.txt", "head content")
+	testutil.GitAdd(t, tmpDir, "head.txt")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
+
+	if !hasFile(priorAICommitFiles(t.Context(), tmpDir), "hostile.txt") {
+		t.Error("a commit body containing \\x1e/\\x1f must not hide its checkpoint trailer")
+	}
+}
+
+// TestPriorAICommitFiles_EmptyMessageCommit pins why the format carries %H: an
+// empty body would otherwise put two adjacent empty fields in the output and
+// mis-frame the following record.
+func TestPriorAICommitFiles_EmptyMessageCommit(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+
+	testutil.WriteFile(t, tmpDir, "ai.txt", "ai content")
+	testutil.GitAdd(t, tmpDir, "ai.txt")
+	cpID := id.MustCheckpointID("abcdef123456")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("ai change", cpID))
+
+	// An empty-message commit between the checkpoint commit and HEAD.
+	testutil.WriteFile(t, tmpDir, "empty.txt", "empty")
+	testutil.GitAdd(t, tmpDir, "empty.txt")
+	testutil.GitCommit(t, tmpDir, "")
+
+	testutil.WriteFile(t, tmpDir, "head.txt", "head content")
+	testutil.GitAdd(t, tmpDir, "head.txt")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
+
+	files := priorAICommitFiles(t.Context(), tmpDir)
+	if !hasFile(files, "ai.txt") {
+		t.Error("an empty-message commit must not mis-frame the records after it")
+	}
+	if hasFile(files, "empty.txt") {
+		t.Error("the empty-message commit carries no trailer; want absent")
+	}
+}
+
+// TestPriorAICommitFiles_MergeCommitContributesNothing pins the deliberate
+// decision documented on priorAICommitFiles, so a future "fix" has to argue
+// with a test rather than silently inflate prior_ai_history.
+func TestPriorAICommitFiles_MergeCommitContributesNothing(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "base.txt", "base")
+	testutil.GitAdd(t, tmpDir, "base.txt")
+	testutil.GitCommit(t, tmpDir, "base")
+
+	branch := testutil.RunGit(t, tmpDir, "rev-parse", "--abbrev-ref", "HEAD")
+	branch = strings.TrimSpace(branch)
+
+	testutil.RunGit(t, tmpDir, "checkout", "-b", "side")
+	testutil.WriteFile(t, tmpDir, "side.txt", "side")
+	testutil.GitAdd(t, tmpDir, "side.txt")
+	testutil.GitCommit(t, tmpDir, "side change")
+
+	testutil.RunGit(t, tmpDir, "checkout", branch)
+	cpID := id.MustCheckpointID("abcdef123456")
+	// A merge commit carrying a checkpoint trailer — the shape 51 of the last
+	// 300 merges on main have.
+	testutil.RunGit(t, tmpDir, "merge", "--no-ff", "-m",
+		trailers.FormatCheckpoint("merge side", cpID), "side")
+
+	testutil.WriteFile(t, tmpDir, "head.txt", "head")
+	testutil.GitAdd(t, tmpDir, "head.txt")
+	testutil.GitCommit(t, tmpDir, trailers.FormatCheckpoint("head change", cpID))
+
+	if hasFile(priorAICommitFiles(t.Context(), tmpDir), "side.txt") {
+		t.Error("a merge commit must contribute no files: its content is already " +
+			"attributed to the commits it brings in, and first-parent diffs would " +
+			"inflate prior_ai_history")
+	}
+}
+
+func TestCommitCondensedEmitter_ProbesAndGatesOnce(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+
+	probeCalls := 0
+	sends := 0
+	restore := emitCommitCondensed
+	emitCommitCondensed = func(telemetry.CommitCondensedSignal, bool, string) { sends++ }
+	t.Cleanup(func() { emitCommitCondensed = restore })
+
+	e := newCommitCondensedEmitter(t.TempDir())
+	e.probeFn = func(context.Context, string) map[string]struct{} {
+		probeCalls++
+		return map[string]struct{}{"shared.go": {}}
+	}
+
+	for _, files := range [][]string{{"shared.go"}, {"other.go"}, {"shared.go", "other.go"}} {
+		e.emit(t.Context(), &commitCondensedSignal{
+			agentType:    agent.AgentTypeClaudeCode,
+			searchProbe:  searchProbe{used: true, source: searchSourceCommand},
+			filesTouched: files,
+		})
+	}
+
+	if probeCalls != 1 {
+		t.Errorf("probe ran %d times across 3 sessions, want 1 — the scan is commit-scoped", probeCalls)
+	}
+	if sends != 3 {
+		t.Errorf("sent %d events, want 3", sends)
+	}
+}
+
+// TestCommitCondensedEmitter_NilSignalCostsNothing pins the laziness that makes
+// a commit which condenses nothing free: no settings read, no subprocess.
+func TestCommitCondensedEmitter_NilSignalCostsNothing(t *testing.T) {
+	t.Parallel()
+
+	probeCalls := 0
+	e := newCommitCondensedEmitter(t.TempDir())
+	e.probeFn = func(context.Context, string) map[string]struct{} {
+		probeCalls++
+		return nil
+	}
+	e.emit(t.Context(), nil)
+
+	if probeCalls != 0 {
+		t.Errorf("probe ran %d times for a nil signal, want 0", probeCalls)
+	}
+	if e.gateResolved {
+		t.Error("a nil signal must not resolve the telemetry gate")
+	}
+}
+
+// TestCommitCondensedEmitter_OptedOutNeverProbes keeps the doc comment's
+// promise: the gate runs in front of the probe, so an opted-out user never pays
+// for the git-log scan.
+func TestCommitCondensedEmitter_OptedOutNeverProbes(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		telemetry string
+	}{
+		{"explicit opt-out", "false"},
+		{"key absent (telemetry is opt-in)", ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			writeTelemetrySettings(t, tt.telemetry)
+
+			probeCalls, sends := 0, 0
+			restore := emitCommitCondensed
+			emitCommitCondensed = func(telemetry.CommitCondensedSignal, bool, string) { sends++ }
+			t.Cleanup(func() { emitCommitCondensed = restore })
+
+			e := newCommitCondensedEmitter(t.TempDir())
+			e.probeFn = func(context.Context, string) map[string]struct{} {
+				probeCalls++
+				return nil
+			}
+			e.emit(t.Context(), &commitCondensedSignal{
+				agentType:    agent.AgentTypeClaudeCode,
+				filesTouched: []string{"a.go"},
+			})
+
+			if probeCalls != 0 {
+				t.Errorf("probe ran %d times while opted out, want 0", probeCalls)
+			}
+			if sends != 0 {
+				t.Errorf("sent %d events while opted out, want 0", sends)
+			}
+		})
+	}
+}
+
+// TestCommitCondensedEmitter_OmitsUsedSearchWhenUnsupported pins the mapping
+// from the probe's tri-state onto the payload's nullable field.
+func TestCommitCondensedEmitter_OmitsUsedSearchWhenUnsupported(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+
+	var got telemetry.CommitCondensedSignal
+	restore := emitCommitCondensed
+	emitCommitCondensed = func(sig telemetry.CommitCondensedSignal, _ bool, _ string) { got = sig }
+	t.Cleanup(func() { emitCommitCondensed = restore })
+
+	e := newCommitCondensedEmitter(t.TempDir())
+	e.probeFn = func(context.Context, string) map[string]struct{} { return nil }
+	e.emit(t.Context(), &commitCondensedSignal{
+		agentType:    agent.AgentTypeClaudeCode,
+		searchProbe:  searchProbe{used: false, source: searchSourceUnsupported},
+		filesTouched: []string{"a.go"},
+	})
+
+	if got.UsedSearch != nil {
+		t.Errorf("UsedSearch = %v, want nil so the property is omitted", *got.UsedSearch)
+	}
+	if got.UsedSearchSource != searchSourceUnsupported {
+		t.Errorf("UsedSearchSource = %q, want %q", got.UsedSearchSource, searchSourceUnsupported)
 	}
 }

--- a/cmd/entire/cli/telemetry/checkpoint_policy.go
+++ b/cmd/entire/cli/telemetry/checkpoint_policy.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"encoding/json"
-	"os"
 	"runtime"
 	"time"
 )
@@ -72,7 +71,7 @@ func BuildCheckpointPolicyBlockedPayload(event CheckpointPolicyBlockedEvent, ver
 // responsible for the settings.Telemetry opt-in check. Honors
 // ENTIRE_TELEMETRY_OPTOUT like the other trackers.
 func TrackCheckpointPolicyBlocked(event CheckpointPolicyBlockedEvent, version string) {
-	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+	if IsEnvOptedOut() {
 		return
 	}
 

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -323,14 +323,22 @@ func TrackSkillInvocationsDetached(invocations []SkillInvocation, isEntireEnable
 	spawnDetachedAnalyticsBatch(payloads)
 }
 
-// CheckpointCondensedSignal is the content-free adoption signal emitted when a
+// CommitCondensedSignal is the content-free adoption signal emitted when a
 // commit condenses a session checkpoint: whether the session consulted entire
 // search, and whether the committed files already carried AI checkpoint
 // history. Together these give the "sessions that edited history-dense files
 // without searching" denominator that raw command counts cannot. Content-free
 // metadata only — booleans, a count, and the agent identifier; never file
 // paths, prompts, or transcript content.
-type CheckpointCondensedSignal struct {
+//
+// A commit is part of the event's identity, not an incidental trigger, which is
+// why it is named for one. Every property is commit-scoped: FilesCommitted
+// counts that commit's files, and PriorAIHistory asks whether commits *before*
+// this one already touched them. The condensation paths that run without a
+// commit (doctor repair, session-end leftovers) deliberately emit nothing —
+// see newCommitCondensedSignal for why folding them in would corrupt the
+// denominator rather than complete it.
+type CommitCondensedSignal struct {
 	// Agent is the session-owning agent's registry key (e.g. "claude-code"),
 	// matching the agent property on skill and command events.
 	Agent string
@@ -344,10 +352,10 @@ type CheckpointCondensedSignal struct {
 	FilesCommitted int
 }
 
-// BuildCheckpointCondensedPayload constructs the telemetry payload for one
+// BuildCommitCondensedPayload constructs the telemetry payload for one
 // condensed checkpoint. Exported for testing. Returns nil if the payload
 // cannot be built.
-func BuildCheckpointCondensedPayload(sig CheckpointCondensedSignal, isEntireEnabled bool, version string) *EventPayload {
+func BuildCommitCondensedPayload(sig CommitCondensedSignal, isEntireEnabled bool, version string) *EventPayload {
 	machineID, err := telemetryMachineID()
 	if err != nil {
 		return nil
@@ -372,22 +380,22 @@ func BuildCheckpointCondensedPayload(sig CheckpointCondensedSignal, isEntireEnab
 	}
 
 	return &EventPayload{
-		Event:      "cli_checkpoint_condensed",
+		Event:      "cli_commit_condensed",
 		DistinctID: machineID,
 		Properties: properties,
 		Timestamp:  time.Now(),
 	}
 }
 
-// TrackCheckpointCondensedDetached records one condensed checkpoint's adoption
+// TrackCommitCondensedDetached records one condensed checkpoint's adoption
 // signal. Like TrackPluginDetached, it only honors the env opt-out itself —
 // call sites must gate on the user's opt-in telemetry setting.
-func TrackCheckpointCondensedDetached(sig CheckpointCondensedSignal, isEntireEnabled bool, version string) {
+func TrackCommitCondensedDetached(sig CommitCondensedSignal, isEntireEnabled bool, version string) {
 	if IsEnvOptedOut() {
 		return
 	}
 
-	payload := BuildCheckpointCondensedPayload(sig, isEntireEnabled, version)
+	payload := BuildCommitCondensedPayload(sig, isEntireEnabled, version)
 	if payload == nil {
 		return
 	}

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -332,11 +332,14 @@ func TrackSkillInvocationsDetached(invocations []SkillInvocation, isEntireEnable
 // paths, prompts, or transcript content.
 //
 // A commit is part of the event's identity, not an incidental trigger, which is
-// why it is named for one. Every property is commit-scoped: FilesCommitted
-// counts that commit's files, and PriorAIHistory asks whether commits *before*
-// this one already touched them. The condensation paths that run without a
-// commit (doctor repair, session-end leftovers) deliberately emit nothing —
-// see newCommitCondensedSignal for why folding them in would corrupt the
+// why it is named for one. FilesCommitted and PriorAIHistory are commit-scoped:
+// the former counts that commit's files, the latter asks whether commits
+// *before* this one already touched them. UsedSearch is deliberately
+// SESSION-scoped — the metric asks whether the session EVER consulted search
+// before landing this commit, so one search early in a session rightly covers
+// its later commits. The condensation paths that run without a commit (doctor
+// repair, session-end leftovers) deliberately emit nothing — see
+// newCommitCondensedSignal for why folding them in would corrupt the
 // denominator rather than complete it.
 type CommitCondensedSignal struct {
 	// Agent is the session-owning agent's registry key (e.g. "claude-code"),

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -342,9 +342,16 @@ type CommitCondensedSignal struct {
 	// Agent is the session-owning agent's registry key (e.g. "claude-code"),
 	// matching the agent property on skill and command events.
 	Agent string
-	// UsedSearch reports whether the session's transcript shows an
-	// `entire search` invocation.
-	UsedSearch bool
+	// UsedSearch reports whether the session invoked `entire search`. Nil means
+	// the question was not answerable for this agent's transcript format, and
+	// the property is then OMITTED from the payload rather than sent as false —
+	// so a consumer filtering on `used_search = false` excludes unknowns instead
+	// of silently counting them as "did not search". UsedSearchSource always
+	// says which case this is.
+	UsedSearch *bool
+	// UsedSearchSource records how UsedSearch was determined: "unsupported",
+	// "none", "command", or "subagent". Always present.
+	UsedSearchSource string
 	// PriorAIHistory reports whether any committed file was touched by a
 	// recent AI checkpoint commit before this one.
 	PriorAIHistory bool
@@ -369,14 +376,18 @@ func BuildCommitCondensedPayload(sig CommitCondensedSignal, isEntireEnabled bool
 	}
 
 	properties := map[string]any{
-		"agent":            agentName,
-		"used_search":      sig.UsedSearch,
-		"prior_ai_history": sig.PriorAIHistory,
-		"files_committed":  sig.FilesCommitted,
-		"isEntireEnabled":  isEntireEnabled,
-		"cli_version":      version,
-		"os":               runtime.GOOS,
-		"arch":             runtime.GOARCH,
+		"agent":              agentName,
+		"used_search_source": sig.UsedSearchSource,
+		"prior_ai_history":   sig.PriorAIHistory,
+		"files_committed":    sig.FilesCommitted,
+		"isEntireEnabled":    isEntireEnabled,
+		"cli_version":        version,
+		"os":                 runtime.GOOS,
+		"arch":               runtime.GOARCH,
+	}
+	// Omitted, not false, when unmeasurable — see UsedSearch's doc comment.
+	if sig.UsedSearch != nil {
+		properties["used_search"] = *sig.UsedSearch
 	}
 
 	return &EventPayload{

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -162,11 +162,19 @@ func spawnDetachedAnalyticsBatch(payloads []*EventPayload) {
 	flush()
 }
 
+// IsEnvOptedOut reports whether the ENTIRE_TELEMETRY_OPTOUT environment
+// opt-out is set. Every tracker honors it internally; callers that do
+// expensive work before tracking (e.g. a git-log probe) should check it
+// first so an opted-out user never pays for signal computation.
+func IsEnvOptedOut() bool {
+	return os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != ""
+}
+
 // TrackCommandDetached tracks a command execution by spawning a detached subprocess.
 // This returns immediately without blocking the CLI.
 func TrackCommandDetached(cmd *cobra.Command, agent string, isEntireEnabled bool, version string) {
 	// Check opt-out environment variables
-	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+	if IsEnvOptedOut() {
 		return
 	}
 
@@ -220,7 +228,7 @@ func BuildPluginEventPayload(pluginName string, isEntireEnabled bool, version st
 // TrackPluginDetached records a plugin invocation. Call sites must gate
 // on the plugin allowlist — this function does no name filtering itself.
 func TrackPluginDetached(pluginName string, isEntireEnabled bool, version string) {
-	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+	if IsEnvOptedOut() {
 		return
 	}
 
@@ -302,7 +310,7 @@ func BuildSkillEventPayload(inv SkillInvocation, isEntireEnabled bool, version s
 // backlog in one call, and a dropped event is never re-reported because the
 // dedupe in session state has already recorded it.
 func TrackSkillInvocationsDetached(invocations []SkillInvocation, isEntireEnabled bool, version string) {
-	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+	if IsEnvOptedOut() {
 		return
 	}
 
@@ -375,7 +383,7 @@ func BuildCheckpointCondensedPayload(sig CheckpointCondensedSignal, isEntireEnab
 // signal. Like TrackPluginDetached, it only honors the env opt-out itself —
 // call sites must gate on the user's opt-in telemetry setting.
 func TrackCheckpointCondensedDetached(sig CheckpointCondensedSignal, isEntireEnabled bool, version string) {
-	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+	if IsEnvOptedOut() {
 		return
 	}
 

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -356,8 +356,13 @@ type CommitCondensedSignal struct {
 	// "none", "command", or "subagent". Always present.
 	UsedSearchSource string
 	// PriorAIHistory reports whether any committed file was touched by a
-	// recent AI checkpoint commit before this one.
-	PriorAIHistory bool
+	// recent AI checkpoint commit before this one. Nil means the git-log probe
+	// could not run (git unavailable, cancelled ctx, shallow-clone failure) and
+	// the property is then OMITTED from the payload rather than sent as false —
+	// same rationale as UsedSearch: a fabricated "no prior history" deflates
+	// the very miss rate this event exists to measure. A commit that landed no
+	// files is a measured false, not an omission.
+	PriorAIHistory *bool
 	// FilesCommitted is the number of files this checkpoint touched.
 	FilesCommitted int
 }
@@ -381,16 +386,19 @@ func BuildCommitCondensedPayload(sig CommitCondensedSignal, isEntireEnabled bool
 	properties := map[string]any{
 		"agent":              agentName,
 		"used_search_source": sig.UsedSearchSource,
-		"prior_ai_history":   sig.PriorAIHistory,
 		"files_committed":    sig.FilesCommitted,
 		"isEntireEnabled":    isEntireEnabled,
 		"cli_version":        version,
 		"os":                 runtime.GOOS,
 		"arch":               runtime.GOARCH,
 	}
-	// Omitted, not false, when unmeasurable — see UsedSearch's doc comment.
+	// Omitted, not false, when unmeasurable — see the doc comments on
+	// UsedSearch and PriorAIHistory.
 	if sig.UsedSearch != nil {
 		properties["used_search"] = *sig.UsedSearch
+	}
+	if sig.PriorAIHistory != nil {
+		properties["prior_ai_history"] = *sig.PriorAIHistory
 	}
 
 	return &EventPayload{

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -15,6 +15,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// autoAgentName is the default value for the agent property when no agent
+// was selected or reported.
+const autoAgentName = "auto"
+
 var (
 	// PostHogAPIKey is set at build time for production
 	PostHogAPIKey = "phc_development_key"
@@ -61,7 +65,7 @@ func BuildEventPayload(cmd *cobra.Command, agent string, isEntireEnabled bool, v
 
 	selectedAgent := agent
 	if selectedAgent == "" {
-		selectedAgent = "auto"
+		selectedAgent = autoAgentName
 	}
 
 	properties := map[string]any{
@@ -265,7 +269,7 @@ func BuildSkillEventPayload(inv SkillInvocation, isEntireEnabled bool, version s
 	// non-empty, queryable value.
 	agentName := inv.Agent
 	if agentName == "" {
-		agentName = "auto"
+		agentName = autoAgentName
 	}
 
 	properties := map[string]any{
@@ -315,10 +319,12 @@ func TrackSkillInvocationsDetached(invocations []SkillInvocation, isEntireEnable
 // commit condenses a session checkpoint: whether the session consulted entire
 // search, and whether the committed files already carried AI checkpoint
 // history. Together these give the "sessions that edited history-dense files
-// without searching" denominator that raw command counts cannot. Booleans and
-// counts only — no file paths, prompts, or transcript content.
+// without searching" denominator that raw command counts cannot. Content-free
+// metadata only — booleans, a count, and the agent identifier; never file
+// paths, prompts, or transcript content.
 type CheckpointCondensedSignal struct {
-	// Agent is the session-owning agent type (e.g. "claude-code").
+	// Agent is the session-owning agent's registry key (e.g. "claude-code"),
+	// matching the agent property on skill and command events.
 	Agent string
 	// UsedSearch reports whether the session's transcript shows an
 	// `entire search` invocation.
@@ -339,8 +345,15 @@ func BuildCheckpointCondensedPayload(sig CheckpointCondensedSignal, isEntireEnab
 		return nil
 	}
 
+	// Match BuildEventPayload's defaulting so the agent property is always a
+	// non-empty, queryable value.
+	agentName := sig.Agent
+	if agentName == "" {
+		agentName = autoAgentName
+	}
+
 	properties := map[string]any{
-		"agent":            sig.Agent,
+		"agent":            agentName,
 		"used_search":      sig.UsedSearch,
 		"prior_ai_history": sig.PriorAIHistory,
 		"files_committed":  sig.FilesCommitted,

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -311,6 +311,71 @@ func TrackSkillInvocationsDetached(invocations []SkillInvocation, isEntireEnable
 	spawnDetachedAnalyticsBatch(payloads)
 }
 
+// CheckpointCondensedSignal is the content-free adoption signal emitted when a
+// commit condenses a session checkpoint: whether the session consulted entire
+// search, and whether the committed files already carried AI checkpoint
+// history. Together these give the "sessions that edited history-dense files
+// without searching" denominator that raw command counts cannot. Booleans and
+// counts only — no file paths, prompts, or transcript content.
+type CheckpointCondensedSignal struct {
+	// Agent is the session-owning agent type (e.g. "claude-code").
+	Agent string
+	// UsedSearch reports whether the session's transcript shows an
+	// `entire search` invocation.
+	UsedSearch bool
+	// PriorAIHistory reports whether any committed file was touched by a
+	// recent AI checkpoint commit before this one.
+	PriorAIHistory bool
+	// FilesCommitted is the number of files this checkpoint touched.
+	FilesCommitted int
+}
+
+// BuildCheckpointCondensedPayload constructs the telemetry payload for one
+// condensed checkpoint. Exported for testing. Returns nil if the payload
+// cannot be built.
+func BuildCheckpointCondensedPayload(sig CheckpointCondensedSignal, isEntireEnabled bool, version string) *EventPayload {
+	machineID, err := telemetryMachineID()
+	if err != nil {
+		return nil
+	}
+
+	properties := map[string]any{
+		"agent":            sig.Agent,
+		"used_search":      sig.UsedSearch,
+		"prior_ai_history": sig.PriorAIHistory,
+		"files_committed":  sig.FilesCommitted,
+		"isEntireEnabled":  isEntireEnabled,
+		"cli_version":      version,
+		"os":               runtime.GOOS,
+		"arch":             runtime.GOARCH,
+	}
+
+	return &EventPayload{
+		Event:      "cli_checkpoint_condensed",
+		DistinctID: machineID,
+		Properties: properties,
+		Timestamp:  time.Now(),
+	}
+}
+
+// TrackCheckpointCondensedDetached records one condensed checkpoint's adoption
+// signal. Like TrackPluginDetached, it only honors the env opt-out itself —
+// call sites must gate on the user's opt-in telemetry setting.
+func TrackCheckpointCondensedDetached(sig CheckpointCondensedSignal, isEntireEnabled bool, version string) {
+	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+		return
+	}
+
+	payload := BuildCheckpointCondensedPayload(sig, isEntireEnabled, version)
+	if payload == nil {
+		return
+	}
+
+	if payloadJSON, err := json.Marshal(payload); err == nil {
+		spawnDetachedAnalytics(string(payloadJSON))
+	}
+}
+
 // SendEvents processes one or more event payloads in the detached subprocess.
 // This is called by the hidden __send_analytics command.
 //

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -257,20 +257,20 @@ func TestBuildSkillEventPayload_UnlistedSkillNameIsNotSent(t *testing.T) {
 	}
 }
 
-func TestBuildCheckpointCondensedPayload(t *testing.T) {
+func TestBuildCommitCondensedPayload(t *testing.T) {
 	t.Parallel()
-	payload := BuildCheckpointCondensedPayload(CheckpointCondensedSignal{
+	payload := BuildCommitCondensedPayload(CommitCondensedSignal{
 		Agent:          testAgentName,
 		UsedSearch:     true,
 		PriorAIHistory: true,
 		FilesCommitted: 4,
 	}, true, "1.2.3")
 	if payload == nil {
-		t.Fatal("BuildCheckpointCondensedPayload returned nil")
+		t.Fatal("BuildCommitCondensedPayload returned nil")
 		return
 	}
-	if payload.Event != "cli_checkpoint_condensed" {
-		t.Errorf("Event = %q, want %q", payload.Event, "cli_checkpoint_condensed")
+	if payload.Event != "cli_commit_condensed" {
+		t.Errorf("Event = %q, want %q", payload.Event, "cli_commit_condensed")
 	}
 	if got := payload.Properties["agent"]; got != testAgentName {
 		t.Errorf("agent property = %v, want %q", got, testAgentName)

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -260,11 +260,12 @@ func TestBuildSkillEventPayload_UnlistedSkillNameIsNotSent(t *testing.T) {
 func TestBuildCommitCondensedPayload(t *testing.T) {
 	t.Parallel()
 	usedSearch := true
+	priorAI := true
 	payload := BuildCommitCondensedPayload(CommitCondensedSignal{
 		Agent:            testAgentName,
 		UsedSearch:       &usedSearch,
 		UsedSearchSource: "command",
-		PriorAIHistory:   true,
+		PriorAIHistory:   &priorAI,
 		FilesCommitted:   4,
 	}, true, "1.2.3")
 	if payload == nil {
@@ -305,11 +306,12 @@ func TestBuildCommitCondensedPayload(t *testing.T) {
 // not search". A missing PostHog property is not false.
 func TestBuildCommitCondensedPayload_UnmeasurableOmitsUsedSearch(t *testing.T) {
 	t.Parallel()
+	priorAI := true
 	payload := BuildCommitCondensedPayload(CommitCondensedSignal{
 		Agent:            testAgentName,
 		UsedSearch:       nil,
 		UsedSearchSource: "unsupported",
-		PriorAIHistory:   true,
+		PriorAIHistory:   &priorAI,
 		FilesCommitted:   2,
 	}, true, "1.2.3")
 	if payload == nil {
@@ -324,5 +326,32 @@ func TestBuildCommitCondensedPayload_UnmeasurableOmitsUsedSearch(t *testing.T) {
 	}
 	if got := payload.Properties["prior_ai_history"]; got != true {
 		t.Errorf("prior_ai_history property = %v, want true", got)
+	}
+}
+
+// TestBuildCommitCondensedPayload_UnmeasurableOmitsPriorAIHistory gives
+// prior_ai_history the same honesty contract as used_search: when the git-log
+// probe could not run, the property is ABSENT rather than false, so a consumer
+// filtering on `prior_ai_history = false` excludes those rows instead of
+// counting them as "touched no AI-dense files".
+func TestBuildCommitCondensedPayload_UnmeasurableOmitsPriorAIHistory(t *testing.T) {
+	t.Parallel()
+	usedSearch := false
+	payload := BuildCommitCondensedPayload(CommitCondensedSignal{
+		Agent:            testAgentName,
+		UsedSearch:       &usedSearch,
+		UsedSearchSource: "none",
+		PriorAIHistory:   nil,
+		FilesCommitted:   2,
+	}, true, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildCommitCondensedPayload returned nil")
+		return
+	}
+	if _, ok := payload.Properties["prior_ai_history"]; ok {
+		t.Errorf("prior_ai_history must be absent when unmeasurable, got %v", payload.Properties["prior_ai_history"])
+	}
+	if got := payload.Properties["used_search"]; got != false {
+		t.Errorf("used_search property = %v, want false", got)
 	}
 }

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// testAgentName is the agent used across the skill/checkpoint payload tests.
+const testAgentName = "claude-code"
+
 func TestBuildPluginEventPayload(t *testing.T) {
 	t.Parallel()
 	payload := BuildPluginEventPayload("pgr", true, "1.2.3")
@@ -184,7 +187,7 @@ func TestBuildSkillEventPayload(t *testing.T) {
 	t.Parallel()
 	payload := BuildSkillEventPayload(SkillInvocation{
 		Skill:     "entire",
-		Agent:     "claude-code",
+		Agent:     testAgentName,
 		Signal:    "prompt_slash_command",
 		EventType: "prompt_invocation",
 	}, true, "1.2.3")
@@ -198,8 +201,8 @@ func TestBuildSkillEventPayload(t *testing.T) {
 	if got := payload.Properties["skill"]; got != "entire" {
 		t.Errorf("skill property = %v, want %q", got, "entire")
 	}
-	if got := payload.Properties["agent"]; got != "claude-code" {
-		t.Errorf("agent property = %v, want %q", got, "claude-code")
+	if got := payload.Properties["agent"]; got != testAgentName {
+		t.Errorf("agent property = %v, want %q", got, testAgentName)
 	}
 	if got := payload.Properties["signal"]; got != "prompt_slash_command" {
 		t.Errorf("signal property = %v, want %q", got, "prompt_slash_command")
@@ -224,7 +227,7 @@ func TestBuildSkillEventPayload(t *testing.T) {
 
 func TestBuildSkillEventPayload_EmptySkill(t *testing.T) {
 	t.Parallel()
-	if got := BuildSkillEventPayload(SkillInvocation{Agent: "claude-code"}, true, "1.0.0"); got != nil {
+	if got := BuildSkillEventPayload(SkillInvocation{Agent: testAgentName}, true, "1.0.0"); got != nil {
 		t.Errorf("expected nil for empty skill name, got %+v", got)
 	}
 }
@@ -236,7 +239,7 @@ func TestBuildSkillEventPayload_UnlistedSkillNameIsNotSent(t *testing.T) {
 	// allowlisted names pass through verbatim.
 	payload := BuildSkillEventPayload(SkillInvocation{
 		Skill:     "customer-acme-incident-123",
-		Agent:     "claude-code",
+		Agent:     testAgentName,
 		Signal:    "prompt_slash_command",
 		EventType: "prompt_invocation",
 	}, true, "1.2.3")
@@ -250,6 +253,42 @@ func TestBuildSkillEventPayload_UnlistedSkillNameIsNotSent(t *testing.T) {
 	for _, v := range payload.Properties {
 		if s, ok := v.(string); ok && s == "customer-acme-incident-123" {
 			t.Errorf("raw skill name leaked into payload property %v", v)
+		}
+	}
+}
+
+func TestBuildCheckpointCondensedPayload(t *testing.T) {
+	t.Parallel()
+	payload := BuildCheckpointCondensedPayload(CheckpointCondensedSignal{
+		Agent:          testAgentName,
+		UsedSearch:     true,
+		PriorAIHistory: true,
+		FilesCommitted: 4,
+	}, true, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildCheckpointCondensedPayload returned nil")
+		return
+	}
+	if payload.Event != "cli_checkpoint_condensed" {
+		t.Errorf("Event = %q, want %q", payload.Event, "cli_checkpoint_condensed")
+	}
+	if got := payload.Properties["agent"]; got != testAgentName {
+		t.Errorf("agent property = %v, want %q", got, testAgentName)
+	}
+	if got := payload.Properties["used_search"]; got != true {
+		t.Errorf("used_search property = %v, want true", got)
+	}
+	if got := payload.Properties["prior_ai_history"]; got != true {
+		t.Errorf("prior_ai_history property = %v, want true", got)
+	}
+	if got := payload.Properties["files_committed"]; got != 4 {
+		t.Errorf("files_committed property = %v, want 4", got)
+	}
+	// The payload must stay content-free: booleans and counts only, never
+	// file paths, prompts, or transcript content.
+	for _, forbidden := range []string{"files", "paths", "prompt", "transcript"} {
+		if _, ok := payload.Properties[forbidden]; ok {
+			t.Errorf("checkpoint payload must not include %q", forbidden)
 		}
 	}
 }

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -259,11 +259,13 @@ func TestBuildSkillEventPayload_UnlistedSkillNameIsNotSent(t *testing.T) {
 
 func TestBuildCommitCondensedPayload(t *testing.T) {
 	t.Parallel()
+	usedSearch := true
 	payload := BuildCommitCondensedPayload(CommitCondensedSignal{
-		Agent:          testAgentName,
-		UsedSearch:     true,
-		PriorAIHistory: true,
-		FilesCommitted: 4,
+		Agent:            testAgentName,
+		UsedSearch:       &usedSearch,
+		UsedSearchSource: "command",
+		PriorAIHistory:   true,
+		FilesCommitted:   4,
 	}, true, "1.2.3")
 	if payload == nil {
 		t.Fatal("BuildCommitCondensedPayload returned nil")
@@ -278,6 +280,9 @@ func TestBuildCommitCondensedPayload(t *testing.T) {
 	if got := payload.Properties["used_search"]; got != true {
 		t.Errorf("used_search property = %v, want true", got)
 	}
+	if got := payload.Properties["used_search_source"]; got != "command" {
+		t.Errorf("used_search_source property = %v, want %q", got, "command")
+	}
 	if got := payload.Properties["prior_ai_history"]; got != true {
 		t.Errorf("prior_ai_history property = %v, want true", got)
 	}
@@ -290,5 +295,34 @@ func TestBuildCommitCondensedPayload(t *testing.T) {
 		if _, ok := payload.Properties[forbidden]; ok {
 			t.Errorf("checkpoint payload must not include %q", forbidden)
 		}
+	}
+}
+
+// TestBuildCommitCondensedPayload_UnmeasurableOmitsUsedSearch pins the shape
+// that keeps the missed-opportunity ratio honest: when the probe could not run,
+// used_search is ABSENT rather than false, so a consumer filtering on
+// `used_search = false` excludes those rows instead of counting them as "did
+// not search". A missing PostHog property is not false.
+func TestBuildCommitCondensedPayload_UnmeasurableOmitsUsedSearch(t *testing.T) {
+	t.Parallel()
+	payload := BuildCommitCondensedPayload(CommitCondensedSignal{
+		Agent:            testAgentName,
+		UsedSearch:       nil,
+		UsedSearchSource: "unsupported",
+		PriorAIHistory:   true,
+		FilesCommitted:   2,
+	}, true, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildCommitCondensedPayload returned nil")
+		return
+	}
+	if _, ok := payload.Properties["used_search"]; ok {
+		t.Errorf("used_search must be absent when unmeasurable, got %v", payload.Properties["used_search"])
+	}
+	if got := payload.Properties["used_search_source"]; got != "unsupported" {
+		t.Errorf("used_search_source property = %v, want %q", got, "unsupported")
+	}
+	if got := payload.Properties["prior_ai_history"]; got != true {
+		t.Errorf("prior_ai_history property = %v, want true", got)
 	}
 }

--- a/cmd/entire/cli/transcript/types.go
+++ b/cmd/entire/cli/transcript/types.go
@@ -55,6 +55,8 @@ type ToolInput struct {
 	Pattern      string `json:"pattern,omitempty"`
 	// Skill tool fields
 	Skill string `json:"skill,omitempty"`
+	// Task/Agent tool fields: the dispatched subagent's name.
+	SubagentType string `json:"subagent_type,omitempty"`
 	// WebFetch tool fields
 	URL    string `json:"url,omitempty"`
 	Prompt string `json:"prompt,omitempty"`


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1071
<!-- entire-trail-link-end -->

Raw search-command counts can't say whether adoption is low — most sessions have nothing worth searching for. The denominator that makes the rate meaningful is **commits that landed files already carrying AI checkpoint history without the session ever consulting search**. Entire is the only tool that can compute it, and nothing emitted it.

On each successful post-commit condensation, emit `cli_commit_condensed`.

## Properties

| Property | Meaning |
| --- | --- |
| `used_search` | Did the session invoke `entire search`? **Omitted** when not measurable — see below. |
| `used_search_source` | How `used_search` was determined: `command`, `subagent`, `none`, or `unsupported`. Always present. |
| `prior_ai_history` | Did any committed file appear in a recent commit carrying an `Entire-Checkpoint` trailer? |
| `files_committed` | Count only. |

The event is named for the **commit**, not the checkpoint, because every property is commit-scoped: `files_committed` counts that commit's files, and `prior_ai_history` asks whether commits *before* this one touched them — which is what the probe's `--skip=1` is for. The commit-less condensation paths (doctor repair, session-end leftovers) deliberately emit nothing; rows without a commit would be indistinguishable from genuine misses and would inflate the denominator rather than complete it. Covering them would need a `trigger` discriminator plus nullable commit-scoped fields — a change to what the metric means, not a bug fix. The rationale is recorded at both call sites and on `newCommitCondensedSignal`.

## Measuring `used_search`

The first version was a `bytes.Contains` probe. Review measured it at **18 false positives to 1 true positive** across 328 real transcripts, and the false positives are structural — Entire installs the artifacts that trip its own probe (`setup_search_skill.go` embeds `entire search --json` in the search skill's body; `investigate/prompt.go` injects it into every investigate prompt). The direction is what made it unusable: inflating `used_search` deflates the missed-opportunity rate, so the metric reads "adoption is fine" for the wrong reason.

It now matches a recorded tool invocation through a new built-in-only `ToolInvocationScanner` capability whose dispatcher returns `(found, supported)`:

- **`command`** — a shell tool ran the command, matched in *command position* (start of command or after a shell separator, tolerating env assignments and a path prefix), so `cd sub && entire search x` matches while `grep -rn "entire search" cmd/` does not.
- **`subagent`** — the `entire-search` subagent was dispatched. This is the primary path, not a nicety: `setup_search_skill.go` installs search as a subagent, so the intended usage records an `Agent`/`Task` `tool_use` and runs the actual command in a *separate* subagent transcript that condensation never reads. A shell-only matcher would report "did not search" for exactly the sessions that adopted the feature.
- **`unsupported`** — no walker exists for this agent's transcript shape. `used_search` is then **omitted from the payload rather than sent as false**, so a consumer filtering `used_search = false` excludes unknowns instead of absorbing them; a missing PostHog property is not `false`. Claude Code is the only implementer today.

Consumers should compute the rate over the measurable population:

```sql
SELECT countIf(properties.prior_ai_history AND NOT properties.used_search) / count()
FROM events
WHERE event = 'cli_commit_condensed'
  AND properties.used_search_source != 'unsupported'
```

## Privacy and cost

Content-free by construction: booleans, a count, and the agent registry key — never file paths, prompts, or transcript content. Gated on `ENTIRE_TELEMETRY_OPTOUT` and then the opt-in telemetry setting **before any probe work**, so an opted-out user never pays for the git-log subprocess. The PostHog call is the existing detached-child path and never blocks the hook.

Both commit-scoped costs are memoized once per commit rather than per session: the settings load and the single `git log`, whose 13.8ms is almost entirely process spawn (8.7ms for `git --version` alone, and flat across a 60x range of output size). Both resolve on first use, so a commit where no session condenses pays nothing.

The `git log` record framing is NUL-anchored (`--format=%x00%H%n%B`). A commit message cannot contain NUL, so the record marker rests on nothing about message content — the previous `%x1e`/`%x1f` framing took its delimiters from the raw body, and a body containing either control character split a record early and dropped a real trailer, making `prior_ai_history` read false and suppressing a genuine miss.

## Tests

Regression coverage for each documented false-positive class (grep, commit message, tool output, assistant prose, the scaffolded skill body being written, the injected investigate prompt); unprobeable agents required to report `unsupported` when fed a transcript that *does* contain a real invocation; the hint/matcher case-sensitivity relationship pinned in both directions; the zero-value probe required not to present itself as a measurement; a commit body containing literal `\x1e`/`\x1f` still attributed; empty-message and merge commits pinned; and the probe and settings load asserted to run once across several sessions.

Verified green: `mise run lint` 0 issues, all 64 packages, plus both canary suites (56 Vogon, 4 roger-roger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
