### PR TITLE
attach: pasteable retry hint and export-install error cleanup

### DIFF
--- a/cmd/entire/cli/agent/opencode/cli_commands_test.go
+++ b/cmd/entire/cli/agent/opencode/cli_commands_test.go
@@ -165,6 +165,38 @@ func TestRenameOverExisting_ReplacesDestination(t *testing.T) {
 	}
 }
 
+// TestRenameOverExisting_LeavesUserFacingWordingToTheCaller covers the
+// non-contention branch. fetchAndCacheExport owns the "failed to install export
+// file" sentence, so this function passes os.Rename's error through untouched;
+// adding the sentence here too is what produced it twice in one message.
+func TestRenameOverExisting_LeavesUserFacingWordingToTheCaller(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	staged := filepath.Join(dir, ".export-ses_x.json-1")
+	if err := os.WriteFile(staged, []byte("fresh"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A directory at dest makes os.Rename fail on every platform, for a reason
+	// isRenameContention never treats as retryable.
+	dest := filepath.Join(dir, "ses_x.json")
+	if err := os.Mkdir(dest, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	err := renameOverExisting(staged, dest)
+	if err == nil {
+		t.Fatal("expected rename onto a directory to fail")
+	}
+	if strings.Contains(err.Error(), "failed to install export file") {
+		t.Errorf("error = %q, want the caller to supply that wording", err)
+	}
+	var linkErr *os.LinkError
+	if !errors.As(err, &linkErr) {
+		t.Errorf("error = %v, want os.Rename's error passed through", err)
+	}
+}
+
 func TestIsRenameContention_NonSharingErrorsAreNotRetried(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/opencode/lifecycle_test.go
+++ b/cmd/entire/cli/agent/opencode/lifecycle_test.go
@@ -541,6 +541,50 @@ func TestFetchAndCacheExport_InstallsValidExportOverCachedTranscript(t *testing.
 	assertNoStagedExports(t, cachedPath)
 }
 
+// TestFetchAndCacheExport_FailedInstallKeepsStagedExport: once the export has been
+// validated it may be the only copy of the session, so a rename that cannot land
+// must preserve the staging file and say where it is — the one case where a staged
+// file is deliberately left behind.
+func TestFetchAndCacheExport_FailedInstallKeepsStagedExport(t *testing.T) {
+	const (
+		sessionID = "ses_install_fails"
+		fresh     = `{"info":{"id":"ses_install_fails"},"messages":[1,2]}`
+	)
+	repo := t.TempDir()
+	t.Chdir(repo)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	tmpDir := filepath.Join(repo, paths.EntireTmpDir)
+	require.NoError(t, os.MkdirAll(tmpDir, 0o750))
+	// A directory where the transcript belongs makes the install fail without
+	// stubbing os.Rename.
+	require.NoError(t, os.Mkdir(filepath.Join(tmpDir, sessionID+".json"), 0o750))
+
+	stubExport(t, func(_ context.Context, _, outputPath string) error {
+		return os.WriteFile(outputPath, []byte(fresh), 0o600)
+	})
+
+	_, err := (&OpenCodeAgent{}).fetchAndCacheExport(context.Background(), sessionID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "export saved at ")
+	require.Equal(t, 1, strings.Count(err.Error(), "failed to install export file"),
+		"the install failure should be named once, not once per wrapping layer")
+
+	entries, readErr := os.ReadDir(tmpDir)
+	require.NoError(t, readErr)
+	var staged []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), exportStagePrefix) {
+			staged = append(staged, entry.Name())
+		}
+	}
+	require.Len(t, staged, 1, "the validated export must be kept, not deleted")
+	content, readErr := os.ReadFile(filepath.Join(tmpDir, staged[0]))
+	require.NoError(t, readErr)
+	require.JSONEq(t, fresh, string(content))
+}
+
 func TestFetchTranscript_ValidatesSessionID(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/opencode/stage_export.go
+++ b/cmd/entire/cli/agent/opencode/stage_export.go
@@ -55,7 +55,11 @@ func renameOverExisting(staged, dest string) error {
 			return nil
 		}
 		if !isRenameContention(err) {
-			return fmt.Errorf("failed to install export file: %w", err)
+			// Deliberately raw: fetchAndCacheExport owns the user-facing wording
+			// for a failed install, because it is also the one that knows where
+			// the validated export was kept. Phrasing it here too would print
+			// the same sentence twice.
+			return err //nolint:wrapcheck // caller (fetchAndCacheExport) wraps this
 		}
 		time.Sleep(renameBackoff)
 	}

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -781,7 +781,7 @@ func resolveAgentAndTranscript(ctx context.Context, w io.Writer, sessionID strin
 			// "is the session ID correct?" for a session that is simply owned by
 			// an agent they did not name.
 			return nil, "", fmt.Errorf("%w (also tried auto-detecting other agents: %w)%s",
-				err, detectErr, unprobedFetcherHint(ag.Name()))
+				err, detectErr, unprobedFetcherHint(ag.Name(), sessionID))
 		}
 		ag = detectedAg
 		transcriptPath = detectedPath
@@ -794,9 +794,11 @@ func resolveAgentAndTranscript(ctx context.Context, w io.Writer, sessionID strin
 
 // unprobedFetcherHint names the registered agents that can materialize a
 // transcript on demand but were not asked to during auto-detection, so a user
-// who named the wrong agent learns the one-flag fix. Returns "" when the only
-// such agent is the one already tried.
-func unprobedFetcherHint(tried types.AgentName) string {
+// who named the wrong agent learns the one-flag fix — as a command to paste,
+// not a fix to assemble. With several such agents the command is labeled an
+// example (we cannot know which one owns the session), naming the first.
+// Returns "" when the only such agent is the one already tried.
+func unprobedFetcherHint(tried types.AgentName, sessionID string) string {
 	var names []string
 	for _, name := range agent.List() {
 		if name == tried {
@@ -813,8 +815,12 @@ func unprobedFetcherHint(tried types.AgentName) string {
 	if len(names) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("; %s can export transcripts on demand — retry with --agent %s",
-		strings.Join(names, " and "), names[0])
+	retryWith := "retry with"
+	if len(names) > 1 {
+		retryWith = "retry with e.g."
+	}
+	return fmt.Sprintf("; %s can export transcripts on demand — %s: entire session attach %s --agent %s",
+		strings.Join(names, " and "), retryWith, sessionID, names[0])
 }
 
 // transcriptFetchError keeps secondary auto-detection failures from obscuring
@@ -891,7 +897,10 @@ func resolveAndValidateTranscript(ctx context.Context, sessionID string, ag agen
 			return fetched, nil
 		}
 		if errors.Is(fetchErr, context.Canceled) {
-			return "", fmt.Errorf("fetch transcript: %w", fetchErr)
+			// Wrapped, not bare: resolveAgentAndTranscript suppresses the
+			// secondary auto-detection failure only for transcriptFetchError,
+			// and a canceled attach has even less use for it than a failed one.
+			return "", &transcriptFetchError{cause: fmt.Errorf("fetch transcript: %w", fetchErr)}
 		}
 		logging.Debug(ctx, "FetchTranscript failed, falling back to project-dir search", "error", fetchErr)
 	}

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -768,6 +768,11 @@ func resolveAgentAndTranscript(ctx context.Context, w io.Writer, sessionID strin
 
 	transcriptPath, err := resolveAndValidateTranscript(ctx, sessionID, ag, lookupAllowFetch)
 	if err != nil {
+		// A canceled attach stops here: the user asked to quit, so probing every
+		// other agent's transcript locations is work nobody is waiting for.
+		if errors.Is(err, context.Canceled) {
+			return nil, "", err
+		}
 		// Auto-detect: try all other agents.
 		detectedAg, detectedPath, detectErr := detectAgentByTranscript(ctx, sessionID, ag.Name())
 		if detectErr != nil {

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -73,20 +73,26 @@ func TestAttach_TranscriptNotFound(t *testing.T) {
 		t.Fatalf("runAttach error = %v, want existing transcript-not-found error", err)
 	}
 	// Auto-detection does not export on the user's behalf, so the error has to
-	// point at the agent that could have.
-	if !strings.Contains(err.Error(), "--agent opencode") {
-		t.Errorf("runAttach error = %v, want a hint naming the on-demand-export agent", err)
+	// point at the agent that could have — as a command to paste, not one to
+	// assemble.
+	if !strings.Contains(err.Error(), "entire session attach nonexistent-session-id --agent opencode") {
+		t.Errorf("runAttach error = %v, want a pasteable retry command", err)
 	}
 }
 
 func TestUnprobedFetcherHint(t *testing.T) {
 	t.Parallel()
 
-	hint := unprobedFetcherHint(agent.AgentNameClaudeCode)
-	if !strings.Contains(hint, "--agent opencode") {
-		t.Errorf("unprobedFetcherHint(claude-code) = %q, want it to name opencode", hint)
+	const sessionID = "f736da47-b2ca-4f86-bb32-a1bbe582e464"
+	hint := unprobedFetcherHint(agent.AgentNameClaudeCode, sessionID)
+	if want := "entire session attach " + sessionID + " --agent opencode"; !strings.Contains(hint, want) {
+		t.Errorf("unprobedFetcherHint(claude-code) = %q, want it to contain %q", hint, want)
 	}
-	if got := unprobedFetcherHint(agent.AgentNameOpenCode); got != "" {
+	// With a single candidate the command is definitive, not an example.
+	if strings.Contains(hint, "e.g.") {
+		t.Errorf("unprobedFetcherHint(claude-code) = %q, want no example marker for a single candidate", hint)
+	}
+	if got := unprobedFetcherHint(agent.AgentNameOpenCode, sessionID); got != "" {
 		t.Errorf("unprobedFetcherHint(opencode) = %q, want empty (nothing left to suggest)", got)
 	}
 }
@@ -129,6 +135,33 @@ func TestResolveAndValidateTranscript_PreservesFetchFailureAfterFallback(t *test
 	}
 	if !errors.Is(err, wantErr) {
 		t.Fatal("final error does not retain the fetch failure")
+	}
+}
+
+// TestResolveAndValidateTranscript_CanceledFetchIsSuppressible: a Ctrl-C during
+// the export must reach resolveAgentAndTranscript as a transcriptFetchError, or
+// the caller appends a secondary auto-detection failure to a cancellation. It also
+// skips the project-dir fallback, which cannot succeed on a dead context.
+func TestResolveAndValidateTranscript_CanceledFetchIsSuppressible(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	baseAgent, err := agent.Get(agent.AgentNameClaudeCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ag := &failingTranscriptFetcher{
+		Agent:      baseAgent,
+		baseDirErr: errors.New("fallback must not be consulted"),
+		err:        context.Canceled,
+	}
+
+	_, err = resolveAndValidateTranscript(context.Background(), "test-canceled-fetch", ag, lookupAllowFetch)
+	var fetchFailure *transcriptFetchError
+	if !errors.As(err, &fetchFailure) {
+		t.Fatalf("resolveAndValidateTranscript error = %v, want a *transcriptFetchError", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want it to retain context.Canceled", err)
 	}
 }
 

--- a/docs/architecture/agent-guide.md
+++ b/docs/architecture/agent-guide.md
@@ -48,6 +48,7 @@ Every agent must implement all 19 methods on the `Agent` interface:
 | `HookHandler` | `GetHookNames` | **Required for CLI hook registration** — `entire hooks <agent> <verb>` subcommands are only created for agents implementing this interface. Typically delegates to `HookNames()`. |
 | `TranscriptAnalyzer` | `GetTranscriptPosition`, `ExtractModifiedFilesFromOffset` | You want richer checkpoints with transcript-derived file lists |
 | `TranscriptPreparer` | `PrepareTranscript` | Agent writes transcripts asynchronously and needs a flush/sync step |
+| `TranscriptFetcher` | `FetchTranscript` | Agent can export a transcript on demand, including for sessions Entire never tracked (no hook-cached file exists) |
 | `TokenCalculator` | `CalculateTokenUsage` | Agent's transcript contains token usage data |
 | `SubagentAwareExtractor` | `ExtractAllModifiedFiles`, `CalculateTotalTokenUsage` | Agent spawns subagents (like Claude Code's Task tool) |
 | `SubagentSessionResolver` | `ResolveSubagentSession` | Agent runs subagents as **detached sessions of their own** rather than as a blocking tool call (Factory AI Droid's Workers) |
@@ -482,6 +483,25 @@ The framework dispatcher (`DispatchLifecycleEvent` in `lifecycle.go`) handles ea
 
 **Method:**
 - `PrepareTranscript(sessionRef) error` - Wait until the transcript is fully written. Called before `ReadTranscript`.
+
+### `TranscriptFetcher`
+
+**What it enables:** `entire session attach` on a session Entire never tracked — one spawned by an external session host rather than a hooked terminal, where no hook ever cached a transcript.
+
+**Without it:** Attach can only work from a transcript already on disk, so an untracked session fails with "transcript not found".
+
+**Implement when:** Your agent can produce a full transcript for an arbitrary session ID on request (e.g. OpenCode's `opencode export <id>`).
+
+**Not the same as `TranscriptPreparer`:** Preparer refreshes a file that already exists; Fetcher conjures one that never did. An agent that writes asynchronously wants Preparer; an agent with an export command wants Fetcher. Implementing both is fine.
+
+**Method:**
+- `FetchTranscript(sessionID) (path, error)` - Write the transcript to the agent's cache location and return that path.
+
+**Contract:**
+- **Errors are user-facing.** They surface after every other transcript source has failed, so return concise, safe-to-display messages rather than raw subprocess output. See `classifyOpenCodeExportError` in `opencode/cli_commands.go`, which maps a missing binary / unknown session / timeout to one sentence each and redacts anything it echoes from stderr.
+- **Never write in place.** Callers may already hold the only local copy of the session at the destination path; export to a staging file, validate it, then rename. See `stageExportPath` / `renameOverExisting` in `opencode/stage_export.go`.
+- **Builtin-only capability.** There is no `DeclaredCaps` gate — `agent.AsTranscriptFetcher` resolves by type assertion alone, like `TranscriptSanitizer`.
+- **Called only for the agent the user named.** Attach threads a `transcriptLookup` through transcript resolution (`cmd/entire/cli/attach.go`) so auto-detection, which probes every registered agent, never spawns your export subprocess on the user's behalf.
 
 ### `TokenCalculator`
 

--- a/docs/architecture/agent-integration-checklist.md
+++ b/docs/architecture/agent-integration-checklist.md
@@ -41,11 +41,12 @@ Store transcripts in the **agent's native format**. Any transformation or normal
 
 ### Transcript Capture
 
-See Guide: [Transcript Format Guide](agent-guide.md#transcript-format-guide), [TranscriptAnalyzer](agent-guide.md#transcriptanalyzer), [TranscriptPreparer](agent-guide.md#transcriptpreparer)
+See Guide: [Transcript Format Guide](agent-guide.md#transcript-format-guide), [TranscriptAnalyzer](agent-guide.md#transcriptanalyzer), [TranscriptPreparer](agent-guide.md#transcriptpreparer), [TranscriptFetcher](agent-guide.md#transcriptfetcher)
 
 - [ ] **Full transcript on every turn**: At turn-end, capture the complete session transcript, not just events since the last checkpoint
 - [ ] **Resumed session handling**: When a user resumes an existing session, the transcript must include all historical messages, not just new ones since the plugin/hook loaded
 - [ ] **Use agent's canonical export**: Prefer the agent's native export command (e.g., reading Claude's JSONL file, Gemini's JSON, Cursor's JSONL, Factory AI Droid's JSONL, Copilot CLI's JSONL, OpenCode's `opencode export` JSON, Pi's JSONL session file) over manually reconstructing from events
+- [ ] **On-demand export**: If the agent can produce a transcript for a session Entire never hooked (e.g. one spawned by an external session host), implement `TranscriptFetcher` so `entire session attach` works for it instead of failing with "transcript not found"
 - [ ] **No custom formats**: Store the agent's native format directly in `NativeData` - do not convert between formats (e.g., JSON to JSONL) or create intermediate representations
 - [ ] **Graceful degradation**: If the canonical source is unavailable (e.g., agent shutting down), fall back to best-effort capture with clear documentation of limitations
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1130
<!-- entire-trail-link-end -->

This draft pull request was opened by [Entire](https://entire.io) after CI was requested for the linked trail. Feel free to edit the title or body — the link above is what keeps the trail and PR connected.

<!-- entire-shadow-pr -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-message and wrapping tweaks plus tests/docs; no change to attach success path or export install semantics beyond who wraps the error.
> 
> **Overview**
> Cleans up two user-facing attach failure paths.
> 
> When auto-detect cannot find a transcript, the hint for agents that can export on demand is now a **pasteable** `entire session attach <session> --agent …` command (with `e.g.` only if more than one fetcher exists). A canceled `FetchTranscript` is wrapped as `transcriptFetchError` so Ctrl-C is not followed by a noisy auto-detect failure.
> 
> OpenCode’s `renameOverExisting` no longer wraps non-contention rename errors; `fetchAndCacheExport` owns the “failed to install export file” wording so it appears once and still points at the preserved staging file. Docs add the `TranscriptFetcher` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738611d2904022984351df495397440c4986806f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->