### PR TITLE
Rename the rewind-point vocabulary to pending checkpoints

### DIFF
--- a/.claude/skills/test-repo/SKILL.md
+++ b/.claude/skills/test-repo/SKILL.md
@@ -84,7 +84,7 @@ Execute these steps in order:
 .claude/skills/test-repo/test-harness.sh verify-session-state
 .claude/skills/test-repo/test-harness.sh verify-shadow-branch
 .claude/skills/test-repo/test-harness.sh verify-metadata-branch
-.claude/skills/test-repo/test-harness.sh list-rewind-points
+.claude/skills/test-repo/test-harness.sh list-pending-checkpoints
 ```
 
 Expected results:
@@ -95,13 +95,13 @@ Expected results:
 | Session state | ✓ Exists |
 | Shadow branch | ✓ entire/{hash} |
 | Metadata branch | ✓ entire/checkpoints/v1 |
-| Rewind points | ✓ At least 1 |
+| Pending checkpoints | ✓ At least 1 |
 
 #### 4. Check Listing After Further Changes
 
 ```bash
 .claude/skills/test-repo/test-harness.sh create-changes
-.claude/skills/test-repo/test-harness.sh list-rewind-points
+.claude/skills/test-repo/test-harness.sh list-pending-checkpoints
 ```
 
 **Expected Behavior:**
@@ -132,7 +132,7 @@ go build -o /tmp/entire-bin ./cmd/entire && \
 .claude/skills/test-repo/test-harness.sh create-transcript && \
 .claude/skills/test-repo/test-harness.sh stop-session && \
 .claude/skills/test-repo/test-harness.sh verify-metadata-branch && \
-.claude/skills/test-repo/test-harness.sh list-rewind-points
+.claude/skills/test-repo/test-harness.sh list-pending-checkpoints
 ```
 
 ## Expected Results by Strategy
@@ -212,7 +212,7 @@ After running the test, report:
 | Session hooks | PASS/FAIL |
 | Clean commits | PASS/FAIL |
 | Metadata branch | PASS/FAIL |
-| Rewind points | PASS/FAIL |
+| Pending checkpoints | PASS/FAIL |
 
 **Overall: PASS/FAIL**
 

--- a/.claude/skills/test-repo/test-harness.sh
+++ b/.claude/skills/test-repo/test-harness.sh
@@ -147,8 +147,8 @@ verify-metadata-branch)
   fi
   ;;
 
-list-rewind-points)
-  echo "==> Listing rewind points..."
+list-pending-checkpoints)
+  echo "==> Listing pending checkpoints..."
   cd "$REPO_DIR"
 
   "$BIN_PATH" checkpoint list --pending --json
@@ -184,20 +184,20 @@ info)
   echo "Unknown step: $step"
   echo ""
   echo "Available steps:"
-  echo "  setup-repo             - Create test repository"
-  echo "  configure-strategy     - Configure Entire with strategy"
-  echo "  start-session          - Start Claude session"
-  echo "  create-files           - Create test files"
-  echo "  create-transcript      - Create session transcript"
-  echo "  stop-session           - Stop session (create checkpoint)"
-  echo "  verify-commit          - Verify active branch commit"
-  echo "  verify-session-state   - Verify session state files"
-  echo "  verify-shadow-branch   - Verify shadow branch exists"
-  echo "  verify-metadata-branch - Verify metadata branch exists"
-  echo "  list-rewind-points     - List available rewind points"
-  echo "  create-changes         - Create changes on top of the checkpoint"
-  echo "  cleanup                - Clean up test environment"
-  echo "  info                   - Show environment info"
+  echo "  setup-repo               - Create test repository"
+  echo "  configure-strategy       - Configure Entire with strategy"
+  echo "  start-session            - Start Claude session"
+  echo "  create-files             - Create test files"
+  echo "  create-transcript        - Create session transcript"
+  echo "  stop-session             - Stop session (create checkpoint)"
+  echo "  verify-commit            - Verify active branch commit"
+  echo "  verify-session-state     - Verify session state files"
+  echo "  verify-shadow-branch     - Verify shadow branch exists"
+  echo "  verify-metadata-branch   - Verify metadata branch exists"
+  echo "  list-pending-checkpoints - List pending (not yet condensed) checkpoints"
+  echo "  create-changes           - Create changes on top of the checkpoint"
+  echo "  cleanup                  - Clean up test environment"
+  echo "  info                     - Show environment info"
   echo ""
   echo "Prerequisites:"
   echo "  Build the CLI first: go build -o /tmp/entire-bin ./cmd/entire"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -997,7 +997,7 @@ The CLI uses a manual-commit strategy for managing session data and checkpoints.
 
 - `SaveStep()` - Save session step checkpoint (code + metadata)
 - `SaveTaskStep()` - Save subagent task step checkpoint
-- `GetRewindPoints()` - List checkpoints (see the note below: there is no restore path)
+- `ListPendingCheckpoints()` - List pending checkpoints (see the note below: there is no restore path)
 - `GetSessionLog()` / `GetSessionInfo()` - Retrieve session data
 
 **There is no restore path.** `Rewind()`, `PreviewRewind()`, `CanRewind()` and
@@ -1006,13 +1006,14 @@ tests still called them. Nothing in the strategy writes checkpoint contents back
 over the worktree, and re-adding that is a product decision, not a refactor.
 
 What survives is everything that reads a checkpoint without touching working
-files. `GetRewindPoints()` / `GetLogsOnlyRewindPoints()` feed
+files. `ListPendingCheckpoints()` / `ListLogsOnlyPendingCheckpoints()` feed
 `checkpoint list --pending`. `RestoreLogsOnly()` writes a checkpoint's session
 logs into the agent's session directory — logs only, never worktree files — and
-feeds `entire resume` and `entire trail resume`. The `RewindPoint`,
-`RestoredSession` and `SessionRestoreStatus` types keep the "rewind point"
-vocabulary; it names a point you can list and resume from, not one the CLI can
-restore files to.
+feeds `entire resume` and `entire trail resume`. The type they return is
+`PendingCheckpoint`: a checkpoint not yet condensed onto
+`entire/checkpoints/v1`, which you can list and resume from but cannot restore
+files from. The `--pending` flag, the command paths, and the `--json` shape are
+unchanged by that rename.
 
 #### How It Works
 
@@ -1049,9 +1050,9 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
 
 #### Key Files
 
-- `strategy.go` - Shared types only, no behaviour: the sentinel errors (`ErrNoMetadata`, `ErrNoSession`, `ErrNotTaskCheckpoint`, `ErrEmptyRepository`), the argument and result structs (`SessionInfo`, `RewindPoint`, `StepContext`, `TaskStepContext`, `TaskCheckpoint`, `SubagentCheckpoint`, `RestoredSession`), and `TaskMetadataDir()`. The strategy type itself and its constructor live in `manual_commit.go`.
+- `strategy.go` - Shared types only, no behaviour: the sentinel errors (`ErrNoMetadata`, `ErrNoSession`, `ErrNotTaskCheckpoint`, `ErrEmptyRepository`), the argument and result structs (`SessionInfo`, `PendingCheckpoint`, `StepContext`, `TaskStepContext`, `TaskCheckpoint`, `SubagentCheckpoint`, `RestoredSession`), and `TaskMetadataDir()`. The strategy type itself and its constructor live in `manual_commit.go`.
 - `common.go` - Helpers for metadata extraction, tree building, `ListCheckpoints()`
-- `manual_commit*.go` - Manual-commit strategy: main impl, types, session state, condensation, checkpoint listing + log restore (`manual_commit_rewind.go`), git ops, logs, hook handlers (prepare-commit-msg, post-commit, post-rewrite, pre-push), reset
+- `manual_commit*.go` - Manual-commit strategy: main impl, types, session state, condensation, pending-checkpoint listing + log restore (`manual_commit_pending.go`), git ops, logs, hook handlers (prepare-commit-msg, post-commit, post-rewrite, pre-push), reset
 - `manual_commit_opf_rewrite.go` - Pre-push OPF re-redaction: walks unpushed v1 commits, runs OPF over their blobs, rebuilds commits with `Entire-OPF-Applied: true` trailer, CAS-updates the local ref. Sentinel error types (use `errors.As`): `V1DivergedError`, `BootstrapTooLargeError`, `V1RefMovedError`, `OPFRuntimeFailedError`, `OPFBatchTooLargeError`, `OPFRawBytesTooLargeError`, `OPFNoCategoriesError` (OPF enabled with zero effective categories — the pre-push decision and the rewrite both fail closed instead of stamping the trailer without a scan).
 - `manual_commit_opf_refs.go` - The git-refs half of pre-push OPF: `RewriteQueuedCheckpointRefsWithOPF` walks the push queue and rewrites every unpushed commit on each queued ref, reusing the v1 rewrite's blob walk, caps, and error types. See the OPF bullet above for why the two backends fail closed differently.
 - `settings/opf_command_trust.go` - Ownership gate for the executed OPF `command` (local-only + untracked); see the OPF trust-boundary bullet above

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1010,10 +1010,14 @@ files. `ListPendingCheckpoints()` / `ListLogsOnlyPendingCheckpoints()` feed
 `checkpoint list --pending`. `RestoreLogsOnly()` writes a checkpoint's session
 logs into the agent's session directory — logs only, never worktree files — and
 feeds `entire resume` and `entire trail resume`. The type they return is
-`PendingCheckpoint`: a checkpoint not yet condensed onto
-`entire/checkpoints/v1`, which you can list and resume from but cannot restore
-files from. The `--pending` flag, the command paths, and the `--json` shape are
-unchanged by that rename.
+`PendingCheckpoint`, and it covers both shapes that listing contains: a live
+checkpoint on the session's shadow branch, not yet condensed onto
+`entire/checkpoints/v1`, **or** a logs-only resume point — a commit on the
+current branch whose logs *are* already condensed there, listed so the
+transcript can be restored. "Pending" names the listing, not a promise that the
+work is un-condensed. Either way you can list it and resume from it, but the
+CLI cannot restore working files from it. The `--pending` flag, the command
+paths, and the `--json` shape are unchanged by that rename.
 
 #### How It Works
 

--- a/api/checkpoint/metadata.go
+++ b/api/checkpoint/metadata.go
@@ -513,7 +513,7 @@ func (m Metadata) GetCompactTranscriptStart() (offset int, ok bool) {
 type SessionFilePaths struct {
 	Metadata string `json:"metadata"`
 	// Transcript points at the raw full.jsonl, which CLI read paths
-	// (rewind/resume/explain) resolve by filename.
+	// (resume/explain) resolve by filename.
 	Transcript string `json:"transcript,omitempty"`
 	// CompactTranscript points at the compact transcript.jsonl when one was
 	// generated alongside full.jsonl. Omitted otherwise (non-compactable,

--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -39,8 +39,8 @@ type Agent interface {
 	// DetectPresence checks if this agent is configured in the repository
 	DetectPresence(ctx context.Context) (bool, error)
 
-	// ProtectedDirs returns repo-root-relative directories that should never be
-	// modified or deleted during rewind or other destructive operations.
+	// ProtectedDirs returns repo-root-relative directories that Entire must never
+	// record as session changes or capture into a checkpoint.
 	// Examples: [".claude"] for Claude, [".gemini"] for Gemini.
 	ProtectedDirs() []string
 
@@ -73,7 +73,7 @@ type Agent interface {
 	// it verbatim when absolute. Callers that source agentSessionID from
 	// untrusted data (e.g. checkpoint metadata on the shared
 	// entire/checkpoints/v1 branch, hook input) MUST validate it with
-	// validation.ValidateSessionID first. The resume/rewind restore paths do
+	// validation.ValidateSessionID first. The resume/log-restore paths do
 	// this at their choke points (transcript.resolveTranscriptPath and
 	// strategy.RestoreLogsOnly); do not call this with unvalidated input.
 	ResolveSessionFile(sessionDir, agentSessionID string) string

--- a/cmd/entire/cli/agent/registry.go
+++ b/cmd/entire/cli/agent/registry.go
@@ -186,7 +186,7 @@ const DefaultAgentName types.AgentName = AgentNameClaudeCode
 // This is acceptable because:
 //   - Agent count is small (~2-20 agents)
 //   - Agent factories are lightweight (empty struct allocation)
-//   - Called infrequently (commit hooks, rewind, debug commands - not hot paths)
+//   - Called infrequently (commit hooks, resume, debug commands - not hot paths)
 //   - Cost is ~400ns worst case vs milliseconds for I/O operations
 //
 // Only optimize if agent count exceeds 100 or profiling shows this as a bottleneck.

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -931,7 +931,7 @@ func TestExtractTranscriptMetadataForAgent_Pi(t *testing.T) {
 // review sessions (and any session where the agent injects an instruction
 // preamble) record the <environment_context> block as the first user message.
 // Attach must use the first genuine user prompt as the checkpoint title — the
-// same filter the rewind display path applies (strategy.FirstDisplayPrompt).
+// same filter the resume display path applies (strategy.FirstDisplayPrompt).
 func TestExtractTranscriptMetadataForAgent_CodexSkipsEnvironmentContext(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -38,7 +38,7 @@ type Type int
 
 const (
 	// Ephemeral checkpoints contain full state (code + metadata) and are stored
-	// on shadow branches (entire/<commit-hash>). Used for intra-session rewind.
+	// on shadow branches (entire/<commit-hash>). Holds pending intra-session state.
 	Ephemeral Type = iota
 
 	// Persistent checkpoints contain metadata + commit reference and are stored
@@ -204,7 +204,7 @@ type WriteEphemeralTaskOptions struct {
 	// SubagentTranscriptPath is the path to the subagent's transcript
 	SubagentTranscriptPath string
 
-	// CheckpointUUID is the UUID for transcript truncation when rewinding
+	// CheckpointUUID is the UUID marking where this checkpoint's transcript slice starts
 	CheckpointUUID string
 
 	// CommitMessage is the commit message (already formatted)
@@ -230,7 +230,7 @@ type WriteEphemeralTaskOptions struct {
 }
 
 // EphemeralCheckpointInfo contains information about a single commit on a shadow branch.
-// Used by ListCheckpoints to provide rewind point data.
+// Used by ListCheckpoints to provide pending checkpoint data.
 type EphemeralCheckpointInfo struct {
 	// CommitHash is the hash of the checkpoint commit
 	CommitHash plumbing.Hash

--- a/cmd/entire/cli/checkpoint/ephemeral.go
+++ b/cmd/entire/cli/checkpoint/ephemeral.go
@@ -494,7 +494,7 @@ func (s *ephemeralStore) addTaskMetadataToTree(ctx context.Context, baseTreeHash
 }
 
 // ListCheckpoints lists all checkpoint commits on a shadow branch.
-// This returns individual commits (rewind points), not just branch info.
+// This returns individual commits (pending checkpoints), not just branch info.
 // The sessionID filter, if provided, limits results to commits from that session.
 // worktreeID should be empty for main worktree or the internal git worktree name for linked worktrees.
 func (s *ephemeralStore) ListCheckpoints(ctx context.Context, baseCommit, worktreeID, sessionID string, limit int) ([]EphemeralCheckpointInfo, error) {
@@ -1211,7 +1211,7 @@ func filterGitIgnoredFiles(ctx context.Context, repo *git.Repository, files []st
 // This mirrors shouldIgnoreSessionTrackingPath in the cli package. The two
 // cannot share an implementation because cli imports checkpoint, so the logic
 // is duplicated deliberately. The first-checkpoint path (collectChangedFiles)
-// must apply the same exclusions as the session-tracking and rewind paths, or
+// must apply the same exclusions as the session-tracking and condensation paths, or
 // protected-dir content is captured into the shadow tree on session start
 // (see the DetectFileChanges / isProtectedPath call sites).
 func isProtectedCheckpointPath(relPath string) bool {

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -552,7 +552,7 @@ func (s *treeWriter) writeTaskRecordEntry(task TaskPayload, basePath string, ent
 //	├── metadata.json         # CheckpointSummary (aggregated stats)
 //	├── 1/                    # First session
 //	│   ├── metadata.json     # Metadata (session-specific, includes initial_attribution)
-//	│   ├── full.jsonl        # Raw agent transcript (CLI rewind/resume/explain)
+//	│   ├── full.jsonl        # Raw agent transcript (CLI resume/explain)
 //	│   ├── transcript.jsonl  # Compact transcript scoped to this checkpoint (pushed; not yet referenced by metadata.json)
 //	│   ├── prompt.txt
 //	│   └── content_hash.txt
@@ -665,7 +665,7 @@ func (s *treeWriter) writeSessionToSubdirectory(ctx context.Context, opts WriteO
 	}
 
 	// Write transcript. Transcript points at full.jsonl (CLI
-	// rewind/resume/explain read it by filename); the compact transcript.jsonl,
+	// resume/explain read it by filename); the compact transcript.jsonl,
 	// when written, is also pushed and pointed at by CompactTranscript.
 	wroteTranscript, compactTranscriptStart, err := s.writeTranscript(ctx, opts, sessionDir, entries)
 	if err != nil {

--- a/cmd/entire/cli/checkpoint_group.go
+++ b/cmd/entire/cli/checkpoint_group.go
@@ -66,7 +66,7 @@ func newCheckpointSearchCmd() *cobra.Command {
 //	                     replacement for the deprecated `rewind --list` bridge
 //
 // The condensed dataset (entire/checkpoints/v1 for the branch) and the pending
-// dataset (strategy.GetRewindPoints; task checkpoints, logs-only points,
+// dataset (strategy.ListPendingCheckpoints; task checkpoints, logs-only points,
 // condensation IDs) are deliberately distinct — see issue #1767.
 func newCheckpointListCmd() *cobra.Command {
 	var sessionFlag string

--- a/cmd/entire/cli/checkpoint_group.go
+++ b/cmd/entire/cli/checkpoint_group.go
@@ -61,8 +61,8 @@ func newCheckpointSearchCmd() *cobra.Command {
 //
 //	(default)            condensed checkpoints on the branch, human view (pager)
 //	--json               condensed checkpoints as JSON (branchCheckpointJSON shape)
-//	--pending            live shadow-branch pending checkpoints, human list
-//	--pending --json     live shadow-branch pending checkpoints as JSON — the drop-in
+//	--pending            pending checkpoints (live + logs-only), human list
+//	--pending --json     pending checkpoints as JSON — the drop-in
 //	                     replacement for the deprecated `rewind --list` bridge
 //
 // The condensed dataset (entire/checkpoints/v1 for the branch) and the pending
@@ -80,12 +80,14 @@ func newCheckpointListCmd() *cobra.Command {
 		Long: `List checkpoints on the current branch.
 
 By default shows condensed checkpoints from the checkpoints branch for the
-current branch. Use --pending to list the live session's shadow-branch pending
-checkpoints instead (task checkpoints, logs-only points, condensation IDs).
+current branch. Use --pending for the resume view instead: live checkpoints on
+the session's shadow branch (not yet condensed), plus logs-only resume points
+recovered from commits whose logs are already condensed.
 
 Output modes:
   --json             Machine-readable JSON instead of the human view.
-  --pending          Select the live shadow-branch pending-checkpoint dataset.
+  --pending          Select the pending dataset: live shadow-branch
+                     checkpoints plus logs-only resume points.
   --pending --json   Pending checkpoints as JSON (replaces the deprecated rewind --list).
 
 Optionally filter condensed checkpoints by session ID with --session
@@ -120,6 +122,6 @@ Optionally filter condensed checkpoints by session ID with --session
 	cmd.Flags().StringVar(&sessionFlag, "session", "", "Filter checkpoints by session ID (or prefix)")
 	cmd.Flags().BoolVar(&noPagerFlag, "no-pager", false, "Disable pager output")
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output as JSON instead of the human view")
-	cmd.Flags().BoolVar(&pendingFlag, "pending", false, "List the live session's shadow-branch pending checkpoints instead of condensed checkpoints")
+	cmd.Flags().BoolVar(&pendingFlag, "pending", false, "List pending checkpoints — live shadow-branch state plus logs-only resume points")
 	return cmd
 }

--- a/cmd/entire/cli/checkpoint_group.go
+++ b/cmd/entire/cli/checkpoint_group.go
@@ -55,14 +55,14 @@ func newCheckpointSearchCmd() *cobra.Command {
 }
 
 // newCheckpointListCmd wraps the existing branch-default list view and adds
-// machine-readable (--json) and pending-rewind-point (--pending) modes.
+// machine-readable (--json) and pending-checkpoint (--pending) modes.
 //
 // Dataset/format matrix:
 //
 //	(default)            condensed checkpoints on the branch, human view (pager)
 //	--json               condensed checkpoints as JSON (branchCheckpointJSON shape)
-//	--pending            live shadow-branch rewind points, human list
-//	--pending --json     live shadow-branch rewind points as JSON — the drop-in
+//	--pending            live shadow-branch pending checkpoints, human list
+//	--pending --json     live shadow-branch pending checkpoints as JSON — the drop-in
 //	                     replacement for the deprecated `rewind --list` bridge
 //
 // The condensed dataset (entire/checkpoints/v1 for the branch) and the pending
@@ -80,13 +80,13 @@ func newCheckpointListCmd() *cobra.Command {
 		Long: `List checkpoints on the current branch.
 
 By default shows condensed checkpoints from the checkpoints branch for the
-current branch. Use --pending to list the live session's shadow-branch rewind
-points instead (task checkpoints, logs-only points, condensation IDs).
+current branch. Use --pending to list the live session's shadow-branch pending
+checkpoints instead (task checkpoints, logs-only points, condensation IDs).
 
 Output modes:
   --json             Machine-readable JSON instead of the human view.
-  --pending          Select the live shadow-branch rewind-point dataset.
-  --pending --json   Rewind points as JSON (replaces the deprecated rewind --list).
+  --pending          Select the live shadow-branch pending-checkpoint dataset.
+  --pending --json   Pending checkpoints as JSON (replaces the deprecated rewind --list).
 
 Optionally filter condensed checkpoints by session ID with --session
 (not applicable with --pending).`,
@@ -120,6 +120,6 @@ Optionally filter condensed checkpoints by session ID with --session
 	cmd.Flags().StringVar(&sessionFlag, "session", "", "Filter checkpoints by session ID (or prefix)")
 	cmd.Flags().BoolVar(&noPagerFlag, "no-pager", false, "Disable pager output")
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output as JSON instead of the human view")
-	cmd.Flags().BoolVar(&pendingFlag, "pending", false, "List the live session's shadow-branch rewind points instead of condensed checkpoints")
+	cmd.Flags().BoolVar(&pendingFlag, "pending", false, "List the live session's shadow-branch pending checkpoints instead of condensed checkpoints")
 	return cmd
 }

--- a/cmd/entire/cli/checkpoint_list.go
+++ b/cmd/entire/cli/checkpoint_list.go
@@ -37,12 +37,12 @@ type pendingCheckpointJSON struct {
 	SessionPrompt    string `json:"session_prompt,omitempty"`
 }
 
-// pendingCheckpointsLimit caps how many live shadow-branch rewind points the
+// pendingCheckpointsLimit caps how many live shadow-branch pending checkpoints the
 // pending views request. Matches the historical `rewind --list` cap of 20 so
 // the migrated output is identical.
 const pendingCheckpointsLimit = 20
 
-// runCheckpointPendingListJSON emits the live shadow-branch rewind points as
+// runCheckpointPendingListJSON emits the live shadow-branch pending checkpoints as
 // JSON. This is the drop-in replacement for (and the implementation behind)
 // the deprecated `rewind --list` bridge: same dataset (strategy.ListPendingCheckpoints),
 // same cap, same JSON shape.
@@ -51,7 +51,7 @@ func runCheckpointPendingListJSON(ctx context.Context, w io.Writer) error {
 
 	points, err := start.ListPendingCheckpoints(ctx, pendingCheckpointsLimit)
 	if err != nil {
-		return fmt.Errorf("failed to find rewind points: %w", err)
+		return fmt.Errorf("failed to list pending checkpoints: %w", err)
 	}
 
 	output := make([]pendingCheckpointJSON, len(points))
@@ -78,7 +78,7 @@ func runCheckpointPendingListJSON(ctx context.Context, w io.Writer) error {
 	return nil
 }
 
-// runCheckpointPendingListHuman prints the live shadow-branch rewind points in
+// runCheckpointPendingListHuman prints the live shadow-branch pending checkpoints in
 // a human-readable list. `rewind --list` was JSON-only, so there is no legacy
 // human output to mirror; this renders each point with the same label format
 // the former interactive rewind picker used (see pendingCheckpointLabel).
@@ -87,12 +87,12 @@ func runCheckpointPendingListHuman(ctx context.Context, w io.Writer) error {
 
 	points, err := start.ListPendingCheckpoints(ctx, pendingCheckpointsLimit)
 	if err != nil {
-		return fmt.Errorf("failed to find rewind points: %w", err)
+		return fmt.Errorf("failed to list pending checkpoints: %w", err)
 	}
 
 	if len(points) == 0 {
-		fmt.Fprintln(w, "No pending rewind points found.")
-		fmt.Fprintln(w, "Pending rewind points are created automatically during active agent sessions.")
+		fmt.Fprintln(w, "No pending checkpoints found.")
+		fmt.Fprintln(w, "Pending checkpoints are created automatically during active agent sessions.")
 		return nil
 	}
 
@@ -115,7 +115,7 @@ func hasMultipleSessions(points []strategy.PendingCheckpoint) bool {
 	return len(sessionIDs) > 1
 }
 
-// pendingCheckpointLabel renders a single rewind point as a display label for the
+// pendingCheckpointLabel renders a single pending checkpoint as a display label for the
 // `checkpoint list --pending` human view. When hasMultipleSessions is true, a
 // sanitized session prompt is appended to help disambiguate concurrent
 // sessions.

--- a/cmd/entire/cli/checkpoint_list.go
+++ b/cmd/entire/cli/checkpoint_list.go
@@ -37,12 +37,12 @@ type pendingCheckpointJSON struct {
 	SessionPrompt    string `json:"session_prompt,omitempty"`
 }
 
-// pendingCheckpointsLimit caps how many live shadow-branch pending checkpoints the
+// pendingCheckpointsLimit caps how many pending checkpoints (both shapes) the
 // pending views request. Matches the historical `rewind --list` cap of 20 so
 // the migrated output is identical.
 const pendingCheckpointsLimit = 20
 
-// runCheckpointPendingListJSON emits the live shadow-branch pending checkpoints as
+// runCheckpointPendingListJSON emits the pending checkpoints as
 // JSON. This is the drop-in replacement for (and the implementation behind)
 // the deprecated `rewind --list` bridge: same dataset (strategy.ListPendingCheckpoints),
 // same cap, same JSON shape.
@@ -78,7 +78,7 @@ func runCheckpointPendingListJSON(ctx context.Context, w io.Writer) error {
 	return nil
 }
 
-// runCheckpointPendingListHuman prints the live shadow-branch pending checkpoints in
+// runCheckpointPendingListHuman prints the pending checkpoints in
 // a human-readable list. `rewind --list` was JSON-only, so there is no legacy
 // human output to mirror; this renders each point with the same label format
 // the former interactive rewind picker used (see pendingCheckpointLabel).

--- a/cmd/entire/cli/checkpoint_list.go
+++ b/cmd/entire/cli/checkpoint_list.go
@@ -12,7 +12,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 )
 
-// pendingRewindPointJSON is the machine-readable shape emitted by
+// pendingCheckpointJSON is the machine-readable shape emitted by
 // `entire checkpoint list --pending --json` (and the deprecated `rewind --list`
 // bridge). It is byte-for-byte the JSON that `rewind --list` historically
 // produced, so downstream consumers (integration and e2e test harnesses,
@@ -21,10 +21,10 @@ import (
 //
 // The field set, JSON names, omitempty markers, and the RFC3339 Date encoding
 // are load-bearing — this is a stable contract. CondensationID carries the
-// checkpoint ID (RewindPoint.CheckpointID) for logs-only points; it is empty
+// checkpoint ID (PendingCheckpoint.CheckpointID) for logs-only points; it is empty
 // for shadow-branch (uncommitted) points. Do not change these without
 // migrating every consumer.
-type pendingRewindPointJSON struct {
+type pendingCheckpointJSON struct {
 	ID               string `json:"id"`
 	Message          string `json:"message"`
 	MetadataDir      string `json:"metadata_dir"`
@@ -37,26 +37,26 @@ type pendingRewindPointJSON struct {
 	SessionPrompt    string `json:"session_prompt,omitempty"`
 }
 
-// pendingRewindPointsLimit caps how many live shadow-branch rewind points the
+// pendingCheckpointsLimit caps how many live shadow-branch rewind points the
 // pending views request. Matches the historical `rewind --list` cap of 20 so
 // the migrated output is identical.
-const pendingRewindPointsLimit = 20
+const pendingCheckpointsLimit = 20
 
 // runCheckpointPendingListJSON emits the live shadow-branch rewind points as
 // JSON. This is the drop-in replacement for (and the implementation behind)
-// the deprecated `rewind --list` bridge: same dataset (strategy.GetRewindPoints),
+// the deprecated `rewind --list` bridge: same dataset (strategy.ListPendingCheckpoints),
 // same cap, same JSON shape.
 func runCheckpointPendingListJSON(ctx context.Context, w io.Writer) error {
 	start := GetStrategy(ctx)
 
-	points, err := start.GetRewindPoints(ctx, pendingRewindPointsLimit)
+	points, err := start.ListPendingCheckpoints(ctx, pendingCheckpointsLimit)
 	if err != nil {
 		return fmt.Errorf("failed to find rewind points: %w", err)
 	}
 
-	output := make([]pendingRewindPointJSON, len(points))
+	output := make([]pendingCheckpointJSON, len(points))
 	for i, p := range points {
-		output[i] = pendingRewindPointJSON{
+		output[i] = pendingCheckpointJSON{
 			ID:               p.ID,
 			Message:          p.Message,
 			MetadataDir:      p.MetadataDir,
@@ -81,11 +81,11 @@ func runCheckpointPendingListJSON(ctx context.Context, w io.Writer) error {
 // runCheckpointPendingListHuman prints the live shadow-branch rewind points in
 // a human-readable list. `rewind --list` was JSON-only, so there is no legacy
 // human output to mirror; this renders each point with the same label format
-// the former interactive rewind picker used (see rewindPointLabel).
+// the former interactive rewind picker used (see pendingCheckpointLabel).
 func runCheckpointPendingListHuman(ctx context.Context, w io.Writer) error {
 	start := GetStrategy(ctx)
 
-	points, err := start.GetRewindPoints(ctx, pendingRewindPointsLimit)
+	points, err := start.ListPendingCheckpoints(ctx, pendingCheckpointsLimit)
 	if err != nil {
 		return fmt.Errorf("failed to find rewind points: %w", err)
 	}
@@ -98,14 +98,14 @@ func runCheckpointPendingListHuman(ctx context.Context, w io.Writer) error {
 
 	multi := hasMultipleSessions(points)
 	for _, p := range points {
-		fmt.Fprintln(w, rewindPointLabel(p, multi))
+		fmt.Fprintln(w, pendingCheckpointLabel(p, multi))
 	}
 	return nil
 }
 
 // hasMultipleSessions reports whether the points span more than one session,
 // which controls whether per-line session identifiers are shown.
-func hasMultipleSessions(points []strategy.RewindPoint) bool {
+func hasMultipleSessions(points []strategy.PendingCheckpoint) bool {
 	sessionIDs := make(map[string]bool)
 	for _, p := range points {
 		if p.SessionID != "" {
@@ -115,11 +115,11 @@ func hasMultipleSessions(points []strategy.RewindPoint) bool {
 	return len(sessionIDs) > 1
 }
 
-// rewindPointLabel renders a single rewind point as a display label for the
+// pendingCheckpointLabel renders a single rewind point as a display label for the
 // `checkpoint list --pending` human view. When hasMultipleSessions is true, a
 // sanitized session prompt is appended to help disambiguate concurrent
 // sessions.
-func rewindPointLabel(p strategy.RewindPoint, hasMultipleSessions bool) string {
+func pendingCheckpointLabel(p strategy.PendingCheckpoint, hasMultipleSessions bool) string {
 	timestamp := p.Date.Format("2006-01-02 15:04")
 
 	sessionLabel := ""

--- a/cmd/entire/cli/checkpoint_list_test.go
+++ b/cmd/entire/cli/checkpoint_list_test.go
@@ -91,7 +91,7 @@ func keysOf(m map[string]any) []string {
 }
 
 // TestRunCheckpointPendingList_EmptyReturnsEmptyArray verifies the pending JSON
-// view emits `[]` (not `null`) when there are no rewind points — the drop-in
+// view emits `[]` (not `null`) when there are no pending checkpoints — the drop-in
 // contract downstream JSON parsers rely on.
 func TestRunCheckpointPendingList_EmptyReturnsEmptyArray(t *testing.T) {
 	setupCheckpointListRepo(t)
@@ -107,13 +107,13 @@ func TestRunCheckpointPendingList_EmptyReturnsEmptyArray(t *testing.T) {
 }
 
 // TestRunCheckpointPendingListHuman_Empty pins the human-view message shown when
-// no pending rewind points exist.
+// no pending checkpoints exist.
 func TestRunCheckpointPendingListHuman_Empty(t *testing.T) {
 	setupCheckpointListRepo(t)
 
 	var stdout bytes.Buffer
 	require.NoError(t, runCheckpointPendingListHuman(context.Background(), &stdout))
-	require.Contains(t, stdout.String(), "No pending rewind points found.")
+	require.Contains(t, stdout.String(), "No pending checkpoints found.")
 }
 
 // TestCheckpointListCmd_Routing drives the real `checkpoint list` command
@@ -134,7 +134,7 @@ func TestCheckpointListCmd_Routing(t *testing.T) {
 
 	// --pending (human) → pending renderer, empty here.
 	pendingHuman := runListCmd(t, "--pending")
-	require.Contains(t, pendingHuman, "No pending rewind points found.",
+	require.Contains(t, pendingHuman, "No pending checkpoints found.",
 		"--pending (human) must route to the pending human renderer")
 
 	// --pending --json → pending JSON renderer, empty array (distinct from the

--- a/cmd/entire/cli/checkpoint_list_test.go
+++ b/cmd/entire/cli/checkpoint_list_test.go
@@ -19,19 +19,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPendingRewindPointJSON_MatchesRewindListContract pins the machine-readable
+// TestPendingCheckpointJSON_MatchesRewindListContract pins the machine-readable
 // shape emitted by `checkpoint list --pending --json`. It must stay byte-for-byte
 // compatible with the JSON `rewind --list` historically produced, so consumers that
 // parsed rewind --list keep working after repointing. Field names, omitempty
 // behavior, and the RFC3339 date encoding are the contract.
-func TestPendingRewindPointJSON_MatchesRewindListContract(t *testing.T) {
+func TestPendingCheckpointJSON_MatchesRewindListContract(t *testing.T) {
 	t.Parallel()
 
 	fixed := time.Date(2026, 7, 9, 12, 30, 0, 0, time.UTC)
 
 	// A logs-only (committed) point: has condensation_id, session_id,
 	// session_prompt; tool_use_id is empty and must be omitted.
-	logsOnly := pendingRewindPointJSON{
+	logsOnly := pendingCheckpointJSON{
 		ID:               "abc123def456",
 		Message:          "user commit",
 		MetadataDir:      ".entire/metadata/s1",
@@ -45,7 +45,7 @@ func TestPendingRewindPointJSON_MatchesRewindListContract(t *testing.T) {
 	// A task (shadow, uncommitted) point: has tool_use_id; condensation_id,
 	// session_id, session_prompt are empty and must be omitted. metadata_dir and
 	// the two bools have no omitempty and must always render.
-	task := pendingRewindPointJSON{
+	task := pendingCheckpointJSON{
 		ID:               "0f1e2d3c",
 		Message:          "task step",
 		MetadataDir:      "",
@@ -55,7 +55,7 @@ func TestPendingRewindPointJSON_MatchesRewindListContract(t *testing.T) {
 		IsLogsOnly:       false,
 	}
 
-	data, err := jsonutil.MarshalIndentWithNewline([]pendingRewindPointJSON{logsOnly, task}, "", "  ")
+	data, err := jsonutil.MarshalIndentWithNewline([]pendingCheckpointJSON{logsOnly, task}, "", "  ")
 	require.NoError(t, err)
 
 	var got []map[string]any
@@ -120,7 +120,7 @@ func TestRunCheckpointPendingListHuman_Empty(t *testing.T) {
 // end-to-end and asserts each flag combination routes to the right
 // dataset/renderer. The repo is seeded with a shadow checkpoint so the
 // condensed dataset is non-empty; the pending dataset stays empty because
-// GetRewindPoints requires active-session state (created by lifecycle hooks,
+// ListPendingCheckpoints requires active-session state (created by lifecycle hooks,
 // exercised by the integration canary), which a raw ephemeral-store seed does
 // not register — this also demonstrates the two datasets are distinct.
 func TestCheckpointListCmd_Routing(t *testing.T) {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -3180,7 +3180,7 @@ type commitEntry struct {
 	message string
 }
 
-// groupByCheckpointID groups rewind points by their checkpoint ID.
+// groupByCheckpointID groups pending checkpoints by their checkpoint ID.
 // Returns groups sorted by latest commit timestamp (most recent first).
 func groupByCheckpointID(points []strategy.PendingCheckpoint) []checkpointGroup {
 	if len(points) == 0 {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -2497,7 +2497,7 @@ func walkFirstParentCommits(ctx context.Context, repo *git.Repository, from plum
 // applied here, so callers cannot reconstruct it from the returned length
 // (the two budgets are independent, so the slice can hold up to 2*limit
 // entries without anything being dropped).
-func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) ([]strategy.RewindPoint, bool, error) {
+func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) ([]strategy.PendingCheckpoint, bool, error) {
 	// Warn (once per process) if metadata branches are disconnected
 	strategy.WarnIfMetadataDisconnected(ctx)
 
@@ -2543,7 +2543,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	if err != nil {
 		// Unborn HEAD (no commits yet) - return empty list instead of erroring
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {
-			return []strategy.RewindPoint{}, false, nil
+			return []strategy.PendingCheckpoint{}, false, nil
 		}
 		return nil, false, fmt.Errorf("failed to get HEAD: %w", err)
 	}
@@ -2551,7 +2551,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	// Check if we're on the default branch (needed for getReachableTemporaryCheckpoints)
 	isOnDefault, _ := strategy.IsOnDefaultBranch(repo)
 
-	var points []strategy.RewindPoint
+	var points []strategy.PendingCheckpoint
 
 	collectCheckpoint := func(c *object.Commit) {
 		cpID, found := trailers.ParseCheckpoint(c.Message)
@@ -2569,7 +2569,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 		// fills them before --session filters run.
 
 		message := strings.Split(c.Message, "\n")[0]
-		point := strategy.RewindPoint{
+		point := strategy.PendingCheckpoint{
 			ID:               c.Hash.String(),
 			Message:          message,
 			Date:             c.Committer.When,
@@ -2656,7 +2656,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	// Append imported (read-only, commit-less) checkpoints after the live points,
 	// bounded by the same limit so a one-month import doesn't produce an
 	// unbounded list. They get their own budget and never displace live points.
-	imported := getImportedRewindPoints(ctx, repo)
+	imported := getImportedPendingCheckpoints(ctx, repo)
 	sort.Slice(imported, func(i, j int) bool {
 		return imported[i].Date.After(imported[j].Date)
 	})
@@ -2670,7 +2670,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 }
 
 // hydrateListedBranchCheckpoints fills SessionID/etc for remote-discovered List
-// stubs among the already-truncated RewindPoints. The whole pass is capped by
+// stubs among the already-truncated PendingCheckpoints. The whole pass is capped by
 // ListHydrationPassTimeout, and each ref additionally gets ListHydrationTimeout
 // (much shorter than the default on-demand fetch). Failures clear ListedStub
 // (fail-once) inside HydrateListedCheckpointInfo; when any stub still lacks
@@ -2683,7 +2683,7 @@ func hydrateListedBranchCheckpoints(
 		Read(ctx context.Context, checkpointID id.CheckpointID) (*checkpoint.CheckpointSummary, error)
 		ReadSessionMetadata(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*checkpoint.Metadata, error)
 	},
-	points []strategy.RewindPoint,
+	points []strategy.PendingCheckpoint,
 	committedByID map[id.CheckpointID]checkpoint.CheckpointInfo,
 ) {
 	passCtx, passCancel := context.WithTimeout(ctx, checkpoint.ListHydrationPassTimeout)
@@ -2727,11 +2727,11 @@ func hydrateListedBranchCheckpoints(
 	}
 }
 
-// getImportedRewindPoints returns read-only imported checkpoints (Kind
-// "imported", flagged Imported) as RewindPoint entries. They live on the v1
+// getImportedPendingCheckpoints returns read-only imported checkpoints (Kind
+// "imported", flagged Imported) as PendingCheckpoint entries. They live on the v1
 // metadata branch but carry no commit trailer, so the commit-driven branch
 // walk never surfaces them. Best-effort: returns nil on read failure.
-func getImportedRewindPoints(ctx context.Context, repo *git.Repository) []strategy.RewindPoint {
+func getImportedPendingCheckpoints(ctx context.Context, repo *git.Repository) []strategy.PendingCheckpoint {
 	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{ReadRemotes: strategy.CheckpointReadRemotes(ctx)})
 	if err != nil {
 		return nil
@@ -2740,7 +2740,7 @@ func getImportedRewindPoints(ctx context.Context, repo *git.Repository) []strate
 	if err != nil {
 		return nil
 	}
-	points := make([]strategy.RewindPoint, 0)
+	points := make([]strategy.PendingCheckpoint, 0)
 	for _, info := range infos {
 		// Imported checkpoints live on v1 alongside normal ones but have no
 		// commit trailer, so the commit-driven walk above never surfaces them.
@@ -2748,7 +2748,7 @@ func getImportedRewindPoints(ctx context.Context, repo *git.Repository) []strate
 		if !info.Imported {
 			continue
 		}
-		point := strategy.RewindPoint{
+		point := strategy.PendingCheckpoint{
 			ID:           info.CheckpointID.String(),
 			Message:      readLatestCommittedSessionPrompt(ctx, stores.Persistent, info.CheckpointID, info.SessionCount),
 			Date:         info.CreatedAt,
@@ -2786,8 +2786,8 @@ func readLatestCommittedSessionPrompt(ctx context.Context, store checkpoint.Sess
 // whose base commit is reachable from the given HEAD hash and that belong to this worktree.
 // For default branches, all shadow branches for this worktree are included.
 // For feature branches, only shadow branches whose base commit is in HEAD's history are included.
-func getReachableTemporaryCheckpoints(ctx context.Context, repo *git.Repository, store checkpoint.EphemeralStore, headHash plumbing.Hash, isOnDefault bool, limit int) []strategy.RewindPoint {
-	var points []strategy.RewindPoint
+func getReachableTemporaryCheckpoints(ctx context.Context, repo *git.Repository, store checkpoint.EphemeralStore, headHash plumbing.Hash, isOnDefault bool, limit int) []strategy.PendingCheckpoint {
+	var points []strategy.PendingCheckpoint
 
 	// Compute current worktree's hash for filtering shadow branches
 	currentWorktreeHash := getCurrentWorktreeHash(ctx)
@@ -2842,14 +2842,14 @@ func isShadowBranchReachable(ctx context.Context, repo *git.Repository, baseComm
 	return found
 }
 
-// convertTemporaryCheckpoint converts a EphemeralCheckpointInfo to a RewindPoint.
+// convertTemporaryCheckpoint converts a EphemeralCheckpointInfo to a PendingCheckpoint.
 // Returns nil if the checkpoint should be skipped (no tree changes or can't be read).
 //
 // Filtering uses hasAnyChanges (O(1) tree hash comparison) rather than a full
 // O(files) diff. This means metadata-only checkpoints (.entire/ changes without
 // code changes) are kept — only true no-ops (identical tree as parent) are dropped.
 // This trade-off is intentional for list-view performance.
-func convertTemporaryCheckpoint(repo *git.Repository, tc checkpoint.EphemeralCheckpointInfo) *strategy.RewindPoint {
+func convertTemporaryCheckpoint(repo *git.Repository, tc checkpoint.EphemeralCheckpointInfo) *strategy.PendingCheckpoint {
 	shadowCommit, commitErr := repo.CommitObject(tc.CommitHash)
 	if commitErr != nil {
 		return nil
@@ -2870,7 +2870,7 @@ func convertTemporaryCheckpoint(repo *git.Repository, tc checkpoint.EphemeralChe
 		sessionPrompt = strategy.ReadSessionPromptFromTree(shadowTree, tc.MetadataDir)
 	}
 
-	return &strategy.RewindPoint{
+	return &strategy.PendingCheckpoint{
 		ID:               tc.CommitHash.String(),
 		Message:          tc.Message,
 		MetadataDir:      tc.MetadataDir,
@@ -3116,7 +3116,7 @@ const (
 // formatBranchCheckpoints formats checkpoint information for a branch.
 // Groups commits by checkpoint ID and shows the prompt for each checkpoint.
 // If sessionFilter is non-empty, only shows checkpoints matching that session ID (or prefix).
-func formatBranchCheckpoints(w io.Writer, branchName string, points []strategy.RewindPoint, sessionFilter string) string {
+func formatBranchCheckpoints(w io.Writer, branchName string, points []strategy.PendingCheckpoint, sessionFilter string) string {
 	var sb strings.Builder
 	styles := newStatusStyles(w)
 
@@ -3125,7 +3125,7 @@ func formatBranchCheckpoints(w io.Writer, branchName string, points []strategy.R
 	// matching only SessionID (latest contributor) silently drops multi-session
 	// checkpoints where the requested session was archived.
 	if sessionFilter != "" {
-		var filtered []strategy.RewindPoint
+		var filtered []strategy.PendingCheckpoint
 		for _, p := range points {
 			if checkpointMatchesSessionFilter(p, sessionFilter) {
 				filtered = append(filtered, p)
@@ -3182,7 +3182,7 @@ type commitEntry struct {
 
 // groupByCheckpointID groups rewind points by their checkpoint ID.
 // Returns groups sorted by latest commit timestamp (most recent first).
-func groupByCheckpointID(points []strategy.RewindPoint) []checkpointGroup {
+func groupByCheckpointID(points []strategy.PendingCheckpoint) []checkpointGroup {
 	if len(points) == 0 {
 		return nil
 	}

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -23,7 +23,7 @@ import (
 // Multi-session checkpoints expose archived contributors via SessionIDs;
 // matching only against SessionID (the latest contributor) silently drops
 // any checkpoint where the requested session was archived.
-func checkpointMatchesSessionFilter(p strategy.RewindPoint, sessionFilter string) bool {
+func checkpointMatchesSessionFilter(p strategy.PendingCheckpoint, sessionFilter string) bool {
 	if strings.HasPrefix(p.SessionID, sessionFilter) {
 		return true
 	}

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -768,17 +768,17 @@ func TestCheckpointExportJSON_PartialContract(t *testing.T) {
 func TestCheckpointMatchesSessionFilter(t *testing.T) {
 	t.Parallel()
 
-	multi := strategy.RewindPoint{
+	multi := strategy.PendingCheckpoint{
 		SessionID:  "9f44f514-b012", // latest
 		SessionIDs: []string{"older-session-aaaa", "9f44f514-b012"},
 	}
-	single := strategy.RewindPoint{
+	single := strategy.PendingCheckpoint{
 		SessionID: "lone-session-bbbb",
 	}
 
 	tests := []struct {
 		name   string
-		point  strategy.RewindPoint
+		point  strategy.PendingCheckpoint
 		filter string
 		want   bool
 	}{

--- a/cmd/entire/cli/explain_remote_discovery_test.go
+++ b/cmd/entire/cli/explain_remote_discovery_test.go
@@ -20,7 +20,7 @@ import (
 // TestGetBranchCheckpoints_HydratesRemoteDiscoveredStub is the trail-871 /
 // PR-1771 headline integration: device B has the trailer commit (pulled) but no
 // local checkpoint ref; with checkpoint_remote configured against a local bare
-// remote that advertises the ref, getBranchCheckpoints must return a RewindPoint
+// remote that advertises the ref, getBranchCheckpoints must return a PendingCheckpoint
 // with the real SessionID (not an empty stub that --session would drop).
 //
 // Offline: provider "local" is unknown to providerHost, so FetchURL falls back
@@ -108,5 +108,5 @@ func TestGetBranchCheckpoints_HydratesRemoteDiscoveredStub(t *testing.T) {
 			break
 		}
 	}
-	require.True(t, found, "RewindPoint for remote-discovered checkpoint %s missing; got %+v", cid, points)
+	require.True(t, found, "PendingCheckpoint for remote-discovered checkpoint %s missing; got %+v", cid, points)
 }

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -3369,7 +3369,7 @@ func TestBuildPagerCmd_HonorsCustomPager(t *testing.T) {
 
 func TestFormatBranchCheckpoints_BasicOutput(t *testing.T) {
 	now := time.Now()
-	points := []strategy.RewindPoint{
+	points := []strategy.PendingCheckpoint{
 		{
 			ID:            "abc123def456",
 			Message:       "Add feature X",
@@ -3414,7 +3414,7 @@ func TestFormatBranchCheckpoints_GroupedByCheckpointID(t *testing.T) {
 	today := time.Date(2026, 1, 22, 10, 0, 0, 0, time.UTC)
 	yesterday := time.Date(2026, 1, 21, 14, 0, 0, 0, time.UTC)
 
-	points := []strategy.RewindPoint{
+	points := []strategy.PendingCheckpoint{
 		{
 			ID:            "abc123def456",
 			Message:       "Today checkpoint 1",
@@ -3483,7 +3483,7 @@ func TestFormatBranchCheckpoints_NoCheckpoints(t *testing.T) {
 
 func TestFormatBranchCheckpoints_ShowsSessionInfo(t *testing.T) {
 	now := time.Now()
-	points := []strategy.RewindPoint{
+	points := []strategy.PendingCheckpoint{
 		{
 			ID:            "abc123def456",
 			Message:       "Test checkpoint",
@@ -3504,7 +3504,7 @@ func TestFormatBranchCheckpoints_ShowsSessionInfo(t *testing.T) {
 
 func TestFormatBranchCheckpoints_ShowsTemporaryIndicator(t *testing.T) {
 	now := time.Now()
-	points := []strategy.RewindPoint{
+	points := []strategy.PendingCheckpoint{
 		{
 			ID:           "abc123def456",
 			Message:      "Committed checkpoint",
@@ -3542,7 +3542,7 @@ func TestFormatBranchCheckpoints_ShowsTemporaryIndicator(t *testing.T) {
 
 func TestFormatBranchCheckpoints_ShowsTaskCheckpoints(t *testing.T) {
 	now := time.Now()
-	points := []strategy.RewindPoint{
+	points := []strategy.PendingCheckpoint{
 		{
 			ID:               "abc123def456",
 			Message:          "Running tests (toolu_01ABC)",
@@ -3608,7 +3608,7 @@ func TestFormatCheckpointGroup_FallsBackToCommitMessage(t *testing.T) {
 func TestFormatBranchCheckpoints_TruncatesLongMessages(t *testing.T) {
 	now := time.Now()
 	longMessage := strings.Repeat("a", 200) // 200 character message
-	points := []strategy.RewindPoint{
+	points := []strategy.PendingCheckpoint{
 		{
 			ID:           "abc123def456",
 			Message:      longMessage,
@@ -4279,7 +4279,7 @@ func TestRunExplainCommit_WithCheckpointTrailer(t *testing.T) {
 
 func TestFormatBranchCheckpoints_SessionFilter(t *testing.T) {
 	now := time.Now()
-	points := []strategy.RewindPoint{
+	points := []strategy.PendingCheckpoint{
 		{
 			ID:            "abc123def456",
 			Message:       "Checkpoint from session 1",
@@ -4370,7 +4370,7 @@ func TestFormatBranchCheckpoints_SessionFilter(t *testing.T) {
 	t.Run("filter matches archived SessionIDs contributor", func(t *testing.T) {
 		// Multi-session checkpoint: latest SessionID is beta, but alpha is still
 		// in SessionIDs. The shared matcher must keep it when filtering for alpha.
-		multi := []strategy.RewindPoint{
+		multi := []strategy.PendingCheckpoint{
 			{
 				ID:           "abc123def456",
 				Message:      "multi-session checkpoint",
@@ -4391,7 +4391,7 @@ func TestFormatBranchCheckpoints_SessionFilter(t *testing.T) {
 		// List stub has empty SessionID, so --session would drop it. Production
 		// collectCheckpoint hydrates before formatting; this asserts the filter
 		// itself does not invent a match for an empty SessionID.
-		stub := []strategy.RewindPoint{
+		stub := []strategy.PendingCheckpoint{
 			{
 				ID:           "abc123def456",
 				Message:      "remote-discovered stub",
@@ -5492,7 +5492,7 @@ func TestGetBranchCheckpoints_DefaultBranchFindsMergedCheckpoints(t *testing.T) 
 }
 
 func TestGetBranchCheckpoints_ReadsPromptFromCommittedCheckpoint(t *testing.T) {
-	// Verifies that getBranchCheckpoints populates RewindPoint.SessionPrompt
+	// Verifies that getBranchCheckpoints populates PendingCheckpoint.SessionPrompt
 	// from prompt.txt on entire/checkpoints/v1 (committed checkpoint) without
 	// needing to read/parse the full transcript.
 	tmpDir := t.TempDir()
@@ -5624,7 +5624,7 @@ func TestGetBranchCheckpoints_PopulatesCommittedSessionIDs(t *testing.T) {
 	points, _, err := getBranchCheckpoints(context.Background(), repo, 10)
 	require.NoError(t, err)
 
-	var found *strategy.RewindPoint
+	var found *strategy.PendingCheckpoint
 	for i := range points {
 		if points[i].CheckpointID == cpID {
 			found = &points[i]

--- a/cmd/entire/cli/gitrepo/status.go
+++ b/cmd/entire/cli/gitrepo/status.go
@@ -77,7 +77,8 @@ func SetStatusBudgetBreachedForTesting(breached bool) {
 // breach the walk goroutine is abandoned — it dies with the short-lived hook
 // process, which is the point — and the returned error wraps
 // ErrStatusBudgetExceeded so callers' warn-and-continue degrade paths apply.
-// Paths where a user is actively waiting on a command (review, rewind) keep
+// Paths where a user is actively waiting on a command (review via
+// review_target.go, and `session adopt` via detectFileChangesUnbounded) keep
 // calling Status directly.
 func StatusWithBudget(ctx context.Context, repo *git.Repository) (git.Status, error) {
 	worktree, err := repo.Worktree()

--- a/cmd/entire/cli/integration_test/submodule_worktree_test.go
+++ b/cmd/entire/cli/integration_test/submodule_worktree_test.go
@@ -21,7 +21,7 @@ import (
 //
 // It builds a real submodule, points the harness at the submodule worktree, and
 // drives the real hook binary end-to-end (user-prompt-submit, a file change, and
-// stop). It then asserts a rewind point exists — i.e. session init succeeded and
+// stop). It then asserts a pending checkpoint exists — i.e. session init succeeded and
 // a checkpoint was saved for work done inside the submodule.
 func TestSubmoduleWorktree_SessionCreatesCheckpoint(t *testing.T) {
 	t.Parallel()
@@ -108,11 +108,11 @@ func TestSubmoduleWorktree_SessionCreatesCheckpoint(t *testing.T) {
 		t.Fatalf("stop: %v", err)
 	}
 
-	// End-to-end proof via the real `checkpoint rewind --list`: a checkpoint was
+	// End-to-end proof via the real `checkpoint list --pending --json`: a checkpoint was
 	// created for the work done inside the submodule. Without the fix, session
-	// init failed on the submodule gitdir, so no checkpoint (and no rewind point)
+	// init failed on the submodule gitdir, so no checkpoint (and no pending checkpoint)
 	// exists.
 	if points := env.ListPendingCheckpoints(); len(points) == 0 {
-		t.Fatal("no rewind point after a session inside a submodule — session init failed on the submodule gitdir, so no checkpoint was created")
+		t.Fatal("no pending checkpoint after a session inside a submodule — session init failed on the submodule gitdir, so no checkpoint was created")
 	}
 }

--- a/cmd/entire/cli/integration_test/submodule_worktree_test.go
+++ b/cmd/entire/cli/integration_test/submodule_worktree_test.go
@@ -112,7 +112,7 @@ func TestSubmoduleWorktree_SessionCreatesCheckpoint(t *testing.T) {
 	// created for the work done inside the submodule. Without the fix, session
 	// init failed on the submodule gitdir, so no checkpoint (and no rewind point)
 	// exists.
-	if points := env.GetRewindPoints(); len(points) == 0 {
+	if points := env.ListPendingCheckpoints(); len(points) == 0 {
 		t.Fatal("no rewind point after a session inside a submodule — session init failed on the submodule gitdir, so no checkpoint was created")
 	}
 }

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -204,7 +204,7 @@ func NewRepoWithCommit(t *testing.T) *TestEnv {
 // NewFeatureBranchEnv creates a TestEnv ready for session testing.
 // It initializes the repo, creates an initial commit on main,
 // and checks out a feature branch. This is the most common setup
-// for session and rewind tests since Entire tracking skips main/master.
+// for session and checkpoint tests since Entire tracking skips main/master.
 func NewFeatureBranchEnv(t *testing.T) *TestEnv {
 	t.Helper()
 	env := NewRepoWithCommit(t)
@@ -718,7 +718,7 @@ type PendingCheckpoint struct {
 	CondensationID   string
 }
 
-// ListPendingCheckpoints returns available rewind points using the CLI.
+// ListPendingCheckpoints returns the session's pending checkpoints using the CLI.
 func (env *TestEnv) ListPendingCheckpoints() []PendingCheckpoint {
 	env.T.Helper()
 
@@ -749,14 +749,14 @@ func (env *TestEnv) ListPendingCheckpoints() []PendingCheckpoint {
 	}
 
 	if err := json.Unmarshal(output, &jsonPoints); err != nil {
-		env.T.Fatalf("failed to parse rewind points: %v\nOutput: %s", err, output)
+		env.T.Fatalf("failed to parse pending checkpoints: %v\nOutput: %s", err, output)
 	}
 
 	points := make([]PendingCheckpoint, len(jsonPoints))
 	for i, jp := range jsonPoints {
 		date, err := time.Parse(time.RFC3339, jp.Date)
 		if err != nil {
-			env.T.Fatalf("failed to parse rewind point date %q: %v", jp.Date, err)
+			env.T.Fatalf("failed to parse pending checkpoint date %q: %v", jp.Date, err)
 		}
 		points[i] = PendingCheckpoint{
 			ID:               jp.ID,

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -706,8 +706,8 @@ func (env *TestEnv) GetCurrentBranch() string {
 	return head.Name().Short()
 }
 
-// RewindPoint mirrors strategy.RewindPoint for test assertions.
-type RewindPoint struct {
+// PendingCheckpoint mirrors strategy.PendingCheckpoint for test assertions.
+type PendingCheckpoint struct {
 	ID               string
 	Message          string
 	MetadataDir      string
@@ -718,8 +718,8 @@ type RewindPoint struct {
 	CondensationID   string
 }
 
-// GetRewindPoints returns available rewind points using the CLI.
-func (env *TestEnv) GetRewindPoints() []RewindPoint {
+// ListPendingCheckpoints returns available rewind points using the CLI.
+func (env *TestEnv) ListPendingCheckpoints() []PendingCheckpoint {
 	env.T.Helper()
 
 	// Run `checkpoint list --pending --json` using the shared binary. This is
@@ -752,13 +752,13 @@ func (env *TestEnv) GetRewindPoints() []RewindPoint {
 		env.T.Fatalf("failed to parse rewind points: %v\nOutput: %s", err, output)
 	}
 
-	points := make([]RewindPoint, len(jsonPoints))
+	points := make([]PendingCheckpoint, len(jsonPoints))
 	for i, jp := range jsonPoints {
 		date, err := time.Parse(time.RFC3339, jp.Date)
 		if err != nil {
 			env.T.Fatalf("failed to parse rewind point date %q: %v", jp.Date, err)
 		}
-		points[i] = RewindPoint{
+		points[i] = PendingCheckpoint{
 			ID:               jp.ID,
 			Message:          jp.Message,
 			MetadataDir:      jp.MetadataDir,

--- a/cmd/entire/cli/integration_test/transcript.go
+++ b/cmd/entire/cli/integration_test/transcript.go
@@ -125,7 +125,7 @@ func (b *TranscriptBuilder) AddTaskToolUse(toolUseID, prompt string) string {
 }
 
 // AddTaskToolResult adds a tool result for a Task tool invocation.
-// The UUID of this message is used as the checkpoint UUID for rewind.
+// The UUID of this message is used as the checkpoint UUID.
 func (b *TranscriptBuilder) AddTaskToolResult(toolUseID, agentID string) string {
 	uuid := fmt.Sprintf("user-%d", len(b.messages)+1)
 

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -443,7 +443,7 @@ func entireTrailContextInjection(scope trailEnablementScope) string {
 	}
 	var b strings.Builder
 	b.WriteString("Entire is enabled for this repo. Run `entire agent-help` to see what entire does and which subcommand to use, then `entire agent-help <command>` for that command's exact, current flags. ")
-	b.WriteString("Commits automatically capture the AI session as a checkpoint, so never create checkpoints by hand — just commit normally. Leave setup and destructive commands (enable, disable, clean, rewind, auth) to the user. ")
+	b.WriteString("Commits automatically capture the AI session as a checkpoint, so never create checkpoints by hand — just commit normally. Leave setup and destructive commands (enable, disable, clean, auth) to the user. ")
 	// Mirror agentHelpRepoBlock's defense-in-depth: this string is injected raw
 	// into the agent's model context (no escaping), so a repo key carrying control
 	// characters (e.g. an <sessionID>.trail-scope.json cache written by a pre-fix

--- a/cmd/entire/cli/paths/paths_test.go
+++ b/cmd/entire/cli/paths/paths_test.go
@@ -105,8 +105,9 @@ func TestCaseInsensitiveFS(t *testing.T) {
 }
 
 // TestIsSubpath_AlwaysCaseSensitive locks in that IsSubpath — the fail-closed
-// containment primitive used by allow gates (rewind/utils) — never folds case
-// on any OS. A differently-cased path must not count as contained, or a
+// containment primitive used by allow gates (utils.go, and strategy's
+// nested-worktree check) — never folds case on any OS. A differently-cased
+// path must not count as contained, or a
 // crafted, attacker-influenced value could fail open on a case-sensitive volume.
 func TestIsSubpath_AlwaysCaseSensitive(t *testing.T) {
 	t.Parallel()

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -899,7 +899,7 @@ func restoreResumeSessions(ctx context.Context, w, errW io.Writer, metadata *str
 	checkpointID := metadata.CheckpointID
 	sessionID := metadata.SessionID
 
-	// Resolve agent from checkpoint metadata (same as rewind)
+	// Resolve agent from checkpoint metadata
 	ag, err := strategy.ResolveAgentForResume(metadata.Agent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve agent: %w", err)
@@ -933,7 +933,7 @@ func restoreResumeSessions(ctx context.Context, w, errW io.Writer, metadata *str
 	strat := GetStrategy(ctx)
 
 	// Use RestoreLogsOnly via LogsOnlyRestorer interface for multi-session support
-	// Create a logs-only rewind point with Agent populated (same as rewind)
+	// Create a logs-only pending checkpoint with Agent populated
 	point := strategy.PendingCheckpoint{
 		IsLogsOnly:   true,
 		CheckpointID: checkpointID,

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -900,7 +900,7 @@ func restoreResumeSessions(ctx context.Context, w, errW io.Writer, metadata *str
 	sessionID := metadata.SessionID
 
 	// Resolve agent from checkpoint metadata (same as rewind)
-	ag, err := strategy.ResolveAgentForRewind(metadata.Agent)
+	ag, err := strategy.ResolveAgentForResume(metadata.Agent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve agent: %w", err)
 	}
@@ -934,7 +934,7 @@ func restoreResumeSessions(ctx context.Context, w, errW io.Writer, metadata *str
 
 	// Use RestoreLogsOnly via LogsOnlyRestorer interface for multi-session support
 	// Create a logs-only rewind point with Agent populated (same as rewind)
-	point := strategy.RewindPoint{
+	point := strategy.PendingCheckpoint{
 		IsLogsOnly:   true,
 		CheckpointID: checkpointID,
 		Agent:        metadata.Agent,
@@ -973,7 +973,7 @@ func displayRestoredSessions(w io.Writer, sessions []strategy.RestoredSession) e
 
 	isMulti := len(sessions) > 1
 	for i, sess := range sessions {
-		sessionAgent, err := strategy.ResolveAgentForRewind(sess.Agent)
+		sessionAgent, err := strategy.ResolveAgentForResume(sess.Agent)
 		if err != nil {
 			return fmt.Errorf("failed to resolve agent for session %s: %w", sess.SessionID, err)
 		}

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -1370,9 +1370,9 @@ func TestDisplayRestoredSessions_SingleSessionOutput(t *testing.T) {
 		CreatedAt: time.Date(2026, time.February, 2, 12, 0, 0, 0, time.UTC),
 	}
 
-	ag, err := strategy.ResolveAgentForRewind(session.Agent)
+	ag, err := strategy.ResolveAgentForResume(session.Agent)
 	if err != nil {
-		t.Fatalf("ResolveAgentForRewind() error = %v", err)
+		t.Fatalf("ResolveAgentForResume() error = %v", err)
 	}
 
 	var output bytes.Buffer
@@ -1403,9 +1403,9 @@ func TestDisplayRestoredSessions_CodexShowsResumeCommand(t *testing.T) {
 		CreatedAt: time.Date(2026, time.April, 8, 18, 46, 0, 0, time.UTC),
 	}
 
-	ag, err := strategy.ResolveAgentForRewind(session.Agent)
+	ag, err := strategy.ResolveAgentForResume(session.Agent)
 	if err != nil {
-		t.Fatalf("ResolveAgentForRewind() error = %v", err)
+		t.Fatalf("ResolveAgentForResume() error = %v", err)
 	}
 
 	var output bytes.Buffer

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -91,7 +91,7 @@ func (k Kind) IsInvestigate() bool {
 // IsImported reports whether this Kind is a read-only session reconstructed by
 // `entire import` from a pre-existing transcript. Imported sessions are exempt
 // from lifecycle management (staleness, orphan cleanup) and are not
-// resumable/rewindable. Centralized here so those call sites don't couple to
+// resumable. Centralized here so those call sites don't couple to
 // the string literal across packages.
 func (k Kind) IsImported() bool {
 	// See IsReview for why this is an equality check rather than a switch.
@@ -238,7 +238,8 @@ type State struct {
 	// Use NormalizeAfterLoad() to migrate.
 	CondensedTranscriptLines int `json:"condensed_transcript_lines,omitempty"`
 
-	// UntrackedFilesAtStart tracks files that existed at session start (to preserve during rewind)
+	// UntrackedFilesAtStart tracks files that existed at session start (so they are
+	// not attributed to the session)
 	UntrackedFilesAtStart []string `json:"untracked_files_at_start,omitempty"`
 
 	// FilesTouched tracks files modified/created/deleted during this session

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -358,7 +358,7 @@ const (
 )
 
 // isProtectedPath returns true if relPath is inside a directory that should
-// never be modified or deleted during rewind or other destructive operations.
+// never be recorded as session changes or captured into a checkpoint.
 // Protected directories include git internals, entire metadata, and all
 // registered agent config directories.
 func isProtectedPath(relPath string) bool {
@@ -1562,7 +1562,8 @@ var ErrBranchNotFound = errors.New("branch not found")
 // Uses `git branch -D` instead of go-git's RemoveReference because go-git v5
 // doesn't properly persist deletions when refs are packed (.git/packed-refs)
 // or in a worktree context. This is the same class of go-git v5 bug that
-// affects checkout and reset --hard (see HardResetWithProtection).
+// affects checkout and reset --hard (see CheckoutBranch in git_operations.go,
+// which shells out to the git CLI for the same reason).
 //
 // Returns ErrBranchNotFound if the branch does not exist, allowing callers
 // to use errors.Is for idempotent deletion patterns.
@@ -1600,7 +1601,7 @@ func branchExistsCLI(ctx context.Context, branchName string) error {
 
 // collectUntrackedFiles collects untracked files in the working directory that are
 // NOT ignored by .gitignore. This is used to capture the initial state when starting
-// a session, ensuring untracked files present at session start are preserved during rewind.
+// a session, distinguishing files present at session start from ones it created.
 // Uses "git ls-files --others --exclude-standard -z" to respect .gitignore rules,
 // avoiding bloated session state from large ignored directories like node_modules/.
 // Returns paths relative to the repository root.

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -1466,7 +1466,7 @@ func fileExists(path string) bool {
 
 // getTaskCheckpointFromTree retrieves a task checkpoint from a commit tree.
 // Shared implementation for shadow and linear-shadow strategies.
-func getTaskCheckpointFromTree(ctx context.Context, point RewindPoint) (*TaskCheckpoint, error) {
+func getTaskCheckpointFromTree(ctx context.Context, point PendingCheckpoint) (*TaskCheckpoint, error) {
 	if !point.IsTaskCheckpoint {
 		return nil, ErrNotTaskCheckpoint
 	}
@@ -1510,7 +1510,7 @@ func getTaskCheckpointFromTree(ctx context.Context, point RewindPoint) (*TaskChe
 
 // getTaskTranscriptFromTree retrieves a task transcript from a commit tree.
 // Shared implementation for shadow and linear-shadow strategies.
-func getTaskTranscriptFromTree(ctx context.Context, point RewindPoint) ([]byte, error) {
+func getTaskTranscriptFromTree(ctx context.Context, point PendingCheckpoint) ([]byte, error) {
 	if !point.IsTaskCheckpoint {
 		return nil, ErrNotTaskCheckpoint
 	}

--- a/cmd/entire/cli/strategy/git_remote_cache.go
+++ b/cmd/entire/cli/strategy/git_remote_cache.go
@@ -15,7 +15,7 @@ import (
 // command against one repository, and there are several: `entire checkpoint list`
 // resolves the chain four times (metadata-disconnection warning, the branch
 // listing itself, the git-refs store's remote discovery, and the
-// imported-rewind-point pass), costing 9 git subprocesses where the same command
+// imported-pending-checkpoint pass), costing 9 git subprocesses where the same command
 // on the pre-election code spent 3.
 //
 // This caches only those two .git/config reads — never the election result.

--- a/cmd/entire/cli/strategy/manual_commit_logs.go
+++ b/cmd/entire/cli/strategy/manual_commit_logs.go
@@ -12,12 +12,12 @@ import (
 )
 
 // GetTaskCheckpoint retrieves a task checkpoint.
-func (s *ManualCommitStrategy) GetTaskCheckpoint(ctx context.Context, point RewindPoint) (*TaskCheckpoint, error) {
+func (s *ManualCommitStrategy) GetTaskCheckpoint(ctx context.Context, point PendingCheckpoint) (*TaskCheckpoint, error) {
 	return getTaskCheckpointFromTree(ctx, point)
 }
 
 // GetTaskCheckpointTranscript retrieves the transcript for a task checkpoint.
-func (s *ManualCommitStrategy) GetTaskCheckpointTranscript(ctx context.Context, point RewindPoint) ([]byte, error) {
+func (s *ManualCommitStrategy) GetTaskCheckpointTranscript(ctx context.Context, point PendingCheckpoint) ([]byte, error) {
 	return getTaskTranscriptFromTree(ctx, point)
 }
 

--- a/cmd/entire/cli/strategy/manual_commit_migration.go
+++ b/cmd/entire/cli/strategy/manual_commit_migration.go
@@ -19,7 +19,7 @@ import (
 // Reconcile path: if HEAD carries this session's LastCheckpointID as an
 // Entire-Checkpoint trailer (e.g. after git reset --hard to a condensed commit),
 // both BaseCommit and AttributionBaseCommit are updated to HEAD. The old shadow
-// branch is intentionally left untouched to preserve rewind data.
+// branch is intentionally left untouched to preserve its checkpoint data.
 //
 // Migrate path: for all other HEAD changes (pull, rebase, tool-call commits),
 // the shadow branch is renamed to the new base and only BaseCommit is updated.
@@ -49,7 +49,7 @@ func (s *ManualCommitStrategy) migrateShadowBranchIfNeeded(ctx context.Context, 
 	// LastCheckpointID, the user has reset back to the last condensed
 	// checkpoint. Update both BaseCommit and AttributionBaseCommit to HEAD.
 	// Deliberately do NOT rename or touch the old shadow branch — it
-	// preserves rewind data from the discarded segment of history.
+	// preserves checkpoint data from the discarded segment of history.
 	//
 	// The SHA guard (currentHead == LastCheckpointCommitHash) distinguishes a
 	// true reset from a cherry-pick/rebase that merely preserved the trailer.

--- a/cmd/entire/cli/strategy/manual_commit_pending.go
+++ b/cmd/entire/cli/strategy/manual_commit_pending.go
@@ -25,9 +25,9 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
-// GetRewindPoints returns available rewind points.
+// ListPendingCheckpoints returns available rewind points.
 // Uses checkpoint.EphemeralStore for reading from shadow branches.
-func (s *ManualCommitStrategy) GetRewindPoints(ctx context.Context, limit int) ([]RewindPoint, error) {
+func (s *ManualCommitStrategy) ListPendingCheckpoints(ctx context.Context, limit int) ([]PendingCheckpoint, error) {
 	repo, err := OpenRepository(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
@@ -52,7 +52,7 @@ func (s *ManualCommitStrategy) GetRewindPoints(ctx context.Context, limit int) (
 		sessions = nil
 	}
 
-	var allPoints []RewindPoint
+	var allPoints []PendingCheckpoint
 
 	// Collect checkpoint points from active sessions using temporary storage.
 	// Cache session prompts by session ID to avoid re-reading the same prompt file
@@ -72,7 +72,7 @@ func (s *ManualCommitStrategy) GetRewindPoints(ctx context.Context, limit int) (
 				sessionPrompts[cp.SessionID] = sessionPrompt
 			}
 
-			allPoints = append(allPoints, RewindPoint{
+			allPoints = append(allPoints, PendingCheckpoint{
 				ID:               cp.CommitHash.String(),
 				Message:          cp.Message,
 				MetadataDir:      cp.MetadataDir,
@@ -100,7 +100,7 @@ func (s *ManualCommitStrategy) GetRewindPoints(ctx context.Context, limit int) (
 			if rec.CompletedAt.IsZero() {
 				message = FormatSubagentRunningMessage(rec.SubagentType, rec.TaskDescription, shortToolUseID)
 			}
-			allPoints = append(allPoints, RewindPoint{
+			allPoints = append(allPoints, PendingCheckpoint{
 				Message:          message,
 				Date:             date,
 				IsTaskCheckpoint: true,
@@ -122,7 +122,7 @@ func (s *ManualCommitStrategy) GetRewindPoints(ctx context.Context, limit int) (
 	}
 
 	// Also include logs-only points from commit history
-	logsOnlyPoints, err := s.GetLogsOnlyRewindPoints(ctx, limit)
+	logsOnlyPoints, err := s.ListLogsOnlyPendingCheckpoints(ctx, limit)
 	if err == nil && len(logsOnlyPoints) > 0 {
 		// Build set of existing point IDs for deduplication
 		existingIDs := make(map[string]bool)
@@ -151,7 +151,7 @@ func (s *ManualCommitStrategy) GetRewindPoints(ctx context.Context, limit int) (
 	return allPoints, nil
 }
 
-// GetLogsOnlyRewindPoints finds commits in the current branch's history that have
+// ListLogsOnlyPendingCheckpoints finds commits in the current branch's history that have
 // condensed session logs in committed checkpoint storage. These are commits that
 // were created with session data but the shadow branch has been condensed.
 //
@@ -160,7 +160,7 @@ func (s *ManualCommitStrategy) GetRewindPoints(ctx context.Context, limit int) (
 // 2. Building a map of checkpoint ID -> checkpoint info
 // 3. Scanning the current branch history for commits with Entire-Checkpoint trailers
 // 4. Matching by checkpoint ID (stable across amend/rebase)
-func (s *ManualCommitStrategy) GetLogsOnlyRewindPoints(ctx context.Context, limit int) ([]RewindPoint, error) {
+func (s *ManualCommitStrategy) ListLogsOnlyPendingCheckpoints(ctx context.Context, limit int) ([]PendingCheckpoint, error) {
 	repo, err := OpenRepository(ctx)
 	if err != nil {
 		return nil, err
@@ -205,7 +205,7 @@ func (s *ManualCommitStrategy) GetLogsOnlyRewindPoints(ctx context.Context, limi
 		return nil, fmt.Errorf("failed to get commit log: %w", err)
 	}
 
-	var points []RewindPoint
+	var points []PendingCheckpoint
 	count := 0
 
 	err = iter.ForEach(func(c *object.Commit) error {
@@ -260,7 +260,7 @@ func (s *ManualCommitStrategy) GetLogsOnlyRewindPoints(ctx context.Context, limi
 			}
 		}
 
-		points = append(points, RewindPoint{
+		points = append(points, PendingCheckpoint{
 			ID:             c.Hash.String(),
 			Message:        message,
 			Date:           c.Author.When,
@@ -313,7 +313,7 @@ func ResolveLatestCheckpointFromMap(cpIDs []id.CheckpointID, infoMap map[id.Chec
 // When multiple sessions were condensed to the same checkpoint, ALL sessions are restored.
 // If force is false, prompts for confirmation when local logs have newer timestamps.
 // Returns info about each restored session so callers can print correct per-session resume commands.
-func (s *ManualCommitStrategy) RestoreLogsOnly(ctx context.Context, w, errW io.Writer, point RewindPoint, force bool) ([]RestoredSession, error) {
+func (s *ManualCommitStrategy) RestoreLogsOnly(ctx context.Context, w, errW io.Writer, point PendingCheckpoint, force bool) ([]RestoredSession, error) {
 	if !point.IsLogsOnly {
 		return nil, errors.New("not a logs-only rewind point")
 	}
@@ -397,7 +397,7 @@ func (s *ManualCommitStrategy) RestoreLogsOnly(ctx context.Context, w, errW io.W
 			fmt.Fprintf(errW, "  Warning: session %d (%s) has no agent metadata, skipping (cannot determine target directory)\n", i, sessionID)
 			continue
 		}
-		sessionAgent, agErr := ResolveAgentForRewind(content.Metadata.Agent)
+		sessionAgent, agErr := ResolveAgentForResume(content.Metadata.Agent)
 		if agErr != nil {
 			fmt.Fprintf(errW, "  Warning: session %d (%s) has unknown agent %q, skipping\n", i, sessionID, content.Metadata.Agent)
 			continue
@@ -552,8 +552,8 @@ func extractPromptsFromTranscriptBytes(extractor agent.PromptExtractor, transcri
 	return prompts, nil
 }
 
-// ResolveAgentForRewind resolves the agent from checkpoint metadata.
-func ResolveAgentForRewind(agentType types.AgentType) (agent.Agent, error) {
+// ResolveAgentForResume resolves the agent from checkpoint metadata.
+func ResolveAgentForResume(agentType types.AgentType) (agent.Agent, error) {
 	ag, err := agent.GetByAgentType(agentType)
 	if err != nil {
 		return nil, fmt.Errorf("resolving agent %q: %w", agentType, err)
@@ -634,7 +634,7 @@ func (s *ManualCommitStrategy) classifySessionsForRestore(ctx context.Context, r
 			continue
 		}
 
-		sessionAgent, agErr := ResolveAgentForRewind(content.Metadata.Agent)
+		sessionAgent, agErr := ResolveAgentForResume(content.Metadata.Agent)
 		if agErr != nil {
 			continue
 		}

--- a/cmd/entire/cli/strategy/manual_commit_pending.go
+++ b/cmd/entire/cli/strategy/manual_commit_pending.go
@@ -25,7 +25,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
-// ListPendingCheckpoints returns available rewind points.
+// ListPendingCheckpoints returns the session's pending (not yet condensed) checkpoints.
 // Uses checkpoint.EphemeralStore for reading from shadow branches.
 func (s *ManualCommitStrategy) ListPendingCheckpoints(ctx context.Context, limit int) ([]PendingCheckpoint, error) {
 	repo, err := OpenRepository(ctx)
@@ -230,7 +230,7 @@ func (s *ManualCommitStrategy) ListLogsOnlyPendingCheckpoints(ctx context.Contex
 			return nil
 		}
 
-		// Create logs-only rewind point
+		// Create logs-only pending checkpoint
 		message := strings.Split(c.Message, "\n")[0]
 
 		// Read session prompts from metadata tree
@@ -307,7 +307,7 @@ func ResolveLatestCheckpointFromMap(cpIDs []id.CheckpointID, infoMap map[id.Chec
 	return latest, found
 }
 
-// RestoreLogsOnly restores session logs from a logs-only rewind point.
+// RestoreLogsOnly restores session logs from a logs-only pending checkpoint.
 // This fetches the transcript from entire/checkpoints/v1 and writes it to the agent's session directory.
 // Does not modify the working directory.
 // When multiple sessions were condensed to the same checkpoint, ALL sessions are restored.
@@ -315,7 +315,7 @@ func ResolveLatestCheckpointFromMap(cpIDs []id.CheckpointID, infoMap map[id.Chec
 // Returns info about each restored session so callers can print correct per-session resume commands.
 func (s *ManualCommitStrategy) RestoreLogsOnly(ctx context.Context, w, errW io.Writer, point PendingCheckpoint, force bool) ([]RestoredSession, error) {
 	if !point.IsLogsOnly {
-		return nil, errors.New("not a logs-only rewind point")
+		return nil, errors.New("not a logs-only pending checkpoint")
 	}
 
 	if point.CheckpointID.IsEmpty() {

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -537,13 +537,13 @@ func (s *ManualCommitStrategy) findSessionsForCommit(ctx context.Context, baseCo
 }
 
 // FindSessionsForCommit is the exported version of findSessionsForCommit.
-// Used by the rewind reset command to find sessions to clean up.
+// Used by `entire clean` to find sessions to clean up.
 func (s *ManualCommitStrategy) FindSessionsForCommit(ctx context.Context, baseCommitSHA string) ([]*SessionState, error) {
 	return s.findSessionsForCommit(ctx, baseCommitSHA)
 }
 
 // ClearSessionState is the exported version of clearSessionState.
-// Used by the rewind reset command to clean up session state files.
+// Used by `entire doctor` to clean up session state files.
 func (s *ManualCommitStrategy) ClearSessionState(ctx context.Context, sessionID string) error {
 	return s.clearSessionState(ctx, sessionID)
 }
@@ -614,7 +614,8 @@ func (s *ManualCommitStrategy) initializeSession(ctx context.Context, repo *git.
 		return fmt.Errorf("failed to get worktree ID: %w", err)
 	}
 
-	// Capture untracked files at session start to preserve them during rewind
+	// Capture untracked files at session start so checkpoint bookkeeping can tell
+	// them apart from files the session created
 	untrackedFiles, err := collectUntrackedFiles(ctx)
 	if err != nil {
 		// Non-fatal: continue even if we can't collect untracked files

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -427,7 +427,7 @@ func TestShadowStrategy_ClearSessionState(t *testing.T) {
 	}
 }
 
-func TestShadowStrategy_GetRewindPoints_NoShadowBranch(t *testing.T) {
+func TestShadowStrategy_ListPendingCheckpoints_NoShadowBranch(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	repo, err := git.PlainOpen(dir)
@@ -457,19 +457,19 @@ func TestShadowStrategy_GetRewindPoints_NoShadowBranch(t *testing.T) {
 	t.Chdir(dir)
 
 	s := NewManualCommitStrategy()
-	points, err := s.GetRewindPoints(context.Background(), 10)
+	points, err := s.ListPendingCheckpoints(context.Background(), 10)
 	if err != nil {
-		t.Errorf("GetRewindPoints() error = %v", err)
+		t.Errorf("ListPendingCheckpoints() error = %v", err)
 	}
 	if len(points) != 0 {
-		t.Errorf("GetRewindPoints() returned %d points, want 0", len(points))
+		t.Errorf("ListPendingCheckpoints() returned %d points, want 0", len(points))
 	}
 }
 
 // Pending subagent work lives on task records now, so `checkpoint list
 // --pending`'s [Task] rows must come from TaskRecords. The session is ENDED
 // with no shadow branch — the shape the orphan cleanup used to discard.
-func TestShadowStrategy_GetRewindPoints_TaskRecordRows(t *testing.T) {
+func TestShadowStrategy_ListPendingCheckpoints_TaskRecordRows(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	testutil.WriteFile(t, dir, "f.txt", "init")
@@ -492,7 +492,7 @@ func TestShadowStrategy_GetRewindPoints_TaskRecordRows(t *testing.T) {
 		},
 	}))
 
-	points, err := s.GetRewindPoints(context.Background(), 10)
+	points, err := s.ListPendingCheckpoints(context.Background(), 10)
 	require.NoError(t, err)
 	require.Len(t, points, 2, "both completed-unmaterialized and live records must produce pending [Task] rows")
 	assert.True(t, points[0].IsTaskCheckpoint && points[1].IsTaskCheckpoint)
@@ -505,7 +505,7 @@ func TestShadowStrategy_GetRewindPoints_TaskRecordRows(t *testing.T) {
 // When the most-recent session of a multi-session condensed checkpoint has no
 // prompt, the picker must fall back to the latest non-empty session prompt
 // rather than displaying nothing.
-func TestShadowStrategy_GetRewindPoints_MultiSessionFallsBackToEarlierPrompt(t *testing.T) {
+func TestShadowStrategy_ListPendingCheckpoints_MultiSessionFallsBackToEarlierPrompt(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	testutil.WriteFile(t, dir, "f.txt", "init")
@@ -547,7 +547,7 @@ func TestShadowStrategy_GetRewindPoints_MultiSessionFallsBackToEarlierPrompt(t *
 	testutil.GitCommit(t, dir, "feat\n\nEntire-Checkpoint: "+cpID.String())
 
 	strat := NewManualCommitStrategy()
-	points, err := strat.GetRewindPoints(t.Context(), 10)
+	points, err := strat.ListPendingCheckpoints(t.Context(), 10)
 	require.NoError(t, err)
 	require.Len(t, points, 1)
 	assert.Equal(t, earlierPrompt, points[0].SessionPrompt,
@@ -598,7 +598,7 @@ func TestShadowStrategy_GetTaskCheckpoint_NotTaskCheckpoint(t *testing.T) {
 
 	s := NewManualCommitStrategy()
 
-	point := RewindPoint{
+	point := PendingCheckpoint{
 		ID:               "abc123",
 		IsTaskCheckpoint: false,
 	}
@@ -617,7 +617,7 @@ func TestShadowStrategy_GetTaskCheckpointTranscript_NotTaskCheckpoint(t *testing
 
 	s := NewManualCommitStrategy()
 
-	point := RewindPoint{
+	point := PendingCheckpoint{
 		ID:               "abc123",
 		IsTaskCheckpoint: false,
 	}

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -1050,7 +1050,7 @@ func TestShadowStrategy_FilesTouched_OnlyModifiedFiles(t *testing.T) {
 	}
 
 	// First checkpoint using SaveStep - captures ALL working directory files
-	// (for rewind purposes), but tracks only modified files in FilesTouched
+	// (the checkpoint tree is a full snapshot), but tracks only modified files in FilesTouched
 	err = s.SaveStep(context.Background(), StepContext{
 		SessionID:      sessionID,
 		ModifiedFiles:  []string{}, // No files modified yet

--- a/cmd/entire/cli/strategy/restore_logs_test.go
+++ b/cmd/entire/cli/strategy/restore_logs_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
-	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode" // Register agent for ResolveAgentForRewind tests
-	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"  // Register agent for ResolveAgentForRewind tests
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode" // Register agent for ResolveAgentForResume tests
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"  // Register agent for ResolveAgentForResume tests
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
@@ -47,14 +47,14 @@ func TestRestoreLogsOnly_KeepsExistingLocalLog(t *testing.T) {
 	sessionID := "keep-existing-session"
 
 	checkpointTranscript := []byte(`{"type":"user","timestamp":"2025-01-02T10:00:00Z","message":{"content":[{"type":"text","text":"from checkpoint"}]}}` + "\n")
-	writeCommittedRewindCheckpoint(t, repo, cpID, sessionID, agentType, checkpointTranscript, time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC))
+	writeCommittedCheckpoint(t, repo, cpID, sessionID, agentType, checkpointTranscript, time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC))
 
 	// Pre-existing local log with a (different) timestamped entry.
 	localPath := filepath.Join(sessionDir, sessionID+".jsonl")
 	existingLocal := []byte(`{"type":"user","timestamp":"2025-06-01T10:00:00Z","message":{"content":[{"type":"text","text":"live local"}]}}` + "\n")
 	require.NoError(t, os.WriteFile(localPath, existingLocal, 0o600))
 
-	point := RewindPoint{IsLogsOnly: true, CheckpointID: cpID}
+	point := PendingCheckpoint{IsLogsOnly: true, CheckpointID: cpID}
 
 	// Non-force: keep the existing local log, but still report the session.
 	var stdout, stderr bytes.Buffer
@@ -151,12 +151,12 @@ func TestFirstDisplayPrompt(t *testing.T) {
 	}
 }
 
-func TestResolveAgentForRewind(t *testing.T) {
+func TestResolveAgentForResume(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty type returns error", func(t *testing.T) {
 		t.Parallel()
-		_, err := ResolveAgentForRewind("")
+		_, err := ResolveAgentForResume("")
 		if err == nil {
 			t.Error("expected error for empty agent type")
 		}
@@ -164,7 +164,7 @@ func TestResolveAgentForRewind(t *testing.T) {
 
 	t.Run("Claude Code type resolves correctly", func(t *testing.T) {
 		t.Parallel()
-		ag, err := ResolveAgentForRewind("Claude Code")
+		ag, err := ResolveAgentForResume("Claude Code")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -175,7 +175,7 @@ func TestResolveAgentForRewind(t *testing.T) {
 
 	t.Run("Gemini CLI type resolves correctly", func(t *testing.T) {
 		t.Parallel()
-		ag, err := ResolveAgentForRewind("Gemini CLI")
+		ag, err := ResolveAgentForResume("Gemini CLI")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -186,7 +186,7 @@ func TestResolveAgentForRewind(t *testing.T) {
 
 	t.Run("unknown type returns error", func(t *testing.T) {
 		t.Parallel()
-		_, err := ResolveAgentForRewind("Nonexistent Agent")
+		_, err := ResolveAgentForResume("Nonexistent Agent")
 		if err == nil {
 			t.Error("expected error for unknown agent type")
 		}
@@ -196,13 +196,13 @@ func TestResolveAgentForRewind(t *testing.T) {
 		t.Parallel()
 
 		// Simulate what external.DiscoverAndRegister does: register an agent at runtime.
-		testName := types.AgentName("test-external-rewind-agent")
-		testType := types.AgentType("Entire Test External Rewind Agent")
+		testName := types.AgentName("test-external-resume-agent")
+		testType := types.AgentType("Entire Test External Resume Agent")
 		agent.Register(testName, func() agent.Agent {
 			return &fakeExternalAgent{name: testName, agentType: testType}
 		})
 
-		ag, err := ResolveAgentForRewind(testType)
+		ag, err := ResolveAgentForResume(testType)
 		if err != nil {
 			t.Fatalf("expected dynamically registered agent to resolve, got error: %v", err)
 		}
@@ -215,7 +215,7 @@ func TestResolveAgentForRewind(t *testing.T) {
 	})
 }
 
-func writeCommittedRewindCheckpoint(
+func writeCommittedCheckpoint(
 	t *testing.T,
 	repo *git.Repository,
 	checkpointID id.CheckpointID,

--- a/cmd/entire/cli/strategy/strategy.go
+++ b/cmd/entire/cli/strategy/strategy.go
@@ -40,10 +40,10 @@ type SessionInfo struct {
 	CommitHash string
 }
 
-// RewindPoint represents a point to which the user can rewind.
+// PendingCheckpoint represents a point to which the user can rewind.
 // This abstraction allows different strategies to use different
 // identifiers (commit hashes, branch names, stash refs, etc.)
-type RewindPoint struct {
+type PendingCheckpoint struct {
 	// ID is the unique identifier for this rewind point
 	// (commit hash, branch name, stash ref, etc.)
 	ID string

--- a/cmd/entire/cli/strategy/strategy.go
+++ b/cmd/entire/cli/strategy/strategy.go
@@ -40,8 +40,21 @@ type SessionInfo struct {
 	CommitHash string
 }
 
-// PendingCheckpoint is a checkpoint that has not yet been condensed onto
-// entire/checkpoints/v1: either live shadow-branch state or a logs-only point.
+// PendingCheckpoint is one row of `checkpoint list --pending`, which is the
+// resume view of the current branch rather than a single kind of thing. A row is
+// one of two shapes:
+//
+//   - A live checkpoint on the session's shadow branch, not yet condensed onto
+//     entire/checkpoints/v1. ID is the shadow commit; CheckpointID is empty.
+//   - A logs-only resume point: a commit on the current branch whose
+//     Entire-Checkpoint trailer resolves to a checkpoint that IS already
+//     condensed onto entire/checkpoints/v1. ID is that commit, CheckpointID the
+//     condensed checkpoint, and IsLogsOnly is true. It is listed so the session
+//     transcript can be restored from v1 (RestoreLogsOnly); file state would
+//     need a git checkout.
+//
+// So "pending" describes the listing, not a guarantee that the underlying work
+// is un-condensed — half these rows are recovered from condensed history.
 // This abstraction allows different strategies to use different
 // identifiers (commit hashes, branch names, stash refs, etc.)
 type PendingCheckpoint struct {

--- a/cmd/entire/cli/strategy/strategy.go
+++ b/cmd/entire/cli/strategy/strategy.go
@@ -18,7 +18,7 @@ var ErrNoMetadata = errors.New("commit has no entire metadata")
 // ErrNoSession is returned when no session info is available.
 var ErrNoSession = errors.New("no session info available")
 
-// ErrNotTaskCheckpoint is returned when a rewind point is not a task checkpoint.
+// ErrNotTaskCheckpoint is returned when a pending checkpoint is not a task checkpoint.
 var ErrNotTaskCheckpoint = errors.New("not a task checkpoint")
 
 // ErrEmptyRepository is returned when the repository has no commits yet.
@@ -40,11 +40,12 @@ type SessionInfo struct {
 	CommitHash string
 }
 
-// PendingCheckpoint represents a point to which the user can rewind.
+// PendingCheckpoint is a checkpoint that has not yet been condensed onto
+// entire/checkpoints/v1: either live shadow-branch state or a logs-only point.
 // This abstraction allows different strategies to use different
 // identifiers (commit hashes, branch names, stash refs, etc.)
 type PendingCheckpoint struct {
-	// ID is the unique identifier for this rewind point
+	// ID is the unique identifier for this pending checkpoint
 	// (commit hash, branch name, stash ref, etc.)
 	ID string
 
@@ -54,7 +55,7 @@ type PendingCheckpoint struct {
 	// MetadataDir is the path to the metadata directory
 	MetadataDir string
 
-	// Date is when this rewind point was created
+	// Date is when this pending checkpoint was created
 	Date time.Time
 
 	// IsTaskCheckpoint indicates if this is a task checkpoint (vs a session checkpoint)
@@ -98,7 +99,7 @@ type PendingCheckpoint struct {
 	SessionPrompts []string
 
 	// Imported indicates this point is a read-only imported (commit-less)
-	// checkpoint on the v1 metadata branch. Imported points are not rewindable.
+	// checkpoint on the v1 metadata branch. Imported points are read-only.
 	Imported bool
 }
 
@@ -180,7 +181,7 @@ type TaskStepContext struct {
 	// SubagentTranscriptPath is the path to the subagent's transcript (if available)
 	SubagentTranscriptPath string
 
-	// CheckpointUUID is the UUID for transcript truncation when rewinding
+	// CheckpointUUID is the UUID marking where this checkpoint's transcript slice starts
 	CheckpointUUID string
 
 	// AuthorName is the name to use for commits

--- a/cmd/entire/cli/testutil/testutil.go
+++ b/cmd/entire/cli/testutil/testutil.go
@@ -18,8 +18,8 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
-// RewindPoint mirrors the `checkpoint list --pending --json` JSON output.
-type RewindPoint struct {
+// PendingCheckpoint mirrors the `checkpoint list --pending --json` JSON output.
+type PendingCheckpoint struct {
 	ID               string    `json:"id"`
 	Message          string    `json:"message"`
 	MetadataDir      string    `json:"metadata_dir"`

--- a/cmd/entire/cli/trail_resume_cmd.go
+++ b/cmd/entire/cli/trail_resume_cmd.go
@@ -404,7 +404,7 @@ func displayTrailRestoredSessions(w io.Writer, sessions []strategy.RestoredSessi
 	isMulti := len(choices) > 1
 	mostRecentSessionID := mostRecentRestoredSessionID(sessions)
 	for _, choice := range choices {
-		sessionAgent, err := strategy.ResolveAgentForRewind(choice.Session.Agent)
+		sessionAgent, err := strategy.ResolveAgentForResume(choice.Session.Agent)
 		if err != nil {
 			return fmt.Errorf("failed to resolve agent for session %s: %w", choice.SessionID, err)
 		}
@@ -1079,7 +1079,7 @@ func findTrailRestoredSession(sessions []strategy.RestoredSession, sessionID str
 }
 
 func launchTrailRestoredSession(ctx context.Context, w io.Writer, session strategy.RestoredSession) error {
-	resumeAgent, err := strategy.ResolveAgentForRewind(session.Agent)
+	resumeAgent, err := strategy.ResolveAgentForResume(session.Agent)
 	if err != nil {
 		return fmt.Errorf("failed to resolve agent for session %s: %w", session.SessionID, err)
 	}

--- a/cmd/entire/cli/transcript.go
+++ b/cmd/entire/cli/transcript.go
@@ -140,8 +140,8 @@ type userMessageWithToolResults struct {
 }
 
 // FindCheckpointUUID finds the UUID of the message containing the tool_result
-// for the given tool_use_id. This is used to find the checkpoint point for
-// where a task's transcript slice starts.
+// for the given tool_use_id. That UUID marks where the task checkpoint's
+// transcript slice starts.
 // Returns the UUID and true if found, empty string and false otherwise.
 func FindCheckpointUUID(lines []transcriptLine, toolUseID string) (string, bool) {
 	for _, line := range lines {

--- a/cmd/entire/cli/transcript.go
+++ b/cmd/entire/cli/transcript.go
@@ -141,7 +141,7 @@ type userMessageWithToolResults struct {
 
 // FindCheckpointUUID finds the UUID of the message containing the tool_result
 // for the given tool_use_id. This is used to find the checkpoint point for
-// transcript truncation when rewinding to a task.
+// where a task's transcript slice starts.
 // Returns the UUID and true if found, empty string and false otherwise.
 func FindCheckpointUUID(lines []transcriptLine, toolUseID string) (string, bool) {
 	for _, line := range lines {

--- a/cmd/entire/cli/transcript_test.go
+++ b/cmd/entire/cli/transcript_test.go
@@ -11,7 +11,7 @@ import (
 // containing path-traversal primitives are rejected before being used to build a
 // filesystem write path.
 //
-// Session IDs reaching the resume/rewind restore paths originate from checkpoint
+// Session IDs reaching the resume/log-restore paths originate from checkpoint
 // metadata stored on the shared entire/checkpoints/v1 branch, which an attacker
 // with push access can craft. Without validation, an absolute or "../"-laden
 // session ID escapes the agent session directory (and for agents like Pi/Codex

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -832,12 +832,14 @@ Strategies determine checkpoint timing and type:
 | On Task Complete | Task record on session state → materialized at condensation |
 | On User Commit | Condense → Committed |
 
-## Rewind
+## Pending Checkpoints
 
-Each `RewindPoint` includes `SessionID` and `SessionPrompt` to help identify which checkpoint belongs to which session when multiple sessions are interleaved.
+Each `PendingCheckpoint` includes `SessionID` and `SessionPrompt` to help identify which checkpoint belongs to which session when multiple sessions are interleaved.
 
-A rewind point is something you can list and resume from, not something the CLI
-restores working files to: the file-restoring path (`Rewind`, `PreviewRewind`,
+A pending checkpoint is one that has not yet been condensed onto
+`entire/checkpoints/v1` — live shadow-branch state, or a logs-only point. You
+can list it (`checkpoint list --pending`) and resume from it, but the CLI cannot
+restore working files to it: the file-restoring path (`Rewind`, `PreviewRewind`,
 `CanRewind`) was removed along with the `rewind` commands. `RestoreLogsOnly`
 still writes a checkpoint's session logs into the agent's session directory for
 `entire resume`, and leaves the worktree alone.

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -836,12 +836,24 @@ Strategies determine checkpoint timing and type:
 
 Each `PendingCheckpoint` includes `SessionID` and `SessionPrompt` to help identify which checkpoint belongs to which session when multiple sessions are interleaved.
 
-A pending checkpoint is one that has not yet been condensed onto
-`entire/checkpoints/v1` — live shadow-branch state, or a logs-only point. You
-can list it (`checkpoint list --pending`) and resume from it, but the CLI cannot
-restore working files to it: the file-restoring path (`Rewind`, `PreviewRewind`,
-`CanRewind`) was removed along with the `rewind` commands. `RestoreLogsOnly`
-still writes a checkpoint's session logs into the agent's session directory for
+`checkpoint list --pending` is the resume view of the current branch, and a
+`PendingCheckpoint` row is one of two things:
+
+- a **live checkpoint** on the session's shadow branch, not yet condensed onto
+  `entire/checkpoints/v1`; or
+- a **logs-only resume point** — a commit on the current branch whose
+  `Entire-Checkpoint` trailer resolves to a checkpoint that *is* already
+  condensed onto `entire/checkpoints/v1`, listed so its session transcript can
+  be restored from there (file state would need a git checkout).
+
+So "pending" describes the listing, not a guarantee that the work behind every
+row is un-condensed: `ListLogsOnlyPendingCheckpoints` builds the second kind by
+scanning branch history against committed checkpoint storage.
+
+Either shape can be listed and resumed from, but the CLI cannot restore working
+files to it: the file-restoring path (`Rewind`, `PreviewRewind`, `CanRewind`) was
+removed along with the `rewind` commands. `RestoreLogsOnly` still writes a
+checkpoint's session logs into the agent's session directory for
 `entire resume`, and leaves the worktree alone.
 
 ## Concurrent Sessions

--- a/scripts/test-attribution-e2e.sh
+++ b/scripts/test-attribution-e2e.sh
@@ -142,8 +142,8 @@ echo -e "${GREEN}main.py after user edit:${NC}"
 cat main.py
 echo ""
 
-# Check rewind points
-echo -e "${BLUE}=== Step 9: Check rewind points ===${NC}"
+# Check pending checkpoints
+echo -e "${BLUE}=== Step 9: Check pending checkpoints ===${NC}"
 entire checkpoint list --pending --json || true
 
 # Show session state (includes PromptAttributions for debugging)
@@ -254,10 +254,10 @@ else
     echo -e "${YELLOW}No Entire-Checkpoint trailer found (user may have removed it)${NC}"
 fi
 
-# Show rewind points summary
+# Show pending checkpoints summary
 echo ""
-echo -e "${BLUE}=== Step 15: Rewind points summary ===${NC}"
-entire checkpoint list --pending --json | jq -r '.[] | "  \(.id[0:8])... - \(.message[0:60])"' 2>/dev/null || echo "  (no rewind points)"
+echo -e "${BLUE}=== Step 15: Pending checkpoints summary ===${NC}"
+entire checkpoint list --pending --json | jq -r '.[] | "  \(.id[0:8])... - \(.message[0:60])"' 2>/dev/null || echo "  (no pending checkpoints)"
 
 # Final summary
 echo ""


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1188
<!-- entire-trail-link-end -->

#2178 removed the rewind restore path, but the listing machinery that survived it kept the name — and what `checkpoint list --pending` returns is a pending checkpoint: one not yet condensed onto `entire/checkpoints/v1`. The rename is safe to do now precisely because the machine-readable surface was already clean: no JSON key, flag, or command path has ever contained "rewind", so this touches only Go identifiers, comments, and human-readable text.

> Was stacked on #2186; that merged, and this PR now targets `main` with just the two rename commits.

## Mapping

| Old | New | Uses |
| --- | --- | --- |
| `RewindPoint` | `PendingCheckpoint` | 63 |
| `ResolveAgentForRewind` | `ResolveAgentForResume` | 19 |
| `GetRewindPoints` | `ListPendingCheckpoints` | 15 |
| `pendingRewindPointJSON` | `pendingCheckpointJSON` | 7 |
| `rewindPointLabel` | `pendingCheckpointLabel` | 4 |
| `pendingRewindPointsLimit` | `pendingCheckpointsLimit` | 4 |
| `GetLogsOnlyRewindPoints` | `ListLogsOnlyPendingCheckpoints` | 3 |
| `getImportedRewindPoints` | `getImportedPendingCheckpoints` | 3 |
| `RewindPoints` | `PendingCheckpoints` | 1 |

119 uses across 20 files. `Get-` became `List-` because these return a slice and take a limit; `ResolveAgentForRewind` became `ForResume` because all three callers are resume commands (`newResumeCmd`, `newCheckpointResumeCmd`, `newTrailResumeCmd`).

Kept as-is per the brief: `RestoreLogsOnly`, `RestoredSession`, `SessionRestoreStatus`, `ClassifyTimestamps`, `ResolveLatestCheckpointFromMap`.

**File moves** (`git mv`): `strategy/manual_commit_rewind.go` → `manual_commit_pending.go`, and `strategy/rewind_test.go` → `strategy/restore_logs_test.go`. The second is deliberately not `manual_commit_pending_test.go`: every test left in that file exercises the log-restore/resume half (`RestoreLogsOnly`, prompt preview, `FirstDisplayPrompt`, `ResolveAgentForResume`), while the listing half is tested in `manual_commit_test.go`.

No gopls on this machine, so renames went through word-boundary regex applied longest-name-first — so `GetRewindPoints` and `GetLogsOnlyRewindPoints` could not be shredded by the `RewindPoint` pass — with `go build ./...` gating every step. Word boundaries also skip test function names (`TestResolveAgentForRewind` has no boundary before `Resolve`), so those were renamed separately, along with the file-local `writeCommittedRewindCheckpoint` helper (now `writeCommittedCheckpoint` — it writes a *committed* checkpoint, not a pending one) and two test-agent fixture strings.

## Explicitly unchanged

- **The `--pending` flag**, every command path, and every alias. The diff's only flag line is its help *text*; no `Use:` or `Aliases:` line moved.
- **The JSON shape.** `grep '^[+-].*json:"'` over the entire diff returns **nothing** — every field in `pendingCheckpointJSON` carries an explicit tag, so renaming the Go type cannot move a key. `checkpoint list --pending --json` stays byte-identical, and `TestPendingCheckpointJSON_MatchesRewindListContract` (which keeps its historical suffix) still passes.
- **CHANGELOG.md** — untouched.
- **`internal/remotehelper/transport/proxy.go`** — its "rewind" is HTTP request-body rewinding.
- **Every "rewind" that means moving a git ref backwards**: `fetch_rewind_protection_test.go` (filename included), `safely_advance_local_ref_test.go`, `checkpoint_remote_test.go`, the explain fetch tests.
- **Historical references**, which explain why the current shape is what it is: the `rewind --list` mentions in `checkpoint_list.go` / `checkpoint_group.go` (that bridge is *why* the JSON is frozen), the "former interactive rewind picker" whose format `pendingCheckpointLabel` inherited, and `deprecated_strings_test.go`'s never-advertise entry for `entire rewind`.

## Strings and comments

`checkpoint list --pending` no longer says "No pending rewind points found." or "Pending rewind points are created automatically…"; the flag help, `Long` text, and two error paths follow. The first-turn context injection listed "(enable, disable, clean, rewind, auth)" as destructive commands — `entire rewind` has not existed since #1747, so a third of that warning pointed at nothing.

Three comments were wrong about *mechanisms*, not just names, and were checked against the code rather than reworded:

- `gitrepo/status.go` named "review, rewind" as the paths keeping the unbounded `Status` walk. The real two are `review_target.go` and `detectFileChangesUnbounded` (`session adopt`); both are now named.
- `manual_commit_session.go` attributed `FindSessionsForCommit` **and** `ClearSessionState` to "the rewind reset command". They belong to *different* commands — `entire clean` (clean.go:177) and `entire doctor` (doctor.go:406).
- `common.go`'s `DeleteBranchCLI` cited `HardResetWithProtection` as its sibling go-git v5 workaround. That function exists nowhere in the tree; the real one is `CheckoutBranch` in `git_operations.go`. (This was the follow-up flagged in #2178 and #2186.)

## Verification

- `mise run fmt && mise run lint` — 0 issues, per commit.
- `go test ./cmd/entire/cli/...` — pass, per commit.
- `bash -n` on both edited shell scripts — clean.
- Full `mise run test:ci` — **exit 0**: unit + integration (`-race`) + canary 56/56 vogon and 4/4 roger-roger. The `TestCodexAppServerHooksList_*` failure known to hit macOS with codex installed did **not** fire.

**String assertions updated** (the only ones that pin text this PR changes): `checkpoint_list_test.go` pinned "No pending rewind points found." twice. Both are exact-match `require.Contains` calls, so nothing else could have drifted silently. `trail_injection_text_test.go` asserts only the prefix "Leave setup and destructive commands", so the context-injection edit leaves it passing. No canary test greps CLI output for "rewind points", and no E2E prompt wording changed.

## Left for a follow-up, not done here

Comments in the **agent implementations** still describe rewind as live: `claudecode/claude.go:188`, `codex/codex.go:91`, `opencode/opencode.go:225-239`, and the two `security_contract_test.go` files. The brief enumerated the comment sites it had verified and these were not among them, so rather than guess at agent-side session-import mechanics I left them. One is a real finding worth its own PR: `claudecode.FindCheckpointUUID` carries a comment saying it "served task checkpoint rewind… no production caller remains… should be removed", i.e. dead exported API — a deletion, not a rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only refactor with preserved JSON contract and no behavior changes to checkpoint listing, resume, or restore-logs paths.
> 
> **Overview**
> After removing the `rewind` restore path, this PR renames the surviving listing vocabulary so it matches what **`checkpoint list --pending`** actually returns: checkpoints not yet condensed onto `entire/checkpoints/v1`.
> 
> **API and types:** `RewindPoint` → `PendingCheckpoint`, `GetRewindPoints` → `ListPendingCheckpoints`, `GetLogsOnlyRewindPoints` → `ListLogsOnlyPendingCheckpoints`, and `ResolveAgentForRewind` → `ResolveAgentForResume` (resume/trail resume callers only). Strategy code moves from `manual_commit_rewind.go` to **`manual_commit_pending.go`**; log-restore tests move to **`restore_logs_test.go`**.
> 
> **User-visible surface:** Help text and empty-state messages say “pending checkpoints” instead of “pending rewind points”; the test harness step is **`list-pending-checkpoints`**. **`--pending`**, command paths, and **`checkpoint list --pending --json`** field names are unchanged so scripts that parsed deprecated `rewind --list` keep working.
> 
> **Docs and comments:** CLAUDE.md, architecture docs, and scattered comments now describe list/resume/log-restore instead of file rewind; a few stale references are corrected (e.g. agent context injection no longer lists `rewind`, `ProtectedDirs` describes checkpoint capture, and wrong command names for session cleanup helpers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcd4e868c5f0119f8511bd43dc44d7b75fb00bd4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

