### PR TITLE
fix(versioncheck): use install.ps1 for Windows update hints

### DIFF
--- a/cmd/entire/cli/checkpoint_policy.go
+++ b/cmd/entire/cli/checkpoint_policy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
 	"github.com/spf13/cobra"
 )
 
@@ -184,4 +185,16 @@ func checkpointPolicyError(message string, err error) error {
 		return NewSilentError(wrapped)
 	}
 	return wrapped
+}
+
+// unsupportedCheckpointPolicyMessage renders the upgrade advice every caller in
+// this package wants: this binary's own update command, plus the shell that
+// command needs, since the message prints it for the user to run rather than
+// running it.
+func unsupportedCheckpointPolicyMessage(policy checkpointpolicy.Policy, currentVersion string) string {
+	return checkpointpolicy.UnsupportedPolicyMessage(
+		policy,
+		versioncheck.UpdateCommandForCurrentBinary(currentVersion),
+		versioncheck.UpdateCommandShell(),
+	)
 }

--- a/cmd/entire/cli/checkpoint_policy_warning.go
+++ b/cmd/entire/cli/checkpoint_policy_warning.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
-	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
 	"github.com/spf13/cobra"
 )
 
@@ -54,8 +53,5 @@ func WarnCheckpointPolicyIfNeeded(ctx context.Context, w io.Writer, currentVersi
 		return
 	}
 
-	fmt.Fprint(w, checkpointpolicy.UnsupportedPolicyMessage(
-		state.Policy,
-		versioncheck.UpdateCommandForCurrentBinary(currentVersion),
-	))
+	fmt.Fprint(w, unsupportedCheckpointPolicyMessage(state.Policy, currentVersion))
 }

--- a/cmd/entire/cli/checkpoint_policy_write.go
+++ b/cmd/entire/cli/checkpoint_policy_write.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
-	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/go-git/go-git/v6"
 )
@@ -35,10 +34,7 @@ func checkpointPolicyForCheckpointData(ctx context.Context, repo *git.Repository
 }
 
 func unsupportedCheckpointPolicyError(policy checkpointpolicy.Policy) error {
-	message := strings.TrimSpace(checkpointpolicy.UnsupportedPolicyMessage(
-		policy,
-		versioncheck.UpdateCommandForCurrentBinary(versioninfo.Version),
-	))
+	message := strings.TrimSpace(unsupportedCheckpointPolicyMessage(policy, versioninfo.Version))
 	return fmt.Errorf("%w:\n%s", errUnsupportedCheckpointPolicy, message)
 }
 

--- a/cmd/entire/cli/checkpointpolicy/policy.go
+++ b/cmd/entire/cli/checkpointpolicy/policy.go
@@ -78,13 +78,24 @@ func CanSatisfyPolicy(policy Policy) bool {
 	return !UnsupportedWrite(policy) && !RequiresUpgrade(policy)
 }
 
-func UnsupportedPolicyMessage(policy Policy, updateCommand string) string {
+// UnsupportedPolicyMessage renders the upgrade advice for a policy this CLI
+// cannot satisfy. commandShell names the shell updateCommand has to run in
+// (versioncheck.UpdateCommandShell), and is "" when any shell will do: the
+// command is printed for the user to paste, and on Windows it is a PowerShell
+// one-liner that misbehaves in cmd.exe or bash, so an unnamed shell is not
+// enough to act on.
+func UnsupportedPolicyMessage(policy Policy, updateCommand, commandShell string) string {
 	if CanSatisfyPolicy(policy) {
 		return ""
 	}
 
+	upgrade := "Upgrade Entire, then rerun the command:"
+	if commandShell != "" {
+		upgrade = fmt.Sprintf("Upgrade Entire by running the following in %s, then rerun the command:", commandShell)
+	}
+
 	var b strings.Builder
-	fmt.Fprintf(&b, "[entire] This repository requires checkpoint support newer than this Entire CLI.\n[entire] Upgrade Entire, then rerun the command:\n[entire]   %s\n", updateCommand)
+	fmt.Fprintf(&b, "[entire] This repository requires checkpoint support newer than this Entire CLI.\n[entire] %s\n[entire]   %s\n", upgrade, updateCommand)
 	details := unsupportedPolicyDetails(policy)
 	if len(details) == 0 {
 		return b.String()

--- a/cmd/entire/cli/checkpointpolicy/warning_test.go
+++ b/cmd/entire/cli/checkpointpolicy/warning_test.go
@@ -56,9 +56,10 @@ func TestUnsupportedPolicyMessageIncludesSettingDetails(t *testing.T) {
 	got := checkpointpolicy.UnsupportedPolicyMessage(checkpointpolicy.Policy{
 		CheckpointVersion:    "refs-v2",
 		CheckpointMinVersion: "refs-v2",
-	}, "brew upgrade entire")
+	}, "brew upgrade entire", "")
 
 	require.Contains(t, got, "[entire] This repository requires checkpoint support newer than this Entire CLI.")
+	require.Contains(t, got, "[entire] Upgrade Entire, then rerun the command:")
 	require.Contains(t, got, "[entire]   brew upgrade entire")
 	require.Contains(t, got, `checkpoint_version "refs-v2" is not writable by this Entire CLI`)
 	require.Contains(t, got, `checkpoint_min_version "refs-v2" is not readable by this Entire CLI`)
@@ -67,5 +68,19 @@ func TestUnsupportedPolicyMessageIncludesSettingDetails(t *testing.T) {
 func TestUnsupportedPolicyMessageEmptyForSatisfiedPolicy(t *testing.T) {
 	t.Parallel()
 
-	require.Empty(t, checkpointpolicy.UnsupportedPolicyMessage(checkpointpolicy.DefaultPolicy(), "brew upgrade entire"))
+	require.Empty(t, checkpointpolicy.UnsupportedPolicyMessage(checkpointpolicy.DefaultPolicy(), "brew upgrade entire", ""))
+}
+
+// A command that only runs in one shell is printed with that shell named: the
+// Windows install.ps1 one-liner is inert or worse in cmd.exe and bash.
+func TestUnsupportedPolicyMessageNamesTheCommandShell(t *testing.T) {
+	t.Parallel()
+
+	got := checkpointpolicy.UnsupportedPolicyMessage(checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v2",
+		CheckpointMinVersion: "refs-v2",
+	}, "irm https://entire.io/install.ps1 | iex", "PowerShell")
+
+	require.Contains(t, got, "[entire] Upgrade Entire by running the following in PowerShell, then rerun the command:")
+	require.Contains(t, got, "[entire]   irm https://entire.io/install.ps1 | iex")
 }

--- a/cmd/entire/cli/hook_registry.go
+++ b/cmd/entire/cli/hook_registry.go
@@ -22,7 +22,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
-	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/perf"
 
@@ -316,7 +315,7 @@ func agentWriteHookLabel(eventType agent.EventType, claudePostTodoCheckpointHook
 
 func sessionStartPolicyWarning(policy checkpointpolicy.Policy) string {
 	message := "Entire CLI is enabled, but this repository's checkpoint policy requires a newer Entire CLI. No Entire checkpoints will be created for this session until you upgrade."
-	details := strings.TrimSpace(checkpointpolicy.UnsupportedPolicyMessage(policy, versioncheck.UpdateCommandForCurrentBinary(versioninfo.Version)))
+	details := strings.TrimSpace(unsupportedCheckpointPolicyMessage(policy, versioninfo.Version))
 	if details == "" {
 		return message
 	}
@@ -331,7 +330,7 @@ func agentCheckpointCaptureDisabledMessage(policy checkpointpolicy.Policy) strin
 	var b strings.Builder
 	b.WriteString("[entire] Checkpoint capture is disabled for this repository.\n")
 	b.WriteString("[entire] No Entire checkpoints will be created until the CLI is upgraded.\n")
-	if details := strings.TrimSpace(checkpointpolicy.UnsupportedPolicyMessage(policy, versioncheck.UpdateCommandForCurrentBinary(versioninfo.Version))); details != "" {
+	if details := strings.TrimSpace(unsupportedCheckpointPolicyMessage(policy, versioninfo.Version)); details != "" {
 		b.WriteString(details)
 		b.WriteByte('\n')
 	}

--- a/cmd/entire/cli/hooks_git_cmd.go
+++ b/cmd/entire/cli/hooks_git_cmd.go
@@ -15,7 +15,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
-	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/perf"
 
@@ -89,10 +88,7 @@ func (g *gitHookContext) skipUnsupportedCheckpointPolicy() bool {
 		slog.String("checkpoint_version", policy.CheckpointVersion),
 		slog.String("checkpoint_min_version", policy.CheckpointMinVersion))
 	if interactive.CanPromptInteractively() {
-		fmt.Fprint(os.Stderr, checkpointpolicy.UnsupportedPolicyMessage(
-			policy,
-			versioncheck.UpdateCommandForCurrentBinary(versioninfo.Version),
-		))
+		fmt.Fprint(os.Stderr, unsupportedCheckpointPolicyMessage(policy, versioninfo.Version))
 	}
 	emitCheckpointPolicyBlocked(g.ctx, telemetry.CheckpointPolicyBlockedEvent{
 		Hook:                 g.hookName,

--- a/cmd/entire/cli/strategy/checkpoint_policy.go
+++ b/cmd/entire/cli/strategy/checkpoint_policy.go
@@ -99,7 +99,11 @@ func warnIfCheckpointPolicyNeedsUpgrade(ctx context.Context, policy checkpointpo
 }
 
 func warnOrLogCheckpointPolicyUpgrade(ctx context.Context, policy checkpointpolicy.Policy) {
-	warning := checkpointpolicy.UnsupportedPolicyMessage(policy, versioncheck.UpdateCommandForCurrentBinary(versioninfo.Version))
+	warning := checkpointpolicy.UnsupportedPolicyMessage(
+		policy,
+		versioncheck.UpdateCommandForCurrentBinary(versioninfo.Version),
+		versioncheck.UpdateCommandShell(),
+	)
 	if interactive.CanPromptInteractively() {
 		fmt.Fprint(stderrWriter, warning)
 		return

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -57,9 +57,9 @@ var (
 // environment like CI / agent subprocess / no TTY) the installer
 // command is printed so the user still learns what to run manually.
 //
-// On Windows + unknown install manager the POSIX curl-pipe-bash fallback
-// can't auto-run and there's no native equivalent, so we point the user
-// at the releases download page instead.
+// On Windows the installer is never auto-run (a running entire.exe cannot
+// replace itself). Scoop, mise, and install.ps1 commands are printed for
+// the user to run after entire has exited.
 func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVersion string) AutoUpdateAction {
 	if !canAutoInstall() {
 		printNotification(w, currentVersion, latestVersion)

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -43,7 +43,7 @@ var (
 //
 // The same 3-option prompt (update / skip / skip until next version) is
 // shown for every install manager that supports auto-installation
-// (brew, mise, scoop, curl-bash). The only thing that varies between
+// (brew, mise, curl-bash). The only thing that varies between
 // installers is the shell command interpolated into option 1.
 //
 // If the installer command fails, a hint with the exact command is
@@ -73,15 +73,9 @@ func maybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 	// suppress a specific version: the nudge returns every 24h until they
 	// update. That is deliberate while the Scoop rename migration is live —
 	// there is no prompt to choose from, so there is no choice to remember.
-	if goos == goosWindows {
+	if !installerAutoRuns || os.Getenv(envKillSwitch) != "" || !interactive.CanPromptInteractively() || !isTerminalOut(w) {
 		printNotification(w, currentVersion, latestVersion)
-		fmt.Fprintf(w, "To update, run the following when entire is not running:\n  %s\n", cmdStr)
-		return autoUpdateActionSkip
-	}
-
-	if os.Getenv(envKillSwitch) != "" || !interactive.CanPromptInteractively() || !isTerminalOut(w) {
-		printNotification(w, currentVersion, latestVersion)
-		fmt.Fprintf(w, "To update, run:\n  %s\n", cmdStr)
+		fmt.Fprintf(w, "To update, run%s:\n  %s\n", manualRunQualifier, cmdStr)
 		return autoUpdateActionSkip
 	}
 

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 
 	"charm.land/huh/v2"
 
@@ -39,7 +38,7 @@ var (
 	isTerminalOut                = interactive.IsTerminalWriter
 )
 
-// MaybeAutoUpdate prints an update notification and offers an interactive
+// maybeAutoUpdate prints an update notification and offers an interactive
 // upgrade. Silent on every failure path — it must never interrupt the CLI.
 //
 // The same 3-option prompt (update / skip / skip until next version) is
@@ -58,9 +57,9 @@ var (
 // command is printed so the user still learns what to run manually.
 //
 // On Windows the installer is never auto-run (a running entire.exe cannot
-// replace itself). Scoop, mise, and install.ps1 commands are printed for
-// the user to run after entire has exited.
-func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVersion string) AutoUpdateAction {
+// replace itself), so scoop, mise, and install.ps1 commands are printed
+// for the user to run once entire has exited.
+func maybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVersion string) AutoUpdateAction {
 	cmdStr := UpdateCommandForCurrentBinary(currentVersion)
 
 	// Windows can't replace a running executable, so no installer can update
@@ -133,27 +132,4 @@ func realChooseUpdate(ctx context.Context, currentVersion, latestVersion, cmdStr
 		return autoUpdateActionSkip, fmt.Errorf("update prompt: %w", err)
 	}
 	return action, nil
-}
-
-// realRunInstaller shells out to the installer command, streaming stdin/stdout/stderr
-// so password prompts and progress output reach the user. In practice it only
-// ever runs the POSIX installers (brew, mise, curl): MaybeAutoUpdate returns
-// before reaching here on Windows, so the cmd.exe branch below is unreachable
-// today. It is kept as cover for Windows print-only being lifted later, and
-// reads the same `goos` seam MaybeAutoUpdate does so a test can drive both
-// consistently.
-func realRunInstaller(ctx context.Context, cmdStr string) error {
-	var c *exec.Cmd
-	if goos == goosWindows {
-		c = exec.CommandContext(ctx, "cmd", "/C", cmdStr)
-	} else {
-		c = exec.CommandContext(ctx, "sh", "-c", cmdStr)
-	}
-	c.Stdin = os.Stdin
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	if err := c.Run(); err != nil {
-		return fmt.Errorf("installer exited: %w", err)
-	}
-	return nil
 }

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -61,7 +61,7 @@ var (
 // replace itself). Scoop, mise, and install.ps1 commands are printed for
 // the user to run after entire has exited.
 func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVersion string) AutoUpdateAction {
-	cmdStr := updateCommand(currentVersion)
+	cmdStr := UpdateCommandForCurrentBinary(currentVersion)
 
 	// Windows can't replace a running executable, so no installer can update
 	// entire in place while it runs. For Scoop this is acute: the live

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -61,12 +61,6 @@ var (
 // replace itself). Scoop, mise, and install.ps1 commands are printed for
 // the user to run after entire has exited.
 func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVersion string) AutoUpdateAction {
-	if !canAutoInstall() {
-		printNotification(w, currentVersion, latestVersion)
-		fmt.Fprintf(w, "To update, download the latest release from:\n  %s\n", downloadsURL)
-		return autoUpdateActionSkip
-	}
-
 	cmdStr := updateCommand(currentVersion)
 
 	// Windows can't replace a running executable, so no installer can update

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -73,9 +73,15 @@ func maybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 	// suppress a specific version: the nudge returns every 24h until they
 	// update. That is deliberate while the Scoop rename migration is live —
 	// there is no prompt to choose from, so there is no choice to remember.
-	if !installerAutoRuns || os.Getenv(envKillSwitch) != "" || !interactive.CanPromptInteractively() || !isTerminalOut(w) {
+	if !installerAutoRuns {
 		printNotification(w, currentVersion, latestVersion)
-		fmt.Fprintf(w, "To update, run%s:\n  %s\n", manualRunQualifier, cmdStr)
+		fmt.Fprintf(w, "To update, run the following when entire is not running:\n  %s\n", cmdStr)
+		return autoUpdateActionSkip
+	}
+
+	if os.Getenv(envKillSwitch) != "" || !interactive.CanPromptInteractively() || !isTerminalOut(w) {
+		printNotification(w, currentVersion, latestVersion)
+		fmt.Fprintf(w, "To update, run:\n  %s\n", cmdStr)
 		return autoUpdateActionSkip
 	}
 

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -75,7 +75,7 @@ func maybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 	// there is no prompt to choose from, so there is no choice to remember.
 	if !installerAutoRuns {
 		printNotification(w, currentVersion, latestVersion)
-		fmt.Fprintf(w, "To update, run the following when entire is not running:\n  %s\n", cmdStr)
+		fmt.Fprintf(w, "To update, run the following in PowerShell when entire is not running:\n  %s\n", cmdStr)
 		return autoUpdateActionSkip
 	}
 

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -189,8 +189,8 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 	if !strings.Contains(out, "when entire is not running") {
 		t.Errorf("missing Windows manual-run hint: %q", out)
 	}
-	if !strings.Contains(out, "  mise upgrade entire") {
-		t.Errorf("manual hint missing command %q: %q", "mise upgrade entire", out)
+	if !strings.Contains(out, "  "+miseUpgradeCmd) {
+		t.Errorf("manual hint missing command %q: %q", miseUpgradeCmd, out)
 	}
 }
 
@@ -270,7 +270,7 @@ func nonWindowsAutoInstallers() []installerCase {
 	// TestMaybeAutoUpdate_WindowsNeverAutoRuns.
 	return []installerCase{
 		{name: "brew", setup: useBrewExecutable, wantCmd: brewUpgradeCmd},
-		{name: "mise", setup: useMiseExecutable, wantCmd: "mise upgrade entire"},
+		{name: "mise", setup: useMiseExecutable, wantCmd: miseUpgradeCmd},
 		{name: "unknown_curl_bash", setup: useUnknownExecutable, wantCmd: "curl -fsSL https://entire.io/install.sh | bash"},
 	}
 }

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -92,9 +92,8 @@ func useUnknownExecutable(t *testing.T) {
 }
 
 // pinNonWindowsGOOS pins the goos seam to a non-Windows value so the
-// table-driven tests below pass on Windows hosts. canAutoInstall() blocks
-// brew and the curl-bash fallback on Windows; without this pin those
-// installer cases would short-circuit to the downloads-page path.
+// table-driven tests below exercise the interactive/auto-run path rather
+// than the Windows print-only branch.
 func pinNonWindowsGOOS(t *testing.T) {
 	t.Helper()
 	orig := goos
@@ -175,36 +174,63 @@ func TestMaybeAutoUpdate_NonTerminalWriter(t *testing.T) {
 }
 
 // TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun verifies that on
-// Windows without a detected install manager we never execute the POSIX
-// curl-pipe-bash fallback (which would error from cmd.exe). Instead the
-// user is pointed at the releases download page.
+// Windows without Scoop or mise we print the install.ps1 one-liner and
+// never auto-run it (a running entire.exe cannot replace itself). The
+// POSIX curl fallback must not appear.
 func TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun(t *testing.T) {
-	f := newAutoUpdateFixture(t)
-	// Force unknown install manager: point executablePath at a plain
-	// Program Files path that matches none of the known prefixes.
-	orig := executablePath
-	executablePath = func() (string, error) {
-		return `C:\Program Files\Entire\entire.exe`, nil
+	tests := []struct {
+		name           string
+		currentVersion string
+		wantCmd        string
+	}{
+		{
+			name:           "stable",
+			currentVersion: "1.0.0",
+			wantCmd:        windowsInstallCmd,
+		},
+		{
+			name:           "nightly",
+			currentVersion: "1.0.1-nightly.202604101200.abc1234",
+			wantCmd:        windowsInstallNightlyCmd,
+		},
 	}
-	t.Cleanup(func() { executablePath = orig })
 
-	origGOOS := goos
-	goos = goosWindows
-	t.Cleanup(func() { goos = origGOOS })
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newAutoUpdateFixture(t)
+			orig := executablePath
+			executablePath = func() (string, error) {
+				return windowsProgramFilesPath, nil
+			}
+			t.Cleanup(func() { executablePath = orig })
 
-	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+			origGOOS := goos
+			goos = goosWindows
+			t.Cleanup(func() { goos = origGOOS })
 
-	if f.installCalls != 0 {
-		t.Errorf("installer was auto-run on Windows + unknown install manager")
-	}
-	out := buf.String()
-	if !strings.Contains(out, "download the latest release") ||
-		!strings.Contains(out, "github.com/entireio/cli/releases") {
-		t.Errorf("expected download-page hint, got: %q", out)
-	}
-	if strings.Contains(out, "curl -fsSL") {
-		t.Errorf("Windows fallback must not show POSIX curl command: %q", out)
+			var buf bytes.Buffer
+			action := MaybeAutoUpdate(context.Background(), &buf, tt.currentVersion, "v2.0.0")
+
+			if f.installCalls != 0 {
+				t.Errorf("installer was auto-run on Windows + unknown install manager")
+			}
+			if action != autoUpdateActionSkip {
+				t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
+			}
+			out := buf.String()
+			if !strings.Contains(out, "when entire is not running") {
+				t.Errorf("missing Windows manual-run hint: %q", out)
+			}
+			if !strings.Contains(out, "  "+tt.wantCmd) {
+				t.Errorf("manual hint missing command %q: %q", tt.wantCmd, out)
+			}
+			if strings.Contains(out, "curl -fsSL") {
+				t.Errorf("Windows fallback must not show POSIX curl command: %q", out)
+			}
+			if strings.Contains(out, "download the latest release") {
+				t.Errorf("Windows unknown installer must not point at the releases page: %q", out)
+			}
+		})
 	}
 }
 
@@ -228,6 +254,18 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 			name:    "mise prints upgrade command",
 			setup:   useMiseExecutable,
 			wantCmd: "mise upgrade entire",
+		},
+		{
+			name: "unknown prints install.ps1 command",
+			setup: func(t *testing.T) {
+				t.Helper()
+				orig := executablePath
+				executablePath = func() (string, error) {
+					return windowsLocalBinPath, nil
+				}
+				t.Cleanup(func() { executablePath = orig })
+			},
+			wantCmd: windowsInstallCmd,
 		},
 	}
 

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -55,7 +55,7 @@ func useBrewExecutable(t *testing.T) {
 	t.Helper()
 	orig := executablePath
 	executablePath = func() (string, error) {
-		return "/opt/homebrew/Cellar/entire/1.0.0/bin/entire", nil
+		return "/opt/homebrew/Caskroom/entire/1.0.0/entire", nil
 	}
 	t.Cleanup(func() { executablePath = orig })
 }
@@ -65,17 +65,7 @@ func useMiseExecutable(t *testing.T) {
 	t.Helper()
 	orig := executablePath
 	executablePath = func() (string, error) {
-		return "/home/user/.local/share/mise/installs/entire/1.0.0/bin/entire", nil
-	}
-	t.Cleanup(func() { executablePath = orig })
-}
-
-// useScoopExecutable points the install-manager detector at a scoop install path.
-func useScoopExecutable(t *testing.T) {
-	t.Helper()
-	orig := executablePath
-	executablePath = func() (string, error) {
-		return `C:\Users\test\scoop\apps\cli\current\entire.exe`, nil
+		return miseExecutablePath, nil
 	}
 	t.Cleanup(func() { executablePath = orig })
 }
@@ -173,130 +163,34 @@ func TestMaybeAutoUpdate_NonTerminalWriter(t *testing.T) {
 	assertManualHint(t, buf.String(), brewUpgradeCmd)
 }
 
-// TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun verifies that on
-// Windows without Scoop or mise we print the install.ps1 one-liner and
-// never auto-run it (a running entire.exe cannot replace itself). The
-// POSIX curl fallback must not appear.
-func TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun(t *testing.T) {
-	tests := []struct {
-		name           string
-		currentVersion string
-		wantCmd        string
-	}{
-		{
-			name:           "stable",
-			currentVersion: "1.0.0",
-			wantCmd:        windowsInstallCmd,
-		},
-		{
-			name:           "nightly",
-			currentVersion: "1.0.1-nightly.202604101200.abc1234",
-			wantCmd:        windowsInstallNightlyCmd,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := newAutoUpdateFixture(t)
-			orig := executablePath
-			executablePath = func() (string, error) {
-				return windowsProgramFilesPath, nil
-			}
-			t.Cleanup(func() { executablePath = orig })
-
-			origGOOS := goos
-			goos = goosWindows
-			t.Cleanup(func() { goos = origGOOS })
-
-			var buf bytes.Buffer
-			action := maybeAutoUpdate(context.Background(), &buf, tt.currentVersion, "v2.0.0")
-
-			if f.installCalls != 0 {
-				t.Errorf("installer was auto-run on Windows + unknown install manager")
-			}
-			if action != autoUpdateActionSkip {
-				t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
-			}
-			out := buf.String()
-			if !strings.Contains(out, "when entire is not running") {
-				t.Errorf("missing Windows manual-run hint: %q", out)
-			}
-			if !strings.Contains(out, "  "+tt.wantCmd) {
-				t.Errorf("manual hint missing command %q: %q", tt.wantCmd, out)
-			}
-			if strings.Contains(out, "curl -fsSL") {
-				t.Errorf("Windows fallback must not show POSIX curl command: %q", out)
-			}
-			if strings.Contains(out, "download the latest release") {
-				t.Errorf("Windows unknown installer must not point at the releases page: %q", out)
-			}
-		})
-	}
-}
-
 // TestMaybeAutoUpdate_WindowsNeverAutoRuns verifies that on Windows the update
 // is never auto-run — a running entire.exe can't replace its own shim — so the
-// command is printed for the user to run once entire has exited. This holds for
-// every auto-installable manager on Windows, not just Scoop: mise is covered so
-// narrowing the branch back to Scoop can't silently regress it.
+// command is printed for the user to run once entire has exited. mise is the
+// shared manager covered here so narrowing the branch back to Scoop can't
+// silently regress it; Scoop and install.ps1 live in autoupdate_windows_test.go.
 func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
-	tests := []struct {
-		name    string
-		setup   func(*testing.T)
-		wantCmd string
-	}{
-		{
-			name:    "scoop cli app prints migration command",
-			setup:   useScoopExecutable,
-			wantCmd: `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`,
-		},
-		{
-			name:    "mise prints upgrade command",
-			setup:   useMiseExecutable,
-			wantCmd: "mise upgrade entire",
-		},
-		{
-			name: "unknown prints install.ps1 command",
-			setup: func(t *testing.T) {
-				t.Helper()
-				orig := executablePath
-				executablePath = func() (string, error) {
-					return windowsLocalBinPath, nil
-				}
-				t.Cleanup(func() { executablePath = orig })
-			},
-			wantCmd: windowsInstallCmd,
-		},
+	f := newAutoUpdateFixture(t)
+	useMiseExecutable(t)
+
+	origGOOS := goos
+	goos = goosWindows
+	t.Cleanup(func() { goos = origGOOS })
+
+	var buf bytes.Buffer
+	action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+
+	if f.installCalls != 0 {
+		t.Fatalf("installer must not auto-run on Windows; calls=%d", f.installCalls)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := newAutoUpdateFixture(t)
-			tt.setup(t)
-
-			origGOOS := goos
-			goos = goosWindows
-			t.Cleanup(func() { goos = origGOOS })
-
-			var buf bytes.Buffer
-			action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
-
-			if f.installCalls != 0 {
-				t.Fatalf("installer must not auto-run on Windows; calls=%d", f.installCalls)
-			}
-			// Plain skip, not skip-until-next-version: Windows gets no prompt,
-			// so there is no per-version choice to persist.
-			if action != autoUpdateActionSkip {
-				t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
-			}
-			out := buf.String()
-			if !strings.Contains(out, "when entire is not running") {
-				t.Errorf("missing Windows manual-run hint: %q", out)
-			}
-			if !strings.Contains(out, "  "+tt.wantCmd) {
-				t.Errorf("manual hint missing command %q: %q", tt.wantCmd, out)
-			}
-		})
+	if action != autoUpdateActionSkip {
+		t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "when entire is not running") {
+		t.Errorf("missing Windows manual-run hint: %q", out)
+	}
+	if !strings.Contains(out, "  mise upgrade entire") {
+		t.Errorf("manual hint missing command %q: %q", "mise upgrade entire", out)
 	}
 }
 

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -385,7 +385,7 @@ func nonWindowsAutoInstallers() []installerCase {
 // that the prompt seam is invoked with the right shell command for every
 // install manager. The huh.Select itself is exercised by the manual
 // smoke script (test-auto.sh); here we only check that the cmd we build
-// from updateCommand() is what reaches the prompt.
+// from UpdateCommandForCurrentBinary() is what reaches the prompt.
 func TestMaybeAutoUpdate_AllInstallers_PromptReceivesCorrectCommand(t *testing.T) {
 	pinNonWindowsGOOS(t)
 	for _, tt := range nonWindowsAutoInstallers() {

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package versioncheck
 
 import (
@@ -9,194 +11,56 @@ import (
 	"testing"
 )
 
-// autoUpdateFixture wires the test seams for maybeAutoUpdate.
-type autoUpdateFixture struct {
-	installCalls int
-	installErr   error
-	lastCommand  string
-	chooseValue  AutoUpdateAction
-	chooseErr    error
-	lastCmdStr   string
-}
-
-func newAutoUpdateFixture(t *testing.T) *autoUpdateFixture {
-	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv(envKillSwitch, "")
-	// Force interactive mode on by default; individual tests can opt out.
-	t.Setenv("ENTIRE_TEST_TTY", "1")
-
-	f := &autoUpdateFixture{chooseValue: autoUpdateActionUpdate}
-
-	origRun := runInstaller
-	runInstaller = func(_ context.Context, cmd string) error {
-		f.installCalls++
-		f.lastCommand = cmd
-		return f.installErr
-	}
-	origChoose := chooseUpdate
-	chooseUpdate = func(_ context.Context, _, _, cmdStr string) (AutoUpdateAction, error) {
-		f.lastCmdStr = cmdStr
-		return f.chooseValue, f.chooseErr
-	}
-	origIsTerminalOut := isTerminalOut
-	isTerminalOut = func(_ io.Writer) bool { return true }
-
-	t.Cleanup(func() {
-		runInstaller = origRun
-		chooseUpdate = origChoose
-		isTerminalOut = origIsTerminalOut
-	})
-	return f
-}
-
-// useBrewExecutable points the install-manager detector at a brew cellar path.
-func useBrewExecutable(t *testing.T) {
-	t.Helper()
-	orig := executablePath
-	executablePath = func() (string, error) {
-		return "/opt/homebrew/Caskroom/entire/1.0.0/entire", nil
-	}
-	t.Cleanup(func() { executablePath = orig })
-}
-
-// useMiseExecutable points the install-manager detector at a mise install path.
-func useMiseExecutable(t *testing.T) {
-	t.Helper()
-	orig := executablePath
-	executablePath = func() (string, error) {
-		return miseExecutablePath, nil
-	}
-	t.Cleanup(func() { executablePath = orig })
-}
-
-// useUnknownExecutable points the install-manager detector at a plain path
-// with no recognised manager prefix (curl-bash fallback).
-func useUnknownExecutable(t *testing.T) {
-	t.Helper()
-	orig := executablePath
-	executablePath = func() (string, error) {
-		return "/usr/local/bin/entire", nil
-	}
-	t.Cleanup(func() { executablePath = orig })
-}
-
-// pinNonWindowsGOOS pins the goos seam to a non-Windows value so the
-// table-driven tests below exercise the interactive/auto-run path rather
-// than the Windows print-only branch.
-func pinNonWindowsGOOS(t *testing.T) {
-	t.Helper()
-	orig := goos
-	goos = "darwin"
-	t.Cleanup(func() { goos = orig })
-}
-
-// assertManualHint checks that the "To update, run:\n  <cmd>" hint
-// was printed when the prompt couldn't be shown, and that the wantCmd
-// installer command is included.
-func assertManualHint(t *testing.T, out, wantCmd string) {
-	t.Helper()
-	if !strings.Contains(out, "To update, run:") {
-		t.Errorf("missing manual-update hint: %q", out)
-	}
-	if !strings.Contains(out, "  "+wantCmd) {
-		t.Errorf("manual hint missing installer command %q: %q", wantCmd, out)
-	}
-}
-
 func TestMaybeAutoUpdate_KillSwitch(t *testing.T) {
 	f := newAutoUpdateFixture(t)
-	useBrewExecutable(t)
+	setExecutablePath(t, brewCaskPath)
 	t.Setenv(envKillSwitch, "1")
 
 	var buf bytes.Buffer
-	maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+	action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
-	if f.installCalls != 0 {
-		t.Errorf("installer called with kill-switch set")
-	}
-	assertManualHint(t, buf.String(), brewUpgradeCmd)
+	assertPrintOnly(t, f, action, buf.String(), brewUpgradeCmd)
 }
 
 func TestMaybeAutoUpdate_NoTTY(t *testing.T) {
 	f := newAutoUpdateFixture(t)
-	useBrewExecutable(t)
+	setExecutablePath(t, brewCaskPath)
 	// No TTY → maybeAutoUpdate must print the manual hint instead of prompting.
 	t.Setenv("ENTIRE_TEST_TTY", "0")
 
 	var buf bytes.Buffer
-	maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+	action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
-	if f.installCalls != 0 {
-		t.Errorf("installer called without TTY")
-	}
-	assertManualHint(t, buf.String(), brewUpgradeCmd)
+	assertPrintOnly(t, f, action, buf.String(), brewUpgradeCmd)
 }
 
 func TestMaybeAutoUpdate_CIEnv(t *testing.T) {
 	f := newAutoUpdateFixture(t)
-	useBrewExecutable(t)
+	setExecutablePath(t, brewCaskPath)
 	// Clear the test override so the real CanPromptInteractively path runs.
 	t.Setenv("ENTIRE_TEST_TTY", "")
 	t.Setenv("CI", "true")
 
 	var buf bytes.Buffer
-	maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+	action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
-	if f.installCalls != 0 {
-		t.Errorf("installer called on CI (CI=true)")
-	}
-	assertManualHint(t, buf.String(), brewUpgradeCmd)
+	assertPrintOnly(t, f, action, buf.String(), brewUpgradeCmd)
 }
 
 func TestMaybeAutoUpdate_NonTerminalWriter(t *testing.T) {
 	f := newAutoUpdateFixture(t)
-	useBrewExecutable(t)
+	setExecutablePath(t, brewCaskPath)
 	isTerminalOut = func(_ io.Writer) bool { return false }
-
-	var buf bytes.Buffer
-	maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
-
-	if f.installCalls != 0 {
-		t.Errorf("installer called with non-terminal output writer")
-	}
-	assertManualHint(t, buf.String(), brewUpgradeCmd)
-}
-
-// TestMaybeAutoUpdate_WindowsNeverAutoRuns verifies that on Windows the update
-// is never auto-run — a running entire.exe can't replace its own shim — so the
-// command is printed for the user to run once entire has exited. mise is the
-// shared manager covered here so narrowing the branch back to Scoop can't
-// silently regress it; Scoop and install.ps1 live in autoupdate_windows_test.go.
-func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
-	f := newAutoUpdateFixture(t)
-	useMiseExecutable(t)
-
-	origGOOS := goos
-	goos = goosWindows
-	t.Cleanup(func() { goos = origGOOS })
 
 	var buf bytes.Buffer
 	action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
-	if f.installCalls != 0 {
-		t.Fatalf("installer must not auto-run on Windows; calls=%d", f.installCalls)
-	}
-	if action != autoUpdateActionSkip {
-		t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
-	}
-	out := buf.String()
-	if !strings.Contains(out, "when entire is not running") {
-		t.Errorf("missing Windows manual-run hint: %q", out)
-	}
-	if !strings.Contains(out, "  "+miseUpgradeCmd) {
-		t.Errorf("manual hint missing command %q: %q", miseUpgradeCmd, out)
-	}
+	assertPrintOnly(t, f, action, buf.String(), brewUpgradeCmd)
 }
 
 func TestMaybeAutoUpdate_UserDeclines(t *testing.T) {
 	f := newAutoUpdateFixture(t)
-	useBrewExecutable(t)
+	setExecutablePath(t, brewCaskPath)
 	f.chooseValue = autoUpdateActionSkip
 
 	var buf bytes.Buffer
@@ -212,7 +76,7 @@ func TestMaybeAutoUpdate_UserDeclines(t *testing.T) {
 
 func TestMaybeAutoUpdate_HappyPath(t *testing.T) {
 	f := newAutoUpdateFixture(t)
-	useBrewExecutable(t)
+	setExecutablePath(t, brewCaskPath)
 
 	var buf bytes.Buffer
 	action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
@@ -233,7 +97,7 @@ func TestMaybeAutoUpdate_HappyPath(t *testing.T) {
 
 func TestMaybeAutoUpdate_InstallerFailurePrintedToUser(t *testing.T) {
 	f := newAutoUpdateFixture(t)
-	useBrewExecutable(t)
+	setExecutablePath(t, brewCaskPath)
 	f.installErr = errors.New("boom")
 
 	var buf bytes.Buffer
@@ -256,22 +120,19 @@ func TestMaybeAutoUpdate_InstallerFailurePrintedToUser(t *testing.T) {
 }
 
 // installerCase covers the same prompt contract for every install manager
-// that supports auto-installation.
+// that supports auto-installation. Scoop is absent: Windows is print-only, see
+// autoupdate_windows_test.go.
 type installerCase struct {
-	name    string
-	setup   func(*testing.T)
-	wantCmd string
+	name     string
+	execPath string
+	wantCmd  string
 }
 
-func nonWindowsAutoInstallers() []installerCase {
-	// Scoop is intentionally absent: it is a Windows-only installer, and on
-	// Windows the update is print-only (never auto-run). Its command building is
-	// covered by TestUpdateCommand and its print-only path by
-	// TestMaybeAutoUpdate_WindowsNeverAutoRuns.
+func autoInstallers() []installerCase {
 	return []installerCase{
-		{name: "brew", setup: useBrewExecutable, wantCmd: brewUpgradeCmd},
-		{name: "mise", setup: useMiseExecutable, wantCmd: miseUpgradeCmd},
-		{name: "unknown_curl_bash", setup: useUnknownExecutable, wantCmd: "curl -fsSL https://entire.io/install.sh | bash"},
+		{name: "brew", execPath: brewCaskPath, wantCmd: brewUpgradeCmd},
+		{name: "mise", execPath: miseExecutablePath, wantCmd: miseUpgradeCmd},
+		{name: "unknown_curl_bash", execPath: plainBinPath, wantCmd: "curl -fsSL https://entire.io/install.sh | bash"},
 	}
 }
 
@@ -281,11 +142,10 @@ func nonWindowsAutoInstallers() []installerCase {
 // smoke script (test-auto.sh); here we only check that the cmd we build
 // from UpdateCommandForCurrentBinary() is what reaches the prompt.
 func TestMaybeAutoUpdate_AllInstallers_PromptReceivesCorrectCommand(t *testing.T) {
-	pinNonWindowsGOOS(t)
-	for _, tt := range nonWindowsAutoInstallers() {
+	for _, tt := range autoInstallers() {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newAutoUpdateFixture(t)
-			tt.setup(t)
+			setExecutablePath(t, tt.execPath)
 			f.chooseValue = autoUpdateActionSkipUntilNextVersion
 
 			var buf bytes.Buffer
@@ -305,11 +165,10 @@ func TestMaybeAutoUpdate_AllInstallers_PromptReceivesCorrectCommand(t *testing.T
 }
 
 func TestMaybeAutoUpdate_AllInstallers_HappyPathRunsInstaller(t *testing.T) {
-	pinNonWindowsGOOS(t)
-	for _, tt := range nonWindowsAutoInstallers() {
+	for _, tt := range autoInstallers() {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newAutoUpdateFixture(t)
-			tt.setup(t)
+			setExecutablePath(t, tt.execPath)
 
 			var buf bytes.Buffer
 			action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
@@ -331,30 +190,25 @@ func TestMaybeAutoUpdate_AllInstallers_HappyPathRunsInstaller(t *testing.T) {
 }
 
 func TestMaybeAutoUpdate_AllInstallers_KillSwitchPrintsManualHint(t *testing.T) {
-	pinNonWindowsGOOS(t)
-	for _, tt := range nonWindowsAutoInstallers() {
+	for _, tt := range autoInstallers() {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newAutoUpdateFixture(t)
-			tt.setup(t)
+			setExecutablePath(t, tt.execPath)
 			t.Setenv(envKillSwitch, "1")
 
 			var buf bytes.Buffer
-			maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+			action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
-			if f.installCalls != 0 {
-				t.Errorf("installer called with kill-switch set")
-			}
-			assertManualHint(t, buf.String(), tt.wantCmd)
+			assertPrintOnly(t, f, action, buf.String(), tt.wantCmd)
 		})
 	}
 }
 
 func TestMaybeAutoUpdate_AllInstallers_UserSkips(t *testing.T) {
-	pinNonWindowsGOOS(t)
-	for _, tt := range nonWindowsAutoInstallers() {
+	for _, tt := range autoInstallers() {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newAutoUpdateFixture(t)
-			tt.setup(t)
+			setExecutablePath(t, tt.execPath)
 			f.chooseValue = autoUpdateActionSkip
 
 			var buf bytes.Buffer

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// autoUpdateFixture wires the test seams for MaybeAutoUpdate.
+// autoUpdateFixture wires the test seams for maybeAutoUpdate.
 type autoUpdateFixture struct {
 	installCalls int
 	installErr   error
@@ -120,7 +120,7 @@ func TestMaybeAutoUpdate_KillSwitch(t *testing.T) {
 	t.Setenv(envKillSwitch, "1")
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+	maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer called with kill-switch set")
@@ -131,11 +131,11 @@ func TestMaybeAutoUpdate_KillSwitch(t *testing.T) {
 func TestMaybeAutoUpdate_NoTTY(t *testing.T) {
 	f := newAutoUpdateFixture(t)
 	useBrewExecutable(t)
-	// No TTY → MaybeAutoUpdate must print the manual hint instead of prompting.
+	// No TTY → maybeAutoUpdate must print the manual hint instead of prompting.
 	t.Setenv("ENTIRE_TEST_TTY", "0")
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+	maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer called without TTY")
@@ -151,7 +151,7 @@ func TestMaybeAutoUpdate_CIEnv(t *testing.T) {
 	t.Setenv("CI", "true")
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+	maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer called on CI (CI=true)")
@@ -165,7 +165,7 @@ func TestMaybeAutoUpdate_NonTerminalWriter(t *testing.T) {
 	isTerminalOut = func(_ io.Writer) bool { return false }
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+	maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer called with non-terminal output writer")
@@ -209,7 +209,7 @@ func TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun(t *testing.T) {
 			t.Cleanup(func() { goos = origGOOS })
 
 			var buf bytes.Buffer
-			action := MaybeAutoUpdate(context.Background(), &buf, tt.currentVersion, "v2.0.0")
+			action := maybeAutoUpdate(context.Background(), &buf, tt.currentVersion, "v2.0.0")
 
 			if f.installCalls != 0 {
 				t.Errorf("installer was auto-run on Windows + unknown install manager")
@@ -279,7 +279,7 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 			t.Cleanup(func() { goos = origGOOS })
 
 			var buf bytes.Buffer
-			action := MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+			action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 			if f.installCalls != 0 {
 				t.Fatalf("installer must not auto-run on Windows; calls=%d", f.installCalls)
@@ -306,7 +306,7 @@ func TestMaybeAutoUpdate_UserDeclines(t *testing.T) {
 	f.chooseValue = autoUpdateActionSkip
 
 	var buf bytes.Buffer
-	action := MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+	action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer called after user declined")
@@ -321,7 +321,7 @@ func TestMaybeAutoUpdate_HappyPath(t *testing.T) {
 	useBrewExecutable(t)
 
 	var buf bytes.Buffer
-	action := MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+	action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 1 {
 		t.Fatalf("installer called %d times, want 1", f.installCalls)
@@ -343,7 +343,7 @@ func TestMaybeAutoUpdate_InstallerFailurePrintedToUser(t *testing.T) {
 	f.installErr = errors.New("boom")
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+	maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 1 {
 		t.Fatalf("installer called %d times, want 1", f.installCalls)
@@ -395,7 +395,7 @@ func TestMaybeAutoUpdate_AllInstallers_PromptReceivesCorrectCommand(t *testing.T
 			f.chooseValue = autoUpdateActionSkipUntilNextVersion
 
 			var buf bytes.Buffer
-			action := MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+			action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 			if f.installCalls != 0 {
 				t.Errorf("installer called after skip-until-next-version")
@@ -418,7 +418,7 @@ func TestMaybeAutoUpdate_AllInstallers_HappyPathRunsInstaller(t *testing.T) {
 			tt.setup(t)
 
 			var buf bytes.Buffer
-			action := MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+			action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 			if f.installCalls != 1 {
 				t.Fatalf("installer called %d times, want 1", f.installCalls)
@@ -445,7 +445,7 @@ func TestMaybeAutoUpdate_AllInstallers_KillSwitchPrintsManualHint(t *testing.T) 
 			t.Setenv(envKillSwitch, "1")
 
 			var buf bytes.Buffer
-			MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+			maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 			if f.installCalls != 0 {
 				t.Errorf("installer called with kill-switch set")
@@ -464,7 +464,7 @@ func TestMaybeAutoUpdate_AllInstallers_UserSkips(t *testing.T) {
 			f.chooseValue = autoUpdateActionSkip
 
 			var buf bytes.Buffer
-			action := MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+			action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 			if f.installCalls != 0 {
 				t.Errorf("installer called after user chose skip")

--- a/cmd/entire/cli/versioncheck/autoupdate_unix.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_unix.go
@@ -10,10 +10,7 @@ import (
 )
 
 // installerAutoRuns: the installer may replace the running binary in place.
-const (
-	installerAutoRuns  = true
-	manualRunQualifier = ""
-)
+const installerAutoRuns = true
 
 // realRunInstaller shells out to the installer command, streaming stdin/stdout/stderr
 // so password prompts and progress output reach the user.

--- a/cmd/entire/cli/versioncheck/autoupdate_unix.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_unix.go
@@ -9,6 +9,12 @@ import (
 	"os/exec"
 )
 
+// installerAutoRuns: the installer may replace the running binary in place.
+const (
+	installerAutoRuns  = true
+	manualRunQualifier = ""
+)
+
 // realRunInstaller shells out to the installer command, streaming stdin/stdout/stderr
 // so password prompts and progress output reach the user.
 func realRunInstaller(ctx context.Context, cmdStr string) error {

--- a/cmd/entire/cli/versioncheck/autoupdate_unix.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_unix.go
@@ -1,0 +1,23 @@
+//go:build unix
+
+package versioncheck
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// realRunInstaller shells out to the installer command, streaming stdin/stdout/stderr
+// so password prompts and progress output reach the user.
+func realRunInstaller(ctx context.Context, cmdStr string) error {
+	c := exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("installer exited: %w", err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/versioncheck/autoupdate_windows.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package versioncheck
+
+import (
+	"context"
+	"errors"
+)
+
+// realRunInstaller is not implemented on Windows. maybeAutoUpdate never
+// reaches here: a running entire.exe cannot replace itself, so Windows
+// prints the command and returns. Do not implement this with cmd.exe —
+// UpdateCommandForCurrentBinary's Windows strings are PowerShell one-liners
+// that cmd /C would split on | and &. Lifting print-only needs
+// powershell -NoProfile -Command, or in-process replace.
+func realRunInstaller(_ context.Context, _ string) error {
+	return errors.New("auto-update is not implemented on Windows")
+}

--- a/cmd/entire/cli/versioncheck/autoupdate_windows.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows.go
@@ -9,10 +9,7 @@ import (
 
 // installerAutoRuns is false on Windows: a running entire.exe cannot replace
 // itself, so the command is printed for the user to run after entire exits.
-const (
-	installerAutoRuns  = false
-	manualRunQualifier = " the following when entire is not running"
-)
+const installerAutoRuns = false
 
 // realRunInstaller is not implemented on Windows. maybeAutoUpdate never
 // reaches here: a running entire.exe cannot replace itself, so Windows

--- a/cmd/entire/cli/versioncheck/autoupdate_windows.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows.go
@@ -7,6 +7,13 @@ import (
 	"errors"
 )
 
+// installerAutoRuns is false on Windows: a running entire.exe cannot replace
+// itself, so the command is printed for the user to run after entire exits.
+const (
+	installerAutoRuns  = false
+	manualRunQualifier = " the following when entire is not running"
+)
+
 // realRunInstaller is not implemented on Windows. maybeAutoUpdate never
 // reaches here: a running entire.exe cannot replace itself, so Windows
 // prints the command and returns. Do not implement this with cmd.exe —

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -45,13 +45,13 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 			name:           "unknown stable prints install.ps1",
 			execPath:       windowsProgramFilesPath,
 			currentVersion: "1.0.0",
-			wantCmd:        windowsInstallCmd + ` -InstallDir 'C:\Program Files\Entire' -NoPathUpdate`,
+			wantCmd:        `iex "& {$(irm https://entire.io/install.ps1)} -InstallDir 'C:\Program Files\Entire' -NoPathUpdate"`,
 		},
 		{
 			name:           "unknown nightly prints install.ps1 -Channel nightly",
 			execPath:       windowsLocalBinPath,
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
-			wantCmd:        windowsInstallCmd + ` -Channel nightly -InstallDir 'C:\Users\test\.local\bin' -NoPathUpdate`,
+			wantCmd:        `iex "& {$(irm https://entire.io/install.ps1)} -Channel nightly -InstallDir 'C:\Users\test\.local\bin' -NoPathUpdate"`,
 		},
 	}
 

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestRealRunInstaller_NotImplemented(t *testing.T) {
+func TestRealRunInstaller_WindowsNotImplemented(t *testing.T) {
 	t.Parallel()
 	err := realRunInstaller(context.Background(), "echo hi")
 	want := "auto-update is not implemented on Windows"

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -45,13 +45,13 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 			name:           "unknown stable prints install.ps1",
 			execPath:       windowsProgramFilesPath,
 			currentVersion: "1.0.0",
-			wantCmd:        windowsInstallCmd + ` -InstallDir 'C:\Program Files\Entire'`,
+			wantCmd:        windowsInstallCmd + ` -InstallDir 'C:\Program Files\Entire' -NoPathUpdate`,
 		},
 		{
 			name:           "unknown nightly prints install.ps1 -Channel nightly",
 			execPath:       windowsLocalBinPath,
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
-			wantCmd:        windowsInstallCmd + ` -Channel nightly -InstallDir 'C:\Users\test\.local\bin'`,
+			wantCmd:        windowsInstallCmd + ` -Channel nightly -InstallDir 'C:\Users\test\.local\bin' -NoPathUpdate`,
 		},
 	}
 

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package versioncheck
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRealRunInstaller_NotImplemented(t *testing.T) {
+	t.Parallel()
+	err := realRunInstaller(context.Background(), "echo hi")
+	want := "auto-update is not implemented on Windows"
+	if err == nil || err.Error() != want {
+		t.Fatalf("error = %v, want %q", err, want)
+	}
+}

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -20,8 +20,8 @@ func TestRealRunInstaller_WindowsNotImplemented(t *testing.T) {
 
 // TestMaybeAutoUpdate_WindowsNeverAutoRuns verifies that on Windows the update
 // is never auto-run — a running entire.exe cannot replace its own shim — so
-// the command is printed for the user to run once entire has exited. The POSIX
-// curl fallback and the releases page must not appear.
+// the command is printed for the user to run in PowerShell once entire has
+// exited.
 func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -67,12 +67,6 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 			assertPrintOnly(t, f, action, out, tt.wantCmd)
 			if !strings.Contains(out, "in PowerShell when entire is not running") {
 				t.Errorf("missing Windows manual-run hint: %q", out)
-			}
-			if strings.Contains(out, "curl -fsSL") {
-				t.Errorf("Windows must not show the POSIX curl command: %q", out)
-			}
-			if strings.Contains(out, "download the latest release") {
-				t.Errorf("Windows must not point at the releases page: %q", out)
 			}
 		})
 	}

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -65,7 +65,7 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 
 			out := buf.String()
 			assertPrintOnly(t, f, action, out, tt.wantCmd)
-			if !strings.Contains(out, "when entire is not running") {
+			if !strings.Contains(out, "in PowerShell when entire is not running") {
 				t.Errorf("missing Windows manual-run hint: %q", out)
 			}
 			if strings.Contains(out, "curl -fsSL") {

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -45,13 +45,13 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 			name:           "unknown stable prints install.ps1",
 			execPath:       windowsProgramFilesPath,
 			currentVersion: "1.0.0",
-			wantCmd:        windowsInstallCmd + ` -InstallDir "C:\Program Files\Entire"`,
+			wantCmd:        windowsInstallCmd + ` -InstallDir 'C:\Program Files\Entire'`,
 		},
 		{
 			name:           "unknown nightly prints install.ps1 -Channel nightly",
 			execPath:       windowsLocalBinPath,
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
-			wantCmd:        windowsInstallCmd + ` -Channel nightly -InstallDir "C:\Users\test\.local\bin"`,
+			wantCmd:        windowsInstallCmd + ` -Channel nightly -InstallDir 'C:\Users\test\.local\bin'`,
 		},
 	}
 

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -3,7 +3,9 @@
 package versioncheck
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -13,5 +15,129 @@ func TestRealRunInstaller_WindowsNotImplemented(t *testing.T) {
 	want := "auto-update is not implemented on Windows"
 	if err == nil || err.Error() != want {
 		t.Fatalf("error = %v, want %q", err, want)
+	}
+}
+
+func useScoopExecutable(t *testing.T) {
+	t.Helper()
+	orig := executablePath
+	executablePath = func() (string, error) {
+		return scoopExecutablePath, nil
+	}
+	t.Cleanup(func() { executablePath = orig })
+}
+
+// TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun verifies that on
+// Windows without Scoop or mise we print the install.ps1 one-liner and
+// never auto-run it (a running entire.exe cannot replace itself). The
+// POSIX curl fallback must not appear.
+func TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		wantCmd        string
+	}{
+		{
+			name:           "stable",
+			currentVersion: "1.0.0",
+			wantCmd:        windowsInstallCmd,
+		},
+		{
+			name:           "nightly",
+			currentVersion: "1.0.1-nightly.202604101200.abc1234",
+			wantCmd:        windowsInstallNightlyCmd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newAutoUpdateFixture(t)
+			orig := executablePath
+			executablePath = func() (string, error) {
+				return windowsProgramFilesPath, nil
+			}
+			t.Cleanup(func() { executablePath = orig })
+
+			origGOOS := goos
+			goos = goosWindows
+			t.Cleanup(func() { goos = origGOOS })
+
+			var buf bytes.Buffer
+			action := maybeAutoUpdate(context.Background(), &buf, tt.currentVersion, "v2.0.0")
+
+			if f.installCalls != 0 {
+				t.Errorf("installer was auto-run on Windows + unknown install manager")
+			}
+			if action != autoUpdateActionSkip {
+				t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
+			}
+			out := buf.String()
+			if !strings.Contains(out, "when entire is not running") {
+				t.Errorf("missing Windows manual-run hint: %q", out)
+			}
+			if !strings.Contains(out, "  "+tt.wantCmd) {
+				t.Errorf("manual hint missing command %q: %q", tt.wantCmd, out)
+			}
+			if strings.Contains(out, "curl -fsSL") {
+				t.Errorf("Windows fallback must not show POSIX curl command: %q", out)
+			}
+			if strings.Contains(out, "download the latest release") {
+				t.Errorf("Windows unknown installer must not point at the releases page: %q", out)
+			}
+		})
+	}
+}
+
+func TestMaybeAutoUpdate_WindowsScoopAndUnknownNeverAutoRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(*testing.T)
+		wantCmd string
+	}{
+		{
+			name:    "scoop cli app prints migration command",
+			setup:   useScoopExecutable,
+			wantCmd: `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`,
+		},
+		{
+			name: "unknown prints install.ps1 command",
+			setup: func(t *testing.T) {
+				t.Helper()
+				orig := executablePath
+				executablePath = func() (string, error) {
+					return windowsLocalBinPath, nil
+				}
+				t.Cleanup(func() { executablePath = orig })
+			},
+			wantCmd: windowsInstallCmd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newAutoUpdateFixture(t)
+			tt.setup(t)
+
+			origGOOS := goos
+			goos = goosWindows
+			t.Cleanup(func() { goos = origGOOS })
+
+			var buf bytes.Buffer
+			action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+
+			if f.installCalls != 0 {
+				t.Fatalf("installer must not auto-run on Windows; calls=%d", f.installCalls)
+			}
+			if action != autoUpdateActionSkip {
+				t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
+			}
+			out := buf.String()
+			if !strings.Contains(out, "when entire is not running") {
+				t.Errorf("missing Windows manual-run hint: %q", out)
+			}
+			if !strings.Contains(out, "  "+tt.wantCmd) {
+				t.Errorf("manual hint missing command %q: %q", tt.wantCmd, out)
+			}
+		})
 	}
 }

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -18,32 +18,38 @@ func TestRealRunInstaller_WindowsNotImplemented(t *testing.T) {
 	}
 }
 
-func useScoopExecutable(t *testing.T) {
-	t.Helper()
-	orig := executablePath
-	executablePath = func() (string, error) {
-		return scoopExecutablePath, nil
-	}
-	t.Cleanup(func() { executablePath = orig })
-}
-
-// TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun verifies that on
-// Windows without Scoop or mise we print the install.ps1 one-liner and
-// never auto-run it (a running entire.exe cannot replace itself). The
-// POSIX curl fallback must not appear.
-func TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun(t *testing.T) {
+// TestMaybeAutoUpdate_WindowsNeverAutoRuns verifies that on Windows the update
+// is never auto-run — a running entire.exe cannot replace its own shim — so
+// the command is printed for the user to run once entire has exited. The POSIX
+// curl fallback and the releases page must not appear.
+func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 	tests := []struct {
 		name           string
+		execPath       string
 		currentVersion string
 		wantCmd        string
 	}{
 		{
-			name:           "stable",
+			name:           "scoop cli app prints migration command",
+			execPath:       scoopExecutablePath,
+			currentVersion: "1.0.0",
+			wantCmd:        scoopMigrateCmd,
+		},
+		{
+			name:           "mise prints mise upgrade",
+			execPath:       miseExecutablePath,
+			currentVersion: "1.0.0",
+			wantCmd:        miseUpgradeCmd,
+		},
+		{
+			name:           "unknown stable prints install.ps1",
+			execPath:       windowsProgramFilesPath,
 			currentVersion: "1.0.0",
 			wantCmd:        windowsInstallCmd,
 		},
 		{
-			name:           "nightly",
+			name:           "unknown nightly prints install.ps1 -Channel nightly",
+			execPath:       windowsLocalBinPath,
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
 			wantCmd:        windowsInstallNightlyCmd,
 		},
@@ -52,91 +58,21 @@ func TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newAutoUpdateFixture(t)
-			orig := executablePath
-			executablePath = func() (string, error) {
-				return windowsProgramFilesPath, nil
-			}
-			t.Cleanup(func() { executablePath = orig })
-
-			origGOOS := goos
-			goos = goosWindows
-			t.Cleanup(func() { goos = origGOOS })
+			setExecutablePath(t, tt.execPath)
 
 			var buf bytes.Buffer
 			action := maybeAutoUpdate(context.Background(), &buf, tt.currentVersion, "v2.0.0")
 
-			if f.installCalls != 0 {
-				t.Errorf("installer was auto-run on Windows + unknown install manager")
-			}
-			if action != autoUpdateActionSkip {
-				t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
-			}
 			out := buf.String()
+			assertPrintOnly(t, f, action, out, tt.wantCmd)
 			if !strings.Contains(out, "when entire is not running") {
 				t.Errorf("missing Windows manual-run hint: %q", out)
-			}
-			if !strings.Contains(out, "  "+tt.wantCmd) {
-				t.Errorf("manual hint missing command %q: %q", tt.wantCmd, out)
 			}
 			if strings.Contains(out, "curl -fsSL") {
-				t.Errorf("Windows fallback must not show POSIX curl command: %q", out)
+				t.Errorf("Windows must not show the POSIX curl command: %q", out)
 			}
 			if strings.Contains(out, "download the latest release") {
-				t.Errorf("Windows unknown installer must not point at the releases page: %q", out)
-			}
-		})
-	}
-}
-
-func TestMaybeAutoUpdate_WindowsScoopAndUnknownNeverAutoRun(t *testing.T) {
-	tests := []struct {
-		name    string
-		setup   func(*testing.T)
-		wantCmd string
-	}{
-		{
-			name:    "scoop cli app prints migration command",
-			setup:   useScoopExecutable,
-			wantCmd: `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`,
-		},
-		{
-			name: "unknown prints install.ps1 command",
-			setup: func(t *testing.T) {
-				t.Helper()
-				orig := executablePath
-				executablePath = func() (string, error) {
-					return windowsLocalBinPath, nil
-				}
-				t.Cleanup(func() { executablePath = orig })
-			},
-			wantCmd: windowsInstallCmd,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := newAutoUpdateFixture(t)
-			tt.setup(t)
-
-			origGOOS := goos
-			goos = goosWindows
-			t.Cleanup(func() { goos = origGOOS })
-
-			var buf bytes.Buffer
-			action := maybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
-
-			if f.installCalls != 0 {
-				t.Fatalf("installer must not auto-run on Windows; calls=%d", f.installCalls)
-			}
-			if action != autoUpdateActionSkip {
-				t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
-			}
-			out := buf.String()
-			if !strings.Contains(out, "when entire is not running") {
-				t.Errorf("missing Windows manual-run hint: %q", out)
-			}
-			if !strings.Contains(out, "  "+tt.wantCmd) {
-				t.Errorf("manual hint missing command %q: %q", tt.wantCmd, out)
+				t.Errorf("Windows must not point at the releases page: %q", out)
 			}
 		})
 	}

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -37,7 +37,7 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 		},
 		{
 			name:           "mise prints mise upgrade",
-			execPath:       miseExecutablePath,
+			execPath:       windowsMiseExecutablePath,
 			currentVersion: "1.0.0",
 			wantCmd:        miseUpgradeCmd,
 		},

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -45,13 +45,13 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 			name:           "unknown stable prints install.ps1",
 			execPath:       windowsProgramFilesPath,
 			currentVersion: "1.0.0",
-			wantCmd:        windowsInstallCmd,
+			wantCmd:        windowsInstallCmd + ` -InstallDir "C:\Program Files\Entire"`,
 		},
 		{
 			name:           "unknown nightly prints install.ps1 -Channel nightly",
 			execPath:       windowsLocalBinPath,
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
-			wantCmd:        windowsInstallNightlyCmd,
+			wantCmd:        windowsInstallCmd + ` -Channel nightly -InstallDir "C:\Users\test\.local\bin"`,
 		},
 	}
 

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -58,7 +58,7 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newAutoUpdateFixture(t)
-			isolateWindowsScoopConfig(t)
+			isolateWindowsInstallEnv(t)
 			setExecutablePath(t, tt.execPath)
 
 			var buf bytes.Buffer

--- a/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_windows_test.go
@@ -58,6 +58,7 @@ func TestMaybeAutoUpdate_WindowsNeverAutoRuns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newAutoUpdateFixture(t)
+			isolateWindowsScoopConfig(t)
 			setExecutablePath(t, tt.execPath)
 
 			var buf bytes.Buffer

--- a/cmd/entire/cli/versioncheck/fixture_test.go
+++ b/cmd/entire/cli/versioncheck/fixture_test.go
@@ -1,0 +1,81 @@
+package versioncheck
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+// autoUpdateFixture wires the test seams for maybeAutoUpdate.
+type autoUpdateFixture struct {
+	installCalls int
+	installErr   error
+	lastCommand  string
+	chooseValue  AutoUpdateAction
+	chooseErr    error
+	lastCmdStr   string
+}
+
+func newAutoUpdateFixture(t *testing.T) *autoUpdateFixture {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(envKillSwitch, "")
+	// Force interactive mode on by default; individual tests can opt out.
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+
+	f := &autoUpdateFixture{chooseValue: autoUpdateActionUpdate}
+
+	origRun := runInstaller
+	runInstaller = func(_ context.Context, cmd string) error {
+		f.installCalls++
+		f.lastCommand = cmd
+		return f.installErr
+	}
+	origChoose := chooseUpdate
+	chooseUpdate = func(_ context.Context, _, _, cmdStr string) (AutoUpdateAction, error) {
+		f.lastCmdStr = cmdStr
+		return f.chooseValue, f.chooseErr
+	}
+	origIsTerminalOut := isTerminalOut
+	isTerminalOut = func(_ io.Writer) bool { return true }
+
+	t.Cleanup(func() {
+		runInstaller = origRun
+		chooseUpdate = origChoose
+		isTerminalOut = origIsTerminalOut
+	})
+	return f
+}
+
+// setExecutable overrides the executable-path seam for the test's lifetime.
+func setExecutable(t *testing.T, fn func() (string, error)) {
+	t.Helper()
+	orig := executablePath
+	executablePath = fn
+	t.Cleanup(func() { executablePath = orig })
+}
+
+// setExecutablePath points the install-manager detector at path.
+func setExecutablePath(t *testing.T, path string) {
+	t.Helper()
+	setExecutable(t, func() (string, error) { return path, nil })
+}
+
+// assertPrintOnly checks that maybeAutoUpdate did not run the installer and
+// instead printed the "To update, run" hint carrying wantCmd.
+func assertPrintOnly(t *testing.T, f *autoUpdateFixture, action AutoUpdateAction, out, wantCmd string) {
+	t.Helper()
+	if f.installCalls != 0 {
+		t.Errorf("installer called %d times, want 0", f.installCalls)
+	}
+	if action != autoUpdateActionSkip {
+		t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
+	}
+	if !strings.Contains(out, "To update, run") {
+		t.Errorf("missing manual-update hint: %q", out)
+	}
+	if !strings.Contains(out, "  "+wantCmd) {
+		t.Errorf("manual hint missing installer command %q: %q", wantCmd, out)
+	}
+}

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -355,12 +355,11 @@ const downloadsURL = "https://github.com/entireio/cli/releases"
 
 // installProbe identifies one install manager from the running binary's path
 // and returns the command that upgrades it. roots are env/config install
-// prefixes (relocated dirs, optional); markers cover default layouts. command
-// receives the exec path relative to the matched root or marker.
+// prefixes (relocated dirs, optional); markers cover default layouts.
 type installProbe struct {
 	roots   func() []string
 	markers []string
-	command func(rest, currentVersion string) string
+	command func(execPath, currentVersion string) string
 }
 
 func miseRoots() []string {
@@ -387,23 +386,20 @@ func normalizeInstallRoot(root string) string {
 	return n
 }
 
-// locate reports whether execPath is under one of the probe's roots or
-// markers and returns the remainder of the path after the match.
-func (p installProbe) locate(execPath string) (string, bool) {
+func (p installProbe) matches(execPath string) bool {
 	if p.roots != nil {
 		for _, raw := range p.roots() {
-			root := normalizeInstallRoot(raw)
-			if root != "" && strings.HasPrefix(execPath, root) {
-				return execPath[len(root):], true
+			if root := normalizeInstallRoot(raw); root != "" && strings.HasPrefix(execPath, root) {
+				return true
 			}
 		}
 	}
-	for _, m := range p.markers {
-		if i := strings.Index(execPath, m); i >= 0 {
-			return execPath[i+len(m):], true
+	for _, marker := range p.markers {
+		if strings.Contains(execPath, marker) {
+			return true
 		}
 	}
-	return "", false
+	return false
 }
 
 const miseUpgradeCmd = "mise upgrade entire"
@@ -426,8 +422,8 @@ func UpdateCommandForCurrentBinary(currentVersion string) string {
 		return fallbackInstallCommand(currentVersion)
 	}
 	for _, p := range installProbes {
-		if rest, ok := p.locate(path); ok {
-			return p.command(rest, currentVersion)
+		if p.matches(path) {
+			return p.command(path, currentVersion)
 		}
 	}
 	return fallbackInstallCommand(currentVersion)

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -32,7 +32,6 @@ const (
 	installManagerBrew    = "brew"
 	installManagerMise    = "mise"
 	installManagerScoop   = "scoop"
-	installManagerUnknown = "unknown"
 	installChannelStable  = "stable"
 	installChannelNightly = "nightly"
 )
@@ -367,114 +366,53 @@ func normalizedExecPath() (string, error) {
 	return strings.ReplaceAll(filepath.ToSlash(realPath), "\\", "/"), nil
 }
 
-// scoopAppName returns the Scoop app directory the running binary lives under
-// — the path segment after `/scoop/apps/` (e.g. "cli" or "entire") — or ""
-// when the binary is not a Scoop install. This is the durable signal for the
-// pre-rename package: a binary running from the `cli` app dir must migrate to
-// `entire` regardless of its version (the fix ships in a final `cli` release,
-// so the migrating binary's version is already past the rename).
-func scoopAppName() string {
-	normalized, err := normalizedExecPath()
-	if err != nil {
-		return ""
-	}
-	_, rest, ok := strings.Cut(normalized, "/scoop/apps/")
-	if !ok {
-		return ""
-	}
-	// Cut returns the whole string when the separator is absent, so this covers
-	// both `.../scoop/apps/cli/current/entire.exe` and a bare app segment.
-	app, _, _ := strings.Cut(rest, "/")
-	return app
-}
-
-func installManagerForCurrentBinary() string {
-	normalizedPath, err := normalizedExecPath()
-	if err != nil {
-		return installManagerUnknown
-	}
-
-	switch {
-	case strings.Contains(normalizedPath, "/Cellar/") ||
-		strings.Contains(normalizedPath, "/opt/homebrew/") ||
-		strings.Contains(normalizedPath, "/linuxbrew/") ||
-		strings.Contains(normalizedPath, "/Caskroom/"):
-		return installManagerBrew
-	case strings.Contains(normalizedPath, "/mise/installs/"):
-		return installManagerMise
-	case strings.Contains(normalizedPath, "/scoop/apps/"):
-		return installManagerScoop
-	default:
-		return installManagerUnknown
-	}
-}
-
 // downloadsURL is the GitHub releases page, used for release-notes links.
 const downloadsURL = "https://github.com/entireio/cli/releases"
 
-// Windows install.ps1 one-liners from the README. Printed, never auto-run.
-const (
-	windowsInstallCmd        = "irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex"
-	windowsInstallNightlyCmd = "& ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly"
-)
+// installProbe identifies one install manager from the running binary's path
+// and returns the command that upgrades it. roots is unused until relocated
+// install dirs are honored; matches is marker-only.
+type installProbe struct {
+	name    string
+	roots   func() []string
+	markers []string
+	command func(execPath, currentVersion string) string
+}
+
+func noInstallRoots() []string { return nil }
+
+func (p installProbe) matches(execPath string) bool {
+	for _, m := range p.markers {
+		if strings.Contains(execPath, m) {
+			return true
+		}
+	}
+	return false
+}
+
+func miseUpgradeCommand(_, _ string) string {
+	return "mise upgrade entire"
+}
+
+var miseProbe = installProbe{
+	name:    installManagerMise,
+	roots:   noInstallRoots,
+	markers: []string{"/mise/installs/"},
+	command: miseUpgradeCommand,
+}
 
 // UpdateCommandForCurrentBinary returns the shell command that updates this
 // binary, based on how it was installed.
 func UpdateCommandForCurrentBinary(currentVersion string) string {
-	switch installManagerForCurrentBinary() {
-	case installManagerBrew:
-		if releaseChannel(currentVersion) == installChannelNightly {
-			return "brew upgrade --yes entire@nightly"
+	path, err := normalizedExecPath()
+	if err == nil {
+		for _, p := range installProbes {
+			if p.matches(path) {
+				return p.command(path, currentVersion)
+			}
 		}
-		return "brew upgrade --yes entire"
-	case installManagerMise:
-		return "mise upgrade entire"
-	case installManagerScoop:
-		// The Scoop package was renamed from `cli` to `entire`. A binary still
-		// running from the old `cli` app dir can never cross the rename with a
-		// plain `scoop update entire/cli`, so migrate it: install the new
-		// `entire` package, remove the old `cli` package, then reset the shared
-		// shims. Both manifests declare `bin: [git-remote-entire.exe,
-		// entire.exe]`, so the two packages contend for the same shims. Current
-		// Scoop handles that itself: installing `entire` renames the displaced
-		// shim to `entire.shim.cli` (warn_on_overwrite) and uninstalling `cli`
-		// removes only that suffixed copy (rm_shim), leaving the active shims
-		// pointing at `entire`. The reset step is belt-and-braces for older
-		// Scoop versions that overwrote shims without that alt-file dance and
-		// would otherwise take `entire.exe` and the git remote helper with them.
-		//
-		// The Windows updater is print-only, so return a self-contained command
-		// users can paste into either cmd or PowerShell. Explicitly invoking
-		// cmd.exe makes `&&` portable across those shells and ensures uninstall
-		// only runs after install succeeds — a stale bucket or transient failure
-		// therefore never removes the working CLI. (The uninstall→reset link is
-		// weaker: `scoop uninstall` ends in an unconditional `exit 0`, so reset
-		// runs even when the uninstall skipped its work. That is harmless, since
-		// reset is a no-op on the Scoop versions that make it unnecessary.)
-		//
-		// `scoop install` also auto-refreshes the bucket when >3h stale
-		// (is_scoop_outdated), so the new manifest usually lands
-		// without an explicit refresh; a bucket clone older than that check can
-		// still fail with "couldn't find manifest", and the README migration
-		// section names `scoop update` as the retry. Binaries already on the
-		// `entire` app just update in place.
-		if scoopAppName() == "cli" {
-			return `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
-		}
-		return "scoop update entire/entire"
 	}
-
-	if goos == goosWindows {
-		if releaseChannel(currentVersion) == installChannelNightly {
-			return windowsInstallNightlyCmd
-		}
-		return windowsInstallCmd
-	}
-
-	if releaseChannel(currentVersion) == installChannelNightly {
-		return "curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly"
-	}
-	return "curl -fsSL https://entire.io/install.sh | bash"
+	return fallbackInstallCommand(currentVersion)
 }
 
 // printNotification prints the version update notification to the user.

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -90,7 +90,7 @@ func CheckAndNotify(ctx context.Context, w io.Writer, currentVersion string) {
 			return
 		}
 
-		action := MaybeAutoUpdate(ctx, w, currentVersion, latestVersion)
+		action := maybeAutoUpdate(ctx, w, currentVersion, latestVersion)
 		if action == autoUpdateActionSkipUntilNextVersion {
 			cache.SkippedVersion = versionCacheKey(latestVersion)
 			if saveErr := saveCache(cache); saveErr != nil {

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -20,17 +19,6 @@ import (
 	"github.com/entireio/cli/internal/entireclient/userdirs"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
-)
-
-const goosWindows = "windows"
-
-// goos is a test seam for runtime.GOOS so the Windows-specific auto-install
-// gating can be exercised from a non-Windows host.
-var goos = runtime.GOOS
-
-const (
-	installChannelStable  = "stable"
-	installChannelNightly = "nightly"
 )
 
 // CheckAndNotify performs a version check and notifies the user if a newer version is available.
@@ -341,26 +329,25 @@ func releaseNotesURL(version string) string {
 // It's a variable so tests can override it.
 var executablePath = os.Executable
 
-func releaseChannel(version string) string {
-	if isNightly(version) {
-		return installChannelNightly
+// normalizePath returns p with symlinks resolved (best-effort), separators as
+// forward slashes, and case folded where the OS compares paths
+// case-insensitively (foldPathCase). Every install-path comparison in this
+// package is a plain prefix or substring test on this form.
+func normalizePath(p string) string {
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		resolved = p
 	}
-	return installChannelStable
+	return foldPathCase(strings.ReplaceAll(filepath.ToSlash(resolved), "\\", "/"))
 }
 
-// normalizedExecPath returns the running binary's real path with all separators
-// normalized to forward slashes (symlinks resolved, best-effort). Both the
-// install-manager detection and the Scoop app-dir lookup key off this form.
+// normalizedExecPath returns the running binary's path in normalizePath form.
 func normalizedExecPath() (string, error) {
 	execPath, err := executablePath()
 	if err != nil {
 		return "", err
 	}
-	realPath, err := filepath.EvalSymlinks(execPath)
-	if err != nil {
-		realPath = execPath
-	}
-	return strings.ReplaceAll(filepath.ToSlash(realPath), "\\", "/"), nil
+	return normalizePath(execPath), nil
 }
 
 // downloadsURL is the GitHub releases page, used for release-notes links.
@@ -368,11 +355,12 @@ const downloadsURL = "https://github.com/entireio/cli/releases"
 
 // installProbe identifies one install manager from the running binary's path
 // and returns the command that upgrades it. roots are env/config install
-// prefixes (relocated dirs); markers cover default layouts.
+// prefixes (relocated dirs, optional); markers cover default layouts. command
+// receives the exec path relative to the matched root or marker.
 type installProbe struct {
 	roots   func() []string
 	markers []string
-	command func(execPath, currentVersion string) string
+	command func(rest, currentVersion string) string
 }
 
 func miseRoots() []string {
@@ -385,38 +373,37 @@ func miseRoots() []string {
 	return nil
 }
 
-// normalizeInstallRoot Clean+EvalSymlinks+ToSlash a root and ensures a trailing
-// slash. Relative values are ignored. EvalSymlinks is best-effort so a root
-// that does not exist on disk still matches by cleaned prefix.
+// normalizeInstallRoot returns an absolute root in normalizePath form with a
+// trailing slash, or "" for empty/relative values. A root that does not exist
+// on disk still matches by cleaned prefix.
 func normalizeInstallRoot(root string) string {
 	if root == "" || !filepath.IsAbs(root) {
 		return ""
 	}
-	cleaned := filepath.Clean(root)
-	resolved, err := filepath.EvalSymlinks(cleaned)
-	if err != nil {
-		resolved = cleaned
-	}
-	n := strings.ReplaceAll(filepath.ToSlash(resolved), "\\", "/")
+	n := normalizePath(filepath.Clean(root))
 	if !strings.HasSuffix(n, "/") {
 		n += "/"
 	}
 	return n
 }
 
-func (p installProbe) matches(execPath string) bool {
-	for _, raw := range p.roots() {
-		root := normalizeInstallRoot(raw)
-		if root != "" && hasNormalizedRootPrefix(execPath, root) {
-			return true
+// locate reports whether execPath is under one of the probe's roots or
+// markers and returns the remainder of the path after the match.
+func (p installProbe) locate(execPath string) (string, bool) {
+	if p.roots != nil {
+		for _, raw := range p.roots() {
+			root := normalizeInstallRoot(raw)
+			if root != "" && strings.HasPrefix(execPath, root) {
+				return execPath[len(root):], true
+			}
 		}
 	}
 	for _, m := range p.markers {
-		if strings.Contains(execPath, m) {
-			return true
+		if i := strings.Index(execPath, m); i >= 0 {
+			return execPath[i+len(m):], true
 		}
 	}
-	return false
+	return "", false
 }
 
 const miseUpgradeCmd = "mise upgrade entire"
@@ -435,11 +422,12 @@ var miseProbe = installProbe{
 // binary, based on how it was installed.
 func UpdateCommandForCurrentBinary(currentVersion string) string {
 	path, err := normalizedExecPath()
-	if err == nil {
-		for _, p := range installProbes {
-			if p.matches(path) {
-				return p.command(path, currentVersion)
-			}
+	if err != nil {
+		return fallbackInstallCommand(currentVersion)
+	}
+	for _, p := range installProbes {
+		if rest, ok := p.locate(path); ok {
+			return p.command(rest, currentVersion)
 		}
 	}
 	return fallbackInstallCommand(currentVersion)

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -418,8 +418,9 @@ const (
 	windowsInstallNightlyCmd = "& ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly"
 )
 
-// updateCommand returns the appropriate update instruction based on how the binary was installed.
-func updateCommand(currentVersion string) string {
+// UpdateCommandForCurrentBinary returns the shell command that updates this
+// binary, based on how it was installed.
+func UpdateCommandForCurrentBinary(currentVersion string) string {
 	switch installManagerForCurrentBinary() {
 	case installManagerBrew:
 		if releaseChannel(currentVersion) == installChannelNightly {
@@ -474,10 +475,6 @@ func updateCommand(currentVersion string) string {
 		return "curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly"
 	}
 	return "curl -fsSL https://entire.io/install.sh | bash"
-}
-
-func UpdateCommandForCurrentBinary(currentVersion string) string {
-	return updateCommand(currentVersion)
 }
 
 // printNotification prints the version update notification to the user.

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -29,9 +29,6 @@ const goosWindows = "windows"
 var goos = runtime.GOOS
 
 const (
-	installManagerBrew    = "brew"
-	installManagerMise    = "mise"
-	installManagerScoop   = "scoop"
 	installChannelStable  = "stable"
 	installChannelNightly = "nightly"
 )
@@ -373,13 +370,10 @@ const downloadsURL = "https://github.com/entireio/cli/releases"
 // and returns the command that upgrades it. roots are env/config install
 // prefixes (relocated dirs); markers cover default layouts.
 type installProbe struct {
-	name    string
 	roots   func() []string
 	markers []string
 	command func(execPath, currentVersion string) string
 }
-
-func noInstallRoots() []string { return nil }
 
 func miseRoots() []string {
 	if d := os.Getenv("MISE_INSTALLS_DIR"); d != "" {
@@ -432,7 +426,6 @@ func miseUpgradeCommand(_, _ string) string {
 }
 
 var miseProbe = installProbe{
-	name:    installManagerMise,
 	roots:   miseRoots,
 	markers: []string{"/mise/installs/"},
 	command: miseUpgradeCommand,

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -370,8 +370,8 @@ func normalizedExecPath() (string, error) {
 const downloadsURL = "https://github.com/entireio/cli/releases"
 
 // installProbe identifies one install manager from the running binary's path
-// and returns the command that upgrades it. roots is unused until relocated
-// install dirs are honored; matches is marker-only.
+// and returns the command that upgrades it. roots are env/config install
+// prefixes (relocated dirs); markers cover default layouts.
 type installProbe struct {
 	name    string
 	roots   func() []string
@@ -381,7 +381,42 @@ type installProbe struct {
 
 func noInstallRoots() []string { return nil }
 
+func miseRoots() []string {
+	if d := os.Getenv("MISE_INSTALLS_DIR"); d != "" {
+		return []string{d}
+	}
+	if d := os.Getenv("MISE_DATA_DIR"); d != "" {
+		return []string{filepath.Join(d, "installs")}
+	}
+	return nil
+}
+
+// normalizeInstallRoot Clean+EvalSymlinks+ToSlash a root and ensures a trailing
+// slash. Relative values are ignored. EvalSymlinks is best-effort so a root
+// that does not exist on disk still matches by cleaned prefix.
+func normalizeInstallRoot(root string) string {
+	if root == "" || !filepath.IsAbs(root) {
+		return ""
+	}
+	cleaned := filepath.Clean(root)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		resolved = cleaned
+	}
+	n := strings.ReplaceAll(filepath.ToSlash(resolved), "\\", "/")
+	if !strings.HasSuffix(n, "/") {
+		n += "/"
+	}
+	return n
+}
+
 func (p installProbe) matches(execPath string) bool {
+	for _, raw := range p.roots() {
+		root := normalizeInstallRoot(raw)
+		if root != "" && hasNormalizedRootPrefix(execPath, root) {
+			return true
+		}
+	}
 	for _, m := range p.markers {
 		if strings.Contains(execPath, m) {
 			return true
@@ -390,13 +425,15 @@ func (p installProbe) matches(execPath string) bool {
 	return false
 }
 
+const miseUpgradeCmd = "mise upgrade entire"
+
 func miseUpgradeCommand(_, _ string) string {
-	return "mise upgrade entire"
+	return miseUpgradeCmd
 }
 
 var miseProbe = installProbe{
 	name:    installManagerMise,
-	roots:   noInstallRoots,
+	roots:   miseRoots,
 	markers: []string{"/mise/installs/"},
 	command: miseUpgradeCommand,
 }

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -410,24 +410,22 @@ func installManagerForCurrentBinary() string {
 }
 
 // canAutoInstall reports whether updateCommand(currentVersion) is safe to
-// execute on the current OS. Returns false on Windows when the install
-// manager is unknown, because the POSIX curl-pipe-bash fallback can't run
-// from cmd.exe and there's no Windows-native installer to substitute.
+// print (and, on non-Windows, auto-run) on the current OS. Always true:
+// POSIX unknown falls back to curl | bash, Windows unknown to install.ps1.
+// Windows still never auto-runs; see MaybeAutoUpdate.
 func canAutoInstall() bool {
-	if goos != goosWindows {
-		return true
-	}
-	switch installManagerForCurrentBinary() {
-	case installManagerScoop, installManagerMise:
-		return true
-	default:
-		return false
-	}
+	return true
 }
 
 // downloadsURL is the public page users visit when we can't offer an
 // auto-installable command on their platform.
 const downloadsURL = "https://github.com/entireio/cli/releases"
+
+// Windows install.ps1 one-liners from the README. Printed, never auto-run.
+const (
+	windowsInstallCmd        = "irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex"
+	windowsInstallNightlyCmd = "& ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly"
+)
 
 // updateCommand returns the appropriate update instruction based on how the binary was installed.
 func updateCommand(currentVersion string) string {
@@ -472,6 +470,13 @@ func updateCommand(currentVersion string) string {
 			return `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
 		}
 		return "scoop update entire/entire"
+	}
+
+	if goos == goosWindows {
+		if releaseChannel(currentVersion) == installChannelNightly {
+			return windowsInstallNightlyCmd
+		}
+		return windowsInstallCmd
 	}
 
 	if releaseChannel(currentVersion) == installChannelNightly {

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -341,15 +341,6 @@ func normalizePath(p string) string {
 	return foldPathCase(strings.ReplaceAll(filepath.ToSlash(resolved), "\\", "/"))
 }
 
-// normalizedExecPath returns the running binary's path in normalizePath form.
-func normalizedExecPath() (string, error) {
-	execPath, err := executablePath()
-	if err != nil {
-		return "", err
-	}
-	return normalizePath(execPath), nil
-}
-
 // downloadsURL is the GitHub releases page, used for release-notes links.
 const downloadsURL = "https://github.com/entireio/cli/releases"
 
@@ -416,17 +407,21 @@ var miseProbe = installProbe{
 
 // UpdateCommandForCurrentBinary returns the shell command that updates this
 // binary, based on how it was installed.
+//
+// The fallback receives the exec path as the OS reports it (not normalized),
+// so the Windows installer hint can name the directory the binary lives in.
 func UpdateCommandForCurrentBinary(currentVersion string) string {
-	path, err := normalizedExecPath()
+	execPath, err := executablePath()
 	if err != nil {
-		return fallbackInstallCommand(currentVersion)
+		return fallbackInstallCommand("", currentVersion)
 	}
+	normalized := normalizePath(execPath)
 	for _, p := range installProbes {
-		if p.matches(path) {
-			return p.command(path, currentVersion)
+		if p.matches(normalized) {
+			return p.command(normalized, currentVersion)
 		}
 	}
-	return fallbackInstallCommand(currentVersion)
+	return fallbackInstallCommand(execPath, currentVersion)
 }
 
 // printNotification prints the version update notification to the user.

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -409,16 +409,7 @@ func installManagerForCurrentBinary() string {
 	}
 }
 
-// canAutoInstall reports whether updateCommand(currentVersion) is safe to
-// print (and, on non-Windows, auto-run) on the current OS. Always true:
-// POSIX unknown falls back to curl | bash, Windows unknown to install.ps1.
-// Windows still never auto-runs; see MaybeAutoUpdate.
-func canAutoInstall() bool {
-	return true
-}
-
-// downloadsURL is the public page users visit when we can't offer an
-// auto-installable command on their platform.
+// downloadsURL is the GitHub releases page, used for release-notes links.
 const downloadsURL = "https://github.com/entireio/cli/releases"
 
 // Windows install.ps1 one-liners from the README. Printed, never auto-run.
@@ -486,9 +477,6 @@ func updateCommand(currentVersion string) string {
 }
 
 func UpdateCommandForCurrentBinary(currentVersion string) string {
-	if !canAutoInstall() {
-		return downloadsURL
-	}
 	return updateCommand(currentVersion)
 }
 

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -424,6 +424,13 @@ func UpdateCommandForCurrentBinary(currentVersion string) string {
 	return fallbackInstallCommand(execPath, currentVersion)
 }
 
+// UpdateCommandShell names the shell UpdateCommandForCurrentBinary's command
+// has to run in, or "" when any shell will do. Callers that print the command
+// instead of running it need it: the Windows commands are PowerShell
+// one-liners, and pasting one into cmd.exe or bash either fails or, in bash's
+// case, expands part of the command before PowerShell sees it.
+func UpdateCommandShell() string { return updateCommandShell }
+
 // printNotification prints the version update notification to the user.
 func printNotification(w io.Writer, current, latest string) {
 	fmt.Fprintf(w, "\nUpdate available! %s -> %s\nRelease notes: %s\n",

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -362,7 +362,7 @@ const windowsProgramFilesPath = `C:\Program Files\Entire\entire.exe`
 
 // TestScoopAppName pins the signal the rename migration keys off. The ""
 // results matter most: they are what keeps the `== "cli"` comparison in
-// updateCommand from misfiring on a non-Scoop binary that happens to live in a
+// UpdateCommandForCurrentBinary from misfiring on a non-Scoop binary that happens to live in a
 // directory named `cli`.
 func TestScoopAppName(t *testing.T) {
 	tests := []struct {
@@ -410,7 +410,7 @@ func TestScoopAppName(t *testing.T) {
 	}
 }
 
-func TestUpdateCommand(t *testing.T) {
+func TestUpdateCommandForCurrentBinary(t *testing.T) {
 	tests := []struct {
 		name           string
 		currentVersion string
@@ -508,61 +508,6 @@ func TestUpdateCommand(t *testing.T) {
 				goos = tt.goos
 				t.Cleanup(func() { goos = origGOOS })
 			}
-
-			if got := updateCommand(tt.currentVersion); got != tt.want {
-				t.Errorf("updateCommand() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestUpdateCommandForCurrentBinary(t *testing.T) {
-	tests := []struct {
-		name           string
-		currentVersion string
-		goos           string
-		execPath       func() (string, error)
-		want           string
-	}{
-		{
-			name:           "known installer returns command",
-			currentVersion: "1.2.3",
-			goos:           goosWindows,
-			execPath:       func() (string, error) { return scoopEntireExecutablePath, nil },
-			want:           "scoop update entire/entire",
-		},
-		{
-			name:           "windows unknown installer returns install.ps1 command",
-			currentVersion: "1.2.3",
-			goos:           goosWindows,
-			execPath:       func() (string, error) { return windowsProgramFilesPath, nil },
-			want:           windowsInstallCmd,
-		},
-		{
-			name:           "windows unknown nightly installer returns install.ps1 -Channel nightly",
-			currentVersion: "1.0.1-nightly.202604101200.abc1234",
-			goos:           goosWindows,
-			execPath:       func() (string, error) { return windowsProgramFilesPath, nil },
-			want:           windowsInstallNightlyCmd,
-		},
-		{
-			name:           "non-windows unknown installer returns curl command",
-			currentVersion: "1.2.3",
-			goos:           "linux",
-			execPath:       func() (string, error) { return plainBinPath, nil },
-			want:           "curl -fsSL https://entire.io/install.sh | bash",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			originalExecPath := executablePath
-			executablePath = tt.execPath
-			t.Cleanup(func() { executablePath = originalExecPath })
-
-			originalGOOS := goos
-			goos = tt.goos
-			t.Cleanup(func() { goos = originalGOOS })
 
 			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {
 				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -347,38 +347,11 @@ func TestParseGitHubRelease(t *testing.T) {
 // it without tripping goconst on repeated string literals.
 const brewUpgradeCmd = "brew upgrade --yes entire"
 
-// plainBinPath is a POSIX install under no recognized install manager.
-const plainBinPath = "/usr/local/bin/entire"
+// brewCaskPath is a brew-installed binary; tests that do not care about the
+// install manager use it.
+const brewCaskPath = "/opt/homebrew/Caskroom/entire/1.0.0/entire"
 
 const miseExecutablePath = "/home/user/.local/share/mise/installs/entire/1.0.0/bin/entire"
-
-func TestUpdateCommandForCurrentBinary(t *testing.T) {
-	tests := []struct {
-		name           string
-		currentVersion string
-		execPath       func() (string, error)
-		want           string
-	}{
-		{
-			name:           "mise path",
-			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return miseExecutablePath, nil },
-			want:           miseUpgradeCmd,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			original := executablePath
-			executablePath = tt.execPath
-			t.Cleanup(func() { executablePath = original })
-
-			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {
-				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
 
 func relocatedTestRoot(elem string) string {
 	if runtime.GOOS == "windows" {
@@ -387,47 +360,43 @@ func relocatedTestRoot(elem string) string {
 	return "/" + elem
 }
 
-func TestUpdateCommandForCurrentBinary_MiseRelocatedInstallsDir(t *testing.T) {
-	root := relocatedTestRoot("srv/tools")
-	t.Setenv("MISE_INSTALLS_DIR", root)
-	t.Setenv("MISE_DATA_DIR", "")
-	orig := executablePath
-	executablePath = func() (string, error) {
-		return filepath.Join(root, "entire", "1.0.0", "bin", "entire"), nil
+// TestUpdateCommandForCurrentBinary_MiseRoots covers mise detection through
+// the env-relocated roots and the default marker.
+func TestUpdateCommandForCurrentBinary_MiseRoots(t *testing.T) {
+	installsDir := relocatedTestRoot("srv/tools")
+	dataDir := relocatedTestRoot("srv/mise")
+	tests := []struct {
+		name        string
+		installsDir string
+		dataDir     string
+		execPath    string
+	}{
+		{
+			name:        "MISE_INSTALLS_DIR",
+			installsDir: installsDir,
+			execPath:    filepath.Join(installsDir, "entire", "1.0.0", "bin", "entire"),
+		},
+		{
+			name:     "MISE_DATA_DIR",
+			dataDir:  dataDir,
+			execPath: filepath.Join(dataDir, "installs", "entire", "1.0.0", "bin", "entire"),
+		},
+		{
+			name:     "default marker",
+			execPath: miseExecutablePath,
+		},
 	}
-	t.Cleanup(func() { executablePath = orig })
 
-	if got := UpdateCommandForCurrentBinary("1.0.0"); got != miseUpgradeCmd {
-		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, miseUpgradeCmd)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("MISE_INSTALLS_DIR", tt.installsDir)
+			t.Setenv("MISE_DATA_DIR", tt.dataDir)
+			setExecutablePath(t, tt.execPath)
 
-func TestUpdateCommandForCurrentBinary_MiseRelocatedDataDir(t *testing.T) {
-	root := relocatedTestRoot("srv/mise")
-	t.Setenv("MISE_INSTALLS_DIR", "")
-	t.Setenv("MISE_DATA_DIR", root)
-	orig := executablePath
-	executablePath = func() (string, error) {
-		return filepath.Join(root, "installs", "entire", "1.0.0", "bin", "entire"), nil
-	}
-	t.Cleanup(func() { executablePath = orig })
-
-	if got := UpdateCommandForCurrentBinary("1.0.0"); got != miseUpgradeCmd {
-		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, miseUpgradeCmd)
-	}
-}
-
-func TestUpdateCommandForCurrentBinary_MiseDefaultMarkerStillMatches(t *testing.T) {
-	t.Setenv("MISE_INSTALLS_DIR", "")
-	t.Setenv("MISE_DATA_DIR", "")
-	orig := executablePath
-	executablePath = func() (string, error) {
-		return miseExecutablePath, nil
-	}
-	t.Cleanup(func() { executablePath = orig })
-
-	if got := UpdateCommandForCurrentBinary("1.0.0"); got != miseUpgradeCmd {
-		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, miseUpgradeCmd)
+			if got := UpdateCommandForCurrentBinary("1.0.0"); got != miseUpgradeCmd {
+				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, miseUpgradeCmd)
+			}
+		})
 	}
 }
 
@@ -549,7 +518,7 @@ func TestCheckAndNotify_BrewSkipUntilNextVersionCachesLatest(t *testing.T) {
 	server := newVersionServer(t, "v2.0.0")
 	cmd, _ := setupCheckAndNotifyTest(t, server.URL)
 	f := newAutoUpdateFixture(t)
-	useBrewExecutable(t)
+	setExecutablePath(t, brewCaskPath)
 	f.chooseValue = autoUpdateActionSkipUntilNextVersion
 
 	CheckAndNotify(context.Background(), cmd.OutOrStdout(), "1.0.0")
@@ -576,7 +545,7 @@ func TestCheckAndNotify_MiseSkipUntilNextVersionCachesLatest(t *testing.T) {
 	server := newVersionServer(t, "v2.0.0")
 	cmd, _ := setupCheckAndNotifyTest(t, server.URL)
 	f := newAutoUpdateFixture(t)
-	useMiseExecutable(t)
+	setExecutablePath(t, miseExecutablePath)
 	f.chooseValue = autoUpdateActionSkipUntilNextVersion
 
 	CheckAndNotify(context.Background(), cmd.OutOrStdout(), "1.0.0")
@@ -600,7 +569,7 @@ func TestCheckAndNotify_SkipsVersionMarkedSkipped(t *testing.T) {
 	server := newVersionServer(t, "v2.0.0")
 	cmd, buf := setupCheckAndNotifyTest(t, server.URL)
 	f := newAutoUpdateFixture(t)
-	useBrewExecutable(t)
+	setExecutablePath(t, brewCaskPath)
 	seedVersionCache(t, &VersionCache{
 		LastCheckTime:  time.Now().Add(-checkInterval - time.Minute),
 		SkippedVersion: "v2.0.0",
@@ -634,7 +603,7 @@ func TestCheckAndNotify_InstallerFailureKeepsCacheFresh(t *testing.T) {
 	// Simulate an interactive user who accepts the upgrade prompt, and an
 	// installer that fails (e.g. brew upgrade blew up mid-run).
 	t.Setenv("ENTIRE_TEST_TTY", "1")
-	useBrewExecutable(t)
+	setExecutablePath(t, brewCaskPath)
 
 	origChoose := chooseUpdate
 	chooseUpdate = func(_ context.Context, _, _, _ string) (AutoUpdateAction, error) {

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -362,7 +363,7 @@ func TestUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "mise path",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return miseExecutablePath, nil },
-			want:           "mise upgrade entire",
+			want:           miseUpgradeCmd,
 		},
 	}
 
@@ -376,6 +377,57 @@ func TestUpdateCommandForCurrentBinary(t *testing.T) {
 				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func relocatedTestRoot(elem string) string {
+	if runtime.GOOS == "windows" {
+		return `D:\` + elem
+	}
+	return "/" + elem
+}
+
+func TestUpdateCommandForCurrentBinary_MiseRelocatedInstallsDir(t *testing.T) {
+	root := relocatedTestRoot("srv/tools")
+	t.Setenv("MISE_INSTALLS_DIR", root)
+	t.Setenv("MISE_DATA_DIR", "")
+	orig := executablePath
+	executablePath = func() (string, error) {
+		return filepath.Join(root, "entire", "1.0.0", "bin", "entire"), nil
+	}
+	t.Cleanup(func() { executablePath = orig })
+
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != miseUpgradeCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, miseUpgradeCmd)
+	}
+}
+
+func TestUpdateCommandForCurrentBinary_MiseRelocatedDataDir(t *testing.T) {
+	root := relocatedTestRoot("srv/mise")
+	t.Setenv("MISE_INSTALLS_DIR", "")
+	t.Setenv("MISE_DATA_DIR", root)
+	orig := executablePath
+	executablePath = func() (string, error) {
+		return filepath.Join(root, "installs", "entire", "1.0.0", "bin", "entire"), nil
+	}
+	t.Cleanup(func() { executablePath = orig })
+
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != miseUpgradeCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, miseUpgradeCmd)
+	}
+}
+
+func TestUpdateCommandForCurrentBinary_MiseDefaultMarkerStillMatches(t *testing.T) {
+	t.Setenv("MISE_INSTALLS_DIR", "")
+	t.Setenv("MISE_DATA_DIR", "")
+	orig := executablePath
+	executablePath = func() (string, error) {
+		return miseExecutablePath, nil
+	}
+	t.Cleanup(func() { executablePath = orig })
+
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != miseUpgradeCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, miseUpgradeCmd)
 	}
 }
 
@@ -539,8 +591,8 @@ func TestCheckAndNotify_MiseSkipUntilNextVersionCachesLatest(t *testing.T) {
 	if cache.SkippedVersion != "v2.0.0" {
 		t.Errorf("SkippedVersion = %q, want v2.0.0", cache.SkippedVersion)
 	}
-	if f.lastCmdStr != "mise upgrade entire" {
-		t.Errorf("prompt got cmd %q, want mise upgrade entire", f.lastCmdStr)
+	if f.lastCmdStr != miseUpgradeCmd {
+		t.Errorf("prompt got cmd %q, want %q", f.lastCmdStr, miseUpgradeCmd)
 	}
 }
 

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -355,6 +355,11 @@ const scoopEntireExecutablePath = `C:\Users\test\scoop\apps\entire\current\entir
 // plainBinPath is a POSIX install under no recognized install manager.
 const plainBinPath = "/usr/local/bin/entire"
 
+// windowsLocalBinPath is a direct install.ps1 destination. windowsProgramFilesPath
+// is an unknown Windows path that matches none of the install-manager prefixes.
+const windowsLocalBinPath = `C:\Users\test\.local\bin\entire.exe`
+const windowsProgramFilesPath = `C:\Program Files\Entire\entire.exe`
+
 // TestScoopAppName pins the signal the rename migration keys off. The ""
 // results matter most: they are what keeps the `== "cli"` comparison in
 // updateCommand from misfiring on a non-Scoop binary that happens to live in a
@@ -409,6 +414,7 @@ func TestUpdateCommand(t *testing.T) {
 	tests := []struct {
 		name           string
 		currentVersion string
+		goos           string
 		execPath       func() (string, error)
 		want           string
 	}{
@@ -457,20 +463,37 @@ func TestUpdateCommand(t *testing.T) {
 		{
 			name:           "unknown path stable falls back to stable curl command",
 			currentVersion: "1.0.0",
+			goos:           "linux",
 			execPath:       func() (string, error) { return plainBinPath, nil },
 			want:           "curl -fsSL https://entire.io/install.sh | bash",
 		},
 		{
 			name:           "unknown path nightly falls back to nightly curl command",
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
+			goos:           "linux",
 			execPath:       func() (string, error) { return plainBinPath, nil },
 			want:           "curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly",
 		},
 		{
 			name:           "executable error falls back to stable curl command",
 			currentVersion: "1.0.0",
+			goos:           "linux",
 			execPath:       func() (string, error) { return "", errors.New("not found") },
 			want:           "curl -fsSL https://entire.io/install.sh | bash",
+		},
+		{
+			name:           "windows unknown path stable uses install.ps1",
+			currentVersion: "1.0.0",
+			goos:           goosWindows,
+			execPath:       func() (string, error) { return windowsLocalBinPath, nil },
+			want:           windowsInstallCmd,
+		},
+		{
+			name:           "windows unknown path nightly uses install.ps1 -Channel nightly",
+			currentVersion: "1.0.1-nightly.202604101200.abc1234",
+			goos:           goosWindows,
+			execPath:       func() (string, error) { return windowsLocalBinPath, nil },
+			want:           windowsInstallNightlyCmd,
 		},
 	}
 
@@ -479,6 +502,12 @@ func TestUpdateCommand(t *testing.T) {
 			original := executablePath
 			executablePath = tt.execPath
 			t.Cleanup(func() { executablePath = original })
+
+			if tt.goos != "" {
+				origGOOS := goos
+				goos = tt.goos
+				t.Cleanup(func() { goos = origGOOS })
+			}
 
 			if got := updateCommand(tt.currentVersion); got != tt.want {
 				t.Errorf("updateCommand() = %q, want %q", got, tt.want)
@@ -503,11 +532,18 @@ func TestUpdateCommandForCurrentBinary(t *testing.T) {
 			want:           "scoop update entire/entire",
 		},
 		{
-			name:           "windows unknown installer returns releases URL",
+			name:           "windows unknown installer returns install.ps1 command",
 			currentVersion: "1.2.3",
 			goos:           goosWindows,
-			execPath:       func() (string, error) { return `C:\Program Files\Entire\entire.exe`, nil },
-			want:           downloadsURL,
+			execPath:       func() (string, error) { return windowsProgramFilesPath, nil },
+			want:           windowsInstallCmd,
+		},
+		{
+			name:           "windows unknown nightly installer returns install.ps1 -Channel nightly",
+			currentVersion: "1.0.1-nightly.202604101200.abc1234",
+			goos:           goosWindows,
+			execPath:       func() (string, error) { return windowsProgramFilesPath, nil },
+			want:           windowsInstallNightlyCmd,
 		},
 		{
 			name:           "non-windows unknown installer returns curl command",

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -346,154 +346,23 @@ func TestParseGitHubRelease(t *testing.T) {
 // it without tripping goconst on repeated string literals.
 const brewUpgradeCmd = "brew upgrade --yes entire"
 
-// scoopExecutablePath is the pre-rename `cli` app dir; scoopEntireExecutablePath
-// is the renamed `entire` app dir. The Scoop update command is chosen by which
-// app dir the binary runs from, not by version.
-const scoopExecutablePath = `C:\Users\test\scoop\apps\cli\current\entire.exe`
-const scoopEntireExecutablePath = `C:\Users\test\scoop\apps\entire\current\entire.exe`
-
 // plainBinPath is a POSIX install under no recognized install manager.
 const plainBinPath = "/usr/local/bin/entire"
 
-// windowsLocalBinPath is a direct install.ps1 destination. windowsProgramFilesPath
-// is an unknown Windows path that matches none of the install-manager prefixes.
-const windowsLocalBinPath = `C:\Users\test\.local\bin\entire.exe`
-const windowsProgramFilesPath = `C:\Program Files\Entire\entire.exe`
-
-// TestScoopAppName pins the signal the rename migration keys off. The ""
-// results matter most: they are what keeps the `== "cli"` comparison in
-// UpdateCommandForCurrentBinary from misfiring on a non-Scoop binary that happens to live in a
-// directory named `cli`.
-func TestScoopAppName(t *testing.T) {
-	tests := []struct {
-		name     string
-		execPath func() (string, error)
-		want     string
-	}{
-		{
-			name:     "pre-rename cli app dir",
-			execPath: func() (string, error) { return scoopExecutablePath, nil },
-			want:     "cli",
-		},
-		{
-			name:     "renamed entire app dir",
-			execPath: func() (string, error) { return scoopEntireExecutablePath, nil },
-			want:     "entire",
-		},
-		{
-			name:     "non-scoop path in a cli directory",
-			execPath: func() (string, error) { return `C:\tools\cli\entire.exe`, nil },
-			want:     "",
-		},
-		{
-			name:     "posix install",
-			execPath: func() (string, error) { return plainBinPath, nil },
-			want:     "",
-		},
-		{
-			name:     "executable path unavailable",
-			execPath: func() (string, error) { return "", errors.New("not found") },
-			want:     "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			original := executablePath
-			executablePath = tt.execPath
-			t.Cleanup(func() { executablePath = original })
-
-			if got := scoopAppName(); got != tt.want {
-				t.Errorf("scoopAppName() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
+const miseExecutablePath = "/home/user/.local/share/mise/installs/entire/1.0.0/bin/entire"
 
 func TestUpdateCommandForCurrentBinary(t *testing.T) {
 	tests := []struct {
 		name           string
 		currentVersion string
-		goos           string
 		execPath       func() (string, error)
 		want           string
 	}{
 		{
-			name:           "homebrew stable cellar path uses brew command",
-			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return "/opt/homebrew/Cellar/entire/1.0.0/bin/entire", nil },
-			want:           brewUpgradeCmd,
-		},
-		{
-			name:           "homebrew stable cask path uses brew command",
-			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return "/opt/homebrew/bin/entire", nil },
-			want:           brewUpgradeCmd,
-		},
-		{
-			name:           "homebrew nightly path uses brew command",
-			currentVersion: "1.0.1-nightly.202604101200.abc1234",
-			execPath:       func() (string, error) { return "/opt/homebrew/bin/entire", nil },
-			want:           "brew upgrade --yes entire@nightly",
-		},
-		{
-			name:           "linuxbrew path",
-			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return "/home/linuxbrew/.linuxbrew/bin/entire", nil },
-			want:           brewUpgradeCmd,
-		},
-		{
 			name:           "mise path",
 			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return "/home/user/.local/share/mise/installs/entire/1.0.0/bin/entire", nil },
+			execPath:       func() (string, error) { return miseExecutablePath, nil },
 			want:           "mise upgrade entire",
-		},
-		{
-			name:           "scoop entire app updates in place",
-			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return scoopEntireExecutablePath, nil },
-			want:           "scoop update entire/entire",
-		},
-		{
-			name:           "scoop cli app routes through package rename regardless of version",
-			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return scoopExecutablePath, nil },
-			want:           `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`,
-		},
-		{
-			name:           "unknown path stable falls back to stable curl command",
-			currentVersion: "1.0.0",
-			goos:           "linux",
-			execPath:       func() (string, error) { return plainBinPath, nil },
-			want:           "curl -fsSL https://entire.io/install.sh | bash",
-		},
-		{
-			name:           "unknown path nightly falls back to nightly curl command",
-			currentVersion: "1.0.1-nightly.202604101200.abc1234",
-			goos:           "linux",
-			execPath:       func() (string, error) { return plainBinPath, nil },
-			want:           "curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly",
-		},
-		{
-			name:           "executable error falls back to stable curl command",
-			currentVersion: "1.0.0",
-			goos:           "linux",
-			execPath:       func() (string, error) { return "", errors.New("not found") },
-			want:           "curl -fsSL https://entire.io/install.sh | bash",
-		},
-		{
-			name:           "windows unknown path stable uses install.ps1",
-			currentVersion: "1.0.0",
-			goos:           goosWindows,
-			execPath:       func() (string, error) { return windowsLocalBinPath, nil },
-			want:           windowsInstallCmd,
-		},
-		{
-			name:           "windows unknown path nightly uses install.ps1 -Channel nightly",
-			currentVersion: "1.0.1-nightly.202604101200.abc1234",
-			goos:           goosWindows,
-			execPath:       func() (string, error) { return windowsLocalBinPath, nil },
-			want:           windowsInstallNightlyCmd,
 		},
 	}
 
@@ -502,12 +371,6 @@ func TestUpdateCommandForCurrentBinary(t *testing.T) {
 			original := executablePath
 			executablePath = tt.execPath
 			t.Cleanup(func() { executablePath = original })
-
-			if tt.goos != "" {
-				origGOOS := goos
-				goos = tt.goos
-				t.Cleanup(func() { goos = origGOOS })
-			}
 
 			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {
 				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)

--- a/cmd/entire/cli/versioncheck/versioncheck_unix.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix.go
@@ -2,6 +2,12 @@
 
 package versioncheck
 
+import "strings"
+
+func hasNormalizedRootPrefix(path, root string) bool {
+	return strings.HasPrefix(path, root)
+}
+
 func brewUpgradeCommand(_ string, currentVersion string) string {
 	if releaseChannel(currentVersion) == installChannelNightly {
 		return "brew upgrade --yes entire@nightly"

--- a/cmd/entire/cli/versioncheck/versioncheck_unix.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix.go
@@ -24,7 +24,7 @@ var brewProbe = installProbe{
 
 var installProbes = []installProbe{brewProbe, miseProbe}
 
-func fallbackInstallCommand(currentVersion string) string {
+func fallbackInstallCommand(_, currentVersion string) string {
 	if isNightly(currentVersion) {
 		return "curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly"
 	}

--- a/cmd/entire/cli/versioncheck/versioncheck_unix.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix.go
@@ -1,0 +1,31 @@
+//go:build unix
+
+package versioncheck
+
+func brewUpgradeCommand(_ string, currentVersion string) string {
+	if releaseChannel(currentVersion) == installChannelNightly {
+		return "brew upgrade --yes entire@nightly"
+	}
+	return "brew upgrade --yes entire"
+}
+
+var brewProbe = installProbe{
+	name:  installManagerBrew,
+	roots: noInstallRoots,
+	markers: []string{
+		"/Caskroom/",
+		"/opt/homebrew/",
+		"/linuxbrew/",
+		"/Cellar/", // defensive: entire ships as a cask, not a formula
+	},
+	command: brewUpgradeCommand,
+}
+
+var installProbes = []installProbe{brewProbe, miseProbe}
+
+func fallbackInstallCommand(currentVersion string) string {
+	if releaseChannel(currentVersion) == installChannelNightly {
+		return "curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly"
+	}
+	return "curl -fsSL https://entire.io/install.sh | bash"
+}

--- a/cmd/entire/cli/versioncheck/versioncheck_unix.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix.go
@@ -2,23 +2,17 @@
 
 package versioncheck
 
-import "strings"
-
-func hasNormalizedRootPrefix(path, root string) bool {
-	return strings.HasPrefix(path, root)
-}
+// foldPathCase is the identity on unix: paths compare case-sensitively.
+func foldPathCase(p string) string { return p }
 
 func brewUpgradeCommand(_ string, currentVersion string) string {
-	if releaseChannel(currentVersion) == installChannelNightly {
+	if isNightly(currentVersion) {
 		return "brew upgrade --yes entire@nightly"
 	}
 	return "brew upgrade --yes entire"
 }
 
-func noInstallRoots() []string { return nil }
-
 var brewProbe = installProbe{
-	roots: noInstallRoots,
 	markers: []string{
 		"/Caskroom/",
 		"/opt/homebrew/",
@@ -31,7 +25,7 @@ var brewProbe = installProbe{
 var installProbes = []installProbe{brewProbe, miseProbe}
 
 func fallbackInstallCommand(currentVersion string) string {
-	if releaseChannel(currentVersion) == installChannelNightly {
+	if isNightly(currentVersion) {
 		return "curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly"
 	}
 	return "curl -fsSL https://entire.io/install.sh | bash"

--- a/cmd/entire/cli/versioncheck/versioncheck_unix.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix.go
@@ -15,8 +15,9 @@ func brewUpgradeCommand(_ string, currentVersion string) string {
 	return "brew upgrade --yes entire"
 }
 
+func noInstallRoots() []string { return nil }
+
 var brewProbe = installProbe{
-	name:  installManagerBrew,
 	roots: noInstallRoots,
 	markers: []string{
 		"/Caskroom/",

--- a/cmd/entire/cli/versioncheck/versioncheck_unix.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix.go
@@ -5,6 +5,10 @@ package versioncheck
 // foldPathCase is the identity on unix: paths compare case-sensitively.
 func foldPathCase(p string) string { return p }
 
+// updateCommandShell is empty on unix: brew, mise, and the curl|bash one-liner
+// all run in any POSIX shell, so no message has to name one.
+const updateCommandShell = ""
+
 func brewUpgradeCommand(_ string, currentVersion string) string {
 	if isNightly(currentVersion) {
 		return "brew upgrade --yes entire@nightly"

--- a/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
@@ -1,0 +1,96 @@
+//go:build unix
+
+package versioncheck
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestUpdateCommandForCurrentBinary_Unix(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		execPath       func() (string, error)
+		want           string
+	}{
+		{
+			name:           "homebrew stable caskroom path uses brew command",
+			currentVersion: "1.0.0",
+			execPath:       func() (string, error) { return "/opt/homebrew/Caskroom/entire/1.0.0/entire", nil },
+			want:           brewUpgradeCmd,
+		},
+		{
+			name:           "homebrew stable prefix bin path uses brew command",
+			currentVersion: "1.0.0",
+			execPath:       func() (string, error) { return "/opt/homebrew/bin/entire", nil },
+			want:           brewUpgradeCmd,
+		},
+		{
+			name:           "homebrew nightly path uses brew command",
+			currentVersion: "1.0.1-nightly.202604101200.abc1234",
+			execPath:       func() (string, error) { return "/opt/homebrew/bin/entire", nil },
+			want:           "brew upgrade --yes entire@nightly",
+		},
+		{
+			name:           "linuxbrew path",
+			currentVersion: "1.0.0",
+			execPath:       func() (string, error) { return "/home/linuxbrew/.linuxbrew/bin/entire", nil },
+			want:           brewUpgradeCmd,
+		},
+		{
+			name:           "unknown path stable falls back to stable curl command",
+			currentVersion: "1.0.0",
+			execPath:       func() (string, error) { return plainBinPath, nil },
+			want:           "curl -fsSL https://entire.io/install.sh | bash",
+		},
+		{
+			name:           "unknown path nightly falls back to nightly curl command",
+			currentVersion: "1.0.1-nightly.202604101200.abc1234",
+			execPath:       func() (string, error) { return plainBinPath, nil },
+			want:           "curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly",
+		},
+		{
+			name:           "executable error falls back to stable curl command",
+			currentVersion: "1.0.0",
+			execPath:       func() (string, error) { return "", errors.New("not found") },
+			want:           "curl -fsSL https://entire.io/install.sh | bash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := executablePath
+			executablePath = tt.execPath
+			t.Cleanup(func() { executablePath = original })
+
+			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {
+				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnixCommandsNeverNameWindowsInstallers(t *testing.T) {
+	t.Parallel()
+	versions := []string{"1.0.0", "1.0.1-nightly.202604101200.abc1234"}
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			t.Parallel()
+			for _, p := range installProbes {
+				assertNoWindowsInstallerNames(t, p.command("/x", version))
+			}
+			assertNoWindowsInstallerNames(t, fallbackInstallCommand(version))
+		})
+	}
+}
+
+func assertNoWindowsInstallerNames(t *testing.T, cmd string) {
+	t.Helper()
+	for _, needle := range []string{"scoop", "irm", "install.ps1"} {
+		if strings.Contains(cmd, needle) {
+			t.Errorf("unix command %q contains %q", cmd, needle)
+		}
+	}
+}

--- a/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
@@ -84,7 +84,7 @@ func TestUnixCommandsNeverNameWindowsInstallers(t *testing.T) {
 			for _, p := range installProbes {
 				assertNoWindowsInstallerNames(t, p.command("/x", version))
 			}
-			assertNoWindowsInstallerNames(t, fallbackInstallCommand(version))
+			assertNoWindowsInstallerNames(t, fallbackInstallCommand("/x/entire", version))
 		})
 	}
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
@@ -4,6 +4,8 @@ package versioncheck
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -83,6 +85,34 @@ func TestUnixCommandsNeverNameWindowsInstallers(t *testing.T) {
 			}
 			assertNoWindowsInstallerNames(t, fallbackInstallCommand(version))
 		})
+	}
+}
+
+func TestUnixMiseRootSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "real")
+	link := filepath.Join(tmp, "link")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MISE_INSTALLS_DIR", link)
+	t.Setenv("MISE_DATA_DIR", "")
+	execPath := filepath.Join(realDir, "entire", "1.0.0", "bin", "entire")
+	if err := os.MkdirAll(filepath.Dir(execPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(execPath, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := executablePath
+	executablePath = func() (string, error) { return execPath, nil }
+	t.Cleanup(func() { executablePath = orig })
+
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != miseUpgradeCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, miseUpgradeCmd)
 	}
 }
 

--- a/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 )
 
+// plainBinPath is a POSIX install under no recognized install manager.
+const plainBinPath = "/usr/local/bin/entire"
+
 func TestUpdateCommandForCurrentBinary_Unix(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -63,9 +66,7 @@ func TestUpdateCommandForCurrentBinary_Unix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			original := executablePath
-			executablePath = tt.execPath
-			t.Cleanup(func() { executablePath = original })
+			setExecutable(t, tt.execPath)
 
 			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {
 				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)
@@ -107,9 +108,7 @@ func TestUnixMiseRootSymlink(t *testing.T) {
 	if err := os.WriteFile(execPath, []byte{}, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	orig := executablePath
-	executablePath = func() (string, error) { return execPath, nil }
-	t.Cleanup(func() { executablePath = orig })
+	setExecutablePath(t, execPath)
 
 	if got := UpdateCommandForCurrentBinary("1.0.0"); got != miseUpgradeCmd {
 		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, miseUpgradeCmd)

--- a/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
@@ -123,3 +123,13 @@ func assertNoWindowsInstallerNames(t *testing.T, cmd string) {
 		}
 	}
 }
+
+// brew, mise, and the curl|bash one-liner all run in any POSIX shell, so
+// messages that print an update command name no shell here.
+func TestUpdateCommandShell_Unix(t *testing.T) {
+	t.Parallel()
+
+	if got := UpdateCommandShell(); got != "" {
+		t.Errorf("UpdateCommandShell() = %q, want %q", got, "")
+	}
+}

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -2,7 +2,16 @@
 
 package versioncheck
 
-import "strings"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func hasNormalizedRootPrefix(path, root string) bool {
+	return strings.HasPrefix(strings.ToLower(path), strings.ToLower(root))
+}
 
 // Windows install.ps1 one-liners from the README. Printed, never auto-run.
 const (
@@ -16,10 +25,74 @@ const (
 // pre-rename package: a binary running from the `cli` app dir must migrate to
 // `entire` regardless of its version (the fix ships in a final `cli` release,
 // so the migrating binary's version is already past the rename).
+func scoopConfigPath() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "scoop", "config.json")
+	}
+	profile := os.Getenv("USERPROFILE")
+	if profile == "" {
+		return ""
+	}
+	return filepath.Join(profile, ".config", "scoop", "config.json")
+}
+
+type scoopConfigFile struct {
+	RootPath   string `json:"root_path"`
+	GlobalPath string `json:"global_path"`
+}
+
+func readScoopConfig() scoopConfigFile {
+	path := scoopConfigPath()
+	if path == "" {
+		return scoopConfigFile{}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return scoopConfigFile{}
+	}
+	var cfg scoopConfigFile
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return scoopConfigFile{}
+	}
+	return cfg
+}
+
+func scoopRoots() []string {
+	var roots []string
+	for _, r := range []string{os.Getenv("SCOOP"), os.Getenv("SCOOP_GLOBAL")} {
+		if r != "" {
+			roots = append(roots, filepath.Join(r, "apps"))
+		}
+	}
+	cfg := readScoopConfig()
+	if cfg.RootPath != "" {
+		roots = append(roots, filepath.Join(cfg.RootPath, "apps"))
+	}
+	if cfg.GlobalPath != "" {
+		roots = append(roots, filepath.Join(cfg.GlobalPath, "apps"))
+	}
+	return roots
+}
+
+func firstPathSegment(rest string) string {
+	app, _, _ := strings.Cut(rest, "/")
+	return app
+}
+
 func scoopAppName() string {
 	normalized, err := normalizedExecPath()
 	if err != nil {
 		return ""
+	}
+	for _, raw := range scoopRoots() {
+		root := normalizeInstallRoot(raw)
+		if root == "" || !hasNormalizedRootPrefix(normalized, root) {
+			continue
+		}
+		if len(normalized) < len(root) {
+			continue
+		}
+		return firstPathSegment(normalized[len(root):])
 	}
 	_, rest, ok := strings.Cut(normalized, "/scoop/apps/")
 	if !ok {
@@ -27,8 +100,7 @@ func scoopAppName() string {
 	}
 	// Cut returns the whole string when the separator is absent, so this covers
 	// both `.../scoop/apps/cli/current/entire.exe` and a bare app segment.
-	app, _, _ := strings.Cut(rest, "/")
-	return app
+	return firstPathSegment(rest)
 }
 
 func scoopUpgradeCommand(_, _ string) string {
@@ -68,7 +140,7 @@ func scoopUpgradeCommand(_, _ string) string {
 
 var scoopProbe = installProbe{
 	name:    installManagerScoop,
-	roots:   noInstallRoots,
+	roots:   scoopRoots,
 	markers: []string{"/scoop/apps/"},
 	command: scoopUpgradeCommand,
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -75,7 +75,10 @@ const scoopAppsMarker = "/scoop/apps/"
 func scoopAppName(execPath string) string {
 	for _, raw := range scoopRoots() {
 		root := normalizeInstallRoot(raw)
-		if below, ok := strings.CutPrefix(execPath, root); ok && root != "" {
+		if root == "" {
+			continue
+		}
+		if below, ok := strings.CutPrefix(execPath, root); ok {
 			return firstPathSegment(below)
 		}
 	}

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -4,6 +4,7 @@ package versioncheck
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,11 +14,10 @@ import (
 // markers below are already lowercase.
 func foldPathCase(p string) string { return strings.ToLower(p) }
 
-// Windows install.ps1 one-liners from the README. Printed, never auto-run.
-const (
-	windowsInstallCmd        = "irm https://entire.io/install.ps1 -UseBasicParsing | iex"
-	windowsInstallNightlyCmd = "& ([scriptblock]::Create((irm https://entire.io/install.ps1 -UseBasicParsing))) -Channel nightly"
-)
+// windowsInstallCmd is the README install.ps1 one-liner in its scriptblock
+// form, which is the only shape that can bind arguments. Printed, never
+// auto-run.
+const windowsInstallCmd = "& ([scriptblock]::Create((irm https://entire.io/install.ps1 -UseBasicParsing)))"
 
 // scoopConfigPath is Scoop's config.json, which records relocated install roots.
 func scoopConfigPath() string {
@@ -136,9 +136,16 @@ var scoopProbe = installProbe{
 
 var installProbes = []installProbe{scoopProbe, miseProbe}
 
-func fallbackInstallCommand(currentVersion string) string {
+// fallbackInstallCommand names the running binary's directory with
+// -InstallDir so install.ps1 replaces it in place instead of taking its
+// Scoop-first default; an explicit -InstallDir opts out of Scoop there.
+func fallbackInstallCommand(execPath, currentVersion string) string {
+	cmd := windowsInstallCmd
 	if isNightly(currentVersion) {
-		return windowsInstallNightlyCmd
+		cmd += " -Channel nightly"
 	}
-	return windowsInstallCmd
+	if execPath != "" {
+		cmd += fmt.Sprintf(` -InstallDir "%s"`, filepath.Dir(execPath))
+	}
+	return cmd
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -4,6 +4,7 @@ package versioncheck
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,10 +14,14 @@ import (
 // markers below are already lowercase.
 func foldPathCase(p string) string { return strings.ToLower(p) }
 
-// windowsInstallCmd is the README install.ps1 one-liner in its scriptblock
-// form, which is the only shape that can bind arguments. Printed, never
-// auto-run.
-const windowsInstallCmd = "& ([scriptblock]::Create((irm https://entire.io/install.ps1 -UseBasicParsing)))"
+// Windows install.ps1 one-liners, in the README's shapes. Printed, never
+// auto-run. windowsInstallCmd is the bare stable form; arguments go through
+// windowsInstallWithArgs, the iex "& {...}" form that can bind them.
+const (
+	windowsInstallURL      = "https://entire.io/install.ps1"
+	windowsInstallCmd      = "irm " + windowsInstallURL + " | iex"
+	windowsInstallWithArgs = `iex "& {$(irm ` + windowsInstallURL + `)} %s"`
+)
 
 // scoopConfigPath is Scoop's config.json, which records relocated install roots.
 func scoopConfigPath() string {
@@ -140,15 +145,24 @@ var installProbes = []installProbe{scoopProbe, miseProbe}
 // Scoop-first default (an explicit -InstallDir opts out of Scoop there), and
 // passes -NoPathUpdate so an update never rewrites the user PATH.
 func fallbackInstallCommand(execPath, currentVersion string) string {
-	cmd := windowsInstallCmd
+	var args []string
 	if isNightly(currentVersion) {
-		cmd += " -Channel nightly"
+		args = append(args, "-Channel nightly")
 	}
 	if execPath != "" {
-		// Single quotes are literal in PowerShell (double quotes would expand
-		// $name and treat backticks as escapes); only a quote needs doubling.
-		dir := strings.ReplaceAll(filepath.Dir(execPath), "'", "''")
-		cmd += " -InstallDir '" + dir + "' -NoPathUpdate"
+		args = append(args, "-InstallDir '"+quoteInsideDoubleQuoted(filepath.Dir(execPath))+"' -NoPathUpdate")
 	}
-	return cmd
+	if len(args) == 0 {
+		return windowsInstallCmd
+	}
+	return fmt.Sprintf(windowsInstallWithArgs, strings.Join(args, " "))
+}
+
+// quoteInsideDoubleQuoted prepares a path for a single-quoted literal that
+// itself sits inside a PowerShell double-quoted string. The outer string
+// still expands $name and treats a backtick as an escape, so both are
+// backtick-escaped; the inner single-quote literal needs a quote doubled.
+func quoteInsideDoubleQuoted(p string) string {
+	r := strings.NewReplacer("`", "``", "$", "`$", "'", "''")
+	return r.Replace(p)
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -4,7 +4,6 @@ package versioncheck
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,7 +144,10 @@ func fallbackInstallCommand(execPath, currentVersion string) string {
 		cmd += " -Channel nightly"
 	}
 	if execPath != "" {
-		cmd += fmt.Sprintf(` -InstallDir "%s"`, filepath.Dir(execPath))
+		// Single quotes are literal in PowerShell (double quotes would expand
+		// $name and treat backticks as escapes); only a quote needs doubling.
+		dir := strings.ReplaceAll(filepath.Dir(execPath), "'", "''")
+		cmd += " -InstallDir '" + dir + "'"
 	}
 	return cmd
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -137,7 +137,8 @@ var installProbes = []installProbe{scoopProbe, miseProbe}
 
 // fallbackInstallCommand names the running binary's directory with
 // -InstallDir so install.ps1 replaces it in place instead of taking its
-// Scoop-first default; an explicit -InstallDir opts out of Scoop there.
+// Scoop-first default (an explicit -InstallDir opts out of Scoop there), and
+// passes -NoPathUpdate so an update never rewrites the user PATH.
 func fallbackInstallCommand(execPath, currentVersion string) string {
 	cmd := windowsInstallCmd
 	if isNightly(currentVersion) {
@@ -147,7 +148,7 @@ func fallbackInstallCommand(execPath, currentVersion string) string {
 		// Single quotes are literal in PowerShell (double quotes would expand
 		// $name and treat backticks as escapes); only a quote needs doubling.
 		dir := strings.ReplaceAll(filepath.Dir(execPath), "'", "''")
-		cmd += " -InstallDir '" + dir + "'"
+		cmd += " -InstallDir '" + dir + "' -NoPathUpdate"
 	}
 	return cmd
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -1,0 +1,83 @@
+//go:build windows
+
+package versioncheck
+
+import "strings"
+
+// Windows install.ps1 one-liners from the README. Printed, never auto-run.
+const (
+	windowsInstallCmd        = "irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex"
+	windowsInstallNightlyCmd = "& ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly"
+)
+
+// scoopAppName returns the Scoop app directory the running binary lives under
+// — the path segment after `/scoop/apps/` (e.g. "cli" or "entire") — or ""
+// when the binary is not a Scoop install. This is the durable signal for the
+// pre-rename package: a binary running from the `cli` app dir must migrate to
+// `entire` regardless of its version (the fix ships in a final `cli` release,
+// so the migrating binary's version is already past the rename).
+func scoopAppName() string {
+	normalized, err := normalizedExecPath()
+	if err != nil {
+		return ""
+	}
+	_, rest, ok := strings.Cut(normalized, "/scoop/apps/")
+	if !ok {
+		return ""
+	}
+	// Cut returns the whole string when the separator is absent, so this covers
+	// both `.../scoop/apps/cli/current/entire.exe` and a bare app segment.
+	app, _, _ := strings.Cut(rest, "/")
+	return app
+}
+
+func scoopUpgradeCommand(_, _ string) string {
+	// The Scoop package was renamed from `cli` to `entire`. A binary still
+	// running from the old `cli` app dir can never cross the rename with a
+	// plain `scoop update entire/cli`, so migrate it: install the new
+	// `entire` package, remove the old `cli` package, then reset the shared
+	// shims. Both manifests declare `bin: [git-remote-entire.exe,
+	// entire.exe]`, so the two packages contend for the same shims. Current
+	// Scoop handles that itself: installing `entire` renames the displaced
+	// shim to `entire.shim.cli` (warn_on_overwrite) and uninstalling `cli`
+	// removes only that suffixed copy (rm_shim), leaving the active shims
+	// pointing at `entire`. The reset step is belt-and-braces for older
+	// Scoop versions that overwrote shims without that alt-file dance and
+	// would otherwise take `entire.exe` and the git remote helper with them.
+	//
+	// The Windows updater is print-only, so return a self-contained command
+	// users can paste into either cmd or PowerShell. Explicitly invoking
+	// cmd.exe makes `&&` portable across those shells and ensures uninstall
+	// only runs after install succeeds — a stale bucket or transient failure
+	// therefore never removes the working CLI. (The uninstall→reset link is
+	// weaker: `scoop uninstall` ends in an unconditional `exit 0`, so reset
+	// runs even when the uninstall skipped its work. That is harmless, since
+	// reset is a no-op on the Scoop versions that make it unnecessary.)
+	//
+	// `scoop install` also auto-refreshes the bucket when >3h stale
+	// (is_scoop_outdated), so the new manifest usually lands
+	// without an explicit refresh; a bucket clone older than that check can
+	// still fail with "couldn't find manifest", and the README migration
+	// section names `scoop update` as the retry. Binaries already on the
+	// `entire` app just update in place.
+	if scoopAppName() == "cli" {
+		return `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
+	}
+	return "scoop update entire/entire"
+}
+
+var scoopProbe = installProbe{
+	name:    installManagerScoop,
+	roots:   noInstallRoots,
+	markers: []string{"/scoop/apps/"},
+	command: scoopUpgradeCommand,
+}
+
+var installProbes = []installProbe{scoopProbe, miseProbe}
+
+func fallbackInstallCommand(currentVersion string) string {
+	if releaseChannel(currentVersion) == installChannelNightly {
+		return windowsInstallNightlyCmd
+	}
+	return windowsInstallCmd
+}

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 )
 
-func hasNormalizedRootPrefix(path, root string) bool {
-	return strings.HasPrefix(strings.ToLower(path), strings.ToLower(root))
-}
+// foldPathCase lowercases: Windows paths compare case-insensitively, and the
+// markers below are already lowercase.
+func foldPathCase(p string) string { return strings.ToLower(p) }
 
 // Windows install.ps1 one-liners from the README. Printed, never auto-run.
 const (
@@ -53,55 +53,28 @@ func readScoopConfig() scoopConfigFile {
 }
 
 func scoopRoots() []string {
+	cfg := readScoopConfig()
 	var roots []string
-	for _, r := range []string{os.Getenv("SCOOP"), os.Getenv("SCOOP_GLOBAL")} {
+	for _, r := range []string{os.Getenv("SCOOP"), os.Getenv("SCOOP_GLOBAL"), cfg.RootPath, cfg.GlobalPath} {
 		if r != "" {
 			roots = append(roots, filepath.Join(r, "apps"))
 		}
 	}
-	cfg := readScoopConfig()
-	if cfg.RootPath != "" {
-		roots = append(roots, filepath.Join(cfg.RootPath, "apps"))
-	}
-	if cfg.GlobalPath != "" {
-		roots = append(roots, filepath.Join(cfg.GlobalPath, "apps"))
-	}
 	return roots
 }
 
-func firstPathSegment(rest string) string {
+// scoopAppName returns the Scoop app directory from a path relative to the
+// Scoop apps root (e.g. "cli" from "cli/current/entire.exe"). This is the
+// durable signal for the pre-rename package: a binary running from the `cli`
+// app dir must migrate to `entire` regardless of its version (the fix ships in
+// a final `cli` release, so the migrating binary's version is already past the
+// rename).
+func scoopAppName(rest string) string {
 	app, _, _ := strings.Cut(rest, "/")
 	return app
 }
 
-// scoopAppName returns the Scoop app directory the running binary lives under
-// — the path segment after `/scoop/apps/` (e.g. "cli" or "entire") — or ""
-// when the binary is not a Scoop install. This is the durable signal for the
-// pre-rename package: a binary running from the `cli` app dir must migrate to
-// `entire` regardless of its version (the fix ships in a final `cli` release,
-// so the migrating binary's version is already past the rename).
-func scoopAppName() string {
-	normalized, err := normalizedExecPath()
-	if err != nil {
-		return ""
-	}
-	for _, raw := range scoopRoots() {
-		root := normalizeInstallRoot(raw)
-		if root == "" || !hasNormalizedRootPrefix(normalized, root) {
-			continue
-		}
-		return firstPathSegment(normalized[len(root):])
-	}
-	_, rest, ok := strings.Cut(normalized, "/scoop/apps/")
-	if !ok {
-		return ""
-	}
-	// Cut returns the whole string when the separator is absent, so this covers
-	// both `.../scoop/apps/cli/current/entire.exe` and a bare app segment.
-	return firstPathSegment(rest)
-}
-
-func scoopUpgradeCommand(_, _ string) string {
+func scoopUpgradeCommand(rest, _ string) string {
 	// The Scoop package was renamed from `cli` to `entire`. A binary still
 	// running from the old `cli` app dir can never cross the rename with a
 	// plain `scoop update entire/cli`, so migrate it: install the new
@@ -130,7 +103,7 @@ func scoopUpgradeCommand(_, _ string) string {
 	// still fail with "couldn't find manifest", and the README migration
 	// section names `scoop update` as the retry. Binaries already on the
 	// `entire` app just update in place.
-	if scoopAppName() == "cli" {
+	if scoopAppName(rest) == "cli" {
 		return `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
 	}
 	return "scoop update entire/entire"
@@ -145,7 +118,7 @@ var scoopProbe = installProbe{
 var installProbes = []installProbe{scoopProbe, miseProbe}
 
 func fallbackInstallCommand(currentVersion string) string {
-	if releaseChannel(currentVersion) == installChannelNightly {
+	if isNightly(currentVersion) {
 		return windowsInstallNightlyCmd
 	}
 	return windowsInstallCmd

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -19,12 +19,7 @@ const (
 	windowsInstallNightlyCmd = "& ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly"
 )
 
-// scoopAppName returns the Scoop app directory the running binary lives under
-// — the path segment after `/scoop/apps/` (e.g. "cli" or "entire") — or ""
-// when the binary is not a Scoop install. This is the durable signal for the
-// pre-rename package: a binary running from the `cli` app dir must migrate to
-// `entire` regardless of its version (the fix ships in a final `cli` release,
-// so the migrating binary's version is already past the rename).
+// scoopConfigPath is Scoop's config.json, which records relocated install roots.
 func scoopConfigPath() string {
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		return filepath.Join(xdg, "scoop", "config.json")
@@ -46,7 +41,7 @@ func readScoopConfig() scoopConfigFile {
 	if path == "" {
 		return scoopConfigFile{}
 	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // fixed per-user config location, not user input
 	if err != nil {
 		return scoopConfigFile{}
 	}
@@ -79,6 +74,12 @@ func firstPathSegment(rest string) string {
 	return app
 }
 
+// scoopAppName returns the Scoop app directory the running binary lives under
+// — the path segment after `/scoop/apps/` (e.g. "cli" or "entire") — or ""
+// when the binary is not a Scoop install. This is the durable signal for the
+// pre-rename package: a binary running from the `cli` app dir must migrate to
+// `entire` regardless of its version (the fix ships in a final `cli` release,
+// so the migrating binary's version is already past the rename).
 func scoopAppName() string {
 	normalized, err := normalizedExecPath()
 	if err != nil {
@@ -87,9 +88,6 @@ func scoopAppName() string {
 	for _, raw := range scoopRoots() {
 		root := normalizeInstallRoot(raw)
 		if root == "" || !hasNormalizedRootPrefix(normalized, root) {
-			continue
-		}
-		if len(normalized) < len(root) {
 			continue
 		}
 		return firstPathSegment(normalized[len(root):])
@@ -139,7 +137,6 @@ func scoopUpgradeCommand(_, _ string) string {
 }
 
 var scoopProbe = installProbe{
-	name:    installManagerScoop,
 	roots:   scoopRoots,
 	markers: []string{"/scoop/apps/"},
 	command: scoopUpgradeCommand,

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -15,8 +15,8 @@ func foldPathCase(p string) string { return strings.ToLower(p) }
 
 // Windows install.ps1 one-liners from the README. Printed, never auto-run.
 const (
-	windowsInstallCmd        = "irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing | iex"
-	windowsInstallNightlyCmd = "& ([scriptblock]::Create((irm https://raw.githubusercontent.com/entireio/cli/main/scripts/install.ps1 -UseBasicParsing))) -Channel nightly"
+	windowsInstallCmd        = "irm https://entire.io/install.ps1 -UseBasicParsing | iex"
+	windowsInstallNightlyCmd = "& ([scriptblock]::Create((irm https://entire.io/install.ps1 -UseBasicParsing))) -Channel nightly"
 )
 
 // scoopConfigPath is Scoop's config.json, which records relocated install roots.

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -63,18 +63,34 @@ func scoopRoots() []string {
 	return roots
 }
 
-// scoopAppName returns the Scoop app directory from a path relative to the
-// Scoop apps root (e.g. "cli" from "cli/current/entire.exe"). This is the
+// scoopAppsMarker is the default Scoop layout; scoopRoots covers relocations.
+const scoopAppsMarker = "/scoop/apps/"
+
+// scoopAppName returns the Scoop app directory the binary runs from ("cli" or
+// "entire"), or "" when execPath is not under a Scoop apps root. This is the
 // durable signal for the pre-rename package: a binary running from the `cli`
 // app dir must migrate to `entire` regardless of its version (the fix ships in
 // a final `cli` release, so the migrating binary's version is already past the
 // rename).
-func scoopAppName(rest string) string {
-	app, _, _ := strings.Cut(rest, "/")
+func scoopAppName(execPath string) string {
+	for _, raw := range scoopRoots() {
+		root := normalizeInstallRoot(raw)
+		if below, ok := strings.CutPrefix(execPath, root); ok && root != "" {
+			return firstPathSegment(below)
+		}
+	}
+	if _, below, ok := strings.Cut(execPath, scoopAppsMarker); ok {
+		return firstPathSegment(below)
+	}
+	return ""
+}
+
+func firstPathSegment(p string) string {
+	app, _, _ := strings.Cut(p, "/")
 	return app
 }
 
-func scoopUpgradeCommand(rest, _ string) string {
+func scoopUpgradeCommand(execPath, _ string) string {
 	// The Scoop package was renamed from `cli` to `entire`. A binary still
 	// running from the old `cli` app dir can never cross the rename with a
 	// plain `scoop update entire/cli`, so migrate it: install the new
@@ -103,7 +119,7 @@ func scoopUpgradeCommand(rest, _ string) string {
 	// still fail with "couldn't find manifest", and the README migration
 	// section names `scoop update` as the retry. Binaries already on the
 	// `entire` app just update in place.
-	if scoopAppName(rest) == "cli" {
+	if scoopAppName(execPath) == "cli" {
 		return `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
 	}
 	return "scoop update entire/entire"
@@ -111,7 +127,7 @@ func scoopUpgradeCommand(rest, _ string) string {
 
 var scoopProbe = installProbe{
 	roots:   scoopRoots,
-	markers: []string{"/scoop/apps/"},
+	markers: []string{scoopAppsMarker},
 	command: scoopUpgradeCommand,
 }
 

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -14,6 +14,14 @@ import (
 // markers below are already lowercase.
 func foldPathCase(p string) string { return strings.ToLower(p) }
 
+// updateCommandShell is PowerShell: the one shell every Windows update command
+// works in. The install.ps1 one-liners below run nowhere else — cmd.exe has no
+// `iex`, and bash expands the `$(irm ...)` substitution itself before
+// PowerShell ever sees it — while the scoop, mise, and cmd.exe-prefixed
+// commands run there as happily as anywhere. Every one of them is printed for
+// the user to paste, so whatever prints one has to say where to paste it.
+const updateCommandShell = "PowerShell"
+
 // Windows install.ps1 one-liners, in the README's shapes. Printed, never
 // auto-run. windowsInstallCmd is the bare stable form; arguments go through
 // windowsInstallWithArgs, the iex "& {...}" form that can bind them.

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -67,7 +67,7 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "non-scoop path in a cli directory uses install.ps1",
 			currentVersion: "1.0.0",
 			execPath:       `C:\tools\cli\entire.exe`,
-			want:           windowsInstallCmd + ` -InstallDir 'C:\tools\cli' -NoPathUpdate`,
+			want:           `iex "& {$(irm https://entire.io/install.ps1)} -InstallDir 'C:\tools\cli' -NoPathUpdate"`,
 		},
 		{
 			name:           "mise default layout uses mise upgrade",
@@ -79,19 +79,19 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "windows unknown path stable uses install.ps1",
 			currentVersion: "1.0.0",
 			execPath:       windowsLocalBinPath,
-			want:           windowsInstallCmd + ` -InstallDir 'C:\Users\test\.local\bin' -NoPathUpdate`,
+			want:           `iex "& {$(irm https://entire.io/install.ps1)} -InstallDir 'C:\Users\test\.local\bin' -NoPathUpdate"`,
 		},
 		{
 			name:           "install dir with $ and a quote is passed literally",
 			currentVersion: "1.0.0",
 			execPath:       `C:\Users\$victor's\bin\entire.exe`,
-			want:           windowsInstallCmd + ` -InstallDir 'C:\Users\$victor''s\bin' -NoPathUpdate`,
+			want:           "iex \"& {$(irm https://entire.io/install.ps1)} -InstallDir 'C:\\Users\\`$victor''s\\bin' -NoPathUpdate\"",
 		},
 		{
 			name:           "windows unknown path nightly uses install.ps1 -Channel nightly",
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
 			execPath:       windowsLocalBinPath,
-			want:           windowsInstallCmd + ` -Channel nightly -InstallDir 'C:\Users\test\.local\bin' -NoPathUpdate`,
+			want:           `iex "& {$(irm https://entire.io/install.ps1)} -Channel nightly -InstallDir 'C:\Users\test\.local\bin' -NoPathUpdate"`,
 		},
 	}
 

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -3,6 +3,7 @@
 package versioncheck
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,7 +67,7 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "non-scoop path in a cli directory uses install.ps1",
 			currentVersion: "1.0.0",
 			execPath:       `C:\tools\cli\entire.exe`,
-			want:           windowsInstallCmd,
+			want:           windowsInstallCmd + ` -InstallDir "C:\tools\cli"`,
 		},
 		{
 			name:           "mise default layout uses mise upgrade",
@@ -78,13 +79,13 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "windows unknown path stable uses install.ps1",
 			currentVersion: "1.0.0",
 			execPath:       windowsLocalBinPath,
-			want:           windowsInstallCmd,
+			want:           windowsInstallCmd + ` -InstallDir "C:\Users\test\.local\bin"`,
 		},
 		{
 			name:           "windows unknown path nightly uses install.ps1 -Channel nightly",
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
 			execPath:       windowsLocalBinPath,
-			want:           windowsInstallNightlyCmd,
+			want:           windowsInstallCmd + ` -Channel nightly -InstallDir "C:\Users\test\.local\bin"`,
 		},
 	}
 
@@ -96,6 +97,16 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// Without an exec path there is no directory to name, so the hint falls back
+// to the bare one-liner and install.ps1 keeps its own default.
+func TestWindowsUpdateCommandWithoutExecPathOmitsInstallDir(t *testing.T) {
+	setExecutable(t, func() (string, error) { return "", errors.New("not found") })
+
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != windowsInstallCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, windowsInstallCmd)
 	}
 }
 
@@ -181,7 +192,7 @@ func TestWindowsCommandsNeverNamePOSIXInstallers(t *testing.T) {
 			for _, p := range installProbes {
 				assertNoPOSIXInstallerNames(t, p.command(`C:\x`, version))
 			}
-			assertNoPOSIXInstallerNames(t, fallbackInstallCommand(version))
+			assertNoPOSIXInstallerNames(t, fallbackInstallCommand(`C:\x\entire.exe`, version))
 		})
 	}
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -67,7 +67,7 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "non-scoop path in a cli directory uses install.ps1",
 			currentVersion: "1.0.0",
 			execPath:       `C:\tools\cli\entire.exe`,
-			want:           windowsInstallCmd + ` -InstallDir 'C:\tools\cli'`,
+			want:           windowsInstallCmd + ` -InstallDir 'C:\tools\cli' -NoPathUpdate`,
 		},
 		{
 			name:           "mise default layout uses mise upgrade",
@@ -79,19 +79,19 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "windows unknown path stable uses install.ps1",
 			currentVersion: "1.0.0",
 			execPath:       windowsLocalBinPath,
-			want:           windowsInstallCmd + ` -InstallDir 'C:\Users\test\.local\bin'`,
+			want:           windowsInstallCmd + ` -InstallDir 'C:\Users\test\.local\bin' -NoPathUpdate`,
 		},
 		{
 			name:           "install dir with $ and a quote is passed literally",
 			currentVersion: "1.0.0",
 			execPath:       `C:\Users\$victor's\bin\entire.exe`,
-			want:           windowsInstallCmd + ` -InstallDir 'C:\Users\$victor''s\bin'`,
+			want:           windowsInstallCmd + ` -InstallDir 'C:\Users\$victor''s\bin' -NoPathUpdate`,
 		},
 		{
 			name:           "windows unknown path nightly uses install.ps1 -Channel nightly",
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
 			execPath:       windowsLocalBinPath,
-			want:           windowsInstallCmd + ` -Channel nightly -InstallDir 'C:\Users\test\.local\bin'`,
+			want:           windowsInstallCmd + ` -Channel nightly -InstallDir 'C:\Users\test\.local\bin' -NoPathUpdate`,
 		},
 	}
 

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -19,6 +19,10 @@ const scoopEntireVersionedExecutablePath = `C:\Users\test\scoop\apps\entire\0.10
 // windowsLocalBinPath is a direct install.ps1 destination. windowsProgramFilesPath
 // is an unknown Windows path that matches none of the install-manager prefixes.
 const windowsLocalBinPath = `C:\Users\test\.local\bin\entire.exe`
+
+// windowsMiseExecutablePath is mise's default Windows layout; the mixed case
+// and backslashes exercise the normalization the marker match relies on.
+const windowsMiseExecutablePath = `C:\Users\test\AppData\Local\mise\installs\entire\1.0.0\bin\entire.exe`
 const windowsProgramFilesPath = `C:\Program Files\Entire\entire.exe`
 
 const scoopUpdateCmd = "scoop update entire/entire"
@@ -63,6 +67,12 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 			currentVersion: "1.0.0",
 			execPath:       `C:\tools\cli\entire.exe`,
 			want:           windowsInstallCmd,
+		},
+		{
+			name:           "mise default layout uses mise upgrade",
+			currentVersion: "1.0.0",
+			execPath:       windowsMiseExecutablePath,
+			want:           miseUpgradeCmd,
 		},
 		{
 			name:           "windows unknown path stable uses install.ps1",

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -4,6 +4,8 @@ package versioncheck
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -124,6 +126,89 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func isolateWindowsScoopConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	t.Setenv("SCOOP", "")
+	t.Setenv("SCOOP_GLOBAL", "")
+	return dir
+}
+
+func withWindowsExecPath(t *testing.T, path string) {
+	t.Helper()
+	orig := executablePath
+	executablePath = func() (string, error) { return path, nil }
+	t.Cleanup(func() { executablePath = orig })
+}
+
+func TestWindowsScoopRelocatedSCOOPEnv(t *testing.T) {
+	isolateWindowsScoopConfig(t)
+	t.Setenv("SCOOP", `D:\tools`)
+	withWindowsExecPath(t, `D:\tools\apps\entire\current\entire.exe`)
+
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != "scoop update entire/entire" {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want scoop update entire/entire", got)
+	}
+}
+
+func TestWindowsScoopRelocatedSCOOPEnvCLIAppMigrates(t *testing.T) {
+	isolateWindowsScoopConfig(t)
+	t.Setenv("SCOOP", `D:\tools`)
+	withWindowsExecPath(t, `D:\tools\apps\cli\current\entire.exe`)
+
+	want := `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != want {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, want)
+	}
+}
+
+func TestWindowsScoopRelocatedSCOOPGlobal(t *testing.T) {
+	isolateWindowsScoopConfig(t)
+	t.Setenv("SCOOP_GLOBAL", `D:\g`)
+	withWindowsExecPath(t, `D:\g\apps\entire\current\entire.exe`)
+
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != "scoop update entire/entire" {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want scoop update entire/entire", got)
+	}
+}
+
+func TestWindowsScoopRelocatedConfigRootPath(t *testing.T) {
+	dir := isolateWindowsScoopConfig(t)
+	cfgDir := filepath.Join(dir, "scoop")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"root_path":"D:\\from-config"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withWindowsExecPath(t, `D:\from-config\apps\entire\current\entire.exe`)
+
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != "scoop update entire/entire" {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want scoop update entire/entire", got)
+	}
+}
+
+func TestWindowsScoopRelocatedCaseInsensitive(t *testing.T) {
+	isolateWindowsScoopConfig(t)
+	t.Setenv("SCOOP", `d:\Tools`)
+	withWindowsExecPath(t, `D:\tools\apps\entire\current\entire.exe`)
+
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != "scoop update entire/entire" {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want scoop update entire/entire", got)
+	}
+}
+
+func TestWindowsScoopDefaultMarkerStillMatches(t *testing.T) {
+	isolateWindowsScoopConfig(t)
+	withWindowsExecPath(t, `C:\Users\x\scoop\apps\entire\current\entire.exe`)
+
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != "scoop update entire/entire" {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want scoop update entire/entire", got)
 	}
 }
 

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -22,6 +22,8 @@ const scoopEntireVersionedExecutablePath = `C:\Users\test\scoop\apps\entire\0.10
 const windowsLocalBinPath = `C:\Users\test\.local\bin\entire.exe`
 const windowsProgramFilesPath = `C:\Program Files\Entire\entire.exe`
 
+const scoopUpdateCmd = "scoop update entire/entire"
+
 // TestWindowsScoopAppName pins the signal the rename migration keys off. The ""
 // results matter most: they are what keeps the `== "cli"` comparison in
 // UpdateCommandForCurrentBinary from misfiring on a non-Scoop binary that happens to live in a
@@ -88,13 +90,13 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "scoop entire app updates in place",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return scoopEntireExecutablePath, nil },
-			want:           "scoop update entire/entire",
+			want:           scoopUpdateCmd,
 		},
 		{
 			name:           "scoop entire versioned path updates in place",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return scoopEntireVersionedExecutablePath, nil },
-			want:           "scoop update entire/entire",
+			want:           scoopUpdateCmd,
 		},
 		{
 			name:           "scoop cli app routes through package rename regardless of version",
@@ -151,8 +153,8 @@ func TestWindowsScoopRelocatedSCOOPEnv(t *testing.T) {
 	t.Setenv("SCOOP", `D:\tools`)
 	withWindowsExecPath(t, `D:\tools\apps\entire\current\entire.exe`)
 
-	if got := UpdateCommandForCurrentBinary("1.0.0"); got != "scoop update entire/entire" {
-		t.Errorf("UpdateCommandForCurrentBinary() = %q, want scoop update entire/entire", got)
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopUpdateCmd)
 	}
 }
 
@@ -172,8 +174,8 @@ func TestWindowsScoopRelocatedSCOOPGlobal(t *testing.T) {
 	t.Setenv("SCOOP_GLOBAL", `D:\g`)
 	withWindowsExecPath(t, `D:\g\apps\entire\current\entire.exe`)
 
-	if got := UpdateCommandForCurrentBinary("1.0.0"); got != "scoop update entire/entire" {
-		t.Errorf("UpdateCommandForCurrentBinary() = %q, want scoop update entire/entire", got)
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopUpdateCmd)
 	}
 }
 
@@ -188,8 +190,8 @@ func TestWindowsScoopRelocatedConfigRootPath(t *testing.T) {
 	}
 	withWindowsExecPath(t, `D:\from-config\apps\entire\current\entire.exe`)
 
-	if got := UpdateCommandForCurrentBinary("1.0.0"); got != "scoop update entire/entire" {
-		t.Errorf("UpdateCommandForCurrentBinary() = %q, want scoop update entire/entire", got)
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopUpdateCmd)
 	}
 }
 
@@ -198,8 +200,8 @@ func TestWindowsScoopRelocatedCaseInsensitive(t *testing.T) {
 	t.Setenv("SCOOP", `d:\Tools`)
 	withWindowsExecPath(t, `D:\tools\apps\entire\current\entire.exe`)
 
-	if got := UpdateCommandForCurrentBinary("1.0.0"); got != "scoop update entire/entire" {
-		t.Errorf("UpdateCommandForCurrentBinary() = %q, want scoop update entire/entire", got)
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopUpdateCmd)
 	}
 }
 
@@ -207,8 +209,8 @@ func TestWindowsScoopDefaultMarkerStillMatches(t *testing.T) {
 	isolateWindowsScoopConfig(t)
 	withWindowsExecPath(t, `C:\Users\x\scoop\apps\entire\current\entire.exe`)
 
-	if got := UpdateCommandForCurrentBinary("1.0.0"); got != "scoop update entire/entire" {
-		t.Errorf("UpdateCommandForCurrentBinary() = %q, want scoop update entire/entire", got)
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopUpdateCmd)
 	}
 }
 

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -192,9 +192,11 @@ func TestWindowsScoopDefaultMarkerStillMatches(t *testing.T) {
 }
 
 func TestWindowsCommandsNeverNamePOSIXInstallers(t *testing.T) {
+	t.Parallel()
 	versions := []string{"1.0.0", "1.0.1-nightly.202604101200.abc1234"}
 	for _, version := range versions {
 		t.Run(version, func(t *testing.T) {
+			t.Parallel()
 			for _, p := range installProbes {
 				assertNoPOSIXInstallerNames(t, p.command(`C:\x`, version))
 			}

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -67,7 +67,7 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "non-scoop path in a cli directory uses install.ps1",
 			currentVersion: "1.0.0",
 			execPath:       `C:\tools\cli\entire.exe`,
-			want:           windowsInstallCmd + ` -InstallDir "C:\tools\cli"`,
+			want:           windowsInstallCmd + ` -InstallDir 'C:\tools\cli'`,
 		},
 		{
 			name:           "mise default layout uses mise upgrade",
@@ -79,13 +79,19 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 			name:           "windows unknown path stable uses install.ps1",
 			currentVersion: "1.0.0",
 			execPath:       windowsLocalBinPath,
-			want:           windowsInstallCmd + ` -InstallDir "C:\Users\test\.local\bin"`,
+			want:           windowsInstallCmd + ` -InstallDir 'C:\Users\test\.local\bin'`,
+		},
+		{
+			name:           "install dir with $ and a quote is passed literally",
+			currentVersion: "1.0.0",
+			execPath:       `C:\Users\$victor's\bin\entire.exe`,
+			want:           windowsInstallCmd + ` -InstallDir 'C:\Users\$victor''s\bin'`,
 		},
 		{
 			name:           "windows unknown path nightly uses install.ps1 -Channel nightly",
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
 			execPath:       windowsLocalBinPath,
-			want:           windowsInstallCmd + ` -Channel nightly -InstallDir "C:\Users\test\.local\bin"`,
+			want:           windowsInstallCmd + ` -Channel nightly -InstallDir 'C:\Users\test\.local\bin'`,
 		},
 	}
 

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -1,0 +1,149 @@
+//go:build windows
+
+package versioncheck
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// scoopExecutablePath is the pre-rename `cli` app dir; scoopEntireExecutablePath
+// is the renamed `entire` app dir. The Scoop update command is chosen by which
+// app dir the binary runs from, not by version.
+const scoopExecutablePath = `C:\Users\test\scoop\apps\cli\current\entire.exe`
+const scoopEntireExecutablePath = `C:\Users\test\scoop\apps\entire\current\entire.exe`
+const scoopEntireVersionedExecutablePath = `C:\Users\test\scoop\apps\entire\0.10.5\entire.exe`
+
+// windowsLocalBinPath is a direct install.ps1 destination. windowsProgramFilesPath
+// is an unknown Windows path that matches none of the install-manager prefixes.
+const windowsLocalBinPath = `C:\Users\test\.local\bin\entire.exe`
+const windowsProgramFilesPath = `C:\Program Files\Entire\entire.exe`
+
+// TestWindowsScoopAppName pins the signal the rename migration keys off. The ""
+// results matter most: they are what keeps the `== "cli"` comparison in
+// UpdateCommandForCurrentBinary from misfiring on a non-Scoop binary that happens to live in a
+// directory named `cli`.
+func TestWindowsScoopAppName(t *testing.T) {
+	tests := []struct {
+		name     string
+		execPath func() (string, error)
+		want     string
+	}{
+		{
+			name:     "pre-rename cli app dir",
+			execPath: func() (string, error) { return scoopExecutablePath, nil },
+			want:     "cli",
+		},
+		{
+			name:     "renamed entire app dir",
+			execPath: func() (string, error) { return scoopEntireExecutablePath, nil },
+			want:     "entire",
+		},
+		{
+			name:     "junction-resolved versioned entire app dir",
+			execPath: func() (string, error) { return scoopEntireVersionedExecutablePath, nil },
+			want:     "entire",
+		},
+		{
+			name:     "non-scoop path in a cli directory",
+			execPath: func() (string, error) { return `C:\tools\cli\entire.exe`, nil },
+			want:     "",
+		},
+		{
+			name:     "posix install",
+			execPath: func() (string, error) { return plainBinPath, nil },
+			want:     "",
+		},
+		{
+			name:     "executable path unavailable",
+			execPath: func() (string, error) { return "", errors.New("not found") },
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := executablePath
+			executablePath = tt.execPath
+			t.Cleanup(func() { executablePath = original })
+
+			if got := scoopAppName(); got != tt.want {
+				t.Errorf("scoopAppName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		execPath       func() (string, error)
+		want           string
+	}{
+		{
+			name:           "scoop entire app updates in place",
+			currentVersion: "1.0.0",
+			execPath:       func() (string, error) { return scoopEntireExecutablePath, nil },
+			want:           "scoop update entire/entire",
+		},
+		{
+			name:           "scoop entire versioned path updates in place",
+			currentVersion: "1.0.0",
+			execPath:       func() (string, error) { return scoopEntireVersionedExecutablePath, nil },
+			want:           "scoop update entire/entire",
+		},
+		{
+			name:           "scoop cli app routes through package rename regardless of version",
+			currentVersion: "1.0.0",
+			execPath:       func() (string, error) { return scoopExecutablePath, nil },
+			want:           `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`,
+		},
+		{
+			name:           "windows unknown path stable uses install.ps1",
+			currentVersion: "1.0.0",
+			execPath:       func() (string, error) { return windowsLocalBinPath, nil },
+			want:           windowsInstallCmd,
+		},
+		{
+			name:           "windows unknown path nightly uses install.ps1 -Channel nightly",
+			currentVersion: "1.0.1-nightly.202604101200.abc1234",
+			execPath:       func() (string, error) { return windowsLocalBinPath, nil },
+			want:           windowsInstallNightlyCmd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := executablePath
+			executablePath = tt.execPath
+			t.Cleanup(func() { executablePath = original })
+
+			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {
+				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWindowsCommandsNeverNamePOSIXInstallers(t *testing.T) {
+	versions := []string{"1.0.0", "1.0.1-nightly.202604101200.abc1234"}
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			for _, p := range installProbes {
+				assertNoPOSIXInstallerNames(t, p.command(`C:\x`, version))
+			}
+			assertNoPOSIXInstallerNames(t, fallbackInstallCommand(version))
+		})
+	}
+}
+
+func assertNoPOSIXInstallerNames(t *testing.T, cmd string) {
+	t.Helper()
+	for _, needle := range []string{"curl", "brew", "sh "} {
+		if strings.Contains(cmd, needle) {
+			t.Errorf("windows command %q contains %q", cmd, needle)
+		}
+	}
+}

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -3,7 +3,6 @@
 package versioncheck
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,106 +22,65 @@ const windowsLocalBinPath = `C:\Users\test\.local\bin\entire.exe`
 const windowsProgramFilesPath = `C:\Program Files\Entire\entire.exe`
 
 const scoopUpdateCmd = "scoop update entire/entire"
+const scoopMigrateCmd = `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
 
-// TestWindowsScoopAppName pins the signal the rename migration keys off. The ""
-// results matter most: they are what keeps the `== "cli"` comparison in
-// UpdateCommandForCurrentBinary from misfiring on a non-Scoop binary that happens to live in a
-// directory named `cli`.
-func TestWindowsScoopAppName(t *testing.T) {
-	tests := []struct {
-		name     string
-		execPath func() (string, error)
-		want     string
-	}{
-		{
-			name:     "pre-rename cli app dir",
-			execPath: func() (string, error) { return scoopExecutablePath, nil },
-			want:     "cli",
-		},
-		{
-			name:     "renamed entire app dir",
-			execPath: func() (string, error) { return scoopEntireExecutablePath, nil },
-			want:     "entire",
-		},
-		{
-			name:     "junction-resolved versioned entire app dir",
-			execPath: func() (string, error) { return scoopEntireVersionedExecutablePath, nil },
-			want:     "entire",
-		},
-		{
-			name:     "non-scoop path in a cli directory",
-			execPath: func() (string, error) { return `C:\tools\cli\entire.exe`, nil },
-			want:     "",
-		},
-		{
-			name:     "posix install",
-			execPath: func() (string, error) { return plainBinPath, nil },
-			want:     "",
-		},
-		{
-			name:     "executable path unavailable",
-			execPath: func() (string, error) { return "", errors.New("not found") },
-			want:     "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			original := executablePath
-			executablePath = tt.execPath
-			t.Cleanup(func() { executablePath = original })
-
-			if got := scoopAppName(); got != tt.want {
-				t.Errorf("scoopAppName() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
+// TestWindowsUpdateCommandForCurrentBinary pins the command per install
+// location. The non-Scoop `cli` directory row keeps the rename migration from
+// misfiring on a binary that merely lives in a directory named `cli`.
 func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 	tests := []struct {
 		name           string
 		currentVersion string
-		execPath       func() (string, error)
+		execPath       string
 		want           string
 	}{
 		{
 			name:           "scoop entire app updates in place",
 			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return scoopEntireExecutablePath, nil },
+			execPath:       scoopEntireExecutablePath,
 			want:           scoopUpdateCmd,
 		},
 		{
 			name:           "scoop entire versioned path updates in place",
 			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return scoopEntireVersionedExecutablePath, nil },
+			execPath:       scoopEntireVersionedExecutablePath,
 			want:           scoopUpdateCmd,
 		},
 		{
 			name:           "scoop cli app routes through package rename regardless of version",
 			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return scoopExecutablePath, nil },
-			want:           `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`,
+			execPath:       scoopExecutablePath,
+			want:           scoopMigrateCmd,
+		},
+		{
+			name:           "scoop marker matches regardless of case",
+			currentVersion: "1.0.0",
+			execPath:       `C:\Users\test\Scoop\Apps\entire\current\entire.exe`,
+			want:           scoopUpdateCmd,
+		},
+		{
+			name:           "non-scoop path in a cli directory uses install.ps1",
+			currentVersion: "1.0.0",
+			execPath:       `C:\tools\cli\entire.exe`,
+			want:           windowsInstallCmd,
 		},
 		{
 			name:           "windows unknown path stable uses install.ps1",
 			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return windowsLocalBinPath, nil },
+			execPath:       windowsLocalBinPath,
 			want:           windowsInstallCmd,
 		},
 		{
 			name:           "windows unknown path nightly uses install.ps1 -Channel nightly",
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
-			execPath:       func() (string, error) { return windowsLocalBinPath, nil },
+			execPath:       windowsLocalBinPath,
 			want:           windowsInstallNightlyCmd,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			original := executablePath
-			executablePath = tt.execPath
-			t.Cleanup(func() { executablePath = original })
+			setExecutablePath(t, tt.execPath)
 
 			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {
 				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)
@@ -141,17 +99,10 @@ func isolateWindowsScoopConfig(t *testing.T) string {
 	return dir
 }
 
-func withWindowsExecPath(t *testing.T, path string) {
-	t.Helper()
-	orig := executablePath
-	executablePath = func() (string, error) { return path, nil }
-	t.Cleanup(func() { executablePath = orig })
-}
-
 func TestWindowsScoopRelocatedSCOOPEnv(t *testing.T) {
 	isolateWindowsScoopConfig(t)
 	t.Setenv("SCOOP", `D:\tools`)
-	withWindowsExecPath(t, `D:\tools\apps\entire\current\entire.exe`)
+	setExecutablePath(t, `D:\tools\apps\entire\current\entire.exe`)
 
 	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
 		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopUpdateCmd)
@@ -161,18 +112,17 @@ func TestWindowsScoopRelocatedSCOOPEnv(t *testing.T) {
 func TestWindowsScoopRelocatedSCOOPEnvCLIAppMigrates(t *testing.T) {
 	isolateWindowsScoopConfig(t)
 	t.Setenv("SCOOP", `D:\tools`)
-	withWindowsExecPath(t, `D:\tools\apps\cli\current\entire.exe`)
+	setExecutablePath(t, `D:\tools\apps\cli\current\entire.exe`)
 
-	want := `cmd.exe /D /C "scoop install entire/entire && scoop uninstall entire/cli && scoop reset entire"`
-	if got := UpdateCommandForCurrentBinary("1.0.0"); got != want {
-		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, want)
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopMigrateCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopMigrateCmd)
 	}
 }
 
 func TestWindowsScoopRelocatedSCOOPGlobal(t *testing.T) {
 	isolateWindowsScoopConfig(t)
 	t.Setenv("SCOOP_GLOBAL", `D:\g`)
-	withWindowsExecPath(t, `D:\g\apps\entire\current\entire.exe`)
+	setExecutablePath(t, `D:\g\apps\entire\current\entire.exe`)
 
 	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
 		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopUpdateCmd)
@@ -188,7 +138,7 @@ func TestWindowsScoopRelocatedConfigRootPath(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"root_path":"D:\\from-config"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	withWindowsExecPath(t, `D:\from-config\apps\entire\current\entire.exe`)
+	setExecutablePath(t, `D:\from-config\apps\entire\current\entire.exe`)
 
 	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
 		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopUpdateCmd)
@@ -198,7 +148,7 @@ func TestWindowsScoopRelocatedConfigRootPath(t *testing.T) {
 func TestWindowsScoopRelocatedCaseInsensitive(t *testing.T) {
 	isolateWindowsScoopConfig(t)
 	t.Setenv("SCOOP", `d:\Tools`)
-	withWindowsExecPath(t, `D:\tools\apps\entire\current\entire.exe`)
+	setExecutablePath(t, `D:\tools\apps\entire\current\entire.exe`)
 
 	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
 		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopUpdateCmd)
@@ -207,7 +157,7 @@ func TestWindowsScoopRelocatedCaseInsensitive(t *testing.T) {
 
 func TestWindowsScoopDefaultMarkerStillMatches(t *testing.T) {
 	isolateWindowsScoopConfig(t)
-	withWindowsExecPath(t, `C:\Users\x\scoop\apps\entire\current\entire.exe`)
+	setExecutablePath(t, `C:\Users\x\scoop\apps\entire\current\entire.exe`)
 
 	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
 		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, scoopUpdateCmd)

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -97,7 +97,7 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			isolateWindowsScoopConfig(t)
+			isolateWindowsInstallEnv(t)
 			setExecutablePath(t, tt.execPath)
 
 			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {
@@ -117,18 +117,23 @@ func TestWindowsUpdateCommandWithoutExecPathOmitsInstallDir(t *testing.T) {
 	}
 }
 
-func isolateWindowsScoopConfig(t *testing.T) string {
+// isolateWindowsInstallEnv points every install-root lookup the probes make —
+// Scoop's env vars and config.json, mise's env vars — at an empty temp dir, so
+// a relocated Scoop or mise on the host cannot claim a test's exec path.
+func isolateWindowsInstallEnv(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	t.Setenv("USERPROFILE", dir)
 	t.Setenv("SCOOP", "")
 	t.Setenv("SCOOP_GLOBAL", "")
+	t.Setenv("MISE_INSTALLS_DIR", "")
+	t.Setenv("MISE_DATA_DIR", "")
 	return dir
 }
 
 func TestWindowsScoopRelocatedSCOOPEnv(t *testing.T) {
-	isolateWindowsScoopConfig(t)
+	isolateWindowsInstallEnv(t)
 	t.Setenv("SCOOP", `D:\tools`)
 	setExecutablePath(t, `D:\tools\apps\entire\current\entire.exe`)
 
@@ -138,7 +143,7 @@ func TestWindowsScoopRelocatedSCOOPEnv(t *testing.T) {
 }
 
 func TestWindowsScoopRelocatedSCOOPEnvCLIAppMigrates(t *testing.T) {
-	isolateWindowsScoopConfig(t)
+	isolateWindowsInstallEnv(t)
 	t.Setenv("SCOOP", `D:\tools`)
 	setExecutablePath(t, `D:\tools\apps\cli\current\entire.exe`)
 
@@ -148,7 +153,7 @@ func TestWindowsScoopRelocatedSCOOPEnvCLIAppMigrates(t *testing.T) {
 }
 
 func TestWindowsScoopRelocatedSCOOPGlobal(t *testing.T) {
-	isolateWindowsScoopConfig(t)
+	isolateWindowsInstallEnv(t)
 	t.Setenv("SCOOP_GLOBAL", `D:\g`)
 	setExecutablePath(t, `D:\g\apps\entire\current\entire.exe`)
 
@@ -158,7 +163,7 @@ func TestWindowsScoopRelocatedSCOOPGlobal(t *testing.T) {
 }
 
 func TestWindowsScoopRelocatedConfigRootPath(t *testing.T) {
-	dir := isolateWindowsScoopConfig(t)
+	dir := isolateWindowsInstallEnv(t)
 	cfgDir := filepath.Join(dir, "scoop")
 	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -174,7 +179,7 @@ func TestWindowsScoopRelocatedConfigRootPath(t *testing.T) {
 }
 
 func TestWindowsScoopRelocatedCaseInsensitive(t *testing.T) {
-	isolateWindowsScoopConfig(t)
+	isolateWindowsInstallEnv(t)
 	t.Setenv("SCOOP", `d:\Tools`)
 	setExecutablePath(t, `D:\tools\apps\entire\current\entire.exe`)
 
@@ -184,7 +189,7 @@ func TestWindowsScoopRelocatedCaseInsensitive(t *testing.T) {
 }
 
 func TestWindowsScoopDefaultMarkerStillMatches(t *testing.T) {
-	isolateWindowsScoopConfig(t)
+	isolateWindowsInstallEnv(t)
 	setExecutablePath(t, `C:\Users\x\scoop\apps\entire\current\entire.exe`)
 
 	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -213,3 +213,14 @@ func assertNoPOSIXInstallerNames(t *testing.T, cmd string) {
 		}
 	}
 }
+
+// The Windows commands are printed for the user to paste, and the install.ps1
+// one-liners only work in PowerShell, so every message that prints one has a
+// shell to name.
+func TestWindowsUpdateCommandShell(t *testing.T) {
+	t.Parallel()
+
+	if got := UpdateCommandShell(); got != "PowerShell" {
+		t.Errorf("UpdateCommandShell() = %q, want %q", got, "PowerShell")
+	}
+}

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -97,6 +97,7 @@ func TestWindowsUpdateCommandForCurrentBinary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			isolateWindowsScoopConfig(t)
 			setExecutablePath(t, tt.execPath)
 
 			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1201
<!-- entire-trail-link-end -->

Follow-up to #2152. Depends on #2152 (`feat/windows-powershell-installer`), which makes an explicit `-InstallDir` opt out of the Scoop-first default (322b4bf18), and documents these one-liner shapes (ec3bfeeff).

Users who installed via `install.ps1` currently get the GitHub releases page when Entire reports an update. This prints the README one-liner instead, naming the directory the running binary lives in so the installer replaces it in place:

```
iex "& {$(irm https://entire.io/install.ps1)} -InstallDir 'C:\Users\me\.local\bin' -NoPathUpdate"
iex "& {$(irm https://entire.io/install.ps1)} -Channel nightly -InstallDir 'C:\Users\me\.local\bin' -NoPathUpdate"
```

These are the README's shapes: bare `irm https://entire.io/install.ps1 | iex` when there is nothing to pass, and the `iex "& {...}"` form Scoop documents for options. Inside that double-quoted string the path's `$` and backtick are backtick-escaped and a quote is doubled, so the single-quoted `-InstallDir` literal reaches install.ps1 untouched. `-NoPathUpdate` keeps an update from rewriting the user PATH: without it the installer would add a Downloads directory permanently, duplicate a machine-PATH entry, or reorder which entire other terminals run. If a different entire is first on PATH the installer still completes and then exits non-zero naming the directory to prioritise. When the exec path is unavailable the hint is the bare one-liner and install.ps1 keeps its own default.

Windows still never auto-runs the installer. The hint reads "To update, run the following in PowerShell when entire is not running:" because the one-liner does not paste into cmd.exe. The checkpoint-policy call sites that also consume `UpdateCommandForCurrentBinary` share a cross-platform message with no room for the shell hint; they print the command as-is.

## Install detection

Detection is split into per-OS probe files (brew and mise on unix; Scoop and mise on Windows), so the runtime GOOS switch is gone and every OS has an update command. Scoop and mise honor relocated install roots (`SCOOP`, `SCOOP_GLOBAL`, Scoop's `config.json` `root_path`/`global_path`, `MISE_INSTALLS_DIR`, `MISE_DATA_DIR`). Path comparison is case-insensitive on Windows via the shared normalizer. The installer runner is per-OS too; the Windows stub deliberately does not shell through cmd.exe because the PowerShell one-liners would be split on `|` and `&`.

## Why `-InstallDir`

Without it, install.ps1 takes its Scoop branch whenever `scoop` is on PATH and a hand-placed binary would gain a sibling under `scoop\apps` while the old copy stays first on PATH. With the #2152 gate, an explicit `-InstallDir` selects the archive install and the binary is replaced where it is. On such a machine the installer's PATH-conflict report may still warn that a Scoop shim exists; that is the honest outcome.
