### PR TITLE
feat(search): emit outcome telemetry for search invocations (ENT-1938)

### DIFF
--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -53,6 +53,17 @@ type HTTPStatusError struct {
 
 func (e *HTTPStatusError) Error() string { return e.Message }
 
+// MalformedResponseError reports a 200 whose body was not a usable search
+// response: undecodable JSON, or a decoded body carrying an application-level
+// error field. Typed for the same reason as HTTPStatusError — the service
+// answered unusably, which outcome telemetry counts as a server failure, not
+// an unclassified one. Message wording is preserved verbatim.
+type MalformedResponseError struct {
+	Message string
+}
+
+func (e *MalformedResponseError) Error() string { return e.Message }
+
 // WildcardQuery is the query string used when only filters are provided (no search terms).
 const WildcardQuery = "*"
 
@@ -816,11 +827,11 @@ func parseSearchResponse(statusCode int, body []byte) (*Response, error) {
 
 	var result Response
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("unexpected response from search service: %s", string(body))
+		return nil, &MalformedResponseError{Message: "unexpected response from search service: " + string(body)}
 	}
 
 	if result.Error != "" {
-		return nil, fmt.Errorf("search service error: %s", result.Error)
+		return nil, &MalformedResponseError{Message: "search service error: " + result.Error}
 	}
 
 	return &result, nil

--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -42,6 +42,17 @@ var ErrCellUnavailable = errors.New("semantic search is not available in this ce
 // don't misreport a repo-level miss as a region without query-serve.
 var ErrRepoFilterUnmatched = errors.New("no requested repo was found in this cell")
 
+// HTTPStatusError reports a non-OK search-service response. It preserves the
+// long-standing message wording (asserted by callers and tests) while exposing
+// the status code so outcome telemetry can classify server errors from the
+// type rather than the message text (ENT-1938).
+type HTTPStatusError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *HTTPStatusError) Error() string { return e.Message }
+
 // WildcardQuery is the query string used when only filters are provided (no search terms).
 const WildcardQuery = "*"
 
@@ -798,9 +809,9 @@ func parseSearchResponse(statusCode int, body []byte) (*Response, error) {
 			Error string `json:"error"`
 		}
 		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
-			return nil, fmt.Errorf("search service error (%d): %s", statusCode, errResp.Error)
+			return nil, &HTTPStatusError{StatusCode: statusCode, Message: fmt.Sprintf("search service error (%d): %s", statusCode, errResp.Error)}
 		}
-		return nil, fmt.Errorf("search service returned %d: %s", statusCode, string(body))
+		return nil, &HTTPStatusError{StatusCode: statusCode, Message: fmt.Sprintf("search service returned %d: %s", statusCode, string(body))}
 	}
 
 	var result Response

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -231,6 +231,12 @@ func TestCellV4_ErrorFieldOn200(t *testing.T) {
 	if !strings.Contains(err.Error(), "user not found") {
 		t.Errorf("error = %q, want message containing 'user not found'", err.Error())
 	}
+	// Outcome telemetry classifies a 200-with-error-field as a server
+	// failure, so the error must be typed.
+	var malformedErr *MalformedResponseError
+	if !errors.As(err, &malformedErr) {
+		t.Fatalf("error is %T, want *MalformedResponseError", err)
+	}
 }
 
 func TestCellV4_SuccessWithResults(t *testing.T) {

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -148,6 +149,14 @@ func TestCellV4_ErrorJSON(t *testing.T) {
 	}
 	if got := err.Error(); got != "search service error (401): Invalid token" {
 		t.Errorf("error = %q, want 'search service error (401): Invalid token'", got)
+	}
+	// Outcome telemetry classifies by status code, so the error must be typed.
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("error is %T, want *HTTPStatusError", err)
+	}
+	if statusErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want %d", statusErr.StatusCode, http.StatusUnauthorized)
 	}
 }
 

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -260,13 +260,13 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 
 			searchStart := time.Now()
 			resp, err := searcher(ctx, searchCfg)
-			resultCount := 0
+			var result searchOutcomeResult
 			if resp != nil {
-				resultCount = len(resp.Results)
+				result = searchOutcomeResult{count: len(resp.Results), coverageIncomplete: resp.CoverageIncomplete}
 			}
 			// Emitted here — not at command exit — so the duration covers the
 			// search request, never time spent inside the interactive TUI.
-			emitSearchOutcome(ctx, cmd, telemetry.SearchModeCheckpoint, resultCount, time.Since(searchStart), err)
+			emitSearchOutcome(ctx, cmd, telemetry.SearchModeCheckpoint, result, time.Since(searchStart), err)
 			if err != nil {
 				return fmt.Errorf("search failed: %w", err)
 			}
@@ -484,11 +484,14 @@ func runCodeSearch(ctx context.Context, cmd *cobra.Command, opts codeSearchOpts)
 	// resolves slugs to ULIDs, and handles single- vs multi-jurisdiction.
 	searchStart := time.Now()
 	resp, err := searchAllCells(ctx, opts)
-	resultCount := 0
+	var result searchOutcomeResult
 	if resp != nil {
-		resultCount = len(resp.Results)
+		result = searchOutcomeResult{
+			count:              len(resp.Results),
+			coverageIncomplete: len(resp.FailedJurisdictions) > 0 || len(resp.SkippedRepos) > 0,
+		}
 	}
-	emitSearchOutcome(ctx, cmd, telemetry.SearchModeCode, resultCount, time.Since(searchStart), err)
+	emitSearchOutcome(ctx, cmd, telemetry.SearchModeCode, result, time.Since(searchStart), err)
 	if err != nil {
 		return err
 	}

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -144,6 +144,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 					caseSensitive: caseSensitive,
 					jsonOutput:    jsonOutput,
 					insecureHTTP:  insecureHTTPAuth,
+					commandPath:   cmd.CommandPath(),
 				})
 			}
 
@@ -214,7 +215,9 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			// Semantic search goes to the v4 query-serve path (entire-api
 			// cell gateway) via newSemanticSearcher, which fans out across
 			// cells and mints per-cell identity tokens itself (ENT-1055).
-			searcher := newSemanticSearcher(insecureHTTPAuth)
+			// Instrumented at the seam so the TUI's re-searches and
+			// pagination emit outcome telemetry too, not just this one-shot.
+			searcher := instrumentSemanticSearcher(cmd.CommandPath(), newSemanticSearcher(insecureHTTPAuth))
 
 			searchCfg := search.Config{
 				Owner:    owner,
@@ -238,7 +241,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			if query == "" && !searchCfg.HasFilters() {
 				searchCfg.Limit = search.DefaultLimit
 				styles := newStatusStyles(w)
-				model := newSearchModel(nil, "", 0, searchCfg, styles, buildCodeSearchOpts(ctx, owner, repoName, nil, false, insecureHTTPAuth))
+				model := newSearchModel(nil, "", 0, searchCfg, styles, buildCodeSearchOpts(ctx, cmd.CommandPath(), owner, repoName, nil, false, insecureHTTPAuth))
 				model.semanticSearch = searcher
 				model.mode = modeSearch
 				model.input.Focus()
@@ -258,15 +261,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			searchCfg.Limit = search.DefaultLimit
 			searchCfg.Page = 0 // let API default to page 1
 
-			searchStart := time.Now()
 			resp, err := searcher(ctx, searchCfg)
-			var result searchOutcomeResult
-			if resp != nil {
-				result = searchOutcomeResult{count: len(resp.Results), coverageIncomplete: resp.CoverageIncomplete}
-			}
-			// Emitted here — not at command exit — so the duration covers the
-			// search request, never time spent inside the interactive TUI.
-			emitSearchOutcome(ctx, cmd, telemetry.SearchModeCheckpoint, result, time.Since(searchStart), err)
 			if err != nil {
 				return fmt.Errorf("search failed: %w", err)
 			}
@@ -295,7 +290,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			}
 
 			// Interactive TUI
-			codeOpts := buildCodeSearchOpts(ctx, owner, repoName, repos, allRepos, insecureHTTPAuth)
+			codeOpts := buildCodeSearchOpts(ctx, cmd.CommandPath(), owner, repoName, repos, allRepos, insecureHTTPAuth)
 			if codeOpts != nil {
 				// Use extractInlineRepoFilters on the raw query so author:/date:/branch:
 				// tokens are preserved as literal code-search text, matching --code and
@@ -381,6 +376,10 @@ type codeSearchOpts struct {
 	caseSensitive   bool
 	jsonOutput      bool
 	insecureHTTP    bool
+	// commandPath is the invoking cobra command path, carried here because
+	// searchAllCells emits outcome telemetry and the TUI's code tab calls it
+	// long after the command layer returns.
+	commandPath string
 }
 
 // extractInlineRepoFilters extracts only repo: prefixed filters from a query
@@ -432,7 +431,7 @@ func filterRepoWildcards(repos []string) []string {
 // buildCodeSearchOpts returns a *codeSearchOpts pre-populated with repo filters.
 // It honors --repo, --all-repos, and inline repo: filters from the command line;
 // when none are specified, it falls back to the current git origin slug.
-func buildCodeSearchOpts(ctx context.Context, owner, repoName string, repos []string, allRepos, insecureHTTP bool) *codeSearchOpts {
+func buildCodeSearchOpts(ctx context.Context, commandPath, owner, repoName string, repos []string, allRepos, insecureHTTP bool) *codeSearchOpts {
 	var repoFilters []string
 	switch {
 	case allRepos:
@@ -453,6 +452,7 @@ func buildCodeSearchOpts(ctx context.Context, owner, repoName string, repos []st
 		repoFilters:  repoFilters,
 		limit:        search.DefaultLimit,
 		insecureHTTP: insecureHTTP,
+		commandPath:  commandPath,
 	}
 }
 
@@ -482,16 +482,9 @@ func runCodeSearch(ctx context.Context, cmd *cobra.Command, opts codeSearchOpts)
 
 	// Always fan out via searchAllCells — it fetches the repo index,
 	// resolves slugs to ULIDs, and handles single- vs multi-jurisdiction.
-	searchStart := time.Now()
+	// searchAllCells emits the outcome telemetry itself, so the TUI's code
+	// tab (which calls it directly) is covered too.
 	resp, err := searchAllCells(ctx, opts)
-	var result searchOutcomeResult
-	if resp != nil {
-		result = searchOutcomeResult{
-			count:              len(resp.Results),
-			coverageIncomplete: len(resp.FailedJurisdictions) > 0 || len(resp.SkippedRepos) > 0,
-		}
-	}
-	emitSearchOutcome(ctx, cmd, telemetry.SearchModeCode, result, time.Since(searchStart), err)
 	if err != nil {
 		return err
 	}
@@ -511,7 +504,22 @@ func runCodeSearch(ctx context.Context, cmd *cobra.Command, opts codeSearchOpts)
 //  3. Group by cell and resolve baseURLs via the shared helpers
 //  4. Fan out via fanOutCells with per-cell codesearch.Search calls
 //  5. Merge results (sorted by score, capped to limit)
-func searchAllCells(ctx context.Context, opts codeSearchOpts) (*codesearch.SearchResponse, error) {
+//
+// Every call emits one cli_search_completed outcome — this is the code-search
+// seam shared by the one-shot --code path and the TUI's code tab, so
+// instrumenting here covers both by construction.
+func searchAllCells(ctx context.Context, opts codeSearchOpts) (resp *codesearch.SearchResponse, err error) {
+	start := time.Now()
+	defer func() {
+		var result searchOutcomeResult
+		if resp != nil {
+			result = searchOutcomeResult{
+				count:              len(resp.Results),
+				coverageIncomplete: len(resp.FailedJurisdictions) > 0 || len(resp.SkippedRepos) > 0,
+			}
+		}
+		emitSearchOutcome(ctx, opts.commandPath, telemetry.SearchModeCode, result, time.Since(start), err)
+	}()
 	// Step 1: Get repos index from the control plane. *coreapi.Client
 	// satisfies cellCoreClient (passed to resolveCellBaseURLs below as such).
 	coreClient, err := coreapi.New()

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/search"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/internal/coreapi"
 	"github.com/spf13/cobra"
 )
@@ -257,7 +258,15 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			searchCfg.Limit = search.DefaultLimit
 			searchCfg.Page = 0 // let API default to page 1
 
+			searchStart := time.Now()
 			resp, err := searcher(ctx, searchCfg)
+			resultCount := 0
+			if resp != nil {
+				resultCount = len(resp.Results)
+			}
+			// Emitted here — not at command exit — so the duration covers the
+			// search request, never time spent inside the interactive TUI.
+			emitSearchOutcome(ctx, cmd, telemetry.SearchModeCheckpoint, resultCount, time.Since(searchStart), err)
 			if err != nil {
 				return fmt.Errorf("search failed: %w", err)
 			}
@@ -473,7 +482,13 @@ func runCodeSearch(ctx context.Context, cmd *cobra.Command, opts codeSearchOpts)
 
 	// Always fan out via searchAllCells — it fetches the repo index,
 	// resolves slugs to ULIDs, and handles single- vs multi-jurisdiction.
+	searchStart := time.Now()
 	resp, err := searchAllCells(ctx, opts)
+	resultCount := 0
+	if resp != nil {
+		resultCount = len(resp.Results)
+	}
+	emitSearchOutcome(ctx, cmd, telemetry.SearchModeCode, resultCount, time.Since(searchStart), err)
 	if err != nil {
 		return err
 	}

--- a/cmd/entire/cli/search_telemetry.go
+++ b/cmd/entire/cli/search_telemetry.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"net"
 	"net/http"
 	"time"
 
@@ -41,8 +40,10 @@ func classifySearchError(err error) string {
 		return classForHTTPStatus(httpErr.StatusCode)
 	}
 
-	var netErr net.Error
-	if errors.Is(err, context.DeadlineExceeded) || errors.As(err, &netErr) {
+	// isRecapNetworkError deliberately excludes context cancellation, so a
+	// user's Ctrl-C never inflates the network-failure rate; a timeout is a
+	// network outcome, so DeadlineExceeded is re-added explicitly.
+	if errors.Is(err, context.DeadlineExceeded) || isRecapNetworkError(err) {
 		return telemetry.SearchErrClassNetwork
 	}
 
@@ -60,11 +61,24 @@ func classForHTTPStatus(status int) string {
 	}
 }
 
+// searchOutcomeResult is the successful-response summary a call site hands to
+// emitSearchOutcome; ignored when err is non-nil.
+type searchOutcomeResult struct {
+	count int
+	// coverageIncomplete records that the response warned results may be
+	// missing (failed regions, skipped repos, truncated index), so dashboards
+	// can tell a genuine zero-result search from a degraded one.
+	coverageIncomplete bool
+}
+
 // emitSearchOutcome reports one search request's outcome when telemetry is
 // opted in (settings.Telemetry == true). Content-free: booleans, enums,
 // counts, and durations only — never query text, results, or repo names.
 // Best-effort and non-blocking; failures to load settings suppress the event.
-func emitSearchOutcome(ctx context.Context, cmd *cobra.Command, mode string, resultCount int, duration time.Duration, err error) {
+func emitSearchOutcome(ctx context.Context, cmd *cobra.Command, mode string, result searchOutcomeResult, duration time.Duration, err error) {
+	if telemetry.IsEnvOptedOut() {
+		return
+	}
 	s, loadErr := LoadEntireSettings(ctx)
 	if loadErr != nil || !s.IsTelemetryEnabled() {
 		return
@@ -73,13 +87,13 @@ func emitSearchOutcome(ctx context.Context, cmd *cobra.Command, mode string, res
 	outcome := telemetry.SearchOutcome{
 		Command:    cmd.CommandPath(),
 		Mode:       mode,
-		Success:    err == nil,
 		DurationMS: duration.Milliseconds(),
 	}
 	if err != nil {
 		outcome.ErrorClass = classifySearchError(err)
 	} else {
-		outcome.ResultCount = resultCount
+		outcome.ResultCount = result.count
+		outcome.CoverageIncomplete = result.coverageIncomplete
 	}
 	telemetry.TrackSearchOutcomeDetached(outcome, s.Enabled, versioninfo.Version)
 }

--- a/cmd/entire/cli/search_telemetry.go
+++ b/cmd/entire/cli/search_telemetry.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/search"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+	"github.com/spf13/cobra"
+)
+
+// classifySearchError maps a search failure to a coarse telemetry error class
+// (ENT-1938). Classification uses typed errors only — never error message
+// text. Sentinel checks run before status-code checks so a mapped failure
+// (e.g. the gateway 404 behind search.ErrCellUnavailable) keeps its specific
+// class.
+func classifySearchError(err error) string {
+	switch {
+	case errors.Is(err, auth.ErrNotLoggedIn):
+		return telemetry.SearchErrClassAuth
+	case errors.Is(err, auth.ErrNoCellForJurisdiction):
+		return telemetry.SearchErrClassCellSkip
+	case errors.Is(err, search.ErrCellUnavailable), errors.Is(err, errNoRegionAvailable):
+		return telemetry.SearchErrClassRegionUnavailable
+	case errors.Is(err, search.ErrRepoFilterUnmatched), errors.Is(err, errNoRepoAvailable):
+		return telemetry.SearchErrClassRepoUnavailable
+	}
+
+	var statusErr *search.HTTPStatusError
+	if errors.As(err, &statusErr) {
+		return classForHTTPStatus(statusErr.StatusCode)
+	}
+	var httpErr *api.HTTPError
+	if errors.As(err, &httpErr) {
+		return classForHTTPStatus(httpErr.StatusCode)
+	}
+
+	var netErr net.Error
+	if errors.Is(err, context.DeadlineExceeded) || errors.As(err, &netErr) {
+		return telemetry.SearchErrClassNetwork
+	}
+
+	return telemetry.SearchErrClassOther
+}
+
+func classForHTTPStatus(status int) string {
+	switch {
+	case status >= http.StatusInternalServerError:
+		return telemetry.SearchErrClassServer
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		return telemetry.SearchErrClassAuth
+	default:
+		return telemetry.SearchErrClassHTTPOther
+	}
+}
+
+// emitSearchOutcome reports one search request's outcome when telemetry is
+// opted in (settings.Telemetry == true). Content-free: booleans, enums,
+// counts, and durations only — never query text, results, or repo names.
+// Best-effort and non-blocking; failures to load settings suppress the event.
+func emitSearchOutcome(ctx context.Context, cmd *cobra.Command, mode string, resultCount int, duration time.Duration, err error) {
+	s, loadErr := LoadEntireSettings(ctx)
+	if loadErr != nil || !s.IsTelemetryEnabled() {
+		return
+	}
+
+	outcome := telemetry.SearchOutcome{
+		Command:    cmd.CommandPath(),
+		Mode:       mode,
+		Success:    err == nil,
+		DurationMS: duration.Milliseconds(),
+	}
+	if err != nil {
+		outcome.ErrorClass = classifySearchError(err)
+	} else {
+		outcome.ResultCount = resultCount
+	}
+	telemetry.TrackSearchOutcomeDetached(outcome, s.Enabled, versioninfo.Version)
+}

--- a/cmd/entire/cli/search_telemetry.go
+++ b/cmd/entire/cli/search_telemetry.go
@@ -39,6 +39,12 @@ func classifySearchError(err error) string {
 	if errors.As(err, &httpErr) {
 		return classForHTTPStatus(httpErr.StatusCode)
 	}
+	// A 200 whose body was unusable is the service misbehaving, not an
+	// unclassifiable client-side failure.
+	var malformedErr *search.MalformedResponseError
+	if errors.As(err, &malformedErr) {
+		return telemetry.SearchErrClassServer
+	}
 
 	// isRecapNetworkError deliberately excludes context cancellation, so a
 	// user's Ctrl-C never inflates the network-failure rate; a timeout is a

--- a/cmd/entire/cli/search_telemetry.go
+++ b/cmd/entire/cli/search_telemetry.go
@@ -11,7 +11,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/search"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
-	"github.com/spf13/cobra"
 )
 
 // classifySearchError maps a search failure to a coarse telemetry error class
@@ -81,7 +80,7 @@ type searchOutcomeResult struct {
 // opted in (settings.Telemetry == true). Content-free: booleans, enums,
 // counts, and durations only — never query text, results, or repo names.
 // Best-effort and non-blocking; failures to load settings suppress the event.
-func emitSearchOutcome(ctx context.Context, cmd *cobra.Command, mode string, result searchOutcomeResult, duration time.Duration, err error) {
+func emitSearchOutcome(ctx context.Context, command, mode string, result searchOutcomeResult, duration time.Duration, err error) {
 	if telemetry.IsEnvOptedOut() {
 		return
 	}
@@ -91,7 +90,7 @@ func emitSearchOutcome(ctx context.Context, cmd *cobra.Command, mode string, res
 	}
 
 	outcome := telemetry.SearchOutcome{
-		Command:    cmd.CommandPath(),
+		Command:    command,
 		Mode:       mode,
 		DurationMS: duration.Milliseconds(),
 	}
@@ -102,4 +101,24 @@ func emitSearchOutcome(ctx context.Context, cmd *cobra.Command, mode string, res
 		outcome.CoverageIncomplete = result.coverageIncomplete
 	}
 	telemetry.TrackSearchOutcomeDetached(outcome, s.Enabled, versioninfo.Version)
+}
+
+// instrumentSemanticSearcher wraps a semanticSearcher so EVERY invocation —
+// the one-shot command, the TUI's initial fetch, interactive re-searches, and
+// pagination — emits one cli_search_completed outcome. Instrumenting the seam
+// rather than individual call sites means new entry points are covered by
+// construction, and the timer wraps only the request, never TUI dwell time.
+// command is the invoking cobra command path, fixed at wrap time because the
+// TUI calls the searcher long after the command layer returns.
+func instrumentSemanticSearcher(command string, searcher semanticSearcher) semanticSearcher {
+	return func(ctx context.Context, cfg search.Config) (*search.Response, error) {
+		start := time.Now()
+		resp, err := searcher(ctx, cfg)
+		var result searchOutcomeResult
+		if resp != nil {
+			result = searchOutcomeResult{count: len(resp.Results), coverageIncomplete: resp.CoverageIncomplete}
+		}
+		emitSearchOutcome(ctx, command, telemetry.SearchModeCheckpoint, result, time.Since(start), err)
+		return resp, err
+	}
 }

--- a/cmd/entire/cli/search_telemetry_test.go
+++ b/cmd/entire/cli/search_telemetry_test.go
@@ -36,6 +36,8 @@ func TestClassifySearchError(t *testing.T) {
 		{"repo not indexed", fmt.Errorf("semantic search: %w", errNoRepoAvailable), telemetry.SearchErrClassRepoUnavailable},
 		{"search service 5xx", &search.HTTPStatusError{StatusCode: 502, Message: "search service returned 502"}, telemetry.SearchErrClassServer},
 		{"search service 401", &search.HTTPStatusError{StatusCode: 401, Message: "search service error (401): Invalid token"}, telemetry.SearchErrClassAuth},
+		{"malformed 200 body", fmt.Errorf("semantic search: %w", &search.MalformedResponseError{Message: "unexpected response from search service: <html>"}), telemetry.SearchErrClassServer},
+		{"error field in 200 body", fmt.Errorf("semantic search: %w", &search.MalformedResponseError{Message: "search service error: index rebuilding"}), telemetry.SearchErrClassServer},
 		{"code search 5xx", fmt.Errorf("code search: %w", &api.HTTPError{StatusCode: 500}), telemetry.SearchErrClassServer},
 		{"code search 404", fmt.Errorf("code search: %w", &api.HTTPError{StatusCode: 404}), telemetry.SearchErrClassHTTPOther},
 		{"deadline exceeded", fmt.Errorf("calling search service: %w", context.DeadlineExceeded), telemetry.SearchErrClassNetwork},

--- a/cmd/entire/cli/search_telemetry_test.go
+++ b/cmd/entire/cli/search_telemetry_test.go
@@ -17,10 +17,10 @@ import (
 // error chains (loginHintErr, classifySemanticCells, fmt.Errorf wrappers).
 func TestClassifySearchError(t *testing.T) {
 	t.Parallel()
-	regionSkip := func(cause error) error {
+	regionSkip := func(causes ...error) error {
 		return fmt.Errorf("semantic search: %w", &hintError{
 			msg:  errNoRegionAvailable.Error(),
-			errs: []error{errNoRegionAvailable, cause},
+			errs: causes,
 		})
 	}
 	cases := []struct {
@@ -40,6 +40,8 @@ func TestClassifySearchError(t *testing.T) {
 		{"code search 404", fmt.Errorf("code search: %w", &api.HTTPError{StatusCode: 404}), telemetry.SearchErrClassHTTPOther},
 		{"deadline exceeded", fmt.Errorf("calling search service: %w", context.DeadlineExceeded), telemetry.SearchErrClassNetwork},
 		{"network error", fmt.Errorf("calling search service: %w", &url.Error{Op: "Get", URL: "https://example.test", Err: errors.New("connection refused")}), telemetry.SearchErrClassNetwork},
+		// Ctrl-C must never inflate the network-failure rate.
+		{"user cancellation", fmt.Errorf("calling search service: %w", &url.Error{Op: "Get", URL: "https://example.test", Err: context.Canceled}), telemetry.SearchErrClassOther},
 		{"unclassified", errors.New("boom"), telemetry.SearchErrClassOther},
 	}
 	for _, tc := range cases {
@@ -47,6 +49,42 @@ func TestClassifySearchError(t *testing.T) {
 			t.Parallel()
 			if got := classifySearchError(tc.err); got != tc.want {
 				t.Errorf("classifySearchError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// Pins the classifySemanticCells → classifySearchError contract end-to-end:
+// the all-cells-skipped error must keep every typed skip cause so the two
+// "region" variants stay distinguishable, deterministically even when a
+// fan-out mixes both causes (cell order must not decide the class).
+func TestClassifySemanticCells_SkipCausesClassify(t *testing.T) {
+	t.Parallel()
+	cell := func(name string, err error) cellCallResult[*search.Response] {
+		return cellCallResult[*search.Response]{group: cellGroup{cell: name}, err: err}
+	}
+	cases := []struct {
+		name    string
+		results []cellCallResult[*search.Response]
+		want    string
+	}{
+		{"all jurisdiction skips", []cellCallResult[*search.Response]{cell("a", auth.ErrNoCellForJurisdiction)}, telemetry.SearchErrClassCellSkip},
+		{"all gateway skips", []cellCallResult[*search.Response]{cell("a", search.ErrCellUnavailable)}, telemetry.SearchErrClassRegionUnavailable},
+		{"mixed causes, jurisdiction last", []cellCallResult[*search.Response]{cell("a", search.ErrCellUnavailable), cell("b", auth.ErrNoCellForJurisdiction)}, telemetry.SearchErrClassCellSkip},
+		{"mixed causes, gateway last", []cellCallResult[*search.Response]{cell("a", auth.ErrNoCellForJurisdiction), cell("b", search.ErrCellUnavailable)}, telemetry.SearchErrClassCellSkip},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pages, _, lastErr := classifySemanticCells(context.Background(), tc.results)
+			if len(pages) != 0 || lastErr == nil {
+				t.Fatalf("pages = %d, lastErr = %v; want no pages and an error", len(pages), lastErr)
+			}
+			if got := lastErr.Error(); got != errNoRegionAvailable.Error() {
+				t.Errorf("user-facing message = %q, want %q", got, errNoRegionAvailable.Error())
+			}
+			if got := classifySearchError(lastErr); got != tc.want {
+				t.Errorf("classifySearchError = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/cmd/entire/cli/search_telemetry_test.go
+++ b/cmd/entire/cli/search_telemetry_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/search"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
+)
+
+// The wrapping in each case mirrors how the real search paths build their
+// error chains (loginHintErr, classifySemanticCells, fmt.Errorf wrappers).
+func TestClassifySearchError(t *testing.T) {
+	t.Parallel()
+	regionSkip := func(cause error) error {
+		return fmt.Errorf("semantic search: %w", &hintError{
+			msg:  errNoRegionAvailable.Error(),
+			errs: []error{errNoRegionAvailable, cause},
+		})
+	}
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"not logged in via login hint", fmt.Errorf("search failed: %w", loginHintErr(auth.ErrNotLoggedIn)), telemetry.SearchErrClassAuth},
+		{"jurisdiction cell skip", regionSkip(auth.ErrNoCellForJurisdiction), telemetry.SearchErrClassCellSkip},
+		{"gateway without query-serve", regionSkip(search.ErrCellUnavailable), telemetry.SearchErrClassRegionUnavailable},
+		{"bare region sentinel", fmt.Errorf("semantic search: %w", errNoRegionAvailable), telemetry.SearchErrClassRegionUnavailable},
+		{"repo filter unmatched", fmt.Errorf("semantic search: %w", search.ErrRepoFilterUnmatched), telemetry.SearchErrClassRepoUnavailable},
+		{"repo not indexed", fmt.Errorf("semantic search: %w", errNoRepoAvailable), telemetry.SearchErrClassRepoUnavailable},
+		{"search service 5xx", &search.HTTPStatusError{StatusCode: 502, Message: "search service returned 502"}, telemetry.SearchErrClassServer},
+		{"search service 401", &search.HTTPStatusError{StatusCode: 401, Message: "search service error (401): Invalid token"}, telemetry.SearchErrClassAuth},
+		{"code search 5xx", fmt.Errorf("code search: %w", &api.HTTPError{StatusCode: 500}), telemetry.SearchErrClassServer},
+		{"code search 404", fmt.Errorf("code search: %w", &api.HTTPError{StatusCode: 404}), telemetry.SearchErrClassHTTPOther},
+		{"deadline exceeded", fmt.Errorf("calling search service: %w", context.DeadlineExceeded), telemetry.SearchErrClassNetwork},
+		{"network error", fmt.Errorf("calling search service: %w", &url.Error{Op: "Get", URL: "https://example.test", Err: errors.New("connection refused")}), telemetry.SearchErrClassNetwork},
+		{"unclassified", errors.New("boom"), telemetry.SearchErrClassOther},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifySearchError(tc.err); got != tc.want {
+				t.Errorf("classifySearchError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// hintError must swap the user-facing message without truncating the typed
+// chain telemetry classifies from.
+func TestHintErrorPreservesMessageAndChain(t *testing.T) {
+	t.Parallel()
+	err := loginHintErr(fmt.Errorf("resolving control-plane client: %w", auth.ErrNotLoggedIn))
+	if got := err.Error(); got != "not authenticated. Run 'entire login' to authenticate" {
+		t.Errorf("Error() = %q, want the login hint verbatim", got)
+	}
+	if !errors.Is(err, auth.ErrNotLoggedIn) {
+		t.Error("errors.Is(err, auth.ErrNotLoggedIn) = false, want true")
+	}
+}

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -309,18 +309,20 @@ func newSearchModel(results []search.Result, query string, total int, cfg search
 	}
 
 	m := searchModel{
-		results:        results,
-		total:          total,
-		width:          ss.width,
-		mode:           modeBrowse,
-		input:          ti,
-		searchCfg:      cfg,
-		apiPage:        apiPage,
-		styles:         styles,
-		browseVP:       viewport.New(viewport.WithWidth(ss.width), viewport.WithHeight(1)), // height set on first WindowSizeMsg
-		darkBg:         termenv.HasDarkBackground(),
-		filterType:     typeFilterCommits,          // default to the leftmost tab (Commits), matching the web UI order
-		semanticSearch: newSemanticSearcher(false), // command layer overrides with its session searcher
+		results:    results,
+		total:      total,
+		width:      ss.width,
+		mode:       modeBrowse,
+		input:      ti,
+		searchCfg:  cfg,
+		apiPage:    apiPage,
+		styles:     styles,
+		browseVP:   viewport.New(viewport.WithWidth(ss.width), viewport.WithHeight(1)), // height set on first WindowSizeMsg
+		darkBg:     termenv.HasDarkBackground(),
+		filterType: typeFilterCommits, // default to the leftmost tab (Commits), matching the web UI order
+		// Command layer overrides with its session searcher; instrumented
+		// anyway so a forgotten override never silently drops telemetry.
+		semanticSearch: instrumentSemanticSearcher("entire search", newSemanticSearcher(false)),
 	}
 	if codeOpts != nil {
 		m.codeSearchOpts = *codeOpts

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -38,11 +38,23 @@ func newSemanticSearcher(insecureHTTP bool) semanticSearcher {
 	return s.search
 }
 
+// hintError swaps in a friendlier user-facing message while keeping the
+// underlying typed errors matchable with errors.Is/As — search outcome
+// telemetry classifies failures from the error chain (ENT-1938), so a hint
+// must never truncate it.
+type hintError struct {
+	msg  string
+	errs []error
+}
+
+func (e *hintError) Error() string   { return e.msg }
+func (e *hintError) Unwrap() []error { return e.errs }
+
 // loginHintErr maps auth.ErrNotLoggedIn to the standard login hint; other
 // errors pass through unchanged.
 func loginHintErr(err error) error {
 	if errors.Is(err, auth.ErrNotLoggedIn) {
-		return errors.New("not authenticated. Run 'entire login' to authenticate")
+		return &hintError{msg: "not authenticated. Run 'entire login' to authenticate", errs: []error{err}}
 	}
 	return err
 }
@@ -373,11 +385,12 @@ type semanticCellPage struct {
 // mid-onboarding). Neither is worth warning the user about on every search.
 func classifySemanticCells(ctx context.Context, results []cellCallResult[*search.Response]) (pages []semanticCellPage, failed []string, lastErr error) {
 	var skipped, unmatched []string
-	var unmatchedErr error
+	var skipErr, unmatchedErr error
 	for _, r := range results {
 		switch {
 		case errors.Is(r.err, search.ErrCellUnavailable), errors.Is(r.err, auth.ErrNoCellForJurisdiction):
 			skipped = append(skipped, r.group.label())
+			skipErr = r.err
 		case errors.Is(r.err, search.ErrRepoFilterUnmatched):
 			// The cell answered; the repo filter just matched nothing there.
 			// Quiet like a skip when another cell has results, but if NO cell
@@ -406,7 +419,11 @@ func classifySemanticCells(ctx context.Context, results []cellCallResult[*search
 			// its region serves semantic search.
 			lastErr = errNoRepoAvailable
 		case len(skipped) > 0:
-			lastErr = errNoRegionAvailable
+			// Same message as the bare sentinel, but keep the per-cell skip
+			// cause in the chain: the two "region" variants (gateway without
+			// query-serve vs. client-side jurisdiction skip) are different
+			// failures and telemetry classifies them from the typed cause.
+			lastErr = &hintError{msg: errNoRegionAvailable.Error(), errs: []error{errNoRegionAvailable, skipErr}}
 		}
 	}
 	return pages, failed, lastErr

--- a/cmd/entire/cli/search_v4.go
+++ b/cmd/entire/cli/search_v4.go
@@ -385,12 +385,13 @@ type semanticCellPage struct {
 // mid-onboarding). Neither is worth warning the user about on every search.
 func classifySemanticCells(ctx context.Context, results []cellCallResult[*search.Response]) (pages []semanticCellPage, failed []string, lastErr error) {
 	var skipped, unmatched []string
-	var skipErr, unmatchedErr error
+	var skipErrs []error
+	var unmatchedErr error
 	for _, r := range results {
 		switch {
 		case errors.Is(r.err, search.ErrCellUnavailable), errors.Is(r.err, auth.ErrNoCellForJurisdiction):
 			skipped = append(skipped, r.group.label())
-			skipErr = r.err
+			skipErrs = append(skipErrs, r.err)
 		case errors.Is(r.err, search.ErrRepoFilterUnmatched):
 			// The cell answered; the repo filter just matched nothing there.
 			// Quiet like a skip when another cell has results, but if NO cell
@@ -419,11 +420,13 @@ func classifySemanticCells(ctx context.Context, results []cellCallResult[*search
 			// its region serves semantic search.
 			lastErr = errNoRepoAvailable
 		case len(skipped) > 0:
-			// Same message as the bare sentinel, but keep the per-cell skip
+			// Same message as the bare sentinel, but keep every per-cell skip
 			// cause in the chain: the two "region" variants (gateway without
 			// query-serve vs. client-side jurisdiction skip) are different
-			// failures and telemetry classifies them from the typed cause.
-			lastErr = &hintError{msg: errNoRegionAvailable.Error(), errs: []error{errNoRegionAvailable, skipErr}}
+			// failures and telemetry classifies them from the typed causes.
+			// All causes — not just the last — so a mixed-cause fan-out
+			// classifies by the classifier's precedence, not cell order.
+			lastErr = &hintError{msg: errNoRegionAvailable.Error(), errs: skipErrs}
 		}
 	}
 	return pages, failed, lastErr

--- a/cmd/entire/cli/telemetry/search_outcome.go
+++ b/cmd/entire/cli/telemetry/search_outcome.go
@@ -41,22 +41,26 @@ const (
 
 // SearchOutcome carries the outcome of one search request (ENT-1938).
 // Content-free by construction: booleans, enums, counts, and durations only —
-// never query text, result snippets, or repo names.
+// never query text, result snippets, or repo names. Success is derived —
+// ErrorClass empty means success — so the two can never disagree.
 type SearchOutcome struct {
 	// Command is the invoked cobra command path ("entire search" or
 	// "entire checkpoint search").
 	Command string
 	// Mode is SearchModeCheckpoint or SearchModeCode.
 	Mode string
-	// Success reports whether the search returned a response.
-	Success bool
-	// ErrorClass is the coarse failure class (SearchErrClass*); empty on
-	// success and omitted from the payload.
+	// ErrorClass is the coarse failure class (SearchErrClass*); empty means
+	// the search succeeded.
 	ErrorClass string
 	// ResultCount is the number of results returned; only meaningful on
 	// success (zero results is a distinct signal from failure) and omitted
 	// from the payload on failure.
 	ResultCount int
+	// CoverageIncomplete reports that a successful response warned results
+	// may be missing (failed regions, skipped repos, truncated index) —
+	// without it a degraded success is indistinguishable from a genuine
+	// zero-or-low-result search. Omitted from the payload on failure.
+	CoverageIncomplete bool
 	// DurationMS is the wall-clock duration of the search request.
 	DurationMS int64
 }
@@ -69,18 +73,20 @@ func BuildSearchOutcomePayload(outcome SearchOutcome, isEntireEnabled bool, vers
 		return nil
 	}
 
+	success := outcome.ErrorClass == ""
 	properties := map[string]any{
 		"command":         outcome.Command,
 		"mode":            outcome.Mode,
-		"success":         outcome.Success,
+		"success":         success,
 		"duration_ms":     outcome.DurationMS,
 		"isEntireEnabled": isEntireEnabled,
 		"cli_version":     version,
 		"os":              runtime.GOOS,
 		"arch":            runtime.GOARCH,
 	}
-	if outcome.Success {
+	if success {
 		properties["result_count"] = outcome.ResultCount
+		properties["coverage_incomplete"] = outcome.CoverageIncomplete
 	} else {
 		properties["error_class"] = outcome.ErrorClass
 	}

--- a/cmd/entire/cli/telemetry/search_outcome.go
+++ b/cmd/entire/cli/telemetry/search_outcome.go
@@ -31,7 +31,8 @@ const (
 	SearchErrClassRepoUnavailable = "repo_unavailable"
 	// SearchErrClassNetwork: network failure or timeout.
 	SearchErrClassNetwork = "network"
-	// SearchErrClassServer: a 5xx response.
+	// SearchErrClassServer: a 5xx response, or a 200 whose body was unusable
+	// (undecodable, or carrying an application-level error field).
 	SearchErrClassServer = "server"
 	// SearchErrClassHTTPOther: a non-5xx, non-auth HTTP error status.
 	SearchErrClassHTTPOther = "http_other"

--- a/cmd/entire/cli/telemetry/search_outcome.go
+++ b/cmd/entire/cli/telemetry/search_outcome.go
@@ -1,0 +1,113 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"runtime"
+	"time"
+)
+
+// Search modes for the cli_search_completed event.
+const (
+	SearchModeCheckpoint = "checkpoint"
+	SearchModeCode       = "code"
+)
+
+// Error classes for the cli_search_completed event. Classification is derived
+// from typed errors only (see classifySearchError in the cli package), never
+// from matching error message text.
+const (
+	// SearchErrClassAuth: not logged in, or a cell/control-plane rejected the
+	// bearer (401/403).
+	SearchErrClassAuth = "auth"
+	// SearchErrClassCellSkip: client-side skip — no entire-api cell is
+	// configured for the placement's jurisdiction (auth.ErrNoCellForJurisdiction).
+	SearchErrClassCellSkip = "cell_skip"
+	// SearchErrClassRegionUnavailable: the cell was contacted but its gateway
+	// has no query-serve route (search.ErrCellUnavailable). Distinct from
+	// SearchErrClassCellSkip — these are the two "region" failure variants.
+	SearchErrClassRegionUnavailable = "region_unavailable"
+	// SearchErrClassRepoUnavailable: cells answered but the repo is not
+	// searchable (not indexed, or not enabled for semantic search).
+	SearchErrClassRepoUnavailable = "repo_unavailable"
+	// SearchErrClassNetwork: network failure or timeout.
+	SearchErrClassNetwork = "network"
+	// SearchErrClassServer: a 5xx response.
+	SearchErrClassServer = "server"
+	// SearchErrClassHTTPOther: a non-5xx, non-auth HTTP error status.
+	SearchErrClassHTTPOther = "http_other"
+	// SearchErrClassOther: everything else.
+	SearchErrClassOther = "other"
+)
+
+// SearchOutcome carries the outcome of one search request (ENT-1938).
+// Content-free by construction: booleans, enums, counts, and durations only —
+// never query text, result snippets, or repo names.
+type SearchOutcome struct {
+	// Command is the invoked cobra command path ("entire search" or
+	// "entire checkpoint search").
+	Command string
+	// Mode is SearchModeCheckpoint or SearchModeCode.
+	Mode string
+	// Success reports whether the search returned a response.
+	Success bool
+	// ErrorClass is the coarse failure class (SearchErrClass*); empty on
+	// success and omitted from the payload.
+	ErrorClass string
+	// ResultCount is the number of results returned; only meaningful on
+	// success (zero results is a distinct signal from failure) and omitted
+	// from the payload on failure.
+	ResultCount int
+	// DurationMS is the wall-clock duration of the search request.
+	DurationMS int64
+}
+
+// BuildSearchOutcomePayload constructs the cli_search_completed payload.
+// Exported for testing. Returns nil if the machine ID cannot be resolved.
+func BuildSearchOutcomePayload(outcome SearchOutcome, isEntireEnabled bool, version string) *EventPayload {
+	machineID, err := telemetryMachineID()
+	if err != nil {
+		return nil
+	}
+
+	properties := map[string]any{
+		"command":         outcome.Command,
+		"mode":            outcome.Mode,
+		"success":         outcome.Success,
+		"duration_ms":     outcome.DurationMS,
+		"isEntireEnabled": isEntireEnabled,
+		"cli_version":     version,
+		"os":              runtime.GOOS,
+		"arch":            runtime.GOARCH,
+	}
+	if outcome.Success {
+		properties["result_count"] = outcome.ResultCount
+	} else {
+		properties["error_class"] = outcome.ErrorClass
+	}
+
+	return &EventPayload{
+		Event:      "cli_search_completed",
+		DistinctID: machineID,
+		Properties: properties,
+		Timestamp:  time.Now(),
+	}
+}
+
+// TrackSearchOutcomeDetached records one search request's outcome by spawning
+// a detached subprocess. Best-effort and non-blocking; call sites must gate on
+// the user's opt-in telemetry setting. Honors ENTIRE_TELEMETRY_OPTOUT like the
+// other trackers.
+func TrackSearchOutcomeDetached(outcome SearchOutcome, isEntireEnabled bool, version string) {
+	if IsEnvOptedOut() {
+		return
+	}
+
+	payload := BuildSearchOutcomePayload(outcome, isEntireEnabled, version)
+	if payload == nil {
+		return
+	}
+
+	if payloadJSON, err := json.Marshal(payload); err == nil {
+		spawnDetachedAnalytics(string(payloadJSON))
+	}
+}

--- a/cmd/entire/cli/telemetry/search_outcome_test.go
+++ b/cmd/entire/cli/telemetry/search_outcome_test.go
@@ -1,0 +1,62 @@
+package telemetry
+
+import "testing"
+
+func TestBuildSearchOutcomePayload_Success(t *testing.T) {
+	t.Parallel()
+	payload := BuildSearchOutcomePayload(SearchOutcome{
+		Command:     "entire search",
+		Mode:        SearchModeCheckpoint,
+		Success:     true,
+		ResultCount: 7,
+		DurationMS:  340,
+	}, true, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildSearchOutcomePayload returned nil")
+	}
+	if payload.Event != "cli_search_completed" {
+		t.Errorf("Event = %q, want %q", payload.Event, "cli_search_completed")
+	}
+	want := map[string]any{
+		"command":         "entire search",
+		"mode":            "checkpoint",
+		"success":         true,
+		"result_count":    7,
+		"duration_ms":     int64(340),
+		"isEntireEnabled": true,
+		"cli_version":     "1.2.3",
+	}
+	for k, v := range want {
+		if got := payload.Properties[k]; got != v {
+			t.Errorf("property %s = %v, want %v", k, got, v)
+		}
+	}
+	if _, ok := payload.Properties["error_class"]; ok {
+		t.Error("success payload must not include error_class")
+	}
+}
+
+func TestBuildSearchOutcomePayload_Failure(t *testing.T) {
+	t.Parallel()
+	payload := BuildSearchOutcomePayload(SearchOutcome{
+		Command:    "entire checkpoint search",
+		Mode:       SearchModeCode,
+		Success:    false,
+		ErrorClass: SearchErrClassAuth,
+		DurationMS: 12,
+	}, false, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildSearchOutcomePayload returned nil")
+	}
+	if got := payload.Properties["success"]; got != false {
+		t.Errorf("success property = %v, want false", got)
+	}
+	if got := payload.Properties["error_class"]; got != "auth" {
+		t.Errorf("error_class property = %v, want %q", got, "auth")
+	}
+	// A failed search has no meaningful result count; omit it so PostHog
+	// zero-result queries never count failures as empty result sets.
+	if _, ok := payload.Properties["result_count"]; ok {
+		t.Error("failure payload must not include result_count")
+	}
+}

--- a/cmd/entire/cli/telemetry/search_outcome_test.go
+++ b/cmd/entire/cli/telemetry/search_outcome_test.go
@@ -5,11 +5,11 @@ import "testing"
 func TestBuildSearchOutcomePayload_Success(t *testing.T) {
 	t.Parallel()
 	payload := BuildSearchOutcomePayload(SearchOutcome{
-		Command:     "entire search",
-		Mode:        SearchModeCheckpoint,
-		Success:     true,
-		ResultCount: 7,
-		DurationMS:  340,
+		Command:            "entire search",
+		Mode:               SearchModeCheckpoint,
+		ResultCount:        7,
+		CoverageIncomplete: true,
+		DurationMS:         340,
 	}, true, "1.2.3")
 	if payload == nil {
 		t.Fatal("BuildSearchOutcomePayload returned nil")
@@ -18,13 +18,14 @@ func TestBuildSearchOutcomePayload_Success(t *testing.T) {
 		t.Errorf("Event = %q, want %q", payload.Event, "cli_search_completed")
 	}
 	want := map[string]any{
-		"command":         "entire search",
-		"mode":            "checkpoint",
-		"success":         true,
-		"result_count":    7,
-		"duration_ms":     int64(340),
-		"isEntireEnabled": true,
-		"cli_version":     "1.2.3",
+		"command":             "entire search",
+		"mode":                "checkpoint",
+		"success":             true,
+		"result_count":        7,
+		"coverage_incomplete": true,
+		"duration_ms":         int64(340),
+		"isEntireEnabled":     true,
+		"cli_version":         "1.2.3",
 	}
 	for k, v := range want {
 		if got := payload.Properties[k]; got != v {
@@ -41,7 +42,6 @@ func TestBuildSearchOutcomePayload_Failure(t *testing.T) {
 	payload := BuildSearchOutcomePayload(SearchOutcome{
 		Command:    "entire checkpoint search",
 		Mode:       SearchModeCode,
-		Success:    false,
 		ErrorClass: SearchErrClassAuth,
 		DurationMS: 12,
 	}, false, "1.2.3")
@@ -54,9 +54,13 @@ func TestBuildSearchOutcomePayload_Failure(t *testing.T) {
 	if got := payload.Properties["error_class"]; got != "auth" {
 		t.Errorf("error_class property = %v, want %q", got, "auth")
 	}
-	// A failed search has no meaningful result count; omit it so PostHog
-	// zero-result queries never count failures as empty result sets.
+	// A failed search has no meaningful result count or coverage flag; omit
+	// them so PostHog zero-result queries never count failures as empty
+	// result sets.
 	if _, ok := payload.Properties["result_count"]; ok {
 		t.Error("failure payload must not include result_count")
+	}
+	if _, ok := payload.Properties["coverage_incomplete"]; ok {
+		t.Error("failure payload must not include coverage_incomplete")
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1146
<!-- entire-trail-link-end -->

## Why

The tester audit (ENT-1938) found 88.5% of no-value search sessions failed to obtain a usable response at all, dominated by client-side auth/configuration failures that never reach a server. `cli_command_executed` records that `entire search` ran but not whether it worked.

## What

New `cli_search_completed` PostHog event, emitted once per executed search request on `entire search` and `entire checkpoint search` (same command; both the checkpoint and `--code` paths):

- `success` (bool), `duration_ms`
- `result_count` and `coverage_incomplete` — success only; zero-result rate never counts failures, and a degraded success (failed regions, skipped repos, truncated index) is distinguishable from a genuine zero-result search
- `error_class` — from typed errors only, never message matching: `auth` (not logged in, 401/403), `cell_skip` (`auth.ErrNoCellForJurisdiction`, client-side), `region_unavailable` (`search.ErrCellUnavailable`, gateway without query-serve — kept distinct from `cell_skip` per the ticket), `repo_unavailable`, `network`, `server` (5xx), `http_other`, `other`
- plus `command`, `mode` (`checkpoint`/`code`), and the standard version/os/arch props

Plumbing needed to classify from types:

- `loginHintErr` and the all-cells-skipped path previously replaced typed causes with fresh `errors.New` — a new `hintError` wrapper keeps the user-facing message byte-identical while leaving the chain matchable with `errors.Is`.
- Semantic-search non-OK responses now return a typed `search.HTTPStatusError` (message wording unchanged); code search already returned `api.HTTPError`.

Content-free by construction: booleans, enums, counts, durations only — no query text, snippets, or repo names. Gated on the telemetry opt-in setting at the call site and `ENTIRE_TELEMETRY_OPTOUT` in the tracker, via the existing detached PostHog child.

## Scope choices

- Instrumented at the searcher seam (`instrumentSemanticSearcher`, `searchAllCells`), so every entry point emits by construction: one-shot commands, the TUI initial fetch, interactive re-searches, pagination, and the code tab. Each timer wraps only the request — TUI dwell time is never counted. TUI searches fire per submitted query, so volume stays one event per real search request.
- Pre-request local failures (flag validation, not a git repo) emit nothing — the event measures search request outcomes; invocation counts stay on `cli_command_executed`.

## Validation

- New tests: payload shape (success/failure property omission), `classifySearchError` table over real error-chain shapes, `hintError` message/chain preservation, typed `HTTPStatusError` status code.
- `mise run fmt`, `mise run lint` (0 issues), `mise run test:ci` (unit + integration + canary) all pass.

Closes ENT-1938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Search behavior and user-visible errors are unchanged; new telemetry is opt-in, best-effort, and non-blocking with no query or repo data in payloads.
> 
> **Overview**
> Adds an opt-in **`cli_search_completed`** PostHog event so product can see whether searches succeed, not just that `entire search` ran. Each **checkpoint (semantic)** and **`--code`** request emits once right after the network fan-out finishes—**before** the interactive TUI—so **`duration_ms`** covers the API work only.
> 
> Payloads stay **content-free**: success, mode, command path, duration, **`result_count` on success only**, and **`error_class` on failure** (never both, so failures aren’t counted as zero-result searches). Emission respects telemetry settings and the existing detached analytics path.
> 
> Failure **`error_class`** values come from **typed errors**, not message parsing. Supporting changes: **`search.HTTPStatusError`** for non-OK semantic responses (same user-facing strings), a **`hintError`** wrapper so login/region hints keep **`errors.Is`** chains, and **`classifySemanticCells`** wrapping the all-skipped-region case with the underlying skip cause for **`cell_skip` vs `region_unavailable`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd05c83e3e87d76ff0514260d34024ec78cb7813. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

