### PR TITLE
fix(trail): push a trail branch to the branch's push remote, not hardcoded origin

### DIFF
--- a/cmd/entire/cli/strategy/checkpoint_sync_capture.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_capture.go
@@ -214,9 +214,7 @@ func commitCapturedSyncRemote(ctx context.Context, pushRemote string) {
 }
 
 // declaredPushDestination resolves where a bare `git push` on the current
-// branch would go, through git's own precedence: branch.<name>.pushRemote,
-// then remote.pushDefault, then branch.<name>.remote. Empty when HEAD is
-// detached or nothing is declared.
+// branch would go. Empty when HEAD is detached or nothing is declared.
 //
 // Phase-1 simplification: the pre-push hook receives only the remote name
 // (refspecs are not plumbed through), so the declaration is read from HEAD's
@@ -227,7 +225,24 @@ func declaredPushDestination(ctx context.Context) string {
 	if err != nil {
 		return ""
 	}
-	branch := strings.TrimSpace(string(out))
+	return DeclaredPushRemoteForBranch(ctx, strings.TrimSpace(string(out)))
+}
+
+// DeclaredPushRemoteForBranch resolves where `git push` would send branch,
+// through git's own precedence: branch.<name>.pushRemote, then
+// remote.pushDefault, then branch.<name>.remote. Empty when branch is empty or
+// nothing is declared — callers supply their own default, since the right one
+// differs per caller ("origin" for a command issuing its own push; "no capture"
+// for the checkpoint gate).
+//
+// This is the "where does this branch push" question, which is NOT the question
+// ResolveCheckpointSyncRemote answers ("which single remote may carry checkpoint
+// data"). Do not substitute one for the other in either direction; that
+// resolver's doc comment holds the full argument, including why checkpoint sync
+// deliberately does not elect from the declaration returned here. The short
+// version: that objection is about a gate deciding whether to piggyback on
+// someone else's push, and does not apply to a caller issuing its own.
+func DeclaredPushRemoteForBranch(ctx context.Context, branch string) string {
 	if branch == "" {
 		return ""
 	}

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1010,14 +1010,19 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr, ty
 		return renderDataAPIAuthError(ctx, cmd.ErrOrStderr(), owner+"/"+repoName, err)
 	}
 
-	branchState, err := prepareTrailCreateBranch(w, errW, repo, branch, currentBranch, noBranch)
+	pushRemote, err := resolveTrailPushRemote(ctx, branch)
+	if err != nil {
+		return err
+	}
+
+	branchState, err := prepareTrailCreateBranch(ctx, w, errW, repo, pushRemote, branch, currentBranch, noBranch)
 	if err != nil {
 		return err
 	}
 
 	createResp, err := postTrailCreate(ctx, client, forge, owner, repoName, title, body, branch, base, statusStr, strings.TrimSpace(typeStr), strings.TrimSpace(priorityStr), assignees)
 	if err != nil {
-		cleanupCreatedTrailBranch(repo, branch, branchState.LocalCreated, branchState.RemotePushed, errW)
+		cleanupCreatedTrailBranch(ctx, repo, pushRemote, branch, branchState.LocalCreated, branchState.RemotePushed, errW)
 		return err
 	}
 	printCreatedTrail(w, createResp.Trail, forge, owner, repoName)
@@ -1095,7 +1100,7 @@ func validateTrailCreateFields(ctx context.Context, title, branch, statusStr str
 	return nil
 }
 
-func prepareTrailCreateBranch(w, errW io.Writer, repo *git.Repository, branch, currentBranch string, noBranch bool) (trailCreateBranchState, error) {
+func prepareTrailCreateBranch(ctx context.Context, w, errW io.Writer, repo *git.Repository, remote, branch, currentBranch string, noBranch bool) (trailCreateBranchState, error) {
 	var state trailCreateBranchState
 	if noBranch || branch == "" {
 		// Branchless trails have no remote branch to create, fetch, or push.
@@ -1103,41 +1108,41 @@ func prepareTrailCreateBranch(w, errW io.Writer, repo *git.Repository, branch, c
 	}
 
 	state.NeedsCreation = branchNeedsCreation(repo, branch)
-	existedOnOrigin, existErr := branchExistsOnOrigin(branch)
+	existedOnRemote, existErr := remoteHasBranch(ctx, remote, branch)
 	if existErr != nil {
-		fmt.Fprintf(errW, "Warning: could not check whether branch %s already exists on origin: %v\n", branch, existErr)
-		existedOnOrigin = true
+		fmt.Fprintf(errW, "Warning: could not check whether branch %s already exists on %s: %v\n", branch, remote, existErr)
+		existedOnRemote = true
 	}
 
-	if err := ensureTrailCreateBranchExists(w, repo, branch, currentBranch, existedOnOrigin, &state); err != nil {
+	if err := ensureTrailCreateBranchExists(ctx, w, repo, remote, branch, currentBranch, existedOnRemote, &state); err != nil {
 		return state, err
 	}
 
 	// For branch-backed trails, always push the branch first: the trail binds to a
 	// remote branch, so deliver it before creating the trail rather than letting
 	// the server backfill it at the base tip. Branchless trails skip this entirely.
-	if err := pushBranchToOrigin(branch); err != nil {
-		cleanupCreatedTrailBranch(repo, branch, state.LocalCreated, false, errW)
-		return state, fmt.Errorf("failed to push branch %q to origin: %w\nhint: the trail was not created because its branch could not be delivered to the remote.\n  - if this is an auth error, link your GitHub account and retry\n  - if this is a non-fast-forward, update branch %q from origin and retry", branch, err, branch)
+	if err := pushBranchToRemote(ctx, remote, branch); err != nil {
+		cleanupCreatedTrailBranch(ctx, repo, remote, branch, state.LocalCreated, false, errW)
+		return state, fmt.Errorf("failed to push branch %q to %q: %w\nhint: the trail was not created because its branch could not be delivered to the remote.\n  - if this is an auth error, link your GitHub account and retry\n  - if this is a non-fast-forward, update branch %q from %q and retry", branch, remote, err, branch, remote)
 	}
-	state.RemotePushed = !existedOnOrigin
-	fmt.Fprintf(w, "Pushed branch %s to origin\n", branch)
+	state.RemotePushed = !existedOnRemote
+	fmt.Fprintf(w, "Pushed branch %s to %s\n", branch, remote)
 	return state, nil
 }
 
-func ensureTrailCreateBranchExists(w io.Writer, repo *git.Repository, branch, currentBranch string, existedOnOrigin bool, state *trailCreateBranchState) error {
+func ensureTrailCreateBranchExists(ctx context.Context, w io.Writer, repo *git.Repository, remote, branch, currentBranch string, existedOnRemote bool, state *trailCreateBranchState) error {
 	if !state.NeedsCreation {
 		if currentBranch != branch {
 			fmt.Fprintf(w, "Note: trail will be created for branch %q (not the current branch)\n", branch)
 		}
 		return nil
 	}
-	if existedOnOrigin {
-		if err := fetchBranchFromOrigin(branch); err != nil {
-			return fmt.Errorf("failed to fetch branch %q from origin: %w", branch, err)
+	if existedOnRemote {
+		if err := fetchBranchFromRemote(ctx, remote, branch); err != nil {
+			return fmt.Errorf("failed to fetch branch %q from %q: %w", branch, remote, err)
 		}
 		state.LocalCreated = true
-		fmt.Fprintf(w, "Fetched branch %s from origin\n", branch)
+		fmt.Fprintf(w, "Fetched branch %s from %s\n", branch, remote)
 		return nil
 	}
 	if err := createBranch(repo, branch); err != nil {
@@ -2173,6 +2178,47 @@ func resolveTrailBranch(ctx context.Context, branchOverride string) (string, err
 	return GetCurrentBranch(ctx)
 }
 
+// defaultTrailPushRemote is where a trail branch goes when git config declares
+// nothing — git's own fallback for a bare push. Not defaultMirrorRemote, which
+// shares the value but means "the remote `mirror use` repoints".
+const defaultTrailPushRemote = "origin"
+
+// resolveTrailPushRemote returns the remote a trail's branch is delivered to,
+// following git's own push precedence for that branch: branch.<name>.pushRemote,
+// then remote.pushDefault, then branch.<name>.remote, and "origin" when nothing
+// is declared.
+//
+// A hardcoded "origin" delivered the branch to the wrong remote, with no warning,
+// in any repo whose branch pushes somewhere else — a fork workflow holding the
+// upstream as origin, or any repo with remote.pushDefault set. A branch being
+// newly created has no branch.<name>.* config yet, so it resolves through
+// remote.pushDefault to "origin": unchanged for the common case.
+//
+// Scope: this fixes delivery only. resolveTrailRemote still reads the trail's
+// forge/owner/repo from "origin", so the two can name different repos in a fork
+// setup, and a repo with no "origin" at all fails there before reaching here.
+//
+// Not strategy.ResolveCheckpointSyncRemote — see
+// strategy.DeclaredPushRemoteForBranch for why those two questions differ.
+func resolveTrailPushRemote(ctx context.Context, branch string) (string, error) {
+	remote := strategy.DeclaredPushRemoteForBranch(ctx, branch)
+	if remote == "" {
+		return defaultTrailPushRemote, nil
+	}
+	// The name reaches git as an argv element, so the hazard is a leading "-"
+	// being read as a flag (`--upload-pack=...`), not shell metacharacters.
+	//
+	// Deliberately narrower than validateGitRemoteName: that whitelist vets names
+	// Entire is about to WRITE into .git/config and is stricter than git itself.
+	// Applied to config the user already has, it rejects values git accepts
+	// wherever a <repository> goes — "." (the local repo) and a bare URL both fail
+	// its leading-alphanumeric rule — turning a working repo into a hard failure.
+	if strings.HasPrefix(remote, "-") {
+		return "", fmt.Errorf("branch %q declares push remote %q, which git would read as a command-line flag", branch, remote)
+	}
+	return remote, nil
+}
+
 // parseTrailRepoArg parses an explicit --repo value into the forge/owner/repo
 // triple. It accepts the canonical "forge/owner/repo" form (e.g. gh/acme/app)
 // as well as a full clone URL (https://, git@, or entire://) that gitremote
@@ -2276,7 +2322,7 @@ func createBranch(repo *git.Repository, branchName string) error {
 	return nil
 }
 
-func cleanupCreatedTrailBranch(repo *git.Repository, branchName string, localCreated, remotePushed bool, errW io.Writer) {
+func cleanupCreatedTrailBranch(ctx context.Context, repo *git.Repository, remote, branchName string, localCreated, remotePushed bool, errW io.Writer) {
 	localRemoved := !localCreated
 	if localCreated {
 		branchRef := plumbing.NewBranchReferenceName(branchName)
@@ -2290,47 +2336,55 @@ func cleanupCreatedTrailBranch(repo *git.Repository, branchName string, localCre
 	}
 	if remotePushed {
 		if !localRemoved {
-			fmt.Fprintf(errW, "Warning: not deleting remote branch %s after trail creation failed because local cleanup did not complete; run 'git push origin --delete %s' if you do not need it\n", branchName, branchName)
+			fmt.Fprintf(errW, "Warning: not deleting remote branch %s after trail creation failed because local cleanup did not complete; run 'git push %s --delete %s' if you do not need it\n", branchName, remote, branchName)
 			return
 		}
-		if err := deleteBranchFromOrigin(branchName); err != nil {
+		if err := deleteBranchFromRemote(ctx, remote, branchName); err != nil {
 			fmt.Fprintf(errW, "Warning: failed to delete remote branch %s after trail creation failed: %v\n", branchName, err)
 		}
 	}
 }
 
-func fetchBranchFromOrigin(branchName string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+func fetchBranchFromRemote(ctx context.Context, remote, branchName string) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 	if err := ValidateBranchName(ctx, branchName); err != nil {
 		return err
 	}
 	refspec := fmt.Sprintf("refs/heads/%s:refs/heads/%s", branchName, branchName)
-	cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "origin", refspec)
+	cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", remote, refspec)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%s: %w", strings.TrimSpace(string(output)), err)
 	}
 	return nil
 }
 
-// pushBranchToOrigin pushes a branch to the origin remote.
-func pushBranchToOrigin(branchName string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+// pushBranchToRemote pushes a branch to remote, which callers resolve through
+// resolveTrailPushRemote rather than assuming "origin".
+func pushBranchToRemote(ctx context.Context, remote, branchName string) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "push", "--no-verify", "-u", "origin", branchName)
+	cmd := exec.CommandContext(ctx, "git", "push", "--no-verify", "-u", remote, branchName)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%s: %w", strings.TrimSpace(string(output)), err)
 	}
 	return nil
 }
 
-// branchExistsOnOrigin reports whether origin already has a branch with the
-// given name, so callers can avoid treating a pre-existing remote branch as one
-// they created.
-func branchExistsOnOrigin(branchName string) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+// remoteHasBranch reports whether remote already has a branch with the given
+// name, so callers can avoid treating a pre-existing remote branch as one they
+// created.
+//
+// Deliberately not the exported BranchExistsOnRemote in git_operations.go, whose
+// name this would otherwise shadow by case alone: that one is origin-only and
+// reports an ls-remote failure as "branch absent". Here a failed check must stay
+// distinguishable from a definite "absent", because callers use the answer to
+// decide whether they created the remote branch — and therefore whether cleanup
+// may delete it.
+func remoteHasBranch(ctx context.Context, remote, branchName string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--heads", "origin", branchName)
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--heads", remote, branchName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", strings.TrimSpace(string(output)), err)
@@ -2338,10 +2392,10 @@ func branchExistsOnOrigin(branchName string) (bool, error) {
 	return strings.TrimSpace(string(output)) != "", nil
 }
 
-func deleteBranchFromOrigin(branchName string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+func deleteBranchFromRemote(ctx context.Context, remote, branchName string) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "push", "--no-verify", "origin", "--delete", branchName)
+	cmd := exec.CommandContext(ctx, "git", "push", "--no-verify", remote, "--delete", branchName)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		outputText := strings.TrimSpace(string(output))
 		if strings.Contains(outputText, "remote ref does not exist") {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -83,7 +83,7 @@ func TestPrepareTrailCreateBranchSkipsBranchlessTrail(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			state, err := prepareTrailCreateBranch(io.Discard, io.Discard, nil, tc.branch, "main", tc.noBranch)
+			state, err := prepareTrailCreateBranch(context.Background(), io.Discard, io.Discard, nil, "origin", tc.branch, "main", tc.noBranch)
 
 			require.NoError(t, err)
 			require.False(t, state.NeedsCreation)
@@ -328,7 +328,7 @@ func TestCleanupCreatedTrailBranch(t *testing.T) {
 			}
 
 			var errBuf bytes.Buffer
-			cleanupCreatedTrailBranch(repo, branch, tc.localCreated, tc.remotePushed, &errBuf)
+			cleanupCreatedTrailBranch(context.Background(), repo, "origin", branch, tc.localCreated, tc.remotePushed, &errBuf)
 
 			require.Equal(t, tc.wantLocalBranch, gitBranchExistsTrailTest(t, localDir, branch), "local branch mismatch; stderr: %s", errBuf.String())
 			require.Equal(t, tc.wantRemoteBranch, gitBranchExistsTrailTest(t, originDir, branch), "remote branch mismatch; stderr: %s", errBuf.String())
@@ -342,6 +342,7 @@ func TestCleanupCreatedTrailBranch(t *testing.T) {
 func initTrailCleanupRepo(t *testing.T) (localDir, originDir string, repo *git.Repository) {
 	t.Helper()
 
+	testutil.IsolateGitConfigEnv(t)
 	tmp := t.TempDir()
 	localDir = filepath.Join(tmp, "local")
 	originDir = filepath.Join(tmp, "origin.git")
@@ -2261,4 +2262,137 @@ func TestBuildTrailUpdateRequestTrimsTypeAndPriority(t *testing.T) {
 	if req.Priority == nil || *req.Priority != string(trail.PriorityHigh) {
 		t.Fatalf("Priority on wire = %v, want trimmed high", req.Priority)
 	}
+}
+
+// TestResolveTrailPushRemote covers the precedence a trail branch's delivery
+// follows. The tiers are git's own, so a repo whose branch pushes somewhere other
+// than "origin" (a fork workflow, remote.pushDefault) gets its branch delivered
+// there instead of silently to whatever "origin" happens to be.
+func TestResolveTrailPushRemote(t *testing.T) {
+	cases := []struct {
+		name    string
+		config  [][]string
+		branch  string
+		want    string
+		wantErr string
+	}{
+		{
+			name:   "nothing declared falls back to origin",
+			branch: "feature/x",
+			want:   "origin",
+		},
+		{
+			name:   "remote.pushDefault wins over nothing",
+			config: [][]string{{"remote.pushDefault", "fork"}},
+			branch: "feature/x",
+			want:   "fork",
+		},
+		{
+			name:   "branch.<name>.remote is used when it is all that is set",
+			config: [][]string{{"branch.feature/x.remote", "base"}},
+			branch: "feature/x",
+			want:   "base",
+		},
+		{
+			name: "branch.<name>.pushRemote outranks both",
+			config: [][]string{
+				{"remote.pushDefault", "fork"},
+				{"branch.feature/x.remote", "base"},
+				{"branch.feature/x.pushRemote", "mine"},
+			},
+			branch: "feature/x",
+			want:   "mine",
+		},
+		{
+			name: "remote.pushDefault outranks branch.<name>.remote",
+			config: [][]string{
+				{"remote.pushDefault", "fork"},
+				{"branch.feature/x.remote", "base"},
+			},
+			branch: "feature/x",
+			want:   "fork",
+		},
+		{
+			// The declaration is read for the branch being created, not for HEAD:
+			// `trail create --branch other` while on feature/x must not inherit
+			// feature/x's push remote.
+			name:   "declaration is read for the target branch, not HEAD",
+			config: [][]string{{"branch.feature/x.pushRemote", "mine"}},
+			branch: "other",
+			want:   "origin",
+		},
+		{
+			// Loud, not silently retargeted at origin: silent retargeting is the
+			// failure this resolver replaced.
+			name:    "a declared name git would read as a flag fails loudly",
+			config:  [][]string{{"remote.pushDefault", "--upload-pack=touched"}},
+			branch:  "feature/x",
+			wantErr: "would read as a command-line flag",
+		},
+		{
+			// A legal git value that the stricter write-direction validator in
+			// repo_mirror_use.go would reject. "." means the local repo.
+			name:   "a legal dot remote is accepted",
+			config: [][]string{{"branch.feature/x.remote", "."}},
+			branch: "feature/x",
+			want:   ".",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Without this, a developer or CI machine carrying a global
+			// remote.pushDefault resolves that instead of the repo-local config
+			// under test — and the "falls back to origin" case fails.
+			testutil.IsolateGitConfigEnv(t)
+			dir := t.TempDir()
+			testutil.InitRepo(t, dir)
+			for _, kv := range tc.config {
+				runGitTrailTest(t, dir, "config", kv[0], kv[1])
+			}
+			t.Chdir(dir)
+
+			got, err := resolveTrailPushRemote(context.Background(), tc.branch)
+
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestPrepareTrailCreateBranchPushesToDeclaredRemote is the end-to-end shape of
+// the bug: origin exists and is a perfectly good remote, but the branch's
+// declared push destination is a different one. The branch must arrive there and
+// nowhere else, and cleanup must undo it on that same remote.
+func TestPrepareTrailCreateBranchPushesToDeclaredRemote(t *testing.T) {
+	localDir, originDir, repo := initTrailCleanupRepo(t)
+	defer repo.Close()
+	forkDir := filepath.Join(filepath.Dir(localDir), "fork.git")
+	runGitTrailTest(t, localDir, "init", "--bare", forkDir)
+	runGitTrailTest(t, localDir, "remote", "add", "fork", forkDir)
+	runGitTrailTest(t, localDir, "config", "remote.pushDefault", "fork")
+	t.Chdir(localDir)
+
+	const branch = "feature/declared"
+	ctx := context.Background()
+	remote, err := resolveTrailPushRemote(ctx, branch)
+	require.NoError(t, err)
+	require.Equal(t, "fork", remote)
+
+	var out, errOut bytes.Buffer
+	state, err := prepareTrailCreateBranch(ctx, &out, &errOut, repo, remote, branch, "main", false)
+
+	require.NoError(t, err, "stderr: %s", errOut.String())
+	require.True(t, state.NeedsCreation)
+	require.True(t, state.RemotePushed)
+	require.True(t, gitBranchExistsTrailTest(t, forkDir, branch), "branch missing from declared remote")
+	require.False(t, gitBranchExistsTrailTest(t, originDir, branch), "branch leaked to origin")
+	require.Contains(t, out.String(), "Pushed branch "+branch+" to fork")
+
+	cleanupCreatedTrailBranch(ctx, repo, remote, branch, state.LocalCreated, state.RemotePushed, &errOut)
+	require.False(t, gitBranchExistsTrailTest(t, forkDir, branch), "cleanup left the branch on the declared remote; stderr: %s", errOut.String())
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1115
<!-- entire-trail-link-end -->

## Problem

`entire trail create` delivered a trail's branch with a hardcoded `origin` in four places — `push`, `ls-remote`, `fetch`, and the cleanup `--delete` — plus the `git push origin --delete` hint in a warning. In any repo whose branch pushes somewhere else the branch went to the wrong remote and **nothing warned**:

- a fork workflow holding the upstream as `origin` and your own fork under another name
- any repo with `remote.pushDefault` set
- any branch with `branch.<name>.pushRemote`

The push path had no test coverage at all — the one existing test exercised the branchless path with a nil repo.

## Fix

Delivery resolves through git's own precedence (`branch.<name>.pushRemote` → `remote.pushDefault` → `branch.<name>.remote` → `origin`), extracted from the checkpoint gate's existing `declaredPushDestination` as `strategy.DeclaredPushRemoteForBranch`. The checkpoint pre-push path is unchanged — same subprocess count, same order, same results.

The resolve happens **once** in `runTrailCreate`, next to the sibling `resolveTrailRemote`, and the name is threaded down, so push and cleanup cannot disagree about where the branch went. A branch being newly created has no `branch.<name>.*` config, so it resolves through `remote.pushDefault` to `origin` — **unchanged for the common case**, which is why this is a fix rather than a behavior change.

### Notes for review

- **Why not `ResolveCheckpointSyncRemote`.** It answers a different question: which single remote may carry checkpoint *data*. It exists to contain session data to one remote, defaults to `origin` outright, and latches on past pushes — so it would not have fixed this. Conversely, checkpoint sync deliberately does not elect from this declaration; that objection is about a gate deciding whether to piggyback on someone else's push and does not apply to a caller issuing its own. Both directions are recorded in the doc comments.
- **Validation is narrower than `validateGitRemoteName`** (judgment call, flagging not deciding). A declared name starting with `-` is rejected rather than silently retargeted at `origin`. `validateGitRemoteName` vets names Entire is about to *write* into `.git/config` and is stricter than git, so against config the user already has it rejects values git accepts wherever a `<repository>` goes — `.` (the local repo) and a bare URL both fail its leading-alphanumeric rule. Move it if you'd rather be strict.
- **`remoteHasBranch`** is named to avoid shadowing the exported `BranchExistsOnRemote` by case alone. Not merged with it: that one is origin-only and reports an `ls-remote` failure as "branch absent", which here would mark the branch as ours and let cleanup delete a branch the user already had.
- **`ctx` threading.** The four wrappers each built `context.Background()` internally, so Ctrl-C during a two-minute push was ignored. They now derive timeouts from the caller's ctx.

## Scope — deliberately not fixed

- `resolveTrailRemote` still reads the trail's `forge/owner/repo` from `origin`. In a fork setup identity and delivery can therefore name different repos, and a repo with **no** `origin` fails there before reaching delivery. Unifying them changes *which repo a trail is created against* (upstream or fork) — a product decision, not a bugfix. Recorded in the code.
- The fetch side (`trail checkout`, `trail_checkout_worktree.go`) still hardcodes `origin`, so it looks for the branch where `create` may no longer put it.

## Tests

Tier table, `origin` fallback, target-branch-not-HEAD, flag rejection, a legal `.` remote, and an end-to-end push against two real bare repos asserting the branch lands on the declared remote, does not leak to `origin`, and that cleanup undoes it there. Verified the e2e test fails against the pre-fix behavior.

Tests isolate global git config via `testutil.IsolateGitConfigEnv` — verified load-bearing: under a hostile `GIT_CONFIG_GLOBAL` carrying `remote.pushDefault`, the fallback case fails without it. That's exactly the population this fix targets.

`mise run check` clean: fmt, lint 0 issues, test:ci green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ed5f8e17c748a2db5e4a82df2795049af6999b8a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->