### PR TITLE
Refuse to run when `.entire` is not a real directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,19 @@ mean "write through it anyway": `checkEntireDirBeforeRun` returns
 `ensureLogger` from creating `.entire/logs` through the symlink. `newLogger`
 repeats the check for the callers that build a logger outside the pre-run.
 
+The pre-run is not the only enforcement point. `LoadEntireSettings` repeats the
+check, because the pre-run does not cover everything: external plugins are
+dispatched from `main.go` before cobra runs at all, and exempt commands still
+reach settings through the post-run telemetry path. Settings are read *from* the
+directory in question, so loading them is the one operation those callers have
+in common — the duplicated `Lstat` on the ordinary path buys the guarantee that
+the check happens at least once on the unusual ones.
+
+Outside a git repository there is no worktree root and so nothing to validate,
+and the check is skipped rather than failing. Commands that need a repository
+report its absence themselves, with a message about the repository rather than
+about `.entire`.
+
 Every exemption needs an entry in `entireDirCheckExemptions`
 (`entiredir_guard_test.go`) giving the reason; `TestEntireDirCheckExemptions`
 fails both on an unlisted exemption and on a stale entry, so an exemption added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,56 @@ return fmt.Errorf("unknown strategy: %s", name)
 - `root.go` - Sets `SilenceErrors: true` on root command
 - `main.go` - Checks for `SilentError` before printing
 
+### `.entire` Must Be a Directory
+
+`<worktree-root>/.entire` is either absent or a real directory. A regular file, a
+symlink — **including a symlink pointing at a perfectly good directory** — a
+FIFO, a socket, or a device is a broken repo, and a command that would read or
+write through the path stops instead.
+
+`paths.ValidateEntireDirAt(worktreeRoot)` / `paths.RequireEntireDir(ctx)`
+(`paths/entiredir.go`) are the only implementation. The stat is `Lstat`, not
+`Stat`, which is the whole point: `.entire` holds session metadata, transcripts,
+and the redaction settings that decide what may be committed, so a path someone
+else owns the far end of is not one we write through. Absent is fine (Entire is
+not enabled yet, or `enable` is about to create it). A stat error other than
+"not exist" is a failure — it is not evidence the invariant is violated, but it
+is not evidence it holds either, and the caller's next move is to write there.
+Not memoized, deliberately: the `Lstat` is free next to the `git rev-parse` that
+precedes it, and a cached "it was fine" is stale in a long-lived `entire mcp`.
+
+**Guarded is the default.** The root `PersistentPreRunE` runs the check for every
+command, above both `settings.IsSetUpAny` and `ensureLogger` because each of
+those already touches the path. A command opts out with
+`exemptFromEntireDirCheck(cmd)` (`entiredir_guard.go`), which sets an annotation
+that `skipsEntireDirCheck` inherits down the parent chain, so annotating a group
+root covers its children. Exemption is registered at the `AddCommand` call in
+`root.go`, so the whole set reads as one list.
+
+Exempt means "this command needs nothing under `.entire`" — control-plane and
+account commands, `version`/`labs`/`completion`, and `doctor`. It does **not**
+mean "write through it anyway": `checkEntireDirBeforeRun` returns
+`safe == false` for an exempt command in a broken repo, which is what keeps
+`ensureLogger` from creating `.entire/logs` through the symlink. `newLogger`
+repeats the check for the callers that build a logger outside the pre-run.
+
+Every exemption needs an entry in `entireDirCheckExemptions`
+(`entiredir_guard_test.go`) giving the reason; `TestEntireDirCheckExemptions`
+fails both on an unlisted exemption and on a stale entry, so an exemption added
+to silence a failing test does not pass for a considered one. `help` and
+`agent-help` are deliberately guarded — someone asking what they can do in this
+repo is told the repo is broken rather than handed a working command list.
+`entire <command> --help` is unaffected in every case, because cobra returns
+`flag.ErrHelp` before it runs any `PersistentPreRunE`; that and `doctor` are the
+escape hatches.
+
+`doctor` is exempt so that it can run **on** a broken repo, which is only worth
+doing if it says what is wrong: `reportBrokenEntireDir` runs in the doctor
+group's `PersistentPreRunE` — ahead of doctor's own `PreRunE`, which loads
+redaction settings from `.entire/settings.json`, and ahead of `doctor logs` /
+`doctor bundle`, which read `.entire/logs` — prints the diagnosis, and stops. It
+does not auto-fix: what occupies the path may be someone's data.
+
 ### Settings
 
 All settings access should go through the `settings` package (`cmd/entire/cli/settings/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,23 @@ and the check is skipped rather than failing. Commands that need a repository
 report its absence themselves, with a message about the repository rather than
 about `.entire`.
 
+**That skip requires git's positive verdict, not merely a failed lookup.**
+`WorktreeRoot` classifies its own failure and wraps `paths.ErrNotARepository`
+only when git ran, exited non-zero, and said "not a git repository"; exit code
+128 alone is not the signal, since git also uses it for dubious ownership and
+permission failures, both of which happen *inside* a repository. Locale
+variables are pinned to C for that subprocess so the message is recognisable on
+a translated machine. Every other outcome — git missing from `PATH`, a cancelled
+context, a killed child, success with empty output — fails closed.
+
+The reason is that "we could not find out" is not the same as "there is nothing
+here", and guessing costs more than a skipped check: `settingsAbsPaths` falls
+back to a path relative to the *current directory* when the root will not
+resolve, so a wrong guess reads `./.entire/settings.json` — through the very
+symlink the guard exists to reject. Refusing to run on a machine whose git is
+broken is the cheaper mistake. Do not "simplify" `RequireEntireDir` back to
+treating any `WorktreeRoot` error as absence.
+
 Every exemption needs an entry in `entireDirCheckExemptions`
 (`entiredir_guard_test.go`) giving the reason; `TestEntireDirCheckExemptions`
 fails both on an unlisted exemption and on a stale entry, so an exemption added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,6 +457,21 @@ is not evidence it holds either, and the caller's next move is to write there.
 Not memoized, deliberately: the `Lstat` is free next to the `git rev-parse` that
 precedes it, and a cached "it was fine" is stale in a long-lived `entire mcp`.
 
+**Three failure conditions, each identified positively.** `ErrEntireDirNotDirectory`
+(the path exists and is the wrong type), `ErrEntireDirUnreadable` (`Lstat`
+itself failed, so nothing is known about the path), and
+`ErrRepositoryUnresolved` (the worktree root would not resolve, so there is no
+path to inspect yet). Callers print a remedy, and the three remedies are
+different things: replace the path, fix ownership/permissions, fix git. Match
+them with `errors.Is` and give an unmatched error **no** remedy — an `else`
+branch is how a filesystem `EACCES` came to be answered with advice about
+`safe.directory`, printed directly under a line that already said "permission
+denied". `writeEntireDirRemedy` and `writeEntireDirDiagnosis` (doctor's
+labelled variant: BROKEN / UNREADABLE / UNVERIFIED) both take the error as a
+parameter so every branch is reachable in a test; staging a genuinely
+unreadable `.entire` is impractical, since removing execute permission on the
+repo root breaks worktree-root discovery first and exercises the wrong branch.
+
 **Guarded is the default.** The root `PersistentPreRunE` runs the check for every
 command, above both `settings.IsSetUpAny` and `ensureLogger` because each of
 those already touches the path. A command opts out with

--- a/cmd/entire/cli/config.go
+++ b/cmd/entire/cli/config.go
@@ -37,7 +37,22 @@ type EntireSettings = settings.EntireSettings
 // then applies any overrides from .entire/settings.local.json if it exists.
 // Returns default settings if neither file exists.
 // Works correctly from any subdirectory within the repository.
+//
+// Fails when `.entire` is not a real directory. The root pre-run already made
+// that check for anything that reaches a command's RunE, so for those callers
+// this is a second Lstat — but the pre-run does not cover everything. External
+// plugins are dispatched from main.go before cobra runs at all, and commands
+// exempt from the pre-run still reach settings through the post-run telemetry
+// path. Settings are read FROM the directory in question, which makes this the
+// one operation those callers have in common and so the place to guarantee the
+// check happens at least once.
+//
+// Outside a repository there is nothing to validate and the check is skipped,
+// so settings still resolve to defaults there.
 func LoadEntireSettings(ctx context.Context) (*settings.EntireSettings, error) {
+	if err := paths.RequireEntireDir(ctx); err != nil {
+		return nil, fmt.Errorf("refusing to load settings: %w", err)
+	}
 	s, err := settings.Load(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("loading settings: %w", err)

--- a/cmd/entire/cli/config.go
+++ b/cmd/entire/cli/config.go
@@ -125,6 +125,14 @@ func newLogger(ctx context.Context) (*logging.Logger, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve worktree root: %w", err)
 	}
+	// The log sink lives under .entire, so it is a write through that path like
+	// any other. The root pre-run has already refused a guarded command by the
+	// time we get here; this covers the callers that build a logger outside it
+	// (`enable`, the hook handlers) and the exempt commands, which run but must
+	// not create .entire/logs through a symlink someone else controls.
+	if err := paths.ValidateEntireDirAt(root); err != nil {
+		return nil, fmt.Errorf("refusing to open log sink: %w", err)
+	}
 	l, err := logging.New(logging.Config{
 		Dir:   filepath.Join(root, logging.LogsDir),
 		Level: resolveLogLevel(ctx),

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -69,6 +69,13 @@ be condensed will be discarded.
 
 Without a terminal to prompt on (agents, CI), doctor reports each issue and
 points at --force instead of prompting.`,
+		// On the group, not on doctor's own PreRunE, so it also covers
+		// `doctor logs` and `doctor bundle`, which read .entire/logs. Runs
+		// before the PreRunE below, which loads redaction settings from
+		// .entire/settings.json — itself a read through the path in question.
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			return reportBrokenEntireDir(cmd)
+		},
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			// Cobra runs the persistent pre-runs before a command's own PreRunE,
 			// so the root hook has already put an initialized logger in this

--- a/cmd/entire/cli/entiredir_guard.go
+++ b/cmd/entire/cli/entiredir_guard.go
@@ -76,34 +76,50 @@ func checkEntireDirBeforeRun(cmd *cobra.Command) (safe bool, err error) {
 // writeEntireDirRemedy prints what is wrong and what to do about it. The error
 // alone names the problem but not the way out, and the way out is not obvious:
 // the natural guess is that Entire is misconfigured, when in fact something has
-// replaced a directory Entire owns, or git cannot say which repository this is.
+// replaced a directory Entire owns, or the path cannot be inspected, or git
+// cannot say which repository this is.
 //
-// Those two are separate remedies, and printing the wrong one is worse than
-// printing none. A discovery failure has established nothing about `.entire`,
-// so telling the user to go replace it sends them after a file that may be
-// perfectly fine.
+// Those are three separate remedies, matched positively. Printing the wrong one
+// is worse than printing none — a filesystem EACCES sent through the git branch
+// tells the user to check safe.directory right after a line that already said
+// "permission denied" — so an error matching none of them gets no remedy at all.
 func writeEntireDirRemedy(w io.Writer, err error) {
 	fmt.Fprintf(w, "%v\n", err)
 	fmt.Fprintf(w, "\n")
 
-	if !errors.Is(err, paths.ErrEntireDirNotDirectory) {
-		fmt.Fprintf(w, "Entire cannot tell which repository this directory belongs to, so it cannot\n")
-		fmt.Fprintf(w, "verify that %s is a directory it owns, and will not read or write through\n", paths.EntireDir)
-		fmt.Fprintf(w, "it on the strength of a guess.\n")
+	switch {
+	case errors.Is(err, paths.ErrEntireDirNotDirectory):
+		fmt.Fprintf(w, "Entire keeps session metadata, transcripts, and the redaction settings that\n")
+		fmt.Fprintf(w, "decide what may be committed under %s, and will not read or write through a\n", paths.EntireDir)
+		fmt.Fprintf(w, "path that is not a real directory it owns.\n")
+		fmt.Fprintf(w, "\n")
+		fmt.Fprintf(w, "Fix: inspect the path, then either replace it with a real directory or remove\n")
+		fmt.Fprintf(w, "it and run `entire enable` again.\n")
+
+	case errors.Is(err, paths.ErrEntireDirUnreadable):
+		fmt.Fprintf(w, "Nothing is known about what is at that path — the check itself failed, so\n")
+		fmt.Fprintf(w, "Entire will not read or write through it.\n")
+		fmt.Fprintf(w, "\n")
+		fmt.Fprintf(w, "Fix: this is a filesystem error, not a git or Entire one. Check ownership and\n")
+		fmt.Fprintf(w, "permissions on %s and the directory holding it, and whether the mount it\n", paths.EntireDir)
+		fmt.Fprintf(w, "lives on is healthy.\n")
+
+	case errors.Is(err, paths.ErrRepositoryUnresolved):
+		fmt.Fprintf(w, "Entire cannot verify that %s is a directory it owns without knowing which\n", paths.EntireDir)
+		fmt.Fprintf(w, "repository this is, and will not read or write through it on a guess.\n")
 		fmt.Fprintf(w, "\n")
 		fmt.Fprintf(w, "Fix: resolve the git error above. Common causes are git missing from PATH\n")
 		fmt.Fprintf(w, "and git's ownership check on a mounted or shared repository, which names\n")
 		fmt.Fprintf(w, "the `git config --global --add safe.directory` line to add.\n")
-		return
+
+	default:
+		// No remedy: an unclassified error gives no grounds to name one, and a
+		// confidently wrong fix costs the user more than silence.
+		fmt.Fprintf(w, "Entire could not verify %s, so it will not read or write through it.\n", paths.EntireDir)
 	}
 
-	fmt.Fprintf(w, "Entire keeps session metadata, transcripts, and the redaction settings that\n")
-	fmt.Fprintf(w, "decide what may be committed under %s, and will not read or write through a\n", paths.EntireDir)
-	fmt.Fprintf(w, "path that is not a real directory it owns.\n")
 	fmt.Fprintf(w, "\n")
-	fmt.Fprintf(w, "Fix: inspect the path, then either replace it with a real directory or remove\n")
-	fmt.Fprintf(w, "it and run `entire enable` again. `entire doctor` still works here, and\n")
-	fmt.Fprintf(w, "`entire <command> --help` is unaffected.\n")
+	fmt.Fprintf(w, "`entire doctor` still works here, and `entire <command> --help` is unaffected.\n")
 }
 
 // reportBrokenEntireDir is doctor's half of the guard. doctor is exempt from the
@@ -122,27 +138,52 @@ func reportBrokenEntireDir(cmd *cobra.Command) error {
 	if err == nil {
 		return nil
 	}
+	writeEntireDirDiagnosis(cmd.OutOrStdout(), err)
+	return NewSilentError(err)
+}
 
-	w := cmd.OutOrStdout()
+// writeEntireDirDiagnosis is doctor's rendering of the same three conditions
+// writeEntireDirRemedy covers. It is separate because doctor's report has its
+// own shape (a labelled heading and indented detail, matching the other
+// checks), and it takes the error as a parameter so each branch is reachable in
+// a test without staging the filesystem condition that produces it.
+//
+// The heading distinguishes the conditions too: calling `.entire` BROKEN when
+// the only thing established is that git would not answer states something we
+// do not know.
+func writeEntireDirDiagnosis(w io.Writer, err error) {
+	switch {
+	case errors.Is(err, paths.ErrEntireDirNotDirectory):
+		fmt.Fprintf(w, "%s: BROKEN\n", paths.EntireDir)
+		fmt.Fprintf(w, "  %v\n", err)
+		fmt.Fprintf(w, "  Entire has refused to read or write through it, so every other command\n")
+		fmt.Fprintf(w, "  in this repository is stopped and no session data is being captured.\n")
+		fmt.Fprintf(w, "  Fix: inspect the path, then either replace it with a real directory or\n")
+		fmt.Fprintf(w, "  remove it and run `entire enable` again.\n")
+		fmt.Fprintf(w, "  Not auto-fixed: what is there may be someone's data, and deleting it is\n")
+		fmt.Fprintf(w, "  not a call doctor should make on your behalf.\n")
 
-	if !errors.Is(err, paths.ErrEntireDirNotDirectory) {
+	case errors.Is(err, paths.ErrEntireDirUnreadable):
+		fmt.Fprintf(w, "%s: UNREADABLE\n", paths.EntireDir)
+		fmt.Fprintf(w, "  %v\n", err)
+		fmt.Fprintf(w, "  The check itself failed, so nothing is known about what is at that path\n")
+		fmt.Fprintf(w, "  and every other command here is stopped.\n")
+		fmt.Fprintf(w, "  Fix: this is a filesystem error, not a git or Entire one. Check ownership\n")
+		fmt.Fprintf(w, "  and permissions on the path and the directory holding it, and whether the\n")
+		fmt.Fprintf(w, "  mount it lives on is healthy.\n")
+
+	case errors.Is(err, paths.ErrRepositoryUnresolved):
 		fmt.Fprintf(w, "%s: UNVERIFIED\n", paths.EntireDir)
 		fmt.Fprintf(w, "  %v\n", err)
 		fmt.Fprintf(w, "  Entire cannot tell which repository this directory belongs to, so it\n")
 		fmt.Fprintf(w, "  cannot verify %s and every other command here is stopped.\n", paths.EntireDir)
 		fmt.Fprintf(w, "  Fix: resolve the git error above. Common causes are git missing from\n")
-		fmt.Fprintf(w, "  PATH and git's ownership check on a mounted or shared repository.\n")
-		return NewSilentError(err)
+		fmt.Fprintf(w, "  PATH and git's ownership check on a mounted or shared repository, which\n")
+		fmt.Fprintf(w, "  names the `git config --global --add safe.directory` line to add.\n")
+
+	default:
+		fmt.Fprintf(w, "%s: UNVERIFIED\n", paths.EntireDir)
+		fmt.Fprintf(w, "  %v\n", err)
+		fmt.Fprintf(w, "  Entire could not verify %s, so every other command here is stopped.\n", paths.EntireDir)
 	}
-
-	fmt.Fprintf(w, "%s: BROKEN\n", paths.EntireDir)
-	fmt.Fprintf(w, "  %v\n", err)
-	fmt.Fprintf(w, "  Entire has refused to read or write through it, so every other command\n")
-	fmt.Fprintf(w, "  in this repository is stopped and no session data is being captured.\n")
-	fmt.Fprintf(w, "  Fix: inspect the path, then either replace it with a real directory or\n")
-	fmt.Fprintf(w, "  remove it and run `entire enable` again.\n")
-	fmt.Fprintf(w, "  Not auto-fixed: what is there may be someone's data, and deleting it is\n")
-	fmt.Fprintf(w, "  not a call doctor should make on your behalf.\n")
-
-	return NewSilentError(err)
 }

--- a/cmd/entire/cli/entiredir_guard.go
+++ b/cmd/entire/cli/entiredir_guard.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+
+	"github.com/spf13/cobra"
+)
+
+// skipEntireDirCheckAnnotation exempts a command from the `.entire` directory
+// check. Guarded is the default, so a new command inherits the check without
+// its author thinking about it, and the cost of forgetting the annotation is a
+// false failure in a repo that is already broken rather than a write through a
+// path someone else controls.
+//
+// Set it on a group root to cover the whole group: cobra does not propagate
+// Annotations to children, so skipsEntireDirCheck walks the parent chain.
+//
+// Exempt the command only when it neither reads nor writes anything under
+// `.entire` — control-plane and account commands, and `doctor`, which has to be
+// able to run on a broken repo in order to report it. Every exemption needs an
+// entry in the allowlist in entiredir_guard_test.go.
+const (
+	skipEntireDirCheckAnnotation = "entire_skip_entire_dir_check"
+	skipEntireDirCheckEnabled    = "true"
+)
+
+// skipsEntireDirCheck reports whether cmd or any ancestor is exempt.
+func skipsEntireDirCheck(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Annotations[skipEntireDirCheckAnnotation] == skipEntireDirCheckEnabled {
+			return true
+		}
+	}
+	return false
+}
+
+// exemptFromEntireDirCheck marks cmd (and everything under it) exempt,
+// preserving any annotations it already carries.
+func exemptFromEntireDirCheck(cmd *cobra.Command) *cobra.Command {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[skipEntireDirCheckAnnotation] = skipEntireDirCheckEnabled
+	return cmd
+}
+
+// checkEntireDirBeforeRun enforces the invariant that `.entire` is either
+// absent or a real directory. It reports whether the caller may go on to touch
+// the path, and returns the error a guarded command should fail with.
+//
+// Both return values matter, and they are not redundant. An exempt command gets
+// (false, nil): it runs, but it must not build a logger or otherwise write
+// under `.entire` — `ensureLogger` opens `.entire/logs/entire.log`, which on a
+// symlinked `.entire` would create the very file we are refusing to write.
+// Exemption means "this command's work does not depend on `.entire`", not
+// "write through it anyway".
+//
+// The exempt path stays silent rather than warning. An exempt command has
+// nothing to do with the repo's session data, and `doctor` reports the problem
+// properly.
+func checkEntireDirBeforeRun(cmd *cobra.Command) (safe bool, err error) {
+	if verr := paths.RequireEntireDir(cmd.Context()); verr != nil {
+		if skipsEntireDirCheck(cmd) {
+			return false, nil
+		}
+		writeEntireDirRemedy(cmd.ErrOrStderr(), verr)
+		return false, NewSilentError(verr)
+	}
+	return true, nil
+}
+
+// writeEntireDirRemedy prints what is wrong and what to do about it. The
+// sentinel error alone names the path but not the way out, and the way out is
+// not obvious: the natural guess is that Entire is misconfigured, when in fact
+// something has replaced a directory Entire owns.
+func writeEntireDirRemedy(w io.Writer, err error) {
+	fmt.Fprintf(w, "%v\n", err)
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "Entire keeps session metadata, transcripts, and the redaction settings that\n")
+	fmt.Fprintf(w, "decide what may be committed under %s, and will not read or write through a\n", paths.EntireDir)
+	fmt.Fprintf(w, "path that is not a real directory it owns.\n")
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "Fix: inspect the path, then either replace it with a real directory or remove\n")
+	fmt.Fprintf(w, "it and run `entire enable` again. `entire doctor` still works here, and\n")
+	fmt.Fprintf(w, "`entire <command> --help` is unaffected.\n")
+}
+
+// reportBrokenEntireDir is doctor's half of the guard. doctor is exempt from the
+// root check so that it can run on a broken repo, which is only worth doing if
+// it says what is wrong — so it diagnoses the problem on its own report channel
+// and stops.
+//
+// It stops rather than continuing with the remaining checks because those read
+// through `.entire`: doctor's PreRunE loads redaction settings from
+// `.entire/settings.json`, and `doctor logs` / `doctor bundle` read
+// `.entire/logs`. Conclusions drawn from config we cannot read are worse than
+// no conclusions, and this problem is a prerequisite for every other fix
+// anyway.
+func reportBrokenEntireDir(cmd *cobra.Command) error {
+	err := paths.RequireEntireDir(cmd.Context())
+	if err == nil {
+		return nil
+	}
+
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "%s: BROKEN\n", paths.EntireDir)
+	fmt.Fprintf(w, "  %v\n", err)
+	fmt.Fprintf(w, "  Entire has refused to read or write through it, so every other command\n")
+	fmt.Fprintf(w, "  in this repository is stopped and no session data is being captured.\n")
+	fmt.Fprintf(w, "  Fix: inspect the path, then either replace it with a real directory or\n")
+	fmt.Fprintf(w, "  remove it and run `entire enable` again.\n")
+	fmt.Fprintf(w, "  Not auto-fixed: what is there may be someone's data, and deleting it is\n")
+	fmt.Fprintf(w, "  not a call doctor should make on your behalf.\n")
+
+	return NewSilentError(err)
+}

--- a/cmd/entire/cli/entiredir_guard.go
+++ b/cmd/entire/cli/entiredir_guard.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -72,13 +73,30 @@ func checkEntireDirBeforeRun(cmd *cobra.Command) (safe bool, err error) {
 	return true, nil
 }
 
-// writeEntireDirRemedy prints what is wrong and what to do about it. The
-// sentinel error alone names the path but not the way out, and the way out is
-// not obvious: the natural guess is that Entire is misconfigured, when in fact
-// something has replaced a directory Entire owns.
+// writeEntireDirRemedy prints what is wrong and what to do about it. The error
+// alone names the problem but not the way out, and the way out is not obvious:
+// the natural guess is that Entire is misconfigured, when in fact something has
+// replaced a directory Entire owns, or git cannot say which repository this is.
+//
+// Those two are separate remedies, and printing the wrong one is worse than
+// printing none. A discovery failure has established nothing about `.entire`,
+// so telling the user to go replace it sends them after a file that may be
+// perfectly fine.
 func writeEntireDirRemedy(w io.Writer, err error) {
 	fmt.Fprintf(w, "%v\n", err)
 	fmt.Fprintf(w, "\n")
+
+	if !errors.Is(err, paths.ErrEntireDirNotDirectory) {
+		fmt.Fprintf(w, "Entire cannot tell which repository this directory belongs to, so it cannot\n")
+		fmt.Fprintf(w, "verify that %s is a directory it owns, and will not read or write through\n", paths.EntireDir)
+		fmt.Fprintf(w, "it on the strength of a guess.\n")
+		fmt.Fprintf(w, "\n")
+		fmt.Fprintf(w, "Fix: resolve the git error above. Common causes are git missing from PATH\n")
+		fmt.Fprintf(w, "and git's ownership check on a mounted or shared repository, which names\n")
+		fmt.Fprintf(w, "the `git config --global --add safe.directory` line to add.\n")
+		return
+	}
+
 	fmt.Fprintf(w, "Entire keeps session metadata, transcripts, and the redaction settings that\n")
 	fmt.Fprintf(w, "decide what may be committed under %s, and will not read or write through a\n", paths.EntireDir)
 	fmt.Fprintf(w, "path that is not a real directory it owns.\n")
@@ -106,6 +124,17 @@ func reportBrokenEntireDir(cmd *cobra.Command) error {
 	}
 
 	w := cmd.OutOrStdout()
+
+	if !errors.Is(err, paths.ErrEntireDirNotDirectory) {
+		fmt.Fprintf(w, "%s: UNVERIFIED\n", paths.EntireDir)
+		fmt.Fprintf(w, "  %v\n", err)
+		fmt.Fprintf(w, "  Entire cannot tell which repository this directory belongs to, so it\n")
+		fmt.Fprintf(w, "  cannot verify %s and every other command here is stopped.\n", paths.EntireDir)
+		fmt.Fprintf(w, "  Fix: resolve the git error above. Common causes are git missing from\n")
+		fmt.Fprintf(w, "  PATH and git's ownership check on a mounted or shared repository.\n")
+		return NewSilentError(err)
+	}
+
 	fmt.Fprintf(w, "%s: BROKEN\n", paths.EntireDir)
 	fmt.Fprintf(w, "  %v\n", err)
 	fmt.Fprintf(w, "  Entire has refused to read or write through it, so every other command\n")

--- a/cmd/entire/cli/entiredir_guard_test.go
+++ b/cmd/entire/cli/entiredir_guard_test.go
@@ -380,3 +380,68 @@ func TestLoadEntireSettings_OutsideRepositoryStillLoads(t *testing.T) {
 		t.Fatalf("LoadEntireSettings outside a repository: %v", err)
 	}
 }
+
+// withoutGit strips git from PATH so worktree-root discovery fails for a reason
+// that is not "no repository". Not parallel: PATH is process-global.
+func withoutGit(t *testing.T) {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+	t.Setenv("PATH", t.TempDir())
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+}
+
+// A discovery failure has established nothing about `.entire`. Sending the user
+// off to replace a file that may be perfectly fine is worse than saying
+// nothing, so the two failures carry different remedies.
+func TestCheckEntireDirBeforeRun_DiscoveryFailureDoesNotBlameTheDirectory(t *testing.T) {
+	withoutGit(t)
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "status"}
+	cmd.SetContext(context.Background())
+	cmd.SetErr(&stderr)
+
+	safe, err := checkEntireDirBeforeRun(cmd)
+	if err == nil {
+		t.Fatal("a guarded command ran with the worktree root unresolved")
+	}
+	if safe {
+		t.Error("checkEntireDirBeforeRun reported the path safe")
+	}
+	if errors.Is(err, paths.ErrEntireDirNotDirectory) {
+		t.Errorf("a discovery failure was reported as a wrong file type: %v", err)
+	}
+
+	msg := stderr.String()
+	if strings.Contains(msg, "replace it with a real directory") {
+		t.Errorf("remedy blames .entire for a failure that says nothing about it:\n%s", msg)
+	}
+	if !strings.Contains(msg, "safe.directory") {
+		t.Errorf("remedy does not name the common cause:\n%s", msg)
+	}
+}
+
+func TestDoctor_ReportsUnverifiedWhenDiscoveryFails(t *testing.T) {
+	withoutGit(t)
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{Use: "doctor"}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&stdout)
+
+	if err := reportBrokenEntireDir(cmd); err == nil {
+		t.Fatal("doctor did not report the unresolved worktree root")
+	}
+
+	report := stdout.String()
+	if !strings.Contains(report, "UNVERIFIED") {
+		t.Errorf("report is not labelled UNVERIFIED:\n%s", report)
+	}
+	if strings.Contains(report, "BROKEN") {
+		t.Errorf("report calls .entire broken on evidence that says nothing about it:\n%s", report)
+	}
+}

--- a/cmd/entire/cli/entiredir_guard_test.go
+++ b/cmd/entire/cli/entiredir_guard_test.go
@@ -1,0 +1,336 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+
+	"github.com/spf13/cobra"
+)
+
+// entireDirCheckExemptions is the full set of commands allowed to run when
+// `.entire` is not a real directory, and why each one is allowed. Guarded is
+// the default; a command belongs here only when it neither reads nor writes
+// anything under `.entire`.
+//
+// Keys are command paths as cobra reports them, and the annotation is
+// inherited, so a group root covers its subcommands. TestEntireDirCheckExemptions
+// fails on an exemption missing from this map and on an entry that no longer
+// matches the tree, which is what stops an exemption being added quietly to
+// make a failing test pass.
+//
+// Deliberately absent: `help` and `agent-help`. Someone asking what they can do
+// in this repo is told the repo is broken rather than handed a working command
+// list. `entire <command> --help` is unaffected either way — cobra returns
+// flag.ErrHelp before it runs any PersistentPreRunE.
+var entireDirCheckExemptions = map[string]string{
+	"entire auth":       "reads ~/.config/entire and the OS keyring, never the repo",
+	"entire login":      "control-plane login; user-level credentials only",
+	"entire logout":     "control-plane logout; user-level credentials only",
+	"entire org":        "control-plane only",
+	"entire project":    "control-plane only",
+	"entire repo":       "control-plane only; git content operations are out of scope",
+	"entire grant":      "control-plane only",
+	"entire api":        "authenticated passthrough; no local state",
+	"entire plugin":     "managed installs live under the per-user dirs",
+	"entire version":    "prints build information; no repo state",
+	"entire labs":       "prints a static list of experimental workflows",
+	"entire completion": "prints a shell script; users eval it from a shell rc, which a broken repo must not break",
+	"entire doctor":     "diagnostic; has to run ON a broken repo in order to report it",
+}
+
+// collectExemptions walks the tree and returns every command path whose own
+// annotations carry the exemption. Children are excluded because they inherit.
+func collectExemptions(root *cobra.Command) []string {
+	var found []string
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		if c.Annotations[skipEntireDirCheckAnnotation] == skipEntireDirCheckEnabled {
+			found = append(found, c.CommandPath())
+			return
+		}
+		for _, child := range c.Commands() {
+			walk(child)
+		}
+	}
+	walk(root)
+	sort.Strings(found)
+	return found
+}
+
+func TestEntireDirCheckExemptions(t *testing.T) {
+	t.Parallel()
+
+	got := collectExemptions(NewRootCmd())
+
+	want := make([]string, 0, len(entireDirCheckExemptions))
+	for path := range entireDirCheckExemptions {
+		want = append(want, path)
+	}
+	sort.Strings(want)
+
+	gotSet := make(map[string]bool, len(got))
+	for _, path := range got {
+		gotSet[path] = true
+	}
+
+	for _, path := range got {
+		if _, ok := entireDirCheckExemptions[path]; !ok {
+			t.Errorf("%q is exempt from the .entire check but is not in entireDirCheckExemptions.\n"+
+				"Exempting a command means it runs in a repo whose .entire is a file or a symlink.\n"+
+				"Add an entry saying why it needs no access to .entire, or drop the annotation.", path)
+		}
+	}
+	for _, path := range want {
+		if !gotSet[path] {
+			t.Errorf("entireDirCheckExemptions lists %q, but no such command carries the exemption annotation.\n"+
+				"Remove the stale entry, or restore the annotation if it was dropped by accident.", path)
+		}
+	}
+	for path, reason := range entireDirCheckExemptions {
+		if strings.TrimSpace(reason) == "" {
+			t.Errorf("exemption for %q has no reason", path)
+		}
+	}
+}
+
+// The annotation is set on group roots, so inheritance is what actually exempts
+// most commands. Cobra does not propagate Annotations, hence the parent walk.
+func TestSkipsEntireDirCheck_InheritedFromParent(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmd()
+
+	exempt, _, err := root.Find([]string{"doctor", "logs"})
+	if err != nil {
+		t.Fatalf("find doctor logs: %v", err)
+	}
+	if !skipsEntireDirCheck(exempt) {
+		t.Errorf("%q should inherit the exemption from `entire doctor`", exempt.CommandPath())
+	}
+
+	guarded, _, err := root.Find([]string{"session", "list"})
+	if err != nil {
+		t.Fatalf("find session list: %v", err)
+	}
+	if skipsEntireDirCheck(guarded) {
+		t.Errorf("%q must be guarded", guarded.CommandPath())
+	}
+}
+
+// exemptFromEntireDirCheck must not discard annotations a command already
+// carries — several commands are also annotated for agent-help.
+func TestExemptFromEntireDirCheck_PreservesExistingAnnotations(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{
+		Use:         "thing",
+		Annotations: map[string]string{agentHelpAnnotation: agentHelpAnnotationEnabled},
+	}
+	exemptFromEntireDirCheck(cmd)
+
+	if !skipsEntireDirCheck(cmd) {
+		t.Error("command is not exempt after exemptFromEntireDirCheck")
+	}
+	if cmd.Annotations[agentHelpAnnotation] != agentHelpAnnotationEnabled {
+		t.Error("exemptFromEntireDirCheck dropped a pre-existing annotation")
+	}
+}
+
+// symlinkEntireDir replaces the repo's `.entire` with a symlink to a directory
+// outside it, and returns the target. A symlink to a valid directory is the
+// case that a Stat-based check would wave through.
+func symlinkEntireDir(t *testing.T, repoDir string) string {
+	t.Helper()
+
+	target := filepath.Join(t.TempDir(), "elsewhere")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(repoDir, paths.EntireDir)); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	return target
+}
+
+// newRepoWithSymlinkedEntireDir builds an isolated repo whose `.entire` is a
+// symlink, points the process at it, and returns the directory the symlink
+// points at. Not parallel: t.Chdir is process-global, and the CWD is what the
+// worktree-root resolution reads.
+func newRepoWithSymlinkedEntireDir(t *testing.T) (target string) {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	target = symlinkEntireDir(t, repoDir)
+
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	return target
+}
+
+func TestCheckEntireDirBeforeRun_GuardedCommandFails(t *testing.T) {
+	newRepoWithSymlinkedEntireDir(t)
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "status"}
+	cmd.SetContext(context.Background())
+	cmd.SetErr(&stderr)
+
+	safe, err := checkEntireDirBeforeRun(cmd)
+	if err == nil {
+		t.Fatal("checkEntireDirBeforeRun returned nil error for a guarded command")
+	}
+	if safe {
+		t.Error("checkEntireDirBeforeRun reported the path safe")
+	}
+	if !errors.Is(err, paths.ErrEntireDirNotDirectory) {
+		t.Errorf("error does not wrap ErrEntireDirNotDirectory: %v", err)
+	}
+
+	// SilentError, because the remedy is printed here rather than by main.go.
+	var silent *SilentError
+	if !errors.As(err, &silent) {
+		t.Errorf("error is not a SilentError, so main.go will print it a second time: %v", err)
+	}
+
+	msg := stderr.String()
+	if !strings.Contains(msg, "symbolic link") {
+		t.Errorf("message does not say what was found:\n%s", msg)
+	}
+	if !strings.Contains(msg, "entire doctor") {
+		t.Errorf("message does not point at a command that still works:\n%s", msg)
+	}
+}
+
+func TestCheckEntireDirBeforeRun_ExemptCommandRunsSilentlyAndIsNotSafe(t *testing.T) {
+	newRepoWithSymlinkedEntireDir(t)
+
+	var stderr bytes.Buffer
+	cmd := exemptFromEntireDirCheck(&cobra.Command{Use: "version"})
+	cmd.SetContext(context.Background())
+	cmd.SetErr(&stderr)
+
+	safe, err := checkEntireDirBeforeRun(cmd)
+	if err != nil {
+		t.Fatalf("exempt command was stopped: %v", err)
+	}
+	// Not safe: the command runs, but it must not go on to build a logger under
+	// .entire, which is a write through the symlink we are refusing.
+	if safe {
+		t.Error("checkEntireDirBeforeRun reported the path safe for an exempt command")
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("exempt command emitted output; doctor owns the reporting:\n%s", stderr.String())
+	}
+}
+
+func TestCheckEntireDirBeforeRun_HealthyRepoIsSafe(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	if err := os.Mkdir(filepath.Join(repoDir, paths.EntireDir), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	cmd := &cobra.Command{Use: "status"}
+	cmd.SetContext(context.Background())
+
+	safe, err := checkEntireDirBeforeRun(cmd)
+	if err != nil {
+		t.Fatalf("checkEntireDirBeforeRun: %v", err)
+	}
+	if !safe {
+		t.Error("a real .entire directory was not reported safe")
+	}
+}
+
+// The log sink lives under .entire, so building a logger is a write through the
+// same path. Without this, an exempt command creates .entire/logs in whatever
+// directory the symlink points at.
+func TestNewLogger_RefusesSymlinkedEntireDir(t *testing.T) {
+	target := newRepoWithSymlinkedEntireDir(t)
+
+	if _, err := newLogger(context.Background()); err == nil {
+		t.Fatal("newLogger built a logger through a symlinked .entire")
+	}
+
+	entries, err := os.ReadDir(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("newLogger created %d entries in the symlink target", len(entries))
+	}
+}
+
+// doctor is exempt so that it can run on a broken repo, which is only useful if
+// it says what is wrong. The report lands in the doctor group's persistent
+// pre-run, ahead of doctor's own PreRunE (which reads redaction settings
+// through .entire) and ahead of `doctor logs`/`doctor bundle` (which read
+// .entire/logs).
+func TestDoctor_ReportsBrokenEntireDir(t *testing.T) {
+	newRepoWithSymlinkedEntireDir(t)
+
+	for _, args := range [][]string{{"doctor"}, {"doctor", "logs"}, {"doctor", "bundle"}} {
+		name := strings.Join(args, " ")
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			root := NewRootCmd()
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs(args)
+
+			err := root.ExecuteContext(context.Background())
+			if err == nil {
+				t.Fatalf("`entire %s` succeeded on a repo with a symlinked .entire", name)
+			}
+			if !errors.Is(err, paths.ErrEntireDirNotDirectory) {
+				t.Fatalf("error does not wrap ErrEntireDirNotDirectory: %v", err)
+			}
+
+			report := stdout.String() + stderr.String()
+			if !strings.Contains(report, "symbolic link") {
+				t.Errorf("report does not say what was found:\n%s", report)
+			}
+			if !strings.Contains(report, paths.EntireDir) {
+				t.Errorf("report does not name %s:\n%s", paths.EntireDir, report)
+			}
+		})
+	}
+}
+
+func TestDoctor_HealthyEntireDirIsNotReported(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	if err := os.Mkdir(filepath.Join(repoDir, paths.EntireDir), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	cmd := &cobra.Command{Use: "doctor"}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	if err := reportBrokenEntireDir(cmd); err != nil {
+		t.Fatalf("reportBrokenEntireDir on a healthy repo: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("healthy repo produced a report:\n%s", stdout.String())
+	}
+}

--- a/cmd/entire/cli/entiredir_guard_test.go
+++ b/cmd/entire/cli/entiredir_guard_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -443,5 +446,84 @@ func TestDoctor_ReportsUnverifiedWhenDiscoveryFails(t *testing.T) {
 	}
 	if strings.Contains(report, "BROKEN") {
 		t.Errorf("report calls .entire broken on evidence that says nothing about it:\n%s", report)
+	}
+}
+
+// The printed remedy is branched on which condition actually occurred. These
+// drive the writers with a synthesized error for each: staging a real
+// unreadable .entire at CLI level would need an unreadable repo root, which
+// breaks worktree-root discovery first and so tests the wrong branch.
+func TestEntireDirRemedyMatchesTheCondition(t *testing.T) {
+	t.Parallel()
+
+	wrongType := fmt.Errorf("/repo/.entire is a symbolic link, %w", paths.ErrEntireDirNotDirectory)
+	unreadable := fmt.Errorf("/repo/.entire %w: %w", paths.ErrEntireDirUnreadable, fs.ErrPermission)
+	unresolved := fmt.Errorf("%w, so .entire cannot be verified: %w",
+		paths.ErrRepositoryUnresolved, errors.New("fatal: detected dubious ownership"))
+	unknown := errors.New("something nobody classified")
+
+	tests := []struct {
+		name    string
+		err     error
+		want    []string
+		exclude []string
+	}{
+		{
+			name:    "wrong file type points at the path",
+			err:     wrongType,
+			want:    []string{"replace it with a real directory"},
+			exclude: []string{"safe.directory", "PATH", "permissions"},
+		},
+		{
+			name:    "unreadable points at the filesystem",
+			err:     unreadable,
+			want:    []string{"ownership", "permissions"},
+			exclude: []string{"safe.directory", "replace it with a real directory"},
+		},
+		{
+			name:    "unresolved repository points at git",
+			err:     unresolved,
+			want:    []string{"safe.directory"},
+			exclude: []string{"replace it with a real directory"},
+		},
+		{
+			name: "unclassified invents no remedy",
+			err:  unknown,
+			// No remedy can be right for an error nobody classified, and a
+			// wrong one costs more than none.
+			exclude: []string{"safe.directory", "replace it with a real directory", "ownership"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, write := range []struct {
+				label string
+				fn    func(io.Writer, error)
+			}{
+				{"guard", writeEntireDirRemedy},
+				{"doctor", writeEntireDirDiagnosis},
+			} {
+				var buf bytes.Buffer
+				write.fn(&buf, tt.err)
+				got := buf.String()
+
+				if !strings.Contains(got, tt.err.Error()) {
+					t.Errorf("%s: output does not restate the error:\n%s", write.label, got)
+				}
+				for _, want := range tt.want {
+					if !strings.Contains(got, want) {
+						t.Errorf("%s: output is missing %q:\n%s", write.label, want, got)
+					}
+				}
+				for _, exclude := range tt.exclude {
+					if strings.Contains(got, exclude) {
+						t.Errorf("%s: output wrongly mentions %q:\n%s", write.label, exclude, got)
+					}
+				}
+			}
+		})
 	}
 }

--- a/cmd/entire/cli/entiredir_guard_test.go
+++ b/cmd/entire/cli/entiredir_guard_test.go
@@ -334,3 +334,49 @@ func TestDoctor_HealthyEntireDirIsNotReported(t *testing.T) {
 		t.Errorf("healthy repo produced a report:\n%s", stdout.String())
 	}
 }
+
+// The root pre-run does not cover everything. External plugins are dispatched
+// before cobra ever runs, and exempt commands reach settings through the
+// post-run telemetry path. Settings are read FROM .entire, so loading them is
+// the one operation every such caller has in common — checking here means the
+// guard runs at least once even where the pre-run did not. Callers that already
+// went through the pre-run just pay a second Lstat.
+func TestLoadEntireSettings_RefusesSymlinkedEntireDir(t *testing.T) {
+	newRepoWithSymlinkedEntireDir(t)
+
+	_, err := LoadEntireSettings(context.Background())
+	if err == nil {
+		t.Fatal("LoadEntireSettings read settings through a symlinked .entire")
+	}
+	if !errors.Is(err, paths.ErrEntireDirNotDirectory) {
+		t.Errorf("error does not wrap ErrEntireDirNotDirectory: %v", err)
+	}
+}
+
+func TestLoadEntireSettings_HealthyRepoLoads(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	if err := os.Mkdir(filepath.Join(repoDir, paths.EntireDir), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	if _, err := LoadEntireSettings(context.Background()); err != nil {
+		t.Fatalf("LoadEntireSettings on a healthy repo: %v", err)
+	}
+}
+
+// Outside a repository the check is skipped, so settings still resolve to
+// defaults rather than failing with a message about `.entire`.
+func TestLoadEntireSettings_OutsideRepositoryStillLoads(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	if _, err := LoadEntireSettings(context.Background()); err != nil {
+		t.Fatalf("LoadEntireSettings outside a repository: %v", err)
+	}
+}

--- a/cmd/entire/cli/integration_test/entiredir_guard_test.go
+++ b/cmd/entire/cli/integration_test/entiredir_guard_test.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+package integration
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// `.entire` must be a real directory. These tests spawn the real binary so the
+// whole path is exercised — cobra's hook ordering, the exit code, and the fact
+// that nothing is written through the replaced path. A unit test on the
+// pre-run cannot show that the process actually stops.
+
+// replaceEntireDirWithSymlink moves the repo's `.entire` aside and symlinks it
+// back. This is the realistic shape: the directory keeps working for anything
+// that follows symlinks, so a Stat-based check sees a valid directory and a
+// test that only checked for a regular file would pass while the hole stayed
+// open. Returns the directory the symlink points at.
+func replaceEntireDirWithSymlink(t *testing.T, repoDir string) string {
+	t.Helper()
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("symlink harness only runs on Unix")
+	}
+
+	entireDir := filepath.Join(repoDir, paths.EntireDir)
+	target := filepath.Join(t.TempDir(), "entire-elsewhere")
+	if err := os.Rename(entireDir, target); err != nil {
+		t.Fatalf("move %s aside: %v", entireDir, err)
+	}
+	if err := os.Symlink(target, entireDir); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	return target
+}
+
+// runEntireInRepo runs the real binary in repoDir and returns its exit code
+// plus stdout and stderr merged, since which stream a message lands on is not
+// what these tests are about. It wraps the package's runEntire to add the exit
+// code, which is the assertion that matters here: the guard has to stop the
+// process, not merely print something.
+func runEntireInRepo(t *testing.T, repoDir string, args ...string) (exitCode int, output string) {
+	t.Helper()
+
+	stdout, stderr, err := runEntire(t, os.Environ(), repoDir, args...)
+	output = stdout + stderr
+	if err == nil {
+		return 0, output
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("run entire %v: %v\n%s", args, err, output)
+	}
+	return exitErr.ExitCode(), output
+}
+
+func TestEntireDirSymlink_GuardedCommandsStop(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	replaceEntireDirWithSymlink(t, env.RepoDir)
+
+	// One per shape that matters: a status read, a checkpoint read, the setup
+	// path that would otherwise MkdirAll through the symlink, and the surface
+	// an agent asks for its instructions on.
+	for _, args := range [][]string{
+		{"status"},
+		{"checkpoint", "list"},
+		{"session", "list"},
+		{"enable"},
+		{"agent-help"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Parallel()
+			exitCode, output := runEntireInRepo(t, env.RepoDir, args...)
+			if exitCode == 0 {
+				t.Fatalf("`entire %s` exited 0 with a symlinked .entire:\n%s",
+					strings.Join(args, " "), output)
+			}
+			if !strings.Contains(output, "symbolic link") {
+				t.Errorf("output does not say what was found:\n%s", output)
+			}
+			if !strings.Contains(output, paths.EntireDir) {
+				t.Errorf("output does not name %s:\n%s", paths.EntireDir, output)
+			}
+		})
+	}
+}
+
+func TestEntireDirSymlink_ExemptCommandsStillRun(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	replaceEntireDirWithSymlink(t, env.RepoDir)
+
+	for _, args := range [][]string{{"version"}, {"completion", "bash"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Parallel()
+			exitCode, output := runEntireInRepo(t, env.RepoDir, args...)
+			if exitCode != 0 {
+				t.Fatalf("`entire %s` exited %d; exempt commands must still run:\n%s",
+					strings.Join(args, " "), exitCode, output)
+			}
+		})
+	}
+}
+
+// --help is the escape hatch that survives regardless: cobra returns
+// flag.ErrHelp before it runs any PersistentPreRunE. It is worth pinning,
+// because guarding `help` rests on it.
+func TestEntireDirSymlink_HelpFlagStillWorks(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	replaceEntireDirWithSymlink(t, env.RepoDir)
+
+	exitCode, output := runEntireInRepo(t, env.RepoDir, "status", "--help")
+	if exitCode != 0 {
+		t.Fatalf("`entire status --help` exited %d:\n%s", exitCode, output)
+	}
+	if !strings.Contains(output, "Usage:") {
+		t.Errorf("no usage in output:\n%s", output)
+	}
+}
+
+func TestEntireDirSymlink_DoctorReportsIt(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	replaceEntireDirWithSymlink(t, env.RepoDir)
+
+	exitCode, output := runEntireInRepo(t, env.RepoDir, "doctor")
+	if exitCode == 0 {
+		t.Fatalf("`entire doctor` exited 0 on a broken repo:\n%s", output)
+	}
+	if !strings.Contains(output, "BROKEN") {
+		t.Errorf("doctor did not report the problem:\n%s", output)
+	}
+	if !strings.Contains(output, "entire enable") {
+		t.Errorf("doctor did not name the remedy:\n%s", output)
+	}
+}
+
+// Refusing to run is only half of it. Nothing may be created through the
+// replaced path either, or an exempt command's log sink lands in whatever
+// directory the symlink points at.
+func TestEntireDirSymlink_NothingIsWrittenThroughIt(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	target := replaceEntireDirWithSymlink(t, env.RepoDir)
+
+	before := dirEntryNames(t, target)
+
+	for _, args := range [][]string{{"status"}, {"version"}, {"doctor"}, {"session", "list"}} {
+		runEntireInRepo(t, env.RepoDir, args...)
+	}
+
+	after := dirEntryNames(t, target)
+	if strings.Join(before, ",") != strings.Join(after, ",") {
+		t.Errorf("symlink target changed.\nbefore: %v\nafter:  %v", before, after)
+	}
+	for _, name := range after {
+		if name == "logs" {
+			t.Error("a log sink was created through the symlinked .entire")
+		}
+	}
+}
+
+func dirEntryNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}

--- a/cmd/entire/cli/paths/entiredir.go
+++ b/cmd/entire/cli/paths/entiredir.go
@@ -1,0 +1,83 @@
+package paths
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ErrEntireDirNotDirectory reports that `.entire` exists but is not a real
+// directory. Callers match it with errors.Is to distinguish a broken repo from
+// a stat that simply failed.
+var ErrEntireDirNotDirectory = errors.New("not a directory")
+
+// ValidateEntireDirAt reports whether worktreeRoot's `.entire` is safe to read
+// and write through. It is safe when the path is absent (Entire is not enabled
+// here yet, or `enable` is about to create it) or is a real directory. Anything
+// else is a broken repo and the caller must not touch the path.
+//
+// The stat is Lstat, not Stat, so a symlink is rejected even when it points at
+// a perfectly good directory. `.entire` holds session metadata, transcripts,
+// and the settings that decide what gets redacted before it is committed, so a
+// path someone else controls the far end of is not a path we write through.
+//
+// A stat error other than "not exist" is also a failure. It is not evidence
+// that the invariant is violated, but neither is it evidence that it holds, and
+// the caller's next move is to write there.
+func ValidateEntireDirAt(worktreeRoot string) error {
+	path := filepath.Join(worktreeRoot, EntireDir)
+
+	info, err := os.Lstat(path)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("cannot determine whether %s is a directory: %w", path, err)
+	case info.Mode().IsDir():
+		return nil
+	}
+
+	return fmt.Errorf("%s is %s, %w", path, describeMode(info.Mode()), ErrEntireDirNotDirectory)
+}
+
+// RequireEntireDir validates the current worktree's `.entire`. Outside a git
+// repository there is no worktree root and so nothing to validate, which is not
+// an error: commands that need a repository report its absence themselves, with
+// a message about the repository rather than about `.entire`.
+//
+// Deliberately not memoized. The Lstat is free next to the `git rev-parse` that
+// WorktreeRoot runs, and a cached "it was fine" is a stale answer in a
+// long-lived process such as `entire mcp`.
+func RequireEntireDir(ctx context.Context) error {
+	root, err := WorktreeRoot(ctx)
+	if err != nil {
+		//nolint:nilerr // No repository means no `.entire` to validate. Reporting
+		// the rev-parse failure here would make every command outside a repo fail
+		// with a message about `.entire` instead of about the missing repository.
+		return nil
+	}
+	return ValidateEntireDirAt(root)
+}
+
+// describeMode names what was found. The sentinel supplies the "not a
+// directory" half of the sentence, so these read as the first half of "X is a
+// symbolic link, not a directory".
+func describeMode(mode fs.FileMode) string {
+	switch {
+	case mode&fs.ModeSymlink != 0:
+		return "a symbolic link"
+	case mode.IsRegular():
+		return "a regular file"
+	case mode&fs.ModeNamedPipe != 0:
+		return "a named pipe"
+	case mode&fs.ModeSocket != 0:
+		return "a socket"
+	case mode&fs.ModeDevice != 0:
+		return "a device"
+	default:
+		return "of an unsupported type"
+	}
+}

--- a/cmd/entire/cli/paths/entiredir.go
+++ b/cmd/entire/cli/paths/entiredir.go
@@ -9,10 +9,28 @@ import (
 	"path/filepath"
 )
 
-// ErrEntireDirNotDirectory reports that `.entire` exists but is not a real
-// directory. Callers match it with errors.Is to distinguish a broken repo from
-// a stat that simply failed.
-var ErrEntireDirNotDirectory = errors.New("not a directory")
+// The three ways validating `.entire` can fail. Each is identified positively
+// and carries a different remedy, which is why they are separate sentinels
+// rather than one error plus an else branch: callers print the fix, and telling
+// someone to reinstall git because their filesystem returned EACCES sends them
+// after the wrong thing. A caller matching none of these must offer no remedy
+// rather than guess at one.
+var (
+	// ErrEntireDirNotDirectory reports that `.entire` exists and is not a real
+	// directory. The remedy is to inspect and replace the path.
+	ErrEntireDirNotDirectory = errors.New("not a directory")
+
+	// ErrEntireDirUnreadable reports that `.entire` could not be inspected at
+	// all — a permission failure, an I/O error, a dead mount. Nothing is known
+	// about what is at the path. The remedy is ownership, permissions, or the
+	// filesystem itself.
+	ErrEntireDirUnreadable = errors.New("cannot be inspected")
+
+	// ErrRepositoryUnresolved reports that the worktree root could not be
+	// determined for a reason other than there being no repository, so there is
+	// no `.entire` path to inspect yet. The remedy is git.
+	ErrRepositoryUnresolved = errors.New("cannot determine which repository this directory belongs to")
+)
 
 // ValidateEntireDirAt reports whether worktreeRoot's `.entire` is safe to read
 // and write through. It is safe when the path is absent (Entire is not enabled
@@ -35,7 +53,7 @@ func ValidateEntireDirAt(worktreeRoot string) error {
 	case errors.Is(err, fs.ErrNotExist):
 		return nil
 	case err != nil:
-		return fmt.Errorf("cannot determine whether %s is a directory: %w", path, err)
+		return fmt.Errorf("%s %w: %w", path, ErrEntireDirUnreadable, err)
 	case info.Mode().IsDir():
 		return nil
 	}
@@ -70,7 +88,7 @@ func RequireEntireDir(ctx context.Context) error {
 	case errors.Is(err, ErrNotARepository):
 		return nil
 	default:
-		return fmt.Errorf("cannot locate the repository holding %s, so it cannot be verified: %w", EntireDir, err)
+		return fmt.Errorf("%w, so %s cannot be verified: %w", ErrRepositoryUnresolved, EntireDir, err)
 	}
 }
 

--- a/cmd/entire/cli/paths/entiredir.go
+++ b/cmd/entire/cli/paths/entiredir.go
@@ -43,23 +43,35 @@ func ValidateEntireDirAt(worktreeRoot string) error {
 	return fmt.Errorf("%s is %s, %w", path, describeMode(info.Mode()), ErrEntireDirNotDirectory)
 }
 
-// RequireEntireDir validates the current worktree's `.entire`. Outside a git
-// repository there is no worktree root and so nothing to validate, which is not
-// an error: commands that need a repository report its absence themselves, with
-// a message about the repository rather than about `.entire`.
+// RequireEntireDir validates the current worktree's `.entire`.
+//
+// Outside a git repository there is no worktree root and so nothing to
+// validate, which is not an error: commands that need a repository report its
+// absence themselves, with a message about the repository rather than about
+// `.entire`. That skip requires git's positive ErrNotARepository verdict.
+//
+// Every other discovery failure — git missing from PATH, a cancelled context, a
+// permission failure, dubious ownership, malformed output — fails closed. Those
+// mean "we could not find out", and the consequence of guessing "no repository"
+// is not merely a skipped check: settings resolution falls back to a path
+// relative to the current directory when the root will not resolve
+// (settingsAbsPaths in the settings package), so a guess would read
+// ./.entire/settings.json — through the very symlink this exists to reject.
+// Refusing to run on a machine whose git is broken is the cheaper mistake.
 //
 // Deliberately not memoized. The Lstat is free next to the `git rev-parse` that
 // WorktreeRoot runs, and a cached "it was fine" is a stale answer in a
 // long-lived process such as `entire mcp`.
 func RequireEntireDir(ctx context.Context) error {
 	root, err := WorktreeRoot(ctx)
-	if err != nil {
-		//nolint:nilerr // No repository means no `.entire` to validate. Reporting
-		// the rev-parse failure here would make every command outside a repo fail
-		// with a message about `.entire` instead of about the missing repository.
+	switch {
+	case err == nil:
+		return ValidateEntireDirAt(root)
+	case errors.Is(err, ErrNotARepository):
 		return nil
+	default:
+		return fmt.Errorf("cannot locate the repository holding %s, so it cannot be verified: %w", EntireDir, err)
 	}
-	return ValidateEntireDirAt(root)
 }
 
 // describeMode names what was found. The sentinel supplies the "not a

--- a/cmd/entire/cli/paths/entiredir_test.go
+++ b/cmd/entire/cli/paths/entiredir_test.go
@@ -187,3 +187,163 @@ func TestRequireEntireDir_OutsideRepositoryIsSkipped(t *testing.T) {
 		t.Fatalf("RequireEntireDir outside a repository: %v", err)
 	}
 }
+
+// withFakeGit puts a stub `git` on an otherwise-empty PATH so a specific
+// discovery failure can be driven exactly. Not parallel: PATH is
+// process-global. Go runs sequential tests to completion before resuming
+// parallel ones, so they never overlap.
+func withFakeGit(t *testing.T, script string) {
+	t.Helper()
+	if runtime.GOOS == osWindows {
+		t.Skip("shell-script git stub is Unix-only")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte("#!/bin/sh\n"+script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	ClearWorktreeRootCache()
+	t.Cleanup(ClearWorktreeRootCache)
+}
+
+// inDirWithSymlinkedEntireDir puts the process in a directory whose `.entire`
+// is a symlink. Every fail-closed case below runs here, because the point is
+// not that an error is returned — it is that this symlink is not read through.
+func inDirWithSymlinkedEntireDir(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "elsewhere")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	symlinkOrSkip(t, target, filepath.Join(dir, EntireDir))
+	t.Chdir(dir)
+}
+
+// Git's own verdict is the one skippable case.
+func TestRequireEntireDir_GitSaysNotARepository(t *testing.T) {
+	inDirWithSymlinkedEntireDir(t)
+	withFakeGit(t, `echo "fatal: not a git repository (or any of the parent directories): .git" >&2
+exit 128`)
+
+	if err := RequireEntireDir(context.Background()); err != nil {
+		t.Fatalf("RequireEntireDir with git's not-a-repository verdict: %v", err)
+	}
+}
+
+// Everything else must fail closed. Exit code 128 is not the signal — git uses
+// it for failures that happen INSIDE a repository too.
+func TestRequireEntireDir_DiscoveryFailuresFailClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{
+			// safe.directory. Exit 128, and we are very much inside a repo.
+			name: "dubious ownership",
+			script: `echo "fatal: detected dubious ownership in repository at '/repo'" >&2
+exit 128`,
+		},
+		{
+			name: "permission denied",
+			script: `echo "fatal: could not read '/repo/.git/config': Permission denied" >&2
+exit 128`,
+		},
+		{
+			name:   "success with no output",
+			script: `exit 0`,
+		},
+		{
+			name: "success with blank output",
+			script: `echo ""
+exit 0`,
+		},
+		{
+			name:   "killed by a signal",
+			script: `kill -TERM $$`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inDirWithSymlinkedEntireDir(t)
+			withFakeGit(t, tt.script)
+
+			err := RequireEntireDir(context.Background())
+			if err == nil {
+				t.Fatal("RequireEntireDir returned nil; a discovery failure must not be read as 'no repository'")
+			}
+			if errors.Is(err, ErrNotARepository) {
+				t.Errorf("failure was classified as not-a-repository: %v", err)
+			}
+		})
+	}
+}
+
+func TestRequireEntireDir_GitMissingFailsClosed(t *testing.T) {
+	inDirWithSymlinkedEntireDir(t)
+	t.Setenv("PATH", t.TempDir())
+	ClearWorktreeRootCache()
+	t.Cleanup(ClearWorktreeRootCache)
+
+	err := RequireEntireDir(context.Background())
+	if err == nil {
+		t.Fatal("RequireEntireDir returned nil with no git on PATH")
+	}
+	if errors.Is(err, ErrNotARepository) {
+		t.Errorf("a missing git was classified as not-a-repository: %v", err)
+	}
+}
+
+func TestRequireEntireDir_CancelledContextFailsClosed(t *testing.T) {
+	inDirWithSymlinkedEntireDir(t)
+	ClearWorktreeRootCache()
+	t.Cleanup(ClearWorktreeRootCache)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := RequireEntireDir(ctx)
+	if err == nil {
+		t.Fatal("RequireEntireDir returned nil for a cancelled context")
+	}
+	if errors.Is(err, ErrNotARepository) {
+		t.Errorf("a cancellation was classified as not-a-repository: %v", err)
+	}
+}
+
+// Git translates its messages, so the classifier pins LC_ALL/LANGUAGE. Without
+// that, a localized machine would fail closed on every command run outside a
+// repository.
+func TestWorktreeRoot_NotARepositoryIsRecognisedUnderALocale(t *testing.T) {
+	t.Setenv("LC_ALL", "de_DE.UTF-8")
+	t.Setenv("LANGUAGE", "de")
+	withFakeGit(t, `if [ "$LC_ALL" = "C" ] && [ -z "$LANGUAGE" ]; then
+  echo "fatal: not a git repository (or any of the parent directories): .git" >&2
+else
+  echo "fatal: Kein Git-Repository (oder irgendein Elternverzeichnis): .git" >&2
+fi
+exit 128`)
+
+	_, err := WorktreeRoot(context.Background())
+	if !errors.Is(err, ErrNotARepository) {
+		t.Fatalf("not-a-repository was not recognised with a locale set: %v", err)
+	}
+}
+
+// "exit status 128" names no cause. The causes that land here are ones the user
+// has to act on, and git already said what they are.
+func TestWorktreeRoot_SurfacesGitsFatal(t *testing.T) {
+	withFakeGit(t, `echo "fatal: detected dubious ownership in repository at '/repo'" >&2
+exit 128`)
+
+	_, err := WorktreeRoot(context.Background())
+	if err == nil {
+		t.Fatal("WorktreeRoot returned nil")
+	}
+	if !strings.Contains(err.Error(), "dubious ownership") {
+		t.Errorf("git's fatal was swallowed: %v", err)
+	}
+}

--- a/cmd/entire/cli/paths/entiredir_test.go
+++ b/cmd/entire/cli/paths/entiredir_test.go
@@ -3,6 +3,7 @@ package paths
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -345,5 +346,81 @@ exit 128`)
 	}
 	if !strings.Contains(err.Error(), "dubious ownership") {
 		t.Errorf("git's fatal was swallowed: %v", err)
+	}
+}
+
+// The three failure conditions are distinguished positively, because each has a
+// different remedy and callers print it. Classification by elimination is how a
+// stat error came to be reported as a git problem.
+func TestEntireDirErrorsAreDistinguishable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wrong file type", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, EntireDir), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		err := ValidateEntireDirAt(root)
+		if !errors.Is(err, ErrEntireDirNotDirectory) {
+			t.Fatalf("want ErrEntireDirNotDirectory, got %v", err)
+		}
+		if errors.Is(err, ErrEntireDirUnreadable) {
+			t.Errorf("a wrong file type must not read as unreadable: %v", err)
+		}
+	})
+
+	t.Run("stat failure", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == osWindows {
+			t.Skip("directory permission bits do not gate stat on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permission bits")
+		}
+
+		root := filepath.Join(t.TempDir(), "repo")
+		if err := os.Mkdir(root, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(filepath.Join(root, EntireDir), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(root, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := os.Chmod(root, 0o750); err != nil {
+				t.Logf("restore permissions on %s: %v", root, err)
+			}
+		})
+
+		err := ValidateEntireDirAt(root)
+		if !errors.Is(err, ErrEntireDirUnreadable) {
+			t.Fatalf("want ErrEntireDirUnreadable, got %v", err)
+		}
+		if errors.Is(err, ErrEntireDirNotDirectory) {
+			t.Errorf("a stat failure must not read as a wrong file type: %v", err)
+		}
+		if !errors.Is(err, fs.ErrPermission) {
+			t.Errorf("the underlying cause was dropped: %v", err)
+		}
+	})
+}
+
+// Separate from the table above because it needs t.Chdir, which cannot run
+// under a parallel parent.
+func TestRequireEntireDir_UnresolvedRepositoryIsItsOwnCondition(t *testing.T) {
+	inDirWithSymlinkedEntireDir(t)
+	withFakeGit(t, `echo "fatal: detected dubious ownership in repository at '/repo'" >&2
+exit 128`)
+
+	err := RequireEntireDir(context.Background())
+	if !errors.Is(err, ErrRepositoryUnresolved) {
+		t.Fatalf("want ErrRepositoryUnresolved, got %v", err)
+	}
+	if errors.Is(err, ErrEntireDirNotDirectory) || errors.Is(err, ErrEntireDirUnreadable) {
+		t.Errorf("an unresolved repository must not read as a problem with the path: %v", err)
 	}
 }

--- a/cmd/entire/cli/paths/entiredir_test.go
+++ b/cmd/entire/cli/paths/entiredir_test.go
@@ -1,6 +1,7 @@
 package paths
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -162,5 +163,27 @@ func TestValidateEntireDirAt_MessageNamesPathAndType(t *testing.T) {
 	}
 	if !strings.Contains(msg, "symbolic link") {
 		t.Errorf("message %q does not say what was found", msg)
+	}
+}
+
+// Outside a git repository there is no worktree root, so there is no `.entire`
+// to validate and the check is skipped. Commands that need a repository report
+// its absence themselves, with a message about the repository rather than one
+// about `.entire`.
+//
+// The stray `.entire` file proves the skip is real: were the check resolving a
+// root some other way, this would trip it.
+func TestRequireEntireDir_OutsideRepositoryIsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, EntireDir), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(dir)
+	ClearWorktreeRootCache()
+	t.Cleanup(ClearWorktreeRootCache)
+
+	if err := RequireEntireDir(context.Background()); err != nil {
+		t.Fatalf("RequireEntireDir outside a repository: %v", err)
 	}
 }

--- a/cmd/entire/cli/paths/entiredir_test.go
+++ b/cmd/entire/cli/paths/entiredir_test.go
@@ -1,0 +1,166 @@
+package paths
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// symlinkOrSkip creates a symlink, skipping the test where the platform or the
+// account cannot make one (Windows without developer mode).
+func symlinkOrSkip(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+}
+
+func TestValidateEntireDirAt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, root string)
+		wantErr bool
+	}{
+		{
+			name:  "absent is fine",
+			setup: func(*testing.T, string) {},
+		},
+		{
+			name: "real directory is fine",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				if err := os.Mkdir(filepath.Join(root, EntireDir), 0o750); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "regular file is rejected",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(root, EntireDir), []byte("nope"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "symlink to a directory is rejected",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				target := filepath.Join(root, "elsewhere")
+				if err := os.Mkdir(target, 0o750); err != nil {
+					t.Fatal(err)
+				}
+				symlinkOrSkip(t, target, filepath.Join(root, EntireDir))
+			},
+			wantErr: true,
+		},
+		{
+			name: "symlink to a file is rejected",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				target := filepath.Join(root, "elsewhere")
+				if err := os.WriteFile(target, []byte("nope"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				symlinkOrSkip(t, target, filepath.Join(root, EntireDir))
+			},
+			wantErr: true,
+		},
+		{
+			name: "dangling symlink is rejected",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				symlinkOrSkip(t, filepath.Join(root, "missing"), filepath.Join(root, EntireDir))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			tt.setup(t, root)
+
+			err := ValidateEntireDirAt(root)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ValidateEntireDirAt returned nil, want error")
+				}
+				if !errors.Is(err, ErrEntireDirNotDirectory) {
+					t.Errorf("error does not wrap ErrEntireDirNotDirectory: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateEntireDirAt: %v", err)
+			}
+		})
+	}
+}
+
+// A directory we cannot stat through is not proof the invariant holds, so it
+// must fail rather than pass. Root bypasses permission bits, and Windows does
+// not honour them here at all.
+func TestValidateEntireDirAt_UnreadableParentFails(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == osWindows {
+		t.Skip("directory permission bits do not gate stat on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission bits")
+	}
+
+	root := filepath.Join(t.TempDir(), "repo")
+	if err := os.Mkdir(root, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, EntireDir), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(root, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(root, 0o750); err != nil {
+			t.Logf("restore permissions on %s: %v", root, err)
+		}
+	})
+
+	err := ValidateEntireDirAt(root)
+	if err == nil {
+		t.Fatal("ValidateEntireDirAt returned nil for an unreadable parent, want error")
+	}
+	if errors.Is(err, ErrEntireDirNotDirectory) {
+		t.Errorf("a stat failure must not be reported as a wrong file type: %v", err)
+	}
+}
+
+// The message is what a user acts on, so it must name the path and what was
+// found there.
+func TestValidateEntireDirAt_MessageNamesPathAndType(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	entire := filepath.Join(root, EntireDir)
+	symlinkOrSkip(t, root, entire)
+
+	err := ValidateEntireDirAt(root)
+	if err == nil {
+		t.Fatal("ValidateEntireDirAt returned nil, want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, entire) {
+		t.Errorf("message %q does not name the path %q", msg, entire)
+	}
+	if !strings.Contains(msg, "symbolic link") {
+		t.Errorf("message %q does not say what was found", msg)
+	}
+}

--- a/cmd/entire/cli/paths/paths.go
+++ b/cmd/entire/cli/paths/paths.go
@@ -1,7 +1,9 @@
 package paths
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -82,12 +84,24 @@ func WorktreeRoot(ctx context.Context) (string, error) {
 
 	// Cache miss - get worktree root and update cache with write lock
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
+	// Force C messages so classifyWorktreeRootError can recognise git's
+	// "not a repository" on a localized machine. Built by filtering rather than
+	// appending, because a duplicate key in the environment resolves to the
+	// first match on Unix, not the last. Everything else is inherited, so the
+	// GIT_DIR/GIT_WORK_TREE a hook exports still selects the worktree.
+	cmd.Env = envWithCMessages(os.Environ())
 	output, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to get git worktree root: %w", err)
+		return "", classifyWorktreeRootError(ctx, err)
 	}
 
 	root := strings.TrimSpace(string(output))
+	// Git printed no path but reported success. Whatever produced that, it is
+	// not an answer, and treating "" as a worktree root resolves every repo
+	// path against the filesystem root.
+	if root == "" {
+		return "", errors.New("git rev-parse --show-toplevel reported success but printed no path")
+	}
 
 	worktreeRootMu.Lock()
 	worktreeRootCache = root
@@ -95,6 +109,78 @@ func WorktreeRoot(ctx context.Context) (string, error) {
 	worktreeRootMu.Unlock()
 
 	return root, nil
+}
+
+// ErrNotARepository reports that git positively identified the working
+// directory as being outside any repository. It is the ONLY worktree-root
+// failure that means "there is nothing here to look at" — every other one
+// (git missing from PATH, a cancelled context, a permission failure, dubious
+// ownership, malformed output) means "we could not find out", which is a
+// different thing and must not be treated as the benign case.
+var ErrNotARepository = errors.New("not a git repository")
+
+// classifyWorktreeRootError separates git's "not a repository" verdict from
+// every other reason `git rev-parse --show-toplevel` can fail.
+//
+// The distinction is load-bearing rather than cosmetic. Callers skip work when
+// there is no repository, and settings resolution falls back to a path relative
+// to the current directory when the root cannot be resolved — so folding an
+// unexpected failure into "not a repository" turns a broken git into a silent
+// read of ./.entire/settings.json, which is exactly the path a `.entire`
+// symlink redirects.
+//
+// Identification is positive, not by elimination: git must have run and exited
+// non-zero, and must have said so. Exit code 128 alone is not enough, since git
+// also uses it for dubious ownership and permission failures, both of which
+// happen INSIDE a repository.
+func classifyWorktreeRootError(ctx context.Context, err error) error {
+	// Checked first: a cancelled context kills the child, and the resulting
+	// exit status carries no verdict about the repository.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("failed to get git worktree root: %w", ctxErr)
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if bytes.Contains(bytes.ToLower(exitErr.Stderr), []byte("not a git repository")) {
+			return fmt.Errorf("%w: %s", ErrNotARepository, firstLine(exitErr.Stderr))
+		}
+		// Git's own fatal, not just the exit status. "exit status 128" names no
+		// cause, and the causes here are ones the user has to act on -- most
+		// often safe.directory's ownership check, whose fix is a git config the
+		// message states outright.
+		if line := firstLine(exitErr.Stderr); line != "" {
+			return fmt.Errorf("failed to get git worktree root: %s", line)
+		}
+	}
+
+	return fmt.Errorf("failed to get git worktree root: %w", err)
+}
+
+// firstLine trims git's stderr to its opening line, which carries the fatal.
+func firstLine(b []byte) string {
+	if i := bytes.IndexByte(b, '\n'); i >= 0 {
+		b = b[:i]
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// envWithCMessages returns env with the locale variables git consults for
+// message translation replaced by C, leaving everything else untouched.
+func envWithCMessages(env []string) []string {
+	out := make([]string, 0, len(env)+2)
+	for _, kv := range env {
+		switch {
+		case strings.HasPrefix(kv, "LC_ALL="),
+			strings.HasPrefix(kv, "LC_MESSAGES="),
+			strings.HasPrefix(kv, "LANGUAGE="),
+			strings.HasPrefix(kv, "LANG="):
+			continue
+		}
+		out = append(out, kv)
+	}
+	// LANGUAGE overrides LC_ALL for gettext, so both are pinned.
+	return append(out, "LC_ALL=C", "LANGUAGE=")
 }
 
 // ClearWorktreeRootCache clears the cached worktree root.

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -92,14 +92,28 @@ func NewRootCmd() *cobra.Command {
 		CompletionOptions: cobra.CompletionOptions{
 			HiddenDefaultCmd: true,
 		},
-		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+		// PersistentPreRunE, not PersistentPreRun, so the `.entire` check can
+		// stop the command. Every check below it reads or writes through
+		// `.entire` — IsSetUpAny stats .entire/settings.json and ensureLogger
+		// opens .entire/logs/entire.log — so the guard has to come first.
+		// cobra.EnableTraverseRunHooks (set in init) runs parent hooks before
+		// child ones, so this fires ahead of the group pre-runs and every RunE.
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if isShellCompletion(cmd) {
-				return
+				return nil
+			}
+			safe, err := checkEntireDirBeforeRun(cmd)
+			if err != nil {
+				return err
+			}
+			if !safe {
+				return nil
 			}
 			if !settings.IsSetUpAny(cmd.Context()) {
-				return
+				return nil
 			}
 			ensureLogger(cmd)
+			return nil
 		},
 		PersistentPostRun: func(cmd *cobra.Command, _ []string) {
 			// Skip for hidden commands (walk parent chain — Cobra doesn't propagate Hidden)
@@ -152,19 +166,19 @@ func NewRootCmd() *cobra.Command {
 	)
 
 	// Noun groups (canonical homes for subcommands).
-	cmd.AddCommand(inGroup(newSessionsCmd(), groupSessions))        // 'session' (with 'sessions' as Cobra alias)
-	cmd.AddCommand(inGroup(newCheckpointGroupCmd(), groupSessions)) // 'checkpoint' / 'cp' / 'checkpoints'
-	experimental.Register(cmd, newTokensGroupCmd())                 // 'tokens' (experimental)
-	cmd.AddCommand(inGroup(newAgentGroupCmd(), groupSetup))         // 'agent'
-	cmd.AddCommand(inGroup(newAuthCmd(), groupAccount))             // 'auth'
-	cmd.AddCommand(inGroup(newDoctorCmd(), groupSetup))             // 'doctor' (group: trace/logs/bundle)
-	cmd.AddCommand(newLabsCmd())                                    // 'labs' (experimental workflow discovery)
-	cmd.AddCommand(inGroup(newPluginGroupCmd(), groupSetup))        // 'plugin' (managed install/list/remove)
-	experimental.Register(cmd, newImportCmd())                      // 'import' (experimental; import pre-existing agent history)
-	cmd.AddCommand(inGroup(newOrgCmd(), groupControlPlane))         // 'org' — control-plane org management
-	cmd.AddCommand(inGroup(newProjectCmd(), groupControlPlane))     // 'project' — control-plane project management
-	cmd.AddCommand(inGroup(newRepoCmd(), groupControlPlane))        // 'repo' — control-plane repo lifecycle
-	cmd.AddCommand(inGroup(newGrantCmd(), groupControlPlane))       // 'grant' — control-plane access grants
+	cmd.AddCommand(inGroup(newSessionsCmd(), groupSessions))                              // 'session' (with 'sessions' as Cobra alias)
+	cmd.AddCommand(inGroup(newCheckpointGroupCmd(), groupSessions))                       // 'checkpoint' / 'cp' / 'checkpoints'
+	experimental.Register(cmd, newTokensGroupCmd())                                       // 'tokens' (experimental)
+	cmd.AddCommand(inGroup(newAgentGroupCmd(), groupSetup))                               // 'agent'
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newAuthCmd(), groupAccount)))         // 'auth'
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newDoctorCmd(), groupSetup)))         // 'doctor' (group: trace/logs/bundle)
+	cmd.AddCommand(exemptFromEntireDirCheck(newLabsCmd()))                                // 'labs' (experimental workflow discovery)
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newPluginGroupCmd(), groupSetup)))    // 'plugin' (managed install/list/remove)
+	experimental.Register(cmd, newImportCmd())                                            // 'import' (experimental; import pre-existing agent history)
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newOrgCmd(), groupControlPlane)))     // 'org' — control-plane org management
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newProjectCmd(), groupControlPlane))) // 'project' — control-plane project management
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newRepoCmd(), groupControlPlane)))    // 'repo' — control-plane repo lifecycle
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newGrantCmd(), groupControlPlane)))   // 'grant' — control-plane access grants
 
 	// Top-level lifecycle and standalone commands.
 	experimental.Register(cmd, cliReview.NewCommand(buildReviewDeps()))        // `review` (experimental)
@@ -176,15 +190,15 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(inGroup(newStatusCmd(), groupSetup))
 	experimental.Register(cmd, newBlameCmd()) // 'blame' (experimental)
 	experimental.Register(cmd, newWhyCmd())   // 'why' (experimental)
-	cmd.AddCommand(inGroup(newLoginCmd(), groupAccount))
-	cmd.AddCommand(inGroup(newLogoutCmd(), groupAccount))
-	cmd.AddCommand(newVersionCmd())
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newLoginCmd(), groupAccount)))
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newLogoutCmd(), groupAccount)))
+	cmd.AddCommand(exemptFromEntireDirCheck(newVersionCmd()))
 	cmd.AddCommand(inGroup(newDispatchCmd(), groupSessions))
 	cmd.AddCommand(inGroup(newActivityCmd(), groupSessions))
 	cmd.AddCommand(inGroup(newRecapCmd(), groupSessions))
-	cmd.AddCommand(inGroup(newAPICmd(), groupControlPlane)) // authenticated passthrough to core/cell APIs
-	cmd.AddCommand(newAgentHelpCmd(cmd))                    // visible: agents on transports without context injection discover it via `entire help`
-	cmd.AddCommand(inGroup(newSearchCmd(), groupSessions))  // 'search' — canonical top-level spelling; 'checkpoint search' stays a working alias
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newAPICmd(), groupControlPlane))) // authenticated passthrough to core/cell APIs
+	cmd.AddCommand(newAgentHelpCmd(cmd))                                              // visible: agents on transports without context injection discover it via `entire help`
+	cmd.AddCommand(inGroup(newSearchCmd(), groupSessions))                            // 'search' — canonical top-level spelling; 'checkpoint search' stays a working alias
 
 	// Experimental labs commands (listed via `entire labs`; not deprecation shortcuts).
 	experimental.Register(cmd, newExpertsCmd()) // 'experts' (experimental); agent/workflow provenance
@@ -205,6 +219,18 @@ func NewRootCmd() *cobra.Command {
 
 	// Replace default help command with custom one that supports -t flag
 	cmd.SetHelpCommand(NewHelpCmd(cmd))
+
+	// Materialize cobra's `completion` command now, so it can be exempted from
+	// the `.entire` check. It prints a shell script and reads nothing from the
+	// repo, and users eval it from a shell rc — a broken repo must not be able
+	// to break someone's shell startup. Cobra calls this again during
+	// ExecuteC, where it returns early because the command already exists.
+	cmd.InitDefaultCompletionCmd()
+	for _, c := range cmd.Commands() {
+		if c.Name() == "completion" {
+			exemptFromEntireDirCheck(c)
+		}
+	}
 
 	return cmd
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1166
<!-- entire-trail-link-end -->

.entire holds session metadata, transcripts, and the redaction settings that decide what may be committed. Nothing checked that the path was a directory Entire owns, so a regular file or a symlink in its place was read and written through: settings loaded from the far end, the log sink created there, and `enable` happy to MkdirAll straight through it.

paths.ValidateEntireDirAt is the single implementation. The stat is Lstat, not Stat, so a symlink is rejected even when it points at a perfectly good directory -- that is the case a Stat check waves through. Absent stays fine, since Entire may not be enabled here yet. A stat error other than "not exist" also fails: it is not evidence the invariant is violated, but it is not evidence that it holds either, and the caller's next move is to write there.

Guarded is the default. The root PersistentPreRunE runs the check above both settings.IsSetUpAny and ensureLogger, because each of those already touches the path. A command opts out with exemptFromEntireDirCheck at its AddCommand line, so the exempt set reads as one list, and every entry needs a reason in entireDirCheckExemptions or the guard test fails.

Exemption does not mean writing through the path anyway: an exempt command in a broken repo runs, but is told the path is unsafe, which is what keeps ensureLogger from creating .entire/logs inside whatever the symlink points at. doctor is exempt so that it can run on a broken repo, and reports the problem in the group's persistent pre-run -- ahead of its own PreRunE, which loads redaction settings through .entire.

help and agent-help stay guarded: someone asking what they can do in this repo is told the repo is broken rather than handed a working command list. `entire <command> --help` is unaffected, because cobra returns flag.ErrHelp before any PersistentPreRunE.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every guarded CLI entry point and settings/logging paths; misclassification of git or exemption drift could block legitimate use or leave a hole, though behavior is heavily tested and intentionally fail-closed.
> 
> **Overview**
> **Blocks reads and writes through a non-directory `.entire`** (file, symlink—even to a valid dir, FIFO, etc.) so session metadata, settings, and logs cannot be redirected to a path Entire does not own. Validation lives in `paths.ValidateEntireDirAt` / `RequireEntireDir` using **`Lstat`**, with three typed errors (`ErrEntireDirNotDirectory`, `ErrEntireDirUnreadable`, `ErrRepositoryUnresolved`) and matching user remedies.
> 
> **Enforcement is layered:** the root `PersistentPreRunE` runs the guard before `settings.IsSetUpAny` and `ensureLogger`; exempt commands (`exemptFromEntireDirCheck` + audited allowlist) may still run but get `safe == false` so logging does not create `.entire/logs` through a bad path. **`LoadEntireSettings`** and **`newLogger`** repeat the check for plugin/telemetry paths the pre-run misses. **`doctor`** diagnoses via its own `PersistentPreRunE` and stops before touching settings/logs.
> 
> **`WorktreeRoot` now fails closed** on ambiguous git failures: only a positive “not a git repository” skips validation; dubious ownership, missing git, empty output, etc. surface as `ErrRepositoryUnresolved` (locale pinned to C for classification). Unit and integration tests cover symlink repos, exemptions, and no writes through the symlink target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1194781d85a24b2233461f465c6a0539f83a7b2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->