### PR TITLE
experts: resolve repo id from placement cell resolution, not a redundant listing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1211,10 +1211,12 @@ therefore has exactly three routing shapes, mirroring the entire.io BFF:
   suspended processing placement, control-plane error, timeout) returns an
   error instead of falling back to home-jurisdiction routing — a wrong-region
   "success" is worse than a command failure for repo-scoped data. Used by
-  trails and experts (`NewAuthenticatedEntireAPICellClient` in
-  `api_client.go`). `resolveRepoCellPlacement` performs the same lookup for
-  callers that also need the placement's id (repo_id) alongside its cell —
-  used by cross-repo checkpoint reads (`explain --repo`, `explain_repo.go`).
+  trails (`NewAuthenticatedEntireAPICellClient` in `api_client.go`) and by
+  `experts --repo <ulid>`. `resolveRepoCellPlacement` performs the same lookup
+  for callers that also need the placement's id (repo_id) alongside its cell —
+  used by cross-repo checkpoint reads (`explain --repo`, `explain_repo.go`) and
+  by `experts --repo owner/repo`, which sends that placement id to entire-api
+  instead of re-deriving it from a data-plane repo listing.
 - **User-scoped `/me` → home cell, never fan out**:
   `auth.NewEntireAPICellClient(ctx, insecure, nil)` routes by the
   `home_jurisdiction` JWT claim; activity/recap use it with a data-API

--- a/cmd/entire/cli/api_client.go
+++ b/cmd/entire/cli/api_client.go
@@ -48,23 +48,21 @@ func NewAuthenticatedAPIClient(ctx context.Context, insecureHTTP bool) (*api.Cli
 }
 
 // NewAuthenticatedEntireAPICellClient creates an API client for repo-scoped
-// entire-api routes (e.g. trails, experts). It exchanges the login JWT for a
+// entire-api routes (e.g. trails). It exchanges the login JWT for a
 // jurisdictional identity token and dials the entire-api cell directly, because
-// the BFF does not proxy these routes for bearer callers (COR-666).
+// the BFF does not proxy these routes for bearer callers.
 //
-// fullName (owner/repo) or ulid identifies the repo whose cell to reach; ulid
-// wins when both are set, and both being empty is an error, not a fallback to
-// the caller's home cell. The repo's PROCESSING cell + jurisdiction are
-// resolved from the control plane
+// fullName (owner/repo) identifies the repo whose cell to reach. The repo's
+// PROCESSING cell + jurisdiction are resolved from the control plane
 // (mirroring the BFF's per-repo cell selection) so the call lands in the
 // region that actually holds the repo's data. This is NOT best-effort: a
 // resolution failure fails the command instead of falling back to the
 // caller's home cell, because for repo-scoped data a silent wrong-region
 // "success" is worse than an error — that fallback is exactly what used to
-// make `entire trail`/`entire experts` read the wrong region for a
-// multi-homed repo like entirehq/entire.io.
-func NewAuthenticatedEntireAPICellClient(ctx context.Context, insecureHTTP bool, fullName, ulid string) (*api.Client, error) {
-	target, err := resolveRepoCellTarget(ctx, fullName, ulid)
+// make `entire trail` read the wrong region for a multi-homed repo like
+// entirehq/entire.io.
+func NewAuthenticatedEntireAPICellClient(ctx context.Context, insecureHTTP bool, fullName string) (*api.Client, error) {
+	target, err := resolveRepoCellTarget(ctx, fullName, "")
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +75,7 @@ func NewAuthenticatedEntireAPICellClient(ctx context.Context, insecureHTTP bool,
 // newTrailAPIClient dials the entire-api cell that owns the repository. It is a
 // package seam so tests can substitute a client pointed at a stub server.
 var newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, fullName string) (*api.Client, error) {
-	client, err := NewAuthenticatedEntireAPICellClient(ctx, insecureHTTP, fullName, "")
+	client, err := NewAuthenticatedEntireAPICellClient(ctx, insecureHTTP, fullName)
 	if errors.Is(err, clusterdiscovery.ErrNoAuthContext) {
 		// Preserve cluster discovery's detailed host/context hint while restoring
 		// the sentinel trail commands use for the standard login UX.

--- a/cmd/entire/cli/authcmd.go
+++ b/cmd/entire/cli/authcmd.go
@@ -66,7 +66,6 @@ func renderDataAPIAuthError(ctx context.Context, errW io.Writer, ownerRepo strin
 // onboarded": zero rows in the repos index also means the caller cannot SEE
 // the repo (where 'entire repo mirror create' would fail too), and a row whose
 // primaries name no processing placement can be a repo mid-onboarding.
-// resolveExpertsRepoID already words the equivalent case this way.
 func renderRepoNotOnboarded(errW io.Writer, ownerRepo string, err error) error {
 	if !errors.Is(err, errRepoNotOnboarded) {
 		return nil

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -285,9 +285,11 @@ type repoCellPlacement struct {
 // resolveRepoCellTarget's owner/repo path delegates to this function and
 // discards RepoID, rather than the two duplicating the same resolution body:
 // the two functions exist separately only because their callers need
-// different return shapes for the same lookup — this one also needs the
-// placement id (repo_id), which resolveRepoCellTarget has no caller for and
-// so doesn't return — not because the resolution logic itself differs.
+// different return shapes for the same lookup. Some owner/repo callers only
+// need the cell (resolveRepoCellTarget's own callers) and go through that
+// thinner wrapper; others — explain --repo, experts --repo — also need the
+// placement id (repo_id) and call this one directly instead of re-deriving it
+// a second way.
 func resolveRepoCellPlacement(ctx context.Context, owner, repo string) (repoCellPlacement, error) {
 	ctx, cancel := context.WithTimeout(ctx, requiredCellResolveTimeout)
 	defer cancel()

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -59,9 +59,7 @@ const (
 	expertsDefaultLimit = 8
 	expertsMaxLimit     = 20
 	// expertsAPIReposPath is the entire-api route prefix for the repo-scoped
-	// experts POST route (see expertsAPIPath). It is no longer also used for a
-	// GET repo-listing lookup — that resolution now happens against the
-	// control plane instead (resolveRepoCellPlacement / resolveRepoCellTarget).
+	// experts POST route (see expertsAPIPath).
 	expertsAPIReposPath = "/api/v1/repos"
 )
 
@@ -228,11 +226,14 @@ func runExperts(ctx context.Context, out, errOut io.Writer, args []string, f *ex
 	}
 
 	// The data API (entire-api) is repo-ULID keyed. --repo may be a ULID (used
-	// directly) or an owner/repo, which we resolve to its ULID after the client
-	// exists (via the caller's accessible-repo list). With no --repo we derive
-	// owner/repo from the git origin.
+	// directly) or an owner/repo, which the control plane resolves to its
+	// processing placement id below, before the cell client is built. With no
+	// --repo we derive owner/repo from the git origin.
 	repoOverride := strings.TrimSpace(f.repo)
 	repoIsULID := looksLikeULID(repoOverride)
+	if repoIsULID {
+		repoOverride = strings.ToUpper(repoOverride) // canonicalize casing before it becomes a path segment
+	}
 	var repoFullName string
 	if !repoIsULID {
 		var err error
@@ -303,10 +304,8 @@ func runExperts(ctx context.Context, out, errOut io.Writer, args []string, f *ex
 			return fmt.Errorf("resolve experts cell: %w", err)
 		}
 	} else {
-		owner, repo, ok := strings.Cut(repoFullName, "/")
-		if !ok {
-			return fmt.Errorf("invalid repo %q: expected owner/repo", repoFullName)
-		}
+		// resolveExpertsRepo already validated repoFullName as "owner/repo".
+		owner, repo, _ := strings.Cut(repoFullName, "/")
 		placement, err := resolveRepoCellPlacement(ctx, owner, repo)
 		if err != nil {
 			// Not-onboarded is the most common way cell resolution fails, and
@@ -323,9 +322,6 @@ func runExperts(ctx context.Context, out, errOut io.Writer, args []string, f *ex
 
 	client, err := newExpertsAPIClient(ctx, f.insecureHTTP, target)
 	if err != nil {
-		if rendered := renderRepoNotOnboarded(errOut, repoFullName, err); rendered != nil {
-			return rendered
-		}
 		return fmt.Errorf("create experts API client: %w", err)
 	}
 

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -15,6 +15,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/palette"
@@ -23,20 +24,20 @@ import (
 )
 
 type expertsAPIClient interface {
-	Get(ctx context.Context, path string) (*http.Response, error)
 	Post(ctx context.Context, path string, body any) (*http.Response, error)
 }
 
-// newExpertsAPIClient builds the entire-api cell client. fullName (owner/repo)
-// or ulid identifies the repo so the client can route to the cell that hosts
-// it; one of them is required (see NewAuthenticatedEntireAPICellClient).
-var newExpertsAPIClient = func(ctx context.Context, insecureHTTP bool, fullName, ulid string) (expertsAPIClient, error) {
-	return NewAuthenticatedEntireAPICellClient(ctx, insecureHTTP, fullName, ulid)
+// newExpertsAPIClient builds the entire-api cell client for target, the cell
+// hosting the repo's processing placement (resolved by the caller via
+// resolveRepoCellPlacement for owner/repo, or resolveRepoCellTarget for a
+// ULID). A seam so tests can substitute a stub without a live cell.
+var newExpertsAPIClient = func(ctx context.Context, insecureHTTP bool, target *auth.CellTarget) (expertsAPIClient, error) {
+	return auth.NewEntireAPICellClient(ctx, insecureHTTP, target)
 }
 
 func setExpertsClientFactoryForTest(
 	t interface{ Helper() },
-	fn func(context.Context, bool, string, string) (expertsAPIClient, error),
+	fn func(context.Context, bool, *auth.CellTarget) (expertsAPIClient, error),
 ) func() {
 	t.Helper()
 	prev := newExpertsAPIClient
@@ -55,9 +56,13 @@ type expertsFlags struct {
 }
 
 const (
-	expertsDefaultLimit  = 8
-	expertsMaxLimit      = 20
-	expertsReposListPath = "/api/v1/repos"
+	expertsDefaultLimit = 8
+	expertsMaxLimit     = 20
+	// expertsAPIReposPath is the entire-api route prefix for the repo-scoped
+	// experts POST route (see expertsAPIPath). It is no longer also used for a
+	// GET repo-listing lookup — that resolution now happens against the
+	// control plane instead (resolveRepoCellPlacement / resolveRepoCellTarget).
+	expertsAPIReposPath = "/api/v1/repos"
 )
 
 // expertLocalScopeResult is the outcome of interpreting a scope argument as a
@@ -279,34 +284,49 @@ func runExperts(ctx context.Context, out, errOut io.Writer, args []string, f *ex
 		}
 	}
 
-	// Identify the repo for cell routing: a ULID goes on the ulid arg, an
-	// owner/repo on the fullName arg. The client uses whichever is set to reach
-	// the cell that hosts the repo's processing placement.
-	cellFullName, cellULID := "", ""
+	// Resolve the repo id and its cell together, from one placement: entire-api
+	// is keyed on the processing placement's id, which is only resolvable by
+	// the cell hosting that placement, so the id and the cell must come from
+	// the same lookup (see resolveRepoCellPlacement's doc comment).
+	var repoID string
+	var target *auth.CellTarget
 	if repoIsULID {
-		cellULID = repoOverride
+		repoID = repoOverride
+		var err error
+		target, err = resolveRepoCellTarget(ctx, "", repoOverride)
+		if err != nil {
+			// renderRepoNotOnboarded falls back to naming no repo when the
+			// ULID form has no owner/repo to show.
+			if rendered := renderRepoNotOnboarded(errOut, "", err); rendered != nil {
+				return rendered
+			}
+			return fmt.Errorf("resolve experts cell: %w", err)
+		}
 	} else {
-		cellFullName = repoFullName
+		owner, repo, ok := strings.Cut(repoFullName, "/")
+		if !ok {
+			return fmt.Errorf("invalid repo %q: expected owner/repo", repoFullName)
+		}
+		placement, err := resolveRepoCellPlacement(ctx, owner, repo)
+		if err != nil {
+			// Not-onboarded is the most common way cell resolution fails, and
+			// its raw chain is internal resolution steps; render it like the
+			// trail commands do instead of burying it under another wrap.
+			if rendered := renderRepoNotOnboarded(errOut, repoFullName, err); rendered != nil {
+				return rendered
+			}
+			return fmt.Errorf("resolve experts cell: %w", err)
+		}
+		repoID = placement.RepoID
+		target = placement.Target
 	}
-	client, err := newExpertsAPIClient(ctx, f.insecureHTTP, cellFullName, cellULID)
+
+	client, err := newExpertsAPIClient(ctx, f.insecureHTTP, target)
 	if err != nil {
-		// Not-onboarded is the most common way cell resolution fails, and its
-		// raw chain is internal resolution steps; render it like the trail
-		// commands do instead of burying it under another wrap. cellFullName is
-		// "" for the ULID form, where renderRepoNotOnboarded falls back to
-		// naming no repo.
-		if rendered := renderRepoNotOnboarded(errOut, cellFullName, err); rendered != nil {
+		if rendered := renderRepoNotOnboarded(errOut, repoFullName, err); rendered != nil {
 			return rendered
 		}
 		return fmt.Errorf("create experts API client: %w", err)
-	}
-
-	repoID := repoOverride
-	if !repoIsULID {
-		repoID, err = resolveExpertsRepoID(ctx, client, repoFullName)
-		if err != nil {
-			return err
-		}
 	}
 
 	resp, err := client.Post(ctx, expertsAPIPath(repoID), req)
@@ -392,61 +412,7 @@ func parseExpertsRepo(value string) (string, error) {
 }
 
 func expertsAPIPath(repoID string) string {
-	return expertsReposListPath + "/" + url.PathEscape(repoID) + "/experts"
-}
-
-// resolveExpertsRepoID maps an owner/repo to its repo ULID for the entire-api
-// data plane, which is ULID-keyed. It reads the caller's accessible-repo list
-// (GET /api/v1/repos) and matches on full name — an authz-safe resolution (the
-// list only contains repos the caller can read, so it never reveals a repo they
-// can't see). A ULID is passed straight through by the caller, so this is only
-// hit for the owner/repo form.
-func resolveExpertsRepoID(ctx context.Context, client expertsAPIClient, fullName string) (string, error) {
-	repos, err := listExpertsAccessibleRepos(ctx, client)
-	if err != nil {
-		return "", err
-	}
-	want := strings.ToLower(fullName)
-	for _, r := range repos {
-		if r.ID != "" && strings.ToLower(r.FullName) == want {
-			return r.ID, nil
-		}
-	}
-	return "", fmt.Errorf("repo %q was not found on the entire-api cell this command reached. It may be homed in another Entire region (cross-region experts routing may be incomplete), not onboarded to Entire, or outside your access", fullName)
-}
-
-type expertsRepoListItem struct {
-	ID       string `json:"id"`
-	FullName string `json:"full_name"`
-}
-
-// listExpertsAccessibleRepos returns every repo the caller can read on this data
-// API. entire-api's GET /repos currently returns the full SpiceDB-filtered set in
-// one response (no page_token), but the loop is forward-compatible if pagination
-// is added — same pattern as fetchAllPages in core list commands.
-func listExpertsAccessibleRepos(ctx context.Context, client expertsAPIClient) ([]expertsRepoListItem, error) {
-	return fetchAllPages(ctx, func(ctx context.Context, cursor string) ([]expertsRepoListItem, string, error) {
-		path := expertsReposListPath
-		if cursor != "" {
-			path += "?" + url.Values{"page_token": {cursor}}.Encode()
-		}
-		resp, err := client.Get(ctx, path)
-		if err != nil {
-			return nil, "", fmt.Errorf("list repos: %w", err)
-		}
-		defer resp.Body.Close()
-		if err := api.CheckResponse(resp); err != nil {
-			return nil, "", fmt.Errorf("list repos: %w", err)
-		}
-		var body struct {
-			Repos         []expertsRepoListItem `json:"repos"`
-			NextPageToken string                `json:"next_page_token,omitempty"`
-		}
-		if err := api.DecodeJSON(resp, &body); err != nil {
-			return nil, "", fmt.Errorf("decode repos: %w", err)
-		}
-		return body.Repos, body.NextPageToken, nil
-	})
+	return expertsAPIReposPath + "/" + url.PathEscape(repoID) + "/experts"
 }
 
 // expertsWebBaseURL is the origin used to build user-facing session links.

--- a/cmd/entire/cli/experts_test.go
+++ b/cmd/entire/cli/experts_test.go
@@ -646,7 +646,7 @@ func TestParseGitStagedScopeLinesNormalizesCRLF(t *testing.T) {
 	}
 }
 
-func TestExpertsCommandAcceptsRepoULIDWithoutResolution(t *testing.T) {
+func TestExpertsCommandAcceptsRepoULIDWithoutRepoIndexLookup(t *testing.T) {
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["api/x.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
 	cellFake := withExpertsFakeCellCore(t)
 	restore := setExpertsClientFactoryForTest(t, func(_ context.Context, _ bool, target *auth.CellTarget) (expertsAPIClient, error) {
@@ -671,6 +671,9 @@ func TestExpertsCommandAcceptsRepoULIDWithoutResolution(t *testing.T) {
 	}
 	if fake.gotPath != expertsAPIReposPath+"/"+expertsTestRepoULID+"/experts" {
 		t.Fatalf("path = %q, want %s/%s/experts", fake.gotPath, expertsAPIReposPath, expertsTestRepoULID)
+	}
+	if fake.gotTarget == nil || fake.gotTarget.BaseURL != expertsTestCellAPIURL {
+		t.Fatalf("cell target = %#v, want BaseURL %s", fake.gotTarget, expertsTestCellAPIURL)
 	}
 }
 

--- a/cmd/entire/cli/experts_test.go
+++ b/cmd/entire/cli/experts_test.go
@@ -15,47 +15,55 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/experimental"
 
 	"charm.land/lipgloss/v2"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/palette"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/internal/coreapi"
 )
 
-// expertsTestRepoULID is the id the fake resolves "acme/widget" to via the
-// accessible-repo list, so path assertions can reference the retargeted
+// expertsTestRepoULID is the processing placement id the fake control plane
+// resolves "acme/widget" to, so path assertions can reference the retargeted
 // /api/v1/repos/{id}/experts route.
 const expertsTestRepoULID = "0123456789ABCDEFGHJKMNPQRS"
 
-var defaultExpertsReposBody = `{"repos":[{"id":"` + expertsTestRepoULID + `","full_name":"acme/widget"}],"from_db":true}`
+const (
+	expertsTestClusterSlug = "cell1"
+	expertsTestClusterHost = "us.entire.io"
+	expertsTestCellAPIURL  = "https://cell.example.test"
+)
 
-type fakeExpertsClient struct {
-	status     int
-	body       string
-	reposBody  string   // GET /api/v1/repos body; defaults to acme/widget -> expertsTestRepoULID
-	reposPages []string // when set, paginated GET /api/v1/repos responses in order
-
-	gotPath     string
-	gotBody     any
-	gotGetPath  string
-	gotGetPaths []string
+func expertsTestCluster() coreapi.Cluster {
+	return coreapi.Cluster{
+		Slug:         expertsTestClusterSlug,
+		Jurisdiction: "us",
+		PublicUrl:    "https://" + expertsTestClusterHost,
+		ApiUrl:       coreapi.NewOptString(expertsTestCellAPIURL),
+	}
 }
 
-// Get serves the accessible-repo discovery list used to resolve owner/repo -> ULID.
-func (f *fakeExpertsClient) Get(_ context.Context, path string) (*http.Response, error) {
-	f.gotGetPath = path
-	f.gotGetPaths = append(f.gotGetPaths, path)
-	var body string
-	switch {
-	case len(f.reposPages) > 0:
-		body = f.reposPages[0]
-		f.reposPages = f.reposPages[1:]
-	case f.reposBody != "":
-		body = f.reposBody
-	default:
-		body = defaultExpertsReposBody
+// withExpertsFakeCellCore wires the control-plane resolution both --repo forms
+// need: resolveRepoCellPlacement for owner/repo ("acme/widget" -> placement id
+// expertsTestRepoULID on expertsTestClusterSlug), and resolveRepoCellTarget for
+// a bare ULID (GetRepo -> expertsTestClusterHost).
+func withExpertsFakeCellCore(t *testing.T) *fakeCellCore {
+	t.Helper()
+	f := &fakeCellCore{
+		repos: reposOutput(repoIndexFixture("acme/widget", expertsTestRepoULID,
+			placementFixture{id: expertsTestRepoULID, slug: expertsTestClusterSlug})),
+		clusters: []coreapi.Cluster{expertsTestCluster()},
+		repo:     &coreapi.Repo{ID: expertsTestRepoULID, ClusterHost: coreapi.NewOptString(expertsTestClusterHost)},
 	}
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(body)),
-	}, nil
+	withFakeCellCore(t, f)
+	return f
+}
+
+type fakeExpertsClient struct {
+	status int
+	body   string
+
+	gotPath   string
+	gotBody   any
+	gotTarget *auth.CellTarget
 }
 
 func (f *fakeExpertsClient) Post(_ context.Context, path string, body any) (*http.Response, error) {
@@ -69,6 +77,18 @@ func (f *fakeExpertsClient) Post(_ context.Context, path string, body any) (*htt
 		StatusCode: status,
 		Body:       io.NopCloser(strings.NewReader(f.body)),
 	}, nil
+}
+
+// withExpertsFakeClient wires the entire-api cell client seam to fake, and the
+// control plane so both --repo forms (owner/repo, ULID) resolve successfully.
+func withExpertsFakeClient(t *testing.T, fake *fakeExpertsClient) {
+	t.Helper()
+	withExpertsFakeCellCore(t)
+	restore := setExpertsClientFactoryForTest(t, func(_ context.Context, _ bool, target *auth.CellTarget) (expertsAPIClient, error) {
+		fake.gotTarget = target
+		return fake, nil
+	})
+	t.Cleanup(restore)
 }
 
 func expertsSuccessBody() string {
@@ -139,7 +159,9 @@ func TestExpertsCommandIsExperimentalAndListedInLabs(t *testing.T) {
 
 func TestExpertsCommandSendsQueryAndPrintsJSON(t *testing.T) {
 	fake := &fakeExpertsClient{body: expertsSuccessBody()}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
+	cellFake := withExpertsFakeCellCore(t)
+	restore := setExpertsClientFactoryForTest(t, func(_ context.Context, _ bool, target *auth.CellTarget) (expertsAPIClient, error) {
+		fake.gotTarget = target
 		return fake, nil
 	})
 	defer restore()
@@ -153,12 +175,16 @@ func TestExpertsCommandSendsQueryAndPrintsJSON(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute experts: %v", err)
 	}
-	if fake.gotPath != expertsReposListPath+"/"+expertsTestRepoULID+"/experts" {
+	if fake.gotPath != expertsAPIReposPath+"/"+expertsTestRepoULID+"/experts" {
 		t.Fatalf("path = %q", fake.gotPath)
 	}
-	if fake.gotGetPath != expertsReposListPath {
-		t.Fatalf("owner/repo should resolve via GET %s, got %q", expertsReposListPath, fake.gotGetPath)
+	if cellFake.lastListReposParams.Filter.Or("") != "acme/widget" {
+		t.Fatalf("control-plane repo lookup Filter = %q, want acme/widget", cellFake.lastListReposParams.Filter.Or(""))
 	}
+	if fake.gotTarget == nil || fake.gotTarget.BaseURL != expertsTestCellAPIURL {
+		t.Fatalf("cell target = %#v", fake.gotTarget)
+	}
+
 	body, ok := fake.gotBody.(expertsRequest)
 	if !ok {
 		t.Fatalf("body type = %T", fake.gotBody)
@@ -184,10 +210,7 @@ func TestExpertsCommandSendsQueryAndPrintsJSON(t *testing.T) {
 
 func TestExpertsCommandPrintsAgentCenteredEvidence(t *testing.T) {
 	fake := &fakeExpertsClient{body: expertsSuccessBody()}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -261,10 +284,7 @@ func TestExpertsCommandUsesStagedFilesAsScopes(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["billing/webhooks/sender.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -303,10 +323,7 @@ func TestExpertsCommandUsesStagedDeletionsAsScopes(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["billing/webhooks/sender.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -343,10 +360,7 @@ func TestExpertsCommandResolvesRepoRootPathFromSubdirectory(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["cmd/entire/cli/experts.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -385,10 +399,7 @@ func TestExpertsCommandResolvesCWDRelativePathFromSubdirectory(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["cmd/entire/cli/experts.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -410,10 +421,7 @@ func TestExpertsCommandResolvesCWDRelativePathFromSubdirectory(t *testing.T) {
 
 func TestExpertsCommandTreatsPathLikeRepoOverrideArgAsScope(t *testing.T) {
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["api/deleted.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -443,10 +451,7 @@ func TestExpertsCommandRelativizesAbsoluteDeletedPathScope(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["api/deleted.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -489,10 +494,7 @@ func TestExpertsCommandRelativizesDeletedPathScopeFromSubdirectory(t *testing.T)
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["cmd/entire/cli/deleted.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -528,10 +530,7 @@ func TestExpertsCommandAcceptsCaseInsensitiveRepoOverrideForLocalScope(t *testin
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["cmd/"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -568,11 +567,8 @@ func TestExpertsCommandRejectsMismatchedRepoOverrideForLocalScope(t *testing.T) 
 	paths.ClearWorktreeRootCache()
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return &fakeExpertsClient{}, nil
-	})
-	defer restore()
-
+	// The mismatch is caught before cell resolution runs, so no control-plane
+	// or entire-api client seam is needed here.
 	root := NewRootCmd()
 	var out bytes.Buffer
 	root.SetOut(&out)
@@ -587,10 +583,7 @@ func TestExpertsCommandRejectsMismatchedRepoOverrideForLocalScope(t *testing.T) 
 
 func TestExpertsCommandDoesNotRewritePathScope503AsCodeSearch(t *testing.T) {
 	fake := &fakeExpertsClient{status: http.StatusServiceUnavailable, body: `{"error":"Database unavailable"}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -613,10 +606,7 @@ func TestExpertsCommandDoesNotRewritePathScope503AsCodeSearch(t *testing.T) {
 // (not the raw "fetch experts: API error" wrap).
 func TestExpertsCommandQuery503ShowsCodeSearchMessage(t *testing.T) {
 	fake := &fakeExpertsClient{status: http.StatusServiceUnavailable, body: `{"error":"Service Unavailable"}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
+	withExpertsFakeClient(t, fake)
 
 	root := NewRootCmd()
 	var out bytes.Buffer
@@ -656,46 +646,11 @@ func TestParseGitStagedScopeLinesNormalizesCRLF(t *testing.T) {
 	}
 }
 
-func TestResolveExpertsRepoIDPaginatesAccessibleRepoList(t *testing.T) {
-	const otherULID = "0123456789ABCDEFGHJKMNPR"
-	fake := &fakeExpertsClient{
-		reposPages: []string{
-			`{"repos":[{"id":"` + otherULID + `","full_name":"other/repo"}],"next_page_token":"page2"}`,
-			`{"repos":[{"id":"` + expertsTestRepoULID + `","full_name":"acme/widget"}]}`,
-		},
-		body: `{"repo_full_name":"acme/widget","scopes":["api/x.go"],"query":null,"branch":"main","source":"db","profiles":[]}`,
-	}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
-		return fake, nil
-	})
-	defer restore()
-
-	root := NewRootCmd()
-	var out bytes.Buffer
-	root.SetOut(&out)
-	root.SetErr(&out)
-	root.SetArgs([]string{"experts", "api/x.go", "--repo", "acme/widget", "--json"})
-
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute experts with paginated repo list: %v", err)
-	}
-	if len(fake.gotGetPaths) != 2 {
-		t.Fatalf("GET paths = %#v, want two paginated requests", fake.gotGetPaths)
-	}
-	if fake.gotGetPaths[0] != expertsReposListPath {
-		t.Fatalf("first GET = %q", fake.gotGetPaths[0])
-	}
-	if fake.gotGetPaths[1] != expertsReposListPath+"?page_token=page2" {
-		t.Fatalf("second GET = %q", fake.gotGetPaths[1])
-	}
-	if fake.gotPath != expertsReposListPath+"/"+expertsTestRepoULID+"/experts" {
-		t.Fatalf("path = %q", fake.gotPath)
-	}
-}
-
 func TestExpertsCommandAcceptsRepoULIDWithoutResolution(t *testing.T) {
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["api/x.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
+	cellFake := withExpertsFakeCellCore(t)
+	restore := setExpertsClientFactoryForTest(t, func(_ context.Context, _ bool, target *auth.CellTarget) (expertsAPIClient, error) {
+		fake.gotTarget = target
 		return fake, nil
 	})
 	defer restore()
@@ -709,12 +664,66 @@ func TestExpertsCommandAcceptsRepoULIDWithoutResolution(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute experts with ULID repo: %v", err)
 	}
-	// A ULID --repo addresses the data API directly — no accessible-repo lookup.
-	if fake.gotGetPath != "" {
-		t.Fatalf("a ULID --repo should skip resolution, but GET %q was called", fake.gotGetPath)
+	// A ULID --repo addresses the data API directly — no control-plane
+	// repo-index lookup (that's the owner/repo-only path).
+	if cellFake.lastListReposParams.Filter.Or("") != "" {
+		t.Fatalf("a ULID --repo should skip the repo-index lookup, but Filter=%q was set", cellFake.lastListReposParams.Filter.Or(""))
 	}
-	if fake.gotPath != expertsReposListPath+"/"+expertsTestRepoULID+"/experts" {
-		t.Fatalf("path = %q, want %s/%s/experts", fake.gotPath, expertsReposListPath, expertsTestRepoULID)
+	if fake.gotPath != expertsAPIReposPath+"/"+expertsTestRepoULID+"/experts" {
+		t.Fatalf("path = %q, want %s/%s/experts", fake.gotPath, expertsAPIReposPath, expertsTestRepoULID)
+	}
+}
+
+// TestExpertsCommandRepoNotOnboarded covers the not-onboarded shape of
+// cell-placement resolution failure surfacing through renderRepoNotOnboarded
+// rather than a raw/double-wrapped error.
+func TestExpertsCommandRepoNotOnboarded(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
+		repos: reposOutput(), // zero rows: not onboarded
+	})
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"experts", "api/x.go", "--repo", "acme/widget"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected an error for a not-onboarded repo")
+	}
+	if !strings.Contains(out.String(), "not onboarded to Entire") {
+		t.Fatalf("expected the not-onboarded message, got:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "resolve experts cell") {
+		t.Fatalf("not-onboarded should render its own message, not the raw wrap:\n%s", out.String())
+	}
+}
+
+// TestExpertsCommandFailedPlacement covers the failed/suspended-placement
+// shape of cell-placement resolution failure, distinct from not-onboarded.
+func TestExpertsCommandFailedPlacement(t *testing.T) {
+	withFakeCellCore(t, &fakeCellCore{
+		repos: reposOutput(repoIndexFixture("acme/widget", expertsTestRepoULID,
+			placementFixture{id: expertsTestRepoULID, slug: expertsTestClusterSlug, status: coreapi.RepoPlacementStatusFailed})),
+		clusters: []coreapi.Cluster{expertsTestCluster()},
+	})
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"experts", "api/x.go", "--repo", "acme/widget"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected an error for a failed placement")
+	}
+	if !strings.Contains(err.Error(), "processing placement is failed") {
+		t.Fatalf("expected the failed-placement message, got: %v\nout:\n%s", err, out.String())
+	}
+	if strings.Contains(out.String(), "not onboarded to Entire") {
+		t.Fatalf("a failed placement is not the not-onboarded case:\n%s", out.String())
 	}
 }
 


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/1204

## Summary

`entire experts --repo owner/repo` resolved its entire-api cell via `resolveRepoCellPlacement` (control plane), then discarded the placement id it got back and re-resolved the same repo's id with a second, redundant `GET /api/v1/repos` call, linear-scanning the caller's accessible-repo list for a `full_name` match.

`resolveRepoCellPlacement` already returns both halves from one lookup: `RepoID` (the processing placement id) and `Target` (the cell hosting it). This mirrors `explain --repo` (`explain_repo.go`), which already does this correctly.

**What now resolves the repo id:** for the owner/repo form, `resolveRepoCellPlacement(ctx, owner, repo)` — its `RepoID` and `Target` come from the same placement, so they can never point at different placements. The ULID form is unchanged: it still calls `resolveRepoCellTarget` directly and uses the ULID as the repo id.

**What was deleted:** `resolveExpertsRepoID`, `listExpertsAccessibleRepos`, `expertsRepoListItem`, and `expertsReposListPath` (the GET-based repo lookup). `expertsAPIClient` is now POST-only — the `Get` method is gone entirely, so a future regression back to a listing-based lookup would fail to compile rather than silently reappear.

**Test seam change:** `newExpertsAPIClient` / `setExpertsClientFactoryForTest` used to take `(fullName, ulid string)`; they now take a resolved `*auth.CellTarget`, since the repo id and the cell are resolved together before the client is built. Tests fake the control plane (`newCellCoreClient`, reusing `cell_target_test.go`'s `fakeCellCore`/`withFakeCellCore`/fixture helpers) to drive `resolveRepoCellPlacement`, and separately fake the entire-api client for the POST call.

**Error messages that change, and why:** a not-onboarded or failed/suspended repo used to surface `resolveExpertsRepoID`'s generic "may be homed in another Entire region, not onboarded, or outside your access" guess. It now goes through the same `errRepoNotOnboarded` / `renderRepoNotOnboarded` path the control-plane resolvers use everywhere else, which distinguishes "not onboarded" from "processing placement is failed/suspended" instead of guessing.

This is the last known CLI caller of entire-api's `GET /repos` (COR-1370 tracks retiring the endpoint once older CLI versions age out).

## Test plan

- [x] `mise run fmt && mise run lint` — clean
- [x] `mise run test` (10333 tests) — all pass
- [x] `mise run test:integration` — all pass except 3 pre-existing failures in `TestPluginRemoteInstall_*` (`git tag: exit status 128: fatal: no tag message?`), confirmed unrelated by reproducing them on a clean `main` checkout before this change
- [x] `mise run test:e2e:canary` (Vogon + roger-roger) — all 60 tests pass
- [x] New/updated experts tests cover: owner/repo resolving via `resolveRepoCellPlacement` with no GET-based repo listing possible (removed from the interface entirely), the ULID form still bypassing resolution, and not-onboarded vs. failed-placement error rendering
- [x] Built old (pre-change) and new binaries and ran both against staging (`entireio/cli`, real control-plane + entire-api): owner/repo form, ULID form, not-onboarded error, and the 503 code-search-unavailable path all produced byte-identical stdout/stderr/exit codes between the two binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)