### PR TITLE
test(hooks): guard the committed dogfood configs against template drift

### DIFF
--- a/cmd/entire/cli/dogfood_hooks_test.go
+++ b/cmd/entire/cli/dogfood_hooks_test.go
@@ -10,6 +10,15 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 )
 
+// committedHookConfigAgents are the agents whose Entire hook config this repo
+// commits: .claude/settings.json, .opencode/plugins/entire.ts, and
+// .pi/extensions/entire/index.ts. Each must be found and current.
+//
+// Named rather than counted. A count would let a newly added agent paper over a
+// committed config that went missing — one appears, one disappears, the total
+// still matches and the test keeps passing while silently guarding less.
+var committedHookConfigAgents = []string{"claude-code", "opencode", "pi"}
+
 // TestCommittedHookConfigsAreCurrent pins this repo's own committed Entire hook
 // configs against what the CLI would install today.
 //
@@ -38,7 +47,7 @@ func TestCommittedHookConfigsAreCurrent(t *testing.T) {
 	t.Chdir(repoRootFromSource(t))
 
 	ctx := context.Background()
-	checked := 0
+	checked := make(map[string]agent.HookConfigState)
 	for _, name := range agent.List() {
 		ag, err := agent.Get(name)
 		if err != nil {
@@ -49,44 +58,52 @@ func TestCommittedHookConfigsAreCurrent(t *testing.T) {
 		if !ok {
 			continue // this agent has no drift check
 		}
-		switch hf.CheckHookConfig(ctx) {
-		case agent.HooksAbsent:
-			// This repo commits no config for this agent — nothing to pin.
-		case agent.HooksCurrent:
-			checked++
-		case agent.HooksOutdated:
-			checked++
+		state := hf.CheckHookConfig(ctx)
+		checked[string(name)] = state
+		if state == agent.HooksOutdated {
 			t.Errorf("committed %s hook config is stale: it no longer matches what "+
 				"InstallHooks writes today. Regenerate with `entire enable --force` "+
 				"at the repo root and commit the result.", ag.Type())
 		}
 	}
 
-	// Without this the test passes vacuously if the committed configs are moved
-	// or renamed: every agent would report HooksAbsent and nothing would be
-	// compared. Failing loudly is the point — a drift guard that quietly stops
-	// guarding is worse than none.
-	if checked == 0 {
-		t.Fatal("no committed hook configs were checked; expected at least one " +
-			"(.pi/extensions/entire/index.ts, .opencode/plugins/entire.ts, " +
-			".claude/settings.json). Either they moved or CheckHookConfig now " +
-			"reports HooksAbsent for all of them")
+	// Assert per agent, not in aggregate. Checking only that *something* was
+	// compared would let this test keep passing while quietly no longer guarding
+	// one of the configs — the same silent-rot failure mode it exists to catch.
+	for _, name := range committedHookConfigAgents {
+		state, ok := checked[name]
+		switch {
+		case !ok:
+			t.Errorf("%s reported no hook-config drift check; this repo commits a "+
+				"config for it, so it must still implement agent.HookFreshness", name)
+		case state == agent.HooksAbsent:
+			t.Errorf("no committed hook config found for %s; this repo is supposed to "+
+				"commit one. If it was intentionally removed, drop %s from "+
+				"committedHookConfigAgents", name, name)
+		}
 	}
 }
 
-// repoRootFromSource returns this repo's root, derived from this file's own
-// compiled-in path rather than the working directory: package cli has tests that
-// t.Chdir, and the root must not depend on what an earlier one left behind.
+// repoRootFromSource returns this repo's root: the nearest directory at or above
+// this file that holds a go.mod.
+//
+// Anchored on this file's own compiled-in path rather than the working
+// directory, because package cli has tests that t.Chdir and the root must not
+// depend on what an earlier one left behind.
 func repoRootFromSource(t *testing.T) string {
 	t.Helper()
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("runtime.Caller: no caller information")
 	}
-	// This file lives at <root>/cmd/entire/cli/dogfood_hooks_test.go.
-	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
-	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
-		t.Fatalf("derived repo root %q has no go.mod (did this file move?): %v", root, err)
+	for dir := filepath.Dir(file); ; {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod at or above %s", filepath.Dir(file))
+		}
+		dir = parent
 	}
-	return root
 }

--- a/cmd/entire/cli/dogfood_hooks_test.go
+++ b/cmd/entire/cli/dogfood_hooks_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// TestCommittedHookConfigsAreCurrent pins this repo's own committed Entire hook
+// configs against what the CLI would install today.
+//
+// This repo commits its dogfood hook configs so every clone gets checkpointing
+// without each person running `entire enable`. Those copies are generated from
+// templates that live in the same tree and keep moving, and nothing regenerates
+// them — so they rot silently. Neither guard that looks at them catches it:
+// AreHooksInstalled only greps the ownership marker, which survives any template
+// change, and Pi's fireHook swallows every error by design. The committed Pi
+// extension sat two commits behind its template for three weeks that way, which
+// cost anyone dogfooding Pi here the ENTIRE_PI_NESTED guard — a subagent
+// forwarded its own lifecycle as if it were the user's session.
+//
+// CheckHookConfig already detects this; it just had no caller on the CI path, so
+// only whoever happened to run `entire doctor` would see it. Running it here
+// fails the next template edit in CI instead of on a teammate's machine.
+//
+// When this fails: run `entire enable --force` at the repo root and commit the
+// regenerated files.
+func TestCommittedHookConfigsAreCurrent(t *testing.T) {
+	// t.Chdir is process-global, so this test must not be parallel. It is needed
+	// because CheckHookConfig resolves the config paths from the working
+	// directory via paths.WorktreeRoot. That resolution is cached, but the cache
+	// is keyed on the working directory, so chdir invalidates it rather than
+	// handing us a root some earlier test left behind.
+	t.Chdir(repoRootFromSource(t))
+
+	ctx := context.Background()
+	checked := 0
+	for _, name := range agent.List() {
+		ag, err := agent.Get(name)
+		if err != nil {
+			t.Errorf("agent.Get(%s): %v", name, err)
+			continue
+		}
+		hf, ok := agent.AsHookFreshness(ag)
+		if !ok {
+			continue // this agent has no drift check
+		}
+		switch hf.CheckHookConfig(ctx) {
+		case agent.HooksAbsent:
+			// This repo commits no config for this agent — nothing to pin.
+		case agent.HooksCurrent:
+			checked++
+		case agent.HooksOutdated:
+			checked++
+			t.Errorf("committed %s hook config is stale: it no longer matches what "+
+				"InstallHooks writes today. Regenerate with `entire enable --force` "+
+				"at the repo root and commit the result.", ag.Type())
+		}
+	}
+
+	// Without this the test passes vacuously if the committed configs are moved
+	// or renamed: every agent would report HooksAbsent and nothing would be
+	// compared. Failing loudly is the point — a drift guard that quietly stops
+	// guarding is worse than none.
+	if checked == 0 {
+		t.Fatal("no committed hook configs were checked; expected at least one " +
+			"(.pi/extensions/entire/index.ts, .opencode/plugins/entire.ts, " +
+			".claude/settings.json). Either they moved or CheckHookConfig now " +
+			"reports HooksAbsent for all of them")
+	}
+}
+
+// repoRootFromSource returns this repo's root, derived from this file's own
+// compiled-in path rather than the working directory: package cli has tests that
+// t.Chdir, and the root must not depend on what an earlier one left behind.
+func repoRootFromSource(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller: no caller information")
+	}
+	// This file lives at <root>/cmd/entire/cli/dogfood_hooks_test.go.
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("derived repo root %q has no go.mod (did this file move?): %v", root, err)
+	}
+	return root
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1113
<!-- entire-trail-link-end -->

## TL;DR

This repo's committed dogfood hook configs are generated from templates in the same tree, and nothing checks they stay in sync. `CheckHookConfig` already detects the drift — it just had no caller on the CI path. This wires it up as a test.

## Problem

`.pi/extensions/entire/index.ts`, `.opencode/plugins/entire.ts`, and `.claude/settings.json` are committed so every clone gets checkpointing without each person running `entire enable`. They're generated, so they go stale whenever the template moves — and both guards that look at them are blind to it:

- `AreHooksInstalled` only greps the ownership marker, which survives any template change.
- Pi's `fireHook` swallows every error by design, so broken hooks are silent.

The committed Pi extension sat two commits behind its template for three weeks that way (`ed42608db` → `d55dfa643`). The cost was the `ENTIRE_PI_NESTED` guard: a Pi subagent forwarded its own lifecycle as if it were the user's session. `a9a676e79` swept it up when it removed local_dev mode, but fixed the symptom across all six artifacts by hand, not the cause.

`entire doctor` reports this correctly today — but only for whoever happens to run it.

## Solution

One test in `cmd/entire/cli` that runs the same `CheckHookConfig` doctor uses, over every registered agent implementing `agent.HookFreshness`, against this repo's own committed configs. `HooksOutdated` fails; `HooksAbsent` is fine (nothing committed for that agent).

No new drift-detection machinery — the check already existed and is already tested. This only puts it on the CI path.

Coverage is whatever implements `HookFreshness`, so a future agent is picked up for free. Today that's Claude Code, OpenCode, and Pi — all three currently `HooksCurrent`. Codex, Cursor, Gemini, Copilot CLI and Factory Droid have no drift check at all, so their committed configs stay unguarded; that's a pre-existing gap this PR doesn't widen or close.

## Test plan

Both arms verified by simulating drift and confirming the failure, then reverting:

| Simulation | Result |
| --- | --- |
| Added a comment line to `entire_extension.ts` (the historical bug: template moves, committed copy doesn't) | ❌ `committed Pi hook config is stale…` |
| Dropped the `TaskCreate\|TaskUpdate` PostToolUse matcher from `.claude/settings.json` | ❌ `committed Claude Code hook config is stale…` |
| Clean tree | ✅ passes, 3 configs checked |

The `checked == 0` guard fails loudly if the configs are moved or renamed, so the test can't quietly stop guarding.

`mise run lint` → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
