### PR TITLE
fix(textutil): strip Cursor transcript <timestamp> wrappers from prompts

### DIFF
--- a/cmd/entire/cli/textutil/ide_tags.go
+++ b/cmd/entire/cli/textutil/ide_tags.go
@@ -18,7 +18,8 @@ var systemTagRegexes = []*regexp.Regexp{
 	regexp.MustCompile(`(?s)<command-message[^>]*>.*?</command-message>`),
 	regexp.MustCompile(`(?s)<command-args[^>]*>.*?</command-args>`),
 	regexp.MustCompile(`(?s)<local-command-stdout[^>]*>.*?</local-command-stdout>`),
-	regexp.MustCompile(`</?user_query>`), // Cursor wraps user text in <user_query> tags; strip tags but keep content
+	regexp.MustCompile(`</?user_query>`),                      // Cursor wraps user text in <user_query> tags; strip tags but keep content
+	regexp.MustCompile(`(?s)<timestamp[^>]*>.*?</timestamp>`), // Cursor wraps transcripts with a <timestamp> tag; drop tag and content
 }
 
 // StripIDEContextTags removes IDE-injected context tags from prompt text.
@@ -30,6 +31,8 @@ var systemTagRegexes = []*regexp.Regexp{
 //   - <local-command-caveat>...</local-command-caveat>
 //   - <system-reminder>...</system-reminder>
 //   - <command-name>...</command-name>
+//   - <timestamp>...</timestamp> - Cursor's transcript wrapper, dropped with
+//     its content rather than unwrapped like <user_query>
 //
 // These shouldn't appear in commit messages or session descriptions.
 func StripIDEContextTags(text string) string {

--- a/cmd/entire/cli/textutil/ide_tags_test.go
+++ b/cmd/entire/cli/textutil/ide_tags_test.go
@@ -98,6 +98,16 @@ func TestStripIDEContextTags(t *testing.T) {
 			input:    "<user_query>\nhello world\n</user_query>",
 			expected: "hello world",
 		},
+		{
+			name:     "cursor timestamp wrapper before user_query",
+			input:    "<timestamp>Wed Aug 19, 2026, 1:51 PM (UTC-4)</timestamp>\n<user_query>\nhello\n</user_query>",
+			expected: "hello",
+		},
+		{
+			name:     "cursor timestamp tag with attributes",
+			input:    "<timestamp tz=\"UTC-4\">Wed Aug 19, 2026</timestamp>\n\nfix the bug",
+			expected: "fix the bug",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1102
<!-- entire-trail-link-end -->

**Trail:** https://entire.io/gh/entireio/cli/trails/1102

**What:** `StripIDEContextTags` now also strips Cursor's `<timestamp>...</timestamp>` transcript wrapper, dropping the tag and its content.

**Why / how it helps:** Cursor wraps transcript entries with a `<timestamp>...</timestamp>` tag alongside `<user_query>`. The stripper already unwraps `<user_query>` (keeping the prompt text) but had no rule for `<timestamp>`, so transcript-derived prompts leaked the raw timestamp tag and its contents into commit messages and session descriptions.

**How:** Added `<timestamp[^>]*>.*?</timestamp>` to `systemTagRegexes`, following the same per-tag-type pattern already used for `<system-reminder>`, `<local-command-caveat>`, etc. Unlike `<user_query>`, the whole tag plus content is dropped rather than unwrapped, since the timestamp text itself isn't part of the prompt.

**Testing:**
- `go test ./cmd/entire/cli/textutil/... -count=1` — 43 passed
- `go test ./cmd/entire/cli/agent/cursor/... ./cmd/entire/cli/transcript/... ./cmd/entire/cli/summarize/... ./cmd/entire/cli/agent/factoryaidroid/... ./cmd/entire/cli/agent/claudecode/... -count=1` (all consumers of `StripIDEContextTags`) — 687 passed total
- Added cases for a realistic Cursor wrapper (`<timestamp>...</timestamp>` followed by `<user_query>`) and a `<timestamp>` tag carrying attributes
- Verified on the committed tree (`git show HEAD --stat`)

Fixes #2065