### PR TITLE
Probe missing checkpoint blobs in one cat-file, not one per blob

### DIFF
--- a/cmd/entire/cli/checkpoint/fetching_tree.go
+++ b/cmd/entire/cli/checkpoint/fetching_tree.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"os/exec"
+	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 
@@ -183,34 +184,100 @@ func (t *FetchingTree) CollectMissingBlobs() []plumbing.Hash {
 }
 
 // collectMissingBlobs recursively walks a tree and returns hashes of blob
-// entries that are not present in the local object store.
+// entries that are not present in the local object store. The walk asks
+// go-git first and settles every storer miss in a single `git cat-file
+// --batch-check`, so the cost is one subprocess per tree rather than one per
+// candidate blob.
 func (t *FetchingTree) collectMissingBlobs(tree *object.Tree) []plumbing.Hash {
-	var missing []plumbing.Hash
+	candidates := t.collectStorerMisses(tree)
+	if len(candidates) == 0 {
+		return nil
+	}
+	return t.rejectBlobsOnDisk(candidates)
+}
+
+// collectStorerMisses walks a tree recursively and returns the hash of every
+// blob entry go-git's storer cannot see. That is only half an answer: in a
+// partial-clone repo the storer also misses blobs that ARE on disk (filtered
+// out of its index, or in a packfile written after this process opened the
+// repo), which is what rejectBlobsOnDisk settles.
+func (t *FetchingTree) collectStorerMisses(tree *object.Tree) []plumbing.Hash {
+	var candidates []plumbing.Hash
 	for _, entry := range tree.Entries {
 		if entry.Mode.IsFile() {
-			if t.storer.HasEncodedObject(entry.Hash) != nil && !t.blobOnDisk(entry.Hash) {
-				missing = append(missing, entry.Hash)
+			if t.storer.HasEncodedObject(entry.Hash) != nil {
+				candidates = append(candidates, entry.Hash)
 			}
-		} else {
-			// Recurse into subtrees (tree objects are local after treeless fetch).
-			subtree, err := tree.Tree(entry.Name)
-			if err == nil {
-				missing = append(missing, t.collectMissingBlobs(subtree)...)
-			}
+			continue
+		}
+		// Recurse into subtrees (tree objects are local after treeless fetch).
+		subtree, err := tree.Tree(entry.Name)
+		if err == nil {
+			candidates = append(candidates, t.collectStorerMisses(subtree)...)
+		}
+	}
+	return candidates
+}
+
+// rejectBlobsOnDisk returns the candidates that git cannot find in the local
+// object store, preserving order. A failed probe is treated as "nothing is on
+// disk" — the same direction the per-hash check failed in, and the safe one: a
+// candidate wrongly reported missing costs one batched fetch, while one wrongly
+// reported present makes File() fall back to a per-blob fetch.
+func (t *FetchingTree) rejectBlobsOnDisk(candidates []plumbing.Hash) []plumbing.Hash {
+	onDisk, err := t.blobsOnDisk(candidates)
+	if err != nil {
+		logging.Debug(t.ctx, "FetchingTree.rejectBlobsOnDisk: batch probe failed, treating every candidate as missing",
+			slog.Int("candidates", len(candidates)),
+			slog.String("error", err.Error()),
+		)
+		return candidates
+	}
+
+	missing := make([]plumbing.Hash, 0, len(candidates))
+	for _, hash := range candidates {
+		if !onDisk[hash.String()] {
+			missing = append(missing, hash)
 		}
 	}
 	return missing
 }
 
-// blobOnDisk returns true if `git cat-file -e <hash>` finds the blob in
-// the local object store. Used as a second-opinion check before deciding
-// a blob needs to be fetched: in partial-clone repos a blob can be on
-// disk but invisible to go-git's storer (filtered out, or in a packfile
-// not in the cached index). We'd rather skip a wasted network round-trip.
-func (t *FetchingTree) blobOnDisk(hash plumbing.Hash) bool {
-	cmd := exec.CommandContext(t.ctx, "git", "cat-file", "-e", hash.String())
+// blobsOnDisk reports which of the given hashes the local object store holds,
+// keyed by hex string, asking `git cat-file --batch-check` once for the whole
+// set — git prints "<oid> missing" for an object it cannot find and
+// "<oid> <type> <size>" for one it can.
+//
+// GIT_NO_LAZY_FETCH is what makes the answer an answer: in a promisor repo
+// (any partial clone, including the URL-keyed remote section our own filtered
+// fetches leave behind) an unguarded probe fetches the very blob it is asking
+// about — one `git fetch --stdin` per missing object — and then reports it
+// present. --batch-check batches the lookups, not the promisor fetches.
+func (t *FetchingTree) blobsOnDisk(hashes []plumbing.Hash) (map[string]bool, error) {
+	lines := make([]string, len(hashes))
+	for i, hash := range hashes {
+		lines[i] = hash.String()
+	}
+
+	cmd := exec.CommandContext(t.ctx, "git", "cat-file", "--batch-check")
 	cmd.Env = append(cmd.Environ(), "GIT_NO_LAZY_FETCH=1")
-	return cmd.Run() == nil
+	cmd.Stdin = strings.NewReader(strings.Join(lines, "\n") + "\n")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("cat-file --batch-check over %d hashes: %w", len(hashes), err)
+	}
+
+	onDisk := make(map[string]bool, len(hashes))
+	for line := range strings.Lines(string(out)) {
+		fields := strings.Fields(line)
+		// "<oid> missing" carries two fields as well, so test the verdict
+		// rather than the field count.
+		if len(fields) < 2 || fields[1] == "missing" {
+			continue
+		}
+		onDisk[fields[0]] = true
+	}
+	return onDisk, nil
 }
 
 // readFileViaGit reads a blob via "git cat-file -p <hash>" and returns an

--- a/cmd/entire/cli/checkpoint/fetching_tree_test.go
+++ b/cmd/entire/cli/checkpoint/fetching_tree_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,17 +32,7 @@ func TestFetchingTreeReadFileViaGitDisablesLazyFetch(t *testing.T) {
 	testutil.GitCommit(t, repoDir, "add fixture")
 	blobHash := strings.TrimSpace(testutil.RunGit(t, repoDir, "rev-parse", "HEAD:fixture.txt"))
 
-	realGit, err := exec.LookPath("git")
-	require.NoError(t, err)
-	binDir := t.TempDir()
-	tracePath := filepath.Join(t.TempDir(), "cat-file-env")
-	script := fmt.Sprintf(`#!/bin/sh
-printf '%%s\t%%s\n' "$2" "$GIT_NO_LAZY_FETCH" > %q
-exec %q "$@"
-`, tracePath, realGit)
-	require.NoError(t, os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755))
-	t.Setenv("GIT_NO_LAZY_FETCH", "0")
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	tracePath := traceGitCatFile(t)
 	t.Chdir(repoDir)
 
 	tree := &FetchingTree{ctx: t.Context()}
@@ -49,7 +41,104 @@ exec %q "$@"
 	contents, err := file.Contents()
 	require.NoError(t, err)
 	require.Equal(t, "checkpoint content", contents)
+	require.Equal(t, []string{"-p\t1"}, readGitCatFileTrace(t, tracePath))
+}
+
+// TestFetchingTreeCollectMissingBlobsProbesOnce pins both halves of the
+// missing-blob probe: one subprocess for the whole candidate set (not one per
+// blob), with lazy fetching disabled so the probe reports absence instead of
+// creating presence.
+func TestFetchingTreeCollectMissingBlobsProbesOnce(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("fake git uses a POSIX shell script")
+	}
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	hashes := make([]plumbing.Hash, 0, 3)
+	entries := make([]object.TreeEntry, 0, 3)
+	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
+		testutil.WriteFile(t, repoDir, name, "content of "+name)
+		testutil.GitAdd(t, repoDir, name)
+	}
+	testutil.GitCommit(t, repoDir, "add fixtures")
+	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
+		hash := plumbing.NewHash(strings.TrimSpace(testutil.RunGit(t, repoDir, "rev-parse", "HEAD:"+name)))
+		hashes = append(hashes, hash)
+		entries = append(entries, object.TreeEntry{Name: name, Mode: filemode.Regular, Hash: hash})
+	}
+
+	// Delete b.txt's loose object so exactly one candidate is genuinely
+	// absent from the object store while the other two remain readable.
+	absent := hashes[1].String()
+	require.NoError(t, os.Remove(filepath.Join(repoDir, ".git", "objects", absent[:2], absent[2:])))
+
+	tracePath := traceGitCatFile(t)
+	t.Chdir(repoDir)
+
+	// A storer that sees nothing makes every entry a candidate — the
+	// partial-clone shape, where go-git's index misses blobs that are on disk.
+	tree := &FetchingTree{
+		inner:  &object.Tree{Entries: entries},
+		ctx:    t.Context(),
+		storer: blindStorer{},
+	}
+
+	require.Equal(t, []plumbing.Hash{hashes[1]}, tree.CollectMissingBlobs())
+	require.Equal(t, []string{"--batch-check\t1"}, readGitCatFileTrace(t, tracePath))
+}
+
+func TestFetchingTreeCollectMissingBlobsProbeFailureKeepsEveryCandidate(t *testing.T) {
+	hash := plumbing.NewHash("1111111111111111111111111111111111111111")
+	tree := &FetchingTree{
+		// Not a git repository, so the batch probe cannot answer.
+		inner:  &object.Tree{Entries: []object.TreeEntry{{Name: "a.txt", Mode: filemode.Regular, Hash: hash}}},
+		ctx:    t.Context(),
+		storer: blindStorer{},
+	}
+	t.Chdir(t.TempDir())
+
+	require.Equal(t, []plumbing.Hash{hash}, tree.CollectMissingBlobs())
+}
+
+// blindStorer reports every object as absent, standing in for go-git's storer
+// in a partial clone.
+type blindStorer struct {
+	storer.EncodedObjectStorer
+}
+
+func (blindStorer) HasEncodedObject(plumbing.Hash) error {
+	return plumbing.ErrObjectNotFound
+}
+
+// traceGitCatFile puts a git wrapper on PATH that records
+// "<first argument>\t<GIT_NO_LAZY_FETCH>" for every cat-file invocation before
+// exec'ing the real git. GIT_NO_LAZY_FETCH is seeded to 0 in this process so
+// the trace shows what the FetchingTree set rather than an inherited value.
+// Returns the trace path.
+func traceGitCatFile(t *testing.T) string {
+	t.Helper()
+
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+	binDir := t.TempDir()
+	tracePath := filepath.Join(t.TempDir(), "cat-file-env")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "cat-file" ]; then
+	printf '%%s\t%%s\n' "$2" "$GIT_NO_LAZY_FETCH" >> %q
+fi
+exec %q "$@"
+`, tracePath, realGit)
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755))
+	t.Setenv("GIT_NO_LAZY_FETCH", "0")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return tracePath
+}
+
+func readGitCatFileTrace(t *testing.T, tracePath string) []string {
+	t.Helper()
+
 	trace, err := os.ReadFile(tracePath)
 	require.NoError(t, err)
-	require.Equal(t, "-p\t1\n", string(trace))
+	return strings.Split(strings.TrimSuffix(string(trace), "\n"), "\n")
 }

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -778,8 +778,8 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	}
 
 	// One spinner covers the entire data-loading pipeline: prefetch's
-	// missing-blob analysis (which spawns one cat-file -e per blob and
-	// can take seconds on a deep checkpoint subtree), the prefetch fetch
+	// missing-blob analysis (one batched cat-file over the subtree, which
+	// can still take a moment on a deep one), the prefetch fetch
 	// itself, the committed checkpoint metadata read, session content
 	// reads, and getAssociatedCommits' git log walk. Stop strictly before
 	// any write to w (stdout) so stderr spinner frames and stdout output
@@ -896,9 +896,9 @@ func loadCheckpointForExplain(ctx context.Context, lookup *explainCheckpointLook
 // FetchingTree's per-File fetcher.
 //
 // Caller is expected to wrap this with a spinner; both the missing-blob
-// analysis (one cat-file -e per blob) and the actual fetch are silent
-// inside this function so the caller's spinner provides continuous
-// feedback.
+// analysis (one batched cat-file over the subtree) and the actual fetch
+// are silent inside this function so the caller's spinner provides
+// continuous feedback.
 func prefetchCheckpointBlobs(ctx context.Context, repo *git.Repository, cpID id.CheckpointID) {
 	refs := checkpoint.ResolveRefs(ctx)
 	loadPrimaryRoot := func(repo *git.Repository) (*object.Tree, error) {

--- a/cmd/entire/cli/integration_test/explain_test.go
+++ b/cmd/entire/cli/integration_test/explain_test.go
@@ -347,7 +347,8 @@ func TestExplain_CheckpointSucceedsAfterTreelessFetch(t *testing.T) {
 		output = stdout + stderr
 
 		traceLines := strings.Split(strings.TrimSpace(string(trace)), "\n")
-		require.Contains(t, traceLines, "-e\t1", "missing-blob probes must disable lazy fetch")
+		require.Contains(t, traceLines, "--batch-check\t1", "missing-blob probes must disable lazy fetch")
+		require.NotContains(t, traceLines, "-e\t1", "missing-blob probes must be batched, not one cat-file per blob")
 		for _, line := range traceLines {
 			require.True(t, strings.HasSuffix(line, "\t1"), "cat-file ran without lazy fetch disabled: %q", line)
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1158
<!-- entire-trail-link-end -->

Follow-up to #2141, which stopped the missing-blob probe from lazily fetching. It left the other half of the per-blob cost in place: `collectMissingBlobs` asks git about every storer miss individually, so a checkpoint subtree with N filtered-out blobs costs N `git cat-file -e` subprocesses before any fetch happens. `explain.go`'s spinner comment already admitted it — "can take seconds on a deep checkpoint subtree".

## What changed

The walk and the verdict are now separate: `collectStorerMisses` gathers candidates from go-git, then one `git cat-file --batch-check` settles the whole set (git prints `<oid> missing` for what it cannot find). Order and duplicates are preserved, so `PreFetch`'s count and fetch set are unchanged.

`GIT_NO_LAZY_FETCH=1` moves to the batched command and stays load-bearing — `--batch-check` batches the *lookups*, not the promisor fetches. Measured on a promisor clone with 5 missing blobs:

| probe | git fetch children spawned |
| --- | --- |
| `cat-file -e` per blob (before #2141) | 5 |
| `cat-file --batch-check`, no env var | 5 — and reports every blob *present*, having just fetched it |
| `cat-file --batch-check`, `GIT_NO_LAZY_FETCH=1` | 0 |

A probe that cannot run still reports every candidate as missing. That is the direction the per-hash check already failed in and the safe one: a candidate wrongly called missing costs one batched fetch, while one wrongly called present sends `File()` back to a per-blob fetch.

## Tests

- `TestFetchingTreeCollectMissingBlobsProbesOnce` — three candidates, one of whose loose objects is deleted: expects exactly one subprocess, carrying `GIT_NO_LAZY_FETCH=1`, returning exactly the deleted blob. Fails on both axes if the probe goes back to per-blob or drops the env var.
- `TestFetchingTreeCollectMissingBlobsProbeFailureKeepsEveryCandidate` — no repo, so the probe cannot answer; every candidate is kept.
- The treeless-explain integration test now pins `--batch-check\t1` and asserts no `-e\t1` line reappears.
- The shim in `fetching_tree_test.go` is shared by both unit tests now (it filters to `cat-file` and appends instead of truncating); #2141's assertion is unchanged.

Verified: `mise run fmt && mise run lint` (0 issues), full `checkpoint/...` and `cli` packages, `-run TestExplain` integration tests. Both new tests skip on Windows for the same reason #2141's does — the shim is a POSIX script; the production change is not OS-specific.

## Not in scope

The remaining `readFileViaGit` path is untouched. The bigger cleanup Paulo raised — on-demand promisor fetch inside go-git, which would remove the reason `readFileViaGit` exists at all (go-git's packfile index never refreshes) — is upstream work and separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized performance and probe logic in checkpoint blob prefetch; failure handling preserves the prior “assume missing” behavior, and tests lock in batching and `GIT_NO_LAZY_FETCH`.
> 
> **Overview**
> **Missing-blob detection in `FetchingTree` no longer runs one `git cat-file -e` per candidate.** The walk still uses go-git’s storer to collect misses, then settles presence in a **single** `git cat-file --batch-check` subprocess (`collectStorerMisses` → `rejectBlobsOnDisk` / `blobsOnDisk`). That cuts subprocess churn before prefetch on deep checkpoint subtrees—especially on `explain`’s loading spinner path.
> 
> **`GIT_NO_LAZY_FETCH=1` stays on the batched probe** so promisor/partial clones don’t lazy-fetch while asking “is this blob local?” (batch-check batches lookups, not promisor fetches). If the batch probe fails, every candidate is still treated as missing (same safe bias as before).
> 
> Tests add unit coverage for one batch invocation, probe failure, and a shared `cat-file` trace shim; the treeless-explain integration test now expects `--batch-check` with lazy fetch disabled and no per-blob `-e` lines. `explain.go` comments only reflect the batched behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2fa823302908055a255c5c42309b5347a0c6a3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->