### PR TITLE
ci: drop the apt-installed keyring from the Linux test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,11 @@ on:
 jobs:
   test-core:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Setup Keyring
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gnome-keyring
-          echo 'somecredstorepass' | gnome-keyring-daemon --unlock
       - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4
       - name: Core Tests
         env:
@@ -25,6 +21,7 @@ jobs:
 
   test-integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -33,11 +30,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Setup Keyring
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gnome-keyring
-          echo 'somecredstorepass' | gnome-keyring-daemon --unlock
       - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4
       - name: Integration Tests
         env:
@@ -46,6 +38,7 @@ jobs:
 
   test-canary:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       # Run the (no-cost, no-API) Vogon canary against each checkpoint backend so
@@ -56,11 +49,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Setup Keyring
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gnome-keyring
-          echo 'somecredstorepass' | gnome-keyring-daemon --unlock
       - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4
       - name: E2E Canary
         env:


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1103
<!-- entire-trail-link-end -->

## The hang

Every ubuntu job in `.github/workflows/ci.yml` started with:

```yaml
- name: Setup Keyring
  run: |
    sudo apt-get update
    sudo apt-get install -y gnome-keyring
    echo 'somecredstorepass' | gnome-keyring-daemon --unlock
```

`apt-get update` intermittently hangs there. From `test-integration (a)` in [run 32237694402](https://github.com/entireio/cli/actions/runs/32237694402):

```
09:28:04 Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease      ← retried 3x
09:28:10 Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease           ← mirror fallback
09:28:11 Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
15:28:09 ##[error]The operation was canceled.
```

The Azure mirror stops answering, apt falls back to `archive.ubuntu.com` via the mirrorlist, and that connection stalls mid-download without apt ever timing out. A healthy run gets `Hit:2 http://azure.archive.ubuntu.com...` and finishes the step in ~15s.

Two things make it expensive:

- **It hits individual runners, not whole runs.** On #2056, `test-canary (git-refs)` cleared the step in 3m27s while five sibling jobs hung. Rerunning is a dice roll.
- **The ubuntu jobs had no `timeout-minutes`,** so a stuck one burns the default 360-minute timeout. Jobs hung 02:52→08:53 and 09:02→15:03 on 2026-08-19, both exactly 6h.

## Why the step can go

It was added in 8f6242a43 (Mar 14), when the auth store used the OS keyring directly. That is no longer true:

- `tokenstore.resolveBackendLocked` returns a temp `fileStore` under `go test` via `internal/testdirs`, so in-process tests never reach a Secret Service.
- Every TestMain that spawns the real binary — `cmd/entire/cli/global_test.go`, `integration_test/setup_test.go`, `e2e/tests/main_test.go` — sets `ENTIRE_TOKEN_STORE=file` process-wide, so children don't either.
- `callKeyringWithTimeout` bounds the call even if something did.
- The daemon line was inert: it prints `SSH_AUTH_SOCK=...` to stdout, which never reaches `$GITHUB_ENV`.

The step's only effect was to make three PR-blocking jobs depend on an Ubuntu mirror.

## Changes

- Removed all three `Setup Keyring` steps — apt is off the PR-blocking path entirely.
- Added `timeout-minutes: 30` to `test-core`, `test-integration`, `test-canary`. Normal runtime is 2–8m (worst recent shard: 21m), so this caps a future hang at 30m instead of 6h.

## Not in scope

`e2e.yml`, `e2e-checkpoint-store.yml`, and `e2e-checkpoints-v2.yml` still `apt-get install gnome-keyring tmux`. They need `tmux` regardless, so dropping the keyring half wouldn't remove their apt dependency, and they already carry 40-minute job timeouts.

## Verification

Workflow YAML only, no Go changes; `mise run lint` clean. The real check is this PR's own CI: these jobs now run with no apt step at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5cebb7851ce751b4fc2161613ef59fcf48d6aec3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
