### PR TITLE
fix(cli): show all agents in picker

### DIFF
--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -18,6 +18,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/uiform"
 	"github.com/entireio/cli/internal/coreapi"
 )
 
@@ -139,18 +140,6 @@ func selectableAvailableRepos(avail []coreapi.AvailableMirror) []coreapi.Availab
 		return out[i].Repo < out[j].Repo
 	})
 	return out
-}
-
-// multiSelectHeight returns an explicit huh multi-select Height that keeps every
-// option visible. huh auto-sizes an unset height to (rendered option lines −
-// title/description rows), which collapses to ~1 visible row for short lists
-// (e.g. 3 regions vs. a long repo list) — the cause of the region picker
-// appearing clamped to one option. We set it to the option count plus slack for
-// the title + (possibly wrapped) description so the whole list shows; huh still
-// scrolls if the list outgrows the terminal.
-func multiSelectHeight(n int) int {
-	const headerSlack = 3 // title (1) + description (1–2 when wrapped)
-	return n + headerSlack
 }
 
 // clusterChoices maps regions to multi-select options (value = bare host),
@@ -449,7 +438,7 @@ func pickRepos(ctx context.Context, w io.Writer, repos []coreapi.AvailableMirror
 				Title("Select repos to mirror").
 				Description("Space to select, enter to confirm.").
 				Options(options...).
-				Height(multiSelectHeight(len(options))).
+				Height(uiform.SingleLineMultiSelectHeight(len(options))).
 				Validate(func(s []string) error {
 					if len(s) == 0 {
 						return errors.New("select at least one repo")
@@ -489,7 +478,7 @@ func pickRegions(ctx context.Context, w io.Writer, regions []regionChoice, juris
 				Title("Select regions to mirror into").
 				Description("Each repo is mirrored into every selected region.").
 				Options(opts...).
-				Height(multiSelectHeight(len(opts))).
+				Height(uiform.SingleLineMultiSelectHeight(len(opts))).
 				Validate(func(s []string) error {
 					if len(s) == 0 {
 						return errors.New("select at least one region")

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/uiform"
 	"github.com/entireio/cli/cmd/entire/cli/vercelconfig"
 
 	"charm.land/huh/v2"
@@ -520,6 +521,7 @@ func runManageAgents(ctx context.Context, w io.Writer, opts EnableOptions, selec
 					Title("Manage agents").
 					Description("Use space to select/deselect, enter to confirm.").
 					Options(options...).
+					Height(uiform.SingleLineMultiSelectHeight(len(options))).
 					Value(&selectedAgentNames),
 			),
 		)
@@ -1691,6 +1693,7 @@ var promptAgentSelection = func(options []huh.Option[string]) ([]string, error) 
 				Title("Select the agents you want to use").
 				Description("Use space to select, enter to confirm.").
 				Options(options...).
+				Height(uiform.SingleLineMultiSelectHeight(len(options))).
 				Validate(func(sel []string) error {
 					if len(sel) == 0 {
 						return errors.New("please select at least one agent")

--- a/cmd/entire/cli/uiform/uiform.go
+++ b/cmd/entire/cli/uiform/uiform.go
@@ -87,6 +87,14 @@ func New(groups ...*huh.Group) *huh.Form {
 	return form
 }
 
+// SingleLineMultiSelectHeight reserves three rows for rendered field headers.
+// Callers with multiline options or headers taller than three rows need a
+// different height strategy. The form still clamps this on short terminals.
+func SingleLineMultiSelectHeight(optionCount int) int {
+	const headerRows = 3
+	return optionCount + headerRows
+}
+
 // PromptYN renders a Confirm form with the standard theme/accessibility
 // behavior and returns the user's answer. On user cancellation (Ctrl+C or
 // context.Canceled) returns (false, nil) so callers treat it as a "no";

--- a/cmd/entire/cli/uiform/uiform_test.go
+++ b/cmd/entire/cli/uiform/uiform_test.go
@@ -1,8 +1,11 @@
 package uiform
 
 import (
+	"strings"
 	"testing"
 
+	"charm.land/bubbletea/v2"
+	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
 )
 
@@ -31,4 +34,60 @@ func TestTheme_BlurredTitlesInheritTerminalForeground(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestSingleLineMultiSelectHeight(t *testing.T) {
+	t.Parallel()
+
+	options := []huh.Option[string]{
+		huh.NewOption("Claude Code", "claude-code"),
+		huh.NewOption("Codex", "codex"),
+		huh.NewOption("Copilot CLI", "copilot-cli"),
+		huh.NewOption("Cursor", "cursor"),
+		huh.NewOption("Factory AI Droid", "factoryai-droid"),
+		huh.NewOption("Gemini CLI", "gemini"),
+		huh.NewOption("OpenCode", "opencode"),
+		huh.NewOption("Pi", "pi"),
+	}
+
+	newForm := func() *huh.Form {
+		field := huh.NewMultiSelect[string]().
+			Title("Select the agents you want to use").
+			Description("Use space to select, enter to confirm.").
+			Options(options...).
+			Height(SingleLineMultiSelectHeight(len(options)))
+		form := New(huh.NewGroup(field))
+		form.Init()
+		return form
+	}
+
+	t.Run("shows every option when space is available", func(t *testing.T) {
+		t.Parallel()
+
+		form := newForm()
+		form.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+		view := form.View()
+		for _, option := range options {
+			if !strings.Contains(view, option.Key) {
+				t.Errorf("option %q is not visible in:\n%s", option.Key, view)
+			}
+		}
+	})
+
+	t.Run("scrolls when the terminal clamps the field", func(t *testing.T) {
+		t.Parallel()
+
+		form := newForm()
+		form.Update(tea.WindowSizeMsg{Width: 100, Height: 8})
+		if view := form.View(); strings.Contains(view, "Pi") {
+			t.Fatalf("last option is visible before scrolling in:\n%s", view)
+		}
+
+		for range len(options) - 1 {
+			form.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+		}
+		if view := form.View(); !strings.Contains(view, "Pi") {
+			t.Errorf("last option is not visible after scrolling in:\n%s", view)
+		}
+	})
 }


### PR DESCRIPTION
Fixes #2126.

## Problem

`entire enable` offers eight agents, but huh v2.0.3 initially displays only six even when the terminal has enough rows. Its unset `MultiSelect` height starts with the rendered option height and then subtracts the title and description height, leaving OpenCode and Pi below the initial viewport.

The underlying sizing issue is upstream in `huh` and remains present on its current `main` branch. This PR applies a
 focused workaround in Entire; a library-level fix will be handled separately upstream.

## What changed

- Add `uiform.SingleLineMultiSelectHeight` for `MultiSelect` fields with one-line options and normal field headers. Multiline options and unusually tall headers intentionally remain outside its contract.
- Apply it to the `promptAgentSelection` and `runManageAgents` agent pickers.
- Move the mirror wizard’s equivalent workaround into `uiform`, migrating `pickRepos` and `pickRegions` without changing their intended behavior.

This does not sweep other picker call sites or broaden the claim to `Select`, which uses different unset-height logic. Accessibility mode is unchanged because huh’s accessible prompt path does not use the rendered viewport height.

## Validation

- Rendering regression test using all eight agent labels:
  - At 24 rows, every option is initially visible.
  - At 8 rows, Pi is initially hidden and appears after downward navigation.
- Manual PTY verification at 24x100 and 8x100.
- `mise run check` passed on the identical implementation before rebase.
- After rebasing onto current `main`, `mise run lint` and `go test ./cmd/entire/cli/uiform` passed.
- `git diff --check` passed.



https://github.com/user-attachments/assets/dbde5b0a-300a-4ff4-8a22-1ecd5ccf49de

<img width="1710" height="551" alt="Screenshot 2026-08-26 at 1 36 11 PM" src="https://github.com/user-attachments/assets/ba0d54c7-35da-46ce-b970-83d0d8c3a76c" />


