### PR TITLE
feat(search): continuous scroll and arrow-key type tabs in the search TUI

### DIFF
--- a/cmd/entire/cli/keys.go
+++ b/cmd/entire/cli/keys.go
@@ -6,16 +6,16 @@ import "charm.land/bubbles/v2/key"
 // truth so help text and matching logic stay aligned, and so the strings "esc",
 // "ctrl+c", etc. live in exactly one place.
 type keyMap struct {
-	Quit     key.Binding
-	Back     key.Binding
-	Search   key.Binding
-	Confirm  key.Binding
-	Up       key.Binding
-	Down     key.Binding
-	NextPage key.Binding
-	PrevPage key.Binding
-	Home     key.Binding
-	End      key.Binding
+	Quit    key.Binding
+	Back    key.Binding
+	Search  key.Binding
+	Confirm key.Binding
+	Up      key.Binding
+	Down    key.Binding
+	NextTab key.Binding
+	PrevTab key.Binding
+	Home    key.Binding
+	End     key.Binding
 }
 
 var keys = keyMap{
@@ -43,13 +43,13 @@ var keys = keyMap{
 		key.WithKeys("down", "j"),
 		key.WithHelp("↓/j", "down"),
 	),
-	NextPage: key.NewBinding(
-		key.WithKeys("n", "right"),
-		key.WithHelp("n/→", "next page"),
+	NextTab: key.NewBinding(
+		key.WithKeys("right", "tab"),
+		key.WithHelp("→", "next type"),
 	),
-	PrevPage: key.NewBinding(
-		key.WithKeys("p", "left"),
-		key.WithHelp("p/←", "prev page"),
+	PrevTab: key.NewBinding(
+		key.WithKeys("left", "shift+tab"),
+		key.WithHelp("←", "prev type"),
 	),
 	Home: key.NewBinding(
 		key.WithKeys("home", "g"),

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -112,7 +112,13 @@ func (s searchStyles) helpItem(keyLabel, desc string) string {
 	return s.render(s.helpKey, keyLabel) + " " + desc
 }
 
+// resultsPerPage is the page size of the non-interactive (JSON) output modes.
+// The TUI itself scrolls continuously and does not page.
 const resultsPerPage = 10
+
+// fetchAheadRows is how close to the end of the loaded list the cursor may get
+// before the next API page is fetched, so continuous scroll stays smooth.
+const fetchAheadRows = 3
 
 // typeFilter represents the active type tab in the TUI.
 type typeFilter string
@@ -120,7 +126,7 @@ type typeFilter string
 const (
 	// typeFilterAll is no longer user-selectable in the TUI (no "All" tab), but
 	// remains the internal sentinel for "show every loaded result" used by the
-	// pagination/fetch-more math that reasons about the grand result total.
+	// fetch-more math that reasons about the grand result total.
 	typeFilterAll         typeFilter = ""
 	typeFilterCheckpoints typeFilter = typeFilter(search.TypeCheckpoint)
 	typeFilterCommits     typeFilter = typeFilter(search.TypeCommit)
@@ -128,11 +134,13 @@ const (
 	typeFilterCode        typeFilter = "code"
 )
 
+// tabOrder is the left-to-right tab sequence cycled by the ←/→ keys.
+var tabOrder = []typeFilter{typeFilterCommits, typeFilterSessions, typeFilterCode}
+
 // searchModel is the bubbletea model for interactive search results.
 type searchModel struct {
 	results          []search.Result
-	cursor           int
-	page             int // 0-based display page index
+	cursor           int // index into the active tab's full loaded list
 	total            int
 	width            int
 	height           int
@@ -207,57 +215,27 @@ func (m searchModel) filteredResults() []search.Result {
 	return out
 }
 
-// pageResults returns the slice of results for the current page.
-func (m searchModel) pageResults() []search.Result {
-	filtered := m.filteredResults()
-	start := m.page * resultsPerPage
-	if start >= len(filtered) {
-		return nil
-	}
-	end := start + resultsPerPage
-	if end > len(filtered) {
-		end = len(filtered)
-	}
-	return filtered[start:end]
-}
-
-// codePageResults returns the slice of code results for the current page.
-func (m searchModel) codePageResults() []codesearch.Result {
-	start := m.page * resultsPerPage
-	if start >= len(m.codeResults) {
-		return nil
-	}
-	end := start + resultsPerPage
-	if end > len(m.codeResults) {
-		end = len(m.codeResults)
-	}
-	return m.codeResults[start:end]
-}
-
-// totalPages returns the number of pages based on the filtered result count.
-func (m searchModel) totalPages() int {
-	var n int
+// visibleCount returns the number of rows in the active tab's loaded list.
+func (m searchModel) visibleCount() int {
 	if m.filterType == typeFilterCode {
-		n = len(m.codeResults)
-	} else {
-		n = len(m.filteredResults())
-		// When showing all types, use the API total if it's larger than loaded results
-		// (we may not have fetched everything yet).
-		if m.filterType == typeFilterAll && m.total > n {
-			n = m.total
-		}
+		return len(m.codeResults)
 	}
-	if n == 0 {
-		return 1
-	}
-	return (n + resultsPerPage - 1) / resultsPerPage
+	return len(m.filteredResults())
 }
 
-// selectedResult returns the currently selected result, accounting for pagination.
+// selectedResult returns the currently selected result.
 func (m searchModel) selectedResult() *search.Result {
-	pageResults := m.pageResults()
-	if m.cursor >= 0 && m.cursor < len(pageResults) {
-		return &pageResults[m.cursor]
+	filtered := m.filteredResults()
+	if m.cursor >= 0 && m.cursor < len(filtered) {
+		return &filtered[m.cursor]
+	}
+	return nil
+}
+
+// selectedCodeResult returns the currently selected code result, or nil.
+func (m searchModel) selectedCodeResult() *codesearch.Result {
+	if m.cursor >= 0 && m.cursor < len(m.codeResults) {
+		return &m.codeResults[m.cursor]
 	}
 	return nil
 }
@@ -280,6 +258,24 @@ func (m searchModel) computeTypeCounts() (commits, sessions int) {
 		}
 	}
 	return
+}
+
+// tabTotal returns the active tab's server-side result count and whether it is
+// a lower bound. Falls back to the loaded count where no per-type total exists.
+func (m searchModel) tabTotal() (total int, lowerBound bool) {
+	cm, ss := m.computeTypeCounts()
+	switch m.filterType {
+	case typeFilterCommits:
+		return cm, m.countsLowerBound["commits"]
+	case typeFilterSessions:
+		return ss, m.countsLowerBound["sessions"] || m.countsLowerBound["checkpoints"]
+	case typeFilterAll:
+		return max(m.total, len(m.results)), false
+	case typeFilterCode, typeFilterCheckpoints:
+		return m.visibleCount(), false
+	default:
+		return m.visibleCount(), false
+	}
 }
 
 func newSearchModel(results []search.Result, query string, total int, cfg search.Config, ss statusStyles, codeOpts *codeSearchOpts) searchModel {
@@ -362,7 +358,6 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 		m.warning = strings.Join(msg.warnings, "; ")
 		m.apiPage = 1
 		m.cursor = 0
-		m.page = 0
 		m.browseVP.GotoTop()
 		m = m.refreshBrowseContent()
 		return m, nil
@@ -381,17 +376,14 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 		if len(msg.results) > 0 {
 			m.results = append(m.results, msg.results...)
 		} else {
-			// API returned no more results — cap total to what we have, and
-			// pull the display page back into range (paging forward advanced
-			// it optimistically before the fetch came back empty).
+			// API returned no more results — cap total so fetch-ahead stops asking.
 			m.total = len(m.results)
-			if last := m.totalPages() - 1; m.page > last {
-				m.page = last
-				m.cursor = 0
-			}
 		}
 		m = m.refreshBrowseContent()
-		return m, nil
+		// A fetched page may add nothing to the active tab (pages interleave
+		// types); keep fetching while the cursor still sits at the end and the
+		// server has more, so one keypress scrolls through sparse tabs too.
+		return m.withFetchAhead()
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -421,7 +413,6 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 		}
 		if m.filterType == typeFilterCode {
 			m.cursor = 0
-			m.page = 0
 			m.browseVP.GotoTop()
 		}
 		m = m.refreshBrowseContent()
@@ -535,106 +526,83 @@ func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 	return m, cmd
 }
 
-func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	// Type tab keys (1/2/3)
-	switch msg.String() {
-	case "1":
-		m.filterType = typeFilterCommits
-		m.cursor = 0
-		m.page = 0
-		m.browseVP.GotoTop()
-		m = m.refreshBrowseContent()
-		return m, nil
-	case "2":
-		m.filterType = typeFilterSessions
-		m.cursor = 0
-		m.page = 0
-		m.browseVP.GotoTop()
-		m = m.refreshBrowseContent()
-		return m, nil
-	case "3":
-		m.filterType = typeFilterCode
-		m.cursor = 0
-		m.page = 0
-		m.browseVP.GotoTop()
-		m = m.refreshBrowseContent()
-		return m, nil
-	}
+// switchTab activates a type tab and resets the list position.
+func (m searchModel) switchTab(f typeFilter) searchModel {
+	m.filterType = f
+	m.cursor = 0
+	m.browseVP.GotoTop()
+	return m.refreshBrowseContent()
+}
 
-	var pageLen int
-	if m.filterType == typeFilterCode {
-		pageLen = len(m.codePageResults())
-	} else {
-		pageLen = len(m.pageResults())
+// cycleTab moves the active tab left (delta -1) or right (+1) through
+// tabOrder, wrapping at the ends.
+func (m searchModel) cycleTab(delta int) searchModel {
+	for i, f := range tabOrder {
+		if f == m.filterType {
+			return m.switchTab(tabOrder[(i+delta+len(tabOrder))%len(tabOrder)])
+		}
 	}
+	// Internal filters (all/checkpoints) have no tab; snap to the first one.
+	return m.switchTab(tabOrder[0])
+}
+
+// withFetchAhead fires the next API page fetch when the cursor is near the end
+// of the loaded list and the server may have more results — the continuous
+// scroll counterpart of explicit paging.
+//
+// ponytail: the semantic total spans all types while tabs filter client-side,
+// so on a sparse tab this can fetch pages that add no visible rows (bounded by
+// the server total). The upgrade path is per-type server pagination.
+func (m searchModel) withFetchAhead() (tea.Model, tea.Cmd) {
+	if m.filterType == typeFilterCode || m.fetchingMore || m.loading {
+		return m, nil
+	}
+	if len(m.results) >= m.total {
+		return m, nil
+	}
+	if m.cursor < m.visibleCount()-fetchAheadRows {
+		return m, nil
+	}
+	m.fetchingMore = true
+	m = m.refreshBrowseContent()
+	return m, m.fetchMoreResults(m.searchCfg, m.apiPage+1)
+}
+
+func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, keys.Quit), key.Matches(msg, keys.Back), msg.String() == "h":
 		return m, tea.Quit
+	case key.Matches(msg, keys.NextTab):
+		return m.cycleTab(1), nil
+	case key.Matches(msg, keys.PrevTab):
+		return m.cycleTab(-1), nil
 	case key.Matches(msg, keys.Up):
 		if m.cursor > 0 {
 			m.cursor--
 			m = m.refreshBrowseContent()
 		}
 	case key.Matches(msg, keys.Down):
-		if m.cursor < pageLen-1 {
+		if m.cursor < m.visibleCount()-1 {
 			m.cursor++
 			m = m.refreshBrowseContent()
 		}
+		return m.withFetchAhead()
 	case key.Matches(msg, keys.Home):
-		m.page = 0
 		m.cursor = 0
 		m = m.refreshBrowseContent()
 		m.browseVP.GotoTop()
 	case key.Matches(msg, keys.End):
-		var totalItems int
-		if m.filterType == typeFilterCode {
-			totalItems = len(m.codeResults)
-		} else {
-			totalItems = len(m.filteredResults())
-		}
-		if totalItems > 0 {
-			lastLoaded := totalItems - 1
-			m.page = min(lastLoaded/resultsPerPage, m.totalPages()-1)
-			var lastPageLen int
-			if m.filterType == typeFilterCode {
-				lastPageLen = len(m.codePageResults())
-			} else {
-				lastPageLen = len(m.pageResults())
-			}
-			if lastPageLen > 0 {
-				m.cursor = lastPageLen - 1
-			}
+		if n := m.visibleCount(); n > 0 {
+			m.cursor = n - 1
 			m = m.refreshBrowseContent()
 			m.browseVP.GotoBottom()
 		}
-	case key.Matches(msg, keys.NextPage):
-		if m.page < m.totalPages()-1 {
-			m.page++
-			m.cursor = 0
-			m.browseVP.GotoTop()
-			// Fetch next API page if we've scrolled past loaded results
-			// (code search loads all results at once, no fetch-more).
-			start := m.page * resultsPerPage
-			if m.filterType != typeFilterCode && start >= len(m.filteredResults()) && !m.fetchingMore {
-				m.fetchingMore = true
-				m = m.refreshBrowseContent()
-				return m, m.fetchMoreResults(m.searchCfg, m.apiPage+1)
-			}
-			m = m.refreshBrowseContent()
-		}
-	case key.Matches(msg, keys.PrevPage):
-		if m.page > 0 {
-			m.page--
-			m.cursor = 0
-			m.browseVP.GotoTop()
-			m = m.refreshBrowseContent()
-		}
+		return m.withFetchAhead()
 	case key.Matches(msg, keys.Confirm):
 		if m.filterType == typeFilterCode {
-			codeResults := m.codePageResults()
-			if m.cursor >= 0 && m.cursor < len(codeResults) {
+			if r := m.selectedCodeResult(); r != nil {
 				m.mode = modeDetail
-				content := m.renderCodeDetail(codeResults[m.cursor], m.width, true)
+				content := m.renderCodeDetail(*r, m.width, true)
 				m.detailVP = viewport.New(viewport.WithWidth(m.width), viewport.WithHeight(max(m.height-2, 1)))
 				m.detailVP.SetContent(content)
 				return m, nil
@@ -818,16 +786,16 @@ func (m searchModel) viewSearchMode() string {
 func (m searchModel) viewTypeTabs() string {
 	cmCount, ssCount := m.computeTypeCounts()
 
-	renderTab := func(label string, filter typeFilter, count int, lowerBound bool, keyHint string) string {
+	renderTab := func(label string, filter typeFilter, count int, lowerBound bool) string {
 		suffix := ""
 		if lowerBound {
 			// The count is a lower bound — that facet's list was capped
 			// upstream. Same "+" the web renders (ENT-1777).
 			suffix = "+"
 		}
-		text := fmt.Sprintf("[%s] %s %d%s", keyHint, label, count, suffix)
+		text := fmt.Sprintf("%s %d%s", label, count, suffix)
 		if m.filterType == filter {
-			return m.styles.render(m.styles.tabActive, text)
+			return m.styles.render(m.styles.tabActive, "‹ "+text+" ›")
 		}
 		return m.styles.render(m.styles.tabInactive, text)
 	}
@@ -840,9 +808,9 @@ func (m searchModel) viewTypeTabs() string {
 	// Sessions ORs the checkpoints flag like the web: session rows fold in
 	// checkpoint hits, so a capped checkpoints list bounds sessions too.
 	tabs := []string{
-		renderTab("Commits", typeFilterCommits, cmCount, m.countsLowerBound["commits"], "1"),
-		renderTab("Sessions", typeFilterSessions, ssCount, m.countsLowerBound["sessions"] || m.countsLowerBound["checkpoints"], "2"),
-		renderTab("Code", typeFilterCode, len(m.codeResults), false, "3"),
+		renderTab("Commits", typeFilterCommits, cmCount, m.countsLowerBound["commits"]),
+		renderTab("Sessions", typeFilterSessions, ssCount, m.countsLowerBound["sessions"] || m.countsLowerBound["checkpoints"]),
+		renderTab("Code", typeFilterCode, len(m.codeResults), false),
 	}
 
 	return strings.Join(tabs, "  ")
@@ -907,11 +875,11 @@ func (m searchModel) viewBrowseHeader() (string, bool) {
 
 	filtered := m.filteredResults()
 	if len(filtered) == 0 {
-		b.WriteString("\n" + pad + m.styles.render(m.styles.dim, "No results for this type."))
-		return b.String(), false
-	}
-	if m.fetchingMore && m.pageResults() == nil {
-		b.WriteString("\n" + pad + m.styles.render(m.styles.dim, "Loading more results..."))
+		if m.fetchingMore {
+			b.WriteString("\n" + pad + m.styles.render(m.styles.dim, "Loading more results..."))
+		} else {
+			b.WriteString("\n" + pad + m.styles.render(m.styles.dim, "No results for this type."))
+		}
 		return b.String(), false
 	}
 
@@ -948,8 +916,7 @@ func (m searchModel) refreshBrowseContent() searchModel {
 func (m searchModel) detailPaneHeight(headerLines int) int {
 	hasSelection := m.selectedResult() != nil
 	if m.filterType == typeFilterCode {
-		codeResults := m.codePageResults()
-		hasSelection = m.cursor >= 0 && m.cursor < len(codeResults)
+		hasSelection = m.selectedCodeResult() != nil
 	}
 	if m.height <= 0 || !hasSelection {
 		return 0
@@ -1009,16 +976,20 @@ func (m searchModel) viewListStatusRow() string {
 		}
 	}
 
-	// Right: page X/Y · N results (drops the page clause for a single page).
-	var n int
-	if m.filterType == typeFilterCode {
-		n = len(m.codeResults)
-	} else {
-		n = len(m.filteredResults())
-	}
+	// Right: loaded count, with the tab's server-side total when more exist
+	// ("N of M results"; "+" marks a lower-bound count, matching the tabs).
+	n := m.visibleCount()
+	tabTotal, lb := m.tabTotal()
 	right := fmt.Sprintf("%d results", n)
-	if pages := m.totalPages(); pages > 1 {
-		right = fmt.Sprintf("page %d/%d · %d results", m.page+1, pages, n)
+	if tabTotal > n || lb {
+		suffix := ""
+		if lb {
+			suffix = "+"
+		}
+		right = fmt.Sprintf("%d of %d%s results", n, tabTotal, suffix)
+	}
+	if m.fetchingMore {
+		right = "loading more… · " + right
 	}
 	warning := m.warning
 	if m.filterType == typeFilterCode {
@@ -1061,7 +1032,7 @@ const (
 	detailGap = 1
 )
 
-// viewResultList renders the current page of results as a two-line list:
+// viewResultList renders the active tab's loaded results as a two-line list:
 // a type-colored graph node + bold title with a right-aligned relative age,
 // then a dim metadata line (type · repo · ⎇ branch · author). Items are
 // separated by a thin rule, mirroring the web activity list.
@@ -1073,8 +1044,7 @@ func (m searchModel) viewResultList() string {
 	rule := pad + m.styles.render(m.styles.dim, strings.Repeat("─", contentWidth)) + "\n"
 
 	if m.filterType == typeFilterCode {
-		codeResults := m.codePageResults()
-		for i, r := range codeResults {
+		for i, r := range m.codeResults {
 			if i > 0 {
 				b.WriteString(rule)
 			}
@@ -1083,7 +1053,7 @@ func (m searchModel) viewResultList() string {
 		return b.String()
 	}
 
-	results := m.pageResults()
+	results := m.filteredResults()
 	for i, r := range results {
 		if i > 0 {
 			b.WriteString(rule)
@@ -1492,8 +1462,7 @@ func (m searchModel) viewDetailPane(paneH int) string {
 	// Code tab uses codeResults; other tabs use selectedResult().
 	var r *search.Result
 	if m.filterType == typeFilterCode {
-		codeResults := m.codePageResults()
-		if m.cursor < 0 || m.cursor >= len(codeResults) {
+		if m.selectedCodeResult() == nil {
 			return strings.TrimSuffix(padToHeight("", paneH), "\n")
 		}
 	} else {
@@ -1522,9 +1491,8 @@ func (m searchModel) viewDetailPane(paneH int) string {
 	contentLines := max(paneH-chrome, 1)
 	var detailContent string
 	if m.filterType == typeFilterCode {
-		codeResults := m.codePageResults()
-		if m.cursor >= 0 && m.cursor < len(codeResults) {
-			detailContent = m.renderCodeDetail(codeResults[m.cursor], contentWidth, false)
+		if cr := m.selectedCodeResult(); cr != nil {
+			detailContent = m.renderCodeDetail(*cr, contentWidth, false)
 		}
 	} else {
 		detailContent = m.renderDetailContent(*r, contentWidth, false)
@@ -1583,18 +1551,13 @@ func (m searchModel) viewHelp() string {
 			m.styles.helpItem(keys.Back.Help().Key, "cancel") + "\n"
 	}
 
-	pages := m.totalPages()
-
 	left := m.styles.helpItem(keys.Search.Help().Key, keys.Search.Help().Desc) + dot +
 		m.styles.helpItem("↑/↓, j/k", "scroll") + dot +
-		m.styles.helpItem("home/end, g/G", "top/bottom")
-	if pages > 1 {
-		left += dot + m.styles.helpItem("n/p", "page")
-	}
-	left += dot + m.styles.helpItem("1-3", "type") + dot +
+		m.styles.helpItem("home/end, g/G", "top/bottom") + dot +
+		m.styles.helpItem("←/→", "type") + dot +
 		m.styles.helpItem(keys.Quit.Help().Key, keys.Quit.Help().Desc)
 
-	// The page / results count lives on the status row beneath the list
+	// The results count lives on the status row beneath the list
 	// (viewListStatusRow), so the footer holds only the key hints.
 	return left + "\n"
 }

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -143,7 +143,7 @@ var tabOrder = []typeFilter{typeFilterCommits, typeFilterSessions, typeFilterCod
 type searchModel struct {
 	results          []search.Result
 	cursor           int  // index into the active tab's full loaded list
-	pinToEnd         bool // End/G pressed: keep the cursor on the last row as fetched pages append
+	pinToEnd         bool // End/G pressed: follow the triggered fetch's rows to the new bottom, then release
 	total            int
 	width            int
 	height           int
@@ -370,6 +370,7 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 		m.fetchingMore = false
 		if msg.err != nil {
 			m.searchErr = RenderUserFacingError(msg.err).Error()
+			m.pinToEnd = false
 			m = m.refreshBrowseContent()
 			return m, nil
 		}
@@ -383,17 +384,21 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 			// API returned no more results — cap total so fetch-ahead stops asking.
 			m.total = len(m.results)
 		}
-		// End/G means the true bottom, not the bottom as of that keypress:
-		// follow rows the fetch appended below the cursor.
+		// End/G follows its triggered fetch to the new bottom, then releases:
+		// the pin repositions once and must not chain further fetches, or one
+		// keypress would download every remaining page. While the tab is still
+		// empty (n == 0) the pin stays armed so the sparse-tab chain below can
+		// keep hunting for the tab's first rows.
 		if m.pinToEnd {
 			if n := m.visibleCount(); n > 0 {
 				m.cursor = n - 1
+				m.pinToEnd = false
+				m = m.refreshBrowseContent()
+				m.browseVP.GotoBottom()
+				return m, nil
 			}
 		}
 		m = m.refreshBrowseContent()
-		if m.pinToEnd {
-			m.browseVP.GotoBottom()
-		}
 		// A fetched page may add nothing to the active tab (pages interleave
 		// types); keep fetching while the cursor still sits at the end and the
 		// server has more, so one keypress scrolls through sparse tabs too.
@@ -620,9 +625,12 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		}
 		return m.withFetchAhead()
 	case key.Matches(msg, keys.Confirm):
+		// Leaving browse mode releases the End pin so a fetch landing while
+		// the detail view is open can't move the highlight underneath it.
 		if m.filterType == typeFilterCode {
 			if r := m.selectedCodeResult(); r != nil {
 				m.mode = modeDetail
+				m.pinToEnd = false
 				content := m.renderCodeDetail(*r, m.width, true)
 				m.detailVP = viewport.New(viewport.WithWidth(m.width), viewport.WithHeight(max(m.height-2, 1)))
 				m.detailVP.SetContent(content)
@@ -630,6 +638,7 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 			}
 		} else if r := m.selectedResult(); r != nil {
 			m.mode = modeDetail
+			m.pinToEnd = false
 			content := m.renderDetailContent(*r, m.width, true)
 			m.detailVP = viewport.New(viewport.WithWidth(m.width), viewport.WithHeight(max(m.height-2, 1)))
 			m.detailVP.SetContent(content)
@@ -637,6 +646,7 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		}
 	case key.Matches(msg, keys.Search):
 		m.mode = modeSearch
+		m.pinToEnd = false
 		m.input.Focus()
 		return m, textinput.Blink
 	default:

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -78,11 +78,13 @@ type searchStyles struct {
 
 // Search palette draws from the shared base16 palette: the primary accent
 // styles titles/tabs/selection, the detail accent frames the detail card, and
-// the link accent is reserved for links inside markdown snippets.
+// the commit accent colors commit nodes/type tags in the result list. Snippet
+// links use the same Cyan/Blue pair as mdrender so markdown reads identically
+// across the CLI.
 const (
 	searchAccent       = palette.Accent  // primary accent (titles, tabs, selection)
 	searchDetailAccent = palette.Accent2 // detail card framing
-	searchLinkAccent   = palette.Blue    // links in markdown snippets
+	searchCommitAccent = palette.Blue    // commit nodes and type tags
 )
 
 func newSearchStyles(ss statusStyles) searchStyles {
@@ -1215,7 +1217,7 @@ func resultNodeStyle(s searchStyles, resultType string, selected bool) lipgloss.
 	case search.TypeSession:
 		return lipgloss.NewStyle().Foreground(lipgloss.Color(searchDetailAccent))
 	case search.TypeCommit:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(searchLinkAccent))
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(searchCommitAccent))
 	default: // checkpoint and unknown
 		return lipgloss.NewStyle().Foreground(lipgloss.Color(searchAccent))
 	}
@@ -1794,10 +1796,11 @@ func snippetMarkdownStyles(dark bool) ansi.StyleConfig {
 	s.List.Color = nil
 
 	// Links are the one place we *want* a colour: an underline alone is easy
-	// to miss inline.
-	linkColor := searchLinkAccent
+	// to miss inline. Match mdrender's link pair (Cyan URL, Blue link text).
+	linkColor := palette.Cyan
+	linkTextColor := palette.Blue
 	s.Link.Color = &linkColor
-	s.LinkText.Color = &linkColor
+	s.LinkText.Color = &linkTextColor
 
 	return s
 }

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -140,7 +140,8 @@ var tabOrder = []typeFilter{typeFilterCommits, typeFilterSessions, typeFilterCod
 // searchModel is the bubbletea model for interactive search results.
 type searchModel struct {
 	results          []search.Result
-	cursor           int // index into the active tab's full loaded list
+	cursor           int  // index into the active tab's full loaded list
+	pinToEnd         bool // End/G pressed: keep the cursor on the last row as fetched pages append
 	total            int
 	width            int
 	height           int
@@ -358,6 +359,7 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 		m.warning = strings.Join(msg.warnings, "; ")
 		m.apiPage = 1
 		m.cursor = 0
+		m.pinToEnd = false
 		m.browseVP.GotoTop()
 		m = m.refreshBrowseContent()
 		return m, nil
@@ -379,7 +381,17 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 			// API returned no more results — cap total so fetch-ahead stops asking.
 			m.total = len(m.results)
 		}
+		// End/G means the true bottom, not the bottom as of that keypress:
+		// follow rows the fetch appended below the cursor.
+		if m.pinToEnd {
+			if n := m.visibleCount(); n > 0 {
+				m.cursor = n - 1
+			}
+		}
 		m = m.refreshBrowseContent()
+		if m.pinToEnd {
+			m.browseVP.GotoBottom()
+		}
 		// A fetched page may add nothing to the active tab (pages interleave
 		// types); keep fetching while the cursor still sits at the end and the
 		// server has more, so one keypress scrolls through sparse tabs too.
@@ -530,6 +542,7 @@ func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 func (m searchModel) switchTab(f typeFilter) searchModel {
 	m.filterType = f
 	m.cursor = 0
+	m.pinToEnd = false
 	m.browseVP.GotoTop()
 	return m.refreshBrowseContent()
 }
@@ -573,15 +586,19 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 	case key.Matches(msg, keys.Quit), key.Matches(msg, keys.Back), msg.String() == "h":
 		return m, tea.Quit
 	case key.Matches(msg, keys.NextTab):
-		return m.cycleTab(1), nil
+		// Fetch-ahead so a sparse tab loads rows instead of sitting on
+		// "No results for this type." while later pages may hold some.
+		return m.cycleTab(1).withFetchAhead()
 	case key.Matches(msg, keys.PrevTab):
-		return m.cycleTab(-1), nil
+		return m.cycleTab(-1).withFetchAhead()
 	case key.Matches(msg, keys.Up):
+		m.pinToEnd = false
 		if m.cursor > 0 {
 			m.cursor--
 			m = m.refreshBrowseContent()
 		}
 	case key.Matches(msg, keys.Down):
+		m.pinToEnd = false
 		if m.cursor < m.visibleCount()-1 {
 			m.cursor++
 			m = m.refreshBrowseContent()
@@ -589,9 +606,11 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		return m.withFetchAhead()
 	case key.Matches(msg, keys.Home):
 		m.cursor = 0
+		m.pinToEnd = false
 		m = m.refreshBrowseContent()
 		m.browseVP.GotoTop()
 	case key.Matches(msg, keys.End):
+		m.pinToEnd = true
 		if n := m.visibleCount(); n > 0 {
 			m.cursor = n - 1
 			m = m.refreshBrowseContent()

--- a/cmd/entire/cli/search_tui_test.go
+++ b/cmd/entire/cli/search_tui_test.go
@@ -195,42 +195,32 @@ func TestSearchModel_TopBottomNavigation(t *testing.T) {
 	tests := []struct {
 		name        string
 		key         tea.KeyPressMsg
-		startPage   int
 		startCursor int
-		wantPage    int
 		wantCursor  int
 	}{
 		{
 			name:        "home",
 			key:         tea.KeyPressMsg{Code: tea.KeyHome},
-			startPage:   1,
-			startCursor: 4,
-			wantPage:    0,
+			startCursor: 14,
 			wantCursor:  0,
 		},
 		{
 			name:        "g",
 			key:         tea.KeyPressMsg{Code: 'g', Text: "g"},
-			startPage:   1,
-			startCursor: 4,
-			wantPage:    0,
+			startCursor: 14,
 			wantCursor:  0,
 		},
 		{
 			name:        "end",
 			key:         tea.KeyPressMsg{Code: tea.KeyEnd},
-			startPage:   0,
 			startCursor: 0,
-			wantPage:    2,
-			wantCursor:  9,
+			wantCursor:  29,
 		},
 		{
 			name:        "G",
 			key:         tea.KeyPressMsg{Code: 'G', Text: "G"},
-			startPage:   0,
 			startCursor: 0,
-			wantPage:    2,
-			wantCursor:  9,
+			wantCursor:  29,
 		},
 	}
 
@@ -242,14 +232,10 @@ func TestSearchModel_TopBottomNavigation(t *testing.T) {
 			cfg := search.Config{}
 			m := initTestViewport(newSearchModel(results, "q", len(results), cfg, ss, nil))
 			m.filterType = typeFilterCheckpoints // checkpoint-typed filler; exercise the generic list plumbing
-			m.page = tt.startPage
 			m.cursor = tt.startCursor
 			m = m.refreshBrowseContent()
 
 			m = updateModel(t, m, tt.key)
-			if m.page != tt.wantPage {
-				t.Errorf("page = %d, want %d", m.page, tt.wantPage)
-			}
 			if m.cursor != tt.wantCursor {
 				t.Errorf("cursor = %d, want %d", m.cursor, tt.wantCursor)
 			}
@@ -425,7 +411,7 @@ func TestSearchModel_ListScrollHint(t *testing.T) {
 		return r
 	}
 
-	// Short terminal + 25 results (multiple pages) → the page's rows can't all fit.
+	// Short terminal + 25 results → the rows can't all fit in the viewport.
 	overflow := newSearchModel(mk(25), "auth", 25, search.Config{}, statusStyles{width: 80}, nil)
 	overflow.filterType = typeFilterCheckpoints // checkpoint-typed filler
 	overflow.height, overflow.width = 28, 80
@@ -435,11 +421,11 @@ func TestSearchModel_ListScrollHint(t *testing.T) {
 	if v := overflow.viewBrowse(); !strings.Contains(v, "↓ more results") {
 		t.Error("expected a down-scroll hint at the top of an overflowing list")
 	}
-	// The page / results count renders on the same status row beneath the list.
-	if v := overflow.viewBrowse(); !strings.Contains(v, "page 1/3") || !strings.Contains(v, "25 results") {
-		t.Errorf("expected page/results count in the list status row: %q", v)
+	// The results count renders on the same status row beneath the list.
+	if v := overflow.viewBrowse(); !strings.Contains(v, "25 results") {
+		t.Errorf("expected results count in the list status row: %q", v)
 	}
-	overflow.cursor = 9
+	overflow.cursor = 24
 	overflow = overflow.refreshBrowseContent()
 	if v := overflow.viewBrowse(); !strings.Contains(v, "↑ more results") {
 		t.Error("expected an up-scroll hint at the bottom of an overflowing list")
@@ -542,53 +528,54 @@ func TestSearchModel_ViewMultiTypes(t *testing.T) {
 	}
 }
 
-func TestSearchModel_TypeFilterKeys(t *testing.T) {
+func TestSearchModel_TypeFilterArrowKeys(t *testing.T) {
 	t.Parallel()
 	m := testMultiTypeModel()
 
-	// Press 1 → filter to commits (leftmost tab and default, matching the web UI order)
-	m = updateModel(t, m, tea.KeyPressMsg{Code: '1', Text: "1"})
+	// Default tab is Commits (leftmost, matching the web UI order).
 	if m.filterType != typeFilterCommits {
-		t.Errorf("after 1: filterType = %q, want %q", m.filterType, typeFilterCommits)
+		t.Fatalf("default filterType = %q, want %q", m.filterType, typeFilterCommits)
 	}
 	if len(m.filteredResults()) != 1 {
 		t.Errorf("commit filter: got %d results, want 1", len(m.filteredResults()))
 	}
 
-	// Press 2 → filter to sessions (the default; checkpoints fold into sessions)
-	m = updateModel(t, m, tea.KeyPressMsg{Code: '2', Text: "2"})
+	// → cycles Commits → Sessions → Code → wraps back to Commits.
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyRight})
 	if m.filterType != typeFilterSessions {
-		t.Errorf("after 2: filterType = %q, want %q", m.filterType, typeFilterSessions)
+		t.Errorf("after →: filterType = %q, want %q", m.filterType, typeFilterSessions)
 	}
 	if len(m.filteredResults()) != 1 {
 		t.Errorf("session filter: got %d results, want 1", len(m.filteredResults()))
 	}
-
-	// Press 3 → filter to code
-	m = updateModel(t, m, tea.KeyPressMsg{Code: '3', Text: "3"})
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyRight})
 	if m.filterType != typeFilterCode {
-		t.Errorf("after 3: filterType = %q, want %q", m.filterType, typeFilterCode)
+		t.Errorf("after →→: filterType = %q, want %q", m.filterType, typeFilterCode)
+	}
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyRight})
+	if m.filterType != typeFilterCommits {
+		t.Errorf("after →→→: filterType = %q, want %q (wrap)", m.filterType, typeFilterCommits)
 	}
 
-	// Press 4 → no-op (the Checkpoints tab was removed); filter stays on code
-	m = updateModel(t, m, tea.KeyPressMsg{Code: '4', Text: "4"})
+	// ← cycles the other way, wrapping from the first tab to the last.
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyLeft})
 	if m.filterType != typeFilterCode {
-		t.Errorf("after 4: filterType = %q, want %q (no-op)", m.filterType, typeFilterCode)
+		t.Errorf("after ←: filterType = %q, want %q (wrap)", m.filterType, typeFilterCode)
+	}
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyLeft})
+	if m.filterType != typeFilterSessions {
+		t.Errorf("after ←←: filterType = %q, want %q", m.filterType, typeFilterSessions)
 	}
 }
 
-func TestSearchModel_TypeFilterResetsCursorAndPage(t *testing.T) {
+func TestSearchModel_TypeFilterResetsCursor(t *testing.T) {
 	t.Parallel()
 	m := testMultiTypeModel()
 	m.cursor = 2
-	m.page = 1
 
-	m = updateModel(t, m, tea.KeyPressMsg{Code: '1', Text: "1"})
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyRight})
 	if m.cursor != 0 {
 		t.Errorf("cursor should reset to 0 on type change, got %d", m.cursor)
-	}
-	if m.page != 0 {
-		t.Errorf("page should reset to 0 on type change, got %d", m.page)
 	}
 }
 
@@ -668,7 +655,7 @@ func TestSearchModel_BrowseFooterHelp(t *testing.T) {
 		"/ search",
 		"↑/↓, j/k scroll",
 		"home/end, g/G top/bottom",
-		"1-3 type",
+		"←/→ type",
 		"q quit",
 	}
 	lastIndex := -1
@@ -683,47 +670,10 @@ func TestSearchModel_BrowseFooterHelp(t *testing.T) {
 		lastIndex = idx
 	}
 
-	for _, unwanted := range []string{"detail", "open", "back", "navigate"} {
+	for _, unwanted := range []string{"detail", "open", "back", "navigate", "page"} {
 		if strings.Contains(footer, unwanted) {
 			t.Fatalf("footer should not mention %q: %q", unwanted, footer)
 		}
-	}
-	if strings.Contains(footer, "n/p page") {
-		t.Fatalf("single-page footer should not mention paging: %q", footer)
-	}
-}
-
-func TestSearchModel_BrowseFooterHelpIncludesPagingForMultiplePages(t *testing.T) {
-	t.Parallel()
-
-	results := make([]search.Result, 30)
-	for i := range results {
-		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
-	}
-
-	ss := statusStyles{colorEnabled: false, width: 120}
-	m := newSearchModel(results, "q", len(results), search.Config{}, ss, nil)
-	m.filterType = typeFilterCheckpoints // checkpoint-typed filler; drive the multi-page footer
-
-	footer := m.viewHelp()
-	wantParts := []string{
-		"/ search",
-		"↑/↓, j/k scroll",
-		"home/end, g/G top/bottom",
-		"n/p page",
-		"1-3 type",
-		"q quit",
-	}
-	lastIndex := -1
-	for _, want := range wantParts {
-		idx := strings.Index(footer, want)
-		if idx == -1 {
-			t.Fatalf("footer missing %q: %q", want, footer)
-		}
-		if idx < lastIndex {
-			t.Fatalf("footer control %q rendered out of order: %q", want, footer)
-		}
-		lastIndex = idx
 	}
 }
 
@@ -957,66 +907,34 @@ func TestRenderSearchStatic(t *testing.T) {
 	}
 }
 
-func TestSearchModel_PageResults(t *testing.T) {
+func TestSearchModel_ContinuousScroll(t *testing.T) {
 	t.Parallel()
 
-	// With 2 results and 25 per page, everything fits on page 0
-	m := testModel()
-	page := m.pageResults()
-	if len(page) != 2 {
-		t.Errorf("pageResults() = %d items, want 2", len(page))
-	}
-
-	// Out-of-range page returns nil
-	m.page = 5
-	if got := m.pageResults(); got != nil {
-		t.Errorf("pageResults() on out-of-range page = %v, want nil", got)
-	}
-}
-
-func TestSearchModel_TotalPages(t *testing.T) {
-	t.Parallel()
-
-	// 2 results, total=2 → 1 page
-	m := testModel()
-	if got := m.totalPages(); got != 1 {
-		t.Errorf("totalPages() with total=2 = %d, want 1", got)
-	}
-
-	// 0 results = 1 page (empty state)
+	// 30 loaded results, all loaded → down keeps advancing past the old
+	// 10-per-page boundary with no page breaks.
 	ss := statusStyles{colorEnabled: false, width: 100}
-	cfg := search.Config{}
-	empty := newSearchModel(nil, "", 0, cfg, ss, nil)
-	if got := empty.totalPages(); got != 1 {
-		t.Errorf("totalPages() with total=0 = %d, want 1", got)
-	}
-
-	// 26 loaded results, total=26 → 2 pages
-	results := make([]search.Result, 26)
+	results := make([]search.Result, 30)
 	for i := range results {
 		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
-	many := newSearchModel(results, "q", 26, cfg, ss, nil)
-	many.filterType = typeFilterCheckpoints // checkpoint-typed filler; exercise the generic pagination math
-	if got := many.totalPages(); got != 3 {
-		t.Errorf("totalPages() with total=26 = %d, want 3", got)
+	m := newSearchModel(results, "q", 30, search.Config{}, ss, nil)
+	m.filterType = typeFilterCheckpoints // checkpoint-typed filler; exercise the generic list plumbing
+
+	for range 15 {
+		m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyDown})
 	}
-}
-
-func TestSearchModel_TotalPagesUsesFilteredCount(t *testing.T) {
-	t.Parallel()
-
-	m := testMultiTypeModel()
-
-	// Unfiltered: 4 results → 1 page
-	if got := m.totalPages(); got != 1 {
-		t.Errorf("unfiltered totalPages = %d, want 1", got)
+	if m.cursor != 15 {
+		t.Errorf("after 15 downs: cursor = %d, want 15", m.cursor)
 	}
 
-	// Filter to checkpoints: 2 results → 1 page
-	m.filterType = typeFilterCheckpoints
-	if got := m.totalPages(); got != 1 {
-		t.Errorf("checkpoint-filtered totalPages = %d, want 1", got)
+	// Down at the last loaded row with nothing more to fetch stays put.
+	m.cursor = 29
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.cursor != 29 {
+		t.Errorf("after down at bottom: cursor = %d, want 29", m.cursor)
+	}
+	if m.fetchingMore {
+		t.Error("fetchingMore should be false when everything is loaded")
 	}
 }
 
@@ -1053,10 +971,11 @@ func TestSearchModel_AppendResults(t *testing.T) {
 	}
 }
 
-func TestSearchModel_FetchMoreOnNavigate(t *testing.T) {
+func TestSearchModel_FetchMoreOnScrollNearEnd(t *testing.T) {
 	t.Parallel()
 
-	// 10 loaded results, total=50 → multiple display pages but only 1 page loaded
+	// 10 loaded results, total=50 → scrolling near the end of the loaded list
+	// fetches the next API page (continuous scroll).
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{Owner: "o", Repo: "r", Limit: 10}
 	results := make([]search.Result, 10)
@@ -1064,20 +983,20 @@ func TestSearchModel_FetchMoreOnNavigate(t *testing.T) {
 		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 	m := newSearchModel(results, "q", 50, cfg, ss, nil)
-	m.filterType = typeFilterAll // fetch-more from the API applies in the All view
+	m.filterType = typeFilterAll
+	m.cursor = 6 // one row shy of the fetch-ahead window
 
-	// Navigate to page 2 — should trigger fetch
-	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m, ok := updated.(searchModel)
 	if !ok {
 		t.Fatalf("Update returned %T, want searchModel", updated)
 	}
 
-	if m.page != 1 {
-		t.Errorf("page = %d, want 1", m.page)
+	if m.cursor != 7 {
+		t.Errorf("cursor = %d, want 7", m.cursor)
 	}
 	if !m.fetchingMore {
-		t.Error("fetchingMore should be true when navigating past loaded results")
+		t.Error("fetchingMore should be true when scrolling into the fetch-ahead window")
 	}
 	if cmd == nil {
 		t.Error("expected a fetch command")
@@ -1087,7 +1006,7 @@ func TestSearchModel_FetchMoreOnNavigate(t *testing.T) {
 func TestSearchModel_NoFetchWhenResultsLoaded(t *testing.T) {
 	t.Parallel()
 
-	// 50 loaded results, total=50 → 2 pages, all loaded
+	// 50 loaded results, total=50 → all loaded, scrolling to the end fetches nothing.
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{Owner: "o", Repo: "r", Limit: 25}
 	results := make([]search.Result, 50)
@@ -1095,23 +1014,59 @@ func TestSearchModel_NoFetchWhenResultsLoaded(t *testing.T) {
 		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 	m := newSearchModel(results, "q", 50, cfg, ss, nil)
-	m.filterType = typeFilterCheckpoints // checkpoint-typed filler; exercise the generic pagination math
+	m.filterType = typeFilterCheckpoints // checkpoint-typed filler; exercise the generic fetch math
 
-	// Navigate to page 2 — should NOT trigger fetch (data already loaded)
-	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnd})
 	m, ok := updated.(searchModel)
 	if !ok {
 		t.Fatalf("Update returned %T, want searchModel", updated)
 	}
 
-	if m.page != 1 {
-		t.Errorf("page = %d, want 1", m.page)
+	if m.cursor != 49 {
+		t.Errorf("cursor = %d, want 49", m.cursor)
 	}
 	if m.fetchingMore {
 		t.Error("fetchingMore should be false when results are already loaded")
 	}
 	if cmd != nil {
 		t.Error("expected no command when results are loaded")
+	}
+}
+
+// TestSearchModel_AppendChainsFetchOnSparseTab pins the continuous-scroll
+// behavior on a tab the fetched page added nothing to: API pages interleave
+// types, so the model keeps fetching until the active tab gains rows or the
+// server runs out.
+func TestSearchModel_AppendChainsFetchOnSparseTab(t *testing.T) {
+	t.Parallel()
+
+	ss := statusStyles{colorEnabled: false, width: 100}
+	results := make([]search.Result, 10)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+	// Default tab is Commits; the checkpoint-typed results give it zero rows.
+	m := newSearchModel(results, "q", 50, search.Config{}, ss, nil)
+	m.fetchingMore = true
+
+	more := make([]search.Result, 10)
+	for i := range more {
+		more[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("new-%02d", i)}}
+	}
+	updated, cmd := m.Update(searchMoreResultsMsg{results: more})
+	m, ok := updated.(searchModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want searchModel", updated)
+	}
+
+	if len(m.results) != 20 {
+		t.Fatalf("len(results) = %d, want 20", len(m.results))
+	}
+	if !m.fetchingMore {
+		t.Error("fetchingMore should stay true: the commits tab is still empty and more pages exist")
+	}
+	if cmd == nil {
+		t.Error("expected a chained fetch command")
 	}
 }
 
@@ -1161,51 +1116,6 @@ func TestSearchModel_SelectedResult(t *testing.T) {
 	m.cursor = 99
 	if got := m.selectedResult(); got != nil {
 		t.Errorf("selectedResult() at cursor 99 = %v, want nil", got)
-	}
-}
-
-func TestSearchModel_PageNavigation(t *testing.T) {
-	t.Parallel()
-
-	// Create model with 20 results (2 pages at 10/page)
-	ss := statusStyles{colorEnabled: false, width: 100}
-	cfg := search.Config{Owner: "o", Repo: "r"}
-	results := make([]search.Result, 20)
-	for i := range results {
-		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
-	}
-	m := newSearchModel(results, "q", 20, cfg, ss, nil)
-	m.filterType = typeFilterCheckpoints // checkpoint-typed filler; exercise the generic paging math
-
-	if m.page != 0 {
-		t.Fatalf("initial page = %d, want 0", m.page)
-	}
-
-	// Navigate to next page
-	m = updateModel(t, m, tea.KeyPressMsg{Code: 'n', Text: "n"})
-	if m.page != 1 {
-		t.Errorf("after 'n': page = %d, want 1", m.page)
-	}
-	if m.cursor != 0 {
-		t.Errorf("after 'n': cursor = %d, want 0 (reset)", m.cursor)
-	}
-
-	// Can't go past last page
-	m = updateModel(t, m, tea.KeyPressMsg{Code: 'n', Text: "n"})
-	if m.page != 1 {
-		t.Errorf("after 'n' on last page: page = %d, want 1", m.page)
-	}
-
-	// Navigate back
-	m = updateModel(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"})
-	if m.page != 0 {
-		t.Errorf("after 'p': page = %d, want 0", m.page)
-	}
-
-	// Can't go before first page
-	m = updateModel(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"})
-	if m.page != 0 {
-		t.Errorf("after 'p' on first page: page = %d, want 0", m.page)
 	}
 }
 
@@ -1291,11 +1201,7 @@ func TestSearchModel_FetchMoreEmpty_CapsTotal(t *testing.T) {
 		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 	m := newSearchModel(results, "q", 100, cfg, ss, nil)
-	m.filterType = typeFilterAll // exercise all-types pagination against m.total
-
-	if m.totalPages() != 10 {
-		t.Fatalf("initial totalPages = %d, want 10", m.totalPages())
-	}
+	m.filterType = typeFilterAll // exercise the all-types fetch math against m.total
 
 	// Simulate API returning empty results (exhausted)
 	m = updateModel(t, m, searchMoreResultsMsg{results: nil})
@@ -1303,15 +1209,17 @@ func TestSearchModel_FetchMoreEmpty_CapsTotal(t *testing.T) {
 	if m.total != 10 {
 		t.Errorf("total should be capped to loaded results (10), got %d", m.total)
 	}
-	if m.totalPages() != 1 {
-		t.Errorf("totalPages should be 1 after cap, got %d", m.totalPages())
+	if m.fetchingMore {
+		t.Error("fetch-ahead should stop once total is capped to the loaded count")
 	}
 }
 
 func TestSearchModel_ViewFetchingMore(t *testing.T) {
 	t.Parallel()
 
-	// Model with 10 loaded results but on page 2 (no data) while fetching
+	// A tab with no visible rows yet, mid fetch-ahead (checkpoint-typed
+	// results, Commits tab) shows the loading message instead of "No results
+	// for this type."
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{}
 	results := make([]search.Result, 10)
@@ -1319,14 +1227,12 @@ func TestSearchModel_ViewFetchingMore(t *testing.T) {
 		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 	m := initTestViewport(newSearchModel(results, "q", 50, cfg, ss, nil))
-	m.filterType = typeFilterCheckpoints // checkpoint-typed filler
-	m.page = 1
 	m.fetchingMore = true
 	m = m.refreshBrowseContent()
 
 	view := m.View().Content
 	if !strings.Contains(view, "Loading more results...") {
-		t.Error("view should show loading message when fetchingMore and page has no data")
+		t.Error("view should show loading message when fetchingMore and the tab has no rows")
 	}
 }
 

--- a/cmd/entire/cli/search_tui_test.go
+++ b/cmd/entire/cli/search_tui_test.go
@@ -1033,6 +1033,81 @@ func TestSearchModel_NoFetchWhenResultsLoaded(t *testing.T) {
 	}
 }
 
+// TestSearchModel_EndFollowsFetchedRows pins the End/G semantics across
+// fetch-ahead: End means the true bottom, so rows appended by the fetch pull
+// the cursor down with them instead of leaving it mid-list.
+func TestSearchModel_EndFollowsFetchedRows(t *testing.T) {
+	t.Parallel()
+
+	ss := statusStyles{colorEnabled: false, width: 100}
+	results := make([]search.Result, 10)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+	m := newSearchModel(results, "q", 50, search.Config{}, ss, nil)
+	m.filterType = typeFilterAll
+
+	// End jumps to the last loaded row and fires a fetch (more exist).
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyEnd})
+	if m.cursor != 9 {
+		t.Fatalf("after End: cursor = %d, want 9", m.cursor)
+	}
+	if !m.fetchingMore {
+		t.Fatal("after End: fetchingMore should be true")
+	}
+
+	// The fetched page lands: the cursor follows to the new bottom.
+	more := make([]search.Result, 10)
+	for i := range more {
+		more[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("new-%02d", i)}}
+	}
+	m = updateModel(t, m, searchMoreResultsMsg{results: more})
+	if m.cursor != 19 {
+		t.Errorf("after append while pinned: cursor = %d, want 19", m.cursor)
+	}
+
+	// Any deliberate cursor move releases the pin: later appends stay put.
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyUp})
+	if m.cursor != 18 {
+		t.Fatalf("after Up: cursor = %d, want 18", m.cursor)
+	}
+	m.fetchingMore = true
+	m = updateModel(t, m, searchMoreResultsMsg{results: more[:5]})
+	if m.cursor != 18 {
+		t.Errorf("after append while unpinned: cursor = %d, want 18", m.cursor)
+	}
+}
+
+// TestSearchModel_TabSwitchFetchesSparseTab pins that switching to a tab with
+// no loaded rows kicks off a fetch when the server has more pages, rather than
+// sitting on "No results for this type."
+func TestSearchModel_TabSwitchFetchesSparseTab(t *testing.T) {
+	t.Parallel()
+
+	ss := statusStyles{colorEnabled: false, width: 100}
+	results := make([]search.Result, 10)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+	// Checkpoint-typed results: both the Commits and Sessions tabs are empty.
+	m := newSearchModel(results, "q", 50, search.Config{}, ss, nil)
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	m, ok := updated.(searchModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want searchModel", updated)
+	}
+	if m.filterType != typeFilterSessions {
+		t.Fatalf("filterType = %q, want %q", m.filterType, typeFilterSessions)
+	}
+	if !m.fetchingMore {
+		t.Error("fetchingMore should be true after switching to an empty tab with more pages")
+	}
+	if cmd == nil {
+		t.Error("expected a fetch command")
+	}
+}
+
 // TestSearchModel_AppendChainsFetchOnSparseTab pins the continuous-scroll
 // behavior on a tab the fetched page added nothing to: API pages interleave
 // types, so the model keeps fetching until the active tab gains rows or the

--- a/cmd/entire/cli/search_tui_test.go
+++ b/cmd/entire/cli/search_tui_test.go
@@ -1034,8 +1034,9 @@ func TestSearchModel_NoFetchWhenResultsLoaded(t *testing.T) {
 }
 
 // TestSearchModel_EndFollowsFetchedRows pins the End/G semantics across
-// fetch-ahead: End means the true bottom, so rows appended by the fetch pull
-// the cursor down with them instead of leaving it mid-list.
+// fetch-ahead: End jumps to the loaded bottom and pulls in the next page; the
+// rows that fetch appends pull the cursor down with them, then the pin
+// releases — one keypress must not chain through every remaining page.
 func TestSearchModel_EndFollowsFetchedRows(t *testing.T) {
 	t.Parallel()
 
@@ -1056,7 +1057,8 @@ func TestSearchModel_EndFollowsFetchedRows(t *testing.T) {
 		t.Fatal("after End: fetchingMore should be true")
 	}
 
-	// The fetched page lands: the cursor follows to the new bottom.
+	// The fetched page lands: the cursor follows to the new bottom, the pin
+	// releases, and no further fetch chains off the repositioned cursor.
 	more := make([]search.Result, 10)
 	for i := range more {
 		more[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("new-%02d", i)}}
@@ -1065,8 +1067,14 @@ func TestSearchModel_EndFollowsFetchedRows(t *testing.T) {
 	if m.cursor != 19 {
 		t.Errorf("after append while pinned: cursor = %d, want 19", m.cursor)
 	}
+	if m.pinToEnd {
+		t.Error("pin should release once the fetched rows land")
+	}
+	if m.fetchingMore {
+		t.Error("one End press must not chain another fetch after repositioning")
+	}
 
-	// Any deliberate cursor move releases the pin: later appends stay put.
+	// A later append with the pin released stays put.
 	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyUp})
 	if m.cursor != 18 {
 		t.Fatalf("after Up: cursor = %d, want 18", m.cursor)
@@ -1075,6 +1083,48 @@ func TestSearchModel_EndFollowsFetchedRows(t *testing.T) {
 	m = updateModel(t, m, searchMoreResultsMsg{results: more[:5]})
 	if m.cursor != 18 {
 		t.Errorf("after append while unpinned: cursor = %d, want 18", m.cursor)
+	}
+}
+
+// TestSearchModel_EndPinReleasedOutsideBrowse pins that opening a detail view
+// (or entering search mode) releases the End pin, so a fetch landing while the
+// detail is open cannot move the highlight underneath it.
+func TestSearchModel_EndPinReleasedOutsideBrowse(t *testing.T) {
+	t.Parallel()
+
+	ss := statusStyles{colorEnabled: false, width: 100}
+	results := make([]search.Result, 10)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+	m := newSearchModel(results, "q", 50, search.Config{}, ss, nil)
+	m.filterType = typeFilterAll
+	m.height = 40
+
+	// End arms the pin and fires a fetch; Enter then opens the detail view.
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyEnd})
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.mode != modeDetail {
+		t.Fatalf("mode = %d, want modeDetail", m.mode)
+	}
+
+	// The in-flight fetch lands while the detail is open: the selection must
+	// not move.
+	more := make([]search.Result, 10)
+	for i := range more {
+		more[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("new-%02d", i)}}
+	}
+	m = updateModel(t, m, searchMoreResultsMsg{results: more})
+	if m.cursor != 9 {
+		t.Errorf("cursor = %d, want 9 (unchanged while detail is open)", m.cursor)
+	}
+
+	// Entering search mode releases the pin too.
+	m.mode = modeBrowse
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyEnd})
+	m = updateModel(t, m, tea.KeyPressMsg{Code: '/', Text: "/"})
+	if m.pinToEnd {
+		t.Error("pin should release when entering search mode")
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1151
<!-- entire-trail-link-end -->

## Why

User feedback on the search TUI: commit search was expected to read like a pruned `git log` with continuous scroll — the 10-per-page display made it look like results ended after one screen ("took me too long to realize that I wasn't scrolling through the 2nd page"). Type tabs were also requested on arrow keys instead of number keys.

## What changed

- **Continuous scroll.** Removed the client-side display paging (`page`, `pageResults`, `totalPages`, `n`/`p` keys). The cursor moves through the full loaded list and the viewport follows. Within 3 rows of the end, the next API page (100 results) is fetched automatically. Because API pages interleave result types, a fetch that adds no rows to the active tab chains another fetch until rows appear or the server total is reached — one keypress scrolls through sparse tabs too.
- **Arrow-key tabs.** ←/→ (also tab/shift+tab) cycle Commits ↔ Sessions ↔ Code with wraparound. The 1-3 number keys and the `[1]`/`[2]`/`[3]` tab hints are gone; the active tab renders as `‹ Commits 20 ›` and the footer shows `←/→ type`.
- The status row replaces `page X/Y · N results` with `N results` / `N of M results` (per-tab server count, `+` for lower-bound counts) and shows `loading more…` during a fetch.

Net −131 lines. The `resultsPerPage` constant remains as the page size of the non-interactive JSON output, which is unchanged.

## Tradeoff

The semantic total spans all types while tabs filter client-side, so fetch-ahead on a sparse tab can fetch pages that add no visible rows (bounded by the server total). Marked in code; the upgrade path is per-type server pagination.

## Validation

- `mise run check` (fmt, lint, unit + integration tests, E2E canary) passes.
- New/updated tests: arrow cycling with wrap, fetch-ahead on scroll near the end, chained fetch on an empty tab, no fetch when everything is loaded, empty-fetch total capping, footer/status-row rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to interactive search TUI UX and shared key names used only by search; no auth, API contracts, or data handling changes.
> 
> **Overview**
> The search TUI drops **10-result display paging** (`page`, `n`/`p`) in favor of **continuous scroll**: the cursor walks the full loaded list for the active tab, and **`withFetchAhead`** loads the next API page when the selection is within three rows of the bottom (also on **End/G**, tab switches, and after appends that still leave a sparse tab empty). **`pinToEnd`** moves the highlight to newly fetched rows once after End, then releases so one keypress does not pull every remaining page; opening detail or search clears the pin.
> 
> **Type tabs** move from **1–3** to **←/→** (plus tab/shift+tab via shared **`NextTab`/`PrevTab`** bindings in `keys.go`), with **`‹ Commits N ›`** styling and footer **`←/→ type`**. The status row shows **`N of M+ results`** and **`loading more…`** instead of **`page X/Y`**. Snippet markdown links and commit node coloring are tweaked to align with **`mdrender`**.
> 
> Tests are rewritten around continuous scroll, fetch-ahead, End pinning, and sparse-tab chaining; non-interactive JSON paging via **`resultsPerPage`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c1539883102dd51910ccc5e6425685f470d127. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->