### PR TITLE
fix(sweep): own the half-ended session shape

### DIFF
--- a/cmd/entire/cli/session_sweep.go
+++ b/cmd/entire/cli/session_sweep.go
@@ -43,8 +43,12 @@ func isSweepableZombie(st *session.State, now time.Time) bool {
 	if !st.IsEnded() {
 		return st.OwnerExited()
 	}
-	if st.Phase != session.PhaseEnded || st.FullyCondensed ||
-		(st.StepCount <= 0 && !st.HasTaskContent()) {
+	// Reaching here means IsEnded() — Phase is ENDED, or EndedAt is stamped
+	// while Phase says otherwise. That second shape is real (State.IsEnded:
+	// "a legacy record, or a partial write"), and re-testing Phase here would
+	// drop it: finalizeExitedSessions already skips it because OwnerExited is
+	// false once IsEnded, so a Phase test here would leave it owned by nobody.
+	if st.FullyCondensed || (st.StepCount <= 0 && !st.HasTaskContent()) {
 		return false
 	}
 	ref := st.EndedAt
@@ -114,12 +118,12 @@ func runSessionSweep(ctx context.Context) error {
 
 	now := time.Now()
 	for _, st := range states {
-		// ENDED-only here: non-ended zombies were finalizeExitedSessions' job
+		// Ended-only here: non-ended zombies were finalizeExitedSessions' job
 		// above. isSweepableZombie returns true for a non-ended dead-owner
-		// session (its finalize failed above), so this phase check is what
-		// keeps those out of the condense path — and skips their pointless
-		// re-load.
-		if st.Phase != session.PhaseEnded || !isSweepableZombie(st, now) {
+		// session (its finalize failed above), so this check is what keeps
+		// those out of the condense path — and skips their pointless re-load.
+		// IsEnded, not Phase: see isSweepableZombie on the half-ended shape.
+		if !st.IsEnded() || !isSweepableZombie(st, now) {
 			continue
 		}
 		// Re-load and re-check right before acting: the snapshot may be stale
@@ -135,7 +139,7 @@ func runSessionSweep(ctx context.Context) error {
 		if fresh == nil {
 			continue // benign: state removed/cleaned up between list and load
 		}
-		if fresh.Phase != session.PhaseEnded || !isSweepableZombie(fresh, now) {
+		if !fresh.IsEnded() || !isSweepableZombie(fresh, now) {
 			continue
 		}
 		if !strategy.IsCondensableEndedSession(repo, fresh) {

--- a/cmd/entire/cli/session_sweep_test.go
+++ b/cmd/entire/cli/session_sweep_test.go
@@ -122,6 +122,20 @@ func TestIsSweepableZombie(t *testing.T) {
 			want: true,
 		},
 		{
+			// EndedAt stamped, Phase left behind: State.IsEnded exists for
+			// exactly this shape ("a legacy record, or a partial write"). It
+			// is ended, so finalizeExitedSessions skips it (OwnerExited is
+			// false once IsEnded) — if the condense half also declined it,
+			// the session would be owned by neither.
+			name: "half-ended state with uncondensed steps is a zombie",
+			state: session.State{
+				Phase:     session.PhaseIdle,
+				EndedAt:   &old,
+				StepCount: 3,
+			},
+			want: true,
+		},
+		{
 			name: "ended with nil EndedAt falls back to LastInteractionTime",
 			state: session.State{
 				Phase:               session.PhaseEnded,
@@ -410,4 +424,60 @@ func TestSweepSessionsCommand_Registered(t *testing.T) {
 	root.SetOut(io.Discard)
 	root.SetErr(io.Discard)
 	require.NoError(t, root.Execute())
+}
+
+// TestRunSessionSweep_CondensesHalfEndedSession — a session can carry EndedAt
+// without PhaseEnded ("a legacy record, or a partial write", per
+// State.IsEnded), and that shape used to fall between the sweep's two halves:
+// finalizeExitedSessions skips it because OwnerExited is false once IsEnded,
+// while the condense half re-tested Phase == PhaseEnded and declined it. Nobody
+// owned it, and doctor's classifySession does not flag it either (the phase
+// switch falls through to default), so only the 7-day stale purge reached it —
+// deleting the uncondensed content rather than condensing it.
+//
+// Not parallel: uses t.Chdir.
+func TestRunSessionSweep_CondensesHalfEndedSession(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	ctx := context.Background()
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	createShadowBranchRef(t, repo, testBaseCommit, "")
+
+	old := time.Now().Add(-48 * time.Hour)
+	halfEnded := &strategy.SessionState{
+		SessionID: "2026-08-22-sweep-half-ended",
+		// EndedAt is stamped but Phase never advanced past IDLE.
+		BaseCommit: testBaseCommit,
+		Phase:      session.PhaseIdle,
+		StepCount:  2,
+		StartedAt:  old.Add(-time.Hour),
+		EndedAt:    &old,
+	}
+	require.NoError(t, strategy.SaveSessionState(ctx, halfEnded))
+
+	require.True(t, isSweepableZombie(halfEnded, time.Now()),
+		"a half-ended session with uncondensed steps must nominate the sweep")
+
+	require.NoError(t, runSessionSweep(ctx))
+
+	states, err := strategy.ListSessionStates(ctx)
+	require.NoError(t, err)
+	byID := map[string]*strategy.SessionState{}
+	for _, st := range states {
+		byID[st.SessionID] = st
+	}
+
+	after, ok := byID["2026-08-22-sweep-half-ended"]
+	require.True(t, ok, "the half-ended session must survive the sweep")
+	assert.False(t, strategy.IsCondensableEndedSession(repo, after),
+		"the half-ended session must no longer hold uncondensed content")
+	// Same two shapes the old-zombie test accepts: the skip path (no
+	// transcript/files, as here) sets FullyCondensed and keeps the phase; a
+	// full condense resets Phase to IDLE and StepCount to 0. Either proves
+	// CondenseSessionByID actually ran rather than the predicate merely
+	// ceasing to match.
+	assert.True(t, after.FullyCondensed || after.StepCount == 0,
+		"the sweep must have condensed the half-ended session, not just skipped it")
 }

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -16,7 +16,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
-	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 
 	"github.com/go-git/go-git/v6"
@@ -138,7 +137,11 @@ func (s *ManualCommitStrategy) listAllSessionStates(ctx context.Context) ([]*Ses
 // Used by the PostCommit stale-session warning and the background zombie
 // sweep.
 func IsCondensableEndedSession(repo *git.Repository, state *SessionState) bool {
-	if state.Phase != session.PhaseEnded || state.FullyCondensed ||
+	// IsEnded, not Phase == PhaseEnded: a state can carry EndedAt without the
+	// phase (State.IsEnded: "a legacy record, or a partial write"), and such a
+	// session holds uncondensed content just the same. Testing Phase here made
+	// the sweep's nomination and its condense gate disagree on that shape.
+	if !state.IsEnded() || state.FullyCondensed ||
 		(state.StepCount <= 0 && !state.HasTaskContent()) {
 		return false
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1126
<!-- entire-trail-link-end -->

Follow-up to #2029 (trail 1073), from re-reviewing it after the fixes landed.

## Problem

A session state can carry `EndedAt` without `PhaseEnded`. `State.IsEnded` exists for exactly that shape, and its doc names it:

> Both halves matter and neither implies the other in practice: Phase is what the state machine sets, EndedAt is what the finalizing write stamps, and a state file can carry one without the other (a legacy record, or a partial write). Callers that filter for active sessions must agree on this rule, so it lives here rather than being re-spelled at each site.

The sweep re-spelled it, and its two halves ended up disagreeing. `isSweepableZombie` correctly used `IsEnded()` to route non-ended zombies to `finalizeExitedSessions`, then three lines later re-tested `Phase == PhaseEnded` before nominating a condense.

For a half-ended state, **both halves declined**:

- `finalizeExitedSessions` skips it, because `OwnerExited()` returns false once `IsEnded()`.
- the condense path skipped it on the phase test.

`entire doctor` does not reach it either — `classifySession`’s phase switch falls through to `default: return nil`. So the only thing that ever touched such a session was the 7-day stale purge, which **deletes** the uncondensed content rather than condensing it.

## Fix

Three gates had to move together, and each is independently load-bearing — reverting any one alone fails the new end-to-end test (verified, see below):

| Gate | Change |
| --- | --- |
| `isSweepableZombie` | Drop the `Phase` re-test. Reaching that line already means `IsEnded()`, so the test could only ever exclude the half-ended shape. |
| `runSessionSweep` | Both loop guards keyed on `Phase`, so a nominated half-ended session was skipped before *and* after the fresh re-load. |
| `IsCondensableEndedSession` | Same `Phase` test, so a session that survived both guards was still reported non-condensable. |

## Blast radius

`IsCondensableEndedSession` is shared with the PostCommit stale-session warning, which now also counts half-ended sessions holding uncondensed content. That is the same correction, not a side effect: they are stale and actionable by doctor for the same reason a `PhaseEnded` one is.

## Deliberately not changed

`doctor`’s `classifySession` has the same phase-switch gap, so a half-ended session is still not listed by `entire doctor`. It is a separate command on a separate path, and the sweep now condenses these before doctor would have to. Happy to fold it in if you would rather have the two consistent.

## Verification

`TestRunSessionSweep_CondensesHalfEndedSession` builds the shape end to end (`Phase: PhaseIdle`, `EndedAt` 48h old, `StepCount: 2`, shadow ref present) and asserts the sweep actually condensed it — not merely that the predicate stopped matching. Mutation-probed all three gates:

```
revert isSweepableZombie          -> FAIL "a half-ended session with uncondensed steps must nominate the sweep"
revert runSessionSweep guards     -> FAIL "the half-ended session must no longer hold uncondensed content"
revert IsCondensableEndedSession  -> FAIL "the sweep must have condensed the half-ended session, not just skipped it"
```

Plus a table case in `TestIsSweepableZombie`. `mise run check` clean (fmt, lint 0 issues, unit + integration + canary all green).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which ended sessions the background sweep will condense, including a shared predicate used by PostCommit warnings. Wrong classification could condense a still-live session or keep dropping half-ended ones, but the change aligns with existing `IsEnded` semantics and is covered by a new e2e test.
> 
> **Overview**
> The background session sweep now treats **half-ended** states (`EndedAt` stamped, `Phase` not `ENDED`) as ended zombies instead of leaving them unowned until the 7-day stale purge deletes uncondensed content.
> 
> `isSweepableZombie`, the condense loop in `runSessionSweep`, and `IsCondensableEndedSession` all key off `IsEnded()` rather than `Phase == PhaseEnded`, so nomination, re-load guards, and the condense gate agree. The PostCommit stale-session warning picks up the same shape.
> 
> Adds a table case and an end-to-end sweep test that asserts a half-ended session is actually condensed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 422cb0146d0ba45f7e01b3011f75a7b37d1be409. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->