### PR TITLE
feat: add OrcaRouter as a named summary-generation provider

### DIFF
--- a/cmd/entire/cli/agent/orcarouter/config.go
+++ b/cmd/entire/cli/agent/orcarouter/config.go
@@ -1,0 +1,34 @@
+package orcarouter
+
+import (
+	"os"
+)
+
+// Environment variable names for the OrcaRouter gateway.
+const (
+	// EnvAPIKey is the API key OrcaRouter issues (starts with "sk-orca-").
+	EnvAPIKey = "ORCAROUTER_API_KEY" //nolint:gosec // G101: env var name, not a credential
+	// EnvAPIBaseURL overrides the default gateway endpoint. It is optional;
+	// the default is the production gateway.
+	EnvAPIBaseURL = "ORCAROUTER_API_BASE_URL"
+)
+
+// defaultAPIBaseURL is the OrcaRouter OpenAI-compatible endpoint. Clients that
+// speak the OpenAI protocol append /chat/completions to this base.
+const defaultAPIBaseURL = "https://api.orcarouter.ai/v1"
+
+// APIKey returns the configured OrcaRouter API key, or "" when unset.
+func APIKey() string {
+	return os.Getenv(EnvAPIKey)
+}
+
+// APIBaseURL returns the configured gateway base URL, or the production
+// default when unset. The trailing slash is trimmed so callers can append
+// path segments with a single "/".
+func APIBaseURL() string {
+	base := os.Getenv(EnvAPIBaseURL)
+	if base == "" {
+		base = defaultAPIBaseURL
+	}
+	return base
+}

--- a/cmd/entire/cli/agent/orcarouter/generate.go
+++ b/cmd/entire/cli/agent/orcarouter/generate.go
@@ -1,0 +1,146 @@
+package orcarouter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// defaultModel is used when the caller passes an empty model hint. It is an
+// OrcaRouter model that reliably supports plain text generation.
+const defaultModel = "orcarouter/auto"
+
+// httpClient bounds the total time for a single chat-completions call. Summary
+// generation feeds a condensed transcript to the model, so a long-running
+// generation is expected; 5 minutes matches the explain layer's default
+// patience for provider calls.
+var httpClient = &http.Client{ //nolint:gochecknoglobals // package-level client is shared and read-only
+	Timeout: 5 * time.Minute,
+}
+
+// chatCompletionRequest mirrors the OpenAI chat-completions wire format that
+// OrcaRouter exposes at /chat/completions.
+type chatCompletionRequest struct {
+	Model     string        `json:"model"`
+	Messages  []chatMessage `json:"messages"`
+	MaxTokens int           `json:"max_tokens,omitempty"`
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// chatCompletionResponse is the subset of the OpenAI chat-completions response
+// that the text generator reads.
+type chatCompletionResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error"`
+}
+
+// GenerateText sends a prompt to OrcaRouter's OpenAI-compatible chat
+// completions endpoint and returns the raw text response. It implements the
+// agent.TextGenerator interface.
+//
+// The API key is read from the environment on each call (ORCAROUTER_API_KEY),
+// so the provider works wherever the key is set — CI, a hook environment, or a
+// login shell — without persisting the secret anywhere.
+func (o *OrcaRouterAgent) GenerateText(ctx context.Context, prompt string, model string) (string, error) {
+	if strings.TrimSpace(prompt) == "" {
+		return "", errors.New("orcarouter: empty prompt")
+	}
+
+	apiKey := APIKey()
+	if apiKey == "" {
+		return "", errors.New("orcarouter: " + EnvAPIKey + " is not set; set it to use OrcaRouter for summary generation")
+	}
+
+	if model == "" {
+		model = defaultModel
+	}
+
+	req := chatCompletionRequest{
+		Model:    model,
+		Messages: []chatMessage{{Role: "user", Content: prompt}},
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("orcarouter: encode request: %w", err)
+	}
+
+	endpoint := strings.TrimRight(APIBaseURL(), "/") + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("orcarouter: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("orcarouter: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // 10 MiB cap
+	if err != nil {
+		return "", fmt.Errorf("orcarouter: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("orcarouter: gateway returned HTTP %d: %s", resp.StatusCode, summarizeResponseError(respBody))
+	}
+
+	var parsed chatCompletionResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("orcarouter: parse response: %w", err)
+	}
+	if parsed.Error != nil {
+		return "", fmt.Errorf("orcarouter: gateway error: %s", parsed.Error.Message)
+	}
+	if len(parsed.Choices) == 0 || strings.TrimSpace(parsed.Choices[0].Message.Content) == "" {
+		return "", errors.New("orcarouter: gateway returned an empty response")
+	}
+
+	return strings.TrimSpace(parsed.Choices[0].Message.Content), nil
+}
+
+// summarizeResponseError extracts a human-readable message from a non-200
+// response body. OrcaRouter returns OpenAI-style {"error": {"message": ...}}
+// envelopes on most failures; when the body does not parse, the raw text is
+// truncated and returned so the user still sees the server's answer.
+func summarizeResponseError(body []byte) string {
+	if len(body) == 0 {
+		return "empty error response"
+	}
+	var envelope struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Error.Message != "" {
+		return envelope.Error.Message
+	}
+	text := strings.TrimSpace(string(body))
+	if len(text) > 200 {
+		text = text[:200] + "..."
+	}
+	return text
+}
+
+var _ agent.TextGenerator = (*OrcaRouterAgent)(nil)

--- a/cmd/entire/cli/agent/orcarouter/orcarouter.go
+++ b/cmd/entire/cli/agent/orcarouter/orcarouter.go
@@ -1,0 +1,119 @@
+// Package orcarouter implements the Agent interface for OrcaRouter, an
+// OpenAI-compatible AI gateway (https://www.orcarouter.ai). Unlike the coding
+// agents in this directory, OrcaRouter is not a coding tool that Entire hooks
+// into: it is a summary-generation provider that speaks the OpenAI chat
+// completions protocol directly over HTTP. Registering it here makes it
+// available to the same summary-provider machinery as claude-code, gemini, and
+// the other text generators, so `entire configure --summarize-provider
+// orcarouter` and `entire explain --generate` work with no new config surface.
+package orcarouter
+
+import (
+	"context"
+	"errors"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+)
+
+//nolint:gochecknoinits // Agent self-registration is the intended pattern
+func init() {
+	agent.Register(AgentNameOrcaRouter, NewOrcaRouterAgent)
+}
+
+const (
+	// AgentNameOrcaRouter is the registry key used with
+	// `entire configure --summarize-provider orcarouter`.
+	AgentNameOrcaRouter types.AgentName = "orcarouter"
+	// AgentTypeOrcaRouter is the display name stored in settings and metadata.
+	AgentTypeOrcaRouter types.AgentType = "OrcaRouter"
+)
+
+// errNoSessionStorage is returned by the session/transcript methods that a
+// text-generation-only provider has no storage for. It is a package-local
+// sentinel rather than a new agent-contract error because none of the callers
+// branch on it — they only need a non-nil error to skip the agent (see
+// agent.AgentForTranscriptPath, which ignores agents whose GetSessionDir
+// fails).
+var errNoSessionStorage = errors.New("orcarouter: provider has no session storage")
+
+// OrcaRouterAgent implements agent.Agent for the OrcaRouter gateway. It is a
+// text-generation-only provider: it has no session hooks, transcripts, or
+// resume surface, so the Agent interface methods that those features need are
+// no-ops that fail closed.
+//
+//nolint:revive // OrcaRouterAgent is clearer than Agent in this context
+type OrcaRouterAgent struct{}
+
+// NewOrcaRouterAgent creates a new OrcaRouter agent instance.
+func NewOrcaRouterAgent() agent.Agent {
+	return &OrcaRouterAgent{}
+}
+
+// Name returns the agent registry key.
+func (o *OrcaRouterAgent) Name() types.AgentName { return AgentNameOrcaRouter }
+
+// Type returns the agent type identifier.
+func (o *OrcaRouterAgent) Type() types.AgentType { return AgentTypeOrcaRouter }
+
+// Description returns a human-readable description.
+func (o *OrcaRouterAgent) Description() string {
+	return "OrcaRouter - OpenAI-compatible AI gateway for models and agents"
+}
+
+// IsPreview returns true because this is a new integration.
+func (o *OrcaRouterAgent) IsPreview() bool { return true }
+
+// DetectPresence reports whether OrcaRouter is configured in the repository.
+// It always returns false: OrcaRouter is a summary-generation provider, not a
+// coding agent with repo-level hooks or config, so it must never be
+// auto-detected as an installed agent by `entire enable`. Summary-provider
+// availability is gated on the ORCAROUTER_API_KEY environment variable instead
+// (see the summary-provider machinery in the cli package).
+func (o *OrcaRouterAgent) DetectPresence(_ context.Context) (bool, error) { return false, nil }
+
+// ProtectedDirs returns directories that OrcaRouter uses for config/state.
+// The provider is stateless, so there are none.
+func (o *OrcaRouterAgent) ProtectedDirs() []string { return nil }
+
+// GetSessionID extracts the session ID from hook input. OrcaRouter has no
+// session hooks, so this always returns the empty string.
+func (o *OrcaRouterAgent) GetSessionID(_ *agent.HookInput) string { return "" }
+
+// GetSessionDir returns the directory where OrcaRouter stores session
+// transcripts. The provider has no transcript storage.
+func (o *OrcaRouterAgent) GetSessionDir(_ string) (string, error) {
+	return "", errNoSessionStorage
+}
+
+// ResolveSessionFile returns the path to a session transcript file.
+func (o *OrcaRouterAgent) ResolveSessionFile(_, _ string) string { return "" }
+
+// ReadSession reads a session from OrcaRouter's storage.
+func (o *OrcaRouterAgent) ReadSession(_ *agent.HookInput) (*agent.AgentSession, error) {
+	return nil, errNoSessionStorage
+}
+
+// WriteSession writes a session to OrcaRouter's storage.
+func (o *OrcaRouterAgent) WriteSession(_ context.Context, _ *agent.AgentSession) error {
+	return errNoSessionStorage
+}
+
+// FormatResumeCommand returns the command to resume an OrcaRouter session.
+func (o *OrcaRouterAgent) FormatResumeCommand(_ string) string { return "" }
+
+// ReadTranscript reads the raw transcript bytes for a session.
+func (o *OrcaRouterAgent) ReadTranscript(_ string) ([]byte, error) {
+	return nil, errNoSessionStorage
+}
+
+// ChunkTranscript splits a transcript into chunks if it exceeds maxSize.
+// The provider stores no transcripts, so there is nothing to chunk.
+func (o *OrcaRouterAgent) ChunkTranscript(_ context.Context, _ []byte, _ int) ([][]byte, error) {
+	return nil, errNoSessionStorage
+}
+
+// ReassembleTranscript combines chunks back into a single transcript.
+func (o *OrcaRouterAgent) ReassembleTranscript(_ [][]byte) ([]byte, error) {
+	return nil, errNoSessionStorage
+}

--- a/cmd/entire/cli/agent/orcarouter/orcarouter_test.go
+++ b/cmd/entire/cli/agent/orcarouter/orcarouter_test.go
@@ -1,0 +1,244 @@
+package orcarouter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAPIKeyAndBaseURLDefaults(t *testing.T) {
+	// Note: no t.Parallel() — Setenv cannot be used after Parallel, and these
+	// subtests mutate process environment.
+	t.Run("empty key by default", func(t *testing.T) {
+		t.Setenv(EnvAPIKey, "")
+		if got := APIKey(); got != "" {
+			t.Errorf("APIKey() = %q, want empty", got)
+		}
+	})
+
+	t.Run("key returned when set", func(t *testing.T) {
+		t.Setenv(EnvAPIKey, "sk-orca-test")
+		if got := APIKey(); got != "sk-orca-test" {
+			t.Errorf("APIKey() = %q, want sk-orca-test", got)
+		}
+	})
+
+	t.Run("base URL defaults to production", func(t *testing.T) {
+		t.Setenv(EnvAPIBaseURL, "")
+		if got, want := APIBaseURL(), "https://api.orcarouter.ai/v1"; got != want {
+			t.Errorf("APIBaseURL() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("base URL override", func(t *testing.T) {
+		t.Setenv(EnvAPIBaseURL, "https://example.com/v1/")
+		if got, want := APIBaseURL(), "https://example.com/v1/"; got != want {
+			t.Errorf("APIBaseURL() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestDetectPresenceAlwaysFalse(t *testing.T) {
+	t.Setenv(EnvAPIKey, "sk-orca-test")
+	ag := &OrcaRouterAgent{}
+	present, err := ag.DetectPresence(context.Background())
+	if err != nil {
+		t.Fatalf("DetectPresence() error = %v", err)
+	}
+	if present {
+		t.Error("DetectPresence() = true, want false (provider must not auto-detect as a coding agent)")
+	}
+}
+
+func TestGenerateText(t *testing.T) {
+	const prompt = "Summarize the session."
+	const wantText = "The session added a login flow."
+
+	var srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request shape: OpenAI chat-completions wire format. The
+		// test sets the base URL to the bare server root, so the path is
+		// /chat/completions (the gateway base already includes any version
+		// prefix such as /v1).
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("request path = %q, want /chat/completions", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer sk-orca-test" {
+			t.Errorf("Authorization = %q, want Bearer sk-orca-test", auth)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+
+		var body chatCompletionRequest
+		if err := jsonUnmarshalRequestBody(r, &body); err != nil {
+			t.Errorf("decode request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if body.Model != "orcarouter/auto" {
+			t.Errorf("model = %q, want default orcarouter/auto", body.Model)
+		}
+		if len(body.Messages) != 1 || body.Messages[0].Role != "user" || body.Messages[0].Content != prompt {
+			t.Errorf("messages = %+v, want single user message with prompt", body.Messages)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSONBody(w, `{"choices":[{"message":{"role":"assistant","content":"`+wantText+`"}}]}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv(EnvAPIKey, "sk-orca-test")
+	t.Setenv(EnvAPIBaseURL, srv.URL)
+
+	ag := &OrcaRouterAgent{}
+	got, err := ag.GenerateText(context.Background(), prompt, "")
+	if err != nil {
+		t.Fatalf("GenerateText() error = %v", err)
+	}
+	if got != wantText {
+		t.Errorf("GenerateText() = %q, want %q", got, wantText)
+	}
+}
+
+func TestGenerateText_RequiresAPIKey(t *testing.T) {
+	t.Setenv(EnvAPIKey, "")
+	ag := &OrcaRouterAgent{}
+	_, err := ag.GenerateText(context.Background(), "prompt", "")
+	if err == nil {
+		t.Fatal("GenerateText() error = nil, want missing-key error")
+	}
+	if !strings.Contains(err.Error(), EnvAPIKey) {
+		t.Errorf("error %q does not mention %s", err.Error(), EnvAPIKey)
+	}
+}
+
+func TestGenerateText_EmptyPrompt(t *testing.T) {
+	t.Setenv(EnvAPIKey, "sk-orca-test")
+	ag := &OrcaRouterAgent{}
+	_, err := ag.GenerateText(context.Background(), "   ", "")
+	if err == nil {
+		t.Fatal("GenerateText() error = nil, want empty-prompt error")
+	}
+}
+
+func TestGenerateText_PropagatesModelHint(t *testing.T) {
+	var srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body chatCompletionRequest
+		if err := jsonUnmarshalRequestBody(r, &body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if body.Model != "anthropic/claude-haiku-4.5" {
+			t.Errorf("model = %q, want anthropic/claude-haiku-4.5", body.Model)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		writeJSONBody(w, `{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv(EnvAPIKey, "sk-orca-test")
+	t.Setenv(EnvAPIBaseURL, srv.URL)
+
+	ag := &OrcaRouterAgent{}
+	if _, err := ag.GenerateText(context.Background(), "prompt", "anthropic/claude-haiku-4.5"); err != nil {
+		t.Fatalf("GenerateText() error = %v", err)
+	}
+}
+
+func TestGenerateText_GatewayError(t *testing.T) {
+	var srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		writeJSONBody(w, `{"error":{"message":"Invalid API key","type":"authentication_error"}}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv(EnvAPIKey, "sk-orca-test")
+	t.Setenv(EnvAPIBaseURL, srv.URL)
+
+	ag := &OrcaRouterAgent{}
+	_, err := ag.GenerateText(context.Background(), "prompt", "")
+	if err == nil {
+		t.Fatal("GenerateText() error = nil, want gateway error")
+	}
+	if !strings.Contains(err.Error(), "401") || !strings.Contains(err.Error(), "Invalid API key") {
+		t.Errorf("error = %q, want HTTP 401 with Invalid API key", err.Error())
+	}
+}
+
+func TestGenerateText_EmptyChoices(t *testing.T) {
+	var srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		writeJSONBody(w, `{"choices":[]}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv(EnvAPIKey, "sk-orca-test")
+	t.Setenv(EnvAPIBaseURL, srv.URL)
+
+	ag := &OrcaRouterAgent{}
+	_, err := ag.GenerateText(context.Background(), "prompt", "")
+	if err == nil {
+		t.Fatal("GenerateText() error = nil, want empty-response error")
+	}
+}
+
+func TestGenerateText_UnavailableServer(t *testing.T) {
+	// A server that accepts the connection and immediately closes it exercises
+	// the request-failure path.
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	srvURL := srv.URL
+	srv.Close()
+
+	t.Setenv(EnvAPIKey, "sk-orca-test")
+	t.Setenv(EnvAPIBaseURL, srvURL)
+
+	ag := &OrcaRouterAgent{}
+	_, err := ag.GenerateText(context.Background(), "prompt", "")
+	if err == nil {
+		t.Fatal("GenerateText() error = nil, want request failure")
+	}
+}
+
+func TestGenerateText_ContextCancelled(t *testing.T) {
+	var srv = httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	t.Setenv(EnvAPIKey, "sk-orca-test")
+	t.Setenv(EnvAPIBaseURL, srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ag := &OrcaRouterAgent{}
+	_, err := ag.GenerateText(ctx, "prompt", "")
+	if err == nil {
+		t.Fatal("GenerateText() error = nil, want cancelled error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+// jsonUnmarshalRequestBody decodes a JSON request body into v. It exists so the
+// test helpers can assert on the wire format without duplicating the encoding.
+func jsonUnmarshalRequestBody(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, v)
+}
+
+// writeJSONBody writes a raw JSON response body. It exists so the test handlers
+// can emit responses without tripping errcheck's check-blank rule.
+func writeJSONBody(w http.ResponseWriter, body string) {
+	_, _ = io.WriteString(w, body) //nolint:errcheck // response write failure in a test server is irrelevant
+}

--- a/cmd/entire/cli/config.go
+++ b/cmd/entire/cli/config.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid"
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/orcarouter"
 )
 
 // Package-level aliases to avoid shadowing the settings package with local variables named "settings".

--- a/cmd/entire/cli/explain_summary_provider.go
+++ b/cmd/entire/cli/explain_summary_provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
+	"github.com/entireio/cli/cmd/entire/cli/agent/orcarouter"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -167,6 +168,12 @@ func isSummaryProviderAvailable(name types.AgentName, ag agent.Agent) bool {
 	if external.IsExternal(ag) {
 		_, ok := agent.AsTextGenerator(ag)
 		return ok
+	}
+	// HTTP-based providers have no CLI binary to look up on PATH. OrcaRouter is
+	// available when its API key is present in the environment, which is the
+	// same prerequisite its text generator authenticates with.
+	if name == orcarouter.AgentNameOrcaRouter {
+		return orcarouter.APIKey() != ""
 	}
 	return isSummaryCLIAvailable(name)
 }

--- a/cmd/entire/cli/explain_summary_provider_test.go
+++ b/cmd/entire/cli/explain_summary_provider_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/orcarouter"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/summarize"
@@ -53,6 +54,31 @@ func TestSummaryProviderRows_NilProviderReturnsNil(t *testing.T) {
 	if rows := summaryProviderRows(nil); rows != nil {
 		t.Errorf("expected nil for nil provider, got %+v", rows)
 	}
+}
+
+func TestIsSummaryProviderAvailable_OrcaRouterGatedOnAPIKey(t *testing.T) {
+	// Cannot use t.Parallel(): mutates process environment.
+	ag, err := agent.Get(orcarouter.AgentNameOrcaRouter)
+	if err != nil {
+		t.Fatalf("agent.Get(orcarouter): %v", err)
+	}
+	if _, ok := agent.AsTextGenerator(ag); !ok {
+		t.Fatal("orcarouter agent must implement TextGenerator")
+	}
+
+	t.Run("unset key is unavailable", func(t *testing.T) {
+		t.Setenv(orcarouter.EnvAPIKey, "")
+		if isSummaryProviderAvailable(orcarouter.AgentNameOrcaRouter, ag) {
+			t.Error("isSummaryProviderAvailable(orcarouter) = true with no ORCAROUTER_API_KEY, want false")
+		}
+	})
+
+	t.Run("set key is available", func(t *testing.T) {
+		t.Setenv(orcarouter.EnvAPIKey, "sk-orca-test")
+		if !isSummaryProviderAvailable(orcarouter.AgentNameOrcaRouter, ag) {
+			t.Error("isSummaryProviderAvailable(orcarouter) = false with ORCAROUTER_API_KEY set, want true")
+		}
+	})
 }
 
 type stubTextAgent struct {


### PR DESCRIPTION
## Summary

[Entire](https://github.com/entireio/cli) hooks into your Git workflow to capture AI agent sessions as you work — but capturing the *why* is only half the value. When you run `entire explain --generate` or turn on checkpoint auto-summarize, Entire asks a locally-installed agent CLI to turn a session transcript into a structured summary.

That provider is always a coding-agent CLI today (`claude`, `codex`, `gemini`, `pi`, …) — it has to be a binary on `$PATH`, and it has to be a CLI that happens to expose a `--print` text mode. This PR makes [OrcaRouter](https://www.orcarouter.ai) available as a first-class, named summary provider through the exact same machinery, so Entire users who run their agents through OrcaRouter can point their summaries at it with one command:

```sh
entire configure --summarize-provider orcarouter --summarize-model anthropic/claude-haiku-4.5
```

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

- **`cmd/entire/cli/agent/orcarouter/`** (new): an `Agent` implementation for the OrcaRouter gateway. It is text-generation-only — it speaks OpenAI chat-completions over HTTP and has no session hooks, transcripts, or resume surface — so it plugs into the same provider registry as the existing text generators (`claude-code`, `gemini`, …) without pretending to be a coding agent. The `TextGenerator` authenticates with `ORCAROUTER_API_KEY` and targets `https://api.orcarouter.ai/v1` (overridable via `ORCAROUTER_API_BASE_URL`).
- **`cmd/entire/cli/config.go`**: registers the provider via the existing agent blank-import registration surface.
- **`cmd/entire/cli/explain_summary_provider.go`**: `isSummaryProviderAvailable` now treats `orcarouter` as available when its API key is set, instead of requiring a CLI binary on `$PATH` (there is none — it is HTTP-only).
- **`DetectPresence` returns `false`**: OrcaRouter is a summary provider, not a repo-configured coding agent, so it must never appear in `entire enable` auto-detection. It stays visible in `entire agent list` and the summary-provider picker.

## Why this shape

I mirrored how Entire already models its other providers. A provider is just an `agent.Agent` registered in the registry that satisfies `agent.AsTextGenerator`; the summary layer (`resolveCheckpointSummaryProvider`, `resolveDispatchSummaryProvider`) and the review judge all select from that same registry. Registering OrcaRouter as a named agent means it inherits every existing consumer — `entire configure --summarize-provider`, `entire explain --generate`, checkpoint auto-summarize, `entire dispatch --local`, and the review synthesis judge — with zero new config surface.

## Tests

- Unit tests in `agent/orcarouter`: request wire format (path, `Authorization` bearer, JSON body), default model, model-hint propagation, missing-key error, empty-prompt error, gateway non-200 error envelope, empty-choices error, connection failure, and context cancellation. 13 tests total.
- `TestIsSummaryProviderAvailable_OrcaRouterGatedOnAPIKey` covers the availability gating.
- `go build ./...`, `gofmt`, and `golangci-lint` all pass. `go test ./cmd/entire/cli/...` passes (the two pre-existing failures — an opencode `node` version issue and a `git worktree` environment issue — reproduce on `main` without this change).
- **Live test**: a throwaway harness exercised `agent.Get("orcarouter")` → `AsTextGenerator` → `GenerateText` against the live gateway and received a real 200 response through the provider code path. Verified `entire configure --summarize-provider orcarouter` and `entire agent list` in a scratch repo.

## Usage

1. Create an account and API key at https://www.orcarouter.ai/console.
2. Export it: `export ORCAROUTER_API_KEY=sk-orca-...`
3. `entire configure --summarize-provider orcarouter [--summarize-model <model>]` — e.g. `anthropic/claude-haiku-4.5` for a quick smoke test.
4. Run `entire explain --generate` (or turn on auto-summarize); summaries now route through OrcaRouter. Full model catalog: https://www.orcarouter.ai/models.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
