### PR TITLE
Top-level 'entire clone' command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,9 +106,11 @@ in stable releases, always runnable): `tokens`, `import`, `review`,
 
 Top-level lifecycle and standalone commands: `enable`, `disable`, `status`,
 `login`, `logout`, `clean`, `version`, `dispatch`, `activity`, `help`,
-`configure`, `agent-help`, `api`, `search`. `search` is the canonical
+`configure`, `agent-help`, `api`, `search`, `clone`. `search` is the canonical
 spelling (visible in every build, grouped with Sessions & Checkpoints);
-`checkpoint search` stays a working alias of the same command.
+`checkpoint search` stays a working alias of the same command. `clone` is
+likewise the canonical top-level spelling (grouped with Control Plane);
+`repo clone` stays a working alias of the same command.
 
 `api` is an authenticated passthrough to Entire's HTTP APIs (gh-style): it
 attaches the right bearer and dials the right host so callers don't plumb auth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,9 @@ Top-level lifecycle and standalone commands: `enable`, `disable`, `status`,
 `configure`, `agent-help`, `api`, `search`, `clone`. `search` is the canonical
 spelling (visible in every build, grouped with Sessions & Checkpoints);
 `checkpoint search` stays a working alias of the same command. `clone` is
-likewise the canonical top-level spelling (grouped with Control Plane);
-`repo clone` stays a working alias of the same command.
+likewise the canonical top-level spelling (in its own Repositories group —
+it's a git content operation, deliberately out of the `repo` group's
+control-plane scope); `repo clone` stays a working alias of the same command.
 
 `api` is an authenticated passthrough to Entire's HTTP APIs (gh-style): it
 attaches the right bearer and dials the right host so callers don't plumb auth

--- a/cmd/entire/cli/agent_help_cmd.go
+++ b/cmd/entire/cli/agent_help_cmd.go
@@ -164,6 +164,7 @@ var agentHelpClassification = map[string]agentHelpFacts{
 	"agent":       {agentHelpAudienceUserOwned, false},
 	"auth":        {agentHelpAudienceUserOwned, false},
 	"clean":       {agentHelpAudienceUserOwned, false},
+	"clone":       {agentHelpAudienceUserOwned, false},
 	"configure":   {agentHelpAudienceUserOwned, false},
 	"disable":     {agentHelpAudienceUserOwned, false},
 	"enable":      {agentHelpAudienceUserOwned, false},

--- a/cmd/entire/cli/entiredir_guard_test.go
+++ b/cmd/entire/cli/entiredir_guard_test.go
@@ -41,6 +41,7 @@ var entireDirCheckExemptions = map[string]string{
 	"entire org":        "control-plane only",
 	"entire project":    "control-plane only",
 	"entire repo":       "control-plane only; git content operations are out of scope",
+	"entire clone":      "clones into a new directory; runs outside any repo",
 	"entire grant":      "control-plane only",
 	"entire api":        "authenticated passthrough; no local state",
 	"entire plugin":     "managed installs live under the per-user dirs",

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -259,12 +259,7 @@ func newRepoCloneCmd() *cobra.Command {
 	return cmd
 }
 
-// newTopLevelCloneCmd is the top-level `entire clone` — the same command as
-// `entire repo clone`, registered at root (like `search`). Registered under the
-// `repo` group it inherits the control-plane persistent flags from
-// addControlPlaneFlags; at top level there is no such parent, so the flags are
-// added here (insecureHTTPRequested fails soft when the flag is undefined,
-// which would silently drop --insecure-http-auth).
+// `repo clone`, registered at root.
 func newTopLevelCloneCmd() *cobra.Command {
 	cmd := newRepoCloneCmd()
 	addControlPlaneFlags(cmd)

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -146,12 +146,12 @@ func newRepoCloneCmd() *cobra.Command {
 			"A full `entire://` URL already names the cluster, so it's passed straight " +
 			"through to `git clone` with no lookup (and --cluster is ignored). The " +
 			"optional [target-dir] is passed through to `git clone` either way.",
-		Example: "  entire repo clone /et/project/example\n" +
-			"  entire repo clone project/example\n" +
-			"  entire repo clone /gh/entirehq/entire-api\n" +
-			"  entire repo clone /gh/entirehq/entire-api ./entire-api\n" +
-			"  entire repo clone /gh/entirehq/entire-api --cluster aws-us-east-2.entire.io\n" +
-			"  entire repo clone entire://aws-us-east-2.entire.io/gh/entirehq/entire-api",
+		Example: "  entire clone /et/project/example\n" +
+			"  entire clone project/example\n" +
+			"  entire clone /gh/entirehq/entire-api\n" +
+			"  entire clone /gh/entirehq/entire-api ./entire-api\n" +
+			"  entire clone /gh/entirehq/entire-api --cluster aws-us-east-2.entire.io\n" +
+			"  entire clone entire://aws-us-east-2.entire.io/gh/entirehq/entire-api",
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
@@ -256,6 +256,18 @@ func newRepoCloneCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&cluster, "cluster", "", "Cluster host to clone from when the repo is mirrored on more than one (may belong to another auth context)")
+	return cmd
+}
+
+// newTopLevelCloneCmd is the top-level `entire clone` — the same command as
+// `entire repo clone`, registered at root (like `search`). Registered under the
+// `repo` group it inherits the control-plane persistent flags from
+// addControlPlaneFlags; at top level there is no such parent, so the flags are
+// added here (insecureHTTPRequested fails soft when the flag is undefined,
+// which would silently drop --insecure-http-auth).
+func newTopLevelCloneCmd() *cobra.Command {
+	cmd := newRepoCloneCmd()
+	addControlPlaneFlags(cmd)
 	return cmd
 }
 

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -196,9 +196,10 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(inGroup(newDispatchCmd(), groupSessions))
 	cmd.AddCommand(inGroup(newActivityCmd(), groupSessions))
 	cmd.AddCommand(inGroup(newRecapCmd(), groupSessions))
-	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newAPICmd(), groupControlPlane))) // authenticated passthrough to core/cell APIs
-	cmd.AddCommand(newAgentHelpCmd(cmd))                                              // visible: agents on transports without context injection discover it via `entire help`
-	cmd.AddCommand(inGroup(newSearchCmd(), groupSessions))                            // 'search' — canonical top-level spelling; 'checkpoint search' stays a working alias
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newAPICmd(), groupControlPlane)))           // authenticated passthrough to core/cell APIs
+	cmd.AddCommand(newAgentHelpCmd(cmd))                                                        // visible: agents on transports without context injection discover it via `entire help`
+	cmd.AddCommand(inGroup(newSearchCmd(), groupSessions))                                      // 'search' — canonical top-level spelling; 'checkpoint search' stays a working alias
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newTopLevelCloneCmd(), groupControlPlane))) // 'clone' — canonical top-level spelling; 'repo clone' stays a working alias
 
 	// Experimental labs commands (listed via `entire labs`; not deprecation shortcuts).
 	experimental.Register(cmd, newExpertsCmd()) // 'experts' (experimental); agent/workflow provenance

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -40,6 +40,7 @@ Environment Variables:
 const (
 	groupSetup        = "setup"
 	groupSessions     = "sessions"
+	groupRepos        = "repositories"
 	groupAccount      = "account"
 	groupControlPlane = "controlplane"
 )
@@ -161,6 +162,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddGroup(
 		&cobra.Group{ID: groupSetup, Title: "Entire Setup:"},
 		&cobra.Group{ID: groupSessions, Title: "Sessions & Checkpoints:"},
+		&cobra.Group{ID: groupRepos, Title: "Repositories:"},
 		&cobra.Group{ID: groupAccount, Title: "Account:"},
 		&cobra.Group{ID: groupControlPlane, Title: "Control Plane:"},
 	)
@@ -196,10 +198,10 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(inGroup(newDispatchCmd(), groupSessions))
 	cmd.AddCommand(inGroup(newActivityCmd(), groupSessions))
 	cmd.AddCommand(inGroup(newRecapCmd(), groupSessions))
-	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newAPICmd(), groupControlPlane)))           // authenticated passthrough to core/cell APIs
-	cmd.AddCommand(newAgentHelpCmd(cmd))                                                        // visible: agents on transports without context injection discover it via `entire help`
-	cmd.AddCommand(inGroup(newSearchCmd(), groupSessions))                                      // 'search' — canonical top-level spelling; 'checkpoint search' stays a working alias
-	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newTopLevelCloneCmd(), groupControlPlane))) // 'clone' — canonical top-level spelling; 'repo clone' stays a working alias
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newAPICmd(), groupControlPlane)))    // authenticated passthrough to core/cell APIs
+	cmd.AddCommand(newAgentHelpCmd(cmd))                                                 // visible: agents on transports without context injection discover it via `entire help`
+	cmd.AddCommand(inGroup(newSearchCmd(), groupSessions))                               // 'search' — canonical top-level spelling; 'checkpoint search' stays a working alias
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newTopLevelCloneCmd(), groupRepos))) // 'clone' — canonical top-level spelling; 'repo clone' stays a working alias
 
 	// Experimental labs commands (listed via `entire labs`; not deprecation shortcuts).
 	experimental.Register(cmd, newExpertsCmd()) // 'experts' (experimental); agent/workflow provenance

--- a/cmd/entire/cli/root_test.go
+++ b/cmd/entire/cli/root_test.go
@@ -300,7 +300,7 @@ func TestRoot_VisibleCommandsAreGrouped(t *testing.T) {
 		"org":        groupControlPlane,
 		"project":    groupControlPlane,
 		"repo":       groupControlPlane,
-		"clone":      groupControlPlane,
+		"clone":      groupRepos,
 		"grant":      groupControlPlane,
 		"api":        groupControlPlane,
 	}

--- a/cmd/entire/cli/root_test.go
+++ b/cmd/entire/cli/root_test.go
@@ -300,6 +300,7 @@ func TestRoot_VisibleCommandsAreGrouped(t *testing.T) {
 		"org":        groupControlPlane,
 		"project":    groupControlPlane,
 		"repo":       groupControlPlane,
+		"clone":      groupControlPlane,
 		"grant":      groupControlPlane,
 		"api":        groupControlPlane,
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1196
<!-- entire-trail-link-end -->

## Why

Cloning is a front-door action; `entire repo clone` buries it one group deep.

## What

`entire clone <repo> [target-dir]` — the same command as `repo clone`, now also registered at top level (the `search` precedent). `repo clone` stays a working alias. Takes `/gh/<owner>/<repo>` refs, `--cluster`, and raw `entire://` URLs exactly as before.

In `entire --help` it gets its own "Repositories:" group (after Sessions & Checkpoints) rather than sitting in Control Plane — clone is a git content operation, deliberately out of the `repo` group's control-plane scope.

agent-help classification: user-owned, unlisted (safe default — promote if desired).

Split out of https://github.com/entireio/cli/pull/2185, which now carries only the `/et/<project>/<repo>` native-ref feature.

## Verification

`mise run fmt && mise run lint` green locally; tests in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)