### PR TITLE
fix(clean): restore dropped logging import to unbreak main

### DIFF
--- a/cmd/entire/cli/clean.go
+++ b/cmd/entire/cli/clean.go
@@ -11,6 +11,7 @@ import (
 
 	"charm.land/huh/v2"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1128
<!-- entire-trail-link-end -->

## Problem

`main` does not compile. Every job in the [E2E Tests run](https://github.com/entireio/cli/actions/runs/32699786438) fails in its `[build]` step — all of them in ~1m20s with the same error, which is why the whole matrix (including Windows) went red at once:

```
# github.com/entireio/cli/cmd/entire/cli
cmd/entire/cli/clean.go:485:4: undefined: logging
```

This is not a test failure. Nothing in the E2E suite actually ran.

## Root cause

Merge commit fe80c26d2 (PR #1877, *fix/opencode-attach-fetch-untracked*) resolved a conflict in `cmd/entire/cli/clean.go` by keeping the body added in f84eb80ab — the `logging.Debug(ctx, "temp file already gone before deletion", ...)` call in the temp-file deletion loop — while dropping `github.com/entireio/cli/cmd/entire/cli/logging` from the import block. f84eb80ab has the import; the merge result does not.

## Fix

Restore the one import line. No behavior change.

## Verification

- `go build ./...` passes (fails on `main` without this)
- `mise run fmt` — no changes
- `mise run lint` — 0 issues

## Follow-up worth considering

The break landed on `main` through a merge whose result was never built. Worth checking whether required checks run against the merge commit rather than the PR head, since a conflict resolution can only be validated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single import restore with no logic, security, or data-handling changes. It only fixes a compile break.
> 
> **Overview**
> Restores the `logging` import in `clean.go` that was dropped during a merge conflict resolution, so `logging.Debug` in `deleteTempFiles` compiles again.
> 
> No behavior change. This unbreaks `main` after every E2E `[build]` job failed with `undefined: logging`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02a29aea7ec3240d944bbc96f28f8a777bff78ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->