### PR TITLE
refactor(external): probe agent binaries in parallel and record failures

### DIFF
--- a/cmd/entire/cli/agent/external/discovery.go
+++ b/cmd/entire/cli/agent/external/discovery.go
@@ -23,18 +23,51 @@ const (
 	osWindows    = "windows"
 )
 
-// discoveryTimeout caps the total time spent scanning $PATH for external agents.
-const discoveryTimeout = 10 * time.Second
+// infoTimeout bounds a single `info` call. Every candidate binary gets its own
+// budget and they all run concurrently, so a scan costs roughly one budget
+// rather than one per binary.
+//
+// A var, not a const, for two reasons: the value is provisional and expected to
+// be retuned, and tests need to raise it. A binary written into a fresh
+// t.TempDir() is always a cold exec — on macOS the first run of a freshly
+// written file pays code-signing validation and cold page-in, measured at
+// 320-394ms, well past this budget. A test that execs a mock must raise this
+// rather than loosen its assertions.
+var infoTimeout = 300 * time.Millisecond //nolint:gochecknoglobals // provisional budget, raised by tests
 
+// Errors that classify why a discovered binary is unusable. exec reports only
+// "signal: killed" when a context kills the child, so without these a budget
+// that is too tight is indistinguishable from a plugin that is actually broken.
 var (
-	statExternalAgent     = os.Stat       //nolint:gochecknoglobals // narrow test seam for stat failures
-	lookPathExternalAgent = exec.LookPath //nolint:gochecknoglobals // narrow test seam for lookup failures
+	// ErrInfoTimeout means the binary did not answer `info` within infoTimeout.
+	ErrInfoTimeout = errors.New("external agent info call timed out")
+	// ErrNotExecutable means a matching regular file has no executable bit (Unix).
+	ErrNotExecutable = errors.New("external agent binary is not executable")
 )
+
+//nolint:gochecknoglobals // narrow test seam for lookup failures
+var lookPathExternalAgent = exec.LookPath
+
+// candidate is a binary that looks like an external agent and has not been
+// ruled out without executing it.
+type candidate struct {
+	name types.AgentName
+	path string
+}
+
+// probeResult pairs a candidate with the outcome of asking it for `info`.
+type probeResult struct {
+	candidate
+
+	ag  agent.Agent
+	err error
+}
 
 // DiscoverAndRegister scans $PATH for executables matching "entire-agent-<name>",
 // calls their "info" subcommand, and registers them in the agent registry.
-// Binaries whose name conflicts with an already-registered agent are skipped.
-// Errors during discovery are logged but do not prevent other agents from loading.
+// Binaries that cannot be loaded are registered as failures so `entire agent
+// list` can explain them. Binaries whose name conflicts with an already-registered
+// agent are skipped without being executed.
 // Discovery is skipped when the external_agents setting is not enabled.
 func DiscoverAndRegister(ctx context.Context) {
 	if !settings.IsExternalAgentsEnabled(ctx) {
@@ -55,39 +88,224 @@ func DiscoverAndRegisterAlways(ctx context.Context) {
 // agent binary matching name. It bypasses the external_agents setting for
 // explicit, one-invocation selections without executing unrelated plugins.
 func DiscoverAndRegisterNamedAlways(ctx context.Context, name types.AgentName) error {
-	return discoverAndRegisterNamed(ctx, name, discoveryTimeout)
+	return discoverAndRegisterNamed(ctx, name)
 }
 
-// discoveryCanceled reports whether either the caller's context or the derived
-// discovery-timeout context has been cancelled.
+// discoverAndRegister runs the three discovery phases: collect candidates from
+// $PATH (filesystem only), probe them all concurrently, then register the
+// results in collect order.
+func discoverAndRegister(ctx context.Context) {
+	pathEnv := os.Getenv("PATH")
+	if pathEnv == "" {
+		return
+	}
+
+	candidates := collectCandidates(ctx, pathEnv)
+	if len(candidates) == 0 {
+		return
+	}
+
+	// A caller whose context is already done is not evidence that a plugin is
+	// broken, but the found-on-$PATH set should still be visible rather than
+	// silently dropped. Record it and execute nothing.
+	if err := ctx.Err(); err != nil {
+		for _, c := range candidates {
+			agent.RegisterExternalFailure(c.name, c.path,
+				fmt.Errorf("discovering external agent %q from binary %q: %w", c.name, c.path, err))
+		}
+		logging.Debug(ctx, "skipped probing external agents (caller context done)",
+			slog.Int("candidates", len(candidates)),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	for _, result := range probeCandidates(ctx, candidates) {
+		applyProbeResult(ctx, result)
+	}
+}
+
+// collectCandidates walks $PATH and returns the binaries worth executing, in
+// $PATH order. It executes nothing; binaries ruled out here (a directory, no
+// exec bit, an unreadable file) are registered as failures on the spot.
+func collectCandidates(ctx context.Context, pathEnv string) []candidate {
+	usable := make(map[types.AgentName]bool)
+	for _, name := range agent.List() {
+		usable[name] = true
+	}
+	probed := agent.ProbedExternalBinaries()
+
+	seen := make(map[types.AgentName]bool) // first $PATH dir wins, as $PATH itself does
+	var candidates []candidate
+
+	for _, dir := range filepath.SplitList(pathEnv) {
+		matches, err := filepath.Glob(filepath.Join(dir, binaryPrefix+"*"))
+		if err != nil {
+			continue // skip unreadable directories
+		}
+		for _, binPath := range matches {
+			// Dedupe on the derived agent name, not the file name: on Windows
+			// entire-agent-foo.exe and entire-agent-foo.com both derive agent
+			// "foo", and PATHEXT decides which one actually runs.
+			name := derivedAgentName(binPath)
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+
+			// Already probed this exact binary in this process, ready or failed.
+			if _, ok := probed[binPath]; ok {
+				continue
+			}
+
+			if usable[name] {
+				// A built-in always wins, and the colliding binary is never
+				// executed. The gated DiscoverAndRegister runs inside the hook
+				// trees, so an override would let a binary dropped anywhere on
+				// $PATH take over transcript reads and checkpoint writes on
+				// every hook. Warn (not Debug) so the attempt is visible.
+				logging.Warn(ctx, "ignoring external agent that shadows an existing agent",
+					slog.String("binary", binPath),
+					slog.String("agent", string(name)))
+				continue
+			}
+
+			ok, err := inspectBinary(name, binPath)
+			if err != nil {
+				agent.RegisterExternalFailure(name, binPath, err)
+				continue
+			}
+			if !ok {
+				continue
+			}
+			candidates = append(candidates, candidate{name: name, path: binPath})
+		}
+	}
+	return candidates
+}
+
+// derivedAgentName maps a binary path to the registry name it would claim.
+func derivedAgentName(binPath string) types.AgentName {
+	base := StripExeExt(filepath.Base(binPath))
+	return types.AgentName(strings.TrimPrefix(base, binaryPrefix))
+}
+
+// inspectBinary reports whether binPath is worth executing. It returns
+// (false, nil) when the path has gone away — a binary that vanished between the
+// glob and the stat is not a broken plugin — and (false, err) when the file is
+// there but cannot be an agent.
+func inspectBinary(name types.AgentName, binPath string) (bool, error) {
+	// G703: binPath comes from a $PATH glob or exec.LookPath, both of which are
+	// process inputs we already trust to name executables.
+	finfo, err := os.Stat(binPath) //nolint:gosec // path is a $PATH-resolved binary, not user input
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspecting external agent %q binary %q: %w", name, binPath, err)
+	}
+	if finfo.IsDir() {
+		return false, fmt.Errorf("external agent %q path %q is a directory, not an executable", name, binPath)
+	}
+	// Windows does not set execute bits.
+	if runtime.GOOS != osWindows && finfo.Mode()&0o111 == 0 {
+		return false, fmt.Errorf("external agent %q binary %q: %w", name, binPath, ErrNotExecutable)
+	}
+	return true, nil
+}
+
+// probeCandidates asks every candidate for its `info` concurrently and returns
+// the results in candidate order, so registration stays deterministic even
+// though completion order is not.
 //
-// Both must be consulted. A context closes its own Done channel *before* cancelling
-// its children, so a goroutine that has just observed the caller's cancellation can
-// run while the derived context still reports no error — and when the caller is not a
-// standard context, propagation happens in a watcher goroutine, widening the window
-// further. Checking only the derived context therefore lets a caller whose deadline
-// expired mid-operation look like it is still live.
-func discoveryCanceled(caller, derived context.Context) bool {
-	return caller.Err() != nil || derived.Err() != nil
+// No worker pool: the realistic candidate count is a handful, and a cap would
+// serialize exactly the case this concurrency exists for.
+func probeCandidates(ctx context.Context, candidates []candidate) []probeResult {
+	results := make(chan probeResult, len(candidates))
+	for _, c := range candidates {
+		go func() {
+			ag, err := loadExternalAgent(ctx, c)
+			results <- probeResult{candidate: c, ag: ag, err: err}
+		}()
+	}
+
+	byPath := make(map[string]probeResult, len(candidates))
+	for range candidates {
+		r := <-results
+		byPath[r.path] = r
+	}
+
+	ordered := make([]probeResult, 0, len(candidates))
+	for _, c := range candidates {
+		ordered = append(ordered, byPath[c.path])
+	}
+	return ordered
 }
 
-// discoveryCtxErr wraps whichever of the two contexts has been cancelled, preferring
-// the caller's, and returns nil when neither has. op names the stage for the message.
-// See discoveryCanceled for why the caller's context must be consulted too: missing it
-// lets a caller whose deadline expired mid-lookup receive a nil error and a silently
-// skipped agent instead of its context error.
-func discoveryCtxErr(caller, derived context.Context, op string) error {
-	err := caller.Err()
-	if err == nil {
-		err = derived.Err()
+// loadExternalAgent runs `info` on one binary under its own budget and wraps
+// the result. It never touches the registry, so it is safe to run concurrently.
+func loadExternalAgent(ctx context.Context, c candidate) (agent.Agent, error) {
+	// Derived from the caller, so a tighter caller deadline still wins.
+	probeCtx, cancel := context.WithTimeout(ctx, infoTimeout)
+	defer cancel()
+
+	ea, err := New(probeCtx, c.path)
+	if err != nil {
+		return nil, classifyLoadError(ctx, probeCtx, c, err)
 	}
-	if err == nil {
-		return nil
+	wrapped, err := Wrap(ea)
+	if err != nil {
+		return nil, fmt.Errorf("wrapping external agent %q from binary %q: %w", c.name, c.path, err)
 	}
-	return fmt.Errorf("%s: %w", op, err)
+	return wrapped, nil
 }
 
-func discoverAndRegisterNamed(ctx context.Context, name types.AgentName, timeout time.Duration) error {
+// classifyLoadError labels a failed `info` call so the caller can tell a budget
+// breach from a genuinely broken plugin.
+func classifyLoadError(caller, probe context.Context, c candidate, err error) error {
+	wrapped := fmt.Errorf("loading info for external agent %q from binary %q: %w", c.name, c.path, err)
+	if callerErr := caller.Err(); callerErr != nil {
+		return fmt.Errorf("%w: %w", callerErr, wrapped)
+	}
+	if probeErr := probe.Err(); probeErr != nil {
+		return fmt.Errorf("%w after %s (%w): %w", ErrInfoTimeout, infoTimeout, probeErr, wrapped)
+	}
+	return wrapped
+}
+
+// applyProbeResult records one probe outcome in the registry. Called only from
+// the goroutine that owns discovery, so registration order is deterministic.
+func applyProbeResult(ctx context.Context, r probeResult) {
+	if r.err != nil {
+		agent.RegisterExternalFailure(r.name, r.path, r.err)
+		logging.Debug(ctx, "external agent found but not loadable",
+			slog.String("binary", r.path),
+			slog.String("agent", string(r.name)),
+			slog.String("error", r.err.Error()))
+		return
+	}
+
+	agent.RegisterExternal(r.name, r.path, func() agent.Agent { return r.ag })
+
+	// The registry key comes from the file name, and every caller resolves
+	// agents by that key, so a binary reporting a different name still works.
+	// Say so rather than leaving the inconsistency to surface in logs later.
+	if declared := r.ag.Name(); declared != r.name {
+		logging.Warn(ctx, "external agent reports a name that differs from its binary",
+			slog.String("binary", r.path),
+			slog.String("registered", string(r.name)),
+			slog.String("declared", string(declared)))
+	}
+
+	logging.Debug(ctx, "registered external agent",
+		slog.String("name", string(r.name)),
+		slog.String("type", string(r.ag.Type())),
+		slog.String("binary", r.path))
+}
+
+// discoverAndRegisterNamed resolves one named binary through $PATH instead of
+// globbing. Unlike the scan, it surfaces the failure to its caller as well as
+// recording it, because the caller named this agent explicitly.
+func discoverAndRegisterNamed(ctx context.Context, name types.AgentName) error {
 	if name == "" {
 		return nil
 	}
@@ -97,140 +315,38 @@ func discoverAndRegisterNamed(ctx context.Context, name types.AgentName, timeout
 	if _, err := agent.Get(name); err == nil {
 		return nil
 	}
-
-	// `ctx` deliberately stays the CALLER's context; the derived timeout gets its own
-	// name. Shadowing `ctx` with the derived context is what caused the bug this
-	// function is guarding against, and it left the trap in place for the next edit.
-	discoveryCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	if err := discoveryCtxErr(ctx, discoveryCtx, fmt.Sprintf("discovering external agent %q", name)); err != nil {
-		return err
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("discovering external agent %q: %w", name, err)
 	}
 
 	binName := binaryPrefix + string(name)
 	binPath, err := lookPathExternalAgent(binName)
-	if ctxErr := discoveryCtxErr(ctx, discoveryCtx, fmt.Sprintf("looking up external agent %q binary %q", name, binName)); ctxErr != nil {
-		return ctxErr
-	}
 	if err != nil {
+		// A missing binary means "no such plugin, fall through to other
+		// resolution" — not a broken agent. Callers depend on the nil.
 		if errors.Is(err, exec.ErrNotFound) {
 			return nil
 		}
 		return fmt.Errorf("looking up external agent %q binary %q: %w", name, binName, err)
 	}
-	registered, err := registerExternalAgent(discoveryCtx, binPath, name)
+
+	c := candidate{name: name, path: binPath}
+	ok, err := inspectBinary(name, binPath)
 	if err != nil {
+		agent.RegisterExternalFailure(name, binPath, err)
 		return err
 	}
-	if !registered {
-		return fmt.Errorf("external agent %q binary %q was found but could not be registered", name, binPath)
+	if !ok {
+		return nil
 	}
+
+	ag, err := loadExternalAgent(ctx, c)
+	if err != nil {
+		agent.RegisterExternalFailure(name, binPath, err)
+		return err
+	}
+	applyProbeResult(ctx, probeResult{candidate: c, ag: ag})
 	return nil
-}
-
-// discoverAndRegister contains the shared scanning logic for external agent discovery.
-func discoverAndRegister(ctx context.Context) {
-	// As above: `ctx` remains the caller's, the derived timeout is named.
-	discoveryCtx, cancel := context.WithTimeout(ctx, discoveryTimeout)
-	defer cancel()
-
-	pathEnv := os.Getenv("PATH")
-	if pathEnv == "" {
-		return
-	}
-
-	// Collect already-registered names to avoid conflicts.
-	registered := make(map[types.AgentName]bool)
-	for _, name := range agent.List() {
-		registered[name] = true
-	}
-
-	seen := make(map[string]bool) // deduplicate binaries across PATH dirs
-	for _, dir := range filepath.SplitList(pathEnv) {
-		if discoveryCanceled(ctx, discoveryCtx) {
-			logging.Debug(ctx, "external agent discovery timed out")
-			return
-		}
-
-		matches, err := filepath.Glob(filepath.Join(dir, binaryPrefix+"*"))
-		if err != nil {
-			continue // skip unreadable directories
-		}
-		for _, binPath := range matches {
-			if discoveryCanceled(ctx, discoveryCtx) {
-				logging.Debug(ctx, "external agent discovery timed out")
-				return
-			}
-
-			name := filepath.Base(binPath)
-			if seen[name] {
-				continue
-			}
-			seen[name] = true
-
-			// Strip Windows executable extensions (.exe, .bat) before deriving agent name.
-			// On Unix, binaries have no extension, so this is a no-op.
-			cleanName := StripExeExt(name)
-			agentName := types.AgentName(strings.TrimPrefix(cleanName, binaryPrefix))
-			if registered[agentName] {
-				logging.Debug(ctx, "skipping external agent (name conflict with built-in)",
-					slog.String("binary", name),
-					slog.String("agent", string(agentName)))
-				continue
-			}
-
-			registeredAgent, err := registerExternalAgent(discoveryCtx, binPath, agentName)
-			if err != nil {
-				logging.Debug(ctx, "skipping external agent (registration failed)",
-					slog.String("binary", binPath),
-					slog.String("agent", string(agentName)),
-					slog.String("error", err.Error()))
-				continue
-			}
-			if registeredAgent {
-				registered[agentName] = true
-			}
-		}
-	}
-}
-
-func registerExternalAgent(ctx context.Context, binPath string, name types.AgentName) (bool, error) {
-	finfo, err := statExternalAgent(binPath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
-		}
-		return false, fmt.Errorf("inspecting external agent %q binary %q: %w", name, binPath, err)
-	}
-	if finfo.IsDir() {
-		return false, nil
-	}
-	// Check executable bit (on Unix; Windows doesn't set execute bits).
-	if runtime.GOOS != osWindows && finfo.Mode()&0o111 == 0 {
-		return false, nil
-	}
-
-	ea, err := New(ctx, binPath)
-	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return false, fmt.Errorf("loading info for external agent %q from binary %q: %w: %w", name, binPath, ctxErr, err)
-		}
-		return false, fmt.Errorf("loading info for external agent %q from binary %q: %w", name, binPath, err)
-	}
-
-	wrapped, err := Wrap(ea)
-	if err != nil {
-		return false, fmt.Errorf("wrapping external agent %q from binary %q: %w", name, binPath, err)
-	}
-	agent.Register(name, func() agent.Agent {
-		return wrapped
-	})
-
-	logging.Debug(ctx, "registered external agent",
-		slog.String("name", string(name)),
-		slog.String("type", string(ea.Type())),
-		slog.String("binary", binPath))
-	return true, nil
 }
 
 // StripExeExt removes Windows executable extensions (.exe, .bat, .cmd, .com)

--- a/cmd/entire/cli/agent/external/discovery.go
+++ b/cmd/entire/cli/agent/external/discovery.go
@@ -27,13 +27,11 @@ const (
 // budget and they all run concurrently, so a scan costs roughly one budget
 // rather than one per binary.
 //
-// A var, not a const, for two reasons: the value is provisional and expected to
-// be retuned, and tests need to raise it. A binary written into a fresh
-// t.TempDir() is always a cold exec — on macOS the first run of a freshly
-// written file pays code-signing validation and cold page-in, measured at
-// 320-394ms, well past this budget. A test that execs a mock must raise this
-// rather than loosen its assertions.
-var infoTimeout = 300 * time.Millisecond //nolint:gochecknoglobals // provisional budget, raised by tests
+// Ten seconds covers cold starts even on a saturated machine. This matches the
+// old aggregate scan budget, but each binary gets the budget concurrently, so
+// several stalled plugins still cost roughly ten seconds rather than N times
+// ten seconds. A var keeps timeout-path tests fast and deterministic.
+var infoTimeout = 10 * time.Second //nolint:gochecknoglobals // policy knob overridden by timeout tests
 
 // Errors that classify why a discovered binary is unusable. exec reports only
 // "signal: killed" when a context kills the child, so without these a budget
@@ -134,7 +132,12 @@ func collectCandidates(ctx context.Context, pathEnv string) []candidate {
 	}
 	probed := agent.ProbedExternalBinaries()
 
-	seen := make(map[types.AgentName]bool) // first $PATH dir wins, as $PATH itself does
+	seen := make(map[types.AgentName]bool) // first runnable $PATH entry wins
+	type staticFailure struct {
+		path string
+		err  error
+	}
+	staticFailures := make(map[types.AgentName]staticFailure)
 	var candidates []candidate
 
 	for _, dir := range filepath.SplitList(pathEnv) {
@@ -150,14 +153,15 @@ func collectCandidates(ctx context.Context, pathEnv string) []candidate {
 			if name == "" || seen[name] {
 				continue
 			}
-			seen[name] = true
 
 			// Already probed this exact binary in this process, ready or failed.
 			if _, ok := probed[binPath]; ok {
+				seen[name] = true
 				continue
 			}
 
 			if usable[name] {
+				seen[name] = true
 				// A built-in always wins, and the colliding binary is never
 				// executed. The gated DiscoverAndRegister runs inside the hook
 				// trees, so an override would let a binary dropped anywhere on
@@ -171,13 +175,22 @@ func collectCandidates(ctx context.Context, pathEnv string) []candidate {
 
 			ok, err := inspectBinary(name, binPath)
 			if err != nil {
-				agent.RegisterExternalFailure(name, binPath, err)
+				if _, exists := staticFailures[name]; !exists {
+					staticFailures[name] = staticFailure{path: binPath, err: err}
+				}
 				continue
 			}
 			if !ok {
 				continue
 			}
+			seen[name] = true
+			delete(staticFailures, name)
 			candidates = append(candidates, candidate{name: name, path: binPath})
+		}
+	}
+	for name, failure := range staticFailures {
+		if !seen[name] {
+			agent.RegisterExternalFailure(name, failure.path, failure.err)
 		}
 	}
 	return candidates
@@ -328,6 +341,9 @@ func discoverAndRegisterNamed(ctx context.Context, name types.AgentName) error {
 			return nil
 		}
 		return fmt.Errorf("looking up external agent %q binary %q: %w", name, binName, err)
+	}
+	if failure, ok := agent.ExternalFailureFor(name); ok && failure.Binary == binPath {
+		return failure.Err
 	}
 
 	c := candidate{name: name, path: binPath}

--- a/cmd/entire/cli/agent/external/discovery_test.go
+++ b/cmd/entire/cli/agent/external/discovery_test.go
@@ -16,27 +16,69 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 )
 
+// NOTE: Tests in this file modify process-global state (os.Setenv, os.Chdir, agent registry)
+// and therefore cannot use t.Parallel().
+
+// discoveryTest isolates one discovery test.
+//
+// It clears external registry entries, because both the registry and the
+// probe memo built from it are process-wide: without this, results leak
+// between tests and the memo makes failures depend on test order.
+//
+// It also raises the info budget. A mock written into a fresh t.TempDir() is
+// always a cold exec — on macOS the first run of a freshly written file was
+// measured at 320-394ms, past the shipped 300ms — so a test that execs a mock
+// must raise the budget rather than loosen its assertions.
+func discoveryTest(t *testing.T) {
+	t.Helper()
+	agent.ResetExternalsForTesting()
+	t.Cleanup(agent.ResetExternalsForTesting)
+	setInfoTimeout(t, 5*time.Second)
+}
+
+func setInfoTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	original := infoTimeout
+	infoTimeout = d
+	t.Cleanup(func() { infoTimeout = original })
+}
+
+func requireSh(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+}
+
+// writeAgentBinary writes an executable entire-agent-<name> into dir with the
+// given shell body and returns its path.
+func writeAgentBinary(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	binPath := filepath.Join(dir, binaryPrefix+name)
+	if err := os.WriteFile(binPath, []byte(body), 0o755); err != nil {
+		t.Fatalf("write mock binary: %v", err)
+	}
+	return binPath
+}
+
 // setupDiscoveryDir creates a temp directory containing a mock entire-agent-<name> binary.
 // Returns the directory path.
 func setupDiscoveryDir(t *testing.T, agentName, infoJSON string) string {
 	t.Helper()
-
 	dir := t.TempDir()
-	binName := binaryPrefix + agentName
-	binPath := filepath.Join(dir, binName)
-
-	script := mockInfoScript(infoJSON)
-	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write mock binary: %v", err)
-	}
+	writeAgentBinary(t, dir, agentName, mockInfoScript(infoJSON))
 	return dir
 }
 
 func makeInfoJSON(name string) string {
+	return makeInfoJSONWithType(name, name+" Agent")
+}
+
+func makeInfoJSONWithType(name, agentType string) string {
 	return `{
   "protocol_version": 1,
   "name": "` + name + `",
-  "type": "` + name + ` Agent",
+  "type": "` + agentType + `",
   "description": "Agent ` + name + `",
   "is_preview": false,
   "protected_dirs": [],
@@ -45,12 +87,75 @@ func makeInfoJSON(name string) string {
 }`
 }
 
-// NOTE: Tests in this file modify process-global state (os.Setenv, os.Chdir, agent registry)
-// and therefore cannot use t.Parallel().
+// stalledScript returns a script body that never answers, so it always breaches
+// the info budget.
+func stalledScript(t *testing.T) string {
+	t.Helper()
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skip("sleep not available")
+	}
+	return fmt.Sprintf("#!/bin/sh\nexec %q 60\n", sleepPath)
+}
+
+// touchOnRunScript answers info correctly but also touches marker, so a test
+// can prove whether the binary was executed at all.
+func touchOnRunScript(name, marker string) string {
+	return "#!/bin/sh\n: > " + marker + "\n" +
+		"case \"$1\" in\n  info)\n    echo '" + makeInfoJSON(name) + "'\n    ;;\nesac\n"
+}
+
+// countOnRunScript appends a line to counter on every invocation, so a test can
+// count executions across repeated discovery calls. reply is the info output.
+func countOnRunScript(counter, reply string) string {
+	return "#!/bin/sh\necho x >> " + counter + "\n" +
+		"case \"$1\" in\n  info)\n    echo '" + reply + "'\n    ;;\nesac\n"
+}
+
+// warmUp executes a mock binary once so its cold-start cost is not charged to
+// the budget under test. A freshly written file pays code-signing validation
+// and page-in on its first run, and that cost grows sharply when several such
+// binaries start at once — measured here as a healthy mock breaching a 1s
+// budget while four neighbours were also starting cold.
+func warmUp(t *testing.T, binPath string) {
+	t.Helper()
+	if err := exec.CommandContext(context.Background(), binPath, "info").Run(); err != nil {
+		t.Fatalf("warm up %s: %v", binPath, err)
+	}
+}
+
+func runCount(t *testing.T, counter string) int {
+	t.Helper()
+	data, err := os.ReadFile(counter)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	return len(strings.Fields(string(data)))
+}
+
+// failureFor returns the recorded failure for name, failing the test if absent.
+func failureFor(t *testing.T, name string) agent.ExternalFailure {
+	t.Helper()
+	for _, f := range agent.ExternalFailures() {
+		if f.Name == types.AgentName(name) {
+			return f
+		}
+	}
+	t.Fatalf("agent %q was not recorded as a failure; failures = %v", name, agent.ExternalFailures())
+	return agent.ExternalFailure{}
+}
 
 // enableExternalAgents creates a temp repo with external_agents enabled in settings
 // and chdir's into it so that settings.Load can find the config.
 func enableExternalAgents(t *testing.T) {
+	t.Helper()
+	writeRepoSettings(t, `{"enabled":true,"external_agents":true}`)
+}
+
+func writeRepoSettings(t *testing.T, settingsJSON string) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
@@ -60,17 +165,15 @@ func enableExternalAgents(t *testing.T) {
 	if err := os.MkdirAll(entireDir, 0o755); err != nil {
 		t.Fatalf("create .entire: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"enabled":true,"external_agents":true}`), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644); err != nil {
 		t.Fatalf("write settings: %v", err)
 	}
 	t.Chdir(tmpDir)
 }
 
 func TestDiscoverAndRegister_FindsAgent(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
+	requireSh(t)
+	discoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-find"
@@ -89,10 +192,8 @@ func TestDiscoverAndRegister_FindsAgent(t *testing.T) {
 }
 
 func TestDiscoverAndRegister_Deduplication(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
+	requireSh(t)
+	discoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-dedup"
@@ -102,7 +203,6 @@ func TestDiscoverAndRegister_Deduplication(t *testing.T) {
 
 	DiscoverAndRegister(context.Background())
 
-	// Verify the agent is registered (just once — no panic or error from double registration).
 	ag, err := agent.Get(types.AgentName(name))
 	if err != nil {
 		t.Fatalf("expected agent %q to be registered: %v", name, err)
@@ -112,79 +212,208 @@ func TestDiscoverAndRegister_Deduplication(t *testing.T) {
 	}
 }
 
-func TestDiscoverAndRegister_SkipsNameConflict(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
+// TestDiscoverAndRegister_DedupesOnDerivedAgentName pins which binary wins when
+// two directories offer the same agent: the earlier $PATH entry, as $PATH itself
+// resolves. The two are told apart by the type they report.
+func TestDiscoverAndRegister_DedupesOnDerivedAgentName(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
+	enableExternalAgents(t)
 
+	name := "disc-dedup-order"
+	firstDir := t.TempDir()
+	secondDir := t.TempDir()
+	writeAgentBinary(t, firstDir, name, mockInfoScript(makeInfoJSONWithType(name, "First On Path")))
+	writeAgentBinary(t, secondDir, name, mockInfoScript(makeInfoJSONWithType(name, "Second On Path")))
+	t.Setenv("PATH", firstDir+string(os.PathListSeparator)+secondDir)
+
+	DiscoverAndRegister(context.Background())
+
+	ag, err := agent.Get(types.AgentName(name))
+	if err != nil {
+		t.Fatalf("expected agent %q to be registered: %v", name, err)
+	}
+	if got := string(ag.Type()); got != "First On Path" {
+		t.Errorf("agent Type() = %q, want the binary from the first PATH dir", got)
+	}
+}
+
+// TestDiscoverAndRegister_SkipsNameConflict covers the rule that a built-in
+// always wins: the colliding binary must not even be executed, because the
+// gated discovery path runs inside the git and agent hook trees.
+func TestDiscoverAndRegister_SkipsNameConflict(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-conflict"
-	// Pre-register an agent with the same name.
 	agent.Register(types.AgentName(name), func() agent.Agent {
 		return nil // placeholder
 	})
 
-	// Create an external binary with the conflicting name, using a different type.
-	conflictJSON := `{
-  "protocol_version": 1,
-  "name": "` + name + `",
-  "type": "Different Type",
-  "description": "Should be skipped",
-  "is_preview": false,
-  "protected_dirs": [],
-  "hook_names": [],
-  "capabilities": {}
-}`
-	dir := setupDiscoveryDir(t, name, conflictJSON)
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "was-executed")
+	writeAgentBinary(t, dir, name, touchOnRunScript(name, marker))
 	t.Setenv("PATH", dir)
 
 	DiscoverAndRegister(context.Background())
 
-	// The pre-registered placeholder should still be there (returns nil).
 	ag, err := agent.Get(types.AgentName(name))
 	if err != nil {
 		t.Fatalf("agent should still be registered: %v", err)
 	}
-	// The placeholder factory returns nil, so it wasn't replaced by the external one.
+	// The placeholder factory returns nil, so it wasn't replaced.
 	if ag != nil {
 		t.Errorf("expected placeholder (nil) agent, got %v", ag)
 	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("shadowing binary was executed; a colliding name must be skipped without running it")
+	}
+	if len(agent.ExternalFailures()) != 0 {
+		t.Errorf("a name collision is not a broken agent, got failures = %v", agent.ExternalFailures())
+	}
 }
 
-func TestDiscoverAndRegister_SkipsNonExecutable(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
+// TestDiscoverAndRegister_RecordsFailedAgent is the point of the refactor: a
+// binary that exists but cannot be loaded keeps its reason instead of
+// disappearing into a debug log, and does not stop a healthy binary loading.
+func TestDiscoverAndRegister_RecordsFailedAgent(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
+	enableExternalAgents(t)
+
+	badName := "disc-bad-json"
+	goodName := "disc-good-json"
+	dir := t.TempDir()
+	badPath := writeAgentBinary(t, dir, badName, "#!/bin/sh\necho 'not json'\n")
+	writeAgentBinary(t, dir, goodName, mockInfoScript(makeInfoJSON(goodName)))
+	t.Setenv("PATH", dir)
+
+	DiscoverAndRegister(context.Background())
+
+	if _, err := agent.Get(types.AgentName(goodName)); err != nil {
+		t.Fatalf("healthy agent %q was not registered alongside a broken one: %v", goodName, err)
+	}
+	for _, name := range agent.List() {
+		if name == types.AgentName(badName) {
+			t.Errorf("broken agent %q is listed as usable", badName)
+		}
 	}
 
+	failure := failureFor(t, badName)
+	if failure.Binary != badPath {
+		t.Errorf("failure.Binary = %q, want %q", failure.Binary, badPath)
+	}
+	if !strings.Contains(failure.Err.Error(), "invalid JSON") {
+		t.Errorf("failure.Err = %q, want the parse failure to be diagnostic", failure.Err)
+	}
+
+	// Resolving it by name explains the problem rather than claiming it is unknown.
+	_, err := agent.Get(types.AgentName(badName))
+	if err == nil || !strings.Contains(err.Error(), "invalid JSON") {
+		t.Errorf("agent.Get(%q) error = %v, want the recorded load failure", badName, err)
+	}
+}
+
+// TestDiscoverAndRegister_ParallelProbesDoNotSerialize is the regression this
+// refactor exists to prevent: before it, one stalled binary consumed the whole
+// discovery budget and every later binary was dropped.
+//
+// Four stalled binaries rather than one: with a single slow binary, serial and
+// concurrent execution differ by only one budget, which is not a gap that can
+// be asserted on reliably.
+func TestDiscoverAndRegister_ParallelProbesDoNotSerialize(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
+	enableExternalAgents(t)
+
+	const budget = time.Second
+	setInfoTimeout(t, budget)
+
+	dir := t.TempDir()
+	stalled := stalledScript(t)
+	stalledNames := []string{"disc-par-slow1", "disc-par-slow2", "disc-par-slow3", "disc-par-slow4"}
+	for _, name := range stalledNames {
+		writeAgentBinary(t, dir, name, stalled)
+	}
+	goodName := "disc-par-good"
+	goodPath := writeAgentBinary(t, dir, goodName, mockInfoScript(makeInfoJSON(goodName)))
+	warmUp(t, goodPath)
+	t.Setenv("PATH", dir)
+
+	started := time.Now()
+	DiscoverAndRegister(context.Background())
+	elapsed := time.Since(started)
+
+	// Serial probing would cost at least 4 budgets; concurrent costs about one
+	// plus the healthy binary's cold start.
+	if elapsed >= time.Duration(len(stalledNames))*budget {
+		t.Errorf("discovery took %v with %d stalled binaries at a %v budget; probes are serialized",
+			elapsed, len(stalledNames), budget)
+	}
+	if _, err := agent.Get(types.AgentName(goodName)); err != nil {
+		t.Errorf("healthy agent %q was not registered despite stalled neighbours: %v", goodName, err)
+	}
+	for _, name := range stalledNames {
+		failureFor(t, name)
+	}
+}
+
+func TestDiscoverAndRegister_TimeoutIsClassifiable(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
+	enableExternalAgents(t)
+	setInfoTimeout(t, 200*time.Millisecond)
+
+	name := "disc-timeout-class"
+	dir := t.TempDir()
+	writeAgentBinary(t, dir, name, stalledScript(t))
+	t.Setenv("PATH", dir)
+
+	DiscoverAndRegister(context.Background())
+
+	err := failureFor(t, name).Err
+	if !errors.Is(err, ErrInfoTimeout) {
+		t.Errorf("failure = %v, want ErrInfoTimeout so a tight budget is diagnosable", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("failure = %v, want it to unwrap to context.DeadlineExceeded too", err)
+	}
+}
+
+func TestDiscoverAndRegister_NonExecutableIsClassifiable(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-noexec"
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, binaryPrefix+name)
-
-	// Write a valid script but WITHOUT executable permission.
-	script := mockInfoScript(makeInfoJSON(name))
-	if err := os.WriteFile(binPath, []byte(script), 0o644); err != nil {
+	if err := os.WriteFile(binPath, []byte(mockInfoScript(makeInfoJSON(name))), 0o644); err != nil {
 		t.Fatalf("write mock binary: %v", err)
 	}
 	t.Setenv("PATH", dir)
 
 	DiscoverAndRegister(context.Background())
 
-	_, err := agent.Get(types.AgentName(name))
-	if err == nil {
-		t.Error("expected non-executable file to be skipped, but agent was registered")
+	if runtime.GOOS == osWindows {
+		// Windows has no execute bit, so the file is a legitimate candidate there.
+		t.Skip("execute bits are not meaningful on Windows")
+	}
+	if _, err := agent.Get(types.AgentName(name)); err == nil {
+		t.Error("non-executable file was registered as a usable agent")
+	}
+	if err := failureFor(t, name).Err; !errors.Is(err, ErrNotExecutable) {
+		t.Errorf("failure = %v, want ErrNotExecutable", err)
 	}
 }
 
-func TestDiscoverAndRegister_SkipsDirectory(t *testing.T) {
+func TestDiscoverAndRegister_DirectoryRecordedAsFailure(t *testing.T) {
+	discoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-dir"
 	dir := t.TempDir()
-
-	// Create a directory (not a file) matching the prefix.
 	if err := os.Mkdir(filepath.Join(dir, binaryPrefix+name), 0o755); err != nil {
 		t.Fatalf("create directory: %v", err)
 	}
@@ -192,30 +421,112 @@ func TestDiscoverAndRegister_SkipsDirectory(t *testing.T) {
 
 	DiscoverAndRegister(context.Background())
 
-	_, err := agent.Get(types.AgentName(name))
-	if err == nil {
-		t.Error("expected directory to be skipped, but agent was registered")
+	if _, err := agent.Get(types.AgentName(name)); err == nil {
+		t.Error("directory was registered as a usable agent")
+	}
+	if err := failureFor(t, name).Err; !strings.Contains(err.Error(), "is a directory") {
+		t.Errorf("failure = %v, want it to say the path is a directory", err)
+	}
+}
+
+// TestDiscoverAndRegister_AlreadyCancelledCallerExecsNothing covers a caller
+// that is out of time before discovery starts. Nothing is executed, but what
+// was found on $PATH stays visible rather than looking uninstalled.
+func TestDiscoverAndRegister_AlreadyCancelledCallerExecsNothing(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
+	enableExternalAgents(t)
+
+	name := "disc-cancelled-caller"
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "was-executed")
+	writeAgentBinary(t, dir, name, touchOnRunScript(name, marker))
+	t.Setenv("PATH", dir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	DiscoverAndRegister(ctx)
+
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("binary was executed despite an already-cancelled caller")
+	}
+	if err := failureFor(t, name).Err; !errors.Is(err, context.Canceled) {
+		t.Errorf("failure = %v, want context.Canceled", err)
+	}
+}
+
+// TestDiscoverAndRegister_MemoizesReadyAndFailed pins that a repeated call does
+// not re-execute anything. One setup flow calls discovery several times, so a
+// failing binary would otherwise pay its full budget on each pass.
+func TestDiscoverAndRegister_MemoizesReadyAndFailed(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
+	enableExternalAgents(t)
+
+	dir := t.TempDir()
+	goodName := "disc-memo-good"
+	badName := "disc-memo-bad"
+	goodCounter := filepath.Join(dir, "good-runs")
+	badCounter := filepath.Join(dir, "bad-runs")
+	writeAgentBinary(t, dir, goodName, countOnRunScript(goodCounter, makeInfoJSON(goodName)))
+	writeAgentBinary(t, dir, badName, countOnRunScript(badCounter, "not json"))
+	t.Setenv("PATH", dir)
+
+	DiscoverAndRegisterAlways(context.Background())
+	firstGood, firstBad := runCount(t, goodCounter), runCount(t, badCounter)
+	if firstGood != 1 || firstBad != 1 {
+		t.Fatalf("first pass ran good=%d bad=%d times, want 1 each", firstGood, firstBad)
+	}
+
+	DiscoverAndRegisterAlways(context.Background())
+
+	if got := runCount(t, goodCounter); got != 1 {
+		t.Errorf("healthy binary executed %d times across two discovery calls, want 1", got)
+	}
+	if got := runCount(t, badCounter); got != 1 {
+		t.Errorf("failing binary executed %d times across two discovery calls, want 1", got)
+	}
+	if _, err := agent.Get(types.AgentName(goodName)); err != nil {
+		t.Errorf("healthy agent lost across the second call: %v", err)
+	}
+	failureFor(t, badName)
+}
+
+// TestDiscoverAndRegister_NameMismatchStillRegisters pins that the registry key
+// comes from the file name. Callers resolve agents by that key, so a binary
+// reporting a different name still works.
+func TestDiscoverAndRegister_NameMismatchStillRegisters(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
+	enableExternalAgents(t)
+
+	binaryName := "disc-mismatch-file"
+	declaredName := "disc-mismatch-declared"
+	dir := t.TempDir()
+	writeAgentBinary(t, dir, binaryName, mockInfoScript(makeInfoJSON(declaredName)))
+	t.Setenv("PATH", dir)
+
+	DiscoverAndRegister(context.Background())
+
+	ag, err := agent.Get(types.AgentName(binaryName))
+	if err != nil {
+		t.Fatalf("expected agent to be registered under its binary name %q: %v", binaryName, err)
+	}
+	if string(ag.Name()) != declaredName {
+		t.Errorf("agent Name() = %q, want the declared %q", ag.Name(), declaredName)
+	}
+	if _, err := agent.Get(types.AgentName(declaredName)); err == nil {
+		t.Errorf("agent should not be resolvable under its declared name %q", declaredName)
 	}
 }
 
 func TestDiscoverAndRegister_SkipsWhenDisabled(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
+	requireSh(t)
+	discoveryTest(t)
 
-	// Set up a repo WITHOUT external_agents enabled (default false)
-	tmpDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
-		t.Fatalf("create .git: %v", err)
-	}
-	entireDir := filepath.Join(tmpDir, ".entire")
-	if err := os.MkdirAll(entireDir, 0o755); err != nil {
-		t.Fatalf("create .entire: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"enabled":true}`), 0o644); err != nil {
-		t.Fatalf("write settings: %v", err)
-	}
-	t.Chdir(tmpDir)
+	// A repo WITHOUT external_agents enabled (default false).
+	writeRepoSettings(t, `{"enabled":true}`)
 
 	name := "disc-disabled"
 	dir := setupDiscoveryDir(t, name, makeInfoJSON(name))
@@ -223,14 +534,16 @@ func TestDiscoverAndRegister_SkipsWhenDisabled(t *testing.T) {
 
 	DiscoverAndRegister(context.Background())
 
-	// Agent should NOT be registered because external_agents is false
-	_, err := agent.Get(types.AgentName(name))
-	if err == nil {
+	if _, err := agent.Get(types.AgentName(name)); err == nil {
 		t.Error("expected agent to NOT be registered when external_agents is disabled")
+	}
+	if len(agent.ExternalFailures()) != 0 {
+		t.Errorf("gated-off discovery recorded failures = %v, want none", agent.ExternalFailures())
 	}
 }
 
 func TestDiscoverAndRegister_EmptyPATH(t *testing.T) {
+	discoveryTest(t)
 	enableExternalAgents(t)
 	t.Setenv("PATH", "")
 
@@ -239,10 +552,8 @@ func TestDiscoverAndRegister_EmptyPATH(t *testing.T) {
 }
 
 func TestDiscoverAndRegister_UnreadableDir(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
+	requireSh(t)
+	discoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-unread"
@@ -253,69 +564,66 @@ func TestDiscoverAndRegister_UnreadableDir(t *testing.T) {
 
 	DiscoverAndRegister(context.Background())
 
-	_, err := agent.Get(types.AgentName(name))
-	if err != nil {
+	if _, err := agent.Get(types.AgentName(name)); err != nil {
 		t.Fatalf("expected agent %q to be registered despite unreadable dir in PATH: %v", name, err)
 	}
 }
 
 func TestDiscoverAndRegisterAlways_FindsAgentWithoutSettings(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
+	requireSh(t)
+	discoveryTest(t)
 
-	// Set up a repo WITHOUT external_agents enabled (default false).
-	tmpDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
-		t.Fatalf("create .git: %v", err)
-	}
-	entireDir := filepath.Join(tmpDir, ".entire")
-	if err := os.MkdirAll(entireDir, 0o755); err != nil {
-		t.Fatalf("create .entire: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"enabled":true}`), 0o644); err != nil {
-		t.Fatalf("write settings: %v", err)
-	}
-	t.Chdir(tmpDir)
+	// Settings exist but external_agents is absent; Always bypasses the gate.
+	writeRepoSettings(t, `{"enabled":true}`)
 
 	name := "disc-always"
 	dir := setupDiscoveryDir(t, name, makeInfoJSON(name))
 	t.Setenv("PATH", dir)
 
-	// DiscoverAndRegisterAlways should find the agent even without external_agents enabled.
 	DiscoverAndRegisterAlways(context.Background())
 
-	ag, err := agent.Get(types.AgentName(name))
-	if err != nil {
-		t.Fatalf("expected agent %q to be registered by DiscoverAndRegisterAlways, got error: %v", name, err)
+	if _, err := agent.Get(types.AgentName(name)); err != nil {
+		t.Fatalf("expected agent %q to be registered by DiscoverAndRegisterAlways: %v", name, err)
 	}
-	if string(ag.Name()) != name {
-		t.Errorf("agent Name() = %q, want %q", ag.Name(), name)
+}
+
+func TestDiscoverAndRegister_ContinuesAfterRegistrationError(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
+
+	badName := "disc-scan-a-invalid"
+	badDir := setupDiscoveryDir(t, badName, "not json")
+	goodName := "disc-scan-z-valid"
+	goodDir := setupDiscoveryDir(t, goodName, makeInfoJSON(goodName))
+	t.Setenv("PATH", badDir+string(os.PathListSeparator)+goodDir)
+
+	DiscoverAndRegisterAlways(context.Background())
+
+	if _, err := agent.Get(types.AgentName(badName)); err == nil {
+		t.Fatalf("invalid external agent %q was registered", badName)
+	}
+	if _, err := agent.Get(types.AgentName(goodName)); err != nil {
+		t.Fatalf("valid external agent %q was not registered after earlier failure: %v", goodName, err)
 	}
 }
 
 func TestDiscoverAndRegisterNamedAlways_TimesOutStalledInfo(t *testing.T) {
-	sleepPath, err := exec.LookPath("sleep")
-	if err != nil {
-		t.Skip("sleep not available")
-	}
+	requireSh(t)
+	discoveryTest(t)
+	setInfoTimeout(t, 200*time.Millisecond)
 
 	name := types.AgentName("disc-named-timeout")
 	dir := t.TempDir()
-	binPath := filepath.Join(dir, binaryPrefix+string(name))
-	script := fmt.Sprintf("#!/bin/sh\nexec %q 60\n", sleepPath)
-	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write stalled mock binary: %v", err)
-	}
+	writeAgentBinary(t, dir, string(name), stalledScript(t))
 	t.Setenv("PATH", dir)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-
 	started := time.Now()
-	err = DiscoverAndRegisterNamedAlways(ctx, name)
+	err := DiscoverAndRegisterNamedAlways(context.Background(), name)
 	if elapsed := time.Since(started); elapsed > 2*time.Second {
-		t.Fatalf("named discovery took %v, want cancellation near context deadline", elapsed)
+		t.Fatalf("named discovery took %v, want cancellation near the info budget", elapsed)
+	}
+	if !errors.Is(err, ErrInfoTimeout) {
+		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want ErrInfoTimeout", err)
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want context deadline exceeded", err)
@@ -326,9 +634,8 @@ func TestDiscoverAndRegisterNamedAlways_TimesOutStalledInfo(t *testing.T) {
 }
 
 func TestDiscoverAndRegisterNamedAlways_CanceledContext(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
+	requireSh(t)
+	discoveryTest(t)
 
 	name := types.AgentName("disc-named-canceled")
 	dir := setupDiscoveryDir(t, string(name), makeInfoJSON(string(name)))
@@ -344,9 +651,8 @@ func TestDiscoverAndRegisterNamedAlways_CanceledContext(t *testing.T) {
 }
 
 func TestDiscoverAndRegisterNamedAlways_InvalidInfo(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
+	requireSh(t)
+	discoveryTest(t)
 
 	name := types.AgentName("disc-named-invalid-info")
 	dir := setupDiscoveryDir(t, string(name), "not json")
@@ -362,18 +668,30 @@ func TestDiscoverAndRegisterNamedAlways_InvalidInfo(t *testing.T) {
 	if !strings.Contains(err.Error(), "info: invalid JSON") {
 		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want invalid info context", err)
 	}
+	// The explicit caller gets the error, and it is also recorded for listing.
+	failureFor(t, string(name))
 }
 
+// TestDiscoverAndRegisterNamedAlways_MissingHelper pins that a missing binary is
+// not a broken agent: the nil return means "no such plugin, fall through", which
+// the --summarize-provider override depends on.
 func TestDiscoverAndRegisterNamedAlways_MissingHelper(t *testing.T) {
+	discoveryTest(t)
+
 	name := types.AgentName("disc-named-missing")
 	t.Setenv("PATH", t.TempDir())
 
 	if err := DiscoverAndRegisterNamedAlways(context.Background(), name); err != nil {
 		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want nil for missing helper", err)
 	}
+	if len(agent.ExternalFailures()) != 0 {
+		t.Errorf("a missing binary was recorded as broken: %v", agent.ExternalFailures())
+	}
 }
 
 func TestDiscoverAndRegisterNamedAlways_RejectsPathSeparators(t *testing.T) {
+	discoveryTest(t)
+
 	originalLookPath := lookPathExternalAgent
 	t.Cleanup(func() { lookPathExternalAgent = originalLookPath })
 
@@ -394,115 +712,9 @@ func TestDiscoverAndRegisterNamedAlways_RejectsPathSeparators(t *testing.T) {
 	}
 }
 
-func TestDiscoverAndRegisterNamedAlways_DeadlineWhileLookingUpMissingHelper(t *testing.T) {
-	name := types.AgentName("disc-named-lookup-deadline")
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-
-	originalLookPath := lookPathExternalAgent
-	t.Cleanup(func() { lookPathExternalAgent = originalLookPath })
-	lookPathExternalAgent = func(string) (string, error) {
-		<-ctx.Done()
-		return "", exec.ErrNotFound
-	}
-
-	err := DiscoverAndRegisterNamedAlways(ctx, name)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want context deadline exceeded", err)
-	}
-}
-
-func TestDiscoverAndRegisterNamedAlways_HelperDisappearsAfterLookup(t *testing.T) {
-	name := types.AgentName("disc-named-helper-disappeared")
-	binPath := filepath.Join(t.TempDir(), binaryPrefix+string(name))
-
-	originalLookPath := lookPathExternalAgent
-	originalStat := statExternalAgent
-	t.Cleanup(func() {
-		lookPathExternalAgent = originalLookPath
-		statExternalAgent = originalStat
-	})
-	lookPathExternalAgent = func(string) (string, error) { return binPath, nil }
-	statExternalAgent = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
-
-	err := DiscoverAndRegisterNamedAlways(context.Background(), name)
-	if err == nil {
-		t.Fatal("DiscoverAndRegisterNamedAlways() error = nil, want helper-disappeared error")
-	}
-	if !strings.Contains(err.Error(), string(name)) || !strings.Contains(err.Error(), binPath) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want agent and binary context", err)
-	}
-	if !strings.Contains(err.Error(), "was found but could not be registered") {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want actionable registration context", err)
-	}
-}
-
-func TestDiscoverAndRegisterNamedAlways_StatError(t *testing.T) {
-	name := types.AgentName("disc-named-stat-error")
-	binPath := filepath.Join(t.TempDir(), binaryPrefix+string(name))
-	wantErr := errors.New("stat failed")
-
-	originalLookPath := lookPathExternalAgent
-	originalStat := statExternalAgent
-	t.Cleanup(func() {
-		lookPathExternalAgent = originalLookPath
-		statExternalAgent = originalStat
-	})
-	lookPathExternalAgent = func(string) (string, error) { return binPath, nil }
-	statExternalAgent = func(string) (os.FileInfo, error) { return nil, wantErr }
-
-	err := DiscoverAndRegisterNamedAlways(context.Background(), name)
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want stat error", err)
-	}
-	if !strings.Contains(err.Error(), string(name)) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want agent name %q", err, name)
-	}
-}
-
-func TestDiscoverAndRegisterNamedAlways_LookPathError(t *testing.T) {
-	name := types.AgentName("disc-named-lookpath-error")
-	wantErr := errors.New("lookup failed")
-
-	originalLookPath := lookPathExternalAgent
-	t.Cleanup(func() { lookPathExternalAgent = originalLookPath })
-	lookPathExternalAgent = func(string) (string, error) { return "", wantErr }
-
-	err := DiscoverAndRegisterNamedAlways(context.Background(), name)
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want lookup error", err)
-	}
-	if !strings.Contains(err.Error(), string(name)) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %q, want agent name %q", err, name)
-	}
-}
-
-func TestDiscoverAndRegister_ContinuesAfterRegistrationError(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
-	badName := "disc-scan-a-invalid"
-	badDir := setupDiscoveryDir(t, badName, "not json")
-	goodName := "disc-scan-z-valid"
-	goodDir := setupDiscoveryDir(t, goodName, makeInfoJSON(goodName))
-	t.Setenv("PATH", badDir+string(os.PathListSeparator)+goodDir)
-
-	DiscoverAndRegisterAlways(context.Background())
-
-	if _, err := agent.Get(types.AgentName(badName)); err == nil {
-		t.Fatalf("invalid external agent %q was registered", badName)
-	}
-	if _, err := agent.Get(types.AgentName(goodName)); err != nil {
-		t.Fatalf("valid external agent %q was not registered after earlier failure: %v", goodName, err)
-	}
-}
-
 func TestIsExternal_WrappedAgent(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
+	requireSh(t)
+	discoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-isext"
@@ -562,32 +774,6 @@ func (f *fakeBuiltInAgent) ReadSession(*agent.HookInput) (*agent.AgentSession, e
 func (f *fakeBuiltInAgent) WriteSession(context.Context, *agent.AgentSession) error { return nil }
 func (f *fakeBuiltInAgent) FormatResumeCommand(string) string                       { return "" }
 
-func TestDiscoverAndRegister_SkipsInfoFailure(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
-	}
-
-	enableExternalAgents(t)
-
-	name := "disc-badjson"
-	dir := t.TempDir()
-	binPath := filepath.Join(dir, binaryPrefix+name)
-
-	// Binary that outputs invalid JSON for "info".
-	script := "#!/bin/sh\necho 'not json'\n"
-	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write mock binary: %v", err)
-	}
-	t.Setenv("PATH", dir)
-
-	DiscoverAndRegister(context.Background())
-
-	_, err := agent.Get(types.AgentName(name))
-	if err == nil {
-		t.Error("expected agent with bad info to be skipped, but it was registered")
-	}
-}
-
 // TestDiscoverAndRegister_RegistersBatOnWindows verifies that a .bat agent
 // binary is discovered and registered on Windows, with the file extension
 // stripped from the agent name. .cmd and .exe follow the same code path.
@@ -595,7 +781,7 @@ func TestDiscoverAndRegister_RegistersBatOnWindows(t *testing.T) {
 	if runtime.GOOS != osWindows {
 		t.Skip("this test only applies on Windows")
 	}
-
+	discoveryTest(t)
 	enableExternalAgents(t)
 
 	name := "disc-bat"
@@ -627,6 +813,7 @@ func TestDiscoverAndRegisterNamedAlways_RegistersBatOnWindows(t *testing.T) {
 	if runtime.GOOS != osWindows {
 		t.Skip("this test only applies on Windows")
 	}
+	discoveryTest(t)
 
 	name := types.AgentName("disc-named-bat")
 	infoJSON := `{"protocol_version":1,"name":"` + string(name) + `","type":"` + string(name) + ` Agent","description":"Named Windows agent","is_preview":false,"protected_dirs":[],"hook_names":[],"capabilities":{}}`
@@ -649,59 +836,5 @@ func TestDiscoverAndRegisterNamedAlways_RegistersBatOnWindows(t *testing.T) {
 	}
 	if ag.Name() != name {
 		t.Fatalf("agent Name() = %q, want %q", ag.Name(), name)
-	}
-}
-
-// stalledPropagationCtx is a context whose cancellation is immediately visible via
-// Done and Err, but whose propagation to derived contexts is not awaited. Because it
-// is not a standard context, context.WithTimeout watches it from a goroutine, so a
-// derived context still reports no error for a moment after this one is cancelled.
-//
-// That window is real, not contrived: even for standard contexts, cancel() closes its
-// own Done channel before cancelling children, so a goroutine woken by the parent can
-// run before the child observes anything. This type just makes the window wide enough
-// to assert on deterministically instead of relying on scheduler luck.
-type stalledPropagationCtx struct {
-	done chan struct{}
-}
-
-func (*stalledPropagationCtx) Deadline() (time.Time, bool) { return time.Time{}, false }
-func (c *stalledPropagationCtx) Done() <-chan struct{}     { return c.done }
-func (*stalledPropagationCtx) Value(any) any               { return nil }
-func (c *stalledPropagationCtx) Err() error {
-	select {
-	case <-c.done:
-		return context.DeadlineExceeded
-	default:
-		return nil
-	}
-}
-
-// TestDiscoverAndRegisterNamedAlways_ReportsCallerDeadlineExpiredDuringLookup pins the
-// contract that a caller whose context expires while the helper binary is being looked
-// up gets its context error back — not a nil "no such agent" result.
-//
-// Before the fix this returned nil: the caller's context was shadowed by the derived
-// timeout context, so the post-lookup check consulted only the derived one, which had
-// not yet observed the caller's cancellation. That is the same defect that made
-// TestDiscoverAndRegisterNamedAlways_DeadlineWhileLookingUpMissingHelper flaky under
-// load, where the window had to be hit by chance.
-func TestDiscoverAndRegisterNamedAlways_ReportsCallerDeadlineExpiredDuringLookup(t *testing.T) {
-	name := types.AgentName("disc-named-caller-deadline")
-	caller := &stalledPropagationCtx{done: make(chan struct{})}
-
-	originalLookPath := lookPathExternalAgent
-	t.Cleanup(func() { lookPathExternalAgent = originalLookPath })
-	lookPathExternalAgent = func(string) (string, error) {
-		// Expire the caller mid-lookup and return straight away, before the derived
-		// context's watcher goroutine can observe it. ErrNotFound is the benign
-		// "no such helper" result the deadline must take precedence over.
-		close(caller.done)
-		return "", exec.ErrNotFound
-	}
-
-	err := DiscoverAndRegisterNamedAlways(caller, name)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want context deadline exceeded", err)
 	}
 }

--- a/cmd/entire/cli/agent/external/discovery_test.go
+++ b/cmd/entire/cli/agent/external/discovery_test.go
@@ -25,15 +25,14 @@ import (
 // probe memo built from it are process-wide: without this, results leak
 // between tests and the memo makes failures depend on test order.
 //
-// It also raises the info budget. A mock written into a fresh t.TempDir() is
-// always a cold exec — on macOS the first run of a freshly written file was
-// measured at 320-394ms, past the shipped 300ms — so a test that execs a mock
-// must raise the budget rather than loosen its assertions.
+// It also raises the info budget so behavioral tests do not depend on machine
+// load. Timeout tests set their own smaller budget. Fixtures are never warmed,
+// so call-site tests still exercise the cold execution path users get.
 func discoveryTest(t *testing.T) {
 	t.Helper()
 	agent.ResetExternalsForTesting()
 	t.Cleanup(agent.ResetExternalsForTesting)
-	setInfoTimeout(t, 5*time.Second)
+	setInfoTimeout(t, 15*time.Second)
 }
 
 func setInfoTimeout(t *testing.T, d time.Duration) {
@@ -110,18 +109,6 @@ func touchOnRunScript(name, marker string) string {
 func countOnRunScript(counter, reply string) string {
 	return "#!/bin/sh\necho x >> " + counter + "\n" +
 		"case \"$1\" in\n  info)\n    echo '" + reply + "'\n    ;;\nesac\n"
-}
-
-// warmUp executes a mock binary once so its cold-start cost is not charged to
-// the budget under test. A freshly written file pays code-signing validation
-// and page-in on its first run, and that cost grows sharply when several such
-// binaries start at once — measured here as a healthy mock breaching a 1s
-// budget while four neighbours were also starting cold.
-func warmUp(t *testing.T, binPath string) {
-	t.Helper()
-	if err := exec.CommandContext(context.Background(), binPath, "info").Run(); err != nil {
-		t.Fatalf("warm up %s: %v", binPath, err)
-	}
 }
 
 func runCount(t *testing.T, counter string) int {
@@ -238,6 +225,34 @@ func TestDiscoverAndRegister_DedupesOnDerivedAgentName(t *testing.T) {
 	}
 }
 
+// TestDiscoverAndRegister_InvalidEarlierPathEntryDoesNotHideValidBinary pins
+// normal PATH lookup behavior: a directory with an executable-looking name is
+// not a command and must not hide a runnable binary in a later PATH directory.
+func TestDiscoverAndRegister_InvalidEarlierPathEntryDoesNotHideValidBinary(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
+	enableExternalAgents(t)
+
+	name := "disc-invalid-before-valid"
+	invalidDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(invalidDir, binaryPrefix+name), 0o755); err != nil {
+		t.Fatalf("create invalid PATH entry: %v", err)
+	}
+	validDir := setupDiscoveryDir(t, name, makeInfoJSON(name))
+	t.Setenv("PATH", invalidDir+string(os.PathListSeparator)+validDir)
+
+	DiscoverAndRegister(context.Background())
+
+	if _, err := agent.Get(types.AgentName(name)); err != nil {
+		t.Fatalf("valid later-PATH agent %q was hidden by a directory: %v", name, err)
+	}
+	for _, failure := range agent.ExternalFailures() {
+		if failure.Name == types.AgentName(name) {
+			t.Errorf("usable agent %q remained recorded as broken: %v", name, failure.Err)
+		}
+	}
+}
+
 // TestDiscoverAndRegister_SkipsNameConflict covers the rule that a built-in
 // always wins: the colliding binary must not even be executed, because the
 // gated discovery path runs inside the git and agent hook trees.
@@ -327,7 +342,7 @@ func TestDiscoverAndRegister_ParallelProbesDoNotSerialize(t *testing.T) {
 	discoveryTest(t)
 	enableExternalAgents(t)
 
-	const budget = time.Second
+	const budget = 10 * time.Second
 	setInfoTimeout(t, budget)
 
 	dir := t.TempDir()
@@ -337,8 +352,7 @@ func TestDiscoverAndRegister_ParallelProbesDoNotSerialize(t *testing.T) {
 		writeAgentBinary(t, dir, name, stalled)
 	}
 	goodName := "disc-par-good"
-	goodPath := writeAgentBinary(t, dir, goodName, mockInfoScript(makeInfoJSON(goodName)))
-	warmUp(t, goodPath)
+	writeAgentBinary(t, dir, goodName, mockInfoScript(makeInfoJSON(goodName)))
 	t.Setenv("PATH", dir)
 
 	started := time.Now()
@@ -670,6 +684,29 @@ func TestDiscoverAndRegisterNamedAlways_InvalidInfo(t *testing.T) {
 	}
 	// The explicit caller gets the error, and it is also recorded for listing.
 	failureFor(t, string(name))
+}
+
+func TestDiscoverAndRegisterNamedAlways_MemoizesFailedBinary(t *testing.T) {
+	requireSh(t)
+	discoveryTest(t)
+
+	name := types.AgentName("disc-named-failure-memo")
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "runs")
+	writeAgentBinary(t, dir, string(name), countOnRunScript(counter, "not json"))
+	t.Setenv("PATH", dir)
+
+	firstErr := DiscoverAndRegisterNamedAlways(context.Background(), name)
+	if firstErr == nil {
+		t.Fatal("first named discovery error = nil, want invalid info error")
+	}
+	secondErr := DiscoverAndRegisterNamedAlways(context.Background(), name)
+	if secondErr == nil {
+		t.Fatal("second named discovery error = nil, want memoized invalid info error")
+	}
+	if got := runCount(t, counter); got != 1 {
+		t.Errorf("failed named binary executed %d times, want once per process", got)
+	}
 }
 
 // TestDiscoverAndRegisterNamedAlways_MissingHelper pins that a missing binary is

--- a/cmd/entire/cli/agent/registry.go
+++ b/cmd/entire/cli/agent/registry.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -40,6 +41,10 @@ type ExternalFailure struct {
 	Err    error
 }
 
+// ErrUnknownAgent marks a name that has no registry entry. Callers use it to
+// distinguish a typo from an installed external agent that failed to load.
+var ErrUnknownAgent = errors.New("unknown agent")
+
 // Register adds an agent factory to the registry.
 // Called from init() in each agent implementation.
 func Register(name types.AgentName, factory Factory) {
@@ -76,7 +81,7 @@ func Get(name types.AgentName) (Agent, error) {
 
 	e, ok := registry[name]
 	if !ok {
-		return nil, fmt.Errorf("unknown agent: %s (available: %v)", name, usableNamesLocked())
+		return nil, fmt.Errorf("%w: %s (available: %v)", ErrUnknownAgent, name, usableNamesLocked())
 	}
 	if e.err != nil {
 		return nil, fmt.Errorf("external agent %q (%s) is not usable: %w", name, e.binary, e.err)
@@ -144,6 +149,18 @@ func ExternalFailures() []ExternalFailure {
 		return strings.Compare(string(a.Name), string(b.Name))
 	})
 	return failures
+}
+
+// ExternalFailureFor returns the recorded failure for name, if any.
+func ExternalFailureFor(name types.AgentName) (ExternalFailure, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	e, ok := registry[name]
+	if !ok || e.err == nil {
+		return ExternalFailure{}, false
+	}
+	return ExternalFailure{Name: name, Binary: e.binary, Err: e.err}, true
 }
 
 // ProbedExternalBinaries returns the set of external binary paths already

--- a/cmd/entire/cli/agent/registry.go
+++ b/cmd/entire/cli/agent/registry.go
@@ -14,45 +14,98 @@ import (
 
 var (
 	registryMu sync.RWMutex
-	registry   = make(map[types.AgentName]Factory)
+	registry   = make(map[types.AgentName]entry)
 )
 
 // Factory creates a new agent instance
 type Factory func() Agent
+
+// entry is one slot in the registry. Exactly one of factory and err is set: a
+// usable agent has a factory, while an external binary that was found on $PATH
+// but could not be loaded carries the reason instead. binary is set for
+// external agents only, and is what lets discovery skip a binary it has
+// already asked for info.
+type entry struct {
+	factory Factory
+	binary  string
+	err     error
+}
+
+// ExternalFailure is an external agent binary that exists on $PATH but could
+// not be loaded. Listing commands use it to answer "why isn't my plugin
+// showing up?", which used to be a Debug log line and nothing else.
+type ExternalFailure struct {
+	Name   types.AgentName
+	Binary string
+	Err    error
+}
 
 // Register adds an agent factory to the registry.
 // Called from init() in each agent implementation.
 func Register(name types.AgentName, factory Factory) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
-	registry[name] = factory
+	registry[name] = entry{factory: factory}
 }
 
-// Get retrieves an agent by name.
-//
+// RegisterExternal adds a usable external agent, remembering which binary it
+// came from so discovery can skip that binary on a later pass.
+func RegisterExternal(name types.AgentName, binary string, factory Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[name] = entry{factory: factory, binary: binary}
+}
 
+// RegisterExternalFailure records an external agent binary that was found but
+// could not be loaded, so the reason survives until something lists it.
+//
+// A failure can never displace a working built-in: discovery skips any binary
+// whose derived name collides with an already-registered agent, without
+// executing it.
+func RegisterExternalFailure(name types.AgentName, binary string, err error) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[name] = entry{binary: binary, err: err}
+}
+
+// Get retrieves an agent by name. An external agent that failed to load
+// returns its load error rather than looking like it was never installed.
 func Get(name types.AgentName) (Agent, error) {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 
-	factory, ok := registry[name]
+	e, ok := registry[name]
 	if !ok {
-		return nil, fmt.Errorf("unknown agent: %s (available: %v)", name, List())
+		return nil, fmt.Errorf("unknown agent: %s (available: %v)", name, usableNamesLocked())
 	}
-	return factory(), nil
+	if e.err != nil {
+		return nil, fmt.Errorf("external agent %q (%s) is not usable: %w", name, e.binary, e.err)
+	}
+	return e.factory(), nil
 }
 
-// List returns all registered agent names in sorted order.
-func List() []types.AgentName {
-	registryMu.RLock()
-	defer registryMu.RUnlock()
-
+// usableNamesLocked returns the sorted usable agent names. The caller must
+// already hold registryMu. List cannot be reused here: re-entering RLock
+// deadlocks whenever a writer queues between the two acquisitions.
+func usableNamesLocked() []types.AgentName {
 	names := make([]types.AgentName, 0, len(registry))
-	for name := range registry {
+	for name, e := range registry {
+		if e.factory == nil {
+			continue
+		}
 		names = append(names, name)
 	}
 	slices.Sort(names)
 	return names
+}
+
+// List returns all usable agent names in sorted order. An external agent whose
+// binary failed to load is not usable and is reported by ExternalFailures
+// instead, so every List consumer keeps meaning "agents you can actually use".
+func List() []types.AgentName {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return usableNamesLocked()
 }
 
 // StringList returns user-facing agent names, excluding test-only agents.
@@ -61,14 +114,67 @@ func StringList() []string {
 	defer registryMu.RUnlock()
 
 	names := make([]string, 0, len(registry))
-	for name, factory := range registry {
-		if to, ok := factory().(TestOnly); ok && to.IsTestOnly() {
+	for name, e := range registry {
+		if e.factory == nil {
+			continue
+		}
+		if to, ok := e.factory().(TestOnly); ok && to.IsTestOnly() {
 			continue
 		}
 		names = append(names, string(name))
 	}
 	slices.Sort(names)
 	return names
+}
+
+// ExternalFailures returns every discovered external agent binary that could
+// not be loaded, sorted by name. The result is a copy.
+func ExternalFailures() []ExternalFailure {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	failures := make([]ExternalFailure, 0, len(registry))
+	for name, e := range registry {
+		if e.err == nil {
+			continue
+		}
+		failures = append(failures, ExternalFailure{Name: name, Binary: e.binary, Err: e.err})
+	}
+	slices.SortFunc(failures, func(a, b ExternalFailure) int {
+		return strings.Compare(string(a.Name), string(b.Name))
+	})
+	return failures
+}
+
+// ProbedExternalBinaries returns the set of external binary paths already
+// probed in this process, loaded or not. Discovery uses it to avoid re-running
+// info on a binary it has already asked, which matters because one setup flow
+// calls discovery several times.
+func ProbedExternalBinaries() map[string]struct{} {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	probed := make(map[string]struct{})
+	for _, e := range registry {
+		if e.binary != "" {
+			probed[e.binary] = struct{}{}
+		}
+	}
+	return probed
+}
+
+// ResetExternalsForTesting drops every external agent entry, ready or failed.
+// Both the registry and the probe memo are process-wide, so without this
+// discovery results leak between tests and the memo makes failures depend on
+// test order. Built-in entries are left alone.
+func ResetExternalsForTesting() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	for name, e := range registry {
+		if e.binary != "" {
+			delete(registry, name)
+		}
+	}
 }
 
 // DetectAll returns all agents whose DetectPresence reports true.
@@ -194,8 +300,11 @@ func GetByAgentType(agentType types.AgentType) (Agent, error) {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 
-	for _, factory := range registry {
-		ag := factory()
+	for _, e := range registry {
+		if e.factory == nil {
+			continue
+		}
+		ag := e.factory()
 		if ag.Type() == agentType {
 			return ag, nil
 		}
@@ -209,8 +318,11 @@ func AllProtectedDirs() []string {
 	// Copy factories under the lock, then release before calling external code.
 	registryMu.RLock()
 	factories := make([]Factory, 0, len(registry))
-	for _, f := range registry {
-		factories = append(factories, f)
+	for _, e := range registry {
+		if e.factory == nil {
+			continue
+		}
+		factories = append(factories, e.factory)
 	}
 	registryMu.RUnlock()
 
@@ -233,8 +345,11 @@ func AllProtectedFiles() []string {
 	// Copy factories under the lock, then release before calling external code.
 	registryMu.RLock()
 	factories := make([]Factory, 0, len(registry))
-	for _, f := range registry {
-		factories = append(factories, f)
+	for _, e := range registry {
+		if e.factory == nil {
+			continue
+		}
+		factories = append(factories, e.factory)
 	}
 	registryMu.RUnlock()
 

--- a/cmd/entire/cli/agent/registry_test.go
+++ b/cmd/entire/cli/agent/registry_test.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -12,13 +14,13 @@ import (
 
 func TestRegistryOperations(t *testing.T) {
 	// Save original registry state and restore after test
-	originalRegistry := make(map[types.AgentName]Factory)
+	originalRegistry := make(map[types.AgentName]entry)
 	registryMu.Lock()
 	for k, v := range registry {
 		originalRegistry[k] = v
 	}
 	// Clear registry for testing
-	registry = make(map[types.AgentName]Factory)
+	registry = make(map[types.AgentName]entry)
 	registryMu.Unlock()
 
 	defer func() {
@@ -54,7 +56,7 @@ func TestRegistryOperations(t *testing.T) {
 	t.Run("List returns registered agents", func(t *testing.T) {
 		// Clear and register fresh
 		registryMu.Lock()
-		registry = make(map[types.AgentName]Factory)
+		registry = make(map[types.AgentName]entry)
 		registryMu.Unlock()
 
 		Register(types.AgentName("agent-b"), func() Agent { return &mockAgent{} })
@@ -85,12 +87,12 @@ func (s *sessionDirAgent) Type() types.AgentType                  { return s.age
 func (s *sessionDirAgent) GetSessionDir(_ string) (string, error) { return s.sessionDir, nil }
 
 func TestAgentForTranscriptPath(t *testing.T) {
-	originalRegistry := make(map[types.AgentName]Factory)
+	originalRegistry := make(map[types.AgentName]entry)
 	registryMu.Lock()
 	for k, v := range registry {
 		originalRegistry[k] = v
 	}
-	registry = make(map[types.AgentName]Factory)
+	registry = make(map[types.AgentName]entry)
 	registryMu.Unlock()
 	t.Cleanup(func() {
 		registryMu.Lock()
@@ -220,12 +222,12 @@ func TestDefaultAgentName(t *testing.T) {
 func TestDefault(t *testing.T) {
 	// Default() returns nil if default agent is not registered
 	// This test verifies the function doesn't panic
-	originalRegistry := make(map[types.AgentName]Factory)
+	originalRegistry := make(map[types.AgentName]entry)
 	registryMu.Lock()
 	for k, v := range registry {
 		originalRegistry[k] = v
 	}
-	registry = make(map[types.AgentName]Factory)
+	registry = make(map[types.AgentName]entry)
 	registryMu.Unlock()
 
 	defer func() {
@@ -252,12 +254,12 @@ func TestDefault(t *testing.T) {
 
 func TestAllProtectedDirs(t *testing.T) {
 	// Save original registry state
-	originalRegistry := make(map[types.AgentName]Factory)
+	originalRegistry := make(map[types.AgentName]entry)
 	registryMu.Lock()
 	for k, v := range registry {
 		originalRegistry[k] = v
 	}
-	registry = make(map[types.AgentName]Factory)
+	registry = make(map[types.AgentName]entry)
 	registryMu.Unlock()
 
 	defer func() {
@@ -275,7 +277,7 @@ func TestAllProtectedDirs(t *testing.T) {
 
 	t.Run("collects dirs from registered agents", func(t *testing.T) {
 		registryMu.Lock()
-		registry = make(map[types.AgentName]Factory)
+		registry = make(map[types.AgentName]entry)
 		registryMu.Unlock()
 
 		Register(types.AgentName("agent-a"), func() Agent {
@@ -300,7 +302,7 @@ func TestAllProtectedDirs(t *testing.T) {
 
 	t.Run("deduplicates across agents", func(t *testing.T) {
 		registryMu.Lock()
-		registry = make(map[types.AgentName]Factory)
+		registry = make(map[types.AgentName]entry)
 		registryMu.Unlock()
 
 		Register(types.AgentName("agent-x"), func() Agent {
@@ -319,12 +321,12 @@ func TestAllProtectedDirs(t *testing.T) {
 
 func TestAllProtectedFiles(t *testing.T) {
 	// Save original registry state
-	originalRegistry := make(map[types.AgentName]Factory)
+	originalRegistry := make(map[types.AgentName]entry)
 	registryMu.Lock()
 	for k, v := range registry {
 		originalRegistry[k] = v
 	}
-	registry = make(map[types.AgentName]Factory)
+	registry = make(map[types.AgentName]entry)
 	registryMu.Unlock()
 
 	defer func() {
@@ -342,7 +344,7 @@ func TestAllProtectedFiles(t *testing.T) {
 
 	t.Run("collects files from registered agents", func(t *testing.T) {
 		registryMu.Lock()
-		registry = make(map[types.AgentName]Factory)
+		registry = make(map[types.AgentName]entry)
 		registryMu.Unlock()
 
 		Register(types.AgentName("agent-no-files"), func() Agent {
@@ -369,7 +371,7 @@ func TestAllProtectedFiles(t *testing.T) {
 
 	t.Run("deduplicates across agents", func(t *testing.T) {
 		registryMu.Lock()
-		registry = make(map[types.AgentName]Factory)
+		registry = make(map[types.AgentName]entry)
 		registryMu.Unlock()
 
 		Register(types.AgentName("agent-x"), func() Agent {
@@ -436,4 +438,133 @@ type mockLauncherAgent struct {
 //nolint:unparam // error is always nil in this mock; satisfies the Launcher interface.
 func (m *mockLauncherAgent) LaunchCmd(ctx context.Context, _ string) (*exec.Cmd, error) {
 	return exec.CommandContext(ctx, "true"), nil
+}
+
+// snapshotRegistry replaces the registry with an empty one for the duration of
+// the test and restores it afterwards.
+func snapshotRegistry(t *testing.T) {
+	t.Helper()
+	registryMu.Lock()
+	original := make(map[types.AgentName]entry, len(registry))
+	for k, v := range registry {
+		original[k] = v
+	}
+	registry = make(map[types.AgentName]entry)
+	registryMu.Unlock()
+
+	t.Cleanup(func() {
+		registryMu.Lock()
+		registry = original
+		registryMu.Unlock()
+	})
+}
+
+func TestGet_FailedExternalReturnsItsLoadError(t *testing.T) {
+	snapshotRegistry(t)
+
+	loadErr := errors.New("info: invalid JSON: unexpected end of input")
+	RegisterExternalFailure("broken-ext", "/usr/local/bin/entire-agent-broken-ext", loadErr)
+
+	_, err := Get("broken-ext")
+	if !errors.Is(err, loadErr) {
+		t.Fatalf("Get() error = %v, want the recorded load error", err)
+	}
+	if !strings.Contains(err.Error(), "/usr/local/bin/entire-agent-broken-ext") {
+		t.Errorf("Get() error = %q, want the binary path so the user can find it", err)
+	}
+}
+
+func TestListAndStringList_ExcludeFailedExternals(t *testing.T) {
+	snapshotRegistry(t)
+
+	Register("built-in", func() Agent { return &protectedDirAgent{} })
+	RegisterExternal("ready-ext", "/bin/entire-agent-ready-ext", func() Agent { return &protectedDirAgent{} })
+	RegisterExternalFailure("broken-ext", "/bin/entire-agent-broken-ext", errors.New("boom"))
+
+	want := []types.AgentName{"built-in", "ready-ext"}
+	if got := List(); !slices.Equal(got, want) {
+		t.Errorf("List() = %v, want %v", got, want)
+	}
+	if got := StringList(); !slices.Equal(got, []string{"built-in", "ready-ext"}) {
+		t.Errorf("StringList() = %v, want built-in and ready-ext", got)
+	}
+}
+
+func TestExternalFailures_SortedSnapshot(t *testing.T) {
+	snapshotRegistry(t)
+
+	RegisterExternalFailure("zed", "/bin/entire-agent-zed", errors.New("zed failed"))
+	RegisterExternalFailure("abe", "/bin/entire-agent-abe", errors.New("abe failed"))
+	RegisterExternal("ready", "/bin/entire-agent-ready", func() Agent { return &protectedDirAgent{} })
+
+	failures := ExternalFailures()
+	if len(failures) != 2 {
+		t.Fatalf("ExternalFailures() returned %d entries, want 2", len(failures))
+	}
+	if failures[0].Name != "abe" || failures[1].Name != "zed" {
+		t.Errorf("ExternalFailures() = %v, want sorted by name", failures)
+	}
+	if failures[0].Binary != "/bin/entire-agent-abe" {
+		t.Errorf("ExternalFailures()[0].Binary = %q, want the discovered path", failures[0].Binary)
+	}
+}
+
+func TestProbedExternalBinaries_CoversReadyAndFailed(t *testing.T) {
+	snapshotRegistry(t)
+
+	Register("built-in", func() Agent { return &protectedDirAgent{} })
+	RegisterExternal("ready", "/bin/entire-agent-ready", func() Agent { return &protectedDirAgent{} })
+	RegisterExternalFailure("broken", "/bin/entire-agent-broken", errors.New("boom"))
+
+	probed := ProbedExternalBinaries()
+	for _, want := range []string{"/bin/entire-agent-ready", "/bin/entire-agent-broken"} {
+		if _, ok := probed[want]; !ok {
+			t.Errorf("ProbedExternalBinaries() missing %q", want)
+		}
+	}
+	if len(probed) != 2 {
+		t.Errorf("ProbedExternalBinaries() = %v, want only external binaries", probed)
+	}
+}
+
+func TestResetExternalsForTesting_KeepsBuiltIns(t *testing.T) {
+	snapshotRegistry(t)
+
+	Register("built-in", func() Agent { return &protectedDirAgent{} })
+	RegisterExternal("ready", "/bin/entire-agent-ready", func() Agent { return &protectedDirAgent{} })
+	RegisterExternalFailure("broken", "/bin/entire-agent-broken", errors.New("boom"))
+
+	ResetExternalsForTesting()
+
+	if got := List(); !slices.Equal(got, []types.AgentName{"built-in"}) {
+		t.Errorf("List() after reset = %v, want only the built-in", got)
+	}
+	if got := ExternalFailures(); len(got) != 0 {
+		t.Errorf("ExternalFailures() after reset = %v, want none", got)
+	}
+	if got := ProbedExternalBinaries(); len(got) != 0 {
+		t.Errorf("ProbedExternalBinaries() after reset = %v, want none", got)
+	}
+}
+
+func TestFailedExternalDoesNotBreakRegistryWalks(t *testing.T) {
+	snapshotRegistry(t)
+
+	RegisterExternalFailure("broken", "/bin/entire-agent-broken", errors.New("boom"))
+	Register("built-in", func() Agent { return &protectedDirAgent{dirs: []string{".built-in"}} })
+
+	// A failed entry has no factory. Every registry walk must skip it rather
+	// than call through a nil factory.
+	if _, err := GetByAgentType("nope"); err == nil {
+		t.Error("GetByAgentType() error = nil, want unknown agent type")
+	}
+	if got := DetectAll(context.Background()); len(got) != 0 {
+		t.Errorf("DetectAll() = %v, want none detected", got)
+	}
+	if got := AllProtectedDirs(); !slices.Equal(got, []string{".built-in"}) {
+		t.Errorf("AllProtectedDirs() = %v, want the built-in's dirs", got)
+	}
+	if got := AllProtectedFiles(); len(got) != 0 {
+		t.Errorf("AllProtectedFiles() = %v, want none", got)
+	}
 }

--- a/cmd/entire/cli/agent/registry_test.go
+++ b/cmd/entire/cli/agent/registry_test.go
@@ -51,6 +51,9 @@ func TestRegistryOperations(t *testing.T) {
 		if !strings.Contains(err.Error(), "unknown agent") {
 			t.Errorf("expected 'unknown agent' in error, got: %v", err)
 		}
+		if !errors.Is(err, ErrUnknownAgent) {
+			t.Errorf("Get() error = %v, want ErrUnknownAgent", err)
+		}
 	})
 
 	t.Run("List returns registered agents", func(t *testing.T) {
@@ -506,6 +509,24 @@ func TestExternalFailures_SortedSnapshot(t *testing.T) {
 	}
 	if failures[0].Binary != "/bin/entire-agent-abe" {
 		t.Errorf("ExternalFailures()[0].Binary = %q, want the discovered path", failures[0].Binary)
+	}
+}
+
+func TestExternalFailureFor(t *testing.T) {
+	snapshotRegistry(t)
+
+	loadErr := errors.New("boom")
+	RegisterExternalFailure("broken", "/bin/entire-agent-broken", loadErr)
+
+	failure, ok := ExternalFailureFor("broken")
+	if !ok {
+		t.Fatal("ExternalFailureFor() ok = false, want true")
+	}
+	if failure.Binary != "/bin/entire-agent-broken" || !errors.Is(failure.Err, loadErr) {
+		t.Errorf("ExternalFailureFor() = %+v, want recorded path and error", failure)
+	}
+	if _, ok := ExternalFailureFor("missing"); ok {
+		t.Error("ExternalFailureFor(missing) ok = true, want false")
 	}
 }
 

--- a/cmd/entire/cli/agent/testutil/externalagent.go
+++ b/cmd/entire/cli/agent/testutil/externalagent.go
@@ -1,28 +1,13 @@
 package testutil
 
 import (
-	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 )
 
 // WriteExternalAgentBinary writes an executable entire-agent-<name> into dir and
 // returns its path.
-//
-// It then runs the binary's `info` subcommand once and discards the result. That
-// warm-up is what makes the test reliable: external agent discovery gives each
-// binary a short budget (a few hundred milliseconds), and the *first* exec of a
-// freshly written file is far slower than later ones — on macOS it pays
-// code-signing validation and cold page-in, measured at 320-394ms sequentially
-// and over a second when several such binaries start at once. Without the
-// warm-up, a perfectly healthy mock intermittently fails to load and the test
-// looks like a discovery bug.
-//
-// Warming is deliberately not a fix for the budget itself: a real user
-// installing a plugin gets no warm-up, and hits exactly the cold path this
-// avoids.
 func WriteExternalAgentBinary(t *testing.T, dir, name, script string) string {
 	t.Helper()
 
@@ -30,9 +15,5 @@ func WriteExternalAgentBinary(t *testing.T, dir, name, script string) string {
 	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil { //nolint:gosec // test fixture must be executable
 		t.Fatalf("write external agent mock %q: %v", binPath, err)
 	}
-	// Best-effort: some mocks intentionally fail `info`, and that is the
-	// scenario under test, not a setup error.
-	//nolint:errcheck // the exit status is irrelevant; this call exists only to pay the cold-start cost
-	_ = exec.CommandContext(context.Background(), binPath, "info").Run()
 	return binPath
 }

--- a/cmd/entire/cli/agent/testutil/externalagent.go
+++ b/cmd/entire/cli/agent/testutil/externalagent.go
@@ -1,0 +1,38 @@
+package testutil
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// WriteExternalAgentBinary writes an executable entire-agent-<name> into dir and
+// returns its path.
+//
+// It then runs the binary's `info` subcommand once and discards the result. That
+// warm-up is what makes the test reliable: external agent discovery gives each
+// binary a short budget (a few hundred milliseconds), and the *first* exec of a
+// freshly written file is far slower than later ones — on macOS it pays
+// code-signing validation and cold page-in, measured at 320-394ms sequentially
+// and over a second when several such binaries start at once. Without the
+// warm-up, a perfectly healthy mock intermittently fails to load and the test
+// looks like a discovery bug.
+//
+// Warming is deliberately not a fix for the budget itself: a real user
+// installing a plugin gets no warm-up, and hits exactly the cold path this
+// avoids.
+func WriteExternalAgentBinary(t *testing.T, dir, name, script string) string {
+	t.Helper()
+
+	binPath := filepath.Join(dir, "entire-agent-"+name)
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil { //nolint:gosec // test fixture must be executable
+		t.Fatalf("write external agent mock %q: %v", binPath, err)
+	}
+	// Best-effort: some mocks intentionally fail `info`, and that is the
+	// scenario under test, not a setup error.
+	//nolint:errcheck // the exit status is irrelevant; this call exists only to pay the cold-start cost
+	_ = exec.CommandContext(context.Background(), binPath, "info").Run()
+	return binPath
+}

--- a/cmd/entire/cli/agent/testutil/externalagent_test.go
+++ b/cmd/entire/cli/agent/testutil/externalagent_test.go
@@ -1,0 +1,21 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteExternalAgentBinary_DoesNotExecuteBinary(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "executed")
+	script := "#!/bin/sh\n: > " + marker + "\n"
+
+	WriteExternalAgentBinary(t, dir, "no-warmup", script)
+
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("WriteExternalAgentBinary executed the fixture, stat error = %v", err)
+	}
+}

--- a/cmd/entire/cli/agent_group.go
+++ b/cmd/entire/cli/agent_group.go
@@ -126,10 +126,12 @@ Examples:
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
+			if err := external.DiscoverAndRegisterNamedAlways(cmd.Context(), types.AgentName(name)); err != nil {
+				return printAgentLookupError(cmd.OutOrStdout(), name, err)
+			}
 			ag, err := agent.Get(types.AgentName(name))
 			if err != nil {
-				printWrongAgentError(cmd.OutOrStdout(), name)
-				return NewSilentError(errors.New("wrong agent name"))
+				return printAgentLookupError(cmd.OutOrStdout(), name, err)
 			}
 			opts := EnableOptions{
 				ForceHooks:     forceHooks,

--- a/cmd/entire/cli/agent_group.go
+++ b/cmd/entire/cli/agent_group.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -66,6 +67,12 @@ func newAgentListCmd() *cobra.Command {
 }
 
 func runAgentList(ctx context.Context, w io.Writer) error {
+	// Discover external plugins so they appear here at all. Always, not the
+	// gated variant: a listing command should show what is actually on $PATH
+	// regardless of the external_agents setting, the same reasoning runSetupFlow
+	// uses.
+	external.DiscoverAndRegisterAlways(ctx)
+
 	installed := GetAgentsWithHooksInstalled(ctx)
 	installedSet := make(map[types.AgentName]struct{}, len(installed))
 	for _, name := range installed {
@@ -85,7 +92,22 @@ func runAgentList(ctx context.Context, w io.Writer) error {
 	if len(installed) == 0 {
 		fmt.Fprintln(w, "\nNo agents installed. Use 'entire agent add <name>' to install hooks.")
 	}
+	printBrokenExternalAgents(w)
 	return nil
+}
+
+// printBrokenExternalAgents lists external agent binaries found on $PATH that
+// could not be loaded, so an installed-but-unusable plugin is visible instead of
+// looking like it was never installed.
+func printBrokenExternalAgents(w io.Writer) {
+	failures := agent.ExternalFailures()
+	if len(failures) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "\nBroken external agents:")
+	for _, f := range failures {
+		fmt.Fprintf(w, "  ✗ %s  (%s): %v\n", f.Name, f.Binary, f.Err)
+	}
 }
 
 func newAgentAddCmd() *cobra.Command {

--- a/cmd/entire/cli/agent_group_test.go
+++ b/cmd/entire/cli/agent_group_test.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	agenttestutil "github.com/entireio/cli/cmd/entire/cli/agent/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
@@ -80,5 +82,46 @@ func TestAgentGroupBareCommandRunsAgentMenu(t *testing.T) {
 	}
 	if strings.Contains(out, "Usage:") {
 		t.Fatalf("bare agent command should not fall through to help, got:\n%s", out)
+	}
+}
+
+// TestRunAgentList_ShowsBrokenExternalAgents covers the payoff of recording
+// discovery failures: a plugin the user installed but that cannot be loaded is
+// named, with its reason, instead of silently missing from the listing.
+//
+// Not parallel: it sets PATH and mutates the process-wide agent registry.
+func TestRunAgentList_ShowsBrokenExternalAgents(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	agent.ResetExternalsForTesting()
+	t.Cleanup(agent.ResetExternalsForTesting)
+
+	dir := t.TempDir()
+	readyName := "list-ready-ext"
+	brokenName := "list-broken-ext"
+	agenttestutil.WriteExternalAgentBinary(t, dir, readyName, "#!/bin/sh\ncase \"$1\" in info) echo '"+
+		`{"protocol_version":1,"name":"`+readyName+`","type":"Ready Ext","description":"d","is_preview":false,"protected_dirs":[],"hook_names":[],"capabilities":{}}`+
+		"' ;; esac\n")
+	brokenPath := agenttestutil.WriteExternalAgentBinary(t, dir, brokenName, "#!/bin/sh\necho 'not json'\n")
+	t.Setenv("PATH", dir)
+
+	var buf bytes.Buffer
+	if err := runAgentList(context.Background(), &buf); err != nil {
+		t.Fatalf("runAgentList: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, readyName) {
+		t.Errorf("ready external agent %q missing from the listing:\n%s", readyName, out)
+	}
+	if !strings.Contains(out, "Broken external agents:") {
+		t.Errorf("missing broken-agent section:\n%s", out)
+	}
+	if !strings.Contains(out, brokenPath) {
+		t.Errorf("broken agent listed without its binary path:\n%s", out)
+	}
+	if !strings.Contains(out, "invalid JSON") {
+		t.Errorf("broken agent listed without a reason:\n%s", out)
 	}
 }

--- a/cmd/entire/cli/agent_group_test.go
+++ b/cmd/entire/cli/agent_group_test.go
@@ -125,3 +125,32 @@ func TestRunAgentList_ShowsBrokenExternalAgents(t *testing.T) {
 		t.Errorf("broken agent listed without a reason:\n%s", out)
 	}
 }
+
+func TestAgentAdd_ReportsBrokenExternalAgentError(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	agent.ResetExternalsForTesting()
+	t.Cleanup(agent.ResetExternalsForTesting)
+
+	name := "add-broken-ext"
+	dir := t.TempDir()
+	agenttestutil.WriteExternalAgentBinary(t, dir, name, "#!/bin/sh\necho 'not json'\n")
+	t.Setenv("PATH", dir)
+
+	cmd := newAgentAddCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{name})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("agent add error = nil, want broken external agent error")
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "invalid JSON") {
+		t.Errorf("agent add output omitted the load error:\n%s", out)
+	}
+	if strings.Contains(out, "Unknown agent") {
+		t.Errorf("agent add mislabeled a known broken plugin as unknown:\n%s", out)
+	}
+}

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid" // register agent
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"      // register agent
 	piagent "github.com/entireio/cli/cmd/entire/cli/agent/pi"
+	agenttestutil "github.com/entireio/cli/cmd/entire/cli/agent/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
@@ -2102,7 +2103,6 @@ func TestAttach_DiscoversExternalAgents(t *testing.T) {
 	agentName := types.AgentName("attachtest-discovery-agent")
 
 	binDir := t.TempDir()
-	binPath := filepath.Join(binDir, "entire-agent-"+string(agentName))
 	infoJSON := `{
   "protocol_version": 1,
   "name": "` + string(agentName) + `",
@@ -2114,9 +2114,7 @@ func TestAttach_DiscoversExternalAgents(t *testing.T) {
   "capabilities": {}
 }`
 	script := "#!/bin/sh\nif [ \"$1\" = \"info\" ]; then\n  echo '" + infoJSON + "'\nfi\n"
-	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("failed to write mock agent binary: %v", err)
-	}
+	agenttestutil.WriteExternalAgentBinary(t, binDir, string(agentName), script)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	cmd := newAttachCmd()

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -18,6 +18,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+	agenttestutil "github.com/entireio/cli/cmd/entire/cli/agent/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
@@ -994,7 +995,7 @@ case "$1" in
     ;;
 esac
 `
-	require.NoError(t, os.WriteFile(filepath.Join(externalDir, "entire-agent-"+name), []byte(script), 0o755))
+	agenttestutil.WriteExternalAgentBinary(t, externalDir, name, script)
 	t.Setenv("PATH", externalDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	got := maybeCompactExternalTranscript(ctx, []byte("not-json"), kind)
@@ -2258,7 +2259,7 @@ case "$1" in
 esac
 `
 	externalDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(externalDir, "entire-agent-"+opts.name), []byte(script), 0o755))
+	agenttestutil.WriteExternalAgentBinary(t, externalDir, opts.name, script)
 	t.Setenv("PATH", externalDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 

--- a/cmd/entire/cli/hooks_git_cmd_test.go
+++ b/cmd/entire/cli/hooks_git_cmd_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	agenttestutil "github.com/entireio/cli/cmd/entire/cli/agent/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -144,7 +145,6 @@ func TestHooksGitCmd_DiscoverExternalAgents_WhenEnabled(t *testing.T) {
 	// Use a unique name to avoid conflicts with agents registered by other tests.
 	agentName := types.AgentName("hooktest-discovery-agent")
 	binDir := t.TempDir()
-	binPath := filepath.Join(binDir, "entire-agent-"+string(agentName))
 	infoJSON := `{
   "protocol_version": 1,
   "name": "` + string(agentName) + `",
@@ -156,9 +156,7 @@ func TestHooksGitCmd_DiscoverExternalAgents_WhenEnabled(t *testing.T) {
   "capabilities": {}
 }`
 	script := "#!/bin/sh\nif [ \"$1\" = \"info\" ]; then\n  echo '" + infoJSON + "'\nfi\n"
-	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("failed to write mock agent binary: %v", err)
-	}
+	agenttestutil.WriteExternalAgentBinary(t, binDir, string(agentName), script)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	// Execute the git hook command (post-commit) so PersistentPreRunE runs

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -902,8 +902,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 			if agentName != "" {
 				ag, err := agent.Get(types.AgentName(agentName))
 				if err != nil {
-					printWrongAgentError(cmd.ErrOrStderr(), agentName)
-					return NewSilentError(errors.New("wrong agent name"))
+					return printAgentLookupError(cmd.ErrOrStderr(), agentName, err)
 				}
 				selectedAgent = ag
 			}
@@ -1585,10 +1584,12 @@ func localExists(ctx context.Context) bool {
 
 // runRemoveAgent removes hooks for a specific agent.
 func runRemoveAgent(ctx context.Context, w io.Writer, name string) error {
+	if err := external.DiscoverAndRegisterNamedAlways(ctx, types.AgentName(name)); err != nil {
+		return printAgentLookupError(w, name, err)
+	}
 	ag, err := agent.Get(types.AgentName(name))
 	if err != nil {
-		printWrongAgentError(w, name)
-		return NewSilentError(errors.New("wrong agent name"))
+		return printAgentLookupError(w, name, err)
 	}
 
 	hookAgent, ok := agent.AsHookSupport(ag)
@@ -1868,6 +1869,15 @@ func printMissingAgentError(w io.Writer) {
 // printWrongAgentError writes a helpful error when an unknown agent name is provided.
 func printWrongAgentError(w io.Writer, name string) {
 	printAgentError(w, fmt.Sprintf("Unknown agent %q.", name))
+}
+
+func printAgentLookupError(w io.Writer, name string, err error) error {
+	if errors.Is(err, agent.ErrUnknownAgent) {
+		printWrongAgentError(w, name)
+		return NewSilentError(errors.New("wrong agent name"))
+	}
+	fmt.Fprintf(w, "Agent %q is unavailable: %v\n", name, err)
+	return NewSilentError(err)
 }
 
 // setupAgentHooksNonInteractive sets up hooks for a specific agent non-interactively.

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
+	agenttestutil "github.com/entireio/cli/cmd/entire/cli/agent/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
@@ -161,9 +162,7 @@ case "$1" in
 esac
 `
 
-	if err := os.WriteFile(filepath.Join(dir, "entire-agent-"+name), []byte(script), 0o755); err != nil {
-		t.Fatalf("Failed to write external agent binary: %v", err)
-	}
+	agenttestutil.WriteExternalAgentBinary(t, dir, name, script)
 }
 
 func writeExternalSummaryAgentBinary(t *testing.T, dir, name string) {
@@ -189,9 +188,7 @@ case "$1" in
 esac
 `
 
-	if err := os.WriteFile(filepath.Join(dir, "entire-agent-"+name), []byte(script), 0o755); err != nil {
-		t.Fatalf("Failed to write external summary agent binary: %v", err)
-	}
+	agenttestutil.WriteExternalAgentBinary(t, dir, name, script)
 }
 
 func TestRunEnable(t *testing.T) {

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	agenttestutil "github.com/entireio/cli/cmd/entire/cli/agent/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
@@ -64,9 +65,7 @@ case "$1" in
 esac
 `
 
-	if err := os.WriteFile(filepath.Join(dir, "entire-agent-"+name), []byte(script), 0o755); err != nil {
-		t.Fatalf("write external summary agent binary: %v", err)
-	}
+	agenttestutil.WriteExternalAgentBinary(t, dir, name, script)
 }
 func TestCalculateTokenUsage_CursorAlwaysNil(t *testing.T) {
 	t.Parallel()

--- a/docs/architecture/external-agent-protocol.md
+++ b/docs/architecture/external-agent-protocol.md
@@ -8,9 +8,12 @@ The Entire CLI supports external agent plugins — standalone binaries that impl
 
 The CLI discovers external agents by scanning `$PATH` for executables matching the pattern `entire-agent-<name>`. For example, `entire-agent-cursor` would register as the "cursor" agent.
 
-- Binaries whose `<name>` conflicts with an already-registered built-in agent are skipped.
-- Discovery runs once during CLI initialization (before building the hooks command tree).
 - The binary must be executable and respond to the `info` subcommand.
+- Discovery runs lazily, per command, not once at startup. Most commands gate it on the `external_agents` setting; setup flows and `entire agent list` always run it.
+- Every candidate binary is asked for its `info` concurrently, each under its own short budget, so one slow plugin cannot delay or crowd out the others.
+- Binaries whose `<name>` conflicts with an already-registered agent are skipped **without being executed**, and the attempt is logged as a warning. A built-in always wins: discovery also runs inside the git and agent hook trees, so allowing an override would let a binary dropped anywhere on `$PATH` take over transcript reads and checkpoint writes.
+- When two directories offer the same agent, the earlier `$PATH` entry wins. On Windows this is decided on the derived agent name, so `entire-agent-foo.exe` and `entire-agent-foo.com` cannot both claim `foo`.
+- A binary is asked for `info` at most once per CLI process, whether it loaded or not.
 
 ## Environment
 
@@ -20,6 +23,7 @@ Every subcommand invocation sets:
 |---|---|
 | `ENTIRE_REPO_ROOT` | Absolute path to the git repository root |
 | `ENTIRE_PROTOCOL_VERSION` | Protocol version (`1`) |
+| `ENTIRE_CLI_VERSION` | Version of the `entire` CLI making the call |
 
 The working directory is set to the repository root.
 
@@ -553,8 +557,9 @@ Returned by `parse-hook`. Represents a normalized lifecycle event.
 - Any non-zero exit code indicates an error.
 - Error messages should be written to stderr.
 - The CLI captures stderr and wraps it in a Go error.
-- If the binary is not found in PATH, the agent is simply not registered.
-- If `info` fails or returns invalid JSON, the binary is skipped during discovery.
+- If the binary is not found in PATH, the agent is simply not registered. A missing binary is not an error.
+- If `info` fails, returns invalid JSON, exceeds its budget, or reports a mismatched protocol version, the binary is recorded as a **broken external agent**: it is not usable, `entire agent list` names it with the reason, and resolving it by name reports that reason instead of "unknown agent". The same applies to a match that turns out to be a directory or to lack the executable bit.
+- A binary whose `info` reports a `name` different from its file name still works. The registry key always comes from the file name, and a warning records the discrepancy.
 
 ## Versioning
 

--- a/docs/architecture/external-commands.md
+++ b/docs/architecture/external-commands.md
@@ -264,7 +264,7 @@ Once allowlisted, `cli_plugin_executed` events for that command will flow throug
 | | External Commands | [Agent Protocol](external-agent-protocol.md) |
 |---|---|---|
 | **Binary name pattern** | `entire-<name>` | `entire-agent-<name>` |
-| **Discovery** | Lazy, on first non-built-in arg | Lazy at command entry, gated by `external_agents` setting (setup flows bypass the gate via `DiscoverAndRegisterAlways`) |
+| **Discovery** | Lazy, on first non-built-in arg | Lazy at command entry, all candidates probed concurrently under a per-binary budget, gated by `external_agents` setting (setup flows and `entire agent list` bypass the gate via `DiscoverAndRegisterAlways`). A binary that cannot be loaded is recorded and shown by `entire agent list` |
 | **Communication** | Process exec; stdio passthrough | Subcommand protocol; JSON over stdin/stdout |
 | **Versioning** | None | `ENTIRE_PROTOCOL_VERSION` envelope |
 | **Lifecycle integration** | None | Full (sessions, checkpoints, hooks, transcripts) |

--- a/docs/external-agents/claude-version.md
+++ b/docs/external-agents/claude-version.md
@@ -269,6 +269,14 @@ Measured on macOS (Apple silicon), forking a freshly written shell script:
 | Each further *newly written* file, same process | 140–170ms |
 | Re-exec of a file already run once | 7–12ms |
 | `paths.WorktreeRoot` shelling out to git, *inside* the budget | ~13ms |
+| Five freshly written files exec'd **concurrently** | >1000ms each |
+
+That last row was measured while implementing this plan, and it is worse than
+the sequential numbers suggest: cold starts contend with each other, so the very
+parallelism that fixes the serialization problem also makes the first-run cost
+spike. A healthy mock breached a **1s** budget while four neighbours were
+starting cold. Two tests therefore execute their mock once before the measured
+call, to keep cold-start cost out of the budget under test.
 
 The cost is dominated by **first exec of a given binary**, not process warm-up:
 on macOS a newly installed binary pays code-signing / Gatekeeper validation and
@@ -281,11 +289,20 @@ cold page-in on its first run. Consequences:
   strictly slower to start than the `sh` script measured above.
 - **Every test that writes a mock agent into a fresh `t.TempDir()` hits the cold
   path.** At 300ms essentially every discovery test that execs a mock fails.
-  This is not a test bug; do not "fix" it by loosening assertions. Make
-  `infoTimeout` a package `var` and have those tests raise it (~2s), keeping the
-  shipped default at 300ms for the requester to tune.
+  This is not a test bug; do not "fix" it by loosening assertions. `infoTimeout`
+  is a package `var` so those tests can raise it, keeping the shipped default at
+  300ms for the requester to tune. Where the budget itself is what a test
+  measures, warm the mock with one throwaway exec instead of raising it.
 - `Agent.run` additionally calls `paths.WorktreeRoot(ctx)`, which can shell out
   to git (~13ms) *inside* the budget, before the plugin is even executed.
+- **Four pre-existing tests broke on the budget alone.** The
+  `TestRunExplain*ExternalNativeTranscript` cases each write a mock agent into a
+  fresh `t.TempDir()` and rely on discovery to find it. They passed in isolation
+  and failed in a full package run, purely because the cold exec exceeded 300ms
+  under load. Nothing about those tests is wrong; the budget is. They pass now
+  only because every test that writes a mock goes through
+  `agenttestutil.WriteExternalAgentBinary`, which warms the binary first — a
+  luxury no real user gets on their first command after installing a plugin.
 
 Whatever value is chosen, `ErrInfoTimeout` must stay distinguishable from a
 genuine load failure.

--- a/docs/external-agents/claude-version.md
+++ b/docs/external-agents/claude-version.md
@@ -204,12 +204,12 @@ re-runs the command.
 
 ## Decisions
 
-### 1. `infoTimeout = 300 * time.Millisecond`, provisional
+### 1. `infoTimeout = 10 * time.Second`
 
 One named constant for both entry points, replacing the 10s aggregate budget.
-The requester owns this number and intends to tune it — see
-[the budget warning](#-the-300ms-budget-is-measured-to-be-too-small) before
-writing tests.
+The value covers cold starts on a saturated machine while keeping the existing
+worst-case wait. Probes run concurrently, so several stalled plugins cost
+roughly one 10s budget rather than one budget each.
 
 ### 2. A built-in always wins a name collision
 
@@ -249,17 +249,17 @@ the binary itself, so the hook command it writes is the plugin's own
 responsibility. Making it an error would break any out-of-tree plugin that
 already has one.
 
-### 5. `DiscoverAndRegisterNamedAlways` drops from 10s to 300ms
+### 5. `DiscoverAndRegisterNamedAlways` uses the same 10s budget
 
-Confirmed. It shares the budget with the scan path. Its only production caller
-is the `--summarize-provider` / dispatch override, and that is still just an
-`info` call.
+It shares the budget with the scan path. The `--summarize-provider` override and
+the explicit `agent add` / `agent remove` paths use it so they probe only the
+named plugin and can report its stored load error.
 
-## ⚠ The 300ms budget is measured to be too small
+## Why the budget is 10s
 
-The requester owns this number and intends to tune it, so it is **not** a
-blocker. But it was measured, and at 300ms the design does not work on a cold
-binary. Do not rediscover this from failing tests.
+The provisional 300ms budget did not work for a cold binary. The implementation
+keeps the previous 10s aggregate allowance, but applies it per binary in
+parallel, based on these measurements.
 
 Measured on macOS (Apple silicon), forking a freshly written shell script:
 
@@ -271,38 +271,18 @@ Measured on macOS (Apple silicon), forking a freshly written shell script:
 | `paths.WorktreeRoot` shelling out to git, *inside* the budget | ~13ms |
 | Five freshly written files exec'd **concurrently** | >1000ms each |
 
-That last row was measured while implementing this plan, and it is worse than
-the sequential numbers suggest: cold starts contend with each other, so the very
-parallelism that fixes the serialization problem also makes the first-run cost
-spike. A healthy mock breached a **1s** budget while four neighbours were
-starting cold. Two tests therefore execute their mock once before the measured
-call, to keep cold-start cost out of the budget under test.
+Cold starts contend with each other, so concurrent first runs can take longer
+than the sequential measurements suggest. A healthy mock breached a 1s budget
+while four neighbours were starting cold. Under the full race suite, healthy
+fixtures also exceeded 5s. The 10s default leaves room for that case without
+making tests or users warm a binary before discovery.
 
-The cost is dominated by **first exec of a given binary**, not process warm-up:
-on macOS a newly installed binary pays code-signing / Gatekeeper validation and
-cold page-in on its first run. Consequences:
-
-- A user who has just installed a plugin gets a failure entry with
-  `ErrInfoTimeout` on the very first `entire` command, and a working plugin from
-  then on. That is the worst possible first impression, and it is intermittent.
-- A real plugin is a compiled binary or, worse, a Node/Python wrapper — both
-  strictly slower to start than the `sh` script measured above.
-- **Every test that writes a mock agent into a fresh `t.TempDir()` hits the cold
-  path.** At 300ms essentially every discovery test that execs a mock fails.
-  This is not a test bug; do not "fix" it by loosening assertions. `infoTimeout`
-  is a package `var` so those tests can raise it, keeping the shipped default at
-  300ms for the requester to tune. Where the budget itself is what a test
-  measures, warm the mock with one throwaway exec instead of raising it.
-- `Agent.run` additionally calls `paths.WorktreeRoot(ctx)`, which can shell out
-  to git (~13ms) *inside* the budget, before the plugin is even executed.
-- **Four pre-existing tests broke on the budget alone.** The
-  `TestRunExplain*ExternalNativeTranscript` cases each write a mock agent into a
-  fresh `t.TempDir()` and rely on discovery to find it. They passed in isolation
-  and failed in a full package run, purely because the cold exec exceeded 300ms
-  under load. Nothing about those tests is wrong; the budget is. They pass now
-  only because every test that writes a mock goes through
-  `agenttestutil.WriteExternalAgentBinary`, which warms the binary first — a
-  luxury no real user gets on their first command after installing a plugin.
+The first execution of a newly installed binary pays code-signing validation
+and cold page-in on macOS. Compiled plugins and Node or Python wrappers may take
+longer than the shell fixture measured above. `Agent.run` also calls
+`paths.WorktreeRoot(ctx)` inside the budget. Tests therefore execute fresh
+binaries without a hidden warm-up; timeout-specific tests override
+`infoTimeout` with a smaller value.
 
 Whatever value is chosen, `ErrInfoTimeout` must stay distinguishable from a
 genuine load failure.
@@ -316,8 +296,9 @@ constraint and its existing comment. Reuse the existing `setupDiscoveryDir`,
 
 Two constraints that will otherwise waste a debugging cycle:
 
-- **Every mock agent written into a fresh `t.TempDir()` is a cold exec** —
-  140–400ms on macOS. Raise `infoTimeout` in any test that execs one.
+- **Every mock agent written into a fresh `t.TempDir()` is a cold exec.** Do not
+  warm it in a shared fixture helper. Timeout-specific tests can override
+  `infoTimeout`; other tests should exercise the same cold path users get.
 - **Reset external registry entries between tests** via
   `ResetExternalsForTesting` in `t.Cleanup`. Without it, discovery results leak
   across tests and the memoization skip makes failures depend on test order.
@@ -411,12 +392,14 @@ naming the shadowing binary.
   `resume.go:66`, `checkpoint_resume.go:62`, `attach.go:116`,
   `explain.go:1118`, `review/cmd.go:193`, `trail_resume_cmd.go:165`,
   `strategy/manual_commit_condensation.go:40`
-- `DiscoverAndRegisterNamedAlways` — `explain_summary_provider.go:31`
+- `DiscoverAndRegisterNamedAlways` — `explain_summary_provider.go:31`,
+  `agent_group.go`, `setup.go` (`agent add` / `agent remove`)
 
 The gated path running in hooks is why
 [decision 2](#2-a-built-in-always-wins-a-name-collision) went the way it did.
-Signatures do not change, so no call site needs editing —
-`runAgentList` gains a call it did not have.
+The discovery signatures stay unchanged. `runAgentList`, `agent add`, and
+`agent remove` gain calls so their user-facing output includes external agents
+and their load failures.
 
 ## Documentation
 
@@ -431,8 +414,7 @@ Signatures do not change, so no call site needs editing —
 
 ## Out of scope
 
-- Retuning `infoTimeout`. The requester owns it; the measured table above is the
-  input.
+- Further tuning of `infoTimeout` beyond the measured 10s default.
 - Turning an `info.name` / binary-suffix mismatch into a hard error.
 - Surfacing broken externals in `entire status` and its `--json` output.
 - Pruning the redundant `DiscoverAndRegisterAlways` call sites in `setup.go`.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1150
<!-- entire-trail-link-end -->

Stacked on #2134, which contains the two implementation plans. This PR implements the `claude-version.md` design and incorporates the follow-up review fixes.

## Summary

External agent discovery now collects candidates without executing them, probes each binary concurrently under its own budget, and applies results in stable PATH order. A slow or broken plugin no longer blocks later plugins, and load failures remain visible instead of disappearing into debug logs.

## What changed

- Store usable and broken external agents in the central agent registry. Registry walks still expose only usable agents, while `agent.Get` can return a recorded load failure.
- Show broken plugins and their reasons in `entire agent list`.
- Make `agent add`, `agent remove`, and explicit setup paths preserve load diagnostics instead of calling a known broken plugin "unknown".
- Probe a failed named binary at most once per process. A different binary path with the same name may still be tried.
- Let an invalid earlier PATH match, such as a directory or non-executable file, fall through to a runnable binary later on PATH. If no runnable binary exists, retain the first static failure for diagnostics.
- Keep built-ins protected from PATH shadowing without executing the colliding binary.
- Use a 10-second per-binary `info` budget. Probes run concurrently, so the aggregate bound remains roughly one budget. The earlier 300ms and 2s values failed on cold binaries, and healthy fixtures exceeded 5s under the full race suite.
- Remove fixture warm-ups. Tests now execute fresh binaries through the same cold-start path users get.
- Add typed unknown-agent classification so callers can distinguish absent names from installed but unloadable plugins.

## Verification

- `mise run fmt`
- mise lint components plus golangci-lint v2.11.3, 0 issues
- `mise run test:ci`
  - full unit and integration suite with race detection
  - Vogon canary, 56 passed
  - roger-roger external-agent canary, 4 passed
