### PR TITLE
test(checkpoint): pin the shadow-branch worktree hash to known-answer vectors

### DIFF
--- a/cmd/entire/cli/checkpoint/ephemeral_test.go
+++ b/cmd/entire/cli/checkpoint/ephemeral_test.go
@@ -6,34 +6,59 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
 
+// TestHashWorktreeID pins the derivation to fixed values, not just to its
+// shape.
+//
+// The hash is half of every shadow branch name, and shadow branches are how a
+// running session finds its own pending checkpoints across invocations. Change
+// the derivation and an upgraded CLI computes a different branch name for the
+// same worktree: the in-flight checkpoints are still on disk but nothing looks
+// for them again, and intra-session rewind silently loses its history. Nothing
+// re-derives the old name, so the break is invisible.
+//
+// Shape assertions cannot see that. A mutation to sha256("wt:" + worktreeID) is
+// still 6 hex chars, still deterministic, still collision-free — and until
+// these vectors existed it left every package in the repo green, including the
+// integration suite, whose shadow-branch assertions compare against
+// checkpoint.ShadowBranchNameForCommit (the function under test) rather than a
+// literal.
+//
+// Vectors are the first 6 hex chars of SHA-256 over the raw worktree ID;
+// reproduce with:
+//
+//	printf %s 'test-123' | shasum -a 256 | cut -c1-6
 func TestHashWorktreeID(t *testing.T) {
 	tests := []struct {
 		name       string
 		worktreeID string
-		wantLen    int
+		want       string
 	}{
 		{
 			name:       "empty string (main worktree)",
 			worktreeID: "",
-			wantLen:    6,
+			want:       "e3b0c4",
 		},
 		{
 			name:       "simple worktree name",
 			worktreeID: "test-123",
-			wantLen:    6,
+			want:       "37eb19",
 		},
 		{
 			name:       "complex worktree name",
 			worktreeID: "feature/auth-system",
-			wantLen:    6,
+			want:       "16b0aa",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := HashWorktreeID(tt.worktreeID)
-			if len(got) != tt.wantLen {
-				t.Errorf("HashWorktreeID(%q) length = %d, want %d", tt.worktreeID, len(got), tt.wantLen)
+			if len(got) != WorktreeIDHashLength {
+				t.Errorf("HashWorktreeID(%q) length = %d, want %d", tt.worktreeID, len(got), WorktreeIDHashLength)
+			}
+			if got != tt.want {
+				t.Errorf("HashWorktreeID(%q) = %q, want %q — this names the shadow branch; a change orphans every in-flight session's pending checkpoints",
+					tt.worktreeID, got, tt.want)
 			}
 		})
 	}
@@ -65,23 +90,26 @@ func TestShadowBranchNameForCommit(t *testing.T) {
 		worktreeID string
 		want       string
 	}{
+		// want is spelled out rather than built with HashWorktreeID: composing
+		// the expectation from the function under test makes the assertion
+		// vacuous for the half of the name that function produces.
 		{
 			name:       "main worktree",
 			baseCommit: "abc1234567890",
 			worktreeID: "",
-			want:       "entire/abc1234-" + HashWorktreeID(""),
+			want:       "entire/abc1234-e3b0c4",
 		},
 		{
 			name:       "linked worktree",
 			baseCommit: "abc1234567890",
 			worktreeID: "test-123",
-			want:       "entire/abc1234-" + HashWorktreeID("test-123"),
+			want:       "entire/abc1234-37eb19",
 		},
 		{
 			name:       "short commit hash",
 			baseCommit: "abc",
 			worktreeID: "wt",
-			want:       "entire/abc-" + HashWorktreeID("wt"),
+			want:       "entire/abc-a721db",
 		},
 	}
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1182
<!-- entire-trail-link-end -->

## What

`HashWorktreeID` names half of every shadow branch (`entire/<commit:7>-<worktreeHash:6>`), and shadow branches are how a running session finds its own pending checkpoints between invocations. If the derivation changes, an upgraded CLI computes a different branch name for the same worktree — the in-flight checkpoints are still on disk, nothing looks for them again, and intra-session rewind silently loses its history.

No test in the repo could see that.

## Why

`TestHashWorktreeID` asserted three properties — length 6, deterministic, different inputs differ.

`TestShadowBranchNameForCommit` built its expectation from the function under test:

```go
want: "entire/abc1234-" + HashWorktreeID(""),
```

so the hashed half compared against itself.

The integration suite is not a backstop: its shadow-branch assertions go through `env.GetShadowBranchNameForCommit` (`integration_test/testenv.go:638`), which calls `checkpoint.ShadowBranchNameForCommit` — the same function again.

Mutation, compiles, preserves all three properties:

```go
h := sha256.Sum256([]byte("wt:" + worktreeID))
```

`go test ./cmd/entire/cli/checkpoint/...` stayed green — 675 tests, 0 failures.

## Fix

Literal vectors, reproducible with `printf %s 'test-123' | shasum -a 256 | cut -c1-6`:

| worktree ID | hash |
|---|---|
| `` (main worktree) | `e3b0c4` |
| `test-123` | `37eb19` |
| `feature/auth-system` | `16b0aa` |
| `wt` | `a721db` |

`TestShadowBranchNameForCommit`'s `want` values are spelled out instead of composed from `HashWorktreeID`. The length assertion is kept and now reads `WorktreeIDHashLength` rather than a repeated `6`.

## Verification

- `go test ./cmd/entire/cli/checkpoint/...` — 675 passed.
- With the `"wt:"` mutation re-applied, `TestHashWorktreeID` and three subtests of `TestShadowBranchNameForCommit` **fail**.