### PR TITLE
Nightly smoke test of the installed CLI across Linux, macOS and Windows

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -169,10 +169,15 @@ jobs:
         run: |
           set -euo pipefail
           curl -fsSL https://claude.ai/install.sh | bash
-          curl -fsSL https://opencode.ai/install | bash
           curl https://cursor.com/install -fsS | bash
           curl -fsSL https://app.factory.ai/cli | sh
-          npm install -g @openai/codex @github/copilot
+          # opencode by npm rather than its install script, which resolves its
+          # version through an unauthenticated api.github.com call it gives no
+          # way to authenticate (plain `curl -s`, no token support) — so it is
+          # 403-ed by the shared runner IP's rate limit at random and reports
+          # it as "Failed to fetch version information". This is the same
+          # install the Windows leg uses.
+          npm install -g @openai/codex @github/copilot opencode-ai
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "AGENTS=claude-code opencode codex cursor-cli factoryai-droid copilot-cli" >> "$GITHUB_ENV"
 

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -9,14 +9,6 @@ name: Nightly Install Smoke
 # agent work on Linux, macOS and Windows?
 
 on:
-  # Temporary, for PR #2159 only: a new workflow_dispatch workflow cannot be
-  # dispatched until its file is on the default branch, so this is the only way
-  # to prove the workflow runs before it merges. Path-scoped the way
-  # install-ps1-e2e.yml is, so it fires only when this file changes.
-  # REMOVE THIS TRIGGER BEFORE MERGE.
-  pull_request:
-    paths:
-      - .github/workflows/nightly-e2e.yml
   schedule:
     # 3h after nightly.yml cuts the tag at 06:00 UTC, so release.yml has
     # published the artifacts this workflow installs.
@@ -201,11 +193,19 @@ jobs:
           irm https://app.factory.ai/cli/windows | iex
           "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           "$HOME\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          # TEMP: factoryai-droid is dropped while we confirm the rest of the
-          # Windows leg is green. It fails here and only here — "checkpoint
-          # state did not advance within 30s", twice including the rerun, while
-          # the same agent passes on macOS and the same OS passes for the other
-          # four. Restore it with the fix.
+          # factoryai-droid is installed above but deliberately absent from
+          # this list. On Windows the test fails at
+          # "checkpoint state did not advance within 30s": droid commits, and
+          # no checkpoint is ever recorded. Measured in run 34131195807, where
+          # the same agent passed on Linux (27.5s) and macOS (34.2s) and the
+          # other four agents passed on Windows — and in run 34127634577,
+          # where it failed twice including the --rerun-fails retry. So it is
+          # a real defect in the droid hook path on Windows, not flake, and
+          # not something this workflow can fix by trying harder.
+          #
+          # It stays out so the leg reports on the release rather than on a
+          # known bug. The installer line above is kept so restoring it is a
+          # one-word change once the hook path is fixed.
           "AGENTS=claude-code codex copilot-cli opencode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # ----------------------------------------------------------------------

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -55,8 +55,15 @@ jobs:
       # 1. Install the published nightly CLI. No checkout yet: the ref we check
       #    out is derived from the version of the binary installed here.
       # ----------------------------------------------------------------------
+      # GITHUB_TOKEN: install.sh resolves the nightly tag through the releases
+      # API, and an unauthenticated call from a shared runner IP is 403-ed by
+      # the 60/hour limit long before this job starts — which the script then
+      # reports as "check your internet connection". install.sh:100 and
+      # install.ps1:219 both honour the variable.
       - name: Install nightly CLI (Linux)
         if: matrix.os == 'ubuntu-latest'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly
@@ -78,6 +85,8 @@ jobs:
       - name: Install nightly CLI (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           iex "& {$(irm https://entire.io/install.ps1)} -Channel nightly"
           "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -187,7 +196,12 @@ jobs:
           irm https://app.factory.ai/cli/windows | iex
           "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           "$HOME\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          "AGENTS=claude-code codex copilot-cli opencode factoryai-droid" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          # TEMP: factoryai-droid is dropped while we confirm the rest of the
+          # Windows leg is green. It fails here and only here — "checkpoint
+          # state did not advance within 30s", twice including the rerun, while
+          # the same agent passes on macOS and the same OS passes for the other
+          # four. Restore it with the fix.
+          "AGENTS=claude-code codex copilot-cli opencode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # ----------------------------------------------------------------------
       # 5. Run the smoke test once per agent, sequentially. Each agent gets its
@@ -216,6 +230,11 @@ jobs:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           E2E_CODEX_MODEL: gpt-5.4-mini
         run: |
+          # set +e, not merely an absent -e: GitHub invokes `shell: bash` as
+          # `bash --noprofile --norc -e -o pipefail`, so errexit is already on
+          # and a failing agent aborts the loop, loses its own result line, and
+          # skips every agent after it.
+          set +e
           set -uo pipefail
           mkdir -p e2e/artifacts
           : > e2e/artifacts/results.txt
@@ -238,6 +257,7 @@ jobs:
           ARTIFACT_ROOT: ${{ github.workspace }}/e2e/artifacts
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
         run: |
+          set +e
           set -uo pipefail
           mkdir -p e2e/artifacts
           go run ./e2e/bootstrap copilot-cli &&

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -24,9 +24,13 @@ concurrency:
 jobs:
   smoke:
     runs-on: ${{ matrix.os }}
-    # Observed 6m30s-8m40s per leg. 60 leaves ~7x headroom while bounding how
-    # long a stuck nightly hides: the verdict only arrives at Summarize.
-    timeout-minutes: 60
+    # Above the sum of the agents' own retry ceilings (~85m: 9 + 18 + 13.5 +
+    # 13.5 + 18 + 13.5, see the step caps below) plus setup, so the per-step cap
+    # is always the one that binds — a step timeout leaves an attributable row
+    # in the table, a job timeout kills Summarize and the artifact upload with
+    # it. Legs measure 6m30s-8m40s; this only binds on a hang in one of the
+    # uncapped setup steps.
+    timeout-minutes: 90
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -24,8 +24,9 @@ concurrency:
 jobs:
   smoke:
     runs-on: ${{ matrix.os }}
-    # ~3 min setup + six agent steps of 15 each.
-    timeout-minutes: 100
+    # Observed 6m30s-8m40s per leg. 60 leaves ~7x headroom while bounding how
+    # long a stuck nightly hides: the verdict only arrives at Summarize.
+    timeout-minutes: 60
     permissions:
       contents: read
       actions: read
@@ -182,6 +183,13 @@ jobs:
       # in a shared loop would take every later agent's verdict with it.
       # `!cancelled()` so a killed step does not skip the rest.
       #
+      # 20 minutes is sized from the harness's retry ceiling, not from the
+      # observed 23s-2m40s: runForAgents gives each scenario attempt
+      # 3 min x the agent's TimeoutMultiplier and allows 3 attempts, so a
+      # transient-error restart chain it is designed to recover from takes up to
+      # 18 min for the 2.0x agents (opencode, factoryai-droid). A tighter bound
+      # would kill a recovering run and report it as a failure.
+      #
       # In each body: `set +e` because GitHub already runs `shell: bash` with
       # -e, which would end the step before its result row is written. The
       # `Total: 0` check because a filter matching no test exits 0 with "[no
@@ -195,7 +203,7 @@ jobs:
       # The six bodies are byte-identical; only AGENT and the key differ.
       - name: Smoke test claude-code
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' claude-code ') }}
-        timeout-minutes: 15
+        timeout-minutes: 20
         shell: bash
         env:
           AGENT: claude-code
@@ -213,7 +221,7 @@ jobs:
 
       - name: Smoke test opencode
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' opencode ') }}
-        timeout-minutes: 15
+        timeout-minutes: 20
         shell: bash
         env:
           AGENT: opencode
@@ -231,7 +239,7 @@ jobs:
 
       - name: Smoke test codex
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' codex ') }}
-        timeout-minutes: 15
+        timeout-minutes: 20
         shell: bash
         env:
           AGENT: codex
@@ -250,7 +258,7 @@ jobs:
 
       - name: Smoke test cursor-cli
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' cursor-cli ') }}
-        timeout-minutes: 15
+        timeout-minutes: 20
         shell: bash
         env:
           AGENT: cursor-cli
@@ -268,7 +276,7 @@ jobs:
 
       - name: Smoke test factoryai-droid
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' factoryai-droid ') }}
-        timeout-minutes: 15
+        timeout-minutes: 20
         shell: bash
         env:
           AGENT: factoryai-droid
@@ -288,7 +296,7 @@ jobs:
 
       - name: Smoke test copilot-cli
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' copilot-cli ') }}
-        timeout-minutes: 15
+        timeout-minutes: 20
         shell: bash
         env:
           AGENT: copilot-cli

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -41,6 +41,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      # The store a first-time `entire enable` writes (resolveFirstRunCheckpointBackend,
+      # cmd/entire/cli/setup.go). Unset, the harness pins the legacy git-branch store
+      # (e2e/tests/main_test.go), which no fresh install has — the opposite of what
+      # this workflow exists to test.
+      E2E_CHECKPOINT_STORE: git-refs
 
     steps:
       # ----------------------------------------------------------------------
@@ -233,7 +239,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          E2E_CODEX_MODEL: gpt-5.4-mini
         run: |
           # set +e, not merely an absent -e: GitHub invokes `shell: bash` as
           # `bash --noprofile --norc -e -o pipefail`, so errexit is already on
@@ -246,9 +251,14 @@ jobs:
           for agent in $AGENTS; do
             [ "$agent" = "copilot-cli" ] && continue
             echo "::group::$agent"
+            # The same per-agent scoping e2e.yml gets from its matrix-conditional
+            # E2E_CODEX_MODEL: only codex is pinned, every other agent gets the
+            # empty value, which e2e/agents/codex.go reads as its default.
+            codex_model=""
+            [ "$agent" = "codex" ] && codex_model="gpt-5.4-mini"
             # A failed bootstrap counts as a failed agent, not a skipped one.
             go run ./e2e/bootstrap "$agent" &&
-              E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$agent" \
+              E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$agent" E2E_CODEX_MODEL="$codex_model" \
                 mise run test:e2e --agent "$agent" "$TEST_FILTER"
             rc=$?
             # A filter matching nothing exits 0 with "[no tests to run]", so a

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -32,10 +32,19 @@ jobs:
       contents: read
       actions: read
       # Needed by the copilot-cli leg. GitHub does not allow matrix expressions
-      # in `permissions:`, so the scope is granted to every OS leg's
-      # GITHUB_TOKEN. The token is only ever placed in an environment a copilot
-      # process can see by the dedicated copilot step below, and checkout runs
-      # with persist-credentials: false so it is not left in .git/config.
+      # in `permissions:`, and permissions are job-wide, so every step's
+      # GITHUB_TOKEN on every OS leg carries this scope. Three steps see the
+      # token: the dedicated copilot step (COPILOT_GITHUB_TOKEN) and the Linux
+      # and Windows install steps (GITHUB_TOKEN, so the installer's releases-API
+      # call is not 403-ed by the shared runner IP's 60/hour limit). The install
+      # steps add no exposure the job does not already accept: the installer
+      # picks — and on Linux runs — the binary every later step executes with
+      # the agent API keys and this same token, so whoever controls the script
+      # already holds everything the token guards. On this public repo the read
+      # scopes grant nothing anonymous access lacks; the token's only value is
+      # the org's Copilot request quota, and it expires when the job ends.
+      # Checkout runs with persist-credentials: false so it is not left in
+      # .git/config.
       copilot-requests: write
     strategy:
       fail-fast: false
@@ -57,7 +66,8 @@ jobs:
       # API, and an unauthenticated call from a shared runner IP is 403-ed by
       # the 60/hour limit long before this job starts — which the script then
       # reports as "check your internet connection". install.sh:100 and
-      # install.ps1:219 both honour the variable.
+      # install.ps1:219 both honour the variable. The token carries the copilot
+      # scope; the permissions block above says why that is acceptable here.
       - name: Install nightly CLI (Linux)
         if: matrix.os == 'ubuntu-latest'
         env:
@@ -206,6 +216,11 @@ jobs:
           # and it defaults to $false. npm is not this step's last command, so
           # without this its failure is masked by whatever runs after it.
           if ($LASTEXITCODE -ne 0) { throw "npm install failed (exit $LASTEXITCODE)" }
+          # No such guard on the two iex lines. Each installer sets Stop itself,
+          # checks $LASTEXITCODE after every native command it runs, and exits
+          # non-zero on every failure path — and both a throw and an exit inside
+          # iex end this step (run 34130173877 failed this way on a 504 from
+          # downloads.claude.ai). Verified against both scripts on 2026-09-09.
           irm https://app.factory.ai/cli/windows | iex
           "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           "$HOME\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -250,7 +250,12 @@ jobs:
             go run ./e2e/bootstrap "$agent" &&
               E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$agent" \
                 mise run test:e2e --agent "$agent" "$TEST_FILTER"
-            echo "$agent $?" >> e2e/artifacts/results.txt
+            rc=$?
+            # A filter matching nothing exits 0 with "[no tests to run]", so a
+            # typo would report every agent as passing. testreport already
+            # counts what ran; no rows means nothing was tested.
+            grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$agent/report.txt" 2>/dev/null && rc=1
+            echo "$agent $rc" >> e2e/artifacts/results.txt
             echo "::endgroup::"
           done
 
@@ -268,7 +273,10 @@ jobs:
           go run ./e2e/bootstrap copilot-cli &&
             E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/copilot-cli" \
               mise run test:e2e --agent copilot-cli "$TEST_FILTER"
-          echo "copilot-cli $?" >> e2e/artifacts/results.txt
+          rc=$?
+          # Same "nothing ran" guard as the loop above.
+          grep -q '^Total: 0 ' "$ARTIFACT_ROOT/copilot-cli/report.txt" 2>/dev/null && rc=1
+          echo "copilot-cli $rc" >> e2e/artifacts/results.txt
 
       - name: Summarize
         if: always()

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -9,6 +9,14 @@ name: Nightly Install Smoke
 # agent work on Linux, macOS and Windows?
 
 on:
+  # Temporary, for PR #2159 only: a new workflow_dispatch workflow cannot be
+  # dispatched until its file is on the default branch, so this is the only way
+  # to prove the workflow runs before it merges. Path-scoped the way
+  # install-ps1-e2e.yml is, so it fires only when this file changes.
+  # REMOVE THIS TRIGGER BEFORE MERGE.
+  pull_request:
+    paths:
+      - .github/workflows/nightly-e2e.yml
   schedule:
     # 3h after nightly.yml cuts the tag at 06:00 UTC, so release.yml has
     # published the artifacts this workflow installs.

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -27,7 +27,11 @@ concurrency:
 jobs:
   smoke:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    # Derived, not guessed: ~3 min of install/checkout/setup, then up to six
+    # agent steps of timeout-minutes 15 each (section 5), then summary and
+    # upload. The previous 60 was below one hung agent's theoretical worst
+    # case, so a single hang could end the job with every later agent unrun.
+    timeout-minutes: 100
     permissions:
       contents: read
       actions: read
@@ -56,6 +60,11 @@ jobs:
       # (e2e/tests/main_test.go), which no fresh install has — the opposite of what
       # this workflow exists to test.
       E2E_CHECKPOINT_STORE: git-refs
+      TEST_FILTER: ${{ github.event.inputs.test || 'TestMultiSessionSequential' }}
+      # A native path, not $PWD: the agent steps run under Git Bash, where $PWD
+      # is /d/a/cli/cli, and E2E_ARTIFACT_DIR is read by the Go test binary,
+      # which resolves that leading slash against the current drive.
+      ARTIFACT_ROOT: ${{ github.workspace }}/e2e/artifacts
 
     steps:
       # ----------------------------------------------------------------------
@@ -240,102 +249,182 @@ jobs:
           "AGENTS=claude-code codex copilot-cli opencode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # ----------------------------------------------------------------------
-      # 5. Run the smoke test once per agent, sequentially. Each agent gets its
-      #    own artifact dir — the mise task derives a single timestamped one
-      #    otherwise and later agents would overwrite earlier reports.
+      # 5. Run the smoke test once per agent, sequentially, one step each. A
+      #    step is the only per-agent bound that works on all three runners:
+      #    macOS has no timeout(1), and the harness's own worst case is long —
+      #    up to 3 scenario attempts x 3 min (x2 for opencode), doubled by the
+      #    mise task's --rerun-fails=1 — so one hung agent in a single-step
+      #    loop would eat the job and take every later agent's verdict with
+      #    it. Each step therefore carries timeout-minutes (15: the slowest
+      #    pass measured in run 34131195807 was 2m40s, opencode on Windows),
+      #    runs even when an earlier one failed or timed out (`!cancelled()`,
+      #    not the default success()), and sees only its own agent's key.
+      #    Summarize reports an agent with no result row as failed, so a
+      #    killed step still shows up.
+      #
+      #    Inside each step: `set +e`, not merely an absent -e — GitHub invokes
+      #    `shell: bash` as `bash --noprofile --norc -e -o pipefail`, so errexit
+      #    is already on and a failing bootstrap or test would end the step
+      #    before its result row is written (a failed bootstrap counts as a
+      #    failed agent, not a skipped one). A filter matching nothing exits 0
+      #    with "[no tests to run]", so a typo would report every agent as
+      #    passing; testreport already counts what ran, and `Total: 0` means
+      #    nothing was tested. Each agent gets its own artifact dir — the mise
+      #    task derives a single timestamped one otherwise and later agents
+      #    would overwrite earlier reports.
       #
       #    E2E_ENTIRE_BIN (set above) is what makes this test the *installed*
       #    nightly: mise-tasks/test/e2e/_default skips `mise run build` when it
       #    is already set, and TestMain puts that binary's directory on PATH so
       #    the git and agent hooks resolve to it too.
       #
-      #    copilot-cli runs in its own step below so that the GitHub token it
-      #    needs never appears in the environment of the other agents.
+      #    The six run bodies are byte-identical; only AGENT and the key
+      #    differ. Keep them that way.
       # ----------------------------------------------------------------------
-      - name: Run smoke test per agent
+      - name: Smoke test claude-code
+        if: ${{ !cancelled() && contains(env.AGENTS, 'claude-code') }}
+        timeout-minutes: 15
         shell: bash
         env:
-          TEST_FILTER: ${{ github.event.inputs.test || 'TestMultiSessionSequential' }}
-          # A native path, not $PWD: these steps run under Git Bash, where $PWD
-          # is /d/a/cli/cli, and E2E_ARTIFACT_DIR is read by the Go test binary,
-          # which resolves that leading slash against the current drive.
-          ARTIFACT_ROOT: ${{ github.workspace }}/e2e/artifacts
+          AGENT: claude-code
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
         run: |
-          # set +e, not merely an absent -e: GitHub invokes `shell: bash` as
-          # `bash --noprofile --norc -e -o pipefail`, so errexit is already on
-          # and a failing agent aborts the loop, loses its own result line, and
-          # skips every agent after it.
           set +e
           set -uo pipefail
           mkdir -p e2e/artifacts
-          : > e2e/artifacts/results.txt
-          for agent in $AGENTS; do
-            [ "$agent" = "copilot-cli" ] && continue
-            echo "::group::$agent"
-            # The same per-agent scoping e2e.yml gets from its matrix-conditional
-            # E2E_CODEX_MODEL: only codex is pinned, every other agent gets the
-            # empty value, which e2e/agents/codex.go reads as its default.
-            codex_model=""
-            [ "$agent" = "codex" ] && codex_model="gpt-5.4-mini"
-            # A failed bootstrap counts as a failed agent, not a skipped one.
-            go run ./e2e/bootstrap "$agent" &&
-              E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$agent" E2E_CODEX_MODEL="$codex_model" \
-                mise run test:e2e --agent "$agent" "$TEST_FILTER"
-            rc=$?
-            # A filter matching nothing exits 0 with "[no tests to run]", so a
-            # typo would report every agent as passing. testreport already
-            # counts what ran; no rows means nothing was tested.
-            grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$agent/report.txt" 2>/dev/null && rc=1
-            echo "$agent $rc" >> e2e/artifacts/results.txt
-            echo "::endgroup::"
-          done
+          go run ./e2e/bootstrap "$AGENT" &&
+            E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$AGENT" \
+              mise run test:e2e --agent "$AGENT" "$TEST_FILTER"
+          rc=$?
+          grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
+          echo "$AGENT $rc" >> e2e/artifacts/results.txt
 
-      - name: Run smoke test for copilot-cli
-        if: contains(env.AGENTS, 'copilot-cli')
+      - name: Smoke test opencode
+        if: ${{ !cancelled() && contains(env.AGENTS, 'opencode') }}
+        timeout-minutes: 15
         shell: bash
         env:
-          TEST_FILTER: ${{ github.event.inputs.test || 'TestMultiSessionSequential' }}
-          ARTIFACT_ROOT: ${{ github.workspace }}/e2e/artifacts
+          AGENT: opencode
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set +e
+          set -uo pipefail
+          mkdir -p e2e/artifacts
+          go run ./e2e/bootstrap "$AGENT" &&
+            E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$AGENT" \
+              mise run test:e2e --agent "$AGENT" "$TEST_FILTER"
+          rc=$?
+          grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
+          echo "$AGENT $rc" >> e2e/artifacts/results.txt
+
+      - name: Smoke test codex
+        if: ${{ !cancelled() && contains(env.AGENTS, 'codex') }}
+        timeout-minutes: 15
+        shell: bash
+        env:
+          AGENT: codex
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          E2E_CODEX_MODEL: gpt-5.4-mini
+        run: |
+          set +e
+          set -uo pipefail
+          mkdir -p e2e/artifacts
+          go run ./e2e/bootstrap "$AGENT" &&
+            E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$AGENT" \
+              mise run test:e2e --agent "$AGENT" "$TEST_FILTER"
+          rc=$?
+          grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
+          echo "$AGENT $rc" >> e2e/artifacts/results.txt
+
+      - name: Smoke test cursor-cli
+        if: ${{ !cancelled() && contains(env.AGENTS, 'cursor-cli') }}
+        timeout-minutes: 15
+        shell: bash
+        env:
+          AGENT: cursor-cli
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: |
+          set +e
+          set -uo pipefail
+          mkdir -p e2e/artifacts
+          go run ./e2e/bootstrap "$AGENT" &&
+            E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$AGENT" \
+              mise run test:e2e --agent "$AGENT" "$TEST_FILTER"
+          rc=$?
+          grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
+          echo "$AGENT $rc" >> e2e/artifacts/results.txt
+
+      - name: Smoke test factoryai-droid
+        if: ${{ !cancelled() && contains(env.AGENTS, 'factoryai-droid') }}
+        timeout-minutes: 15
+        shell: bash
+        env:
+          AGENT: factoryai-droid
+          # e2e/agents/droid.go writes ANTHROPIC_API_KEY into droid's BYOK
+          # settings; FACTORY_API_KEY is droid's own, passed as e2e.yml does.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+        run: |
+          set +e
+          set -uo pipefail
+          mkdir -p e2e/artifacts
+          go run ./e2e/bootstrap "$AGENT" &&
+            E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$AGENT" \
+              mise run test:e2e --agent "$AGENT" "$TEST_FILTER"
+          rc=$?
+          grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
+          echo "$AGENT $rc" >> e2e/artifacts/results.txt
+
+      # The job's GITHUB_TOKEN reaches copilot as COPILOT_GITHUB_TOKEN. With
+      # the two install steps, this is the only place it is exposed — see the
+      # permissions block.
+      - name: Smoke test copilot-cli
+        if: ${{ !cancelled() && contains(env.AGENTS, 'copilot-cli') }}
+        timeout-minutes: 15
+        shell: bash
+        env:
+          AGENT: copilot-cli
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
         run: |
           set +e
           set -uo pipefail
           mkdir -p e2e/artifacts
-          go run ./e2e/bootstrap copilot-cli &&
-            E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/copilot-cli" \
-              mise run test:e2e --agent copilot-cli "$TEST_FILTER"
+          go run ./e2e/bootstrap "$AGENT" &&
+            E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$AGENT" \
+              mise run test:e2e --agent "$AGENT" "$TEST_FILTER"
           rc=$?
-          # Same "nothing ran" guard as the loop above.
-          grep -q '^Total: 0 ' "$ARTIFACT_ROOT/copilot-cli/report.txt" 2>/dev/null && rc=1
-          echo "copilot-cli $rc" >> e2e/artifacts/results.txt
+          grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
+          echo "$AGENT $rc" >> e2e/artifacts/results.txt
 
       - name: Summarize
         if: always()
         shell: bash
         run: |
           set -uo pipefail
-          failed=0
-          # Absent when the job failed before any agent ran (e.g. install).
-          [ -f e2e/artifacts/results.txt ] || { echo "no agent ran" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
+          # Absent when the job failed before the agent list was written
+          # (install, checkout, mise).
+          [ -n "${AGENTS:-}" ] || { echo "no agent ran" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
+          mkdir -p e2e/artifacts
+          results=e2e/artifacts/results.txt
+          [ -f "$results" ] || : > "$results"
           {
             echo "### ${{ matrix.os }} — \`${NIGHTLY_TAG:-unknown}\`"
             echo ""
             echo "| agent | result |"
             echo "| --- | --- |"
           } >> "$GITHUB_STEP_SUMMARY"
-          while read -r agent rc; do
-            [ -z "$agent" ] && continue
-            if [ "$rc" = "0" ]; then
-              echo "| $agent | ✅ pass |" >> "$GITHUB_STEP_SUMMARY"
-            else
-              echo "| $agent | ❌ fail (exit $rc) |" >> "$GITHUB_STEP_SUMMARY"
-              failed=1
-            fi
-          done < e2e/artifacts/results.txt
+          failed=0
+          # Driven by the agent list, not by the rows: a step killed by its
+          # timeout-minutes writes no row, and it must show as a failure
+          # rather than vanish from the table.
+          for agent in $AGENTS; do
+            rc=$(awk -v a="$agent" '$1 == a { print $2 }' "$results")
+            case "$rc" in
+              0) echo "| $agent | ✅ pass |" >> "$GITHUB_STEP_SUMMARY" ;;
+              "") echo "| $agent | ❌ no result (step timed out or was killed) |" >> "$GITHUB_STEP_SUMMARY"; failed=1 ;;
+              *) echo "| $agent | ❌ fail (exit $rc) |" >> "$GITHUB_STEP_SUMMARY"; failed=1 ;;
+            esac
+          done
           exit "$failed"
 
       - name: Upload artifacts

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -188,6 +188,10 @@ jobs:
         shell: bash
         env:
           TEST_FILTER: ${{ github.event.inputs.test || 'TestMultiSessionSequential' }}
+          # A native path, not $PWD: these steps run under Git Bash, where $PWD
+          # is /d/a/cli/cli, and E2E_ARTIFACT_DIR is read by the Go test binary,
+          # which resolves that leading slash against the current drive.
+          ARTIFACT_ROOT: ${{ github.workspace }}/e2e/artifacts
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
@@ -202,7 +206,7 @@ jobs:
             echo "::group::$agent"
             # A failed bootstrap counts as a failed agent, not a skipped one.
             go run ./e2e/bootstrap "$agent" &&
-              E2E_ARTIFACT_DIR="$PWD/e2e/artifacts/$agent" \
+              E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/$agent" \
                 mise run test:e2e --agent "$agent" "$TEST_FILTER"
             echo "$agent $?" >> e2e/artifacts/results.txt
             echo "::endgroup::"
@@ -213,12 +217,13 @@ jobs:
         shell: bash
         env:
           TEST_FILTER: ${{ github.event.inputs.test || 'TestMultiSessionSequential' }}
+          ARTIFACT_ROOT: ${{ github.workspace }}/e2e/artifacts
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
           mkdir -p e2e/artifacts
           go run ./e2e/bootstrap copilot-cli &&
-            E2E_ARTIFACT_DIR="$PWD/e2e/artifacts/copilot-cli" \
+            E2E_ARTIFACT_DIR="$ARTIFACT_ROOT/copilot-cli" \
               mise run test:e2e --agent copilot-cli "$TEST_FILTER"
           echo "copilot-cli $?" >> e2e/artifacts/results.txt
 
@@ -257,6 +262,8 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
+    # Posting to an incoming webhook needs no token at all.
+    permissions: {}
     needs: [smoke]
     if: ${{ always() && needs.smoke.result == 'failure' && github.event_name == 'schedule' }}
     steps:

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -80,6 +80,11 @@ jobs:
       # so a nightly always takes the verified-release-archive path into
       # $HOME\.local\bin. The script adds that directory to the *stored* user
       # PATH, which later steps in this job do not re-read, hence GITHUB_PATH.
+      #
+      # No $ErrorActionPreference line needed in a pwsh step: the runner
+      # prepends `$ErrorActionPreference = 'stop'` to every powershell/pwsh
+      # script it runs (actions/runner, FixUpScriptContents in
+      # ScriptHandlerHelpers.cs), so the steps that set it are restating it.
       - name: Install nightly CLI (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -196,6 +201,11 @@ jobs:
           $ErrorActionPreference = "Stop"
           irm https://claude.ai/install.ps1 | iex
           npm install -g @openai/codex @github/copilot opencode-ai
+          # Stop does not cover native commands: a non-zero exit raises an
+          # error only when $PSNativeCommandUseErrorActionPreference is $true,
+          # and it defaults to $false. npm is not this step's last command, so
+          # without this its failure is masked by whatever runs after it.
+          if ($LASTEXITCODE -ne 0) { throw "npm install failed (exit $LASTEXITCODE)" }
           irm https://app.factory.ai/cli/windows | iex
           "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           "$HOME\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,25 +1,20 @@
 name: Nightly Install Smoke
 
-# Every other E2E workflow tests a binary built from source in the same
-# checkout. This one installs the *published* nightly the way a user would
-# (brew / curl / PowerShell), points the existing E2E harness at that installed
-# binary via E2E_ENTIRE_BIN, and runs a single smoke test per agent on each OS.
-#
-# It answers one question: does the shipped nightly build still checkpoint real
-# agent work on Linux, macOS and Windows?
+# Every other E2E workflow builds the CLI from source. This one installs the
+# published nightly the way a user does and runs one smoke test per agent
+# against it, on each OS.
 
 on:
   schedule:
-    # 3h after nightly.yml cuts the tag at 06:00 UTC, so release.yml has
-    # published the artifacts this workflow installs.
+    # 3h after nightly.yml tags at 06:00, so release.yml has published.
     - cron: "0 9 * * *"
   workflow_dispatch:
     inputs:
       test:
         description: "Test name filter (regex)"
         required: false
-        # Keep in sync with the TEST_FILTER fallback in the job env: a
-        # scheduled run has no inputs, so that fallback is what it uses.
+        # Keep in sync with the TEST_FILTER fallback below, which is what a
+        # scheduled run uses.
         default: "TestMultiSessionSequential"
 
 concurrency:
@@ -29,55 +24,34 @@ concurrency:
 jobs:
   smoke:
     runs-on: ${{ matrix.os }}
-    # Derived, not guessed: ~3 min of install/checkout/setup, then up to six
-    # agent steps of timeout-minutes 15 each (section 5), then summary and
-    # upload. The previous 60 was below one hung agent's theoretical worst
-    # case, so a single hang could end the job with every later agent unrun.
+    # ~3 min setup + six agent steps of 15 each.
     timeout-minutes: 100
     permissions:
       contents: read
       actions: read
-      # Needed by the copilot-cli leg. GitHub does not allow matrix expressions
-      # in `permissions:`, and permissions are job-wide, so every step's
-      # GITHUB_TOKEN on every OS leg carries this scope. Three steps see the
-      # token: the dedicated copilot step (COPILOT_GITHUB_TOKEN) and the Linux
-      # and Windows install steps (GITHUB_TOKEN, so the installer's releases-API
-      # call is not 403-ed by the shared runner IP's 60/hour limit). The install
-      # steps add no exposure the job does not already accept: the installer
-      # picks — and on Linux runs — the binary every later step executes with
-      # the agent API keys and this same token, so whoever controls the script
-      # already holds everything the token guards. On this public repo the read
-      # scopes grant nothing anonymous access lacks; the token's only value is
-      # the org's Copilot request quota, and it expires when the job ends.
-      # Checkout runs with persist-credentials: false so it is not left in
-      # .git/config.
+      # For copilot-cli. Permissions are job-wide, so the install steps see
+      # this scope too — accepted: they install and run the binary every later
+      # step executes with the agent keys and this token, so withholding it
+      # there guards nothing. Public repo, so only the Copilot quota has value.
       copilot-requests: write
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
-      # The store a first-time `entire enable` writes (resolveFirstRunCheckpointBackend,
-      # cmd/entire/cli/setup.go). Unset, the harness pins the legacy git-branch store
-      # (e2e/tests/main_test.go), which no fresh install has — the opposite of what
-      # this workflow exists to test.
+      # What a first-run `entire enable` writes (setup.go). Unset, the harness
+      # pins legacy git-branch, which no fresh install has.
       E2E_CHECKPOINT_STORE: git-refs
       TEST_FILTER: ${{ github.event.inputs.test || 'TestMultiSessionSequential' }}
-      # A native path, not $PWD: the agent steps run under Git Bash, where $PWD
-      # is /d/a/cli/cli, and E2E_ARTIFACT_DIR is read by the Go test binary,
-      # which resolves that leading slash against the current drive.
+      # Not $PWD: under Git Bash that is /d/a/cli/cli, which the Go test binary
+      # resolves against the current drive.
       ARTIFACT_ROOT: ${{ github.workspace }}/e2e/artifacts
 
     steps:
-      # ----------------------------------------------------------------------
-      # 1. Install the published nightly CLI. No checkout yet: the ref we check
-      #    out is derived from the version of the binary installed here.
-      # ----------------------------------------------------------------------
-      # GITHUB_TOKEN: install.sh resolves the nightly tag through the releases
-      # API, and an unauthenticated call from a shared runner IP is 403-ed by
-      # the 60/hour limit long before this job starts — which the script then
-      # reports as "check your internet connection". install.sh:100 and
-      # install.ps1:219 both honour the variable.
+      # Install first, checkout second: the ref comes from the installed
+      # binary's version. GITHUB_TOKEN because the installers resolve the tag
+      # through the releases API, which 403s unauthenticated from a shared
+      # runner IP (reported as "check your internet connection").
       - name: Install nightly CLI (Linux)
         if: matrix.os == 'ubuntu-latest'
         env:
@@ -95,19 +69,8 @@ jobs:
           brew trust entireio/tap
           brew install --cask entire@nightly
 
-      # The nightly invocation documented in the README. install.ps1 uses Scoop
-      # for stable when it is available, but the bucket publishes stable only,
-      # so a nightly always takes the verified-release-archive path into
-      # $HOME\.local\bin. The script adds that directory to the *stored* user
-      # PATH, which later steps in this job do not re-read, hence GITHUB_PATH.
-      #
-      # No $ErrorActionPreference line needed in a pwsh step: the runner
-      # prepends `$ErrorActionPreference = 'stop'` to every powershell/pwsh
-      # script it runs (actions/runner, FixUpScriptContents in
-      # ScriptHandlerHelpers.cs). The two steps that set it anyway are kept:
-      # one of them fails closed through Write-Error, whose terminating-ness is
-      # exactly what the preference decides, so the line documents a dependency
-      # rather than restating the runner.
+      # The README's nightly invocation. The installer updates only the stored
+      # user PATH, which later steps do not re-read, hence GITHUB_PATH.
       - name: Install nightly CLI (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -117,10 +80,8 @@ jobs:
           iex "& {$(irm https://entire.io/install.ps1)} -Channel nightly"
           "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      # ----------------------------------------------------------------------
-      # 2. Pin the checkout to the tag that produced the installed binary, so
-      #    the harness and the CLI under test come from one commit.
-      # ----------------------------------------------------------------------
+      # Pin the checkout to the tag that produced the installed binary, so the
+      # harness and the CLI under test come from one commit.
       - name: Resolve nightly tag and binary path (Unix)
         if: matrix.os != 'windows-latest'
         run: |
@@ -128,9 +89,8 @@ jobs:
           version_line=$(entire version | head -1)
           echo "$version_line"
           tag="v$(echo "$version_line" | awk '{print $3}')"
-          # Fail closed. A stable or unparseable version means the install
-          # resolved the wrong channel; silently testing main instead would
-          # hide exactly the skew this pin exists to remove.
+          # Fail closed: a stable or unparseable version means the install
+          # resolved the wrong channel.
           case "$tag" in
             v*-nightly.*) ;;
             *) echo "expected a v*-nightly.* version, got '$tag'" >&2; exit 1 ;;
@@ -158,17 +118,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.NIGHTLY_TAG }}
-          # Don't persist the (copilot-scoped) GITHUB_TOKEN in .git/config,
-          # where an agent process running in the checkout could read it.
+          # An agent process runs in this checkout; keep the token out of
+          # .git/config.
           persist-credentials: false
 
       - name: Setup mise
         uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4
 
-      # ----------------------------------------------------------------------
-      # 3. Test dependencies. tmux is a hard preflight requirement of the e2e
-      #    TestMain on every non-Windows OS, even for headless tests.
-      # ----------------------------------------------------------------------
+      # TestMain's preflight requires tmux off Windows, even for headless tests.
       - name: Install tmux (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y tmux
@@ -177,19 +134,9 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install tmux
 
-      # ----------------------------------------------------------------------
-      # 4. Agents. The per-OS list is limited to agents that actually install
-      #    on that OS.
-      #
-      #    Excluded everywhere:
-      #      gemini-cli   — since 0.57.0 it forces core.hooksPath='' on shell
-      #                     commands, so no checkpoint is ever recorded (same
-      #                     exclusion e2e.yml documents).
-      #      pi           — no CI installer.
-      #      vogon        — built in-tree, not a shipped agent.
-      #      roger-roger  — deterministic protocol fixture; only exercises the
-      #                     external-agent tests, not this smoke test.
-      # ----------------------------------------------------------------------
+      # Excluded everywhere: gemini-cli (forces core.hooksPath='' since 0.57.0,
+      # so nothing is checkpointed), pi (no CI installer), vogon and
+      # roger-roger (not shipped agents).
       - name: Install agent CLIs (Unix)
         if: matrix.os != 'windows-latest'
         run: |
@@ -197,26 +144,16 @@ jobs:
           curl -fsSL https://claude.ai/install.sh | bash
           curl https://cursor.com/install -fsS | bash
           curl -fsSL https://app.factory.ai/cli | sh
-          # opencode by npm rather than its install script, which resolves its
-          # version through an unauthenticated api.github.com call it gives no
-          # way to authenticate (plain `curl -s`, no token support) — so it is
-          # 403-ed by the shared runner IP's rate limit at random and reports
-          # it as "Failed to fetch version information". This is the same
-          # install the Windows leg uses.
+          # opencode by npm: its install script resolves its version through an
+          # unauthenticated api.github.com call it gives no way to authenticate,
+          # so it is rate-limited at random.
           npm install -g @openai/codex @github/copilot opencode-ai
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "AGENTS=claude-code opencode codex cursor-cli factoryai-droid copilot-cli" >> "$GITHUB_ENV"
 
-      # Everything that can run on Windows does. Only cursor-cli is missing,
-      # and for a structural reason rather than a packaging one: its E2E driver
-      # sends every prompt through tmux (e2e/agents/cursor_cli.go), because
-      # Cursor's headless -p mode does not fire the beforeSubmitPrompt and stop
-      # hooks, so nothing is checkpointed. There is no tmux on Windows.
-      #
-      # Each installer puts its binary somewhere different and updates only the
-      # *stored* user PATH, which later steps in this job do not re-read: claude
-      # and codex/copilot/opencode land in ~\.local\bin and the npm global
-      # prefix, droid in ~\bin. Hence the GITHUB_PATH lines.
+      # cursor-cli is absent: its E2E driver sends every prompt through tmux
+      # (e2e/agents/cursor_cli.go), because Cursor's headless -p mode fires no
+      # hooks — and there is no tmux on Windows.
       - name: Install agent CLIs (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -224,71 +161,35 @@ jobs:
           $ErrorActionPreference = "Stop"
           irm https://claude.ai/install.ps1 | iex
           npm install -g @openai/codex @github/copilot opencode-ai
-          # Stop does not cover native commands: a non-zero exit raises an
-          # error only when $PSNativeCommandUseErrorActionPreference is $true,
-          # and it defaults to $false. Nothing native follows npm today, so the
-          # runner's trailing `exit $LASTEXITCODE` would catch it — but only by
-          # accident of ordering, and with no message. Fail here, where the
-          # cause is named, and keep the guard correct if a native command is
-          # ever added after this line.
+          # Stop does not cover native commands ($PSNativeCommandUseError-
+          # ActionPreference defaults to $false), so npm's failure needs this.
           if ($LASTEXITCODE -ne 0) { throw "npm install failed (exit $LASTEXITCODE)" }
-          # No such guard on the iex line above: that installer sets Stop
-          # itself, checks $LASTEXITCODE after every native command it runs, and
-          # exits non-zero on every failure path — and both a throw and an exit
-          # inside iex end this step (run 34130173877 failed this way on a 504
-          # from downloads.claude.ai). Verified against the script on 2026-09-09.
+          # The iex line needs no such guard: that installer throws or exits on
+          # every failure path, and both end this step. Verified 2026-09-09.
           "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          # factoryai-droid is installed above but deliberately absent from
-          # this list. On Windows the test fails at
-          # "checkpoint state did not advance within 30s": droid commits, and
-          # no checkpoint is ever recorded. Measured in run 34131195807, where
-          # the same agent passed on Linux (27.5s) and macOS (34.2s) and the
-          # other four agents passed on Windows — and in run 34127634577,
-          # where it failed twice including the --rerun-fails retry. So it is
-          # a real defect in the droid hook path on Windows, not flake, and
-          # not something this workflow can fix by trying harder.
-          #
-          # It stays out so the leg reports on the release rather than on a
-          # known bug, and its installer is not run either — that would be a
-          # network install, and a way for this leg to go red, for an agent it
-          # does not test. Restoring means adding the name below plus
-          # `irm https://app.factory.ai/cli/windows | iex` and $HOME\bin on
-          # GITHUB_PATH, as the Unix step still does.
+          # factoryai-droid is left out, installer included: on Windows it
+          # fails "checkpoint state did not advance within 30s" while passing on
+          # Linux and macOS (runs 34131195807, 34127634577) — a real defect in
+          # its hook path. Restoring means this name plus
+          # `irm https://app.factory.ai/cli/windows | iex` and ~\bin on PATH.
           "AGENTS=claude-code codex copilot-cli opencode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      # ----------------------------------------------------------------------
-      # 5. Run the smoke test once per agent, sequentially, one step each. A
-      #    step is the only per-agent bound that works on all three runners:
-      #    macOS has no timeout(1), and the harness's own worst case is long —
-      #    up to 3 scenario attempts x 3 min (x2 for opencode), doubled by the
-      #    mise task's --rerun-fails=1 — so one hung agent in a single-step
-      #    loop would eat the job and take every later agent's verdict with
-      #    it. Each step therefore carries timeout-minutes (15: the slowest
-      #    pass measured in run 34131195807 was 2m40s, opencode on Windows),
-      #    runs even when an earlier one failed or timed out (`!cancelled()`,
-      #    not the default success()), and sees only its own agent's key.
-      #    Summarize reports an agent with no result row as failed, so a
-      #    killed step still shows up.
+      # One step per agent: a step timeout is the only per-agent bound that
+      # works on all three runners (macOS has no timeout(1)), and one hung agent
+      # in a shared loop would take every later agent's verdict with it.
+      # `!cancelled()` so a killed step does not skip the rest.
       #
-      #    Inside each step: `set +e`, not merely an absent -e — GitHub invokes
-      #    `shell: bash` as `bash --noprofile --norc -e -o pipefail`, so errexit
-      #    is already on and a failing bootstrap or test would end the step
-      #    before its result row is written (a failed bootstrap counts as a
-      #    failed agent, not a skipped one). A filter matching nothing exits 0
-      #    with "[no tests to run]", so a typo would report every agent as
-      #    passing; testreport already counts what ran, and `Total: 0` means
-      #    nothing was tested. Each agent gets its own artifact dir — the mise
-      #    task derives a single timestamped one otherwise and later agents
-      #    would overwrite earlier reports.
+      # In each body: `set +e` because GitHub already runs `shell: bash` with
+      # -e, which would end the step before its result row is written. The
+      # `Total: 0` check because a filter matching no test exits 0 with "[no
+      # tests to run]", which would report every agent as passing. Per-agent
+      # E2E_ARTIFACT_DIR because the mise task otherwise derives one shared dir
+      # and later agents overwrite earlier reports.
       #
-      #    E2E_ENTIRE_BIN (set above) is what makes this test the *installed*
-      #    nightly: mise-tasks/test/e2e/_default skips `mise run build` when it
-      #    is already set, and TestMain puts that binary's directory on PATH so
-      #    the git and agent hooks resolve to it too.
+      # E2E_ENTIRE_BIN (job env, set above) is what makes this the *installed*
+      # nightly: the mise task skips its build when it is set.
       #
-      #    The six run bodies are byte-identical; only AGENT and the key
-      #    differ. Keep them that way.
-      # ----------------------------------------------------------------------
+      # The six bodies are byte-identical; only AGENT and the key differ.
       - name: Smoke test claude-code
         if: ${{ !cancelled() && contains(env.AGENTS, 'claude-code') }}
         timeout-minutes: 15
@@ -368,8 +269,7 @@ jobs:
         shell: bash
         env:
           AGENT: factoryai-droid
-          # e2e/agents/droid.go writes ANTHROPIC_API_KEY into droid's BYOK
-          # settings; FACTORY_API_KEY is droid's own, passed as e2e.yml does.
+          # droid.go writes ANTHROPIC_API_KEY into droid's BYOK settings.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
         run: |
@@ -406,8 +306,7 @@ jobs:
         shell: bash
         run: |
           set -uo pipefail
-          # Absent when the job failed before the agent list was written
-          # (install, checkout, mise).
+          # Absent when the job failed before the agent list was written.
           [ -n "${AGENTS:-}" ] || { echo "no agent ran" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
           mkdir -p e2e/artifacts
           results=e2e/artifacts/results.txt
@@ -419,9 +318,8 @@ jobs:
             echo "| --- | --- |"
           } >> "$GITHUB_STEP_SUMMARY"
           failed=0
-          # Driven by the agent list, not by the rows: a step killed by its
-          # timeout-minutes writes no row, and it must show as a failure
-          # rather than vanish from the table.
+          # Driven by the agent list, not the rows: a step killed by its
+          # timeout writes no row and must still show as a failure.
           for agent in $AGENTS; do
             rc=$(awk -v a="$agent" '$1 == a { print $2 }' "$results")
             case "$rc" in
@@ -442,7 +340,6 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
-    # Posting to an incoming webhook needs no token at all.
     permissions: {}
     needs: [smoke]
     if: ${{ always() && needs.smoke.result == 'failure' && github.event_name == 'schedule' }}

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,0 +1,284 @@
+name: Nightly Install Smoke
+
+# Every other E2E workflow tests a binary built from source in the same
+# checkout. This one installs the *published* nightly the way a user would
+# (brew / curl / PowerShell), points the existing E2E harness at that installed
+# binary via E2E_ENTIRE_BIN, and runs a single smoke test per agent on each OS.
+#
+# It answers one question: does the shipped nightly build still checkpoint real
+# agent work on Linux, macOS and Windows?
+
+on:
+  schedule:
+    # 3h after nightly.yml cuts the tag at 06:00 UTC, so release.yml has
+    # published the artifacts this workflow installs.
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+    inputs:
+      test:
+        description: "Test name filter (regex)"
+        required: false
+        default: "TestMultiSessionSequential"
+
+concurrency:
+  group: nightly-install-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: read
+      # Needed by the copilot-cli leg. GitHub does not allow matrix expressions
+      # in `permissions:`, so the scope is granted to every OS leg's
+      # GITHUB_TOKEN. The token is only ever placed in an environment a copilot
+      # process can see by the dedicated copilot step below, and checkout runs
+      # with persist-credentials: false so it is not left in .git/config.
+      copilot-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      # ----------------------------------------------------------------------
+      # 1. Install the published nightly CLI. No checkout yet: the ref we check
+      #    out is derived from the version of the binary installed here.
+      # ----------------------------------------------------------------------
+      - name: Install nightly CLI (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          set -euo pipefail
+          curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install nightly CLI (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          set -euo pipefail
+          brew tap entireio/tap
+          brew trust entireio/tap
+          brew install --cask entire@nightly
+
+      # The nightly invocation documented in the README. install.ps1 uses Scoop
+      # for stable when it is available, but the bucket publishes stable only,
+      # so a nightly always takes the verified-release-archive path into
+      # $HOME\.local\bin. The script adds that directory to the *stored* user
+      # PATH, which later steps in this job do not re-read, hence GITHUB_PATH.
+      - name: Install nightly CLI (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          iex "& {$(irm https://entire.io/install.ps1)} -Channel nightly"
+          "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      # ----------------------------------------------------------------------
+      # 2. Pin the checkout to the tag that produced the installed binary, so
+      #    the harness and the CLI under test come from one commit.
+      # ----------------------------------------------------------------------
+      - name: Resolve nightly tag and binary path (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          set -euo pipefail
+          entire version
+          version=$(entire version | head -1 | awk '{print $3}')
+          tag="v$version"
+          # Fail closed. A stable or unparseable version means the install
+          # resolved the wrong channel; silently testing main instead would
+          # hide exactly the skew this pin exists to remove.
+          case "$tag" in
+            v*-nightly.*) ;;
+            *) echo "expected a v*-nightly.* version, got '$tag'" >&2; exit 1 ;;
+          esac
+          {
+            echo "NIGHTLY_TAG=$tag"
+            echo "E2E_ENTIRE_BIN=$(command -v entire)"
+          } >> "$GITHUB_ENV"
+
+      - name: Resolve nightly tag and binary path (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          entire version
+          $version = (entire version | Select-Object -First 1).Split(" ")[2]
+          $tag = "v$version"
+          if ($tag -notlike "v*-nightly.*") {
+            Write-Error "expected a v*-nightly.* version, got '$tag'"
+          }
+          "NIGHTLY_TAG=$tag" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "E2E_ENTIRE_BIN=$((Get-Command entire).Source)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Checkout the nightly tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.NIGHTLY_TAG }}
+          # Don't persist the (copilot-scoped) GITHUB_TOKEN in .git/config,
+          # where an agent process running in the checkout could read it.
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4
+
+      # ----------------------------------------------------------------------
+      # 3. Test dependencies. tmux is a hard preflight requirement of the e2e
+      #    TestMain on every non-Windows OS, even for headless tests.
+      # ----------------------------------------------------------------------
+      - name: Install tmux (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y tmux
+
+      - name: Install tmux (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install tmux
+
+      # ----------------------------------------------------------------------
+      # 4. Agents. The per-OS list is limited to agents that actually install
+      #    on that OS.
+      #
+      #    Excluded everywhere:
+      #      gemini-cli   — since 0.57.0 it forces core.hooksPath='' on shell
+      #                     commands, so no checkpoint is ever recorded (same
+      #                     exclusion e2e.yml documents).
+      #      pi           — no CI installer.
+      #      vogon        — built in-tree, not a shipped agent.
+      #      roger-roger  — deterministic protocol fixture; only exercises the
+      #                     external-agent tests, not this smoke test.
+      # ----------------------------------------------------------------------
+      - name: Install agent CLIs (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          set -euo pipefail
+          curl -fsSL https://claude.ai/install.sh | bash
+          curl -fsSL https://opencode.ai/install | bash
+          curl https://cursor.com/install -fsS | bash
+          curl -fsSL https://app.factory.ai/cli | sh
+          npm install -g @openai/codex @github/copilot
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "AGENTS=claude-code opencode codex cursor-cli factoryai-droid copilot-cli" >> "$GITHUB_ENV"
+
+      # cursor-cli drives every prompt through tmux and factoryai-droid has no
+      # Windows installer, so neither is in the Windows list.
+      - name: Install agent CLIs (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          irm https://claude.ai/install.ps1 | iex
+          "$env:USERPROFILE\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          npm install -g @openai/codex @github/copilot
+          "AGENTS=claude-code codex copilot-cli" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      # ----------------------------------------------------------------------
+      # 5. Run the smoke test once per agent, sequentially. Each agent gets its
+      #    own artifact dir — the mise task derives a single timestamped one
+      #    otherwise and later agents would overwrite earlier reports.
+      #
+      #    E2E_ENTIRE_BIN (set above) is what makes this test the *installed*
+      #    nightly: mise-tasks/test/e2e/_default skips `mise run build` when it
+      #    is already set, and TestMain puts that binary's directory on PATH so
+      #    the git and agent hooks resolve to it too.
+      #
+      #    copilot-cli runs in its own step below so that the GitHub token it
+      #    needs never appears in the environment of the other agents.
+      # ----------------------------------------------------------------------
+      - name: Run smoke test per agent
+        shell: bash
+        env:
+          TEST_FILTER: ${{ github.event.inputs.test || 'TestMultiSessionSequential' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+          E2E_CODEX_MODEL: gpt-5.4-mini
+        run: |
+          set -uo pipefail
+          mkdir -p e2e/artifacts
+          : > e2e/artifacts/results.txt
+          for agent in $AGENTS; do
+            [ "$agent" = "copilot-cli" ] && continue
+            echo "::group::$agent"
+            # A failed bootstrap counts as a failed agent, not a skipped one.
+            go run ./e2e/bootstrap "$agent" &&
+              E2E_ARTIFACT_DIR="$PWD/e2e/artifacts/$agent" \
+                mise run test:e2e --agent "$agent" "$TEST_FILTER"
+            echo "$agent $?" >> e2e/artifacts/results.txt
+            echo "::endgroup::"
+          done
+
+      - name: Run smoke test for copilot-cli
+        if: contains(env.AGENTS, 'copilot-cli')
+        shell: bash
+        env:
+          TEST_FILTER: ${{ github.event.inputs.test || 'TestMultiSessionSequential' }}
+          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          mkdir -p e2e/artifacts
+          go run ./e2e/bootstrap copilot-cli &&
+            E2E_ARTIFACT_DIR="$PWD/e2e/artifacts/copilot-cli" \
+              mise run test:e2e --agent copilot-cli "$TEST_FILTER"
+          echo "copilot-cli $?" >> e2e/artifacts/results.txt
+
+      - name: Summarize
+        if: always()
+        shell: bash
+        run: |
+          set -uo pipefail
+          failed=0
+          # Absent when the job failed before any agent ran (e.g. install).
+          [ -f e2e/artifacts/results.txt ] || { echo "no agent ran" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
+          {
+            echo "### ${{ matrix.os }} — \`${NIGHTLY_TAG:-unknown}\`"
+            echo ""
+            echo "| agent | result |"
+            echo "| --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          while read -r agent rc; do
+            [ -z "$agent" ] && continue
+            if [ "$rc" = "0" ]; then
+              echo "| $agent | ✅ pass |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| $agent | ❌ fail (exit $rc) |" >> "$GITHUB_STEP_SUMMARY"
+              failed=1
+            fi
+          done < e2e/artifacts/results.txt
+          exit "$failed"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: nightly-smoke-${{ matrix.os }}
+          path: e2e/artifacts/
+          retention-days: 7
+
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs: [smoke]
+    if: ${{ always() && needs.smoke.result == 'failure' && github.event_name == 'schedule' }}
+    steps:
+      - name: Notify Slack of nightly smoke failure
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook: ${{ secrets.E2E_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#d50200",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": ":red_circle: *Nightly install smoke failed* — the published nightly CLI did not pass the checkpoint smoke test on at least one OS.\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run details>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -104,10 +104,14 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
+          # Stop is what makes the Write-Error below terminating. The runner
+          # prepends it too, but this step depends on it, so it says so.
           $ErrorActionPreference = "Stop"
-          entire version
-          $version = (entire version | Select-Object -First 1).Split(" ")[2]
-          $tag = "v$version"
+          $versionLine = (entire version | Select-Object -First 1)
+          Write-Host $versionLine
+          $tag = "v$($versionLine.Split(' ')[2])"
+          # Fail closed: a stable or unparseable version means the install
+          # resolved the wrong channel.
           if ($tag -notlike "v*-nightly.*") {
             Write-Error "expected a v*-nightly.* version, got '$tag'"
           }
@@ -158,7 +162,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          $ErrorActionPreference = "Stop"
           irm https://claude.ai/install.ps1 | iex
           npm install -g @openai/codex @github/copilot opencode-ai
           # Stop does not cover native commands ($PSNativeCommandUseError-
@@ -191,7 +194,7 @@ jobs:
       #
       # The six bodies are byte-identical; only AGENT and the key differ.
       - name: Smoke test claude-code
-        if: ${{ !cancelled() && contains(env.AGENTS, 'claude-code') }}
+        if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' claude-code ') }}
         timeout-minutes: 15
         shell: bash
         env:
@@ -209,7 +212,7 @@ jobs:
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
 
       - name: Smoke test opencode
-        if: ${{ !cancelled() && contains(env.AGENTS, 'opencode') }}
+        if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' opencode ') }}
         timeout-minutes: 15
         shell: bash
         env:
@@ -227,7 +230,7 @@ jobs:
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
 
       - name: Smoke test codex
-        if: ${{ !cancelled() && contains(env.AGENTS, 'codex') }}
+        if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' codex ') }}
         timeout-minutes: 15
         shell: bash
         env:
@@ -246,7 +249,7 @@ jobs:
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
 
       - name: Smoke test cursor-cli
-        if: ${{ !cancelled() && contains(env.AGENTS, 'cursor-cli') }}
+        if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' cursor-cli ') }}
         timeout-minutes: 15
         shell: bash
         env:
@@ -264,7 +267,7 @@ jobs:
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
 
       - name: Smoke test factoryai-droid
-        if: ${{ !cancelled() && contains(env.AGENTS, 'factoryai-droid') }}
+        if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' factoryai-droid ') }}
         timeout-minutes: 15
         shell: bash
         env:
@@ -284,7 +287,7 @@ jobs:
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
 
       - name: Smoke test copilot-cli
-        if: ${{ !cancelled() && contains(env.AGENTS, 'copilot-cli') }}
+        if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' copilot-cli ') }}
         timeout-minutes: 15
         shell: bash
         env:

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -18,6 +18,8 @@ on:
       test:
         description: "Test name filter (regex)"
         required: false
+        # Keep in sync with the TEST_FILTER fallback in the job env: a
+        # scheduled run has no inputs, so that fallback is what it uses.
         default: "TestMultiSessionSequential"
 
 concurrency:
@@ -75,8 +77,7 @@ jobs:
       # API, and an unauthenticated call from a shared runner IP is 403-ed by
       # the 60/hour limit long before this job starts — which the script then
       # reports as "check your internet connection". install.sh:100 and
-      # install.ps1:219 both honour the variable. The token carries the copilot
-      # scope; the permissions block above says why that is acceptable here.
+      # install.ps1:219 both honour the variable.
       - name: Install nightly CLI (Linux)
         if: matrix.os == 'ubuntu-latest'
         env:
@@ -103,7 +104,10 @@ jobs:
       # No $ErrorActionPreference line needed in a pwsh step: the runner
       # prepends `$ErrorActionPreference = 'stop'` to every powershell/pwsh
       # script it runs (actions/runner, FixUpScriptContents in
-      # ScriptHandlerHelpers.cs), so the steps that set it are restating it.
+      # ScriptHandlerHelpers.cs). The two steps that set it anyway are kept:
+      # one of them fails closed through Write-Error, whose terminating-ness is
+      # exactly what the preference decides, so the line documents a dependency
+      # rather than restating the runner.
       - name: Install nightly CLI (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -121,9 +125,9 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: |
           set -euo pipefail
-          entire version
-          version=$(entire version | head -1 | awk '{print $3}')
-          tag="v$version"
+          version_line=$(entire version | head -1)
+          echo "$version_line"
+          tag="v$(echo "$version_line" | awk '{print $3}')"
           # Fail closed. A stable or unparseable version means the install
           # resolved the wrong channel; silently testing main instead would
           # hide exactly the skew this pin exists to remove.
@@ -222,17 +226,18 @@ jobs:
           npm install -g @openai/codex @github/copilot opencode-ai
           # Stop does not cover native commands: a non-zero exit raises an
           # error only when $PSNativeCommandUseErrorActionPreference is $true,
-          # and it defaults to $false. npm is not this step's last command, so
-          # without this its failure is masked by whatever runs after it.
+          # and it defaults to $false. Nothing native follows npm today, so the
+          # runner's trailing `exit $LASTEXITCODE` would catch it — but only by
+          # accident of ordering, and with no message. Fail here, where the
+          # cause is named, and keep the guard correct if a native command is
+          # ever added after this line.
           if ($LASTEXITCODE -ne 0) { throw "npm install failed (exit $LASTEXITCODE)" }
-          # No such guard on the two iex lines. Each installer sets Stop itself,
-          # checks $LASTEXITCODE after every native command it runs, and exits
-          # non-zero on every failure path — and both a throw and an exit inside
-          # iex end this step (run 34130173877 failed this way on a 504 from
-          # downloads.claude.ai). Verified against both scripts on 2026-09-09.
-          irm https://app.factory.ai/cli/windows | iex
+          # No such guard on the iex line above: that installer sets Stop
+          # itself, checks $LASTEXITCODE after every native command it runs, and
+          # exits non-zero on every failure path — and both a throw and an exit
+          # inside iex end this step (run 34130173877 failed this way on a 504
+          # from downloads.claude.ai). Verified against the script on 2026-09-09.
           "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          "$HOME\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           # factoryai-droid is installed above but deliberately absent from
           # this list. On Windows the test fails at
           # "checkpoint state did not advance within 30s": droid commits, and
@@ -244,8 +249,11 @@ jobs:
           # not something this workflow can fix by trying harder.
           #
           # It stays out so the leg reports on the release rather than on a
-          # known bug. The installer line above is kept so restoring it is a
-          # one-word change once the hook path is fixed.
+          # known bug, and its installer is not run either — that would be a
+          # network install, and a way for this leg to go red, for an agent it
+          # does not test. Restoring means adding the name below plus
+          # `irm https://app.factory.ai/cli/windows | iex` and $HOME\bin on
+          # GITHUB_PATH, as the Unix step still does.
           "AGENTS=claude-code codex copilot-cli opencode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # ----------------------------------------------------------------------
@@ -375,9 +383,6 @@ jobs:
           grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
 
-      # The job's GITHUB_TOKEN reaches copilot as COPILOT_GITHUB_TOKEN. With
-      # the two install steps, this is the only place it is exposed — see the
-      # permissions block.
       - name: Smoke test copilot-cli
         if: ${{ !cancelled() && contains(env.AGENTS, 'copilot-cli') }}
         timeout-minutes: 15

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -159,17 +159,27 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "AGENTS=claude-code opencode codex cursor-cli factoryai-droid copilot-cli" >> "$GITHUB_ENV"
 
-      # cursor-cli drives every prompt through tmux and factoryai-droid has no
-      # Windows installer, so neither is in the Windows list.
+      # Everything that can run on Windows does. Only cursor-cli is missing,
+      # and for a structural reason rather than a packaging one: its E2E driver
+      # sends every prompt through tmux (e2e/agents/cursor_cli.go), because
+      # Cursor's headless -p mode does not fire the beforeSubmitPrompt and stop
+      # hooks, so nothing is checkpointed. There is no tmux on Windows.
+      #
+      # Each installer puts its binary somewhere different and updates only the
+      # *stored* user PATH, which later steps in this job do not re-read: claude
+      # and codex/copilot/opencode land in ~\.local\bin and the npm global
+      # prefix, droid in ~\bin. Hence the GITHUB_PATH lines.
       - name: Install agent CLIs (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
           irm https://claude.ai/install.ps1 | iex
-          "$env:USERPROFILE\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          npm install -g @openai/codex @github/copilot
-          "AGENTS=claude-code codex copilot-cli" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          npm install -g @openai/codex @github/copilot opencode-ai
+          irm https://app.factory.ai/cli/windows | iex
+          "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "$HOME\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "AGENTS=claude-code codex copilot-cli opencode factoryai-droid" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # ----------------------------------------------------------------------
       # 5. Run the smoke test once per agent, sequentially. Each agent gets its


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1170
<!-- entire-trail-link-end -->

## Why

Every existing E2E workflow (`e2e.yml`, `e2e-windows.yml`, `e2e-isolated.yml`, …) tests a binary **built from source in the same checkout**. Nothing tests the artifact users actually install. `nightly.yml` cuts a tag at 06:00 UTC and `release.yml` publishes it to the Homebrew tap, the `install.sh` nightly channel, `install.ps1` and Scoop — and no job ever installs any of those to check the CLI still works.

This adds one scheduled workflow answering a single question: *does the shipped nightly still checkpoint real agent work on Linux, macOS and Windows?* It complements `install-ps1-e2e.yml`, which tests the installer script; this tests what the installer *installed*.

## What it does

`.github/workflows/nightly-e2e.yml`, the only file added.

- **Trigger** — `schedule: 0 9 * * *`, three hours after `nightly.yml` tags, so `release.yml` has published. Plus `workflow_dispatch` with a `test` filter input.
- **One job per OS** (`fail-fast: false`), and inside each, **one step per agent** — not a loop. A step timeout is the only per-agent bound that works on all three runners (macOS has no `timeout(1)`), each step carries `timeout-minutes: 15`, and `!cancelled()` means a killed step doesn't skip the rest. Each step also sees only its own agent's API key.
- **Installs the nightly as the README documents it**: `brew install --cask entire@nightly`, `install.sh --channel nightly`, `iex "& {$(irm https://entire.io/install.ps1)} -Channel nightly"`.
- **Pins the checkout to the installed binary's tag.** `entire version` is parsed into `NIGHTLY_TAG`, which becomes the checkout ref, so the harness and the CLI under test come from one commit. Fails closed unless the version matches `v*-nightly.*`.
- **Points the harness at the installed binary** via `E2E_ENTIRE_BIN` — `mise-tasks/test/e2e/_default` skips its build when that is set. Without it the job would silently test a source build.
- **Runs against `git-refs`** (`E2E_CHECKPOINT_STORE`), the store a first-run `entire enable` writes. Unset, the harness pins legacy `git-branch`, which no fresh install has.

## The test: `TestMultiSessionSequential`

`e2e/tests/multi_session_test.go:43` — two prompts, each creating a file and committing it, then asserting two new commits, a checkpoint trailer on `HEAD` and `HEAD~1`, both checkpoints existing with a single session each, the sessions distinct, and no leftover `entire/*` shadow branches.

Rejected: `TestMultiSessionManualCommit` (two prompts, one commit → one checkpoint, weaker) and `TestSingleSessionManualCommit` (one prompt).

## Agents

| OS | agents |
| --- | --- |
| ubuntu-latest | claude-code, opencode, codex, cursor-cli, factoryai-droid, copilot-cli |
| macos-latest | same six |
| windows-latest | claude-code, codex, opencode, copilot-cli |

Two absences on Windows, for different reasons. **cursor-cli** is structural and permanent: its E2E driver sends every prompt through tmux (`e2e/agents/cursor_cli.go:113`) because Cursor's headless `-p` mode fires no `beforeSubmitPrompt`/`stop` hooks — and Windows runners have no tmux. **factoryai-droid** is a real bug in our own hook path, see below; its installer is skipped too, so the leg doesn't pay a network install for an agent it can't test.

Excluded everywhere: **gemini-cli** (forces `core.hooksPath=''` since 0.57.0, so nothing is checkpointed — the same exclusion `e2e.yml` carries), **pi** (no CI installer), **vogon** and **roger-roger** (not shipped agents).

## Guards worth reviewing

- **`set +e`, not `set -euo pipefail`.** GitHub invokes `shell: bash` as `bash --noprofile --norc -e -o pipefail`, so errexit is already on and would end a step before its result row is written. A review bot has suggested "fix" this once already.
- **`Total: 0` check** after each run. A filter matching no test exits 0 with `[no tests to run]`, so a typo in the dispatch input would report every agent as passing.
- **`ARTIFACT_ROOT` from `github.workspace`, never `$PWD`.** Under Git Bash `$PWD` is `/d/a/cli/cli`, which the Go test binary resolves against the current drive.
- **npm `$LASTEXITCODE` guard on Windows.** `$ErrorActionPreference = Stop` does not cover native commands — `$PSNativeCommandUseErrorActionPreference` defaults to `$false`.
- **Summarize iterates the agent list, not the result rows**, so a step killed by its own timeout shows as a failure instead of vanishing from the table.
- **The job's `GITHUB_TOKEN` carries `copilot-requests: write` and the install steps see it.** Permissions are job-wide and there is no per-step scoping. Accepted deliberately: those steps install and run the binary every later step executes with the agent keys and this token, so withholding it there guards nothing; the repo is public, so only the Copilot quota has value. The permissions comment says so rather than claiming otherwise.

## Verification

Run [34352592024](https://github.com/entireio/cli/actions/runs/34352592024) — green on all three OSes against `0.10.7-nightly.202609090626.b58e65cd7`, **16/16 agent runs**:

| OS | result |
| --- | --- |
| ubuntu-latest | 6/6 ✅ |
| macos-latest | 6/6 ✅ |
| windows-latest | 4/4 ✅ (cursor-cli and factoryai-droid correctly skipped) |

Proved by temporarily adding a path-scoped `pull_request` trigger, since a new `workflow_dispatch` workflow is not dispatchable until its file is on the default branch. That trigger has been removed — which does mean further edits to this file get no CI until it merges.

Found and fixed along the way: `install.sh` rate-limited by the unauthenticated releases API from a shared runner IP; the agent loop aborting on the first failure (the `set +e` above); opencode's own installer having the same rate-limit bug with no way to authenticate it, so it comes from npm; and the Windows artifact path being built from a Git Bash `$PWD`.

## Known issue this surfaced

**factoryai-droid does not checkpoint on Windows.** `AssertNewCommits` passes — droid writes both files and makes both commits — and then `WaitForCheckpoint` times out: no checkpoint is recorded at all. It failed twice including the `--rerun-fails` retry in run 34127634577, while passing on Linux (25.5s) and macOS (33.2s) in run 34352592024. A defect in the droid hook path on Windows, not flake, and notably `cmd/entire/cli/agent/factoryaidroid/` contains no Windows branch at all. Excluded here with that reasoning recorded at the exclusion, and being fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
