### PR TITLE
fix: warn on every entire investigate run that agent sandboxing is off

### DIFF
--- a/cmd/entire/cli/investigate/cmd.go
+++ b/cmd/entire/cli/investigate/cmd.go
@@ -373,6 +373,27 @@ func runInvestigate(ctx context.Context, cmd *cobra.Command, args []string, f ru
 	return runFresh(ctx, cmd, args, f, deps)
 }
 
+// sandboxBypassNotice is printed once per investigate run (fresh or
+// resumed) that reaches agent spawn without going through the stronger,
+// blocking confirmUntrustedIssueSeed gate. Every agent this package spawns
+// runs with sandbox and approval checks unconditionally disabled --
+// Claude Code's --permission-mode bypassPermissions and Codex's
+// --dangerously-bypass-approvals-and-sandbox are not conditioned on
+// --issue-link or any other flag. Only the launched agent's own prompt
+// text discourages destructive actions; nothing else restricts what it
+// can execute, including reading and acting on content in the repository
+// itself (a cloned, not-yet-reviewed repo is investigate's documented use
+// case). This is non-blocking by design -- unlike confirmUntrustedIssueSeed,
+// which gates the highest-risk case (remote-attacker-controlled seed
+// content) behind an interactive confirmation or an explicit
+// --allow-untrusted-seed opt-in for automation, this banner exists so the
+// operator is not left with zero signal about the ordinary case, without
+// adding a confirmation prompt to entire investigate's routine use.
+const sandboxBypassNotice = "Note: entire investigate spawns AI agents with sandbox and approval " +
+	"checks disabled (Claude Code: --permission-mode bypassPermissions; " +
+	"Codex: --dangerously-bypass-approvals-and-sandbox). Only the agent's " +
+	"own prompt restricts destructive actions."
+
 // errUntrustedSeedRefused is returned when a non-interactive --issue-link run
 // is blocked because --allow-untrusted-seed was not passed. Surfaced as a
 // SilentError by the caller (a custom message is already printed to stderr).
@@ -504,6 +525,7 @@ func runContinue(ctx context.Context, cmd *cobra.Command, f runFlags, deps Deps)
 		fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
 		return wrapSilent(silentErr, err)
 	}
+	fmt.Fprintln(cmd.ErrOrStderr(), sandboxBypassNotice)
 
 	// Resume reuses the originally selected agents — the multipicker does
 	// NOT reopen on --continue; persisted state already captures intent.
@@ -704,6 +726,8 @@ func runFresh(ctx context.Context, cmd *cobra.Command, args []string, f runFlags
 		if !ok {
 			return nil
 		}
+	} else {
+		fmt.Fprintln(cmd.ErrOrStderr(), sandboxBypassNotice)
 	}
 
 	commonDir, err := session.GetGitCommonDir(ctx)

--- a/cmd/entire/cli/investigate/cmd_test.go
+++ b/cmd/entire/cli/investigate/cmd_test.go
@@ -297,6 +297,46 @@ func TestNewCommand_FreshRunWritesManifest(t *testing.T) {
 	}
 }
 
+// TestNewCommand_FreshRunWarnsSandboxBypass verifies that an ordinary
+// investigate run (no --issue-link, so confirmUntrustedIssueSeed's own
+// stronger warning never fires) still tells the operator that the agents
+// it is about to spawn run with sandbox/approval checks disabled. Before
+// this fix, that fact was silent for every run except the --issue-link
+// case -- a plain `entire investigate "..."` on a freshly cloned,
+// not-yet-reviewed repo gave no signal that the spawned agent could
+// execute arbitrary commands unsandboxed.
+func TestNewCommand_FreshRunWarnsSandboxBypass(t *testing.T) {
+	setupInvestigateRepo(t)
+
+	if err := saveInvestigateSettings(&settings.InvestigateConfig{
+		Agents:   []string{"stub-agent"},
+		MaxTurns: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, runFn := captureLoopRun()
+	deps := newTestDeps(t, []types.AgentName{"stub-agent"}, []string{"stub-agent"})
+	deps.LoopRun = runFn
+
+	cmd := investigate.NewCommand(deps)
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errBuf)
+	cmd.SetArgs([]string{seedArg(t, "test investigation")})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	if !strings.Contains(errBuf.String(), "sandbox and approval") {
+		t.Errorf("expected a sandbox-bypass notice on stderr for a plain (non --issue-link) run, got:\n%s", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "bypassPermissions") || !strings.Contains(errBuf.String(), "dangerously-bypass-approvals-and-sandbox") {
+		t.Errorf("expected the notice to name both agents' actual bypass flags, got:\n%s", errBuf.String())
+	}
+}
+
 // TestNewCommand_FreshRunPausedKeepsPerRunDir verifies that resumable
 // outcomes (Paused/Cancelled) leave the per-run directory in place so
 // `entire investigate --continue` has files to read, and the manifest


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1215
<!-- entire-trail-link-end -->

## Summary
- Every agent `entire investigate` spawns runs with sandbox/approval checks unconditionally disabled — Claude Code's `--permission-mode bypassPermissions` and Codex's `--dangerously-bypass-approvals-and-sandbox` are not conditioned on any flag.
- The only existing warning (`confirmUntrustedIssueSeed`) covers just the `--issue-link` case, framed specifically around external GitHub content. A plain `entire investigate "..."` run — including on a freshly cloned, not-yet-reviewed repo, the tool's own documented use case — gave the operator zero signal that the spawned agent could execute arbitrary commands unsandboxed, restrained only by its own prompt text.
- Adds a non-blocking informational notice, printed once per run (fresh, without an issue-link seed, and on `--continue`), naming both bypass flags concretely.

## Why not a confirmation gate like `--issue-link`'s
That mechanism exists for the genuinely higher-risk case (remote-attacker-controlled content driving an unsandboxed agent). Turning `entire investigate`'s ordinary use into a prompted confirmation would just train operators to reflexively accept it — this closes the "totally silent" gap without adding friction to the tool's core function. Happy to revisit the UX call if a maintainer feels this should gate harder.

## Verification
- Real command-execution test (`TestNewCommand_FreshRunWarnsSandboxBypass`, via `investigate.NewCommand` + `cmd.Execute()`) asserting the notice appears on stderr for a plain run with no `--issue-link`.
- **Mutation-verified**: temporarily removed the notice call, confirmed the test fails (stderr genuinely empty, matching the exact pre-fix silence), then restored the fix and confirmed the full `investigate` package test suite passes with no regressions.
- `go build` passes. Full `mise run check` deferred to a follow-up pass to keep local CI load down.

## Test plan
- [x] New reproduction test added and passing
- [x] Verified test fails without the fix (mutation check)
- [x] Full `investigate` package test suite green, no regressions
- [ ] Full `mise run check` (deferred, will run before merge)