### PR TITLE
Update ephemeral_test.go

### DIFF
--- a/cmd/entire/cli/checkpoint/ephemeral_test.go
+++ b/cmd/entire/cli/checkpoint/ephemeral_test.go
@@ -27,7 +27,8 @@ import (
 // reproduce with:
 //
 //	printf %s 'test-123' | shasum -a 256 | cut -c1-6
-func TestHashWorktreeID(t *testing.T) {
+ func TestHashWorktreeID(t *testing.T) {
+ 	t.Parallel()
 	tests := []struct {
 		name       string
 		worktreeID string
@@ -84,9 +85,10 @@ func TestHashWorktreeID_DifferentInputs(t *testing.T) {
 }
 
 func TestShadowBranchNameForCommit(t *testing.T) {
-	tests := []struct {
-		name       string
-		baseCommit string
+    t.Parallel()
+    tests := []struct {
+        name       string
+        baseCommit string
 		worktreeID string
 		want       string
 	}{


### PR DESCRIPTION
These tests don’t call t.Parallel(), but most other tests in this package do (e.g. cmd/entire/cli/checkpoint/objectsigner_test.go:13, cmd/entire/cli/checkpoint/persistent_reader_test.go:16). Adding it here will keep the suite consistent and improve overall test runtime.