### PR TITLE
docs(checkpoints): OPF does not follow the checkpoint primary

### DIFF
--- a/docs/architecture/ref-checkpoint-backend.md
+++ b/docs/architecture/ref-checkpoint-backend.md
@@ -22,7 +22,7 @@ Both backends are **git-backed** — they store the committed record in the repo
 
 Checkpoint storage is pluggable. The topology is a single **primary** plus zero or more **mirrors**:
 
-- **Primary** — the source of truth. It serves all reads and writes, and the full checkpoint lifecycle (resume bootstrap, `doctor` reconcile, `explain` tree reads, push, cleanup, pre-push OPF) drives *its* record.
+- **Primary** — the source of truth. It serves all reads and writes, and the full checkpoint lifecycle (resume bootstrap, `doctor` reconcile, `explain` tree reads, push, cleanup) drives *its* record. Pre-push OPF is the one exception: it is git-branch-only, and does not follow the primary (see [Known limitations](#known-limitations-and-deferred-work)).
 - **Mirror** — an independent backend that receives best-effort **write fan-out** only. Reads never come from a mirror.
 
 Backends register in `checkpoint/registry.go`. Each carries a `gitBacked` capability:


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1112
<!-- entire-trail-link-end -->

One line. `ref-checkpoint-backend.md`'s backend-taxonomy section listed pre-push OPF among the lifecycle paths the **primary** backend drives:

> **Primary** — … the full checkpoint lifecycle (resume bootstrap, `doctor` reconcile, `explain` tree reads, push, cleanup, **pre-push OPF**) drives *its* record.

Its own "Known limitations" section, 200 lines further down, says the opposite:

> **OPF (OpenAI Privacy Filter) at pre-push is git-branch-only for now.** The per-ref push does not run OPF re-redaction.

The code agrees with the limitations section: `RewriteUnpushedV1WithOPF` has exactly one call site, on the git-branch pre-push path, and the git-refs per-ref push runs no OPF re-redaction.

Worth fixing rather than leaving as a doc nit, because it is load-bearing for anything that adds new content to a checkpoint: read the first list and you conclude the 9th redaction layer follows whatever backend you configured — so shipping content to git-refs looks safe when it silently gets 8.

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 72d471affde4e854e56d8ec8d54460475b2dd565. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->