### PR TITLE
Expand on os.Root coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -891,7 +891,12 @@ comments at each site say which case applies:
   symlink that *escapes* a root but follows one pointing elsewhere *inside* it,
   and an escaping one otherwise fails later with an opaque errno far from the
   cause. `entire doctor` reports what is already there
-  (`checkEntireDirSymlinks`). `.entire` **itself is refused too**: `entiredir`
+  (`checkEntireDirSymlinks` for `.entire`, `checkAgentDirSymlinks` for every path
+  Entire creates or writes on an agent's behalf — derived from
+  `agent.HookConfigLocator` and the scaffold templates, deliberately not from
+  `ProtectedDirs`, which both misses the levels Entire creates under an agent's
+  directory and includes directories it never writes to). `.entire` **itself is
+  refused too**: `entiredir`
   opens it as a checked child of the worktree root (`osroot.SharedChild`), which
   `Lstat`s before and `SameFile`s after. An earlier revision allowed it on the
   grounds that `os.OpenRoot` follows a symlinked root and an existing setup
@@ -912,11 +917,18 @@ comments at each site say which case applies:
   through it — and uninstall `RemoveAll` through it — without the user ever
   naming pi. Its uninstall is also the one caller of
   `HookConfigFile.RemoveDir`, because pi discovers extensions by directory, so
-  removing only the file would leave a half-uninstalled extension behind. The config FILE may still be a symlink — pointing
-  `.claude/settings.json` at a dotfile repo is a real setup — with one behaviour
-  change worth knowing: an **absolute** link there no longer resolves, since
-  `os.Root` refuses absolute symlinks unconditionally. A relative one inside the
-  worktree still works.
+  removing only the file would leave a half-uninstalled extension behind.
+
+  The config FILE is refused too, not just its parents: the merge READ would
+  otherwise pull the link target's contents into
+  what Entire then writes, and the write is a rename, which replaces the link
+  with a regular file rather than following it. Both happen silently, so
+  refusing is the legible version of the same outcome. Pointing
+  `.claude/settings.json` at a dotfile repo is still a real setup — it just has
+  to stay out of the repository (`git rm --cached` plus a .gitignore entry),
+  which is what makes it the developer's rather than the checkout's.
+  `checkAgentDirSymlinks` reports every one of these paths, so the condition is
+  named rather than showing up as hooks that mysteriously will not install.
 
   **A symlinked agent DIRECTORY is refused by every operation, not just the ones
   that create.** `os.Root` blocks a link that escapes the worktree and follows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -778,7 +778,7 @@ to `os.ReadFile`/`os.WriteFile`/`os.MkdirAll`/`os.ReadDir`/`filepath.Walk`.**
 | `.entire` | `entiredir` | worktree root (`paths.WorktreeRoot`), cwd only when there is provably no repo |
 | git common dir | `gitdir` | `git rev-parse --git-common-dir`, absolutized |
 | the working tree | `worktreedir` | worktree root |
-| an agent's hook config | `agent.HookConfigFile` | worktree root (`.claude/`, `.cursor/`, `.gemini/`, `.github/hooks/`, `.factory/`, `.codex/`, `.opencode/plugin/`) |
+| an agent's hook config | `agent.HookConfigFile` | worktree root (`.claude/`, `.cursor/`, `.gemini/`, `.github/hooks/`, `.factory/`, `.codex/`, `.opencode/plugins/`, `.pi/extensions/entire/`) |
 | an agent's session store | `agent.SessionStore` | the agent's own `GetSessionDir` |
 | per-user config / cache | `userdirs.ConfigRoot` / `CacheRoot` | `$ENTIRE_CONFIG_DIR` else `~/.config/entire`; `$XDG_CACHE_HOME/entire` else `~/.cache/entire` |
 | managed plugin tree | `pluginRoot` (`plugin_store.go`) | `pluginParentDir()` — `$ENTIRE_PLUGIN_DIR`, `%LOCALAPPDATA%`, or `$XDG_DATA_HOME` |
@@ -902,9 +902,17 @@ comments at each site say which case applies:
   stopped rather than that the setup is fine.
   The agent hook-config directories get the same treatment via
   `agent.HookConfigFile`: a symlinked `.claude` / `.cursor` / `.gemini` /
-  `.codex` is refused at the create, because a working tree arrives by clone and
-  `entire enable` must not create directories and write JSON through a link the
-  repository supplied. The config FILE may still be a symlink — pointing
+  `.codex` / `.pi` is refused at the create, because a working tree arrives by
+  clone and `entire enable` must not create directories and write JSON through a
+  link the repository supplied. Pi was the last agent still joining its path onto
+  the repo root and calling `os.ReadFile` / `os.MkdirAll` / `os.WriteFile` /
+  `os.RemoveAll` on the result, which was worse there than for the settings-file
+  agents because pi is **auto-detected**: `DetectPresence` stats `.pi`, which
+  follows the link, so a repository shipping one had `entire enable` install
+  through it — and uninstall `RemoveAll` through it — without the user ever
+  naming pi. Its uninstall is also the one caller of
+  `HookConfigFile.RemoveDir`, because pi discovers extensions by directory, so
+  removing only the file would leave a half-uninstalled extension behind. The config FILE may still be a symlink — pointing
   `.claude/settings.json` at a dotfile repo is a real setup — with one behaviour
   change worth knowing: an **absolute** link there no longer resolves, since
   `os.Root` refuses absolute symlinks unconditionally. A relative one inside the

--- a/cmd/entire/cli/agent/claudecode/hooks.go
+++ b/cmd/entire/cli/agent/claudecode/hooks.go
@@ -18,6 +18,7 @@ import (
 // Ensure ClaudeCodeAgent implements HookSupport
 var (
 	_ agent.HookSupport           = (*ClaudeCodeAgent)(nil)
+	_ agent.HookConfigLocator     = (*ClaudeCodeAgent)(nil)
 	_ agent.HookFreshness         = (*ClaudeCodeAgent)(nil)
 	_ agent.PermissionConfigOwner = (*ClaudeCodeAgent)(nil)
 )
@@ -107,7 +108,7 @@ func claudeHookConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	return agent.OpenHookConfig(repoRoot, ".claude/"+ClaudeSettingsFileName) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
+	return agent.OpenHookConfig(repoRoot, (&ClaudeCodeAgent{}).HookConfigRelPath()) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 }
 
 // resolveInstallRepoRoot locates the repo root InstallHooks writes under,
@@ -686,3 +687,6 @@ func removeEntireHooksFromMatchers(matchers []ClaudeHookMatcher) []ClaudeHookMat
 func (c *ClaudeCodeAgent) PermissionConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 	return claudeHookConfig(ctx)
 }
+
+// HookConfigRelPath implements agent.HookConfigLocator.
+func (c *ClaudeCodeAgent) HookConfigRelPath() string { return ".claude/" + ClaudeSettingsFileName }

--- a/cmd/entire/cli/agent/codex/hook_root.go
+++ b/cmd/entire/cli/agent/codex/hook_root.go
@@ -218,7 +218,7 @@ func (p WorktreeHooksPath) Path() string {
 // `.codex` a NAME inside the worktree, which is what MkdirAllNoSymlink can
 // refuse. It also covers the writes, which had no root at all.
 func (p WorktreeHooksPath) hookConfig() (*agent.HookConfigFile, error) {
-	return agent.OpenHookConfig(p.worktreeRoot, ".codex/"+HooksFileName) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
+	return agent.OpenHookConfig(p.worktreeRoot, (&CodexAgent{}).HookConfigRelPath()) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 }
 
 // ResolveWorktreeHooksPath resolves the hooks file owned by the current

--- a/cmd/entire/cli/agent/codex/hooks.go
+++ b/cmd/entire/cli/agent/codex/hooks.go
@@ -534,7 +534,7 @@ func hooksDocumentRoot(path string) (*os.Root, string, error) {
 		return nil, "", fmt.Errorf("codex hooks path %q is not a .codex/%s", path, HooksFileName)
 	}
 	projectRoot := strings.TrimSuffix(path, string(filepath.Separator)+name)
-	cfg, err := agent.OpenHookConfig(projectRoot, ".codex/"+HooksFileName)
+	cfg, err := agent.OpenHookConfig(projectRoot, (&CodexAgent{}).HookConfigRelPath())
 	if err != nil {
 		return nil, "", err //nolint:wrapcheck // caller names the path it asked about
 	}
@@ -790,3 +790,6 @@ func removeEntireHooks(groups []MatcherGroup) []MatcherGroup {
 	}
 	return result
 }
+
+// HookConfigRelPath implements agent.HookConfigLocator.
+func (c *CodexAgent) HookConfigRelPath() string { return ".codex/" + HooksFileName }

--- a/cmd/entire/cli/agent/codex/lifecycle.go
+++ b/cmd/entire/cli/agent/codex/lifecycle.go
@@ -14,6 +14,7 @@ import (
 // Compile-time interface assertions.
 var (
 	_ agent.HookSupport              = (*CodexAgent)(nil)
+	_ agent.HookConfigLocator        = (*CodexAgent)(nil)
 	_ agent.HookFreshness            = (*CodexAgent)(nil)
 	_ agent.EffectiveHookDiagnostics = (*CodexAgent)(nil)
 	_ agent.HookResponseWriter       = (*CodexAgent)(nil)

--- a/cmd/entire/cli/agent/copilotcli/hooks.go
+++ b/cmd/entire/cli/agent/copilotcli/hooks.go
@@ -44,7 +44,7 @@ func copilotHookConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 		// chose rather than one derived from anything read off disk.
 		worktreeRoot = "."
 	}
-	return agent.OpenHookConfig(worktreeRoot, hooksDir+"/"+HooksFileName) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
+	return agent.OpenHookConfig(worktreeRoot, (&CopilotCLIAgent{}).HookConfigRelPath()) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 }
 
 // InstallHooks installs Copilot CLI hooks in .github/hooks/entire.json.
@@ -358,3 +358,6 @@ func removeEntireHooks(entries []CopilotHookEntry) []CopilotHookEntry {
 	}
 	return result
 }
+
+// HookConfigRelPath implements agent.HookConfigLocator.
+func (c *CopilotCLIAgent) HookConfigRelPath() string { return hooksDir + "/" + HooksFileName }

--- a/cmd/entire/cli/agent/copilotcli/lifecycle.go
+++ b/cmd/entire/cli/agent/copilotcli/lifecycle.go
@@ -23,7 +23,10 @@ func isSubagentSessionID(sessionID string) bool {
 }
 
 // Ensure CopilotCLIAgent implements HookSupport at compile time.
-var _ agent.HookSupport = (*CopilotCLIAgent)(nil)
+var (
+	_ agent.HookSupport       = (*CopilotCLIAgent)(nil)
+	_ agent.HookConfigLocator = (*CopilotCLIAgent)(nil)
+)
 
 // Copilot CLI hook names - these become subcommands under `entire hooks copilot-cli`
 const (

--- a/cmd/entire/cli/agent/cursor/hooks.go
+++ b/cmd/entire/cli/agent/cursor/hooks.go
@@ -15,7 +15,8 @@ import (
 
 // Ensure CursorAgent implements HookSupport
 var (
-	_ agent.HookSupport = (*CursorAgent)(nil)
+	_ agent.HookSupport       = (*CursorAgent)(nil)
+	_ agent.HookConfigLocator = (*CursorAgent)(nil)
 )
 
 // Cursor hook names - these become subcommands under `entire hooks cursor`
@@ -58,7 +59,7 @@ func cursorHookConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 		// chose rather than one derived from anything read off disk.
 		worktreeRoot = "."
 	}
-	return agent.OpenHookConfig(worktreeRoot, ".cursor/"+HooksFileName) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
+	return agent.OpenHookConfig(worktreeRoot, (&CursorAgent{}).HookConfigRelPath()) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 }
 
 // InstallHooks installs Cursor hooks in .cursor/hooks.json.
@@ -406,3 +407,6 @@ func removeEntireHooks(entries []CursorHookEntry) []CursorHookEntry {
 	}
 	return result
 }
+
+// HookConfigRelPath implements agent.HookConfigLocator.
+func (c *CursorAgent) HookConfigRelPath() string { return ".cursor/" + HooksFileName }

--- a/cmd/entire/cli/agent/factoryaidroid/hooks.go
+++ b/cmd/entire/cli/agent/factoryaidroid/hooks.go
@@ -16,6 +16,7 @@ import (
 // Ensure FactoryAIDroidAgent implements HookSupport
 var (
 	_ agent.HookSupport           = (*FactoryAIDroidAgent)(nil)
+	_ agent.HookConfigLocator     = (*FactoryAIDroidAgent)(nil)
 	_ agent.PermissionConfigOwner = (*FactoryAIDroidAgent)(nil)
 )
 
@@ -54,7 +55,7 @@ func factoryHookConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 			return nil, fmt.Errorf("failed to get current directory: %w", err)
 		}
 	}
-	return agent.OpenHookConfig(repoRoot, ".factory/"+FactorySettingsFileName) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
+	return agent.OpenHookConfig(repoRoot, (&FactoryAIDroidAgent{}).HookConfigRelPath()) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 }
 
 // InstallHooks installs Factory AI Droid hooks in .factory/settings.json.
@@ -501,4 +502,9 @@ func removeEntireHooks(matchers []FactoryHookMatcher) []FactoryHookMatcher {
 // without knowing Factory Droid's layout.
 func (f *FactoryAIDroidAgent) PermissionConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 	return factoryHookConfig(ctx)
+}
+
+// HookConfigRelPath implements agent.HookConfigLocator.
+func (f *FactoryAIDroidAgent) HookConfigRelPath() string {
+	return ".factory/" + FactorySettingsFileName
 }

--- a/cmd/entire/cli/agent/geminicli/hooks.go
+++ b/cmd/entire/cli/agent/geminicli/hooks.go
@@ -17,7 +17,10 @@ import (
 )
 
 // Ensure GeminiCLIAgent implements HookSupport
-var _ agent.HookSupport = (*GeminiCLIAgent)(nil)
+var (
+	_ agent.HookSupport       = (*GeminiCLIAgent)(nil)
+	_ agent.HookConfigLocator = (*GeminiCLIAgent)(nil)
+)
 
 // Gemini CLI hook names - these become subcommands under `entire hooks gemini`
 const (
@@ -55,7 +58,7 @@ func geminiHookConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 			return nil, fmt.Errorf("failed to get current directory: %w", err)
 		}
 	}
-	return agent.OpenHookConfig(repoRoot, ".gemini/"+GeminiSettingsFileName) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
+	return agent.OpenHookConfig(repoRoot, (&GeminiCLIAgent{}).HookConfigRelPath()) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 }
 
 // InstallHooks installs Gemini CLI hooks in .gemini/settings.json.
@@ -542,3 +545,6 @@ func removeEntireHooks(matchers []GeminiHookMatcher) []GeminiHookMatcher {
 	}
 	return result
 }
+
+// HookConfigRelPath implements agent.HookConfigLocator.
+func (g *GeminiCLIAgent) HookConfigRelPath() string { return ".gemini/" + GeminiSettingsFileName }

--- a/cmd/entire/cli/agent/hook_command.go
+++ b/cmd/entire/cli/agent/hook_command.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"runtime"
 	"slices"
@@ -14,9 +13,11 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 )
 
-// GeneratedHookFileState reports hook-config drift for agents whose entire
+// generatedStateFromContent reports hook-config drift for agents whose entire
 // Entire integration is one generated file in the repo (Pi's extension,
-// OpenCode's plugin), for use by HookFreshness implementations.
+// OpenCode's plugin), for use by HookFreshness implementations. Reached through
+// HookConfigFile.GeneratedState, which reads the bytes through the worktree's
+// root.
 //
 // The file counts as ours only if it contains marker, and as current only if it
 // matches render — what InstallHooks writes today. Pass exactly that one render:
@@ -37,17 +38,6 @@ import (
 // A file that exists but lacks marker reads as HooksAbsent, not HooksOutdated:
 // InstallHooks refuses to overwrite a foreign file at our path, so there is no
 // Entire config there for us to call stale.
-func GeneratedHookFileState(path, marker, render string) HookConfigState {
-	data, err := os.ReadFile(path) //nolint:gosec // path constructed from validated repo root
-	if err != nil {
-		return HooksAbsent
-	}
-	return generatedStateFromContent(string(data), marker, render)
-}
-
-// generatedStateFromContent is GeneratedHookFileState once the bytes are in
-// hand, shared with HookConfigFile.GeneratedState, which reads them through a
-// root instead of through a path.
 func generatedStateFromContent(content, marker, render string) HookConfigState {
 	if !strings.Contains(content, marker) {
 		return HooksAbsent

--- a/cmd/entire/cli/agent/hook_config_file.go
+++ b/cmd/entire/cli/agent/hook_config_file.go
@@ -14,9 +14,9 @@ import (
 // HookConfigFile is an agent's hook-configuration file inside the worktree —
 // .claude/settings.json, .cursor/hooks.json, .gemini/settings.json,
 // .github/hooks/entire.json, .factory/settings.json, .codex/hooks.json,
-// .opencode/plugin/entire.ts.
+// .opencode/plugins/entire.ts, .pi/extensions/entire/index.ts.
 //
-// Seven agents each carried the same four lines: filepath.Join a repo root with
+// Eight agents each carried the same four lines: filepath.Join a repo root with
 // a fixed relative path, then os.ReadFile / os.MkdirAll / os.WriteFile /
 // os.Remove on the result, each with a //nolint:gosec saying the path came from
 // the repo root. That justification is about where the path was BUILT and says
@@ -29,9 +29,11 @@ import (
 // Anchoring on worktreedir fixes that at the root rather than at each call site:
 // the base is the worktree root, the agent's fixed subpath is a NAME inside it,
 // and directories are created with MkdirAllNoSymlink so a symlinked component is
-// refused by name instead of silently followed. It also collapses the seven
+// refused by name instead of silently followed. It also collapses the eight
 // copies into one, which is what keeps the next agent integration from
-// reintroducing the pattern.
+// reintroducing the pattern. Pi was the one that got left behind on the first
+// pass and had to be migrated afterwards, which is the argument for routing a
+// new agent through here rather than for trusting that someone will notice.
 //
 // Every symlink component is refused, including the file itself. os.Root blocks
 // a link that escapes the worktree but follows one pointing elsewhere inside
@@ -124,6 +126,31 @@ func (f *HookConfigFile) Write(data []byte, perm os.FileMode) error {
 func (f *HookConfigFile) Remove() error {
 	if err := osroot.RemoveNoSymlinks(f.root, f.name); err != nil {
 		return fmt.Errorf("remove %s: %w", f.path, err)
+	}
+	return nil
+}
+
+// RemoveDir deletes the directory the file lives in, and everything in it,
+// refusing a symlink at any component along the way.
+//
+// One agent needs this, and it is not a general uninstall: Pi's whole
+// integration is `.pi/extensions/entire/index.ts`, a directory that exists only
+// to hold that one file, and pi discovers extensions BY DIRECTORY — so removing
+// the file alone leaves an empty `.pi/extensions/entire` for pi to find and
+// nothing to load from it. Every other agent writes into a directory the agent
+// itself owns (`.claude`, `.codex`, `.cursor`), where Remove of the file is the
+// correct uninstall and taking the parent would delete the user's own config
+// with it.
+//
+// Refuses to act when the file sits directly at the worktree root, which would
+// make the directory to delete the repository.
+func (f *HookConfigFile) RemoveDir() error {
+	dir := path.Dir(f.name)
+	if dir == "." {
+		return fmt.Errorf("remove %s: refusing to remove the worktree root", filepath.Dir(f.path))
+	}
+	if err := osroot.RemoveAllNoSymlinks(f.root, dir); err != nil {
+		return fmt.Errorf("remove %s: %w", filepath.Dir(f.path), err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/agent/hook_config_file.go
+++ b/cmd/entire/cli/agent/hook_config_file.go
@@ -58,6 +58,28 @@ type HookConfigFile struct {
 	path string
 }
 
+// HookConfigLocator is implemented by an agent whose Entire hook configuration
+// is a file inside the worktree: it returns the same worktree-relative,
+// slash-separated path the agent passes to OpenHookConfig.
+//
+// It exists for the callers that must reason about that path WITHOUT doing I/O
+// on it. Doctor's symlink diagnosis is the first: the directories BETWEEN an
+// agent's own directory and its config file — `.pi/extensions`,
+// `.pi/extensions/entire`, `.opencode/plugins` — are created by Entire and
+// appear in no other registry, because ProtectedDirs names what the AGENT owns
+// (`.pi`, `.opencode`) and stops there. Deriving them from a hand-kept list in
+// the caller is how two of them came to be unchecked in the first place.
+//
+// Optional: an agent whose hooks are not a worktree file (an external plugin
+// declaring them in its manifest) does not implement it. See
+// TestAllHookConfigRelPaths_CoversEveryWorktreeConfigAgent for the ones that
+// must.
+type HookConfigLocator interface {
+	// HookConfigRelPath returns the config file's path relative to the worktree
+	// root, slash-separated, exactly as passed to OpenHookConfig.
+	HookConfigRelPath() string
+}
+
 // OpenHookConfig returns the hook-config file at relPath inside worktreeRoot.
 //
 // relPath is slash-separated and relative to the worktree root

--- a/cmd/entire/cli/agent/opencode/hooks.go
+++ b/cmd/entire/cli/agent/opencode/hooks.go
@@ -14,8 +14,9 @@ import (
 
 // Compile-time interface assertions
 var (
-	_ agent.HookSupport   = (*OpenCodeAgent)(nil)
-	_ agent.HookFreshness = (*OpenCodeAgent)(nil)
+	_ agent.HookSupport       = (*OpenCodeAgent)(nil)
+	_ agent.HookConfigLocator = (*OpenCodeAgent)(nil)
+	_ agent.HookFreshness     = (*OpenCodeAgent)(nil)
 )
 
 const (
@@ -43,7 +44,7 @@ func pluginConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 			return nil, fmt.Errorf("failed to get current directory: %w", err)
 		}
 	}
-	return agent.OpenHookConfig(repoRoot, ".opencode/"+pluginDirName+"/"+pluginFileName) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
+	return agent.OpenHookConfig(repoRoot, (&OpenCodeAgent{}).HookConfigRelPath()) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 }
 
 // renderPlugin returns the plugin file content. The template names the "entire"
@@ -151,4 +152,9 @@ func (a *OpenCodeAgent) GetSupportedHooks() []agent.HookType {
 		agent.HookUserPromptSubmit,
 		agent.HookStop,
 	}
+}
+
+// HookConfigRelPath implements agent.HookConfigLocator.
+func (a *OpenCodeAgent) HookConfigRelPath() string {
+	return ".opencode/" + pluginDirName + "/" + pluginFileName
 }

--- a/cmd/entire/cli/agent/pi/hooks.go
+++ b/cmd/entire/cli/agent/pi/hooks.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -47,17 +46,28 @@ const (
 	piNestedEnvVar = "ENTIRE_PI_NESTED"
 )
 
-func extensionPath(ctx context.Context) (string, error) {
+// extensionConfig returns .pi/extensions/entire/index.ts for the current
+// worktree, opened through the worktree's root so the extension directory is
+// created, read, and removed as a name inside the repository rather than
+// through whatever a checked-in `.pi` symlink points at.
+//
+// Pi was the last registered agent still joining its path onto the repo root
+// and handing the result to os.ReadFile / os.MkdirAll / os.WriteFile /
+// os.RemoveAll. That is worse here than for the agents whose config is a
+// settings file, because pi is auto-detected: DetectPresence stats `.pi`, which
+// follows the link, so a repository shipping one had `entire enable` install
+// through it without the user ever naming pi.
+func extensionConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 	root, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		// Fall back to CWD for tests run outside a git repo.
 		//nolint:forbidigo // explicit fallback when WorktreeRoot fails
 		root, err = os.Getwd()
 		if err != nil {
-			return "", fmt.Errorf("resolve repo root: %w", err)
+			return nil, fmt.Errorf("resolve repo root: %w", err)
 		}
 	}
-	return filepath.Join(root, extensionDirName, extensionFileName), nil
+	return agent.OpenHookConfig(root, extensionDirName+"/"+extensionFileName) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 }
 
 // renderExtension returns the extension file content, substituting the entire
@@ -76,45 +86,40 @@ func renderExtension() string {
 // true — this protects user-authored extensions that happen to live at
 // .pi/extensions/entire/index.ts.
 func (a *PiAgent) InstallHooks(ctx context.Context, force bool) (int, error) {
-	path, err := extensionPath(ctx)
+	cfg, err := extensionConfig(ctx)
 	if err != nil {
 		return 0, err
 	}
 	content := renderExtension()
 
 	if !force {
-		//nolint:gosec // path constructed from validated repo root
-		existing, readErr := os.ReadFile(path)
+		existing, readErr := cfg.Read()
 		switch {
 		case readErr == nil && string(existing) == content:
 			return 0, nil // already up-to-date
 		case readErr == nil && !strings.Contains(string(existing), entireMarker):
-			return 0, fmt.Errorf("refusing to overwrite foreign file at %s; remove it or pass --force", path)
+			return 0, fmt.Errorf("refusing to overwrite foreign file at %s; remove it or pass --force", cfg.Path())
 		}
 	}
 
-	//nolint:gosec // G301: pi reads the directory; standard 0755 permissions
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return 0, fmt.Errorf("create extension dir: %w", err)
-	}
-	//nolint:gosec // G306: pi reads the file; standard 0644 permissions
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		return 0, fmt.Errorf("write extension: %w", err)
+	// Write creates .pi/extensions/entire with MkdirAllNoSymlink. 0644 because
+	// pi reads the extension itself.
+	if err := cfg.Write([]byte(content), 0o644); err != nil {
+		return 0, err //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 	}
 	return 1, nil
 }
 
 // UninstallHooks removes the entire pi extension directory (if present).
 func (a *PiAgent) UninstallHooks(ctx context.Context) error {
-	path, err := extensionPath(ctx)
+	cfg, err := extensionConfig(ctx)
 	if err != nil {
 		return err
 	}
-	dir := filepath.Dir(path)
-	if err := os.RemoveAll(dir); err != nil {
-		return fmt.Errorf("remove pi extension dir: %w", err)
-	}
-	return nil
+	// The directory, not just the file: pi discovers extensions by directory, so
+	// an empty .pi/extensions/entire left behind is a half-uninstalled
+	// extension. See HookConfigFile.RemoveDir for why no other agent does this.
+	return cfg.RemoveDir() //nolint:wrapcheck // agent.HookConfigFile already names the directory in its error
 }
 
 // AreHooksInstalled returns true when the extension file exists and is
@@ -126,19 +131,18 @@ func (a *PiAgent) UninstallHooks(ctx context.Context) error {
 // "we could not tell" and "there are none" are different things to a caller
 // deciding whether hooks can be left alone.
 func (a *PiAgent) AreHooksInstalled(ctx context.Context) (bool, error) {
-	path, err := extensionPath(ctx)
+	cfg, err := extensionConfig(ctx)
 	if err != nil {
 		logging.Warn(ctx, "pi: failed to resolve extension path", "err", err)
 		return false, err
 	}
-	//nolint:gosec // path from validated repo root
-	data, err := os.ReadFile(path)
+	data, err := cfg.Read()
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
 	if err != nil {
-		logging.Warn(ctx, "pi: failed to read extension file", "path", path, "err", err)
-		return false, fmt.Errorf("read %s: %w", path, err)
+		logging.Warn(ctx, "pi: failed to read extension file", "path", cfg.Path(), "err", err)
+		return false, fmt.Errorf("read %s: %w", cfg.Path(), err)
 	}
 	return strings.Contains(string(data), entireMarker), nil
 }
@@ -155,12 +159,12 @@ func (a *PiAgent) AreHooksInstalled(ctx context.Context) (bool, error) {
 // fireHook swallows every error by design, so broken hooks are silent. Without
 // this check a stale committed extension reads as healthy forever.
 func (a *PiAgent) CheckHookConfig(ctx context.Context) agent.HookConfigState {
-	path, err := extensionPath(ctx)
+	cfg, err := extensionConfig(ctx)
 	if err != nil {
 		return agent.HooksAbsent
 	}
 	// Only the binary render counts as current. An extension left behind by
 	// local-dev mode still carries entireMarker, so it reads as ours but
 	// outdated and gets rewritten rather than being trusted as up to date.
-	return agent.GeneratedHookFileState(path, entireMarker, renderExtension())
+	return cfg.GeneratedState(entireMarker, renderExtension())
 }

--- a/cmd/entire/cli/agent/pi/hooks.go
+++ b/cmd/entire/cli/agent/pi/hooks.go
@@ -15,8 +15,9 @@ import (
 
 // Compile-time interface assertions
 var (
-	_ agent.HookSupport   = (*PiAgent)(nil)
-	_ agent.HookFreshness = (*PiAgent)(nil)
+	_ agent.HookSupport       = (*PiAgent)(nil)
+	_ agent.HookConfigLocator = (*PiAgent)(nil)
+	_ agent.HookFreshness     = (*PiAgent)(nil)
 )
 
 //go:embed entire_extension.ts
@@ -67,7 +68,7 @@ func extensionConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 			return nil, fmt.Errorf("resolve repo root: %w", err)
 		}
 	}
-	return agent.OpenHookConfig(root, extensionDirName+"/"+extensionFileName) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
+	return agent.OpenHookConfig(root, (&PiAgent{}).HookConfigRelPath()) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 }
 
 // renderExtension returns the extension file content, substituting the entire
@@ -168,3 +169,6 @@ func (a *PiAgent) CheckHookConfig(ctx context.Context) agent.HookConfigState {
 	// outdated and gets rewritten rather than being trusted as up to date.
 	return cfg.GeneratedState(entireMarker, renderExtension())
 }
+
+// HookConfigRelPath implements agent.HookConfigLocator.
+func (a *PiAgent) HookConfigRelPath() string { return extensionDirName + "/" + extensionFileName }

--- a/cmd/entire/cli/agent/pi/hooks_test.go
+++ b/cmd/entire/cli/agent/pi/hooks_test.go
@@ -2,6 +2,7 @@ package pi
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/testutil"
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
 )
 
 // Note: t.Parallel is incompatible with t.Chdir.
@@ -105,10 +107,11 @@ func TestInstallHooks_RewritesStaleRender(t *testing.T) {
 
 	// Seed the render the removed local-dev mode used to write, then reinstall:
 	// differing content must be rewritten to the binary form.
-	path, err := extensionPath(ctx)
+	cfg, err := extensionConfig(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+	path := cfg.Path()
 	legacy := strings.ReplaceAll(extensionTemplate, entireCmdPlaceholder, testutil.LegacyLocalDevCommand(""))
 	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
 		t.Fatal(err)
@@ -289,10 +292,11 @@ func TestCheckHookConfig_LegacyLocalDevIsDrift(t *testing.T) {
 	if _, err := a.InstallHooks(ctx, false); err != nil {
 		t.Fatalf("InstallHooks: %v", err)
 	}
-	path, err := extensionPath(ctx)
+	cfg, err := extensionConfig(ctx)
 	if err != nil {
-		t.Fatalf("extensionPath: %v", err)
+		t.Fatalf("extensionConfig: %v", err)
 	}
+	path := cfg.Path()
 	legacy := strings.ReplaceAll(extensionTemplate, entireCmdPlaceholder, testutil.LegacyLocalDevCommand(""))
 	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
 		t.Fatal(err)
@@ -352,4 +356,76 @@ func hooksInstalledNow(t *testing.T, ag interface {
 		t.Fatalf("AreHooksInstalled() error = %v", err)
 	}
 	return installed
+}
+
+// TestHooks_RefuseSymlinkedExtensionDir pins the three operations that used to
+// resolve .pi through a checked-in symlink. A repository shipping
+// `.pi -> /somewhere/else` got arbitrary file creation outside the worktree from
+// InstallHooks and recursive deletion of an arbitrary directory from
+// UninstallHooks, and AreHooksInstalled read the far end as its own answer.
+//
+// It is reachable without the user naming pi: DetectPresence stats .pi, which
+// follows the link, so pi reads as present and `entire enable` installs through
+// it unprompted in CI or under --yes.
+func TestHooks_RefuseSymlinkedExtensionDir(t *testing.T) {
+	outside := t.TempDir()
+	worktree := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(worktree, ".pi")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	// The link's far end already holds an extension, so a followed read has
+	// something to report and a followed delete has something to destroy.
+	planted := filepath.Join(outside, "extensions", "entire")
+	if err := os.MkdirAll(planted, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(planted, extensionFileName), []byte(entireMarker), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(worktree)
+
+	a := &PiAgent{}
+
+	if _, err := a.InstallHooks(context.Background(), false); !errors.Is(err, osroot.ErrSymlinkedPath) {
+		t.Errorf("InstallHooks err = %v, want osroot.ErrSymlinkedPath", err)
+	}
+
+	// An unreadable answer is not "no hooks": a caller deciding whether hooks
+	// can be left alone must not be told the far end's content is ours.
+	installed, err := a.AreHooksInstalled(context.Background())
+	if !errors.Is(err, osroot.ErrSymlinkedPath) {
+		t.Errorf("AreHooksInstalled err = %v, want osroot.ErrSymlinkedPath", err)
+	}
+	if installed {
+		t.Error("AreHooksInstalled followed the link and claimed the planted file")
+	}
+
+	if err := a.UninstallHooks(context.Background()); !errors.Is(err, osroot.ErrSymlinkedPath) {
+		t.Errorf("UninstallHooks err = %v, want osroot.ErrSymlinkedPath", err)
+	}
+	if _, err := os.Stat(planted); err != nil {
+		t.Errorf("UninstallHooks deleted outside the worktree: %v", err)
+	}
+
+	if state := a.CheckHookConfig(context.Background()); state != agent.HooksAbsent {
+		t.Errorf("CheckHookConfig = %v, want HooksAbsent", state)
+	}
+}
+
+// TestUninstallHooks_RemovesDirectoryNotJustFile pins the behaviour RemoveDir
+// exists for: pi discovers extensions by directory, so leaving an empty
+// .pi/extensions/entire behind is a half-uninstalled extension.
+func TestUninstallHooks_RemovesDirectoryNotJustFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	a := &PiAgent{}
+	if _, err := a.InstallHooks(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.UninstallHooks(context.Background()); err != nil {
+		t.Fatalf("UninstallHooks: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, extensionDirName)); !os.IsNotExist(err) {
+		t.Errorf("extension directory survived uninstall: err = %v", err)
+	}
 }

--- a/cmd/entire/cli/agent/registry.go
+++ b/cmd/entire/cli/agent/registry.go
@@ -228,6 +228,38 @@ func AllProtectedDirs() []string {
 	return dirs
 }
 
+// AllHookConfigRelPaths returns the worktree-relative path of every registered
+// agent's hook-configuration file, for the agents that declare one
+// (HookConfigLocator). Sorted and deduplicated.
+func AllHookConfigRelPaths() []string {
+	registryMu.RLock()
+	factories := make([]Factory, 0, len(registry))
+	for _, f := range registry {
+		factories = append(factories, f)
+	}
+	registryMu.RUnlock()
+
+	seen := make(map[string]struct{})
+	var out []string
+	for _, factory := range factories {
+		locator, ok := factory().(HookConfigLocator)
+		if !ok {
+			continue
+		}
+		p := locator.HookConfigRelPath()
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	slices.Sort(out)
+	return out
+}
+
 // AllProtectedFiles returns the union of ProtectedFiles from all registered agents.
 func AllProtectedFiles() []string {
 	// Copy factories under the lock, then release before calling external code.

--- a/cmd/entire/cli/agent_hook_config_guard_test.go
+++ b/cmd/entire/cli/agent_hook_config_guard_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"os/exec"
+	"path"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAllHookConfigRelPaths_CoversEveryWorktreeConfigAgent fails the build when
+// an agent opens a hook-config file without also declaring where it lives.
+//
+// A source-level guard rather than a comment, because the omission is invisible
+// at the call site: the agent works, its hooks install, and the only thing that
+// silently loses coverage is doctor's symlink diagnosis — which reports nothing
+// rather than reporting a problem, so no one finds out. Pi and OpenCode nest
+// their config below the directory ProtectedDirs names, and the levels in
+// between went unchecked exactly this way.
+//
+// It runs in package cli because that is where every agent's init() has run and
+// the registry is fully populated.
+func TestAllHookConfigRelPaths_CoversEveryWorktreeConfigAgent(t *testing.T) {
+	t.Parallel()
+
+	// Both subprocesses run with git's repo selectors scrubbed. They inherit the
+	// environment, and GIT_DIR / GIT_WORK_TREE take precedence over both the
+	// working directory and grep.Dir — so a `go test` launched from anywhere
+	// that exports them (a `git rebase --exec`, a hook, this CLI's own test
+	// harnesses) resolved some other repository entirely. Measured against a
+	// decoy repo, the unscrubbed version fails with "no agent calls
+	// agent.OpenHookConfig", which is a guard failing for a reason that has
+	// nothing to do with what it guards; a decoy that happened to contain
+	// matching paths would instead have it pass having checked nothing.
+	topLevel := exec.Command("git", "rev-parse", "--show-toplevel") //nolint:noctx // guard test, no cancellation needed
+	topLevel.Env = gitrepo.EnvWithoutRepoOverrides()
+	repoRoot, err := topLevel.Output()
+	if err != nil {
+		t.Skipf("not in a git checkout: %v", err)
+	}
+
+	grep := exec.Command("git", "grep", "-l", "--fixed-strings", "--", //nolint:noctx // guard test, no cancellation needed
+		"agent.OpenHookConfig(", "--", ":(glob)cmd/entire/cli/agent/**/*.go")
+	grep.Dir = strings.TrimSpace(string(repoRoot))
+	grep.Env = gitrepo.EnvWithoutRepoOverrides()
+	out, grepErr := grep.Output()
+	require.NoError(t, grepErr, "no agent calls agent.OpenHookConfig, which cannot be right")
+
+	callers := make(map[string]struct{})
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if line == "" || strings.HasSuffix(line, "_test.go") {
+			continue
+		}
+		callers[path.Dir(line)] = struct{}{}
+	}
+	require.NotEmpty(t, callers, "the detection pattern has gone stale and must be re-pointed")
+
+	declared := agent.AllHookConfigRelPaths()
+	require.Len(t, declared, len(callers),
+		"%d agent packages call agent.OpenHookConfig (%s) but %d declare a path (%s).\n"+
+			"Every agent whose hook config is a worktree file must implement "+
+			"agent.HookConfigLocator, or the directories Entire creates between its "+
+			"own directory and that file go unchecked by doctor's symlink diagnosis.",
+		len(callers), strings.Join(sortedPackageDirs(callers), ", "), len(declared), strings.Join(declared, ", "))
+}
+
+func sortedPackageDirs(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/cmd/entire/cli/checkpoint/migrate_test.go
+++ b/cmd/entire/cli/checkpoint/migrate_test.go
@@ -217,9 +217,9 @@ func TestMigrateBranchToRefs_IdempotentRerunDoesNotUpdateRef(t *testing.T) {
 				t.Helper()
 				_, commonDir, err := repositoryDirs(t.Context(), repo)
 				require.NoError(t, err)
-				lockPath, err := persistentRefLockPath(commonDir, refName)
+				lockRoot, lockName, err := persistentRefLock(commonDir, refName)
 				require.NoError(t, err)
-				release, err := flock.Acquire(lockPath)
+				release, err := flock.AcquireIn(lockRoot, lockName)
 				require.NoError(t, err)
 				t.Cleanup(release)
 			},

--- a/cmd/entire/cli/checkpoint/persistent_ref_update.go
+++ b/cmd/entire/cli/checkpoint/persistent_ref_update.go
@@ -7,11 +7,12 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
+	"github.com/entireio/cli/cmd/entire/cli/gitdir"
 	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -59,21 +60,38 @@ func casUpdateRef(ctx context.Context, repoRoot string, refName plumbing.Referen
 	return fmt.Errorf("git update-ref %s: %s: %w", refName, strings.TrimSpace(out), err)
 }
 
-func persistentRefLockPath(commonDir string, refName plumbing.ReferenceName) (string, error) {
-	lockDir := filepath.Join(commonDir, "entire-persistent-ref-locks")
-	if err := os.MkdirAll(lockDir, 0o750); err != nil {
-		return "", fmt.Errorf("create persistent ref lock directory: %w", err)
+// persistentRefLockDirName is the persistent-ref lock directory inside the git
+// common dir, alongside shadowLockDirName.
+const persistentRefLockDirName = "entire-persistent-ref-locks"
+
+// persistentRefLock returns the git common dir's root and the per-ref lock
+// file's name inside it, mirroring shadowBranchLock. Ref names are escaped
+// because "refs/entire/checkpoints/v1" would otherwise nest directories.
+//
+// Through the root like every other .git-resident lock: this was the last one
+// still opening by path, and flock's os.OpenFile(path, O_RDWR|O_CREATE) follows
+// a symlink at the lock path. Git will not check a path out into .git, so this
+// is defence in depth rather than a reachable escape — but it is the reason
+// openLockFileIn exists, and leaving one caller outside it is how the next one
+// gets written that way too.
+func persistentRefLock(commonDir string, refName plumbing.ReferenceName) (*os.Root, string, error) {
+	root, err := gitdir.OpenAt(commonDir)
+	if err != nil {
+		return nil, "", fmt.Errorf("open git common dir: %w", err)
+	}
+	if err := osroot.MkdirAllNoSymlink(root, persistentRefLockDirName, 0o750); err != nil {
+		return nil, "", fmt.Errorf("create persistent ref lock directory: %w", err)
 	}
 	safe := strings.NewReplacer("/", "_", "\\", "_", ":", "_").Replace(refName.String())
-	return filepath.Join(lockDir, safe+".lock"), nil
+	return root, persistentRefLockDirName + "/" + safe + ".lock", nil
 }
 
 func withPersistentRefFlock(ctx context.Context, commonDir string, refName plumbing.ReferenceName, fn func() error) error {
-	path, err := persistentRefLockPath(commonDir, refName)
+	root, name, err := persistentRefLock(commonDir, refName)
 	if err != nil {
 		return err
 	}
-	release, err := flock.AcquireContext(ctx, path)
+	release, err := flock.AcquireContextIn(ctx, root, name)
 	if err != nil {
 		return fmt.Errorf("acquire persistent ref flock %s: %w", refName, err)
 	}

--- a/cmd/entire/cli/checkpoint/persistent_ref_update_test.go
+++ b/cmd/entire/cli/checkpoint/persistent_ref_update_test.go
@@ -21,9 +21,9 @@ func TestUpdatePersistentRef_StopsWaitingWhenContextDeadlineExpires(t *testing.T
 
 	_, commonDir, err := repositoryDirs(context.Background(), repo)
 	require.NoError(t, err)
-	lockPath, err := persistentRefLockPath(commonDir, refName)
+	lockRoot, lockName, err := persistentRefLock(commonDir, refName)
 	require.NoError(t, err)
-	release, err := flock.Acquire(lockPath)
+	release, err := flock.AcquireIn(lockRoot, lockName)
 	require.NoError(t, err)
 	t.Cleanup(release)
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	"charm.land/huh/v2"
@@ -23,6 +25,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -144,6 +147,7 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 	// Before checkLogSink, because a symlinked .entire/logs is one of the reasons
 	// that check fires and this one names the cause.
 	checkEntireDirSymlinks(cmd)
+	checkAgentDirSymlinks(cmd)
 
 	// Before the remaining checks, because it is the channel they and every
 	// other command write their diagnostics to: if this is broken, an empty
@@ -736,6 +740,197 @@ func checkEntireDirSymlinks(cmd *cobra.Command) {
 	fmt.Fprintln(w, "  anything that belongs under one of these paths is not being captured.")
 	fmt.Fprintln(w, "  Fix: replace each path above with a real directory. If it is tracked in git,")
 	fmt.Fprintln(w, "  `git rm --cached` it first, and add it to .gitignore so it does not come back.")
+}
+
+// checkAgentDirSymlinks reports a symlink at any directory component Entire
+// creates or writes through for an agent: the agents' own config directories
+// (.claude, .codex, .cursor, .gemini, .factory, .opencode, .pi, .github/hooks)
+// and the managed skill scaffolds' parents (.claude/skills, .codex/agents, ...).
+//
+// The condition is otherwise invisible after the fact. `entire enable` fails
+// loudly on it (agent.HookConfigFile and writeManagedScaffold both create
+// through osroot.MkdirAllNoSymlink), but once the repo is enabled
+// HookConfigFile.Exists() deliberately reports a symlinked parent as absent —
+// so `entire status` shows the hooks missing without saying why, and
+// `entire clean` skips the directory on the stated grounds that doctor is what
+// reports a symlinked agent directory. Until this check, nothing did.
+//
+// Unlike .entire, these trees are the agent's and largely the user's, so this
+// examines only the components Entire itself creates and writes through, rather
+// than listing every symlink beneath them the way checkEntireDirSymlinks does.
+// A `.claude/skills/my-own -> ../../shared/skills/my-own` is a real setup and
+// none of Entire's business; reporting it would train the user to ignore this
+// section.
+//
+// Read-only. The fix means deciding what to do with whatever the link pointed
+// at, which is not doctor's call.
+func checkAgentDirSymlinks(cmd *cobra.Command) {
+	ctx := cmd.Context()
+	w := cmd.OutOrStdout()
+
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return // no repository: nothing to check
+	}
+	root, err := worktreedir.OpenAt(worktreeRoot)
+	if err != nil {
+		return
+	}
+
+	var links, unreadable []string
+	reported := make(map[string]struct{})
+	for _, candidate := range agentSymlinkCheckPaths() {
+		name, outcome := scanForSymlinkedComponent(root, candidate)
+		if outcome == componentScanClean {
+			continue
+		}
+		// Several candidates share a prefix (.claude, .claude/settings.json), so
+		// a symlinked .claude would otherwise be named once per candidate.
+		if _, dup := reported[name]; dup {
+			continue
+		}
+		reported[name] = struct{}{}
+		if outcome == componentScanUnreadable {
+			unreadable = append(unreadable, name)
+			continue
+		}
+		links = append(links, name)
+	}
+
+	if len(links) > 0 {
+		fmt.Fprintln(w, "Agent config directories: SYMLINKS PRESENT")
+		for i, name := range links {
+			if i == symlinkReportLimit {
+				fmt.Fprintf(w, "  ... and %d more\n", len(links)-symlinkReportLimit)
+				break
+			}
+			fmt.Fprintf(w, "  %s -> %s\n", name, readlinkOrUnknownIn(root, name))
+		}
+		fmt.Fprintln(w, "  Entire will not create or write through a symlinked path here, so the")
+		fmt.Fprintln(w, "  hooks and skills that belong under these paths are not installed, and")
+		fmt.Fprintln(w, "  `entire status` reports them as absent rather than as blocked.")
+		fmt.Fprintln(w, "  Fix: replace each path above with a real directory or file. If it is")
+		fmt.Fprintln(w, "  tracked in git, `git rm --cached` it first, and add it to .gitignore so it")
+		fmt.Fprintln(w, "  does not come back.")
+	}
+
+	// Separate from the links, and reported rather than swallowed: "we could not
+	// find out" is not "there is nothing here". Entire's own write will fail on
+	// the same path, so a silent scan would leave the user with hooks that never
+	// install and a doctor that says nothing.
+	if len(unreadable) > 0 {
+		fmt.Fprintln(w, "Agent config directories: NOT READABLE")
+		for i, name := range unreadable {
+			if i == symlinkReportLimit {
+				fmt.Fprintf(w, "  ... and %d more\n", len(unreadable)-symlinkReportLimit)
+				break
+			}
+			fmt.Fprintf(w, "  %s\n", name)
+		}
+		fmt.Fprintln(w, "  Entire could not tell whether these paths are real directories, so it")
+		fmt.Fprintln(w, "  cannot say whether hooks and skills can be installed under them.")
+		fmt.Fprintln(w, "  Fix: check the ownership and permissions of each path above.")
+	}
+}
+
+// componentScanOutcome is what scanForSymlinkedComponent found.
+type componentScanOutcome int
+
+const (
+	// componentScanClean: every component that exists is a real file or
+	// directory. A component that is simply absent lands here too — an agent
+	// Entire was never enabled for has no directory, and that is not a fault.
+	componentScanClean componentScanOutcome = iota
+	// componentScanLinked: the named component is a symlink.
+	componentScanLinked
+	// componentScanUnreadable: the named component could not be statted, so
+	// nothing is known about it.
+	componentScanUnreadable
+)
+
+// agentSymlinkCheckPaths returns the worktree-relative paths Entire creates or
+// writes through on behalf of an agent, sorted and deduplicated. Each is a full
+// path rather than a directory, because firstSymlinkedComponent examines every
+// component of what it is given and the leaf is refused too: HookConfigFile
+// reads and writes through ReadFileNoFollow / a pinned-parent rename, and
+// writeManagedScaffold does the same, so a symlinked .claude/settings.json is
+// as broken as a symlinked .claude.
+//
+// Two sources, both read from the registry rather than from a list kept here,
+// so a newly integrated agent is covered without anyone remembering this
+// function: the hook-config paths (agent.HookConfigLocator) and the scaffold
+// templates.
+//
+// Deliberately NOT agent.ProtectedDirs(). That names what the AGENT owns, which
+// is a different set in both directions. It is too narrow — `.pi` is there but
+// the `.pi/extensions` and `.pi/extensions/entire` that Entire creates below it
+// are not, and a symlink at either produced no output at all until the config
+// paths were added here. And it is too broad — `.vogon` and an external
+// plugin's directories are in it while Entire writes nothing into them, so
+// reporting a link there would contradict the rule this list follows. Every
+// top-level agent directory Entire does write to is already covered, as a
+// component of the config or scaffold path underneath it.
+func agentSymlinkCheckPaths() []string {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(p string) {
+		p = filepath.ToSlash(p)
+		if p == "" || p == "." || p == "/" {
+			return
+		}
+		if _, ok := seen[p]; ok {
+			return
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+
+	for _, relPath := range agent.AllHookConfigRelPaths() {
+		add(relPath)
+	}
+	for _, name := range agent.List() {
+		if relPath, _, ok := searchSkillTemplate(name); ok {
+			add(relPath)
+		}
+		if relPath, _, ok := agentHelpSkillTemplate(name); ok {
+			add(relPath)
+		}
+	}
+
+	slices.Sort(out)
+	return out
+}
+
+// scanForSymlinkedComponent walks name one component at a time and reports the
+// shortest prefix that is a symlink, or that could not be statted at all.
+//
+// Prefixes are examined shortest first so the walk stops at a link before it
+// would resolve anything through it, which is both the correct answer to report
+// (the outermost link is the one to replace) and the reason a plain root.Lstat
+// of the full name is not enough: that call follows an in-root parent link and
+// reports the far end's mode.
+//
+// A component that does not exist ends the walk clean — an absent .claude is
+// not a misconfiguration — but every OTHER stat error is reported, matching
+// checkEntireDirSymlinks' NOT READABLE arm. Treating them alike would answer
+// "we could not find out" with "everything is fine", on exactly the paths
+// Entire is about to try to write to.
+func scanForSymlinkedComponent(root *os.Root, name string) (string, componentScanOutcome) {
+	components := strings.Split(name, "/")
+	for i := range components {
+		prefix := strings.Join(components[:i+1], "/")
+		info, err := root.Lstat(prefix)
+		if os.IsNotExist(err) {
+			return "", componentScanClean
+		}
+		if err != nil {
+			return prefix, componentScanUnreadable
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return prefix, componentScanLinked
+		}
+	}
+	return "", componentScanClean
 }
 
 // readlinkOrUnknown renders a symlink's target for a diagnostic, never failing:

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -1477,3 +1477,206 @@ func TestCheckDisconnectedMetadata_Aligned_StaysQuiet(t *testing.T) {
 	assert.Contains(t, output, "✓ Metadata branches: OK")
 	assert.NotContains(t, output, "DIVERGED")
 }
+
+// A symlinked agent directory arrives by clone and is invisible everywhere else:
+// enable refuses to write through it, then HookConfigFile.Exists() reports the
+// config as absent, so status says hooks are missing without saying why and
+// clean skips the directory on the grounds that doctor reports it.
+func TestCheckAgentDirSymlinks_ReportsSymlinkedAgentDir(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Cleanup(osroot.ResetShared)
+
+	elsewhere := t.TempDir()
+	if err := os.Symlink(elsewhere, filepath.Join(dir, ".claude")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cmd, stdout := newTestCmd(t)
+	checkAgentDirSymlinks(cmd)
+
+	output := stdout.String()
+	assert.Contains(t, output, "SYMLINKS PRESENT")
+	assert.Contains(t, output, ".claude", "the report must name the path to fix")
+	assert.Contains(t, output, elsewhere, "and where it currently points")
+}
+
+// The scaffold parents are Entire's to create too, and a link there is reported
+// as itself rather than as the .claude above it.
+func TestCheckAgentDirSymlinks_ReportsSymlinkedScaffoldParent(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Cleanup(osroot.ResetShared)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o750))
+	if err := os.Symlink(t.TempDir(), filepath.Join(dir, ".claude", "skills")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cmd, stdout := newTestCmd(t)
+	checkAgentDirSymlinks(cmd)
+
+	output := stdout.String()
+	assert.Contains(t, output, ".claude/skills")
+	assert.NotContains(t, output, "  .claude ->", "the real .claude must not be reported")
+}
+
+// The levels between an agent's own directory and its config file are Entire's
+// to create and belong to no ProtectedDirs, so they went unchecked until this
+// test: a symlink at either produced no doctor output at all.
+func TestCheckAgentDirSymlinks_ReportsIntermediateHookConfigDirs(t *testing.T) {
+	for _, tc := range []struct {
+		parent string
+		link   string
+	}{
+		{parent: ".pi", link: ".pi/extensions"},
+		{parent: ".opencode", link: ".opencode/plugins"},
+	} {
+		t.Run(tc.link, func(t *testing.T) {
+			dir := setupGitRepoForPhaseTest(t)
+			t.Chdir(dir)
+			paths.ClearWorktreeRootCache()
+			t.Cleanup(paths.ClearWorktreeRootCache)
+			t.Cleanup(osroot.ResetShared)
+
+			require.NoError(t, os.MkdirAll(filepath.Join(dir, tc.parent), 0o750))
+			if err := os.Symlink(t.TempDir(), filepath.Join(dir, filepath.FromSlash(tc.link))); err != nil {
+				t.Skipf("symlink not supported: %v", err)
+			}
+
+			cmd, stdout := newTestCmd(t)
+			checkAgentDirSymlinks(cmd)
+
+			assert.Contains(t, stdout.String(), tc.link)
+		})
+	}
+}
+
+// The config file itself is refused too (HookConfigFile reads it with
+// ReadFileNoFollow and replaces it by pinned-parent rename), so a link there is
+// as broken as one at the directory and must be reported the same way.
+func TestCheckAgentDirSymlinks_ReportsSymlinkedConfigFile(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Cleanup(osroot.ResetShared)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o750))
+	if err := os.Symlink(filepath.Join(t.TempDir(), "settings.json"), filepath.Join(dir, ".claude", "settings.json")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cmd, stdout := newTestCmd(t)
+	checkAgentDirSymlinks(cmd)
+
+	assert.Contains(t, stdout.String(), ".claude/settings.json")
+}
+
+// Every path an agent's hook config resolves through must be a candidate. The
+// registry is the source, so this fails when a new agent's config nests below a
+// directory nothing else declares.
+func TestAgentSymlinkCheckPaths_CoversEveryHookConfigPath(t *testing.T) {
+	t.Parallel()
+	candidates := agentSymlinkCheckPaths()
+	for _, relPath := range agent.AllHookConfigRelPaths() {
+		assert.Contains(t, candidates, relPath,
+			"%s is written by Entire, so every component above it needs checking", relPath)
+	}
+	assert.Contains(t, candidates, ".pi/extensions/entire/index.ts",
+		"the nested agents are the reason this list is not just ProtectedDirs")
+}
+
+// A symlinked .claude is named once, not once per candidate path underneath it.
+func TestCheckAgentDirSymlinks_NamesTheOutermostLinkOnce(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Cleanup(osroot.ResetShared)
+
+	if err := os.Symlink(t.TempDir(), filepath.Join(dir, ".claude")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cmd, stdout := newTestCmd(t)
+	checkAgentDirSymlinks(cmd)
+
+	assert.Equal(t, 1, strings.Count(stdout.String(), ".claude ->"),
+		".claude, .claude/skills and .claude/agents are all candidates; the link is one finding")
+}
+
+// "We could not find out" is not "there is nothing here": Entire's own write
+// fails on the same path, so a swallowed stat error would leave the user with
+// hooks that never install and a doctor that says nothing.
+func TestCheckAgentDirSymlinks_ReportsAnUnreadableComponent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission bits this test removes")
+	}
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Cleanup(osroot.ResetShared)
+
+	claude := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(filepath.Join(claude, "skills"), 0o750))
+	require.NoError(t, os.Chmod(claude, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(claude, 0o750) }) //nolint:errcheck // best-effort restore so t.TempDir can clean up
+
+	cmd, stdout := newTestCmd(t)
+	checkAgentDirSymlinks(cmd)
+
+	output := stdout.String()
+	assert.Contains(t, output, "NOT READABLE")
+	assert.Contains(t, output, ".claude/")
+	assert.NotContains(t, output, "SYMLINKS PRESENT", "an unreadable path is not a link")
+}
+
+// Entire writes nothing into .vogon or an external plugin's directories, so a
+// link there is not this check's business — the list is what Entire creates.
+func TestAgentSymlinkCheckPaths_ExcludesDirectoriesEntireNeverWritesTo(t *testing.T) {
+	t.Parallel()
+	assert.NotContains(t, agentSymlinkCheckPaths(), ".vogon",
+		"vogon installs no hook config and no scaffold")
+	for _, candidate := range agentSymlinkCheckPaths() {
+		assert.Contains(t, candidate, "/",
+			"%s is a bare agent directory; candidates are full paths Entire writes, "+
+				"so that the components above them are what gets checked", candidate)
+	}
+}
+
+// Silent on the happy path, including the common case of no agent directories at
+// all, or the check trains users to skip doctor's output. A user's own symlink
+// deeper inside an agent directory is deliberately not reported: Entire neither
+// creates nor writes through it.
+func TestCheckAgentDirSymlinks_SilentWhenClean(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Cleanup(osroot.ResetShared)
+
+	t.Run("no agent directories", func(t *testing.T) {
+		cmd, stdout := newTestCmd(t)
+		checkAgentDirSymlinks(cmd)
+		assert.Empty(t, stdout.String())
+	})
+
+	t.Run("real directories and a user's own link inside one", func(t *testing.T) {
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".claude", "skills"), 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".claude", "settings.json"), []byte("{}"), 0o600))
+		if err := os.Symlink(t.TempDir(), filepath.Join(dir, ".claude", "skills", "my-own")); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+
+		cmd, stdout := newTestCmd(t)
+		checkAgentDirSymlinks(cmd)
+		assert.Empty(t, stdout.String(),
+			"a shared skill symlinked into place is a real setup and none of Entire's business")
+	})
+}

--- a/cmd/entire/cli/osroot/osroot.go
+++ b/cmd/entire/cli/osroot/osroot.go
@@ -368,6 +368,35 @@ func RemoveNoSymlinks(root *os.Root, name string) error {
 	return Remove(parent, leaf)
 }
 
+// RemoveAllNoSymlinks removes name and everything beneath it, rejecting a
+// symlink in every parent directory component. A missing name is not an error.
+//
+// os.Root.RemoveAll on its own is not enough, and the reason is the same one
+// that makes OpenChild necessary next to a bare Root.OpenRoot: it refuses a
+// symlink that would take the descent OUT of the root, and it unlinks a
+// symlinked leaf rather than deleting whatever is at the far end, but it says
+// nothing about the components ABOVE the leaf. A repository shipping
+// `.pi -> /home/victim/notes` therefore had `.pi/extensions/entire` removed
+// from inside /home/victim, with every component Root examined still nominally
+// inside the worktree.
+//
+// The leaf is unlinked rather than followed, which is os.RemoveAll's behaviour
+// too, so a symlink there costs the link and not its target.
+func RemoveAllNoSymlinks(root *os.Root, name string) error {
+	parent, leaf, closeParent, err := OpenParentNoSymlinks(root, name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer closeParent()
+	if err := parent.RemoveAll(leaf); err != nil {
+		return fmt.Errorf("remove %s: %w", name, err)
+	}
+	return nil
+}
+
 // WalkDirNoSymlinks walks dir within root, refusing a symlink anywhere it goes:
 // at the walk root, and at every entry beneath it.
 //

--- a/cmd/entire/cli/osroot/osroot_test.go
+++ b/cmd/entire/cli/osroot/osroot_test.go
@@ -660,3 +660,73 @@ func TestSymlinkPaths_ReportsASymlinkedWalkRootRatherThanDescending(t *testing.T
 	require.NoError(t, err)
 	require.Equal(t, []string{"logs"}, found)
 }
+
+func TestRemoveAllNoSymlinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes a real tree", func(t *testing.T) {
+		t.Parallel()
+		base := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(base, "a", "b", "c"), 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(base, "a", "b", "c", "f"), []byte("x"), 0o600))
+		root, err := os.OpenRoot(base)
+		require.NoError(t, err)
+		defer root.Close()
+
+		require.NoError(t, osroot.RemoveAllNoSymlinks(root, "a/b"))
+		_, statErr := os.Stat(filepath.Join(base, "a", "b"))
+		assert.True(t, os.IsNotExist(statErr))
+		assert.DirExists(t, filepath.Join(base, "a"), "only the named subtree goes")
+	})
+
+	t.Run("a missing name is not an error", func(t *testing.T) {
+		t.Parallel()
+		base := t.TempDir()
+		root, err := os.OpenRoot(base)
+		require.NoError(t, err)
+		defer root.Close()
+
+		assert.NoError(t, osroot.RemoveAllNoSymlinks(root, "a/b"))
+	})
+
+	// The case os.Root.RemoveAll does not cover on its own: every component it
+	// examines is nominally inside the root, but the deletion lands wherever the
+	// parent link points.
+	t.Run("refuses a symlinked parent component", func(t *testing.T) {
+		t.Parallel()
+		base := t.TempDir()
+		outside := t.TempDir()
+		victim := filepath.Join(outside, "extensions", "entire")
+		require.NoError(t, os.MkdirAll(victim, 0o750))
+		if err := os.Symlink(outside, filepath.Join(base, "link")); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		root, err := os.OpenRoot(base)
+		require.NoError(t, err)
+		defer root.Close()
+
+		err = osroot.RemoveAllNoSymlinks(root, "link/extensions/entire")
+		require.ErrorIs(t, err, osroot.ErrSymlinkedPath)
+		assert.DirExists(t, victim, "the deletion must not reach through the link")
+	})
+
+	// A link at the leaf costs the link, not the tree at the far end, which is
+	// os.RemoveAll's behaviour too.
+	t.Run("unlinks a symlinked leaf without following it", func(t *testing.T) {
+		t.Parallel()
+		base := t.TempDir()
+		outside := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(outside, "keep"), []byte("x"), 0o600))
+		if err := os.Symlink(outside, filepath.Join(base, "leaf")); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		root, err := os.OpenRoot(base)
+		require.NoError(t, err)
+		defer root.Close()
+
+		require.NoError(t, osroot.RemoveAllNoSymlinks(root, "leaf"))
+		_, statErr := os.Lstat(filepath.Join(base, "leaf"))
+		assert.True(t, os.IsNotExist(statErr), "the link is gone")
+		assert.FileExists(t, filepath.Join(outside, "keep"), "its target is not")
+	})
+}

--- a/cmd/entire/cli/runner_gather.go
+++ b/cmd/entire/cli/runner_gather.go
@@ -166,14 +166,28 @@ func listWorktreeTopLevel(repoRoot string) ([]os.DirEntry, error) {
 }
 
 // readCapped reads name from the worktree at repoRoot and truncates it to maxLen
-// characters, appending a truncation marker when cut. Returns ok=false when the
-// file can't be read.
+// bytes, appending a truncation marker when cut. Returns ok=false when the file
+// can't be read.
+//
+// The read itself is bounded, not just the result. These are working-tree files
+// named by convention (README.md, CONTRIBUTING.md), so they arrive by clone and
+// their size is not ours to trust — and the caller has already said how much of
+// one it will use. Reading a gigabyte in order to keep its first 4KB is a cost
+// with no return.
 func readCapped(repoRoot, name string, maxLen int) (string, bool) {
 	root, err := worktreedir.OpenAt(repoRoot)
 	if err != nil {
 		return "", false
 	}
-	data, err := osroot.ReadFileNoFollow(root, name)
+	f, err := osroot.OpenNoFollow(root, name)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+
+	// maxLen+1 so a file sitting exactly on the cap is distinguishable from one
+	// over it, which is what decides whether the marker is appended.
+	data, err := io.ReadAll(io.LimitReader(f, int64(maxLen)+1))
 	if err != nil {
 		return "", false
 	}

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -2310,26 +2310,32 @@ func promptTelemetryConsent(settings *EntireSettings, telemetryFlag bool) error 
 func maybePromptVercelDeploymentDisable(ctx context.Context, w io.Writer, targetFile string, promptFn func() (bool, error)) (bool, error) {
 	repoRoot, rootErr := paths.WorktreeRoot(ctx)
 	if rootErr == nil {
-		vercelJSONPath := filepath.Join(repoRoot, "vercel.json")
+		// Through the worktree's root: these are working-tree files, so they
+		// arrive by clone, and a joined path handed to os.Stat/os.ReadFile
+		// resolves wherever a checked-in symlink points. In-repo links are
+		// still followed, which is what a monorepo's shared vercel.json needs.
+		worktree, err := worktreedir.OpenAt(repoRoot)
+		if err != nil {
+			fmt.Fprintf(w, "Note: Skipping Vercel deployment update: could not open the worktree: %v\n", err)
+			return false, nil
+		}
+
 		hasVercelJSON := false
-		if _, err := os.Stat(vercelJSONPath); err == nil {
+		if _, err := worktree.Stat(vercelconfig.FileName); err == nil {
 			hasVercelJSON = true
 		} else if !os.IsNotExist(err) {
-			fmt.Fprintf(w, "Note: Skipping Vercel deployment update: could not check vercel.json: %v\n", err)
+			fmt.Fprintf(w, "Note: Skipping Vercel deployment update: could not check %s: %v\n", vercelconfig.FileName, err)
 			return false, nil
 		}
 
 		hasVercelProject := hasVercelJSON
 		if !hasVercelProject {
-			for _, path := range []string{
-				filepath.Join(repoRoot, ".vercel"),
-				filepath.Join(repoRoot, "vercel.ts"),
-			} {
-				if _, err := os.Stat(path); err == nil {
+			for _, name := range []string{".vercel", "vercel.ts"} {
+				if _, err := worktree.Stat(name); err == nil {
 					hasVercelProject = true
 					break
 				} else if !os.IsNotExist(err) {
-					fmt.Fprintf(w, "Note: Skipping Vercel deployment update: could not check %s: %v\n", path, err)
+					fmt.Fprintf(w, "Note: Skipping Vercel deployment update: could not check %s: %v\n", name, err)
 					return false, nil
 				}
 			}
@@ -2353,7 +2359,7 @@ func maybePromptVercelDeploymentDisable(ctx context.Context, w io.Writer, target
 			return false, nil
 		}
 
-		if config, alreadyDisabled, loadErr := vercelconfig.Load(vercelJSONPath); loadErr == nil &&
+		if config, alreadyDisabled, loadErr := vercelconfig.LoadIn(worktree, vercelconfig.FileName); loadErr == nil &&
 			config != nil && alreadyDisabled {
 			targetSettings.Vercel = true
 			if err := saveSettingsToTarget(ctx, targetSettings, targetFile); err != nil {

--- a/cmd/entire/cli/vercelconfig/vercelconfig.go
+++ b/cmd/entire/cli/vercelconfig/vercelconfig.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"sync"
@@ -70,15 +71,35 @@ func ResetSettingsCache() {
 	cachedSettingsMu.Unlock()
 }
 
-// Load reads a Vercel config file if present.
-func Load(path string) (map[string]any, bool, error) {
-	//nolint:gosec // path is provided by repository-local callers and intentionally supports arbitrary locations in tests
-	data, err := os.ReadFile(path)
+// maxConfigBytes bounds the vercel.json read. The file arrives with the
+// checkout, so its size is not ours to trust, and everything downstream of the
+// parse collapses to a single bool.
+const maxConfigBytes = 1 << 20
+
+// LoadIn reads the Vercel config file named inside root, if present.
+//
+// Through the worktree's root rather than a path joined onto the repo root:
+// vercel.json is a working-tree file, so it arrives by clone. A symlink that
+// stays inside the repository is still followed — pointing vercel.json at a
+// monorepo's shared config is a real setup, and this file is the user's, not
+// Entire's — while one leaving the worktree is refused, which is the property
+// the worktreedir anchor exists to give.
+func LoadIn(root *os.Root, name string) (map[string]any, bool, error) {
+	f, err := root.Open(name)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return make(map[string]any), false, nil
 		}
 		return nil, false, fmt.Errorf("read %s: %w", FileName, err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, maxConfigBytes+1))
+	if err != nil {
+		return nil, false, fmt.Errorf("read %s: %w", FileName, err)
+	}
+	if len(data) > maxConfigBytes {
+		return nil, false, fmt.Errorf("%s exceeds %d bytes", FileName, maxConfigBytes)
 	}
 
 	var config map[string]any

--- a/cmd/entire/cli/vercelconfig/vercelconfig_test.go
+++ b/cmd/entire/cli/vercelconfig/vercelconfig_test.go
@@ -1,0 +1,110 @@
+package vercelconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func openRoot(t *testing.T, dir string) *os.Root {
+	t.Helper()
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("OpenRoot: %v", err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return root
+}
+
+func TestLoadIn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("absent file yields an empty config", func(t *testing.T) {
+		t.Parallel()
+		config, disabled, err := LoadIn(openRoot(t, t.TempDir()), FileName)
+		if err != nil {
+			t.Fatalf("LoadIn: %v", err)
+		}
+		if len(config) != 0 || disabled {
+			t.Errorf("config = %v, disabled = %v", config, disabled)
+		}
+	})
+
+	t.Run("reads a config and reports whether Entire branches are disabled", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		body := []byte(`{"git":{"deploymentEnabled":{"` + BranchPattern + `":false}}}`)
+		if err := os.WriteFile(filepath.Join(dir, FileName), body, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		config, disabled, err := LoadIn(openRoot(t, dir), FileName)
+		if err != nil {
+			t.Fatalf("LoadIn: %v", err)
+		}
+		if config == nil {
+			t.Fatal("config is nil")
+		}
+		if !disabled {
+			t.Error("deployment should read as disabled")
+		}
+	})
+
+	t.Run("malformed JSON is an error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, FileName), []byte("{"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := LoadIn(openRoot(t, dir), FileName); err == nil {
+			t.Error("want a parse error")
+		}
+	})
+
+	// vercel.json arrives with the checkout, so its size is not ours to trust.
+	t.Run("refuses a file over the cap", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		body := `{"padding":"` + strings.Repeat("x", maxConfigBytes) + `"}`
+		if err := os.WriteFile(filepath.Join(dir, FileName), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := LoadIn(openRoot(t, dir), FileName)
+		if err == nil || !strings.Contains(err.Error(), "exceeds") {
+			t.Errorf("err = %v, want an over-cap error", err)
+		}
+	})
+
+	// The containment the root exists for: a link that stays inside the
+	// repository is a real monorepo setup and is followed, one leaving it is not.
+	t.Run("symlinks", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		outside := t.TempDir()
+
+		if err := os.WriteFile(filepath.Join(dir, "shared.json"), []byte(`{"inside":true}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("shared.json", filepath.Join(dir, FileName)); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		config, _, err := LoadIn(openRoot(t, dir), FileName)
+		if err != nil {
+			t.Fatalf("an in-repo link must still be followed: %v", err)
+		}
+		if config["inside"] != true {
+			t.Errorf("config = %v", config)
+		}
+
+		escaping := filepath.Join(outside, "escape.json")
+		if err := os.WriteFile(escaping, []byte(`{"outside":true}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(escaping, filepath.Join(dir, "vercel.escaping.json")); err != nil {
+			t.Fatal(err)
+		}
+		if got, _, err := LoadIn(openRoot(t, dir), "vercel.escaping.json"); err == nil {
+			t.Errorf("LoadIn followed a link out of the worktree: %v", got)
+		}
+	})
+}

--- a/cmd/entire/cli/worktreedir/worktreedir.go
+++ b/cmd/entire/cli/worktreedir/worktreedir.go
@@ -62,7 +62,22 @@ func OpenAt(worktreeRoot string) (*os.Root, error) {
 // absolute ones from them; this is the single conversion back, so callers stop
 // joining a root path onto a git path and reading the result.
 func Name(worktreeRoot, p string) (string, error) {
-	if !filepath.IsAbs(p) {
+	// VolumeName alongside IsAbs, the pairing SessionStore.Name,
+	// validation.ValidateSessionID and gitrepo's alternates checks already use.
+	// A Windows drive-relative path like "C:foo" contains no separator and IsAbs
+	// reports false, so it would otherwise be taken as a name inside the
+	// worktree — while filepath.Join drops the base directory when the appended
+	// element carries a volume. Sending it down the absolute branch makes
+	// filepath.Rel reject it across volumes, which is the answer this
+	// containment check exists to give. No-op on Unix, where VolumeName is
+	// always empty.
+	//
+	// Go's os.Root rejects such a name one layer down (every name goes through
+	// filepathlite.IsLocal), so this is not a reachable escape today. It is
+	// closed anyway because Name exists to answer "is this inside the worktree?"
+	// independently of the caller, and readWorktreeFileSafely feeds it paths
+	// that arrive from the API.
+	if !filepath.IsAbs(p) && filepath.VolumeName(p) == "" {
 		cleaned := filepath.ToSlash(filepath.Clean(filepath.FromSlash(p)))
 		if cleaned == "." || paths.IsRelativeTraversal(cleaned) {
 			return "", fmt.Errorf("%q does not name a file in the worktree", p)

--- a/cmd/entire/cli/worktreedir/worktreedir_test.go
+++ b/cmd/entire/cli/worktreedir/worktreedir_test.go
@@ -1,0 +1,75 @@
+package worktreedir
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestName(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(string(filepath.Separator), "repo")
+
+	t.Run("relative name is kept", func(t *testing.T) {
+		t.Parallel()
+		got, err := Name(root, "api/src/types.ts")
+		if err != nil {
+			t.Fatalf("Name: %v", err)
+		}
+		if got != "api/src/types.ts" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("absolute path inside the worktree is relativized", func(t *testing.T) {
+		t.Parallel()
+		got, err := Name(root, filepath.Join(root, "api", "file.ts"))
+		if err != nil {
+			t.Fatalf("Name: %v", err)
+		}
+		if got != "api/file.ts" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	for _, p := range []string{
+		"",
+		".",
+		"../escape",
+		"api/../../escape",
+	} {
+		t.Run("rejects "+p, func(t *testing.T) {
+			t.Parallel()
+			if got, err := Name(root, p); err == nil {
+				t.Errorf("Name(%q) = %q, want error", p, got)
+			}
+		})
+	}
+
+	// "C:foo" is drive-relative on Windows: separator-free, and IsAbs reports
+	// false, so pairing IsAbs with VolumeName is what keeps it off the name
+	// branch — filepath.Join would otherwise drop the base directory. On Unix
+	// the same string is an ordinary relative filename and must be accepted,
+	// which is why this asserts each platform's answer rather than skipping.
+	t.Run("drive-relative path", func(t *testing.T) {
+		t.Parallel()
+		got, err := Name(root, "C:foo")
+		if filepath.VolumeName("C:foo") != "" {
+			if err == nil {
+				t.Errorf("Name(\"C:foo\") = %q, want error on a volume-aware platform", got)
+			}
+			return
+		}
+		if err != nil || got != "C:foo" {
+			t.Errorf("Name(\"C:foo\") = %q, %v; want it kept as a plain filename", got, err)
+		}
+	})
+
+	t.Run("rejects an absolute path outside the worktree", func(t *testing.T) {
+		t.Parallel()
+		outside := filepath.Join(string(filepath.Separator), "elsewhere", "file.ts")
+		if got, err := Name(root, outside); err == nil {
+			t.Errorf("Name(%q) = %q, want error", outside, got)
+		}
+	})
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1202
<!-- entire-trail-link-end -->

Follow-up to #2180. A second pass over the migrated tree found five places still
doing filesystem work outside an anchor, and the diagnostic that would surface the
condition they now refuse. This brings them onto the same footing as the rest of
the tree.

## Pi's extension directory

`agent/pi/hooks.go` was the last registered agent whose hook-config surface had
not moved. It joined `.pi/extensions/entire/index.ts` onto the repo root and
handed the result to `os.ReadFile` / `os.MkdirAll` / `os.WriteFile` /
`os.RemoveAll`, each with a `//nolint:gosec` about where the path was *built*
rather than where it *resolves* — the justification `agent.HookConfigFile`'s doc
comment already calls out as the one that says nothing useful. A working tree
arrives by clone, so `.pi` is a component the repository supplies, and every one
of those four calls resolved through it.

Routed through `agent.OpenHookConfig`, which the other eight agents already use:
the base is the worktree root, `.pi/extensions/entire/index.ts` is a name inside
it, and directories are created with `MkdirAllNoSymlink` so a symlinked compon
is refused by name instead of followed. `.opencode/plugins/entire.ts` is the
structurally identical case — embedded TS file, worktree-resident, marker-chec
— and was already on this path; pi is now the same shape rather than the exception
beside it. Worth noting for the next integration: pi is auto-detected
(`DetectPresence` stats `.pi`), so it reaches these operations without the user
naming it, which is the argument for routing a new agent through the anchor by
default rather than trusting review to notice.

Two supporting pieces:

- **`osroot.RemoveAllNoSymlinks`.** `os.Root.RemoveAll` refuses a descent that
  would leave the root and unlinks a symlinked leaf rather than following it, but
  it says nothing about the components *above* the leaf — which is where `.pi`
  sits. This pins the parent first, then removes a single named component. Same
  relationship `OpenChild` has to a bare `Root.OpenRoot`.
- **`HookConfigFile.RemoveDir`.** Pi discovers extensions *by directory*, so
  removing only the file leaves an empty `.pi/extensions/entire` for pi to find
  with nothing to load. Deliberately not general: every other agent writes into a
  directory the agent itself owns, where `Remove` of the file is the correct
  uninstall and taking the parent would delete the user's own config with it.
  Refuses the case where the directory to remove would be the worktree root.

`agent.GeneratedHookFileState` — the path-based drift check that predates the
rooted `HookConfigFile.GeneratedState` — had pi as its only caller and is
deleted, so there is no unrooted variant left to pick up.

## Four sites beside it

- **`vercel.json`** (`setup.go`, `vercelconfig`). A working-tree file read wit
  `os.Stat` / `os.ReadFile` on a joined path. Now read through the worktree an
  as `LoadIn(root, name)`, with a 1 MiB cap: the file arrives with the checkout, so
  its size is not ours to choose, and everything downstream of the parse collapses
  to a single bool. In-repo symlinks are still followed on purpose — pointing
  `vercel.json` at a monorepo's shared config is a real setup, and this file i
  user's rather than Entire's — while one leaving the worktree is refused, which is
  the property the anchor exists to give.
- **`worktreedir.Name`**. Given the `VolumeName` pairing `SessionStore.Name` got in
  57b275ac6, which `ValidateSessionID` and gitrepo's alternates checks already
  `os.Root` rejects a drive-relative name one layer down (`filepathlite.IsLocal`),
  so this changes no behaviour today; it is closed because `Name` exists to an
  "is this inside the worktree?" independently of its caller, and
  `readWorktreeFileSafely` feeds it paths that arrive from the API. It was the
  remaining `IsAbs` in a containment role without the pairing.
- **The persistent-ref lock** (`checkpoint/persistent_ref_update.go`). The las
  `.git`-resident lock still opening by path rather than through the common dir's
  root. Now mirrors `shadowBranchLock`: `gitdir.OpenAt` + `MkdirAllNoSymlink` +
  `AcquireContextIn`. Git will not check a path out into `.git`, so this is
  consistency and defence in depth — but `openLockFileIn` exists for exactly t
  and one caller sitting outside it is how the next one gets written that way
- **`readCapped`** (`runner_gather.go`). Bounds the read, not just the result.
  These are working-tree files named by convention (`README.md`, `CLAUDE.md`), so
  their size is not ours to assume, and the caller has already said how much of one
  it will use. Reading a gigabyte to keep its first 4 KB is a cost with no ret

## `doctor` now reports symlinked agent directories

The condition these refusals produce was invisible after the fact. `enable` fa
loudly on it, but once a repo is enabled `HookConfigFile.Exists()` deliberately
reports a symlinked parent as *absent* — so `entire status` showed hooks missi
without saying why, and `entire clean` skipped the directory on the stated grounds
that doctor reports a symlinked agent directory. Nothing did.

`checkAgentDirSymlinks` runs beside `checkEntireDirSymlinks` and names the
outermost link, once per finding. Candidates come from the registry and the
scaffold templates rather than a list in the function. Unlike `.entire`, these
trees are largely the user's, so it examines only the components Entire itself
creates and writes through: `.claude/skills/my-own -> ../../shared/skills/my-o
is a real setup, and reporting it would train people to skip this section.

## Follow-up

`agentSymlinkCheckPaths` derives from `AllProtectedDirs()` plus the skill
templates, not from the hook-config relPaths, so the two agents whose config nests
below their top-level directory have their Entire-created intermediate directories
unchecked — a symlink at `.pi/extensions` or `.opencode/plugins` produces no
doctor output. The refusals cover both; this is reporting only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hook install/uninstall and recursive delete paths where symlink mistakes could write or destroy files outside the repo; changes are defensive with new doctor reporting and tests, but they affect every agent’s enable flow.
> 
> **Overview**
> This PR finishes **os.Root / worktree anchoring** for agent hook configuration and closes gaps where symlinked repo paths could still be followed or deleted outside the worktree.
> 
> **Pi** is migrated off raw `os.ReadFile` / `MkdirAll` / `WriteFile` / `RemoveAll` onto `agent.HookConfigFile` like the other agents. Uninstall uses new **`HookConfigFile.RemoveDir`** (backed by **`osroot.RemoveAllNoSymlinks`**) so the whole `.pi/extensions/entire` tree is removed without following a symlinked `.pi`. Path-based **`GeneratedHookFileState`** is removed; drift checks go through **`HookConfigFile.GeneratedState`**.
> 
> **`agent.HookConfigLocator`** (`HookConfigRelPath`) centralizes each agent’s config path for **`AllHookConfigRelPaths()`**, refactors all `OpenHookConfig` call sites, and powers a **build guard** ensuring every agent that opens a hook config declares its path.
> 
> **`entire doctor`** gains **`checkAgentDirSymlinks`**, listing symlinked or unreadable components on paths Entire creates (hook config paths from the locator plus skill scaffold parents), so “hooks missing” on `status` gets an explicit cause.
> 
> Additional hardening: **persistent ref flock** via `gitdir` + `flock.AcquireContextIn`; **`vercelconfig.LoadIn`** and setup’s Vercel probe through the worktree with a read cap; **`readCapped`** bounded reads; **`worktreedir.Name`** treats Windows drive-relative paths like other containment checks. Docs in **`CLAUDE.md`** are expanded for symlinked hook files/dirs and Pi auto-detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98bdf18e1e25b02ce9f5f32112eec79bd6503236. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->