### PR TITLE
fix(auth): keep auth-go's process lock out of the real user cache under test

### DIFF
--- a/cmd/entire/cli/auth/refresh.go
+++ b/cmd/entire/cli/auth/refresh.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
+	"github.com/entireio/cli/internal/testdirs"
 )
 
 // defaultSavedTokenTTL is the encoded keychain expiry used when a refreshed
@@ -130,11 +131,34 @@ func newContextTokenManager(c *contexts.Context, transport http.RoundTripper, al
 		Transport:         transport,
 		AllowInsecureHTTP: allowInsecureHTTP,
 		UserAgent:         oauthClientID,
+		LockDir:           tokenManagerLockDir(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("init token manager for context %q: %w", c.Name, err)
 	}
 	return mgr, nil
+}
+
+// tokenManagerLockDir picks the directory holding auth-go's cross-process
+// advisory lock file. Empty means auth-go's own default,
+// os.UserCacheDir()/auth-go, which is what production wants.
+//
+// Under `go test` that default is the developer's real user cache directory
+// (~/Library/Caches/auth-go on macOS, which os.UserCacheDir resolves without
+// consulting XDG_CACHE_HOME), so every test that builds a per-context manager
+// litters it with lock files keyed on (ClientID, Issuer). Route it to the same
+// throwaway per-process directory the config, cache, and tokenstore surfaces
+// already use under test — internal/testdirs exists precisely so a test that
+// forgets an override cannot reach real user state.
+//
+// The lock file holds no credentials; the harm is writing into a directory that
+// is not ours to write to, and sharing a cross-process lock with whatever else
+// is running.
+func tokenManagerLockDir() string {
+	if dir, ok := testdirs.Dir("authlock"); ok {
+		return dir
+	}
+	return ""
 }
 
 // reauthError carries a friendly, context-named re-login message while still

--- a/cmd/entire/cli/auth/refresh_test.go
+++ b/cmd/entire/cli/auth/refresh_test.go
@@ -489,8 +489,8 @@ func TestTokenManagerLockDir_NeverRealUserCache(t *testing.T) {
 	if err != nil {
 		t.Skipf("os.UserCacheDir unavailable: %v", err)
 	}
-	real := filepath.Join(cache, "auth-go")
-	if dir == real || strings.HasPrefix(dir, real+string(os.PathSeparator)) {
-		t.Fatalf("tokenManagerLockDir() = %q, which resolves under the real %q", dir, real)
+	realLockDir := filepath.Join(cache, "auth-go")
+	if dir == realLockDir || strings.HasPrefix(dir, realLockDir+string(os.PathSeparator)) {
+		t.Fatalf("tokenManagerLockDir() = %q, which resolves under the real %q", dir, realLockDir)
 	}
 }

--- a/cmd/entire/cli/auth/refresh_test.go
+++ b/cmd/entire/cli/auth/refresh_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -418,3 +419,78 @@ func failRoundTripper(t *testing.T) http.RoundTripper {
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// TestNewContextTokenManager_LockNeverInRealUserCache is the end-to-end guard:
+// drive one real refresh through the per-context manager and prove auth-go's
+// cross-process lock file did not land in the user cache directory. HOME and
+// XDG_CACHE_HOME are redirected so os.UserCacheDir resolves inside the test's
+// own tree on both macOS ($HOME/Library/Caches) and Linux ($XDG_CACHE_HOME);
+// anything appearing under <home>/auth-go there would be written to the
+// developer's real cache in a normal run.
+//
+// Not parallel: it sets process-wide environment.
+func TestNewContextTokenManager_LockNeverInRealUserCache(t *testing.T) {
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_CACHE_HOME", fakeHome)
+
+	newJWT := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example","handle":"alice","exp":%d}`, time.Now().Add(time.Hour).Unix()))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"access_token":%q,"refresh_token":"entr_new","token_type":"Bearer","expires_in":3600}`, newJWT)
+	}))
+	defer srv.Close()
+
+	svc := tokenstore.CoreKeyringService(srv.URL)
+	staleJWT := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, srv.URL, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(staleJWT, 7200)); err != nil {
+		t.Fatalf("seed access token: %v", err)
+	}
+	if err := tokenstore.Set(tokenstore.RefreshService(svc), "alice", "entr_old"); err != nil {
+		t.Fatalf("seed refresh token: %v", err)
+	}
+
+	c := &contexts.Context{Name: "alice@core", CoreURL: srv.URL, Handle: "alice", KeychainService: svc}
+	credential, err := NewRefreshingLoginCredential(c, srv.Client().Transport, true)
+	if err != nil {
+		t.Fatalf("NewRefreshingLoginCredential: %v", err)
+	}
+	// ForceRefresh takes the cross-process lock before re-minting.
+	if _, err := credential.ForceRefresh(t.Context(), staleJWT); err != nil {
+		t.Fatalf("ForceRefresh: %v", err)
+	}
+
+	for _, dir := range []string{
+		filepath.Join(fakeHome, "auth-go"),                      // Linux: XDG_CACHE_HOME/auth-go
+		filepath.Join(fakeHome, "Library", "Caches", "auth-go"), // macOS: HOME/Library/Caches/auth-go
+	} {
+		if _, statErr := os.Stat(dir); statErr == nil {
+			t.Errorf("auth-go lock directory %q was created; the token manager must not write into the user cache dir under test", dir)
+		}
+	}
+}
+
+// TestTokenManagerLockDir_NeverRealUserCache pins the test-isolation half of
+// the LockDir contract: under `go test`, auth-go's cross-process lock must not
+// land in the developer's real user cache directory. Returning "" here would
+// hand auth-go its production default, os.UserCacheDir()/auth-go, which on
+// macOS is ~/Library/Caches/auth-go regardless of XDG_CACHE_HOME.
+func TestTokenManagerLockDir_NeverRealUserCache(t *testing.T) {
+	t.Parallel()
+
+	dir := tokenManagerLockDir()
+	if dir == "" {
+		t.Fatal("tokenManagerLockDir() = \"\" under go test; auth-go would fall back to the real user cache dir")
+	}
+
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		t.Skipf("os.UserCacheDir unavailable: %v", err)
+	}
+	real := filepath.Join(cache, "auth-go")
+	if dir == real || strings.HasPrefix(dir, real+string(os.PathSeparator)) {
+		t.Fatalf("tokenManagerLockDir() = %q, which resolves under the real %q", dir, real)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1181
<!-- entire-trail-link-end -->

## What

`go test ./cmd/entire/cli/auth` writes lock files into the developer's real user cache directory, and reports `ok` either way.

## Measurement

Every package was run with `HOME` pointed at a throwaway directory and the directory diffed afterwards. `cmd/entire/cli/auth` was one of three packages that wrote outside its temp dirs:

```
### github.com/entireio/cli/cmd/entire/cli/auth (rc=0)
    ~/Library/Caches/auth-go/1b63a21147bb08bb2fab113f82357c23041f5733891951a115cd002a6c36ce30.lock
    ~/Library/Caches/auth-go/2c7c3110e429b52df812c8a78d0939cacaae619aa83129bb1c7979f831b66180.lock
    ~/Library/Caches/auth-go/bc9c8dde6591f4616e75c52ea7884a9f9b07760d23705aca57c9befac3cb71eb.lock
    ~/Library/Caches/auth-go/ca5d6b2009155bcdc721a63bbf902db2cffb5d94922809af40699bf9af58bd9f.lock
```

On this machine the *real* `~/Library/Caches/auth-go` had accumulated **281** such files.

## Cause

`newContextTokenManager` (`cmd/entire/cli/auth/refresh.go`) leaves `tokenmanager.Config.LockDir` empty, so auth-go falls back to:

```go
if cache, err := os.UserCacheDir(); err == nil {
    dir = filepath.Join(cache, "auth-go")
}
```

On macOS `os.UserCacheDir()` is `$HOME/Library/Caches` and **ignores `XDG_CACHE_HOME`** — so the `XDG_CACHE_HOME` override the integration/e2e/`cli` TestMains already set does not redirect it. `internal/testdirs` covers config, cache, and tokenstore; the auth-go lock directory was the one surface nothing covered.

The lock file holds no credentials. The problem is writing into a directory that is not ours, unbounded, from the test suite — the exact thing `internal/testdirs` was written to prevent ("real auth contexts have been polluted with test fixtures this way").

## Fix

Route `LockDir` through `testdirs`, mirroring `tokenstore.resolveBackendLocked`:

```go
func tokenManagerLockDir() string {
	if dir, ok := testdirs.Dir("authlock"); ok {
		return dir
	}
	return "" // auth-go's own default; production behaviour unchanged
}
```

`testdirs.Dir` returns `ok == false` outside `go test`, so production keeps `os.UserCacheDir()/auth-go`.

## Verification

- Clean-`HOME` run of the package now creates no `Library/Caches` at all.
- `go test ./cmd/entire/cli/auth`: 101 → 102 passed, 0 failed.
- Two guards added. Deleting the `LockDir:` line makes the end-to-end one fail:
  ```
  --- FAIL: TestNewContextTokenManager_LockNeverInRealUserCache
      auth-go lock directory ".../Library/Caches/auth-go" was created
  ```