### PR TITLE
Fix stale lock cleanup

### DIFF
--- a/cmd/entire/cli/clean.go
+++ b/cmd/entire/cli/clean.go
@@ -345,7 +345,7 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 	}
 
 	// Group items by type for display
-	var branches, states, checkpoints, redactCaches []strategy.CleanupItem
+	var branches, states, checkpoints, redactCaches, lockFiles []strategy.CleanupItem
 	for _, item := range items {
 		switch item.Type {
 		case strategy.CleanupTypeShadowBranch:
@@ -356,6 +356,8 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 			checkpoints = append(checkpoints, item)
 		case strategy.CleanupTypeRedactCache:
 			redactCaches = append(redactCaches, item)
+		case strategy.CleanupTypeLockFile:
+			lockFiles = append(lockFiles, item)
 		}
 	}
 
@@ -368,6 +370,7 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 		printSection(w, "Session states", cleanupItemIDs(states))
 		printSection(w, "Checkpoint metadata", cleanupItemIDs(checkpoints))
 		printSection(w, "Redaction cache", cleanupItemIDs(redactCaches))
+		printSection(w, "Lock files", cleanupItemIDs(lockFiles))
 		printSection(w, "Temp files", tempFiles)
 		printSection(w, "Stray agent temp files", orphanTemps)
 		printUnscannedNote(w, unscanned)
@@ -409,8 +412,8 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 	failedTempFiles = append(failedTempFiles, failedOrphans...)
 
 	// Report results
-	totalDeleted := len(result.ShadowBranches) + len(result.SessionStates) + len(result.Checkpoints) + len(deletedTempFiles)
-	totalFailed := len(result.FailedBranches) + len(result.FailedStates) + len(result.FailedCheckpoints) + len(failedTempFiles)
+	totalDeleted := len(result.ShadowBranches) + len(result.SessionStates) + len(result.Checkpoints) + len(result.RedactCaches) + len(result.LockFiles) + len(deletedTempFiles)
+	totalFailed := len(result.FailedBranches) + len(result.FailedStates) + len(result.FailedCheckpoints) + len(result.FailedRedactCache) + len(result.FailedLockFiles) + len(failedTempFiles)
 
 	if totalDeleted > 0 {
 		fmt.Fprintf(w, "✓ Deleted %d %s:\n", totalDeleted, itemWord(totalDeleted))
@@ -418,6 +421,8 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 		printResultSection(w, "Shadow branches", result.ShadowBranches)
 		printResultSection(w, "Session states", result.SessionStates)
 		printResultSection(w, "Checkpoints", result.Checkpoints)
+		printResultSection(w, "Redaction cache", result.RedactCaches)
+		printResultSection(w, "Lock files", result.LockFiles)
 
 		printResultSection(w, "Temp files", deletedTempFiles)
 		printResultSection(w, "Stray agent temp files", deletedOrphans)
@@ -430,6 +435,8 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 		printResultSection(errW, "Shadow branches", result.FailedBranches)
 		printResultSection(errW, "Session states", result.FailedStates)
 		printResultSection(errW, "Checkpoints", result.FailedCheckpoints)
+		printResultSection(errW, "Redaction cache", result.FailedRedactCache)
+		printResultSection(errW, "Lock files", result.FailedLockFiles)
 
 		if len(failedTempFiles) > 0 {
 			fmt.Fprintf(errW, "\nTemp files:\n")

--- a/cmd/entire/cli/clean.go
+++ b/cmd/entire/cli/clean.go
@@ -294,6 +294,23 @@ func runCleanAll(ctx context.Context, cmd *cobra.Command, force, dryRun bool) er
 		unscanned = append(unscanned, "stray agent temp files")
 	}
 
+	if !force && !dryRun {
+		activeSessions, err := activeSessionsInRepository(ctx)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not check for active sessions: %v\n", err)
+			fmt.Fprintln(cmd.ErrOrStderr(), "Use --force to override.")
+			return nil
+		}
+		if len(activeSessions) > 0 {
+			fmt.Fprintln(cmd.ErrOrStderr(), "Active sessions detected:")
+			for _, s := range activeSessions {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  %s (phase: %s)\n", s.SessionID, s.Phase)
+			}
+			fmt.Fprintln(cmd.ErrOrStderr(), "Use --force to override or wait for sessions to finish.")
+			return nil
+		}
+	}
+
 	return runCleanAllWithItems(ctx, cmd, force, dryRun, items, tempFiles, orphanTemps, unscanned)
 }
 
@@ -413,6 +430,7 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 
 	// Report results
 	totalDeleted := len(result.ShadowBranches) + len(result.SessionStates) + len(result.Checkpoints) + len(result.RedactCaches) + len(result.LockFiles) + len(deletedTempFiles)
+	totalSkipped := len(result.SkippedLockFiles)
 	totalFailed := len(result.FailedBranches) + len(result.FailedStates) + len(result.FailedCheckpoints) + len(result.FailedRedactCache) + len(result.FailedLockFiles) + len(failedTempFiles)
 
 	if totalDeleted > 0 {
@@ -428,6 +446,11 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 		printResultSection(w, "Stray agent temp files", deletedOrphans)
 	}
 	printUnscannedNote(w, unscanned)
+
+	if totalSkipped > 0 {
+		fmt.Fprintf(w, "\nSkipped %d active %s:\n", totalSkipped, itemWord(totalSkipped))
+		printResultSection(w, "Lock files", result.SkippedLockFiles)
+	}
 
 	if totalFailed > 0 {
 		fmt.Fprintf(errW, "\nFailed to delete %d %s:\n", totalFailed, itemWord(totalFailed))
@@ -653,6 +676,22 @@ func activeSessionsOnCurrentHead(ctx context.Context) ([]*session.State, error) 
 		if state.BaseCommit != currentHead {
 			continue
 		}
+		if state.Phase.IsActive() {
+			active = append(active, state)
+		}
+	}
+
+	return active, nil
+}
+
+func activeSessionsInRepository(ctx context.Context) ([]*session.State, error) {
+	states, err := strategy.ListSessionStates(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list session states: %w", err)
+	}
+
+	var active []*session.State
+	for _, state := range states {
 		if state.Phase.IsActive() {
 			active = append(active, state)
 		}

--- a/cmd/entire/cli/clean_test.go
+++ b/cmd/entire/cli/clean_test.go
@@ -13,8 +13,10 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/go-git/go-git/v6"
@@ -529,6 +531,40 @@ func TestCleanCmd_All_ForceMode(t *testing.T) {
 	}
 }
 
+func TestCleanCmd_All_ActiveSessionGuard(t *testing.T) {
+	_, commitHash := setupCleanTestRepo(t)
+
+	if err := strategy.SaveSessionState(context.Background(), &strategy.SessionState{
+		SessionID:  "active-session",
+		BaseCommit: commitHash.String(),
+		StartedAt:  time.Now(),
+		Phase:      session.PhaseActive,
+	}); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+
+	cmd := newCleanCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--all"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("clean --all error = %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Active sessions detected") {
+		t.Fatalf("expected active-session warning, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+
+	states, err := strategy.ListSessionStates(context.Background())
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("active session should be preserved, got %d states", len(states))
+	}
+}
+
 func TestCleanCmd_All_SessionsBranchPreserved(t *testing.T) {
 	repo, commitHash := setupCleanTestRepo(t)
 
@@ -770,6 +806,40 @@ func TestRunCleanAllWithItems_AllFailures(t *testing.T) {
 	errOutput := stderr.String()
 	if !strings.Contains(errOutput, "Failed to delete 2 items:") {
 		t.Errorf("Stderr should show 'Failed to delete 2 items:', got: %s", errOutput)
+	}
+}
+
+func TestRunCleanAllWithItems_SkippedLockFilesDoNotFail(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+
+	lockID := filepath.Join("entire-shadow-locks", "held.lock")
+	lockPath := filepath.Join(dir, ".git", lockID)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		t.Fatalf("mkdir lock dir: %v", err)
+	}
+	release, err := flock.Acquire(lockPath)
+	if err != nil {
+		t.Fatalf("acquire lock: %v", err)
+	}
+	defer release()
+
+	items := []strategy.CleanupItem{
+		{Type: strategy.CleanupTypeLockFile, ID: lockID, Reason: "test"},
+	}
+
+	cmd, stdout, stderr := newTestCleanCmd(t)
+	err = runCleanAllWithItems(cmd.Context(), cmd, true, false, items, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("runCleanAllWithItems() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Skipped 1 active item") {
+		t.Fatalf("expected skipped lock output, got: %s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got: %s", stderr.String())
 	}
 }
 

--- a/cmd/entire/cli/internal/flock/flock_unix.go
+++ b/cmd/entire/cli/internal/flock/flock_unix.go
@@ -22,8 +22,8 @@ const pollInterval = 25 * time.Millisecond
 // Acquire takes an exclusive advisory lock on path, creating the file if
 // needed. The returned release closes the file, which drops the flock.
 // Callers must invoke release exactly once. The lock file persists between
-// runs — flock state is held by the file descriptor, not by the inode on
-// disk — so the lockfile contents are immaterial.
+// runs - flock state is held by the file descriptor, not by the inode on
+// disk - so the lockfile contents are immaterial.
 //
 // Acquire blocks indefinitely until the lock is available. Use AcquireContext
 // with a deadline to bound the wait.
@@ -39,11 +39,15 @@ func Acquire(path string) (release func(), err error) {
 // (turn-start) bound their wait and degrade gracefully instead of stalling
 // behind a long-running lock holder (e.g. checkpoint condensation).
 func AcquireContext(ctx context.Context, path string) (release func(), err error) {
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec // caller is responsible for path validation
-	if err != nil {
-		return nil, fmt.Errorf("open flock: %w", err)
-	}
-	return lockFile(ctx, f)
+	return lockFile(ctx, func() (*os.File, error) {
+		f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec // caller is responsible for path validation
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	}, func(f *os.File) (bool, error) {
+		return holdsCurrentPathInode(f, path)
+	})
 }
 
 // AcquireIn is Acquire for a lock file named inside root. It is the form the
@@ -56,46 +60,105 @@ func AcquireIn(root *os.Root, name string) (release func(), err error) {
 
 // AcquireContextIn is AcquireContext for a lock file named inside root.
 func AcquireContextIn(ctx context.Context, root *os.Root, name string) (release func(), err error) {
-	f, err := openLockFileIn(root, name)
-	if err != nil {
-		return nil, fmt.Errorf("open flock: %w", err)
-	}
-	return lockFile(ctx, f)
+	return lockFile(ctx, func() (*os.File, error) {
+		return openLockFileIn(root, name)
+	}, func(f *os.File) (bool, error) {
+		return holdsCurrentRootInode(f, root, name)
+	})
 }
 
 // lockFile holds the locking logic shared by the path- and root-based entry
-// points, which differ only in how the file was opened.
-func lockFile(ctx context.Context, f *os.File) (release func(), err error) {
-	// Fast path: no deadline -> block in the kernel exactly like the historical
-	// Acquire. This preserves behavior (and efficiency) for callers that must
-	// wait as long as it takes, such as turn-end checkpoint condensation.
+// points, which differ only in how the file is opened and revalidated.
+func lockFile(ctx context.Context, open func() (*os.File, error), holdsCurrent func(*os.File) (bool, error)) (release func(), err error) {
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil { //nolint:gosec // file descriptors are non-negative; standard Go pattern for syscall.Flock
+		for {
+			f, err := open()
+			if err != nil {
+				return nil, fmt.Errorf("open flock: %w", err)
+			}
+			if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil { //nolint:gosec // file descriptors are non-negative; standard Go pattern for syscall.Flock
+				_ = f.Close()
+				return nil, fmt.Errorf("flock: %w", err)
+			}
+			current, err := holdsCurrent(f)
+			if err != nil {
+				_ = f.Close()
+				return nil, err
+			}
+			if current {
+				return func() { _ = f.Close() }, nil
+			}
 			_ = f.Close()
-			return nil, fmt.Errorf("flock: %w", err)
 		}
-		return func() { _ = f.Close() }, nil
 	}
 
-	// Bounded path: poll a non-blocking lock until acquired or ctx is done.
 	for {
+		f, err := open()
+		if err != nil {
+			return nil, fmt.Errorf("open flock: %w", err)
+		}
 		lockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB) //nolint:gosec // see above
 		if lockErr == nil {
-			return func() { _ = f.Close() }, nil
-		}
-		if !errors.Is(lockErr, syscall.EWOULDBLOCK) {
+			current, err := holdsCurrent(f)
+			if err != nil {
+				_ = f.Close()
+				return nil, err
+			}
+			if current {
+				return func() { _ = f.Close() }, nil
+			}
 			_ = f.Close()
+			continue
+		}
+		_ = f.Close()
+		if !errors.Is(lockErr, syscall.EWOULDBLOCK) {
 			return nil, fmt.Errorf("flock: %w", lockErr)
 		}
 		if err := ctx.Err(); err != nil {
-			_ = f.Close()
 			return nil, fmt.Errorf("flock: %w", err)
 		}
 		select {
 		case <-ctx.Done():
-			_ = f.Close()
 			return nil, fmt.Errorf("flock: %w", ctx.Err())
 		case <-time.After(pollInterval):
 		}
 	}
+}
+
+func holdsCurrentPathInode(f *os.File, path string) (bool, error) {
+	pathInfo, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat flock path: %w", err)
+	}
+	return sameInode(f, pathInfo, "path")
+}
+
+func holdsCurrentRootInode(f *os.File, root *os.Root, name string) (bool, error) {
+	pathInfo, err := root.Stat(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat flock root path: %w", err)
+	}
+	return sameInode(f, pathInfo, "root path")
+}
+
+func sameInode(f *os.File, pathInfo os.FileInfo, label string) (bool, error) {
+	heldInfo, err := f.Stat()
+	if err != nil {
+		return false, fmt.Errorf("stat flock fd: %w", err)
+	}
+	held, ok := heldInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, fmt.Errorf("stat flock fd: unexpected stat type %T", heldInfo.Sys())
+	}
+	current, ok := pathInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, fmt.Errorf("stat flock %s: unexpected stat type %T", label, pathInfo.Sys())
+	}
+	return held.Dev == current.Dev && held.Ino == current.Ino, nil
 }

--- a/cmd/entire/cli/internal/flock/flock_unix_test.go
+++ b/cmd/entire/cli/internal/flock/flock_unix_test.go
@@ -1,0 +1,111 @@
+//go:build unix
+
+package flock
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAcquireRevalidatesReplacedLockFileInode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resource.lock")
+
+	releaseOld, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire old lock: %v", err)
+	}
+
+	waiter := make(chan func(), 1)
+	errs := make(chan error, 1)
+	go func() {
+		release, err := Acquire(path)
+		if err != nil {
+			errs <- err
+			return
+		}
+		waiter <- release
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove old lock path: %v", err)
+	}
+
+	releaseNew, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire new lock: %v", err)
+	}
+
+	releaseOld()
+
+	select {
+	case release := <-waiter:
+		release()
+		t.Fatal("waiter acquired the unlinked inode while the current lock file was held")
+	case err := <-errs:
+		t.Fatalf("waiter failed: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	releaseNew()
+
+	select {
+	case release := <-waiter:
+		release()
+	case err := <-errs:
+		t.Fatalf("waiter failed: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter did not acquire after current lock was released")
+	}
+}
+
+func TestAcquireContextRevalidatesReplacedLockFileInode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resource.lock")
+
+	releaseOld, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire old lock: %v", err)
+	}
+
+	waiter := make(chan func(), 1)
+	errs := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		release, err := AcquireContext(ctx, path)
+		if err != nil {
+			errs <- err
+			return
+		}
+		waiter <- release
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove old lock path: %v", err)
+	}
+
+	releaseNew, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire new lock: %v", err)
+	}
+	defer releaseNew()
+
+	releaseOld()
+
+	select {
+	case release := <-waiter:
+		release()
+		t.Fatal("waiter acquired the unlinked inode while the current lock file was held")
+	case err := <-errs:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("waiter error = %v, want context deadline exceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter did not time out while current lock was held")
+	}
+}

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/gitdir"
+	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -33,6 +35,7 @@ const (
 	// Purely derived data -- it is rebuilt on the next checkpoint -- so it is
 	// removed wholesale rather than per entry.
 	CleanupTypeRedactCache CleanupType = "redact-cache"
+	CleanupTypeLockFile    CleanupType = "lock-file"
 )
 
 // CleanupItem represents an item that can be cleaned up.
@@ -45,6 +48,7 @@ type CleanupItem struct {
 // CleanupResult contains the results of a cleanup operation.
 type CleanupResult struct {
 	RedactCaches      []string // Deleted redaction prefix cache directories
+	LockFiles         []string // Deleted stale lock files
 	ShadowBranches    []string // Deleted shadow branches
 	SessionStates     []string // Deleted session state files
 	Checkpoints       []string // Deleted checkpoint metadata
@@ -52,6 +56,8 @@ type CleanupResult struct {
 	FailedStates      []string // Session states that failed to delete
 	FailedCheckpoints []string // Checkpoints that failed to delete
 	FailedRedactCache []string // Redaction caches that failed to delete
+	FailedLockFiles   []string // Lock files that failed to delete
+	SkippedLockFiles  []string // Lock files preserved because they are actively held
 }
 
 // shadowBranchPattern matches shadow branch names in both old and new formats:
@@ -86,6 +92,13 @@ var shadowBranchPattern = regexp.MustCompile(`^entire/[0-9a-fA-F]{7,}(-[0-9a-fA-
 // legacy naming from before the worktree-hash suffix was introduced --
 // see isAutoDeletableShadowBranch's doc comment for why.
 var autoDeletableShadowBranchPattern = regexp.MustCompile(`^entire/[0-9a-fA-F]{7,}-[0-9a-fA-F]{6}$`)
+
+var cleanupLockDirs = []string{
+	"entire-shadow-locks",
+	"entire-persistent-ref-locks",
+}
+
+var errCleanupLockHeld = errors.New("cleanup lock held")
 
 // IsShadowBranch returns true if the branch name matches the shadow branch pattern.
 // Shadow branches have the format "entire/<commit-hash>-<worktree-hash>" where the
@@ -536,6 +549,18 @@ func ListAllItems(ctx context.Context) ([]CleanupItem, error) {
 		}
 	}
 
+	lockFiles, err := listCleanupLockFiles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing lock files: %w", err)
+	}
+	for _, lockFile := range lockFiles {
+		cleanupItems = append(cleanupItems, CleanupItem{
+			Type:   CleanupTypeLockFile,
+			ID:     lockFile,
+			Reason: "clean all",
+		})
+	}
+
 	return cleanupItems, nil
 }
 
@@ -547,6 +572,37 @@ func redactCacheDir(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("resolve git common dir: %w", err)
 	}
 	return filepath.Join(commonDir, checkpoint.RedactCacheDirName), nil
+}
+
+func listCleanupLockFiles(ctx context.Context) ([]string, error) {
+	commonDir, err := session.GetGitCommonDir(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve git common dir: %w", err)
+	}
+
+	var lockFiles []string
+	for _, dirName := range cleanupLockDirs {
+		dir := filepath.Join(commonDir, dirName)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			logging.Debug(ctx, "skipping unreadable lock directory",
+				slog.String("dir", dirName),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			lockFiles = append(lockFiles, filepath.Join(dirName, entry.Name()))
+		}
+	}
+	sort.Strings(lockFiles)
+	return lockFiles, nil
 }
 
 // DeleteAllCleanupItems deletes all specified cleanup items.
@@ -562,7 +618,7 @@ func DeleteAllCleanupItems(ctx context.Context, items []CleanupItem) (*CleanupRe
 	}
 
 	// Group items by type
-	var branches, states, checkpoints, redactCaches []string
+	var branches, states, checkpoints, redactCaches, lockFiles []string
 	for _, item := range items {
 		switch item.Type {
 		case CleanupTypeShadowBranch:
@@ -573,6 +629,8 @@ func DeleteAllCleanupItems(ctx context.Context, items []CleanupItem) (*CleanupRe
 			redactCaches = append(redactCaches, item.ID)
 		case CleanupTypeCheckpoint:
 			checkpoints = append(checkpoints, item.ID)
+		case CleanupTypeLockFile:
+			lockFiles = append(lockFiles, item.ID)
 		}
 	}
 
@@ -672,17 +730,54 @@ func DeleteAllCleanupItems(ctx context.Context, items []CleanupItem) (*CleanupRe
 		}
 	}
 
+	if len(lockFiles) > 0 {
+		deleted, skipped, failed, err := deleteCleanupLockFiles(ctx, lockFiles)
+		if err != nil {
+			return result, err
+		}
+		result.LockFiles = deleted
+		result.SkippedLockFiles = skipped
+		result.FailedLockFiles = failed
+
+		for _, id := range deleted {
+			logging.Info(logCtx, "deleted lock file",
+				slog.String("type", string(CleanupTypeLockFile)),
+				slog.String("id", id),
+				slog.String("reason", reasonMap[id]),
+			)
+		}
+		for _, id := range skipped {
+			logging.Info(logCtx, "skipped active lock file",
+				slog.String("type", string(CleanupTypeLockFile)),
+				slog.String("id", id),
+				slog.String("reason", reasonMap[id]),
+			)
+		}
+		for _, id := range failed {
+			logging.Warn(logCtx, "failed to delete lock file",
+				slog.String("type", string(CleanupTypeLockFile)),
+				slog.String("id", id),
+				slog.String("reason", reasonMap[id]),
+			)
+		}
+	}
+
 	// Log summary
-	totalDeleted := len(result.ShadowBranches) + len(result.SessionStates) + len(result.Checkpoints)
-	totalFailed := len(result.FailedBranches) + len(result.FailedStates) + len(result.FailedCheckpoints)
+	totalDeleted := len(result.ShadowBranches) + len(result.SessionStates) + len(result.Checkpoints) + len(result.RedactCaches) + len(result.LockFiles)
+	totalFailed := len(result.FailedBranches) + len(result.FailedStates) + len(result.FailedCheckpoints) + len(result.FailedRedactCache) + len(result.FailedLockFiles)
 	if totalDeleted > 0 || totalFailed > 0 {
 		logging.Info(logCtx, "cleanup completed",
 			slog.Int("deleted_branches", len(result.ShadowBranches)),
 			slog.Int("deleted_session_states", len(result.SessionStates)),
 			slog.Int("deleted_checkpoints", len(result.Checkpoints)),
+			slog.Int("deleted_redact_caches", len(result.RedactCaches)),
+			slog.Int("deleted_lock_files", len(result.LockFiles)),
+			slog.Int("skipped_lock_files", len(result.SkippedLockFiles)),
 			slog.Int("failed_branches", len(result.FailedBranches)),
 			slog.Int("failed_session_states", len(result.FailedStates)),
 			slog.Int("failed_checkpoints", len(result.FailedCheckpoints)),
+			slog.Int("failed_redact_caches", len(result.FailedRedactCache)),
+			slog.Int("failed_lock_files", len(result.FailedLockFiles)),
 		)
 	}
 
@@ -705,4 +800,66 @@ func deleteRedactCache(ctx context.Context) error {
 		return fmt.Errorf("remove redaction cache %s: %w", dir, err)
 	}
 	return nil
+}
+
+func deleteCleanupLockFiles(ctx context.Context, lockFiles []string) (deleted []string, skipped []string, failed []string, err error) {
+	commonDir, err := session.GetGitCommonDir(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("resolve git common dir: %w", err)
+	}
+
+	for _, lockFile := range lockFiles {
+		if !isCleanupLockFileID(lockFile) {
+			failed = append(failed, lockFile)
+			continue
+		}
+
+		path := filepath.Join(commonDir, lockFile)
+		release, err := tryAcquireCleanupLock(ctx, path)
+		if err != nil {
+			if errors.Is(err, errCleanupLockHeld) {
+				skipped = append(skipped, lockFile)
+				continue
+			}
+			failed = append(failed, lockFile)
+			continue
+		}
+		removeErr := removeAcquiredCleanupLockFile(path, release)
+		if removeErr != nil {
+			if os.IsNotExist(removeErr) {
+				deleted = append(deleted, lockFile)
+				continue
+			}
+			failed = append(failed, lockFile)
+			continue
+		}
+		deleted = append(deleted, lockFile)
+	}
+	return deleted, skipped, failed, nil
+}
+
+func isCleanupLockFileID(lockFile string) bool {
+	cleaned := filepath.Clean(lockFile)
+	if cleaned != lockFile || filepath.IsAbs(lockFile) {
+		return false
+	}
+	for _, dirName := range cleanupLockDirs {
+		if filepath.Dir(lockFile) == dirName && filepath.Base(lockFile) != "." {
+			return true
+		}
+	}
+	return false
+}
+
+func tryAcquireCleanupLock(ctx context.Context, path string) (func(), error) {
+	lockCtx, cancel := context.WithTimeout(ctx, 0)
+	defer cancel()
+	release, err := flock.AcquireContext(lockCtx, path)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, errCleanupLockHeld
+		}
+		return nil, fmt.Errorf("acquire cleanup lock: %w", err)
+	}
+	return release, nil
 }

--- a/cmd/entire/cli/strategy/cleanup_lock_files_test.go
+++ b/cmd/entire/cli/strategy/cleanup_lock_files_test.go
@@ -43,6 +43,7 @@ func TestLockFiles_ListedAndDeletedByCleanAll(t *testing.T) {
 		filepath.Join("entire-shadow-locks", "entire_deadbeef.lock"),
 		filepath.Join("entire-persistent-ref-locks", "refs_heads_entire_checkpoints_v1.lock"),
 	}, result.LockFiles)
+	require.Empty(t, result.SkippedLockFiles)
 	require.Empty(t, result.FailedLockFiles)
 	require.NoFileExists(t, shadowLock)
 	require.NoFileExists(t, persistentLock)

--- a/cmd/entire/cli/strategy/cleanup_lock_files_test.go
+++ b/cmd/entire/cli/strategy/cleanup_lock_files_test.go
@@ -1,0 +1,74 @@
+package strategy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLockFiles_ListedAndDeletedByCleanAll covers stale lock files in the git
+// common dir. They are only coordination sentinels, so unlocked files should not
+// survive `entire clean` indefinitely.
+//
+// Not parallel: t.Chdir sets process-global state.
+func TestLockFiles_ListedAndDeletedByCleanAll(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+
+	ctx := context.Background()
+	shadowLock := filepath.Join(tmpDir, ".git", "entire-shadow-locks", "entire_deadbeef.lock")
+	persistentLock := filepath.Join(tmpDir, ".git", "entire-persistent-ref-locks", "refs_heads_entire_checkpoints_v1.lock")
+	require.NoError(t, os.MkdirAll(filepath.Dir(shadowLock), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Dir(persistentLock), 0o700))
+	require.NoError(t, os.WriteFile(shadowLock, nil, 0o600))
+	require.NoError(t, os.WriteFile(persistentLock, nil, 0o600))
+
+	items, err := ListAllItems(ctx)
+	require.NoError(t, err)
+	require.Contains(t, cleanupItemTypes(items), CleanupTypeLockFile)
+
+	result, err := DeleteAllCleanupItems(ctx, items)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		filepath.Join("entire-shadow-locks", "entire_deadbeef.lock"),
+		filepath.Join("entire-persistent-ref-locks", "refs_heads_entire_checkpoints_v1.lock"),
+	}, result.LockFiles)
+	require.Empty(t, result.FailedLockFiles)
+	require.NoFileExists(t, shadowLock)
+	require.NoFileExists(t, persistentLock)
+}
+
+// TestDeleteCleanupLockFiles_HeldLockIsPreserved verifies that cleanup never
+// unlinks a file while another process still holds the advisory lock.
+func TestDeleteCleanupLockFiles_HeldLockIsPreserved(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+
+	lockID := filepath.Join("entire-shadow-locks", "held.lock")
+	lockPath := filepath.Join(tmpDir, ".git", lockID)
+	require.NoError(t, os.MkdirAll(filepath.Dir(lockPath), 0o700))
+	release, err := flock.Acquire(lockPath)
+	require.NoError(t, err)
+	defer release()
+
+	deleted, skipped, failed, err := deleteCleanupLockFiles(context.Background(), []string{lockID})
+	require.NoError(t, err)
+	require.Empty(t, deleted)
+	require.Equal(t, []string{lockID}, skipped)
+	require.Empty(t, failed)
+	require.FileExists(t, lockPath)
+}

--- a/cmd/entire/cli/strategy/cleanup_lock_unix.go
+++ b/cmd/entire/cli/strategy/cleanup_lock_unix.go
@@ -1,0 +1,11 @@
+//go:build unix
+
+package strategy
+
+import "os"
+
+func removeAcquiredCleanupLockFile(path string, release func()) error {
+	err := os.Remove(path)
+	release()
+	return err
+}

--- a/cmd/entire/cli/strategy/cleanup_lock_windows.go
+++ b/cmd/entire/cli/strategy/cleanup_lock_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package strategy
+
+import "os"
+
+func removeAcquiredCleanupLockFile(path string, release func()) error {
+	release()
+	return os.Remove(path)
+}


### PR DESCRIPTION
Closes #2197.

## Summary

Adds cleanup support for stale lock files created under the git common dir:

- `entire-shadow-locks`
- `entire-persistent-ref-locks`

`entire clean --all` now discovers those lock files, reports them in dry-run output, and includes them in deletion summaries.

## Review follow-up

This update addresses the lock-safety review feedback:

- Revalidates Unix flock acquisitions against the current lock-file inode before returning from both blocking `Acquire` and bounded `AcquireContext` paths.
- Moves stale lock cleanup to run after shadow branch, session state, and checkpoint cleanup so normal cleanup operations use their locks first.
- Treats actively held lock files as skipped, not failed, so live sessions do not make `entire clean --all` exit non-zero just because a lock is busy.
- Adds an active-session guard for `entire clean --all` unless `--force` or `--dry-run` is used.
- Keeps lock-directory listing best-effort if one lock directory is unreadable.
- Uses platform-specific lock-file removal ordering for Unix and Windows.

## Tests

```bash
GOCACHE=/private/tmp/entire-go-build-cache go test ./cmd/entire/cli/internal/flock ./cmd/entire/cli/strategy
GOCACHE=/private/tmp/entire-go-build-cache go test ./cmd/entire/cli -run TestClean
GOCACHE=/private/tmp/entire-go-build-cache go test ./cmd/entire/...
GOCACHE=/private/tmp/entire-go-build-cache go build ./cmd/entire
git diff --check
```
