### PR TITLE
test(strategy): link the real dirname instead of writing a fake one

### DIFF
--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -1421,10 +1421,14 @@ func TestGitHookCommitMsg_EntireFailureAllowsCommit(t *testing.T) {
 		t.Fatalf("failed to write commit message: %v", err)
 	}
 
-	fakeEntire := filepath.Join(binDir, "entire")
-	if err := os.WriteFile(fakeEntire, []byte("#!/bin/sh\nexit 42\n"), 0o755); err != nil {
-		t.Fatalf("failed to write fake entire: %v", err)
-	}
+	// The hook only needs an `entire` that exists and fails: it emits
+	// `if command -v entire ...; then entire hooks git commit-msg "$1" || true;
+	// else <warn>; fi`, so the name has to resolve (or the warning this test
+	// forbids would print) and `|| true` discards whatever it exits with. The
+	// script this replaces exited 42, but no code path read that value, so
+	// linking `false` preserves the behaviour under test and — being a link,
+	// not a written file — cannot hit the ETXTBSY race described above.
+	linkExecutable(t, filepath.Join(binDir, "entire"), "false")
 
 	hook := findHookSpec(t, buildHookSpecs("entire"), "commit-msg")
 	hookPath := filepath.Join(tempDir, "commit-msg")
@@ -1456,24 +1460,9 @@ func TestGitHookCommitMsg_MissingEntireStillRunsChainedHook(t *testing.T) {
 	}
 	// The generated hook calls dirname (hooks.go: _entire_hook_dir=...), and
 	// envWithPath makes binDir the entire PATH, so binDir has to provide it.
-	// Symlink the real one instead of writing a stand-in script: a
-	// written-then-exec'd file is an ETXTBSY target (golang/go#22315). Between
-	// os.WriteFile's open-for-write and its close, any of this package's ~33
-	// parallel tests can fork, the child inherits the write fd, and exec of
-	// that file then fails with "Text file busy" until the child closes it.
-	// Go's os/exec retries ETXTBSY for commands it starts, but this exec
-	// happens inside the sh subprocess, so nothing retries: the hook dies at
-	// its first dirname call and the test reports "backup hook did not run",
-	// which points nowhere near the cause. A symlink is never a write target,
-	// and the stand-in it replaces only reimplemented ${1%/*}, so behaviour
-	// here is unchanged.
-	realDirname, err := exec.LookPath("dirname")
-	if err != nil {
-		t.Skip("dirname not available")
-	}
-	if err := os.Symlink(realDirname, filepath.Join(binDir, "dirname")); err != nil {
-		t.Fatalf("failed to link dirname into the fake PATH: %v", err)
-	}
+	// The stand-in it replaces only reimplemented ${1%/*}, so linking the real
+	// one is behaviour-identical.
+	linkExecutable(t, filepath.Join(binDir, "dirname"), "dirname")
 
 	hook := findHookSpec(t, buildHookSpecs("entire"), "commit-msg")
 	hookPath := filepath.Join(tempDir, "commit-msg")
@@ -1495,6 +1484,40 @@ func TestGitHookCommitMsg_MissingEntireStillRunsChainedHook(t *testing.T) {
 	}
 	if _, err := os.Stat(markerFile); err != nil {
 		t.Fatalf("backup hook did not run: %v\n%s", err, output)
+	}
+}
+
+// linkExecutable places an ETXTBSY-immune stand-in for the real `name` binary
+// at dst, for tests that hand a fabricated PATH to a shell subprocess.
+//
+// Writing the stand-in as a script is the shape to avoid: a written-then-exec'd
+// file is an ETXTBSY target (golang/go#22315). Between os.WriteFile's
+// open-for-write and its close, any of this package's parallel tests can fork,
+// the child inherits the write fd, and exec of that file then fails with "Text
+// file busy" until the child closes it. Go's os/exec retries ETXTBSY for
+// commands it starts, but these execs happen inside the sh subprocess, so
+// nothing retries: the hook dies mid-script and the test reports whichever
+// later assertion noticed, which points nowhere near the cause. A link is never
+// a write target, so the race has no purchase.
+//
+// Symlink first, hard link second: Windows without Developer Mode or admin
+// refuses symlinks, while a hard link is the same inode (equally immune) but
+// cannot cross filesystems, which is the common case here since t.TempDir and
+// the system binary usually differ. Skip if neither works — this is a test
+// prerequisite, like requireShell's missing sh, not a failure of the code under
+// test.
+func linkExecutable(t *testing.T, dst, name string) {
+	t.Helper()
+
+	realPath, err := exec.LookPath(name)
+	if err != nil {
+		t.Skipf("%s not available on PATH", name)
+	}
+	if symlinkErr := os.Symlink(realPath, dst); symlinkErr == nil {
+		return
+	}
+	if linkErr := os.Link(realPath, dst); linkErr != nil {
+		t.Skipf("cannot link %s into the fake PATH: %v", name, linkErr)
 	}
 }
 

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -1454,9 +1454,25 @@ func TestGitHookCommitMsg_MissingEntireStillRunsChainedHook(t *testing.T) {
 	if err := os.WriteFile(msgFile, []byte("commit message\n"), 0o600); err != nil {
 		t.Fatalf("failed to write commit message: %v", err)
 	}
-	fakeDirname := "#!/bin/sh\ncase \"$1\" in */*) printf '%s\\n' \"${1%/*}\" ;; *) printf '.\\n' ;; esac\n"
-	if err := os.WriteFile(filepath.Join(binDir, "dirname"), []byte(fakeDirname), 0o755); err != nil {
-		t.Fatalf("failed to write fake dirname: %v", err)
+	// The generated hook calls dirname (hooks.go: _entire_hook_dir=...), and
+	// envWithPath makes binDir the entire PATH, so binDir has to provide it.
+	// Symlink the real one instead of writing a stand-in script: a
+	// written-then-exec'd file is an ETXTBSY target (golang/go#22315). Between
+	// os.WriteFile's open-for-write and its close, any of this package's ~33
+	// parallel tests can fork, the child inherits the write fd, and exec of
+	// that file then fails with "Text file busy" until the child closes it.
+	// Go's os/exec retries ETXTBSY for commands it starts, but this exec
+	// happens inside the sh subprocess, so nothing retries: the hook dies at
+	// its first dirname call and the test reports "backup hook did not run",
+	// which points nowhere near the cause. A symlink is never a write target,
+	// and the stand-in it replaces only reimplemented ${1%/*}, so behaviour
+	// here is unchanged.
+	realDirname, err := exec.LookPath("dirname")
+	if err != nil {
+		t.Skip("dirname not available")
+	}
+	if err := os.Symlink(realDirname, filepath.Join(binDir, "dirname")); err != nil {
+		t.Fatalf("failed to link dirname into the fake PATH: %v", err)
 	}
 
 	hook := findHookSpec(t, buildHookSpecs("entire"), "commit-msg")


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/1121

`TestGitHookCommitMsg_MissingEntireStillRunsChainedHook` flakes on Linux CI. The assertion that fails is a red herring:

```
--- FAIL: TestGitHookCommitMsg_MissingEntireStillRunsChainedHook
    hooks_test.go:1481: backup hook did not run: stat .../COMMIT_EDITMSG.backup-ran: no such file
        /tmp/.../commit-msg: 6: dirname: Text file busy
```

**`dirname: Text file busy` is the actual fault** — ETXTBSY, [golang/go#22315]. The test wrote a stand-in `dirname` into a temp dir that `envWithPath` then makes the *entire* PATH. Between `os.WriteFile`'s open-for-write and its close, another of this package's parallel tests forks (`hooks_test.go` alone has 33 `t.Parallel()` calls, and the package shells out to git constantly), the child inherits the write fd, and exec of that file returns ETXTBSY until the child closes it.

Go's `os/exec` retries ETXTBSY for commands *it* starts — but this exec happens inside the `sh` subprocess, so nothing retries. The hook dies at its first `dirname` call (`hooks.go`: `_entire_hook_dir="$(dirname "$0")"`), long before reaching the backup hook the test is actually about, so the reported failure is three steps downstream of the cause.

## Fix

A new `linkExecutable` helper places a **link** to the real binary instead of writing a script. A link is never a write target, so the race has no purchase. Symlink first, hard link second (same inode, equally immune, but cannot cross filesystems — and `t.TempDir` and the system binary usually differ), then skip. A missing link facility is a test prerequisite, like `requireShell`'s missing `sh`, not a failure of the code under test.

Applied to both exec'd stand-ins in this file:

- **`dirname`** — the script only reimplemented `${1%/*}`, so linking the real one is behaviour-identical.
- **`fakeEntire`** — links `false`. The hook emits `if command -v entire ...; then entire hooks git commit-msg "$1" || true; else <warn>; fi`, so the stub only has to resolve by name and fail; `|| true` discards its exit status and nothing ever read the `42`. Note the trail review's suggested remedy here — symlink or copy a real `entire` — would **not** have worked: the stub's purpose is to fail, which a working `entire` cannot do.

## Corrections to this PR's earlier reasoning

Both worth stating, since the first version of this PR shipped them:

1. It deferred `fakeEntire` on the grounds that these sites "need real scripts". Wrong, per the above — now fixed rather than deferred.
2. It claimed five further sites (`:751`, `:823`, `:844`, `:1249`, `:1289`) share the exposure. **They do not.** Every one is written and then only *read* — classified by `gitHookStateInHooksDir`, or checked for survival by `RemoveGitHook`/`InstallGitHook`. ETXTBSY only arises on **exec**, so a file that is never exec'd cannot raise it. `dirname` and `fakeEntire` were the only two exec'd stand-ins, and both are now links, so this closes the class rather than leaving a standing exception.

## Verification

- Both affected tests report **PASS, not SKIP** — confirming the links are really in use and the fallback didn't silently drop coverage
- `go test -race -run TestGitHook -count=25 -parallel 16 ./cmd/entire/cli/strategy/` — clean
- `mise run fmt && mise run lint` — 0 issues
- `mise run test:ci` — strategy ok, canary 56/56 and 4/4, no failures

Caveat worth stating: this flake is Linux-only in practice, and the fix removes the mechanism rather than reducing a probability, so a green stress run is supporting evidence, not proof. The mechanism is gone because there is no longer a file that is written and then exec'd.

[golang/go#22315]: https://github.com/golang/go/issues/22315

🤖 Generated with [Claude Code](https://claude.com/claude-code)