### PR TITLE
fix: don't let a tool call's own payload spoof the image-object redaction skip

### DIFF
--- a/redact/redact.go
+++ b/redact/redact.go
@@ -980,26 +980,49 @@ func isSingleJSONValue(dec *json.Decoder) bool {
 // string replacements via the supplied per-leaf redactor. JSONLContent
 // passes String; the OPF-enabled flow passes a closure that combines the
 // regex layers with cached batched OPF spans.
+//
+// The walk also tracks toolPayload: whether the current position is inside
+// a tool call's own schema-controlled data (a "tool_use" block's "input",
+// or a "tool_result" block's "content"/"output"). Field names and shapes in
+// there come from whatever tool declared them — for an MCP tool, that's a
+// third party, not Entire's own transcript writer — so shouldSkipJSONLObject
+// (a whole-subtree skip keyed on a bare "type" value) is honored only
+// outside toolPayload: a tool argument or result deliberately shaped as
+// {"type":"base64", ...} would otherwise hide an arbitrarily large sibling
+// secret behind a single spoofed tag. Genuine externalized image assets
+// (pasted screenshots) are message content blocks, not tool call
+// input/output, so this does not affect that already-documented,
+// intentional skip (see docs/security-and-privacy.md).
+//
+// shouldSkipJSONLField's per-leaf skips (id/signature suffixes, path-family
+// exact matches) are deliberately NOT gated on toolPayload here: several of
+// them are load-bearing for real built-in tool calls (e.g. Read/Grep's own
+// "file_path"/"path" arguments live inside tool_use.input), and narrowing
+// them without full visibility into every supported agent's wire format
+// risks reintroducing the false positives they exist to avoid. Scoping
+// those more precisely is tracked as follow-up work.
 func collectJSONLReplacements(v any, redactor func(string) string) []jsonReplacement {
 	seen := make(map[string]bool)
 	var repls []jsonReplacement
-	var walk func(key string, credentialContext bool, v any)
-	walk = func(key string, credentialContext bool, v any) {
+	var walk func(key string, credentialContext, toolPayload bool, v any)
+	walk = func(key string, credentialContext, toolPayload bool, v any) {
 		switch val := v.(type) {
 		case map[string]any:
-			if shouldSkipJSONLObject(val) {
+			if !toolPayload && shouldSkipJSONLObject(val) {
 				return
 			}
 			childCredentialContext := credentialContext || isCredentialJSONObject(val)
+			blockType, _ := val["type"].(string)
 			for k, child := range val {
 				if shouldSkipJSONLField(k) {
 					continue
 				}
-				walk(k, childCredentialContext, child)
+				childToolPayload := toolPayload || isToolPayloadField(blockType, k)
+				walk(k, childCredentialContext, childToolPayload, child)
 			}
 		case []any:
 			for _, child := range val {
-				walk("", credentialContext, child)
+				walk("", credentialContext, toolPayload, child)
 			}
 		case string:
 			redacted := redactor(val)
@@ -1015,8 +1038,25 @@ func collectJSONLReplacements(v any, redactor func(string) string) []jsonReplace
 			}
 		}
 	}
-	walk("", false, v)
+	walk("", false, false, v)
 	return repls
+}
+
+// isToolPayloadField reports whether key, found on an object whose own
+// "type" field is blockType, is the field that carries a tool call's
+// schema-controlled data: "input" on a "tool_use" block, or "content"/
+// "output" on a "tool_result" block. Once true for an ancestor, the walk
+// keeps toolPayload true for every descendant (a tool's own nested
+// structures are still that tool's, not Entire's).
+func isToolPayloadField(blockType, key string) bool {
+	switch blockType {
+	case "tool_use":
+		return key == "input"
+	case "tool_result":
+		return key == "content" || key == "output"
+	default:
+		return false
+	}
 }
 
 // shouldSkipJSONLField returns true if a JSON key should be excluded from scanning/redaction.

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -1289,6 +1289,56 @@ func TestShouldSkipJSONLObject_RedactionBehavior(t *testing.T) {
 	}
 }
 
+// TestCollectJSONLReplacements_ToolPayloadCannotSpoofImageSkip is a genuine
+// reproduction of the scanner-evasion technique this fix closes: an MCP
+// tool's own schema (which is not Entire's transcript writer, and may be
+// malicious or compromised) can name its call's input/output shape however
+// it likes. Before this fix, wrapping a real secret in {"type":"base64",
+// ...} anywhere in the tree -- including inside a tool_use block's own
+// "input" -- hid it from every scanning layer via shouldSkipJSONLObject's
+// unscoped, whole-subtree skip. This asserts the secret IS now caught when
+// it's inside a tool call's own payload, while the top-level, genuine
+// externalized-image case (TestShouldSkipJSONLObject_RedactionBehavior
+// above) is untouched -- real image assets are message content blocks, not
+// tool call input/output, so that documented, intentional skip still
+// applies exactly where it did before.
+func TestCollectJSONLReplacements_ToolPayloadCannotSpoofImageSkip(t *testing.T) {
+	// A tool_use block whose *own* input wraps a real secret in a spoofed
+	// {"type":"base64", ...} object -- the exact evasion shape a malicious
+	// or compromised MCP tool's schema could produce.
+	toolUse := map[string]any{
+		"type": "tool_use",
+		"id":   "toolu_evasion_test",
+		"name": "some_mcp_tool",
+		"input": map[string]any{
+			"config": map[string]any{
+				"type":    "base64",
+				"payload": highEntropySecret,
+			},
+		},
+	}
+	repls := collectJSONLReplacements(toolUse, String)
+	want := []jsonReplacement{{key: "payload", original: highEntropySecret, redacted: "REDACTED"}}
+	if !slices.Equal(repls, want) {
+		t.Errorf("secret inside a tool_use block's own input must not be hidden by a spoofed type:base64 wrapper; got %q, want %q", repls, want)
+	}
+
+	// Same shape, but inside a tool_result's content -- the other half of
+	// the evasion surface (a malicious tool RESPONSE spoofing the tag).
+	toolResult := map[string]any{
+		"type": "tool_result",
+		"content": map[string]any{
+			"type": "image",
+			"data": highEntropySecret,
+		},
+	}
+	repls2 := collectJSONLReplacements(toolResult, String)
+	want2 := []jsonReplacement{{key: "data", original: highEntropySecret, redacted: "REDACTED"}}
+	if !slices.Equal(repls2, want2) {
+		t.Errorf("secret inside a tool_result block's own content must not be hidden by a spoofed type:image wrapper; got %q, want %q", repls2, want2)
+	}
+}
+
 func TestString_FilePaths(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1216
<!-- entire-trail-link-end -->

## Summary
- `collectJSONLReplacements`'s `shouldSkipJSONLObject` check (skip an entire subtree when an object's `"type"` field starts with `"image"` or equals `"base64"`) applied unconditionally anywhere in a transcript line's JSON tree — including inside a `tool_use` block's own `"input"` or a `tool_result`'s `"content"`/`"output"`, fields whose shape is controlled by whatever tool declared them. For an MCP tool, that's a third party, not Entire's transcript writer.
- A tool call argument or response deliberately shaped as `{"type":"base64", ...}` hid an arbitrarily large sibling secret behind a single spoofed tag, from every scanning layer (regex, entropy), then shipped unredacted to a pushed branch.
- Threads a `toolPayload` flag through the walk, set once the recursion enters a `tool_use` block's `input` or a `tool_result` block's `content`/`output`, sticky for all descendants. `shouldSkipJSONLObject` is honored only outside `toolPayload`. Genuine externalized image assets (pasted screenshots) are message content blocks, not tool call input/output, so the documented, intentional image-asset skip (`docs/security-and-privacy.md`) is unaffected.

## Deliberately scoped — what this does NOT touch
`shouldSkipJSONLField`'s id/signature-suffix and path-family skips are **not** touched here. Several are load-bearing for real built-in tool calls (Read/Grep's own `file_path`/`path` arguments live inside `tool_use.input`), and narrowing them without full visibility into every supported agent's wire format (Claude Code, Codex, Copilot CLI, Gemini, Factory Droid, Pi each have their own shape) risks reintroducing the false positives they exist to prevent. I verified this against real fixture data (`cmd/entire/cli/transcript/compact/testdata/*.jsonl`) and confirmed e.g. Copilot's own hook payload legitimately nests `sessionId`/`cwd` inside an `input` object unrelated to tool calls. Flagging this as follow-up rather than guessing at a broader fix under time pressure.

## Verification
- Genuine reproduction (`TestCollectJSONLReplacements_ToolPayloadCannotSpoofImageSkip`): a real secret wrapped in a spoofed `type:base64`/`type:image` object inside both a `tool_use.input` and a `tool_result.content`, asserting it is now caught.
- **Mutation-verified**: temporarily reverted the `toolPayload` gate, confirmed the test fails (both evasion shapes reproduce exactly as described, secret silently unredacted), then restored the fix.
- Full `redact` package test suite passes with no changes to existing behavior — including `TestShouldSkipJSONLObject_RedactionBehavior` (the genuine image-skip case) and `TestShouldSkipJSONLField` (the field-name skip cases), both unmodified and still green.
- `go build ./...` passes across the whole module. Full `mise run check` deferred to a follow-up pass to keep local CI load down.

## Test plan
- [x] New reproduction test added and passing
- [x] Verified test fails without the fix (mutation check, both evasion shapes reproduced)
- [x] Full `redact` package test suite green, no regressions to legitimate skip behavior
- [ ] Full `mise run check` (deferred, will run before merge)