### PR TITLE
docs: disclose that pasted images bypass all redaction

### DIFF
--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -36,6 +36,16 @@ Entire automatically scans transcript and metadata content before writing it to 
 
 Detected secrets are replaced with `REDACTED` before the data is ever written to a git object. Of the six secret-detection passes above, the scanner layer (pass 2) is configurable — see [Choosing secret-scanner engines](#choosing-secret-scanner-engines) below — while the other five are **always on** and cannot be disabled. User-defined rules (inline `custom_redactions` and rule packs) add a seventh secret-detection pass that only runs when configured.
 
+### What Entire does NOT scan: pasted images and screenshots
+
+**Every layer described above — all nine passes, including the opt-in PII and OpenAI Privacy Filter layers — operates only on transcript text. None of them ever inspect image content.**
+
+When you paste an image into an agent conversation (a screenshot of a terminal with a visible API key, a cloud console page showing a misconfigured resource, a photo of a document), Entire externalizes it out of the transcript and stores it as a **raw binary blob** under the checkpoint's `assets/` folder — completely unredacted, byte-for-byte identical to what you pasted. This blob is written to `entire/checkpoints/v1` (or the equivalent per-checkpoint ref on the `git-refs` backend) and pushed to your remote like any other checkpoint content.
+
+This is a **deliberate design choice, not a bug**: byte-level regex and entropy redaction cannot safely touch binary image data without corrupting the image, so Entire does not attempt it. There is currently no OCR pass, no vision-model PII/secret scan, and no gate that holds image assets back until reviewed — an image that enters a conversation ships to your checkpoint history exactly as pasted.
+
+**If you would not commit an image to your repository unredacted, do not paste it into an agent conversation.** This applies equally to a private repository — anyone with read access to checkpoint data can see it — and especially to a public one.
+
 ### Choosing secret-scanner engines
 
 Pattern matching (layer 2 above) is served by two independent scanner engines, each of which can be turned on or off:
@@ -362,6 +372,7 @@ If your AI sessions will touch sensitive data:
 
 - **Use a private repository.** This is the simplest and most complete protection. Committed checkpoints are then only visible to collaborators.
 - **Avoid passing sensitive files to your agent.** Content that never enters the agent conversation never appears in transcripts.
+- **Never paste a screenshot or image containing secrets or personal data.** Unlike text, pasted images are never scanned or redacted by any layer — see [What Entire does NOT scan: pasted images and screenshots](#what-entire-does-not-scan-pasted-images-and-screenshots).
 - **Review before pushing.** Checkpoints are written locally at commit time and pushed separately, so there is always a window to inspect them:
 
   ```fish
@@ -512,7 +523,7 @@ File an issue when the rule would benefit every Entire user (e.g., a major SaaS 
 
 - **Best-effort.** Novel or low-entropy secrets (short passwords, predictable tokens) may not be caught.
 - **Filenames and binary data.** Secrets in filenames, binary files, or deeply nested structures may not be detected.
-- **JSONL skip rules.** Entire skips scanning fields named `signature`, fields ending in `id`/`ids`, structural-path fields (`filepath`, `file_path`, `cwd`, `root`, `directory`, `dir`, `path`), and objects whose `type` starts with `image` or equals `base64` — all to avoid false positives.
+- **JSONL skip rules.** Entire skips scanning fields named `signature`, fields ending in `id`/`ids`, and structural-path fields (`filepath`, `file_path`, `cwd`, `root`, `directory`, `dir`, `path`) to avoid false positives. Objects whose `type` starts with `image` or equals `base64` are also skipped by the text scanner — but this is not merely a false-positive optimization: images are never scanned by *any* layer, text or otherwise. See [What Entire does NOT scan: pasted images and screenshots](#what-entire-does-not-scan-pasted-images-and-screenshots) above for the full picture.
 - **Built-in PII patterns are US-centric.** `phone` matches North American (NANP) formats only — international formats, including E.164 numbers outside `+1`, are not detected. `address` matches the street line only; city, state, and ZIP/postcode are preserved. If you handle personal data from other regions, add `custom_patterns` for your locale rather than relying on the built-in categories alone.
 - **Custom PII patterns are user-authored.** Teams own the correctness of their `custom_patterns`. An invalid regex is logged and skipped, not enforced.
 - **Users are ultimately responsible** for reviewing what they commit and push. Redaction is a safety net, not a guarantee.

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -40,9 +40,14 @@ Detected secrets are replaced with `REDACTED` before the data is ever written to
 
 **Every layer described above — all nine passes, including the opt-in PII and OpenAI Privacy Filter layers — operates only on transcript text. None of them ever inspect image content.**
 
-When you paste an image into an agent conversation (a screenshot of a terminal with a visible API key, a cloud console page showing a misconfigured resource, a photo of a document), Entire externalizes it out of the transcript and stores it as a **raw binary blob** under the checkpoint's `assets/` folder — completely unredacted, byte-for-byte identical to what you pasted. This blob is written to `entire/checkpoints/v1` (or the equivalent per-checkpoint ref on the `git-refs` backend) and pushed to your remote like any other checkpoint content.
+When you paste an image into an agent conversation (a screenshot of a terminal with a visible API key, a cloud console page showing a misconfigured resource, a photo of a document), it is stored **completely unredacted, byte-for-byte identical to what you pasted**. Where it is stored depends on one setting, but the exposure is the same either way:
 
-This is a **deliberate design choice, not a bug**: byte-level regex and entropy redaction cannot safely touch binary image data without corrupting the image, so Entire does not attempt it. There is currently no OCR pass, no vision-model PII/secret scan, and no gate that holds image assets back until reviewed — an image that enters a conversation ships to your checkpoint history exactly as pasted.
+- **By default**, the image stays inline in the stored transcript as base64. The text scanner skips it (see the `type: image` / `type: base64` skip rule below) rather than scanning it.
+- **With `redaction.externalize_images` enabled** (off by default; the `ENTIRE_EXTERNALIZE_IMAGES=1` environment variable is an equivalent override), the image is lifted out of the transcript and written as a raw binary blob under the checkpoint's `assets/` folder instead.
+
+Either way the bytes become part of checkpoint content on `entire/checkpoints/v1` (or the equivalent per-checkpoint ref on the `git-refs` backend). Like all checkpoint data, that is written locally at commit time and pushed separately — so an image reaches your remote when checkpoint data is pushed, not the instant you paste it. That gap is your window to inspect it — see the **Review before pushing** bullet under [Recommendations](#recommendations) below.
+
+This is a **deliberate design choice, not a bug**: byte-level regex and entropy redaction cannot safely touch binary image data without corrupting the image, so Entire does not attempt it. There is currently no OCR pass, no vision-model PII/secret scan, and no gate that holds an image back until reviewed — an image that enters a conversation lands in your checkpoint history exactly as pasted, in whichever of the two forms above applies.
 
 **If you would not commit an image to your repository unredacted, do not paste it into an agent conversation.** This applies equally to a private repository — anyone with read access to checkpoint data can see it — and especially to a public one.
 

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -36,18 +36,27 @@ Entire automatically scans transcript and metadata content before writing it to 
 
 Detected secrets are replaced with `REDACTED` before the data is ever written to a git object. Of the six secret-detection passes above, the scanner layer (pass 2) is configurable — see [Choosing secret-scanner engines](#choosing-secret-scanner-engines) below — while the other five are **always on** and cannot be disabled. User-defined rules (inline `custom_redactions` and rule packs) add a seventh secret-detection pass that only runs when configured.
 
-### What Entire does NOT scan: pasted images and screenshots
+### What Entire does NOT understand: pasted images and screenshots
 
-**Every layer described above — all nine passes, including the opt-in PII and OpenAI Privacy Filter layers — operates only on transcript text. None of them ever inspect image content.**
+**Every layer described above — all nine passes, including the opt-in PII and OpenAI Privacy Filter layers — reads transcript *text*. There is no OCR pass, no vision-model PII or secret scan, and no gate that holds an image back until someone reviews it. Nothing in Entire ever reads what an image depicts.**
 
-When you paste an image into an agent conversation (a screenshot of a terminal with a visible API key, a cloud console page showing a misconfigured resource, a photo of a document), it is stored **completely unredacted, byte-for-byte identical to what you pasted**. Where it is stored depends on one setting, but the exposure is the same either way:
+What that means for an image you paste is **not uniform across agents**, because it depends on how the agent writes the image into its transcript. There are three outcomes, and only the first is an exposure:
 
-- **By default**, the image stays inline in the stored transcript as base64. The text scanner skips it (see the `type: image` / `type: base64` skip rule below) rather than scanning it.
-- **With `redaction.externalize_images` enabled** (off by default; the `ENTIRE_EXTERNALIZE_IMAGES=1` environment variable is an equivalent override), the image is lifted out of the transcript and written as a raw binary blob under the checkpoint's `assets/` folder instead.
+| Agent | Default | With `redaction.externalize_images` on |
+| --- | --- | --- |
+| Claude Code | **Stored unredacted**, inline in the transcript as base64. The text scanner skips it (the `type: image` / `type: base64` skip rule below) rather than scanning it. | **Stored unredacted** as a raw binary blob under the checkpoint's `assets/` folder. |
+| Codex | **Destroyed.** Codex writes images as `data:` URIs inside `image_url` and tool-output strings, which the skip rule does not match, so the entropy layer treats the base64 as a secret and replaces it. The stored transcript keeps the surrounding message; the image is gone. | **Stored unredacted** under `assets/` (externalization runs before redaction, which is what preserves it). |
+| Cursor | **Not stored in the repository at all.** Cursor keeps images in its own per-session SQLite store, never in the transcript Entire reads. | **Stored unredacted** under `assets/`, captured from that store. |
+| Gemini CLI, OpenCode, Copilot CLI, Factory Droid, Pi | Depends on the agent's own transcript shape; Entire has no image handling for these. Assume the Claude Code row unless you have checked. | Unchanged — the setting only affects the three agents above. |
 
-Either way the bytes become part of checkpoint content on `entire/checkpoints/v1` (or the equivalent per-checkpoint ref on the `git-refs` backend). Like all checkpoint data, that is written locally at commit time and pushed separately — so an image reaches your remote when checkpoint data is pushed, not the instant you paste it. That gap is your window to inspect it — see the **Review before pushing** bullet under [Recommendations](#recommendations) below.
+**Do not treat the Codex row as a protection.** It is a side effect of a skip rule not matching a shape, not a deliberate safeguard: it destroys data you may want, it does not apply to the `assets/` path, and a change to either the rule or Codex's format would flip it to the exposure case without notice.
 
-This is a **deliberate design choice, not a bug**: byte-level regex and entropy redaction cannot safely touch binary image data without corrupting the image, so Entire does not attempt it. There is currently no OCR pass, no vision-model PII/secret scan, and no gate that holds an image back until reviewed — an image that enters a conversation lands in your checkpoint history exactly as pasted, in whichever of the two forms above applies.
+Where an image *is* stored, it is byte-for-byte what you pasted — completely unredacted — because byte-level regex and entropy redaction cannot inspect binary image data without corrupting it, so Entire does not attempt it. That is a deliberate design choice, not a bug.
+
+Two things about *when* those bytes reach git, both of which narrow the window you have to catch a mistake:
+
+- **A checkpoint's copy** lands on `entire/checkpoints/v1` (or the equivalent per-checkpoint ref on the `git-refs` backend). Like all checkpoint data it is written locally and pushed separately, so it reaches your remote only when checkpoint data is pushed — see the **Review before pushing** bullet under [Recommendations](#recommendations).
+- **A shadow-branch copy** is written earlier, at the end of the agent turn, before you commit anything and regardless of the setting above. The shadow write does not externalize images, so for Claude Code the base64 is committed into your local git objects at turn end. Shadow branches are local-only and are never pushed (see [Where data is stored](#where-data-is-stored) above), but `entire checkpoint list` will not show this copy — it exists before any checkpoint does.
 
 **If you would not commit an image to your repository unredacted, do not paste it into an agent conversation.** This applies equally to a private repository — anyone with read access to checkpoint data can see it — and especially to a public one.
 
@@ -377,7 +386,7 @@ If your AI sessions will touch sensitive data:
 
 - **Use a private repository.** This is the simplest and most complete protection. Committed checkpoints are then only visible to collaborators.
 - **Avoid passing sensitive files to your agent.** Content that never enters the agent conversation never appears in transcripts.
-- **Never paste a screenshot or image containing secrets or personal data.** Unlike text, pasted images are never scanned or redacted by any layer — see [What Entire does NOT scan: pasted images and screenshots](#what-entire-does-not-scan-pasted-images-and-screenshots).
+- **Never paste a screenshot or image containing secrets or personal data.** Nothing in Entire reads what an image depicts, and on most agents the image is stored unredacted — see [What Entire does NOT understand: pasted images and screenshots](#what-entire-does-not-understand-pasted-images-and-screenshots).
 - **Review before pushing.** Checkpoints are written locally at commit time and pushed separately, so there is always a window to inspect them:
 
   ```fish
@@ -528,7 +537,7 @@ File an issue when the rule would benefit every Entire user (e.g., a major SaaS 
 
 - **Best-effort.** Novel or low-entropy secrets (short passwords, predictable tokens) may not be caught.
 - **Filenames and binary data.** Secrets in filenames, binary files, or deeply nested structures may not be detected.
-- **JSONL skip rules.** Entire skips scanning fields named `signature`, fields ending in `id`/`ids`, and structural-path fields (`filepath`, `file_path`, `cwd`, `root`, `directory`, `dir`, `path`) to avoid false positives. Objects whose `type` starts with `image` or equals `base64` are also skipped by the text scanner — but this is not merely a false-positive optimization: images are never scanned by *any* layer, text or otherwise. See [What Entire does NOT scan: pasted images and screenshots](#what-entire-does-not-scan-pasted-images-and-screenshots) above for the full picture.
+- **JSONL skip rules.** Entire skips scanning fields whose name *ends in* `signature` (so `thinkingSignature` too), fields ending in `id`/`ids`, and structural-path fields (`filepath`, `file_path`, `cwd`, `root`, `directory`, `dir`, `path`) to avoid false positives. Objects whose `type` starts with `image` or equals `base64` are also skipped — and that skip is what leaves a pasted image unredacted rather than merely unflagged. It matches some agents' image shapes and not others, which is why the outcome differs per agent: see [What Entire does NOT understand: pasted images and screenshots](#what-entire-does-not-understand-pasted-images-and-screenshots) above.
 - **Built-in PII patterns are US-centric.** `phone` matches North American (NANP) formats only — international formats, including E.164 numbers outside `+1`, are not detected. `address` matches the street line only; city, state, and ZIP/postcode are preserved. If you handle personal data from other regions, add `custom_patterns` for your locale rather than relying on the built-in categories alone.
 - **Custom PII patterns are user-authored.** Teams own the correctness of their `custom_patterns`. An invalid regex is logged and skipped, not enforced.
 - **Users are ultimately responsible** for reviewing what they commit and push. Redaction is a safety net, not a guarantee.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1209
<!-- entire-trail-link-end -->

## Summary
- Pasted images/screenshots are externalized as raw binary blobs (`checkpoint/persistent.go`'s `writeAssets`) with no redaction call anywhere in the write path, and both OPF rewrite tree walkers explicitly skip the `assets/` subtree. This is a deliberate, defensible design choice — byte-level regex/entropy redaction can't safely touch binary image data without corrupting it — but `docs/security-and-privacy.md` didn't disclose it anywhere a user would actually look for it.
- The only related text was a low-level "JSONL skip rules" footnote framing the `type:image` skip as a false-positive-avoidance optimization for the text scanner, which reads as "we're careful not to over-flag images," not "images are never scanned by anything, ever."

## Change
- New, prominent "What Entire does NOT scan: pasted images and screenshots" section directly under "What Entire redacts automatically."
- Updated the "protecting sensitive data" checklist with an explicit "never paste a screenshot with secrets" bullet.
- Corrected the misleading JSONL-skip-rules footnote to point at the real explanation.

Docs-only change; no code behavior modified (deliberately — remediation depth like OCR-based scanning is a separate product decision, out of scope here).

## Test plan
- [x] Verified the disclosure accurately matches current code behavior (`writeAssets`, `manual_commit_opf_rewrite.go`)
- [ ] Full `mise run check` deferred to a follow-up pass (docs-only change, low risk)