### PR TITLE
ci(lint): shellcheck scripts/ and stop skipping env-shebang tasks

### DIFF
--- a/mise-tasks/lint/shellcheck
+++ b/mise-tasks/lint/shellcheck
@@ -1,4 +1,4 @@
 #!/bin/sh
 #MISE description="Lint shell scripts with shellcheck"
 
-find mise-tasks -type f -exec sh -c 'head -1 "$1" | grep -q "^#!/bin/sh\|^#!/bin/bash"' _ {} \; -print0 | xargs -0 shellcheck
+find mise-tasks scripts -type f -exec sh -c 'head -1 "$1" | grep -qE "^#!(/usr/bin/env +)?(/bin/)?(sh|bash)\\b"' _ {} \; -print0 | xargs -0 shellcheck

--- a/scripts/download-e2e-artifacts.sh
+++ b/scripts/download-e2e-artifacts.sh
@@ -89,7 +89,7 @@ cd - >/dev/null
 
 # --- Write run metadata ---
 
-agents_found=$(cd "$dest" && ls -d */ 2>/dev/null | tr -d '/' | tr '\n' ', ' | sed 's/,$//')
+agents_found=$(cd "$dest" && find . -maxdepth 1 -mindepth 1 -type d -exec basename {} \; 2>/dev/null | sort | tr '\n' ',' | sed 's/,$//')
 
 cat > "$dest/.run-info.json" <<EOF
 {
@@ -97,7 +97,7 @@ cat > "$dest/.run-info.json" <<EOF
   "run_url": "$run_url",
   "commit": "$commit",
   "downloaded_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "agents": "$(echo "$agents_found" | sed 's/"/\\"/g')"
+  "agents": "${agents_found//\"/\\\"}"
 }
 EOF
 

--- a/scripts/migrate-sessions.sh
+++ b/scripts/migrate-sessions.sh
@@ -424,6 +424,9 @@ migrate_new_format() {
         }]' "$CHECKPOINT_PATH/metadata.json" > "$TARGET_DIR/$CHECKPOINT_DIR/metadata.json"
 
     # Copy and transform each session subdir's metadata.json
+    # -name '[0-9]*' restricts matches to numeric session directories, which cannot
+    # contain whitespace or globbing characters, so word splitting is safe here.
+    # shellcheck disable=SC2044
     for SUBDIR in $(find "$CHECKPOINT_PATH" -maxdepth 1 -mindepth 1 -type d -name '[0-9]*'); do
         local SUBDIR_NUM
         SUBDIR_NUM=$(basename "$SUBDIR")

--- a/scripts/test-codex-agent-integration.sh
+++ b/scripts/test-codex-agent-integration.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Declared for parity with test-copilot-cli-agent-integration.sh, which prints it in its banner.
+# shellcheck disable=SC2034
 AGENT_NAME="Codex"
 AGENT_SLUG="codex"
 AGENT_BIN="codex"
@@ -156,6 +158,9 @@ if [ "${1:-}" = "--run-cmd" ]; then
     shift
     echo "=== Automated Run ==="
     echo "Running: $*"
+    # --run-cmd takes a command *string*, which is intentionally re-parsed so that
+    # pipelines and redirection work. Executing "$@" directly would break that.
+    # shellcheck disable=SC2294
     eval "$@" || true
     sleep 2
 elif [ "${1:-}" = "--manual-live" ]; then

--- a/scripts/test-copilot-cli-agent-integration.sh
+++ b/scripts/test-copilot-cli-agent-integration.sh
@@ -292,7 +292,7 @@ check_event() {
     local event_name="$1"
     local entire_event="$2"
     local found=false
-    for f in "$CAPTURE_DIR"/${event_name}-*.json; do
+    for f in "$CAPTURE_DIR"/"${event_name}"-*.json; do
         [[ -e "$f" ]] && found=true && break
     done
     if $found; then
@@ -317,7 +317,7 @@ echo ""
 REQUIRED_EVENTS=("sessionStart" "userPromptSubmitted" "agentStop" "sessionEnd")
 REQUIRED_FOUND=0
 for evt in "${REQUIRED_EVENTS[@]}"; do
-    for f in "$CAPTURE_DIR"/${evt}-*.json; do
+    for f in "$CAPTURE_DIR"/"${evt}"-*.json; do
         [[ -e "$f" ]] && REQUIRED_FOUND=$((REQUIRED_FOUND + 1)) && break
     done
 done


### PR DESCRIPTION
Closes #2203.

## The gap

`mise-tasks/lint/shellcheck` ran `find mise-tasks`, so nothing under `scripts/` was ever linted — including `scripts/install.sh`, which is served from `https://entire.io/install.sh` and piped into users' shells.

While fixing that I found a second hole in the same line. The shebang test was:

```sh
head -1 "$1" | grep -q "^#!/bin/sh\|^#!/bin/bash"
```

That matches only literal `/bin/sh` and `/bin/bash`, so four tasks using `#!/usr/bin/env bash` — `bench/cpu`, `bench/compare`, `bench/mem`, `dev/publish` — were silently skipped **inside `mise-tasks` itself**. They were never covered, and nothing reported that.

Widening the path and the matcher takes coverage from **18 files to 32**.

## Findings

`scripts/install.sh` — the script the issue is actually about — is **already clean**. The seven findings were elsewhere, and all are fixed or documented:

| File | Rule | Treatment |
|---|---|---|
| `download-e2e-artifacts.sh` | SC2012, SC2035 | `ls -d */` → `find` |
| `download-e2e-artifacts.sh` | SC2001 | `sed` → parameter expansion |
| `test-copilot-cli-agent-integration.sh` | SC2231 ×2 | quoted the glob prefix |
| `test-codex-agent-integration.sh` | SC2034 | documented `disable` |
| `test-codex-agent-integration.sh` | SC2294 | documented `disable` |
| `migrate-sessions.sh` | SC2044 | documented `disable` |

I used `disable` only where the existing code is correct and changing it would be wrong:

- **SC2294** — `--run-cmd` takes a command *string* that is intentionally re-parsed, so pipelines and redirection work. Executing `"$@"` directly would break that.
- **SC2044** — the `find` is constrained by `-name '[0-9]*'`, so matches cannot contain whitespace or glob characters.
- **SC2034** — `AGENT_NAME` is genuinely unused in the codex probe, but its copilot sibling prints it in a banner. Left in place for parity rather than deleted.

## Equivalence of the two rewrites

The `agents_found` rewrite preserves sorted, comma-joined output, including the dash-containing name that SC2035 warned about, and still ignores loose files:

```
fixture: claude/ codex/ copilot-cli/ zed/ loose-file.txt
before:  claude,codex,copilot-cli,zed
after:   claude,codex,copilot-cli,zed
```

The SC2001 rewrite is likewise identical (`a"b,c"d` → `a\"b,c\"d` both ways).

`basename` is used instead of `find -printf`, which is GNU-only and absent on macOS.

## No PowerShell linter

The issue also suggested adding PSScriptAnalyzer for `scripts/install.ps1`. **That file does not exist** — there are no `.ps1` files anywhere in the repository (`extension:ps1` code search returns 0). I left it out rather than add a job that lints nothing; happy to add it alongside the first `.ps1` that lands.

## Verification

```
$ sh mise-tasks/lint/shellcheck ; echo $?
0
```

32 files, shellcheck 0.11.0, clean.