### PR TITLE
refactor(logging): close the logger in one place

### DIFF
--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -2855,9 +2855,9 @@ func TestNewRefreshTrailEnablementCmd_APIFailureExitsZero(t *testing.T) {
 // network) and that failure has to be logged to the repo's log file.
 //
 // Executed through the real root command, because the root PersistentPreRunE is
-// what opens the log file (and its PersistentPostRun is what flushes it) — the
-// same path the detached child takes through main.go. Constructing the
-// subcommand alone would exercise a wiring production never uses.
+// what opens the log file — the same path the detached child takes through
+// main.go. Constructing the subcommand alone would exercise a wiring production
+// never uses.
 func TestRefreshTrailEnablementCmd_LogsBackgroundFailureToFile(t *testing.T) {
 	setupStopTestRepo(t)
 	markRepoSetUpForLogging(t)

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/experimental"
 	"github.com/entireio/cli/cmd/entire/cli/investigate"
-	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	cliReview "github.com/entireio/cli/cmd/entire/cli/review"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -101,12 +100,6 @@ func NewRootCmd() *cobra.Command {
 			ensureLogger(cmd)
 		},
 		PersistentPostRun: func(cmd *cobra.Command, _ []string) {
-			// Deferred so it runs after the telemetry and version-check calls
-			// below, which log, and so the hidden-command early return still
-			// flushes. main.go closes again for the paths cobra skips this hook
-			// on; Close is idempotent and nil-safe.
-			defer func() { _ = logging.LoggerFromContext(cmd.Context()).Close() }()
-
 			// Skip for hidden commands (walk parent chain — Cobra doesn't propagate Hidden)
 			for c := cmd; c != nil; c = c.Parent() {
 				if c.Hidden {

--- a/cmd/entire/cli/root_logging_test.go
+++ b/cmd/entire/cli/root_logging_test.go
@@ -30,7 +30,8 @@ func markRepoSetUpForLogging(t *testing.T) {
 }
 
 // executeThroughRoot runs args through a real root command — the only way to
-// exercise the pre-run that builds the logger and the post-run that flushes it.
+// exercise the pre-run that builds the logger — then closes it the way main.go
+// does so buffered lines reach the file.
 func executeThroughRoot(t *testing.T, args ...string) error {
 	t.Helper()
 
@@ -38,7 +39,12 @@ func executeThroughRoot(t *testing.T, args ...string) error {
 	root.SetOut(&bytes.Buffer{})
 	root.SetErr(&bytes.Buffer{})
 	root.SetArgs(args)
-	return root.ExecuteContext(context.Background())
+
+	executed, err := root.ExecuteContextC(context.Background())
+	if closeErr := logging.LoggerFromContext(executed.Context()).Close(); closeErr != nil {
+		t.Fatalf("Close(): %v", closeErr)
+	}
+	return err
 }
 
 // setUpRepoForRootLogging makes cwd a set-up git repo. setupStopTestRepo also
@@ -54,8 +60,8 @@ func setUpRepoForRootLogging(t *testing.T) string {
 }
 
 // runProbeUnder attaches a probe under the given command path, runs it through
-// the real root, and reports the logger its RunE saw — writing probeMarker while
-// the file is still open, since the post-run closes on the way out.
+// the real root, and reports the logger its RunE saw, closing it the way main.go
+// does so buffered lines reach the file.
 //
 // Hidden so the post-run's Hidden walk short-circuits before its telemetry and
 // version-check calls, which would otherwise hit the network mid-test.
@@ -92,6 +98,9 @@ func runProbeUnder(t *testing.T, parents ...string) *logging.Logger {
 	root.SetArgs(append(append([]string{}, parents...), probe.Use))
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute %v %s: %v", parents, probe.Use, err)
+	}
+	if err := observed.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
 	}
 	return observed
 }
@@ -147,9 +156,8 @@ func TestInitRootLogging_SkipsRepoThatNeverEnabledEntire(t *testing.T) {
 
 // Pins the flush main.go depends on: cobra returns out of execute() as soon as
 // RunE errors or required-flag validation fails, both before its post-run loop,
-// so root's flush never runs and the command ExecuteContextC hands back is the
-// only route to the buffered lines. (Errors raised before any pre-run carry no
-// logger, so there is nothing to lose.)
+// so the command ExecuteContextC hands back is the only route to the buffered
+// lines.
 func TestExecutedCommandCarriesLoggerOnFailure(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -212,8 +220,7 @@ func TestExecutedCommandCarriesLoggerOnFailure(t *testing.T) {
 
 			logFile := filepath.Join(dir, paths.EntireDir, "logs", "entire.log")
 
-			// Exactly what main.go does after ExecuteContextC. Nothing else can
-			// have flushed: cobra skips its PostRun loop on both these paths.
+			// Exactly what main.go does after ExecuteContextC.
 			if closeErr := logging.LoggerFromContext(executed.Context()).Close(); closeErr != nil {
 				t.Fatalf("Close() error = %v", closeErr)
 			}

--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -96,6 +96,12 @@ func main() {
 	}
 
 	executed, err := rootCmd.ExecuteContextC(ctx)
+	// The only place the logger is closed, and it must be here: cobra returns out
+	// of Command.execute() as soon as RunE errors or required-flag validation
+	// fails, both before its PersistentPostRun loop, so those paths would
+	// otherwise exit with up to 8KB of buffered diagnostics unwritten. The logger
+	// rides the executed command's context, where the root pre-run put it; a
+	// failure raised before any pre-run carries none, and nothing logged yet.
 	if l := logging.LoggerFromContext(executed.Context()); l != nil {
 		_ = l.Close()
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1119
<!-- entire-trail-link-end -->

The logger was closed in two places: a deferred close at the top of the root command's `PersistentPostRun`, and `main.go` right after `ExecuteContextC` returns. The second is a strict superset — it runs on every path `Execute` returns from, including the RunE-error and required-flag-validation paths cobra skips its post-run loop on. Nothing logs between the two.

- Removed the deferred close from `cmd/entire/cli/root.go` (and the now-unused `logging` import).
- Documented at `main.go`'s close why it has to stay there, now that it is the only one.

Two test helpers reached the log file through a bare `root.Execute()` and were quietly relying on root's flush; both now close the way `main.go` does. No test asserted the deleted close, and none became redundant — each still covers a distinct property (injection, traverse-run-hooks, no `.entire/` creation in an unenabled repo, flush on error paths, no logger for shell completion).

`mise run fmt && mise run lint && mise run test:ci` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle refactor: logger close is already idempotent and tests still flush logs. No change to log content or command behavior.
> 
> **Overview**
> Stops closing the file logger from root `PersistentPostRun` and leaves a single close in `main.go` after `ExecuteContextC`.
> 
> Cobra skips post-run on `RunE` errors and missing required flags, so the old deferred close never ran on those paths. Closing from `main` already covered every return, including those, so the extra close was redundant.
> 
> Test helpers that used to rely on the post-run flush now close the logger the same way production does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d75abd38e2f5d7eaf03e158497a6e6458ea67a8a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->