### PR TITLE
perf(telemetry): resolve the machine ID once per process, not once per event

### DIFF
--- a/cmd/entire/cli/telemetry/checkpoint_policy.go
+++ b/cmd/entire/cli/telemetry/checkpoint_policy.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"runtime"
 	"time"
-
-	"github.com/denisbrodbeck/machineid"
 )
 
 // Property values for the checkpoint_policy_blocked event.
@@ -37,7 +35,7 @@ type CheckpointPolicyBlockedEvent struct {
 // BuildCheckpointPolicyBlockedPayload constructs the event payload. Exported for
 // testing. Returns nil if the machine ID cannot be resolved.
 func BuildCheckpointPolicyBlockedPayload(event CheckpointPolicyBlockedEvent, version string) *EventPayload {
-	machineID, err := machineid.ProtectedID("entire-cli")
+	machineID, err := telemetryMachineID()
 	if err != nil {
 		return nil
 	}

--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/denisbrodbeck/machineid"
 	"github.com/entireio/cli/cmd/entire/cli/execx"
 	"github.com/posthog/posthog-go"
 	"github.com/spf13/cobra"
@@ -49,7 +48,7 @@ func BuildEventPayload(cmd *cobra.Command, agent string, isEntireEnabled bool, v
 	}
 
 	// Get machine ID for distinct_id
-	machineID, err := machineid.ProtectedID("entire-cli")
+	machineID, err := telemetryMachineID()
 	if err != nil {
 		return nil
 	}
@@ -192,7 +191,7 @@ func BuildPluginEventPayload(pluginName string, isEntireEnabled bool, version st
 		return nil
 	}
 
-	machineID, err := machineid.ProtectedID("entire-cli")
+	machineID, err := telemetryMachineID()
 	if err != nil {
 		return nil
 	}
@@ -257,7 +256,7 @@ func BuildSkillEventPayload(inv SkillInvocation, isEntireEnabled bool, version s
 		return nil
 	}
 
-	machineID, err := machineid.ProtectedID("entire-cli")
+	machineID, err := telemetryMachineID()
 	if err != nil {
 		return nil
 	}

--- a/cmd/entire/cli/telemetry/machine_id.go
+++ b/cmd/entire/cli/telemetry/machine_id.go
@@ -1,0 +1,47 @@
+package telemetry
+
+import (
+	"sync"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+// machineIDAppKey scopes the derived ID to this application, so the value sent
+// to PostHog is not the raw platform UUID.
+const machineIDAppKey = "entire-cli"
+
+// machineid.ProtectedID is not a cheap lookup. On macOS it shells out to
+// `ioreg -rd1 -c IOPlatformExpertDevice` (measured p50 11.8ms); Linux and
+// Windows read a file or the registry. Every payload builder needs the same
+// value, and payload builders run in loops — TrackSkillInvocationsDetached
+// builds one per skill event — so an uncached call made the per-event cost
+// 11.6ms and put 218ms of blocking `ioreg` on the hook path for a 20-event
+// batch. The machine ID cannot change while the process runs, so resolve it
+// once. paths.WorktreeRoot memoizes `git rev-parse` for the same reason.
+//
+// The error is cached too: a failed lookup means telemetry is skipped (callers
+// treat it as "no payload"), and retrying it once per event would reintroduce
+// exactly the per-event subprocess this exists to remove.
+
+// machineIDResolver performs the underlying platform lookup. Swapped by tests.
+//
+//nolint:gochecknoglobals // test seam, set and restored by in-package tests.
+var machineIDResolver = func() (string, error) { return machineid.ProtectedID(machineIDAppKey) }
+
+// cachedMachineID memoizes machineIDResolver for the process lifetime.
+//
+//nolint:gochecknoglobals // process-lifetime memoization, reset only by tests.
+var cachedMachineID = sync.OnceValues(func() (string, error) { return machineIDResolver() })
+
+// telemetryMachineID returns the app-scoped machine ID used as the PostHog
+// distinct ID, resolving it at most once per process.
+func telemetryMachineID() (string, error) {
+	return cachedMachineID()
+}
+
+// resetMachineIDCacheForTest clears the memoized value so a test can install a
+// different resolver. Not safe for concurrent use; callers must not run in
+// parallel with anything that builds a payload.
+func resetMachineIDCacheForTest() {
+	cachedMachineID = sync.OnceValues(func() (string, error) { return machineIDResolver() })
+}

--- a/cmd/entire/cli/telemetry/machine_id_test.go
+++ b/cmd/entire/cli/telemetry/machine_id_test.go
@@ -1,0 +1,123 @@
+package telemetry
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// testMachineID is the value the stub resolver returns.
+const testMachineID = "machine-abc"
+
+// withMachineIDResolver installs a resolver and clears the memoized value,
+// restoring both afterwards. Not parallel-safe: these tests mutate package
+// state, like the other seam-driven tests in this package.
+func withMachineIDResolver(t *testing.T, fn func() (string, error)) {
+	t.Helper()
+	prev := machineIDResolver
+	machineIDResolver = fn
+	resetMachineIDCacheForTest()
+	t.Cleanup(func() {
+		machineIDResolver = prev
+		resetMachineIDCacheForTest()
+	})
+}
+
+// The contract that matters: payload builders run in loops, so the platform
+// lookup must happen once per process no matter how many payloads are built.
+// On macOS each miss is an `ioreg` subprocess (~11.8ms), which is what made a
+// 20-event batch cost 218ms of blocking hook time.
+func TestTelemetryMachineID_ResolvesOncePerProcess(t *testing.T) {
+	var calls int
+	withMachineIDResolver(t, func() (string, error) {
+		calls++
+		return testMachineID, nil
+	})
+
+	inv := SkillInvocation{Skill: "entire", Agent: "claude-code",
+		Signal: "prompt_slash_command", EventType: "prompt_invocation"}
+	for range 20 {
+		if p := BuildSkillEventPayload(inv, true, "1.0.0"); p == nil {
+			t.Fatal("BuildSkillEventPayload returned nil")
+		}
+	}
+	// Other event types share the same cache.
+	if p := BuildPluginEventPayload("entire-review", true, "1.0.0"); p == nil {
+		t.Fatal("BuildPluginEventPayload returned nil")
+	}
+
+	if calls != 1 {
+		t.Errorf("platform lookup ran %d times, want 1", calls)
+	}
+}
+
+func TestTelemetryMachineID_ReturnsCachedValue(t *testing.T) {
+	withMachineIDResolver(t, func() (string, error) { return testMachineID, nil })
+
+	first, err := telemetryMachineID()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	second, err := telemetryMachineID()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if first != testMachineID || second != first {
+		t.Errorf("got %q then %q, want both %q", first, second, testMachineID)
+	}
+}
+
+// A failed lookup is cached deliberately: callers treat it as "no payload", and
+// retrying per event would reintroduce the per-event subprocess.
+func TestTelemetryMachineID_CachesFailureAndDropsPayload(t *testing.T) {
+	var calls int
+	wantErr := errors.New("ioreg unavailable")
+	withMachineIDResolver(t, func() (string, error) {
+		calls++
+		return "", wantErr
+	})
+
+	inv := SkillInvocation{Skill: "entire", Agent: "claude-code",
+		Signal: "prompt_slash_command", EventType: "prompt_invocation"}
+	for range 5 {
+		if p := BuildSkillEventPayload(inv, true, "1.0.0"); p != nil {
+			t.Fatal("expected nil payload when the machine ID is unavailable")
+		}
+	}
+	if calls != 1 {
+		t.Errorf("platform lookup ran %d times, want 1", calls)
+	}
+	if _, err := telemetryMachineID(); !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want %v", err, wantErr)
+	}
+}
+
+// sync.OnceValues must serialize concurrent first callers to a single lookup.
+func TestTelemetryMachineID_ConcurrentCallersResolveOnce(t *testing.T) {
+	var mu sync.Mutex
+	var calls int
+	withMachineIDResolver(t, func() (string, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return testMachineID, nil
+	})
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if id, err := telemetryMachineID(); err != nil || id != testMachineID {
+				t.Errorf("got (%q, %v)", id, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Errorf("platform lookup ran %d times under concurrency, want 1", calls)
+	}
+}

--- a/cmd/entire/cli/telemetry/machine_id_test.go
+++ b/cmd/entire/cli/telemetry/machine_id_test.go
@@ -10,10 +10,18 @@ import (
 const testMachineID = "machine-abc"
 
 // withMachineIDResolver installs a resolver and clears the memoized value,
-// restoring both afterwards. Not parallel-safe: these tests mutate package
-// state, like the other seam-driven tests in this package.
+// restoring both afterwards.
+//
+// Swapping package state is only safe because a caller cannot be parallel: Go
+// resumes parallel top-level tests after every sequential one has finished, so
+// the parallel payload-builder tests in this package never overlap this window.
+// The t.Setenv call enforces that rather than documenting it — Go panics with
+// "test using t.Setenv or t.Chdir can not use t.Parallel" if anyone adds
+// t.Parallel() to a test that calls this, instead of it silently becoming a
+// data race on the globals below.
 func withMachineIDResolver(t *testing.T, fn func() (string, error)) {
 	t.Helper()
+	t.Setenv("ENTIRE_TEST_MACHINE_ID_SEAM", "1")
 	prev := machineIDResolver
 	machineIDResolver = fn
 	resetMachineIDCacheForTest()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1125
<!-- entire-trail-link-end -->

`machineid.ProtectedID` is not a cheap lookup. On macOS it shells out to `ioreg -rd1 -c IOPlatformExpertDevice` (measured p50 **11.8 ms**); Linux reads a file, Windows the registry. Nothing cached it, and every payload builder calls it — including `BuildSkillEventPayload`, which `TrackSkillInvocationsDetached` runs **once per skill event**.

So the per-event cost was a subprocess, paid synchronously in the parent hook process. Measured on the pre-fix code with the detached spawn hooked out, so this is parent-side blocking time only:

| events | parent-side blocking |
| --- | --- |
| 1 | 11.5 ms |
| 5 | 55.9 ms |
| 20 | **217.6 ms** |

Linear at ~11.6 ms/event.

#2023 batched the detached sends specifically to remove per-event process cost — but those spawns were *non-blocking*, and the blocking `ioreg` calls it left behind were the dominant term. Removing the 10-event cap in the same change (correct for data fidelity) also removed the accidental ~115 ms bound on this, and the uncapped path is exactly the one that drains a session's whole skill-event backlog in one call.

## The fix

Resolve it once per process with `sync.OnceValues`. The machine ID cannot change while the process runs.

A 20-event batch goes from 217.6 ms to one resolve plus ~60 µs of payload building, and the cost stops scaling with event count. All four builders share the cache, so a hook that emits skill events and (with #2024) a commit-condensed event pays one lookup between them — and every `entire` command drops ~11.6 ms from `BuildEventPayload`.

`paths.WorktreeRoot` memoizes `git rev-parse` for the same reason; this follows that precedent rather than inventing a pattern.

The error is cached too, deliberately: a failed lookup means callers skip telemetry (nil payload), and retrying per event would reintroduce the subprocess this removes.

## Deliberately not done

Two further steps, both out of scope here:

- **Resolving the ID in the detached child**, next to `gitVersion` — that would take it to zero on the hook path, but `DistinctID` is set by the parent today, and `SendEvents` is lenient precisely because a self-update can hand a payload to a different build. An older child receiving an empty `DistinctID` would send events with none.
- **Persisting it to the cache dir**, which would make even the first call free. That writes a derived machine identifier to disk, which is a product call, not a perf one.

## Tests

The contract that matters, each verified to fail against the unfixed behavior:

- one platform lookup per process across 20 payload builds and across event types (fails with 21)
- a cached failure still drops payloads and does not retry (fails with 5)
- 32 concurrent first callers resolve once (fails with 32)

`mise run fmt`, `mise run lint` clean. 9,645 unit / 529 integration / canary 56+4 all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal telemetry memoization only; distinct ID derivation and skip-on-failure behavior are unchanged.
> 
> **Overview**
> Stops resolving `machineid.ProtectedID` on every telemetry payload. That lookup shells out to `ioreg` on macOS (~12ms) and was running once per skill event, so a 20-event batch blocked ~218ms on the parent hook path.
> 
> All payload builders now share `telemetryMachineID()`, which uses `sync.OnceValues` for process-lifetime caching (success and failure). Tests cover once-per-process across event types, cached failures dropping payloads, and concurrent first callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d577546cc78d942f9eaed09ffe225f5baab6287. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->