### PR TITLE
fix(cursor): detect Cursor by its project state dir, not just .cursor/

### DIFF
--- a/cmd/entire/cli/agent/cursor/cursor.go
+++ b/cmd/entire/cli/agent/cursor/cursor.go
@@ -55,7 +55,21 @@ func (c *CursorAgent) Description() string {
 
 func (c *CursorAgent) IsPreview() bool { return true }
 
-// DetectPresence checks if Cursor is configured in the repository.
+// DetectPresence checks whether Cursor is used for this repository.
+//
+// Two signals, because a repo-local check alone is structurally biased against
+// Cursor. Every other agent keeps its per-project config in the repo (.claude,
+// .codex, .gemini), so "does <repo>/.<agent> exist" is a fair test for them.
+// Cursor does not: project rules are optional, and its actual per-project state
+// lives in ~/.cursor/projects/<sanitized-repo-path>. A repo driven daily from
+// Cursor therefore reported "not present", and since `entire enable` enables
+// only detected agents when non-interactive and pre-selects only detected ones
+// on first run (see selectAgents in setup.go), Cursor silently ended up with no
+// hooks installed while enable still reported success.
+//
+// The home-dir signal deliberately accepts a false positive — a repo opened in
+// Cursor once and never used with its agent — because that installs hooks that
+// simply never fire, whereas a false negative captures nothing and says nothing.
 func (c *CursorAgent) DetectPresence(ctx context.Context) (bool, error) {
 	worktreeRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
@@ -64,6 +78,16 @@ func (c *CursorAgent) DetectPresence(ctx context.Context) (bool, error) {
 
 	cursorDir := filepath.Join(worktreeRoot, ".cursor")
 	if _, err := os.Stat(cursorDir); err == nil {
+		return true, nil
+	}
+
+	// Cursor's own per-project state directory, keyed by the repo path.
+	projectDir, err := c.projectStateDir(worktreeRoot)
+	if err != nil {
+		// No resolvable home dir is not an error here, just no second signal.
+		return false, nil //nolint:nilerr // detection is best-effort
+	}
+	if info, err := os.Stat(projectDir); err == nil && info.IsDir() {
 		return true, nil
 	}
 	return false, nil
@@ -101,13 +125,23 @@ func (c *CursorAgent) GetSessionDir(repoPath string) (string, error) {
 		return override, nil
 	}
 
+	projectDir, err := c.projectStateDir(repoPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(projectDir, "agent-transcripts"), nil
+}
+
+// projectStateDir returns Cursor's per-project state directory for repoPath:
+// ~/.cursor/projects/<sanitized-repo-path>. Both GetSessionDir (which appends
+// agent-transcripts) and DetectPresence resolve it through here so the two can
+// never disagree about where Cursor keeps a repo's state.
+func (c *CursorAgent) projectStateDir(repoPath string) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
-
-	projectDir := sanitizePathForCursor(repoPath)
-	return filepath.Join(homeDir, ".cursor", "projects", projectDir, "agent-transcripts"), nil
+	return filepath.Join(homeDir, ".cursor", "projects", sanitizePathForCursor(repoPath)), nil
 }
 
 // GetSessionBaseDir returns the base directory containing per-project session subdirectories.

--- a/cmd/entire/cli/agent/cursor/cursor_test.go
+++ b/cmd/entire/cli/agent/cursor/cursor_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
 
 // sampleTranscriptLines returns JSONL lines matching real Cursor transcript format.
@@ -618,9 +620,35 @@ func TestChunkTranscript_PreservesLineOrder(t *testing.T) {
 
 // --- DetectPresence ---
 
+// isolateHome points os.UserHomeDir() at a throwaway directory so
+// DetectPresence cannot read (or be influenced by) the developer's real
+// ~/.cursor while tests run. Returns the fake home.
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)        // unix
+	t.Setenv("USERPROFILE", home) // windows
+	return home
+}
+
+// cursorProjectStateDirFor returns the ~/.cursor/projects entry Cursor would
+// use for the repo currently rooted at the process CWD. It resolves the root
+// through paths.WorktreeRoot rather than reusing the t.TempDir() value, because
+// on macOS a temp dir is /var/... while the resolved root is /private/var/...,
+// and the two sanitize to different directory names.
+func cursorProjectStateDirFor(t *testing.T, home string) string {
+	t.Helper()
+	root, err := paths.WorktreeRoot(context.Background())
+	if err != nil {
+		t.Fatalf("WorktreeRoot() error = %v", err)
+	}
+	return filepath.Join(home, ".cursor", "projects", sanitizePathForCursor(root))
+}
+
 func TestDetectPresence_NoCursorDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	isolateHome(t)
 
 	ag := &CursorAgent{}
 	present, err := ag.DetectPresence(context.Background())
@@ -629,6 +657,104 @@ func TestDetectPresence_NoCursorDir(t *testing.T) {
 	}
 	if present {
 		t.Error("DetectPresence() = true, want false")
+	}
+}
+
+// TestDetectPresence_CursorProjectStateDir is the regression test for Cursor
+// being undetectable in the common case: the user drives the repo from Cursor
+// but has no repo-local .cursor/ directory, because project rules are optional
+// and Cursor's real per-project state lives under ~/.cursor/projects/. Before
+// this signal existed, `entire enable` left Cursor with no hooks installed and
+// still reported success, so nothing was ever captured.
+func TestDetectPresence_CursorProjectStateDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	initGitRepo(t, tmpDir)
+	t.Chdir(tmpDir)
+	home := isolateHome(t)
+
+	// Deliberately NO repo-local .cursor/ directory.
+	if _, err := os.Stat(filepath.Join(tmpDir, ".cursor")); err == nil {
+		t.Fatal("test setup: repo-local .cursor must not exist")
+	}
+
+	ag := &CursorAgent{}
+
+	present, err := ag.DetectPresence(context.Background())
+	if err != nil {
+		t.Fatalf("DetectPresence() error = %v", err)
+	}
+	if present {
+		t.Fatal("DetectPresence() = true before Cursor state exists, want false")
+	}
+
+	if err := os.MkdirAll(cursorProjectStateDirFor(t, home), 0o755); err != nil {
+		t.Fatalf("failed to create Cursor project state dir: %v", err)
+	}
+
+	present, err = ag.DetectPresence(context.Background())
+	if err != nil {
+		t.Fatalf("DetectPresence() error = %v", err)
+	}
+	if !present {
+		t.Error("DetectPresence() = false with a Cursor project state dir, want true")
+	}
+}
+
+// TestDetectPresence_ProjectStateDirEmptyStillCounts pins the deliberate
+// false-positive tolerance: a project dir Cursor created on workspace open,
+// with no transcripts in it yet, still counts as "uses Cursor here". Installing
+// hooks that never fire is harmless; failing to install them is silent data loss.
+func TestDetectPresence_ProjectStateDirEmptyStillCounts(t *testing.T) {
+	tmpDir := t.TempDir()
+	initGitRepo(t, tmpDir)
+	t.Chdir(tmpDir)
+	home := isolateHome(t)
+
+	stateDir := cursorProjectStateDirFor(t, home)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("failed to create Cursor project state dir: %v", err)
+	}
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		t.Fatalf("failed to read state dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("test setup: state dir should be empty, has %d entries", len(entries))
+	}
+
+	ag := &CursorAgent{}
+	present, err := ag.DetectPresence(context.Background())
+	if err != nil {
+		t.Fatalf("DetectPresence() error = %v", err)
+	}
+	if !present {
+		t.Error("DetectPresence() = false for an empty project state dir, want true")
+	}
+}
+
+// TestDetectPresence_ProjectStateDirIsFile guards the IsDir() check: a stray
+// regular file at the project-dir path must not read as presence.
+func TestDetectPresence_ProjectStateDirIsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	initGitRepo(t, tmpDir)
+	t.Chdir(tmpDir)
+	home := isolateHome(t)
+
+	stateDir := cursorProjectStateDirFor(t, home)
+	if err := os.MkdirAll(filepath.Dir(stateDir), 0o755); err != nil {
+		t.Fatalf("failed to create projects dir: %v", err)
+	}
+	if err := os.WriteFile(stateDir, []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("failed to write file at state dir path: %v", err)
+	}
+
+	ag := &CursorAgent{}
+	present, err := ag.DetectPresence(context.Background())
+	if err != nil {
+		t.Fatalf("DetectPresence() error = %v", err)
+	}
+	if present {
+		t.Error("DetectPresence() = true for a file at the project dir path, want false")
 	}
 }
 
@@ -684,14 +810,26 @@ func TestSanitizePathForCursor(t *testing.T) {
 
 // --- helpers ---
 
+// initGitRepo creates a real repository in dir.
+//
+// A hand-written .git/HEAD is not something the git CLI accepts, so
+// paths.WorktreeRoot — which shells out to git rev-parse — failed with exit 128
+// on the previous fake. Tests that only need "some .git exists" were unaffected
+// because DetectPresence falls back to CWD, but any test asserting on the
+// resolved worktree root needs a repo git will actually open.
+//
+// This package cannot use testutil.InitRepo: architecture_test.go deliberately
+// forbids agent packages from importing cli internals.
 func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
-	gitDir := filepath.Join(dir, ".git")
-	if err := os.MkdirAll(gitDir, 0o755); err != nil {
-		t.Fatalf("failed to create .git: %v", err)
-	}
-	// Minimal HEAD file so go-git / paths.RepoRoot() can find it
-	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
-		t.Fatalf("failed to write HEAD: %v", err)
+	cmd := exec.CommandContext(t.Context(), "git", "init", "-q")
+	cmd.Dir = dir
+	// Keep the repo self-contained: no signing, no reliance on global config.
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
 	}
 }

--- a/cmd/entire/cli/agent/cursor/cursor_test.go
+++ b/cmd/entire/cli/agent/cursor/cursor_test.go
@@ -824,10 +824,16 @@ func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
 	cmd := exec.CommandContext(t.Context(), "git", "init", "-q")
 	cmd.Dir = dir
-	// Keep the repo self-contained: no signing, no reliance on global config.
+	// Keep the repo self-contained: no reliance on the developer's git config
+	// (core.hooksPath or init templates would otherwise leak in). Point both
+	// config vars at paths inside a temp dir rather than a null device — git
+	// treats a missing config file as empty, and a real filesystem path is
+	// portable, whereas /dev/null does not exist on Windows. Matches the
+	// GIT_CONFIG_GLOBAL convention in gitrepo/reftable_test.go.
+	emptyCfg := t.TempDir()
 	cmd.Env = append(os.Environ(),
-		"GIT_CONFIG_GLOBAL=/dev/null",
-		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_CONFIG_GLOBAL="+filepath.Join(emptyCfg, "gitconfig"),
+		"GIT_CONFIG_SYSTEM="+filepath.Join(emptyCfg, "gitconfig-system"),
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init failed: %v\n%s", err, out)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1132
<!-- entire-trail-link-end -->

Every agent's `DetectPresence` asks *"does `<repo>/.<agent>/` exist"*. That's a fair test for Claude Code, Codex, and Gemini, which all create repo-local config as a matter of course. It's structurally unfair to Cursor: project rules are optional, and Cursor's real per-project state lives in `~/.cursor/projects/<sanitized-repo-path>`.

So a repo driven daily from Cursor reports "not present". `entire enable` enables only detected agents when non-interactive, and pre-selects only detected ones on first run (`selectAgents`, `setup.go:1771-1795`). The observed result is worse than Cursor merely being skipped — enable falls back to the **default** agent, wires Claude Code, and prints "Ready.":

| | before | after |
|---|---|---|
| enable says | `Agent: Claude Code (use --agent to change)` | `Detected agent: Cursor` |
| `.cursor/hooks.json` | absent | 7 hooks |
| wired instead | `.claude/settings.json` | — |

A/B'd with real binaries in a fresh repo with `~/.cursor/projects/<repo>/` present and no repo-local `.cursor/`.

## Why this is load-bearing: the missing counterpart to #1262

#1262 reported this exact repo state — Claude Code hooks installed, `.cursor/hooks.json` absent, Cursor in use — and its consequence: the Cursor session was *claimed* by Claude's forwarded hooks and misattributed. `fadc4a06a` fixed that with `hook_guard.go`, which inspects the transcript path and makes the forwarded hook no-op when the session belongs to another agent.

That fix is correct, and it changes the failure mode for anyone in that state:

- **before** — Claude's forwarded hook claimed the session → sessions appeared under the wrong agent. Wrong, but visible.
- **after** — the guard correctly declines → nothing claims the session → **zero capture, silently**.

#1262 shipped one half. The guard stops the *wrong* agent from claiming a Cursor session; nothing ensured the *right* agent is wired to claim it. Users in that state went from misattributed sessions to correct attribution of nothing at all. This is that second half.

The user-visible symptom has been reported from outside more than once — #574 ("Unable to see agent steps on dashboard") and #898 ("empty Cursor session panel").

## What changed

`DetectPresence` keeps the repo-local check first and adds the state dir as a second signal. `GetSessionDir` and `DetectPresence` both resolve it through a new `projectStateDir` helper, so the two cannot disagree about where Cursor keeps a repo's state.

The second signal deliberately tolerates a false positive — a repo opened in Cursor once and never used with its agent. That installs hooks which never fire, which is harmless; a false negative captures nothing and says nothing.

## Verification

Cursor capture itself is healthy once hooks exist — `TestSingleSessionManualCommit` with `cursor-cli` passes on Cursor CLI `2026.08.11`, full lifecycle (`SessionStart` → `TurnStart` → `TurnEnd` → checkpoint saved → condensed), commit trailered `Entire-Checkpoint`, v1 checkpoint carrying `Entire-Agent: Cursor`. Detection was the only thing standing between a Cursor user and that path.

Four tests, two RED-verified (they fail with the second signal stubbed, pass with it). Tests set `HOME`/`USERPROFILE` to a temp dir so they never read the developer's real `~/.cursor`.

`initGitRepo` now runs a real `git init`: the hand-written `.git/HEAD` it created before is not a repo the git CLI accepts, so `paths.WorktreeRoot` failed with exit 128 on it — existing tests never noticed because `DetectPresence` falls back to CWD on that error. This package can't use `testutil.InitRepo`; `architecture_test.go` forbids agent packages from importing `cli` internals.

`mise run check` green.

## Not addressed here

Found while investigating, each worth its own issue: headless (`cursor-agent -p`) captures nothing at all because only `sessionStart`/`sessionEnd` fire so no session state is created — though the transcript *is* written to disk, so it's fixable from `sessionEnd`; Cursor has no `ContextInjector`, and `sessionStart`'s `additional_context` is verified working, so that's now viable; and nothing anywhere detects "hooks installed, never fired", which is the state every one of these leaves you in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which agent `entire enable` auto-selects and installs hooks for. False positives can wire unused Cursor hooks; false negatives previously caused silent missed capture.
> 
> **Overview**
> Cursor is now treated as present when `~/.cursor/projects/<sanitized-repo-path>` exists, even if the repo has no `.cursor/` directory. That was the common case (project rules are optional), so `entire enable` skipped Cursor, installed the default agent instead, and captured nothing.
> 
> `DetectPresence` still checks repo-local `.cursor/` first, then the home-dir project state dir. `GetSessionDir` and detection share a new `projectStateDir` helper so they cannot disagree on the path. An empty project dir still counts as present (hooks that never fire beat silent data loss).
> 
> Tests isolate `HOME`/`USERPROFILE` and use a real `git init` so `WorktreeRoot` resolves the same path Cursor would sanitize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42d4a7bb30505072073d37847a002b7da6d422de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->