### PR TITLE
fix: refuse cross-host redirects in OAuth token-exchange POST

### DIFF
--- a/internal/entireclient/httputil/oauth.go
+++ b/internal/entireclient/httputil/oauth.go
@@ -129,9 +129,12 @@ func PostOAuthToken(ctx context.Context, httpClient *http.Client, coreURL string
 	// copies the request body unconditionally — a POST body is not
 	// protected the way a bearer header is. Guard here, once, for every
 	// caller, rather than requiring each constructed *http.Client to set
-	// its own CheckRedirect. A shallow copy avoids mutating (and
-	// overriding any redirect policy already set on) a client instance
-	// callers may share elsewhere.
+	// its own CheckRedirect. The guard is applied to a shallow copy so a
+	// client instance callers may share elsewhere is not mutated; note
+	// that it does take precedence over any CheckRedirect the caller had
+	// set, for the duration of this request. No caller sets one today,
+	// and a caller that needs a different policy here should be given a
+	// same-host-preserving hook rather than having this guard removed.
 	guarded := *httpClient
 	guarded.CheckRedirect = rejectCrossHostRedirect
 	resp, err := guarded.Do(req)

--- a/internal/entireclient/httputil/oauth.go
+++ b/internal/entireclient/httputil/oauth.go
@@ -11,6 +11,21 @@ import (
 	"strings"
 )
 
+// rejectCrossHostRedirect stops a redirect chain from leaving the host the
+// request was sent to. Mirrors cmd/entire/cli/api.rejectCrossHostRedirect —
+// duplicated rather than imported to avoid a dependency from this
+// low-level package onto the CLI's api package. Same-host redirects (e.g.
+// a trailing-slash normalize) still follow, up to Go's usual 10-hop cap.
+func rejectCrossHostRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	if len(via) > 0 && !strings.EqualFold(req.URL.Host, via[0].URL.Host) {
+		return fmt.Errorf("refusing redirect to a different host (%s -> %s): the OAuth token request body must not leave its origin", via[0].URL.Host, req.URL.Host)
+	}
+	return nil
+}
+
 // RFC 8693 grant + token-type URNs. Re-export the literals so callers
 // composing /oauth/token forms don't keep parallel copies. Lifted out
 // of core/repoadmin and core/api during COR-337 cleanup.
@@ -107,7 +122,19 @@ func PostOAuthToken(ctx context.Context, httpClient *http.Client, coreURL string
 		req.SetBasicAuth(url.QueryEscape(clientID), url.QueryEscape(clientSecret))
 	}
 
-	resp, err := httpClient.Do(req)
+	// The form body (subject_token, and for password-style exchanges the
+	// caller's credentials) must never follow a redirect to a different
+	// host: Go's default client only strips sensitive *headers* on a
+	// cross-host redirect (net/http's shouldCopyHeaderOnRedirect), and
+	// copies the request body unconditionally — a POST body is not
+	// protected the way a bearer header is. Guard here, once, for every
+	// caller, rather than requiring each constructed *http.Client to set
+	// its own CheckRedirect. A shallow copy avoids mutating (and
+	// overriding any redirect policy already set on) a client instance
+	// callers may share elsewhere.
+	guarded := *httpClient
+	guarded.CheckRedirect = rejectCrossHostRedirect
+	resp, err := guarded.Do(req)
 	if err != nil {
 		return "", 0, fmt.Errorf("token request: %w", err)
 	}

--- a/internal/entireclient/httputil/oauth_test.go
+++ b/internal/entireclient/httputil/oauth_test.go
@@ -51,6 +51,44 @@ func TestPostOAuthToken_LiftsAndPercentEncodesClientCreds(t *testing.T) {
 	assert.Empty(t, gotForm.Get("client_secret"), "client_secret must be dropped from the body")
 }
 
+// TestPostOAuthToken_RefusesCrossHostRedirect proves the subject_token (the
+// caller's login JWT) never reaches a different host, even when the origin
+// server issues a 307/308 redirect. Go's default client only strips
+// sensitive *headers* on a cross-host redirect (shouldCopyHeaderOnRedirect in
+// net/http) — the POST body, where subject_token actually lives, is copied
+// unconditionally. This is a genuine two-server reproduction: origin
+// redirects to attacker, and the test fails if attacker ever sees the token.
+func TestPostOAuthToken_RefusesCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	const secretSubjectToken = "super-secret-login-jwt"
+
+	var attackerSawToken bool
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm() //nolint:errcheck // test stub
+		if r.PostForm.Get("subject_token") == secretSubjectToken {
+			attackerSawToken = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"stolen","expires_in":900}`)) //nolint:errcheck // test stub
+	}))
+	defer attacker.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/oauth/token", http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", GrantTypeTokenExchange)
+	form.Set("subject_token", secretSubjectToken)
+
+	_, _, err := PostOAuthToken(context.Background(), origin.Client(), origin.URL, form)
+
+	require.Error(t, err, "a cross-host redirect must be refused, not silently followed")
+	assert.False(t, attackerSawToken, "subject_token must never reach a host other than the one the caller targeted")
+}
+
 // TestPostOAuthToken_ErrorCode pins that a non-200 response surfaces as
 // *OAuthError with the RFC 6749 `error` code and `error_description` parsed
 // from the body (both empty for non-JSON bodies), so callers can branch on

--- a/internal/entireclient/httputil/oauth_test.go
+++ b/internal/entireclient/httputil/oauth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,11 +64,16 @@ func TestPostOAuthToken_RefusesCrossHostRedirect(t *testing.T) {
 
 	const secretSubjectToken = "super-secret-login-jwt"
 
-	var attackerSawToken bool
+	// atomic.Bool because the write happens on the attacker server's
+	// handler goroutine and the read below happens on the test goroutine.
+	// The handler never runs while the guard works, so this does not race
+	// in practice — it is atomic so that a future regression is reported
+	// as a failed assertion rather than as a data race.
+	var attackerSawToken atomic.Bool
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm() //nolint:errcheck // test stub
 		if r.PostForm.Get("subject_token") == secretSubjectToken {
-			attackerSawToken = true
+			attackerSawToken.Store(true)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"access_token":"stolen","expires_in":900}`)) //nolint:errcheck // test stub
@@ -85,8 +91,13 @@ func TestPostOAuthToken_RefusesCrossHostRedirect(t *testing.T) {
 
 	_, _, err := PostOAuthToken(context.Background(), origin.Client(), origin.URL, form)
 
+	// The leak check comes first, deliberately. It is the assertion that
+	// pins this test's headline claim, and require.Error below aborts the
+	// test — so with the two in the other order any regression failed on
+	// the error assertion alone and never evaluated whether the token had
+	// actually reached the attacker.
+	assert.False(t, attackerSawToken.Load(), "subject_token must never reach a host other than the one the caller targeted")
 	require.Error(t, err, "a cross-host redirect must be refused, not silently followed")
-	assert.False(t, attackerSawToken, "subject_token must never reach a host other than the one the caller targeted")
 }
 
 // TestPostOAuthToken_ErrorCode pins that a non-200 response surfaces as


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1206
<!-- entire-trail-link-end -->

## Summary
- `PostOAuthToken`'s request body carries `subject_token` (the caller's login JWT, or a jurisdiction-scoped exchange token) as a POST form field, not a header. Go's default `http.Client` only strips sensitive *headers* on a cross-host redirect (`net/http`'s `shouldCopyHeaderOnRedirect`) — it copies the request body unconditionally regardless of host change. A malicious or compromised token-exchange endpoint issuing a 307/308 redirect could therefore have the CLI hand its login JWT to a different origin.
- Both call sites that reach `PostOAuthToken` (`auth/cell_data_api.go`'s jurisdiction exchange, `internal/coreapi/cross_juris_transport.go`'s cross-jurisdiction exchange) construct their own `*http.Client` with no `CheckRedirect`, so this affected both.
- Fixed at the shared choke point (`PostOAuthToken` itself) rather than requiring every caller's client construction to opt in — mirrors the `rejectCrossHostRedirect` pattern `cmd/entire/cli/api/client.go` already uses for its own client.

## Verification
- Added `TestPostOAuthToken_RefusesCrossHostRedirect`: a genuine two-`httptest.Server` reproduction (origin redirects to attacker via 307) asserting the attacker server never receives `subject_token`.
- Confirmed this test **fails** against the pre-fix code (redirect silently followed, no error) before confirming it **passes** with the fix — mutation-verified, not just "test exists and is green."
- `mise run check` (fmt + lint + test:ci) passes.

## Test plan
- [x] New reproduction test added and passing
- [x] Verified test fails without the fix (mutation check)
- [x] `mise run check` green