### PR TITLE
Extend the .entire guard one level down, and refuse symlinked settings files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,10 +446,15 @@ symlink — **including a symlink pointing at a perfectly good directory** — a
 FIFO, a socket, or a device is a broken repo, and a command that would read or
 write through the path stops instead.
 
-**The entries directly inside it must not be symlinks either.** A symlinked
+**The entries directly inside it must be regular files or directories.** That is
+an allowlist, not a list of known-bad types: Entire only ever creates files and
+directories under `.entire`, so anything else arrived some other way and a mode
+bit nobody has considered yet is refused by default. A symlinked
 `.entire/metadata` redirects transcripts; a symlinked `.entire/settings.local.json`
-redirects the file that names the command Entire executes at pre-push. The scan
-is one level deep, and it is a symlink check only — see the non-goals below.
+redirects the file that names the command Entire executes at pre-push; a FIFO in
+either place hangs the read instead. The scan is one level deep, and
+`fs.ModeIrregular` is its one deliberate exception — see the entry-scan
+mechanics below.
 
 `paths.ValidateEntireDirAt(worktreeRoot)` / `paths.RequireEntireDir(ctx)`
 (`paths/entiredir.go`) are the only implementation. The stat is `Lstat`, not
@@ -464,8 +469,8 @@ to the `git rev-parse` that precedes them, and a cached "it was fine" is stale i
 a long-lived `entire mcp`.
 
 **Four failure conditions, each identified positively.** `ErrEntireDirNotDirectory`
-(the path exists and is the wrong type), `ErrEntireDirSymlinkedEntry` (an entry
-directly inside it is a symlink), `ErrEntireDirUnreadable` (`Lstat` or the
+(the path exists and is the wrong type), `ErrEntireDirUnsupportedEntry` (an entry
+directly inside it is neither a regular file nor a directory), `ErrEntireDirUnreadable` (`Lstat` or the
 directory listing failed, so nothing is known about the path), and
 `ErrRepositoryUnresolved` (the worktree root would not resolve, so there is no
 path to inspect yet). Callers print a remedy, and the remedies are different
@@ -478,11 +483,11 @@ labelled variant: BROKEN / UNREADABLE / UNVERIFIED) both take the error as a
 parameter so every branch is reachable in a test; staging a genuinely
 unreadable `.entire` is impractical, since removing execute permission on the
 repo root breaks worktree-root discovery first and exercises the wrong branch.
-A symlinked entry and a wrong-typed `.entire` share doctor's BROKEN heading:
+An unsupported entry and a wrong-typed `.entire` share doctor's BROKEN heading:
 to the reader they are one condition — something replaced a path Entire owns —
 differing only in which path and what to put back.
 
-**`ErrEntireDirNotDirectory` is not reused for a symlinked entry**, even though
+**`ErrEntireDirNotDirectory` is not reused for an unsupported entry**, even though
 both remedies are "replace it". `.entire/settings.json` is not required to be a
 directory, so telling someone it is not one names the wrong problem. The entry
 remedy says "replace it with a real file or directory"; the `.entire` remedy says
@@ -490,25 +495,48 @@ remedy says "replace it with a real file or directory"; the `.entire` remedy say
 asserts neither branch prints the other's phrase.
 
 **Entry-scan mechanics.** `validateEntireDirEntries` does one `os.ReadDir` and
-tests `DirEntry.Type()&fs.ModeSymlink`, with **no `Lstat` of its own** — the type
-comes from the directory read where the platform reports one, and where it does
-not, `os.ReadDir` does the `Lstat` internally, *skipping an entry that vanished
-between the read and the stat*. Adding an `Lstat` here reintroduces that race,
-which matters because `.entire/tmp` and `.entire/metadata/<session>` churn under
-concurrent hooks. The entries are checked **before** `ReadDir`'s error, because
-`os.ReadDir` returns what it managed to read alongside a partial-read error and a
-symlink among those is a positive finding — a stronger statement than "the
-listing failed". One error names the first offender in `ReadDir`'s sorted order
-(so the message is deterministic) and counts the rest, rather than one error per
-entry: the remedy is identical for all of them, and a user who reruns the command
-once per planted link is paying for our formatting.
+passes each `DirEntry.Type()` to `unsupportedEntryType`, with **no `Lstat` of its
+own** — the type comes from the directory read where the platform reports one,
+and where it does not, `os.ReadDir` does the `Lstat` internally, *skipping an
+entry that vanished between the read and the stat*. `DirEntry.Type()` is
+therefore never unresolved, and `Type() == 0` means a regular file, not unknown
+(`direntType` returns `^FileMode(0)` for unknown, which sets every bit including
+`ModeSymlink`, so even a leak would fail closed). Adding an `Lstat` here
+reintroduces that race, which matters because `.entire/tmp` and
+`.entire/metadata/<session>` churn under concurrent hooks. The entries are
+checked **before** `ReadDir`'s error, because `os.ReadDir` returns what it
+managed to read alongside a partial-read error and an unsupported entry among
+those is a positive finding — a stronger statement than "the listing failed". One
+error names the first offender in `ReadDir`'s sorted order (so the message is
+deterministic) and counts the rest, rather than one error per entry: the remedy
+is identical for all of them, and a user who reruns the command once per planted
+entry is paying for our formatting.
+
+**`fs.ModeIrregular` is tolerated, and that is the one place the allowlist
+bends.** Windows overloads the bit: Go maps every reparse tag it has no category
+for onto it (the `default` arm of `fileStat.mode` in `os/types_windows.go`),
+which lands NTFS directory junctions *and* OneDrive Files On-Demand placeholders
+in the same bucket, indistinguishable from a `DirEntry`. Refusing the bucket
+would hard-fail every command in a repo inside a synced folder, with a remedy the
+user cannot act on, and the placeholder arrives with nobody attacking anything.
+The junction it would also catch cannot arrive by checkout — git has no
+tree-object mode for one — so planting it already requires local code execution,
+at which point this check is not what stands in the way. The bit is tolerated
+only on its own: anything carrying a rejected type is rejected whatever else it
+carries. Distinguishing the two would mean reading the reparse tag through a
+Windows-only syscall (`FindFirstFile`, then `Reserved0 & 0x20000000` for the
+name-surrogate tags); that is the upgrade path if junctions ever become worth
+catching.
 
 **A settings file is never read through a link, and the settings reader enforces
 that itself.** `readConfined` (`settings/settings.go`) — the chokepoint every
 settings read funnels through, including `LoadFromFile`, `LoadProjectRaw`,
 `LoadLocalRaw`, and clone preferences — `Lstat`s the entry through its own
 `os.Root` handle and refuses a symlink outright, wrapping
-`paths.ErrEntireDirSymlinkedEntry` via the shared `paths.SymlinkedEntryError`.
+`paths.ErrEntireDirUnsupportedEntry` via the shared `paths.SymlinkedEntryError`
+(the symlink-specific message builder, which names the link target; the entry
+scan reaches it through `unsupportedEntryError` and describes other types with
+`describeMode`).
 
 This is deliberately redundant with the `.entire` entry scan, because the two
 cover different callers: the scan hangs off the root pre-run and
@@ -538,12 +566,11 @@ than writing through it.
 
 **Non-goals, deliberately.** The scan is *not* recursive — walking deeper would
 traverse every session's transcripts on every command, and the checkpoint writer
-already skips symlinks as it walks the metadata directory. It is *not* a general
-type check either: a FIFO at `.entire/settings.json` would still hang the
-settings read, which is a hang rather than a redirection, so it is a different
-failure with a different fix. Relocating `.entire/logs` and `.entire/tmp` out of
-the worktree is a separate change; until then, redirecting them with a symlink is
-refused rather than supported, and the remedy text says so.
+already skips symlinks as it walks the metadata directory. It does *not* look at
+permissions or ownership, only at type. Relocating `.entire/logs` and
+`.entire/tmp` out of the worktree is a separate change; until then, redirecting
+them with a symlink is refused rather than supported, and the remedy text says
+so.
 
 Cost of the second phase: measured 8.2µs against 1.0µs for the `Lstat` alone, on
 a `.entire` holding six subdirectories, three files, and 51 session directories

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,6 +446,11 @@ symlink — **including a symlink pointing at a perfectly good directory** — a
 FIFO, a socket, or a device is a broken repo, and a command that would read or
 write through the path stops instead.
 
+**The entries directly inside it must not be symlinks either.** A symlinked
+`.entire/metadata` redirects transcripts; a symlinked `.entire/settings.local.json`
+redirects the file that names the command Entire executes at pre-push. The scan
+is one level deep, and it is a symlink check only — see the non-goals below.
+
 `paths.ValidateEntireDirAt(worktreeRoot)` / `paths.RequireEntireDir(ctx)`
 (`paths/entiredir.go`) are the only implementation. The stat is `Lstat`, not
 `Stat`, which is the whole point: `.entire` holds session metadata, transcripts,
@@ -454,16 +459,18 @@ else owns the far end of is not one we write through. Absent is fine (Entire is
 not enabled yet, or `enable` is about to create it). A stat error other than
 "not exist" is a failure — it is not evidence the invariant is violated, but it
 is not evidence it holds either, and the caller's next move is to write there.
-Not memoized, deliberately: the `Lstat` is free next to the `git rev-parse` that
-precedes it, and a cached "it was fine" is stale in a long-lived `entire mcp`.
+Not memoized, deliberately: the `Lstat` and the one-level listing are free next
+to the `git rev-parse` that precedes them, and a cached "it was fine" is stale in
+a long-lived `entire mcp`.
 
-**Three failure conditions, each identified positively.** `ErrEntireDirNotDirectory`
-(the path exists and is the wrong type), `ErrEntireDirUnreadable` (`Lstat`
-itself failed, so nothing is known about the path), and
+**Four failure conditions, each identified positively.** `ErrEntireDirNotDirectory`
+(the path exists and is the wrong type), `ErrEntireDirSymlinkedEntry` (an entry
+directly inside it is a symlink), `ErrEntireDirUnreadable` (`Lstat` or the
+directory listing failed, so nothing is known about the path), and
 `ErrRepositoryUnresolved` (the worktree root would not resolve, so there is no
-path to inspect yet). Callers print a remedy, and the three remedies are
-different things: replace the path, fix ownership/permissions, fix git. Match
-them with `errors.Is` and give an unmatched error **no** remedy — an `else`
+path to inspect yet). Callers print a remedy, and the remedies are different
+things: replace the path, replace the entry, fix ownership/permissions, fix git.
+Match them with `errors.Is` and give an unmatched error **no** remedy — an `else`
 branch is how a filesystem `EACCES` came to be answered with advice about
 `safe.directory`, printed directly under a line that already said "permission
 denied". `writeEntireDirRemedy` and `writeEntireDirDiagnosis` (doctor's
@@ -471,6 +478,78 @@ labelled variant: BROKEN / UNREADABLE / UNVERIFIED) both take the error as a
 parameter so every branch is reachable in a test; staging a genuinely
 unreadable `.entire` is impractical, since removing execute permission on the
 repo root breaks worktree-root discovery first and exercises the wrong branch.
+A symlinked entry and a wrong-typed `.entire` share doctor's BROKEN heading:
+to the reader they are one condition — something replaced a path Entire owns —
+differing only in which path and what to put back.
+
+**`ErrEntireDirNotDirectory` is not reused for a symlinked entry**, even though
+both remedies are "replace it". `.entire/settings.json` is not required to be a
+directory, so telling someone it is not one names the wrong problem. The entry
+remedy says "replace it with a real file or directory"; the `.entire` remedy says
+"replace it with a real directory", and `TestEntireDirRemedyMatchesTheCondition`
+asserts neither branch prints the other's phrase.
+
+**Entry-scan mechanics.** `validateEntireDirEntries` does one `os.ReadDir` and
+tests `DirEntry.Type()&fs.ModeSymlink`, with **no `Lstat` of its own** — the type
+comes from the directory read where the platform reports one, and where it does
+not, `os.ReadDir` does the `Lstat` internally, *skipping an entry that vanished
+between the read and the stat*. Adding an `Lstat` here reintroduces that race,
+which matters because `.entire/tmp` and `.entire/metadata/<session>` churn under
+concurrent hooks. The entries are checked **before** `ReadDir`'s error, because
+`os.ReadDir` returns what it managed to read alongside a partial-read error and a
+symlink among those is a positive finding — a stronger statement than "the
+listing failed". One error names the first offender in `ReadDir`'s sorted order
+(so the message is deterministic) and counts the rest, rather than one error per
+entry: the remedy is identical for all of them, and a user who reruns the command
+once per planted link is paying for our formatting.
+
+**A settings file is never read through a link, and the settings reader enforces
+that itself.** `readConfined` (`settings/settings.go`) — the chokepoint every
+settings read funnels through, including `LoadFromFile`, `LoadProjectRaw`,
+`LoadLocalRaw`, and clone preferences — `Lstat`s the entry through its own
+`os.Root` handle and refuses a symlink outright, wrapping
+`paths.ErrEntireDirSymlinkedEntry` via the shared `paths.SymlinkedEntryError`.
+
+This is deliberately redundant with the `.entire` entry scan, because the two
+cover different callers: the scan hangs off the root pre-run and
+`LoadEntireSettings`, while **eighteen files call `settings.Load` directly** —
+`strategy/hooks.go`, `manual_commit_hooks.go`, `checkpoint/remote/*`, `review/*`,
+`investigate/*` — and reach settings without ever passing the pre-run.
+
+**`os.Root` confinement is not the invariant, and was not sufficient.** Measured
+against `readConfined` before the change: an absolute target (even one pointing
+inside `.entire`) and an escaping relative target were refused, but as `path
+escapes from parent`, naming neither cause nor fix; and two shapes got through:
+
+| link | before | after |
+| --- | --- | --- |
+| `settings.local.json -> planted.json` (relative, stays inside) | **followed** | refused |
+| `settings.json -> missing.json` (dangling) | **ENOENT → silently default settings** | refused |
+
+The dangling case was the worse of the two: every caller reads ENOENT as
+"absent", so a planted link made Entire ignore the project's settings without
+saying anything. Do not "simplify" the `Lstat` away on the grounds that
+`os.OpenRoot` already confines the read — it confines it, which is a different
+property from refusing a link.
+
+Writes are already safe and need no equivalent: `jsonutil.WriteFileAtomic`
+finishes with `os.Rename` over the target, which *replaces* a symlink rather
+than writing through it.
+
+**Non-goals, deliberately.** The scan is *not* recursive — walking deeper would
+traverse every session's transcripts on every command, and the checkpoint writer
+already skips symlinks as it walks the metadata directory. It is *not* a general
+type check either: a FIFO at `.entire/settings.json` would still hang the
+settings read, which is a hang rather than a redirection, so it is a different
+failure with a different fix. Relocating `.entire/logs` and `.entire/tmp` out of
+the worktree is a separate change; until then, redirecting them with a symlink is
+refused rather than supported, and the remedy text says so.
+
+Cost of the second phase: measured 8.2µs against 1.0µs for the `Lstat` alone, on
+a `.entire` holding six subdirectories, three files, and 51 session directories
+it does not descend into. That is ~0.1% of the `git rev-parse` subprocess that
+`WorktreeRoot` runs immediately before it, which is why the deliberate
+non-memoization below still holds.
 
 **Guarded is the default.** The root `PersistentPreRunE` runs the check for every
 command, above both `settings.IsSetUpAny` and `ensureLogger` because each of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,9 +521,27 @@ would hard-fail every command in a repo inside a synced folder, with a remedy th
 user cannot act on, and the placeholder arrives with nobody attacking anything.
 The junction it would also catch cannot arrive by checkout — git has no
 tree-object mode for one — so planting it already requires local code execution,
-at which point this check is not what stands in the way. The bit is tolerated
-only on its own: anything carrying a rejected type is rejected whatever else it
-carries. Distinguishing the two would mean reading the reparse tag through a
+at which point this check is not what stands in the way. **The bit is masked
+out of the type, not matched against it** — `mode.Type() &^ fs.ModeIrregular`
+must equal `0` or `fs.ModeDir` — because Windows does not hand it over alone:
+`ModeDir` is withheld only for a *name-surrogate* reparse tag, and the cloud
+tags are not surrogates, so a placeholder **directory** arrives as
+`ModeDir|ModeIrregular` while a junction (a surrogate) arrives as
+`ModeIrregular` by itself. `.entire`'s own entries are mostly directories, so an
+exact match on the bare bit would reject `metadata`, `logs`, and `tmp` in exactly
+the synced folder the tolerance exists for. Masking does not soften the rest of
+the field: anything carrying a rejected type is rejected whatever else it
+carries, `ModeIrregular` included.
+
+**The comparison is against the whole type field, never `IsRegular`/`IsDir`.**
+Those examine single bits (`IsDir` is `mode&ModeDir != 0`), so an allowlist
+keyed on them lets a rejected type in by *also* setting an accepted bit:
+`ModeDir|ModeSymlink` and `ModeDir|ModeNamedPipe` both satisfy `IsDir`, and so
+does the all-bits-set unknown mode above — which is what made the "even a leak
+would fail closed" claim false until it was fixed. An allowlist a rejected type
+can enter by setting an extra bit is not an allowlist.
+`TestUnsupportedEntryType` pins each combination. Distinguishing junction from
+placeholder would mean reading the reparse tag through a
 Windows-only syscall (`FindFirstFile`, then `Reserved0 & 0x20000000` for the
 name-surrogate tags); that is the upgrade path if junctions ever become worth
 catching.

--- a/cmd/entire/cli/entiredir_guard.go
+++ b/cmd/entire/cli/entiredir_guard.go
@@ -79,7 +79,7 @@ func checkEntireDirBeforeRun(cmd *cobra.Command) (safe bool, err error) {
 // replaced a directory Entire owns, or the path cannot be inspected, or git
 // cannot say which repository this is.
 //
-// Those are three separate remedies, matched positively. Printing the wrong one
+// Those are four separate remedies, matched positively. Printing the wrong one
 // is worse than printing none — a filesystem EACCES sent through the git branch
 // tells the user to check safe.directory right after a line that already said
 // "permission denied" — so an error matching none of them gets no remedy at all.
@@ -95,6 +95,16 @@ func writeEntireDirRemedy(w io.Writer, err error) {
 		fmt.Fprintf(w, "\n")
 		fmt.Fprintf(w, "Fix: inspect the path, then either replace it with a real directory or remove\n")
 		fmt.Fprintf(w, "it and run `entire enable` again.\n")
+
+	case errors.Is(err, paths.ErrEntireDirSymlinkedEntry):
+		fmt.Fprintf(w, "Everything directly under %s belongs to Entire, and a symbolic link puts\n", paths.EntireDir)
+		fmt.Fprintf(w, "the far end outside its control. A redirected settings file names the\n")
+		fmt.Fprintf(w, "command Entire runs before a push and decides what may be committed; a\n")
+		fmt.Fprintf(w, "redirected subdirectory sends session transcripts somewhere else.\n")
+		fmt.Fprintf(w, "\n")
+		fmt.Fprintf(w, "Fix: replace it with a real file or directory, after inspecting where the\n")
+		fmt.Fprintf(w, "link points. Redirecting %s/logs or %s/tmp elsewhere this way\n", paths.EntireDir, paths.EntireDir)
+		fmt.Fprintf(w, "is not supported.\n")
 
 	case errors.Is(err, paths.ErrEntireDirUnreadable):
 		fmt.Fprintf(w, "Nothing is known about what is at that path — the check itself failed, so\n")
@@ -142,7 +152,7 @@ func reportBrokenEntireDir(cmd *cobra.Command) error {
 	return NewSilentError(err)
 }
 
-// writeEntireDirDiagnosis is doctor's rendering of the same three conditions
+// writeEntireDirDiagnosis is doctor's rendering of the same four conditions
 // writeEntireDirRemedy covers. It is separate because doctor's report has its
 // own shape (a labelled heading and indented detail, matching the other
 // checks), and it takes the error as a parameter so each branch is reachable in
@@ -150,7 +160,9 @@ func reportBrokenEntireDir(cmd *cobra.Command) error {
 //
 // The heading distinguishes the conditions too: calling `.entire` BROKEN when
 // the only thing established is that git would not answer states something we
-// do not know.
+// do not know. A wrong file type and a symlinked entry share the BROKEN heading
+// because they are one condition to the reader — something has replaced a path
+// Entire owns — and differ only in which path and what to replace it with.
 func writeEntireDirDiagnosis(w io.Writer, err error) {
 	switch {
 	case errors.Is(err, paths.ErrEntireDirNotDirectory):
@@ -162,6 +174,18 @@ func writeEntireDirDiagnosis(w io.Writer, err error) {
 		fmt.Fprintf(w, "  remove it and run `entire enable` again.\n")
 		fmt.Fprintf(w, "  Not auto-fixed: what is there may be someone's data, and deleting it is\n")
 		fmt.Fprintf(w, "  not a call doctor should make on your behalf.\n")
+
+	case errors.Is(err, paths.ErrEntireDirSymlinkedEntry):
+		fmt.Fprintf(w, "%s: BROKEN\n", paths.EntireDir)
+		fmt.Fprintf(w, "  %v\n", err)
+		fmt.Fprintf(w, "  Everything directly under %s belongs to Entire, and a symbolic link\n", paths.EntireDir)
+		fmt.Fprintf(w, "  puts the far end outside its control. Entire has refused to read or\n")
+		fmt.Fprintf(w, "  write through it, so every other command in this repository is stopped\n")
+		fmt.Fprintf(w, "  and no session data is being captured.\n")
+		fmt.Fprintf(w, "  Fix: replace it with a real file or directory, after inspecting where\n")
+		fmt.Fprintf(w, "  the link points.\n")
+		fmt.Fprintf(w, "  Not auto-fixed: what is on the far end may be someone's data, and\n")
+		fmt.Fprintf(w, "  deleting either end is not a call doctor should make on your behalf.\n")
 
 	case errors.Is(err, paths.ErrEntireDirUnreadable):
 		fmt.Fprintf(w, "%s: UNREADABLE\n", paths.EntireDir)

--- a/cmd/entire/cli/entiredir_guard.go
+++ b/cmd/entire/cli/entiredir_guard.go
@@ -96,15 +96,17 @@ func writeEntireDirRemedy(w io.Writer, err error) {
 		fmt.Fprintf(w, "Fix: inspect the path, then either replace it with a real directory or remove\n")
 		fmt.Fprintf(w, "it and run `entire enable` again.\n")
 
-	case errors.Is(err, paths.ErrEntireDirSymlinkedEntry):
-		fmt.Fprintf(w, "Everything directly under %s belongs to Entire, and a symbolic link puts\n", paths.EntireDir)
-		fmt.Fprintf(w, "the far end outside its control. A redirected settings file names the\n")
-		fmt.Fprintf(w, "command Entire runs before a push and decides what may be committed; a\n")
-		fmt.Fprintf(w, "redirected subdirectory sends session transcripts somewhere else.\n")
+	case errors.Is(err, paths.ErrEntireDirUnsupportedEntry):
+		fmt.Fprintf(w, "Everything directly under %s belongs to Entire, and Entire only ever puts\n", paths.EntireDir)
+		fmt.Fprintf(w, "real files and directories there. A symbolic link puts the far end outside\n")
+		fmt.Fprintf(w, "its control: a redirected settings file names the command Entire runs\n")
+		fmt.Fprintf(w, "before a push and decides what may be committed, and a redirected\n")
+		fmt.Fprintf(w, "subdirectory sends session transcripts somewhere else. A pipe, socket, or\n")
+		fmt.Fprintf(w, "device in their place stalls or breaks the read instead.\n")
 		fmt.Fprintf(w, "\n")
-		fmt.Fprintf(w, "Fix: replace it with a real file or directory, after inspecting where the\n")
-		fmt.Fprintf(w, "link points. Redirecting %s/logs or %s/tmp elsewhere this way\n", paths.EntireDir, paths.EntireDir)
-		fmt.Fprintf(w, "is not supported.\n")
+		fmt.Fprintf(w, "Fix: replace it with a real file or directory, after inspecting what is\n")
+		fmt.Fprintf(w, "there and, for a link, where it points. Redirecting %s/logs or\n", paths.EntireDir)
+		fmt.Fprintf(w, "%s/tmp elsewhere this way is not supported.\n", paths.EntireDir)
 
 	case errors.Is(err, paths.ErrEntireDirUnreadable):
 		fmt.Fprintf(w, "Nothing is known about what is at that path — the check itself failed, so\n")
@@ -160,9 +162,10 @@ func reportBrokenEntireDir(cmd *cobra.Command) error {
 //
 // The heading distinguishes the conditions too: calling `.entire` BROKEN when
 // the only thing established is that git would not answer states something we
-// do not know. A wrong file type and a symlinked entry share the BROKEN heading
-// because they are one condition to the reader — something has replaced a path
-// Entire owns — and differ only in which path and what to replace it with.
+// do not know. A wrong file type and an unsupported entry share the BROKEN
+// heading because they are one condition to the reader — something has replaced
+// a path Entire owns — and differ only in which path and what to replace it
+// with.
 func writeEntireDirDiagnosis(w io.Writer, err error) {
 	switch {
 	case errors.Is(err, paths.ErrEntireDirNotDirectory):
@@ -175,17 +178,18 @@ func writeEntireDirDiagnosis(w io.Writer, err error) {
 		fmt.Fprintf(w, "  Not auto-fixed: what is there may be someone's data, and deleting it is\n")
 		fmt.Fprintf(w, "  not a call doctor should make on your behalf.\n")
 
-	case errors.Is(err, paths.ErrEntireDirSymlinkedEntry):
+	case errors.Is(err, paths.ErrEntireDirUnsupportedEntry):
 		fmt.Fprintf(w, "%s: BROKEN\n", paths.EntireDir)
 		fmt.Fprintf(w, "  %v\n", err)
-		fmt.Fprintf(w, "  Everything directly under %s belongs to Entire, and a symbolic link\n", paths.EntireDir)
-		fmt.Fprintf(w, "  puts the far end outside its control. Entire has refused to read or\n")
+		fmt.Fprintf(w, "  Everything directly under %s belongs to Entire, and Entire only ever\n", paths.EntireDir)
+		fmt.Fprintf(w, "  puts real files and directories there. Entire has refused to read or\n")
 		fmt.Fprintf(w, "  write through it, so every other command in this repository is stopped\n")
 		fmt.Fprintf(w, "  and no session data is being captured.\n")
-		fmt.Fprintf(w, "  Fix: replace it with a real file or directory, after inspecting where\n")
-		fmt.Fprintf(w, "  the link points.\n")
-		fmt.Fprintf(w, "  Not auto-fixed: what is on the far end may be someone's data, and\n")
-		fmt.Fprintf(w, "  deleting either end is not a call doctor should make on your behalf.\n")
+		fmt.Fprintf(w, "  Fix: replace it with a real file or directory, after inspecting what is\n")
+		fmt.Fprintf(w, "  there and, for a link, where it points.\n")
+		fmt.Fprintf(w, "  Not auto-fixed: what is there, or on the far end of a link, may be\n")
+		fmt.Fprintf(w, "  someone's data, and deleting it is not a call doctor should make on\n")
+		fmt.Fprintf(w, "  your behalf.\n")
 
 	case errors.Is(err, paths.ErrEntireDirUnreadable):
 		fmt.Fprintf(w, "%s: UNREADABLE\n", paths.EntireDir)

--- a/cmd/entire/cli/entiredir_guard_test.go
+++ b/cmd/entire/cli/entiredir_guard_test.go
@@ -457,8 +457,10 @@ func TestEntireDirRemedyMatchesTheCondition(t *testing.T) {
 	t.Parallel()
 
 	wrongType := fmt.Errorf("/repo/.entire is a symbolic link, %w", paths.ErrEntireDirNotDirectory)
-	symlinkedEntry := fmt.Errorf("/repo/.entire/settings.local.json %w to /elsewhere.json",
-		paths.ErrEntireDirSymlinkedEntry)
+	symlinkedEntry := fmt.Errorf("/repo/.entire/settings.local.json is a symbolic link to /elsewhere.json, %w",
+		paths.ErrEntireDirUnsupportedEntry)
+	pipedEntry := fmt.Errorf("/repo/.entire/settings.json is a named pipe, %w",
+		paths.ErrEntireDirUnsupportedEntry)
 	unreadable := fmt.Errorf("/repo/.entire %w: %w", paths.ErrEntireDirUnreadable, fs.ErrPermission)
 	unresolved := fmt.Errorf("%w, so .entire cannot be verified: %w",
 		paths.ErrRepositoryUnresolved, errors.New("fatal: detected dubious ownership"))
@@ -482,6 +484,14 @@ func TestEntireDirRemedyMatchesTheCondition(t *testing.T) {
 			// told it is not one names the wrong problem.
 			name:    "symlinked entry points at the entry",
 			err:     symlinkedEntry,
+			want:    []string{"replace it with a real file or directory"},
+			exclude: []string{"safe.directory", "PATH", "ownership", "replace it with a real directory"},
+		},
+		{
+			// An entry can be unsupported without being a link, and the remedy
+			// is the same one. The wording must not assume a far end to inspect.
+			name:    "unsupported entry that is not a link shares the remedy",
+			err:     pipedEntry,
 			want:    []string{"replace it with a real file or directory"},
 			exclude: []string{"safe.directory", "PATH", "ownership", "replace it with a real directory"},
 		},
@@ -600,8 +610,8 @@ func TestCheckEntireDirBeforeRun_SymlinkedEntryFailsGuardedCommand(t *testing.T)
 			if safe {
 				t.Error("checkEntireDirBeforeRun reported the path safe")
 			}
-			if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
-				t.Errorf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+			if !errors.Is(err, paths.ErrEntireDirUnsupportedEntry) {
+				t.Errorf("error does not wrap ErrEntireDirUnsupportedEntry: %v", err)
 			}
 			if report := stderr.String(); !strings.Contains(report, entry) {
 				t.Errorf("stderr does not name the offending entry:\n%s", report)
@@ -624,8 +634,8 @@ func TestLoadEntireSettings_RefusesSymlinkedSettingsFile(t *testing.T) {
 			if err == nil {
 				t.Fatalf("LoadEntireSettings read settings through a symlinked %s", entry)
 			}
-			if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
-				t.Errorf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+			if !errors.Is(err, paths.ErrEntireDirUnsupportedEntry) {
+				t.Errorf("error does not wrap ErrEntireDirUnsupportedEntry: %v", err)
 			}
 		})
 	}
@@ -658,8 +668,8 @@ func TestLoadEntireSettings_RefusesSettingsSymlinkedWithinEntireDir(t *testing.T
 	if err == nil {
 		t.Fatal("LoadEntireSettings read settings through a link pointing inside .entire")
 	}
-	if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
-		t.Errorf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+	if !errors.Is(err, paths.ErrEntireDirUnsupportedEntry) {
+		t.Errorf("error does not wrap ErrEntireDirUnsupportedEntry: %v", err)
 	}
 }
 
@@ -698,8 +708,8 @@ func TestDoctor_ReportsSymlinkedEntireDirEntry(t *testing.T) {
 			if err == nil {
 				t.Fatalf("`entire %s` succeeded on a repo with a symlinked .entire entry", name)
 			}
-			if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
-				t.Fatalf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+			if !errors.Is(err, paths.ErrEntireDirUnsupportedEntry) {
+				t.Fatalf("error does not wrap ErrEntireDirUnsupportedEntry: %v", err)
 			}
 
 			report := stdout.String() + stderr.String()

--- a/cmd/entire/cli/entiredir_guard_test.go
+++ b/cmd/entire/cli/entiredir_guard_test.go
@@ -457,6 +457,8 @@ func TestEntireDirRemedyMatchesTheCondition(t *testing.T) {
 	t.Parallel()
 
 	wrongType := fmt.Errorf("/repo/.entire is a symbolic link, %w", paths.ErrEntireDirNotDirectory)
+	symlinkedEntry := fmt.Errorf("/repo/.entire/settings.local.json %w to /elsewhere.json",
+		paths.ErrEntireDirSymlinkedEntry)
 	unreadable := fmt.Errorf("/repo/.entire %w: %w", paths.ErrEntireDirUnreadable, fs.ErrPermission)
 	unresolved := fmt.Errorf("%w, so .entire cannot be verified: %w",
 		paths.ErrRepositoryUnresolved, errors.New("fatal: detected dubious ownership"))
@@ -472,7 +474,16 @@ func TestEntireDirRemedyMatchesTheCondition(t *testing.T) {
 			name:    "wrong file type points at the path",
 			err:     wrongType,
 			want:    []string{"replace it with a real directory"},
-			exclude: []string{"safe.directory", "PATH", "permissions"},
+			exclude: []string{"safe.directory", "PATH", "permissions", "real file or directory"},
+		},
+		{
+			// Shares the wrong-type row's shape but not its sentence:
+			// settings.local.json is not required to be a directory, so being
+			// told it is not one names the wrong problem.
+			name:    "symlinked entry points at the entry",
+			err:     symlinkedEntry,
+			want:    []string{"replace it with a real file or directory"},
+			exclude: []string{"safe.directory", "PATH", "ownership", "replace it with a real directory"},
 		},
 		{
 			name:    "unreadable points at the filesystem",
@@ -484,14 +495,17 @@ func TestEntireDirRemedyMatchesTheCondition(t *testing.T) {
 			name:    "unresolved repository points at git",
 			err:     unresolved,
 			want:    []string{"safe.directory"},
-			exclude: []string{"replace it with a real directory"},
+			exclude: []string{"replace it with a real directory", "real file or directory"},
 		},
 		{
 			name: "unclassified invents no remedy",
 			err:  unknown,
 			// No remedy can be right for an error nobody classified, and a
 			// wrong one costs more than none.
-			exclude: []string{"safe.directory", "replace it with a real directory", "ownership"},
+			exclude: []string{
+				"safe.directory", "replace it with a real directory",
+				"real file or directory", "ownership",
+			},
 		},
 	}
 
@@ -525,5 +539,210 @@ func TestEntireDirRemedyMatchesTheCondition(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// symlinkEntireDirEntry builds a repo whose `.entire` is a real directory
+// holding one symlinked entry, points the process at it, and returns the
+// symlink's target. Named entries are the ones Entire actually reads and
+// writes, so callers pass the one whose redirection they care about.
+//
+// Not parallel: t.Chdir is process-global, and the CWD is what the
+// worktree-root resolution reads.
+func newRepoWithSymlinkedEntireDirEntry(t *testing.T, entry string) (target string) {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+
+	entireDir := filepath.Join(repoDir, paths.EntireDir)
+	if err := os.Mkdir(entireDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	target = filepath.Join(t.TempDir(), "elsewhere")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(entireDir, entry)); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	return target
+}
+
+// A real `.entire` holding a redirected entry is the case a check that stopped
+// at `.entire` itself waves through, which is the whole reason the scan goes one
+// level down.
+func TestCheckEntireDirBeforeRun_SymlinkedEntryFailsGuardedCommand(t *testing.T) {
+	for _, entry := range []string{
+		"settings.json",
+		"settings.local.json",
+		"metadata",
+		"logs",
+		"tmp",
+	} {
+		t.Run(entry, func(t *testing.T) {
+			newRepoWithSymlinkedEntireDirEntry(t, entry)
+
+			var stderr bytes.Buffer
+			cmd := &cobra.Command{Use: "status"}
+			cmd.SetContext(context.Background())
+			cmd.SetErr(&stderr)
+
+			safe, err := checkEntireDirBeforeRun(cmd)
+			if err == nil {
+				t.Fatalf("checkEntireDirBeforeRun accepted a symlinked %s", entry)
+			}
+			if safe {
+				t.Error("checkEntireDirBeforeRun reported the path safe")
+			}
+			if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
+				t.Errorf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+			}
+			if report := stderr.String(); !strings.Contains(report, entry) {
+				t.Errorf("stderr does not name the offending entry:\n%s", report)
+			}
+		})
+	}
+}
+
+// The settings files are the ones with teeth: settings.local.json names the
+// command Entire executes at pre-push, and both decide what is redacted before
+// it is committed. os.OpenRoot, which the loader already opens them through,
+// refuses only a link that leaves `.entire` — so the in-directory case below is
+// the one it lets past.
+func TestLoadEntireSettings_RefusesSymlinkedSettingsFile(t *testing.T) {
+	for _, entry := range []string{"settings.json", "settings.local.json"} {
+		t.Run(entry, func(t *testing.T) {
+			newRepoWithSymlinkedEntireDirEntry(t, entry)
+
+			_, err := LoadEntireSettings(context.Background())
+			if err == nil {
+				t.Fatalf("LoadEntireSettings read settings through a symlinked %s", entry)
+			}
+			if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
+				t.Errorf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+			}
+		})
+	}
+}
+
+// Staying inside `.entire` is not the invariant. This is the case os.OpenRoot
+// confinement follows without complaint, so it needs its own coverage rather
+// than sharing the escaping-link cases above.
+func TestLoadEntireSettings_RefusesSettingsSymlinkedWithinEntireDir(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+
+	entireDir := filepath.Join(repoDir, paths.EntireDir)
+	if err := os.Mkdir(entireDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	planted := filepath.Join(entireDir, "planted.json")
+	if err := os.WriteFile(planted, []byte(`{"enabled":false}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(planted, filepath.Join(entireDir, "settings.local.json")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	_, err := LoadEntireSettings(context.Background())
+	if err == nil {
+		t.Fatal("LoadEntireSettings read settings through a link pointing inside .entire")
+	}
+	if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
+		t.Errorf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+	}
+}
+
+// A symlinked .entire/logs is the log sink itself being redirected, so the
+// refusal has to happen before anything is written — the target must come out
+// of this untouched.
+func TestNewLogger_RefusesSymlinkedLogsDir(t *testing.T) {
+	target := newRepoWithSymlinkedEntireDirEntry(t, "logs")
+
+	if _, err := newLogger(context.Background()); err == nil {
+		t.Fatal("newLogger built a logger through a symlinked .entire/logs")
+	}
+
+	entries, err := os.ReadDir(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("newLogger created %d entries in the symlink target", len(entries))
+	}
+}
+
+func TestDoctor_ReportsSymlinkedEntireDirEntry(t *testing.T) {
+	newRepoWithSymlinkedEntireDirEntry(t, "settings.local.json")
+
+	for _, args := range [][]string{{"doctor"}, {"doctor", "logs"}, {"doctor", "bundle"}} {
+		name := strings.Join(args, " ")
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			root := NewRootCmd()
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs(args)
+
+			err := root.ExecuteContext(context.Background())
+			if err == nil {
+				t.Fatalf("`entire %s` succeeded on a repo with a symlinked .entire entry", name)
+			}
+			if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
+				t.Fatalf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+			}
+
+			report := stdout.String() + stderr.String()
+			for _, want := range []string{"symbolic link", "settings.local.json"} {
+				if !strings.Contains(report, want) {
+					t.Errorf("report is missing %q:\n%s", want, report)
+				}
+			}
+		})
+	}
+}
+
+// Everything Entire itself puts under `.entire` is a real file or directory, so
+// a populated repo has to pass. Without this, the scan is one stray symlink in
+// our own layout away from failing every command in every repo.
+func TestCheckEntireDirBeforeRun_PopulatedEntireDirIsSafe(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+
+	entireDir := filepath.Join(repoDir, paths.EntireDir)
+	for _, sub := range []string{"", "logs", "metadata", "tmp", "runners", "redactors"} {
+		if err := os.Mkdir(filepath.Join(entireDir, sub), 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, file := range []string{".gitignore", "settings.json", "settings.local.json"} {
+		if err := os.WriteFile(filepath.Join(entireDir, file), []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	cmd := &cobra.Command{Use: "status"}
+	cmd.SetContext(context.Background())
+
+	safe, err := checkEntireDirBeforeRun(cmd)
+	if err != nil {
+		t.Fatalf("checkEntireDirBeforeRun on a populated .entire: %v", err)
+	}
+	if !safe {
+		t.Error("a populated .entire directory was not reported safe")
 	}
 }

--- a/cmd/entire/cli/integration_test/entiredir_guard_test.go
+++ b/cmd/entire/cli/integration_test/entiredir_guard_test.go
@@ -181,3 +181,133 @@ func dirEntryNames(t *testing.T, dir string) []string {
 	}
 	return names
 }
+
+// symlinkEntireDirEntry leaves `.entire` a real directory and replaces one
+// entry inside it with a symlink, creating the directory if the repo has none
+// yet. Returns the directory the symlink points at.
+//
+// This is the shape a check that stopped at `.entire` itself waves through, and
+// the one a pull request can deliver: git records symlinks, so the entry arrives
+// by checkout in every clone.
+func symlinkEntireDirEntry(t *testing.T, repoDir, entry string) string {
+	t.Helper()
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("symlink harness only runs on Unix")
+	}
+
+	entireDir := filepath.Join(repoDir, paths.EntireDir)
+	if err := os.MkdirAll(entireDir, 0o750); err != nil {
+		t.Fatalf("create %s: %v", entireDir, err)
+	}
+	link := filepath.Join(entireDir, entry)
+	if err := os.RemoveAll(link); err != nil {
+		t.Fatalf("clear %s: %v", link, err)
+	}
+	target := filepath.Join(t.TempDir(), "entry-elsewhere")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatalf("create %s: %v", target, err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	return target
+}
+
+func TestEntireDirSymlinkedEntry_GuardedCommandsStop(t *testing.T) {
+	t.Parallel()
+
+	// One per entry Entire actually reads or writes: the two settings files,
+	// the transcript store, the log sink, and the scratch directory.
+	for _, entry := range []string{
+		"settings.json",
+		"settings.local.json",
+		"metadata",
+		"logs",
+		"tmp",
+	} {
+		t.Run(entry, func(t *testing.T) {
+			t.Parallel()
+			env := NewRepoWithCommit(t)
+			symlinkEntireDirEntry(t, env.RepoDir, entry)
+
+			exitCode, output := runEntireInRepo(t, env.RepoDir, "status")
+			if exitCode == 0 {
+				t.Fatalf("`entire status` exited 0 with a symlinked %s:\n%s", entry, output)
+			}
+			if !strings.Contains(output, "symbolic link") {
+				t.Errorf("output does not say what was found:\n%s", output)
+			}
+			if !strings.Contains(output, entry) {
+				t.Errorf("output does not name the offending entry %q:\n%s", entry, output)
+			}
+		})
+	}
+}
+
+// The point of the settings half of the guard: a redirected settings file must
+// not be honoured. The planted file would turn Entire off, which is a visible,
+// silent-looking outcome — so a run that prints "disabled" instead of failing is
+// the exact regression this pins.
+func TestEntireDirSymlinkedEntry_RedirectedSettingsAreNotHonoured(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("symlink harness only runs on Unix")
+	}
+	entireDir := filepath.Join(env.RepoDir, paths.EntireDir)
+	if err := os.MkdirAll(entireDir, 0o750); err != nil {
+		t.Fatalf("create %s: %v", entireDir, err)
+	}
+	planted := filepath.Join(t.TempDir(), "planted.json")
+	if err := os.WriteFile(planted, []byte(`{"enabled":false}`), 0o600); err != nil {
+		t.Fatalf("write %s: %v", planted, err)
+	}
+	if err := os.Symlink(planted, filepath.Join(entireDir, "settings.local.json")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	exitCode, output := runEntireInRepo(t, env.RepoDir, "status")
+	if exitCode == 0 {
+		t.Fatalf("`entire status` exited 0 with a redirected settings.local.json:\n%s", output)
+	}
+	if !strings.Contains(output, "symbolic link") {
+		t.Errorf("output does not say what was found:\n%s", output)
+	}
+}
+
+func TestEntireDirSymlinkedEntry_DoctorReportsIt(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	symlinkEntireDirEntry(t, env.RepoDir, "settings.local.json")
+
+	exitCode, output := runEntireInRepo(t, env.RepoDir, "doctor")
+	if exitCode == 0 {
+		t.Fatalf("`entire doctor` exited 0 on a repo with a symlinked entry:\n%s", output)
+	}
+	if !strings.Contains(output, "BROKEN") {
+		t.Errorf("doctor did not report the problem:\n%s", output)
+	}
+	if !strings.Contains(output, "real file or directory") {
+		t.Errorf("doctor did not name the remedy:\n%s", output)
+	}
+	if !strings.Contains(output, "settings.local.json") {
+		t.Errorf("doctor did not name the offending entry:\n%s", output)
+	}
+}
+
+// A symlinked .entire/logs is the log sink redirected, so the refusal has to
+// land before anything is written there.
+func TestEntireDirSymlinkedEntry_NothingIsWrittenThroughIt(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	target := symlinkEntireDirEntry(t, env.RepoDir, "logs")
+
+	for _, args := range [][]string{{"status"}, {"version"}, {"doctor"}, {"session", "list"}} {
+		runEntireInRepo(t, env.RepoDir, args...)
+	}
+
+	if names := dirEntryNames(t, target); len(names) != 0 {
+		t.Errorf("entries were created through the symlinked .entire/logs: %v", names)
+	}
+}

--- a/cmd/entire/cli/paths/entiredir.go
+++ b/cmd/entire/cli/paths/entiredir.go
@@ -168,17 +168,30 @@ func firstUnsupportedEntry(dir string, entries []os.DirEntry) error {
 // already requires local code execution, at which point this check is not what
 // stands in the way. Tolerating the ambiguous bit is the cheaper mistake.
 //
-// The bit is tolerated only on its own: anything carrying a type we do reject
-// is rejected whatever else it carries.
+// So the bit is masked off rather than matched on, because it does not arrive
+// alone. Go only skips ModeDir for a reparse tag that is a name surrogate (the
+// !isReparseTagNameSurrogate branch of the same function), and the cloud tags
+// are not surrogates, so a placeholder directory reports ModeDir|ModeIrregular
+// while a junction, which is a surrogate, reports ModeIrregular by itself.
+// `.entire`'s own entries are mostly directories, so demanding the bit stand
+// alone would reject `metadata`, `logs`, and `tmp` in exactly the synced folder
+// this exception exists to keep working.
+//
+// What masking does not do is excuse the rest of the field: anything carrying a
+// type we reject is rejected whatever else it carries, ModeIrregular included.
+//
+// The remainder is then compared against the whole type field, fs.FileMode.
+// Type(), and not tested with IsRegular and IsDir. Those two examine single
+// bits rather than the field: IsDir is `mode&ModeDir != 0`. A mode carrying
+// ModeDir alongside ModeSymlink or ModeNamedPipe therefore satisfies IsDir, as
+// does the all-bits-set mode os.ReadDir's direntType returns when a type cannot
+// be resolved at all. An allowlist a rejected type can enter by also setting an
+// accepted bit is not an allowlist. Permission bits and the non-type bits above
+// ModeType (setuid, sticky, and friends) sit outside the field, so they do not
+// affect the answer, which is what IsRegular already did.
 func unsupportedEntryType(mode fs.FileMode) bool {
-	switch {
-	case mode.IsRegular(), mode.IsDir():
-		return false
-	case mode == fs.ModeIrregular:
-		return false
-	default:
-		return true
-	}
+	t := mode.Type() &^ fs.ModeIrregular
+	return t != 0 && t != fs.ModeDir
 }
 
 // unsupportedEntryError reports that path is a type Entire does not put under

--- a/cmd/entire/cli/paths/entiredir.go
+++ b/cmd/entire/cli/paths/entiredir.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 )
 
-// The three ways validating `.entire` can fail. Each is identified positively
+// The four ways validating `.entire` can fail. Each is identified positively
 // and carries a different remedy, which is why they are separate sentinels
 // rather than one error plus an else branch: callers print the fix, and telling
 // someone to reinstall git because their filesystem returned EACCES sends them
@@ -19,6 +19,13 @@ var (
 	// ErrEntireDirNotDirectory reports that `.entire` exists and is not a real
 	// directory. The remedy is to inspect and replace the path.
 	ErrEntireDirNotDirectory = errors.New("not a directory")
+
+	// ErrEntireDirSymlinkedEntry reports that an entry directly under `.entire`
+	// is a symbolic link. The remedy is to inspect that entry and replace it,
+	// which is the same shape as ErrEntireDirNotDirectory's but not the same
+	// sentence: `.entire/settings.json` is not required to be a directory, so
+	// telling someone it is not one names the wrong problem.
+	ErrEntireDirSymlinkedEntry = errors.New("is a symbolic link")
 
 	// ErrEntireDirUnreadable reports that `.entire` could not be inspected at
 	// all — a permission failure, an I/O error, a dead mount. Nothing is known
@@ -34,13 +41,26 @@ var (
 
 // ValidateEntireDirAt reports whether worktreeRoot's `.entire` is safe to read
 // and write through. It is safe when the path is absent (Entire is not enabled
-// here yet, or `enable` is about to create it) or is a real directory. Anything
-// else is a broken repo and the caller must not touch the path.
+// here yet, or `enable` is about to create it), or is a real directory whose own
+// entries are real files and directories. Anything else is a broken repo and
+// the caller must not touch the path.
 //
 // The stat is Lstat, not Stat, so a symlink is rejected even when it points at
 // a perfectly good directory. `.entire` holds session metadata, transcripts,
 // and the settings that decide what gets redacted before it is committed, so a
 // path someone else controls the far end of is not a path we write through.
+//
+// The same reasoning covers one level down, so the entries directly inside are
+// checked too: a symlinked `.entire/metadata` redirects transcripts, and a
+// symlinked `.entire/settings.local.json` redirects the file that names the
+// command Entire executes at pre-push. See validateEntireDirEntries for why the
+// scan stops there.
+//
+// The settings package refuses a symlinked settings file at the read itself as
+// well (readConfined). Neither check subsumes the other: this one stops a
+// command before it does anything, and covers the subdirectories no settings
+// read touches, while that one covers the many callers that reach settings.Load
+// without passing through a command's pre-run.
 //
 // A stat error other than "not exist" is also a failure. It is not evidence
 // that the invariant is violated, but neither is it evidence that it holds, and
@@ -54,11 +74,103 @@ func ValidateEntireDirAt(worktreeRoot string) error {
 		return nil
 	case err != nil:
 		return fmt.Errorf("%s %w: %w", path, ErrEntireDirUnreadable, err)
-	case info.Mode().IsDir():
+	case !info.Mode().IsDir():
+		return fmt.Errorf("%s is %s, %w", path, describeMode(info.Mode()), ErrEntireDirNotDirectory)
+	}
+
+	return validateEntireDirEntries(path)
+}
+
+// validateEntireDirEntries rejects a symbolic link sitting directly inside a
+// `.entire` already established to be a real directory.
+//
+// The entries one level down are Entire's own — `logs`, `metadata`, `tmp`, and
+// the two settings files — so the reasoning that rejects a symlinked `.entire`
+// applies to them unchanged: the far end is outside Entire's control, and for
+// the settings files it decides what may be committed.
+//
+// Deliberately not recursive, and not a stricter type check. Walking deeper
+// would mean traversing every session's transcripts on every command, and the
+// checkpoint writer already skips symlinks as it walks the metadata directory.
+// Entries of some other wrong type are also left alone: a FIFO at
+// `.entire/settings.json` is a hang rather than a redirection, which is a
+// different failure with a different fix.
+func validateEntireDirEntries(dir string) error {
+	entries, err := os.ReadDir(dir)
+
+	// Checked before err, not after. os.ReadDir returns what it managed to read
+	// alongside a partial-read error, and a symlink among those entries is a
+	// positive finding — a stronger statement than "the listing failed", and
+	// one with an actionable remedy.
+	if symlinkErr := firstSymlinkedEntry(dir, entries); symlinkErr != nil {
+		return symlinkErr
+	}
+	if err != nil {
+		return fmt.Errorf("%s %w: %w", dir, ErrEntireDirUnreadable, err)
+	}
+	return nil
+}
+
+// firstSymlinkedEntry names the first symlink among entries and counts the
+// rest, or returns nil when there is none.
+//
+// One error naming one entry, rather than one per entry: the remedy is the same
+// for all of them, and a user who has to rerun the command once per planted
+// link pays for our formatting choice. The named entry is the first in
+// os.ReadDir's sorted order, so the message is deterministic.
+//
+// No Lstat of our own. DirEntry.Type() comes from the directory read itself on
+// the platforms that report a type there, and where the filesystem does not,
+// os.ReadDir does the Lstat internally — skipping an entry that vanished
+// between the read and the stat, and surfacing any other failure as the
+// partial-read error validateEntireDirEntries reports. Adding an Lstat here
+// would reintroduce the vanished-entry race that os.ReadDir already handles.
+func firstSymlinkedEntry(dir string, entries []os.DirEntry) error {
+	var first string
+	others := 0
+	for _, entry := range entries {
+		if entry.Type()&fs.ModeSymlink == 0 {
+			continue
+		}
+		if first != "" {
+			others++
+			continue
+		}
+		first = filepath.Join(dir, entry.Name())
+	}
+	if first == "" {
 		return nil
 	}
 
-	return fmt.Errorf("%s is %s, %w", path, describeMode(info.Mode()), ErrEntireDirNotDirectory)
+	err := SymlinkedEntryError(first)
+	if others > 0 {
+		err = fmt.Errorf("%w%s", err, otherSymlinksClause(others, dir))
+	}
+	return err
+}
+
+// SymlinkedEntryError reports that path is a symbolic link, naming the target
+// when it can be read. A Readlink that fails leaves the entry named, which is
+// still enough to act on.
+//
+// Exported because this sentence has two producers — the `.entire` entry scan
+// here and the settings reader, which refuses a symlinked settings file at the
+// read itself (see readConfined in the settings package). One function so the
+// two cannot drift into describing the same condition differently.
+func SymlinkedEntryError(path string) error {
+	if target, err := os.Readlink(path); err == nil {
+		return fmt.Errorf("%s %w to %s", path, ErrEntireDirSymlinkedEntry, target)
+	}
+	return fmt.Errorf("%s %w", path, ErrEntireDirSymlinkedEntry)
+}
+
+// otherSymlinksClause accounts for symlinked entries beyond the one named.
+// Number and verb are built together so they cannot disagree.
+func otherSymlinksClause(n int, dir string) string {
+	if n == 1 {
+		return fmt.Sprintf(" (and 1 other entry under %s is too)", dir)
+	}
+	return fmt.Sprintf(" (and %d other entries under %s are too)", n, dir)
 }
 
 // RequireEntireDir validates the current worktree's `.entire`.
@@ -77,8 +189,9 @@ func ValidateEntireDirAt(worktreeRoot string) error {
 // ./.entire/settings.json — through the very symlink this exists to reject.
 // Refusing to run on a machine whose git is broken is the cheaper mistake.
 //
-// Deliberately not memoized. The Lstat is free next to the `git rev-parse` that
-// WorktreeRoot runs, and a cached "it was fine" is a stale answer in a
+// Deliberately not memoized. The Lstat and the one-level listing are free next
+// to the `git rev-parse` that WorktreeRoot runs — measured 8.2µs against a
+// ~millisecond subprocess — and a cached "it was fine" is a stale answer in a
 // long-lived process such as `entire mcp`.
 func RequireEntireDir(ctx context.Context) error {
 	root, err := WorktreeRoot(ctx)

--- a/cmd/entire/cli/paths/entiredir.go
+++ b/cmd/entire/cli/paths/entiredir.go
@@ -20,12 +20,13 @@ var (
 	// directory. The remedy is to inspect and replace the path.
 	ErrEntireDirNotDirectory = errors.New("not a directory")
 
-	// ErrEntireDirSymlinkedEntry reports that an entry directly under `.entire`
-	// is a symbolic link. The remedy is to inspect that entry and replace it,
-	// which is the same shape as ErrEntireDirNotDirectory's but not the same
-	// sentence: `.entire/settings.json` is not required to be a directory, so
-	// telling someone it is not one names the wrong problem.
-	ErrEntireDirSymlinkedEntry = errors.New("is a symbolic link")
+	// ErrEntireDirUnsupportedEntry reports that an entry directly under
+	// `.entire` is neither a regular file nor a directory. The remedy is to
+	// inspect that entry and replace it, which is the same shape as
+	// ErrEntireDirNotDirectory's but not the same sentence:
+	// `.entire/settings.json` is not required to be a directory, so telling
+	// someone it is not one names the wrong problem.
+	ErrEntireDirUnsupportedEntry = errors.New("not a regular file or directory")
 
 	// ErrEntireDirUnreadable reports that `.entire` could not be inspected at
 	// all — a permission failure, an I/O error, a dead mount. Nothing is known
@@ -51,10 +52,12 @@ var (
 // path someone else controls the far end of is not a path we write through.
 //
 // The same reasoning covers one level down, so the entries directly inside are
-// checked too: a symlinked `.entire/metadata` redirects transcripts, and a
+// checked too, and there the rule is an allowlist: Entire only ever creates
+// regular files and directories under `.entire`, so anything else arrived some
+// other way. A symlinked `.entire/metadata` redirects transcripts, and a
 // symlinked `.entire/settings.local.json` redirects the file that names the
 // command Entire executes at pre-push. See validateEntireDirEntries for why the
-// scan stops there.
+// scan stops there, and unsupportedEntryType for the one type it tolerates.
 //
 // The settings package refuses a symlinked settings file at the read itself as
 // well (readConfined). Neither check subsumes the other: this one stops a
@@ -81,29 +84,27 @@ func ValidateEntireDirAt(worktreeRoot string) error {
 	return validateEntireDirEntries(path)
 }
 
-// validateEntireDirEntries rejects a symbolic link sitting directly inside a
-// `.entire` already established to be a real directory.
+// validateEntireDirEntries rejects anything other than a regular file or a
+// directory sitting directly inside a `.entire` already established to be a
+// real directory.
 //
 // The entries one level down are Entire's own — `logs`, `metadata`, `tmp`, and
 // the two settings files — so the reasoning that rejects a symlinked `.entire`
 // applies to them unchanged: the far end is outside Entire's control, and for
 // the settings files it decides what may be committed.
 //
-// Deliberately not recursive, and not a stricter type check. Walking deeper
-// would mean traversing every session's transcripts on every command, and the
-// checkpoint writer already skips symlinks as it walks the metadata directory.
-// Entries of some other wrong type are also left alone: a FIFO at
-// `.entire/settings.json` is a hang rather than a redirection, which is a
-// different failure with a different fix.
+// Deliberately not recursive. Walking deeper would mean traversing every
+// session's transcripts on every command, and the checkpoint writer already
+// skips symlinks as it walks the metadata directory.
 func validateEntireDirEntries(dir string) error {
 	entries, err := os.ReadDir(dir)
 
 	// Checked before err, not after. os.ReadDir returns what it managed to read
-	// alongside a partial-read error, and a symlink among those entries is a
+	// alongside a partial-read error, and an unsupported entry among those is a
 	// positive finding — a stronger statement than "the listing failed", and
 	// one with an actionable remedy.
-	if symlinkErr := firstSymlinkedEntry(dir, entries); symlinkErr != nil {
-		return symlinkErr
+	if entryErr := firstUnsupportedEntry(dir, entries); entryErr != nil {
+		return entryErr
 	}
 	if err != nil {
 		return fmt.Errorf("%s %w: %w", dir, ErrEntireDirUnreadable, err)
@@ -111,12 +112,12 @@ func validateEntireDirEntries(dir string) error {
 	return nil
 }
 
-// firstSymlinkedEntry names the first symlink among entries and counts the
-// rest, or returns nil when there is none.
+// firstUnsupportedEntry names the first entry that is neither a regular file
+// nor a directory and counts the rest, or returns nil when there is none.
 //
 // One error naming one entry, rather than one per entry: the remedy is the same
 // for all of them, and a user who has to rerun the command once per planted
-// link pays for our formatting choice. The named entry is the first in
+// entry pays for our formatting choice. The named entry is the first in
 // os.ReadDir's sorted order, so the message is deterministic.
 //
 // No Lstat of our own. DirEntry.Type() comes from the directory read itself on
@@ -125,28 +126,70 @@ func validateEntireDirEntries(dir string) error {
 // between the read and the stat, and surfacing any other failure as the
 // partial-read error validateEntireDirEntries reports. Adding an Lstat here
 // would reintroduce the vanished-entry race that os.ReadDir already handles.
-func firstSymlinkedEntry(dir string, entries []os.DirEntry) error {
-	var first string
+func firstUnsupportedEntry(dir string, entries []os.DirEntry) error {
+	var first os.DirEntry
 	others := 0
 	for _, entry := range entries {
-		if entry.Type()&fs.ModeSymlink == 0 {
+		if !unsupportedEntryType(entry.Type()) {
 			continue
 		}
-		if first != "" {
+		if first != nil {
 			others++
 			continue
 		}
-		first = filepath.Join(dir, entry.Name())
+		first = entry
 	}
-	if first == "" {
+	if first == nil {
 		return nil
 	}
 
-	err := SymlinkedEntryError(first)
+	err := unsupportedEntryError(filepath.Join(dir, first.Name()), first.Type())
 	if others > 0 {
-		err = fmt.Errorf("%w%s", err, otherSymlinksClause(others, dir))
+		err = fmt.Errorf("%w%s", err, otherUnsupportedClause(others, dir))
 	}
 	return err
+}
+
+// unsupportedEntryType reports whether an entry directly under `.entire` is a
+// type Entire never creates there. It is an allowlist — regular files and
+// directories are the whole of Entire's own layout — so a mode bit nobody has
+// considered yet is refused rather than waved through, which is the safer
+// direction for a path holding transcripts and the redaction settings.
+//
+// fs.ModeIrregular is the deliberate exception, and it has to be an exception
+// rather than an allowlist member because Windows overloads it. Go maps every
+// reparse tag it has no category for onto that one bit (see the default arm of
+// fileStat.mode in os/types_windows.go), which lands NTFS directory junctions
+// and OneDrive Files On-Demand placeholders in the same bucket. Refusing the
+// bucket would hard-fail every command in a repo inside a synced folder, with a
+// remedy the user cannot act on, and the placeholder arrives with nobody
+// attacking anything. The junction it would also catch cannot arrive by
+// checkout at all — git has no tree-object mode for one — so planting it
+// already requires local code execution, at which point this check is not what
+// stands in the way. Tolerating the ambiguous bit is the cheaper mistake.
+//
+// The bit is tolerated only on its own: anything carrying a type we do reject
+// is rejected whatever else it carries.
+func unsupportedEntryType(mode fs.FileMode) bool {
+	switch {
+	case mode.IsRegular(), mode.IsDir():
+		return false
+	case mode == fs.ModeIrregular:
+		return false
+	default:
+		return true
+	}
+}
+
+// unsupportedEntryError reports that path is a type Entire does not put under
+// `.entire`, naming what was found. A symlink goes through SymlinkedEntryError
+// so that the message also names where it points, which is what the user needs
+// in order to decide what to do with the far end.
+func unsupportedEntryError(path string, mode fs.FileMode) error {
+	if mode&fs.ModeSymlink != 0 {
+		return SymlinkedEntryError(path)
+	}
+	return fmt.Errorf("%s is %s, %w", path, describeMode(mode), ErrEntireDirUnsupportedEntry)
 }
 
 // SymlinkedEntryError reports that path is a symbolic link, naming the target
@@ -159,18 +202,20 @@ func firstSymlinkedEntry(dir string, entries []os.DirEntry) error {
 // two cannot drift into describing the same condition differently.
 func SymlinkedEntryError(path string) error {
 	if target, err := os.Readlink(path); err == nil {
-		return fmt.Errorf("%s %w to %s", path, ErrEntireDirSymlinkedEntry, target)
+		return fmt.Errorf("%s is a symbolic link to %s, %w", path, target, ErrEntireDirUnsupportedEntry)
 	}
-	return fmt.Errorf("%s %w", path, ErrEntireDirSymlinkedEntry)
+	return fmt.Errorf("%s is a symbolic link, %w", path, ErrEntireDirUnsupportedEntry)
 }
 
-// otherSymlinksClause accounts for symlinked entries beyond the one named.
-// Number and verb are built together so they cannot disagree.
-func otherSymlinksClause(n int, dir string) string {
+// otherUnsupportedClause accounts for unsupported entries beyond the one named.
+// Number and verb are built together so they cannot disagree, and the wording
+// is type-neutral because the entries it counts need not share the named one's
+// type.
+func otherUnsupportedClause(n int, dir string) string {
 	if n == 1 {
-		return fmt.Sprintf(" (and 1 other entry under %s is too)", dir)
+		return fmt.Sprintf(" (and 1 other entry under %s is unsupported too)", dir)
 	}
-	return fmt.Sprintf(" (and %d other entries under %s are too)", n, dir)
+	return fmt.Sprintf(" (and %d other entries under %s are unsupported too)", n, dir)
 }
 
 // RequireEntireDir validates the current worktree's `.entire`.
@@ -205,9 +250,9 @@ func RequireEntireDir(ctx context.Context) error {
 	}
 }
 
-// describeMode names what was found. The sentinel supplies the "not a
-// directory" half of the sentence, so these read as the first half of "X is a
-// symbolic link, not a directory".
+// describeMode names what was found. The sentinel supplies the rest of the
+// sentence, so these read as the first half of "X is a symbolic link, not a
+// directory" or "X is a named pipe, not a regular file or directory".
 func describeMode(mode fs.FileMode) string {
 	switch {
 	case mode&fs.ModeSymlink != 0:

--- a/cmd/entire/cli/paths/entiredir_test.go
+++ b/cmd/entire/cli/paths/entiredir_test.go
@@ -167,6 +167,265 @@ func TestValidateEntireDirAt_MessageNamesPathAndType(t *testing.T) {
 	}
 }
 
+// makeEntireDir creates a real `.entire` under root and returns its path, so
+// the entry-level tests below start from a directory that already satisfies the
+// first phase of the check.
+func makeEntireDir(t *testing.T, root string) string {
+	t.Helper()
+	entire := filepath.Join(root, EntireDir)
+	if err := os.Mkdir(entire, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	return entire
+}
+
+// The entries directly under `.entire` are Entire's too, so a symlink among
+// them is the same problem one level down: the far end is outside Entire's
+// control, and for the settings files it decides what gets redacted before it
+// is committed.
+//
+// The check is deliberately shallow, which the last case pins down.
+func TestValidateEntireDirAt_SymlinkedEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, root, entire string)
+		wantErr bool
+	}{
+		{
+			name:  "empty directory is fine",
+			setup: func(*testing.T, string, string) {},
+		},
+		{
+			name: "real subdirectories and settings files are fine",
+			setup: func(t *testing.T, _, entire string) {
+				t.Helper()
+				for _, sub := range []string{"logs", "metadata", "tmp"} {
+					if err := os.Mkdir(filepath.Join(entire, sub), 0o750); err != nil {
+						t.Fatal(err)
+					}
+				}
+				for _, file := range []string{"settings.json", "settings.local.json"} {
+					if err := os.WriteFile(filepath.Join(entire, file), []byte("{}"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+		},
+		{
+			name: "symlinked settings.json is rejected",
+			setup: func(t *testing.T, root, entire string) {
+				t.Helper()
+				target := filepath.Join(root, "elsewhere.json")
+				if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				symlinkOrSkip(t, target, filepath.Join(entire, "settings.json"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "symlinked settings.local.json is rejected",
+			setup: func(t *testing.T, root, entire string) {
+				t.Helper()
+				target := filepath.Join(root, "elsewhere.json")
+				if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				symlinkOrSkip(t, target, filepath.Join(entire, "settings.local.json"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "symlinked subdirectory is rejected",
+			setup: func(t *testing.T, root, entire string) {
+				t.Helper()
+				target := filepath.Join(root, "elsewhere")
+				if err := os.Mkdir(target, 0o750); err != nil {
+					t.Fatal(err)
+				}
+				symlinkOrSkip(t, target, filepath.Join(entire, "metadata"))
+			},
+			wantErr: true,
+		},
+		{
+			// os.OpenRoot confinement, which the settings loader already
+			// applies, follows a symlink whose target stays inside the root.
+			// Staying inside is not the invariant: the entry is still not the
+			// file Entire owns.
+			name: "symlink whose target is inside .entire is rejected",
+			setup: func(t *testing.T, _, entire string) {
+				t.Helper()
+				target := filepath.Join(entire, "planted.json")
+				if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				symlinkOrSkip(t, target, filepath.Join(entire, "settings.local.json"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "dangling symlink is rejected",
+			setup: func(t *testing.T, root, entire string) {
+				t.Helper()
+				symlinkOrSkip(t, filepath.Join(root, "missing"), filepath.Join(entire, "settings.json"))
+			},
+			wantErr: true,
+		},
+		{
+			// The scan stops at `.entire`'s own entries. Deeper paths are
+			// walked by the checkpoint writer, which skips symlinks itself, and
+			// scanning them here would mean walking every session's transcripts
+			// on every command.
+			name: "a symlink one level deeper is not this check's business",
+			setup: func(t *testing.T, root, entire string) {
+				t.Helper()
+				metadata := filepath.Join(entire, "metadata")
+				if err := os.Mkdir(metadata, 0o750); err != nil {
+					t.Fatal(err)
+				}
+				symlinkOrSkip(t, root, filepath.Join(metadata, "session"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			entire := makeEntireDir(t, root)
+			tt.setup(t, root, entire)
+
+			err := ValidateEntireDirAt(root)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ValidateEntireDirAt returned nil, want error")
+				}
+				if !errors.Is(err, ErrEntireDirSymlinkedEntry) {
+					t.Errorf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+				}
+				if errors.Is(err, ErrEntireDirNotDirectory) {
+					t.Errorf("a symlinked entry must not read as `.entire` being the wrong type: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateEntireDirAt: %v", err)
+			}
+		})
+	}
+}
+
+// The user acts on the message, and acting means finding the link and deciding
+// what to do with what is on the far end. Both halves have to be in it.
+func TestValidateEntireDirAt_SymlinkedEntryMessageNamesEntryAndTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	entire := makeEntireDir(t, root)
+	target := filepath.Join(root, "elsewhere.json")
+	if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entry := filepath.Join(entire, "settings.local.json")
+	symlinkOrSkip(t, target, entry)
+
+	err := ValidateEntireDirAt(root)
+	if err == nil {
+		t.Fatal("ValidateEntireDirAt returned nil, want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, entry) {
+		t.Errorf("message %q does not name the entry %q", msg, entry)
+	}
+	if !strings.Contains(msg, target) {
+		t.Errorf("message %q does not name the link target %q", msg, target)
+	}
+	if !strings.Contains(msg, "symbolic link") {
+		t.Errorf("message %q does not say what was found", msg)
+	}
+}
+
+// A repo with several planted links should not cost the user one round trip per
+// link, so the message names one and counts the rest. The named one is the
+// first in os.ReadDir's sorted order, which keeps the message deterministic.
+func TestValidateEntireDirAt_SymlinkedEntriesCountTheRest(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	entire := makeEntireDir(t, root)
+	for _, name := range []string{"logs", "metadata", "settings.json"} {
+		symlinkOrSkip(t, root, filepath.Join(entire, name))
+	}
+
+	err := ValidateEntireDirAt(root)
+	if err == nil {
+		t.Fatal("ValidateEntireDirAt returned nil, want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, filepath.Join(entire, "logs")) {
+		t.Errorf("message %q does not name the first entry in sorted order", msg)
+	}
+	if !strings.Contains(msg, "2 other entries") {
+		t.Errorf("message %q does not count the remaining entries", msg)
+	}
+}
+
+// A single extra link reads as "1 other entry", not "1 other entries".
+func TestValidateEntireDirAt_SymlinkedEntriesCountIsSingular(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	entire := makeEntireDir(t, root)
+	for _, name := range []string{"logs", "metadata"} {
+		symlinkOrSkip(t, root, filepath.Join(entire, name))
+	}
+
+	err := ValidateEntireDirAt(root)
+	if err == nil {
+		t.Fatal("ValidateEntireDirAt returned nil, want error")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "1 other entry") {
+		t.Errorf("message %q does not count the remaining entry in the singular", msg)
+	}
+}
+
+// `.entire` is a real directory but its contents cannot be listed. That is not
+// evidence the entries are clean, and the remedy is the filesystem's, so it
+// joins the existing unreadable condition rather than becoming a fourth one.
+func TestValidateEntireDirAt_UnlistableDirectoryIsUnreadable(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == osWindows {
+		t.Skip("directory permission bits do not gate readdir on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission bits")
+	}
+
+	root := t.TempDir()
+	entire := makeEntireDir(t, root)
+	if err := os.Chmod(entire, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(entire, 0o750); err != nil {
+			t.Logf("restore permissions on %s: %v", entire, err)
+		}
+	})
+
+	err := ValidateEntireDirAt(root)
+	if !errors.Is(err, ErrEntireDirUnreadable) {
+		t.Fatalf("want ErrEntireDirUnreadable, got %v", err)
+	}
+	if errors.Is(err, ErrEntireDirNotDirectory) || errors.Is(err, ErrEntireDirSymlinkedEntry) {
+		t.Errorf("a listing failure must not read as a verdict about the contents: %v", err)
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("the underlying cause was dropped: %v", err)
+	}
+}
+
 // Outside a git repository there is no worktree root, so there is no `.entire`
 // to validate and the check is skipped. Commands that need a repository report
 // its absence themselves, with a message about the repository rather than one
@@ -405,6 +664,24 @@ func TestEntireDirErrorsAreDistinguishable(t *testing.T) {
 		}
 		if !errors.Is(err, fs.ErrPermission) {
 			t.Errorf("the underlying cause was dropped: %v", err)
+		}
+	})
+
+	t.Run("symlinked entry", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		entire := makeEntireDir(t, root)
+		symlinkOrSkip(t, root, filepath.Join(entire, "metadata"))
+
+		err := ValidateEntireDirAt(root)
+		if !errors.Is(err, ErrEntireDirSymlinkedEntry) {
+			t.Fatalf("want ErrEntireDirSymlinkedEntry, got %v", err)
+		}
+		if errors.Is(err, ErrEntireDirNotDirectory) {
+			t.Errorf("a symlinked entry must not read as `.entire` being the wrong type: %v", err)
+		}
+		if errors.Is(err, ErrEntireDirUnreadable) {
+			t.Errorf("a symlinked entry must not read as unreadable: %v", err)
 		}
 	})
 }

--- a/cmd/entire/cli/paths/entiredir_test.go
+++ b/cmd/entire/cli/paths/entiredir_test.go
@@ -302,8 +302,8 @@ func TestValidateEntireDirAt_SymlinkedEntries(t *testing.T) {
 				if err == nil {
 					t.Fatal("ValidateEntireDirAt returned nil, want error")
 				}
-				if !errors.Is(err, ErrEntireDirSymlinkedEntry) {
-					t.Errorf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+				if !errors.Is(err, ErrEntireDirUnsupportedEntry) {
+					t.Errorf("error does not wrap ErrEntireDirUnsupportedEntry: %v", err)
 				}
 				if errors.Is(err, ErrEntireDirNotDirectory) {
 					t.Errorf("a symlinked entry must not read as `.entire` being the wrong type: %v", err)
@@ -418,7 +418,7 @@ func TestValidateEntireDirAt_UnlistableDirectoryIsUnreadable(t *testing.T) {
 	if !errors.Is(err, ErrEntireDirUnreadable) {
 		t.Fatalf("want ErrEntireDirUnreadable, got %v", err)
 	}
-	if errors.Is(err, ErrEntireDirNotDirectory) || errors.Is(err, ErrEntireDirSymlinkedEntry) {
+	if errors.Is(err, ErrEntireDirNotDirectory) || errors.Is(err, ErrEntireDirUnsupportedEntry) {
 		t.Errorf("a listing failure must not read as a verdict about the contents: %v", err)
 	}
 	if !errors.Is(err, fs.ErrPermission) {
@@ -674,8 +674,8 @@ func TestEntireDirErrorsAreDistinguishable(t *testing.T) {
 		symlinkOrSkip(t, root, filepath.Join(entire, "metadata"))
 
 		err := ValidateEntireDirAt(root)
-		if !errors.Is(err, ErrEntireDirSymlinkedEntry) {
-			t.Fatalf("want ErrEntireDirSymlinkedEntry, got %v", err)
+		if !errors.Is(err, ErrEntireDirUnsupportedEntry) {
+			t.Fatalf("want ErrEntireDirUnsupportedEntry, got %v", err)
 		}
 		if errors.Is(err, ErrEntireDirNotDirectory) {
 			t.Errorf("a symlinked entry must not read as `.entire` being the wrong type: %v", err)

--- a/cmd/entire/cli/paths/entiredir_type_test.go
+++ b/cmd/entire/cli/paths/entiredir_type_test.go
@@ -1,0 +1,54 @@
+package paths
+
+import (
+	"io/fs"
+	"testing"
+)
+
+// The entries directly under `.entire` are Entire's own, and Entire only ever
+// creates regular files and directories there. Anything else arrived some other
+// way, so the check is an allowlist rather than a list of known-bad types: a
+// mode bit nobody has thought about yet is refused by default.
+//
+// ModeIrregular is the deliberate exception, and the reason it cannot be part
+// of the allowlist is that Windows overloads it. Go maps every reparse tag it
+// has no category for onto that single bit, which puts NTFS directory junctions
+// and OneDrive Files On-Demand placeholders in the same bucket. Refusing the
+// bucket would hard-fail every command in a repo inside a synced folder, and
+// the placeholder gets there without anyone attacking anything, while a
+// junction cannot arrive by checkout at all: git has no tree-object mode for
+// one. Tolerating the ambiguous bit is the cheaper mistake.
+func TestUnsupportedEntryType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode fs.FileMode
+		want bool
+	}{
+		{name: "regular file", mode: 0},
+		{name: "directory", mode: fs.ModeDir},
+		{name: "symbolic link", mode: fs.ModeSymlink, want: true},
+		{name: "named pipe", mode: fs.ModeNamedPipe, want: true},
+		{name: "socket", mode: fs.ModeSocket, want: true},
+		{name: "block device", mode: fs.ModeDevice, want: true},
+		{name: "character device", mode: fs.ModeDevice | fs.ModeCharDevice, want: true},
+		{name: "irregular is tolerated", mode: fs.ModeIrregular},
+		{
+			// Nothing produces this today, and if something starts to, the
+			// symlink half is the half that matters.
+			name: "irregular alongside a rejected bit is still rejected",
+			mode: fs.ModeIrregular | fs.ModeSymlink,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := unsupportedEntryType(tt.mode); got != tt.want {
+				t.Errorf("unsupportedEntryType(%v) = %v, want %v", tt.mode, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/paths/entiredir_type_test.go
+++ b/cmd/entire/cli/paths/entiredir_type_test.go
@@ -18,6 +18,11 @@ import (
 // the placeholder gets there without anyone attacking anything, while a
 // junction cannot arrive by checkout at all: git has no tree-object mode for
 // one. Tolerating the ambiguous bit is the cheaper mistake.
+//
+// It is tolerated by being masked out rather than matched on, because Windows
+// hands it over alongside ModeDir whenever the reparse tag is not a name
+// surrogate, which is what a placeholder directory is. Rejected types are
+// rejected regardless of the bit.
 func TestUnsupportedEntryType(t *testing.T) {
 	t.Parallel()
 
@@ -33,13 +38,72 @@ func TestUnsupportedEntryType(t *testing.T) {
 		{name: "socket", mode: fs.ModeSocket, want: true},
 		{name: "block device", mode: fs.ModeDevice, want: true},
 		{name: "character device", mode: fs.ModeDevice | fs.ModeCharDevice, want: true},
-		{name: "irregular is tolerated", mode: fs.ModeIrregular},
+		{
+			// A junction, or a cloud placeholder standing in for a file.
+			name: "irregular is tolerated",
+			mode: fs.ModeIrregular,
+		},
+		{
+			// A cloud placeholder standing in for a directory. Go withholds
+			// ModeDir only for a name-surrogate reparse tag, and the cloud tags
+			// are not surrogates, so this is the shape `.entire/metadata`,
+			// `logs`, and `tmp` take inside a synced folder. Demanding
+			// ModeIrregular stand alone would reject the very case it is
+			// tolerated for.
+			name: "irregular alongside a directory is tolerated",
+			mode: fs.ModeDir | fs.ModeIrregular,
+		},
 		{
 			// Nothing produces this today, and if something starts to, the
 			// symlink half is the half that matters.
 			name: "irregular alongside a rejected bit is still rejected",
 			mode: fs.ModeIrregular | fs.ModeSymlink,
 			want: true,
+		},
+		{
+			name: "irregular alongside a directory and a rejected bit is still rejected",
+			mode: fs.ModeDir | fs.ModeIrregular | fs.ModeNamedPipe,
+			want: true,
+		},
+		{
+			// The allowlist is exclusive, so the directory bit does not
+			// launder a rejected one. fs.FileMode.IsDir tests a single bit,
+			// which is why this must be checked against the whole type rather
+			// than against IsDir.
+			name: "directory alongside a rejected bit is still rejected",
+			mode: fs.ModeDir | fs.ModeSymlink,
+			want: true,
+		},
+		{
+			name: "directory alongside a named pipe is still rejected",
+			mode: fs.ModeDir | fs.ModeNamedPipe,
+			want: true,
+		},
+		{
+			// What os.ReadDir's direntType returns when the platform reports
+			// no type and the internal Lstat cannot supply one. Every bit is
+			// set, the directory bit among them, so an allowlist keyed on
+			// IsDir would wave it through.
+			name: "unknown type is rejected",
+			mode: ^fs.FileMode(0),
+			want: true,
+		},
+		{
+			// Permission and non-type bits do not change what an entry is.
+			name: "regular file with permission bits",
+			mode: 0o644,
+		},
+		{
+			name: "irregular with permission bits is tolerated",
+			mode: fs.ModeIrregular | 0o644,
+		},
+		{
+			name: "setuid regular file",
+			mode: fs.ModeSetuid | 0o755,
+		},
+		{
+			name: "directory with permission bits",
+			mode: fs.ModeDir | 0o755,
 		},
 	}
 

--- a/cmd/entire/cli/paths/entiredir_unix_test.go
+++ b/cmd/entire/cli/paths/entiredir_unix_test.go
@@ -1,0 +1,89 @@
+//go:build unix
+
+package paths
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// A FIFO at `.entire/settings.json` used to be left alone on the grounds that
+// it hangs the settings read rather than redirecting it. A hang with no error
+// and no way to interrupt the hook is not a better outcome than a refusal, and
+// Entire never creates one, so it is refused with the same remedy as any other
+// entry it did not put there.
+func TestValidateEntireDirAt_NamedPipeEntryIsRejected(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	entire := makeEntireDir(t, root)
+	entry := filepath.Join(entire, "settings.json")
+	if err := syscall.Mkfifo(entry, 0o600); err != nil {
+		t.Skipf("cannot create a named pipe: %v", err)
+	}
+
+	err := ValidateEntireDirAt(root)
+	if !errors.Is(err, ErrEntireDirUnsupportedEntry) {
+		t.Fatalf("want ErrEntireDirUnsupportedEntry, got %v", err)
+	}
+	if errors.Is(err, ErrEntireDirNotDirectory) {
+		t.Errorf("an unsupported entry must not read as `.entire` being the wrong type: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, entry) {
+		t.Errorf("message %q does not name the entry %q", msg, entry)
+	}
+	if !strings.Contains(msg, "named pipe") {
+		t.Errorf("message %q does not say what was found", msg)
+	}
+}
+
+func TestValidateEntireDirAt_SocketEntryIsRejected(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	entire := makeEntireDir(t, root)
+	entry := filepath.Join(entire, "tmp")
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "unix", entry)
+	if err != nil {
+		t.Skipf("cannot create a unix socket: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := listener.Close(); err != nil {
+			t.Logf("close listener: %v", err)
+		}
+	})
+
+	if err := ValidateEntireDirAt(root); !errors.Is(err, ErrEntireDirUnsupportedEntry) {
+		t.Fatalf("want ErrEntireDirUnsupportedEntry, got %v", err)
+	}
+}
+
+// The allowlist must not start refusing the layout Entire itself writes.
+func TestValidateEntireDirAt_EntireOwnLayoutIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	entire := makeEntireDir(t, root)
+	for _, sub := range []string{"logs", "metadata", "tmp"} {
+		if err := os.Mkdir(filepath.Join(entire, sub), 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, file := range []string{"settings.json", "settings.local.json"} {
+		if err := os.WriteFile(filepath.Join(entire, file), []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := ValidateEntireDirAt(root); err != nil {
+		t.Fatalf("ValidateEntireDirAt rejected Entire's own layout: %v", err)
+	}
+}

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -844,10 +844,11 @@ func LoadFromBytes(data []byte) (*EntireSettings, error) {
 // but as "path escapes from parent", which describes neither the cause nor the
 // fix. All four now give the same verdict and the same remedy.
 //
-// The Lstat goes through the same root handle as the open, so the two cannot
-// disagree about which file they are talking about. It is the only check made
-// on the entry: any Lstat failure falls through to the open, which reports it in
-// the terms callers already classify.
+// Lstat and Open are separate operations, so checking only before the open
+// leaves a race: the entry can become an in-root symlink between them and
+// os.Root will follow it. After opening, validate that the path is still a real
+// file and names the same object as the open descriptor. Once that succeeds,
+// later path swaps do not matter because the read uses the already-open file.
 //
 // This overlaps paths.ValidateEntireDirAt, which rejects a symlinked entry in
 // `.entire` before a command runs at all. The duplication is deliberate: that
@@ -862,7 +863,11 @@ func readConfined(filePath string) ([]byte, error) {
 	defer root.Close()
 
 	base := filepath.Base(filePath)
-	if info, lerr := root.Lstat(base); lerr == nil && info.Mode()&fs.ModeSymlink != 0 {
+	info, err := root.Lstat(base)
+	if err != nil {
+		return nil, fmt.Errorf("inspect settings file: %w", err)
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
 		//nolint:wrapcheck // sentinel surfaces verbatim for the caller's errors.Is; callers add the reading-context prefix
 		return nil, paths.SymlinkedEntryError(filePath)
 	}
@@ -873,11 +878,39 @@ func readConfined(filePath string) ([]byte, error) {
 	}
 	defer f.Close()
 
+	if err := validateOpenedFile(root, base, filePath, f); err != nil {
+		return nil, err
+	}
+
 	data, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("read settings file: %w", err)
 	}
 	return data, nil
+}
+
+// validateOpenedFile closes the Lstat/Open race in readConfined. The path must
+// still be a non-symlink and must identify the object held by f. A replacement
+// after this check cannot redirect the read, because f is already bound to the
+// validated object.
+func validateOpenedFile(root *os.Root, base, filePath string, f *os.File) error {
+	pathInfo, err := root.Lstat(base)
+	if err != nil {
+		return fmt.Errorf("reinspect settings file: %w", err)
+	}
+	if pathInfo.Mode()&fs.ModeSymlink != 0 {
+		//nolint:wrapcheck // sentinel surfaces verbatim for the caller's errors.Is; callers add the reading-context prefix
+		return paths.SymlinkedEntryError(filePath)
+	}
+
+	openedInfo, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("inspect opened settings file: %w", err)
+	}
+	if !os.SameFile(pathInfo, openedInfo) {
+		return fmt.Errorf("settings file changed while it was being opened: %s", filePath)
+	}
+	return nil
 }
 
 // loadFromFile loads settings from a specific file path.

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -819,12 +819,41 @@ func LoadFromBytes(data []byte) (*EntireSettings, error) {
 }
 
 // readConfined reads filePath through an os.Root anchored at its parent
-// directory. The root confines the open to that directory, so the read cannot
-// be redirected outside it by a swapped or symlinked path between resolution and
-// open (TOCTOU) — unlike a bare os.ReadFile of an absolute path. A symlink that
-// escapes the directory surfaces as a non-ENOENT error. Callers must classify
-// "missing" with errors.Is(err, fs.ErrNotExist) rather than os.IsNotExist,
-// since the returned errors are wrapped.
+// directory, refusing outright to read it if it is a symbolic link.
+//
+// The root confines the open to that directory, so the read cannot be
+// redirected outside it by a swapped or symlinked path between resolution and
+// open (TOCTOU) — unlike a bare os.ReadFile of an absolute path. Callers must
+// classify "missing" with errors.Is(err, fs.ErrNotExist) rather than
+// os.IsNotExist, since the returned errors are wrapped.
+//
+// Confinement alone is NOT the invariant, which is why the Lstat is here as
+// well. Entire's config files are never read through a link, wherever it points,
+// and os.Root leaves two gaps against that:
+//
+//   - A RELATIVE link whose target stays inside the directory is followed
+//     without complaint. `.entire/settings.local.json -> planted.json` is the
+//     case that matters: that file names the command Entire executes at
+//     pre-push, so following it hands the far end a say in what runs.
+//   - A DANGLING link surfaces as ENOENT, which every caller here reads as
+//     "absent" and answers with default settings. A planted
+//     `.entire/settings.json -> missing.json` therefore made Entire silently
+//     ignore the project's settings rather than fail.
+//
+// An absolute target, and a relative one that escapes, were already refused —
+// but as "path escapes from parent", which describes neither the cause nor the
+// fix. All four now give the same verdict and the same remedy.
+//
+// The Lstat goes through the same root handle as the open, so the two cannot
+// disagree about which file they are talking about. It is the only check made
+// on the entry: any Lstat failure falls through to the open, which reports it in
+// the terms callers already classify.
+//
+// This overlaps paths.ValidateEntireDirAt, which rejects a symlinked entry in
+// `.entire` before a command runs at all. The duplication is deliberate: that
+// guard hangs off the root pre-run and cli.LoadEntireSettings, while eighteen
+// files call settings.Load directly — the strategy hook paths among them — and
+// this is the read those callers have in common.
 func readConfined(filePath string) ([]byte, error) {
 	root, err := os.OpenRoot(filepath.Dir(filePath))
 	if err != nil {
@@ -832,7 +861,13 @@ func readConfined(filePath string) ([]byte, error) {
 	}
 	defer root.Close()
 
-	f, err := root.Open(filepath.Base(filePath))
+	base := filepath.Base(filePath)
+	if info, lerr := root.Lstat(base); lerr == nil && info.Mode()&fs.ModeSymlink != 0 {
+		//nolint:wrapcheck // sentinel surfaces verbatim for the caller's errors.Is; callers add the reading-context prefix
+		return nil, paths.SymlinkedEntryError(filePath)
+	}
+
+	f, err := root.Open(base)
 	if err != nil {
 		return nil, fmt.Errorf("open settings file: %w", err)
 	}

--- a/cmd/entire/cli/settings/symlink_test.go
+++ b/cmd/entire/cli/settings/symlink_test.go
@@ -206,3 +206,37 @@ func TestLoad_RealSettingsFilesStillLoad(t *testing.T) {
 			got.Enabled, got.AbsoluteGitHookPath)
 	}
 }
+
+// The pre-open Lstat and the open are separate syscalls. Model a replacement
+// between them deterministically by validating a descriptor for one file
+// against the path of another; the production path must reject this rather
+// than read from the descriptor.
+func TestValidateOpenedFile_RejectsReplacedEntry(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	plantedPath := filepath.Join(dir, "planted.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"enabled":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plantedPath, []byte(`{"enabled":false}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	planted, err := root.Open("planted.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer planted.Close()
+
+	if err := validateOpenedFile(root, "settings.json", settingsPath, planted); err == nil {
+		t.Fatal("validateOpenedFile accepted a descriptor for a replacement file")
+	}
+}

--- a/cmd/entire/cli/settings/symlink_test.go
+++ b/cmd/entire/cli/settings/symlink_test.go
@@ -1,0 +1,208 @@
+package settings
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// A settings file is never read through a symbolic link, and where the link
+// points makes no difference. The `.entire` guard in the cli package covers the
+// commands that go through the root pre-run, but eighteen files call
+// settings.Load directly — every strategy hook path among them — so the
+// invariant has to hold here too, at the read itself.
+//
+// os.OpenRoot, which readConfined already opens through, rejects only a link
+// that leaves `.entire`. That is why the in-directory rows below exist: they are
+// the cases confinement follows without complaint.
+func TestLoad_RejectsSymlinkedSettingsFile(t *testing.T) {
+	for _, name := range []string{"settings.json", "settings.local.json"} {
+		for _, target := range []string{"relative-inside", "absolute-inside", "outside", "escaping", "dangling"} {
+			t.Run(name+"/"+target, func(t *testing.T) {
+				root := t.TempDir()
+				testutil.InitRepo(t, root)
+				entireDir := filepath.Join(root, ".entire")
+				if err := os.MkdirAll(entireDir, 0o750); err != nil {
+					t.Fatal(err)
+				}
+
+				var linkTarget string
+				switch target {
+				case "relative-inside":
+					// The case os.Root confinement follows without complaint.
+					if err := os.WriteFile(filepath.Join(entireDir, "planted.json"), []byte(`{"enabled":false}`), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					linkTarget = "planted.json"
+				case "absolute-inside":
+					linkTarget = filepath.Join(entireDir, "planted.json")
+					if err := os.WriteFile(linkTarget, []byte(`{"enabled":false}`), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				case "outside":
+					linkTarget = filepath.Join(t.TempDir(), "planted.json")
+					if err := os.WriteFile(linkTarget, []byte(`{"enabled":false}`), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				case "escaping":
+					if err := os.WriteFile(filepath.Join(root, "planted.json"), []byte(`{"enabled":false}`), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					linkTarget = "../planted.json"
+				case "dangling":
+					// Previously ENOENT, which every caller reads as "absent"
+					// and answers with default settings.
+					linkTarget = "missing.json"
+				}
+				if err := os.Symlink(linkTarget, filepath.Join(entireDir, name)); err != nil {
+					t.Skipf("cannot create symlink: %v", err)
+				}
+
+				_, err := Load(WithWorktreeRoot(context.Background(), root))
+				if err == nil {
+					t.Fatalf("Load read %s through a symbolic link", name)
+				}
+				if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
+					t.Errorf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+				}
+				if msg := err.Error(); !strings.Contains(msg, name) {
+					t.Errorf("message %q does not name the offending file", msg)
+				}
+			})
+		}
+	}
+}
+
+// The refusal has to be the whole outcome, not a fallback to defaults: a
+// redirected settings.local.json saying `enabled: false` must not be able to
+// turn Entire off, and neither may the error be swallowed into a default-on
+// settings object that looks the same as a healthy repo.
+func TestLoad_SymlinkedLocalSettingsAreNotHonoured(t *testing.T) {
+	root := t.TempDir()
+	testutil.InitRepo(t, root)
+	entireDir := filepath.Join(root, ".entire")
+	if err := os.MkdirAll(entireDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"enabled":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "planted.json"), []byte(`{"enabled":false}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("planted.json", filepath.Join(entireDir, "settings.local.json")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	got, err := Load(WithWorktreeRoot(context.Background(), root))
+	if err == nil {
+		t.Fatalf("Load honoured a redirected settings.local.json (enabled=%v)", got.Enabled)
+	}
+	if got != nil {
+		t.Errorf("Load returned settings alongside the error: %+v", got)
+	}
+}
+
+// The single-file readers serve `entire status` and the raw read-modify-write
+// halves. They read the same files, so they refuse the same links; LoadLocalRaw
+// is ungated for trackedness but that is a different question from this one.
+func TestSingleFileReaders_RejectSymlinkedSettingsFile(t *testing.T) {
+	root := t.TempDir()
+	testutil.InitRepo(t, root)
+	entireDir := filepath.Join(root, ".entire")
+	if err := os.MkdirAll(entireDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "planted.json"), []byte(`{"enabled":false}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"settings.json", "settings.local.json"} {
+		if err := os.Symlink("planted.json", filepath.Join(entireDir, name)); err != nil {
+			t.Skipf("cannot create symlink: %v", err)
+		}
+	}
+
+	t.Chdir(root)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	t.Run("LoadFromFile", func(t *testing.T) {
+		_, err := LoadFromFile(filepath.Join(entireDir, "settings.json"))
+		if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
+			t.Fatalf("want ErrEntireDirSymlinkedEntry, got %v", err)
+		}
+	})
+
+	t.Run("LoadProjectRaw", func(t *testing.T) {
+		_, _, _, err := LoadProjectRaw(context.Background())
+		if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
+			t.Fatalf("want ErrEntireDirSymlinkedEntry, got %v", err)
+		}
+	})
+
+	t.Run("LoadLocalRaw", func(t *testing.T) {
+		_, _, _, err := LoadLocalRaw(context.Background())
+		if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
+			t.Fatalf("want ErrEntireDirSymlinkedEntry, got %v", err)
+		}
+	})
+}
+
+// Clone preferences live in the git common dir rather than `.entire`, but they
+// are Entire's own state read through the same chokepoint, so they get the same
+// treatment. Worth pinning: the check sits in readConfined, so this follows from
+// where it was put rather than from a decision made at this call site.
+func TestLoadClonePreferences_RejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	testutil.InitRepo(t, root)
+
+	path, err := clonePreferencesPathForWorktreeRoot(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(filepath.Dir(path), "planted.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("planted.json", path); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	if _, err := Load(WithWorktreeRoot(context.Background(), root)); !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
+		t.Fatalf("want ErrEntireDirSymlinkedEntry, got %v", err)
+	}
+}
+
+// Real files must keep loading. Without this the check is one mistake away from
+// refusing every settings read in every repo.
+func TestLoad_RealSettingsFilesStillLoad(t *testing.T) {
+	root := t.TempDir()
+	testutil.InitRepo(t, root)
+	entireDir := filepath.Join(root, ".entire")
+	if err := os.MkdirAll(entireDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"enabled":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.local.json"), []byte(`{"absolute_git_hook_path":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Load(WithWorktreeRoot(context.Background(), root))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !got.Enabled || !got.AbsoluteGitHookPath {
+		t.Errorf("both layers did not merge: enabled=%v absolute_git_hook_path=%v",
+			got.Enabled, got.AbsoluteGitHookPath)
+	}
+}

--- a/cmd/entire/cli/settings/symlink_test.go
+++ b/cmd/entire/cli/settings/symlink_test.go
@@ -68,8 +68,8 @@ func TestLoad_RejectsSymlinkedSettingsFile(t *testing.T) {
 				if err == nil {
 					t.Fatalf("Load read %s through a symbolic link", name)
 				}
-				if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
-					t.Errorf("error does not wrap ErrEntireDirSymlinkedEntry: %v", err)
+				if !errors.Is(err, paths.ErrEntireDirUnsupportedEntry) {
+					t.Errorf("error does not wrap ErrEntireDirUnsupportedEntry: %v", err)
 				}
 				if msg := err.Error(); !strings.Contains(msg, name) {
 					t.Errorf("message %q does not name the offending file", msg)
@@ -134,22 +134,22 @@ func TestSingleFileReaders_RejectSymlinkedSettingsFile(t *testing.T) {
 
 	t.Run("LoadFromFile", func(t *testing.T) {
 		_, err := LoadFromFile(filepath.Join(entireDir, "settings.json"))
-		if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
-			t.Fatalf("want ErrEntireDirSymlinkedEntry, got %v", err)
+		if !errors.Is(err, paths.ErrEntireDirUnsupportedEntry) {
+			t.Fatalf("want ErrEntireDirUnsupportedEntry, got %v", err)
 		}
 	})
 
 	t.Run("LoadProjectRaw", func(t *testing.T) {
 		_, _, _, err := LoadProjectRaw(context.Background())
-		if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
-			t.Fatalf("want ErrEntireDirSymlinkedEntry, got %v", err)
+		if !errors.Is(err, paths.ErrEntireDirUnsupportedEntry) {
+			t.Fatalf("want ErrEntireDirUnsupportedEntry, got %v", err)
 		}
 	})
 
 	t.Run("LoadLocalRaw", func(t *testing.T) {
 		_, _, _, err := LoadLocalRaw(context.Background())
-		if !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
-			t.Fatalf("want ErrEntireDirSymlinkedEntry, got %v", err)
+		if !errors.Is(err, paths.ErrEntireDirUnsupportedEntry) {
+			t.Fatalf("want ErrEntireDirUnsupportedEntry, got %v", err)
 		}
 	})
 }
@@ -176,8 +176,8 @@ func TestLoadClonePreferences_RejectsSymlink(t *testing.T) {
 		t.Skipf("cannot create symlink: %v", err)
 	}
 
-	if _, err := Load(WithWorktreeRoot(context.Background(), root)); !errors.Is(err, paths.ErrEntireDirSymlinkedEntry) {
-		t.Fatalf("want ErrEntireDirSymlinkedEntry, got %v", err)
+	if _, err := Load(WithWorktreeRoot(context.Background(), root)); !errors.Is(err, paths.ErrEntireDirUnsupportedEntry) {
+		t.Fatalf("want ErrEntireDirUnsupportedEntry, got %v", err)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1168
<!-- entire-trail-link-end -->

Problem: The CLI validates that .entire itself is a real directory, but does not check whether entries _inside_ .entire are symlinks. This allows redirected .entire/metadata (transcripts) and .entire/settings.local.json (the file naming the pre-push command) to escape Entire's control. Dangling symlinks to settings files are silently treated as "absent," causing Entire to ignore project settings without error.

Solution: Add validation of entries directly inside .entire:
- New ErrEntireDirSymlinkedEntry error distinguishes symlinked entries from .entire being the wrong type
- ValidateEntireDirAt() now calls validateEntireDirEntries() to scan one level deep using os.ReadDir() without reintroducing a race condition
- Reports the first symlink in sorted order plus a count of others, so users do not fix one per command retry
- Settings reader (readConfined) also rejects symlinked settings files at the read itself, with a post-open validation to close the Lstat/Open race
- Updated error messages in writeEntireDirRemedy() and writeEntireDirDiagnosis() to guide users on the specific remedy (replace the entry)
- Comprehensive unit and integration tests covering escaped, in-directory, and dangling symlinks, plus safe-to-pass real-file cases

The scan is deliberately one level deep (no recursion) to avoid walking every session transcript on every command. Settings files receive redundant protection at both the command pre-run level and at each read, because the strategy hooks reach settings.Load directly without traversing the guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security-sensitive local trust boundaries (settings, logs, metadata paths) and fail-closed behavior on every guarded command; regressions could block legitimate repos (e.g. synced folders) or break settings load paths that bypass the CLI pre-run.
> 
> **Overview**
> **Hardens `.entire` so Entire never reads or writes through redirected or odd filesystem entries.** After confirming `.entire` is a real directory, validation now does a shallow `ReadDir` and rejects any immediate child that is not a regular file or directory (symlinks, FIFOs, sockets, etc.), using a new `ErrEntireDirUnsupportedEntry` with its own remedy text distinct from “not a directory.” Guarded commands, doctor, and logger setup inherit this; user-facing remedy/diagnosis paths are updated accordingly.
> 
> **Settings reads are tightened in parallel.** `readConfined` `Lstat`s through `os.Root` and refuses symlinks (including in-directory and dangling links that previously fell through to default settings), with post-open `SameFile` validation to close a TOCTOU gap. Shared `SymlinkedEntryError` keeps messages aligned with the entry scan.
> 
> **Windows / cloud-sync edge case:** `fs.ModeIrregular` is masked out of the type allowlist so OneDrive-style placeholder directories under `.entire` are not false positives; combined rejected types still fail closed.
> 
> Documentation (`CLAUDE.md`) and broad unit/integration/settings tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8871d4f39f65f096a21b32eecd422d2544fb0138. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->