### PR TITLE
fix(checkpoint): pass --no-optional-locks to every git status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -554,7 +554,7 @@ where a user is actively waiting on a command (review, rewind, and
 #### `git status` Is a Write - Always Pass `--no-optional-locks`
 
 **Every `git status` Entire runs must pass `--no-optional-locks`.** A guard test
-(`TestGitStatusCallSitesPassNoOptionalLocks` in `checkpoint/`) fails the build on
+(`TestGitStatusCallSitesPassNoOptionalLocks` in `cmd/entire/cli/gitrepo/`) fails the build on
 any call site that omits it.
 
 `git status` is not a read. It refreshes the index's stat cache and, whenever any

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,6 +551,68 @@ where a user is actively waiting on a command (review, rewind, and
 `session adopt` via `detectFileChangesUnbounded`) keep the unbounded
 `gitrepo.Status`.
 
+#### `git status` Is a Write - Always Pass `--no-optional-locks`
+
+**Every `git status` Entire runs must pass `--no-optional-locks`.** A guard test
+(`TestGitStatusCallSitesPassNoOptionalLocks` in `checkpoint/`) fails the build on
+any call site that omits it.
+
+`git status` is not a read. It refreshes the index's stat cache and, whenever any
+entry is stale, writes the result back: `builtin/commit.c` takes
+`.git/index.lock` for the duration of the *whole worktree walk*, then renames a
+fresh index over `.git/index` (`tempfile.c`, `rename(2)`). The gate is
+`use_optional_locks()`, and `--no-optional-locks` is literally `setenv(
+GIT_OPTIONAL_LOCKS, "0")` — so the flag also propagates to child git processes,
+and `GIT_OPTIONAL_LOCKS=0` in the environment is an equivalent user-side
+mitigation. Output is byte-identical either way. The write fires on
+mtime-moved-but-content-identical files — the ordinary aftermath of an agent
+turn, a formatter, or an editor save — not on content edits.
+
+That refresh is git working as designed, and running `git status` is not itself
+a mistake. The reason we always drop the write is that **Entire never benefits
+from it**: every call site reads the porcelain output once and discards it, so
+the stat-cache update is a cost with no return.
+
+Three consequences, all observed in the field (issue #2111):
+
+- **A repo-deleting commit.** The rename replaces `.git/index` with a new inode.
+  On a filesystem where rename-over-existing is not atomic against a concurrent
+  lookup — Docker Desktop / virtiofs bind mounts, measured at 9.9% of opens
+  during continuous replacement versus 0 on ext4 — a concurrent reader gets
+  ENOENT. Git silently treats ENOENT on the index, **and only ENOENT**, as an
+  *empty* index (every other errno calls `die_errno`), so a `git commit` landing
+  in that window records the empty tree with exit code 0 and no warning: a commit
+  that deletes every tracked file. Recovery is `git reset --mixed HEAD~1`.
+- **The user's own `git add` failing** with `Unable to create '.git/index.lock':
+  File exists` while Entire holds the lock across its walk.
+- **A permanently stale `index.lock`** when a budget (`StatusWalkBudget`)
+  SIGKILLs the child mid-walk, breaking every later `git add`/`git commit` until
+  someone removes the file by hand.
+
+**Passing the flag does not make the hazard go away, and must not be described
+as if it did.** On an affected filesystem *any* concurrent `git status` opens the
+same window: the user's own, another tool's, a file watcher's — and in
+particular **N agents working the same repo**, each running its own hooks, which
+is precisely the workflow Entire encourages. Our share is the one write that is
+both unnecessary and asynchronous to the human's terminal, so it is the one that
+can land between someone's `git add` and their `git commit`. For the writers we
+do not control, the mitigation is `GIT_OPTIONAL_LOCKS=0` in the environment
+(devcontainers: `containerEnv`), which covers every git process in the session.
+
+Related: any git subprocess that can run inside a git hook and names its target
+with `cmd.Dir` or `-C` must also set `cmd.Env = gitrepo.EnvWithoutRepoOverrides()`
+(`gitrepo/env.go`). Git exports `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` to
+hooks and those take precedence over `cmd.Dir`, so a bare `exec.Command`
+silently operates on the hook's repo. Deliberately *not* applied to user-invoked
+commands that act on the current directory (`status`, `doctor`, `review`): there
+a `GIT_DIR` the user exported is an instruction, not contamination.
+
+This exact producer was diagnosed once before (ENT-242, Feb 2026) and lost: the
+fix was closed unmerged on the premise that `git status --porcelain -z` "reads
+without rewriting", which is false, and it would have grown the number of
+index-rewriting call sites from one to eleven. That is why the guard test exists
+rather than a comment.
+
 #### go-git v5 Bugs - Use CLI Instead
 
 **Do NOT use go-git v5 for `checkout` or `reset --hard` operations.**

--- a/cmd/entire/cli/checkpoint/collect_changed_files_index_test.go
+++ b/cmd/entire/cli/checkpoint/collect_changed_files_index_test.go
@@ -1,0 +1,137 @@
+package checkpoint
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// TestCollectChangedFiles_DoesNotRewriteUserIndex is the regression test for
+// issue #2111: a repository-deleting commit, caused by this hook-path helper
+// replacing the user's .git/index behind their back.
+//
+// `git status` is not a read. It refreshes the index's stat cache and, when
+// anything is stale, writes the result back — builtin/commit.c takes
+// .git/index.lock for the whole worktree walk and renames a fresh index over
+// .git/index (tempfile.c, rename(2)). The replacement gives .git/index a new
+// inode, and on a filesystem where rename-over-existing is not atomic against a
+// concurrent lookup (measured on a virtiofs bind mount: 9.9% of opens during
+// continuous replacement, 0 on ext4) a concurrent reader gets ENOENT. Git
+// silently treats ENOENT on the index — and only ENOENT — as an empty index, so
+// a `git commit` landing in that window records the empty tree with exit code 0
+// and no warning.
+//
+// Entire only ever wants the porcelain output, so the write is pure collateral
+// and --no-optional-locks removes it with byte-identical output. This test
+// asserts the file identity is preserved, which is the property that matters:
+// no replacement means no window.
+func TestCollectChangedFiles_DoesNotRewriteUserIndex(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
+		testutil.WriteFile(t, repoDir, name, "initial\n")
+		testutil.GitAdd(t, repoDir, name)
+	}
+	testutil.GitCommit(t, repoDir, "init")
+
+	repo, err := gitrepo.OpenPath(repoDir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+
+	indexPath := filepath.Join(repoDir, ".git", "index")
+
+	// Make the stat cache stale without changing content. This is the state git
+	// writes the index back for, and it is the ordinary aftermath of an agent
+	// turn, a formatter, or an editor save.
+	stale := time.Now().Add(2 * time.Second)
+	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
+		if err := os.Chtimes(filepath.Join(repoDir, name), stale, stale); err != nil {
+			t.Fatalf("chtimes %s: %v", name, err)
+		}
+	}
+
+	before, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("stat index before: %v", err)
+	}
+
+	if _, err := collectChangedFiles(context.Background(), repo); err != nil {
+		t.Fatalf("collectChangedFiles: %v", err)
+	}
+
+	after, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("stat index after: %v", err)
+	}
+
+	if !os.SameFile(before, after) {
+		t.Error("collectChangedFiles replaced the user's .git/index (new inode); " +
+			"the git status subprocess must pass --no-optional-locks so it never " +
+			"takes index.lock or renames a new index into place (issue #2111)")
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Errorf("collectChangedFiles rewrote the user's .git/index: mtime %v -> %v",
+			before.ModTime(), after.ModTime())
+	}
+}
+
+// TestCollectChangedFiles_IgnoresInheritedGitEnv proves the subprocess resolves
+// the repository from cmd.Dir rather than from an inherited GIT_DIR.
+//
+// Git exports GIT_DIR (and sometimes GIT_WORK_TREE / GIT_INDEX_FILE) to its
+// hooks, and those variables take precedence over the child's working
+// directory — so a bare exec.Command inherits them and silently operates on the
+// hook's repo instead of the one cmd.Dir names. Two other call sites in the
+// codebase already strip them; this one did not.
+func TestCollectChangedFiles_IgnoresInheritedGitEnv(t *testing.T) {
+	// Cannot be parallel: t.Setenv is process-global.
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "tracked.txt", "initial\n")
+	testutil.GitAdd(t, repoDir, "tracked.txt")
+	testutil.GitCommit(t, repoDir, "init")
+	testutil.WriteFile(t, repoDir, "untracked.txt", "new\n")
+
+	// A decoy repo, as a git hook's exported GIT_DIR would name.
+	decoyDir := t.TempDir()
+	testutil.InitRepo(t, decoyDir)
+	testutil.WriteFile(t, decoyDir, "decoy.txt", "decoy\n")
+
+	t.Setenv("GIT_DIR", filepath.Join(decoyDir, ".git"))
+	t.Setenv("GIT_WORK_TREE", decoyDir)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(decoyDir, ".git", "index"))
+
+	repo, err := gitrepo.OpenPath(repoDir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+
+	result, err := collectChangedFiles(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("collectChangedFiles: %v", err)
+	}
+
+	var sawReal bool
+	for _, f := range result.Changed {
+		if f == "untracked.txt" {
+			sawReal = true
+		}
+		if f == "decoy.txt" {
+			t.Errorf("resolved the decoy repo from the inherited GIT_DIR instead of "+
+				"cmd.Dir; got %v", result.Changed)
+		}
+	}
+	if !sawReal {
+		t.Errorf("expected untracked.txt from the real repo, got %v", result.Changed)
+	}
+}

--- a/cmd/entire/cli/checkpoint/ephemeral.go
+++ b/cmd/entire/cli/checkpoint/ephemeral.go
@@ -1286,8 +1286,40 @@ func collectChangedFiles(ctx context.Context, repo *git.Repository) (changedFile
 	// Use -uall to list individual untracked files instead of collapsed directories.
 	// Note: CLAUDE.md warns against -uall for user-facing display, but we need the full list
 	// for checkpointing.
-	cmd := exec.CommandContext(statusCtx, "git", "status", "--porcelain", "-z", "-uall")
+	//
+	// --no-optional-locks matters because `git status` is a WRITE, not a read.
+	// It refreshes the index's stat cache and, whenever any entry is stale,
+	// takes .git/index.lock for the whole worktree walk and renames a fresh
+	// index over .git/index. That behaviour is git working as designed — the
+	// refresh is what makes later status calls cheap — and running `git status`
+	// here was never wrong. The point is that *we get nothing from the write*:
+	// we read the porcelain output once per hook and discard it, so the flag
+	// drops a cost we were paying for no benefit. Output is byte-identical.
+	//
+	// The cost is only visible on a filesystem where rename-over-existing is
+	// not atomic against a concurrent lookup (virtiofs / gRPC-FUSE bind mounts,
+	// i.e. Docker Desktop devcontainers): there a concurrent reader can see
+	// ENOENT on .git/index, git silently treats ENOENT — and only ENOENT — as
+	// an *empty* index, and a `git commit` in that window records the empty
+	// tree with exit code 0 and no warning: a commit deleting every tracked
+	// file (issue #2111). Dropping the write also removes the index.lock
+	// contention that makes a concurrent `git add` fail, and the stale lock
+	// left behind when the budget SIGKILLs this child.
+	//
+	// Removing our write does not remove the hazard: on such a filesystem ANY
+	// concurrent `git status` opens the same window — the user's own, another
+	// tool's, and in particular N agents working the same repo, each firing
+	// this path. What we can own is not contributing a write we don't need,
+	// from a hook that runs asynchronously to the human's terminal. Users on
+	// affected mounts should set GIT_OPTIONAL_LOCKS=0 for the writers we do
+	// not control.
+	//
+	// EnvWithoutRepoOverrides is required because this runs inside git hooks,
+	// which export GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE; those take
+	// precedence over cmd.Dir and would silently point this at another repo.
+	cmd := exec.CommandContext(statusCtx, "git", "--no-optional-locks", "status", "--porcelain", "-z", "-uall")
 	cmd.Dir = repoRoot
+	cmd.Env = gitrepo.EnvWithoutRepoOverrides()
 	output, err := cmd.Output()
 	if err != nil {
 		if errors.Is(statusCtx.Err(), context.DeadlineExceeded) {

--- a/cmd/entire/cli/doctor_bundle.go
+++ b/cmd/entire/cli/doctor_bundle.go
@@ -114,7 +114,7 @@ func writeDoctorBundle(ctx context.Context, repoRoot, outPath string, raw bool) 
 		}
 	}
 
-	if err := addCommandOutput(ctx, zw, "git-status.txt", repoRoot, raw, "git", "status", "--short", "--branch"); err != nil {
+	if err := addCommandOutput(ctx, zw, "git-status.txt", repoRoot, raw, "git", "--no-optional-locks", "status", "--short", "--branch"); err != nil {
 		return err
 	}
 	if err := addCommandOutput(ctx, zw, "git-log.txt", repoRoot, raw, "git", "log", "-n", "50", "--oneline"); err != nil {

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -211,7 +211,9 @@ func GetCurrentBranch(ctx context.Context) (string, error) {
 // Uses git CLI instead of go-git because go-git doesn't respect global gitignore
 // (core.excludesfile) which can cause false positives for globally ignored files.
 func HasUncommittedChanges(ctx context.Context) (bool, error) {
-	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
+	// --no-optional-locks keeps this a read: a bare `git status` rewrites
+	// .git/index to refresh its stat cache (issue #2111).
+	cmd := exec.CommandContext(ctx, "git", "--no-optional-locks", "status", "--porcelain")
 	output, err := cmd.Output()
 	if err != nil {
 		return false, fmt.Errorf("failed to get git status: %w", err)

--- a/cmd/entire/cli/gitrepo/env.go
+++ b/cmd/entire/cli/gitrepo/env.go
@@ -1,0 +1,53 @@
+package gitrepo
+
+import (
+	"os"
+	"strings"
+)
+
+// repoOverrideEnvVars are git's repo-selector environment variables. Git
+// exports them to its hooks, and they take precedence over a child process's
+// working directory — so `exec.Command("git", ...)` with cmd.Dir set still
+// resolves the *hook's* repository, not the directory named, and
+// GIT_INDEX_FILE redirects index reads and writes to a different file
+// entirely.
+var repoOverrideEnvVars = []string{
+	"GIT_DIR=",
+	"GIT_WORK_TREE=",
+	"GIT_INDEX_FILE=",
+}
+
+// EnvWithoutRepoOverrides returns the current environment minus git's
+// repo-selector variables (GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE), so a git
+// subprocess resolves its repository from cmd.Dir as the call site intends.
+//
+// Use this for any git subprocess that can run inside a git hook and that
+// names its target with cmd.Dir or `-C`. Inheriting these variables makes the
+// child silently operate on the hook's repository instead: `git -C <other>
+// rev-parse` reports the hook's repo, and an index-touching command reads and
+// writes whatever GIT_INDEX_FILE names.
+//
+// Deliberately not applied to user-invoked commands that operate on the
+// current directory (`entire status`, `entire doctor`, `entire review`): there
+// a GIT_DIR the user exported in their own shell is an instruction, not
+// contamination.
+func EnvWithoutRepoOverrides() []string {
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, kv := range env {
+		if hasAnyPrefix(kv, repoOverrideEnvVars) {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	return filtered
+}
+
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/gitrepo/env_test.go
+++ b/cmd/entire/cli/gitrepo/env_test.go
@@ -1,0 +1,45 @@
+package gitrepo
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestEnvWithoutRepoOverrides_StripsRepoSelectors(t *testing.T) {
+	// Cannot be parallel: t.Setenv is process-global.
+	t.Setenv("GIT_DIR", "/decoy/.git")
+	t.Setenv("GIT_WORK_TREE", "/decoy")
+	t.Setenv("GIT_INDEX_FILE", "/decoy/.git/index")
+	t.Setenv("ENTIRE_ENV_TEST_KEEP", "keep-me")
+
+	env := EnvWithoutRepoOverrides()
+
+	for _, banned := range []string{"GIT_DIR=", "GIT_WORK_TREE=", "GIT_INDEX_FILE="} {
+		if slices.ContainsFunc(env, func(kv string) bool { return strings.HasPrefix(kv, banned) }) {
+			t.Errorf("EnvWithoutRepoOverrides kept %s", strings.TrimSuffix(banned, "="))
+		}
+	}
+
+	if !slices.Contains(env, "ENTIRE_ENV_TEST_KEEP=keep-me") {
+		t.Error("EnvWithoutRepoOverrides dropped an unrelated variable; it must only " +
+			"strip git's repo selectors")
+	}
+}
+
+// TestEnvWithoutRepoOverrides_DoesNotStripPrefixMatches guards against a
+// substring-style filter: GIT_DIRECTORY and GIT_INDEX_VERSION are not repo
+// selectors and must survive. The filter matches on "NAME=" for exactly this
+// reason.
+func TestEnvWithoutRepoOverrides_DoesNotStripPrefixMatches(t *testing.T) {
+	t.Setenv("GIT_DIRECTORY", "unrelated")
+	t.Setenv("GIT_WORK_TREES_CACHE", "unrelated")
+
+	env := EnvWithoutRepoOverrides()
+
+	for _, want := range []string{"GIT_DIRECTORY=unrelated", "GIT_WORK_TREES_CACHE=unrelated"} {
+		if !slices.Contains(env, want) {
+			t.Errorf("EnvWithoutRepoOverrides stripped %q, which is not a repo selector", want)
+		}
+	}
+}

--- a/cmd/entire/cli/gitrepo/gitstatus_guard_test.go
+++ b/cmd/entire/cli/gitrepo/gitstatus_guard_test.go
@@ -1,0 +1,94 @@
+package gitrepo
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// gitInvocationMarkers identify a line that shells out to git, as opposed to
+// the ~90 unrelated Go lines that merely contain the string "status" (JSON
+// field tags, agent stream subtypes, the agent-help classification table).
+var gitInvocationMarkers = []string{
+	`"git"`,          // exec.Command("git", ...) and runner.RunInDir(..., "git", ...)
+	"runGit",         // review's thin wrapper
+	"gitexec",        // the shared git exec helper
+	"RunInDir",       // bootstrapRunner
+	"CommandContext", // any remaining direct spawn on the same line
+}
+
+// TestGitStatusCallSitesPassNoOptionalLocks fails the build on any `git status`
+// invocation that omits --no-optional-locks.
+//
+// `git status` is a WRITE: it refreshes the index's stat cache and, when
+// anything is stale, takes .git/index.lock for the whole worktree walk and
+// renames a fresh index over .git/index. Entire only ever wants the porcelain
+// output, so that write is pure collateral — and it cost a user a commit that
+// deleted every tracked file (issue #2111). See the "`git status` Is a Write"
+// section of CLAUDE.md for the full chain.
+//
+// This is a source-level guard rather than a comment on purpose. The exact same
+// producer was diagnosed once before (ENT-242, Feb 2026), the fix was closed
+// unmerged on the false premise that `git status --porcelain -z` "reads without
+// rewriting", and the knowledge left the codebase entirely.
+//
+// Limitation: the check is per-line, so an invocation that gofmt wraps across
+// several lines could carry the flag on a different line than "status" and read
+// as a violation. That direction is safe — it fails loudly and the fix is to
+// keep the argv on one line or add the flag beside "status".
+func TestGitStatusCallSitesPassNoOptionalLocks(t *testing.T) {
+	t.Parallel()
+
+	root, err := exec.Command("git", "rev-parse", "--show-toplevel").Output() //nolint:noctx // guard test, no cancellation needed
+	if err != nil {
+		t.Skipf("not in a git checkout: %v", err)
+	}
+
+	grep := exec.Command("git", "grep", "-n", "--", `"status"`, "--", "cmd", "internal") //nolint:noctx // guard test, no cancellation needed
+	grep.Dir = strings.TrimSpace(string(root))
+	out, err := grep.Output()
+	if err != nil {
+		t.Fatalf(`git grep for "status" found nothing, which cannot be right: %v`, err)
+	}
+
+	var checked int
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		path, rest, ok := strings.Cut(line, ":")
+		if !ok || !strings.HasSuffix(path, ".go") {
+			continue
+		}
+		// Test files and fixtures may assert on the unguarded argv shape.
+		if strings.HasSuffix(path, "_test.go") || strings.Contains(path, "/testutil/") {
+			continue
+		}
+		if !containsAnyMarker(rest) {
+			continue // not a git invocation
+		}
+		checked++
+		if strings.Contains(rest, `"--no-optional-locks"`) {
+			continue
+		}
+		t.Errorf("git status invocation without --no-optional-locks:\n  %s\n"+
+			"`git status` rewrites the user's .git/index (issue #2111). Add "+
+			`"--no-optional-locks" before "status", and set `+
+			"cmd.Env = gitrepo.EnvWithoutRepoOverrides() if the call can run "+
+			"inside a git hook.", line)
+	}
+
+	// If a refactor moves every call site behind a helper this pattern no longer
+	// recognises, the guard would silently pass forever. Fail instead so someone
+	// re-points it.
+	if checked == 0 {
+		t.Error("guard matched no git status invocations at all; the detection " +
+			"pattern has gone stale and must be re-pointed (gitInvocationMarkers)")
+	}
+}
+
+func containsAnyMarker(line string) bool {
+	for _, m := range gitInvocationMarkers {
+		if strings.Contains(line, m) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/review/scope.go
+++ b/cmd/entire/cli/review/scope.go
@@ -233,7 +233,9 @@ func countFilesChanged(ctx context.Context, repoRoot, baseRef string) (int, erro
 // countUncommitted returns the number of lines in `git status --porcelain`
 // (each line corresponds to one changed or untracked file).
 func countUncommitted(ctx context.Context, repoRoot string) (int, error) {
-	out, err := runGit(ctx, repoRoot, "status", "--porcelain")
+	// --no-optional-locks keeps this a read: a bare `git status` rewrites
+	// .git/index to refresh its stat cache (issue #2111).
+	out, err := runGit(ctx, repoRoot, "--no-optional-locks", "status", "--porcelain")
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -805,7 +805,9 @@ func doInitialCommit(ctx context.Context, runner bootstrapRunner, dir, message s
 		return false, wrapExecError("git add", err)
 	}
 	// Check if the staging area has anything at all.
-	out, err := runner.RunInDir(ctx, dir, "git", "status", "--porcelain")
+	// --no-optional-locks keeps this a read: a bare `git status` rewrites
+	// .git/index to refresh its stat cache (issue #2111).
+	out, err := runner.RunInDir(ctx, dir, "git", "--no-optional-locks", "status", "--porcelain")
 	if err != nil {
 		return false, wrapExecError("git status", err)
 	}

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -307,7 +307,7 @@ func TestDoInitialCommit_EmptyFolder(t *testing.T) {
 	dir := t.TempDir()
 	r := newFakeRunner()
 	r.set("git", []string{"add", "-A"}, "", nil)
-	r.set("git", []string{"status", "--porcelain"}, "", nil)
+	r.set("git", []string{"--no-optional-locks", "status", "--porcelain"}, "", nil)
 
 	committed, err := doInitialCommit(context.Background(), r, dir, "msg")
 	if err != nil {
@@ -323,7 +323,7 @@ func TestDoInitialCommit_WithFiles(t *testing.T) {
 	dir := t.TempDir()
 	r := newFakeRunner()
 	r.set("git", []string{"add", "-A"}, "", nil)
-	r.set("git", []string{"status", "--porcelain"}, " M README.md\n", nil)
+	r.set("git", []string{"--no-optional-locks", "status", "--porcelain"}, " M README.md\n", nil)
 	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "msg"}, "", nil)
 
 	committed, err := doInitialCommit(context.Background(), r, dir, "msg")
@@ -359,7 +359,7 @@ func TestRunGitHubBootstrap_NoGitHubFlow(t *testing.T) {
 	r.setIdentityConfigured()
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
-	r.set("git", []string{"status", "--porcelain"}, " M file\n", nil)
+	r.set("git", []string{"--no-optional-locks", "status", "--porcelain"}, " M file\n", nil)
 	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "First!"}, "", nil)
 
 	opts := GitHubBootstrapOptions{
@@ -393,7 +393,7 @@ func TestRunGitHubBootstrap_GhMissingFallsBackToLocal(t *testing.T) {
 	r.set("gh", []string{"--version"}, "", errors.New("not found"))
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
-	r.set("git", []string{"status", "--porcelain"}, "", nil)
+	r.set("git", []string{"--no-optional-locks", "status", "--porcelain"}, "", nil)
 
 	// A repo flag is an explicit GitHub request, so gh is probed; since it's
 	// missing we warn and fall back to local-only.
@@ -422,7 +422,7 @@ func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
 	r.set("gh", []string{"repo", "view", "octocat/my-new", "--json", "name"}, "", errors.New("not found"))
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
-	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
+	r.set("git", []string{"--no-optional-locks", "status", "--porcelain"}, " M f\n", nil)
 	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Seed"}, "", nil)
 	r.set("gh", []string{
 		"repo", "create", "octocat/my-new",
@@ -646,7 +646,7 @@ func TestRunGitHubBootstrap_RepoFlagsCreateButDoNotPush(t *testing.T) {
 	r.set("gh", []string{"repo", "view", "octocat/create-only", "--json", "name"}, "", errors.New("not found"))
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
-	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
+	r.set("git", []string{"--no-optional-locks", "status", "--porcelain"}, " M f\n", nil)
 	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Seed"}, "", nil)
 	r.set("gh", []string{
 		"repo", "create", "octocat/create-only",
@@ -695,7 +695,7 @@ func TestRunGitHubBootstrap_InitBeforeFinalize(t *testing.T) {
 	r.set("gh", []string{"repo", "view", "octocat/phased", "--json", "name"}, "", errors.New("not found"))
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
-	r.set("git", []string{"status", "--porcelain"}, " A .entire/settings.json\n", nil)
+	r.set("git", []string{"--no-optional-locks", "status", "--porcelain"}, " A .entire/settings.json\n", nil)
 	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "First"}, "", nil)
 	r.set("gh", []string{
 		"repo", "create", "octocat/phased",
@@ -723,7 +723,7 @@ func TestRunGitHubBootstrap_InitBeforeFinalize(t *testing.T) {
 	}
 	forbidden := [][]string{
 		{"add", "-A"},
-		{"status", "--porcelain"},
+		{"--no-optional-locks", "status", "--porcelain"},
 		{"-c", "commit.gpgsign=false", "commit", "-m", "First"},
 	}
 	for _, args := range forbidden {
@@ -1336,7 +1336,7 @@ func TestRunGitHubBootstrapFinalize_HonorsPushFalse(t *testing.T) {
 
 	r := newFakeRunner()
 	r.set("git", []string{"add", "-A"}, "", nil)
-	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
+	r.set("git", []string{"--no-optional-locks", "status", "--porcelain"}, " M f\n", nil)
 	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Seed"}, "", nil)
 	r.set("gh", []string{
 		"repo", "create", "octocat/no-push",
@@ -1399,7 +1399,7 @@ func TestRunGitHubBootstrap_YesAcceptsAllDefaults(t *testing.T) {
 	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "myorg\n", nil)
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
-	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
+	r.set("git", []string{"--no-optional-locks", "status", "--porcelain"}, " M f\n", nil)
 	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", defaultInitialCommitMessage}, "", nil)
 
 	// Expect repo created under the user's account (not org), private
@@ -1510,7 +1510,7 @@ func TestRunGitHubBootstrap_YesWithNoGitHub(t *testing.T) {
 	r.setIdentityConfigured()
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
-	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
+	r.set("git", []string{"--no-optional-locks", "status", "--porcelain"}, " M f\n", nil)
 	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", defaultInitialCommitMessage}, "", nil)
 
 	opts := GitHubBootstrapOptions{Yes: true, NoGitHub: true}

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -440,7 +440,7 @@ func gitCommonDirForWorktree(ctx context.Context, worktreePath string) (string, 
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "rev-parse", "--git-common-dir")
-	cmd.Env = gitEnvWithoutRepoOverrides()
+	cmd.Env = gitrepo.EnvWithoutRepoOverrides()
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get git common dir for %s: %w", worktreePath, err)
@@ -458,25 +458,6 @@ func gitCommonDirForWorktree(ctx context.Context, worktreePath string) (string, 
 		commonDir = resolved
 	}
 	return commonDir, nil
-}
-
-// gitEnvWithoutRepoOverrides returns the current environment minus git's
-// repo-selector variables. Git hooks run with GIT_DIR (and sometimes
-// GIT_WORK_TREE / GIT_INDEX_FILE) exported for the hook's own repo; inheriting
-// them would make `git -C <other-worktree>` resolve against the hook's repo
-// instead of the requested path.
-func gitEnvWithoutRepoOverrides() []string {
-	env := os.Environ()
-	filtered := make([]string, 0, len(env))
-	for _, kv := range env {
-		if strings.HasPrefix(kv, "GIT_DIR=") ||
-			strings.HasPrefix(kv, "GIT_WORK_TREE=") ||
-			strings.HasPrefix(kv, "GIT_INDEX_FILE=") {
-			continue
-		}
-		filtered = append(filtered, kv)
-	}
-	return filtered
 }
 
 func isNestedWorktreeOfRecordedRepo(recordedWorktreePath, commitWorktreePath string) bool {

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -10,6 +10,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
@@ -326,7 +327,7 @@ func detectSearchUsage(ag agent.Agent, transcriptData []byte) searchProbe {
 // ambient HEAD matters twice over: the probe runs after the session gate
 // releases, so HEAD may have moved (a chained hook amending, a concurrent
 // commit), and hooks inherit git's exported GIT_DIR/GIT_WORK_TREE, which
-// override -C's repo selection — gitEnvWithoutRepoOverrides scrubs those, same
+// override -C's repo selection — gitrepo.EnvWithoutRepoOverrides scrubs those, same
 // as this package's other `git -C` call site. Paths match git log --name-only
 // output, i.e. the same form as SessionState.FilesTouched.
 //
@@ -364,7 +365,7 @@ func priorAICommitFiles(ctx context.Context, repoRoot, commit string) (result ma
 	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "log", "-z",
 		"--skip=1", "-n", strconv.Itoa(priorAICheckpointsLookback),
 		"--name-only", "--format=%x00%H%n%B", commit)
-	cmd.Env = gitEnvWithoutRepoOverrides()
+	cmd.Env = gitrepo.EnvWithoutRepoOverrides()
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, false


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1156
<!-- entire-trail-link-end -->

Addresses #2111.

## What this is, and what it is not

`git status` is a **write**. It refreshes the index's stat cache and, whenever any entry is stale, takes `.git/index.lock` for the duration of the *whole worktree walk*, then renames a fresh index over `.git/index`:

| where | what |
| --- | --- |
| `builtin/commit.c` `cmd_status` | `repo_read_index()` → `refresh_index(...)` sets `cache_changed` |
| same, a few lines down | `if (use_optional_locks()) fd = repo_hold_locked_index(...)` ← the gate |
| after `wt_status_collect()` | `repo_update_index_if_able(...)` |
| `read-cache.c` | `write_locked_index(..., COMMIT_LOCK)` |
| `lockfile.c` → `tempfile.c` | `rename(tempfile, path)` ← replaces `.git/index` |

That refresh is git working as designed, and running `git status` from the checkpoint path was **not wrong**. What makes the write not worth its cost is that **Entire gets nothing from it** — every call site reads the porcelain output once and discards it, so the stat-cache update is pure overhead. Output is byte-identical with the flag (md5-verified), and `--no-optional-locks` has existed since git 2.15.

The write only becomes visible on a filesystem where rename-over-existing is not atomic against a concurrent lookup — virtiofs / gRPC-FUSE bind mounts, i.e. Docker Desktop devcontainers. There a concurrent reader can observe ENOENT on `.git/index`; git silently treats ENOENT, **and only ENOENT**, as an *empty* index (every other errno calls `die_errno`); and a `git commit` landing in that window records the empty tree with exit code 0 and no warning — a commit that deletes every tracked file. Recovery is `git reset --mixed HEAD~1`.

## This does not eliminate the hazard

Worth stating plainly, because it would be easy to read this PR as "fixed":

On an affected mount **any** concurrent `git status` opens the same window — the user's own, another tool's, a file watcher's, and in particular **several agents working the same repo**, each running its own hooks. That last case is precisely the workflow Entire encourages, and it multiplies exposure in a way no change on our side addresses.

What we can own is not contributing a write we don't need, from a hook that runs asynchronously to the human's terminal — which makes ours the one write that can land *between* someone's `git add` and their `git commit`, where nobody expects it. For the writers we do not control, the mitigation is `GIT_OPTIONAL_LOCKS=0` in the environment (devcontainers: `containerEnv`), which covers every git process in the session, including ours, since the flag is literally `setenv(GIT_OPTIONAL_LOCKS, "0")`.

## Evidence

Isolating the filesystem factor — real `rename(2)` racing `open()`:

| filesystem | opens | ENOENT | zero-length | renames |
| --- | --- | --- | --- | --- |
| virtiofs bind mount | 29,596 | **2,939 (9.9%)** | 0 | 12,545 |
| ext4 | 1,930,880 | **0** | 0 | 199,846 |

End to end, the reporter's `add` + `commit` workflow racing the writer:

| filesystem | writer | empty-index reads | empty-tree commits |
| --- | --- | --- | --- |
| virtiofs | plain `git status` | 13 / 3449 | **11 / 615** |
| ext4 | plain `git status` | 0 / 5413 | 0 / 2630 |
| virtiofs | `--no-optional-locks` | 0 / 2876 | 0 / 394 |

With the **real binary** through real hooks on virtiofs:

| binary | `.git/index` across one stop hook | |
| --- | --- | --- |
| shipped | ino 121446 → 121485 | replaced |
| this branch | ino 121638 → 121638 | untouched |

Capture is unchanged: identical shadow-branch trees across a change set with modified, new, deleted, renamed, spaces, nested dirs, and mtime-only touches.

Calibration, since it cuts against the fix: racing the real hook cycle (one first-checkpoint per turn, microsecond window) produced **0 empty-tree commits in 6,667 attempts**. Entire's own cadence does not explain the reporter's "under 5 attempts" — a higher-duty-cycle writer in their repo (they ship a `graphify` skill with a file watcher) or Docker Desktop's gRPC-FUSE being worse than colima's virtiofs would. So this removes a real and unnecessary contribution, not a proven sole cause.

## Also fixed

The same call site inherited `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` from the enclosing git hook, and those take precedence over `cmd.Dir` — so it could resolve a different repository entirely. `strategy`'s private env scrubber moves to `gitrepo.EnvWithoutRepoOverrides` so `checkpoint` can share it without an import cycle. Deliberately **not** applied to user-invoked commands acting on the current directory (`status`, `doctor`, `review`), where a `GIT_DIR` the user exported is an instruction, not contamination.

The stale-`index.lock`-after-SIGKILL failure (`fatal: Unable to create '.git/index.lock': File exists`, permanent until removed by hand) needs no separate fix — with the flag no lock is ever taken, and this budget-killed subprocess was the only site under a kill budget.

## Tests

Written first, all confirmed RED before the fix:

- `TestCollectChangedFiles_DoesNotRewriteUserIndex` — stales the stat cache, then asserts `os.SameFile` and mtime on `.git/index`. The bug, encoded directly.
- `TestCollectChangedFiles_IgnoresInheritedGitEnv` — decoy repo in `GIT_DIR`; before the fix this returned `[decoy.txt]`.
- `TestGitStatusCallSitesPassNoOptionalLocks` — source guard over `cmd/` and `internal/`. Verified by reverting one call site and watching it fail. It also fails if it matches *zero* invocations, so a refactor behind a new helper cannot make it silently vacuous.
- `gitrepo/env_test.go` — includes that `GIT_DIRECTORY` is not stripped.

The guard exists instead of a comment because **this exact producer was diagnosed once before and the knowledge left the codebase**: ENT-242 (Feb 2026) reached the right conclusion, attributed it to another vendor's binary, and closed PR #171 unmerged — on the stated premise that `git status --porcelain -z` "reads without rewriting", which this PR measures as false. That PR would have grown the number of index-rewriting call sites from one to eleven.

## Verification

`mise run fmt && mise run lint && mise run test:ci` — lint 0 issues; one pre-existing failure, `TestCodexAppServerHooksList_BareWorktreeUsesLayoutRoot` (`/var` vs `/private/var` symlink resolution), confirmed to fail identically on a pristine checkout of `HEAD` with none of these changes. Integration suite green with it skipped.

## Follow-ups, not in this PR

- **Empty-tree commit guard.** `prepare-commit-msg` already reads the index and could refuse a commit whose tree is `4b825dc6…` while HEAD has files. But the hooks are installed `2>/dev/null || true` specifically so Entire can never abort a user's commit. Reversing that contract is a product decision.
- `TestCodexAppServerHooksList_BareWorktreeUsesLayoutRoot` needs `EvalSymlinks` on its expected path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
