### PR TITLE
Credit OPF no-categories reporter in 0.10.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Thanks to @MuskanPaliwal for tracking down the checkpoint metadata bloat — both the nested-checkout status walk and the `files_touched` dedupe at the write boundary — which had made `entire/checkpoints/v1` unpushable on repos with agent worktrees!
 
+Thanks to @ChetanReddyC for privately reporting that the OpenAI privacy filter, when enabled with no effective categories, stamped `Entire-OPF-Applied: true` on commits it never scanned — fixed in this release by failing closed at push time!
+
 ## [0.10.0] - 2026-08-12
 
 ### Added


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1091
<!-- entire-trail-link-end -->

Adds a Thanks entry to the v0.10.1 changelog crediting @ChetanReddyC, who privately reported the OpenAI privacy filter false-success trailer bug (OPF enabled with zero effective categories still stamped `Entire-OPF-Applied: true`), fixed in [#1986](https://github.com/entireio/cli/pull/1986).

Credit was deliberately left out of the fix PR while the report was private; release-note credit was promised for when the fix shipped, and v0.10.1 shipped it. The wording also clarifies the shipped behavior is a push-time fail-closed abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit; no runtime or build impact.
> 
> **Overview**
> Adds a **Thanks** line under **v0.10.1** for @ChetanReddyC, who privately reported that the OpenAI privacy filter could stamp `Entire-OPF-Applied: true` on commits when OPF was enabled but had no effective categories.
> 
> The note ties that report to the shipped fix (push-time fail-closed) already listed under **Fixed** for [#1986](https://github.com/entireio/cli/pull/1986), without changing product behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 071f7e36078ea0164452bf90dd3700877d6a9ec6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->