### PR TITLE
fix(search): drop the MySQL-sourced repo description from compact output (ENT-1912 follow-up)

### DIFF
--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -364,9 +364,10 @@ func (r *Result) ResultAuthor() string {
 }
 
 // ResultID returns the primary ID for any result type. Types without a typed
-// struct (repo, pr) fall back to the "id" field of the raw payload, so a
-// cross-cell merge can still identify the same logical result returned by two
-// cells (e.g. a repo mirrored in both).
+// struct (repo, pr) fall back to the "id" field of the raw payload; for a repo
+// row that is the placement ULID query-serve keys the namespace on (ENT-1912,
+// entire-search#198), the same identifier the repo index and the `repo` filter
+// use.
 func (r *Result) ResultID() string {
 	if id := resultField(r,
 		func(c *CheckpointResult) string { return c.ID },
@@ -448,13 +449,6 @@ func (r *Result) ResultTitle() string {
 		return v
 	}
 	return r.rawString("title", "name", "fullName")
-}
-
-// ResultDescription returns the repo description for raw-payload rows
-// (searcher.RepoResult). Typed rows return "" — rawFields is never populated
-// for them.
-func (r *Result) ResultDescription() string {
-	return r.rawString("description")
 }
 
 // ResultCheckpointCount returns the indexed checkpoint count for raw-payload

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -1047,10 +1047,11 @@ type compactSearchHit struct {
 	Date         string   `json:"date,omitempty"`
 	Title        string   `json:"title"`
 	FilesTouched []string `json:"filesTouched,omitempty"`
-	// Description and CheckpointCount only appear on repo rows — without them
-	// a repo hit is just {id, repo, title, score}, too thin for the skill's
-	// "summarize from the compact fields alone" instruction.
-	Description     string  `json:"description,omitempty"`
+	// CheckpointCount only appears on repo rows — without it a repo hit is
+	// just {id, repo, title, score}, too thin for the skill's "summarize from
+	// the compact fields alone" instruction. The repo description is not
+	// carried: its only source was the retired MySQL repos table, so the v1
+	// wire keeps the key but it is always null (ENT-1912, entire-search#198).
 	CheckpointCount int     `json:"checkpointCount,omitempty"`
 	Score           float64 `json:"score"`
 	// Snippet is the matched text (the title is just the commit subject or
@@ -1100,7 +1101,6 @@ func writeSearchCompactJSON(w io.Writer, resp *search.Response, limit, page int)
 			Author:          r.ResultAuthor(),
 			Date:            r.ResultCreatedAt(),
 			Title:           title,
-			Description:     r.ResultDescription(),
 			CheckpointCount: r.ResultCheckpointCount(),
 			Score:           r.Meta.Score,
 			Snippet:         compactSnippet(title, truncateOneLine(r.Meta.Snippet, compactTitleMaxLen)),

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -150,7 +150,11 @@ func TestWriteSearchCompactJSON_TrimsResults(t *testing.T) {
 
 // Repo/pr rows (reachable via --all-repos) have no typed struct; compact hits
 // must still carry identifying info from the raw payload instead of collapsing
-// to just {id, type, score}.
+// to just {id, type, score}. checkpointCount is carried through (core
+// repo_facts); the repo description is not — its only source was the retired
+// MySQL repos table and the v1 wire now sends it as always-null (ENT-1912,
+// entire-search#198). The fixture sends a non-null value to prove the CLI
+// drops it regardless of what an un-redeployed cell still emits.
 func TestWriteSearchCompactJSON_RepoAndPRRowsKeepIdentifyingFields(t *testing.T) {
 	t.Parallel()
 
@@ -173,7 +177,6 @@ func TestWriteSearchCompactJSON_RepoAndPRRowsKeepIdentifyingFields(t *testing.T)
 		`"id": "01JREPO"`,
 		`"repo": "acme/backend"`,
 		`"title": "backend"`,
-		`"description": "Backend services"`,
 		`"checkpointCount": 18`,
 		`"id": "pr-9"`,
 		`"title": "Fix login retry"`,
@@ -186,6 +189,10 @@ func TestWriteSearchCompactJSON_RepoAndPRRowsKeepIdentifyingFields(t *testing.T)
 	// The owner must never be doubled when the payload carries a qualified fullName.
 	if strings.Contains(output, "acme/acme/") {
 		t.Errorf("compact output doubled the repo owner:\n%s", output)
+	}
+	// The MySQL-era repo description is never surfaced, even when a cell sends it.
+	if strings.Contains(output, `"description"`) {
+		t.Errorf("compact output carries retired repo description:\n%s", output)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1142
<!-- entire-trail-link-end -->

## What was broken

`entire search --json --compact` still surfaced a repo `description` on repo hits. That value only ever existed because the search service read it from the legacy PlanetScale (MySQL) repos table. With entirehq/entire-search#198 (ENT-1912) that source is gone: the v1 wire keeps the key for compatibility but it is always `null`, so the CLI was carrying a field that can never be populated again.

## Why

The CLI itself never touched MySQL — it only speaks HTTP to the control plane and to query-serve through the entire-api cell gateway, and the old v3 worker route was removed in #1800. The one MySQL-shaped assumption left was this repo-field reader in the compact output.

## The fix

1. Drop the repo-description accessor and the `description` field from compact hits.
2. Keep `checkpointCount` on repo hits — #198 re-sources it from core's repo facts, so it stays populated.
3. Note in the repo-id comment that a repo hit's `id` is now the placement ULID (the same key the repo index and `--repo` filter use).

Safe to ship before or after #198 is promoted: the CLI ignores keys it doesn't read, and the service keeps `description` on the wire as `null`.

## Verified

`mise run fmt && mise run lint` (0 issues), `mise run test` (9824 tests pass), `mise run test:integration` (530 pass). Compact-output test now asserts `description` is never emitted even when a cell still sends a value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tdxy7nmeGg3sFPFMhFfSM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agent-facing compact JSON shape change only; no auth or search request behavior changes.
> 
> **Overview**
> **`entire search --json --compact` no longer includes repo `description` on repo hits.** That field only came from the legacy MySQL repos table; after ENT-1912 / entire-search#198 the v1 wire keeps the key as always-null, so the CLI stops surfacing it.
> 
> The change removes `ResultDescription()` and the `description` field on `compactSearchHit`, while **`checkpointCount` stays** on repo rows (sourced from core repo facts). Comments now note that repo hit **`id` is the placement ULID** used by query-serve, the repo index, and `--repo` filtering.
> 
> Tests assert compact JSON never contains `"description"`, even when a cell still sends a non-null value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c66faf9d0bb531885d84df3a27057a4dc03340a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->