### PR TITLE
fix(clean): add the logging import dropped by a merge, unbreaking main

### DIFF
--- a/cmd/entire/cli/clean.go
+++ b/cmd/entire/cli/clean.go
@@ -11,6 +11,7 @@ import (
 
 	"charm.land/huh/v2"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1127
<!-- entire-trail-link-end -->

## main does not compile

```
$ go build ./...
cmd/entire/cli/clean.go:485:4: undefined: logging
```

Reproduced on a pristine detached worktree at `origin/main` (fe80c26d2), so it is not local state.

## Why CI did not catch it

A semantic merge conflict — the kind where both sides are individually green:

- **#1877** added a `logging.Debug` call to `deleteTempFiles`, plus the `logging` import.
- **#2002** independently rewrote `clean.go`'s import block (the redaction-cache section).
- The merge (fe80c26d2) took the **import block from main** and the **Debug call from the branch**, so the call landed without its import.

Per-PR CI ran against each branch, where each compiled. Nothing re-ran a build on the merge result.

## Why this restores only the import

The branch also carried a `logging.SetLogLevelGetter` / `logging.Init` / `defer logging.Close()` block in the command's `RunE` that the merge dropped, which looks like more lost work. It is not: **those functions no longer exist.** I tried restoring them and the compiler rejected all three.

Nothing in `cmd/` initializes logging that way any more — `logging.Debug` and friends resolve a logger through `LoggerFromContext(ctx)` and fall back to `slog.Default()`, so the `Debug` call works with no init. The merge's outcome was correct for the current API and only needed the import.

## Verification

- `go build ./...` clean
- `mise run lint` — 0 issues
- `go vet ./cmd/entire/cli/` clean, `cli` package tests pass

## Note on releases

The break is in fe80c26d2 only. Today's nightly (`v0.10.3-nightly.202608230611.b1e086253`) was cut from the **parent**, so no published artifact carries it — but the next nightly build would have failed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line import restore with no behavior change; only unblocks compilation.
> 
> **Overview**
> Restores the `logging` import in `clean.go` so `deleteTempFiles` can compile after a semantic merge conflict left a `logging.Debug` call without its import.
> 
> Does not re-add the dropped `SetLogLevelGetter` / `Init` / `Close` setup — those APIs no longer exist; debug logging now goes through context/`slog.Default()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02ceaa70b60a0885084b230f1d95144ec1aeed64. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->