### PR TITLE
feat(search): align the CLI's merge, counts, and flags with the web BFF (ENT-1777)

### DIFF
--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -497,6 +497,16 @@ type Response struct {
 	Reranked *bool       `json:"reranked,omitempty"`
 	Counts   *TypeCounts `json:"counts,omitempty"`
 
+	// Completeness metadata, same names and semantics as the BFF's merged
+	// response (entire.io api/src/routes/search.ts mergeCellResponses) so web
+	// and CLI surface identical signals (ENT-1777). Parsed from each cell and
+	// re-synthesized by the CLI's own merge.
+	Partial            bool            `json:"partial,omitempty"`
+	Truncated          bool            `json:"truncated,omitempty"`
+	CoverageIncomplete bool            `json:"coverage_incomplete,omitempty"`
+	TruncatedTypes     map[string]bool `json:"truncated_types,omitempty"`
+	CountsLowerBound   map[string]bool `json:"counts_lower_bound,omitempty"`
+
 	// Warnings are client-side completeness notes (e.g. a truncated repo
 	// index or a failed region in a cross-cell fan-out) surfaced to the user
 	// on stderr. Never part of the wire format.

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -305,6 +305,11 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			model := newSearchModel(resp.Results, query, resp.Total, searchCfg, styles, codeOpts)
 			model.semanticSearch = searcher
 			model.warning = strings.Join(resp.Warnings, "; ")
+			// The initial response's counts metadata must reach the model the
+			// same way a re-search's does, or the tab counts and their
+			// lower-bound "+" are missing on the first view (ENT-1777).
+			model.counts = resp.Counts
+			model.countsLowerBound = resp.CountsLowerBound
 			p := tea.NewProgram(model)
 			if _, err := p.Run(); err != nil {
 				return fmt.Errorf("TUI error: %w", err)

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -281,7 +281,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 					fmt.Fprintln(w, "No results found.")
 					return nil
 				}
-				renderSearchStatic(w, resp.Results, query, resp.Total, styles)
+				renderSearchStatic(w, resp.Results, query, resp.Total, len(resp.CountsLowerBound) > 0, styles)
 				return nil
 			}
 
@@ -997,13 +997,25 @@ func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int) error 
 		TotalPages int                `json:"total_pages"`
 		Limit      int                `json:"limit"`
 		Counts     *search.TypeCounts `json:"counts,omitempty"`
+		// Completeness metadata, passed through from the merged response with
+		// the BFF's names and semantics (ENT-1777).
+		Partial            bool            `json:"partial,omitempty"`
+		Truncated          bool            `json:"truncated,omitempty"`
+		CoverageIncomplete bool            `json:"coverage_incomplete,omitempty"`
+		TruncatedTypes     map[string]bool `json:"truncated_types,omitempty"`
+		CountsLowerBound   map[string]bool `json:"counts_lower_bound,omitempty"`
 	}{
-		Results:    pageResults,
-		Total:      total,
-		Page:       page,
-		TotalPages: totalPages,
-		Limit:      limit,
-		Counts:     resp.Counts,
+		Results:            pageResults,
+		Total:              total,
+		Page:               page,
+		TotalPages:         totalPages,
+		Limit:              limit,
+		Counts:             resp.Counts,
+		Partial:            resp.Partial,
+		Truncated:          resp.Truncated,
+		CoverageIncomplete: resp.CoverageIncomplete,
+		TruncatedTypes:     resp.TruncatedTypes,
+		CountsLowerBound:   resp.CountsLowerBound,
 	}
 	data, err := jsonutil.MarshalIndentWithNewline(out, "", "  ")
 	if err != nil {
@@ -1100,13 +1112,25 @@ func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int)
 		TotalPages int                `json:"total_pages"`
 		Limit      int                `json:"limit"`
 		Counts     *search.TypeCounts `json:"counts,omitempty"`
+		// Completeness metadata, passed through from the merged response with
+		// the BFF's names and semantics (ENT-1777).
+		Partial            bool            `json:"partial,omitempty"`
+		Truncated          bool            `json:"truncated,omitempty"`
+		CoverageIncomplete bool            `json:"coverage_incomplete,omitempty"`
+		TruncatedTypes     map[string]bool `json:"truncated_types,omitempty"`
+		CountsLowerBound   map[string]bool `json:"counts_lower_bound,omitempty"`
 	}{
-		Results:    hits,
-		Total:      total,
-		Page:       page,
-		TotalPages: totalPages,
-		Limit:      limit,
-		Counts:     resp.Counts,
+		Results:            hits,
+		Total:              total,
+		Page:               page,
+		TotalPages:         totalPages,
+		Limit:              limit,
+		Counts:             resp.Counts,
+		Partial:            resp.Partial,
+		Truncated:          resp.Truncated,
+		CoverageIncomplete: resp.CoverageIncomplete,
+		TruncatedTypes:     resp.TruncatedTypes,
+		CountsLowerBound:   resp.CountsLowerBound,
 	}
 	data, err := jsonutil.MarshalIndentWithNewline(out, "", "  ")
 	if err != nil {

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -1009,6 +1009,7 @@ func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int) error 
 		CoverageIncomplete bool            `json:"coverage_incomplete,omitempty"`
 		TruncatedTypes     map[string]bool `json:"truncated_types,omitempty"`
 		CountsLowerBound   map[string]bool `json:"counts_lower_bound,omitempty"`
+		Reranked           *bool           `json:"reranked,omitempty"`
 	}{
 		Results:            pageResults,
 		Total:              total,
@@ -1021,6 +1022,7 @@ func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int) error 
 		CoverageIncomplete: resp.CoverageIncomplete,
 		TruncatedTypes:     resp.TruncatedTypes,
 		CountsLowerBound:   resp.CountsLowerBound,
+		Reranked:           resp.Reranked,
 	}
 	data, err := jsonutil.MarshalIndentWithNewline(out, "", "  ")
 	if err != nil {
@@ -1124,6 +1126,7 @@ func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int)
 		CoverageIncomplete bool            `json:"coverage_incomplete,omitempty"`
 		TruncatedTypes     map[string]bool `json:"truncated_types,omitempty"`
 		CountsLowerBound   map[string]bool `json:"counts_lower_bound,omitempty"`
+		Reranked           *bool           `json:"reranked,omitempty"`
 	}{
 		Results:            hits,
 		Total:              total,
@@ -1136,6 +1139,7 @@ func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int)
 		CoverageIncomplete: resp.CoverageIncomplete,
 		TruncatedTypes:     resp.TruncatedTypes,
 		CountsLowerBound:   resp.CountsLowerBound,
+		Reranked:           resp.Reranked,
 	}
 	data, err := jsonutil.MarshalIndentWithNewline(out, "", "  ")
 	if err != nil {

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -35,11 +35,14 @@ const (
 
 // searchResultsMsg is sent when a search API call completes.
 type searchResultsMsg struct {
-	results  []search.Result
-	total    int
-	counts   *search.TypeCounts
-	warnings []string
-	err      error
+	results []search.Result
+	total   int
+	counts  *search.TypeCounts
+	// countsLowerBound marks facets whose lists were capped upstream, so
+	// their counts are "at least N" (rendered as "N+", matching the web).
+	countsLowerBound map[string]bool
+	warnings         []string
+	err              error
 }
 
 // searchMoreResultsMsg is sent when a fetch-more-results call completes.
@@ -127,24 +130,25 @@ const (
 
 // searchModel is the bubbletea model for interactive search results.
 type searchModel struct {
-	results      []search.Result
-	cursor       int
-	page         int // 0-based display page index
-	total        int
-	width        int
-	height       int
-	mode         searchMode
-	loading      bool
-	fetchingMore bool // true while fetching next API page
-	searchErr    string
-	input        textinput.Model
-	searchCfg    search.Config
-	apiPage      int // 1-based last-fetched API page
-	styles       searchStyles
-	detailVP     viewport.Model     // full-screen detail view
-	browseVP     viewport.Model     // scrollable browse view
-	filterType   typeFilter         // active type tab filter
-	counts       *search.TypeCounts // per-type counts from API
+	results          []search.Result
+	cursor           int
+	page             int // 0-based display page index
+	total            int
+	width            int
+	height           int
+	mode             searchMode
+	loading          bool
+	fetchingMore     bool // true while fetching next API page
+	searchErr        string
+	input            textinput.Model
+	searchCfg        search.Config
+	apiPage          int // 1-based last-fetched API page
+	styles           searchStyles
+	detailVP         viewport.Model     // full-screen detail view
+	browseVP         viewport.Model     // scrollable browse view
+	filterType       typeFilter         // active type tab filter
+	counts           *search.TypeCounts // per-type counts from API
+	countsLowerBound map[string]bool    // facets whose counts are lower bounds
 
 	// semanticSearch performs checkpoint searches (initial, re-search, and
 	// pagination). The command layer injects its session searcher so every
@@ -354,6 +358,7 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 		m.results = msg.results
 		m.total = msg.total
 		m.counts = msg.counts
+		m.countsLowerBound = msg.countsLowerBound
 		m.warning = strings.Join(msg.warnings, "; ")
 		m.apiPage = 1
 		m.cursor = 0
@@ -678,7 +683,7 @@ func (m searchModel) performSearch(cfg search.Config) tea.Cmd {
 		if err != nil {
 			return searchResultsMsg{err: err}
 		}
-		return searchResultsMsg{results: resp.Results, total: resp.Total, counts: resp.Counts, warnings: resp.Warnings}
+		return searchResultsMsg{results: resp.Results, total: resp.Total, counts: resp.Counts, countsLowerBound: resp.CountsLowerBound, warnings: resp.Warnings}
 	}
 }
 
@@ -813,8 +818,14 @@ func (m searchModel) viewSearchMode() string {
 func (m searchModel) viewTypeTabs() string {
 	cmCount, ssCount := m.computeTypeCounts()
 
-	renderTab := func(label string, filter typeFilter, count int, keyHint string) string {
-		text := fmt.Sprintf("[%s] %s %d", keyHint, label, count)
+	renderTab := func(label string, filter typeFilter, count int, lowerBound bool, keyHint string) string {
+		suffix := ""
+		if lowerBound {
+			// The count is a lower bound — that facet's list was capped
+			// upstream. Same "+" the web renders (ENT-1777).
+			suffix = "+"
+		}
+		text := fmt.Sprintf("[%s] %s %d%s", keyHint, label, count, suffix)
 		if m.filterType == filter {
 			return m.styles.render(m.styles.tabActive, text)
 		}
@@ -826,10 +837,12 @@ func (m searchModel) viewTypeTabs() string {
 	// matches the web, which dropped its Checkpoints tab. Raw checkpoints stay
 	// reachable by ID via `entire checkpoint explain <id>` (folded session rows
 	// route there).
+	// Sessions ORs the checkpoints flag like the web: session rows fold in
+	// checkpoint hits, so a capped checkpoints list bounds sessions too.
 	tabs := []string{
-		renderTab("Commits", typeFilterCommits, cmCount, "1"),
-		renderTab("Sessions", typeFilterSessions, ssCount, "2"),
-		renderTab("Code", typeFilterCode, len(m.codeResults), "3"),
+		renderTab("Commits", typeFilterCommits, cmCount, m.countsLowerBound["commits"], "1"),
+		renderTab("Sessions", typeFilterSessions, ssCount, m.countsLowerBound["sessions"] || m.countsLowerBound["checkpoints"], "2"),
+		renderTab("Code", typeFilterCode, len(m.codeResults), false, "3"),
 	}
 
 	return strings.Join(tabs, "  ")
@@ -1810,8 +1823,14 @@ func snippetMarkdownStyles(dark bool) ansi.StyleConfig {
 // ─── Static Fallback ─────────────────────────────────────────────────────────
 
 // renderSearchStatic writes a non-interactive table for accessible mode.
-func renderSearchStatic(w io.Writer, results []search.Result, query string, total int, styles statusStyles) {
-	fmt.Fprintf(w, "Found %d results matching %q\n\n", total, query)
+func renderSearchStatic(w io.Writer, results []search.Result, query string, total int, lowerBound bool, styles statusStyles) {
+	// "+" marks a lower bound — some type's list was capped, so more matches
+	// exist than are counted (the web renders the same suffix; ENT-1777).
+	suffix := ""
+	if lowerBound {
+		suffix = "+"
+	}
+	fmt.Fprintf(w, "Found %d%s results matching %q\n\n", total, suffix, query)
 
 	cols := computeColumns(styles.width)
 

--- a/cmd/entire/cli/search_tui_test.go
+++ b/cmd/entire/cli/search_tui_test.go
@@ -934,7 +934,7 @@ func TestRenderSearchStatic(t *testing.T) {
 	var buf bytes.Buffer
 	styles := statusStyles{colorEnabled: false, width: 120}
 	results := testMultiTypeResults()
-	renderSearchStatic(&buf, results, "auth", len(results), styles)
+	renderSearchStatic(&buf, results, "auth", len(results), false, styles)
 	output := buf.String()
 
 	if !strings.Contains(output, `Found 4 results matching "auth"`) {

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -99,6 +99,7 @@ func (s *semanticSearchV4Session) search(ctx context.Context, cfg search.Config)
 	var cells []cellGroup
 	var skipped []string
 	var warnings []string
+	indexTruncated := false
 	scoped := !allRepos
 	if scoped {
 		if len(slugs) == 0 {
@@ -122,6 +123,7 @@ func (s *semanticSearchV4Session) search(ctx context.Context, cfg search.Config)
 			// commands whose context carries no logger.
 			logging.Debug(ctx, "semantic search: repo index truncated; cross-repo results may be incomplete")
 			warnings = append(warnings, "repo index truncated; cross-repo results may be incomplete")
+			indexTruncated = true
 		}
 		// Broad requests send no repo pins; query-serve narrows pin-less
 		// scope by the same election routedRepoPlacement picks by (ENT-1776),
@@ -132,9 +134,27 @@ func (s *semanticSearchV4Session) search(ctx context.Context, cfg search.Config)
 	if len(skipped) > 0 {
 		warnings = append(warnings, fmt.Sprintf("skipped %d repo(s) with no searchable placement (missing or not ready): %s", len(skipped), strings.Join(skipped, ", ")))
 	}
+	// The BFF's scope-loss channels (search.ts): a truncated repo index means
+	// broad coverage silently misses repos; an explicitly-filtered repo
+	// skipped as not-ready narrows the promised scope. Unfiltered skips stay
+	// silent — nothing advertised was narrowed.
+	scopeNarrowed := scoped && len(skipped) > 0
 
 	if len(cells) == 0 {
-		return &search.Response{Results: []search.Result{}, Page: 1, Warnings: warnings}, nil
+		resp := &search.Response{Results: []search.Result{}, Page: 1, Warnings: warnings, Counts: &search.TypeCounts{}}
+		if indexTruncated {
+			// Every facet count is a lower bound, not an exact zero — same
+			// contract as the BFF's zero-routable-cells answer.
+			resp.Truncated = true
+			resp.CountsLowerBound = map[string]bool{
+				"repos": true, "checkpoints": true, "commits": true, "prs": true, "sessions": true,
+			}
+		}
+		if indexTruncated || scopeNarrowed {
+			resp.Partial = true
+			resp.CoverageIncomplete = true
+		}
+		return resp, nil
 	}
 	resolveCellBaseURLs(ctx, s.clusterClient(coreClient), cells)
 
@@ -161,6 +181,13 @@ func (s *semanticSearchV4Session) search(ctx context.Context, cfg search.Config)
 		return nil, err
 	}
 	resp.Warnings = append(warnings, resp.Warnings...)
+	if indexTruncated {
+		resp.Truncated = true
+	}
+	if indexTruncated || scopeNarrowed {
+		resp.Partial = true
+		resp.CoverageIncomplete = true
+	}
 	return resp, nil
 }
 
@@ -308,12 +335,8 @@ func (c *cachedClusterClient) ListRepos(ctx context.Context, params coreapi.List
 	return c.inner.ListRepos(ctx, params) //nolint:wrapcheck // transparent delegation
 }
 
-// mergedTier2Max mirrors query-serve's maxTier2 and the BFF's MERGED_TIER2_MAX:
-// the ANN-only fallback tail is capped when it's all there is.
-const mergedTier2Max = 15
-
-// tierOf returns a result's tier, or -1 when unset (treated as the ANN-only
-// fallback tier).
+// tierOf returns a result's tier, or -1 when unset (dropped by the merge,
+// like every tier outside 0/1 — see rankSemanticResults).
 func tierOf(r search.Result) int {
 	if r.Meta.Tier == nil {
 		return -1
@@ -338,21 +361,9 @@ func rerankOf(r search.Result) float64 {
 	return 0
 }
 
-// annOrScoreOf prefers the raw ANN score, falling back to the overall score —
-// the ordering key query-serve/BFF use for the tier-2 ANN fallback (for
-// tier-2 rows Score is itself ANN-derived, so lower is better in both cases).
-func annOrScoreOf(r search.Result) float64 {
-	if r.Meta.ANNScore != nil {
-		return *r.Meta.ANNScore
-	}
-	return r.Meta.Score
-}
-
-// semanticCellPage is one cell's successful response plus the classification
-// bit the merge keys on.
+// semanticCellPage is one cell's successful response.
 type semanticCellPage struct {
-	body     *search.Response
-	hasUpper bool // any non-repo tier-0/1 row
+	body *search.Response
 }
 
 // classifySemanticCells splits per-cell outcomes into successful pages, hard
@@ -377,16 +388,7 @@ func classifySemanticCells(ctx context.Context, results []cellCallResult[*search
 			lastErr = r.err
 			failed = append(failed, r.group.label())
 		case r.value != nil:
-			p := semanticCellPage{body: r.value}
-			for _, res := range r.value.Results {
-				// Repo rows never count as an upper tier — they're always
-				// merged regardless of the cell's checkpoint/commit tiers.
-				if res.Type != search.TypeRepo && (tierOf(res) == 0 || tierOf(res) == 1) {
-					p.hasUpper = true
-					break
-				}
-			}
-			pages = append(pages, p)
+			pages = append(pages, semanticCellPage{body: r.value})
 		}
 	}
 	if len(skipped) > 0 {
@@ -429,24 +431,17 @@ type tier0Row struct {
 }
 
 // rankSemanticResults buckets every page's rows and applies the SAME ordering
-// the BFF's cross-cell merge uses (searcher.go / routes/search.ts): repos
-// first, then tier 0 and tier 1 EACH by rerank score desc (ENT-1425/ENT-1431),
-// then promoted tier-2 by ANN asc. Ordering by rerank score — not BM25 or the
-// per-namespace retrieval Score — is what keeps the CLI in parity with the web:
-// query-serve documents that Score "is not the field results are ordered by …
-// sorting by it undoes reranking." Tier-2 rows arriving alongside tier 0/1 from
-// the same cell were deliberately promoted by query-serve; a cell whose page is
-// entirely tier 2 had nothing better — its ANN fallback, shown (uncapped here)
-// only when tiers 0/1 are empty everywhere.
-func rankSemanticResults(pages []semanticCellPage) (merged []search.Result, globalUpper bool) {
-	for _, p := range pages {
-		if p.hasUpper {
-			globalUpper = true
-			break
-		}
-	}
-
-	var repos, tier1, promotedTier2, fallbackTier2 []search.Result
+// the BFF's cross-cell merge uses (see the ordering contract on
+// mergeSemanticV4Responses): repos first by retrieval score desc, then tier 0
+// (sortTier0Rows), then tier 1 by rerank desc with retrieval Score tiebreak.
+// Every other non-repo row — tier 2 (the retired ANN-only fallback, still
+// emitted by un-redeployed cells) and rows with no tier at all — is DROPPED,
+// exactly as the BFF drops them. Ordering by rerank score — not BM25 or the
+// per-namespace retrieval Score — is what keeps the CLI in parity with the
+// web: query-serve documents that Score "is not the field results are ordered
+// by … sorting by it undoes reranking."
+func rankSemanticResults(pages []semanticCellPage) (merged []search.Result) {
+	var repos, tier1 []search.Result
 	var tier0 []tier0Row
 	for _, p := range pages {
 		cellRank := 0
@@ -459,36 +454,25 @@ func rankSemanticResults(pages []semanticCellPage) (merged []search.Result, glob
 				cellRank++
 			case tierOf(r) == 1:
 				tier1 = append(tier1, r)
-			case p.hasUpper:
-				promotedTier2 = append(promotedTier2, r)
-			default:
-				fallbackTier2 = append(fallbackTier2, r)
 			}
 		}
 	}
 	sort.SliceStable(repos, func(i, j int) bool { return repos[i].Meta.Score > repos[j].Meta.Score })
 	merged = append(merged, repos...)
-	if globalUpper {
-		sortTier0Rows(tier0)
-		// Tier 1: rerank score decides, retrieval Score breaks ties. Rows whose
-		// cell fell back (no rerank score) sort last, matching the BFF.
-		sort.SliceStable(tier1, func(i, j int) bool {
-			if ri, rj := rerankOf(tier1[i]), rerankOf(tier1[j]); ri != rj {
-				return ri > rj
-			}
-			return tier1[i].Meta.Score > tier1[j].Meta.Score
-		})
-		sort.SliceStable(promotedTier2, func(i, j int) bool { return annOrScoreOf(promotedTier2[i]) < annOrScoreOf(promotedTier2[j]) })
-		for _, t := range tier0 {
-			merged = append(merged, t.r)
+	sortTier0Rows(tier0)
+	// Tier 1: rerank score decides, retrieval Score breaks ties. Rows whose
+	// cell fell back (no rerank score) sort last, matching the BFF.
+	sort.SliceStable(tier1, func(i, j int) bool {
+		if ri, rj := rerankOf(tier1[i]), rerankOf(tier1[j]); ri != rj {
+			return ri > rj
 		}
-		merged = append(merged, tier1...)
-		merged = append(merged, promotedTier2...)
-	} else {
-		sort.SliceStable(fallbackTier2, func(i, j int) bool { return annOrScoreOf(fallbackTier2[i]) < annOrScoreOf(fallbackTier2[j]) })
-		merged = append(merged, fallbackTier2...)
+		return tier1[i].Meta.Score > tier1[j].Meta.Score
+	})
+	for _, t := range tier0 {
+		merged = append(merged, t.r)
 	}
-	return merged, globalUpper
+	merged = append(merged, tier1...)
+	return merged
 }
 
 // sortTier0Rows orders the tier-0 band the way the BFF's sortTier0 does
@@ -524,18 +508,22 @@ func sortTier0Rows(tier0 []tier0Row) {
 	})
 }
 
-// dedupSemanticResults removes cross-cell duplicates by type+id, keeping the
-// first (higher-ranked) copy. The fan-out routes each repo to one home cell
-// (ENT-1672/ENT-1776), so per-repo rows no longer repeat — this guards the cases
-// that still can: a crosslinked session attached to repos in different cells,
-// and unfiltered queries where overlapping cell scopes return the same row.
-// Results without an id are always kept. The per-type dupe tally feeds the
-// total/count corrections.
-func dedupSemanticResults(merged []search.Result) ([]search.Result, map[string]int) {
-	seen := make(map[string]bool, len(merged))
-	dupesByType := make(map[string]int)
+// dedupSemanticResults removes cross-cell duplicate SESSION rows, keeping the
+// first (higher-ranked) copy — the BFF's exact rule: sessions are the one type
+// that legitimately repeats across cells (a crosslinked session attached to
+// repos homed in different cells), while repo-bound types are canonical to one
+// cell since the fan-out routes each repo to its single home placement
+// (ENT-1672/ENT-1776). The key is the global session id when present, else the
+// repo-qualified carrier checkpoint (server-folded legacy rows, ENT-1595);
+// rows with neither are always kept.
+func dedupSemanticResults(merged []search.Result) []search.Result {
+	seen := make(map[string]bool)
 	deduped := merged[:0]
 	for _, r := range merged {
+		if r.Type != search.TypeSession {
+			deduped = append(deduped, r)
+			continue
+		}
 		id := r.DedupID()
 		if id == "" {
 			deduped = append(deduped, r)
@@ -543,67 +531,114 @@ func dedupSemanticResults(merged []search.Result) ([]search.Result, map[string]i
 		}
 		key := r.Type + "\x00" + id
 		if seen[key] {
-			dupesByType[r.Type]++
 			continue
 		}
 		seen[key] = true
 		deduped = append(deduped, r)
 	}
-	return deduped, dupesByType
+	return deduped
 }
 
-// aggregateSemanticTotals sums per-cell totals and counts, minus dedup, and
-// excluding cells whose entire page was a discarded ANN fallback — their
-// matches are unreachable, so they must not be advertised.
-func aggregateSemanticTotals(pages []semanticCellPage, globalUpper bool, dupesByType map[string]int) (int, *search.TypeCounts) {
-	dupes := 0
-	for _, n := range dupesByType {
-		dupes += n
+// semanticFacetOf maps a wire result type to its counts/truncation facet name
+// (the BFF's RESULT_TYPE_TO_FACET). Unknown types have no facet: they are kept
+// in results, exempt from the per-type cap, and counted only in the total.
+func semanticFacetOf(typ string) (string, bool) {
+	switch typ {
+	case search.TypeRepo:
+		return "repos", true
+	case search.TypeCheckpoint:
+		return "checkpoints", true
+	case search.TypeCommit:
+		return "commits", true
+	case search.TypePR:
+		return "prs", true
+	case search.TypeSession:
+		return "sessions", true
 	}
-	total := -dupes
-	counts := &search.TypeCounts{}
-	for _, p := range pages {
-		if globalUpper && !p.hasUpper {
-			// This page's non-repo rows were its ANN fallback and were
-			// dropped by the merge — those matches are unreachable, so only
-			// its repo rows (which are always merged) may be counted.
-			repoRows := 0
-			if p.body.Counts != nil {
-				repoRows = p.body.Counts.Repos
-			} else {
-				for _, r := range p.body.Results {
-					if r.Type == search.TypeRepo {
-						repoRows++
-					}
-				}
-			}
-			total += repoRows
-			counts.Repos += repoRows
+	return "", false
+}
+
+// capSemanticPerType applies the BFF's per-type window: walk the merged list
+// in order and keep at most `limit` rows of each facet, recording which facets
+// overflowed. Rows without a facet mapping are kept uncounted.
+func capSemanticPerType(merged []search.Result, limit int) ([]search.Result, map[string]bool) {
+	truncated := make(map[string]bool)
+	if limit <= 0 {
+		return merged, truncated
+	}
+	perFacet := make(map[string]int, 5)
+	out := merged[:0]
+	for _, r := range merged {
+		facet, ok := semanticFacetOf(r.Type)
+		if !ok {
+			out = append(out, r)
 			continue
 		}
-		total += p.body.Total
-		if p.body.Counts != nil {
-			counts.Repos += p.body.Counts.Repos
-			counts.Checkpoints += p.body.Counts.Checkpoints
-			counts.Commits += p.body.Counts.Commits
-			counts.PRs += p.body.Counts.PRs
-			counts.Sessions += p.body.Counts.Sessions
+		perFacet[facet]++
+		if perFacet[facet] > limit {
+			truncated[facet] = true
+			continue
 		}
+		out = append(out, r)
 	}
-	subtractDupeCounts(counts, dupesByType)
-	return max(total, 0), counts
+	return out, truncated
 }
 
-// mergeSemanticV4Responses interleaves per-cell query-serve responses into one,
-// applying the SAME ordering query-serve uses within a cell (see
-// rankSemanticResults); when no cell produced tier 0/1 the ANN-only fallback
-// tail is shown (deduped, then capped). Results are deduped by type+id and
-// capped to limit. Rerank scores share a space across cells (same Cohere
-// model), so interleaving is meaningful.
+// deriveSemanticCounts computes total and per-type counts from the FINAL
+// merged list — the BFF's per-type contract (ENT-1363): counts describe
+// exactly what the caller can see, never the cells' corpus-count passes,
+// with counts_lower_bound marking the facets whose lists were capped.
+func deriveSemanticCounts(merged []search.Result) (int, *search.TypeCounts) {
+	counts := &search.TypeCounts{}
+	for _, r := range merged {
+		switch r.Type {
+		case search.TypeRepo:
+			counts.Repos++
+		case search.TypeCheckpoint:
+			counts.Checkpoints++
+		case search.TypeCommit:
+			counts.Commits++
+		case search.TypePR:
+			counts.PRs++
+		case search.TypeSession:
+			counts.Sessions++
+		}
+	}
+	return len(merged), counts
+}
+
+// mergeSemanticV4Responses interleaves per-cell query-serve responses into
+// one final page. THE CROSS-CELL MERGE ORDERING CONTRACT lives here and in
+// the BFF's mergeCellResponses (entire.io api/src/routes/search.ts) — the two
+// implementations must stay byte-identical (ENT-1777); change one, change
+// both, and update this block:
 //
-// Totals/counts include only cells whose results were actually mergeable (see
-// aggregateSemanticTotals). All-cells-failed is an error; a partial failure is
-// noted in Warnings and the surviving cells are merged.
+//  1. Band order: repo rows first (retrieval score desc), then tier 0, then
+//     tier 1. Tier 2 and tier-less non-repo rows are dropped — the ANN-only
+//     fallback tier is retired and only un-redeployed cells still emit it.
+//     Band order deliberately overrides each cell's own post-fold final
+//     order (entire-search#181 folds after ranking): the clients match each
+//     other, not the leaf.
+//  2. Tier 0: when every row carries a rerank score, rerank desc with BM25
+//     tiebreak; when any cell predates tier-0 reranking, positional
+//     interleave by in-cell rank with BM25 tiebreak (sortTier0Rows). Tier 1:
+//     rerank desc, retrieval Score tiebreak. All sorts are STABLE — equal
+//     keys keep cell-response order.
+//  3. Dedupe AFTER ordering, BEFORE the per-type cap, sessions only, first
+//     (highest-ranked) copy wins (dedupSemanticResults).
+//  4. Per-type window: at most `limit` rows of each facet, overflow recorded
+//     in truncated_types, unioned with the cells' own truncated_types
+//     (capSemanticPerType). No global cut.
+//  5. Counts and total derive from the FINAL list (deriveSemanticCounts);
+//     counts_lower_bound == the capped facets.
+//  6. Flags: truncated = any cell truncated; partial = truncated ∨ any cell
+//     failed ∨ any cell partial ∨ mixed rerank capability; coverage_incomplete
+//     = the same minus rerank-mix; reranked = every cell reranked (emitted
+//     when any cell reported the field).
+//
+// Rerank scores share a space across cells (same Cohere model), so
+// interleaving is meaningful. All-cells-failed is an error; a partial failure
+// is noted in Warnings (and the flags) and the surviving cells are merged.
 func mergeSemanticV4Responses(ctx context.Context, limit, page int, results []cellCallResult[*search.Response]) (*search.Response, error) {
 	pages, failed, lastErr := classifySemanticCells(ctx, results)
 	if len(pages) == 0 {
@@ -622,55 +657,67 @@ func mergeSemanticV4Responses(ctx context.Context, limit, page int, results []ce
 		warnings = append(warnings, fmt.Sprintf("search failed in %d of %d regions; results may be incomplete", len(failed), len(pages)+len(failed)))
 	}
 
-	merged, globalUpper := rankSemanticResults(pages)
-	merged, dupesByType := dedupSemanticResults(merged)
-
-	// Cap the ANN-only fallback tail AFTER dedup (repos always precede it),
-	// so cross-cell duplicates don't shrink the visible page below the cap.
-	if !globalUpper {
-		nRepos := 0
-		for _, r := range merged {
-			if r.Type != search.TypeRepo {
-				break
+	merged := rankSemanticResults(pages)
+	merged = dedupSemanticResults(merged)
+	merged, truncatedTypes := capSemanticPerType(merged, limit)
+	for _, p := range pages {
+		for facet, v := range p.body.TruncatedTypes {
+			if v {
+				truncatedTypes[facet] = true
 			}
-			nRepos++
 		}
-		if len(merged) > nRepos+mergedTier2Max {
-			merged = merged[:nRepos+mergedTier2Max]
-		}
-	}
-	if limit > 0 && len(merged) > limit {
-		merged = merged[:limit]
 	}
 	if merged == nil {
 		merged = []search.Result{}
 	}
 
-	total, counts := aggregateSemanticTotals(pages, globalUpper, dupesByType)
-	return &search.Response{
+	total, counts := deriveSemanticCounts(merged)
+	resp := &search.Response{
 		Results:  merged,
 		Total:    total,
 		Page:     max(page, 1),
 		Counts:   counts,
 		Warnings: warnings,
-	}, nil
-}
-
-// subtractDupeCounts removes deduplicated rows from the aggregate per-type
-// counts so `counts` reflects distinct results, matching the corrected total.
-func subtractDupeCounts(counts *search.TypeCounts, dupesByType map[string]int) {
-	for typ, n := range dupesByType {
-		switch typ {
-		case search.TypeCheckpoint:
-			counts.Checkpoints = max(0, counts.Checkpoints-n)
-		case search.TypeCommit:
-			counts.Commits = max(0, counts.Commits-n)
-		case search.TypeSession:
-			counts.Sessions = max(0, counts.Sessions-n)
-		case search.TypeRepo:
-			counts.Repos = max(0, counts.Repos-n)
-		case search.TypePR:
-			counts.PRs = max(0, counts.PRs-n)
+	}
+	if len(truncatedTypes) > 0 {
+		resp.TruncatedTypes = truncatedTypes
+		resp.CountsLowerBound = make(map[string]bool, len(truncatedTypes))
+		for facet := range truncatedTypes {
+			resp.CountsLowerBound[facet] = true
 		}
 	}
+
+	anyRerankedField, anyReranked, allReranked := false, false, true
+	for _, p := range pages {
+		if p.body.Truncated {
+			resp.Truncated = true
+		}
+		if p.body.Partial {
+			resp.Partial = true
+			resp.CoverageIncomplete = true
+		}
+		if p.body.Reranked != nil {
+			anyRerankedField = true
+			if *p.body.Reranked {
+				anyReranked = true
+			} else {
+				allReranked = false
+			}
+		} else {
+			allReranked = false
+		}
+	}
+	if len(failed) > 0 || resp.Truncated {
+		resp.Partial = true
+		resp.CoverageIncomplete = true
+	}
+	if anyReranked && !allReranked {
+		// Mixed rerank capability skews ordering but not coverage — partial
+		// without coverage_incomplete, matching the BFF.
+		resp.Partial = true
+	}
+	if anyRerankedField {
+		resp.Reranked = &allReranked
+	}
+	return resp, nil
 }

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -147,7 +147,7 @@ func (s *semanticSearchV4Session) search(ctx context.Context, cfg search.Config)
 			// contract as the BFF's zero-routable-cells answer.
 			resp.Truncated = true
 			resp.CountsLowerBound = map[string]bool{
-				"repos": true, "checkpoints": true, "commits": true, "prs": true, "sessions": true,
+				facetRepos: true, facetCheckpoints: true, facetCommits: true, facetPRs: true, facetSessions: true,
 			}
 		}
 		if indexTruncated || scopeNarrowed {
@@ -539,21 +539,31 @@ func dedupSemanticResults(merged []search.Result) []search.Result {
 	return deduped
 }
 
+// Facet names for the wire maps (truncated_types / counts_lower_bound) — the
+// BFF's RESULT_TYPE_TO_FACET values.
+const (
+	facetRepos       = "repos"
+	facetCheckpoints = "checkpoints"
+	facetCommits     = "commits"
+	facetPRs         = "prs"
+	facetSessions    = "sessions"
+)
+
 // semanticFacetOf maps a wire result type to its counts/truncation facet name
 // (the BFF's RESULT_TYPE_TO_FACET). Unknown types have no facet: they are kept
 // in results, exempt from the per-type cap, and counted only in the total.
 func semanticFacetOf(typ string) (string, bool) {
 	switch typ {
 	case search.TypeRepo:
-		return "repos", true
+		return facetRepos, true
 	case search.TypeCheckpoint:
-		return "checkpoints", true
+		return facetCheckpoints, true
 	case search.TypeCommit:
-		return "commits", true
+		return facetCommits, true
 	case search.TypePR:
-		return "prs", true
+		return facetPRs, true
 	case search.TypeSession:
-		return "sessions", true
+		return facetSessions, true
 	}
 	return "", false
 }

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -99,10 +99,10 @@ func v4Ckpt(id string, tier int, meta search.Meta) search.Result {
 	}
 }
 
-func v4Commit(sha string, tier int, meta search.Meta) search.Result {
-	if tier >= 0 {
-		meta.Tier = iptr(tier)
-	}
+// v4Commit builds a tier-1 commit result (every merge test uses tier 1 for
+// commits; tier variation is exercised via checkpoints).
+func v4Commit(sha string, meta search.Meta) search.Result {
+	meta.Tier = iptr(1)
 	return search.Result{
 		Type:   search.TypeCommit,
 		Meta:   meta,
@@ -338,8 +338,8 @@ func TestMergeSemanticV4Responses_PerTypeWindowAndLowerBounds(t *testing.T) {
 			v4RepoRow(t, "repo-1", 0.9),
 			v4Ckpt("ck-a", 1, search.Meta{Score: 0.9}),
 			v4Ckpt("ck-b", 1, search.Meta{Score: 0.8}),
-			v4Commit("sha-a", 1, search.Meta{Score: 0.7}),
-			v4Commit("sha-b", 1, search.Meta{Score: 0.6}),
+			v4Commit("sha-a", search.Meta{Score: 0.7}),
+			v4Commit("sha-b", search.Meta{Score: 0.6}),
 		}, Total: 5, Counts: &search.TypeCounts{Repos: 1, Checkpoints: 999, Commits: 999}}),
 	})
 	if err != nil {
@@ -455,7 +455,7 @@ func TestMergeSemanticV4Responses_DedupAdjustsTotalsAndCounts(t *testing.T) {
 	cellA := &search.Response{
 		Results: []search.Result{
 			v4Session("sess-dup", "backend", 0.9),
-			v4Commit("sha1", 1, search.Meta{Score: 0.6}),
+			v4Commit("sha1", search.Meta{Score: 0.6}),
 		},
 		Total:  2,
 		Counts: &search.TypeCounts{Sessions: 1, Commits: 1},
@@ -528,7 +528,7 @@ func TestMergeSemanticV4Responses_SameIDDifferentTypeNotDeduped(t *testing.T) {
 	resp, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
 		v4CellOK(&search.Response{Results: []search.Result{
 			v4Ckpt("x", 1, search.Meta{Score: 0.9}),
-			v4Commit("x", 1, search.Meta{Score: 0.8}),
+			v4Commit("x", search.Meta{Score: 0.8}),
 		}, Total: 2}),
 	})
 	if err != nil {
@@ -684,7 +684,7 @@ func TestMergeSemanticV4Responses_NilCountsBodiesTolerated(t *testing.T) {
 			v4Ckpt("a", 1, search.Meta{Score: 0.9}),
 		}, Total: 1}), // no Counts
 		v4CellOK(&search.Response{Results: []search.Result{
-			v4Commit("sha", 1, search.Meta{Score: 0.5}),
+			v4Commit("sha", search.Meta{Score: 0.5}),
 		}, Total: 1, Counts: &search.TypeCounts{Commits: 1}}),
 	})
 	if err != nil {

--- a/cmd/entire/cli/search_v4_test.go
+++ b/cmd/entire/cli/search_v4_test.go
@@ -14,57 +14,70 @@ import (
 
 // --- dedup ------------------------------------------------------------------
 
-// TestDedupSemanticResults_RepoScopedIDs exercises the deduper itself (not just
-// DedupID in isolation) over every id type that can repeat across repos:
-// server-folded legacy sessions (ENT-1595), raw checkpoints, and commits (the
-// same SHA lives in a fork and its upstream). On main these rows either had an
-// empty ResultID (legacy sessions, never deduped) or a bare repo-scoped/shared
-// id (checkpoints/commits, collapsed across repos). DedupID now repo-qualifies
-// all three, so the same four cases must hold for each.
-func TestDedupSemanticResults_RepoScopedIDs(t *testing.T) {
+// TestDedupSemanticResults_SessionsOnly exercises the deduper's web-parity
+// contract (ENT-1777): SESSION rows are the one type deduped across cells —
+// by global session id, else the repo-qualified carrier checkpoint
+// (server-folded legacy rows, ENT-1595) — while repo-bound types pass through
+// untouched, since the fan-out routes each repo to one home placement and
+// cross-cell duplicates of them are structurally impossible (ENT-1672/1776).
+func TestDedupSemanticResults_SessionsOnly(t *testing.T) {
 	t.Parallel()
 
-	for _, typ := range []string{search.TypeSession, search.TypeCheckpoint, search.TypeCommit} {
-		t.Run(typ, func(t *testing.T) {
-			t.Parallel()
+	// Distinct legacy sessions in the same repo must all survive.
+	if out := dedupSemanticResults([]search.Result{
+		v4RepoScopedRow(search.TypeSession, "id-a", "backend", 0.9),
+		v4RepoScopedRow(search.TypeSession, "id-b", "backend", 0.8),
+	}); len(out) != 2 {
+		t.Errorf("distinct ids collapsed: in=2 out=%d", len(out))
+	}
 
-			// Distinct ids in the same repo must all survive.
-			if out, _ := dedupSemanticResults([]search.Result{
-				v4RepoScopedRow(typ, "id-a", "backend", 0.9),
-				v4RepoScopedRow(typ, "id-b", "backend", 0.8),
-			}); len(out) != 2 {
-				t.Errorf("distinct ids collapsed: in=2 out=%d", len(out))
-			}
+	// The SAME legacy session from a repo mirrored across cells collapses,
+	// first (higher-ranked) copy winning.
+	out := dedupSemanticResults([]search.Result{
+		v4RepoScopedRow(search.TypeSession, "id-x", "backend", 0.9),
+		v4RepoScopedRow(search.TypeSession, "id-x", "backend", 0.8),
+	})
+	if len(out) != 1 {
+		t.Errorf("mirrored session not deduped: in=2 out=%d", len(out))
+	} else if out[0].Meta.Score != 0.9 {
+		t.Errorf("kept score = %v, want the first/higher-ranked 0.9", out[0].Meta.Score)
+	}
 
-			// The SAME row from a repo mirrored across cells collapses to one.
-			out, dupes := dedupSemanticResults([]search.Result{
-				v4RepoScopedRow(typ, "id-x", "backend", 0.9),
-				v4RepoScopedRow(typ, "id-x", "backend", 0.8),
-			})
-			if len(out) != 1 {
-				t.Errorf("mirrored row not deduped: in=2 out=%d", len(out))
-			}
-			if dupes[typ] != 1 {
-				t.Errorf("dupe tally = %v, want %s:1", dupes, typ)
-			}
+	// Repo casing skew across cells (git remote vs repo index) still dedupes.
+	if out := dedupSemanticResults([]search.Result{
+		v4RepoScopedRow(search.TypeSession, "id-x", "backend", 0.9),
+		v4RepoScopedRow(search.TypeSession, "id-x", "Backend", 0.8),
+	}); len(out) != 1 {
+		t.Errorf("casing skew leaked a duplicate: in=2 out=%d", len(out))
+	}
 
-			// Repo casing skew across cells (git remote vs repo index) still dedupes.
-			if out, _ := dedupSemanticResults([]search.Result{
-				v4RepoScopedRow(typ, "id-x", "backend", 0.9),
-				v4RepoScopedRow(typ, "id-x", "Backend", 0.8),
-			}); len(out) != 1 {
-				t.Errorf("casing skew leaked a duplicate: in=2 out=%d", len(out))
-			}
+	// The same carrier id in DIFFERENT repos is a distinct result.
+	if out := dedupSemanticResults([]search.Result{
+		v4RepoScopedRow(search.TypeSession, "id-dup", "backend", 0.9),
+		v4RepoScopedRow(search.TypeSession, "id-dup", "frontend", 0.8),
+	}); len(out) != 2 {
+		t.Errorf("cross-repo same carrier collapsed: in=2 out=%d", len(out))
+	}
 
-			// The same id in DIFFERENT repos (a fork/upstream, or two legacy repos)
-			// is a distinct result — it must NOT collapse.
-			if out, _ := dedupSemanticResults([]search.Result{
-				v4RepoScopedRow(typ, "id-dup", "backend", 0.9),
-				v4RepoScopedRow(typ, "id-dup", "frontend", 0.8),
-			}); len(out) != 2 {
-				t.Errorf("cross-repo same id collapsed: in=2 out=%d", len(out))
-			}
-		})
+	// A session with a global id dedupes ACROSS repos — that is the case the
+	// session-only rule exists for (a crosslinked session attached to repos
+	// homed in different cells).
+	if out := dedupSemanticResults([]search.Result{
+		v4Session("sess-1", "backend", 0.9),
+		v4Session("sess-1", "frontend", 0.8),
+	}); len(out) != 1 {
+		t.Errorf("crosslinked session not deduped: in=2 out=%d", len(out))
+	}
+
+	// Checkpoint and commit duplicates pass through untouched — the web does
+	// not dedupe repo-bound types.
+	for _, typ := range []string{search.TypeCheckpoint, search.TypeCommit} {
+		if out := dedupSemanticResults([]search.Result{
+			v4RepoScopedRow(typ, "id-x", "backend", 0.9),
+			v4RepoScopedRow(typ, "id-x", "backend", 0.8),
+		}); len(out) != 2 {
+			t.Errorf("%s rows deduped: in=2 out=%d, want pass-through", typ, len(out))
+		}
 	}
 }
 
@@ -114,6 +127,18 @@ func v4RepoScopedRow(typ, id, repo string, score float64) search.Result {
 	return r
 }
 
+// v4Session builds a session row with a GLOBAL session id (the primary dedup
+// key) in the given repo.
+func v4Session(sessionID, repo string, score float64) search.Result {
+	return search.Result{
+		Type: search.TypeSession,
+		Meta: search.Meta{Score: score, Tier: iptr(1)},
+		Session: &search.SessionResult{
+			SessionID: sessionID, Org: "acme", Repo: repo,
+		},
+	}
+}
+
 // v4RepoRow builds a repo-type result via the wire format, since repo rows
 // have no typed struct (payload lives in rawData).
 func v4RepoRow(t *testing.T, id string, score float64) search.Result {
@@ -151,9 +176,9 @@ func v4ResultIDs(t *testing.T, results []search.Result) []string {
 // --- merge: tier ordering ------------------------------------------------------
 
 // TestMergeSemanticV4Responses_TierOrdering verifies the cross-cell interleave
-// applies query-serve's own ordering: repos first, then tier 0 and tier 1 EACH
-// by rerank score desc (ENT-1425/ENT-1431), then promoted tier-2 by ANN asc —
-// regardless of which cell each result came from. The BM25/Score values are set
+// applies the shared ordering contract: repos first, then tier 0 and tier 1
+// EACH by rerank score desc (ENT-1425/ENT-1431), tier-2 dropped — regardless
+// of which cell each result came from. The BM25/Score values are set
 // to the OPPOSITE order from the rerank scores so the assertion fails if the
 // merge ever regresses to sorting by BM25 (tier 0) or Score (tier 1).
 func TestMergeSemanticV4Responses_TierOrdering(t *testing.T) {
@@ -181,13 +206,15 @@ func TestMergeSemanticV4Responses_TierOrdering(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"repo-1", "b-t0-rr-hi", "a-t0-rr-lo", "b-t1-rr-hi", "a-t1-rr-lo", "b-t2", "a-t2"}
+	// Tier-2 rows (a-t2, b-t2) are dropped — the retired ANN-only fallback
+	// never merges, matching the BFF.
+	want := []string{"repo-1", "b-t0-rr-hi", "a-t0-rr-lo", "b-t1-rr-hi", "a-t1-rr-lo"}
 	got := v4ResultIDs(t, resp.Results)
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Errorf("merged order = %v, want %v", got, want)
 	}
-	if resp.Total != 7 {
-		t.Errorf("total = %d, want 7", resp.Total)
+	if resp.Total != 5 {
+		t.Errorf("total = %d, want 5 (derived from the final list)", resp.Total)
 	}
 	if resp.Page != 1 {
 		t.Errorf("page = %d, want 1", resp.Page)
@@ -275,70 +302,75 @@ func TestMergeSemanticV4Responses_PagePassthrough(t *testing.T) {
 	}
 }
 
-// TestMergeSemanticV4Responses_ANNFallback verifies that when no cell produced
-// tier 0/1 results, the ANN-only tail is shown, ordered ANN asc and capped at
-// mergedTier2Max. Results without a tier field count as the fallback tier.
-func TestMergeSemanticV4Responses_ANNFallback(t *testing.T) {
+// TestMergeSemanticV4Responses_TierlessAndTier2Dropped verifies rows outside
+// tiers 0/1 — the retired ANN-only fallback (tier 2) and rows with no tier at
+// all — never merge, even when they are all a cell returned. The BFF drops
+// them identically (ENT-1777).
+func TestMergeSemanticV4Responses_TierlessAndTier2Dropped(t *testing.T) {
 	t.Parallel()
 
-	var results []search.Result
-	for i := range mergedTier2Max + 5 {
-		results = append(results, v4Ckpt(
-			"c-"+string(rune('a'+i)), -1,
-			search.Meta{ANNScore: fptr(float64(i) / 100)},
-		))
-	}
 	resp, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
-		v4CellOK(&search.Response{Results: results, Total: len(results)}),
+		v4CellOK(&search.Response{Results: []search.Result{
+			v4Ckpt("tierless", -1, search.Meta{ANNScore: fptr(0.01)}),
+			v4Ckpt("tier2", 2, search.Meta{ANNScore: fptr(0.02)}),
+		}, Total: 2}),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(resp.Results) != mergedTier2Max {
-		t.Errorf("fallback results = %d, want capped at %d", len(resp.Results), mergedTier2Max)
+	if len(resp.Results) != 0 {
+		t.Errorf("results = %v, want none (tier-2/tier-less rows dropped)", v4ResultIDs(t, resp.Results))
 	}
-	// ANN asc: the lowest scores survive the cap, in ascending order.
-	for i := 1; i < len(resp.Results); i++ {
-		if *resp.Results[i-1].Meta.ANNScore > *resp.Results[i].Meta.ANNScore {
-			t.Errorf("fallback not sorted ANN asc at %d", i)
-		}
+	if resp.Total != 0 {
+		t.Errorf("total = %d, want 0 (derived from the final list)", resp.Total)
 	}
 }
 
-// TestMergeSemanticV4Responses_FallbackCapAfterDedup guards the cap ordering:
-// cross-cell duplicates in the fallback tail must not shrink the visible page
-// below mergedTier2Max when enough unique results exist.
-func TestMergeSemanticV4Responses_FallbackCapAfterDedup(t *testing.T) {
+// TestMergeSemanticV4Responses_PerTypeWindowAndLowerBounds verifies the BFF's
+// per-type window: at most `limit` rows of each facet survive, overflowing
+// facets are flagged in truncated_types, and counts_lower_bound mirrors them —
+// counts describe what the caller can see, never the cells' corpus counts.
+func TestMergeSemanticV4Responses_PerTypeWindowAndLowerBounds(t *testing.T) {
 	t.Parallel()
 
-	// Two cells return the same 20 ANN-only checkpoints (mirrored repo).
-	mk := func() []search.Result {
-		var rs []search.Result
-		for i := range mergedTier2Max + 5 {
-			rs = append(rs, v4Ckpt(
-				"c-"+string(rune('a'+i)), -1,
-				search.Meta{ANNScore: fptr(float64(i) / 100)},
-			))
-		}
-		return rs
-	}
-	resp, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
-		v4CellOK(&search.Response{Results: mk(), Total: mergedTier2Max + 5}),
-		v4CellOK(&search.Response{Results: mk(), Total: mergedTier2Max + 5}),
+	resp, err := mergeSemanticV4Responses(context.Background(), 1, 0, []cellCallResult[*search.Response]{
+		v4CellOK(&search.Response{Results: []search.Result{
+			v4RepoRow(t, "repo-1", 0.9),
+			v4Ckpt("ck-a", 1, search.Meta{Score: 0.9}),
+			v4Ckpt("ck-b", 1, search.Meta{Score: 0.8}),
+			v4Commit("sha-a", 1, search.Meta{Score: 0.7}),
+			v4Commit("sha-b", 1, search.Meta{Score: 0.6}),
+		}, Total: 5, Counts: &search.TypeCounts{Repos: 1, Checkpoints: 999, Commits: 999}}),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(resp.Results) != mergedTier2Max {
-		t.Errorf("fallback results = %d, want the full cap %d despite duplicates (dedup must run before the cap)", len(resp.Results), mergedTier2Max)
+	got := v4ResultIDs(t, resp.Results)
+	want := []string{"repo-1", "ck-a", "sha-a"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("results = %v, want %v (one per facet at limit 1)", got, want)
+	}
+	if resp.Total != 3 {
+		t.Errorf("total = %d, want 3 — derived from the final list, never the cells' corpus counts", resp.Total)
+	}
+	if resp.Counts.Checkpoints != 1 || resp.Counts.Commits != 1 || resp.Counts.Repos != 1 {
+		t.Errorf("counts = %+v, want 1/1/1 derived", resp.Counts)
+	}
+	for _, facet := range []string{"checkpoints", "commits", "repos"} {
+		wantFlag := facet != "repos"
+		if resp.TruncatedTypes[facet] != wantFlag {
+			t.Errorf("truncated_types[%s] = %v, want %v", facet, resp.TruncatedTypes[facet], wantFlag)
+		}
+		if resp.CountsLowerBound[facet] != wantFlag {
+			t.Errorf("counts_lower_bound[%s] = %v, want %v", facet, resp.CountsLowerBound[facet], wantFlag)
+		}
 	}
 }
 
 // TestMergeSemanticV4Responses_FallbackDroppedWhenUpperTiersExist documents
-// that a cell whose page is entirely tier-2 (its ANN fallback) contributes
-// nothing when another cell produced tier 0/1 — matching how query-serve only
-// shows the fallback tail when there is nothing better. Its Total must be
-// excluded too: those matches are unreachable, so they must not be advertised.
+// that a cell whose page is entirely tier-2 contributes nothing — tier-2 is
+// dropped unconditionally — and its corpus Total is never advertised: totals
+// and counts derive from the final merged list alone (ENT-1777).
 func TestMergeSemanticV4Responses_FallbackDroppedWhenUpperTiersExist(t *testing.T) {
 	t.Parallel()
 
@@ -413,26 +445,27 @@ func TestMergeSemanticV4Responses_RepoOnlyPageCountsJustRepos(t *testing.T) {
 
 // --- merge: dedup ---------------------------------------------------------------
 
-// TestMergeSemanticV4Responses_DedupAdjustsTotalsAndCounts verifies a result
-// mirrored across cells is kept once (first/higher-ranked wins) and that both
-// the total and the per-type counts are reduced accordingly.
+// TestMergeSemanticV4Responses_DedupAdjustsTotalsAndCounts verifies a session
+// mirrored across cells (a crosslinked session, the one legitimate cross-cell
+// duplicate) is kept once — first/higher-ranked copy wins — and that totals
+// and counts, derived from the final list, reflect the deduped set.
 func TestMergeSemanticV4Responses_DedupAdjustsTotalsAndCounts(t *testing.T) {
 	t.Parallel()
 
 	cellA := &search.Response{
 		Results: []search.Result{
-			v4Ckpt("dup", 1, search.Meta{Score: 0.9}),
+			v4Session("sess-dup", "backend", 0.9),
 			v4Commit("sha1", 1, search.Meta{Score: 0.6}),
 		},
 		Total:  2,
-		Counts: &search.TypeCounts{Checkpoints: 1, Commits: 1},
+		Counts: &search.TypeCounts{Sessions: 1, Commits: 1},
 	}
 	cellB := &search.Response{
 		Results: []search.Result{
-			v4Ckpt("dup", 1, search.Meta{Score: 0.4}),
+			v4Session("sess-dup", "frontend", 0.4),
 		},
 		Total:  1,
-		Counts: &search.TypeCounts{Checkpoints: 1},
+		Counts: &search.TypeCounts{Sessions: 1},
 	}
 
 	resp, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
@@ -441,37 +474,38 @@ func TestMergeSemanticV4Responses_DedupAdjustsTotalsAndCounts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got := v4ResultIDs(t, resp.Results)
-	want := []string{"dup", "sha1"}
-	if strings.Join(got, ",") != strings.Join(want, ",") {
-		t.Errorf("results = %v, want %v", got, want)
+	if len(resp.Results) != 2 {
+		t.Fatalf("results = %v, want 2 (session deduped)", v4ResultIDs(t, resp.Results))
 	}
-	// The kept "dup" is cell A's higher-ranked copy.
-	if resp.Results[0].Meta.Score != 0.9 {
-		t.Errorf("kept dup score = %v, want the first/higher-ranked 0.9", resp.Results[0].Meta.Score)
+	// The kept copy is cell A's higher-ranked one.
+	kept := resp.Results[0]
+	if kept.Type != search.TypeSession || kept.Meta.Score != 0.9 {
+		t.Errorf("kept session = %+v, want the first/higher-ranked 0.9 copy", kept.Meta)
 	}
 	if resp.Total != 2 {
-		t.Errorf("total = %d, want 2 (3 rows - 1 dupe)", resp.Total)
+		t.Errorf("total = %d, want 2 (3 rows - 1 session dupe, derived)", resp.Total)
 	}
-	if resp.Counts.Checkpoints != 1 || resp.Counts.Commits != 1 {
-		t.Errorf("counts = %+v, want checkpoints=1 commits=1", resp.Counts)
+	if resp.Counts.Sessions != 1 || resp.Counts.Commits != 1 {
+		t.Errorf("counts = %+v, want sessions=1 commits=1", resp.Counts)
 	}
 }
 
-// TestMergeSemanticV4Responses_RepoRowsDedupAcrossCells verifies the mirrored-
-// repo case the fan-out exists for: both cells return the same logical repo
-// row, which must appear once (repo rows carry their id in the raw payload).
-func TestMergeSemanticV4Responses_RepoRowsDedupAcrossCells(t *testing.T) {
+// TestMergeSemanticV4Responses_RepoRowsNotDeduped documents the web-parity
+// dedupe scope (ENT-1777): only sessions dedupe. Repo rows — like every other
+// repo-bound type — pass through untouched, because the fan-out routes each
+// repo to its single home placement (ENT-1672/ENT-1776), so a genuine
+// cross-cell duplicate is structurally impossible; a fabricated one here
+// stays visible rather than being silently collapsed.
+func TestMergeSemanticV4Responses_RepoRowsNotDeduped(t *testing.T) {
 	t.Parallel()
 
 	mk := func(score float64) *search.Response {
 		return &search.Response{
 			Results: []search.Result{
 				v4RepoRow(t, "repo-dup", score),
-				v4Ckpt("ck-"+jsonFloat(score), 1, search.Meta{Score: score}),
 			},
-			Total:  2,
-			Counts: &search.TypeCounts{Repos: 1, Checkpoints: 1},
+			Total:  1,
+			Counts: &search.TypeCounts{Repos: 1},
 		}
 	}
 	resp, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
@@ -480,20 +514,9 @@ func TestMergeSemanticV4Responses_RepoRowsDedupAcrossCells(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repoRows := 0
-	for _, r := range resp.Results {
-		if r.Type == search.TypeRepo {
-			repoRows++
-		}
-	}
-	if repoRows != 1 {
-		t.Errorf("repo rows = %d, want 1 (mirrored repo deduped across cells)", repoRows)
-	}
-	if resp.Counts.Repos != 1 {
-		t.Errorf("counts.Repos = %d, want 1 after dedup", resp.Counts.Repos)
-	}
-	if resp.Total != 3 {
-		t.Errorf("total = %d, want 3 (4 rows - 1 repo dupe)", resp.Total)
+	if len(resp.Results) != 2 || resp.Counts.Repos != 2 || resp.Total != 2 {
+		t.Errorf("results=%d counts.Repos=%d total=%d, want 2/2/2 (no repo dedupe)",
+			len(resp.Results), resp.Counts.Repos, resp.Total)
 	}
 }
 
@@ -535,6 +558,9 @@ func TestMergeSemanticV4Responses_PartialFailureMergesSurvivorsWithWarning(t *te
 	}
 	if len(resp.Warnings) != 1 || !strings.Contains(resp.Warnings[0], "1 of 2 regions") {
 		t.Errorf("warnings = %v, want a visible partial-failure warning naming 1 of 2 regions", resp.Warnings)
+	}
+	if !resp.Partial || !resp.CoverageIncomplete {
+		t.Errorf("partial=%v coverage_incomplete=%v, want both true on a cell failure", resp.Partial, resp.CoverageIncomplete)
 	}
 }
 
@@ -642,8 +668,11 @@ func TestMergeSemanticV4Responses_LimitCapsResults(t *testing.T) {
 	if len(resp.Results) != 2 {
 		t.Errorf("results = %d, want capped at limit 2", len(resp.Results))
 	}
-	if resp.Total != 3 {
-		t.Errorf("total = %d, want 3 (limit caps the page, not the total)", resp.Total)
+	if resp.Total != 2 {
+		t.Errorf("total = %d, want 2 — totals derive from the final list; the cap is reported via counts_lower_bound instead", resp.Total)
+	}
+	if !resp.CountsLowerBound["checkpoints"] || !resp.TruncatedTypes["checkpoints"] {
+		t.Errorf("lower-bound flags = %v/%v, want checkpoints flagged", resp.CountsLowerBound, resp.TruncatedTypes)
 	}
 }
 
@@ -661,8 +690,60 @@ func TestMergeSemanticV4Responses_NilCountsBodiesTolerated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.Counts == nil || resp.Counts.Commits != 1 || resp.Counts.Checkpoints != 0 {
-		t.Errorf("counts = %+v, want commits=1 from the one counted body", resp.Counts)
+	if resp.Counts == nil || resp.Counts.Commits != 1 || resp.Counts.Checkpoints != 1 {
+		t.Errorf("counts = %+v, want commits=1 checkpoints=1 derived from the merged list", resp.Counts)
+	}
+}
+
+// TestMergeSemanticV4Responses_FlagSynthesis mirrors the BFF's flag rules:
+// truncated = any cell truncated; partial adds cell failures, cell-reported
+// partial, and mixed rerank capability; coverage_incomplete excludes only the
+// rerank-mix case; reranked = every cell reranked; the cells' own
+// truncated_types union into the merged map.
+func TestMergeSemanticV4Responses_FlagSynthesis(t *testing.T) {
+	t.Parallel()
+
+	tr, fa := true, false
+	resp, err := mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
+		v4CellOK(&search.Response{
+			Results:        []search.Result{v4Ckpt("a", 1, search.Meta{Score: 0.9, RerankScore: fptr(0.5)})},
+			Total:          1,
+			Truncated:      true,
+			TruncatedTypes: map[string]bool{"sessions": true},
+			Reranked:       &tr,
+		}),
+		v4CellOK(&search.Response{
+			Results:  []search.Result{v4Ckpt("b", 1, search.Meta{Score: 0.8})},
+			Total:    1,
+			Reranked: &fa,
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Truncated {
+		t.Error("truncated: want true when any cell truncated")
+	}
+	if !resp.Partial || !resp.CoverageIncomplete {
+		t.Errorf("partial=%v coverage=%v, want both (truncation implies both)", resp.Partial, resp.CoverageIncomplete)
+	}
+	if resp.Reranked == nil || *resp.Reranked {
+		t.Errorf("reranked = %v, want false (not every cell reranked)", resp.Reranked)
+	}
+	if !resp.TruncatedTypes["sessions"] {
+		t.Errorf("truncated_types = %v, want the cell's sessions flag unioned in", resp.TruncatedTypes)
+	}
+
+	// Mixed rerank capability alone: partial without coverage_incomplete.
+	resp, err = mergeSemanticV4Responses(context.Background(), 0, 0, []cellCallResult[*search.Response]{
+		v4CellOK(&search.Response{Results: []search.Result{v4Ckpt("a", 1, search.Meta{Score: 0.9})}, Total: 1, Reranked: &tr}),
+		v4CellOK(&search.Response{Results: []search.Result{v4Ckpt("b", 1, search.Meta{Score: 0.8})}, Total: 1, Reranked: &fa}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Partial || resp.CoverageIncomplete {
+		t.Errorf("partial=%v coverage=%v, want partial-only for a rerank mix", resp.Partial, resp.CoverageIncomplete)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1117
<!-- entire-trail-link-end -->

## Why

The per-cell search responses are identical for web and CLI — only the client-side merges diverged. With routing parity complete (ENT-1672/ENT-1776), these were the remaining measured divergences: the CLI cut the merged list globally at 100 while the web windows per type; showed summed corpus counts up to 13× larger than the web's; deduped all types where the web dedupes sessions only; and silently dropped every completeness flag.

Linear: [ENT-1777](https://linear.app/entirehq/issue/ENT-1777)

## What (each maps to a ticket item; the web's semantics win everywhere)

- **Limit = per-type window** (item 2): at most `limit` rows per facet survive the merge; overflow reports via `truncated_types` + `counts_lower_bound`. The global cut is gone.
- **Counts derived from the final list** (item 3): totals and per-type counts describe exactly what the caller can see (ENT-1363's rationale); `aggregateSemanticTotals` and dupe-subtraction deleted.
- **Flags parsed, synthesized, and rendered** (item 4): `partial` / `truncated` / `coverage_incomplete` / `truncated_types` / `counts_lower_bound` / `reranked` now flow end to end — '+' suffixes on lower-bound counts in the static table and TUI tabs (sessions ORs the checkpoints flag, as the web does), and all fields pass through `--json`/`--compact` envelopes.
- **Dedupe = sessions only** (item 5): global session id first, repo-qualified carrier checkpoint for server-folded legacy rows, first-ranked copy wins. Repo-bound types pass through — the fan-out routes each repo to one home placement, so their cross-cell duplicates are structurally impossible.
- **Ordering contract documented once** (item 6): the full cross-cell merge contract lives on `mergeSemanticV4Responses`, explicitly paired with the BFF's `mergeCellResponses` — including the band-order note (clients match each other, not the leaf's post-fold order).
- Also aligned: tier-2/tier-less rows drop unconditionally (the retired ANN fallback machinery — `mergedTier2Max`, `hasUpper` — is deleted), and the BFF's scope-loss channels (truncated index → all-facet lower bounds on the zero-cell answer; filtered not-ready skip → `partial`+`coverage_incomplete`; unfiltered skips silent).

## Behavior changes users can see

CLI counts shrink to match the web (window-derived, with '+' when lower-bounded); the ANN-only fallback tail no longer renders when nothing better exists (matching the web, which never showed it); incomplete results are now labeled instead of silent.

## Validation

Full `cmd/entire/cli` + `search` packages green (197s). Merge suite rewritten to the shared contract: per-type window + lower bounds, sessions-only dedupe (incl. crosslinked-session collapse and repo-row pass-through), derived counts, tier-2 drop, flag synthesis incl. the partial-without-coverage rerank-mix case. `gofmt`/`go vet` clean.

## Follow-up

Parity acceptance (the 20/20 paired query matrix) needs the harness rebuilt — the original lived in a since-deleted workspace's .context. Release note: parity only reaches users once a CLI release ships this (0.10.2 predates it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ranking, totals, and completeness signals for semantic search, so CLI results and JSON envelopes can differ from prior releases. Not auth or data-write, but merge logic is user-visible and must stay in lockstep with the BFF.
> 
> **Overview**
> Brings the CLI's cross-cell semantic merge in line with the BFF (`mergeCellResponses`) so web and CLI share the same ranking, counts, and completeness signals (ENT-1777).
> 
> **Limit is now a per-type window**, not a global cut: at most `limit` rows per facet survive, overflow is recorded in `truncated_types` / `counts_lower_bound`, and totals/counts are derived from the final list instead of summed cell corpus counts.
> 
> **Dedupe is sessions only** (global session id, else repo-qualified carrier checkpoint). Repo-bound types pass through. **Tier 2 and tier-less rows are dropped** (retired ANN fallback); `mergedTier2Max` / `hasUpper` are gone.
> 
> Completeness flags (`partial`, `truncated`, `coverage_incomplete`, `reranked`) are parsed from cells, re-synthesized on merge (including truncated-index / skipped-scope cases), passed through `--json`/`--compact`, and shown as **`+` lower-bound suffixes** on TUI tabs and the accessible static header. The full merge contract is documented on `mergeSemanticV4Responses`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5325bf0daa696677e8c224ac06e3ef95fce25fa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->