### PR TITLE
fix(trailers): patch single-line bypass in shadow commit subjects

### DIFF
--- a/cmd/entire/cli/trailers/trailer_forgery_test.go
+++ b/cmd/entire/cli/trailers/trailer_forgery_test.go
@@ -58,6 +58,15 @@ func TestFormatShadowCommit_SubjectCannotForgeTrailers(t *testing.T) {
 	if got, want := trailerStartedLines(msg), 3; got != want {
 		t.Errorf("message has %d trailer-started lines, want %d:\n%s", got, want, msg)
 	}
+	
+	// Single-line bypass: a hostile subject that begins with a trailer key must not win.
+ 	msg2 := FormatShadowCommit("Entire-Session: attacker-session", realDir, realSession)
+ 	if got, ok := ParseSession(msg2); !ok || got != realSession {
+ 		t.Errorf("ParseSession (single-line bypass) = %q (ok=%v), want %q", got, ok, realSession)
+ 	}
+ 	if got, want := trailerStartedLines(msg2), 3; got != want {
+ 		t.Errorf("message has %d trailer-started lines, want %d:\n%s", got, want, msg2)
+ 	}
 }
 
 // trailerStartedLines counts lines that begin with an "Entire-" trailer key.

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -183,7 +183,12 @@ func FormatSourceRef(branch, commitHash string) string {
 // for the rest. Applied to the trailer VALUES too: a value carrying a newline
 // would splice an extra trailer line into the block just as effectively.
 func flattenSubject(s string) string {
-	return stringutil.CollapseWhitespace(s)
+ 	s = stringutil.CollapseWhitespace(s)
+ 	// Prevent a subject line from being parsed as an Entire trailer when it begins with a trailer key.
+ 	if strings.HasPrefix(s, "Entire-") {
+ 		return "(subject) " + s
+ 	}
+ 	return s
 }
 
 // FormatShadowCommit creates a commit message for manual-commit strategy checkpoints.


### PR DESCRIPTION
Edge case: a single-line bypass. 

Because the regexes are anchored to the line-start, a hostile single-line subject that begins exactly with a trailer key (e.g., `Entire-Session: attacker`) is still evaluated as line 1 and successfully parsed as a trailer. 

This layers onto your forgery fix by:
- Updating `flattenSubject()` to check if the flattened subject starts with `Entire-`. If it does, it prepends `(subject) ` to safely neutralize the line-start anchor.
- Adding a regression test in `trailer_forgery_test.go` to explicitly pin this single-line bypass behavior.