### PR TITLE
Prevent lazy blob fetches during explain

### DIFF
--- a/cmd/entire/cli/checkpoint/fetching_tree.go
+++ b/cmd/entire/cli/checkpoint/fetching_tree.go
@@ -209,6 +209,7 @@ func (t *FetchingTree) collectMissingBlobs(tree *object.Tree) []plumbing.Hash {
 // not in the cached index). We'd rather skip a wasted network round-trip.
 func (t *FetchingTree) blobOnDisk(hash plumbing.Hash) bool {
 	cmd := exec.CommandContext(t.ctx, "git", "cat-file", "-e", hash.String())
+	cmd.Env = append(cmd.Environ(), "GIT_NO_LAZY_FETCH=1")
 	return cmd.Run() == nil
 }
 
@@ -217,6 +218,7 @@ func (t *FetchingTree) blobOnDisk(hash plumbing.Hash) bool {
 // stale packfile index after external git commands fetched new objects.
 func (t *FetchingTree) readFileViaGit(path string, entry *object.TreeEntry) (*object.File, error) {
 	cmd := exec.CommandContext(t.ctx, "git", "cat-file", "-p", entry.Hash.String())
+	cmd.Env = append(cmd.Environ(), "GIT_NO_LAZY_FETCH=1")
 	content, cmdErr := cmd.Output()
 	if cmdErr != nil {
 		logging.Warn(t.ctx, "FetchingTree.readFileViaGit: cat-file failed",

--- a/cmd/entire/cli/checkpoint/fetching_tree_test.go
+++ b/cmd/entire/cli/checkpoint/fetching_tree_test.go
@@ -1,0 +1,48 @@
+package checkpoint
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchingTreeReadFileViaGitDisablesLazyFetch(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "fixture.txt", "checkpoint content")
+	testutil.GitAdd(t, repoDir, "fixture.txt")
+	testutil.GitCommit(t, repoDir, "add fixture")
+	blobHash := strings.TrimSpace(testutil.RunGit(t, repoDir, "rev-parse", "HEAD:fixture.txt"))
+
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+	binDir := t.TempDir()
+	tracePath := filepath.Join(t.TempDir(), "cat-file-env")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\t%%s\n' "$2" "$GIT_NO_LAZY_FETCH" > %q
+exec %q "$@"
+`, tracePath, realGit)
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755))
+	t.Setenv("GIT_NO_LAZY_FETCH", "0")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Chdir(repoDir)
+
+	tree := &FetchingTree{ctx: t.Context()}
+	file, err := tree.readFileViaGit("fixture.txt", &object.TreeEntry{Hash: plumbing.NewHash(blobHash)})
+	require.NoError(t, err)
+	contents, err := file.Contents()
+	require.NoError(t, err)
+	require.Equal(t, "checkpoint content", contents)
+	trace, err := os.ReadFile(tracePath)
+	require.NoError(t, err)
+	require.Equal(t, "-p\t1\n", string(trace))
+}

--- a/cmd/entire/cli/checkpoint/fetching_tree_test.go
+++ b/cmd/entire/cli/checkpoint/fetching_tree_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -15,7 +16,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const windowsOS = "windows"
+
 func TestFetchingTreeReadFileViaGitDisablesLazyFetch(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("fake git uses a POSIX shell script")
+	}
+
 	repoDir := t.TempDir()
 	testutil.InitRepo(t, repoDir)
 	testutil.WriteFile(t, repoDir, "fixture.txt", "checkpoint content")

--- a/cmd/entire/cli/integration_test/explain_test.go
+++ b/cmd/entire/cli/integration_test/explain_test.go
@@ -3,9 +3,11 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -333,9 +335,46 @@ func TestExplain_CheckpointSucceedsAfterTreelessFetch(t *testing.T) {
 	cloneDir := setupTreelessClone(t, bareURL, "+refs/heads/"+paths.MetadataBranchName+":refs/heads/"+paths.MetadataBranchName)
 	requireBlobMissing(t, cloneDir, checkpointID)
 
-	output := runExplainInDir(t, cloneDir, checkpointID)
+	var output string
+	if runtime.GOOS == windowsGOOS {
+		output = runExplainInDir(t, cloneDir, checkpointID)
+	} else {
+		gitEnv, catFileTrace := traceCatFileLazyFetchEnv(t)
+		stdout, stderr, commandErr := runEntire(t, gitEnv, cloneDir, "checkpoint", "explain", "--checkpoint", checkpointID)
+		trace, traceErr := os.ReadFile(catFileTrace)
+		require.NoError(t, traceErr)
+		require.NoError(t, commandErr, "explain failed\nstdout: %s\nstderr: %s\ncat-file trace: %s", stdout, stderr, trace)
+		output = stdout + stderr
+
+		traceLines := strings.Split(strings.TrimSpace(string(trace)), "\n")
+		require.Contains(t, traceLines, "-e\t1", "missing-blob probes must disable lazy fetch")
+		for _, line := range traceLines {
+			require.True(t, strings.HasSuffix(line, "\t1"), "cat-file ran without lazy fetch disabled: %q", line)
+		}
+	}
 	require.Contains(t, output, "Treeless v1 prompt",
 		"explain should succeed and surface the prompt despite blobs being absent locally")
+}
+
+func traceCatFileLazyFetchEnv(t *testing.T) ([]string, string) {
+	t.Helper()
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+
+	binDir := t.TempDir()
+	tracePath := filepath.Join(t.TempDir(), "cat-file-env")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "cat-file" ]; then
+	printf '%%s\t%%s\n' "$2" "$GIT_NO_LAZY_FETCH" >> %q
+fi
+exec %q "$@"
+`, tracePath, realGit)
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755))
+
+	return append(testutil.GitIsolatedEnv(),
+		"GIT_NO_LAZY_FETCH=0",
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	), tracePath
 }
 
 func createAndPushCheckpoint(t *testing.T, env *TestEnv, fileName, prompt string) string {
@@ -358,7 +397,7 @@ func createAndPushCheckpoint(t *testing.T, env *TestEnv, fileName, prompt string
 // setupTreelessClone creates a fresh git repo in a fresh TempDir, fetches
 // the given refspec from bareURL with --filter=blob:none --depth=1 (so
 // trees but no blobs land locally), and writes a minimal entire settings
-// file pointing at bareURL as the checkpoint_remote. Returns the new dir.
+// file enabling filtered fetches. Returns the new dir.
 //
 // Note: the bare and the fetch must go through the smart protocol for
 // --filter to be honored; the default local-path transport optimization
@@ -375,7 +414,8 @@ func setupTreelessClone(t *testing.T, barePath, refspec string) string {
 
 	for _, args := range [][]string{
 		{"init", "-q"},
-		{"-c", "protocol.file.allow=always", "fetch", "--filter=blob:none", "--depth=1", "--no-tags", fileURL, refspec},
+		{"remote", "add", "origin", fileURL},
+		{"-c", "protocol.file.allow=always", "fetch", "--filter=blob:none", "--depth=1", "--no-tags", "origin", refspec},
 	} {
 		cmd := exec.CommandContext(t.Context(), "git", args...)
 		cmd.Dir = cloneDir
@@ -385,7 +425,7 @@ func setupTreelessClone(t *testing.T, barePath, refspec string) string {
 		}
 	}
 
-	require.NoError(t, writeMinimalEntireSettings(cloneDir, barePath))
+	require.NoError(t, writeMinimalEntireSettings(cloneDir))
 	return cloneDir
 }
 
@@ -406,10 +446,8 @@ func enableFilterOnBare(t *testing.T, barePath string, gitEnv []string) {
 }
 
 // writeMinimalEntireSettings writes the smallest valid settings.json that
-// configures the manual-commit strategy with filtered_fetches enabled and
-// a custom checkpoint_remote URL — the partial-clone setup that triggered
-// the original bug.
-func writeMinimalEntireSettings(dir, bareURL string) error {
+// configures the manual-commit strategy with filtered_fetches enabled.
+func writeMinimalEntireSettings(dir string) error {
 	entireDir := filepath.Join(dir, ".entire")
 	if err := os.MkdirAll(entireDir, 0o755); err != nil {
 		return err
@@ -419,10 +457,6 @@ func writeMinimalEntireSettings(dir, bareURL string) error {
 		"strategy": "manual-commit",
 		"strategy_options": map[string]any{
 			"filtered_fetches": true,
-			"checkpoint_remote": map[string]any{
-				"provider": "url",
-				"url":      bareURL,
-			},
 		},
 	}
 	data, err := jsonutil.MarshalIndentWithNewline(settings, "", "  ")


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1154
<!-- entire-trail-link-end -->

## Why

In partial clones, checking whether checkpoint blobs exist with git cat-file could trigger Git lazy fetches before Entire reached its batched prefetch path. A checkpoint with many unavailable blobs could therefore produce one remote request per blob and promisor remote, making explain slow and hammering mirrors.

## What changed

Set GIT_NO_LAZY_FETCH=1 on both local cat-file probes and fallback reads. Missing blobs now reach the existing explicit batch fetch path, while the per-file recovery path remains available.

## Usage example

    entire checkpoint explain --checkpoint <checkpoint-id> --json

In a blob-filtered clone, missing checkpoint blobs are classified locally and fetched through the existing batch operation instead of probe-triggered lazy fetches.

## Decisions made during development

The override is applied to both cat-file -e and cat-file -p so neither analysis nor a fallback read can initiate an implicit fetch. The implementation leaves the explicit batch and per-file fetchers unchanged and does not add negative caching or a Git version branch.

## Technical tradeoffs

Git versions that do not recognize GIT_NO_LAZY_FETCH ignore it and retain their existing behavior. Avoiding runtime version parsing keeps the client path simple and lets newer Git versions provide the protection without making older installations fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how missing checkpoint blobs are detected in filtered/partial clones; incorrect behavior could affect explain/fetch timing, though older Git versions simply ignore the variable.
> 
> **Overview**
> **Checkpoint blob checks no longer trigger Git’s lazy fetch** in partial clones. `FetchingTree` now sets `GIT_NO_LAZY_FETCH=1` on `git cat-file -e` (missing-blob probes) and `git cat-file -p` (fallback reads), so absent blobs are classified locally and handled by the existing batch fetch path instead of one network round-trip per blob.
> 
> Tests assert the env override: a unit test wraps `git` to verify `readFileViaGit` passes `GIT_NO_LAZY_FETCH=1`, and the treeless-fetch integration test traces `cat-file` on non-Windows. The treeless clone harness now adds an `origin` remote for filtered fetch and drops the custom `checkpoint_remote` from minimal settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b4130782bd6d36ab3c96cfcb1678798457e1ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->