### PR TITLE
fix: verify cross-repo checkpoint response identity before rendering

### DIFF
--- a/cmd/entire/cli/checkpoint_api_reader.go
+++ b/cmd/entire/cli/checkpoint_api_reader.go
@@ -134,7 +134,11 @@ func (r *apiCheckpointReader) Read(ctx context.Context, checkpointID id.Checkpoi
 	// second one behind the first one's JSON field would quietly mislead every
 	// consumer of `explain --json`.
 	return &checkpoint.CheckpointSummary{
-		CheckpointID:     checkpointID,
+		// The server's own checkpointId, not the requested param: loadDetail has
+		// already verified the two agree, but sourcing this from info keeps a
+		// future regression in that check from silently papering over a real
+		// mismatch by relabeling foreign data with the id the caller asked for.
+		CheckpointID:     id.CheckpointID(info.CheckpointID),
 		Strategy:         "manual-commit",
 		CommitSHA:        info.CommitSha,
 		CheckpointsCount: info.TotalSteps,
@@ -229,7 +233,8 @@ func (r *apiCheckpointReader) ReadSessionMetadataAndPrompts(ctx context.Context,
 	s := info.Sessions[sessionIndex]
 
 	meta := &checkpoint.Metadata{
-		CheckpointID:     checkpointID,
+		// The server's own checkpointId — see the matching comment in Read().
+		CheckpointID:     id.CheckpointID(info.CheckpointID),
 		SessionID:        s.SessionID,
 		Strategy:         "manual-commit",
 		CreatedAt:        parseAPITime(s.CreatedAt, info.CreatedAt),
@@ -361,10 +366,41 @@ func (r *apiCheckpointReader) loadDetail(ctx context.Context, checkpointID id.Ch
 	if len(env.Checkpoint.Sessions) == 0 {
 		return nil, fmt.Errorf("checkpoint %s in %s has no sessions to explain", checkpointID, r.ownerRepo)
 	}
+	if err := r.verifyResponseIdentity(checkpointID, env); err != nil {
+		return nil, err
+	}
 
 	r.detail = env.Checkpoint
 	r.detailID = checkpointID
 	return r.detail, nil
+}
+
+// verifyResponseIdentity checks the envelope's own identity fields
+// (repo_full_name, checkpointId) against what was actually requested, before
+// the response is cached or rendered. This is the content-layer equivalent of
+// cell_target.go's resolveProcessingPlacement self-check at the routing
+// layer: a cell that answers with the wrong repo's or wrong checkpoint's data
+// — a server bug, a cache-key collision, an authz bug scoping by checkpoint ID
+// without cross-checking repo ownership — must produce an error here, not a
+// "successful" read of foreign private transcript/session data silently
+// labeled as belonging to the repo the caller asked about.
+func (r *apiCheckpointReader) verifyResponseIdentity(checkpointID id.CheckpointID, env apiCheckpointEnvelope) error {
+	if got := env.Checkpoint.CheckpointID; got != checkpointID.String() {
+		return fmt.Errorf("checkpoint identity mismatch: requested checkpoint %s from %s, but the server returned checkpoint %q; refusing to display possibly-mismatched data (this looks like a server-side bug, please report it)",
+			checkpointID, r.ownerRepo, got)
+	}
+	// repo_full_name is normally the "owner/repo" display name, but entire-api
+	// (repoFullNameOr) legitimately falls back to echoing the bare repo ID when
+	// that repo's metadata hasn't resolved a display name yet — so either form
+	// is an honest claim to be the requested repo. An outright empty value is
+	// tolerated (never observed from a real 200, but some minimal test/legacy
+	// payloads omit it) rather than treated as a mismatch, since there is
+	// nothing to disagree with the request in that case.
+	if got := env.RepoFullName; got != "" && !strings.EqualFold(got, r.ownerRepo) && got != r.repoID {
+		return fmt.Errorf("checkpoint identity mismatch: requested checkpoint %s from %s, but the server returned data for repo %q; refusing to display possibly-mismatched data (this looks like a server-side bug, please report it)",
+			checkpointID, r.ownerRepo, got)
+	}
+	return nil
 }
 
 // parseAPITime parses the first parseable RFC3339 timestamp from the given

--- a/cmd/entire/cli/checkpoint_api_reader.go
+++ b/cmd/entire/cli/checkpoint_api_reader.go
@@ -390,25 +390,37 @@ func (r *apiCheckpointReader) loadDetail(ctx context.Context, checkpointID id.Ch
 // "successful" read of foreign private transcript/session data silently
 // labeled as belonging to the repo the caller asked about.
 func (r *apiCheckpointReader) verifyResponseIdentity(checkpointID id.CheckpointID, env apiCheckpointEnvelope) error {
-	// EqualFold on both comparisons below is defensive, not a live fix:
-	// id.Validate accepts only the canonical uppercase ULID alphabet
-	// ([0-9ABCDEFGHJKMNPQRSTVWXYZ]), so a lowercase id never reaches here
-	// and the cell returns canonical case today. Folding costs nothing and
-	// cannot weaken the check -- two distinct valid IDs stay distinct under
-	// it -- while a strict compare would fail closed on a server-side
-	// casing change, breaking `explain --repo` rather than protecting it.
-	if got := env.Checkpoint.CheckpointID; !strings.EqualFold(got, checkpointID.String()) {
+	// Byte equality, NOT EqualFold. Case is load-bearing for a checkpoint
+	// ID because the two kinds have opposite canonical spellings: a legacy
+	// ID is 12 LOWERCASE hex (id.Pattern) and a ULID is canonical
+	// UPPERCASE (isULID requires ulid.ParseStrict(s).String() == s). So a
+	// fold would accept a non-canonical spelling of a real ID and then --
+	// because CheckpointID below is sourced from the server's value -- mint
+	// an id.CheckpointID that id.Validate itself rejects. An honest server
+	// echoes the ID it was asked for, byte for byte; anything else is the
+	// mismatch this function exists to catch.
+	if got := env.Checkpoint.CheckpointID; got != checkpointID.String() {
 		return fmt.Errorf("checkpoint identity mismatch: requested checkpoint %s from %s, but the server returned checkpoint %q; refusing to display possibly-mismatched data (this looks like a server-side bug, please report it)",
 			checkpointID, r.ownerRepo, got)
 	}
-	// repo_full_name is normally the "owner/repo" display name, but entire-api
-	// (repoFullNameOr) legitimately falls back to echoing the bare repo ID when
-	// that repo's metadata hasn't resolved a display name yet — so either form
-	// is an honest claim to be the requested repo. An outright empty value is
-	// tolerated (never observed from a real 200, but some minimal test/legacy
-	// payloads omit it) rather than treated as a mismatch, since there is
-	// nothing to disagree with the request in that case.
-	if got := env.RepoFullName; got != "" && !strings.EqualFold(got, r.ownerRepo) && !strings.EqualFold(got, r.repoID) {
+	// repo_full_name is REQUIRED, not best-effort. It is the only field that
+	// ties the response to the repo that was asked about: checkpointId alone
+	// proves nothing, since any response -- including one carrying another
+	// repo's private transcripts -- satisfies it by echoing the ID it was
+	// handed. Tolerating an empty value therefore let the verified party opt
+	// out of its own verification, which is not verification. Every 200 from
+	// a real cell carries it (checked against aws-us-east-2: "entireio/cli").
+	if env.RepoFullName == "" {
+		return fmt.Errorf("checkpoint identity unverifiable: requested checkpoint %s from %s, but the server returned no repo_full_name to confirm which repo answered; refusing to display possibly-mismatched data (this looks like a server-side bug, please report it)",
+			checkpointID, r.ownerRepo)
+	}
+	// entire-api (repoFullNameOr) legitimately falls back to echoing the bare
+	// repo ULID when the repo's metadata has not resolved a display name yet,
+	// so either form is an honest claim to be the requested repo. EqualFold is
+	// right for ownerRepo -- forge owner/repo names are case-insensitive -- and
+	// the repo ULID is compared byte-for-byte, canonical uppercase like any
+	// other ULID.
+	if got := env.RepoFullName; !strings.EqualFold(got, r.ownerRepo) && got != r.repoID {
 		return fmt.Errorf("checkpoint identity mismatch: requested checkpoint %s from %s, but the server returned data for repo %q; refusing to display possibly-mismatched data (this looks like a server-side bug, please report it)",
 			checkpointID, r.ownerRepo, got)
 	}

--- a/cmd/entire/cli/checkpoint_api_reader.go
+++ b/cmd/entire/cli/checkpoint_api_reader.go
@@ -363,11 +363,16 @@ func (r *apiCheckpointReader) loadDetail(ctx context.Context, checkpointID id.Ch
 	if env.Checkpoint == nil {
 		return nil, fmt.Errorf("checkpoint %s is not available for %s (the server returned no checkpoint)", checkpointID, r.ownerRepo)
 	}
-	if len(env.Checkpoint.Sessions) == 0 {
-		return nil, fmt.Errorf("checkpoint %s in %s has no sessions to explain", checkpointID, r.ownerRepo)
-	}
+	// Identity first, ahead of every content-based check below: a
+	// wrong-repo or wrong-checkpoint response that also happens to trip one
+	// of those (zero sessions, say) would otherwise be reported as a fact
+	// about the checkpoint the caller asked for -- "checkpoint X in Y has no
+	// sessions" when the server never answered about X in Y at all.
 	if err := r.verifyResponseIdentity(checkpointID, env); err != nil {
 		return nil, err
+	}
+	if len(env.Checkpoint.Sessions) == 0 {
+		return nil, fmt.Errorf("checkpoint %s in %s has no sessions to explain", checkpointID, r.ownerRepo)
 	}
 
 	r.detail = env.Checkpoint
@@ -385,7 +390,14 @@ func (r *apiCheckpointReader) loadDetail(ctx context.Context, checkpointID id.Ch
 // "successful" read of foreign private transcript/session data silently
 // labeled as belonging to the repo the caller asked about.
 func (r *apiCheckpointReader) verifyResponseIdentity(checkpointID id.CheckpointID, env apiCheckpointEnvelope) error {
-	if got := env.Checkpoint.CheckpointID; got != checkpointID.String() {
+	// EqualFold on both comparisons below is defensive, not a live fix:
+	// id.Validate accepts only the canonical uppercase ULID alphabet
+	// ([0-9ABCDEFGHJKMNPQRSTVWXYZ]), so a lowercase id never reaches here
+	// and the cell returns canonical case today. Folding costs nothing and
+	// cannot weaken the check -- two distinct valid IDs stay distinct under
+	// it -- while a strict compare would fail closed on a server-side
+	// casing change, breaking `explain --repo` rather than protecting it.
+	if got := env.Checkpoint.CheckpointID; !strings.EqualFold(got, checkpointID.String()) {
 		return fmt.Errorf("checkpoint identity mismatch: requested checkpoint %s from %s, but the server returned checkpoint %q; refusing to display possibly-mismatched data (this looks like a server-side bug, please report it)",
 			checkpointID, r.ownerRepo, got)
 	}
@@ -396,7 +408,7 @@ func (r *apiCheckpointReader) verifyResponseIdentity(checkpointID id.CheckpointI
 	// tolerated (never observed from a real 200, but some minimal test/legacy
 	// payloads omit it) rather than treated as a mismatch, since there is
 	// nothing to disagree with the request in that case.
-	if got := env.RepoFullName; got != "" && !strings.EqualFold(got, r.ownerRepo) && got != r.repoID {
+	if got := env.RepoFullName; got != "" && !strings.EqualFold(got, r.ownerRepo) && !strings.EqualFold(got, r.repoID) {
 		return fmt.Errorf("checkpoint identity mismatch: requested checkpoint %s from %s, but the server returned data for repo %q; refusing to display possibly-mismatched data (this looks like a server-side bug, please report it)",
 			checkpointID, r.ownerRepo, got)
 	}

--- a/cmd/entire/cli/checkpoint_api_reader_test.go
+++ b/cmd/entire/cli/checkpoint_api_reader_test.go
@@ -277,6 +277,75 @@ func TestAPICheckpointReader_EmptyEnvelopeIsNotFound(t *testing.T) {
 	require.ErrorContains(t, err, "not available")
 }
 
+// If the cell ever answers with a DIFFERENT repo's checkpoint data than the
+// one requested (server bug, cache-key collision, authz bug), the reader must
+// refuse it instead of caching and rendering it labeled as the requested
+// repo. This is the reproduction for the cross-repo checkpoint identity gap.
+func TestAPICheckpointReader_RepoFullNameMismatchIsRejected(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/transcript/raw") {
+			fmt.Fprint(w, `{"type":"user"}`)
+			return
+		}
+		// Same checkpoint payload, but the envelope claims a DIFFERENT repo than
+		// the one the reader was constructed for (testAPIOwnerRep = acme/widgets).
+		fmt.Fprint(w, strings.Replace(checkpointEnvelopeJSON, `"repo_full_name": "acme/widgets"`, `"repo_full_name": "totally-different/other-repo"`, 1))
+	})
+
+	_, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.Error(t, err, "a wrong-repo response must not be accepted as the requested repo's checkpoint")
+	assert.Contains(t, err.Error(), "identity mismatch")
+	assert.Contains(t, err.Error(), "other-repo")
+
+	// The same guard applies to every read tier that flows through loadDetail,
+	// not just Read().
+	_, _, err = reader.ReadSessionMetadataAndPrompts(context.Background(), testAPICheckpointID, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity mismatch")
+}
+
+// The repo's own ULID is a legitimate stand-in for repo_full_name (entire-api
+// falls back to it when the repo's display name hasn't resolved yet), so it
+// must NOT be rejected as a mismatch.
+func TestAPICheckpointReader_RepoFullNameAsRepoIDIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/transcript/raw") {
+			fmt.Fprint(w, `{"type":"user"}`)
+			return
+		}
+		fmt.Fprint(w, strings.Replace(checkpointEnvelopeJSON, `"repo_full_name": "acme/widgets"`, `"repo_full_name": "`+testAPIRepoID+`"`, 1))
+	})
+
+	summary, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.NoError(t, err)
+	assert.Equal(t, testAPICheckpointID, summary.CheckpointID)
+}
+
+// If the cell ever answers with a DIFFERENT checkpoint than the one
+// requested, the reader must refuse it rather than relabeling the mismatched
+// content with the requested ID.
+func TestAPICheckpointReader_CheckpointIDMismatchIsRejected(t *testing.T) {
+	t.Parallel()
+
+	const otherCheckpointID = "01KXGTTNGCEACC83QZEJ5YAFOTHER"
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/transcript/raw") {
+			fmt.Fprint(w, `{"type":"user"}`)
+			return
+		}
+		fmt.Fprint(w, strings.Replace(checkpointEnvelopeJSON, `"checkpointId": "01KXGTTNGCEACC83QZEJ5YAF0D"`, `"checkpointId": "`+otherCheckpointID+`"`, 1))
+	})
+
+	_, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.Error(t, err, "a wrong-checkpoint response must not be accepted as the requested checkpoint")
+	assert.Contains(t, err.Error(), "identity mismatch")
+	assert.Contains(t, err.Error(), otherCheckpointID)
+}
+
 func TestAPICheckpointReader_NoSessionsIsAnError(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/checkpoint_api_reader_test.go
+++ b/cmd/entire/cli/checkpoint_api_reader_test.go
@@ -356,6 +356,54 @@ func TestAPICheckpointReader_NoSessionsIsAnError(t *testing.T) {
 	require.ErrorContains(t, err, "no sessions to explain")
 }
 
+// A wrong-checkpoint response that ALSO trips a content-based check must be
+// reported as the identity mismatch it is, not as a fact about the checkpoint
+// the caller asked for. With the identity check ordered after the
+// zero-sessions guard, this payload produced "checkpoint <requested> in
+// acme/widgets has no sessions to explain" -- a statement about a checkpoint
+// the server never answered about, and the misleading error Copilot flagged
+// on the PR.
+func TestAPICheckpointReader_IdentityCheckedBeforeContentGuards(t *testing.T) {
+	t.Parallel()
+
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"repo_full_name":"totally-different/other-repo","checkpoint": {"checkpointId":"01KXGTTNGCEACC83QZEJ5YAFOTHER","sessions":[]}}`)
+	})
+	_, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity mismatch")
+	assert.NotContains(t, err.Error(), "no sessions to explain",
+		"a foreign response must not be described as a property of the requested checkpoint")
+}
+
+// The identity comparisons fold case, so a cell that returned a
+// differently-cased spelling of the very checkpoint that was requested is
+// accepted rather than failing closed. id.Validate only admits the canonical
+// uppercase ULID alphabet, so this cannot arise from user input today -- the
+// test pins the tolerance so a later "tighten it to ==" does not silently
+// make a server-side casing change break `explain --repo`.
+func TestAPICheckpointReader_IdentityComparisonFoldsCase(t *testing.T) {
+	t.Parallel()
+
+	lower := strings.ToLower(testAPICheckpointID.String())
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/transcript/raw") {
+			fmt.Fprint(w, `{"type":"user"}`)
+			return
+		}
+		body := strings.Replace(checkpointEnvelopeJSON,
+			`"checkpointId": "01KXGTTNGCEACC83QZEJ5YAF0D"`, `"checkpointId": "`+lower+`"`, 1)
+		body = strings.Replace(body,
+			`"repo_full_name": "acme/widgets"`, `"repo_full_name": "ACME/WIDGETS"`, 1)
+		fmt.Fprint(w, body)
+	})
+
+	summary, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.NoError(t, err, "a differently-cased spelling of the requested identity must not be a mismatch")
+	assert.Equal(t, id.CheckpointID(lower), summary.CheckpointID,
+		"CheckpointID is sourced from the verified server response, so it carries the server's spelling")
+}
+
 // A transcript larger than the read cap must fail loudly. Truncating it would
 // hand the renderer a silently-incomplete transcript, which reads as a real one.
 func TestAPICheckpointReader_OversizeTranscriptFailsLoudly(t *testing.T) {

--- a/cmd/entire/cli/checkpoint_api_reader_test.go
+++ b/cmd/entire/cli/checkpoint_api_reader_test.go
@@ -350,7 +350,7 @@ func TestAPICheckpointReader_NoSessionsIsAnError(t *testing.T) {
 	t.Parallel()
 
 	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, `{"checkpoint": {"checkpointId":"01KXGTTNGCEACC83QZEJ5YAF0D","sessions":[]}}`)
+		fmt.Fprint(w, `{"repo_full_name":"acme/widgets","checkpoint": {"checkpointId":"01KXGTTNGCEACC83QZEJ5YAF0D","sessions":[]}}`)
 	})
 	_, err := reader.Read(context.Background(), testAPICheckpointID)
 	require.ErrorContains(t, err, "no sessions to explain")
@@ -376,32 +376,55 @@ func TestAPICheckpointReader_IdentityCheckedBeforeContentGuards(t *testing.T) {
 		"a foreign response must not be described as a property of the requested checkpoint")
 }
 
-// The identity comparisons fold case, so a cell that returned a
-// differently-cased spelling of the very checkpoint that was requested is
-// accepted rather than failing closed. id.Validate only admits the canonical
-// uppercase ULID alphabet, so this cannot arise from user input today -- the
-// test pins the tolerance so a later "tighten it to ==" does not silently
-// make a server-side casing change break `explain --repo`.
-func TestAPICheckpointReader_IdentityComparisonFoldsCase(t *testing.T) {
+// repo_full_name is required, not best-effort. A response that simply omits
+// it used to skip the repo check entirely, leaving only checkpointId -- which
+// any wrong-repo response satisfies by echoing the ID it was handed. That made
+// the guard something the verified party could opt out of: this exact payload
+// rendered as acme/widgets data before the fix.
+func TestAPICheckpointReader_MissingRepoFullNameIsRejected(t *testing.T) {
 	t.Parallel()
 
-	lower := strings.ToLower(testAPICheckpointID.String())
 	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/transcript/raw") {
 			fmt.Fprint(w, `{"type":"user"}`)
 			return
 		}
-		body := strings.Replace(checkpointEnvelopeJSON,
-			`"checkpointId": "01KXGTTNGCEACC83QZEJ5YAF0D"`, `"checkpointId": "`+lower+`"`, 1)
-		body = strings.Replace(body,
-			`"repo_full_name": "acme/widgets"`, `"repo_full_name": "ACME/WIDGETS"`, 1)
-		fmt.Fprint(w, body)
+		fmt.Fprint(w, strings.Replace(checkpointEnvelopeJSON,
+			`"repo_full_name": "acme/widgets"`, `"repo_full_name": ""`, 1))
 	})
 
-	summary, err := reader.Read(context.Background(), testAPICheckpointID)
-	require.NoError(t, err, "a differently-cased spelling of the requested identity must not be a mismatch")
-	assert.Equal(t, id.CheckpointID(lower), summary.CheckpointID,
-		"CheckpointID is sourced from the verified server response, so it carries the server's spelling")
+	_, err := reader.Read(context.Background(), testAPICheckpointID)
+	require.Error(t, err, "a response that does not say which repo it answered for must not render as the requested repo's data")
+	assert.Contains(t, err.Error(), "identity unverifiable")
+}
+
+// The checkpoint-ID comparison is byte equality, deliberately. The two ID
+// kinds have opposite canonical spellings -- a legacy ID is 12 lowercase hex
+// (id.Pattern), a ULID is canonical uppercase (isULID requires
+// ParseStrict(s).String() == s) -- so folding case would accept a
+// non-canonical spelling and, because CheckpointID is sourced from the
+// server's value, mint an id.CheckpointID that id.Validate itself rejects.
+// This pins the legacy-hex case, the one a fold actually breaks.
+func TestAPICheckpointReader_LegacyHexIDIsCaseSensitive(t *testing.T) {
+	t.Parallel()
+
+	const legacyID = "abc123def456"
+	require.NoError(t, id.Validate(legacyID), "fixture must be a valid legacy ID")
+	upper := strings.ToUpper(legacyID)
+	require.Error(t, id.Validate(upper), "the uppercased form must itself be invalid, which is the point")
+
+	reader, _ := newTestAPIReader(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/transcript/raw") {
+			fmt.Fprint(w, `{"type":"user"}`)
+			return
+		}
+		fmt.Fprint(w, strings.Replace(checkpointEnvelopeJSON,
+			`"checkpointId": "01KXGTTNGCEACC83QZEJ5YAF0D"`, `"checkpointId": "`+upper+`"`, 1))
+	})
+
+	_, err := reader.Read(context.Background(), id.CheckpointID(legacyID))
+	require.Error(t, err, "an uppercased legacy ID is not the ID that was requested")
+	assert.Contains(t, err.Error(), "identity mismatch")
 }
 
 // A transcript larger than the read cap must fail loudly. Truncating it would


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1207
<!-- entire-trail-link-end -->

## Summary
- `checkpoint_api_reader.go` decodes an entire-api cell's response identity fields (`repo_full_name`, `checkpointId`) but never checked them against what was actually requested (`r.ownerRepo`, the requested `checkpointID`).
- `loadDetail` cached the response under the *requested* id, and `Read()`/`ReadSessionMetadataAndPrompts()` relabeled whatever came back with the requested `checkpointID` rather than the server's own value — so a wrong-repo/wrong-checkpoint response (server bug, cache-key collision, authz bug) would render silently as belonging to the repo the caller asked about.
- Added `verifyResponseIdentity`, checked before the response is cached or rendered — mirroring `cell_target.go`'s existing self-check pattern (`resolveProcessingPlacement`'s `EqualFold` check) at the routing layer, brought up to the content layer.
- `Read()`/`ReadSessionMetadataAndPrompts()` now source `CheckpointID` from the verified server response, not the request param, so a future regression in the check can't silently paper over a real mismatch by relabeling.

## Verification
- Two-`httptest.Server`-style reproduction test with a mismatched `repo_full_name`/`checkpointId` in the response.
- Confirmed the test fails against the pre-fix code (mismatch silently accepted) before confirming it passes with the fix.
- `go build ./cmd/entire/...` and the package's own test suite (`go test ./cmd/entire/cli/ -run TestAPICheckpointReader`) pass.
- Full `mise run check` (fmt/lint/full test:ci) deferred to a follow-up pass to keep local CI load down; will run before merge.

## Test plan
- [x] New identity-mismatch reproduction test added and passing
- [x] Verified test fails without the fix (mutation check)
- [ ] Full `mise run check` (deferred, will run before merge)