### PR TITLE
repo clone: tighten native shorthand, keep parse errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,13 @@ the commands are always runnable in every build.
   choose a placement through the shared `selectPlacement` picker. `clone`
   accepts a native `/et/<project>/<repo>` ref (or the `<project>/<repo>`
   shorthand — the `gh`/`et` forge tokens can never be project names, which are
-  3+ chars server-side, so the grammar is unambiguous), a mirror
-  `/gh/<owner>/<repo>` ref, or a full `entire://` URL passed through verbatim.
+  3+ chars server-side, so the grammar is unambiguous; both segments must also
+  match the server's name charsets, so `git@github.com:foo/bar` is not a
+  shorthand), a mirror `/gh/<owner>/<repo>` ref, or a full `entire://` URL
+  passed through verbatim. A ref matching none of these gets a targeted error
+  (`invalidCloneRefError`): a GitHub URL is pointed at its `/gh/` form, a
+  malformed `gh/` ref keeps the mirror parser's reason, anything else lists
+  the accepted shapes.
   A native ref resolves project → repo ULID → `GetRepo`, whose response is the
   only one carrying both `clusterHost` and `path`, and clones
   `entire://<clusterHost><path>` from the repo's home cluster (no `.git`

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -62,21 +62,32 @@ func mirrorCloneURL(host, owner, repo string) string {
 // URLs (`/et/<project>/<repo>`), mirroring the server's repourls.URLPathPrefix.
 const nativeCloneForge = "et"
 
+// nativeProjectRe / nativeRepoRe are the server's project- and repo-name
+// charsets (entiredb core/resource/project_name.go: letters, digits, '-', plus
+// '.' for repos; lookups fold case, so uppercase is accepted here). Length and
+// edge-character rules are left to the server — this check only has to tell a
+// native ref apart from things that are not one.
+var (
+	nativeProjectRe = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
+	nativeRepoRe    = regexp.MustCompile(`^[A-Za-z0-9.-]+$`)
+)
+
 // parseNativeCloneRef turns a native clone ref — `/et/<project>/<repo>` or the
 // `<project>/<repo>` shorthand, leading slash optional — into its project and
 // repo names. Not a match (ok == false) is not an error: the caller falls
 // through to the mirror grammar. The `gh`/`et` forge tokens are never valid
 // project names (3–32 chars server-side), so a two-segment ref starting with
 // one is a malformed forge ref, not a shorthand, and is rejected here so the
-// mirror parser can name the expected shape. Segments are not charset-checked:
-// they flow only into control-plane lookup params, and the clone URL is built
-// from the server's authoritative clusterHost + path, never from these values.
+// mirror parser can name the expected shape. Segments must match the server's
+// name charsets: without that, any "x/y" — `git@github.com:foo/bar` included —
+// parsed as a shorthand and produced a control-plane lookup error instead of a
+// hint about the accepted shapes.
 func parseNativeCloneRef(ref string) (project, repo string, ok bool) {
 	segs := strings.Split(strings.TrimPrefix(strings.TrimSpace(ref), "/"), "/")
 	if len(segs) == 3 && segs[0] == nativeCloneForge {
 		segs = segs[1:]
 	}
-	if len(segs) != 2 || segs[0] == "" || segs[1] == "" {
+	if len(segs) != 2 || !nativeProjectRe.MatchString(segs[0]) || !nativeRepoRe.MatchString(segs[1]) {
 		return "", "", false
 	}
 	if segs[0] == nativeCloneForge || segs[0] == "gh" {
@@ -113,6 +124,34 @@ func resolveNativeCloneURL(ctx context.Context, c *coreapi.Client, project, repo
 	return cloneURL, nil
 }
 
+// mirrorCloneRefPrefixRe matches the `gh/` forge token (leading slash optional)
+// that says the user meant a mirror ref, so a malformed one gets an error about
+// its owner/repo rather than a list of every shape `repo clone` accepts.
+var mirrorCloneRefPrefixRe = regexp.MustCompile(`^/?gh/`)
+
+// cloneRefShapes lists every ref shape `repo clone` accepts, for error text.
+const cloneRefShapes = "/et/<project>/<repo>, <project>/<repo>, /gh/<owner>/<repo>, or a full entire:// URL"
+
+// invalidCloneRefError explains why ref matched none of the clone grammars.
+// A GitHub URL gets pointed at the `/gh/` form it should have been; a `gh/`
+// ref that the mirror parser rejected keeps the parser's reason (bad owner or
+// repo charset, dot-only repo, missing segment), and anything else gets the
+// list of accepted shapes.
+func invalidCloneRefError(ref string, mirrorErr error) error {
+	// Only the hosted github.com forms, not gitHubBareRe: bare `x/y` is what
+	// the native shorthand already rejected, and a truncated `gh/foo` would
+	// otherwise read as owner "gh".
+	for _, re := range []*regexp.Regexp{gitHubHTTPSRe, gitHubSSHRe} {
+		if m := re.FindStringSubmatch(ref); m != nil {
+			return fmt.Errorf("invalid <repo> %q: pass GitHub mirrors as /gh/%s/%s", ref, strings.ToLower(m[1]), strings.ToLower(m[2]))
+		}
+	}
+	if mirrorCloneRefPrefixRe.MatchString(ref) {
+		return fmt.Errorf("invalid <repo> %q: %w", ref, mirrorErr)
+	}
+	return fmt.Errorf("invalid <repo> %q: expected %s", ref, cloneRefShapes)
+}
+
 // parseMirrorCloneRef turns a clone ref like `/gh/entirehq/entire-api` into the
 // API provider ("github") and the lowercased owner/repo. The `gh` token is the
 // path provider used in entire:// clone URLs; it maps to the "github" upstream
@@ -120,7 +159,7 @@ func resolveNativeCloneURL(ctx context.Context, c *coreapi.Client, project, repo
 func parseMirrorCloneRef(ref string) (provider, owner, repo string, err error) {
 	m := mirrorCloneRefRe.FindStringSubmatch(strings.TrimSpace(ref))
 	if m == nil {
-		return "", "", "", fmt.Errorf("expected gh/<owner>/<repo> (leading slash optional), got %q", ref)
+		return "", "", "", fmt.Errorf("expected gh/<owner>/<repo> (leading slash optional; owner: letters, digits, '-'; repo: letters, digits, '.', '_', '-'), got %q", ref)
 	}
 	owner, repo = strings.ToLower(m[1]), strings.ToLower(m[2])
 	if gitHubDotOnlyRe.MatchString(repo) {
@@ -202,7 +241,7 @@ func newRepoCloneCmd() *cobra.Command {
 			// resolver pins the provider itself, so it's not threaded through.
 			_, owner, repo, err := parseMirrorCloneRef(ref)
 			if err != nil {
-				return fmt.Errorf("invalid <repo> %q: expected /et/<project>/<repo>, <project>/<repo>, /gh/<owner>/<repo>, or a full entire:// URL", ref)
+				return invalidCloneRefError(ref, err)
 			}
 
 			var placements []coreapi.ResolvedPlacement

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -138,13 +138,11 @@ const cloneRefShapes = "/et/<project>/<repo>, <project>/<repo>, /gh/<owner>/<rep
 // repo charset, dot-only repo, missing segment), and anything else gets the
 // list of accepted shapes.
 func invalidCloneRefError(ref string, mirrorErr error) error {
-	// Only the hosted github.com forms, not gitHubBareRe: bare `x/y` is what
-	// the native shorthand already rejected, and a truncated `gh/foo` would
-	// otherwise read as owner "gh".
-	for _, re := range []*regexp.Regexp{gitHubHTTPSRe, gitHubSSHRe} {
-		if m := re.FindStringSubmatch(ref); m != nil {
-			return fmt.Errorf("invalid <repo> %q: pass GitHub mirrors as /gh/%s/%s", ref, strings.ToLower(m[1]), strings.ToLower(m[2]))
-		}
+	// Hosted forms only: bare `x/y` is what the native shorthand already
+	// rejected, and a truncated `gh/foo` would otherwise read as owner "gh".
+	// The parser's dot-only guard also keeps `foo/..` out of the hint.
+	if owner, repo, err := parseHostedGitHubURL(ref); err == nil {
+		return fmt.Errorf("invalid <repo> %q: pass GitHub mirrors as /gh/%s/%s", ref, owner, repo)
 	}
 	if mirrorCloneRefPrefixRe.MatchString(ref) {
 		return fmt.Errorf("invalid <repo> %q: %w", ref, mirrorErr)

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -59,6 +59,13 @@ func TestParseNativeCloneRef(t *testing.T) {
 		{name: "no leading slash", ref: "et/paul/dogbark", wantProject: "paul", wantRepo: "dogbark", wantOk: true},
 		{name: "shorthand", ref: "paul/dogbark", wantProject: "paul", wantRepo: "dogbark", wantOk: true},
 		{name: "shorthand leading slash", ref: "/paul/dogbark", wantProject: "paul", wantRepo: "dogbark", wantOk: true},
+		{name: "uppercase folds server-side", ref: "Paul/DogBark", wantProject: "Paul", wantRepo: "DogBark", wantOk: true},
+		{name: "dotted repo", ref: "paul/entire-trails.el", wantProject: "paul", wantRepo: "entire-trails.el", wantOk: true},
+		{name: "ssh github url is not a shorthand", ref: "git@github.com:foo/bar", wantOk: false},
+		{name: "ssh github url with .git", ref: "git@github.com:foo/bar.git", wantOk: false},
+		{name: "dotted project", ref: "github.com/dogbark", wantOk: false},
+		{name: "underscore in project", ref: "foo_bar/dogbark", wantOk: false},
+		{name: "space in repo", ref: "paul/dog bark", wantOk: false},
 		{name: "gh ref is not native", ref: "/gh/entirehq/entire-api", wantOk: false},
 		{name: "truncated gh ref is not a shorthand", ref: "/gh/entirehq", wantOk: false},
 		{name: "truncated et ref", ref: "/et/paul", wantOk: false},
@@ -78,6 +85,37 @@ func TestParseNativeCloneRef(t *testing.T) {
 			}
 			require.Equal(t, tt.wantProject, project)
 			require.Equal(t, tt.wantRepo, repo)
+		})
+	}
+}
+
+func TestInvalidCloneRefError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		ref      string
+		want     string
+		dontWant string
+	}{
+		{name: "ssh github url points at /gh/", ref: "git@github.com:Foo/Bar", want: "pass GitHub mirrors as /gh/foo/bar"},
+		{name: "https github url points at /gh/", ref: "https://github.com/foo/bar.git", want: "pass GitHub mirrors as /gh/foo/bar"},
+		{name: "bad owner keeps parser reason", ref: "/gh/foo_bar/baz", want: "owner: letters, digits, '-'", dontWant: "/et/<project>/<repo>"},
+		{name: "dot-only repo keeps parser reason", ref: "/gh/foo/..", want: "repo cannot be dot-only", dontWant: "/et/<project>/<repo>"},
+		{name: "missing repo keeps parser reason", ref: "gh/foo", want: "expected gh/<owner>/<repo>", dontWant: "/et/<project>/<repo>"},
+		{name: "unknown shape lists all shapes", ref: "/gl/foo/bar", want: cloneRefShapes, dontWant: "expected gh/"},
+		{name: "single segment lists all shapes", ref: "dogbark", want: cloneRefShapes},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, _, parseErr := parseMirrorCloneRef(tt.ref)
+			require.Error(t, parseErr)
+			got := invalidCloneRefError(tt.ref, parseErr).Error()
+			require.Contains(t, got, `invalid <repo> "`+tt.ref+`"`)
+			require.Contains(t, got, tt.want)
+			if tt.dontWant != "" {
+				require.NotContains(t, got, tt.dontWant)
+			}
 		})
 	}
 }

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -99,6 +99,7 @@ func TestInvalidCloneRefError(t *testing.T) {
 	}{
 		{name: "ssh github url points at /gh/", ref: "git@github.com:Foo/Bar", want: "pass GitHub mirrors as /gh/foo/bar"},
 		{name: "https github url points at /gh/", ref: "https://github.com/foo/bar.git", want: "pass GitHub mirrors as /gh/foo/bar"},
+		{name: "dot-only github url gets no /gh/ hint", ref: "git@github.com:foo/..", want: cloneRefShapes, dontWant: "/gh/foo/.."},
 		{name: "bad owner keeps parser reason", ref: "/gh/foo_bar/baz", want: "owner: letters, digits, '-'", dontWant: "/et/<project>/<repo>"},
 		{name: "dot-only repo keeps parser reason", ref: "/gh/foo/..", want: "repo cannot be dot-only", dontWant: "/et/<project>/<repo>"},
 		{name: "missing repo keeps parser reason", ref: "gh/foo", want: "expected gh/<owner>/<repo>", dontWant: "/et/<project>/<repo>"},

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -51,7 +51,18 @@ var (
 )
 
 func parseGitHubURL(rawURL string) (owner, repo string, err error) {
-	for _, re := range []*regexp.Regexp{gitHubHTTPSRe, gitHubSSHRe, gitHubBareRe} {
+	return matchGitHubURL(rawURL, gitHubHTTPSRe, gitHubSSHRe, gitHubBareRe)
+}
+
+// parseHostedGitHubURL accepts only the github.com-hosted shapes (https, ssh),
+// not the bare `owner/repo` one, for callers where a bare pair means something
+// else (the native clone shorthand). Same dot-only guard as parseGitHubURL.
+func parseHostedGitHubURL(rawURL string) (owner, repo string, err error) {
+	return matchGitHubURL(rawURL, gitHubHTTPSRe, gitHubSSHRe)
+}
+
+func matchGitHubURL(rawURL string, res ...*regexp.Regexp) (owner, repo string, err error) {
+	for _, re := range res {
 		m := re.FindStringSubmatch(rawURL)
 		if m == nil {
 			continue


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1205
<!-- entire-trail-link-end -->

## Why

Two findings on the trail for https://github.com/entireio/cli/pull/2185 were missed before merge:

- `entire repo clone git@github.com:foo/bar` parsed as the native `<project>/<repo>` shorthand and failed with a control-plane lookup error.
- Every mirror-parse failure (bad owner charset, dot-only repo, missing segment) was replaced by one generic "expected /et/… /gh/…" message.

## What

- Native shorthand segments must match the server's project/repo name charsets (letters, digits, `-`, plus `.` for repos).
- A ref matching no grammar gets a targeted error: GitHub URLs are pointed at their `/gh/<owner>/<repo>` form, malformed `gh/` refs keep the parser's reason, anything else lists the accepted shapes.

## Verification

```
go test ./cmd/entire/cli/ -run 'TestParseNativeCloneRef|TestParseMirrorCloneRef|TestInvalidCloneRefError'
ok  	github.com/entireio/cli/cmd/entire/cli	0.054s
```

golangci-lint: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only ref validation and user-facing error text for `repo clone`; no auth, data handling, or server contract changes beyond stricter client-side pre-checks.
> 
> **Overview**
> **`entire repo clone`** no longer treats arbitrary `x/y` strings (e.g. `git@github.com:foo/bar`) as the native `<project>/<repo>` shorthand. Native segments must match the server’s project/repo character sets before any control-plane lookup runs.
> 
> Invalid refs now get **`invalidCloneRefError`**: GitHub HTTPS/SSH URLs are rewritten to the suggested `/gh/<owner>/<repo>` form; refs that start with `gh/` keep the mirror parser’s specific reason; everything else sees the list of accepted shapes. Mirror parse failures no longer collapse into one generic “expected /et/… /gh/…” message.
> 
> Docs in **`CLAUDE.md`** and unit tests (`TestParseNativeCloneRef`, **`TestInvalidCloneRefError`**) cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0083f834d72e75231367d7b80d5d8d5ae39bb272. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->