### PR TITLE
Send the versioned User-Agent from every CLI HTTP client

### DIFF
--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/httputil"
@@ -350,13 +351,13 @@ func resolveEnvTokenCellSubject(raw string, insecureHTTP bool) (cellSubject, err
 func cellExchangeHTTPClient(origin string) *http.Client {
 	switch {
 	case cellExchangeTransportForTest != nil:
-		return &http.Client{Timeout: cellDataAPITimeout, Transport: cellExchangeTransportForTest}
+		return &http.Client{Timeout: cellDataAPITimeout, Transport: versioninfo.WrapTransport(cellExchangeTransportForTest)}
 	case shouldUsePlainHTTPDiscovery(origin):
 		c := dataAPIDiscoveryClient(origin)
 		c.Timeout = cellDataAPITimeout
 		return c
 	default:
-		return &http.Client{Timeout: cellDataAPITimeout}
+		return &http.Client{Timeout: cellDataAPITimeout, Transport: versioninfo.WrapTransport(nil)}
 	}
 }
 

--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/userdirs"
@@ -81,7 +82,7 @@ func ResolveControlPlaneTargetForCluster(ctx context.Context, clusterHost string
 	if clusterHost == "" {
 		return ControlPlaneTarget{}, errors.New("cluster-addressed control-plane command requires a target cluster host")
 	}
-	httpClient := &http.Client{Timeout: controlPlaneClusterDiscoveryTimeout}
+	httpClient := &http.Client{Timeout: controlPlaneClusterDiscoveryTimeout, Transport: versioninfo.WrapTransport(nil)}
 	c, err := resolveContextForCluster(ctx, userdirs.Config(), userdirs.Cache(), clusterHost, httpClient, nil)
 	if err != nil {
 		return ControlPlaneTarget{}, err

--- a/cmd/entire/cli/auth/data_api.go
+++ b/cmd/entire/cli/auth/data_api.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/userdirs"
@@ -111,17 +112,12 @@ func (t dataAPIHTTPDiscoveryTransport) RoundTrip(req *http.Request) (*http.Respo
 }
 
 func dataAPIDiscoveryClient(dataOrigin string) *http.Client {
-	client := &http.Client{Timeout: dataAPIDiscoveryTimeout}
+	client := &http.Client{Timeout: dataAPIDiscoveryTimeout, Transport: versioninfo.WrapTransport(nil)}
 	if !shouldUsePlainHTTPDiscovery(dataOrigin) {
 		return client
 	}
 
-	var base http.RoundTripper
-	base = http.DefaultTransport
-	if client.Transport != nil {
-		base = client.Transport
-	}
-	client.Transport = dataAPIHTTPDiscoveryTransport{base: base}
+	client.Transport = dataAPIHTTPDiscoveryTransport{base: client.Transport}
 	return client
 }
 

--- a/cmd/entire/cli/auth/useragent_test.go
+++ b/cmd/entire/cli/auth/useragent_test.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+)
+
+// uaSink records the User-Agent of every request an httptest server received.
+// Mutex-guarded: HTTP completion is not a happens-before edge the race
+// detector recognises, so the handler goroutine and the test goroutine need
+// real synchronisation.
+type uaSink struct {
+	mu   sync.Mutex
+	seen []string
+}
+
+func (s *uaSink) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.seen = append(s.seen, r.Header.Get("User-Agent"))
+		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`)) //nolint:errcheck // test fixture response
+	}
+}
+
+func (s *uaSink) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.seen...)
+}
+
+// This package's HTTP clients are handed to helpers that build their own
+// requests — clusterdiscovery's well-known fetch and resolveCellAPIBaseURL's
+// cluster listing — so nothing in this package sets a User-Agent per call.
+// It has to ride on the transport, which means each constructor is on the hook
+// for it.
+func TestAuthHTTPClients_SendVersionedUserAgent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// build receives the test server's origin so the loopback-HTTP branch
+		// can be selected by a real loopback URL rather than a global flag.
+		build func(origin string) *http.Client
+	}{
+		{
+			name:  "data API discovery, https origin",
+			build: func(string) *http.Client { return dataAPIDiscoveryClient("https://entire.io") },
+		},
+		{
+			// The plain-HTTP branch layers dataAPIHTTPDiscoveryTransport over
+			// the stamp; it has to survive that.
+			name:  "data API discovery, loopback http origin",
+			build: dataAPIDiscoveryClient,
+		},
+		{
+			name:  "cell exchange client",
+			build: func(string) *http.Client { return cellExchangeHTTPClient("https://entire.io") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sink := &uaSink{}
+			srv := httptest.NewServer(sink.handler())
+			t.Cleanup(srv.Close)
+
+			client := tt.build(srv.URL)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/api/v1/clusters", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			want := versioninfo.UserAgent()
+			if got := sink.snapshot(); len(got) != 1 || got[0] != want {
+				t.Fatalf("User-Agent seen = %v, want [%s]", got, want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/plugin_fetch.go
+++ b/cmd/entire/cli/plugin_fetch.go
@@ -20,6 +20,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 // Release-asset download. The one irreducibly forge-specific piece of the
@@ -93,7 +95,8 @@ const maxAssetRedirects = 10
 // https:// entry point could deliver both the asset and its checksums.txt over
 // plaintext — exactly the outcome requireSecureAssetURL exists to prevent.
 var pluginHTTPClient = &http.Client{
-	Timeout: 5 * time.Minute,
+	Timeout:   5 * time.Minute,
+	Transport: versioninfo.WrapTransport(nil),
 	CheckRedirect: func(req *http.Request, via []*http.Request) error {
 		if len(via) >= maxAssetRedirects {
 			return fmt.Errorf("stopped after %d redirects", maxAssetRedirects)

--- a/cmd/entire/cli/plugin_fetch_useragent_test.go
+++ b/cmd/entire/cli/plugin_fetch_useragent_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+)
+
+// Plugin asset downloads go out through one shared client, so the User-Agent
+// belongs on its transport rather than at the two call sites (httpGetSmall and
+// the asset download) that use it.
+func TestPluginHTTPClient_SendsVersionedUserAgent(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("User-Agent"))
+		mu.Unlock()
+		w.Write([]byte("ok")) //nolint:errcheck // test fixture response
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/checksums.txt", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := pluginHTTPClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := versioninfo.UserAgent()
+	if len(seen) != 1 || seen[0] != want {
+		t.Fatalf("User-Agent seen = %v, want [%s]", seen, want)
+	}
+}

--- a/cmd/entire/cli/versioninfo/transport.go
+++ b/cmd/entire/cli/versioninfo/transport.go
@@ -19,11 +19,28 @@ import (
 // the chain rather than on top: a transport above it may synthesize requests of
 // its own and send them straight to its base, bypassing anything wrapped
 // outside it. Stamping at the base catches every request that actually leaves
-// the process. (httpclient.UserAgentTransport clones before mutating, so
-// wrapping never disturbs the caller's request.)
+// the process.
+//
+// The User-Agent is resolved per request rather than captured here, because
+// construction can happen before the version is known: main() calls Load() to
+// recover it from the binary's build info, and any client built during package
+// initialization — pluginHTTPClient is one — would otherwise pin
+// "entire-cli/dev" for the life of the process on every build without ldflags
+// (`go install ...@<version>`). Binding late makes construction order
+// irrelevant.
 func WrapTransport(next http.RoundTripper) http.RoundTripper {
 	if next == nil {
 		next = http.DefaultTransport
 	}
-	return &httpclient.UserAgentTransport{Next: next, UA: UserAgent()}
+	return userAgentTransport{next: next}
+}
+
+// userAgentTransport supplies the User-Agent later than construction and leaves
+// the stamping itself to httpclient.UserAgentTransport, so the
+// clone-before-mutate contract lives in exactly one place.
+type userAgentTransport struct{ next http.RoundTripper }
+
+func (t userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	//nolint:wrapcheck // thin passthrough; the wrapped transport owns the error semantics.
+	return (&httpclient.UserAgentTransport{Next: t.next, UA: UserAgent()}).RoundTrip(req)
 }

--- a/cmd/entire/cli/versioninfo/transport.go
+++ b/cmd/entire/cli/versioninfo/transport.go
@@ -1,0 +1,29 @@
+package versioninfo
+
+import (
+	"net/http"
+
+	"github.com/entireio/cli/internal/entireclient/httpclient"
+)
+
+// WrapTransport returns next wrapped so every request sent through it carries
+// UserAgent(). A nil next means Go's default transport, matching how
+// http.Client treats a nil Transport.
+//
+// Prefer this over setting the header at a call site whenever the *http.Client
+// is handed to a helper that builds its own requests (clusterdiscovery's
+// well-known fetch, coreapi's token exchange): those requests never pass
+// through the caller's code, so only the transport can stamp them.
+//
+// Wrap innermost. When a client layers transports, this belongs at the base of
+// the chain rather than on top: a transport above it may synthesize requests of
+// its own and send them straight to its base, bypassing anything wrapped
+// outside it. Stamping at the base catches every request that actually leaves
+// the process. (httpclient.UserAgentTransport clones before mutating, so
+// wrapping never disturbs the caller's request.)
+func WrapTransport(next http.RoundTripper) http.RoundTripper {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	return &httpclient.UserAgentTransport{Next: next, UA: UserAgent()}
+}

--- a/cmd/entire/cli/versioninfo/transport_test.go
+++ b/cmd/entire/cli/versioninfo/transport_test.go
@@ -1,0 +1,91 @@
+package versioninfo
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/entireio/cli/internal/entireclient/httpclient"
+)
+
+// uaRecorder is the terminal RoundTripper in a wrapped chain: it records the
+// User-Agent each request carried by the time it would have hit the network.
+// Mutex-guarded because a transport may be driven from more than one goroutine.
+type uaRecorder struct {
+	mu   sync.Mutex
+	seen []string
+}
+
+func (r *uaRecorder) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.mu.Lock()
+	r.seen = append(r.seen, req.Header.Get("User-Agent"))
+	r.mu.Unlock()
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+}
+
+func (r *uaRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.seen...)
+}
+
+func TestWrapTransport_StampsUserAgent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		callerU string // User-Agent the caller set, if any
+	}{
+		{name: "no user-agent set"},
+		{name: "overwrites go default", callerU: "Go-http-client/2.0"},
+		{name: "overwrites caller value", callerU: "something-else/1.2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rec := &uaRecorder{}
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://entire.io/api/v1/x", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.callerU != "" {
+				req.Header.Set("User-Agent", tt.callerU)
+			}
+
+			resp, err := WrapTransport(rec).RoundTrip(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			want := UserAgent()
+			if got := rec.snapshot(); len(got) != 1 || got[0] != want {
+				t.Fatalf("User-Agent sent = %v, want [%s]", got, want)
+			}
+			// The caller's own request must be left as it was: callers reuse
+			// requests across retries.
+			if got := req.Header.Get("User-Agent"); got != tt.callerU {
+				t.Fatalf("caller request mutated: User-Agent = %q, want %q", got, tt.callerU)
+			}
+		})
+	}
+}
+
+// A nil next means "Go's default transport", so callers can wrap a client that
+// has no Transport of its own without reaching for http.DefaultTransport.
+func TestWrapTransport_NilNextUsesDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	wrapped, ok := WrapTransport(nil).(*httpclient.UserAgentTransport)
+	if !ok {
+		t.Fatalf("WrapTransport(nil) = %T, want *httpclient.UserAgentTransport", WrapTransport(nil))
+	}
+	if wrapped.Next != http.DefaultTransport {
+		t.Fatalf("Next = %v, want http.DefaultTransport", wrapped.Next)
+	}
+	if wrapped.UA != UserAgent() {
+		t.Fatalf("UA = %q, want %q", wrapped.UA, UserAgent())
+	}
+}

--- a/cmd/entire/cli/versioninfo/transport_test.go
+++ b/cmd/entire/cli/versioninfo/transport_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"sync"
 	"testing"
-
-	"github.com/entireio/cli/internal/entireclient/httpclient"
 )
 
 // uaRecorder is the terminal RoundTripper in a wrapped chain: it records the
@@ -78,14 +76,44 @@ func TestWrapTransport_StampsUserAgent(t *testing.T) {
 func TestWrapTransport_NilNextUsesDefaultTransport(t *testing.T) {
 	t.Parallel()
 
-	wrapped, ok := WrapTransport(nil).(*httpclient.UserAgentTransport)
+	wrapped, ok := WrapTransport(nil).(userAgentTransport)
 	if !ok {
-		t.Fatalf("WrapTransport(nil) = %T, want *httpclient.UserAgentTransport", WrapTransport(nil))
+		t.Fatalf("WrapTransport(nil) = %T, want userAgentTransport", WrapTransport(nil))
 	}
-	if wrapped.Next != http.DefaultTransport {
-		t.Fatalf("Next = %v, want http.DefaultTransport", wrapped.Next)
+	if wrapped.next != http.DefaultTransport {
+		t.Fatalf("next = %v, want http.DefaultTransport", wrapped.next)
 	}
-	if wrapped.UA != UserAgent() {
-		t.Fatalf("UA = %q, want %q", wrapped.UA, UserAgent())
+}
+
+// The version is not known at package-initialization time: main() calls Load()
+// to recover it from build info. A transport built before that — a package-level
+// client like pluginHTTPClient — must still send the resolved version, so the
+// User-Agent has to be read per request rather than captured at construction.
+//
+// Not parallel: it swaps the package-level Version. Go runs sequential top-level
+// tests to completion before parallel ones resume, so the parallel tests above
+// never observe the swap.
+func TestWrapTransport_ResolvesUserAgentPerRequest(t *testing.T) {
+	rec := &uaRecorder{}
+	// Built first, while Version is still the pre-Load default.
+	rt := WrapTransport(rec)
+
+	original := Version
+	t.Cleanup(func() { Version = original })
+	Version = "9.9.9"
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://entire.io/api/v1/x", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	const want = "entire-cli/9.9.9"
+	if got := rec.snapshot(); len(got) != 1 || got[0] != want {
+		t.Fatalf("User-Agent sent = %v, want [%s] — the transport captured the version at construction", got, want)
 	}
 }

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/internal/entireclient/httpclient"
 	"github.com/entireio/cli/internal/entireclient/httputil"
 )
@@ -25,7 +26,11 @@ import (
 // home jurisdiction is another region. Inert for same-jurisdiction calls.
 func newCrossJurisHTTPClient() *http.Client {
 	return &http.Client{
-		Transport: newCrossJurisRoundTripper(httpclient.NewTransport(false)),
+		// The User-Agent wrapper goes *under* the cross-juris round tripper,
+		// not over it. That transport sends requests it builds itself — the
+		// RFC 8693 exchange and the federation manifest fetch, both straight
+		// to t.base — and those bypass anything wrapped outside it.
+		Transport: newCrossJurisRoundTripper(versioninfo.WrapTransport(httpclient.NewTransport(false))),
 	}
 }
 

--- a/internal/coreapi/cross_juris_useragent_test.go
+++ b/internal/coreapi/cross_juris_useragent_test.go
@@ -1,0 +1,114 @@
+package coreapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+)
+
+// uaByHop records the User-Agent each kind of request arrived with. Same
+// cross-goroutine rationale as authRecorder: HTTP completion is not a
+// happens-before edge the race detector recognises, so the map is mutex-guarded.
+type uaByHop struct {
+	mu   sync.Mutex
+	seen map[string][]string
+}
+
+func newUAByHop() *uaByHop { return &uaByHop{seen: make(map[string][]string)} }
+
+func (u *uaByHop) add(hop string, r *http.Request) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.seen[hop] = append(u.seen[hop], r.Header.Get("User-Agent"))
+}
+
+func (u *uaByHop) snapshot() map[string][]string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	out := make(map[string][]string, len(u.seen))
+	for hop, vals := range u.seen {
+		out[hop] = append([]string(nil), vals...)
+	}
+	return out
+}
+
+// The control-plane client must send entire-cli/<version> on every request it
+// puts on the wire — including the two the cross-juris transport builds itself:
+// the federation manifest fetch and the RFC 8693 exchange. Neither passes
+// through caller code, and both go straight to t.base, so a User-Agent wrapper
+// placed *above* the transport would leave them as Go's default. This test is
+// what pins the wrapper to the base of the chain.
+//
+// It drives newCrossJurisHTTPClient rather than transportFor(t) on purpose:
+// the wiring is what's under test, not the round tripper in isolation.
+func TestNewCrossJurisHTTPClient_StampsUserAgentOnEveryHop(t *testing.T) {
+	t.Parallel()
+	ua := newUAByHop()
+
+	homeCore := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == oauthTokenPath {
+			ua.add("exchange", r)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"home-exchanged-jwt","token_type":"Bearer","expires_in":300}`)) //nolint:errcheck // test
+			return
+		}
+		ua.add("home-api", r)
+		if r.Header.Get("Authorization") == bearerHomeExchanged {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(homeCore.Close)
+
+	// The wrong core 421s to the home core, which makes the transport fetch
+	// the federation manifest before it will follow.
+	wrongCore := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == federationWellKnownPath {
+			ua.add("federation", r)
+			writeTestFederation(w, []string{homeCore.URL})
+			return
+		}
+		ua.add("wrong-api", r)
+		w.WriteHeader(http.StatusMisdirectedRequest)
+		w.Write([]byte(`{"home_core_url":"` + homeCore.URL + `"}`)) //nolint:errcheck // test
+	}))
+	t.Cleanup(wrongCore.Close)
+
+	client := newCrossJurisHTTPClient()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, wrongCore.URL+"/api/v1/mirrors", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer original-login-jwt")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the 421 → federation → exchange chain must complete)", resp.StatusCode)
+	}
+
+	// Every hop must be present: an absent hop means the chain changed shape
+	// and this test silently stopped covering the synthesized requests.
+	hops := ua.snapshot()
+	want := versioninfo.UserAgent()
+	for _, hop := range []string{"wrong-api", "federation", "home-api", "exchange"} {
+		got := hops[hop]
+		if len(got) == 0 {
+			t.Fatalf("no %q request recorded; hops = %v", hop, hops)
+		}
+		for i, sent := range got {
+			if sent != want {
+				t.Errorf("%s request %d: User-Agent = %q, want %q", hop, i, sent, want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1122
<!-- entire-trail-link-end -->

## Summary

Follow-up to #2049. That PR's premise — that `api.Client` already stamped `entire-cli/<version>` on "every other CLI request" — wasn't true. The biggest hole was the control plane: `coreapi.newCrossJurisHTTPClient` wrapped `httpclient.NewTransport` with no `UserAgentTransport`, so **every** `entire org|project|repo|grant|search|api|auth` request went out as `Go-http-client/2.0`.

Fixed at the client constructors, not the call sites, so a new request site can't silently regress — the structural version of a nit raised on #2049.

### What was uncovered

| Client | Reaches | Was sending |
| --- | --- | --- |
| `coreapi.newCrossJurisHTTPClient` | every control-plane call (~20 files' worth of commands) | `Go-http-client/2.0` |
| `auth`'s 3 bare clients, which carry `clusterdiscovery`'s well-known fetch and the cluster-catalog GET | `https://entire.io/.well-known/entire-api.json`, core `/api/v1/clusters` | `Go-http-client/2.0` |
| `pluginHTTPClient` | plugin release assets + `checksums.txt` | `Go-http-client/2.0` |

Already covered, unchanged: `api.Client` and its `bearerTransport` (which is also what entire-api **cell** clients use), `versioncheck`, dispatch (#2049), and `git-remote-entire` + `remotehelper/transport`, which pass their own binary identity.

Audited by enumerating every non-test `http.Client{}` construction and every `http.NewRequest*` site under `cmd/` and `internal/`; each one is now either transport-wrapped or sets the header itself.

### New helper

`versioninfo.WrapTransport` binds `httpclient.UserAgentTransport` to `UserAgent()` in one place rather than repeating the same two lines in three packages. `httpclient` stays binary-agnostic (it still takes `UA` as a field, which is how `git-remote-entire` supplies its own).

`internal/coreapi` importing `cmd/entire/cli/versioninfo` follows what that file already does — it imports `cmd/entire/cli/auth` today — and avoids a startup-order footgun: nothing has to remember to call a setter before the first request.

### The load-bearing detail: wrap innermost

The wrapper goes at the **base** of a transport chain, never on top. `crossJurisRoundTripper` builds two requests of its own — the RFC 8693 token exchange and the federation manifest fetch — and sends both straight to `t.base`, bypassing anything wrapped outside it.

`TestNewCrossJurisHTTPClient_StampsUserAgentOnEveryHop` pins this. Moving the wrapper outside the round tripper makes it fail:

```
federation request 0: User-Agent = "Go-http-client/1.1", want "entire-cli/dev"
exchange request 0:   User-Agent = "Go-http-client/1.1", want "entire-cli/dev"
```

It drives the real `newCrossJurisHTTPClient` rather than the existing `transportFor(t)` helper, because the wiring is what's under test.

## Test plan

- [x] `TestWrapTransport_StampsUserAgent` (table: unset / Go default / caller value) + asserts the caller's own request is not mutated, and `TestWrapTransport_NilNextUsesDefaultTransport`.
- [x] `TestNewCrossJurisHTTPClient_StampsUserAgentOnEveryHop` — 421 → federation manifest → bare 401 → RFC 8693 exchange → retry, asserting the UA on all four hop kinds and failing if any hop stops happening. Mutation-verified above.
- [x] `TestAuthHTTPClients_SendVersionedUserAgent` — table over `dataAPIDiscoveryClient` (https and loopback-http branches, the latter checking the stamp survives `dataAPIHTTPDiscoveryTransport` layered on top) and `cellExchangeHTTPClient`.
- [x] `TestPluginHTTPClient_SendsVersionedUserAgent`.
- [x] New recorders are mutex-guarded, per the `authRecorder` convention in `internal/coreapi`: HTTP completion is not a happens-before edge the race detector recognises.
- [x] `mise run fmt && mise run lint` clean; `mise run test:ci` green.

## Left alone on purpose

- **The OAuth flows send an unversioned UA.** `auth`'s device-flow, auth-code, and refresh clients set `UserAgent: oauthClientID`, i.e. `User-Agent: entire-cli` with no version. That value is deliberately the OAuth client ID and it is read by the **login server**, not the BFF, so retargeting it is a server-coupled product call rather than part of a mechanical sweep. Worth deciding separately if login traffic ever needs version attribution.
- **`entire-cli/dev` is not semver.** Local and `go build` binaries send it, and entire.io#3783's gate passes non-semver untouched by design.

## Sequencing note before flipping `CLI_MIN_VERSION`

This makes a large amount of previously-anonymous traffic gate-*visible*, which is the point, but it also means the blast radius of flipping `CLI_MIN_VERSION` grows the moment it ships. Worth letting version telemetry show the real distribution of old clients first. Also worth confirming server-side that the semver parse tolerates prerelease suffixes — nightlies send `entire-cli/0.6.2-nightly.202605160654.ddf1a331`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every control-plane request plus discovery and plugin downloads by changing shared HTTP transports. Behavior is header-only, but wrapping order in the cross-jurisdiction client is load-bearing.
> 
> **Overview**
> Stamps `entire-cli/<version>` on CLI HTTP clients that were still sending Go's default User-Agent, by wrapping transports at construction time rather than at each call site.
> 
> Adds `versioninfo.WrapTransport` and applies it to the control-plane client (innermost, so federation fetch and RFC 8693 exchange are covered), auth discovery/cell-exchange clients, and plugin asset downloads. Tests pin the header on those paths, including every hop of a 421 → federation → exchange chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b37febed32a082ed937cf5e19913c024061926bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->