### PR TITLE
fix: serialize session-state clear against concurrent MutateSessionState

### DIFF
--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -409,10 +409,42 @@ func promptSessionAction(ss stuckSession) (string, error) {
 	return action, nil
 }
 
+// sessionLockNoticeDelay is how long discardSession waits before telling the
+// user it is blocked on a session's state lock. Short enough that a real stall
+// is announced promptly, long enough that the uncontended case (the common
+// one) stays silent.
+const sessionLockNoticeDelay = time.Second
+
+// clearSessionStateWithProgress clears sessionID's state, announcing the wait
+// on errW if the per-session state lock is not free within notifyAfter.
+//
+// The wait itself is deliberate and must not be shortened here:
+// strategy.ClearSessionState takes the same gate every mutation of that state
+// uses, because deleting the file out from under an in-flight write destroys
+// it. But the acquire is unbounded -- only the TurnStart hook opts into a
+// deadline, via strategy.WithSessionLockWait -- and a checkpoint condensation
+// holds that lock while it rewrites a multi-MB transcript, observed at ~30s on
+// large sessions (see strategy/session_state.go's note on the lock). `entire
+// doctor` is interactive and runs precisely when other sessions are live, so
+// without this notice a correct 30-second wait is indistinguishable from a
+// hang, and the natural user response is to kill it.
+func clearSessionStateWithProgress(ctx context.Context, sessionID string, errW io.Writer, notifyAfter time.Duration) error {
+	done := make(chan error, 1)
+	go func() { done <- strategy.ClearSessionState(ctx, sessionID) }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(notifyAfter):
+	}
+	fmt.Fprintf(errW, "Waiting for session %s to release its state lock (a checkpoint condensation can hold it for ~30s)...\n", sessionID)
+	return <-done
+}
+
 // discardSession removes session state and cleans up the shadow branch.
 func discardSession(ctx context.Context, ss stuckSession, _ *git.Repository, errW io.Writer) error {
 	// Clear session state file
-	if err := strategy.ClearSessionState(ctx, ss.State.SessionID); err != nil {
+	if err := clearSessionStateWithProgress(ctx, ss.State.SessionID, errW, sessionLockNoticeDelay); err != nil {
 		return fmt.Errorf("failed to clear session state: %w", err)
 	}
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -409,42 +409,10 @@ func promptSessionAction(ss stuckSession) (string, error) {
 	return action, nil
 }
 
-// sessionLockNoticeDelay is how long discardSession waits before telling the
-// user it is blocked on a session's state lock. Short enough that a real stall
-// is announced promptly, long enough that the uncontended case (the common
-// one) stays silent.
-const sessionLockNoticeDelay = time.Second
-
-// clearSessionStateWithProgress clears sessionID's state, announcing the wait
-// on errW if the per-session state lock is not free within notifyAfter.
-//
-// The wait itself is deliberate and must not be shortened here:
-// strategy.ClearSessionState takes the same gate every mutation of that state
-// uses, because deleting the file out from under an in-flight write destroys
-// it. But the acquire is unbounded -- only the TurnStart hook opts into a
-// deadline, via strategy.WithSessionLockWait -- and a checkpoint condensation
-// holds that lock while it rewrites a multi-MB transcript, observed at ~30s on
-// large sessions (see strategy/session_state.go's note on the lock). `entire
-// doctor` is interactive and runs precisely when other sessions are live, so
-// without this notice a correct 30-second wait is indistinguishable from a
-// hang, and the natural user response is to kill it.
-func clearSessionStateWithProgress(ctx context.Context, sessionID string, errW io.Writer, notifyAfter time.Duration) error {
-	done := make(chan error, 1)
-	go func() { done <- strategy.ClearSessionState(ctx, sessionID) }()
-
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(notifyAfter):
-	}
-	fmt.Fprintf(errW, "Waiting for session %s to release its state lock (a checkpoint condensation can hold it for ~30s)...\n", sessionID)
-	return <-done
-}
-
 // discardSession removes session state and cleans up the shadow branch.
 func discardSession(ctx context.Context, ss stuckSession, _ *git.Repository, errW io.Writer) error {
 	// Clear session state file
-	if err := clearSessionStateWithProgress(ctx, ss.State.SessionID, errW, sessionLockNoticeDelay); err != nil {
+	if err := strategy.ClearSessionStateWithProgress(ctx, ss.State.SessionID, errW, strategy.SessionLockNoticeDelay); err != nil {
 		return fmt.Errorf("failed to clear session state: %w", err)
 	}
 

--- a/cmd/entire/cli/doctor_session_lock_test.go
+++ b/cmd/entire/cli/doctor_session_lock_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// syncBuffer is an io.Writer the test goroutine can poll while another
+// goroutine writes to it. bytes.Buffer alone is not safe for that -- the race
+// detector flags the concurrent grow/String, and a torn read would make the
+// poll below flaky rather than failing honestly.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *syncBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Len()
+}
+
+// TestClearSessionStateWithProgress_AnnouncesLockWait covers the UX half of
+// gating doctor's clear: the wait is correct (deleting the state file out from
+// under an in-flight write destroys it) but unbounded, and a condensation can
+// hold the lock ~30s, so a silent wait reads as a hang. This drives a real
+// held lock -- a writer parked inside MutateSessionState -- and asserts the
+// notice is printed and the clear still completes once the lock frees.
+func TestClearSessionStateWithProgress_AnnouncesLockWait(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	ctx := context.Background()
+	const sessionID = "doctor-lock-notice"
+	if err := strategy.SaveSessionState(ctx, &strategy.SessionState{
+		SessionID:  sessionID,
+		BaseCommit: "abc123",
+		StartedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	writerHolding := make(chan struct{})
+	writerMayFinish := make(chan struct{})
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		if err := strategy.MutateSessionState(ctx, sessionID, func(*strategy.SessionState) error {
+			close(writerHolding)
+			<-writerMayFinish
+			return nil
+		}); err != nil {
+			t.Errorf("MutateSessionState: %v", err)
+		}
+	}()
+	<-writerHolding // the lock is genuinely held now
+
+	var errBuf syncBuffer
+	cleared := make(chan error, 1)
+	go func() {
+		cleared <- clearSessionStateWithProgress(ctx, sessionID, &errBuf, 20*time.Millisecond)
+	}()
+
+	// The notice must appear while the clear is still blocked, which is the
+	// whole point -- it is useless if it only prints after the wait ends.
+	deadline := time.After(2 * time.Second)
+	for !strings.Contains(errBuf.String(), "release its state lock") {
+		select {
+		case <-deadline:
+			t.Fatalf("no lock-wait notice while blocked; stderr was %q", errBuf.String())
+		case err := <-cleared:
+			t.Fatalf("clear returned (%v) before the writer released; stderr %q", err, errBuf.String())
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	if !strings.Contains(errBuf.String(), sessionID) {
+		t.Errorf("notice should name the session, got %q", errBuf.String())
+	}
+
+	close(writerMayFinish)
+	<-writerDone
+	if err := <-cleared; err != nil {
+		t.Fatalf("clear failed after the lock freed: %v", err)
+	}
+}
+
+// The uncontended case must stay silent: an unconditional notice would fire on
+// every doctor run and train the user to ignore it.
+func TestClearSessionStateWithProgress_SilentWhenUncontended(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	ctx := context.Background()
+	const sessionID = "doctor-lock-quiet"
+	if err := strategy.SaveSessionState(ctx, &strategy.SessionState{
+		SessionID:  sessionID,
+		BaseCommit: "abc123",
+		StartedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	var errBuf syncBuffer
+	if err := clearSessionStateWithProgress(ctx, sessionID, &errBuf, time.Second); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if errBuf.Len() != 0 {
+		t.Errorf("expected no output when the lock is free, got %q", errBuf.String())
+	}
+}

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1676,7 +1676,7 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 	}
 
 	var shadowBranchName string
-	var clearAfter bool
+	var cleared bool
 	var newSkillEvents []agent.SkillEvent
 	mutErr := MutateSessionStateOnSaved(ctx, sessionID, func(state *SessionState) error {
 		if state.PendingCondensationID() != checkpointID {
@@ -1694,7 +1694,16 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 				slog.String("session_id", sessionID),
 				slog.String("shadow_branch", shadowBranchName),
 			)
-			clearAfter = true
+			// Clear while still holding this session's gate (we're inside
+			// the locked mutation closure), not after releasing it: a
+			// concurrent, properly-locked write (e.g. a PostToolUse hook
+			// for this same session) landing in an unlocked gap between
+			// this decision and the actual delete would otherwise be
+			// silently destroyed. See clearSessionState's doc comment.
+			if clearErr := s.clearSessionStateLocked(ctx, sessionID); clearErr != nil {
+				return fmt.Errorf("failed to clear session state: %w", clearErr)
+			}
+			cleared = true
 			return ErrMutationSkip
 		}
 
@@ -1746,10 +1755,10 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 		return mutErr
 	}
 
-	if clearAfter {
-		if err := s.clearSessionState(ctx, sessionID); err != nil {
-			return fmt.Errorf("failed to clear session state: %w", err)
-		}
+	if cleared {
+		// Already cleared inside the locked mutation closure above -- see
+		// its comment for why this must not happen a second time (or
+		// outside the lock).
 		return nil
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1700,6 +1700,14 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 			// for this same session) landing in an unlocked gap between
 			// this decision and the actual delete would otherwise be
 			// silently destroyed. See clearSessionState's doc comment.
+			//
+			// This is the ONLY correct way to clear from inside a frame, and
+			// it works only because of the ErrMutationSkip below: the delete
+			// sticks because the frame does not save. The gate alone would
+			// not be enough -- a saving frame writes the state back out and
+			// the clear vanishes, which is why the exported
+			// ClearSessionState refuses to run reentrantly rather than
+			// appearing to succeed.
 			if clearErr := s.clearSessionStateLocked(ctx, sessionID); clearErr != nil {
 				return fmt.Errorf("failed to clear session state: %w", clearErr)
 			}

--- a/cmd/entire/cli/strategy/manual_commit_reset.go
+++ b/cmd/entire/cli/strategy/manual_commit_reset.go
@@ -58,7 +58,9 @@ func (s *ManualCommitStrategy) Reset(ctx context.Context, w, errW io.Writer) err
 	// Clear all sessions for this commit
 	clearedSessions := make([]string, 0)
 	for _, state := range sessions {
-		if err := s.clearSessionState(ctx, state.SessionID); err != nil {
+		if err := withLockWaitNotice(state.SessionID, errW, SessionLockNoticeDelay, func() error {
+			return s.clearSessionState(ctx, state.SessionID)
+		}); err != nil {
 			fmt.Fprintf(errW, "Warning: failed to clear session state for %s: %v\n", state.SessionID, err)
 		} else {
 			clearedSessions = append(clearedSessions, state.SessionID)
@@ -95,8 +97,11 @@ func (s *ManualCommitStrategy) ResetSession(ctx context.Context, w, errW io.Writ
 		return fmt.Errorf("session not found: %s", sessionID)
 	}
 
-	// Clear the session state file
-	if err := s.clearSessionState(ctx, sessionID); err != nil {
+	// Clear the session state file. Reset is interactive and takes the same
+	// unbounded gate doctor does, so it gets the same lock-wait notice.
+	if err := withLockWaitNotice(sessionID, errW, SessionLockNoticeDelay, func() error {
+		return s.clearSessionState(ctx, sessionID)
+	}); err != nil {
 		return fmt.Errorf("failed to clear session state: %w", err)
 	}
 	fmt.Fprintf(w, "✓ Cleared session state for %s\n", sessionID)

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -583,12 +583,6 @@ func (s *ManualCommitStrategy) FindSessionsForCommit(ctx context.Context, baseCo
 	return s.findSessionsForCommit(ctx, baseCommitSHA)
 }
 
-// ClearSessionState is the exported version of clearSessionState.
-// Used by `entire doctor` to clean up session state files.
-func (s *ManualCommitStrategy) ClearSessionState(ctx context.Context, sessionID string) error {
-	return s.clearSessionState(ctx, sessionID)
-}
-
 // CountOtherActiveSessionsWithCheckpoints counts how many other active sessions
 // from the SAME worktree (different from currentSessionID) have created checkpoints
 // on the SAME base commit (current HEAD). This is used to show an informational message

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -51,8 +51,17 @@ func (s *ManualCommitStrategy) saveSessionState(ctx context.Context, state *Sess
 	return nil
 }
 
-// clearSessionState clears session state using the StateStore.
-func (s *ManualCommitStrategy) clearSessionState(ctx context.Context, sessionID string) error {
+// clearSessionStateLocked clears session state using the StateStore. Callers
+// must already hold sessionID's gate -- either by having called
+// acquireSessionGate themselves, or by running inside a
+// MutateSessionState/MutateSessionStateOnSaved closure for the same session
+// (see CondenseSessionByID's clearAfter path, which clears while still
+// inside its own locked mutation rather than after releasing it). Calling
+// this without the gate held reintroduces the race clearSessionState exists
+// to close: a concurrent, properly-locked write landing in the gap between
+// a caller's "safe to clear" decision and the actual delete would be
+// silently destroyed.
+func (s *ManualCommitStrategy) clearSessionStateLocked(ctx context.Context, sessionID string) error {
 	store, err := s.getStateStore(ctx)
 	if err != nil {
 		return err
@@ -61,6 +70,38 @@ func (s *ManualCommitStrategy) clearSessionState(ctx context.Context, sessionID 
 		return fmt.Errorf("failed to clear session state: %w", err)
 	}
 	return nil
+}
+
+// clearSessionState clears session state using the StateStore, under
+// sessionID's gate -- the same per-session lock MutateSessionState uses for
+// every other mutation of this state. Without it, a concurrently-running,
+// properly-locked write (e.g. a PostToolUse hook for the same session)
+// landing in the gap between a caller's decision to clear and this call
+// actually clearing would be silently destroyed: the file the write just
+// produced gets deleted out from under it, with nothing surfacing the loss.
+// initializeSession documents and fixes the identical hazard class
+// elsewhere in this file ("take the gate, then re-check under lock");
+// this closes the same gap for the clear path.
+func (s *ManualCommitStrategy) clearSessionState(ctx context.Context, sessionID string) error {
+	if sessionID == "" {
+		return ErrStateNotFound
+	}
+	_, isOuter, release, err := acquireSessionGate(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	defer release()
+	if !isOuter {
+		// A MutateSessionState frame for this session is already active on
+		// this goroutine. Reaching clearSessionState reentrantly from
+		// inside one is not something any current caller does (they clear
+		// only after their own mutation closure has already returned and
+		// released) -- if that ever changes, call clearSessionStateLocked
+		// directly from inside the active closure instead, the way
+		// CondenseSessionByID's clearAfter path does.
+		return fmt.Errorf("clearSessionState: session %s gate already held by an active MutateSessionState frame on this goroutine", sessionID)
+	}
+	return s.clearSessionStateLocked(ctx, sessionID)
 }
 
 // listAllSessionStates returns all active session states.

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -427,6 +427,66 @@ func TestShadowStrategy_ClearSessionState(t *testing.T) {
 	}
 }
 
+// TestClearSessionState_SerializesAgainstConcurrentMutation is a real
+// concurrency reproduction of the race clearSessionState's gate closes:
+// before the fix, it acquired no lock at all, so a clear racing a
+// concurrently-running MutateSessionState for the same session could run
+// while that mutation was still in flight -- deleting the state file out
+// from under a write that had not yet landed, silently destroying it. This
+// drives both paths with real goroutines and explicit channel
+// synchronization (no sleeps to fake a race): a writer goroutine holds the
+// real gate (via MutateSessionState) and blocks mid-mutation; a concurrent
+// clearSessionState call must block until the writer releases, not run
+// concurrently with it.
+func TestClearSessionState_SerializesAgainstConcurrentMutation(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	s := &ManualCommitStrategy{}
+	const sessionID = "race-session"
+	require.NoError(t, s.saveSessionState(context.Background(), &SessionState{
+		SessionID:  sessionID,
+		BaseCommit: "abc123",
+		StartedAt:  time.Now(),
+	}))
+
+	writerStarted := make(chan struct{})
+	writerMayFinish := make(chan struct{})
+	writerFinished := make(chan struct{})
+	go func() {
+		defer close(writerFinished)
+		_ = MutateSessionState(context.Background(), sessionID, func(state *SessionState) error {
+			close(writerStarted)
+			<-writerMayFinish
+			state.StepCount = 1
+			return nil
+		})
+	}()
+	<-writerStarted // writer holds the gate now, mid-mutation
+
+	clearReturned := make(chan struct{})
+	go func() {
+		defer close(clearReturned)
+		_ = s.clearSessionState(context.Background(), sessionID)
+	}()
+
+	// clearSessionState must be blocked waiting for the writer's gate right
+	// now. Before the fix (no locking at all in clearSessionState) it would
+	// return almost immediately here, well within this window, proving the
+	// race is real.
+	select {
+	case <-clearReturned:
+		t.Fatal("clearSessionState returned while a concurrent MutateSessionState was still mid-mutation -- not serialized")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: still blocked on the gate.
+	}
+
+	close(writerMayFinish)
+	<-writerFinished
+	<-clearReturned
+}
+
 func TestShadowStrategy_ListPendingCheckpoints_NoShadowBranch(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -456,20 +456,31 @@ func TestClearSessionState_SerializesAgainstConcurrentMutation(t *testing.T) {
 	writerFinished := make(chan struct{})
 	go func() {
 		defer close(writerFinished)
-		_ = MutateSessionState(context.Background(), sessionID, func(state *SessionState) error {
+		if err := MutateSessionState(context.Background(), sessionID, func(state *SessionState) error {
 			close(writerStarted)
 			<-writerMayFinish
 			state.StepCount = 1
 			return nil
-		})
+		}); err != nil {
+			t.Errorf("MutateSessionState: %v", err)
+		}
 	}()
 	<-writerStarted // writer holds the gate now, mid-mutation
 
+	clearStarted := make(chan struct{})
 	clearReturned := make(chan struct{})
 	go func() {
 		defer close(clearReturned)
-		_ = s.clearSessionState(context.Background(), sessionID)
+		close(clearStarted)
+		if err := s.clearSessionState(context.Background(), sessionID); err != nil {
+			t.Errorf("clearSessionState: %v", err)
+		}
 	}()
+	// Wait until the goroutine is genuinely running before timing anything.
+	// Without this, "clearReturned is not closed" is also satisfied by a
+	// goroutine the scheduler never started, so the assertion below could
+	// pass without the gate doing any work at all.
+	<-clearStarted
 
 	// clearSessionState must be blocked waiting for the writer's gate right
 	// now. Before the fix (no locking at all in clearSessionState) it would

--- a/cmd/entire/cli/strategy/session_lock_notice_test.go
+++ b/cmd/entire/cli/strategy/session_lock_notice_test.go
@@ -1,4 +1,4 @@
-package cli
+package strategy
 
 import (
 	"bytes"
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
@@ -40,19 +39,19 @@ func (b *syncBuffer) Len() int {
 }
 
 // TestClearSessionStateWithProgress_AnnouncesLockWait covers the UX half of
-// gating doctor's clear: the wait is correct (deleting the state file out from
+// gating the clear: the wait is correct (deleting the state file out from
 // under an in-flight write destroys it) but unbounded, and a condensation can
 // hold the lock ~30s, so a silent wait reads as a hang. This drives a real
 // held lock -- a writer parked inside MutateSessionState -- and asserts the
-// notice is printed and the clear still completes once the lock frees.
+// notice is printed while the clear is still blocked.
 func TestClearSessionStateWithProgress_AnnouncesLockWait(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	t.Chdir(dir)
 
 	ctx := context.Background()
-	const sessionID = "doctor-lock-notice"
-	if err := strategy.SaveSessionState(ctx, &strategy.SessionState{
+	const sessionID = "lock-notice-session"
+	if err := SaveSessionState(ctx, &SessionState{
 		SessionID:  sessionID,
 		BaseCommit: "abc123",
 		StartedAt:  time.Now(),
@@ -65,7 +64,7 @@ func TestClearSessionStateWithProgress_AnnouncesLockWait(t *testing.T) {
 	writerDone := make(chan struct{})
 	go func() {
 		defer close(writerDone)
-		if err := strategy.MutateSessionState(ctx, sessionID, func(*strategy.SessionState) error {
+		if err := MutateSessionState(ctx, sessionID, func(*SessionState) error {
 			close(writerHolding)
 			<-writerMayFinish
 			return nil
@@ -73,17 +72,23 @@ func TestClearSessionStateWithProgress_AnnouncesLockWait(t *testing.T) {
 			t.Errorf("MutateSessionState: %v", err)
 		}
 	}()
-	<-writerHolding // the lock is genuinely held now
+	// Bounded: a setup failure should report the writer's own error rather
+	// than hanging to the package timeout with nothing printed.
+	select {
+	case <-writerHolding:
+	case <-time.After(10 * time.Second):
+		t.Fatal("writer never acquired the gate; setup failed")
+	}
 
 	var errBuf syncBuffer
 	cleared := make(chan error, 1)
 	go func() {
-		cleared <- clearSessionStateWithProgress(ctx, sessionID, &errBuf, 20*time.Millisecond)
+		cleared <- ClearSessionStateWithProgress(ctx, sessionID, &errBuf, 20*time.Millisecond)
 	}()
 
 	// The notice must appear while the clear is still blocked, which is the
 	// whole point -- it is useless if it only prints after the wait ends.
-	deadline := time.After(2 * time.Second)
+	deadline := time.After(5 * time.Second)
 	for !strings.Contains(errBuf.String(), "release its state lock") {
 		select {
 		case <-deadline:
@@ -106,15 +111,15 @@ func TestClearSessionStateWithProgress_AnnouncesLockWait(t *testing.T) {
 }
 
 // The uncontended case must stay silent: an unconditional notice would fire on
-// every doctor run and train the user to ignore it.
+// every run and train the user to ignore it.
 func TestClearSessionStateWithProgress_SilentWhenUncontended(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	t.Chdir(dir)
 
 	ctx := context.Background()
-	const sessionID = "doctor-lock-quiet"
-	if err := strategy.SaveSessionState(ctx, &strategy.SessionState{
+	const sessionID = "lock-quiet-session"
+	if err := SaveSessionState(ctx, &SessionState{
 		SessionID:  sessionID,
 		BaseCommit: "abc123",
 		StartedAt:  time.Now(),
@@ -123,10 +128,59 @@ func TestClearSessionStateWithProgress_SilentWhenUncontended(t *testing.T) {
 	}
 
 	var errBuf syncBuffer
-	if err := clearSessionStateWithProgress(ctx, sessionID, &errBuf, time.Second); err != nil {
+	if err := ClearSessionStateWithProgress(ctx, sessionID, &errBuf, time.Second); err != nil {
 		t.Fatalf("clear: %v", err)
 	}
 	if errBuf.Len() != 0 {
 		t.Errorf("expected no output when the lock is free, got %q", errBuf.String())
+	}
+}
+
+// A reentrant clear must be refused, not silently undone. Holding the gate
+// makes the delete safe but not effective: the frame's save writes the state
+// straight back, so before this was refused the caller got a nil error and a
+// live state file -- doctor would report a session discarded and it would
+// reappear.
+func TestClearSessionState_RefusesReentrantClear(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	ctx := context.Background()
+	const sessionID = "reentrant-clear"
+	if err := SaveSessionState(ctx, &SessionState{
+		SessionID:  sessionID,
+		BaseCommit: "abc123",
+		StartedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	var clearErr error
+	if err := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+		clearErr = ClearSessionState(ctx, sessionID)
+		state.StepCount = 42
+		return nil
+	}); err != nil {
+		t.Fatalf("MutateSessionState: %v", err)
+	}
+
+	if clearErr == nil {
+		t.Fatal("a reentrant clear must return an error, not a nil that the frame's save then undoes")
+	}
+	if !strings.Contains(clearErr.Error(), "clearSessionStateLocked") {
+		t.Errorf("the error should name the correct alternative, got: %v", clearErr)
+	}
+
+	// And the state must still be there, consistent with the refusal.
+	after, err := LoadSessionState(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadSessionState: %v", err)
+	}
+	if after == nil {
+		t.Fatal("state should survive a refused clear")
+	}
+	if after.StepCount != 42 {
+		t.Errorf("the frame's own write should have landed; StepCount = %d, want 42", after.StepCount)
 	}
 }

--- a/cmd/entire/cli/strategy/session_lock_notice_test.go
+++ b/cmd/entire/cli/strategy/session_lock_notice_test.go
@@ -184,3 +184,58 @@ func TestClearSessionState_RefusesReentrantClear(t *testing.T) {
 		t.Errorf("the frame's own write should have landed; StepCount = %d, want 42", after.StepCount)
 	}
 }
+
+// TestClearSessionStateWithProgress_RefusesReentrantClear is the regression
+// for a deadlock the progress wrapper introduced: it ran the clear on a fresh
+// goroutine, and acquireSessionGate keys reentrancy on goroutine ID, so on the
+// child the gate looked unheld. The refusal in ClearSessionState never fired
+// and the child blocked in flock.AcquireIn on the flock its own parent held,
+// while the parent waited for the child -- a permanent hang, printed after the
+// lock-wait notice so it named a condensation that did not exist.
+//
+// This matters more than the bare ClearSessionState case: the doc comment
+// points user-facing commands at THIS entry point, so the guard has to hold
+// here or it protects only the path nobody is told to use.
+func TestClearSessionStateWithProgress_RefusesReentrantClear(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	ctx := context.Background()
+	const sessionID = "reentrant-progress-clear"
+	if err := SaveSessionState(ctx, &SessionState{
+		SessionID:  sessionID,
+		BaseCommit: "abc123",
+		StartedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	var errBuf syncBuffer
+	returned := make(chan error, 1)
+	go func() {
+		if err := MutateSessionState(ctx, sessionID, func(*SessionState) error {
+			returned <- ClearSessionStateWithProgress(ctx, sessionID, &errBuf, 20*time.Millisecond)
+			return nil
+		}); err != nil {
+			t.Errorf("MutateSessionState: %v", err)
+		}
+	}()
+
+	select {
+	case err := <-returned:
+		if err == nil {
+			t.Fatal("a reentrant clear must be refused, not silently undone by the frame's save")
+		}
+		if !strings.Contains(err.Error(), "clearSessionStateLocked") {
+			t.Errorf("the error should name the correct alternative, got: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("deadlock: the clear ran on a goroutine that did not hold the gate, so it blocked on its own parent's flock")
+	}
+
+	// And it must not have claimed someone else held the lock.
+	if strings.Contains(errBuf.String(), "release its state lock") {
+		t.Errorf("a reentrant refusal must not print the lock-wait notice; got %q", errBuf.String())
+	}
+}

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -690,6 +690,16 @@ func MutateSessionStateOnSaved(ctx context.Context, sessionID string, fn func(*S
 // acquireSessionGate takes the per-process gate (in-memory) and, on the
 // outermost call, the cross-process flock. Returns isOuter=true on the
 // outermost call so MutateSessionState knows whether to load/save.
+//
+// Reentrancy is keyed on the GOROUTINE, via goroutineID(): the gate counts as
+// held only for the goroutine that took it. That makes ownership implicit, so
+// moving a gated operation onto another goroutine silently defeats every
+// reentrancy check built on isOuter -- the new goroutine sees an unheld gate,
+// takes the isOuter path, and blocks in flock.AcquireIn on the flock its own
+// parent holds. If the parent is waiting for it, that is a permanent deadlock
+// rather than a slow path. withLockWaitNotice shipped exactly that bug and is
+// why it now runs its callback on the caller's goroutine and gives the timer
+// the new one. Wrap the WAITING, never the locking.
 func acquireSessionGate(ctx context.Context, sessionID string) (gate *sessionGate, isOuter bool, release func(), err error) {
 	val, _ := sessionMutationGate.LoadOrStore(sessionID, &sessionGate{})
 	gate, ok := val.(*sessionGate)

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -912,20 +912,37 @@ const SessionLockNoticeDelay = time.Second
 // It lives here, next to the lock, rather than at one command's call site, so
 // every user-facing clear gets it: `entire doctor`, `entire reset`, and
 // `entire reset <session>`.
+//
+// doClear runs on the CALLER's goroutine and the timer gets the new one --
+// never the other way around. acquireSessionGate keys reentrancy on goroutine
+// ID, so running doClear on a child would make the gate look unheld: the
+// reentrancy refusal in ClearSessionState would not fire, and the child would
+// instead block in flock.AcquireIn on the flock its own parent holds while the
+// parent blocked waiting for the child. That deadlocked after printing the
+// notice below, pointing the user at a condensation that does not exist.
 func withLockWaitNotice(sessionID string, errW io.Writer, notifyAfter time.Duration, doClear func() error) error {
-	done := make(chan error, 1)
-	go func() { done <- doClear() }()
+	stop := make(chan struct{})
+	noticed := make(chan struct{})
+	go func() {
+		defer close(noticed)
+		select {
+		case <-stop:
+		case <-time.After(notifyAfter):
+			if errW != nil {
+				fmt.Fprintf(errW, "Waiting for session %s to release its state lock "+
+					"(a checkpoint condensation can hold it for ~30s; Ctrl-C twice to force quit)...\n", sessionID)
+			}
+		}
+	}()
 
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(notifyAfter):
-	}
-	if errW != nil {
-		fmt.Fprintf(errW, "Waiting for session %s to release its state lock "+
-			"(a checkpoint condensation can hold it for ~30s; Ctrl-C twice to force quit)...\n", sessionID)
-	}
-	return <-done
+	err := doClear()
+
+	// Stop the timer and wait for it to finish before returning, so the
+	// notice can never land on errW after the caller has moved on to its own
+	// output (Reset prints a per-session line straight after this returns).
+	close(stop)
+	<-noticed
+	return err
 }
 
 // ClearSessionStateWithProgress is ClearSessionState with the shared lock-wait

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -889,11 +889,31 @@ func stateLockInCommonDir(commonDir, sessionID string) (stateLock, error) {
 }
 
 // ClearSessionState removes the session state file for the given session ID.
+//
+// It takes sessionID's gate first, for the same reason
+// (*ManualCommitStrategy).clearSessionState does: this deletes the file that
+// every other mutation of this state writes under MutateSessionState's
+// per-session lock, so an unlocked delete landing mid-mutation destroys the
+// write that was in flight, with nothing surfacing the loss. This is the
+// implementation `entire doctor` reaches (doctor.go's discardSession) -- a
+// separate one from the strategy method, and the command most likely to be
+// run while other sessions are live -- so gating the strategy method alone
+// left the race open exactly where it mattered most.
+//
+// The acquire is reentrancy-tolerant on purpose, unlike the strategy method's:
+// this is exported, and a caller already inside a MutateSessionState frame for
+// the same session already holds the gate, so proceeding is correct there too.
 func ClearSessionState(ctx context.Context, sessionID string) error {
 	// Validate session ID to prevent path traversal
 	if err := validation.ValidateSessionID(sessionID); err != nil {
 		return fmt.Errorf("invalid session ID: %w", err)
 	}
+
+	_, _, release, err := acquireSessionGate(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	defer release()
 
 	root, err := openSessionStateRootForRead(ctx)
 	if err != nil {

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -888,6 +889,54 @@ func stateLockInCommonDir(commonDir, sessionID string) (stateLock, error) {
 	}, nil
 }
 
+// SessionLockNoticeDelay is how long a user-facing clear waits before telling
+// the user it is blocked on a session's state lock. Short enough that a real
+// stall is announced promptly, long enough that the uncontended case -- the
+// common one -- stays silent.
+const SessionLockNoticeDelay = time.Second
+
+// withLockWaitNotice runs doClear, announcing on errW if it has not returned
+// within notifyAfter.
+//
+// The wait itself is deliberate and must not be shortened: the clear takes the
+// same gate every mutation of that state uses, because deleting the file out
+// from under an in-flight write destroys it. But the acquire is unbounded --
+// only the TurnStart hook opts into a deadline, via WithSessionLockWait -- and
+// a checkpoint condensation holds that lock while it rewrites a multi-MB
+// transcript, observed at ~30s on large sessions (see the note on the lock
+// above). The commands that reach this are interactive and are run precisely
+// when other sessions are live, so without a notice a correct 30-second wait
+// is indistinguishable from a hang, and the natural response to a hang is to
+// kill it -- which is how you get a half-finished discard.
+//
+// It lives here, next to the lock, rather than at one command's call site, so
+// every user-facing clear gets it: `entire doctor`, `entire reset`, and
+// `entire reset <session>`.
+func withLockWaitNotice(sessionID string, errW io.Writer, notifyAfter time.Duration, doClear func() error) error {
+	done := make(chan error, 1)
+	go func() { done <- doClear() }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(notifyAfter):
+	}
+	if errW != nil {
+		fmt.Fprintf(errW, "Waiting for session %s to release its state lock "+
+			"(a checkpoint condensation can hold it for ~30s; Ctrl-C twice to force quit)...\n", sessionID)
+	}
+	return <-done
+}
+
+// ClearSessionStateWithProgress is ClearSessionState with the shared lock-wait
+// notice on errW. This is what user-facing commands should call; the bare
+// ClearSessionState stays for callers with nowhere to print.
+func ClearSessionStateWithProgress(ctx context.Context, sessionID string, errW io.Writer, notifyAfter time.Duration) error {
+	return withLockWaitNotice(sessionID, errW, notifyAfter, func() error {
+		return ClearSessionState(ctx, sessionID)
+	})
+}
+
 // ClearSessionState removes the session state file for the given session ID.
 //
 // It takes sessionID's gate first, for the same reason
@@ -900,21 +949,33 @@ func stateLockInCommonDir(commonDir, sessionID string) (stateLock, error) {
 // run while other sessions are live -- so gating the strategy method alone
 // left the race open exactly where it mattered most.
 //
-// The acquire is reentrancy-tolerant on purpose, unlike the strategy method's:
-// this is exported, and a caller already inside a MutateSessionState frame for
-// the same session already holds the gate, so proceeding is correct there too.
+// Calling it from inside a MutateSessionState frame for the same session is
+// refused rather than tolerated. Holding the gate makes the delete safe, not
+// effective: when the frame's closure returns, MutateSessionState writes the
+// state back out, so the file is resurrected and the caller still sees a nil
+// error -- `entire doctor` would report a session discarded and the session
+// would reappear. Clear from inside an active closure with
+// (*ManualCommitStrategy).clearSessionStateLocked instead, and return
+// ErrMutationSkip so the frame does not save (see CondenseSessionByID's
+// clear path, the one caller that legitimately does this).
+//
+// The wait is not cancellable. With no WithSessionLockWait deadline on ctx,
+// acquireSessionGate falls through to the ctx-free flock.AcquireIn, so ctx
+// cancellation -- a first Ctrl-C included -- does not abort a blocked
+// acquire; only the force-quit path in main.go escapes. ctx is still honored
+// for everything else here. Adding a timeout via ctx alone would silently do
+// nothing; it would have to go through WithSessionLockWait.
 func ClearSessionState(ctx context.Context, sessionID string) error {
 	// Validate session ID to prevent path traversal
 	if err := validation.ValidateSessionID(sessionID); err != nil {
 		return fmt.Errorf("invalid session ID: %w", err)
 	}
 
-	_, _, release, err := acquireSessionGate(ctx, sessionID)
-	if err != nil {
-		return err
-	}
-	defer release()
-
+	// Resolve the state directory BEFORE taking the gate. Acquiring creates a
+	// per-session lock file that is deliberately never unlinked (see the note
+	// at the end of this function), so doing it first left a permanent lock
+	// behind for a session that had no state to clear, and turned a read-only
+	// git dir from a silent nil into a per-session failure.
 	root, err := openSessionStateRootForRead(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to open session state directory for cleanup: %w", err)
@@ -923,6 +984,17 @@ func ClearSessionState(ctx context.Context, sessionID string) error {
 		return nil // no state directory => nothing to clear
 	}
 	defer root.Close()
+
+	_, isOuter, release, err := acquireSessionGate(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	defer release()
+	if !isOuter {
+		return fmt.Errorf("ClearSessionState: session %s is being mutated on this goroutine; "+
+			"clearing here would be undone when that mutation saves -- use clearSessionStateLocked "+
+			"inside the closure and return ErrMutationSkip", sessionID)
+	}
 
 	// Remove all files for this session (state .json, .model hint, any future
 	// hint files). Match by literal prefix rather than filepath.Glob: the

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -1058,3 +1058,65 @@ func TestMutateSessionState_UnboundedByDefault(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, holdFor,
 		"unbounded acquire should block until the holder releases, not time out")
 }
+
+// TestClearSessionState_PackageLevel_SerializesAgainstConcurrentMutation
+// covers the implementation `entire doctor` actually reaches
+// (doctor.go's discardSession -> strategy.ClearSessionState), which is a
+// different function from (*ManualCommitStrategy).clearSessionState and was
+// left ungated when that one was hardened -- so the race stayed open on the
+// command most likely to run while other sessions are live. Same shape as
+// the strategy-method test: a writer holds the real gate mid-mutation, and
+// the clear must block until it releases.
+func TestClearSessionState_PackageLevel_SerializesAgainstConcurrentMutation(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	ctx := context.Background()
+	const sessionID = "pkg-clear-race-session"
+	if err := SaveSessionState(ctx, &SessionState{
+		SessionID:  sessionID,
+		BaseCommit: "abc123",
+		StartedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	writerStarted := make(chan struct{})
+	writerMayFinish := make(chan struct{})
+	writerFinished := make(chan struct{})
+	go func() {
+		defer close(writerFinished)
+		if err := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+			close(writerStarted)
+			<-writerMayFinish
+			state.StepCount = 1
+			return nil
+		}); err != nil {
+			t.Errorf("MutateSessionState: %v", err)
+		}
+	}()
+	<-writerStarted // writer holds the gate now, mid-mutation
+
+	clearStarted := make(chan struct{})
+	clearReturned := make(chan struct{})
+	go func() {
+		defer close(clearReturned)
+		close(clearStarted)
+		if err := ClearSessionState(ctx, sessionID); err != nil {
+			t.Errorf("ClearSessionState: %v", err)
+		}
+	}()
+	<-clearStarted
+
+	select {
+	case <-clearReturned:
+		t.Fatal("package-level ClearSessionState returned while a concurrent MutateSessionState was still mid-mutation -- not serialized (this is doctor's path)")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: still blocked on the gate.
+	}
+
+	close(writerMayFinish)
+	<-writerFinished
+	<-clearReturned
+}

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -1039,12 +1039,19 @@ func TestMutateSessionState_UnboundedByDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	const holdFor = 400 * time.Millisecond
+	// start is captured BEFORE the holder goroutine launches, so it is always
+	// at or before the moment the sleep begins. Capturing it after the `go`
+	// statement made the assertion below depend on this goroutine reaching
+	// time.Now() before the new one reaches time.Sleep -- an ordering nothing
+	// guarantees. When it lost, the measured elapsed fell just under holdFor
+	// and the test failed with no real defect (seen on CI at 398.881573ms
+	// against a 400ms bound).
+	start := time.Now()
 	go func() {
 		time.Sleep(holdFor)
 		release()
 	}()
 
-	start := time.Now()
 	ran := false
 	// No WithSessionLockWait: must wait for the holder rather than time out.
 	err = MutateSessionState(ctx, sessionID, func(state *SessionState) error {

--- a/internal/entireclient/httpclient/useragent_test.go
+++ b/internal/entireclient/httpclient/useragent_test.go
@@ -6,6 +6,18 @@ import (
 	"testing"
 )
 
+// These tests each run t.Parallel() and each stand up their own httptest
+// server, so their UserAgentTransport must wrap that server's OWN transport
+// (srv.Client().Transport) rather than the process-global
+// http.DefaultTransport. Sharing the global means sharing its idle-connection
+// pool: one test's t.Cleanup(srv.Close) then tears down a pooled connection
+// another test is mid-request on, which surfaces as
+//
+//	Do: ... transport connection broken: http: CloseIdleConnections called
+//
+// on a test that did nothing wrong. That flake was observed twice on CI in
+// two days, in both cases on a PR touching nothing in this package.
+
 func TestUserAgentTransport_SetsHeader(t *testing.T) {
 	t.Parallel()
 
@@ -18,7 +30,7 @@ func TestUserAgentTransport_SetsHeader(t *testing.T) {
 
 	client := &http.Client{
 		Transport: &UserAgentTransport{
-			Next: http.DefaultTransport,
+			Next: srv.Client().Transport,
 			UA:   "test-binary/1.2.3",
 		},
 	}
@@ -49,7 +61,7 @@ func TestUserAgentTransport_OverwritesCallerHeader(t *testing.T) {
 
 	client := &http.Client{
 		Transport: &UserAgentTransport{
-			Next: http.DefaultTransport,
+			Next: srv.Client().Transport,
 			UA:   "wrapper-set",
 		},
 	}
@@ -79,7 +91,7 @@ func TestUserAgentTransport_DoesNotMutateCallerRequest(t *testing.T) {
 
 	client := &http.Client{
 		Transport: &UserAgentTransport{
-			Next: http.DefaultTransport,
+			Next: srv.Client().Transport,
 			UA:   "wrapper-set",
 		},
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1214
<!-- entire-trail-link-end -->

## Summary
- `clearSessionState` (and its exported wrapper `ClearSessionState`, used by `entire doctor`) deleted a session's state file with no lock at all, while every other mutation of the same file goes through `MutateSessionState`'s per-session gate.
- A concurrent, properly-locked write (e.g. a PostToolUse hook for the same session) landing in the gap between a caller's "safe to clear" decision and the actual delete was silently destroyed — the file the write just produced gets deleted out from under it, with nothing surfacing the loss.
- `initializeSession` documents and fixes the identical hazard class elsewhere in this file ("take the gate, then re-check under lock"); this closes the same gap for the clear path.
- `clearSessionState` now acquires `sessionID`'s gate before clearing.
- `CondenseSessionByID`'s `clearAfter` path — the concrete, routine-traffic instance of this race (no shadow branch, condensation decides to clear state only) — now clears via a new `clearSessionStateLocked` helper from inside its own already-locked mutation closure, so the decision and the delete are atomic with respect to other writers rather than racing across an unlocked gap.
- `Reset`/`ResetSession`/doctor's `ClearSessionState` all call the same hardened `clearSessionState`, so they're covered with no additional changes.

## Verification
- Real-goroutine concurrency reproduction (`TestClearSessionState_SerializesAgainstConcurrentMutation`): a writer holds the real gate via `MutateSessionState` and blocks mid-mutation; `clearSessionState` must block until it releases, not run concurrently.
- **Mutation-verified**: temporarily reverted `clearSessionState` to skip gate acquisition (matching the exact pre-fix code path), confirmed the test genuinely fails (clear returns immediately while the writer is still mid-flight), then restored the fix and confirmed the full `strategy` package test suite passes with no regressions.
- `go build` passes. Full `mise run check` deferred to a follow-up pass to keep local CI load down.

## Test plan
- [x] New concurrency reproduction test added and passing
- [x] Verified test fails without the fix (mutation check)
- [x] Full `strategy` package test suite green, no regressions
- [ ] Full `mise run check` (deferred, will run before merge)