### PR TITLE
docs(logging): point the flush comments at main.go

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -206,9 +206,9 @@ func attachPrompts(meta transcriptMetadata) []string {
 }
 
 func runAttach(ctx context.Context, w, errW io.Writer, sessionID string, agentName types.AgentName, opts attachOptions) error {
-	// The logger arrives in ctx from the root PersistentPreRun, and the root
-	// PersistentPostRun flushes it (main.go does for the error path cobra skips
-	// that hook on) — so attach neither builds nor closes one, the way
+	// The logger arrives in ctx from the root PersistentPreRun, and main.go
+	// closes it — the only close site, covering every path ExecuteContextC
+	// returns from — so attach neither builds nor closes one, the way
 	// resume/clean/reset/explain do not either. Only the session is attach's to
 	// add, so its lines are filterable.
 	ctx = logging.WithSessionID(ctx, sessionID)

--- a/cmd/entire/cli/hook_registry_test.go
+++ b/cmd/entire/cli/hook_registry_test.go
@@ -581,9 +581,8 @@ func TestExecuteAgentHookPostTodoFailsWhenPolicyUnsupported(t *testing.T) {
 // TestAgentHooksCmd_AttachesHookSessionContext pins where each agent hook tree
 // gets its context and where flushing happens. PersistentPreRun attaches the
 // hook session context; PersistentPostRun/E must stay unset, because the log
-// sink is opened by the root PersistentPreRun and flushed by its
-// PersistentPostRun (and again by main.go for the error path cobra skips
-// post-runs on).
+// sink is opened by the root PersistentPreRun and closed by main.go, which is
+// the only close site.
 //
 // Both variants are asserted because cobra picks PersistentPreRunE over
 // PersistentPreRun when both are set, so a stray E would silently shadow this
@@ -607,9 +606,9 @@ func TestAgentHooksCmd_AttachesHookSessionContext(t *testing.T) {
 			require.Nil(t, agentCmd.PersistentPreRunE,
 				"PersistentPreRunE must stay unset: cobra would run it instead of PersistentPreRun")
 			require.Nil(t, agentCmd.PersistentPostRun,
-				"PersistentPostRun must stay unset: the root PersistentPostRun and main.go flush the log sink")
+				"PersistentPostRun must stay unset: main.go flushes the log sink")
 			require.Nil(t, agentCmd.PersistentPostRunE,
-				"PersistentPostRunE must stay unset: the root PersistentPostRun and main.go flush the log sink")
+				"PersistentPostRunE must stay unset: main.go flushes the log sink")
 		})
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1131
<!-- entire-trail-link-end -->

Follow-up to #2093, which deleted the root `PersistentPostRun`'s deferred close and left `main.go` as the only close site. Three comments still describe the deleted hook as the one that flushes:

- `cmd/entire/cli/attach.go:209-213` — the note on why attach neither builds nor closes a logger
- `cmd/entire/cli/hook_registry_test.go:582-586` — `TestAgentHooksCmd_AttachesHookSessionContext`'s doc comment
- `cmd/entire/cli/hook_registry_test.go:609,611` — that test's two `require.Nil` failure messages

The failure messages are the ones that matter. The test exists to stop someone adding a `PersistentPostRun` to the agent hook tree, and it was pointing whoever tripped it at a hook that no longer closes anything.

Copilot flagged the first two on #2093 as a suppressed comment; the assertion messages are the same defect and went unnoticed. Nothing in the tree asserts on these strings.

Comments and assertion strings only — no behaviour change. `mise run fmt && mise run lint` clean, `mise run test` green (9685 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and assertion strings only; no runtime or logging-lifecycle change.
> 
> **Overview**
> Updates leftover comments and test assertion messages so they say the log sink is closed only in `main.go`, not by a root `PersistentPostRun` that was already removed.
> 
> Touches `runAttach`’s logger note and `TestAgentHooksCmd_AttachesHookSessionContext` (doc comment plus the `PersistentPostRun`/`E` must-stay-unset messages). No behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 389cf09d71c5efe0984543fbe44d4c36f730f4d2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->