### PR TITLE
test(e2e): assert the Factory Worker task-record contract, not shadow task data

### DIFF
--- a/cmd/entire/cli/integration_test/factoryai_worker_session_test.go
+++ b/cmd/entire/cli/integration_test/factoryai_worker_session_test.go
@@ -12,11 +12,12 @@ import (
 // PostToolUse hook fires when the Worker is launched, before it has touched the
 // worktree, and the Worker then runs its own SessionStart/UserPromptSubmit/Stop
 // cycle. These tests pin the resulting attribution — a Worker's turn must land
-// as a task checkpoint on the parent, not as an unrelated top-level session.
+// as a task record on the parent, not as an unrelated top-level session.
 
 // TestFactoryDroidWorkerSessionBecomesTaskCheckpoint covers the regression that
-// broke TestFactoryTaskCheckpointExistsBeforeCommit: a Worker's work reached the
-// shadow branch, but under its own session ID, so no task checkpoint existed.
+// broke the E2E TestFactoryTaskRecordExistsBeforeCommit: a Worker's work reached
+// the shadow branch, but under its own session ID, so the parent had nothing
+// attributing it to the task.
 func TestFactoryDroidWorkerSessionBecomesTaskCheckpoint(t *testing.T) {
 	t.Parallel()
 

--- a/e2e/tests/factory_hooks_test.go
+++ b/e2e/tests/factory_hooks_test.go
@@ -4,6 +4,7 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFactoryTaskCheckpointExistsBeforeCommit(t *testing.T) {
+func TestFactoryTaskRecordExistsBeforeCommit(t *testing.T) {
 	testutil.ForEachAgent(t, 3*time.Minute, func(t *testing.T, s *testutil.RepoState, ctx context.Context) {
 		if s.Agent.Name() != "factoryai-droid" {
 			t.Skip("factory-only regression test")
@@ -36,7 +37,8 @@ func TestFactoryTaskCheckpointExistsBeforeCommit(t *testing.T) {
 		// file wait must absorb the Worker's runtime (60-120s turns on CI).
 		testutil.WaitForFileExists(t, s.Dir, "docs/factory-hook-check.md", 120*time.Second)
 
-		waitForTaskCheckpoint(t, s.Dir, 30*time.Second)
+		waitForCompletedTaskRecord(t, s.Dir, 30*time.Second)
+		assertNoShadowTaskData(t, s.Dir)
 	})
 }
 
@@ -60,10 +62,11 @@ func TestFactoryCommittedCheckpointExcludesPreExistingUntrackedFiles(t *testing.
 			"Can you run a Worker that inspects this code and writes its findings to docs/factory-prehook-worker.md as one short paragraph followed by exactly 3 bullet points? Do not read, modify, or mention docs/factory-preexisting-human-note.md. Do not create or edit the file in the main agent process. Only the Worker should write docs/factory-prehook-worker.md. Do not commit. Do not ask for confirmation.")
 		s.WaitFor(t, session, s.Agent.PromptPattern(), 90*time.Second)
 
-		// See TestFactoryTaskCheckpointExistsBeforeCommit: the file wait must
+		// See TestFactoryTaskRecordExistsBeforeCommit: the file wait must
 		// absorb the Worker's runtime because WaitFor can return mid-turn.
 		testutil.WaitForFileExists(t, s.Dir, "docs/factory-prehook-worker.md", 120*time.Second)
-		waitForTaskCheckpoint(t, s.Dir, 30*time.Second)
+		waitForCompletedTaskRecord(t, s.Dir, 30*time.Second)
+		assertNoShadowTaskData(t, s.Dir)
 
 		s.Git(t, "add", "docs/factory-prehook-worker.md")
 		s.Git(t, "commit", "-m", "Add factory worker checkpoint regression fixtures")
@@ -79,20 +82,58 @@ func TestFactoryCommittedCheckpointExcludesPreExistingUntrackedFiles(t *testing.
 	})
 }
 
-// waitForTaskCheckpoint polls the shadow branches until a task checkpoint
-// (metadata under a tasks/<tool-use-id>/ directory) appears.
-func waitForTaskCheckpoint(t *testing.T, dir string, timeout time.Duration) {
+// A Factory Worker's turn is captured as a COMPLETED session.TaskRecord on the
+// parent's session state — not as task metadata on a shadow branch. #2032
+// ("capture background subagent work durably") moved materialization to
+// condensation time, so before the user commits there is a record and no
+// shadow task tree; the record's transcript is written into the parent's
+// checkpoint under tasks/<toolUseID>/ only once condensation runs.
+//
+// These two helpers pin that contract in both directions. The positive one
+// replaced a poll for a shadow-branch tasks/ path, which asserted the
+// pre-#2032 behaviour and so failed on every push to main from ed9c31c0d
+// onwards; the negative one is the same assertion #2032 added to
+// TestFactoryDroidWorkerSessionBecomesTaskCheckpoint ("a Worker's turn must
+// write a task record, not shadow data"), narrowed to task data because a
+// parent session legitimately has shadow branches of its own (shadow pinning
+// keys on StepCount, so their existence says nothing about task content).
+//
+// Whether losing the pre-commit shadow copy weakens durability is #2058's
+// question, not this test's: these assert the shipped contract.
+func waitForCompletedTaskRecord(t *testing.T, dir string, timeout time.Duration) {
 	t.Helper()
 
+	stateDir := filepath.Join(dir, ".git", "entire-sessions")
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		for _, branch := range testutil.ShadowBranches(t, dir) {
-			out, err := testutil.GitOutputErr(dir, "ls-tree", "-r", "--name-only", branch)
+		entries, err := os.ReadDir(stateDir)
+		if err != nil {
+			// The directory may not exist yet; keep polling.
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") ||
+				strings.HasSuffix(entry.Name(), ".tmp") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(stateDir, entry.Name()))
 			if err != nil {
 				continue
 			}
-			for _, path := range strings.Split(out, "\n") {
-				if strings.Contains(path, "/tasks/") {
+			var state struct {
+				TaskRecords []struct {
+					ToolUseID   string `json:"tool_use_id"`
+					CompletedAt string `json:"completed_at"`
+				} `json:"task_records"`
+			}
+			if err := json.Unmarshal(data, &state); err != nil {
+				continue
+			}
+			// An in-flight record has a zero CompletedAt, which omitempty drops
+			// from the file entirely — so a non-empty value is the completion.
+			for _, rec := range state.TaskRecords {
+				if rec.ToolUseID != "" && rec.CompletedAt != "" {
 					return
 				}
 			}
@@ -100,5 +141,21 @@ func waitForTaskCheckpoint(t *testing.T, dir string, timeout time.Duration) {
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	t.Fatalf("expected task checkpoint within %s", timeout)
+	t.Fatalf("expected a completed task record in %s within %s", stateDir, timeout)
+}
+
+// assertNoShadowTaskData asserts no shadow branch carries task metadata.
+func assertNoShadowTaskData(t *testing.T, dir string) {
+	t.Helper()
+
+	for _, branch := range testutil.ShadowBranches(t, dir) {
+		out, err := testutil.GitOutputErr(dir, "ls-tree", "-r", "--name-only", branch)
+		if err != nil {
+			continue
+		}
+		for _, path := range strings.Split(out, "\n") {
+			assert.NotContains(t, path, "/tasks/",
+				"a Worker's turn must write a task record, not shadow task data (branch %s)", branch)
+		}
+	}
 }

--- a/e2e/tests/factory_hooks_test.go
+++ b/e2e/tests/factory_hooks_test.go
@@ -5,8 +5,10 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -37,7 +39,7 @@ func TestFactoryTaskRecordExistsBeforeCommit(t *testing.T) {
 		// file wait must absorb the Worker's runtime (60-120s turns on CI).
 		testutil.WaitForFileExists(t, s.Dir, "docs/factory-hook-check.md", 120*time.Second)
 
-		waitForCompletedTaskRecord(t, s.Dir, 30*time.Second)
+		waitForCompletedTaskRecord(t, s.Dir, "docs/factory-hook-check.md", 30*time.Second)
 		assertNoShadowTaskData(t, s.Dir)
 	})
 }
@@ -65,7 +67,7 @@ func TestFactoryCommittedCheckpointExcludesPreExistingUntrackedFiles(t *testing.
 		// See TestFactoryTaskRecordExistsBeforeCommit: the file wait must
 		// absorb the Worker's runtime because WaitFor can return mid-turn.
 		testutil.WaitForFileExists(t, s.Dir, "docs/factory-prehook-worker.md", 120*time.Second)
-		waitForCompletedTaskRecord(t, s.Dir, 30*time.Second)
+		waitForCompletedTaskRecord(t, s.Dir, "docs/factory-prehook-worker.md", 30*time.Second)
 		assertNoShadowTaskData(t, s.Dir)
 
 		s.Git(t, "add", "docs/factory-prehook-worker.md")
@@ -92,7 +94,9 @@ func TestFactoryCommittedCheckpointExcludesPreExistingUntrackedFiles(t *testing.
 // These two helpers pin that contract in both directions. The positive one
 // replaced a poll for a shadow-branch tasks/ path, which asserted the
 // pre-#2032 behaviour and so failed on every push to main from ed9c31c0d
-// onwards; the negative one is the same assertion #2032 added to
+// onwards; it requires the Worker's own output on a completed record, so it
+// cannot be satisfied by an unrelated task. The negative one is the same
+// assertion #2032 added to
 // TestFactoryDroidWorkerSessionBecomesTaskCheckpoint ("a Worker's turn must
 // write a task record, not shadow data"), narrowed to task data because a
 // parent session legitimately has shadow branches of its own (shadow pinning
@@ -100,12 +104,14 @@ func TestFactoryCommittedCheckpointExcludesPreExistingUntrackedFiles(t *testing.
 //
 // Whether losing the pre-commit shadow copy weakens durability is #2058's
 // question, not this test's: these assert the shipped contract.
-func waitForCompletedTaskRecord(t *testing.T, dir string, timeout time.Duration) {
+func waitForCompletedTaskRecord(t *testing.T, dir, wantFile string, timeout time.Duration) {
 	t.Helper()
 
 	stateDir := filepath.Join(dir, ".git", "entire-sessions")
 	deadline := time.Now().Add(timeout)
+	var seen []string
 	for time.Now().Before(deadline) {
+		seen = nil
 		entries, err := os.ReadDir(stateDir)
 		if err != nil {
 			// The directory may not exist yet; keep polling.
@@ -123,17 +129,32 @@ func waitForCompletedTaskRecord(t *testing.T, dir string, timeout time.Duration)
 			}
 			var state struct {
 				TaskRecords []struct {
-					ToolUseID   string `json:"tool_use_id"`
-					CompletedAt string `json:"completed_at"`
+					ToolUseID string   `json:"tool_use_id"`
+					AgentID   string   `json:"agent_id"`
+					Files     []string `json:"files"`
+					// Decoded as time.Time, NOT string: CompletedAt is tagged
+					// omitempty, and omitempty does not drop a zero struct — an
+					// in-flight record serializes as "0001-01-01T00:00:00Z", so a
+					// non-empty-string test would report every record complete.
+					// IsZero is the only honest check.
+					CompletedAt time.Time `json:"completed_at"`
 				} `json:"task_records"`
 			}
 			if err := json.Unmarshal(data, &state); err != nil {
 				continue
 			}
-			// An in-flight record has a zero CompletedAt, which omitempty drops
-			// from the file entirely — so a non-empty value is the completion.
 			for _, rec := range state.TaskRecords {
-				if rec.ToolUseID != "" && rec.CompletedAt != "" {
+				seen = append(seen, fmt.Sprintf("{tool_use_id:%q agent_id:%q completed:%t files:%v}",
+					rec.ToolUseID, rec.AgentID, !rec.CompletedAt.IsZero(), rec.Files))
+				if rec.CompletedAt.IsZero() {
+					continue
+				}
+				// Require the Worker's own output on the record, not merely that
+				// some task completed: saveSubagentSessionTaskStep always sets
+				// Files from the Worker turn's detected changes, so the file the
+				// caller already waited for must be there. Without this the
+				// assertion would pass on any unrelated completed record.
+				if slices.Contains(rec.Files, wantFile) {
 					return
 				}
 			}
@@ -141,7 +162,8 @@ func waitForCompletedTaskRecord(t *testing.T, dir string, timeout time.Duration)
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	t.Fatalf("expected a completed task record in %s within %s", stateDir, timeout)
+	t.Fatalf("expected a completed task record carrying %q in %s within %s; records seen: %v",
+		wantFile, stateDir, timeout, seen)
 }
 
 // assertNoShadowTaskData asserts no shadow branch carries task metadata.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1120
<!-- entire-trail-link-end -->

`E2E Tests` has failed on **every push to `main` since `ed9c31c0d`** (#2032, "capture background subagent work durably") — seven consecutive runs. One job (`e2e-tests (factoryai-droid)`), two tests, both at `expected task checkpoint within 30s`, and both failing again on gotestsum's automatic re-run, so this is deterministic rather than agent nondeterminism.

It bisects cleanly: run 32411315115 on `ed34d4db5` (#2018) had Factory green, and `ed34d4db5` is `ed9c31c0d`'s only parent.

## This is not a bug in #2032

`waitForTaskCheckpoint` polled the **shadow branches** for a `tasks/` path — exactly what #2032 stopped writing. Under the new model a Worker's turn lands as a completed `session.TaskRecord` on the parent, and the transcript is materialized into the parent's checkpoint under `tasks/<toolUseID>/` at condensation time.

#2032 already moved everything else onto that contract — its own integration test now asserts the inverse ("a Worker's turn must write a task record, not shadow data"), and CLAUDE.md says "records never live on the shadow branch". These two E2E tests were the only holdout, and they could not object during review because `E2E Tests` runs on push-to-main and never on a PR.

## What this does

Moves both tests onto the shipped contract, in both directions:

- **`waitForCompletedTaskRecord`** polls `.git/entire-sessions/*.json` for a record with a non-empty `completed_at`. `omitempty` drops the zero value, so presence *is* the completion signal. Same strength as the existence check it replaces.
- **`assertNoShadowTaskData`** pins the inverse: no shadow branch carries a `tasks/` path. Narrowed to task data deliberately — a parent session legitimately has shadow branches of its own, because shadow pinning keys on `StepCount` and says nothing about task content.

`TestFactoryTaskCheckpointExistsBeforeCommit` → `TestFactoryTaskRecordExistsBeforeCommit`. There is no pre-commit *checkpoint* under the new model, but the durability intent in the name is still what's tested: the Worker's work is captured before the user commits.

Also updates the stale cross-reference and pre-#2032 wording in `factoryai_worker_session_test.go`'s header comments, which named the renamed test.

## Scope note

Whether dropping the pre-commit shadow copy **weakens durability** is #2058's question, not this PR's. These tests assert what shipped; they do not settle whether it should have. Flagging explicitly so the red build isn't mistaken for that question being answered.

## Verification

- `mise run fmt && mise run lint` — clean (0 issues)
- `mise run test:ci` — integration ok, canary 56/56 and 4/4, no failures
- `go vet -tags=e2e ./e2e/tests/` — clean
- The changed E2E tests themselves are **not run here**: they need a real Factory Droid agent, so `E2E Tests` on merge to main is the actual verification. Prompts are untouched (Vogon regexes unaffected) and both tests skip on non-Factory agents (canary unaffected).

## Also worth fixing separately

`E2E Tests` being push-to-main-only is what let this land. The Worker task path has no pre-merge coverage at all, and the canary is free and deterministic — extending it to cover the Worker task record would have caught this in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion changes; no production behavior. Residual risk is E2E-only verification on merge to main.
> 
> **Overview**
> Aligns Factory Droid E2E coverage with the post-#2032 contract: a Worker turn is a completed parent `TaskRecord` before commit, not `tasks/` metadata on a shadow branch.
> 
> `waitForTaskCheckpoint` now polls `.git/entire-sessions/*.json` for a record with `tool_use_id` and `completed_at`, and `assertNoShadowTaskData` fails if any shadow tree still has a `/tasks/` path. The pre-commit test is renamed to `TestFactoryTaskRecordExistsBeforeCommit`. Integration-test comments are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33d5866832c8f26131978fee4cd7c964650c58fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->