### PR TITLE
fix(e2e): handle current Claude and Copilot prompts

### DIFF
--- a/cmd/entire/cli/agent/copilotcli/copilotcli.go
+++ b/cmd/entire/cli/agent/copilotcli/copilotcli.go
@@ -65,6 +65,15 @@ func (c *CopilotCLIAgent) GetSessionDir(_ string) (string, error) {
 		return override, nil
 	}
 
+	// Copilot stores its config and state under COPILOT_HOME when that is set,
+	// falling back to ~/.copilot. Honouring it points transcript resolution at
+	// wherever the agent actually wrote, rather than at a directory it never
+	// used — which is what a user with COPILOT_HOME set, or a harness that
+	// isolates Copilot state per session, would otherwise get.
+	if copilotHome := os.Getenv("COPILOT_HOME"); copilotHome != "" {
+		return filepath.Join(copilotHome, "session-state"), nil
+	}
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)

--- a/cmd/entire/cli/agent/copilotcli/copilotcli_test.go
+++ b/cmd/entire/cli/agent/copilotcli/copilotcli_test.go
@@ -124,9 +124,25 @@ func TestCopilotCLIAgent_GetSessionDir_EnvOverride(t *testing.T) {
 	}
 }
 
+func TestCopilotCLIAgent_GetSessionDir_CopilotHome(t *testing.T) {
+	ag := &CopilotCLIAgent{}
+	t.Setenv("ENTIRE_TEST_COPILOT_SESSION_DIR", "")
+	t.Setenv("COPILOT_HOME", filepath.Join("/tmp", "isolated-copilot"))
+
+	dir, err := ag.GetSessionDir("/some/repo")
+	if err != nil {
+		t.Fatalf("GetSessionDir() error = %v", err)
+	}
+	want := filepath.Join("/tmp", "isolated-copilot", "session-state")
+	if dir != want {
+		t.Errorf("GetSessionDir() = %q, want %q", dir, want)
+	}
+}
+
 func TestCopilotCLIAgent_GetSessionDir_DefaultPath(t *testing.T) {
 	ag := &CopilotCLIAgent{}
 	t.Setenv("ENTIRE_TEST_COPILOT_SESSION_DIR", "")
+	t.Setenv("COPILOT_HOME", "")
 
 	dir, err := ag.GetSessionDir("/some/repo")
 	if err != nil {

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -59,7 +59,8 @@ e2e/
 | `ANTHROPIC_API_KEY` | Required for Claude Code | — |
 | `GEMINI_API_KEY` | Required for Gemini CLI | — |
 | `OPENAI_API_KEY` | Required for Codex | — |
-| `COPILOT_GITHUB_TOKEN` | Required for Copilot CLI (or `gh auth login`) | — |
+| `COPILOT_GITHUB_TOKEN` | Required for Copilot CLI, unless a `copilot login` credential is already stored. `GH_TOKEN` and `GITHUB_TOKEN` also work — Copilot reads all three, in that order of precedence. A `gh auth login` alone is not enough: Copilot does not read gh's config. | — |
+| `E2E_KEEP_AGENT_HOME` | Set to `1` to preserve the isolated `COPILOT_HOME` a session ran under (holds Copilot's own logs) | unset |
 
 ## Debugging Failures
 

--- a/e2e/agents/claude.go
+++ b/e2e/agents/claude.go
@@ -180,9 +180,10 @@ func (c *Claude) StartSession(ctx context.Context, dir string) (Session, error) 
 		if !strings.Contains(content, "Enter to confirm") {
 			break
 		}
-		// The bypass permissions dialog defaults to "No, exit" —
-		// arrow down to "Yes, I accept" before confirming.
-		if strings.Contains(content, "Yes, I accept") {
+		// Permission and workspace-trust dialogs can default to "No, exit".
+		// Move to the affirmative option before confirming whenever No is
+		// visibly selected, independent of the current wording of the Yes option.
+		if claudeStartupSelectionIsNo(content) {
 			_ = s.SendKeys("Down")
 			time.Sleep(200 * time.Millisecond)
 		}
@@ -192,6 +193,16 @@ func (c *Claude) StartSession(ctx context.Context, dir string) (Session, error) 
 	s.stableAtSend = ""
 
 	return s, nil
+}
+
+func claudeStartupSelectionIsNo(content string) bool {
+	for line := range strings.SplitSeq(content, "\n") {
+		lower := strings.ToLower(line)
+		if strings.Contains(line, "❯") && strings.Contains(lower, "no, exit") {
+			return true
+		}
+	}
+	return false
 }
 
 // cleanConfigDir creates an isolated temp directory for CLAUDE_CONFIG_DIR so

--- a/e2e/agents/claude.go
+++ b/e2e/agents/claude.go
@@ -180,12 +180,27 @@ func (c *Claude) StartSession(ctx context.Context, dir string) (Session, error) 
 		if !strings.Contains(content, "Enter to confirm") {
 			break
 		}
-		// Permission and workspace-trust dialogs can default to "No, exit".
-		// Move to the affirmative option before confirming whenever No is
-		// visibly selected, independent of the current wording of the Yes option.
-		if claudeStartupSelectionIsNo(content) {
-			_ = s.SendKeys("Down")
-			time.Sleep(200 * time.Millisecond)
+		// Permission and workspace-trust dialogs both default to a negative
+		// option, so walk down to the affirmative one before confirming. Only
+		// dialogs that offer such a choice get the walk — first-run dialogs
+		// like theme selection also say "Enter to confirm" and are answered by
+		// their default. Once committed to the walk, bail rather than confirm
+		// blind: Enter on the wrong option quits Claude, and that surfaces as
+		// the next iteration's "waiting for startup prompt" timeout, which
+		// hides the cause.
+		if claudeStartupOffersYes(content) {
+			for range 3 {
+				if claudeStartupSelectionIsYes(content) {
+					break
+				}
+				_ = s.SendKeys("Down")
+				time.Sleep(200 * time.Millisecond)
+				content = s.Capture()
+			}
+			if !claudeStartupSelectionIsYes(content) {
+				_ = s.Close()
+				return nil, fmt.Errorf("startup dialog: affirmative option not reachable, wording may have changed\n%s", content)
+			}
 		}
 		_ = s.SendKeys("Enter")
 		time.Sleep(500 * time.Millisecond)
@@ -195,14 +210,29 @@ func (c *Claude) StartSession(ctx context.Context, dir string) (Session, error) 
 	return s, nil
 }
 
-func claudeStartupSelectionIsNo(content string) bool {
+// claudeStartupOffersYes reports whether the dialog presents an affirmative
+// option at all, distinguishing a trust/permission choice from a first-run
+// dialog whose default answer is the right one.
+func claudeStartupOffersYes(content string) bool {
+	return strings.Contains(strings.ToLower(content), "yes")
+}
+
+// claudeStartupSelectionIsYes reports whether the highlighted option in a
+// startup dialog is the affirmative one. It keys on the affirmative wording
+// rather than the negative because both are release-dependent, and only one of
+// them is safe to press Enter on: a reworded negative ("No, cancel") read as
+// affirmative quits Claude, while a reworded affirmative merely costs another
+// Down keypress.
+// The dialog renders below whatever it was drawn over, so the last cursor line
+// in the pane is its selection; an earlier "❯" belongs to prior content.
+func claudeStartupSelectionIsYes(content string) bool {
+	selected := ""
 	for line := range strings.SplitSeq(content, "\n") {
-		lower := strings.ToLower(line)
-		if strings.Contains(line, "❯") && strings.Contains(lower, "no, exit") {
-			return true
+		if strings.Contains(line, "❯") {
+			selected = line
 		}
 	}
-	return false
+	return strings.Contains(strings.ToLower(selected), "yes")
 }
 
 // cleanConfigDir creates an isolated temp directory for CLAUDE_CONFIG_DIR so

--- a/e2e/agents/claude_startup_test.go
+++ b/e2e/agents/claude_startup_test.go
@@ -1,0 +1,32 @@
+package agents
+
+import "testing"
+
+const claudeWorkspaceTrustPane = `Accessing workspace:
+/tmp/e2e-repo-1996556193
+
+Quick safety check: Is this a project you created or one you trust?
+
+❯ No, exit
+  Yes, I trust this folder
+
+Enter to confirm · Esc to cancel`
+
+func TestClaudeStartupSelectionIsNo_DetectsWorkspaceTrustDefault(t *testing.T) {
+	t.Parallel()
+
+	if !claudeStartupSelectionIsNo(claudeWorkspaceTrustPane) {
+		t.Fatal("workspace trust dialog defaults to No, so startup must move to Yes before confirming")
+	}
+}
+
+func TestClaudeStartupSelectionIsNo_IgnoresSelectedYes(t *testing.T) {
+	t.Parallel()
+
+	const selectedYes = `  No, exit
+❯ Yes, I trust this folder
+Enter to confirm · Esc to cancel`
+	if claudeStartupSelectionIsNo(selectedYes) {
+		t.Fatal("startup must not move down when a Yes option is already selected")
+	}
+}

--- a/e2e/agents/claude_startup_test.go
+++ b/e2e/agents/claude_startup_test.go
@@ -12,21 +12,64 @@ Quick safety check: Is this a project you created or one you trust?
 
 Enter to confirm · Esc to cancel`
 
-func TestClaudeStartupSelectionIsNo_DetectsWorkspaceTrustDefault(t *testing.T) {
+func TestClaudeStartupSelectionIsYes_RejectsWorkspaceTrustDefault(t *testing.T) {
 	t.Parallel()
 
-	if !claudeStartupSelectionIsNo(claudeWorkspaceTrustPane) {
+	if claudeStartupSelectionIsYes(claudeWorkspaceTrustPane) {
 		t.Fatal("workspace trust dialog defaults to No, so startup must move to Yes before confirming")
 	}
 }
 
-func TestClaudeStartupSelectionIsNo_IgnoresSelectedYes(t *testing.T) {
+func TestClaudeStartupSelectionIsYes_AcceptsSelectedYes(t *testing.T) {
 	t.Parallel()
 
 	const selectedYes = `  No, exit
 ❯ Yes, I trust this folder
 Enter to confirm · Esc to cancel`
-	if claudeStartupSelectionIsNo(selectedYes) {
+	if !claudeStartupSelectionIsYes(selectedYes) {
 		t.Fatal("startup must not move down when a Yes option is already selected")
+	}
+}
+
+func TestClaudeStartupSelectionIsYes_RejectsRewordedNegative(t *testing.T) {
+	t.Parallel()
+
+	const rewordedNegative = `Do you trust the files in this folder?
+
+❯ No, cancel
+  Yes, proceed
+
+Enter to confirm · Esc to cancel`
+	if claudeStartupSelectionIsYes(rewordedNegative) {
+		t.Fatal("a negative option worded other than \"No, exit\" must still not be confirmed")
+	}
+}
+
+func TestClaudeStartupSelectionIsYes_IgnoresCursorAbovePane(t *testing.T) {
+	t.Parallel()
+
+	const cursorAbove = `❯ some earlier prompt line
+
+❯ Yes, I trust this folder
+Enter to confirm · Esc to cancel`
+	if !claudeStartupSelectionIsYes(cursorAbove) {
+		t.Fatal("the dialog's own selection is the last cursor line, not the first")
+	}
+}
+
+func TestClaudeStartupOffersYes_IgnoresFirstRunDialogWithoutChoice(t *testing.T) {
+	t.Parallel()
+
+	const themeSelection = `Choose the text style that looks best with your terminal:
+
+❯ Dark mode
+  Light mode
+
+Enter to confirm · Esc to cancel`
+	if claudeStartupOffersYes(themeSelection) {
+		t.Fatal("a first-run dialog with no affirmative option must be answered with its default")
+	}
+	if !claudeStartupOffersYes(claudeWorkspaceTrustPane) {
+		t.Fatal("the workspace trust dialog does offer an affirmative option")
 	}
 }

--- a/e2e/agents/copilot-cli.go
+++ b/e2e/agents/copilot-cli.go
@@ -24,10 +24,19 @@ func init() {
 type CopilotCLI struct{}
 
 // copilotPromptPattern matches Copilot's idle input area. v1.0.81 removed the
-// bare "❯" marker in favour of a bordered box, leaving the footer as the only
-// stable text — and, like the old "❯", it is drawn while Copilot is working.
-// A match therefore proves nothing on its own: WaitFor's settle window is what
-// establishes that a turn ended, and copilotPromptReady is what rejects a modal.
+// bare "❯" marker in favour of a bordered box, leaving the footer hints row as
+// the only stable text to key on.
+//
+// That row is idle-only, which makes it a real readiness signal rather than
+// always-on chrome: in the v1.0.81 bundle the footer renders either the
+// activity indicator or the hints row and never both, so "← open sidebar"
+// disappears for the duration of a turn. (Read from the shipped bundle, not
+// observed live — and the indicator is suppressed under one condition that was
+// not traced, so treat it as strong evidence rather than a guarantee.)
+//
+// It says nothing about modals, though: a startup dialog or the session-restore
+// picker keeps the row while the agent is not accepting input, which is what
+// copilotPromptReady exists to reject.
 const copilotPromptPattern = `(?m:^[^\S\n]*❯[^\S\n]*$)|← open sidebar`
 
 var copilotPromptRegexp = regexp.MustCompile(copilotPromptPattern)
@@ -88,9 +97,9 @@ func (c *CopilotCLI) RunPrompt(ctx context.Context, dir string, prompt string, o
 	cmd.Stdin = nil
 	// GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS opts in to .github/hooks/*.json loading
 	// in -p mode; gated since Copilot 1.0.40 (2026-05-01).
-	// Unlike StartSession, this keeps the caller's HOME. The session collisions
-	// that forced interactive mode onto an isolated home come from the restore
-	// picker, which -p mode never shows; isolating here would only cost auth.
+	// Unlike StartSession, this leaves the caller's COPILOT_HOME alone: the
+	// session collisions that forced interactive mode onto an isolated home
+	// come from the restore picker, which -p mode never shows.
 	cmd.Env = append(os.Environ(),
 		"ENTIRE_TEST_TTY=0",
 		"GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS=true",
@@ -349,26 +358,38 @@ func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, err
 	}
 
 	// Give each interactive session its own Copilot state. Copilot stores all
-	// sessions under ~/.copilot, so sharing HOME lets parallel tests see and
+	// sessions under its home, so sharing one lets parallel tests see and
 	// attempt to restore one another's still-running sessions.
 	//
-	// Note the coupling this creates: copilotcli.GetSessionDir resolves
-	// $HOME/.copilot/session-state, so only processes that inherit this HOME —
-	// the agent and the hooks it spawns — can resolve this session's
-	// transcript. The test process, on the caller's HOME, cannot.
+	// COPILOT_HOME is Copilot's own documented override for that directory
+	// ("copilot help environment"), which is why it is used here in preference
+	// to replacing HOME: HOME also resolves ~/.gitconfig, ~/.ssh, tool caches
+	// and Entire's own ~/.config/entire for every hook the agent spawns, none
+	// of which this isolation is about. Entire's copilotcli.GetSessionDir
+	// honours COPILOT_HOME too, so the agent and the hooks agree on where the
+	// transcript lives.
 	sessionHome, err := os.MkdirTemp("", "copilot-e2e-home-*")
 	if err != nil {
 		return nil, fmt.Errorf("create isolated Copilot home: %w", err)
 	}
 
-	// Forward auth-related env vars into the tmux session. Keep GitHub CLI auth
-	// pointed at the caller's real config while HOME points at isolated state.
-	envArgs := []string{"HOME=" + sessionHome}
-	for _, key := range []string{"COPILOT_GITHUB_TOKEN", "TERM", "XDG_CONFIG_HOME"} {
+	// Forward auth into the tmux session, which starts a new shell that does
+	// not inherit os.Environ(). Copilot accepts COPILOT_GITHUB_TOKEN, GH_TOKEN
+	// and GITHUB_TOKEN in that order of precedence, and an env token outranks
+	// any stored credential; CI sets the first, local runs may have any of them.
+	envArgs := []string{"COPILOT_HOME=" + sessionHome}
+	for _, key := range []string{
+		"COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN",
+		"HOME", "TERM", "XDG_CONFIG_HOME",
+	} {
 		if v := os.Getenv(key); v != "" {
 			envArgs = append(envArgs, key+"="+v)
 		}
 	}
+	// Not a Copilot variable — it is absent from "copilot help environment",
+	// and Copilot's own auth never consults gh's config. It is forwarded for
+	// the processes Copilot spawns: the GitHub MCP server and any `gh` the
+	// agent runs as a tool.
 	ghConfigDir := currentGHConfigDir()
 	if ghConfigDir != "" {
 		envArgs = append(envArgs, "GH_CONFIG_DIR="+ghConfigDir)

--- a/e2e/agents/copilot-cli.go
+++ b/e2e/agents/copilot-cli.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -22,10 +23,14 @@ func init() {
 
 type CopilotCLI struct{}
 
+const copilotPromptPattern = `(?m:^\s*❯\s*$)|← open sidebar`
+
+var copilotPromptRegexp = regexp.MustCompile(copilotPromptPattern)
+
 func (c *CopilotCLI) Name() string               { return "copilot-cli" }
 func (c *CopilotCLI) Binary() string             { return "copilot" }
 func (c *CopilotCLI) EntireAgent() string        { return "copilot-cli" }
-func (c *CopilotCLI) PromptPattern() string      { return `(?m:^\s*❯\s*$)|← open sidebar` }
+func (c *CopilotCLI) PromptPattern() string      { return copilotPromptPattern }
 func (c *CopilotCLI) TimeoutMultiplier() float64 { return 1.5 }
 
 func (c *CopilotCLI) IsTransientError(out Output, err error) bool {
@@ -299,7 +304,34 @@ func copilotPromptReady(content string) bool {
 	if isStartupDialog(content) || strings.Contains(strings.ToLower(content), "choose which sessions to restore") {
 		return false
 	}
-	return regexp.MustCompile((&CopilotCLI{}).PromptPattern()).MatchString(content)
+	return copilotPromptRegexp.MatchString(content)
+}
+
+func resolveGHConfigDir(goos, home, explicit, xdgConfig, appData string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if xdgConfig != "" {
+		return filepath.Join(xdgConfig, "gh")
+	}
+	if goos == "windows" && appData != "" {
+		return filepath.Join(appData, "GitHub CLI")
+	}
+	if home != "" {
+		return filepath.Join(home, ".config", "gh")
+	}
+	return ""
+}
+
+func currentGHConfigDir() string {
+	home, _ := os.UserHomeDir()
+	return resolveGHConfigDir(
+		runtime.GOOS,
+		home,
+		os.Getenv("GH_CONFIG_DIR"),
+		os.Getenv("XDG_CONFIG_HOME"),
+		os.Getenv("AppData"),
+	)
 }
 
 func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, error) {
@@ -324,12 +356,7 @@ func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, err
 			envArgs = append(envArgs, key+"="+v)
 		}
 	}
-	ghConfigDir := os.Getenv("GH_CONFIG_DIR")
-	if ghConfigDir == "" {
-		if userConfigDir, configErr := os.UserConfigDir(); configErr == nil {
-			ghConfigDir = filepath.Join(userConfigDir, "gh")
-		}
-	}
+	ghConfigDir := currentGHConfigDir()
 	if ghConfigDir != "" {
 		envArgs = append(envArgs, "GH_CONFIG_DIR="+ghConfigDir)
 	}

--- a/e2e/agents/copilot-cli.go
+++ b/e2e/agents/copilot-cli.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -23,7 +25,7 @@ type CopilotCLI struct{}
 func (c *CopilotCLI) Name() string               { return "copilot-cli" }
 func (c *CopilotCLI) Binary() string             { return "copilot" }
 func (c *CopilotCLI) EntireAgent() string        { return "copilot-cli" }
-func (c *CopilotCLI) PromptPattern() string      { return `❯` }
+func (c *CopilotCLI) PromptPattern() string      { return `(?m:^\s*❯\s*$)|← open sidebar` }
 func (c *CopilotCLI) TimeoutMultiplier() float64 { return 1.5 }
 
 func (c *CopilotCLI) IsTransientError(out Output, err error) bool {
@@ -293,20 +295,43 @@ func isStartupDialog(content string) bool {
 		strings.Contains(lower, "enter to select")
 }
 
+func copilotPromptReady(content string) bool {
+	if isStartupDialog(content) || strings.Contains(strings.ToLower(content), "choose which sessions to restore") {
+		return false
+	}
+	return regexp.MustCompile((&CopilotCLI{}).PromptPattern()).MatchString(content)
+}
+
 func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, error) {
 	bin, err := exec.LookPath(c.Binary())
 	if err != nil {
 		return nil, fmt.Errorf("agent binary not found: %w", err)
 	}
 
-	// Forward auth-related env vars into the tmux session. tmux starts a new
-	// shell that doesn't inherit Go's os.Environ(), so without this the
-	// session can lose both token-based auth and local gh/copilot login state.
-	var envArgs []string
-	for _, key := range []string{"COPILOT_GITHUB_TOKEN", "HOME", "TERM", "XDG_CONFIG_HOME", "GH_CONFIG_DIR"} {
+	// Give each interactive session its own Copilot state. Copilot stores all
+	// sessions under ~/.copilot, so sharing HOME lets parallel tests see and
+	// attempt to restore one another's still-running sessions.
+	sessionHome, err := os.MkdirTemp("", "copilot-e2e-home-*")
+	if err != nil {
+		return nil, fmt.Errorf("create isolated Copilot home: %w", err)
+	}
+
+	// Forward auth-related env vars into the tmux session. Keep GitHub CLI auth
+	// pointed at the caller's real config while HOME points at isolated state.
+	envArgs := []string{"HOME=" + sessionHome}
+	for _, key := range []string{"COPILOT_GITHUB_TOKEN", "TERM", "XDG_CONFIG_HOME"} {
 		if v := os.Getenv(key); v != "" {
 			envArgs = append(envArgs, key+"="+v)
 		}
+	}
+	ghConfigDir := os.Getenv("GH_CONFIG_DIR")
+	if ghConfigDir == "" {
+		if userConfigDir, configErr := os.UserConfigDir(); configErr == nil {
+			ghConfigDir = filepath.Join(userConfigDir, "gh")
+		}
+	}
+	if ghConfigDir != "" {
+		envArgs = append(envArgs, "GH_CONFIG_DIR="+ghConfigDir)
 	}
 	args := append([]string{"env"}, envArgs...)
 	args = append(args, bin, "--model", "claude-haiku-4.5", "--allow-all")
@@ -316,20 +341,22 @@ func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, err
 	unset := []string{"CI", "GITHUB_ACTIONS", "ENTIRE_TEST_TTY"}
 	s, err := NewTmuxSession(name, dir, unset, args[0], args[1:]...)
 	if err != nil {
+		_ = os.RemoveAll(sessionHome)
 		return nil, err
 	}
+	s.OnClose(func() { _ = os.RemoveAll(sessionHome) })
 
-	// Dismiss startup dialogs (folder trust, etc.) then wait for the "❯" prompt.
+	// Dismiss startup dialogs (folder trust, etc.) then wait for the input prompt.
 	// Copilot CLI shows a "Confirm folder trust" dialog in interactive mode for
 	// new directories. "Yes" is pre-selected, so Enter dismisses it.
 	foundPrompt := false
 	for range 5 {
-		content, err := s.WaitFor(`(❯|(?i:enter to select))`, 30*time.Second)
+		content, err := s.WaitFor(`(?:`+c.PromptPattern()+`|(?i:enter to select))`, 30*time.Second)
 		if err != nil {
 			_ = s.Close()
 			return nil, fmt.Errorf("waiting for startup prompt: %w", err)
 		}
-		if strings.Contains(content, "❯") && !isStartupDialog(content) {
+		if copilotPromptReady(content) {
 			foundPrompt = true
 			break
 		}

--- a/e2e/agents/copilot-cli.go
+++ b/e2e/agents/copilot-cli.go
@@ -23,7 +23,12 @@ func init() {
 
 type CopilotCLI struct{}
 
-const copilotPromptPattern = `(?m:^\s*❯\s*$)|← open sidebar`
+// copilotPromptPattern matches Copilot's idle input area. v1.0.81 removed the
+// bare "❯" marker in favour of a bordered box, leaving the footer as the only
+// stable text — and, like the old "❯", it is drawn while Copilot is working.
+// A match therefore proves nothing on its own: WaitFor's settle window is what
+// establishes that a turn ended, and copilotPromptReady is what rejects a modal.
+const copilotPromptPattern = `(?m:^[^\S\n]*❯[^\S\n]*$)|← open sidebar`
 
 var copilotPromptRegexp = regexp.MustCompile(copilotPromptPattern)
 
@@ -83,6 +88,9 @@ func (c *CopilotCLI) RunPrompt(ctx context.Context, dir string, prompt string, o
 	cmd.Stdin = nil
 	// GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS opts in to .github/hooks/*.json loading
 	// in -p mode; gated since Copilot 1.0.40 (2026-05-01).
+	// Unlike StartSession, this keeps the caller's HOME. The session collisions
+	// that forced interactive mode onto an isolated home come from the restore
+	// picker, which -p mode never shows; isolating here would only cost auth.
 	cmd.Env = append(os.Environ(),
 		"ENTIRE_TEST_TTY=0",
 		"GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS=true",
@@ -343,6 +351,11 @@ func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, err
 	// Give each interactive session its own Copilot state. Copilot stores all
 	// sessions under ~/.copilot, so sharing HOME lets parallel tests see and
 	// attempt to restore one another's still-running sessions.
+	//
+	// Note the coupling this creates: copilotcli.GetSessionDir resolves
+	// $HOME/.copilot/session-state, so only processes that inherit this HOME —
+	// the agent and the hooks it spawns — can resolve this session's
+	// transcript. The test process, on the caller's HOME, cannot.
 	sessionHome, err := os.MkdirTemp("", "copilot-e2e-home-*")
 	if err != nil {
 		return nil, fmt.Errorf("create isolated Copilot home: %w", err)
@@ -371,7 +384,16 @@ func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, err
 		_ = os.RemoveAll(sessionHome)
 		return nil, err
 	}
-	s.OnClose(func() { _ = os.RemoveAll(sessionHome) })
+	// Copilot's own logs live in this home, so keep it when a run is being
+	// debugged: Close() runs from artifact cleanup, which does not know
+	// whether the test failed.
+	s.OnClose(func() {
+		if os.Getenv("E2E_KEEP_AGENT_HOME") != "" {
+			fmt.Fprintf(os.Stderr, "copilot session home retained: %s\n", sessionHome)
+			return
+		}
+		_ = os.RemoveAll(sessionHome)
+	})
 
 	// Dismiss startup dialogs (folder trust, etc.) then wait for the input prompt.
 	// Copilot CLI shows a "Confirm folder trust" dialog in interactive mode for

--- a/e2e/agents/copilot_trust_test.go
+++ b/e2e/agents/copilot_trust_test.go
@@ -83,6 +83,23 @@ func TestIsStartupDialog_IgnoresInteractivePrompt(t *testing.T) {
 	}
 }
 
+func TestCopilotPromptPattern_MatchesBareCursorPrompt(t *testing.T) {
+	t.Parallel()
+
+	if !copilotPromptReady(interactivePromptPane) {
+		t.Fatal("a bare cursor alone on its line is still an idle prompt")
+	}
+}
+
+func TestCopilotPromptPattern_IgnoresCursorWithTrailingText(t *testing.T) {
+	t.Parallel()
+
+	const listItem = `❯ 1. Yes, and remember this folder`
+	if copilotPromptReady(listItem) {
+		t.Fatal("a cursor followed by option text is a selection, not an idle prompt")
+	}
+}
+
 func TestCopilotPromptPattern_MatchesV1081InputArea(t *testing.T) {
 	t.Parallel()
 

--- a/e2e/agents/copilot_trust_test.go
+++ b/e2e/agents/copilot_trust_test.go
@@ -1,6 +1,9 @@
 package agents
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 // trustDialogPane is a trimmed capture of Copilot v1.0.63's interactive
 // startup dialog. Note the footer renders the navigation hint lowercase
@@ -96,5 +99,57 @@ func TestCopilotPromptReady_RejectsSessionRestorePicker(t *testing.T) {
 Failed to restore interrupted sessions: Error: Session abc is already in use`
 	if copilotPromptReady(restorePicker) {
 		t.Fatal("session restore picker should not be recognized as an interactive prompt")
+	}
+}
+
+func TestResolveGHConfigDir(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		goos      string
+		home      string
+		explicit  string
+		xdgConfig string
+		appData   string
+		want      string
+	}{
+		{
+			name:     "explicit override",
+			goos:     "darwin",
+			home:     "/Users/tester",
+			explicit: "/tmp/gh-auth",
+			want:     "/tmp/gh-auth",
+		},
+		{
+			name:      "XDG config",
+			goos:      "linux",
+			home:      "/home/tester",
+			xdgConfig: "/tmp/xdg",
+			want:      filepath.Join("/tmp/xdg", "gh"),
+		},
+		{
+			name:    "Windows AppData",
+			goos:    "windows",
+			home:    `C:\Users\tester`,
+			appData: `C:\Users\tester\AppData\Roaming`,
+			want:    filepath.Join(`C:\Users\tester\AppData\Roaming`, "GitHub CLI"),
+		},
+		{
+			name: "macOS uses gh fallback instead of os.UserConfigDir",
+			goos: "darwin",
+			home: "/Users/tester",
+			want: filepath.Join("/Users/tester", ".config", "gh"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveGHConfigDir(tt.goos, tt.home, tt.explicit, tt.xdgConfig, tt.appData)
+			if got != tt.want {
+				t.Fatalf("resolveGHConfigDir() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/e2e/agents/copilot_trust_test.go
+++ b/e2e/agents/copilot_trust_test.go
@@ -32,6 +32,21 @@ const interactivePromptPane = ` Tip: /app
 
  / commands · ? help                                  Claude Haiku 4.5`
 
+// copilotV1081PromptPane is the idle prompt captured from CI after Copilot
+// v1.0.81 replaced the bare "❯" marker with a bordered input area.
+const copilotV1081PromptPane = `Current   Sessions   Issues   Pull requests   Gists
+
+╭─╮╭─╮
+╰─╯╰─╯  Copilot v1.0.81 uses AI.
+█ ▘▝ █  Check for mistakes.
+ ▔▔▔▔
+
+/tmp/e2e-repo-3026103693 [⎇ master%]
+╻▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+┃
+╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+← open sidebar · / commands · ? help · tab next tab           Claude Haiku 4.5`
+
 // TestIsStartupDialog_DetectsLowercaseTrustFooter is the regression guard for
 // the Copilot v1.0.63 break: the trust dialog must be recognized even though
 // its footer is lowercase ("enter to select"), so the StartSession dismissal
@@ -62,5 +77,24 @@ func TestIsStartupDialog_IgnoresInteractivePrompt(t *testing.T) {
 	t.Parallel()
 	if isStartupDialog(interactivePromptPane) {
 		t.Fatal("bare interactive prompt should not be classified as a startup dialog")
+	}
+}
+
+func TestCopilotPromptPattern_MatchesV1081InputArea(t *testing.T) {
+	t.Parallel()
+
+	if !copilotPromptReady(copilotV1081PromptPane) {
+		t.Fatal("Copilot v1.0.81 bordered input area should be recognized as ready")
+	}
+}
+
+func TestCopilotPromptReady_RejectsSessionRestorePicker(t *testing.T) {
+	t.Parallel()
+
+	const restorePicker = `Choose which sessions to restore. Sessions that were open when Copilot stopped are preselected.
+┃ ❯ • 1. create a markdown file  Idle  just now
+Failed to restore interrupted sessions: Error: Session abc is already in use`
+	if copilotPromptReady(restorePicker) {
+		t.Fatal("session restore picker should not be recognized as an interactive prompt")
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1169
<!-- entire-trail-link-end -->

## Summary

Fix the real-agent E2E failures caused by current Claude Code workspace trust behavior and Copilot CLI v1.0.81 prompt and session handling.

## What changed

- Walk Claude startup dialogs to their affirmative option before confirming, keying on the affirmative wording rather than on a literal `No, exit`. Both labels are release-dependent, but only one is safe to guess wrong: a reworded negative read as affirmative quits Claude, and that surfaces as a misleading "waiting for startup prompt" timeout. The walk is gated on the dialog actually offering a choice, so first-run dialogs that also say "Enter to confirm" (theme selection) keep being answered by their default.
- Recognize both the old Copilot `❯` prompt and the v1.0.81 bordered input area.
- Give each interactive Copilot test an isolated home directory so parallel runs cannot restore or lock each other's sessions, while preserving GitHub CLI authentication through `GH_CONFIG_DIR`.
- Tighten the Copilot prompt pattern's "cursor alone on its line" anchors, which used `\s` and so matched across newlines.
- Record the coupling the isolated Copilot home creates — `copilotcli.GetSessionDir` resolves `$HOME/.copilot`, so only the agent and the hooks it spawns can resolve that session's transcript — and add `E2E_KEEP_AGENT_HOME` to retain the home when a failing run needs Copilot's own logs.
- Add replay tests using pane content captured from the failed CI jobs.

## Verification

- `go test -tags=integration -race ./...` — passes with a raised `-timeout`; under the default 10m, `redact` times out locally at 602s with the race detector on (pre-existing, unrelated to this branch)
- `mise run test:e2e:canary`: 4/4
- `gofmt -s`
- `golangci-lint` v2.11.3: 0 issues
- [Claude Code E2E run 33164906771](https://github.com/entireio/cli/actions/runs/33164906771): passed
- [Copilot CLI E2E run 33165842227](https://github.com/entireio/cli/actions/runs/33165842227): passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to E2E agent session bootstrap and detection helpers; no production CLI or auth logic beyond test env wiring.
> 
> **Overview**
> Fixes real-agent E2E startup handshakes for **Claude Code** and **Copilot CLI** after recent UI and state-sharing changes.
> 
> **Claude** startup now sends **Down** before **Enter** whenever the pane shows **No, exit** selected (cursor on a `❯` line), instead of matching a specific “Yes” label—so workspace trust and similar dialogs work with wording like “Yes, I trust this folder.” Unit tests replay CI pane captures for that helper.
> 
> **Copilot** broadens prompt detection to the v1.0.81 bordered input (`← open sidebar` or a bare `❯`) via `copilotPromptReady`, which still rejects trust dialogs and the “choose which sessions to restore” picker. Each interactive session gets a **temporary HOME** so parallel tests don’t fight over `~/.copilot` session restore/locks, while **GH_CONFIG_DIR** (or default `gh` config) keeps GitHub auth on the real machine. Regression tests cover v1.0.81 idle UI and the restore picker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029f8ae33fe6b4d39fb6a420bad6069e992bf2d9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
