### PR TITLE
Update status.go

### DIFF
--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -77,7 +77,7 @@ func runStatus(ctx context.Context, w io.Writer, detailed, jsonOutput bool) erro
 	// Check which settings files exist
 	projectExists, localExists, err := settings.FilesPresent(ctx)
 	if err != nil {
-		return fmt.Errorf("%w", err)
+		return err
 	}
 
 	if !projectExists && !localExists {


### PR DESCRIPTION
settings.FilesPresent errors are already contextual; wrapping with fmt.Errorf("%w", err) is a no-op for the message but changes the concrete error value (which can break any direct equality checks). Prefer returning the original error directly.