### PR TITLE
Let hook checkpoint reads fetch blobs a partial clone filtered out

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -2,8 +2,10 @@ package strategy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
@@ -113,15 +115,65 @@ func (s *ManualCommitStrategy) hookCheckpointStoreOptions(ctx context.Context) c
 // object store, which on a full clone never happens — the cost lands on
 // partial clones, where the alternative is not "no network" but a checkpoint
 // read that reports the checkpoint missing.
+//
+// The returned fetcher also memoizes budget exhaustion for its own lifetime
+// (one hook invocation), which is the blob-side counterpart of
+// gitRefsStore.fetchFailure. The ref memo is consulted only in
+// resolveRefMaybeFetch, so it does not cover blob reads: those go through
+// NewFetchingTree, which holds no memo. Without one, finalizeAllTurnCheckpoints
+// looping state.TurnCheckpointIDs against a single store paid
+// WriteProbeFetchBudget PER CHECKPOINT on a dead network — and FetchingTree.File
+// fetches one hash at a time, so a read touching several missing blobs paid it
+// several times. Nothing bounds the total: newGitHookContext adds no deadline,
+// and an agent kills the hook long before the loop ends.
+//
+// Only budget exhaustion is memoized, deliberately. It is the dead-network
+// signature and the only failure expensive enough to be worth not repeating; a
+// fast error is cheap to retry and may be one blob's genuine remote absence,
+// which must not stop the next blob from being fetched. As in the ref memo, a
+// cancellation originating from the CALLER says nothing about the remote and is
+// never memoized.
 func (s *ManualCommitStrategy) hookBlobFetcher() checkpoint.BlobFetchFunc {
 	if s.blobFetcher == nil {
 		return nil
 	}
+	var (
+		mu        sync.Mutex
+		exhausted error
+	)
 	return func(ctx context.Context, hashes []plumbing.Hash) error {
-		ctx, cancel := context.WithTimeout(remote.WithNonInteractiveSSH(ctx), remote.WriteProbeFetchBudget)
+		mu.Lock()
+		prior := exhausted
+		mu.Unlock()
+		if prior != nil {
+			return prior
+		}
+
+		fetchCtx, cancel := context.WithTimeout(remote.WithNonInteractiveSSH(ctx), hookBlobFetchBudget)
 		defer cancel()
-		return s.blobFetcher(ctx, hashes)
+		err := s.blobFetcher(fetchCtx, hashes)
+		if err != nil && ctx.Err() == nil && errors.Is(fetchCtx.Err(), context.DeadlineExceeded) {
+			mu.Lock()
+			if exhausted == nil {
+				exhausted = err
+			}
+			mu.Unlock()
+		}
+		return err
 	}
+}
+
+// hookBlobFetchBudget bounds one blob fetch on a git-hook path. A var, not a
+// const, only so tests can shorten it; production always uses the write-probe
+// budget the ref probe on the same hooks already uses.
+var hookBlobFetchBudget = remote.WriteProbeFetchBudget
+
+// setHookBlobFetchBudgetForTesting shortens the per-fetch budget and returns a
+// func restoring it.
+func setHookBlobFetchBudgetForTesting(d time.Duration) (restore func()) {
+	orig := hookBlobFetchBudget
+	hookBlobFetchBudget = d
+	return func() { hookBlobFetchBudget = orig }
 }
 
 // ValidateRepository validates that the repository is suitable for this strategy.

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -149,6 +149,16 @@ func (s *ManualCommitStrategy) hookBlobFetcher() checkpoint.BlobFetchFunc {
 		exhausted error
 	)
 	return func(ctx context.Context, hashes []plumbing.Hash) error {
+		// The lock covers the read and is then released — deliberately not held
+		// across the check and fetch below. Two things forbid widening it: the
+		// fetch is a bounded network call, and the memo write further down
+		// re-acquires this same non-reentrant mutex, so holding it here
+		// deadlocks. That leaves a check-then-act window where two concurrent
+		// first-callers would both fetch, which is acceptable: every caller on
+		// these paths is sequential (finalizeAllTurnCheckpoints loops one
+		// checkpoint at a time; FetchingTree.File and PreFetch are sequential
+		// within a read), and if it were ever reached the cost is one duplicate
+		// fetch, not a wrong answer.
 		mu.Lock()
 		prior := exhausted
 		mu.Unlock()

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -28,6 +28,13 @@ type ManualCommitStrategy struct {
 	// blobFetcher, when set, is passed to the checkpoint store to enable
 	// on-demand blob fetching after treeless fetches. Set via SetBlobFetcher.
 	blobFetcher checkpoint.BlobFetchFunc
+
+	// blobFetchBudget bounds one blob fetch on a git-hook path. Zero means
+	// remote.WriteProbeFetchBudget. Per-instance rather than a package var so
+	// tests can shorten it without mutating process-global state, which
+	// t.Parallel() makes a data race (CLAUDE.md: "Tests that modify
+	// process-global state cannot be parallelized").
+	blobFetchBudget time.Duration
 }
 
 // getStateStore returns the session state store, initializing it lazily if needed.
@@ -149,7 +156,11 @@ func (s *ManualCommitStrategy) hookBlobFetcher() checkpoint.BlobFetchFunc {
 			return prior
 		}
 
-		fetchCtx, cancel := context.WithTimeout(remote.WithNonInteractiveSSH(ctx), hookBlobFetchBudget)
+		budget := s.blobFetchBudget
+		if budget == 0 {
+			budget = remote.WriteProbeFetchBudget
+		}
+		fetchCtx, cancel := context.WithTimeout(remote.WithNonInteractiveSSH(ctx), budget)
 		defer cancel()
 		err := s.blobFetcher(fetchCtx, hashes)
 		if err != nil && ctx.Err() == nil && errors.Is(fetchCtx.Err(), context.DeadlineExceeded) {
@@ -161,19 +172,6 @@ func (s *ManualCommitStrategy) hookBlobFetcher() checkpoint.BlobFetchFunc {
 		}
 		return err
 	}
-}
-
-// hookBlobFetchBudget bounds one blob fetch on a git-hook path. A var, not a
-// const, only so tests can shorten it; production always uses the write-probe
-// budget the ref probe on the same hooks already uses.
-var hookBlobFetchBudget = remote.WriteProbeFetchBudget
-
-// setHookBlobFetchBudgetForTesting shortens the per-fetch budget and returns a
-// func restoring it.
-func setHookBlobFetchBudgetForTesting(d time.Duration) (restore func()) {
-	orig := hookBlobFetchBudget
-	hookBlobFetchBudget = d
-	return func() { hookBlobFetchBudget = orig }
 }
 
 // ValidateRepository validates that the repository is suitable for this strategy.

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -6,8 +6,10 @@ import (
 	"sync"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 // ManualCommitStrategy implements the manual-commit strategy for session management.
@@ -85,6 +87,41 @@ func (s *ManualCommitStrategy) SetBlobFetcher(f checkpoint.BlobFetchFunc) {
 // Used in tests to verify the strategy is properly wired for treeless fetch support.
 func (s *ManualCommitStrategy) HasBlobFetcher() bool {
 	return s.blobFetcher != nil
+}
+
+// hookCheckpointStoreOptions is the store envelope for a git-hook read: the
+// bounded ref probe, the bounded blob fetch, and the read-candidate chain. The
+// two bounds live together because a hook that has one and not the other still
+// fails — a ref fetcher with no blob fetcher resolves the checkpoint's ref and
+// then reads its filtered-out metadata.json as absent, reporting a checkpoint
+// that exists as missing.
+func (s *ManualCommitStrategy) hookCheckpointStoreOptions(ctx context.Context) checkpoint.OpenOptions {
+	return checkpoint.OpenOptions{
+		RefFetcher:  remote.HookCheckpointRefFetcher(),
+		BlobFetcher: s.hookBlobFetcher(),
+		ReadRemotes: CheckpointReadRemotes(ctx),
+	}
+}
+
+// hookBlobFetcher returns the strategy's blob fetcher bounded for git-hook
+// contexts: the write-probe budget over the whole call plus BatchMode SSH, the
+// same envelope remote.HookCheckpointRefFetcher puts around the ref probe those
+// hooks already run. Reads there must not inherit the interactive read chain's
+// minutes while a user's git command waits on the hook.
+//
+// It fires only when a checkpoint blob is genuinely absent from the local
+// object store, which on a full clone never happens — the cost lands on
+// partial clones, where the alternative is not "no network" but a checkpoint
+// read that reports the checkpoint missing.
+func (s *ManualCommitStrategy) hookBlobFetcher() checkpoint.BlobFetchFunc {
+	if s.blobFetcher == nil {
+		return nil
+	}
+	return func(ctx context.Context, hashes []plumbing.Hash) error {
+		ctx, cancel := context.WithTimeout(remote.WithNonInteractiveSSH(ctx), remote.WriteProbeFetchBudget)
+		defer cancel()
+		return s.blobFetcher(ctx, hashes)
+	}
 }
 
 // ValidateRepository validates that the repository is suitable for this strategy.

--- a/cmd/entire/cli/strategy/manual_commit_hook_blob_fetcher_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_hook_blob_fetcher_test.go
@@ -133,8 +133,7 @@ func TestHookBlobFetcher_MemoizesBudgetExhaustion(t *testing.T) {
 		return ctx.Err()
 	})
 
-	restore := setHookBlobFetchBudgetForTesting(20 * time.Millisecond)
-	defer restore()
+	s.blobFetchBudget = 20 * time.Millisecond
 
 	fetch := s.hookBlobFetcher()
 	for range 5 {
@@ -190,8 +189,7 @@ func TestHookBlobFetcher_DoesNotMemoizeCallerCancellation(t *testing.T) {
 	cancel()
 	require.Error(t, fetch(cancelled, []plumbing.Hash{plumbing.ZeroHash}))
 
-	restore := setHookBlobFetchBudgetForTesting(20 * time.Millisecond)
-	defer restore()
+	s.blobFetchBudget = 20 * time.Millisecond
 	require.Error(t, fetch(context.Background(), []plumbing.Hash{plumbing.ZeroHash}))
 
 	require.Equal(t, 2, calls, "caller cancellation must not memoize a network verdict")

--- a/cmd/entire/cli/strategy/manual_commit_hook_blob_fetcher_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_hook_blob_fetcher_test.go
@@ -1,0 +1,99 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHookCheckpointStoreOptions_CarriesBothBounds is the guard for the shape
+// that broke: a hook store that fetches missing refs but not missing blobs
+// resolves a checkpoint's ref and then reports the checkpoint itself missing on
+// any partial clone.
+func TestHookCheckpointStoreOptions_CarriesBothBounds(t *testing.T) {
+	t.Parallel()
+
+	s := NewManualCommitStrategy()
+	s.SetBlobFetcher(func(context.Context, []plumbing.Hash) error { return nil })
+
+	opts := s.hookCheckpointStoreOptions(context.Background())
+
+	require.NotNil(t, opts.RefFetcher, "hook reads must be able to fetch a ref that exists only on the remote")
+	require.NotNil(t, opts.BlobFetcher, "hook reads must be able to fetch a blob a partial clone filtered out")
+}
+
+func TestHookBlobFetcher_NilWithoutBlobFetcher(t *testing.T) {
+	t.Parallel()
+
+	s := NewManualCommitStrategy()
+
+	require.Nil(t, s.hookBlobFetcher(), "no fetcher to bound means no fetcher to hand the store")
+}
+
+// TestHookBlobFetcher_BoundsTheCallAndPassesHashes pins the envelope the hook
+// paths rely on: the interactive read chain's minutes must not be inherited by
+// a hook the user's git command is waiting on, and SSH must not be able to
+// prompt for a passphrase there.
+func TestHookBlobFetcher_BoundsTheCallAndPassesHashes(t *testing.T) {
+	t.Parallel()
+
+	want := []plumbing.Hash{
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+		plumbing.NewHash("2222222222222222222222222222222222222222"),
+	}
+	sentinel := errors.New("fetch failed")
+
+	var (
+		gotHashes   []plumbing.Hash
+		gotDeadline time.Time
+		gotBatchSSH bool
+		called      int
+	)
+	s := NewManualCommitStrategy()
+	s.SetBlobFetcher(func(ctx context.Context, hashes []plumbing.Hash) error {
+		called++
+		gotHashes = hashes
+		gotDeadline, _ = ctx.Deadline()
+		gotBatchSSH = remote.IsNonInteractiveSSH(ctx)
+		return sentinel
+	})
+
+	fetch := s.hookBlobFetcher()
+	require.NotNil(t, fetch)
+	require.ErrorIs(t, fetch(context.Background(), want), sentinel, "the store must still see why a fetch failed")
+
+	require.Equal(t, 1, called)
+	require.Equal(t, want, gotHashes)
+	require.True(t, gotBatchSSH, "a hook fetch must not be able to prompt for an SSH passphrase")
+	require.WithinDuration(t, time.Now().Add(remote.WriteProbeFetchBudget), gotDeadline, remote.WriteProbeFetchBudget,
+		"the hook fetch must carry the write-probe budget, not the interactive read chain's")
+	require.Less(t, time.Until(gotDeadline), remote.ReadChainBudget,
+		"the hook fetch must be bounded well inside the interactive read chain")
+}
+
+// TestHookBlobFetcher_DoesNotExtendACallerDeadline guards the direction that
+// matters when the hook itself is already running out of time (an agent's
+// session-end budget): bounding must never push a deadline out.
+func TestHookBlobFetcher_DoesNotExtendACallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	var gotDeadline time.Time
+	s := NewManualCommitStrategy()
+	s.SetBlobFetcher(func(ctx context.Context, _ []plumbing.Hash) error {
+		gotDeadline, _ = ctx.Deadline()
+		return nil
+	})
+
+	tight := 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), tight)
+	defer cancel()
+	require.NoError(t, s.hookBlobFetcher()(ctx, []plumbing.Hash{plumbing.ZeroHash}))
+
+	require.LessOrEqual(t, time.Until(gotDeadline), tight)
+}

--- a/cmd/entire/cli/strategy/manual_commit_hook_blob_fetcher_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_hook_blob_fetcher_test.go
@@ -73,7 +73,7 @@ func TestHookBlobFetcher_BoundsTheCallAndPassesHashes(t *testing.T) {
 	require.Equal(t, want, gotHashes)
 	require.True(t, gotBatchSSH, "a hook fetch must not be able to prompt for an SSH passphrase")
 	require.True(t, gotHasDeadline, "a hook fetch must carry a deadline at all")
-	require.WithinDuration(t, time.Now().Add(remote.WriteProbeFetchBudget), gotDeadline, remote.WriteProbeFetchBudget,
+	require.WithinDuration(t, time.Now().Add(remote.WriteProbeFetchBudget), gotDeadline, 2*time.Second,
 		"the hook fetch must carry the write-probe budget, not the interactive read chain's")
 	require.Less(t, time.Until(gotDeadline), remote.ReadChainBudget,
 		"the hook fetch must be bounded well inside the interactive read chain")

--- a/cmd/entire/cli/strategy/manual_commit_hook_blob_fetcher_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_hook_blob_fetcher_test.go
@@ -50,16 +50,17 @@ func TestHookBlobFetcher_BoundsTheCallAndPassesHashes(t *testing.T) {
 	sentinel := errors.New("fetch failed")
 
 	var (
-		gotHashes   []plumbing.Hash
-		gotDeadline time.Time
-		gotBatchSSH bool
-		called      int
+		gotHashes      []plumbing.Hash
+		gotDeadline    time.Time
+		gotHasDeadline bool
+		gotBatchSSH    bool
+		called         int
 	)
 	s := NewManualCommitStrategy()
 	s.SetBlobFetcher(func(ctx context.Context, hashes []plumbing.Hash) error {
 		called++
 		gotHashes = hashes
-		gotDeadline, _ = ctx.Deadline()
+		gotDeadline, gotHasDeadline = ctx.Deadline()
 		gotBatchSSH = remote.IsNonInteractiveSSH(ctx)
 		return sentinel
 	})
@@ -71,6 +72,7 @@ func TestHookBlobFetcher_BoundsTheCallAndPassesHashes(t *testing.T) {
 	require.Equal(t, 1, called)
 	require.Equal(t, want, gotHashes)
 	require.True(t, gotBatchSSH, "a hook fetch must not be able to prompt for an SSH passphrase")
+	require.True(t, gotHasDeadline, "a hook fetch must carry a deadline at all")
 	require.WithinDuration(t, time.Now().Add(remote.WriteProbeFetchBudget), gotDeadline, remote.WriteProbeFetchBudget,
 		"the hook fetch must carry the write-probe budget, not the interactive read chain's")
 	require.Less(t, time.Until(gotDeadline), remote.ReadChainBudget,
@@ -83,10 +85,13 @@ func TestHookBlobFetcher_BoundsTheCallAndPassesHashes(t *testing.T) {
 func TestHookBlobFetcher_DoesNotExtendACallerDeadline(t *testing.T) {
 	t.Parallel()
 
-	var gotDeadline time.Time
+	var (
+		gotDeadline    time.Time
+		gotHasDeadline bool
+	)
 	s := NewManualCommitStrategy()
 	s.SetBlobFetcher(func(ctx context.Context, _ []plumbing.Hash) error {
-		gotDeadline, _ = ctx.Deadline()
+		gotDeadline, gotHasDeadline = ctx.Deadline()
 		return nil
 	})
 
@@ -95,5 +100,99 @@ func TestHookBlobFetcher_DoesNotExtendACallerDeadline(t *testing.T) {
 	defer cancel()
 	require.NoError(t, s.hookBlobFetcher()(ctx, []plumbing.Hash{plumbing.ZeroHash}))
 
+	// Assert the deadline EXISTS before comparing it. Without this the test is a
+	// false positive in the direction that matters most: if the wrapper stopped
+	// propagating a deadline, ctx.Deadline() returns (time.Time{}, false),
+	// gotDeadline stays at the zero time — year 1 — and time.Until of that is
+	// hugely negative, so the upper bound below is satisfied and an unbounded
+	// hook fetch passes as bounded.
+	require.True(t, gotHasDeadline, "bounding must not drop the caller's deadline entirely")
 	require.LessOrEqual(t, time.Until(gotDeadline), tight)
+}
+
+// TestHookBlobFetcher_MemoizesBudgetExhaustion is the guard for the N-times
+// stall the ref path already avoids and the blob path did not.
+//
+// gitRefsStore.fetchFailure memoizes a dead network for the store's lifetime,
+// and its doc comment names the exact scenario: "a loop over N missing refs
+// (e.g. a stop hook finalizing every checkpoint of a turn) pays a dead network
+// once instead of N times". But it is consulted only in resolveRefMaybeFetch —
+// the ref path. Blob reads go through NewFetchingTree, which holds no memo, so
+// finalizeAllTurnCheckpoints looping TurnCheckpointIDs with one store paid
+// WriteProbeFetchBudget per checkpoint (and File() fetches one hash at a time,
+// so a read touching several missing blobs paid it several times). Nothing
+// encloses that: newGitHookContext adds no deadline.
+func TestHookBlobFetcher_MemoizesBudgetExhaustion(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	s := NewManualCommitStrategy()
+	s.SetBlobFetcher(func(ctx context.Context, _ []plumbing.Hash) error {
+		calls++
+		<-ctx.Done() // a dead network: burn the whole budget
+		return ctx.Err()
+	})
+
+	restore := setHookBlobFetchBudgetForTesting(20 * time.Millisecond)
+	defer restore()
+
+	fetch := s.hookBlobFetcher()
+	for range 5 {
+		require.Error(t, fetch(context.Background(), []plumbing.Hash{plumbing.ZeroHash}))
+	}
+
+	require.Equal(t, 1, calls,
+		"a budget-exhausted blob fetch must be memoized for the hook's lifetime; "+
+			"otherwise a stop hook finalizing N checkpoints pays the budget N times")
+}
+
+// TestHookBlobFetcher_DoesNotMemoizeAFastFailure keeps the memo from poisoning
+// recoverable reads. Only budget exhaustion — the dead-network signature, and
+// the only failure expensive enough to be worth not repeating — is memoized. A
+// fast error may be one blob's genuine absence, and must not stop the next
+// blob from being fetched.
+func TestHookBlobFetcher_DoesNotMemoizeAFastFailure(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("remote has no such blob")
+	var calls int
+	s := NewManualCommitStrategy()
+	s.SetBlobFetcher(func(context.Context, []plumbing.Hash) error {
+		calls++
+		return sentinel
+	})
+
+	fetch := s.hookBlobFetcher()
+	for range 3 {
+		require.ErrorIs(t, fetch(context.Background(), []plumbing.Hash{plumbing.ZeroHash}), sentinel)
+	}
+
+	require.Equal(t, 3, calls, "a fast failure is cheap to repeat and may be per-blob absence")
+}
+
+// TestHookBlobFetcher_DoesNotMemoizeCallerCancellation mirrors the ref memo's
+// guard: a cancellation originating from the CALLER's context says nothing
+// about the remote and must not poison later fetches on this hook.
+func TestHookBlobFetcher_DoesNotMemoizeCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	s := NewManualCommitStrategy()
+	s.SetBlobFetcher(func(ctx context.Context, _ []plumbing.Hash) error {
+		calls++
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	fetch := s.hookBlobFetcher()
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Error(t, fetch(cancelled, []plumbing.Hash{plumbing.ZeroHash}))
+
+	restore := setHookBlobFetchBudgetForTesting(20 * time.Millisecond)
+	defer restore()
+	require.Error(t, fetch(context.Background(), []plumbing.Hash{plumbing.ZeroHash}))
+
+	require.Equal(t, 2, calls, "caller cancellation must not memoize a network verdict")
 }

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
-	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
 	"github.com/entireio/cli/cmd/entire/cli/gitops"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
@@ -1129,13 +1128,12 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 	repoDir string,
 ) error {
 	logCtx := logging.WithComponent(ctx, "attribution")
-	// RefFetcher: the attribution backfill's absence probe fetches a ref that
-	// exists remotely but not locally. Bounded budget + the store's failure
-	// memo keep a dead network from stalling the post-commit hook.
-	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{
-		RefFetcher:  remote.HookCheckpointRefFetcher(),
-		ReadRemotes: CheckpointReadRemotes(ctx),
-	})
+	// The hook store envelope (see hookCheckpointStoreOptions): the attribution
+	// backfill's absence probe fetches a ref that exists remotely but not
+	// locally, and on a partial clone the checkpoint's own blobs need fetching
+	// too. Bounded budgets + the store's failure memo keep a dead network from
+	// stalling the post-commit hook.
+	stores, err := checkpoint.Open(ctx, repo, s.hookCheckpointStoreOptions(ctx))
 	if err != nil {
 		return fmt.Errorf("open checkpoint store: %w", err)
 	}
@@ -3165,14 +3163,12 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 	// Post-commit emits regex-only blobs; the writer joins + redacts
 	// via checkpoint.redactedJoinedPrompts. OPF runs later, once per
 	// push, in the pre-push rewrite path.
-	// RefFetcher: the transcript finalize targets existing checkpoints whose
-	// refs may live only on the remote (resumed/adopted multi-machine
-	// sessions). Bounded budget + the store's failure memo keep a dead
-	// network from stalling the stop hook N times.
-	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{
-		RefFetcher:  remote.HookCheckpointRefFetcher(),
-		ReadRemotes: CheckpointReadRemotes(ctx),
-	})
+	// The hook store envelope (see hookCheckpointStoreOptions): the transcript
+	// finalize targets existing checkpoints whose refs — and, on a partial
+	// clone, whose blobs — may live only on the remote (resumed/adopted
+	// multi-machine sessions). Bounded budgets + the store's failure memo keep
+	// a dead network from stalling the stop hook N times.
+	stores, err := checkpoint.Open(ctx, repo, s.hookCheckpointStoreOptions(ctx))
 	if err != nil {
 		logging.Warn(logCtx, "finalize: failed to open checkpoint store",
 			slog.String("error", err.Error()),

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1131,8 +1131,10 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 	// The hook store envelope (see hookCheckpointStoreOptions): the attribution
 	// backfill's absence probe fetches a ref that exists remotely but not
 	// locally, and on a partial clone the checkpoint's own blobs need fetching
-	// too. Bounded budgets + the store's failure memo keep a dead network from
-	// stalling the post-commit hook.
+	// too. Bounded budgets keep a dead network from stalling the post-commit
+	// hook: the ref store memoizes a failed ref fetch (gitRefsStore.fetchFailure)
+	// and hookBlobFetcher memoizes an exhausted blob fetch, so the two paths are
+	// bounded independently.
 	stores, err := checkpoint.Open(ctx, repo, s.hookCheckpointStoreOptions(ctx))
 	if err != nil {
 		return fmt.Errorf("open checkpoint store: %w", err)
@@ -3166,8 +3168,11 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 	// The hook store envelope (see hookCheckpointStoreOptions): the transcript
 	// finalize targets existing checkpoints whose refs — and, on a partial
 	// clone, whose blobs — may live only on the remote (resumed/adopted
-	// multi-machine sessions). Bounded budgets + the store's failure memo keep
-	// a dead network from stalling the stop hook N times.
+	// multi-machine sessions). This loops over every checkpoint of the turn
+	// against one store, so both fetch paths need their own memo or a dead
+	// network costs the budget N times: gitRefsStore.fetchFailure covers refs,
+	// and hookBlobFetcher memoizes an exhausted blob fetch. Nothing else bounds
+	// the total — newGitHookContext adds no deadline.
 	stores, err := checkpoint.Open(ctx, repo, s.hookCheckpointStoreOptions(ctx))
 	if err != nil {
 		logging.Warn(logCtx, "finalize: failed to open checkpoint store",


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1159
<!-- entire-trail-link-end -->

Follow-up to #2141. Disabling git's lazy fetch on the checkpoint read path was right, but two hook paths open the store with a bounded *ref* fetcher and **no blob fetcher**, and on a partial clone that combination now fails silently.

## The mechanism

`updateCombinedAttributionForCheckpoint` (post-commit) and `finalizeAllTurnCheckpoints` (stop hook) both open with `RefFetcher: remote.HookCheckpointRefFetcher()` and no `BlobFetcher`. On a partial clone the ref resolves, then the checkpoint's `metadata.json` is a filtered-out blob, `FetchingTree.File` fails at every tier, and `GitStore.Read` maps that to `(nil, nil)` — *checkpoint not found*. Attribution is skipped; the finalized transcript never reaches its checkpoints. Nothing above `Debug` says why.

Verified against a real promisor clone (bare with `uploadpack.allowFilter` + `allowAnySHA1InWant`, `git fetch --filter=blob:none` from a named remote, so `remote.origin.promisor=true`), reading through a `FetchingTree` with a nil fetcher:

- with #2141 → `blob 22d75e350a99 not available locally and no fetcher configured`
- with #2141's two env lines reverted → succeeds, via git's promisor fetch

So before #2141 these reads worked — by doing an *unbounded* promisor fetch, one round-trip per blob, from inside a hook the user's `git commit` was waiting on. That's the thing worth not going back to.

## What changed

Both sites now take the same envelope the ref probe already has, from one place:

```go
func (s *ManualCommitStrategy) hookCheckpointStoreOptions(ctx context.Context) checkpoint.OpenOptions {
	return checkpoint.OpenOptions{
		RefFetcher:  remote.HookCheckpointRefFetcher(),
		BlobFetcher: s.hookBlobFetcher(),
		ReadRemotes: CheckpointReadRemotes(ctx),
	}
}
```

`hookBlobFetcher` wraps the strategy's injected fetcher in `remote.WriteProbeFetchBudget` (15s over the whole call, not the interactive chain's 3 minutes) plus `remote.WithNonInteractiveSSH`, so a passphrase-protected key can neither prompt nor invisibly hang. It returns nil when no fetcher was injected, and never extends a caller's tighter deadline — an agent's session-end budget still wins.

The two bounds share a constructor on purpose: a hook that fetches refs but not blobs still reports checkpoints that exist as missing, which is exactly the shape being fixed. The fetcher fires only when a blob is genuinely absent locally, so a full clone pays nothing.

## The memo, and why it belongs in this PR

Putting a `BlobFetcher` on these two opens is what creates the exposure below — before this PR both passed `RefFetcher` only — so the mitigation ships with it rather than as a follow-up.

`gitRefsStore.fetchFailure` already memoizes a dead network for the store's lifetime, and its doc comment names the exact case: *"a loop over N missing refs (e.g. a stop hook finalizing every checkpoint of a turn) pays a dead network once instead of N times"*. But it is consulted only in `resolveRefMaybeFetch` (`refs_store.go:402`) — the ref path. Blob reads go through `NewFetchingTree`, whose struct is `{inner, ctx, storer, fetch}` with no memo, and which is rebuilt per tree read at `refs_store.go:377`.

So without a blob-side memo, `finalizeAllTurnCheckpoints` — one store, looping `state.TurnCheckpointIDs`, `errCount++; continue` past each failure — pays `WriteProbeFetchBudget` **per checkpoint** on a dead network. And `FetchingTree.File` fetches one hash at a time, so a read touching several missing blobs pays it several times over. Nothing bounds the total: `newGitHookContext` adds no deadline, so the ceiling is the agent killing the hook (~60s for Claude Code), after which nothing past the loop runs.

`hookBlobFetcher` now memoizes for its own lifetime — one `hookCheckpointStoreOptions` call, therefore one store open, the same scope as the ref memo. Two choices worth stating:

- **In the closure, not on the store.** The condition is "*our* budget expired", and only the code that created the timeout can distinguish that from a caller deadline or a remote refusal. A store-level memo would be more symmetric but would also reach interactive paths like `checkpoint explain`, which have a 3-minute budget and a user watching.
- **Only budget exhaustion is memoized.** That is the dead-network signature and the only failure expensive enough to be worth not repeating. A fast error is cheap to retry and may be one blob's genuine remote absence, which must not stop the next blob from being fetched. As in the ref memo, a cancellation originating from the caller says nothing about the remote and is never memoized.

Both comments that claimed *"Bounded budgets + the store's failure memo"* are corrected — the ref memo lives on the store, the blob memo on the fetcher, and they are bounded independently.

## Judgment call, flagged rather than buried

This puts a bounded network call in a hook. The precedent is `HookCheckpointRefFetcher` in the same `OpenOptions` with the same reasoning, and the alternative on partial clones is not "no network" but silently wrong checkpoint data. If you'd rather these paths stay strictly local and surface a warning instead, that's a one-line change to `hookBlobFetcher` and I'm happy to flip it.

## Deliberately not in scope

Four other fetcher-less read sites, left alone for stated reasons:

- `head_checkpoint_flags.go:56` — feeds `entire status`; a fetch there is worse than the missing review/investigation hint.
- `review_context.go:100` — best-effort context enrichment, loops over many checkpoints.
- `dispatch/mode_local.go:230` — needs the fetcher plumbed across a package boundary (`dispatch` cannot import `cli`).
- `explain.go:733` — the temporary-checkpoint store reads the shadow branch, whose blobs are always local.

Also out of scope, and pre-existing: **a slow-but-alive network defeats both memos.** Each fetch returns just under budget, neither memo trips, and N still accumulate — 5 × 14s is as fatal to a 60s hook as 5 × 15s. Fixing that needs an enclosing deadline over the finalize loop plus a decision about silently leaving later checkpoints unfinalized (probably fine — finalize is already best-effort and PostCommit retries — but that deserves its own review, and it interacts with Codex's `SessionEndBudgeter`).

## Tests

`manual_commit_hook_blob_fetcher_test.go`: the envelope carries both fetchers; the bound is the write-probe budget and well inside `ReadChainBudget`; BatchMode SSH is marked; hashes and errors pass through; a tighter caller deadline is not extended; nil in, nil out. Plus the memo's three cases — exhaustion is memoized, a fast failure is not, caller cancellation is not.

Two of these were mutation-tested rather than just run: dropping the deadline from `hookBlobFetcher` fails both deadline tests, and removing the memo consult fails the memo test.

One test was a **false positive** before this commit, flagged in review. `TestHookBlobFetcher_DoesNotExtendACallerDeadline` discarded the `ok` from `ctx.Deadline()`, so if the wrapper stopped propagating a deadline entirely, `gotDeadline` stayed at the zero time — year 1 — and `time.Until` of that is hugely negative, satisfying the upper bound. It passed in the failure mode that matters most: an unbounded network fetch inside a git hook. `BoundsTheCallAndPassesHashes` had the same discard but was protected incidentally by `require.WithinDuration`; that requirement is now explicit so loosening the assertion cannot reopen it.

Verified: `mise run fmt && mise run lint` (0 issues), full `strategy` package, full integration suite, `test:e2e:canary` (4/4). One integration failure is pre-existing on `main` and unrelated — `TestCodexAppServerHooksList_BareWorktreeUsesLayoutRoot` compares `/var` against macOS's `/private/var`.

There is no end-to-end coverage of hooks running inside a partial clone; the harness has no such fixture, and I'd rather say that than imply the wiring is proven end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds bounded network blob fetches inside post-commit and stop hooks, which can affect commit/stop latency on partial clones or slow remotes, though budgets mirror existing hook ref-fetch behavior.
> 
> **Overview**
> **Git hooks that read checkpoints** (post-commit combined attribution and stop-hook transcript finalize) no longer open the store with only a bounded remote **ref** fetcher. They now use shared `hookCheckpointStoreOptions`, which pairs `HookCheckpointRefFetcher` with a **`hookBlobFetcher`** wrapper around the strategy’s injected blob fetcher.
> 
> On **partial clones**, resolving the checkpoint ref but missing filtered-out blobs (e.g. `metadata.json`) used to surface as “checkpoint not found,” skipping attribution and finalize. The blob path only runs when objects are absent locally, so full clones stay unchanged.
> 
> **`hookBlobFetcher`** applies the same hook constraints as the ref probe: `WriteProbeFetchBudget` (not the long interactive read chain), non-interactive SSH, and it does not extend a tighter caller deadline. Tests lock in both fetchers being present, timeout/SSH behavior, hash pass-through, and nil when no fetcher is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd0da4cb1bb3c0438058e772acbecddb1d61cc6e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
