### PR TITLE
Apply the OPF gate to the queued-checkpoint-ref push

### DIFF
--- a/cmd/entire/cli/doctor_migrate.go
+++ b/cmd/entire/cli/doctor_migrate.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
+	git "github.com/go-git/go-git/v6"
 	"github.com/spf13/cobra"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
@@ -35,13 +37,6 @@ New refs are queued for push. Run interactively, it asks whether to push them
 now; non-interactively it never pushes — the refs stay queued and flush on the
 next push once the git-refs store is the configured primary.`,
 		Args: cobra.NoArgs,
-		// Doctor configures redaction in its own PreRunE, which cobra does not
-		// inherit, so this subcommand must do it too: the OPF gate on the push
-		// below reads a process-global flag, and an unconfigured one reads as
-		// "OPF off" and waves un-OPF'd checkpoint content through.
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return strategy.EnsureRedactionConfigured(cmd.Context())
-		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			out := cmd.OutOrStdout()
@@ -104,39 +99,59 @@ next push once the git-refs store is the configured primary.`,
 				return nil
 			}
 
-			pushed, pushDisabled, err := strategy.PushQueuedCheckpointRefs(ctx, repo, pushRemote)
-			if err != nil {
-				if errors.Is(err, context.Canceled) {
-					return NewSilentError(err)
-				}
-				// Ctrl-C at the OPF prompt is the same gesture as declining the
-				// push prompt above, and lands in the same place: nothing
-				// shipped, refs still queued. confirmDoctorFix reports that as a
-				// clean decline, so this must not report it as a failure.
-				if errors.Is(err, strategy.ErrOPFAbortedByUser) {
-					fmt.Fprintln(out, "OPF cancelled; refs stay queued for the next push.")
-					return nil
-				}
-				return fmt.Errorf("push migrated refs: %w", err)
-			}
-			switch {
-			case pushDisabled:
-				// Confirmed, but checkpoint pushing is disabled in settings, so
-				// nothing went to the remote. The refs stay queued locally.
-				fmt.Fprintln(out, "Checkpoint pushing is disabled in settings; refs stay queued for the next push.")
-			case pushed == 0:
-				// Enabled, but the queue was already empty — e.g. a concurrent
-				// git push flushed the just-migrated refs while we prompted.
-				fmt.Fprintln(out, "No queued refs to push (they may have already been pushed).")
-			default:
-				fmt.Fprintf(out, "Pushed %d checkpoint ref(s).\n", pushed)
-			}
-			return nil
+			return pushMigratedRefs(ctx, out, repo, pushRemote)
 		},
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report what would be migrated without writing refs")
 	cmd.Flags().StringVar(&remote, "remote", "", "Remote to push migrated refs to (default: the checkpoint sync remote)")
 	return cmd
+}
+
+// pushMigratedRefs configures redaction, flushes the queued checkpoint refs and
+// reports the outcome.
+//
+// It owns the redaction step rather than a PreRunE because the OPF gate inside
+// the push reads process-global config that only EnsureRedactionConfigured
+// sets, and an unconfigured one reads as "OPF off" and waves un-OPF'd
+// checkpoint content through. Doing it here rather than up-front keeps the
+// precondition on the one path that has it: --dry-run, an already-primary
+// store, and a run with nothing migrated all return above without ever
+// consulting redaction settings, so they must not fail on them. It also means
+// the guarantee does not depend on where a parent command happens to configure
+// redaction — cobra does not inherit PreRunE, and doctor's lives on its own.
+func pushMigratedRefs(ctx context.Context, out io.Writer, repo *git.Repository, pushRemote string) error {
+	if err := strategy.EnsureRedactionConfigured(ctx); err != nil {
+		return fmt.Errorf("configure redaction before pushing: %w", err)
+	}
+
+	pushed, pushDisabled, err := strategy.PushQueuedCheckpointRefs(ctx, repo, pushRemote)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return NewSilentError(err)
+		}
+		// Ctrl-C at the OPF prompt is the same gesture as declining the push
+		// prompt, and lands in the same place: nothing shipped, refs still
+		// queued. confirmDoctorFix reports that as a clean decline, so this
+		// must not report it as a failure.
+		if errors.Is(err, strategy.ErrOPFAbortedByUser) {
+			fmt.Fprintln(out, "OPF cancelled; refs stay queued for the next push.")
+			return nil
+		}
+		return fmt.Errorf("push migrated refs: %w", err)
+	}
+	switch {
+	case pushDisabled:
+		// Confirmed, but checkpoint pushing is disabled in settings, so nothing
+		// went to the remote. The refs stay queued locally.
+		fmt.Fprintln(out, "Checkpoint pushing is disabled in settings; refs stay queued for the next push.")
+	case pushed == 0:
+		// Enabled, but the queue was already empty — e.g. a concurrent git push
+		// flushed the just-migrated refs while we prompted.
+		fmt.Fprintln(out, "No queued refs to push (they may have already been pushed).")
+	default:
+		fmt.Fprintf(out, "Pushed %d checkpoint ref(s).\n", pushed)
+	}
+	return nil
 }
 
 // resolveMigratePushRemote picks the remote migrated refs push to: the

--- a/cmd/entire/cli/doctor_migrate.go
+++ b/cmd/entire/cli/doctor_migrate.go
@@ -35,6 +35,13 @@ New refs are queued for push. Run interactively, it asks whether to push them
 now; non-interactively it never pushes — the refs stay queued and flush on the
 next push once the git-refs store is the configured primary.`,
 		Args: cobra.NoArgs,
+		// Doctor configures redaction in its own PreRunE, which cobra does not
+		// inherit, so this subcommand must do it too: the OPF gate on the push
+		// below reads a process-global flag, and an unconfigured one reads as
+		// "OPF off" and waves un-OPF'd checkpoint content through.
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return strategy.EnsureRedactionConfigured(cmd.Context())
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			out := cmd.OutOrStdout()
@@ -101,6 +108,14 @@ next push once the git-refs store is the configured primary.`,
 			if err != nil {
 				if errors.Is(err, context.Canceled) {
 					return NewSilentError(err)
+				}
+				// Ctrl-C at the OPF prompt is the same gesture as declining the
+				// push prompt above, and lands in the same place: nothing
+				// shipped, refs still queued. confirmDoctorFix reports that as a
+				// clean decline, so this must not report it as a failure.
+				if errors.Is(err, strategy.ErrOPFAbortedByUser) {
+					fmt.Fprintln(out, "OPF cancelled; refs stay queued for the next push.")
+					return nil
 				}
 				return fmt.Errorf("push migrated refs: %w", err)
 			}

--- a/cmd/entire/cli/doctor_migrate_test.go
+++ b/cmd/entire/cli/doctor_migrate_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	git "github.com/go-git/go-git/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -117,35 +118,79 @@ func TestDoctorMigrateCheckpoints_RefusesWhenRefsPrimary(t *testing.T) {
 		"must refuse to migrate when git-refs is already the primary store")
 }
 
-// A command whose push gates on redact.OPFEnabled() must configure redaction at
-// its own entry point. EnsureRedactionConfigured lives in doctor's PreRunE,
-// which cobra does not inherit, so a subcommand that omits it reads a
-// process-global OPF flag nothing ever set — and its OPF gate passes silently,
-// pushing un-OPF'd checkpoint content.
-func TestDoctorMigrateCheckpoints_ConfiguresRedaction(t *testing.T) {
+// The OPF gate inside the push reads process-global config that only
+// EnsureRedactionConfigured sets, so the push path must configure it before
+// gating — otherwise the gate reads "OPF off" and flushes unscanned content.
+//
+// Asserted on the push path itself rather than through cobra: the guarantee
+// must not depend on whether a parent command configures redaction, since
+// PreRunE is not inherited and doctor's lives on its own.
+func TestPushMigratedRefs_ConfiguresRedactionBeforeGating(t *testing.T) {
+	repo, bareDir := setupMigratePushRepo(t,
+		`{"enabled": true, "redaction": {"openai_privacy_filter": {"enabled": true, "categories": {"private_person": true}}}}`)
+
+	strategy.ResetRedactionConfiguredForTest()
+	t.Cleanup(strategy.ResetRedactionConfiguredForTest)
+	redact.ResetOPFConfigForTest()
+	t.Cleanup(redact.ResetOPFConfigForTest)
+	require.False(t, redact.OPFEnabled(), "precondition: OPF unconfigured before the push")
+
+	var out bytes.Buffer
+	require.NoError(t, pushMigratedRefs(context.Background(), &out, repo, bareDir))
+
+	assert.True(t, redact.OPFEnabled(),
+		"the push must configure redaction, or its OPF gate is a no-op and ships unscanned content")
+}
+
+// Read-only outcomes must not consult redaction settings at all: a repo whose
+// scanner config is invalid still gets an honest --dry-run report. Regression —
+// an unconditional PreRunE ran ahead of these early returns and failed here.
+func TestDoctorMigrateCheckpoints_ReadOnlyPathsIgnoreScannerConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	testutil.InitRepo(t, tmpDir)
 	testutil.WriteFile(t, tmpDir, "f.txt", "init")
 	testutil.GitAdd(t, tmpDir, "f.txt")
 	testutil.GitCommit(t, tmpDir, "init")
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755))
+	// Both scanners off — settings.Load fails with ErrScannerConfig.
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".entire", "settings.json"),
-		[]byte(`{"enabled": true, "redaction": {"openai_privacy_filter": {"enabled": true, "categories": {"private_person": true}}}}`), 0o644))
+		[]byte(`{"enabled": true, "redaction": {"betterleaks": {"enabled": false}, "goredact": {"enabled": false}}}`), 0o644))
 	t.Chdir(tmpDir)
 	paths.ClearWorktreeRootCache()
-
-	strategy.ResetRedactionConfiguredForTest()
-	t.Cleanup(strategy.ResetRedactionConfiguredForTest)
-	redact.ResetOPFConfigForTest()
-	t.Cleanup(redact.ResetOPFConfigForTest)
 
 	cmd := newDoctorMigrateCheckpointsCmd()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--dry-run"})
 	cmd.SetContext(context.Background())
-	require.NoError(t, cmd.Execute())
 
-	assert.True(t, redact.OPFEnabled(),
-		"the OPF gate on this command's push reads this flag; unconfigured it is always false and the gate is a no-op")
+	require.NoError(t, cmd.Execute(), "--dry-run reads nothing redaction-related and must not fail on it")
+	assert.Contains(t, out.String(), "nothing to migrate")
+}
+
+// setupMigratePushRepo builds a repo with the given .entire/settings.json, a
+// bare remote, and one queued checkpoint ref, and returns the open repo plus
+// the remote path.
+func setupMigratePushRepo(t *testing.T, settingsJSON string) (*git.Repository, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, ".entire", "settings.json"), []byte(settingsJSON), 0o644))
+	t.Chdir(tmpDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	bareDir := t.TempDir()
+	testutil.RunGit(t, bareDir, "init", "--bare")
+
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { repo.Close() })
+	return repo, bareDir
 }

--- a/cmd/entire/cli/doctor_migrate_test.go
+++ b/cmd/entire/cli/doctor_migrate_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/redact"
 )
 
 // Not parallel: uses t.Chdir()
@@ -113,4 +115,37 @@ func TestDoctorMigrateCheckpoints_RefusesWhenRefsPrimary(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 	assert.Contains(t, out.String(), "already the primary",
 		"must refuse to migrate when git-refs is already the primary store")
+}
+
+// A command whose push gates on redact.OPFEnabled() must configure redaction at
+// its own entry point. EnsureRedactionConfigured lives in doctor's PreRunE,
+// which cobra does not inherit, so a subcommand that omits it reads a
+// process-global OPF flag nothing ever set — and its OPF gate passes silently,
+// pushing un-OPF'd checkpoint content.
+func TestDoctorMigrateCheckpoints_ConfiguresRedaction(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".entire", "settings.json"),
+		[]byte(`{"enabled": true, "redaction": {"openai_privacy_filter": {"enabled": true, "categories": {"private_person": true}}}}`), 0o644))
+	t.Chdir(tmpDir)
+	paths.ClearWorktreeRootCache()
+
+	strategy.ResetRedactionConfiguredForTest()
+	t.Cleanup(strategy.ResetRedactionConfiguredForTest)
+	redact.ResetOPFConfigForTest()
+	t.Cleanup(redact.ResetOPFConfigForTest)
+
+	cmd := newDoctorMigrateCheckpointsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetContext(context.Background())
+	require.NoError(t, cmd.Execute())
+
+	assert.True(t, redact.OPFEnabled(),
+		"the OPF gate on this command's push reads this flag; unconfigured it is always false and the gate is a no-op")
 }

--- a/cmd/entire/cli/doctor_migrate_test.go
+++ b/cmd/entire/cli/doctor_migrate_test.go
@@ -169,9 +169,18 @@ func TestDoctorMigrateCheckpoints_ReadOnlyPathsIgnoreScannerConfig(t *testing.T)
 	assert.Contains(t, out.String(), "nothing to migrate")
 }
 
-// setupMigratePushRepo builds a repo with the given .entire/settings.json, a
-// bare remote, and one queued checkpoint ref, and returns the open repo plus
-// the remote path.
+// setupMigratePushRepo builds a repo with the given .entire/settings.json and a
+// bare remote, and returns the open repo plus the remote path.
+//
+// It queues no checkpoint refs, deliberately. The caller asserts that the push
+// path configures redaction before it gates, which happens before the flush and
+// so does not depend on the queue holding anything. Queuing one would tie the
+// test to whether the fixture's content reaches the OPF runtime at all:
+// redact.BatchBytesWithPrivacyFilter only shells out for leaves containing a
+// space, so this fixture ("init") sends none and passes without `opf` installed
+// — until someone puts a space in it, at which point the test needs a real OPF
+// binary. Real queued refs scanned by a fake runtime are covered by
+// TestPushQueuedCheckpointRefs_OPFAppliedBeforePush.
 func setupMigratePushRepo(t *testing.T, settingsJSON string) (*git.Repository, string) {
 	t.Helper()
 	tmpDir := t.TempDir()

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -21,10 +21,15 @@ import (
 	"github.com/entireio/cli/redact"
 )
 
-// errOPFAbortedByUser is returned when the user chose Abort (or pressed
+// ErrOPFAbortedByUser is returned when the user chose Abort (or pressed
 // Ctrl-C) at the OPF prompt. PrePush returns it verbatim; the hook
 // command propagates the non-zero exit code so git push aborts.
-var errOPFAbortedByUser = errors.New("OPF prompt aborted by user; push cancelled")
+//
+// Exported because a user-initiated abort is a decline, not a failure, and
+// only the calling command knows how to say so: `doctor migrate-checkpoints`
+// matches it to report the same clean "refs stay queued" its own declined
+// prompt does, rather than an error.
+var ErrOPFAbortedByUser = errors.New("OPF prompt aborted by user; push cancelled")
 
 var opfPrePushProgressWriter io.Writer = os.Stderr
 
@@ -146,7 +151,7 @@ func (s *ManualCommitStrategy) prePush(ctx context.Context, remote string, prote
 		}
 		switch decision {
 		case OPFAbort:
-			return errOPFAbortedByUser
+			return ErrOPFAbortedByUser
 		case OPFSkip:
 			// User opted out for this push (or settings/env say
 			// "never"). Push regex-only (8-layer) content as-is.
@@ -246,6 +251,14 @@ func opfPrePushDecision(ctx context.Context) (OPFDecision, error) {
 // Reporting belongs to the caller: the pre-push hook warns and carries on,
 // because a checkpoint failure must never block the user's own git push, while
 // an explicitly requested push surfaces the error instead.
+//
+// Precondition, and the one way to make this gate a silent no-op: OPFEnabled
+// reads process-global config that only EnsureRedactionConfigured sets, so a
+// caller whose entry point skipped it reads "OPF off" and flushes everything
+// unscanned. It is not called here because its error is the scanner-config one
+// hooks deliberately survive (see setupHookContext), which is not this gate's
+// to raise. `doctor migrate-checkpoints` needed its own PreRunE for exactly
+// this reason — cobra does not inherit a parent's.
 func opfGateForCheckpointRefs(ctx context.Context, repo *git.Repository) error {
 	if !redact.OPFEnabled() {
 		return nil
@@ -256,7 +269,7 @@ func opfGateForCheckpointRefs(ctx context.Context, repo *git.Repository) error {
 	}
 	switch decision {
 	case OPFAbort:
-		return errOPFAbortedByUser
+		return ErrOPFAbortedByUser
 	case OPFSkip:
 		// Explicit opt-out for this push: flush the 8-layer content as-is,
 		// untagged — same as the v1 path.

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -254,11 +254,15 @@ func opfPrePushDecision(ctx context.Context) (OPFDecision, error) {
 //
 // Precondition, and the one way to make this gate a silent no-op: OPFEnabled
 // reads process-global config that only EnsureRedactionConfigured sets, so a
-// caller whose entry point skipped it reads "OPF off" and flushes everything
-// unscanned. It is not called here because its error is the scanner-config one
-// hooks deliberately survive (see setupHookContext), which is not this gate's
-// to raise. `doctor migrate-checkpoints` needed its own PreRunE for exactly
-// this reason — cobra does not inherit a parent's.
+// caller that reaches here without it having run reads "OPF off" and flushes
+// everything unscanned. Every caller must ensure it — the hook path via
+// withHookSession (hooks_git_cmd.go), the migration push via pushMigratedRefs
+// (doctor_migrate.go).
+//
+// This gate does not call it itself: on the hook path its scanner-config error
+// is deliberately logged and survived rather than propagated, so raising it
+// here would withhold pushes on a condition that path documents as
+// non-fatal.
 func opfGateForCheckpointRefs(ctx context.Context, repo *git.Repository) error {
 	if !redact.OPFEnabled() {
 		return nil

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -460,7 +460,12 @@ func PushQueuedCheckpointRefs(ctx context.Context, repo *git.Repository, remote 
 		return 0, false, errors.New("checkpoint policy does not allow pushing checkpoint refs; refs stay queued")
 	}
 	if opfErr := opfGateForCheckpointRefs(ctx, repo); opfErr != nil {
-		return 0, false, fmt.Errorf("OPF did not run, so checkpoint refs stay queued: %w", opfErr)
+		// Names no cause, matching flushCheckpointRefsQueue's retry message
+		// below: the gate fails on an unresolvable decision or a failed scan,
+		// but also on a ref update that lost a race after a scan that ran
+		// fine, so "OPF did not run" would sometimes send the user after the
+		// wrong problem. The wrapped error says which it was.
+		return 0, false, fmt.Errorf("checkpoint refs stay queued: %w", opfErr)
 	}
 	pushed, err = flushCheckpointRefsQueue(ctx, repo, ps)
 	// Clean up even on a partial/failed flush: a diverged batch can push some

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -232,20 +232,31 @@ func opfPrePushDecision(ctx context.Context) (OPFDecision, error) {
 	return resolveOPFDecisionForPrePush(ctx, opfCfg, opfPrePushProgressWriter)
 }
 
-// runOPFForCheckpointRefs resolves the OPF decision and, when it says run,
-// rewrites the queued checkpoint refs. It reports whether the flush may
-// proceed: false means OPF failed or the user aborted, so the caller withholds
-// the checkpoint push and leaves the refs queued.
-func runOPFForCheckpointRefs(ctx context.Context, repo *git.Repository) bool {
+// opfGateForCheckpointRefs resolves the OPF decision and, when it says run,
+// rewrites the queued checkpoint refs. A nil error means the flush may proceed;
+// a non-nil one means it must be withheld, leaving the refs queued rather than
+// shipping 8-layer content the user did not opt out of. OPF being disabled is a
+// nil error, so every flush can call this unconditionally.
+//
+// Every path that flushes the queue must pass through here, because skipping it
+// is not the same as an OPFSkip: a skip is a decision the user made for this
+// push and it ships untagged content deliberately, while a missing gate ships
+// exactly the same bytes having never asked.
+//
+// Reporting belongs to the caller: the pre-push hook warns and carries on,
+// because a checkpoint failure must never block the user's own git push, while
+// an explicitly requested push surfaces the error instead.
+func opfGateForCheckpointRefs(ctx context.Context, repo *git.Repository) error {
+	if !redact.OPFEnabled() {
+		return nil
+	}
 	decision, err := opfPrePushDecision(ctx)
 	if err != nil {
-		warnOPFCheckpointRefsWithheld(ctx, err)
-		return false
+		return err
 	}
 	switch decision {
 	case OPFAbort:
-		warnOPFCheckpointRefsWithheld(ctx, errOPFAbortedByUser)
-		return false
+		return errOPFAbortedByUser
 	case OPFSkip:
 		// Explicit opt-out for this push: flush the 8-layer content as-is,
 		// untagged — same as the v1 path.
@@ -255,11 +266,10 @@ func runOPFForCheckpointRefs(ctx context.Context, repo *git.Repository) bool {
 		defer opfSpan.End()
 		if rewriteErr := RewriteQueuedCheckpointRefsWithOPF(ctx, repo); rewriteErr != nil {
 			opfSpan.RecordError(rewriteErr)
-			warnOPFCheckpointRefsWithheld(ctx, rewriteErr)
-			return false
+			return rewriteErr
 		}
 	}
-	return true
+	return nil
 }
 
 // warnOPFCheckpointRefsWithheld reports a withheld flush on both channels: the
@@ -396,7 +406,8 @@ func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pus
 	// checkpoint-ref failure must never do that (see this function's doc), so
 	// failing closed means withholding the flush — nothing un-OPF'd ships, the
 	// refs stay queued, and the user's push proceeds.
-	if redact.OPFEnabled() && !runOPFForCheckpointRefs(ctx, repo) {
+	if opfErr := opfGateForCheckpointRefs(ctx, repo); opfErr != nil {
+		warnOPFCheckpointRefsWithheld(ctx, opfErr)
 		return nil
 	}
 
@@ -422,9 +433,10 @@ func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pus
 // caller owns the repo. It returns the number of refs pushed and whether
 // pushing is disabled in settings — a distinct signal from pushed==0 with
 // pushing enabled (an empty queue), so callers can report the two accurately.
-// Like the pre-push paths, a checkpoint policy that blocks pushing errors with
-// the refs left queued. Currently used by the checkpoint migration command's
-// opt-in "push now".
+// Like the pre-push paths, a checkpoint policy that blocks pushing — or, when
+// OPF is enabled, an OPF rewrite that cannot run — errors with the refs left
+// queued. Currently used by the checkpoint migration command's opt-in
+// "push now".
 func PushQueuedCheckpointRefs(ctx context.Context, repo *git.Repository, remote string) (pushed int, pushDisabled bool, err error) {
 	ps := resolvePushSettings(ctx, remote)
 	if ps.pushDisabled {
@@ -433,6 +445,9 @@ func PushQueuedCheckpointRefs(ctx context.Context, repo *git.Repository, remote 
 	syncCheckpointPolicyForPrePush(ctx, repo, ps)
 	if !checkpointPolicyAllowsGitHook(ctx, repo) {
 		return 0, false, errors.New("checkpoint policy does not allow pushing checkpoint refs; refs stay queued")
+	}
+	if opfErr := opfGateForCheckpointRefs(ctx, repo); opfErr != nil {
+		return 0, false, fmt.Errorf("OPF did not run, so checkpoint refs stay queued: %w", opfErr)
 	}
 	pushed, err = flushCheckpointRefsQueue(ctx, repo, ps)
 	// Clean up even on a partial/failed flush: a diverged batch can push some

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -288,12 +288,19 @@ func opfGateForCheckpointRefs(ctx context.Context, repo *git.Repository) error {
 // warnOPFCheckpointRefsWithheld reports a withheld flush on both channels: the
 // log for diagnosis, and the user's terminal so a silently un-synced checkpoint
 // is never the first they hear of it.
+//
+// Names no cause, for the reason PushQueuedCheckpointRefs does not either: the
+// gate withholds on an unresolvable decision or a failed scan, but also on a
+// ref update that lost a race after a scan that ran fine. Saying "OPF did not
+// run" on the pre-push channel — the one nearly every withheld flush comes
+// through — would send those users after the wrong problem. The wrapped error
+// says which it was.
 func warnOPFCheckpointRefsWithheld(ctx context.Context, err error) {
-	logging.Warn(ctx, "OPF pre-push failed; skipping checkpoint ref push, refs left queued",
+	logging.Warn(ctx, "checkpoint ref push withheld; refs left queued",
 		slog.String("error", err.Error()),
 	)
 	fmt.Fprintf(stderrWriter,
-		"[entire] OPF did not run, so checkpoint refs were not pushed and stay queued for your next push: %v\n", err)
+		"[entire] Your checkpoint refs were not pushed and stay queued for the next push: %v\n", err)
 }
 
 // deferCheckpointPushOnEmptyRemote reports whether publication of the git-branch

--- a/cmd/entire/cli/strategy/refs_push_test.go
+++ b/cmd/entire/cli/strategy/refs_push_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
 )
 
 // mustRefName builds a checkpoint ref for a known-valid ID in tests.
@@ -273,13 +274,7 @@ func TestPushQueuedCheckpointRefs_PolicyBlocked(t *testing.T) {
 	require.NoError(t, err)
 	assert.ElementsMatch(t, refs, remaining, "blocked push leaves refs queued")
 
-	lsCmd := exec.CommandContext(context.Background(), "git", "ls-remote", bareDir)
-	lsCmd.Env = testutil.GitIsolatedEnv()
-	out, err := lsCmd.CombinedOutput()
-	require.NoError(t, err, "ls-remote failed: %s", out)
-	for _, ref := range refs {
-		assert.NotContains(t, string(out), ref.String(), "blocked push must not reach the remote")
-	}
+	assertRefsAbsentFromRemote(t, bareDir, refs, "blocked push must not reach the remote")
 }
 
 func TestPushQueuedCheckpointRefs_FailureLeavesRefsQueued(t *testing.T) {
@@ -311,6 +306,15 @@ func remoteRefFiles(t *testing.T, bareDir string, ref plumbing.ReferenceName) st
 	return string(out)
 }
 
+// assertRefsAbsentFromRemote fails if any of refs reached the bare remote.
+func assertRefsAbsentFromRemote(t *testing.T, bareDir string, refs []plumbing.ReferenceName, msg string) {
+	t.Helper()
+	out := testutil.RunGit(t, bareDir, "ls-remote", bareDir)
+	for _, ref := range refs {
+		assert.NotContains(t, out, ref.String(), msg)
+	}
+}
+
 // remoteRefHash returns the object hash a ref points at on the bare remote.
 func remoteRefHash(t *testing.T, bareDir string, ref plumbing.ReferenceName) string {
 	t.Helper()
@@ -321,4 +325,48 @@ func remoteRefHash(t *testing.T, bareDir string, ref plumbing.ReferenceName) str
 	fields := strings.Fields(strings.TrimSpace(string(out)))
 	require.NotEmpty(t, fields, "ref %s not found on remote", ref)
 	return fields[0]
+}
+
+// TestPushQueuedCheckpointRefs_OPFAppliedBeforePush pins the gate this path was
+// missing: with OPF enabled, the migration command's opt-in push must re-redact
+// the queued refs before they leave the machine, so what lands on the remote is
+// the rewritten, OPF-applied commit rather than the 8-layer one.
+func TestPushQueuedCheckpointRefs_OPFAppliedBeforePush(t *testing.T) {
+	configureFakeOPF(t, &fakeOPFForRewrite{})
+	bareDir, repo, refs := setupGitRefsOPFRepo(t, "a1b2c3d4e5f6", "b2c3d4e5f6a1")
+	before := refHashes(t, repo, refs)
+
+	pushed, pushDisabled, err := PushQueuedCheckpointRefs(t.Context(), repo, bareDir)
+	require.NoError(t, err)
+	assert.False(t, pushDisabled)
+	assert.Equal(t, len(refs), pushed)
+
+	after := refHashes(t, repo, refs)
+	for i, ref := range refs {
+		require.NotEqual(t, before[i], after[i], "ref %s must be rewritten before it is pushed", ref)
+		commit, commitErr := repo.CommitObject(after[i])
+		require.NoError(t, commitErr)
+		assert.True(t, trailers.HasOPFApplied(commit.Message), "pushed commit must carry the OPF trailer")
+		assert.NotContains(t, treeContents(t, repo, after[i]), "PERSONABC", "the sentinel must be scrubbed")
+		assert.Equal(t, after[i].String(), remoteRefHash(t, bareDir, ref),
+			"the rewritten commit is what reached the remote, not the 8-layer one")
+	}
+	assert.Empty(t, queuedRefs(t, repo), "pushed refs leave the queue")
+}
+
+// TestPushQueuedCheckpointRefs_OPFFailureWithholdsPush is the fail-closed half:
+// when OPF is enabled but the rewrite cannot run, nothing may reach the remote.
+func TestPushQueuedCheckpointRefs_OPFFailureWithholdsPush(t *testing.T) {
+	configureFakeOPF(t, &fakeRuntimeAlwaysFails{})
+	bareDir, repo, refs := setupGitRefsOPFRepo(t, "a1b2c3d4e5f6", "b2c3d4e5f6a1")
+	before := refHashes(t, repo, refs)
+
+	pushed, pushDisabled, err := PushQueuedCheckpointRefs(t.Context(), repo, bareDir)
+	require.Error(t, err)
+	assert.False(t, pushDisabled)
+	assert.Equal(t, 0, pushed)
+
+	assert.Equal(t, before, refHashes(t, repo, refs), "a withheld push must leave every ref unmoved")
+	assert.ElementsMatch(t, refs, queuedRefs(t, repo), "withheld refs stay queued")
+	assertRefsAbsentFromRemote(t, bareDir, refs, "withheld push must not reach the remote")
 }

--- a/cmd/entire/cli/strategy/testhelpers.go
+++ b/cmd/entire/cli/strategy/testhelpers.go
@@ -1,0 +1,10 @@
+package strategy
+
+// ResetRedactionConfiguredForTest reinitializes the EnsureRedactionConfigured
+// sync.Once so a test in another package can assert that a command's entry
+// point configures redaction. Without it the Once may already be consumed by
+// an earlier test in the same process, and the assertion passes or fails on
+// test order rather than on the wiring under test.
+func ResetRedactionConfiguredForTest() {
+	resetRedactionConfiguredForTest()
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1218
<!-- entire-trail-link-end -->

## What was wrong

`PushQueuedCheckpointRefs` (`manual_commit_push.go`) flushed the checkpoint-ref push queue with no OPF gate. Its only production caller is the migration command's opt-in push (`doctor_migrate.go`), so with `redaction.openai_privacy_filter.enabled` set, answering yes to "Push N migrated checkpoint ref(s) now?" sent 8-layer content to the remote, untagged.

Un-OPF'd content reaching a remote is not itself the bug — `OPFSkip` does exactly that, deliberately, when the user opts out for a push. The bug is that this path took the skip outcome without the decision ever being resolved or surfaced. A user who enabled OPF and never chose to skip got the skip anyway, and the two answers to the one prompt they did see had opposite safety: "No" left the refs queued for the next `git push`, which applies OPF; "Yes" sent them now, without it.

Scope is the git-refs backend. The `entire/checkpoints/v1` branch has its own pre-push OPF rewrite and is unaffected.

## The fix

`PushQueuedCheckpointRefs` gets the same gate `prePushCheckpointRefs` already had, in the same position — after the checkpoint-policy check, before the flush.

The shared piece, `runOPFForCheckpointRefs`, becomes `opfGateForCheckpointRefs` and returns an error rather than a bool, so each caller reports failure its own way. Pre-push warns and continues, because a checkpoint failure must never block the user's own `git push`. This push was explicitly requested, so it errors with the refs left queued — matching how the same function already handles a blocking checkpoint policy, and leaving the next `git push` to apply OPF and deliver them. `redact.OPFEnabled()` moved inside the gate, so a caller cannot half-apply it by remembering the function and forgetting the flag.

With OPF enabled and no persisted `prompt_default`, answering yes to "Push now?" now shows the standard "Run OpenAI Privacy Filter on these checkpoints?" prompt. That second prompt is the point: it is the decision that was previously hard-coded to skip.

## Tests

Two tests in `refs_push_test.go`, both on the existing `setupGitRefsOPFRepo` fixture so they assert observable state rather than that a function was called. The first pins that the commit reaching the remote is the rewritten one — sentinel scrubbed, `Entire-OPF-Applied` trailer present, remote ref hash equal to the rewritten local hash. The second pins fail-closed: an OPF runtime failure errors, leaves every ref unmoved and queued, and puts nothing on the remote. Both fail against unmodified `main`, where two refs reach the bare remote with zero OPF invocations and no trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes privacy/redaction behavior on an explicit push path and centralizes OPF gating for checkpoint refs; mistakes could ship un-redacted data or block migration pushes incorrectly.
> 
> **Overview**
> **`PushQueuedCheckpointRefs`** (migration “push now”) previously flushed the queue without resolving OPF, so with redaction enabled, “yes” could ship **8-layer, untagged** checkpoint refs while a normal **`git push`** would prompt and rewrite first.
> 
> The shared helper is renamed to **`opfGateForCheckpointRefs`** and now returns **`error`** instead of a bool, with **`redact.OPFEnabled()`** checked inside so every flush path can call it unconditionally. **Pre-push** still **warns and continues** the user’s push when the gate fails; the **explicit queued push** **errors** and leaves refs queued, matching checkpoint-policy blocking.
> 
> Tests add **`assertRefsAbsentFromRemote`**, and two cases pin **rewrite-before-push** (OPF trailer, scrubbed content, remote hash) and **fail-closed** when OPF rewrite fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11446fb26af096003960e74188b326b623612677. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->