### PR TITLE
fix(strategy): log a commit trailer no session condensed into

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1053,6 +1053,8 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 	// the time it runs.
 	condensedTelemetry := newCommitCondensedEmitter(worktreePath, newHead)
 
+	trailerOwned := anySessionOwnsCheckpoint(sessions, checkpointID)
+
 	loopCtx, processSessionsLoop := perf.StartLoop(ctx, "process_sessions")
 	for _, sess := range sessions {
 		if sess.FullyCondensed && sess.Phase == session.PhaseEnded {
@@ -1063,10 +1065,12 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		var newSkillEvents []agent.SkillEvent
 		var condensedSignal *commitCondensedSignal
 		mutErr := MutateSessionStateOnSaved(iterCtx, sessionID, func(state *SessionState) error {
-			newSkillEvents, condensedSignal = s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
+			var condensed bool
+			newSkillEvents, condensedSignal, condensed = s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
 				head, commit, newHead, worktreePath, headTree, parentTree,
 				committedFileSet, shadowBranchesToDelete, uncondensedActiveOnBranch, allAgentFiles,
 				sessionsWithCommittedFiles, condensedTelemetry)
+			trailerOwned = trailerOwned || condensed
 			return nil
 		}, func() {
 			EmitSkillInvocationTelemetry(iterCtx, newSkillEvents)
@@ -1080,6 +1084,8 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		iterSpan.End()
 	}
 	processSessionsLoop.End()
+
+	logUnclaimedCheckpointTrailer(logCtx, checkpointID, sessions, trailerOwned, isRebase)
 
 	if err := s.updateCombinedAttributionForCheckpoint(ctx, repo, checkpointID, headTree, parentTree, worktreePath); err != nil {
 		logging.Warn(logCtx, "failed to update combined checkpoint attribution",
@@ -1115,6 +1121,74 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// anySessionOwnsCheckpoint reports whether any session already recorded cpID as
+// its most recent condensation. Ownership is what makes an Entire-Checkpoint
+// trailer resolvable, and it survives across commits: condenseAndUpdateState
+// stores the ID in LastCheckpointID so a later amend can restore the same
+// trailer. So a session owning cpID means the checkpoint exists, whether it was
+// written by this commit or the one being amended.
+//
+// Read from the pre-loop session snapshot, so it still counts a session that
+// PostCommit's loop skips as fully-condensed and ENDED — an amend whose owning
+// session has since finished.
+func anySessionOwnsCheckpoint(sessions []*SessionState, cpID id.CheckpointID) bool {
+	for _, state := range sessions {
+		if state.LastCheckpointID == cpID {
+			return true
+		}
+	}
+	return false
+}
+
+// logUnclaimedCheckpointTrailer records a commit whose Entire-Checkpoint
+// trailer no session condensed into. The case worth catching is a
+// trailer/condense divergence: PrepareCommitMsg stamped a session it judged
+// eligible and PostCommit then declined to condense it, leaving `entire
+// explain` on that commit resolving to nothing. Both halves individually look
+// like routine skips, so the divergence is invisible without this line.
+//
+// Two cases reach "no session condensed" while the checkpoint exists, and both
+// are excluded here: `claimed` covers amend, seeded from LastCheckpointID by
+// the commit being amended; `isSequenceOp` covers cherry-pick, revert, and
+// rebase replay, where the trailer rides along from a source commit whose
+// session may not exist in this worktree at all.
+//
+// `claimed` must come from postCommitProcessSessionLocked's condensed result,
+// never from its *commitCondensedSignal: newCommitCondensedSignal returns nil
+// for an amend that re-condenses a checkpoint it already reported, so the
+// telemetry signal is absent in exactly the case that must count as claimed.
+//
+// DEBUG, not WARN, because those are not all of them: `git merge --squash` and
+// `git commit -C` copy a trailer out of an existing commit message without
+// being sequencer operations, and PrepareCommitMsg deliberately never stamps a
+// squash (see its source switch), so no local session owns the inherited ID
+// and this cannot tell that from the real bug.
+//
+// Distinguishing those exactly would mean recording, at stamp time, that
+// Entire minted this trailer for this commit. PrepareCommitMsg writes no
+// session state at all today, so that adds a lock-taking write to a read-only
+// hook on the latency-critical path — not worth it for a diagnostic. An
+// authoritative check belongs in `entire doctor`, which can afford to ask the
+// checkpoint store whether the ID resolves.
+func logUnclaimedCheckpointTrailer(logCtx context.Context, checkpointID id.CheckpointID, sessions []*SessionState, claimed, isSequenceOp bool) {
+	if claimed || isSequenceOp {
+		return
+	}
+	phases := make([]string, 0, len(sessions))
+	totalTaskRecords := 0
+	for _, state := range sessions {
+		phases = append(phases, string(state.Phase))
+		totalTaskRecords += len(state.TaskRecords)
+	}
+	logging.Debug(logCtx, "post-commit: no session condensed into the commit's checkpoint trailer",
+		slog.String("strategy", "manual-commit"),
+		slog.String("checkpoint_id", checkpointID.String()),
+		slog.Int("sessions", len(sessions)),
+		slog.Any("session_phases", phases),
+		slog.Int("task_records", totalTaskRecords),
+	)
 }
 
 // updateCombinedAttributionForCheckpoint computes holistic attribution across all sessions.
@@ -1243,6 +1317,14 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 // Pre-resolved git objects (headTree, parentTree) are shared across all sessions;
 // per-session shadow ref/tree are resolved once here and threaded through sub-calls.
 //
+// The third result reports whether this session condensed into checkpointID.
+// It is distinct from the second (the telemetry signal, which is nil for an
+// amend re-condensing an already-reported checkpoint) and cannot be inferred
+// from state afterwards: carry-forward on a partial commit clears
+// LastCheckpointID that condenseAndUpdateState had just set, so the post-loop
+// state of a successful partial condensation is indistinguishable from never
+// having condensed.
+//
 // MUST be called from inside MutateSessionState. Mutations to state are persisted
 // by the caller's outer save — calling this function standalone silently loses
 // every field change (StepCount, FilesTouched, CheckpointTranscriptStart, …).
@@ -1283,7 +1365,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 	allAgentFiles map[string]struct{},
 	sessionsWithCommittedFiles int,
 	condensedTelemetry *commitCondensedEmitter,
-) (newSkillEvents []agent.SkillEvent, condensedSignal *commitCondensedSignal) {
+) (newSkillEvents []agent.SkillEvent, condensedSignal *commitCondensedSignal, condensed bool) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	shadowBranchName := getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
 	reservedCheckpointID := state.PendingCondensationID()
@@ -1293,7 +1375,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 			slog.String("reserved_checkpoint_id", reservedCheckpointID.String()),
 			slog.String("commit_checkpoint_id", checkpointID.String()))
 		uncondensedActiveOnBranch[shadowBranchName] = true
-		return newSkillEvents, condensedSignal
+		return newSkillEvents, condensedSignal, false
 	}
 
 	shadowRef, shadowTree := resolveShadowRefAndTree(ctx, repo, shadowBranchName)
@@ -1461,7 +1543,7 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 		uncondensedActiveOnBranch[shadowBranchName] = true
 	}
 
-	return handler.newSkillEvents, handler.condensedSignal
+	return handler.newSkillEvents, handler.condensedSignal, handler.condensed
 }
 
 // condenseAndUpdateState runs condensation for a session and updates state afterward.
@@ -1674,10 +1756,13 @@ func truncateHash(h string) string {
 // filterSessionsWithNewContent returns the sessions this commit may claim a
 // trailer for: those with new content beyond what was already condensed, minus
 // those whose only new content is a task record too stale (or in the wrong
-// phase) for idleWithTaskContent. Such a record still condenses — PostCommit
-// reaches it through sessionHasNewContent, so its transcript-so-far is never
-// stranded — but it must not mint an Entire-Checkpoint the commit's own
-// condensation then declines to write.
+// phase) for idleWithTaskContent. Such a record is not stranded — its
+// transcript-so-far is materialized by the session's final condensation at
+// endSessionNow, and by any later commit that does stamp a trailer — but it
+// must not mint an Entire-Checkpoint the commit's own condensation then
+// declines to write. Note the record is NOT rescued by this commit's own
+// PostCommit: withholding the trailer means PostCommit returns at its
+// no-trailer early exit before reaching any session.
 // Computes the staged files list once and reuses it across all sessions to avoid
 // redundant `git diff --cached` calls (previously called up to 3 times per session).
 func (s *ManualCommitStrategy) filterSessionsWithNewContent(ctx context.Context, repo *git.Repository, sessions []*SessionState) []*SessionState {

--- a/cmd/entire/cli/strategy/unclaimed_trailer_test.go
+++ b/cmd/entire/cli/strategy/unclaimed_trailer_test.go
@@ -1,0 +1,245 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/object"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unclaimedTrailerLogMessage is the line logUnclaimedCheckpointTrailer emits.
+// Asserting on the log is the only way to observe it: it deliberately has no
+// return value and no state side effect, because its whole purpose is to be
+// greppable in .entire/logs.
+const unclaimedTrailerLogMessage = "no session condensed into the commit's checkpoint trailer"
+
+// TestPostCommit_UnclaimedCheckpointTrailer covers the one shape the line is
+// for and the three the caller excludes. The exclusions matter even at DEBUG:
+// an amend and a cherry-pick both reach "no session condensed" while their
+// checkpoint exists, so without them the line says nothing useful when someone
+// greps for it.
+func TestPostCommit_UnclaimedCheckpointTrailer(t *testing.T) {
+	const trailerID = "f6a1b2c3d4e5"
+
+	tests := []struct {
+		name string
+		// phase the session is in when the trailered commit lands.
+		phase session.Phase
+		// noNewContent pins the transcript baseline to what the shadow branch
+		// already holds, so condensation finds nothing to do — the state that
+		// leaves a stamped trailer unfilled.
+		noNewContent bool
+		// ownsTrailer presets LastCheckpointID to the committed trailer, which
+		// is what an amend looks like: the trailer is inherited and the
+		// checkpoint was written by the commit being amended.
+		ownsTrailer bool
+		// sequenceOp simulates rebase/cherry-pick/revert via .git/rebase-merge.
+		sequenceOp bool
+		// endedAndCondensed makes the loop skip this session entirely, so its
+		// ownership is only visible from the pre-loop snapshot.
+		endedAndCondensed bool
+		// signalAlreadyReported makes newCommitCondensedSignal dedupe and return
+		// nil for a condensation that still happens — the amend-re-condense
+		// shape, and the reason claim cannot be read off the telemetry signal.
+		signalAlreadyReported bool
+		wantLogged            bool
+	}{
+		{
+			name:         "idle session with nothing to condense is unclaimed",
+			phase:        session.PhaseIdle,
+			noNewContent: true,
+			wantLogged:   true,
+		},
+		{
+			name:         "amend is claimed: the session already owns the checkpoint",
+			phase:        session.PhaseIdle,
+			noNewContent: true,
+			ownsTrailer:  true,
+		},
+		{
+			name:              "amend after the session ended is claimed: the loop skips its owner",
+			phase:             session.PhaseEnded,
+			noNewContent:      true,
+			ownsTrailer:       true,
+			endedAndCondensed: true,
+		},
+		{
+			name:         "sequence operation is excluded: ownership is not local",
+			phase:        session.PhaseIdle,
+			noNewContent: true,
+			sequenceOp:   true,
+		},
+		{
+			name:  "active session that condenses is claimed",
+			phase: session.PhaseActive,
+		},
+		{
+			name:                  "condensing with a deduped telemetry signal is still claimed",
+			phase:                 session.PhaseActive,
+			signalAlreadyReported: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := setupGitRepo(t)
+			t.Chdir(dir)
+
+			repo, err := OpenRepository(context.Background())
+			require.NoError(t, err)
+
+			s := &ManualCommitStrategy{}
+			sessionID := "test-unclaimed-trailer"
+			setupSessionWithCheckpoint(t, s, repo, dir, sessionID)
+
+			state, err := s.loadSessionState(context.Background(), sessionID)
+			require.NoError(t, err)
+			state.Phase = tt.phase
+			if tt.noNewContent {
+				state.LastInteractionTime = nil
+				state.CheckpointTranscriptStart = 2
+				state.CheckpointTranscriptSize = shadowTranscriptSize(t, repo, state)
+			}
+			if tt.ownsTrailer {
+				state.LastCheckpointID = id.MustCheckpointID(trailerID)
+			}
+			if tt.endedAndCondensed {
+				state.FullyCondensed = true
+			}
+			if tt.signalAlreadyReported {
+				state.CommitCondensedSignalCheckpointID = id.MustCheckpointID(trailerID).String()
+			}
+			require.NoError(t, s.saveSessionState(context.Background(), state))
+
+			if tt.sequenceOp {
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git", "rebase-merge"), 0o750))
+			}
+
+			commitWithCheckpointTrailer(t, repo, dir, trailerID)
+
+			logs := captureStrategyLogs(t, func(ctx context.Context) {
+				require.NoError(t, s.PostCommit(ctx))
+			})
+
+			if tt.wantLogged {
+				assert.Contains(t, logs, unclaimedTrailerLogMessage,
+					"expected the unclaimed-trailer line")
+				assert.Contains(t, logs, `"level":"DEBUG"`,
+					"DEBUG, not WARN: the condition has false-positive classes this cannot exclude")
+				return
+			}
+			assert.NotContains(t, logs, unclaimedTrailerLogMessage,
+				"the trailer resolves to a real checkpoint here; logging it would be a false positive")
+		})
+	}
+}
+
+// captureStrategyLogs runs fn with a real Logger writing to a temp directory and
+// returns everything it emitted. A real Logger rather than a fake handler keeps
+// the assertion honest about level, since that is half of what is under test.
+func captureStrategyLogs(t *testing.T, fn func(ctx context.Context)) string {
+	t.Helper()
+
+	logDir := t.TempDir()
+	logger, err := logging.New(logging.Config{Dir: logDir, Level: slog.LevelDebug})
+	require.NoError(t, err)
+
+	fn(logging.WithLogger(context.Background(), logger))
+	require.NoError(t, logger.Close())
+
+	content, err := os.ReadFile(filepath.Join(logDir, "entire.log"))
+	if errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	require.NoError(t, err)
+	return string(content)
+}
+
+// TestPostCommit_PartialCommit_TrailerIsClaimed is the regression guard for inferring
+// condensation from session state instead of reading it from
+// postCommitProcessSessionLocked. A partial commit condenses successfully and
+// then carries the uncommitted files forward, and carryForwardToNewShadowBranch
+// clears LastCheckpointID on the way out — so the post-loop state of a
+// successful condensation is identical to never having condensed.
+// TestPostCommit_ActiveSession_CarryForward_PartialCommit pins that clearing as
+// intended behaviour; this pins that the trailer is still counted as claimed.
+func TestPostCommit_PartialCommit_TrailerIsClaimed(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	repo, err := OpenRepository(context.Background())
+	require.NoError(t, err)
+
+	s := &ManualCommitStrategy{}
+	sessionID := "test-unclaimed-partial-commit"
+
+	metadataDir := ".entire/metadata/" + sessionID
+	metadataDirAbs := filepath.Join(dir, metadataDir)
+	require.NoError(t, os.MkdirAll(metadataDirAbs, 0o750))
+	transcript := `{"type":"human","message":{"content":"create files A B C"}}
+{"type":"assistant","message":{"content":"creating files"}}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(metadataDirAbs, paths.TranscriptFileName), []byte(transcript), 0o600))
+
+	for _, name := range []string{"A.txt", "B.txt", "C.txt"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(name), 0o600))
+	}
+	require.NoError(t, s.SaveStep(context.Background(), StepContext{
+		SessionID:      sessionID,
+		NewFiles:       []string{"A.txt", "B.txt", "C.txt"},
+		MetadataDir:    metadataDir,
+		MetadataDirAbs: metadataDirAbs,
+		CommitMessage:  "Checkpoint: files A, B, C",
+		AuthorName:     "Test",
+		AuthorEmail:    "test@test.com",
+	}))
+
+	state, err := s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	state.Phase = session.PhaseActive
+	require.NoError(t, s.saveSessionState(context.Background(), state))
+
+	// Commit A and B but not C, so condensation succeeds and carry-forward runs.
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("A.txt")
+	require.NoError(t, err)
+	_, err = wt.Add("B.txt")
+	require.NoError(t, err)
+	_, err = wt.Commit(
+		"commit A and B\n\n"+trailers.CheckpointTrailerKey+": cf1cf2cf3cf4\n",
+		&git.CommitOptions{Author: &object.Signature{
+			Name: "Test", Email: "test@test.com", When: time.Now(),
+		}})
+	require.NoError(t, err)
+
+	logs := captureStrategyLogs(t, func(ctx context.Context) {
+		require.NoError(t, s.PostCommit(ctx))
+	})
+
+	state, err = s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"C.txt"}, state.FilesTouched,
+		"precondition: carry-forward must have run, which is what clears LastCheckpointID")
+	require.Empty(t, state.LastCheckpointID,
+		"precondition: carry-forward cleared the ID the warning must not depend on")
+
+	assert.NotContains(t, logs, unclaimedTrailerLogMessage,
+		"a partial commit condensed successfully; the trailer resolves")
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1138
<!-- entire-trail-link-end -->

Extracted from #2034 at review request — the warning it added fired on ordinary git usage, so it came out of that PR and lands here with the guards it needed.

## The gap

`PrepareCommitMsg` stamps an `Entire-Checkpoint` trailer on a session it judges eligible. `PostCommit` then decides independently whether to condense that session. When the two disagree, the commit ships a trailer naming a checkpoint nobody wrote, and `entire explain` on it resolves to nothing.

Each half looks like a routine skip on its own — "session not eligible", "nothing new to condense" — so the divergence is invisible today. There's a known live instance of this shape (IDLE session with empty `FilesTouched`), which is what motivated the warning.

## Why DEBUG, not WARN

Review found two more false-positive classes beyond the two guarded below, and the second is not cheaply fixable: `git merge --squash` and `git commit -C` copy an `Entire-Checkpoint` trailer out of an existing commit message without being sequencer operations, and `PrepareCommitMsg` deliberately never stamps a squash — so no local session owns the inherited ID and `isGitSequenceOperation` does not see it.

The exact discriminator is "did Entire mint this trailer for this commit", but `PrepareCommitMsg` writes no session state at all today, so recording that adds a lock-taking write to a read-only hook on the latency-critical path. Not worth it for a diagnostic. So this logs at DEBUG, where a false positive costs nothing; an authoritative check belongs in `entire doctor`, which can afford to ask the store whether the ID resolves. That is the natural follow-up and is not in this PR.

## The signal

Two inputs, because neither alone is sufficient:

- **This invocation** — `postCommitProcessSessionLocked` now reports whether the session condensed. This has to be read from the call rather than inferred from state afterwards: carry-forward on a partial commit clears `LastCheckpointID` that `condenseAndUpdateState` had just set (`TestPostCommit_ActiveSession_CarryForward_PartialCommit` pins that clearing as intended), so a successful partial condensation is indistinguishable from never having condensed. Caught in review; regression test added.
- **A previous commit** — ownership seeded from `LastCheckpointID` across the pre-loop snapshot, which is the amend case and also covers an amend whose owning session has since ended and is skipped by the loop.

## The two exclusions

These matter even at DEBUG: without them the line says nothing useful to whoever greps for it.

- **Amend.** `handleAmendCommitMsg` preserves or restores the trailer, and a message-only amend has nothing new to condense. Covered by seeding ownership from the pre-loop snapshot, which also catches the case where the owning session has since ended and the loop skips it.
- **Cherry-pick, revert, rebase replay.** The trailer rides along from a source commit whose session may not exist in this worktree at all, so ownership can't be established locally. Covered by the `isRebase` guard (`isGitSequenceOperation` already detects all three).

## Tests

Five subtests in `TestPostCommit_UnclaimedCheckpointTrailer` — the shape the line is for, plus amend, amend-after-session-ended, sequence operation, and a session that does condense — and `TestPostCommit_PartialCommit_TrailerIsClaimed` for the carry-forward case.

Every guard has a test that fails when that guard alone is removed, verified by mutation. That kept catching things: the first version passed every case while the pre-loop seed was dead code, because the amend case as written was caught by the in-loop check instead. The seed only matters for an amend after the session ended, so that case was added.

## Also

Corrects `filterSessionsWithNewContent`'s doc comment. It claimed a withheld stale task record is rescued by "PostCommit … through `sessionHasNewContent`", but withholding the trailer means PostCommit returns at its no-trailer early exit before reaching any session. The rescue is `endSessionNow` or a later trailered commit.

## Verification

`mise run fmt`, `mise run lint` (0 issues), `mise run test:ci` (unit + integration + canary) all clean.

Rebased onto #2013, which added a second `LastCheckpointID` assignment for guest condensation and moved PostCommit onto `findSessionsForCommitLinking` — the same resolver PrepareCommitMsg uses. Had those diverged, every identity-linked guest commit would have false-positived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
