### PR TITLE
Remove stale references to the removed rewind command

### DIFF
--- a/.claude/skills/agent-integration/implementer.md
+++ b/.claude/skills/agent-integration/implementer.md
@@ -206,14 +206,14 @@ Run: `mise run fmt && mise run lint`
 
 **Commit:** Use `/commit` to commit all files. Skip if no files changed.
 
-### Step 11: E2E Tier 6 — Interactive and Rewind Tests
+### Step 11: E2E Tier 6 — Interactive and Resume Tests
 
 Run these if the agent supports interactive multi-step sessions:
 
 - `TestInteractiveMultiStep` — Multiple prompts in one session
-- `TestRewindPreCommit` — Rewind to a checkpoint before committing
-- `TestRewindAfterCommit` — Rewind to a checkpoint after committing
-- `TestRewindMultipleFiles` — Rewind with multiple files changed
+- `TestResumeFromFeatureBranch` — Resume a session from its branch
+- `TestResumeFromClonedRepo` — Resume where the checkpoint comes from the remote
+- `TestResumeOlderCheckpointWithNewerCommits` — Resume an earlier checkpoint with newer commits present
 
 **Cycle:** Same pattern — run, **watch it fail**, `/e2e:debug` on failures, fix, repeat.
 

--- a/.claude/skills/agent-integration/test-writer.md
+++ b/.claude/skills/agent-integration/test-writer.md
@@ -21,7 +21,7 @@ Read these files to understand the existing test patterns.
 4. `e2e/agents/tmux.go` — `TmuxSession` for interactive PTY-based tests: `NewTmuxSession`, `Send`, `SendKeys`, `WaitFor` (with settle-time logic), `Capture`, `Close`
 5. `e2e/testutil/assertions.go` — Rich assertion helpers: `AssertFileExists`, `WaitForFileExists`, `AssertNewCommits`, `WaitForCheckpoint`, `AssertCheckpointAdvanced`, `AssertHasCheckpointTrailer`, `AssertCheckpointExists`, `AssertCommitLinkedToCheckpoint`, `AssertCheckpointMetadataComplete`, `ValidateCheckpointDeep`, and many more
 6. `e2e/testutil/metadata.go` — `CheckpointMetadata`, `SessionMetadata`, `TokenUsage`, `Attribution`, `SessionRef` types; `CheckpointPath()` helper for sharded directory layout
-7. `e2e/entire/entire.go` — CLI wrapper: `BinPath()` (builds from source or uses `E2E_ENTIRE_BIN`), `Enable`, `Disable`, `RewindList`, `Rewind`, `RewindLogsOnly`, `Explain`, `ExplainGenerate`, `ExplainCommit`, `Resume`
+7. `e2e/entire/entire.go` — CLI wrapper: `BinPath()` (builds from source or uses `E2E_ENTIRE_BIN`), `Enable`, `Disable`, `Doctor`, `CleanDryRun`, `CleanForce`, `Explain`, `AttachWithEnv`, `Resume` / `ResumeWithEnv`
 8. `e2e/testutil/artifacts.go` — Automatic artifact capture via `t.Cleanup`: `CaptureArtifacts` saves git-log, git-tree, checkpoint metadata, entire logs, and tmux pane content
 
 ### Step 2: Read Existing E2E Test Scenarios
@@ -30,7 +30,7 @@ Run `Glob("e2e/tests/*_test.go")` to find all existing test files. Read a few to
 - How tests use `testutil.ForEachAgent` with a timeout and callback `func(t, s, ctx)`
 - How prompts are written inline (no separate prompt template file)
 - How `s.RunPrompt`, `s.Git`, `s.StartSession`, `s.WaitFor`, `s.Send` are used
-- How assertions validate checkpoints, rewind, metadata, etc.
+- How assertions validate checkpoints, resume, metadata, etc.
 
 ### Step 3: Read Checkpoint Scenarios Doc
 
@@ -192,7 +192,7 @@ Use `/commit` to commit all files.
 - **Repo setup**: `ForEachAgent` calls `SetupRepo` automatically — do not call it manually
 - **Prompts**: Write prompts inline in the test. Include "Do not ask for confirmation" to prevent agent stalling
 - **Assertions**: Use helpers from `e2e/testutil/assertions.go` — see `AssertFileExists`, `WaitForCheckpoint`, `AssertCommitLinkedToCheckpoint`, `ValidateCheckpointDeep`, etc.
-- **CLI operations**: Use the `e2e/entire` package (`entire.Enable`, `entire.RewindList`, `entire.Rewind`, etc.) — never call the binary via raw `exec.Command`
+- **CLI operations**: Use the `e2e/entire` package (`entire.Enable`, `entire.Explain`, `entire.Resume`, etc.) — never call the binary via raw `exec.Command`
 - **No hardcoded paths**: Use `s.Dir` for repo paths, `s.ArtifactDir` for artifacts
 - **Console logging**: All operations through `s.RunPrompt`, `s.Git`, `s.Send`, `s.WaitFor` are automatically logged to `console.log`
 - **Transient errors**: `s.RunPrompt` auto-retries once on transient API errors via `IsTransientError`

--- a/.claude/skills/test-repo/README.md
+++ b/.claude/skills/test-repo/README.md
@@ -61,5 +61,5 @@ This runs the full test suite and is the recommended approach for validation.
 The test harness is most useful for:
 - Debugging specific strategy behaviors
 - Manual verification of edge cases
-- Interactive exploration of the checkpoint/rewind workflow
+- Interactive exploration of the checkpoint workflow
 - Understanding how the system works step-by-step

--- a/.claude/skills/test-repo/SKILL.md
+++ b/.claude/skills/test-repo/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: test-repo
-description: Use this skill to test strategy changes against a fresh test repository. Invoke when the user asks to "test against a test repo", "validate the changes", or wants to verify session hooks, commits, and rewind functionality work correctly.
+description: Use this skill to test strategy changes against a fresh test repository. Invoke when the user asks to "test against a test repo", "validate the changes", or wants to verify session hooks, commits, and checkpoint creation work correctly.
 ---
 
 # Test Repository Skill
 
-This skill validates the CLI's session management and rewind functionality by running an end-to-end test against a fresh temporary repository.
+This skill validates the CLI's session management and checkpoint creation by running an end-to-end test against a fresh temporary repository.
 
 ## When to Use
 
 - User asks to "test against a test repo"
 - User wants to validate strategy changes (manual-commit)
-- User asks to verify session hooks, commits, or rewind functionality
+- User asks to verify session hooks, commits, or checkpoint creation
 - After making changes to strategy code
 
 ## Testing Approaches
@@ -25,7 +25,7 @@ Run the comprehensive integration test suite. Best for verifying correctness aft
 **Manual Testing (this skill):**
 Use the test harness for:
 - Debugging specific strategy behaviors
-- Interactive exploration of checkpoint/rewind workflow
+- Interactive exploration of the checkpoint workflow
 - Manual verification of edge cases
 - Understanding how the system works step-by-step
 
@@ -97,23 +97,17 @@ Expected results:
 | Metadata branch | ✓ entire/checkpoints/v1 |
 | Rewind points | ✓ At least 1 |
 
-#### 4. Test Rewind
+#### 4. Check Listing After Further Changes
 
 ```bash
 .claude/skills/test-repo/test-harness.sh create-changes
-.claude/skills/test-repo/test-harness.sh list-rewind-points  # Get checkpoint ID from output
-.claude/skills/test-repo/test-harness.sh rewind <checkpoint-id>
-.claude/skills/test-repo/test-harness.sh verify-rewind
+.claude/skills/test-repo/test-harness.sh list-rewind-points
 ```
 
 **Expected Behavior:**
-- Shows warning listing untracked files that will be deleted (files created after the checkpoint that weren't present at session start)
-
-Example warning output (manual-commit):
-```
-Warning: The following untracked files will be DELETED:
-  - extra.js
-```
+- The checkpoint from step 2 is still listed; the new uncommitted changes do not
+  disturb it. There is no restore step: the CLI has no `rewind` command, and
+  nothing writes a checkpoint back over the worktree.
 
 #### 5. Cleanup
 
@@ -147,9 +141,6 @@ go build -o /tmp/entire-bin ./cmd/entire && \
 - Active branch commits: **NO modifications** (no commits created by Entire)
 - Shadow branches: `entire/<commit-hash[:7]>` created for checkpoints
 - Metadata: stored on both shadow branches and `entire/checkpoints/v1` branch (condensed on user commits)
-- Rewind: restores files from shadow branch commit tree (no git reset)
-  - **Shows preview warning** listing untracked files that will be deleted
-  - Preserves untracked files that existed at session start
 - AllowsMainBranch: **true** (safe on main/master)
 
 ## Additional Testing (Optional)
@@ -222,7 +213,6 @@ After running the test, report:
 | Clean commits | PASS/FAIL |
 | Metadata branch | PASS/FAIL |
 | Rewind points | PASS/FAIL |
-| Rewind restore | PASS/FAIL |
 
 **Overall: PASS/FAIL**
 

--- a/.claude/skills/test-repo/test-harness.sh
+++ b/.claude/skills/test-repo/test-harness.sh
@@ -155,7 +155,7 @@ list-rewind-points)
   ;;
 
 create-changes)
-  echo "==> Creating additional changes for rewind test..."
+  echo "==> Creating post-checkpoint changes..."
   cd "$REPO_DIR"
 
   echo "// More changes" >>app.js
@@ -163,37 +163,6 @@ create-changes)
 
   echo "Modified: app.js"
   echo "Created: extra.js"
-  ;;
-
-rewind)
-  checkpoint_id="${1:-}"
-  if [ -z "$checkpoint_id" ]; then
-    echo "Usage: $0 rewind <checkpoint-id>"
-    exit 1
-  fi
-
-  echo "==> Rewinding to checkpoint: $checkpoint_id"
-  cd "$REPO_DIR"
-
-  git stash
-  "$BIN_PATH" rewind --to "$checkpoint_id"
-
-  echo "Rewound to: $checkpoint_id"
-  ;;
-
-verify-rewind)
-  echo "==> Verifying rewind..."
-  cd "$REPO_DIR"
-
-  echo "Contents of app.js:"
-  cat app.js
-
-  if [ -f extra.js ]; then
-    echo "✗ FAIL: extra.js should not exist after rewind"
-    exit 1
-  else
-    echo "✓ PASS: extra.js correctly removed"
-  fi
   ;;
 
 cleanup)
@@ -226,9 +195,7 @@ info)
   echo "  verify-shadow-branch   - Verify shadow branch exists"
   echo "  verify-metadata-branch - Verify metadata branch exists"
   echo "  list-rewind-points     - List available rewind points"
-  echo "  create-changes         - Create changes for rewind test"
-  echo "  rewind <id>            - Rewind to checkpoint ID"
-  echo "  verify-rewind          - Verify rewind worked"
+  echo "  create-changes         - Create changes on top of the checkpoint"
   echo "  cleanup                - Clean up test environment"
   echo "  info                   - Show environment info"
   echo ""

--- a/cmd/entire/cli/agent/copilotcli/AGENT.md
+++ b/cmd/entire/cli/agent/copilotcli/AGENT.md
@@ -195,7 +195,7 @@ for the implementation.
 
 ## Protected Directories
 
-- `.github` — contains hook configs (committed to repo, unlikely to be affected by rewind)
+- `.github` — contains hook configs (committed to repo, so not something Entire would record as a session's own change)
 - No agent-specific repo directory to protect
 
 ## Subagent Lifecycle

--- a/cmd/entire/cli/agent/copilotcli/AGENT.md
+++ b/cmd/entire/cli/agent/copilotcli/AGENT.md
@@ -195,7 +195,7 @@ for the implementation.
 
 ## Protected Directories
 
-- `.github` — contains hook configs (committed to repo, so not something Entire would record as a session's own change)
+- `.github/hooks` — the hook config directory; listed in `ProtectedDirs()`, so Entire filters it out of change tracking and checkpoints
 - No agent-specific repo directory to protect
 
 ## Subagent Lifecycle

--- a/docs/architecture/agent-guide.md
+++ b/docs/architecture/agent-guide.md
@@ -24,7 +24,7 @@ Every agent must implement all 19 methods on the `Agent` interface:
 | | `Type()` | Display name for metadata (e.g., `"Claude Code"`) |
 | | `Description()` | Human-readable description for UI |
 | | `DetectPresence()` | Check if agent is configured in the repo |
-| | `ProtectedDirs()` | Directories to preserve during rewind |
+| | `ProtectedDirs()` | The agent's own dirs, excluded from tracked changes and checkpoints |
 | **Event Mapping** | `HookNames()` | Hook verbs that become CLI subcommands |
 | | `ParseHookEvent()` | **Core contribution surface** - translate native hooks to Events |
 | **Transcript** | `ReadTranscript()` | Read raw transcript bytes |

--- a/docs/architecture/agent-integration-checklist.md
+++ b/docs/architecture/agent-integration-checklist.md
@@ -8,7 +8,7 @@ For step-by-step implementation instructions, code templates, and testing patter
 
 Entire stores the **complete session transcript** at every checkpoint, not incremental diffs. This enables:
 
-- Simple rewind: restore the full transcript, agent resumes from that state
+- Simple resume: `RestoreLogsOnly` writes the full transcript back to the agent's session directory, and the agent resumes from that state
 - No dependency on previous checkpoints being intact
 - Consistent behavior across all checkpoint types (committed, uncommitted)
 
@@ -16,7 +16,7 @@ Entire stores the **complete session transcript** at every checkpoint, not incre
 
 ## Core Principle: Native Format Preservation
 
-Store transcripts in the **agent's native format**. Any transformation or normalization should only be done to support CLI features (rewind, resume, summarization, file extraction), not for backend or web UI consumption.
+Store transcripts in the **agent's native format**. Any transformation or normalization should only be done to support CLI features (resume, summarization, file extraction), not for backend or web UI consumption.
 
 **Why:**
 - The backend/web UI should handle format differences, not the CLI
@@ -102,9 +102,8 @@ See Guide: [Step 6 - InstallHooks](agent-guide.md)
       `testutil.AssertCommittedDogfoodFile` / `AssertCommittedDogfoodConfigStable`
       if this repo commits the agent's config for its own dogfooding.
 
-### Rewind/Resume Support
+### Resume Support
 
-- [ ] **Rewind restores full state**: After rewind, agent can continue from that point with full context
 - [ ] **Resume command**: `FormatResumeCommand()` returns the CLI command to resume a session
 - [ ] **Session ID preservation**: Restored sessions maintain original session ID where possible
 
@@ -114,6 +113,6 @@ See Guide: [Testing Patterns](agent-guide.md#testing-patterns)
 
 - [ ] **New session**: Create session, multiple turns, verify full transcript at each checkpoint
 - [ ] **Resumed session**: Resume existing session, add turns, verify checkpoint includes historical messages
-- [ ] **Rewind**: Rewind to earlier checkpoint, verify agent can continue from that state
+- [ ] **Restored session**: Restore logs from an earlier checkpoint, verify the agent can continue from that state
 - [ ] **Agent shutdown**: Verify graceful handling if agent exits during checkpoint
 - [ ] **Manual token validation for session-wide aggregate agents**: If an agent emits authoritative token totals only at session end (for example Copilot CLI `session.shutdown`), manually verify checkpoint-scoped metadata and full-session status separately. See [Copilot Token Validation](copilot-token-validation.md).

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -510,7 +510,7 @@ Metadata only, sharded by checkpoint ID. Supports **multiple sessions per checkp
 ├── metadata.json        # CheckpointSummary (aggregated stats)
 ├── 0/                   # First session (0-based indexing)
 │   ├── metadata.json    # Session-specific Metadata
-│   ├── full.jsonl       # Agent transcript, sanitized + redacted (CLI rewind/resume/explain)
+│   ├── full.jsonl       # Agent transcript, sanitized + redacted (CLI resume/explain)
 │   ├── transcript.jsonl # Full compacted session (slice at compact_transcript_start)
 │   ├── prompt.txt       # Checkpoint-scoped user prompts
 │   └── content_hash.txt # sha256 of full.jsonl (dedup short-circuit)
@@ -548,7 +548,7 @@ root `metadata.json` `sessions[].transcript` pointer keeps targeting
 `full.jsonl`; when a compact transcript was generated the session entry also
 carries a `compact_transcript` path pointing at `transcript.jsonl` (omitted
 otherwise) so external readers can find it next to `full.jsonl`.
-CLI read paths (rewind/resume/explain) read `full.jsonl` by filename. Compact
+CLI read paths (resume/explain) read `full.jsonl` by filename. Compact
 generation is best-effort: failures are logged but never fail the checkpoint
 write. It is also **skipped when the compacted output exceeds the 50MB blob cap**
 — unlike `full.jsonl`, `transcript.jsonl` is not chunked, so a very long session


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/1187

purge stale references to the removed `entire rewind` command and the removed restore capability from docs and skills. Covers both pointers from the #2178 approval plus a full grep sweep. Docs and one shell script only — no Go changes.

**test-repo skill** — drop the broken `rewind`/`verify-rewind` harness verbs (they shelled out to `entire rewind --to`, removed in #1747) plus the SKILL.md/README steps that walked through them. `list-rewind-points` stays: `checkpoint list --pending` is live.

**Agent docs** — `agent-integration-checklist.md`: "Rewind/Resume Support" → "Resume Support", rewind items removed or reworded to resume (`RestoreLogsOnly`). `agent-guide.md` and `copilotcli/AGENT.md`: `ProtectedDirs()` now described by what its live call sites do (agent dirs excluded from tracked changes and checkpoints), not "preserve during rewind". `sessions-and-checkpoints.md`: `full.jsonl`'s reader list is now "resume/explain" (deferred from #2178).

**Also fixed, found by the sweep** — `.claude/skills/agent-integration/test-writer.md` recommended `e2e/entire` helpers that don't exist (`RewindList`, `Rewind`, `RewindLogsOnly`, plus `ExplainGenerate`/`ExplainCommit`), and `implementer.md`'s Tier 6 listed nonexistent `TestRewind*` E2E tests; both now point at real helpers and real resume tests.

**Deliberately left**: CHANGELOG entries (history), "rewind point" list/resume vocabulary (`list-rewind-points`, `scripts/test-attribution-e2e.sh`), Copilot CLI's own `rewind-snapshots/` directory, and `claude-hooks-integration.md:192` ("rewind linking" — the UUID linking is live, unclear if the phrase means the removed restore). Out of scope, Go doc comments noted only: `agent.go:42` still says "during rewind"; `DeleteBranchCLI` cites the nonexistent `HardResetWithProtection`.

Verified: `bash -n` on the edited harness; `mise run fmt && mise run lint` — 0 issues (shellcheck covers the script). No Go edits, so no `test:ci` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a manual test harness script only; no runtime or CLI behavior changes.
> 
> **Overview**
> Follow-up to removing file-restoring **rewind** from the CLI: this PR **realigns docs and skills** with **resume** and **checkpoint listing**, without Go changes.
> 
> **Test-repo skill:** `test-harness.sh` drops broken `rewind` / `verify-rewind` (they called removed `entire rewind --to`) and the associated `git stash`. **`list-rewind-points`** and **`create-changes`** stay; `SKILL.md` replaces the rewind restore step with a check that pending checkpoints still list after extra worktree edits, and trims manual-commit rewind-restore expectations from the report template.
> 
> **Architecture & agent docs:** Wording shifts from rewind to **resume** (`RestoreLogsOnly`, transcript CLI readers) and reframes **`ProtectedDirs()`** as agent dirs excluded from tracked changes—not “preserve during rewind.” The integration checklist drops rewind-specific requirements and renames testing to **restored session** behavior.
> 
> **Agent-integration skills:** Tier 6 is **Interactive and Resume** with real E2E tests (`TestResumeFromFeatureBranch`, etc.) instead of nonexistent `TestRewind*`. **`test-writer.md`** documents the actual `e2e/entire` helpers (`Resume`, `Explain`, `Doctor`, …) instead of removed `Rewind*` / bogus explain variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5894f050d92e94d0cdb8969276c8efbb158db8df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
