### PR TITLE
fix: serialize shadow-branch migration against concurrent checkpoint writes

### DIFF
--- a/cmd/entire/cli/checkpoint/persistent_ref_update.go
+++ b/cmd/entire/cli/checkpoint/persistent_ref_update.go
@@ -59,6 +59,27 @@ func casUpdateRef(ctx context.Context, repoRoot string, refName plumbing.Referen
 	return fmt.Errorf("git update-ref %s: %s: %w", refName, strings.TrimSpace(out), err)
 }
 
+// casDeleteRef atomically deletes refName through native Git's lock protocol,
+// via `git update-ref -d <ref> <old>`. The delete only succeeds if the ref
+// currently points at expectedHash; otherwise it returns ErrShadowRefBusy so
+// the caller can decide whether that's a benign race (someone else already
+// moved or removed it) or a real conflict.
+func casDeleteRef(ctx context.Context, repoRoot string, refName plumbing.ReferenceName, expectedHash plumbing.Hash) error {
+	cmd := exec.CommandContext(ctx, "git", "update-ref", "-d", refName.String(), expectedHash.String())
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	out := string(output)
+	if strings.Contains(out, "cannot lock ref") || strings.Contains(out, "but expected") {
+		return ErrShadowRefBusy
+	}
+	return fmt.Errorf("git update-ref -d %s: %s: %w", refName, strings.TrimSpace(out), err)
+}
+
 func persistentRefLockPath(commonDir string, refName plumbing.ReferenceName) (string, error) {
 	lockDir := filepath.Join(commonDir, "entire-persistent-ref-locks")
 	if err := os.MkdirAll(lockDir, 0o750); err != nil {

--- a/cmd/entire/cli/checkpoint/shadow_ref.go
+++ b/cmd/entire/cli/checkpoint/shadow_ref.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand/v2"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/gitdir"
 	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -114,6 +117,123 @@ func withShadowBranchFlock(commonDir, branchName string, fn func() error) error 
 	}
 	defer release()
 	return fn()
+}
+
+// readRefHash resolves refName's current commit via a native git subprocess.
+// Returns (hash, false, nil) when the ref doesn't exist -- not an error, since
+// "old shadow branch is already gone" is a normal, expected outcome for
+// MigrateShadowBranchRef's caller.
+func readRefHash(ctx context.Context, repoRoot string, refName plumbing.ReferenceName) (plumbing.Hash, bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", refName.String())
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return plumbing.ZeroHash, false, nil
+		}
+		return plumbing.ZeroHash, false, fmt.Errorf("git rev-parse --verify %s: %w", refName, err)
+	}
+	return plumbing.NewHash(strings.TrimSpace(string(out))), true, nil
+}
+
+// MigrateShadowBranchRef atomically renames a shadow branch from oldBranch to
+// newBranch (both refs/heads branch names, not full ref names), used when a
+// session's shadow branch needs to move to a new base-commit-derived name
+// (see migrateShadowBranchToBaseCommit in the strategy package).
+//
+// This shares the exact locking/CAS discipline writeCheckpoint/writeTask use
+// (withShadowBranchFlock + casUpdateShadowBranchRef) rather than the
+// unlocked go-git Reference/SetReference/CLI-delete sequence this replaced:
+// two sessions can legitimately share one worktree's shadow branch (a
+// documented, supported configuration -- main agent + Task-tool subagent is
+// the common case), and a checkpoint write racing an unlocked migration
+// could silently orphan or overwrite committed checkpoint data. Both branch
+// names are locked (in a stable, name-sorted order, so two migrations that
+// happen to touch the same pair of branches from opposite directions can't
+// deadlock) before either ref is touched.
+//
+// Returns (migrated, err). migrated is false with a nil error when there was
+// nothing to do: the old branch no longer exists (first checkpoint after
+// HEAD changed, or a concurrent migration already moved it), or the new
+// branch already exists pointing at different content than the old one (a
+// concurrent writer got there first -- left alone rather than clobbered).
+func MigrateShadowBranchRef(ctx context.Context, repoRoot, commonDir, oldBranch, newBranch string) (bool, error) {
+	first, second := oldBranch, newBranch
+	if second < first {
+		first, second = second, first
+	}
+	var migrated bool
+	err := withShadowBranchFlock(commonDir, first, func() error {
+		return withShadowBranchFlock(commonDir, second, func() error {
+			m, innerErr := migrateShadowBranchRefLocked(ctx, repoRoot, oldBranch, newBranch)
+			migrated = m
+			return innerErr
+		})
+	})
+	return migrated, err
+}
+
+// migrateShadowBranchRefLocked performs the actual rename. Callers must hold
+// both branches' flocks (see MigrateShadowBranchRef).
+func migrateShadowBranchRefLocked(ctx context.Context, repoRoot, oldBranch, newBranch string) (bool, error) {
+	oldRefName := plumbing.NewBranchReferenceName(oldBranch)
+	newRefName := plumbing.NewBranchReferenceName(newBranch)
+
+	oldHash, exists, err := readRefHash(ctx, repoRoot, oldRefName)
+	if err != nil {
+		return false, fmt.Errorf("read old shadow branch %s: %w", oldBranch, err)
+	}
+	if !exists {
+		return false, nil
+	}
+
+	newHash, newExists, err := readRefHash(ctx, repoRoot, newRefName)
+	if err != nil {
+		return false, fmt.Errorf("read new shadow branch %s: %w", newBranch, err)
+	}
+	if newExists {
+		if newHash != oldHash {
+			// A concurrent writer already created the destination with
+			// different content; leave both alone rather than guess which
+			// should win.
+			return false, nil
+		}
+		// Destination already carries the old branch's content (a concurrent
+		// migration finished the create half already) -- finish the cleanup
+		// if the old ref is still exactly what we just read.
+		if delErr := casDeleteRef(ctx, repoRoot, oldRefName, oldHash); delErr != nil && !errors.Is(delErr, ErrShadowRefBusy) {
+			return true, fmt.Errorf("delete already-migrated old shadow branch %s: %w", oldBranch, delErr)
+		}
+		return true, nil
+	}
+
+	if err := casUpdateShadowBranchRef(ctx, repoRoot, newBranch, oldHash, plumbing.ZeroHash); err != nil {
+		if errors.Is(err, ErrShadowRefBusy) {
+			// Someone else created newBranch between our read above and now.
+			return false, nil
+		}
+		return false, fmt.Errorf("create new shadow branch %s: %w", newBranch, err)
+	}
+
+	if err := casDeleteRef(ctx, repoRoot, oldRefName, oldHash); err != nil {
+		if errors.Is(err, ErrShadowRefBusy) {
+			// oldBranch moved since we read it -- a concurrent legitimate
+			// writer (e.g. writeCheckpoint) advanced it after our read but
+			// before our delete. newBranch already carries the content we
+			// migrated; leave oldBranch for its own writer to retry its CAS
+			// against (it will see the ref moved and follow its normal
+			// retry path -- see casUpdateShadowBranchRef's callers).
+			logging.Warn(logging.WithComponent(ctx, "checkpoint"),
+				"shadow branch migration: old ref moved before delete, leaving in place",
+				slog.String("old_branch", oldBranch), slog.String("new_branch", newBranch))
+			return true, nil
+		}
+		return false, fmt.Errorf("delete old shadow branch %s: %w", oldBranch, err)
+	}
+
+	return true, nil
 }
 
 // tryDeleteLooseObject best-effort removes a loose object file. Used to

--- a/cmd/entire/cli/checkpoint/shadow_ref_migration_test.go
+++ b/cmd/entire/cli/checkpoint/shadow_ref_migration_test.go
@@ -1,0 +1,142 @@
+package checkpoint
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6/plumbing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func runGitOut(t *testing.T, repoRoot string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v: %s", args, out)
+	return strings.TrimSpace(string(out))
+}
+
+// TestMigrateShadowBranchRef_SerializesAgainstConcurrentCheckpointWrite is a
+// genuine, real-git reproduction of the race this function exists to close:
+// migrateShadowBranchToBaseCommit used to read the old branch's hash and
+// SetReference/delete it with no lock at all, while writeCheckpoint's
+// casUpdateShadowBranchRef advances the SAME branch under a real flock.
+// Before the fix, a migration racing a concurrent checkpoint write could
+// read a stale hash and migrate it, then delete the branch out from under
+// the in-flight write -- silently orphaning the checkpoint the write was
+// about to land.
+//
+// This test drives both paths concurrently with real synchronization (not
+// sleeps): the "writer" goroutine holds the real shadow-branch flock,
+// signals it has started, advances the branch to a new commit, then
+// releases. MigrateShadowBranchRef is invoked while the writer holds the
+// lock, so it can only proceed once the writer's advance has landed --
+// proving the two now share a lock domain instead of racing.
+func TestMigrateShadowBranchRef_SerializesAgainstConcurrentCheckpointWrite(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	testutil.InitRepo(t, repoRoot)
+	testutil.WriteFile(t, repoRoot, "f.txt", "init")
+	testutil.GitAdd(t, repoRoot, "f.txt")
+	testutil.GitCommit(t, repoRoot, "init")
+
+	commonDir := filepath.Join(repoRoot, ".git")
+	headHash := runGitOut(t, repoRoot, "rev-parse", "HEAD")
+
+	const oldBranch = "entire/oldbranch"
+	const newBranch = "entire/newbranch"
+	runGitOut(t, repoRoot, "branch", oldBranch, headHash)
+
+	writerStarted := make(chan struct{})
+	writerMayFinish := make(chan struct{})
+	var wg sync.WaitGroup
+	var writerErr error
+	var advancedHash string
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		writerErr = withShadowBranchFlock(commonDir, oldBranch, func() error {
+			close(writerStarted)
+			// Simulate the writer's real work (building/redacting a
+			// commit) by waiting for the test to tell it to proceed --
+			// this is the exact window the pre-fix migration could race
+			// into.
+			<-writerMayFinish
+			runGitOut(t, repoRoot, "commit", "--allow-empty", "-m", "concurrent checkpoint")
+			advancedHash = runGitOut(t, repoRoot, "rev-parse", "HEAD")
+			return casUpdateShadowBranchRef(context.Background(), repoRoot, oldBranch,
+				plumbing.NewHash(advancedHash), plumbing.NewHash(headHash))
+		})
+	}()
+
+	<-writerStarted // writer holds the flock now
+
+	migrateDone := make(chan struct {
+		migrated bool
+		err      error
+	})
+	go func() {
+		m, err := MigrateShadowBranchRef(context.Background(), repoRoot, commonDir, oldBranch, newBranch)
+		migrateDone <- struct {
+			migrated bool
+			err      error
+		}{m, err}
+	}()
+
+	// Give the migration goroutine a moment to reach (and block on) the
+	// flock acquire before releasing the writer -- without this the
+	// scheduler could run the migration to completion before the writer
+	// even starts, which wouldn't exercise the race at all.
+	time.Sleep(20 * time.Millisecond)
+	close(writerMayFinish)
+
+	result := <-migrateDone
+	wg.Wait()
+
+	require.NoError(t, writerErr)
+	require.NoError(t, result.err)
+	require.True(t, result.migrated)
+	require.NotEmpty(t, advancedHash, "writer goroutine did not run its commit")
+
+	// The new branch must carry the WRITER's latest commit -- not a stale
+	// hash read before the writer's advance landed. This is the property
+	// that was broken pre-fix: an unlocked migration could read headHash,
+	// migrate that stale value, and the writer's CAS would then fail
+	// against a branch the migration had already deleted.
+	gotHash := runGitOut(t, repoRoot, "rev-parse", "--verify", "refs/heads/"+newBranch)
+	require.Equal(t, advancedHash, gotHash,
+		"migrated branch must carry the concurrent writer's commit, not a stale pre-race hash")
+
+	// Old branch must be gone -- migration completed cleanly.
+	cmd := exec.Command("git", "rev-parse", "--verify", "refs/heads/"+oldBranch)
+	cmd.Dir = repoRoot
+	require.Error(t, cmd.Run(), "old shadow branch should have been removed by the migration")
+}
+
+// TestMigrateShadowBranchRef_NoOldBranch confirms the ordinary case (no
+// concurrent writer, old branch simply doesn't exist yet) still behaves as
+// documented: not an error, migrated=false.
+func TestMigrateShadowBranchRef_NoOldBranch(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	testutil.InitRepo(t, repoRoot)
+	testutil.WriteFile(t, repoRoot, "f.txt", "init")
+	testutil.GitAdd(t, repoRoot, "f.txt")
+	testutil.GitCommit(t, repoRoot, "init")
+
+	commonDir := filepath.Join(repoRoot, ".git")
+	migrated, err := MigrateShadowBranchRef(context.Background(), repoRoot, commonDir, "entire/doesnotexist", "entire/newbranch")
+	require.NoError(t, err)
+	require.False(t, migrated)
+}

--- a/cmd/entire/cli/strategy/manual_commit_migration.go
+++ b/cmd/entire/cli/strategy/manual_commit_migration.go
@@ -10,7 +10,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 
 	"github.com/go-git/go-git/v6"
-	"github.com/go-git/go-git/v6/plumbing"
 )
 
 // migrateShadowBranchIfNeeded checks if HEAD has changed since the session started
@@ -115,33 +114,32 @@ func (s *ManualCommitStrategy) migrateShadowBranchToBaseCommit(ctx context.Conte
 		return true, nil
 	}
 
-	oldRefName := plumbing.NewBranchReferenceName(oldShadowBranch)
-	oldRef, err := repo.Reference(oldRefName, true)
+	// The rename below touches the same refs writeCheckpoint/writeTask do
+	// (checkpoint/ephemeral.go), so it must go through the same
+	// flock+CAS discipline those use rather than the unlocked go-git
+	// read/SetReference/CLI-delete this function used to do directly --
+	// two sessions sharing this worktree's shadow branch (a documented,
+	// supported configuration) could otherwise race a concurrent
+	// checkpoint write against this migration and silently lose or
+	// clobber committed checkpoint data. See MigrateShadowBranchRef's
+	// doc comment for the locking/CAS shape.
+	commonDir, err := GetGitCommonDir(ctx)
 	if err != nil {
-		// Old shadow branch doesn't exist - just update state.BaseCommit
-		// This can happen if this is the first checkpoint after HEAD changed
-		state.BaseCommit = newBaseCommit
-		logging.Info(logging.WithComponent(ctx, "migration"), "updated session base commit",
-			slog.String("new_base", newBaseCommit[:7]))
-		return true, nil //nolint:nilerr // err is "reference not found" which is fine - just need to update state
+		return false, fmt.Errorf("resolve git common dir for shadow branch migration: %w", err)
 	}
-
-	// Old shadow branch exists - move it to new base commit
-	newRefName := plumbing.NewBranchReferenceName(newShadowBranch)
-
-	// Create new reference pointing to same commit as old shadow branch
-	newRef := plumbing.NewHashReference(newRefName, oldRef.Hash())
-	if err := repo.Storer.SetReference(newRef); err != nil {
-		return false, fmt.Errorf("failed to create new shadow branch %s: %w", newShadowBranch, err)
-	}
-
-	// Delete old reference via CLI (go-git v5's RemoveReference doesn't persist with packed refs/worktrees)
 	logCtx := logging.WithComponent(ctx, "migration")
-	if err := DeleteBranchCLI(ctx, oldShadowBranch); err != nil {
-		// Non-fatal: log but continue - the important thing is the new branch exists
-		logging.Warn(logCtx, "failed to remove old shadow branch",
-			slog.String("shadow_branch", oldShadowBranch),
-			slog.String("error", err.Error()))
+	migrated, err := checkpoint.MigrateShadowBranchRef(ctx, state.WorktreePath, commonDir, oldShadowBranch, newShadowBranch)
+	if err != nil {
+		return false, fmt.Errorf("migrate shadow branch %s -> %s: %w", oldShadowBranch, newShadowBranch, err)
+	}
+	if !migrated {
+		// Old branch didn't exist (first checkpoint after HEAD changed) or a
+		// concurrent writer already migrated it -- either way state still
+		// advances to the new base commit below.
+		logging.Info(logCtx, "updated session base commit",
+			slog.String("new_base", newBaseCommit[:7]))
+		state.BaseCommit = newBaseCommit
+		return true, nil
 	}
 
 	logging.Info(logCtx, "moved shadow branch (HEAD changed during session)",


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1208
<!-- entire-trail-link-end -->

## Summary
- `migrateShadowBranchToBaseCommit` moved a session's shadow branch to a new base-commit-derived name via an unlocked go-git `Reference` read, a non-CAS `SetReference`, and an unconditional `git branch -D` — entirely outside the flock+CAS discipline `writeCheckpoint`/`writeTask` use for the exact same refs (`withShadowBranchFlock` + `casUpdateShadowBranchRef`, `checkpoint/ephemeral.go`).
- Two sessions sharing a worktree's shadow branch is a documented, supported configuration (main agent + Task-tool subagent). A checkpoint write racing this migration could have its work silently orphaned (migration reads a stale hash and migrates that, missing the write) or the write's own CAS could fail against a branch the migration already deleted — checkpoint data loss with no error surfaced to the user.
- Adds `checkpoint.MigrateShadowBranchRef`, which takes both branches' flocks (stable sorted order, avoids deadlocking against a migration running the opposite direction) before touching either ref, CAS-creates the new branch, CAS-deletes the old one. `manual_commit_migration.go` now routes through it instead of the unlocked read/write/delete sequence.

## Verification
- Real-git, real-flock concurrency reproduction test (`TestMigrateShadowBranchRef_SerializesAgainstConcurrentCheckpointWrite`): a writer goroutine holds the shadow flock and advances the branch while migration is blocked waiting on the same lock, then confirms the migrated branch carries the writer's actual latest commit rather than a stale pre-race hash.
- `go build ./cmd/entire/...` and the targeted new tests pass.
- Full `mise run check` (fmt/lint/full test:ci) deferred to a follow-up pass to keep local CI load down; will run before merge.

## Test plan
- [x] New concurrency reproduction test added and passing
- [x] `go build` passes
- [ ] Full `mise run check` (deferred, will run before merge)