### PR TITLE
Resolve cluster auth against the core's cluster registry

### DIFF
--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -2,26 +2,12 @@ package auth
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"strings"
-	"time"
 
-	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
-
-// controlPlaneClusterDiscoveryTimeout bounds the one
-// /.well-known/entire-cluster.json GET a cluster-addressed control-plane
-// command makes to learn which core fronts the cluster. Short so an absent or
-// slow endpoint fails the command promptly.
-const controlPlaneClusterDiscoveryTimeout = 8 * time.Second
-
-// resolveContextForCluster is the discovery seam, swapped in tests so they
-// don't reach the network. Mirrors clusterdiscovery.ResolveContextForCluster.
-var resolveContextForCluster resolveContextFunc = clusterdiscovery.ResolveContextForCluster
 
 // ControlPlaneTarget is the resolved login server a control-plane request
 // (org/repo/project/grant) should dial, plus the bearer source for it.
@@ -56,36 +42,6 @@ func ResolveControlPlaneTarget() (ControlPlaneTarget, error) {
 		}
 	}
 
-	return targetForContext(c)
-}
-
-// ResolveControlPlaneTargetForCluster chooses which core a *resource-provider*
-// control-plane command should dial — one whose subject is a mirror on a
-// specific cluster (mirror create/remove, mirror collaborators list)
-// rather than the caller's own account.
-//
-// Unlike ResolveControlPlaneTarget, the core is NOT taken from the active
-// context: a cluster's mirror lives in the federation that fronts that cluster,
-// which may differ from the active login (e.g. a partial.to context acting on a
-// prod entire.io cluster). We discover the cluster's trusted cores from its
-// /.well-known/entire-cluster.json and require the ACTIVE context to be issued
-// by one of them — exactly as git and data-API resolution do (see
-// ResolveDataAPIToken). The bearer is that context's refreshing login provider
-// (silent JWT re-mint from its stored refresh token).
-//
-// When the active context isn't trusted by the cluster the discovery resolver
-// says so and names the saved logins that are (or, when none is, the cluster's
-// cores), so the user switches with `entire auth use` or logs in to the right
-// federation rather than seeing an opaque "unknown cluster_host" 400.
-func ResolveControlPlaneTargetForCluster(ctx context.Context, clusterHost string) (ControlPlaneTarget, error) {
-	if clusterHost == "" {
-		return ControlPlaneTarget{}, errors.New("cluster-addressed control-plane command requires a target cluster host")
-	}
-	httpClient := &http.Client{Timeout: controlPlaneClusterDiscoveryTimeout}
-	c, err := resolveContextForCluster(ctx, userdirs.Config(), userdirs.Cache(), clusterHost, httpClient, nil)
-	if err != nil {
-		return ControlPlaneTarget{}, err
-	}
 	return targetForContext(c)
 }
 

--- a/cmd/entire/cli/auth/control_plane_test.go
+++ b/cmd/entire/cli/auth/control_plane_test.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
@@ -61,74 +59,6 @@ func TestResolveControlPlaneTarget_ActiveContextWins(t *testing.T) {
 	}
 	if got != jwt {
 		t.Fatalf("TokenSource returned %q, want the context's stored JWT", got)
-	}
-}
-
-// A cluster-addressed control-plane command dials the core that fronts the
-// cluster (discovered from /.well-known) using the matching local context —
-// NOT the active context, which may belong to a different federation. This is
-// the fix for `repo mirror collaborators list … <prod-cluster>` 400ing with
-// "unknown cluster_host" while the active context is a staging login.
-func TestResolveControlPlaneTargetForCluster_DialsClusterCoreNotActive(t *testing.T) {
-	configDir := t.TempDir()
-	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
-
-	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
-	t.Cleanup(restore)
-
-	const (
-		activeCore  = "https://eu.auth.partial.to"
-		clusterCore = "https://eu.auth.entire.io"
-		clusterHost = "aws-us-east-2.entire.io"
-	)
-	// Seed a fresh token only for the cluster's core context — the one we
-	// expect to win. The active (partial) context deliberately has no token, so
-	// a regression that dialed it would fail loudly rather than pass by luck.
-	clusterSvc := tokenstore.CoreKeyringService(clusterCore)
-	jwt := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, clusterCore, time.Now().Add(2*time.Hour).Unix()))
-	if err := tokenstore.Set(clusterSvc, "alice", tokenstore.EncodeTokenWithExpiration(jwt, 7200)); err != nil {
-		t.Fatalf("seed token: %v", err)
-	}
-
-	activeCtx := &contexts.Context{Name: "alice@partial", CoreURL: activeCore, Handle: "alice", KeychainService: tokenstore.CoreKeyringService(activeCore)}
-	clusterCtx := &contexts.Context{Name: "alice@prod", CoreURL: clusterCore, Handle: "alice", KeychainService: clusterSvc}
-	if err := contexts.Save(configDir, &contexts.File{CurrentContext: activeCtx.Name, Contexts: []*contexts.Context{activeCtx, clusterCtx}}); err != nil {
-		t.Fatalf("write contexts.json: %v", err)
-	}
-
-	// Stub cluster discovery so the test doesn't hit the network: the cluster
-	// resolves to the prod context (what /.well-known + requireActiveContext would
-	// yield), NOT the active partial context.
-	prev := resolveContextForCluster
-	resolveContextForCluster = func(_ context.Context, _, _, host string, _ *http.Client, _ clusterdiscovery.DebugFunc) (*contexts.Context, error) {
-		if host != clusterHost {
-			t.Fatalf("discovery host = %q, want %q", host, clusterHost)
-		}
-		return clusterCtx, nil
-	}
-	t.Cleanup(func() { resolveContextForCluster = prev })
-
-	target, err := ResolveControlPlaneTargetForCluster(context.Background(), clusterHost)
-	if err != nil {
-		t.Fatalf("ResolveControlPlaneTargetForCluster: %v", err)
-	}
-	if target.CoreURL != clusterCore {
-		t.Fatalf("CoreURL = %q, want the cluster's core %q (not the active context's %q)", target.CoreURL, clusterCore, activeCore)
-	}
-	got, err := target.TokenSource(context.Background())
-	if err != nil {
-		t.Fatalf("TokenSource: %v", err)
-	}
-	if got != jwt {
-		t.Fatalf("TokenSource returned %q, want the cluster context's stored JWT", got)
-	}
-}
-
-// An empty cluster host is a caller bug — fail fast rather than discovering
-// against "".
-func TestResolveControlPlaneTargetForCluster_EmptyHost(t *testing.T) {
-	if _, err := ResolveControlPlaneTargetForCluster(context.Background(), ""); err == nil {
-		t.Fatal("want an error for empty cluster host, got nil")
 	}
 }
 

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -331,22 +331,11 @@ func isActiveMirror(m coreapi.Mirror) bool {
 // matchClusterByHost finds the catalog cluster whose public host equals
 // clusterHost (case-insensitive). The cluster's apiUrl + jurisdiction are the
 // authoritative cell coordinates. Used by the ULID path (GetRepo returns a
-// host, not a slug).
+// host, not a slug), and by the cluster-host gate on the credential paths
+// (coreapi.VerifyClusterRegistered), which is why the matcher itself lives in
+// coreapi.
 func matchClusterByHost(clusters []coreapi.Cluster, clusterHost string) (coreapi.Cluster, bool) {
-	want := strings.ToLower(strings.TrimSpace(clusterHost))
-	if want == "" {
-		return coreapi.Cluster{}, false
-	}
-	for _, cl := range clusters {
-		host, err := hostFromPublicURL(cl.PublicUrl)
-		if err != nil {
-			continue
-		}
-		if strings.EqualFold(strings.TrimSpace(host), want) {
-			return cl, true
-		}
-	}
-	return coreapi.Cluster{}, false
+	return coreapi.MatchClusterByHost(clusters, clusterHost)
 }
 
 // matchClusterBySlug finds the catalog cluster whose Slug equals clusterSlug

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -565,8 +565,8 @@ var activeCoreClient = func(context.Context) (*coreapi.Client, error) { return c
 
 // clusterCoreClient builds the control-plane client for cluster-addressed
 // commands (see runCoreForCluster). Same test seam as activeCoreClient —
-// production wiring is coreapi.NewForCluster, which does live /.well-known
-// discovery that command-level tests must not reach.
+// production wiring is coreapi.NewForCluster, whose cluster-registry lookup
+// command-level tests must not reach.
 var clusterCoreClient func(ctx context.Context, clusterHost string) (*coreapi.Client, error) = coreapi.NewForCluster
 
 // runCore is the shared base for every active-context control-plane command:
@@ -581,12 +581,11 @@ func runCore(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client)
 }
 
 // runCoreForCluster is runCore for resource-provider commands addressed at a
-// specific cluster (mirror create/remove, mirror collaborators list):
-// it dials the core that fronts clusterHost — discovered from the cluster's
-// /.well-known/entire-cluster.json, authenticating with the matching local
-// context — instead of the active context. So the command works on a cluster in
-// a federation other than the active login, instead of failing with "unknown
-// cluster_host". See coreapi.NewForCluster.
+// specific cluster (mirror create/remove, mirror collaborators list): it dials
+// the active context's core like runCore, but only after that core's cluster
+// registry confirms it fronts clusterHost — so a typo'd or foreign host fails
+// with an actionable error naming the core consulted, rather than an opaque
+// "unknown cluster_host" 400. See coreapi.NewForCluster.
 func runCoreForCluster(cmd *cobra.Command, clusterHost string, fn func(ctx context.Context, c *coreapi.Client) error) error {
 	return runCoreClient(cmd, func(ctx context.Context) (*coreapi.Client, error) {
 		return clusterCoreClient(ctx, clusterHost)

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -6,9 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/url"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -407,44 +405,12 @@ func clusterArgAt(args []string, idx int) string {
 	return defaultClusterHost
 }
 
-// clusterHostLabelRe matches one DNS label: alphanumeric, internal hyphens
-// allowed, no leading/trailing hyphen.
-var clusterHostLabelRe = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$`)
-
 // validateClusterHost rejects a cluster host that is anything other than a
-// bare DNS name or IP with an optional :port. The host is concatenated as
-// "https://"+host into the clone URL and the STS audience
-// (entireclient/repocreds), so a value carrying URL metacharacters can redirect
-// the request — and the repo-scoped basic-auth token it carries — somewhere
-// other than the intended cluster. Classic case:
-// `aws-us-east-2.entire.io@evil.com`, which Go's URL parser reads as
-// host=evil.com with the real cluster demoted to userinfo, leaking the token
-// to evil.com. We parse the host the same way the rest of the code does and
-// require it to round-trip to a bare host with no userinfo, path, query, or
-// fragment, then confirm the hostname is a valid IP or DNS name. This is
-// cheap client-side defense-in-depth and doesn't depend on the server's STS
-// invalid_target canonicalization catching the trick.
+// bare DNS name or IP with an optional :port — see coreapi.ValidateClusterHost
+// for why the shape matters. It lives in coreapi so the git remote helper and
+// the control-plane client share one definition with these commands.
 func validateClusterHost(host string) error {
-	if strings.TrimSpace(host) == "" {
-		return errors.New("cluster host is empty")
-	}
-	u, err := url.Parse("https://" + host)
-	if err != nil {
-		return fmt.Errorf("%q is not a valid host", host)
-	}
-	if u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" || u.Host != host {
-		return fmt.Errorf("%q must be a bare host[:port] (no scheme, userinfo, path, query, or fragment)", host)
-	}
-	hostname := u.Hostname()
-	if net.ParseIP(hostname) != nil {
-		return nil
-	}
-	for _, label := range strings.Split(hostname, ".") {
-		if !clusterHostLabelRe.MatchString(label) {
-			return fmt.Errorf("%q is not a valid DNS name or IP", host)
-		}
-	}
-	return nil
+	return coreapi.ValidateClusterHost(host)
 }
 
 // newRepoMirrorCmd is the `entire repo mirror` subtree: manage EntireDB

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -81,40 +79,11 @@ func clustersToRegions(clusters []coreapi.Cluster) []regionChoice {
 }
 
 // hostFromPublicURL extracts the bare cluster host from a cluster's public_url
-// (with or without a scheme) and runs it through validateClusterHost, the same
-// anti-token-leak guard the positional <cluster-host> arg uses. Kept separate
-// so the ListClusters → regionChoice mapping is unit-testable without a live
-// catalog.
+// and runs it through the anti-token-leak guard the positional <cluster-host>
+// arg uses. Shared with the git remote helper's registry check, so the two can
+// never disagree about which catalog rows name a usable host.
 func hostFromPublicURL(raw string) (string, error) {
-	s := strings.TrimSpace(raw)
-	if s == "" {
-		return "", errors.New("empty public_url")
-	}
-	if !strings.Contains(s, "://") {
-		s = "https://" + s
-	}
-	u, err := url.Parse(s)
-	if err != nil {
-		return "", fmt.Errorf("parse public_url %q: %w", raw, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("public_url %q has no host", raw)
-	}
-	// Reject anything beyond scheme://host[:port]. url.Parse demotes the
-	// `host@evil.com` userinfo trick into u.User (leaving u.Host=evil.com) and
-	// stashes a trailing path in u.Path, neither of which validateClusterHost
-	// would otherwise see. A bare "/" path is tolerated: publicUrl is a trusted
-	// catalog field, and a trailing slash (https://host/) is benign — rejecting
-	// it would silently drop the cluster and could leave the wizard with no
-	// regions. Anything richer (a real path, query, fragment, userinfo) is still
-	// refused, since the host flows into clone URLs and the STS audience.
-	if u.User != nil || (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
-		return "", fmt.Errorf("public_url %q must be scheme://host[:port] only", raw)
-	}
-	if err := validateClusterHost(u.Host); err != nil {
-		return "", err
-	}
-	return u.Host, nil
+	return coreapi.HostFromPublicURL(raw)
 }
 
 // selectableAvailableRepos narrows the ListAvailableMirrors result to repos the

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -11,11 +11,12 @@
 // or log line corrupts the transfer. Diagnostics go to stderr (and the
 // ENTIRE_DEBUG-gated debuglog).
 //
-// Authentication resolves the login context for the target cluster from the
-// shared contexts.json: the cluster's cores come from the cluster_cores.json
-// cache (or a live /.well-known fetch on miss), then the account is selected
-// from local contexts. It uses that context's login JWT (or ENTIRE_TOKEN in
-// CI) directly as the git-transport bearer.
+// Authentication acts as the active login context from the shared
+// contexts.json (or ENTIRE_TOKEN in CI), and confirms the target cluster is one
+// that identity's control-plane core actually fronts by consulting the core's
+// cluster registry (GET /api/v1/clusters) — the same authoritative source the
+// cell-routed commands resolve against. It then uses that context's login JWT
+// (or the env token) directly as the git-transport bearer.
 package main
 
 import (
@@ -37,7 +38,8 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
-	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
+	"github.com/entireio/cli/internal/coreapi"
+	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/httpclient"
 	"github.com/entireio/cli/internal/entireclient/httputil"
 	"github.com/entireio/cli/internal/entireclient/userdirs"
@@ -122,7 +124,7 @@ func run(args []string) int {
 		},
 	}
 
-	creds, onUnauthorized, err := resolveCreds(ctx, parsedURL, skipTLS, httpClient)
+	creds, onUnauthorized, err := resolveCreds(ctx, parsedURL, skipTLS, httpClient, userdirs.Cache(), defaultClusterRegistry)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 		return 128
@@ -346,14 +348,35 @@ func parseProtocolVersion(raw string, warn io.Writer) int {
 	return defaultVersion
 }
 
+// clusterRegistryFactory builds the control-plane client the auth path asks
+// "is this a cluster you front?". Injected (rather than called directly) so the
+// credential gate is unit-testable against a fake registry, with no network and
+// no keyring.
+type clusterRegistryFactory func(coreURL string, token credentialProvider, skipTLS bool) (coreapi.ClusterLister, error)
+
+// defaultClusterRegistry dials the core with the same credential the git
+// transport will use, so the registry lookup shares its silent re-mint instead
+// of pinning a token snapshot.
+func defaultClusterRegistry(coreURL string, token credentialProvider, skipTLS bool) (coreapi.ClusterLister, error) {
+	return coreapi.NewWithTokenSource(coreURL, token, skipTLS)
+}
+
 // resolveCreds returns the credential provider used by the git transport:
 //
 //   - ENTIRE_TOKEN set: use the env JWT verbatim. Skips contexts.json and the
 //     keyring entirely — the CI / workload path. A non-URL aud is a hard error,
 //     never a silent fallback to context resolution.
-//   - otherwise: resolve the login context for this cluster from contexts.json
-//     and use its refreshed login JWT.
-func resolveCreds(ctx context.Context, parsedURL *url.URL, skipTLS bool, httpClient *http.Client) (credentialProvider, func(), error) {
+//   - otherwise: use the active login context from contexts.json and its
+//     refreshed login JWT.
+//
+// Either way the target cluster host is confirmed against the *core's* cluster
+// registry before any credential is handed out — see
+// coreapi.VerifyClusterRegistered for why the cluster's own
+// /.well-known/entire-cluster.json no longer decides this. cacheDir carries the
+// positive-answer cache that keeps a warm git op off the control plane
+// (userdirs.Cache() in production); a confirmed cluster therefore costs no
+// round trip on the next fetch, and survives a brief core outage.
+func resolveCreds(ctx context.Context, parsedURL *url.URL, skipTLS bool, httpClient *http.Client, cacheDir string, newRegistry clusterRegistryFactory) (credentialProvider, func(), error) {
 	// Presence of ENTIRE_TOKEN is the signal: if it's set at all (LookupEnv,
 	// not Getenv, so we can tell set-empty from unset), we commit to the
 	// env-token path and any failure to use it is fatal — never a silent
@@ -367,20 +390,18 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, skipTLS bool, httpCli
 		if envToken == "" {
 			return nil, nil, fmt.Errorf("%s is set but blank", auth.EnvTokenVar)
 		}
-		return resolveEnvTokenCreds(ctx, envToken, parsedURL.Host, userdirs.Cache(), httpClient)
+		return resolveEnvTokenCreds(ctx, envToken, parsedURL.Host, skipTLS, cacheDir, newRegistry)
 	}
 
-	// Resolve which login context authenticates this cluster: the cluster's
-	// login servers are taken from the cluster_cores.json cache (or a live
-	// /.well-known fetch on miss/expiry), and the ACTIVE context must be issued
-	// by one of them. No other saved login is substituted, so which identity
-	// pushed or fetched is always readable from current_context.
-	cfgDir := userdirs.Config()
-	clusterAuth, err := clusterdiscovery.ResolveClusterAuth(ctx, cfgDir, userdirs.Cache(), parsedURL.Host, httpClient, debuglog.Printf)
+	// The acting identity is the ACTIVE context — `--context`/$ENTIRE_CONTEXT
+	// for one invocation, else the stored current_context, and nothing else. No
+	// other saved login is substituted, so which identity pushed or fetched is
+	// always readable from current_context. Its core is then the core we ask
+	// about the cluster.
+	clusterCtx, err := activeLoginContext(parsedURL.Host)
 	if err != nil {
-		return nil, nil, err //nolint:wrapcheck // ResolveClusterAuth already returns a user-facing error; preserved verbatim for the "fatal: <msg>" surface
+		return nil, nil, err
 	}
-	clusterCtx := clusterAuth.Context
 
 	// The login-JWT provider transparently refreshes an expired login JWT
 	// from the stored refresh token (serialised across processes, rotated
@@ -389,60 +410,79 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, skipTLS bool, httpCli
 	if err != nil {
 		return nil, nil, err //nolint:wrapcheck // NewRefreshingLoginCredential already returns a user-facing error
 	}
-
-	debuglog.Printf("auth: login token bearer (core=%s)", clusterCtx.CoreURL)
 	provider, onUnauthorized := refreshingProvider(loginCredential)
+
+	coreURL := strings.TrimRight(clusterCtx.CoreURL, "/")
+	registry, err := newRegistry(coreURL, provider, skipTLS)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := coreapi.VerifyClusterRegistered(ctx, registry, cacheDir, coreURL, parsedURL.Host); err != nil {
+		return nil, nil, err
+	}
+
+	debuglog.Printf("auth: login token bearer (core=%s)", coreURL)
 	return provider, onUnauthorized, nil
 }
 
-// resolveEnvTokenCreds returns a fixed ENTIRE_TOKEN provider after validating
-// its control-plane audience against the target cluster. Split out of
-// resolveCreds with explicit clusterHost/cacheDir params (no os.Getenv /
-// userdirs.Cache globals) so the trust gate below is unit-testable against a
-// fake well-known server.
+// activeLoginContext returns the active contexts.json login, or an error
+// naming the cluster we were about to authenticate against. A context with no
+// CoreURL is an unusable pointer: it names no core to consult, so it is
+// reported as "no active login" rather than dialing an empty host.
+func activeLoginContext(clusterHost string) (*contexts.Context, error) {
+	f, err := contexts.Load(userdirs.Config())
+	if err != nil {
+		return nil, fmt.Errorf("load contexts: %w", err)
+	}
+	sel, err := f.Active()
+	if err != nil {
+		return nil, err //nolint:wrapcheck // UnknownContextError is already a complete operator message
+	}
+	if sel.Context == nil || sel.Context.CoreURL == "" {
+		return nil, errors.New(noActiveContextHint(clusterHost))
+	}
+	return sel.Context, nil
+}
+
+// noActiveContextHint renders the "nothing to authenticate as" message. Built
+// as a string so the multi-line, punctuated operator text stays out of an
+// error-string literal.
+func noActiveContextHint(clusterHost string) string {
+	return fmt.Sprintf("no active auth context for cluster %s.\nRun `entire login`, or select a saved login with `entire auth use <context>`.", clusterHost)
+}
+
+// resolveEnvTokenCreds returns a fixed ENTIRE_TOKEN provider after confirming
+// the target cluster is one the token's own core fronts. Split out of
+// resolveCreds with explicit clusterHost / cacheDir / registry-factory params
+// (no os.Getenv, no userdirs globals, no network) so the trust gate below is
+// unit-testable.
 //
-// SECURITY: coreURL is derived from the env token's *unverified* aud claim, and
-// we confirm the core is one the target cluster actually advertises — anchored
-// to the clone URL's host the user typed (TLS to its
-// /.well-known/entire-cluster.json), not to the token's own claims.
-//
-// The gate is only as strong as that TLS verification: with
-// ENTIRE_TLS_SKIP_VERIFY=true (a local-dev escape hatch) the well-known fetch
-// is no longer authenticated, so a MITM could advertise an attacker host as a
-// trusted core. Do not combine ENTIRE_TOKEN with ENTIRE_TLS_SKIP_VERIFY in
-// CI / workload environments.
-func resolveEnvTokenCreds(ctx context.Context, envToken, clusterHost, cacheDir string, httpClient *http.Client) (credentialProvider, func(), error) {
+// SECURITY: coreURL is derived from the env token's *unverified* aud claim, so
+// the gate can't stop there — an attacker-minted aud would otherwise pick its
+// own core. What anchors it is that the core named by aud must ALSO claim the
+// cluster host the user typed: a token pointing at an attacker core reaches a
+// registry that does not list the real cluster, and the clone fails before any
+// credential is attached. The previous shape asked the target host which cores
+// to trust, which inverted the trust: the host under scrutiny got to nominate
+// its own auditors.
+func resolveEnvTokenCreds(ctx context.Context, envToken, clusterHost string, skipTLS bool, cacheDir string, newRegistry clusterRegistryFactory) (credentialProvider, func(), error) {
 	coreURL, err := auth.CoreURLFromEnvToken(envToken)
 	if err != nil {
 		return nil, nil, err //nolint:wrapcheck // CoreURLFromEnvToken already returns a user-facing, ENTIRE_TOKEN-prefixed error
 	}
-	cluster, err := clusterdiscovery.ResolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debuglog.Printf)
+	provider := func(context.Context) (string, error) { return envToken, nil }
+	registry, err := newRegistry(coreURL, provider, skipTLS)
 	if err != nil {
-		return nil, nil, err //nolint:wrapcheck // ResolveClusterCores returns a user-facing discovery error
+		return nil, nil, err
 	}
-	if !coreTrusted(coreURL, cluster.CoreURLs) {
-		return nil, nil, fmt.Errorf("%s aud %q is not a trusted login server for cluster %s (advertised: %s); the token belongs to a different cluster",
-			auth.EnvTokenVar, coreURL, clusterHost, strings.Join(cluster.CoreURLs, ", "))
+	if err := coreapi.VerifyClusterRegistered(ctx, registry, cacheDir, coreURL, clusterHost); err != nil {
+		return nil, nil, fmt.Errorf("%s aud %q does not front cluster %s: %w", auth.EnvTokenVar, coreURL, clusterHost, err)
 	}
 	debuglog.Printf("auth: %s bearer (core=%s)", auth.EnvTokenVar, coreURL)
-	provider := func(context.Context) (string, error) { return envToken, nil }
 	onUnauthorized := func() {
 		debuglog.Printf("data plane rejected static %s bearer; transport will retry once with the configured token", auth.EnvTokenVar)
 	}
 	return provider, onUnauthorized, nil
-}
-
-// coreTrusted reports whether coreURL is in the cluster's advertised core
-// set, comparing on trailing-slash-insensitive equality to match how core
-// URLs are compared elsewhere (contexts.ContextsForIssuer, auth.sameIssuer).
-func coreTrusted(coreURL string, trusted []string) bool {
-	want := strings.TrimRight(coreURL, "/")
-	for _, t := range trusted {
-		if strings.TrimRight(t, "/") == want {
-			return true
-		}
-	}
-	return false
 }
 
 // gitActionFromRequest classifies a smart-HTTP request as "pull" or "push".

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -4,16 +4,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/internal/coreapi"
+	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/httputil"
 )
 
@@ -265,41 +267,10 @@ func TestMissingClusterHostMessage(t *testing.T) {
 	}
 }
 
-func TestCoreTrusted(t *testing.T) {
-	t.Parallel()
-	trusted := []string{"https://core.us.entire.io", "https://core.eu.entire.io/"}
-	tests := []struct {
-		name    string
-		coreURL string
-		want    bool
-	}{
-		{"exact match", "https://core.us.entire.io", true},
-		{"trailing slash on candidate", "https://core.us.entire.io/", true},
-		{"trailing slash on trusted entry", "https://core.eu.entire.io", true},
-		{"not in set", "https://attacker.example.com", false},
-		{"empty against set", "", false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if got := coreTrusted(tc.coreURL, trusted); got != tc.want {
-				t.Fatalf("coreTrusted(%q) = %v, want %v", tc.coreURL, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestCoreTrusted_EmptyTrustedSet(t *testing.T) {
-	t.Parallel()
-	if coreTrusted("https://core.us.entire.io", nil) {
-		t.Fatal("coreTrusted should be false against an empty trusted set")
-	}
-}
-
 // makeTestJWT builds a three-segment JWT (alg:HS256 so ParseClaims accepts it)
 // carrying the given aud. The signature segment is filler — the env-token path
-// reads the aud unverified and gates it on cluster-advertised cores, never on
-// the signature.
+// reads the aud unverified and gates it on that core's cluster registry, never
+// on the signature.
 func makeTestJWT(t *testing.T, aud string) string {
 	t.Helper()
 	enc := base64.RawURLEncoding
@@ -308,98 +279,222 @@ func makeTestJWT(t *testing.T, aud string) string {
 	return header + "." + payload + "." + enc.EncodeToString([]byte("sig"))
 }
 
-// wellKnownServer serves /.well-known/entire-cluster.json advertising the
-// given cores, jurisdiction audience, and jurisdiction core over TLS,
-// returning the server and the host:port to use as clusterHost. An empty
-// audience models a cluster predating jurisdiction-token git auth.
-func wellKnownServer(t *testing.T, cores []string, jurisdictionAudience, jurisdictionCoreURL string) (*httptest.Server, string) {
+// fakeRegistry stands in for the core's GET /api/v1/clusters. It records the
+// core it was built for so tests can assert which core the credential decision
+// consulted — the whole point of the change is that it is the acting identity's
+// core, never the target host itself.
+type fakeRegistry struct {
+	hosts   []string
+	err     error
+	coreURL string
+	calls   int
+}
+
+func (f *fakeRegistry) ListClusters(context.Context) (*coreapi.ListClustersOutputBody, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	clusters := make([]coreapi.Cluster, 0, len(f.hosts))
+	for _, h := range f.hosts {
+		clusters = append(clusters, coreapi.Cluster{
+			PublicUrl:    "https://" + h,
+			ApiUrl:       coreapi.NewOptString("https://api." + h),
+			Jurisdiction: "us",
+			Slug:         h,
+		})
+	}
+	return &coreapi.ListClustersOutputBody{Clusters: clusters}, nil
+}
+
+// registryFactory returns a clusterRegistryFactory serving reg, capturing the
+// core URL it is asked to dial.
+func registryFactory(reg *fakeRegistry) clusterRegistryFactory {
+	return func(coreURL string, _ credentialProvider, _ bool) (coreapi.ClusterLister, error) {
+		reg.coreURL = coreURL
+		return reg, nil
+	}
+}
+
+func TestResolveEnvTokenCreds_RegisteredClusterSucceeds(t *testing.T) {
+	t.Parallel()
+	const core = "https://core.us.entire.io"
+	const clusterHost = "aws-us-east-2.entire.io"
+	envToken := makeTestJWT(t, core)
+	reg := &fakeRegistry{hosts: []string{"other.entire.io", clusterHost}}
+
+	creds, _, err := resolveEnvTokenCreds(t.Context(), envToken, clusterHost, false, t.TempDir(), registryFactory(reg))
+	if err != nil {
+		t.Fatalf("expected a registered cluster to resolve, got: %v", err)
+	}
+	if reg.coreURL != core {
+		t.Errorf("registry dialed %q, want the env token's aud core %q", reg.coreURL, core)
+	}
+	got, err := creds(t.Context())
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	if got != envToken {
+		t.Errorf("creds = %q, want ENTIRE_TOKEN verbatim", got)
+	}
+}
+
+// A second git operation against an already-confirmed cluster must not pay
+// another control-plane round trip: every clone/fetch/push resolves credentials,
+// and the path this replaced served a warm on-disk cache.
+func TestResolveEnvTokenCreds_WarmCacheSkipsTheRegistry(t *testing.T) {
+	t.Parallel()
+	const clusterHost = "aws-us-east-2.entire.io"
+	envToken := makeTestJWT(t, "https://core.us.entire.io")
+	reg := &fakeRegistry{hosts: []string{clusterHost}}
+	cacheDir := t.TempDir()
+
+	for i := range 3 {
+		if _, _, err := resolveEnvTokenCreds(t.Context(), envToken, clusterHost, false, cacheDir, registryFactory(reg)); err != nil {
+			t.Fatalf("op %d: %v", i, err)
+		}
+	}
+	if reg.calls != 1 {
+		t.Fatalf("registry consulted %d times across 3 git ops, want 1", reg.calls)
+	}
+}
+
+// A cluster host the token's core does not front must fail closed, with no
+// credential built and no second opinion sought from the host itself.
+func TestResolveEnvTokenCreds_UnregisteredClusterFails(t *testing.T) {
+	t.Parallel()
+	const core = "https://core.us.entire.io"
+	envToken := makeTestJWT(t, core)
+	reg := &fakeRegistry{hosts: []string{"aws-us-east-2.entire.io"}}
+
+	creds, onUnauthorized, err := resolveEnvTokenCreds(t.Context(), envToken, "evil.example.com", false, t.TempDir(), registryFactory(reg))
+	if err == nil {
+		t.Fatal("an unregistered cluster host must fail")
+	}
+	if creds != nil || onUnauthorized != nil {
+		t.Fatal("no credential may be built for an unregistered cluster host")
+	}
+	if !errors.Is(err, coreapi.ErrClusterNotRegistered) {
+		t.Errorf("err = %v, want it to wrap ErrClusterNotRegistered", err)
+	}
+	for _, want := range []string{"evil.example.com", core, "entire auth use"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, missing %q", err.Error(), want)
+		}
+	}
+}
+
+// A registry we cannot consult is a failure, never a fallback to the target
+// host's own /.well-known claims.
+func TestResolveEnvTokenCreds_RegistryUnavailableFails(t *testing.T) {
+	t.Parallel()
+	envToken := makeTestJWT(t, "https://core.us.entire.io")
+	reg := &fakeRegistry{err: errors.New("connection refused")}
+
+	creds, _, err := resolveEnvTokenCreds(t.Context(), envToken, "aws-us-east-2.entire.io", false, t.TempDir(), registryFactory(reg))
+	if err == nil {
+		t.Fatal("an unreachable cluster registry must fail the clone")
+	}
+	if creds != nil {
+		t.Fatal("no credential may be built when the registry is unavailable")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("err = %q, want the underlying registry failure", err.Error())
+	}
+}
+
+// seedActiveContext writes a contexts.json with one active login on coreURL and
+// points $ENTIRE_CONFIG_DIR at it. The keychain slot is populated because
+// NewRefreshingLoginCredential requires one to build the token manager; no
+// token is ever fetched — the registry fake never calls the provider.
+func seedActiveContext(t *testing.T, coreURL string) {
 	t.Helper()
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/.well-known/entire-cluster.json" {
-			http.NotFound(w, r)
-			return
-		}
-		body := map[string]any{"core_urls": cores}
-		if jurisdictionAudience != "" {
-			body["jurisdiction_audience"] = jurisdictionAudience
-		}
-		if jurisdictionCoreURL != "" {
-			body["jurisdiction_core_url"] = jurisdictionCoreURL
-		}
-		_ = json.NewEncoder(w).Encode(body) //nolint:errcheck // best-effort in test stub
-	}))
-	t.Cleanup(srv.Close)
-	u, err := url.Parse(srv.URL)
-	if err != nil {
-		t.Fatalf("parse server URL: %v", err)
+	configDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+	c := &contexts.Context{Name: "alice@us", CoreURL: coreURL, Handle: "alice", KeychainService: "entire-cli-test"}
+	if err := contexts.Save(configDir, &contexts.File{CurrentContext: c.Name, Contexts: []*contexts.Context{c}}); err != nil {
+		t.Fatalf("write contexts.json: %v", err)
 	}
-	return srv, u.Host
 }
 
-func TestResolveEnvTokenCreds_TrustedAudSucceeds(t *testing.T) {
-	t.Parallel()
+// The context path resolves the cluster against the ACTIVE context's core —
+// not the target host's self-reported discovery document. Sets process-global
+// env, so not parallel.
+func TestResolveCreds_ContextPathVerifiesAgainstActiveCore(t *testing.T) {
 	const core = "https://core.us.entire.io"
-	const audience = "https://us.entire.io"
-	srv, clusterHost := wellKnownServer(t, []string{core}, audience, core)
-	envToken := makeTestJWT(t, core)
+	const clusterHost = "aws-us-east-2.entire.io"
+	seedActiveContext(t, core)
+	t.Setenv(auth.EnvTokenVar, "")
+	os.Unsetenv(auth.EnvTokenVar)
 
-	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), envToken, clusterHost, t.TempDir(), srv.Client(),
+	reg := &fakeRegistry{hosts: []string{clusterHost}}
+	creds, onUnauthorized, err := resolveCreds(
+		t.Context(),
+		&url.URL{Scheme: "entire", Host: clusterHost},
+		false,
+		&http.Client{},
+		t.TempDir(),
+		registryFactory(reg),
 	)
 	if err != nil {
-		t.Fatalf("expected trusted aud to succeed, got: %v", err)
+		t.Fatalf("resolveCreds: %v", err)
 	}
-	got, err := creds(t.Context())
-	if err != nil {
-		t.Fatalf("provider: %v", err)
+	if creds == nil || onUnauthorized == nil {
+		t.Fatal("expected a credential provider for a registered cluster")
 	}
-	if got != envToken {
-		t.Errorf("creds = %q, want ENTIRE_TOKEN verbatim", got)
+	if reg.coreURL != core {
+		t.Errorf("registry dialed %q, want the active context's core %q", reg.coreURL, core)
+	}
+	if reg.calls != 1 {
+		t.Errorf("registry consulted %d times, want exactly 1", reg.calls)
 	}
 }
 
-func TestResolveEnvTokenCreds_CrossJurisdictionTokenUsesBearer(t *testing.T) {
-	t.Parallel()
-	// Clusters advertise every jurisdiction's cores, so a token minted at a
-	// sibling core passes the trust gate and is used directly as the bearer.
-	const tokenCore = "https://core.eu.entire.io"
-	const jurisdictionCore = "https://core.us.entire.io"
-	srv, clusterHost := wellKnownServer(t, []string{tokenCore, jurisdictionCore}, "https://us.entire.io", jurisdictionCore)
-	envToken := makeTestJWT(t, tokenCore)
-
-	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), envToken, clusterHost, t.TempDir(), srv.Client(),
-	)
-	if err != nil {
-		t.Fatalf("cross-jurisdiction token must resolve, got: %v", err)
-	}
-	got, err := creds(t.Context())
-	if err != nil {
-		t.Fatalf("provider: %v", err)
-	}
-	if got != envToken {
-		t.Errorf("creds = %q, want ENTIRE_TOKEN verbatim", got)
-	}
-}
-
-func TestResolveEnvTokenCreds_DoesNotRequireJurisdictionAudience(t *testing.T) {
-	t.Parallel()
+func TestResolveCreds_ContextPathUnregisteredClusterFails(t *testing.T) {
 	const core = "https://core.us.entire.io"
-	srv, clusterHost := wellKnownServer(t, []string{core}, "", "")
-	envToken := makeTestJWT(t, core)
+	seedActiveContext(t, core)
+	t.Setenv(auth.EnvTokenVar, "")
+	os.Unsetenv(auth.EnvTokenVar)
 
-	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), envToken, clusterHost, t.TempDir(), srv.Client(),
+	reg := &fakeRegistry{hosts: []string{"aws-us-east-2.entire.io"}}
+	creds, _, err := resolveCreds(
+		t.Context(),
+		&url.URL{Scheme: "entire", Host: "evil.example.com"},
+		false,
+		&http.Client{},
+		t.TempDir(),
+		registryFactory(reg),
 	)
-	if err != nil {
-		t.Fatalf("resolve direct bearer without jurisdiction audience: %v", err)
+	if err == nil {
+		t.Fatal("an unregistered cluster host must fail")
 	}
-	got, err := creds(t.Context())
-	if err != nil {
-		t.Fatalf("provider: %v", err)
+	if creds != nil {
+		t.Fatal("no credential may be built for an unregistered cluster host")
 	}
-	if got != envToken {
-		t.Errorf("creds = %q, want ENTIRE_TOKEN verbatim", got)
+	if !errors.Is(err, coreapi.ErrClusterNotRegistered) {
+		t.Errorf("err = %v, want it to wrap ErrClusterNotRegistered", err)
+	}
+}
+
+func TestResolveCreds_ContextPathRegistryUnavailableFails(t *testing.T) {
+	seedActiveContext(t, "https://core.us.entire.io")
+	t.Setenv(auth.EnvTokenVar, "")
+	os.Unsetenv(auth.EnvTokenVar)
+
+	reg := &fakeRegistry{err: errors.New("connection refused")}
+	creds, _, err := resolveCreds(
+		t.Context(),
+		&url.URL{Scheme: "entire", Host: "aws-us-east-2.entire.io"},
+		false,
+		&http.Client{},
+		t.TempDir(),
+		registryFactory(reg),
+	)
+	if err == nil {
+		t.Fatal("an unreachable cluster registry must fail the clone")
+	}
+	if creds != nil {
+		t.Fatal("no credential may be built when the registry is unavailable")
 	}
 }
 
@@ -411,7 +506,7 @@ func TestResolveCreds_BlankEnvTokenFailsClosed(t *testing.T) {
 	dummyURL := &url.URL{Scheme: "entire", Host: "cluster.example.com"}
 	for _, blank := range []string{"", " ", "\t", "\n", " \t\n "} {
 		t.Setenv(auth.EnvTokenVar, blank)
-		creds, _, err := resolveCreds(t.Context(), dummyURL, false, nil)
+		creds, _, err := resolveCreds(t.Context(), dummyURL, false, nil, t.TempDir(), registryFactory(&fakeRegistry{}))
 		if err == nil {
 			t.Fatalf("blank ENTIRE_TOKEN %q should fail closed", blank)
 		}
@@ -495,76 +590,37 @@ func TestRefreshingProvider_ForceRefreshesAfterUnauthorized(t *testing.T) {
 	}
 }
 
-func TestResolveEnvTokenCreds_UntrustedAudAborts(t *testing.T) {
+// An aud pointing at an attacker-chosen core buys nothing: that core's
+// registry is then the one consulted, and it does not list the cluster the
+// user typed, so the clone fails before any credential is attached.
+func TestResolveEnvTokenCreds_AttackerAudAborts(t *testing.T) {
 	t.Parallel()
-	// The cluster advertises only core.us; the token's aud points elsewhere.
-	// The gate must abort before building creds (i.e. before any exchange).
-	srv, clusterHost := wellKnownServer(t, []string{"https://core.us.entire.io"}, "https://us.entire.io", "https://core.us.entire.io")
+	const clusterHost = "aws-us-east-2.entire.io"
+	reg := &fakeRegistry{hosts: []string{"attacker-owned.example.com"}}
 
 	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, "https://attacker.example.com"), clusterHost, t.TempDir(), srv.Client(),
+		t.Context(), makeTestJWT(t, "https://attacker.example.com"), clusterHost, false, t.TempDir(), registryFactory(reg),
 	)
 	if err == nil {
-		t.Fatal("expected untrusted aud to be rejected")
+		t.Fatal("expected an aud whose core does not front the cluster to be rejected")
 	}
 	if creds != nil {
-		t.Fatal("expected nil creds when aud is untrusted")
+		t.Fatal("expected nil creds when the token's core does not front the cluster")
 	}
-	if !strings.Contains(err.Error(), "not a trusted login server") {
-		t.Fatalf("expected trust-gate error, got: %v", err)
-	}
-}
-
-func TestResolveEnvTokenCreds_EmptyAdvertisedCoresAborts(t *testing.T) {
-	t.Parallel()
-	// Discovery succeeds (HTTP 200) but advertises no cores. With nothing to
-	// trust, the gate must fail closed rather than trusting the token's aud.
-	srv, clusterHost := wellKnownServer(t, []string{}, "https://us.entire.io", "https://core.us.entire.io")
-
-	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, "https://core.us.entire.io"), clusterHost, t.TempDir(), srv.Client(),
-	)
-	if err == nil {
-		t.Fatal("expected empty advertised core set to be rejected")
-	}
-	if creds != nil {
-		t.Fatal("expected nil creds when no cores are advertised")
-	}
-}
-
-func TestResolveEnvTokenCreds_DiscoveryFailureAborts(t *testing.T) {
-	t.Parallel()
-	// Cluster advertises no cores (HTTP 503) → discovery fails → we must abort
-	// rather than fall back to trusting the token's own aud.
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}))
-	t.Cleanup(srv.Close)
-	u, err := url.Parse(srv.URL)
-	if err != nil {
-		t.Fatalf("parse server URL: %v", err)
-	}
-
-	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, "https://core.us.entire.io"), u.Host, t.TempDir(), srv.Client(),
-	)
-	if err == nil {
-		t.Fatal("expected discovery failure to abort")
-	}
-	if creds != nil {
-		t.Fatal("expected nil creds on discovery failure")
+	if !errors.Is(err, coreapi.ErrClusterNotRegistered) {
+		t.Fatalf("err = %v, want it to wrap ErrClusterNotRegistered", err)
 	}
 }
 
 func TestResolveEnvTokenCreds_MalformedTokenAborts(t *testing.T) {
 	t.Parallel()
-	// A malformed aud must fail at the parse/validate step, before any network
-	// discovery happens — so a nil httpClient is safe here.
+	// A malformed aud must fail at the parse/validate step, before the registry
+	// is consulted at all — so a nil factory is safe here.
 	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, "http://core.us.entire.io"), "cluster.example.com", t.TempDir(), nil,
+		t.Context(), makeTestJWT(t, "http://core.us.entire.io"), "cluster.example.com", false, t.TempDir(), nil,
 	)
 	if err == nil {
-		t.Fatal("expected http aud to be rejected before discovery")
+		t.Fatal("expected http aud to be rejected before the registry lookup")
 	}
 	if creds != nil {
 		t.Fatal("expected nil creds for invalid aud")

--- a/docs/architecture/upstream-host-resolution.md
+++ b/docs/architecture/upstream-host-resolution.md
@@ -19,7 +19,7 @@ accept a core's JWTs.
 | Role | Service (prod / staging) | Hit by | Trusted-core discovery |
 |---|---|---|---|
 | **Core** — IdP **and** control-plane API, co-located | `entire-core`, per region (`us.auth.entire.io`, `eu.auth.entire.io`), fronted by the apex `auth.entire.io` | `org` / `repo` / `project` / `grant`, `auth *`, `login` | none needed — the host *is* the core |
-| **Resource: git cluster** | `entire-server` / `entiredb` | `git-remote-entire` (clone/push) | `/.well-known/entire-cluster.json` → `core_urls` |
+| **Resource: git cluster** | `entire-server` / `entiredb` | `git-remote-entire` (clone/push), cluster-addressed `repo mirror …` | the acting identity's core: `GET /api/v1/clusters` → `publicUrl` |
 | **Resource: web/data API** | `entire.io` (`partial.to`) | `activity` / `search` / `trail` / `dispatch` | `/.well-known/entire-api.json` → `trusted_issuers` (audience = the host origin) |
 
 `contexts.json` (`$ENTIRE_CONFIG_DIR/contexts.json`, shared with entiredb's
@@ -61,13 +61,50 @@ that persisted `CoreURL`. The apex is only ever the entry point.
 
 ## Resolution per call type
 
-### Git cluster (done — `internal/entireclient/clusterdiscovery`)
+### Git cluster (done — the core's cluster registry)
 
-`ResolveContextForCluster(host)` fetches+caches the cluster's
-`/.well-known/entire-cluster.json`, reads `core_urls`, then requires the
-**active context** to be issued by one of them. There is no implicit
-selection — see [Account selection](#account-selection) below. The token is
-then exchanged for the cluster.
+The acting identity is the **active context** (or `ENTIRE_TOKEN`), and its core
+is the core we dial. The cluster host the user typed
+(`entire://<host>/…`, or the positional arg of a cluster-addressed `repo
+mirror …`) must name a cluster **that core fronts**, per the core's own
+registry: `GET /api/v1/clusters`, matched on `publicUrl`
+(`coreapi.VerifyClusterRegistered`). If it doesn't match, or the registry can't
+be consulted, the command fails — naming the core it asked and pointing at
+`entire auth use`. There is no fallback tier.
+
+A confirmed pairing is cached on disk — `cluster_registry.json` in the cache
+dir, keyed on (core origin, cluster host), 24h TTL, the same shape and lifetime
+the old host→cores cache had — so a warm clone/fetch/push costs no round trip
+and a known cluster keeps working through a brief core outage. **Only successes
+are cached.** A host the core does not list, and a registry that could not be
+consulted, are re-checked every time: the refusal is the security-relevant
+answer, and a newly onboarded cluster resolves on the very next command.
+
+This is the same authoritative source cell routing already resolves against
+(`cell_target.go`'s `resolveRepoCellTarget` → `matchClusterByHost`), so cluster
+identity comes from one place.
+
+It deliberately replaced a per-host `/.well-known/entire-cluster.json` fetch
+whose `core_urls` decided which login was acceptable. That document is
+**self-reported**: the host under scrutiny nominated the login servers a client
+should trust it with. The registry is the record of which clusters exist and
+what public host each has.
+
+Two consequences worth knowing:
+
+- Acting on a cluster fronted by a federation *other* than your active login now
+  fails instead of silently switching cores. Switch with `entire auth use
+  <context>`.
+- `ENTIRE_TOKEN` still derives its core from the token's own (unverified) `aud`,
+  but that buys nothing: the core named by `aud` must **also** list the cluster
+  host the user typed, so a token pointing at an attacker core reaches a registry
+  that doesn't list the real cluster and the clone fails before any credential is
+  attached.
+
+Key files: `internal/coreapi/clusters.go` (the gate and the host matcher),
+`internal/entireclient/discovery/cluster_registry.go` (the positive-answer cache),
+`cmd/git-remote-entire/main.go` (`resolveCreds` / `resolveEnvTokenCreds`),
+`internal/coreapi/client.go` (`NewForCluster`).
 
 ### Control plane (done — this slice)
 

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ogen-go/ogen/ogenerrors"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
 
 // apiBasePath is appended to the control-plane origin to reach the v1
@@ -47,24 +48,35 @@ func New() (*Client, error) {
 // whose subject is a mirror on clusterHost (mirror create/remove, mirror
 // collaborators list).
 //
-// Unlike New — which dials the active context — the core is discovered from the
-// cluster's /.well-known/entire-cluster.json and the matching local context
-// supplies the bearer (see auth.ResolveControlPlaneTargetForCluster). This is
-// what lets a command act on a cluster fronted by a federation other than the
-// active login, e.g. running `repo mirror collaborators list … aws-us-east-2.entire.io`
-// while the active context is a partial.to login: without it the active
-// context's core 400s with "unknown cluster_host" because it doesn't front the
-// cluster. ENTIRE_TOKEN is honoured identically to New.
+// The client is the same one New returns — the acting identity is the active
+// context (or ENTIRE_TOKEN), and its core is the core we dial. What
+// NewForCluster adds is a gate: clusterHost must name a cluster that core
+// actually fronts, per its own cluster registry (VerifyClusterRegistered).
+//
+// The core is deliberately NOT discovered from the cluster's
+// /.well-known/entire-cluster.json any more. That document is self-reported by
+// the host under scrutiny, and let a host nominate the login servers a client
+// should trust it with; the control plane's registry is the authoritative
+// record of which clusters exist, and is already what cell routing resolves
+// against. The cost of the change is that acting on a cluster fronted by a
+// federation other than your active login now fails instead of silently
+// switching cores — with an error naming the core consulted and pointing at
+// `entire auth use`.
 func NewForCluster(ctx context.Context, clusterHost string) (*Client, error) {
-	if client, ok, err := clientFromEnvToken(); ok {
-		return client, err
-	}
-	target, err := auth.ResolveControlPlaneTargetForCluster(ctx, clusterHost)
+	client, err := newActiveClient()
 	if err != nil {
-		return nil, fmt.Errorf("resolve control-plane target for cluster %q: %w", clusterHost, err)
+		return nil, err
 	}
-	return clientForTarget(target)
+	if err := VerifyClusterRegistered(ctx, client, userdirs.Cache(), client.CoreOrigin(), clusterHost); err != nil {
+		return nil, err
+	}
+	return client, nil
 }
+
+// newActiveClient is New, as a seam: NewForCluster's own test needs a client
+// pointed at a fake control plane, which no amount of env/context fixture can
+// produce (New builds an https client from real credentials).
+var newActiveClient = New
 
 // clientFromEnvToken handles the ENTIRE_TOKEN bypass shared by New and
 // NewForCluster. ok=true commits the caller to this mode (the var is present);
@@ -81,24 +93,18 @@ func NewForCluster(ctx context.Context, clusterHost string) (*Client, error) {
 // CoreURLFromEnvToken validates aud is a https bare-origin URL, and makes that
 // the resource the static bearer is sent to.
 //
-// NO TRUST GATE — and deliberately so, in contrast to the env-token path
-// in cmd/git-remote-entire/main.go:resolveEnvTokenCreds. That path derives
-// coreURL from the same unverified aud claim, then gates it through
-// clusterdiscovery.ResolveClusterCores + coreTrusted, anchored to the host
-// the user typed in the clone URL — exactly the verification
-// CoreURLFromEnvToken's doc mandates of callers. We cannot reuse that gate:
-// control-plane commands have no user-supplied resource host to anchor
-// against, so coreURL would only ever be the token's own (unverified) aud,
-// gating it against itself. We skip it because aud-redirection carries no
-// escalation here: git-remote uses the env token as an STS subject_token
-// (exchanged via repocreds for a repo-scoped credential), whereas coreapi
-// sends the token verbatim as the control-plane bearer — the token IS the
-// credential, so re-pointing aud at an attacker host requires already
-// holding a valid token and yields nothing the holder didn't already have.
+// NO CLUSTER GATE — the target-host check lives one level up, in
+// NewForCluster / VerifyClusterRegistered, because it needs a cluster host to
+// check and New has none: a control-plane command addressed at no particular
+// cluster has nothing to anchor against, so the token's aud would only ever be
+// gated against itself.
 //
-// (NewForCluster doesn't tighten this even though it has a cluster host to
-// anchor against: the same no-escalation argument holds — the env token is the
-// credential, sent verbatim, not exchanged.)
+// That is safe here because aud-redirection carries no escalation for a
+// verbatim bearer: the token IS the credential, so re-pointing aud at an
+// attacker host requires already holding a valid token and yields nothing the
+// holder didn't already have. (The git remote helper's env-token path uses the
+// token as an STS subject_token instead, and does gate it — against the
+// registry of the core aud names, anchored by the cluster host the user typed.)
 func clientFromEnvToken() (*Client, bool, error) {
 	raw, ok := os.LookupEnv(auth.EnvTokenVar)
 	if !ok {
@@ -144,8 +150,29 @@ func (c *Client) CoreOrigin() string {
 // cross-jurisdiction call still follows the home core's 421 and exchanges
 // this token for that core's audience (see newCrossJurisHTTPClient).
 func NewWithBearer(coreBaseURL, token string) (*Client, error) {
+	return NewWithBearerSkipTLS(coreBaseURL, token, false)
+}
+
+// NewWithBearerSkipTLS is NewWithBearer with the ENTIRE_TLS_SKIP_VERIFY
+// local-dev escape hatch plumbed through. Only git-remote-entire passes true:
+// it honours that variable for the whole clone, and its cluster-registry check
+// must not be the one call that hard-fails against a self-signed dev core.
+func NewWithBearerSkipTLS(coreBaseURL, token string, skipTLS bool) (*Client, error) {
 	base := strings.TrimRight(coreBaseURL, "/")
-	client, err := NewClient(base+apiBasePath, staticBearer{token: token}, WithClient(newCrossJurisHTTPClient()))
+	client, err := NewClient(base+apiBasePath, staticBearer{token: token}, WithClient(newCrossJurisHTTPClientSkipTLS(skipTLS)))
+	if err != nil {
+		return nil, fmt.Errorf("build Entire API client: %w", err)
+	}
+	return client, nil
+}
+
+// NewWithTokenSource returns a *Client that resolves its bearer per request
+// from provide — the shape a caller holding a refreshing login credential
+// wants, so a registry lookup shares that credential (and its silent re-mint)
+// instead of pinning a token snapshot.
+func NewWithTokenSource(coreBaseURL string, provide func(context.Context) (string, error), skipTLS bool) (*Client, error) {
+	src := &providerSource{provide: provide}
+	client, err := NewClient(strings.TrimRight(coreBaseURL, "/")+apiBasePath, src, WithClient(newCrossJurisHTTPClientSkipTLS(skipTLS)))
 	if err != nil {
 		return nil, fmt.Errorf("build Entire API client: %w", err)
 	}

--- a/internal/coreapi/clusters.go
+++ b/internal/coreapi/clusters.go
@@ -1,0 +1,230 @@
+package coreapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/internal/entireclient/discovery"
+)
+
+// clusterRegistryTimeout bounds the single GET /api/v1/clusters a
+// cluster-addressed command makes to confirm its target host. Some deadline is
+// required: the coreapi HTTP client sets only a dial timeout, so a
+// reachable-but-slow core would otherwise hang the command (a `git clone`
+// included) with no output at all.
+const clusterRegistryTimeout = 15 * time.Second
+
+// ClusterLister is the control-plane surface a cluster-host check needs: the
+// core's authoritative registry of the clusters it fronts. An interface (not
+// *Client) so callers outside this package — the git remote helper's auth
+// path — can be unit-tested against a fake registry.
+type ClusterLister interface {
+	ListClusters(ctx context.Context) (*ListClustersOutputBody, error)
+}
+
+// ErrClusterNotRegistered marks a cluster host that the consulted core does
+// not front. Distinct from a registry that could not be consulted at all:
+// callers may want to tell "wrong login" from "control plane unreachable"
+// apart, and neither is ever a reason to fall back to asking the target host
+// about itself.
+var ErrClusterNotRegistered = errors.New("cluster is not in the control plane's cluster registry")
+
+// VerifyClusterRegistered confirms clusterHost names a cluster that the core
+// behind c actually fronts, and is the single gate every cluster-addressed
+// credential decision passes through (git-remote-entire's auth path,
+// coreapi.NewForCluster).
+//
+// The registry is authoritative and there is no fallback tier. The
+// alternative — asking the target host to describe itself via
+// /.well-known/entire-cluster.json — takes a self-reported answer at face
+// value: the host under scrutiny names the login servers it would like the
+// client to trust. The control plane's own catalog is the record of which
+// clusters exist and what public host each has, and it is already the
+// authoritative source for cell routing (cell_target.go's
+// resolveRepoCellTarget), so cluster identity resolves in one place.
+//
+// coreOrigin names the core consulted, both as the cache key and for the error;
+// pass Client.CoreOrigin() (never a re-derivation, which can name a core the
+// request never touched).
+//
+// cacheDir enables the positive-answer cache (discovery.ClusterRegistryCache),
+// which keeps a warm clone/fetch/push off the control plane's critical path and
+// keeps a known cluster working through a brief core outage. Empty disables it:
+// every call then asks the core. Misses and errors are never cached — see the
+// cache type's doc comment.
+func VerifyClusterRegistered(ctx context.Context, c ClusterLister, cacheDir, coreOrigin, clusterHost string) error {
+	if strings.TrimSpace(clusterHost) == "" {
+		return errors.New("cluster-addressed request requires a target cluster host")
+	}
+	if cacheDir != "" && clusterRegistryVerified(cacheDir, coreOrigin, clusterHost) {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, clusterRegistryTimeout)
+	defer cancel()
+
+	out, err := c.ListClusters(ctx)
+	if err != nil {
+		if msg := APIError(err); msg != "" {
+			err = errors.New(msg)
+		}
+		return fmt.Errorf("consult the cluster registry on %s to verify %s: %w", coreOrigin, clusterHost, err)
+	}
+	if _, ok := MatchClusterByHost(out.Clusters, clusterHost); !ok {
+		return fmt.Errorf("%w: %s", ErrClusterNotRegistered, notRegisteredHint(coreOrigin, clusterHost, out.Clusters))
+	}
+	if cacheDir != "" {
+		markClusterRegistryVerified(cacheDir, coreOrigin, clusterHost)
+	}
+	return nil
+}
+
+// clusterRegistryVerified reports a warm cache hit for this (core, cluster)
+// pair. A cache that can't be read is simply a miss: the point of the cache is
+// latency, so a broken one costs a round trip, never a failure.
+func clusterRegistryVerified(cacheDir, coreOrigin, clusterHost string) bool {
+	cache, err := discovery.LoadClusterRegistry(cacheDir)
+	if err != nil {
+		return false
+	}
+	return cache.Verified(coreOrigin, clusterHost)
+}
+
+// markClusterRegistryVerified records a confirmed pairing. Best-effort: a
+// cache we can't write just means the next operation re-asks the core, which
+// is exactly what happened before the cache existed.
+func markClusterRegistryVerified(cacheDir, coreOrigin, clusterHost string) {
+	_ = discovery.ModifyClusterRegistry(cacheDir, func(cache discovery.ClusterRegistryCache) error { //nolint:errcheck // see doc comment: a cache write failure must not fail the operation
+		cache.MarkVerified(coreOrigin, clusterHost)
+		return nil
+	})
+}
+
+// notRegisteredHint renders the body of the not-registered error: which core
+// answered, what it does front, and the one action that can fix it. Built as a
+// string (rather than inlined into fmt.Errorf) so the multi-line, punctuated
+// operator message stays out of the error-string literal.
+func notRegisteredHint(coreOrigin, clusterHost string, clusters []Cluster) string {
+	return fmt.Sprintf("%s does not front %s.\nKnown clusters: %s\nIf another saved login fronts it, switch with `entire auth use <context>` (`entire auth contexts` lists them).",
+		coreOrigin, clusterHost, describeClusters(clusters))
+}
+
+// describeClusters renders the registry's public hosts for the
+// not-registered error, so the user can see what the core they're logged into
+// does front — typically enough to spot a typo or a staging/prod mixup.
+func describeClusters(clusters []Cluster) string {
+	hosts := make([]string, 0, len(clusters))
+	for _, cl := range clusters {
+		host, err := HostFromPublicURL(cl.PublicUrl)
+		if err != nil {
+			continue
+		}
+		hosts = append(hosts, host)
+	}
+	if len(hosts) == 0 {
+		return "(none)"
+	}
+	return strings.Join(hosts, ", ")
+}
+
+// MatchClusterByHost finds the registry cluster whose public host equals
+// clusterHost (case-insensitive). The cluster's apiUrl + jurisdiction are the
+// authoritative cell coordinates.
+func MatchClusterByHost(clusters []Cluster, clusterHost string) (Cluster, bool) {
+	want := strings.ToLower(strings.TrimSpace(clusterHost))
+	if want == "" {
+		return Cluster{}, false
+	}
+	for _, cl := range clusters {
+		host, err := HostFromPublicURL(cl.PublicUrl)
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(host), want) {
+			return cl, true
+		}
+	}
+	return Cluster{}, false
+}
+
+// HostFromPublicURL extracts the bare cluster host from a cluster's public_url
+// (with or without a scheme) and runs it through ValidateClusterHost, the same
+// anti-token-leak guard the positional <cluster-host> arg uses. Kept separate
+// so the ListClusters → host mapping is unit-testable without a live catalog.
+func HostFromPublicURL(raw string) (string, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return "", errors.New("empty public_url")
+	}
+	if !strings.Contains(s, "://") {
+		s = "https://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("parse public_url %q: %w", raw, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("public_url %q has no host", raw)
+	}
+	// Reject anything beyond scheme://host[:port]. url.Parse demotes the
+	// `host@evil.com` userinfo trick into u.User (leaving u.Host=evil.com) and
+	// stashes a trailing path in u.Path, neither of which ValidateClusterHost
+	// would otherwise see. A bare "/" path is tolerated: publicUrl is a trusted
+	// catalog field, and a trailing slash (https://host/) is benign — rejecting
+	// it would silently drop the cluster and could leave a picker with no
+	// regions. Anything richer (a real path, query, fragment, userinfo) is still
+	// refused, since the host flows into clone URLs and the STS audience.
+	if u.User != nil || (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("public_url %q must be scheme://host[:port] only", raw)
+	}
+	if err := ValidateClusterHost(u.Host); err != nil {
+		return "", err
+	}
+	return u.Host, nil
+}
+
+// clusterHostLabelRe matches one DNS label: alphanumeric, internal hyphens
+// allowed, no leading/trailing hyphen.
+var clusterHostLabelRe = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$`)
+
+// ValidateClusterHost rejects a cluster host that is anything other than a
+// bare DNS name or IP with an optional :port. The host is concatenated as
+// "https://"+host into the clone URL and the STS audience
+// (entireclient/repocreds), so a value carrying URL metacharacters can redirect
+// the request — and the repo-scoped basic-auth token it carries — somewhere
+// other than the intended cluster. Classic case:
+// `aws-us-east-2.entire.io@evil.com`, which Go's URL parser reads as
+// host=evil.com with the real cluster demoted to userinfo, leaking the token
+// to evil.com. We parse the host the same way the rest of the code does and
+// require it to round-trip to a bare host with no userinfo, path, query, or
+// fragment, then confirm the hostname is a valid IP or DNS name. This is
+// cheap client-side defense-in-depth and doesn't depend on the server's STS
+// invalid_target canonicalization catching the trick.
+func ValidateClusterHost(host string) error {
+	if strings.TrimSpace(host) == "" {
+		return errors.New("cluster host is empty")
+	}
+	u, err := url.Parse("https://" + host)
+	if err != nil {
+		return fmt.Errorf("%q is not a valid host", host)
+	}
+	if u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" || u.Host != host {
+		return fmt.Errorf("%q must be a bare host[:port] (no scheme, userinfo, path, query, or fragment)", host)
+	}
+	hostname := u.Hostname()
+	if net.ParseIP(hostname) != nil {
+		return nil
+	}
+	for _, label := range strings.Split(hostname, ".") {
+		if !clusterHostLabelRe.MatchString(label) {
+			return fmt.Errorf("%q is not a valid DNS name or IP", host)
+		}
+	}
+	return nil
+}

--- a/internal/coreapi/clusters_test.go
+++ b/internal/coreapi/clusters_test.go
@@ -1,0 +1,283 @@
+package coreapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeLister is a ClusterLister that answers from a fixed host list, or fails.
+type fakeLister struct {
+	hosts []string
+	err   error
+}
+
+func (f fakeLister) ListClusters(context.Context) (*ListClustersOutputBody, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	clusters := make([]Cluster, 0, len(f.hosts))
+	for _, h := range f.hosts {
+		clusters = append(clusters, Cluster{PublicUrl: "https://" + h, Slug: h, Jurisdiction: "us"})
+	}
+	return &ListClustersOutputBody{Clusters: clusters}, nil
+}
+
+func TestVerifyClusterRegistered(t *testing.T) {
+	t.Parallel()
+	const core = "https://core.us.entire.io"
+	hosts := []string{"aws-us-east-2.entire.io", "aws-eu-west-1.entire.io"}
+
+	t.Run("registered host passes", func(t *testing.T) {
+		t.Parallel()
+		if err := VerifyClusterRegistered(t.Context(), fakeLister{hosts: hosts}, "", core, "aws-us-east-2.entire.io"); err != nil {
+			t.Fatalf("registered host must pass: %v", err)
+		}
+	})
+
+	// DNS is case-insensitive, so a host typed in mixed case names the same
+	// cluster and must not be refused.
+	t.Run("host match folds case", func(t *testing.T) {
+		t.Parallel()
+		if err := VerifyClusterRegistered(t.Context(), fakeLister{hosts: hosts}, "", core, "AWS-US-East-2.entire.io"); err != nil {
+			t.Fatalf("case-folded host must pass: %v", err)
+		}
+	})
+
+	t.Run("unregistered host fails actionably", func(t *testing.T) {
+		t.Parallel()
+		err := VerifyClusterRegistered(t.Context(), fakeLister{hosts: hosts}, "", core, "evil.example.com")
+		if !errors.Is(err, ErrClusterNotRegistered) {
+			t.Fatalf("err = %v, want ErrClusterNotRegistered", err)
+		}
+		// The message must name the core consulted (so the user can tell which
+		// login answered) and the way out.
+		for _, want := range []string{core, "evil.example.com", "aws-us-east-2.entire.io", "entire auth use"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("err = %q, missing %q", err.Error(), want)
+			}
+		}
+	})
+
+	// An unreachable registry is a failure, never a pass: the whole point is
+	// that nothing else gets to vouch for the host.
+	t.Run("registry failure fails closed", func(t *testing.T) {
+		t.Parallel()
+		err := VerifyClusterRegistered(t.Context(), fakeLister{err: errors.New("connection refused")}, "", core, "aws-us-east-2.entire.io")
+		if err == nil {
+			t.Fatal("an unreachable registry must fail")
+		}
+		if errors.Is(err, ErrClusterNotRegistered) {
+			t.Fatal("an unreachable registry must not be reported as 'not registered'")
+		}
+		if !strings.Contains(err.Error(), "connection refused") {
+			t.Errorf("err = %q, want the underlying failure", err.Error())
+		}
+	})
+
+	t.Run("empty host is a caller bug", func(t *testing.T) {
+		t.Parallel()
+		if err := VerifyClusterRegistered(t.Context(), fakeLister{hosts: hosts}, "", core, "  "); err == nil {
+			t.Fatal("an empty cluster host must fail")
+		}
+	})
+}
+
+// countingLister records how many registry round trips a caller actually made,
+// which is the whole point of the cache.
+type countingLister struct {
+	hosts []string
+	err   error
+	calls int
+}
+
+func (c *countingLister) ListClusters(ctx context.Context) (*ListClustersOutputBody, error) {
+	c.calls++
+	return fakeLister{hosts: c.hosts, err: c.err}.ListClusters(ctx)
+}
+
+// A confirmed cluster is cached, so routine git operations stop paying a
+// control-plane round trip — and keep working while the core is unreachable.
+func TestVerifyClusterRegistered_CachesPositiveAnswers(t *testing.T) {
+	t.Parallel()
+	const core = "https://core.us.entire.io"
+	const host = "aws-us-east-2.entire.io"
+	cacheDir := t.TempDir()
+
+	lister := &countingLister{hosts: []string{host}}
+	for i := range 3 {
+		if err := VerifyClusterRegistered(t.Context(), lister, cacheDir, core, host); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if lister.calls != 1 {
+		t.Fatalf("registry consulted %d times, want 1 (later calls must hit the cache)", lister.calls)
+	}
+
+	// DNS is case-insensitive and a core URL's trailing slash is
+	// insignificant, so the same pairing typed differently must still hit.
+	if err := VerifyClusterRegistered(t.Context(), lister, cacheDir, core+"/", "AWS-US-East-2.entire.io"); err != nil {
+		t.Fatalf("case/slash variant: %v", err)
+	}
+	if lister.calls != 1 {
+		t.Fatalf("registry consulted %d times, want 1 (normalised key must hit the cache)", lister.calls)
+	}
+
+	// The cached pairing keeps working when the core is down — the outage
+	// resilience the cache exists for.
+	down := &countingLister{err: errors.New("connection refused")}
+	if err := VerifyClusterRegistered(t.Context(), down, cacheDir, core, host); err != nil {
+		t.Fatalf("a cached cluster must survive a core outage: %v", err)
+	}
+}
+
+// The cache is scoped to the core that answered: switching logins must not
+// reuse another core'"'"'s verdict.
+func TestVerifyClusterRegistered_CacheIsPerCore(t *testing.T) {
+	t.Parallel()
+	const host = "aws-us-east-2.entire.io"
+	cacheDir := t.TempDir()
+
+	if err := VerifyClusterRegistered(t.Context(), fakeLister{hosts: []string{host}}, cacheDir, "https://core.us.entire.io", host); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	other := &countingLister{hosts: []string{"somewhere-else.entire.io"}}
+	if err := VerifyClusterRegistered(t.Context(), other, cacheDir, "https://core.partial.to", host); !errors.Is(err, ErrClusterNotRegistered) {
+		t.Fatalf("err = %v, want a fresh check against the other core to fail", err)
+	}
+	if other.calls != 1 {
+		t.Fatalf("other core consulted %d times, want 1", other.calls)
+	}
+}
+
+// Misses and errors are re-checked every time: caching a refusal would let a
+// stale "no" outlive an onboarding, and caching an outage would turn a blip
+// into a sticky failure.
+func TestVerifyClusterRegistered_DoesNotCacheFailures(t *testing.T) {
+	t.Parallel()
+	const core = "https://core.us.entire.io"
+	cacheDir := t.TempDir()
+
+	miss := &countingLister{hosts: []string{"aws-us-east-2.entire.io"}}
+	for i := range 2 {
+		if err := VerifyClusterRegistered(t.Context(), miss, cacheDir, core, "not-yet.entire.io"); !errors.Is(err, ErrClusterNotRegistered) {
+			t.Fatalf("call %d: err = %v, want ErrClusterNotRegistered", i, err)
+		}
+	}
+	if miss.calls != 2 {
+		t.Fatalf("registry consulted %d times, want 2 (a miss must never be cached)", miss.calls)
+	}
+	// ... and once the cluster IS onboarded, the very next call sees it.
+	miss.hosts = append(miss.hosts, "not-yet.entire.io")
+	if err := VerifyClusterRegistered(t.Context(), miss, cacheDir, core, "not-yet.entire.io"); err != nil {
+		t.Fatalf("a newly onboarded cluster must resolve immediately: %v", err)
+	}
+
+	failing := &countingLister{err: errors.New("connection refused")}
+	for i := range 2 {
+		if err := VerifyClusterRegistered(t.Context(), failing, cacheDir, core, "aws-eu-west-1.entire.io"); err == nil {
+			t.Fatalf("call %d: an unreachable registry must fail", i)
+		}
+	}
+	if failing.calls != 2 {
+		t.Fatalf("registry consulted %d times, want 2 (an error must never be cached)", failing.calls)
+	}
+}
+
+// An empty cacheDir disables the cache outright — every call asks the core.
+func TestVerifyClusterRegistered_NoCacheDirAlwaysAsks(t *testing.T) {
+	t.Parallel()
+	const host = "aws-us-east-2.entire.io"
+	lister := &countingLister{hosts: []string{host}}
+	for i := range 2 {
+		if err := VerifyClusterRegistered(t.Context(), lister, "", "https://core.us.entire.io", host); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if lister.calls != 2 {
+		t.Fatalf("registry consulted %d times, want 2 (caching must be off)", lister.calls)
+	}
+}
+
+// clusterRegistryServer serves GET /api/v1/clusters with the given hosts (or a
+// 500 when hosts is nil), and returns a *Client dialing it.
+func clusterRegistryServer(t *testing.T, hosts []string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != apiBasePath+"/clusters" {
+			http.NotFound(w, r)
+			return
+		}
+		if hosts == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		clusters := make([]map[string]any, 0, len(hosts))
+		for _, h := range hosts {
+			clusters = append(clusters, map[string]any{
+				"apiUrl": "https://api." + h, "isDefault": false,
+				"jurisdiction": "us", "publicUrl": "https://" + h, "slug": h,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"clusters": clusters}) //nolint:errcheck // best-effort in test stub
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewWithBearer(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("NewWithBearer: %v", err)
+	}
+	return c
+}
+
+// NewForCluster (the `entire repo mirror …` path) now dials the acting
+// identity's core and gates on that core's registry, instead of discovering a
+// core from the target host's own /.well-known document.
+func TestNewForCluster(t *testing.T) {
+	const clusterHost = "aws-us-east-2.entire.io"
+
+	t.Run("registered host returns the active client", func(t *testing.T) {
+		client := clusterRegistryServer(t, []string{clusterHost})
+		withActiveClient(t, client)
+		got, err := NewForCluster(t.Context(), clusterHost)
+		if err != nil {
+			t.Fatalf("NewForCluster: %v", err)
+		}
+		if got != client {
+			t.Fatal("NewForCluster must return the active-context client, not a re-derived one")
+		}
+	})
+
+	t.Run("unregistered host fails", func(t *testing.T) {
+		client := clusterRegistryServer(t, []string{clusterHost})
+		withActiveClient(t, client)
+		got, err := NewForCluster(t.Context(), "evil.example.com")
+		if !errors.Is(err, ErrClusterNotRegistered) {
+			t.Fatalf("err = %v, want ErrClusterNotRegistered", err)
+		}
+		if got != nil {
+			t.Fatal("no client may be returned for an unregistered cluster host")
+		}
+	})
+
+	t.Run("registry failure fails closed", func(t *testing.T) {
+		client := clusterRegistryServer(t, nil)
+		withActiveClient(t, client)
+		if _, err := NewForCluster(t.Context(), clusterHost); err == nil {
+			t.Fatal("a registry that cannot be consulted must fail the command")
+		}
+	})
+}
+
+// withActiveClient points NewForCluster's client seam at c for one test. Not
+// parallel-safe (a package-level var), which is why these subtests aren't.
+func withActiveClient(t *testing.T, c *Client) {
+	t.Helper()
+	prev := newActiveClient
+	newActiveClient = func() (*Client, error) { return c, nil }
+	t.Cleanup(func() { newActiveClient = prev })
+}

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -24,8 +24,16 @@ import (
 // requires, so a home-region login JWT can operate on a resource whose
 // home jurisdiction is another region. Inert for same-jurisdiction calls.
 func newCrossJurisHTTPClient() *http.Client {
+	return newCrossJurisHTTPClientSkipTLS(false)
+}
+
+// newCrossJurisHTTPClientSkipTLS is newCrossJurisHTTPClient with certificate
+// verification optionally disabled — the ENTIRE_TLS_SKIP_VERIFY local-dev
+// escape hatch, plumbed through for git-remote-entire only. Every other caller
+// passes false via newCrossJurisHTTPClient.
+func newCrossJurisHTTPClientSkipTLS(skipTLS bool) *http.Client {
 	return &http.Client{
-		Transport: newCrossJurisRoundTripper(httpclient.NewTransport(false)),
+		Transport: newCrossJurisRoundTripper(httpclient.NewTransport(skipTLS)),
 	}
 }
 

--- a/internal/entireclient/discovery/cluster_registry.go
+++ b/internal/entireclient/discovery/cluster_registry.go
@@ -1,0 +1,104 @@
+package discovery
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// clusterRegistryFileName caches "core X lists cluster Y" answers. Its own
+	// file (not cluster_cores.json) because it caches a different fact keyed on
+	// a different thing: a (core, cluster) pair rather than a host, and
+	// membership in a core's registry rather than a host's advertised issuers.
+	clusterRegistryFileName = "cluster_registry.json"
+
+	// ClusterRegistryTTL bounds how long a confirmed (core, cluster) pairing is
+	// treated as fresh. Which clusters a core fronts is near-static infra — a
+	// cluster is onboarded once and stays — so the same long TTL the
+	// host→cores cache uses applies, and it is what keeps routine git ops off
+	// the control plane's critical path.
+	ClusterRegistryTTL = 24 * time.Hour
+)
+
+// ClusterRegistryCache memoizes POSITIVE cluster-registry lookups: a core
+// confirmed that it fronts a cluster host. It exists so routine git operations
+// (every clone/fetch/push resolves credentials) don't each pay a synchronous
+// control-plane round trip, and so a brief core outage doesn't break git
+// against a cluster we already know is legitimate.
+//
+// Only successes are stored, and deliberately so. A "not registered" answer is
+// the security-relevant one — it is what refuses to hand credentials to an
+// unknown host — and a registry error is transient by nature; caching either
+// would trade a fresh check for a stale refusal. So a host the core does not
+// list is re-checked every single time, and only the boring "yes, still one of
+// mine" answer is allowed to go stale.
+//
+// It stores no credential and no identity — just the objective fact that a core
+// listed a cluster, keyed by both, so switching logins never reuses another
+// core's answer.
+//
+// Cache file: cluster_registry.json in the cache dir (alongside nodes.json).
+// Safe to delete by hand to force re-verification.
+type ClusterRegistryCache map[string]*ClusterRegistryEntry
+
+// ClusterRegistryEntry records when a (core, cluster) pairing was last
+// confirmed. Freshness is VerifiedAt + ClusterRegistryTTL, computed at read
+// time so a TTL change re-interprets existing entries without a migration.
+type ClusterRegistryEntry struct {
+	VerifiedAt time.Time `json:"verified_at"`
+}
+
+// LoadClusterRegistry reads the (core, cluster)→verified cache. A missing or
+// corrupt file yields an empty cache. Unlocked read; use ModifyClusterRegistry
+// for a read-modify-write sequence.
+func LoadClusterRegistry(cacheDir string) (ClusterRegistryCache, error) {
+	return readClusterRegistryNoLock(filepath.Join(cacheDir, clusterRegistryFileName))
+}
+
+// ModifyClusterRegistry atomically applies fn to the (core, cluster)→verified
+// cache under a single exclusive flock, so two concurrent git processes filling
+// the same entry can't clobber each other.
+func ModifyClusterRegistry(cacheDir string, fn func(ClusterRegistryCache) error) error {
+	return modifyCacheFile(cacheDir, clusterRegistryFileName, readClusterRegistryNoLock, writeClusterRegistryNoLock, fn)
+}
+
+func readClusterRegistryNoLock(path string) (ClusterRegistryCache, error) {
+	cache := make(ClusterRegistryCache)
+	err := loadCacheFile(path, &cache, func() ClusterRegistryCache { return make(ClusterRegistryCache) })
+	return cache, err
+}
+
+func writeClusterRegistryNoLock(path string, cache ClusterRegistryCache) error {
+	return writeCacheFile(path, cache)
+}
+
+// Verified reports whether coreOrigin was recently confirmed to front
+// clusterHost. A missing or expired entry is false — the caller then asks the
+// core and, on a yes, calls MarkVerified.
+func (c ClusterRegistryCache) Verified(coreOrigin, clusterHost string) bool {
+	entry := c[clusterRegistryKey(coreOrigin, clusterHost)]
+	if entry == nil {
+		return false
+	}
+	return time.Now().Before(entry.VerifiedAt.Add(ClusterRegistryTTL))
+}
+
+// MarkVerified records that coreOrigin currently fronts clusterHost, stamped
+// now. Only ever called for a confirmed match — see the type's doc comment for
+// why misses and errors are never stored.
+func (c ClusterRegistryCache) MarkVerified(coreOrigin, clusterHost string) {
+	c[clusterRegistryKey(coreOrigin, clusterHost)] = &ClusterRegistryEntry{VerifiedAt: time.Now()}
+}
+
+// clusterRegistryKey folds a (core, cluster) pair into one cache key. Both
+// halves are normalised the way their comparisons are elsewhere — trailing
+// slashes and case are insignificant in a core URL, DNS is case-insensitive —
+// so a host typed in mixed case hits the entry its lowercase twin wrote. The
+// separator is a space: neither a URL origin nor a validated cluster host can
+// contain one, so the two halves can never be confused for each other.
+func clusterRegistryKey(coreOrigin, clusterHost string) string {
+	core := strings.ToLower(strings.TrimRight(strings.TrimSpace(coreOrigin), "/"))
+	host := strings.ToLower(strings.TrimSpace(clusterHost))
+	return core + " " + host
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1147
<!-- entire-trail-link-end -->

## What

The git remote helper (`git clone entire://<host>/…`) and the cluster-addressed `entire repo mirror …` commands decided which login could authenticate a cluster by fetching **that cluster's own** `/.well-known/entire-cluster.json` and checking the active context against the `core_urls` it advertised.

That is a self-reported source: the host under scrutiny nominates the login servers a client should trust it with. Both paths now resolve the target against the **core's cluster registry** (`GET /api/v1/clusters`, matched on `publicUrl`) — the same authoritative source cell routing already uses (`cell_target.go`'s `resolveRepoCellTarget` → `matchClusterByHost`), so cluster identity comes from one place.

The acting identity is unchanged: the active context (or `ENTIRE_TOKEN`), whose core is the core consulted. Resolution is **authoritative, not best-effort** — an unlisted host, or a registry that can't be consulted, fails with an error naming the core it asked and pointing at `entire auth use`. No fallback to per-host discovery.

The `ENTIRE_TOKEN` path still derives its core from the token's own (unverified) `aud`, but that now buys nothing: the core `aud` names must **also** list the cluster host the user typed, so a token pointing at an attacker core reaches a registry that doesn't list the real cluster and the clone fails before any credential is attached.

## Caching

Confirmed pairings are cached in `cluster_registry.json` (cache dir, 24h TTL, keyed on core origin + cluster host), mirroring the `cluster_cores.json` cache this replaces — a warm clone/fetch/push pays no control-plane round trip, and a known cluster keeps working through a brief core outage.

**Only successes are cached.** A host the core doesn't list, and a registry that couldn't be consulted, are re-checked every time: the refusal is the security-relevant answer, and a newly onboarded cluster resolves on the very next command.

## Behaviour change (deliberate)

Acting on a cluster fronted by a **federation other than the active login** now errors instead of silently switching cores. Cross-region within a federation is unaffected — the registry is federation-global. The error points at `entire auth use <context>`.

## Also

- The host matcher and the bare-host guard (`MatchClusterByHost`, `HostFromPublicURL`, `ValidateClusterHost`) move to `internal/coreapi` so `cli`, `coreapi` and `git-remote-entire` share one definition; the `cli` copies delegate.
- `auth.ResolveControlPlaneTargetForCluster` is deleted with its sole consumer.
- `internal/entireclient/clusterdiscovery`'s cluster entry points (`ResolveContextForCluster`, `ResolveClusterAuth`, `ResolveClusterCores`) now have no production callers — left in place since the package's API-host half is still live; deletable follow-up.
- The remote helper binary grows 9.9M → 10.7M from linking the generated coreapi client (no lighter way to call `ListClusters`).
- `docs/architecture/upstream-host-resolution.md` updated.

## Verification

- `mise run lint` — clean
- `mise run test` — 15 failures, all pre-existing `TestExplainCmd_*` (verified failing on the untouched tree)
- `mise run test:integration` — 3 pre-existing `TestPluginRemoteInstall_*` failures (local `git tag` env issue)
- `mise run test:e2e:canary` — passing
- New tests: registered/case-folded host resolves, absent host fails wrapping `ErrClusterNotRegistered` with nothing attached, registry-unavailable fails closed, attacker `aud` gains nothing, warm cache does one round trip across three ops, cached cluster survives a core outage, misses/errors never cached, cache scoped per core, `NewForCluster` covered end-to-end against an httptest control plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how git credentials and cluster-addressed control-plane calls establish trust (registry vs self-reported well-known), with security and cross-federation user-visible behavior impacts.
> 
> **Overview**
> **Cluster-addressed git and CLI paths no longer trust the target host’s `/.well-known/entire-cluster.json` to pick a login server.** They still use the **active context** (or `ENTIRE_TOKEN`) and dial **that identity’s core**, but first require `GET /api/v1/clusters` on that core to list the typed cluster host (`coreapi.VerifyClusterRegistered`)—the same catalog cell routing already uses.
> 
> **`git-remote-entire`** applies the same gate before handing out credentials; **`ENTIRE_TOKEN`** is checked against the token `aud` core’s registry, not the cluster’s advertised cores. **`NewForCluster`** / **`runCoreForCluster`** (mirror create/remove, collaborators list) dial the active client and gate on the registry instead of **`ResolveControlPlaneTargetForCluster`** and per-host discovery.
> 
> **Shared cluster-host parsing and validation** (`MatchClusterByHost`, `HostFromPublicURL`, `ValidateClusterHost`) move into **`internal/coreapi`** so CLI, remote helper, and control-plane client stay aligned. Successful (core, host) checks are cached in **`cluster_registry.json`** (24h, successes only); misses and registry errors are always re-checked.
> 
> **Deliberate behavior change:** acting on a cluster fronted by another federation **errors** with the core consulted and an **`entire auth use`** hint, rather than silently switching cores. Architecture docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26fc1b957173ee507403734be42ccbc33e6a3c7a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->