### PR TITLE
test(strategy): isolate hooks_test git commands from the developer's global config

### DIFF
--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
 const goosWindows = "windows"
@@ -23,6 +24,7 @@ func clearGlobalHooksPath(t *testing.T, repoDir string) {
 	t.Helper()
 	cmd := exec.CommandContext(context.Background(), "git", "config", "--local", "core.hooksPath", filepath.Join(repoDir, ".git", "hooks"))
 	cmd.Dir = repoDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to set local core.hooksPath: %v", err)
 	}
@@ -38,6 +40,7 @@ func initHooksTestRepo(t *testing.T) (string, string) {
 	ctx := context.Background()
 	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init git repo: %v", err)
 	}
@@ -55,6 +58,7 @@ func TestGetGitDirInPath_RegularRepo(t *testing.T) {
 	ctx := context.Background()
 	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init git repo: %v", err)
 	}
@@ -97,6 +101,7 @@ func TestGetGitDirInPath_Worktree(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init main repo: %v", err)
 	}
@@ -105,12 +110,14 @@ func TestGetGitDirInPath_Worktree(t *testing.T) {
 	// Configure git user for the commit
 	cmd = exec.CommandContext(ctx, "git", "config", "user.email", "test@test.com")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to configure git email: %v", err)
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "config", "user.name", "Test User")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to configure git name: %v", err)
 	}
@@ -118,6 +125,7 @@ func TestGetGitDirInPath_Worktree(t *testing.T) {
 	// Disable GPG signing for test commits
 	cmd = exec.CommandContext(ctx, "git", "config", "commit.gpgsign", "false")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to configure commit.gpgsign: %v", err)
 	}
@@ -130,12 +138,14 @@ func TestGetGitDirInPath_Worktree(t *testing.T) {
 
 	cmd = exec.CommandContext(ctx, "git", "add", ".")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to git add: %v", err)
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "commit", "-m", "initial")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to git commit: %v", err)
 	}
@@ -143,6 +153,7 @@ func TestGetGitDirInPath_Worktree(t *testing.T) {
 	// Create a worktree
 	cmd = exec.CommandContext(ctx, "git", "worktree", "add", worktreeDir, "-b", "feature")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to create worktree: %v", err)
 	}
@@ -193,6 +204,7 @@ func TestGetHooksDirInPath_RegularRepo(t *testing.T) {
 	ctx := context.Background()
 	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init git repo: %v", err)
 	}
@@ -254,6 +266,7 @@ func TestGetHooksDirInPath_CoreHooksPath(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init git repo: %v", err)
 	}
@@ -261,6 +274,7 @@ func TestGetHooksDirInPath_CoreHooksPath(t *testing.T) {
 	// Relative core.hooksPath should resolve relative to repo root.
 	cmd = exec.CommandContext(ctx, "git", "config", "core.hooksPath", ".githooks")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to set relative core.hooksPath: %v", err)
 	}
@@ -277,6 +291,7 @@ func TestGetHooksDirInPath_CoreHooksPath(t *testing.T) {
 	absHooksPath := filepath.Join(tmpDir, "abs-hooks")
 	cmd = exec.CommandContext(ctx, "git", "config", "core.hooksPath", absHooksPath)
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to set absolute core.hooksPath: %v", err)
 	}
@@ -298,6 +313,7 @@ func TestInstallGitHook_HooksPathNotADirectory(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init git repo: %v", err)
 	}
@@ -311,6 +327,7 @@ func TestInstallGitHook_HooksPathNotADirectory(t *testing.T) {
 	}
 	cmd = exec.CommandContext(ctx, "git", "config", "core.hooksPath", hooksPath)
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to set core.hooksPath: %v", err)
 	}
@@ -354,11 +371,13 @@ func TestInstallGitHook_HooksPathUnderNonDirectory(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init git repo: %v", err)
 	}
 	cmd = exec.CommandContext(ctx, "git", "config", "core.hooksPath", "/dev/null/hooks")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to set core.hooksPath: %v", err)
 	}
@@ -384,12 +403,14 @@ func TestInstallGitHook_HooksPathNonexistentIsCreated(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init git repo: %v", err)
 	}
 	hooksPath := filepath.Join(tmpDir, "githooks-not-yet-created")
 	cmd = exec.CommandContext(ctx, "git", "config", "core.hooksPath", hooksPath)
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to set core.hooksPath: %v", err)
 	}
@@ -444,6 +465,7 @@ func TestInstallGitHook_WorktreeInstallsInCommonHooks(t *testing.T) {
 	ctx := context.Background()
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-dir")
 	cmd.Dir = worktreeDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	output, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("failed to get worktree git dir: %v", err)
@@ -478,6 +500,7 @@ func initHooksWorktreeRepo(t *testing.T) (string, string) {
 	ctx := context.Background()
 	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init main repo: %v", err)
 	}
@@ -485,18 +508,21 @@ func initHooksWorktreeRepo(t *testing.T) (string, string) {
 
 	cmd = exec.CommandContext(ctx, "git", "config", "user.email", "test@test.com")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to configure git email: %v", err)
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "config", "user.name", "Test User")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to configure git name: %v", err)
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "config", "commit.gpgsign", "false")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to configure commit.gpgsign: %v", err)
 	}
@@ -508,18 +534,21 @@ func initHooksWorktreeRepo(t *testing.T) (string, string) {
 
 	cmd = exec.CommandContext(ctx, "git", "add", ".")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to git add: %v", err)
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "commit", "-m", "initial")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to git commit: %v", err)
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "worktree", "add", worktreeDir, "-b", "feature")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to create worktree: %v", err)
 	}
@@ -600,18 +629,21 @@ func TestIsGitSequenceOperation_Worktree(t *testing.T) {
 	// Initialize main repo with a commit
 	cmd := exec.CommandContext(ctx, "git", "init")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init main repo: %v", err)
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "config", "user.email", "test@test.com")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to configure git email: %v", err)
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "config", "user.name", "Test User")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to configure git name: %v", err)
 	}
@@ -619,6 +651,7 @@ func TestIsGitSequenceOperation_Worktree(t *testing.T) {
 	// Disable GPG signing for test commits
 	cmd = exec.CommandContext(ctx, "git", "config", "commit.gpgsign", "false")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to configure commit.gpgsign: %v", err)
 	}
@@ -630,12 +663,14 @@ func TestIsGitSequenceOperation_Worktree(t *testing.T) {
 
 	cmd = exec.CommandContext(ctx, "git", "add", ".")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to git add: %v", err)
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "commit", "-m", "initial")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to git commit: %v", err)
 	}
@@ -643,6 +678,7 @@ func TestIsGitSequenceOperation_Worktree(t *testing.T) {
 	// Create a worktree
 	cmd = exec.CommandContext(ctx, "git", "worktree", "add", worktreeDir, "-b", "feature")
 	cmd.Dir = mainRepo
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to create worktree: %v", err)
 	}
@@ -658,6 +694,7 @@ func TestIsGitSequenceOperation_Worktree(t *testing.T) {
 	// Get the worktree's git dir and simulate rebase state there
 	cmd = exec.CommandContext(ctx, "git", "rev-parse", "--git-dir")
 	cmd.Dir = worktreeDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	output, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("failed to get git dir: %v", err)
@@ -1101,6 +1138,7 @@ func TestInstallGitHook_CoreHooksPathRelative(t *testing.T) {
 	// Simulate Husky-style override: hooks live outside .git/hooks.
 	cmd := exec.CommandContext(ctx, "git", "config", "core.hooksPath", ".husky/_")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to set core.hooksPath: %v", err)
 	}
@@ -1145,6 +1183,7 @@ func TestRemoveGitHook_CoreHooksPathRelative(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, "git", "config", "core.hooksPath", ".husky/_")
 	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to set core.hooksPath: %v", err)
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1179
<!-- entire-trail-link-end -->

## What

Four tests in `cmd/entire/cli/strategy/hooks_test.go` fail on a clean checkout of `main`, on a machine whose `~/.gitconfig` sets `init.defaultBranch = feature`.

```
$ go test ./cmd/entire/cli/strategy
--- FAIL: TestGetGitDirInPath_Worktree
    hooks_test.go:147: failed to create worktree: exit status 255
--- FAIL: TestGetHooksDirInPath_Worktree
    hooks_test.go:225: failed to create worktree: exit status 255
--- FAIL: TestInstallGitHook_WorktreeInstallsInCommonHooks
    hooks_test.go:420: failed to create worktree: exit status 255
--- FAIL: TestIsGitSequenceOperation_Worktree
    hooks_test.go:647: failed to create worktree: exit status 255
```

## Cause

The 38 `exec.CommandContext(ctx, "git", …)` calls in this file leave `cmd.Env` unset, so every child git reads the developer's real global config. The worktree setups do:

```go
cmd = exec.CommandContext(ctx, "git", "worktree", "add", worktreeDir, "-b", "feature")
```

With `init.defaultBranch = feature`, `git init` has already created that branch, so the add fails with `fatal: a branch named 'feature' already exists`. Isolating the cause:

```
$ git worktree add /tmp/wt -b feature
fatal: a branch named 'feature' already exists
EXIT=255
$ GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git worktree add /tmp/wt2 -b feature2
HEAD is now at 4dce75c init
EXIT=0
```

And on the unmodified tree:

```
$ GIT_CONFIG_GLOBAL=/tmp/empty GIT_CONFIG_SYSTEM=/tmp/empty go test ./cmd/entire/cli/strategy -run Worktree
ok      github.com/entireio/cli/cmd/entire/cli/strategy  1.843s
$ go test ./cmd/entire/cli/strategy -run Worktree
FAIL
```

This is the failure mode that erodes trust in the gate: `mise run check` goes red for a correct change, the message (`exit status 255`, no stderr) explains nothing, and it gets written off as a flake.

The file already knew about the problem in one shape — `clearGlobalHooksPath` exists to defeat a global `core.hooksPath` — but that fix is per-setting. `init.defaultBranch`, `commit.gpgsign`, `core.autocrlf`, aliases, and `init.templateDir` all still leak in.

## Fix

`cmd.Env = testutil.GitIsolatedEnv()` on every git invocation in the file. That helper is already the repo's answer here: it strips inherited `GIT_CONFIG_*` and points global and system config at an empty file. Unlike `testutil.IsolateGitConfigEnv`/`t.Setenv` it is safe in the parallel tests in this file.

`clearGlobalHooksPath` is kept — pinning the local value is still correct for a repo under test.

## Verification

`go test ./cmd/entire/cli/strategy`: 1065 passed / 4 failed → **1069 passed / 0 failed**.