### PR TITLE
fix(checkpoint): surface load errors for missing checkpoints

### DIFF
--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -1573,7 +1573,7 @@ func (s *GitStore) ReadTaskRecords(ctx context.Context, checkpointID id.Checkpoi
 	}
 	checkpointTree, err := s.getCheckpointFetchingTree(ctx, checkpointID)
 	if err != nil {
-		return nil, ErrCheckpointNotFound
+		return nil, err
 	}
 	return readTaskRecordsFromCheckpointTree(ctx, checkpointTree)
 }

--- a/cmd/entire/cli/checkpoint_api_reader.go
+++ b/cmd/entire/cli/checkpoint_api_reader.go
@@ -288,7 +288,11 @@ func (r *apiCheckpointReader) ReadSessionContent(ctx context.Context, checkpoint
 // ReadTaskRecords reports no task records: the API exposes no per-subagent
 // task record endpoint, so a checkpoint read this way has no attributable
 // subagent work.
-func (r *apiCheckpointReader) ReadTaskRecords(context.Context, id.CheckpointID) ([]checkpoint.StoredTaskRecord, error) {
+func (r *apiCheckpointReader) ReadTaskRecords(ctx context.Context, checkpointID id.CheckpointID) ([]checkpoint.StoredTaskRecord, error) {
+ 	// Ensure missing/forbidden checkpoints surface the same errors as other read paths.
+ 	if _, err := r.loadDetail(ctx, checkpointID); err != nil {
+ 		return nil, err
+ 	}
 	return nil, nil
 }
 


### PR DESCRIPTION
This addresses `ReadTaskRecords` swallowing errors when a checkpoint ID is invalid or unavailable. 

**Changes:**
* **`cmd/entire/cli/checkpoint_api_reader.go`**: Updated `ReadTaskRecords` to validate the checkpoint via `loadDetail` and surface resulting errors instead of unconditionally returning `nil, nil`.
* **`cmd/entire/cli/checkpoint/persistent.go`**: Updated `GitStore.ReadTaskRecords` to return the actual underlying `err` rather than hardcoding `ErrCheckpointNotFound`.