### PR TITLE
fix(login): keep a completed login when the keyring is missing, stop offering a browser there isn't

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,24 +228,33 @@ Multiple AI sessions can run on the same commit. If you start a second session w
 ## Headless & CI Authentication
 
 By default `entire login` stores tokens in the OS keyring (macOS Keychain,
-Linux Secret Service, Windows Credential Manager). Machines without a usable
-keyring — headless servers, containers, minimal VMs, CI runners — have two
-supported paths:
+Linux Secret Service, Windows Credential Manager).
 
 ### Interactive login on a headless machine
 
-Use the file-backed token store. The device-auth flow already works without a
-local browser (the CLI prints an approval URL you can open on any machine);
-only token storage needs the override:
+Nothing to configure: `entire login` works on headless servers, containers and
+minimal VMs as-is. The device-auth flow already works without a local browser
+(the CLI prints an approval URL you can open on any machine), and when the OS
+keyring is unusable the CLI stores the tokens in a file instead of discarding a
+login you just completed. It says so when it happens:
 
-```bash
-ENTIRE_TOKEN_STORE=file entire login
+```
+Warning: OS keyring (Secret Service (D-Bus)) is unavailable: exec: "dbus-launch": executable file not found in $PATH
+Credentials saved to /home/you/.config/entire/tokens.json instead (mode 0600). Set ENTIRE_TOKEN_STORE=file to skip the keyring, or ENTIRE_TOKEN_STORE=keyring to fail instead of writing a file.
 ```
 
 Tokens are written with `0600` permissions to `tokens.json` in your Entire
 config directory (`~/.config/entire` by default). Override the location with
-`ENTIRE_TOKEN_STORE_PATH`. Set `ENTIRE_TOKEN_STORE=file` persistently (e.g. in
-your shell profile) so later commands read from the same store.
+`ENTIRE_TOKEN_STORE_PATH`. Later commands find them there without any
+environment variable — the keyring is still tried first, so a machine that
+grows a working one goes back to using it.
+
+Two overrides are available when you want to decide rather than be adapted to:
+
+```bash
+ENTIRE_TOKEN_STORE=file entire login     # never touch the keyring
+ENTIRE_TOKEN_STORE=keyring entire login  # require the keyring; fail rather than write a file
+```
 
 ### Non-interactive automation (CI, workload identity)
 

--- a/cmd/entire/cli/browser_open_other.go
+++ b/cmd/entire/cli/browser_open_other.go
@@ -4,22 +4,77 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 )
 
+// browserOpenerCommand names the platform's URL opener, or "" when this
+// platform has none we know how to drive.
+func browserOpenerCommand() string {
+	switch runtime.GOOS {
+	case darwinGOOS:
+		return "open"
+	case "linux":
+		return "xdg-open"
+	default:
+		return ""
+	}
+}
+
+// browserOpenerAvailable reports whether asking this machine to open a URL
+// has a realistic chance of putting it in front of the user. It gates what
+// the login prompt advertises: offering "[Enter] Open browser" on a headless
+// box only trades a keystroke for an exec error, which is how a login on an
+// SSH session ended up printing `exec: "xdg-open": executable file not found
+// in $PATH` right after telling the user to press Enter.
+//
+// The opener binary must exist, and on Linux there must also be a graphical
+// session for it to hand the URL to — xdg-open on a display-less server
+// either fails or opens a terminal browser the user (sitting somewhere else)
+// never sees. WSL is included because its opener bridges to the Windows host
+// without a local X/Wayland display.
+//
+// This is deliberately a check on what to *advertise*, not a veto: pressing
+// Enter anyway still attempts the open as long as the binary exists, so an
+// unusual-but-working setup is never locked out.
+func browserOpenerAvailable() bool {
+	command := browserOpenerCommand()
+	if command == "" {
+		return false
+	}
+	if _, err := exec.LookPath(command); err != nil {
+		return false
+	}
+	if runtime.GOOS == darwinGOOS {
+		return true
+	}
+	return hasGraphicalSession()
+}
+
+// hasGraphicalSession reports whether a display server (or a WSL bridge to
+// the Windows host) is reachable from this process's environment.
+func hasGraphicalSession() bool {
+	for _, key := range []string{"DISPLAY", "WAYLAND_DISPLAY", "WSL_DISTRO_NAME", "WSL_INTEROP"} {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // openBrowserPlatform launches the platform's URL opener with browserURL as a
 // single argv element. No shell is involved.
 func openBrowserPlatform(browserURL string) error {
-	var command string
-
-	switch runtime.GOOS {
-	case darwinGOOS:
-		command = "open"
-	case "linux":
-		command = "xdg-open"
-	default:
+	command := browserOpenerCommand()
+	if command == "" {
 		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	}
+
+	// Resolve the opener first so a machine without one gets a sentence a
+	// user can act on instead of a nested exec error.
+	if _, err := exec.LookPath(command); err != nil {
+		return fmt.Errorf("no URL opener on this machine (%s is not installed)", command)
 	}
 
 	// exec.Command, not exec.CommandContext: this is deliberately

--- a/cmd/entire/cli/browser_open_windows.go
+++ b/cmd/entire/cli/browser_open_windows.go
@@ -13,6 +13,13 @@ import (
 // the shell association without launching a real browser.
 var shellExecute = windows.ShellExecute
 
+// browserOpenerAvailable reports whether this machine can open a URL for the
+// user. Windows always can: ShellExecute goes through the scheme association
+// rather than an external opener binary, so there is nothing to look up on
+// $PATH and no display server to detect. Kept as a per-platform function so
+// the login prompt's action gating has one shape everywhere.
+func browserOpenerAvailable() bool { return true }
+
 // openBrowserPlatform hands browserURL to the Windows shell association for
 // its scheme, which is the user's default browser.
 //

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -64,21 +64,49 @@ type loginURLActionReadFunc func(ctx context.Context) (loginURLAction, error)
 // clipboardCopyTimeout bounds a single clipboard write. See copyLoginURL.
 const clipboardCopyTimeout = 3 * time.Second
 
+// loginURLActions reports which of the URL prompt's actions this process can
+// actually honour, so the prompt never advertises a keystroke that can only
+// produce a warning. keys covers terminal input (see loginURLKeysAvailable);
+// browser and clipboard cover the two side effects a key would trigger — a
+// headless machine typically has neither, and an SSH session usually has no
+// display for a browser and no X clipboard helper.
+type loginURLActions struct {
+	keys      bool
+	browser   bool
+	clipboard bool
+}
+
+// usable reports whether reading keys can lead anywhere. When it can't, the
+// prompt is suppressed *and* the terminal is left alone: taking a TTY into raw
+// mode to collect keystrokes whose only possible outcome is "this machine
+// can't do that" costs the user their native Ctrl-C for nothing.
+func (a loginURLActions) usable() bool {
+	return a.keys && (a.browser || a.clipboard)
+}
+
 // loginURLInteractor owns the side effects behind the interactive URL prompt.
 // Production uses the controlling TTY, system clipboard, and default browser;
-// tests provide deterministic functions instead. keysAvailable answers whether
-// readAction can actually deliver keys, so the prompt only advertises actions
-// this process can honour.
+// tests provide deterministic functions instead. availableActions answers what
+// this process can honour, so the prompt only advertises those actions.
 type loginURLInteractor struct {
-	keysAvailable func() bool
-	readAction    loginURLActionReadFunc
-	copyURL       clipboardWriteFunc
-	openURL       browserOpenFunc
+	availableActions func() loginURLActions
+	readAction       loginURLActionReadFunc
+	copyURL          clipboardWriteFunc
+	openURL          browserOpenFunc
 }
 
 func defaultLoginURLInteractor(errW io.Writer) loginURLInteractor {
 	return loginURLInteractor{
-		keysAvailable: loginURLKeysAvailable,
+		availableActions: func() loginURLActions {
+			return loginURLActions{
+				keys:    loginURLKeysAvailable(),
+				browser: browserOpenerAvailable(),
+				// atotto/clipboard resolves its helper (pbcopy, xclip, xsel,
+				// wl-copy, …) at init and reports the absence here, which is
+				// the headless/SSH case.
+				clipboard: !clipboard.Unsupported,
+			}
+		},
 		readAction: func(ctx context.Context) (loginURLAction, error) {
 			return readLoginURLAction(ctx, errW)
 		},
@@ -290,6 +318,10 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 	} else {
 		fmt.Fprint(outW, "Waiting for approval… ")
 		result, err = wait(ctx)
+		// Close the status line unconditionally. Whatever comes next — the
+		// completion message, or an error printed by main — must start on its
+		// own line instead of being glued to "Waiting for approval… ".
+		fmt.Fprintln(outW)
 	}
 	if err != nil {
 		return fmt.Errorf("complete login: %w", err)
@@ -481,13 +513,18 @@ func loginCompleteLine(token, dialled string) string {
 }
 
 // withHeadlessStoreHint appends file-token-store guidance to a credential
-// store write failure. The default backend is the OS keyring, which locked
-// or keyring-less machines (CI, containers, minimal server VMs) can't use —
-// the raw store error gives those users no way forward (#1036). The hint is
-// skipped when ENTIRE_TOKEN_STORE=file is already set (suggesting it again
-// would be nonsense) and for failures the file store wouldn't help with.
+// store write failure. The default backend now falls back to the file store
+// on its own when the keyring is unusable, so this is left for the cases
+// where a write genuinely failed and the file store is still worth naming:
+// ENTIRE_TOKEN_STORE=keyring (fallback deliberately disabled), or a keyring
+// error the store did not classify as unusable. The hint is skipped when the
+// file store is already selected or has already been tried and failed
+// (suggesting it again would be nonsense), and for failures it wouldn't help
+// with (#1036).
 func withHeadlessStoreHint(err error) error {
-	if !errors.Is(err, auth.ErrCredentialStoreWrite) || tokenstore.FileBackendSelected() {
+	if !errors.Is(err, auth.ErrCredentialStoreWrite) ||
+		tokenstore.FileBackendSelected() ||
+		errors.Is(err, tokenstore.ErrFileFallbackFailed) {
 		return err
 	}
 
@@ -699,7 +736,37 @@ func waitForApproval(ctx context.Context, poller deviceAuthClient, deviceCode st
 	}
 }
 
-const loginURLPrompt = "[Enter] Open browser  [c] Copy URL"
+const (
+	loginURLOpenHint = "[Enter] Open browser"
+	loginURLCopyHint = "[c] Copy URL"
+	// loginURLPrompt is the fully-equipped prompt; loginURLPromptLine drops
+	// the hints this machine cannot honour.
+	loginURLPrompt = loginURLOpenHint + "  " + loginURLCopyHint
+)
+
+// noBrowserOpenerNotice answers an Enter this machine cannot act on. The hint
+// was already withheld (see loginURLPromptLine), so this only fires when the
+// user pressed Enter anyway — as a plain "get on with it" gesture.
+const noBrowserOpenerNotice = "No browser to open on this machine; open the login URL above instead."
+
+// loginURLPromptLine renders the hints for the actions available here,
+// returning "" when there is nothing to advertise — either the terminal
+// cannot deliver keys or neither side effect is possible on this machine.
+// Sign-in always completes through the URL printed above it, so an empty
+// prompt costs nothing but a line of output.
+func loginURLPromptLine(actions loginURLActions) string {
+	if !actions.keys {
+		return ""
+	}
+	hints := make([]string, 0, 2)
+	if actions.browser {
+		hints = append(hints, loginURLOpenHint)
+	}
+	if actions.clipboard {
+		hints = append(hints, loginURLCopyHint)
+	}
+	return strings.Join(hints, "  ")
+}
 
 const (
 	browserLoginURLLabel = "Login URL:"
@@ -777,12 +844,16 @@ func waitForLoginURLResult[T any](
 		}
 	}
 
+	// Resolved once: the prompt below and the Enter handler must agree on
+	// what this machine can do.
+	actions := interactor.availableActions()
+
 	statusLineOpen := false
 	renderInitialPrompt := func() {
-		// Only advertise the keys when the terminal can actually deliver them.
-		// Authentication still completes through the always-visible URL.
-		if interactor.keysAvailable() {
-			fmt.Fprintln(outW, loginURLPrompt)
+		// Only advertise actions this process can honour. Authentication
+		// still completes through the always-visible URL.
+		if prompt := loginURLPromptLine(actions); prompt != "" {
+			fmt.Fprintln(outW, prompt)
 		}
 		fmt.Fprint(outW, waitingMessage)
 		statusLineOpen = true
@@ -794,7 +865,9 @@ func waitForLoginURLResult[T any](
 		}
 	}
 	renderInitialPrompt()
-	startActionRead()
+	if actions.usable() {
+		startActionRead()
+	}
 
 	for {
 		select {
@@ -838,6 +911,11 @@ func waitForLoginURLResult[T any](
 				}
 				startActionRead()
 			case loginURLOpen:
+				if !actions.browser {
+					fmt.Fprintln(errW, noBrowserOpenerNotice)
+					startActionRead()
+					continue
+				}
 				if err := interactor.openURL(flowCtx, loginURL); err != nil {
 					fmt.Fprintf(errW, "Warning: failed to open default browser: %v\n", err)
 					startActionRead()

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -433,7 +433,9 @@ func noopCopyURL(string) error { return nil }
 func newTestLoginURLInteractor(actions ...loginURLAction) loginURLInteractor {
 	next := 0
 	return loginURLInteractor{
-		keysAvailable: func() bool { return true },
+		availableActions: func() loginURLActions {
+			return loginURLActions{keys: true, browser: true, clipboard: true}
+		},
 		readAction: func(ctx context.Context) (loginURLAction, error) {
 			if next >= len(actions) {
 				<-ctx.Done()
@@ -455,7 +457,7 @@ func TestWaitForLoginURLResult_NoKeysSuppressesPrompt(t *testing.T) {
 	t.Parallel()
 
 	interactor := newTestLoginURLInteractor()
-	interactor.keysAvailable = func() bool { return false }
+	interactor.availableActions = func() loginURLActions { return loginURLActions{} }
 	interactor.readAction = func(context.Context) (loginURLAction, error) {
 		return loginURLNone, nil
 	}
@@ -767,6 +769,171 @@ func TestLoginURLActionModel(t *testing.T) {
 				t.Errorf("quit command present = %v, want %v", gotQuit, tt.wantSelected)
 			}
 		})
+	}
+}
+
+// The prompt only advertises what this machine can honour: a headless box has
+// no browser opener and no clipboard helper, and offering keys for either just
+// trades a keystroke for a warning.
+func TestLoginURLPromptLine(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		actions loginURLActions
+		want    string
+	}{
+		{name: "everything available", actions: loginURLActions{keys: true, browser: true, clipboard: true}, want: loginURLPrompt},
+		{name: "no browser", actions: loginURLActions{keys: true, clipboard: true}, want: loginURLCopyHint},
+		{name: "no clipboard", actions: loginURLActions{keys: true, browser: true}, want: loginURLOpenHint},
+		{name: "headless machine with a terminal", actions: loginURLActions{keys: true}, want: ""},
+		{name: "no keys", actions: loginURLActions{browser: true, clipboard: true}, want: ""},
+		{name: "nothing", actions: loginURLActions{}, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := loginURLPromptLine(tc.actions); got != tc.want {
+				t.Errorf("loginURLPromptLine(%+v) = %q, want %q", tc.actions, got, tc.want)
+			}
+		})
+	}
+}
+
+// A terminal that can deliver keys, on a machine where no key can lead
+// anywhere, must be left alone: no prompt, and no raw-mode reader taking over
+// the user's Ctrl-C for a keystroke that could only be refused.
+func TestWaitForLoginURLResult_NoUsableActionsLeavesTerminalAlone(t *testing.T) {
+	t.Parallel()
+
+	reads := make(chan struct{}, 1)
+	interactor := newTestLoginURLInteractor()
+	interactor.availableActions = func() loginURLActions { return loginURLActions{keys: true} }
+	interactor.readAction = func(ctx context.Context) (loginURLAction, error) {
+		reads <- struct{}{}
+		<-ctx.Done()
+		return loginURLNone, ctx.Err()
+	}
+
+	var out bytes.Buffer
+	got, err := waitForLoginURLResult(
+		context.Background(), &out, &bytes.Buffer{},
+		"https://auth.test/device?code=ABCD", "Waiting... ", interactor,
+		func(context.Context) (string, error) { return testLoginComplete, nil },
+	)
+	if err != nil {
+		t.Fatalf("waitForLoginURLResult() error = %v", err)
+	}
+	if got != testLoginComplete {
+		t.Errorf("result = %q, want complete", got)
+	}
+	select {
+	case <-reads:
+		t.Error("keys were read on a machine that can honour none of the actions")
+	default:
+	}
+	if strings.Contains(out.String(), "[") {
+		t.Errorf("output advertised an action:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Waiting... ") {
+		t.Errorf("output missing waiting message:\n%s", out.String())
+	}
+}
+
+// Enter is a natural "get on with it" keystroke, so it can arrive even though
+// the hint was withheld. Without an opener it must answer with a sentence
+// instead of launching an exec that can only fail, and sign-in must carry on.
+func TestWaitForLoginURLResult_EnterWithoutBrowserOpenerRefusesToExec(t *testing.T) {
+	t.Parallel()
+
+	opened := make(chan struct{}, 1)
+	reads := make(chan int, 2)
+	readCount := 0
+	interactor := loginURLInteractor{
+		availableActions: func() loginURLActions {
+			return loginURLActions{keys: true, clipboard: true}
+		},
+		// Called serially by waitForLoginURLResult, one reader at a time.
+		readAction: func(ctx context.Context) (loginURLAction, error) {
+			readCount++
+			reads <- readCount
+			if readCount == 1 {
+				return loginURLOpen, nil
+			}
+			<-ctx.Done()
+			return loginURLNone, ctx.Err()
+		},
+		copyURL: noopCopyURL,
+		openURL: func(context.Context, string) error {
+			opened <- struct{}{}
+			return nil
+		},
+	}
+
+	authComplete := make(chan struct{})
+	var out, errOut bytes.Buffer
+	resultCh := make(chan loginURLWaitResult[string], 1)
+	go func() {
+		value, err := waitForLoginURLResult(
+			context.Background(), &out, &errOut,
+			"https://auth.test/device?code=ABCD", "Waiting... ", interactor,
+			func(context.Context) (string, error) {
+				<-authComplete
+				return testLoginComplete, nil
+			},
+		)
+		resultCh <- loginURLWaitResult[string]{value: value, err: err}
+	}()
+
+	// A second key read only starts once the Enter has been handled, so it is
+	// the signal that the refusal path ran to completion.
+	<-reads
+	<-reads
+	close(authComplete)
+
+	result := <-resultCh
+	if result.err != nil {
+		t.Fatalf("waitForLoginURLResult() error = %v", result.err)
+	}
+	if result.value != testLoginComplete {
+		t.Errorf("result = %q, want complete", result.value)
+	}
+	select {
+	case <-opened:
+		t.Error("openURL was called on a machine with no browser opener")
+	default:
+	}
+	if !strings.Contains(errOut.String(), noBrowserOpenerNotice) {
+		t.Errorf("Enter was swallowed without explanation:\n%s", errOut.String())
+	}
+	if strings.Contains(out.String(), loginURLOpenHint) {
+		t.Errorf("prompt advertised a browser this machine cannot open:\n%s", out.String())
+	}
+}
+
+// The non-interactive device flow prints "Waiting for approval… " without a
+// newline; whatever comes next (here a failure) must not be glued onto it.
+func TestRunLogin_NonInteractiveClosesWaitingLine(t *testing.T) {
+	t.Parallel()
+
+	client := &mockClient{
+		start: &auth.DeviceAuthStart{
+			DeviceCode:              "device-123",
+			UserCode:                "ABCD-EFGH",
+			VerificationURIComplete: "https://auth.test/device?code=ABCD-EFGH",
+			ExpiresIn:               60,
+		},
+		responses: []pollResponse{{result: &auth.DeviceAuthPoll{Error: "access_denied"}}},
+	}
+	var out bytes.Buffer
+	if err := runLogin(context.Background(), &out, &bytes.Buffer{}, client, newTestLoginURLInteractor(), false); err == nil {
+		t.Fatal("runLogin() error = nil, want device authorization denied")
+	}
+	if !strings.HasSuffix(out.String(), "Waiting for approval… \n") {
+		t.Errorf("waiting line was left open, so the error would run into it:\n%q", out.String())
+	}
+	if strings.Contains(out.String(), loginURLPrompt) {
+		t.Errorf("non-interactive login advertised key actions:\n%s", out.String())
 	}
 }
 

--- a/cmd/entire/cli/login_tty_test.go
+++ b/cmd/entire/cli/login_tty_test.go
@@ -108,7 +108,9 @@ func TestWaitForLoginURLResult_AuthCompletionCancelsTTYAndRestoresTerminal(t *te
 
 	authComplete := make(chan struct{})
 	interactor := loginURLInteractor{
-		keysAvailable: func() bool { return true },
+		availableActions: func() loginURLActions {
+			return loginURLActions{keys: true, browser: true, clipboard: true}
+		},
 		readAction: func(ctx context.Context) (loginURLAction, error) {
 			return readLoginURLActionFromTTY(ctx, io.Discard, tty)
 		},

--- a/internal/entireclient/tokenstore/fallback.go
+++ b/internal/entireclient/tokenstore/fallback.go
@@ -1,0 +1,213 @@
+package tokenstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+// ErrFileFallbackFailed marks the case where the OS keyring refused a write
+// *and* the file store could not take it either. Callers use it to suppress
+// "try the file store instead" guidance that has already been tried.
+var ErrFileFallbackFailed = errors.New("keyring unavailable and file token store write failed")
+
+// fallbackWarnW receives the one-time file-fallback warning. Package-level so
+// tests can capture it; production writes to stderr, matching the
+// loose-permissions warning in file.go.
+var fallbackWarnW io.Writer = os.Stderr
+
+var (
+	fallbackMu   sync.Mutex
+	fallbackPath string // set once credentials were written to the file store because the keyring refused them
+)
+
+// FellBackToFileStore reports whether this process stored credentials in the
+// file backend after the OS keyring refused them, and where. User-facing
+// provenance (e.g. `entire auth status`) uses it so the reported location is
+// where the tokens actually are.
+func FellBackToFileStore() (path string, ok bool) {
+	fallbackMu.Lock()
+	defer fallbackMu.Unlock()
+	return fallbackPath, fallbackPath != ""
+}
+
+// resetFileFallbackForTesting clears the process-wide fallback marker so a
+// test asserting on the one-time warning starts from a known state.
+func resetFileFallbackForTesting() {
+	fallbackMu.Lock()
+	defer fallbackMu.Unlock()
+	fallbackPath = ""
+}
+
+// noteFileFallback records that a credential landed in the file store and
+// warns — once per process — that it is on disk rather than in the keyring.
+// The user chose neither, so they get told: the tokens are bearer credentials,
+// and where they live is the user's call to review.
+func noteFileFallback(path string, keyringErr error) {
+	fallbackMu.Lock()
+	first := fallbackPath == ""
+	fallbackPath = path
+	fallbackMu.Unlock()
+
+	if !first {
+		return
+	}
+	fmt.Fprintf(fallbackWarnW,
+		"Warning: OS keyring (%s) is unavailable: %v\nCredentials saved to %s instead (mode 0600). Set %s=file to skip the keyring, or %s=keyring to fail instead of writing a file.\n",
+		keyringProviderName(), keyringErr, path, BackendEnvVar, BackendEnvVar)
+}
+
+// fallbackStore is the default backend: the OS keyring, with the file store
+// standing in whenever the keyring is unusable.
+//
+// The fallback exists because the alternative is throwing away a login the
+// user already completed. `entire login` finishes the whole device/browser
+// flow — code entered, browser approved — and only then writes tokens; on a
+// machine with no Secret Service (headless server, container, plain SSH box)
+// that write failed with `exec: "dbus-launch": executable file not found`,
+// the command exited 1, and the user was told to re-run the entire flow with
+// ENTIRE_TOKEN_STORE=file. Storing the tokens they just earned, in the
+// documented 0600 file, is strictly better than discarding them — announced
+// on stderr (noteFileFallback), never silent.
+//
+// The keyring stays first, so a working keyring is always preferred and a
+// machine that grows one later goes back to using it. ENTIRE_TOKEN_STORE
+// overrides the whole arrangement in either direction: "file" skips the
+// keyring attempt, "keyring" requires it and fails rather than writing a file.
+type fallbackStore struct {
+	keyring store
+	file    *fileStore
+
+	// mu guards unusable, a process-local latch: once the keyring has failed
+	// there is no point paying for it again (a hung provider costs up to
+	// keyringTimeout per call, and a CLI run makes several).
+	mu       sync.Mutex
+	unusable bool
+}
+
+func (s *fallbackStore) keyringUsable() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.unusable
+}
+
+func (s *fallbackStore) markKeyringUnusable() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unusable = true
+}
+
+// interruptedKeyringCall reports whether err is the wrapped context.Canceled
+// that callKeyringWithTimeout returns when the user pressed Ctrl-C. That is a
+// user aborting the command, not a broken keyring: it must propagate
+// untouched (main turns it into the quiet SIGINT exit) and must never be
+// answered by writing a token to disk. A timeout wraps DeadlineExceeded
+// instead, which does mean "unusable".
+func interruptedKeyringCall(err error) bool {
+	return errors.Is(err, context.Canceled)
+}
+
+// Get prefers the keyring and consults the file store when the keyring has no
+// answer. A keyring miss (ErrNotFound) still checks the file, because that is
+// exactly where an earlier fallback write would have put the entry. A keyring
+// *failure* with nothing in the file surfaces the keyring error rather than
+// ErrNotFound, so a broken keyring never masquerades as "not logged in".
+func (s *fallbackStore) Get(service, user string) (string, error) {
+	var keyringErr error
+	if s.keyringUsable() {
+		value, err := s.keyring.Get(service, user)
+		switch {
+		case err == nil:
+			return value, nil
+		case interruptedKeyringCall(err):
+			return "", err //nolint:wrapcheck // user abort propagates verbatim
+		case errors.Is(err, ErrNotFound):
+			// Keyring is healthy and simply holds no entry.
+		default:
+			s.markKeyringUnusable()
+			keyringErr = err
+		}
+	}
+
+	value, fileErr := s.file.Get(service, user)
+	if fileErr == nil {
+		return value, nil
+	}
+	if keyringErr != nil {
+		return "", keyringErr
+	}
+
+	return "", fileErr
+}
+
+// Set writes to the keyring, falling back to the file store when it refuses.
+func (s *fallbackStore) Set(service, user, password string) error {
+	if s.keyringUsable() {
+		err := s.keyring.Set(service, user, password)
+		if err == nil {
+			return nil
+		}
+		if interruptedKeyringCall(err) {
+			return err //nolint:wrapcheck // user abort propagates verbatim
+		}
+		s.markKeyringUnusable()
+		if fileErr := s.file.Set(service, user, password); fileErr != nil {
+			return fmt.Errorf("%w: keyring: %w; file %s: %w", ErrFileFallbackFailed, err, s.file.path, fileErr)
+		}
+		noteFileFallback(s.file.path, err)
+		return nil
+	}
+
+	// The keyring already failed earlier in this process; the warning has
+	// been printed and the file store is where this belongs.
+	if err := s.file.Set(service, user, password); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete clears the credential from both backends: a fallback write may have
+// left a copy in either, and logout has to remove all of them. It succeeds if
+// any backend had the entry and removed it, reports ErrNotFound only when
+// every backend agreed there was nothing to remove, and otherwise surfaces
+// the first real failure.
+func (s *fallbackStore) Delete(service, user string) error {
+	deleted := false
+	var firstErr error
+
+	note := func(err error) {
+		switch {
+		case err == nil:
+			deleted = true
+		case errors.Is(err, ErrNotFound):
+			// Nothing here to remove.
+		case firstErr == nil:
+			firstErr = err
+		}
+	}
+
+	if s.keyringUsable() {
+		err := s.keyring.Delete(service, user)
+		if interruptedKeyringCall(err) {
+			return err //nolint:wrapcheck // user abort propagates verbatim
+		}
+		if err != nil && !errors.Is(err, ErrNotFound) {
+			s.markKeyringUnusable()
+		}
+		note(err)
+	}
+	note(s.file.Delete(service, user))
+
+	switch {
+	case deleted:
+		return nil
+	case firstErr != nil:
+
+		return firstErr
+	default:
+		return ErrNotFound
+	}
+}

--- a/internal/entireclient/tokenstore/fallback_test.go
+++ b/internal/entireclient/tokenstore/fallback_test.go
@@ -1,0 +1,329 @@
+package tokenstore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeKeyring stands in for the OS keyring. err is returned by every
+// operation when set; calls counts what actually reached it, which is how the
+// process-local unusable latch is observed.
+type fakeKeyring struct {
+	err    error
+	values map[string]string
+	calls  int
+}
+
+func (f *fakeKeyring) key(service, user string) string { return service + "\x00" + user }
+
+func (f *fakeKeyring) Get(service, user string) (string, error) {
+	f.calls++
+	if f.err != nil {
+		return "", f.err
+	}
+	if v, ok := f.values[f.key(service, user)]; ok {
+		return v, nil
+	}
+	return "", ErrNotFound
+}
+
+func (f *fakeKeyring) Set(service, user, password string) error {
+	f.calls++
+	if f.err != nil {
+		return f.err
+	}
+	if f.values == nil {
+		f.values = make(map[string]string)
+	}
+	f.values[f.key(service, user)] = password
+	return nil
+}
+
+func (f *fakeKeyring) Delete(service, user string) error {
+	f.calls++
+	if f.err != nil {
+		return f.err
+	}
+	if _, ok := f.values[f.key(service, user)]; !ok {
+		return ErrNotFound
+	}
+	delete(f.values, f.key(service, user))
+	return nil
+}
+
+// newFallbackStoreForTest wires a fallbackStore over a fake keyring and a
+// per-test file, and captures the one-time fallback warning. It resets the
+// process-wide fallback marker, so these tests cannot run in parallel with
+// anything reading it (FellBackToFileStore, BackendDescription).
+func newFallbackStoreForTest(t *testing.T, keyringErr error) (*fallbackStore, *fakeKeyring, *bytes.Buffer) {
+	t.Helper()
+
+	kr := &fakeKeyring{err: keyringErr}
+	s := &fallbackStore{
+		keyring: kr,
+		file:    &fileStore{path: filepath.Join(t.TempDir(), "tokens.json")},
+	}
+
+	var warn bytes.Buffer
+	prevWarn := fallbackWarnW
+	fallbackWarnW = &warn
+	resetFileFallbackForTesting()
+	t.Cleanup(func() {
+		fallbackWarnW = prevWarn
+		resetFileFallbackForTesting()
+	})
+
+	return s, kr, &warn
+}
+
+// errKeyringless is the shape of the real failure on a machine with no Secret
+// Service: the provider's helper binary is simply absent.
+var errKeyringless = errors.New(`exec: "dbus-launch": executable file not found in $PATH`)
+
+// A login is completed before its tokens are written, so a keyring-less
+// machine must not lose it: the write lands in the 0600 file store, is
+// readable afterwards, and the user is told once.
+func TestFallbackStore_SetFallsBackToFileAndStaysReadable(t *testing.T) {
+	s, kr, warn := newFallbackStoreForTest(t, errKeyringless)
+
+	if err := s.Set("entire-core:https://auth.test", "alice", "token-1"); err != nil {
+		t.Fatalf("Set() error = %v, want nil", err)
+	}
+
+	got, err := s.Get("entire-core:https://auth.test", "alice")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got != "token-1" {
+		t.Errorf("Get() = %q, want %q", got, "token-1")
+	}
+
+	path, ok := FellBackToFileStore()
+	if !ok || path != s.file.path {
+		t.Errorf("FellBackToFileStore() = (%q, %v), want (%q, true)", path, ok, s.file.path)
+	}
+	for _, want := range []string{keyringProviderName(), s.file.path, "dbus-launch", BackendEnvVar + "=file", BackendEnvVar + "=keyring"} {
+		if !strings.Contains(warn.String(), want) {
+			t.Errorf("warning missing %q:\n%s", want, warn.String())
+		}
+	}
+	// The latch: one failed call is enough to stop paying for the keyring,
+	// which can cost keyringTimeout per call when a provider hangs.
+	if kr.calls != 1 {
+		t.Errorf("keyring calls = %d, want 1 (unusable latch not held)", kr.calls)
+	}
+}
+
+// The warning is a once-per-process notice, not per credential — a login
+// writes both a refresh and an access token.
+func TestFallbackStore_WarnsOncePerProcess(t *testing.T) {
+	s, _, warn := newFallbackStoreForTest(t, errKeyringless)
+
+	for _, service := range []string{"entire-core:https://auth.test:refresh", "entire-core:https://auth.test"} {
+		if err := s.Set(service, "alice", "token"); err != nil {
+			t.Fatalf("Set(%q) error = %v", service, err)
+		}
+	}
+
+	if got := strings.Count(warn.String(), "Credentials saved to"); got != 1 {
+		t.Errorf("fallback warning printed %d times, want 1:\n%s", got, warn.String())
+	}
+}
+
+// A healthy keyring is always preferred, and nothing is written to disk.
+func TestFallbackStore_PrefersHealthyKeyring(t *testing.T) {
+	s, kr, warn := newFallbackStoreForTest(t, nil)
+
+	if err := s.Set("svc", "alice", "token-1"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if got := kr.values[kr.key("svc", "alice")]; got != "token-1" {
+		t.Errorf("keyring holds %q, want %q", got, "token-1")
+	}
+	if value, err := s.file.Get("svc", "alice"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("file store holds %q (err %v); a working keyring must not spill tokens to disk", value, err)
+	}
+	if _, ok := FellBackToFileStore(); ok {
+		t.Error("FellBackToFileStore() = true with a healthy keyring")
+	}
+	if warn.Len() != 0 {
+		t.Errorf("unexpected warning:\n%s", warn.String())
+	}
+}
+
+// A keyring miss is not a keyring failure: the entry may still be in the file
+// store from an earlier fallback, and the keyring stays usable.
+func TestFallbackStore_KeyringMissConsultsFile(t *testing.T) {
+	s, kr, _ := newFallbackStoreForTest(t, nil)
+
+	if err := s.file.Set("svc", "alice", "from-file"); err != nil {
+		t.Fatalf("seed file store: %v", err)
+	}
+
+	got, err := s.Get("svc", "alice")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got != "from-file" {
+		t.Errorf("Get() = %q, want %q", got, "from-file")
+	}
+	if !s.keyringUsable() {
+		t.Error("a keyring miss marked the keyring unusable")
+	}
+	if kr.calls != 1 {
+		t.Errorf("keyring calls = %d, want 1", kr.calls)
+	}
+}
+
+// A broken keyring with nothing in the file must surface the keyring error, so
+// a keyring problem never reads as "not logged in".
+func TestFallbackStore_GetSurfacesKeyringFailureOverNotFound(t *testing.T) {
+	s, _, _ := newFallbackStoreForTest(t, errKeyringless)
+
+	_, err := s.Get("svc", "alice")
+	if !errors.Is(err, errKeyringless) {
+		t.Fatalf("Get() error = %v, want the keyring failure", err)
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Error("a broken keyring reported ErrNotFound")
+	}
+}
+
+// Ctrl-C during a keyring call is the user aborting the command, not a broken
+// keyring: it must propagate and must never be answered by writing a bearer
+// token to disk.
+func TestFallbackStore_InterruptDoesNotWriteToDisk(t *testing.T) {
+	s, _, warn := newFallbackStoreForTest(t, fmt.Errorf("set interrupted: %w", context.Canceled))
+
+	err := s.Set("svc", "alice", "token-1")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Set() error = %v, want context.Canceled", err)
+	}
+	if value, fileErr := s.file.Get("svc", "alice"); !errors.Is(fileErr, ErrNotFound) {
+		t.Errorf("file store holds %q (err %v) after an interrupt", value, fileErr)
+	}
+	if _, ok := FellBackToFileStore(); ok {
+		t.Error("FellBackToFileStore() = true after an interrupt")
+	}
+	if warn.Len() != 0 {
+		t.Errorf("unexpected warning:\n%s", warn.String())
+	}
+	if !s.keyringUsable() {
+		t.Error("an interrupt marked the keyring unusable")
+	}
+}
+
+// When neither backend can take the write, the error says so — and marks
+// itself so login stops suggesting the file store it just tried.
+func TestFallbackStore_BothBackendsFailing(t *testing.T) {
+	s, _, _ := newFallbackStoreForTest(t, errKeyringless)
+	// A path whose parent is a file, so MkdirAll (and the write) must fail.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0600); err != nil {
+		t.Fatalf("seed blocker: %v", err)
+	}
+	s.file = &fileStore{path: filepath.Join(blocker, "tokens.json")}
+
+	err := s.Set("svc", "alice", "token-1")
+	if !errors.Is(err, ErrFileFallbackFailed) {
+		t.Fatalf("Set() error = %v, want ErrFileFallbackFailed", err)
+	}
+	if !strings.Contains(err.Error(), "dbus-launch") {
+		t.Errorf("error drops the keyring cause: %v", err)
+	}
+}
+
+// Logout has to clear every copy: a fallback write may have left the
+// credential in either backend.
+func TestFallbackStore_DeleteClearsBothBackends(t *testing.T) {
+	s, kr, _ := newFallbackStoreForTest(t, nil)
+
+	if err := kr.Set("svc", "alice", "from-keyring"); err != nil {
+		t.Fatalf("seed keyring: %v", err)
+	}
+	if err := s.file.Set("svc", "alice", "from-file"); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	if err := s.Delete("svc", "alice"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, err := kr.Get("svc", "alice"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("keyring copy survived delete: %v", err)
+	}
+	if _, err := s.file.Get("svc", "alice"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("file copy survived delete: %v", err)
+	}
+}
+
+// Nothing anywhere still reports ErrNotFound, which callers (logout) match on.
+func TestFallbackStore_DeleteMissingReportsNotFound(t *testing.T) {
+	s, _, _ := newFallbackStoreForTest(t, nil)
+
+	if err := s.Delete("svc", "alice"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Delete() error = %v, want ErrNotFound", err)
+	}
+}
+
+// A broken keyring must not stop the delete from clearing the file copy.
+func TestFallbackStore_DeleteSucceedsWithBrokenKeyring(t *testing.T) {
+	s, _, _ := newFallbackStoreForTest(t, errKeyringless)
+
+	if err := s.file.Set("svc", "alice", "from-file"); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if err := s.Delete("svc", "alice"); err != nil {
+		t.Fatalf("Delete() error = %v, want nil", err)
+	}
+	if _, err := s.file.Get("svc", "alice"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("file copy survived delete: %v", err)
+	}
+}
+
+// Provenance follows the tokens: after a fallback, auth status must name the
+// file, not the keyring that refused the write.
+func TestBackendDescription_ReflectsFileFallback(t *testing.T) {
+	s, _, _ := newFallbackStoreForTest(t, errKeyringless)
+	t.Setenv(BackendEnvVar, "")
+
+	if got := BackendDescription(); got != keyringProviderName() {
+		t.Errorf("BackendDescription() = %q before any fallback, want %q", got, keyringProviderName())
+	}
+	if err := s.Set("svc", "alice", "token-1"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	got := BackendDescription()
+	if !strings.Contains(got, s.file.path) || !strings.Contains(got, keyringProviderName()) {
+		t.Errorf("BackendDescription() = %q, want it to name %q and %q", got, s.file.path, keyringProviderName())
+	}
+}
+
+func TestBackendSelectionEnvVar(t *testing.T) {
+	cases := []struct {
+		value       string
+		wantFile    bool
+		wantKeyring bool
+	}{
+		{value: "", wantFile: false, wantKeyring: false},
+		{value: "file", wantFile: true, wantKeyring: false},
+		{value: "keyring", wantFile: false, wantKeyring: true},
+		{value: "nonsense", wantFile: false, wantKeyring: false},
+	}
+	for _, tc := range cases {
+		t.Run("value="+tc.value, func(t *testing.T) {
+			t.Setenv(BackendEnvVar, tc.value)
+			if got := FileBackendSelected(); got != tc.wantFile {
+				t.Errorf("FileBackendSelected() = %v, want %v", got, tc.wantFile)
+			}
+			if got := KeyringOnlySelected(); got != tc.wantKeyring {
+				t.Errorf("KeyringOnlySelected() = %v, want %v", got, tc.wantKeyring)
+			}
+		})
+	}
+}

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -2,8 +2,14 @@
 // entiredb and entire-core CLIs.
 //
 // By default it delegates to the OS keyring (macOS Keychain, Linux Secret
-// Service, etc.). Set ENTIRE_TOKEN_STORE=file to use a JSON file instead,
-// which is useful in CI environments that lack a keyring daemon.
+// Service, etc.), falling back to a JSON file when the keyring is unusable —
+// headless servers, containers, and CI runners have no keyring daemon, and
+// losing a completed login to that is worse than storing the tokens in the
+// documented 0600 file. The fallback is announced on stderr; see fallback.go.
+//
+// ENTIRE_TOKEN_STORE overrides the arrangement in either direction: "file"
+// skips the keyring entirely, "keyring" requires it and fails rather than
+// writing tokens to disk.
 //
 // When using the file backend the tokens are stored in
 // $ENTIRE_TOKEN_STORE_PATH (default: tokens.json in the per-user config
@@ -19,6 +25,7 @@
 package tokenstore
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -93,21 +100,35 @@ func currentBackend() store {
 	return backend
 }
 
-// BackendEnvVar selects the credential backend: set to "file" to use the
-// JSON file store instead of the OS keyring. PathEnvVar overrides where the
-// file store lives (default: tokens.json in the per-user config directory).
-// Exported so user-facing guidance (e.g. login's headless hint) names the
-// same variables this package actually reads.
+// BackendEnvVar selects the credential backend: "file" uses the JSON file
+// store and never touches the OS keyring, "keyring" requires the keyring and
+// fails rather than falling back to a file. Anything else (including unset)
+// gets the default keyring-then-file arrangement. PathEnvVar overrides where
+// the file store lives (default: tokens.json in the per-user config
+// directory). Exported so user-facing guidance (e.g. login's headless hint)
+// names the same variables this package actually reads.
 const (
 	BackendEnvVar = "ENTIRE_TOKEN_STORE"
 	PathEnvVar    = "ENTIRE_TOKEN_STORE_PATH"
+)
+
+// Values BackendEnvVar accepts. Anything else means "default".
+const (
+	backendValueFile    = "file"
+	backendValueKeyring = "keyring"
 )
 
 // FileBackendSelected reports whether the environment selects the file
 // backend — the single predicate shared by backend resolution, provenance
 // wording, and login's headless hint, so they can never disagree.
 func FileBackendSelected() bool {
-	return os.Getenv(BackendEnvVar) == "file"
+	return os.Getenv(BackendEnvVar) == backendValueFile
+}
+
+// KeyringOnlySelected reports whether the environment demands the OS keyring
+// with no file fallback: a deliberate "never write my bearer tokens to disk".
+func KeyringOnlySelected() bool {
+	return os.Getenv(BackendEnvVar) == backendValueKeyring
 }
 
 // BackendDescription names the credential backend the current environment
@@ -118,6 +139,11 @@ func FileBackendSelected() bool {
 func BackendDescription() string {
 	if FileBackendSelected() {
 		return "file " + FileBackendPath()
+	}
+	// A fallback write already happened, so name where the tokens actually
+	// are rather than the keyring that refused them.
+	if path, ok := FellBackToFileStore(); ok {
+		return fmt.Sprintf("file %s (%s unavailable)", path, keyringProviderName())
 	}
 	return keyringProviderName()
 }
@@ -144,7 +170,13 @@ func resolveBackendLocked() store {
 	if dir, ok := testdirs.Dir("tokenstore"); ok {
 		return &fileStore{path: filepath.Join(dir, "tokens.json")}
 	}
-	return keyringStore{}
+	if KeyringOnlySelected() {
+		return keyringStore{}
+	}
+	return &fallbackStore{
+		keyring: keyringStore{},
+		file:    &fileStore{path: FileBackendPath()},
+	}
 }
 
 // Get retrieves a credential.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1116
<!-- entire-trail-link-end -->

## The transcript this fixes

```
dev% go run ./cmd/entire login
SSH session detected; using device-code flow (a browser opened here couldn't reach this machine).
Device code: 6ULF-BR4P
Login URL:   https://us.auth.entire.io/cli/auth?user_code=6ULF-BR4P

Press Enter to open in browser...

Warning: failed to open browser: start browser command "xdg-open": exec: "xdg-open": executable file not found in $PATH
Open this URL in your browser to approve this login: https://us.auth.entire.io/cli/auth?user_code=6ULF-BR4P
Waiting for approval... save login: store refresh token in credential store: exec: "dbus-launch": executable file not found in $PATH
...
exit status 1
```

Three separate problems, in the order they hurt.

## 1. A login the user already completed was thrown away

The credential write happens *after* approval, so on a box with no D-Bus the user entered the code, approved in a browser on another machine — and then got `exit status 1` plus instructions to re-run the entire flow with `ENTIRE_TOKEN_STORE=file`.

The default backend is now keyring-then-file (`internal/entireclient/tokenstore/fallback.go`):

- The keyring is still tried **first**, so a working keyring is always preferred and a machine that grows one later goes back to using it.
- When it refuses the write, the tokens land in the already-documented `0600` file instead of being discarded, and the fallback is announced on stderr — once per process, never silent.
- Reads follow the same order, so later commands find the tokens with no env var set.
- **Ctrl-C during a keyring call stays an abort**: it propagates untouched and never answers a user's interrupt by writing a bearer token to disk.
- A keyring *failure* with nothing in the file surfaces the keyring error rather than `ErrNotFound`, so a broken keyring never masquerades as \"not logged in\".
- `Delete` clears both backends, so logout removes every copy a fallback write may have left.

On a keyring-less machine:

```
Warning: OS keyring (Secret Service (D-Bus)) is unavailable: exec: \"dbus-launch\": executable file not found in \$PATH
Credentials saved to ~/.config/entire/tokens.json instead (mode 0600). Set ENTIRE_TOKEN_STORE=file to skip the keyring, or ENTIRE_TOKEN_STORE=keyring to fail instead of writing a file.
```

**The one product judgment call here**, flagged for a human: auto-fallback-with-a-warning over failing. Discarding an approved login seemed clearly worse than storing it in the location the README already documents — but it does mean a machine that silently lost its keyring starts writing tokens to disk. `ENTIRE_TOKEN_STORE=keyring` is the new opt-out for \"never put my bearer tokens on disk\"; `=file` still skips the keyring entirely. Happy to make it a prompt instead if that's the wrong default.

## 2. It offered a browser that doesn't exist

`[Enter] Open browser  [c] Copy URL` was advertised unconditionally, so on a headless SSH box the keystroke could only buy a nested `exec: \"xdg-open\"` error — right after the CLI told the user to press it.

The prompt now advertises only what the machine can honour: an opener on `\$PATH` **plus** a graphical session (or a WSL bridge) for the browser, and `clipboard.Unsupported` for the copy hint. With neither available the prompt line disappears and the key reader never starts, which also leaves Ctrl-C native instead of taking a TTY into raw mode to collect keystrokes that could only be refused.

This gates what is *advertised*, not a veto: pressing Enter is still honoured wherever the opener binary exists, so an unusual-but-working setup isn't locked out — and where it doesn't exist, the answer is a sentence rather than an exec error.

## 3. The error was glued to the status line

`Waiting for approval... save login: store refresh token…` — the non-interactive device path printed `Waiting for approval… ` with no newline and never closed it, so whatever came next ran into it. The status line is now always closed.

## Also

- README's headless section: interactive login on a headless machine needs no env var now, and both overrides are documented.
- `tokenstore` package doc describes the new arrangement.

## Testing

- New white-box tests for the fallback store: fallback write + read-back, once-per-process warning, healthy keyring never spilling to disk, keyring-miss-consults-file, failure-over-`ErrNotFound`, interrupt writes nothing, both-backends-failing (`ErrFileFallbackFailed`), delete across both backends, provenance in `BackendDescription`, and the env-var matrix.
- New login tests: the prompt-line matrix, Enter-without-an-opener refusing to exec, no-usable-actions leaving the terminal alone, and the non-interactive waiting line being closed.
- `mise run fmt && mise run lint` clean; unit, integration, and both canary suites pass. Verified the fallback end-to-end on a real keyring-less machine (warning, write, read-back, provenance, delete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)