### PR TITLE
feat(trail): write a trail body through the new trail-body endpoint with etag-based CAS

### DIFF
--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -133,8 +133,8 @@ type TrailUpdateResponse struct {
 // The route also accepts contentJson (ProseMirror JSON, written as-is) in place
 // of markdown; the CLI only ever writes Markdown, so contentJson is not
 // modeled here. The route also accepts an If-Match header for optimistic
-// concurrency, populated from a prior read's or write's TrailBodyDocument.ETag
-// — see sendTrailBody for the dispatch between If-Match and Overwrite.
+// concurrency, populated from a prior read of TrailBodyDocument.ETag — see
+// sendTrailBody for the dispatch between If-Match and Overwrite.
 type TrailBodyRequest struct {
 	Markdown  string `json:"markdown"`
 	Overwrite bool   `json:"overwrite,omitempty"`

--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -50,9 +50,12 @@ type TrailResource struct {
 // is the rendered plain text displayed by the CLI. The document is also what a
 // body write returns (see TrailBodyRequest), so both directions decode into this
 // type; the fields the CLI does not use (id, documentKey, schemaVersion,
-// contentJson, updatedAt) are simply left out of it.
+// contentJson, updatedAt) are simply left out of it. ETag is populated on a
+// read as well as on a write response, and is what makes If-Match viable on
+// the next write (see sendTrailBody).
 type TrailBodyDocument struct {
 	TextSnapshot string `json:"textSnapshot"`
+	ETag         string `json:"etag,omitempty"`
 }
 
 // ToMetadata converts a TrailResource to display metadata.
@@ -128,9 +131,10 @@ type TrailUpdateResponse struct {
 // rejected as "exactly one of markdown/contentJson is required".
 //
 // The route also accepts contentJson (ProseMirror JSON, written as-is) in place
-// of markdown, and an If-Match header for optimistic concurrency. Neither is
-// modeled here: the CLI writes Markdown, and it has no ETag to send — that
-// value only comes back from a prior write through this same route.
+// of markdown; the CLI only ever writes Markdown, so contentJson is not
+// modeled here. The route also accepts an If-Match header for optimistic
+// concurrency, populated from a prior read's or write's TrailBodyDocument.ETag
+// — see sendTrailBody for the dispatch between If-Match and Overwrite.
 type TrailBodyRequest struct {
 	Markdown  string `json:"markdown"`
 	Overwrite bool   `json:"overwrite,omitempty"`

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1285,7 +1285,7 @@ func newTrailUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&statusStr, "status", "", "Update status")
 	cmd.Flags().StringVar(&title, "title", "", "Update title")
 	cmd.Flags().StringVar(&body, "body", "", "Replace the description (--body= clears it)")
-	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Replace the description unconditionally, even if it changed since being read")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Replace the description unconditionally, even if it changed since being read (only applies when --body is also given)")
 	cmd.Flags().StringVar(&branch, "branch", "", "Branch to update trail for (defaults to current)")
 	cmd.Flags().StringSliceVar(&assigneeAdd, "add-assignee", nil, "Add assignee(s) by login")
 	cmd.Flags().StringSliceVar(&assigneeRemove, "remove-assignee", nil, "Remove assignee(s) by login")
@@ -1687,7 +1687,7 @@ func sendTrailBody(ctx context.Context, client *api.Client, path, body, ifMatch 
 	if err := checkTrailResponse(resp); err != nil {
 		switch {
 		case api.IsHTTPErrorStatus(err, http.StatusPreconditionFailed):
-			return fmt.Errorf("%w — trail body changed since it was read; re-run to see the current text, or pass --overwrite", err)
+			return fmt.Errorf("%w — trail body changed since it was read; run 'entire trail show' to see the current text and merge it in, then re-run — or pass --overwrite to discard it", err)
 		case api.IsHTTPErrorStatus(err, http.StatusConflict):
 			return fmt.Errorf("%w — trail body is not empty; pass --overwrite to replace it", err)
 		default:

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1236,9 +1236,12 @@ func resolveTrailUpdateBody(ctx context.Context, client *api.Client, forge, owne
 		}
 		// fetchTrailDescription already trims; a non-empty result supersedes
 		// the list body, an empty one (older/partial server) leaves it intact.
+		// The etag is kept either way — it describes the document read, not
+		// the text, so it's valid even when the description is legitimately
+		// empty (avoids a redundant refetch below).
+		etag = et
 		if bt != "" {
 			body = bt
-			etag = et
 		}
 	}
 	return body, etag, nil
@@ -1465,14 +1468,23 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 			return err
 		}
 	}
-	if inputs.BodyChanged && bodyETag == "" && !inputs.Overwrite && found.Number > 0 {
-		// Non-interactive --body path: the interactive form already read the
-		// body (and its etag) above to seed the editor, but a --body caller
-		// supplied the replacement text directly and skipped that read. Do it
-		// here, best-effort, purely for the etag — a failure just leaves
-		// bodyETag empty and falls through to sendTrailBody's graceful
-		// Overwrite fallback rather than failing the whole command.
-		if _, etag, ferr := fetchTrailDescription(ctx, client, forge, owner, repoName, found.Number); ferr == nil {
+	if !noFlags && inputs.BodyChanged && bodyETag == "" && !inputs.Overwrite {
+		// Non-interactive --body path only (noFlags is the interactive
+		// branch, which already read the body and its etag above to seed the
+		// editor — gating on that branch rather than on bodyETag=="" matters:
+		// an interactive session can legitimately end with no etag too (e.g.
+		// the seed read failed and the user was already warned), and redoing
+		// the read here would silently pair an etag for content the user
+		// never saw with their edit). A --body caller supplied the
+		// replacement text directly and skipped that read, so do it here,
+		// best-effort, purely for the etag. A failure just leaves bodyETag
+		// empty and falls through to sendTrailBody's graceful Overwrite
+		// fallback rather than failing the whole command — but say so, since
+		// this is the unattended path most likely to run without anyone
+		// watching for a silently downgraded conflict check.
+		if _, etag, ferr := fetchTrailDescription(ctx, client, forge, owner, repoName, found.Number); ferr != nil {
+			fmt.Fprintf(errW, "Warning: could not verify trail body is unchanged (%v); writing without conflict detection\n", ferr)
+		} else {
 			bodyETag = etag
 		}
 	}
@@ -1657,12 +1669,9 @@ func sendTrailPatch(ctx context.Context, client *api.Client, path string, req ap
 func sendTrailBody(ctx context.Context, client *api.Client, path, body, ifMatch string, overwrite bool) error {
 	req := api.TrailBodyRequest{Markdown: body}
 	var headers http.Header
-	switch {
-	case overwrite:
-		req.Overwrite = true
-	case ifMatch != "":
+	if ifMatch != "" && !overwrite {
 		headers = http.Header{"If-Match": []string{ifMatch}}
-	default:
+	} else {
 		req.Overwrite = true
 	}
 

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -243,7 +244,7 @@ func runTrailShowWithClient(ctx context.Context, w, errW io.Writer, client *api.
 			bodyText = snapshot
 		}
 	case found.Number > 0:
-		if bt, derr := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number); derr == nil {
+		if bt, _, derr := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number); derr == nil {
 			// A successful fetch means we authoritatively consulted the
 			// description, but it only supersedes the seeded list body when
 			// it actually carries text: an older/partial server that omits
@@ -428,27 +429,28 @@ func trailWebURL(base, forge, owner, repo string, number int) string {
 }
 
 // fetchTrailDescription fetches a trail's rendered description text
-// (`trail.body_document.text_snapshot`), which the list endpoint omits, by
-// integer number. It returns only the description — the list result already
-// supplies the metadata — and decodes only the fields it needs, so it is
-// unaffected by the shape of sibling fields like `checkpoints`/`thread`.
-func fetchTrailDescription(ctx context.Context, client *api.Client, forge, owner, repo string, number int) (string, error) {
+// (`trail.body_document.text_snapshot`) and its etag, which the list endpoint
+// omits, by integer number. It returns only the description and etag — the
+// list result already supplies the metadata — and decodes only the fields it
+// needs, so it is unaffected by the shape of sibling fields like
+// `checkpoints`/`thread`.
+func fetchTrailDescription(ctx context.Context, client *api.Client, forge, owner, repo string, number int) (string, string, error) {
 	resp, err := client.Get(ctx, trailNumberPath(forge, owner, repo, number))
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch trail detail: %w", err)
+		return "", "", fmt.Errorf("failed to fetch trail detail: %w", err)
 	}
 	defer resp.Body.Close()
 	if err := checkTrailResponse(resp); err != nil {
-		return "", err
+		return "", "", err
 	}
 	detail, err := decodeTrailResource(resp)
 	if err != nil {
-		return "", fmt.Errorf("failed to decode trail detail: %w", err)
+		return "", "", fmt.Errorf("failed to decode trail detail: %w", err)
 	}
 	if detail.BodyDocument == nil {
-		return "", nil
+		return "", "", nil
 	}
-	return strings.TrimSpace(detail.BodyDocument.TextSnapshot), nil
+	return strings.TrimSpace(detail.BodyDocument.TextSnapshot), detail.BodyDocument.ETag, nil
 }
 
 // decodeTrailResource decodes entire-api's direct detail resource.
@@ -1215,32 +1217,37 @@ func newTrailCreateRequest(title, body, branch, base, statusStr, typeStr, priori
 }
 
 // resolveTrailUpdateBody returns the body text to seed the interactive update
-// form with. The list resource omits the description (it lives in
-// body_document, served only by the detail endpoint), so update must fetch the
-// detail body — otherwise the form prefills from the empty list body and a
-// user edit against that blank baseline can overwrite a description they never
-// saw. Best-effort: on a failed detail fetch it returns the list body plus the
-// error so the caller can warn (mirroring runTrailShow); an empty detail body
-// (older/partial server) falls back to the list body with no error.
-func resolveTrailUpdateBody(ctx context.Context, client *api.Client, forge, owner, repo string, found *api.TrailResource) (string, error) {
-	body := found.Body
+// form with, plus the etag of the description as read (empty when unavailable,
+// e.g. an older server or a fallback to the list body — see sendTrailBody for
+// how a missing etag is handled). The list resource omits the description (it
+// lives in body_document, served only by the detail endpoint), so update must
+// fetch the detail body — otherwise the form prefills from the empty list body
+// and a user edit against that blank baseline can overwrite a description they
+// never saw. Best-effort: on a failed detail fetch it returns the list body
+// (and no etag) plus the error so the caller can warn (mirroring
+// runTrailShow); an empty detail body (older/partial server) falls back to the
+// list body with no error.
+func resolveTrailUpdateBody(ctx context.Context, client *api.Client, forge, owner, repo string, found *api.TrailResource) (body, etag string, err error) {
+	body = found.Body
 	if found.Number > 0 {
-		bt, err := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number)
-		if err != nil {
-			return body, err
+		bt, et, ferr := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number)
+		if ferr != nil {
+			return body, "", ferr
 		}
 		// fetchTrailDescription already trims; a non-empty result supersedes
 		// the list body, an empty one (older/partial server) leaves it intact.
 		if bt != "" {
 			body = bt
+			etag = et
 		}
 	}
-	return body, nil
+	return body, etag, nil
 }
 
 func newTrailUpdateCmd() *cobra.Command {
 	var statusStr, title, body, branch, typeStr, priorityStr string
 	var assigneeAdd, assigneeRemove, reviewerAdd, reviewerRemove []string
+	var overwrite bool
 
 	cmd := &cobra.Command{
 		Use:   "update",
@@ -1257,6 +1264,7 @@ func newTrailUpdateCmd() *cobra.Command {
 				TitleChanged:    cmd.Flags().Changed("title"),
 				Body:            body,
 				BodyChanged:     cmd.Flags().Changed("body"),
+				Overwrite:       overwrite,
 				Branch:          branch,
 				Repo:            trailRepoFlag(cmd),
 				AssigneeAdd:     assigneeAdd,
@@ -1274,6 +1282,7 @@ func newTrailUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&statusStr, "status", "", "Update status")
 	cmd.Flags().StringVar(&title, "title", "", "Update title")
 	cmd.Flags().StringVar(&body, "body", "", "Replace the description (--body= clears it)")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Replace the description unconditionally, even if it changed since being read")
 	cmd.Flags().StringVar(&branch, "branch", "", "Branch to update trail for (defaults to current)")
 	cmd.Flags().StringSliceVar(&assigneeAdd, "add-assignee", nil, "Add assignee(s) by login")
 	cmd.Flags().StringSliceVar(&assigneeRemove, "remove-assignee", nil, "Remove assignee(s) by login")
@@ -1292,6 +1301,7 @@ type trailUpdateInputs struct {
 	TitleChanged    bool
 	Body            string
 	BodyChanged     bool
+	Overwrite       bool
 	Branch          string
 	Repo            string
 	AssigneeAdd     []string
@@ -1340,6 +1350,7 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 	statusStr := inputs.Status
 	title := inputs.Title
 	body := inputs.Body
+	var bodyETag string
 	noFlags := !inputs.StatusChanged && !inputs.TitleChanged && !inputs.BodyChanged &&
 		inputs.AssigneeAdd == nil && inputs.AssigneeRemove == nil &&
 		inputs.ReviewerAdd == nil && inputs.ReviewerRemove == nil &&
@@ -1364,11 +1375,12 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 		// the form prefills with the current text and change detection below
 		// compares against the real server value. Warn on a fetch failure so
 		// a blank baseline doesn't silently overwrite an unseen description.
-		seedBody, bodyErr := resolveTrailUpdateBody(ctx, client, forge, owner, repoName, found)
+		seedBody, seedETag, bodyErr := resolveTrailUpdateBody(ctx, client, forge, owner, repoName, found)
 		if bodyErr != nil {
 			fmt.Fprintf(errW, "Warning: could not load current trail body: %v\n", bodyErr)
 		}
 		body = seedBody
+		bodyETag = seedETag
 		origStatus, origTitle, origBody := statusStr, title, body
 
 		form := NewAccessibleForm(
@@ -1453,8 +1465,19 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 			return err
 		}
 	}
+	if inputs.BodyChanged && bodyETag == "" && !inputs.Overwrite && found.Number > 0 {
+		// Non-interactive --body path: the interactive form already read the
+		// body (and its etag) above to seed the editor, but a --body caller
+		// supplied the replacement text directly and skipped that read. Do it
+		// here, best-effort, purely for the etag — a failure just leaves
+		// bodyETag empty and falls through to sendTrailBody's graceful
+		// Overwrite fallback rather than failing the whole command.
+		if _, etag, ferr := fetchTrailDescription(ctx, client, forge, owner, repoName, found.Number); ferr == nil {
+			bodyETag = etag
+		}
+	}
 	if inputs.BodyChanged {
-		if err := sendTrailBody(ctx, client, trailBodyPath(forge, owner, repoName, found.Number), body); err != nil {
+		if err := sendTrailBody(ctx, client, trailBodyPath(forge, owner, repoName, found.Number), body, bodyETag, inputs.Overwrite); err != nil {
 			if hasMeta {
 				return fmt.Errorf("trail metadata was updated, but the body update failed (the metadata change already applied; retry only the --body change): %w", err)
 			}
@@ -1616,31 +1639,51 @@ func sendTrailPatch(ctx context.Context, client *api.Client, path string, req ap
 // one that serves body writes (api.TrailUpdateRequest documents why the metadata
 // PATCH does not). path must already be that route — see trailBodyPath.
 //
-// Overwrite is set because that is what `trail update --body` already means: the
-// caller named the replacement text, and the interactive path shows them the
-// current description before they edit it (resolveTrailUpdateBody). Left false,
-// the route refuses with 409 document_not_empty against any trail whose
-// description is non-empty — i.e. everything except a first write — so the flag
-// is what makes editing an existing description work at all.
+// Three dispatch modes, in order:
 //
-// The cost is that a description changed elsewhere between that read and this
-// write is replaced rather than reported. The route's If-Match is not a fix for
-// that here: its ETag comes only from a body write's own response (including the
-// 409's), so the CLI can obtain one just by being refused and retrying — which
-// clobbers exactly as overwrite does, one round trip later. A true
-// compare-and-set would need the ETag of the document the user actually read,
-// and a trail read carries none (bodyDocument has no ETag, and its updatedAt is
-// formatted to a different precision than the header, so reconstructing one from
-// a read yields a value that never matches). Giving the user that choice is a
-// flag decision, not something to bury here.
-func sendTrailBody(ctx context.Context, client *api.Client, path, body string) error {
-	resp, err := client.Put(ctx, path, api.TrailBodyRequest{Markdown: body, Overwrite: true})
+//   - overwrite: sends Overwrite: true and no If-Match. This is the explicit
+//     --overwrite flag — the caller wants the replacement to win regardless of
+//     what's there.
+//   - ifMatch non-empty (and !overwrite): sends If-Match instead of Overwrite,
+//     so the write is rejected with 412 if the description changed since
+//     ifMatch was read (resolveTrailUpdateBody / the non-interactive etag
+//     fetch in runTrailUpdateWithClient).
+//   - neither: falls back to Overwrite: true. This is deliberate graceful
+//     degradation, not a shortcut to remove — it's what runs against a server
+//     that predates the etag field, a trail with no body document yet, or
+//     after a failed best-effort etag read. Refusing to write in that case
+//     would make `trail update --body` unusable against anything older or
+//     partial than the newest server.
+func sendTrailBody(ctx context.Context, client *api.Client, path, body, ifMatch string, overwrite bool) error {
+	req := api.TrailBodyRequest{Markdown: body}
+	var headers http.Header
+	switch {
+	case overwrite:
+		req.Overwrite = true
+	case ifMatch != "":
+		headers = http.Header{"If-Match": []string{ifMatch}}
+	default:
+		req.Overwrite = true
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal trail body request: %w", err)
+	}
+	resp, err := client.Request(ctx, http.MethodPut, path, headers, bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("failed to update trail body: %w", err)
 	}
 	defer resp.Body.Close()
 	if err := checkTrailResponse(resp); err != nil {
-		return err
+		switch {
+		case api.IsHTTPErrorStatus(err, http.StatusPreconditionFailed):
+			return fmt.Errorf("%w — trail body changed since it was read; re-run to see the current text, or pass --overwrite", err)
+		case api.IsHTTPErrorStatus(err, http.StatusConflict):
+			return fmt.Errorf("%w — trail body is not empty; pass --overwrite to replace it", err)
+		default:
+			return err
+		}
 	}
 	// Nothing reads the document back; decoding it only confirms the success
 	// really was this route's JSON response, and drains the body — the same

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -39,6 +39,9 @@ const (
 	trailListTestAuthorBob   = "bob"
 	// trailTestBasePath is the trails endpoint for the gh/acme/repo fixture.
 	trailTestBasePath = "/api/v1/trails/gh/acme/repo"
+	// trailTestListBody is the stand-in list-resource body used across the
+	// resolveTrailUpdateBody fallback tests.
+	trailTestListBody = "list body"
 )
 
 func TestNewTrailCreateRequestUsesLinkBranchAction(t *testing.T) {
@@ -623,7 +626,7 @@ func TestFetchTrailDescription_ReadsNestedBodyDocument(t *testing.T) {
 func TestResolveTrailUpdateBody_PrefersDetailSnapshot(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if _, err := io.WriteString(w, `{"number":42,"bodyDocument":{"textSnapshot":"the real body"},"checkpoints":[],"hasWritePermission":true}`); err != nil {
+		if _, err := io.WriteString(w, `{"number":42,"bodyDocument":{"textSnapshot":"the real body","etag":"W/\"etag-real\""},"checkpoints":[],"hasWritePermission":true}`); err != nil {
 			t.Errorf("write response: %v", err)
 		}
 	}))
@@ -640,8 +643,36 @@ func TestResolveTrailUpdateBody_PrefersDetailSnapshot(t *testing.T) {
 	if body != "the real body" {
 		t.Fatalf("body = %q, want %q", body, "the real body")
 	}
-	if etag != "" {
-		t.Fatalf("etag = %q, want empty (fixture supplies no etag)", etag)
+	if etag != `W/"etag-real"` {
+		t.Fatalf("etag = %q, want the detail's real etag to survive the round trip", etag)
+	}
+}
+
+// TestResolveTrailUpdateBody_ReturnsETagEvenWhenSnapshotEmpty covers a real
+// document whose description happens to be empty (already cleared): the etag
+// describes the document that was read, not its text, so it must still come
+// back — dropping it here would force the non-interactive best-effort refetch
+// in runTrailUpdateWithClient to redo a read that already succeeded.
+func TestResolveTrailUpdateBody_ReturnsETagEvenWhenSnapshotEmpty(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := io.WriteString(w, `{"number":42,"bodyDocument":{"textSnapshot":"","etag":"W/\"etag-empty-doc\""},"checkpoints":[],"hasWritePermission":true}`); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	found := &api.TrailResource{Number: 42, Body: trailTestListBody}
+	body, etag, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	if err != nil {
+		t.Fatalf("resolveTrailUpdateBody: %v", err)
+	}
+	if body != trailTestListBody {
+		t.Fatalf("body = %q, want fallback %q (empty snapshot doesn't override it)", body, trailTestListBody)
+	}
+	if etag != `W/"etag-empty-doc"` {
+		t.Fatalf("etag = %q, want the real etag even though the snapshot was empty", etag)
 	}
 }
 
@@ -657,13 +688,13 @@ func TestResolveTrailUpdateBody_FallsBackToListBody(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	found := &api.TrailResource{Number: 42, Body: "list body"}
+	found := &api.TrailResource{Number: 42, Body: trailTestListBody}
 	body, etag, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
 	if err != nil {
 		t.Fatalf("resolveTrailUpdateBody: %v", err)
 	}
-	if body != "list body" {
-		t.Fatalf("body = %q, want %q", body, "list body")
+	if body != trailTestListBody {
+		t.Fatalf("body = %q, want %q", body, trailTestListBody)
 	}
 	if etag != "" {
 		t.Fatalf("etag = %q, want empty when falling back to the list body", etag)
@@ -680,13 +711,13 @@ func TestResolveTrailUpdateBody_ReturnsErrorOnFetchFailure(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	found := &api.TrailResource{Number: 42, Body: "list body"}
+	found := &api.TrailResource{Number: 42, Body: trailTestListBody}
 	body, etag, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
 	if err == nil {
 		t.Fatal("expected error on fetch failure, got nil")
 	}
-	if body != "list body" {
-		t.Fatalf("body = %q, want fallback %q", body, "list body")
+	if body != trailTestListBody {
+		t.Fatalf("body = %q, want fallback %q", body, trailTestListBody)
 	}
 	if etag != "" {
 		t.Fatalf("etag = %q, want empty on fetch failure", etag)
@@ -1718,7 +1749,7 @@ func TestRunTrailShowJSONLeavesBodyEmptyWithoutDescription(t *testing.T) {
 func TestRunTrailShowJSONKeepsStdoutParseableWhenDescriptionFetchFails(t *testing.T) {
 	t.Parallel()
 
-	srv := trailShowTestServer(t, api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x", Title: "T", Body: "list body", Status: string(trail.StatusOpen)}, "", http.StatusInternalServerError)
+	srv := trailShowTestServer(t, api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x", Title: "T", Body: trailTestListBody, Status: string(trail.StatusOpen)}, "", http.StatusInternalServerError)
 
 	var out, errOut bytes.Buffer
 	err := runTrailShowWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailShowOptions{Selector: "feature/x", JSON: true})
@@ -1728,7 +1759,7 @@ func TestRunTrailShowJSONKeepsStdoutParseableWhenDescriptionFetchFails(t *testin
 
 	var got trail.Metadata
 	require.NoError(t, json.Unmarshal(out.Bytes(), &got), "stdout must stay valid JSON: %s", out.String())
-	require.Equal(t, "list body", got.Body, "the list body is the fallback when the detail fetch fails")
+	require.Equal(t, trailTestListBody, got.Body, "the list body is the fallback when the detail fetch fails")
 }
 
 func TestRunTrailShowTextStillRendersTheHumanView(t *testing.T) {
@@ -2225,10 +2256,10 @@ func TestRunTrailUpdateReportsAppliedMetadataWhenBodyWriteFails(t *testing.T) {
 	require.ErrorContains(t, err, "trail metadata was updated, but the body update failed")
 }
 
-// boolFieldOrFalse reads a bool field from a decoded JSON map, treating a
-// missing (omitempty-dropped) key the same as an explicit false.
-func boolFieldOrFalse(m map[string]any, key string) bool {
-	v, ok := m[key].(bool)
+// overwriteFieldOrFalse reads the "overwrite" field from a decoded JSON map,
+// treating a missing (omitempty-dropped) key the same as an explicit false.
+func overwriteFieldOrFalse(m map[string]any) bool {
+	v, ok := m["overwrite"].(bool)
 	if !ok {
 		return false
 	}
@@ -2298,7 +2329,7 @@ func TestSendTrailBody_DispatchModes(t *testing.T) {
 
 			require.Equal(t, tc.wantIfMatch, gotIfMatch, "If-Match header")
 			require.Equal(t, "new body", gotBody["markdown"])
-			require.Equal(t, tc.wantOverwrite, boolFieldOrFalse(gotBody, "overwrite"), "overwrite field")
+			require.Equal(t, tc.wantOverwrite, overwriteFieldOrFalse(gotBody), "overwrite field")
 		})
 	}
 }
@@ -2328,7 +2359,13 @@ func TestSendTrailBody_PreconditionFailedMapsToRerunOrOverwriteHint(t *testing.T
 // TestSendTrailBody_ConflictMapsToOverwriteHint covers the 409 the route
 // returns when writing without Overwrite against a non-empty description that
 // carried no etag (e.g. an older server) — the caller must be told the flag
-// that unblocks it, not just "conflict".
+// that unblocks it, not just "conflict". Note this pins the message-mapping
+// logic in isolation rather than a request shape sendTrailBody's own dispatch
+// would produce today: with ifMatch=="" it always sets Overwrite:true, so the
+// route (which only 409s when Overwrite is absent) would not actually reject
+// this exact request. Kept as a direct unit test of the mapping regardless,
+// since a future dispatch change (or a server behavior change) could make it
+// reachable again.
 func TestSendTrailBody_ConflictMapsToOverwriteHint(t *testing.T) {
 	t.Parallel()
 
@@ -2382,7 +2419,7 @@ func TestRunTrailUpdateWithClient_EtagThreadsToIfMatch(t *testing.T) {
 				t.Errorf("decode body request: %v", err)
 				return
 			}
-			gotOverwrite = boolFieldOrFalse(got, "overwrite")
+			gotOverwrite = overwriteFieldOrFalse(got)
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(api.TrailBodyDocument{TextSnapshot: "new body"}); err != nil {
 				t.Errorf("encode body response: %v", err)
@@ -2430,7 +2467,7 @@ func TestRunTrailUpdateWithClient_OverwriteFlagSkipsEtagFetch(t *testing.T) {
 				t.Errorf("decode body request: %v", err)
 				return
 			}
-			gotOverwrite = boolFieldOrFalse(got, "overwrite")
+			gotOverwrite = overwriteFieldOrFalse(got)
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(api.TrailBodyDocument{TextSnapshot: "new body"}); err != nil {
 				t.Errorf("encode body response: %v", err)
@@ -2451,6 +2488,60 @@ func TestRunTrailUpdateWithClient_OverwriteFlagSkipsEtagFetch(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, gotOverwrite)
 	require.Empty(t, gotIfMatch)
+}
+
+// TestRunTrailUpdateWithClient_EtagFetchFailureWarnsAndFallsBackToOverwrite
+// covers the non-interactive best-effort etag fetch actually failing (a hard
+// server error, not just an absent bodyDocument): the command must still
+// succeed by falling back to Overwrite, but — unlike the graceful
+// no-bodyDocument case — this is a real failure, so the caller must be warned
+// that the conflict check was skipped rather than have it disappear silently.
+func TestRunTrailUpdateWithClient_EtagFetchFailureWarnsAndFallsBackToOverwrite(t *testing.T) {
+	t.Parallel()
+
+	var gotOverwrite bool
+	var gotIfMatch string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath:
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{
+				Trails: []api.TrailResource{{ID: "trl_1", Number: 7, Branch: "feature/x", Status: string(trail.StatusOpen)}},
+				Total:  1,
+			}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath+"/7":
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == http.MethodPut && r.URL.Path == trailTestBasePath+"/7/body":
+			gotIfMatch = r.Header.Get("If-Match")
+			var got map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode body request: %v", err)
+				return
+			}
+			gotOverwrite = overwriteFieldOrFalse(got)
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailBodyDocument{TextSnapshot: "new body"}); err != nil {
+				t.Errorf("encode body response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	var errBuf bytes.Buffer
+	err := runTrailUpdateWithClient(t.Context(), io.Discard, &errBuf, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+		Branch:      "feature/x",
+		Body:        "new body",
+		BodyChanged: true,
+	})
+
+	require.NoError(t, err, "a failed best-effort etag read must not fail the whole command")
+	require.True(t, gotOverwrite, "no etag in hand must fall back to Overwrite")
+	require.Empty(t, gotIfMatch)
+	require.Contains(t, errBuf.String(), "Warning", "the caller must be told the conflict check was skipped, not have it disappear silently")
 }
 
 func TestTrailUpdateCmdHasCollaborationFlags(t *testing.T) {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -608,7 +608,7 @@ func TestFetchTrailDescription_ReadsNestedBodyDocument(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	bodyText, err := fetchTrailDescription(t.Context(), client, "gh", "acme", "repo", 777)
+	bodyText, _, err := fetchTrailDescription(t.Context(), client, "gh", "acme", "repo", 777)
 	if err != nil {
 		t.Fatalf("fetchTrailDescription: %v", err)
 	}
@@ -633,12 +633,15 @@ func TestResolveTrailUpdateBody_PrefersDetailSnapshot(t *testing.T) {
 	// The list resource omits the description, so found.Body is empty. The
 	// seed must come from the detail endpoint, not the empty list body.
 	found := &api.TrailResource{Number: 42, Body: ""}
-	body, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	body, etag, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
 	if err != nil {
 		t.Fatalf("resolveTrailUpdateBody: %v", err)
 	}
 	if body != "the real body" {
 		t.Fatalf("body = %q, want %q", body, "the real body")
+	}
+	if etag != "" {
+		t.Fatalf("etag = %q, want empty (fixture supplies no etag)", etag)
 	}
 }
 
@@ -655,12 +658,15 @@ func TestResolveTrailUpdateBody_FallsBackToListBody(t *testing.T) {
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
 	found := &api.TrailResource{Number: 42, Body: "list body"}
-	body, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	body, etag, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
 	if err != nil {
 		t.Fatalf("resolveTrailUpdateBody: %v", err)
 	}
 	if body != "list body" {
 		t.Fatalf("body = %q, want %q", body, "list body")
+	}
+	if etag != "" {
+		t.Fatalf("etag = %q, want empty when falling back to the list body", etag)
 	}
 }
 
@@ -675,12 +681,15 @@ func TestResolveTrailUpdateBody_ReturnsErrorOnFetchFailure(t *testing.T) {
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
 	found := &api.TrailResource{Number: 42, Body: "list body"}
-	body, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	body, etag, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
 	if err == nil {
 		t.Fatal("expected error on fetch failure, got nil")
 	}
 	if body != "list body" {
 		t.Fatalf("body = %q, want fallback %q", body, "list body")
+	}
+	if etag != "" {
+		t.Fatalf("etag = %q, want empty on fetch failure", etag)
 	}
 }
 
@@ -1279,6 +1288,14 @@ func TestRunTrailUpdateClearsDescriptionWithEmptyBody(t *testing.T) {
 				Total:  1,
 			}); err != nil {
 				t.Errorf("encode list response: %v", err)
+			}
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath+"/7":
+			// No bodyDocument, so the etag fetch below comes back empty and
+			// the write still falls back to Overwrite — the case this test
+			// pins.
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x"}); err != nil {
+				t.Errorf("encode detail response: %v", err)
 			}
 		case r.Method == http.MethodPut && r.URL.Path == trailTestBasePath+"/7/body":
 			mu.Lock()
@@ -2065,6 +2082,13 @@ func TestRunTrailUpdateSendsTitleAsPatchAndBodyAsPut(t *testing.T) {
 			}); err != nil {
 				t.Errorf("encode list response: %v", err)
 			}
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath+"/7":
+			// No bodyDocument, so the etag fetch below comes back empty and
+			// the write falls back to Overwrite, as asserted below.
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x", Title: "old title"}); err != nil {
+				t.Errorf("encode detail response: %v", err)
+			}
 		case r.Method == http.MethodPatch && r.URL.Path == trailTestBasePath+"/7":
 			got := record(r)
 			if got == nil {
@@ -2169,6 +2193,11 @@ func TestRunTrailUpdateReportsAppliedMetadataWhenBodyWriteFails(t *testing.T) {
 			}); err != nil {
 				t.Errorf("encode list response: %v", err)
 			}
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath+"/7":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x"}); err != nil {
+				t.Errorf("encode detail response: %v", err)
+			}
 		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/body"):
 			w.WriteHeader(http.StatusServiceUnavailable)
 			if err := json.NewEncoder(w).Encode(map[string]string{"error": "yjs engine is not configured"}); err != nil {
@@ -2196,10 +2225,238 @@ func TestRunTrailUpdateReportsAppliedMetadataWhenBodyWriteFails(t *testing.T) {
 	require.ErrorContains(t, err, "trail metadata was updated, but the body update failed")
 }
 
+// boolFieldOrFalse reads a bool field from a decoded JSON map, treating a
+// missing (omitempty-dropped) key the same as an explicit false.
+func boolFieldOrFalse(m map[string]any, key string) bool {
+	v, ok := m[key].(bool)
+	if !ok {
+		return false
+	}
+	return v
+}
+
+// TestSendTrailBody_DispatchModes drives sendTrailBody's three-way dispatch
+// directly against a fake body route, asserting on the exact request the
+// server received: which of Overwrite/If-Match went out, and which didn't.
+// Flipping the mode logic to always send Overwrite, or dropping the If-Match
+// header, or refusing the no-etag case, each fails a case here.
+func TestSendTrailBody_DispatchModes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		ifMatch       string
+		overwrite     bool
+		wantIfMatch   string
+		wantOverwrite bool
+	}{
+		{
+			name:          "overwrite flag wins even with an etag in hand",
+			ifMatch:       "W/\"etag-1\"",
+			overwrite:     true,
+			wantIfMatch:   "",
+			wantOverwrite: true,
+		},
+		{
+			name:          "etag available, no overwrite: If-Match, no Overwrite",
+			ifMatch:       "W/\"etag-1\"",
+			overwrite:     false,
+			wantIfMatch:   "W/\"etag-1\"",
+			wantOverwrite: false,
+		},
+		{
+			name:          "no etag, no overwrite: falls back to Overwrite",
+			ifMatch:       "",
+			overwrite:     false,
+			wantIfMatch:   "",
+			wantOverwrite: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotIfMatch string
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotIfMatch = r.Header.Get("If-Match")
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Errorf("decode request body: %v", err)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(api.TrailBodyDocument{TextSnapshot: "new body"}); err != nil {
+					t.Errorf("encode response: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			client := api.NewClientWithBaseURL("tok", srv.URL)
+			err := sendTrailBody(t.Context(), client, "/api/v1/trails/gh/acme/repo/7/body", "new body", tc.ifMatch, tc.overwrite)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.wantIfMatch, gotIfMatch, "If-Match header")
+			require.Equal(t, "new body", gotBody["markdown"])
+			require.Equal(t, tc.wantOverwrite, boolFieldOrFalse(gotBody, "overwrite"), "overwrite field")
+		})
+	}
+}
+
+// TestSendTrailBody_PreconditionFailedMapsToRerunOrOverwriteHint covers the
+// 412 the route returns when the If-Match etag is stale: the CLI must not
+// retry with Overwrite on its own, only explain the two ways out.
+func TestSendTrailBody_PreconditionFailedMapsToRerunOrOverwriteHint(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusPreconditionFailed)
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "etag mismatch"}); err != nil {
+			t.Errorf("encode rejection: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	err := sendTrailBody(t.Context(), client, "/api/v1/trails/gh/acme/repo/7/body", "new body", "W/\"stale\"", false)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "re-run")
+	require.ErrorContains(t, err, "--overwrite")
+	require.True(t, api.IsHTTPErrorStatus(err, http.StatusPreconditionFailed))
+}
+
+// TestSendTrailBody_ConflictMapsToOverwriteHint covers the 409 the route
+// returns when writing without Overwrite against a non-empty description that
+// carried no etag (e.g. an older server) — the caller must be told the flag
+// that unblocks it, not just "conflict".
+func TestSendTrailBody_ConflictMapsToOverwriteHint(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "document_not_empty"}); err != nil {
+			t.Errorf("encode rejection: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	err := sendTrailBody(t.Context(), client, "/api/v1/trails/gh/acme/repo/7/body", "new body", "", false)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "--overwrite")
+	require.True(t, api.IsHTTPErrorStatus(err, http.StatusConflict))
+}
+
+// TestRunTrailUpdateWithClient_EtagThreadsToIfMatch is the end-to-end
+// non-interactive case: --body with no --overwrite must fetch the trail
+// detail purely for its etag (the interactive path already reads the body
+// itself; --body skips straight to sendTrailBody, so runTrailUpdateWithClient
+// has to do that read itself) and carry it through as If-Match.
+func TestRunTrailUpdateWithClient_EtagThreadsToIfMatch(t *testing.T) {
+	t.Parallel()
+
+	var gotIfMatch string
+	var gotOverwrite bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath:
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{
+				Trails: []api.TrailResource{{ID: "trl_1", Number: 7, Branch: "feature/x", Status: string(trail.StatusOpen)}},
+				Total:  1,
+			}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath+"/7":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailResource{
+				ID: "trl_1", Number: 7, Branch: "feature/x",
+				BodyDocument: &api.TrailBodyDocument{TextSnapshot: "old body", ETag: `W/"etag-current"`},
+			}); err != nil {
+				t.Errorf("encode detail response: %v", err)
+			}
+		case r.Method == http.MethodPut && r.URL.Path == trailTestBasePath+"/7/body":
+			gotIfMatch = r.Header.Get("If-Match")
+			var got map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode body request: %v", err)
+				return
+			}
+			gotOverwrite = boolFieldOrFalse(got, "overwrite")
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailBodyDocument{TextSnapshot: "new body"}); err != nil {
+				t.Errorf("encode body response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	err := runTrailUpdateWithClient(t.Context(), io.Discard, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+		Branch:      "feature/x",
+		Body:        "new body",
+		BodyChanged: true,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, `W/"etag-current"`, gotIfMatch, "the etag read from the detail fetch must reach the wire as If-Match")
+	require.False(t, gotOverwrite, "an etag in hand must not also send Overwrite")
+}
+
+// TestRunTrailUpdateWithClient_OverwriteFlagSkipsEtagFetch covers --overwrite:
+// no etag needed, so the extra detail fetch must not happen at all — a
+// request to the detail route here would fail the test via the switch's
+// default case.
+func TestRunTrailUpdateWithClient_OverwriteFlagSkipsEtagFetch(t *testing.T) {
+	t.Parallel()
+
+	var gotOverwrite bool
+	var gotIfMatch string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == trailTestBasePath:
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{
+				Trails: []api.TrailResource{{ID: "trl_1", Number: 7, Branch: "feature/x", Status: string(trail.StatusOpen)}},
+				Total:  1,
+			}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
+		case r.Method == http.MethodPut && r.URL.Path == trailTestBasePath+"/7/body":
+			gotIfMatch = r.Header.Get("If-Match")
+			var got map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode body request: %v", err)
+				return
+			}
+			gotOverwrite = boolFieldOrFalse(got, "overwrite")
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(api.TrailBodyDocument{TextSnapshot: "new body"}); err != nil {
+				t.Errorf("encode body response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request (etag fetch must be skipped under --overwrite): %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	err := runTrailUpdateWithClient(t.Context(), io.Discard, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+		Branch:      "feature/x",
+		Body:        "new body",
+		BodyChanged: true,
+		Overwrite:   true,
+	})
+
+	require.NoError(t, err)
+	require.True(t, gotOverwrite)
+	require.Empty(t, gotIfMatch)
+}
+
 func TestTrailUpdateCmdHasCollaborationFlags(t *testing.T) {
 	t.Parallel()
 	cmd := newTrailUpdateCmd()
-	for _, name := range []string{"add-assignee", "remove-assignee", "add-reviewer", "remove-reviewer", "type", "priority"} {
+	for _, name := range []string{"add-assignee", "remove-assignee", "add-reviewer", "remove-reviewer", "type", "priority", "overwrite"} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("trail update missing --%s flag", name)
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1107
<!-- entire-trail-link-end -->

## Summary

Implements ENT-1741: `entire trail update --body` now reads the description's ETag and sends it as `If-Match`, so a body write is rejected (412) rather than silently clobbering a description that changed since it was read, instead of always sending `Overwrite: true` unconditionally.

- `TrailBodyDocument.ETag` decodes the new `bodyDocument.etag` field on a trail read.
- `sendTrailBody` dispatches between three modes: `--overwrite` (unconditional, explicit), an available etag (`If-Match`, no `Overwrite`), or neither (graceful fallback to `Overwrite: true` — covers a server predating the etag field, a trail with no body document yet, or a failed best-effort etag read).
- New `--overwrite` bool flag on `trail update`, named for what it destroys per the ticket ("`--overwrite`, not `--force`").
- 412 → "changed since read, re-run or pass --overwrite"; 409 → "not empty, pass --overwrite". Neither auto-retries with overwrite.
- The interactive form path gets its etag for free from the existing detail read; the non-interactive `--body` path does one extra best-effort GET purely for the etag (skipped entirely under `--overwrite`), and now warns on stderr if that read fails rather than silently downgrading the conflict check.

## Live-server verification

Confirmed against a real trail on `gh/entireio/cli` (not just test fixtures) that `bodyDocument.etag` is a real, populated field: trail 1076 returned `etag = W/"2026-08-18T23:29:25.468469Z"`; trail 1075 returned an empty etag alongside an empty snapshot, exercising the graceful-degradation path. The entire-api schema also lists `etag` as required on `TrailBodyDocumentJSON`.

## Known tradeoff (by design, not a bug)

The non-interactive `--body` path fetches an etag purely to attempt CAS, even though the caller supplied replacement text without having read the current document — this etag doesn't protect against a race the caller could have avoided by reading first, only against one that happens to occur in the fetch-to-write window. This is the ticket's explicit design (Linear ENT-1741), not something this PR reconsiders; flagging it here since a reviewer raised it independently.

That fetch-to-write window is also the only one closable today: `trail show --json` emits no etag field, so a read-modify-write caller (read the description, compose an edit, write back later) has no way to pass back what they read — there is no `--if-match` escape hatch. Widening CAS to cover that case (etag on `trail show --json`, an `--if-match` flag) is out of scope for ENT-1741; filed as a follow-up finding on the trail so it isn't lost.

## Out of scope (per ticket)

`--body-file`/stdin, other `trail` subcommands, presence/live-session detection.

## Review process

Ran `slop-reviewer` + 4 `/pr-review-toolkit:review-pr` dimensions (code, tests, silent-failures, comments) in parallel before opening this PR. Slop rating: **small**. Fixed all accepted findings in a second commit: a stale doc comment overclaiming write-etag-chaining, a silently-swallowed refetch failure (now warns), a guard that could mis-pair an etag with unseen content in a corner of the interactive path, plus two added tests and a switch-statement simplification.

## Test plan

- [x] `mise run fmt && mise run lint` clean
- [x] `go test -race -run Trail ./cmd/entire/cli/...` — all pass
- [x] `mise run test:ci` (unit + integration + e2e canary) — pass (one flaky failure in an unrelated pre-existing test, `TestHooksGitCmd_DiscoverExternalAgents_WhenEnabled`-class cross-test pollution in the large parallel `cmd/entire/cli` package; reproduced 3 different unrelated failures across repeated full-package runs, confirmed unrelated to this diff by 2 clean reruns)
- [x] New tests cover all 3 dispatch modes, both error mappings, the etag-fetch-only-when-needed logic, `--overwrite` skipping the fetch, and the refetch-failure warning path

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how trail descriptions are written (conflict detection vs silent overwrite) and adds backward-compatible fallback paths; scope is limited to the trail CLI body PUT path with broad test coverage.
> 
> **Overview**
> **Trail description writes** no longer always send `Overwrite: true`. The CLI decodes **`bodyDocument.etag`** on trail reads and threads it through **`fetchTrailDescription`** / **`resolveTrailUpdateBody`** so **`sendTrailBody`** can send **`If-Match`** when an etag is available and **`--overwrite`** is not set.
> 
> **`entire trail update`** gains **`--overwrite`** for unconditional replacement. Non-interactive **`--body`** does a best-effort detail GET for the etag (skipped under **`--overwrite`**); if that fetch fails, stderr warns and the write still proceeds via the **`Overwrite`** fallback. **412** and **409** responses get actionable hints (re-run / **`--overwrite`**). Interactive update seeds the form from the existing detail read, so it gets the etag without an extra fetch.
> 
> Tests cover dispatch modes, error mapping, etag threading, and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc4af34ddb446a855ba8a719867ad8960be5dd1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
