### PR TITLE
Send versioned User-Agent from dispatch CloudClient

### DIFF
--- a/cmd/entire/cli/dispatch/cloud.go
+++ b/cmd/entire/cli/dispatch/cloud.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 type CloudConfig struct {
@@ -170,6 +171,7 @@ func (c *CloudClient) doJSON(ctx context.Context, method, path string, reqBody, 
 		return fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", versioninfo.UserAgent())
 	if reqBody != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/cmd/entire/cli/dispatch/cloud_test.go
+++ b/cmd/entire/cli/dispatch/cloud_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 func newTestCloudClient(t *testing.T, baseURL, token string) *CloudClient {
@@ -77,6 +79,34 @@ func TestCloudClient_CreateDispatch_Happy(t *testing.T) {
 	}
 	if got.GeneratedMarkdown != "hi" {
 		t.Fatalf("bad generated markdown: %q", got.GeneratedMarkdown)
+	}
+}
+
+func TestCloudClient_CreateDispatch_SetsVersionedUserAgent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	var gotUserAgent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"window":{"normalized_since":"2026-04-09T00:00:00Z","normalized_until":"2026-04-16T00:00:00Z"},"covered_repos":["entireio/cli"],"repos":[],"generated_markdown":"hi"}`)) //nolint:errcheck // test fixture response
+	}))
+	defer srv.Close()
+
+	client := newTestCloudClient(t, srv.URL, "t")
+	_, err := client.CreateDispatch(ctx, CreateDispatchRequest{
+		Repos:    []string{"entireio/cli"},
+		Since:    "2026-04-09T00:00:00Z",
+		Until:    "2026-04-16T00:00:00Z",
+		Generate: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := versioninfo.UserAgent(); gotUserAgent != want {
+		t.Fatalf("expected User-Agent %q, got %q", want, gotUserAgent)
 	}
 }
 

--- a/cmd/entire/cli/dispatch/cloud_test.go
+++ b/cmd/entire/cli/dispatch/cloud_test.go
@@ -97,7 +97,7 @@ func TestCloudClient_CreateDispatch_SetsVersionedUserAgent(t *testing.T) {
 
 	client := newTestCloudClient(t, srv.URL, "t")
 	_, err := client.CreateDispatch(ctx, CreateDispatchRequest{
-		Repos:    []string{"entireio/cli"},
+		Repos:    []string{testRepoFullName},
 		Since:    "2026-04-09T00:00:00Z",
 		Until:    "2026-04-16T00:00:00Z",
 		Generate: true,


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1090
<!-- entire-trail-link-end -->

## Summary
- `CloudClient.doJSON` (`cmd/entire/cli/dispatch/cloud.go`) never set a User-Agent, so cloud-mode `entire dispatch` traffic went out as Go's default `Go-http-client/2.0` instead of `entire-cli/<version>`.
- entire.io#3783 added a dark-shipped CLI version gate on the BFF keyed on `User-Agent: entire-cli/<semver>` — anything else passes untouched by design, so dispatch traffic from arbitrarily old CLIs bypassed the gate entirely. Fixing this is a recorded precondition for ever flipping `CLI_MIN_VERSION`.
- Sets the shared `versioninfo.UserAgent()` on every `doJSON` request, matching what `api.Client` already does for every other CLI request.

## Test plan
- [x] Added `TestCloudClient_CreateDispatch_SetsVersionedUserAgent` (failing-first): stub server captures the request, asserts `User-Agent` equals `versioninfo.UserAgent()`.
- [x] Mutation check: removed the header line, confirmed the test fails, restored it.
- [x] `mise run fmt && mise run lint` clean.
- [x] `mise run test:ci` — full unit + integration + E2E canary suite passes.

https://claude.ai/code/session_01NSafCAEzEQ2AKW5RV3v3Bs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2243a31936ed533755827fb29288bd1a64f09e84. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->