### PR TITLE
docs: lead with the refs checkpoint backend; cut claims that contradict the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ With Entire, you can:
 
 - **Understand why code changed** — see the full prompt/response transcript and files touched
 - **Recover instantly** — resume from a known-good checkpoint when an agent goes sideways
-- **Keep Git history clean** — preserve agent context on a separate branch
+- **Keep Git history clean** — agent context lives outside your branch's history
 - **Onboard faster** — show the path from prompt → change → commit
 - **Maintain traceability** — support audit and compliance requirements when needed
 
@@ -20,13 +20,17 @@ With Entire, you can:
 ## Table of Contents
 
 - [Why Entire](#why-entire)
+- [Requirements](#requirements)
 - [Quick Start](#quick-start)
+- [Release Channels](#release-channels)
 - [Typical Workflow](#typical-workflow)
 - [Key Concepts](#key-concepts)
+  - [Sessions](#sessions)
+  - [Checkpoints](#checkpoints)
+  - [Checkpoint Storage](#checkpoint-storage)
   - [How It Works](#how-it-works)
   - [Strategy](#strategy)
 - [Headless & CI Authentication](#headless--ci-authentication)
-- [Local Device Auth Testing](#local-device-auth-testing)
 - [Commands Reference](#commands-reference)
 - [Plugins](#plugins)
 - [Configuration](#configuration)
@@ -41,6 +45,7 @@ With Entire, you can:
 - Git
 - macOS, Linux or Windows
 - [Supported agent](#agent-hook-configuration) installed and authenticated
+- Go 1.26+ only if you install with `go install` (the packaged installs bundle their own runtime)
 
 ## Quick Start
 
@@ -99,6 +104,8 @@ go install github.com/entireio/cli/cmd/entire@latest
 export PATH="$HOME/go/bin:$PATH"
 ```
 
+This installs `entire` only. The packaged installs above also ship `git-remote-entire`, which is what resolves `entire://` and `entire clone` URLs — install with Homebrew, Scoop, or `install.sh` if you need those.
+
 ### Enable in your project
 
 ```bash
@@ -142,7 +149,7 @@ After setup:
 - Use `entire agent` to add or remove agents.
 - Use `entire configure` to update non-agent settings (telemetry, hooks, checkpoint remote, summary provider).
 
-The hooks capture session data as you work. Checkpoints are created when you or the agent make a git commit. Your code commits stay clean, Entire never creates commits on your active branch. All session metadata is stored on a separate `entire/checkpoints/v1` branch.
+The hooks capture session data as you work. Checkpoints are created when you or the agent make a git commit. Your code commits stay clean, Entire never creates commits on your active branch. Session metadata is stored outside your branch's history, in the checkpoint storage described under [Checkpoint Storage](#checkpoint-storage).
 
 ### 2. Work with Your AI Agent
 
@@ -176,38 +183,80 @@ Removes the git hooks. Your code and commit history remain untouched.
 
 A **session** represents a complete interaction with your AI agent, from start to finish. Each session captures all prompts, responses, files modified, and timestamps.
 
-**Session ID format:** `YYYY-MM-DD-<UUID>` (e.g., `2026-01-08-abc123de-f456-7890-abcd-ef1234567890`)
+The session ID is the agent's own session identifier — a UUID for every currently supported agent (e.g. `019efea2-b46a-7cbc-be01-4c13460f5019`), so an ID you see in `entire session list` is the same one the agent uses.
 
-Sessions are stored separately from your code commits on the `entire/checkpoints/v1` branch.
+Sessions are stored separately from your code commits, in the repo's checkpoint storage.
 
 ### Checkpoints
 
 A **checkpoint** is a snapshot within a session—a "save point" in your work.
 
-Checkpoints are created when you or the agent make a git commit. **Checkpoint IDs** are 12-character hex strings (e.g., `a3b2c4d5e6f7`).
+Checkpoints are created when you or the agent make a git commit, and the commit carries an `Entire-Checkpoint: <id>` trailer linking the two.
+
+**Checkpoint IDs** come in two formats, decided by the storage backend: a 26-character ULID (e.g. `01K9TQ8ZP7X3F5M2WVJ4CNRB6D`) on the default `git-refs` backend, or a legacy 12-character hex string (e.g. `a3b2c4d5e6f7`) on `git-branch`. Both formats stay readable in the same repo.
+
+### Checkpoint Storage
+
+Checkpoints live in your repository's own git object store, never in your branch's history. Two backends exist, and which one a repo uses is recorded in its `.entire/settings.json`:
+
+**`git-refs` — the default for new repos, and the recommended backend.** Each checkpoint is its own git ref:
+
+```
+refs/entire/checkpoints/<shard>/<id>
+```
+
+The ref points at a commit whose tree *is* that checkpoint. Because checkpoints are independent refs, they are written, pushed, and fetched independently: there is no shared tip for concurrent sessions to contend on, and a reader can fetch exactly the one checkpoint it needs instead of a whole branch of history. Checkpoint IDs are ULIDs, which sort by creation time.
+
+**`git-branch` — the legacy backend.** Every checkpoint is a subtree of one long-lived branch, `entire/checkpoints/v1`. That branch is a serialization point: every checkpoint rewrites its tip, every push races on the same ref, and the entire history travels together on fetch. Checkpoint IDs are 12-character hex strings.
+
+`entire enable` writes `git-refs` into the settings of a repo it sets up for the first time. A repo configured before that default — anything with no `checkpoints` block in its settings — keeps running on `git-branch`, unchanged, until you switch it.
+
+Choose or change the backend:
+
+```bash
+entire configure --checkpoint-backend refs      # switch an existing repo to per-checkpoint refs
+entire configure --checkpoint-backend branch    # back to the shared v1 branch
+entire enable --checkpoint-backend branch       # opt out at first-time setup
+```
+
+Or set it directly:
+
+```json
+{
+  "checkpoints": {
+    "primary": { "type": "git-refs" }
+  }
+}
+```
+
+**Switching is safe in both directions and needs no migration.** Readers route by checkpoint ID: a ULID resolves through refs, and a legacy hex ID is tried in refs first and then on the `entire/checkpoints/v1` branch. Checkpoints already written stay readable exactly where they are; only new checkpoints use the new backend. This holds for every reader — the CLI, entire.io, and the Entire API all route the same way.
+
+Moving existing branch checkpoints into refs is optional. `entire doctor migrate-checkpoints` does it, is idempotent, and leaves the existing branch commits in place; run it with `--dry-run` first to see what it would convert.
+
+One consequence worth knowing: an older CLI cannot read ULID checkpoints. It fails closed with an upgrade prompt rather than half-working.
 
 ### How It Works
 
 ```
-Your Branch                    entire/checkpoints/v1
+Your Branch                      Checkpoint storage
      │                                  │
      ▼                                  │
 [Base Commit]                           │
      │                                  │
      │  ┌─── Agent works ───┐           │
-     │  │  Step 1           │           │
-     │  │  Step 2           │           │
-     │  │  Step 3           │           │
+     │  │  Turn 1           │           │
+     │  │  Turn 2           │           │
+     │  │  Turn 3           │           │
      │  └───────────────────┘           │
      │                                  │
      ▼                                  ▼
-[Your Commit] ─────────────────► [Session Metadata]
-     │                           (transcript, prompts,
-     │                            files touched)
+[Your Commit] ─────────────────► [Checkpoint]
+  Entire-Checkpoint: <id>          (transcript, prompts,
+     │                              files touched, tokens)
      ▼
 ```
 
-Checkpoints are saved as you work. When you commit, session metadata is permanently stored on the `entire/checkpoints/v1` branch and linked to your commit.
+Work in progress is held on a short-lived shadow branch as you go. When you commit, that work is condensed into a permanent checkpoint and linked to your commit by an `Entire-Checkpoint` trailer.
 
 ### Strategy
 
@@ -215,7 +264,7 @@ Entire uses a manual-commit strategy that keeps your git history clean:
 
 - **No commits on your branch** — Entire never creates commits on the active branch
 - **Safe on any branch** — works on main, master, and feature branches alike
-- **Metadata stored separately** — all session data lives on the `entire/checkpoints/v1` branch
+- **Metadata stored separately** — session data lives in per-checkpoint refs (or on the `entire/checkpoints/v1` branch on the legacy backend), never in your branch's history
 
 ### Git Worktrees
 
@@ -223,20 +272,22 @@ Entire works seamlessly with [git worktrees](https://git-scm.com/docs/git-worktr
 
 ### Concurrent Sessions
 
-Multiple AI sessions can run on the same commit. If you start a second session while another has uncommitted work, Entire warns you and tracks them separately. Both sessions' checkpoints are preserved and can be rewound independently.
+Multiple AI sessions can run on the same commit. If you start a second session while another has uncommitted work, Entire warns you and tracks them separately. Both sessions' checkpoints are preserved, and a commit condenses every session with pending work in that worktree.
 
 ## Headless & CI Authentication
 
-By default `entire login` stores tokens in the OS keyring (macOS Keychain,
-Linux Secret Service, Windows Credential Manager). Machines without a usable
-keyring — headless servers, containers, minimal VMs, CI runners — have two
-supported paths:
+By default `entire login` opens a browser to sign in and stores tokens in the OS
+keyring (macOS Keychain, Linux Secret Service, Windows Credential Manager).
+Machines without a usable browser or keyring — headless servers, containers,
+minimal VMs, CI runners — have two supported paths:
 
 ### Interactive login on a headless machine
 
-Use the file-backed token store. The device-auth flow already works without a
-local browser (the CLI prints an approval URL you can open on any machine);
-only token storage needs the override:
+Sign-in itself already handles this: with no interactive terminal, or over SSH,
+`entire login` switches to the device-code flow on its own and prints an
+approval URL you can open on any machine. `entire login --device` forces that
+flow explicitly. Only token *storage* needs an override — use the file-backed
+store:
 
 ```bash
 ENTIRE_TOKEN_STORE=file entire login
@@ -263,80 +314,99 @@ path for CI pipelines and service accounts.
 > `entire login`?** That's the OS keyring being unavailable — use one of the
 > two paths above.
 
-## Local Device Auth Testing
-
-If you're working on the CLI device auth flow against a local `entire.io` checkout:
-
-```bash
-# In your app repo
-cd ../entire.io-1
-mise run dev
-
-# In this repo, point the CLI at the local API. The login flow targets
-# the local server via --server (the default is the production
-# auth.entire.io, which dispatches to a regional login server such as
-# us.auth.entire.io).
-cd ../cli
-export ENTIRE_API_BASE_URL=http://localhost:8787
-entire login --server https://localhost:8180
-
-# Run the smoke test
-./scripts/local-device-auth-smoke.sh
-```
-
-Useful commands while developing:
-
-```bash
-# Run the login flow against a local server (prompts to press Enter before opening the browser)
-go run ./cmd/entire login --server https://localhost:8180
-
-# Run the focused integration coverage for login
-go test -tags=integration ./cmd/entire/cli/integration_test -run TestLogin
-```
-
 ## Commands Reference
 
-| Command          | Description                                                                                       |
-| ---------------- | ------------------------------------------------------------------------------------------------- |
-| `entire clean`   | Clean up session data and orphaned Entire data (use `--all` for repo-wide cleanup)                |
-| `entire agent`   | Add, remove, or list agent integrations for the current repository                                |
-| `entire configure` | Update non-agent settings (telemetry, git hook, strategy options, summary provider)            |
-| `entire disable` | Remove Entire hooks from repository                                                               |
-| `entire doctor`  | Fix or clean up stuck sessions                                                                    |
-| `entire enable`  | Enable Entire in your repository                                                                  |
-| `entire checkpoint`        | List, explain, and search checkpoints                                                   |
-| `entire checkpoint explain` | Explain a session, commit, or checkpoint                                               |
-| `entire login`   | Authenticate the CLI with Entire device auth                                                      |
-| `entire org`     | Manage Entire organizations (create, list, get, delete)                                           |
-| `entire plugin`  | Discover, install, upgrade, and remove plugins (see [Plugins](#plugins))                          |
-| `entire project` | Manage Entire projects (create, list, get, delete)                                                |
-| `entire repo`    | Manage Entire repositories (create, list, get, delete, clone, mirror, visibility)                 |
-| `entire grant`   | Manage access grants and org membership (org, project, repo)                                      |
-| `entire session` | View and manage agent sessions tracked by Entire                                                  |
-| `entire session resume`    | Switch to a branch, restore latest checkpointed session metadata, and show command(s) |
-| `entire session attach`    | Attach to a previously detached session                                                |
-| `entire status`  | Show current session info                                                                         |
-| `entire doctor trace` | Show hook performance traces                                                                 |
-| `entire version` | Show Entire CLI version                                                                           |
+Descriptions below are the commands' own summaries. `entire help` always reflects the installed binary; `entire agent-help` is the machine-readable version agents read.
 
-`entire blame` and `entire why` are experimental Labs commands. Run `entire
-labs` to discover them. `entire blame <file>` shows which current file lines
-came from an Entire checkpoint, and `entire why <file>:<line>` jumps from a
-specific line back to the prompt, session, and checkpoint that created it. Use
-`entire blame <file> --long` for the full agent, model, author, and session
-table.
+### Setup
+
+| Command            | Description                                                                        |
+| ------------------ | ---------------------------------------------------------------------------------- |
+| `entire enable`    | Enable Entire in current repository                                                |
+| `entire disable`   | Disable Entire in current repository                                               |
+| `entire status`    | Show Entire status (`--json` for structured output)                                |
+| `entire agent`     | Manage agent integrations (`add`, `remove`, `list`)                                |
+| `entire configure` | Update non-agent Entire settings in the current repository                          |
+| `entire doctor`    | Diagnose and fix session issues (`trace`, `logs`, `bundle`, `migrate-checkpoints`)  |
+| `entire clean`     | Clean up Entire session data (`--all` for repo-wide cleanup)                       |
+| `entire plugin`    | Manage Entire plugins (see [Plugins](#plugins))                                    |
+
+### Sessions & Checkpoints
+
+| Command                       | Description                                                                              |
+| ----------------------------- | ---------------------------------------------------------------------------------------- |
+| `entire session`              | Manage agent sessions (`list`, `info`, `current`, `stop`, `attach`, `adopt`, `resume`, `tokens`) |
+| `entire session resume`       | Resume a stopped session — interactive picker, or by branch                               |
+| `entire checkpoint`           | Inspect and search checkpoints (`list`, `explain`, `tokens`, `search`)                    |
+| `entire checkpoint explain`   | Explain a checkpoint, commit, or session                                                 |
+| `entire search`               | Search checkpoints, commits, and sessions using semantic and keyword matching            |
+| `entire activity`             | Show your activity overview                                                              |
+| `entire recap`                | Summarize recent checkpoint activity                                                     |
+| `entire dispatch`             | Generate a dispatch summarizing recent agent work                                         |
+
+### Account
+
+| Command          | Description                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------ |
+| `entire login`   | Log in to Entire (browser by default; `--device` for the device-code flow)            |
+| `entire logout`  | Log out of Entire                                                                    |
+| `entire auth`    | Manage authentication (`status`, `contexts`, `use`, `token`, `login`, `logout`)       |
+
+### Control Plane
+
+| Command          | Description                                                                       |
+| ---------------- | --------------------------------------------------------------------------------- |
+| `entire clone`   | Clone an Entire repository                                                        |
+| `entire org`     | Manage Entire organizations (`create`, `list`, `get`, `delete`)                    |
+| `entire project` | Manage Entire projects (`create`, `list`, `get`, `delete`)                         |
+| `entire repo`    | Manage Entire repositories (`create`, `list`, `get`, `delete`, `clone`, `mirror`, `visibility`) |
+| `entire grant`   | Manage Entire access grants and org membership (`org`, `project`, `repo`)          |
+| `entire api`     | Make an authenticated request to an Entire API and print the response              |
+
+### Other
+
+| Command             | Description                                                                    |
+| ------------------- | ------------------------------------------------------------------------------ |
+| `entire agent-help` | Machine-readable usage for coding agents (always matches the installed CLI)     |
+| `entire labs`       | Explore experimental Entire workflows                                          |
+| `entire version`    | Show build information                                                         |
+
+### Experimental Commands
+
+These are visible in developer and nightly builds and hidden in stable releases, but always runnable in every build. Run `entire labs` to discover them.
+
+| Command              | Description                                              |
+| -------------------- | -------------------------------------------------------- |
+| `entire review`      | Run a multi-agent review against a branch                |
+| `entire investigate` | Run a multi-agent investigation against the current branch |
+| `entire tokens`      | Analyze token usage across sessions and checkpoints       |
+| `entire blame`       | Show which lines came from Entire checkpoints             |
+| `entire why`         | Show why a line exists                                   |
+| `entire experts`     | Rank agent provenance for code scopes                    |
+| `entire import`      | Import pre-existing agent history into Entire            |
+| `entire runner`      | Set up and tune trail runners for this repository        |
+
+`entire blame <file>` shows which current file lines came from an Entire checkpoint (`--long` for the full agent, model, author, and session table), and `entire why <file>:<line>` jumps from a specific line back to the prompt, session, and checkpoint that created it.
 
 ### `entire enable` Flags
 
 | Flag                                        | Description                                                                                                       |
 | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `--agent <name>`                            | AI agent to install hooks for: `claude-code`, `codex`, `gemini`, `opencode`, `cursor`, `factoryai-droid`, or `copilot-cli` |
+| `--agent <name>`                            | Agent to set up hooks for: `claude-code`, `codex`, `copilot-cli`, `cursor`, `factoryai-droid`, `gemini`, `opencode`, `pi` (external agents on `$PATH` also work). Enables non-interactive mode |
+| `--yes`, `-y`                               | Accept all defaults without prompting                                                                             |
 | `--force`, `-f`                             | Force reinstall hooks (removes existing Entire hooks first)                                                       |
-| `--local`                                   | Write settings to `settings.local.json` instead of `settings.json`                                                |
-| `--project`                                 | Write settings to `settings.json` even if it already exists                                                       |
-| `--skip-push-sessions`                      | Disable automatic pushing of session logs on git push                                                             |
-| `--checkpoint-remote <provider:owner/repo>` | Push checkpoint branches to a separate repo (e.g., `github:org/checkpoints-repo`)                                 |
+| `--checkpoint-backend refs` / `branch`      | Checkpoint storage backend (see [Checkpoint Storage](#checkpoint-storage)); new repos default to `refs`            |
+| `--checkpoint-remote <provider:owner/repo>` | Push checkpoint data to a separate repo (e.g., `github:org/checkpoints-repo`)                                     |
+| `--skip-push-sessions`                      | Disable automatic pushing of checkpoint data on git push                                                           |
+| `--local`                                   | Write settings to `.entire/settings.local.json` instead of `.entire/settings.json`                                |
+| `--project`                                 | Write settings to `.entire/settings.json` even if it already exists                                               |
+| `--absolute-git-hook-path`                  | Embed the full binary path in git hooks (for GUI git clients that don't source shell profiles)                    |
+| `--import-history`                          | During first-time setup, import the selected agents' existing session history (last 30 days) without prompting     |
+| `--search-skill`                            | Install the optional Entire search skill for the selected agent(s)                                                |
+| `--agent-help-skill`                        | Install the Entire agent-help skill (points agents at `entire agent-help`) for the selected agent(s)              |
 | `--telemetry=false`                         | Disable anonymous usage analytics                                                                                 |
+
+Run in a directory that is not a git repository, `entire enable` offers to initialize one and (optionally) create a matching GitHub repo via the `gh` CLI. That path is driven by `--init-repo` / `--no-init-repo`, `--no-github`, `--repo-name`, `--repo-owner`, `--repo-visibility`, `--push`, `--skip-initial-commit`, and `--initial-commit-message`. See `entire enable --help` for the full list.
 
 **Examples:**
 
@@ -364,8 +434,9 @@ Typical uses:
 
 - Toggle telemetry
 - Reinstall the Entire git hook (`--force`, `--absolute-git-hook-path`)
+- Switch the checkpoint storage backend (`--checkpoint-backend`)
 - Update strategy options such as `--checkpoint-remote` or `--skip-push-sessions`
-- Pick a summary provider for `entire explain --generate`
+- Pick the provider, model, and timeout for `entire checkpoint explain --generate` (`--summarize-provider`, `--summarize-model`, `--summarize-timeout-seconds`)
 
 **Examples:**
 
@@ -379,10 +450,19 @@ entire configure --telemetry=false
 # Reinstall the Entire git hook with an absolute binary path
 entire configure --absolute-git-hook-path
 
+# Move this repo to per-checkpoint refs
+entire configure --checkpoint-backend refs
+
 # Update strategy options on an existing repo
 entire configure --checkpoint-remote github:myorg/checkpoints-private
 
-# Add or remove an agent
+# Choose who generates summaries
+entire configure --summarize-provider claude-code
+```
+
+Adding or removing an agent lives under `entire agent`:
+
+```bash
 entire agent add claude-code
 entire agent remove claude-code
 ```
@@ -392,14 +472,16 @@ entire agent remove claude-code
 Plugins extend the CLI with new verbs: any executable named `entire-<name>` on `$PATH` runs as `entire <name>`, kubectl-style — stdio passes through, exit codes propagate, no SDK or protocol required.
 
 ```sh
-entire plugin search                                    # browse the plugin index
-entire plugin install upgrade                           # install by name (index lookup)
+entire plugin search                                    # search the plugin index
+entire plugin browse                                    # browse the index interactively and install
+entire plugin install run                               # install by name (index lookup)
 entire plugin install https://github.com/you/entire-x   # install from any git host
 entire plugin install ./dist/entire-x                   # link a local build
-entire upgrade                                          # run an installed plugin
+entire plugin list                                      # list what's installed
+entire run                                              # run an installed plugin
 entire plugin upgrade --all                             # update remote-installed plugins
 entire plugin doctor                                    # check for broken installs and missing dependencies
-entire plugin remove x
+entire plugin remove run
 ```
 
 Remote installs are forge-agnostic: the newest stable semver tag is resolved over the git protocol (prereleases need an explicit `--pin`), and the platform's release asset is downloaded over HTTPS and verified against the release's `checksums.txt`. A release that publishes no checksums is refused unless you pass `--allow-unverified` — installing means making those bytes executable. `entire plugin doctor` re-checks installed binaries against the digests recorded at install time. Plugins can declare dependencies on other plugins in an `entire-plugin.yml`; missing ones are installed after a single confirmation.
@@ -414,11 +496,14 @@ Entire uses two configuration files in the `.entire/` directory:
 
 ### settings.json (Project Settings)
 
-Shared across the team, typically committed to git:
+Shared across the team, typically committed to git. This is what `entire enable` writes for a new repo:
 
 ```json
 {
-  "enabled": true
+  "enabled": true,
+  "checkpoints": {
+    "primary": { "type": "git-refs" }
+  }
 }
 ```
 
@@ -435,14 +520,25 @@ Personal overrides, gitignored by default:
 
 ### Configuration Options
 
-| Option                               | Values                                       | Description                                             |
-| ------------------------------------ | -------------------------------------------- | ------------------------------------------------------- |
-| `enabled`                            | `true`, `false`                              | Enable/disable Entire                                   |
-| `log_level`                          | `debug`, `info`, `warn`, `error`             | Logging verbosity                                       |
-| `strategy_options.push_sessions`     | `true`, `false`                              | Auto-push `entire/checkpoints/v1` branch on git push    |
-| `strategy_options.checkpoint_remote` | `{"provider": "github", "repo": "org/repo"}` | Push checkpoint branches to a separate repo (see below) |
-| `strategy_options.summarize.enabled` | `true`, `false`                              | Auto-generate AI summaries at commit time               |
-| `telemetry`                          | `true`, `false`                              | Send anonymous usage statistics to Posthog              |
+| Option                                    | Values                                       | Description                                                                       |
+| ----------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------- |
+| `enabled`                                 | `true`, `false`                              | Enable/disable Entire                                                             |
+| `log_level`                               | `debug`, `info`, `warn`, `error`             | Logging verbosity                                                                 |
+| `checkpoints.primary.type`                | `git-refs`, `git-branch`                     | Checkpoint storage backend (see [Checkpoint Storage](#checkpoint-storage)). Absent means `git-branch` |
+| `telemetry`                               | `true`, `false`                              | Send anonymous usage statistics to Posthog                                        |
+| `absolute_git_hook_path`                  | `true`, `false`                              | Embed the full binary path in git hooks, for GUI git clients that don't source shell profiles |
+| `commit_linking`                          | `always`, `prompt`                           | Link commits to sessions automatically, or ask each time (default `prompt`)        |
+| `sign_checkpoint_commits`                 | `true`, `false`                              | Sign checkpoint commits (default: on). See [checkpoint signing](docs/architecture/checkpoint-signing.md) |
+| `vercel`                                  | `true`, `false`                              | Stop Vercel from deploying Entire's metadata branch (see below)                   |
+| `strategy_options.push_sessions`          | `true`, `false`                              | Auto-push checkpoint data on git push (default `true`)                            |
+| `strategy_options.checkpoint_remote`      | `{"provider": "github", "repo": "org/repo"}` | Push checkpoint data to a separate repo (see below)                               |
+| `strategy_options.checkpoint_push_remote` | remote name, e.g. `"upstream"`               | Pin which single remote carries checkpoint data (see below)                       |
+| `strategy_options.filtered_fetches`       | `true`, `false`                              | Use `--filter=blob:none` on checkpoint fetches                                    |
+| `strategy_options.summarize.enabled`      | `true`, `false`                              | Auto-generate AI summaries at commit time                                         |
+| `summary_generation.provider`             | e.g. `claude-code`, `codex`, `gemini`        | Which agent generates summaries (defaults to Claude)                              |
+| `summary_generation.model`                | provider-specific model hint                 | Model hint for summary generation (requires `provider`)                            |
+| `summary_timeout_seconds`                 | seconds, `0` clears                          | Hard deadline for `entire checkpoint explain --generate` (default 5m)             |
+| `redaction.*`                             | nested object                                | PII redaction, custom secret patterns, scanner engines, and the OpenAI Privacy Filter — documented in [docs/security-and-privacy.md](docs/security-and-privacy.md) |
 
 ### Agent Hook Configuration
 
@@ -463,7 +559,17 @@ You can enable multiple agents at the same time — each agent's hooks are indep
 
 ### Checkpoint Remote
 
-By default, Entire pushes `entire/checkpoints/v1` to the same remote as your code. If you want to push checkpoint data to a separate repo (e.g., a private repo for public projects), configure `checkpoint_remote` with a structured provider and repo:
+By default, checkpoint data rides along with your own pushes — but only to **one** remote, the elected checkpoint sync remote. Entire picks it in this order:
+
+1. `strategy_options.checkpoint_push_remote`, if set. This is fail-closed: if it names a remote that isn't configured, checkpoints don't sync.
+2. A remote captured from your own habits: the first push whose target matches the branch's declared push destination elects that remote, announces it on stderr, and carries the checkpoints. The first capture sticks.
+3. `origin`
+4. The sole remote, if the repo has exactly one
+5. The first remote in `.git/config` order
+
+A push to any *other* remote carries no checkpoint data. `entire status` shows the current destination, where it came from, and how many checkpoints are unpushed. This matters if you push code to several remotes: checkpoints go to exactly one of them.
+
+If instead you want checkpoint data in a separate repo (e.g., a private repo for a public project), configure `checkpoint_remote` with a structured provider and repo. A dedicated `checkpoint_remote` is addressed directly and is exempt from the single-remote election above:
 
 ```json
 {
@@ -484,9 +590,9 @@ entire enable --checkpoint-remote github:myorg/checkpoints-private
 
 Entire derives the git URL automatically using the same protocol (SSH or HTTPS) as your push remote. It will:
 
-- Fetch the checkpoint branch locally if it exists on the remote but not locally (one-time)
-- Push `entire/checkpoints/v1` to the checkpoint repo instead of your default push remote
-- Ignore the setting if it looks inherited rather than yours, and push checkpoints to your own push remote instead. `checkpoint_remote` is normally committed in `.entire/settings.json`, so cloning or forking a project inherits it — without this, a contributor's session data would be pushed into the upstream project's checkpoint repo. A setting is treated as yours when it lives in the gitignored `.entire/settings.local.json`, or when your `origin` **and every push URL** of the remote you are pushing to are owned by the same account or org as the checkpoint repo. Requiring the push destination too covers contributors who cloned the upstream repo and added their own fork, where `origin` belongs to the upstream project rather than to them; requiring every push URL covers mirror-style remotes that fan out to several repositories
+- Fetch existing checkpoint data locally if the remote has it and you don't (one-time)
+- Push checkpoint data to the checkpoint repo instead of your default push remote
+- Ignore the setting if it looks inherited rather than yours, and fall back to `origin` (or, failing that, the remote you are pushing to). `checkpoint_remote` is normally committed in `.entire/settings.json`, so cloning or forking a project inherits it — without this, a contributor's session data would be pushed into the upstream project's checkpoint repo. A setting is treated as yours when it lives in the gitignored `.entire/settings.local.json`, or when your `origin` **and every push URL** of the remote you are pushing to are owned by the same account or org as the checkpoint repo. Requiring the push destination too covers contributors who cloned the upstream repo and added their own fork, where `origin` belongs to the upstream project rather than to them; requiring every push URL covers mirror-style remotes that fan out to several repositories
 - If your checkpoint repo is owned by a different account or org than `origin`, configure it in `.entire/settings.local.json` so it is always honored
 - If the remote is unreachable, warn and continue without blocking your main push
 
@@ -519,16 +625,49 @@ When enabled, Entire automatically generates AI summaries for checkpoints at com
 }
 ```
 
+Summaries are also generated on demand, with or without this setting, by `entire checkpoint explain --generate`.
+
+**Which agent writes them.** By default Claude Code (`claude` on your `PATH`, model `sonnet`). Set a different one with `summary_generation.provider` — `claude-code`, `codex`, `copilot-cli`, `cursor`, `gemini`, or `pi`, plus an optional `summary_generation.model` hint:
+
+```bash
+entire configure --summarize-provider codex
+```
+
+`opencode` and `factoryai-droid` cannot generate summaries. Whichever provider you pick must be installed and authenticated.
+
 **Requirements:**
 
-- Claude CLI must be installed and authenticated (`claude` command available in PATH)
+- The configured provider's CLI installed and authenticated
 - Summary generation is non-blocking: failures are logged but don't prevent commits
 
-**Note:** Currently uses Claude CLI for summary generation. Other AI backends may be supported in future versions.
+### Vercel Projects
+
+On the legacy `git-branch` backend, Entire pushes a real branch — `entire/checkpoints/v1` — and Vercel builds a deployment for every branch it sees. `vercel: true` stops that: Entire merges a `vercel.json` into the metadata branch's own tree setting
+
+```json
+{
+  "git": {
+    "deploymentEnabled": {
+      "entire/**": false
+    }
+  }
+}
+```
+
+so Vercel skips the branch. Any other `vercel.json` content already on that branch is preserved, and your repo's own `vercel.json` is never modified.
+
+`entire enable` and `entire configure` detect a Vercel project (a `vercel.json`, `.vercel`, or `vercel.ts` in the repo root) and offer to set this. Without an interactive terminal they print a note instead, so run `entire configure` interactively to answer it.
+
+The setting has no effect on the default `git-refs` backend: per-checkpoint refs live under `refs/entire/checkpoints/`, which are not branches, so Vercel never sees them and there is nothing to disable. The detection doesn't check the backend, so you may still be asked — answering either way is harmless there.
 
 ### Settings Priority
 
-Local settings override project settings field-by-field. When you run `entire status`, it shows both project and local (effective) settings.
+Local settings override project settings field-by-field. `entire status --detailed` shows the state of each settings file.
+
+Two exceptions to field-by-field merging:
+
+- The `checkpoints` block is **replaced wholesale** by the local one, not deep-merged — it selects a backend, so a half-merged block would be meaningless.
+- A `settings.local.json` that is **tracked in git** is ignored entirely, and Entire tells you to `git rm --cached` it. `.gitignore` doesn't apply to an already-tracked path, so a committed local file would otherwise override project settings for everyone who clones.
 
 ### Agent-Specific Steps & Limitations
 
@@ -539,34 +678,22 @@ Local settings override project settings field-by-field. When you run `entire st
 
 ## Security & Privacy
 
-**Your session transcripts are stored in your git repository** on the `entire/checkpoints/v1` branch. If your repository is public, this data is visible to anyone.
+**Your session transcripts are stored in your git repository** — in per-checkpoint refs or on the `entire/checkpoints/v1` branch, depending on the [backend](#checkpoint-storage). If your repository is public, this data is visible to anyone.
 
-Entire automatically redacts detected secrets (API keys, tokens, credentials) when writing to `entire/checkpoints/v1`, but redaction is best-effort. Temporary shadow branches used during a session may contain unredacted data and should not be pushed. See [docs/security-and-privacy.md](docs/security-and-privacy.md) for details.
+Entire automatically redacts detected secrets (API keys, tokens, credentials) from transcripts and metadata before writing a checkpoint, but redaction is best-effort.
+
+The temporary shadow branches used during a session get the same redaction for transcripts and metadata, but their **code-file snapshots are raw blobs of your working tree**, so a secret hardcoded in your source appears unredacted there. Entire never pushes shadow branches — don't push them manually. See [docs/security-and-privacy.md](docs/security-and-privacy.md) for the full picture, including the configurable scanner layers, opt-in PII redaction, and the OpenAI Privacy Filter pass.
 
 ## Troubleshooting
 
 ### Common Issues
 
-| Issue                    | Solution                                                |
-| ------------------------ | ------------------------------------------------------- |
-| "Not a git repository"   | Navigate to a Git repository first                      |
-| "Entire is disabled"     | Run `entire enable`                                     |
-| "shadow branch conflict" | Run `entire clean --force`                              |
-
-### SSH Authentication Errors
-
-If you see an error like this when running `entire resume`:
-
-```
-Failed to fetch metadata: failed to fetch entire/checkpoints/v1 from origin: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
-```
-
-This is a [known issue with go-git's SSH handling](https://github.com/go-git/go-git/issues/411). Fix it by adding GitHub's host keys to your known_hosts file:
-
-```
-ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-ssh-keyscan -t ecdsa github.com >> ~/.ssh/known_hosts
-```
+| Issue                              | Solution                                                          |
+| ---------------------------------- | ----------------------------------------------------------------- |
+| "Not a git repository"             | Navigate to a Git repository first                                |
+| "Entire is disabled"               | Run `entire enable`                                               |
+| A session stuck ACTIVE, or leftover session state | Run `entire doctor`, then `entire clean --force` if it persists |
+| Anything else                      | Run `entire doctor`; `entire doctor bundle` produces a redacted diagnostic bundle for a bug report |
 
 ### Debug Mode
 
@@ -640,7 +767,7 @@ devcontainer up --workspace-folder .
 devcontainer exec --workspace-folder . bash -lc '.devcontainer/run-with-keyring.sh'
 ```
 
-The container's `postCreateCommand` runs `mise trust --yes && mise install`, so Go, `golangci-lint`, `gotestsum`, `shellcheck`, and the canary E2E helper binaries are ready after creation. Use `.devcontainer/run-with-keyring.sh <command>` for commands that touch the Linux keyring, including `mise run test:ci`.
+The container's `postCreateCommand` runs `.devcontainer/post-create.sh`, which does `mise trust --yes && mise install`, so Go, `golangci-lint`, `gotestsum`, `shellcheck`, and the canary E2E helper binaries are ready after creation. Use `.devcontainer/run-with-keyring.sh <command>` for commands that touch the Linux keyring, including `mise run test:ci`.
 
 If `ENTIRE_DEVCONTAINER_KEYRING_PASSWORD` is set in the environment, `.devcontainer/run-with-keyring.sh` uses that value to unlock the keyring non-interactively. If it is unset, the script generates a random password for the session automatically.
 
@@ -653,7 +780,7 @@ mise run test
 # Run integration tests
 mise run test:integration
 
-# Run all tests (unit + integration, CI mode)
+# Run all tests: unit + integration under -race, then the E2E canary
 mise run test:ci
 
 # Lint the code
@@ -661,6 +788,36 @@ mise run lint
 
 # Format the code
 mise run fmt
+```
+
+### Local Device Auth Testing
+
+If you're working on the CLI login flow against a locally running Entire API,
+use the smoke script. It defaults to `http://localhost:8787` for both the data
+API and the login server, and passes the hidden `--insecure-http-auth` flag that
+a plain-HTTP login server requires:
+
+```bash
+./scripts/local-device-auth-smoke.sh
+```
+
+Override either endpoint with `ENTIRE_API_BASE_URL` and `ENTIRE_LOGIN_SERVER`:
+
+```bash
+ENTIRE_LOGIN_SERVER=http://localhost:8180 ./scripts/local-device-auth-smoke.sh
+```
+
+The script starts a login, opens the approval URL, waits for the CLI to finish,
+and then verifies a matching context was written to `contexts.json`.
+
+To drive the flow by hand, or to run the focused integration coverage:
+
+```bash
+# Login against a local server (--device forces the device-code flow)
+go run ./cmd/entire login --server http://localhost:8787 --insecure-http-auth --device
+
+# Focused integration coverage for login
+go test -tags=integration ./cmd/entire/cli/integration_test -run TestLogin
 ```
 
 ## Getting Help

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Removes the git hooks. Your code and commit history remain untouched.
 
 A **session** represents a complete interaction with your AI agent, from start to finish. Each session captures all prompts, responses, files modified, and timestamps.
 
-The session ID is the agent's own session identifier — a UUID for every currently supported agent (e.g. `019efea2-b46a-7cbc-be01-4c13460f5019`), so an ID you see in `entire session list` is the same one the agent uses.
+The session ID is the unique identifier the agent itself provides — Entire never mints its own — so an ID you see in `entire session list` is the same one the agent uses. The format is the agent's to choose: most supply a UUID (e.g. `019efea2-b46a-7cbc-be01-4c13460f5019`), while OpenCode uses `ses_`-prefixed IDs.
 
 Sessions are stored separately from your code commits, in the repo's checkpoint storage.
 

--- a/README.md
+++ b/README.md
@@ -199,33 +199,21 @@ A **checkpoint** is a snapshot within a session—a "save point" in your work.
 
 Checkpoints are created when you or the agent make a git commit, and the commit carries an `Entire-Checkpoint: <id>` trailer linking the two.
 
-**Checkpoint IDs** come in two formats, decided by the storage backend: a 26-character ULID (e.g. `01K9TQ8ZP7X3F5M2WVJ4CNRB6D`) on the default `git-refs` backend, or a legacy 12-character hex string (e.g. `a3b2c4d5e6f7`) on `git-branch`. Both formats stay readable in the same repo.
+**Checkpoint IDs** are 26-character ULIDs (e.g. `01K9TQ8ZP7X3F5M2WVJ4CNRB6D`), which sort by creation time. Checkpoints written by older versions of Entire carry a legacy 12-character hex ID (e.g. `a3b2c4d5e6f7`); both formats stay readable in the same repo, and you can pass either to any command that takes a checkpoint ID.
 
 ### Checkpoint Storage
 
-Checkpoints live in your repository's own git object store, never in your branch's history. Two backends exist, and which one a repo uses is recorded in its `.entire/settings.json`:
-
-**`git-refs` — the default for new repos, and the recommended backend.** Each checkpoint is its own git ref:
+Checkpoints live in your repository's own git object store, never in your branch's history. Each checkpoint is its own git ref:
 
 ```
 refs/entire/checkpoints/<shard>/<id>
 ```
 
-The ref points at a commit whose tree *is* that checkpoint. Because checkpoints are independent refs, they are written, pushed, and fetched independently: there is no shared tip for concurrent sessions to contend on, and a reader can fetch exactly the one checkpoint it needs instead of a whole branch of history. Checkpoint IDs are ULIDs, which sort by creation time.
+The ref points at a commit whose tree *is* that checkpoint — `metadata.json`, the per-session transcript files, and any subagent task records. `<shard>` is the last two characters of the ID, which keeps the refs evenly distributed.
 
-**`git-branch` — the legacy backend.** Every checkpoint is a subtree of one long-lived branch, `entire/checkpoints/v1`. That branch is a serialization point: every checkpoint rewrites its tip, every push races on the same ref, and the entire history travels together on fetch. Checkpoint IDs are 12-character hex strings.
+Because checkpoints are independent refs, they are written, pushed, and fetched independently. There is no shared branch tip for concurrent sessions to contend on, and a reader can fetch exactly the one checkpoint it needs instead of a whole history. A checkpoint written on another machine is fetched on demand the first time you read it.
 
-`entire enable` writes `git-refs` into the settings of a repo it sets up for the first time. A repo configured before that default — anything with no `checkpoints` block in its settings — keeps running on `git-branch`, unchanged, until you switch it.
-
-Choose or change the backend:
-
-```bash
-entire configure --checkpoint-backend refs      # switch an existing repo to per-checkpoint refs
-entire configure --checkpoint-backend branch    # back to the shared v1 branch
-entire enable --checkpoint-backend branch       # opt out at first-time setup
-```
-
-Or set it directly:
+`entire enable` sets this up; there is nothing to configure. It is recorded in `.entire/settings.json` as:
 
 ```json
 {
@@ -235,11 +223,13 @@ Or set it directly:
 }
 ```
 
-**Switching is safe in both directions and needs no migration.** Readers route by checkpoint ID: a ULID resolves through refs, and a legacy hex ID is tried in refs first and then on the `entire/checkpoints/v1` branch. Checkpoints already written stay readable exactly where they are; only new checkpoints use the new backend. This holds for every reader — the CLI, entire.io, and the Entire API all route the same way.
+Inspect what a repo has locally with plain git, or through Entire:
 
-Moving existing branch checkpoints into refs is optional. `entire doctor migrate-checkpoints` does it, is idempotent, and leaves the existing branch commits in place; run it with `--dry-run` first to see what it would convert.
-
-One consequence worth knowing: an older CLI cannot read ULID checkpoints. It fails closed with an upgrade prompt rather than half-working.
+```bash
+git for-each-ref refs/entire/checkpoints    # the raw refs
+entire checkpoint list                      # checkpoints on this branch
+entire checkpoint explain <id>              # one checkpoint in full
+```
 
 ### How It Works
 
@@ -270,7 +260,7 @@ Entire uses a manual-commit strategy that keeps your git history clean:
 
 - **No commits on your branch** — Entire never creates commits on the active branch
 - **Safe on any branch** — works on main, master, and feature branches alike
-- **Metadata stored separately** — session data lives in per-checkpoint refs (or on the `entire/checkpoints/v1` branch on the legacy backend), never in your branch's history
+- **Metadata stored separately** — session data lives in per-checkpoint refs, never in your branch's history
 
 ### Git Worktrees
 
@@ -401,7 +391,6 @@ These are visible in developer and nightly builds and hidden in stable releases,
 | `--agent <name>`                            | Agent to set up hooks for: `claude-code`, `codex`, `copilot-cli`, `cursor`, `factoryai-droid`, `gemini`, `opencode`, `pi` (external agents on `$PATH` also work). Enables non-interactive mode |
 | `--yes`, `-y`                               | Accept all defaults without prompting                                                                             |
 | `--force`, `-f`                             | Force reinstall hooks (removes existing Entire hooks first)                                                       |
-| `--checkpoint-backend refs` / `branch`      | Checkpoint storage backend (see [Checkpoint Storage](#checkpoint-storage)); new repos default to `refs`            |
 | `--checkpoint-remote <provider:owner/repo>` | Push checkpoint data to a separate repo (e.g., `github:org/checkpoints-repo`)                                     |
 | `--skip-push-sessions`                      | Disable automatic pushing of checkpoint data on git push                                                           |
 | `--local`                                   | Write settings to `.entire/settings.local.json` instead of `.entire/settings.json`                                |
@@ -440,7 +429,6 @@ Typical uses:
 
 - Toggle telemetry
 - Reinstall the Entire git hook (`--force`, `--absolute-git-hook-path`)
-- Switch the checkpoint storage backend (`--checkpoint-backend`)
 - Update strategy options such as `--checkpoint-remote` or `--skip-push-sessions`
 - Pick the provider, model, and timeout for `entire checkpoint explain --generate` (`--summarize-provider`, `--summarize-model`, `--summarize-timeout-seconds`)
 
@@ -455,9 +443,6 @@ entire configure --telemetry=false
 
 # Reinstall the Entire git hook with an absolute binary path
 entire configure --absolute-git-hook-path
-
-# Move this repo to per-checkpoint refs
-entire configure --checkpoint-backend refs
 
 # Update strategy options on an existing repo
 entire configure --checkpoint-remote github:myorg/checkpoints-private
@@ -530,12 +515,11 @@ Personal overrides, gitignored by default:
 | ----------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------- |
 | `enabled`                                 | `true`, `false`                              | Enable/disable Entire                                                             |
 | `log_level`                               | `debug`, `info`, `warn`, `error`             | Logging verbosity                                                                 |
-| `checkpoints.primary.type`                | `git-refs`, `git-branch`                     | Checkpoint storage backend (see [Checkpoint Storage](#checkpoint-storage)). Absent means `git-branch` |
+| `checkpoints.primary.type`                | `git-refs`                                   | Checkpoint storage backend — written by `entire enable`, see [Checkpoint Storage](#checkpoint-storage) |
 | `telemetry`                               | `true`, `false`                              | Send anonymous usage statistics to Posthog                                        |
 | `absolute_git_hook_path`                  | `true`, `false`                              | Embed the full binary path in git hooks, for GUI git clients that don't source shell profiles |
 | `commit_linking`                          | `always`, `prompt`                           | Link commits to sessions automatically, or ask each time (default `prompt`)        |
 | `sign_checkpoint_commits`                 | `true`, `false`                              | Sign checkpoint commits (default: on). See [checkpoint signing](docs/architecture/checkpoint-signing.md) |
-| `vercel`                                  | `true`, `false`                              | Stop Vercel from deploying Entire's metadata branch (see below)                   |
 | `strategy_options.push_sessions`          | `true`, `false`                              | Auto-push checkpoint data on git push (default `true`)                            |
 | `strategy_options.checkpoint_remote`      | `{"provider": "github", "repo": "org/repo"}` | Push checkpoint data to a separate repo (see below)                               |
 | `strategy_options.checkpoint_push_remote` | remote name, e.g. `"upstream"`               | Pin which single remote carries checkpoint data (see below)                       |
@@ -646,26 +630,6 @@ entire configure --summarize-provider codex
 - The configured provider's CLI installed and authenticated
 - Summary generation is non-blocking: failures are logged but don't prevent commits
 
-### Vercel Projects
-
-On the legacy `git-branch` backend, Entire pushes a real branch — `entire/checkpoints/v1` — and Vercel builds a deployment for every branch it sees. `vercel: true` stops that: Entire merges a `vercel.json` into the metadata branch's own tree setting
-
-```json
-{
-  "git": {
-    "deploymentEnabled": {
-      "entire/**": false
-    }
-  }
-}
-```
-
-so Vercel skips the branch. Any other `vercel.json` content already on that branch is preserved, and your repo's own `vercel.json` is never modified.
-
-`entire enable` and `entire configure` detect a Vercel project (a `vercel.json`, `.vercel`, or `vercel.ts` in the repo root) and offer to set this. Without an interactive terminal they print a note instead, so run `entire configure` interactively to answer it.
-
-The setting has no effect on the default `git-refs` backend: per-checkpoint refs live under `refs/entire/checkpoints/`, which are not branches, so Vercel never sees them and there is nothing to disable. The detection doesn't check the backend, so you may still be asked — answering either way is harmless there.
-
 ### Settings Priority
 
 Local settings override project settings field-by-field. `entire status --detailed` shows the state of each settings file.
@@ -684,7 +648,7 @@ Two exceptions to field-by-field merging:
 
 ## Security & Privacy
 
-**Your session transcripts are stored in your git repository** — in per-checkpoint refs or on the `entire/checkpoints/v1` branch, depending on the [backend](#checkpoint-storage). If your repository is public, this data is visible to anyone.
+**Your session transcripts are stored in your git repository**, in the [per-checkpoint refs](#checkpoint-storage) described above. If your repository is public, this data is visible to anyone.
 
 Entire automatically redacts detected secrets (API keys, tokens, credentials) from transcripts and metadata before writing a checkpoint, but redaction is best-effort.
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,17 @@ attempt leaves your existing install working.
 ```bash
 go install github.com/entireio/cli/cmd/entire@latest
 
+# The git remote helper that resolves entire:// URLs, needed for `entire clone`
+# and `git clone entire://…`. The packaged installs above bundle it.
+go install github.com/entireio/cli/cmd/git-remote-entire@latest
+
 # Add Go binaries to PATH (add to ~/.zshrc or ~/.bashrc if not already configured)
 export PATH="$HOME/go/bin:$PATH"
 ```
 
-This installs `entire` only. The packaged installs above also ship `git-remote-entire`, which is what resolves `entire://` and `entire clone` URLs — install with Homebrew, Scoop, or `install.sh` if you need those.
+Install both, or just `entire` if you never clone over `entire://`. Git finds the helper by name on `$PATH`, which is what `go install` produces, so nothing else needs configuring.
+
+One difference from a stable release: a `go install` build leaves [experimental commands](#experimental-commands) visible in `entire help`, the same as a nightly or a local build.
 
 ### Enable in your project
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If the first step fails with "couldn't find manifest", your bucket clone predate
 ```bash
 go install github.com/entireio/cli/cmd/entire@latest
 
-# The git remote helper that resolves entire:// URLs, needed for `entire clone`
+# The git remote helper that resolves entire:// URLs, needed for `entire repo clone`
 # and `git clone entire://…`. The packaged installs above bundle it.
 go install github.com/entireio/cli/cmd/git-remote-entire@latest
 
@@ -329,7 +329,6 @@ Descriptions below are the commands' own summaries. `entire help` always reflect
 
 | Command          | Description                                                                       |
 | ---------------- | --------------------------------------------------------------------------------- |
-| `entire clone`   | Clone an Entire repository                                                        |
 | `entire org`     | Manage Entire organizations (`create`, `list`, `get`, `delete`)                    |
 | `entire project` | Manage Entire projects (`create`, `list`, `get`, `delete`)                         |
 | `entire repo`    | Manage Entire repositories (`create`, `list`, `get`, `delete`, `clone`, `mirror`, `visibility`) |
@@ -504,7 +503,7 @@ Personal overrides, gitignored by default:
 | `strategy_options.summarize.enabled`      | `true`, `false`                              | Auto-generate AI summaries at commit time                                         |
 | `summary_generation.provider`             | e.g. `claude-code`, `codex`, `gemini`        | Which agent generates summaries (defaults to Claude)                              |
 | `summary_generation.model`                | provider-specific model hint                 | Model hint for summary generation (requires `provider`)                            |
-| `summary_timeout_seconds`                 | seconds, `0` clears                          | Hard deadline for `entire checkpoint explain --generate` (default 5m)             |
+| `summary_timeout_seconds`                 | seconds                                      | Hard deadline for `entire checkpoint explain --generate`. Unset or `0` means **no deadline** |
 | `redaction.*`                             | nested object                                | PII redaction, custom secret patterns, scanner engines, and the OpenAI Privacy Filter — documented in [docs/security-and-privacy.md](docs/security-and-privacy.md) |
 
 ### Agent Hook Configuration

--- a/README.md
+++ b/README.md
@@ -78,22 +78,13 @@ scoop install entire/entire
 
 #### Migrating an old `cli` Scoop install (package rename)
 
-The Scoop package was renamed from `cli` to `entire`. If your install is still
-registered as the old `cli` package, run the migration below. It installs the
-new package before removing the old one, so the old install is only removed
-once the new one is in place (`scoop reset` re-links the shared `entire.exe`
-and `git-remote-entire.exe` shims). Run it where `entire` is **not** running — a
-live `entire.exe` locks its own shim, so Scoop can't relink or uninstall it
-mid-run:
+The Scoop package was renamed from `cli` to `entire`. If your install is still registered as the old `cli` package, run the migration below. It installs the new package before removing the old one, so the old install is only removed once the new one is in place (`scoop reset` re-links the shared `entire.exe` and `git-remote-entire.exe` shims). Run it where `entire` is **not** running — a live `entire.exe` locks its own shim, so Scoop can't relink or uninstall it mid-run:
 
 ```powershell
 cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"
 ```
 
-If the first step fails with "couldn't find manifest", your bucket clone
-predates the renamed package — run `scoop update` to refresh it, then retry the
-command above. Nothing is removed until the install succeeds, so a failed
-attempt leaves your existing install working.
+If the first step fails with "couldn't find manifest", your bucket clone predates the renamed package — run `scoop update` to refresh it, then retry the command above. Nothing is removed until the install succeeds, so a failed attempt leaves your existing install working.
 
 ### Go (development/manual setup)
 
@@ -272,27 +263,17 @@ Multiple AI sessions can run on the same commit. If you start a second session w
 
 ## Headless & CI Authentication
 
-By default `entire login` opens a browser to sign in and stores tokens in the OS
-keyring (macOS Keychain, Linux Secret Service, Windows Credential Manager).
-Machines without a usable browser or keyring — headless servers, containers,
-minimal VMs, CI runners — have two supported paths:
+By default `entire login` opens a browser to sign in and stores tokens in the OS keyring (macOS Keychain, Linux Secret Service, Windows Credential Manager). Machines without a usable browser or keyring — headless servers, containers, minimal VMs, CI runners — have two supported paths:
 
 ### Interactive login on a headless machine
 
-Sign-in itself already handles this: with no interactive terminal, or over SSH,
-`entire login` switches to the device-code flow on its own and prints an
-approval URL you can open on any machine. `entire login --device` forces that
-flow explicitly. Only token *storage* needs an override — use the file-backed
-store:
+Sign-in itself already handles this: with no interactive terminal, or over SSH, `entire login` switches to the device-code flow on its own and prints an approval URL you can open on any machine. `entire login --device` forces that flow explicitly. Only token *storage* needs an override — use the file-backed store:
 
 ```bash
 ENTIRE_TOKEN_STORE=file entire login
 ```
 
-Tokens are written with `0600` permissions to `tokens.json` in your Entire
-config directory (`~/.config/entire` by default). Override the location with
-`ENTIRE_TOKEN_STORE_PATH`. Set `ENTIRE_TOKEN_STORE=file` persistently (e.g. in
-your shell profile) so later commands read from the same store.
+Tokens are written with `0600` permissions to `tokens.json` in your Entire config directory (`~/.config/entire` by default). Override the location with `ENTIRE_TOKEN_STORE_PATH`. Set `ENTIRE_TOKEN_STORE=file` persistently (e.g. in your shell profile) so later commands read from the same store.
 
 ### Non-interactive automation (CI, workload identity)
 
@@ -302,13 +283,9 @@ Skip login and storage entirely by injecting a token per invocation:
 ENTIRE_TOKEN=<login-or-sa-session-JWT> entire ...
 ```
 
-`ENTIRE_TOKEN` bypasses stored credentials; the CLI derives the control-plane
-endpoint from the token itself. Nothing is written to disk. This is the right
-path for CI pipelines and service accounts.
+`ENTIRE_TOKEN` bypasses stored credentials; the CLI derives the control-plane endpoint from the token itself. Nothing is written to disk. This is the right path for CI pipelines and service accounts.
 
-> **Seeing `save login` / `failed to unlock correct collection` errors from
-> `entire login`?** That's the OS keyring being unavailable — use one of the
-> two paths above.
+> **Seeing `save login` / `failed to unlock correct collection` errors from `entire login`?** That's the OS keyring being unavailable — use one of the two paths above.
 
 ## Commands Reference
 
@@ -762,10 +739,7 @@ mise run fmt
 
 ### Local Device Auth Testing
 
-If you're working on the CLI login flow against a locally running Entire API,
-use the smoke script. It defaults to `http://localhost:8787` for both the data
-API and the login server, and passes the hidden `--insecure-http-auth` flag that
-a plain-HTTP login server requires:
+If you're working on the CLI login flow against a locally running Entire API, use the smoke script. It defaults to `http://localhost:8787` for both the data API and the login server, and passes the hidden `--insecure-http-auth` flag that a plain-HTTP login server requires:
 
 ```bash
 ./scripts/local-device-auth-smoke.sh
@@ -777,8 +751,7 @@ Override either endpoint with `ENTIRE_API_BASE_URL` and `ENTIRE_LOGIN_SERVER`:
 ENTIRE_LOGIN_SERVER=http://localhost:8180 ./scripts/local-device-auth-smoke.sh
 ```
 
-The script starts a login, opens the approval URL, waits for the CLI to finish,
-and then verifies a matching context was written to `contexts.json`.
+The script starts a login, opens the approval URL, waits for the CLI to finish, and then verifies a matching context was written to `contexts.json`.
 
 To drive the flow by hand, or to run the focused integration coverage:
 

--- a/cmd/entire/cli/checkpoint_backend.go
+++ b/cmd/entire/cli/checkpoint_backend.go
@@ -20,6 +20,19 @@ const (
 	checkpointBackendRefsAlias   = "refs"
 )
 
+// checkpointBackendFlagUsage is the shared --checkpoint-backend help text. Both
+// `enable` and `configure` register the flag, so it lives here rather than being
+// spelled twice: the two commands drifting would advertise two different stories
+// about which backend a repo gets.
+//
+// It names refs as the default rather than merely "recommended", because that is
+// what a first-time `entire enable` writes, with no prompt (see
+// resolveFirstRunCheckpointBackend). branch is labelled legacy: it is an explicit
+// escape hatch for interoperating with older clients, not a co-equal choice.
+const checkpointBackendFlagUsage = "Checkpoint storage backend: " +
+	checkpointBackendRefsAlias + " (default; one git ref per checkpoint) or " +
+	checkpointBackendBranchAlias + " (legacy shared entire/checkpoints/v1 branch)"
+
 // resolveCheckpointBackendType maps a user-facing backend name to the canonical
 // settings backend type and validates it may serve as the primary. It accepts
 // the friendly aliases "branch"/"refs" and the canonical "git-branch"/"git-refs"

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -715,7 +715,7 @@ Examples:
   entire configure --absolute-git-hook-path       # Reinstall git hook with absolute path
   entire configure --force                        # Reinstall git hook
   entire configure --checkpoint-remote github:org/checkpoints
-  entire configure --checkpoint-backend refs      # Store each checkpoint as its own git ref
+  entire configure --checkpoint-backend refs      # Move a legacy repo to per-checkpoint git refs
   entire configure --summarize-provider claude-code
   entire configure --summarize-timeout-seconds 300   # 5m deadline for explain --generate`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -775,7 +775,7 @@ Examples:
 	cmd.Flags().BoolVarP(&opts.ForceHooks, flagForce, "f", false, "Reinstall the Entire git hook")
 	cmd.Flags().BoolVar(&opts.SkipPushSessions, flagSkipPushSessions, false, "Disable automatic pushing of session logs on git push")
 	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
-	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", "Checkpoint storage backend: refs (one git ref per checkpoint; recommended) or branch (shared entire/checkpoints/v1 branch)")
+	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", checkpointBackendFlagUsage)
 	cmd.Flags().StringVar(&summarizeProvider, flagSummarizeAgent, "", "Set the provider used by explain --generate (e.g., claude-code, codex, gemini, pi, cursor, copilot-cli)")
 	cmd.Flags().StringVar(&summarizeModel, flagSummarizeModel, "", "Set the model hint used by explain --generate")
 	cmd.Flags().IntVar(&summarizeTimeoutSeconds, flagSummarizeTimeout, 0, "Set the hard deadline (seconds) for explain --generate summary generation. 0 clears (falls back to 5m default).")
@@ -933,7 +933,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	cmd.Flags().BoolVarP(&opts.ForceHooks, flagForce, "f", false, "Force reinstall hooks (removes existing Entire hooks first)")
 	cmd.Flags().BoolVar(&opts.SkipPushSessions, flagSkipPushSessions, false, "Disable automatic pushing of session logs on git push")
 	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
-	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", "Checkpoint storage backend: refs (one git ref per checkpoint; recommended) or branch (shared entire/checkpoints/v1 branch)")
+	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", checkpointBackendFlagUsage)
 	cmd.Flags().BoolVar(&opts.Telemetry, flagTelemetry, true, "Enable anonymous usage analytics")
 	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
 	cmd.Flags().BoolVar(&opts.SearchSkill, flagSearchSkill, false, "Install the optional Entire search skill for selected agent(s)")

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -778,7 +778,7 @@ Examples:
 	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", checkpointBackendFlagUsage)
 	cmd.Flags().StringVar(&summarizeProvider, flagSummarizeAgent, "", "Set the provider used by explain --generate (e.g., claude-code, codex, gemini, pi, cursor, copilot-cli)")
 	cmd.Flags().StringVar(&summarizeModel, flagSummarizeModel, "", "Set the model hint used by explain --generate")
-	cmd.Flags().IntVar(&summarizeTimeoutSeconds, flagSummarizeTimeout, 0, "Set the hard deadline (seconds) for explain --generate summary generation. 0 clears (falls back to 5m default).")
+	cmd.Flags().IntVar(&summarizeTimeoutSeconds, flagSummarizeTimeout, 0, "Set the hard deadline (seconds) for explain --generate summary generation. 0 clears the setting, leaving summary generation unbounded.")
 	cmd.Flags().BoolVar(&opts.Telemetry, flagTelemetry, true, "Enable anonymous usage analytics")
 	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
 

--- a/docs/architecture/ref-checkpoint-backend.md
+++ b/docs/architecture/ref-checkpoint-backend.md
@@ -163,6 +163,7 @@ Backend selection lives in the `checkpoints` block of settings (`settings/checkp
 ```
 
 - `primary.type` is required. When the whole block is absent, the layer defaults to the **git-branch** backend with no mirrors — so existing repos are unchanged.
+- **A first-time `entire enable` writes `git-refs` explicitly, with no prompt.** Both setup paths do it — the interactive flow and the non-interactive `--agent` flow — via `resolveFirstRunCheckpointBackend` / `firstRunCheckpointBackendDefault` (`setup.go`). There is deliberately **no setup question**: storage topology is not answerable at first-run, so the recommended backend is written silently and `git-branch` is reachable only by typing `--checkpoint-backend branch`. The one case that writes nothing is an active `ENTIRE_CHECKPOINTS_PRIMARY`, since the env fully replaces the settings block and persisting a default would only record diverging config.
 - `settings.local.json`'s `checkpoints` block **replaces** the one in `settings.json` wholesale (this is a selection config, not a deep-merged document).
 - Config loading is **fail-soft**: a missing file, a whole-file JSON syntax error, or unrelated invalid fields all resolve to "no config" → default git-branch. It errors *only* when a present `checkpoints` block is itself invalid.
 - Unknown fields are rejected (`DisallowUnknownFields`) to surface typos. The trade-off: adding a `checkpoints` field is a coordinated rollout — ship the reader before any writer emits the field.
@@ -177,7 +178,7 @@ The switch is a **primary flip**, not a dual-write phase. There is no "run both 
 
 | State | `primary` | Behavior |
 |-------|-----------|----------|
-| **Config-less fallback** | `git-branch` | Hex checkpoints on the `v1` branch; unchanged legacy behavior for repos set up before the git-refs default (new setups write an explicit primary — `git-refs` as the recommended pick unless the setup question chose branch) |
+| **Config-less fallback** | `git-branch` | Hex checkpoints on the `v1` branch; unchanged legacy behavior for repos set up before the git-refs default. A repo reaches this state only by predating that default (or by having its `checkpoints` block removed) — a first-time `entire enable` always writes an explicit primary |
 | **Refs-only** | `git-refs` | New checkpoints are ULIDs written as per-checkpoint refs; pre-existing hex/`v1` checkpoints stay readable via the read-routing fallback |
 
 ## Checkpoint version and policy

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -6,17 +6,26 @@ Entire stores AI session transcripts and metadata in your git repository. This d
 
 ### Where data is stored
 
-When you use Entire with an AI agent (Claude Code, Codex, Gemini CLI, OpenCode, Cursor, Factory AI Droid, Copilot CLI, Pi), session transcripts, user prompts, and checkpoint metadata are committed to a dedicated branch in your git repository (`entire/checkpoints/v1`). This branch is separate from your working branches, your code commits stay clean, but it lives in the same repository.
+When you use Entire with an AI agent (Claude Code, Codex, Gemini CLI, OpenCode, Cursor, Factory AI Droid, Copilot CLI, Pi), session transcripts, user prompts, and checkpoint metadata are committed to **your own git repository**. They stay out of your working branches' history, but they live in the same repo and travel with it.
 
-Entire also creates temporary local branches (e.g., `entire/<short-hash>`) as working storage during a session. Metadata written to these shadow branches — transcripts, prompts, incremental checkpoint data, subagent transcripts — goes through the same redaction pipeline as `entire/checkpoints/v1`. **Code-file snapshots, however, are written as raw blobs of your working tree without redaction**, so any hardcoded secrets in your source code would appear unredacted on the shadow branch. Gitignored files (e.g., `.env`) are filtered out of these snapshots as a partial defense. Shadow branches are **not** pushed by Entire; do not push them manually, because unredacted source content would be visible on the remote. They are cleaned up when session data is condensed into `entire/checkpoints/v1` at commit time.
+Exactly where depends on the [checkpoint backend](architecture/ref-checkpoint-backend.md) the repo uses:
 
-Anyone with access to your repository can view the transcript data on the `entire/checkpoints/v1` branch. This includes the full prompt/response history and session metadata. Note that transcripts capture all tool interactions — including file contents, MCP server calls, and other data exchanged during the session.
+| Backend | Committed checkpoints land in | Notes |
+|---|---|---|
+| `git-refs` (default for new repos) | One ref per checkpoint: `refs/entire/checkpoints/<shard>/<id>` | Not a branch. Pushed individually, and fetched individually on demand |
+| `git-branch` (legacy) | Subtrees of one long-lived branch, `entire/checkpoints/v1` | A branch, so it shows up in branch listings, CI branch triggers, and platform previews |
+
+Which one a repo is on is recorded as `checkpoints.primary.type` in `.entire/settings.json` (or `settings.local.json`); an absent `checkpoints` block means `git-branch`. The redaction described in this document applies identically to both — the pipeline is shared, and only the destination differs. Where the distinction matters below, it is called out.
+
+Entire also creates temporary local **shadow branches** (e.g. `entire/<commit>-<worktree>`) as working storage during a session, on both backends. Metadata written there — transcripts, prompts, incremental checkpoint data, subagent transcripts — goes through the same redaction pipeline as a committed checkpoint. **Code-file snapshots, however, are written as raw blobs of your working tree without redaction**, so any hardcoded secrets in your source code would appear unredacted on the shadow branch. Gitignored files (e.g., `.env`) are filtered out of these snapshots as a partial defense. Shadow branches are **not** pushed by Entire; do not push them manually, because unredacted source content would be visible on the remote. They are cleaned up when session data is condensed into a checkpoint at commit time.
+
+Anyone with access to your repository can read committed checkpoint data: the full prompt/response history and session metadata. Note that transcripts capture all tool interactions — including file contents, MCP server calls, and other data exchanged during the session. Per-checkpoint refs are less *visible* than a branch, but they are not less accessible: a `git fetch` of `refs/entire/checkpoints/*` reads them just as well.
 
 If your repository is **public**, this data is visible to the entire internet.
 
 ### What Entire redacts automatically
 
-Entire automatically scans transcript and metadata content before writing it to the `entire/checkpoints/v1` branch. Five always-on secret detection methods plus a configurable scanner layer (pattern matching, method 2 below) run during condensation, plus a conditional seventh pass for user-defined secret rules (see [Customizing redaction](#customizing-redaction) below), an opt-in eighth pass for PII (see [Optional PII redaction](#optional-pii-redaction) below), and an opt-in ninth pass that shells out to the OpenAI Privacy Filter model (see [Optional OpenAI Privacy Filter](#optional-openai-privacy-filter-opf) below):
+Entire automatically scans transcript and metadata content before writing it to a git object. Five always-on secret detection methods plus a configurable scanner layer (pattern matching, method 2 below) run during condensation, plus a conditional seventh pass for user-defined secret rules (see [Customizing redaction](#customizing-redaction) below), an opt-in eighth pass for PII (see [Optional PII redaction](#optional-pii-redaction) below), and an opt-in ninth pass that shells out to the OpenAI Privacy Filter model (see [Optional OpenAI Privacy Filter](#optional-openai-privacy-filter-opf) below):
 
 1. **Entropy scoring** — Identifies high-entropy strings (Shannon entropy > 4.5) that look like randomly generated secrets, even if they don't match a known pattern.
 2. **Pattern matching** — Runs one or both configurable scanner engines against known secret formats: [Betterleaks](https://github.com/betterleaks/betterleaks) (default on) and/or [goredact](https://github.com/lastpersonlabs/goredact) (default off). See [Choosing secret-scanner engines](#choosing-secret-scanner-engines) below.
@@ -131,7 +140,7 @@ Available categories (set to `true` to enable, `false` or omit to skip):
 
 Unknown category names are rejected at settings load time so typos surface immediately instead of silently disabling a category.
 
-The filter needs at least one enabled category to run. This is enforced at push time, not settings load: with `enabled: true` and no effective category (`categories` omitted, empty, or all-false) the model scan cannot run, so the push aborts with a configuration error rather than tagging commits as OPF-applied without a scan. Enable a category, set `enabled: false`, or pass `ENTIRE_OPF=no` on a push to skip the filter for that push only.
+The filter needs at least one enabled category to run. This is enforced at push time, not settings load: with `enabled: true` and no effective category (`categories` omitted, empty, or all-false) the model scan cannot run. Rather than tagging commits as OPF-applied without a scan, it fails closed the same way a runtime failure does: `git-branch` aborts the push, `git-refs` withholds the checkpoint refs and lets your push through. Enable a category, set `enabled: false`, or pass `ENTIRE_OPF=no` on a push to skip the filter for that push only.
 
 Full settings reference:
 
@@ -224,17 +233,17 @@ Ctrl-C to cancel the push.
 - **Yes** runs OPF for this push only.
 - **No** skips OPF for this push only; the 8-layer-redacted content reaches the remote.
 - **Always** runs OPF this push AND writes `prompt_default: "always"` to `.entire/settings.local.json` so future pushes don't ask.
-- **Ctrl-C** aborts the push entirely — `git push` exits non-zero, no refs go to the remote.
+- **Ctrl-C** cancels OPF. What that costs depends on the backend: on `git-branch` your `git push` aborts and exits non-zero; on `git-refs` your push completes and the checkpoint refs stay queued for a later push. Either way nothing under-redacted reaches the remote.
 
-Non-interactive contexts (CI, scripted pipes with no TTY) skip the prompt and run OPF automatically when enabled, printing `→ OpenAI Privacy Filter: scanning checkpoints…` to stderr so the wait isn't silent. Set `ENTIRE_OPF=no` to skip OPF in those contexts without disabling the feature globally.
+Non-interactive contexts (CI, scripted pipes with no TTY) skip the prompt and run OPF automatically when enabled, printing `→ OpenAI Privacy Filter: scanning checkpoints before push (may take ~30s)…` to stderr so the wait isn't silent. Progress and completion are reported as `→ OpenAI Privacy Filter: scanning checkpoints…` and `✓ OpenAI Privacy Filter: done (12.4s, 37 blobs)`. Set `ENTIRE_OPF=no` to skip OPF in those contexts without disabling the feature globally.
 
-**CI consideration**: if you've enabled OPF locally and your CI runs `git push` (e.g. an agent-driven workflow), the CI push will attempt to run OPF too. If the `opf` binary isn't installed in CI, the push will abort with `OPFRuntimeFailedError` rather than silently shipping under-redacted content — by design, since "I enabled OPF" should mean "no content leaves my machines without OPF." The remedies are (a) install `opf` in CI, (b) set `ENTIRE_OPF=no` for CI pushes, or (c) set `prompt_default: "never"` if you only want OPF on interactive pushes.
+**CI consideration**: if you've enabled OPF locally and your CI runs `git push` (e.g. an agent-driven workflow), the CI push will attempt to run OPF too. If the `opf` binary isn't installed in CI, the failure is fail-closed rather than silently shipping under-redacted content — by design, since "I enabled OPF" should mean "no content leaves my machines without OPF." On `git-branch` that aborts the CI push; on `git-refs` the push succeeds but the checkpoints don't ship, which means they can accumulate unpushed until someone notices. The remedies are (a) install `opf` in CI, (b) set `ENTIRE_OPF=no` for CI pushes, or (c) set `prompt_default: "never"` if you only want OPF on interactive pushes.
 
 OPF failures at push time are **fail-closed**: if OPF is not on PATH, fails to start, or times out during the pre-push rewrite, the per-process circuit breaker trips and no under-redacted content reaches the remote. The intent is that "the user enabled OPF" means "I do not want unredacted content leaving this machine" — falling back to 8-layer silently on the push path would violate that contract. Fix the install or set `ENTIRE_OPF=no` for a one-off push.
 
 How that is enforced depends on the checkpoint backend, because they have different escape hatches:
 
-- **git-branch**: the rewrite aborts the push with `OPF runtime failed; aborting push`. Your `git push` exits non-zero. The checkpoint branch travels with that push, so refusing the push is the only way to withhold it.
+- **git-branch**: the rewrite aborts the push with `OPF runtime failed during pre-push rewrite (command=…); aborting push so regex-only content isn't tagged as OPF-applied`. Your `git push` exits non-zero. The checkpoint branch travels with that push, so refusing the push is the only way to withhold it.
 - **git-refs**: checkpoint refs are pushed separately from your branch and stay queued when they are not flushed, so the failure withholds the checkpoint push and lets your own `git push` succeed. Nothing under-redacted ships either way. This is not silent: a warning names the failure and states that checkpoint refs stayed queued for the next push.
 
 (The circuit breaker is per-process, so a broken install costs one warning instead of one timeout per blob — but the push still aborts.)
@@ -245,84 +254,157 @@ Cost note: each shell-out loads the OPF model (~1.5B parameters on CPU). The pre
 
 OPF execution lives in the pre-push hook. The flow:
 
-1. **Post-commit** writes the checkpoint with **8-layer-only** redaction to your local `entire/checkpoints/v1` branch. Fast, predictable, no OPF cost on the hot path.
-2. **Pre-push** (`git push`): if OPF is enabled, the hook re-reads each unpushed `entire/checkpoints/v1` commit, runs the OpenAI Privacy Filter over its blobs to add the categories the regex layers don't catch (person names, addresses, etc.), and builds **new commits** carrying an `Entire-OPF-Applied: true` trailer. The local v1 ref fast-forwards atomically to the new tip, and the (now 9-layer-redacted) commits are what get pushed.
+1. **Post-commit** writes the checkpoint with **8-layer-only** redaction to local git objects — per-checkpoint refs on `git-refs`, the `entire/checkpoints/v1` branch on `git-branch`. Fast, predictable, no OPF cost on the hot path.
+2. **Pre-push** (`git push`): if OPF is enabled, the hook re-reads each not-yet-OPF'd commit, runs the OpenAI Privacy Filter over its blobs to add the categories the regex layers don't catch (person names, addresses, etc.), and builds **new commits** carrying an `Entire-OPF-Applied: true` trailer. Each backend then points its own local ref at the new tip with a compare-and-swap, and the (now 9-layer-redacted) commits are what get pushed.
 3. The original 8-layer-only commits become **unreachable** in the local git object database and eventually get swept by `git gc`.
+
+The two backends differ in **how they find the commits to rewrite**:
+
+| | `git-refs` | `git-branch` |
+|---|---|---|
+| What it walks | Every ref in the push-discovery queue | The `entire/checkpoints/v1` commit chain |
+| Where it stops | The first ancestor already carrying `Entire-OPF-Applied: true` — the trailer is the watermark | The remote's v1 tip, fetched live (not a stale tracking ref) |
+| Already-OPF'd commits | Left byte-identical; they *are* the boundary | Re-parented onto the new chain, but not re-redacted |
+| Ref update | Each queued ref rewritten in place, CAS'd individually | One CAS on the local v1 ref |
+
+In steady state the `git-refs` walk stops at the last commit the previous push OPF'd. That is usually the tip's parent, but not always: each write to a checkpoint advances its ref by one commit, so a turn that creates a checkpoint and then backfills its transcript and summary leaves a three-commit chain to rewrite.
+
+Note that the local ref move is **not** a fast-forward on either backend — the rewritten chain replaces the old commits rather than descending from them, which is exactly why step 3 leaves them unreachable. The *push* is still fast-forward-only and never forced, because the new chain is parented on a commit the remote already has.
 
 This means:
 
 - **The remote only ever sees 9-layer-redacted content** when OPF is enabled.
 - **Local-only commits are 8-layer-redacted** until the moment you push. If you never push, OPF never runs.
-- **Re-running pre-push is idempotent** — commits already carrying the trailer get re-parented into the chain but are not re-redacted.
+- **Re-running pre-push is idempotent** — commits already carrying the trailer are never re-redacted.
 
-#### Force-pushed remote, bootstrap, and concurrent pushes
+#### Divergence, caps, and concurrent pushes
 
-The rewrite refuses to proceed and aborts the push when it detects a divergent state, so checkpoints on the remote are never silently rebased:
+The rewrite refuses to proceed in a divergent or oversized state rather than silently rebasing or shipping unscanned content. As always, `git-branch` enforces this by aborting your push and `git-refs` by withholding the checkpoint refs.
 
-- **Diverged remote**: if local `entire/checkpoints/v1` has commits that aren't ancestors of `<remote>/entire/checkpoints/v1`, the hook exits with a `entire/checkpoints/v1 has diverged from remote` error. Fetch the remote and either reset local v1 to the remote tip or resolve manually before pushing.
-- **Bootstrap** (remote has no `entire/checkpoints/v1` yet, e.g. first push): the cap is `100` unpushed commits by default. Override via the env var on the push invocation:
+**Divergence.** On `git-branch`, if local `entire/checkpoints/v1` has commits that aren't ancestors of the remote's v1, the hook exits with a `entire/checkpoints/v1 has diverged from remote` error. Fetch the remote and either reset local v1 to the remote tip or resolve manually before pushing.
 
-  ```fish
-  set -x ENTIRE_OPF_BOOTSTRAP_LIMIT 500; git push
-  # or fully unbounded:
-  set -x ENTIRE_OPF_BOOTSTRAP_LIMIT unlimited; git push
-  ```
+`git-refs` has no divergence pre-check, and doesn't need one: each checkpoint is its own ref, so divergence shows up at push time as a non-fast-forward rejection for that one ref. Recovery fetches the remote ref and replays the local-only commits on top, then retries — still without forcing, so the remote commit is preserved as an ancestor. A ref that can't be replayed stays queued.
 
-- **Batch-size cap**: independent of commit count, the rewrite refuses pushes whose cumulative prose-leaf content exceeds `ENTIRE_OPF_BATCH_LIMIT` bytes (default: 2 MiB ≈ ~110s of inference). The two caps protect different failure modes — the bootstrap cap stops "100 throwaway commits", the batch cap stops "one commit with 50 MB of pasted transcript". An `OPF would run inference on …` error means you've hit this; bump the env var or push without OPF for that push:
+**Un-OPF'd commit cap: `100` by default.** Override per push:
 
-  ```fish
-  set -x ENTIRE_OPF_BATCH_LIMIT 10485760; git push   # 10 MiB
-  # or fully unbounded:
-  set -x ENTIRE_OPF_BATCH_LIMIT unlimited; git push
-  ```
+```fish
+set -x ENTIRE_OPF_BOOTSTRAP_LIMIT 500; git push
+# or fully unbounded:
+set -x ENTIRE_OPF_BOOTSTRAP_LIMIT unlimited; git push
+```
 
-- **Concurrent push** from another worktree: the rewrite uses a CAS to update the local v1 ref. If another process moved the ref while OPF was running, the hook exits with a "concurrent push detected" error and `git push` aborts the whole batch. Fetch and retry.
+The two backends trip this differently. On `git-branch` it applies **only on bootstrap** — the first push, when the remote has no v1 yet — counted across all unpushed commits. On `git-refs` it applies on **every** push, counted **per queued ref** over that ref's un-trailered ancestry. In practice the `git-refs` trigger is "OPF was enabled late" or "checkpoints were just migrated from the branch", not "first push".
+
+**Batch cap: `2 MiB` of cumulative prose-leaf content by default** (≈110s of inference), on both backends. An `OPF would run inference on …` error means you've hit it:
+
+```fish
+set -x ENTIRE_OPF_BATCH_LIMIT 10485760; git push   # 10 MiB
+# or fully unbounded:
+set -x ENTIRE_OPF_BATCH_LIMIT unlimited; git push
+```
+
+**Raw-byte cap: `200 MiB` of blob content buffered in memory**, on both backends. It has no env var of its own — it is derived as 100× the batch cap, so raising `ENTIRE_OPF_BATCH_LIMIT` raises it too. It is checked incrementally as blobs load, so on a pathological push (one commit carrying a huge pasted transcript) this is the cap that fires first.
+
+The three caps protect different failure modes: the commit cap stops "100 throwaway commits", the batch cap stops "one commit with 50 MB of prose", and the raw-byte cap stops the loader exhausting memory before either of the others can be evaluated. On `git-refs` the two byte caps are cumulative across the whole flush (all queued refs together) while the commit cap is per ref.
+
+**Concurrent push** from another worktree: both backends compare-and-swap the local ref. If another process moved it while OPF was running, `git-branch` exits with `entire/checkpoints/v1 moved during OPF rewrite …; re-run 'git push' (no fetch needed; the move was local)` and aborts. On `git-refs` the affected ref simply stays queued and the next push picks it up. Note that the `git-refs` rewrite rebuilds every commit before touching any ref, but the ref updates themselves are not atomic *across* refs: a conflict partway through leaves the earlier refs already rewritten. They stay queued and push OPF-applied next time, so this is safe — just not "nothing moved".
 
 #### Persistence of un-redacted-by-OPF content
 
-Three places retain content that OPF *didn't* redact, with different lifetimes. Understanding them matters if your threat model goes beyond "what reaches the remote":
+Several places retain content that OPF *didn't* redact, with different lifetimes. Understanding them matters if your threat model goes beyond "what reaches the remote":
 
 | Location | Redaction level | Lifetime | Reaches remote? |
 |---|---|---|---|
-| `.entire/<session>.jsonl` | **None — raw** | Until session is deleted (managed by the agent) | No |
+| `.entire/metadata/<session>/full.jsonl` | **None — raw** | Until the session's data is cleaned up (`entire clean`) | No |
+| The agent's own transcript (e.g. `~/.claude/projects/…`) | **None — raw** | Owned and managed by the agent | No |
 | Shadow branch `entire/<commit>-<worktree>` | 8-layer | Auto-deleted after the next successful push (only when its session has ended cleanly) | No |
-| Unreachable git objects after pre-push rewrite | 8-layer | Until `git gc --prune` (default `gc.pruneExpire` is 2 weeks) | No |
-| Reflog `git reflog show entire/checkpoints/v1` | 8-layer tips | Default `gc.reflogExpire` is 90 days | No |
-| `<remote>/entire/checkpoints/v1` | 9-layer (after OPF rewrite) | Until you delete the branch on the remote | Yes |
+| Unreachable git objects after the pre-push rewrite | 8-layer | Until `git gc --prune` (default `gc.pruneExpire` is 2 weeks) | No |
+| Local `refs/entire/checkpoints/*` (`git-refs`) | 8-layer before push, 9-layer after the rewrite | Kept indefinitely — these refs are never deleted after pushing | Yes, once pushed |
+| Local `entire/checkpoints/v1` (`git-branch`) | 8-layer before push, 9-layer after the rewrite | Until you delete the branch | Yes, once pushed |
+| Reflog of `entire/checkpoints/v1` (`git-branch` only) | 8-layer tips | Default `gc.reflogExpire` is 90 days | No |
+| A configured `git-branch` **mirror** | 8-layer, indefinitely | Until you delete the branch | No — mirrors aren't pushed at pre-push |
+| A leftover `entire/checkpoints/v1` after migrating to `git-refs` | 8-layer | Until you delete the branch | No |
+| The remote's copy of the pushed refs/branch | 9-layer (after OPF rewrite) | Until you delete them on the remote | Yes |
 
-The `.entire/<session>.jsonl` files are raw working state owned by the agent (Claude Code, etc.) — Entire reads from them but does not redact them in place, because the agent is reading and writing them continuously and editing under the agent's feet would corrupt the session.
+Two notes on the `git-refs` rows:
+
+- **There is no reflog concern for `refs/entire/checkpoints/*`.** Git's `core.logAllRefUpdates` default only auto-logs `refs/heads/*`, `refs/remotes/*`, `refs/notes/*`, and `HEAD`, and Entire's checkpoint-ref writes don't append reflog entries themselves. The reflog row above is genuinely branch-only (unless you've set `logAllRefUpdates=always`).
+- **The push queue holds no content.** `entire-checkpoint-push-queue.jsonl` in the git common dir stores one ref *name* per line, mode `0600`. Nothing in it is redactable.
+
+Two `git-branch`-shaped leftovers are easy to miss once a repo has moved on:
+
+- **A `git-branch` mirror never gets OPF'd.** Mirrors receive best-effort write fan-out only and never ref-level mutations, so a mirror branch keeps 8-layer content indefinitely. It isn't pushed at pre-push, so it doesn't reach the remote — but it is local content, and it has a `refs/heads/` reflog.
+- **Migration doesn't delete the old branch.** `entire doctor migrate-checkpoints` imports from `entire/checkpoints/v1` and leaves it in place, 8-layer, along with its reflog. Migrated refs also carry no OPF trailer, so the first push after a migration re-OPFs every migrated ref — one commit per ref keeps the commit cap happy, but the 2 MiB batch cap is the realistic trip point.
+
+`.entire/metadata/<session>/full.jsonl` is Entire's own local working copy of the transcript, written mode `0600`. It is *sanitized* (agent state that cannot be replayed out of a checkpoint is stripped) but **not redacted** — redaction happens on the way into a git object, not on this file. It is the input the shadow-branch walk and condensation read from.
+
+The agent's own transcript is never modified at all. Entire reads from it and leaves it alone, because the agent is writing to it continuously and editing under the agent's feet would corrupt the session.
 
 To aggressively scrub the unreachable git objects from the pre-push rewrite (instead of waiting for the 2-week GC window):
 
 ```fish
+# git-refs
+git reflog expire --expire-unreachable=now --all
+git gc --prune=now
+
+# git-branch
 git reflog expire --expire-unreachable=now refs/heads/entire/checkpoints/v1
 git gc --prune=now
 ```
 
 This is I/O-heavy on large repositories; it's not run automatically. If you want it as part of your push workflow, wrap `git push` in a script that invokes it after a successful push.
 
-Verifying it's working:
+#### Verifying OPF is working
+
+After enabling OPF, run an agent turn whose prompt contains a name — e.g. *"Create notes.txt with: Alice Johnson reviewed the proposal."* — then commit (which stays on the fast 8-layer pipeline) and push, which is when OPF runs.
 
 ```fish
-# After enabling OPF, run an agent turn that includes a name in the prompt,
-# e.g. "Create notes.txt with: Alice Johnson reviewed the proposal."
-# Commit (this stays on the fast 8-layer pipeline), then push. OPF runs
-# during the pre-push step:
 git commit -m "demo"
-git push   # → "→ OpenAI Privacy Filter: scanning N checkpoints (~30s)…"
-git log --oneline entire/checkpoints/v1 | head -2
-entire checkpoint explain HEAD | grep -i 'REDACTED_PERSON'
+git push   # → "OpenAI Privacy Filter: scanning checkpoints…"
 ```
 
-If `[REDACTED_PERSON]` appears in the prompt or transcript section and the latest `entire/checkpoints/v1` commit carries `Entire-OPF-Applied: true`, OPF is active.
+Then confirm the redaction landed and the trailer is present. Note that `git log --oneline` **cannot** show a trailer — it prints only the subject line — so use a format that includes the body:
+
+```fish
+# git-refs: which checkpoint refs exist, and which are OPF-applied
+git for-each-ref --sort=-committerdate \
+  --format='%(refname)  %(trailers:key=Entire-OPF-Applied)' refs/entire/checkpoints/
+
+# git-branch: the trailer on the latest v1 commit
+git log -1 --format='%H%n%B' entire/checkpoints/v1
+
+# either backend: confirm the content itself was redacted
+entire checkpoint list
+entire checkpoint explain <checkpoint-id> | grep -i 'REDACTED_PERSON'
+```
+
+If `[REDACTED_PERSON]` appears in the prompt or transcript section and the checkpoint's commit carries `Entire-OPF-Applied: true`, OPF is active.
+
+On `git-refs` you can also confirm nothing was withheld — an absent or empty queue file means everything flushed:
+
+```fish
+cat "$(git rev-parse --git-common-dir)/entire-checkpoint-push-queue.jsonl"
+```
 
 ### Recommendations
 
 If your AI sessions will touch sensitive data:
 
-- **Use a private repository.** This is the simplest and most complete protection. Transcripts on `entire/checkpoints/v1` are only visible to collaborators.
+- **Use a private repository.** This is the simplest and most complete protection. Committed checkpoints are then only visible to collaborators.
 - **Avoid passing sensitive files to your agent.** Content that never enters the agent conversation never appears in transcripts.
-- **Review before pushing.** You can inspect the `entire/checkpoints/v1` branch locally before pushing it to a remote.
+- **Review before pushing.** Checkpoints are written locally at commit time and pushed separately, so there is always a window to inspect them:
+
+  ```fish
+  # git-refs: list local checkpoint refs, then read one
+  git for-each-ref refs/entire/checkpoints
+  entire checkpoint list
+  entire checkpoint explain <id>
+
+  # git-branch: inspect the branch directly
+  git log --oneline entire/checkpoints/v1
+  ```
+
+- **Know your push destination.** Checkpoint data syncs to exactly one elected remote; `entire status` names it and reports how many checkpoints are still unpushed.
 
 ## What Gets Redacted
 

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -171,52 +171,22 @@ Full settings reference:
 
 ### Why `command` is local-only
 
-`command` becomes `argv[0]` of a process Entire executes during `git push`, so
-whoever controls that string controls what runs on the developer's machine.
-`.entire/settings.json` is version-controlled, which would let an ordinary pull
-request pair a `command` with a payload committed alongside it — and a JSON
-settings diff does not read as executable to a reviewer. The pre-push prompt is
-no defense either: it never names the command, `prompt_default: "always"` skips
-it, and non-TTY pushes (CI, agent-driven) auto-run.
+`command` becomes `argv[0]` of a process Entire executes during `git push`, so whoever controls that string controls what runs on the developer's machine. `.entire/settings.json` is version-controlled, which would let an ordinary pull request pair a `command` with a payload committed alongside it — and a JSON settings diff does not read as executable to a reviewer. The pre-push prompt is no defense either: it never names the command, `prompt_default: "always"` skips it, and non-TTY pushes (CI, agent-driven) auto-run.
 
 Entire therefore honors `command` only when it is genuinely developer-owned:
 
 - it must come from `.entire/settings.local.json`, not `.entire/settings.json`
 - that file must be **untracked** — absent from both the git index and `HEAD`
 
-The second check matters because the filename alone proves nothing:
-`.gitignore` does not apply to a path that is already tracked, so
-`git add -f .entire/settings.local.json` commits it and a fresh clone
-materializes it with the committed content.
+The second check matters because the filename alone proves nothing: `.gitignore` does not apply to a path that is already tracked, so `git add -f .entire/settings.local.json` commits it and a fresh clone materializes it with the committed content.
 
-This is enforced for the whole file, not just this setting: a tracked
-`.entire/settings.local.json` is ignored in its entirety, because it is not
-local to your clone — it arrives with the repository and would override project
-settings for everyone. Entire warns on stderr and tells you to run
-`git rm --cached .entire/settings.local.json`. The load still succeeds using
-project settings, so a committed file cannot brick the repository.
+This is enforced for the whole file, not just this setting: a tracked `.entire/settings.local.json` is ignored in its entirety, because it is not local to your clone — it arrives with the repository and would override project settings for everyone. Entire warns on stderr and tells you to run `git rm --cached .entire/settings.local.json`. The load still succeeds using project settings, so a committed file cannot brick the repository.
 
-The two checks also differ in depth. The layer check looks at the git index; the
-`command` check also looks at `HEAD`. A pull request that commits the file puts
-it in the index of every clone that checks the branch out, so the index is what
-catches a delivered attack — and checkout cannot produce a file that is absent
-from the index, so "committed, then `git rm --cached`" is a state you created
-locally, not one that arrived with the repository. Reading `HEAD` is the
-expensive half, so it is reserved for the setting that gets executed.
+The two checks also differ in depth. The layer check looks at the git index; the `command` check also looks at `HEAD`. A pull request that commits the file puts it in the index of every clone that checks the branch out, so the index is what catches a delivered attack — and checkout cannot produce a file that is absent from the index, so "committed, then `git rm --cached`" is a state you created locally, not one that arrived with the repository. Reading `HEAD` is the expensive half, so it is reserved for the setting that gets executed.
 
-The two checks fail in opposite directions on purpose. If the repository cannot
-be read at all, the local layer is still applied — losing every local
-preference over an unreadable repo is worse than the risk. The executed
-`command` is dropped in that case, because being wrong there means running
-someone else's binary. With no repository at all, nothing can have arrived by
-cloning, so the file is treated as yours.
+The two checks fail in opposite directions on purpose. If the repository cannot be read at all, the local layer is still applied — losing every local preference over an unreadable repo is worse than the risk. The executed `command` is dropped in that case, because being wrong there means running someone else's binary. With no repository at all, nothing can have arrived by cloning, so the file is treated as yours.
 
-When a `command` fails these checks it is ignored with a warning in
-`.entire/logs/entire.log` and OPF falls back to resolving `opf` on `$PATH`. If
-that binary is missing, the pre-push rewrite fails closed rather than pushing
-content you believed OPF had scanned. Everything else in the OPF block
-(`enabled`, `categories`, `timeout_seconds`, `prompt_default`) is ordinary
-configuration and still works from the shared project file.
+When a `command` fails these checks it is ignored with a warning in `.entire/logs/entire.log` and OPF falls back to resolving `opf` on `$PATH`. If that binary is missing, the pre-push rewrite fails closed rather than pushing content you believed OPF had scanned. Everything else in the OPF block (`enabled`, `categories`, `timeout_seconds`, `prompt_default`) is ordinary configuration and still works from the shared project file.
 
 The interactive prompt offers three options and reacts to **Ctrl-C** for cancellation:
 

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -285,7 +285,7 @@ Several places retain content that OPF *didn't* redact, with different lifetimes
 
 | Location | Redaction level | Lifetime | Reaches remote? |
 |---|---|---|---|
-| `.entire/metadata/<session>/full.jsonl` | **None — raw** | Until the session's data is cleaned up (`entire clean`) | No |
+| `.entire/metadata/<session>/full.jsonl` | **None** — sanitized, not redacted | Until the session's data is cleaned up (`entire clean`) | No |
 | The agent's own transcript (e.g. `~/.claude/projects/…`) | **None — raw** | Owned and managed by the agent | No |
 | Shadow branch `entire/<commit>-<worktree>` | 8-layer | Auto-deleted after the next successful push (only when its session has ended cleanly) | No |
 | Unreachable git objects after the pre-push rewrite | 8-layer | Until `git gc --prune` (default `gc.pruneExpire` is 2 weeks) | No |


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1200
<!-- entire-trail-link-end -->

`README.md` and `docs/security-and-privacy.md` described checkpoints as living on a single `entire/checkpoints/v1` branch. New repos have defaulted to the `git-refs` backend for a while, so both docs described storage most new repos don't use, and the enable flow's actual behaviour was documented nowhere. Verifying the rest turned up a set of claims that were not merely stale but wrong: commands that don't exist, error strings absent from the codebase, and a verification recipe that cannot work.

Mostly docs. Two small code changes are called out below.

## The README presents refs as the only storage model

There is no backend comparison and no switching guide, because **the enable flow offers no choice**: both first-run paths write `git-refs` silently and `git-branch` is reachable only by explicitly passing `--checkpoint-backend branch`. Documenting a decision users don't get to make was the original problem.

Checkpoint ID formats stay documented as current (26-char ULID) and legacy (12-char hex), since both remain readable and either can be passed to any command taking an ID.

## Claims cut as wrong, not reworded

| Claim | Why it went |
| --- | --- |
| Session ID format `YYYY-MM-DD-<UUID>` | No code builds a date prefix; real IDs are the agent's bare UUID. The only survivors are two stale doc comments in `paths.go` |
| SSH `known_hosts` troubleshooting section | Checkpoint fetches shell out to the git CLI, not go-git. Neither the quoted error nor `known_hosts` appears in `cmd/` |
| `"shadow branch conflict"` row | That string exists only in the README; the error type it named is a doc comment with no implementation |
| A top-level `entire clone` | `newRepoCloneCmd()` is registered only under the `repo` group — it is `entire repo clone`, and `entire clone` exits "unknown command" |
| `entire resume`, `entire explain` | Neither is top-level; they are `entire session resume` and `entire checkpoint explain` |
| "can be rewound independently" | There is no `entire rewind` |
| `summary_timeout_seconds` "default 5m" | `resolveSummaryTimeout` returns 0 when flag and setting are unset, and 0 skips `context.WithTimeout` entirely — there is no default deadline |
| Auto-summarization "uses Claude CLI; other backends may be supported in future" | The provider is configurable; six agents support it, `opencode` and `factoryai-droid` don't |
| "pushes to the same remote as your code" | Predates the single-remote sync election. Now documents the 5-tier precedence and that a push to any other remote carries nothing |

Also refreshed against the live surface: the Commands Reference (was missing `auth`, `search`, `activity`, `recap`, `dispatch`, `api`, `agent-help`, `labs`), the `entire enable` flag table, the settings table, login's browser-first default, the devcontainer `postCreateCommand`, and `test:ci`. The dev-only local auth testing section set one port then logged in against another, used the wrong scheme, omitted the `--insecure-http-auth` the smoke script passes, and named a personal sibling checkout — rewritten from the script and moved under Development.

## security-and-privacy.md

Leads with a backend table, and notes that per-checkpoint refs are *less visible* than a branch but not less accessible — a `git fetch` of `refs/entire/checkpoints/*` reads them just as well.

The OPF section was the larger gap: everything from "When OPF actually runs" onward assumed git-branch, though two bullets above it already split the backends. It gains a discovery comparison table and threads the fail-closed asymmetry — **git-branch aborts your push, git-refs withholds the checkpoint refs and lets your push through** — through Ctrl-C, the CI note, and zero-categories. Corrections:

- **"The local v1 ref fast-forwards atomically to the new tip"** was false on both backends. The rewritten chain replaces the old commits rather than descending from them, which is exactly why the next sentence says they become unreachable. The *push* is fast-forward-only; the local move is not.
- Already-trailered commits are re-parented on git-branch only; on git-refs such a commit *is* the walk boundary and stays byte-identical.
- The 100-commit cap applies on **every** git-refs push, per queued ref — not only at bootstrap. The realistic trigger is "OPF enabled late" or "just migrated".
- git-refs has **no divergence pre-check**; divergence surfaces per-ref at push time with fetch-and-replay recovery.
- The **200 MiB raw-byte cap** was undocumented and is the one most likely to fire first on a large push. No env var of its own — it scales as 100× `ENTIRE_OPF_BATCH_LIMIT`.
- Two quoted strings did not exist in the codebase, and the concurrent-push remedy said "fetch and retry" where the real message says to re-run without fetching.
- "Three places retain content" sat above a six-row table, which also missed the git-refs rows and two 8-layer sinks: a git-branch **mirror** never receives ref-level mutations so is never OPF'd, and `doctor migrate-checkpoints` leaves the old branch and reflog in place.
- The verification recipe used `git log --oneline` to look for a trailer, which `--oneline` cannot print — broken for git-branch too.

## The two code changes

**Flag help stopped presenting the backends as co-equal.** `refs (one git ref per checkpoint; recommended) or branch (shared …)` reads as a live decision with a nudge; it now names `refs` the default (what `enable` writes) and `branch` legacy. Moved to a shared `checkpointBackendFlagUsage` const built from the alias constants, since it was spelled out once per command and drift would advertise two different stories.

**`configure --summarize-timeout-seconds` help claimed a 5m fallback that does not exist.** This is where the README's wrong claim came from, and it contradicted `explain --generate`'s own `--summary-timeout-seconds` help, which already described the behaviour correctly.

Behaviour is unchanged: `--checkpoint-backend` still accepts `refs`, `branch`, `git-refs`, `git-branch`, and still rejects anything else before writing settings — all five verified against a built binary.

## Smaller items

- `go install` now covers `git-remote-entire` too. It is its own `main` package, git finds a remote helper by name on `$PATH` (which is what `go install` produces), and `versioninfo.Load()` recovers the version from module build info, so nothing degrades. Previously the README told `go install` users to switch to a packaged install for `entire://` support.
- Hard-wrapped prose unwrapped in both docs, one paragraph per line.
- `docs/architecture/ref-checkpoint-backend.md` described new setups picking git-refs "unless the setup question chose branch" — a setup question that was never built. Replaced with the real mechanism, documented next to the config-less default it is easily confused with.

## Verification

Command descriptions, subcommand lists and flag tables come from `--help` on a binary built from this branch, not from memory. Anchors, relative links, code-fence balance and table column counts validated in every file. New git plumbing commands in the docs were run against real refs. The unwrap is provably content-neutral: with whitespace collapsed and blockquote markers normalised, the word stream is byte-identical to the previous revision in both files.

Worth knowing how the `entire clone` error got in, since it bears on how much to trust the rest: I built the first verification binary while this worktree's HEAD sat on the unmerged `paul/clone-et` commit, which *does* add a top-level `clone`. The sweep meant to catch exactly this was also silently broken — each child inherited the loop's stdin and swallowed the command list, so it validated at most one entry. Re-run correctly over 46 distinct command phrases across the three docs, `entire clone` was the only failure. Both defects were found by this branch's trail review agent and are resolved there.

`mise run lint`, `go vet` and `mise run test` (10131 tests) pass. `test:ci` skipped locally — it fails on clean main on this machine for an unrelated reason (a codex integration test comparing `/var` with `/private/var`) and dirties `.opencode/package-lock.json`, so CI is the honest gate for the integration and canary legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
