### PR TITLE
fix(checkpoint): name the sync remote in the multi-remote note

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -176,6 +176,139 @@ func fetchURLAuthoritative(ctx context.Context, opts ...FetchURLOptions) (string
 	return checkpointURL, true, nil
 }
 
+// PushDecision is the state CheckpointPushURL decides from: everything about
+// this repository's remotes and settings that the answer depends on, gathered by
+// the caller.
+//
+// It exists so a caller with several questions to ask — "is the store in effect
+// for each of these remotes?" — can read git once and answer them all from that
+// one read. Asking through PushURL instead re-reads the same two git values per
+// remote, and two reads of the same fact can disagree when a subprocess fails in
+// one call and succeeds in the next.
+type PushDecision struct {
+	// Remote is the remote being pushed to. Used for the fallback URL and for
+	// log context; never for a config lookup.
+	Remote string
+	// Config is the configured checkpoint_remote. Must be non-nil: "no store
+	// configured" is not a decision this makes.
+	Config *settings.CheckpointRemoteConfig
+	// OriginURL is origin's fetch URL, empty when the repo has no origin.
+	OriginURL string
+	// RemoteFetchURL is Remote's own fetch URL, used for the fallback when
+	// there is no origin to fall back to. May be empty.
+	RemoteFetchURL string
+	// PushURLs is every URL a push to Remote delivers to, in git's order. Must
+	// be non-empty; the first drives transport derivation.
+	PushURLs []string
+	// StoreIsLocalOnly reports that checkpoint_remote came from
+	// .entire/settings.local.json, which makes it this developer's own choice
+	// and exempt from the ownership test. Passed in rather than read here so
+	// that a caller deciding for several remotes gets one answer for all of
+	// them: the read behind it returns false on failure, so re-reading per
+	// remote can flip the ownership verdict mid-command.
+	StoreIsLocalOnly bool
+}
+
+// CheckpointPushURL decides the effective checkpoint push URL from already-read
+// state. The boolean reports whether the configured checkpoint_remote is in
+// effect; when false, the returned URL is the fallback the caller should push to
+// instead.
+//
+// PushURL is the same decision with the reads attached; see it for the rules.
+func CheckpointPushURL(ctx context.Context, in PushDecision) (string, bool, error) {
+	pushRemoteURL := in.PushURLs[0]
+
+	// Whether to use the checkpoint remote at all is a question about ownership
+	// ("is this checkpoint_remote mine, or did I inherit it by cloning?"), which
+	// both remotes get a vote on: origin says which project this is, the push
+	// destinations say which repos we are writing to. Any one of them owned by
+	// somebody other than the checkpoint repo's owner means inherited. See
+	// checkpointRemoteIsInherited.
+	if inherited, reason := checkpointRemoteIsInherited(in.Config, in.OriginURL, in.PushURLs, in.StoreIsLocalOnly); inherited {
+		fallbackURL, fallbackErr := in.fallbackURL()
+		if fallbackErr != nil {
+			return "", false, fmt.Errorf("no push URL found: %w", fallbackErr)
+		}
+		logging.Warn(ctx, "checkpoint-remote: ignoring checkpoint_remote that appears to belong to another owner; pushing checkpoints to the push remote instead",
+			slog.String("checkpoint_repo", in.Config.Repo),
+			slog.String("reason", reason),
+			slog.String("hint", "if this checkpoint repo is yours, configure checkpoint_remote in .entire/settings.local.json"),
+		)
+		return fallbackURL, false, nil
+	}
+
+	pushInfo, err := ParseURL(pushRemoteURL)
+	if err != nil {
+		if in.OriginURL != "" {
+			logFallback(ctx, "push", in.OriginURL, "parse push remote URL", err,
+				slog.String("push_remote", in.Remote),
+			)
+			return in.OriginURL, false, nil
+		}
+		return "", true, fmt.Errorf("no push URL found: %w", err)
+	}
+	withToken := strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != ""
+	if withToken && isDirectGitTransport(pushInfo.Protocol) {
+		// Coerce a direct (ssh/https) remote to HTTPS so the token applies,
+		// keeping the host so enterprise installations stay on their own host.
+		// An entire:// remote carries a cluster host that isn't a usable HTTPS
+		// host, so it's handled separately after the owner check below.
+		//
+		// Keep the port only when the source was already HTTPS. SSH ports
+		// (e.g., :2222) don't map to HTTPS ports on the same host.
+		port := ""
+		if pushInfo.Protocol == ProtocolHTTPS {
+			port = pushInfo.Port
+		}
+		pushInfo = &Info{
+			Protocol: ProtocolHTTPS,
+			Host:     pushInfo.Host,
+			Port:     port,
+			Owner:    pushInfo.Owner,
+			Repo:     pushInfo.Repo,
+		}
+	}
+
+	if withToken && pushInfo.Protocol == ProtocolEntire {
+		// The checkpoint token is an HTTPS credential for the provider host;
+		// it can't ride through the entire:// helper (which does its own
+		// auth). Route to the provider over HTTPS instead of the mirror.
+		if providerURL, ok := resolveProviderCheckpointURL(ctx, in.Config, ""); ok {
+			return providerURL, true, nil
+		}
+	}
+
+	pushURL, err := deriveCheckpointURLFromInfo(pushInfo, in.Config)
+	if err != nil {
+		// The push remote's protocol can't be mapped to a checkpoint URL
+		// (e.g. file://, or an entire:// mirror of a different forge than the
+		// configured provider). Honor the configured checkpoint_remote by
+		// targeting the provider's canonical host over HTTPS rather than
+		// misrouting checkpoints to the origin remote.
+		if providerURL, ok := resolveProviderCheckpointURL(ctx, in.Config, ""); ok {
+			return providerURL, true, nil
+		}
+		fallbackURL, fallbackErr := in.fallbackURL()
+		if fallbackErr == nil {
+			logFallback(ctx, "push", fallbackURL, "derive push checkpoint URL", err,
+				slog.String("push_remote", in.Remote),
+			)
+			return fallbackURL, false, nil
+		}
+		return "", true, fmt.Errorf("no push URL found: %w", err)
+	}
+
+	return pushURL, true, nil
+}
+
+// fallbackURL is where checkpoints go when the configured store does not apply:
+// origin, or this remote's own fetch URL when there is no origin. Mirrors
+// resolvePushFallbackURL without its git read, since the caller already has both
+// URLs.
+func (in PushDecision) fallbackURL() (string, error) {
+	return pushFallbackURL(in.Remote, in.OriginURL, in.RemoteFetchURL)
+}
+
 // PushURL returns the effective checkpoint push URL for the current repository.
 // Unlike FetchURL:
 //   - it derives protocol from the requested push remote, not always origin
@@ -191,6 +324,11 @@ func fetchURLAuthoritative(ctx context.Context, opts ...FetchURLOptions) (string
 // The boolean return value reports whether a dedicated checkpoint_remote is
 // configured and should be used for push. When false, the returned URL is the
 // repository's origin URL as a fallback.
+//
+// This is the read-it-yourself entry point, for callers with one remote to ask
+// about — the pre-push hook, which must see current state. Callers asking about
+// several remotes should read a gitremote.Snapshot once and call
+// CheckpointPushURL, so their answers cannot disagree with each other.
 func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 	originURL := ""
 	if resolvedOriginURL, err := GetRemoteURL(ctx, originRemote); err == nil {
@@ -233,89 +371,24 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 		}
 		return "", true, fmt.Errorf("no push URL found: %w", err)
 	}
-	pushRemoteURL := pushRemoteURLs[0]
 
-	// Whether to use the checkpoint remote at all is a question about ownership
-	// ("is this checkpoint_remote mine, or did I inherit it by cloning?"), which
-	// both remotes get a vote on: origin says which project this is, the push
-	// destinations say which repos we are writing to. Any one of them owned by
-	// somebody other than the checkpoint repo's owner means inherited. See
-	// checkpointRemoteIsInherited.
-	if inherited, reason := checkpointRemoteIsInherited(ctx, config, originURL, pushRemoteURLs); inherited {
-		fallbackURL, fallbackErr := resolvePushFallbackURL(ctx, pushRemoteName, originURL)
-		if fallbackErr != nil {
-			return "", false, fmt.Errorf("no push URL found: %w", fallbackErr)
-		}
-		logging.Warn(ctx, "checkpoint-remote: ignoring checkpoint_remote that appears to belong to another owner; pushing checkpoints to the push remote instead",
-			slog.String("checkpoint_repo", config.Repo),
-			slog.String("reason", reason),
-			slog.String("hint", "if this checkpoint repo is yours, configure checkpoint_remote in .entire/settings.local.json"),
-		)
-		return fallbackURL, false, nil
-	}
-
-	pushInfo, err := ParseURL(pushRemoteURL)
-	if err != nil {
-		if originURL != "" {
-			logFallback(ctx, "push", originURL, "parse push remote URL", err,
-				slog.String("push_remote", pushRemoteName),
-			)
-			return originURL, false, nil
-		}
-		return "", true, fmt.Errorf("no push URL found: %w", err)
-	}
-	withToken := strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != ""
-	if withToken && isDirectGitTransport(pushInfo.Protocol) {
-		// Coerce a direct (ssh/https) remote to HTTPS so the token applies,
-		// keeping the host so enterprise installations stay on their own host.
-		// An entire:// remote carries a cluster host that isn't a usable HTTPS
-		// host, so it's handled separately after the owner check below.
-		//
-		// Keep the port only when the source was already HTTPS. SSH ports
-		// (e.g., :2222) don't map to HTTPS ports on the same host.
-		port := ""
-		if pushInfo.Protocol == ProtocolHTTPS {
-			port = pushInfo.Port
-		}
-		pushInfo = &Info{
-			Protocol: ProtocolHTTPS,
-			Host:     pushInfo.Host,
-			Port:     port,
-			Owner:    pushInfo.Owner,
-			Repo:     pushInfo.Repo,
+	// Read only when the fallback would need it — there is no origin to fall
+	// back to — so the ordinary repo pays for two git reads, as before.
+	remoteFetchURL := ""
+	if originURL == "" && pushRemoteName != "" && pushRemoteName != originRemote {
+		if u, urlErr := GetRemoteURL(ctx, pushRemoteName); urlErr == nil {
+			remoteFetchURL = u
 		}
 	}
 
-	if withToken && pushInfo.Protocol == ProtocolEntire {
-		// The checkpoint token is an HTTPS credential for the provider host;
-		// it can't ride through the entire:// helper (which does its own
-		// auth). Route to the provider over HTTPS instead of the mirror.
-		if providerURL, ok := resolveProviderCheckpointURL(ctx, config, ""); ok {
-			return providerURL, true, nil
-		}
-	}
-
-	pushURL, err := deriveCheckpointURLFromInfo(pushInfo, config)
-	if err != nil {
-		// The push remote's protocol can't be mapped to a checkpoint URL
-		// (e.g. file://, or an entire:// mirror of a different forge than the
-		// configured provider). Honor the configured checkpoint_remote by
-		// targeting the provider's canonical host over HTTPS rather than
-		// misrouting checkpoints to the origin remote.
-		if providerURL, ok := resolveProviderCheckpointURL(ctx, config, ""); ok {
-			return providerURL, true, nil
-		}
-		fallbackURL, fallbackErr := resolvePushFallbackURL(ctx, pushRemoteName, originURL)
-		if fallbackErr == nil {
-			logFallback(ctx, "push", fallbackURL, "derive push checkpoint URL", err,
-				slog.String("push_remote", pushRemoteName),
-			)
-			return fallbackURL, false, nil
-		}
-		return "", true, fmt.Errorf("no push URL found: %w", err)
-	}
-
-	return pushURL, true, nil
+	return CheckpointPushURL(ctx, PushDecision{
+		Remote:           pushRemoteName,
+		Config:           config,
+		OriginURL:        originURL,
+		RemoteFetchURL:   remoteFetchURL,
+		PushURLs:         pushRemoteURLs,
+		StoreIsLocalOnly: settings.CheckpointRemoteIsLocalOnly(ctx),
+	})
 }
 
 // Configured reports whether a structured checkpoint_remote is configured.
@@ -402,14 +475,14 @@ func GetPushURLs(ctx context.Context, remoteName string) ([]string, error) {
 // setting we cannot confirm ownership, and falling back preserves the previous
 // behavior for those repos. settings.local.json is the escape hatch when the
 // checkpoint repo is genuinely ours but owned by a different account or org.
-func checkpointRemoteIsInherited(ctx context.Context, config *settings.CheckpointRemoteConfig, originURL string, pushRemoteURLs []string) (bool, string) {
+func checkpointRemoteIsInherited(config *settings.CheckpointRemoteConfig, originURL string, pushRemoteURLs []string, storeIsLocalOnly bool) (bool, string) {
 	checkpointOwner := config.Owner()
 	if checkpointOwner == "" {
 		// No owner to compare (malformed repo field). Matches the predecessor,
 		// which skipped the check rather than blocking on it.
 		return false, ""
 	}
-	if settings.CheckpointRemoteIsLocalOnly(ctx) {
+	if storeIsLocalOnly {
 		return false, ""
 	}
 
@@ -651,6 +724,41 @@ func logFallback(ctx context.Context, operation, fallbackURL, reason string, err
 	logging.Warn(ctx, "checkpoint remote URL resolution fell back to alternate remote URL", logAttrs...)
 }
 
+// pushFallbackURL is the fallback destination, decided from URLs the caller
+// already has. resolvePushFallbackURL is the same rule with the git read for
+// remoteFetchURL attached.
+func pushFallbackURL(pushRemoteName, originURL, remoteFetchURL string) (string, error) {
+	if originURL != "" {
+		if withCheckpointToken() {
+			if tokenURL, ok := deriveTokenOriginURL(originURL); ok {
+				return tokenURL, nil
+			}
+		}
+		return originURL, nil
+	}
+	if pushRemoteName == "" {
+		return "", fmt.Errorf("no push remote specified and remote %q not found", originRemote)
+	}
+	if pushRemoteName == originRemote {
+		return "", fmt.Errorf("remote %q not found", originRemote)
+	}
+	if remoteFetchURL == "" {
+		return "", fmt.Errorf("remote %q not found", pushRemoteName)
+	}
+	if withCheckpointToken() {
+		if tokenURL, ok := deriveTokenOriginURL(remoteFetchURL); ok {
+			return tokenURL, nil
+		}
+	}
+	return remoteFetchURL, nil
+}
+
+// withCheckpointToken reports whether ENTIRE_CHECKPOINT_TOKEN is set, which
+// forces HTTPS so the token can be used.
+func withCheckpointToken() bool {
+	return strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != ""
+}
+
 func resolvePushFallbackURL(ctx context.Context, pushRemoteName, originURL string) (string, error) {
 	if originURL != "" {
 		if strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != "" {
@@ -670,10 +778,5 @@ func resolvePushFallbackURL(ctx context.Context, pushRemoteName, originURL strin
 	if err != nil {
 		return "", err
 	}
-	if strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != "" {
-		if tokenURL, ok := deriveTokenOriginURL(pushURL); ok {
-			return tokenURL, nil
-		}
-	}
-	return pushURL, nil
+	return pushFallbackURL(pushRemoteName, originURL, pushURL)
 }

--- a/cmd/entire/cli/checkpoint_tokens.go
+++ b/cmd/entire/cli/checkpoint_tokens.go
@@ -428,7 +428,7 @@ func buildCheckpointTokensComparison(target, baseline checkpointTokensReport) *c
 	comparison.Status = checkpointComparisonStatus(comparison.Total)
 	comparison.Qualification = checkpointComparisonQualification(comparison.Status)
 	if classes := checkpointCostProxyPressureIncreased(comparison); len(classes) > 0 {
-		comparison.Qualification += fmt.Sprintf(" Cost-proxy pressure increased for %s even though total tokens decreased.", formatProseList(classes))
+		comparison.Qualification += fmt.Sprintf(" Cost-proxy pressure increased for %s even though total tokens decreased.", formatTokenClassList(classes))
 	}
 	return comparison
 }
@@ -447,19 +447,16 @@ func checkpointCostProxyPressureIncreased(comparison *checkpointTokensComparison
 	return classes
 }
 
-// formatProseList joins items for prose: "a", "a and b", "a, b, and c". Shared
-// with the checkpoint-destination note's remote lists (quoteNames), so the two
-// commands punctuate lists the same way.
-func formatProseList(items []string) string {
-	switch len(items) {
+func formatTokenClassList(classes []string) string {
+	switch len(classes) {
 	case 0:
 		return ""
 	case 1:
-		return items[0]
+		return classes[0]
 	case 2:
-		return items[0] + " and " + items[1]
+		return classes[0] + " and " + classes[1]
 	default:
-		return strings.Join(items[:len(items)-1], ", ") + ", and " + items[len(items)-1]
+		return strings.Join(classes[:len(classes)-1], ", ") + ", and " + classes[len(classes)-1]
 	}
 }
 

--- a/cmd/entire/cli/checkpoint_tokens.go
+++ b/cmd/entire/cli/checkpoint_tokens.go
@@ -428,7 +428,7 @@ func buildCheckpointTokensComparison(target, baseline checkpointTokensReport) *c
 	comparison.Status = checkpointComparisonStatus(comparison.Total)
 	comparison.Qualification = checkpointComparisonQualification(comparison.Status)
 	if classes := checkpointCostProxyPressureIncreased(comparison); len(classes) > 0 {
-		comparison.Qualification += fmt.Sprintf(" Cost-proxy pressure increased for %s even though total tokens decreased.", formatTokenClassList(classes))
+		comparison.Qualification += fmt.Sprintf(" Cost-proxy pressure increased for %s even though total tokens decreased.", formatProseList(classes))
 	}
 	return comparison
 }
@@ -447,16 +447,19 @@ func checkpointCostProxyPressureIncreased(comparison *checkpointTokensComparison
 	return classes
 }
 
-func formatTokenClassList(classes []string) string {
-	switch len(classes) {
+// formatProseList joins items for prose: "a", "a and b", "a, b, and c". Shared
+// with the checkpoint-destination note's remote lists (quoteNames), so the two
+// commands punctuate lists the same way.
+func formatProseList(items []string) string {
+	switch len(items) {
 	case 0:
 		return ""
 	case 1:
-		return classes[0]
+		return items[0]
 	case 2:
-		return classes[0] + " and " + classes[1]
+		return items[0] + " and " + items[1]
 	default:
-		return strings.Join(classes[:len(classes)-1], ", ") + ", and " + classes[len(classes)-1]
+		return strings.Join(items[:len(items)-1], ", ") + ", and " + items[len(items)-1]
 	}
 }
 

--- a/cmd/entire/cli/gitremote/snapshot.go
+++ b/cmd/entire/cli/gitremote/snapshot.go
@@ -1,0 +1,129 @@
+package gitremote
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// RemoteURLs is where one remote fetches from and pushes to.
+//
+// Fetch is remote.<name>.url (the first, when several are configured) — the same
+// value GetRemoteURL reports. Push is every destination a push delivers to, in
+// git's order — the same set GetPushURLs reports. Either may be empty: a remote
+// configured with only a pushurl has no fetch URL, and `git remote -v` prints an
+// empty field for it.
+type RemoteURLs struct {
+	Fetch string
+	Push  []string
+}
+
+// Snapshot is every remote in a repository and its URLs, read in one pass.
+//
+// It exists because the URLs of one remote are needed to answer questions about
+// another — the checkpoint-remote ownership test compares a remote's push URLs
+// against origin's — so asking git per remote means asking the same questions
+// several times per command, and getting answers that can disagree when a
+// subprocess fails in one call and succeeds in the next. One `git remote -v`
+// carries everything those per-remote reads were fetching, so callers that need
+// more than one answer should take a Snapshot and derive the rest from it.
+//
+// A Snapshot is a point-in-time read. That is the point: every claim derived
+// from it describes the same moment. Code that must act on current state (the
+// pre-push hook deciding where this push goes) should read live instead.
+type Snapshot struct {
+	// order is remote names, sorted, so callers render them deterministically.
+	order []string
+	urls  map[string]RemoteURLs
+}
+
+// LoadSnapshot reads every remote and its URLs from dir with one `git remote -v`.
+//
+// `git remote -v` is used rather than a `git remote get-url` per remote because
+// it already applies git's pushurl-replaces-url rule and lists every push URL in
+// order, so N+1 subprocesses collapse to one. It also applies url.<base>.insteadOf
+// rewrites exactly as `git remote get-url` does (verified against git 2.55), so
+// the values here are the values those calls would return.
+//
+// An empty dir runs in the process working directory. A repository with no
+// remotes is a successful empty Snapshot, not an error — callers distinguish
+// "no remotes" from "could not read" by the error.
+func LoadSnapshot(ctx context.Context, dir string) (Snapshot, error) {
+	cmd := exec.CommandContext(ctx, "git", "remote", "-v")
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("list git remotes: %w", err)
+	}
+	return parseRemoteVerbose(string(out)), nil
+}
+
+// parseRemoteVerbose turns `git remote -v` output into a Snapshot.
+//
+// Each line is "<name>\t<url> (fetch)" or "<name>\t<url> (push)". A remote with
+// no fetch URL still gets a line, with an empty URL field.
+func parseRemoteVerbose(out string) Snapshot {
+	urls := make(map[string]RemoteURLs)
+	for line := range strings.SplitSeq(out, "\n") {
+		name, rest, found := strings.Cut(strings.TrimRight(line, "\r"), "\t")
+		if !found {
+			continue
+		}
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		entry := urls[name]
+		switch {
+		case strings.HasSuffix(rest, "(push)"):
+			if url := strings.TrimSpace(strings.TrimSuffix(rest, "(push)")); url != "" {
+				entry.Push = append(entry.Push, url)
+			}
+		case strings.HasSuffix(rest, "(fetch)"):
+			// First wins: git prints one fetch line per remote, but a
+			// malformed read must not silently prefer a later value.
+			if entry.Fetch == "" {
+				entry.Fetch = strings.TrimSpace(strings.TrimSuffix(rest, "(fetch)"))
+			}
+		default:
+			// Not a URL line; the remote itself is still known to exist.
+		}
+		urls[name] = entry
+	}
+
+	order := make([]string, 0, len(urls))
+	for name := range urls {
+		order = append(order, name)
+	}
+	sort.Strings(order)
+	return Snapshot{order: order, urls: urls}
+}
+
+// Names lists the configured remotes in sorted order.
+func (s Snapshot) Names() []string { return s.order }
+
+// Get returns a remote's URLs. The second result reports whether the remote is
+// configured at all, which an empty RemoteURLs cannot express — a remote with
+// only a pushurl has no fetch URL, and one whose url is empty has neither.
+func (s Snapshot) Get(name string) (RemoteURLs, bool) {
+	u, ok := s.urls[name]
+	return u, ok
+}
+
+// OriginURL is origin's fetch URL, or empty when there is no origin. It is
+// singled out because the checkpoint-remote ownership test asks "which project
+// is this?" of origin specifically, whatever remote is being pushed.
+func (s Snapshot) OriginURL() string {
+	u, ok := s.urls[originRemote]
+	if !ok {
+		return ""
+	}
+	return u.Fetch
+}
+
+// originRemote is the conventional name for the remote identifying the project.
+const originRemote = "origin"

--- a/cmd/entire/cli/gitremote/snapshot.go
+++ b/cmd/entire/cli/gitremote/snapshot.go
@@ -84,8 +84,9 @@ func parseRemoteVerbose(out string) Snapshot {
 				entry.Push = append(entry.Push, url)
 			}
 		case strings.HasSuffix(rest, "(fetch)"):
-			// First wins: git prints one fetch line per remote, but a
-			// malformed read must not silently prefer a later value.
+			// First wins: a multi-url remote gets one fetch line per
+			// configured url, and the first is the one GetRemoteURL reports,
+			// so a later line must not silently replace it.
 			if entry.Fetch == "" {
 				entry.Fetch = strings.TrimSpace(strings.TrimSuffix(rest, "(fetch)"))
 			}

--- a/cmd/entire/cli/gitremote/snapshot_test.go
+++ b/cmd/entire/cli/gitremote/snapshot_test.go
@@ -1,0 +1,158 @@
+package gitremote
+
+import (
+	"context"
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestParseRemoteVerbose(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		out   string
+		names []string
+		want  map[string]RemoteURLs
+	}{
+		{
+			name:  "fetch and push of one remote",
+			out:   "origin\thttps://example.com/a.git (fetch)\norigin\thttps://example.com/a.git (push)\n",
+			names: []string{"origin"},
+			want:  map[string]RemoteURLs{"origin": {Fetch: "https://example.com/a.git", Push: []string{"https://example.com/a.git"}}},
+		},
+		{
+			// Several push URLs keep git's order: the first is where the
+			// git-refs backend sends checkpoints, so order is load-bearing.
+			name: "several push URLs keep their order",
+			out: "two\thttps://example.com/a.git (fetch)\n" +
+				"two\thttps://example.com/a.git (push)\n" +
+				"two\thttps://example.com/b.git (push)\n",
+			names: []string{"two"},
+			want: map[string]RemoteURLs{"two": {
+				Fetch: "https://example.com/a.git",
+				Push:  []string{"https://example.com/a.git", "https://example.com/b.git"},
+			}},
+		},
+		{
+			// A remote configured with only a pushurl: git prints an empty
+			// fetch field for it.
+			name:  "remote with no fetch URL",
+			out:   "pushonly\t\npushonly\thttps://example.com/p.git (push)\n",
+			names: []string{"pushonly"},
+			want:  map[string]RemoteURLs{"pushonly": {Push: []string{"https://example.com/p.git"}}},
+		},
+		{
+			name:  "no remotes",
+			out:   "",
+			names: nil,
+			want:  map[string]RemoteURLs{},
+		},
+		{
+			name: "remotes are sorted, not in git's listing order",
+			out: "zeta\thttps://example.com/z.git (fetch)\nzeta\thttps://example.com/z.git (push)\n" +
+				"alpha\thttps://example.com/a.git (fetch)\nalpha\thttps://example.com/a.git (push)\n",
+			names: []string{"alpha", "zeta"},
+			want: map[string]RemoteURLs{
+				"alpha": {Fetch: "https://example.com/a.git", Push: []string{"https://example.com/a.git"}},
+				"zeta":  {Fetch: "https://example.com/z.git", Push: []string{"https://example.com/z.git"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			snap := parseRemoteVerbose(tt.out)
+			if !slices.Equal(snap.Names(), tt.names) {
+				t.Errorf("Names() = %v, want %v", snap.Names(), tt.names)
+			}
+			for name, want := range tt.want {
+				got, ok := snap.Get(name)
+				if !ok {
+					t.Errorf("Get(%q) reported the remote as absent", name)
+					continue
+				}
+				if got.Fetch != want.Fetch {
+					t.Errorf("Get(%q).Fetch = %q, want %q", name, got.Fetch, want.Fetch)
+				}
+				if !slices.Equal(got.Push, want.Push) {
+					t.Errorf("Get(%q).Push = %v, want %v", name, got.Push, want.Push)
+				}
+			}
+			if _, ok := snap.Get("absent"); ok {
+				t.Error("Get() reported an unconfigured remote as present")
+			}
+		})
+	}
+}
+
+// TestSnapshotMatchesGetURL pins the equivalence the Snapshot rests on: the
+// values it reads from one `git remote -v` are the values GetRemoteURL and
+// GetPushURLs would return per remote. Everything derived from a Snapshot
+// instead of those calls is only correct while this holds.
+//
+// insteadOf is the case most likely to break it — a rewrite that one command
+// applies and the other does not would silently change which repository a
+// checkpoint URL is derived from. Not parallel: chdir, because GetPushURLs has
+// no dir-aware variant.
+func TestSnapshotMatchesGetURL(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	run("init", "-q")
+	// A fetch rewrite (applied by both commands) and a push rewrite (applied by
+	// neither at report time) — both directions of the risk.
+	run("config", "url.https://github.com/.insteadOf", "gh:")
+	run("config", "url.ssh://git@github.com/.pushInsteadOf", "https://github.com/")
+	run("remote", "add", "origin", "gh:me/app.git")
+	run("remote", "add", "two", "https://github.com/me/two.git")
+	run("remote", "set-url", "--add", "--push", "two", "https://github.com/me/two.git")
+	run("remote", "set-url", "--add", "--push", "two", "https://github.com/me/two-mirror.git")
+
+	snap, err := LoadSnapshot(ctx, dir)
+	if err != nil {
+		t.Fatalf("LoadSnapshot() error = %v", err)
+	}
+
+	for _, name := range []string{"origin", "two"} {
+		got, ok := snap.Get(name)
+		if !ok {
+			t.Fatalf("Snapshot is missing remote %q", name)
+		}
+		wantFetch, err := GetRemoteURL(ctx, name)
+		if err != nil {
+			t.Fatalf("GetRemoteURL(%q) error = %v", name, err)
+		}
+		if got.Fetch != wantFetch {
+			t.Errorf("remote %q: snapshot fetch URL = %q, GetRemoteURL = %q", name, got.Fetch, wantFetch)
+		}
+		wantPush, err := GetPushURLs(ctx, name)
+		if err != nil {
+			t.Fatalf("GetPushURLs(%q) error = %v", name, err)
+		}
+		if !slices.Equal(got.Push, wantPush) {
+			t.Errorf("remote %q: snapshot push URLs = %v, GetPushURLs = %v", name, got.Push, wantPush)
+		}
+	}
+
+	// The rewrite really was in play, or this test proves nothing.
+	if origin, _ := snap.Get("origin"); !strings.HasPrefix(origin.Fetch, "https://github.com/") {
+		t.Errorf("insteadOf was not applied; fetch URL = %q, so the equivalence above went untested", origin.Fetch)
+	}
+	if snap.OriginURL() == "" {
+		t.Error("OriginURL() is empty for a repo that has an origin")
+	}
+}

--- a/cmd/entire/cli/integration_test/multi_pushurl_test.go
+++ b/cmd/entire/cli/integration_test/multi_pushurl_test.go
@@ -395,7 +395,7 @@ func TestMultiPushURL_DestinationNoteSurfaces(t *testing.T) {
 			want:  []string{"Checkpoint destination", "pushes to 2 URLs", "first URL only", "checkpoint_remote"},
 		},
 		{
-			// Two phrasings this note has already been wrong with, asserted
+			// Three phrasings this note has already been wrong with, asserted
 			// absent rather than merely asserting the current text: that
 			// checkpoints "follow whichever remote you push to" (they follow the
 			// election), that reading them back "always looks at origin" (a read

--- a/cmd/entire/cli/integration_test/multi_pushurl_test.go
+++ b/cmd/entire/cli/integration_test/multi_pushurl_test.go
@@ -395,16 +395,18 @@ func TestMultiPushURL_DestinationNoteSurfaces(t *testing.T) {
 			want:  []string{"Checkpoint destination", "pushes to 2 URLs", "first URL only", "checkpoint_remote"},
 		},
 		{
-			// The note used to say checkpoints "follow whichever remote you push
-			// to" — the opposite of the single-remote election, where a push to a
-			// non-elected remote carries no session history — and that reading
-			// them back "always looks at origin", which stopped being true when
-			// the read-candidate chain landed. Assert the false phrasings are
-			// gone, not merely that the correct text is present.
+			// Two phrasings this note has already been wrong with, asserted
+			// absent rather than merely asserting the current text: that
+			// checkpoints "follow whichever remote you push to" (they follow the
+			// election), that reading them back "always looks at origin" (a read
+			// chain replaced that), and that a push to any other remote carries
+			// "no session history" — untrue for the push that elects a remote by
+			// agreeing with the branch's declared destination, which carries the
+			// checkpoints with it.
 			name:   "several remotes",
 			setup:  func(env *TestEnv) { env.SetupNamedBareRemote("backup") },
-			want:   []string{"2 remotes", "single elected remote", "entire status"},
-			absent: []string{"follow whichever remote", "always looks at origin"},
+			want:   []string{"2 remotes", `right now "origin"`, "entire status", "checkpoint_push_remote"},
+			absent: []string{"follow whichever remote", "always looks at origin", "no session history"},
 		},
 	}
 

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"sort"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
-	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -80,41 +78,18 @@ func inspectRemoteTopology(ctx context.Context) remoteTopology {
 		return t
 	}
 
-	// One `git remote -v` rather than `git remote` plus a get-url per remote:
-	// it already applies git's pushurl-replaces-url rule and lists every push
-	// URL in order, so N+1 subprocesses collapse to one — and all of it runs in
-	// repoRoot instead of mixing dir-aware and cwd-dependent lookups.
-	pushURLs, err := pushURLsByRemote(ctx, repoRoot)
+	// One `git remote -v` for the whole function, and every claim below derived
+	// from it. Asking git per remote meant asking the same two questions N+1
+	// times per command and getting answers that could disagree with each other
+	// — the note naming a store while claiming no remote reached it.
+	snap, err := gitremote.LoadSnapshot(ctx, repoRoot)
 	if err != nil {
 		logging.Debug(ctx, "remote topology: could not read remotes", slog.String("error", err.Error()))
 		return t
 	}
 
-	names := make([]string, 0, len(pushURLs))
-	for name := range pushURLs {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
-		dest := remoteDestination{name: name, pushURLs: pushURLs[name]}
-		if _, enabled, err := remote.PushURL(ctx, name); err == nil {
-			dest.pinned = enabled
-		}
-		t.destinations = append(t.destinations, dest)
-	}
-
-	if cpCfg, err := settings.LoadCheckpointsConfig(ctx); err == nil {
-		t.primaryIsRefs = checkpoint.PrimaryIsRefs(cpCfg)
-	}
-
-	// Share the status computation rather than re-deriving the destination, for
-	// the same reason `pinned` asks the resolver: what is shown must be what
-	// pushes actually use. A local re-derivation here is what let this note
-	// name a remote while `entire status` named a dedicated store.
-	//
-	// A settings read failure degrades to a nil settings object — dedicated
-	// mode simply goes undetected — rather than becoming an Err, which the note
+	// A settings read failure degrades to a nil settings object — the store
+	// simply goes undetected — rather than becoming an Err, which the note
 	// renders as "Checkpoints are NOT syncing". A transient read failure is not
 	// that, and this note must never obstruct enable or doctor.
 	s, err := LoadEntireSettings(ctx)
@@ -123,33 +98,29 @@ func inspectRemoteTopology(ctx context.Context) remoteTopology {
 			slog.String("error", err.Error()))
 		s = nil
 	}
-	t.sync = resolveCheckpointSyncDestination(ctx, s)
+	probe := newCheckpointStoreProbe(ctx, s, snap)
+
+	for _, name := range snap.Names() {
+		urls, _ := snap.Get(name)
+		t.destinations = append(t.destinations, remoteDestination{
+			name:     name,
+			pushURLs: urls.Push,
+			pinned:   probe.inEffectFor(ctx, name),
+		})
+	}
+
+	if cpCfg, cfgErr := settings.LoadCheckpointsConfig(ctx); cfgErr == nil {
+		t.primaryIsRefs = checkpoint.PrimaryIsRefs(cpCfg)
+	}
+
+	// Share the status computation rather than re-deriving the destination: what
+	// is shown must be what pushes actually use. A local re-derivation here is
+	// what let this note name a remote while `entire status` named a dedicated
+	// store. The probe carries the same snapshot the loop above used, so the
+	// destination and every remote's pinned flag cannot disagree.
+	t.sync = resolveCheckpointSyncDestination(ctx, probe)
 
 	return t
-}
-
-// pushURLsByRemote parses `git remote -v` into remote name -> push URLs in git's
-// own order.
-func pushURLsByRemote(ctx context.Context, dir string) (map[string][]string, error) {
-	out, err := gitRunner(ctx, dir, "remote", "-v")
-	if err != nil {
-		return nil, fmt.Errorf("list git remotes: %w", err)
-	}
-	urls := make(map[string][]string)
-	for _, line := range strings.Split(out, "\n") {
-		// "<name>\t<url> (push)" — fetch lines are the same shape and ignored.
-		name, rest, found := strings.Cut(strings.TrimSpace(line), "\t")
-		if !found || !strings.HasSuffix(rest, "(push)") {
-			continue
-		}
-		url := strings.TrimSpace(strings.TrimSuffix(rest, "(push)"))
-		if url != "" {
-			urls[name] = append(urls[name], url)
-		}
-	}
-	// An empty map is a legitimate answer (a repo with no remotes), so it is
-	// returned as such rather than as an error the caller would have to classify.
-	return urls, nil
 }
 
 // ambiguous reports whether anything is worth telling the user: a remote whose
@@ -169,180 +140,237 @@ func (t remoteTopology) ambiguous() bool {
 
 // describeCheckpointDestination writes an explanation of where checkpoints go,
 // under the given header. Writes nothing when the destination is unambiguous.
+//
+// The body is composed before the header is written, and a body that came out
+// empty suppresses the header with it. Deciding the two separately is what
+// printed `Checkpoint destination: REVIEW` and nothing else: `ambiguous()` said
+// the repo needed explaining while every explaining branch was gated on
+// something narrower. Composing first makes the header a consequence of having
+// something to say rather than a second opinion about it.
 func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string) {
 	if !t.ambiguous() {
 		return
 	}
-
+	var body strings.Builder
+	t.writeDestinationBody(&body)
+	if body.Len() == 0 {
+		return
+	}
 	fmt.Fprintln(w, header)
+	fmt.Fprint(w, body.String())
+}
 
-	// Destination first: every claim below it is about how checkpoints reach
-	// that destination, and the URL breakdown read as the whole answer when it
-	// came first.
-	if names := t.unpinnedNames(); len(names) > 1 {
+// writeDestinationBody writes the explanation itself, destination first: every
+// claim after it is about how checkpoints reach that destination, and the URL
+// breakdown read as the whole answer when it came first.
+func (t remoteTopology) writeDestinationBody(b *strings.Builder) {
+	if len(t.unpinnedNames()) > 1 {
 		// Every remote, not just the unpinned ones. The count orients the
 		// reader in their own repo, and omitting a pinned remote let the note
 		// name a destination missing from its own list.
-		all := make([]string, 0, len(t.destinations))
-		for _, d := range t.destinations {
-			all = append(all, d.name)
-		}
-		fmt.Fprintf(w, "  This repo has %d remotes (%s).\n", len(all), strings.Join(all, ", "))
-		t.describeSyncRemote(w)
+		fmt.Fprintf(b, "  This repo has %d remotes (%s).\n", len(t.destinations), strings.Join(t.allNames(), ", "))
 	}
+	t.describeDestination(b)
+	t.describeIgnoredStore(b)
+	t.describeFanOut(b)
 
-	t.describeIgnoredStore(w)
-
-	for _, d := range t.destinations {
-		// Only the elected remote's URLs are a checkpoint destination. Another
-		// remote's pushes are gated out entirely (checkpointSyncAllowedForRemote),
-		// so "checkpoints go to the first URL only" would be false of it — as it
-		// is of every remote when the election failed or resolved to nothing.
-		if !d.fansOut() || t.dedicated() || d.name != t.sync.Remote {
-			continue
-		}
-		fmt.Fprintf(w, "  Remote %q pushes to %d URLs:\n", d.name, len(d.pushURLs))
-		for i, u := range d.pushURLs {
-			marker := "  "
-			if i == 0 && t.primaryIsRefs {
-				marker = "→ "
-			}
-			fmt.Fprintf(w, "    %s%s\n", marker, gitremote.RedactURLOrPath(u))
-		}
-		if t.primaryIsRefs {
-			fmt.Fprintln(w, "    Checkpoints go to the first URL only; the others receive your code but")
-			fmt.Fprintln(w, "    no session history. Clone that first repository to resume elsewhere.")
-		} else {
-			fmt.Fprintln(w, "    Checkpoints are pushed to every URL. If one rejects them or is")
-			fmt.Fprintln(w, "    unreachable it is reported and left behind, and only the fetch URL is")
-			fmt.Fprintln(w, "    ever reconciled — so those URLs can fall permanently out of date.")
-		}
-	}
-
-	// The advice is "configure a checkpoint_remote" — already done in both
+	// The advice is "configure a checkpoint_remote" — already taken in both
 	// states where one exists, and off-target when a fail-closed election means
-	// nothing is syncing at all.
-	if t.dedicated() || t.sync.IgnoredStore != "" || t.sync.Err != "" {
+	// nothing is syncing at all. It also never stands alone: on its own it would
+	// turn the note on for repos that have nothing else to report.
+	if b.Len() == 0 || t.sync.storeConfigured() || t.sync.Err != "" {
 		return
 	}
-	fmt.Fprintln(w, "  To pin one repository for checkpoints, set checkpoint_remote in")
-	fmt.Fprintln(w, "  .entire/settings.json (or .entire/settings.local.json to keep it to this clone).")
+	fmt.Fprintln(b, "  To pin one repository for checkpoints, set checkpoint_remote in")
+	fmt.Fprintln(b, "  .entire/settings.json (or .entire/settings.local.json to keep it to this clone).")
 }
 
-// dedicated reports that a checkpoint_remote store is the destination, so none
-// of this repo's remotes is where checkpoints land.
-func (t remoteTopology) dedicated() bool { return t.sync.dedicated() }
-
-// describeIgnoredStore reports a checkpoint_remote that is configured but not in
-// effect. Everywhere else this is a logging.Warn inside remote.PushURL, so the
-// setting is silently ignored and the fallback looks like an ordinary election.
+// describeDestination names where checkpoints land. Every branch here holds
+// whatever the repo's remote count is, which is why none of them sits behind the
+// several-remotes gate: a fail-closed election and a dedicated store are facts
+// about the configuration, and gating them on "more than one remote" is what
+// left a broken checkpoint_push_remote as the state that said least.
 //
-// The cause is stated as a likelihood, not a fact: PushURL returns a bare
-// enabled=false for the ownership rejection, an unparseable push URL and an
-// unmappable protocol alike, so the note cannot tell which applied.
-func (t remoteTopology) describeIgnoredStore(w io.Writer) {
-	if t.sync.IgnoredStore == "" {
-		return
+// Only the tier wording is genuinely about choosing among several remotes, so
+// only it stays gated.
+func (t remoteTopology) describeDestination(b *strings.Builder) {
+	switch {
+	case t.sync.Err != "":
+		// Same fact `entire status` reports as "Checkpoints NOT syncing": the
+		// pre-push gate is skipping checkpoint sync entirely until the setting
+		// is fixed. The one branch here that is a warning, not orientation.
+		fmt.Fprintf(b, "  Checkpoints are NOT syncing: %s\n", t.sync.Err)
+	case t.sync.dedicated():
+		t.describeDedicatedStore(b)
+	case t.sync.Remote == "":
+		// The election could not be read at all. Saying nothing would leave a
+		// multi-remote repo with a bare remote count and no hint that the
+		// destination is one remote rather than all of them, so fall back to
+		// the part that holds on every tier.
+		fmt.Fprintln(b, "  Checkpoints sync to a single elected remote; `entire status` shows which.")
+	default:
+		if len(t.unpinnedNames()) > 1 {
+			t.describeElectedTier(b)
+		}
 	}
-	fmt.Fprintf(w, "    A checkpoint_remote (%q) is configured but not in effect\n", t.sync.IgnoredStore)
-	fmt.Fprintln(w, "    here — most often because it looks like it belongs to another owner.")
-	fmt.Fprintf(w, "    Checkpoints go to %q instead; set it in .entire/settings.local.json\n", t.sync.Remote)
-	fmt.Fprintln(w, "    if the store is yours.")
 }
 
-// describeSyncRemote names the one remote that carries checkpoints. It stays
-// to three lines at most on purpose: capture already routes the fork topology
-// correctly and announces itself when it does, a gated push says so at the
-// time (strategy.hintGatedCheckpointSync), and `entire status` reports the
+// describeDedicatedStore explains a checkpoint_remote that is in effect: the
+// destination is a repository of its own, and the pushes that reach it are the
+// ones the store applies to.
+//
+// It drops the "no session history" clause the settled tiers carry: in this mode
+// checkpoints never ride a code push to a remote at all, so there is no "other
+// remote" for that sentence to be about. Naming the carriers matters instead —
+// a repo that never pushes one of them strands its transcripts, and nothing else
+// in this note would say so.
+func (t remoteTopology) describeDedicatedStore(b *strings.Builder) {
+	fmt.Fprintf(b, "  Checkpoints go to the dedicated store %q (set by\n", t.sync.Remote)
+	fmt.Fprintln(b, "  checkpoint_remote), not to any of these remotes.")
+	// The store is in effect because it resolved for the elected remote, and
+	// that resolution and this list come from one snapshot — so there is
+	// normally a name here. The exception is narrow enough to be worth a
+	// sentence rather than a claim: the resolution can still take a branch that
+	// opens the repository, and a failure there flips one answer and not the
+	// other. Saying no remote carries them would be the one false thing to say,
+	// since a push is reaching the store.
+	if carriers := t.pinnedNames(); len(carriers) > 0 {
+		fmt.Fprintf(b, "  Pushes to %s carry them there.\n", quoteNames(carriers))
+		return
+	}
+	fmt.Fprintln(b, "  `entire status` shows whether your pushes are reaching it.")
+}
+
+// describeElectedTier words which remote carries checkpoints and how firmly.
+// It stays to three lines at most on purpose: capture already routes the fork
+// topology correctly and announces itself when it does, a gated push says so at
+// the time (strategy.hintGatedCheckpointSync), and `entire status` reports the
 // destination on demand — so this is orientation at setup, not a warning about
 // something the user must go and fix.
 //
-// Naming today's remote alone would be a promise the next push can break,
-// hence the second clause on the tiers where the election is still open: a
-// push whose target agrees with the branch's declared push destination elects
-// that remote and carries the checkpoints with it, so "checkpoints go to
-// origin, full stop" is exactly what must not be said here.
+// Naming today's remote alone would be a promise the next push can break, hence
+// the second clause on the tiers where the election is still open: a push whose
+// target agrees with the branch's declared push destination elects that remote
+// and carries the checkpoints with it, so "checkpoints go to origin, full stop"
+// is exactly what must not be said here.
 //
-// The "no session history" line is the inverse promise, and belongs only to
-// the tiers where the election is settled: with checkpoint_push_remote set or
-// a capture already in force, captureEligible refuses every displacement, so
-// no push can move the destination and every push to another remote really
-// does leave the transcripts behind. On the open tiers the same sentence would
-// be false for the electing push itself.
-//
-// The exception to the orientation-not-warning rule is a failed election: that
-// is fail-closed, so checkpoints are going nowhere at all and the note has to
-// say so.
-//
-// A dedicated checkpoint_remote store is answered before the tier switch, and
-// deliberately drops the "no session history" clause the settled tiers carry:
-// in dedicated mode checkpoints never ride a code push to a remote at all, so
-// there is no "other remote" for that sentence to be about. It names the pinned
-// remotes instead, because those are the pushes that reach the store — a repo
-// where none of them is ever pushed strands its transcripts, and nothing else
-// in this note would say so.
-func (t remoteTopology) describeSyncRemote(w io.Writer) {
-	// A dedicated store is not a tier of the election — status.go synthesizes
-	// it — so it is answered before the switch, which stays typed on the
-	// resolver's enum so `exhaustive` keeps turning a new tier into a decision
-	// here.
-	if t.dedicated() {
-		fmt.Fprintf(w, "    Checkpoints go to the dedicated store %q (set by\n", t.sync.Remote)
-		fmt.Fprintf(w, "    checkpoint_remote), not to any of these remotes. Pushes to %s\n",
-			quoteNames(t.pinnedNames()))
-		fmt.Fprintln(w, "    carry them there.")
-		return
-	}
-	if t.sync.Remote == "" {
-		if t.sync.Err != "" {
-			// Same fact `entire status` reports as "Checkpoints NOT syncing":
-			// the pre-push gate is skipping checkpoint sync entirely until the
-			// setting is fixed.
-			fmt.Fprintf(w, "    Checkpoints are NOT syncing: %s\n", t.sync.Err)
-			return
-		}
-		// The election could not be read at all. Saying nothing here would
-		// leave a multi-remote repo with a bare remote count and no hint that
-		// the destination is one remote rather than all of them, so fall back
-		// to the part that holds on every tier.
-		fmt.Fprintln(w, "    Checkpoints sync to a single elected remote; `entire status` shows which.")
-		return
-	}
+// The "no session history" line is the inverse promise, and belongs only to the
+// tiers where the election is settled: with checkpoint_push_remote set or a
+// capture already in force, captureEligible refuses every displacement, so no
+// push can move the destination and every push to another remote really does
+// leave the transcripts behind. On the open tiers the same sentence would be
+// false for the electing push itself.
+func (t remoteTopology) describeElectedTier(b *strings.Builder) {
 	switch strategy.CheckpointSyncRemoteSource(t.sync.Source) {
 	case strategy.SyncRemoteSourceConfig:
 		// The decision is already made; repeating the setting key as advice
 		// would read as a warning that something still needs doing.
-		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q (set by checkpoint_push_remote).\n", t.sync.Remote)
-		fmt.Fprintln(w, "    A push to any other remote carries your code but no session history.")
+		fmt.Fprintf(b, "    Checkpoints sync to one remote — %q (set by checkpoint_push_remote).\n", t.sync.Remote)
+		fmt.Fprintln(b, "    A push to any other remote carries your code but no session history.")
 	case strategy.SyncRemoteSourceObserved:
 		// Same fact `entire status` reports as "follows your branch's push
 		// destination", shortened to hold one line at this indent.
-		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q, your branch's push destination.\n", t.sync.Remote)
-		fmt.Fprintln(w, "    A push to any other remote carries your code but no session history.")
-		fmt.Fprintln(w, "    Set strategy_options.checkpoint_push_remote to pin a different one.")
+		fmt.Fprintf(b, "    Checkpoints sync to one remote — %q, your branch's push destination.\n", t.sync.Remote)
+		fmt.Fprintln(b, "    A push to any other remote carries your code but no session history.")
+		fmt.Fprintln(b, "    Set strategy_options.checkpoint_push_remote to pin a different one.")
 	case strategy.SyncRemoteSourceDefault, strategy.SyncRemoteSourceSole, strategy.SyncRemoteSourceFirst:
 		// One wording for all three because the user-visible fact is the same:
 		// nothing has chosen the destination yet, so a push can still move it.
-		// Sole is all but unreachable from this caller, which writes the note
-		// only when two or more remotes are unpinned while the resolver
-		// reaches sole with exactly one remote configured — the two count
-		// remotes with different git commands, so the arm stays shared rather
-		// than assert an impossibility.
+		// Sole is all but unreachable from this caller, which words the tier
+		// only when two or more remotes are unpinned while the resolver reaches
+		// sole with exactly one remote configured — and the two count remotes
+		// with different git reads, so the arm stays shared rather than assert
+		// an impossibility.
 		//
 		// "a different remote" rather than "your branch's own remote": capture
 		// requires the push target to both agree with the branch's declared
 		// push destination and differ from today's election, so on the common
 		// setup where they already agree, no push moves anything.
-		fmt.Fprintf(w, "    Checkpoints sync to one remote — right now %q. A push to a different\n", t.sync.Remote)
-		fmt.Fprintln(w, "    remote of your own can move it; `entire status` shows where they go.")
-		fmt.Fprintln(w, "    Set strategy_options.checkpoint_push_remote to pin one yourself.")
+		fmt.Fprintf(b, "    Checkpoints sync to one remote — right now %q. A push to a different\n", t.sync.Remote)
+		fmt.Fprintln(b, "    remote of your own can move it; `entire status` shows where they go.")
+		fmt.Fprintln(b, "    Set strategy_options.checkpoint_push_remote to pin one yourself.")
 	}
 }
 
-// pinnedNames lists the remotes a checkpoint_remote is in effect for — which is
-// exactly the set whose pushes reach the store, since the pre-push exemption
-// (pushSettings.hasCheckpointURL) is the same remote.PushURL answer that sets
-// `pinned`.
+// describeIgnoredStore reports a checkpoint_remote that is configured but not in
+// effect. Everywhere else this is a logging.Warn inside the URL resolution, so
+// the setting is silently ignored and the fallback looks like an ordinary
+// election.
+//
+// The cause is stated as a likelihood, not a fact: the resolution reports a bare
+// "not in effect" for the ownership rejection, an unparseable push URL and an
+// unmappable protocol alike, so the note cannot tell which applied.
+func (t remoteTopology) describeIgnoredStore(b *strings.Builder) {
+	// IgnoredStore is only ever set alongside an elected remote, which is what
+	// the fallback destination named below is.
+	if t.sync.IgnoredStore == "" {
+		return
+	}
+	fmt.Fprintf(b, "  A checkpoint_remote (%q) is configured but not in\n", t.sync.IgnoredStore)
+	fmt.Fprintln(b, "  effect here — most often because it looks like it belongs to another owner.")
+	fmt.Fprintf(b, "  Checkpoints go to %q instead; set it in .entire/settings.local.json\n", t.sync.Remote)
+	fmt.Fprintln(b, "  if the store is yours.")
+}
+
+// describeFanOut breaks down the push URLs of the one remote whose pushes carry
+// checkpoints.
+//
+// Only that remote's URLs are a checkpoint destination: a push to any other is
+// gated out entirely (strategy.checkpointSyncAllowedForRemote), so "checkpoints
+// go to the first URL only" would be false of it — as it is of every remote when
+// the election failed or resolved to nothing, and of all of them when a
+// dedicated store bypasses the remotes altogether.
+func (t remoteTopology) describeFanOut(b *strings.Builder) {
+	d := t.electedDestination()
+	if d == nil || !d.fansOut() || t.sync.dedicated() {
+		return
+	}
+	fmt.Fprintf(b, "  Remote %q pushes to %d URLs:\n", d.name, len(d.pushURLs))
+	for i, u := range d.pushURLs {
+		marker := "  "
+		if i == 0 && t.primaryIsRefs {
+			marker = "→ "
+		}
+		fmt.Fprintf(b, "    %s%s\n", marker, gitremote.RedactURLOrPath(u))
+	}
+	if t.primaryIsRefs {
+		fmt.Fprintln(b, "    Checkpoints go to the first URL only; the others receive your code but")
+		fmt.Fprintln(b, "    no session history. Clone that first repository to resume elsewhere.")
+	} else {
+		fmt.Fprintln(b, "    Checkpoints are pushed to every URL. If one rejects them or is")
+		fmt.Fprintln(b, "    unreachable it is reported and left behind, and only the fetch URL is")
+		fmt.Fprintln(b, "    ever reconciled — so those URLs can fall permanently out of date.")
+	}
+}
+
+// electedDestination returns the remote whose pushes carry checkpoints, or nil
+// when the election named nothing, failed, or named something that is not one of
+// this repo's remotes — a dedicated store's org/repo slug, or a remote the
+// election can see and `git remote -v` cannot.
+func (t remoteTopology) electedDestination() *remoteDestination {
+	if t.sync.Remote == "" {
+		return nil
+	}
+	for i, d := range t.destinations {
+		if d.name == t.sync.Remote {
+			return &t.destinations[i]
+		}
+	}
+	return nil
+}
+
+// allNames lists every configured remote, in the order the snapshot sorted them.
+func (t remoteTopology) allNames() []string {
+	names := make([]string, 0, len(t.destinations))
+	for _, d := range t.destinations {
+		names = append(names, d.name)
+	}
+	return names
+}
+
+// pinnedNames lists the remotes a checkpoint_remote is in effect for — exactly
+// the set whose pushes reach the store, since the pre-push exemption
+// (pushSettings.hasCheckpointURL) is the same answer that sets `pinned`.
 func (t remoteTopology) pinnedNames() []string {
 	var names []string
 	for _, d := range t.destinations {
@@ -351,22 +379,6 @@ func (t remoteTopology) pinnedNames() []string {
 		}
 	}
 	return names
-}
-
-// quoteNames renders remote names for prose: `"a"`, `"a" and "b"`, `"a", "b" and "c"`.
-func quoteNames(names []string) string {
-	quoted := make([]string, 0, len(names))
-	for _, n := range names {
-		quoted = append(quoted, fmt.Sprintf("%q", n))
-	}
-	switch len(quoted) {
-	case 0:
-		return "no remote"
-	case 1:
-		return quoted[0]
-	default:
-		return strings.Join(quoted[:len(quoted)-1], ", ") + " and " + quoted[len(quoted)-1]
-	}
 }
 
 // unpinnedNames lists the remotes whose checkpoint destination is not already
@@ -379,6 +391,31 @@ func (t remoteTopology) unpinnedNames() []string {
 		}
 	}
 	return names
+}
+
+// quoteNames renders remote names for prose: `"a"`, `"a" and "b"`, `"a", "b" and "c"`.
+//
+// Deliberately not shared with formatTokenClassList (checkpoint_tokens.go),
+// which does the same joining for a different command: unifying them is a
+// worthwhile cleanup, but it renames a function in an unrelated file, so it
+// belongs in its own change rather than this one. Note the two already disagree
+// on the Oxford comma.
+//
+// Empty in, empty out — a caller with no names to print must drop the sentence
+// rather than print one about nothing.
+func quoteNames(names []string) string {
+	quoted := make([]string, 0, len(names))
+	for _, n := range names {
+		quoted = append(quoted, fmt.Sprintf("%q", n))
+	}
+	switch len(quoted) {
+	case 0:
+		return ""
+	case 1:
+		return quoted[0]
+	default:
+		return strings.Join(quoted[:len(quoted)-1], ", ") + " and " + quoted[len(quoted)-1]
+	}
 }
 
 // printCheckpointDestinationNote explains where checkpoints go when this repo's

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -59,12 +59,13 @@ type remoteTopology struct {
 	// failure this note exists to prevent.
 	syncRemote string
 	syncSource strategy.CheckpointSyncRemoteSource
-	// syncErr is the election failure, kept rather than swallowed because it
-	// is the only reason syncRemote can be empty where the note is written:
-	// that branch runs with at least two remotes configured, and a successful
-	// election over two or more remotes always yields a name. So an empty name
-	// there means checkpoint sync is fail-closed off, which is the one thing
-	// the note must not stay silent about.
+	// syncErr is the election failure, kept rather than swallowed because a
+	// fail-closed election is the one case where checkpoints are going
+	// nowhere at all, which the note must not stay silent about. It is not
+	// the only way syncRemote ends up empty: the resolver also returns an
+	// unnamed remote with no error when its own `git config` read fails
+	// transiently (cachedRemotesInConfigOrder answers nil rather than caching
+	// the failure), so the note carries a tier-agnostic fallback too.
 	syncErr error
 }
 
@@ -215,9 +216,16 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 // that remote and carries the checkpoints with it, so "checkpoints go to
 // origin, full stop" is exactly what must not be said here.
 //
-// The exception to the orientation-not-warning rule is a failed election: with
-// two or more remotes that only happens fail-closed, so checkpoints are going
-// nowhere at all and the note has to say so.
+// The "no session history" line is the inverse promise, and belongs only to
+// the tiers where the election is settled: with checkpoint_push_remote set or
+// a capture already in force, captureEligible refuses every displacement, so
+// no push can move the destination and every push to another remote really
+// does leave the transcripts behind. On the open tiers the same sentence would
+// be false for the electing push itself.
+//
+// The exception to the orientation-not-warning rule is a failed election: that
+// is fail-closed, so checkpoints are going nowhere at all and the note has to
+// say so.
 func (t remoteTopology) describeSyncRemote(w io.Writer) {
 	if t.syncRemote == "" {
 		if t.syncErr != nil {
@@ -225,28 +233,42 @@ func (t remoteTopology) describeSyncRemote(w io.Writer) {
 			// the pre-push gate is skipping checkpoint sync entirely until the
 			// setting is fixed.
 			fmt.Fprintf(w, "    Checkpoints are NOT syncing: %v\n", t.syncErr)
+			return
 		}
+		// The election could not be read at all. Saying nothing here would
+		// leave a multi-remote repo with a bare remote count and no hint that
+		// the destination is one remote rather than all of them, so fall back
+		// to the part that holds on every tier.
+		fmt.Fprintln(w, "    Checkpoints sync to a single elected remote; `entire status` shows which.")
 		return
 	}
 	switch t.syncSource {
 	case strategy.SyncRemoteSourceConfig:
-		// The decision is already made; repeating the setting key would read
-		// as a warning that something still needs doing.
+		// The decision is already made; repeating the setting key as advice
+		// would read as a warning that something still needs doing.
 		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q (set by checkpoint_push_remote).\n", t.syncRemote)
+		fmt.Fprintln(w, "    A push to any other remote carries your code but no session history.")
 	case strategy.SyncRemoteSourceObserved:
 		// Same fact `entire status` reports as "follows your branch's push
 		// destination", shortened to hold one line at this indent.
 		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q, your branch's push destination.\n", t.syncRemote)
+		fmt.Fprintln(w, "    A push to any other remote carries your code but no session history.")
 		fmt.Fprintln(w, "    Set strategy_options.checkpoint_push_remote to pin a different one.")
 	case strategy.SyncRemoteSourceDefault, strategy.SyncRemoteSourceSole, strategy.SyncRemoteSourceFirst:
-		// Sole is listed for exhaustiveness only and cannot occur here: the
-		// caller writes this note solely when two or more remotes are
-		// unpinned, and the resolver reaches the sole tier only with exactly
-		// one remote configured. If that gate ever loosens, sole needs its own
-		// wording — "your first push takes it over" is meaningless when there
-		// is nothing to take it from.
-		fmt.Fprintf(w, "    Checkpoints sync to one remote — right now %q, and your first push to\n", t.syncRemote)
-		fmt.Fprintln(w, "    your branch's own remote takes it over. `entire status` shows where.")
+		// One wording for all three because the user-visible fact is the same:
+		// nothing has chosen the destination yet, so a push can still move it.
+		// Sole is all but unreachable from this caller, which writes the note
+		// only when two or more remotes are unpinned while the resolver
+		// reaches sole with exactly one remote configured — the two count
+		// remotes with different git commands, so the arm stays shared rather
+		// than assert an impossibility.
+		//
+		// "a different remote" rather than "your branch's own remote": capture
+		// requires the push target to both agree with the branch's declared
+		// push destination and differ from today's election, so on the common
+		// setup where they already agree, no push moves anything.
+		fmt.Fprintf(w, "    Checkpoints sync to one remote — right now %q. A push to a different\n", t.syncRemote)
+		fmt.Fprintln(w, "    remote of your own can move it; `entire status` shows where they go.")
 		fmt.Fprintln(w, "    Set strategy_options.checkpoint_push_remote to pin one yourself.")
 	}
 }

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -52,21 +52,20 @@ type remoteTopology struct {
 	// primaryIsRefs reports whether the git-refs backend is active, which
 	// decides what a fanning-out remote means for checkpoints.
 	primaryIsRefs bool
-	// syncRemote is the elected checkpoint sync remote — the one remote whose
-	// pushes carry checkpoints — and syncSource says which tier elected it.
-	// Both are empty when the election found nothing or failed, and the note
-	// then names no destination: naming one the push side would not use is the
-	// failure this note exists to prevent.
-	syncRemote string
-	syncSource strategy.CheckpointSyncRemoteSource
-	// syncErr is the election failure, kept rather than swallowed because a
-	// fail-closed election is the one case where checkpoints are going
-	// nowhere at all, which the note must not stay silent about. It is not
-	// the only way syncRemote ends up empty: the resolver also returns an
-	// unnamed remote with no error when its own `git config` read fails
-	// transiently (cachedRemotesInConfigOrder answers nil rather than caching
-	// the failure), so the note carries a tier-agnostic fallback too.
-	syncErr error
+	// sync is where checkpoints actually go, from the same computation behind
+	// `entire status` and `entire status --json` (status.go), so the three
+	// surfaces cannot disagree about one election. Its Unpushed is always 0
+	// here: the note needs the destination only, and must stay cheap.
+	//
+	// sync.Remote is empty when the election found nothing or failed, and the
+	// note then names no destination — naming one the push side would not use
+	// is the failure this note exists to prevent. sync.Err is a fail-closed
+	// election, the one case where checkpoints go nowhere at all, which the
+	// note must not stay silent about. An empty name with no error is the
+	// third case: the resolver answers that way when its own `git config` read
+	// fails transiently (cachedRemotesInConfigOrder returns nil rather than
+	// caching the failure), so the note carries a tier-agnostic fallback too.
+	sync checkpointSyncInfo
 }
 
 // inspectRemoteTopology reads the repo's remotes and checkpoint configuration.
@@ -109,17 +108,22 @@ func inspectRemoteTopology(ctx context.Context) remoteTopology {
 		t.primaryIsRefs = checkpoint.PrimaryIsRefs(cpCfg)
 	}
 
-	// Ask the resolver rather than reading checkpoint_push_remote out of
-	// settings, for the same reason `pinned` does: the destination shown must
-	// be the one pushes actually use, never a re-derivation that can disagree.
-	elected, err := strategy.ResolveCheckpointSyncRemote(ctx)
+	// Share the status computation rather than re-deriving the destination, for
+	// the same reason `pinned` asks the resolver: what is shown must be what
+	// pushes actually use. A local re-derivation here is what let this note
+	// name a remote while `entire status` named a dedicated store.
+	//
+	// A settings read failure degrades to a nil settings object — dedicated
+	// mode simply goes undetected — rather than becoming an Err, which the note
+	// renders as "Checkpoints are NOT syncing". A transient read failure is not
+	// that, and this note must never obstruct enable or doctor.
+	s, err := LoadEntireSettings(ctx)
 	if err != nil {
-		t.syncErr = err
-		logging.Debug(ctx, "remote topology: could not resolve the checkpoint sync remote",
+		logging.Debug(ctx, "remote topology: could not load settings",
 			slog.String("error", err.Error()))
-	} else {
-		t.syncRemote, t.syncSource = elected.Name, elected.Source
+		s = nil
 	}
+	t.sync = resolveCheckpointSyncDestination(ctx, s)
 
 	return t
 }
@@ -172,8 +176,29 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 
 	fmt.Fprintln(w, header)
 
+	// Destination first: every claim below it is about how checkpoints reach
+	// that destination, and the URL breakdown read as the whole answer when it
+	// came first.
+	if names := t.unpinnedNames(); len(names) > 1 {
+		// Every remote, not just the unpinned ones. The count orients the
+		// reader in their own repo, and omitting a pinned remote let the note
+		// name a destination missing from its own list.
+		all := make([]string, 0, len(t.destinations))
+		for _, d := range t.destinations {
+			all = append(all, d.name)
+		}
+		fmt.Fprintf(w, "  This repo has %d remotes (%s).\n", len(all), strings.Join(all, ", "))
+		t.describeSyncRemote(w)
+	}
+
+	t.describeIgnoredStore(w)
+
 	for _, d := range t.destinations {
-		if !d.fansOut() {
+		// Only the elected remote's URLs are a checkpoint destination. Another
+		// remote's pushes are gated out entirely (checkpointSyncAllowedForRemote),
+		// so "checkpoints go to the first URL only" would be false of it — as it
+		// is of every remote when the election failed or resolved to nothing.
+		if !d.fansOut() || t.dedicated() || d.name != t.sync.Remote {
 			continue
 		}
 		fmt.Fprintf(w, "  Remote %q pushes to %d URLs:\n", d.name, len(d.pushURLs))
@@ -194,13 +219,35 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 		}
 	}
 
-	if names := t.unpinnedNames(); len(names) > 1 {
-		fmt.Fprintf(w, "  This repo has %d remotes (%s).\n", len(names), strings.Join(names, ", "))
-		t.describeSyncRemote(w)
+	// The advice is "configure a checkpoint_remote" — already done in both
+	// states where one exists, and off-target when a fail-closed election means
+	// nothing is syncing at all.
+	if t.dedicated() || t.sync.IgnoredStore != "" || t.sync.Err != "" {
+		return
 	}
-
 	fmt.Fprintln(w, "  To pin one repository for checkpoints, set checkpoint_remote in")
 	fmt.Fprintln(w, "  .entire/settings.json (or .entire/settings.local.json to keep it to this clone).")
+}
+
+// dedicated reports that a checkpoint_remote store is the destination, so none
+// of this repo's remotes is where checkpoints land.
+func (t remoteTopology) dedicated() bool { return t.sync.dedicated() }
+
+// describeIgnoredStore reports a checkpoint_remote that is configured but not in
+// effect. Everywhere else this is a logging.Warn inside remote.PushURL, so the
+// setting is silently ignored and the fallback looks like an ordinary election.
+//
+// The cause is stated as a likelihood, not a fact: PushURL returns a bare
+// enabled=false for the ownership rejection, an unparseable push URL and an
+// unmappable protocol alike, so the note cannot tell which applied.
+func (t remoteTopology) describeIgnoredStore(w io.Writer) {
+	if t.sync.IgnoredStore == "" {
+		return
+	}
+	fmt.Fprintf(w, "    A checkpoint_remote (%q) is configured but not in effect\n", t.sync.IgnoredStore)
+	fmt.Fprintln(w, "    here — most often because it looks like it belongs to another owner.")
+	fmt.Fprintf(w, "    Checkpoints go to %q instead; set it in .entire/settings.local.json\n", t.sync.Remote)
+	fmt.Fprintln(w, "    if the store is yours.")
 }
 
 // describeSyncRemote names the one remote that carries checkpoints. It stays
@@ -226,13 +273,32 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 // The exception to the orientation-not-warning rule is a failed election: that
 // is fail-closed, so checkpoints are going nowhere at all and the note has to
 // say so.
+//
+// A dedicated checkpoint_remote store is answered before the tier switch, and
+// deliberately drops the "no session history" clause the settled tiers carry:
+// in dedicated mode checkpoints never ride a code push to a remote at all, so
+// there is no "other remote" for that sentence to be about. It names the pinned
+// remotes instead, because those are the pushes that reach the store — a repo
+// where none of them is ever pushed strands its transcripts, and nothing else
+// in this note would say so.
 func (t remoteTopology) describeSyncRemote(w io.Writer) {
-	if t.syncRemote == "" {
-		if t.syncErr != nil {
+	// A dedicated store is not a tier of the election — status.go synthesizes
+	// it — so it is answered before the switch, which stays typed on the
+	// resolver's enum so `exhaustive` keeps turning a new tier into a decision
+	// here.
+	if t.dedicated() {
+		fmt.Fprintf(w, "    Checkpoints go to the dedicated store %q (set by\n", t.sync.Remote)
+		fmt.Fprintf(w, "    checkpoint_remote), not to any of these remotes. Pushes to %s\n",
+			quoteNames(t.pinnedNames()))
+		fmt.Fprintln(w, "    carry them there.")
+		return
+	}
+	if t.sync.Remote == "" {
+		if t.sync.Err != "" {
 			// Same fact `entire status` reports as "Checkpoints NOT syncing":
 			// the pre-push gate is skipping checkpoint sync entirely until the
 			// setting is fixed.
-			fmt.Fprintf(w, "    Checkpoints are NOT syncing: %v\n", t.syncErr)
+			fmt.Fprintf(w, "    Checkpoints are NOT syncing: %s\n", t.sync.Err)
 			return
 		}
 		// The election could not be read at all. Saying nothing here would
@@ -242,16 +308,16 @@ func (t remoteTopology) describeSyncRemote(w io.Writer) {
 		fmt.Fprintln(w, "    Checkpoints sync to a single elected remote; `entire status` shows which.")
 		return
 	}
-	switch t.syncSource {
+	switch strategy.CheckpointSyncRemoteSource(t.sync.Source) {
 	case strategy.SyncRemoteSourceConfig:
 		// The decision is already made; repeating the setting key as advice
 		// would read as a warning that something still needs doing.
-		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q (set by checkpoint_push_remote).\n", t.syncRemote)
+		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q (set by checkpoint_push_remote).\n", t.sync.Remote)
 		fmt.Fprintln(w, "    A push to any other remote carries your code but no session history.")
 	case strategy.SyncRemoteSourceObserved:
 		// Same fact `entire status` reports as "follows your branch's push
 		// destination", shortened to hold one line at this indent.
-		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q, your branch's push destination.\n", t.syncRemote)
+		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q, your branch's push destination.\n", t.sync.Remote)
 		fmt.Fprintln(w, "    A push to any other remote carries your code but no session history.")
 		fmt.Fprintln(w, "    Set strategy_options.checkpoint_push_remote to pin a different one.")
 	case strategy.SyncRemoteSourceDefault, strategy.SyncRemoteSourceSole, strategy.SyncRemoteSourceFirst:
@@ -267,9 +333,39 @@ func (t remoteTopology) describeSyncRemote(w io.Writer) {
 		// requires the push target to both agree with the branch's declared
 		// push destination and differ from today's election, so on the common
 		// setup where they already agree, no push moves anything.
-		fmt.Fprintf(w, "    Checkpoints sync to one remote — right now %q. A push to a different\n", t.syncRemote)
+		fmt.Fprintf(w, "    Checkpoints sync to one remote — right now %q. A push to a different\n", t.sync.Remote)
 		fmt.Fprintln(w, "    remote of your own can move it; `entire status` shows where they go.")
 		fmt.Fprintln(w, "    Set strategy_options.checkpoint_push_remote to pin one yourself.")
+	}
+}
+
+// pinnedNames lists the remotes a checkpoint_remote is in effect for — which is
+// exactly the set whose pushes reach the store, since the pre-push exemption
+// (pushSettings.hasCheckpointURL) is the same remote.PushURL answer that sets
+// `pinned`.
+func (t remoteTopology) pinnedNames() []string {
+	var names []string
+	for _, d := range t.destinations {
+		if d.pinned {
+			names = append(names, d.name)
+		}
+	}
+	return names
+}
+
+// quoteNames renders remote names for prose: `"a"`, `"a" and "b"`, `"a", "b" and "c"`.
+func quoteNames(names []string) string {
+	quoted := make([]string, 0, len(names))
+	for _, n := range names {
+		quoted = append(quoted, fmt.Sprintf("%q", n))
+	}
+	switch len(quoted) {
+	case 0:
+		return "no remote"
+	case 1:
+		return quoted[0]
+	default:
+		return strings.Join(quoted[:len(quoted)-1], ", ") + " and " + quoted[len(quoted)-1]
 	}
 }
 

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -179,22 +179,28 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 	// Destination first: every claim below it is about how checkpoints reach
 	// that destination, and the URL breakdown read as the whole answer when it
 	// came first.
-	if len(t.unpinnedNames()) > 1 {
-		// Every remote, not just the unpinned ones: the count orients the
+	if names := t.unpinnedNames(); len(names) > 1 {
+		// Every remote, not just the unpinned ones. The count orients the
 		// reader in their own repo, and omitting a pinned remote let the note
 		// name a destination missing from its own list.
-		fmt.Fprintf(w, "  This repo has %d remotes (%s).\n", len(t.destinations), strings.Join(t.allNames(), ", "))
+		all := make([]string, 0, len(t.destinations))
+		for _, d := range t.destinations {
+			all = append(all, d.name)
+		}
+		fmt.Fprintf(w, "  This repo has %d remotes (%s).\n", len(all), strings.Join(all, ", "))
 		t.describeSyncRemote(w)
 	}
 
 	t.describeIgnoredStore(w)
 
-	// Only the elected remote's URLs are a checkpoint destination. Another
-	// remote's pushes are gated out entirely (checkpointSyncAllowedForRemote),
-	// so "checkpoints go to the first URL only" would be false of it — as it is
-	// of every remote when the election failed or resolved to nothing, and of
-	// all of them when a dedicated store bypasses the remotes altogether.
-	if d := t.electedDestination(); d != nil && d.fansOut() && !t.sync.dedicated() {
+	for _, d := range t.destinations {
+		// Only the elected remote's URLs are a checkpoint destination. Another
+		// remote's pushes are gated out entirely (checkpointSyncAllowedForRemote),
+		// so "checkpoints go to the first URL only" would be false of it — as it
+		// is of every remote when the election failed or resolved to nothing.
+		if !d.fansOut() || t.dedicated() || d.name != t.sync.Remote {
+			continue
+		}
 		fmt.Fprintf(w, "  Remote %q pushes to %d URLs:\n", d.name, len(d.pushURLs))
 		for i, u := range d.pushURLs {
 			marker := "  "
@@ -213,15 +219,19 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 		}
 	}
 
-	// The advice is "configure a checkpoint_remote" — already taken in both
+	// The advice is "configure a checkpoint_remote" — already done in both
 	// states where one exists, and off-target when a fail-closed election means
 	// nothing is syncing at all.
-	if t.sync.storeConfigured() || t.sync.Err != "" {
+	if t.dedicated() || t.sync.IgnoredStore != "" || t.sync.Err != "" {
 		return
 	}
 	fmt.Fprintln(w, "  To pin one repository for checkpoints, set checkpoint_remote in")
 	fmt.Fprintln(w, "  .entire/settings.json (or .entire/settings.local.json to keep it to this clone).")
 }
+
+// dedicated reports that a checkpoint_remote store is the destination, so none
+// of this repo's remotes is where checkpoints land.
+func (t remoteTopology) dedicated() bool { return t.sync.dedicated() }
 
 // describeIgnoredStore reports a checkpoint_remote that is configured but not in
 // effect. Everywhere else this is a logging.Warn inside remote.PushURL, so the
@@ -234,14 +244,10 @@ func (t remoteTopology) describeIgnoredStore(w io.Writer) {
 	if t.sync.IgnoredStore == "" {
 		return
 	}
-	// Two-space indent, like the remote count and unlike describeSyncRemote's
-	// detail lines: this is a fact about the repo's configuration, and it prints
-	// even when no remote list preceded it (a lone fanning-out remote is enough
-	// to reach here), where a deeper indent would hang off nothing.
-	fmt.Fprintf(w, "  A checkpoint_remote (%q) is configured but not in\n", t.sync.IgnoredStore)
-	fmt.Fprintln(w, "  effect here — most often because it looks like it belongs to another owner.")
-	fmt.Fprintf(w, "  Checkpoints go to %q instead; set it in .entire/settings.local.json\n", t.sync.Remote)
-	fmt.Fprintln(w, "  if the store is yours.")
+	fmt.Fprintf(w, "    A checkpoint_remote (%q) is configured but not in effect\n", t.sync.IgnoredStore)
+	fmt.Fprintln(w, "    here — most often because it looks like it belongs to another owner.")
+	fmt.Fprintf(w, "    Checkpoints go to %q instead; set it in .entire/settings.local.json\n", t.sync.Remote)
+	fmt.Fprintln(w, "    if the store is yours.")
 }
 
 // describeSyncRemote names the one remote that carries checkpoints. It stays
@@ -280,18 +286,11 @@ func (t remoteTopology) describeSyncRemote(w io.Writer) {
 	// it — so it is answered before the switch, which stays typed on the
 	// resolver's enum so `exhaustive` keeps turning a new tier into a decision
 	// here.
-	if t.sync.dedicated() {
+	if t.dedicated() {
 		fmt.Fprintf(w, "    Checkpoints go to the dedicated store %q (set by\n", t.sync.Remote)
-		fmt.Fprintln(w, "    checkpoint_remote), not to any of these remotes.")
-		// Normally at least the elected remote is pinned — being pinned is what
-		// put us in dedicated mode. It can still come back empty, because the
-		// per-remote probes in inspectRemoteTopology drop their errors while the
-		// election's own probe succeeded, so a transient git failure leaves the
-		// carrier unnamed. Then say nothing: the pushes do reach the store, so
-		// naming none of them would be the one claim that is false.
-		if names := t.pinnedNames(); len(names) > 0 {
-			fmt.Fprintf(w, "    Pushes to %s carry them there.\n", quoteNames(names))
-		}
+		fmt.Fprintf(w, "    checkpoint_remote), not to any of these remotes. Pushes to %s\n",
+			quoteNames(t.pinnedNames()))
+		fmt.Fprintln(w, "    carry them there.")
 		return
 	}
 	if t.sync.Remote == "" {
@@ -340,31 +339,6 @@ func (t remoteTopology) describeSyncRemote(w io.Writer) {
 	}
 }
 
-// allNames lists every configured remote, in the sorted order inspectRemoteTopology
-// built them.
-func (t remoteTopology) allNames() []string {
-	names := make([]string, 0, len(t.destinations))
-	for _, d := range t.destinations {
-		names = append(names, d.name)
-	}
-	return names
-}
-
-// electedDestination returns the remote whose pushes carry checkpoints, or nil
-// when the election named nothing, failed, or named something that is not one of
-// this repo's remotes (a dedicated store's org/repo slug).
-func (t remoteTopology) electedDestination() *remoteDestination {
-	if t.sync.Remote == "" {
-		return nil
-	}
-	for i, d := range t.destinations {
-		if d.name == t.sync.Remote {
-			return &t.destinations[i]
-		}
-	}
-	return nil
-}
-
 // pinnedNames lists the remotes a checkpoint_remote is in effect for — which is
 // exactly the set whose pushes reach the store, since the pre-push exemption
 // (pushSettings.hasCheckpointURL) is the same remote.PushURL answer that sets
@@ -379,15 +353,20 @@ func (t remoteTopology) pinnedNames() []string {
 	return names
 }
 
-// quoteNames renders remote names for prose: `"a"`, `"a" and "b"`, `"a", "b", and "c"`.
-// Empty in, empty out — callers that have no names to print must drop the
-// sentence rather than print one about nothing.
+// quoteNames renders remote names for prose: `"a"`, `"a" and "b"`, `"a", "b" and "c"`.
 func quoteNames(names []string) string {
 	quoted := make([]string, 0, len(names))
 	for _, n := range names {
 		quoted = append(quoted, fmt.Sprintf("%q", n))
 	}
-	return formatProseList(quoted)
+	switch len(quoted) {
+	case 0:
+		return "no remote"
+	case 1:
+		return quoted[0]
+	default:
+		return strings.Join(quoted[:len(quoted)-1], ", ") + " and " + quoted[len(quoted)-1]
+	}
 }
 
 // unpinnedNames lists the remotes whose checkpoint destination is not already

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -14,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
 )
 
 // Checkpoint destinations are unambiguous in the ordinary single-remote,
@@ -51,6 +52,13 @@ type remoteTopology struct {
 	// primaryIsRefs reports whether the git-refs backend is active, which
 	// decides what a fanning-out remote means for checkpoints.
 	primaryIsRefs bool
+	// syncRemote is the elected checkpoint sync remote — the one remote whose
+	// pushes carry checkpoints — and syncSource says which tier elected it.
+	// Both are empty when the election found nothing or failed, and the note
+	// then says nothing about where checkpoints go: naming a destination the
+	// push side would not use is the failure this note exists to prevent.
+	syncRemote string
+	syncSource strategy.CheckpointSyncRemoteSource
 }
 
 // inspectRemoteTopology reads the repo's remotes and checkpoint configuration.
@@ -91,6 +99,16 @@ func inspectRemoteTopology(ctx context.Context) remoteTopology {
 
 	if cpCfg, err := settings.LoadCheckpointsConfig(ctx); err == nil {
 		t.primaryIsRefs = checkpoint.PrimaryIsRefs(cpCfg)
+	}
+
+	// Ask the resolver rather than reading checkpoint_push_remote out of
+	// settings, for the same reason `pinned` does: the destination shown must
+	// be the one pushes actually use, never a re-derivation that can disagree.
+	if elected, err := strategy.ResolveCheckpointSyncRemote(ctx); err == nil {
+		t.syncRemote, t.syncSource = elected.Name, elected.Source
+	} else {
+		logging.Debug(ctx, "remote topology: could not resolve the checkpoint sync remote",
+			slog.String("error", err.Error()))
 	}
 
 	return t
@@ -168,14 +186,44 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 
 	if names := t.unpinnedNames(); len(names) > 1 {
 		fmt.Fprintf(w, "  This repo has %d remotes (%s).\n", len(names), strings.Join(names, ", "))
-		fmt.Fprintln(w, "    Checkpoints sync to a single elected remote — not to whichever one you")
-		fmt.Fprintln(w, "    push to. A push to any other remote carries your code but no session")
-		fmt.Fprintln(w, "    history. Run `entire status` to see the elected destination and how many")
-		fmt.Fprintln(w, "    checkpoints are waiting for it.")
+		t.describeSyncRemote(w)
 	}
 
 	fmt.Fprintln(w, "  To pin one repository for checkpoints, set checkpoint_remote in")
 	fmt.Fprintln(w, "  .entire/settings.json (or .entire/settings.local.json to keep it to this clone).")
+}
+
+// describeSyncRemote names the one remote that carries checkpoints. It stays
+// to three lines at most on purpose: capture already routes the fork topology
+// correctly and announces itself when it does, a gated push says so at the
+// time (strategy.hintGatedCheckpointSync), and `entire status` reports the
+// destination on demand — so this is orientation at setup, not a warning about
+// something the user must go and fix.
+//
+// Naming today's remote alone would be a promise the next push can break,
+// hence the second clause on the tiers where the election is still open: a
+// push whose target agrees with the branch's declared push destination elects
+// that remote and carries the checkpoints with it, so "checkpoints go to
+// origin, full stop" is exactly what must not be said here.
+func (t remoteTopology) describeSyncRemote(w io.Writer) {
+	if t.syncRemote == "" {
+		return
+	}
+	switch t.syncSource {
+	case strategy.SyncRemoteSourceConfig:
+		// The decision is already made; repeating the setting key would read
+		// as a warning that something still needs doing.
+		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q (set by checkpoint_push_remote).\n", t.syncRemote)
+	case strategy.SyncRemoteSourceObserved:
+		// Same fact `entire status` reports as "follows your branch's push
+		// destination", shortened to hold one line at this indent.
+		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q, your branch's push destination.\n", t.syncRemote)
+		fmt.Fprintln(w, "    Set strategy_options.checkpoint_push_remote to pin a different one.")
+	default:
+		fmt.Fprintf(w, "    Checkpoints sync to one remote — right now %q, and your first push to\n", t.syncRemote)
+		fmt.Fprintln(w, "    your branch's own remote takes it over. `entire status` shows where.")
+		fmt.Fprintln(w, "    Set strategy_options.checkpoint_push_remote to pin one yourself.")
+	}
 }
 
 // unpinnedNames lists the remotes whose checkpoint destination is not already

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -55,10 +55,17 @@ type remoteTopology struct {
 	// syncRemote is the elected checkpoint sync remote — the one remote whose
 	// pushes carry checkpoints — and syncSource says which tier elected it.
 	// Both are empty when the election found nothing or failed, and the note
-	// then says nothing about where checkpoints go: naming a destination the
-	// push side would not use is the failure this note exists to prevent.
+	// then names no destination: naming one the push side would not use is the
+	// failure this note exists to prevent.
 	syncRemote string
 	syncSource strategy.CheckpointSyncRemoteSource
+	// syncErr is the election failure, kept rather than swallowed because it
+	// is the only reason syncRemote can be empty where the note is written:
+	// that branch runs with at least two remotes configured, and a successful
+	// election over two or more remotes always yields a name. So an empty name
+	// there means checkpoint sync is fail-closed off, which is the one thing
+	// the note must not stay silent about.
+	syncErr error
 }
 
 // inspectRemoteTopology reads the repo's remotes and checkpoint configuration.
@@ -104,11 +111,13 @@ func inspectRemoteTopology(ctx context.Context) remoteTopology {
 	// Ask the resolver rather than reading checkpoint_push_remote out of
 	// settings, for the same reason `pinned` does: the destination shown must
 	// be the one pushes actually use, never a re-derivation that can disagree.
-	if elected, err := strategy.ResolveCheckpointSyncRemote(ctx); err == nil {
-		t.syncRemote, t.syncSource = elected.Name, elected.Source
-	} else {
+	elected, err := strategy.ResolveCheckpointSyncRemote(ctx)
+	if err != nil {
+		t.syncErr = err
 		logging.Debug(ctx, "remote topology: could not resolve the checkpoint sync remote",
 			slog.String("error", err.Error()))
+	} else {
+		t.syncRemote, t.syncSource = elected.Name, elected.Source
 	}
 
 	return t
@@ -205,8 +214,18 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 // push whose target agrees with the branch's declared push destination elects
 // that remote and carries the checkpoints with it, so "checkpoints go to
 // origin, full stop" is exactly what must not be said here.
+//
+// The exception to the orientation-not-warning rule is a failed election: with
+// two or more remotes that only happens fail-closed, so checkpoints are going
+// nowhere at all and the note has to say so.
 func (t remoteTopology) describeSyncRemote(w io.Writer) {
 	if t.syncRemote == "" {
+		if t.syncErr != nil {
+			// Same fact `entire status` reports as "Checkpoints NOT syncing":
+			// the pre-push gate is skipping checkpoint sync entirely until the
+			// setting is fixed.
+			fmt.Fprintf(w, "    Checkpoints are NOT syncing: %v\n", t.syncErr)
+		}
 		return
 	}
 	switch t.syncSource {
@@ -219,7 +238,13 @@ func (t remoteTopology) describeSyncRemote(w io.Writer) {
 		// destination", shortened to hold one line at this indent.
 		fmt.Fprintf(w, "    Checkpoints sync to one remote — %q, your branch's push destination.\n", t.syncRemote)
 		fmt.Fprintln(w, "    Set strategy_options.checkpoint_push_remote to pin a different one.")
-	default:
+	case strategy.SyncRemoteSourceDefault, strategy.SyncRemoteSourceSole, strategy.SyncRemoteSourceFirst:
+		// Sole is listed for exhaustiveness only and cannot occur here: the
+		// caller writes this note solely when two or more remotes are
+		// unpinned, and the resolver reaches the sole tier only with exactly
+		// one remote configured. If that gate ever loosens, sole needs its own
+		// wording — "your first push takes it over" is meaningless when there
+		// is nothing to take it from.
 		fmt.Fprintf(w, "    Checkpoints sync to one remote — right now %q, and your first push to\n", t.syncRemote)
 		fmt.Fprintln(w, "    your branch's own remote takes it over. `entire status` shows where.")
 		fmt.Fprintln(w, "    Set strategy_options.checkpoint_push_remote to pin one yourself.")

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -282,9 +282,16 @@ func (t remoteTopology) describeSyncRemote(w io.Writer) {
 	// here.
 	if t.sync.dedicated() {
 		fmt.Fprintf(w, "    Checkpoints go to the dedicated store %q (set by\n", t.sync.Remote)
-		fmt.Fprintf(w, "    checkpoint_remote), not to any of these remotes. Pushes to %s\n",
-			quoteNames(t.pinnedNames()))
-		fmt.Fprintln(w, "    carry them there.")
+		fmt.Fprintln(w, "    checkpoint_remote), not to any of these remotes.")
+		// Normally at least the elected remote is pinned — being pinned is what
+		// put us in dedicated mode. It can still come back empty, because the
+		// per-remote probes in inspectRemoteTopology drop their errors while the
+		// election's own probe succeeded, so a transient git failure leaves the
+		// carrier unnamed. Then say nothing: the pushes do reach the store, so
+		// naming none of them would be the one claim that is false.
+		if names := t.pinnedNames(); len(names) > 0 {
+			fmt.Fprintf(w, "    Pushes to %s carry them there.\n", quoteNames(names))
+		}
 		return
 	}
 	if t.sync.Remote == "" {
@@ -373,12 +380,9 @@ func (t remoteTopology) pinnedNames() []string {
 }
 
 // quoteNames renders remote names for prose: `"a"`, `"a" and "b"`, `"a", "b", and "c"`.
-// The empty case is worded here rather than in the shared joiner, which has no
-// remotes to speak of.
+// Empty in, empty out — callers that have no names to print must drop the
+// sentence rather than print one about nothing.
 func quoteNames(names []string) string {
-	if len(names) == 0 {
-		return "no remote"
-	}
 	quoted := make([]string, 0, len(names))
 	for _, n := range names {
 		quoted = append(quoted, fmt.Sprintf("%q", n))

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -179,28 +179,22 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 	// Destination first: every claim below it is about how checkpoints reach
 	// that destination, and the URL breakdown read as the whole answer when it
 	// came first.
-	if names := t.unpinnedNames(); len(names) > 1 {
-		// Every remote, not just the unpinned ones. The count orients the
+	if len(t.unpinnedNames()) > 1 {
+		// Every remote, not just the unpinned ones: the count orients the
 		// reader in their own repo, and omitting a pinned remote let the note
 		// name a destination missing from its own list.
-		all := make([]string, 0, len(t.destinations))
-		for _, d := range t.destinations {
-			all = append(all, d.name)
-		}
-		fmt.Fprintf(w, "  This repo has %d remotes (%s).\n", len(all), strings.Join(all, ", "))
+		fmt.Fprintf(w, "  This repo has %d remotes (%s).\n", len(t.destinations), strings.Join(t.allNames(), ", "))
 		t.describeSyncRemote(w)
 	}
 
 	t.describeIgnoredStore(w)
 
-	for _, d := range t.destinations {
-		// Only the elected remote's URLs are a checkpoint destination. Another
-		// remote's pushes are gated out entirely (checkpointSyncAllowedForRemote),
-		// so "checkpoints go to the first URL only" would be false of it — as it
-		// is of every remote when the election failed or resolved to nothing.
-		if !d.fansOut() || t.dedicated() || d.name != t.sync.Remote {
-			continue
-		}
+	// Only the elected remote's URLs are a checkpoint destination. Another
+	// remote's pushes are gated out entirely (checkpointSyncAllowedForRemote),
+	// so "checkpoints go to the first URL only" would be false of it — as it is
+	// of every remote when the election failed or resolved to nothing, and of
+	// all of them when a dedicated store bypasses the remotes altogether.
+	if d := t.electedDestination(); d != nil && d.fansOut() && !t.sync.dedicated() {
 		fmt.Fprintf(w, "  Remote %q pushes to %d URLs:\n", d.name, len(d.pushURLs))
 		for i, u := range d.pushURLs {
 			marker := "  "
@@ -219,19 +213,15 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 		}
 	}
 
-	// The advice is "configure a checkpoint_remote" — already done in both
+	// The advice is "configure a checkpoint_remote" — already taken in both
 	// states where one exists, and off-target when a fail-closed election means
 	// nothing is syncing at all.
-	if t.dedicated() || t.sync.IgnoredStore != "" || t.sync.Err != "" {
+	if t.sync.storeConfigured() || t.sync.Err != "" {
 		return
 	}
 	fmt.Fprintln(w, "  To pin one repository for checkpoints, set checkpoint_remote in")
 	fmt.Fprintln(w, "  .entire/settings.json (or .entire/settings.local.json to keep it to this clone).")
 }
-
-// dedicated reports that a checkpoint_remote store is the destination, so none
-// of this repo's remotes is where checkpoints land.
-func (t remoteTopology) dedicated() bool { return t.sync.dedicated() }
 
 // describeIgnoredStore reports a checkpoint_remote that is configured but not in
 // effect. Everywhere else this is a logging.Warn inside remote.PushURL, so the
@@ -244,10 +234,14 @@ func (t remoteTopology) describeIgnoredStore(w io.Writer) {
 	if t.sync.IgnoredStore == "" {
 		return
 	}
-	fmt.Fprintf(w, "    A checkpoint_remote (%q) is configured but not in effect\n", t.sync.IgnoredStore)
-	fmt.Fprintln(w, "    here — most often because it looks like it belongs to another owner.")
-	fmt.Fprintf(w, "    Checkpoints go to %q instead; set it in .entire/settings.local.json\n", t.sync.Remote)
-	fmt.Fprintln(w, "    if the store is yours.")
+	// Two-space indent, like the remote count and unlike describeSyncRemote's
+	// detail lines: this is a fact about the repo's configuration, and it prints
+	// even when no remote list preceded it (a lone fanning-out remote is enough
+	// to reach here), where a deeper indent would hang off nothing.
+	fmt.Fprintf(w, "  A checkpoint_remote (%q) is configured but not in\n", t.sync.IgnoredStore)
+	fmt.Fprintln(w, "  effect here — most often because it looks like it belongs to another owner.")
+	fmt.Fprintf(w, "  Checkpoints go to %q instead; set it in .entire/settings.local.json\n", t.sync.Remote)
+	fmt.Fprintln(w, "  if the store is yours.")
 }
 
 // describeSyncRemote names the one remote that carries checkpoints. It stays
@@ -286,7 +280,7 @@ func (t remoteTopology) describeSyncRemote(w io.Writer) {
 	// it — so it is answered before the switch, which stays typed on the
 	// resolver's enum so `exhaustive` keeps turning a new tier into a decision
 	// here.
-	if t.dedicated() {
+	if t.sync.dedicated() {
 		fmt.Fprintf(w, "    Checkpoints go to the dedicated store %q (set by\n", t.sync.Remote)
 		fmt.Fprintf(w, "    checkpoint_remote), not to any of these remotes. Pushes to %s\n",
 			quoteNames(t.pinnedNames()))
@@ -339,6 +333,31 @@ func (t remoteTopology) describeSyncRemote(w io.Writer) {
 	}
 }
 
+// allNames lists every configured remote, in the sorted order inspectRemoteTopology
+// built them.
+func (t remoteTopology) allNames() []string {
+	names := make([]string, 0, len(t.destinations))
+	for _, d := range t.destinations {
+		names = append(names, d.name)
+	}
+	return names
+}
+
+// electedDestination returns the remote whose pushes carry checkpoints, or nil
+// when the election named nothing, failed, or named something that is not one of
+// this repo's remotes (a dedicated store's org/repo slug).
+func (t remoteTopology) electedDestination() *remoteDestination {
+	if t.sync.Remote == "" {
+		return nil
+	}
+	for i, d := range t.destinations {
+		if d.name == t.sync.Remote {
+			return &t.destinations[i]
+		}
+	}
+	return nil
+}
+
 // pinnedNames lists the remotes a checkpoint_remote is in effect for — which is
 // exactly the set whose pushes reach the store, since the pre-push exemption
 // (pushSettings.hasCheckpointURL) is the same remote.PushURL answer that sets
@@ -353,20 +372,18 @@ func (t remoteTopology) pinnedNames() []string {
 	return names
 }
 
-// quoteNames renders remote names for prose: `"a"`, `"a" and "b"`, `"a", "b" and "c"`.
+// quoteNames renders remote names for prose: `"a"`, `"a" and "b"`, `"a", "b", and "c"`.
+// The empty case is worded here rather than in the shared joiner, which has no
+// remotes to speak of.
 func quoteNames(names []string) string {
+	if len(names) == 0 {
+		return "no remote"
+	}
 	quoted := make([]string, 0, len(names))
 	for _, n := range names {
 		quoted = append(quoted, fmt.Sprintf("%q", n))
 	}
-	switch len(quoted) {
-	case 0:
-		return "no remote"
-	case 1:
-		return quoted[0]
-	default:
-		return strings.Join(quoted[:len(quoted)-1], ", ") + " and " + quoted[len(quoted)-1]
-	}
+	return formatProseList(quoted)
 }
 
 // unpinnedNames lists the remotes whose checkpoint destination is not already

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -192,7 +192,9 @@ func (t remoteTopology) writeDestinationBody(b *strings.Builder) {
 // left a broken checkpoint_push_remote as the state that said least.
 //
 // Only the tier wording is genuinely about choosing among several remotes, so
-// only it stays gated.
+// only it stays gated. The note as a whole still sits behind ambiguous(),
+// though: a single-remote, single-URL repo prints nothing even in these states,
+// and `entire status` is the surface that always reports them.
 func (t remoteTopology) describeDestination(b *strings.Builder) {
 	switch {
 	case t.sync.Err != "":

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -304,8 +304,10 @@ func (t remoteTopology) describeElectedTier(b *strings.Builder) {
 // unmappable protocol alike, so the note cannot tell which applied.
 func (t remoteTopology) describeIgnoredStore(b *strings.Builder) {
 	// IgnoredStore is only ever set alongside an elected remote, which is what
-	// the fallback destination named below is.
-	if t.sync.IgnoredStore == "" {
+	// the fallback destination named below is. The Remote check guards that
+	// invariant here as well: naming %q of an empty string would render
+	// `Checkpoints go to "" instead`.
+	if t.sync.IgnoredStore == "" || t.sync.Remote == "" {
 		return
 	}
 	fmt.Fprintf(b, "  A checkpoint_remote (%q) is configured but not in\n", t.sync.IgnoredStore)

--- a/cmd/entire/cli/remote_topology_test.go
+++ b/cmd/entire/cli/remote_topology_test.go
@@ -1,12 +1,19 @@
 package cli
 
 import (
-	"errors"
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
+
+// syncTopology builds a topology carrying only a checkpoint-sync result, for
+// the cases that exercise wording rather than remote layout.
+func syncTopology(info checkpointSyncInfo) remoteTopology {
+	return remoteTopology{sync: info}
+}
 
 // TestDescribeSyncRemote covers every tier the note words differently, plus
 // the fail-closed case where the election yields no name at all.
@@ -21,7 +28,7 @@ func TestDescribeSyncRemote(t *testing.T) {
 	}{
 		{
 			name: "pinned by setting says nothing further",
-			topo: remoteTopology{syncRemote: "publish", syncSource: strategy.SyncRemoteSourceConfig},
+			topo: syncTopology(checkpointSyncInfo{Remote: "publish", Source: string(strategy.SyncRemoteSourceConfig)}),
 			// A settled election is the case where "no session history" is
 			// unconditionally true: no push can displace the setting, so every
 			// push elsewhere really does leave the transcripts behind.
@@ -32,13 +39,13 @@ func TestDescribeSyncRemote(t *testing.T) {
 		},
 		{
 			name:   "captured election is settled",
-			topo:   remoteTopology{syncRemote: "fork", syncSource: strategy.SyncRemoteSourceObserved},
+			topo:   syncTopology(checkpointSyncInfo{Remote: "fork", Source: string(strategy.SyncRemoteSourceObserved)}),
 			want:   []string{`"fork"`, "push destination", "no session history", "Set strategy_options.checkpoint_push_remote"},
 			absent: []string{"right now"},
 		},
 		{
 			name: "open election says a push can move it",
-			topo: remoteTopology{syncRemote: "origin", syncSource: strategy.SyncRemoteSourceDefault},
+			topo: syncTopology(checkpointSyncInfo{Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault)}),
 			want: []string{`right now "origin"`, "entire status", "Set strategy_options.checkpoint_push_remote"},
 			// False on an open tier: the electing push is exactly the one that
 			// carries its session history to the remote it elects.
@@ -46,16 +53,33 @@ func TestDescribeSyncRemote(t *testing.T) {
 		},
 		{
 			name:   "first-remote election words like any other open one",
-			topo:   remoteTopology{syncRemote: "base", syncSource: strategy.SyncRemoteSourceFirst},
+			topo:   syncTopology(checkpointSyncInfo{Remote: "base", Source: string(strategy.SyncRemoteSourceFirst)}),
 			want:   []string{`right now "base"`, "entire status"},
 			absent: []string{"no session history"},
 		},
 		{
 			name: "fail-closed election reports sync is off",
-			topo: remoteTopology{syncErr: errors.New(`checkpoint_push_remote "gone" is not a configured git remote`)},
+			topo: syncTopology(checkpointSyncInfo{Err: `checkpoint_push_remote "gone" is not a configured git remote`}),
 			want: []string{"NOT syncing", `"gone"`},
 			// No destination may be named when the push side has none.
 			absent: []string{"sync to one remote", "single elected remote"},
+		},
+		{
+			// The destination is the store, and the pushes that reach it are
+			// the pinned ones — naming the elected remote instead was the bug:
+			// it is absent from the remote list the caller just printed.
+			name: "dedicated store names the store and its carrier",
+			topo: remoteTopology{
+				destinations: []remoteDestination{
+					{name: "colleague", pushURLs: []string{"https://github.com/them/app.git"}},
+					{name: "origin", pushURLs: []string{"https://github.com/me/app.git"}, pinned: true},
+				},
+				sync: checkpointSyncInfo{Remote: "me/checkpoints", Source: checkpointSyncSourceDedicated},
+			},
+			want: []string{`"me/checkpoints"`, "checkpoint_remote", `Pushes to "origin"`},
+			// Checkpoints do not ride a code push to any remote here, so the
+			// settled-tier sentence would be about nothing.
+			absent: []string{"no session history", "right now", "sync to one remote"},
 		},
 		{
 			// The resolver answers with no name and no error when its own git
@@ -84,5 +108,171 @@ func TestDescribeSyncRemote(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestDescribeCheckpointDestination covers the note as a whole: which claims it
+// makes, and — the part every past bug here got wrong — which it must not make
+// about a remote that carries no checkpoints.
+func TestDescribeCheckpointDestination(t *testing.T) {
+	t.Parallel()
+
+	oneURL := func(name string, pinned bool) remoteDestination {
+		return remoteDestination{name: name, pushURLs: []string{"https://github.com/x/" + name + ".git"}, pinned: pinned}
+	}
+	twoURLs := func(name string) remoteDestination {
+		return remoteDestination{name: name, pushURLs: []string{
+			"https://github.com/x/" + name + ".git",
+			"https://github.com/x/" + name + "-mirror.git",
+		}}
+	}
+
+	tests := []struct {
+		name   string
+		topo   remoteTopology
+		silent bool
+		want   []string
+		absent []string
+	}{
+		{
+			// One remote, one URL: nothing about the destination is a choice.
+			name:   "single remote says nothing",
+			topo:   remoteTopology{destinations: []remoteDestination{oneURL("origin", false)}},
+			silent: true,
+		},
+		{
+			// A checkpoint_remote in settings.local.json pins every remote, so
+			// the destination is the store no matter which remote is pushed.
+			name: "every remote pinned says nothing",
+			topo: remoteTopology{
+				destinations: []remoteDestination{oneURL("origin", true), oneURL("upstream", true)},
+				sync:         checkpointSyncInfo{Remote: "me/checkpoints", Source: checkpointSyncSourceDedicated},
+			},
+			silent: true,
+		},
+		{
+			name: "dedicated store is named instead of the elected remote",
+			topo: remoteTopology{
+				destinations: []remoteDestination{oneURL("colleague", false), oneURL("origin", true), oneURL("upstream", false)},
+				sync:         checkpointSyncInfo{Remote: "me/checkpoints", Source: checkpointSyncSourceDedicated},
+			},
+			// The count covers every remote: omitting the pinned one is how the
+			// note came to name a destination missing from its own list.
+			want: []string{"This repo has 3 remotes (colleague, origin, upstream).", `"me/checkpoints"`, `Pushes to "origin"`},
+			// Nothing may suggest a remote is the destination, and the closing
+			// advice is to set the very setting that produced this state.
+			absent: []string{`right now "origin"`, "To pin one repository"},
+		},
+		{
+			name: "ignored store is reported, not swallowed",
+			topo: remoteTopology{
+				destinations: []remoteDestination{oneURL("colleague", false), oneURL("origin", false), oneURL("upstream", false)},
+				sync: checkpointSyncInfo{
+					Remote:       "origin",
+					Source:       string(strategy.SyncRemoteSourceDefault),
+					IgnoredStore: "them/checkpoints",
+				},
+			},
+			want: []string{`"them/checkpoints"`, "not in effect", "settings.local.json", `right now "origin"`},
+			// A checkpoint_remote already exists; advising one reads as a task.
+			absent: []string{"To pin one repository"},
+		},
+		{
+			// Pushes to a remote that is not the elected one are gated out
+			// entirely, so its URLs are not a checkpoint destination at all.
+			name: "fan-out on a non-elected remote makes no URL claim",
+			topo: remoteTopology{
+				destinations:  []remoteDestination{oneURL("origin", false), twoURLs("origin2")},
+				primaryIsRefs: true,
+				sync:          checkpointSyncInfo{Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault)},
+			},
+			want:   []string{"This repo has 2 remotes (origin, origin2).", `right now "origin"`},
+			absent: []string{"pushes to 2 URLs", "first URL only"},
+		},
+		{
+			name: "fan-out on the elected remote is explained",
+			topo: remoteTopology{
+				destinations:  []remoteDestination{oneURL("colleague", false), twoURLs("origin")},
+				primaryIsRefs: true,
+				sync:          checkpointSyncInfo{Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault)},
+			},
+			want: []string{`Remote "origin" pushes to 2 URLs`, "→ https://github.com/x/origin.git", "first URL only"},
+		},
+		{
+			// Fail-closed: nothing is syncing anywhere, so a URL breakdown
+			// would be describing delivery that does not happen.
+			name: "fail-closed election suppresses every URL claim",
+			topo: remoteTopology{
+				destinations:  []remoteDestination{oneURL("colleague", false), twoURLs("origin")},
+				primaryIsRefs: true,
+				sync:          checkpointSyncInfo{Err: `checkpoint_push_remote "gone" is not a configured git remote`},
+			},
+			want:   []string{"NOT syncing", `"gone"`},
+			absent: []string{"pushes to 2 URLs", "first URL only", "To pin one repository"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var b strings.Builder
+			tt.topo.describeCheckpointDestination(&b, "Checkpoint destination: REVIEW")
+			if tt.silent {
+				if b.Len() != 0 {
+					t.Errorf("note should say nothing, got:\n%s", b.String())
+				}
+				return
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(b.String(), want) {
+					t.Errorf("note should mention %q:\n%s", want, b.String())
+				}
+			}
+			for _, absent := range tt.absent {
+				if strings.Contains(b.String(), absent) {
+					t.Errorf("note should not mention %q:\n%s", absent, b.String())
+				}
+			}
+		})
+	}
+}
+
+// TestInspectRemoteTopology_DedicatedStore drives the note against a real repo
+// rather than a hand-built topology. The literal tables above assert wording;
+// only this one proves the note and `entire status` read the same election —
+// which is the property that actually broke, because inspectRemoteTopology had
+// its own copy of it.
+//
+// Not parallel: setupTestRepo chdirs.
+func TestInspectRemoteTopology_DedicatedStore(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	// Tracked settings.json, not settings.local.json: a local declaration is
+	// "always ours" and pins every remote, which silences the note entirely.
+	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`)
+	// origin's owner matches the store's, so the store is in effect for it;
+	// the other two are owned by someone else and stay unpinned, which is what
+	// makes the destination ambiguous enough for the note to speak.
+	testutil.AddRemote(t, ".", "origin", "https://github.com/org/app.git")
+	testutil.AddRemote(t, ".", "upstream", "https://github.com/other/app.git")
+	testutil.AddRemote(t, ".", "colleague", "https://github.com/someone/app.git")
+
+	var b strings.Builder
+	inspectRemoteTopology(context.Background()).describeCheckpointDestination(&b, "Checkpoint destination: REVIEW")
+	out := b.String()
+
+	for _, want := range []string{
+		"This repo has 3 remotes (colleague, origin, upstream).",
+		`"org/checkpoints"`,
+		`Pushes to "origin"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("note should mention %q:\n%s", want, out)
+		}
+	}
+	// The regression: origin was named as the destination while being absent
+	// from the list, and checkpoints go to the store, not to origin.
+	if strings.Contains(out, `right now "origin"`) {
+		t.Errorf("note must not name a remote as the destination in dedicated mode:\n%s", out)
 	}
 }

--- a/cmd/entire/cli/remote_topology_test.go
+++ b/cmd/entire/cli/remote_topology_test.go
@@ -9,10 +9,34 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
-// syncTopology builds a topology carrying only a checkpoint-sync result, for
-// the cases that exercise wording rather than remote layout.
-func syncTopology(info checkpointSyncInfo) remoteTopology {
-	return remoteTopology{sync: info}
+// oneURL and twoURLs build the two remote shapes these tests care about: an
+// ordinary remote, and one whose pushes fan out across several repositories.
+func oneURL(name string, pinned bool) remoteDestination {
+	return remoteDestination{name: name, pushURLs: []string{"https://github.com/x/" + name + ".git"}, pinned: pinned}
+}
+
+func twoURLs(name string) remoteDestination {
+	return remoteDestination{name: name, pushURLs: []string{
+		"https://github.com/x/" + name + ".git",
+		"https://github.com/x/" + name + "-mirror.git",
+	}}
+}
+
+// assertNote checks the phrases a note must and must not contain, reporting the
+// whole output on failure — the wording is the behaviour under test, so the
+// surrounding lines are what make a failure diagnosable.
+func assertNote(t *testing.T, out string, want, absent []string) {
+	t.Helper()
+	for _, w := range want {
+		if !strings.Contains(out, w) {
+			t.Errorf("note should mention %q:\n%s", w, out)
+		}
+	}
+	for _, a := range absent {
+		if strings.Contains(out, a) {
+			t.Errorf("note should not mention %q:\n%s", a, out)
+		}
+	}
 }
 
 // TestDescribeSyncRemote covers every tier the note words differently, plus
@@ -28,7 +52,7 @@ func TestDescribeSyncRemote(t *testing.T) {
 	}{
 		{
 			name: "pinned by setting says nothing further",
-			topo: syncTopology(checkpointSyncInfo{Remote: "publish", Source: string(strategy.SyncRemoteSourceConfig)}),
+			topo: remoteTopology{sync: checkpointSyncInfo{Remote: "publish", Source: string(strategy.SyncRemoteSourceConfig)}},
 			// A settled election is the case where "no session history" is
 			// unconditionally true: no push can displace the setting, so every
 			// push elsewhere really does leave the transcripts behind.
@@ -39,13 +63,13 @@ func TestDescribeSyncRemote(t *testing.T) {
 		},
 		{
 			name:   "captured election is settled",
-			topo:   syncTopology(checkpointSyncInfo{Remote: "fork", Source: string(strategy.SyncRemoteSourceObserved)}),
+			topo:   remoteTopology{sync: checkpointSyncInfo{Remote: "fork", Source: string(strategy.SyncRemoteSourceObserved)}},
 			want:   []string{`"fork"`, "push destination", "no session history", "Set strategy_options.checkpoint_push_remote"},
 			absent: []string{"right now"},
 		},
 		{
 			name: "open election says a push can move it",
-			topo: syncTopology(checkpointSyncInfo{Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault)}),
+			topo: remoteTopology{sync: checkpointSyncInfo{Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault)}},
 			want: []string{`right now "origin"`, "entire status", "Set strategy_options.checkpoint_push_remote"},
 			// False on an open tier: the electing push is exactly the one that
 			// carries its session history to the remote it elects.
@@ -53,13 +77,13 @@ func TestDescribeSyncRemote(t *testing.T) {
 		},
 		{
 			name:   "first-remote election words like any other open one",
-			topo:   syncTopology(checkpointSyncInfo{Remote: "base", Source: string(strategy.SyncRemoteSourceFirst)}),
+			topo:   remoteTopology{sync: checkpointSyncInfo{Remote: "base", Source: string(strategy.SyncRemoteSourceFirst)}},
 			want:   []string{`right now "base"`, "entire status"},
 			absent: []string{"no session history"},
 		},
 		{
 			name: "fail-closed election reports sync is off",
-			topo: syncTopology(checkpointSyncInfo{Err: `checkpoint_push_remote "gone" is not a configured git remote`}),
+			topo: remoteTopology{sync: checkpointSyncInfo{Err: `checkpoint_push_remote "gone" is not a configured git remote`}},
 			want: []string{"NOT syncing", `"gone"`},
 			// No destination may be named when the push side has none.
 			absent: []string{"sync to one remote", "single elected remote"},
@@ -97,16 +121,7 @@ func TestDescribeSyncRemote(t *testing.T) {
 			t.Parallel()
 			var b strings.Builder
 			tt.topo.describeSyncRemote(&b)
-			for _, want := range tt.want {
-				if !strings.Contains(b.String(), want) {
-					t.Errorf("note should mention %q:\n%s", want, b.String())
-				}
-			}
-			for _, absent := range tt.absent {
-				if strings.Contains(b.String(), absent) {
-					t.Errorf("note should not mention %q:\n%s", absent, b.String())
-				}
-			}
+			assertNote(t, b.String(), tt.want, tt.absent)
 		})
 	}
 }
@@ -116,16 +131,6 @@ func TestDescribeSyncRemote(t *testing.T) {
 // about a remote that carries no checkpoints.
 func TestDescribeCheckpointDestination(t *testing.T) {
 	t.Parallel()
-
-	oneURL := func(name string, pinned bool) remoteDestination {
-		return remoteDestination{name: name, pushURLs: []string{"https://github.com/x/" + name + ".git"}, pinned: pinned}
-	}
-	twoURLs := func(name string) remoteDestination {
-		return remoteDestination{name: name, pushURLs: []string{
-			"https://github.com/x/" + name + ".git",
-			"https://github.com/x/" + name + "-mirror.git",
-		}}
-	}
 
 	tests := []struct {
 		name   string
@@ -173,7 +178,8 @@ func TestDescribeCheckpointDestination(t *testing.T) {
 					IgnoredStore: "them/checkpoints",
 				},
 			},
-			want: []string{`"them/checkpoints"`, "not in effect", "settings.local.json", `right now "origin"`},
+			// Phrases chosen to survive the paragraph's line wrapping.
+			want: []string{`"them/checkpoints"`, "configured but not in", "settings.local.json", `right now "origin"`},
 			// A checkpoint_remote already exists; advising one reads as a task.
 			absent: []string{"To pin one repository"},
 		},
@@ -223,16 +229,7 @@ func TestDescribeCheckpointDestination(t *testing.T) {
 				}
 				return
 			}
-			for _, want := range tt.want {
-				if !strings.Contains(b.String(), want) {
-					t.Errorf("note should mention %q:\n%s", want, b.String())
-				}
-			}
-			for _, absent := range tt.absent {
-				if strings.Contains(b.String(), absent) {
-					t.Errorf("note should not mention %q:\n%s", absent, b.String())
-				}
-			}
+			assertNote(t, b.String(), tt.want, tt.absent)
 		})
 	}
 }
@@ -261,18 +258,9 @@ func TestInspectRemoteTopology_DedicatedStore(t *testing.T) {
 	inspectRemoteTopology(context.Background()).describeCheckpointDestination(&b, "Checkpoint destination: REVIEW")
 	out := b.String()
 
-	for _, want := range []string{
-		"This repo has 3 remotes (colleague, origin, upstream).",
-		`"org/checkpoints"`,
-		`Pushes to "origin"`,
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("note should mention %q:\n%s", want, out)
-		}
-	}
-	// The regression: origin was named as the destination while being absent
-	// from the list, and checkpoints go to the store, not to origin.
-	if strings.Contains(out, `right now "origin"`) {
-		t.Errorf("note must not name a remote as the destination in dedicated mode:\n%s", out)
-	}
+	assertNote(t, out,
+		[]string{"This repo has 3 remotes (colleague, origin, upstream).", `"org/checkpoints"`, `Pushes to "origin"`},
+		// The regression: origin was named as the destination while being
+		// absent from the list, and checkpoints go to the store, not to origin.
+		[]string{`right now "origin"`})
 }

--- a/cmd/entire/cli/remote_topology_test.go
+++ b/cmd/entire/cli/remote_topology_test.go
@@ -9,34 +9,10 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
-// oneURL and twoURLs build the two remote shapes these tests care about: an
-// ordinary remote, and one whose pushes fan out across several repositories.
-func oneURL(name string, pinned bool) remoteDestination {
-	return remoteDestination{name: name, pushURLs: []string{"https://github.com/x/" + name + ".git"}, pinned: pinned}
-}
-
-func twoURLs(name string) remoteDestination {
-	return remoteDestination{name: name, pushURLs: []string{
-		"https://github.com/x/" + name + ".git",
-		"https://github.com/x/" + name + "-mirror.git",
-	}}
-}
-
-// assertNote checks the phrases a note must and must not contain, reporting the
-// whole output on failure — the wording is the behaviour under test, so the
-// surrounding lines are what make a failure diagnosable.
-func assertNote(t *testing.T, out string, want, absent []string) {
-	t.Helper()
-	for _, w := range want {
-		if !strings.Contains(out, w) {
-			t.Errorf("note should mention %q:\n%s", w, out)
-		}
-	}
-	for _, a := range absent {
-		if strings.Contains(out, a) {
-			t.Errorf("note should not mention %q:\n%s", a, out)
-		}
-	}
+// syncTopology builds a topology carrying only a checkpoint-sync result, for
+// the cases that exercise wording rather than remote layout.
+func syncTopology(info checkpointSyncInfo) remoteTopology {
+	return remoteTopology{sync: info}
 }
 
 // TestDescribeSyncRemote covers every tier the note words differently, plus
@@ -52,7 +28,7 @@ func TestDescribeSyncRemote(t *testing.T) {
 	}{
 		{
 			name: "pinned by setting says nothing further",
-			topo: remoteTopology{sync: checkpointSyncInfo{Remote: "publish", Source: string(strategy.SyncRemoteSourceConfig)}},
+			topo: syncTopology(checkpointSyncInfo{Remote: "publish", Source: string(strategy.SyncRemoteSourceConfig)}),
 			// A settled election is the case where "no session history" is
 			// unconditionally true: no push can displace the setting, so every
 			// push elsewhere really does leave the transcripts behind.
@@ -63,13 +39,13 @@ func TestDescribeSyncRemote(t *testing.T) {
 		},
 		{
 			name:   "captured election is settled",
-			topo:   remoteTopology{sync: checkpointSyncInfo{Remote: "fork", Source: string(strategy.SyncRemoteSourceObserved)}},
+			topo:   syncTopology(checkpointSyncInfo{Remote: "fork", Source: string(strategy.SyncRemoteSourceObserved)}),
 			want:   []string{`"fork"`, "push destination", "no session history", "Set strategy_options.checkpoint_push_remote"},
 			absent: []string{"right now"},
 		},
 		{
 			name: "open election says a push can move it",
-			topo: remoteTopology{sync: checkpointSyncInfo{Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault)}},
+			topo: syncTopology(checkpointSyncInfo{Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault)}),
 			want: []string{`right now "origin"`, "entire status", "Set strategy_options.checkpoint_push_remote"},
 			// False on an open tier: the electing push is exactly the one that
 			// carries its session history to the remote it elects.
@@ -77,13 +53,13 @@ func TestDescribeSyncRemote(t *testing.T) {
 		},
 		{
 			name:   "first-remote election words like any other open one",
-			topo:   remoteTopology{sync: checkpointSyncInfo{Remote: "base", Source: string(strategy.SyncRemoteSourceFirst)}},
+			topo:   syncTopology(checkpointSyncInfo{Remote: "base", Source: string(strategy.SyncRemoteSourceFirst)}),
 			want:   []string{`right now "base"`, "entire status"},
 			absent: []string{"no session history"},
 		},
 		{
 			name: "fail-closed election reports sync is off",
-			topo: remoteTopology{sync: checkpointSyncInfo{Err: `checkpoint_push_remote "gone" is not a configured git remote`}},
+			topo: syncTopology(checkpointSyncInfo{Err: `checkpoint_push_remote "gone" is not a configured git remote`}),
 			want: []string{"NOT syncing", `"gone"`},
 			// No destination may be named when the push side has none.
 			absent: []string{"sync to one remote", "single elected remote"},
@@ -106,18 +82,6 @@ func TestDescribeSyncRemote(t *testing.T) {
 			absent: []string{"no session history", "right now", "sync to one remote"},
 		},
 		{
-			// Reachable when the per-remote probes failed transiently while the
-			// election's own probe succeeded. The pushes do reach the store, so
-			// the note drops the clause instead of naming none of them.
-			name: "dedicated store with no pinned remote drops the carrier clause",
-			topo: remoteTopology{
-				destinations: []remoteDestination{oneURL("colleague", false), oneURL("upstream", false)},
-				sync:         checkpointSyncInfo{Remote: "me/checkpoints", Source: checkpointSyncSourceDedicated},
-			},
-			want:   []string{`"me/checkpoints"`, "not to any of these remotes"},
-			absent: []string{"Pushes to", "no remote"},
-		},
-		{
 			// The resolver answers with no name and no error when its own git
 			// read fails transiently. Staying silent would leave the caller's
 			// remote count with nothing explaining what happens to it.
@@ -133,7 +97,16 @@ func TestDescribeSyncRemote(t *testing.T) {
 			t.Parallel()
 			var b strings.Builder
 			tt.topo.describeSyncRemote(&b)
-			assertNote(t, b.String(), tt.want, tt.absent)
+			for _, want := range tt.want {
+				if !strings.Contains(b.String(), want) {
+					t.Errorf("note should mention %q:\n%s", want, b.String())
+				}
+			}
+			for _, absent := range tt.absent {
+				if strings.Contains(b.String(), absent) {
+					t.Errorf("note should not mention %q:\n%s", absent, b.String())
+				}
+			}
 		})
 	}
 }
@@ -143,6 +116,16 @@ func TestDescribeSyncRemote(t *testing.T) {
 // about a remote that carries no checkpoints.
 func TestDescribeCheckpointDestination(t *testing.T) {
 	t.Parallel()
+
+	oneURL := func(name string, pinned bool) remoteDestination {
+		return remoteDestination{name: name, pushURLs: []string{"https://github.com/x/" + name + ".git"}, pinned: pinned}
+	}
+	twoURLs := func(name string) remoteDestination {
+		return remoteDestination{name: name, pushURLs: []string{
+			"https://github.com/x/" + name + ".git",
+			"https://github.com/x/" + name + "-mirror.git",
+		}}
+	}
 
 	tests := []struct {
 		name   string
@@ -190,8 +173,7 @@ func TestDescribeCheckpointDestination(t *testing.T) {
 					IgnoredStore: "them/checkpoints",
 				},
 			},
-			// Phrases chosen to survive the paragraph's line wrapping.
-			want: []string{`"them/checkpoints"`, "configured but not in", "settings.local.json", `right now "origin"`},
+			want: []string{`"them/checkpoints"`, "not in effect", "settings.local.json", `right now "origin"`},
 			// A checkpoint_remote already exists; advising one reads as a task.
 			absent: []string{"To pin one repository"},
 		},
@@ -241,7 +223,16 @@ func TestDescribeCheckpointDestination(t *testing.T) {
 				}
 				return
 			}
-			assertNote(t, b.String(), tt.want, tt.absent)
+			for _, want := range tt.want {
+				if !strings.Contains(b.String(), want) {
+					t.Errorf("note should mention %q:\n%s", want, b.String())
+				}
+			}
+			for _, absent := range tt.absent {
+				if strings.Contains(b.String(), absent) {
+					t.Errorf("note should not mention %q:\n%s", absent, b.String())
+				}
+			}
 		})
 	}
 }
@@ -270,9 +261,18 @@ func TestInspectRemoteTopology_DedicatedStore(t *testing.T) {
 	inspectRemoteTopology(context.Background()).describeCheckpointDestination(&b, "Checkpoint destination: REVIEW")
 	out := b.String()
 
-	assertNote(t, out,
-		[]string{"This repo has 3 remotes (colleague, origin, upstream).", `"org/checkpoints"`, `Pushes to "origin"`},
-		// The regression: origin was named as the destination while being
-		// absent from the list, and checkpoints go to the store, not to origin.
-		[]string{`right now "origin"`})
+	for _, want := range []string{
+		"This repo has 3 remotes (colleague, origin, upstream).",
+		`"org/checkpoints"`,
+		`Pushes to "origin"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("note should mention %q:\n%s", want, out)
+		}
+	}
+	// The regression: origin was named as the destination while being absent
+	// from the list, and checkpoints go to the store, not to origin.
+	if strings.Contains(out, `right now "origin"`) {
+		t.Errorf("note must not name a remote as the destination in dedicated mode:\n%s", out)
+	}
 }

--- a/cmd/entire/cli/remote_topology_test.go
+++ b/cmd/entire/cli/remote_topology_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+)
+
+// TestDescribeSyncRemote covers every tier the note words differently, plus
+// the fail-closed case where the election yields no name at all.
+func TestDescribeSyncRemote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		topo   remoteTopology
+		want   []string
+		absent []string
+	}{
+		{
+			name: "pinned by setting says nothing further",
+			topo: remoteTopology{syncRemote: "publish", syncSource: strategy.SyncRemoteSourceConfig},
+			want: []string{`"publish"`, "checkpoint_push_remote"},
+			// The decision is already made; telling the user to set the key
+			// they just set reads as a warning that something is unfinished.
+			absent: []string{"Set strategy_options", "right now"},
+		},
+		{
+			name:   "captured election is settled",
+			topo:   remoteTopology{syncRemote: "fork", syncSource: strategy.SyncRemoteSourceObserved},
+			want:   []string{`"fork"`, "push destination", "Set strategy_options.checkpoint_push_remote"},
+			absent: []string{"right now"},
+		},
+		{
+			name:   "open election says a push can move it",
+			topo:   remoteTopology{syncRemote: "origin", syncSource: strategy.SyncRemoteSourceDefault},
+			want:   []string{`right now "origin"`, "entire status", "Set strategy_options.checkpoint_push_remote"},
+			absent: []string{"no session history"},
+		},
+		{
+			name: "fail-closed election reports sync is off",
+			topo: remoteTopology{syncErr: errors.New(`checkpoint_push_remote "gone" is not a configured git remote`)},
+			want: []string{"NOT syncing", `"gone"`},
+			// No destination may be named when the push side has none.
+			absent: []string{"sync to one remote"},
+		},
+		{
+			name:   "no remotes at all stays silent",
+			topo:   remoteTopology{},
+			absent: []string{"Checkpoints"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var b strings.Builder
+			tt.topo.describeSyncRemote(&b)
+			for _, want := range tt.want {
+				if !strings.Contains(b.String(), want) {
+					t.Errorf("note should mention %q:\n%s", want, b.String())
+				}
+			}
+			for _, absent := range tt.absent {
+				if strings.Contains(b.String(), absent) {
+					t.Errorf("note should not mention %q:\n%s", absent, b.String())
+				}
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/remote_topology_test.go
+++ b/cmd/entire/cli/remote_topology_test.go
@@ -106,6 +106,18 @@ func TestDescribeSyncRemote(t *testing.T) {
 			absent: []string{"no session history", "right now", "sync to one remote"},
 		},
 		{
+			// Reachable when the per-remote probes failed transiently while the
+			// election's own probe succeeded. The pushes do reach the store, so
+			// the note drops the clause instead of naming none of them.
+			name: "dedicated store with no pinned remote drops the carrier clause",
+			topo: remoteTopology{
+				destinations: []remoteDestination{oneURL("colleague", false), oneURL("upstream", false)},
+				sync:         checkpointSyncInfo{Remote: "me/checkpoints", Source: checkpointSyncSourceDedicated},
+			},
+			want:   []string{`"me/checkpoints"`, "not to any of these remotes"},
+			absent: []string{"Pushes to", "no remote"},
+		},
+		{
 			// The resolver answers with no name and no error when its own git
 			// read fails transiently. Staying silent would leave the caller's
 			// remote count with nothing explaining what happens to it.

--- a/cmd/entire/cli/remote_topology_test.go
+++ b/cmd/entire/cli/remote_topology_test.go
@@ -22,7 +22,10 @@ func TestDescribeSyncRemote(t *testing.T) {
 		{
 			name: "pinned by setting says nothing further",
 			topo: remoteTopology{syncRemote: "publish", syncSource: strategy.SyncRemoteSourceConfig},
-			want: []string{`"publish"`, "checkpoint_push_remote"},
+			// A settled election is the case where "no session history" is
+			// unconditionally true: no push can displace the setting, so every
+			// push elsewhere really does leave the transcripts behind.
+			want: []string{`"publish"`, "checkpoint_push_remote", "no session history"},
 			// The decision is already made; telling the user to set the key
 			// they just set reads as a warning that something is unfinished.
 			absent: []string{"Set strategy_options", "right now"},
@@ -30,13 +33,21 @@ func TestDescribeSyncRemote(t *testing.T) {
 		{
 			name:   "captured election is settled",
 			topo:   remoteTopology{syncRemote: "fork", syncSource: strategy.SyncRemoteSourceObserved},
-			want:   []string{`"fork"`, "push destination", "Set strategy_options.checkpoint_push_remote"},
+			want:   []string{`"fork"`, "push destination", "no session history", "Set strategy_options.checkpoint_push_remote"},
 			absent: []string{"right now"},
 		},
 		{
-			name:   "open election says a push can move it",
-			topo:   remoteTopology{syncRemote: "origin", syncSource: strategy.SyncRemoteSourceDefault},
-			want:   []string{`right now "origin"`, "entire status", "Set strategy_options.checkpoint_push_remote"},
+			name: "open election says a push can move it",
+			topo: remoteTopology{syncRemote: "origin", syncSource: strategy.SyncRemoteSourceDefault},
+			want: []string{`right now "origin"`, "entire status", "Set strategy_options.checkpoint_push_remote"},
+			// False on an open tier: the electing push is exactly the one that
+			// carries its session history to the remote it elects.
+			absent: []string{"no session history"},
+		},
+		{
+			name:   "first-remote election words like any other open one",
+			topo:   remoteTopology{syncRemote: "base", syncSource: strategy.SyncRemoteSourceFirst},
+			want:   []string{`right now "base"`, "entire status"},
 			absent: []string{"no session history"},
 		},
 		{
@@ -44,12 +55,16 @@ func TestDescribeSyncRemote(t *testing.T) {
 			topo: remoteTopology{syncErr: errors.New(`checkpoint_push_remote "gone" is not a configured git remote`)},
 			want: []string{"NOT syncing", `"gone"`},
 			// No destination may be named when the push side has none.
-			absent: []string{"sync to one remote"},
+			absent: []string{"sync to one remote", "single elected remote"},
 		},
 		{
-			name:   "no remotes at all stays silent",
+			// The resolver answers with no name and no error when its own git
+			// read fails transiently. Staying silent would leave the caller's
+			// remote count with nothing explaining what happens to it.
+			name:   "unreadable election still says how the destination works",
 			topo:   remoteTopology{},
-			absent: []string{"Checkpoints"},
+			want:   []string{"single elected remote", "entire status"},
+			absent: []string{"NOT syncing"},
 		},
 	}
 

--- a/cmd/entire/cli/remote_topology_test.go
+++ b/cmd/entire/cli/remote_topology_test.go
@@ -9,123 +9,30 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
-// syncTopology builds a topology carrying only a checkpoint-sync result, for
-// the cases that exercise wording rather than remote layout.
-func syncTopology(info checkpointSyncInfo) remoteTopology {
-	return remoteTopology{sync: info}
+// oneURL and twoURLs build the two remote shapes these tests care about: an
+// ordinary remote, and one whose pushes fan out across several repositories.
+func oneURL(name string, pinned bool) remoteDestination {
+	return remoteDestination{name: name, pushURLs: []string{"https://github.com/x/" + name + ".git"}, pinned: pinned}
 }
 
-// TestDescribeSyncRemote covers every tier the note words differently, plus
-// the fail-closed case where the election yields no name at all.
-func TestDescribeSyncRemote(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name   string
-		topo   remoteTopology
-		want   []string
-		absent []string
-	}{
-		{
-			name: "pinned by setting says nothing further",
-			topo: syncTopology(checkpointSyncInfo{Remote: "publish", Source: string(strategy.SyncRemoteSourceConfig)}),
-			// A settled election is the case where "no session history" is
-			// unconditionally true: no push can displace the setting, so every
-			// push elsewhere really does leave the transcripts behind.
-			want: []string{`"publish"`, "checkpoint_push_remote", "no session history"},
-			// The decision is already made; telling the user to set the key
-			// they just set reads as a warning that something is unfinished.
-			absent: []string{"Set strategy_options", "right now"},
-		},
-		{
-			name:   "captured election is settled",
-			topo:   syncTopology(checkpointSyncInfo{Remote: "fork", Source: string(strategy.SyncRemoteSourceObserved)}),
-			want:   []string{`"fork"`, "push destination", "no session history", "Set strategy_options.checkpoint_push_remote"},
-			absent: []string{"right now"},
-		},
-		{
-			name: "open election says a push can move it",
-			topo: syncTopology(checkpointSyncInfo{Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault)}),
-			want: []string{`right now "origin"`, "entire status", "Set strategy_options.checkpoint_push_remote"},
-			// False on an open tier: the electing push is exactly the one that
-			// carries its session history to the remote it elects.
-			absent: []string{"no session history"},
-		},
-		{
-			name:   "first-remote election words like any other open one",
-			topo:   syncTopology(checkpointSyncInfo{Remote: "base", Source: string(strategy.SyncRemoteSourceFirst)}),
-			want:   []string{`right now "base"`, "entire status"},
-			absent: []string{"no session history"},
-		},
-		{
-			name: "fail-closed election reports sync is off",
-			topo: syncTopology(checkpointSyncInfo{Err: `checkpoint_push_remote "gone" is not a configured git remote`}),
-			want: []string{"NOT syncing", `"gone"`},
-			// No destination may be named when the push side has none.
-			absent: []string{"sync to one remote", "single elected remote"},
-		},
-		{
-			// The destination is the store, and the pushes that reach it are
-			// the pinned ones — naming the elected remote instead was the bug:
-			// it is absent from the remote list the caller just printed.
-			name: "dedicated store names the store and its carrier",
-			topo: remoteTopology{
-				destinations: []remoteDestination{
-					{name: "colleague", pushURLs: []string{"https://github.com/them/app.git"}},
-					{name: "origin", pushURLs: []string{"https://github.com/me/app.git"}, pinned: true},
-				},
-				sync: checkpointSyncInfo{Remote: "me/checkpoints", Source: checkpointSyncSourceDedicated},
-			},
-			want: []string{`"me/checkpoints"`, "checkpoint_remote", `Pushes to "origin"`},
-			// Checkpoints do not ride a code push to any remote here, so the
-			// settled-tier sentence would be about nothing.
-			absent: []string{"no session history", "right now", "sync to one remote"},
-		},
-		{
-			// The resolver answers with no name and no error when its own git
-			// read fails transiently. Staying silent would leave the caller's
-			// remote count with nothing explaining what happens to it.
-			name:   "unreadable election still says how the destination works",
-			topo:   remoteTopology{},
-			want:   []string{"single elected remote", "entire status"},
-			absent: []string{"NOT syncing"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			var b strings.Builder
-			tt.topo.describeSyncRemote(&b)
-			for _, want := range tt.want {
-				if !strings.Contains(b.String(), want) {
-					t.Errorf("note should mention %q:\n%s", want, b.String())
-				}
-			}
-			for _, absent := range tt.absent {
-				if strings.Contains(b.String(), absent) {
-					t.Errorf("note should not mention %q:\n%s", absent, b.String())
-				}
-			}
-		})
-	}
+func twoURLs(name string) remoteDestination {
+	return remoteDestination{name: name, pushURLs: []string{
+		"https://github.com/x/" + name + ".git",
+		"https://github.com/x/" + name + "-mirror.git",
+	}}
 }
 
-// TestDescribeCheckpointDestination covers the note as a whole: which claims it
-// makes, and — the part every past bug here got wrong — which it must not make
-// about a remote that carries no checkpoints.
+func electedSync(name string, source strategy.CheckpointSyncRemoteSource) checkpointSyncInfo {
+	return checkpointSyncInfo{Remote: name, Source: string(source)}
+}
+
+const noteHeader = "Checkpoint destination: REVIEW"
+
+// TestDescribeCheckpointDestination covers the note as users see it: which
+// claims it makes, and — the part every past bug here got wrong — which it must
+// not make about a remote that carries no checkpoints.
 func TestDescribeCheckpointDestination(t *testing.T) {
 	t.Parallel()
-
-	oneURL := func(name string, pinned bool) remoteDestination {
-		return remoteDestination{name: name, pushURLs: []string{"https://github.com/x/" + name + ".git"}, pinned: pinned}
-	}
-	twoURLs := func(name string) remoteDestination {
-		return remoteDestination{name: name, pushURLs: []string{
-			"https://github.com/x/" + name + ".git",
-			"https://github.com/x/" + name + "-mirror.git",
-		}}
-	}
 
 	tests := []struct {
 		name   string
@@ -137,18 +44,47 @@ func TestDescribeCheckpointDestination(t *testing.T) {
 		{
 			// One remote, one URL: nothing about the destination is a choice.
 			name:   "single remote says nothing",
-			topo:   remoteTopology{destinations: []remoteDestination{oneURL("origin", false)}},
+			topo:   remoteTopology{destinations: []remoteDestination{oneURL("origin", false)}, sync: electedSync("origin", strategy.SyncRemoteSourceDefault)},
 			silent: true,
 		},
 		{
-			// A checkpoint_remote in settings.local.json pins every remote, so
-			// the destination is the store no matter which remote is pushed.
+			// A checkpoint_remote in settings.local.json applies to every
+			// remote, so the destination is the store whichever one is pushed.
 			name: "every remote pinned says nothing",
 			topo: remoteTopology{
 				destinations: []remoteDestination{oneURL("origin", true), oneURL("upstream", true)},
 				sync:         checkpointSyncInfo{Remote: "me/checkpoints", Source: checkpointSyncSourceDedicated},
 			},
 			silent: true,
+		},
+		{
+			name: "open election says a push can still move it",
+			topo: remoteTopology{
+				destinations: []remoteDestination{oneURL("colleague", false), oneURL("origin", false)},
+				sync:         electedSync("origin", strategy.SyncRemoteSourceDefault),
+			},
+			want: []string{"This repo has 2 remotes (colleague, origin).", `right now "origin"`, "To pin one repository"},
+			// False on an open tier: the electing push is exactly the one that
+			// carries its history to the remote it elects.
+			absent: []string{"no session history"},
+		},
+		{
+			name: "pinned by setting says nothing further",
+			topo: remoteTopology{
+				destinations: []remoteDestination{oneURL("colleague", false), oneURL("publish", false)},
+				sync:         electedSync("publish", strategy.SyncRemoteSourceConfig),
+			},
+			want:   []string{`"publish"`, "checkpoint_push_remote", "no session history"},
+			absent: []string{"right now", "Set strategy_options"},
+		},
+		{
+			name: "captured election is settled",
+			topo: remoteTopology{
+				destinations: []remoteDestination{oneURL("colleague", false), oneURL("fork", false)},
+				sync:         electedSync("fork", strategy.SyncRemoteSourceObserved),
+			},
+			want:   []string{`"fork"`, "push destination", "no session history", "Set strategy_options.checkpoint_push_remote"},
+			absent: []string{"right now"},
 		},
 		{
 			name: "dedicated store is named instead of the elected remote",
@@ -161,19 +97,31 @@ func TestDescribeCheckpointDestination(t *testing.T) {
 			want: []string{"This repo has 3 remotes (colleague, origin, upstream).", `"me/checkpoints"`, `Pushes to "origin"`},
 			// Nothing may suggest a remote is the destination, and the closing
 			// advice is to set the very setting that produced this state.
-			absent: []string{`right now "origin"`, "To pin one repository"},
+			absent: []string{`right now "origin"`, "To pin one repository", "no session history"},
+		},
+		{
+			// Narrow, but the sentence must not read "no remote carries them"
+			// when a push is in fact reaching the store.
+			name: "dedicated store with no carrier defers instead of denying",
+			topo: remoteTopology{
+				destinations: []remoteDestination{oneURL("colleague", false), oneURL("upstream", false)},
+				sync:         checkpointSyncInfo{Remote: "me/checkpoints", Source: checkpointSyncSourceDedicated},
+			},
+			want:   []string{`"me/checkpoints"`, "whether your pushes are reaching it"},
+			absent: []string{"no remote", "Pushes to"},
 		},
 		{
 			name: "ignored store is reported, not swallowed",
 			topo: remoteTopology{
-				destinations: []remoteDestination{oneURL("colleague", false), oneURL("origin", false), oneURL("upstream", false)},
+				destinations: []remoteDestination{oneURL("colleague", false), oneURL("origin", false)},
 				sync: checkpointSyncInfo{
 					Remote:       "origin",
 					Source:       string(strategy.SyncRemoteSourceDefault),
 					IgnoredStore: "them/checkpoints",
 				},
 			},
-			want: []string{`"them/checkpoints"`, "not in effect", "settings.local.json", `right now "origin"`},
+			// Phrases chosen to survive the paragraph's line wrapping.
+			want: []string{`"them/checkpoints"`, "configured but not in", "settings.local.json", `right now "origin"`},
 			// A checkpoint_remote already exists; advising one reads as a task.
 			absent: []string{"To pin one repository"},
 		},
@@ -184,7 +132,7 @@ func TestDescribeCheckpointDestination(t *testing.T) {
 			topo: remoteTopology{
 				destinations:  []remoteDestination{oneURL("origin", false), twoURLs("origin2")},
 				primaryIsRefs: true,
-				sync:          checkpointSyncInfo{Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault)},
+				sync:          electedSync("origin", strategy.SyncRemoteSourceDefault),
 			},
 			want:   []string{"This repo has 2 remotes (origin, origin2).", `right now "origin"`},
 			absent: []string{"pushes to 2 URLs", "first URL only"},
@@ -194,13 +142,22 @@ func TestDescribeCheckpointDestination(t *testing.T) {
 			topo: remoteTopology{
 				destinations:  []remoteDestination{oneURL("colleague", false), twoURLs("origin")},
 				primaryIsRefs: true,
-				sync:          checkpointSyncInfo{Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault)},
+				sync:          electedSync("origin", strategy.SyncRemoteSourceDefault),
 			},
 			want: []string{`Remote "origin" pushes to 2 URLs`, "→ https://github.com/x/origin.git", "first URL only"},
 		},
 		{
-			// Fail-closed: nothing is syncing anywhere, so a URL breakdown
-			// would be describing delivery that does not happen.
+			name: "git-branch backend explains the fan-out differently",
+			topo: remoteTopology{
+				destinations: []remoteDestination{oneURL("colleague", false), twoURLs("origin")},
+				sync:         electedSync("origin", strategy.SyncRemoteSourceDefault),
+			},
+			want:   []string{"pushed to every URL", "fall permanently out of date"},
+			absent: []string{"first URL only"},
+		},
+		{
+			// The state a broken checkpoint_push_remote leaves: nothing is
+			// syncing anywhere, so no URL breakdown can be true.
 			name: "fail-closed election suppresses every URL claim",
 			topo: remoteTopology{
 				destinations:  []remoteDestination{oneURL("colleague", false), twoURLs("origin")},
@@ -210,55 +167,170 @@ func TestDescribeCheckpointDestination(t *testing.T) {
 			want:   []string{"NOT syncing", `"gone"`},
 			absent: []string{"pushes to 2 URLs", "first URL only", "To pin one repository"},
 		},
+		{
+			// A lone fanning-out remote makes the note speak, and a fail-closed
+			// election is the fact it must lead with — this printed a bare
+			// header once, because the warning sat behind a remote-count gate.
+			name: "fail-closed election speaks even with one remote",
+			topo: remoteTopology{
+				destinations:  []remoteDestination{twoURLs("origin")},
+				primaryIsRefs: true,
+				sync:          checkpointSyncInfo{Err: `checkpoint_push_remote "gone" is not a configured git remote`},
+			},
+			want:   []string{"NOT syncing", `"gone"`},
+			absent: []string{"This repo has", "pushes to 2 URLs"},
+		},
+		{
+			// Same bare-header regression from the other side: a store in
+			// effect plus one unpinned remote that fans out.
+			name: "dedicated store speaks even with one unpinned remote",
+			topo: remoteTopology{
+				destinations:  []remoteDestination{oneURL("origin", true), twoURLs("upstream")},
+				primaryIsRefs: true,
+				sync:          checkpointSyncInfo{Remote: "me/checkpoints", Source: checkpointSyncSourceDedicated},
+			},
+			want:   []string{`"me/checkpoints"`, `Pushes to "origin"`},
+			absent: []string{"This repo has", "pushes to 2 URLs"},
+		},
+		{
+			// The resolver answers with no name and no error when its own git
+			// read fails transiently. Staying silent would leave the remote
+			// count with nothing explaining what happens to it.
+			name: "unreadable election still says how the destination works",
+			topo: remoteTopology{
+				destinations: []remoteDestination{oneURL("colleague", false), oneURL("origin", false)},
+			},
+			want:   []string{"single elected remote", "entire status"},
+			absent: []string{"NOT syncing"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var b strings.Builder
-			tt.topo.describeCheckpointDestination(&b, "Checkpoint destination: REVIEW")
+			tt.topo.describeCheckpointDestination(&b, noteHeader)
+			out := b.String()
 			if tt.silent {
-				if b.Len() != 0 {
-					t.Errorf("note should say nothing, got:\n%s", b.String())
+				if out != "" {
+					t.Errorf("note should say nothing, got:\n%s", out)
 				}
 				return
 			}
+			if !strings.Contains(out, noteHeader) {
+				t.Errorf("note has a body but no header:\n%s", out)
+			}
 			for _, want := range tt.want {
-				if !strings.Contains(b.String(), want) {
-					t.Errorf("note should mention %q:\n%s", want, b.String())
+				if !strings.Contains(out, want) {
+					t.Errorf("note should mention %q:\n%s", want, out)
 				}
 			}
 			for _, absent := range tt.absent {
-				if strings.Contains(b.String(), absent) {
-					t.Errorf("note should not mention %q:\n%s", absent, b.String())
+				if strings.Contains(out, absent) {
+					t.Errorf("note should not mention %q:\n%s", absent, out)
 				}
 			}
 		})
 	}
 }
 
+// TestNoteNeverPrintsABareHeader is the invariant behind the shape of this note:
+// the header claims the repo needs explaining, so a topology that reaches it must
+// produce an explanation. It was violated by gating each explaining branch on a
+// condition narrower than the header's own, which no per-state assertion catches
+// — every one of those states looked right on its own.
+func TestNoteNeverPrintsABareHeader(t *testing.T) {
+	t.Parallel()
+
+	syncStates := map[string]checkpointSyncInfo{
+		"config":     electedSync("origin", strategy.SyncRemoteSourceConfig),
+		"observed":   electedSync("origin", strategy.SyncRemoteSourceObserved),
+		"default":    electedSync("origin", strategy.SyncRemoteSourceDefault),
+		"sole":       electedSync("origin", strategy.SyncRemoteSourceSole),
+		"first":      electedSync("origin", strategy.SyncRemoteSourceFirst),
+		"unresolved": {},
+		"failclosed": {Err: `checkpoint_push_remote "gone" is not a configured git remote`},
+		"dedicated":  {Remote: "me/checkpoints", Source: checkpointSyncSourceDedicated},
+		"ignored": {
+			Remote: "origin", Source: string(strategy.SyncRemoteSourceDefault),
+			IgnoredStore: "them/checkpoints",
+		},
+	}
+	layouts := map[string][]remoteDestination{
+		"lone fan-out":              {twoURLs("origin")},
+		"fan-out beside a pinned":   {oneURL("origin", true), twoURLs("upstream")},
+		"two remotes":               {oneURL("origin", false), oneURL("upstream", false)},
+		"two remotes, one fans out": {twoURLs("origin"), oneURL("upstream", false)},
+		"fan-out on a non-elected":  {oneURL("origin", false), twoURLs("other")},
+		"three, one pinned":         {oneURL("colleague", false), oneURL("origin", true), oneURL("upstream", false)},
+	}
+
+	for layoutName, dests := range layouts {
+		for syncName, sync := range syncStates {
+			for _, refs := range []bool{true, false} {
+				t.Run(layoutName+"/"+syncName, func(t *testing.T) {
+					t.Parallel()
+					topo := remoteTopology{destinations: dests, sync: sync, primaryIsRefs: refs}
+					if !topo.ambiguous() {
+						return // silence is correct here; nothing to assert
+					}
+					if !topo.consistent() {
+						return // a combination inspectRemoteTopology cannot produce
+					}
+					var b strings.Builder
+					topo.describeCheckpointDestination(&b, noteHeader)
+					out := b.String()
+					if out == "" {
+						t.Fatal("ambiguous topology printed nothing at all")
+					}
+					if strings.TrimSpace(strings.TrimPrefix(out, noteHeader)) == "" {
+						t.Errorf("header with no body:\n%s", out)
+					}
+				})
+			}
+		}
+	}
+}
+
+// consistent reports whether this hand-built topology is one
+// inspectRemoteTopology could actually produce. The cross-product above includes
+// combinations the producer rules out, and asserting on those would be asserting
+// on states that cannot happen: the store being in effect for the elected remote
+// is precisely what makes the destination the store, so an elected-remote
+// destination cannot coexist with a pinned elected remote — both answers come
+// from one probe of one snapshot.
+func (t remoteTopology) consistent() bool {
+	d := t.electedDestination()
+	if d == nil {
+		return true
+	}
+	if t.sync.dedicated() {
+		return true // Remote is a store slug here, never a remote name
+	}
+	return !d.pinned
+}
+
 // TestInspectRemoteTopology_DedicatedStore drives the note against a real repo
-// rather than a hand-built topology. The literal tables above assert wording;
-// only this one proves the note and `entire status` read the same election —
-// which is the property that actually broke, because inspectRemoteTopology had
-// its own copy of it.
+// rather than a hand-built topology. The tables above assert wording; only this
+// proves the note and `entire status` read the same state — the property that
+// actually broke, because the note used to resolve it separately.
 //
 // Not parallel: setupTestRepo chdirs.
 func TestInspectRemoteTopology_DedicatedStore(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
-	// Tracked settings.json, not settings.local.json: a local declaration is
-	// "always ours" and pins every remote, which silences the note entirely.
+	// Tracked settings.json, not settings.local.json: a local declaration
+	// applies to every remote, which leaves nothing ambiguous to report.
 	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`)
-	// origin's owner matches the store's, so the store is in effect for it;
-	// the other two are owned by someone else and stay unpinned, which is what
-	// makes the destination ambiguous enough for the note to speak.
+	// origin's owner matches the store's, so the store applies to it; the other
+	// two are owned by someone else and do not, which is what makes the
+	// destination ambiguous enough for the note to speak.
 	testutil.AddRemote(t, ".", "origin", "https://github.com/org/app.git")
 	testutil.AddRemote(t, ".", "upstream", "https://github.com/other/app.git")
 	testutil.AddRemote(t, ".", "colleague", "https://github.com/someone/app.git")
 
 	var b strings.Builder
-	inspectRemoteTopology(context.Background()).describeCheckpointDestination(&b, "Checkpoint destination: REVIEW")
+	inspectRemoteTopology(context.Background()).describeCheckpointDestination(&b, noteHeader)
 	out := b.String()
 
 	for _, want := range []string{
@@ -274,5 +346,10 @@ func TestInspectRemoteTopology_DedicatedStore(t *testing.T) {
 	// from the list, and checkpoints go to the store, not to origin.
 	if strings.Contains(out, `right now "origin"`) {
 		t.Errorf("note must not name a remote as the destination in dedicated mode:\n%s", out)
+	}
+	// The carrier came from the same read as the remote list, so it is named
+	// rather than deferred.
+	if strings.Contains(out, "whether your pushes are reaching it") {
+		t.Errorf("carrier should be named when the store resolves for a remote:\n%s", out)
 	}
 }

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -397,6 +397,16 @@ func (p checkpointStoreProbe) inEffectFor(ctx context.Context, remote string) bo
 	return err == nil && enabled
 }
 
+// canJudge reports whether the snapshot carries enough about remote to say if
+// the store applies to it. False when the snapshot read failed (empty) or the
+// remote is missing from it — inEffectFor answers false there too, but that
+// "no" means "cannot tell", not "the store was rejected", and only a genuine
+// rejection may surface as a user-facing warning.
+func (p checkpointStoreProbe) canJudge(remote string) bool {
+	urls, ok := p.snap.Get(remote)
+	return ok && len(urls.Push) > 0
+}
+
 // loadRemoteSnapshot reads the repo's remotes once, best-effort: an unreadable
 // repo yields an empty snapshot, which reports no store in effect — the same
 // degradation as unreadable settings, and never an obstruction.
@@ -452,15 +462,22 @@ func resolveCheckpointSyncDestination(ctx context.Context, probe checkpointStore
 		if probe.inEffectFor(ctx, elected.Name) {
 			return checkpointSyncInfo{Remote: probe.storeRepo(), Source: checkpointSyncSourceDedicated}
 		}
-		// Configured but not in effect for the elected remote, so checkpoints
-		// fall back to that remote. Recorded rather than dropped: the rejection
-		// is otherwise only a logging.Warn, and the fallback is
-		// indistinguishable from never having configured a store.
-		return checkpointSyncInfo{
-			Remote:       elected.Name,
-			Source:       string(elected.Source),
-			IgnoredStore: probe.storeRepo(),
+		if probe.canJudge(elected.Name) {
+			// Configured but rejected for the elected remote, so checkpoints
+			// fall back to that remote. Recorded rather than dropped: the
+			// rejection is otherwise only a logging.Warn, and the fallback is
+			// indistinguishable from never having configured a store.
+			return checkpointSyncInfo{
+				Remote:       elected.Name,
+				Source:       string(elected.Source),
+				IgnoredStore: probe.storeRepo(),
+			}
 		}
+		// The snapshot has nothing on the elected remote: its read failed while
+		// the election's own git read succeeded. Whether the store applies is
+		// unknowable this run, and a transient read failure must not surface as
+		// a "store ignored" warning, so degrade to plain elected-remote sync
+		// exactly as if no store were configured.
 	}
 
 	return checkpointSyncInfo{Remote: elected.Name, Source: string(elected.Source)}

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	checkpointremote "github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -328,6 +329,96 @@ type checkpointSyncInfo struct {
 // than one of the repo's git remotes.
 func (i checkpointSyncInfo) dedicated() bool { return i.Source == checkpointSyncSourceDedicated }
 
+// checkpointStoreProbe answers "is the configured checkpoint_remote in effect
+// for this remote?" from state read once.
+//
+// One value, built once per command, is the point: the answer depends on the
+// repo's remote URLs and on settings, and asking git again per remote produced
+// answers that disagreed with each other inside a single command — the note
+// naming a store while claiming no remote reached it. Everything here is derived
+// from the snapshot it was built with.
+type checkpointStoreProbe struct {
+	snap gitremote.Snapshot
+	// store is the configured checkpoint_remote, nil when none is configured or
+	// the entry is malformed.
+	store *settings.CheckpointRemoteConfig
+	// localOnly records that the store was declared in
+	// .entire/settings.local.json, which exempts it from the ownership test. Read
+	// once for the same reason as the snapshot: the read answers false on
+	// failure, so re-reading per remote can flip the verdict mid-command.
+	localOnly bool
+}
+
+// newCheckpointStoreProbe builds the probe. s may be nil when the caller could
+// not load settings; the probe then reports no store, which degrades to ordinary
+// elected-remote sync rather than guessing.
+func newCheckpointStoreProbe(ctx context.Context, s *EntireSettings, snap gitremote.Snapshot) checkpointStoreProbe {
+	p := checkpointStoreProbe{snap: snap}
+	if s == nil {
+		return p
+	}
+	if p.store = s.GetCheckpointRemote(); p.store != nil {
+		p.localOnly = settings.CheckpointRemoteIsLocalOnly(ctx)
+	}
+	return p
+}
+
+// configured reports whether a checkpoint_remote is configured at all, whether
+// or not it turns out to apply.
+func (p checkpointStoreProbe) configured() bool { return p.store != nil }
+
+// storeRepo is the configured store's org/repo slug, empty when none.
+func (p checkpointStoreProbe) storeRepo() string {
+	if p.store == nil {
+		return ""
+	}
+	return p.store.Repo
+}
+
+// inEffectFor reports whether a push to remote delivers to the store rather than
+// to the remote's own repositories. Same predicate the pre-push hook applies
+// (pushSettings.hasCheckpointURL), evaluated against the snapshot.
+func (p checkpointStoreProbe) inEffectFor(ctx context.Context, remote string) bool {
+	if p.store == nil || remote == "" {
+		return false
+	}
+	urls, ok := p.snap.Get(remote)
+	if !ok || len(urls.Push) == 0 {
+		return false
+	}
+	_, enabled, err := checkpointremote.CheckpointPushURL(ctx, checkpointremote.PushDecision{
+		Remote:           remote,
+		Config:           p.store,
+		OriginURL:        p.snap.OriginURL(),
+		RemoteFetchURL:   urls.Fetch,
+		PushURLs:         urls.Push,
+		StoreIsLocalOnly: p.localOnly,
+	})
+	return err == nil && enabled
+}
+
+// loadRemoteSnapshot reads the repo's remotes once, best-effort: an unreadable
+// repo yields an empty snapshot, which reports no store in effect — the same
+// degradation as unreadable settings, and never an obstruction.
+func loadRemoteSnapshot(ctx context.Context) gitremote.Snapshot {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return gitremote.Snapshot{}
+	}
+	snap, err := gitremote.LoadSnapshot(ctx, repoRoot)
+	if err != nil {
+		logging.Debug(ctx, "checkpoint sync: could not read git remotes",
+			slog.String("error", err.Error()))
+		return gitremote.Snapshot{}
+	}
+	return snap
+}
+
+// storeConfigured reports that a checkpoint_remote exists at all: dedicated is
+// the half where it is in effect, IgnoredStore the half where it is not. Both
+// mean advising the user to configure one would be advice they already took.
+func (i checkpointSyncInfo) storeConfigured() bool { return i.dedicated() || i.IgnoredStore != "" }
+
 // resolveCheckpointSyncDestination answers only *where* checkpoints go — the
 // elected remote, the dedicated store, or the fail-closed error — with no
 // unpushed count. Split out from computeCheckpointSyncInfo so surfaces that need
@@ -335,10 +426,7 @@ func (i checkpointSyncInfo) dedicated() bool { return i.Source == checkpointSync
 // the checkpoint-destination note in remote_topology.go opted out and drifted,
 // which is the bug this split closes. Local-only and cheap — no ref walk, no
 // push-queue read, no network.
-//
-// s may be nil when the caller could not load settings; dedicated mode is then
-// simply not detected, which is the right degradation for a best-effort caller.
-func resolveCheckpointSyncDestination(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
+func resolveCheckpointSyncDestination(ctx context.Context, probe checkpointStoreProbe) checkpointSyncInfo {
 	elected, err := strategy.ResolveCheckpointSyncRemote(ctx)
 	if err != nil {
 		// Fail-closed: checkpoint_push_remote names a remote that does not
@@ -347,40 +435,35 @@ func resolveCheckpointSyncDestination(ctx context.Context, s *EntireSettings) ch
 		// Accepted divergence: if a structured checkpoint_remote is also
 		// configured, the gate's dedicated exemption may still sync checkpoint
 		// data even while this fail-closed warning is shown, since there is no
-		// elected remote left to probe PushURL against here.
+		// elected remote left to probe against here.
 		return checkpointSyncInfo{Err: err.Error()}
 	}
 	if elected.Name == "" {
 		return checkpointSyncInfo{} // no remotes configured: show nothing
 	}
 
-	// Dedicated checkpoint_remote mode is reported only when PushURL derives
-	// an eligible URL for the elected remote, mirroring the pre-push
-	// exemption (ps.hasCheckpointURL); otherwise the gate applies normal
-	// single-remote sync, so status reports that instead. PushURL is
-	// local-only; never call resolvePushSettings here — its follow-up
-	// metadata fetch dials, and status must stay network-free.
+	// Dedicated checkpoint_remote mode is reported only when the store is in
+	// effect for the elected remote, mirroring the pre-push exemption
+	// (ps.hasCheckpointURL); otherwise the gate applies normal single-remote
+	// sync, so status reports that instead.
 	// Accepted divergence: a real push to a different named remote may derive
-	// PushURL differently than this elected-remote probe does.
-	ignoredStore := ""
-	if s != nil {
-		if cr := s.GetCheckpointRemote(); cr != nil {
-			if _, enabled, purlErr := checkpointremote.PushURL(ctx, elected.Name); purlErr == nil && enabled {
-				return checkpointSyncInfo{Remote: cr.Repo, Source: checkpointSyncSourceDedicated}
-			}
-			// Configured but not in effect for the elected remote, so
-			// checkpoints fall back to that remote. Recorded rather than
-			// dropped: PushURL only logs the rejection, and the fallback is
-			// otherwise indistinguishable from never having configured a store.
-			ignoredStore = cr.Repo
+	// its URL differently than this elected-remote probe does.
+	if probe.configured() {
+		if probe.inEffectFor(ctx, elected.Name) {
+			return checkpointSyncInfo{Remote: probe.storeRepo(), Source: checkpointSyncSourceDedicated}
+		}
+		// Configured but not in effect for the elected remote, so checkpoints
+		// fall back to that remote. Recorded rather than dropped: the rejection
+		// is otherwise only a logging.Warn, and the fallback is
+		// indistinguishable from never having configured a store.
+		return checkpointSyncInfo{
+			Remote:       elected.Name,
+			Source:       string(elected.Source),
+			IgnoredStore: probe.storeRepo(),
 		}
 	}
 
-	return checkpointSyncInfo{
-		Remote:       elected.Name,
-		Source:       string(elected.Source),
-		IgnoredStore: ignoredStore,
-	}
+	return checkpointSyncInfo{Remote: elected.Name, Source: string(elected.Source)}
 }
 
 // computeCheckpointSyncInfo is the single shared computation behind both the
@@ -388,15 +471,15 @@ func resolveCheckpointSyncDestination(ctx context.Context, s *EntireSettings) ch
 // above, plus the unpushed counter those two sections show and no other surface
 // needs.
 func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
-	info := resolveCheckpointSyncDestination(ctx, s)
+	info := resolveCheckpointSyncDestination(ctx, newCheckpointStoreProbe(ctx, s, loadRemoteSnapshot(ctx)))
 	switch {
 	case info.Err != "" || info.Remote == "":
 		return info
-	case info.dedicated():
-		// The unpushed counter is meaningful here only on the git-refs
-		// backend (push-queue length is local and accurate). The git-branch
-		// comparison is omitted: pushes to a raw URL update no remote-tracking
-		// ref, so it would permanently read "all unpushed".
+	case info.Source == checkpointSyncSourceDedicated:
+		// The unpushed counter is meaningful here only on the git-refs backend
+		// (push-queue length is local and accurate). The git-branch comparison is
+		// omitted: pushes to a raw URL update no remote-tracking ref, so it would
+		// permanently read "all unpushed".
 		if cpCfg, cfgErr := settings.LoadCheckpointsConfig(ctx); cfgErr == nil && checkpoint.PrimaryIsRefs(cpCfg) {
 			info.Unpushed = countUnpushedCheckpointsForStatus(ctx, "")
 		}

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -315,9 +315,30 @@ type checkpointSyncInfo struct {
 	// when none, when counting failed, or when the count would be a lie
 	// (dedicated URL mode on the git-branch backend).
 	Unpushed int
+	// IgnoredStore names a checkpoint_remote that is configured but NOT in
+	// effect for the elected remote, so checkpoints fall back to that remote.
+	// Empty in every other state, dedicated mode included — there the store IS
+	// in effect. Reported because the rejection is otherwise invisible: it is a
+	// logging.Warn inside remote.PushURL, and every other surface renders the
+	// fallback as if no store had been configured at all.
+	IgnoredStore string
 }
 
-func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
+// dedicated reports that a checkpoint_remote store is the destination, rather
+// than one of the repo's git remotes.
+func (i checkpointSyncInfo) dedicated() bool { return i.Source == checkpointSyncSourceDedicated }
+
+// resolveCheckpointSyncDestination answers only *where* checkpoints go — the
+// elected remote, the dedicated store, or the fail-closed error — with no
+// unpushed count. Split out from computeCheckpointSyncInfo so surfaces that need
+// the destination alone can share this one election instead of re-deriving it:
+// the checkpoint-destination note in remote_topology.go opted out and drifted,
+// which is the bug this split closes. Local-only and cheap — no ref walk, no
+// push-queue read, no network.
+//
+// s may be nil when the caller could not load settings; dedicated mode is then
+// simply not detected, which is the right degradation for a best-effort caller.
+func resolveCheckpointSyncDestination(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
 	elected, err := strategy.ResolveCheckpointSyncRemote(ctx)
 	if err != nil {
 		// Fail-closed: checkpoint_push_remote names a remote that does not
@@ -341,26 +362,48 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 	// metadata fetch dials, and status must stay network-free.
 	// Accepted divergence: a real push to a different named remote may derive
 	// PushURL differently than this elected-remote probe does.
-	if cr := s.GetCheckpointRemote(); cr != nil {
-		if _, enabled, purlErr := checkpointremote.PushURL(ctx, elected.Name); purlErr == nil && enabled {
-			info := checkpointSyncInfo{Remote: cr.Repo, Source: checkpointSyncSourceDedicated}
-			// The unpushed counter is meaningful here only on the git-refs
-			// backend (push-queue length is local and accurate). The
-			// git-branch comparison is omitted: pushes to a raw URL update
-			// no remote-tracking ref, so it would permanently read "all
-			// unpushed".
-			if cpCfg, cfgErr := settings.LoadCheckpointsConfig(ctx); cfgErr == nil && checkpoint.PrimaryIsRefs(cpCfg) {
-				info.Unpushed = countUnpushedCheckpointsForStatus(ctx, "")
+	ignoredStore := ""
+	if s != nil {
+		if cr := s.GetCheckpointRemote(); cr != nil {
+			if _, enabled, purlErr := checkpointremote.PushURL(ctx, elected.Name); purlErr == nil && enabled {
+				return checkpointSyncInfo{Remote: cr.Repo, Source: checkpointSyncSourceDedicated}
 			}
-			return info
+			// Configured but not in effect for the elected remote, so
+			// checkpoints fall back to that remote. Recorded rather than
+			// dropped: PushURL only logs the rejection, and the fallback is
+			// otherwise indistinguishable from never having configured a store.
+			ignoredStore = cr.Repo
 		}
 	}
 
 	return checkpointSyncInfo{
-		Remote:   elected.Name,
-		Source:   string(elected.Source),
-		Unpushed: countUnpushedCheckpointsForStatus(ctx, elected.Name),
+		Remote:       elected.Name,
+		Source:       string(elected.Source),
+		IgnoredStore: ignoredStore,
 	}
+}
+
+// computeCheckpointSyncInfo is the single shared computation behind both the
+// text and JSON checkpoint-sync sections of `entire status`: the destination
+// above, plus the unpushed counter those two sections show and no other surface
+// needs.
+func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
+	info := resolveCheckpointSyncDestination(ctx, s)
+	switch {
+	case info.Err != "" || info.Remote == "":
+		return info
+	case info.dedicated():
+		// The unpushed counter is meaningful here only on the git-refs
+		// backend (push-queue length is local and accurate). The git-branch
+		// comparison is omitted: pushes to a raw URL update no remote-tracking
+		// ref, so it would permanently read "all unpushed".
+		if cpCfg, cfgErr := settings.LoadCheckpointsConfig(ctx); cfgErr == nil && checkpoint.PrimaryIsRefs(cpCfg) {
+			info.Unpushed = countUnpushedCheckpointsForStatus(ctx, "")
+		}
+	default:
+		info.Unpushed = countUnpushedCheckpointsForStatus(ctx, info.Remote)
+	}
+	return info
 }
 
 // countUnpushedCheckpointsForStatus counts best-effort: status must never fail
@@ -387,7 +430,7 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 		b.WriteString(sty.render(sty.yellow, "  ! Checkpoints NOT syncing: "+info.Err))
 	case info.Remote == "":
 		return
-	case info.Source == checkpointSyncSourceDedicated:
+	case info.dedicated():
 		b.WriteString("\n  Checkpoints sync to: ")
 		b.WriteString(sty.render(sty.cyan, "dedicated checkpoint remote ("+info.Remote+")"))
 	default:
@@ -399,6 +442,13 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 		case string(strategy.SyncRemoteSourceObserved):
 			b.WriteString(sty.render(sty.dim, " (follows your branch's push destination)"))
 		}
+	}
+	if info.IgnoredStore != "" {
+		// The rejection is per-push and local-only, so this is the first place
+		// a user can see that the store they configured is not being used.
+		b.WriteString("\n")
+		b.WriteString(sty.render(sty.yellow, fmt.Sprintf(
+			"  ! checkpoint_remote %q is not in effect; checkpoints go to %s", info.IgnoredStore, info.Remote)))
 	}
 	if info.Unpushed > 0 {
 		b.WriteString("\n  ")
@@ -416,7 +466,7 @@ func formatUnpushedCheckpointsLine(info checkpointSyncInfo) string {
 		noun = "checkpoint"
 		pronoun = "it syncs"
 	}
-	if info.Source == checkpointSyncSourceDedicated {
+	if info.dedicated() {
 		return fmt.Sprintf("%d %s not yet pushed", info.Unpushed, noun)
 	}
 	return fmt.Sprintf("%d %s not yet on %s — %s with your next 'git push %s'",
@@ -797,7 +847,10 @@ type statusJSON struct {
 	CheckpointSyncRemote       string `json:"checkpoint_sync_remote,omitempty"`
 	CheckpointSyncRemoteSource string `json:"checkpoint_sync_remote_source,omitempty"` // config|observed|default|sole|first|dedicated
 	CheckpointSyncError        string `json:"checkpoint_sync_error,omitempty"`         // fail-closed message
-	UnpushedCheckpoints        int    `json:"unpushed_checkpoints,omitempty"`
+	// CheckpointRemoteIgnored names a checkpoint_remote that is configured but
+	// not in effect, so checkpoints go to CheckpointSyncRemote instead.
+	CheckpointRemoteIgnored string `json:"checkpoint_remote_ignored,omitempty"`
+	UnpushedCheckpoints     int    `json:"unpushed_checkpoints,omitempty"`
 	// SecretScanners lists the enabled engines when non-default; omitted when default.
 	SecretScanners []string `json:"secret_scanners,omitempty"`
 	Error          string   `json:"error,omitempty"`
@@ -872,6 +925,7 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		result.CheckpointSyncRemote = syncInfo.Remote
 		result.CheckpointSyncRemoteSource = syncInfo.Source
 		result.CheckpointSyncError = syncInfo.Err
+		result.CheckpointRemoteIgnored = syncInfo.IgnoredStore
 		result.UnpushedCheckpoints = syncInfo.Unpushed
 
 		if store, err := session.NewStateStore(ctx); err == nil {

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -297,10 +297,9 @@ func formatSettingsStatus(prefix string, s *EntireSettings, sty statusStyles) st
 // stays pure "which configured git remote" (spec Unit 1).
 const checkpointSyncSourceDedicated = "dedicated"
 
-// checkpointSyncInfo is the single shared computation behind both the text and
-// JSON checkpoint-sync sections of `entire status`, so the two outputs cannot
-// drift. Everything here reads local state only (settings, .git/config, local
-// refs, the push queue) — status must stay network-free.
+// checkpointSyncInfo is where checkpoints go, plus the unpushed count the
+// `entire status` sections add on top. Read from local state only (settings,
+// .git/config, local refs, the push queue) — status must stay network-free.
 type checkpointSyncInfo struct {
 	// Remote is the elected git remote name, or the org/repo slug in
 	// dedicated checkpoint_remote mode. Empty when nothing resolved (no
@@ -327,6 +326,11 @@ type checkpointSyncInfo struct {
 // dedicated reports that a checkpoint_remote store is the destination, rather
 // than one of the repo's git remotes.
 func (i checkpointSyncInfo) dedicated() bool { return i.Source == checkpointSyncSourceDedicated }
+
+// storeConfigured reports that a checkpoint_remote exists at all: dedicated is
+// the half where it is in effect, IgnoredStore the half where it is not. Both
+// mean advising the user to configure one would be advice they already took.
+func (i checkpointSyncInfo) storeConfigured() bool { return i.dedicated() || i.IgnoredStore != "" }
 
 // resolveCheckpointSyncDestination answers only *where* checkpoints go — the
 // elected remote, the dedicated store, or the fail-closed error — with no
@@ -389,10 +393,10 @@ func resolveCheckpointSyncDestination(ctx context.Context, s *EntireSettings) ch
 // needs.
 func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
 	info := resolveCheckpointSyncDestination(ctx, s)
-	switch {
-	case info.Err != "" || info.Remote == "":
+	if info.Err != "" || info.Remote == "" {
 		return info
-	case info.dedicated():
+	}
+	if info.dedicated() {
 		// The unpushed counter is meaningful here only on the git-refs
 		// backend (push-queue length is local and accurate). The git-branch
 		// comparison is omitted: pushes to a raw URL update no remote-tracking
@@ -400,9 +404,9 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 		if cpCfg, cfgErr := settings.LoadCheckpointsConfig(ctx); cfgErr == nil && checkpoint.PrimaryIsRefs(cpCfg) {
 			info.Unpushed = countUnpushedCheckpointsForStatus(ctx, "")
 		}
-	default:
-		info.Unpushed = countUnpushedCheckpointsForStatus(ctx, info.Remote)
+		return info
 	}
+	info.Unpushed = countUnpushedCheckpointsForStatus(ctx, info.Remote)
 	return info
 }
 

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -297,9 +297,10 @@ func formatSettingsStatus(prefix string, s *EntireSettings, sty statusStyles) st
 // stays pure "which configured git remote" (spec Unit 1).
 const checkpointSyncSourceDedicated = "dedicated"
 
-// checkpointSyncInfo is where checkpoints go, plus the unpushed count the
-// `entire status` sections add on top. Read from local state only (settings,
-// .git/config, local refs, the push queue) — status must stay network-free.
+// checkpointSyncInfo is the single shared computation behind both the text and
+// JSON checkpoint-sync sections of `entire status`, so the two outputs cannot
+// drift. Everything here reads local state only (settings, .git/config, local
+// refs, the push queue) — status must stay network-free.
 type checkpointSyncInfo struct {
 	// Remote is the elected git remote name, or the org/repo slug in
 	// dedicated checkpoint_remote mode. Empty when nothing resolved (no
@@ -326,11 +327,6 @@ type checkpointSyncInfo struct {
 // dedicated reports that a checkpoint_remote store is the destination, rather
 // than one of the repo's git remotes.
 func (i checkpointSyncInfo) dedicated() bool { return i.Source == checkpointSyncSourceDedicated }
-
-// storeConfigured reports that a checkpoint_remote exists at all: dedicated is
-// the half where it is in effect, IgnoredStore the half where it is not. Both
-// mean advising the user to configure one would be advice they already took.
-func (i checkpointSyncInfo) storeConfigured() bool { return i.dedicated() || i.IgnoredStore != "" }
 
 // resolveCheckpointSyncDestination answers only *where* checkpoints go — the
 // elected remote, the dedicated store, or the fail-closed error — with no
@@ -393,10 +389,10 @@ func resolveCheckpointSyncDestination(ctx context.Context, s *EntireSettings) ch
 // needs.
 func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
 	info := resolveCheckpointSyncDestination(ctx, s)
-	if info.Err != "" || info.Remote == "" {
+	switch {
+	case info.Err != "" || info.Remote == "":
 		return info
-	}
-	if info.dedicated() {
+	case info.dedicated():
 		// The unpushed counter is meaningful here only on the git-refs
 		// backend (push-queue length is local and accurate). The git-branch
 		// comparison is omitted: pushes to a raw URL update no remote-tracking
@@ -404,9 +400,9 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 		if cpCfg, cfgErr := settings.LoadCheckpointsConfig(ctx); cfgErr == nil && checkpoint.PrimaryIsRefs(cpCfg) {
 			info.Unpushed = countUnpushedCheckpointsForStatus(ctx, "")
 		}
-		return info
+	default:
+		info.Unpushed = countUnpushedCheckpointsForStatus(ctx, info.Remote)
 	}
-	info.Unpushed = countUnpushedCheckpointsForStatus(ctx, info.Remote)
 	return info
 }
 

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -2355,6 +2355,11 @@ func TestRunStatus_CheckpointSyncDedicated_GitBranch_NoCounter(t *testing.T) {
 	if !strings.Contains(out, "Checkpoints sync to: dedicated checkpoint remote (org/checkpoints)") {
 		t.Errorf("expected dedicated destination line with repo slug, got:\n%s", out)
 	}
+	// In effect is the opposite of ignored; the warning belongs only to the
+	// fallback case.
+	if strings.Contains(out, "is not in effect") {
+		t.Errorf("dedicated mode must not warn about an ignored store, got:\n%s", out)
+	}
 	if strings.Contains(out, "not yet") {
 		t.Errorf("dedicated + git-branch: counter must be suppressed, got:\n%s", out)
 	}
@@ -2513,6 +2518,11 @@ func TestRunStatus_CheckpointSyncDedicated_IneligibleFallsBackToElected(t *testi
 	if !strings.Contains(out, "2 checkpoints not yet on origin") {
 		t.Errorf("expected elected-remote counter in fallback mode, got:\n%s", out)
 	}
+	// The rejection is a log line everywhere else, so status is where a user
+	// learns the store they configured is not being used.
+	if !strings.Contains(out, `checkpoint_remote "org/checkpoints" is not in effect; checkpoints go to origin`) {
+		t.Errorf("expected the ignored-store warning, got:\n%s", out)
+	}
 }
 
 func TestRunStatusJSON_CheckpointSync_DedicatedIneligible(t *testing.T) {
@@ -2538,6 +2548,9 @@ func TestRunStatusJSON_CheckpointSync_DedicatedIneligible(t *testing.T) {
 	}
 	if result.CheckpointSyncError != "" {
 		t.Errorf("checkpoint_sync_error should be empty, got %q", result.CheckpointSyncError)
+	}
+	if result.CheckpointRemoteIgnored != "org/checkpoints" {
+		t.Errorf("checkpoint_remote_ignored = %q, want the configured store", result.CheckpointRemoteIgnored)
 	}
 }
 

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -2158,6 +2159,13 @@ func TestRunStatus_PrintsBothReviewAndInvestigation(t *testing.T) {
 
 // --- Checkpoint sync visibility (single-remote gate observability) ---
 
+// electedOriginRemote and testCheckpointStoreRepo are the remote name and
+// checkpoint_remote slug the checkpoint-sync tests assert against.
+const (
+	electedOriginRemote     = "origin"
+	testCheckpointStoreRepo = "org/checkpoints"
+)
+
 // checkpointSyncTestCommit creates a commit in the cwd test repo and returns
 // its hash. setupTestRepo leaves the repo without commits, and both the v1
 // counter and ref updates need at least one.
@@ -2420,7 +2428,7 @@ func TestRunStatusJSON_CheckpointSync_Elected(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
-	if result.CheckpointSyncRemote != "origin" {
+	if result.CheckpointSyncRemote != electedOriginRemote {
 		t.Errorf("checkpoint_sync_remote = %q, want %q", result.CheckpointSyncRemote, "origin")
 	}
 	if result.CheckpointSyncRemoteSource != "default" {
@@ -2475,7 +2483,7 @@ func TestRunStatusJSON_CheckpointSync_Dedicated(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
-	if result.CheckpointSyncRemote != "org/checkpoints" {
+	if result.CheckpointSyncRemote != testCheckpointStoreRepo {
 		t.Errorf("checkpoint_sync_remote = %q, want the org/repo slug", result.CheckpointSyncRemote)
 	}
 	if result.CheckpointSyncRemoteSource != "dedicated" {
@@ -2540,7 +2548,7 @@ func TestRunStatusJSON_CheckpointSync_DedicatedIneligible(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
-	if result.CheckpointSyncRemote != "origin" {
+	if result.CheckpointSyncRemote != electedOriginRemote {
 		t.Errorf("checkpoint_sync_remote = %q, want the elected remote %q", result.CheckpointSyncRemote, "origin")
 	}
 	if result.CheckpointSyncRemoteSource != "default" {
@@ -2549,8 +2557,47 @@ func TestRunStatusJSON_CheckpointSync_DedicatedIneligible(t *testing.T) {
 	if result.CheckpointSyncError != "" {
 		t.Errorf("checkpoint_sync_error should be empty, got %q", result.CheckpointSyncError)
 	}
-	if result.CheckpointRemoteIgnored != "org/checkpoints" {
+	if result.CheckpointRemoteIgnored != testCheckpointStoreRepo {
 		t.Errorf("checkpoint_remote_ignored = %q, want the configured store", result.CheckpointRemoteIgnored)
+	}
+}
+
+// TestResolveCheckpointSyncDestination_UnreadableSnapshot pins the degradation
+// for a failed `git remote -v`: the probe cannot judge the store, and "cannot
+// tell" must not surface as the "store ignored" warning — that warning claims
+// the store was rejected, which a transient read failure does not establish.
+//
+// Not parallel: setupTestRepo chdirs.
+func TestResolveCheckpointSyncDestination_UnreadableSnapshot(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`)
+	// Remote owner "other" != store owner "org": with a readable snapshot this
+	// is exactly the rejected-store state.
+	testutil.AddRemote(t, ".", "origin", "https://github.com/other/repo.git")
+
+	ctx := context.Background()
+	s, err := LoadEntireSettings(ctx)
+	if err != nil {
+		t.Fatalf("LoadEntireSettings() error = %v", err)
+	}
+
+	// Control: the live snapshot judges the store and reports it ignored.
+	live := resolveCheckpointSyncDestination(ctx, newCheckpointStoreProbe(ctx, s, loadRemoteSnapshot(ctx)))
+	if live.IgnoredStore != testCheckpointStoreRepo {
+		t.Errorf("live snapshot: IgnoredStore = %q, want the configured store", live.IgnoredStore)
+	}
+
+	// An empty snapshot is what a failed `git remote -v` degrades to.
+	info := resolveCheckpointSyncDestination(ctx, newCheckpointStoreProbe(ctx, s, gitremote.Snapshot{}))
+	if info.IgnoredStore != "" {
+		t.Errorf("unreadable snapshot: IgnoredStore = %q, want none — a transient read failure is not a rejection", info.IgnoredStore)
+	}
+	if info.dedicated() {
+		t.Errorf("unreadable snapshot must not claim dedicated mode, got source %q", info.Source)
+	}
+	if info.Remote != electedOriginRemote {
+		t.Errorf("Remote = %q, want plain elected-remote sync to %q", info.Remote, "origin")
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1108
<!-- entire-trail-link-end -->

## The problem

The several-remotes note printed by `entire enable` / `entire doctor` says:

> Checkpoints sync to a single elected remote — not to whichever one you push to. **A push to any other remote carries your code but no session history.** Run `entire status` to see the elected destination and how many checkpoints are waiting for it.

That bolded sentence is not true of the one push that matters most. `pendingCaptureCheckpointSyncRemote` runs **before** the single-remote gate in `prePush`, so a push whose target agrees with the branch's declared push destination elects that remote *and* carries the checkpoints there in the same push (`TestCheckpointSyncRemote_TrackedPushCapturesElection` asserts exactly that). The note was warning about a case the CLI now handles by itself.

It also never said where checkpoints actually go — the one thing a user standing in a multi-remote repo wants to know.

## The change

`inspectRemoteTopology` asks `strategy.ResolveCheckpointSyncRemote` for the election (never re-derived from settings — the same rule the existing `pinned` field follows, so the shown destination cannot diverge from where pushes go), and the note says the concrete thing. Election still open:

```
  This repo has 3 remotes (custom, origin, upstream).
    Checkpoints sync to one remote — right now "origin". A push to a different
    remote of your own can move it; `entire status` shows where they go.
    Set strategy_options.checkpoint_push_remote to pin one yourself.
```

"a different remote" rather than "your branch's own remote": capture requires the push target to both agree with the branch's declared push destination *and* differ from today's election, so on the ordinary setup where they already agree, no push moves anything — and the earlier wording promised a takeover that cannot happen.

Observed tier — destination settled, capture clause gone:

```
    Checkpoints sync to one remote — "custom", your branch's push destination.
    A push to any other remote carries your code but no session history.
    Set strategy_options.checkpoint_push_remote to pin a different one.
```

Explicit `checkpoint_push_remote` — no advice line, because repeating the key they already set reads as a warning that something still needs doing:

```
    Checkpoints sync to one remote — "custom" (set by checkpoint_push_remote).
    A push to any other remote carries your code but no session history.
```

The sentence this PR set out to delete survives on exactly these two tiers. It is untrue only where the election is still open, because there the electing push carries its own history to the remote it elects. Once `checkpoint_push_remote` is set or a capture is in force, `captureEligible` refuses every displacement, so no push can move the destination and the warning is exactly right — and it is the fact a multi-remote user most needs. Deleting it repo-wide traded one wrong sentence for a missing one.

Two more states name no remote at all. The first is a failed election — the resolver failing closed on a `checkpoint_push_remote` that names a remote which does not exist, or on a settings file it could not read. Checkpoints are going nowhere until that is fixed, so the error is kept on the topology rather than swallowed into a debug log, and reported in the wording `entire status` already uses:

```
    Checkpoints are NOT syncing: checkpoint_push_remote "gone" is not a configured git remote; checkpoint sync disabled until fixed
```

That is the only branch here that is a warning rather than orientation.

The second is an election that came back with no name *and* no error. An earlier revision of this PR ruled that out — with two or more remotes a successful election was said to always return a name — but the resolver's own `git config` read answers nil on a transient failure rather than caching it (`cachedRemotesInConfigOrder`), so an unnamed, error-free answer is reachable. Left silent it printed the remote count and nothing else, strictly less than the static text this replaces, so it falls back to the one clause true on every tier:

```
    Checkpoints sync to a single elected remote; `entire status` shows which.
```

The fan-out block above (one remote, several push URLs) is untouched — that one is still genuinely lossy.

The tier switch names the three open tiers instead of falling through to `default`: golangci-lint's `exhaustive` rule rejects the default clause. `SyncRemoteSourceSole` is all but unreachable at this call site — this note is written only when two or more remotes are unpinned, and the resolver reaches the sole tier only with exactly one remote configured — so it is grouped with the open tiers. Not asserted as impossible, though: the two sides count remotes with different git commands (`git remote -v` here, `git config --local --get-regexp` in the resolver), which can disagree, and the shared wording reads correctly either way.

## Test

`TestMultiPushURL_DestinationNoteSurfaces` runs on the open-election tier, so it still asserts `"no session history"` **absent** there, alongside the two phrasings this note was already wrong with (`"follow whichever remote"`, `"always looks at origin"`), so a future rewrite cannot reintroduce any of the three.

`TestDescribeSyncRemote` (new, `cmd/entire/cli/remote_topology_test.go`) covers every tier the note words differently — config, observed, open election by `default` and by `first`, fail-closed, and unresolved — asserting both the text that must appear and the text that must not, since the integration test only ever reaches the open-election tier. The settled tiers assert `"no session history"` **present** and the open ones assert it absent, which is where that split is pinned. `describeSyncRemote` is a pure function of two fields and an `io.Writer`, so the table is cheap.

## Verification

- `golangci-lint 2.11.3 ./cmd/entire/cli/...` → 0 issues, `gofmt` clean. (An earlier revision of this PR claimed lint was clean when it was not: `exhaustive` was failing on the tier switch. Fixed here.)
- `mise run test` → 9313 tests, 4 skipped, 0 failures (186s), as of f9eb943f3's parent; re-run after f9eb943f3 was scoped to `go test ./cmd/entire/cli/...`, which passes.
- `TestMultiPushURL` (integration, all cases) and `TestDescribeSyncRemote` pass.
- The four states that existed at 6c71f739b were verified by hand against a 3-remote repo. The two added since — the fail-closed warning and the unresolved fallback — are covered by `TestDescribeSyncRemote` only, since the unresolved one needs a transient git failure to reproduce by hand.

## Trail findings

One finding on [trail #1108](https://entire.io/gh/entireio/cli/trails/1108), dismissed as not applicable: it asked for separate wording for `SyncRemoteSourceSole`, which this call site does not reach. Recorded in a code comment instead of a fourth message.

Copilot's inline review caught the silent-return case above before the fail-closed branch landed; its second half — an unnamed election with no error — outlived that fix and is closed by f9eb943f3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

