### PR TITLE
test: skip git-core config in GitIsolatedEnv

### DIFF
--- a/cmd/entire/cli/testutil/testutil.go
+++ b/cmd/entire/cli/testutil/testutil.go
@@ -339,9 +339,17 @@ func gitEmptyConfigPath() string {
 // GIT_CONFIG_PARAMETERS and the indexed KEY_/VALUE_ pairs that can inject
 // `git -c` overrides — so our explicit isolation overrides take effect
 // regardless of parent env.
+//
+// GIT_CONFIG_NOSYSTEM=1 is required, not redundant with GIT_CONFIG_SYSTEM.
+// Apple Git still reads credential.helper=osxkeychain from
+// /Library/Developer/CommandLineTools/usr/share/git-core/gitconfig when only
+// GIT_CONFIG_SYSTEM is overridden; that helper is what hangs a 401 from a
+// loopback HTTPS server (GIT_TERMINAL_PROMPT=0 does not stop helpers, and the
+// hermetic proxy does not cover 127.0.0.1). IsolateGitConfigEnv sets the same
+// flag for in-process git.
 func GitIsolatedEnv() []string {
 	env := os.Environ()
-	filtered := make([]string, 0, len(env)+2)
+	filtered := make([]string, 0, len(env)+3)
 	for _, e := range env {
 		if isGitConfigEnv(e) {
 			continue
@@ -351,6 +359,7 @@ func GitIsolatedEnv() []string {
 	return append(filtered,
 		"GIT_CONFIG_GLOBAL="+gitEmptyConfigPath(), // Isolate from user's global git config (e.g. global gitignore)
 		"GIT_CONFIG_SYSTEM="+gitEmptyConfigPath(), // Isolate from system git config
+		"GIT_CONFIG_NOSYSTEM=1",                   // Skip Apple git-core config (osxkeychain); GIT_CONFIG_SYSTEM does not replace it
 	)
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1199
<!-- entire-trail-link-end -->

## Summary

`GitIsolatedEnv` now sets `GIT_CONFIG_NOSYSTEM=1`, matching `IsolateGitConfigEnv`.

`GIT_CONFIG_SYSTEM` does not replace Apple Git's `git-core/gitconfig`, so integration tests still loaded `credential.helper=osxkeychain`. A 401 from the in-process HTTPS git server then hung `git` (`GIT_TERMINAL_PROMPT=0` does not stop helpers). That stalled `TestHTTPS_PushFailsWithoutToken/git-refs` until the 10-minute package timeout and broke the complexity-tooling coverage run.

Stacked on #2194 so it can be reviewed against that branch.

## Test plan

- [x] `gofmt` + golangci-lint on `./cmd/entire/cli/testutil/`
- [ ] `go test -tags=integration -timeout=60s -run TestHTTPS_PushFailsWithoutToken ./cmd/entire/cli/integration_test/`
- [ ] Re-run the complexity coverage integration profile (`go test -tags=integration -coverprofile=...`) and confirm it no longer times out on that test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only environment wiring in shared testutil; no production behavior change.
> 
> **Overview**
> **`GitIsolatedEnv`** now appends **`GIT_CONFIG_NOSYSTEM=1`**, aligning subprocess git isolation with **`IsolateGitConfigEnv`**.
> 
> On Apple Git, overriding **`GIT_CONFIG_SYSTEM`** alone still loads **`credential.helper=osxkeychain`** from the Command Line Tools **`git-core/gitconfig`**. Integration tests that hit a loopback HTTPS git server and get a 401 could then hang in the keychain helper ( **`GIT_TERMINAL_PROMPT=0`** and the hermetic proxy do not cover that path for **`127.0.0.1`**), which stalled **`TestHTTPS_PushFailsWithoutToken`** and long coverage runs.
> 
> Comments in **`testutil.go`** document why **`GIT_CONFIG_NOSYSTEM`** is required and not redundant with **`GIT_CONFIG_SYSTEM`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fb846d7bbaae2f9ae0910c5541e5bf71b205956. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->