### PR TITLE
Add Windows PowerShell installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,20 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Windows PowerShell 5 installer syntax
+        shell: powershell
+        run: |
+          if ($PSVersionTable.PSVersion.Major -ne 5) {
+            throw "Expected Windows PowerShell 5.x, got $($PSVersionTable.PSVersion)"
+          }
+          .\scripts\install.ps1 -Help
+      - name: PowerShell 7 installer syntax
+        shell: pwsh
+        run: |
+          if ($PSVersionTable.PSVersion.Major -lt 7) {
+            throw "Expected PowerShell 7 or later, got $($PSVersionTable.PSVersion)"
+          }
+          .\scripts\install.ps1 -Help
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,22 +77,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Windows PowerShell 5 installer tests
-        shell: powershell
-        run: |
-          if ($PSVersionTable.PSVersion.Major -ne 5) {
-            throw "Expected Windows PowerShell 5.x, got $($PSVersionTable.PSVersion)"
-          }
-          .\scripts\install.ps1 -Help
-          .\scripts\test\run.ps1
-      - name: PowerShell 7 installer tests
-        shell: pwsh
-        run: |
-          if ($PSVersionTable.PSVersion.Major -lt 7) {
-            throw "Expected PowerShell 7 or later, got $($PSVersionTable.PSVersion)"
-          }
-          .\scripts\install.ps1 -Help
-          .\scripts\test\run.ps1
+      # install.ps1 and its tests run in install-ps1-e2e.yml, which is gated
+      # to the files that can affect them.
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      # install.ps1 and its tests run in install-ps1-e2e.yml, which is gated
-      # to the files that can affect them.
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,20 +77,22 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Windows PowerShell 5 installer syntax
+      - name: Windows PowerShell 5 installer tests
         shell: powershell
         run: |
           if ($PSVersionTable.PSVersion.Major -ne 5) {
             throw "Expected Windows PowerShell 5.x, got $($PSVersionTable.PSVersion)"
           }
           .\scripts\install.ps1 -Help
-      - name: PowerShell 7 installer syntax
+          .\scripts\test\run.ps1
+      - name: PowerShell 7 installer tests
         shell: pwsh
         run: |
           if ($PSVersionTable.PSVersion.Major -lt 7) {
             throw "Expected PowerShell 7 or later, got $($PSVersionTable.PSVersion)"
           }
           .\scripts\install.ps1 -Help
+          .\scripts\test\run.ps1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/install-ps1-e2e.yml
+++ b/.github/workflows/install-ps1-e2e.yml
@@ -1,9 +1,14 @@
-name: install.ps1 E2E
+name: install.ps1 tests
 
-# Runs scripts/install.ps1 for real against GitHub Releases on a Windows
-# runner, in both shells, and checks what the installer leaves behind: the
-# binaries, the raw user PATH, the replace-while-running path and the
-# nightly install. The offline suite stays in ci.yml; this is the network job.
+# All testing of scripts/install.ps1 lives here, gated to the files that can
+# affect it: the offline suite first (PSScriptAnalyzer plus the Pester tests,
+# in both Windows PowerShell 5.1 and pwsh), then, only if that passes, a real
+# install against GitHub Releases that checks what the installer leaves
+# behind: the binaries, the raw user PATH, the replace-while-running path,
+# the nightly install and the machine-PATH report.
+#
+# There is deliberately no schedule; workflow_dispatch runs it against the
+# current releases on demand.
 #
 # Scoop is deliberately not installed here: the Scoop branch's exit-code
 # contract is pinned by the unit tests, and get.scoop.sh plus a bucket clone
@@ -23,18 +28,41 @@ on:
       - scripts/install.ps1
       - scripts/test/**
       - .github/workflows/install-ps1-e2e.yml
-  schedule:
-    # Weekly, an hour after nightly.yml's 06:00 UTC daily build, so the
-    # nightly phase installs a release that is at most a day old. The
-    # releases side can drift under the installer between changes to it.
-    - cron: "0 7 * * 1"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  # Not named `test`: that context is a required check owned by ci.yml, and a
+  # second workflow reporting the same name could satisfy it.
+  suite:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shell: [powershell, pwsh]
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Installer suite
+        run: |
+          if ('${{ matrix.shell }}' -eq 'powershell' -and $PSVersionTable.PSVersion.Major -ne 5) {
+            throw "Expected Windows PowerShell 5.x, got $($PSVersionTable.PSVersion)"
+          }
+          if ('${{ matrix.shell }}' -eq 'pwsh' -and $PSVersionTable.PSVersion.Major -lt 7) {
+            throw "Expected PowerShell 7 or later, got $($PSVersionTable.PSVersion)"
+          }
+          .\scripts\install.ps1 -Help
+          .\scripts\test\run.ps1
+
   install:
+    needs: suite
     runs-on: windows-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/install-ps1-e2e.yml
+++ b/.github/workflows/install-ps1-e2e.yml
@@ -1,0 +1,56 @@
+name: install.ps1 E2E
+
+# Runs scripts/install.ps1 for real against GitHub Releases on a Windows
+# runner, in both shells, and checks what the installer leaves behind: the
+# binaries, the raw user PATH, the replace-while-running path and the
+# nightly install. The offline suite stays in ci.yml; this is the network job.
+#
+# Scoop is deliberately not installed here: the Scoop branch's exit-code
+# contract is pinned by the unit tests, and get.scoop.sh plus a bucket clone
+# would add two third-party network dependencies to every installer PR. If
+# real-Scoop coverage is ever wanted it belongs in the weekly schedule run,
+# as a separate job with continue-on-error.
+on:
+  pull_request:
+    paths:
+      - scripts/install.ps1
+      - scripts/test/**
+      - .github/workflows/install-ps1-e2e.yml
+  push:
+    branches:
+      - main
+    paths:
+      - scripts/install.ps1
+      - scripts/test/**
+      - .github/workflows/install-ps1-e2e.yml
+  schedule:
+    # Weekly, an hour after nightly.yml's 06:00 UTC daily build, so the
+    # nightly phase installs a release that is at most a day old. The
+    # releases side can drift under the installer between changes to it.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shell: [powershell, pwsh]
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    env:
+      # Invoke-GitHubApi sends this as a bearer; runners share egress IPs
+      # and the unauthenticated GitHub API limit is 60 requests an hour.
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Install, reinstall while running, install nightly
+        run: ./scripts/test/e2e.ps1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,9 +252,11 @@ mise run test:integration
 ### Running the Windows Installer Tests
 
 `scripts/install.ps1` has its own Pester suite and PSScriptAnalyzer pass under
-`scripts/test/`; CI runs it in both Windows PowerShell 5.1 and pwsh, and
-`mise run test:ps1` runs it locally when `pwsh` is installed (it skips cleanly
-otherwise; it is not part of `check`). On a fresh machine run
+`scripts/test/`; `.github/workflows/install-ps1-e2e.yml` runs it in both
+Windows PowerShell 5.1 and pwsh on PRs that touch the installer or its tests,
+followed by a real install on a Windows runner, and `mise run test:ps1` runs
+the suite locally when `pwsh` is installed (it skips cleanly otherwise; it is
+not part of `check`). On a fresh machine run
 `scripts/test/init.ps1` once first: it installs Pester and PSScriptAnalyzer for
 the current user and, on Windows PowerShell 5.1, the NuGet package provider
 that `Install-Module` needs there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,16 @@ mise run test
 mise run test:integration
 ```
 
+### Running the Windows Installer Tests
+
+`scripts/install.ps1` has its own Pester suite and PSScriptAnalyzer pass under
+`scripts/test/`; CI runs it in both Windows PowerShell 5.1 and pwsh, and
+`mise run test:ps1` runs it locally when `pwsh` is installed (it skips cleanly
+otherwise; it is not part of `check`). On a fresh machine run
+`scripts/test/init.ps1` once first: it installs Pester and PSScriptAnalyzer for
+the current user and, on Windows PowerShell 5.1, the NuGet package provider
+that `Install-Module` needs there.
+
 ### Running All Tests (CI)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -69,7 +69,20 @@ curl -fsSL https://entire.io/install.sh | bash                          # stable
 
 ### Windows
 
-Install with Scoop:
+Install with Windows PowerShell 5.1 or later:
+
+```powershell
+irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex
+# & ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly
+```
+
+For stable releases, the PowerShell installer uses Scoop when it is available,
+adding the Entire bucket if needed. Without Scoop — and for nightly releases —
+it verifies the release checksum and installs both `entire.exe` and
+`git-remote-entire.exe` to `%USERPROFILE%\.local\bin`, adding that directory to
+your user `PATH` if needed.
+
+Or install the stable release with Scoop:
 
 ```powershell
 scoop bucket add entire https://github.com/entireio/scoop-bucket.git
@@ -128,6 +141,8 @@ How to use each channel:
 - Homebrew nightly: `brew install --cask entire@nightly`
 - `install.sh` stable: `curl -fsSL https://entire.io/install.sh | bash`
 - `install.sh` nightly: `curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly`
+- `install.ps1` stable (uses Scoop when available): `irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex`
+- `install.ps1` nightly: `& ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly`
 - Scoop: currently supports `stable` only via `scoop install entire/entire`
 
 ## Typical Workflow

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ curl -fsSL https://entire.io/install.sh | bash                          # stable
 Install with Windows PowerShell 5.1 or later:
 
 ```powershell
-irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex
-# & ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly
+irm https://entire.io/install.ps1 -UseBasicParsing | iex
+# & ([scriptblock]::Create((irm https://entire.io/install.ps1 -UseBasicParsing))) -Channel nightly
 ```
 
 For stable releases, the PowerShell installer uses Scoop when it is available,
@@ -141,8 +141,8 @@ How to use each channel:
 - Homebrew nightly: `brew install --cask entire@nightly`
 - `install.sh` stable: `curl -fsSL https://entire.io/install.sh | bash`
 - `install.sh` nightly: `curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly`
-- `install.ps1` stable (uses Scoop when available): `irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex`
-- `install.ps1` nightly: `& ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly`
+- `install.ps1` stable (uses Scoop when available): `irm https://entire.io/install.ps1 -UseBasicParsing | iex`
+- `install.ps1` nightly: `& ([scriptblock]::Create((irm https://entire.io/install.ps1 -UseBasicParsing))) -Channel nightly`
 - Scoop: currently supports `stable` only via `scoop install entire/entire`
 
 ## Typical Workflow

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ curl -fsSL https://entire.io/install.sh | bash                          # stable
 Install with Windows PowerShell 5.1 or later:
 
 ```powershell
-irm https://entire.io/install.ps1 -UseBasicParsing | iex  # stable
+irm https://entire.io/install.ps1 | iex  # stable
 # or nightly:
-# & ([scriptblock]::Create((irm https://entire.io/install.ps1 -UseBasicParsing))) -Channel nightly
+# iex "& {$(irm https://entire.io/install.ps1)} -Channel nightly"
 ```
 
 For stable releases, the PowerShell installer uses Scoop when it is available,
@@ -142,8 +142,8 @@ How to use each channel:
 - Homebrew nightly: `brew install --cask entire@nightly`
 - `install.sh` stable: `curl -fsSL https://entire.io/install.sh | bash`
 - `install.sh` nightly: `curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly`
-- `install.ps1` stable (uses Scoop when available): `irm https://entire.io/install.ps1 -UseBasicParsing | iex`
-- `install.ps1` nightly: `& ([scriptblock]::Create((irm https://entire.io/install.ps1 -UseBasicParsing))) -Channel nightly`
+- `install.ps1` stable (uses Scoop when available): `irm https://entire.io/install.ps1 | iex`
+- `install.ps1` nightly: `iex "& {$(irm https://entire.io/install.ps1)} -Channel nightly"`
 - Scoop: currently supports `stable` only via `scoop install entire/entire`
 
 ## Typical Workflow

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ curl -fsSL https://entire.io/install.sh | bash                          # stable
 Install with Windows PowerShell 5.1 or later:
 
 ```powershell
-irm https://entire.io/install.ps1 -UseBasicParsing | iex
+irm https://entire.io/install.ps1 -UseBasicParsing | iex  # stable
+# or nightly:
 # & ([scriptblock]::Create((irm https://entire.io/install.ps1 -UseBasicParsing))) -Channel nightly
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Install with Windows PowerShell 5.1 or later:
 
 ```powershell
 irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex
+# & ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly
 ```
 
 For stable releases, the PowerShell installer uses Scoop when it is available,

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Install with Windows PowerShell 5.1 or later:
 
 ```powershell
 irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex
-# & ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly
 ```
 
 For stable releases, the PowerShell installer uses Scoop when it is available,

--- a/mise-tasks/test/ps1
+++ b/mise-tasks/test/ps1
@@ -1,0 +1,11 @@
+#!/bin/sh
+#MISE description="Run the PowerShell installer tests and linter (skips when pwsh is absent)"
+
+# Probe with a real invocation, not just `command -v`: a mise shim for pwsh can
+# exist on PATH while no version is activated, and then fails on every call.
+if ! command -v pwsh >/dev/null 2>&1 || ! pwsh -NoProfile -NonInteractive -Command 'exit 0' >/dev/null 2>&1; then
+  echo "test:ps1: pwsh not available, skipping" >&2
+  exit 0
+fi
+
+exec pwsh -NoProfile -NonInteractive -File scripts/test/run.ps1

--- a/scripts/PSScriptAnalyzerSettings.psd1
+++ b/scripts/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,13 @@
+@{
+    Severity     = @('Error', 'Warning')
+
+    ExcludeRules = @(
+        # The installer runs as `irm ... | iex` and its only channel to the
+        # user is the host: anything sent to the output stream is returned into
+        # the caller's pipeline instead of being displayed, and the coloured
+        # status lines need Write-Host. The rule's own escape hatch (functions
+        # with the Show verb) does not cover the inline Write-Host calls in the
+        # PATH-conflict report, so the rule is excluded for the whole directory.
+        'PSAvoidUsingWriteHost'
+    )
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,389 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("stable", "nightly")]
+    [string] $Channel = "stable",
+
+    [ValidateNotNullOrEmpty()]
+    [string] $InstallDir = (Join-Path $HOME ".local\bin"),
+
+    [switch] $NoPathUpdate,
+
+    [Alias("h")]
+    [switch] $Help
+)
+
+# Keep all installer functions and preference changes in a child scope. This
+# matters when the script is piped to Invoke-Expression in an existing shell.
+& {
+    param(
+        [string] $SelectedChannel,
+        [string] $SelectedInstallDir,
+        [bool] $SkipPathUpdate,
+        [bool] $ShowHelp
+    )
+
+    Set-StrictMode -Version 2.0
+    $ErrorActionPreference = "Stop"
+    $ProgressPreference = "SilentlyContinue"
+
+    $GitHubRepo = "entireio/cli"
+    $ScoopBucketUrl = "https://github.com/entireio/scoop-bucket.git"
+
+    function Write-Info {
+        param([string] $Message)
+        Write-Host "==> $Message" -ForegroundColor Cyan
+    }
+
+    function Write-Success {
+        param([string] $Message)
+        Write-Host "==> $Message" -ForegroundColor Green
+    }
+
+    function Write-InstallerWarning {
+        param([string] $Message)
+        Write-Host "Warning: $Message" -ForegroundColor Yellow
+    }
+
+    function Write-Usage {
+        Write-Host @"
+Usage: install.ps1 [-Channel stable|nightly] [-InstallDir <path>] [-NoPathUpdate]
+
+Options:
+  -Channel       Release channel to install (default: stable)
+  -InstallDir    Direct-install destination (default: `$HOME\.local\bin)
+  -NoPathUpdate  Do not add a direct-install destination to the user PATH
+  -Help, -h      Show this help message
+
+Stable installs use Scoop when it is available. Nightly installs use the
+verified release archive because the Scoop bucket only publishes stable builds.
+"@
+    }
+
+    function Install-EntireWithScoop {
+        Write-Info "Scoop detected; installing Entire CLI with Scoop..."
+
+        $bucketOutput = & "scoop" bucket list 2>&1
+        $bucketExitCode = $LASTEXITCODE
+        if ($bucketExitCode -ne 0) {
+            $details = ($bucketOutput | Out-String).Trim()
+            throw "Failed to list Scoop buckets. $details"
+        }
+
+        $bucketList = $bucketOutput | Out-String
+        if ($bucketList -notmatch "(?im)^\s*entire(?:\s|$)") {
+            Write-Info "Adding the Entire Scoop bucket..."
+            & "scoop" bucket add entire $ScoopBucketUrl
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to add the Entire Scoop bucket."
+            }
+        }
+
+        & "scoop" prefix entire *> $null
+        $isInstalled = $LASTEXITCODE -eq 0
+        if ($isInstalled) {
+            Write-Info "Updating Entire CLI with Scoop..."
+            & "scoop" update entire/entire
+        }
+        else {
+            Write-Info "Installing Entire CLI with Scoop..."
+            & "scoop" install entire/entire
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+            throw "Scoop failed to install Entire CLI."
+        }
+
+        Write-Success "Entire CLI installed with Scoop"
+    }
+
+    function Get-PlatformArchitecture {
+        # PROCESSOR_ARCHITEW6432 identifies the native OS architecture when
+        # this script is running in a 32-bit PowerShell process.
+        $architecture = $env:PROCESSOR_ARCHITEW6432
+        if ([string]::IsNullOrWhiteSpace($architecture)) {
+            $architecture = $env:PROCESSOR_ARCHITECTURE
+        }
+
+        if ([string]::IsNullOrWhiteSpace($architecture)) {
+            throw "Cannot determine the Windows architecture."
+        }
+
+        switch ($architecture.ToUpperInvariant()) {
+            { $_ -in @("AMD64", "X86_64") } { return "amd64" }
+            { $_ -in @("ARM64", "AARCH64") } { return "arm64" }
+            default { throw "Unsupported architecture: $architecture" }
+        }
+    }
+
+    function Invoke-GitHubApi {
+        param([string] $Uri)
+
+        $headers = @{
+            "Accept"     = "application/vnd.github+json"
+            "User-Agent" = "entire-install.ps1"
+        }
+        if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+            $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
+        }
+
+        Invoke-RestMethod -Uri $Uri -Headers $headers -UseBasicParsing
+    }
+
+    function Get-ReleaseVersion {
+        param([string] $ReleaseChannel)
+
+        if ($ReleaseChannel -eq "nightly") {
+            $uri = "https://api.github.com/repos/$GitHubRepo/releases?per_page=20"
+            $releases = Invoke-GitHubApi -Uri $uri
+            $release = $null
+
+            # Windows PowerShell 5.1 returns a JSON array from
+            # Invoke-RestMethod as one pipeline object. A Where-Object pipeline
+            # would therefore test the whole release list at once instead of
+            # each release, so enumerate it explicitly.
+            foreach ($candidate in $releases) {
+                if ($candidate.tag_name -like "*nightly*") {
+                    $release = $candidate
+                    break
+                }
+            }
+        }
+        else {
+            $uri = "https://api.github.com/repos/$GitHubRepo/releases/latest"
+            $release = Invoke-GitHubApi -Uri $uri
+        }
+
+        if ($null -eq $release -or [string]::IsNullOrWhiteSpace([string] $release.tag_name)) {
+            throw "Failed to fetch the latest $ReleaseChannel version from GitHub. Check your internet connection."
+        }
+
+        $version = ([string] $release.tag_name) -replace "^v", ""
+        if ($version -notmatch "^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$") {
+            throw "GitHub returned an invalid release version: $version"
+        }
+
+        return $version
+    }
+
+    function Save-RemoteFile {
+        param(
+            [string] $Uri,
+            [string] $Destination
+        )
+
+        Invoke-WebRequest -Uri $Uri -OutFile $Destination -UseBasicParsing
+    }
+
+    function Assert-Checksum {
+        param(
+            [string] $ArchivePath,
+            [string] $ArchiveName,
+            [string] $ChecksumsPath
+        )
+
+        $escapedArchiveName = [regex]::Escape($ArchiveName)
+        $checksumLine = Get-Content -LiteralPath $ChecksumsPath |
+            Where-Object { $_ -match "(?i)^[0-9a-f]{64}\s+\*?$escapedArchiveName\s*$" } |
+            Select-Object -First 1
+
+        if ([string]::IsNullOrWhiteSpace([string] $checksumLine)) {
+            throw "Checksum for $ArchiveName was not found in checksums.txt."
+        }
+
+        $expectedChecksum = ([string] $checksumLine -split "\s+")[0]
+        $actualChecksum = (Get-FileHash -LiteralPath $ArchivePath -Algorithm SHA256).Hash
+        if (-not [string]::Equals($actualChecksum, $expectedChecksum, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Checksum verification failed. Expected: $expectedChecksum, actual: $actualChecksum"
+        }
+    }
+
+    function Get-NormalizedPath {
+        param([string] $Path)
+
+        return [IO.Path]::GetFullPath($Path).TrimEnd([IO.Path]::DirectorySeparatorChar)
+    }
+
+    function Test-SamePath {
+        param(
+            [string] $Left,
+            [string] $Right
+        )
+
+        if ([string]::IsNullOrWhiteSpace($Left) -or [string]::IsNullOrWhiteSpace($Right)) {
+            return $false
+        }
+
+        try {
+            return [string]::Equals(
+                (Get-NormalizedPath -Path $Left),
+                (Get-NormalizedPath -Path $Right),
+                [StringComparison]::OrdinalIgnoreCase
+            )
+        }
+        catch {
+            return $false
+        }
+    }
+
+    function Test-PathContains {
+        param(
+            [AllowNull()]
+            [string] $PathValue,
+            [string] $Directory
+        )
+
+        if ([string]::IsNullOrWhiteSpace($PathValue)) {
+            return $false
+        }
+
+        foreach ($entry in ($PathValue -split ";")) {
+            if (Test-SamePath -Left $entry.Trim() -Right $Directory) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    function Add-ToUserPath {
+        param([string] $Directory)
+
+        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        if (-not (Test-PathContains -PathValue $userPath -Directory $Directory)) {
+            if ([string]::IsNullOrWhiteSpace($userPath)) {
+                $newUserPath = $Directory
+            }
+            else {
+                $newUserPath = "$Directory;$userPath"
+            }
+            [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+        }
+
+        # Make the command available immediately when install.ps1 is evaluated
+        # in the caller's current PowerShell process.
+        if (-not (Test-PathContains -PathValue $env:Path -Directory $Directory)) {
+            $env:Path = "$Directory;$($env:Path)"
+        }
+    }
+
+    function Install-Entire {
+        if ($ShowHelp) {
+            Write-Usage
+            return
+        }
+
+        Write-Info "Installing Entire CLI..."
+
+        $scoopCommand = Get-Command "scoop" -ErrorAction SilentlyContinue
+        if ($SelectedChannel -eq "stable" -and $null -ne $scoopCommand) {
+            Install-EntireWithScoop
+            return
+        }
+        if ($SelectedChannel -eq "nightly" -and $null -ne $scoopCommand) {
+            Write-InstallerWarning "Scoop only publishes stable releases; installing nightly from the verified release archive."
+        }
+
+        # GitHub requires TLS 1.2. Use the numeric value so this remains valid
+        # on .NET versions whose SecurityProtocolType enum omits the name.
+        [Net.ServicePointManager]::SecurityProtocol =
+            [Net.ServicePointManager]::SecurityProtocol -bor 3072
+
+        $architecture = Get-PlatformArchitecture
+        Write-Info "Detected platform: windows/$architecture"
+
+        Write-Info "Fetching latest $SelectedChannel version..."
+        $version = Get-ReleaseVersion -ReleaseChannel $SelectedChannel
+        Write-Info "Installing version: $version"
+
+        $archiveName = "entire_windows_$architecture.zip"
+        $releaseBaseUrl = "https://github.com/$GitHubRepo/releases/download/v$version"
+        $downloadUrl = "$releaseBaseUrl/$archiveName"
+        $checksumsUrl = "$releaseBaseUrl/checksums.txt"
+
+        $tempDir = Join-Path ([IO.Path]::GetTempPath()) ("entire-install-" + [guid]::NewGuid().ToString("N"))
+        New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+        try {
+            $archivePath = Join-Path $tempDir $archiveName
+            $checksumsPath = Join-Path $tempDir "checksums.txt"
+            $extractDir = Join-Path $tempDir "extracted"
+
+            Write-Info "Downloading $archiveName..."
+            Save-RemoteFile -Uri $downloadUrl -Destination $archivePath
+
+            Write-Info "Downloading checksums..."
+            Save-RemoteFile -Uri $checksumsUrl -Destination $checksumsPath
+
+            Write-Info "Verifying checksum..."
+            Assert-Checksum -ArchivePath $archivePath -ArchiveName $archiveName -ChecksumsPath $checksumsPath
+            Write-Success "Checksum verified"
+
+            Write-Info "Extracting..."
+            Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
+
+            $sourceBinary = Join-Path $extractDir "entire.exe"
+            $sourceHelper = Join-Path $extractDir "git-remote-entire.exe"
+            if (-not (Test-Path -LiteralPath $sourceBinary -PathType Leaf)) {
+                throw "entire.exe was not found in $archiveName."
+            }
+
+            $resolvedInstallDir = Get-NormalizedPath -Path $SelectedInstallDir
+            Write-Info "Installing to $resolvedInstallDir..."
+            New-Item -ItemType Directory -Path $resolvedInstallDir -Force | Out-Null
+
+            $installPath = Join-Path $resolvedInstallDir "entire.exe"
+            Copy-Item -LiteralPath $sourceBinary -Destination $installPath -Force
+
+            if (Test-Path -LiteralPath $sourceHelper -PathType Leaf) {
+                Copy-Item -LiteralPath $sourceHelper -Destination (Join-Path $resolvedInstallDir "git-remote-entire.exe") -Force
+            }
+            else {
+                Write-InstallerWarning "git-remote-entire.exe was not found in the archive; entire:// clones will not work until the next release includes it."
+            }
+
+            & $installPath version *> $null
+            if ($LASTEXITCODE -ne 0) {
+                throw "Installation completed, but entire.exe failed to execute."
+            }
+            Write-Success "Entire CLI installed to $installPath"
+
+            $pathCommand = Get-Command "entire" -CommandType Application -ErrorAction SilentlyContinue |
+                Select-Object -First 1
+            if ($null -ne $pathCommand -and -not (Test-SamePath -Left $pathCommand.Source -Right $installPath)) {
+                Write-Host ""
+                Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
+                Write-Host "!"
+                Write-Host "! Installed to: $installPath"
+                Write-Host "! But 'entire' resolves to: $($pathCommand.Source)"
+                Write-Host "!"
+                Write-Host "! Remove the old installation or adjust PATH to prioritize:"
+                Write-Host "!   $resolvedInstallDir"
+                Write-Host ""
+                throw "Installation completed, but PATH needs adjustment."
+            }
+
+            if ($SkipPathUpdate) {
+                if ($null -eq $pathCommand) {
+                    Write-InstallerWarning "$resolvedInstallDir is not on PATH. Add it before running entire."
+                }
+            }
+            else {
+                Add-ToUserPath -Directory $resolvedInstallDir
+                if ($null -eq $pathCommand) {
+                    Write-Success "Added $resolvedInstallDir to your user PATH"
+                    Write-Host "Restart your terminal, then run entire to get started."
+                }
+            }
+        }
+        finally {
+            Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    try {
+        Install-Entire
+    }
+    catch {
+        Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Red
+        throw
+    }
+} $Channel $InstallDir $NoPathUpdate.IsPresent $Help.IsPresent

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -737,7 +737,11 @@ function Install-Entire {
         $scoopRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $scoopPrefix))
         $scoopShim = Join-Path $scoopRoot "shims\entire.exe"
 
+        # The verdict is about what this shell runs; the list is about every
+        # copy the user has, including ones this shell cannot see yet. Both
+        # are assigned before being piped (see the archive branch).
         $pathCommands = Get-EntireOnPath
+        $copies = Get-EntireCopy
         $first = $pathCommands | Select-Object -First 1
         if ($null -eq $first -or -not (Test-SamePath -Left $first.Source -Right $scoopShim)) {
             Write-Host ""
@@ -756,7 +760,7 @@ function Install-Entire {
             throw "Scoop installed Entire CLI, but its shim does not take priority on PATH."
         }
 
-        $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $scoopShim) })
+        $conflicting = @($copies | Where-Object { -not (Test-SamePath -Left $_.Source -Right $scoopShim) })
         if ($conflicting.Count -gt 0) {
             Write-Host ""
             Write-Host "! WARNING: Other Entire CLI installations remain on PATH" -ForegroundColor Yellow

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -542,8 +542,10 @@ Scoop chooses its own install location and manages its own PATH entry, so
                 # neither the verdict below nor reordering the user PATH can fix
                 # it.
                 $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+                $machineConflict = $false
                 foreach ($cmd in $conflicting) {
                     if (Test-PathContains -PathValue $machinePath -Directory (Split-Path -Parent $cmd.Source)) {
+                        $machineConflict = $true
                         Write-Host "!"
                         Write-Host "! $($cmd.Source) is on the machine-wide PATH, which Windows places"
                         Write-Host "! ahead of your user PATH. It will win in a new terminal even though"
@@ -563,9 +565,15 @@ Scoop chooses its own install location and manages its own PATH entry, so
                     }
                     throw "Installation completed, but PATH needs adjustment."
                 }
-                Write-Host "!"
-                Write-Host "! The installed version takes priority, but consider removing"
-                Write-Host "! the other installation to avoid confusion."
+                # Suppressed on a machine-PATH conflict: the paragraph above has
+                # already said that install wins in a new terminal, and claiming
+                # priority as well leaves the reader nothing to act on.
+                if (-not $machineConflict) {
+                    $others = if ($conflicting.Count -gt 1) { "the other installations" } else { "the other installation" }
+                    Write-Host "!"
+                    Write-Host "! The installed version takes priority, but consider removing"
+                    Write-Host "! $others to avoid confusion."
+                }
                 Write-Host ""
             }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,11 @@
 [CmdletBinding()]
+# The wrapper scriptblock's parameters are read inside its nested functions,
+# which PSScriptAnalyzer does not follow when deciding whether a parameter is
+# used. One suppression per parameter, so a new unused parameter still reports.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SelectedChannel')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SelectedInstallDir')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SkipPathUpdate')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ShowHelp')]
 param(
     [ValidateSet("stable", "nightly")]
     [string] $Channel = "stable",
@@ -297,6 +304,8 @@ Scoop chooses its own install location and manages its own PATH entry, so
     }
 
     function Test-PathContains {
+        # "Contains" is a verb form, not a plural noun.
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
         param(
             [AllowNull()]
             [string] $PathValue,
@@ -388,7 +397,7 @@ Scoop chooses its own install location and manages its own PATH entry, so
         # Write-Output with the unary comma prevents PowerShell from unrolling
         # a single-element array, which would lose .Count under StrictMode 2.0.
         $results = @(Get-Command "entire" -CommandType Application -All -ErrorAction SilentlyContinue)
-        Write-Output -NoEnumerate $results
+        Write-Output -NoEnumerate -InputObject $results
     }
 
     function Install-Entire {
@@ -604,7 +613,7 @@ Scoop chooses its own install location and manages its own PATH entry, so
             exit 1
         }
         # irm | iex: throw without Write-Host so the message appears once, and
-        # do not exit 1 — that would close the user's interactive shell.
+        # do not exit 1 -- that would close the user's interactive shell.
         throw $message
     }
 } $Channel $InstallDir $NoPathUpdate.IsPresent $Help.IsPresent (-not [string]::IsNullOrEmpty($MyInvocation.MyCommand.Path))

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -31,6 +31,7 @@ param(
 
     $GitHubRepo = "entireio/cli"
     $ScoopBucketUrl = "https://github.com/entireio/scoop-bucket.git"
+    $WebTimeoutSec = 60
 
     function Write-Info {
         param([string] $Message)
@@ -130,7 +131,7 @@ verified release archive because the Scoop bucket only publishes stable builds.
             $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
         }
 
-        Invoke-RestMethod -Uri $Uri -Headers $headers
+        Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $WebTimeoutSec
     }
 
     function Get-ReleaseVersion {
@@ -177,7 +178,7 @@ verified release archive because the Scoop bucket only publishes stable builds.
 
         # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
         # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
-        Invoke-WebRequest -Uri $Uri -OutFile $Destination -UseBasicParsing
+        Invoke-WebRequest -Uri $Uri -OutFile $Destination -UseBasicParsing -TimeoutSec $WebTimeoutSec
     }
 
     function Assert-Checksum {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -259,25 +259,71 @@ verified release archive because the Scoop bucket only publishes stable builds.
         return $false
     }
 
+    function Test-PathIsFirst {
+        param(
+            [AllowNull()]
+            [string] $PathValue,
+            [string] $Directory
+        )
+
+        if ([string]::IsNullOrWhiteSpace($PathValue)) {
+            return $false
+        }
+
+        foreach ($entry in ($PathValue -split ";")) {
+            $trimmed = $entry.Trim()
+            if ([string]::IsNullOrWhiteSpace($trimmed)) {
+                continue
+            }
+            return (Test-SamePath -Left $trimmed -Right $Directory)
+        }
+        return $false
+    }
+
+    function Get-PathWithDirectoryFirst {
+        param(
+            [AllowNull()]
+            [string] $PathValue,
+            [string] $Directory
+        )
+
+        $parts = New-Object System.Collections.Generic.List[string]
+        if (-not [string]::IsNullOrWhiteSpace($PathValue)) {
+            foreach ($entry in ($PathValue -split ";")) {
+                $trimmed = $entry.Trim()
+                if ([string]::IsNullOrWhiteSpace($trimmed)) {
+                    continue
+                }
+                if (-not (Test-SamePath -Left $trimmed -Right $Directory)) {
+                    $parts.Add($trimmed)
+                }
+            }
+        }
+        if ($parts.Count -eq 0) {
+            return $Directory
+        }
+        return "$Directory;" + ($parts -join ";")
+    }
+
     function Add-ToUserPath {
         param([string] $Directory)
 
         $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-        if (-not (Test-PathContains -PathValue $userPath -Directory $Directory)) {
-            if ([string]::IsNullOrWhiteSpace($userPath)) {
-                $newUserPath = $Directory
-            }
-            else {
-                $newUserPath = "$Directory;$userPath"
-            }
+        $userPathChanged = $false
+        if (-not (Test-PathIsFirst -PathValue $userPath -Directory $Directory)) {
+            $newUserPath = Get-PathWithDirectoryFirst -PathValue $userPath -Directory $Directory
             [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+            $userPathChanged = $true
         }
 
         # Make the command available immediately when install.ps1 is evaluated
-        # in the caller's current PowerShell process.
-        if (-not (Test-PathContains -PathValue $env:Path -Directory $Directory)) {
-            $env:Path = "$Directory;$($env:Path)"
+        # in the caller's current PowerShell process. Do this before Get-Command
+        # "entire", which caches the first Application hit for the session.
+        if (-not (Test-PathIsFirst -PathValue $env:Path -Directory $Directory)) {
+            $env:Path = Get-PathWithDirectoryFirst -PathValue $env:Path -Directory $Directory
         }
+
+        return $userPathChanged
     }
 
     function Get-EntireOnPath {
@@ -409,8 +455,14 @@ verified release archive because the Scoop bucket only publishes stable builds.
             }
             Write-Success "Entire CLI installed to $installPath"
 
-            # Check for PATH conflicts now that the binary exists on disk,
-            # so Test-SamePath can resolve both paths reliably.
+            # Prepend PATH before Get-Command "entire". Checking first throws on
+            # the documented nightly path (Scoop stable already installed) and
+            # never updates PATH, so a rerun fails the same way.
+            $userPathChanged = $false
+            if (-not $SkipPathUpdate) {
+                $userPathChanged = Add-ToUserPath -Directory $resolvedInstallDir
+            }
+
             $pathCommands = Get-EntireOnPath
             $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
             if ($conflicting.Count -gt 0) {
@@ -429,6 +481,9 @@ verified release archive because the Scoop bucket only publishes stable builds.
                     Write-Host "! Remove the old installation or adjust PATH to prioritize:"
                     Write-Host "!   $resolvedInstallDir"
                     Write-Host ""
+                    if ($SkipPathUpdate) {
+                        throw "Installation completed, but PATH was not updated (-NoPathUpdate)."
+                    }
                     throw "Installation completed, but PATH needs adjustment."
                 }
                 Write-Host "!"
@@ -438,16 +493,13 @@ verified release archive because the Scoop bucket only publishes stable builds.
             }
 
             if ($SkipPathUpdate) {
-                if ($pathCommands.Count -eq 0) {
+                if (-not (Test-PathContains -PathValue $env:Path -Directory $resolvedInstallDir)) {
                     Write-InstallerWarning "$resolvedInstallDir is not on PATH. Add it before running entire."
                 }
             }
-            else {
-                Add-ToUserPath -Directory $resolvedInstallDir
-                if ($pathCommands.Count -eq 0) {
-                    Write-Success "Added $resolvedInstallDir to your user PATH"
-                    Write-Host "Restart your terminal, then run entire to get started."
-                }
+            elseif ($userPathChanged) {
+                Write-Success "Added $resolvedInstallDir to your user PATH"
+                Write-Host "Restart your terminal, then run entire to get started."
             }
         }
         finally {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -56,6 +56,40 @@ Scoop chooses its own install location and manages its own PATH entry, so
 "@
 }
 
+# $env:OS is "Windows_NT" in both Windows PowerShell and pwsh on Windows and
+# unset elsewhere; $IsWindows does not exist in Windows PowerShell 5.1.
+function Test-IsWindows {
+    $env:OS -eq 'Windows_NT'
+}
+
+# A runtime check, not `#Requires -Version`: that line is honoured when the
+# script runs from its file and ignored when the text arrives through
+# irm | iex or [scriptblock]::Create.
+function Test-MinimumPowerShell {
+    $PSVersionTable.PSVersion -ge [version]'5.1'
+}
+
+function Test-FullLanguageMode {
+    $ExecutionContext.SessionState.LanguageMode -eq 'FullLanguage'
+}
+
+function Assert-Prerequisite {
+    if (-not (Test-IsWindows)) {
+        throw "install.ps1 supports Windows only. On macOS and Linux, run: curl -fsSL https://entire.io/install.sh | bash"
+    }
+    # No TLS 1.2 check follows: Windows PowerShell 5.1 needs .NET Framework
+    # 4.5.2 or later, which has had Tls12 since 4.5, so a host that passes this
+    # check always has it.
+    if (-not (Test-MinimumPowerShell)) {
+        throw "Windows PowerShell 5.1 or later is required; this is $($PSVersionTable.PSVersion). Get a newer PowerShell at https://aka.ms/powershell"
+    }
+    # Later steps use registry types and Add-Type, which ConstrainedLanguage
+    # rejects with errors that do not name the cause.
+    if (-not (Test-FullLanguageMode)) {
+        throw "PowerShell FullLanguage mode is required; this session is in $($ExecutionContext.SessionState.LanguageMode) mode (usually set by an AppLocker or WDAC policy)."
+    }
+}
+
 function Invoke-Scoop {
     param(
         [Parameter(Mandatory = $true, ValueFromRemainingArguments = $true)]
@@ -396,6 +430,8 @@ function Install-Entire {
         Write-Usage
         return
     }
+
+    Assert-Prerequisite
 
     Write-Info "Installing Entire CLI..."
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -14,12 +14,15 @@ param(
 
 # Keep all installer functions and preference changes in a child scope. This
 # matters when the script is piped to Invoke-Expression in an existing shell.
+# Path is empty under irm | iex; pass it in so the child can tell file vs pipe
+# without leaking a variable into the caller's session.
 & {
     param(
         [string] $SelectedChannel,
         [string] $SelectedInstallDir,
         [bool] $SkipPathUpdate,
-        [bool] $ShowHelp
+        [bool] $ShowHelp,
+        [bool] $InvokedFromFile
     )
 
     Set-StrictMode -Version 2.0
@@ -202,7 +205,17 @@ verified release archive because the Scoop bucket only publishes stable builds.
     function Get-NormalizedPath {
         param([string] $Path)
 
-        return [IO.Path]::GetFullPath($Path).TrimEnd([IO.Path]::DirectorySeparatorChar)
+        $fullPath = [IO.Path]::GetFullPath($Path)
+        $root = [IO.Path]::GetPathRoot($fullPath)
+        if ([string]::Equals($fullPath, $root, [StringComparison]::OrdinalIgnoreCase)) {
+            return $root
+        }
+
+        [char[]] $separators = @(
+            [IO.Path]::DirectorySeparatorChar,
+            [IO.Path]::AltDirectorySeparatorChar
+        )
+        return $fullPath.TrimEnd($separators)
     }
 
     function Test-SamePath {
@@ -267,6 +280,12 @@ verified release archive because the Scoop bucket only publishes stable builds.
         }
     }
 
+    function Get-EntireOnPath {
+        # -All is required: without it Get-Command returns only the first
+        # Application, so a later Scoop shim is never seen.
+        return @(Get-Command "entire" -CommandType Application -All -ErrorAction SilentlyContinue)
+    }
+
     function Install-Entire {
         if ($ShowHelp) {
             Write-Usage
@@ -278,10 +297,79 @@ verified release archive because the Scoop bucket only publishes stable builds.
         $scoopCommand = Get-Command "scoop" -ErrorAction SilentlyContinue
         if ($SelectedChannel -eq "stable" -and $null -ne $scoopCommand) {
             Install-EntireWithScoop
+
+            $prefixOutput = & "scoop" prefix entire 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Scoop installed Entire CLI, but its installation path could not be resolved."
+            }
+            $scoopPrefix = ($prefixOutput | Select-Object -First 1).ToString().Trim()
+            $scoopRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $scoopPrefix))
+            $scoopShim = Join-Path $scoopRoot "shims\entire.exe"
+
+            $pathCommands = Get-EntireOnPath
+            $first = $pathCommands | Select-Object -First 1
+            if ($null -eq $first -or -not (Test-SamePath -Left $first.Source -Right $scoopShim)) {
+                Write-Host ""
+                Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
+                Write-Host "!"
+                Write-Host "! Scoop shim: $scoopShim"
+                if ($null -eq $first) {
+                    Write-Host "! 'entire' does not resolve to an executable on PATH."
+                }
+                else {
+                    Write-Host "! 'entire' currently resolves to: $($first.Source)"
+                }
+                Write-Host "! Remove the old installation or adjust PATH to prioritize:"
+                Write-Host "!   $(Split-Path -Parent $scoopShim)"
+                Write-Host ""
+                throw "Scoop installed Entire CLI, but its shim does not take priority on PATH."
+            }
+
+            $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $scoopShim) })
+            if ($conflicting.Count -gt 0) {
+                Write-Host ""
+                Write-Host "! WARNING: Other Entire CLI installations remain on PATH" -ForegroundColor Yellow
+                foreach ($cmd in $conflicting) {
+                    Write-Host "! Also found: $($cmd.Source)"
+                }
+                Write-Host "! The Scoop shim takes priority, but consider removing the other installation."
+                Write-Host ""
+            }
             return
         }
         if ($SelectedChannel -eq "nightly" -and $null -ne $scoopCommand) {
             Write-InstallerWarning "Scoop only publishes stable releases; installing nightly from the verified release archive."
+        }
+
+        $resolvedInstallDir = Get-NormalizedPath -Path $SelectedInstallDir
+        $installPath = Join-Path $resolvedInstallDir "entire.exe"
+
+        # Match install.sh: abort if another entire wins on PATH. Check before
+        # copying so a conflict does not leave files behind.
+        $pathCommands = Get-EntireOnPath
+        $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
+        if ($conflicting.Count -gt 0) {
+            $first = $pathCommands | Select-Object -First 1
+            $firstIsOurs = Test-SamePath -Left $first.Source -Right $installPath
+            Write-Host ""
+            Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
+            Write-Host "!"
+            Write-Host "! Install destination: $installPath"
+            foreach ($cmd in $conflicting) {
+                Write-Host "! Also found:   $($cmd.Source)"
+            }
+            if (-not $firstIsOurs) {
+                Write-Host "!"
+                Write-Host "! 'entire' currently resolves to: $($first.Source)"
+                Write-Host "! Remove the old installation or adjust PATH to prioritize:"
+                Write-Host "!   $resolvedInstallDir"
+                Write-Host ""
+                throw "PATH needs adjustment. Then rerun the installation."
+            }
+            Write-Host "!"
+            Write-Host "! The installed version takes priority, but consider removing"
+            Write-Host "! the other installation to avoid confusion."
+            Write-Host ""
         }
 
         # GitHub requires TLS 1.2. Use the numeric value so this remains valid
@@ -328,11 +416,9 @@ verified release archive because the Scoop bucket only publishes stable builds.
                 throw "entire.exe was not found in $archiveName."
             }
 
-            $resolvedInstallDir = Get-NormalizedPath -Path $SelectedInstallDir
             Write-Info "Installing to $resolvedInstallDir..."
             New-Item -ItemType Directory -Path $resolvedInstallDir -Force | Out-Null
 
-            $installPath = Join-Path $resolvedInstallDir "entire.exe"
             Copy-Item -LiteralPath $sourceBinary -Destination $installPath -Force
 
             if (Test-Path -LiteralPath $sourceHelper -PathType Leaf) {
@@ -347,35 +433,6 @@ verified release archive because the Scoop bucket only publishes stable builds.
                 throw "Installation completed, but entire.exe failed to execute."
             }
             Write-Success "Entire CLI installed to $installPath"
-
-            $pathCommands = @(Get-Command "entire" -CommandType Application -ErrorAction SilentlyContinue)
-            $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
-            if ($conflicting.Count -gt 0) {
-                $first = $pathCommands | Select-Object -First 1
-                $firstIsOurs = Test-SamePath -Left $first.Source -Right $installPath
-                Write-Host ""
-                Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
-                Write-Host "!"
-                Write-Host "! Installed to: $installPath"
-                foreach ($cmd in $conflicting) {
-                    Write-Host "! Also found:   $($cmd.Source)"
-                }
-                if (-not $firstIsOurs) {
-                    Write-Host "!"
-                    Write-Host "! 'entire' currently resolves to: $($first.Source)"
-                    Write-Host "! Remove the old installation or adjust PATH to prioritize:"
-                    Write-Host "!   $resolvedInstallDir"
-                }
-                else {
-                    Write-Host "!"
-                    Write-Host "! The installed version takes priority, but consider removing"
-                    Write-Host "! the other installation to avoid confusion."
-                }
-                Write-Host ""
-                if (-not $firstIsOurs) {
-                    throw "Installation completed, but PATH needs adjustment."
-                }
-            }
 
             if ($SkipPathUpdate) {
                 if ($pathCommands.Count -eq 0) {
@@ -399,7 +456,13 @@ verified release archive because the Scoop bucket only publishes stable builds.
         Install-Entire
     }
     catch {
-        Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Red
-        throw
+        $message = "Error: $($_.Exception.Message)"
+        if ($InvokedFromFile) {
+            Write-Host $message -ForegroundColor Red
+            exit 1
+        }
+        # irm | iex: throw without Write-Host so the message appears once, and
+        # do not exit 1 — that would close the user's interactive shell.
+        throw $message
     }
-} $Channel $InstallDir $NoPathUpdate.IsPresent $Help.IsPresent
+} $Channel $InstallDir $NoPathUpdate.IsPresent $Help.IsPresent (-not [string]::IsNullOrEmpty($MyInvocation.MyCommand.Path))

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -59,7 +59,7 @@ Options:
 Stable installs use Scoop when it is available. Nightly installs use the
 verified release archive because the Scoop bucket only publishes stable builds.
 
-Scoop chooses its own install location and manages its own PATH entry, so
+Scoop chooses its own install location and manages its own PATH entry.
 An explicit -InstallDir selects a release-archive install even when Scoop
 is available; -NoPathUpdate applies only to release-archive installs.
 "@

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -548,9 +548,11 @@ Scoop chooses its own install location and manages its own PATH entry, so
                         $machineConflict = $true
                         Write-Host "!"
                         Write-Host "! $($cmd.Source) is on the machine-wide PATH, which Windows places"
-                        Write-Host "! ahead of your user PATH. It will win in a new terminal even though"
-                        Write-Host "! this session now resolves to the new install. Remove it, or run"
-                        Write-Host "! entire from $resolvedInstallDir explicitly."
+                        Write-Host "! ahead of your user PATH, so it wins in a new terminal however your"
+                        Write-Host "! user PATH is ordered. Remove that copy, or drop its directory from"
+                        Write-Host "! the machine PATH (needs an administrator). To install over it"
+                        Write-Host "! instead, rerun with:"
+                        Write-Host "!   -InstallDir $(Split-Path -Parent $cmd.Source)"
                     }
                 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -185,14 +185,18 @@ function Install-EntireWithScoop {
     Write-Success "Entire CLI installed with Scoop"
 }
 
+function Get-NativeArchitectureName {
+    $environmentKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+    (Get-ItemProperty -LiteralPath $environmentKey -Name "PROCESSOR_ARCHITECTURE").PROCESSOR_ARCHITECTURE
+}
+
 function Get-PlatformArchitecture {
     # The machine-level value is the native OS architecture. The
     # $env:PROCESSOR_ARCHITECTURE seen by the script is the process's, so
     # x64 PowerShell on ARM64 Windows reports AMD64. RuntimeInformation is
     # not an option either: it needs .NET 4.7.1+, so it is missing on
     # stock Windows PowerShell 5.1 installs.
-    $environmentKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
-    $architecture = (Get-ItemProperty -LiteralPath $environmentKey -Name "PROCESSOR_ARCHITECTURE").PROCESSOR_ARCHITECTURE
+    $architecture = Get-NativeArchitectureName
 
     if ([string]::IsNullOrWhiteSpace($architecture)) {
         throw "Cannot determine the Windows architecture."
@@ -659,14 +663,15 @@ function Get-EntireOnPath {
 
 # Every entire.exe that will compete for the name once the user opens a new
 # terminal: the copies this process can see, in Get-Command order so the
-# priority verdict is unchanged, followed by copies that are only on the
-# stored user or machine PATH. A shell started before an earlier run wrote
-# the registry cannot see that run's directory through $env:Path, and the
-# installer tells the user to restart between installs.
+# priority verdict is unchanged (Active = $true), followed by copies that
+# are only on the stored user or machine PATH (Active = $false). A shell
+# started before an earlier run wrote the registry cannot see that run's
+# directory through $env:Path, and the installer tells the user to restart
+# between installs.
 function Get-EntireCopy {
     $found = @()
     foreach ($command in (Get-EntireOnPath)) {
-        $found += [pscustomobject]@{ Source = $command.Source }
+        $found += [pscustomobject]@{ Source = $command.Source; Active = $true }
     }
 
     $stored = @(
@@ -695,11 +700,32 @@ function Get-EntireCopy {
                 }
             }
             if (-not $known) {
-                $found += [pscustomobject]@{ Source = $candidate }
+                $found += [pscustomobject]@{ Source = $candidate; Active = $false }
             }
         }
     }
     Write-Output -NoEnumerate -InputObject $found
+}
+
+# The "Also found" lines read as a ranking, and only the copies this shell
+# can run are ranked: the ones known from the stored PATH alone will compete
+# after a restart, not now, so they go under their own heading.
+function Write-OtherCopyReport {
+    param(
+        [object[]] $Copies,
+        [string] $Indent
+    )
+
+    foreach ($copy in ($Copies | Where-Object { $_.Active })) {
+        Write-Host "! Also found:$Indent$($copy.Source)"
+    }
+    $inactive = @($Copies | Where-Object { -not $_.Active })
+    if ($inactive.Count -gt 0) {
+        Write-Host "! Also on your saved PATH, not active in this shell:"
+        foreach ($copy in $inactive) {
+            Write-Host "!   $($copy.Source)"
+        }
+    }
 }
 
 function Install-Entire {
@@ -764,9 +790,7 @@ function Install-Entire {
         if ($conflicting.Count -gt 0) {
             Write-Host ""
             Write-Host "! WARNING: Other Entire CLI installations remain on PATH" -ForegroundColor Yellow
-            foreach ($cmd in $conflicting) {
-                Write-Host "! Also found: $($cmd.Source)"
-            }
+            Write-OtherCopyReport -Copies $conflicting -Indent ' '
             Write-Host "! The Scoop shim takes priority, but consider removing the other installation."
             Write-Host ""
         }
@@ -868,9 +892,7 @@ function Install-Entire {
             Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
             Write-Host "!"
             Write-Host "! Installed to: $installPath"
-            foreach ($cmd in $conflicting) {
-                Write-Host "! Also found:   $($cmd.Source)"
-            }
+            Write-OtherCopyReport -Copies $conflicting -Indent '   '
 
             # Our PATH write only ever lands in the user half, and Windows
             # composes a new session as machine-then-user. So a conflict on

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -307,6 +307,10 @@ function Save-RemoteFile {
     Invoke-WebRequest -Uri $Uri -OutFile $Destination -UseBasicParsing @stallGuard
 }
 
+# Verifies the archive against checksums.txt from the same release. That
+# guards against a corrupted transfer and against installing the wrong asset
+# (another architecture or version). It does not guard against a compromised
+# release origin or TLS path: the checksum and the archive share a trust root.
 function Assert-Checksum {
     param(
         [string] $ArchivePath,
@@ -655,8 +659,10 @@ function Add-ToUserPath {
 function Get-EntireOnPath {
     # -All is required: without it Get-Command returns only the first
     # Application, so a later Scoop shim is never seen.
-    # Write-Output with the unary comma prevents PowerShell from unrolling
-    # a single-element array, which would lose .Count under StrictMode 2.0.
+    # -NoEnumerate returns the array itself, so a single element keeps its
+    # .Count under StrictMode 2.0. Callers must assign the result before
+    # piping it: a -NoEnumerate array reaches a pipeline as one object on
+    # pwsh and as its items on Windows PowerShell 5.1.
     $results = @(Get-Command "entire" -CommandType Application -All -ErrorAction SilentlyContinue)
     Write-Output -NoEnumerate -InputObject $results
 }
@@ -704,6 +710,7 @@ function Get-EntireCopy {
             }
         }
     }
+    # Same contract as Get-EntireOnPath: assign before piping.
     Write-Output -NoEnumerate -InputObject $found
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -171,6 +171,8 @@ verified release archive because the Scoop bucket only publishes stable builds.
             [string] $Destination
         )
 
+        # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
+        # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
         Invoke-WebRequest -Uri $Uri -OutFile $Destination -UseBasicParsing
     }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -134,37 +134,42 @@ function Test-ScoopAppInstalled {
     }
 }
 
+function Format-ScoopOutput {
+    param($Output)
+    ($Output | Out-String).Trim()
+}
+
+# `scoop bucket add` exits 0 when it adds the bucket and 2 when the bucket
+# is already there (0 in Scoop releases before v0.3.0); every real failure
+# exits 1. Asking first with `bucket list` is not an option: its output is
+# rendered text whose shape changes with the number of columns, and on a
+# Scoop with no buckets at all it exits 2 itself.
+function Add-EntireScoopBucket {
+    Write-Info "Adding the Entire Scoop bucket..."
+    $added = Invoke-Scoop bucket add entire $ScoopBucketUrl
+    if ($added.ExitCode -notin 0, 2) {
+        throw "Failed to add the Entire Scoop bucket (scoop exited $($added.ExitCode)). $(Format-ScoopOutput $added.Output)"
+    }
+}
+
 function Install-EntireWithScoop {
     Write-Info "Scoop detected; installing Entire CLI with Scoop..."
 
-    $listed = Invoke-Scoop bucket list
-    if ($listed.ExitCode -ne 0) {
-        $details = ($listed.Output | Out-String).Trim()
-        throw "Failed to list Scoop buckets. $details"
-    }
-
-    $bucketList = $listed.Output | Out-String
-    if ($bucketList -notmatch "(?im)^\s*entire(?:\s|$)") {
-        Write-Info "Adding the Entire Scoop bucket..."
-        $added = Invoke-Scoop bucket add entire $ScoopBucketUrl
-        if ($added.ExitCode -ne 0) {
-            throw "Failed to add the Entire Scoop bucket."
-        }
-    }
+    Add-EntireScoopBucket
 
     $isInstalled = Test-ScoopAppInstalled -AppName "entire"
     if ($isInstalled) {
         Write-Info "Updating Entire CLI with Scoop..."
         $updated = Invoke-Scoop update entire/entire
         if ($updated.ExitCode -ne 0) {
-            throw "Scoop failed to install Entire CLI."
+            throw "Scoop failed to update Entire CLI (scoop exited $($updated.ExitCode)). $(Format-ScoopOutput $updated.Output)"
         }
     }
     else {
         Write-Info "Installing Entire CLI with Scoop..."
         $installed = Invoke-Scoop install entire/entire
         if ($installed.ExitCode -ne 0) {
-            throw "Scoop failed to install Entire CLI."
+            throw "Scoop failed to install Entire CLI (scoop exited $($installed.ExitCode)). $(Format-ScoopOutput $installed.Output)"
         }
     }
 
@@ -204,7 +209,19 @@ function Invoke-GitHubApi {
 
     # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
     # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
-    Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $WebTimeoutSec -UseBasicParsing
+    try {
+        Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $WebTimeoutSec -UseBasicParsing
+    }
+    catch {
+        # Only WebException (5.1) and HttpResponseException (pwsh) carry a
+        # Response; a timeout surfaces as TaskCanceledException, which has no
+        # such property, and under StrictMode reading it would throw.
+        $response = $_.Exception.PSObject.Properties['Response']
+        if ($null -ne $response -and $null -ne $response.Value) {
+            throw "GitHub returned HTTP $([int] $response.Value.StatusCode) for $Uri. $($_.Exception.Message)"
+        }
+        throw "Could not reach GitHub at $Uri. $($_.Exception.Message) Check your internet connection."
+    }
 }
 
 function Get-ReleaseVersion {
@@ -214,16 +231,24 @@ function Get-ReleaseVersion {
         $uri = "https://api.github.com/repos/$GitHubRepo/releases?per_page=20"
         $releases = Invoke-GitHubApi -Uri $uri
         $release = $null
+        $checked = 0
 
         # GitHub returns created_at descending. The first *nightly* tag is
         # the latest nightly. Windows PowerShell 5.1 returns a JSON array
         # from Invoke-RestMethod as one pipeline object, so enumerate it
         # explicitly instead of piping to Where-Object.
         foreach ($candidate in $releases) {
+            $checked++
             if ($candidate.tag_name -like "*nightly*") {
                 $release = $candidate
                 break
             }
+        }
+        # Invoke-GitHubApi has already thrown for any network or HTTP
+        # failure, so an empty result here means GitHub answered and nothing
+        # in the answer was a nightly.
+        if ($null -eq $release) {
+            throw "No nightly release found among the $checked most recent releases of $GitHubRepo. Try -Channel stable."
         }
     }
     else {
@@ -232,7 +257,7 @@ function Get-ReleaseVersion {
     }
 
     if ($null -eq $release -or [string]::IsNullOrWhiteSpace([string] $release.tag_name)) {
-        throw "Failed to fetch the latest $ReleaseChannel version from GitHub. Check your internet connection."
+        throw "GitHub returned the latest release of $GitHubRepo without a tag name, so the version cannot be determined."
     }
 
     $version = ([string] $release.tag_name) -replace "^v", ""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -220,10 +220,11 @@ function Invoke-GitHubApi {
         $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
     }
 
-    # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
-    # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
+    # No -UseBasicParsing here: only Invoke-WebRequest runs the Internet
+    # Explorer HTML parser on Windows PowerShell 5.1; Invoke-RestMethod
+    # decodes the body itself. See Save-RemoteFile for the one that needs it.
     try {
-        Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $ApiTimeoutSec -UseBasicParsing
+        Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $ApiTimeoutSec
     }
     catch {
         # Only WebException (5.1) and HttpResponseException (pwsh) carry a

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -205,7 +205,12 @@ verified release archive because the Scoop bucket only publishes stable builds.
     function Get-NormalizedPath {
         param([string] $Path)
 
-        $fullPath = [IO.Path]::GetFullPath($Path)
+        # Resolve against $PWD and expand ~. [IO.Path]::GetFullPath alone uses
+        # [Environment]::CurrentDirectory, which Windows PowerShell 5.1 does
+        # not keep in sync with Set-Location, and does not expand ~.
+        $fullPath = [IO.Path]::GetFullPath(
+            $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+        )
         $root = [IO.Path]::GetPathRoot($fullPath)
         if ([string]::Equals($fullPath, $root, [StringComparison]::OrdinalIgnoreCase)) {
             return $root

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -534,6 +534,24 @@ Scoop chooses its own install location and manages its own PATH entry, so
                 foreach ($cmd in $conflicting) {
                     Write-Host "! Also found:   $($cmd.Source)"
                 }
+
+                # Our PATH write only ever lands in the user half, and Windows
+                # composes a new session as machine-then-user. So a conflict on
+                # the machine PATH outranks this install in every new terminal,
+                # whatever the current session resolves to -- say so, because
+                # neither the verdict below nor reordering the user PATH can fix
+                # it.
+                $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+                foreach ($cmd in $conflicting) {
+                    if (Test-PathContains -PathValue $machinePath -Directory (Split-Path -Parent $cmd.Source)) {
+                        Write-Host "!"
+                        Write-Host "! $($cmd.Source) is on the machine-wide PATH, which Windows places"
+                        Write-Host "! ahead of your user PATH. It will win in a new terminal even though"
+                        Write-Host "! this session now resolves to the new install. Remove it, or run"
+                        Write-Host "! entire from $resolvedInstallDir explicitly."
+                    }
+                }
+
                 if (-not $firstIsOurs) {
                     Write-Host "!"
                     Write-Host "! 'entire' currently resolves to: $($first.Source)"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -21,7 +21,10 @@ param(
 
 $GitHubRepo = "entireio/cli"
 $ScoopBucketUrl = "https://github.com/entireio/scoop-bucket.git"
-$WebTimeoutSec = 60
+# Two limits, deliberately not one: the API calls get a whole-request cap,
+# the archive download gets only a stall guard. See Save-RemoteFile.
+$ApiTimeoutSec = 60
+$DownloadStallTimeoutSec = 60
 
 function Write-Info {
     param([string] $Message)
@@ -210,7 +213,7 @@ function Invoke-GitHubApi {
     # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
     # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
     try {
-        Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $WebTimeoutSec -UseBasicParsing
+        Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $ApiTimeoutSec -UseBasicParsing
     }
     catch {
         # Only WebException (5.1) and HttpResponseException (pwsh) carry a
@@ -274,9 +277,24 @@ function Save-RemoteFile {
         [string] $Destination
     )
 
+    # No -TimeoutSec on the download. What it means depends on the host:
+    # Windows PowerShell 5.1 applies it to the response headers only (the body
+    # read has its own 5-minute stall default); PowerShell 7.0-7.3 applied it
+    # to the whole transfer, so a 21 MB archive on a link below ~3 Mbit/s was
+    # cancelled at 60 s with "The operation was canceled."; PowerShell 7.4+
+    # made it an alias of -ConnectionTimeoutSeconds, which caps the connection
+    # only. Instead, where the host has -OperationTimeoutSeconds (7.4+), the
+    # download is cut when no data arrives for $DownloadStallTimeoutSec: a slow
+    # link finishes, a dead connection is reported instead of hanging, since
+    # the host has no stall detector of its own.
+    #
     # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
     # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
-    Invoke-WebRequest -Uri $Uri -OutFile $Destination -UseBasicParsing -TimeoutSec $WebTimeoutSec
+    $stallGuard = @{}
+    if ((Get-Command Invoke-WebRequest).Parameters.ContainsKey('OperationTimeoutSeconds')) {
+        $stallGuard['OperationTimeoutSeconds'] = $DownloadStallTimeoutSec
+    }
+    Invoke-WebRequest -Uri $Uri -OutFile $Destination -UseBasicParsing @stallGuard
 }
 
 function Assert-Checksum {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -308,6 +308,12 @@ function Test-SamePath {
         return $false
     }
 
+    # The user PATH is read unexpanded, so an entry may be stored as
+    # %USERPROFILE%\.local\bin. Expand before normalising: unexpanded, the
+    # entry would be resolved relative to the current directory instead.
+    $Left = [Environment]::ExpandEnvironmentVariables($Left)
+    $Right = [Environment]::ExpandEnvironmentVariables($Right)
+
     try {
         return [string]::Equals(
             (Get-NormalizedPath -Path $Left),
@@ -369,34 +375,110 @@ function Get-PathWithDirectoryFirst {
         [string] $Directory
     )
 
-    $parts = New-Object System.Collections.Generic.List[string]
+    # The value is someone's registry string and this function owns one
+    # entry in it: other entries are kept verbatim, empty entries and a
+    # trailing ";" included. When the directory is already present, its first
+    # occurrence moves to the front as stored, so an entry written as
+    # %USERPROFILE%\... stays unexpanded; only when it is absent is the
+    # literal $Directory added.
+    $kept = New-Object System.Collections.Generic.List[string]
+    $existing = $null
     if (-not [string]::IsNullOrWhiteSpace($PathValue)) {
         foreach ($entry in ($PathValue -split ";")) {
-            $trimmed = $entry.Trim()
-            if ([string]::IsNullOrWhiteSpace($trimmed)) {
+            if (Test-SamePath -Left $entry.Trim() -Right $Directory) {
+                if ($null -eq $existing) {
+                    $existing = $entry
+                }
                 continue
             }
-            if (-not (Test-SamePath -Left $trimmed -Right $Directory)) {
-                $parts.Add($trimmed)
-            }
+            $kept.Add($entry)
         }
     }
-    if ($parts.Count -eq 0) {
-        return $Directory
+    $first = if ($null -ne $existing) { $existing } else { $Directory }
+    if ($kept.Count -eq 0) {
+        return $first
     }
-    return "$Directory;" + ($parts -join ";")
+    return "$first;" + ($kept -join ";")
+}
+
+# [Environment]::GetEnvironmentVariable expands REG_EXPAND_SZ on read and
+# SetEnvironmentVariable writes REG_SZ, so a round trip through them bakes
+# the current %USERPROFILE% into the stored value and downgrades its kind.
+# These read and write the registry value as stored.
+function Get-UserEnvironmentValue {
+    param([string] $Name)
+
+    $key = (Get-Item -LiteralPath 'HKCU:').OpenSubKey('Environment')
+    if ($null -eq $key) {
+        return $null
+    }
+    return $key.GetValue($Name, $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+}
+
+function Write-UserEnvironmentValue {
+    param(
+        [string] $Name,
+        [string] $Value
+    )
+
+    $key = (Get-Item -LiteralPath 'HKCU:').CreateSubKey('Environment')
+    $existing = $key.GetValue($Name, $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+    $kind = if ($Value.Contains('%')) {
+        [Microsoft.Win32.RegistryValueKind]::ExpandString
+    }
+    elseif ($null -ne $existing) {
+        $key.GetValueKind($Name)
+    }
+    else {
+        [Microsoft.Win32.RegistryValueKind]::String
+    }
+    $key.SetValue($Name, $Value, $kind)
+    Publish-EnvironmentChange
+}
+
+# Tell Explorer and processes started from it that the environment changed.
+# Consoles that are already open keep their copy, which is why the caller
+# still says to restart the terminal.
+function Publish-EnvironmentChange {
+    if (-not ('Win32.NativeMethods' -as [Type])) {
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+    IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+    uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+'@
+    }
+
+    $HWND_BROADCAST = [IntPtr] 0xffff
+    $WM_SETTINGCHANGE = 0x1a
+    $SMTO_ABORTIFHUNG = 2
+    $result = [UIntPtr]::Zero
+    [Win32.NativeMethods]::SendMessageTimeout(
+        $HWND_BROADCAST, $WM_SETTINGCHANGE, [UIntPtr]::Zero, 'Environment',
+        $SMTO_ABORTIFHUNG, 5000, [ref] $result
+    ) | Out-Null
+}
+
+# Puts $Directory first in the named user environment variable, read and
+# written as stored. Returns whether the value changed.
+function Add-UserPathEntry {
+    param(
+        [string] $Name,
+        [string] $Directory
+    )
+
+    $value = Get-UserEnvironmentValue -Name $Name
+    if (Test-PathIsFirst -PathValue $value -Directory $Directory) {
+        return $false
+    }
+    Write-UserEnvironmentValue -Name $Name -Value (Get-PathWithDirectoryFirst -PathValue $value -Directory $Directory)
+    return $true
 }
 
 function Add-ToUserPath {
     param([string] $Directory)
 
-    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    $userPathChanged = $false
-    if (-not (Test-PathIsFirst -PathValue $userPath -Directory $Directory)) {
-        $newUserPath = Get-PathWithDirectoryFirst -PathValue $userPath -Directory $Directory
-        [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
-        $userPathChanged = $true
-    }
+    $userPathChanged = Add-UserPathEntry -Name 'Path' -Directory $Directory
 
     # Make the command available immediately when install.ps1 is evaluated
     # in the caller's current PowerShell process. Do this before Get-Command

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -21,6 +21,11 @@ param(
 
 $GitHubRepo = "entireio/cli"
 $ScoopBucketUrl = "https://github.com/entireio/scoop-bucket.git"
+# Whether the caller chose the install directory. Read here because
+# $PSBoundParameters inside a function is that function's own; the functions
+# read this the way they read $InstallDir.
+$InstallDirExplicit = $PSBoundParameters.ContainsKey('InstallDir')
+
 # Two limits, deliberately not one: the API calls get a whole-request cap,
 # the archive download gets only a stall guard. See Save-RemoteFile.
 $ApiTimeoutSec = 60
@@ -55,7 +60,8 @@ Stable installs use Scoop when it is available. Nightly installs use the
 verified release archive because the Scoop bucket only publishes stable builds.
 
 Scoop chooses its own install location and manages its own PATH entry, so
--InstallDir and -NoPathUpdate apply only to release-archive installs.
+An explicit -InstallDir selects a release-archive install even when Scoop
+is available; -NoPathUpdate applies only to release-archive installs.
 "@
 }
 
@@ -606,10 +612,12 @@ function Install-Entire {
     Write-Info "Installing Entire CLI..."
 
     $scoopCommand = Get-Command "scoop" -ErrorAction SilentlyContinue
-    if ($Channel -eq "stable" -and $null -ne $scoopCommand) {
+    if ($Channel -eq "stable" -and $null -ne $scoopCommand -and -not $InstallDirExplicit) {
         # Scoop owns the install location and the shims directory it puts on
-        # PATH, so -InstallDir and -NoPathUpdate do not apply on this branch.
-        # Write-Usage says so; keep the two in step if this changes.
+        # PATH, so -NoPathUpdate does not apply on this branch, and a caller
+        # who chose a directory is sent to the archive install instead (the
+        # update hint names the running binary's directory so that binary is
+        # replaced in place). Write-Usage says so; keep the two in step.
         Install-EntireWithScoop
 
         $prefixResult = Invoke-Scoop prefix entire
@@ -653,6 +661,9 @@ function Install-Entire {
     }
     if ($Channel -eq "nightly" -and $null -ne $scoopCommand) {
         Write-InstallerWarning "Scoop only publishes stable releases; installing nightly from the verified release archive."
+    }
+    elseif ($null -ne $scoopCommand) {
+        Write-Info "Scoop detected, but -InstallDir was given; installing from the verified release archive."
     }
 
     $resolvedInstallDir = Get-NormalizedPath -Path $InstallDir

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -63,38 +63,62 @@ verified release archive because the Scoop bucket only publishes stable builds.
 "@
     }
 
+    function Invoke-Scoop {
+        param(
+            [Parameter(Mandatory = $true, ValueFromRemainingArguments = $true)]
+            [string[]] $ScoopArgs
+        )
+
+        # Native stderr redirected with 2>&1 becomes ErrorRecord. With
+        # $ErrorActionPreference Stop that is terminating even when scoop
+        # exits 0 (update notices, deprecation warnings).
+        $previous = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        try {
+            $output = & "scoop" @ScoopArgs 2>&1
+            return @{
+                ExitCode = [int] $LASTEXITCODE
+                Output   = $output
+            }
+        }
+        finally {
+            $ErrorActionPreference = $previous
+        }
+    }
+
     function Install-EntireWithScoop {
         Write-Info "Scoop detected; installing Entire CLI with Scoop..."
 
-        $bucketOutput = & "scoop" bucket list 2>&1
-        $bucketExitCode = $LASTEXITCODE
-        if ($bucketExitCode -ne 0) {
-            $details = ($bucketOutput | Out-String).Trim()
+        $listed = Invoke-Scoop bucket list
+        if ($listed.ExitCode -ne 0) {
+            $details = ($listed.Output | Out-String).Trim()
             throw "Failed to list Scoop buckets. $details"
         }
 
-        $bucketList = $bucketOutput | Out-String
+        $bucketList = $listed.Output | Out-String
         if ($bucketList -notmatch "(?im)^\s*entire(?:\s|$)") {
             Write-Info "Adding the Entire Scoop bucket..."
-            & "scoop" bucket add entire $ScoopBucketUrl
-            if ($LASTEXITCODE -ne 0) {
+            $added = Invoke-Scoop bucket add entire $ScoopBucketUrl
+            if ($added.ExitCode -ne 0) {
                 throw "Failed to add the Entire Scoop bucket."
             }
         }
 
-        & "scoop" prefix entire *> $null
-        $isInstalled = $LASTEXITCODE -eq 0
+        $probe = Invoke-Scoop prefix entire
+        $isInstalled = $probe.ExitCode -eq 0
         if ($isInstalled) {
             Write-Info "Updating Entire CLI with Scoop..."
-            & "scoop" update entire/entire
+            $updated = Invoke-Scoop update entire/entire
+            if ($updated.ExitCode -ne 0) {
+                throw "Scoop failed to install Entire CLI."
+            }
         }
         else {
             Write-Info "Installing Entire CLI with Scoop..."
-            & "scoop" install entire/entire
-        }
-
-        if ($LASTEXITCODE -ne 0) {
-            throw "Scoop failed to install Entire CLI."
+            $installed = Invoke-Scoop install entire/entire
+            if ($installed.ExitCode -ne 0) {
+                throw "Scoop failed to install Entire CLI."
+            }
         }
 
         Write-Success "Entire CLI installed with Scoop"
@@ -131,7 +155,9 @@ verified release archive because the Scoop bucket only publishes stable builds.
             $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
         }
 
-        Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $WebTimeoutSec
+        # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
+        # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
+        Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $WebTimeoutSec -UseBasicParsing
     }
 
     function Get-ReleaseVersion {
@@ -142,10 +168,10 @@ verified release archive because the Scoop bucket only publishes stable builds.
             $releases = Invoke-GitHubApi -Uri $uri
             $release = $null
 
-            # Windows PowerShell 5.1 returns a JSON array from
-            # Invoke-RestMethod as one pipeline object. A Where-Object pipeline
-            # would therefore test the whole release list at once instead of
-            # each release, so enumerate it explicitly.
+            # GitHub returns created_at descending. The first *nightly* tag is
+            # the latest nightly. Windows PowerShell 5.1 returns a JSON array
+            # from Invoke-RestMethod as one pipeline object, so enumerate it
+            # explicitly instead of piping to Where-Object.
             foreach ($candidate in $releases) {
                 if ($candidate.tag_name -like "*nightly*") {
                     $release = $candidate
@@ -354,11 +380,11 @@ verified release archive because the Scoop bucket only publishes stable builds.
         if ($SelectedChannel -eq "stable" -and $null -ne $scoopCommand) {
             Install-EntireWithScoop
 
-            $prefixOutput = & "scoop" prefix entire 2>&1
-            if ($LASTEXITCODE -ne 0) {
+            $prefixResult = Invoke-Scoop prefix entire
+            if ($prefixResult.ExitCode -ne 0) {
                 throw "Scoop installed Entire CLI, but its installation path could not be resolved."
             }
-            $scoopPrefix = ($prefixOutput | Select-Object -First 1).ToString().Trim()
+            $scoopPrefix = ($prefixResult.Output | Select-Object -First 1).ToString().Trim()
             $scoopRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $scoopPrefix))
             $scoopShim = Join-Path $scoopRoot "shims\entire.exe"
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -561,7 +561,12 @@ function Get-PathWithDirectoryFirst {
 function Get-UserEnvironmentValue {
     param([string] $Name)
 
-    $key = (Get-Item -LiteralPath 'HKCU:').OpenSubKey('Environment')
+    # No HKCU: drive (not Windows) reads as no value, like a missing key.
+    $hive = Get-Item -LiteralPath 'HKCU:' -ErrorAction SilentlyContinue
+    if ($null -eq $hive) {
+        return $null
+    }
+    $key = $hive.OpenSubKey('Environment')
     if ($null -eq $key) {
         return $null
     }
@@ -650,6 +655,51 @@ function Get-EntireOnPath {
     # a single-element array, which would lose .Count under StrictMode 2.0.
     $results = @(Get-Command "entire" -CommandType Application -All -ErrorAction SilentlyContinue)
     Write-Output -NoEnumerate -InputObject $results
+}
+
+# Every entire.exe that will compete for the name once the user opens a new
+# terminal: the copies this process can see, in Get-Command order so the
+# priority verdict is unchanged, followed by copies that are only on the
+# stored user or machine PATH. A shell started before an earlier run wrote
+# the registry cannot see that run's directory through $env:Path, and the
+# installer tells the user to restart between installs.
+function Get-EntireCopy {
+    $found = @()
+    foreach ($command in (Get-EntireOnPath)) {
+        $found += [pscustomobject]@{ Source = $command.Source }
+    }
+
+    $stored = @(
+        (Get-UserEnvironmentValue -Name 'Path'),
+        [Environment]::GetEnvironmentVariable('Path', 'Machine')
+    )
+
+    foreach ($value in $stored) {
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            continue
+        }
+        foreach ($entry in ($value -split ';')) {
+            $directory = [Environment]::ExpandEnvironmentVariables($entry.Trim())
+            if ([string]::IsNullOrWhiteSpace($directory)) {
+                continue
+            }
+            $candidate = Join-Path $directory 'entire.exe'
+            if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+                continue
+            }
+            $known = $false
+            foreach ($existing in $found) {
+                if (Test-SamePath -Left $existing.Source -Right $candidate) {
+                    $known = $true
+                    break
+                }
+            }
+            if (-not $known) {
+                $found += [pscustomobject]@{ Source = $candidate }
+            }
+        }
+    }
+    Write-Output -NoEnumerate -InputObject $found
 }
 
 function Install-Entire {
@@ -798,11 +848,15 @@ function Install-Entire {
             $userPathChanged = Add-ToUserPath -Directory $resolvedInstallDir
         }
 
+        # The verdict is about what this shell runs; the list is about every
+        # copy the user has, including ones this shell cannot see yet.
         $pathCommands = Get-EntireOnPath
-        $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
+        $conflicting = @(Get-EntireCopy | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
         if ($conflicting.Count -gt 0) {
+            # $first can be empty: with -NoPathUpdate nothing put the new
+            # install on this shell's PATH, while stored copies still list.
             $first = $pathCommands | Select-Object -First 1
-            $firstIsOurs = Test-SamePath -Left $first.Source -Right $installPath
+            $firstIsOurs = ($null -ne $first) -and (Test-SamePath -Left $first.Source -Right $installPath)
             Write-Host ""
             Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
             Write-Host "!"
@@ -834,7 +888,12 @@ function Install-Entire {
 
             if (-not $firstIsOurs) {
                 Write-Host "!"
-                Write-Host "! 'entire' currently resolves to: $($first.Source)"
+                if ($null -eq $first) {
+                    Write-Host "! 'entire' does not resolve to an executable on this shell's PATH."
+                }
+                else {
+                    Write-Host "! 'entire' currently resolves to: $($first.Source)"
+                }
                 Write-Host "! Remove the old installation or adjust PATH to prioritize:"
                 Write-Host "!   $resolvedInstallDir"
                 Write-Host ""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -100,20 +100,13 @@ verified release archive because the Scoop bucket only publishes stable builds.
     }
 
     function Get-PlatformArchitecture {
-        # PROCESSOR_ARCHITEW6432 identifies the native OS architecture when
-        # this script is running in a 32-bit PowerShell process.
-        $architecture = $env:PROCESSOR_ARCHITEW6432
-        if ([string]::IsNullOrWhiteSpace($architecture)) {
-            $architecture = $env:PROCESSOR_ARCHITECTURE
-        }
-
-        if ([string]::IsNullOrWhiteSpace($architecture)) {
-            throw "Cannot determine the Windows architecture."
-        }
+        # OSArchitecture is the machine, not this process. PROCESSOR_* env
+        # vars report AMD64 for x64 PowerShell on ARM64 Windows.
+        $architecture = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
 
         switch ($architecture.ToUpperInvariant()) {
-            { $_ -in @("AMD64", "X86_64") } { return "amd64" }
-            { $_ -in @("ARM64", "AARCH64") } { return "arm64" }
+            "X64" { return "amd64" }
+            "ARM64" { return "arm64" }
             default { throw "Unsupported architecture: $architecture" }
         }
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -849,9 +849,12 @@ function Install-Entire {
         }
 
         # The verdict is about what this shell runs; the list is about every
-        # copy the user has, including ones this shell cannot see yet.
+        # copy the user has, including ones this shell cannot see yet. Both
+        # are assigned before being piped: their -NoEnumerate output reaches a
+        # pipeline as one array on pwsh, and as its items on 5.1.
         $pathCommands = Get-EntireOnPath
-        $conflicting = @(Get-EntireCopy | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
+        $copies = Get-EntireCopy
+        $conflicting = @($copies | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
         if ($conflicting.Count -gt 0) {
             # $first can be empty: with -NoPathUpdate nothing put the new
             # install on this shell's PATH, while stored copies still list.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -100,12 +100,20 @@ verified release archive because the Scoop bucket only publishes stable builds.
     }
 
     function Get-PlatformArchitecture {
-        # OSArchitecture is the machine, not this process. PROCESSOR_* env
-        # vars report AMD64 for x64 PowerShell on ARM64 Windows.
-        $architecture = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+        # The machine-level value is the native OS architecture. The
+        # $env:PROCESSOR_ARCHITECTURE seen by the script is the process's, so
+        # x64 PowerShell on ARM64 Windows reports AMD64. RuntimeInformation is
+        # not an option either: it needs .NET 4.7.1+, so it is missing on
+        # stock Windows PowerShell 5.1 installs.
+        $environmentKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+        $architecture = (Get-ItemProperty -LiteralPath $environmentKey -Name "PROCESSOR_ARCHITECTURE").PROCESSOR_ARCHITECTURE
+
+        if ([string]::IsNullOrWhiteSpace($architecture)) {
+            throw "Cannot determine the Windows architecture."
+        }
 
         switch ($architecture.ToUpperInvariant()) {
-            "X64" { return "amd64" }
+            "AMD64" { return "amd64" }
             "ARM64" { return "arm64" }
             default { throw "Unsupported architecture: $architecture" }
         }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,11 +1,11 @@
 [CmdletBinding()]
-# The wrapper scriptblock's parameters are read inside its nested functions,
-# which PSScriptAnalyzer does not follow when deciding whether a parameter is
-# used. One suppression per parameter, so a new unused parameter still reports.
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SelectedChannel')]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SelectedInstallDir')]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SkipPathUpdate')]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ShowHelp')]
+# The parameters are read inside functions, which PSScriptAnalyzer does not
+# follow when deciding whether a parameter is used. One suppression per
+# parameter, so a new unused parameter still reports.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Channel')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'InstallDir')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'NoPathUpdate')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Help')]
 param(
     [ValidateSet("stable", "nightly")]
     [string] $Channel = "stable",
@@ -19,44 +19,27 @@ param(
     [switch] $Help
 )
 
-# Keep all installer functions and preference changes in a child scope. This
-# matters when the script is piped to Invoke-Expression in an existing shell.
-# Path is empty under irm | iex; pass it in so the child can tell file vs pipe
-# without leaking a variable into the caller's session.
-& {
-    param(
-        [string] $SelectedChannel,
-        [string] $SelectedInstallDir,
-        [bool] $SkipPathUpdate,
-        [bool] $ShowHelp,
-        [bool] $InvokedFromFile
-    )
+$GitHubRepo = "entireio/cli"
+$ScoopBucketUrl = "https://github.com/entireio/scoop-bucket.git"
+$WebTimeoutSec = 60
 
-    Set-StrictMode -Version 2.0
-    $ErrorActionPreference = "Stop"
-    $ProgressPreference = "SilentlyContinue"
+function Write-Info {
+    param([string] $Message)
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
 
-    $GitHubRepo = "entireio/cli"
-    $ScoopBucketUrl = "https://github.com/entireio/scoop-bucket.git"
-    $WebTimeoutSec = 60
+function Write-Success {
+    param([string] $Message)
+    Write-Host "==> $Message" -ForegroundColor Green
+}
 
-    function Write-Info {
-        param([string] $Message)
-        Write-Host "==> $Message" -ForegroundColor Cyan
-    }
+function Write-InstallerWarning {
+    param([string] $Message)
+    Write-Host "Warning: $Message" -ForegroundColor Yellow
+}
 
-    function Write-Success {
-        param([string] $Message)
-        Write-Host "==> $Message" -ForegroundColor Green
-    }
-
-    function Write-InstallerWarning {
-        param([string] $Message)
-        Write-Host "Warning: $Message" -ForegroundColor Yellow
-    }
-
-    function Write-Usage {
-        Write-Host @"
+function Write-Usage {
+    Write-Host @"
 Usage: install.ps1 [-Channel stable|nightly] [-InstallDir <path>] [-NoPathUpdate]
 
 Options:
@@ -71,544 +54,559 @@ verified release archive because the Scoop bucket only publishes stable builds.
 Scoop chooses its own install location and manages its own PATH entry, so
 -InstallDir and -NoPathUpdate apply only to release-archive installs.
 "@
+}
+
+function Invoke-Scoop {
+    param(
+        [Parameter(Mandatory = $true, ValueFromRemainingArguments = $true)]
+        [string[]] $ScoopArgs
+    )
+
+    # Native stderr redirected with 2>&1 becomes ErrorRecord. With
+    # $ErrorActionPreference Stop that is terminating even when scoop
+    # exits 0 (update notices, deprecation warnings).
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $output = & "scoop" @ScoopArgs 2>&1
+        return @{
+            ExitCode = [int] $LASTEXITCODE
+            Output   = $output
+        }
+    }
+    finally {
+        $ErrorActionPreference = $previous
+    }
+}
+
+function Test-ScoopAppInstalled {
+    param([string] $AppName)
+
+    # Only the exit code matters, so discard every stream. scoop's abort /
+    # warn / info all use Write-Host, i.e. the information stream, which
+    # 2>&1 neither captures nor suppresses -- a failed probe would
+    # otherwise print "Could not find app path for '<app>'" straight to the
+    # console and read as a failure during a successful first install.
+    # Deliberately not folded into Invoke-Scoop: a blanket redirect there
+    # would also hide scoop's install and update progress, which is useful.
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & "scoop" prefix $AppName *> $null
+        return $LASTEXITCODE -eq 0
+    }
+    finally {
+        $ErrorActionPreference = $previous
+    }
+}
+
+function Install-EntireWithScoop {
+    Write-Info "Scoop detected; installing Entire CLI with Scoop..."
+
+    $listed = Invoke-Scoop bucket list
+    if ($listed.ExitCode -ne 0) {
+        $details = ($listed.Output | Out-String).Trim()
+        throw "Failed to list Scoop buckets. $details"
     }
 
-    function Invoke-Scoop {
-        param(
-            [Parameter(Mandatory = $true, ValueFromRemainingArguments = $true)]
-            [string[]] $ScoopArgs
-        )
+    $bucketList = $listed.Output | Out-String
+    if ($bucketList -notmatch "(?im)^\s*entire(?:\s|$)") {
+        Write-Info "Adding the Entire Scoop bucket..."
+        $added = Invoke-Scoop bucket add entire $ScoopBucketUrl
+        if ($added.ExitCode -ne 0) {
+            throw "Failed to add the Entire Scoop bucket."
+        }
+    }
 
-        # Native stderr redirected with 2>&1 becomes ErrorRecord. With
-        # $ErrorActionPreference Stop that is terminating even when scoop
-        # exits 0 (update notices, deprecation warnings).
-        $previous = $ErrorActionPreference
-        $ErrorActionPreference = "Continue"
-        try {
-            $output = & "scoop" @ScoopArgs 2>&1
-            return @{
-                ExitCode = [int] $LASTEXITCODE
-                Output   = $output
+    $isInstalled = Test-ScoopAppInstalled -AppName "entire"
+    if ($isInstalled) {
+        Write-Info "Updating Entire CLI with Scoop..."
+        $updated = Invoke-Scoop update entire/entire
+        if ($updated.ExitCode -ne 0) {
+            throw "Scoop failed to install Entire CLI."
+        }
+    }
+    else {
+        Write-Info "Installing Entire CLI with Scoop..."
+        $installed = Invoke-Scoop install entire/entire
+        if ($installed.ExitCode -ne 0) {
+            throw "Scoop failed to install Entire CLI."
+        }
+    }
+
+    Write-Success "Entire CLI installed with Scoop"
+}
+
+function Get-PlatformArchitecture {
+    # The machine-level value is the native OS architecture. The
+    # $env:PROCESSOR_ARCHITECTURE seen by the script is the process's, so
+    # x64 PowerShell on ARM64 Windows reports AMD64. RuntimeInformation is
+    # not an option either: it needs .NET 4.7.1+, so it is missing on
+    # stock Windows PowerShell 5.1 installs.
+    $environmentKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+    $architecture = (Get-ItemProperty -LiteralPath $environmentKey -Name "PROCESSOR_ARCHITECTURE").PROCESSOR_ARCHITECTURE
+
+    if ([string]::IsNullOrWhiteSpace($architecture)) {
+        throw "Cannot determine the Windows architecture."
+    }
+
+    switch ($architecture.ToUpperInvariant()) {
+        "AMD64" { return "amd64" }
+        "ARM64" { return "arm64" }
+        default { throw "Unsupported architecture: $architecture" }
+    }
+}
+
+function Invoke-GitHubApi {
+    param([string] $Uri)
+
+    $headers = @{
+        "Accept"     = "application/vnd.github+json"
+        "User-Agent" = "entire-install.ps1"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+        $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
+    }
+
+    # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
+    # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
+    Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $WebTimeoutSec -UseBasicParsing
+}
+
+function Get-ReleaseVersion {
+    param([string] $ReleaseChannel)
+
+    if ($ReleaseChannel -eq "nightly") {
+        $uri = "https://api.github.com/repos/$GitHubRepo/releases?per_page=20"
+        $releases = Invoke-GitHubApi -Uri $uri
+        $release = $null
+
+        # GitHub returns created_at descending. The first *nightly* tag is
+        # the latest nightly. Windows PowerShell 5.1 returns a JSON array
+        # from Invoke-RestMethod as one pipeline object, so enumerate it
+        # explicitly instead of piping to Where-Object.
+        foreach ($candidate in $releases) {
+            if ($candidate.tag_name -like "*nightly*") {
+                $release = $candidate
+                break
             }
         }
-        finally {
-            $ErrorActionPreference = $previous
-        }
+    }
+    else {
+        $uri = "https://api.github.com/repos/$GitHubRepo/releases/latest"
+        $release = Invoke-GitHubApi -Uri $uri
     }
 
-    function Test-ScoopAppInstalled {
-        param([string] $AppName)
-
-        # Only the exit code matters, so discard every stream. scoop's abort /
-        # warn / info all use Write-Host, i.e. the information stream, which
-        # 2>&1 neither captures nor suppresses -- a failed probe would
-        # otherwise print "Could not find app path for '<app>'" straight to the
-        # console and read as a failure during a successful first install.
-        # Deliberately not folded into Invoke-Scoop: a blanket redirect there
-        # would also hide scoop's install and update progress, which is useful.
-        $previous = $ErrorActionPreference
-        $ErrorActionPreference = "Continue"
-        try {
-            & "scoop" prefix $AppName *> $null
-            return $LASTEXITCODE -eq 0
-        }
-        finally {
-            $ErrorActionPreference = $previous
-        }
+    if ($null -eq $release -or [string]::IsNullOrWhiteSpace([string] $release.tag_name)) {
+        throw "Failed to fetch the latest $ReleaseChannel version from GitHub. Check your internet connection."
     }
 
-    function Install-EntireWithScoop {
-        Write-Info "Scoop detected; installing Entire CLI with Scoop..."
-
-        $listed = Invoke-Scoop bucket list
-        if ($listed.ExitCode -ne 0) {
-            $details = ($listed.Output | Out-String).Trim()
-            throw "Failed to list Scoop buckets. $details"
-        }
-
-        $bucketList = $listed.Output | Out-String
-        if ($bucketList -notmatch "(?im)^\s*entire(?:\s|$)") {
-            Write-Info "Adding the Entire Scoop bucket..."
-            $added = Invoke-Scoop bucket add entire $ScoopBucketUrl
-            if ($added.ExitCode -ne 0) {
-                throw "Failed to add the Entire Scoop bucket."
-            }
-        }
-
-        $isInstalled = Test-ScoopAppInstalled -AppName "entire"
-        if ($isInstalled) {
-            Write-Info "Updating Entire CLI with Scoop..."
-            $updated = Invoke-Scoop update entire/entire
-            if ($updated.ExitCode -ne 0) {
-                throw "Scoop failed to install Entire CLI."
-            }
-        }
-        else {
-            Write-Info "Installing Entire CLI with Scoop..."
-            $installed = Invoke-Scoop install entire/entire
-            if ($installed.ExitCode -ne 0) {
-                throw "Scoop failed to install Entire CLI."
-            }
-        }
-
-        Write-Success "Entire CLI installed with Scoop"
+    $version = ([string] $release.tag_name) -replace "^v", ""
+    if ($version -notmatch "^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$") {
+        throw "GitHub returned an invalid release version: $version"
     }
 
-    function Get-PlatformArchitecture {
-        # The machine-level value is the native OS architecture. The
-        # $env:PROCESSOR_ARCHITECTURE seen by the script is the process's, so
-        # x64 PowerShell on ARM64 Windows reports AMD64. RuntimeInformation is
-        # not an option either: it needs .NET 4.7.1+, so it is missing on
-        # stock Windows PowerShell 5.1 installs.
-        $environmentKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
-        $architecture = (Get-ItemProperty -LiteralPath $environmentKey -Name "PROCESSOR_ARCHITECTURE").PROCESSOR_ARCHITECTURE
+    return $version
+}
 
-        if ([string]::IsNullOrWhiteSpace($architecture)) {
-            throw "Cannot determine the Windows architecture."
-        }
+function Save-RemoteFile {
+    param(
+        [string] $Uri,
+        [string] $Destination
+    )
 
-        switch ($architecture.ToUpperInvariant()) {
-            "AMD64" { return "amd64" }
-            "ARM64" { return "arm64" }
-            default { throw "Unsupported architecture: $architecture" }
-        }
+    # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
+    # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
+    Invoke-WebRequest -Uri $Uri -OutFile $Destination -UseBasicParsing -TimeoutSec $WebTimeoutSec
+}
+
+function Assert-Checksum {
+    param(
+        [string] $ArchivePath,
+        [string] $ArchiveName,
+        [string] $ChecksumsPath
+    )
+
+    $escapedArchiveName = [regex]::Escape($ArchiveName)
+    $checksumLine = Get-Content -LiteralPath $ChecksumsPath |
+        Where-Object { $_ -match "(?i)^[0-9a-f]{64}\s+\*?$escapedArchiveName\s*$" } |
+        Select-Object -First 1
+
+    if ([string]::IsNullOrWhiteSpace([string] $checksumLine)) {
+        throw "Checksum for $ArchiveName was not found in checksums.txt."
     }
 
-    function Invoke-GitHubApi {
-        param([string] $Uri)
+    $expectedChecksum = ([string] $checksumLine -split "\s+")[0]
+    $actualChecksum = (Get-FileHash -LiteralPath $ArchivePath -Algorithm SHA256).Hash
+    if (-not [string]::Equals($actualChecksum, $expectedChecksum, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Checksum verification failed. Expected: $expectedChecksum, actual: $actualChecksum"
+    }
+}
 
-        $headers = @{
-            "Accept"     = "application/vnd.github+json"
-            "User-Agent" = "entire-install.ps1"
-        }
-        if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
-            $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
-        }
+function Get-NormalizedPath {
+    param([string] $Path)
 
-        # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
-        # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
-        Invoke-RestMethod -Uri $Uri -Headers $headers -TimeoutSec $WebTimeoutSec -UseBasicParsing
+    # Resolve against $PWD and expand ~. [IO.Path]::GetFullPath alone uses
+    # [Environment]::CurrentDirectory, which Windows PowerShell 5.1 does
+    # not keep in sync with Set-Location, and does not expand ~.
+    $fullPath = [IO.Path]::GetFullPath(
+        $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+    )
+    $root = [IO.Path]::GetPathRoot($fullPath)
+    if ([string]::Equals($fullPath, $root, [StringComparison]::OrdinalIgnoreCase)) {
+        return $root
     }
 
-    function Get-ReleaseVersion {
-        param([string] $ReleaseChannel)
+    [char[]] $separators = @(
+        [IO.Path]::DirectorySeparatorChar,
+        [IO.Path]::AltDirectorySeparatorChar
+    )
+    return $fullPath.TrimEnd($separators)
+}
 
-        if ($ReleaseChannel -eq "nightly") {
-            $uri = "https://api.github.com/repos/$GitHubRepo/releases?per_page=20"
-            $releases = Invoke-GitHubApi -Uri $uri
-            $release = $null
+function Test-SamePath {
+    param(
+        [string] $Left,
+        [string] $Right
+    )
 
-            # GitHub returns created_at descending. The first *nightly* tag is
-            # the latest nightly. Windows PowerShell 5.1 returns a JSON array
-            # from Invoke-RestMethod as one pipeline object, so enumerate it
-            # explicitly instead of piping to Where-Object.
-            foreach ($candidate in $releases) {
-                if ($candidate.tag_name -like "*nightly*") {
-                    $release = $candidate
-                    break
-                }
-            }
-        }
-        else {
-            $uri = "https://api.github.com/repos/$GitHubRepo/releases/latest"
-            $release = Invoke-GitHubApi -Uri $uri
-        }
-
-        if ($null -eq $release -or [string]::IsNullOrWhiteSpace([string] $release.tag_name)) {
-            throw "Failed to fetch the latest $ReleaseChannel version from GitHub. Check your internet connection."
-        }
-
-        $version = ([string] $release.tag_name) -replace "^v", ""
-        if ($version -notmatch "^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$") {
-            throw "GitHub returned an invalid release version: $version"
-        }
-
-        return $version
-    }
-
-    function Save-RemoteFile {
-        param(
-            [string] $Uri,
-            [string] $Destination
-        )
-
-        # -UseBasicParsing is required for Windows PowerShell 5.1 (skips the IE
-        # DOM parser). In PowerShell 7+ it is accepted and silently ignored.
-        Invoke-WebRequest -Uri $Uri -OutFile $Destination -UseBasicParsing -TimeoutSec $WebTimeoutSec
-    }
-
-    function Assert-Checksum {
-        param(
-            [string] $ArchivePath,
-            [string] $ArchiveName,
-            [string] $ChecksumsPath
-        )
-
-        $escapedArchiveName = [regex]::Escape($ArchiveName)
-        $checksumLine = Get-Content -LiteralPath $ChecksumsPath |
-            Where-Object { $_ -match "(?i)^[0-9a-f]{64}\s+\*?$escapedArchiveName\s*$" } |
-            Select-Object -First 1
-
-        if ([string]::IsNullOrWhiteSpace([string] $checksumLine)) {
-            throw "Checksum for $ArchiveName was not found in checksums.txt."
-        }
-
-        $expectedChecksum = ([string] $checksumLine -split "\s+")[0]
-        $actualChecksum = (Get-FileHash -LiteralPath $ArchivePath -Algorithm SHA256).Hash
-        if (-not [string]::Equals($actualChecksum, $expectedChecksum, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Checksum verification failed. Expected: $expectedChecksum, actual: $actualChecksum"
-        }
-    }
-
-    function Get-NormalizedPath {
-        param([string] $Path)
-
-        # Resolve against $PWD and expand ~. [IO.Path]::GetFullPath alone uses
-        # [Environment]::CurrentDirectory, which Windows PowerShell 5.1 does
-        # not keep in sync with Set-Location, and does not expand ~.
-        $fullPath = [IO.Path]::GetFullPath(
-            $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
-        )
-        $root = [IO.Path]::GetPathRoot($fullPath)
-        if ([string]::Equals($fullPath, $root, [StringComparison]::OrdinalIgnoreCase)) {
-            return $root
-        }
-
-        [char[]] $separators = @(
-            [IO.Path]::DirectorySeparatorChar,
-            [IO.Path]::AltDirectorySeparatorChar
-        )
-        return $fullPath.TrimEnd($separators)
-    }
-
-    function Test-SamePath {
-        param(
-            [string] $Left,
-            [string] $Right
-        )
-
-        if ([string]::IsNullOrWhiteSpace($Left) -or [string]::IsNullOrWhiteSpace($Right)) {
-            return $false
-        }
-
-        try {
-            return [string]::Equals(
-                (Get-NormalizedPath -Path $Left),
-                (Get-NormalizedPath -Path $Right),
-                [StringComparison]::OrdinalIgnoreCase
-            )
-        }
-        catch {
-            return $false
-        }
-    }
-
-    function Test-PathContains {
-        # "Contains" is a verb form, not a plural noun.
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
-        param(
-            [AllowNull()]
-            [string] $PathValue,
-            [string] $Directory
-        )
-
-        if ([string]::IsNullOrWhiteSpace($PathValue)) {
-            return $false
-        }
-
-        foreach ($entry in ($PathValue -split ";")) {
-            if (Test-SamePath -Left $entry.Trim() -Right $Directory) {
-                return $true
-            }
-        }
+    if ([string]::IsNullOrWhiteSpace($Left) -or [string]::IsNullOrWhiteSpace($Right)) {
         return $false
     }
 
-    function Test-PathIsFirst {
-        param(
-            [AllowNull()]
-            [string] $PathValue,
-            [string] $Directory
+    try {
+        return [string]::Equals(
+            (Get-NormalizedPath -Path $Left),
+            (Get-NormalizedPath -Path $Right),
+            [StringComparison]::OrdinalIgnoreCase
         )
+    }
+    catch {
+        return $false
+    }
+}
 
-        if ([string]::IsNullOrWhiteSpace($PathValue)) {
-            return $false
+function Test-PathContains {
+    # "Contains" is a verb form, not a plural noun.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
+    param(
+        [AllowNull()]
+        [string] $PathValue,
+        [string] $Directory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return $false
+    }
+
+    foreach ($entry in ($PathValue -split ";")) {
+        if (Test-SamePath -Left $entry.Trim() -Right $Directory) {
+            return $true
         }
+    }
+    return $false
+}
 
+function Test-PathIsFirst {
+    param(
+        [AllowNull()]
+        [string] $PathValue,
+        [string] $Directory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return $false
+    }
+
+    foreach ($entry in ($PathValue -split ";")) {
+        $trimmed = $entry.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed)) {
+            continue
+        }
+        return (Test-SamePath -Left $trimmed -Right $Directory)
+    }
+    return $false
+}
+
+function Get-PathWithDirectoryFirst {
+    param(
+        [AllowNull()]
+        [string] $PathValue,
+        [string] $Directory
+    )
+
+    $parts = New-Object System.Collections.Generic.List[string]
+    if (-not [string]::IsNullOrWhiteSpace($PathValue)) {
         foreach ($entry in ($PathValue -split ";")) {
             $trimmed = $entry.Trim()
             if ([string]::IsNullOrWhiteSpace($trimmed)) {
                 continue
             }
-            return (Test-SamePath -Left $trimmed -Right $Directory)
+            if (-not (Test-SamePath -Left $trimmed -Right $Directory)) {
+                $parts.Add($trimmed)
+            }
         }
-        return $false
+    }
+    if ($parts.Count -eq 0) {
+        return $Directory
+    }
+    return "$Directory;" + ($parts -join ";")
+}
+
+function Add-ToUserPath {
+    param([string] $Directory)
+
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $userPathChanged = $false
+    if (-not (Test-PathIsFirst -PathValue $userPath -Directory $Directory)) {
+        $newUserPath = Get-PathWithDirectoryFirst -PathValue $userPath -Directory $Directory
+        [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+        $userPathChanged = $true
     }
 
-    function Get-PathWithDirectoryFirst {
-        param(
-            [AllowNull()]
-            [string] $PathValue,
-            [string] $Directory
-        )
-
-        $parts = New-Object System.Collections.Generic.List[string]
-        if (-not [string]::IsNullOrWhiteSpace($PathValue)) {
-            foreach ($entry in ($PathValue -split ";")) {
-                $trimmed = $entry.Trim()
-                if ([string]::IsNullOrWhiteSpace($trimmed)) {
-                    continue
-                }
-                if (-not (Test-SamePath -Left $trimmed -Right $Directory)) {
-                    $parts.Add($trimmed)
-                }
-            }
-        }
-        if ($parts.Count -eq 0) {
-            return $Directory
-        }
-        return "$Directory;" + ($parts -join ";")
+    # Make the command available immediately when install.ps1 is evaluated
+    # in the caller's current PowerShell process. Do this before Get-Command
+    # "entire", which caches the first Application hit for the session.
+    if (-not (Test-PathIsFirst -PathValue $env:Path -Directory $Directory)) {
+        $env:Path = Get-PathWithDirectoryFirst -PathValue $env:Path -Directory $Directory
     }
 
-    function Add-ToUserPath {
-        param([string] $Directory)
+    return $userPathChanged
+}
 
-        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-        $userPathChanged = $false
-        if (-not (Test-PathIsFirst -PathValue $userPath -Directory $Directory)) {
-            $newUserPath = Get-PathWithDirectoryFirst -PathValue $userPath -Directory $Directory
-            [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
-            $userPathChanged = $true
-        }
+function Get-EntireOnPath {
+    # -All is required: without it Get-Command returns only the first
+    # Application, so a later Scoop shim is never seen.
+    # Write-Output with the unary comma prevents PowerShell from unrolling
+    # a single-element array, which would lose .Count under StrictMode 2.0.
+    $results = @(Get-Command "entire" -CommandType Application -All -ErrorAction SilentlyContinue)
+    Write-Output -NoEnumerate -InputObject $results
+}
 
-        # Make the command available immediately when install.ps1 is evaluated
-        # in the caller's current PowerShell process. Do this before Get-Command
-        # "entire", which caches the first Application hit for the session.
-        if (-not (Test-PathIsFirst -PathValue $env:Path -Directory $Directory)) {
-            $env:Path = Get-PathWithDirectoryFirst -PathValue $env:Path -Directory $Directory
-        }
+function Install-Entire {
+    # Set here rather than at script scope: preference variables assigned
+    # in a function are local to it and its callees, and Set-StrictMode
+    # applies to the current scope and its children, so under irm | iex
+    # none of this reaches the caller's session.
+    Set-StrictMode -Version 2.0
+    $ErrorActionPreference = "Stop"
+    $ProgressPreference = "SilentlyContinue"
 
-        return $userPathChanged
+    if ($Help) {
+        Write-Usage
+        return
     }
 
-    function Get-EntireOnPath {
-        # -All is required: without it Get-Command returns only the first
-        # Application, so a later Scoop shim is never seen.
-        # Write-Output with the unary comma prevents PowerShell from unrolling
-        # a single-element array, which would lose .Count under StrictMode 2.0.
-        $results = @(Get-Command "entire" -CommandType Application -All -ErrorAction SilentlyContinue)
-        Write-Output -NoEnumerate -InputObject $results
-    }
+    Write-Info "Installing Entire CLI..."
 
-    function Install-Entire {
-        if ($ShowHelp) {
-            Write-Usage
-            return
+    $scoopCommand = Get-Command "scoop" -ErrorAction SilentlyContinue
+    if ($Channel -eq "stable" -and $null -ne $scoopCommand) {
+        # Scoop owns the install location and the shims directory it puts on
+        # PATH, so -InstallDir and -NoPathUpdate do not apply on this branch.
+        # Write-Usage says so; keep the two in step if this changes.
+        Install-EntireWithScoop
+
+        $prefixResult = Invoke-Scoop prefix entire
+        if ($prefixResult.ExitCode -ne 0) {
+            throw "Scoop installed Entire CLI, but its installation path could not be resolved."
         }
+        $scoopPrefix = ($prefixResult.Output | Select-Object -First 1).ToString().Trim()
+        $scoopRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $scoopPrefix))
+        $scoopShim = Join-Path $scoopRoot "shims\entire.exe"
 
-        Write-Info "Installing Entire CLI..."
-
-        $scoopCommand = Get-Command "scoop" -ErrorAction SilentlyContinue
-        if ($SelectedChannel -eq "stable" -and $null -ne $scoopCommand) {
-            # Scoop owns the install location and the shims directory it puts on
-            # PATH, so -InstallDir and -NoPathUpdate do not apply on this branch.
-            # Write-Usage says so; keep the two in step if this changes.
-            Install-EntireWithScoop
-
-            $prefixResult = Invoke-Scoop prefix entire
-            if ($prefixResult.ExitCode -ne 0) {
-                throw "Scoop installed Entire CLI, but its installation path could not be resolved."
-            }
-            $scoopPrefix = ($prefixResult.Output | Select-Object -First 1).ToString().Trim()
-            $scoopRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $scoopPrefix))
-            $scoopShim = Join-Path $scoopRoot "shims\entire.exe"
-
-            $pathCommands = Get-EntireOnPath
-            $first = $pathCommands | Select-Object -First 1
-            if ($null -eq $first -or -not (Test-SamePath -Left $first.Source -Right $scoopShim)) {
-                Write-Host ""
-                Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
-                Write-Host "!"
-                Write-Host "! Scoop shim: $scoopShim"
-                if ($null -eq $first) {
-                    Write-Host "! 'entire' does not resolve to an executable on PATH."
-                }
-                else {
-                    Write-Host "! 'entire' currently resolves to: $($first.Source)"
-                }
-                Write-Host "! Remove the old installation or adjust PATH to prioritize:"
-                Write-Host "!   $(Split-Path -Parent $scoopShim)"
-                Write-Host ""
-                throw "Scoop installed Entire CLI, but its shim does not take priority on PATH."
-            }
-
-            $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $scoopShim) })
-            if ($conflicting.Count -gt 0) {
-                Write-Host ""
-                Write-Host "! WARNING: Other Entire CLI installations remain on PATH" -ForegroundColor Yellow
-                foreach ($cmd in $conflicting) {
-                    Write-Host "! Also found: $($cmd.Source)"
-                }
-                Write-Host "! The Scoop shim takes priority, but consider removing the other installation."
-                Write-Host ""
-            }
-            return
-        }
-        if ($SelectedChannel -eq "nightly" -and $null -ne $scoopCommand) {
-            Write-InstallerWarning "Scoop only publishes stable releases; installing nightly from the verified release archive."
-        }
-
-        $resolvedInstallDir = Get-NormalizedPath -Path $SelectedInstallDir
-        $installPath = Join-Path $resolvedInstallDir "entire.exe"
-
-        # GitHub requires TLS 1.2. Use the numeric value so this remains valid
-        # on .NET versions whose SecurityProtocolType enum omits the name.
-        [Net.ServicePointManager]::SecurityProtocol =
-            [Net.ServicePointManager]::SecurityProtocol -bor 3072
-
-        $architecture = Get-PlatformArchitecture
-        Write-Info "Detected platform: windows/$architecture"
-
-        Write-Info "Fetching latest $SelectedChannel version..."
-        $version = Get-ReleaseVersion -ReleaseChannel $SelectedChannel
-        Write-Info "Installing version: $version"
-
-        $archiveName = "entire_windows_$architecture.zip"
-        $releaseBaseUrl = "https://github.com/$GitHubRepo/releases/download/v$version"
-        $downloadUrl = "$releaseBaseUrl/$archiveName"
-        $checksumsUrl = "$releaseBaseUrl/checksums.txt"
-
-        $tempDir = Join-Path ([IO.Path]::GetTempPath()) ("entire-install-" + [guid]::NewGuid().ToString("N"))
-        New-Item -ItemType Directory -Path $tempDir | Out-Null
-
-        try {
-            $archivePath = Join-Path $tempDir $archiveName
-            $checksumsPath = Join-Path $tempDir "checksums.txt"
-            $extractDir = Join-Path $tempDir "extracted"
-
-            Write-Info "Downloading $archiveName..."
-            Save-RemoteFile -Uri $downloadUrl -Destination $archivePath
-
-            Write-Info "Downloading checksums..."
-            Save-RemoteFile -Uri $checksumsUrl -Destination $checksumsPath
-
-            Write-Info "Verifying checksum..."
-            Assert-Checksum -ArchivePath $archivePath -ArchiveName $archiveName -ChecksumsPath $checksumsPath
-            Write-Success "Checksum verified"
-
-            Write-Info "Extracting..."
-            Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
-
-            $sourceBinary = Join-Path $extractDir "entire.exe"
-            $sourceHelper = Join-Path $extractDir "git-remote-entire.exe"
-            if (-not (Test-Path -LiteralPath $sourceBinary -PathType Leaf)) {
-                throw "entire.exe was not found in $archiveName."
-            }
-
-            Write-Info "Installing to $resolvedInstallDir..."
-            New-Item -ItemType Directory -Path $resolvedInstallDir -Force | Out-Null
-
-            Copy-Item -LiteralPath $sourceBinary -Destination $installPath -Force
-
-            if (Test-Path -LiteralPath $sourceHelper -PathType Leaf) {
-                Copy-Item -LiteralPath $sourceHelper -Destination (Join-Path $resolvedInstallDir "git-remote-entire.exe") -Force
+        $pathCommands = Get-EntireOnPath
+        $first = $pathCommands | Select-Object -First 1
+        if ($null -eq $first -or -not (Test-SamePath -Left $first.Source -Right $scoopShim)) {
+            Write-Host ""
+            Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
+            Write-Host "!"
+            Write-Host "! Scoop shim: $scoopShim"
+            if ($null -eq $first) {
+                Write-Host "! 'entire' does not resolve to an executable on PATH."
             }
             else {
-                Write-InstallerWarning "git-remote-entire.exe was not found in the archive; entire:// clones will not work until the next release includes it."
+                Write-Host "! 'entire' currently resolves to: $($first.Source)"
             }
-
-            & $installPath version *> $null
-            if ($LASTEXITCODE -ne 0) {
-                throw "Installation completed, but entire.exe failed to execute."
-            }
-            Write-Success "Entire CLI installed to $installPath"
-
-            # Prepend PATH before Get-Command "entire". Checking first throws on
-            # the documented nightly path (Scoop stable already installed) and
-            # never updates PATH, so a rerun fails the same way.
-            $userPathChanged = $false
-            if (-not $SkipPathUpdate) {
-                $userPathChanged = Add-ToUserPath -Directory $resolvedInstallDir
-            }
-
-            $pathCommands = Get-EntireOnPath
-            $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
-            if ($conflicting.Count -gt 0) {
-                $first = $pathCommands | Select-Object -First 1
-                $firstIsOurs = Test-SamePath -Left $first.Source -Right $installPath
-                Write-Host ""
-                Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
-                Write-Host "!"
-                Write-Host "! Installed to: $installPath"
-                foreach ($cmd in $conflicting) {
-                    Write-Host "! Also found:   $($cmd.Source)"
-                }
-
-                # Our PATH write only ever lands in the user half, and Windows
-                # composes a new session as machine-then-user. So a conflict on
-                # the machine PATH outranks this install in every new terminal,
-                # whatever the current session resolves to -- say so, because
-                # neither the verdict below nor reordering the user PATH can fix
-                # it.
-                $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
-                $machineConflict = $false
-                foreach ($cmd in $conflicting) {
-                    if (Test-PathContains -PathValue $machinePath -Directory (Split-Path -Parent $cmd.Source)) {
-                        $machineConflict = $true
-                        Write-Host "!"
-                        Write-Host "! $($cmd.Source) is on the machine-wide PATH, which Windows places"
-                        Write-Host "! ahead of your user PATH, so it wins in a new terminal however your"
-                        Write-Host "! user PATH is ordered. Remove that copy, or drop its directory from"
-                        Write-Host "! the machine PATH (needs an administrator). To install over it"
-                        Write-Host "! instead, rerun with:"
-                        Write-Host "!   -InstallDir $(Split-Path -Parent $cmd.Source)"
-                    }
-                }
-
-                if (-not $firstIsOurs) {
-                    Write-Host "!"
-                    Write-Host "! 'entire' currently resolves to: $($first.Source)"
-                    Write-Host "! Remove the old installation or adjust PATH to prioritize:"
-                    Write-Host "!   $resolvedInstallDir"
-                    Write-Host ""
-                    if ($SkipPathUpdate) {
-                        throw "Installation completed, but PATH was not updated (-NoPathUpdate)."
-                    }
-                    throw "Installation completed, but PATH needs adjustment."
-                }
-                # Suppressed on a machine-PATH conflict: the paragraph above has
-                # already said that install wins in a new terminal, and claiming
-                # priority as well leaves the reader nothing to act on.
-                if (-not $machineConflict) {
-                    $others = if ($conflicting.Count -gt 1) { "the other installations" } else { "the other installation" }
-                    Write-Host "!"
-                    Write-Host "! The installed version takes priority, but consider removing"
-                    Write-Host "! $others to avoid confusion."
-                }
-                Write-Host ""
-            }
-
-            if ($SkipPathUpdate) {
-                if (-not (Test-PathContains -PathValue $env:Path -Directory $resolvedInstallDir)) {
-                    Write-InstallerWarning "$resolvedInstallDir is not on PATH. Add it before running entire."
-                }
-            }
-            elseif ($userPathChanged) {
-                Write-Success "Added $resolvedInstallDir to your user PATH"
-                Write-Host "Restart your terminal, then run entire to get started."
-            }
+            Write-Host "! Remove the old installation or adjust PATH to prioritize:"
+            Write-Host "!   $(Split-Path -Parent $scoopShim)"
+            Write-Host ""
+            throw "Scoop installed Entire CLI, but its shim does not take priority on PATH."
         }
-        finally {
-            Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+
+        $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $scoopShim) })
+        if ($conflicting.Count -gt 0) {
+            Write-Host ""
+            Write-Host "! WARNING: Other Entire CLI installations remain on PATH" -ForegroundColor Yellow
+            foreach ($cmd in $conflicting) {
+                Write-Host "! Also found: $($cmd.Source)"
+            }
+            Write-Host "! The Scoop shim takes priority, but consider removing the other installation."
+            Write-Host ""
         }
+        return
+    }
+    if ($Channel -eq "nightly" -and $null -ne $scoopCommand) {
+        Write-InstallerWarning "Scoop only publishes stable releases; installing nightly from the verified release archive."
     }
 
+    $resolvedInstallDir = Get-NormalizedPath -Path $InstallDir
+    $installPath = Join-Path $resolvedInstallDir "entire.exe"
+
+    # GitHub requires TLS 1.2. Use the numeric value so this remains valid
+    # on .NET versions whose SecurityProtocolType enum omits the name.
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.ServicePointManager]::SecurityProtocol -bor 3072
+
+    $architecture = Get-PlatformArchitecture
+    Write-Info "Detected platform: windows/$architecture"
+
+    Write-Info "Fetching latest $Channel version..."
+    $version = Get-ReleaseVersion -ReleaseChannel $Channel
+    Write-Info "Installing version: $version"
+
+    $archiveName = "entire_windows_$architecture.zip"
+    $releaseBaseUrl = "https://github.com/$GitHubRepo/releases/download/v$version"
+    $downloadUrl = "$releaseBaseUrl/$archiveName"
+    $checksumsUrl = "$releaseBaseUrl/checksums.txt"
+
+    $tempDir = Join-Path ([IO.Path]::GetTempPath()) ("entire-install-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+    try {
+        $archivePath = Join-Path $tempDir $archiveName
+        $checksumsPath = Join-Path $tempDir "checksums.txt"
+        $extractDir = Join-Path $tempDir "extracted"
+
+        Write-Info "Downloading $archiveName..."
+        Save-RemoteFile -Uri $downloadUrl -Destination $archivePath
+
+        Write-Info "Downloading checksums..."
+        Save-RemoteFile -Uri $checksumsUrl -Destination $checksumsPath
+
+        Write-Info "Verifying checksum..."
+        Assert-Checksum -ArchivePath $archivePath -ArchiveName $archiveName -ChecksumsPath $checksumsPath
+        Write-Success "Checksum verified"
+
+        Write-Info "Extracting..."
+        Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
+
+        $sourceBinary = Join-Path $extractDir "entire.exe"
+        $sourceHelper = Join-Path $extractDir "git-remote-entire.exe"
+        if (-not (Test-Path -LiteralPath $sourceBinary -PathType Leaf)) {
+            throw "entire.exe was not found in $archiveName."
+        }
+
+        Write-Info "Installing to $resolvedInstallDir..."
+        New-Item -ItemType Directory -Path $resolvedInstallDir -Force | Out-Null
+
+        Copy-Item -LiteralPath $sourceBinary -Destination $installPath -Force
+
+        if (Test-Path -LiteralPath $sourceHelper -PathType Leaf) {
+            Copy-Item -LiteralPath $sourceHelper -Destination (Join-Path $resolvedInstallDir "git-remote-entire.exe") -Force
+        }
+        else {
+            Write-InstallerWarning "git-remote-entire.exe was not found in the archive; entire:// clones will not work until the next release includes it."
+        }
+
+        & $installPath version *> $null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Installation completed, but entire.exe failed to execute."
+        }
+        Write-Success "Entire CLI installed to $installPath"
+
+        # Prepend PATH before Get-Command "entire". Checking first throws on
+        # the documented nightly path (Scoop stable already installed) and
+        # never updates PATH, so a rerun fails the same way.
+        $userPathChanged = $false
+        if (-not $NoPathUpdate) {
+            $userPathChanged = Add-ToUserPath -Directory $resolvedInstallDir
+        }
+
+        $pathCommands = Get-EntireOnPath
+        $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
+        if ($conflicting.Count -gt 0) {
+            $first = $pathCommands | Select-Object -First 1
+            $firstIsOurs = Test-SamePath -Left $first.Source -Right $installPath
+            Write-Host ""
+            Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
+            Write-Host "!"
+            Write-Host "! Installed to: $installPath"
+            foreach ($cmd in $conflicting) {
+                Write-Host "! Also found:   $($cmd.Source)"
+            }
+
+            # Our PATH write only ever lands in the user half, and Windows
+            # composes a new session as machine-then-user. So a conflict on
+            # the machine PATH outranks this install in every new terminal,
+            # whatever the current session resolves to -- say so, because
+            # neither the verdict below nor reordering the user PATH can fix
+            # it.
+            $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+            $machineConflict = $false
+            foreach ($cmd in $conflicting) {
+                if (Test-PathContains -PathValue $machinePath -Directory (Split-Path -Parent $cmd.Source)) {
+                    $machineConflict = $true
+                    Write-Host "!"
+                    Write-Host "! $($cmd.Source) is on the machine-wide PATH, which Windows places"
+                    Write-Host "! ahead of your user PATH, so it wins in a new terminal however your"
+                    Write-Host "! user PATH is ordered. Remove that copy, or drop its directory from"
+                    Write-Host "! the machine PATH (needs an administrator). To install over it"
+                    Write-Host "! instead, rerun with:"
+                    Write-Host "!   -InstallDir $(Split-Path -Parent $cmd.Source)"
+                }
+            }
+
+            if (-not $firstIsOurs) {
+                Write-Host "!"
+                Write-Host "! 'entire' currently resolves to: $($first.Source)"
+                Write-Host "! Remove the old installation or adjust PATH to prioritize:"
+                Write-Host "!   $resolvedInstallDir"
+                Write-Host ""
+                if ($NoPathUpdate) {
+                    throw "Installation completed, but PATH was not updated (-NoPathUpdate)."
+                }
+                throw "Installation completed, but PATH needs adjustment."
+            }
+            # Suppressed on a machine-PATH conflict: the paragraph above has
+            # already said that install wins in a new terminal, and claiming
+            # priority as well leaves the reader nothing to act on.
+            if (-not $machineConflict) {
+                $others = if ($conflicting.Count -gt 1) { "the other installations" } else { "the other installation" }
+                Write-Host "!"
+                Write-Host "! The installed version takes priority, but consider removing"
+                Write-Host "! $others to avoid confusion."
+            }
+            Write-Host ""
+        }
+
+        if ($NoPathUpdate) {
+            if (-not (Test-PathContains -PathValue $env:Path -Directory $resolvedInstallDir)) {
+                Write-InstallerWarning "$resolvedInstallDir is not on PATH. Add it before running entire."
+            }
+        }
+        elseif ($userPathChanged) {
+            Write-Success "Added $resolvedInstallDir to your user PATH"
+            Write-Host "Restart your terminal, then run entire to get started."
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Dot-sourcing loads the functions and nothing else, so tests can call
+# them. Every other invocation installs: -File, `.\install.ps1`, `& path`,
+# `irm | iex`, and the scriptblock form.
+if ($MyInvocation.InvocationName -ne '.') {
+    # MyCommand.Path is empty under irm | iex and the scriptblock form, and
+    # set whenever the script runs from its file.
+    $invokedFromFile = -not [string]::IsNullOrEmpty($MyInvocation.MyCommand.Path)
     try {
         Install-Entire
     }
     catch {
         $message = "Error: $($_.Exception.Message)"
-        if ($InvokedFromFile) {
+        if ($invokedFromFile) {
             Write-Host $message -ForegroundColor Red
             exit 1
         }
@@ -616,4 +614,4 @@ Scoop chooses its own install location and manages its own PATH entry, so
         # do not exit 1 -- that would close the user's interactive shell.
         throw $message
     }
-} $Channel $InstallDir $NoPathUpdate.IsPresent $Help.IsPresent (-not [string]::IsNullOrEmpty($MyInvocation.MyCommand.Path))
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -347,34 +347,6 @@ verified release archive because the Scoop bucket only publishes stable builds.
         $resolvedInstallDir = Get-NormalizedPath -Path $SelectedInstallDir
         $installPath = Join-Path $resolvedInstallDir "entire.exe"
 
-        # Match install.sh: abort if another entire wins on PATH. Check before
-        # copying so a conflict does not leave files behind.
-        $pathCommands = Get-EntireOnPath
-        $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
-        if ($conflicting.Count -gt 0) {
-            $first = $pathCommands | Select-Object -First 1
-            $firstIsOurs = Test-SamePath -Left $first.Source -Right $installPath
-            Write-Host ""
-            Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
-            Write-Host "!"
-            Write-Host "! Install destination: $installPath"
-            foreach ($cmd in $conflicting) {
-                Write-Host "! Also found:   $($cmd.Source)"
-            }
-            if (-not $firstIsOurs) {
-                Write-Host "!"
-                Write-Host "! 'entire' currently resolves to: $($first.Source)"
-                Write-Host "! Remove the old installation or adjust PATH to prioritize:"
-                Write-Host "!   $resolvedInstallDir"
-                Write-Host ""
-                throw "PATH needs adjustment. Then rerun the installation."
-            }
-            Write-Host "!"
-            Write-Host "! The installed version takes priority, but consider removing"
-            Write-Host "! the other installation to avoid confusion."
-            Write-Host ""
-        }
-
         # GitHub requires TLS 1.2. Use the numeric value so this remains valid
         # on .NET versions whose SecurityProtocolType enum omits the name.
         [Net.ServicePointManager]::SecurityProtocol =
@@ -437,15 +409,42 @@ verified release archive because the Scoop bucket only publishes stable builds.
             }
             Write-Success "Entire CLI installed to $installPath"
 
-            $postInstallCommands = Get-EntireOnPath
+            # Check for PATH conflicts now that the binary exists on disk,
+            # so Test-SamePath can resolve both paths reliably.
+            $pathCommands = Get-EntireOnPath
+            $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
+            if ($conflicting.Count -gt 0) {
+                $first = $pathCommands | Select-Object -First 1
+                $firstIsOurs = Test-SamePath -Left $first.Source -Right $installPath
+                Write-Host ""
+                Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
+                Write-Host "!"
+                Write-Host "! Installed to: $installPath"
+                foreach ($cmd in $conflicting) {
+                    Write-Host "! Also found:   $($cmd.Source)"
+                }
+                if (-not $firstIsOurs) {
+                    Write-Host "!"
+                    Write-Host "! 'entire' currently resolves to: $($first.Source)"
+                    Write-Host "! Remove the old installation or adjust PATH to prioritize:"
+                    Write-Host "!   $resolvedInstallDir"
+                    Write-Host ""
+                    throw "Installation completed, but PATH needs adjustment."
+                }
+                Write-Host "!"
+                Write-Host "! The installed version takes priority, but consider removing"
+                Write-Host "! the other installation to avoid confusion."
+                Write-Host ""
+            }
+
             if ($SkipPathUpdate) {
-                if ($postInstallCommands.Count -eq 0) {
+                if ($pathCommands.Count -eq 0) {
                     Write-InstallerWarning "$resolvedInstallDir is not on PATH. Add it before running entire."
                 }
             }
             else {
                 Add-ToUserPath -Directory $resolvedInstallDir
-                if ($postInstallCommands.Count -eq 0) {
+                if ($pathCommands.Count -eq 0) {
                     Write-Success "Added $resolvedInstallDir to your user PATH"
                     Write-Host "Restart your terminal, then run entire to get started."
                 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -60,6 +60,9 @@ Options:
 
 Stable installs use Scoop when it is available. Nightly installs use the
 verified release archive because the Scoop bucket only publishes stable builds.
+
+Scoop chooses its own install location and manages its own PATH entry, so
+-InstallDir and -NoPathUpdate apply only to release-archive installs.
 "@
     }
 
@@ -86,6 +89,27 @@ verified release archive because the Scoop bucket only publishes stable builds.
         }
     }
 
+    function Test-ScoopAppInstalled {
+        param([string] $AppName)
+
+        # Only the exit code matters, so discard every stream. scoop's abort /
+        # warn / info all use Write-Host, i.e. the information stream, which
+        # 2>&1 neither captures nor suppresses -- a failed probe would
+        # otherwise print "Could not find app path for '<app>'" straight to the
+        # console and read as a failure during a successful first install.
+        # Deliberately not folded into Invoke-Scoop: a blanket redirect there
+        # would also hide scoop's install and update progress, which is useful.
+        $previous = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        try {
+            & "scoop" prefix $AppName *> $null
+            return $LASTEXITCODE -eq 0
+        }
+        finally {
+            $ErrorActionPreference = $previous
+        }
+    }
+
     function Install-EntireWithScoop {
         Write-Info "Scoop detected; installing Entire CLI with Scoop..."
 
@@ -104,8 +128,7 @@ verified release archive because the Scoop bucket only publishes stable builds.
             }
         }
 
-        $probe = Invoke-Scoop prefix entire
-        $isInstalled = $probe.ExitCode -eq 0
+        $isInstalled = Test-ScoopAppInstalled -AppName "entire"
         if ($isInstalled) {
             Write-Info "Updating Entire CLI with Scoop..."
             $updated = Invoke-Scoop update entire/entire
@@ -378,6 +401,9 @@ verified release archive because the Scoop bucket only publishes stable builds.
 
         $scoopCommand = Get-Command "scoop" -ErrorAction SilentlyContinue
         if ($SelectedChannel -eq "stable" -and $null -ne $scoopCommand) {
+            # Scoop owns the install location and the shims directory it puts on
+            # PATH, so -InstallDir and -NoPathUpdate do not apply on this branch.
+            # Write-Usage says so; keep the two in step if this changes.
             Install-EntireWithScoop
 
             $prefixResult = Invoke-Scoop prefix entire

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -126,7 +126,7 @@ verified release archive because the Scoop bucket only publishes stable builds.
             $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
         }
 
-        Invoke-RestMethod -Uri $Uri -Headers $headers -UseBasicParsing
+        Invoke-RestMethod -Uri $Uri -Headers $headers
     }
 
     function Get-ReleaseVersion {
@@ -346,29 +346,43 @@ verified release archive because the Scoop bucket only publishes stable builds.
             }
             Write-Success "Entire CLI installed to $installPath"
 
-            $pathCommand = Get-Command "entire" -CommandType Application -ErrorAction SilentlyContinue |
-                Select-Object -First 1
-            if ($null -ne $pathCommand -and -not (Test-SamePath -Left $pathCommand.Source -Right $installPath)) {
+            $pathCommands = @(Get-Command "entire" -CommandType Application -ErrorAction SilentlyContinue)
+            $conflicting = @($pathCommands | Where-Object { -not (Test-SamePath -Left $_.Source -Right $installPath) })
+            if ($conflicting.Count -gt 0) {
+                $first = $pathCommands | Select-Object -First 1
+                $firstIsOurs = Test-SamePath -Left $first.Source -Right $installPath
                 Write-Host ""
                 Write-Host "! WARNING: PATH conflict detected" -ForegroundColor Yellow
                 Write-Host "!"
                 Write-Host "! Installed to: $installPath"
-                Write-Host "! But 'entire' resolves to: $($pathCommand.Source)"
-                Write-Host "!"
-                Write-Host "! Remove the old installation or adjust PATH to prioritize:"
-                Write-Host "!   $resolvedInstallDir"
+                foreach ($cmd in $conflicting) {
+                    Write-Host "! Also found:   $($cmd.Source)"
+                }
+                if (-not $firstIsOurs) {
+                    Write-Host "!"
+                    Write-Host "! 'entire' currently resolves to: $($first.Source)"
+                    Write-Host "! Remove the old installation or adjust PATH to prioritize:"
+                    Write-Host "!   $resolvedInstallDir"
+                }
+                else {
+                    Write-Host "!"
+                    Write-Host "! The installed version takes priority, but consider removing"
+                    Write-Host "! the other installation to avoid confusion."
+                }
                 Write-Host ""
-                throw "Installation completed, but PATH needs adjustment."
+                if (-not $firstIsOurs) {
+                    throw "Installation completed, but PATH needs adjustment."
+                }
             }
 
             if ($SkipPathUpdate) {
-                if ($null -eq $pathCommand) {
+                if ($pathCommands.Count -eq 0) {
                     Write-InstallerWarning "$resolvedInstallDir is not on PATH. Add it before running entire."
                 }
             }
             else {
                 Add-ToUserPath -Directory $resolvedInstallDir
-                if ($null -eq $pathCommand) {
+                if ($pathCommands.Count -eq 0) {
                     Write-Success "Added $resolvedInstallDir to your user PATH"
                     Write-Host "Restart your terminal, then run entire to get started."
                 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -326,6 +326,65 @@ function Assert-Checksum {
     }
 }
 
+# Classifies a failed file operation by its cause, walking the exception
+# chain because PowerShell wraps provider and .NET errors differently:
+# Move-Item surfaces UnauthorizedAccessException directly, a .NET method call
+# puts it inside MethodInvocationException. Type is checked before HResult so
+# a wrapper with its own HResult cannot hide the cause.
+function Get-WriteFailureKind {
+    param($Exception)
+
+    $current = $Exception
+    while ($null -ne $current) {
+        if ($current -is [UnauthorizedAccessException] -or $current.HResult -eq 0x80070005) {
+            return 'denied'
+        }
+        # ERROR_SHARING_VIOLATION and ERROR_LOCK_VIOLATION
+        if ($current -is [IO.IOException] -and ($current.HResult -eq 0x80070020 -or $current.HResult -eq 0x80070021)) {
+            return 'held'
+        }
+        $current = $current.InnerException
+    }
+    return 'other'
+}
+
+# The message for a failed write, naming the remedy only when the cause is
+# known: access denied gets elevation or another directory, a held file gets
+# "close the program", anything else is reported as it is.
+function Get-WriteFailureMessage {
+    param(
+        [string] $Action,
+        [string] $Path,
+        [string] $Directory,
+        $Exception
+    )
+
+    switch (Get-WriteFailureKind -Exception $Exception) {
+        'denied' {
+            return "Access denied writing to $Directory. Run PowerShell as Administrator, or pass -InstallDir with a directory you can write to. ($($Exception.Message))"
+        }
+        'held' {
+            return "Cannot replace $Path because another program holds it open. Close entire (including any running 'entire mcp') and any tool that has the file open, then rerun the installer. ($($Exception.Message))"
+        }
+        default {
+            return "Could not $Action $Path. ($($Exception.Message))"
+        }
+    }
+}
+
+# New-Item has no -LiteralPath; CreateDirectory takes the path as written,
+# creates parents, and is a no-op when it exists.
+function Initialize-InstallDirectory {
+    param([string] $Path)
+
+    try {
+        [IO.Directory]::CreateDirectory($Path) | Out-Null
+    }
+    catch {
+        throw (Get-WriteFailureMessage -Action 'create' -Path $Path -Directory $Path -Exception $_.Exception)
+    }
+}
+
 # Windows lets a running executable be renamed but not overwritten or
 # deleted, so an existing binary is moved aside, the verified file copied in,
 # and the old image removed if nothing holds it. A .old that is itself still
@@ -352,7 +411,7 @@ function Install-BinaryFile {
             Move-Item -LiteralPath $Destination -Destination $retired -ErrorAction Stop
         }
         catch {
-            throw "Cannot replace $Destination because another program holds it open. Close entire (including any running 'entire mcp') and any tool that has the file open, then rerun the installer. ($($_.Exception.Message))"
+            throw (Get-WriteFailureMessage -Action 'move aside' -Path $Destination -Directory (Split-Path -Parent $Destination) -Exception $_.Exception)
         }
     }
 
@@ -363,7 +422,7 @@ function Install-BinaryFile {
         if ($null -ne $retired) {
             Move-Item -LiteralPath $retired -Destination $Destination -Force -ErrorAction SilentlyContinue
         }
-        throw
+        throw (Get-WriteFailureMessage -Action 'write' -Path $Destination -Directory (Split-Path -Parent $Destination) -Exception $_.Exception)
     }
 
     if ($null -ne $retired) {
@@ -714,9 +773,7 @@ function Install-Entire {
         }
 
         Write-Info "Installing to $resolvedInstallDir..."
-        # New-Item has no -LiteralPath; CreateDirectory takes the path as
-        # written, creates parents, and is a no-op when it exists.
-        [IO.Directory]::CreateDirectory($resolvedInstallDir) | Out-Null
+        Initialize-InstallDirectory -Path $resolvedInstallDir
 
         Install-BinaryFile -Source $sourceBinary -Destination $installPath
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -283,7 +283,10 @@ verified release archive because the Scoop bucket only publishes stable builds.
     function Get-EntireOnPath {
         # -All is required: without it Get-Command returns only the first
         # Application, so a later Scoop shim is never seen.
-        return @(Get-Command "entire" -CommandType Application -All -ErrorAction SilentlyContinue)
+        # Write-Output with the unary comma prevents PowerShell from unrolling
+        # a single-element array, which would lose .Count under StrictMode 2.0.
+        $results = @(Get-Command "entire" -CommandType Application -All -ErrorAction SilentlyContinue)
+        Write-Output -NoEnumerate $results
     }
 
     function Install-Entire {
@@ -434,14 +437,15 @@ verified release archive because the Scoop bucket only publishes stable builds.
             }
             Write-Success "Entire CLI installed to $installPath"
 
+            $postInstallCommands = Get-EntireOnPath
             if ($SkipPathUpdate) {
-                if ($pathCommands.Count -eq 0) {
+                if ($postInstallCommands.Count -eq 0) {
                     Write-InstallerWarning "$resolvedInstallDir is not on PATH. Add it before running entire."
                 }
             }
             else {
                 Add-ToUserPath -Directory $resolvedInstallDir
-                if ($pathCommands.Count -eq 0) {
+                if ($postInstallCommands.Count -eq 0) {
                     Write-Success "Added $resolvedInstallDir to your user PATH"
                     Write-Host "Restart your terminal, then run entire to get started."
                 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -277,6 +277,51 @@ function Assert-Checksum {
     }
 }
 
+# Windows lets a running executable be renamed but not overwritten or
+# deleted, so an existing binary is moved aside, the verified file copied in,
+# and the old image removed if nothing holds it. A .old that is itself still
+# running gets out of the way under a unique name, and stale *.old files
+# left by a previous run are removed first. The copy failing puts the old
+# binary back before the error propagates.
+function Install-BinaryFile {
+    param(
+        [string] $Source,
+        [string] $Destination
+    )
+
+    $leaf = Split-Path -Leaf $Destination
+    Get-ChildItem -LiteralPath (Split-Path -Parent $Destination) -Filter "$leaf*.old" -File -ErrorAction SilentlyContinue |
+        Remove-Item -Force -ErrorAction SilentlyContinue
+
+    $retired = $null
+    if (Test-Path -LiteralPath $Destination -PathType Leaf) {
+        $retired = "$Destination.old"
+        if (Test-Path -LiteralPath $retired) {
+            $retired = "$Destination.$([guid]::NewGuid().ToString('N')).old"
+        }
+        try {
+            Move-Item -LiteralPath $Destination -Destination $retired -ErrorAction Stop
+        }
+        catch {
+            throw "Cannot replace $Destination because another program holds it open. Close entire (including any running 'entire mcp') and any tool that has the file open, then rerun the installer. ($($_.Exception.Message))"
+        }
+    }
+
+    try {
+        Copy-Item -LiteralPath $Source -Destination $Destination -ErrorAction Stop
+    }
+    catch {
+        if ($null -ne $retired) {
+            Move-Item -LiteralPath $retired -Destination $Destination -Force -ErrorAction SilentlyContinue
+        }
+        throw
+    }
+
+    if ($null -ne $retired) {
+        Remove-Item -LiteralPath $retired -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Get-NormalizedPath {
     param([string] $Path)
 
@@ -588,7 +633,7 @@ function Install-Entire {
     $checksumsUrl = "$releaseBaseUrl/checksums.txt"
 
     $tempDir = Join-Path ([IO.Path]::GetTempPath()) ("entire-install-" + [guid]::NewGuid().ToString("N"))
-    New-Item -ItemType Directory -Path $tempDir | Out-Null
+    [IO.Directory]::CreateDirectory($tempDir) | Out-Null
 
     try {
         $archivePath = Join-Path $tempDir $archiveName
@@ -615,12 +660,14 @@ function Install-Entire {
         }
 
         Write-Info "Installing to $resolvedInstallDir..."
-        New-Item -ItemType Directory -Path $resolvedInstallDir -Force | Out-Null
+        # New-Item has no -LiteralPath; CreateDirectory takes the path as
+        # written, creates parents, and is a no-op when it exists.
+        [IO.Directory]::CreateDirectory($resolvedInstallDir) | Out-Null
 
-        Copy-Item -LiteralPath $sourceBinary -Destination $installPath -Force
+        Install-BinaryFile -Source $sourceBinary -Destination $installPath
 
         if (Test-Path -LiteralPath $sourceHelper -PathType Leaf) {
-            Copy-Item -LiteralPath $sourceHelper -Destination (Join-Path $resolvedInstallDir "git-remote-entire.exe") -Force
+            Install-BinaryFile -Source $sourceHelper -Destination (Join-Path $resolvedInstallDir "git-remote-entire.exe")
         }
         else {
             Write-InstallerWarning "git-remote-entire.exe was not found in the archive; entire:// clones will not work until the next release includes it."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -61,7 +61,11 @@ detect_os() {
             echo "linux"
             ;;
         mingw*|msys*|cygwin*)
-            error "install.sh does not support Windows, you can install the Entire CLI using scoop:
+            error "install.sh does not support Windows. Run this from PowerShell 5.1 or later:
+
+    irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex
+
+  Or install the Entire CLI using Scoop:
 
     scoop install entire/entire
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,7 +63,7 @@ detect_os() {
         mingw*|msys*|cygwin*)
             error "install.sh does not support Windows. Run this from PowerShell 5.1 or later:
 
-    irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex
+    irm https://entire.io/install.ps1 -UseBasicParsing | iex
 
   Or install the Entire CLI using Scoop:
 

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -502,3 +502,28 @@ Describe 'Invoke-GitHubApi' {
         { Invoke-GitHubApi -Uri 'https://api.github.com/x' } | Should -Throw -ExpectedMessage '*Could not reach GitHub*The operation was canceled.*'
     }
 }
+
+Describe 'Web timeouts' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+    }
+
+    # Pester exposes a mocked call's arguments to the filter as variables, with
+    # alias names filled in too, so $TimeoutSec is set whether the host binds
+    # it as TimeoutSec (5.1) or ConnectionTimeoutSeconds (7.4+).
+    It 'caps the GitHub API calls at 60 seconds' {
+        Mock Invoke-RestMethod { @{} }
+        Invoke-GitHubApi -Uri 'https://api.github.com/x'
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter { $TimeoutSec -eq 60 }
+    }
+
+    It 'downloads with a stall guard where the host has one and no whole-transfer cap' {
+        $hostHasStallGuard = (Get-Command Invoke-WebRequest).Parameters.ContainsKey('OperationTimeoutSeconds')
+        Mock Invoke-WebRequest {}
+        Save-RemoteFile -Uri 'https://example.invalid/a.zip' -Destination (Join-Path $TestDrive 'a.zip')
+        Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
+            $null -eq $TimeoutSec -and $null -eq $ConnectionTimeoutSeconds -and
+            $(if ($hostHasStallGuard) { $OperationTimeoutSeconds -eq 60 } else { $null -eq $OperationTimeoutSeconds })
+        }
+    }
+}

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -30,10 +30,25 @@ Describe 'install.ps1' {
             [pscustomobject]@{ Output = $output; ExitCode = $LASTEXITCODE }
         }
 
+        # On Windows the run reaches the direct-install branch and fails at the
+        # stubbed network call; elsewhere the OS guard refuses first, so the
+        # message that proves the installer ran is the guard's.
         function Assert-DirectInstallBranch {
             param([pscustomobject] $Run)
             $Run.Output | Should -Contain 'SCOOP:False'
-            $Run.Output | Should -Contain '==> Installing Entire CLI...'
+            if ($env:OS -eq 'Windows_NT') {
+                $Run.Output | Should -Contain '==> Installing Entire CLI...'
+            }
+        }
+
+        function Assert-ExpectedFailure {
+            param([string[]] $Output, [string] $Prefix)
+            if ($env:OS -eq 'Windows_NT') {
+                $Output | Should -Contain "${Prefix}Error: entire-test: network blocked"
+            }
+            else {
+                @($Output | Where-Object { $_ -like "${Prefix}Error: install.ps1 supports Windows only.*" }) | Should -HaveCount 1
+            }
         }
 
         # The installer's own `exit 1` must not be reached when it runs inside
@@ -44,9 +59,7 @@ Describe 'install.ps1' {
             Assert-DirectInstallBranch -Run $Run
             @($Run.Output | Where-Object { $_ -like 'CAUGHT:Error: *' }) | Should -HaveCount 1
             @($Run.Output | Where-Object { $_ -like 'Error: *' }) | Should -HaveCount 0
-            if ($env:OS -eq 'Windows_NT') {
-                $Run.Output | Should -Contain 'CAUGHT:Error: entire-test: network blocked'
-            }
+            Assert-ExpectedFailure -Output $Run.Output -Prefix 'CAUGHT:'
             $Run.Output | Should -Contain 'ALIVE'
             $Run.ExitCode | Should -Be 7
         }
@@ -97,9 +110,7 @@ Describe 'install.ps1' {
             $run = Invoke-InstallerChild -Body "& '$(Get-InstallerPath)' -InstallDir '$installDir'; exit `$LASTEXITCODE"
             Assert-DirectInstallBranch -Run $run
             Assert-NoExceptionFormatting -Output $run.Output
-            if ($env:OS -eq 'Windows_NT') {
-                $run.Output | Should -Contain 'Error: entire-test: network blocked'
-            }
+            Assert-ExpectedFailure -Output $run.Output -Prefix ''
             $run.ExitCode | Should -Be 1
         }
 
@@ -107,15 +118,58 @@ Describe 'install.ps1' {
         # inherits the cut-down PATH, but it is a fresh process, so the
         # Invoke-RestMethod stub cannot reach it. A drive that does not exist
         # fails in Get-NormalizedPath, which runs before the registry read and
-        # the first network call on every OS, so this case asserts the provider
-        # message instead of the sentinel.
+        # the first network call, so on Windows this case asserts the provider
+        # message instead of the sentinel. Elsewhere the OS guard refuses first.
         It 'exits the process with 1 when run with -File' {
             $shell = (Get-Process -Id $PID).Path
             $run = Invoke-InstallerChild -Body "& '$shell' -NoProfile -NonInteractive -File '$(Get-InstallerPath)' -InstallDir 'entiretestnodrive:\bin'; exit `$LASTEXITCODE"
             Assert-DirectInstallBranch -Run $run
             Assert-NoExceptionFormatting -Output $run.Output
-            @($run.Output | Where-Object { $_ -like 'Error: *Cannot find drive*entiretestnodrive*' }) | Should -HaveCount 1
+            if ($env:OS -eq 'Windows_NT') {
+                @($run.Output | Where-Object { $_ -like 'Error: *Cannot find drive*entiretestnodrive*' }) | Should -HaveCount 1
+            }
+            else {
+                @($run.Output | Where-Object { $_ -like 'Error: install.ps1 supports Windows only.*' }) | Should -HaveCount 1
+            }
             $run.ExitCode | Should -Be 1
         }
+    }
+}
+
+Describe 'Assert-Prerequisite' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+    }
+
+    It 'refuses a non-Windows host and points at install.sh' {
+        Mock Test-IsWindows { $false }
+        { Assert-Prerequisite } | Should -Throw -ExpectedMessage '*supports Windows only*install.sh*'
+    }
+
+    It 'refuses PowerShell older than 5.1' {
+        Mock Test-IsWindows { $true }
+        Mock Test-MinimumPowerShell { $false }
+        { Assert-Prerequisite } | Should -Throw -ExpectedMessage '*5.1 or later is required*'
+    }
+
+    It 'refuses a session that is not in FullLanguage mode' {
+        Mock Test-IsWindows { $true }
+        Mock Test-MinimumPowerShell { $true }
+        Mock Test-FullLanguageMode { $false }
+        { Assert-Prerequisite } | Should -Throw -ExpectedMessage '*FullLanguage mode is required*'
+    }
+
+    It 'reports the host before the PowerShell version' {
+        Mock Test-IsWindows { $false }
+        Mock Test-MinimumPowerShell { $false }
+        Mock Test-FullLanguageMode { $false }
+        { Assert-Prerequisite } | Should -Throw -ExpectedMessage '*supports Windows only*'
+    }
+
+    It 'passes when every prerequisite holds' {
+        Mock Test-IsWindows { $true }
+        Mock Test-MinimumPowerShell { $true }
+        Mock Test-FullLanguageMode { $true }
+        { Assert-Prerequisite } | Should -Not -Throw
     }
 }

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -572,3 +572,73 @@ Describe 'Scoop or archive selection' {
         Should -Invoke Get-ReleaseVersion -Times 0 -Exactly
     }
 }
+
+Describe 'Get-WriteFailureKind' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+    }
+
+    It 'classifies <Name> as <Expected>' -TestCases @(
+        @{ Name = 'UnauthorizedAccessException'; Expected = 'denied'; Build = { [UnauthorizedAccessException]::new('denied') } }
+        @{ Name = 'IOException with the access-denied HResult'; Expected = 'denied'; Build = { [IO.IOException]::new('denied', 0x80070005) } }
+        @{ Name = 'IOException with ERROR_SHARING_VIOLATION'; Expected = 'held'; Build = { [IO.IOException]::new('held', 0x80070020) } }
+        @{ Name = 'IOException with ERROR_LOCK_VIOLATION'; Expected = 'held'; Build = { [IO.IOException]::new('held', 0x80070021) } }
+        @{ Name = 'IOException with another HResult'; Expected = 'other'; Build = { [IO.IOException]::new('disk full', 0x80070070) } }
+        @{ Name = 'an unrelated exception'; Expected = 'other'; Build = { [InvalidOperationException]::new('nope') } }
+        @{ Name = 'a PowerShell wrapper around access denied'; Expected = 'denied'; Build = { [System.Management.Automation.RuntimeException]::new('wrapped', [UnauthorizedAccessException]::new('denied')) } }
+        @{ Name = 'a PowerShell wrapper around a sharing violation'; Expected = 'held'; Build = { [System.Management.Automation.RuntimeException]::new('wrapped', [IO.IOException]::new('held', 0x80070020)) } }
+    ) {
+        Get-WriteFailureKind -Exception (& $Build) | Should -Be $Expected
+    }
+}
+
+Describe 'Denied writes' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+
+        # Removes or restores write access for the current user on a directory.
+        function Edit-DirectoryWriteAccess {
+            param([string] $Path, [bool] $Writable)
+            if ($env:OS -eq 'Windows_NT') {
+                $ace = "$($env:USERNAME):(W)"
+                if ($Writable) { icacls $Path /remove:d $env:USERNAME | Out-Null }
+                else { icacls $Path /deny $ace | Out-Null }
+            }
+            else {
+                chmod $(if ($Writable) { '755' } else { '555' }) $Path
+            }
+        }
+    }
+
+    It 'names access denied, not a held file, when the directory is not writable' {
+        $dir = Join-Path $TestDrive 'locked'
+        $target = Join-Path $dir 'entire.exe'
+        [IO.Directory]::CreateDirectory($dir) | Out-Null
+        Set-Content -LiteralPath $target -Value 'old' -NoNewline
+        Set-Content -LiteralPath (Join-Path $TestDrive 'src.bin') -Value 'new' -NoNewline
+        Edit-DirectoryWriteAccess -Path $dir -Writable $false
+        try {
+            $thrown = $null
+            try { Install-BinaryFile -Source (Join-Path $TestDrive 'src.bin') -Destination $target } catch { $thrown = $_.Exception.Message }
+            $thrown | Should -BeLike "Access denied writing to $dir.*"
+            $thrown | Should -Not -BeLike '*holds it open*'
+        }
+        finally {
+            Edit-DirectoryWriteAccess -Path $dir -Writable $true
+        }
+        Get-Content -LiteralPath $target -Raw | Should -Be 'old'
+    }
+
+    It 'names access denied when the install directory cannot be created' {
+        $parent = Join-Path $TestDrive 'ro-parent'
+        [IO.Directory]::CreateDirectory($parent) | Out-Null
+        Edit-DirectoryWriteAccess -Path $parent -Writable $false
+        try {
+            $wanted = Join-Path $parent 'bin'
+            { Initialize-InstallDirectory -Path $wanted } | Should -Throw -ExpectedMessage "Access denied writing to $wanted.*"
+        }
+        finally {
+            Edit-DirectoryWriteAccess -Path $parent -Writable $true
+        }
+    }
+}

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -44,7 +44,8 @@ Describe 'install.ps1' {
         function Assert-ExpectedFailure {
             param([string[]] $Output, [string] $Prefix)
             if ($env:OS -eq 'Windows_NT') {
-                $Output | Should -Contain "${Prefix}Error: entire-test: network blocked"
+                # Invoke-GitHubApi wraps the stub's message, so match inside the line.
+                @($Output | Where-Object { $_ -like "${Prefix}Error: *entire-test: network blocked*" }) | Should -HaveCount 1
             }
             else {
                 @($Output | Where-Object { $_ -like "${Prefix}Error: install.ps1 supports Windows only.*" }) | Should -HaveCount 1
@@ -409,5 +410,95 @@ Describe 'Install-BinaryFile' {
             Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination $target
             Get-OldFile -Directory $dir | Should -HaveCount 0
         }
+    }
+}
+
+Describe 'Install-EntireWithScoop' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+    }
+
+    BeforeEach {
+        Mock Write-Info {}
+        Mock Write-Success {}
+        Mock Test-ScoopAppInstalled { $false }
+        Mock Invoke-Scoop { @{ ExitCode = 0; Output = @() } }
+    }
+
+    It 'installs after the bucket is added (exit <ExitCode>)' -TestCases @(
+        @{ ExitCode = 0 }
+        @{ ExitCode = 2 }
+    ) {
+        Mock Invoke-Scoop { @{ ExitCode = $ExitCode; Output = @() } } -ParameterFilter { $ScoopArgs[0] -eq 'bucket' -and $ScoopArgs[1] -eq 'add' }
+        Install-EntireWithScoop
+        Should -Invoke Invoke-Scoop -Times 1 -Exactly -ParameterFilter { $ScoopArgs[0] -eq 'install' }
+        Should -Invoke Invoke-Scoop -Times 0 -Exactly -ParameterFilter { $ScoopArgs[0] -eq 'bucket' -and $ScoopArgs[1] -eq 'list' }
+    }
+
+    It 'reports scoop output when adding the bucket fails' {
+        Mock Invoke-Scoop { @{ ExitCode = 1; Output = @('boom: no git') } } -ParameterFilter { $ScoopArgs[0] -eq 'bucket' -and $ScoopArgs[1] -eq 'add' }
+        { Install-EntireWithScoop } | Should -Throw -ExpectedMessage '*Failed to add the Entire Scoop bucket (scoop exited 1)*boom: no git*'
+        Should -Invoke Invoke-Scoop -Times 0 -Exactly -ParameterFilter { $ScoopArgs[0] -eq 'install' }
+        Should -Invoke Invoke-Scoop -Times 0 -Exactly -ParameterFilter { $ScoopArgs[0] -eq 'bucket' -and $ScoopArgs[1] -eq 'list' }
+    }
+
+    It 'updates instead of installing when entire is already present' {
+        Mock Test-ScoopAppInstalled { $true }
+        Install-EntireWithScoop
+        Should -Invoke Invoke-Scoop -Times 1 -Exactly -ParameterFilter { $ScoopArgs[0] -eq 'update' }
+        Should -Invoke Invoke-Scoop -Times 0 -Exactly -ParameterFilter { $ScoopArgs[0] -eq 'install' }
+    }
+
+    It 'reports scoop output when the install fails' {
+        Mock Invoke-Scoop { @{ ExitCode = 1; Output = @('manifest not found') } } -ParameterFilter { $ScoopArgs[0] -eq 'install' }
+        { Install-EntireWithScoop } | Should -Throw -ExpectedMessage '*Scoop failed to install Entire CLI (scoop exited 1)*manifest not found*'
+    }
+}
+
+Describe 'Get-ReleaseVersion' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+    }
+
+    It 'names the missing nightly when GitHub returns no releases' {
+        Mock Invoke-GitHubApi { $null }
+        { Get-ReleaseVersion -ReleaseChannel nightly } | Should -Throw -ExpectedMessage '*No nightly release found among the 0 most recent releases*'
+    }
+
+    It 'names the missing nightly when every release is stable' {
+        Mock Invoke-GitHubApi { @(@{ tag_name = 'v1.2.0' }, @{ tag_name = 'v1.1.0' }, @{ tag_name = 'v1.0.0' }) }
+        { Get-ReleaseVersion -ReleaseChannel nightly } | Should -Throw -ExpectedMessage '*No nightly release found among the 3 most recent releases*'
+    }
+
+    It 'returns the first nightly tag' {
+        Mock Invoke-GitHubApi { @(@{ tag_name = 'v1.2.0' }, @{ tag_name = 'v1.2.1-nightly.202609040000.abc1234' }, @{ tag_name = 'v1.1.0-nightly.1' }) }
+        Get-ReleaseVersion -ReleaseChannel nightly | Should -Be '1.2.1-nightly.202609040000.abc1234'
+    }
+
+    It 'names a stable release without a tag' {
+        Mock Invoke-GitHubApi { @{ tag_name = '' } }
+        { Get-ReleaseVersion -ReleaseChannel stable } | Should -Throw -ExpectedMessage '*without a tag name*'
+    }
+
+    It 'returns the stable version without its v prefix' {
+        Mock Invoke-GitHubApi { @{ tag_name = 'v1.2.3' } }
+        Get-ReleaseVersion -ReleaseChannel stable | Should -Be '1.2.3'
+    }
+}
+
+Describe 'Invoke-GitHubApi' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+    }
+
+    It 'blames connectivity when no response came back' {
+        Mock Invoke-RestMethod { throw 'No such host is known.' }
+        { Invoke-GitHubApi -Uri 'https://api.github.com/x' } | Should -Throw -ExpectedMessage '*Could not reach GitHub at https://api.github.com/x. No such host is known. Check your internet connection.*'
+    }
+
+    It 'survives an exception type without a Response property under StrictMode' {
+        Mock Invoke-RestMethod { throw [System.Threading.Tasks.TaskCanceledException]::new('The operation was canceled.') }
+        Set-StrictMode -Version 2.0
+        { Invoke-GitHubApi -Uri 'https://api.github.com/x' } | Should -Throw -ExpectedMessage '*Could not reach GitHub*The operation was canceled.*'
     }
 }

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -396,7 +396,11 @@ Describe 'Install-BinaryFile' {
             $target = Join-Path $dir 'entire.exe'
             [IO.Directory]::CreateDirectory($dir) | Out-Null
             Write-TestBinary -Path (Join-Path $dir 'src.bin') -Content 'new'
-            $old = Invoke-RunningCopy -Path "$target.old"
+            # A running .old arises the way the installer makes it: the image
+            # is started as entire.exe and then renamed while running. Windows
+            # will not start a process from a file named entire.exe.old.
+            $old = Invoke-RunningCopy -Path $target
+            Move-Item -LiteralPath $target -Destination "$target.old"
             $current = Invoke-RunningCopy -Path $target
             try {
                 Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination $target

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -1,0 +1,113 @@
+Describe 'install.ps1' {
+    BeforeAll {
+        function Get-InstallerPath {
+            Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1'
+        }
+
+        # Runs $Body in a child process of the same shell, so the Windows
+        # PowerShell 5.1 and pwsh CI steps each test their own host.
+        #
+        # The child's PATH is cut down to the shell's own directory. The
+        # installer branches on `Get-Command scoop` before it does anything
+        # else, and with Scoop resolvable a stable-channel run performs a real
+        # `scoop bucket add` and `scoop install`. Scrubbing PATH pins every case
+        # here to the direct-install branch whatever the host has installed; the
+        # child reports the resolution so the scrub is asserted, not assumed.
+        #
+        # The child also shadows Invoke-RestMethod with a function that throws:
+        # command resolution prefers functions over cmdlets, so the direct-install
+        # branch's first network call fails with the sentinel and nothing is
+        # downloaded.
+        function Invoke-InstallerChild {
+            param([string] $Body)
+            $shell = (Get-Process -Id $PID).Path
+            $preamble = @(
+                "`$env:PATH = '$(Split-Path -Parent $shell)'"
+                "'SCOOP:' + [bool](Get-Command scoop -ErrorAction SilentlyContinue)"
+                "function Invoke-RestMethod { throw 'entire-test: network blocked' }"
+            ) -join '; '
+            $output = @(& $shell -NoProfile -NonInteractive -Command "$preamble; $Body" 2>&1 | ForEach-Object { "$_" })
+            [pscustomobject]@{ Output = $output; ExitCode = $LASTEXITCODE }
+        }
+
+        function Assert-DirectInstallBranch {
+            param([pscustomobject] $Run)
+            $Run.Output | Should -Contain 'SCOOP:False'
+            $Run.Output | Should -Contain '==> Installing Entire CLI...'
+        }
+
+        # The installer's own `exit 1` must not be reached when it runs inside
+        # a live session, so the child continues past it and ends with its own
+        # exit code: seeing 7 is the proof that the session survived.
+        function Assert-ThrowsWithoutExiting {
+            param([pscustomobject] $Run)
+            Assert-DirectInstallBranch -Run $Run
+            @($Run.Output | Where-Object { $_ -like 'CAUGHT:Error: *' }) | Should -HaveCount 1
+            @($Run.Output | Where-Object { $_ -like 'Error: *' }) | Should -HaveCount 0
+            if ($env:OS -eq 'Windows_NT') {
+                $Run.Output | Should -Contain 'CAUGHT:Error: entire-test: network blocked'
+            }
+            $Run.Output | Should -Contain 'ALIVE'
+            $Run.ExitCode | Should -Be 7
+        }
+
+        function Assert-NoExceptionFormatting {
+            param([string[]] $Output)
+            @($Output | Where-Object { $_ -like 'Error: *' }) | Should -HaveCount 1
+            @($Output | Where-Object { $_ -match 'At line:|CategoryInfo|FullyQualifiedErrorId' }) | Should -HaveCount 0
+        }
+    }
+
+    Context 'documented invocation shapes' {
+        It 'runs as a scriptblock with -Help' {
+            $installer = [scriptblock]::Create((Get-Content -Raw (Get-InstallerPath)))
+            $output = @(& $installer -Help 6>&1 | ForEach-Object { "$_" })
+            $output[0] | Should -BeLike 'Usage: install.ps1*'
+        }
+
+        It 'binds -Channel nightly through the scriptblock form' {
+            $installer = [scriptblock]::Create((Get-Content -Raw (Get-InstallerPath)))
+            $output = @(& $installer -Channel nightly -Help 6>&1 | ForEach-Object { "$_" })
+            $output[0] | Should -BeLike 'Usage: install.ps1*'
+        }
+    }
+
+    Context 'error path' {
+        It 'throws and leaves the session running when piped to Invoke-Expression' {
+            $run = Invoke-InstallerChild -Body "try { Get-Content -Raw '$(Get-InstallerPath)' | Invoke-Expression } catch { 'CAUGHT:' + `$_.Exception.Message }; 'ALIVE'; exit 7"
+            Assert-ThrowsWithoutExiting -Run $run
+        }
+
+        It 'throws and leaves the session running when run as a scriptblock with parameters' {
+            $installDir = Join-Path $TestDrive 'bin'
+            $run = Invoke-InstallerChild -Body "try { & ([scriptblock]::Create((Get-Content -Raw '$(Get-InstallerPath)'))) -InstallDir '$installDir' } catch { 'CAUGHT:' + `$_.Exception.Message }; 'ALIVE'; exit 7"
+            Assert-ThrowsWithoutExiting -Run $run
+        }
+
+        It 'prints one Error: line and exits 1 when run from a file' {
+            $installDir = Join-Path $TestDrive 'bin'
+            $run = Invoke-InstallerChild -Body "& '$(Get-InstallerPath)' -InstallDir '$installDir'; exit `$LASTEXITCODE"
+            Assert-DirectInstallBranch -Run $run
+            Assert-NoExceptionFormatting -Output $run.Output
+            if ($env:OS -eq 'Windows_NT') {
+                $run.Output | Should -Contain 'Error: entire-test: network blocked'
+            }
+            $run.ExitCode | Should -Be 1
+        }
+
+        # The -File process is spawned from inside the scrubbed child so it
+        # inherits the cut-down PATH, but it is a fresh process, so the
+        # Invoke-RestMethod stub cannot reach it. A drive that does not exist
+        # fails in Get-NormalizedPath, which runs before the registry read and
+        # the first network call on every OS, so this case asserts the provider
+        # message instead of the sentinel.
+        It 'exits the process with 1 when run with -File' {
+            $shell = (Get-Process -Id $PID).Path
+            $run = Invoke-InstallerChild -Body "& '$shell' -NoProfile -NonInteractive -File '$(Get-InstallerPath)' -InstallDir 'entiretestnodrive:\bin'; exit `$LASTEXITCODE"
+            Assert-DirectInstallBranch -Run $run
+            Assert-NoExceptionFormatting -Output $run.Output
+            @($run.Output | Where-Object { $_ -like 'Error: *Cannot find drive*entiretestnodrive*' }) | Should -HaveCount 1
+            $run.ExitCode | Should -Be 1
+        }
+    }
+}

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -559,6 +559,33 @@ Describe 'Scoop or archive selection' {
         Should -Invoke Get-ReleaseVersion -Times 1 -Exactly
     }
 
+    It 'reports a copy that is only on the stored PATH after a Scoop install' {
+        function scoop {}
+        Set-Variable -Name Channel -Value 'stable'
+        Set-Variable -Name InstallDirExplicit -Value $false
+        $shim = Join-Path (Join-Path $TestDrive 'scoop') 'shims\entire.exe'
+        $otherDir = Join-Path $TestDrive 'elsewhere'
+        [IO.Directory]::CreateDirectory($otherDir) | Out-Null
+        Set-Content -LiteralPath (Join-Path $otherDir 'entire.exe') -Value 'x' -NoNewline
+        Mock Invoke-Scoop { @{ ExitCode = 0; Output = @((Join-Path (Join-Path (Join-Path $TestDrive 'scoop') 'apps\entire') 'current')) } } -ParameterFilter { $ScoopArgs[0] -eq 'prefix' }
+        Mock Get-EntireOnPath { @([pscustomobject]@{ Source = $shim }) }
+        Mock Get-UserEnvironmentValue { $otherDir }
+        $report = @(Install-Entire 6>&1 | ForEach-Object { "$_" })
+        $report | Should -Contain "! Also found: $(Join-Path $otherDir 'entire.exe')"
+    }
+
+    It 'reports nothing extra when the stored PATH holds no other copy' {
+        function scoop {}
+        Set-Variable -Name Channel -Value 'stable'
+        Set-Variable -Name InstallDirExplicit -Value $false
+        $shim = Join-Path (Join-Path $TestDrive 'scoop') 'shims\entire.exe'
+        Mock Invoke-Scoop { @{ ExitCode = 0; Output = @((Join-Path (Join-Path (Join-Path $TestDrive 'scoop') 'apps\entire') 'current')) } } -ParameterFilter { $ScoopArgs[0] -eq 'prefix' }
+        Mock Get-EntireOnPath { @([pscustomobject]@{ Source = $shim }) }
+        Mock Get-UserEnvironmentValue { Join-Path $TestDrive 'nothing-here' }
+        $report = @(Install-Entire 6>&1 | ForEach-Object { "$_" })
+        @($report | Where-Object { $_ -like '! Also found:*' }) | Should -HaveCount 0
+    }
+
     It 'uses Scoop on stable when -InstallDir was not given' {
         function scoop {}
         # Set-Variable, not assignment: these are read by Install-Entire through

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -531,3 +531,43 @@ Describe 'Web timeouts' {
         }
     }
 }
+
+Describe 'Scoop or archive selection' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+    }
+
+    BeforeEach {
+        Mock Assert-Prerequisite {}
+        Mock Write-Info {}
+        Mock Install-EntireWithScoop {}
+        Mock Get-PlatformArchitecture { 'amd64' }
+        # The archive branch's first step after the directory is resolved; stop there.
+        Mock Get-ReleaseVersion { throw 'stop-here' }
+    }
+
+    It 'takes the archive path when -InstallDir is explicit even with Scoop on PATH' {
+        function scoop {}
+        # Set-Variable, not assignment: these are read by Install-Entire through
+        # the scope chain, which the linter's unused-variable rule cannot see.
+        Set-Variable -Name Channel -Value 'stable'
+        Set-Variable -Name InstallDir -Value (Join-Path $TestDrive 'chosen')
+        Set-Variable -Name InstallDirExplicit -Value $true
+        { Install-Entire } | Should -Throw -ExpectedMessage '*stop-here*'
+        Should -Invoke Install-EntireWithScoop -Times 0 -Exactly
+        Should -Invoke Get-ReleaseVersion -Times 1 -Exactly
+    }
+
+    It 'uses Scoop on stable when -InstallDir was not given' {
+        function scoop {}
+        # Set-Variable, not assignment: these are read by Install-Entire through
+        # the scope chain, which the linter's unused-variable rule cannot see.
+        Set-Variable -Name Channel -Value 'stable'
+        Set-Variable -Name InstallDirExplicit -Value $false
+        # Stop inside the Scoop branch; what follows it shells out to scoop.
+        Mock Install-EntireWithScoop { throw 'scoop-branch' }
+        { Install-Entire } | Should -Throw -ExpectedMessage '*scoop-branch*'
+        Should -Invoke Install-EntireWithScoop -Times 1 -Exactly
+        Should -Invoke Get-ReleaseVersion -Times 0 -Exactly
+    }
+}

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -642,3 +642,35 @@ Describe 'Denied writes' {
         }
     }
 }
+
+Describe 'Get-EntireCopy' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+    }
+
+    It 'adds copies that are only on the stored user PATH and lists shared ones once' {
+        $processDir = Join-Path $TestDrive 'proc'
+        $storedDir = Join-Path $TestDrive 'stored'
+        foreach ($dir in $processDir, $storedDir) {
+            [IO.Directory]::CreateDirectory($dir) | Out-Null
+            Set-Content -LiteralPath (Join-Path $dir 'entire.exe') -Value 'x' -NoNewline
+        }
+        Mock Get-EntireOnPath { @([pscustomobject]@{ Source = (Join-Path $processDir 'entire.exe') }) }
+        Mock Get-UserEnvironmentValue { "$storedDir;$processDir" }
+
+        $sources = @(Get-EntireCopy | ForEach-Object { $_.Source })
+        $sources[0] | Should -Be (Join-Path $processDir 'entire.exe')
+        $sources | Should -Contain (Join-Path $storedDir 'entire.exe')
+        @($sources | Where-Object { $_ -eq (Join-Path $processDir 'entire.exe') }) | Should -HaveCount 1
+    }
+
+    It 'ignores stored PATH directories without an entire.exe' {
+        $processDir = Join-Path $TestDrive 'proc2'
+        [IO.Directory]::CreateDirectory($processDir) | Out-Null
+        Set-Content -LiteralPath (Join-Path $processDir 'entire.exe') -Value 'x' -NoNewline
+        Mock Get-EntireOnPath { @([pscustomobject]@{ Source = (Join-Path $processDir 'entire.exe') }) }
+        Mock Get-UserEnvironmentValue { (Join-Path $TestDrive 'empty') + ';;' }
+
+        @(Get-EntireCopy | Where-Object { $_.Source -like "*$TestDrive*" }) | Should -HaveCount 1
+    }
+}

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -77,6 +77,7 @@ Describe 'install.ps1' {
             $installer = [scriptblock]::Create((Get-Content -Raw (Get-InstallerPath)))
             $output = @(& $installer -Help 6>&1 | ForEach-Object { "$_" })
             $output[0] | Should -BeLike 'Usage: install.ps1*'
+            ($output -join "`n") | Should -BeLike '*manages its own PATH entry.*An explicit -InstallDir selects a release-archive install*'
         }
 
         It 'binds -Channel nightly through the scriptblock form' {

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -283,3 +283,131 @@ Describe 'User environment registry' -Skip:($env:OS -ne 'Windows_NT') {
         { Publish-EnvironmentChange } | Should -Not -Throw
     }
 }
+
+Describe 'Install-BinaryFile' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+
+        function Write-TestBinary {
+            param([string] $Path, [string] $Content)
+            [IO.Directory]::CreateDirectory((Split-Path -Parent $Path)) | Out-Null
+            Set-Content -LiteralPath $Path -Value $Content -NoNewline
+        }
+
+        function Get-OldFile {
+            param([string] $Directory)
+            @(Get-ChildItem -LiteralPath $Directory -Filter '*.old' -File -ErrorAction SilentlyContinue)
+        }
+    }
+
+    It 'copies into place when no binary exists yet' {
+        $dir = Join-Path $TestDrive 'fresh'
+        Write-TestBinary -Path (Join-Path $dir 'src.bin') -Content 'new'
+        Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination (Join-Path $dir 'entire.exe')
+        Get-Content -LiteralPath (Join-Path $dir 'entire.exe') -Raw | Should -Be 'new'
+        Get-OldFile -Directory $dir | Should -HaveCount 0
+    }
+
+    It 'puts the old binary back when the copy fails' {
+        $dir = Join-Path $TestDrive 'rollback'
+        $target = Join-Path $dir 'entire.exe'
+        Write-TestBinary -Path $target -Content 'old'
+        { Install-BinaryFile -Source (Join-Path $dir 'missing.bin') -Destination $target } | Should -Throw
+        Get-Content -LiteralPath $target -Raw | Should -Be 'old'
+        Get-OldFile -Directory $dir | Should -HaveCount 0
+    }
+
+    It 'removes stale .old files before writing' {
+        $dir = Join-Path $TestDrive 'sweep'
+        Write-TestBinary -Path (Join-Path $dir 'entire.exe.old') -Content 'stale'
+        Write-TestBinary -Path (Join-Path $dir 'git-remote-entire.exe.old') -Content 'stale'
+        Write-TestBinary -Path (Join-Path $dir 'src.bin') -Content 'new'
+        Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination (Join-Path $dir 'entire.exe')
+        Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination (Join-Path $dir 'git-remote-entire.exe')
+        Get-OldFile -Directory $dir | Should -HaveCount 0
+    }
+
+    It 'treats brackets in the install directory literally' {
+        $dir = Join-Path (Join-Path $TestDrive '[x]') 'bin'
+        [IO.Directory]::CreateDirectory($dir) | Out-Null
+        Write-TestBinary -Path (Join-Path $dir 'src.bin') -Content 'new'
+        Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination (Join-Path $dir 'entire.exe')
+        Test-Path -LiteralPath (Join-Path $dir 'entire.exe') -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path $TestDrive 'x') | Should -BeFalse
+    }
+
+    # Windows will not overwrite or delete a mapped executable image but will
+    # rename it; Unix allows all three, so these cases have no meaning there.
+    Context 'on Windows' -Skip:($env:OS -ne 'Windows_NT') {
+        BeforeAll {
+            function Invoke-RunningCopy {
+                param([string] $Path)
+                Copy-Item -LiteralPath $env:ComSpec -Destination $Path
+                Start-Process -FilePath $Path -ArgumentList '/c', 'timeout', '/t', '120', '/nobreak' -WindowStyle Hidden -PassThru
+            }
+
+            function Close-RunningCopy {
+                param($Process)
+                if ($null -ne $Process -and -not $Process.HasExited) {
+                    Stop-Process -Id $Process.Id -Force
+                    $Process.WaitForExit()
+                }
+            }
+        }
+
+        It 'replaces a running binary and clears the old image once it exits' {
+            $dir = Join-Path $TestDrive 'running'
+            $target = Join-Path $dir 'entire.exe'
+            [IO.Directory]::CreateDirectory($dir) | Out-Null
+            Write-TestBinary -Path (Join-Path $dir 'src.bin') -Content 'new'
+            $process = Invoke-RunningCopy -Path $target
+            try {
+                { Copy-Item -LiteralPath (Join-Path $dir 'src.bin') -Destination $target -Force -ErrorAction Stop } | Should -Throw
+                Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination $target
+                Get-Content -LiteralPath $target -Raw | Should -Be 'new'
+                Test-Path -LiteralPath "$target.old" -PathType Leaf | Should -BeTrue
+            }
+            finally {
+                Close-RunningCopy -Process $process
+            }
+            Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination $target
+            Get-OldFile -Directory $dir | Should -HaveCount 0
+        }
+
+        It 'names the remedy when another program holds the binary open' {
+            $dir = Join-Path $TestDrive 'held'
+            $target = Join-Path $dir 'entire.exe'
+            Write-TestBinary -Path $target -Content 'old'
+            Write-TestBinary -Path (Join-Path $dir 'src.bin') -Content 'new'
+            $handle = [IO.File]::Open($target, [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::None)
+            try {
+                { Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination $target } | Should -Throw -ExpectedMessage '*another program holds it open*'
+            }
+            finally {
+                $handle.Dispose()
+            }
+            Get-Content -LiteralPath $target -Raw | Should -Be 'old'
+            Get-OldFile -Directory $dir | Should -HaveCount 0
+        }
+
+        It 'moves aside under a unique name when the previous .old is still running' {
+            $dir = Join-Path $TestDrive 'twice'
+            $target = Join-Path $dir 'entire.exe'
+            [IO.Directory]::CreateDirectory($dir) | Out-Null
+            Write-TestBinary -Path (Join-Path $dir 'src.bin') -Content 'new'
+            $old = Invoke-RunningCopy -Path "$target.old"
+            $current = Invoke-RunningCopy -Path $target
+            try {
+                Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination $target
+                Get-Content -LiteralPath $target -Raw | Should -Be 'new'
+                Get-OldFile -Directory $dir | Should -HaveCount 2
+            }
+            finally {
+                Close-RunningCopy -Process $current
+                Close-RunningCopy -Process $old
+            }
+            Install-BinaryFile -Source (Join-Path $dir 'src.bin') -Destination $target
+            Get-OldFile -Directory $dir | Should -HaveCount 0
+        }
+    }
+}

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -571,7 +571,9 @@ Describe 'Scoop or archive selection' {
         Mock Get-EntireOnPath { @([pscustomobject]@{ Source = $shim }) }
         Mock Get-UserEnvironmentValue { $otherDir }
         $report = @(Install-Entire 6>&1 | ForEach-Object { "$_" })
-        $report | Should -Contain "! Also found: $(Join-Path $otherDir 'entire.exe')"
+        $report | Should -Contain '! Also on your saved PATH, not active in this shell:'
+        $report | Should -Contain "!   $(Join-Path $otherDir 'entire.exe')"
+        @($report | Where-Object { $_ -like '! Also found:*' }) | Should -HaveCount 0
     }
 
     It 'reports nothing extra when the stored PATH holds no other copy' {
@@ -691,7 +693,9 @@ Describe 'Get-EntireCopy' {
         $copies = Get-EntireCopy
         @($copies) | Should -HaveCount 2
         $copies[0].Source | Should -Be (Join-Path $processDir 'entire.exe')
+        $copies[0].Active | Should -BeTrue
         $copies[1].Source | Should -Be (Join-Path $storedDir 'entire.exe')
+        $copies[1].Active | Should -BeFalse
     }
 
     It 'ignores stored PATH directories without an entire.exe' {
@@ -703,5 +707,30 @@ Describe 'Get-EntireCopy' {
 
         $copies = Get-EntireCopy
         @($copies | Where-Object { $_.Source -like "*$TestDrive*" }) | Should -HaveCount 1
+    }
+}
+
+Describe 'Get-PlatformArchitecture' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+    }
+
+    It 'maps <Native> to <Expected>' -TestCases @(
+        @{ Native = 'AMD64'; Expected = 'amd64' }
+        @{ Native = 'ARM64'; Expected = 'arm64' }
+        @{ Native = 'arm64'; Expected = 'arm64' }
+    ) {
+        Mock Get-NativeArchitectureName { $Native }
+        Get-PlatformArchitecture | Should -Be $Expected
+    }
+
+    It 'refuses an architecture it has no build for' {
+        Mock Get-NativeArchitectureName { 'x86' }
+        { Get-PlatformArchitecture } | Should -Throw -ExpectedMessage 'Unsupported architecture: x86'
+    }
+
+    It 'refuses an empty architecture value' {
+        Mock Get-NativeArchitectureName { '' }
+        { Get-PlatformArchitecture } | Should -Throw -ExpectedMessage 'Cannot determine the Windows architecture.'
     }
 }

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -173,3 +173,113 @@ Describe 'Assert-Prerequisite' {
         { Assert-Prerequisite } | Should -Not -Throw
     }
 }
+
+Describe 'PATH entry handling' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+        # An environment variable this process owns, so %ENTIRE_TEST_ROOT% is
+        # an unexpanded entry on every OS.
+        $env:ENTIRE_TEST_ROOT = $TestDrive
+    }
+
+    AfterAll {
+        Remove-Item -Path Env:ENTIRE_TEST_ROOT -ErrorAction SilentlyContinue
+    }
+
+    It 'treats an unexpanded entry as the same path as its expansion' {
+        Test-SamePath -Left '%ENTIRE_TEST_ROOT%/sub' -Right (Join-Path $TestDrive 'sub') | Should -BeTrue
+    }
+
+    It 'adds the directory when it is absent and keeps the rest verbatim' {
+        $other = Join-Path $TestDrive 'other'
+        $target = Join-Path $TestDrive 'sub'
+        Get-PathWithDirectoryFirst -PathValue "$other;" -Directory $target | Should -Be "$target;$other;"
+        Get-PathWithDirectoryFirst -PathValue "$other;;$other" -Directory $target | Should -Be "$target;$other;;$other"
+        Get-PathWithDirectoryFirst -PathValue '' -Directory $target | Should -Be $target
+    }
+
+    It 'moves an unexpanded entry to the front as stored' {
+        $other = Join-Path $TestDrive 'other'
+        $target = Join-Path $TestDrive 'sub'
+        Get-PathWithDirectoryFirst -PathValue "$other;%ENTIRE_TEST_ROOT%/sub" -Directory $target | Should -Be "%ENTIRE_TEST_ROOT%/sub;$other"
+    }
+
+    It 'moves a literal entry to the front instead of adding a second one' {
+        $other = Join-Path $TestDrive 'other'
+        $target = Join-Path $TestDrive 'sub'
+        Get-PathWithDirectoryFirst -PathValue "$other;$target" -Directory $target | Should -Be "$target;$other"
+    }
+
+    It 'recognises an unexpanded first entry' {
+        Test-PathIsFirst -PathValue ";%ENTIRE_TEST_ROOT%/sub;other" -Directory (Join-Path $TestDrive 'sub') | Should -BeTrue
+    }
+}
+
+Describe 'User environment registry' -Skip:($env:OS -ne 'Windows_NT') {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1')
+
+        # A throwaway value in the real HKCU:\Environment, named per process
+        # and removed in AfterAll. The real Path value is never touched.
+        function Get-TestValueName { "ENTIRE_INSTALL_TEST_$PID" }
+
+        function Write-RawTestValue {
+            param([string] $Value, [Microsoft.Win32.RegistryValueKind] $Kind)
+            $key = (Get-Item -LiteralPath 'HKCU:').OpenSubKey('Environment', $true)
+            $key.SetValue((Get-TestValueName), $Value, $Kind)
+        }
+
+        function Get-TestValueKind {
+            (Get-Item -LiteralPath 'HKCU:').OpenSubKey('Environment').GetValueKind((Get-TestValueName))
+        }
+    }
+
+    AfterAll {
+        $key = (Get-Item -LiteralPath 'HKCU:').OpenSubKey('Environment', $true)
+        if ($null -ne $key) {
+            $key.DeleteValue("ENTIRE_INSTALL_TEST_$PID", $false)
+        }
+    }
+
+    It 'stores a value containing % unexpanded, as REG_EXPAND_SZ' {
+        Write-UserEnvironmentValue -Name (Get-TestValueName) -Value '%USERPROFILE%\entire-test-a'
+        Get-UserEnvironmentValue -Name (Get-TestValueName) | Should -Be '%USERPROFILE%\entire-test-a'
+        Get-TestValueKind | Should -Be ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+    }
+
+    It 'keeps REG_SZ for a value without %' {
+        Write-RawTestValue -Value 'C:\plain' -Kind ([Microsoft.Win32.RegistryValueKind]::String)
+        Write-UserEnvironmentValue -Name (Get-TestValueName) -Value 'C:\plain;C:\more'
+        Get-TestValueKind | Should -Be ([Microsoft.Win32.RegistryValueKind]::String)
+    }
+
+    It 'keeps REG_EXPAND_SZ when the new value has no %' {
+        Write-RawTestValue -Value '%USERPROFILE%\x' -Kind ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+        Write-UserEnvironmentValue -Name (Get-TestValueName) -Value 'C:\plain'
+        Get-TestValueKind | Should -Be ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+    }
+
+    It 'leaves an unexpanded first entry alone' {
+        Write-RawTestValue -Value '%USERPROFILE%\entire-test-leaf;C:\other' -Kind ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+        Add-UserPathEntry -Name (Get-TestValueName) -Directory (Join-Path $env:USERPROFILE 'entire-test-leaf') | Should -BeFalse
+        Get-UserEnvironmentValue -Name (Get-TestValueName) | Should -Be '%USERPROFILE%\entire-test-leaf;C:\other'
+    }
+
+    It 'moves an unexpanded entry to the front without expanding it' {
+        Write-RawTestValue -Value 'C:\other;%USERPROFILE%\entire-test-leaf' -Kind ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+        Add-UserPathEntry -Name (Get-TestValueName) -Directory (Join-Path $env:USERPROFILE 'entire-test-leaf') | Should -BeTrue
+        Get-UserEnvironmentValue -Name (Get-TestValueName) | Should -Be '%USERPROFILE%\entire-test-leaf;C:\other'
+        Get-TestValueKind | Should -Be ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+    }
+
+    It 'moves a literal entry to the front' {
+        $leaf = Join-Path $env:USERPROFILE 'entire-test-leaf'
+        Write-RawTestValue -Value "C:\other;$leaf" -Kind ([Microsoft.Win32.RegistryValueKind]::String)
+        Add-UserPathEntry -Name (Get-TestValueName) -Directory $leaf | Should -BeTrue
+        Get-UserEnvironmentValue -Name (Get-TestValueName) | Should -Be "$leaf;C:\other"
+    }
+
+    It 'broadcasts the change without throwing' {
+        { Publish-EnvironmentChange } | Should -Not -Throw
+    }
+}

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -70,6 +70,14 @@ Describe 'install.ps1' {
             $output = @(& $installer -Channel nightly -Help 6>&1 | ForEach-Object { "$_" })
             $output[0] | Should -BeLike 'Usage: install.ps1*'
         }
+
+        It 'loads functions without installing when dot-sourced' {
+            $run = Invoke-InstallerChild -Body ". '$(Get-InstallerPath)'; 'INSTALL-ENTIRE:' + [bool](Get-Command Install-Entire -CommandType Function -ErrorAction SilentlyContinue); 'ALIVE'; exit 7"
+            $run.Output | Should -Contain 'INSTALL-ENTIRE:True'
+            $run.Output | Should -Not -Contain '==> Installing Entire CLI...'
+            $run.Output | Should -Contain 'ALIVE'
+            $run.ExitCode | Should -Be 7
+        }
     }
 
     Context 'error path' {

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -658,10 +658,13 @@ Describe 'Get-EntireCopy' {
         Mock Get-EntireOnPath { @([pscustomobject]@{ Source = (Join-Path $processDir 'entire.exe') }) }
         Mock Get-UserEnvironmentValue { "$storedDir;$processDir" }
 
-        $sources = @(Get-EntireCopy | ForEach-Object { $_.Source })
-        $sources[0] | Should -Be (Join-Path $processDir 'entire.exe')
-        $sources | Should -Contain (Join-Path $storedDir 'entire.exe')
-        @($sources | Where-Object { $_ -eq (Join-Path $processDir 'entire.exe') }) | Should -HaveCount 1
+        # Assigned, then indexed: piping the -NoEnumerate result straight into
+        # ForEach-Object would member-enumerate .Source over the whole array on
+        # pwsh and hide a wrong element count.
+        $copies = Get-EntireCopy
+        @($copies) | Should -HaveCount 2
+        $copies[0].Source | Should -Be (Join-Path $processDir 'entire.exe')
+        $copies[1].Source | Should -Be (Join-Path $storedDir 'entire.exe')
     }
 
     It 'ignores stored PATH directories without an entire.exe' {
@@ -671,6 +674,7 @@ Describe 'Get-EntireCopy' {
         Mock Get-EntireOnPath { @([pscustomobject]@{ Source = (Join-Path $processDir 'entire.exe') }) }
         Mock Get-UserEnvironmentValue { (Join-Path $TestDrive 'empty') + ';;' }
 
-        @(Get-EntireCopy | Where-Object { $_.Source -like "*$TestDrive*" }) | Should -HaveCount 1
+        $copies = Get-EntireCopy
+        @($copies | Where-Object { $_.Source -like "*$TestDrive*" }) | Should -HaveCount 1
     }
 }

--- a/scripts/test/Installer.Tests.ps1
+++ b/scripts/test/Installer.Tests.ps1
@@ -1,3 +1,8 @@
+# One case runs the installer through the documented `iex "& {...}"` shape,
+# which is the point of that case.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '', Justification = 'Pins the documented iex one-liner shape')]
+param()
+
 Describe 'install.ps1' {
     BeforeAll {
         function Get-InstallerPath {
@@ -83,6 +88,14 @@ Describe 'install.ps1' {
         It 'binds -Channel nightly through the scriptblock form' {
             $installer = [scriptblock]::Create((Get-Content -Raw (Get-InstallerPath)))
             $output = @(& $installer -Channel nightly -Help 6>&1 | ForEach-Object { "$_" })
+            $output[0] | Should -BeLike 'Usage: install.ps1*'
+        }
+
+        # The README's nightly one-liner, with the download replaced by a file
+        # read: the fetched text is wrapped in braces and called with arguments.
+        It 'binds arguments through the documented iex "& {...}" form' {
+            $path = Get-InstallerPath
+            $output = @(Invoke-Expression "& {$(Get-Content -Raw $path)} -Channel nightly -Help" 6>&1 | ForEach-Object { "$_" })
             $output[0] | Should -BeLike 'Usage: install.ps1*'
         }
 

--- a/scripts/test/Linter.Tests.ps1
+++ b/scripts/test/Linter.Tests.ps1
@@ -1,0 +1,26 @@
+Describe 'PSScriptAnalyzer' -Tag 'Linter' {
+    It 'has a settings file' {
+        Join-Path (Split-Path -Parent $PSScriptRoot) 'PSScriptAnalyzerSettings.psd1' | Should -Exist
+    }
+
+    # A green suite with zero findings looks the same whether the analyzer
+    # evaluated every rule or none, so prove it reports a rule the settings file
+    # does not exclude. The bad script lives in $TestDrive, outside scripts/, so
+    # the recursive scan below never sees it.
+    It 'reports a known-bad script under the same settings' {
+        $settings = Join-Path (Split-Path -Parent $PSScriptRoot) 'PSScriptAnalyzerSettings.psd1'
+        $bad = Join-Path $TestDrive 'empty-catch.ps1'
+        Set-Content -Path $bad -Value "try { Get-Item . } catch { }"
+        $analysis = @(Invoke-ScriptAnalyzer -Path $bad -Settings $settings)
+        $analysis.RuleName | Should -Contain 'PSAvoidUsingEmptyCatchBlock'
+    }
+
+    It 'reports no findings under scripts/' {
+        $scriptsDir = Split-Path -Parent $PSScriptRoot
+        $analysis = @(Invoke-ScriptAnalyzer -Path $scriptsDir -Recurse -Settings (Join-Path $scriptsDir 'PSScriptAnalyzerSettings.psd1'))
+        foreach ($result in $analysis) {
+            Write-Warning ("{0} {1} {2}:{3} {4}" -f $result.Severity, $result.RuleName, $result.ScriptName, $result.Line, $result.Message)
+        }
+        $analysis | Should -HaveCount 0
+    }
+}

--- a/scripts/test/Runner.Tests.ps1
+++ b/scripts/test/Runner.Tests.ps1
@@ -1,0 +1,36 @@
+Describe 'run.ps1' {
+    BeforeAll {
+        function Invoke-Runner {
+            param([string] $Directory)
+            $shell = (Get-Process -Id $PID).Path
+            $output = @(& $shell -NoProfile -NonInteractive -File (Join-Path $PSScriptRoot 'run.ps1') -Path $Directory 2>&1 | ForEach-Object { "$_" })
+            [pscustomobject]@{ Output = $output; ExitCode = $LASTEXITCODE }
+        }
+    }
+
+    It 'exits 0 for a passing container' {
+        $dir = Join-Path $TestDrive 'passing'
+        [IO.Directory]::CreateDirectory($dir) | Out-Null
+        Set-Content -LiteralPath (Join-Path $dir 'Ok.Tests.ps1') -Value 'Describe "ok" { It "passes" { 1 | Should -Be 1 } }'
+        (Invoke-Runner -Directory $dir).ExitCode | Should -Be 0
+    }
+
+    # A file that fails to parse produces no failed tests, only a failed
+    # container, so an exit code taken from FailedCount would be 0.
+    It 'exits non-zero when a test file fails to load' {
+        $dir = Join-Path $TestDrive 'broken'
+        [IO.Directory]::CreateDirectory($dir) | Out-Null
+        Set-Content -LiteralPath (Join-Path $dir 'Ok.Tests.ps1') -Value 'Describe "ok" { It "passes" { 1 | Should -Be 1 } }'
+        Set-Content -LiteralPath (Join-Path $dir 'Broken.Tests.ps1') -Value "Describe 'broken' {`n    It 'never runs' { 1 | Should -Be 1 }"
+        $run = Invoke-Runner -Directory $dir
+        $run.ExitCode | Should -Not -Be 0
+        ($run.Output -join "`n") | Should -BeLike '*Failed*'
+    }
+
+    It 'exits non-zero when a BeforeAll throws' {
+        $dir = Join-Path $TestDrive 'beforeall'
+        [IO.Directory]::CreateDirectory($dir) | Out-Null
+        Set-Content -LiteralPath (Join-Path $dir 'Setup.Tests.ps1') -Value 'Describe "setup" { BeforeAll { throw "no" }; It "never runs" { 1 | Should -Be 1 } }'
+        (Invoke-Runner -Directory $dir).ExitCode | Should -Not -Be 0
+    }
+}

--- a/scripts/test/e2e.ps1
+++ b/scripts/test/e2e.ps1
@@ -72,6 +72,11 @@ function Get-ExpectedKind {
 function Invoke-Installer {
     param([string[]] $Arguments)
     $installer = [scriptblock]::Create((Get-Content -Raw -LiteralPath $installerPath))
+    # Splatting an absent [string[]] passes one empty string, which binds
+    # positionally to -Channel and fails its ValidateSet.
+    if ($null -eq $Arguments -or $Arguments.Count -eq 0) {
+        $Arguments = @()
+    }
     # Write-Host is the information stream; merge it so the report can be asserted.
     & $installer @Arguments 6>&1 | ForEach-Object { "$_" }
 }

--- a/scripts/test/e2e.ps1
+++ b/scripts/test/e2e.ps1
@@ -1,0 +1,188 @@
+#Requires -Version 5.1
+
+# Runs scripts/install.ps1 for real against GitHub Releases and checks what it
+# leaves behind. It rewrites the user PATH and installs binaries under the
+# profile, so it refuses to run anywhere but GitHub Actions; the raw user PATH
+# and its value kind are restored at the end regardless.
+#
+# Phases, each asserting before the next:
+#   1. stable install through the documented `irm | iex` shape
+#   2. reinstall while entire.exe is running, then again after it exits
+#   3. nightly install into a second directory, alongside the first
+
+# Phase 1 runs the installer through the documented `irm | iex` shape, which
+# is the point of that phase.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '', Justification = 'Phase 1 exercises the documented irm | iex shape')]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+if ($env:CI -ne 'true' -or $env:GITHUB_ACTIONS -ne 'true') {
+    throw 'scripts/test/e2e.ps1 installs into the user profile and rewrites the user PATH; it runs only in GitHub Actions CI.'
+}
+
+$installerPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'install.ps1'
+# Dot-sourcing loads the functions without installing.
+. $installerPath
+
+function Assert-Equal {
+    param([string] $Phase, [string] $What, $Expected, $Actual)
+    if (-not [object]::Equals($Expected, $Actual)) {
+        throw "[$Phase] $What`n  expected: $Expected`n  actual:   $Actual"
+    }
+}
+
+function Assert-True {
+    param([string] $Phase, [string] $What, [bool] $Condition)
+    if (-not $Condition) {
+        throw "[$Phase] $What"
+    }
+}
+
+function Get-PathEntry {
+    param([AllowNull()] [string] $Value)
+    if ([string]::IsNullOrEmpty($Value)) {
+        return @()
+    }
+    return @($Value -split ';')
+}
+
+function Get-UserPathKind {
+    $key = (Get-Item -LiteralPath 'HKCU:').OpenSubKey('Environment')
+    if ($null -eq $key -or $null -eq $key.GetValue('Path', $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)) {
+        return $null
+    }
+    return $key.GetValueKind('Path')
+}
+
+# The kind Write-UserEnvironmentValue promises: ExpandString when the value
+# contains %, otherwise whatever the value had before, String if it did not
+# exist.
+function Get-ExpectedKind {
+    param([string] $NewValue, $PreviousKind)
+    if ($NewValue.Contains('%')) {
+        return [Microsoft.Win32.RegistryValueKind]::ExpandString
+    }
+    if ($null -ne $PreviousKind) {
+        return $PreviousKind
+    }
+    return [Microsoft.Win32.RegistryValueKind]::String
+}
+
+function Invoke-Installer {
+    param([string[]] $Arguments)
+    $installer = [scriptblock]::Create((Get-Content -Raw -LiteralPath $installerPath))
+    # Write-Host is the information stream; merge it so the report can be asserted.
+    & $installer @Arguments 6>&1 | ForEach-Object { "$_" }
+}
+
+function Get-EntireVersion {
+    param([string] $Phase, [string] $Directory)
+    $output = & (Join-Path $Directory 'entire.exe') version 2>&1 | Out-String
+    Assert-Equal -Phase $Phase -What 'entire.exe version exit code' -Expected 0 -Actual $LASTEXITCODE
+    return $output.Trim()
+}
+
+$snapshot = Get-UserEnvironmentValue -Name 'Path'
+$snapshotKind = Get-UserPathKind
+$snapshotEntries = Get-PathEntry $snapshot
+$stableDir = Join-Path $env:USERPROFILE '.local\bin'
+$nightlyDir = Join-Path $env:USERPROFILE 'entire-nightly'
+$running = $null
+
+try {
+    # ---- Phase 1: stable through irm | iex --------------------------------
+    $phase = 'phase 1: stable via iex'
+    Write-Host "==> $phase"
+    Get-Content -Raw -LiteralPath $installerPath | Invoke-Expression
+
+    Assert-True -Phase $phase -What 'entire.exe installed' -Condition (Test-Path -LiteralPath (Join-Path $stableDir 'entire.exe') -PathType Leaf)
+    Assert-True -Phase $phase -What 'git-remote-entire.exe installed' -Condition (Test-Path -LiteralPath (Join-Path $stableDir 'git-remote-entire.exe') -PathType Leaf)
+
+    $afterStable = Get-UserEnvironmentValue -Name 'Path'
+    $entries = Get-PathEntry $afterStable
+    Assert-Equal -Phase $phase -What 'first raw PATH entry' -Expected $stableDir -Actual $entries[0]
+    Assert-Equal -Phase $phase -What 'remaining raw PATH entries' -Expected ($snapshotEntries -join ';') -Actual (($entries | Select-Object -Skip 1) -join ';')
+    Assert-Equal -Phase $phase -What 'raw PATH value kind' -Expected (Get-ExpectedKind -NewValue $afterStable -PreviousKind $snapshotKind) -Actual (Get-UserPathKind)
+    Assert-Equal -Phase $phase -What 'first in-process $env:Path entry' -Expected $stableDir -Actual ((Get-PathEntry $env:Path)[0])
+    $stableVersion = Get-EntireVersion -Phase $phase -Directory $stableDir
+    Write-Host "    stable: $stableVersion"
+
+    # ---- Phase 2: reinstall while entire.exe is running -------------------
+    $phase = 'phase 2: reinstall while running'
+    Write-Host "==> $phase"
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = Join-Path $stableDir 'entire.exe'
+    $startInfo.Arguments = 'mcp'
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.RedirectStandardOutput = $true
+    # stdin is never written to or closed, so the MCP server waits on it.
+    $running = [System.Diagnostics.Process]::Start($startInfo)
+    Start-Sleep -Seconds 2
+    Assert-True -Phase $phase -What 'entire mcp is still running' -Condition (-not $running.HasExited)
+
+    # A mapped executable image refuses to be opened for writing. Prove that
+    # without writing anything: if the open succeeds, the file is untouched
+    # and the precondition, not a later phase, is what fails.
+    $opened = $false
+    try {
+        $handle = [IO.File]::Open((Join-Path $stableDir 'entire.exe'), [IO.FileMode]::Open, [IO.FileAccess]::Write)
+        $handle.Dispose()
+        $opened = $true
+    }
+    catch {
+        $opened = $false
+    }
+    Assert-True -Phase $phase -What 'running entire.exe refuses a write handle (precondition)' -Condition (-not $opened)
+
+    Invoke-Installer | Out-Null
+    Assert-True -Phase $phase -What 'entire.exe.old left behind while the old image runs' -Condition (Test-Path -LiteralPath (Join-Path $stableDir 'entire.exe.old') -PathType Leaf)
+    Get-EntireVersion -Phase $phase -Directory $stableDir | Out-Null
+    Assert-Equal -Phase $phase -What 'raw PATH after reinstall' -Expected $afterStable -Actual (Get-UserEnvironmentValue -Name 'Path')
+
+    $running.Kill()
+    $running.WaitForExit()
+    $running = $null
+    Invoke-Installer | Out-Null
+    $stale = @(Get-ChildItem -LiteralPath $stableDir -Filter 'entire.exe*.old' -File)
+    Assert-Equal -Phase $phase -What 'stale .old files after the old image exited' -Expected 0 -Actual $stale.Count
+    Assert-Equal -Phase $phase -What 'raw PATH after the third install' -Expected $afterStable -Actual (Get-UserEnvironmentValue -Name 'Path')
+
+    # ---- Phase 3: nightly into a second directory -------------------------
+    $phase = 'phase 3: nightly to a custom dir'
+    Write-Host "==> $phase"
+    $report = Invoke-Installer -Arguments @('-Channel', 'nightly', '-InstallDir', $nightlyDir) | Out-String
+
+    Assert-True -Phase $phase -What 'conflict warning printed' -Condition ($report -match '! WARNING: PATH conflict detected')
+    Assert-True -Phase $phase -What 'stable install named as the other copy' -Condition ($report.Contains("! Also found:   $(Join-Path $stableDir 'entire.exe')"))
+    Assert-True -Phase $phase -What 'nightly install reported as taking priority' -Condition ($report -match 'The installed version takes priority')
+
+    $afterNightly = Get-UserEnvironmentValue -Name 'Path'
+    $entries = Get-PathEntry $afterNightly
+    Assert-Equal -Phase $phase -What 'first raw PATH entry' -Expected $nightlyDir -Actual $entries[0]
+    Assert-Equal -Phase $phase -What 'second raw PATH entry (stable, moved down, not removed)' -Expected $stableDir -Actual $entries[1]
+    Assert-Equal -Phase $phase -What 'remaining raw PATH entries' -Expected ($snapshotEntries -join ';') -Actual (($entries | Select-Object -Skip 2) -join ';')
+    Assert-Equal -Phase $phase -What 'raw PATH value kind' -Expected (Get-ExpectedKind -NewValue $afterNightly -PreviousKind $snapshotKind) -Actual (Get-UserPathKind)
+    $nightlyVersion = Get-EntireVersion -Phase $phase -Directory $nightlyDir
+    Write-Host "    nightly: $nightlyVersion"
+    Assert-True -Phase $phase -What 'nightly binary reports a nightly version' -Condition ($nightlyVersion -match 'nightly')
+    Assert-True -Phase $phase -What 'nightly and stable versions differ' -Condition ($nightlyVersion -ne $stableVersion)
+
+    Write-Host '==> all phases passed'
+}
+finally {
+    if ($null -ne $running -and -not $running.HasExited) {
+        $running.Kill()
+        $running.WaitForExit()
+    }
+    # The runner is ephemeral; restoring anyway records that this script
+    # knows it mutated shared state.
+    $key = (Get-Item -LiteralPath 'HKCU:').CreateSubKey('Environment')
+    if ($null -eq $snapshot) {
+        $key.DeleteValue('Path', $false)
+    }
+    else {
+        $key.SetValue('Path', $snapshot, $snapshotKind)
+    }
+}

--- a/scripts/test/e2e.ps1
+++ b/scripts/test/e2e.ps1
@@ -70,13 +70,9 @@ function Get-ExpectedKind {
 }
 
 function Invoke-Installer {
-    param([string[]] $Arguments)
+    # A hashtable splat binds by name; an array splat would bind positionally.
+    param([hashtable] $Arguments = @{})
     $installer = [scriptblock]::Create((Get-Content -Raw -LiteralPath $installerPath))
-    # Splatting an absent [string[]] passes one empty string, which binds
-    # positionally to -Channel and fails its ValidateSet.
-    if ($null -eq $Arguments -or $Arguments.Count -eq 0) {
-        $Arguments = @()
-    }
     # Write-Host is the information stream; merge it so the report can be asserted.
     & $installer @Arguments 6>&1 | ForEach-Object { "$_" }
 }
@@ -157,7 +153,7 @@ try {
     # ---- Phase 3: nightly into a second directory -------------------------
     $phase = 'phase 3: nightly to a custom dir'
     Write-Host "==> $phase"
-    $report = Invoke-Installer -Arguments @('-Channel', 'nightly', '-InstallDir', $nightlyDir) | Out-String
+    $report = Invoke-Installer -Arguments @{ Channel = 'nightly'; InstallDir = $nightlyDir } | Out-String
 
     Assert-True -Phase $phase -What 'conflict warning printed' -Condition ($report -match '! WARNING: PATH conflict detected')
     Assert-True -Phase $phase -What 'stable install named as the other copy' -Condition ($report.Contains("! Also found:   $(Join-Path $stableDir 'entire.exe')"))

--- a/scripts/test/e2e.ps1
+++ b/scripts/test/e2e.ps1
@@ -69,6 +69,22 @@ function Get-ExpectedKind {
     return [Microsoft.Win32.RegistryValueKind]::String
 }
 
+# The machine PATH as stored, for the phase that plants a copy on it.
+function Get-MachinePathKey {
+    (Get-Item -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager').OpenSubKey('Environment', $true)
+}
+
+function Get-MachinePath {
+    (Get-MachinePathKey).GetValue('Path', $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+}
+
+# Runs $Body in a child of the same shell, so each CI leg tests its own host.
+function Invoke-ChildShell {
+    param([string] $Body)
+    $shell = (Get-Process -Id $PID).Path
+    @(& $shell -NoProfile -NonInteractive -Command $Body 2>&1 | ForEach-Object { "$_" })
+}
+
 function Invoke-Installer {
     # A hashtable splat binds by name; an array splat would bind positionally.
     param([hashtable] $Arguments = @{})
@@ -87,6 +103,12 @@ function Get-EntireVersion {
 $snapshot = Get-UserEnvironmentValue -Name 'Path'
 $snapshotKind = Get-UserPathKind
 $snapshotEntries = Get-PathEntry $snapshot
+# This process's PATH before any install: what a terminal opened before the
+# first install would inherit.
+$processPathBefore = $env:Path
+$machineSnapshot = Get-MachinePath
+$machineSnapshotKind = (Get-MachinePathKey).GetValueKind('Path')
+$stubDir = Join-Path $env:TEMP 'entire-machine-stub'
 $stableDir = Join-Path $env:USERPROFILE '.local\bin'
 $nightlyDir = Join-Path $env:USERPROFILE 'entire-nightly'
 $running = $null
@@ -150,15 +172,27 @@ try {
     Assert-Equal -Phase $phase -What 'stale .old files after the old image exited' -Expected 0 -Actual $stale.Count
     Assert-Equal -Phase $phase -What 'raw PATH after the third install' -Expected $afterStable -Actual (Get-UserEnvironmentValue -Name 'Path')
 
-    # ---- Phase 3: nightly into a second directory -------------------------
-    $phase = 'phase 3: nightly to a custom dir'
+    # ---- Phase 3: nightly into a second directory, from a stale shell ------
+    # The installer tells the user to restart the terminal between installs.
+    # A terminal opened before phase 1 wrote the registry has a PATH without
+    # the stable directory, so this install runs in a child given exactly that
+    # PATH; the stable copy must then be reported from the stored PATH alone.
+    $phase = 'phase 3: nightly to a custom dir from a stale shell'
     Write-Host "==> $phase"
-    $report = Invoke-Installer -Arguments @{ Channel = 'nightly'; InstallDir = $nightlyDir } | Out-String
+    $childBody = @(
+        "`$env:Path = '$processPathBefore'"
+        "if (@(`$env:Path -split ';' | Where-Object { `$_ -eq '$stableDir' }).Count -eq 0) { 'PRECONDITION: stable dir absent from this shell' }"
+        "& ([scriptblock]::Create((Get-Content -Raw -LiteralPath '$installerPath'))) -Channel nightly -InstallDir '$nightlyDir' 6>&1 | ForEach-Object { `"`$_`" }"
+    ) -join '; '
+    $reportLines = Invoke-ChildShell -Body $childBody
+    $report = $reportLines -join "`n"
     # The assertions below judge this text; show it so a failure is diagnosable from the log.
     Write-Host $report
 
+    Assert-True -Phase $phase -What 'child shell PATH lacked the stable dir (precondition)' -Condition ($reportLines -contains 'PRECONDITION: stable dir absent from this shell')
     Assert-True -Phase $phase -What 'conflict warning printed' -Condition ($report -match '! WARNING: PATH conflict detected')
-    Assert-True -Phase $phase -What 'stable install named as the other copy' -Condition ($report.Contains("! Also found:   $(Join-Path $stableDir 'entire.exe')"))
+    Assert-True -Phase $phase -What 'stored-PATH group printed' -Condition ($reportLines -contains '! Also on your saved PATH, not active in this shell:')
+    Assert-True -Phase $phase -What 'stable install named under the stored-PATH group' -Condition ($reportLines -contains "!   $(Join-Path $stableDir 'entire.exe')")
     Assert-True -Phase $phase -What 'nightly install reported as taking priority' -Condition ($report -match 'The installed version takes priority')
 
     $afterNightly = Get-UserEnvironmentValue -Name 'Path'
@@ -172,6 +206,28 @@ try {
     Assert-True -Phase $phase -What 'nightly binary reports a nightly version' -Condition ($nightlyVersion -match 'nightly')
     Assert-True -Phase $phase -What 'nightly and stable versions differ' -Condition ($nightlyVersion -ne $stableVersion)
 
+    # ---- Phase 4: a copy on the machine-wide PATH ---------------------------
+    # Windows composes a new session as machine PATH then user PATH, so a copy
+    # in a machine-PATH directory outranks anything the installer writes; the
+    # report has a paragraph for that. The runner is elevated, so plant one.
+    $phase = 'phase 4: copy on the machine PATH'
+    Write-Host "==> $phase"
+    [IO.Directory]::CreateDirectory($stubDir) | Out-Null
+    Copy-Item -LiteralPath $env:ComSpec -Destination (Join-Path $stubDir 'entire.exe')
+    (Get-MachinePathKey).SetValue('Path', "$machineSnapshot;$stubDir", $machineSnapshotKind)
+    $report = Invoke-Installer | Out-String
+    Write-Host $report
+
+    Assert-True -Phase $phase -What 'machine-PATH paragraph printed' -Condition ($report -match 'is on the machine-wide PATH')
+    Assert-True -Phase $phase -What 'machine-PATH copy named' -Condition ($report.Contains("$(Join-Path $stubDir 'entire.exe') is on the machine-wide PATH"))
+    Assert-True -Phase $phase -What 'install-over remedy names the machine-PATH directory' -Condition ($report.Contains("!   -InstallDir $stubDir"))
+    # Reinstalling stable puts its directory first again; the nightly entry
+    # moves down by one and nothing else changes.
+    $entries = Get-PathEntry (Get-UserEnvironmentValue -Name 'Path')
+    Assert-Equal -Phase $phase -What 'first raw PATH entry' -Expected $stableDir -Actual $entries[0]
+    Assert-Equal -Phase $phase -What 'second raw PATH entry' -Expected $nightlyDir -Actual $entries[1]
+    Assert-Equal -Phase $phase -What 'remaining raw PATH entries' -Expected ($snapshotEntries -join ';') -Actual (($entries | Select-Object -Skip 2) -join ';')
+
     Write-Host '==> all phases passed'
 }
 finally {
@@ -181,6 +237,10 @@ finally {
     }
     # The runner is ephemeral; restoring anyway records that this script
     # knows it mutated shared state.
+    if ($null -ne $machineSnapshot) {
+        (Get-MachinePathKey).SetValue('Path', $machineSnapshot, $machineSnapshotKind)
+    }
+    Remove-Item -LiteralPath $stubDir -Recurse -Force -ErrorAction SilentlyContinue
     $key = (Get-Item -LiteralPath 'HKCU:').CreateSubKey('Environment')
     if ($null -eq $snapshot) {
         $key.DeleteValue('Path', $false)

--- a/scripts/test/e2e.ps1
+++ b/scripts/test/e2e.ps1
@@ -154,6 +154,8 @@ try {
     $phase = 'phase 3: nightly to a custom dir'
     Write-Host "==> $phase"
     $report = Invoke-Installer -Arguments @{ Channel = 'nightly'; InstallDir = $nightlyDir } | Out-String
+    # The assertions below judge this text; show it so a failure is diagnosable from the log.
+    Write-Host $report
 
     Assert-True -Phase $phase -What 'conflict warning printed' -Condition ($report -match '! WARNING: PATH conflict detected')
     Assert-True -Phase $phase -What 'stable install named as the other copy' -Condition ($report.Contains("! Also found:   $(Join-Path $stableDir 'entire.exe')"))

--- a/scripts/test/init.ps1
+++ b/scripts/test/init.ps1
@@ -1,0 +1,47 @@
+#Requires -Version 5.1
+
+# Installs what scripts/test/run.ps1 needs, for the current user, once on a
+# fresh machine. Safe to rerun: each step is skipped when already satisfied.
+#
+# Stock Windows PowerShell 5.1 ships PowerShellGet 1.0.0.1 without the NuGet
+# package provider, and its bootstrap is an interactive prompt that -Force
+# does not suppress, so a non-interactive Install-Module fails there until
+# the provider is installed. pwsh ships a modern PowerShellGet and skips that
+# step. GitHub's Windows runners preinstall both modules, so CI never runs this.
+$ErrorActionPreference = 'Stop'
+
+Write-Output "PowerShell $($PSVersionTable.PSVersion) ($($PSVersionTable.PSEdition))"
+
+if ($PSVersionTable.PSEdition -eq 'Desktop') {
+    $nuget = Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue |
+        Where-Object { $_.Version -ge [version]'2.8.5.201' } | Select-Object -First 1
+    if ($null -ne $nuget) {
+        Write-Output "NuGet provider $($nuget.Version) is already installed."
+    }
+    else {
+        Write-Output 'Installing the NuGet package provider...'
+        Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Scope CurrentUser -Force | Out-Null
+    }
+}
+
+# Pester 5.2 is the floor run.ps1 imports; 6.x is also known to work, so
+# there is no ceiling.
+$pester = Get-Module -Name Pester -ListAvailable | Where-Object { $_.Version -ge [version]'5.2.0' } | Select-Object -First 1
+if ($null -ne $pester) {
+    Write-Output "Pester $($pester.Version) is already installed."
+}
+else {
+    Write-Output 'Installing Pester...'
+    Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name Pester -MinimumVersion 5.2.0 -SkipPublisherCheck
+}
+
+$analyzer = Get-Module -Name PSScriptAnalyzer -ListAvailable | Where-Object { $_.Version -ge [version]'1.17.1' } | Select-Object -First 1
+if ($null -ne $analyzer) {
+    Write-Output "PSScriptAnalyzer $($analyzer.Version) is already installed."
+}
+else {
+    Write-Output 'Installing PSScriptAnalyzer...'
+    Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name PSScriptAnalyzer -MinimumVersion 1.17.1 -SkipPublisherCheck
+}
+
+Write-Output 'Ready: run scripts/test/run.ps1 or `mise run test:ps1`.'

--- a/scripts/test/run.ps1
+++ b/scripts/test/run.ps1
@@ -11,13 +11,21 @@
 # `exit` code come back as 0, so a failing suite would pass CI. Import-Module
 # also selects the highest satisfying version, which matters on Windows where
 # the OS-bundled Pester 3.4.0 sits next to the modern one.
+#
+# The exit code keys on the run's overall Result, not on FailedCount: a test
+# file that fails to parse, or a BeforeAll that throws, leaves FailedCount at
+# 0 (the tests never existed to fail) while Result is Failed.
+#
+# -Path exists so a test can run this against a directory of its own.
+param([string] $Path = $PSScriptRoot)
+
 $ErrorActionPreference = 'Stop'
 Import-Module Pester -MinimumVersion 5.2.0
 Import-Module PSScriptAnalyzer -MinimumVersion 1.17.1
 
 $pesterConfig = New-PesterConfiguration -Hashtable @{
     Run    = @{
-        Path     = $PSScriptRoot
+        Path     = $Path
         PassThru = $true
     }
     Output = @{
@@ -26,4 +34,7 @@ $pesterConfig = New-PesterConfiguration -Hashtable @{
 }
 
 $result = Invoke-Pester -Configuration $pesterConfig
-exit $result.FailedCount
+if ($result.Result -ne 'Passed') {
+    exit 1
+}
+exit 0

--- a/scripts/test/run.ps1
+++ b/scripts/test/run.ps1
@@ -2,7 +2,9 @@
 
 # Runs the PowerShell test suite under scripts/test. CI (both Windows
 # PowerShell 5.1 and pwsh) and `mise run test:ps1` call this, so Pester
-# configuration lives here once.
+# configuration lives here once. On a fresh machine run scripts/test/init.ps1
+# first; it installs Pester, PSScriptAnalyzer and, on Windows PowerShell 5.1,
+# the NuGet provider they need.
 #
 # The module floors are enforced with Import-Module rather than `#Requires
 # -Modules`: under `pwsh -File`, a `#Requires -Modules` line makes the script's

--- a/scripts/test/run.ps1
+++ b/scripts/test/run.ps1
@@ -1,0 +1,27 @@
+#Requires -Version 5.1
+
+# Runs the PowerShell test suite under scripts/test. CI (both Windows
+# PowerShell 5.1 and pwsh) and `mise run test:ps1` call this, so Pester
+# configuration lives here once.
+#
+# The module floors are enforced with Import-Module rather than `#Requires
+# -Modules`: under `pwsh -File`, a `#Requires -Modules` line makes the script's
+# `exit` code come back as 0, so a failing suite would pass CI. Import-Module
+# also selects the highest satisfying version, which matters on Windows where
+# the OS-bundled Pester 3.4.0 sits next to the modern one.
+$ErrorActionPreference = 'Stop'
+Import-Module Pester -MinimumVersion 5.2.0
+Import-Module PSScriptAnalyzer -MinimumVersion 1.17.1
+
+$pesterConfig = New-PesterConfiguration -Hashtable @{
+    Run    = @{
+        Path     = $PSScriptRoot
+        PassThru = $true
+    }
+    Output = @{
+        Verbosity = 'Detailed'
+    }
+}
+
+$result = Invoke-Pester -Configuration $pesterConfig
+exit $result.FailedCount


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1164
<!-- entire-trail-link-end -->

## Summary

- add a Windows installer compatible with Windows PowerShell 5.1 and PowerShell 7
- resolve stable/nightly GitHub releases, verify SHA-256 checksums, and install `entire.exe` plus `git-remote-entire.exe`
- prefer Scoop for stable installs when available, including bucket setup and install-versus-update behavior
- document the PowerShell install commands and point Git Bash/MSYS users to the native installer
- exercise installer parsing under both `powershell` and `pwsh` in the Windows CI job

## Verification

- `mise run lint` — passes with 0 issues after formatting and immediately before push
- Azure Windows VM, Windows PowerShell 5.1.26100.33158:
  - stable and nightly verified-download installs
  - checksum verification and both binaries validated
  - Scoop first-install and repeat-update delegation validated with an isolated shim
- Azure Windows VM, portable PowerShell 7.6.5:
  - help path and stable verified-download install
  - `entire.exe` execution and `git-remote-entire.exe` presence
  - Scoop first-install and repeat-update delegation
- Azure test runtimes, binaries, fake Scoop state, and PATH changes were removed after verification

## Known local test failures

`mise run check` completed formatting and lint successfully, but its race-enabled Go test phase hit existing/unrelated failures on this macOS checkout:

- versioncheck tests classify their mocked unknown `/usr/local` executable path as Homebrew on this machine
- `TestCodexAppServerHooksList_BareWorktreeUsesLayoutRoot` compares `/var/...` with the canonical `/private/var/...` path
- parallel external-agent discovery failures from the full run passed when rerun in isolation, as did `TestAttach_DiscoversExternalAgents`

This change does not modify Go production or test code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to install scripts, docs, and CI smoke checks; no CLI runtime or auth logic is modified.
> 
> **Overview**
> Adds **`scripts/install.ps1`**, a Windows-native installer for PowerShell 5.1 and 7, with **stable** and **nightly** channels. Stable installs **delegate to Scoop** when it is on PATH (bucket add, install vs update); otherwise the script downloads the release zip, **verifies SHA-256** against `checksums.txt`, and installs **`entire.exe`** and **`git-remote-entire.exe`** under `%USERPROFILE%\.local\bin`, optionally updating the user **PATH** and surfacing PATH conflicts like `install.sh`.
> 
> **README** now leads with the `irm … | iex` flow, documents Scoop vs direct install behavior, and lists `install.ps1` in release channels. **`install.sh`**’s MSYS/Git Bash error text points users at the PowerShell installer instead of Scoop-only wording.
> 
> **CI** runs `.\scripts\install.ps1 -Help` under both **`powershell`** (5.x) and **`pwsh`** (7+) in the Windows job before existing Go tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8453cc9e35a89ba8ed7d2da959f7b1cfad741818. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->