### PR TITLE
fix(checkpoint): avoid false empty result after truncated session scan

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -2935,7 +2935,7 @@ func runExplainBranchWithFilter(ctx context.Context, w, errW io.Writer, noPager 
 	}
 
 	// Format output
-	output := formatBranchCheckpoints(w, branchName, points, sessionFilter)
+	output := formatBranchCheckpointsWithTruncation(w, branchName, points, sessionFilter, truncated)
 
 	outputExplainContent(w, output, noPager)
 
@@ -3117,6 +3117,12 @@ const (
 // Groups commits by checkpoint ID and shows the prompt for each checkpoint.
 // If sessionFilter is non-empty, only shows checkpoints matching that session ID (or prefix).
 func formatBranchCheckpoints(w io.Writer, branchName string, points []strategy.RewindPoint, sessionFilter string) string {
+	return formatBranchCheckpointsWithTruncation(w, branchName, points, sessionFilter, false)
+}
+
+// formatBranchCheckpointsWithTruncation formats a branch view while preserving
+// whether the underlying checkpoint scan was truncated before filtering.
+func formatBranchCheckpointsWithTruncation(w io.Writer, branchName string, points []strategy.RewindPoint, sessionFilter string, truncated bool) string {
 	var sb strings.Builder
 	styles := newStatusStyles(w)
 
@@ -3149,8 +3155,13 @@ func formatBranchCheckpoints(w io.Writer, branchName string, points []strategy.R
 	sb.WriteString("\n")
 
 	if len(groups) == 0 {
-		sb.WriteString("No checkpoints found on this branch.\n")
-		sb.WriteString("Checkpoints will appear here after you save changes during an agent session.\n")
+		if truncated && sessionFilter != "" {
+			sb.WriteString("No checkpoints matching this session were found in the scanned results.\n")
+			sb.WriteString("The checkpoint scan was truncated; older checkpoints may be hidden.\n")
+		} else {
+			sb.WriteString("No checkpoints found on this branch.\n")
+			sb.WriteString("Checkpoints will appear here after you save changes during an agent session.\n")
+		}
 		return sb.String()
 	}
 

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -4367,6 +4367,24 @@ func TestFormatBranchCheckpoints_SessionFilter(t *testing.T) {
 		}
 	})
 
+	t.Run("truncated scan with no filtered matches is not definitive", func(t *testing.T) {
+		output := formatBranchCheckpointsWithTruncation(
+			io.Discard, "main", points, "nonexistent-session", true,
+		)
+		if !strings.Contains(output, "checkpoints  0") {
+			t.Errorf("expected 'checkpoints  0' in output, got:\n%s", output)
+		}
+		if !strings.Contains(output, "No checkpoints matching this session were found in the scanned results.") {
+			t.Errorf("expected non-definitive filtered result, got:\n%s", output)
+		}
+		if !strings.Contains(output, "checkpoint scan was truncated") {
+			t.Errorf("expected truncation explanation, got:\n%s", output)
+		}
+		if strings.Contains(output, "No checkpoints found on this branch.") {
+			t.Errorf("must not claim the branch has no checkpoints, got:\n%s", output)
+		}
+	})
+
 	t.Run("filter matches archived SessionIDs contributor", func(t *testing.T) {
 		// Multi-session checkpoint: latest SessionID is beta, but alpha is still
 		// in SessionIDs. The shared matcher must keep it when filtering for alpha.


### PR DESCRIPTION
## Summary

Fixes #2089.

`checkpoint explain --session <id>` can report `checkpoints 0` and `No checkpoints found on this branch.` when the underlying checkpoint scan reaches its limit and the requested session is not present in the returned window. That output is a false negative: older checkpoints may exist but were not examined.

## Root cause

`getBranchCheckpoints` already returns a truncation signal, but the branch-view path discarded that state before applying the session filter. When filtering removed every checkpoint from the bounded result, the formatter could not distinguish “the branch has no checkpoints” from “no matching checkpoint was found in an incomplete scan.”

## Changes

* Preserve the scan-truncation state through the branch formatter.
* Report that no matching checkpoint was found **in the scanned results** when a session-filtered scan is truncated.
* Keep the existing empty-history message unchanged for genuinely non-truncated empty results.
* Add a native regression test covering the truncated, zero-match-after-filter case.

This change does not alter checkpoint collection limits, JSON output, or the behavior of an unfiltered empty branch.

## Validation

* `go test ./cmd/entire/cli -run 'TestFormatBranchCheckpoints|TestGetBranchCheckpoints_TruncationSignal|TestRunExplainBranchWithFilter'`
* `go test ./cmd/entire/cli`
* `git diff --check`

Both targeted and complete `cmd/entire/cli` package tests pass locally.