### PR TITLE
test(summarize): stop the nil-generator test launching the real claude CLI

### DIFF
--- a/cmd/entire/cli/summarize/summarize_test.go
+++ b/cmd/entire/cli/summarize/summarize_test.go
@@ -720,15 +720,43 @@ func TestGenerateFromTranscript_EmptyTranscript(t *testing.T) {
 	}
 }
 
+// TestGenerateFromTranscript_NilGenerator pins the nil-generator contract: the
+// call must fall back to the default ClaudeGenerator and return that
+// generator's summary, not silently produce nothing.
+//
+// The default generator is stubbed via defaultTextGeneratorFactory. Without the
+// stub this test launches the real `claude` binary — on a developer machine
+// that spends model quota, rewrites ~/.claude.json (keeping a backup) and
+// leaves a session transcript under ~/.claude/projects, all from `mise run
+// check`. The factory swap is process-global, so this test must not be
+// parallel.
 func TestGenerateFromTranscript_NilGenerator(t *testing.T) {
 	transcript := []byte(`{"type":"user","message":{"content":"Hello"}}`)
 
-	// With nil generator, should use default ClaudeGenerator
-	// This will fail because claude CLI isn't available in test, but tests the nil handling
-	_, err := GenerateFromTranscript(context.Background(), redact.AlreadyRedacted(transcript), []string{}, "", nil, nil)
-	// Error is expected (claude CLI not available), but function should not panic
-	if err == nil {
-		t.Log("Unexpectedly succeeded - claude CLI must be available")
+	factoryCalls := 0
+	originalFactory := defaultTextGeneratorFactory
+	defaultTextGeneratorFactory = func() (agent.TextGenerator, error) {
+		factoryCalls++
+		return &stubTextGenerator{
+			text: `{"intent":"stubbed intent","outcome":"stubbed outcome","learnings":{"repo":[],"code":[],"workflow":[]},"friction":[],"open_items":[]}`,
+		}, nil
+	}
+	t.Cleanup(func() {
+		defaultTextGeneratorFactory = originalFactory
+	})
+
+	summary, err := GenerateFromTranscript(context.Background(), redact.AlreadyRedacted(transcript), []string{}, "", nil, nil)
+	if err != nil {
+		t.Fatalf("GenerateFromTranscript with nil generator: %v", err)
+	}
+	if factoryCalls != 1 {
+		t.Errorf("default text generator factory called %d times, want 1 — a nil generator must fall back to ClaudeGenerator", factoryCalls)
+	}
+	if summary == nil {
+		t.Fatal("summary is nil; a nil generator must still produce the default generator's summary")
+	}
+	if summary.Intent != "stubbed intent" || summary.Outcome != "stubbed outcome" {
+		t.Errorf("summary = {Intent:%q Outcome:%q}, want the default generator's output", summary.Intent, summary.Outcome)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1177
<!-- entire-trail-link-end -->

## What

`TestGenerateFromTranscript_NilGenerator` asserted nothing and, as a side effect, executed the real `claude` binary on every `mise run check`.

## The test pinned no behaviour

```go
_, err := GenerateFromTranscript(ctx, ..., nil, nil)
if err == nil {
    t.Log("Unexpectedly succeeded - claude CLI must be available")
}
```

Error → pass. Success → `t.Log` → pass. Verified by mutation: replacing the fallback in `GenerateFromTranscript` with

```go
if generator == nil {
    return nil, nil
}
```

compiles and leaves `go test ./cmd/entire/cli/summarize` green. `GenerateFromTranscript` is the only nil-tolerant entry point, so nothing else in the repo covers it either.

## It also spawned a real agent

The nil path builds `&ClaudeGenerator{}`, which resolves `defaultTextGeneratorFactory` to the Claude Code agent and executes `claude`. The comment assumed the CLI is unavailable under test; it is present on any developer machine.

Reproduced with a throwaway `HOME`:

```
$ HOME=/tmp/canary go test -count=1 ./cmd/entire/cli/summarize
ok      github.com/entireio/cli/cmd/entire/cli/summarize 0.949s
$ find /tmp/canary -type f
/tmp/canary/.claude.json
/tmp/canary/.claude/backups/.claude.json.backup.1787994517170
/tmp/canary/.claude/projects/<tmpdir>/a291efca-....jsonl
```

The session file contains the `summarizationPromptTemplate` prompt verbatim. On a logged-in machine this is a live model call, plus a rewrite of the developer's real `~/.claude.json`, from the pre-commit gate. CI is unaffected only because `claude` is not installed on the runners.

## Fix

Stub `defaultTextGeneratorFactory` — the pattern `TestClaudeGenerator_UsesDefaultTextGenerator` already uses in this package — and assert the actual contract: the factory is consulted exactly once, and the summary returned is the default generator's output. The test is deliberately not parallel because the factory is package-global.

## Verification

- `go test ./cmd/entire/cli/summarize` — green, and a clean-`HOME` run now writes nothing under `$HOME`.
- Re-applying the `return nil, nil` mutation now **fails**:
  ```
  --- FAIL: TestGenerateFromTranscript_NilGenerator
      default text generator factory called 0 times, want 1
      summary is nil; a nil generator must still produce the default generator's summary
  ```