### PR TITLE
perf(deps): pin go-runewidth to 0.0.25 to drop 15ms of init from every invocation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,12 @@ updates:
       # Pinned to 1.5.0 until fixed upstream.
       - dependency-name: "github.com/betterleaks/betterleaks"
         versions: [">=1.6.0"]
+      # go-runewidth >=0.0.26 builds a 2.2MB width lookup table
+      # (strictWidthLUT) eagerly in package init(), adding ~15ms to every
+      # entire invocation — including every hook fire on every agent turn.
+      # Pinned to 0.0.25 until the LUT is built lazily upstream.
+      - dependency-name: "github.com/mattn/go-runewidth"
+        versions: [">=0.0.26"]
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-isatty v0.0.24
-	github.com/mattn/go-runewidth v0.0.27
+	github.com/mattn/go-runewidth v0.0.25
 	github.com/muesli/termenv v0.16.0
 	github.com/ogen-go/ogen v1.24.0
 	github.com/oklog/ulid/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
-github.com/mattn/go-runewidth v0.0.27 h1:Feg/Oou5zI/wnpgDF6omIU0OokC9GxLC/WRknhVlIR0=
-github.com/mattn/go-runewidth v0.0.27/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
+github.com/mattn/go-runewidth v0.0.25 h1:oMKkImkjfRyxEpuCiQdowA9mElm4TTjPBwUaoTutcNI=
+github.com/mattn/go-runewidth v0.0.25/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mholt/archives v0.1.6-0.20260429171216-ef71b7a32fae h1:J5ek2lGxYgdh5SMMmlNTSKLmS1x2oJQla/V0NaAH7vo=
 github.com/mholt/archives v0.1.6-0.20260429171216-ef71b7a32fae/go.mod h1:IbMrpOL3881/V4qoZRFTSTSRzjjZkD3qoRLX07MitpY=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=


### PR DESCRIPTION
## What

Downgrades `github.com/mattn/go-runewidth` v0.0.27 → v0.0.25 and adds a dependabot ignore rule for `>=0.0.26`.

## Why

go-runewidth v0.0.26 introduced `strictWidthLUT [2][0x110000]byte` — a 2.2MB lookup table built rune-by-rune, **unconditionally, in package `init()`** (`initStrictWidthLUT`, runewidth.go). Because Go runs the inits of everything linked, every single `entire` invocation pays ~15ms of CPU before `main()` — including every hook fire on every agent turn, where nothing ever measures a rune width.

Measured with `GODEBUG=inittrace=1`, go-runewidth was the single largest init in the binary (15ms of a ~27ms total init tail). Whole-process, `hyperfine -N --warmup 50 --runs 400 'entire version'`:

| | mean | min |
|---|---:|---:|
| before (v0.0.27) | 33.8 ms ± 0.9 | 32.1 ms |
| after (v0.0.25) | **18.0 ms ± 0.8** | **16.5 ms** |

1.88× faster process startup, across the board.

## Why this is safe

- v0.0.27 arrived via a routine dependabot group bump (c3283c0c6), not a deliberate upgrade.
- Nothing in the dependency tree requires anything newer than v0.0.24 (the charm stack's own maximum); our one direct import (`investigate/flowchart`) only uses `StringWidth`/`RuneWidth`, unchanged across these versions.
- v0.0.25 is the last version before the eager LUT; its `init()` builds only a 768-byte table.
- The dependabot ignore (following the existing betterleaks precedent) prevents the next daily group bump from silently reintroducing the regression, until the LUT is built lazily upstream.

## Follow-up (not in this PR)

The remaining init tail is chroma (`lexers` + `styles`, ~7ms combined, pulled in via glamour) — harder to remove without dropping syntax highlighting or splitting the hook path into a thinner binary.

`mise run check` (fmt + lint + unit + integration + canary) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
