### PR TITLE
fix(e2e): resolve every runner's per-prompt timeout in one place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,7 +307,9 @@ E2E tests:
 
 - `E2E_AGENT` - Agent to test with (default: `claude-code`)
 - `E2E_CLAUDE_MODEL` - Claude model to use (default: `haiku` for cost efficiency)
-- `E2E_TIMEOUT` - Timeout per prompt (default: `2m`)
+- `E2E_TIMEOUT` - Per-prompt timeout, overriding each runner's own default (e.g. `E2E_TIMEOUT=4m`)
+
+The per-prompt default is the runner's, not a single number: codex, copilot-cli and gemini use 60s, cursor 90s, opencode 2m, and claude-code, droid, pi, vogon and roger-roger impose no per-prompt bound at all — for those the scenario timeout passed to `ForEachAgent` is the only deadline. `E2E_TIMEOUT` sets a bound for every runner including those, and a per-test `agents.WithPromptTimeout(...)` overrides it. All ten resolve through `promptTimeout` in `e2e/agents/agent.go`; a runner that resolves its own is a build failure (`TestEveryRunPromptResolvesThroughPromptTimeout`). A malformed value is an error rather than a silent fall back to the default.
 
 ### Test Parallelization
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -52,7 +52,7 @@ e2e/
 |----------|-------------|---------|
 | `E2E_AGENT` | Agent to test (`claude-code`, `gemini-cli`, `opencode`, `codex`, `cursor`, `factoryai-droid`, `copilot-cli`) | all registered |
 | `E2E_ENTIRE_BIN` | Path to a pre-built `entire` binary | builds from source |
-| `E2E_TIMEOUT` | Timeout per prompt | `2m` |
+| `E2E_TIMEOUT` | Per-prompt timeout, overriding every runner's own default. A per-test `agents.WithPromptTimeout(...)` still wins over it, and a malformed value is a hard error rather than a silent fall back. | per runner: 60s (codex, copilot-cli, gemini), 90s (cursor), 2m (opencode), none (claude-code, droid, pi, vogon, roger-roger — bounded only by the scenario timeout) |
 | `E2E_KEEP_REPOS` | Set to `1` to preserve temp repos after test | unset |
 | `E2E_CHECKPOINT_STORE` | Checkpoint backend to run the suite against (`git-branch`, `git-refs`). Maps to the `ENTIRE_CHECKPOINTS_PRIMARY` override that every spawned binary/hook honors. | `git-branch` |
 | `E2E_ARTIFACT_DIR` | Override artifact output directory | `e2e/artifacts/<timestamp>` |

--- a/e2e/agents/agent.go
+++ b/e2e/agents/agent.go
@@ -29,6 +29,69 @@ func WithPromptTimeout(d time.Duration) Option {
 	return func(c *runConfig) { c.PromptTimeout = d }
 }
 
+// PromptTimeoutEnv is the environment variable that overrides every agent's
+// per-prompt timeout. It is documented in e2e/README.md and CLAUDE.md.
+const PromptTimeoutEnv = "E2E_TIMEOUT"
+
+// promptTimeout resolves the per-prompt deadline for a single RunPrompt call.
+//
+// Precedence is agentDefault < E2E_TIMEOUT < WithPromptTimeout, so the
+// environment widens a runner's own default and an individual test still has
+// the last word. Every runner resolves through here; before this existed each
+// one open-coded the chain, and the copies drifted — only opencode read
+// E2E_TIMEOUT, and five runners accepted WithPromptTimeout and then ignored it.
+//
+// A zero result means "impose no per-prompt bound", which is how the runners
+// that never had one stay that way: for them the scenario context from
+// ForEachAgent remains the only deadline unless someone asks for a tighter
+// one. Callers must therefore branch on the result rather than passing it
+// straight to context.WithTimeout, where zero means "already expired".
+//
+// A malformed E2E_TIMEOUT is an error, not a fallback to the default. Silently
+// ignoring it is how you widen a budget, watch the run fail at the old ceiling
+// anyway, and conclude the agent is slow.
+func promptTimeout(agentDefault time.Duration, cfg *runConfig) (time.Duration, error) {
+	timeout := agentDefault
+	if v := strings.TrimSpace(os.Getenv(PromptTimeoutEnv)); v != "" {
+		parsed, err := time.ParseDuration(v)
+		if err != nil {
+			return 0, fmt.Errorf("%s=%q is not a valid duration (e.g. 90s, 4m): %w", PromptTimeoutEnv, v, err)
+		}
+		if parsed <= 0 {
+			return 0, fmt.Errorf("%s=%q must be positive", PromptTimeoutEnv, v)
+		}
+		timeout = parsed
+	}
+	if cfg != nil && cfg.PromptTimeout > 0 {
+		timeout = cfg.PromptTimeout
+	}
+	return timeout, nil
+}
+
+// boundPrompt applies the resolved per-prompt timeout to ctx, for the runners
+// that want nothing from it but a deadline. The returned cancel is always
+// non-nil, so callers defer it unconditionally.
+//
+// This exists so the "zero means leave ctx alone" rule from promptTimeout is
+// implemented once. It was hand-copied into five runners at first, and a rule
+// restated in five places is the shape of the drift this whole change is
+// undoing.
+//
+// Runners that need the duration itself — cursor computes an absolute deadline
+// from it, and codex, copilot-cli and gemini derive a separate promptCtx — call
+// promptTimeout directly.
+func boundPrompt(ctx context.Context, agentDefault time.Duration, cfg *runConfig) (context.Context, context.CancelFunc, error) {
+	timeout, err := promptTimeout(agentDefault, cfg)
+	if err != nil {
+		return ctx, func() {}, err
+	}
+	if timeout <= 0 {
+		return ctx, func() {}, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	return ctx, cancel, nil
+}
+
 type Agent interface {
 	Name() string
 	// Binary returns the CLI binary name (e.g. "claude", "gemini").

--- a/e2e/agents/claude.go
+++ b/e2e/agents/claude.go
@@ -88,6 +88,12 @@ func (c *Claude) RunPrompt(ctx context.Context, dir string, prompt string, opts 
 		o(cfg)
 	}
 
+	ctx, cancel, err := boundPrompt(ctx, 0, cfg)
+	if err != nil {
+		return Output{}, err
+	}
+	defer cancel()
+
 	configDir, err := cleanConfigDir()
 	if err != nil {
 		return Output{}, fmt.Errorf("create clean config dir: %w", err)

--- a/e2e/agents/codex.go
+++ b/e2e/agents/codex.go
@@ -88,9 +88,9 @@ func (c *Codex) RunPrompt(ctx context.Context, dir string, prompt string, opts .
 		o(cfg)
 	}
 
-	timeout := 60 * time.Second
-	if cfg.PromptTimeout > 0 {
-		timeout = cfg.PromptTimeout
+	timeout, err := promptTimeout(60*time.Second, cfg)
+	if err != nil {
+		return Output{}, err
 	}
 	promptCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/e2e/agents/copilot-cli.go
+++ b/e2e/agents/copilot-cli.go
@@ -83,9 +83,9 @@ func (c *CopilotCLI) RunPrompt(ctx context.Context, dir string, prompt string, o
 		o(cfg)
 	}
 
-	timeout := 60 * time.Second
-	if cfg.PromptTimeout > 0 {
-		timeout = cfg.PromptTimeout
+	timeout, err := promptTimeout(60*time.Second, cfg)
+	if err != nil {
+		return Output{}, err
 	}
 	promptCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/e2e/agents/cursor_cli.go
+++ b/e2e/agents/cursor_cli.go
@@ -103,9 +103,9 @@ func (a *CursorCLI) RunPrompt(ctx context.Context, dir string, prompt string, op
 		o(cfg)
 	}
 
-	timeout := 90 * time.Second
-	if cfg.PromptTimeout > 0 {
-		timeout = cfg.PromptTimeout
+	timeout, err := promptTimeout(90*time.Second, cfg)
+	if err != nil {
+		return Output{}, err
 	}
 
 	displayCmd := a.Binary() + " --force --workspace " + dir + " (interactive prompt: " + prompt + ")"

--- a/e2e/agents/droid.go
+++ b/e2e/agents/droid.go
@@ -149,6 +149,12 @@ func (d *Droid) RunPrompt(ctx context.Context, dir string, prompt string, opts .
 		model = defaultDroidModel
 	}
 
+	ctx, cancel, err := boundPrompt(ctx, 0, cfg)
+	if err != nil {
+		return Output{}, err
+	}
+	defer cancel()
+
 	args := []string{"exec", "--skip-permissions-unsafe", "--model", model, prompt}
 	displayArgs := []string{"exec", "--skip-permissions-unsafe", "--model", model, fmt.Sprintf("%q", prompt)}
 
@@ -163,7 +169,7 @@ func (d *Droid) RunPrompt(ctx context.Context, dir string, prompt string, opts .
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	exitCode := 0
 	if err != nil {
 		exitErr := &exec.ExitError{}

--- a/e2e/agents/gemini.go
+++ b/e2e/agents/gemini.go
@@ -99,10 +99,11 @@ func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts 
 	}
 
 	// Per-prompt timeout so a slow response gets killed early enough to
-	// retry within the test's overall budget.
-	timeout := 60 * time.Second
-	if cfg.PromptTimeout > 0 {
-		timeout = cfg.PromptTimeout
+	// retry within the test's overall budget. Note the 60s is not scaled by
+	// TimeoutMultiplier, which applies to the scenario budget, not to this.
+	timeout, err := promptTimeout(60*time.Second, cfg)
+	if err != nil {
+		return Output{}, err
 	}
 	promptCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -365,15 +365,9 @@ func (a *openCodeAgent) RunPrompt(ctx context.Context, dir string, prompt string
 	}
 	args = append(args, prompt)
 
-	timeout := a.timeout
-	if envTimeout := os.Getenv("E2E_TIMEOUT"); envTimeout != "" {
-		if parsed, err := time.ParseDuration(envTimeout); err == nil {
-			timeout = parsed
-		}
-	}
-	// Per-prompt timeout is the most specific override.
-	if cfg.PromptTimeout > 0 {
-		timeout = cfg.PromptTimeout
+	timeout, err := promptTimeout(a.timeout, cfg)
+	if err != nil {
+		return Output{}, err
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -387,7 +381,7 @@ func (a *openCodeAgent) RunPrompt(ctx context.Context, dir string, prompt string
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	out := Output{
 		Command: a.Binary() + " " + strings.Join(args, " "),
 		Stdout:  stdout.String(),

--- a/e2e/agents/pi.go
+++ b/e2e/agents/pi.go
@@ -116,6 +116,12 @@ func (p *Pi) RunPrompt(ctx context.Context, dir string, prompt string, opts ...O
 		o(cfg)
 	}
 
+	ctx, cancel, err := boundPrompt(ctx, 0, cfg)
+	if err != nil {
+		return Output{}, err
+	}
+	defer cancel()
+
 	bin, err := exec.LookPath(p.Binary())
 	if err != nil {
 		return Output{}, fmt.Errorf("%s not in PATH: %w", p.Binary(), err)

--- a/e2e/agents/prompt_timeout_test.go
+++ b/e2e/agents/prompt_timeout_test.go
@@ -1,0 +1,259 @@
+package agents
+
+import (
+	"context"
+
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPromptTimeoutPrecedence pins the chain documented in e2e/README.md:
+// the runner's own default is widened by E2E_TIMEOUT, and an individual test
+// still overrides both.
+//
+// Cannot be parallel: t.Setenv is process-global state.
+func TestPromptTimeoutPrecedence(t *testing.T) {
+	cases := []struct {
+		name       string
+		agentDflt  time.Duration
+		env        string
+		perTest    time.Duration
+		want       time.Duration
+		wantErrSub string
+	}{
+		{name: "default applies when nothing overrides", agentDflt: 60 * time.Second, want: 60 * time.Second},
+		{name: "env widens the default", agentDflt: 60 * time.Second, env: "4m", want: 4 * time.Minute},
+		{name: "env narrows the default", agentDflt: 90 * time.Second, env: "30s", want: 30 * time.Second},
+		{name: "per-test beats env", agentDflt: 60 * time.Second, env: "4m", perTest: 2 * time.Minute, want: 2 * time.Minute},
+		{name: "per-test beats default", agentDflt: 60 * time.Second, perTest: 2 * time.Minute, want: 2 * time.Minute},
+		{name: "surrounding whitespace is tolerated", agentDflt: 60 * time.Second, env: "  45s\n", want: 45 * time.Second},
+
+		// A zero default means "no bound of our own". It must survive an empty
+		// env untouched, because that is what keeps the scenario context from
+		// ForEachAgent in charge for the runners that never had a ceiling.
+		{name: "zero default stays unbounded", agentDflt: 0, want: 0},
+		{name: "zero default still honors env", agentDflt: 0, env: "90s", want: 90 * time.Second},
+		{name: "zero default still honors per-test", agentDflt: 0, perTest: 30 * time.Second, want: 30 * time.Second},
+
+		// Rejected rather than ignored: a typo that silently kept the old
+		// ceiling is indistinguishable from a slow agent.
+		{name: "malformed env is an error", agentDflt: 60 * time.Second, env: "4min", wantErrSub: "not a valid duration"},
+		{name: "bare number is an error", agentDflt: 60 * time.Second, env: "240", wantErrSub: "not a valid duration"},
+		{name: "zero env is an error", agentDflt: 60 * time.Second, env: "0s", wantErrSub: "must be positive"},
+		{name: "negative env is an error", agentDflt: 60 * time.Second, env: "-30s", wantErrSub: "must be positive"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(PromptTimeoutEnv, tc.env)
+			if tc.env == "" {
+				// t.Setenv cannot unset, and an empty value is what an unset
+				// var looks like to os.Getenv anyway.
+				t.Setenv(PromptTimeoutEnv, "")
+			}
+
+			got, err := promptTimeout(tc.agentDflt, &runConfig{PromptTimeout: tc.perTest})
+
+			if tc.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("promptTimeout(%v, %q) = %v, want error containing %q", tc.agentDflt, tc.env, got, tc.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("error = %q, want it to contain %q", err, tc.wantErrSub)
+				}
+				// The message must name the variable so the operator knows
+				// which knob they mistyped.
+				if !strings.Contains(err.Error(), PromptTimeoutEnv) {
+					t.Errorf("error = %q, want it to name %s", err, PromptTimeoutEnv)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("promptTimeout(%v, %q) returned unexpected error: %v", tc.agentDflt, tc.env, err)
+			}
+			if got != tc.want {
+				t.Errorf("promptTimeout(%v, env=%q, perTest=%v) = %v, want %v",
+					tc.agentDflt, tc.env, tc.perTest, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPromptTimeoutNilConfig covers the defensive nil branch: a runner that
+// resolves before building its runConfig must not panic.
+func TestPromptTimeoutNilConfig(t *testing.T) {
+	t.Setenv(PromptTimeoutEnv, "")
+	got, err := promptTimeout(60*time.Second, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 60*time.Second {
+		t.Errorf("got %v, want 60s", got)
+	}
+}
+
+// TestBoundPrompt covers the ctx-wrapping half: a zero resolution must leave
+// the caller's context alone, which is what keeps the scenario timeout in
+// charge for the runners that never had a per-prompt ceiling.
+func TestBoundPrompt(t *testing.T) {
+	t.Run("zero leaves ctx unbounded", func(t *testing.T) {
+		t.Setenv(PromptTimeoutEnv, "")
+		got, cancel, err := boundPrompt(context.Background(), 0, &runConfig{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer cancel()
+		if _, ok := got.Deadline(); ok {
+			t.Error("boundPrompt(0) set a deadline; the scenario context must stay in charge")
+		}
+	})
+
+	t.Run("env bounds a previously unbounded runner", func(t *testing.T) {
+		t.Setenv(PromptTimeoutEnv, "30s")
+		got, cancel, err := boundPrompt(context.Background(), 0, &runConfig{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer cancel()
+		deadline, ok := got.Deadline()
+		if !ok {
+			t.Fatal("boundPrompt did not set a deadline despite E2E_TIMEOUT")
+		}
+		if d := time.Until(deadline); d <= 0 || d > 30*time.Second {
+			t.Errorf("deadline is %v away, want (0, 30s]", d)
+		}
+	})
+
+	t.Run("agent default bounds ctx", func(t *testing.T) {
+		t.Setenv(PromptTimeoutEnv, "")
+		got, cancel, err := boundPrompt(context.Background(), 60*time.Second, &runConfig{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer cancel()
+		if _, ok := got.Deadline(); !ok {
+			t.Error("boundPrompt did not apply the agent default")
+		}
+	})
+
+	// The cancel must be safe to defer even on the error path, since callers
+	// check err after deferring.
+	t.Run("error path returns a usable cancel", func(t *testing.T) {
+		t.Setenv(PromptTimeoutEnv, "nonsense")
+		got, cancel, err := boundPrompt(context.Background(), 0, &runConfig{})
+		if err == nil {
+			t.Fatal("expected an error for a malformed E2E_TIMEOUT")
+		}
+		if got == nil {
+			t.Error("boundPrompt returned a nil context on the error path")
+		}
+		if cancel == nil {
+			t.Fatal("boundPrompt returned a nil cancel on the error path")
+		}
+		cancel() // must not panic
+	})
+}
+
+// TestEveryRunPromptResolvesThroughPromptTimeout fails the build on any agent
+// runner that resolves its per-prompt deadline itself instead of calling
+// promptTimeout.
+//
+// This is a source-level guard because the drift it catches is silent and
+// already happened twice. Each runner used to open-code the chain, and the
+// copies diverged: only opencode ever read E2E_TIMEOUT, so the variable the
+// docs describe as universal moved nothing for the other nine; and claude,
+// droid, pi, vogon and roger-roger accepted WithPromptTimeout and dropped it on
+// the floor, which made the per-test overrides in split_commits_test.go and
+// multi_session_test.go no-ops for half the matrix. Neither failure shows up as
+// a test failure — you get a run that ignores the budget you set.
+func TestEveryRunPromptResolvesThroughPromptTimeout(t *testing.T) {
+	t.Parallel()
+
+	// A plain directory walk rather than parser.ParseDir (deprecated, and it
+	// ignores build tags): this package carries no build constraints, so every
+	// non-test .go file here is part of it.
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var checked int
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != "RunPrompt" || fn.Recv == nil || fn.Body == nil {
+				continue
+			}
+			checked++
+			if !callsAny(fn.Body, "promptTimeout", "boundPrompt") {
+				t.Errorf("%s: %s.RunPrompt resolves its own per-prompt deadline.\n"+
+					"Every runner must go through boundPrompt (when it just wants a "+
+					"bounded ctx) or promptTimeout (when it needs the duration), so "+
+					"E2E_TIMEOUT and WithPromptTimeout apply uniformly. Pass the "+
+					"runner's own default, or 0 to stay bounded only by the scenario "+
+					"context.",
+					name, receiverName(fn))
+			}
+		}
+	}
+
+	// A walk that matched nothing would pass vacuously, which is the one way
+	// this guard could stop guarding.
+	if checked < 5 {
+		t.Fatalf("found only %d RunPrompt implementations; the AST walk is broken", checked)
+	}
+}
+
+// callsAny reports whether body contains a call to any of the named
+// package-level functions. boundPrompt delegates to promptTimeout, so a runner
+// using either is resolving through the shared chain.
+func callsAny(body *ast.BlockStmt, names ...string) bool {
+	want := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		want[n] = struct{}{}
+	}
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := call.Fun.(*ast.Ident); ok {
+			if _, ok := want[id.Name]; ok {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func receiverName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return "?"
+	}
+	switch t := fn.Recv.List[0].Type.(type) {
+	case *ast.StarExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			return "*" + id.Name
+		}
+	case *ast.Ident:
+		return t.Name
+	}
+	return "?"
+}

--- a/e2e/agents/roger_roger.go
+++ b/e2e/agents/roger_roger.go
@@ -42,6 +42,19 @@ func (r *RogerRoger) IsTransientError(_ Output, _ error) bool { return false }
 func (r *RogerRoger) IsExternalAgent() bool { return true }
 
 func (r *RogerRoger) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
+	cfg := &runConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	// No default, same reasoning as vogon: a local stub needs no ceiling of
+	// ours, but an explicitly requested one must still apply.
+	ctx, cancel, err := boundPrompt(ctx, 0, cfg)
+	if err != nil {
+		return Output{}, err
+	}
+	defer cancel()
+
 	// roger-roger reads prompts from stdin line by line.
 	// An empty line causes the REPL to exit gracefully.
 	cmd := exec.CommandContext(ctx, r.Binary())
@@ -55,7 +68,7 @@ func (r *RogerRoger) RunPrompt(ctx context.Context, dir string, prompt string, o
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	exitCode := 0
 	if err != nil {
 		exitErr := &exec.ExitError{}

--- a/e2e/agents/vogon.go
+++ b/e2e/agents/vogon.go
@@ -40,6 +40,20 @@ func (v *Vogon) Bootstrap() error { return nil }
 func (v *Vogon) IsTransientError(_ Output, _ error) bool { return false }
 
 func (v *Vogon) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
+	cfg := &runConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	// No default: the canary answers in seconds, so a ceiling of our own would
+	// only ever misfire. It still honors an explicit one — a hung fake agent is
+	// the reason someone reaches for E2E_TIMEOUT on the canary leg.
+	ctx, cancel, err := boundPrompt(ctx, 0, cfg)
+	if err != nil {
+		return Output{}, err
+	}
+	defer cancel()
+
 	args := []string{"-p", prompt}
 	displayArgs := []string{"-p", fmt.Sprintf("%q", prompt)}
 	env := filterEnv(os.Environ(), "ENTIRE_TEST_TTY")


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1133
<!-- entire-trail-link-end -->

`E2E_TIMEOUT` is documented in `CLAUDE.md` and `e2e/README.md` as **the** per-prompt timeout, and only `opencode.go` read it. On the other nine runners the variable moved nothing, so anyone reaching for it to widen a leg got the hardcoded ceiling anyway.

This replaces the original cursor-only patch. Fixing one runner would have made it 2-of-10 and left the docs just as wrong.

## What was actually broken

| | before | after |
| --- | --- | --- |
| Runners reading `E2E_TIMEOUT` | 1 of 10 (`opencode`) | 10 of 10 |
| Runners honoring `WithPromptTimeout` | 5 of 10 | 10 of 10 |
| Documented default | `2m` — true of one runner | per-runner defaults, named |
| Malformed value | silently ignored | error |

The second row is the one I did not expect. `claude`, `droid`, `pi`, `vogon` and `roger_roger` all accept `opts ...Option`, build no `runConfig` or ignore its `PromptTimeout`, and bound the prompt only by the incoming ctx — so the per-test overrides at `split_commits_test.go:69,82` (2m) and `multi_session_test.go:48,55` were no-ops for half the matrix. Nothing fails when that happens; you just get a run that ignores the budget you set.

Each runner had open-coded the same precedence chain and the copies drifted. That is the actual defect, so the fix is structural rather than another copy.

## The change

Resolution lives in `e2e/agents/agent.go`:

- `promptTimeout(agentDefault, cfg)` — the chain, `agentDefault < E2E_TIMEOUT < WithPromptTimeout`. For the runners that need the duration itself: `cursor` derives an absolute deadline from it, and `codex` / `copilot-cli` / `gemini` derive a separate `promptCtx`.
- `boundPrompt(ctx, agentDefault, cfg)` — applies it to a ctx, for the five that want nothing but a deadline. It exists so the "zero means leave ctx alone" rule is implemented once; I hand-copied it into five runners first, and five copies of a rule is the shape of the drift this change is undoing.
- `TestEveryRunPromptResolvesThroughPromptTimeout` walks the package AST and fails the build on a `RunPrompt` that resolves its own. Mutation-checked by reverting `cursor`, `pi` and `droid` in turn — each time it named the offending file and receiver.

## No agent's default changes, deliberately

You suggested the documented `2m` as the uniform default. I did not do that half, because it is wrong in both directions:

- For `codex` / `copilot-cli` / `gemini` (60s) and `cursor` (90s) it *raises* the tolerance for a genuinely hung agent — the same objection that sank this PR's original 90s→4m raise.
- For `claude-code`, `droid`, `pi`, `vogon` and `roger-roger` it *tightens* things: they have no per-prompt bound today, so 2m would be a new ceiling below several scenario budgets. That is a behaviour change no free test leg can validate, and the paid legs are the ones it would break.

So each runner keeps its current effective behaviour, and the five unbounded ones stay bounded only by the `ForEachAgent` scenario timeout unless someone explicitly asks for a per-prompt one. The docs now name the per-runner defaults instead of claiming a single number.

## Why the original 90s→4m raise is gone

The premise no longer holds. The `cursor-cli` leg is green on `main` — runs [34045646261](https://github.com/entireio/cli/actions/runs/34045646261) (Sep 6), [33989646512](https://github.com/entireio/cli/actions/runs/33989646512) (Sep 5) and [33890961426](https://github.com/entireio/cli/actions/runs/33890961426) (Sep 4), the latest reporting `56 passed, 0 failed` with zero `out of usage` and zero `timed out waiting` messages.

My 188.7s measurement was taken while the account was quota-throttled (66 `out of usage` errors in that same run), which this PR's original description already identified as the real cause of the then-red leg. Throttled responses being slow is the obvious confound. The slowest test in the Sep 6 run, `TestAgentAmendsCommit` at 90.4s, looks like it is grazing the 90s ceiling but is not: it runs two prompts with no override, and its wall clock also covers the trust dialog, a 45s TUI-readiness wait, git ops and teardown.

## Verification

`10727` unit + `562` integration + `60` canary tests pass. `mise run lint` clean, `GOOS=windows go vet ./e2e/...` clean.

Behaviourally, on the free canary leg — which covers `vogon` and `roger-roger`, the two runners this PR newly wires:

```
E2E_TIMEOUT=1ms   → prompt killed in 0.2s   (previously: did nothing at all)
E2E_TIMEOUT=4min  → E2E_TIMEOUT="4min" is not a valid duration (e.g. 90s, 4m)
                    (previously: silently ignored)
E2E_TIMEOUT=3m    → ALL 1 TESTS PASSED
```

No paid agent leg was run. The eight runners that touch a vendor API are covered by the unit tests and the AST guard; their behaviour is unchanged by construction, since each keeps the default it had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
