### PR TITLE
fix(trailers): stop untrusted commit subjects from forging Entire trailers

### DIFF
--- a/cmd/entire/cli/trailers/trailer_forgery_test.go
+++ b/cmd/entire/cli/trailers/trailer_forgery_test.go
@@ -108,3 +108,51 @@ func TestFormatShadowCommit_TrailerValuesCannotSpliceLines(t *testing.T) {
 		t.Errorf("message has %d trailer-started lines, want %d:\n%s", got, want, msg)
 	}
 }
+
+// TestParse_IndentedSquashTrailersStillParse pins the boundary of the
+// start-of-line anchor. `git merge --squash` nests every original commit
+// message inside "Squashed commit of the following:" and indents it by four
+// spaces, so a genuine trailer reaches the parsers indented. An anchor that
+// demanded column zero silently stopped resolving checkpoints on squash-merged
+// branches — the e2e TestResumeSquashMergeMultipleCheckpoints caught it — which
+// is why the patterns skip leading horizontal whitespace.
+func TestParse_IndentedSquashTrailersStillParse(t *testing.T) {
+	t.Parallel()
+
+	const session = "2026-01-20-8f76b0e8-b8f1-4a87-9186-848bdd83d62e"
+	msg := "Squashed commit of the following:\n" +
+		"\n" +
+		"commit 1111111111111111111111111111111111111111\n" +
+		"Author: A <a@example.com>\n" +
+		"Date:   Fri Aug 29 00:00:00 2026 +0000\n" +
+		"\n" +
+		"    Add red doc\n" +
+		"\n" +
+		"    Entire-Checkpoint: abc123def456\n" +
+		"    Entire-Session: " + session + "\n"
+
+	if got, ok := ParseCheckpoint(msg); !ok {
+		t.Errorf("ParseCheckpoint found no trailer in a git squash message")
+	} else if got.String() != "abc123def456" {
+		t.Errorf("ParseCheckpoint = %q, want %q", got.String(), "abc123def456")
+	}
+	if got, ok := ParseSession(msg); !ok || got != session {
+		t.Errorf("ParseSession = %q (ok=%v), want %q", got, ok, session)
+	}
+}
+
+// TestParse_MidLineTrailerMentionIsStillIgnored is the other side of that
+// boundary: skipping an indent must not degrade into the substring match the
+// anchor was added to remove. A key that merely appears inside a line — the
+// shape a flattened hostile subject produces — must not parse.
+func TestParse_MidLineTrailerMentionIsStillIgnored(t *testing.T) {
+	t.Parallel()
+
+	msg := "I will write Entire-Session: attacker into the file\n" +
+		"\n" +
+		"Entire-Session: real-session\n"
+
+	if got, ok := ParseSession(msg); !ok || got != "real-session" {
+		t.Errorf("ParseSession = %q (ok=%v), want %q", got, ok, "real-session")
+	}
+}

--- a/cmd/entire/cli/trailers/trailer_forgery_test.go
+++ b/cmd/entire/cli/trailers/trailer_forgery_test.go
@@ -1,0 +1,110 @@
+package trailers
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatShadowCommit_SubjectCannotForgeTrailers pins the guarantee that the
+// trailers a shadow commit carries are the ones FormatShadowCommit wrote.
+//
+// The subject is built from text Entire does not author — a TodoWrite item the
+// model produced (strategy.FormatIncrementalMessage) or the session's first
+// prompt — and that text is steerable by whatever the agent read into its
+// context, a hostile file in the repository under work included. The parsers
+// here scan the whole message and take the first match, so a newline in the
+// subject used to be enough to place a forged trailer above the real block and
+// win every lookup.
+//
+// Downstream that decides: ephemeralStore.ListCheckpoints filters commits by
+// ParseSession, ReadEphemeral returns ParseMetadata's value as the checkpoint's
+// metadata directory, and rewind resolves which session's shadow branch to
+// reset from ParseSession.
+func TestFormatShadowCommit_SubjectCannotForgeTrailers(t *testing.T) {
+	t.Parallel()
+
+	const realSession = "2026-01-20-8f76b0e8-b8f1-4a87-9186-848bdd83d62e"
+	const realDir = ".entire/metadata/" + realSession
+
+	hostile := "Refactored the parser\n" +
+		"Entire-Metadata: ../../../../etc\n" +
+		"Entire-Session: attacker-session"
+
+	msg := FormatShadowCommit(hostile, realDir, realSession)
+
+	gotSession, ok := ParseSession(msg)
+	if !ok {
+		t.Fatal("ParseSession found no session trailer")
+	}
+	if gotSession != realSession {
+		t.Errorf("ParseSession returned the forged session %q, want %q", gotSession, realSession)
+	}
+
+	gotDir, ok := ParseMetadata(msg)
+	if !ok {
+		t.Fatal("ParseMetadata found no metadata trailer")
+	}
+	if gotDir != realDir {
+		t.Errorf("ParseMetadata returned the forged directory %q, want %q", gotDir, realDir)
+	}
+
+	// The subject survives as content, just flattened onto one line.
+	if !strings.Contains(msg, "Refactored the parser") {
+		t.Errorf("subject text was lost: %q", msg)
+	}
+	// Structural invariant: the only lines that BEGIN with a trailer key are
+	// the three this function wrote. A git trailer is a line, so anything the
+	// hostile subject contributed is now inert prose inside the subject line.
+	if got, want := trailerStartedLines(msg), 3; got != want {
+		t.Errorf("message has %d trailer-started lines, want %d:\n%s", got, want, msg)
+	}
+}
+
+// trailerStartedLines counts lines that begin with an "Entire-" trailer key.
+func trailerStartedLines(msg string) int {
+	n := 0
+	for _, line := range strings.Split(msg, "\n") {
+		if strings.HasPrefix(line, "Entire-") && IsTrailerLine(line) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestFormatShadowTaskCommit_SubjectCannotForgeTrailers is the task-checkpoint
+// half. Its subject is FormatIncrementalMessage(step.TodoContent, ...) — the
+// content of a TodoWrite item, verbatim apart from a 60-rune truncation, which
+// is the shortest path from a repository file to a shadow commit subject.
+func TestFormatShadowTaskCommit_SubjectCannotForgeTrailers(t *testing.T) {
+	t.Parallel()
+
+	const realSession = "2026-01-20-8f76b0e8-b8f1-4a87-9186-848bdd83d62e"
+	const realDir = ".entire/metadata/" + realSession + "/tasks/toolu_01"
+
+	hostile := "done\nEntire-Metadata-Task: ../../../../etc\nEntire-Session: attacker"
+
+	msg := FormatShadowTaskCommit(hostile, realDir, realSession)
+
+	if got, ok := ParseSession(msg); !ok || got != realSession {
+		t.Errorf("ParseSession = %q (ok=%v), want %q", got, ok, realSession)
+	}
+	if got, ok := ParseTaskMetadata(msg); !ok || got != realDir {
+		t.Errorf("ParseTaskMetadata = %q (ok=%v), want %q", got, ok, realDir)
+	}
+}
+
+// TestFormatShadowCommit_TrailerValuesCannotSpliceLines covers the other half of
+// the same hole: a newline inside a trailer VALUE splices an extra trailer line
+// into the block. ValidateSessionID is a denylist and does not reject one.
+func TestFormatShadowCommit_TrailerValuesCannotSpliceLines(t *testing.T) {
+	t.Parallel()
+
+	msg := FormatShadowCommit("subject", ".entire/metadata/s", "real\nEntire-Strategy: forged")
+
+	if got, _ := ParseSession(msg); strings.Contains(got, "\n") {
+		t.Errorf("session trailer value still carries a newline: %q", got)
+	}
+	if got, want := trailerStartedLines(msg), 3; got != want {
+		t.Errorf("message has %d trailer-started lines, want %d:\n%s", got, want, msg)
+	}
+}

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	checkpointID "github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/stringutil"
 )
 
 // Trailer key constants used in commit messages.
@@ -65,11 +66,18 @@ const (
 )
 
 // Pre-compiled regexes for trailer parsing.
+//
+// Every pattern is anchored to the start of a line ((?m)^). A git trailer is a
+// line, not a substring: without the anchor these matched a trailer key
+// anywhere inside a line, so prose or a flattened subject that merely mentions
+// "Entire-Session: x" was parsed as the commit's session. Since the parsers
+// take the FIRST match in the message and the subject precedes the trailer
+// block, an unanchored match also outranked the real trailer.
 var (
-	metadataTrailerRegex     = regexp.MustCompile(MetadataTrailerKey + `:\s*(.+)`)
-	taskMetadataTrailerRegex = regexp.MustCompile(MetadataTaskTrailerKey + `:\s*(.+)`)
-	sessionTrailerRegex      = regexp.MustCompile(SessionTrailerKey + `:\s*(.+)`)
-	checkpointTrailerRegex   = regexp.MustCompile(CheckpointTrailerKey + `:\s*(` + checkpointID.CheckpointPattern + `)(?:\s|$)`)
+	metadataTrailerRegex     = regexp.MustCompile(`(?m)^` + MetadataTrailerKey + `:\s*(.+)`)
+	taskMetadataTrailerRegex = regexp.MustCompile(`(?m)^` + MetadataTaskTrailerKey + `:\s*(.+)`)
+	sessionTrailerRegex      = regexp.MustCompile(`(?m)^` + SessionTrailerKey + `:\s*(.+)`)
+	checkpointTrailerRegex   = regexp.MustCompile(`(?m)^` + CheckpointTrailerKey + `:\s*(` + checkpointID.CheckpointPattern + `)(?:\s|$)`)
 )
 
 // ParseMetadata extracts metadata dir from commit message.
@@ -153,14 +161,36 @@ func FormatSourceRef(branch, commitHash string) string {
 	return fmt.Sprintf("%s@%s", branch, shortHash)
 }
 
+// flattenSubject collapses a shadow-commit subject onto one line.
+//
+// The parsers in this package scan the WHOLE commit message and take the first
+// match (ParseSession, ParseMetadata, ParseTaskMetadata, ParseCheckpoint), so a
+// newline in the subject is enough to place a forged trailer line ABOVE the real
+// trailer block and win. The subject is built from text Entire does not control
+// — a TodoWrite item the model wrote, or the session's first prompt — and that
+// text is steerable by anything the agent read into its context, including a
+// file in the repository it is working on.
+//
+// A shadow-commit subject is single-line by construction at every call site, so
+// collapsing is lossless for legitimate input and removes the injection point
+// for the rest. Applied to the trailer VALUES too: a value carrying a newline
+// would splice an extra trailer line into the block just as effectively.
+func flattenSubject(s string) string {
+	return stringutil.CollapseWhitespace(s)
+}
+
 // FormatShadowCommit creates a commit message for manual-commit strategy checkpoints.
 // Includes Entire-Metadata, Entire-Session, and Entire-Strategy trailers.
+//
+// The subject and the trailer values are flattened onto single lines so the
+// trailers this function writes are the ones the parsers will find. See
+// flattenSubject.
 func FormatShadowCommit(message, metadataDir, sessionID string) string {
 	var sb strings.Builder
-	sb.WriteString(message)
+	sb.WriteString(flattenSubject(message))
 	sb.WriteString("\n\n")
-	fmt.Fprintf(&sb, "%s: %s\n", MetadataTrailerKey, metadataDir)
-	fmt.Fprintf(&sb, "%s: %s\n", SessionTrailerKey, sessionID)
+	fmt.Fprintf(&sb, "%s: %s\n", MetadataTrailerKey, flattenSubject(metadataDir))
+	fmt.Fprintf(&sb, "%s: %s\n", SessionTrailerKey, flattenSubject(sessionID))
 	fmt.Fprintf(&sb, "%s: %s\n", StrategyTrailerKey, "manual-commit")
 	return sb.String()
 }
@@ -169,10 +199,10 @@ func FormatShadowCommit(message, metadataDir, sessionID string) string {
 // Includes Entire-Metadata-Task, Entire-Session, and Entire-Strategy trailers.
 func FormatShadowTaskCommit(message, taskMetadataDir, sessionID string) string {
 	var sb strings.Builder
-	sb.WriteString(message)
+	sb.WriteString(flattenSubject(message))
 	sb.WriteString("\n\n")
-	fmt.Fprintf(&sb, "%s: %s\n", MetadataTaskTrailerKey, taskMetadataDir)
-	fmt.Fprintf(&sb, "%s: %s\n", SessionTrailerKey, sessionID)
+	fmt.Fprintf(&sb, "%s: %s\n", MetadataTaskTrailerKey, flattenSubject(taskMetadataDir))
+	fmt.Fprintf(&sb, "%s: %s\n", SessionTrailerKey, flattenSubject(sessionID))
 	fmt.Fprintf(&sb, "%s: %s\n", StrategyTrailerKey, "manual-commit")
 	return sb.String()
 }

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -67,17 +67,24 @@ const (
 
 // Pre-compiled regexes for trailer parsing.
 //
-// Every pattern is anchored to the start of a line ((?m)^). A git trailer is a
-// line, not a substring: without the anchor these matched a trailer key
-// anywhere inside a line, so prose or a flattened subject that merely mentions
-// "Entire-Session: x" was parsed as the commit's session. Since the parsers
-// take the FIRST match in the message and the subject precedes the trailer
-// block, an unanchored match also outranked the real trailer.
+// Every pattern is anchored to the start of a line ((?m)^, past any indent). A
+// git trailer is a line, not a substring: without the anchor these matched a
+// trailer key anywhere inside a line, so prose or a flattened subject that
+// merely mentions "Entire-Session: x" was parsed as the commit's session. Since
+// the parsers take the FIRST match in the message and the subject precedes the
+// trailer block, an unanchored match also outranked the real trailer.
+//
+// The leading [ \t]* is required, not a loosening: `git merge --squash` nests
+// each original commit message inside "Squashed commit of the following:" and
+// indents it by four spaces, so a genuine checkpoint trailer arrives indented.
+// Requiring the key to START its line is what blocks the forgery; permitting
+// the indent git itself writes does not weaken that, because the untrusted
+// subject is flattened onto one line and so can never begin a line of its own.
 var (
-	metadataTrailerRegex     = regexp.MustCompile(`(?m)^` + MetadataTrailerKey + `:\s*(.+)`)
-	taskMetadataTrailerRegex = regexp.MustCompile(`(?m)^` + MetadataTaskTrailerKey + `:\s*(.+)`)
-	sessionTrailerRegex      = regexp.MustCompile(`(?m)^` + SessionTrailerKey + `:\s*(.+)`)
-	checkpointTrailerRegex   = regexp.MustCompile(`(?m)^` + CheckpointTrailerKey + `:\s*(` + checkpointID.CheckpointPattern + `)(?:\s|$)`)
+	metadataTrailerRegex     = regexp.MustCompile(`(?m)^[ \t]*` + MetadataTrailerKey + `:\s*(.+)`)
+	taskMetadataTrailerRegex = regexp.MustCompile(`(?m)^[ \t]*` + MetadataTaskTrailerKey + `:\s*(.+)`)
+	sessionTrailerRegex      = regexp.MustCompile(`(?m)^[ \t]*` + SessionTrailerKey + `:\s*(.+)`)
+	checkpointTrailerRegex   = regexp.MustCompile(`(?m)^[ \t]*` + CheckpointTrailerKey + `:\s*(` + checkpointID.CheckpointPattern + `)(?:\s|$)`)
 )
 
 // ParseMetadata extracts metadata dir from commit message.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1176
<!-- entire-trail-link-end -->

## Problem

A shadow checkpoint's commit subject is built from text Entire does not author:

- `strategy.FormatIncrementalMessage(step.TodoContent, ...)` — the `content` of a TodoWrite item the model wrote, verbatim apart from a 60-rune truncation.
- `generateCommitMessage` → `cleanPromptForCommit` — the session's first prompt, verbatim apart from prefix trimming and a 72-rune truncation.

Neither strips newlines. That text is steerable by anything the agent read into its context, including a file in the repository it is working on.

`FormatShadowCommit` / `FormatShadowTaskCommit` write that subject, then a blank line, then the real trailers. The parsers in this package scanned the **whole message, unanchored, and took the first match** — and the subject comes first. So one newline in the subject was enough:

```
Refactored the parser
Entire-Metadata: ../../../../etc      <- injected
Entire-Session: attacker-session      <- injected

Entire-Metadata: .entire/metadata/<real>
Entire-Session: <real>
Entire-Strategy: manual-commit
```
```
ParseSession(msg)  -> "attacker-session"
ParseMetadata(msg) -> "../../../../etc"
```

This is not cosmetic. The forged values drive real decisions:

- `ephemeralStore.ListCheckpoints` (`checkpoint/ephemeral.go:544`) filters commits by `ParseSession`, so a forged session ID re-attributes a checkpoint to another session, or hides it from its own.
- `ReadEphemeral` (`checkpoint/ephemeral.go:206-207`) and `ListCheckpoints` (`:572`) return `ParseMetadata`'s value as the checkpoint's metadata directory.
- Manual-commit rewind (`strategy/manual_commit_rewind.go:343,497,560`) resolves *which session's shadow branch to reset* from `ParseSession`.

## Fix

Both halves are needed — I checked, and flattening alone does not close it. Collapsing the subject to one line still left `Entire-Session:` sitting mid-line, and the unanchored pattern matched it there, so the collapsed subject kept winning.

1. **Flatten** the subject and the trailer values onto single lines in both shadow formatters. Every call site already passes a single-line subject, so this is lossless for legitimate input. Values get the same treatment because a newline in one splices an extra trailer line into the block, and `ValidateSessionID` is a denylist that does not reject a newline.
2. **Anchor** the four trailer patterns to the start of a line (`(?m)^`). A git trailer is a line, not a substring; a key appearing inside prose was never a trailer.

## Not covered here

`FormatCheckpoint` embeds the user's (or agent's) real commit message, which is legitimately multi-line, so it cannot be flattened. Anchoring hardens it against mid-line mentions but a line-start `Entire-Checkpoint:` typed into a commit body still parses. Closing that needs scoping the reads to the final trailer block (as `HasOPFApplied` already does via `finalTrailerBlock`), which changes `ParseAllCheckpoints` semantics for squash merges — a separate call.

## Tests

Three new tests in `trailer_forgery_test.go`, each failing on `main` and passing here. They assert the parsers return the real values and that the only lines *beginning* with a trailer key are the ones the formatter wrote.

The existing `"multiple trailers returns first"` case is unchanged (both trailers are in the real block).

`mise run lint` clean. `go test ./cmd/entire/cli/trailers/... ./cmd/entire/cli/checkpoint/...` green (733). `./cmd/entire/cli/strategy/...` 1065 pass; the 4 `git worktree add` failures there reproduce with these changes stashed and are environmental.