### PR TITLE
fix(dispatch): send CLI user agent so the version gate applies

### DIFF
--- a/cmd/entire/cli/dispatch/cloud.go
+++ b/cmd/entire/cli/dispatch/cloud.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 type CloudConfig struct {
@@ -176,6 +177,7 @@ func (c *CloudClient) doJSON(ctx context.Context, method, path string, reqBody, 
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
+	req.Header.Set("User-Agent", versioninfo.UserAgent())
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/cmd/entire/cli/dispatch/cloud_test.go
+++ b/cmd/entire/cli/dispatch/cloud_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 func newTestCloudClient(t *testing.T, baseURL, token string) *CloudClient {
@@ -312,6 +314,36 @@ func TestCloudClient_CreateDispatch_AcceptsVoiceResponseField(t *testing.T) {
 	}
 	if got.Voice == nil || *got.Voice != "calm and direct" {
 		t.Fatalf("unexpected voice response: %v", got.Voice)
+	}
+}
+
+func TestCloudClient_CreateDispatch_SetsUserAgent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	var capturedUserAgent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUserAgent = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"window":{"normalized_since":"2026-04-09T00:00:00Z","normalized_until":"2026-04-16T00:00:00Z"},"covered_repos":["entireio/cli"],"repos":[],"totals":{"checkpoints":0,"used_checkpoint_count":0,"branches":0,"files_touched":0},"warnings":{"access_denied_count":0,"pending_count":0,"failed_count":0,"unknown_count":0,"uncategorized_count":0},"generated_markdown":"hi"}`)) //nolint:errcheck // test fixture response
+	}))
+	defer srv.Close()
+
+	client := newTestCloudClient(t, srv.URL, "t")
+	_, err := client.CreateDispatch(ctx, CreateDispatchRequest{
+		Repos:    []string{"entireio/cli"},
+		Since:    "2026-04-09T00:00:00Z",
+		Until:    "2026-04-16T00:00:00Z",
+		Generate: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := versioninfo.UserAgent()
+	if capturedUserAgent != want {
+		t.Errorf("User-Agent = %q, want %q", capturedUserAgent, want)
 	}
 }
 

--- a/cmd/entire/cli/dispatch/cloud_test.go
+++ b/cmd/entire/cli/dispatch/cloud_test.go
@@ -321,9 +321,9 @@ func TestCloudClient_CreateDispatch_SetsUserAgent(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	var capturedUserAgent string
+	capturedUserAgent := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedUserAgent = r.Header.Get("User-Agent")
+		capturedUserAgent <- r.Header.Get("User-Agent")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte(`{"window":{"normalized_since":"2026-04-09T00:00:00Z","normalized_until":"2026-04-16T00:00:00Z"},"covered_repos":["entireio/cli"],"repos":[],"totals":{"checkpoints":0,"used_checkpoint_count":0,"branches":0,"files_touched":0},"warnings":{"access_denied_count":0,"pending_count":0,"failed_count":0,"unknown_count":0,"uncategorized_count":0},"generated_markdown":"hi"}`)) //nolint:errcheck // test fixture response
@@ -342,8 +342,8 @@ func TestCloudClient_CreateDispatch_SetsUserAgent(t *testing.T) {
 	}
 
 	want := versioninfo.UserAgent()
-	if capturedUserAgent != want {
-		t.Errorf("User-Agent = %q, want %q", capturedUserAgent, want)
+	if got := <-capturedUserAgent; got != want {
+		t.Errorf("User-Agent = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1092
<!-- entire-trail-link-end -->

Part of [ENT-1547](https://linear.app/entirehq/issue/ENT-1547/decide-the-cell-ownership-and-persistence-model-for-inline) (slice 6/6, independent of the rest): `CloudClient.doJSON` built its own `http.Request` with no User-Agent, so dispatch traffic went out as `Go-http-client/2.0` and bypassed the BFF's `CLI_MIN_VERSION` gate (a recorded floor-flip precondition on entire.io#3783).

One line — `req.Header.Set("User-Agent", versioninfo.UserAgent())` in `doJSON`, the choke point every dispatch request flows through — plus a regression test that fails with the Go default UA when the line is removed (mutation-verified).

Noted for follow-up, not this PR: `cmd/entire/cli/auth/cell_data_api.go:605` and `internal/entireclient/httputil/oauth.go:98` also send no User-Agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2rAjPbkVg8a3sxDBevwN9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 20df20c93064f32cc394e0bdd725258fa71db8eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->