### PR TITLE
fix(checkpoint): never store a shadow checkpoint with a transcript chunk hole

### DIFF
--- a/cmd/entire/cli/checkpoint/ephemeral.go
+++ b/cmd/entire/cli/checkpoint/ephemeral.go
@@ -43,6 +43,12 @@ const (
 	WorktreeIDHashLength = 6
 )
 
+// createBlobFromContent is an indirection over CreateBlobFromContent so tests
+// can force a single blob write to fail and assert that the shadow write
+// refuses to commit a partial transcript chunk set. Production code paths
+// always use the real function. Mirrors chunkTranscript in persistent.go.
+var createBlobFromContent = CreateBlobFromContent
+
 // HashWorktreeID returns a short hash of the worktree identifier.
 // Used to create unique shadow branch names per worktree.
 func HashWorktreeID(worktreeID string) string {
@@ -410,7 +416,17 @@ func (s *ephemeralStore) addTaskMetadataToTree(ctx context.Context, baseTreeHash
 
 		// Add session transcript (with chunking support for large transcripts)
 		if opts.TranscriptPath != "" {
-			if transcriptContent, readErr := os.ReadFile(opts.TranscriptPath); readErr == nil {
+			transcriptContent, readErr := os.ReadFile(opts.TranscriptPath)
+			if readErr != nil {
+				// Not fatal: the agent may not have flushed its transcript yet.
+				// It IS worth a line, though — before this the checkpoint was
+				// stored transcript-free with no trace of why.
+				logging.Warn(ctx, "failed to read transcript, checkpoint will be saved without it",
+					slog.String("error", readErr.Error()),
+					slog.String("session_id", opts.SessionID),
+					slog.String("transcript_path", opts.TranscriptPath),
+				)
+			} else {
 				agentType := agent.DetectAgentTypeFromContent(transcriptContent)
 
 				// Chunk if necessary
@@ -423,14 +439,17 @@ func (s *ephemeralStore) addTaskMetadataToTree(ctx context.Context, baseTreeHash
 				} else {
 					for i, chunk := range chunks {
 						chunkPath := sessionMetadataDir + "/" + agent.ChunkFileName(paths.TranscriptFileName, i)
-						blobHash, blobErr := CreateBlobFromContent(s.repo, chunk)
+						blobHash, blobErr := createBlobFromContent(s.repo, chunk)
 						if blobErr != nil {
-							logging.Warn(ctx, "failed to create blob for transcript chunk",
-								slog.String("error", blobErr.Error()),
-								slog.String("session_id", opts.SessionID),
-								slog.Int("chunk_index", i),
-							)
-							continue
+							// Never commit a partial chunk set. Readers
+							// reassemble whatever chunks are present, in index
+							// order, with no gap marker (agent.SortChunkFiles /
+							// ReassembleTranscript), so skipping one chunk
+							// yields a transcript that parses cleanly and is
+							// silently short by up to agent.MaxChunkSize. Fail
+							// the write instead, exactly as the committed store
+							// does for the same operation.
+							return plumbing.ZeroHash, fmt.Errorf("failed to create blob for transcript chunk %d of %d: %w", i, len(chunks), blobErr)
 						}
 						changes = append(changes, TreeChange{
 							Path:  chunkPath,

--- a/cmd/entire/cli/checkpoint/ephemeral_transcript_chunk_test.go
+++ b/cmd/entire/cli/checkpoint/ephemeral_transcript_chunk_test.go
@@ -1,0 +1,123 @@
+package checkpoint
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// TestAddTaskMetadataToTree_PartialTranscriptChunkSetFails pins the invariant
+// that a shadow checkpoint is never written with a hole in its transcript
+// chunk set.
+//
+// Readers reassemble a chunked transcript from whatever chunk files are
+// present, in index order, with no gap marker (agent.SortChunkFiles +
+// agent.ReassembleTranscript on the CLI side; the same base-plus-".%03d"
+// convention on every other consumer). A chunk that fails to write and is
+// skipped therefore produces a transcript that parses cleanly and is silently
+// short by up to agent.MaxChunkSize — and because condensation reads the
+// session transcript out of the shadow tree, that truncation propagates into
+// the committed checkpoint. Both transcript-chunk loops in the committed store
+// return on a blob failure; this one must too.
+func TestAddTaskMetadataToTree_PartialTranscriptChunkSetFails(t *testing.T) {
+	repo, dir := setupTestRepo(t)
+	store := newEphemeralStore(repo, DefaultV1Refs())
+
+	transcriptPath := filepath.Join(dir, "full.jsonl")
+	if err := os.WriteFile(transcriptPath, []byte(`{"type":"user"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	// Fail the transcript chunk write the way a full disk or a read-only
+	// object store would. Only the chunk loop goes through this seam, so every
+	// other blob in the checkpoint still writes normally.
+	original := createBlobFromContent
+	t.Cleanup(func() { createBlobFromContent = original })
+	createBlobFromContent = func(*git.Repository, []byte) (plumbing.Hash, error) {
+		return plumbing.ZeroHash, os.ErrPermission
+	}
+
+	baseTreeHash := headTreeHash(t, repo)
+	opts := WriteEphemeralTaskOptions{
+		SessionID:      "sess-chunk",
+		ToolUseID:      "tool-chunk",
+		AgentID:        "agent-chunk",
+		CheckpointUUID: "uuid-chunk",
+		TranscriptPath: transcriptPath,
+	}
+
+	_, err := store.addTaskMetadataToTree(context.Background(), baseTreeHash, opts)
+	if err == nil {
+		t.Fatal("addTaskMetadataToTree succeeded after a transcript chunk blob write failed; " +
+			"the checkpoint would be stored with a silently missing transcript chunk")
+	}
+	if !strings.Contains(err.Error(), "transcript chunk") {
+		t.Errorf("error does not name the failing transcript chunk: %v", err)
+	}
+}
+
+// TestAddTaskMetadataToTree_WritesEveryTranscriptChunk is the positive half:
+// with blob writes working, every chunk index the chunker produced is present
+// in the resulting tree.
+func TestAddTaskMetadataToTree_WritesEveryTranscriptChunk(t *testing.T) {
+	t.Parallel()
+
+	repo, dir := setupTestRepo(t)
+	store := newEphemeralStore(repo, DefaultV1Refs())
+
+	transcriptPath := filepath.Join(dir, "full.jsonl")
+	content := []byte(`{"type":"user"}` + "\n" + `{"type":"assistant"}` + "\n")
+	if err := os.WriteFile(transcriptPath, content, 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	chunks, err := agent.ChunkTranscript(context.Background(), content, agent.DetectAgentTypeFromContent(content))
+	if err != nil {
+		t.Fatalf("chunk transcript: %v", err)
+	}
+
+	baseTreeHash := headTreeHash(t, repo)
+	opts := WriteEphemeralTaskOptions{
+		SessionID:      "sess-chunk-ok",
+		ToolUseID:      "tool-chunk-ok",
+		AgentID:        "agent-chunk-ok",
+		CheckpointUUID: "uuid-chunk-ok",
+		TranscriptPath: transcriptPath,
+	}
+
+	treeHash, err := store.addTaskMetadataToTree(context.Background(), baseTreeHash, opts)
+	if err != nil {
+		t.Fatalf("addTaskMetadataToTree: %v", err)
+	}
+	tree, err := repo.TreeObject(treeHash)
+	if err != nil {
+		t.Fatalf("tree: %v", err)
+	}
+	for i := range chunks {
+		want := paths.EntireMetadataDir + "/" + opts.SessionID + "/" + agent.ChunkFileName(paths.TranscriptFileName, i)
+		if _, err := tree.File(want); err != nil {
+			t.Errorf("transcript chunk %d missing from tree at %s: %v", i, want, err)
+		}
+	}
+}
+
+func headTreeHash(t *testing.T, repo *git.Repository) plumbing.Hash {
+	t.Helper()
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	return commit.TreeHash
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1175
<!-- entire-trail-link-end -->

## Problem

A transcript larger than `agent.MaxChunkSize` (50 MB) is stored as `full.jsonl`, `full.jsonl.001`, `full.jsonl.002` … and every consumer reassembles it from whatever chunk files are present, in index order, with **no gap marker** (`agent.SortChunkFiles` + `agent.ReassembleTranscript`, and the same `base + ".%03d"` convention elsewhere).

`addTaskMetadataToTree` logged a warning and `continue`d when a chunk's blob write failed:

```go
blobHash, blobErr := CreateBlobFromContent(s.repo, chunk)
if blobErr != nil {
    logging.Warn(ctx, "failed to create blob for transcript chunk", ...)
    continue
}
```

so the checkpoint was committed with that chunk missing. `full.jsonl` + `full.jsonl.002` reassembles into a syntactically clean transcript that is silently short by up to 50 MB — no error, no marker, nothing a reader can detect.

This does not stay in the shadow branch. Condensation extracts the session transcript **out of the shadow tree** (`extractOrCreateSessionData` → `prepareTranscriptForStorage`), so the truncation is copied into the committed checkpoint on `entire/checkpoints/v1` and into everything downstream of it.

Both transcript-chunk loops in the committed store already return on a blob failure (`persistent.go:1063`, `persistent.go:2038`), as does the shadow store's own session-metadata walker (`ephemeral.go:998`). This loop was the only one that swallowed it.

## Fix

- A failed chunk blob write now fails the checkpoint write. A partial chunk set is unusable data, and failing leaves the previous shadow commit intact rather than replacing it with a corrupt one.
- The transcript **read** failure is now logged. It stays non-fatal (the agent may not have flushed its transcript yet), but until now an unreadable transcript produced a transcript-free checkpoint with no trace of why — the `if readErr == nil` had no `else` at all.

## Tests

`TestAddTaskMetadataToTree_PartialTranscriptChunkSetFails` fails on `main` (the write succeeds and the transcript is silently absent) and passes here. `TestAddTaskMetadataToTree_WritesEveryTranscriptChunk` pins the positive half.

`createBlobFromContent` is a test seam over `CreateBlobFromContent` so a single blob write can be failed, mirroring the existing `chunkTranscript` seam in `persistent.go`.

`mise run lint` clean; `go test ./cmd/entire/cli/checkpoint/...` green (677 tests).