### PR TITLE
Close the remaining git isolation gaps for #2202

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -119,6 +119,16 @@ linters:
         - pattern: '^.*\.(Print|Println|Printf)$'
           msg: "cobra's Print* writes to OutOrStderr (stderr in production); use fmt.Fprint*(cmd.OutOrStdout(), ...)"
           pkg: 'github\.com/spf13/cobra'
+        # forbidigo matches identifiers/selectors, not call arguments, so it
+        # cannot single out exec.Command(..., "git", ...) from other exec.Command
+        # uses (spawning the test binary, "sh", etc). It bans the whole
+        # exec.Command/CommandContext selector instead, scoped down to just the
+        # test files that should exclusively shell to git through the isolated
+        # helper (testutil.RunGit / gitenv.Run) via the path-except exclusion
+        # below - see the "git isolation" exclusion rule.
+        - pattern: '^exec\.(Command|CommandContext)$'
+          msg: "raw exec.Command/CommandContext in this test file reads the developer's global gitconfig - shell out via testutil.RunGit(t, dir, args...) (or gitenv.Run) so GitIsolatedEnv() applies; see #2202"
+          pkg: '^os/exec$'
     govet:
       enable-all: true
       disable:
@@ -142,7 +152,29 @@ linters:
         linters:
           - gosec
           - wrapcheck
+      # forbidigo's other rules (os.Getwd, go-git Reset/Checkout/Worktree.Status,
+      # cobra Print*) are about production code; test files legitimately use
+      # some of these APIs directly, so those specific messages stay exempt
+      # here exactly as before. The git-isolation rule added above is NOT
+      # listed here on purpose - it must keep firing in the handful of test
+      # files it targets (see the path-except rule below), or the whole point
+      # of adding it is defeated.
+      - path: _test\.go
+        linters:
           - forbidigo
+        text: "os\\.Getwd\\(\\) breaks when running from subdirectories|go-git Reset deletes \\.gitignored dirs|go-git Checkout deletes \\.gitignored dirs|go-git Worktree\\.Status\\(\\) walks the whole worktree|cobra's Print\\* writes to OutOrStderr"
+      # The git-isolation exec.Command/CommandContext ban (see forbidigo.forbid
+      # above) is scoped to just the test files issue #2202 covers. Enabling it
+      # repo-wide would also flag every other pre-existing direct git shell-out
+      # in *_test.go (a much larger, separate cleanup) and the handful of
+      # legitimate non-git exec.Command calls (spawning the built binary, `sh`
+      # for a fake-failure fixture) inside these same files, which carry their
+      # own //nolint:forbidigo instead. path-except keeps the issue suppressed
+      # everywhere except inside this file list, i.e. it only fires there.
+      - linters:
+          - forbidigo
+        text: "raw exec\\.Command/CommandContext in this test file reads the developer's global gitconfig"
+        path-except: '(^|/)cmd/entire/cli/(review/scope_test\.go|gitrepo/gitstatus_guard_test\.go|strategy/commit_hook_perf_test\.go|review_context_test\.go|integration_test/resume_test\.go|checkpoint/redact_cache_scope_test\.go|checkpoint/remote/git_test\.go)$'
       - path: ^e2e/
         linters:
           - errcheck

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -773,7 +773,7 @@ func envToMap(env []string) map[string]string {
 // gitConfigBool reads a local git config key and reports whether it is set to a
 // true value. Missing keys and read errors report false.
 func gitConfigBool(ctx context.Context, dir, key string) bool {
-	cmd := exec.CommandContext(ctx, "git", "config", "--local", "--get", "--type=bool", key)
+	cmd := exec.CommandContext(ctx, "git", "config", "--local", "--get", "--type=bool", key) //nolint:forbidigo // returns false (not *testing.T fatal) on a missing key, so it can't use testutil.RunGit; isolated via GitIsolatedEnv() below
 	cmd.Env = testutil.GitIsolatedEnv()
 	if dir != "" {
 		cmd.Dir = dir
@@ -1259,7 +1259,7 @@ func TestFormatGitCommandError_RedactsRemoteURL(t *testing.T) {
 
 	remote := "https://user:hunter2@github.com/org/repo.git"
 	// Output() populates ExitError.Stderr (Run() does not).
-	cmd := exec.CommandContext(context.Background(), "sh", "-c",
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", //nolint:forbidigo // fakes a git failure via /bin/sh, doesn't invoke git itself
 		fmt.Sprintf(`printf 'fatal: repository "%s" not found\n' >&2; exit 128`, remote))
 	_, err := cmd.Output()
 	require.Error(t, err)

--- a/cmd/entire/cli/integration_test/resume_test.go
+++ b/cmd/entire/cli/integration_test/resume_test.go
@@ -506,7 +506,7 @@ func (env *TestEnv) RunResumeForce(branchName string) (string, error) {
 	env.T.Helper()
 
 	ctx := env.T.Context()
-	cmd := exec.CommandContext(ctx, getTestBinary(), "session", "resume", "--force", branchName)
+	cmd := exec.CommandContext(ctx, getTestBinary(), "session", "resume", "--force", branchName) //nolint:forbidigo // spawns the compiled entire binary, not git; cmd.Env below still isolates it
 	cmd.Dir = env.RepoDir
 	cmd.Env = append(testutil.GitIsolatedEnv(),
 		"ENTIRE_TEST_CLAUDE_PROJECT_DIR="+env.ClaudeProjectDir,

--- a/cmd/entire/cli/review_context_test.go
+++ b/cmd/entire/cli/review_context_test.go
@@ -98,12 +98,14 @@ func TestReviewCheckpointContext_UsesTargetRepoCheckpointRemotes(t *testing.T) {
 
 	localRef := "refs/heads/" + paths.MetadataBranchName
 	cmd := exec.CommandContext(t.Context(), "git", "-C", repoRoot, "rev-parse", localRef)
+	cmd.Env = testutil.GitIsolatedEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatal(err)
 	}
 	testutil.GitUpdateRef(t, repoRoot, "refs/remotes/upstream/"+paths.MetadataBranchName, strings.TrimSpace(string(out)))
 	cmd = exec.CommandContext(t.Context(), "git", "-C", repoRoot, "update-ref", "-d", localRef)
+	cmd.Env = testutil.GitIsolatedEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("delete local checkpoint ref: %v\n%s", err, out)
 	}


### PR DESCRIPTION
Addresses the remaining part of #2202: isolates the two raw git calls in review_context_test.go and adds a forbidigo rule banning bare exec.Command git in _test.go (nolint on the legitimate sites). NOTE: much of #2202 already landed on main — please confirm with maintainers this gap is still open before merging. Verified: build + vet + tests green under a hostile global gitconfig.