### PR TITLE
fix(claude): quote CLAUDE_PROJECT_DIR in SessionStart remote-setup hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PROJECT_DIR}/.claude/scripts/remote-setup.sh"
+            "command": "bash \"${CLAUDE_PROJECT_DIR}\"/.claude/scripts/remote-setup.sh"
           },
           {
             "type": "command",


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1152
<!-- entire-trail-link-end -->

## Summary

The committed Claude Code `SessionStart` hook in `.claude/settings.json` ran

```
bash ${CLAUDE_PROJECT_DIR}/.claude/scripts/remote-setup.sh
```

with the placeholder unquoted. Any checkout whose path contains a space fails on every session start with:

```
SessionStart:startup hook error
Failed with non-blocking status code: bash: /Users/<user>/Documents/Documents: No such file or directory
```

(Seen on a macOS machine where iCloud moved the dev tree under `~/Documents/Documents - <Mac name>/…`.)

This wraps the placeholder in double quotes — the form the [Claude Code hooks docs](https://code.claude.com/docs/en/hooks) recommend for shell-form commands referencing a path placeholder ("In shell form, wrap each placeholder in double quotes").

## Verification

Ran the exact command string Claude Code executes, with `CLAUDE_PROJECT_DIR` set to a path containing spaces:

- unquoted (before): `bash: /Users/peytonmontei/Documents/Documents: No such file or directory`, exit 127
- quoted (after): exit 0 (`remote-setup.sh` correctly no-ops outside `CLAUDE_CODE_REMOTE=true`)

`mise run lint` passes. No Go code changed; `entire enable` preserves this hook entry verbatim, so the fix survives hook reinstalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line hook string change in Claude Code config; no application or security logic affected.
> 
> **Overview**
> Fixes **SessionStart** failures when the repo lives on a path that contains spaces (e.g. iCloud `Documents - …` layouts on macOS).
> 
> The `remote-setup.sh` hook command in `.claude/settings.json` now wraps `${CLAUDE_PROJECT_DIR}` in double quotes so the shell treats the full directory as one argument instead of splitting at spaces and looking for a non-existent truncated path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8a6ae22c056474c68bd5fb39a1626f91fdf1cac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->