### PR TITLE
fix(doctor): report a log directory Entire cannot write to

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,25 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.18.15"
-      }
-    },
-    "node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "@opencode-ai/plugin": "1.4.7"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
-      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
       "cpu": [
         "arm64"
       ],
@@ -34,9 +22,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
-      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
       "cpu": [
         "x64"
       ],
@@ -47,9 +35,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
-      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
       "cpu": [
         "arm"
       ],
@@ -60,9 +48,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
-      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
       "cpu": [
         "arm64"
       ],
@@ -73,9 +61,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
-      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
       "cpu": [
         "x64"
       ],
@@ -86,9 +74,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
-      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
       "cpu": [
         "x64"
       ],
@@ -99,26 +87,21 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.15",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.15.tgz",
-      "integrity": "sha512-AY10RtFbzLkf951dbLkSGJdBeddeS6ojbjvqCpWnINedqlj2cK/GF91xWjWnlHpqQZ4GABLPCuoSJx8mGmKvCw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.7.tgz",
+      "integrity": "sha512-RbzMl7ILvQDHpZNvqzi6RCYaGcB3eBwNIMRZww467drLvMd1eOwr4/qAurrvYDsIIEctE6cKsrLuSGIKCW/Fxg==",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.15",
-        "effect": "4.0.0-beta.83",
+        "@opencode-ai/sdk": "1.4.7",
+        "effect": "4.0.0-beta.48",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.4.5",
-        "@opentui/keymap": ">=0.4.5",
-        "@opentui/solid": ">=0.4.5"
+        "@opentui/core": ">=0.1.99",
+        "@opentui/solid": ">=0.1.99"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
-          "optional": true
-        },
-        "@opentui/keymap": {
           "optional": true
         },
         "@opentui/solid": {
@@ -127,9 +110,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.15",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.15.tgz",
-      "integrity": "sha512-8sfo9nGiVwesAZW9Wqkvynyn7w4wYaHx1O9qOHpYL65+Bs2XUpHP3kBbZe58gjQydFgk6I74kUF7sqCiPu2arQ==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.7.tgz",
+      "integrity": "sha512-onEtaooQyoDP5gTShQeQSf0Sd8V7949G9pPNyIyRXnVtFqyDIhUDLGtL/a/+EIW9x5s+Y6lDy/3oVoGMvQ0rQQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -166,27 +149,27 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.83",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
-      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
+      "version": "4.0.0-beta.48",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
+      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.8.0",
+        "fast-check": "^4.6.0",
         "find-my-way-ts": "^0.1.6",
-        "ini": "^7.0.0",
+        "ini": "^6.0.0",
         "kubernetes-types": "^1.30.0",
-        "msgpackr": "^2.0.1",
+        "msgpackr": "^1.11.9",
         "multipasta": "^0.2.7",
         "toml": "^4.1.1",
-        "uuid": "^14.0.0",
-        "yaml": "^2.9.0"
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/fast-check": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
-      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
       "funding": [
         {
           "type": "individual",
@@ -212,12 +195,12 @@
       "license": "MIT"
     },
     "node_modules/ini": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
-      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "license": "ISC",
       "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/isexe": {
@@ -226,12 +209,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/kubernetes-types": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
@@ -239,18 +216,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
-      "integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
+      "integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.4"
+        "msgpackr-extract": "^3.0.2"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
-      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -261,18 +238,18 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
       }
     },
     "node_modules/multipasta": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
-      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
       "license": "MIT"
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -300,9 +277,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
-      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
       "funding": [
         {
           "type": "individual",
@@ -337,18 +314,18 @@
       }
     },
     "node_modules/toml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
-      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
-      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -374,9 +351,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,13 +5,25 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.4.7"
+        "@opencode-ai/plugin": "1.18.15"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
       "cpu": [
         "arm64"
       ],
@@ -22,9 +34,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
       "cpu": [
         "x64"
       ],
@@ -35,9 +47,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
       "cpu": [
         "arm"
       ],
@@ -48,9 +60,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
       "cpu": [
         "arm64"
       ],
@@ -61,9 +73,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
       "cpu": [
         "x64"
       ],
@@ -74,9 +86,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
       "cpu": [
         "x64"
       ],
@@ -87,21 +99,26 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.7.tgz",
-      "integrity": "sha512-RbzMl7ILvQDHpZNvqzi6RCYaGcB3eBwNIMRZww467drLvMd1eOwr4/qAurrvYDsIIEctE6cKsrLuSGIKCW/Fxg==",
+      "version": "1.18.15",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.15.tgz",
+      "integrity": "sha512-AY10RtFbzLkf951dbLkSGJdBeddeS6ojbjvqCpWnINedqlj2cK/GF91xWjWnlHpqQZ4GABLPCuoSJx8mGmKvCw==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.4.7",
-        "effect": "4.0.0-beta.48",
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/sdk": "1.18.15",
+        "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.99",
-        "@opentui/solid": ">=0.1.99"
+        "@opentui/core": ">=0.4.5",
+        "@opentui/keymap": ">=0.4.5",
+        "@opentui/solid": ">=0.4.5"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
           "optional": true
         },
         "@opentui/solid": {
@@ -110,9 +127,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.7.tgz",
-      "integrity": "sha512-onEtaooQyoDP5gTShQeQSf0Sd8V7949G9pPNyIyRXnVtFqyDIhUDLGtL/a/+EIW9x5s+Y6lDy/3oVoGMvQ0rQQ==",
+      "version": "1.18.15",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.15.tgz",
+      "integrity": "sha512-8sfo9nGiVwesAZW9Wqkvynyn7w4wYaHx1O9qOHpYL65+Bs2XUpHP3kBbZe58gjQydFgk6I74kUF7sqCiPu2arQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -149,27 +166,27 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.48",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
-      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
+      "version": "4.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.6.0",
+        "fast-check": "^4.8.0",
         "find-my-way-ts": "^0.1.6",
-        "ini": "^6.0.0",
+        "ini": "^7.0.0",
         "kubernetes-types": "^1.30.0",
-        "msgpackr": "^1.11.9",
+        "msgpackr": "^2.0.1",
         "multipasta": "^0.2.7",
         "toml": "^4.1.1",
-        "uuid": "^13.0.0",
-        "yaml": "^2.8.3"
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/fast-check": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
-      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
       "funding": [
         {
           "type": "individual",
@@ -195,12 +212,12 @@
       "license": "MIT"
     },
     "node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
       "license": "ISC",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/isexe": {
@@ -209,6 +226,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/kubernetes-types": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
@@ -216,18 +239,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
-      "integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
+      "integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
+        "msgpackr-extract": "^3.0.4"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -238,18 +261,18 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
       }
     },
     "node_modules/multipasta": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
-      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
       "license": "MIT"
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -277,9 +300,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
       "funding": [
         {
           "type": "individual",
@@ -314,18 +337,18 @@
       }
     },
     "node_modules/toml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
-      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -351,9 +374,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/cmd/entire/cli/config.go
+++ b/cmd/entire/cli/config.go
@@ -96,12 +96,6 @@ func resolveLogLevel(ctx context.Context) slog.Level {
 	return level
 }
 
-// newLogger opens .entire/logs/entire.log for the current worktree.
-//
-// It CREATES the log directory, so every caller must already have decided that
-// writing into this repo is allowed: the root PersistentPreRun gates on
-// IsSetUpAny, and enable calls this only after every check that can still reject
-// the invocation, so a rejected enable leaves an untouched repo untouched.
 // ensureLogger attaches a logger to cmd's context unless one is already there,
 // and is the only place that installs one. Two loggers on the same file means
 // two 8KB buffers, and whichever lands in the context second orphans the first —
@@ -119,6 +113,12 @@ func ensureLogger(cmd *cobra.Command) {
 	cmd.SetContext(logging.WithLogger(ctx, l))
 }
 
+// newLogger builds the logger for .entire/logs/entire.log in the current
+// worktree. Nothing is created on disk here — the directory and file arrive with
+// the first line actually written — so the caller's remaining obligation is
+// narrower than it once was but has not gone away: `enable` still calls this
+// only after every check that can still reject the invocation, so a rejected
+// enable that goes on to log leaves an untouched repo untouched.
 func newLogger(ctx context.Context) (*logging.Logger, error) {
 	root, err := paths.WorktreeRoot(ctx)
 	if err != nil {

--- a/cmd/entire/cli/context_flag.go
+++ b/cmd/entire/cli/context_flag.go
@@ -9,11 +9,17 @@ import (
 // parses it.
 //
 // Binding through a pflag.Value rather than a PersistentPreRun is deliberate:
-// Cobra runs only the CLOSEST PersistentPreRun in the chain, and subtrees here
-// define their own (agent_group.go, the per-agent hooks commands), so a root hook
-// would be silently skipped for exactly the commands that inherited the flag.
 // Set() runs during flag parsing — before any PreRun, before RunE, and before
 // anything resolves a token — so there is no ordering to get wrong.
+//
+// That ordering is the whole reason, and it is worth being clear that it is now
+// the only one. This used to also argue that a root PersistentPreRun would be
+// shadowed by the subtrees that define their own (agent_group.go, the per-agent
+// hooks commands), because cobra runs only the closest hook in the chain by
+// default. It no longer does: root.go sets cobra.EnableTraverseRunHooks, so
+// every ancestor's hook runs, root first. A pre-run would therefore work today
+// — it would just resolve the identity later than flag parsing does, for no
+// gain.
 type contextFlagValue struct{ name string }
 
 func (v *contextFlagValue) String() string { return v.name }

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -37,19 +38,24 @@ Checks performed:
      entire/checkpoints/v1 branches share no common ancestor (caused by a
      previous bug). Fixes by cherry-picking local checkpoints onto remote tip.
 
+  2. Operational logs: warn when .entire/logs cannot be written. Every other
+     diagnostic is delivered by writing there, and that write is silent about
+     its own failure, so an unwritable log directory looks exactly like a repo
+     where nothing ran.
+
   When Codex hooks are installed:
-  2. Codex hook trust: warn when hooks declared in .codex/hooks.json
+  3. Codex hook trust: warn when hooks declared in .codex/hooks.json
      lack a trusted_hash entry in the user's Codex config (i.e. /hooks
      review hasn't run yet on this machine, or a newer entire release
      added a hook the user hasn't approved yet).
 
   For each installed agent that reports hook-config drift:
-  3. Hook config: warn when the installed hooks no longer match what this
+  4. Hook config: warn when the installed hooks no longer match what this
      CLI writes (e.g. an older release wrote Claude Code tool matchers that
      no longer fire, or a committed Pi/OpenCode extension has gone stale).
      Fix by re-running 'entire enable --force'.
 
-  4. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
+  5. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
 
 A session is considered stuck if:
   - It is in ACTIVE phase with no interaction for over 1 hour
@@ -120,6 +126,11 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Error: git hook check failed: %v\n", hooksErr)
 		finalErr = NewSilentError(fmt.Errorf("git hook check failed: %w", hooksErr))
 	}
+
+	// Before the remaining checks, because it is the channel they and every
+	// other command write their diagnostics to: if this is broken, an empty
+	// entire.log is not evidence of a healthy repo.
+	checkLogSink(cmd)
 
 	// Agent-specific: Codex hook trust state.
 	checkCodexHookTrust(cmd)
@@ -588,6 +599,37 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 	}
 	fmt.Fprintln(w, "  ✓ Fixed: git hooks reinstalled")
 	return nil
+}
+
+// checkLogSink reports a .entire/logs Entire cannot write to.
+//
+// Every other diagnostic in the CLI is delivered by writing there, and that
+// write is deliberately silent about its own failure — a dropped log line must
+// never surface as an error in the caller. So an unwritable log directory
+// presents exactly like a repo where nothing ever ran: no message, exit 0, and
+// an absent or empty entire.log. That is the shape of the support report this
+// logging work exists to fix, so doctor is the wrong command to reproduce it.
+//
+// Read-only. The fixes are ownership and permissions, which doctor cannot take
+// on the user's behalf.
+//
+// A nil logger means the entry point declined to build one, i.e. Entire was
+// never set up here — nothing to nag about, and reading it back from the
+// context is what keeps this check on the same directory the logger actually
+// uses instead of re-deriving the path.
+func checkLogSink(cmd *cobra.Command) {
+	err := logging.LoggerFromContext(cmd.Context()).EnsureOpen()
+	if err == nil {
+		return
+	}
+
+	w := cmd.OutOrStdout()
+	fmt.Fprintln(w, "Operational logs: NOT WRITABLE")
+	fmt.Fprintf(w, "  %v\n", err)
+	fmt.Fprintf(w, "  Entire's diagnostics are being dropped, including the redaction warnings\n")
+	fmt.Fprintf(w, "  that explain why a custom rule isn't matching. `entire doctor logs` and\n")
+	fmt.Fprintf(w, "  `entire doctor bundle` have nothing to report until this is fixed.\n")
+	fmt.Fprintf(w, "  Fix: make %s writable, then re-run.\n", logging.LogsDir)
 }
 
 // checkHookDrift warns when an installed agent's Entire hook config is out of

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -629,7 +629,8 @@ func checkLogSink(cmd *cobra.Command) {
 	fmt.Fprintf(w, "  Entire's diagnostics are being dropped, including the redaction warnings\n")
 	fmt.Fprintf(w, "  that explain why a custom rule isn't matching. `entire doctor logs` and\n")
 	fmt.Fprintf(w, "  `entire doctor bundle` have nothing to report until this is fixed.\n")
-	fmt.Fprintf(w, "  Fix: make %s writable, then re-run.\n", logging.LogsDir)
+	fmt.Fprintf(w, "  Fix: resolve the error above so %s is a writable directory — commonly\n", logging.LogsDir)
+	fmt.Fprintln(w, "  ownership or permissions, a regular file occupying the path, or a full disk.")
 }
 
 // checkHookDrift warns when an installed agent's Entire hook config is out of

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -518,6 +518,63 @@ func TestRunSessionsFix_HandlerLogsStayOffTheTerminal(t *testing.T) {
 	assert.NotEmpty(t, logged, "nothing was logged, so this test proves nothing about where logs go")
 }
 
+// An unwritable .entire/logs is the one Entire failure with no channel of its
+// own: the write that would report it is the write being dropped, so it exits 0
+// with an empty log and looks exactly like a repo where nothing ran. doctor is
+// the command users reach for when a redaction rule seems not to fire, so it has
+// to be the one that says so.
+func TestCheckLogSink_ReportsUnwritableLogDirectory(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	// A regular file where the directory must go. Chosen over chmod because it
+	// fails MkdirAll on Windows too, where the test suite also runs.
+	entireDir := filepath.Join(dir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "logs"), []byte("not a directory"), 0o600))
+
+	l, err := newLogger(context.Background())
+	require.NoError(t, err, "an unusable log dir must not fail logger construction")
+	t.Cleanup(func() { _ = l.Close() })
+
+	cmd, stdout := newTestCmd(t)
+	cmd.SetContext(logging.WithLogger(cmd.Context(), l))
+	checkLogSink(cmd)
+
+	output := stdout.String()
+	assert.Contains(t, output, "Operational logs: NOT WRITABLE")
+	assert.Contains(t, output, logging.LogsDir,
+		"the report must name the directory to fix")
+}
+
+// The check has to be silent on the happy path, or it trains users to skip
+// doctor's output — and silent for a repo that never set Entire up, where the
+// entry point installs no logger and there is nothing to nag about.
+func TestCheckLogSink_SilentWhenWritableOrAbsent(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	t.Run("writable", func(t *testing.T) {
+		l, err := newLogger(context.Background())
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = l.Close() })
+
+		cmd, stdout := newTestCmd(t)
+		cmd.SetContext(logging.WithLogger(cmd.Context(), l))
+		checkLogSink(cmd)
+
+		assert.Empty(t, stdout.String(), "a writable log directory must produce no output")
+	})
+
+	t.Run("no logger installed", func(t *testing.T) {
+		cmd, stdout := newTestCmd(t)
+		checkLogSink(cmd)
+
+		assert.Empty(t, stdout.String(),
+			"a repo where Entire was never set up has no logger and nothing to report")
+	})
+}
+
 // TestCheckCodexHookTrust_SilentWhenCodexNotInstalled — `entire doctor`
 // shouldn't print anything Codex-related when this repo doesn't have
 // .codex/hooks.json. Other agents (Claude, Cursor) keep their existing

--- a/cmd/entire/cli/logging/logger.go
+++ b/cmd/entire/cli/logging/logger.go
@@ -60,9 +60,12 @@ type Logger struct {
 // logger that wrote to the terminal would splash operational lines over the
 // user's output.
 //
-// A directory that cannot be created or opened is reported by Close, not here —
-// by then lines have already been dropped, which is the same outcome as any
-// other write failure and must never surface as an error in the caller.
+// A directory that cannot be created or opened is not reported here — by then
+// lines have already been dropped, which is the same outcome as any other write
+// failure and must never surface as an error in the caller. Two things can still
+// surface it: Close returns it, and EnsureOpen asks for it up front, which is
+// how `entire doctor` reports a log sink that is silently swallowing every
+// diagnostic.
 func New(cfg Config) (*Logger, error) {
 	if cfg.Dir == "" {
 		return nil, errors.New("logging: Config.Dir is required")
@@ -92,6 +95,36 @@ func (l *Logger) open() error {
 	l.file = f
 	l.buf = bufio.NewWriterSize(f, writeBufferSize)
 	return nil
+}
+
+// EnsureOpen opens the log file now instead of on the first line written, and
+// reports a directory it cannot use.
+//
+// It exists so the failure has one caller that looks: the deferred open drops
+// the line and returns nil, so an unwritable .entire/logs makes every
+// diagnostic vanish with no exit code, no message, and an empty log to grep —
+// indistinguishable from "Entire never ran". `entire doctor` calls this to name
+// it. Idempotent, and nil-safe so a caller need not know whether the entry
+// point installed a logger.
+//
+// It creates the directory and file, which is what the next logged line would
+// have done anyway. That does cost the empty-file-free property New buys for
+// commands that log nothing, so call it from commands that are diagnosing, not
+// from hot paths.
+func (l *Logger) EnsureOpen() error {
+	if l == nil {
+		return nil
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Already open, already closed, or already failed: open() would leak the
+	// current file handle if called a second time.
+	if l.closed || l.buf != nil {
+		return l.openErr
+	}
+	return l.open()
 }
 
 // Slog returns the underlying *slog.Logger, for packages that take one by

--- a/cmd/entire/cli/logging/logger.go
+++ b/cmd/entire/cli/logging/logger.go
@@ -119,8 +119,9 @@ func (l *Logger) EnsureOpen() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	// Already open, already closed, or already failed: open() would leak the
-	// current file handle if called a second time.
+	// A second open() would reassign buf and file, leaking the handle this
+	// logger already holds. A previous failure needs no guard of its own here:
+	// open() memoizes openErr and returns it without retrying the syscalls.
 	if l.closed || l.buf != nil {
 		return l.openErr
 	}

--- a/cmd/entire/cli/logging/logger_test.go
+++ b/cmd/entire/cli/logging/logger_test.go
@@ -144,6 +144,98 @@ func TestLogger_UnusableDirDropsLinesAndCloseReports(t *testing.T) {
 	}
 }
 
+// EnsureOpen is the only way a caller can learn about an unusable log directory
+// before lines start disappearing into it, which is what `entire doctor` needs:
+// the deferred open drops the line and returns nil, so silence is otherwise
+// indistinguishable from a healthy repo that logged nothing.
+func TestEnsureOpen_ReportsUnusableDir(t *testing.T) {
+	t.Parallel()
+
+	occupied := filepath.Join(t.TempDir(), "logs")
+	if err := os.WriteFile(occupied, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("failed to write blocking file: %v", err)
+	}
+	l, err := New(Config{Dir: occupied})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	if err := l.EnsureOpen(); err == nil {
+		t.Error("EnsureOpen() = nil error for a directory that cannot be created")
+	}
+}
+
+// Nil-safe because the caller cannot know whether the entry point installed a
+// logger: a repo where Entire was never set up has none, and that is not a
+// failure to report.
+func TestEnsureOpen_NilLoggerIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	var l *Logger
+	if err := l.EnsureOpen(); err != nil {
+		t.Errorf("(*Logger)(nil).EnsureOpen() = %v, want nil", err)
+	}
+}
+
+// open() reassigns buf and file unconditionally, so a second EnsureOpen must not
+// reach it — that would leak the first handle and orphan any buffered line.
+func TestEnsureOpen_IsIdempotentAndKeepsWriting(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	l, err := New(Config{Dir: dir})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := l.EnsureOpen(); err != nil {
+		t.Fatalf("first EnsureOpen() error = %v", err)
+	}
+	l.Slog().Warn("before the second call")
+	firstFile := l.file
+	if err := l.EnsureOpen(); err != nil {
+		t.Fatalf("second EnsureOpen() error = %v", err)
+	}
+	if l.file != firstFile {
+		t.Error("second EnsureOpen() replaced the open file, leaking the first handle")
+	}
+	l.Slog().Warn("after the second call")
+
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(dir, logFileName))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	for _, want := range []string{"before the second call", "after the second call"} {
+		if !strings.Contains(string(content), want) {
+			t.Errorf("log missing %q, so a line was lost across EnsureOpen: %s", want, content)
+		}
+	}
+}
+
+// The file is created up front, unlike the deferred open New documents — the
+// property doctor trades away for being able to report the failure at all.
+func TestEnsureOpen_CreatesTheFileBeforeAnyLine(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	l, err := New(Config{Dir: dir})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	if err := l.EnsureOpen(); err != nil {
+		t.Fatalf("EnsureOpen() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, logFileName)); err != nil {
+		t.Errorf("EnsureOpen() did not create the log file: %v", err)
+	}
+}
+
 func TestLogger_WritesJSON(t *testing.T) {
 	t.Parallel()
 

--- a/docs/architecture/logging.md
+++ b/docs/architecture/logging.md
@@ -2,7 +2,24 @@
 
 ## Overview
 
-The CLI uses Go's `log/slog` package for structured JSON logging. All logs are written to a single file `.entire/logs/entire.log` and help debug hook execution and CLI behavior. When a session ID is known, the `session_id` attribute on each log line allows filtering by session.
+The CLI uses Go's `log/slog` package for structured JSON logging. All logs are written to a single file `.entire/logs/entire.log` and help debug hook execution and CLI behavior. Lines logged once a session has been resolved carry a `session_id` attribute, which is how you filter the file down to one session.
+
+## Lifecycle
+
+One `*logging.Logger` per process, carried in the context — the package holds no global state, so nothing has to trust that something upstream initialized it.
+
+| Step | Where |
+|------|-------|
+| Build it | The root `PersistentPreRun` (`config.go`'s `ensureLogger`), gated on `settings.IsSetUpAny`. `enable` builds one itself only when that gate declined, which is the fresh-repo case it exists for. |
+| Pass it | `logging.WithLogger(ctx, l)`, read back with `logging.LoggerFromContext(ctx)`. |
+| Close it | The root `PersistentPostRun`, plus `main.go` for the two paths cobra returns on before reaching it (a `RunE` error, and required-flag validation). |
+
+Two consequences worth knowing:
+
+- **A context with no logger falls back to `slog.Default()`**, i.e. the user's terminal. `logging.Debug/Info/Warn/Error` resolve the logger from the context first, so a call site using `context.Background()` writes to stderr no matter what the configured level is — `slog.Default()` is fixed at INFO and ignores `ENTIRE_LOG_LEVEL`.
+- **The log file is created on the first line actually written**, not when the logger is built, so a command that logs nothing leaves no empty `entire.log` behind. The flip side is that a `.entire/logs` that cannot be created reports nothing on its own: the failing write drops the line and returns no error. `entire doctor` calls `Logger.EnsureOpen` to name that case.
+
+Packages that cannot take a context — `redact` holds an injected `*slog.Logger` and calls it without one — get theirs from `logging.SessionLoggerFromContext(ctx)`, which stamps the session but deliberately not the component, since those packages tag their own lines and slog does not dedupe attributes.
 
 ## Log Levels
 
@@ -31,7 +48,7 @@ Logs use a hierarchical tracing model inspired by OpenTelemetry concepts:
 
 | Field | Scope | Description |
 |-------|-------|-------------|
-| `session_id` | Root trace | Entire session ID, auto-added to all log entries |
+| `session_id` | Root trace | Entire session ID. Added to lines logged through a context stamped with `logging.WithSessionID` — the hook paths do this once they have resolved a session, so it is not on every line in the file. A call site that passes `session_id` itself wins, and the context's copy is dropped rather than emitted twice. |
 | `tool_use_id` | Span | Unique ID for a subagent task lifecycle |
 | `agent_id` | Span metadata | The subagent's ID (returned by Claude Code) |
 
@@ -135,6 +152,13 @@ Logs are tagged with a `component` field indicating the logging source:
 |-----------|-------------|
 | `hooks` | Hook execution (agent hooks, git hooks) |
 | `checkpoint` | Checkpoint operations (saves, condensation, branch cleanup) |
+| `lifecycle` | Session phase transitions |
+| `session` | Session state reads and writes |
+| `redaction` | Rule loading, regex compile failures, pack sample mismatches, and the load-time `redaction configured` summary — the lines to grep when a custom rule is not matching |
+| `attribution` | Prompt-to-change attribution |
+| `migration` | Checkpoint-format migration |
+
+The list is not closed — `grep -rn 'WithComponent(' cmd/ internal/` is the source of truth. Smaller ones in use today: `state`, `resume`, `manual-commit`, `attach`, `cleanup`, `summarize`, `condense-by-id`, `filter-uncommitted`, `trail-refresh`.
 
 ## Implementation Details
 
@@ -142,8 +166,10 @@ Logs are tagged with a `component` field indicating the logging source:
 
 | File | Purpose |
 |------|---------|
-| `cmd/entire/cli/logging/logger.go` | Core logging infrastructure |
-| `cmd/entire/cli/logging/context.go` | Context helpers (WithComponent, WithSession) |
+| `cmd/entire/cli/logging/logger.go` | `Logger` (one log file), `New`, `Close`, `EnsureOpen`, and the `Debug/Info/Warn/Error` entry points |
+| `cmd/entire/cli/logging/context.go` | Context carriers: `WithLogger`/`LoggerFromContext`, `SessionLoggerFromContext` for packages that hold a bare `*slog.Logger`, and the attribute decorators `WithSessionID`, `WithComponent`, `WithAgent` |
+| `cmd/entire/cli/config.go` | `ensureLogger`/`newLogger` — the only place a logger is installed, and where the level is resolved |
+| `cmd/entire/cli/root.go` | Builds the logger in `PersistentPreRun`, flushes it in `PersistentPostRun` |
 | `cmd/entire/cli/hooks_git_cmd.go` | Git hook logging (uses gitHookContext helper) |
 | `cmd/entire/cli/hooks_claudecode_handlers.go` | Claude Code hook logging |
 | `cmd/entire/cli/hook_registry.go` | Hook wrapper logging |
@@ -209,4 +235,6 @@ Logs are tagged with a `component` field indicating the logging source:
 
 ### Buffered I/O
 
-Logs use an 8KB buffer (`bufio.Writer`) to batch writes and reduce syscall overhead. The buffer is flushed on `logging.Close()`.
+Logs use an 8KB buffer (`bufio.Writer`) to batch writes and reduce syscall overhead. The buffer is flushed by `Logger.Close`, which the root `PersistentPostRun` calls (and `main.go` for the paths cobra returns on before reaching it). Writes after `Close` are dropped rather than reopening the file.
+
+Because the flush happens at command exit, a long-running command holds up to 8KB of lines invisible for its lifetime — `tail -f` shows nothing until it ends, and a process killed outright loses the buffer.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1111
<!-- entire-trail-link-end -->

Stacked on #1973 — base is `fix/redact-log-routing`, so review that one first.

## Problem

An unwritable `.entire/logs` is the one Entire failure with no channel of its own.

The log file is opened on the first line actually written (`Logger.open`). A failure there stores the error, drops the line, and returns `nil` — deliberately, because losing a log line must never surface as an error in the caller. The error reached exactly one place, `Close()`, whose return value both production callers discard: `root.go`'s `PersistentPostRun` and `main.go`. `openErr` had no reader anywhere in the tree, and `doctor` had no log-writability check.

So a read-only worktree, a root-owned `.entire` after a sudo run, `.entire/logs` occupied by a regular file, or a full disk all presented as: exit 0, no message, empty log to grep.

That is the shape of the support report #1973 exists to fix — a user greps for `component=redaction`, finds nothing, concludes their rules never ran. Reproduced on `fix/redact-log-routing` with `.entire/logs` occupied by a file plus a broken inline rule and a broken PII pattern:

```
$ entire doctor --force ; echo exit=$?
✓ Metadata branches: OK
No stuck sessions found.
exit=0                      # stderr empty; neither broken rule mentioned
```

`main` was louder here: the deleted `Init` fell back to `createLogger(os.Stderr, level)` on both `MkdirAll` and `OpenFile` failure, so those warnings still reached the terminal.

## Fix

`Logger.EnsureOpen` opens up front and returns the error; `doctor` reports it.

```
Operational logs: NOT WRITABLE
  create log directory: mkdir /path/.entire/logs: not a directory
  Entire's diagnostics are being dropped, including the redaction warnings
  that explain why a custom rule isn't matching. `entire doctor logs` and
  `entire doctor bundle` have nothing to report until this is fixed.
  Fix: make .entire/logs writable, then re-run.
```

Read-only. The fixes are ownership and permissions, which doctor cannot take on the user's behalf — so no `--force` path, matching `checkHookDrift`.

Two details worth keeping:

- **doctor reads the logger back out of the context** instead of re-deriving `.entire/logs` from the worktree root, so the check cannot end up probing a different directory than the logger writes to. A nil logger means the entry point declined to build one (Entire was never set up here), which is not something to nag about — and that falls out of the same lookup rather than needing its own gate.
- **`EnsureOpen` returns early when the file is already open.** `open()` reassigns `buf` and `file` unconditionally, so a second call would leak the first handle and orphan whatever was buffered.

Placed before the agent-hook checks in `runSessionsFix`, because it is the channel those checks and every other command write their diagnostics to: if this is broken, an empty `entire.log` is not evidence of a healthy repo.

### Cost, stated plainly

`EnsureOpen` creates the directory and file, so the empty-file-free property lazy opening buys is traded away for whoever calls it. That is why it is a method a diagnosing command opts into rather than something the entry point does. Verified `version`, `__complete`, and `status` still leave no `.entire/logs` behind.

## Comment fixes

- `config.go` had two doc comments merged into one: attached to `ensureLogger`, but opening `// newLogger opens ...` and asserting `// It CREATES the log directory` — untrue since opening became lazy — while `newLogger` itself was undocumented. Split, with `newLogger`'s caller obligation restated narrowly: nothing is created here, so what survives is that a rejected `enable` which goes on to log must leave an untouched repo untouched.
- `logging.New` said an unusable directory "is reported by Close" — true of the return value, false in effect. Now names both surfaces that actually report it.

## Test

- `checkLogSink`: reports on an unwritable dir and names the path; silent when writable; silent with no logger installed. The fixture puts a regular file where the directory goes rather than using chmod, so it also fails `MkdirAll` on Windows, where the suite runs.
- `EnsureOpen`: reports an unusable dir, nil-safe, idempotent without losing a line across the second call, and creates the file up front.
- `mise run fmt` clean, `mise run lint` 0 issues, `mise run test:ci` green (unit + integration + canary 56/56 and 4/4).
- Verified against a built binary on the repro above: the failure is now named, and the happy path stays silent.

## Also here: two stale docs the refactor invalidated

Second commit, no behaviour change. Both described a binary that no longer exists, and both were found while reviewing #1973.

**`docs/architecture/logging.md`** documented `logging.Close()` (deleted); described `session_id` as "auto-added to all log entries" (now only under a `WithSessionID` context); listed `context.go`'s helpers as "WithComponent, WithSession" — a name that never existed — with no mention of `WithLogger`, `LoggerFromContext`, or `SessionLoggerFromContext`; and listed 2 of the 16 `component` values actually in use, omitting `redaction`, the one this work exists to make greppable.

Added the lifecycle section the doc never had — who builds the logger, who passes it, who closes it — since that is both what changed and what a reader now needs. With it, the two behaviours that surprise people:

- a context carrying no logger falls back to `slog.Default()`, which is the terminal and is pinned at INFO regardless of `ENTIRE_LOG_LEVEL`;
- the file appears on the first line written, so an absent `entire.log` is not by itself evidence of anything.

Also noted that the 8KB buffer is flushed at command exit, so a long-running command's lines are invisible to `tail -f` until it ends and are lost if it is killed. Components are given as a table of the ones worth knowing plus a `grep`, rather than an exhaustive list that would go stale the same way.

**`cmd/entire/cli/context_flag.go`** justified binding `--context` through a `pflag.Value` with "Cobra runs only the CLOSEST PersistentPreRun in the chain" — false since #1973 set `cobra.EnableTraverseRunHooks`. Left alone, that file and `root.go` documented opposite cobra semantics. The conclusion still holds on its own terms (`Set()` runs during flag parsing, earlier than any pre-run), so the dead half is replaced by a note that the ordering is now the only reason.

## Not in scope

Left for whoever picks them up, all found while reviewing #1973:

- **`entire mcp` buffers its diagnostics for its whole lifetime.** It is a long-lived stdio server that now gets a logger from the root pre-run, and the 8KB buffer only flushes on `Close()` — so `tail -f entire.log` shows nothing while the host session is live, and a host that SIGKILLs the server on shutdown loses the buffer. Before #1973 `mcp` called no `Init`, so those lines went to stderr where the host captured them immediately. Documented in `logging.md` here; not fixed, and not verified end to end.
- `docs/security-and-privacy.md`'s "My rule doesn't redact anything" entry doesn't mention the new `redaction configured` summary line, which is the direct answer to that exact question.
- `root.go`'s traverse comment names `checkpoint`, `session`, and `agent`, but `hooks_git_cmd.go` and `hook_registry.go` also define `PersistentPreRun`, so the per-commit and per-turn hook paths depend on traversal just as much. `root_logging_test.go` covers the same three and omits both hook trees.
- `TestHookPreRuns_GateSkipsRepo` leaves the `gitHooksDisabled` package global set to `true`; every other test in that file self-defends with `gitHooksDisabled = false`.
- `redact/pii.go`: when `compilePIIPatterns` returns nil (no builtins enabled and every custom pattern dropped), `detectPII` recompiles per call, so an invalid `custom_patterns` entry could warn once per redacted string — now into the log file rather than stderr. Reported by review, not verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit dff8679d7763b65e3ab5144b34ebc7931987f154. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
