### PR TITLE
test(e2e): fail the canary when no agent registered instead of skipping everything

### DIFF
--- a/e2e/tests/main_test.go
+++ b/e2e/tests/main_test.go
@@ -89,6 +89,25 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	// Preflight: at least one agent must be registered. Registration happens in
+	// each agent package's init, and is conditional on E2E_AGENT naming that
+	// agent AND its binary being on PATH at process start. When nothing
+	// registers, the missing-binaries loop above has nothing to iterate,
+	// ForEachAgent calls t.Skip in every test, and the run exits 0 — the suite
+	// reports success having exercised nothing. Measured on this suite: with
+	// E2E_AGENT=vogon and vogon absent from PATH, 54 of 56 tests skip and
+	// `go test -tags=e2e ./e2e/tests` passes in 1.5s.
+	//
+	// The e2e canary is the deterministic gate that guards checkpoint capture
+	// on every PR, so a green run that ran nothing is worse than a red one.
+	// Fail the same way a missing binary does.
+	if len(agents.All()) == 0 {
+		fmt.Fprintf(os.Stderr,
+			"preflight: no agents registered (E2E_AGENT=%q); every test would skip and the run would report success\n",
+			os.Getenv("E2E_AGENT"))
+		os.Exit(1)
+	}
+
 	version := "unknown"
 	if out, err := exec.Command(entireBin, "version").Output(); err == nil {
 		version = string(out)

--- a/mise-tasks/test/e2e/canary
+++ b/mise-tasks/test/e2e/canary
@@ -25,6 +25,15 @@ rr_rc=0
 
 # --- vogon: runs all tests (built-in agent) ---
 echo "--- canary: vogon ---"
+
+# Preflight, mirroring the roger-roger check below: vogon registers itself only
+# if its binary is on PATH when the test binary starts. Without it nothing
+# registers, every test skips, and the lane exits 0 having run nothing.
+if ! PATH="$E2E_PATH" command -v vogon >/dev/null 2>&1; then
+  echo "error: vogon binary not found on PATH after build; the canary lane would skip every test and still report success." >&2
+  exit 1
+fi
+
 PATH="$E2E_PATH" E2E_AGENT=vogon gotestsum --format dots \
   --jsonfile "$E2E_ARTIFACT_DIR/test-events-vogon.json" -- \
   -tags=e2e -count=1 -timeout=10m \


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1180
<!-- entire-trail-link-end -->

## What

The e2e canary lane can report success having run nothing.

Each agent registers itself from `init`, conditional on `E2E_AGENT` naming it **and** its binary being on `PATH` at process start (`e2e/agents/vogon.go:17-21`). When nothing registers:

- the existing missing-binaries preflight loops over `agents.All()` — an empty list — and passes;
- `ForEachAgent` hits `if len(all) == 0 { t.Skip(...) }` in every test;
- `go test` exits 0.

## Measurement

`E2E_AGENT=vogon`, `vogon` absent from `PATH`, everything else present:

```
$ go test -tags=e2e -count=1 ./e2e/tests
ok      github.com/entireio/cli/e2e/tests  1.495s

top-level PASS 2   SKIP 54   FAIL 0
sample skips: TestExternalAgentSessionMetadata, TestSessionDepletedManualEditNoCheckpoint,
              TestAttachSessionCreatesCheckpoint, TestPartialCommitStashNewPrompt, ...
```

54 of 56 tests skipped, exit 0, 1.5 seconds. This is the lane that guards checkpoint capture on every PR (`ci.yml` `test-canary`, both checkpoint backends) and in `mise run check`. A green run that exercised nothing is worse than a red one.

The task author already worried about exactly this for the other leg — `mise-tasks/test/e2e/canary` fails fast if `roger-roger` or `entire-agent-roger-roger` is missing, with the comment *"so the suite cannot silently 'succeed' without exercising the external agent."* The vogon leg had no such check, and the Go-side floor was missing for both.

## Fix

1. `e2e/tests/main_test.go`: after the binaries preflight, exit 1 when `agents.All()` is empty, naming `E2E_AGENT` in the message.
2. `mise-tasks/test/e2e/canary`: preflight `command -v vogon` on the leg's `PATH`, mirroring the roger-roger check.

## Verification

```
# vogon OFF PATH
preflight: no agents registered (E2E_AGENT="vogon"); every test would skip and the run would report success
FAIL    github.com/entireio/cli/e2e/tests  0.457s

# vogon ON PATH
--- PASS: TestSingleSessionManualCommit (1.55s)
--- PASS: TestHumanOnlyChangesAndCommits (5.88s)
ok      github.com/entireio/cli/e2e/tests  6.254s
```

`shellcheck mise-tasks/test/e2e/canary` clean; `gofmt` clean.