### PR TITLE
Update dispatch_wizard.go

### DIFF
--- a/cmd/entire/cli/dispatch_wizard.go
+++ b/cmd/entire/cli/dispatch_wizard.go
@@ -264,6 +264,10 @@ func runDispatchWizard(cmd *cobra.Command) (dispatchpkg.Options, error) {
 	jurisdiction := &dispatchJurisdictionAccessor{state: &state}
 
 	validateRepos := func(value []string) error {
+		// In local mode, the repo list is unused (and --repos is invalid), so don't require a selection.
+ 		if state.isLocal() {
+ 			return nil
+ 		}
 		selected := normalizeDispatchWizardSelections(value)
 		if len(selected) == 0 {
 			return errors.New("select at least one repo")


### PR DESCRIPTION
In accessible mode the repo picker is always included, but the validator still requires at least one repo even when the user selects Local mode (where repos are ignored). This makes Local flow unnecessarily blocked/awkward in accessible mode.