### PR TITLE
Keep the per-user config dir private to its owner

### DIFF
--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -107,9 +107,16 @@ func globalConfigDirPath() string {
 }
 
 // ensureGlobalConfigDir creates the global config directory if it doesn't exist.
+//
+// It goes through userdirs.EnsurePrivateDir rather than MkdirAll because this
+// directory is shared with contexts.json and the file token store, both of
+// which hold bearer tokens. The version check runs from the root command's
+// PersistentPostRun, so on a fresh machine it is almost always what creates
+// the directory — before the first login ever runs. Creating it world-readable
+// here left it that way permanently, since the credential stores' own
+// MkdirAll(0700) cannot change the mode of a directory that already exists.
 func ensureGlobalConfigDir() error {
-	//nolint:gosec // ~/.config/entire is user home directory, 0o755 is appropriate
-	if err := os.MkdirAll(globalConfigDirPath(), 0o755); err != nil {
+	if err := userdirs.EnsurePrivateDir(globalConfigDirPath()); err != nil {
 		return fmt.Errorf("creating config directory: %w", err)
 	}
 

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
 
 // Context is a single kubectl-style entry: which core to talk to, as
@@ -61,7 +63,7 @@ type File struct {
 // FilePath returns $configDir/contexts.json after ensuring the directory
 // exists with 0700 perms.
 func FilePath(configDir string) (string, error) {
-	if err := os.MkdirAll(configDir, 0700); err != nil {
+	if err := userdirs.EnsurePrivateDir(configDir); err != nil {
 		return "", fmt.Errorf("create config dir: %w", err)
 	}
 	return filepath.Join(configDir, "contexts.json"), nil

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -61,7 +61,8 @@ type File struct {
 }
 
 // FilePath returns $configDir/contexts.json after ensuring the directory
-// exists with 0700 perms.
+// exists and is private to its owner — 0700, or stricter if the user already
+// made it so; see userdirs.EnsurePrivateDir.
 func FilePath(configDir string) (string, error) {
 	if err := userdirs.EnsurePrivateDir(configDir); err != nil {
 		return "", fmt.Errorf("create config dir: %w", err)

--- a/internal/entireclient/tokenstore/file.go
+++ b/internal/entireclient/tokenstore/file.go
@@ -30,7 +30,15 @@ var loosePermsWarnW io.Writer = os.Stderr
 // The file format is: { "service": { "user": "password" } }
 type fileStore struct {
 	path string
-	mu   sync.Mutex
+	// ownsDir reports whether filepath.Dir(path) is a directory Entire
+	// chose — the per-user config dir it shares with contexts.json — as
+	// opposed to one the user named through PathEnvVar. Only the former is
+	// tightened to a private mode. A user-supplied path can be a CI secret
+	// mount, a read-only volume, a shared secrets directory, or $HOME
+	// itself: chmod-ing it is a side effect nobody asked for when it works,
+	// and takes down every Get/Set/Delete when it doesn't.
+	ownsDir bool
+	mu      sync.Mutex
 	// warnedLoosePerms dedupes the loose-permissions warning to once per
 	// store instance — effectively once per CLI invocation, since
 	// currentBackend caches a single fileStore for the process. Like the
@@ -43,8 +51,8 @@ type fileStore struct {
 // withFileLock runs fn while holding an exclusive flock on f.path + ".lock".
 // The lock coordinates across processes; the in-process mu handles goroutines.
 func (f *fileStore) withFileLock(fn func() error) error {
-	if err := userdirs.EnsurePrivateDir(filepath.Dir(f.path)); err != nil {
-		return fmt.Errorf("creating token store directory: %w", err)
+	if err := f.ensureDir(); err != nil {
+		return err
 	}
 
 	fl := flock.New(f.path + ".lock")
@@ -65,6 +73,25 @@ func (f *fileStore) withFileLock(fn func() error) error {
 	}()
 
 	return fn()
+}
+
+// ensureDir makes sure the store file's directory exists. Creating it is
+// mandatory — there is nowhere to write otherwise — but re-moding an existing
+// one happens only for a directory Entire owns; see fileStore.ownsDir. A
+// directory created here is private either way, since it is new and nothing
+// else was using it.
+func (f *fileStore) ensureDir() error {
+	dir := filepath.Dir(f.path)
+	if f.ownsDir {
+		if err := userdirs.EnsurePrivateDir(dir); err != nil {
+			return fmt.Errorf("creating token store directory: %w", err)
+		}
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating token store directory: %w", err)
+	}
+	return nil
 }
 
 func (f *fileStore) load() (map[string]map[string]string, error) {

--- a/internal/entireclient/tokenstore/file.go
+++ b/internal/entireclient/tokenstore/file.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
 
 // goosWindows is runtime.GOOS on Windows, where unix permission bits don't
@@ -41,7 +43,7 @@ type fileStore struct {
 // withFileLock runs fn while holding an exclusive flock on f.path + ".lock".
 // The lock coordinates across processes; the in-process mu handles goroutines.
 func (f *fileStore) withFileLock(fn func() error) error {
-	if err := os.MkdirAll(filepath.Dir(f.path), 0700); err != nil {
+	if err := userdirs.EnsurePrivateDir(filepath.Dir(f.path)); err != nil {
 		return fmt.Errorf("creating token store directory: %w", err)
 	}
 

--- a/internal/entireclient/tokenstore/file_test.go
+++ b/internal/entireclient/tokenstore/file_test.go
@@ -417,3 +417,81 @@ func TestLoosePermsWarnWriter_DefaultsToStderr(t *testing.T) {
 		t.Fatalf("loosePermsWarnW default = %T, want the process stderr", loosePermsWarnW)
 	}
 }
+
+// A path the user pointed us at with ENTIRE_TOKEN_STORE_PATH names a
+// directory Entire did not choose — a CI secret mount, a shared secrets
+// directory, or $HOME itself. Tightening it is a side effect nobody asked
+// for, and on a mount the caller doesn't own the chmod fails and takes every
+// Get/Set/Delete with it.
+func TestFileStore_LeavesUnownedDirectoryModeAlone(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("unix permission bits are synthetic on Windows")
+	}
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s := &fileStore{path: filepath.Join(dir, "tokens.json")}
+
+	if err := s.Set("svc", "alice", "secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Errorf("directory mode = %04o, want 0755 left as the user set it", got)
+	}
+}
+
+// The default location is Entire's own config directory, shared with
+// contexts.json, and a mode-0755 one left behind by an early version check is
+// exactly what EnsurePrivateDir exists to repair.
+func TestFileStore_TightensOwnedDirectory(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("unix permission bits are synthetic on Windows")
+	}
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s := &fileStore{path: filepath.Join(dir, "tokens.json"), ownsDir: true}
+
+	if err := s.Set("svc", "alice", "secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got&0o077 != 0 {
+		t.Errorf("directory mode = %04o, still accessible by group/other", got)
+	}
+}
+
+func TestResolveBackend_OwnsDirOnlyForTheDefaultPath(t *testing.T) {
+	t.Setenv(BackendEnvVar, "file")
+
+	t.Setenv(PathEnvVar, "")
+	def, ok := resolveBackendLocked().(*fileStore)
+	if !ok {
+		t.Fatalf("default path: got %T, want *fileStore", resolveBackendLocked())
+	}
+	if !def.ownsDir {
+		t.Error("default path: ownsDir = false, want true")
+	}
+
+	t.Setenv(PathEnvVar, filepath.Join(t.TempDir(), "tokens.json"))
+	custom, ok := resolveBackendLocked().(*fileStore)
+	if !ok {
+		t.Fatalf("custom path: got %T, want *fileStore", resolveBackendLocked())
+	}
+	if custom.ownsDir {
+		t.Error("custom path: ownsDir = true, want false")
+	}
+}

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -134,7 +134,10 @@ func FileBackendPath() string {
 
 func resolveBackendLocked() store {
 	if FileBackendSelected() {
-		return &fileStore{path: FileBackendPath()}
+		// Entire owns the directory only when it also picked it: an
+		// explicit PathEnvVar names a location the user chose, and its
+		// mode is theirs to set.
+		return &fileStore{path: FileBackendPath(), ownsDir: os.Getenv(PathEnvVar) == ""}
 	}
 	// Under `go test`, never fall through to the real OS keyring: a test
 	// that forgets tokenstore.UseFileBackendForTesting would otherwise write
@@ -142,7 +145,7 @@ func resolveBackendLocked() store {
 	// need isolation from each other still swap in a per-test file via
 	// UseFileBackendForTesting.
 	if dir, ok := testdirs.Dir("tokenstore"); ok {
-		return &fileStore{path: filepath.Join(dir, "tokens.json")}
+		return &fileStore{path: filepath.Join(dir, "tokens.json"), ownsDir: true}
 	}
 	return keyringStore{}
 }

--- a/internal/entireclient/userdirs/userdirs.go
+++ b/internal/entireclient/userdirs/userdirs.go
@@ -50,7 +50,7 @@ func Cache() string {
 }
 
 // EnsurePrivateDir creates dir as a private, user-only directory (0700) and,
-// when it already exists with group or other access, tightens it back to 0700.
+// when it already exists with group or other access, clears those bits.
 //
 // The tightening step is the point. Config() holds bearer tokens — the login
 // JWTs in contexts.json and the file token store's tokens.json — and those
@@ -61,9 +61,12 @@ func Cache() string {
 // the first login used to leave it 0755 for good, and the credential stores'
 // own MkdirAll(0700) could never repair it.
 //
-// An already-private directory is left exactly as the user set it, so a mode
-// stricter than 0700 (0500, say) survives. Only group and other bits are
-// cleared.
+// Only the group and other bits are ever cleared: the owner bits are carried
+// across untouched, so a directory the user deliberately made stricter than
+// 0700 stays that way whether or not it also needed tightening (0500 survives,
+// 0555 becomes 0500). Masking can leave the owner no access at all, which is
+// the same thing an already-private 0000 directory gets: this function makes a
+// directory private, and does not claim to make it usable.
 //
 // Windows has no unix permission bits (Go reports synthetic modes and Chmod
 // only toggles the read-only flag), so the tightening step is skipped there.
@@ -81,9 +84,7 @@ func EnsurePrivateDir(dir string) error {
 	if info.Mode().Perm()&0o077 == 0 {
 		return nil
 	}
-	//nolint:gosec // G302 is about file modes; 0700 on a directory is the
-	// strictest mode that still lets the owner traverse and list it.
-	if err := os.Chmod(dir, 0o700); err != nil {
+	if err := os.Chmod(dir, info.Mode().Perm()&^0o077); err != nil {
 		return fmt.Errorf("tighten %s: %w", dir, err)
 	}
 	return nil

--- a/internal/entireclient/userdirs/userdirs.go
+++ b/internal/entireclient/userdirs/userdirs.go
@@ -14,8 +14,10 @@
 package userdirs
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/entireio/cli/internal/testdirs"
 )
@@ -45,4 +47,44 @@ func Cache() string {
 	}
 	home, _ := os.UserHomeDir() //nolint:errcheck // best-effort default
 	return filepath.Join(home, ".cache", "entire")
+}
+
+// EnsurePrivateDir creates dir as a private, user-only directory (0700) and,
+// when it already exists with group or other access, tightens it back to 0700.
+//
+// The tightening step is the point. Config() holds bearer tokens — the login
+// JWTs in contexts.json and the file token store's tokens.json — and those
+// files are written 0600, but a mode-0755 parent leaks their existence and
+// hands anyone on the box a directory they can traverse and enumerate. Because
+// os.MkdirAll is a no-op on an existing path, whichever caller created the
+// directory first fixes its mode permanently: a version check that ran before
+// the first login used to leave it 0755 for good, and the credential stores'
+// own MkdirAll(0700) could never repair it.
+//
+// An already-private directory is left exactly as the user set it, so a mode
+// stricter than 0700 (0500, say) survives. Only group and other bits are
+// cleared.
+//
+// Windows has no unix permission bits (Go reports synthetic modes and Chmod
+// only toggles the read-only flag), so the tightening step is skipped there.
+func EnsurePrivateDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", dir, err)
+	}
+	if info.Mode().Perm()&0o077 == 0 {
+		return nil
+	}
+	//nolint:gosec // G302 is about file modes; 0700 on a directory is the
+	// strictest mode that still lets the owner traverse and list it.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("tighten %s: %w", dir, err)
+	}
+	return nil
 }

--- a/internal/entireclient/userdirs/userdirs_test.go
+++ b/internal/entireclient/userdirs/userdirs_test.go
@@ -3,11 +3,16 @@ package userdirs_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
+
+// goosWindows is runtime.GOOS on Windows, where unix permission bits are
+// synthetic and the tightening step is skipped.
+const goosWindows = "windows"
 
 func TestConfig_HonorsEnv(t *testing.T) {
 	t.Setenv("ENTIRE_CONFIG_DIR", "/tmp/explicit/path")
@@ -48,5 +53,69 @@ func TestTestRunsNeverResolveRealDirs(t *testing.T) {
 		if tc.got == tc.realDir || strings.HasPrefix(tc.got, tc.realDir+string(os.PathSeparator)) {
 			t.Fatalf("%s: %q resolves to the real dir %q during tests", name, tc.got, tc.realDir)
 		}
+	}
+}
+
+func TestEnsurePrivateDir_CreatesAt0700(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "entire")
+	if err := userdirs.EnsurePrivateDir(dir); err != nil {
+		t.Fatalf("EnsurePrivateDir: %v", err)
+	}
+	st, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if runtime.GOOS != goosWindows && st.Mode().Perm() != 0o700 {
+		t.Errorf("mode = %04o, want 0700", st.Mode().Perm())
+	}
+}
+
+func TestEnsurePrivateDir_TightensLooseExistingDir(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("unix permission bits are synthetic on Windows")
+	}
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "entire")
+	// Reproduces the state left by a version check that ran before login.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if err := userdirs.EnsurePrivateDir(dir); err != nil {
+		t.Fatalf("EnsurePrivateDir: %v", err)
+	}
+	st, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := st.Mode().Perm(); got&0o077 != 0 {
+		t.Errorf("mode = %04o, still accessible by group/other", got)
+	}
+}
+
+func TestEnsurePrivateDir_LeavesAlreadyPrivateDirAlone(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("unix permission bits are synthetic on Windows")
+	}
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "entire")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if err := userdirs.EnsurePrivateDir(dir); err != nil {
+		t.Fatalf("EnsurePrivateDir: %v", err)
+	}
+	st, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := st.Mode().Perm(); got != 0o500 {
+		t.Errorf("mode = %04o, want 0500 preserved", got)
 	}
 }

--- a/internal/entireclient/userdirs/userdirs_test.go
+++ b/internal/entireclient/userdirs/userdirs_test.go
@@ -119,3 +119,27 @@ func TestEnsurePrivateDir_LeavesAlreadyPrivateDirAlone(t *testing.T) {
 		t.Errorf("mode = %04o, want 0500 preserved", got)
 	}
 }
+
+func TestEnsurePrivateDir_PreservesOwnerBitsWhileTightening(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("unix permission bits are synthetic on Windows")
+	}
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "entire")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if err := userdirs.EnsurePrivateDir(dir); err != nil {
+		t.Fatalf("EnsurePrivateDir: %v", err)
+	}
+	st, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := st.Mode().Perm(); got != 0o500 {
+		t.Errorf("mode = %04o, want 0500 (group/other cleared, owner untouched)", got)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1171
<!-- entire-trail-link-end -->

`~/.config/entire` was created `0755` where it should be `0700`.

os.MkdirAll is a no-op on a path that already exists, so the directory's mode belongs to whichever caller created it first. Three callers create this one. Two ask for 0700; the third asked for 0755, and because it runs from the root command's PersistentPostRun it fires after essentially any command, so on a fresh machine it is almost always the one that wins. The two 0700 callers could never repair the result.

Route all three through userdirs.EnsurePrivateDir, which creates at 0700 and clears group and other bits from a directory that already exists. That second half is what reaches installs already in this state; correcting the creation mode alone would only help users who have not yet run the CLI. A mode stricter than 0700 is left as the user set it, and the tightening is skipped on Windows, where the permission bits are synthetic and Chmod only toggles the read-only flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential directory creation and may chmod existing config dirs on Unix; behavior is intentionally limited for custom token-store paths but still affects real user home config layouts.
> 
> **Overview**
> Fixes a case where **`~/.config/entire`** could stay **world/group-traversable (0755)** because the version check often created the directory first with loose permissions, and later **`MkdirAll(0700)`** calls could not fix an existing directory.
> 
> Adds **`userdirs.EnsurePrivateDir`**, which creates directories at **0700** and, on Unix, **strips group/other permission bits** from directories that already exist (while preserving stricter owner modes). **Version check**, **contexts.json**, and the **default file token store** now use this helper instead of ad-hoc **`MkdirAll`**.
> 
> The file token store only tightens directories Entire chose (**`ownsDir`**): paths from **`ENTIRE_TOKEN_STORE_PATH`** are still created with **`MkdirAll(0700)`** without **`chmod`** on the parent, so CI mounts and user-chosen locations are not modified. Tests cover **`EnsurePrivateDir`** behavior and owned vs unowned token-store paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c53af1200a8bfd41905138009b712a05f6fe3e6d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->