### PR TITLE
refactor(external): load agent plugins concurrently and keep their failures

### DIFF
--- a/cmd/entire/cli/agent/external/discovery.go
+++ b/cmd/entire/cli/agent/external/discovery.go
@@ -9,7 +9,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -23,19 +25,85 @@ const (
 	osWindows    = "windows"
 )
 
-// discoveryTimeout caps the total time spent scanning $PATH for external agents.
-const discoveryTimeout = 10 * time.Second
+// infoTimeout caps how long a single external agent binary may take to answer
+// its "info" subcommand.
+//
+// The budget is per binary, not per scan: binaries are loaded concurrently, so a
+// whole scan costs roughly one infoTimeout no matter how many plugins are
+// installed. That is the point of the concurrency — before it, one stalled
+// plugin consumed a shared budget and every binary after it was dropped.
+//
+// The value looks enormous for a call that returns static metadata (a healthy,
+// warm plugin answers in ~10ms) because it is sized for the worst legitimate
+// case, not the typical one: a binary's FIRST execution on a loaded machine.
+// Measured on macOS, forking a freshly written executable costs 320-394ms
+// against 7-12ms once the same file has been run before, because a newly
+// installed binary pays code signing/Gatekeeper validation and cold page-in on
+// first use — and on a saturated machine (a full `-race` test suite) that same
+// cold fork was observed to exceed two seconds. Node- or Python-wrapped plugins
+// start slower still.
+//
+// Undersizing this is not a benign performance choice: it turns "the user just
+// installed a plugin" into a broken-agent entry on the next command, which then
+// works forever after — the worst kind of intermittent. Since discovery is
+// concurrent and a healthy plugin never approaches the budget, a generous value
+// costs nothing in the common case and only bounds a genuinely hung binary.
+//
+// The value deliberately matches the total budget the serial implementation used
+// to allow for the whole scan, so the worst case a user can wait is unchanged
+// while the typical case collapses from N budgets to one. Picking anything
+// smaller would make discovery stricter than what already shipped: at 5s, a cold
+// exec on a machine running a full parallel test suite was still being killed
+// mid-flight.
+//
+// It is a var so tests can tighten it (to exercise the timeout path quickly) or
+// relax it (so a happy-path assertion doesn't depend on machine load).
+var infoTimeout = 10 * time.Second //nolint:gochecknoglobals // tunable policy knob; test seam
 
 var (
-	statExternalAgent     = os.Stat       //nolint:gochecknoglobals // narrow test seam for stat failures
-	lookPathExternalAgent = exec.LookPath //nolint:gochecknoglobals // narrow test seam for lookup failures
+	// ErrInfoTimeout marks a binary whose "info" call exceeded infoTimeout.
+	// It exists because exec reports a context-killed child only as
+	// "signal: killed", which is indistinguishable from a crash; callers need to
+	// tell "too slow" from "broken" without matching on strings.
+	ErrInfoTimeout = errors.New("external agent info command timed out")
+
+	// ErrNotExecutable marks a matching file that is missing its execute bit —
+	// the forgot-chmod case, which used to fail invisibly.
+	ErrNotExecutable = errors.New("external agent binary is not executable")
 )
 
+// lookPathExternalAgent is a narrow test seam for named lookup.
+var lookPathExternalAgent = exec.LookPath //nolint:gochecknoglobals // narrow test seam
+
+// BrokenAgent is an external agent binary that exists on $PATH but could not be
+// loaded. Keeping these lets the CLI report "installed but unusable" instead of
+// behaving as though the plugin were never installed.
+type BrokenAgent struct {
+	Name       types.AgentName
+	BinaryPath string
+	Err        error
+}
+
+// Discovery results live in two registries. Ready agents are additionally
+// registered in the agent package, which must keep meaning "agents you can
+// actually use" — so broken entries are recorded here only.
+var (
+	discoveryMu  sync.RWMutex                            //nolint:gochecknoglobals // process-wide discovery result
+	readyAgents  = make(map[types.AgentName]agent.Agent) //nolint:gochecknoglobals // process-wide discovery result
+	brokenAgents = make(map[types.AgentName]BrokenAgent) //nolint:gochecknoglobals // process-wide discovery result
+)
+
+// candidate is a binary that matched the external agent naming pattern and
+// passed the cheap filesystem checks — i.e. one worth executing.
+type candidate struct {
+	name    types.AgentName
+	binPath string
+}
+
 // DiscoverAndRegister scans $PATH for executables matching "entire-agent-<name>",
-// calls their "info" subcommand, and registers them in the agent registry.
-// Binaries whose name conflicts with an already-registered agent are skipped.
-// Errors during discovery are logged but do not prevent other agents from loading.
-// Discovery is skipped when the external_agents setting is not enabled.
+// calls their "info" subcommand concurrently, and registers the ones that answer.
+// Binaries that fail are recorded (see BrokenAgents) rather than aborting the
+// scan. Discovery is skipped when the external_agents setting is not enabled.
 func DiscoverAndRegister(ctx context.Context) {
 	if !settings.IsExternalAgentsEnabled(ctx) {
 		logging.Debug(ctx, "external agent discovery disabled (external_agents not enabled in settings)")
@@ -45,52 +113,23 @@ func DiscoverAndRegister(ctx context.Context) {
 }
 
 // DiscoverAndRegisterAlways is like DiscoverAndRegister but bypasses the
-// external_agents settings check. Use this in interactive setup flows where
-// the user explicitly chooses agents.
+// external_agents settings check. Use this in interactive setup flows where the
+// user explicitly chooses agents and the setting may not exist yet.
 func DiscoverAndRegisterAlways(ctx context.Context) {
 	discoverAndRegister(ctx)
 }
 
-// DiscoverAndRegisterNamedAlways discovers and registers only the external
-// agent binary matching name. It bypasses the external_agents setting for
-// explicit, one-invocation selections without executing unrelated plugins.
-func DiscoverAndRegisterNamedAlways(ctx context.Context, name types.AgentName) error {
-	return discoverAndRegisterNamed(ctx, name, discoveryTimeout)
-}
-
-// discoveryCanceled reports whether either the caller's context or the derived
-// discovery-timeout context has been cancelled.
+// DiscoverAndRegisterNamedAlways discovers and registers only the external agent
+// binary matching name. It bypasses the external_agents setting for explicit,
+// one-invocation selections without executing unrelated plugins.
 //
-// Both must be consulted. A context closes its own Done channel *before* cancelling
-// its children, so a goroutine that has just observed the caller's cancellation can
-// run while the derived context still reports no error — and when the caller is not a
-// standard context, propagation happens in a watcher goroutine, widening the window
-// further. Checking only the derived context therefore lets a caller whose deadline
-// expired mid-operation look like it is still live.
-func discoveryCanceled(caller, derived context.Context) bool {
-	return caller.Err() != nil || derived.Err() != nil
-}
-
-// discoveryCtxErr wraps whichever of the two contexts has been cancelled, preferring
-// the caller's, and returns nil when neither has. op names the stage for the message.
-// See discoveryCanceled for why the caller's context must be consulted too: missing it
-// lets a caller whose deadline expired mid-lookup receive a nil error and a silently
-// skipped agent instead of its context error.
-func discoveryCtxErr(caller, derived context.Context, op string) error {
-	err := caller.Err()
-	if err == nil {
-		err = derived.Err()
-	}
-	if err == nil {
-		return nil
-	}
-	return fmt.Errorf("%s: %w", op, err)
-}
-
-func discoverAndRegisterNamed(ctx context.Context, name types.AgentName, timeout time.Duration) error {
+// A binary that isn't installed is not an error: callers rely on a nil return to
+// mean "no such plugin, fall through to other resolution".
+func DiscoverAndRegisterNamedAlways(ctx context.Context, name types.AgentName) error {
 	if name == "" {
 		return nil
 	}
+	// Checked before lookup so a traversal attempt never reaches exec.LookPath.
 	if strings.ContainsAny(string(name), `/\`) {
 		return fmt.Errorf("invalid external agent name %q: contains path separators", name)
 	}
@@ -98,139 +137,304 @@ func discoverAndRegisterNamed(ctx context.Context, name types.AgentName, timeout
 		return nil
 	}
 
-	// `ctx` deliberately stays the CALLER's context; the derived timeout gets its own
-	// name. Shadowing `ctx` with the derived context is what caused the bug this
-	// function is guarding against, and it left the trap in place for the next edit.
-	discoveryCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	if err := discoveryCtxErr(ctx, discoveryCtx, fmt.Sprintf("discovering external agent %q", name)); err != nil {
-		return err
-	}
-
 	binName := binaryPrefix + string(name)
 	binPath, err := lookPathExternalAgent(binName)
-	if ctxErr := discoveryCtxErr(ctx, discoveryCtx, fmt.Sprintf("looking up external agent %q binary %q", name, binName)); ctxErr != nil {
-		return ctxErr
-	}
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return nil
 		}
 		return fmt.Errorf("looking up external agent %q binary %q: %w", name, binName, err)
 	}
-	registered, err := registerExternalAgent(discoveryCtx, binPath, name)
+
+	cand := candidate{name: name, binPath: binPath}
+	usable, err := inspectBinary(binPath)
 	if err != nil {
+		recordBroken(ctx, cand, err)
 		return err
 	}
-	if !registered {
-		return fmt.Errorf("external agent %q binary %q was found but could not be registered", name, binPath)
+	if !usable {
+		return nil
 	}
+
+	// A dead caller is reported as cancellation, not as a plugin failure.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		err := fmt.Errorf("discovering external agent %q: %w", name, ctxErr)
+		recordBroken(ctx, cand, err)
+		return err
+	}
+
+	ag, err := loadExternalAgent(ctx, cand)
+	if err != nil {
+		recordBroken(ctx, cand, err)
+		return err
+	}
+	recordReady(ctx, cand, ag)
 	return nil
 }
 
-// discoverAndRegister contains the shared scanning logic for external agent discovery.
+// discoverAndRegister is the shared scan: a cheap $PATH pass to collect
+// candidates, then one goroutine per candidate to load it.
 func discoverAndRegister(ctx context.Context) {
-	// As above: `ctx` remains the caller's, the derived timeout is named.
-	discoveryCtx, cancel := context.WithTimeout(ctx, discoveryTimeout)
-	defer cancel()
-
-	pathEnv := os.Getenv("PATH")
-	if pathEnv == "" {
+	candidates := scanPath(ctx)
+	if len(candidates) == 0 {
 		return
 	}
 
-	// Collect already-registered names to avoid conflicts.
+	// A cancelled caller is not evidence that any plugin is broken, but the set
+	// found on $PATH is still worth surfacing, so record it rather than dropping
+	// it silently. Nothing is executed.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		logging.Debug(ctx, "external agent discovery canceled before loading candidates",
+			slog.Int("candidates", len(candidates)),
+			slog.String("error", ctxErr.Error()))
+		for _, cand := range candidates {
+			recordBroken(ctx, cand, fmt.Errorf("discovering external agent %q: %w", cand.name, ctxErr))
+		}
+		return
+	}
+
+	results := make(chan loadResult, len(candidates))
+	var wg sync.WaitGroup
+	for i, cand := range candidates {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ag, err := loadExternalAgent(ctx, cand)
+			results <- loadResult{index: i, agent: ag, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	// Apply in $PATH order rather than completion order, so registration stays
+	// deterministic even though loading is concurrent.
+	ordered := make([]loadResult, len(candidates))
+	for res := range results {
+		ordered[res.index] = res
+	}
+	for i, res := range ordered {
+		if res.err != nil {
+			recordBroken(ctx, candidates[i], res.err)
+			continue
+		}
+		recordReady(ctx, candidates[i], res.agent)
+	}
+}
+
+// loadResult carries one candidate's outcome back to the collector. index is the
+// candidate's position in $PATH order.
+type loadResult struct {
+	index int
+	agent agent.Agent
+	err   error
+}
+
+// scanPath walks $PATH and returns the binaries worth executing, in $PATH order.
+// Everything that can be decided without running anything is decided here:
+// non-agents are dropped, unusable files are recorded as broken.
+func scanPath(ctx context.Context) []candidate {
+	pathEnv := os.Getenv("PATH")
+	if pathEnv == "" {
+		return nil
+	}
+
 	registered := make(map[types.AgentName]bool)
 	for _, name := range agent.List() {
 		registered[name] = true
 	}
 
-	seen := make(map[string]bool) // deduplicate binaries across PATH dirs
+	var candidates []candidate
+	seen := make(map[types.AgentName]bool) // first $PATH dir wins
 	for _, dir := range filepath.SplitList(pathEnv) {
-		if discoveryCanceled(ctx, discoveryCtx) {
-			logging.Debug(ctx, "external agent discovery timed out")
-			return
-		}
-
 		matches, err := filepath.Glob(filepath.Join(dir, binaryPrefix+"*"))
 		if err != nil {
-			continue // skip unreadable directories
+			continue // unreadable directory
 		}
 		for _, binPath := range matches {
-			if discoveryCanceled(ctx, discoveryCtx) {
-				logging.Debug(ctx, "external agent discovery timed out")
-				return
-			}
-
-			name := filepath.Base(binPath)
-			if seen[name] {
+			// Strip Windows executable extensions (.exe, .bat, …) before deriving
+			// the agent name. On Unix this is a no-op.
+			base := StripExeExt(filepath.Base(binPath))
+			name := types.AgentName(strings.TrimPrefix(base, binaryPrefix))
+			if name == "" || seen[name] {
 				continue
 			}
 			seen[name] = true
 
-			// Strip Windows executable extensions (.exe, .bat) before deriving agent name.
-			// On Unix, binaries have no extension, so this is a no-op.
-			cleanName := StripExeExt(name)
-			agentName := types.AgentName(strings.TrimPrefix(cleanName, binaryPrefix))
-			if registered[agentName] {
-				logging.Debug(ctx, "skipping external agent (name conflict with built-in)",
-					slog.String("binary", name),
-					slog.String("agent", string(agentName)))
+			// Already resolved in this process: don't pay for the exec again.
+			// setup.go reaches discovery from several independent entry points,
+			// so the redundant calls must cost a glob and nothing more.
+			if isKnown(name) {
 				continue
 			}
 
-			registeredAgent, err := registerExternalAgent(discoveryCtx, binPath, agentName)
-			if err != nil {
-				logging.Debug(ctx, "skipping external agent (registration failed)",
+			// A registered agent always wins a name collision, and the shadowing
+			// binary is not executed. agent.Register overwrites process-wide and
+			// the gated scan runs inside git hooks, so allowing an override would
+			// let any writable $PATH directory take over the agent that reads
+			// transcripts and writes checkpoints.
+			if registered[name] {
+				logging.Warn(ctx, "ignoring external agent binary that shadows a registered agent",
 					slog.String("binary", binPath),
-					slog.String("agent", string(agentName)),
-					slog.String("error", err.Error()))
+					slog.String("agent", string(name)))
 				continue
 			}
-			if registeredAgent {
-				registered[agentName] = true
+
+			cand := candidate{name: name, binPath: binPath}
+			usable, err := inspectBinary(binPath)
+			if err != nil {
+				recordBroken(ctx, cand, err)
+				continue
 			}
+			if !usable {
+				continue
+			}
+			candidates = append(candidates, cand)
 		}
 	}
+	return candidates
 }
 
-func registerExternalAgent(ctx context.Context, binPath string, name types.AgentName) (bool, error) {
-	finfo, err := statExternalAgent(binPath)
+// inspectBinary reports whether binPath is worth executing. It returns
+// (false, nil) for entries that aren't plugins at all — a directory, or a file
+// that vanished between glob and stat — and an error for a file that looks like
+// a plugin but cannot be run.
+func inspectBinary(binPath string) (bool, error) {
+	// binPath is not user input: it comes from a $PATH glob or exec.LookPath, and
+	// a name carrying a path separator is rejected before lookup.
+	finfo, err := os.Stat(binPath) //nolint:gosec // G703: path comes from $PATH, not from user input
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
 		}
-		return false, fmt.Errorf("inspecting external agent %q binary %q: %w", name, binPath, err)
+		return false, fmt.Errorf("inspecting external agent binary %q: %w", binPath, err)
 	}
 	if finfo.IsDir() {
 		return false, nil
 	}
-	// Check executable bit (on Unix; Windows doesn't set execute bits).
+	// Windows doesn't set execute bits; executability there comes from PATHEXT.
 	if runtime.GOOS != osWindows && finfo.Mode()&0o111 == 0 {
-		return false, nil
+		return false, fmt.Errorf("%w: %q", ErrNotExecutable, binPath)
 	}
+	return true, nil
+}
 
-	ea, err := New(ctx, binPath)
+// loadExternalAgent runs the binary's "info" subcommand under the per-binary
+// budget and wraps the result. It never touches the registries, so callers
+// decide whether a failure is returned, recorded, or both.
+func loadExternalAgent(ctx context.Context, cand candidate) (agent.Agent, error) {
+	// ctx stays the CALLER's; the budget gets its own name. Shadowing ctx here
+	// would hide caller cancellation behind the derived deadline.
+	runCtx, cancel := context.WithTimeout(ctx, infoTimeout)
+	defer cancel()
+
+	ea, err := New(runCtx, cand.binPath)
 	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return false, fmt.Errorf("loading info for external agent %q from binary %q: %w: %w", name, binPath, ctxErr, err)
-		}
-		return false, fmt.Errorf("loading info for external agent %q from binary %q: %w", name, binPath, err)
+		return nil, fmt.Errorf("loading info for external agent %q from binary %q: %w",
+			cand.name, cand.binPath, classifyLoadError(ctx, runCtx, err))
 	}
 
 	wrapped, err := Wrap(ea)
 	if err != nil {
-		return false, fmt.Errorf("wrapping external agent %q from binary %q: %w", name, binPath, err)
+		return nil, fmt.Errorf("wrapping external agent %q from binary %q: %w", cand.name, cand.binPath, err)
 	}
-	agent.Register(name, func() agent.Agent {
-		return wrapped
-	})
+	return wrapped, nil
+}
+
+// classifyLoadError labels a failed "info" call so callers can tell a timeout
+// from a genuine failure; exec surfaces a killed child only as "signal: killed".
+//
+// ErrInfoTimeout is attached only when the budget expired on its own: if the
+// caller was cancelled the binary never got its full budget, so calling it slow
+// would be a lie.
+func classifyLoadError(caller, runCtx context.Context, err error) error {
+	runErr := runCtx.Err()
+	if runErr == nil {
+		return err
+	}
+	if caller.Err() != nil {
+		return errors.Join(runErr, err)
+	}
+	return errors.Join(ErrInfoTimeout, runErr, err)
+}
+
+// isKnown reports whether discovery already has a verdict for name.
+func isKnown(name types.AgentName) bool {
+	discoveryMu.RLock()
+	defer discoveryMu.RUnlock()
+	_, ready := readyAgents[name]
+	_, broken := brokenAgents[name]
+	return ready || broken
+}
+
+func recordReady(ctx context.Context, cand candidate, ag agent.Agent) {
+	discoveryMu.Lock()
+	readyAgents[cand.name] = ag
+	delete(brokenAgents, cand.name)
+	discoveryMu.Unlock()
+
+	agent.Register(cand.name, func() agent.Agent { return ag })
 
 	logging.Debug(ctx, "registered external agent",
-		slog.String("name", string(name)),
-		slog.String("type", string(ea.Type())),
-		slog.String("binary", binPath))
-	return true, nil
+		slog.String("name", string(cand.name)),
+		slog.String("type", string(ag.Type())),
+		slog.String("binary", cand.binPath))
+}
+
+func recordBroken(ctx context.Context, cand candidate, err error) {
+	discoveryMu.Lock()
+	brokenAgents[cand.name] = BrokenAgent{Name: cand.name, BinaryPath: cand.binPath, Err: err}
+	discoveryMu.Unlock()
+
+	logging.Debug(ctx, "external agent binary could not be loaded",
+		slog.String("name", string(cand.name)),
+		slog.String("binary", cand.binPath),
+		slog.String("error", err.Error()))
+}
+
+// Get returns a discovered external agent by name. A binary that was found but
+// failed to load returns its load error, so callers can explain why a plugin the
+// user has installed isn't available.
+func Get(name types.AgentName) (agent.Agent, error) {
+	discoveryMu.RLock()
+	defer discoveryMu.RUnlock()
+
+	if ag, ok := readyAgents[name]; ok {
+		return ag, nil
+	}
+	if b, ok := brokenAgents[name]; ok {
+		return nil, b.Err
+	}
+	return nil, fmt.Errorf("no external agent %q discovered", name)
+}
+
+// ReadyAgents returns the names of external agents that loaded successfully,
+// sorted.
+func ReadyAgents() []types.AgentName {
+	discoveryMu.RLock()
+	defer discoveryMu.RUnlock()
+
+	names := make([]types.AgentName, 0, len(readyAgents))
+	for name := range readyAgents {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// BrokenAgents returns the external agent binaries that were found on $PATH but
+// could not be loaded, sorted by name.
+func BrokenAgents() []BrokenAgent {
+	discoveryMu.RLock()
+	defer discoveryMu.RUnlock()
+
+	broken := make([]BrokenAgent, 0, len(brokenAgents))
+	for _, b := range brokenAgents {
+		broken = append(broken, b)
+	}
+	slices.SortFunc(broken, func(a, b BrokenAgent) int {
+		return strings.Compare(string(a.Name), string(b.Name))
+	})
+	return broken
 }
 
 // StripExeExt removes Windows executable extensions (.exe, .bat, .cmd, .com)

--- a/cmd/entire/cli/agent/external/discovery_test.go
+++ b/cmd/entire/cli/agent/external/discovery_test.go
@@ -16,20 +16,97 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 )
 
-// setupDiscoveryDir creates a temp directory containing a mock entire-agent-<name> binary.
-// Returns the directory path.
+// NOTE: Tests in this file modify process-global state (os.Setenv, t.Chdir, the
+// agent registry, and the external ready/broken registries) and therefore cannot
+// use t.Parallel().
+//
+// Every mock agent is written into a fresh t.TempDir(), so every exec in this
+// file is a COLD one — see the infoTimeout doc comment for why that costs
+// hundreds of milliseconds rather than the ~10ms a warm plugin does, and why on
+// a saturated machine it has been seen to exceed two seconds.
+//
+// That is why no test here runs against the production budget. Tests that need
+// a binary to SUCCEED raise it via withInfoTimeout so they can't flake when the
+// machine is busy; tests that need one to TIME OUT lower it so they stay fast
+// and deterministic. A happy-path assertion that depends on how loaded the CI
+// box is would be worse than no assertion at all.
+
+// setupDiscoveryTest clears the external ready/broken registries and installs a
+// budget generous enough that no healthy binary can time out.
+//
+// The reset matters because the idempotency skip in scanPath would otherwise let
+// one test's verdicts leak into the next and make failures depend on test order.
+// The agent registry itself is never reset; tests use unique agent names.
+//
+// The budget matters because every mock here is a cold exec (see the file
+// comment). Tests that specifically exercise the timeout path opt back down with
+// withInfoTimeout(t, shortInfoTimeout).
+func setupDiscoveryTest(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		discoveryMu.Lock()
+		defer discoveryMu.Unlock()
+		readyAgents = make(map[types.AgentName]agent.Agent)
+		brokenAgents = make(map[types.AgentName]BrokenAgent)
+	}
+	reset()
+	t.Cleanup(reset)
+	withInfoTimeout(t, generousInfoTimeout)
+}
+
+// setupDiscoveryDir creates a temp directory containing a mock
+// entire-agent-<name> binary and returns the directory path.
 func setupDiscoveryDir(t *testing.T, agentName, infoJSON string) string {
 	t.Helper()
 
 	dir := t.TempDir()
-	binName := binaryPrefix + agentName
-	binPath := filepath.Join(dir, binName)
+	writeMockAgent(t, dir, agentName, mockInfoScript(infoJSON))
+	return dir
+}
 
-	script := mockInfoScript(infoJSON)
+// writeMockAgent writes an executable entire-agent-<name> script into dir.
+func writeMockAgent(t *testing.T, dir, agentName, script string) {
+	t.Helper()
+
+	binPath := filepath.Join(dir, binaryPrefix+agentName)
 	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write mock binary: %v", err)
 	}
-	return dir
+}
+
+// writeStalledAgent writes an agent binary that never answers "info", so its
+// load has to be cut off by the per-binary budget.
+func writeStalledAgent(t *testing.T, dir, agentName string) {
+	t.Helper()
+
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skip("sleep not available")
+	}
+	writeMockAgent(t, dir, agentName, fmt.Sprintf("#!/bin/sh\nexec %q 60\n", sleepPath))
+}
+
+// writeMarkerAgent writes an agent binary that appends a line to markerPath on
+// every invocation, so a test can count how many times it was actually executed.
+// body runs after the marker write (valid info JSON, garbage, whatever).
+func writeMarkerAgent(t *testing.T, dir, agentName, markerPath, body string) {
+	t.Helper()
+
+	writeMockAgent(t, dir, agentName, fmt.Sprintf("#!/bin/sh\necho run >> %q\n%s\n", markerPath, body))
+}
+
+// markerRuns counts how many times a marker-writing agent binary was executed.
+func markerRuns(t *testing.T, markerPath string) int {
+	t.Helper()
+
+	data, err := os.ReadFile(markerPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("read marker %q: %v", markerPath, err)
+	}
+	return len(strings.Fields(string(data)))
 }
 
 func makeInfoJSON(name string) string {
@@ -45,13 +122,52 @@ func makeInfoJSON(name string) string {
 }`
 }
 
-// NOTE: Tests in this file modify process-global state (os.Setenv, os.Chdir, agent registry)
-// and therefore cannot use t.Parallel().
+// echoInfo is a shell body that answers "info" with valid metadata.
+func echoInfo(name string) string {
+	return "echo '" + makeInfoJSON(name) + "'"
+}
 
-// enableExternalAgents creates a temp repo with external_agents enabled in settings
-// and chdir's into it so that settings.Load can find the config.
+// brokenEntry returns the broken-registry entry for name, failing if absent.
+func brokenEntry(t *testing.T, name string) BrokenAgent {
+	t.Helper()
+
+	for _, b := range BrokenAgents() {
+		if b.Name == types.AgentName(name) {
+			return b
+		}
+	}
+	t.Fatalf("agent %q not recorded as broken; broken = %v", name, BrokenAgents())
+	return BrokenAgent{}
+}
+
+// requireNotBroken asserts name was not recorded in the broken registry.
+func requireNotBroken(t *testing.T, name string) {
+	t.Helper()
+
+	for _, b := range BrokenAgents() {
+		if b.Name == types.AgentName(name) {
+			t.Fatalf("agent %q unexpectedly recorded as broken: %v", name, b.Err)
+		}
+	}
+}
+
+// enableExternalAgents creates a temp repo with external_agents enabled and
+// chdir's into it so settings.Load can find the config.
 func enableExternalAgents(t *testing.T) {
 	t.Helper()
+	writeRepoSettings(t, `{"enabled":true,"external_agents":true}`)
+}
+
+// disableExternalAgents creates a temp repo with external_agents absent (the
+// default, i.e. disabled) and chdir's into it.
+func disableExternalAgents(t *testing.T) {
+	t.Helper()
+	writeRepoSettings(t, `{"enabled":true}`)
+}
+
+func writeRepoSettings(t *testing.T, settingsJSON string) {
+	t.Helper()
+
 	tmpDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
 		t.Fatalf("create .git: %v", err)
@@ -60,22 +176,59 @@ func enableExternalAgents(t *testing.T) {
 	if err := os.MkdirAll(entireDir, 0o755); err != nil {
 		t.Fatalf("create .entire: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"enabled":true,"external_agents":true}`), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644); err != nil {
 		t.Fatalf("write settings: %v", err)
 	}
 	t.Chdir(tmpDir)
 }
 
-func TestDiscoverAndRegister_FindsAgent(t *testing.T) {
+func requireSh(t *testing.T) {
+	t.Helper()
+
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("sh not available")
 	}
+}
 
+// generousInfoTimeout is used by tests that expect a binary to load. It is far
+// above any legitimate cold-start cost, so these tests assert behaviour rather
+// than machine speed.
+const generousInfoTimeout = 60 * time.Second
+
+// shortInfoTimeout is used by tests that expect the budget to expire. It is long
+// enough that a healthy binary would still answer, so a timeout here means the
+// binary really never responded.
+const shortInfoTimeout = 250 * time.Millisecond
+
+// withInfoTimeout overrides the per-binary budget for one test.
+func withInfoTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+
+	original := infoTimeout
+	infoTimeout = d
+	t.Cleanup(func() { infoTimeout = original })
+}
+
+// warmUpBinary runs a mock agent once and discards the result, so the exec the
+// test actually measures is a warm one (~10ms) rather than a cold one (hundreds
+// of ms). Only for tests that must run a healthy binary under a short budget.
+func warmUpBinary(t *testing.T, binPath string) {
+	t.Helper()
+
+	if err := exec.CommandContext(t.Context(), binPath, "info").Run(); err != nil {
+		t.Fatalf("warm up %q: %v", binPath, err)
+	}
+}
+
+// --- Scan and register: agents that load ---
+
+func TestDiscoverAndRegister_FindsAgent(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-find"
-	dir := setupDiscoveryDir(t, name, makeInfoJSON(name))
-	t.Setenv("PATH", dir)
+	t.Setenv("PATH", setupDiscoveryDir(t, name, makeInfoJSON(name)))
 
 	DiscoverAndRegister(context.Background())
 
@@ -86,13 +239,12 @@ func TestDiscoverAndRegister_FindsAgent(t *testing.T) {
 	if string(ag.Name()) != name {
 		t.Errorf("agent Name() = %q, want %q", ag.Name(), name)
 	}
+	requireNotBroken(t, name)
 }
 
 func TestDiscoverAndRegister_Deduplication(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
+	requireSh(t)
+	setupDiscoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-dedup"
@@ -102,7 +254,6 @@ func TestDiscoverAndRegister_Deduplication(t *testing.T) {
 
 	DiscoverAndRegister(context.Background())
 
-	// Verify the agent is registered (just once — no panic or error from double registration).
 	ag, err := agent.Get(types.AgentName(name))
 	if err != nil {
 		t.Fatalf("expected agent %q to be registered: %v", name, err)
@@ -112,79 +263,107 @@ func TestDiscoverAndRegister_Deduplication(t *testing.T) {
 	}
 }
 
-func TestDiscoverAndRegister_SkipsNameConflict(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
+// TestDiscoverAndRegister_FirstPathDirWins pins that the earlier $PATH entry
+// wins a duplicate name, which is what keeps registration deterministic even
+// though the binaries are loaded concurrently.
+func TestDiscoverAndRegister_FirstPathDirWins(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
 	enableExternalAgents(t)
 
-	name := "disc-conflict"
-	// Pre-register an agent with the same name.
-	agent.Register(types.AgentName(name), func() agent.Agent {
-		return nil // placeholder
-	})
-
-	// Create an external binary with the conflicting name, using a different type.
-	conflictJSON := `{
-  "protocol_version": 1,
-  "name": "` + name + `",
-  "type": "Different Type",
-  "description": "Should be skipped",
-  "is_preview": false,
-  "protected_dirs": [],
-  "hook_names": [],
-  "capabilities": {}
-}`
-	dir := setupDiscoveryDir(t, name, conflictJSON)
-	t.Setenv("PATH", dir)
+	name := "disc-firstwins"
+	firstDir := setupDiscoveryDir(t, name, makeInfoJSON(name))
+	// The second copy on $PATH is broken; it must never be consulted.
+	secondDir := t.TempDir()
+	writeMockAgent(t, secondDir, name, "#!/bin/sh\necho 'not json'\n")
+	t.Setenv("PATH", firstDir+string(os.PathListSeparator)+secondDir)
 
 	DiscoverAndRegister(context.Background())
 
-	// The pre-registered placeholder should still be there (returns nil).
+	if _, err := agent.Get(types.AgentName(name)); err != nil {
+		t.Fatalf("expected first-$PATH agent %q to be registered: %v", name, err)
+	}
+	requireNotBroken(t, name)
+}
+
+func TestDiscoverAndRegisterAlways_FindsAgentWithoutSettings(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+	disableExternalAgents(t)
+
+	name := "disc-always"
+	t.Setenv("PATH", setupDiscoveryDir(t, name, makeInfoJSON(name)))
+
+	DiscoverAndRegisterAlways(context.Background())
+
 	ag, err := agent.Get(types.AgentName(name))
 	if err != nil {
-		t.Fatalf("agent should still be registered: %v", err)
+		t.Fatalf("expected agent %q to be registered by DiscoverAndRegisterAlways: %v", name, err)
 	}
-	// The placeholder factory returns nil, so it wasn't replaced by the external one.
-	if ag != nil {
-		t.Errorf("expected placeholder (nil) agent, got %v", ag)
+	if string(ag.Name()) != name {
+		t.Errorf("agent Name() = %q, want %q", ag.Name(), name)
 	}
 }
 
-func TestDiscoverAndRegister_SkipsNonExecutable(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
+func TestDiscoverAndRegister_SkipsWhenDisabled(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+	disableExternalAgents(t)
 
-	enableExternalAgents(t)
-
-	name := "disc-noexec"
+	name := "disc-disabled"
+	marker := filepath.Join(t.TempDir(), "runs")
 	dir := t.TempDir()
-	binPath := filepath.Join(dir, binaryPrefix+name)
-
-	// Write a valid script but WITHOUT executable permission.
-	script := mockInfoScript(makeInfoJSON(name))
-	if err := os.WriteFile(binPath, []byte(script), 0o644); err != nil {
-		t.Fatalf("write mock binary: %v", err)
-	}
+	writeMarkerAgent(t, dir, name, marker, echoInfo(name))
 	t.Setenv("PATH", dir)
 
 	DiscoverAndRegister(context.Background())
 
-	_, err := agent.Get(types.AgentName(name))
-	if err == nil {
-		t.Error("expected non-executable file to be skipped, but agent was registered")
+	if _, err := agent.Get(types.AgentName(name)); err == nil {
+		t.Error("expected agent to NOT be registered when external_agents is disabled")
+	}
+	// The gate short-circuits before scanning, so nothing is recorded either.
+	requireNotBroken(t, name)
+	if runs := markerRuns(t, marker); runs != 0 {
+		t.Errorf("disabled discovery executed the binary %d time(s), want 0", runs)
 	}
 }
 
+func TestDiscoverAndRegister_EmptyPATH(t *testing.T) {
+	setupDiscoveryTest(t)
+	enableExternalAgents(t)
+	t.Setenv("PATH", "")
+
+	DiscoverAndRegister(context.Background()) // must not panic
+
+	if got := BrokenAgents(); len(got) != 0 {
+		t.Errorf("BrokenAgents() = %v, want empty for an empty PATH", got)
+	}
+}
+
+func TestDiscoverAndRegister_UnreadableDir(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+	enableExternalAgents(t)
+
+	name := "disc-unread"
+	goodDir := setupDiscoveryDir(t, name, makeInfoJSON(name))
+	t.Setenv("PATH", "/nonexistent/path"+string(os.PathListSeparator)+goodDir)
+
+	DiscoverAndRegister(context.Background())
+
+	if _, err := agent.Get(types.AgentName(name)); err != nil {
+		t.Fatalf("expected agent %q to be registered despite an unreadable dir in PATH: %v", name, err)
+	}
+}
+
+// --- Scan and register: candidates that are not usable agents ---
+
 func TestDiscoverAndRegister_SkipsDirectory(t *testing.T) {
+	setupDiscoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-dir"
 	dir := t.TempDir()
-
-	// Create a directory (not a file) matching the prefix.
 	if err := os.Mkdir(filepath.Join(dir, binaryPrefix+name), 0o755); err != nil {
 		t.Fatalf("create directory: %v", err)
 	}
@@ -192,188 +371,395 @@ func TestDiscoverAndRegister_SkipsDirectory(t *testing.T) {
 
 	DiscoverAndRegister(context.Background())
 
-	_, err := agent.Get(types.AgentName(name))
-	if err == nil {
+	if _, err := agent.Get(types.AgentName(name)); err == nil {
 		t.Error("expected directory to be skipped, but agent was registered")
 	}
+	// A directory is not a plugin at all, so it must not be reported as broken.
+	requireNotBroken(t, name)
 }
 
-func TestDiscoverAndRegister_SkipsWhenDisabled(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
+// TestDiscoverAndRegister_NonExecutableIsBroken covers the forgot-chmod case.
+// It used to be an invisible skip; surfacing it is why the broken registry exists.
+func TestDiscoverAndRegister_NonExecutableIsBroken(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("Windows does not use exec bits")
 	}
+	requireSh(t)
+	setupDiscoveryTest(t)
+	enableExternalAgents(t)
 
-	// Set up a repo WITHOUT external_agents enabled (default false)
-	tmpDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
-		t.Fatalf("create .git: %v", err)
+	name := "disc-noexec"
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, binaryPrefix+name)
+	if err := os.WriteFile(binPath, []byte(mockInfoScript(makeInfoJSON(name))), 0o644); err != nil {
+		t.Fatalf("write mock binary: %v", err)
 	}
-	entireDir := filepath.Join(tmpDir, ".entire")
-	if err := os.MkdirAll(entireDir, 0o755); err != nil {
-		t.Fatalf("create .entire: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"enabled":true}`), 0o644); err != nil {
-		t.Fatalf("write settings: %v", err)
-	}
-	t.Chdir(tmpDir)
-
-	name := "disc-disabled"
-	dir := setupDiscoveryDir(t, name, makeInfoJSON(name))
 	t.Setenv("PATH", dir)
 
 	DiscoverAndRegister(context.Background())
 
-	// Agent should NOT be registered because external_agents is false
-	_, err := agent.Get(types.AgentName(name))
-	if err == nil {
-		t.Error("expected agent to NOT be registered when external_agents is disabled")
+	if _, err := agent.Get(types.AgentName(name)); err == nil {
+		t.Error("expected non-executable file to not be registered")
+	}
+	entry := brokenEntry(t, name)
+	if !errors.Is(entry.Err, ErrNotExecutable) {
+		t.Errorf("broken entry error = %v, want ErrNotExecutable", entry.Err)
+	}
+	if entry.BinaryPath != binPath {
+		t.Errorf("broken entry BinaryPath = %q, want %q", entry.BinaryPath, binPath)
 	}
 }
 
-func TestDiscoverAndRegister_EmptyPATH(t *testing.T) {
+// TestDiscoverAndRegister_RegisteredAgentWinsNameConflict pins the anti-hijack
+// rule: an external binary never replaces an already-registered agent, and is
+// not even executed. Without this, dropping entire-agent-claude-code anywhere on
+// $PATH would take over transcript reading and checkpoint writing on every hook,
+// because agent.Register overwrites process-wide and the gated scan runs in hooks.
+func TestDiscoverAndRegister_RegisteredAgentWinsNameConflict(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
 	enableExternalAgents(t)
-	t.Setenv("PATH", "")
 
-	// Should return without error or panic.
-	DiscoverAndRegister(context.Background())
-}
+	name := "disc-conflict"
+	agent.Register(types.AgentName(name), func() agent.Agent {
+		return nil // sentinel: a nil agent proves the original factory survived
+	})
 
-func TestDiscoverAndRegister_UnreadableDir(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
-	enableExternalAgents(t)
-
-	name := "disc-unread"
-	goodDir := setupDiscoveryDir(t, name, makeInfoJSON(name))
-
-	// Include a non-existent directory in PATH — it should be silently skipped.
-	t.Setenv("PATH", "/nonexistent/path"+string(os.PathListSeparator)+goodDir)
-
-	DiscoverAndRegister(context.Background())
-
-	_, err := agent.Get(types.AgentName(name))
-	if err != nil {
-		t.Fatalf("expected agent %q to be registered despite unreadable dir in PATH: %v", name, err)
-	}
-}
-
-func TestDiscoverAndRegisterAlways_FindsAgentWithoutSettings(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
-	// Set up a repo WITHOUT external_agents enabled (default false).
-	tmpDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
-		t.Fatalf("create .git: %v", err)
-	}
-	entireDir := filepath.Join(tmpDir, ".entire")
-	if err := os.MkdirAll(entireDir, 0o755); err != nil {
-		t.Fatalf("create .entire: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"enabled":true}`), 0o644); err != nil {
-		t.Fatalf("write settings: %v", err)
-	}
-	t.Chdir(tmpDir)
-
-	name := "disc-always"
-	dir := setupDiscoveryDir(t, name, makeInfoJSON(name))
+	marker := filepath.Join(t.TempDir(), "runs")
+	dir := t.TempDir()
+	writeMarkerAgent(t, dir, name, marker, echoInfo(name))
 	t.Setenv("PATH", dir)
 
-	// DiscoverAndRegisterAlways should find the agent even without external_agents enabled.
-	DiscoverAndRegisterAlways(context.Background())
+	DiscoverAndRegister(context.Background())
 
 	ag, err := agent.Get(types.AgentName(name))
 	if err != nil {
-		t.Fatalf("expected agent %q to be registered by DiscoverAndRegisterAlways, got error: %v", name, err)
+		t.Fatalf("agent should still be registered: %v", err)
 	}
-	if string(ag.Name()) != name {
-		t.Errorf("agent Name() = %q, want %q", ag.Name(), name)
+	if ag != nil {
+		t.Errorf("external agent replaced the registered one: got %v, want the nil sentinel", ag)
+	}
+	if runs := markerRuns(t, marker); runs != 0 {
+		t.Errorf("shadowing binary was executed %d time(s), want 0", runs)
+	}
+	// A shadowed binary is not a broken agent.
+	requireNotBroken(t, name)
+}
+
+// --- Scan and register: failures are recorded, not swallowed ---
+
+func TestDiscoverAndRegister_InvalidInfoIsBroken(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+	enableExternalAgents(t)
+
+	name := "disc-badjson"
+	dir := t.TempDir()
+	writeMockAgent(t, dir, name, "#!/bin/sh\necho 'not json'\n")
+	t.Setenv("PATH", dir)
+
+	DiscoverAndRegister(context.Background())
+
+	if _, err := agent.Get(types.AgentName(name)); err == nil {
+		t.Error("expected agent with bad info to not be registered")
+	}
+	entry := brokenEntry(t, name)
+	if !strings.Contains(entry.Err.Error(), "invalid JSON") {
+		t.Errorf("broken entry error = %v, want invalid JSON context", entry.Err)
+	}
+	if errors.Is(entry.Err, ErrInfoTimeout) {
+		t.Errorf("broken entry error = %v, want a load failure, not a timeout", entry.Err)
 	}
 }
 
-func TestDiscoverAndRegisterNamedAlways_TimesOutStalledInfo(t *testing.T) {
-	sleepPath, err := exec.LookPath("sleep")
-	if err != nil {
-		t.Skip("sleep not available")
+func TestDiscoverAndRegister_ContinuesAfterFailure(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+	enableExternalAgents(t)
+
+	badName := "disc-scan-a-invalid"
+	badDir := t.TempDir()
+	writeMockAgent(t, badDir, badName, "#!/bin/sh\necho 'not json'\n")
+	goodName := "disc-scan-z-valid"
+	goodDir := setupDiscoveryDir(t, goodName, makeInfoJSON(goodName))
+	t.Setenv("PATH", badDir+string(os.PathListSeparator)+goodDir)
+
+	DiscoverAndRegisterAlways(context.Background())
+
+	if _, err := agent.Get(types.AgentName(badName)); err == nil {
+		t.Fatalf("invalid external agent %q was registered", badName)
 	}
+	if _, err := agent.Get(types.AgentName(goodName)); err != nil {
+		t.Fatalf("valid external agent %q was not registered after a failure: %v", goodName, err)
+	}
+}
+
+// TestDiscoverAndRegister_SlowBinariesDoNotBlockFastOnes is the regression this
+// refactor exists to prevent. Serially, four stalled binaries would burn
+// 4*infoTimeout before the valid one was even attempted — and under the old
+// shared budget it would have been dropped entirely. Concurrently the whole scan
+// costs roughly one infoTimeout.
+func TestDiscoverAndRegister_SlowBinariesDoNotBlockFastOnes(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+	// Short enough that the stalled binaries are cut off quickly, long enough that
+	// the (warmed) fast one comfortably answers.
+	withInfoTimeout(t, time.Second)
+	enableExternalAgents(t)
+
+	const stalledCount = 4
+	dir := t.TempDir()
+	for i := range stalledCount {
+		writeStalledAgent(t, dir, fmt.Sprintf("disc-par-slow-%d", i))
+	}
+	fastName := "disc-par-fast"
+	writeMockAgent(t, dir, fastName, mockInfoScript(makeInfoJSON(fastName)))
+	// The fast binary must beat the budget on merit, not on cold-start luck.
+	warmUpBinary(t, filepath.Join(dir, binaryPrefix+fastName))
+	t.Setenv("PATH", dir)
+
+	started := time.Now()
+	DiscoverAndRegisterAlways(context.Background())
+	elapsed := time.Since(started)
+
+	if _, err := agent.Get(types.AgentName(fastName)); err != nil {
+		t.Fatalf("fast agent %q was not registered alongside stalled ones: %v", fastName, err)
+	}
+	for i := range stalledCount {
+		stalled := fmt.Sprintf("disc-par-slow-%d", i)
+		entry := brokenEntry(t, stalled)
+		if !errors.Is(entry.Err, ErrInfoTimeout) {
+			t.Errorf("stalled agent %q error = %v, want ErrInfoTimeout", stalled, entry.Err)
+		}
+		if !errors.Is(entry.Err, context.DeadlineExceeded) {
+			t.Errorf("stalled agent %q error = %v, want context.DeadlineExceeded", stalled, entry.Err)
+		}
+	}
+	// Serial execution cannot finish in under stalledCount*infoTimeout, because
+	// each stalled binary burns the whole budget in turn. Concurrent execution
+	// needs ~infoTimeout plus cold-start overhead, so the threshold sits between
+	// the two. The gap is what the assertion rests on, not absolute speed: the
+	// budget is deliberately short here, and a cold start that eats the slack
+	// would have to eat more than a whole extra budget to produce a false failure.
+	if maxElapsed := stalledCount * infoTimeout / 2; elapsed > maxElapsed {
+		t.Errorf("discovery took %v, want < %v (binaries loaded serially?)", elapsed, maxElapsed)
+	}
+}
+
+// TestDiscoverAndRegister_CanceledCallerRecordsCandidates pins the agreed
+// behaviour for a dead caller: the $PATH scan still runs (it is cheap and has no
+// side effects) so the plugins found stay visible, but nothing is executed and
+// the failure is attributed to cancellation rather than to the plugins.
+func TestDiscoverAndRegister_CanceledCallerRecordsCandidates(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+	enableExternalAgents(t)
+
+	name := "disc-canceled-caller"
+	marker := filepath.Join(t.TempDir(), "runs")
+	dir := t.TempDir()
+	writeMarkerAgent(t, dir, name, marker, echoInfo(name))
+	t.Setenv("PATH", dir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	DiscoverAndRegisterAlways(ctx)
+
+	entry := brokenEntry(t, name)
+	if !errors.Is(entry.Err, context.Canceled) {
+		t.Errorf("broken entry error = %v, want context.Canceled", entry.Err)
+	}
+	if errors.Is(entry.Err, ErrInfoTimeout) {
+		t.Errorf("broken entry error = %v, want cancellation, not a timeout", entry.Err)
+	}
+	if runs := markerRuns(t, marker); runs != 0 {
+		t.Errorf("binary executed %d time(s) under a canceled caller, want 0", runs)
+	}
+}
+
+// TestDiscoverAndRegister_IdempotentAcrossCalls matters because setup.go reaches
+// discovery up to three times per process from independently reachable entry
+// points. A name with a verdict must not be re-executed, so the redundant calls
+// cost a $PATH glob and nothing more.
+func TestDiscoverAndRegister_IdempotentAcrossCalls(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+	enableExternalAgents(t)
+
+	brokenName := "disc-idem-broken"
+	brokenMarker := filepath.Join(t.TempDir(), "broken-runs")
+	readyName := "disc-idem-ready"
+	readyMarker := filepath.Join(t.TempDir(), "ready-runs")
+
+	dir := t.TempDir()
+	writeMarkerAgent(t, dir, brokenName, brokenMarker, "echo 'not json'")
+	writeMarkerAgent(t, dir, readyName, readyMarker, echoInfo(readyName))
+	t.Setenv("PATH", dir)
+
+	DiscoverAndRegisterAlways(context.Background())
+	firstBroken, firstReady := len(BrokenAgents()), len(ReadyAgents())
+
+	DiscoverAndRegisterAlways(context.Background())
+
+	if runs := markerRuns(t, brokenMarker); runs != 1 {
+		t.Errorf("broken binary executed %d time(s) across two calls, want 1", runs)
+	}
+	if runs := markerRuns(t, readyMarker); runs != 1 {
+		t.Errorf("ready binary executed %d time(s) across two calls, want 1", runs)
+	}
+	if got := len(BrokenAgents()); got != firstBroken {
+		t.Errorf("BrokenAgents() len = %d after second call, want %d", got, firstBroken)
+	}
+	if got := len(ReadyAgents()); got != firstReady {
+		t.Errorf("ReadyAgents() len = %d after second call, want %d", got, firstReady)
+	}
+}
+
+// --- Get ---
+
+func TestGet(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+	enableExternalAgents(t)
+
+	readyName := "disc-get-ready"
+	brokenName := "disc-get-broken"
+	dir := t.TempDir()
+	writeMockAgent(t, dir, readyName, mockInfoScript(makeInfoJSON(readyName)))
+	writeMockAgent(t, dir, brokenName, "#!/bin/sh\necho 'not json'\n")
+	t.Setenv("PATH", dir)
+
+	DiscoverAndRegisterAlways(context.Background())
+
+	ag, err := Get(types.AgentName(readyName))
+	if err != nil {
+		t.Fatalf("Get(%q) error = %v, want nil", readyName, err)
+	}
+	if string(ag.Name()) != readyName {
+		t.Errorf("Get(%q).Name() = %q, want %q", readyName, ag.Name(), readyName)
+	}
+
+	_, err = Get(types.AgentName(brokenName))
+	if err == nil {
+		t.Fatalf("Get(%q) error = nil, want the recorded load failure", brokenName)
+	}
+	if !strings.Contains(err.Error(), "invalid JSON") {
+		t.Errorf("Get(%q) error = %v, want the recorded load failure", brokenName, err)
+	}
+
+	if _, err := Get(types.AgentName("disc-get-unknown")); err == nil {
+		t.Error("Get(unknown) error = nil, want a not-found error")
+	}
+}
+
+// --- Named discovery (shares the load path and the budget) ---
+
+func TestDiscoverAndRegisterNamedAlways_Registers(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+
+	name := types.AgentName("disc-named-ok")
+	t.Setenv("PATH", setupDiscoveryDir(t, string(name), makeInfoJSON(string(name))))
+
+	if err := DiscoverAndRegisterNamedAlways(context.Background(), name); err != nil {
+		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v", err)
+	}
+	if _, err := agent.Get(name); err != nil {
+		t.Fatalf("expected named agent %q to be registered: %v", name, err)
+	}
+}
+
+// TestDiscoverAndRegisterNamedAlways_MissingHelper pins that an absent binary is
+// "no such plugin, fall through", not a broken agent. The --summarize-provider
+// override in explain_summary_provider.go depends on the nil error.
+func TestDiscoverAndRegisterNamedAlways_MissingHelper(t *testing.T) {
+	setupDiscoveryTest(t)
+
+	name := types.AgentName("disc-named-missing")
+	t.Setenv("PATH", t.TempDir())
+
+	if err := DiscoverAndRegisterNamedAlways(context.Background(), name); err != nil {
+		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want nil for a missing helper", err)
+	}
+	requireNotBroken(t, string(name))
+}
+
+func TestDiscoverAndRegisterNamedAlways_InvalidInfo(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+
+	name := types.AgentName("disc-named-invalid-info")
+	t.Setenv("PATH", setupDiscoveryDir(t, string(name), "not json"))
+
+	err := DiscoverAndRegisterNamedAlways(context.Background(), name)
+	if err == nil {
+		t.Fatal("DiscoverAndRegisterNamedAlways() error = nil, want an invalid info error")
+	}
+	if !strings.Contains(err.Error(), string(name)) {
+		t.Errorf("error = %q, want agent name %q", err, name)
+	}
+	if !strings.Contains(err.Error(), "invalid JSON") {
+		t.Errorf("error = %q, want invalid info context", err)
+	}
+	// The failure is both returned to the caller and recorded for listing.
+	brokenEntry(t, string(name))
+}
+
+// TestDiscoverAndRegisterNamedAlways_TimesOutStalledInfo pins that named
+// discovery shares the strict per-binary budget rather than the old 10s one.
+func TestDiscoverAndRegisterNamedAlways_TimesOutStalledInfo(t *testing.T) {
+	requireSh(t)
+	setupDiscoveryTest(t)
+	withInfoTimeout(t, shortInfoTimeout)
 
 	name := types.AgentName("disc-named-timeout")
 	dir := t.TempDir()
-	binPath := filepath.Join(dir, binaryPrefix+string(name))
-	script := fmt.Sprintf("#!/bin/sh\nexec %q 60\n", sleepPath)
-	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write stalled mock binary: %v", err)
-	}
+	writeStalledAgent(t, dir, string(name))
 	t.Setenv("PATH", dir)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-
 	started := time.Now()
-	err = DiscoverAndRegisterNamedAlways(ctx, name)
-	if elapsed := time.Since(started); elapsed > 2*time.Second {
-		t.Fatalf("named discovery took %v, want cancellation near context deadline", elapsed)
+	err := DiscoverAndRegisterNamedAlways(context.Background(), name)
+	elapsed := time.Since(started)
+
+	if !errors.Is(err, ErrInfoTimeout) {
+		t.Fatalf("error = %v, want ErrInfoTimeout", err)
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want context deadline exceeded", err)
+		t.Errorf("error = %v, want context.DeadlineExceeded", err)
+	}
+	// Generous multiple of the budget: this asserts the call is bounded at all,
+	// not how fast the machine is.
+	if maxElapsed := 20 * shortInfoTimeout; elapsed > maxElapsed {
+		t.Errorf("named discovery took %v, want < %v", elapsed, maxElapsed)
 	}
 	if _, err := agent.Get(name); err == nil {
-		t.Fatal("stalled external agent was registered")
+		t.Error("stalled external agent was registered")
 	}
 }
 
 func TestDiscoverAndRegisterNamedAlways_CanceledContext(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
+	requireSh(t)
+	setupDiscoveryTest(t)
 
 	name := types.AgentName("disc-named-canceled")
-	dir := setupDiscoveryDir(t, string(name), makeInfoJSON(string(name)))
-	t.Setenv("PATH", dir)
+	t.Setenv("PATH", setupDiscoveryDir(t, string(name), makeInfoJSON(string(name))))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	err := DiscoverAndRegisterNamedAlways(ctx, name)
 	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want context canceled", err)
+		t.Fatalf("error = %v, want context.Canceled", err)
 	}
-}
-
-func TestDiscoverAndRegisterNamedAlways_InvalidInfo(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
-	name := types.AgentName("disc-named-invalid-info")
-	dir := setupDiscoveryDir(t, string(name), "not json")
-	t.Setenv("PATH", dir)
-
-	err := DiscoverAndRegisterNamedAlways(context.Background(), name)
-	if err == nil {
-		t.Fatal("DiscoverAndRegisterNamedAlways() error = nil, want invalid info error")
-	}
-	if !strings.Contains(err.Error(), string(name)) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want agent name %q", err, name)
-	}
-	if !strings.Contains(err.Error(), "info: invalid JSON") {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want invalid info context", err)
-	}
-}
-
-func TestDiscoverAndRegisterNamedAlways_MissingHelper(t *testing.T) {
-	name := types.AgentName("disc-named-missing")
-	t.Setenv("PATH", t.TempDir())
-
-	if err := DiscoverAndRegisterNamedAlways(context.Background(), name); err != nil {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want nil for missing helper", err)
+	if errors.Is(err, ErrInfoTimeout) {
+		t.Errorf("error = %v, want cancellation, not a timeout", err)
 	}
 }
 
 func TestDiscoverAndRegisterNamedAlways_RejectsPathSeparators(t *testing.T) {
+	setupDiscoveryTest(t)
+
 	originalLookPath := lookPathExternalAgent
 	t.Cleanup(func() { lookPathExternalAgent = originalLookPath })
 
@@ -386,7 +772,7 @@ func TestDiscoverAndRegisterNamedAlways_RejectsPathSeparators(t *testing.T) {
 
 		err := DiscoverAndRegisterNamedAlways(context.Background(), name)
 		if err == nil || !strings.Contains(err.Error(), "path separators") {
-			t.Errorf("DiscoverAndRegisterNamedAlways(%q) error = %v, want path separator error", name, err)
+			t.Errorf("DiscoverAndRegisterNamedAlways(%q) error = %v, want a path separator error", name, err)
 		}
 		if lookedUp {
 			t.Errorf("DiscoverAndRegisterNamedAlways(%q) called exec.LookPath for an invalid name", name)
@@ -394,120 +780,82 @@ func TestDiscoverAndRegisterNamedAlways_RejectsPathSeparators(t *testing.T) {
 	}
 }
 
-func TestDiscoverAndRegisterNamedAlways_DeadlineWhileLookingUpMissingHelper(t *testing.T) {
-	name := types.AgentName("disc-named-lookup-deadline")
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
+// --- Windows binary extensions ---
 
-	originalLookPath := lookPathExternalAgent
-	t.Cleanup(func() { lookPathExternalAgent = originalLookPath })
-	lookPathExternalAgent = func(string) (string, error) {
-		<-ctx.Done()
-		return "", exec.ErrNotFound
+// TestDiscoverAndRegister_RegistersBatOnWindows verifies that a .bat agent
+// binary is discovered and registered on Windows, with the file extension
+// stripped from the agent name. .cmd and .exe follow the same code path.
+func TestDiscoverAndRegister_RegistersBatOnWindows(t *testing.T) {
+	if runtime.GOOS != osWindows {
+		t.Skip("this test only applies on Windows")
 	}
+	setupDiscoveryTest(t)
+	enableExternalAgents(t)
 
-	err := DiscoverAndRegisterNamedAlways(ctx, name)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want context deadline exceeded", err)
+	name := "disc-bat"
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, binaryPrefix+name+".bat")
+	if err := os.WriteFile(binPath, []byte(windowsInfoBat(name)), 0o755); err != nil {
+		t.Fatalf("write mock binary: %v", err)
 	}
-}
+	t.Setenv("PATH", dir)
 
-func TestDiscoverAndRegisterNamedAlways_HelperDisappearsAfterLookup(t *testing.T) {
-	name := types.AgentName("disc-named-helper-disappeared")
-	binPath := filepath.Join(t.TempDir(), binaryPrefix+string(name))
+	DiscoverAndRegister(context.Background())
 
-	originalLookPath := lookPathExternalAgent
-	originalStat := statExternalAgent
-	t.Cleanup(func() {
-		lookPathExternalAgent = originalLookPath
-		statExternalAgent = originalStat
-	})
-	lookPathExternalAgent = func(string) (string, error) { return binPath, nil }
-	statExternalAgent = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
-
-	err := DiscoverAndRegisterNamedAlways(context.Background(), name)
-	if err == nil {
-		t.Fatal("DiscoverAndRegisterNamedAlways() error = nil, want helper-disappeared error")
+	ag, err := agent.Get(types.AgentName(name))
+	if err != nil {
+		t.Fatalf("expected agent %q to be registered after stripping .bat: %v", name, err)
 	}
-	if !strings.Contains(err.Error(), string(name)) || !strings.Contains(err.Error(), binPath) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want agent and binary context", err)
-	}
-	if !strings.Contains(err.Error(), "was found but could not be registered") {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want actionable registration context", err)
+	if string(ag.Name()) != name {
+		t.Errorf("agent Name() = %q, want %q", ag.Name(), name)
 	}
 }
 
-func TestDiscoverAndRegisterNamedAlways_StatError(t *testing.T) {
-	name := types.AgentName("disc-named-stat-error")
-	binPath := filepath.Join(t.TempDir(), binaryPrefix+string(name))
-	wantErr := errors.New("stat failed")
-
-	originalLookPath := lookPathExternalAgent
-	originalStat := statExternalAgent
-	t.Cleanup(func() {
-		lookPathExternalAgent = originalLookPath
-		statExternalAgent = originalStat
-	})
-	lookPathExternalAgent = func(string) (string, error) { return binPath, nil }
-	statExternalAgent = func(string) (os.FileInfo, error) { return nil, wantErr }
-
-	err := DiscoverAndRegisterNamedAlways(context.Background(), name)
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want stat error", err)
+// TestDiscoverAndRegisterNamedAlways_RegistersBatOnWindows covers the explicit
+// named-discovery path, which uses exec.LookPath and therefore depends on
+// Windows PATHEXT handling rather than the scan-all filepath.Glob path above.
+func TestDiscoverAndRegisterNamedAlways_RegistersBatOnWindows(t *testing.T) {
+	if runtime.GOOS != osWindows {
+		t.Skip("this test only applies on Windows")
 	}
-	if !strings.Contains(err.Error(), string(name)) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want agent name %q", err, name)
+	setupDiscoveryTest(t)
+
+	name := types.AgentName("disc-named-bat")
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, binaryPrefix+string(name)+".bat")
+	if err := os.WriteFile(binPath, []byte(windowsInfoBat(string(name))), 0o755); err != nil {
+		t.Fatalf("write mock binary: %v", err)
 	}
-}
+	t.Setenv("PATH", dir)
+	t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
 
-func TestDiscoverAndRegisterNamedAlways_LookPathError(t *testing.T) {
-	name := types.AgentName("disc-named-lookpath-error")
-	wantErr := errors.New("lookup failed")
-
-	originalLookPath := lookPathExternalAgent
-	t.Cleanup(func() { lookPathExternalAgent = originalLookPath })
-	lookPathExternalAgent = func(string) (string, error) { return "", wantErr }
-
-	err := DiscoverAndRegisterNamedAlways(context.Background(), name)
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want lookup error", err)
+	if err := DiscoverAndRegisterNamedAlways(context.Background(), name); err != nil {
+		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), string(name)) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want agent name %q", err, name)
+	ag, err := agent.Get(name)
+	if err != nil {
+		t.Fatalf("expected named .bat agent %q to be registered: %v", name, err)
+	}
+	if ag.Name() != name {
+		t.Fatalf("agent Name() = %q, want %q", ag.Name(), name)
 	}
 }
 
-func TestDiscoverAndRegister_ContinuesAfterRegistrationError(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
-	badName := "disc-scan-a-invalid"
-	badDir := setupDiscoveryDir(t, badName, "not json")
-	goodName := "disc-scan-z-valid"
-	goodDir := setupDiscoveryDir(t, goodName, makeInfoJSON(goodName))
-	t.Setenv("PATH", badDir+string(os.PathListSeparator)+goodDir)
-
-	DiscoverAndRegisterAlways(context.Background())
-
-	if _, err := agent.Get(types.AgentName(badName)); err == nil {
-		t.Fatalf("invalid external agent %q was registered", badName)
-	}
-	if _, err := agent.Get(types.AgentName(goodName)); err != nil {
-		t.Fatalf("valid external agent %q was not registered after earlier failure: %v", goodName, err)
-	}
+func windowsInfoBat(name string) string {
+	infoJSON := `{"protocol_version":1,"name":"` + name + `","type":"` + name + ` Agent","description":"Agent ` + name + `","is_preview":false,"protected_dirs":[],"hook_names":[],"capabilities":{}}`
+	return "@echo off\r\nif not \"%1\"==\"info\" goto :notinfo\r\necho " + infoJSON +
+		"\r\ngoto :eof\r\n:notinfo\r\necho unknown subcommand: %1 1>&2\r\nexit /b 1\r\n"
 }
+
+// --- IsExternal ---
 
 func TestIsExternal_WrappedAgent(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
+	requireSh(t)
+	setupDiscoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-isext"
-	dir := setupDiscoveryDir(t, name, makeInfoJSON(name))
-	t.Setenv("PATH", dir)
+	t.Setenv("PATH", setupDiscoveryDir(t, name, makeInfoJSON(name)))
 
 	DiscoverAndRegister(context.Background())
 
@@ -521,7 +869,6 @@ func TestIsExternal_WrappedAgent(t *testing.T) {
 }
 
 func TestIsExternal_BuiltInAgent(t *testing.T) {
-	// Register a non-external (built-in) agent.
 	name := "disc-builtin"
 	builtIn := &fakeBuiltInAgent{name: types.AgentName(name)}
 	agent.Register(types.AgentName(name), func() agent.Agent {
@@ -561,147 +908,3 @@ func (f *fakeBuiltInAgent) ReadSession(*agent.HookInput) (*agent.AgentSession, e
 }
 func (f *fakeBuiltInAgent) WriteSession(context.Context, *agent.AgentSession) error { return nil }
 func (f *fakeBuiltInAgent) FormatResumeCommand(string) string                       { return "" }
-
-func TestDiscoverAndRegister_SkipsInfoFailure(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
-	enableExternalAgents(t)
-
-	name := "disc-badjson"
-	dir := t.TempDir()
-	binPath := filepath.Join(dir, binaryPrefix+name)
-
-	// Binary that outputs invalid JSON for "info".
-	script := "#!/bin/sh\necho 'not json'\n"
-	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write mock binary: %v", err)
-	}
-	t.Setenv("PATH", dir)
-
-	DiscoverAndRegister(context.Background())
-
-	_, err := agent.Get(types.AgentName(name))
-	if err == nil {
-		t.Error("expected agent with bad info to be skipped, but it was registered")
-	}
-}
-
-// TestDiscoverAndRegister_RegistersBatOnWindows verifies that a .bat agent
-// binary is discovered and registered on Windows, with the file extension
-// stripped from the agent name. .cmd and .exe follow the same code path.
-func TestDiscoverAndRegister_RegistersBatOnWindows(t *testing.T) {
-	if runtime.GOOS != osWindows {
-		t.Skip("this test only applies on Windows")
-	}
-
-	enableExternalAgents(t)
-
-	name := "disc-bat"
-	infoJSON := `{"protocol_version":1,"name":"` + name + `","type":"` + name + ` Agent","description":"Agent ` + name + `","is_preview":false,"protected_dirs":[],"hook_names":[],"capabilities":{}}`
-	script := "@echo off\r\nif not \"%1\"==\"info\" goto :notinfo\r\necho " + infoJSON + "\r\ngoto :eof\r\n:notinfo\r\necho unknown subcommand: %1 1>&2\r\nexit /b 1\r\n"
-
-	dir := t.TempDir()
-	binPath := filepath.Join(dir, binaryPrefix+name+".bat")
-	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write mock binary: %v", err)
-	}
-	t.Setenv("PATH", dir)
-
-	DiscoverAndRegister(context.Background())
-
-	ag, err := agent.Get(types.AgentName(name))
-	if err != nil {
-		t.Fatalf("expected agent %q to be registered after stripping .bat, got error: %v", name, err)
-	}
-	if string(ag.Name()) != name {
-		t.Errorf("agent Name() = %q, want %q", ag.Name(), name)
-	}
-}
-
-// TestDiscoverAndRegisterNamedAlways_RegistersBatOnWindows covers the explicit
-// named-discovery path, which uses exec.LookPath and therefore depends on
-// Windows PATHEXT handling rather than the scan-all filepath.Glob path above.
-func TestDiscoverAndRegisterNamedAlways_RegistersBatOnWindows(t *testing.T) {
-	if runtime.GOOS != osWindows {
-		t.Skip("this test only applies on Windows")
-	}
-
-	name := types.AgentName("disc-named-bat")
-	infoJSON := `{"protocol_version":1,"name":"` + string(name) + `","type":"` + string(name) + ` Agent","description":"Named Windows agent","is_preview":false,"protected_dirs":[],"hook_names":[],"capabilities":{}}`
-	script := "@echo off\r\nif not \"%1\"==\"info\" goto :notinfo\r\necho " + infoJSON + "\r\ngoto :eof\r\n:notinfo\r\necho unknown subcommand: %1 1>&2\r\nexit /b 1\r\n"
-
-	dir := t.TempDir()
-	binPath := filepath.Join(dir, binaryPrefix+string(name)+".bat")
-	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write mock binary: %v", err)
-	}
-	t.Setenv("PATH", dir)
-	t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
-
-	if err := DiscoverAndRegisterNamedAlways(context.Background(), name); err != nil {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v", err)
-	}
-	ag, err := agent.Get(name)
-	if err != nil {
-		t.Fatalf("expected named .bat agent %q to be registered: %v", name, err)
-	}
-	if ag.Name() != name {
-		t.Fatalf("agent Name() = %q, want %q", ag.Name(), name)
-	}
-}
-
-// stalledPropagationCtx is a context whose cancellation is immediately visible via
-// Done and Err, but whose propagation to derived contexts is not awaited. Because it
-// is not a standard context, context.WithTimeout watches it from a goroutine, so a
-// derived context still reports no error for a moment after this one is cancelled.
-//
-// That window is real, not contrived: even for standard contexts, cancel() closes its
-// own Done channel before cancelling children, so a goroutine woken by the parent can
-// run before the child observes anything. This type just makes the window wide enough
-// to assert on deterministically instead of relying on scheduler luck.
-type stalledPropagationCtx struct {
-	done chan struct{}
-}
-
-func (*stalledPropagationCtx) Deadline() (time.Time, bool) { return time.Time{}, false }
-func (c *stalledPropagationCtx) Done() <-chan struct{}     { return c.done }
-func (*stalledPropagationCtx) Value(any) any               { return nil }
-func (c *stalledPropagationCtx) Err() error {
-	select {
-	case <-c.done:
-		return context.DeadlineExceeded
-	default:
-		return nil
-	}
-}
-
-// TestDiscoverAndRegisterNamedAlways_ReportsCallerDeadlineExpiredDuringLookup pins the
-// contract that a caller whose context expires while the helper binary is being looked
-// up gets its context error back — not a nil "no such agent" result.
-//
-// Before the fix this returned nil: the caller's context was shadowed by the derived
-// timeout context, so the post-lookup check consulted only the derived one, which had
-// not yet observed the caller's cancellation. That is the same defect that made
-// TestDiscoverAndRegisterNamedAlways_DeadlineWhileLookingUpMissingHelper flaky under
-// load, where the window had to be hit by chance.
-func TestDiscoverAndRegisterNamedAlways_ReportsCallerDeadlineExpiredDuringLookup(t *testing.T) {
-	name := types.AgentName("disc-named-caller-deadline")
-	caller := &stalledPropagationCtx{done: make(chan struct{})}
-
-	originalLookPath := lookPathExternalAgent
-	t.Cleanup(func() { lookPathExternalAgent = originalLookPath })
-	lookPathExternalAgent = func(string) (string, error) {
-		// Expire the caller mid-lookup and return straight away, before the derived
-		// context's watcher goroutine can observe it. ErrNotFound is the benign
-		// "no such helper" result the deadline must take precedence over.
-		close(caller.done)
-		return "", exec.ErrNotFound
-	}
-
-	err := DiscoverAndRegisterNamedAlways(caller, name)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want context deadline exceeded", err)
-	}
-}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1149
<!-- entire-trail-link-end -->

Stacked on #2134 (`refactor-discover-and-register-external-agents`). Implements the plan in `docs/external-agents/pi-version.md`, which that PR adds. **Review after it merges** — the diff here is only the two discovery files.

## The problem

`discoverAndRegister` — shared by `DiscoverAndRegister` and `DiscoverAndRegisterAlways` — executed every `entire-agent-*` binary on `$PATH` **serially** under one shared 10s budget, checking for cancellation only *between* binaries. So one slow plugin consumed the whole budget and every binary after it was dropped, reported as a timeout it had no part in.

Every failure was `logging.Debug`'d and then discarded, so a plugin that is installed but unloadable looked exactly like one that was never installed. The forgot-`chmod +x` case failed completely silently.

Both matter because `...Always` runs on interactive, user-waiting paths, up to three times per process (`setup.go:891`, `:402`, `:496` — independently reachable entry points).

## What changed

A cheap `$PATH` scan collects candidates; one goroutine per candidate runs `info` under its own budget. A scan costs ~one budget instead of N, and a stalled plugin can't hide the ones behind it. Results are applied in `$PATH` order, so registration stays deterministic despite concurrent loading.

Outcomes go into two registries. Ready agents still land in the `agent` registry, which must keep meaning "agents you can actually use" — so broken binaries are held separately with their reason, reachable via `external.Get`, `ReadyAgents()`, `BrokenAgents()`. That is the groundwork for listing external agent state.

Errors are classified. `exec` reports a context-killed child only as `signal: killed`, so `ErrInfoTimeout` and `ErrNotExecutable` exist to let callers tell "too slow" and "forgot chmod" from a genuine protocol failure without matching on strings.

`DiscoverAndRegisterNamedAlways` shares the same load path and budget, and still returns `nil` for a binary that isn't installed — its `--summarize-provider` caller relies on that to fall through.

## Two decisions worth reviewing

**A registered agent still wins a name collision, and the shadowing binary is still never executed.** Overriding was considered and rejected: `agent.Register` overwrites process-wide and the gated scan runs inside `hooks_cmd.go` / `hooks_git_cmd.go`, so dropping `entire-agent-claude-code` into any writable `$PATH` directory would take over the agent that reads transcripts and writes checkpoints, on every hook. The same mechanism shadows `vogon` and would break the e2e canary in a way that looks like a CLI bug. The collision is now logged at `Warn` instead of vanishing, which fixes the original invisibility complaint without the takeover.

**The budget stays at 10s** — the same total the serial scan already allowed for a whole scan. Worst-case wait is therefore unchanged, while the typical case collapses from N budgets to one. The original spec asked for 300ms; that was measured and rejected:

| Case | Time |
| --- | --- |
| First exec of a freshly written binary | 320–394ms |
| Each further newly written binary | 140–170ms |
| Re-exec once warm | 7–12ms |

A newly installed binary pays code signing and cold page-in on first use, and at 5s a cold exec on a machine running the full parallel `-race` suite was *still* killed mid-flight. Undersizing this turns "the user just installed a plugin" into a broken-agent entry that then fixes itself on the next run — the worst kind of intermittent. It is a `var`, so it stays easy to tune.

## Testing

Tests no longer race the production budget: they raise it when a binary must load, and lower it when one must time out, so no assertion depends on machine load. That was found the hard way — the happy-path tests passed standalone and failed under a saturated `test:ci`.

New coverage: concurrency (four stalled binaries must not stop a fast one, asserted against the serial floor), timeout and non-executable classification, `Get` across ready/broken/unknown, a cancelled caller recording candidates without executing them, and idempotency across repeated calls (marker-file exec counts).

Deleted the mocked `os.Stat`/`exec.LookPath` failure tests and the hand-rolled `stalledPropagationCtx`, which existed to prove a context-shadowing bug this structure removes by construction.

`mise run check` passes: fmt, lint (0 issues), and `test:ci` including both e2e canaries — `roger-roger` is itself a real external agent binary, so it exercises this path end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how external agents are discovered and registered on hook/setup paths, including anti-hijack rules for name collisions; misbehavior could affect which agent handles transcripts/checkpoints, though built-ins are protected from PATH override.
> 
> **Overview**
> External agent discovery no longer walks `$PATH` serially under one shared timeout. It **globs candidates first**, runs each binary’s `info` **in parallel** with a **per-plugin** `infoTimeout` (still 10s), and applies results in **`$PATH` order** so registration stays deterministic.
> 
> **Failures are retained instead of debug-only skips.** Ready plugins still register in `agent`; unloadable binaries go into a separate **broken** registry with `BrokenAgent` + `Get`, `ReadyAgents()`, and `BrokenAgents()`. Typed errors **`ErrInfoTimeout`** and **`ErrNotExecutable`** distinguish slow kills from missing chmod. Non-executable plugins and bad `info` output are recorded; missing binaries on named discovery still return **nil**.
> 
> **Safety and repeat calls:** an external binary **cannot override** an already-registered agent (shadow binary is not executed; collision is **`Warn`**). Repeated discovery **skips re-exec** for names already judged ready/broken. A cancelled caller records candidates as broken with cancellation and does not run plugins.
> 
> Tests were expanded for concurrency, timeouts, idempotency, and CI-stable budgets via tunable `infoTimeout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a10a19515a9895d3b57d49ecd56419ed665542ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->