### PR TITLE
Route trails-enablement probes through the repo's entire-api cell, not the BFF

### DIFF
--- a/cmd/entire/cli/agent_help_cmd.go
+++ b/cmd/entire/cli/agent_help_cmd.go
@@ -342,6 +342,8 @@ func agentHelpRepoContext(ctx context.Context) (repoLine string, trailsEnabled b
 // because agent-help is an explicit command whose output must reflect the
 // current availability decision. SessionStart uses the detached
 // refreshTrailsEnabledCacheIfStaleForScope path instead to avoid hook latency.
+// Routes through trailRefreshAPIClient (see its doc for why) rather than the
+// generic data-API/BFF client.
 func refreshAgentHelpTrailsEnabledCacheIfStaleForScope(ctx context.Context, scope trailEnablementScope) error {
 	if cachedTrailsEnablementForScope(ctx, scope, time.Now()) != trailEnablementCacheUnknown {
 		return nil
@@ -349,7 +351,12 @@ func refreshAgentHelpTrailsEnabledCacheIfStaleForScope(ctx context.Context, scop
 	if !scope.Supported {
 		return saveTrailsEnabledForScope(ctx, scope, false, time.Now())
 	}
-	client, err := NewAuthenticatedAPIClient(ctx, false)
+	client, handled, err := trailsClientOrCacheNotOnboarded(ctx, false, scope.Owner+"/"+scope.Repo, func() error {
+		return saveTrailsEnabledForScope(ctx, scope, false, time.Now())
+	})
+	if handled {
+		return err
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/entire/cli/agent_help_cmd_test.go
+++ b/cmd/entire/cli/agent_help_cmd_test.go
@@ -5,17 +5,25 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/spf13/cobra"
 )
 
 const agentHelpTestRepo = "gh/acme/app"
+
+// testTrailCellRoutedFullName is the "owner/repo" fullName the entire-api
+// cell-routed client (trailRefreshAPIClient) is expected to receive when a
+// repo-scoped trails probe routes correctly through it, shared by the tests
+// covering the two legacy-BFF-routing fixes.
+const testTrailCellRoutedFullName = "acme/widget"
 
 // commandNames returns the Use-name of each command, for assertions.
 func commandNames(cmds []*cobra.Command) []string {
@@ -223,6 +231,78 @@ func TestAgentHelpRepoContext_SkipsRefreshWithoutLocalIdentity(t *testing.T) {
 	}
 	if enabled {
 		t.Fatal("trails should not be advertised without a local auth identity")
+	}
+}
+
+// refreshAgentHelpTrailsEnabledCacheIfStaleForScope must route the repo-scoped
+// trails-enablement probe through the entire-api cell that hosts THIS repo
+// (trailRefreshAPIClient), never through the generic data-API/BFF client — the
+// BFF does not proxy /api/v1/trails/... for bearer callers (COR-666).
+// Not parallel: changes the process working directory.
+func TestRefreshAgentHelpTrailsEnabledCacheIfStaleForScope_RoutesThroughRepoCell(t *testing.T) {
+	// A non-repo cwd makes the shared cache lookup return "unknown", so the
+	// refresh path below always runs.
+	t.Chdir(t.TempDir())
+
+	previous := trailRefreshAPIClient
+	var gotFullName string
+	wantErr := errors.New("cell client unavailable")
+	trailRefreshAPIClient = func(_ context.Context, _ bool, fullName string) (*api.Client, error) {
+		gotFullName = fullName
+		return nil, wantErr
+	}
+	t.Cleanup(func() { trailRefreshAPIClient = previous })
+
+	scope := trailEnablementScope{
+		Forge:     "gh",
+		Owner:     "acme",
+		Repo:      "widget",
+		RepoKey:   trailEnablementRepoKey("gh", "acme", "widget"),
+		APIBase:   api.BaseURL(),
+		AuthKey:   "test-auth-key",
+		Supported: true,
+	}
+
+	err := refreshAgentHelpTrailsEnabledCacheIfStaleForScope(t.Context(), scope)
+
+	if gotFullName != testTrailCellRoutedFullName {
+		t.Fatalf("trailRefreshAPIClient fullName = %q, want %s", gotFullName, testTrailCellRoutedFullName)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+}
+
+// refreshAgentHelpTrailsEnabledCacheIfStaleForScope must persist a definitive
+// negative when trailRefreshAPIClient fails because the repo has no
+// processing placement (errRepoNotOnboarded), matching
+// runTrailEnablementRefresh's handling of the same sentinel. Without this,
+// agent-help falls into the short refresh-failure backoff instead, re-paying
+// the full control-plane round trip every 5 minutes forever instead of caching
+// the hour-long definitive negative like every other trails-enablement
+// consumer.
+// Not parallel: changes the process working directory.
+func TestRefreshAgentHelpTrailsEnabledCacheIfStaleForScope_NotOnboardedSavesDisabledCache(t *testing.T) {
+	setupStopTestRepo(t)
+	runGitInDir(t, ".", "remote", "add", "origin", "https://github.com/acme/widget.git")
+
+	previous := trailRefreshAPIClient
+	trailRefreshAPIClient = func(context.Context, bool, string) (*api.Client, error) {
+		return nil, fmt.Errorf("resolve the Entire cell for acme/widget: %w", errRepoNotOnboarded)
+	}
+	t.Cleanup(func() { trailRefreshAPIClient = previous })
+
+	scope, err := currentTrailEnablementScope(t.Context())
+	if err != nil {
+		t.Fatalf("resolve trail scope: %v", err)
+	}
+
+	if err := refreshAgentHelpTrailsEnabledCacheIfStaleForScope(t.Context(), scope); err != nil {
+		t.Fatalf("err = %v, want nil (not-onboarded is a definitive negative, not a refresh failure)", err)
+	}
+
+	if got := cachedTrailsEnablementForScope(t.Context(), scope, time.Now()); got != trailEnablementCacheDisabled {
+		t.Fatalf("cached enablement = %v, want trailEnablementCacheDisabled (saved, not left unknown)", got)
 	}
 }
 

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -992,10 +992,12 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 }
 
 // reportRepoEnabled records the `entire enable` against the backend so the web
-// onboarding can reflect it. It is strictly best-effort and fully silent:
-// enabling works offline, and every outcome (no origin remote, not logged in,
-// network error, App-can't-reach-repo) is swallowed — the web onboarding
-// surfaces the "install the GitHub App" nudge, so the CLI stays quiet.
+// onboarding can reflect it, and — as a second, independent, best-effort step
+// — probes and caches whether trails are enabled for the repo. Both steps are
+// strictly best-effort and fully silent: enabling works offline, and every
+// outcome (no origin remote, not logged in, network error, App-can't-reach-
+// repo, trails probe failure) is swallowed — the web onboarding surfaces the
+// "install the GitHub App" nudge, so the CLI stays quiet.
 func reportRepoEnabled(ctx context.Context, insecureHTTPAuth bool) {
 	// This runs synchronously on the enable success path, so bound it: a backend
 	// that accepts the connection but never responds must not hang the command
@@ -1025,26 +1027,44 @@ func reportRepoEnabled(ctx context.Context, insecureHTTPAuth bool) {
 		return
 	}
 
-	cleanURL, err := cleanRemoteURLForReport(rawURL)
-	if err != nil {
-		logging.Debug(ctx, "skipping enable report: unparseable origin remote", "error", err)
-		return
-	}
+	reportEnableToBackend(ctx, insecureHTTPAuth, info)
+	probeAndCacheTrailsEnablement(ctx, insecureHTTPAuth, info)
+}
 
+// reportEnableToBackend tells the backend which repo was just enabled, purely
+// for the web onboarding UI and the GitHub-App-reachability nudge. Best-effort
+// and independent of the trails probe: a failure here (not logged in, network
+// error, backend rejects the URL) must not block that probe.
+func reportEnableToBackend(ctx context.Context, insecureHTTPAuth bool, info *gitremote.Info) {
 	client, err := NewAuthenticatedAPIClient(ctx, insecureHTTPAuth)
 	if err != nil {
 		// Not logged in / token unavailable — enable already succeeded locally.
 		logging.Debug(ctx, "skipping enable report", "error", err)
 		return
 	}
-
-	if _, err := client.ReportEnable(ctx, cleanURL); err != nil {
-		// The enable report is best-effort and independent from the trails cache:
-		// still try the trails probe so a reporting failure doesn't leave the
-		// prompt-path cache stale or unknown.
+	if _, err := client.ReportEnable(ctx, cleanRemoteURLForReport(info)); err != nil {
 		logging.Debug(ctx, "enable report failed", "error", err)
 	}
+}
 
+// probeAndCacheTrailsEnablement checks whether trails are enabled for the repo
+// that was just enabled, and caches the decision. Routes through
+// trailRefreshAPIClient (see its doc for why) rather than the generic
+// data-API/BFF client.
+func probeAndCacheTrailsEnablement(ctx context.Context, insecureHTTPAuth bool, info *gitremote.Info) {
+	client, handled, err := trailsClientOrCacheNotOnboarded(ctx, insecureHTTPAuth, info.Owner+"/"+info.Repo, func() error {
+		return saveTrailsEnabledForRemote(ctx, info.Forge, info.Owner, info.Repo, false)
+	})
+	if handled {
+		if err != nil {
+			logging.Debug(ctx, "failed to cache trails enablement", "error", err)
+		}
+		return
+	}
+	if err != nil {
+		logging.Debug(ctx, "trails enablement probe client unavailable", "error", err)
+		return
+	}
 	enabled, err := client.TrailsEnabled(ctx, info.Forge, info.Owner, info.Repo)
 	if err != nil {
 		logging.Debug(ctx, "trails enablement probe failed", "error", err)
@@ -1055,20 +1075,15 @@ func reportRepoEnabled(ctx context.Context, insecureHTTPAuth bool) {
 	}
 }
 
-// cleanRemoteURLForReport turns a raw git remote URL into a clean,
+// cleanRemoteURLForReport turns a parsed git remote into a clean,
 // credential-free HTTPS URL safe to send to the backend. The raw remote can
 // carry embedded credentials (https://token@host/...) or query params, so we
-// never forward it verbatim: parse it and rebuild from host/owner/repo alone.
-// Returns an error if the URL can't be parsed (the caller skips reporting).
-func cleanRemoteURLForReport(rawURL string) (string, error) {
-	info, err := gitremote.ParseURL(rawURL)
-	if err != nil {
-		return "", fmt.Errorf("parse remote URL: %w", err)
-	}
+// never forward it verbatim: rebuild from host/owner/repo alone.
+func cleanRemoteURLForReport(info *gitremote.Info) string {
 	// Use CanonicalHost, not Host: an entire://cluster/gh/owner/repo origin (an
 	// already-mirrored repo) carries the Entire cluster as Host, so reporting
 	// Host verbatim would point the backend at the cluster instead of github.com.
-	return fmt.Sprintf("https://%s/%s/%s.git", info.CanonicalHost(), info.Owner, info.Repo), nil
+	return fmt.Sprintf("https://%s/%s/%s.git", info.CanonicalHost(), info.Owner, info.Repo)
 }
 
 func newDisableCmd() *cobra.Command {

--- a/cmd/entire/cli/setup_report_enabled_test.go
+++ b/cmd/entire/cli/setup_report_enabled_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// probeAndCacheTrailsEnablement must route the repo-scoped trails-enablement
+// probe through the entire-api cell that hosts THIS repo (trailRefreshAPIClient),
+// never through the generic data-API/BFF client — the BFF does not proxy
+// /api/v1/trails/... for bearer callers (COR-666).
+// probeAndCacheTrailsEnablement performs no cache lookup of its own — this
+// isolates saveTrailsEnabledForRemote/debug logging below from the developer's
+// real repo, since the probe always runs regardless of cwd.
+// Not parallel: changes the process working directory.
+func TestProbeAndCacheTrailsEnablement_RoutesThroughRepoCell(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	previous := trailRefreshAPIClient
+	var gotFullName string
+	wantErr := errors.New("cell client unavailable")
+	trailRefreshAPIClient = func(_ context.Context, _ bool, fullName string) (*api.Client, error) {
+		gotFullName = fullName
+		return nil, wantErr
+	}
+	t.Cleanup(func() { trailRefreshAPIClient = previous })
+
+	info := &gitremote.Info{Forge: "gh", Owner: "acme", Repo: "widget"}
+	probeAndCacheTrailsEnablement(t.Context(), false, info)
+
+	if gotFullName != testTrailCellRoutedFullName {
+		t.Fatalf("trailRefreshAPIClient fullName = %q, want %s", gotFullName, testTrailCellRoutedFullName)
+	}
+}
+
+// When the repo-routed client resolves and the probe succeeds, the decision is
+// cached exactly like the pre-split reportRepoEnabled did.
+// Not parallel: changes the process working directory and env.
+func TestProbeAndCacheTrailsEnablement_CachesEnabledDecision(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	previous := trailRefreshAPIClient
+	trailRefreshAPIClient = func(_ context.Context, _ bool, _ string) (*api.Client, error) {
+		return api.NewClientWithBaseURL("tok", srv.URL), nil
+	}
+	t.Cleanup(func() { trailRefreshAPIClient = previous })
+
+	info := &gitremote.Info{Forge: "gh", Owner: "acme", Repo: "widget"}
+	probeAndCacheTrailsEnablement(t.Context(), false, info)
+
+	prefs, err := settings.LoadClonePreferences(t.Context())
+	if err != nil {
+		t.Fatalf("load clone preferences: %v", err)
+	}
+	if prefs.TrailsEnabled == nil || !*prefs.TrailsEnabled {
+		t.Fatalf("cached trails-enabled decision = %v, want true", prefs.TrailsEnabled)
+	}
+	wantRepoKey := trailEnablementRepoKey("gh", "acme", "widget")
+	if prefs.TrailsEnabledRepoKey != wantRepoKey {
+		t.Fatalf("cached repo key = %q, want %q", prefs.TrailsEnabledRepoKey, wantRepoKey)
+	}
+}
+
+// probeAndCacheTrailsEnablement must persist a definitive negative when
+// trailRefreshAPIClient fails because the repo has no processing placement
+// (errRepoNotOnboarded), matching runTrailEnablementRefresh's handling of the
+// same sentinel. Without this, the cache is left unknown forever, and a repo
+// that was later de-onboarded could keep a stale cached `true` from a prior
+// enable until the hourly TTL expires.
+// Not parallel: changes the process working directory and env.
+func TestProbeAndCacheTrailsEnablement_NotOnboardedSavesDisabledCache(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	previous := trailRefreshAPIClient
+	trailRefreshAPIClient = func(context.Context, bool, string) (*api.Client, error) {
+		return nil, fmt.Errorf("resolve the Entire cell for acme/widget: %w", errRepoNotOnboarded)
+	}
+	t.Cleanup(func() { trailRefreshAPIClient = previous })
+
+	info := &gitremote.Info{Forge: "gh", Owner: "acme", Repo: "widget"}
+	probeAndCacheTrailsEnablement(t.Context(), false, info)
+
+	prefs, err := settings.LoadClonePreferences(t.Context())
+	if err != nil {
+		t.Fatalf("load clone preferences: %v", err)
+	}
+	if prefs.TrailsEnabled == nil || *prefs.TrailsEnabled {
+		t.Fatalf("cached trails-enabled decision = %v, want false (not left unknown)", prefs.TrailsEnabled)
+	}
+	wantRepoKey := trailEnablementRepoKey("gh", "acme", "widget")
+	if prefs.TrailsEnabledRepoKey != wantRepoKey {
+		t.Fatalf("cached repo key = %q, want %q", prefs.TrailsEnabledRepoKey, wantRepoKey)
+	}
+}

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -3797,16 +3798,17 @@ func TestCleanRemoteURLForReport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := cleanRemoteURLForReport(tt.rawURL)
+			info, err := gitremote.ParseURL(tt.rawURL)
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("expected error for %q, got %q", tt.rawURL, got)
+					t.Fatalf("expected ParseURL error for %q", tt.rawURL)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("unexpected error for %q: %v", tt.rawURL, err)
+				t.Fatalf("unexpected error parsing %q: %v", tt.rawURL, err)
 			}
+			got := cleanRemoteURLForReport(info)
 			if got != tt.want {
 				t.Errorf("cleanRemoteURLForReport(%q) = %q, want %q", tt.rawURL, got, tt.want)
 			}

--- a/cmd/entire/cli/trail_context_cache.go
+++ b/cmd/entire/cli/trail_context_cache.go
@@ -257,12 +257,37 @@ func refreshTrailsEnabledCacheIfStaleForScope(ctx context.Context, scope trailEn
 }
 
 // trailRefreshAPIClient is the authenticated-client seam used by
-// runTrailEnablementRefresh, swapped in tests so they can force the
+// runTrailEnablementRefresh, refreshAgentHelpTrailsEnabledCacheIfStaleForScope,
+// and probeAndCacheTrailsEnablement, swapped in tests so they can force the
 // refreshTrailsEnabledCacheForScope error branch (e.g. a broken API host)
 // without a real login context. Production code always uses the repo-routed
-// entire-api cell client.
+// entire-api cell client (newTrailAPIClient) rather than the generic
+// data-API/BFF client: the BFF does not proxy /api/v1/trails/... for bearer
+// callers (COR-666), so probing it via the generic client silently misreads a
+// supported repo as disabled.
 var trailRefreshAPIClient = func(ctx context.Context, insecureHTTP bool, fullName string) (*api.Client, error) {
 	return newTrailAPIClient(ctx, insecureHTTP, fullName)
+}
+
+// trailsClientOrCacheNotOnboarded resolves the entire-api cell client for
+// ownerRepo via trailRefreshAPIClient. errRepoNotOnboarded (cell_target.go) is
+// a DEFINITIVE, not transient, negative — the repo has no processing
+// placement — so every caller of this seam must persist it via save rather
+// than treat it like an ordinary client-construction failure: leaving the
+// cache unknown means every future refresh re-attempts (and re-fails) the
+// same client build forever. handled reports whether err (construction failed
+// with errRepoNotOnboarded) or the result of save; handled is false for a
+// plain client-construction failure, which the caller must handle on its own
+// terms (log-and-skip, backoff, etc.).
+func trailsClientOrCacheNotOnboarded(ctx context.Context, insecureHTTP bool, ownerRepo string, save func() error) (client *api.Client, handled bool, err error) {
+	client, err = trailRefreshAPIClient(ctx, insecureHTTP, ownerRepo)
+	if err == nil {
+		return client, false, nil
+	}
+	if !errors.Is(err, errRepoNotOnboarded) {
+		return nil, false, err
+	}
+	return nil, true, save()
 }
 
 // runTrailEnablementRefresh performs the actual (potentially slow) network
@@ -295,18 +320,20 @@ func runTrailEnablementRefresh(ctx context.Context) error {
 		}
 		return nil
 	}
-	client, err := trailRefreshAPIClient(ctx, false, scope.Owner+"/"+scope.Repo)
-	if err != nil {
-		if errors.Is(err, errRepoNotOnboarded) {
-			// A definitive, permanent negative: without this, every
-			// SessionStart re-forks a refresh child for this repo forever
-			// (see trailRefreshSpawnThrottle above), because the cache is
-			// never written and so never leaves "unknown".
-			if saveErr := saveTrailsEnabledForScope(ctx, scope, false, time.Now()); saveErr != nil {
-				logging.Debug(logCtx, "trails enablement refresh failed to save not-onboarded scope", "error", saveErr.Error())
-			}
-			return nil
+	client, handled, err := trailsClientOrCacheNotOnboarded(ctx, false, scope.Owner+"/"+scope.Repo, func() error {
+		return saveTrailsEnabledForScope(ctx, scope, false, time.Now())
+	})
+	if handled {
+		// A definitive, permanent negative: without this, every SessionStart
+		// re-forks a refresh child for this repo forever (see
+		// trailRefreshSpawnThrottle above), because the cache is never
+		// written and so never leaves "unknown".
+		if err != nil {
+			logging.Debug(logCtx, "trails enablement refresh failed to save not-onboarded scope", "error", err.Error())
 		}
+		return nil
+	}
+	if err != nil {
 		logging.Debug(logCtx, "trails enablement refresh skipped: authenticated client unavailable", "error", err.Error())
 		return nil
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1089
<!-- entire-trail-link-end -->

## Summary

Stacked on #2046 — **merge order: #2046 first, then this.**

Two more call sites had the same bug class #2046 fixed for `entire trail`/`entire experts`: they built an entire-api client via `NewAuthenticatedAPIClient` (the generic data-API/BFF client) and then probed `TrailsEnabled` on it for a specific repo. The BFF does not proxy `/api/v1/trails/...` for CLI bearer callers (COR-666), so this silently misreads trails enablement instead of erroring.

- `entire agent-help`'s `refreshAgentHelpTrailsEnabledCacheIfStaleForScope`
- `entire enable`'s post-success report, `reportRepoEnabled`

Both now route through the existing `trailRefreshAPIClient` seam (already used correctly by the background SessionStart refresh in `trail_context_cache.go`), which resolves the repo's actual processing-placement cell via #2046's fix.

## What changed

- `agent_help_cmd.go`: swapped the client-construction line.
- `setup.go`: split `reportRepoEnabled` into `reportEnableToBackend` (unchanged — stays on the BFF client, since `ReportEnable` is an account/onboarding-level report, not repo-scoped cell data) and a new `probeAndCacheTrailsEnablement` (the fixed part). This also makes the changed code independently unit-testable — previously the whole function short-circuited on any `ReportEnable` auth failure before ever reaching the trails probe.
- **Also fixed**: none of the three trails-refresh call sites handled `errRepoNotOnboarded` (the definitive-negative sentinel from #2046) consistently. Only the background refresh cached it; the other two left the cache unresolved forever — `agent-help` would re-pay a full control-plane round trip every 5 minutes instead of caching for an hour, and `entire enable` risked leaving a stale cached `true` for a repo that was later de-onboarded (since nothing would overwrite it). Extracted a shared helper (`trailsClientOrCacheNotOnboarded`) now that three call sites need the identical classification logic.

## Review

Went through slop-reviewer (rated `small`) plus code-reviewer, pr-test-analyzer, silent-failure-hunter, and comment-analyzer. One real "Important" finding (the `errRepoNotOnboarded` handling gap above) was fixed before pushing; the rest were minor comment/test cleanups, also applied.

## Verification

- `mise run fmt && mise run lint` — 0 issues.
- `go test -count=1 ./cmd/entire/cli/...` — full pass.
- `go build ./...` — clean.
- TDD: new tests written first and confirmed failing (red) against the pre-fix code, then passing (green) after each fix.

## Size

`git diff --numstat` vs the base branch: 6 files, +285/−40 — comfortably small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoNnrvHqAHfUqs9vi4JFiY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 32fb4dbe542c1e187d97753862cd6c3224d8aa18. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->