### PR TITLE
fix(trail): write trail descriptions through the body route, not the metadata PATCH

### DIFF
--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -85,7 +85,10 @@ func (r *TrailResource) UnmarshalJSON(data []byte) error {
 }
 
 // TrailBodyDocument is the trail's description editor document. TextSnapshot
-// is the rendered plain text displayed by the CLI.
+// is the rendered plain text displayed by the CLI. The document is also what a
+// body write returns (see TrailBodyRequest), so both directions decode into this
+// type; the fields the CLI does not use (id, documentKey, schemaVersion,
+// contentJson, updatedAt) are simply left out of it.
 type TrailBodyDocument struct {
 	TextSnapshot string `json:"textSnapshot"`
 }
@@ -130,10 +133,17 @@ type TrailCreateResponse struct {
 // There is deliberately no Labels field: the trails API does not accept label
 // writes, so `trail update` exposes no label flags (labels are read-only, see
 // TrailResource.Labels).
+//
+// There is deliberately no Body field either. The trails API does not serve
+// body writes on this route — it rejects a body field outright and names the
+// dedicated route to use instead — so the description has its own route and its
+// own request shape; see TrailBodyRequest. Do not reintroduce the field to save
+// a request: the rejection has been served as a redacted 5xx, which reads to
+// the caller as a flaky server rather than as the wrong route, and that is what
+// made this bug survive as long as it did.
 type TrailUpdateRequest struct {
 	Status             *string   `json:"status,omitempty"`
 	Title              *string   `json:"title,omitempty"`
-	Body               *string   `json:"body,omitempty"`
 	Assignees          *[]string `json:"assignees,omitempty"`
 	RequestedReviewers *[]string `json:"requestedReviewers,omitempty"`
 	Type               *string   `json:"type,omitempty"`
@@ -142,6 +152,26 @@ type TrailUpdateRequest struct {
 
 type TrailUpdateResponse struct {
 	Trail TrailResource `json:"trail"`
+}
+
+// TrailBodyRequest is the body for PUT
+// /api/v1/trails/:host/:owner/:repo/:number/body, the only route that writes a
+// trail's description (see TrailUpdateRequest for why it is not PATCH). The
+// route answers with the resulting document, which decodes into
+// TrailBodyDocument.
+//
+// Markdown carries no omitempty: an empty string is how a description is
+// cleared, and the server distinguishes present-and-empty from absent — with
+// omitempty the field would vanish from the JSON and the request would be
+// rejected as "exactly one of markdown/contentJson is required".
+//
+// The route also accepts contentJson (ProseMirror JSON, written as-is) in place
+// of markdown, and an If-Match header for optimistic concurrency. Neither is
+// modeled here: the CLI writes Markdown, and it has no ETag to send — that
+// value only comes back from a prior write through this same route.
+type TrailBodyRequest struct {
+	Markdown  string `json:"markdown"`
+	Overwrite bool   `json:"overwrite,omitempty"`
 }
 
 // TrailApproval is a single approval decision on a trail. Author is exposed as

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1273,7 +1273,7 @@ func newTrailUpdateCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&statusStr, "status", "", "Update status")
 	cmd.Flags().StringVar(&title, "title", "", "Update title")
-	cmd.Flags().StringVar(&body, "body", "", "Update body")
+	cmd.Flags().StringVar(&body, "body", "", "Replace the description (--body= clears it)")
 	cmd.Flags().StringVar(&branch, "branch", "", "Branch to update trail for (defaults to current)")
 	cmd.Flags().StringSliceVar(&assigneeAdd, "add-assignee", nil, "Add assignee(s) by login")
 	cmd.Flags().StringSliceVar(&assigneeRemove, "remove-assignee", nil, "Remove assignee(s) by login")
@@ -1411,14 +1411,13 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 		return err
 	}
 
-	// Build update request with only changed fields.
+	// Build the metadata request with only changed fields. The description is
+	// not part of it — it is written separately, from the `body` local below.
 	updateReq := buildTrailUpdateRequest(found, trailUpdateInputs{
 		Status:          statusStr,
 		StatusChanged:   inputs.StatusChanged,
 		Title:           title,
 		TitleChanged:    inputs.TitleChanged,
-		Body:            body,
-		BodyChanged:     inputs.BodyChanged,
 		AssigneeAdd:     inputs.AssigneeAdd,
 		AssigneeRemove:  inputs.AssigneeRemove,
 		ReviewerAdd:     inputs.ReviewerAdd,
@@ -1436,27 +1435,26 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 	}
 	path := trailNumberPath(forge, owner, repoName, found.Number)
 
-	// The server rejects body + metadata in one PATCH, so send them as
-	// separate requests when both are present. These two calls are not
-	// atomic: if the metadata PATCH lands and the body PATCH then fails, the
-	// metadata change persists. Report that partial state explicitly so the
-	// caller knows the metadata already applied and only the body needs a
-	// retry, rather than assuming nothing changed.
-	meta, hasMeta, bodyReq := splitTrailUpdate(updateReq)
-	if !hasMeta && bodyReq == nil {
+	// Metadata and description live on different routes, so an update touching
+	// both sends two requests. They are not atomic: if the metadata PATCH lands
+	// and the body PUT then fails, the metadata change persists. Report that
+	// partial state explicitly so the caller knows the metadata already applied
+	// and only the body needs a retry, rather than assuming nothing changed.
+	hasMeta := trailUpdateRequestHasFields(updateReq)
+	if !hasMeta && !inputs.BodyChanged {
 		// Nothing changed — most often the interactive form opened and closed
-		// untouched. Say so instead of printing the success line: no PATCH went
+		// untouched. Say so instead of printing the success line: no request went
 		// out, and agents read that line as confirmation the write landed.
 		fmt.Fprintf(w, "No changes to apply to the trail for branch %s\n", branch)
 		return nil
 	}
 	if hasMeta {
-		if err := sendTrailPatch(ctx, client, path, meta); err != nil {
+		if err := sendTrailPatch(ctx, client, path, updateReq); err != nil {
 			return err
 		}
 	}
-	if bodyReq != nil {
-		if err := sendTrailPatch(ctx, client, path, *bodyReq); err != nil {
+	if inputs.BodyChanged {
+		if err := sendTrailBody(ctx, client, trailBodyPath(forge, owner, repoName, found.Number), body); err != nil {
 			if hasMeta {
 				return fmt.Errorf("trail metadata was updated, but the body update failed (the metadata change already applied; retry only the --body change): %w", err)
 			}
@@ -1538,7 +1536,10 @@ func mergeStringSet(current, add, remove []string) []string {
 	return out
 }
 
-// buildTrailUpdateRequest constructs a PATCH request body from the current trail and the requested changes.
+// buildTrailUpdateRequest constructs the metadata PATCH body from the current
+// trail and the requested changes. It deliberately ignores inputs.Body: the
+// description is not part of this request, it is written by sendTrailBody
+// against its own route, and api.TrailUpdateRequest has no field to put it in.
 func buildTrailUpdateRequest(current *api.TrailResource, inputs trailUpdateInputs) api.TrailUpdateRequest {
 	var req api.TrailUpdateRequest
 
@@ -1547,9 +1548,6 @@ func buildTrailUpdateRequest(current *api.TrailResource, inputs trailUpdateInput
 	}
 	if inputs.TitleChanged {
 		req.Title = &inputs.Title
-	}
-	if inputs.BodyChanged {
-		req.Body = &inputs.Body
 	}
 	if inputs.TypeChanged {
 		typ := strings.TrimSpace(inputs.Type)
@@ -1572,36 +1570,18 @@ func buildTrailUpdateRequest(current *api.TrailResource, inputs trailUpdateInput
 	return req
 }
 
-// splitTrailUpdate separates a full update into a metadata request and an
-// optional body request. The server rejects a body update combined with
-// status/title/branch/base/assignees/reviewers/type/priority ("Body updates
-// cannot be combined with metadata updates"), so the two must be sent as
-// separate PATCH calls — that split is what makes `trail update --title X
-// --body Y` work in one command. hasMeta reports whether the metadata request
-// has any field set.
-func splitTrailUpdate(full api.TrailUpdateRequest) (meta api.TrailUpdateRequest, hasMeta bool, bodyReq *api.TrailUpdateRequest) {
-	if full.Body != nil {
-		b := *full.Body
-		bodyReq = &api.TrailUpdateRequest{Body: &b}
-	}
-	meta = full
-	meta.Body = nil
-	return meta, trailUpdateRequestHasFields(meta), bodyReq
-}
-
 // trailUpdateRequestHasFields reports whether req sets any field at all. It
 // walks the struct reflectively rather than naming each field, so a field added
-// to TrailUpdateRequest later — a branch rename, say — counts as metadata
-// without anyone having to remember to extend this check. Forgetting to would
-// make splitTrailUpdate return hasMeta=false and drop that change silently: the
-// PATCH is never sent, yet the command still reports success.
+// to api.TrailUpdateRequest later — a branch rename, say — counts as a metadata
+// change without anyone having to remember to extend this check. Forgetting to
+// would drop that change silently: the PATCH is never sent, yet the command
+// still reports success.
 //
-// The reflective default is only right for fields the server treats as
-// metadata. A field that has to travel *with* the body instead — a hypothetical
-// body_format or body_version — would be routed into the metadata PATCH here
-// and rejected under the very "Body updates cannot be combined with metadata
-// updates" rule the split exists to satisfy. Adding one means deciding
-// explicitly where it belongs in splitTrailUpdate; it is not handled for free.
+// The reflective default is only right for fields the metadata route actually
+// serves. A field that has to travel with the description instead — a
+// hypothetical body_format or body_version — belongs in api.TrailBodyRequest
+// and on the body PUT; put it here and it goes out on a route that does not
+// know it, which is the same wrong-route mistake the body itself used to make.
 func trailUpdateRequestHasFields(req api.TrailUpdateRequest) bool {
 	v := reflect.ValueOf(req)
 	for i := range v.NumField() {
@@ -1614,7 +1594,8 @@ func trailUpdateRequestHasFields(req api.TrailUpdateRequest) bool {
 	return false
 }
 
-// sendTrailPatch issues a single trail PATCH and validates the response.
+// sendTrailPatch issues a single trail metadata PATCH and validates the
+// response. The description is not sent here — see sendTrailBody.
 func sendTrailPatch(ctx context.Context, client *api.Client, path string, req api.TrailUpdateRequest) error {
 	resp, err := client.Patch(ctx, path, req)
 	if err != nil {
@@ -1627,6 +1608,46 @@ func sendTrailPatch(ctx context.Context, client *api.Client, path string, req ap
 	var updateResp api.TrailUpdateResponse
 	if err := api.DecodeJSON(resp, &updateResp); err != nil {
 		return fmt.Errorf("failed to decode update response: %w", err)
+	}
+	return nil
+}
+
+// sendTrailBody writes a trail's description through the body route, the only
+// one that serves body writes (api.TrailUpdateRequest documents why the metadata
+// PATCH does not). path must already be that route — see trailBodyPath.
+//
+// Overwrite is set because that is what `trail update --body` already means: the
+// caller named the replacement text, and the interactive path shows them the
+// current description before they edit it (resolveTrailUpdateBody). Left false,
+// the route refuses with 409 document_not_empty against any trail whose
+// description is non-empty — i.e. everything except a first write — so the flag
+// is what makes editing an existing description work at all.
+//
+// The cost is that a description changed elsewhere between that read and this
+// write is replaced rather than reported. The route's If-Match is not a fix for
+// that here: its ETag comes only from a body write's own response (including the
+// 409's), so the CLI can obtain one just by being refused and retrying — which
+// clobbers exactly as overwrite does, one round trip later. A true
+// compare-and-set would need the ETag of the document the user actually read,
+// and a trail read carries none (bodyDocument has no ETag, and its updatedAt is
+// formatted to a different precision than the header, so reconstructing one from
+// a read yields a value that never matches). Giving the user that choice is a
+// flag decision, not something to bury here.
+func sendTrailBody(ctx context.Context, client *api.Client, path, body string) error {
+	resp, err := client.Put(ctx, path, api.TrailBodyRequest{Markdown: body, Overwrite: true})
+	if err != nil {
+		return fmt.Errorf("failed to update trail body: %w", err)
+	}
+	defer resp.Body.Close()
+	if err := checkTrailResponse(resp); err != nil {
+		return err
+	}
+	// Nothing reads the document back; decoding it only confirms the success
+	// really was this route's JSON response, and drains the body — the same
+	// check sendTrailPatch makes on the metadata route.
+	var doc api.TrailBodyDocument
+	if err := api.DecodeJSON(resp, &doc); err != nil {
+		return fmt.Errorf("failed to decode trail body response: %w", err)
 	}
 	return nil
 }
@@ -2108,6 +2129,13 @@ func trailsBasePath(forge, owner, repo string) string {
 // integer here and rejects the trail UUID, so callers must pass Number, not ID.
 func trailNumberPath(forge, owner, repo string, number int) string {
 	return trailsBasePath(forge, owner, repo) + "/" + strconv.Itoa(number)
+}
+
+// trailBodyPath returns the route that writes a trail's description
+// (e.g. "/api/v1/trails/gh/acme/repo/575/body"). It is the only route that does;
+// see api.TrailBodyRequest.
+func trailBodyPath(forge, owner, repo string, number int) string {
+	return trailNumberPath(forge, owner, repo, number) + "/body"
 }
 
 // resolveTrailRemote resolves the origin remote and ensures the forge is

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -1258,6 +1258,59 @@ func TestFindTrailStopsAtMaxPagesWithoutTotal(t *testing.T) {
 	}
 }
 
+// TestRunTrailUpdateClearsDescriptionWithEmptyBody covers `--body=`: an empty
+// description is a value to write, not an absence. Two things have to hold for
+// that, and neither is visible from a passing update test — the write must be
+// triggered by the flag having been set rather than by the text being non-empty,
+// and markdown must reach the wire as an empty string (with omitempty it would
+// drop out of the JSON and the server would reject the write as "exactly one of
+// markdown/contentJson is required"). Both failures silently do nothing.
+func TestRunTrailUpdateClearsDescriptionWithEmptyBody(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var put map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath:
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{
+				Trails: []api.TrailResource{{ID: "trl_1", Number: 7, Branch: "feature/x", Status: string(trail.StatusOpen)}},
+				Total:  1,
+			}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
+		case r.Method == http.MethodPut && r.URL.Path == trailTestBasePath+"/7/body":
+			mu.Lock()
+			defer mu.Unlock()
+			if err := json.NewDecoder(r.Body).Decode(&put); err != nil {
+				t.Errorf("decode body request: %v", err)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailBodyDocument{}); err != nil {
+				t.Errorf("encode body response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	err := runTrailUpdateWithClient(t.Context(), &out, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+		Branch:      "feature/x",
+		Body:        "",
+		BodyChanged: true,
+	})
+
+	require.NoError(t, err)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, map[string]any{"markdown": "", "overwrite": true}, put)
+	require.Contains(t, out.String(), "Updated trail for branch feature/x")
+}
+
 func TestValidateTrailUpdateFieldsRejectsEmptyTitle(t *testing.T) {
 	t.Parallel()
 	if err := validateTrailUpdateFields(trailUpdateInputs{TitleChanged: true, Title: "   "}); err == nil {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -39,8 +39,6 @@ const (
 	trailListTestAuthorBob   = "bob"
 	// trailTestBasePath is the trails endpoint for the gh/acme/repo fixture.
 	trailTestBasePath = "/api/v1/trails/gh/acme/repo"
-	// trailBodyField is the PATCH field name carrying a trail's description.
-	trailBodyField = "body"
 )
 
 func TestNewTrailCreateRequestUsesLinkBranchAction(t *testing.T) {
@@ -1260,17 +1258,6 @@ func TestFindTrailStopsAtMaxPagesWithoutTotal(t *testing.T) {
 	}
 }
 
-func TestBuildTrailUpdateRequestCanClearBody(t *testing.T) {
-	t.Parallel()
-	req := buildTrailUpdateRequest(&api.TrailResource{Body: "old"}, trailUpdateInputs{BodyChanged: true, Body: ""})
-	if req.Body == nil {
-		t.Fatal("Body pointer is nil, want empty string pointer")
-	}
-	if *req.Body != "" {
-		t.Fatalf("Body = %q, want empty string", *req.Body)
-	}
-}
-
 func TestValidateTrailUpdateFieldsRejectsEmptyTitle(t *testing.T) {
 	t.Parallel()
 	if err := validateTrailUpdateFields(trailUpdateInputs{TitleChanged: true, Title: "   "}); err == nil {
@@ -1951,44 +1938,19 @@ func TestValidateTrailUpdateFieldsRejectsInvalidTypePriority(t *testing.T) {
 	}
 }
 
-func TestSplitTrailUpdateSeparatesBodyFromMetadata(t *testing.T) {
-	t.Parallel()
-	body := "new body"
-	title := "new title"
-	full := api.TrailUpdateRequest{Body: &body, Title: &title}
-	meta, hasMeta, bodyReq := splitTrailUpdate(full)
-	if !hasMeta || meta.Title == nil || *meta.Title != "new title" {
-		t.Fatalf("meta = %#v, hasMeta = %v, want title-only metadata", meta, hasMeta)
-	}
-	if meta.Body != nil {
-		t.Fatal("metadata request must not carry body")
-	}
-	if bodyReq == nil || bodyReq.Body == nil || *bodyReq.Body != "new body" {
-		t.Fatalf("bodyReq = %#v, want body-only request", bodyReq)
-	}
-
-	_, hasMeta2, bodyReq2 := splitTrailUpdate(api.TrailUpdateRequest{Body: &body})
-	if hasMeta2 {
-		t.Error("body-only update must not produce a metadata request")
-	}
-	if bodyReq2 == nil {
-		t.Error("body-only update must produce a body request")
-	}
-}
-
-// TestSplitTrailUpdateCountsEveryNonBodyFieldAsMetadata pins the structural
-// rule splitTrailUpdate relies on: any field other than Body makes a metadata
-// PATCH. Naming the fields by hand is how a later addition (a branch rename,
-// say) gets dropped silently — hasMeta stays false, no PATCH is sent, and the
-// command still reports success. This test grows with the struct instead.
-func TestSplitTrailUpdateCountsEveryNonBodyFieldAsMetadata(t *testing.T) {
+// TestTrailUpdateRequestCountsEveryFieldAsMetadata pins the structural rule
+// runTrailUpdateWithClient relies on: every field of api.TrailUpdateRequest
+// makes a metadata PATCH. Naming the fields by hand is how a later addition (a
+// branch rename, say) gets dropped silently — hasMeta stays false, no PATCH is
+// sent, and the command still reports success. This test grows with the struct
+// instead. The description is not among them: it has no field here at all, and
+// travels as its own PUT .../body.
+func TestTrailUpdateRequestCountsEveryFieldAsMetadata(t *testing.T) {
 	t.Parallel()
 	typ := reflect.TypeOf(api.TrailUpdateRequest{})
+	require.NotZero(t, typ.NumField(), "api.TrailUpdateRequest has no fields; this test would pass vacuously")
 	for i := range typ.NumField() {
 		field := typ.Field(i)
-		if field.Name == "Body" {
-			continue
-		}
 		t.Run(field.Name, func(t *testing.T) {
 			t.Parallel()
 			// Fail rather than skip: a skipped subtest passes quietly, so a
@@ -2001,25 +1963,45 @@ func TestSplitTrailUpdateCountsEveryNonBodyFieldAsMetadata(t *testing.T) {
 			// field is cleared (e.g. an empty title, an emptied assignee list).
 			reflect.ValueOf(&req).Elem().Field(i).Set(reflect.New(field.Type.Elem()))
 
-			_, hasMeta, _ := splitTrailUpdate(req)
-
-			require.Truef(t, hasMeta, "field %s must count as metadata, otherwise splitTrailUpdate drops it without sending a PATCH", field.Name)
+			require.Truef(t, trailUpdateRequestHasFields(req),
+				"field %s must count as metadata, otherwise the update drops it without sending a PATCH", field.Name)
 		})
 	}
 }
 
-// TestRunTrailUpdateSendsTitleAndBodyAsSeparatePatches drives the whole update
-// path against a server that rejects body+metadata in one PATCH exactly as
-// production does, so `trail update --title X --body Y` stays working end to
-// end and not just in splitTrailUpdate's unit test.
-func TestRunTrailUpdateSendsTitleAndBodyAsSeparatePatches(t *testing.T) {
+// TestRunTrailUpdateSendsTitleAsPatchAndBodyAsPut drives the whole update path
+// against a server shaped like production's: metadata on PATCH .../{number}, the
+// description only on PUT .../{number}/body. The PATCH handler fails the test if
+// a description ever appears on it, which is the invariant that matters and the
+// one production enforces — it rejects that field naming the PUT route to use
+// instead. The rejection's status code is deliberately not modeled: it has been
+// a redacted 5xx and is moving to a 4xx, and the CLI must not care either way.
+func TestRunTrailUpdateSendsTitleAsPatchAndBodyAsPut(t *testing.T) {
 	t.Parallel()
 
-	// patches is written from the handler goroutine and read from the test
+	type trailWrite struct {
+		method string
+		path   string
+		body   map[string]any
+	}
+	// writes is appended from the handler goroutine and read from the test
 	// goroutine, so it is guarded — the counter-based tests in this file use
 	// sync/atomic for the same reason; a slice needs a mutex instead.
 	var mu sync.Mutex
-	var patches []map[string]any
+	var writes []trailWrite
+	// Returns nil on a decode failure, which the caller treats as "stop here";
+	// the t.Errorf has already failed the test.
+	record := func(r *http.Request) map[string]any {
+		var got map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode %s request: %v", r.Method, err)
+			return nil
+		}
+		mu.Lock()
+		writes = append(writes, trailWrite{method: r.Method, path: r.URL.Path, body: got})
+		mu.Unlock()
+		return got
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath:
@@ -2031,33 +2013,26 @@ func TestRunTrailUpdateSendsTitleAndBodyAsSeparatePatches(t *testing.T) {
 				t.Errorf("encode list response: %v", err)
 			}
 		case r.Method == http.MethodPatch && r.URL.Path == trailTestBasePath+"/7":
-			var got map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-				t.Errorf("decode patch request: %v", err)
+			got := record(r)
+			if got == nil {
 				return
 			}
-			mu.Lock()
-			patches = append(patches, got)
-			mu.Unlock()
-			// Mirror the server's own rule ("Body updates cannot be combined
-			// with metadata updates").
-			_, hasBody := got[trailBodyField]
-			hasMeta := false
-			for key := range got {
-				if key != trailBodyField {
-					hasMeta = true
-				}
-			}
-			if hasBody && hasMeta {
-				w.WriteHeader(http.StatusBadRequest)
-				if err := json.NewEncoder(w).Encode(map[string]string{"error": "Body updates cannot be combined with metadata updates"}); err != nil {
-					t.Errorf("encode rejection: %v", err)
-				}
+			if _, hasBody := got["body"]; hasBody {
+				// The metadata route does not serve body writes at all, so a
+				// description reaching it is the bug this test exists to catch.
+				t.Errorf("metadata PATCH carried a description: %v", got)
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(api.TrailUpdateResponse{Trail: api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x"}}); err != nil {
 				t.Errorf("encode update response: %v", err)
+			}
+		case r.Method == http.MethodPut && r.URL.Path == trailTestBasePath+"/7/body":
+			record(r)
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("ETag", `W/"2026-08-19T00:00:00.000Z"`)
+			if err := json.NewEncoder(w).Encode(api.TrailBodyDocument{TextSnapshot: "new body"}); err != nil {
+				t.Errorf("encode body response: %v", err)
 			}
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -2077,9 +2052,12 @@ func TestRunTrailUpdateSendsTitleAndBodyAsSeparatePatches(t *testing.T) {
 	require.NoError(t, err)
 	mu.Lock()
 	defer mu.Unlock()
-	require.Len(t, patches, 2, "title and body must go out as two PATCHes")
-	require.Equal(t, map[string]any{"title": "new title"}, patches[0])
-	require.Equal(t, map[string]any{trailBodyField: "new body"}, patches[1])
+	require.Equal(t, []trailWrite{
+		{method: http.MethodPatch, path: trailTestBasePath + "/7", body: map[string]any{"title": "new title"}},
+		// overwrite is what makes editing an existing description work: without
+		// it the route 409s on any non-empty body.
+		{method: http.MethodPut, path: trailTestBasePath + "/7/body", body: map[string]any{"markdown": "new body", "overwrite": true}},
+	}, writes, "title must go out as a metadata PATCH and the body as a PUT .../body")
 	require.Contains(t, out.String(), "Updated trail for branch feature/x")
 	require.Empty(t, errOut.String())
 }
@@ -2122,10 +2100,10 @@ func TestRunTrailUpdateReportsNoChangesWhenNothingWasSent(t *testing.T) {
 	require.NotContains(t, out.String(), "Updated trail")
 }
 
-// TestRunTrailUpdateReportsAppliedMetadataWhenBodyPatchFails covers the
-// non-atomic half of the two-PATCH split: the metadata already landed, so the
-// error has to say so rather than reading as "nothing changed".
-func TestRunTrailUpdateReportsAppliedMetadataWhenBodyPatchFails(t *testing.T) {
+// TestRunTrailUpdateReportsAppliedMetadataWhenBodyWriteFails covers the
+// non-atomic half of the two-request update: the metadata PATCH already landed,
+// so the error has to say so rather than reading as "nothing changed".
+func TestRunTrailUpdateReportsAppliedMetadataWhenBodyWriteFails(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2138,19 +2116,12 @@ func TestRunTrailUpdateReportsAppliedMetadataWhenBodyPatchFails(t *testing.T) {
 			}); err != nil {
 				t.Errorf("encode list response: %v", err)
 			}
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/body"):
+			w.WriteHeader(http.StatusServiceUnavailable)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "yjs engine is not configured"}); err != nil {
+				t.Errorf("encode rejection: %v", err)
+			}
 		case r.Method == http.MethodPatch:
-			var got map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-				t.Errorf("decode patch request: %v", err)
-				return
-			}
-			if _, hasBody := got[trailBodyField]; hasBody {
-				w.WriteHeader(http.StatusServiceUnavailable)
-				if err := json.NewEncoder(w).Encode(map[string]string{"error": "Editor collaboration not configured"}); err != nil {
-					t.Errorf("encode rejection: %v", err)
-				}
-				return
-			}
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(api.TrailUpdateResponse{Trail: api.TrailResource{ID: "trl_1", Number: 7}}); err != nil {
 				t.Errorf("encode update response: %v", err)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1094
<!-- entire-trail-link-end -->

## Problem

`entire trail update --body` never worked. It sent the description as a `body` field on `PATCH /api/v1/trails/{host}/{owner}/{repo}/{number}`, and that route does not serve body writes at all — it rejects the field and names the dedicated route to use instead. Because the rejection has been served as a redacted 5xx, the caller only ever saw a bare `Service Unavailable`.

That redaction is why this survived: it read as a flaky server, not a wrong route. It was previously measured across payload sizes from 200 B to 4 KB and retried over ten minutes, with `--title` PATCH, `trail create --body`, `trail show` and `trail delete` all succeeding in the same minute.

## Fix

The description now goes to `PUT .../trails/{number}/body` as `{"markdown": ..., "overwrite": true}`.

- **`overwrite` is what makes editing work.** Left false, the route refuses any non-empty description with `409 document_not_empty` — every write except the first. It also matches what `--body` already means, and the interactive path shows the current description before you edit it.
- **`If-Match` is not a substitute.** That ETag is only handed out by a body write's own response, so obtaining one means being refused and retrying — which clobbers exactly as `overwrite` does, one round trip later. A true compare-and-set would need the ETag of the document the user read, and a trail read carries none. If we want users to have that choice, it's a flag, not a default buried in the send helper.
- **`api.TrailUpdateRequest` loses its `Body` field entirely**, so sending a description on the metadata route is no longer representable. `splitTrailUpdate`, which existed only to send the body as its own PATCH, goes with it.
- Metadata and description still travel as two non-atomic requests; the existing "metadata was updated, but the body update failed" error is unchanged.
- `--body`'s help now reads `Replace the description (--body= clears it)`.

No status code is pinned in the CLI's comments or tests. The rejection has been a redacted 5xx and is moving to a 4xx that serves the actionable message verbatim; the CLI must behave the same either way, so the test asserts the invariant (a description must never appear on the metadata PATCH) rather than mimicking a rejection.

## Verification

- Route and request shape checked against the **deployed cell's OpenAPI**, not just the server source: `PUT /trails/{host}/{owner}/{repo}/{number}/body` accepts `markdown`/`contentJson` plus `overwrite`, with a 409 and 412 declared.
- New end-to-end test drives the whole command against a fake cell: title goes out as the metadata PATCH, description as the body PUT, and the PATCH handler fails the test if a description ever reaches it.
- Second commit covers `--body=` (clearing), whose two silent-failure modes — gating on non-empty text instead of the flag, and `omitempty` dropping `markdown` — are invisible to the other update tests.
- `mise run check` green (fmt, lint, unit, integration, e2e canary).

**Verified live against production**, on this PR's own trail ([#1094](https://entire.io/gh/entireio/cli/trails/1094)), in both states the route distinguishes: the first write against an empty document, and a second write replacing it — the non-empty case that returns `409 document_not_empty` without `overwrite`. Both succeeded and read back. This trail's description is the output of the fixed CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how trail descriptions are persisted (wrong route before); behavior is well covered by HTTP-level tests but metadata and body updates remain non-atomic.
> 
> **Overview**
> **`entire trail update --body` now writes descriptions to the dedicated body API** instead of sending a `body` field on the metadata PATCH, which the server rejects (often surfaced as a misleading 5xx).
> 
> The CLI sends **`PUT …/{number}/body`** with `{"markdown": …, "overwrite": true}` via new `TrailBodyRequest`, `sendTrailBody`, and `trailBodyPath`. **`Body` is removed from `TrailUpdateRequest`** so metadata PATCH cannot carry a description again; the old `splitTrailUpdate` two-PATCH helper is gone. Combined title/metadata + description updates still use **two non-atomic requests**, with the same partial-failure error if the body PUT fails after metadata succeeds.
> 
> **`--body=`** clears the description when the flag is set (empty `markdown` is intentional, not omitted). Tests assert PATCH vs PUT routing, empty-body clears, and that metadata PATCH never includes a description field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ecd48f37545e6d8f81280c867ce07bc60a2418. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
