### PR TITLE
fix(lint): drop --fix so `mise run lint` never rewrites source

### DIFF
--- a/mise-tasks/lint/go
+++ b/mise-tasks/lint/go
@@ -12,5 +12,12 @@ golangci-lint config verify
 if [ "$CI" = "true" ]; then
   echo "skipped because CI=true"
 else
-  golangci-lint run --timeout=30m --fix ./...
+  # Deliberately no --fix: this must be read-only, like the CI path. Rewriting source belongs to
+  # `mise run fmt`. CLAUDE.md tells contributors to run this before every commit and every push, so
+  # a lint that edits files turns "verify my tree" into "mutate my tree" — and --fix is
+  # all-or-nothing (golangci-lint has no per-linter fix exclusion), which includes nolintlint's
+  # fixer deleting //nolint directives it judges unnecessary. That has stripped the
+  # //nolint:staticcheck directives in cmd/entire/cli/agent/architecture_test.go, leaving an
+  # unrelated file dirty and the next run failing on SA1019.
+  golangci-lint run --timeout=30m ./...
 fi

--- a/mise-tasks/lint/go
+++ b/mise-tasks/lint/go
@@ -12,12 +12,7 @@ golangci-lint config verify
 if [ "$CI" = "true" ]; then
   echo "skipped because CI=true"
 else
-  # Deliberately no --fix: this must be read-only, like the CI path. Rewriting source belongs to
-  # `mise run fmt`. CLAUDE.md tells contributors to run this before every commit and every push, so
-  # a lint that edits files turns "verify my tree" into "mutate my tree" — and --fix is
-  # all-or-nothing (golangci-lint has no per-linter fix exclusion), which includes nolintlint's
-  # fixer deleting //nolint directives it judges unnecessary. That has stripped the
-  # //nolint:staticcheck directives in cmd/entire/cli/agent/architecture_test.go, leaving an
-  # unrelated file dirty and the next run failing on SA1019.
+  # No --fix: lint is read-only, like CI. `mise run fmt` owns rewriting.
+  # --fix let nolintlint delete //nolint directives in architecture_test.go.
   golangci-lint run --timeout=30m ./...
 fi


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1136
<!-- entire-trail-link-end -->

## Problem

`mise-tasks/lint/go` ran `golangci-lint run --timeout=30m --fix ./...` on the local (non-CI) path, which made lint a **mutating** command.

CLAUDE.md tells contributors to run `mise run fmt && mise run lint` before every commit and `mise run lint` before every push. So the documented verification sequence could edit your working tree.

Observed fallout, starting from a clean tree:

1. `mise run lint` → reports `0 issues`, but leaves `cmd/entire/cli/agent/architecture_test.go` modified — nolintlint's fixer had deleted the two `//nolint:staticcheck` directives above the `parser.ParseDir` calls, each replaced by a blank line.
2. `mise run lint` again → fails with 2 issues, `SA1019: parser.ParseDir has been deprecated since Go 1.25` at `cmd/entire/cli/agent/architecture_test.go:166` and `:221`.

A developer following the documented sequence either commits the stripped file or is blocked by a failure they did not cause. `mise run check` (fmt + lint + test:ci) hits it too. CI was unaffected because it uses `golangci/golangci-lint-action@v9`, which does not pass `--fix`.

## Fix

Drop `--fix`. Local lint is now read-only, matching the CI path. Rewriting source stays with `mise run fmt`. A comment records why, so it doesn't come back.

## Alternatives considered

- **Per-linter fix exclusion** — not available. golangci-lint 2.11.3's `--fix` is all-or-nothing (`run --help` offers no per-linter form), and nolintlint (`[fast, auto-fix]`) exposes no key to disable its fixer. The only config lever is `nolintlint.allow-unused: true`, which would disable a useful check repo-wide.
- **Migrate off the deprecated `parser.ParseDir`** — the deprecation notice points at `golang.org/x/tools/go/packages` precisely *because* it honors build tags, which is the opposite of what `extractImports` wants ("scan all files regardless of build tags to catch forbidden imports in test files too"). A correct replacement is a hand-rolled `os.ReadDir` + `parser.ParseFile` loop, but it leaves the underlying hazard intact: `--fix` could strip some other `//nolint` directive tomorrow. Worth doing on its own merits, separately.

## Verification

From a clean tree, `mise run lint` twice in a row: both report `0 issues`, tree unchanged after each. The documented `mise run fmt && mise run lint` sequence is likewise clean. `shellcheck` passes on the edited script (`mise run lint` lints itself via `lint:shellcheck`). `mise run test:ci` passes.

## Caveat for the reviewer

**I could not reproduce the directive-stripping on my machine** — same repo, same golangci-lint 2.11.3. `--fix` with a cold cache, scoped to the agent package, and via `mise run lint` all left the file untouched and reported 0 issues. What I did confirm directly is the second half: deleting those two directives makes SA1019 fire at exactly those lines.

I also tested and **disproved** my first hypothesis for the trigger (that nolintlint strips a directive when the suppressed linter didn't report — `--fix -D staticcheck` did *not* strip it), so no mechanism is asserted in the comment I added. The trigger is still unidentified.

This fix does not depend on identifying it: lint can no longer write to any file, which removes the whole class regardless of cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
