### PR TITLE
feat(doctor): aggregate hook traces, and correct the trace help text

### DIFF
--- a/cmd/entire/cli/trace.go
+++ b/cmd/entire/cli/trace.go
@@ -36,8 +36,11 @@ type traceEntry struct {
 	// Slow marks a root span that exceeded the slow threshold and was therefore
 	// logged at WARN rather than DEBUG (see perf.DefaultSlowSpanThreshold), which
 	// is what makes these visible in a default-level session at all.
-	Slow  bool        `json:"slow,omitempty"`
-	Time  time.Time   `json:"time"`
+	Slow bool `json:"slow,omitempty"`
+	// Time is omitted when zero rather than serialized as year 1: the parser
+	// tolerates a missing or malformed time key, and a JSON consumer should see
+	// the absence rather than a timestamp that was never recorded.
+	Time  time.Time   `json:"time,omitzero"`
 	Steps []traceStep `json:"steps,omitempty"`
 }
 
@@ -212,8 +215,14 @@ func traceStepChildIndex(parentName, childName string) (int, bool) {
 
 // collectTraceEntries reads a JSONL log file and returns the last N trace entries,
 // ordered newest first. If hookFilter is non-empty, only entries with a matching
-// Op field are included.
-func collectTraceEntries(logFile string, last int, hookFilter string) ([]traceEntry, error) {
+// Op field are included; if slowOnly is set, only entries flagged slow are.
+//
+// Both filters are applied before the last-N truncation, so "the last N" always
+// means the last N entries the caller asked to see. Filtering after truncation
+// instead would make --slow return the slow entries among the last N traces
+// rather than the last N slow traces — which reads as "no traces" whenever
+// DEBUG logging fills the window with fast ones.
+func collectTraceEntries(logFile string, last int, hookFilter string, slowOnly bool) ([]traceEntry, error) {
 	f, err := os.Open(logFile) //nolint:gosec // logFile is a CLI-resolved path, not user-supplied input
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -233,6 +242,9 @@ func collectTraceEntries(logFile string, last int, hookFilter string) ([]traceEn
 			continue
 		}
 		if hookFilter != "" && entry.Op != hookFilter {
+			continue
+		}
+		if slowOnly && !entry.Slow {
 			continue
 		}
 		entries = append(entries, *entry)
@@ -477,13 +489,20 @@ func summarizeTraces(entries []traceEntry) traceSummary {
 
 // percentileMs returns the p-th percentile of a sorted slice using nearest-rank,
 // so p50 of one sample is that sample rather than an interpolation.
+//
+// The rank is ceil(p/100 * n), converted to a 0-based index. Truncating instead
+// of rounding up overshoots by one whole sample whenever p*n divides evenly,
+// which is exactly the round-numbered case: p90 of 10 samples would report the
+// maximum, making the P90 and MAX columns duplicates of each other.
 func percentileMs(sorted []int64, p int) int64 {
 	if len(sorted) == 0 {
 		return 0
 	}
-	idx := (p * len(sorted)) / 100
-	if idx >= len(sorted) {
-		idx = len(sorted) - 1
+	n := len(sorted)
+	rank := (p*n + 99) / 100 // ceil(p*n/100)
+	idx := max(rank-1, 0)
+	if idx >= n {
+		idx = n - 1
 	}
 	return sorted[idx]
 }
@@ -509,17 +528,23 @@ func renderTraceSummary(w io.Writer, summary traceSummary) {
 
 	fmt.Fprintf(w, "%d trace(s), %d slow\n\n", summary.Total, summary.Slow)
 
-	fmt.Fprintf(w, "  %-22s %6s %6s %9s %9s %9s  %s\n", "HOOK", "N", "SLOW", "P50", "P90", "MAX", "DOMINANT STEP")
+	// Durations are rendered into strings and padded as strings so the header and
+	// the rows share one width. Padding the number and appending "ms" instead
+	// makes each column two characters wider than its header, which stays
+	// invisible until a five-digit duration shows up.
+	ms := func(v int64) string { return strconv.FormatInt(v, 10) + "ms" }
+
+	fmt.Fprintf(w, "  %-22s %6s %10s %10s %10s %10s  %s\n", "HOOK", "N", "SLOW", "P50", "P90", "MAX", "DOMINANT STEP")
 	for _, op := range summary.Ops {
-		fmt.Fprintf(w, "  %-22s %6d %6d %8dms %8dms %8dms  %s\n",
-			op.Op, op.Count, op.Slow, op.P50Ms, op.P90Ms, op.MaxMs, op.Dominant)
+		fmt.Fprintf(w, "  %-22s %6d %10d %10s %10s %10s  %s\n",
+			op.Op, op.Count, op.Slow, ms(op.P50Ms), ms(op.P90Ms), ms(op.MaxMs), op.Dominant)
 	}
 
 	if len(summary.StepCounts) > 0 {
 		fmt.Fprintln(w)
 		fmt.Fprintf(w, "  %-42s %6s %11s\n", "DOMINANT STEP", "N", "TOTAL")
 		for _, sc := range summary.StepCounts {
-			fmt.Fprintf(w, "  %-42s %6d %9dms\n", sc.Step, sc.Count, sc.TotalMs)
+			fmt.Fprintf(w, "  %-42s %6d %11s\n", sc.Step, sc.Count, ms(sc.TotalMs))
 		}
 	}
 }

--- a/cmd/entire/cli/trace.go
+++ b/cmd/entire/cli/trace.go
@@ -22,19 +22,23 @@ import (
 // Nested spans are represented as SubSteps. Loop iterations keep their numeric
 // suffixes in the step name, e.g. "process_sessions.0".
 type traceStep struct {
-	Name       string
-	DurationMs int64
-	Error      bool
-	SubSteps   []traceStep
+	Name       string      `json:"name"`
+	DurationMs int64       `json:"duration_ms"`
+	Error      bool        `json:"error,omitempty"`
+	SubSteps   []traceStep `json:"sub_steps,omitempty"`
 }
 
 // traceEntry represents a parsed performance trace log entry.
 type traceEntry struct {
-	Op         string
-	DurationMs int64
-	Error      bool
-	Time       time.Time
-	Steps      []traceStep
+	Op         string `json:"op"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      bool   `json:"error,omitempty"`
+	// Slow marks a root span that exceeded the slow threshold and was therefore
+	// logged at WARN rather than DEBUG (see perf.DefaultSlowSpanThreshold), which
+	// is what makes these visible in a default-level session at all.
+	Slow  bool        `json:"slow,omitempty"`
+	Time  time.Time   `json:"time"`
+	Steps []traceStep `json:"steps,omitempty"`
 }
 
 // parseTraceEntry parses a JSON log line into a traceEntry.
@@ -72,6 +76,9 @@ func parseTraceEntry(line string) *traceEntry {
 	}
 	if errRaw, ok := raw["error"]; ok {
 		_ = json.Unmarshal(errRaw, &entry.Error) //nolint:errcheck // best-effort
+	}
+	if slowRaw, ok := raw["slow"]; ok {
+		_ = json.Unmarshal(slowRaw, &entry.Slow) //nolint:errcheck // best-effort
 	}
 
 	// Extract time
@@ -248,14 +255,20 @@ func collectTraceEntries(logFile string, last int, hookFilter string) ([]traceEn
 
 // renderTraceEntries writes a formatted table of trace entries to w.
 // If entries is empty, it prints a help message about enabling traces.
+// renderNoTraces explains how traces get emitted. Shared by the per-entry and
+// summary renderers so there is one description of the rules, not two that drift.
+func renderNoTraces(w io.Writer) {
+	fmt.Fprintln(w, "No trace entries found.")
+	fmt.Fprintf(w, "By default, hooks taking %s or longer are traced at WARN; set %s=0\n",
+		perf.DefaultSlowSpanThreshold, perf.SlowSpanEnvVar)
+	fmt.Fprintln(w, `to turn that off, and note that a log_level above WARN hides them too.`)
+	fmt.Fprintln(w, `To trace every hook, set ENTIRE_LOG_LEVEL=DEBUG in your shell profile,`)
+	fmt.Fprintln(w, `or log_level to "DEBUG" in .entire/settings.json.`)
+}
+
 func renderTraceEntries(w io.Writer, entries []traceEntry) {
 	if len(entries) == 0 {
-		fmt.Fprintln(w, "No trace entries found.")
-		fmt.Fprintf(w, "By default, hooks taking %s or longer are traced at WARN; set %s=0\n",
-			perf.DefaultSlowSpanThreshold, perf.SlowSpanEnvVar)
-		fmt.Fprintln(w, `to turn that off, and note that a log_level above WARN hides them too.`)
-		fmt.Fprintln(w, `To trace every hook, set ENTIRE_LOG_LEVEL=DEBUG in your shell profile,`)
-		fmt.Fprintln(w, `or log_level to "DEBUG" in .entire/settings.json.`)
+		renderNoTraces(w)
 		return
 	}
 
@@ -328,4 +341,185 @@ func renderTraceTableRow(w io.Writer, nameWidth int, label, duration string, has
 		line += "  x"
 	}
 	fmt.Fprintln(w, line)
+}
+
+// dominantStep returns the name of the longest step anywhere in the entry's tree,
+// nested steps included. That is the question a slow hook actually raises — which
+// piece of work owned the time — and nesting means the top-level step is often a
+// wrapper rather than the culprit.
+func dominantStepMs(entry traceEntry) (string, int64, bool) {
+	var best string
+	var bestMs int64 = -1
+	var walk func(steps []traceStep)
+	walk = func(steps []traceStep) {
+		for _, s := range steps {
+			if s.DurationMs > bestMs {
+				best, bestMs = s.Name, s.DurationMs
+			}
+			walk(s.SubSteps)
+		}
+	}
+	walk(entry.Steps)
+	if bestMs < 0 {
+		return "", 0, false
+	}
+	return best, bestMs, true
+}
+
+// renderTraceJSON writes entries as a JSON array, newest first.
+func renderTraceJSON(w io.Writer, entries []traceEntry) error {
+	if entries == nil {
+		entries = []traceEntry{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(entries); err != nil {
+		return fmt.Errorf("encoding trace entries: %w", err)
+	}
+	return nil
+}
+
+// traceOpSummary aggregates the traces recorded for one hook.
+type traceOpSummary struct {
+	Op       string `json:"op"`
+	Count    int    `json:"count"`
+	Slow     int    `json:"slow"`
+	P50Ms    int64  `json:"p50_ms"`
+	P90Ms    int64  `json:"p90_ms"`
+	MaxMs    int64  `json:"max_ms"`
+	Dominant string `json:"dominant_step,omitempty"`
+}
+
+// traceSummary is the aggregate view across many traces.
+type traceSummary struct {
+	Total      int              `json:"total"`
+	Slow       int              `json:"slow"`
+	Ops        []traceOpSummary `json:"ops"`
+	StepCounts []traceStepCount `json:"dominant_steps"`
+}
+
+// traceStepCount is how often a step was the dominant one, and how much time it
+// accounted for while dominant. Total time is the stronger signal — one 4s
+// offender matters more than three 200ms ones — so output sorts on it.
+type traceStepCount struct {
+	Step    string `json:"step"`
+	Count   int    `json:"count"`
+	TotalMs int64  `json:"total_ms"`
+}
+
+// summarizeTraces aggregates entries per hook and counts which step dominated.
+// Individual traces answer "why was this invocation slow"; this answers "what is
+// slow in general", which is the question worth asking once slow traces are
+// plentiful.
+func summarizeTraces(entries []traceEntry) traceSummary {
+	byOp := map[string][]traceEntry{}
+	stepCounts := map[string]int{}
+	stepTotals := map[string]int64{}
+	summary := traceSummary{Total: len(entries)}
+
+	for _, e := range entries {
+		byOp[e.Op] = append(byOp[e.Op], e)
+		if e.Slow {
+			summary.Slow++
+		}
+		if step, ms, ok := dominantStepMs(e); ok {
+			stepCounts[step]++
+			stepTotals[step] += ms
+		}
+	}
+
+	for op, group := range byOp {
+		durations := make([]int64, 0, len(group))
+		slow := 0
+		perOpSteps := map[string]int64{}
+		for _, e := range group {
+			durations = append(durations, e.DurationMs)
+			if e.Slow {
+				slow++
+			}
+			if step, ms, ok := dominantStepMs(e); ok {
+				perOpSteps[step] += ms
+			}
+		}
+		slices.Sort(durations)
+		summary.Ops = append(summary.Ops, traceOpSummary{
+			Op:       op,
+			Count:    len(group),
+			Slow:     slow,
+			P50Ms:    percentileMs(durations, 50),
+			P90Ms:    percentileMs(durations, 90),
+			MaxMs:    durations[len(durations)-1],
+			Dominant: heaviestStep(perOpSteps),
+		})
+	}
+	// Busiest hook first; name breaks ties so output is stable.
+	slices.SortFunc(summary.Ops, func(a, b traceOpSummary) int {
+		if a.Count != b.Count {
+			return cmp.Compare(b.Count, a.Count)
+		}
+		return cmp.Compare(a.Op, b.Op)
+	})
+
+	for step, n := range stepCounts {
+		summary.StepCounts = append(summary.StepCounts, traceStepCount{
+			Step: step, Count: n, TotalMs: stepTotals[step],
+		})
+	}
+	slices.SortFunc(summary.StepCounts, func(a, b traceStepCount) int {
+		if a.TotalMs != b.TotalMs {
+			return cmp.Compare(b.TotalMs, a.TotalMs)
+		}
+		return cmp.Compare(a.Step, b.Step)
+	})
+
+	return summary
+}
+
+// percentileMs returns the p-th percentile of a sorted slice using nearest-rank,
+// so p50 of one sample is that sample rather than an interpolation.
+func percentileMs(sorted []int64, p int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := (p * len(sorted)) / 100
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+// heaviestStep returns the step accounting for the most time, breaking ties by
+// name so the result does not depend on map iteration order.
+func heaviestStep(totals map[string]int64) string {
+	best, bestMs := "", int64(-1)
+	for k, ms := range totals {
+		if ms > bestMs || (ms == bestMs && k < best) {
+			best, bestMs = k, ms
+		}
+	}
+	return best
+}
+
+// renderTraceSummary writes the aggregate view as a table.
+func renderTraceSummary(w io.Writer, summary traceSummary) {
+	if summary.Total == 0 {
+		renderNoTraces(w)
+		return
+	}
+
+	fmt.Fprintf(w, "%d trace(s), %d slow\n\n", summary.Total, summary.Slow)
+
+	fmt.Fprintf(w, "  %-22s %6s %6s %9s %9s %9s  %s\n", "HOOK", "N", "SLOW", "P50", "P90", "MAX", "DOMINANT STEP")
+	for _, op := range summary.Ops {
+		fmt.Fprintf(w, "  %-22s %6d %6d %8dms %8dms %8dms  %s\n",
+			op.Op, op.Count, op.Slow, op.P50Ms, op.P90Ms, op.MaxMs, op.Dominant)
+	}
+
+	if len(summary.StepCounts) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "  %-42s %6s %11s\n", "DOMINANT STEP", "N", "TOTAL")
+		for _, sc := range summary.StepCounts {
+			fmt.Fprintf(w, "  %-42s %6d %9dms\n", sc.Step, sc.Count, sc.TotalMs)
+		}
+	}
 }

--- a/cmd/entire/cli/trace_cmd.go
+++ b/cmd/entire/cli/trace_cmd.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/perf"
 	"github.com/spf13/cobra"
 )
 
@@ -25,11 +26,14 @@ func newTraceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "trace",
 		Short: "Show hook performance traces",
-		Long: `Show timing information for recent hook invocations.
+		// The threshold and env var come from perf rather than being written out
+		// here: this help text already went stale once by describing the old
+		// DEBUG-only behaviour, and a hardcoded copy is what let that happen.
+		Long: fmt.Sprintf(`Show timing information for recent hook invocations.
 
-Hooks that take 1.5s or longer are traced by default, at WARN level, so a slow
+Hooks that take %s or longer are traced by default, at WARN level, so a slow
 hook records its own breakdown without any configuration. Set
-ENTIRE_PERF_SLOW_MS=0 to turn that off; a log_level above WARN also hides them.
+%s=0 to turn that off; a log_level above WARN also hides them.
 
 To trace every hook, including fast ones, raise verbosity instead:
   - Set ENTIRE_LOG_LEVEL=DEBUG in your shell profile
@@ -42,6 +46,7 @@ Examples:
   entire doctor trace --summary           Aggregate: which step dominates, per hook
   entire doctor trace --summary --slow    Aggregate only the slow traces
   entire doctor trace --last 20 --json    Machine-readable output`,
+			perf.DefaultSlowSpanThreshold, perf.SlowSpanEnvVar),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if last < 1 {
 				return fmt.Errorf("--last must be at least 1, got %d", last)
@@ -62,19 +67,9 @@ Examples:
 
 			logFile := filepath.Join(repoRoot, logging.LogsDir, "entire.log")
 
-			entries, err := collectTraceEntries(logFile, last, hookFilter)
+			entries, err := collectTraceEntries(logFile, last, hookFilter, slowOnly)
 			if err != nil {
 				return fmt.Errorf("collecting trace entries: %w", err)
-			}
-
-			if slowOnly {
-				kept := make([]traceEntry, 0, len(entries))
-				for _, e := range entries {
-					if e.Slow {
-						kept = append(kept, e)
-					}
-				}
-				entries = kept
 			}
 
 			switch {

--- a/cmd/entire/cli/trace_cmd.go
+++ b/cmd/entire/cli/trace_cmd.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -9,26 +10,47 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// summaryDefaultLast is the window --summary uses when --last was not given.
+// Aggregating over the default of 1 trace would be useless, and asking every
+// caller to remember a second flag is worse than picking a sensible window.
+const summaryDefaultLast = 200
+
 func newTraceCmd() *cobra.Command {
 	var last int
 	var hookFilter string
+	var jsonOut bool
+	var summary bool
+	var slowOnly bool
 
 	cmd := &cobra.Command{
 		Use:   "trace",
 		Short: "Show hook performance traces",
 		Long: `Show timing information for recent hook invocations.
 
-Traces are emitted at DEBUG log level. To enable them, either:
+Hooks that take 1.5s or longer are traced by default, at WARN level, so a slow
+hook records its own breakdown without any configuration. Set
+ENTIRE_PERF_SLOW_MS=0 to turn that off; a log_level above WARN also hides them.
+
+To trace every hook, including fast ones, raise verbosity instead:
   - Set ENTIRE_LOG_LEVEL=DEBUG in your shell profile
   - Add "log_level": "DEBUG" to .entire/settings.json
 
 Examples:
   entire doctor trace                     Show the most recent hook trace
   entire doctor trace --last 5            Show the last 5 hook traces
-  entire doctor trace --hook post-commit  Show only post-commit hook traces`,
+  entire doctor trace --hook post-commit  Show only post-commit hook traces
+  entire doctor trace --summary           Aggregate: which step dominates, per hook
+  entire doctor trace --summary --slow    Aggregate only the slow traces
+  entire doctor trace --last 20 --json    Machine-readable output`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if last < 1 {
 				return fmt.Errorf("--last must be at least 1, got %d", last)
+			}
+			if jsonOut && summary {
+				return errors.New("--json and --summary are mutually exclusive")
+			}
+			if summary && !cmd.Flags().Changed("last") {
+				last = summaryDefaultLast
 			}
 
 			repoRoot, err := paths.WorktreeRoot(cmd.Context())
@@ -45,13 +67,34 @@ Examples:
 				return fmt.Errorf("collecting trace entries: %w", err)
 			}
 
-			renderTraceEntries(cmd.OutOrStdout(), entries)
+			if slowOnly {
+				kept := make([]traceEntry, 0, len(entries))
+				for _, e := range entries {
+					if e.Slow {
+						kept = append(kept, e)
+					}
+				}
+				entries = kept
+			}
+
+			switch {
+			case jsonOut:
+				return renderTraceJSON(cmd.OutOrStdout(), entries)
+			case summary:
+				renderTraceSummary(cmd.OutOrStdout(), summarizeTraces(entries))
+			default:
+				renderTraceEntries(cmd.OutOrStdout(), entries)
+			}
 			return nil
 		},
 	}
 
 	cmd.Flags().IntVar(&last, "last", 1, "Show last N hook invocations")
 	cmd.Flags().StringVar(&hookFilter, "hook", "", "Filter by hook type (e.g. post-commit, prepare-commit-msg, pre-push)")
+	cmd.Flags().BoolVar(&summary, "summary", false,
+		fmt.Sprintf("Aggregate across traces instead of showing each one (uses --last %d unless given)", summaryDefaultLast))
+	cmd.Flags().BoolVar(&slowOnly, "slow", false, "Only include traces flagged slow (those logged at WARN)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 
 	return cmd
 }

--- a/cmd/entire/cli/trace_summary_test.go
+++ b/cmd/entire/cli/trace_summary_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -151,4 +153,75 @@ func TestParseTraceEntry_ReadsSlowMarker(t *testing.T) {
 	e = parseTraceEntry(`{"msg":"perf","op":"stop","duration_ms":42,"steps.a_ms":10}`)
 	require.NotNil(t, e)
 	require.False(t, e.Slow, "absent slow key means not slow")
+}
+
+// TestCollectTraceEntries_SlowFilterAppliesBeforeTruncation pins the ordering of
+// the two filters. Filtering slow entries after the last-N cut returns "the slow
+// traces among the last N", which under DEBUG logging is usually none — so
+// --slow would report no traces while hundreds sat in the log.
+func TestCollectTraceEntries_SlowFilterAppliesBeforeTruncation(t *testing.T) {
+	t.Parallel()
+
+	// Two slow traces, then three fast ones on top of them.
+	lines := []string{
+		`{"time":"2026-01-15T10:00:00Z","level":"WARN","msg":"perf","op":"stop","duration_ms":4000,"slow":true}`,
+		`{"time":"2026-01-15T10:01:00Z","level":"WARN","msg":"perf","op":"stop","duration_ms":5000,"slow":true}`,
+		`{"time":"2026-01-15T10:02:00Z","level":"DEBUG","msg":"perf","op":"stop","duration_ms":10}`,
+		`{"time":"2026-01-15T10:03:00Z","level":"DEBUG","msg":"perf","op":"stop","duration_ms":11}`,
+		`{"time":"2026-01-15T10:04:00Z","level":"DEBUG","msg":"perf","op":"stop","duration_ms":12}`,
+	}
+	logFile := filepath.Join(t.TempDir(), "trace.jsonl")
+	require.NoError(t, os.WriteFile(logFile, []byte(strings.Join(lines, "\n")+"\n"), 0o600))
+
+	// --last 2 --slow must mean "the last 2 slow traces", not "the slow ones
+	// among the last 2 traces" (which would be empty, since both are fast).
+	entries, err := collectTraceEntries(logFile, 2, "", true)
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "slow entries must survive the last-N window")
+	require.Equal(t, int64(5000), entries[0].DurationMs, "newest slow trace first")
+	require.Equal(t, int64(4000), entries[1].DurationMs)
+
+	// Without --slow the same window is the three most recent, all fast.
+	all, err := collectTraceEntries(logFile, 3, "", false)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	for _, e := range all {
+		require.False(t, e.Slow)
+	}
+}
+
+// TestPercentileMs_NearestRank guards the round-numbered cases, where truncating
+// the rank overshoots by a full sample and makes P90 a duplicate of MAX.
+func TestPercentileMs_NearestRank(t *testing.T) {
+	t.Parallel()
+
+	ten := []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+
+	require.Equal(t, int64(9), percentileMs(ten, 90), "p90 of 10 samples is the 9th, not the max")
+	require.Equal(t, int64(5), percentileMs(ten, 50), "p50 of 10 samples is the 5th")
+	require.Equal(t, int64(10), percentileMs(ten, 100))
+	require.Equal(t, int64(1), percentileMs(ten, 1), "a percentile below one rank still lands on the first sample")
+
+	require.Equal(t, int64(7), percentileMs([]int64{7}, 50), "p50 of one sample is that sample")
+	require.Equal(t, int64(7), percentileMs([]int64{7}, 90))
+	require.Equal(t, int64(1), percentileMs([]int64{1, 2}, 50), "p50 of an even count takes the lower median")
+	require.Equal(t, int64(0), percentileMs(nil, 50))
+}
+
+// TestRenderTraceJSON_OmitsUnsetTime keeps the JSON honest: the parser tolerates
+// a missing time key, and a consumer should see its absence rather than a
+// year-1 timestamp that was never recorded.
+func TestRenderTraceJSON_OmitsUnsetTime(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	require.NoError(t, renderTraceJSON(&buf, []traceEntry{{Op: "stop", DurationMs: 12}}))
+
+	require.NotContains(t, buf.String(), "0001-01-01")
+
+	var decoded []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	require.Len(t, decoded, 1)
+	_, hasTime := decoded[0]["time"]
+	require.False(t, hasTime, "an unrecorded time must be absent, not zero")
 }

--- a/cmd/entire/cli/trace_summary_test.go
+++ b/cmd/entire/cli/trace_summary_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func slowEntry(op string, dur int64, steps ...traceStep) traceEntry {
+	return traceEntry{Op: op, DurationMs: dur, Slow: true, Steps: steps}
+}
+
+func step(name string, ms int64, subs ...traceStep) traceStep {
+	return traceStep{Name: name, DurationMs: ms, SubSteps: subs}
+}
+
+// TestSummarizeTraces_DominanceIsTimeWeighted is the property that makes the
+// summary trustworthy. A frequency count ties a 3900ms offender with a 150ms one
+// and then resolves alphabetically, which names the wrong step on the row whose
+// max is 4200ms.
+func TestSummarizeTraces_DominanceIsTimeWeighted(t *testing.T) {
+	t.Parallel()
+
+	entries := []traceEntry{
+		slowEntry("stop", 4200, step("write_temporary_checkpoint", 3900), step("detect_file_changes", 120)),
+		{Op: "stop", DurationMs: 320, Steps: []traceStep{step("write_temporary_checkpoint", 90), step("detect_file_changes", 150)}},
+	}
+
+	s := summarizeTraces(entries)
+	require.Len(t, s.Ops, 1)
+	require.Equal(t, "write_temporary_checkpoint", s.Ops[0].Dominant,
+		"per-hook dominance must follow time, not how many traces name a step")
+	require.Equal(t, 2, s.Ops[0].Count)
+	require.Equal(t, 1, s.Ops[0].Slow)
+	require.Equal(t, int64(4200), s.Ops[0].MaxMs)
+
+	// The global table ranks by total time, so the heaviest step leads. TotalMs
+	// counts time accrued *while dominant*, which is what keeps it coherent with
+	// Count (= number of traces where the step was the culprit): the fast trace's
+	// 90ms is attributed to detect_file_changes, which dominated there.
+	require.Equal(t, "write_temporary_checkpoint", s.StepCounts[0].Step)
+	require.Equal(t, int64(3900), s.StepCounts[0].TotalMs)
+	byStep := map[string]traceStepCount{}
+	for _, sc := range s.StepCounts {
+		byStep[sc.Step] = sc
+	}
+	require.Equal(t, int64(150), byStep["detect_file_changes"].TotalMs,
+		"the fast trace's dominant step carries that trace's time")
+}
+
+// TestSummarizeTraces_DominanceLooksInsideNestedSteps guards the tree walk: the
+// top-level step is often a wrapper, so the culprit can be a child.
+func TestSummarizeTraces_DominanceLooksInsideNestedSteps(t *testing.T) {
+	t.Parallel()
+
+	entries := []traceEntry{
+		slowEntry("post-commit", 5000,
+			step("process_sessions", 4800,
+				step("process_sessions.0", 200),
+				step("process_sessions.1", 4500),
+			),
+		),
+	}
+	s := summarizeTraces(entries)
+	require.Equal(t, "process_sessions", s.Ops[0].Dominant,
+		"the parent owns 4800ms, more than any single child")
+
+	nested := []traceEntry{
+		slowEntry("stop", 5000, step("wrapper", 100), step("outer", 900, step("inner", 850))),
+	}
+	require.Equal(t, "outer", summarizeTraces(nested).Ops[0].Dominant)
+}
+
+// TestSummarizeTraces_StableOrderAcrossRuns pins tie-breaking so output does not
+// depend on Go's map iteration order.
+func TestSummarizeTraces_StableOrderAcrossRuns(t *testing.T) {
+	t.Parallel()
+
+	entries := []traceEntry{
+		slowEntry("aaa", 100, step("s_b", 50)),
+		slowEntry("bbb", 100, step("s_a", 50)),
+	}
+	first := summarizeTraces(entries)
+	for range 12 {
+		got := summarizeTraces(entries)
+		require.Equal(t, first, got, "equal counts and totals must break ties deterministically")
+	}
+	require.Equal(t, "aaa", first.Ops[0].Op, "equal counts tie-break by hook name")
+	require.Equal(t, "s_a", first.StepCounts[0].Step, "equal totals tie-break by step name")
+}
+
+// TestSummarizeTraces_EmptyAndStepless covers shapes that must not panic.
+func TestSummarizeTraces_EmptyAndStepless(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 0, summarizeTraces(nil).Total)
+
+	s := summarizeTraces([]traceEntry{{Op: "stop", DurationMs: 10}})
+	require.Equal(t, 1, s.Total)
+	require.Empty(t, s.StepCounts, "an entry with no steps contributes no dominant step")
+	require.Empty(t, s.Ops[0].Dominant)
+}
+
+// TestRenderTraceSummary_EmptyExplainsHowTracesAreEmitted keeps the empty state
+// useful rather than silent, and shares its wording with the per-entry renderer.
+func TestRenderTraceSummary_EmptyExplainsHowTracesAreEmitted(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	renderTraceSummary(&b, summarizeTraces(nil))
+	out := b.String()
+	require.Contains(t, out, "No trace entries found.")
+	require.Contains(t, out, "traced at WARN")
+	require.Contains(t, out, "ENTIRE_LOG_LEVEL=DEBUG")
+}
+
+// TestRenderTraceJSON_IsValidAndCarriesSlow pins the machine-readable contract
+// agents rely on.
+func TestRenderTraceJSON_IsValidAndCarriesSlow(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	require.NoError(t, renderTraceJSON(&b, []traceEntry{
+		slowEntry("stop", 4200, step("write_temporary_checkpoint", 3900)),
+	}))
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(b.Bytes(), &got))
+	require.Len(t, got, 1)
+	require.Equal(t, "stop", got[0]["op"])
+	require.Equal(t, true, got[0]["slow"])
+	require.InDelta(t, 4200, got[0]["duration_ms"], 0)
+
+	// Empty input must still be a JSON array, not "null" — callers pipe this to jq.
+	var empty bytes.Buffer
+	require.NoError(t, renderTraceJSON(&empty, nil))
+	require.Equal(t, "[]", strings.TrimSpace(empty.String()))
+}
+
+// TestParseTraceEntry_ReadsSlowMarker ties the parser to what #1984 writes.
+func TestParseTraceEntry_ReadsSlowMarker(t *testing.T) {
+	t.Parallel()
+
+	e := parseTraceEntry(`{"msg":"perf","op":"stop","duration_ms":4200,"slow":true,"steps.a_ms":10}`)
+	require.NotNil(t, e)
+	require.True(t, e.Slow)
+
+	e = parseTraceEntry(`{"msg":"perf","op":"stop","duration_ms":42,"steps.a_ms":10}`)
+	require.NotNil(t, e)
+	require.False(t, e.Slow, "absent slow key means not slow")
+}

--- a/cmd/entire/cli/trace_test.go
+++ b/cmd/entire/cli/trace_test.go
@@ -117,7 +117,7 @@ func TestCollectTraceEntries(t *testing.T) {
 		t.Parallel()
 		logFile := writeFixture(t)
 
-		entries, err := collectTraceEntries(logFile, 2, "")
+		entries, err := collectTraceEntries(logFile, 2, "", false)
 		if err != nil {
 			t.Fatalf("collectTraceEntries returned error: %v", err)
 		}
@@ -145,7 +145,7 @@ func TestCollectTraceEntries(t *testing.T) {
 		t.Parallel()
 		logFile := writeFixture(t)
 
-		entries, err := collectTraceEntries(logFile, 10, testOpPostCommit)
+		entries, err := collectTraceEntries(logFile, 10, testOpPostCommit, false)
 		if err != nil {
 			t.Fatalf("collectTraceEntries returned error: %v", err)
 		}
@@ -161,7 +161,7 @@ func TestCollectTraceEntries(t *testing.T) {
 	t.Run("file not found returns empty", func(t *testing.T) {
 		t.Parallel()
 
-		entries, err := collectTraceEntries("/nonexistent/path/trace.jsonl", 10, "")
+		entries, err := collectTraceEntries("/nonexistent/path/trace.jsonl", 10, "", false)
 		if err != nil {
 			t.Fatalf("expected nil error for missing file, got %v", err)
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1118
<!-- entire-trail-link-end -->

Follow-up to #2091. Two problems, both created by #1984 making slow traces plentiful.

## The help text went stale

`doctor trace --help` still said:

> Traces are emitted at DEBUG log level. To enable them, either: …

Slow hooks have traced at **WARN by default** since #1984, so this advertised configuration for something the reader already had. #1984 updated the empty-state message and missed the command's `Long`. Now corrected, and the empty state is a shared renderer so there is one description of the rules rather than two that drift — which is how the stale copy survived.

## `doctor trace` couldn't answer the useful question

It could only show the last N traces individually. With slow traces now accumulating on their own, the question is not *"why was this one slow"* but *"what is slow in general"* — which meant hand-rolling a grep/python one-liner over `.entire/logs` (as #2091 currently has to).

```
$ entire doctor trace --summary --slow

93 trace(s), 93 slow

  HOOK             N   SLOW      P50      P90      MAX  DOMINANT STEP
  pre-push        38     38   4001ms   6820ms   9002ms  push_checkpoint_refs
  stop            32     32   2554ms   3966ms   4471ms  write_temporary_checkpoint
  post-commit     27     27   1970ms   2600ms   3255ms  process_sessions

  DOMINANT STEP                       N       TOTAL
  push_checkpoint_refs               36    144036ms
  process_sessions                   27     53190ms
  write_temporary_checkpoint         24     33960ms
```

New flags:

- `--summary` — aggregate instead of per-trace tables. Defaults to a 200-trace window when `--last` isn't given, since aggregating the default of 1 is useless.
- `--slow` — restrict to traces flagged slow (the WARN-level ones).
- `--json` — this repo's convention for structured output (`status`, `agent-help`, `sessions`, `search` all have it), and an agent shouldn't have to parse a table. Mutually exclusive with `--summary` rather than silently preferring one.

## One design note worth reviewing

**Dominance is weighted by time, not by how many traces name a step.** My first cut counted frequency, which ties a 3900ms offender with a 150ms one and then resolves alphabetically — so the row reporting `MAX 4200ms` named the *fast* trace's culprit. I caught that running it over real logs, and it's now pinned by a test.

It also walks nested steps, because the top-level step is often a wrapper (`process_sessions`) rather than the work.

`TotalMs` counts time accrued **while that step was dominant**, which is what keeps it coherent with `N` (= traces where the step was the culprit). Summing all time for a step regardless of dominance would put two different populations in one row.

## Testing

7 new tests covering the time-weighting property, nested-step dominance, deterministic tie-breaking across 12 runs (Go map order), empty/stepless shapes, the JSON contract (including `[]` not `null` for empty, since callers pipe to `jq`), and that the parser reads `#1984`'s `slow` marker.

`mise run fmt && lint` clean (0 issues), `mise run test:ci` green (56 unit + 4 canary). Exercised against real logs in two repos plus a synthetic mixed-level log to verify `--slow` actually filters (real logs are all-WARN, so they can't prove it).

Once this lands, #2091's one-liner can be replaced with `entire doctor trace --summary --slow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI diagnostics only: reads existing logs and prints tables/JSON. No auth, data mutation, or hook-runtime changes.
> 
> **Overview**
> `entire doctor trace` can now answer “what is slow in general,” not just dump the last N traces.
> 
> Adds `--summary` (p50/p90/max per hook plus time-weighted dominant steps, default window 200), `--slow` to keep only WARN-flagged traces, and `--json` for structured output (`--json` and `--summary` are mutually exclusive). The parser now reads the `slow` marker, and help/empty-state copy is unified so it no longer claims traces are DEBUG-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b35da67573c28998c664c5afda56a5772f65b4e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->