### PR TITLE
e2e: stop running the gemini-cli leg

### DIFF
--- a/.github/workflows/e2e-checkpoint-store.yml
+++ b/.github/workflows/e2e-checkpoint-store.yml
@@ -46,7 +46,10 @@ jobs:
           if [ -n "$input" ]; then
             echo "agents=[\"$input\"]" >> "$GITHUB_OUTPUT"
           else
-            echo 'agents=["claude-code","opencode","gemini-cli","factoryai-droid","cursor-cli","copilot-cli","roger-roger","codex"]' >> "$GITHUB_OUTPUT"
+            # gemini-cli is excluded from the fan-out for the same reason as in
+            # e2e.yml (Gemini CLI >=0.57.0 forces `core.hooksPath=''`); select it
+            # explicitly to run it anyway.
+            echo 'agents=["claude-code","opencode","factoryai-droid","cursor-cli","copilot-cli","roger-roger","codex"]' >> "$GITHUB_OUTPUT"
           fi
 
   e2e-checkpoint-store:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,12 +34,19 @@ jobs:
       agents: ${{ steps.set.outputs.agents }}
     steps:
       - id: set
+        # gemini-cli is deliberately absent from the all-agents list. Since
+        # Gemini CLI 0.57.0 the agent forces `core.hooksPath=''` on every shell
+        # command it runs, so no checkpoint is recorded for a commit it makes and
+        # the leg fails for a reason no change on our side can fix. It stays in
+        # the workflow_dispatch choices above so the leg can be run by hand
+        # against a newer Gemini release; put it back in this list (it is still
+        # in the RED "reliable" tier in notify-slack) once one restores hooks.
         run: |
           input="${{ github.event.inputs.agent }}"
           if [ -n "$input" ]; then
             echo "agents=[\"$input\"]" >> "$GITHUB_OUTPUT"
           else
-            echo 'agents=["claude-code","opencode","gemini-cli","factoryai-droid","cursor-cli","copilot-cli","roger-roger","codex"]' >> "$GITHUB_OUTPUT"
+            echo 'agents=["claude-code","opencode","factoryai-droid","cursor-cli","copilot-cli","roger-roger","codex"]' >> "$GITHUB_OUTPUT"
           fi
 
   e2e-tests:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,11 @@ jobs:
       agents: ${{ steps.set.outputs.agents }}
     steps:
       - id: set
+        # Pass the input through env rather than interpolating it into the script:
+        # `type: choice` only constrains the UI, so a REST-API dispatch could inject
+        # shell metacharacters here otherwise.
+        env:
+          AGENT_INPUT: ${{ github.event.inputs.agent }}
         # gemini-cli is deliberately absent from the all-agents list. Since
         # Gemini CLI 0.57.0 the agent forces `core.hooksPath=''` on every shell
         # command it runs, so no checkpoint is recorded for a commit it makes and
@@ -42,7 +47,7 @@ jobs:
         # against a newer Gemini release; put it back in this list (it is still
         # in the RED "reliable" tier in notify-slack) once one restores hooks.
         run: |
-          input="${{ github.event.inputs.agent }}"
+          input="$AGENT_INPUT"
           if [ -n "$input" ]; then
             echo "agents=[\"$input\"]" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1160
<!-- entire-trail-link-end -->

## What

Drops `gemini-cli` from the two E2E agent fan-outs:

- `.github/workflows/e2e.yml` — the all-agents matrix. This is the only workflow that runs E2E automatically (`push` to `main`), so this is the change that stops the failing leg and its Slack alert.
- `.github/workflows/e2e-checkpoint-store.yml` — its empty-input ("run all agents") fan-out. Dispatch-only, but excluded for consistency.

## Why

Since Gemini CLI 0.57.0 the agent forces `core.hooksPath=''` on every shell command it runs. No checkpoint is recorded for a commit the agent makes, so the leg fails for a reason no change on our side can fix, and it has been reddening `main` on every push.

Note this turns off the alarm, not the bug — the underlying product regression (agent-made commits capture nothing under Gemini ≥0.57.0) is real and currently has no tracking issue.

## What stays

- `gemini-cli` remains in every `workflow_dispatch` choice list, so the leg can be run by hand against a newer Gemini release to check whether hooks came back.
- It remains in the RED `reliable` tier in `notify-slack` (unreachable while the leg is off, since that job only runs on `push`), so re-enabling is a one-line change to the matrix.
- The Go-side Gemini agent and its tests (`e2e/agents/gemini.go`, `gemini_test.go`) are untouched.
- Nothing local needed changing: `mise run test:e2e` takes a single `--agent` (default `claude-code`), so there is no local fan-out that included Gemini.

Both facts above are recorded in a comment next to the matrix so the next person doesn't have to rediscover them.

## Verification

`mise run lint` clean; both emitted matrices parse as JSON and now list 7 agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI matrix-only change with no application code or auth paths touched; manual gemini runs remain available via dispatch.
> 
> **Overview**
> Removes **`gemini-cli`** from the default “run all agents” matrices in **`e2e.yml`** and **`e2e-checkpoint-store.yml`**, so pushes to **`main`** no longer run that leg automatically and stop failing CI for an upstream Gemini CLI behavior (≥0.57.0 clears **`core.hooksPath`**, so checkpoints are never recorded).
> 
> **`gemini-cli`** stays in **`workflow_dispatch`** agent choices and in install/bootstrap wiring, so it can still be selected manually when testing a fixed Gemini release. Inline comments document why it was dropped and how to add it back to the fan-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df0a99b6944cd637aa4a6b8b1695b32c58a3f34. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->