### PR TITLE
fix: don't let findInaccessiblePlugin re-find a binary via a relative PATH entry

### DIFF
--- a/cmd/entire/cli/plugin.go
+++ b/cmd/entire/cli/plugin.go
@@ -126,9 +126,25 @@ func resolvePlugin(rootCmd *cobra.Command, args []string) (binPath string, plugi
 // given name. Only meaningful after exec.LookPath has already failed —
 // indicates the file exists but lacks the executable bit (or the
 // equivalent platform-specific accessibility).
+//
+// Only ABSOLUTE PATH entries are scanned. A relative entry (including bare
+// "." and the empty string, which POSIX treats as the current directory) is
+// skipped outright, even if it points at a real, inaccessible file. That
+// mirrors exec.LookPath's own refusal: when LookPath finds a binary via a
+// relative PATH entry it deliberately returns exec.ErrDot rather than
+// resolving it — the fix for the classic "dot in PATH" RCE class, where a
+// planted binary in an untrusted working directory silently executes with
+// the user's privileges. LookPath's error does not distinguish ErrDot from
+// a genuine "exists but not executable" case, so if this function re-walked
+// relative entries too, it would blindly re-find and return the exact
+// binary LookPath just correctly refused — and the caller (runPlugin) execs
+// it via a path that contains a separator, which bypasses Go's exec.Command
+// ErrDot re-check (that only fires for a bare name with no separator). Do
+// not remove this filter without also making resolvePlugin ErrDot-aware
+// some other way.
 func findInaccessiblePlugin(filename string) (string, bool) {
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
-		if dir == "" {
+		if dir == "" || !filepath.IsAbs(dir) {
 			continue
 		}
 		candidate := filepath.Join(dir, filename)

--- a/cmd/entire/cli/plugin_test.go
+++ b/cmd/entire/cli/plugin_test.go
@@ -174,6 +174,52 @@ func TestResolvePlugin_PathTraversal(t *testing.T) {
 	}
 }
 
+// TestMaybeRunPlugin_RelativePathEntry_ErrDotNotBypassed reproduces the
+// concrete RCE precondition: $PATH contains a relative entry (a common shape
+// from direnv PATH_add, project-local bin/ wrappers, node_modules/.bin-style
+// patterns, or a literal "."), and the current directory contains a
+// repo-planted entire-<name> binary reachable through that relative entry.
+//
+// exec.LookPath deliberately refuses to resolve a binary found via a
+// relative PATH entry (returns exec.ErrDot) -- that refusal is Go's fix for
+// the classic "dot in PATH" RCE class. Before the fix, resolvePlugin's
+// fallback (findInaccessiblePlugin) re-walked the same PATH entries with a
+// plain os.Stat, blind to *why* LookPath failed, re-found the very file
+// LookPath just refused, and runPlugin executed it -- because the resolved
+// path contains a separator, Go's exec.Command does not re-apply the ErrDot
+// check for it. Net effect: a planted binary in an untrusted working
+// directory ran silently with the user's full privileges.
+func TestMaybeRunPlugin_RelativePathEntry_ErrDotNotBypassed(t *testing.T) { //nolint:paralleltest // mutates PATH and CWD via t.Setenv/t.Chdir
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("PATH separator / ErrDot semantics are POSIX-specific")
+	}
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	// A real, executable, shebang'd binary -- not a mock -- planted under a
+	// RELATIVE subdirectory of what will become the current directory.
+	argFile := filepath.Join(root, "args.txt")
+	writePluginBinary(t, binDir, "entire-errdotcheck", argFile, 0)
+
+	origPath := os.Getenv("PATH")
+	t.Chdir(root)
+	// "bin" is relative: exactly the direnv PATH_add / project-local-bin
+	// shape the finding describes. This is a real os.Setenv the real
+	// exec.LookPath call inside resolvePlugin will observe.
+	t.Setenv("PATH", "bin"+string(os.PathListSeparator)+origPath)
+
+	handled, _ := MaybeRunPlugin(context.Background(), newTestRoot(), []string{"errdotcheck"})
+	if handled {
+		t.Fatal("a plugin reachable only via a RELATIVE PATH entry must not resolve/execute " +
+			"(this is the exec.ErrDot bypass / RCE the fix prevents)")
+	}
+	if _, err := os.Stat(argFile); err == nil {
+		t.Fatal("planted binary via relative PATH entry WAS EXECUTED -- RCE bypass of exec.ErrDot reproduced")
+	}
+}
+
 func TestRunPlugin_ExitCodePropagation(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1210
<!-- entire-trail-link-end -->

## Summary
- `exec.LookPath` deliberately refuses (`exec.ErrDot`) to resolve a binary found via a relative `\$PATH` entry — Go's fix for the classic "dot in PATH" RCE class.
- `resolvePlugin`'s fallback for `LookPath` failures, `findInaccessiblePlugin`, didn't distinguish that refusal from a genuine "exists but lacks the executable bit" case: it re-walked the same PATH entries with a plain `os.Stat` and returned `found=true` for the exact file `LookPath` just refused.
- `runPlugin` then execs it via a path containing a separator, which bypasses Go's `exec.Command` ErrDot re-check (that only fires for a bare name with no separator).
- **Net effect:** any relative `\$PATH` entry (direnv `PATH_add`, a project-local `bin/`, `node_modules/.bin`-style patterns — all common, not exotic) plus an untrusted repo containing `<relative-dir>/entire-<name>` gave silent code execution with the user's full privileges on `entire <name>`.

## Fix
`findInaccessiblePlugin` now only scans absolute PATH entries, mirroring `exec.LookPath`'s own refusal for the relative case.

## Verification
- Real reproduction (not a mock): a real executable shebang'd binary planted under a relative `bin/` directory, `PATH` set to include it, `MaybeRunPlugin` invoked directly, and a marker-file assertion proving the planted binary was never executed.
- **Mutation-verified**: temporarily reverted just the one-line fix, reran the new test, confirmed it fails exactly as expected (RCE reproduced — "planted binary via relative PATH entry WAS EXECUTED"), then restored the fix and confirmed the test passes again.
- Full package test suite for the affected area (`TestResolvePlugin*`, `TestRunPlugin*`, `TestMaybeRunPlugin*`) passes.
- Full `mise run check` (fmt/lint/full test:ci) deferred to a follow-up pass to keep local CI load down; will run before merge.

## Test plan
- [x] New reproduction test added and passing
- [x] Verified test fails without the fix (mutation check) — confirmed actual RCE reproduction
- [x] Targeted package test suite green
- [ ] Full `mise run check` (deferred, will run before merge)