### PR TITLE
refactor(hooks): stage absolute_git_hook_path scoping, and detect a dead pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,10 +378,15 @@ entire configure --telemetry=false
 
 # Reinstall the Entire git hook with an absolute binary path, for GUI git
 # clients (Xcode, Tower) that never source a shell profile and so cannot find
-# `entire` on PATH. It names this machine's binary, so it is written to and
-# honored only from .entire/settings.local.json — committing it to
-# .entire/settings.json would pin every cloner's hooks to a path chosen on
-# whichever machine ran the command, and Entire ignores it there.
+# `entire` on PATH. It names this machine's binary, so it is written to
+# .entire/settings.local.json.
+#
+# If you have absolute_git_hook_path in a committed .entire/settings.json (which
+# is where earlier versions of this flag put it), it still works today, but a
+# future release will honor it only from the local file — committing it pins
+# every cloner's hooks to a path chosen on whichever machine ran the command.
+# `entire doctor` will copy it across for you; your own hooks keep working
+# unchanged.
 entire configure --absolute-git-hook-path
 
 # Update strategy options on an existing repo

--- a/README.md
+++ b/README.md
@@ -376,7 +376,12 @@ entire configure
 # Opt out of telemetry
 entire configure --telemetry=false
 
-# Reinstall the Entire git hook with an absolute binary path
+# Reinstall the Entire git hook with an absolute binary path, for GUI git
+# clients (Xcode, Tower) that never source a shell profile and so cannot find
+# `entire` on PATH. It names this machine's binary, so it is written to and
+# honored only from .entire/settings.local.json — committing it to
+# .entire/settings.json would pin every cloner's hooks to a path chosen on
+# whichever machine ran the command, and Entire ignores it there.
 entire configure --absolute-git-hook-path
 
 # Update strategy options on an existing repo

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"charm.land/huh/v2"
@@ -534,7 +535,18 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 	ctx := cmd.Context()
 	w := cmd.OutOrStdout()
 
-	switch strategy.CheckGitHookState(ctx) {
+	// Reported whatever the hook state is: a setting present in the repository
+	// but deliberately not applied is confusing precisely when everything else
+	// looks fine.
+	if s, err := settings.Load(ctx); err == nil {
+		if reason := s.AbsoluteGitHookPathRejection(); reason != "" {
+			fmt.Fprintln(w, "Git hooks: absolute_git_hook_path ignored")
+			fmt.Fprintf(w, "  %s\n", reason)
+		}
+	}
+
+	state, outdatedReason := strategy.CheckGitHookStateWithReason(ctx)
+	switch state {
 	case strategy.GitHooksCurrent:
 		fmt.Fprintln(w, "✓ Git hooks: OK")
 		return nil
@@ -560,10 +572,12 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 	case strategy.GitHooksOutdated:
 		// Actionable whatever the settings say: a hook carrying Entire's marker
 		// means this repo opted in at some point, and a stale one is actively
-		// broken rather than merely missing.
+		// broken rather than merely missing. The reason comes from the check
+		// because the causes need different advice.
 		fmt.Fprintln(w, "Git hooks: OUT OF DATE")
-		fmt.Fprintln(w, "  A hook still runs Entire from the working tree instead of the installed")
-		fmt.Fprintln(w, "  binary. This can reject `git push`, because the path it names is gone.")
+		for line := range strings.SplitSeq(outdatedReason, "\n") {
+			fmt.Fprintf(w, "  %s\n", line)
+		}
 	}
 	fmt.Fprintln(w, "  Fix: reinstall the managed git hooks (any non-Entire hook is backed up).")
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -534,23 +534,49 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 	ctx := cmd.Context()
 	w := cmd.OutOrStdout()
 
-	reportAbsoluteGitHookPathRejection := func() {
-		// A setting present in the repository but deliberately not applied is
-		// confusing precisely when everything else looks fine, so this is
-		// reported alongside a healthy result too — but not in a repository that
-		// never opted into Entire, where the whole check stays silent.
-		if s, err := settings.Load(ctx); err == nil {
-			if reason := s.AbsoluteGitHookPathRejection(); reason != "" {
-				fmt.Fprintln(w, "Git hooks: absolute_git_hook_path ignored")
-				fmt.Fprintf(w, "  %s\n", reason)
+	migrateAbsoluteGitHookPath := func() {
+		// Reported alongside a healthy result too: the hooks are fine today and
+		// will stop being fine on upgrade, which is exactly when a warning is
+		// worth reading. Not reported in a repository that never opted into
+		// Entire, where the whole check stays silent.
+		s, err := settings.Load(ctx)
+		if err != nil || s.AbsoluteGitHookPathDeprecation() == "" {
+			return
+		}
+		fmt.Fprintln(w, "absolute_git_hook_path: COMMITTED")
+		fmt.Fprintf(w, "  %s\n", s.AbsoluteGitHookPathDeprecation())
+		fmt.Fprintf(w, "  Fix: copy it to %s. Your hooks keep working exactly as they do now.\n",
+			settings.EntireSettingsLocalFile)
+
+		if !force {
+			// Same degradation as the hook repair below: an agent or CI run must
+			// not block on a prompt, and must not edit settings unasked.
+			if !interactive.CanPromptInteractively() {
+				fmt.Fprintln(w, "  Run `entire doctor --force` to apply it.")
+				return
+			}
+			proceed, promptErr := confirmDoctorFix(ctx, w, "Copy absolute_git_hook_path to local settings?")
+			if promptErr != nil || !proceed {
+				return
 			}
 		}
+
+		// Copy, not move: the committed key is left alone. Editing a tracked file
+		// would put an unexpected change in the user's next commit, and once the
+		// local file sets the key the committed one is redundant — it stops being
+		// honored on upgrade without anything else happening.
+		if err := setAbsoluteGitHookPathLocal(ctx, true); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "  could not write %s: %v\n", settings.EntireSettingsLocalFile, err)
+			return
+		}
+		fmt.Fprintf(w, "  ✓ Copied to %s (the committed value is now redundant and can be removed at your leisure)\n",
+			settings.EntireSettingsLocalFile)
 	}
 
 	state, outdatedReason := strategy.CheckGitHookState(ctx)
 	switch state {
 	case strategy.GitHooksCurrent:
-		reportAbsoluteGitHookPathRejection()
+		migrateAbsoluteGitHookPath()
 		fmt.Fprintln(w, "✓ Git hooks: OK")
 		return nil
 
@@ -569,7 +595,7 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 		if !settings.IsSetUpAny(ctx) {
 			return nil
 		}
-		reportAbsoluteGitHookPathRejection()
+		migrateAbsoluteGitHookPath()
 		fmt.Fprintln(w, "Git hooks: NOT INSTALLED")
 		fmt.Fprintln(w, "  Commits in this repository are not captured as checkpoints.")
 
@@ -578,7 +604,7 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 		// means this repo opted in at some point, and a stale one is actively
 		// broken rather than merely missing. The reason comes from the check
 		// because the causes need different advice.
-		reportAbsoluteGitHookPathRejection()
+		migrateAbsoluteGitHookPath()
 		fmt.Fprintln(w, "Git hooks: OUT OF DATE")
 		fmt.Fprintf(w, "  %s\n", outdatedReason)
 	}

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"charm.land/huh/v2"
@@ -535,19 +534,23 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 	ctx := cmd.Context()
 	w := cmd.OutOrStdout()
 
-	// Reported whatever the hook state is: a setting present in the repository
-	// but deliberately not applied is confusing precisely when everything else
-	// looks fine.
-	if s, err := settings.Load(ctx); err == nil {
-		if reason := s.AbsoluteGitHookPathRejection(); reason != "" {
-			fmt.Fprintln(w, "Git hooks: absolute_git_hook_path ignored")
-			fmt.Fprintf(w, "  %s\n", reason)
+	reportAbsoluteGitHookPathRejection := func() {
+		// A setting present in the repository but deliberately not applied is
+		// confusing precisely when everything else looks fine, so this is
+		// reported alongside a healthy result too — but not in a repository that
+		// never opted into Entire, where the whole check stays silent.
+		if s, err := settings.Load(ctx); err == nil {
+			if reason := s.AbsoluteGitHookPathRejection(); reason != "" {
+				fmt.Fprintln(w, "Git hooks: absolute_git_hook_path ignored")
+				fmt.Fprintf(w, "  %s\n", reason)
+			}
 		}
 	}
 
-	state, outdatedReason := strategy.CheckGitHookStateWithReason(ctx)
+	state, outdatedReason := strategy.CheckGitHookState(ctx)
 	switch state {
 	case strategy.GitHooksCurrent:
+		reportAbsoluteGitHookPathRejection()
 		fmt.Fprintln(w, "✓ Git hooks: OK")
 		return nil
 
@@ -566,6 +569,7 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 		if !settings.IsSetUpAny(ctx) {
 			return nil
 		}
+		reportAbsoluteGitHookPathRejection()
 		fmt.Fprintln(w, "Git hooks: NOT INSTALLED")
 		fmt.Fprintln(w, "  Commits in this repository are not captured as checkpoints.")
 
@@ -574,10 +578,9 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 		// means this repo opted in at some point, and a stale one is actively
 		// broken rather than merely missing. The reason comes from the check
 		// because the causes need different advice.
+		reportAbsoluteGitHookPathRejection()
 		fmt.Fprintln(w, "Git hooks: OUT OF DATE")
-		for line := range strings.SplitSeq(outdatedReason, "\n") {
-			fmt.Fprintf(w, "  %s\n", line)
-		}
+		fmt.Fprintf(w, "  %s\n", outdatedReason)
 	}
 	fmt.Fprintln(w, "  Fix: reinstall the managed git hooks (any non-Entire hook is backed up).")
 

--- a/cmd/entire/cli/integration_test/local_dev_migration_test.go
+++ b/cmd/entire/cli/integration_test/local_dev_migration_test.go
@@ -338,3 +338,65 @@ func TestDoctor_LeavesNeverEnabledRepoAlone(t *testing.T) {
 		t.Error("doctor backed up the repo's own hook, so it installed over it")
 	}
 }
+
+// TestDoctor_MigratesCommittedAbsoluteGitHookPath covers the staged rollout for
+// absolute_git_hook_path.
+//
+// The only way to enable that feature used to write it exclusively to the
+// committed .entire/settings.json, so everyone who ever used it has it there. It
+// is still honored from that scope; doctor warns and offers to copy it to the
+// local file, so a later release can stop honoring the committed value without
+// unpinning anyone's hooks. Copy, not move: editing a tracked file would land an
+// unexpected change in the user's next commit.
+func TestDoctor_MigratesCommittedAbsoluteGitHookPath(t *testing.T) {
+	t.Parallel()
+
+	env := NewRepoWithCommit(t)
+	settingsPath := filepath.Join(env.RepoDir, ".entire", "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{
+  "enabled": true,
+  "absolute_git_hook_path": true
+}
+`), 0o600); err != nil {
+		t.Fatalf("failed to seed committed settings: %v", err)
+	}
+
+	out, err := env.RunCLIWithError("doctor", "--force")
+	if err != nil {
+		t.Fatalf("doctor --force failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "absolute_git_hook_path: COMMITTED") {
+		t.Errorf("doctor should warn about the committed setting, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Copied to") {
+		t.Errorf("doctor --force should perform the copy, got:\n%s", out)
+	}
+
+	localPath := filepath.Join(env.RepoDir, ".entire", "settings.local.json")
+	local, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("the migration should have written the local file: %v", err)
+	}
+	if !strings.Contains(string(local), "absolute_git_hook_path") {
+		t.Errorf("local settings should carry the migrated key, got:\n%s", local)
+	}
+
+	// Copy, not move: the committed file is untouched, so the user gets no
+	// surprise diff and nothing breaks if they never upgrade.
+	project, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(project), "absolute_git_hook_path") {
+		t.Errorf("the committed value must be left in place, got:\n%s", project)
+	}
+
+	// Having migrated, the warning stops: the committed value is now redundant.
+	out, err = env.RunCLIWithError("doctor", "--force")
+	if err != nil {
+		t.Fatalf("second doctor --force failed: %v\noutput: %s", err, out)
+	}
+	if strings.Contains(out, "absolute_git_hook_path: COMMITTED") {
+		t.Errorf("the warning should stop once the local file sets the key, got:\n%s", out)
+	}
+}

--- a/cmd/entire/cli/settings/absolute_hook_path_scope.go
+++ b/cmd/entire/cli/settings/absolute_hook_path_scope.go
@@ -1,0 +1,37 @@
+package settings
+
+// absoluteGitHookPathProjectReason explains why absolute_git_hook_path is
+// ignored when it comes from the committed project file.
+const absoluteGitHookPathProjectReason = "it was set in .entire/settings.json, which is committed — absolute_git_hook_path describes one machine's installation, so it is honored only from .entire/settings.local.json"
+
+// enforceAbsoluteGitHookPathScope drops absolute_git_hook_path unless it comes
+// from a scope that is local to this clone.
+//
+// The setting replaces bare "entire" in every generated git hook with the
+// absolute path of the binary that ran `entire enable`. That is the right trade
+// for the GUI git clients it exists for, but it is a statement about one
+// machine's filesystem, and honoring it from a version-controlled file lets a
+// repository impose it on everyone who clones — pinning their hooks to a path
+// chosen by whichever binary they happened to run, which is strictly more
+// brittle than resolving through PATH.
+//
+// Unlike the OPF command gate this does NOT re-verify the local file with the
+// deep index-and-HEAD check, and the difference is deliberate: that setting
+// becomes argv[0] of an exec, so an attacker-controlled value runs code. This
+// one only chooses between "entire" and os.Executable() — a binary the user
+// already invoked — so the worst outcome is a fragile hook, not execution of
+// someone else's payload. The layer-level tracked-file rejection
+// (localLayerTrackedReason) already covers the case of a committed local file.
+//
+// Called after the project file is loaded and before the local layer merges, so
+// a value seen here can only have come from the project file. A rejection is
+// recorded rather than logged: the loader is reached from logging.Init, and a
+// line in .entire/logs is not a signal anyone sees — `entire status` and
+// `entire doctor` report it instead.
+func enforceAbsoluteGitHookPathScope(s *EntireSettings) {
+	if s == nil || !s.AbsoluteGitHookPath {
+		return
+	}
+	s.AbsoluteGitHookPath = false
+	s.absoluteGitHookPathRejection = absoluteGitHookPathProjectReason
+}

--- a/cmd/entire/cli/settings/absolute_hook_path_scope.go
+++ b/cmd/entire/cli/settings/absolute_hook_path_scope.go
@@ -1,11 +1,26 @@
 package settings
 
-// absoluteGitHookPathProjectReason explains why absolute_git_hook_path is
-// ignored when it comes from the committed project file.
-const absoluteGitHookPathProjectReason = "it was set in .entire/settings.json, which is committed — absolute_git_hook_path describes one machine's installation, so it is honored only from .entire/settings.local.json"
+import "encoding/json"
 
-// recordAbsoluteGitHookPathScopeRejection notes that a committed
-// absolute_git_hook_path was not applied.
+// absoluteGitHookPathProjectDeprecation is shown when absolute_git_hook_path is
+// being honored from the committed project file.
+const absoluteGitHookPathProjectDeprecation = "absolute_git_hook_path is set in .entire/settings.json, which is committed. It describes one machine's installation, so a future release will honor it only from .entire/settings.local.json. Run `entire doctor` to copy it there now — nothing changes for you, and the committed value stops pinning your collaborators' hooks."
+
+// localSetsAbsoluteGitHookPath reports whether the local override file explicitly
+// sets absolute_git_hook_path.
+//
+// Presence is the question, not value: both layers may set the same bool, so
+// comparing the effective value after the merge would misattribute provenance.
+func localSetsAbsoluteGitHookPath(data []byte) bool {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+	return rawHasKey(raw, "absolute_git_hook_path")
+}
+
+// recordAbsoluteGitHookPathDeprecation notes that absolute_git_hook_path is being
+// honored from the committed project file, which a future release will stop doing.
 //
 // The setting replaces bare "entire" in every generated git hook with the absolute
 // path of the binary that ran `entire enable`. That is the right trade for the GUI
@@ -13,26 +28,33 @@ const absoluteGitHookPathProjectReason = "it was set in .entire/settings.json, w
 // and honoring it from a version-controlled file lets a repository impose it on
 // everyone who clones — pinning their hooks to a path chosen by whichever binary
 // they happened to run, which is strictly more brittle than resolving through
-// PATH. The loader therefore zeroes it before the local layer merges, and only the
-// local file can turn it back on.
+// PATH.
 //
-// Unlike the OPF command gate this does NOT re-verify the local file with the deep
-// index-and-HEAD check, and the difference is deliberate: that setting becomes
-// argv[0] of an exec, so an attacker-controlled value runs code. This one only
-// chooses between "entire" and os.Executable() — a binary the user already invoked
-// — so the worst outcome is a fragile hook, not execution of someone else's
-// payload. The layer-level tracked-file rejection (localLayerTrackedReason)
-// already covers the case of a committed local file.
+// Staged rather than switched off here, because the only way to enable the feature
+// used to write it exclusively to the project file: `entire configure
+// --absolute-git-hook-path` reported "Settings updated (.entire/settings.json)"
+// and created no local file at all. Everyone who ever used the feature therefore
+// has it committed, and dropping it silently would unpin their hooks — in the GUI
+// git client that cannot find `entire` on PATH, which is the whole reason they
+// enabled it. The guard would take its else branch and capture nothing, with no
+// error. This is a robustness fix, not a security one (the value only chooses
+// between "entire" and os.Executable(), a binary the user already invoked), so
+// there is no case for breaking anyone quickly.
 //
-// Called with the final merged value so the record reflects the outcome: if the
-// local file enabled the setting anyway, the project value was redundant rather
-// than overridden, and reporting "ignored" beside a hook that IS pinned reads as a
-// contradiction. Recorded rather than logged — the loader is reached from
-// logging.Init, and a line in .entire/logs is not a signal anyone sees, so
-// `entire status` and `entire doctor` report it instead.
-func recordAbsoluteGitHookPathScopeRejection(s *EntireSettings, projectRequested bool) {
-	if s == nil || !projectRequested || s.AbsoluteGitHookPath {
+// Provenance comes from the local file's raw keys rather than from call order, so
+// this is safe to call at any point after the merge.
+//
+// Recorded rather than logged: the loader is reached from logging.Init, and a line
+// in .entire/logs is not a signal anyone sees, so `entire status` and `entire
+// doctor` report it instead.
+func recordAbsoluteGitHookPathDeprecation(s *EntireSettings, localData []byte) {
+	if s == nil || !s.AbsoluteGitHookPath {
 		return
 	}
-	s.absoluteGitHookPathRejection = absoluteGitHookPathProjectReason
+	if localSetsAbsoluteGitHookPath(localData) {
+		// Already migrated: the local file is the authority, and the committed
+		// value is redundant rather than load-bearing.
+		return
+	}
+	s.absoluteGitHookPathDeprecation = absoluteGitHookPathProjectDeprecation
 }

--- a/cmd/entire/cli/settings/absolute_hook_path_scope.go
+++ b/cmd/entire/cli/settings/absolute_hook_path_scope.go
@@ -4,34 +4,35 @@ package settings
 // ignored when it comes from the committed project file.
 const absoluteGitHookPathProjectReason = "it was set in .entire/settings.json, which is committed — absolute_git_hook_path describes one machine's installation, so it is honored only from .entire/settings.local.json"
 
-// enforceAbsoluteGitHookPathScope drops absolute_git_hook_path unless it comes
-// from a scope that is local to this clone.
+// recordAbsoluteGitHookPathScopeRejection notes that a committed
+// absolute_git_hook_path was not applied.
 //
-// The setting replaces bare "entire" in every generated git hook with the
-// absolute path of the binary that ran `entire enable`. That is the right trade
-// for the GUI git clients it exists for, but it is a statement about one
-// machine's filesystem, and honoring it from a version-controlled file lets a
-// repository impose it on everyone who clones — pinning their hooks to a path
-// chosen by whichever binary they happened to run, which is strictly more
-// brittle than resolving through PATH.
+// The setting replaces bare "entire" in every generated git hook with the absolute
+// path of the binary that ran `entire enable`. That is the right trade for the GUI
+// git clients it exists for, but it is a statement about one machine's filesystem,
+// and honoring it from a version-controlled file lets a repository impose it on
+// everyone who clones — pinning their hooks to a path chosen by whichever binary
+// they happened to run, which is strictly more brittle than resolving through
+// PATH. The loader therefore zeroes it before the local layer merges, and only the
+// local file can turn it back on.
 //
-// Unlike the OPF command gate this does NOT re-verify the local file with the
-// deep index-and-HEAD check, and the difference is deliberate: that setting
-// becomes argv[0] of an exec, so an attacker-controlled value runs code. This
-// one only chooses between "entire" and os.Executable() — a binary the user
-// already invoked — so the worst outcome is a fragile hook, not execution of
-// someone else's payload. The layer-level tracked-file rejection
-// (localLayerTrackedReason) already covers the case of a committed local file.
+// Unlike the OPF command gate this does NOT re-verify the local file with the deep
+// index-and-HEAD check, and the difference is deliberate: that setting becomes
+// argv[0] of an exec, so an attacker-controlled value runs code. This one only
+// chooses between "entire" and os.Executable() — a binary the user already invoked
+// — so the worst outcome is a fragile hook, not execution of someone else's
+// payload. The layer-level tracked-file rejection (localLayerTrackedReason)
+// already covers the case of a committed local file.
 //
-// Called after the project file is loaded and before the local layer merges, so
-// a value seen here can only have come from the project file. A rejection is
-// recorded rather than logged: the loader is reached from logging.Init, and a
-// line in .entire/logs is not a signal anyone sees — `entire status` and
-// `entire doctor` report it instead.
-func enforceAbsoluteGitHookPathScope(s *EntireSettings) {
-	if s == nil || !s.AbsoluteGitHookPath {
+// Called with the final merged value so the record reflects the outcome: if the
+// local file enabled the setting anyway, the project value was redundant rather
+// than overridden, and reporting "ignored" beside a hook that IS pinned reads as a
+// contradiction. Recorded rather than logged — the loader is reached from
+// logging.Init, and a line in .entire/logs is not a signal anyone sees, so
+// `entire status` and `entire doctor` report it instead.
+func recordAbsoluteGitHookPathScopeRejection(s *EntireSettings, projectRequested bool) {
+	if s == nil || !projectRequested || s.AbsoluteGitHookPath {
 		return
 	}
-	s.AbsoluteGitHookPath = false
 	s.absoluteGitHookPathRejection = absoluteGitHookPathProjectReason
 }

--- a/cmd/entire/cli/settings/absolute_hook_path_scope_test.go
+++ b/cmd/entire/cli/settings/absolute_hook_path_scope_test.go
@@ -1,0 +1,125 @@
+package settings
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAbsoluteGitHookPath_ScopeGate pins where the setting is honored.
+//
+// It rewrites every generated git hook to name one machine's binary path, so a
+// committed value would impose that on everyone who clones — pinning their hooks
+// to whichever binary they happened to run, which is more brittle than resolving
+// through PATH.
+func TestAbsoluteGitHookPath_ScopeGate(t *testing.T) {
+	cases := []struct {
+		name          string
+		project       string
+		local         string
+		want          bool
+		wantRejection bool
+	}{
+		{
+			name:          "committed project file is ignored",
+			project:       `{"enabled": true, "absolute_git_hook_path": true}`,
+			want:          false,
+			wantRejection: true,
+		},
+		{
+			name:    "local override is honored",
+			project: `{"enabled": true}`,
+			local:   `{"absolute_git_hook_path": true}`,
+			want:    true,
+		},
+		{
+			// The local file is the authority, so it can also turn it back off.
+			name:          "local override wins over the project file",
+			project:       `{"enabled": true, "absolute_git_hook_path": true}`,
+			local:         `{"absolute_git_hook_path": false}`,
+			want:          false,
+			wantRejection: true,
+		},
+		{
+			// A project value of false is a no-op, so there is nothing to report.
+			name:    "an explicit false in the project file is not a rejection",
+			project: `{"enabled": true, "absolute_git_hook_path": false}`,
+			want:    false,
+		},
+		{
+			// The project value was redundant, not overridden: reporting it as
+			// ignored beside a hook that is in fact pinned reads as a
+			// contradiction.
+			name:          "no rejection reported when the local file enables it anyway",
+			project:       `{"enabled": true, "absolute_git_hook_path": true}`,
+			local:         `{"absolute_git_hook_path": true}`,
+			want:          true,
+			wantRejection: false,
+		},
+		{
+			name:    "absent everywhere",
+			project: `{"enabled": true}`,
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			if err := os.MkdirAll(filepath.Join(dir, ".entire"), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, EntireSettingsFile), []byte(tc.project), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if tc.local != "" {
+				if err := os.WriteFile(filepath.Join(dir, EntireSettingsLocalFile), []byte(tc.local), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			s, err := Load(context.Background())
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if s.AbsoluteGitHookPath != tc.want {
+				t.Errorf("AbsoluteGitHookPath = %v, want %v", s.AbsoluteGitHookPath, tc.want)
+			}
+			gotRejection := s.AbsoluteGitHookPathRejection() != ""
+			if gotRejection != tc.wantRejection {
+				t.Errorf("rejection recorded = %v, want %v (reason %q)", gotRejection, tc.wantRejection, s.AbsoluteGitHookPathRejection())
+			}
+		})
+	}
+}
+
+// TestAbsoluteGitHookPath_RejectionDoesNotSerialize guards against writing the
+// dropped value back to disk as though the user had unset it.
+func TestAbsoluteGitHookPath_RejectionDoesNotSerialize(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".entire"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, EntireSettingsFile),
+		[]byte(`{"enabled": true, "absolute_git_hook_path": true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if s.AbsoluteGitHookPathRejection() == "" {
+		t.Fatal("expected a rejection to have been recorded")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, EntireSettingsFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"enabled": true, "absolute_git_hook_path": true}` {
+		t.Errorf("Load must not rewrite the settings file, got:\n%s", data)
+	}
+}

--- a/cmd/entire/cli/settings/absolute_hook_path_scope_test.go
+++ b/cmd/entire/cli/settings/absolute_hook_path_scope_test.go
@@ -23,55 +23,58 @@ func newHookPathRepo(t *testing.T) (projectPath, localPath string) {
 	return filepath.Join(root, EntireSettingsFile), filepath.Join(root, EntireSettingsLocalFile)
 }
 
-// TestAbsoluteGitHookPath_ScopeGate pins where the setting is honored.
+// TestAbsoluteGitHookPath_ProjectScopeIsDeprecatedNotDropped pins the staged
+// rollout.
 //
-// It rewrites every generated git hook to name one machine's binary path, so a
-// committed value would impose that on everyone who clones — pinning their hooks
-// to whichever binary they happened to run, which is more brittle than resolving
-// through PATH.
-func TestAbsoluteGitHookPath_ScopeGate(t *testing.T) {
+// The setting rewrites every generated git hook to name one machine's binary
+// path, so a committed value imposes that on everyone who clones. It is still
+// honored from there for now: the only way to enable the feature used to write it
+// exclusively to the project file, so dropping it immediately would unpin the
+// hooks of everyone who ever used it — silently, in the GUI git client that
+// cannot find `entire` on PATH. So the committed value keeps working AND reports
+// a deprecation, and the deprecation goes quiet once the local file sets the key.
+func TestAbsoluteGitHookPath_ProjectScopeIsDeprecatedNotDropped(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name          string
-		project       string
-		local         string
-		want          bool
-		wantRejection bool
+		name           string
+		project        string
+		local          string
+		want           bool
+		wantDeprecated bool
 	}{
 		{
-			name:          "committed project file is ignored",
-			project:       `{"enabled": true, "absolute_git_hook_path": true}`,
-			want:          false,
-			wantRejection: true,
+			// Still honored — nobody's hooks change — but warned about.
+			name:           "committed project file is honored and deprecated",
+			project:        `{"enabled": true, "absolute_git_hook_path": true}`,
+			want:           true,
+			wantDeprecated: true,
 		},
 		{
-			name:    "local override is honored",
+			name:    "local override is honored with no warning",
 			project: `{"enabled": true}`,
 			local:   `{"absolute_git_hook_path": true}`,
 			want:    true,
 		},
 		{
-			// The local file is the authority, so it can also turn it back off.
-			name:          "local override wins over the project file",
-			project:       `{"enabled": true, "absolute_git_hook_path": true}`,
-			local:         `{"absolute_git_hook_path": false}`,
-			want:          false,
-			wantRejection: true,
+			// The local file is the authority, so it can turn it back off. No
+			// warning: the user has already stated their choice locally.
+			name:    "local false wins over a committed true",
+			project: `{"enabled": true, "absolute_git_hook_path": true}`,
+			local:   `{"absolute_git_hook_path": false}`,
+			want:    false,
 		},
 		{
-			// The project value was redundant, not overridden: reporting it as
-			// ignored beside a hook that is in fact pinned reads as a
-			// contradiction.
-			name:          "no rejection reported when the local file enables it anyway",
-			project:       `{"enabled": true, "absolute_git_hook_path": true}`,
-			local:         `{"absolute_git_hook_path": true}`,
-			want:          true,
-			wantRejection: false,
+			// Post-migration state: the committed value is redundant, so warning
+			// about it would be noise the user cannot act on further.
+			name:    "no warning once the local file sets the key",
+			project: `{"enabled": true, "absolute_git_hook_path": true}`,
+			local:   `{"absolute_git_hook_path": true}`,
+			want:    true,
 		},
 		{
-			// A project value of false is a no-op, so there is nothing to report.
-			name:    "an explicit false in the project file is not a rejection",
+			// A committed false pins nothing, so there is nothing to warn about.
+			name:    "an explicit false in the project file is not deprecated",
 			project: `{"enabled": true, "absolute_git_hook_path": false}`,
 			want:    false,
 		},
@@ -95,15 +98,16 @@ func TestAbsoluteGitHookPath_ScopeGate(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, tc.want, s.AbsoluteGitHookPath, "effective absolute_git_hook_path")
-			require.Equal(t, tc.wantRejection, s.AbsoluteGitHookPathRejection() != "",
-				"rejection recorded (reason %q)", s.AbsoluteGitHookPathRejection())
+			require.Equal(t, tc.wantDeprecated, s.AbsoluteGitHookPathDeprecation() != "",
+				"deprecation recorded (notice %q)", s.AbsoluteGitHookPathDeprecation())
 		})
 	}
 }
 
-// TestAbsoluteGitHookPath_RejectionDoesNotSerialize guards against writing the
-// dropped value back to disk as though the user had unset it.
-func TestAbsoluteGitHookPath_RejectionDoesNotSerialize(t *testing.T) {
+// TestAbsoluteGitHookPath_DeprecationDoesNotSerialize guards against the notice
+// leaking into a written settings file, and against the loader rewriting a file
+// it only read.
+func TestAbsoluteGitHookPath_DeprecationDoesNotSerialize(t *testing.T) {
 	t.Parallel()
 
 	const body = `{"enabled": true, "absolute_git_hook_path": true}`
@@ -112,7 +116,7 @@ func TestAbsoluteGitHookPath_RejectionDoesNotSerialize(t *testing.T) {
 
 	s, err := loadMergedSettings(t.Context(), projectPath, "", localPath)
 	require.NoError(t, err)
-	require.NotEmpty(t, s.AbsoluteGitHookPathRejection(), "expected a rejection to be recorded")
+	require.NotEmpty(t, s.AbsoluteGitHookPathDeprecation(), "expected a deprecation to be recorded")
 
 	after, err := os.ReadFile(projectPath)
 	require.NoError(t, err)

--- a/cmd/entire/cli/settings/absolute_hook_path_scope_test.go
+++ b/cmd/entire/cli/settings/absolute_hook_path_scope_test.go
@@ -1,11 +1,27 @@
 package settings
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+// newHookPathRepo returns the absolute project and local settings paths under a
+// fresh temp root.
+//
+// Goes through loadMergedSettings directly rather than Load, matching
+// opf_command_trust_test.go: Load resolves clone preferences from the cwd, so a
+// Load-based test must t.Chdir (blocking t.Parallel) and pays a `git rev-parse`
+// per case. loadMergedSettings takes explicit paths and covers both code sites
+// under test.
+func newHookPathRepo(t *testing.T) (projectPath, localPath string) {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".entire"), 0o755))
+	return filepath.Join(root, EntireSettingsFile), filepath.Join(root, EntireSettingsLocalFile)
+}
 
 // TestAbsoluteGitHookPath_ScopeGate pins where the setting is honored.
 //
@@ -14,6 +30,8 @@ import (
 // to whichever binary they happened to run, which is more brittle than resolving
 // through PATH.
 func TestAbsoluteGitHookPath_ScopeGate(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name          string
 		project       string
@@ -42,12 +60,6 @@ func TestAbsoluteGitHookPath_ScopeGate(t *testing.T) {
 			wantRejection: true,
 		},
 		{
-			// A project value of false is a no-op, so there is nothing to report.
-			name:    "an explicit false in the project file is not a rejection",
-			project: `{"enabled": true, "absolute_git_hook_path": false}`,
-			want:    false,
-		},
-		{
 			// The project value was redundant, not overridden: reporting it as
 			// ignored beside a hook that is in fact pinned reads as a
 			// contradiction.
@@ -58,6 +70,12 @@ func TestAbsoluteGitHookPath_ScopeGate(t *testing.T) {
 			wantRejection: false,
 		},
 		{
+			// A project value of false is a no-op, so there is nothing to report.
+			name:    "an explicit false in the project file is not a rejection",
+			project: `{"enabled": true, "absolute_git_hook_path": false}`,
+			want:    false,
+		},
+		{
 			name:    "absent everywhere",
 			project: `{"enabled": true}`,
 			want:    false,
@@ -66,31 +84,19 @@ func TestAbsoluteGitHookPath_ScopeGate(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			t.Chdir(dir)
-			if err := os.MkdirAll(filepath.Join(dir, ".entire"), 0o750); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.WriteFile(filepath.Join(dir, EntireSettingsFile), []byte(tc.project), 0o600); err != nil {
-				t.Fatal(err)
-			}
+			t.Parallel()
+			projectPath, localPath := newHookPathRepo(t)
+			require.NoError(t, os.WriteFile(projectPath, []byte(tc.project), 0o600))
 			if tc.local != "" {
-				if err := os.WriteFile(filepath.Join(dir, EntireSettingsLocalFile), []byte(tc.local), 0o600); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, os.WriteFile(localPath, []byte(tc.local), 0o600))
 			}
 
-			s, err := Load(context.Background())
-			if err != nil {
-				t.Fatalf("Load() error = %v", err)
-			}
-			if s.AbsoluteGitHookPath != tc.want {
-				t.Errorf("AbsoluteGitHookPath = %v, want %v", s.AbsoluteGitHookPath, tc.want)
-			}
-			gotRejection := s.AbsoluteGitHookPathRejection() != ""
-			if gotRejection != tc.wantRejection {
-				t.Errorf("rejection recorded = %v, want %v (reason %q)", gotRejection, tc.wantRejection, s.AbsoluteGitHookPathRejection())
-			}
+			s, err := loadMergedSettings(t.Context(), projectPath, "", localPath)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.want, s.AbsoluteGitHookPath, "effective absolute_git_hook_path")
+			require.Equal(t, tc.wantRejection, s.AbsoluteGitHookPathRejection() != "",
+				"rejection recorded (reason %q)", s.AbsoluteGitHookPathRejection())
 		})
 	}
 }
@@ -98,28 +104,17 @@ func TestAbsoluteGitHookPath_ScopeGate(t *testing.T) {
 // TestAbsoluteGitHookPath_RejectionDoesNotSerialize guards against writing the
 // dropped value back to disk as though the user had unset it.
 func TestAbsoluteGitHookPath_RejectionDoesNotSerialize(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-	if err := os.MkdirAll(filepath.Join(dir, ".entire"), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, EntireSettingsFile),
-		[]byte(`{"enabled": true, "absolute_git_hook_path": true}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	t.Parallel()
 
-	s, err := Load(context.Background())
-	if err != nil {
-		t.Fatalf("Load() error = %v", err)
-	}
-	if s.AbsoluteGitHookPathRejection() == "" {
-		t.Fatal("expected a rejection to have been recorded")
-	}
-	data, err := os.ReadFile(filepath.Join(dir, EntireSettingsFile))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != `{"enabled": true, "absolute_git_hook_path": true}` {
-		t.Errorf("Load must not rewrite the settings file, got:\n%s", data)
-	}
+	const body = `{"enabled": true, "absolute_git_hook_path": true}`
+	projectPath, localPath := newHookPathRepo(t)
+	require.NoError(t, os.WriteFile(projectPath, []byte(body), 0o600))
+
+	s, err := loadMergedSettings(t.Context(), projectPath, "", localPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, s.AbsoluteGitHookPathRejection(), "expected a rejection to be recorded")
+
+	after, err := os.ReadFile(projectPath)
+	require.NoError(t, err)
+	require.Equal(t, body, string(after), "loading must not rewrite the settings file")
 }

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -97,7 +97,16 @@ type EntireSettings struct {
 	// AbsoluteGitHookPath embeds the full binary path in git hooks instead of
 	// bare "entire". This is needed for GUI git clients (Xcode, Tower, etc.)
 	// that don't source shell profiles and can't find "entire" on PATH.
+	//
+	// Honored ONLY from .entire/settings.local.json — it describes one machine's
+	// installation, not the repository. See enforceAbsoluteGitHookPathScope.
 	AbsoluteGitHookPath bool `json:"absolute_git_hook_path,omitempty"`
+
+	// absoluteGitHookPathRejection records an absolute_git_hook_path dropped
+	// because it came from the committed project file, for the consumer to
+	// report. Unexported so it never serializes back to disk as if the user had
+	// unset it. See enforceAbsoluteGitHookPathScope.
+	absoluteGitHookPathRejection string
 
 	// Telemetry controls anonymous usage analytics.
 	// nil = not asked yet (show prompt), true = opted in, false = opted out
@@ -326,6 +335,17 @@ type OPFSettings struct {
 	// "always" runs without asking. ENTIRE_OPF=yes|no on the push
 	// invocation overrides this setting per-push.
 	PromptDefault string `json:"prompt_default,omitempty"`
+}
+
+// AbsoluteGitHookPathRejection reports why Load dropped absolute_git_hook_path,
+// or "" when it did not. Callers that report on hook configuration should
+// surface this — it is the only signal that a setting present in the repository
+// is deliberately not being applied.
+func (s *EntireSettings) AbsoluteGitHookPathRejection() string {
+	if s == nil {
+		return ""
+	}
+	return s.absoluteGitHookPathRejection
 }
 
 // CommandRejection reports a Command that Load dropped as untrusted: the
@@ -574,6 +594,11 @@ func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs
 		return nil, fmt.Errorf("reading settings file: %w", err)
 	}
 
+	// Only the project file has been read at this point, so a value here came
+	// from the committed file. Drop it before the local layer gets a chance to
+	// set it legitimately.
+	enforceAbsoluteGitHookPathScope(settings)
+
 	if preferencesFileAbs != "" {
 		preferences, err := loadClonePreferencesFromFile(preferencesFileAbs)
 		if err != nil {
@@ -604,6 +629,14 @@ func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs
 	// openai_privacy_filter.command is executed, so it is honored only from a
 	// local file positively verified as this developer's own.
 	enforceOPFCommandTrust(ctx, settings, localSettingsFileAbs, localData)
+
+	// A rejection only matters if it changed the outcome. When the local file
+	// enables absolute_git_hook_path anyway, the project value was redundant
+	// rather than overridden, and reporting "ignored" next to a hook that IS
+	// pinned reads as a contradiction.
+	if settings.AbsoluteGitHookPath {
+		settings.absoluteGitHookPathRejection = ""
+	}
 
 	// Re-validate after merge. Individual files are validated by loadFromFile,
 	// but mergeJSON patches fields independently and can produce combinations

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -99,14 +99,14 @@ type EntireSettings struct {
 	// that don't source shell profiles and can't find "entire" on PATH.
 	//
 	// Honored ONLY from .entire/settings.local.json — it describes one machine's
-	// installation, not the repository. See recordAbsoluteGitHookPathScopeRejection.
+	// installation, not the repository. See recordAbsoluteGitHookPathDeprecation.
 	AbsoluteGitHookPath bool `json:"absolute_git_hook_path,omitempty"`
 
-	// absoluteGitHookPathRejection records an absolute_git_hook_path dropped
-	// because it came from the committed project file, for the consumer to
-	// report. Unexported so it never serializes back to disk as if the user had
-	// unset it. See recordAbsoluteGitHookPathScopeRejection.
-	absoluteGitHookPathRejection string
+	// absoluteGitHookPathDeprecation records that absolute_git_hook_path is being
+	// honored from the committed project file, which a future release will stop
+	// doing. Unexported so it never serializes to disk.
+	// See recordAbsoluteGitHookPathDeprecation.
+	absoluteGitHookPathDeprecation string
 
 	// Telemetry controls anonymous usage analytics.
 	// nil = not asked yet (show prompt), true = opted in, false = opted out
@@ -337,15 +337,15 @@ type OPFSettings struct {
 	PromptDefault string `json:"prompt_default,omitempty"`
 }
 
-// AbsoluteGitHookPathRejection reports why Load dropped absolute_git_hook_path,
-// or "" when it did not. Callers that report on hook configuration should
-// surface this — it is the only signal that a setting present in the repository
-// is deliberately not being applied.
-func (s *EntireSettings) AbsoluteGitHookPathRejection() string {
+// AbsoluteGitHookPathDeprecation reports that absolute_git_hook_path is being
+// honored from the committed project file, or "" when it is not. Callers that
+// report on hook configuration should surface this: it is the only warning before
+// a future release stops honoring that scope.
+func (s *EntireSettings) AbsoluteGitHookPathDeprecation() string {
 	if s == nil {
 		return ""
 	}
-	return s.absoluteGitHookPathRejection
+	return s.absoluteGitHookPathDeprecation
 }
 
 // CommandRejection reports a Command that Load dropped as untrusted: the
@@ -594,12 +594,6 @@ func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs
 		return nil, fmt.Errorf("reading settings file: %w", err)
 	}
 
-	// Only the project file has been read at this point, so a value here came
-	// from the committed file. Dropped now; whether that changed the outcome is
-	// decided after the local layer has had its say.
-	projectRequestedHookPathPin := settings.AbsoluteGitHookPath
-	settings.AbsoluteGitHookPath = false
-
 	if preferencesFileAbs != "" {
 		preferences, err := loadClonePreferencesFromFile(preferencesFileAbs)
 		if err != nil {
@@ -631,7 +625,9 @@ func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs
 	// local file positively verified as this developer's own.
 	enforceOPFCommandTrust(ctx, settings, localSettingsFileAbs, localData)
 
-	recordAbsoluteGitHookPathScopeRejection(settings, projectRequestedHookPathPin)
+	// Still honored from the project file for now; this only warns. See
+	// recordAbsoluteGitHookPathDeprecation for why the switch is staged.
+	recordAbsoluteGitHookPathDeprecation(settings, localData)
 
 	// Re-validate after merge. Individual files are validated by loadFromFile,
 	// but mergeJSON patches fields independently and can produce combinations
@@ -1668,24 +1664,14 @@ func saveToFile(ctx context.Context, settings *EntireSettings, filePath string) 
 		return fmt.Errorf("creating settings directory: %w", err)
 	}
 
-	toWrite := settings
-	if filePath == EntireSettingsFile {
-		// Machine-local fields must never reach the committed file, and the
-		// writer is the only place that can guarantee it. Callers assemble the
-		// struct from a merged or partially-merged view and there are several of
-		// them, so each one relying on remembering this is how the value leaks:
-		// absolute_git_hook_path did exactly that from three separate call sites
-		// even though the loader was already gating it on read.
-		//
-		// Copied rather than mutated: the caller keeps using its struct after
-		// this returns (to decide whether to reinstall hooks), and zeroing it
-		// under them would silently change that decision.
-		stripped := *settings
-		stripped.AbsoluteGitHookPath = false
-		toWrite = &stripped
-	}
-
-	data, err := jsonutil.MarshalIndentWithNewline(toWrite, "", "  ")
+	// Deliberately no stripping of machine-local fields here. It is tempting —
+	// the writer is the one place that could guarantee absolute_git_hook_path
+	// never reaches the committed file — but while that value is still honored
+	// from the project scope, stripping it would delete a working setting out of
+	// a tracked file as a side effect of an unrelated `entire configure`. The
+	// callers keep it out instead (see setAbsoluteGitHookPathLocal). Revisit when
+	// the project scope stops being honored and the key is inert.
+	data, err := jsonutil.MarshalIndentWithNewline(settings, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -99,13 +99,13 @@ type EntireSettings struct {
 	// that don't source shell profiles and can't find "entire" on PATH.
 	//
 	// Honored ONLY from .entire/settings.local.json — it describes one machine's
-	// installation, not the repository. See enforceAbsoluteGitHookPathScope.
+	// installation, not the repository. See recordAbsoluteGitHookPathScopeRejection.
 	AbsoluteGitHookPath bool `json:"absolute_git_hook_path,omitempty"`
 
 	// absoluteGitHookPathRejection records an absolute_git_hook_path dropped
 	// because it came from the committed project file, for the consumer to
 	// report. Unexported so it never serializes back to disk as if the user had
-	// unset it. See enforceAbsoluteGitHookPathScope.
+	// unset it. See recordAbsoluteGitHookPathScopeRejection.
 	absoluteGitHookPathRejection string
 
 	// Telemetry controls anonymous usage analytics.
@@ -595,9 +595,10 @@ func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs
 	}
 
 	// Only the project file has been read at this point, so a value here came
-	// from the committed file. Drop it before the local layer gets a chance to
-	// set it legitimately.
-	enforceAbsoluteGitHookPathScope(settings)
+	// from the committed file. Dropped now; whether that changed the outcome is
+	// decided after the local layer has had its say.
+	projectRequestedHookPathPin := settings.AbsoluteGitHookPath
+	settings.AbsoluteGitHookPath = false
 
 	if preferencesFileAbs != "" {
 		preferences, err := loadClonePreferencesFromFile(preferencesFileAbs)
@@ -630,13 +631,7 @@ func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs
 	// local file positively verified as this developer's own.
 	enforceOPFCommandTrust(ctx, settings, localSettingsFileAbs, localData)
 
-	// A rejection only matters if it changed the outcome. When the local file
-	// enables absolute_git_hook_path anyway, the project value was redundant
-	// rather than overridden, and reporting "ignored" next to a hook that IS
-	// pinned reads as a contradiction.
-	if settings.AbsoluteGitHookPath {
-		settings.absoluteGitHookPathRejection = ""
-	}
+	recordAbsoluteGitHookPathScopeRejection(settings, projectRequestedHookPathPin)
 
 	// Re-validate after merge. Individual files are validated by loadFromFile,
 	// but mergeJSON patches fields independently and can produce combinations
@@ -652,6 +647,12 @@ func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs
 // LoadFromFile loads settings from a specific file path without merging local overrides.
 // Returns default settings if the file doesn't exist.
 // Use this when you need to display individual settings files separately.
+//
+// Reads the file verbatim: none of the scope gating Load applies is run here, so
+// a field that is only honored from a particular scope (absolute_git_hook_path,
+// redaction.openai_privacy_filter.command) comes back ungated. Treat the result
+// as "what this file says", never as "what is in effect" — deciding behavior from
+// it reintroduces exactly the imposition those gates prevent.
 func LoadFromFile(filePath string) (*EntireSettings, error) {
 	return loadFromFile(filePath)
 }
@@ -1667,7 +1668,24 @@ func saveToFile(ctx context.Context, settings *EntireSettings, filePath string) 
 		return fmt.Errorf("creating settings directory: %w", err)
 	}
 
-	data, err := jsonutil.MarshalIndentWithNewline(settings, "", "  ")
+	toWrite := settings
+	if filePath == EntireSettingsFile {
+		// Machine-local fields must never reach the committed file, and the
+		// writer is the only place that can guarantee it. Callers assemble the
+		// struct from a merged or partially-merged view and there are several of
+		// them, so each one relying on remembering this is how the value leaks:
+		// absolute_git_hook_path did exactly that from three separate call sites
+		// even though the loader was already gating it on read.
+		//
+		// Copied rather than mutated: the caller keeps using its struct after
+		// this returns (to decide whether to reinstall hooks), and zeroing it
+		// under them would silently change that decision.
+		stripped := *settings
+		stripped.AbsoluteGitHookPath = false
+		toWrite = &stripped
+	}
+
+	data, err := jsonutil.MarshalIndentWithNewline(toWrite, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -307,9 +307,11 @@ func updateGlobalSettings(ctx context.Context, cmd *cobra.Command, w io.Writer, 
 		s.Telemetry = &v
 	}
 	if cmd.Flags().Changed(flagAbsoluteGitHookPath) {
-		// Deliberately not written into s: this key belongs in the local file
-		// regardless of the target scope. Kept in memory so the reinstall below
-		// uses the value the user just asked for.
+		// Persisted to the local file explicitly, because that is the only scope
+		// the loader honors it from. Also set on s so the reinstall below uses
+		// the value the user just asked for — saveSettingsToTarget cannot carry
+		// it into a committed file, because the writer strips machine-local
+		// fields from a project-scope save.
 		if err := setAbsoluteGitHookPathLocal(ctx, opts.AbsoluteGitHookPath); err != nil {
 			return fmt.Errorf("failed to save absolute_git_hook_path: %w", err)
 		}
@@ -322,10 +324,23 @@ func updateGlobalSettings(ctx context.Context, cmd *cobra.Command, w io.Writer, 
 	}
 
 	if cmd.Flags().Changed(flagForce) || cmd.Flags().Changed(flagAbsoluteGitHookPath) {
-		if _, err := strategy.InstallGitHook(ctx, true, s.AbsoluteGitHookPath); err != nil {
+		// Whether to pin comes from the merged view, not from s. s was loaded
+		// with settings.LoadFromFile, which reads one file verbatim and applies
+		// no scope gating, so using it here let a committed
+		// absolute_git_hook_path pin a cloner's hooks via `entire configure
+		// --force` — the very imposition the loader gate exists to prevent.
+		// setupAgentHooksNonInteractive already reads the merged view for this
+		// same decision.
+		pinHookPath := s.AbsoluteGitHookPath
+		if merged, mergedErr := LoadEntireSettings(ctx); mergedErr == nil {
+			pinHookPath = merged.AbsoluteGitHookPath
+		} else {
+			logging.Warn(ctx, "could not load merged settings for hook installation; using target-scoped settings", "error", mergedErr)
+		}
+		if _, err := strategy.InstallGitHook(ctx, true, pinHookPath); err != nil {
 			return fmt.Errorf("failed to reinstall git hook: %w", err)
 		}
-		strategy.CheckAndWarnHookManagers(ctx, w, s.AbsoluteGitHookPath)
+		strategy.CheckAndWarnHookManagers(ctx, w, pinHookPath)
 		fmt.Fprintln(w, "  ✓ Reinstalled git hook")
 	}
 
@@ -795,7 +810,7 @@ Examples:
 	cmd.Flags().StringVar(&summarizeModel, flagSummarizeModel, "", "Set the model hint used by explain --generate")
 	cmd.Flags().IntVar(&summarizeTimeoutSeconds, flagSummarizeTimeout, 0, "Set the hard deadline (seconds) for explain --generate summary generation. 0 clears (falls back to 5m default).")
 	cmd.Flags().BoolVar(&opts.Telemetry, flagTelemetry, true, "Enable anonymous usage analytics")
-	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
+	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles); written to and honored only from .entire/settings.local.json, as it describes this machine")
 
 	return cmd
 }
@@ -962,7 +977,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
 	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", "Checkpoint storage backend: refs (one git ref per checkpoint; recommended) or branch (shared entire/checkpoints/v1 branch)")
 	cmd.Flags().BoolVar(&opts.Telemetry, flagTelemetry, true, "Enable anonymous usage analytics")
-	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
+	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles); written to and honored only from .entire/settings.local.json, as it describes this machine")
 	cmd.Flags().BoolVar(&opts.SearchSkill, flagSearchSkill, false, "Install the optional Entire search skill for selected agent(s)")
 	cmd.Flags().BoolVar(&opts.AgentHelpSkill, flagAgentHelpSkill, false, "Install the stable Entire agent-help skill (points agents at `entire agent-help`) for selected agent(s)")
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Accept all defaults without prompting (in a non-repo directory: init git, create private GitHub repo, commit, and push; then enable all agents and accept telemetry). Does not import existing agent history — see --"+flagImportHistory)
@@ -1298,7 +1313,8 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 	// Update the specific fields
 	settings.Enabled = true
 	if opts.AbsoluteGitHookPath {
-		// Local file, not the target scope — see setAbsoluteGitHookPathLocal.
+		// Persisted to the local file; kept on the struct only so the hook
+		// install below pins. The writer strips it from a project-scope save.
 		if err := setAbsoluteGitHookPathLocal(ctx, true); err != nil {
 			return fmt.Errorf("failed to save absolute_git_hook_path: %w", err)
 		}
@@ -1551,49 +1567,55 @@ func setEnabledFlag(ctx context.Context, enabled, useProjectSettings bool) error
 
 // setEnabledRaw loads a settings file via load, sets its "enabled" key, and
 // writes it back via save, preserving every other key already in that file.
-// setAbsoluteGitHookPathLocal writes absolute_git_hook_path into
-// .entire/settings.local.json, whatever scope the surrounding command is writing.
-//
-// The setting is honored only from the local file (see
-// the settings loader drops it from the project scope): it names one machine's binary path.
-// The default write target is the project file whenever one exists, so putting it
-// wherever the command happened to be writing would land it in a committed file,
-// where the loader ignores it — the hook would be pinned once by this run and
-// silently revert to bare "entire" on the next EnsureSetup.
-//
-// Edits only that one key, so it cannot disturb anything else in the local file.
-func setAbsoluteGitHookPathLocal(ctx context.Context, value bool) error {
-	path, raw, _, err := settings.LoadLocalRaw(ctx)
-	if err != nil {
-		return fmt.Errorf("read local settings: %w", err)
-	}
-	encoded, err := json.Marshal(value)
-	if err != nil {
-		return fmt.Errorf("marshal absolute_git_hook_path: %w", err)
-	}
-	raw["absolute_git_hook_path"] = encoded
-	if err := settings.SaveLocalRaw(path, raw); err != nil {
-		return fmt.Errorf("write local settings: %w", err)
-	}
-	return nil
-}
-
 func setEnabledRaw(
 	ctx context.Context,
 	load func(context.Context) (path string, raw map[string]json.RawMessage, exists bool, err error),
 	save func(path string, raw map[string]json.RawMessage) error,
 	enabled bool,
 ) error {
+	return setRawKey(ctx, load, save, "enabled", enabled)
+}
+
+// setRawKey edits exactly one key in one settings file's own raw JSON, leaving
+// every other key byte-identical. This is the primitive behind the scope rules
+// documented on setEnabledFlag: writing a whole struct back would carry the other
+// scope's fields with it.
+func setRawKey(
+	ctx context.Context,
+	load func(context.Context) (path string, raw map[string]json.RawMessage, exists bool, err error),
+	save func(path string, raw map[string]json.RawMessage) error,
+	key string,
+	value any,
+) error {
 	path, raw, _, err := load(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("read settings for %s: %w", key, err)
 	}
-	value, err := json.Marshal(enabled)
+	if raw == nil {
+		// A file whose entire content is `null` unmarshals to a nil map, which
+		// would panic on assignment below.
+		raw = make(map[string]json.RawMessage)
+	}
+	encoded, err := json.Marshal(value)
 	if err != nil {
-		return fmt.Errorf("marshal enabled flag: %w", err)
+		return fmt.Errorf("marshal %s: %w", key, err)
 	}
-	raw["enabled"] = value
-	return save(path, raw)
+	raw[key] = encoded
+	if err := save(path, raw); err != nil {
+		return fmt.Errorf("write settings for %s: %w", key, err)
+	}
+	return nil
+}
+
+// setAbsoluteGitHookPathLocal writes absolute_git_hook_path into
+// .entire/settings.local.json, whatever scope the surrounding command is writing.
+//
+// The loader honors it only from there: it names one machine's binary path. The
+// default write target is the project file whenever one exists, so following the
+// surrounding command's scope would land it in a committed file where it is
+// ignored.
+func setAbsoluteGitHookPathLocal(ctx context.Context, value bool) error {
+	return setRawKey(ctx, settings.LoadLocalRaw, settings.SaveLocalRaw, "absolute_git_hook_path", value)
 }
 
 // saveEnabledState writes the caller-provided, already-target-scoped struct s
@@ -1980,7 +2002,8 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 	}
 	targetSettings.Enabled = true
 	if opts.AbsoluteGitHookPath {
-		// Local file, not the target scope — see setAbsoluteGitHookPathLocal.
+		// Persisted to the local file; kept on the struct only so the hook
+		// install below pins. The writer strips it from a project-scope save.
 		if err := setAbsoluteGitHookPathLocal(ctx, true); err != nil {
 			return fmt.Errorf("failed to save absolute_git_hook_path: %w", err)
 		}

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -307,15 +307,13 @@ func updateGlobalSettings(ctx context.Context, cmd *cobra.Command, w io.Writer, 
 		s.Telemetry = &v
 	}
 	if cmd.Flags().Changed(flagAbsoluteGitHookPath) {
-		// Persisted to the local file explicitly, because that is the only scope
-		// the loader honors it from. Also set on s so the reinstall below uses
-		// the value the user just asked for — saveSettingsToTarget cannot carry
-		// it into a committed file, because the writer strips machine-local
-		// fields from a project-scope save.
+		// Written straight to the local file and deliberately NOT onto s: s is
+		// saved to the target scope below, which defaults to the committed
+		// project file, and this key describes one machine. The reinstall further
+		// down reads the merged view, so it still sees what was just written.
 		if err := setAbsoluteGitHookPathLocal(ctx, opts.AbsoluteGitHookPath); err != nil {
 			return fmt.Errorf("failed to save absolute_git_hook_path: %w", err)
 		}
-		s.AbsoluteGitHookPath = opts.AbsoluteGitHookPath
 		fmt.Fprintf(w, "  absolute_git_hook_path written to %s (it describes this machine)\n", settings.EntireSettingsLocalFile)
 	}
 
@@ -810,7 +808,7 @@ Examples:
 	cmd.Flags().StringVar(&summarizeModel, flagSummarizeModel, "", "Set the model hint used by explain --generate")
 	cmd.Flags().IntVar(&summarizeTimeoutSeconds, flagSummarizeTimeout, 0, "Set the hard deadline (seconds) for explain --generate summary generation. 0 clears (falls back to 5m default).")
 	cmd.Flags().BoolVar(&opts.Telemetry, flagTelemetry, true, "Enable anonymous usage analytics")
-	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles); written to and honored only from .entire/settings.local.json, as it describes this machine")
+	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles); written to .entire/settings.local.json, as it describes this machine")
 
 	return cmd
 }
@@ -977,7 +975,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
 	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", "Checkpoint storage backend: refs (one git ref per checkpoint; recommended) or branch (shared entire/checkpoints/v1 branch)")
 	cmd.Flags().BoolVar(&opts.Telemetry, flagTelemetry, true, "Enable anonymous usage analytics")
-	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles); written to and honored only from .entire/settings.local.json, as it describes this machine")
+	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles); written to .entire/settings.local.json, as it describes this machine")
 	cmd.Flags().BoolVar(&opts.SearchSkill, flagSearchSkill, false, "Install the optional Entire search skill for selected agent(s)")
 	cmd.Flags().BoolVar(&opts.AgentHelpSkill, flagAgentHelpSkill, false, "Install the stable Entire agent-help skill (points agents at `entire agent-help`) for selected agent(s)")
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Accept all defaults without prompting (in a non-repo directory: init git, create private GitHub repo, commit, and push; then enable all agents and accept telemetry). Does not import existing agent history — see --"+flagImportHistory)
@@ -1313,12 +1311,11 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 	// Update the specific fields
 	settings.Enabled = true
 	if opts.AbsoluteGitHookPath {
-		// Persisted to the local file; kept on the struct only so the hook
-		// install below pins. The writer strips it from a project-scope save.
+		// Local file only, never onto the struct saved to the target scope —
+		// see the same block in updateGlobalSettings.
 		if err := setAbsoluteGitHookPathLocal(ctx, true); err != nil {
 			return fmt.Errorf("failed to save absolute_git_hook_path: %w", err)
 		}
-		settings.AbsoluteGitHookPath = true
 	}
 
 	// Auto-enable external_agents if any selected agent is external.
@@ -2002,12 +1999,11 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 	}
 	targetSettings.Enabled = true
 	if opts.AbsoluteGitHookPath {
-		// Persisted to the local file; kept on the struct only so the hook
-		// install below pins. The writer strips it from a project-scope save.
+		// Local file only, never onto the struct saved to the target scope —
+		// see the same block in updateGlobalSettings.
 		if err := setAbsoluteGitHookPathLocal(ctx, true); err != nil {
 			return fmt.Errorf("failed to save absolute_git_hook_path: %w", err)
 		}
-		targetSettings.AbsoluteGitHookPath = true
 	}
 
 	// Auto-enable external_agents setting if the agent is external.

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -307,7 +307,14 @@ func updateGlobalSettings(ctx context.Context, cmd *cobra.Command, w io.Writer, 
 		s.Telemetry = &v
 	}
 	if cmd.Flags().Changed(flagAbsoluteGitHookPath) {
+		// Deliberately not written into s: this key belongs in the local file
+		// regardless of the target scope. Kept in memory so the reinstall below
+		// uses the value the user just asked for.
+		if err := setAbsoluteGitHookPathLocal(ctx, opts.AbsoluteGitHookPath); err != nil {
+			return fmt.Errorf("failed to save absolute_git_hook_path: %w", err)
+		}
 		s.AbsoluteGitHookPath = opts.AbsoluteGitHookPath
+		fmt.Fprintf(w, "  absolute_git_hook_path written to %s (it describes this machine)\n", settings.EntireSettingsLocalFile)
 	}
 
 	if err := saveSettingsToTarget(ctx, s, targetFile); err != nil {
@@ -1291,6 +1298,10 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 	// Update the specific fields
 	settings.Enabled = true
 	if opts.AbsoluteGitHookPath {
+		// Local file, not the target scope — see setAbsoluteGitHookPathLocal.
+		if err := setAbsoluteGitHookPathLocal(ctx, true); err != nil {
+			return fmt.Errorf("failed to save absolute_git_hook_path: %w", err)
+		}
 		settings.AbsoluteGitHookPath = true
 	}
 
@@ -1540,6 +1551,33 @@ func setEnabledFlag(ctx context.Context, enabled, useProjectSettings bool) error
 
 // setEnabledRaw loads a settings file via load, sets its "enabled" key, and
 // writes it back via save, preserving every other key already in that file.
+// setAbsoluteGitHookPathLocal writes absolute_git_hook_path into
+// .entire/settings.local.json, whatever scope the surrounding command is writing.
+//
+// The setting is honored only from the local file (see
+// the settings loader drops it from the project scope): it names one machine's binary path.
+// The default write target is the project file whenever one exists, so putting it
+// wherever the command happened to be writing would land it in a committed file,
+// where the loader ignores it — the hook would be pinned once by this run and
+// silently revert to bare "entire" on the next EnsureSetup.
+//
+// Edits only that one key, so it cannot disturb anything else in the local file.
+func setAbsoluteGitHookPathLocal(ctx context.Context, value bool) error {
+	path, raw, _, err := settings.LoadLocalRaw(ctx)
+	if err != nil {
+		return fmt.Errorf("read local settings: %w", err)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal absolute_git_hook_path: %w", err)
+	}
+	raw["absolute_git_hook_path"] = encoded
+	if err := settings.SaveLocalRaw(path, raw); err != nil {
+		return fmt.Errorf("write local settings: %w", err)
+	}
+	return nil
+}
+
 func setEnabledRaw(
 	ctx context.Context,
 	load func(context.Context) (path string, raw map[string]json.RawMessage, exists bool, err error),
@@ -1942,6 +1980,10 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 	}
 	targetSettings.Enabled = true
 	if opts.AbsoluteGitHookPath {
+		// Local file, not the target scope — see setAbsoluteGitHookPathLocal.
+		if err := setAbsoluteGitHookPathLocal(ctx, true); err != nil {
+			return fmt.Errorf("failed to save absolute_git_hook_path: %w", err)
+		}
 		targetSettings.AbsoluteGitHookPath = true
 	}
 

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -3941,18 +3941,20 @@ func TestConfigureCmd_AbsoluteGitHookPathFlag_KeepsProjectFileClean(t *testing.T
 	}
 }
 
-// TestConfigureCmd_ForceDoesNotHonorCommittedAbsoluteHookPath pins the scope rule
-// at the install side.
+// TestConfigureCmd_ForceHonorsLocalAbsoluteHookPath pins that the hook-install
+// decision comes from the merged view.
 //
-// updateGlobalSettings loads the target file with settings.LoadFromFile, which
-// applies no scope gating, so feeding that value to InstallGitHook let a committed
-// absolute_git_hook_path pin a cloner's hooks via `entire configure --force` —
-// reaching the same imposition the loader gate blocks, just actively instead of
-// passively.
-func TestConfigureCmd_ForceDoesNotHonorCommittedAbsoluteHookPath(t *testing.T) {
+// updateGlobalSettings loads its target scope with settings.LoadFromFile, which
+// reads one file verbatim. Deciding from that missed a value set only in the local
+// file — the only scope that will be honored once the project scope is retired —
+// so `entire configure --force` would silently unpin a correctly configured repo.
+// It also read the project scope ungated, which is the route by which a committed
+// value will keep imposing itself after the loader stops honoring it.
+func TestConfigureCmd_ForceHonorsLocalAbsoluteHookPath(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir
 	setupTestRepo(t)
-	writeSettings(t, `{"enabled": true, "absolute_git_hook_path": true}`)
+	writeSettings(t, testSettingsEnabled)
+	writeLocalSettings(t, `{"absolute_git_hook_path": true}`)
 
 	cmd := newSetupCmd()
 	var stdout bytes.Buffer
@@ -3971,7 +3973,7 @@ func TestConfigureCmd_ForceDoesNotHonorCommittedAbsoluteHookPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read post-commit hook: %v", err)
 	}
-	if !strings.Contains(string(hook), "command -v entire") {
-		t.Errorf("a committed absolute_git_hook_path must not pin the hook, got:\n%s", hook)
+	if strings.Contains(string(hook), "command -v entire") {
+		t.Errorf("a local absolute_git_hook_path must pin the hook, got:\n%s", hook)
 	}
 }

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -3886,3 +3886,92 @@ func TestRunEnableInteractive_FirstRunDefaultsToGitRefs(t *testing.T) {
 		}
 	})
 }
+
+// TestConfigureCmd_AbsoluteGitHookPathFlag_KeepsProjectFileClean pins the scope
+// rule at the write side.
+//
+// The pre-existing flag test asserts only against the merged view, so it passes
+// whether or not the key also lands in the committed file — and it did: the
+// struct assignment stayed and saveSettingsToTarget marshals the whole struct to
+// the target, which defaults to the project file whenever one exists. One
+// `configure` plus a commit and every cloner's hooks get pinned to a path chosen
+// on somebody else's machine, which is the imposition this setting's scope rule
+// exists to prevent.
+func TestConfigureCmd_AbsoluteGitHookPathFlag_KeepsProjectFileClean(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+
+	cmd := newSetupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--absolute-git-hook-path"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("configure --absolute-git-hook-path failed: %v\noutput: %s", err, stdout.String())
+	}
+
+	projectContent, err := os.ReadFile(EntireSettingsFile)
+	if err != nil {
+		t.Fatalf("failed to read project settings: %v", err)
+	}
+	if strings.Contains(string(projectContent), "absolute_git_hook_path") {
+		t.Errorf("absolute_git_hook_path must not reach the committed file, got:\n%s", projectContent)
+	}
+
+	localContent, err := os.ReadFile(EntireSettingsLocalFile)
+	if err != nil {
+		t.Fatalf("the flag should have written the local file: %v", err)
+	}
+	if !strings.Contains(string(localContent), "absolute_git_hook_path") {
+		t.Errorf("expected the flag to persist locally, got:\n%s", localContent)
+	}
+
+	// The feature must still work: the hook is pinned, not left on PATH.
+	hooksDir, err := strategy.GetHooksDir(context.Background())
+	if err != nil {
+		t.Fatalf("GetHooksDir() error = %v", err)
+	}
+	hook, err := os.ReadFile(filepath.Join(hooksDir, "post-commit"))
+	if err != nil {
+		t.Fatalf("failed to read post-commit hook: %v", err)
+	}
+	if strings.Contains(string(hook), "command -v entire") {
+		t.Errorf("hook should be pinned to an absolute path, got:\n%s", hook)
+	}
+}
+
+// TestConfigureCmd_ForceDoesNotHonorCommittedAbsoluteHookPath pins the scope rule
+// at the install side.
+//
+// updateGlobalSettings loads the target file with settings.LoadFromFile, which
+// applies no scope gating, so feeding that value to InstallGitHook let a committed
+// absolute_git_hook_path pin a cloner's hooks via `entire configure --force` —
+// reaching the same imposition the loader gate blocks, just actively instead of
+// passively.
+func TestConfigureCmd_ForceDoesNotHonorCommittedAbsoluteHookPath(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir
+	setupTestRepo(t)
+	writeSettings(t, `{"enabled": true, "absolute_git_hook_path": true}`)
+
+	cmd := newSetupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("configure --force failed: %v\noutput: %s", err, stdout.String())
+	}
+
+	hooksDir, err := strategy.GetHooksDir(context.Background())
+	if err != nil {
+		t.Fatalf("GetHooksDir() error = %v", err)
+	}
+	hook, err := os.ReadFile(filepath.Join(hooksDir, "post-commit"))
+	if err != nil {
+		t.Fatalf("failed to read post-commit hook: %v", err)
+	}
+	if !strings.Contains(string(hook), "command -v entire") {
+		t.Errorf("a committed absolute_git_hook_path must not pin the hook, got:\n%s", hook)
+	}
+}

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -164,8 +164,8 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 		}
 	}
 
-	if reason := effectiveSettings.AbsoluteGitHookPathRejection(); reason != "" {
-		fmt.Fprintf(w, "absolute_git_hook_path ignored: %s\n", reason)
+	if notice := effectiveSettings.AbsoluteGitHookPathDeprecation(); notice != "" {
+		fmt.Fprintf(w, "absolute_git_hook_path: %s\n", notice)
 	}
 
 	if effectiveSettings.Enabled {

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -164,6 +164,10 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 		}
 	}
 
+	if reason := effectiveSettings.AbsoluteGitHookPathRejection(); reason != "" {
+		fmt.Fprintf(w, "absolute_git_hook_path ignored: %s\n", reason)
+	}
+
 	if effectiveSettings.Enabled {
 		writeActiveSessions(ctx, w, sty)
 	}

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -151,22 +151,22 @@ const (
 	// GitHooksCurrent means every managed hook is ours and in the shape this
 	// version writes.
 	GitHooksCurrent
-	// GitHooksOutdated means the hooks are ours but at least one is a shape we no
-	// longer write. Today that means running Entire from the working tree, which
-	// is broken as well as stale — the path it names is gone.
+	// GitHooksOutdated means the hooks are ours but not what this version would
+	// write. Two causes, both broken rather than merely stale, and each with its
+	// own advice (see hookOutdatedReason):
+	//   - a hook runs Entire from the working tree, whose launcher is gone
+	//   - a hook is pinned to an absolute binary path that no longer resolves
+	// The second is a shape we DO still write; only its environment changed.
 	GitHooksOutdated
 )
 
-// CheckGitHookState reports the state of the active hooks directory.
-func CheckGitHookState(ctx context.Context) GitHookState {
-	state, _ := CheckGitHookStateWithReason(ctx)
-	return state
-}
-
-// CheckGitHookStateWithReason also reports why the hooks read as outdated, for
-// callers that show the user what to do about it. The reason is "" for any state
-// other than GitHooksOutdated.
-func CheckGitHookStateWithReason(ctx context.Context) (GitHookState, string) {
+// CheckGitHookState reports the state of the active hooks directory, and why the
+// hooks read as outdated. The reason is "" for any state other than
+// GitHooksOutdated, and the two Outdated causes need different advice — see
+// hookOutdatedReason.
+//
+//nolint:unparam // the reason is consumed cross-package by doctor's checkGitHooks; the two in-package callers are predicates that discard it
+func CheckGitHookState(ctx context.Context) (GitHookState, string) {
 	hooksDir, err := GetHooksDir(ctx)
 	if err != nil {
 		return GitHooksAbsent, ""
@@ -190,7 +190,8 @@ func CheckGitHookStateInDir(ctx context.Context, repoDir string) GitHookState {
 // doctor — must use CheckGitHookState instead, or they will treat a stale hook as
 // if it were not there.
 func IsGitHookInstalled(ctx context.Context) bool {
-	return CheckGitHookState(ctx) == GitHooksCurrent
+	state, _ := CheckGitHookState(ctx)
+	return state == GitHooksCurrent
 }
 
 // IsGitHookInstalledInDir checks if a current set of Entire CLI hooks is installed
@@ -203,7 +204,8 @@ func IsGitHookInstalledInDir(ctx context.Context, repoDir string) bool {
 // current or not. This is what uninstall needs: a stale hook is still ours, and
 // still ours to remove.
 func AnyGitHookInstalled(ctx context.Context) bool {
-	return CheckGitHookState(ctx) != GitHooksAbsent
+	state, _ := CheckGitHookState(ctx)
+	return state != GitHooksAbsent
 }
 
 // ReinstallGitHooks rewrites the managed git hooks using this repo's hook
@@ -237,11 +239,15 @@ var legacyGitHookLaunchers = []string{"scripts/entire-dev", "go run "}
 const bareEntireHookCmd = "entire"
 
 // gitHookStateInHooksDir classifies the hooks in the given directory. A hook that
-// is present but still invokes a removed local-dev launcher reads Outdated, not
-// Current, which is what makes EnsureSetup reinstall it rather than leaving a
-// broken hook in place forever.
+// is present but broken — invoking a removed local-dev launcher, or pinned to a
+// binary path that no longer resolves — reads Outdated, not Current, which is what
+// makes EnsureSetup reinstall it rather than leaving it in place forever.
 func gitHookStateInHooksDir(hooksDir string) (GitHookState, string) {
 	reason := ""
+	// All hooks in a set are generated from one prefix, so they carry the same
+	// pinned path; remembering the ones already probed avoids stat-ing it once
+	// per hook.
+	checkedPins := map[string]bool{}
 	for _, hook := range gitHookNames {
 		hookPath := filepath.Join(hooksDir, hook)
 		data, err := os.ReadFile(hookPath) //nolint:gosec // Path is constructed from constants
@@ -256,15 +262,11 @@ func gitHookStateInHooksDir(hooksDir string) (GitHookState, string) {
 		// need different advice, though — one hook runs deleted repo content, the
 		// other points at a binary that moved — so the first cause found is
 		// carried out rather than collapsing into a single message.
-		if reason != "" {
-			continue
-		}
-		if entireHookLineRunsFromWorkingTree(content) {
-			reason = gitHookWorkingTreeReason
-		} else if pinned := entireHookPinnedPath(content); pinned != "" {
-			if _, statErr := os.Stat(pinned); statErr != nil {
-				reason = fmt.Sprintf(gitHookDeadPinReasonFmt, pinned)
-			}
+		//
+		// Note the loop keeps going after a cause is found: a later hook that is
+		// missing or foreign still has to downgrade the whole set to Absent.
+		if reason == "" {
+			reason = hookOutdatedReason(content, &checkedPins)
 		}
 	}
 	if reason != "" {
@@ -275,38 +277,69 @@ func gitHookStateInHooksDir(hooksDir string) (GitHookState, string) {
 
 // Reasons a hook set reads as GitHooksOutdated, for the caller to report.
 const (
-	gitHookWorkingTreeReason = "A hook still runs Entire from the working tree instead of the installed\n" +
-		"binary. This can reject `git push`, because the path it names is gone."
-	gitHookDeadPinReasonFmt = "A hook is pinned to a binary path that no longer exists, so hooks are\n" +
-		"silently skipped and no checkpoints are captured:\n  %s"
+	gitHookWorkingTreeReason = "A hook still runs Entire from the working tree instead of the installed binary. This can reject `git push`, because the path it names is gone."
+	gitHookDeadPinReasonFmt  = "A hook is pinned to a binary path that no longer exists, so hooks are silently skipped and no checkpoints are captured: %s"
 )
 
-// entireHookLineRunsFromWorkingTree reports whether the hook's OWN Entire
-// invocation names a legacy launcher.
-//
-// Scoped to the invocation line, not the whole file. A user may hand-edit a hook
-// Entire installed to append their own steps, and one of those steps containing
-// `go run ` must not make the file read as ours-but-stale: InstallGitHook only
-// backs up a hook that does NOT carry entireHookMarker, so a hand-edited hook is
-// rewritten with no backup and a false positive here would silently discard their
-// additions. Every generated invocation contains `hooks git `, so keying on that
-// line separates Entire's command from anything around it.
-func entireHookLineRunsFromWorkingTree(content string) bool {
-	for line := range strings.SplitSeq(content, "\n") {
-		if !strings.Contains(line, "hooks git ") {
-			continue
-		}
-		for _, launcher := range legacyGitHookLaunchers {
-			if strings.Contains(line, launcher) {
-				return true
-			}
-		}
+// shellUnquote reverses shellQuote.
+func shellUnquote(s string) string {
+	if len(s) < 2 || s[0] != '\'' || s[len(s)-1] != '\'' {
+		return s
 	}
-	return false
+	return strings.ReplaceAll(s[1:len(s)-1], `'\''`, "'")
 }
 
-// entireHookPinnedPath returns the absolute binary path a hook is pinned to, or
-// "" when it resolves `entire` through PATH.
+// hookOutdatedReason reports why a hook Entire owns is not what this version
+// would write, or "" when it is current. checkedPins remembers pinned paths
+// already probed, so a set of hooks generated from one prefix stats it once
+// rather than once per hook.
+//
+// Both causes are read off the hook's OWN invocation line rather than the whole
+// file. A user may hand-edit a hook Entire installed to append their own steps,
+// and InstallGitHook only backs up a hook that does NOT carry entireHookMarker —
+// so a hand-edited hook is rewritten with no backup, and mistaking one of their
+// lines for ours silently discards their additions. Every generated invocation
+// contains `hooks git `, which is what separates it from anything around it.
+func hookOutdatedReason(content string, checkedPins *map[string]bool) string {
+	line, found := entireHookInvocationLine(content)
+	if !found {
+		return ""
+	}
+	for _, launcher := range legacyGitHookLaunchers {
+		if strings.Contains(line, launcher) {
+			return gitHookWorkingTreeReason
+		}
+	}
+	pinned := hookGuardPinnedPath(line)
+	if pinned == "" {
+		return ""
+	}
+	if dead, seen := (*checkedPins)[pinned]; seen {
+		if dead {
+			return fmt.Sprintf(gitHookDeadPinReasonFmt, pinned)
+		}
+		return ""
+	}
+	dead := !fileExists(pinned)
+	(*checkedPins)[pinned] = dead
+	if dead {
+		return fmt.Sprintf(gitHookDeadPinReasonFmt, pinned)
+	}
+	return ""
+}
+
+// entireHookInvocationLine returns the line on which the hook invokes Entire.
+func entireHookInvocationLine(content string) (string, bool) {
+	for line := range strings.SplitSeq(content, "\n") {
+		if strings.Contains(line, "hooks git ") {
+			return line, true
+		}
+	}
+	return "", false
+}
+
+// hookGuardPinnedPath returns the absolute binary path the guard on line tests
+// for, or "" when the hook resolves `entire` through PATH.
 //
 // absolute_git_hook_path exists for GUI git clients that never source a shell
 // profile, and it trades PATH resolution for a path fixed at install time. That
@@ -318,35 +351,44 @@ func entireHookLineRunsFromWorkingTree(content string) bool {
 //
 // Treating a dead pin as outdated is what makes that self-healing: reinstalling
 // re-pins to the binary now running, which is exactly the repair.
-func entireHookPinnedPath(content string) string {
-	for line := range strings.SplitSeq(content, "\n") {
-		if !strings.Contains(line, "hooks git ") {
+func hookGuardPinnedPath(line string) string {
+	// gitHookCommand emits `if <test>; then <invocation>; else :; fi`, and
+	// gitHookCommandAvailableTest makes <test> either `[ -x <path> ]` or, for a
+	// Windows path where Git-for-Windows' sh has no reliable -x, `[ -f <path> ]`.
+	//
+	// Cut at "; then" first, then take the LAST " ]" in the guard. A path may
+	// itself contain " ]" — shellQuote passes it through untouched — and scanning
+	// forward for the first one truncated the path, which surfaced as a permanent
+	// false "outdated" plus a reinstall on every turn-start that could never
+	// repair it. TestInstallGitHook_PinnedHookRoundTrips keeps this parser tied to
+	// the generator above.
+	guard, _, found := strings.Cut(line, "; then")
+	if !found {
+		return ""
+	}
+	for _, marker := range []string{"[ -x ", "[ -f "} {
+		start := strings.Index(guard, marker)
+		if start < 0 {
 			continue
 		}
-		// gitHookCommandAvailableTest emits `[ -x <path> ]`, or `[ -f <path> ]`
-		// for a Windows path where Git-for-Windows' sh has no reliable -x.
-		for _, marker := range []string{"[ -x ", "[ -f "} {
-			start := strings.Index(line, marker)
-			if start < 0 {
-				continue
-			}
-			rest := line[start+len(marker):]
-			end := strings.Index(rest, " ]")
-			if end < 0 {
-				continue
-			}
-			return shellUnquote(rest[:end])
+		rest := guard[start+len(marker):]
+		end := strings.LastIndex(rest, " ]")
+		if end < 0 {
+			continue
 		}
+		return shellUnquote(rest[:end])
 	}
 	return ""
 }
 
-// shellUnquote reverses shellQuote.
-func shellUnquote(s string) string {
-	if len(s) < 2 || s[0] != '\'' || s[len(s)-1] != '\'' {
-		return s
+// entireHookPinnedPath returns the absolute binary path a hook is pinned to, or
+// "" when it resolves `entire` through PATH. See hookGuardPinnedPath.
+func entireHookPinnedPath(content string) string {
+	line, found := entireHookInvocationLine(content)
+	if !found {
+		return ""
 	}
-	return strings.ReplaceAll(s[1:len(s)-1], `'\''`, "'")
+	return hookGuardPinnedPath(line)
 }
 
 // buildHookSpecs returns the hook specifications for all managed hooks.

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -159,9 +159,17 @@ const (
 
 // CheckGitHookState reports the state of the active hooks directory.
 func CheckGitHookState(ctx context.Context) GitHookState {
+	state, _ := CheckGitHookStateWithReason(ctx)
+	return state
+}
+
+// CheckGitHookStateWithReason also reports why the hooks read as outdated, for
+// callers that show the user what to do about it. The reason is "" for any state
+// other than GitHooksOutdated.
+func CheckGitHookStateWithReason(ctx context.Context) (GitHookState, string) {
 	hooksDir, err := GetHooksDir(ctx)
 	if err != nil {
-		return GitHooksAbsent
+		return GitHooksAbsent, ""
 	}
 	return gitHookStateInHooksDir(hooksDir)
 }
@@ -173,7 +181,8 @@ func CheckGitHookStateInDir(ctx context.Context, repoDir string) GitHookState {
 	if err != nil {
 		return GitHooksAbsent
 	}
-	return gitHookStateInHooksDir(hooksDir)
+	state, _ := gitHookStateInHooksDir(hooksDir)
+	return state
 }
 
 // IsGitHookInstalled reports whether a CURRENT set of Entire git hooks is
@@ -231,27 +240,46 @@ const bareEntireHookCmd = "entire"
 // is present but still invokes a removed local-dev launcher reads Outdated, not
 // Current, which is what makes EnsureSetup reinstall it rather than leaving a
 // broken hook in place forever.
-func gitHookStateInHooksDir(hooksDir string) GitHookState {
-	outdated := false
+func gitHookStateInHooksDir(hooksDir string) (GitHookState, string) {
+	reason := ""
 	for _, hook := range gitHookNames {
 		hookPath := filepath.Join(hooksDir, hook)
 		data, err := os.ReadFile(hookPath) //nolint:gosec // Path is constructed from constants
 		if err != nil {
-			return GitHooksAbsent
+			return GitHooksAbsent, ""
 		}
 		content := string(data)
 		if !strings.Contains(content, entireHookMarker) {
-			return GitHooksAbsent
+			return GitHooksAbsent, ""
+		}
+		// Both causes below mean "ours, but not what we would write now". They
+		// need different advice, though — one hook runs deleted repo content, the
+		// other points at a binary that moved — so the first cause found is
+		// carried out rather than collapsing into a single message.
+		if reason != "" {
+			continue
 		}
 		if entireHookLineRunsFromWorkingTree(content) {
-			outdated = true
+			reason = gitHookWorkingTreeReason
+		} else if pinned := entireHookPinnedPath(content); pinned != "" {
+			if _, statErr := os.Stat(pinned); statErr != nil {
+				reason = fmt.Sprintf(gitHookDeadPinReasonFmt, pinned)
+			}
 		}
 	}
-	if outdated {
-		return GitHooksOutdated
+	if reason != "" {
+		return GitHooksOutdated, reason
 	}
-	return GitHooksCurrent
+	return GitHooksCurrent, ""
 }
+
+// Reasons a hook set reads as GitHooksOutdated, for the caller to report.
+const (
+	gitHookWorkingTreeReason = "A hook still runs Entire from the working tree instead of the installed\n" +
+		"binary. This can reject `git push`, because the path it names is gone."
+	gitHookDeadPinReasonFmt = "A hook is pinned to a binary path that no longer exists, so hooks are\n" +
+		"silently skipped and no checkpoints are captured:\n  %s"
+)
 
 // entireHookLineRunsFromWorkingTree reports whether the hook's OWN Entire
 // invocation names a legacy launcher.
@@ -275,6 +303,50 @@ func entireHookLineRunsFromWorkingTree(content string) bool {
 		}
 	}
 	return false
+}
+
+// entireHookPinnedPath returns the absolute binary path a hook is pinned to, or
+// "" when it resolves `entire` through PATH.
+//
+// absolute_git_hook_path exists for GUI git clients that never source a shell
+// profile, and it trades PATH resolution for a path fixed at install time. That
+// path can stop resolving — an upgrade into a new version directory, a binary
+// built in a temp dir, a `go install` that relocates it — and the failure is
+// quiet: the guard simply takes its else branch, so git keeps working while
+// nothing is captured. Only commit-msg carries the missing-binary warning, and it
+// reads like a generic "not installed" notice.
+//
+// Treating a dead pin as outdated is what makes that self-healing: reinstalling
+// re-pins to the binary now running, which is exactly the repair.
+func entireHookPinnedPath(content string) string {
+	for line := range strings.SplitSeq(content, "\n") {
+		if !strings.Contains(line, "hooks git ") {
+			continue
+		}
+		// gitHookCommandAvailableTest emits `[ -x <path> ]`, or `[ -f <path> ]`
+		// for a Windows path where Git-for-Windows' sh has no reliable -x.
+		for _, marker := range []string{"[ -x ", "[ -f "} {
+			start := strings.Index(line, marker)
+			if start < 0 {
+				continue
+			}
+			rest := line[start+len(marker):]
+			end := strings.Index(rest, " ]")
+			if end < 0 {
+				continue
+			}
+			return shellUnquote(rest[:end])
+		}
+	}
+	return ""
+}
+
+// shellUnquote reverses shellQuote.
+func shellUnquote(s string) string {
+	if len(s) < 2 || s[0] != '\'' || s[len(s)-1] != '\'' {
+		return s
+	}
+	return strings.ReplaceAll(s[1:len(s)-1], `'\''`, "'")
 }
 
 // buildHookSpecs returns the hook specifications for all managed hooks.

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -1994,90 +1994,107 @@ func TestResolveHookExePath(t *testing.T) {
 	})
 }
 
-// TestCheckGitHookState_DeadPinnedPathIsDrift pins that a hook whose embedded
-// absolute path no longer resolves reads as outdated rather than healthy.
+// writeGeneratedHooks writes every managed hook exactly as InstallGitHook would
+// for the given command prefix, by going through the generator itself.
 //
-// absolute_git_hook_path fixes the binary path at install time, so an upgrade or
-// a relocated binary leaves the guard failing its else branch: git keeps working
-// and nothing is captured. Reporting Current there is what made it silent —
-// `entire doctor` said "✓ Git hooks: OK" while no checkpoint was written.
-func TestCheckGitHookState_DeadPinnedPathIsDrift(t *testing.T) {
-	t.Parallel()
-
-	live := filepath.Join(t.TempDir(), "entire")
-	if err := os.WriteFile(live, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
+// Fixtures are generated rather than hand-copied on purpose: entireHookPinnedPath
+// parses the shell guard that gitHookCommandAvailableTest emits, so a hand-written
+// fixture lets the two drift silently — change `[ -x ` to `test -x` and a parser
+// that now returns nothing still passes every assertion.
+func writeGeneratedHooks(t *testing.T, dir, cmdPrefix string) {
+	t.Helper()
+	for _, spec := range buildHookSpecs(cmdPrefix) {
+		if err := os.WriteFile(filepath.Join(dir, spec.name), []byte(spec.content), 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
+}
+
+// TestEntireHookPinnedPath covers extraction from generated hooks, including the
+// quoting cases that make naive parsing wrong.
+func TestEntireHookPinnedPath(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		name string
 		path string
-		want GitHookState
+		want string
 	}{
-		{"a pin that still resolves is current", live, GitHooksCurrent},
-		{"a pin that no longer resolves is outdated", filepath.Join(t.TempDir(), "moved-away", "entire"), GitHooksOutdated},
+		{"absolute unix path", "/opt/homebrew/bin/entire", "/opt/homebrew/bin/entire"},
+		{"path containing spaces", "/Users/A B/bin/entire", "/Users/A B/bin/entire"},
+		// shellQuote renders ' as '\'' — the case a naive split on quotes gets wrong.
+		{"path containing an apostrophe", "/Users/John O'Brien/bin/entire", "/Users/John O'Brien/bin/entire"},
+		// A path containing the guard's own delimiter. Scanning forward for the
+		// first " ]" truncated this, which read as a dead pin forever.
+		{"path containing the closing-bracket delimiter", "/Users/a ]b/bin/entire", "/Users/a ]b/bin/entire"},
+		// Windows paths take the -f branch of gitHookCommandAvailableTest.
+		{"windows path", `C:\Program Files\Entire\entire.exe`, `C:\Program Files\Entire\entire.exe`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
-			for _, hook := range gitHookNames {
-				// The exact shape gitHookCommand emits for an absolute prefix.
-				quoted := shellQuote(tc.path)
-				content := "#!/bin/sh\n# " + entireHookMarker + "\n" +
-					"if [ -x " + quoted + " ]; then " + quoted + " hooks git " + hook + "; else :; fi\n"
-				if err := os.WriteFile(filepath.Join(dir, hook), []byte(content), 0o755); err != nil {
-					t.Fatal(err)
-				}
+			writeGeneratedHooks(t, dir, shellQuote(tc.path))
+			data, err := os.ReadFile(filepath.Join(dir, "pre-push"))
+			if err != nil {
+				t.Fatal(err)
 			}
-			if got, _ := gitHookStateInHooksDir(dir); got != tc.want {
-				t.Errorf("state = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-// TestEntireHookPinnedPath covers extraction, including the quoting cases that
-// make naive parsing wrong.
-func TestEntireHookPinnedPath(t *testing.T) {
-	t.Parallel()
-
-	hookLine := func(prefix string) string {
-		return "#!/bin/sh\n# " + entireHookMarker + "\nif [ -x " + prefix + " ]; then " + prefix + " hooks git pre-push; else :; fi\n"
-	}
-
-	cases := []struct {
-		name    string
-		content string
-		want    string
-	}{
-		{
-			// A PATH-resolved hook is not pinned and must not be probed.
-			name:    "bare entire is not pinned",
-			content: "#!/bin/sh\n# " + entireHookMarker + "\nif command -v entire >/dev/null 2>&1; then entire hooks git pre-push; else :; fi\n",
-			want:    "",
-		},
-		{"absolute unix path", hookLine(shellQuote("/opt/homebrew/bin/entire")), "/opt/homebrew/bin/entire"},
-		{"path containing spaces", hookLine(shellQuote("/Users/A B/bin/entire")), "/Users/A B/bin/entire"},
-		{
-			// shellQuote renders ' as '\'' — the case a naive split on quotes gets wrong.
-			name:    "path containing an apostrophe",
-			content: hookLine(shellQuote("/Users/John O'Brien/bin/entire")),
-			want:    "/Users/John O'Brien/bin/entire",
-		},
-		{"windows path uses -f", hookLine(shellQuote(`C:\Program Files\Entire\entire.exe`)), `C:\Program Files\Entire\entire.exe`},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			content := tc.content
-			if tc.name == "windows path uses -f" {
-				content = strings.Replace(content, "[ -x ", "[ -f ", 1)
-			}
-			if got := entireHookPinnedPath(content); got != tc.want {
+			if got := entireHookPinnedPath(string(data)); got != tc.want {
 				t.Errorf("entireHookPinnedPath() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+
+	t.Run("a PATH-resolved hook is not pinned", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeGeneratedHooks(t, dir, bareEntireHookCmd)
+		data, err := os.ReadFile(filepath.Join(dir, "pre-push"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := entireHookPinnedPath(string(data)); got != "" {
+			t.Errorf("a bare-entire hook must not look pinned, got %q", got)
+		}
+	})
+}
+
+// TestInstallGitHook_PinnedHookRoundTrips is the coupling that keeps the parser
+// honest against the generator.
+//
+// Every other test in this file installs with absolutePath=false, so nothing else
+// installs a pinned hook and reads it back. Without this, changing the guard
+// gitHookCommandAvailableTest emits would silently stop dead-pin detection from
+// working while the whole suite stayed green.
+func TestInstallGitHook_PinnedHookRoundTrips(t *testing.T) {
+	_, hooksDir := initHooksTestRepo(t)
+
+	if _, err := InstallGitHook(context.Background(), true, true); err != nil {
+		t.Fatalf("InstallGitHook(absolutePath=true) error = %v", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error = %v", err)
+	}
+	want, err := resolveHookExePath(exe, filepath.EvalSymlinks, runtime.GOOS)
+	if err != nil {
+		t.Fatalf("resolveHookExePath() error = %v", err)
+	}
+
+	for _, hook := range gitHookNames {
+		data, readErr := os.ReadFile(filepath.Join(hooksDir, hook))
+		if readErr != nil {
+			t.Fatalf("hook %s should exist: %v", hook, readErr)
+		}
+		if got := entireHookPinnedPath(string(data)); got != want {
+			t.Errorf("hook %s: parsed pin = %q, want %q\nhook body:\n%s", hook, got, want, data)
+		}
+	}
+
+	// The binary running the test exists, so a freshly pinned set is healthy.
+	if got, _ := gitHookStateInHooksDir(hooksDir); got != GitHooksCurrent {
+		t.Errorf("a live pinned install should read Current, got %v", got)
 	}
 }
 

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -738,7 +738,7 @@ func TestCheckGitHookState(t *testing.T) {
 
 	t.Run("no hooks at all is Absent", func(t *testing.T) {
 		t.Parallel()
-		if got := gitHookStateInHooksDir(t.TempDir()); got != GitHooksAbsent {
+		if got, _ := gitHookStateInHooksDir(t.TempDir()); got != GitHooksAbsent {
 			t.Errorf("empty hooks dir = %v, want GitHooksAbsent", got)
 		}
 	})
@@ -751,7 +751,7 @@ func TestCheckGitHookState(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(dir, "pre-push"), []byte("#!/bin/sh\necho lefthook\n"), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if got := gitHookStateInHooksDir(dir); got != GitHooksAbsent {
+		if got, _ := gitHookStateInHooksDir(dir); got != GitHooksAbsent {
 			t.Errorf("foreign hook = %v, want GitHooksAbsent", got)
 		}
 	})
@@ -763,7 +763,7 @@ func TestCheckGitHookState(t *testing.T) {
 		if err := os.Remove(filepath.Join(dir, "post-commit")); err != nil {
 			t.Fatal(err)
 		}
-		if got := gitHookStateInHooksDir(dir); got != GitHooksAbsent {
+		if got, _ := gitHookStateInHooksDir(dir); got != GitHooksAbsent {
 			t.Errorf("incomplete set = %v, want GitHooksAbsent", got)
 		}
 	})
@@ -776,7 +776,7 @@ func TestCheckGitHookState(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		writeCurrentManagedHooks(t, dir)
-		if got := gitHookStateInHooksDir(dir); got != GitHooksCurrent {
+		if got, _ := gitHookStateInHooksDir(dir); got != GitHooksCurrent {
 			t.Errorf("current-shape hooks = %v, want GitHooksCurrent", got)
 		}
 	})
@@ -793,7 +793,7 @@ func TestCheckGitHookState(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dir, "pre-push"), []byte(legacyContent), 0o755); err != nil {
 				t.Fatal(err)
 			}
-			if got := gitHookStateInHooksDir(dir); got != GitHooksOutdated {
+			if got, _ := gitHookStateInHooksDir(dir); got != GitHooksOutdated {
 				t.Errorf("legacy hook %q = %v, want GitHooksOutdated", legacy, got)
 			}
 		}
@@ -824,7 +824,7 @@ func TestCheckGitHookState_UserAdditionsAreNotDrift(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if got := gitHookStateInHooksDir(dir); got != GitHooksCurrent {
+		if got, _ := gitHookStateInHooksDir(dir); got != GitHooksCurrent {
 			t.Errorf("a hook whose own Entire line is current must read Current despite the user line %q, got %v", userLine, got)
 		}
 	}
@@ -845,7 +845,7 @@ func TestCheckGitHookState_LegacyEntireLineIsStillDrift(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if got := gitHookStateInHooksDir(dir); got != GitHooksOutdated {
+	if got, _ := gitHookStateInHooksDir(dir); got != GitHooksOutdated {
 		t.Errorf("a legacy launcher on Entire's own invocation line must read Outdated, got %v", got)
 	}
 }
@@ -869,7 +869,7 @@ func TestIsGitHookInstalled_LegacyLocalDevCountsAsNotInstalled(t *testing.T) {
 	if _, err := InstallGitHook(context.Background(), true, false); err != nil {
 		t.Fatalf("InstallGitHook() error = %v", err)
 	}
-	if got := gitHookStateInHooksDir(hooksDir); got != GitHooksCurrent {
+	if got, _ := gitHookStateInHooksDir(hooksDir); got != GitHooksCurrent {
 		t.Fatalf("a freshly installed hook set should read as current, got %v", got)
 	}
 
@@ -887,7 +887,7 @@ func TestIsGitHookInstalled_LegacyLocalDevCountsAsNotInstalled(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte(legacy), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if got := gitHookStateInHooksDir(hooksDir); got != GitHooksOutdated {
+		if got, _ := gitHookStateInHooksDir(hooksDir); got != GitHooksOutdated {
 			t.Errorf("a hook running Entire from the working tree must read as outdated, got %v: %s", got, legacyCmd)
 		}
 	}
@@ -1990,6 +1990,151 @@ func TestResolveHookExePath(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "failed to resolve symlinks") {
 			t.Errorf("error should mention symlink resolution, got: %v", err)
+		}
+	})
+}
+
+// TestCheckGitHookState_DeadPinnedPathIsDrift pins that a hook whose embedded
+// absolute path no longer resolves reads as outdated rather than healthy.
+//
+// absolute_git_hook_path fixes the binary path at install time, so an upgrade or
+// a relocated binary leaves the guard failing its else branch: git keeps working
+// and nothing is captured. Reporting Current there is what made it silent —
+// `entire doctor` said "✓ Git hooks: OK" while no checkpoint was written.
+func TestCheckGitHookState_DeadPinnedPathIsDrift(t *testing.T) {
+	t.Parallel()
+
+	live := filepath.Join(t.TempDir(), "entire")
+	if err := os.WriteFile(live, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		path string
+		want GitHookState
+	}{
+		{"a pin that still resolves is current", live, GitHooksCurrent},
+		{"a pin that no longer resolves is outdated", filepath.Join(t.TempDir(), "moved-away", "entire"), GitHooksOutdated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			for _, hook := range gitHookNames {
+				// The exact shape gitHookCommand emits for an absolute prefix.
+				quoted := shellQuote(tc.path)
+				content := "#!/bin/sh\n# " + entireHookMarker + "\n" +
+					"if [ -x " + quoted + " ]; then " + quoted + " hooks git " + hook + "; else :; fi\n"
+				if err := os.WriteFile(filepath.Join(dir, hook), []byte(content), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got, _ := gitHookStateInHooksDir(dir); got != tc.want {
+				t.Errorf("state = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEntireHookPinnedPath covers extraction, including the quoting cases that
+// make naive parsing wrong.
+func TestEntireHookPinnedPath(t *testing.T) {
+	t.Parallel()
+
+	hookLine := func(prefix string) string {
+		return "#!/bin/sh\n# " + entireHookMarker + "\nif [ -x " + prefix + " ]; then " + prefix + " hooks git pre-push; else :; fi\n"
+	}
+
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			// A PATH-resolved hook is not pinned and must not be probed.
+			name:    "bare entire is not pinned",
+			content: "#!/bin/sh\n# " + entireHookMarker + "\nif command -v entire >/dev/null 2>&1; then entire hooks git pre-push; else :; fi\n",
+			want:    "",
+		},
+		{"absolute unix path", hookLine(shellQuote("/opt/homebrew/bin/entire")), "/opt/homebrew/bin/entire"},
+		{"path containing spaces", hookLine(shellQuote("/Users/A B/bin/entire")), "/Users/A B/bin/entire"},
+		{
+			// shellQuote renders ' as '\'' — the case a naive split on quotes gets wrong.
+			name:    "path containing an apostrophe",
+			content: hookLine(shellQuote("/Users/John O'Brien/bin/entire")),
+			want:    "/Users/John O'Brien/bin/entire",
+		},
+		{"windows path uses -f", hookLine(shellQuote(`C:\Program Files\Entire\entire.exe`)), `C:\Program Files\Entire\entire.exe`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			content := tc.content
+			if tc.name == "windows path uses -f" {
+				content = strings.Replace(content, "[ -x ", "[ -f ", 1)
+			}
+			if got := entireHookPinnedPath(content); got != tc.want {
+				t.Errorf("entireHookPinnedPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGitHookStateReason_DistinguishesCauses pins that the two ways a hook set
+// can be outdated report differently. Collapsing them told a user with a moved
+// binary that their hook "runs Entire from the working tree", which is false and
+// points at the wrong fix.
+func TestGitHookStateReason_DistinguishesCauses(t *testing.T) {
+	t.Parallel()
+
+	write := func(t *testing.T, dir, body string) {
+		t.Helper()
+		for _, hook := range gitHookNames {
+			content := "#!/bin/sh\n# " + entireHookMarker + "\n" + strings.ReplaceAll(body, "%HOOK%", hook) + "\n"
+			if err := os.WriteFile(filepath.Join(dir, hook), []byte(content), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	t.Run("working-tree hook mentions git push", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		write(t, dir, "./scripts/entire-dev hooks git %HOOK%")
+		state, reason := gitHookStateInHooksDir(dir)
+		if state != GitHooksOutdated {
+			t.Fatalf("state = %v, want GitHooksOutdated", state)
+		}
+		if !strings.Contains(reason, "working tree") || !strings.Contains(reason, "git push") {
+			t.Errorf("reason should describe the working-tree cause, got:\n%s", reason)
+		}
+	})
+
+	t.Run("dead pin names the missing path", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		missing := filepath.Join(dir, "gone", "entire")
+		quoted := shellQuote(missing)
+		write(t, dir, "if [ -x "+quoted+" ]; then "+quoted+" hooks git %HOOK%; else :; fi")
+		state, reason := gitHookStateInHooksDir(dir)
+		if state != GitHooksOutdated {
+			t.Fatalf("state = %v, want GitHooksOutdated", state)
+		}
+		if !strings.Contains(reason, missing) {
+			t.Errorf("reason should name the missing path, got:\n%s", reason)
+		}
+		if strings.Contains(reason, "working tree") {
+			t.Errorf("a moved binary must not be reported as a working-tree hook, got:\n%s", reason)
+		}
+	})
+
+	t.Run("a healthy set has no reason", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeCurrentManagedHooks(t, dir)
+		if state, reason := gitHookStateInHooksDir(dir); state != GitHooksCurrent || reason != "" {
+			t.Errorf("state = %v, reason = %q; want GitHooksCurrent with no reason", state, reason)
 		}
 	})
 }


### PR DESCRIPTION
Two residuals from the local_dev removal (#1999), both about `absolute_git_hook_path` — the setting that makes git hooks embed an absolute binary path instead of bare `entire`, for GUI git clients that never source a shell profile.

**The scope change is staged.** Phase one warns and migrates; a later release flips it. See below for why a hard break was wrong.

## Why staged

Verified against the pre-change binary from `main`:

```
$ entire configure --absolute-git-hook-path
✓ Settings updated (.entire/settings.json)
project: {"enabled":true,"absolute_git_hook_path":true}
local:   (none)
```

The documented way to enable the feature wrote it **exclusively to the tracked file**. So the affected population isn't an edge case — it's every user of it.

And the failure mode is the worst available: the setting exists because their GUI git client can't find `entire` on PATH. Unpinning means the guard takes `else :` there, capturing nothing, with no error. They'd lose checkpoints in exactly the tool they enabled it for.

This is a **robustness fix, not a security one** — the value only chooses between `entire` and `os.Executable()`, a binary the user already invoked. There's no case for breaking anyone quickly.

### Phase one (this PR)

- The committed value is **still honored**. Nobody's hooks change.
- It reports a deprecation, in `entire status` and `entire doctor`.
- `doctor` offers the migration, reusing the confirm/`--force`/non-interactive degradation already here.
- **New writes already go local**, so the population stops growing now rather than at phase two.

**Copy, not move.** Editing a tracked file would land an unexpected change in the user's next commit. Once the local file sets the key the committed one is redundant, so it simply stops mattering when the scope is retired — and the warning goes quiet at that point, which the "no warning once the local file sets the key" case pins. Verified `git status` shows no tracked-file change after migrating.

### Phase two (a release after this reaches stable)

`recordAbsoluteGitHookPathDeprecation` becomes the enforcing version and the table in `absolute_hook_path_scope_test.go` flips. Silent for anyone who ran `doctor`.

## A dead pin failed silently

An upgrade into a new version directory, a binary built in a temp dir, a `go install` that relocates it — the guard takes its else branch, so git keeps working while nothing is captured. Verified before fixing:

```
$ git commit -m "after the binary moved"
Entire-Checkpoint trailers: 0
$ entire doctor
✓ Git hooks: OK          ← reported healthy
```

Now `GitHooksOutdated`, which makes it **self-healing**: reinstalling re-pins to the running binary. Nothing revalidated a pinned path after install before this. This helps the same population as the staged change above.

That gave `GitHooksOutdated` two causes needing different advice, so the check reports which — collapsing them told a user with a moved binary that their hook "runs Entire from the working tree", which is false and points at the wrong fix.

## Found by `/simplify`, all reproduced first

- **The flag wrote the key into the committed file.** The struct assignment stayed and `saveSettingsToTarget` marshals the whole struct to the target, which defaults to project. My own earlier check missed it because the fixture already contained the key.
- **`configure --force` decided pinning from an ungated read.** `settings.LoadFromFile` reads one file verbatim, so it both missed a local-only value and honored a committed one directly. Now reads the merged view; `LoadFromFile`'s doc says it's display-only.
- **The pin parser was wrong**: `strings.Index(rest, " ]")` matched inside a path, so `/Users/a ]b/entire` parsed as `'/Users/a` — a permanent false "outdated" plus a reinstall every turn-start that could never repair it.
- **Nothing coupled the parser to the generator.** Every existing test installed with `absolutePath=false`, so changing the guard would have silently disabled dead-pin detection with the suite green. Verified by swapping `[ -x ` for `test -x` and watching the new round-trip test fail. Fixtures now come from `buildHookSpecs`, which also deleted a `tc.name` branch inside a table test.

Plus: one pass over the invocation line instead of two and one `os.Stat` instead of five; the mid-loop `continue` removed (it sat below two `Absent` returns, so a future Absent check would have been skipped for hooks 2–5); `setEnabledRaw` generalized to `setRawKey`, restoring a doc comment an earlier edit had orphaned and carrying a nil-map guard; provenance from `rawHasKey` rather than call order; three exported entry points → two; the settings test moved to `loadMergedSettings` + `t.Parallel` like its sibling (0.21s → 0.00s, no git subprocess per case).

## Deliberately not done

- **`saveToFile` stripping machine-local fields.** Tempting as a single choke point, but while the committed value is still honored it would delete a working setting out of a tracked file as a side effect of an unrelated `entire configure`. Revisit at phase two, when the key is inert.
- **A declarative per-field scope registry.** Two gates with different verification depth and failure policy aren't a table's worth, and there's no seam to hang it on.
- **Unified rejection reporting** across the three existing shapes, and adding it to `status --json`. That's where a fourth such field's cost lands, but it's a separate change.
- **A machine-readable pin marker** in the hook format, which would remove the parse coupling entirely — needs a transition release, and the round-trip test buys the protection now.

## Testing

`mise run fmt && mise run lint && mise run test:ci` pass. Every new guard was verified to fail against the defect it protects against.

Verified end to end with a built binary: an existing user's hooks stay pinned and they get a warning with a one-command fix; `doctor --force` migrates with no tracked-file change; the warning then stops and the hooks are still pinned; a moved binary is diagnosed with the right message and repaired.