### PR TITLE
feat(cursor): implement ToolInvocationScanner so Cursor sessions are measurable

### DIFF
--- a/cmd/entire/cli/agent/claudecode/tool_invocations.go
+++ b/cmd/entire/cli/agent/claudecode/tool_invocations.go
@@ -1,105 +1,34 @@
 package claudecode
 
 import (
-	"bytes"
 	"encoding/json"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
 )
 
-// toolUseToken is the literal that must appear in a raw transcript line for it
-// to carry a tool_use content block. Both quotes are part of the token on
-// purpose: it makes the check exact without whitespace normalization, and it is
-// what keeps `"tool_use_id"` — which appears on every tool_result line, the
-// single largest false-positive class for any substring probe — from matching.
-var toolUseToken = []byte(`"tool_use"`)
-
 // ScanToolInvocations walks the Bash/Task-style tool calls recorded in a Claude
 // Code JSONL transcript. See agent.ToolInvocationScanner for the contract,
 // including that hints is a performance filter and not a semantic one.
 //
-// Lines are split by hand with bytes.IndexByte rather than with bufio.Scanner:
-// a single Claude Code transcript line routinely carries a multi-megabyte tool
-// result, so Scanner's 64KiB default token limit would silently truncate the
-// walk. Two byte-level prefilters run before any JSON work, so a transcript
-// with no candidate line costs one pass and zero allocations — the same order
-// as the substring probe this replaces, on the miss path that dominates.
+// The walk itself — line splitting, the two byte-level prefilters, the
+// assistant-envelope gate, and why each is done the way it is — lives in
+// transcript.ScanToolUseBlocks, shared with Cursor. What stays here is the only
+// Claude-specific part: which input keys carry a shell command and a dispatched
+// subagent.
+//
+// A block whose input fails to decode is skipped, not reported: the transcript
+// is written by another process and this is a telemetry read.
 func (c *ClaudeCodeAgent) ScanToolInvocations(transcriptData []byte, hints [][]byte, visit func(agent.ToolInvocation) bool) bool {
-	for rest := transcriptData; len(rest) > 0; {
-		line := rest
-		if idx := bytes.IndexByte(rest, '\n'); idx >= 0 {
-			line, rest = rest[:idx], rest[idx+1:]
-		} else {
-			rest = nil
-		}
-		if !lineMayCarryInvocation(line, hints) {
-			continue
-		}
-		if scanLineInvocations(line, visit) {
-			return true
-		}
-	}
-	return false
-}
-
-// lineMayCarryInvocation applies the two prefilters: the caller's hints (nil
-// means visit every line) and the tool_use token. Hints are checked first
-// because they are the selective half — a transcript typically has thousands of
-// tool_use lines and a handful mentioning whatever the caller is looking for.
-func lineMayCarryInvocation(line []byte, hints [][]byte) bool {
-	if hints != nil && !containsAny(line, hints) {
-		return false
-	}
-	return bytes.Contains(line, toolUseToken)
-}
-
-// containsAny reports whether line contains at least one of needles.
-func containsAny(line []byte, needles [][]byte) bool {
-	for _, needle := range needles {
-		if bytes.Contains(line, needle) {
-			return true
-		}
-	}
-	return false
-}
-
-// scanLineInvocations decodes one candidate line and offers each of its
-// tool_use blocks to visit. Malformed lines are skipped rather than reported:
-// the transcript is written by another process and may be mid-write, and this
-// is a telemetry read, never a correctness one.
-func scanLineInvocations(line []byte, visit func(agent.ToolInvocation) bool) bool {
-	var parsed transcript.Line
-	if err := json.Unmarshal(line, &parsed); err != nil || len(parsed.Message) == 0 {
-		return false
-	}
-	// Only assistant envelopes carry live tool calls — the same gate every
-	// other tool_use consumer in this package applies (ExtractModifiedFiles,
-	// ExtractSkillEvents, ExtractAllModifiedFiles). Without it, a non-assistant
-	// envelope whose message happens to decode into tool_use-shaped content
-	// (replayed/sidechain or summary lines) would count as a real invocation.
-	if parsed.Type != envelopeTypeAssistant {
-		return false
-	}
-	var msg assistantMessage
-	if err := json.Unmarshal(parsed.Message, &msg); err != nil {
-		return false
-	}
-	for _, block := range msg.Content {
-		if block.Type != transcript.ContentTypeToolUse || len(block.Input) == 0 {
-			continue
-		}
+	return transcript.ScanToolUseBlocks(transcriptData, hints, func(block transcript.ContentBlock) bool {
 		var input toolInput
 		if err := json.Unmarshal(block.Input, &input); err != nil {
-			continue
+			return false
 		}
-		if visit(agent.ToolInvocation{
+		return visit(agent.ToolInvocation{
 			Tool:         block.Name,
 			Command:      input.Command,
 			SubagentType: input.SubagentType,
-		}) {
-			return true
-		}
-	}
-	return false
+		})
+	})
 }

--- a/cmd/entire/cli/agent/cursor/AGENT.md
+++ b/cmd/entire/cli/agent/cursor/AGENT.md
@@ -189,6 +189,8 @@ Note: IDE also sends `composer_mode: "agent"` — CLI omits this field.
   | `Shell` | `command`, `description`, optional `working_directory` | unattributable |
 
   `path` values are absolute. Note the divergence from Claude Code, which keys the target file as `file_path` — this is why `transcript.ToolInput` does not fit and `cursor.toolInput` exists. Blocks carry no `id` field. `ExtractModifiedFiles` reads `Write` and `StrReplace`; git status remains the broader signal because `Shell` can modify files while recording only a command string.
+- The shell command key does NOT diverge: `Shell` keys it `command`, the same as Claude Code's `Bash`. That is what lets Cursor implement `agent.ToolInvocationScanner` (`tool_invocations.go`) reusing `agent.ToolInvocation.Command` unchanged, so "did this session run X?" is answerable for Cursor sessions instead of reporting `unsupported`. The walk itself is shared with Claude Code via `transcript.ScanToolUseBlocks`; what Cursor adds is envelope normalization, since Cursor keys the envelope `role` where Claude Code keys it `type`.
+- Subagent dispatch is NOT probed. Cursor dispatches subagents (see the `subagentStart` hook's `subagent_type`), but the transcript input key naming them is unconfirmed, so `ToolInvocation.SubagentType` is left unset rather than guessed. Nothing is lost today: Entire never scaffolded an `entire-search` subagent for Cursor, so no Cursor session carries a legacy dispatch to match.
 - Override for testing: set `ENTIRE_TEST_CURSOR_PROJECT_DIR` env var to override the transcript directory
 
 ## Config Preservation
@@ -222,6 +224,7 @@ Note: IDE also sends `composer_mode: "agent"` — CLI omits this field.
 3. **No `composer_mode` field in CLI**: IDE sends `"agent"`, CLI omits it. Not impactful.
 4. **Shell-driven file changes are unattributable**: `ExtractModifiedFiles` covers `Write` and `StrReplace`, but a file changed by a `Shell` command records only the command string, so git status stays the backstop. (Through 2026-08 this entry instead read "transcript lacks tool_use blocks", which was never true of the format and disabled file extraction entirely; see the transcript section above.)
 5. **`tool_use_id` format**: Contains newline (`call_xxx\nctc_xxx`) — may need sanitization if used as identifiers.
+6. **Subagent dispatch is not visible to the tool-invocation probe**: the transcript input key naming a dispatched subagent is unconfirmed, so `ScanToolInvocations` reports tool names and shell commands only. Confirm the key against a real session before relying on a subagent signal for Cursor.
 
 ## Captured Payloads
 

--- a/cmd/entire/cli/agent/cursor/tool_invocations.go
+++ b/cmd/entire/cli/agent/cursor/tool_invocations.go
@@ -1,0 +1,46 @@
+package cursor
+
+import (
+	"encoding/json"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/transcript"
+)
+
+// Compile-time interface assertion.
+var _ agent.ToolInvocationScanner = (*CursorAgent)(nil)
+
+// ScanToolInvocations walks the tool calls recorded in a Cursor JSONL
+// transcript. See agent.ToolInvocationScanner for the contract, including that
+// hints is a performance filter and not a semantic one.
+//
+// Cursor records tool_use content blocks in the same shape as Claude Code, so
+// the walk is transcript.ScanToolUseBlocks — including the envelope
+// normalization Cursor specifically needs, since it keys the envelope "role"
+// where Claude Code keys it "type". What is Cursor-specific is the input key,
+// and it needs no divergence: Cursor's shell tool is `Shell` and it keys the
+// command `command`, the same key Claude Code uses. That was the one thing
+// blocking this implementation, and it was confirmed against a real session —
+// see toolInput and testdata/real_session_tool_use.jsonl.
+//
+// SubagentType is deliberately left unset, which is not the same omission it
+// would be for Claude Code. ToolInvocation.SubagentType exists so the probe can
+// match a dispatch of Entire's own `entire-search` subagent, and Cursor never
+// had one: the installer reported the search skill as unsupported for Cursor
+// until it began scaffolding a real SKILL.md, so no Cursor session can carry a
+// legacy dispatch to miss. Cursor does dispatch subagents of its own, but the
+// input key naming them is unconfirmed, and guessing it is exactly the silent
+// false negative agent.ToolInvocationScanner warns against. Confirm the key
+// against a real session before reading anything into a subagent field here.
+func (c *CursorAgent) ScanToolInvocations(transcriptData []byte, hints [][]byte, visit func(agent.ToolInvocation) bool) bool {
+	return transcript.ScanToolUseBlocks(transcriptData, hints, func(block transcript.ContentBlock) bool {
+		var input toolInput
+		if err := json.Unmarshal(block.Input, &input); err != nil {
+			return false
+		}
+		return visit(agent.ToolInvocation{
+			Tool:    block.Name,
+			Command: input.Command,
+		})
+	})
+}

--- a/cmd/entire/cli/agent/cursor/tool_invocations_test.go
+++ b/cmd/entire/cli/agent/cursor/tool_invocations_test.go
@@ -1,0 +1,236 @@
+package cursor
+
+import (
+	"os"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// Cursor-shaped transcript lines. The envelope key is "role", not "type" —
+// that difference is the whole reason these fixtures cannot be borrowed from
+// claudecode, and the reason a walker that skips normalization sees nothing at
+// all in a Cursor transcript.
+const (
+	cursorShellSearch = `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"entire search \"retry backoff\" --json","description":"search history"}}]}}
+`
+	cursorShellUnrelated = `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"git status --short"}}]}}
+`
+	cursorWriteBlock = `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"path":"/tmp/x/notes.md","contents":"line 1"}}]}}
+`
+	// A tool result: carries "tool_use_id", never "tool_use", and rides a
+	// non-assistant envelope. Both prefilters must reject it.
+	cursorToolResult = `{"role":"user","message":{"content":[{"type":"tool_result","tool_use_id":"c1","content":"$ entire search foo\nno results"}]}}
+`
+	// Cursor closes a turn with an envelope that has a type and no message.
+	cursorTurnEnded = `{"type":"turn_ended","status":"success"}
+`
+)
+
+// TestCursorAgent_ImplementsToolInvocationScanner is the inverse of the
+// TestCursorAgent_MustNotImplementToolInvocationScanner this replaces. That
+// test held Cursor out of the probe while its shell-command input key was
+// unconfirmed; the key is confirmed (`Shell` keys it `command`, verified
+// against the real session in TestCursorAgent_RealSessionContainsToolUseBlocks),
+// so the capability is now the thing worth pinning. Dropping the interface
+// would silently downgrade every Cursor session to "cannot tell".
+func TestCursorAgent_ImplementsToolInvocationScanner(t *testing.T) {
+	t.Parallel()
+	if _, ok := agent.AsToolInvocationScanner(&CursorAgent{}); !ok {
+		t.Fatal("CursorAgent must implement ToolInvocationScanner: its shell-command input key " +
+			"is confirmed, and dropping it reports every Cursor session as unsupported")
+	}
+}
+
+// TestCursorAgent_ScanToolInvocations_RoleEnvelope is the Cursor-specific
+// regression. Cursor keys the envelope "role"; Claude Code keys it "type". A
+// walker that gates on Type without normalizing Role first returns false for
+// every line of every Cursor transcript — a total, silent miss that still
+// reports as a confident "did not run", since the agent implements the
+// interface and is therefore counted as measurable.
+func TestCursorAgent_ScanToolInvocations_RoleEnvelope(t *testing.T) {
+	t.Parallel()
+
+	var got []agent.ToolInvocation
+	found := (&CursorAgent{}).ScanToolInvocations([]byte(cursorShellSearch), nil, func(inv agent.ToolInvocation) bool {
+		got = append(got, inv)
+		return false
+	})
+
+	if found {
+		t.Error("ScanToolInvocations() = true, want false (visitor never accepted)")
+	}
+	if len(got) != 1 {
+		t.Fatalf("visited %d invocations, want 1: %+v", len(got), got)
+	}
+	if got[0].Tool != "Shell" {
+		t.Errorf("Tool = %q, want %q", got[0].Tool, "Shell")
+	}
+	if got[0].Command != `entire search "retry backoff" --json` {
+		t.Errorf("Command = %q, want the shell command verbatim", got[0].Command)
+	}
+}
+
+// TestCursorAgent_ScanToolInvocations_CommandKeyIsPopulated pins the one thing
+// that blocked this implementation: that reading Cursor's shell command through
+// ToolInvocation.Command yields the command rather than an empty string. An
+// empty Command here is the exact false negative the interface exists to
+// prevent — it reads downstream as "this session ran no such command".
+func TestCursorAgent_ScanToolInvocations_CommandKeyIsPopulated(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(realSessionFixture)
+	if err != nil {
+		t.Fatalf("read %s: %v", realSessionFixture, err)
+	}
+
+	shellCommands := 0
+	(&CursorAgent{}).ScanToolInvocations(data, nil, func(inv agent.ToolInvocation) bool {
+		if inv.Tool != "Shell" {
+			return false
+		}
+		shellCommands++
+		if inv.Command == "" {
+			t.Errorf("Shell invocation carries an empty Command; the `command` input key is not being read")
+		}
+		return false
+	})
+
+	// The fixture records two Shell calls, at lines 1 and 7.
+	if shellCommands != 2 {
+		t.Errorf("saw %d Shell invocations in the real session, want 2", shellCommands)
+	}
+}
+
+// TestCursorAgent_ScanToolInvocations_RealSessionToolNames walks the captured
+// session and pins the tool names reaching a caller, so a Cursor rename shows
+// up here rather than as a quiet drop in whatever the caller matches on.
+func TestCursorAgent_ScanToolInvocations_RealSessionToolNames(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(realSessionFixture)
+	if err != nil {
+		t.Fatalf("read %s: %v", realSessionFixture, err)
+	}
+
+	seen := map[string]bool{}
+	(&CursorAgent{}).ScanToolInvocations(data, nil, func(inv agent.ToolInvocation) bool {
+		seen[inv.Tool] = true
+		return false
+	})
+
+	for _, want := range []string{"Shell", "Write", "StrReplace", "Read", "Glob", "Grep"} {
+		if !seen[want] {
+			t.Errorf("tool %q not visited; saw %v", want, seen)
+		}
+	}
+}
+
+// TestCursorAgent_ScanToolInvocations_SkipsToolResultAndNonAssistant covers the
+// two shapes that must never count: a tool_result line (whose "tool_use_id" is
+// the largest false-positive class for any substring probe) and a
+// non-assistant envelope.
+func TestCursorAgent_ScanToolInvocations_SkipsToolResultAndNonAssistant(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(cursorToolResult + cursorTurnEnded)
+	visited := 0
+	found := (&CursorAgent{}).ScanToolInvocations(data, nil, func(agent.ToolInvocation) bool {
+		visited++
+		return true
+	})
+
+	if found || visited != 0 {
+		t.Errorf("ScanToolInvocations() = %v after %d visits, want false after 0", found, visited)
+	}
+}
+
+// TestCursorAgent_ScanToolInvocations_HonorsHints pins the prefilter as a
+// performance filter: a line containing none of the hints is skipped, and nil
+// hints visit everything.
+func TestCursorAgent_ScanToolInvocations_HonorsHints(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(cursorShellUnrelated + cursorShellSearch)
+
+	visited := 0
+	found := (&CursorAgent{}).ScanToolInvocations(data, [][]byte{[]byte("entire search")}, func(inv agent.ToolInvocation) bool {
+		visited++
+		return inv.Command == `entire search "retry backoff" --json`
+	})
+	if !found {
+		t.Error("ScanToolInvocations() = false, want true (the hinted line carries the invocation)")
+	}
+	if visited != 1 {
+		t.Errorf("visited %d invocations with a hint, want 1 (the unrelated line must be skipped)", visited)
+	}
+
+	visited = 0
+	(&CursorAgent{}).ScanToolInvocations(data, nil, func(agent.ToolInvocation) bool {
+		visited++
+		return false
+	})
+	if visited != 2 {
+		t.Errorf("visited %d invocations with nil hints, want 2", visited)
+	}
+}
+
+// TestCursorAgent_ScanToolInvocations_StopsOnFirstAccept pins that the walk
+// short-circuits, so a caller answering "did this happen at all" does not pay
+// for the rest of a multi-megabyte transcript.
+func TestCursorAgent_ScanToolInvocations_StopsOnFirstAccept(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(cursorShellSearch + cursorWriteBlock + cursorShellUnrelated)
+	visited := 0
+	found := (&CursorAgent{}).ScanToolInvocations(data, nil, func(agent.ToolInvocation) bool {
+		visited++
+		return true
+	})
+
+	if !found {
+		t.Error("ScanToolInvocations() = false, want true")
+	}
+	if visited != 1 {
+		t.Errorf("visited %d invocations, want 1 (walk must stop on the first accept)", visited)
+	}
+}
+
+// TestCursorAgent_ScanToolInvocations_MalformedAndEmpty covers the fail-open
+// paths: a half-written line (the transcript is written by another process) and
+// an empty transcript must neither panic nor abort the walk.
+func TestCursorAgent_ScanToolInvocations_MalformedAndEmpty(t *testing.T) {
+	t.Parallel()
+
+	truncated := `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","inp`
+	data := []byte(truncated + "\n" + cursorShellSearch)
+
+	visited := 0
+	found := (&CursorAgent{}).ScanToolInvocations(data, nil, func(agent.ToolInvocation) bool {
+		visited++
+		return true
+	})
+	if !found || visited != 1 {
+		t.Errorf("ScanToolInvocations() = %v after %d visits, want true after 1 (malformed line skipped, walk continues)", found, visited)
+	}
+
+	if (&CursorAgent{}).ScanToolInvocations(nil, nil, func(agent.ToolInvocation) bool { return true }) {
+		t.Error("ScanToolInvocations(nil) = true, want false")
+	}
+}
+
+// TestCursorAgent_ScanToolInvocations_FinalLineWithoutNewline pins that the
+// hand-rolled line split does not drop a transcript's last line — Cursor writes
+// the file incrementally, so the newest invocation is routinely the unterminated
+// one.
+func TestCursorAgent_ScanToolInvocations_FinalLineWithoutNewline(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(cursorWriteBlock + `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"entire search foo"}}]}}`)
+
+	if !(&CursorAgent{}).ScanToolInvocations(data, nil, func(inv agent.ToolInvocation) bool {
+		return inv.Command == "entire search foo"
+	}) {
+		t.Error("ScanToolInvocations() = false, want true (final line without a trailing newline must be walked)")
+	}
+}

--- a/cmd/entire/cli/agent/cursor/transcript_test.go
+++ b/cmd/entire/cli/agent/cursor/transcript_test.go
@@ -221,26 +221,6 @@ func TestCursorAgent_ExtractModifiedFilesFromOffset_EmptyPath(t *testing.T) {
 	}
 }
 
-// TestCursorAgent_MustNotImplementToolInvocationScanner pins that Cursor stays
-// out of the tool-invocation probe until its shell-command input key is
-// confirmed.
-//
-// Not because Cursor is unprobeable. It shares this JSONL shape and does record
-// tool_use blocks; the "contains no tool_use blocks" claims elsewhere in this
-// package date to 2026-03, are pinned by no test, and are stale — they also
-// make ExtractModifiedFilesFromOffset give up entirely, which deserves its own
-// look. The narrow blocker is that ToolInvocation.Command assumes Claude's
-// `command` input key; guessing it for Cursor would produce the silent false
-// negative the interface exists to prevent. Confirm the mapping, implement the
-// scanner, and delete this test.
-func TestCursorAgent_MustNotImplementToolInvocationScanner(t *testing.T) {
-	t.Parallel()
-	if _, ok := agent.AsToolInvocationScanner(&CursorAgent{}); ok {
-		t.Fatal("CursorAgent must not implement ToolInvocationScanner until its shell-command " +
-			"input key is confirmed: reusing Claude's `command` key would fabricate negatives")
-	}
-}
-
 // --- Real captured session ---
 
 // realSessionFixture is a verbatim 9-line excerpt of a real Cursor session,

--- a/cmd/entire/cli/agent/cursor/types.go
+++ b/cmd/entire/cli/agent/cursor/types.go
@@ -201,10 +201,18 @@ type subagentStopHookInputRaw struct {
 // shared with claudecode.FileModificationTools.
 var FileModificationTools = []string{"Write", "StrReplace"}
 
-// toolInput is the subset of a Cursor tool_use input that carries the target file.
+// toolInput is the subset of a Cursor tool_use input this package reads: the
+// target file of a file-modifying tool, and the command of a Shell call.
 //
-// Cursor keys it "path", where Claude Code uses "file_path" — which is why the
-// shared transcript.ToolInput type does not fit. Values observed are absolute.
+// Cursor keys the file "path", where Claude Code uses "file_path" — which is why
+// the shared transcript.ToolInput type does not fit. Values observed are
+// absolute. The command key does NOT diverge: Cursor's Shell tool keys it
+// "command", the same as Claude Code's Bash, which is what lets
+// ScanToolInvocations reuse agent.ToolInvocation.Command as-is.
+//
+// Both keys are confirmed against a real session, not assumed — see
+// testdata/real_session_tool_use.jsonl and AGENT.md's tool table.
 type toolInput struct {
-	Path string `json:"path"`
+	Path    string `json:"path"`
+	Command string `json:"command"`
 }

--- a/cmd/entire/cli/agent/tool_invocations.go
+++ b/cmd/entire/cli/agent/tool_invocations.go
@@ -26,13 +26,19 @@ type ToolInvocation struct {
 // aggregate.
 //
 // "No walker yet" is the only reason any agent is absent — do not read it as
-// "impossible". Cursor in particular shares this JSONL shape (see the
-// transcript package doc) and does record tool_use blocks; the "contains no
-// tool_use blocks" comments in cmd/entire/cli/agent/cursor date to 2026-03,
-// are pinned by no test, and are stale. What blocks a Cursor implementation is
-// narrower: its input key for a shell command is unconfirmed, so reusing
-// ToolInvocation.Command would risk the very false negative this interface
-// exists to prevent. A name-based matcher (subagent dispatch) would work today.
+// "impossible". Claude Code and Cursor both implement it, sharing one walk via
+// transcript.ScanToolUseBlocks; an agent whose transcript records tool calls
+// structurally can join them by decoding its own input keys. Confirm those keys
+// against a real captured session first: guessing one produces the silent false
+// negative this interface exists to prevent, which is why Cursor waited for its
+// `Shell`/`command` mapping to be verified rather than borrowing Claude's.
+//
+// Codex is the next candidate and carries a live trap worth recording. Its
+// rollout does record shell calls structurally, but the command arrives wrapped
+// (`/bin/zsh -lc "…"`), and a caller that matches shell commands may sanitize
+// quoted spans away before matching — so yielding the wrapper verbatim as
+// Command can report a confident negative for a command that did run. Unwrap
+// before yielding, or leave Codex unimplemented and honestly unsupported.
 type ToolInvocationScanner interface {
 	// ScanToolInvocations calls visit for each recorded tool invocation and
 	// returns true as soon as visit does, stopping the walk.

--- a/cmd/entire/cli/strategy/telemetry_signals.go
+++ b/cmd/entire/cli/strategy/telemetry_signals.go
@@ -283,8 +283,10 @@ func skipHeredocBody(cmd string, i int, delim string) int {
 // sessions still on the old artifact. Skill-based sessions run the command in
 // the main transcript and surface through the command match instead — but
 // only where the command match runs at all: ScanToolInvocations requires
-// ToolInvocationScanner, which Claude Code alone implements, so the other
-// agents' sessions report searchSourceUnsupported regardless of skill use.
+// ToolInvocationScanner, which Claude Code and Cursor implement, so the
+// remaining agents' sessions report searchSourceUnsupported regardless of
+// skill use. That is a hole in the measurement, not a verdict about those
+// sessions — see agent.ToolInvocationScanner for what closing one takes.
 const EntireSearchSubagentName = "entire-search"
 
 // detectSearchUsage reports whether the session consulted Entire's history

--- a/cmd/entire/cli/strategy/telemetry_signals_test.go
+++ b/cmd/entire/cli/strategy/telemetry_signals_test.go
@@ -131,13 +131,14 @@ func TestDetectSearchUsage_MixedTranscriptFindsTheInvocation(t *testing.T) {
 // fabricated data point indistinguishable in aggregate from a real miss.
 //
 // These agents are unprobeable because no ToolInvocationScanner walker exists
-// for them yet — not because one is impossible. Cursor in particular shares
-// the tool_use JSONL shape and could implement one; see the interface doc in
-// agent/tool_invocations.go for what blocks it.
+// for them yet — not because one is impossible. Cursor used to be on this list
+// and no longer is: it shares the tool_use JSONL shape, and once its
+// shell-command input key was confirmed it got a walker. See the interface doc
+// in agent/tool_invocations.go for what implementing another one takes.
 func TestDetectSearchUsage_UnprobeableAgentsReportUnsupported(t *testing.T) {
 	t.Parallel()
 
-	for _, agentType := range []types.AgentType{agent.AgentTypeCursor, agent.AgentTypePi, agent.AgentTypeCopilotCLI} {
+	for _, agentType := range []types.AgentType{agent.AgentTypePi, agent.AgentTypeCopilotCLI} {
 		t.Run(string(agentType), func(t *testing.T) {
 			t.Parallel()
 			ag, err := agent.GetByAgentType(agentType)
@@ -149,6 +150,40 @@ func TestDetectSearchUsage_UnprobeableAgentsReportUnsupported(t *testing.T) {
 				t.Errorf("detectSearchUsage(%s) = %+v, want %+v", agentType, got, want)
 			}
 		})
+	}
+}
+
+// cursorShellSearch is a Cursor-shaped assistant line: the envelope is keyed
+// "role" rather than "type", and the shell tool is Shell rather than Bash. The
+// command key is the same, which is what lets one ToolInvocation shape serve
+// both agents.
+const cursorShellSearch = `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"entire search \"retry backoff\" --json"}}]}}
+`
+
+// TestDetectSearchUsage_CursorReportsCommand is the end-to-end half of Cursor
+// gaining a walker: the probe must now return a measured verdict for a Cursor
+// session instead of "cannot tell". Asserting it here rather than only in the
+// cursor package is deliberate — this is the seam where a Cursor transcript
+// meets the matcher, and where an envelope-normalization regression would show
+// up as a confident, wrong `none`.
+func TestDetectSearchUsage_CursorReportsCommand(t *testing.T) {
+	t.Parallel()
+
+	ag, err := agent.GetByAgentType(agent.AgentTypeCursor)
+	if err != nil {
+		t.Fatalf("GetByAgentType(cursor) error: %v", err)
+	}
+
+	want := searchProbe{used: true, source: searchSourceCommand}
+	if got := detectSearchUsage(ag, []byte(cursorShellSearch)); got != want {
+		t.Errorf("detectSearchUsage(cursor, shell search) = %+v, want %+v", got, want)
+	}
+
+	// And the negative direction: a measured "did not search", not unsupported.
+	unrelated := `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"git status --short"}}]}}` + "\n"
+	wantNone := searchProbe{used: false, source: searchSourceNone}
+	if got := detectSearchUsage(ag, []byte(unrelated)); got != wantNone {
+		t.Errorf("detectSearchUsage(cursor, unrelated shell) = %+v, want %+v", got, wantNone)
 	}
 }
 

--- a/cmd/entire/cli/transcript/tool_invocations.go
+++ b/cmd/entire/cli/transcript/tool_invocations.go
@@ -1,0 +1,115 @@
+package transcript
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// toolUseToken is the literal that must appear in a raw transcript line for it
+// to carry a tool_use content block. Both quotes are part of the token on
+// purpose: it makes the check exact without whitespace normalization, and it is
+// what keeps `"tool_use_id"` — which appears on every tool_result line, the
+// single largest false-positive class for any substring probe — from matching.
+//
+//nolint:gochecknoglobals // immutable literal, read-only.
+var toolUseToken = []byte(`"tool_use"`)
+
+// ScanToolUseBlocks walks the tool_use content blocks recorded in a JSONL
+// transcript of the Claude Code shape — which Cursor shares, and which is why
+// this package exists — offering each to visit and returning true as soon as
+// visit does.
+//
+// Callers decode block.Input themselves. The envelope and the content block are
+// genuinely common across these agents; the input KEYS are not. Claude Code
+// keys a shell command `command` and a target file `file_path`, Cursor keys the
+// file `path`, and a walker that decoded either one for both would quietly
+// return zero values for the other. Handing back the raw input keeps this
+// function honest about the part that is actually shared.
+//
+// hints is a PERFORMANCE filter and not a semantic one: an implementation may
+// skip any line whose raw bytes contain none of the hints, so a caller must
+// pass hints that every block it can possibly match is guaranteed to contain
+// literally, or nil to visit everything. See agent.ToolInvocationScanner for
+// the full contract, which this function is the shared engine for.
+//
+// Lines are split by hand with bytes.IndexByte rather than with bufio.Scanner:
+// a single transcript line routinely carries a multi-megabyte tool result, so
+// Scanner's 64KiB default token limit would silently truncate the walk. Two
+// byte-level prefilters run before any JSON work, so a transcript with no
+// candidate line costs one pass and zero allocations — the order that matters,
+// since the miss path dominates.
+func ScanToolUseBlocks(data []byte, hints [][]byte, visit func(ContentBlock) bool) bool {
+	for rest := data; len(rest) > 0; {
+		line := rest
+		if idx := bytes.IndexByte(rest, '\n'); idx >= 0 {
+			line, rest = rest[:idx], rest[idx+1:]
+		} else {
+			rest = nil
+		}
+		if !lineMayCarryToolUse(line, hints) {
+			continue
+		}
+		if scanLineToolUseBlocks(line, visit) {
+			return true
+		}
+	}
+	return false
+}
+
+// lineMayCarryToolUse applies the two prefilters: the caller's hints (nil means
+// visit every line) and the tool_use token. Hints are checked first because
+// they are the selective half — a transcript typically has thousands of
+// tool_use lines and a handful mentioning whatever the caller is looking for.
+func lineMayCarryToolUse(line []byte, hints [][]byte) bool {
+	if hints != nil && !containsAny(line, hints) {
+		return false
+	}
+	return bytes.Contains(line, toolUseToken)
+}
+
+// containsAny reports whether line contains at least one of needles.
+func containsAny(line []byte, needles [][]byte) bool {
+	for _, needle := range needles {
+		if bytes.Contains(line, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// scanLineToolUseBlocks decodes one candidate line and offers each of its
+// tool_use blocks to visit. Malformed lines are skipped rather than reported:
+// the transcript is written by another process and may be mid-write, and every
+// caller here is a telemetry read, never a correctness one.
+func scanLineToolUseBlocks(line []byte, visit func(ContentBlock) bool) bool {
+	var parsed Line
+	if err := json.Unmarshal(line, &parsed); err != nil || len(parsed.Message) == 0 {
+		return false
+	}
+	// Cursor keys the envelope "role" where Claude Code keys it "type"; every
+	// other consumer in this package reaches this line through ParseFromBytes,
+	// which normalizes the same way.
+	normalizeLineType(&parsed)
+	// Only assistant envelopes carry live tool calls — the same gate every
+	// other tool_use consumer applies (claudecode.ExtractModifiedFiles,
+	// ExtractSkillEvents, cursor.ExtractModifiedFiles). Without it, a
+	// non-assistant envelope whose message happens to decode into
+	// tool_use-shaped content (replayed/sidechain or summary lines) would count
+	// as a real invocation.
+	if parsed.Type != TypeAssistant {
+		return false
+	}
+	var msg AssistantMessage
+	if err := json.Unmarshal(parsed.Message, &msg); err != nil {
+		return false
+	}
+	for _, block := range msg.Content {
+		if block.Type != ContentTypeToolUse || len(block.Input) == 0 {
+			continue
+		}
+		if visit(block) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1194
<!-- entire-trail-link-end -->

Closes the measurement hole that [#2198](https://github.com/entireio/cli/pull/2198) documented and deliberately left open. #2198 has since merged, so this now also corrects the claim it added to `telemetry_signals.go` ("ToolInvocationScanner, which Claude Code alone implements"), which this PR makes false.

## Why

`detectSearchUsage` returns `searchSourceUnsupported` for every agent except Claude Code, because Claude Code is the only one implementing `agent.ToolInvocationScanner`. For a Cursor session that is not "did not search" — it is "cannot tell". Honest, but it means the `cli_commit_condensed` missed-opportunity signal shipped in 0.10.3 measures exactly one agent, and that data is what the case for defaulting the search skill install on is supposed to rest on.

Cursor was held out by one narrow blocker, and it is already resolved. `TestCursorAgent_MustNotImplementToolInvocationScanner` said so itself:

> The narrow blocker is that `ToolInvocation.Command` assumes Claude's `command` input key; guessing it for Cursor would produce the silent false negative the interface exists to prevent. **Confirm the mapping, implement the scanner, and delete this test.**

[#2120](https://github.com/entireio/cli/pull/2120) confirmed the mapping against a real captured session: Cursor's shell tool is `Shell` and it keys the command `command` — the same key Claude Code uses. Nothing is guessed here.

## What changed

- **`cursor.ScanToolInvocations`** — Cursor implements `ToolInvocationScanner`, reusing `ToolInvocation.Command` unchanged.
- **The walk is extracted, not copied.** Line splitting, the two byte-level prefilters, and the assistant-envelope gate are identical for both agents, so they move to `transcript.ScanToolUseBlocks` — the package whose doc already says it exists for "agents that share the same JSONL format (Claude Code, Cursor)". Callers decode `block.Input` themselves, because the envelope is shared and the input *keys* are not (Claude keys a file `file_path`, Cursor keys it `path`). `claudecode.ScanToolInvocations` becomes a thin wrapper; every rationale comment moved with the code it explains.
- **Envelope normalization**, which is the Cursor-specific hazard — see below.
- Strategy: Cursor comes off the unprobeable list, and gains an end-to-end test in both directions (`command` on a search, `none` on an unrelated shell call).
- `agent/tool_invocations.go`'s Cursor paragraph is now stale, so it is replaced with what implementing the *next* one takes — including the Codex trap found while scoping this (below).

## The hazard worth reviewing

**Cursor keys the envelope `"role"`; Claude Code keys it `"type"`.** A walker that gates on `Type` without normalizing `Role` first returns false for *every line of every Cursor transcript* — and because the agent now implements the interface, that total miss reports as a confident `used=false, source=none` rather than `unsupported`. Strictly worse than not implementing it at all.

The shared walker normalizes the same way `ParseFromBytes` already does for every other consumer, and `TestCursorAgent_ScanToolInvocations_RoleEnvelope` pins it.

**Claude Code is unaffected**: normalization only fires when `type` is empty, and Claude's transcripts always set it (no fixture in `claudecode/testdata` carries a role-keyed envelope). The only reachable delta would be a Claude line with `role` and no `type`, which would newly count — strictly more correct, and consistent with every other consumer in the package.

## Deliberately not done

`SubagentType` is left unset for Cursor. Cursor does dispatch subagents, but the transcript input key naming them is unconfirmed, and guessing it is the precise false negative the interface warns against. Nothing is lost today: Entire never scaffolded an `entire-search` subagent for Cursor — the installer reported the skill unsupported there — so no Cursor session carries a legacy dispatch to match. Documented in the code, in `AGENT.md`'s tool table, and as a new limitation entry.

## Found while scoping, recorded not fixed

**Codex is the next candidate and carries a live trap.** Its rollout records shell calls structurally, but the command arrives wrapped: `"command":"/bin/zsh -lc \"…\""`. `sanitizeShellCommandForMatching` blanks double-quoted spans, so yielding that wrapper verbatim as `Command` sanitizes to `/bin/zsh -lc ␀` and the pattern never matches — a confident negative for a command that did run. Whoever takes Codex must unwrap `-c`/`-lc` payloads before yielding, or leave Codex honestly unsupported. This is now recorded in the interface doc so it is not rediscovered the hard way.

## Validation

Rebased onto `main` at `7c96d9e5b` (clean, no conflicts) and re-verified there:

- `mise run fmt`, `mise run lint` — 0 issues.
- `mise run test:ci` — unit + integration under `-race` + E2E canary, all pass, exit 0.
- `mise run dup` — no new duplication; the extraction removes the copy this would otherwise have added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
