### PR TITLE
fix(telemetry): only announce skill events the outermost frame saved

### DIFF
--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -244,7 +244,7 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 	// so ErrStateNotFound is the normal first-session path — only warn on
 	// genuinely unexpected errors, matching the rest of this file.
 	var appendedSkillEvents []agent.SkillEvent
-	stateSaved, mutErr := strategy.MutateSessionStateSaved(ctx, event.SessionID, func(state *strategy.SessionState) error {
+	mutErr := strategy.MutateSessionStateOnSaved(ctx, event.SessionID, func(state *strategy.SessionState) error {
 		if state.AdoptedIntoWorktreePath != "" {
 			logging.Info(logCtx, "skipping adopted-away source session start",
 				slog.String("adopted_into_worktree", state.AdoptedIntoWorktreePath))
@@ -256,13 +256,12 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 				slog.String("error", transErr.Error()))
 		}
 		return nil
+	}, func() {
+		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	})
 	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to update session state on start",
 			slog.String("error", mutErr.Error()))
-	}
-	if stateSaved {
-		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	}
 
 	// Opportunistic self-heal: if any session in this repo is a zombie
@@ -637,7 +636,10 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 	// happen for fresh investigate spawns. Both functions short-circuit on
 	// state.Kind != "" to keep the conflict harmless if it ever arises.
 	var appendedSkillEvents []agent.SkillEvent
-	stateSaved, mutErr := strategy.MutateSessionStateSaved(ctx, sessionID, func(state *strategy.SessionState) error {
+	// The telemetry effect is handed to the mutator rather than run here: it
+	// must follow a durable write and must run outside the session gate
+	// (settings load and a process spawn would otherwise extend the lock hold).
+	mutErr := strategy.MutateSessionStateOnSaved(ctx, sessionID, func(state *strategy.SessionState) error {
 		before := *state
 		// Slice fields share their backing array under struct copy. If
 		// adoptReviewEnv ever mutates ReviewSkills in place, the diff check
@@ -668,16 +670,12 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 			return strategy.ErrMutationSkip
 		}
 		return nil
+	}, func() {
+		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	})
 	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to save session state after review/investigate env adoption",
 			slog.String("error", mutErr.Error()))
-	}
-	// Telemetry runs after the session gate is released — settings load and
-	// process spawn must not extend the lock hold (and only after a successful
-	// save, so we never report events that weren't persisted).
-	if stateSaved {
-		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	}
 	initSpan.End()
 
@@ -1079,20 +1077,19 @@ func handleLifecycleCompaction(ctx context.Context, ag agent.Agent, event *agent
 
 	// Fire EventCompaction to trigger ActionCondenseIfFilesTouched (stays in ACTIVE)
 	var appendedSkillEvents []agent.SkillEvent
-	stateSaved, mutErr := strategy.MutateSessionStateSaved(ctx, event.SessionID, func(state *strategy.SessionState) error {
+	mutErr := strategy.MutateSessionStateOnSaved(ctx, event.SessionID, func(state *strategy.SessionState) error {
 		appendedSkillEvents = persistEventMetadataToState(event, state)
 		if transErr := strategy.TransitionAndLog(ctx, state, session.EventCompaction, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
 			logging.Warn(logCtx, "compaction transition failed",
 				slog.String("error", transErr.Error()))
 		}
 		return nil
+	}, func() {
+		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	})
 	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to save session state after compaction",
 			slog.String("error", mutErr.Error()))
-	}
-	if stateSaved {
-		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	}
 
 	logging.Info(logCtx, "context compaction detected")
@@ -1922,7 +1919,7 @@ func recordCaptureDegraded(ctx context.Context, sessionID string, degraded bool)
 func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agent.Event) {
 	logCtx := logging.WithComponent(ctx, "lifecycle")
 	var appendedSkillEvents []agent.SkillEvent
-	stateSaved, mutErr := strategy.MutateSessionStateSaved(ctx, sessionID, func(state *strategy.SessionState) error {
+	mutErr := strategy.MutateSessionStateOnSaved(ctx, sessionID, func(state *strategy.SessionState) error {
 		appendedSkillEvents = persistEventMetadataToState(event, state)
 		if err := strategy.TransitionAndLog(ctx, state, session.EventTurnEnd, session.TransitionContext{}, session.NoOpActionHandler{}); err != nil {
 			logging.Warn(logCtx, "turn-end transition failed",
@@ -1930,7 +1927,8 @@ func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agen
 		}
 		// HandleTurnEnd mutates state in-place; the outer MutateSessionState
 		// save flushes those changes. Any reentrant MutateSessionState calls
-		// it makes on this session ID share this state pointer via the gate.
+		// it makes on this session ID share this state pointer via the gate —
+		// and any post-save effect they register is flushed by this frame.
 		strat := GetStrategy(ctx)
 		// The turn-end finalize extracts skill events from the full transcript
 		// and appends the new ones to state.SkillEvents — snapshot its growth
@@ -1947,13 +1945,12 @@ func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agen
 			appendedSkillEvents = append(appendedSkillEvents, state.SkillEvents[skillEventsBefore:]...)
 		}
 		return nil
+	}, func() {
+		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	})
 	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to update session phase on turn end",
 			slog.String("error", mutErr.Error()))
-	}
-	if stateSaved {
-		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	}
 }
 
@@ -2006,7 +2003,7 @@ const (
 // actually ended.
 func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string, guard func(*strategy.SessionState) bool, when endedAtPolicy) (ended bool, err error) {
 	var appendedSkillEvents []agent.SkillEvent
-	stateSaved, mutErr := strategy.MutateSessionStateSaved(ctx, sessionID, func(state *strategy.SessionState) error {
+	mutErr := strategy.MutateSessionStateOnSaved(ctx, sessionID, func(state *strategy.SessionState) error {
 		if guard != nil && !guard(state) {
 			return strategy.ErrMutationSkip
 		}
@@ -2030,15 +2027,14 @@ func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string,
 		}
 		ended = true
 		return nil
+	}, func() {
+		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	})
 	if errors.Is(mutErr, strategy.ErrStateNotFound) || errors.Is(mutErr, strategy.ErrMutationSkip) {
 		return false, nil
 	}
 	if mutErr != nil {
 		return false, fmt.Errorf("failed to save session state: %w", mutErr)
-	}
-	if stateSaved {
-		strategy.EmitSkillInvocationTelemetry(ctx, appendedSkillEvents)
 	}
 	return ended, nil
 }

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1675,7 +1675,7 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 	var shadowBranchName string
 	var clearAfter bool
 	var newSkillEvents []agent.SkillEvent
-	stateSaved, mutErr := MutateSessionStateSaved(ctx, sessionID, func(state *SessionState) error {
+	mutErr := MutateSessionStateOnSaved(ctx, sessionID, func(state *SessionState) error {
 		if state.PendingCondensationID() != checkpointID {
 			return ErrMutationSkip
 		}
@@ -1726,14 +1726,7 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 		state.PromptAttributions = nil
 		state.PendingPromptAttribution = nil
 		return nil
-	})
-	if errors.Is(mutErr, ErrStateNotFound) {
-		return fmt.Errorf("session not found: %s", sessionID)
-	}
-	if mutErr != nil {
-		return mutErr
-	}
-	if stateSaved {
+	}, func() {
 		// Skill telemetry only. commitCondensedEmitter.emit is deliberately NOT
 		// called here: its payload is commit-scoped (files_committed counts a
 		// commit's files, and prior_ai_history's git-log probe uses --skip=1 to
@@ -1742,6 +1735,12 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 		// meaningless and --skip=1 would exclude an unrelated HEAD. See
 		// newCommitCondensedSignal.
 		EmitSkillInvocationTelemetry(ctx, newSkillEvents)
+	})
+	if errors.Is(mutErr, ErrStateNotFound) {
+		return fmt.Errorf("session not found: %s", sessionID)
+	}
+	if mutErr != nil {
+		return mutErr
 	}
 
 	if clearAfter {
@@ -1861,7 +1860,7 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 
 	var didCondense bool
 	var newSkillEvents []agent.SkillEvent
-	stateSaved, mutErr := MutateSessionStateSaved(ctx, sessionID, func(state *SessionState) error {
+	mutErr := MutateSessionStateOnSaved(ctx, sessionID, func(state *SessionState) error {
 		var preflightErr error
 		shadowBranchName, shouldCondense, preflightErr = prepareEagerCondensation(logCtx, repo, state)
 		if preflightErr != nil || !shouldCondense {
@@ -1908,18 +1907,17 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 		)
 		didCondense = true
 		return nil
+	}, func() {
+		// Skill telemetry only — same reason as CondenseSessionByID: this
+		// condenses the work left over after the last commit, so there is no
+		// commit for the commit-condensed signal to describe.
+		EmitSkillInvocationTelemetry(ctx, newSkillEvents)
 	})
 	if errors.Is(mutErr, ErrStateNotFound) {
 		return nil
 	}
 	if mutErr != nil {
 		return fmt.Errorf("failed to save session state: %w", mutErr)
-	}
-	if stateSaved {
-		// Skill telemetry only — same reason as CondenseSessionByID: this
-		// condenses the work left over after the last commit, so there is no
-		// commit for the commit-condensed signal to describe.
-		EmitSkillInvocationTelemetry(ctx, newSkillEvents)
 	}
 
 	if didCondense && shadowBranchName != "" {

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1062,21 +1062,20 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		iterCtx, iterSpan := processSessionsLoop.Iteration(loopCtx)
 		var newSkillEvents []agent.SkillEvent
 		var condensedSignal *commitCondensedSignal
-		stateSaved, mutErr := MutateSessionStateSaved(iterCtx, sessionID, func(state *SessionState) error {
+		mutErr := MutateSessionStateOnSaved(iterCtx, sessionID, func(state *SessionState) error {
 			newSkillEvents, condensedSignal = s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
 				head, commit, newHead, worktreePath, headTree, parentTree,
 				committedFileSet, shadowBranchesToDelete, uncondensedActiveOnBranch, allAgentFiles,
 				sessionsWithCommittedFiles, condensedTelemetry)
 			return nil
+		}, func() {
+			EmitSkillInvocationTelemetry(iterCtx, newSkillEvents)
+			condensedTelemetry.emit(iterCtx, condensedSignal)
 		})
 		if mutErr != nil && !errors.Is(mutErr, ErrStateNotFound) {
 			logging.Warn(logCtx, "post-commit: session mutation failed",
 				slog.String("session_id", sessionID),
 				slog.String("error", mutErr.Error()))
-		}
-		if stateSaved {
-			EmitSkillInvocationTelemetry(iterCtx, newSkillEvents)
-			condensedTelemetry.emit(iterCtx, condensedSignal)
 		}
 		iterSpan.End()
 	}

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"slices"
 	"strconv"
 	"strings"
@@ -535,6 +536,34 @@ func MutateSessionState(ctx context.Context, sessionID string, fn func(*SessionS
 	return MutateSessionStateOnSaved(ctx, sessionID, fn, nil)
 }
 
+// runPostSaveEffect runs one post-save effect, containing a panic to that
+// effect rather than letting it escape.
+//
+// Two things make propagating wrong here, and neither is about the effect being
+// likely to panic. The effects are best-effort telemetry — a settings read and a
+// detached spawn — and they run from the outermost frame's defer, so an escaping
+// panic both skips every effect queued behind it and unwinds out of
+// MutateSessionStateOnSaved into callers that do not recover (PostCommit),
+// killing a git hook mid-commit over a signal that is fail-open everywhere else.
+// Note the asymmetry this closes: a panic in the mutation function is already
+// handled deliberately (the queue is discarded, and the gate is released first
+// so it stays usable), so the effects were the one path where the same
+// discipline was not applied.
+//
+// The panic is logged rather than swallowed. It is a bug wherever it comes from,
+// and .entire/logs is where the next person looks for it; a silent recover would
+// trade a crash for an invisible failure.
+func runPostSaveEffect(ctx context.Context, effect func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			logging.Error(ctx, "post-save effect panicked",
+				slog.Any("panic", r),
+				slog.String("stack", string(debug.Stack())))
+		}
+	}()
+	effect()
+}
+
 // MutateSessionStateOnSaved is MutateSessionState plus onSaved, an effect that
 // runs only once the state fn mutated has been durably written — and never
 // while the session gate is held.
@@ -604,7 +633,7 @@ func MutateSessionStateOnSaved(ctx context.Context, sessionID string, fn func(*S
 		gate.afterSave = nil
 		release()
 		for _, effect := range effects {
-			effect()
+			runPostSaveEffect(ctx, effect)
 		}
 	}()
 

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -473,6 +473,12 @@ type sessionGate struct {
 	depth       int
 	flockRel    func()
 	activeState *SessionState // shared state pointer for nested mutations
+	// afterSave holds post-save effects registered by nested frames, in
+	// registration order. Only the outermost frame saves, so only it can
+	// know whether those effects are owed; it drains this queue (and clears
+	// it) when it exits. Guarded by gate ownership rather than gate.mu: only
+	// the owning goroutine ever touches it.
+	afterSave []func()
 }
 
 // goroutineID extracts the runtime goroutine ID from the stack header. Used
@@ -522,66 +528,112 @@ func goroutineID() int64 {
 // All session-state mutations funnel through this helper so the hot-path
 // PostToolUse hook cannot revert fields written by lifecycle handlers
 // (TurnEnd, PostCommit, ModelUpdate) that ran between our load and our save.
+//
+// A nil return is not proof that anything was written. Callers with a side
+// effect that must follow a durable write want MutateSessionStateOnSaved.
 func MutateSessionState(ctx context.Context, sessionID string, fn func(*SessionState) error) error {
-	_, err := MutateSessionStateSaved(ctx, sessionID, fn)
-	return err
+	return MutateSessionStateOnSaved(ctx, sessionID, fn, nil)
 }
 
-// MutateSessionStateSaved is MutateSessionState plus whether the mutation was
-// actually persisted. A nil error is NOT proof of a save: ErrMutationSkip
-// reports success without writing, so callers with side effects that must only
-// follow a durable write (telemetry that would otherwise double-report a
-// re-derived event) have to distinguish the two.
+// MutateSessionStateOnSaved is MutateSessionState plus onSaved, an effect that
+// runs only once the state fn mutated has been durably written — and never
+// while the session gate is held.
 //
-// saved is true for a nested call whose fn succeeded, because the outer frame
-// flushes those mutations; if that outer frame then skips or fails, the caller
-// has acted on an unsaved change — the same exposure the plain error return
-// always had, and self-correcting for events that later re-derive.
-func MutateSessionStateSaved(ctx context.Context, sessionID string, fn func(*SessionState) error) (saved bool, err error) {
+// It exists because a nil error is not proof of a save (ErrMutationSkip reports
+// success without writing) and because *this* frame is not necessarily the one
+// that saves. Only the outermost frame loads and saves; a nested frame's
+// mutations are flushed by whoever owns that save. So a nested frame cannot
+// answer "was this persisted?" at the moment it returns — the answer arrives
+// later, from a frame further up the stack. Handing the effect to the helper
+// rather than returning a bool moves the decision to the only frame that can
+// make it: nested registrations are queued on the gate, and the outermost frame
+// runs them after its own save succeeds, discarding them if it skips or fails.
+//
+// That distinction is load-bearing for anything irreversible. Skill-invocation
+// telemetry is the motivating case: extraction re-derives from transcript
+// offset 0 on every pass and dedupes against a ledger in session state, so
+// announcing an event whose ledger entry never landed does not self-correct —
+// the next pass sees an unrecorded event and reports it again, duplicating it
+// in PostHog. Not emitting is the recoverable direction: the append is
+// re-derived and re-announced by the next pass.
+//
+// onSaved runs after the gate is released, so its I/O (settings load, detached
+// process spawn) never extends the hold time for a concurrent hook. Effects run
+// in registration order, so nested registrations precede the outermost frame's
+// own effect.
+//
+// One gap this does not close: a nested frame whose fn *errors* has already
+// mutated the shared state, and an outer frame that swallows that error still
+// saves those mutations — with no effect registered. That direction loses an
+// announcement rather than duplicating one, and is inherent to nested frames
+// sharing a state pointer.
+func MutateSessionStateOnSaved(ctx context.Context, sessionID string, fn func(*SessionState) error, onSaved func()) error {
 	if sessionID == "" {
-		return false, ErrStateNotFound
+		return ErrStateNotFound
 	}
 	gate, isOuter, release, err := acquireSessionGate(ctx, sessionID)
 	if err != nil {
-		return false, err
+		return err
 	}
-	defer release()
 
 	if !isOuter {
+		defer release()
 		// Nested call: reuse the outer's state pointer. The outer save will
 		// flush our mutations; we don't load or save here.
 		if gate.activeState == nil {
-			return false, ErrStateNotFound
+			return ErrStateNotFound
 		}
 		if err := fn(gate.activeState); err != nil {
 			if errors.Is(err, ErrMutationSkip) {
-				return false, nil
+				return nil
 			}
-			return false, err
+			return err
 		}
-		return true, nil
+		if onSaved != nil {
+			gate.afterSave = append(gate.afterSave, onSaved)
+		}
+		return nil
 	}
+
+	// Outermost frame: it owns the save, so it owns every queued effect too.
+	// One defer keeps the order explicit — clear the gate's per-frame fields,
+	// drop the lock, then run the effects outside it.
+	var effects []func()
+	defer func() {
+		gate.activeState = nil
+		gate.afterSave = nil
+		release()
+		for _, effect := range effects {
+			effect()
+		}
+	}()
 
 	state, err := LoadSessionState(ctx, sessionID)
 	if err != nil {
-		return false, fmt.Errorf("load session state: %w", err)
+		return fmt.Errorf("load session state: %w", err)
 	}
 	if state == nil {
-		return false, ErrStateNotFound
+		return ErrStateNotFound
 	}
 	gate.activeState = state
-	defer func() { gate.activeState = nil }()
 
 	if err := fn(state); err != nil {
 		if errors.Is(err, ErrMutationSkip) {
-			return false, nil
+			return nil
 		}
-		return false, err
+		return err
 	}
 	if err := SaveSessionState(ctx, state); err != nil {
-		return false, fmt.Errorf("save session state: %w", err)
+		return fmt.Errorf("save session state: %w", err)
 	}
-	return true, nil
+	// Copied out before the defer clears gate.afterSave, into a fresh slice so
+	// the queue never shares a backing array with the gate.
+	effects = make([]func(), 0, len(gate.afterSave)+1)
+	effects = append(effects, gate.afterSave...)
+	if onSaved != nil {
+		effects = append(effects, onSaved)
+	}
+	return nil
 }
 
 // acquireSessionGate takes the per-process gate (in-memory) and, on the

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -627,11 +627,15 @@ func MutateSessionStateOnSaved(ctx context.Context, sessionID string, fn func(*S
 		return fmt.Errorf("save session state: %w", err)
 	}
 	// Copied out before the defer clears gate.afterSave, into a fresh slice so
-	// the queue never shares a backing array with the gate.
-	effects = make([]func(), 0, len(gate.afterSave)+1)
-	effects = append(effects, gate.afterSave...)
-	if onSaved != nil {
-		effects = append(effects, onSaved)
+	// the queue never shares a backing array with the gate. Guarded because the
+	// overwhelmingly common case is a plain MutateSessionState with nothing
+	// queued, and that runs on the PostToolUse hot path — no effects, no alloc.
+	if len(gate.afterSave) > 0 || onSaved != nil {
+		effects = make([]func(), 0, len(gate.afterSave)+1)
+		effects = append(effects, gate.afterSave...)
+		if onSaved != nil {
+			effects = append(effects, onSaved)
+		}
 	}
 	return nil
 }

--- a/cmd/entire/cli/strategy/skill_events.go
+++ b/cmd/entire/cli/strategy/skill_events.go
@@ -38,8 +38,9 @@ func skillEventKey(ev agent.SkillEvent) string {
 // turn-end finalize both re-extract skill events from the full transcript
 // (offset 0) on every run, so without a durable record each pass would
 // re-surface the same events. Callers forward the returned slice to telemetry
-// only after their surrounding MutateSessionState saves the state — an
-// unsaved append is re-derived (and re-returned) by the next pass.
+// from MutateSessionStateOnSaved's post-save effect, so it is announced only
+// once the append is on disk — an unsaved append is re-derived (and
+// re-returned) by the next pass.
 func appendNewSkillEvents(state *SessionState, candidates []agent.SkillEvent) []agent.SkillEvent {
 	if len(candidates) == 0 {
 		return nil

--- a/cmd/entire/cli/strategy/skill_telemetry.go
+++ b/cmd/entire/cli/strategy/skill_telemetry.go
@@ -15,11 +15,13 @@ import (
 // custom names never leave the machine verbatim. Skill names and signal kinds
 // only, never prompt text or transcript content.
 //
-// Call this AFTER the surrounding MutateSessionState returns, never inside its
-// closure: the settings load (disk I/O) and detached-process spawn must not
-// extend the session gate hold time and block concurrent hooks. Emitting only
-// after a successful save also keeps reporting exactly-once — events whose
-// append was never persisted are re-derived by the next extraction pass.
+// Hand this to MutateSessionStateOnSaved as the post-save effect rather than
+// calling it inside the mutation closure. That helper runs the effect only once
+// the state was durably written, and only after the session gate is released:
+// the settings load (disk I/O) and detached-process spawn must not extend the
+// gate hold time and block concurrent hooks, and emitting only after a save
+// keeps reporting exactly-once — events whose append was never persisted are
+// re-derived, and re-announced, by the next extraction pass.
 func EmitSkillInvocationTelemetry(ctx context.Context, events []agent.SkillEvent) {
 	if len(events) == 0 {
 		return

--- a/cmd/entire/cli/strategy/skill_telemetry_test.go
+++ b/cmd/entire/cli/strategy/skill_telemetry_test.go
@@ -225,6 +225,48 @@ func TestMutateSessionStateOnSaved_NestedEffectHeldForTheOuterFrame(t *testing.T
 	}
 }
 
+// A panicking frame never saved, so it must announce nothing — and must leave
+// the gate usable, since the release happens before the (discarded) effects.
+func TestMutateSessionStateOnSaved_PanicDiscardsQueuedEffects(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+
+	sessionID := "sess-panic-discard"
+	require.NoError(t, (&ManualCommitStrategy{}).InitializeSession(
+		t.Context(), sessionID, agent.AgentTypeClaudeCode, "", "prompt", ""))
+
+	effects := 0
+	func() {
+		defer func() {
+			require.NotNil(t, recover(), "the panic must propagate out of the mutation")
+		}()
+		//nolint:errcheck // the closure panics, so this call never returns a value.
+		MutateSessionStateOnSaved(t.Context(), sessionID, func(_ *SessionState) error {
+			require.NoError(t, MutateSessionStateOnSaved(t.Context(), sessionID,
+				func(nested *SessionState) error {
+					nested.LastPrompt = "written-by-nested"
+					return nil
+				},
+				func() { effects++ },
+			))
+			panic("boom")
+		}, func() { effects++ })
+	}()
+	require.Zero(t, effects, "a panicking frame must not announce anything")
+
+	reloaded, err := LoadSessionState(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotEqual(t, "written-by-nested", reloaded.LastPrompt,
+		"the panic aborted the save, so nothing may be on disk")
+
+	// The gate must be free (release runs before the effects would have) and
+	// the panicking frame's queue must not survive into this one.
+	require.NoError(t, MutateSessionStateOnSaved(t.Context(), sessionID, func(state *SessionState) error {
+		state.StepCount++
+		return nil
+	}, nil))
+	require.Zero(t, effects, "a later frame ran an effect the panicking frame queued")
+}
+
 // The queue is per-frame: effects owed to one outer frame must not fire again
 // for the next one on the same session.
 func TestMutateSessionStateOnSaved_NestedEffectDoesNotLeakToTheNextFrame(t *testing.T) {

--- a/cmd/entire/cli/strategy/skill_telemetry_test.go
+++ b/cmd/entire/cli/strategy/skill_telemetry_test.go
@@ -146,6 +146,10 @@ func TestEmitSkillInvocationTelemetry_RunsOutsideTheSessionGate(t *testing.T) {
 // The "emit only after a durable save" contract: a skipped mutation runs no
 // post-save effect, so callers never announce events the next extraction pass
 // will re-derive.
+// nestedPrompt is the marker a nested frame writes, so a test can tell whether
+// the outer frame flushed the nested mutation to disk.
+const nestedPrompt = "written-by-nested"
+
 func TestMutateSessionStateOnSaved_SkipRunsNoEffect(t *testing.T) {
 	writeTelemetrySettings(t, "true")
 
@@ -197,7 +201,7 @@ func TestMutateSessionStateOnSaved_NestedEffectHeldForTheOuterFrame(t *testing.T
 			var effects []string
 			err := MutateSessionStateOnSaved(t.Context(), sessionID, func(_ *SessionState) error {
 				nestedErr := MutateSessionStateOnSaved(t.Context(), sessionID, func(nested *SessionState) error {
-					nested.LastPrompt = "written-by-nested"
+					nested.LastPrompt = nestedPrompt
 					return nil
 				}, func() { effects = append(effects, "nested") })
 				require.NoError(t, nestedErr)
@@ -215,10 +219,10 @@ func TestMutateSessionStateOnSaved_NestedEffectHeldForTheOuterFrame(t *testing.T
 			reloaded, loadErr := LoadSessionState(t.Context(), sessionID)
 			require.NoError(t, loadErr)
 			if tt.outerResult == nil {
-				require.Equal(t, "written-by-nested", reloaded.LastPrompt,
+				require.Equal(t, nestedPrompt, reloaded.LastPrompt,
 					"the outer save must flush the nested mutation")
 			} else {
-				require.NotEqual(t, "written-by-nested", reloaded.LastPrompt,
+				require.NotEqual(t, nestedPrompt, reloaded.LastPrompt,
 					"no save happened, so the nested mutation must not be on disk")
 			}
 		})
@@ -243,7 +247,7 @@ func TestMutateSessionStateOnSaved_PanicDiscardsQueuedEffects(t *testing.T) {
 		MutateSessionStateOnSaved(t.Context(), sessionID, func(_ *SessionState) error {
 			require.NoError(t, MutateSessionStateOnSaved(t.Context(), sessionID,
 				func(nested *SessionState) error {
-					nested.LastPrompt = "written-by-nested"
+					nested.LastPrompt = nestedPrompt
 					return nil
 				},
 				func() { effects++ },
@@ -255,7 +259,7 @@ func TestMutateSessionStateOnSaved_PanicDiscardsQueuedEffects(t *testing.T) {
 
 	reloaded, err := LoadSessionState(t.Context(), sessionID)
 	require.NoError(t, err)
-	require.NotEqual(t, "written-by-nested", reloaded.LastPrompt,
+	require.NotEqual(t, nestedPrompt, reloaded.LastPrompt,
 		"the panic aborted the save, so nothing may be on disk")
 
 	// The gate must be free (release runs before the effects would have) and
@@ -290,4 +294,46 @@ func TestMutateSessionStateOnSaved_NestedEffectDoesNotLeakToTheNextFrame(t *test
 		return nil
 	}, nil))
 	require.Equal(t, 1, nestedRuns, "a later frame re-ran an effect it did not own")
+}
+
+// A panicking effect must not take the effects queued behind it down with it,
+// and must not escape into callers that do not recover — PostCommit would die
+// mid-commit over best-effort telemetry. The panic in the MUTATION function is
+// already covered above; this is the same discipline applied to the effects,
+// which is where it was missing.
+func TestMutateSessionStateOnSaved_PanickingEffectDoesNotSkipTheRest(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+
+	sessionID := "sess-effect-panic"
+	require.NoError(t, (&ManualCommitStrategy{}).InitializeSession(
+		t.Context(), sessionID, agent.AgentTypeClaudeCode, "", "prompt", ""))
+
+	var effects []string
+	err := MutateSessionStateOnSaved(t.Context(), sessionID, func(_ *SessionState) error {
+		nestedErr := MutateSessionStateOnSaved(t.Context(), sessionID, func(nested *SessionState) error {
+			nested.LastPrompt = nestedPrompt
+			return nil
+		}, func() {
+			effects = append(effects, "nested")
+			panic("effect boom")
+		})
+		require.NoError(t, nestedErr)
+		return nil
+	}, func() { effects = append(effects, "outer") })
+
+	require.NoError(t, err, "an effect's panic must not surface as the mutation's error")
+	require.Equal(t, []string{"nested", "outer"}, effects,
+		"the outer effect must still run after the nested one panicked")
+
+	// The save itself happened before any effect ran, so the panic must not
+	// have cost the mutation.
+	reloaded, loadErr := LoadSessionState(t.Context(), sessionID)
+	require.NoError(t, loadErr)
+	require.Equal(t, nestedPrompt, reloaded.LastPrompt)
+
+	// The gate must still be usable: release() runs before the effects.
+	require.NoError(t, MutateSessionStateOnSaved(t.Context(), sessionID, func(state *SessionState) error {
+		state.LastPrompt = "after-panic"
+		return nil
+	}, func() {}))
 }

--- a/cmd/entire/cli/strategy/skill_telemetry_test.go
+++ b/cmd/entire/cli/strategy/skill_telemetry_test.go
@@ -1,8 +1,10 @@
 package strategy
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -128,44 +130,122 @@ func TestEmitSkillInvocationTelemetry_RunsOutsideTheSessionGate(t *testing.T) {
 	t.Cleanup(func() { emitSkillTelemetry = prev })
 
 	var appended []agent.SkillEvent
-	saved, err := MutateSessionStateSaved(t.Context(), sessionID, func(state *SessionState) error {
-		appended = AppendNewSkillEvents(state, []agent.SkillEvent{telemetrySkillEvent("a")})
-		return nil
-	})
-	require.NoError(t, err)
-	require.True(t, saved)
+	require.NoError(t, MutateSessionStateOnSaved(t.Context(), sessionID,
+		func(state *SessionState) error {
+			appended = AppendNewSkillEvents(state, []agent.SkillEvent{telemetrySkillEvent("a")})
+			return nil
+		},
+		func() { EmitSkillInvocationTelemetry(t.Context(), appended) },
+	))
 	require.Len(t, appended, 1)
-
-	EmitSkillInvocationTelemetry(t.Context(), appended)
 
 	require.True(t, emitterWritePersisted,
 		"the emitter's mutation did not persist, so it ran nested inside the session gate")
 }
 
-// The "emit only after a durable save" contract: a skipped mutation reports no
-// save, so callers never announce events the next extraction pass will re-derive.
-func TestMutateSessionStateSaved_ReportsSkipAsUnsaved(t *testing.T) {
+// The "emit only after a durable save" contract: a skipped mutation runs no
+// post-save effect, so callers never announce events the next extraction pass
+// will re-derive.
+func TestMutateSessionStateOnSaved_SkipRunsNoEffect(t *testing.T) {
 	writeTelemetrySettings(t, "true")
 
 	sessionID := "sess-skip-report"
 	require.NoError(t, (&ManualCommitStrategy{}).InitializeSession(
 		t.Context(), sessionID, agent.AgentTypeClaudeCode, "", "prompt", ""))
 
-	saved, err := MutateSessionStateSaved(t.Context(), sessionID, func(state *SessionState) error {
+	effects := 0
+	err := MutateSessionStateOnSaved(t.Context(), sessionID, func(state *SessionState) error {
 		state.LastPrompt = "not-persisted"
 		return ErrMutationSkip
-	})
+	}, func() { effects++ })
 	require.NoError(t, err, "ErrMutationSkip is not an error")
-	require.False(t, saved, "a skipped mutation must not report itself as saved")
+	require.Zero(t, effects, "a skipped mutation must not run its post-save effect")
 
 	reloaded, err := LoadSessionState(t.Context(), sessionID)
 	require.NoError(t, err)
 	require.NotEqual(t, "not-persisted", reloaded.LastPrompt, "skip must not have written")
 
-	saved, err = MutateSessionStateSaved(t.Context(), sessionID, func(state *SessionState) error {
+	require.NoError(t, MutateSessionStateOnSaved(t.Context(), sessionID, func(state *SessionState) error {
 		state.LastPrompt = "persisted"
 		return nil
-	})
-	require.NoError(t, err)
-	require.True(t, saved)
+	}, func() { effects++ }))
+	require.Equal(t, 1, effects, "a saved mutation must run its post-save effect exactly once")
+}
+
+// A nested frame does not save, so it cannot know whether its mutation lands.
+// When the outer frame skips, the nested frame's effect must not run: for skill
+// telemetry the ledger entry never landed, so the next extraction pass
+// re-derives the event — and an announcement made here would duplicate it.
+func TestMutateSessionStateOnSaved_NestedEffectHeldForTheOuterFrame(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+
+	tests := []struct {
+		name        string
+		outerResult error
+		wantEffects []string
+	}{
+		{"outer saves", nil, []string{"nested", "outer"}},
+		{"outer skips", ErrMutationSkip, nil},
+		{"outer fails", errors.New("boom"), nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessionID := "sess-nested-" + strings.ReplaceAll(tt.name, " ", "-")
+			require.NoError(t, (&ManualCommitStrategy{}).InitializeSession(
+				t.Context(), sessionID, agent.AgentTypeClaudeCode, "", "prompt", ""))
+
+			var effects []string
+			err := MutateSessionStateOnSaved(t.Context(), sessionID, func(_ *SessionState) error {
+				nestedErr := MutateSessionStateOnSaved(t.Context(), sessionID, func(nested *SessionState) error {
+					nested.LastPrompt = "written-by-nested"
+					return nil
+				}, func() { effects = append(effects, "nested") })
+				require.NoError(t, nestedErr)
+				require.Empty(t, effects, "the nested effect must not run while the outer frame is still open")
+				return tt.outerResult
+			}, func() { effects = append(effects, "outer") })
+
+			if tt.outerResult == nil || errors.Is(tt.outerResult, ErrMutationSkip) {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tt.outerResult)
+			}
+			require.Equal(t, tt.wantEffects, effects)
+
+			reloaded, loadErr := LoadSessionState(t.Context(), sessionID)
+			require.NoError(t, loadErr)
+			if tt.outerResult == nil {
+				require.Equal(t, "written-by-nested", reloaded.LastPrompt,
+					"the outer save must flush the nested mutation")
+			} else {
+				require.NotEqual(t, "written-by-nested", reloaded.LastPrompt,
+					"no save happened, so the nested mutation must not be on disk")
+			}
+		})
+	}
+}
+
+// The queue is per-frame: effects owed to one outer frame must not fire again
+// for the next one on the same session.
+func TestMutateSessionStateOnSaved_NestedEffectDoesNotLeakToTheNextFrame(t *testing.T) {
+	writeTelemetrySettings(t, "true")
+
+	sessionID := "sess-nested-no-leak"
+	require.NoError(t, (&ManualCommitStrategy{}).InitializeSession(
+		t.Context(), sessionID, agent.AgentTypeClaudeCode, "", "prompt", ""))
+
+	nestedRuns := 0
+	require.NoError(t, MutateSessionStateOnSaved(t.Context(), sessionID, func(_ *SessionState) error {
+		return MutateSessionStateOnSaved(t.Context(), sessionID, func(nested *SessionState) error {
+			nested.StepCount++
+			return nil
+		}, func() { nestedRuns++ })
+	}, nil))
+	require.Equal(t, 1, nestedRuns)
+
+	require.NoError(t, MutateSessionStateOnSaved(t.Context(), sessionID, func(state *SessionState) error {
+		state.StepCount++
+		return nil
+	}, nil))
+	require.Equal(t, 1, nestedRuns, "a later frame re-ran an effect it did not own")
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1124
<!-- entire-trail-link-end -->

Review feedback on #2023 that I missed before it landed.

`MutateSessionStateSaved` reported `saved=true` for a **nested** frame on the grounds that the outer frame flushes its mutations. That is a prediction, not a fact: if the outer frame then returns `ErrMutationSkip` or fails, the caller has already emitted telemetry for an append that never reached disk. The landed doc comment waved this off as "the same exposure the plain error return always had, and self-correcting for events that later re-derive" — which is wrong in the second half, and re-derivation is precisely the mechanism that makes it worse:

- extraction re-derives skill events from transcript offset 0 on **every** pass;
- dedupe is against the ledger in session state (`state.SkillEvents`);
- so an event whose ledger entry never landed is re-derived next pass, returned as new, and announced a **second** time.

The result is duplicate `cli_skill_invoked` events in PostHog — exactly what the ledger exists to prevent. Not emitting is the recoverable direction; emitting early is not.

## The fix

Replace the bool with `MutateSessionStateOnSaved(ctx, id, fn, onSaved)`. The caller hands the effect to the helper instead of deciding from a return value it cannot trust, and the helper runs it from the only frame that knows whether a save happened:

- a nested frame **queues** its effect on the session gate;
- the outermost frame drains the queue after its own save succeeds, and discards it when it skips, fails, or panics;
- effects still run after `release()`, so the settings load and detached-process spawn never extend the gate hold.

`MutateSessionState` becomes a one-line wrapper (`onSaved = nil`), so the migrated call sites lose their `stateSaved` branch rather than gaining a new concept.

A panicking effect is contained to that effect (`runPostSaveEffect`), so it neither skips the effects queued behind it nor unwinds into callers that don't recover — `PostCommit` is one, and a telemetry bug should not kill a git hook mid-commit over a signal that is fail-open everywhere else. It logs rather than swallows: a panic is a bug wherever it comes from, and a silent recover would trade a crash for an invisible failure. This closes the one path where the panic discipline already applied to the mutation function was missing.

## Scope

**No behavior change today.** I traced every `Saved` call site before writing this: `handleLifecycleSessionStart`, `handleLifecycleTurnStart`, `handleLifecycleCompaction`, `transitionSessionTurnEnd`, `markSessionEnded`, `PostCommit`, `CondenseSessionByID`, and `CondenseAndMarkFullyCondensed` are all reached only at hook-handler or command-body level, so the nested branch is currently unreachable. This closes it as a landmine, not as a live duplicate — the next refactor that moves one of those handlers under a gate (`transitionSessionTurnEnd` already runs `HandleTurnEnd`, with its reentrant mutations, inside its own closure) would have gotten silent PostHog duplicates with no failing test.

One gap deliberately left open and documented on the helper: a nested frame whose `fn` *errors* has already mutated the shared state, and an outer frame that swallows that error still saves those mutations, with no effect registered. That direction loses an announcement rather than duplicating one, and is inherent to nested frames sharing a state pointer.

Also updates the contract doc comments in `skill_events.go` and `skill_telemetry.go` that told callers to emit "after the surrounding `MutateSessionState` returns" to name the new helper.

## Tests

The nested contract as a table — outer saves / skips / fails — asserting the effect never runs while the outer frame is still open, that a skipped outer frame leaves the nested mutation off disk, and that a queued effect does not leak into the next frame on the same session. Plus the panic cases from both directions: a panicking *mutation* discards the queue and leaves the gate usable, and a panicking *effect* does not stop the effects behind it or surface as the mutation's error.

Verified each case fails against the old behavior — patching the nested branch to call `onSaved()` inline reproduces the three nested failures, and reverting `runPostSaveEffect` to a bare `effect()` call lets the panic escape and crash the test binary. The existing "runs outside the session gate" test keeps its durability probe, now driven through the new helper.

Verified green: `mise run lint` 0 issues, all packages, plus both canary suites (56 Vogon, 4 roger-roger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
