### PR TITLE
feat(search): report result selections from the CLI search TUI (ENT-2073)

### DIFF
--- a/cmd/entire/cli/search_selection_telemetry_test.go
+++ b/cmd/entire/cli/search_selection_telemetry_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/search"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
+)
+
+// The selection ledger (searchModel.selectionsReported) is the dedupe
+// mechanism, so these tests assert on it directly. emitSearchSelection is gated
+// on loaded settings and is a no-op under test, so calling reportSelection here
+// exercises the dedupe without emitting anything.
+
+func TestReportSelection_DedupesRepeatedOpensOfSameRow(t *testing.T) {
+	t.Parallel()
+	var m searchModel
+
+	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 2, 10)
+	if len(m.selectionsReported) != 1 {
+		t.Fatalf("after first selection, ledger has %d entries, want 1", len(m.selectionsReported))
+	}
+
+	// Opening the same row again (enter, esc, enter) is one act of selection.
+	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 2, 10)
+	if len(m.selectionsReported) != 1 {
+		t.Errorf("reopening the same row grew the ledger to %d entries, want 1", len(m.selectionsReported))
+	}
+}
+
+func TestReportSelection_DistinctRanksEachReport(t *testing.T) {
+	t.Parallel()
+	var m searchModel
+
+	// Digging through four results before finding the right one is itself the
+	// relevance signal, so each distinct rank must report.
+	for rank := range 4 {
+		m = m.reportSelection(telemetry.SearchModeCheckpoint, "session", rank, 12)
+	}
+	if len(m.selectionsReported) != 4 {
+		t.Errorf("ledger has %d entries after 4 distinct ranks, want 4", len(m.selectionsReported))
+	}
+}
+
+// The ledger is keyed by mode as well as rank: rank 0 on the Code tab is a
+// different result from rank 0 on the Commits tab.
+func TestReportSelection_ModesDoNotCollide(t *testing.T) {
+	t.Parallel()
+	var m searchModel
+
+	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	m = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 3)
+	if len(m.selectionsReported) != 2 {
+		t.Errorf("ledger has %d entries, want 2 — mode must be part of the key", len(m.selectionsReported))
+	}
+}
+
+func TestResetSelectionReporting_ClearsLedger(t *testing.T) {
+	t.Parallel()
+	var m searchModel
+
+	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	m = m.resetSelectionReporting()
+	if len(m.selectionsReported) != 0 {
+		t.Fatalf("ledger has %d entries after reset, want 0", len(m.selectionsReported))
+	}
+
+	// After a fresh result set, rank 0 is a different row and must report again.
+	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	if len(m.selectionsReported) != 1 {
+		t.Errorf("ledger has %d entries after re-selecting rank 0, want 1", len(m.selectionsReported))
+	}
+}
+
+// searchSelectionResultType must pass through every type the search API
+// models and clamp anything else, since Result.UnmarshalJSON assigns
+// server-supplied types verbatim.
+func TestSearchSelectionResultType(t *testing.T) {
+	t.Parallel()
+	for _, known := range []string{
+		search.TypeCheckpoint, search.TypeCommit, search.TypeSession,
+		search.TypeRepo, search.TypePR,
+	} {
+		if got := searchSelectionResultType(known); got != known {
+			t.Errorf("searchSelectionResultType(%q) = %q, want passthrough", known, got)
+		}
+	}
+
+	for _, unknown := range []string{
+		"",
+		"some-future-type",
+		// The failure this guards against: a server-supplied string that is
+		// content rather than a type discriminator.
+		"fix the login bug in auth.go",
+	} {
+		if got := searchSelectionResultType(unknown); got != telemetry.SearchSelectionTypeOther {
+			t.Errorf("searchSelectionResultType(%q) = %q, want %q", unknown, got, telemetry.SearchSelectionTypeOther)
+		}
+	}
+}

--- a/cmd/entire/cli/search_selection_telemetry_test.go
+++ b/cmd/entire/cli/search_selection_telemetry_test.go
@@ -22,13 +22,13 @@ func TestReportSelection_DedupesRepeatedOpensOfSameRow(t *testing.T) {
 	t.Parallel()
 	var m searchModel
 
-	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 2, 10)
+	m, _ = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 2, 10)
 	if m.reportedCount() != 1 {
 		t.Fatalf("after first selection, ledger has %d entries, want 1", m.reportedCount())
 	}
 
 	// Opening the same row again (enter, esc, enter) is one act of selection.
-	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 2, 10)
+	m, _ = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 2, 10)
 	if m.reportedCount() != 1 {
 		t.Errorf("reopening the same row grew the ledger to %d entries, want 1", m.reportedCount())
 	}
@@ -41,7 +41,7 @@ func TestReportSelection_DistinctRanksEachReport(t *testing.T) {
 	// Digging through four results before finding the right one is itself the
 	// relevance signal, so each distinct rank must report.
 	for rank := range 4 {
-		m = m.reportSelection(telemetry.SearchModeCheckpoint, "session", rank, 12)
+		m, _ = m.reportSelection(telemetry.SearchModeCheckpoint, "session", rank, 12)
 	}
 	if m.reportedCount() != 4 {
 		t.Errorf("ledger has %d entries after 4 distinct ranks, want 4", m.reportedCount())
@@ -54,9 +54,9 @@ func TestReportSelection_TabsDoNotCollide(t *testing.T) {
 	t.Parallel()
 	m := searchModel{filterType: typeFilterCommits}
 
-	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	m, _ = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
 	m = m.switchTab(typeFilterCode)
-	m = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 3)
+	m, _ = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 3)
 	if m.reportedCount() != 2 {
 		t.Errorf("ledger has %d entries, want 2 — tab must be part of the key", m.reportedCount())
 	}
@@ -71,12 +71,12 @@ func TestReportSelection_SameModeDifferentTabsBothReport(t *testing.T) {
 	t.Parallel()
 	m := searchModel{filterType: typeFilterCommits}
 
-	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	m, _ = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
 	m = m.switchTab(typeFilterSessions)
 	if m.cursor != 0 {
 		t.Fatalf("switchTab left cursor at %d, want 0 — the premise of this test", m.cursor)
 	}
-	m = m.reportSelection(telemetry.SearchModeCheckpoint, "session", 0, 10)
+	m, _ = m.reportSelection(telemetry.SearchModeCheckpoint, "session", 0, 10)
 
 	if m.reportedCount() != 2 {
 		t.Errorf("ledger has %d entries, want 2 — rank 0 on Commits and rank 0 on Sessions are different results", m.reportedCount())
@@ -87,14 +87,14 @@ func TestResetSemanticSelectionReporting_ClearsLedger(t *testing.T) {
 	t.Parallel()
 	m := searchModel{filterType: typeFilterCommits}
 
-	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	m, _ = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
 	m = m.resetSemanticSelectionReporting()
 	if m.reportedCount() != 0 {
 		t.Fatalf("ledger has %d entries after reset, want 0", m.reportedCount())
 	}
 
 	// After a fresh result set, rank 0 is a different row and must report again.
-	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	m, _ = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
 	if m.reportedCount() != 1 {
 		t.Errorf("ledger has %d entries after re-selecting rank 0, want 1", m.reportedCount())
 	}
@@ -110,7 +110,7 @@ func TestSelectionLedgers_SiblingRefreshDoesNotClearTheOtherSet(t *testing.T) {
 
 	// User is on the Code tab and opens the top code result.
 	m := searchModel{filterType: typeFilterCode}
-	m = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 5)
+	m, _ = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 5)
 	if len(m.codeSelectionsReported) != 1 {
 		t.Fatalf("code ledger has %d entries, want 1", len(m.codeSelectionsReported))
 	}
@@ -122,14 +122,14 @@ func TestSelectionLedgers_SiblingRefreshDoesNotClearTheOtherSet(t *testing.T) {
 	}
 
 	// Re-opening that same unchanged code row must NOT report again.
-	m = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 5)
+	m, _ = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 5)
 	if len(m.codeSelectionsReported) != 1 {
 		t.Errorf("re-opening the same code row after a semantic refresh double-reported (%d entries, want 1)", len(m.codeSelectionsReported))
 	}
 
 	// And the mirror case: a new code search must not clear semantic keys.
 	m2 := searchModel{filterType: typeFilterCommits}
-	m2 = m2.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	m2, _ = m2.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
 	m2 = m2.resetCodeSelectionReporting()
 	if len(m2.semanticSelectionsReported) != 1 {
 		t.Errorf("code refresh cleared the semantic ledger (%d entries, want 1)", len(m2.semanticSelectionsReported))
@@ -160,5 +160,42 @@ func TestSearchSelectionResultType(t *testing.T) {
 		if got := searchSelectionResultType(unknown); got != telemetry.SearchSelectionTypeOther {
 			t.Errorf("searchSelectionResultType(%q) = %q, want %q", unknown, got, telemetry.SearchSelectionTypeOther)
 		}
+	}
+}
+
+// The emit must be handed back as a tea.Cmd, never run inline: it loads
+// settings (a stat, a directory scan, and a git-backed tracked-file probe) and
+// forks the analytics process, which would stall bubbletea's single-threaded
+// Update loop on every Enter press. A first selection therefore returns a
+// non-nil Cmd, and an already-reported one returns nil so no needless work is
+// scheduled. Found by trail review on this branch.
+func TestReportSelection_DefersEmitToACommand(t *testing.T) {
+	t.Parallel()
+	m := searchModel{filterType: typeFilterCommits}
+
+	m, emit := m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	if emit == nil {
+		t.Fatal("first selection returned a nil Cmd — the emit must be deferred, not run inline")
+	}
+
+	_, repeat := m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	if repeat != nil {
+		t.Error("an already-reported selection returned a non-nil Cmd, scheduling a duplicate emit")
+	}
+}
+
+// The returned Cmd must be runnable and produce no follow-up message, so it
+// cannot loop the Update cycle. Telemetry itself is gated off under test, so
+// running it here exercises the wiring rather than emitting anything.
+func TestReportSelection_CommandReturnsNoMessage(t *testing.T) {
+	t.Parallel()
+	m := searchModel{filterType: typeFilterCode}
+
+	_, emit := m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 3)
+	if emit == nil {
+		t.Fatal("expected a Cmd")
+	}
+	if msg := emit(); msg != nil {
+		t.Errorf("Cmd returned %T, want nil — it must not trigger another Update", msg)
 	}
 }

--- a/cmd/entire/cli/search_selection_telemetry_test.go
+++ b/cmd/entire/cli/search_selection_telemetry_test.go
@@ -7,24 +7,30 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 )
 
-// The selection ledger (searchModel.selectionsReported) is the dedupe
-// mechanism, so these tests assert on it directly. emitSearchSelection is gated
-// on loaded settings and is a no-op under test, so calling reportSelection here
-// exercises the dedupe without emitting anything.
+// The selection ledgers (searchModel.semanticSelectionsReported /
+// codeSelectionsReported) are the dedupe mechanism, so these tests assert on
+// them directly. emitSearchSelection is gated on loaded settings and is a no-op
+// under test, so calling reportSelection here exercises the dedupe without
+// emitting anything.
+
+// reportedCount is the total across both ledgers.
+func (m searchModel) reportedCount() int {
+	return len(m.semanticSelectionsReported) + len(m.codeSelectionsReported)
+}
 
 func TestReportSelection_DedupesRepeatedOpensOfSameRow(t *testing.T) {
 	t.Parallel()
 	var m searchModel
 
 	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 2, 10)
-	if len(m.selectionsReported) != 1 {
-		t.Fatalf("after first selection, ledger has %d entries, want 1", len(m.selectionsReported))
+	if m.reportedCount() != 1 {
+		t.Fatalf("after first selection, ledger has %d entries, want 1", m.reportedCount())
 	}
 
 	// Opening the same row again (enter, esc, enter) is one act of selection.
 	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 2, 10)
-	if len(m.selectionsReported) != 1 {
-		t.Errorf("reopening the same row grew the ledger to %d entries, want 1", len(m.selectionsReported))
+	if m.reportedCount() != 1 {
+		t.Errorf("reopening the same row grew the ledger to %d entries, want 1", m.reportedCount())
 	}
 }
 
@@ -37,8 +43,8 @@ func TestReportSelection_DistinctRanksEachReport(t *testing.T) {
 	for rank := range 4 {
 		m = m.reportSelection(telemetry.SearchModeCheckpoint, "session", rank, 12)
 	}
-	if len(m.selectionsReported) != 4 {
-		t.Errorf("ledger has %d entries after 4 distinct ranks, want 4", len(m.selectionsReported))
+	if m.reportedCount() != 4 {
+		t.Errorf("ledger has %d entries after 4 distinct ranks, want 4", m.reportedCount())
 	}
 }
 
@@ -51,8 +57,8 @@ func TestReportSelection_TabsDoNotCollide(t *testing.T) {
 	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
 	m = m.switchTab(typeFilterCode)
 	m = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 3)
-	if len(m.selectionsReported) != 2 {
-		t.Errorf("ledger has %d entries, want 2 — tab must be part of the key", len(m.selectionsReported))
+	if m.reportedCount() != 2 {
+		t.Errorf("ledger has %d entries, want 2 — tab must be part of the key", m.reportedCount())
 	}
 }
 
@@ -72,25 +78,61 @@ func TestReportSelection_SameModeDifferentTabsBothReport(t *testing.T) {
 	}
 	m = m.reportSelection(telemetry.SearchModeCheckpoint, "session", 0, 10)
 
-	if len(m.selectionsReported) != 2 {
-		t.Errorf("ledger has %d entries, want 2 — rank 0 on Commits and rank 0 on Sessions are different results", len(m.selectionsReported))
+	if m.reportedCount() != 2 {
+		t.Errorf("ledger has %d entries, want 2 — rank 0 on Commits and rank 0 on Sessions are different results", m.reportedCount())
 	}
 }
 
-func TestResetSelectionReporting_ClearsLedger(t *testing.T) {
+func TestResetSemanticSelectionReporting_ClearsLedger(t *testing.T) {
 	t.Parallel()
-	var m searchModel
+	m := searchModel{filterType: typeFilterCommits}
 
 	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
-	m = m.resetSelectionReporting()
-	if len(m.selectionsReported) != 0 {
-		t.Fatalf("ledger has %d entries after reset, want 0", len(m.selectionsReported))
+	m = m.resetSemanticSelectionReporting()
+	if m.reportedCount() != 0 {
+		t.Fatalf("ledger has %d entries after reset, want 0", m.reportedCount())
 	}
 
 	// After a fresh result set, rank 0 is a different row and must report again.
 	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
-	if len(m.selectionsReported) != 1 {
-		t.Errorf("ledger has %d entries after re-selecting rank 0, want 1", len(m.selectionsReported))
+	if m.reportedCount() != 1 {
+		t.Errorf("ledger has %d entries after re-selecting rank 0, want 1", m.reportedCount())
+	}
+}
+
+// Regression: one query dispatches both a semantic and a code search, and
+// either can land first. With a single shared ledger, the slower sibling's
+// arrival cleared the keys of the set the user was actually looking at, so
+// re-opening an unchanged row reported a second time. Each ledger must be
+// reset only by its own set's refresh. Found by bugbot on this branch.
+func TestSelectionLedgers_SiblingRefreshDoesNotClearTheOtherSet(t *testing.T) {
+	t.Parallel()
+
+	// User is on the Code tab and opens the top code result.
+	m := searchModel{filterType: typeFilterCode}
+	m = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 5)
+	if len(m.codeSelectionsReported) != 1 {
+		t.Fatalf("code ledger has %d entries, want 1", len(m.codeSelectionsReported))
+	}
+
+	// The slower semantic response now lands. Code results are unchanged.
+	m = m.resetSemanticSelectionReporting()
+	if len(m.codeSelectionsReported) != 1 {
+		t.Fatalf("semantic refresh cleared the code ledger (%d entries, want 1)", len(m.codeSelectionsReported))
+	}
+
+	// Re-opening that same unchanged code row must NOT report again.
+	m = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 5)
+	if len(m.codeSelectionsReported) != 1 {
+		t.Errorf("re-opening the same code row after a semantic refresh double-reported (%d entries, want 1)", len(m.codeSelectionsReported))
+	}
+
+	// And the mirror case: a new code search must not clear semantic keys.
+	m2 := searchModel{filterType: typeFilterCommits}
+	m2 = m2.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	m2 = m2.resetCodeSelectionReporting()
+	if len(m2.semanticSelectionsReported) != 1 {
+		t.Errorf("code refresh cleared the semantic ledger (%d entries, want 1)", len(m2.semanticSelectionsReported))
 	}
 }
 

--- a/cmd/entire/cli/search_selection_telemetry_test.go
+++ b/cmd/entire/cli/search_selection_telemetry_test.go
@@ -42,16 +42,38 @@ func TestReportSelection_DistinctRanksEachReport(t *testing.T) {
 	}
 }
 
-// The ledger is keyed by mode as well as rank: rank 0 on the Code tab is a
+// The ledger is keyed by tab as well as rank: rank 0 on the Code tab is a
 // different result from rank 0 on the Commits tab.
-func TestReportSelection_ModesDoNotCollide(t *testing.T) {
+func TestReportSelection_TabsDoNotCollide(t *testing.T) {
 	t.Parallel()
-	var m searchModel
+	m := searchModel{filterType: typeFilterCommits}
 
 	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	m = m.switchTab(typeFilterCode)
 	m = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, 0, 3)
 	if len(m.selectionsReported) != 2 {
-		t.Errorf("ledger has %d entries, want 2 — mode must be part of the key", len(m.selectionsReported))
+		t.Errorf("ledger has %d entries, want 2 — tab must be part of the key", len(m.selectionsReported))
+	}
+}
+
+// Regression: Commits and Sessions both report mode "checkpoint", and
+// switchTab resets the cursor to 0 without clearing the ledger. Keying the
+// ledger on the reported mode therefore swallowed rank 0 on whichever of the
+// two tabs the user visited second — an ordinary navigation flow, silently
+// undercounted. Found by trail review on this branch.
+func TestReportSelection_SameModeDifferentTabsBothReport(t *testing.T) {
+	t.Parallel()
+	m := searchModel{filterType: typeFilterCommits}
+
+	m = m.reportSelection(telemetry.SearchModeCheckpoint, "commit", 0, 10)
+	m = m.switchTab(typeFilterSessions)
+	if m.cursor != 0 {
+		t.Fatalf("switchTab left cursor at %d, want 0 — the premise of this test", m.cursor)
+	}
+	m = m.reportSelection(telemetry.SearchModeCheckpoint, "session", 0, 10)
+
+	if len(m.selectionsReported) != 2 {
+		t.Errorf("ledger has %d entries, want 2 — rank 0 on Commits and rank 0 on Sessions are different results", len(m.selectionsReported))
 	}
 }
 

--- a/cmd/entire/cli/search_telemetry.go
+++ b/cmd/entire/cli/search_telemetry.go
@@ -122,3 +122,42 @@ func instrumentSemanticSearcher(command string, searcher semanticSearcher) seman
 		return resp, err
 	}
 }
+
+// emitSearchSelection reports that the user opened one search result, when
+// telemetry is opted in (settings.Telemetry == true). Content-free: enums,
+// counts, and the selected result's rank only — never query text, result
+// titles, repo names, or file paths. Best-effort and non-blocking; failures to
+// load settings suppress the event.
+//
+// Gating is deliberately identical to emitSearchOutcome's, so a user opted out
+// of one search event is opted out of both.
+func emitSearchSelection(ctx context.Context, selection telemetry.SearchSelection) {
+	if telemetry.IsEnvOptedOut() {
+		return
+	}
+	s, loadErr := LoadEntireSettings(ctx)
+	if loadErr != nil || !s.IsTelemetryEnabled() {
+		return
+	}
+
+	telemetry.TrackSearchSelectionDetached(selection, s.Enabled, versioninfo.Version)
+}
+
+// searchSelectionResultType clamps a semantic result's type to the vocabulary
+// the search API is known to emit, mapping anything else to "other".
+//
+// This is not defensive padding: search.Result.UnmarshalJSON assigns
+// raw.Type verbatim and its default branch accepts types it does not model, so
+// an unrecognized string from a newer (or misbehaving) server would otherwise
+// reach PostHog as a property value. Clamping is what makes SearchSelection's
+// "content-free by construction" claim true here rather than a matter of
+// trusting the server, and it keeps the property's cardinality bounded. A new
+// result type added server-side lands in "other" until it is added below.
+func searchSelectionResultType(resultType string) string {
+	switch resultType {
+	case search.TypeCheckpoint, search.TypeCommit, search.TypeSession, search.TypeRepo, search.TypePR:
+		return resultType
+	default:
+		return telemetry.SearchSelectionTypeOther
+	}
+}

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -192,13 +192,20 @@ type searchModel struct {
 	codeSearchGen  uint64              // generation counter; incremented on each new code search
 
 	// selectionsReported dedupes cli_search_result_selected within one result
-	// set, keyed by "<mode>:<rank>". Opening a result, backing out, and opening
+	// set, keyed by "<tab>:<rank>". Opening a result, backing out, and opening
 	// it again is one act of selection, not two, so an idle enter/esc/enter must
 	// not inflate the click-through rate. Distinct ranks still each report —
 	// having to open four results before finding the right one is itself the
 	// signal. Reset whenever a fresh result set replaces the old one (see
 	// resetSelectionReporting); a map field on this value-type model is shared
 	// by reference across copies, which is what lets a write in Update persist.
+	//
+	// The key is the TAB, not the reported mode: Commits and Sessions both
+	// report mode "checkpoint", and switching tabs resets the cursor to 0
+	// without clearing this ledger, so a mode-keyed ledger silently swallowed
+	// rank 0 on the second tab the user visited. The tab is also the coordinate
+	// space cursor actually indexes into, which is what makes it the correct
+	// discriminator rather than merely a wider one.
 	selectionsReported map[string]bool
 }
 
@@ -360,14 +367,17 @@ func (m searchModel) resetSelectionReporting() searchModel {
 }
 
 // reportSelection emits one cli_search_result_selected for the row the user
-// just opened, at most once per (mode, rank) per result set. Called from the
+// just opened, at most once per (tab, rank) per result set. Called from the
 // Confirm key handler — the single seam both tabs' detail views open through,
 // so this is the CLI's equivalent of a search-result click.
+//
+// Dedupe is keyed on the active tab rather than the reported mode; see the
+// selectionsReported field comment for why the distinction matters.
 //
 // Content-free: the result's type enum, its rank, and the size of the list it
 // came from. Nothing derived from the query or from what the result says.
 func (m searchModel) reportSelection(mode, resultType string, rank, resultCount int) searchModel {
-	key := mode + ":" + strconv.Itoa(rank)
+	key := string(m.filterType) + ":" + strconv.Itoa(rank)
 	if m.selectionsReported[key] {
 		return m
 	}

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -382,18 +382,29 @@ func (m searchModel) resetCodeSelectionReporting() searchModel {
 	return m
 }
 
-// reportSelection emits one cli_search_result_selected for the row the user
-// just opened, at most once per (tab, rank) per result set. Called from the
-// Confirm key handler — the single seam both tabs' detail views open through,
-// so this is the CLI's equivalent of a search-result click.
+// reportSelection records that the user opened a row and returns the tea.Cmd
+// that emits its cli_search_result_selected, at most once per (tab, rank) per
+// result set. Called from the Confirm key handler — the single seam both tabs'
+// detail views open through, so this is the CLI's equivalent of a
+// search-result click. Returns a nil Cmd when the selection was already
+// reported.
 //
 // Dedupe is keyed on the active tab and recorded in the ledger belonging to
 // that tab's result set; see the ledger field comment for why both the key and
 // the split matter.
 //
+// The ledger write is synchronous (a map write, and it must be ordered against
+// the key press) but the EMIT is not: it is handed back as a tea.Cmd so
+// bubbletea runs it off the Update loop. emitSearchSelection loads settings —
+// a stat plus a directory scan plus a git-backed tracked-file probe, single-digit
+// to tens of milliseconds depending on the ref backend — and then forks the
+// detached analytics process. Doing that inline would stall the single-threaded
+// Update loop on every Enter press. This matches the outcome event, which only
+// ever emits from inside the async searcher Cmd.
+//
 // Content-free: the result's type enum, its rank, and the size of the list it
 // came from. Nothing derived from the query or from what the result says.
-func (m searchModel) reportSelection(mode, resultType string, rank, resultCount int) searchModel {
+func (m searchModel) reportSelection(mode, resultType string, rank, resultCount int) (searchModel, tea.Cmd) {
 	key := string(m.filterType) + ":" + strconv.Itoa(rank)
 	isCode := m.filterType == typeFilterCode
 
@@ -402,7 +413,7 @@ func (m searchModel) reportSelection(mode, resultType string, rank, resultCount 
 		ledger = m.codeSelectionsReported
 	}
 	if ledger[key] {
-		return m
+		return m, nil
 	}
 	if ledger == nil {
 		ledger = make(map[string]bool)
@@ -414,17 +425,21 @@ func (m searchModel) reportSelection(mode, resultType string, rank, resultCount 
 	}
 	ledger[key] = true
 
-	// context.Background matches the other telemetry/search call sites in this
-	// file: bubbletea's Update carries no context, and the emit is detached and
-	// best-effort, so there is nothing for a cancellable context to cancel.
-	emitSearchSelection(context.Background(), telemetry.SearchSelection{
+	selection := telemetry.SearchSelection{
 		Command:     searchTUICommandPath,
 		Mode:        mode,
 		ResultType:  resultType,
 		Rank:        rank,
 		ResultCount: resultCount,
-	})
-	return m
+	}
+	return m, func() tea.Msg {
+		// context.Background matches the other telemetry/search call sites in
+		// this file: the emit is detached and best-effort, so there is nothing
+		// for a cancellable context to cancel. Returning nil produces no
+		// follow-up Update.
+		emitSearchSelection(context.Background(), selection)
+		return nil
+	}
 }
 
 func (m searchModel) Init() tea.Cmd {
@@ -729,22 +744,24 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		// the detail view is open can't move the highlight underneath it.
 		if m.filterType == typeFilterCode {
 			if r := m.selectedCodeResult(); r != nil {
-				m = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, m.cursor, len(m.codeResults))
+				var emit tea.Cmd
+				m, emit = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, m.cursor, len(m.codeResults))
 				m.mode = modeDetail
 				m.pinToEnd = false
 				content := m.renderCodeDetail(*r, m.width, true)
 				m.detailVP = viewport.New(viewport.WithWidth(m.width), viewport.WithHeight(max(m.height-2, 1)))
 				m.detailVP.SetContent(content)
-				return m, nil
+				return m, emit
 			}
 		} else if r := m.selectedResult(); r != nil {
-			m = m.reportSelection(telemetry.SearchModeCheckpoint, searchSelectionResultType(r.Type), m.cursor, m.visibleCount())
+			var emit tea.Cmd
+			m, emit = m.reportSelection(telemetry.SearchModeCheckpoint, searchSelectionResultType(r.Type), m.cursor, m.visibleCount())
 			m.mode = modeDetail
 			m.pinToEnd = false
 			content := m.renderDetailContent(*r, m.width, true)
 			m.detailVP = viewport.New(viewport.WithWidth(m.width), viewport.WithHeight(max(m.height-2, 1)))
 			m.detailVP.SetContent(content)
-			return m, nil
+			return m, emit
 		}
 	case key.Matches(msg, keys.Search):
 		m.mode = modeSearch

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -191,22 +191,29 @@ type searchModel struct {
 	codeSearchOpts codeSearchOpts      // opts for code search (set by caller)
 	codeSearchGen  uint64              // generation counter; incremented on each new code search
 
-	// selectionsReported dedupes cli_search_result_selected within one result
-	// set, keyed by "<tab>:<rank>". Opening a result, backing out, and opening
-	// it again is one act of selection, not two, so an idle enter/esc/enter must
+	// selection ledgers dedupe cli_search_result_selected within one result set,
+	// keyed by "<tab>:<rank>". Opening a result, backing out, and opening it
+	// again is one act of selection, not two, so an idle enter/esc/enter must
 	// not inflate the click-through rate. Distinct ranks still each report —
 	// having to open four results before finding the right one is itself the
-	// signal. Reset whenever a fresh result set replaces the old one (see
-	// resetSelectionReporting); a map field on this value-type model is shared
-	// by reference across copies, which is what lets a write in Update persist.
+	// signal. A map field on this value-type model is shared by reference across
+	// copies, which is what lets a write in Update persist.
 	//
 	// The key is the TAB, not the reported mode: Commits and Sessions both
 	// report mode "checkpoint", and switching tabs resets the cursor to 0
-	// without clearing this ledger, so a mode-keyed ledger silently swallowed
+	// without clearing the ledger, so a mode-keyed ledger silently swallowed
 	// rank 0 on the second tab the user visited. The tab is also the coordinate
 	// space cursor actually indexes into, which is what makes it the correct
 	// discriminator rather than merely a wider one.
-	selectionsReported map[string]bool
+	//
+	// There are TWO ledgers because the semantic and code result sets refresh on
+	// independent schedules — one query dispatches both, and either can land
+	// first. A single shared ledger is therefore cleared by the *sibling* set's
+	// refresh: open a code row, let the slower semantic response land, and
+	// re-opening that same unchanged code row reports a second time. Each ledger
+	// is reset only by the refresh of the set it belongs to.
+	semanticSelectionsReported map[string]bool
+	codeSelectionsReported     map[string]bool
 }
 
 // codeSearchWarning summarizes a code response's scope loss for the status
@@ -357,12 +364,21 @@ func newSearchModel(results []search.Result, query string, total int, cfg search
 	return m
 }
 
-// resetSelectionReporting clears the per-result-set selection dedupe so the
-// next result set reports its own selections. Called wherever a fresh set
-// replaces the previous one — never on pagination, which appends to the set
-// the user is already looking at and whose earlier ranks are unchanged.
-func (m searchModel) resetSelectionReporting() searchModel {
-	m.selectionsReported = nil
+// resetSemanticSelectionReporting clears the semantic (non-code tabs) selection
+// dedupe so the next semantic result set reports its own selections. Called
+// wherever a fresh semantic set replaces the previous one — never on
+// pagination, which appends to the set the user is already looking at and whose
+// earlier ranks are unchanged. Deliberately leaves the code ledger alone: the
+// code results are unchanged by a semantic refresh.
+func (m searchModel) resetSemanticSelectionReporting() searchModel {
+	m.semanticSelectionsReported = nil
+	return m
+}
+
+// resetCodeSelectionReporting is the code-tab counterpart, called when a new
+// code search is dispatched. Likewise leaves the semantic ledger alone.
+func (m searchModel) resetCodeSelectionReporting() searchModel {
+	m.codeSelectionsReported = nil
 	return m
 }
 
@@ -371,20 +387,32 @@ func (m searchModel) resetSelectionReporting() searchModel {
 // Confirm key handler — the single seam both tabs' detail views open through,
 // so this is the CLI's equivalent of a search-result click.
 //
-// Dedupe is keyed on the active tab rather than the reported mode; see the
-// selectionsReported field comment for why the distinction matters.
+// Dedupe is keyed on the active tab and recorded in the ledger belonging to
+// that tab's result set; see the ledger field comment for why both the key and
+// the split matter.
 //
 // Content-free: the result's type enum, its rank, and the size of the list it
 // came from. Nothing derived from the query or from what the result says.
 func (m searchModel) reportSelection(mode, resultType string, rank, resultCount int) searchModel {
 	key := string(m.filterType) + ":" + strconv.Itoa(rank)
-	if m.selectionsReported[key] {
+	isCode := m.filterType == typeFilterCode
+
+	ledger := m.semanticSelectionsReported
+	if isCode {
+		ledger = m.codeSelectionsReported
+	}
+	if ledger[key] {
 		return m
 	}
-	if m.selectionsReported == nil {
-		m.selectionsReported = make(map[string]bool)
+	if ledger == nil {
+		ledger = make(map[string]bool)
+		if isCode {
+			m.codeSelectionsReported = ledger
+		} else {
+			m.semanticSelectionsReported = ledger
+		}
 	}
-	m.selectionsReported[key] = true
+	ledger[key] = true
 
 	// context.Background matches the other telemetry/search call sites in this
 	// file: bubbletea's Update carries no context, and the emit is detached and
@@ -421,8 +449,9 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 			return m, nil
 		}
 		m.searchErr = ""
-		// A fresh set: previously reported ranks now index different rows.
-		m = m.resetSelectionReporting()
+		// A fresh semantic set: previously reported ranks now index different
+		// rows. The code ledger is untouched — code results did not change.
+		m = m.resetSemanticSelectionReporting()
 		m.results = msg.results
 		m.total = msg.total
 		m.counts = msg.counts
@@ -562,7 +591,7 @@ func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 				}
 			}
 			m.codeSearchGen++
-			m = m.resetSelectionReporting()
+			m = m.resetCodeSelectionReporting()
 			m.codeLoading = true
 			m.codeResults = nil
 			m.codeSearchErr = ""
@@ -574,7 +603,7 @@ func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 			// from a prior query is discarded when it completes. Nothing
 			// will arrive to overwrite the warning, so clear it here too.
 			m.codeSearchGen++
-			m = m.resetSelectionReporting()
+			m = m.resetCodeSelectionReporting()
 			m.codeLoading = false
 			m.codeResults = nil
 			m.codeSearchErr = ""

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -21,8 +21,14 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/palette"
 	"github.com/entireio/cli/cmd/entire/cli/search"
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/muesli/termenv"
 )
+
+// searchTUICommandPath is the command label reported on telemetry emitted from
+// inside the TUI. The TUI outlives the cobra command layer that launched it, so
+// the path is fixed here rather than read from a *cobra.Command at emit time.
+const searchTUICommandPath = "entire search"
 
 // searchMode tracks whether the user is browsing results or editing the search bar.
 type searchMode int
@@ -184,6 +190,16 @@ type searchModel struct {
 	codeWarning    string              // code tab's completeness note (failed regions, skipped repos)
 	codeSearchOpts codeSearchOpts      // opts for code search (set by caller)
 	codeSearchGen  uint64              // generation counter; incremented on each new code search
+
+	// selectionsReported dedupes cli_search_result_selected within one result
+	// set, keyed by "<mode>:<rank>". Opening a result, backing out, and opening
+	// it again is one act of selection, not two, so an idle enter/esc/enter must
+	// not inflate the click-through rate. Distinct ranks still each report —
+	// having to open four results before finding the right one is itself the
+	// signal. Reset whenever a fresh result set replaces the old one (see
+	// resetSelectionReporting); a map field on this value-type model is shared
+	// by reference across copies, which is what lets a write in Update persist.
+	selectionsReported map[string]bool
 }
 
 // codeSearchWarning summarizes a code response's scope loss for the status
@@ -321,7 +337,7 @@ func newSearchModel(results []search.Result, query string, total int, cfg search
 		filterType: typeFilterCommits, // default to the leftmost tab (Commits), matching the web UI order
 		// Command layer overrides with its session searcher; instrumented
 		// anyway so a forgotten override never silently drops telemetry.
-		semanticSearch: instrumentSemanticSearcher("entire search", newSemanticSearcher(false)),
+		semanticSearch: instrumentSemanticSearcher(searchTUICommandPath, newSemanticSearcher(false)),
 	}
 	if codeOpts != nil {
 		m.codeSearchOpts = *codeOpts
@@ -331,6 +347,45 @@ func newSearchModel(results []search.Result, query string, total int, cfg search
 		}
 	}
 	m = m.refreshBrowseContent()
+	return m
+}
+
+// resetSelectionReporting clears the per-result-set selection dedupe so the
+// next result set reports its own selections. Called wherever a fresh set
+// replaces the previous one — never on pagination, which appends to the set
+// the user is already looking at and whose earlier ranks are unchanged.
+func (m searchModel) resetSelectionReporting() searchModel {
+	m.selectionsReported = nil
+	return m
+}
+
+// reportSelection emits one cli_search_result_selected for the row the user
+// just opened, at most once per (mode, rank) per result set. Called from the
+// Confirm key handler — the single seam both tabs' detail views open through,
+// so this is the CLI's equivalent of a search-result click.
+//
+// Content-free: the result's type enum, its rank, and the size of the list it
+// came from. Nothing derived from the query or from what the result says.
+func (m searchModel) reportSelection(mode, resultType string, rank, resultCount int) searchModel {
+	key := mode + ":" + strconv.Itoa(rank)
+	if m.selectionsReported[key] {
+		return m
+	}
+	if m.selectionsReported == nil {
+		m.selectionsReported = make(map[string]bool)
+	}
+	m.selectionsReported[key] = true
+
+	// context.Background matches the other telemetry/search call sites in this
+	// file: bubbletea's Update carries no context, and the emit is detached and
+	// best-effort, so there is nothing for a cancellable context to cancel.
+	emitSearchSelection(context.Background(), telemetry.SearchSelection{
+		Command:     searchTUICommandPath,
+		Mode:        mode,
+		ResultType:  resultType,
+		Rank:        rank,
+		ResultCount: resultCount,
+	})
 	return m
 }
 
@@ -356,6 +411,8 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 			return m, nil
 		}
 		m.searchErr = ""
+		// A fresh set: previously reported ranks now index different rows.
+		m = m.resetSelectionReporting()
 		m.results = msg.results
 		m.total = msg.total
 		m.counts = msg.counts
@@ -495,6 +552,7 @@ func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 				}
 			}
 			m.codeSearchGen++
+			m = m.resetSelectionReporting()
 			m.codeLoading = true
 			m.codeResults = nil
 			m.codeSearchErr = ""
@@ -506,6 +564,7 @@ func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 			// from a prior query is discarded when it completes. Nothing
 			// will arrive to overwrite the warning, so clear it here too.
 			m.codeSearchGen++
+			m = m.resetSelectionReporting()
 			m.codeLoading = false
 			m.codeResults = nil
 			m.codeSearchErr = ""
@@ -631,6 +690,7 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		// the detail view is open can't move the highlight underneath it.
 		if m.filterType == typeFilterCode {
 			if r := m.selectedCodeResult(); r != nil {
+				m = m.reportSelection(telemetry.SearchModeCode, telemetry.SearchSelectionTypeCode, m.cursor, len(m.codeResults))
 				m.mode = modeDetail
 				m.pinToEnd = false
 				content := m.renderCodeDetail(*r, m.width, true)
@@ -639,6 +699,7 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 				return m, nil
 			}
 		} else if r := m.selectedResult(); r != nil {
+			m = m.reportSelection(telemetry.SearchModeCheckpoint, searchSelectionResultType(r.Type), m.cursor, m.visibleCount())
 			m.mode = modeDetail
 			m.pinToEnd = false
 			content := m.renderDetailContent(*r, m.width, true)

--- a/cmd/entire/cli/telemetry/search_selection.go
+++ b/cmd/entire/cli/telemetry/search_selection.go
@@ -1,0 +1,95 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"runtime"
+	"time"
+)
+
+// SearchSelectionTypeCode is the result_type reported for a code-search hit.
+// Semantic results carry their own type from the search API (checkpoint,
+// commit, session, ...); code results have no such field, so they are
+// reported under this single kind.
+const SearchSelectionTypeCode = "code"
+
+// SearchSelectionTypeOther is the result_type reported for a semantic result
+// whose type is outside the vocabulary the CLI models. The search API's
+// decoder passes unrecognized types through verbatim, so the cli package
+// clamps to this rather than forwarding an arbitrary server-supplied string
+// (see searchSelectionResultType).
+const SearchSelectionTypeOther = "other"
+
+// SearchSelection carries one act of the user opening a search result
+// (ENT-2073) — the CLI counterpart of the web app's search_result_clicked.
+// Without it, cli_search_completed can say a search returned results but not
+// whether any of them were worth opening, which is the click-through half of
+// "is search any good?".
+//
+// Content-free by construction, exactly like SearchOutcome: enums, counts,
+// and positions only — never query text, result titles, repo names, file
+// paths, or snippets.
+type SearchSelection struct {
+	// Command is the invoked cobra command path ("entire search").
+	Command string
+	// Mode is SearchModeCheckpoint or SearchModeCode.
+	Mode string
+	// ResultType is the selected result's kind — the search API's own enum
+	// (search.TypeCheckpoint, TypeCommit, TypeSession, ...) for semantic
+	// results, or SearchSelectionTypeCode for code hits. A fixed vocabulary,
+	// never user content.
+	ResultType string
+	// Rank is the selected result's zero-based position in the list the user
+	// was looking at. This is the core relevance signal: a healthy ranker is
+	// selected at rank 0 far more often than at rank 20.
+	Rank int
+	// ResultCount is how many results were loaded in the active tab when the
+	// selection happened, so Rank can be read against the size of the list it
+	// indexes into.
+	ResultCount int
+}
+
+// BuildSearchSelectionPayload constructs the cli_search_result_selected
+// payload. Exported for testing. Returns nil if the machine ID cannot be
+// resolved.
+func BuildSearchSelectionPayload(selection SearchSelection, isEntireEnabled bool, version string) *EventPayload {
+	machineID, err := telemetryMachineID()
+	if err != nil {
+		return nil
+	}
+
+	return &EventPayload{
+		Event:      "cli_search_result_selected",
+		DistinctID: machineID,
+		Properties: map[string]any{
+			"command":         selection.Command,
+			"mode":            selection.Mode,
+			"result_type":     selection.ResultType,
+			"rank":            selection.Rank,
+			"result_count":    selection.ResultCount,
+			"isEntireEnabled": isEntireEnabled,
+			"cli_version":     version,
+			"os":              runtime.GOOS,
+			"arch":            runtime.GOARCH,
+		},
+		Timestamp: time.Now(),
+	}
+}
+
+// TrackSearchSelectionDetached records one result selection by spawning a
+// detached subprocess. Best-effort and non-blocking; call sites must gate on
+// the user's opt-in telemetry setting. Honors ENTIRE_TELEMETRY_OPTOUT like the
+// other trackers.
+func TrackSearchSelectionDetached(selection SearchSelection, isEntireEnabled bool, version string) {
+	if IsEnvOptedOut() {
+		return
+	}
+
+	payload := BuildSearchSelectionPayload(selection, isEntireEnabled, version)
+	if payload == nil {
+		return
+	}
+
+	if payloadJSON, err := json.Marshal(payload); err == nil {
+		spawnDetachedAnalytics(string(payloadJSON))
+	}
+}

--- a/cmd/entire/cli/telemetry/search_selection_test.go
+++ b/cmd/entire/cli/telemetry/search_selection_test.go
@@ -1,0 +1,88 @@
+package telemetry
+
+import "testing"
+
+func TestBuildSearchSelectionPayload(t *testing.T) {
+	t.Parallel()
+	payload := BuildSearchSelectionPayload(SearchSelection{
+		Command:     "entire search",
+		Mode:        SearchModeCheckpoint,
+		ResultType:  "commit",
+		Rank:        3,
+		ResultCount: 20,
+	}, true, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildSearchSelectionPayload returned nil")
+	}
+	if payload.Event != "cli_search_result_selected" {
+		t.Errorf("Event = %q, want %q", payload.Event, "cli_search_result_selected")
+	}
+	want := map[string]any{
+		"command":         "entire search",
+		"mode":            "checkpoint",
+		"result_type":     "commit",
+		"rank":            3,
+		"result_count":    20,
+		"isEntireEnabled": true,
+		"cli_version":     "1.2.3",
+	}
+	for k, v := range want {
+		if got := payload.Properties[k]; got != v {
+			t.Errorf("property %s = %v, want %v", k, got, v)
+		}
+	}
+}
+
+// TestBuildSearchSelectionPayload_CodeMode pins the code tab's reported kind:
+// code results carry no type from the API, so they report under one fixed kind
+// rather than an empty string that would read as missing data.
+func TestBuildSearchSelectionPayload_CodeMode(t *testing.T) {
+	t.Parallel()
+	payload := BuildSearchSelectionPayload(SearchSelection{
+		Command:     "entire search",
+		Mode:        SearchModeCode,
+		ResultType:  SearchSelectionTypeCode,
+		Rank:        0,
+		ResultCount: 5,
+	}, false, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildSearchSelectionPayload returned nil")
+	}
+	if payload.Properties["mode"] != "code" {
+		t.Errorf("mode = %v, want code", payload.Properties["mode"])
+	}
+	if payload.Properties["result_type"] != "code" {
+		t.Errorf("result_type = %v, want code", payload.Properties["result_type"])
+	}
+	if payload.Properties["rank"] != 0 {
+		t.Errorf("rank = %v, want 0", payload.Properties["rank"])
+	}
+}
+
+// TestSearchSelectionPayloadCarriesNoContent is the privacy guard: the payload
+// must never carry query text, result titles, repo names, or file paths. It
+// asserts on the property key set, so a field added later fails here rather
+// than shipping content to PostHog unnoticed.
+func TestSearchSelectionPayloadCarriesNoContent(t *testing.T) {
+	t.Parallel()
+	payload := BuildSearchSelectionPayload(SearchSelection{
+		Command:     "entire search",
+		Mode:        SearchModeCheckpoint,
+		ResultType:  "session",
+		Rank:        1,
+		ResultCount: 9,
+	}, true, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildSearchSelectionPayload returned nil")
+	}
+	allowed := map[string]bool{
+		"command": true, "mode": true, "result_type": true, "rank": true,
+		"result_count": true, "isEntireEnabled": true, "cli_version": true,
+		"os": true, "arch": true,
+	}
+	for k := range payload.Properties {
+		if !allowed[k] {
+			t.Errorf("unexpected property %q in selection payload — content-free by construction", k)
+		}
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1192
<!-- entire-trail-link-end -->

## What was missing

We couldn't tell whether CLI search is any *good* — only that it was alive.

An important correction to the ticket first: **the CLI is not uninstrumented.** An existing search event already reports that a search ran, how long it took, how many results came back, and how it failed. It shipped a few days ago and is landing normally — 64 events from 7 users. It just lands in a **separate PostHog project for CLI telemetry**, not the web app's project, which is where the audit looked. There's no ingestion bug to chase, and four of the five things the ticket asked for already existed.

The real gap was the fifth: whether the user opened any of the results.

## Why it matters

Counts and timings measure liveness, not relevance. A search returning 80 results in three seconds looks equally healthy whether the user found what they wanted in the first row or gave up after the twentieth. The web app has tracked result clicks all along; the CLI had no equivalent, so the click-through half of "is search any good?" was invisible.

## The fix

One new event, emitted when the user opens a result's detail view in the search TUI.

1. Instrumented at the single key handler both the checkpoint tabs and the code tab open through, so both surfaces are covered without per-tab wiring.
2. Reports the result's kind, its position in the list, the size of that list, and which surface. **Position is the point** — a healthy ranking gets picked from the top row far more often than the twentieth, and that isn't derivable from counts.
3. Deduped per position within a result set, so opening and closing the same row repeatedly counts once. Opening several *different* rows still counts each, because having to dig is itself the signal.
4. The result-kind value is clamped to a known list. The search decoder passes unrecognized kinds straight through from the server, so without clamping an arbitrary server-supplied string could have been forwarded into analytics.

No query text, result titles, repo names, or file paths are sent — enums, counts, and one position only. A test asserts on the payload's key set, so a field added later fails rather than quietly leaking. Opt-out gating is identical to the existing search event's, so anyone opted out of one is opted out of both.

## Naming, for the parallel MCP work

Scheme is surface prefix plus what happened, so the MCP surface should emit its own completed/selected pair reusing these property names. Note that cross-surface dashboards need **both** PostHog projects — CLI events don't go to the web app's.

## Verified

All unit tests and lint pass clean. Main merged in with no conflicts. Reviewed the branch diff for regressions and dead code — none found.

Trail review caught one real bug during review, now fixed in a follow-up commit: the dedupe was keyed on the reported surface rather than the active tab, and since two tabs report the same surface, opening the top row of the second tab you visited was silently swallowed. Keyed on the tab instead; the added regression test fails against the old key.

No changelog entry: this repo writes the changelog in one batch per release, not per PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes with opt-in gating and no search or auth behavior changes; main risk is miscounted analytics if dedupe logic regresses, which the new tests target.
> 
> **Overview**
> Adds **click-through telemetry** for the interactive `entire search` TUI via a new `cli_search_result_selected` event, emitted when the user confirms a row and opens the detail view (checkpoint tabs and Code tab share the same Confirm handler).
> 
> Payloads stay **content-free**: command path, search mode, clamped result type, rank, and result count—gated the same way as existing search outcome telemetry (settings + env opt-out), with emit deferred as a `tea.Cmd` so settings load and detached analytics do not block the Update loop.
> 
> **Deduping** uses separate semantic and code ledgers keyed by `tab:rank`, reset only when that result set refreshes (not on pagination), fixing undercount when Commits/Sessions share mode `checkpoint` and double-report when parallel semantic/code responses land at different times. Unknown API result types map to `other` before analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e7e3e5a6928f11acb1b3c04f0c6323b4666afc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->