### PR TITLE
fix: remove stale rewind code from agent integrations

### DIFF
--- a/cmd/entire/cli/agent/claudecode/claude.go
+++ b/cmd/entire/cli/agent/claudecode/claude.go
@@ -182,56 +182,6 @@ func (c *ClaudeCodeAgent) FormatResumeCommand(sessionID string) string {
 	return "claude -r " + sessionID
 }
 
-// Session helper methods - work on AgentSession with Claude's native JSONL data
-
-// TruncateAtUUID returns a new session truncated at the given UUID (inclusive).
-// Requires NativeData to be populated.
-func (c *ClaudeCodeAgent) TruncateAtUUID(session *agent.AgentSession, uuid string) (*agent.AgentSession, error) {
-	if session == nil {
-		return nil, errors.New("session is nil")
-	}
-
-	if len(session.NativeData) == 0 {
-		return nil, errors.New("session has no native data")
-	}
-
-	if uuid == "" {
-		// No truncation needed, return copy
-		return &agent.AgentSession{
-			SessionID:     session.SessionID,
-			AgentName:     session.AgentName,
-			RepoPath:      session.RepoPath,
-			SessionRef:    session.SessionRef,
-			StartTime:     session.StartTime,
-			NativeData:    session.NativeData,
-			ModifiedFiles: session.ModifiedFiles,
-		}, nil
-	}
-
-	// Parse, truncate, re-serialize
-	lines, err := transcript.ParseFromBytes(session.NativeData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse transcript: %w", err)
-	}
-
-	truncated := TruncateAtUUID(lines, uuid)
-
-	newData, err := SerializeTranscript(truncated)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize truncated transcript: %w", err)
-	}
-
-	return &agent.AgentSession{
-		SessionID:     session.SessionID,
-		AgentName:     session.AgentName,
-		RepoPath:      session.RepoPath,
-		SessionRef:    session.SessionRef,
-		StartTime:     session.StartTime,
-		NativeData:    newData,
-		ModifiedFiles: ExtractModifiedFiles(truncated),
-	}, nil
-}
-
 // ReadSessionFromPath is a convenience method that reads a session directly from a file path.
 // This is useful when you have the path but not a HookInput.
 func (c *ClaudeCodeAgent) ReadSessionFromPath(transcriptPath, sessionID string) (*agent.AgentSession, error) {

--- a/cmd/entire/cli/agent/claudecode/claude.go
+++ b/cmd/entire/cli/agent/claudecode/claude.go
@@ -185,7 +185,6 @@ func (c *ClaudeCodeAgent) FormatResumeCommand(sessionID string) string {
 // Session helper methods - work on AgentSession with Claude's native JSONL data
 
 // TruncateAtUUID returns a new session truncated at the given UUID (inclusive).
-// This is used for rewind operations to restore transcript state.
 // Requires NativeData to be populated.
 func (c *ClaudeCodeAgent) TruncateAtUUID(session *agent.AgentSession, uuid string) (*agent.AgentSession, error) {
 	if session == nil {
@@ -231,27 +230,6 @@ func (c *ClaudeCodeAgent) TruncateAtUUID(session *agent.AgentSession, uuid strin
 		NativeData:    newData,
 		ModifiedFiles: ExtractModifiedFiles(truncated),
 	}, nil
-}
-
-// FindCheckpointUUID finds the UUID of the message containing the tool_result
-// for the given tool use ID.
-// Returns the UUID and true if found, empty string and false otherwise.
-//
-// No production caller remains: this served task checkpoint rewind, which went
-// away with the rewind commands. Only a test exercises it now, so it should be
-// removed along with the rest of the strategy-level rewind machinery rather
-// than kept as exported-but-unreachable API.
-func (c *ClaudeCodeAgent) FindCheckpointUUID(session *agent.AgentSession, toolUseID string) (string, bool) {
-	if session == nil || len(session.NativeData) == 0 {
-		return "", false
-	}
-
-	lines, err := transcript.ParseFromBytes(session.NativeData)
-	if err != nil {
-		return "", false
-	}
-
-	return FindCheckpointUUID(lines, toolUseID)
 }
 
 // ReadSessionFromPath is a convenience method that reads a session directly from a file path.

--- a/cmd/entire/cli/agent/codex/codex.go
+++ b/cmd/entire/cli/agent/codex/codex.go
@@ -88,7 +88,7 @@ func (c *CodexAgent) GetSessionDir(_ string) (string, error) {
 
 // ResolveSessionFile returns the path to a Codex session transcript file.
 // Codex provides the transcript path directly in hook payloads as an absolute path.
-// When only a session ID is available, attach/rewind must recover it from the
+// When only a session ID is available, callers recover it from the
 // sessions/YYYY/MM/DD/rollout-...-<session-id>.jsonl layout.
 func (c *CodexAgent) ResolveSessionFile(sessionDir, agentSessionID string) string {
 	if filepath.IsAbs(agentSessionID) {

--- a/cmd/entire/cli/agent/codex/security_contract_test.go
+++ b/cmd/entire/cli/agent/codex/security_contract_test.go
@@ -14,8 +14,8 @@ import (
 // reject it first via validation.ValidateSessionID.
 //
 // This test fails if either the verbatim behavior changes silently OR the shared
-// validator stops rejecting absolute IDs — i.e. it guards the resume/rewind fix
-// from regressing out from under this agent.
+// validator stops rejecting absolute IDs — i.e. it guards checkpoint-session
+// restoration from regressing out from under this agent.
 func TestResolveSessionFile_AbsoluteVerbatim_GuardedByValidator(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/copilotcli/security_contract_test.go
+++ b/cmd/entire/cli/agent/copilotcli/security_contract_test.go
@@ -16,8 +16,8 @@ import (
 // must validate first.
 //
 // This test fails if the validator stops rejecting ".." (regressing the
-// resume/rewind guard) or if the layout changes such that the ID is no longer a
-// directory component without a matching guard update.
+// checkpoint-session restoration guard) or if the layout changes such that the
+// ID is no longer a directory component without a matching guard update.
 func TestResolveSessionFile_DirComponent_GuardedByValidator(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/opencode/opencode.go
+++ b/cmd/entire/cli/agent/opencode/opencode.go
@@ -222,22 +222,21 @@ func (a *OpenCodeAgent) WriteSession(ctx context.Context, session *agent.AgentSe
 	}
 
 	// Import the session into OpenCode's database.
-	// This enables `opencode -s <id>` for both resume and rewind.
+	// This enables `opencode -s <id>` to resume the restored session.
 	return a.importSessionIntoOpenCode(ctx, session.SessionID, session.NativeData)
 }
 
 // importSessionIntoOpenCode writes the export JSON to a temp file and runs
 // `opencode import` to restore the session into OpenCode's database.
-// For rewind (session already exists), the session is deleted first so the
-// reimport replaces it with the checkpoint-state messages.
+// An existing session is deleted first so the import replaces its messages.
 func (a *OpenCodeAgent) importSessionIntoOpenCode(ctx context.Context, sessionID string, exportData []byte) error {
 	// Delete existing session first so reimport replaces it cleanly.
 	// opencode import uses ON CONFLICT DO NOTHING, so existing messages
-	// would be skipped without this step (breaking rewind).
+	// would be skipped without this step.
 	if err := runOpenCodeSessionDelete(ctx, sessionID); err != nil {
 		// Non-fatal: session might not exist yet (first session).
-		// Import will still work for new sessions; only rewind of existing sessions
-		// would have stale messages.
+		// Import will still work for new sessions; restoring an existing session
+		// would leave stale messages.
 		logging.Warn(ctx, "could not delete existing opencode session",
 			slog.String("session_id", sessionID),
 			slog.String("error", err.Error()),

--- a/cmd/entire/cli/integration_test/agent_test.go
+++ b/cmd/entire/cli/integration_test/agent_test.go
@@ -341,44 +341,6 @@ func TestClaudeCodeHelperMethods(t *testing.T) {
 			t.Errorf("last line UUID = %q, want %q", lines[len(lines)-1].UUID, "a1")
 		}
 	})
-
-	t.Run("FindCheckpointUUID finds tool result", func(t *testing.T) {
-		t.Parallel()
-		env := NewTestEnv(t)
-
-		transcriptPath := filepath.Join(env.RepoDir, "transcript.jsonl")
-		content := `{"type":"assistant","uuid":"a1","message":{"content":[{"type":"tool_use","id":"tool-123"}]}}
-{"type":"user","uuid":"u1","message":{"content":[{"type":"tool_result","tool_use_id":"tool-123"}]}}
-`
-		if err := os.WriteFile(transcriptPath, []byte(content), 0o644); err != nil {
-			t.Fatalf("failed to write transcript: %v", err)
-		}
-
-		ag, err := agent.Get(agentClaudeCode)
-		if err != nil {
-			t.Fatalf("agent.Get(claude-code) error = %v", err)
-		}
-		ccAgent, ok := ag.(*claudecode.ClaudeCodeAgent)
-		if !ok {
-			t.Fatalf("ag is not *claudecode.ClaudeCodeAgent, got %T", ag)
-		}
-
-		session, err := ag.ReadSession(&agent.HookInput{
-			SessionID:  "test",
-			SessionRef: transcriptPath,
-		})
-		if err != nil {
-			t.Fatalf("ReadSession() error = %v", err)
-		}
-
-		uuid, found := ccAgent.FindCheckpointUUID(session, "tool-123")
-		if !found {
-			t.Error("FindCheckpointUUID() found = false, want true")
-		}
-		if uuid != "u1" {
-			t.Errorf("FindCheckpointUUID() uuid = %q, want %q", uuid, "u1")
-		}
-	})
 }
 
 // TestGeminiCLIAgentDetection verifies Gemini CLI agent detection.

--- a/cmd/entire/cli/integration_test/agent_test.go
+++ b/cmd/entire/cli/integration_test/agent_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid"
 	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/opencode" // Register OpenCode agent
-	"github.com/entireio/cli/cmd/entire/cli/transcript"
 )
 
 // TestAgentDetection verifies agent detection and default behavior.
@@ -285,60 +284,6 @@ func TestAgentSessionOperations(t *testing.T) {
 		err = ag.WriteSession(context.Background(), session)
 		if err == nil {
 			t.Error("WriteSession() should reject session from different agent")
-		}
-	})
-}
-
-// TestClaudeCodeHelperMethods verifies Claude-specific helper methods.
-func TestClaudeCodeHelperMethods(t *testing.T) {
-	t.Parallel()
-
-	t.Run("TruncateAtUUID truncates transcript", func(t *testing.T) {
-		t.Parallel()
-		env := NewTestEnv(t)
-
-		transcriptPath := filepath.Join(env.RepoDir, "transcript.jsonl")
-		content := `{"type":"user","uuid":"u1","message":{"content":"first"}}
-{"type":"assistant","uuid":"a1","message":{"content":[]}}
-{"type":"user","uuid":"u2","message":{"content":"second"}}
-{"type":"assistant","uuid":"a2","message":{"content":[]}}
-`
-		if err := os.WriteFile(transcriptPath, []byte(content), 0o644); err != nil {
-			t.Fatalf("failed to write transcript: %v", err)
-		}
-
-		ag, err := agent.Get(agentClaudeCode)
-		if err != nil {
-			t.Fatalf("agent.Get(claude-code) error = %v", err)
-		}
-		ccAgent, ok := ag.(*claudecode.ClaudeCodeAgent)
-		if !ok {
-			t.Fatalf("ag is not *claudecode.ClaudeCodeAgent, got %T", ag)
-		}
-
-		session, err := ag.ReadSession(&agent.HookInput{
-			SessionID:  "test",
-			SessionRef: transcriptPath,
-		})
-		if err != nil {
-			t.Fatalf("ReadSession() error = %v", err)
-		}
-
-		truncated, err := ccAgent.TruncateAtUUID(session, "a1")
-		if err != nil {
-			t.Fatalf("TruncateAtUUID() error = %v", err)
-		}
-
-		// Parse the truncated native data to verify
-		lines, err := transcript.ParseFromBytes(truncated.NativeData)
-		if err != nil {
-			t.Fatalf("ParseFromBytes() error = %v", err)
-		}
-		if len(lines) != 2 {
-			t.Errorf("truncated transcript has %d lines, want 2", len(lines))
-		}
-		if lines[len(lines)-1].UUID != "a1" {
-			t.Errorf("last line UUID = %q, want %q", lines[len(lines)-1].UUID, "a1")
 		}
 	})
 }


### PR DESCRIPTION
Follow-up to #2187.

The rewind restore path was removed in #2178, but several agent implementations still described rewind as a live operation. Claude Code also retained an exported `FindCheckpointUUID` wrapper with no production callers.

## The cleanup

Remove the dead `ClaudeCodeAgent.FindCheckpointUUID` method and its integration assertion.

Update the remaining Claude Code, Codex, OpenCode, and security-contract comments to describe the live checkpoint-session restoration and resume flow. The lower-level transcript parsing primitive remains independently tested and unchanged.

## Verification

- `mise run check`
- Focused Claude Code, Codex, Copilot CLI, and OpenCode package tests
- Focused `TestClaudeCodeHelperMethods` integration test