### PR TITLE
Resolve repo-scoped cell targets via processing placement, not mirrors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -647,10 +647,19 @@ caller's home cell, and no server-side cross-cell aggregator exists. The CLI
 therefore has exactly three routing shapes, mirroring the entire.io BFF:
 
 - **Repo-scoped → one cell**: `resolveRepoCellTarget` (`cell_target.go`) maps
-  a repo (ULID or owner/repo) to the cell hosting it via mirrors + the cluster
-  catalog. Best-effort: any failure returns nil and the auth layer falls back
-  to home-jurisdiction routing. Used by experts
-  (`NewAuthenticatedEntireAPICellClient` in `api_client.go`).
+  a repo (ULID or owner/repo) to the cell hosting it — via `GetRepo`'s
+  `ClusterHost` for a ULID, or via the control plane's consolidated repos
+  index (`ListRepos`) for owner/repo, resolved to the repo's PROCESSING
+  placement (`primaries.processing`), not just any active mirror, since a
+  repo can be mirrored in several regions but only one placement holds its
+  actual data. NOT best-effort: any failure (not onboarded, no/failed/
+  suspended processing placement, control-plane error, timeout) returns an
+  error instead of falling back to home-jurisdiction routing — a wrong-region
+  "success" is worse than a command failure for repo-scoped data. Used by
+  trails and experts (`NewAuthenticatedEntireAPICellClient` in
+  `api_client.go`). `resolveRepoCellPlacement` performs the same lookup for
+  callers that also need the placement's id (repo_id) alongside its cell —
+  used by cross-repo checkpoint reads (`explain --repo`, `explain_repo.go`).
 - **User-scoped `/me` → home cell, never fan out**:
   `auth.NewEntireAPICellClient(ctx, insecure, nil)` routes by the
   `home_jurisdiction` JWT claim; activity/recap use it with a data-API

--- a/cmd/entire/cli/activity_cmd_test.go
+++ b/cmd/entire/cli/activity_cmd_test.go
@@ -27,6 +27,14 @@ func strPtr(v string) *string { return &v }
 // "Not logged in" hint; that was wrong because real STS / network
 // failures got mis-labeled. This PR surfaces real errors but has to
 // keep the cancellation case silent.
+//
+// The passed-in context is actually cancelled (not merely a mock returning
+// context.Canceled) to mirror main.go, which cancels the real ctx on
+// Ctrl+C before any command code runs: renderDataAPIAuthError silences a
+// wrapped context.Canceled/DeadlineExceeded only when the caller's own ctx
+// has actually fired (ctx.Err() != nil), precisely to distinguish this case
+// from an internal resolver timeout that fires on its own derived context
+// while the caller's ctx is still live.
 func TestRunActivity_SilencesContextCanceled(t *testing.T) {
 	// No t.Parallel: SetResolveContextForAPIForTest mutates package-level
 	// auth state.
@@ -39,8 +47,11 @@ func TestRunActivity_SilencesContextCanceled(t *testing.T) {
 			return nil, context.Canceled
 		}))
 
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
 	var out, errOut bytes.Buffer
-	err := runActivity(t.Context(), &out, &errOut, false)
+	err := runActivity(ctx, &out, &errOut, false)
 	if err == nil {
 		t.Fatal("expected error when STS exchange is cancelled")
 	}

--- a/cmd/entire/cli/api_client.go
+++ b/cmd/entire/cli/api_client.go
@@ -50,18 +50,24 @@ func NewAuthenticatedAPIClient(ctx context.Context, insecureHTTP bool) (*api.Cli
 }
 
 // NewAuthenticatedEntireAPICellClient creates an API client for repo-scoped
-// entire-api routes (e.g. experts). It exchanges the login JWT for a
+// entire-api routes (e.g. trails, experts). It exchanges the login JWT for a
 // jurisdictional identity token and dials the entire-api cell directly, because
 // the BFF does not proxy these routes for bearer callers (COR-666).
 //
-// fullName (owner/repo) and/or ulid identify the repo whose cell to reach. When
-// either is supplied, the repo's OWNING cell + jurisdiction are resolved from
-// the control plane (mirroring the BFF's per-repo cell selection) so the call
-// lands in the region that hosts the repo. Resolution is best-effort: any
-// failure yields a nil target and NewEntireAPICellClient falls back to
-// home-jurisdiction routing, so the common same-region case never regresses.
+// fullName (owner/repo) and/or ulid identify the repo whose cell to reach. The
+// repo's PROCESSING cell + jurisdiction are resolved from the control plane
+// (mirroring the BFF's per-repo cell selection) so the call lands in the
+// region that actually holds the repo's data. This is NOT best-effort: a
+// resolution failure fails the command instead of falling back to the
+// caller's home cell, because for repo-scoped data a silent wrong-region
+// "success" is worse than an error — that fallback is exactly what used to
+// make `entire trail`/`entire experts` read the wrong region for a
+// multi-homed repo like entirehq/entire.io.
 func NewAuthenticatedEntireAPICellClient(ctx context.Context, insecureHTTP bool, fullName, ulid string) (*api.Client, error) {
-	target := resolveRepoCellTarget(ctx, fullName, ulid)
+	target, err := resolveRepoCellTarget(ctx, fullName, ulid)
+	if err != nil {
+		return nil, err
+	}
 	// NewEntireAPICellClient already returns user-facing, context-rich errors
 	// (login hint, discovery-unavailable, region guidance); re-wrapping here
 	// would bury them, so surface them verbatim.

--- a/cmd/entire/cli/api_client.go
+++ b/cmd/entire/cli/api_client.go
@@ -54,8 +54,10 @@ func NewAuthenticatedAPIClient(ctx context.Context, insecureHTTP bool) (*api.Cli
 // jurisdictional identity token and dials the entire-api cell directly, because
 // the BFF does not proxy these routes for bearer callers (COR-666).
 //
-// fullName (owner/repo) and/or ulid identify the repo whose cell to reach. The
-// repo's PROCESSING cell + jurisdiction are resolved from the control plane
+// fullName (owner/repo) or ulid identifies the repo whose cell to reach; ulid
+// wins when both are set, and both being empty is an error, not a fallback to
+// the caller's home cell. The repo's PROCESSING cell + jurisdiction are
+// resolved from the control plane
 // (mirroring the BFF's per-repo cell selection) so the call lands in the
 // region that actually holds the repo's data. This is NOT best-effort: a
 // resolution failure fails the command instead of falling back to the

--- a/cmd/entire/cli/authcmd.go
+++ b/cmd/entire/cli/authcmd.go
@@ -29,12 +29,21 @@ func runAuthenticatedDataAPI(ctx context.Context, errW io.Writer, insecureHTTP b
 // context.DeadlineExceeded) even though the caller's context is perfectly
 // live. Silencing on that alone would print nothing for a slow-but-reachable
 // control plane — a worse outcome than the error it would otherwise show.
+//
+// The not-onboarded case is replaced rather than wrapped: it is the most common
+// way a repo-scoped command fails, its raw chain is a stack of internal
+// resolution steps the user can do nothing with, and every caller reaching here
+// is scoped to the current repo, so the line needs no repo name.
 func renderDataAPIAuthError(ctx context.Context, errW io.Writer, err error) error {
 	if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 		return NewSilentError(err)
 	}
 	if errors.Is(err, auth.ErrNotLoggedIn) {
 		fmt.Fprintln(errW, "Not logged in. Run 'entire login' to authenticate.")
+		return NewSilentError(err)
+	}
+	if errors.Is(err, errRepoNotOnboarded) {
+		fmt.Fprintln(errW, "This repository is not onboarded to Entire. Run 'entire repo mirror create' to onboard it.")
 		return NewSilentError(err)
 	}
 	return err

--- a/cmd/entire/cli/authcmd.go
+++ b/cmd/entire/cli/authcmd.go
@@ -16,13 +16,21 @@ import (
 func runAuthenticatedDataAPI(ctx context.Context, errW io.Writer, insecureHTTP bool, fn func(context.Context, *api.Client) error) error {
 	client, err := NewAuthenticatedAPIClient(ctx, insecureHTTP)
 	if err != nil {
-		return renderDataAPIAuthError(errW, err)
+		return renderDataAPIAuthError(ctx, errW, err)
 	}
 	return fn(ctx, client)
 }
 
-func renderDataAPIAuthError(errW io.Writer, err error) error {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+// renderDataAPIAuthError decides whether err should print or stay silent.
+// Silence is reserved for the caller's own context actually firing (checked
+// via ctx.Err(), not errors.Is(err, ...)): a resolver called from inside err's
+// chain (e.g. resolveRepoCellTarget) runs under its own internal timeout, and
+// the resulting wrapped error still satisfies errors.Is(err,
+// context.DeadlineExceeded) even though the caller's context is perfectly
+// live. Silencing on that alone would print nothing for a slow-but-reachable
+// control plane — a worse outcome than the error it would otherwise show.
+func renderDataAPIAuthError(ctx context.Context, errW io.Writer, err error) error {
+	if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 		return NewSilentError(err)
 	}
 	if errors.Is(err, auth.ErrNotLoggedIn) {

--- a/cmd/entire/cli/authcmd_test.go
+++ b/cmd/entire/cli/authcmd_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -34,6 +35,11 @@ func TestRenderDataAPIAuthError_DistinguishesCallerContextFromWrappedDeadline(t 
 		if !errors.Is(result, context.DeadlineExceeded) {
 			t.Fatalf("expected returned error to still wrap context.DeadlineExceeded, got %v", result)
 		}
+		// Only the not-logged-in and not-onboarded branches print; a plain
+		// resolution failure is returned for main.go to render.
+		if errW.Len() != 0 {
+			t.Fatalf("expected nothing written to stderr, got %q", errW.String())
+		}
 	})
 
 	t.Run("actually cancelled caller context stays silent", func(t *testing.T) {
@@ -42,12 +48,53 @@ func TestRenderDataAPIAuthError_DistinguishesCallerContextFromWrappedDeadline(t 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
+		// Pair the cancelled context with a Canceled-wrapping error: that is
+		// what the real path produces, since the in-flight call that observed
+		// the cancellation is what builds this error.
+		wrappedCanceled := fmt.Errorf("resolve the Entire cell for acme/widget: %w", context.Canceled)
+
 		var errW bytes.Buffer
-		result := renderDataAPIAuthError(ctx, &errW, wrappedDeadline)
+		result := renderDataAPIAuthError(ctx, &errW, wrappedCanceled)
 
 		var silent *SilentError
 		if !errors.As(result, &silent) {
 			t.Fatalf("expected a SilentError when the caller's own context is cancelled, got %v", result)
 		}
+		if errW.Len() != 0 {
+			t.Fatalf("expected a silent error to print nothing, got %q", errW.String())
+		}
 	})
+}
+
+// The not-onboarded chain is a stack of internal resolution steps, so the render
+// boundary replaces it with one actionable line instead of printing it.
+func TestRenderDataAPIAuthError_NotOnboardedPrintsOneActionableLine(t *testing.T) {
+	t.Parallel()
+
+	// The shape resolveRepoCellPlacement actually returns: the sentinel wrapped
+	// by the caller's context, which is what errors.Is has to see through.
+	err := fmt.Errorf("resolve processing placement for acme/widget: %w", errRepoNotOnboarded)
+
+	var errW bytes.Buffer
+	result := renderDataAPIAuthError(context.Background(), &errW, err)
+
+	var silent *SilentError
+	if !errors.As(result, &silent) {
+		t.Fatalf("expected a SilentError so main.go does not also print the raw chain, got %v", result)
+	}
+	out := errW.String()
+	if !strings.Contains(out, "not onboarded to Entire") {
+		t.Errorf("stderr = %q, want it to say the repo is not onboarded", out)
+	}
+	if !strings.Contains(out, "entire repo mirror create") {
+		t.Errorf("stderr = %q, want it to name the command that onboards the repo", out)
+	}
+	// The whole point is that the internal resolution chain does not reach the
+	// user; printing it alongside the clean line would defeat the change.
+	if strings.Contains(out, "resolve processing placement") {
+		t.Errorf("stderr = %q, want the internal resolution chain replaced, not appended", out)
+	}
+	if strings.Count(out, "\n") != 1 {
+		t.Errorf("stderr = %q, want exactly one line", out)
+	}
 }

--- a/cmd/entire/cli/authcmd_test.go
+++ b/cmd/entire/cli/authcmd_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestRenderDataAPIAuthError_DistinguishesCallerContextFromWrappedDeadline
+// guards against a regression where any error chain merely satisfying
+// errors.Is(err, context.DeadlineExceeded) was treated as the caller's own
+// context firing. resolveRepoCellTarget runs under its own internal
+// context.WithTimeout, so its timeout error still satisfies that errors.Is
+// check even when the caller's context is perfectly live — silencing on that
+// basis alone would print nothing for a slow-but-reachable control plane
+// (worse than the bug the fail-loud change was meant to fix).
+func TestRenderDataAPIAuthError_DistinguishesCallerContextFromWrappedDeadline(t *testing.T) {
+	t.Parallel()
+
+	wrappedDeadline := fmt.Errorf("resolve the Entire cell for acme/widget: %w", context.DeadlineExceeded)
+
+	t.Run("live caller context with wrapped DeadlineExceeded is printed, not swallowed", func(t *testing.T) {
+		t.Parallel()
+
+		var errW bytes.Buffer
+		result := renderDataAPIAuthError(context.Background(), &errW, wrappedDeadline)
+
+		var silent *SilentError
+		if errors.As(result, &silent) {
+			t.Fatalf("expected a non-silent error for a live caller context, got silent: %v", result)
+		}
+		if !errors.Is(result, context.DeadlineExceeded) {
+			t.Fatalf("expected returned error to still wrap context.DeadlineExceeded, got %v", result)
+		}
+	})
+
+	t.Run("actually cancelled caller context stays silent", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var errW bytes.Buffer
+		result := renderDataAPIAuthError(ctx, &errW, wrappedDeadline)
+
+		var silent *SilentError
+		if !errors.As(result, &silent) {
+			t.Fatalf("expected a SilentError when the caller's own context is cancelled, got %v", result)
+		}
+	})
+}

--- a/cmd/entire/cli/cell_fanout.go
+++ b/cmd/entire/cli/cell_fanout.go
@@ -122,10 +122,11 @@ func groupReposByCell(repos []coreapi.RepoIndexEntry) []cellGroup {
 
 // resolveCellBaseURLs fills each group's baseURL from the cluster catalog,
 // joining on ClusterSlug ↔ Cluster.Slug. Best-effort: on a catalog error or
-// timeout (bounded by cellResolveTimeout, like resolveRepoCellTarget — a hung
-// core must not stall the command) or a missing/incomplete cluster row, the
-// group keeps baseURL "" and falls back to jurisdiction routing — a degraded
-// catalog must not sink the fan-out.
+// timeout (bounded by cellResolveTimeout — a hung core must not stall the
+// command) or a missing/incomplete cluster row, the group keeps baseURL ""
+// and falls back to jurisdiction routing — a degraded catalog must not sink
+// the fan-out. Unlike resolveRepoCellTarget, which fails loudly on the same
+// class of error for a single repo-scoped read.
 func resolveCellBaseURLs(ctx context.Context, c cellCoreClient, cells []cellGroup) {
 	ctx, cancel := context.WithTimeout(ctx, cellResolveTimeout)
 	defer cancel()

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -78,7 +78,7 @@ func resolveRepoCellTarget(ctx context.Context, fullName, ulid string) (*auth.Ce
 		}
 		repo, err := c.GetRepo(ctx, coreapi.GetRepoParams{RepoId: ulid})
 		if err != nil {
-			return nil, fmt.Errorf("resolve the Entire cell for %s: %w", ulid, err)
+			return nil, cellPlacementError(ctx, ulid, fmt.Errorf("resolve the Entire cell for %s: %w", ulid, err))
 		}
 		clusterHost := strings.TrimSpace(repo.ClusterHost.Or(""))
 		if clusterHost == "" {
@@ -86,7 +86,7 @@ func resolveRepoCellTarget(ctx context.Context, fullName, ulid string) (*auth.Ce
 		}
 		target, err := cellTargetForClusterHost(ctx, c, clusterHost)
 		if err != nil {
-			return nil, fmt.Errorf("resolve the Entire cell for %s: %w", ulid, err)
+			return nil, cellPlacementError(ctx, ulid, fmt.Errorf("resolve the Entire cell for %s: %w", ulid, err))
 		}
 		return target, nil
 	}
@@ -169,13 +169,17 @@ var errRepoNotOnboarded = errors.New("repo is not onboarded to Entire")
 // mirroring the entire.io BFF's processingPlacement() selection
 // (list-repos-index.ts). A repo can be mirrored in several regions; only this
 // one placement is guaranteed to hold the repo's actual data.
+//
+// Its errors deliberately omit fullName: every caller already wraps them with
+// the repo name, and naming it here too is what produced the doubled
+// "resolve processing placement for X: X: repo is not onboarded" output.
 func resolveProcessingPlacement(ctx context.Context, c cellCoreClient, fullName string) (coreapi.RepoPlacement, error) {
 	out, err := c.ListRepos(ctx, coreapi.ListReposParams{Filter: coreapi.NewOptString(fullName)})
 	if err != nil {
 		return coreapi.RepoPlacement{}, fmt.Errorf("list repos: %w", err)
 	}
 	if len(out.Repos) == 0 {
-		return coreapi.RepoPlacement{}, fmt.Errorf("%s: %w", fullName, errRepoNotOnboarded)
+		return coreapi.RepoPlacement{}, errRepoNotOnboarded
 	}
 	entry := out.Repos[0]
 	// Filter is documented as an exact-match lookup restricted to fullName, so
@@ -195,27 +199,27 @@ func resolveProcessingPlacement(ctx context.Context, c cellCoreClient, fullName 
 	// shape — a repo a developer just happens to work in — as opposed to the
 	// zero-rows case below (caller can't see it, or it doesn't exist at all).
 	if _, isCandidate := entry.Candidate.Get(); isCandidate {
-		return coreapi.RepoPlacement{}, fmt.Errorf("%s: %w", fullName, errRepoNotOnboarded)
+		return coreapi.RepoPlacement{}, errRepoNotOnboarded
 	}
 	var processingID string
 	if primaries, ok := entry.Primaries.Get(); ok {
 		processingID = strings.TrimSpace(primaries.Processing)
 	}
 	if processingID == "" {
-		return coreapi.RepoPlacement{}, fmt.Errorf("%s has no processing placement: %w", fullName, errRepoNotOnboarded)
+		return coreapi.RepoPlacement{}, errRepoNotOnboarded
 	}
 	for _, p := range entry.Placements {
 		if p.ID != processingID {
 			continue
 		}
 		if p.Status == coreapi.RepoPlacementStatusFailed || p.Status == coreapi.RepoPlacementStatusSuspended {
-			return coreapi.RepoPlacement{}, fmt.Errorf("%s's processing placement is %s", fullName, p.Status)
+			return coreapi.RepoPlacement{}, fmt.Errorf("processing placement is %s", p.Status)
 		}
 		return p, nil
 	}
 	// Defensive: primaries.processing should always name a placement present
 	// in the same response.
-	return coreapi.RepoPlacement{}, fmt.Errorf("%s's processing placement %q is not in its placement list", fullName, processingID)
+	return coreapi.RepoPlacement{}, fmt.Errorf("processing placement %q is not in the repo's placement list", processingID)
 }
 
 // repoCellPlacement is a repo's processing placement: the id entire-api keys
@@ -257,11 +261,11 @@ func resolveRepoCellPlacement(ctx context.Context, owner, repo string) (repoCell
 	fullName := owner + "/" + repo
 	placement, err := resolveProcessingPlacement(ctx, c, fullName)
 	if err != nil {
-		return repoCellPlacement{}, cellPlacementError(ctx, owner, repo, fmt.Errorf("resolve processing placement for %s: %w", fullName, err))
+		return repoCellPlacement{}, cellPlacementError(ctx, fullName, fmt.Errorf("resolve processing placement for %s: %w", fullName, err))
 	}
 	target, err := cellTargetForClusterSlug(ctx, c, placement.ClusterSlug)
 	if err != nil {
-		return repoCellPlacement{}, cellPlacementError(ctx, owner, repo, fmt.Errorf("resolve cell for %s: %w", fullName, err))
+		return repoCellPlacement{}, cellPlacementError(ctx, fullName, fmt.Errorf("resolve cell for %s: %w", fullName, err))
 	}
 	return repoCellPlacement{RepoID: placement.ID, Target: target}, nil
 }
@@ -269,10 +273,16 @@ func resolveRepoCellPlacement(ctx context.Context, owner, repo string) (repoCell
 // cellPlacementError reports a timeout as a timeout: without this, a fired
 // deadline surfaces as whichever "not found"/"no processing placement" error
 // the caller's lookup happened to return, and the user goes looking for a
-// missing mirror instead of a slow control plane.
-func cellPlacementError(ctx context.Context, owner, repo string, fallback error) error {
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return fmt.Errorf("resolving the Entire cell for %s/%s timed out: %w", owner, repo, ctxErr)
+// missing mirror instead of a slow control plane. subject is the repo the
+// lookup was for, named however the caller addressed it (owner/repo or ULID).
+//
+// Only DeadlineExceeded is relabelled. A cancelled context is a Ctrl+C, not a
+// timeout, and calling it one sends the user hunting a slow control plane that
+// was never the problem; the cancelled in-flight call's own error already
+// carries context.Canceled, which is what renderDataAPIAuthError silences on.
+func cellPlacementError(ctx context.Context, subject string, fallback error) error {
+	if ctxErr := ctx.Err(); errors.Is(ctxErr, context.DeadlineExceeded) {
+		return fmt.Errorf("resolving the Entire cell for %s timed out: %w", subject, ctxErr)
 	}
 	return fallback
 }

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -149,12 +149,18 @@ func cellTargetFromCluster(cluster coreapi.Cluster) (*auth.CellTarget, error) {
 	return &auth.CellTarget{BaseURL: apiURL, Jurisdiction: jurisdiction}, nil
 }
 
-// errRepoNotOnboarded signals that fullName has no entry at all in the
-// control plane's repos index — a definitive, not transient, negative.
-// Callers that persist a per-repo enabled/disabled decision (trails'
-// background enablement cache) should treat this the same way they'd treat
-// an explicit "not found" from the data API, rather than leaving the
-// decision unresolved forever.
+// errRepoNotOnboarded signals that fullName has no processing placement to
+// resolve, in any of its three shapes: no entry at all in the control plane's
+// repos index, a Candidate row (on the forge, never onboarded), or a row whose
+// primaries name no processing placement. Callers that persist a per-repo
+// enabled/disabled decision (trails' background enablement cache) should treat
+// this the same way they'd treat an explicit "not found" from the data API,
+// rather than leaving the decision unresolved forever.
+//
+// The third shape can be transient (a repo mid-onboarding has placements
+// before its primaries are set) and is still grouped with the permanent two
+// deliberately: repo-scoped data is unreachable either way, and the one
+// consumer caches under a TTL, so a completed onboarding self-heals.
 var errRepoNotOnboarded = errors.New("repo is not onboarded to Entire")
 
 // resolveProcessingPlacement resolves fullName's PROCESSING placement — the
@@ -191,9 +197,11 @@ func resolveProcessingPlacement(ctx context.Context, c cellCoreClient, fullName 
 	if _, isCandidate := entry.Candidate.Get(); isCandidate {
 		return coreapi.RepoPlacement{}, fmt.Errorf("%s: %w", fullName, errRepoNotOnboarded)
 	}
-	primaries, ok := entry.Primaries.Get()
-	processingID := strings.TrimSpace(primaries.Processing)
-	if !ok || processingID == "" {
+	var processingID string
+	if primaries, ok := entry.Primaries.Get(); ok {
+		processingID = strings.TrimSpace(primaries.Processing)
+	}
+	if processingID == "" {
 		return coreapi.RepoPlacement{}, fmt.Errorf("%s has no processing placement: %w", fullName, errRepoNotOnboarded)
 	}
 	for _, p := range entry.Placements {

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -2,29 +2,30 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
-	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// cellResolveTimeout bounds the best-effort control-plane lookups that
-// pick a repo's cell. Without it, a reachable-but-hung control plane would block
-// the calling command (experts, and any future cell-routed command) instead of
-// degrading to home-jurisdiction routing — the "any failure falls back" contract
-// must hold for slow cores, not just erroring ones.
+// cellResolveTimeout bounds the best-effort control-plane lookups that pick a
+// repo's cell for a multi-repo fan-out (cell_fanout.go's resolveCellBaseURLs).
+// Without it, a reachable-but-hung control plane would block the calling
+// command instead of degrading to jurisdiction routing — the "any failure
+// falls back" contract must hold for slow cores, not just erroring ones.
 const cellResolveTimeout = 5 * time.Second
 
 // requiredCellResolveTimeout bounds the control-plane lookups a repo-scoped
-// cell read cannot proceed without (resolveRepoCellPlacement).
+// cell read cannot proceed without: resolveRepoCellTarget (trails, experts)
+// and resolveRepoCellPlacement (checkpoint/explain --repo).
 //
-// Deliberately not cellResolveTimeout: that budget bounds *best-effort* lookups
-// whose failure silently degrades to home-jurisdiction routing, so it can be
-// aggressive. Here a timeout is a visible command failure, and the budget has
-// to cover two sequential control-plane round trips (the repo's mirrors, then
+// Deliberately not cellResolveTimeout: that budget bounds *best-effort*
+// lookups whose failure silently degrades to jurisdiction routing, so it can
+// be aggressive. Here a timeout is a visible command failure, and the budget
+// has to cover two sequential control-plane round trips (a repo lookup, then
 // the cluster catalog), so it is more patient.
 //
 // Some deadline is required: the coreapi HTTP client sets only a dial timeout,
@@ -38,7 +39,7 @@ const requiredCellResolveTimeout = 15 * time.Second
 type cellCoreClient interface {
 	GetRepo(ctx context.Context, params coreapi.GetRepoParams) (*coreapi.Repo, error)
 	ListClusters(ctx context.Context) (*coreapi.ListClustersOutputBody, error)
-	ListMirrors(ctx context.Context, params coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error)
+	ListRepos(ctx context.Context, params coreapi.ListReposParams) (*coreapi.ListReposOutputBody, error)
 }
 
 // newCellCoreClient builds the control-plane client used for cell resolution.
@@ -46,90 +47,197 @@ type cellCoreClient interface {
 var newCellCoreClient = func() (cellCoreClient, error) { return coreapi.New() }
 
 // resolveRepoCellTarget resolves the entire-api cell that HOSTS the given
-// repo, plus that cell's jurisdiction, so a repo-scoped call (experts today)
+// repo, plus that cell's jurisdiction, so a repo-scoped call (trails, experts)
 // reaches the region that owns the repo — mirroring how the entire.io BFF
-// selects a cell per repo (resolve-cluster-host.ts / repos-stream.ts) rather
+// selects a cell per repo (list-repos-index.ts' processingPlacement()) rather
 // than using the caller's home cell.
 //
-// It is deliberately best-effort: ANY failure (not logged in, control-plane
-// error or timeout, unknown/ambiguous placement, missing apiUrl) returns nil,
-// and the auth-layer client falls back to home-jurisdiction routing. That
-// fallback is exactly the previous behaviour, so this can never regress the
-// common same-region case (where the repo's jurisdiction equals the caller's
-// home). A short deadline keeps a slow control plane from stalling the command.
+// This is NOT best-effort: every failure (control-plane error or timeout,
+// repo not onboarded, no/failed/suspended processing placement, missing
+// apiUrl) returns a descriptive error instead of falling back to the
+// caller's home cell. A silent wrong-region "success" is worse than a command
+// failure for repo-scoped data — that fallback is exactly how a mirrored repo
+// like entirehq/entire.io used to read (or fail to read) the wrong region's
+// trails.
 //
 // Placement source:
-//   - ulid form: coreapi.GetRepo(ulid) -> Repo.ClusterHost;
-//   - owner/repo form: coreapi mirrors filtered to this repo -> ClusterHost.
-//
-// The cluster host is then mapped to a cell apiUrl + jurisdiction via the
-// coreapi cluster catalog (ListClusters), the authoritative source for a
-// jurisdiction's cell URL.
-func resolveRepoCellTarget(ctx context.Context, fullName, ulid string) *auth.CellTarget {
-	ctx, cancel := context.WithTimeout(ctx, cellResolveTimeout)
-	defer cancel()
+//   - ulid form: coreapi.GetRepo(ulid) -> Repo.ClusterHost, mapped by host via
+//     cellTargetForClusterHost. A ULID already names one placement
+//     unambiguously, so there is no processing-placement lookup to do.
+//   - owner/repo form: delegates to resolveRepoCellPlacement (see its doc
+//     comment for why the two functions stay separate) and discards the
+//     placement id.
+func resolveRepoCellTarget(ctx context.Context, fullName, ulid string) (*auth.CellTarget, error) {
+	if strings.TrimSpace(ulid) != "" {
+		ctx, cancel := context.WithTimeout(ctx, requiredCellResolveTimeout)
+		defer cancel()
 
-	c, err := newCellCoreClient()
+		c, err := newCellCoreClient()
+		if err != nil {
+			return nil, fmt.Errorf("control plane unavailable: %w", err)
+		}
+		repo, err := c.GetRepo(ctx, coreapi.GetRepoParams{RepoId: ulid})
+		if err != nil {
+			return nil, fmt.Errorf("resolve the Entire cell for %s: %w", ulid, err)
+		}
+		clusterHost := strings.TrimSpace(repo.ClusterHost.Or(""))
+		if clusterHost == "" {
+			return nil, fmt.Errorf("resolve the Entire cell for %s: repo has no cluster host", ulid)
+		}
+		target, err := cellTargetForClusterHost(ctx, c, clusterHost)
+		if err != nil {
+			return nil, fmt.Errorf("resolve the Entire cell for %s: %w", ulid, err)
+		}
+		return target, nil
+	}
+
+	owner, repo, ok := strings.Cut(strings.TrimSpace(fullName), "/")
+	if !ok || owner == "" || repo == "" {
+		return nil, fmt.Errorf("invalid repo %q: expected owner/repo", fullName)
+	}
+	placement, err := resolveRepoCellPlacement(ctx, owner, repo)
 	if err != nil {
-		logging.Debug(ctx, "cell target: core client unavailable, using home-jurisdiction routing", "error", err.Error())
-		return nil
+		return nil, err
 	}
-
-	clusterHost, ok := resolveRepoClusterHost(ctx, c, fullName, ulid)
-	if !ok || clusterHost == "" {
-		return nil
-	}
-
-	return cellTargetForClusterHost(ctx, c, clusterHost)
+	return placement.Target, nil
 }
 
 // cellTargetForClusterHost maps a known cluster host to a cell apiUrl +
 // jurisdiction via the coreapi cluster catalog, the authoritative source for a
-// jurisdiction's cell URL. Returns nil for every unresolvable case so callers
-// fall back to home-jurisdiction routing.
-func cellTargetForClusterHost(ctx context.Context, c cellCoreClient, clusterHost string) *auth.CellTarget {
+// jurisdiction's cell URL. Used by the ULID path only: a GetRepo response
+// names a cluster host, not a slug.
+func cellTargetForClusterHost(ctx context.Context, c cellCoreClient, clusterHost string) (*auth.CellTarget, error) {
 	clusters, err := c.ListClusters(ctx)
 	if err != nil {
-		logging.Debug(ctx, "cell target: list clusters failed, using home-jurisdiction routing", "error", err.Error())
-		return nil
+		return nil, fmt.Errorf("list clusters: %w", err)
 	}
 	cluster, ok := matchClusterByHost(clusters.Clusters, clusterHost)
 	if !ok {
-		logging.Debug(ctx, "cell target: no cluster matched repo host, using home-jurisdiction routing", "cluster_host", clusterHost)
-		return nil
+		return nil, fmt.Errorf("no cluster matches host %q", clusterHost)
 	}
+	return cellTargetFromCluster(cluster)
+}
+
+// cellTargetForClusterSlug maps a known cluster slug (a RepoPlacement's
+// ClusterSlug) to a cell apiUrl + jurisdiction via the coreapi cluster
+// catalog. The slug, not the host, is the reliable join key for a
+// RepoPlacement — see cell_fanout.go's groupReposByCell for the same rule
+// applied to the repo-set fan-out path.
+func cellTargetForClusterSlug(ctx context.Context, c cellCoreClient, clusterSlug string) (*auth.CellTarget, error) {
+	clusters, err := c.ListClusters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list clusters: %w", err)
+	}
+	cluster, ok := matchClusterBySlug(clusters.Clusters, clusterSlug)
+	if !ok {
+		return nil, fmt.Errorf("no cluster matches slug %q", clusterSlug)
+	}
+	return cellTargetFromCluster(cluster)
+}
+
+// cellTargetFromCluster extracts the apiUrl + jurisdiction a matched catalog
+// cluster resolves to, shared by the host- and slug-keyed joins above.
+func cellTargetFromCluster(cluster coreapi.Cluster) (*auth.CellTarget, error) {
 	apiURL := strings.TrimRight(strings.TrimSpace(cluster.ApiUrl.Or("")), "/")
 	// DNS is case-insensitive; normalise the catalog jurisdiction so a
 	// non-lowercase value still passes the auth layer's strict label check
 	// instead of hard-failing the target path.
 	jurisdiction := strings.ToLower(strings.TrimSpace(cluster.Jurisdiction))
 	if apiURL == "" || jurisdiction == "" {
-		logging.Debug(ctx, "cell target: matched cluster missing apiUrl/jurisdiction, using home-jurisdiction routing", "cluster_host", clusterHost)
-		return nil
+		return nil, fmt.Errorf("matched cluster %q is missing apiUrl/jurisdiction", cluster.Slug)
 	}
-	return &auth.CellTarget{BaseURL: apiURL, Jurisdiction: jurisdiction}
+	return &auth.CellTarget{BaseURL: apiURL, Jurisdiction: jurisdiction}, nil
 }
 
-// repoCellPlacement is one active mirror placement: the id entire-api keys
+// errRepoNotOnboarded signals that fullName has no entry at all in the
+// control plane's repos index — a definitive, not transient, negative.
+// Callers that persist a per-repo enabled/disabled decision (trails'
+// background enablement cache) should treat this the same way they'd treat
+// an explicit "not found" from the data API, rather than leaving the
+// decision unresolved forever.
+var errRepoNotOnboarded = errors.New("repo is not onboarded to Entire")
+
+// resolveProcessingPlacement resolves fullName's PROCESSING placement — the
+// placement id and cell entire-api and the control plane treat as
+// authoritative for repo-scoped data (trails, experts, checkpoint/explain),
+// mirroring the entire.io BFF's processingPlacement() selection
+// (list-repos-index.ts). A repo can be mirrored in several regions; only this
+// one placement is guaranteed to hold the repo's actual data.
+func resolveProcessingPlacement(ctx context.Context, c cellCoreClient, fullName string) (coreapi.RepoPlacement, error) {
+	out, err := c.ListRepos(ctx, coreapi.ListReposParams{Filter: coreapi.NewOptString(fullName)})
+	if err != nil {
+		return coreapi.RepoPlacement{}, fmt.Errorf("list repos: %w", err)
+	}
+	if len(out.Repos) == 0 {
+		return coreapi.RepoPlacement{}, fmt.Errorf("%s: %w", fullName, errRepoNotOnboarded)
+	}
+	entry := out.Repos[0]
+	// Filter is documented as an exact-match lookup restricted to fullName, so
+	// beyond this identity check and the zero-length check above, Repos[0] is
+	// the only possible row. The check exists because that promise lives only
+	// in the OpenAPI doc, not in this code: if the control plane ever ignored
+	// or dropped Filter, entry could silently be an unrelated repo — exactly
+	// the wrong-region-success bug class this resolver exists to kill.
+	if !strings.EqualFold(strings.TrimSpace(entry.FullName), strings.TrimSpace(fullName)) {
+		return coreapi.RepoPlacement{}, fmt.Errorf("control plane returned %q for %s", entry.FullName, fullName)
+	}
+	// A Filter lookup bypasses ListRepos' default scope=onboarded restriction
+	// (see the OpenAPI doc on ListReposParams.Filter), so it can return a row
+	// for a repo that exists on the forge and is visible to the caller but was
+	// never onboarded to Entire: a Candidate set, with no placements or
+	// primaries to resolve. This is the common real-world "not onboarded"
+	// shape — a repo a developer just happens to work in — as opposed to the
+	// zero-rows case below (caller can't see it, or it doesn't exist at all).
+	if _, isCandidate := entry.Candidate.Get(); isCandidate {
+		return coreapi.RepoPlacement{}, fmt.Errorf("%s: %w", fullName, errRepoNotOnboarded)
+	}
+	primaries, ok := entry.Primaries.Get()
+	processingID := strings.TrimSpace(primaries.Processing)
+	if !ok || processingID == "" {
+		return coreapi.RepoPlacement{}, fmt.Errorf("%s has no processing placement: %w", fullName, errRepoNotOnboarded)
+	}
+	for _, p := range entry.Placements {
+		if p.ID != processingID {
+			continue
+		}
+		if p.Status == coreapi.RepoPlacementStatusFailed || p.Status == coreapi.RepoPlacementStatusSuspended {
+			return coreapi.RepoPlacement{}, fmt.Errorf("%s's processing placement is %s", fullName, p.Status)
+		}
+		return p, nil
+	}
+	// Defensive: primaries.processing should always name a placement present
+	// in the same response.
+	return coreapi.RepoPlacement{}, fmt.Errorf("%s's processing placement %q is not in its placement list", fullName, processingID)
+}
+
+// repoCellPlacement is a repo's processing placement: the id entire-api keys
 // repo-scoped routes on, paired with the cell that actually holds it.
 type repoCellPlacement struct {
-	// RepoID is the mirror id, which entire-api uses as its repo_id.
+	// RepoID is the placement id (coreapi.RepoPlacement.ID), which entire-api
+	// uses as its repo_id — verified identical to the id the old
+	// mirrors-based lookup used (coreapi.Mirror.MirrorId) for the same
+	// placement.
 	RepoID string
 	// Target is the cell hosting THIS placement.
 	Target *auth.CellTarget
 }
 
-// resolveRepoCellPlacement resolves a GitHub repo to one active placement's
-// (repo_id, cell) pair for repo-scoped cell reads.
+// resolveRepoCellPlacement resolves a GitHub repo to its processing
+// placement's (repo_id, cell) pair for repo-scoped cell reads.
 //
-// The pair must come from the same placement: each placement has its own mirror
-// id, and only the cell hosting that placement can resolve it. Taking the id
-// from one placement and routing to a cell chosen some other way — the caller's
-// home cell, say — asks a cell about an id it has never seen, which comes back
-// as an indistinguishable 404. That is also why this does not reuse
-// resolveRepoCellTarget's owner/repo path: that one deliberately refuses to pick
-// among multi-region placements and falls back to the home cell, which is
-// exactly the mismatch to avoid here.
+// The pair must come from the same placement: a placement id is only
+// resolvable by the cell hosting that placement, and entire-api's data lives
+// on exactly one placement (the processing one) even when the repo is
+// mirrored elsewhere too. Taking the id from one placement and routing to a
+// cell chosen some other way asks a cell about an id it has never seen, which
+// comes back as an indistinguishable 404.
+//
+// resolveRepoCellTarget's owner/repo path delegates to this function and
+// discards RepoID, rather than the two duplicating the same resolution body:
+// the two functions exist separately only because their callers need
+// different return shapes for the same lookup — this one also needs the
+// placement id (repo_id), which resolveRepoCellTarget has no caller for and
+// so doesn't return — not because the resolution logic itself differs.
 func resolveRepoCellPlacement(ctx context.Context, owner, repo string) (repoCellPlacement, error) {
 	ctx, cancel := context.WithTimeout(ctx, requiredCellResolveTimeout)
 	defer cancel()
@@ -138,79 +246,27 @@ func resolveRepoCellPlacement(ctx context.Context, owner, repo string) (repoCell
 	if err != nil {
 		return repoCellPlacement{}, fmt.Errorf("control plane unavailable: %w", err)
 	}
-	mirrors, err := listMirrorsForRepo(ctx, c, mirrorCloneProviderGitHub, strings.ToLower(owner), strings.ToLower(repo))
+	fullName := owner + "/" + repo
+	placement, err := resolveProcessingPlacement(ctx, c, fullName)
 	if err != nil {
-		return repoCellPlacement{}, cellPlacementError(ctx, owner, repo, fmt.Errorf("list mirrors for %s/%s: %w", owner, repo, err))
+		return repoCellPlacement{}, cellPlacementError(ctx, owner, repo, fmt.Errorf("resolve processing placement for %s: %w", fullName, err))
 	}
-	for i := range mirrors {
-		if !isActiveMirror(mirrors[i]) {
-			continue
-		}
-		repoID := strings.TrimSpace(mirrors[i].MirrorId)
-		clusterHost := strings.TrimSpace(mirrors[i].ClusterHost)
-		if repoID == "" || clusterHost == "" {
-			continue
-		}
-		target := cellTargetForClusterHost(ctx, c, clusterHost)
-		if target == nil {
-			// The catalog can't place this cluster; try the next placement
-			// rather than falling back to a cell that doesn't know this id.
-			continue
-		}
-		return repoCellPlacement{RepoID: repoID, Target: target}, nil
+	target, err := cellTargetForClusterSlug(ctx, c, placement.ClusterSlug)
+	if err != nil {
+		return repoCellPlacement{}, cellPlacementError(ctx, owner, repo, fmt.Errorf("resolve cell for %s: %w", fullName, err))
 	}
-	// A deadline that fired mid-loop leaves cellTargetForClusterHost returning
-	// nil for every placement, which would otherwise be reported as "no
-	// reachable mirror" — a wrong diagnosis for a slow control plane.
-	return repoCellPlacement{}, cellPlacementError(ctx, owner, repo,
-		fmt.Errorf("no reachable Entire mirror for %s/%s", owner, repo))
+	return repoCellPlacement{RepoID: placement.ID, Target: target}, nil
 }
 
-// cellPlacementError reports a timeout as a timeout. The underlying lookups
-// degrade quietly (cellTargetForClusterHost logs and returns nil), so without
-// this a fired deadline surfaces as whichever "not found" message the caller
-// reached, and the user goes looking for a missing mirror instead of a slow
-// control plane.
+// cellPlacementError reports a timeout as a timeout: without this, a fired
+// deadline surfaces as whichever "not found"/"no processing placement" error
+// the caller's lookup happened to return, and the user goes looking for a
+// missing mirror instead of a slow control plane.
 func cellPlacementError(ctx context.Context, owner, repo string, fallback error) error {
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		return fmt.Errorf("resolving the Entire mirror for %s/%s timed out: %w", owner, repo, ctxErr)
+		return fmt.Errorf("resolving the Entire cell for %s/%s timed out: %w", owner, repo, ctxErr)
 	}
 	return fallback
-}
-
-// resolveRepoClusterHost finds the public cluster host that owns the repo. It
-// returns ok=false to signal "fall back to home-jurisdiction routing" for every
-// unresolved or ambiguous case, never an error.
-func resolveRepoClusterHost(ctx context.Context, c cellCoreClient, fullName, ulid string) (string, bool) {
-	if strings.TrimSpace(ulid) != "" {
-		repo, err := c.GetRepo(ctx, coreapi.GetRepoParams{RepoId: ulid})
-		if err != nil {
-			logging.Debug(ctx, "cell target: GetRepo failed, using home-jurisdiction routing", "error", err.Error())
-			return "", false
-		}
-		return strings.TrimSpace(repo.ClusterHost.Or("")), true
-	}
-
-	owner, repo, ok := strings.Cut(strings.TrimSpace(fullName), "/")
-	if !ok || owner == "" || repo == "" {
-		return "", false
-	}
-	mirrors, err := listMirrorsForRepo(ctx, c, mirrorCloneProviderGitHub, strings.ToLower(owner), strings.ToLower(repo))
-	if err != nil {
-		logging.Debug(ctx, "cell target: list mirrors failed, using home-jurisdiction routing", "error", err.Error())
-		return "", false
-	}
-	hosts := distinctActiveClusterHosts(mirrors)
-	if len(hosts) != 1 {
-		// Zero placements (not mirrored / unknown) or multiple regions
-		// (ambiguous which cell holds the repo-scoped data): fall back rather than
-		// guess a region.
-		if len(hosts) > 1 {
-			logging.Debug(ctx, "cell target: repo mirrored in multiple regions, using home-jurisdiction routing", "count", len(hosts))
-		}
-		return "", false
-	}
-	return hosts[0], true
 }
 
 // isActiveMirror reports whether a mirror placement can currently serve the
@@ -225,37 +281,10 @@ func isActiveMirror(m coreapi.Mirror) bool {
 	return st != coreapi.MirrorStatusFailed && st != coreapi.MirrorStatusSuspended
 }
 
-// distinctActiveClusterHosts returns the set of cluster hosts a repo is actively
-// serviced on: excluding archived placements and unhealthy ones (failed /
-// suspended clone status), since those cells can't answer for the repo.
-// A failed/suspended placement must neither manufacture false cross-region
-// ambiguity nor become a sole "active" host. Case-folded to match DNS
-// semantics; order is unimportant (callers only use a single-member set).
-func distinctActiveClusterHosts(mirrors []coreapi.Mirror) []string {
-	seen := make(map[string]string, len(mirrors))
-	for _, m := range mirrors {
-		if !isActiveMirror(m) {
-			continue
-		}
-		host := strings.TrimSpace(m.ClusterHost)
-		if host == "" {
-			continue
-		}
-		key := strings.ToLower(host)
-		if _, ok := seen[key]; !ok {
-			seen[key] = host
-		}
-	}
-	out := make([]string, 0, len(seen))
-	for _, host := range seen {
-		out = append(out, host)
-	}
-	return out
-}
-
 // matchClusterByHost finds the catalog cluster whose public host equals
 // clusterHost (case-insensitive). The cluster's apiUrl + jurisdiction are the
-// authoritative cell coordinates.
+// authoritative cell coordinates. Used by the ULID path (GetRepo returns a
+// host, not a slug).
 func matchClusterByHost(clusters []coreapi.Cluster, clusterHost string) (coreapi.Cluster, bool) {
 	want := strings.ToLower(strings.TrimSpace(clusterHost))
 	if want == "" {
@@ -267,6 +296,24 @@ func matchClusterByHost(clusters []coreapi.Cluster, clusterHost string) (coreapi
 			continue
 		}
 		if strings.EqualFold(strings.TrimSpace(host), want) {
+			return cl, true
+		}
+	}
+	return coreapi.Cluster{}, false
+}
+
+// matchClusterBySlug finds the catalog cluster whose Slug equals clusterSlug
+// (case-insensitive). Used by the owner/repo path: a RepoPlacement carries a
+// ClusterSlug, not a host, so this is the reliable join for it (the catalog
+// does not expose a cell field, so slug — not cell name — is the only
+// reliable join key; see cell_fanout.go's groupReposByCell for the same rule).
+func matchClusterBySlug(clusters []coreapi.Cluster, clusterSlug string) (coreapi.Cluster, bool) {
+	want := strings.ToLower(strings.TrimSpace(clusterSlug))
+	if want == "" {
+		return coreapi.Cluster{}, false
+	}
+	for _, cl := range clusters {
+		if strings.EqualFold(strings.TrimSpace(cl.Slug), want) {
 			return cl, true
 		}
 	}

--- a/cmd/entire/cli/cell_target_test.go
+++ b/cmd/entire/cli/cell_target_test.go
@@ -425,7 +425,8 @@ func processingResolutionErrorCases() []processingResolutionErrorCase {
 				e.Primaries = coreapi.OptRepoPrimaries{} // unset
 				return e
 			}()),
-			clusters: clustersWithSlugs(),
+			clusters:         clustersWithSlugs(),
+			wantNotOnboarded: true,
 		},
 		{
 			name: "processing placement failed",
@@ -472,8 +473,8 @@ func TestResolveRepoCellTarget_OwnerRepo_ProcessingResolutionErrors(t *testing.T
 			if target != nil {
 				t.Fatalf("expected a nil target alongside the error, got %+v", target)
 			}
-			if tc.wantNotOnboarded && !errors.Is(err, errRepoNotOnboarded) {
-				t.Fatalf("expected errRepoNotOnboarded, got: %v", err)
+			if got := errors.Is(err, errRepoNotOnboarded); got != tc.wantNotOnboarded {
+				t.Fatalf("errors.Is(err, errRepoNotOnboarded) = %v, want %v (err: %v)", got, tc.wantNotOnboarded, err)
 			}
 		})
 	}
@@ -487,8 +488,8 @@ func TestResolveRepoCellPlacement_ProcessingResolutionErrors(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected an error")
 			}
-			if tc.wantNotOnboarded && !errors.Is(err, errRepoNotOnboarded) {
-				t.Fatalf("expected errRepoNotOnboarded, got: %v", err)
+			if got := errors.Is(err, errRepoNotOnboarded); got != tc.wantNotOnboarded {
+				t.Fatalf("errors.Is(err, errRepoNotOnboarded) = %v, want %v (err: %v)", got, tc.wantNotOnboarded, err)
 			}
 		})
 	}

--- a/cmd/entire/cli/cell_target_test.go
+++ b/cmd/entire/cli/cell_target_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -15,38 +14,18 @@ const euCellAPIURL = "https://eu.api.entire.io"
 
 const euWestCell = "aws-eu-west-1"
 
-func TestDistinctActiveClusterHosts(t *testing.T) {
-	t.Parallel()
-	mirrors := []coreapi.Mirror{
-		{ClusterHost: "aws-us-east-2.entire.io"},
-		{ClusterHost: "AWS-US-EAST-2.entire.io"}, // dup (case-insensitive) → collapses
-		{ClusterHost: "aws-eu-west-1.entire.io"}, // distinct active
-		// Unique host that is archived → must be excluded (observably absent).
-		{ClusterHost: "aws-ap-south-1.entire.io", IsArchived: coreapi.NewOptBool(true)},
-		// Unique host with a failed clone → excluded (can't serve experts).
-		{ClusterHost: "aws-sa-east-1.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusFailed)},
-		// Unique host suspended → excluded.
-		{ClusterHost: "aws-ca-central-1.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusSuspended)},
-		{ClusterHost: ""}, // empty → excluded
-	}
-	got := distinctActiveClusterHosts(mirrors)
-	sort.Strings(got)
-	want := []string{"aws-eu-west-1.entire.io", "aws-us-east-2.entire.io"}
-	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
-		t.Fatalf("distinctActiveClusterHosts = %v, want %v", got, want)
-	}
-}
+// usCellAPIURL and usClusterSlug mirror the real aws-us-east-2 cell that
+// entirehq/entire.io's processing placement lives on in prod, so the
+// multi-homed regression tests below reproduce the actual bug rather than an
+// invented topology.
+const (
+	usCellAPIURL  = "https://aws-us-east-2.api.entire.io"
+	usClusterSlug = "aws-us-east-2"
 
-func TestDistinctActiveClusterHosts_AllInactive(t *testing.T) {
-	t.Parallel()
-	mirrors := []coreapi.Mirror{
-		{ClusterHost: "aws-us-east-2.entire.io", IsArchived: coreapi.NewOptBool(true)},
-		{ClusterHost: "aws-eu-west-1.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusFailed)},
-	}
-	if got := distinctActiveClusterHosts(mirrors); len(got) != 0 {
-		t.Fatalf("distinctActiveClusterHosts = %v, want empty", got)
-	}
-}
+	euClusterSlug          = euWestCell
+	apSoutheastClusterSlug = "aws-ap-southeast-1"
+	apSouthClusterSlug     = "aws-ap-south-1"
+)
 
 func TestMatchClusterByHost(t *testing.T) {
 	t.Parallel()
@@ -72,38 +51,47 @@ func TestMatchClusterByHost(t *testing.T) {
 	}
 }
 
-// TestClusterHostJoin exercises the realistic invariant that a mirror's
-// ClusterHost joins to a cluster whose PublicUrl host equals it — the actual
-// key the resolver relies on.
-func TestClusterHostJoin(t *testing.T) {
+// TestMatchClusterBySlug mirrors TestMatchClusterByHost for the slug-keyed
+// join used by the processing-placement path: the catalog's Slug, not its
+// PublicUrl host, is the reliable join key for a RepoPlacement.
+func TestMatchClusterBySlug(t *testing.T) {
 	t.Parallel()
-	mirrors := []coreapi.Mirror{{ClusterHost: "eu.entire.io", Repo: "widget"}}
-	clusters := []coreapi.Cluster{
-		{PublicUrl: "https://us.entire.io", Jurisdiction: "us", ApiUrl: coreapi.NewOptString("https://us.api.entire.io")},
-		{PublicUrl: "https://eu.entire.io", Jurisdiction: "eu", ApiUrl: coreapi.NewOptString(euCellAPIURL)},
+	clusters := clustersWithSlugs()
+
+	cl, ok := matchClusterBySlug(clusters, usClusterSlug)
+	if !ok {
+		t.Fatalf("expected a match for %s", usClusterSlug)
 	}
-	hosts := distinctActiveClusterHosts(mirrors)
-	if len(hosts) != 1 {
-		t.Fatalf("hosts = %v, want 1", hosts)
+	if cl.Jurisdiction != "us" || cl.ApiUrl.Or("") != usCellAPIURL {
+		t.Fatalf("matched wrong cluster: %+v", cl)
 	}
-	cl, ok := matchClusterByHost(clusters, hosts[0])
-	if !ok || cl.Jurisdiction != "eu" || cl.ApiUrl.Or("") != euCellAPIURL {
-		t.Fatalf("join failed: ok=%v cluster=%+v", ok, cl)
+
+	if _, ok := matchClusterBySlug(clusters, "unknown-slug"); ok {
+		t.Fatal("expected no match for unknown slug")
+	}
+	if _, ok := matchClusterBySlug(clusters, ""); ok {
+		t.Fatal("expected no match for empty slug")
 	}
 }
 
-// fakeCellCore is a stub control plane for resolveRepoCellTarget tests.
+// fakeCellCore is a stub control plane for resolveRepoCellTarget /
+// resolveRepoCellPlacement tests.
 type fakeCellCore struct {
 	repo        *coreapi.Repo
 	repoErr     error
-	mirrors     []coreapi.Mirror
-	mirrorsErr  error
 	clusters    []coreapi.Cluster
 	clustersErr error
-	// blockUntilCtxDone makes the lookups hang until the caller's deadline
+	repos       *coreapi.ListReposOutputBody
+	reposErr    error
+	// blockUntilCtxDone makes ListRepos hang until the caller's deadline
 	// fires, standing in for a reachable-but-slow control plane. Off by
 	// default, so existing tests are unaffected.
 	blockUntilCtxDone bool
+	// lastListReposParams records the params passed to the most recent
+	// ListRepos call, so a test can assert the resolver actually sets Filter
+	// to the requested repo rather than merely returning whatever fixture was
+	// configured regardless of what was asked.
+	lastListReposParams coreapi.ListReposParams
 }
 
 // waitIfBlocking simulates a core that accepts the connection and then stalls.
@@ -126,14 +114,18 @@ func (f *fakeCellCore) ListClusters(context.Context) (*coreapi.ListClustersOutpu
 	return &coreapi.ListClustersOutputBody{Clusters: f.clusters}, nil
 }
 
-func (f *fakeCellCore) ListMirrors(ctx context.Context, _ coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error) {
+func (f *fakeCellCore) ListRepos(ctx context.Context, params coreapi.ListReposParams) (*coreapi.ListReposOutputBody, error) {
+	f.lastListReposParams = params
 	if err := f.waitIfBlocking(ctx); err != nil {
 		return nil, err
 	}
-	if f.mirrorsErr != nil {
-		return nil, f.mirrorsErr
+	if f.reposErr != nil {
+		return nil, f.reposErr
 	}
-	return &coreapi.ListMirrorsOutputBody{Mirrors: f.mirrors}, nil
+	if f.repos != nil {
+		return f.repos, nil
+	}
+	return &coreapi.ListReposOutputBody{}, nil
 }
 
 func withFakeCellCore(t *testing.T, f *fakeCellCore) {
@@ -143,10 +135,106 @@ func withFakeCellCore(t *testing.T, f *fakeCellCore) {
 	t.Cleanup(func() { newCellCoreClient = prev })
 }
 
+// euClusters is keyed by PublicUrl host, the join the ULID path uses
+// (cellTargetForClusterHost / matchClusterByHost).
 func euClusters() []coreapi.Cluster {
 	return []coreapi.Cluster{
 		{PublicUrl: "https://us.entire.io", Jurisdiction: "us", ApiUrl: coreapi.NewOptString("https://us.api.entire.io")},
 		{PublicUrl: "https://eu.entire.io", Jurisdiction: "eu", ApiUrl: coreapi.NewOptString(euCellAPIURL)},
+	}
+}
+
+// clustersWithSlugs is keyed by Slug, the join the owner/repo path uses
+// (cellTargetForClusterSlug / matchClusterBySlug) against a RepoPlacement's
+// ClusterSlug.
+func clustersWithSlugs() []coreapi.Cluster {
+	return []coreapi.Cluster{
+		{Slug: usClusterSlug, Jurisdiction: "us", PublicUrl: "https://us.entire.io", ApiUrl: coreapi.NewOptString(usCellAPIURL)},
+		{Slug: euClusterSlug, Jurisdiction: "eu", PublicUrl: "https://eu.entire.io", ApiUrl: coreapi.NewOptString(euCellAPIURL)},
+		{Slug: apSoutheastClusterSlug, Jurisdiction: "ap-southeast", PublicUrl: "https://ap-southeast.entire.io", ApiUrl: coreapi.NewOptString("https://aws-ap-southeast-1.api.entire.io")},
+		{Slug: apSouthClusterSlug, Jurisdiction: "ap-south", PublicUrl: "https://ap-south.entire.io", ApiUrl: coreapi.NewOptString("https://aws-ap-south-1.api.entire.io")},
+	}
+}
+
+// placementFixture is one entry of a RepoIndexEntry.Placements list.
+type placementFixture struct {
+	id     string
+	slug   string
+	status coreapi.RepoPlacementStatus
+}
+
+// repoIndexFixture builds a RepoIndexEntry for fullName from an ordered list
+// of placements, with processingID naming the placement that is
+// primaries.processing. Order in placements is preserved, so a fixture can
+// deliberately put the processing placement somewhere other than index 0 -
+// proving a resolver picks it by id, not by position.
+func repoIndexFixture(fullName, processingID string, placements ...placementFixture) coreapi.RepoIndexEntry {
+	out := make([]coreapi.RepoPlacement, 0, len(placements))
+	for _, p := range placements {
+		status := p.status
+		if status == "" {
+			status = coreapi.RepoPlacementStatusReady
+		}
+		out = append(out, coreapi.RepoPlacement{
+			ID:          p.id,
+			ClusterSlug: p.slug,
+			Cell:        p.slug,
+			Status:      status,
+		})
+	}
+	return coreapi.RepoIndexEntry{
+		FullName:   fullName,
+		ID:         "repo-" + fullName,
+		Primaries:  coreapi.NewOptRepoPrimaries(coreapi.RepoPrimaries{Processing: processingID}),
+		Placements: out,
+	}
+}
+
+// fourRegionFixture reproduces entirehq/entire.io's real prod topology: four
+// active placements, with the US one (deliberately not first in the list)
+// naming primaries.processing. This is the shape that used to make
+// resolveRepoClusterHost see >1 distinct active cluster host and refuse.
+func fourRegionFixture() coreapi.RepoIndexEntry {
+	return repoIndexFixture("entirehq/entire.io", "mirror-us",
+		placementFixture{id: "mirror-eu", slug: euClusterSlug},
+		placementFixture{id: "mirror-ap-southeast", slug: apSoutheastClusterSlug},
+		placementFixture{id: "mirror-ap-south", slug: apSouthClusterSlug},
+		placementFixture{id: "mirror-us", slug: usClusterSlug},
+	)
+}
+
+// fourRegionFixtureProcessingInMiddle is the same real topology as
+// fourRegionFixture but with the processing placement in the middle of the
+// list, so neither a "first" nor a "last" positional heuristic could
+// accidentally satisfy this test — only selection by primaries.processing id
+// can.
+func fourRegionFixtureProcessingInMiddle() coreapi.RepoIndexEntry {
+	return repoIndexFixture("entirehq/entire.io", "mirror-us",
+		placementFixture{id: "mirror-eu", slug: euClusterSlug},
+		placementFixture{id: "mirror-us", slug: usClusterSlug},
+		placementFixture{id: "mirror-ap-southeast", slug: apSoutheastClusterSlug},
+		placementFixture{id: "mirror-ap-south", slug: apSouthClusterSlug},
+	)
+}
+
+func reposOutput(entries ...coreapi.RepoIndexEntry) *coreapi.ListReposOutputBody {
+	return &coreapi.ListReposOutputBody{Repos: entries}
+}
+
+// candidateRepoIndexFixture builds a RepoIndexEntry for a repo that ListRepos'
+// Filter can find (it exists on the forge and the caller can see it) but that
+// has never been onboarded to Entire: a Candidate is set, and there are no
+// placements or primaries to resolve. This is the common "random repo a
+// developer works in" shape, as opposed to the zero-rows "not found at all"
+// shape.
+func candidateRepoIndexFixture(fullName string) coreapi.RepoIndexEntry {
+	return coreapi.RepoIndexEntry{
+		FullName: fullName,
+		ID:       "repo-" + fullName,
+		Candidate: coreapi.NewOptRepoCandidate(coreapi.RepoCandidate{
+			Access:      coreapi.RepoCandidateAccessRead,
+			Onboardable: true,
+		}),
 	}
 }
 
@@ -155,7 +243,10 @@ func TestResolveRepoCellTarget_ULID(t *testing.T) {
 		repo:     &coreapi.Repo{ID: "ULID", ClusterHost: coreapi.NewOptString("eu.entire.io")},
 		clusters: euClusters(),
 	})
-	target := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	target, err := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	if err != nil {
+		t.Fatalf("resolveRepoCellTarget: %v", err)
+	}
 	if target == nil {
 		t.Fatal("expected a target for a resolvable ULID")
 	}
@@ -164,50 +255,28 @@ func TestResolveRepoCellTarget_ULID(t *testing.T) {
 	}
 }
 
-func TestResolveRepoCellTarget_ULIDError_FallsBack(t *testing.T) {
+func TestResolveRepoCellTarget_ULIDError_ReturnsError(t *testing.T) {
 	withFakeCellCore(t, &fakeCellCore{repoErr: errors.New("boom"), clusters: euClusters()})
-	if target := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV"); target != nil {
-		t.Fatalf("expected nil (fallback) on GetRepo error, got %+v", target)
+	target, err := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	if err == nil {
+		t.Fatalf("expected an error on GetRepo failure, got target=%+v", target)
+	}
+	if target != nil {
+		t.Fatalf("expected a nil target alongside the error, got %+v", target)
 	}
 }
 
-func TestResolveRepoCellTarget_OwnerRepoSingleRegion(t *testing.T) {
-	withFakeCellCore(t, &fakeCellCore{
-		mirrors: []coreapi.Mirror{
-			{Repo: "widget", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
-			// A failed placement in another region must be ignored, not create ambiguity.
-			{Repo: "widget", ClusterHost: "us.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusFailed)},
-			// A different repo must be filtered out by listMirrorsForRepo.
-			{Repo: "other", ClusterHost: "us.entire.io"},
-		},
-		clusters: euClusters(),
-	})
-	target := resolveRepoCellTarget(context.Background(), "acme/widget", "")
-	if target == nil || target.Jurisdiction != "eu" || target.BaseURL != euCellAPIURL {
-		t.Fatalf("target = %+v, want eu cell", target)
-	}
-}
-
-func TestResolveRepoCellTarget_MultiRegion_FallsBack(t *testing.T) {
-	withFakeCellCore(t, &fakeCellCore{
-		mirrors: []coreapi.Mirror{
-			{Repo: "widget", ClusterHost: "eu.entire.io"},
-			{Repo: "widget", ClusterHost: "us.entire.io"},
-		},
-		clusters: euClusters(),
-	})
-	if target := resolveRepoCellTarget(context.Background(), "acme/widget", ""); target != nil {
-		t.Fatalf("expected nil (fallback) for ambiguous multi-region repo, got %+v", target)
-	}
-}
-
-func TestResolveRepoCellTarget_NoClusterMatch_FallsBack(t *testing.T) {
+func TestResolveRepoCellTarget_NoClusterMatch_ReturnsError(t *testing.T) {
 	withFakeCellCore(t, &fakeCellCore{
 		repo:     &coreapi.Repo{ClusterHost: coreapi.NewOptString("ap.entire.io")}, // not in catalog
 		clusters: euClusters(),
 	})
-	if target := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV"); target != nil {
-		t.Fatalf("expected nil (fallback) when no cluster matches, got %+v", target)
+	target, err := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	if err == nil {
+		t.Fatalf("expected an error when no cluster matches, got target=%+v", target)
+	}
+	if target != nil {
+		t.Fatalf("expected a nil target alongside the error, got %+v", target)
 	}
 }
 
@@ -218,23 +287,225 @@ func TestResolveRepoCellTarget_JurisdictionLowercased(t *testing.T) {
 			{PublicUrl: "https://eu.entire.io", Jurisdiction: "EU", ApiUrl: coreapi.NewOptString(euCellAPIURL)},
 		},
 	})
-	target := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	target, err := resolveRepoCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	if err != nil {
+		t.Fatalf("resolveRepoCellTarget: %v", err)
+	}
 	if target == nil || target.Jurisdiction != "eu" {
 		t.Fatalf("target = %+v, want lowercased jurisdiction eu", target)
 	}
 }
 
+func TestResolveRepoCellTarget_OwnerRepo_SingleHomedRepo(t *testing.T) {
+	fake := &fakeCellCore{
+		repos: reposOutput(repoIndexFixture("acme/widget", "mirror-eu",
+			placementFixture{id: "mirror-eu", slug: euClusterSlug},
+		)),
+		clusters: clustersWithSlugs(),
+	}
+	withFakeCellCore(t, fake)
+	target, err := resolveRepoCellTarget(context.Background(), "acme/widget", "")
+	if err != nil {
+		t.Fatalf("resolveRepoCellTarget: %v", err)
+	}
+	if target == nil || target.Jurisdiction != "eu" || target.BaseURL != euCellAPIURL {
+		t.Fatalf("target = %+v, want eu cell", target)
+	}
+	// Proves the resolver actually sets Filter to the requested repo, not
+	// just that the fake happens to return the right fixture regardless of
+	// what was asked.
+	if got := fake.lastListReposParams.Filter.Or(""); got != "acme/widget" {
+		t.Errorf("ListRepos Filter = %q, want %q", got, "acme/widget")
+	}
+}
+
+// This is the regression test for the actual production bug: a repo mirrored
+// in 4 regions (entirehq/entire.io's real topology) used to make
+// resolveRepoClusterHost see >1 distinct cluster host and refuse, falling
+// back to home-jurisdiction routing (wrong-region silent failure for `entire
+// trail`/`entire experts`). It must resolve to the PROCESSING placement's
+// cell (us) regardless of how many other regions the repo is mirrored in.
+func TestResolveRepoCellTarget_OwnerRepo_MultiHomedRepo_ResolvesProcessingCell(t *testing.T) {
+	fixtures := map[string]coreapi.RepoIndexEntry{
+		"processing last":   fourRegionFixture(),
+		"processing middle": fourRegionFixtureProcessingInMiddle(),
+	}
+	for name, fixture := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			withFakeCellCore(t, &fakeCellCore{
+				repos:    reposOutput(fixture),
+				clusters: clustersWithSlugs(),
+			})
+			target, err := resolveRepoCellTarget(context.Background(), "entirehq/entire.io", "")
+			if err != nil {
+				t.Fatalf("resolveRepoCellTarget: %v", err)
+			}
+			if target == nil {
+				t.Fatal("expected a target for a multi-homed repo's processing cell")
+			}
+			if target.Jurisdiction != "us" || target.BaseURL != usCellAPIURL {
+				t.Fatalf("target = %+v, want the us processing cell, not any of the other 3 mirrored regions", target)
+			}
+		})
+	}
+}
+
+func TestResolveRepoCellTarget_OwnerRepo_JurisdictionLowercased(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
+		repos: reposOutput(repoIndexFixture("acme/widget", "mirror-eu",
+			placementFixture{id: "mirror-eu", slug: euClusterSlug},
+		)),
+		clusters: []coreapi.Cluster{
+			{Slug: euClusterSlug, Jurisdiction: "EU", PublicUrl: "https://eu.entire.io", ApiUrl: coreapi.NewOptString(euCellAPIURL)},
+		},
+	})
+	target, err := resolveRepoCellTarget(context.Background(), "acme/widget", "")
+	if err != nil {
+		t.Fatalf("resolveRepoCellTarget: %v", err)
+	}
+	if target == nil || target.Jurisdiction != "eu" {
+		t.Fatalf("target = %+v, want lowercased jurisdiction eu", target)
+	}
+}
+
+// processingResolutionErrorCase names one way processing-placement
+// resolution can fail. Shared between resolveRepoCellTarget's owner/repo path
+// and resolveRepoCellPlacement, since both now go through
+// resolveProcessingPlacement + cellTargetForClusterSlug.
+type processingResolutionErrorCase struct {
+	name        string
+	repos       *coreapi.ListReposOutputBody
+	reposErr    error
+	clusters    []coreapi.Cluster
+	clustersErr error
+	// wantNotOnboarded marks the cases that must surface errRepoNotOnboarded
+	// specifically (not just any error), so callers like the trail
+	// enablement cache can tell "not onboarded" apart from a transient
+	// placement failure.
+	wantNotOnboarded bool
+}
+
+func processingResolutionErrorCases() []processingResolutionErrorCase {
+	activePlacement := placementFixture{id: "mirror-eu", slug: euClusterSlug}
+
+	return []processingResolutionErrorCase{
+		{
+			name:             "repo not found",
+			repos:            reposOutput(), // zero rows
+			clusters:         clustersWithSlugs(),
+			wantNotOnboarded: true,
+		},
+		{
+			// The more common real trigger for "not onboarded": a repo that
+			// exists on the forge and is visible to the caller, but was never
+			// onboarded to Entire. ListRepos' Filter bypasses the default
+			// scope=onboarded restriction, so this comes back as a row with a
+			// Candidate set instead of a zero-row response.
+			name:             "repo discoverable but not onboarded (candidate row)",
+			repos:            reposOutput(candidateRepoIndexFixture("acme/widget")),
+			clusters:         clustersWithSlugs(),
+			wantNotOnboarded: true,
+		},
+		{
+			// Guards the identity check: the control plane's Filter param is
+			// documented as an exact-match lookup, but nothing enforces that
+			// here. If Filter were ever ignored/dropped server-side, an
+			// unchecked Repos[0] would silently resolve an unrelated repo's
+			// cell instead of erroring.
+			name: "repo index returns a different repo than requested",
+			repos: reposOutput(repoIndexFixture("some/other-repo", "mirror-eu",
+				placementFixture{id: "mirror-eu", slug: euClusterSlug},
+			)),
+			clusters: clustersWithSlugs(),
+		},
+		{
+			name: "no processing primary",
+			repos: reposOutput(func() coreapi.RepoIndexEntry {
+				e := repoIndexFixture("acme/widget", "", activePlacement)
+				e.Primaries = coreapi.OptRepoPrimaries{} // unset
+				return e
+			}()),
+			clusters: clustersWithSlugs(),
+		},
+		{
+			name: "processing placement failed",
+			repos: reposOutput(repoIndexFixture("acme/widget", "mirror-eu",
+				placementFixture{id: "mirror-eu", slug: euClusterSlug, status: coreapi.RepoPlacementStatusFailed},
+			)),
+			clusters: clustersWithSlugs(),
+		},
+		{
+			name: "processing placement suspended",
+			repos: reposOutput(repoIndexFixture("acme/widget", "mirror-eu",
+				placementFixture{id: "mirror-eu", slug: euClusterSlug, status: coreapi.RepoPlacementStatusSuspended},
+			)),
+			clusters: clustersWithSlugs(),
+		},
+		{
+			name:     "list repos errors",
+			reposErr: errors.New("core unavailable"),
+			clusters: clustersWithSlugs(),
+		},
+		{
+			name:        "list clusters errors",
+			repos:       reposOutput(repoIndexFixture("acme/widget", "mirror-eu", activePlacement)),
+			clustersErr: errors.New("core unavailable"),
+		},
+		{
+			name:  "no cluster matches the placement's slug",
+			repos: reposOutput(repoIndexFixture("acme/widget", "mirror-eu", activePlacement)),
+			clusters: []coreapi.Cluster{
+				{Slug: "some-other-slug", Jurisdiction: "us", PublicUrl: "https://us.entire.io", ApiUrl: coreapi.NewOptString("https://us.api.entire.io")},
+			},
+		},
+	}
+}
+
+func TestResolveRepoCellTarget_OwnerRepo_ProcessingResolutionErrors(t *testing.T) {
+	for _, tc := range processingResolutionErrorCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			withFakeCellCore(t, &fakeCellCore{repos: tc.repos, reposErr: tc.reposErr, clusters: tc.clusters, clustersErr: tc.clustersErr})
+			target, err := resolveRepoCellTarget(context.Background(), "acme/widget", "")
+			if err == nil {
+				t.Fatalf("expected an error, got target=%+v", target)
+			}
+			if target != nil {
+				t.Fatalf("expected a nil target alongside the error, got %+v", target)
+			}
+			if tc.wantNotOnboarded && !errors.Is(err, errRepoNotOnboarded) {
+				t.Fatalf("expected errRepoNotOnboarded, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveRepoCellPlacement_ProcessingResolutionErrors(t *testing.T) {
+	for _, tc := range processingResolutionErrorCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			withFakeCellCore(t, &fakeCellCore{repos: tc.repos, reposErr: tc.reposErr, clusters: tc.clusters, clustersErr: tc.clustersErr})
+			_, err := resolveRepoCellPlacement(context.Background(), "acme", "widget")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if tc.wantNotOnboarded && !errors.Is(err, errRepoNotOnboarded) {
+				t.Fatalf("expected errRepoNotOnboarded, got: %v", err)
+			}
+		})
+	}
+}
+
 // Bugbot (PR #1942): cross-repo reads must take the repo_id and the cell from
 // the SAME placement. A mirror id is only resolvable by the cell holding that
-// placement, so pairing one placement's id with a cell picked another way (the
-// caller's home cell, which is what resolveRepoCellTarget falls back to for a
-// multi-region repo) asks a cell about an id it has never seen.
+// placement, so pairing one placement's id with a cell picked another way
+// asks a cell about an id it has never seen. With a single placement this is
+// trivially true; TestResolveRepoCellPlacement_MultiHomedRepo_ResolvesProcessingPlacement
+// below is the version of this invariant that actually exercises a choice.
 func TestResolveRepoCellPlacement_PairsIDWithItsOwnCell(t *testing.T) {
 	withFakeCellCore(t, &fakeCellCore{
-		mirrors: []coreapi.Mirror{
-			{Repo: "widget", MirrorId: "mirror-eu", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
-		},
-		clusters: euClusters(),
+		repos: reposOutput(repoIndexFixture("acme/widget", "mirror-eu",
+			placementFixture{id: "mirror-eu", slug: euClusterSlug},
+		)),
+		clusters: clustersWithSlugs(),
 	})
 	got, err := resolveRepoCellPlacement(context.Background(), "acme", "widget")
 	if err != nil {
@@ -248,57 +519,34 @@ func TestResolveRepoCellPlacement_PairsIDWithItsOwnCell(t *testing.T) {
 	}
 }
 
-// A multi-region repo must still resolve to a real placement's cell. This is the
-// case resolveRepoCellTarget deliberately refuses (returning nil so the auth
-// layer routes to the caller's home cell) — for a repo_id-keyed read that
-// fallback is a wrong-cell 404, so this path picks a placement instead.
-func TestResolveRepoCellPlacement_MultiRegionPicksAPlacement(t *testing.T) {
-	withFakeCellCore(t, &fakeCellCore{
-		mirrors: []coreapi.Mirror{
-			{Repo: "widget", MirrorId: "mirror-eu", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
-			{Repo: "widget", MirrorId: "mirror-us", ClusterHost: "us.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
-		},
-		clusters: euClusters(),
-	})
-	got, err := resolveRepoCellPlacement(context.Background(), "acme", "widget")
-	if err != nil {
-		t.Fatalf("resolveRepoCellPlacement: %v", err)
+// A multi-homed repo must resolve to its PROCESSING placement specifically,
+// not merely "some" placement (the pre-fix behavior in resolveRepoCellTarget
+// was to refuse; resolveRepoCellPlacement's pre-fix behavior was to take
+// whichever active mirror came first). The fixture orders the processing
+// placement (mirror-us) last, so a resolver that still picked "first active"
+// would fail this test.
+func TestResolveRepoCellPlacement_MultiHomedRepo_ResolvesProcessingPlacement(t *testing.T) {
+	fixtures := map[string]coreapi.RepoIndexEntry{
+		"processing last":   fourRegionFixture(),
+		"processing middle": fourRegionFixtureProcessingInMiddle(),
 	}
-	// Whichever placement is chosen, its id and its cell must agree.
-	wantJurisdiction := map[string]string{"mirror-eu": "eu", "mirror-us": "us"}[got.RepoID]
-	if wantJurisdiction == "" {
-		t.Fatalf("RepoID = %q, want one of the two placements", got.RepoID)
-	}
-	if got.Target == nil || got.Target.Jurisdiction != wantJurisdiction {
-		t.Fatalf("Target = %+v, want the %s cell to match %s", got.Target, wantJurisdiction, got.RepoID)
-	}
-}
-
-// An inactive placement can't serve the repo, so it must not be chosen.
-func TestResolveRepoCellPlacement_SkipsInactiveAndUnplaceable(t *testing.T) {
-	withFakeCellCore(t, &fakeCellCore{
-		mirrors: []coreapi.Mirror{
-			{Repo: "widget", MirrorId: "mirror-failed", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusFailed)},
-			// Not in the cluster catalog: unplaceable, so skip rather than fall
-			// back to a cell that doesn't know this id.
-			{Repo: "widget", MirrorId: "mirror-unknown", ClusterHost: "nowhere.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
-			{Repo: "widget", MirrorId: "mirror-eu", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
-		},
-		clusters: euClusters(),
-	})
-	got, err := resolveRepoCellPlacement(context.Background(), "acme", "widget")
-	if err != nil {
-		t.Fatalf("resolveRepoCellPlacement: %v", err)
-	}
-	if got.RepoID != "mirror-eu" {
-		t.Errorf("RepoID = %q, want mirror-eu (the only active, placeable mirror)", got.RepoID)
-	}
-}
-
-func TestResolveRepoCellPlacement_NoMirror(t *testing.T) {
-	withFakeCellCore(t, &fakeCellCore{clusters: euClusters()})
-	if _, err := resolveRepoCellPlacement(context.Background(), "acme", "widget"); err == nil {
-		t.Fatal("expected an error when the repo has no reachable mirror")
+	for name, fixture := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			withFakeCellCore(t, &fakeCellCore{
+				repos:    reposOutput(fixture),
+				clusters: clustersWithSlugs(),
+			})
+			got, err := resolveRepoCellPlacement(context.Background(), "entirehq", "entire.io")
+			if err != nil {
+				t.Fatalf("resolveRepoCellPlacement: %v", err)
+			}
+			if got.RepoID != "mirror-us" {
+				t.Errorf("RepoID = %q, want mirror-us (the processing placement, regardless of its position in the list)", got.RepoID)
+			}
+			if got.Target == nil || got.Target.Jurisdiction != "us" || got.Target.BaseURL != usCellAPIURL {
+				t.Fatalf("Target = %+v, want the us cell that holds mirror-us", got.Target)
+			}
+		})
 	}
 }
 
@@ -307,9 +555,11 @@ func TestResolveRepoCellPlacement_NoMirror(t *testing.T) {
 // timeout — so a reachable-but-slow control plane stalled `explain --repo`
 // indefinitely, before its spinner had even started. The parent deadline here
 // is shorter than requiredCellResolveTimeout, which is what keeps this test
-// fast; the point is that the wait is bounded and reported as a timeout.
+// fast; the point is that the wait is bounded and reported as a timeout. The
+// blocking now happens on ListRepos (the processing-placement lookup), not
+// ListMirrors.
 func TestResolveRepoCellPlacement_BoundedByDeadline(t *testing.T) {
-	withFakeCellCore(t, &fakeCellCore{blockUntilCtxDone: true, clusters: euClusters()})
+	withFakeCellCore(t, &fakeCellCore{blockUntilCtxDone: true, clusters: clustersWithSlugs()})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()

--- a/cmd/entire/cli/cell_target_test.go
+++ b/cmd/entire/cli/cell_target_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -83,8 +84,9 @@ type fakeCellCore struct {
 	clustersErr error
 	repos       *coreapi.ListReposOutputBody
 	reposErr    error
-	// blockUntilCtxDone makes ListRepos hang until the caller's deadline
-	// fires, standing in for a reachable-but-slow control plane. Off by
+	// blockUntilCtxDone makes ListRepos and GetRepo hang until the caller's
+	// deadline fires, standing in for a reachable-but-slow control plane —
+	// both, so the owner/repo and ULID paths can each be tested. Off by
 	// default, so existing tests are unaffected.
 	blockUntilCtxDone bool
 	// lastListReposParams records the params passed to the most recent
@@ -103,7 +105,10 @@ func (f *fakeCellCore) waitIfBlocking(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func (f *fakeCellCore) GetRepo(context.Context, coreapi.GetRepoParams) (*coreapi.Repo, error) {
+func (f *fakeCellCore) GetRepo(ctx context.Context, _ coreapi.GetRepoParams) (*coreapi.Repo, error) {
+	if err := f.waitIfBlocking(ctx); err != nil {
+		return nil, err
+	}
 	return f.repo, f.repoErr
 }
 
@@ -429,6 +434,17 @@ func processingResolutionErrorCases() []processingResolutionErrorCase {
 			wantNotOnboarded: true,
 		},
 		{
+			// The defensive branch: primaries names a processing placement that
+			// is absent from the same response's placement list. Should not be
+			// reachable via the control plane, but it is the difference between
+			// a clear error and a zero-value placement resolving to no cell.
+			name: "processing placement id absent from the placement list",
+			repos: reposOutput(repoIndexFixture("acme/widget", "mirror-vanished",
+				placementFixture{id: "mirror-eu", slug: euClusterSlug},
+			)),
+			clusters: clustersWithSlugs(),
+		},
+		{
 			name: "processing placement failed",
 			repos: reposOutput(repoIndexFixture("acme/widget", "mirror-eu",
 				placementFixture{id: "mirror-eu", slug: euClusterSlug, status: coreapi.RepoPlacementStatusFailed},
@@ -551,6 +567,41 @@ func TestResolveRepoCellPlacement_MultiHomedRepo_ResolvesProcessingPlacement(t *
 	}
 }
 
+// The not-onboarded error is what a user in a non-onboarded repo sees, and the
+// fail-loud path made it the most common failure — so it must not read like a
+// stack trace. Each resolution layer naming the repo produced
+// "resolve processing placement for acme/widget: acme/widget: repo is not
+// onboarded to Entire"; the name belongs to exactly one layer.
+func TestResolveRepoCellPlacement_NotOnboardedNamesTheRepoOnce(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		repos *coreapi.ListReposOutputBody
+	}{
+		{name: "no row in the repos index", repos: reposOutput()},
+		{name: "candidate row", repos: reposOutput(candidateRepoIndexFixture("acme/widget"))},
+		{
+			name: "row with no processing primary",
+			repos: reposOutput(func() coreapi.RepoIndexEntry {
+				e := repoIndexFixture("acme/widget", "", placementFixture{id: "mirror-eu", slug: euClusterSlug})
+				e.Primaries = coreapi.OptRepoPrimaries{}
+				return e
+			}()),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withFakeCellCore(t, &fakeCellCore{repos: tc.repos, clusters: clustersWithSlugs()})
+
+			_, err := resolveRepoCellPlacement(context.Background(), "acme", "widget")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := strings.Count(err.Error(), "acme/widget"); got != 1 {
+				t.Errorf("error = %q names the repo %d times, want exactly 1", err, got)
+			}
+		})
+	}
+}
+
 // Trail #1003 finding: resolveRepoCellPlacement was the one cell-resolution
 // entry point with no deadline, and the coreapi HTTP client sets only a dial
 // timeout — so a reachable-but-slow control plane stalled `explain --repo`
@@ -580,6 +631,53 @@ func TestResolveRepoCellPlacement_BoundedByDeadline(t *testing.T) {
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("error = %q, want it to wrap context.DeadlineExceeded", err)
+	}
+}
+
+// The ULID path resolves a placement the caller already named, so it skips the
+// processing-placement lookup entirely — but a stalled control plane must still
+// report a timeout as a timeout, in the same words as the owner/repo path. The
+// two paths reaching different wording for the same failure is what made the
+// shared cellPlacementError worth routing both through.
+func TestResolveRepoCellTarget_ULIDPathReportsTimeoutAsTimeout(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{blockUntilCtxDone: true, clusters: euClusters()})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := resolveRepoCellTarget(ctx, "", "01J000000000000000000000")
+	if err == nil {
+		t.Fatal("expected a timeout error from a stalled control plane")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("resolveRepoCellTarget waited %s; the ULID lookup is not bounded", elapsed)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %q, want it to name a timeout like the owner/repo path does", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error = %q, want it to wrap context.DeadlineExceeded", err)
+	}
+}
+
+// A cancelled context is a Ctrl+C, not a slow control plane; calling it a
+// timeout sends the user debugging the wrong thing.
+func TestCellPlacementError_CancellationIsNotReportedAsTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fallback := fmt.Errorf("list repos: %w", context.Canceled)
+	err := cellPlacementError(ctx, "acme/widget", fallback)
+
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %q, want a cancellation not to be labelled a timeout", err)
+	}
+	// The Canceled chain has to survive: renderDataAPIAuthError silences on it.
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %q, want it to still wrap context.Canceled", err)
 	}
 }
 

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -28,8 +28,8 @@ type expertsAPIClient interface {
 }
 
 // newExpertsAPIClient builds the entire-api cell client. fullName (owner/repo)
-// and/or ulid identify the repo so the client can route to the cell that hosts
-// it (see NewAuthenticatedEntireAPICellClient).
+// or ulid identifies the repo so the client can route to the cell that hosts
+// it; one of them is required (see NewAuthenticatedEntireAPICellClient).
 var newExpertsAPIClient = func(ctx context.Context, insecureHTTP bool, fullName, ulid string) (expertsAPIClient, error) {
 	return NewAuthenticatedEntireAPICellClient(ctx, insecureHTTP, fullName, ulid)
 }

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -281,7 +281,7 @@ func runExperts(ctx context.Context, out, errOut io.Writer, args []string, f *ex
 
 	// Identify the repo for cell routing: a ULID goes on the ulid arg, an
 	// owner/repo on the fullName arg. The client uses whichever is set to reach
-	// the cell that hosts the repo (falling back to home-jurisdiction routing).
+	// the cell that hosts the repo's processing placement.
 	cellFullName, cellULID := "", ""
 	if repoIsULID {
 		cellULID = repoOverride

--- a/cmd/entire/cli/integration_test/trail_resume_test.go
+++ b/cmd/entire/cli/integration_test/trail_resume_test.go
@@ -19,10 +19,16 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/internal/coreapi"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/discovery"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
+
+// trailResumeIntegrationClusterSlug is the fake processing placement's
+// cluster, used to join /api/v1/repos' RepoPlacement.ClusterSlug to
+// /api/v1/clusters' Cluster.Slug (see cell_target.go's cellTargetForClusterSlug).
+const trailResumeIntegrationClusterSlug = "trail-resume-cluster"
 
 func TestTrailResume_UsesCheckpointSessionsWhenLocalStateIsMissing(t *testing.T) {
 	t.Parallel()
@@ -124,13 +130,55 @@ func TestTrailResume_UsesCheckpointSessionsWhenLocalStateIsMissing(t *testing.T)
 func newTrailResumeIntegrationAPIServer(t *testing.T, trail api.TrailResource) *httptest.Server {
 	t.Helper()
 
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == pathOAuthToken:
 			writeTrailResumeIntegrationJSON(t, w, map[string]any{
 				"access_token": "trail-resume-data-token",
 				"token_type":   "Bearer",
 				"expires_in":   3600,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos":
+			// Backs resolveRepoCellTarget/resolveRepoCellPlacement's
+			// processing-placement lookup (cell_target.go): a single placement,
+			// named as this repo's processing placement, joined to the cluster
+			// below by ClusterSlug.
+			// *ListReposOutputBody, not the value: its MarshalJSON (which
+			// correctly omits unset Opt* fields via the generated jx encoder)
+			// has a pointer receiver, and stdlib encoding/json only picks that
+			// up if the boxed value's dynamic type is the pointer.
+			writeTrailResumeIntegrationJSON(t, w, &coreapi.ListReposOutputBody{
+				Repos: []coreapi.RepoIndexEntry{
+					{
+						FullName: "entireio/cli",
+						ID:       "repo-entireio-cli",
+						Primaries: coreapi.NewOptRepoPrimaries(coreapi.RepoPrimaries{
+							Processing: "placement-primary",
+							GitData:    "placement-primary",
+						}),
+						Placements: []coreapi.RepoPlacement{
+							{
+								ID:           "placement-primary",
+								ClusterSlug:  trailResumeIntegrationClusterSlug,
+								Cell:         trailResumeIntegrationClusterSlug,
+								Jurisdiction: "us",
+								Status:       coreapi.RepoPlacementStatusReady,
+							},
+						},
+					},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/clusters":
+			writeTrailResumeIntegrationJSON(t, w, &coreapi.ListClustersOutputBody{
+				Clusters: []coreapi.Cluster{
+					{
+						Slug:         trailResumeIntegrationClusterSlug,
+						Jurisdiction: "us",
+						PublicUrl:    serverURLWithPath(r, ""),
+						ApiUrl:       coreapi.NewOptString(serverURLWithPath(r, "")),
+						IsDefault:    true,
+					},
+				},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/trails/gh/entireio/cli":
 			writeTrailResumeIntegrationJSON(t, w, api.TrailListResponse{
@@ -150,6 +198,7 @@ func newTrailResumeIntegrationAPIServer(t *testing.T, trail api.TrailResource) *
 			http.NotFound(w, r)
 		}
 	}))
+	return server
 }
 
 func writeTrailResumeIntegrationJSON(t *testing.T, w http.ResponseWriter, body any) {

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -23,6 +24,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/internal/coreapi"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/stretchr/testify/require"
@@ -2312,50 +2314,120 @@ func TestHandleLifecycleSessionStart_NoSynchronousNetworkForTrailEnablement(t *t
 	}
 }
 
+// blockingCellCore is a cellCoreClient that hangs every call until its
+// caller's context is done, standing in for a reachable-but-unresponsive
+// control plane.
+type blockingCellCore struct{}
+
+func (blockingCellCore) GetRepo(ctx context.Context, _ coreapi.GetRepoParams) (*coreapi.Repo, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (blockingCellCore) ListClusters(ctx context.Context) (*coreapi.ListClustersOutputBody, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (blockingCellCore) ListRepos(ctx context.Context, _ coreapi.ListReposParams) (*coreapi.ListReposOutputBody, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
 // TestRunTrailEnablementRefresh_BoundedByTimeoutAgainstUnresponsiveHost
 // verifies the deferred refresh work still completes (or at least
-// gives up) within its own bounded timeout when the API host never
+// gives up) within its own bounded timeout when the control plane never
 // responds — the network work that used to block SessionStart must still
 // happen, just out of the hook's critical path, and it must not hang forever.
+//
+// The hang is injected at the cell-target resolver (newCellCoreClient) rather
+// than at a blackholed ENTIRE_API_BASE_URL listener as this test used to:
+// resolveRepoCellTarget (cell_target.go) no longer falls back to a live
+// network dial when it can't resolve the repo's processing placement — a
+// resolution failure is now a fast, direct error — so a blackholed data-API
+// host would never be dialed at all and this test would pass for the wrong
+// reason (an early return, not a bounded wait).
 func TestRunTrailEnablementRefresh_BoundedByTimeoutAgainstUnresponsiveHost(t *testing.T) {
 	setupStopTestRepo(t)
 	runGitInDir(t, ".", "remote", "add", "origin", "https://github.com/entirehq/example.git")
 
-	var lc net.ListenConfig
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer ln.Close()
-	var accepted int32
-	go func() {
-		for {
-			conn, acceptErr := ln.Accept()
-			if acceptErr != nil {
-				return
-			}
-			atomic.AddInt32(&accepted, 1)
-			// Accept the connection but never write anything back (no TLS
-			// handshake, no HTTP response) — simulates a blackholed/firewalled
-			// host, which is what triggered the original 1s stall per call.
-			_ = conn
-		}
-	}()
-	t.Setenv("ENTIRE_API_BASE_URL", "https://"+ln.Addr().String())
+	var attempted int32
+	prevCellCore := newCellCoreClient
+	newCellCoreClient = func() (cellCoreClient, error) {
+		atomic.AddInt32(&attempted, 1)
+		return blockingCellCore{}, nil
+	}
+	t.Cleanup(func() { newCellCoreClient = prevCellCore })
 
 	start := time.Now()
 	refreshErr := runTrailEnablementRefresh(context.Background())
 	elapsed := time.Since(start)
 
-	// Best-effort: network failure must not surface as a hard error.
+	// Best-effort: control-plane failure must not surface as a hard error.
 	require.NoError(t, refreshErr)
 	if elapsed > trailEnablementRefreshTimeout+2*time.Second {
 		t.Fatalf("runTrailEnablementRefresh took %v, expected to give up within roughly %v", elapsed, trailEnablementRefreshTimeout)
 	}
-	// Prove the test actually exercised the network path rather than passing
-	// via an early return (e.g. scope resolution or auth failing before any
-	// dial): the blackholed listener must have accepted at least one
-	// connection attempt.
-	if got := atomic.LoadInt32(&accepted); got == 0 {
-		t.Fatalf("expected at least one dial attempt against the unresponsive host, got %d", got)
+	// Prove the test actually exercised the blocking resolver rather than
+	// passing via an early return (e.g. scope resolution failing first).
+	if got := atomic.LoadInt32(&attempted); got == 0 {
+		t.Fatalf("expected the cell-target resolver to have been invoked at least once")
+	}
+}
+
+// TestRunTrailEnablementRefresh_NotOnboardedSavesDisabledCache guards a
+// regression: before the fail-loud cell-resolution rewrite, a not-onboarded
+// repo still got a client (the old home-jurisdiction fallback), and the
+// subsequent TrailsEnabled API call's 403/404 was what cached enabled=false.
+// Now trailRefreshAPIClient fails before a client exists for the exact same
+// repos, landing in the generic "authenticated client unavailable" branch,
+// which never writes the cache — cachedTrailsEnablementForScope stays
+// unknown forever and trailRefreshSpawnThrottle can't stop SessionStart from
+// re-forking a refresh child on every invocation. errRepoNotOnboarded is the
+// one error this refresh must recognize as a permanent negative and persist.
+func TestRunTrailEnablementRefresh_NotOnboardedSavesDisabledCache(t *testing.T) {
+	setupStopTestRepo(t)
+	runGitInDir(t, ".", "remote", "add", "origin", "https://github.com/entirehq/example.git")
+
+	prevClient := trailRefreshAPIClient
+	trailRefreshAPIClient = func(context.Context, bool, string) (*api.Client, error) {
+		return nil, fmt.Errorf("resolve the Entire cell for entirehq/example: %w", errRepoNotOnboarded)
+	}
+	t.Cleanup(func() { trailRefreshAPIClient = prevClient })
+
+	require.NoError(t, runTrailEnablementRefresh(context.Background()))
+
+	scope, err := currentTrailEnablementScope(context.Background())
+	require.NoError(t, err)
+	if got := cachedTrailsEnablementForScope(context.Background(), scope, time.Now()); got != trailEnablementCacheDisabled {
+		t.Fatalf("cached enablement = %v, want trailEnablementCacheDisabled (saved, not left unknown)", got)
+	}
+}
+
+// TestRunTrailEnablementRefresh_CandidateRowSavesDisabledCache is the
+// candidate-row counterpart to TestRunTrailEnablementRefresh_NotOnboardedSavesDisabledCache
+// above, and exercises the real resolution chain (rather than mocking
+// trailRefreshAPIClient directly) so it also proves resolveProcessingPlacement
+// itself classifies a discoverable-but-unonboarded repo as errRepoNotOnboarded:
+// a repos-index row with Candidate set but no placements/primaries is the more
+// common real trigger for "not onboarded" than the zero-rows case (a random
+// repo a developer works in, vs. one the caller can't see or that doesn't
+// exist).
+func TestRunTrailEnablementRefresh_CandidateRowSavesDisabledCache(t *testing.T) {
+	setupStopTestRepo(t)
+	runGitInDir(t, ".", "remote", "add", "origin", "https://github.com/entirehq/example.git")
+
+	withFakeCellCore(t, &fakeCellCore{
+		repos:    reposOutput(candidateRepoIndexFixture("entirehq/example")),
+		clusters: clustersWithSlugs(),
+	})
+
+	require.NoError(t, runTrailEnablementRefresh(context.Background()))
+
+	scope, err := currentTrailEnablementScope(context.Background())
+	require.NoError(t, err)
+	if got := cachedTrailsEnablementForScope(context.Background(), scope, time.Now()); got != trailEnablementCacheDisabled {
+		t.Fatalf("cached enablement = %v, want trailEnablementCacheDisabled (saved, not left unknown)", got)
 	}
 }
 

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -179,8 +179,9 @@ func newRepoCloneCmd() *cobra.Command {
 }
 
 // mirrorLister is the subset of the control-plane client listMirrorsForRepo
-// needs. Narrowing to an interface lets callers (e.g. the experts cell-target
-// resolver) inject a fake control plane in tests; *coreapi.Client satisfies it.
+// needs. Narrowing to an interface lets callers (e.g. resolveCurrentRepoID in
+// api_cmd.go, and entireapi_client.go's currentRepoRef) inject a fake control
+// plane in tests; *coreapi.Client satisfies it.
 type mirrorLister interface {
 	ListMirrors(ctx context.Context, params coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error)
 }

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -489,9 +489,8 @@ func runCodeSearch(ctx context.Context, cmd *cobra.Command, opts codeSearchOpts)
 //  4. Fan out via fanOutCells with per-cell codesearch.Search calls
 //  5. Merge results (sorted by score, capped to limit)
 func searchAllCells(ctx context.Context, opts codeSearchOpts) (*codesearch.SearchResponse, error) {
-	// Step 1: Get repos index from the control plane.
-	// coreapi.Client satisfies cellCoreClient (for resolveCellBaseURLs)
-	// and also provides ListRepos (which cellCoreClient doesn't expose).
+	// Step 1: Get repos index from the control plane. *coreapi.Client
+	// satisfies cellCoreClient (passed to resolveCellBaseURLs below as such).
 	coreClient, err := coreapi.New()
 	if err != nil {
 		if errors.Is(err, auth.ErrNotLoggedIn) {

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -294,8 +294,8 @@ func (c *cachedClusterClient) GetRepo(ctx context.Context, params coreapi.GetRep
 	return c.inner.GetRepo(ctx, params) //nolint:wrapcheck // transparent delegation
 }
 
-func (c *cachedClusterClient) ListMirrors(ctx context.Context, params coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error) {
-	return c.inner.ListMirrors(ctx, params) //nolint:wrapcheck // transparent delegation
+func (c *cachedClusterClient) ListRepos(ctx context.Context, params coreapi.ListReposParams) (*coreapi.ListReposOutputBody, error) {
+	return c.inner.ListRepos(ctx, params) //nolint:wrapcheck // transparent delegation
 }
 
 // mergedTier2Max mirrors query-serve's maxTier2 and the BFF's MERGED_TIER2_MAX:

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1007,7 +1007,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr, ty
 	}
 	client, err := newTrailAPIClient(ctx, trailInsecureHTTP(cmd), owner+"/"+repoName)
 	if err != nil {
-		return renderDataAPIAuthError(cmd.ErrOrStderr(), err)
+		return renderDataAPIAuthError(ctx, cmd.ErrOrStderr(), err)
 	}
 
 	branchState, err := prepareTrailCreateBranch(w, errW, repo, branch, currentBranch, noBranch)

--- a/cmd/entire/cli/trail_context_cache.go
+++ b/cmd/entire/cli/trail_context_cache.go
@@ -297,6 +297,16 @@ func runTrailEnablementRefresh(ctx context.Context) error {
 	}
 	client, err := trailRefreshAPIClient(ctx, false, scope.Owner+"/"+scope.Repo)
 	if err != nil {
+		if errors.Is(err, errRepoNotOnboarded) {
+			// A definitive, permanent negative: without this, every
+			// SessionStart re-forks a refresh child for this repo forever
+			// (see trailRefreshSpawnThrottle above), because the cache is
+			// never written and so never leaves "unknown".
+			if saveErr := saveTrailsEnabledForScope(ctx, scope, false, time.Now()); saveErr != nil {
+				logging.Debug(logCtx, "trails enablement refresh failed to save not-onboarded scope", "error", saveErr.Error())
+			}
+			return nil
+		}
 		logging.Debug(logCtx, "trails enablement refresh skipped: authenticated client unavailable", "error", err.Error())
 		return nil
 	}
@@ -485,7 +495,7 @@ func runAuthenticatedTrailAPI(ctx context.Context, errW io.Writer, insecureHTTP 
 	}
 	client, err := newTrailAPIClient(ctx, insecureHTTP, owner+"/"+repo)
 	if err != nil {
-		return renderDataAPIAuthError(errW, err)
+		return renderDataAPIAuthError(ctx, errW, err)
 	}
 	err = fn(ctx, client)
 	if repoOverride == "" {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1088
<!-- entire-trail-link-end -->

## Summary

`resolveRepoCellTarget`/`resolveRepoCellPlacement` (`cmd/entire/cli/cell_target.go`) used to scan mirrors and refuse — falling back to home-jurisdiction routing — whenever a repo was mirrored in more than one region. Since PR #2021 (shipped in v0.10.1), trail commands always dial the resolved cell, so this fallback became a **silent wrong-region read**: `entire trail list --repo gh/entirehq/entire.io` (a 4-region repo) printed "No open trails found." instead of erroring, because the repo's real trails live on `aws-us-east-2` and the fallback landed on the caller's home cell instead.

This PR resolves the repo's **processing placement** via the control plane's consolidated repos index (`ListRepos` + `primaries.processing`) instead of scanning mirrors — mirroring the entire.io BFF's `processingPlacement()` selection (`list-repos-index.ts`). Every resolution failure is now a loud, returned error instead of a silent nil/fallback: for repo-scoped data, a wrong-region "success" is worse than a command failure.

**⚠️ v0.10.1 silently returns wrong/empty trail data whenever the caller's home cell is not the repo's processing cell.** The blast radius is caller-dependent, not universal: for `entirehq/entire.io` (processing placement on `aws-us-east-2`), a caller whose home jurisdiction is already `us` reads it correctly on v0.10.1 — the home-cell fallback happens to land on the right cell — which is a large part of why this went unnoticed. Every caller homed elsewhere reads the wrong region. Bug and fix are both real; flagging the accurate scope so v0.10.2 urgency can be weighed against it rather than against "every multi-homed repo".

## What changed

- `resolveRepoCellTarget` (owner/repo path) and `resolveRepoCellPlacement` now both resolve via the repo's processing placement (`resolveProcessingPlacement`), joined to the cluster catalog by `ClusterSlug` (not host — the catalog doesn't expose a cell field, `ClusterSlug ↔ Cluster.Slug` is the only reliable join key, matching `cell_fanout.go`'s existing rule).
- `resolveRepoCellTarget`'s owner/repo path now delegates to `resolveRepoCellPlacement` instead of duplicating its body, so both share one resolution body and one set of error messages.
- The ULID path's *placement resolution* is unchanged (`GetRepo` → `ClusterHost` by host match, since a ULID already names one placement unambiguously), but it now routes its failures through the shared `cellPlacementError` too, so a stalled control plane is reported as a timeout in the same words on both paths. Previously only the owner/repo path was timeout-labeled.
- `resolveProcessingPlacement` verifies the returned row's `full_name` matches what was requested (defense against the control plane ever ignoring the `Filter` param), and treats both a zero-row response and a `Candidate` row (a repo that's discoverable via `Filter` but never onboarded — the common real-world "not onboarded" shape) as the same definitive "not onboarded" case via a new `errRepoNotOnboarded` sentinel.
- `NewAuthenticatedEntireAPICellClient` (used by `entire trail` and `entire experts`) now propagates a resolution failure instead of ever falling back to home-jurisdiction routing.
- **Fixed along the way** (regressions the fail-loud change would have introduced): `renderDataAPIAuthError` was swallowing `entire trail` commands into *zero-output* failures on a slow control plane, because it couldn't distinguish the caller's own context firing from the resolver's internal timeout both satisfying `errors.Is(err, context.DeadlineExceeded)`. The background trail-enablement cache (`trail_context_cache.go`) could no longer record a definitive "not onboarded" decision, which would have left `SessionStart` re-forking refresh children indefinitely for any non-onboarded repo.
- **Not-onboarded output** (review follow-up): the fail-loud path made "repo is not onboarded" the most common failure, and each resolution layer was naming the repo, so `trail list` in a non-onboarded repo printed `resolve processing placement for owner/x: owner/x: repo is not onboarded to Entire`. The repo name now belongs to exactly one layer, and `renderDataAPIAuthError` replaces the internal chain with one actionable line (`This repository is not onboarded to Entire. Run 'entire repo mirror create' to onboard it.`), matching the existing not-logged-in branch. `cellPlacementError` also no longer calls a cancelled context (Ctrl+C) a timeout.
- Removed `ListMirrors` from the now-obsolete `cellCoreClient` interface (no remaining caller through it) and updated the stale "Entire-API Cell Routing" section in `CLAUDE.md`.

## Verification

- `mise run fmt && mise run lint` — 0 issues.
- `go test ./cmd/entire/cli/...` — full pass.
- `go test -tags=integration -race ./cmd/entire/cli/integration_test/...` — full pass.
- `mise run test:ci` — full pass (unit + integration + e2e vogon canary).
- **Regression proof**: the pre-fix code's own test (`TestResolveRepoCellTarget_MultiRegion_FallsBack`) asserts that a multi-region repo resolves to `nil` (i.e. falls back) — that assertion is the bug. The new tests assert the opposite: a 4-placement fixture reproducing `entirehq/entire.io`'s real topology (with the processing placement deliberately placed in the **middle** of the list, not first or last, closing a mutation-tested positional-heuristic gap) resolves to the correct region regardless of mirror count.
- **Live proof against prod** (read-only): `go run ./cmd/entire trail list --repo gh/entirehq/entire.io` now lists real open trails sourced from `aws-us-east-2`, instead of the old silent "No open trails found."
- Also independently verified live that `RepoPlacement.ID` (the new `repo_id` source) and the old `Mirror.MirrorId` are the same value for the same placement (`entirehq/entire.io`'s us-east-2 placement: `01KS6GKTXQW8Z1CV8CNPYRV2ZJ` from both `/api/v1/mirrors` and `/api/v1/repos`).

## Size note

`git diff --numstat origin/main`: 16 files, +871/−355. Net (insertions − deletions) is ~516; total churn (insertions + deletions) is ~1226 — over the repo's ~800-line hard churn ceiling. This PR went through three rounds of independent review (code-reviewer, pr-test-analyzer, silent-failure-hunter, comment-analyzer, slop-reviewer — ratings converged medium → small across rounds) before landing here, which accounts for a meaningful share of the size: two real functional regressions surfaced by review (`renderDataAPIAuthError`, the trail-enablement cache) needed fixing in the same PR, since splitting them out would leave an intermediate PR failing CI (the production behavior change and the test/caller fixes it requires are not independently shippable). I'm flagging this per the repo's PR-sizing convention rather than deciding unilaterally that it's fine — happy to discuss splitting if reviewers would rather see it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoNnrvHqAHfUqs9vi4JFiY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core routing for trails/experts and data-plane cell selection; wrong behavior previously looked like success, so regressions affect multi-homed repos and onboarding edge cases.
> 
> **Overview**
> **Repo-scoped entire-api routing** (`entire trail`, `entire experts`, checkpoint/explain) no longer scans mirrors or **falls back to the caller's home cell** when resolution fails. It resolves the repo's **processing placement** via control-plane `ListRepos` + `primaries.processing`, joins the cluster catalog by **`ClusterSlug`**, and **returns an error** on any failure so multi-region repos (e.g. `entirehq/entire.io`) don't get silent wrong-region empty results.
> 
> `NewAuthenticatedEntireAPICellClient` propagates those errors instead of dialing home. **`renderDataAPIAuthError`** only treats cancellation/deadline as silent when **`ctx.Err()`** is set (so internal resolver timeouts still surface), and maps **`errRepoNotOnboarded`** to one onboarding hint. The background **trail enablement cache** persists **disabled** for not-onboarded repos so SessionStart doesn't fork refresh forever.
> 
> Docs and tests updated; mirror-based cell resolution helpers removed from the resolver path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9066d61c93b4673da99126c64806a19d72e66b7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

