### PR TITLE
refactor(gitrepo): centralize metadata resolution (split part 1)

### DIFF
--- a/cmd/entire/cli/gitrepo/metadata.go
+++ b/cmd/entire/cli/gitrepo/metadata.go
@@ -3,11 +3,23 @@ package gitrepo
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 )
+
+// maxMetadataPointerSize matches git's own refusal threshold for .git pointer
+// files (setup.c caps at 4*PATH_MAX with "too large to be a .git file").
+// Anything larger is not repository metadata, and reading it unbounded turns a
+// sparse pointer file of near-zero disk size into gigabytes of allocation.
+const maxMetadataPointerSize = 4 * 4096
+
+// maxMetadataErrorPathLen bounds how much of a pointer-derived path an error
+// message echoes; a hostile pointer must not become a multi-kilobyte error.
+const maxMetadataErrorPathLen = 256
 
 // ErrWorktreeMetadataNotFound reports that an explicit worktree root has no
 // .git entry. Repository opening uses it to distinguish a possible bare
@@ -84,11 +96,11 @@ func resolveWorktreeGitDir(worktreeRoot string) (string, error) {
 		return "", fmt.Errorf(".git entry at %s is neither a directory nor a regular file", gitEntry)
 	}
 
-	content, err := os.ReadFile(gitEntry) //nolint:gosec // path is anchored at the explicit worktree root.
+	content, err := readMetadataPointerFile(".git", gitEntry)
 	if err != nil {
-		return "", fmt.Errorf("read .git file at %s: %w", gitEntry, err)
+		return "", err
 	}
-	pointer, ok := strings.CutPrefix(strings.TrimRight(string(content), "\r\n"), "gitdir: ")
+	pointer, ok := strings.CutPrefix(strings.TrimRight(content, "\r\n"), "gitdir: ")
 	if !ok {
 		return "", fmt.Errorf("parse .git file at %s: missing gitdir prefix", gitEntry)
 	}
@@ -116,11 +128,11 @@ func resolveWorktreeCommonDir(gitDirPath string) (string, error) {
 		return "", fmt.Errorf("commondir entry at %s is not a regular file", commonFile)
 	}
 
-	content, err := os.ReadFile(commonFile) //nolint:gosec // path is inside the validated per-worktree Git directory.
+	content, err := readMetadataPointerFile("commondir", commonFile)
 	if err != nil {
-		return "", fmt.Errorf("read commondir file at %s: %w", commonFile, err)
+		return "", err
 	}
-	pointer := strings.TrimRight(string(content), "\r\n")
+	pointer := strings.TrimRight(content, "\r\n")
 	if pointer == "" {
 		return "", fmt.Errorf("parse commondir file at %s: empty value", commonFile)
 	}
@@ -161,6 +173,38 @@ func resolveWorktreeID(gitDirPath, commonDir string) (string, error) {
 	return id, nil
 }
 
+// readMetadataPointerFile reads a .git or commondir pointer file with git's own
+// size cap, so a hostile pointer file cannot force an unbounded allocation.
+func readMetadataPointerFile(kind, path string) (string, error) {
+	file, err := os.Open(path) //nolint:gosec // path is anchored at validated repository metadata.
+	if err != nil {
+		return "", fmt.Errorf("read %s file at %s: %w", kind, path, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	content, err := io.ReadAll(io.LimitReader(file, maxMetadataPointerSize+1))
+	if err != nil {
+		return "", fmt.Errorf("read %s file at %s: %w", kind, path, err)
+	}
+	if len(content) > maxMetadataPointerSize {
+		return "", fmt.Errorf("parse %s file at %s: too large to be a %s file", kind, path, kind)
+	}
+	return string(content), nil
+}
+
+// elideMetadataPath bounds a pointer-derived path for error display. Elision
+// backs up to a rune boundary so the message stays valid UTF-8.
+func elideMetadataPath(path string) string {
+	if len(path) <= maxMetadataErrorPathLen {
+		return path
+	}
+	cut := maxMetadataErrorPathLen
+	for cut > 0 && !utf8.RuneStart(path[cut]) {
+		cut--
+	}
+	return fmt.Sprintf("%s… (%d bytes elided)", path[:cut], len(path)-cut)
+}
+
 // Preserve the pointer spelling until validation so a missing component cannot
 // disappear through lexical cleaning before the filesystem sees it.
 func resolveMetadataPath(base, value string) string {
@@ -188,24 +232,27 @@ func resolveMetadataDirectory(label, base, value string) (string, error) {
 
 	physical, err := filepath.EvalSymlinks(resolved)
 	if err != nil {
-		return "", fmt.Errorf("resolve %s at %s: %w", label, resolved, err)
+		return "", fmt.Errorf("resolve %s at %s: %w", label, elideMetadataPath(resolved), err)
 	}
 	return filepath.Clean(physical), nil
 }
 
+// The path may carry a pointer file's contents verbatim. The pointer size cap
+// is what bounds the message; eliding here keeps the readable part readable
+// instead of burying it under a padded path.
 func requireMetadataDirectory(label, path string) error {
-	info, err := os.Stat(path) //nolint:gosec // the explicit-root API resolves caller-selected repository metadata.
+	info, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("inspect %s at %s: %w", label, path, err)
+		return fmt.Errorf("inspect %s at %s: %w", label, elideMetadataPath(path), err)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("%s at %s is not a directory", label, path)
+		return fmt.Errorf("%s at %s is not a directory", label, elideMetadataPath(path))
 	}
 	return nil
 }
 
 func metadataDirectoriesIdentifySameFile(a, b string) (bool, error) {
-	aInfo, err := os.Stat(a) //nolint:gosec // explicit-root metadata paths are validated before identity comparison.
+	aInfo, err := os.Stat(a)
 	if err != nil {
 		return false, fmt.Errorf("inspect %s: %w", a, err)
 	}

--- a/cmd/entire/cli/gitrepo/metadata.go
+++ b/cmd/entire/cli/gitrepo/metadata.go
@@ -26,7 +26,7 @@ type WorktreeMetadata struct {
 // worktree root. It does not discover a root, inspect Git environment
 // variables, run Git, cache results, or decide caller policy.
 func ResolveWorktreeMetadata(worktreeRoot string) (WorktreeMetadata, error) {
-	if strings.TrimSpace(worktreeRoot) == "" {
+	if worktreeRoot == "" {
 		return WorktreeMetadata{}, errors.New("worktree root is required")
 	}
 
@@ -96,11 +96,11 @@ func resolveWorktreeGitDir(worktreeRoot string) (string, error) {
 		return "", fmt.Errorf("parse .git file at %s: empty gitdir value", gitEntry)
 	}
 
-	resolved := resolveMetadataPath(worktreeRoot, pointer)
-	if err := requireMetadataDirectory("Git directory", resolved); err != nil {
+	resolved, err := resolveMetadataDirectory("Git directory", worktreeRoot, pointer)
+	if err != nil {
 		return "", err
 	}
-	return filepath.Clean(resolved), nil
+	return resolved, nil
 }
 
 func resolveWorktreeCommonDir(gitDirPath string) (string, error) {
@@ -125,11 +125,11 @@ func resolveWorktreeCommonDir(gitDirPath string) (string, error) {
 		return "", fmt.Errorf("parse commondir file at %s: empty value", commonFile)
 	}
 
-	resolved := resolveMetadataPath(gitDirPath, pointer)
-	if err := requireMetadataDirectory("common Git directory", resolved); err != nil {
+	resolved, err := resolveMetadataDirectory("common Git directory", gitDirPath, pointer)
+	if err != nil {
 		return "", err
 	}
-	return filepath.Clean(resolved), nil
+	return resolved, nil
 }
 
 func resolveWorktreeID(gitDirPath, commonDir string) (string, error) {
@@ -142,15 +142,26 @@ func resolveWorktreeID(gitDirPath, commonDir string) (string, error) {
 	}
 
 	registrationRoot := filepath.Join(commonDir, "worktrees")
-	same, err = metadataDirectoriesIdentifySameFile(filepath.Dir(gitDirPath), registrationRoot)
+	registrationPath := gitDirPath
+	same, err = metadataDirectoriesIdentifySameFile(filepath.Dir(registrationPath), registrationRoot)
 	if err != nil {
 		return "", fmt.Errorf("validate linked-worktree registration for %s: %w", gitDirPath, err)
 	}
 	if !same {
-		return "", fmt.Errorf("git directory %s is not an immediate child of %s", gitDirPath, registrationRoot)
+		registrationPath, err = filepath.EvalSymlinks(gitDirPath)
+		if err != nil {
+			return "", fmt.Errorf("resolve linked-worktree registration %s: %w", gitDirPath, err)
+		}
+		same, err = metadataDirectoriesIdentifySameFile(filepath.Dir(registrationPath), registrationRoot)
+		if err != nil {
+			return "", fmt.Errorf("validate linked-worktree registration for %s: %w", gitDirPath, err)
+		}
+		if !same {
+			return "", fmt.Errorf("git directory %s is not an immediate child of %s", gitDirPath, registrationRoot)
+		}
 	}
 
-	id := filepath.Base(gitDirPath)
+	id := filepath.Base(registrationPath)
 	if id == "." || id == string(filepath.Separator) || id == "" {
 		return "", fmt.Errorf("git directory %s has no worktree registration name", gitDirPath)
 	}
@@ -166,6 +177,29 @@ func resolveMetadataPath(base, value string) string {
 	return base + string(filepath.Separator) + value
 }
 
+func resolveMetadataDirectory(label, base, value string) (string, error) {
+	resolved := resolveMetadataPath(base, value)
+	if err := requireMetadataDirectory(label, resolved); err != nil {
+		return "", err
+	}
+
+	cleaned := filepath.Clean(resolved)
+	if cleaned == resolved {
+		return cleaned, nil
+	}
+	// Cleaning a path through a symlink before resolving ".." can change which
+	// directory it names, so keep the lexical result only when identity agrees.
+	if same, err := metadataDirectoriesIdentifySameFile(resolved, cleaned); err == nil && same {
+		return cleaned, nil
+	}
+
+	physical, err := filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s at %s: %w", label, resolved, err)
+	}
+	return filepath.Clean(physical), nil
+}
+
 func requireMetadataDirectory(label, path string) error {
 	info, err := os.Stat(path) //nolint:gosec // the explicit-root API resolves caller-selected repository metadata.
 	if err != nil {
@@ -178,7 +212,7 @@ func requireMetadataDirectory(label, path string) error {
 }
 
 func metadataDirectoriesIdentifySameFile(a, b string) (bool, error) {
-	aInfo, err := os.Stat(a)
+	aInfo, err := os.Stat(a) //nolint:gosec // explicit-root metadata paths are validated before identity comparison.
 	if err != nil {
 		return false, fmt.Errorf("inspect %s: %w", a, err)
 	}

--- a/cmd/entire/cli/gitrepo/metadata.go
+++ b/cmd/entire/cli/gitrepo/metadata.go
@@ -1,0 +1,196 @@
+package gitrepo
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrWorktreeMetadataNotFound reports that an explicit worktree root has no
+// .git entry. Repository opening uses it to distinguish a possible bare
+// repository from broken worktree metadata.
+var ErrWorktreeMetadataNotFound = errors.New("worktree Git metadata not found")
+
+// WorktreeMetadata contains Git directory facts for one explicit worktree
+// root. Paths are cleaned and absolute but retain their lexical spelling.
+type WorktreeMetadata struct {
+	GitDir     string
+	CommonDir  string
+	WorktreeID string
+}
+
+// ResolveWorktreeMetadata resolves filesystem metadata for an explicit
+// worktree root. It does not discover a root, inspect Git environment
+// variables, run Git, cache results, or decide caller policy.
+func ResolveWorktreeMetadata(worktreeRoot string) (WorktreeMetadata, error) {
+	if strings.TrimSpace(worktreeRoot) == "" {
+		return WorktreeMetadata{}, errors.New("worktree root is required")
+	}
+
+	root, err := filepath.Abs(worktreeRoot)
+	if err != nil {
+		return WorktreeMetadata{}, fmt.Errorf("resolve worktree root %q: %w", worktreeRoot, err)
+	}
+	root = filepath.Clean(root)
+	if err := requireMetadataDirectory("worktree root", root); err != nil {
+		return WorktreeMetadata{}, err
+	}
+
+	gitDirPath, err := resolveWorktreeGitDir(root)
+	if err != nil {
+		return WorktreeMetadata{}, err
+	}
+	commonDir, err := resolveWorktreeCommonDir(gitDirPath)
+	if err != nil {
+		return WorktreeMetadata{}, err
+	}
+	worktreeID, err := resolveWorktreeID(gitDirPath, commonDir)
+	if err != nil {
+		return WorktreeMetadata{}, err
+	}
+
+	return WorktreeMetadata{
+		GitDir:     gitDirPath,
+		CommonDir:  commonDir,
+		WorktreeID: worktreeID,
+	}, nil
+}
+
+func resolveWorktreeGitDir(worktreeRoot string) (string, error) {
+	gitEntry := filepath.Join(worktreeRoot, gitDir)
+	info, err := os.Lstat(gitEntry)
+	if errors.Is(err, fs.ErrNotExist) {
+		if rootErr := requireMetadataDirectory("worktree root", worktreeRoot); rootErr != nil {
+			return "", rootErr
+		}
+		return "", fmt.Errorf("%w at %s: %w", ErrWorktreeMetadataNotFound, gitEntry, err)
+	}
+	if err != nil {
+		return "", fmt.Errorf("inspect .git entry at %s: %w", gitEntry, err)
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		info, err = os.Stat(gitEntry)
+		if err != nil {
+			return "", fmt.Errorf("inspect .git entry at %s: %w", gitEntry, err)
+		}
+	}
+	if info.IsDir() {
+		return gitEntry, nil
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf(".git entry at %s is neither a directory nor a regular file", gitEntry)
+	}
+
+	content, err := os.ReadFile(gitEntry) //nolint:gosec // path is anchored at the explicit worktree root.
+	if err != nil {
+		return "", fmt.Errorf("read .git file at %s: %w", gitEntry, err)
+	}
+	pointer, ok := strings.CutPrefix(strings.TrimRight(string(content), "\r\n"), "gitdir: ")
+	if !ok {
+		return "", fmt.Errorf("parse .git file at %s: missing gitdir prefix", gitEntry)
+	}
+	if pointer == "" {
+		return "", fmt.Errorf("parse .git file at %s: empty gitdir value", gitEntry)
+	}
+
+	resolved := resolveMetadataPath(worktreeRoot, pointer)
+	if err := requireMetadataDirectory("Git directory", resolved); err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func resolveWorktreeCommonDir(gitDirPath string) (string, error) {
+	commonFile := filepath.Join(gitDirPath, "commondir")
+	info, err := os.Lstat(commonFile)
+	if errors.Is(err, fs.ErrNotExist) {
+		return gitDirPath, nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("inspect commondir file at %s: %w", commonFile, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("commondir entry at %s is not a regular file", commonFile)
+	}
+
+	content, err := os.ReadFile(commonFile) //nolint:gosec // path is inside the validated per-worktree Git directory.
+	if err != nil {
+		return "", fmt.Errorf("read commondir file at %s: %w", commonFile, err)
+	}
+	pointer := strings.TrimRight(string(content), "\r\n")
+	if pointer == "" {
+		return "", fmt.Errorf("parse commondir file at %s: empty value", commonFile)
+	}
+
+	resolved := resolveMetadataPath(gitDirPath, pointer)
+	if err := requireMetadataDirectory("common Git directory", resolved); err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func resolveWorktreeID(gitDirPath, commonDir string) (string, error) {
+	same, err := metadataDirectoriesIdentifySameFile(gitDirPath, commonDir)
+	if err != nil {
+		return "", fmt.Errorf("compare Git and common directories: %w", err)
+	}
+	if same {
+		return "", nil
+	}
+
+	registrationRoot := filepath.Join(commonDir, "worktrees")
+	same, err = metadataDirectoriesIdentifySameFile(filepath.Dir(gitDirPath), registrationRoot)
+	if err != nil {
+		return "", fmt.Errorf("validate linked-worktree registration for %s: %w", gitDirPath, err)
+	}
+	if !same {
+		return "", fmt.Errorf("git directory %s is not an immediate child of %s", gitDirPath, registrationRoot)
+	}
+
+	id := filepath.Base(gitDirPath)
+	if id == "." || id == string(filepath.Separator) || id == "" {
+		return "", fmt.Errorf("git directory %s has no worktree registration name", gitDirPath)
+	}
+	return id, nil
+}
+
+// Preserve the pointer spelling until validation so a missing component cannot
+// disappear through lexical cleaning before the filesystem sees it.
+func resolveMetadataPath(base, value string) string {
+	if filepath.IsAbs(value) {
+		return value
+	}
+	return base + string(filepath.Separator) + value
+}
+
+func requireMetadataDirectory(label, path string) error {
+	info, err := os.Stat(path) //nolint:gosec // the explicit-root API resolves caller-selected repository metadata.
+	if err != nil {
+		return fmt.Errorf("inspect %s at %s: %w", label, path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s at %s is not a directory", label, path)
+	}
+	return nil
+}
+
+func metadataDirectoriesIdentifySameFile(a, b string) (bool, error) {
+	aInfo, err := os.Stat(a)
+	if err != nil {
+		return false, fmt.Errorf("inspect %s: %w", a, err)
+	}
+	if !aInfo.IsDir() {
+		return false, fmt.Errorf("%s is not a directory", a)
+	}
+	bInfo, err := os.Stat(b)
+	if err != nil {
+		return false, fmt.Errorf("inspect %s: %w", b, err)
+	}
+	if !bInfo.IsDir() {
+		return false, fmt.Errorf("%s is not a directory", b)
+	}
+	return os.SameFile(aInfo, bInfo), nil
+}

--- a/cmd/entire/cli/gitrepo/metadata.go
+++ b/cmd/entire/cli/gitrepo/metadata.go
@@ -142,23 +142,16 @@ func resolveWorktreeID(gitDirPath, commonDir string) (string, error) {
 	}
 
 	registrationRoot := filepath.Join(commonDir, "worktrees")
-	registrationPath := gitDirPath
+	registrationPath, err := filepath.EvalSymlinks(gitDirPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve linked-worktree registration %s: %w", gitDirPath, err)
+	}
 	same, err = metadataDirectoriesIdentifySameFile(filepath.Dir(registrationPath), registrationRoot)
 	if err != nil {
 		return "", fmt.Errorf("validate linked-worktree registration for %s: %w", gitDirPath, err)
 	}
 	if !same {
-		registrationPath, err = filepath.EvalSymlinks(gitDirPath)
-		if err != nil {
-			return "", fmt.Errorf("resolve linked-worktree registration %s: %w", gitDirPath, err)
-		}
-		same, err = metadataDirectoriesIdentifySameFile(filepath.Dir(registrationPath), registrationRoot)
-		if err != nil {
-			return "", fmt.Errorf("validate linked-worktree registration for %s: %w", gitDirPath, err)
-		}
-		if !same {
-			return "", fmt.Errorf("git directory %s is not an immediate child of %s", gitDirPath, registrationRoot)
-		}
+		return "", fmt.Errorf("git directory %s is not an immediate child of %s", gitDirPath, registrationRoot)
 	}
 
 	id := filepath.Base(registrationPath)

--- a/cmd/entire/cli/gitrepo/metadata_guard_test.go
+++ b/cmd/entire/cli/gitrepo/metadata_guard_test.go
@@ -1,0 +1,172 @@
+package gitrepo
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
+	t.Parallel()
+
+	legacyTraversalOwners := map[string]string{
+		"gitrepo/repository.go:resolveDotGitPath":    "Codex still uses the exported legacy resolver until GMT-005",
+		"gitrepo/repository.go:resolveCommonGitPath": "Codex still uses the exported legacy resolver until GMT-005",
+		"paths/worktree.go:GetWorktreeID":            "worktree-ID consumers migrate across GMT-003 through GMT-005",
+		"status.go:resolveWorktreeBranch":            "status migrates in GMT-005",
+	}
+	policyDotGitInspections := map[string]string{
+		"agent/codex/hook_root.go:hasDotGitEntry":                    "Codex policy checks whether a candidate checkout owns a .git entry",
+		"agent/codex/hook_root.go:linkedWorktreeRegistrationMatches": "Codex backlink policy validates the registered worktree path",
+		"dispatch_wizard.go:discoverLocalRepoRoots":                  "dispatch discovery filters sibling repository candidates",
+		"gitrepo/status.go:insideNestedCheckout":                     "status walking stops at nested checkout boundaries",
+	}
+	allowedCommonDirQueries := map[string]string{
+		"checkpoint/git_common_dir.go:resolveGitCommonDir":          "checkpoint migrates in GMT-002",
+		"gitdir/gitdir.go:CommonDir":                                "session removes the current-worktree resolver in GMT-003",
+		"gitdir/gitdir.go:CommonDirForWorktree":                     "session removes the explicit-worktree resolver in GMT-003",
+		"session_adopt.go:stateStoreForWorktree":                    "adoption validates an arbitrary source repository in GMT-003",
+		"settings/settings.go:clonePreferencesPathForWorktreeRoot":  "settings migrates in GMT-005",
+		"strategy/common.go:GetGitCommonDir":                        "strategy migrates in GMT-004",
+		"strategy/manual_commit_session.go:gitCommonDirForWorktree": "session routing compares explicit repositories in GMT-004",
+		"strategy/metadata_reconcile.go:loadShallowHashes":          "shallow metadata access migrates in GMT-004",
+		"trail_checkout_worktree.go:gitCommonDirForTrailWorktree":   "trail storage paths migrate in GMT-005",
+		"trail_checkout_worktree.go:validateTrailWorktreeReuse":     "trail reuse validates repository identity in GMT-005",
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve guard source path")
+	}
+	cliRoot := filepath.Dir(filepath.Dir(thisFile))
+	fset := token.NewFileSet()
+	canonicalTokens := 0
+
+	err := filepath.WalkDir(cliRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(cliRoot, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if !strings.HasSuffix(rel, ".go") || strings.HasSuffix(rel, "_test.go") ||
+			strings.HasPrefix(rel, "integration_test/") || strings.HasPrefix(rel, "benchutil/") {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			key := rel + ":" + fn.Name.Name
+			canonicalOwner := rel == "gitrepo/metadata.go"
+			_, legacyOwner := legacyTraversalOwners[key]
+			_, policyInspection := policyDotGitInspections[key]
+
+			hasDotGitReference := containsMetadataString(fn.Body, ".git") || containsIdentifier(fn.Body, "gitDir")
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				switch n := node.(type) {
+				case *ast.BasicLit:
+					if n.Kind != token.STRING {
+						return true
+					}
+					value, unquoteErr := strconv.Unquote(n.Value)
+					if unquoteErr != nil {
+						return true
+					}
+					if value == "--git-common-dir" {
+						if _, allowed := allowedCommonDirQueries[key]; !allowed {
+							t.Errorf("%s runs an unaudited --git-common-dir query; use gitrepo.ResolveWorktreeMetadata or document a semantic-query exception", fset.Position(n.Pos()))
+						}
+					}
+					if value != "gitdir: " && value != "gitdir:" && value != "commondir" {
+						return true
+					}
+					if canonicalOwner {
+						canonicalTokens++
+						return true
+					}
+					if !legacyOwner {
+						t.Errorf("%s independently parses Git metadata token %q; use gitrepo.ResolveWorktreeMetadata", fset.Position(n.Pos()), value)
+					}
+				case *ast.CallExpr:
+					if !hasDotGitReference || !isOSMetadataInspection(n) || canonicalOwner || legacyOwner || policyInspection {
+						return true
+					}
+					t.Errorf("%s independently inspects a .git entry; use gitrepo.ResolveWorktreeMetadata or document a narrow policy exception", fset.Position(n.Pos()))
+				}
+				return true
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan Go sources: %v", err)
+	}
+	if canonicalTokens < 2 {
+		t.Fatal("guard found no canonical gitdir/commondir parser tokens")
+	}
+}
+
+func isOSMetadataInspection(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok || pkg.Name != "os" {
+		return false
+	}
+	switch selector.Sel.Name {
+	case "Lstat", "Open", "OpenFile", "ReadDir", "ReadFile", "Stat":
+		return true
+	default:
+		return false
+	}
+}
+
+func containsMetadataString(node ast.Node, want string) bool {
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		literal, ok := n.(*ast.BasicLit)
+		if !ok || literal.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(literal.Value)
+		if err == nil && value == want {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func containsIdentifier(node ast.Node, want string) bool {
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if ok && ident.Name == want {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/cmd/entire/cli/gitrepo/metadata_guard_test.go
+++ b/cmd/entire/cli/gitrepo/metadata_guard_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -102,11 +103,11 @@ type gitMetadataGuardResult struct {
 }
 
 func scanGitMetadataSources(repoRoot string, policy gitMetadataGuardPolicy) (gitMetadataGuardResult, error) {
-	packageValues, err := collectGuardPackageStringValues(repoRoot)
-	if err != nil {
-		return gitMetadataGuardResult{}, fmt.Errorf("collect package string values: %w", err)
-	}
 	fset := token.NewFileSet()
+	packages, err := collectGuardPackages(fset, repoRoot)
+	if err != nil {
+		return gitMetadataGuardResult{}, fmt.Errorf("collect guard packages: %w", err)
+	}
 	result := gitMetadataGuardResult{
 		legacyOwnersSeen:        map[string]bool{},
 		policyInspectionsSeen:   map[string]bool{},
@@ -114,97 +115,79 @@ func scanGitMetadataSources(repoRoot string, policy gitMetadataGuardPolicy) (git
 		legacyResolverCallsSeen: map[string]bool{},
 	}
 
-	err = filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(repoRoot, path)
-		if err != nil {
-			return err
-		}
-		rel = filepath.ToSlash(rel)
-		if !isGuardSourceFile(rel) {
-			return nil
-		}
+	for _, pkg := range packages {
+		valueResolver := newGuardValueResolver(fset, pkg)
+		for _, source := range pkg.files {
+			rel, file := source.rel, source.file
+			gitrepoImports, dotImportedGitrepo := gitrepoImportNames(file)
+			samePackage := filepath.ToSlash(filepath.Dir(rel)) == "cmd/entire/cli/gitrepo"
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				key := guardSourceKey(rel, fn.Name.Name)
+				canonicalOwner := guardSourcePath(rel) == "gitrepo/metadata.go"
+				_, legacyOwner := policy.legacyTraversalOwners[key]
+				_, policyInspection := policy.policyDotGitInspections[key]
 
-		file, err := parser.ParseFile(fset, path, nil, 0)
-		if err != nil {
-			return err
-		}
-		values := packageValues[guardPackageKey(rel, file)]
-		valueResolver := newGuardValueResolver(fset, file, values)
-		gitrepoImports, dotImportedGitrepo := gitrepoImportNames(file)
-		samePackage := filepath.ToSlash(filepath.Dir(rel)) == "cmd/entire/cli/gitrepo"
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
-				continue
-			}
-			key := guardSourceKey(rel, fn.Name.Name)
-			canonicalOwner := guardSourcePath(rel) == "gitrepo/metadata.go"
-			_, legacyOwner := policy.legacyTraversalOwners[key]
-			_, policyInspection := policy.policyDotGitInspections[key]
-
-			for _, value := range []string{"gitdir: ", "gitdir:", "commondir"} {
-				if !valueResolver.contains(fn.Body, value) {
-					continue
-				}
-				if canonicalOwner {
-					result.canonicalTokens++
-					continue
-				}
-				if legacyOwner {
-					result.legacyOwnersSeen[key] = true
-					continue
-				}
-				result.violations = append(result.violations, fmt.Sprintf("%s independently parses Git metadata token %q; use gitrepo.ResolveWorktreeMetadata", fset.Position(fn.Pos()), value))
-			}
-			if valueResolver.contains(fn.Body, "rev-parse") {
-				for _, flag := range []string{"--absolute-git-dir", "--git-common-dir", "--git-dir", "--show-toplevel"} {
-					if !valueResolver.contains(fn.Body, flag) {
+				for _, value := range []string{"gitdir: ", "gitdir:", "commondir"} {
+					if !valueResolver.contains(fn.Body, value) {
 						continue
 					}
-					query := guardMetadataQuery{source: key, flag: flag}
-					if _, allowed := policy.allowedMetadataQueries[query]; allowed {
-						result.metadataQueriesSeen[query] = true
-					} else {
-						result.violations = append(result.violations, fmt.Sprintf("%s runs an unaudited git rev-parse %s query; use gitrepo.ResolveWorktreeMetadata or document a semantic-query exception", fset.Position(fn.Pos()), flag))
+					if canonicalOwner {
+						result.canonicalTokens++
+						continue
+					}
+					if legacyOwner {
+						result.legacyOwnersSeen[key] = true
+						continue
+					}
+					result.violations = append(result.violations, fmt.Sprintf("%s independently parses Git metadata token %q; use gitrepo.ResolveWorktreeMetadata", fset.Position(fn.Pos()), value))
+				}
+				if valueResolver.contains(fn.Body, "rev-parse") {
+					for _, flag := range []string{"--absolute-git-dir", "--git-common-dir", "--git-dir", "--show-toplevel"} {
+						if !valueResolver.contains(fn.Body, flag) {
+							continue
+						}
+						query := guardMetadataQuery{source: key, flag: flag}
+						if _, allowed := policy.allowedMetadataQueries[query]; allowed {
+							result.metadataQueriesSeen[query] = true
+						} else {
+							result.violations = append(result.violations, fmt.Sprintf("%s runs an unaudited git rev-parse %s query; use gitrepo.ResolveWorktreeMetadata or document a semantic-query exception", fset.Position(fn.Pos()), flag))
+						}
 					}
 				}
+				ast.Inspect(fn.Body, func(node ast.Node) bool {
+					call, ok := node.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					if isLegacyMetadataResolverCall(call, gitrepoImports, dotImportedGitrepo, samePackage) {
+						if _, allowed := policy.allowedLegacyCalls[key]; allowed {
+							result.legacyResolverCallsSeen[key] = true
+						} else {
+							result.violations = append(result.violations, fmt.Sprintf("%s calls a legacy Git metadata resolver; use gitrepo.ResolveWorktreeMetadata or document the migration exception", fset.Position(call.Pos())))
+						}
+					}
+					if !valueResolver.contains(call, ".git") || !isFilesystemMetadataInspection(call) || canonicalOwner {
+						return true
+					}
+					if legacyOwner {
+						result.legacyOwnersSeen[key] = true
+						return true
+					}
+					if policyInspection {
+						result.policyInspectionsSeen[key] = true
+						return true
+					}
+					result.violations = append(result.violations, fmt.Sprintf("%s independently inspects a .git entry; use gitrepo.ResolveWorktreeMetadata or document a narrow policy exception", fset.Position(call.Pos())))
+					return true
+				})
 			}
-			ast.Inspect(fn.Body, func(node ast.Node) bool {
-				call, ok := node.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				if isLegacyMetadataResolverCall(call, gitrepoImports, dotImportedGitrepo, samePackage) {
-					if _, allowed := policy.allowedLegacyCalls[key]; allowed {
-						result.legacyResolverCallsSeen[key] = true
-					} else {
-						result.violations = append(result.violations, fmt.Sprintf("%s calls a legacy Git metadata resolver; use gitrepo.ResolveWorktreeMetadata or document the migration exception", fset.Position(call.Pos())))
-					}
-				}
-				if !valueResolver.contains(call, ".git") || !isFilesystemMetadataInspection(call) || canonicalOwner {
-					return true
-				}
-				if legacyOwner {
-					result.legacyOwnersSeen[key] = true
-					return true
-				}
-				if policyInspection {
-					result.policyInspectionsSeen[key] = true
-					return true
-				}
-				result.violations = append(result.violations, fmt.Sprintf("%s independently inspects a .git entry; use gitrepo.ResolveWorktreeMetadata or document a narrow policy exception", fset.Position(call.Pos())))
-				return true
-			})
 		}
-		return nil
-	})
-	return result, err
+	}
+	return result, nil
 }
 
 func TestGitMetadataGuardRecognizesBypassForms(t *testing.T) {
@@ -275,6 +258,18 @@ func TestGitMetadataGuardRecognizesBypassForms(t *testing.T) {
 			kind:   "filesystem",
 			want:   false,
 		},
+		{
+			name:   "parameter shadowing a package constant is not metadata traversal",
+			source: `package probe; import "os"; const gitDir = ".git"; func inspect(gitDir string) { _, _ = os.Stat(gitDir) }`,
+			kind:   "filesystem",
+			want:   false,
+		},
+		{
+			name:   "struct field named after a package constant is not metadata traversal",
+			source: `package probe; import "os"; const gitDir = ".git"; type layout struct{ gitDir string }; func inspect(l layout) { _, _ = os.Stat(l.gitDir) }`,
+			kind:   "filesystem",
+			want:   false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -285,8 +280,8 @@ func TestGitMetadataGuardRecognizesBypassForms(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parse probe: %v", err)
 			}
-			values := packageStringValues(file)
-			valueResolver := newGuardValueResolver(fset, file, values)
+			pkg := guardPackage{key: "probe", files: []guardSourceFile{{rel: "probe.go", file: file}}}
+			valueResolver := newGuardValueResolver(fset, pkg)
 			imports, dotImported := gitrepoImportNames(file)
 			found := false
 			for _, decl := range file.Decls {
@@ -326,11 +321,16 @@ func TestGitMetadataGuardScansCompleteRepository(t *testing.T) {
 	t.Parallel()
 
 	repoRoot := t.TempDir()
-	writeGuardSource(t, repoRoot, "probe/tokens.go", `package probe; const dotGitName = ".git"`)
+	writeGuardSource(t, repoRoot, "probe/tokens.go", `package probe; const dotGitName = ".git"; const gitDir = ".git"`)
 	writeGuardSource(t, repoRoot, "probe/use.go", `package probe; import "os"; func crossFileConstant() { _, _ = os.Stat(dotGitName) }`)
 	writeGuardSource(t, repoRoot, "internal/probe/probe.go", `package probe; import "os"; func internalReadlink() { _, _ = os.Readlink(".git") }`)
 	writeGuardSource(t, repoRoot, "probe/shadow.go", `package probe; import "os"; func shadowed(gitDir string) { _, _ = os.Stat(gitDir) }`)
 	writeGuardSource(t, repoRoot, "probe/query.go", `package probe; import "os/exec"; func existingException() { _ = exec.Command("git", "rev-parse", "--show-toplevel", "--git-dir") }`)
+	// The field is declared in one file and read in another, while the package
+	// also declares a gitDir constant. A per-file check cannot resolve the
+	// selector, and resolving it by name instead reported this as a traversal.
+	writeGuardSource(t, repoRoot, "probe/layout.go", `package probe; type layout struct{ gitDir string }`)
+	writeGuardSource(t, repoRoot, "probe/method.go", `package probe; import "os"; func (l layout) crossFileField() { _, _ = os.Stat(l.gitDir) }`)
 
 	allowedQuery := guardMetadataQuery{source: "probe/query.go:existingException", flag: "--show-toplevel"}
 	result, err := scanGitMetadataSources(repoRoot, gitMetadataGuardPolicy{
@@ -351,7 +351,7 @@ func TestGitMetadataGuardScansCompleteRepository(t *testing.T) {
 			t.Errorf("violations do not contain %q:\n%s", want, violations)
 		}
 	}
-	for _, notWant := range []string{"probe/shadow.go", "--show-toplevel"} {
+	for _, notWant := range []string{"probe/shadow.go", "probe/method.go", "--show-toplevel"} {
 		if strings.Contains(violations, notWant) {
 			t.Errorf("violations unexpectedly contain %q:\n%s", notWant, violations)
 		}
@@ -382,9 +382,22 @@ func isFilesystemMetadataInspection(call *ast.CallExpr) bool {
 	}
 }
 
-func collectGuardPackageStringValues(repoRoot string) (map[string]map[string]string, error) {
-	values := map[string]map[string]string{}
-	fset := token.NewFileSet()
+type guardSourceFile struct {
+	rel  string
+	file *ast.File
+}
+
+type guardPackage struct {
+	key   string
+	files []guardSourceFile
+}
+
+// collectGuardPackages groups every scanned file by the package it belongs to,
+// so identifiers can later be resolved against the whole package rather than
+// against one file in isolation. Packages come back in key order so a scan
+// reports violations deterministically.
+func collectGuardPackages(fset *token.FileSet, repoRoot string) ([]guardPackage, error) {
+	byKey := map[string][]guardSourceFile{}
 	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -405,42 +418,20 @@ func collectGuardPackageStringValues(repoRoot string) (map[string]map[string]str
 			return err
 		}
 		key := guardPackageKey(rel, file)
-		if values[key] == nil {
-			values[key] = map[string]string{}
-		}
-		for name, value := range packageStringValues(file) {
-			values[key][name] = value
-		}
+		byKey[key] = append(byKey[key], guardSourceFile{rel: rel, file: file})
 		return nil
 	})
-	return values, err
-}
-
-func packageStringValues(file *ast.File) map[string]string {
-	values := map[string]string{}
-	for _, decl := range file.Decls {
-		gen, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-		for _, spec := range gen.Specs {
-			valueSpec, ok := spec.(*ast.ValueSpec)
-			if !ok {
-				continue
-			}
-			for i, expr := range valueSpec.Values {
-				literal, ok := expr.(*ast.BasicLit)
-				if !ok || literal.Kind != token.STRING || i >= len(valueSpec.Names) {
-					continue
-				}
-				unquoted, err := strconv.Unquote(literal.Value)
-				if err == nil {
-					values[valueSpec.Names[i].Name] = unquoted
-				}
-			}
-		}
+	if err != nil {
+		return nil, err
 	}
-	return values
+
+	packages := make([]guardPackage, 0, len(byKey))
+	for key, files := range byKey {
+		sort.Slice(files, func(i, j int) bool { return files[i].rel < files[j].rel })
+		packages = append(packages, guardPackage{key: key, files: files})
+	}
+	sort.Slice(packages, func(i, j int) bool { return packages[i].key < packages[j].key })
+	return packages, nil
 }
 
 func gitrepoImportNames(file *ast.File) (map[string]bool, bool) {
@@ -497,56 +488,73 @@ func assertMetadataQueryLedgerSeen(t *testing.T, ledger map[guardMetadataQuery]s
 }
 
 type guardValueResolver struct {
-	packageValues map[string]string
-	typeInfo      *types.Info
-	bindings      map[types.Object]ast.Expr
+	typeInfo *types.Info
+	bindings map[types.Object]ast.Expr
 }
 
-func newGuardValueResolver(fset *token.FileSet, file *ast.File, packageValues map[string]string) guardValueResolver {
+// newGuardValueResolver type-checks a whole package at once, so an identifier
+// declared in one file resolves from another, and a local name that shadows a
+// package-level constant resolves to the local declaration.
+//
+// Checking one file at a time cannot do either. The fallback that compensated
+// for it matched an unresolved identifier against package constants by name, so
+// any parameter, field, or local sharing a name with a constant elsewhere in the
+// package was reported as a violation. That fires on gitDir, which strategy
+// declares as a constant and several functions take as a parameter, failing the
+// build for code the guard is not looking for while naming neither cause nor
+// fix. An identifier that still does not resolve now matches nothing.
+func newGuardValueResolver(fset *token.FileSet, pkg guardPackage) guardValueResolver {
 	typeInfo := &types.Info{
 		Defs: map[*ast.Ident]types.Object{},
 		Uses: map[*ast.Ident]types.Object{},
 	}
-	config := types.Config{Error: func(error) {}}
-	_, typeErr := config.Check(file.Name.Name, fset, []*ast.File{file}, typeInfo)
-	// Files are checked in isolation, so unresolved cross-file imports are
-	// expected; local definitions collected before that error remain usable.
-	if typeErr != nil && len(typeInfo.Defs) == 0 && len(typeInfo.Uses) == 0 {
-		return guardValueResolver{packageValues: packageValues, typeInfo: typeInfo}
+	files := make([]*ast.File, 0, len(pkg.files))
+	for _, source := range pkg.files {
+		files = append(files, source.file)
 	}
+	name := "guard"
+	if len(files) > 0 {
+		name = files[0].Name.Name
+	}
+	// Imports are not resolved, so type errors are the expected outcome; the
+	// identifiers declared inside the package are recorded regardless, and
+	// those are all the resolver reads.
+	config := types.Config{Error: func(error) {}}
+	config.Check(name, fset, files, typeInfo) //nolint:errcheck // unresolved imports always error here.
 	return guardValueResolver{
-		packageValues: packageValues,
-		typeInfo:      typeInfo,
-		bindings:      guardValueBindings(file, typeInfo),
+		typeInfo: typeInfo,
+		bindings: guardValueBindings(files, typeInfo),
 	}
 }
 
-func guardValueBindings(file *ast.File, typeInfo *types.Info) map[types.Object]ast.Expr {
+func guardValueBindings(files []*ast.File, typeInfo *types.Info) map[types.Object]ast.Expr {
 	bindings := map[types.Object]ast.Expr{}
-	ast.Inspect(file, func(node ast.Node) bool {
-		switch decl := node.(type) {
-		case *ast.ValueSpec:
-			for i, name := range decl.Names {
-				if object := typeInfo.Defs[name]; object != nil {
-					bindings[object] = expressionAt(decl.Values, i)
+	for _, file := range files {
+		ast.Inspect(file, func(node ast.Node) bool {
+			switch decl := node.(type) {
+			case *ast.ValueSpec:
+				for i, name := range decl.Names {
+					if object := typeInfo.Defs[name]; object != nil {
+						bindings[object] = expressionAt(decl.Values, i)
+					}
+				}
+			case *ast.AssignStmt:
+				if decl.Tok != token.DEFINE {
+					return true
+				}
+				for i, lhs := range decl.Lhs {
+					name, ok := lhs.(*ast.Ident)
+					if !ok {
+						continue
+					}
+					if object := typeInfo.Defs[name]; object != nil {
+						bindings[object] = expressionAt(decl.Rhs, i)
+					}
 				}
 			}
-		case *ast.AssignStmt:
-			if decl.Tok != token.DEFINE {
-				return true
-			}
-			for i, lhs := range decl.Lhs {
-				name, ok := lhs.(*ast.Ident)
-				if !ok {
-					continue
-				}
-				if object := typeInfo.Defs[name]; object != nil {
-					bindings[object] = expressionAt(decl.Rhs, i)
-				}
-			}
-		}
-		return true
-	})
+			return true
+		})
+	}
 	return bindings
 }
 
@@ -583,9 +591,6 @@ func (r guardValueResolver) containsSeen(node ast.Node, want string, seen map[ty
 				object = r.typeInfo.Defs[value]
 			}
 			if object == nil {
-				if r.packageValues[value.Name] == want {
-					found = true
-				}
 				return false
 			}
 			if seen[object] {

--- a/cmd/entire/cli/gitrepo/metadata_guard_test.go
+++ b/cmd/entire/cli/gitrepo/metadata_guard_test.go
@@ -1,10 +1,13 @@
 package gitrepo
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -22,23 +25,28 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 		"status.go:resolveWorktreeBranch":            "status migrates with the remaining consumers",
 	}
 	policyDotGitInspections := map[string]string{
-		"agent/codex/hook_root.go:hasDotGitEntry":                    "Codex policy checks whether a candidate checkout owns a .git entry",
-		"agent/codex/hook_root.go:linkedWorktreeRegistrationMatches": "Codex backlink policy validates the registered worktree path",
-		"dispatch_wizard.go:discoverLocalRepoRoots":                  "dispatch discovery filters sibling repository candidates",
-		"gitrepo/status.go:insideNestedCheckout":                     "status walking stops at nested checkout boundaries",
-		"plugin_index.go:SyncPluginIndex":                            "plugin index sync checks whether Entire's cache directory contains its clone",
+		"agent/codex/hook_root.go:hasDotGitEntry":   "Codex policy checks whether a candidate checkout owns a .git entry",
+		"dispatch_wizard.go:discoverLocalRepoRoots": "dispatch discovery filters sibling repository candidates",
+		"gitrepo/status.go:insideNestedCheckout":    "status walking stops at nested checkout boundaries",
+		"plugin_index.go:SyncPluginIndex":           "plugin index sync checks whether Entire's cache directory contains its clone",
 	}
-	allowedCommonDirQueries := map[string]string{
-		"checkpoint/git_common_dir.go:resolveGitCommonDir":          "checkpoint migrates in the checkpoint split",
-		"gitdir/gitdir.go:CommonDir":                                "session removes the current-worktree resolver in the session split",
-		"gitdir/gitdir.go:CommonDirForWorktree":                     "session removes the explicit-worktree resolver in the session split",
-		"session_adopt.go:stateStoreForWorktree":                    "adoption validates an arbitrary source repository in the session split",
-		"settings/settings.go:clonePreferencesPathForWorktreeRoot":  "settings migrates with the remaining consumers",
-		"strategy/common.go:GetGitCommonDir":                        "strategy migrates in the strategy-and-hooks split",
-		"strategy/manual_commit_session.go:gitCommonDirForWorktree": "session routing migrates in the strategy-and-hooks split",
-		"strategy/metadata_reconcile.go:loadShallowHashes":          "shallow metadata access migrates in the strategy-and-hooks split",
-		"trail_checkout_worktree.go:gitCommonDirForTrailWorktree":   "trail storage paths migrate with the remaining consumers",
-		"trail_checkout_worktree.go:validateTrailWorktreeReuse":     "trail reuse validation migrates with the remaining consumers",
+	allowedMetadataQueries := map[guardMetadataQuery]string{
+		{source: "checkpoint/git_common_dir.go:resolveGitCommonDir", flag: "--git-common-dir"}:          "checkpoint migrates in the checkpoint split",
+		{source: "dispatch/mode_local.go:resolveRepoRoots", flag: "--show-toplevel"}:                    "local dispatch resolves explicit repository candidates",
+		{source: "dispatch_wizard.go:resolveGitTopLevel", flag: "--show-toplevel"}:                      "dispatch discovery resolves explicit repository candidates",
+		{source: "gitdir/gitdir.go:CommonDir", flag: "--git-common-dir"}:                                "session removes the current-worktree resolver in the session split",
+		{source: "gitdir/gitdir.go:CommonDirForWorktree", flag: "--git-common-dir"}:                     "session removes the explicit-worktree resolver in the session split",
+		{source: "paths/paths.go:resolveWorktreeRoot", flag: "--show-toplevel"}:                         "worktree-root discovery remains separate from explicit-root metadata resolution",
+		{source: "session_adopt.go:stateStoreForWorktree", flag: "--git-common-dir"}:                    "adoption validates an arbitrary source repository in the session split",
+		{source: "session_adopt.go:stateStoreForWorktree", flag: "--show-toplevel"}:                     "adoption validates an arbitrary source repository in the session split",
+		{source: "settings/settings.go:clonePreferencesPathForWorktreeRoot", flag: "--git-common-dir"}:  "settings migrates with the remaining consumers",
+		{source: "strategy/common.go:GetGitCommonDir", flag: "--git-common-dir"}:                        "strategy migrates in the strategy-and-hooks split",
+		{source: "strategy/hooks.go:getGitDirInPath", flag: "--git-dir"}:                                "hook directory discovery migrates in the strategy-and-hooks split",
+		{source: "strategy/manual_commit_session.go:gitCommonDirForWorktree", flag: "--git-common-dir"}: "session routing migrates in the strategy-and-hooks split",
+		{source: "strategy/metadata_reconcile.go:loadShallowHashes", flag: "--git-common-dir"}:          "shallow metadata access migrates in the strategy-and-hooks split",
+		{source: "trail_checkout_worktree.go:gitCommonDirForTrailWorktree", flag: "--git-common-dir"}:   "trail storage paths migrate with the remaining consumers",
+		{source: "trail_checkout_worktree.go:validateTrailWorktreeReuse", flag: "--git-common-dir"}:     "trail reuse validation migrates with the remaining consumers",
+		{source: "trail_checkout_worktree.go:validateTrailWorktreeReuse", flag: "--show-toplevel"}:      "trail reuse validation migrates with the remaining consumers",
 	}
 	allowedLegacyResolverCalls := map[string]string{
 		"agent/codex/hook_root.go:resolveHookDiscovery": "Codex discovery migrates with the remaining consumers",
@@ -49,28 +57,76 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 	if !ok {
 		t.Fatal("resolve guard source path")
 	}
-	cliRoot := filepath.Dir(filepath.Dir(thisFile))
-	fset := token.NewFileSet()
-	canonicalTokens := 0
-	legacyOwnersSeen := map[string]bool{}
-	policyInspectionsSeen := map[string]bool{}
-	commonDirQueriesSeen := map[string]bool{}
-	legacyResolverCallsSeen := map[string]bool{}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", "..", ".."))
+	policy := gitMetadataGuardPolicy{
+		legacyTraversalOwners:   legacyTraversalOwners,
+		policyDotGitInspections: policyDotGitInspections,
+		allowedMetadataQueries:  allowedMetadataQueries,
+		allowedLegacyCalls:      allowedLegacyResolverCalls,
+	}
+	result, err := scanGitMetadataSources(repoRoot, policy)
+	if err != nil {
+		t.Fatalf("scan Go sources: %v", err)
+	}
+	for _, violation := range result.violations {
+		t.Error(violation)
+	}
+	if result.canonicalTokens < 2 {
+		t.Fatal("guard found no canonical gitdir/commondir parser tokens")
+	}
+	assertGuardLedgerSeen(t, "legacy traversal owner", legacyTraversalOwners, result.legacyOwnersSeen)
+	assertGuardLedgerSeen(t, ".git policy inspection", policyDotGitInspections, result.policyInspectionsSeen)
+	assertMetadataQueryLedgerSeen(t, allowedMetadataQueries, result.metadataQueriesSeen)
+	assertGuardLedgerSeen(t, "legacy resolver call", allowedLegacyResolverCalls, result.legacyResolverCallsSeen)
+}
 
-	err := filepath.WalkDir(cliRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+type guardMetadataQuery struct {
+	source string
+	flag   string
+}
+
+type gitMetadataGuardPolicy struct {
+	legacyTraversalOwners   map[string]string
+	policyDotGitInspections map[string]string
+	allowedMetadataQueries  map[guardMetadataQuery]string
+	allowedLegacyCalls      map[string]string
+}
+
+type gitMetadataGuardResult struct {
+	canonicalTokens         int
+	legacyOwnersSeen        map[string]bool
+	policyInspectionsSeen   map[string]bool
+	metadataQueriesSeen     map[guardMetadataQuery]bool
+	legacyResolverCallsSeen map[string]bool
+	violations              []string
+}
+
+func scanGitMetadataSources(repoRoot string, policy gitMetadataGuardPolicy) (gitMetadataGuardResult, error) {
+	packageValues, err := collectGuardPackageStringValues(repoRoot)
+	if err != nil {
+		return gitMetadataGuardResult{}, fmt.Errorf("collect package string values: %w", err)
+	}
+	fset := token.NewFileSet()
+	result := gitMetadataGuardResult{
+		legacyOwnersSeen:        map[string]bool{},
+		policyInspectionsSeen:   map[string]bool{},
+		metadataQueriesSeen:     map[guardMetadataQuery]bool{},
+		legacyResolverCallsSeen: map[string]bool{},
+	}
+
+	err = filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
 		if entry.IsDir() {
 			return nil
 		}
-		rel, err := filepath.Rel(cliRoot, path)
+		rel, err := filepath.Rel(repoRoot, path)
 		if err != nil {
 			return err
 		}
 		rel = filepath.ToSlash(rel)
-		if !strings.HasSuffix(rel, ".go") || strings.HasSuffix(rel, "_test.go") ||
-			strings.HasPrefix(rel, "integration_test/") || strings.HasPrefix(rel, "benchutil/") {
+		if !isGuardSourceFile(rel) {
 			return nil
 		}
 
@@ -78,114 +134,146 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		dotGitIdentifiers := metadataStringIdentifiers(file, ".git")
-		dotGitIdentifiers["gitDir"] = true
+		values := packageValues[guardPackageKey(rel, file)]
+		valueResolver := newGuardValueResolver(fset, file, values)
 		gitrepoImports, dotImportedGitrepo := gitrepoImportNames(file)
-		filesystemImports := filesystemImportNames(file)
+		samePackage := filepath.ToSlash(filepath.Dir(rel)) == "cmd/entire/cli/gitrepo"
 		for _, decl := range file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
 			if !ok || fn.Body == nil {
 				continue
 			}
-			key := rel + ":" + fn.Name.Name
-			canonicalOwner := rel == "gitrepo/metadata.go"
-			_, legacyOwner := legacyTraversalOwners[key]
-			_, policyInspection := policyDotGitInspections[key]
+			key := guardSourceKey(rel, fn.Name.Name)
+			canonicalOwner := guardSourcePath(rel) == "gitrepo/metadata.go"
+			_, legacyOwner := policy.legacyTraversalOwners[key]
+			_, policyInspection := policy.policyDotGitInspections[key]
 
-			hasDotGitReference := containsMetadataString(fn.Body, ".git") || containsAnyIdentifier(fn.Body, dotGitIdentifiers)
-			ast.Inspect(fn.Body, func(node ast.Node) bool {
-				switch n := node.(type) {
-				case *ast.BasicLit:
-					if n.Kind != token.STRING {
-						return true
-					}
-					value, unquoteErr := strconv.Unquote(n.Value)
-					if unquoteErr != nil {
-						return true
-					}
-					if value == "--git-common-dir" {
-						if _, allowed := allowedCommonDirQueries[key]; allowed {
-							commonDirQueriesSeen[key] = true
-						} else {
-							t.Errorf("%s runs an unaudited --git-common-dir query; use gitrepo.ResolveWorktreeMetadata or document a semantic-query exception", fset.Position(n.Pos()))
-						}
-					}
-					if value != "gitdir: " && value != "gitdir:" && value != "commondir" {
-						return true
-					}
-					if canonicalOwner {
-						canonicalTokens++
-						return true
-					}
-					if legacyOwner {
-						legacyOwnersSeen[key] = true
-					} else {
-						t.Errorf("%s independently parses Git metadata token %q; use gitrepo.ResolveWorktreeMetadata", fset.Position(n.Pos()), value)
-					}
-				case *ast.CallExpr:
-					if isLegacyMetadataResolverCall(n, gitrepoImports, dotImportedGitrepo) {
-						if _, allowed := allowedLegacyResolverCalls[key]; allowed {
-							legacyResolverCallsSeen[key] = true
-						} else {
-							t.Errorf("%s calls a legacy Git metadata resolver; use gitrepo.ResolveWorktreeMetadata or document the migration exception", fset.Position(n.Pos()))
-						}
-					}
-					callHasDotGitReference := containsMetadataString(n, ".git") || containsAnyIdentifier(n, dotGitIdentifiers)
-					packageInspection := hasDotGitReference && isPackageFilesystemInspection(n, filesystemImports)
-					if (!callHasDotGitReference && !packageInspection) || !isFilesystemMetadataInspection(n) || canonicalOwner {
-						return true
-					}
-					if legacyOwner {
-						legacyOwnersSeen[key] = true
-						return true
-					}
-					if policyInspection {
-						policyInspectionsSeen[key] = true
-						return true
-					}
-					t.Errorf("%s independently inspects a .git entry; use gitrepo.ResolveWorktreeMetadata or document a narrow policy exception", fset.Position(n.Pos()))
+			for _, value := range []string{"gitdir: ", "gitdir:", "commondir"} {
+				if !valueResolver.contains(fn.Body, value) {
+					continue
 				}
+				if canonicalOwner {
+					result.canonicalTokens++
+					continue
+				}
+				if legacyOwner {
+					result.legacyOwnersSeen[key] = true
+					continue
+				}
+				result.violations = append(result.violations, fmt.Sprintf("%s independently parses Git metadata token %q; use gitrepo.ResolveWorktreeMetadata", fset.Position(fn.Pos()), value))
+			}
+			if valueResolver.contains(fn.Body, "rev-parse") {
+				for _, flag := range []string{"--absolute-git-dir", "--git-common-dir", "--git-dir", "--show-toplevel"} {
+					if !valueResolver.contains(fn.Body, flag) {
+						continue
+					}
+					query := guardMetadataQuery{source: key, flag: flag}
+					if _, allowed := policy.allowedMetadataQueries[query]; allowed {
+						result.metadataQueriesSeen[query] = true
+					} else {
+						result.violations = append(result.violations, fmt.Sprintf("%s runs an unaudited git rev-parse %s query; use gitrepo.ResolveWorktreeMetadata or document a semantic-query exception", fset.Position(fn.Pos()), flag))
+					}
+				}
+			}
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if isLegacyMetadataResolverCall(call, gitrepoImports, dotImportedGitrepo, samePackage) {
+					if _, allowed := policy.allowedLegacyCalls[key]; allowed {
+						result.legacyResolverCallsSeen[key] = true
+					} else {
+						result.violations = append(result.violations, fmt.Sprintf("%s calls a legacy Git metadata resolver; use gitrepo.ResolveWorktreeMetadata or document the migration exception", fset.Position(call.Pos())))
+					}
+				}
+				if !valueResolver.contains(call, ".git") || !isFilesystemMetadataInspection(call) || canonicalOwner {
+					return true
+				}
+				if legacyOwner {
+					result.legacyOwnersSeen[key] = true
+					return true
+				}
+				if policyInspection {
+					result.policyInspectionsSeen[key] = true
+					return true
+				}
+				result.violations = append(result.violations, fmt.Sprintf("%s independently inspects a .git entry; use gitrepo.ResolveWorktreeMetadata or document a narrow policy exception", fset.Position(call.Pos())))
 				return true
 			})
 		}
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("scan Go sources: %v", err)
-	}
-	if canonicalTokens < 2 {
-		t.Fatal("guard found no canonical gitdir/commondir parser tokens")
-	}
-	assertGuardLedgerSeen(t, "legacy traversal owner", legacyTraversalOwners, legacyOwnersSeen)
-	assertGuardLedgerSeen(t, ".git policy inspection", policyDotGitInspections, policyInspectionsSeen)
-	assertGuardLedgerSeen(t, "--git-common-dir query", allowedCommonDirQueries, commonDirQueriesSeen)
-	assertGuardLedgerSeen(t, "legacy resolver call", allowedLegacyResolverCalls, legacyResolverCallsSeen)
+	return result, err
 }
 
 func TestGitMetadataGuardRecognizesBypassForms(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		source     string
-		wantLegacy bool
+		name        string
+		source      string
+		kind        string
+		value       string
+		samePackage bool
+		want        bool
 	}{
 		{
-			name:   "rooted filesystem",
-			source: `package probe; import "os"; func inspect(root *os.Root) { _, _ = root.Lstat(".git") }`,
+			name:   "rooted filesystem with local alias",
+			source: `package probe; import "os"; func inspect(root *os.Root) { name := ".git"; _, _ = root.Lstat(name) }`,
+			kind:   "filesystem",
+			want:   true,
 		},
 		{
 			name:   "package constant",
 			source: `package probe; import "os"; const dotGitName = ".git"; func inspect() { _, _ = os.Stat(dotGitName) }`,
+			kind:   "filesystem",
+			want:   true,
+		},
+		{
+			name:   "open root",
+			source: `package probe; import "os"; func inspect() { _, _ = os.OpenRoot(".git") }`,
+			kind:   "filesystem",
+			want:   true,
 		},
 		{
 			name:   "readlink",
 			source: `package probe; import "os"; func inspect() { _, _ = os.Readlink(".git") }`,
+			kind:   "filesystem",
+			want:   true,
 		},
 		{
-			name:       "aliased legacy resolver import",
-			source:     `package probe; import repo "github.com/entireio/cli/cmd/entire/cli/gitrepo"; func inspect() { _, _ = repo.ResolveDotGitPath(".") }`,
-			wantLegacy: true,
+			name:   "package parser token",
+			source: `package probe; import "strings"; const prefix = "gitdir: "; func inspect(data string) { _, _ = strings.CutPrefix(data, prefix) }`,
+			kind:   "token",
+			value:  "gitdir: ",
+			want:   true,
+		},
+		{
+			name:   "absolute git directory query",
+			source: `package probe; import "os/exec"; const flag = "--absolute-git-dir"; func inspect() { _ = exec.Command("git", "rev-parse", flag) }`,
+			kind:   "query",
+			value:  "--absolute-git-dir",
+			want:   true,
+		},
+		{
+			name:   "aliased legacy resolver import",
+			source: `package probe; import repo "github.com/entireio/cli/cmd/entire/cli/gitrepo"; func inspect() { _, _ = repo.ResolveDotGitPath(".") }`,
+			kind:   "legacy",
+			want:   true,
+		},
+		{
+			name:        "same-package legacy resolver",
+			source:      `package gitrepo; func inspect() { _, _ = ResolveDotGitPath(".") }`,
+			kind:        "legacy",
+			samePackage: true,
+			want:        true,
+		},
+		{
+			name:   "git directory parameter is not metadata traversal",
+			source: `package probe; import "os"; func inspect(gitDir string) { _, _ = os.Stat(gitDir) }`,
+			kind:   "filesystem",
+			want:   false,
 		},
 	}
 
@@ -197,8 +285,8 @@ func TestGitMetadataGuardRecognizesBypassForms(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parse probe: %v", err)
 			}
-			identifiers := metadataStringIdentifiers(file, ".git")
-			identifiers["gitDir"] = true
+			values := packageStringValues(file)
+			valueResolver := newGuardValueResolver(fset, file, values)
 			imports, dotImported := gitrepoImportNames(file)
 			found := false
 			for _, decl := range file.Decls {
@@ -206,24 +294,78 @@ func TestGitMetadataGuardRecognizesBypassForms(t *testing.T) {
 				if !ok || fn.Body == nil {
 					continue
 				}
-				hasDotGitReference := containsMetadataString(fn.Body, ".git") || containsAnyIdentifier(fn.Body, identifiers)
+				switch tt.kind {
+				case "token":
+					found = valueResolver.contains(fn.Body, tt.value)
+				case "query":
+					found = valueResolver.contains(fn.Body, "rev-parse") &&
+						valueResolver.contains(fn.Body, tt.value)
+				}
 				ast.Inspect(fn.Body, func(node ast.Node) bool {
 					call, ok := node.(*ast.CallExpr)
 					if !ok {
 						return true
 					}
-					if tt.wantLegacy {
-						found = found || isLegacyMetadataResolverCall(call, imports, dotImported)
-					} else {
-						found = found || hasDotGitReference && isFilesystemMetadataInspection(call)
+					switch tt.kind {
+					case "legacy":
+						found = found || isLegacyMetadataResolverCall(call, imports, dotImported, tt.samePackage)
+					case "filesystem":
+						found = found || valueResolver.contains(call, ".git") && isFilesystemMetadataInspection(call)
 					}
 					return true
 				})
 			}
-			if !found {
-				t.Fatal("guard did not recognize probe")
+			if found != tt.want {
+				t.Fatalf("guard recognition = %t, want %t", found, tt.want)
 			}
 		})
+	}
+}
+
+func TestGitMetadataGuardScansCompleteRepository(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeGuardSource(t, repoRoot, "probe/tokens.go", `package probe; const dotGitName = ".git"`)
+	writeGuardSource(t, repoRoot, "probe/use.go", `package probe; import "os"; func crossFileConstant() { _, _ = os.Stat(dotGitName) }`)
+	writeGuardSource(t, repoRoot, "internal/probe/probe.go", `package probe; import "os"; func internalReadlink() { _, _ = os.Readlink(".git") }`)
+	writeGuardSource(t, repoRoot, "probe/shadow.go", `package probe; import "os"; func shadowed(gitDir string) { _, _ = os.Stat(gitDir) }`)
+	writeGuardSource(t, repoRoot, "probe/query.go", `package probe; import "os/exec"; func existingException() { _ = exec.Command("git", "rev-parse", "--show-toplevel", "--git-dir") }`)
+
+	allowedQuery := guardMetadataQuery{source: "probe/query.go:existingException", flag: "--show-toplevel"}
+	result, err := scanGitMetadataSources(repoRoot, gitMetadataGuardPolicy{
+		allowedMetadataQueries: map[guardMetadataQuery]string{allowedQuery: "fixture exception"},
+	})
+	if err != nil {
+		t.Fatalf("scan fixture repository: %v", err)
+	}
+	if !result.metadataQueriesSeen[allowedQuery] {
+		t.Fatal("scanner did not observe the exact allowed metadata query")
+	}
+	if len(result.violations) != 3 {
+		t.Fatalf("violations = %d, want 3:\n%s", len(result.violations), strings.Join(result.violations, "\n"))
+	}
+	violations := strings.Join(result.violations, "\n")
+	for _, want := range []string{"probe/use.go", "internal/probe/probe.go", "--git-dir"} {
+		if !strings.Contains(violations, want) {
+			t.Errorf("violations do not contain %q:\n%s", want, violations)
+		}
+	}
+	for _, notWant := range []string{"probe/shadow.go", "--show-toplevel"} {
+		if strings.Contains(violations, notWant) {
+			t.Errorf("violations unexpectedly contain %q:\n%s", notWant, violations)
+		}
+	}
+}
+
+func writeGuardSource(t *testing.T, repoRoot, rel, source string) {
+	t.Helper()
+	path := filepath.Join(repoRoot, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatalf("write fixture source: %v", err)
 	}
 }
 
@@ -233,15 +375,49 @@ func isFilesystemMetadataInspection(call *ast.CallExpr) bool {
 		return false
 	}
 	switch selector.Sel.Name {
-	case "Lstat", "Open", "OpenFile", "ReadDir", "ReadFile", "Readlink", "Stat":
+	case "DirFS", "Lstat", "Open", "OpenFile", "OpenInRoot", "OpenRoot", "ReadDir", "ReadFile", "Readlink", "Stat":
 		return true
 	default:
 		return false
 	}
 }
 
-func metadataStringIdentifiers(file *ast.File, want string) map[string]bool {
-	identifiers := map[string]bool{}
+func collectGuardPackageStringValues(repoRoot string) (map[string]map[string]string, error) {
+	values := map[string]map[string]string{}
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if !isGuardSourceFile(rel) {
+			return nil
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		key := guardPackageKey(rel, file)
+		if values[key] == nil {
+			values[key] = map[string]string{}
+		}
+		for name, value := range packageStringValues(file) {
+			values[key][name] = value
+		}
+		return nil
+	})
+	return values, err
+}
+
+func packageStringValues(file *ast.File) map[string]string {
+	values := map[string]string{}
 	for _, decl := range file.Decls {
 		gen, ok := decl.(*ast.GenDecl)
 		if !ok {
@@ -252,19 +428,19 @@ func metadataStringIdentifiers(file *ast.File, want string) map[string]bool {
 			if !ok {
 				continue
 			}
-			for i, value := range valueSpec.Values {
-				literal, ok := value.(*ast.BasicLit)
-				if !ok || literal.Kind != token.STRING {
+			for i, expr := range valueSpec.Values {
+				literal, ok := expr.(*ast.BasicLit)
+				if !ok || literal.Kind != token.STRING || i >= len(valueSpec.Names) {
 					continue
 				}
 				unquoted, err := strconv.Unquote(literal.Value)
-				if err == nil && unquoted == want && i < len(valueSpec.Names) {
-					identifiers[valueSpec.Names[i].Name] = true
+				if err == nil {
+					values[valueSpec.Names[i].Name] = unquoted
 				}
 			}
 		}
 	}
-	return identifiers
+	return values
 }
 
 func gitrepoImportNames(file *ast.File) (map[string]bool, bool) {
@@ -287,38 +463,12 @@ func gitrepoImportNames(file *ast.File) (map[string]bool, bool) {
 	return names, dotImported
 }
 
-func filesystemImportNames(file *ast.File) map[string]bool {
-	names := map[string]bool{}
-	for _, spec := range file.Imports {
-		path, err := strconv.Unquote(spec.Path.Value)
-		if err != nil || (path != "os" && path != "io/fs") || (spec.Name != nil && spec.Name.Name == "_") {
-			continue
-		}
-		switch {
-		case spec.Name == nil:
-			names[filepath.Base(path)] = true
-		case spec.Name.Name != ".":
-			names[spec.Name.Name] = true
-		}
-	}
-	return names
-}
-
-func isPackageFilesystemInspection(call *ast.CallExpr, importNames map[string]bool) bool {
-	selector, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return false
-	}
-	pkg, ok := selector.X.(*ast.Ident)
-	return ok && importNames[pkg.Name]
-}
-
-func isLegacyMetadataResolverCall(call *ast.CallExpr, importNames map[string]bool, dotImported bool) bool {
+func isLegacyMetadataResolverCall(call *ast.CallExpr, importNames map[string]bool, dotImported, samePackage bool) bool {
 	legacyName := func(name string) bool {
 		return name == "ResolveDotGitPath" || name == "ResolveCommonGitPath"
 	}
 	if ident, ok := call.Fun.(*ast.Ident); ok {
-		return dotImported && legacyName(ident.Name)
+		return (dotImported || samePackage) && legacyName(ident.Name)
 	}
 	selector, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || !legacyName(selector.Sel.Name) {
@@ -337,32 +487,152 @@ func assertGuardLedgerSeen(t *testing.T, label string, ledger map[string]string,
 	}
 }
 
-func containsMetadataString(node ast.Node, want string) bool {
-	found := false
-	ast.Inspect(node, func(n ast.Node) bool {
-		literal, ok := n.(*ast.BasicLit)
-		if !ok || literal.Kind != token.STRING {
-			return true
+func assertMetadataQueryLedgerSeen(t *testing.T, ledger map[guardMetadataQuery]string, seen map[guardMetadataQuery]bool) {
+	t.Helper()
+	for query, reason := range ledger {
+		if !seen[query] {
+			t.Errorf("documented git metadata query %s %s (%s) no longer exists; remove or update the exception", query.source, query.flag, reason)
 		}
-		value, err := strconv.Unquote(literal.Value)
-		if err == nil && value == want {
-			found = true
-			return false
+	}
+}
+
+type guardValueResolver struct {
+	packageValues map[string]string
+	typeInfo      *types.Info
+	bindings      map[types.Object]ast.Expr
+}
+
+func newGuardValueResolver(fset *token.FileSet, file *ast.File, packageValues map[string]string) guardValueResolver {
+	typeInfo := &types.Info{
+		Defs: map[*ast.Ident]types.Object{},
+		Uses: map[*ast.Ident]types.Object{},
+	}
+	config := types.Config{Error: func(error) {}}
+	_, typeErr := config.Check(file.Name.Name, fset, []*ast.File{file}, typeInfo)
+	// Files are checked in isolation, so unresolved cross-file imports are
+	// expected; local definitions collected before that error remain usable.
+	if typeErr != nil && len(typeInfo.Defs) == 0 && len(typeInfo.Uses) == 0 {
+		return guardValueResolver{packageValues: packageValues, typeInfo: typeInfo}
+	}
+	return guardValueResolver{
+		packageValues: packageValues,
+		typeInfo:      typeInfo,
+		bindings:      guardValueBindings(file, typeInfo),
+	}
+}
+
+func guardValueBindings(file *ast.File, typeInfo *types.Info) map[types.Object]ast.Expr {
+	bindings := map[types.Object]ast.Expr{}
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch decl := node.(type) {
+		case *ast.ValueSpec:
+			for i, name := range decl.Names {
+				if object := typeInfo.Defs[name]; object != nil {
+					bindings[object] = expressionAt(decl.Values, i)
+				}
+			}
+		case *ast.AssignStmt:
+			if decl.Tok != token.DEFINE {
+				return true
+			}
+			for i, lhs := range decl.Lhs {
+				name, ok := lhs.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				if object := typeInfo.Defs[name]; object != nil {
+					bindings[object] = expressionAt(decl.Rhs, i)
+				}
+			}
 		}
 		return true
+	})
+	return bindings
+}
+
+func expressionAt(expressions []ast.Expr, index int) ast.Expr {
+	if index < len(expressions) {
+		return expressions[index]
+	}
+	if len(expressions) == 1 {
+		return expressions[0]
+	}
+	return nil
+}
+
+func (r guardValueResolver) contains(node ast.Node, want string) bool {
+	return r.containsSeen(node, want, map[types.Object]bool{})
+}
+
+func (r guardValueResolver) containsSeen(node ast.Node, want string, seen map[types.Object]bool) bool {
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch value := n.(type) {
+		case *ast.BasicLit:
+			if value.Kind != token.STRING {
+				return true
+			}
+			unquoted, err := strconv.Unquote(value.Value)
+			if err == nil && unquoted == want {
+				found = true
+				return false
+			}
+		case *ast.Ident:
+			object := r.typeInfo.Uses[value]
+			if object == nil {
+				object = r.typeInfo.Defs[value]
+			}
+			if object == nil {
+				if r.packageValues[value.Name] == want {
+					found = true
+				}
+				return false
+			}
+			if seen[object] {
+				return false
+			}
+			expr := r.bindings[object]
+			if expr == nil {
+				return false
+			}
+			seen[object] = true
+			if r.containsSeen(expr, want, seen) {
+				found = true
+			}
+			delete(seen, object)
+			return false
+		}
+		return !found
 	})
 	return found
 }
 
-func containsAnyIdentifier(node ast.Node, want map[string]bool) bool {
-	found := false
-	ast.Inspect(node, func(n ast.Node) bool {
-		ident, ok := n.(*ast.Ident)
-		if ok && want[ident.Name] {
-			found = true
+func guardPackageKey(rel string, file *ast.File) string {
+	return filepath.ToSlash(filepath.Dir(rel)) + ":" + file.Name.Name
+}
+
+func guardSourceKey(rel, function string) string {
+	return guardSourcePath(rel) + ":" + function
+}
+
+func guardSourcePath(rel string) string {
+	return strings.TrimPrefix(filepath.ToSlash(rel), "cmd/entire/cli/")
+}
+
+func isGuardSourceFile(rel string) bool {
+	rel = filepath.ToSlash(rel)
+	if !strings.HasSuffix(rel, ".go") || strings.HasSuffix(rel, "_test.go") {
+		return false
+	}
+	for _, prefix := range []string{
+		"cmd/entire/cli/agent/testutil/",
+		"cmd/entire/cli/benchutil/",
+		"cmd/entire/cli/integration_test/",
+		"e2e/",
+	} {
+		if strings.HasPrefix(rel, prefix) {
 			return false
 		}
-		return true
-	})
-	return found
+	}
+	return true
 }

--- a/cmd/entire/cli/gitrepo/metadata_guard_test.go
+++ b/cmd/entire/cli/gitrepo/metadata_guard_test.go
@@ -16,28 +16,33 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 	t.Parallel()
 
 	legacyTraversalOwners := map[string]string{
-		"gitrepo/repository.go:resolveDotGitPath":    "Codex still uses the exported legacy resolver until GMT-005",
-		"gitrepo/repository.go:resolveCommonGitPath": "Codex still uses the exported legacy resolver until GMT-005",
-		"paths/worktree.go:GetWorktreeID":            "worktree-ID consumers migrate across GMT-003 through GMT-005",
-		"status.go:resolveWorktreeBranch":            "status migrates in GMT-005",
+		"gitrepo/repository.go:resolveDotGitPath":    "Codex still uses the exported legacy resolver until the remaining-consumer split",
+		"gitrepo/repository.go:resolveCommonGitPath": "Codex still uses the exported legacy resolver until the remaining-consumer split",
+		"paths/worktree.go:GetWorktreeID":            "worktree-ID consumers migrate with session and the remaining consumers",
+		"status.go:resolveWorktreeBranch":            "status migrates with the remaining consumers",
 	}
 	policyDotGitInspections := map[string]string{
 		"agent/codex/hook_root.go:hasDotGitEntry":                    "Codex policy checks whether a candidate checkout owns a .git entry",
 		"agent/codex/hook_root.go:linkedWorktreeRegistrationMatches": "Codex backlink policy validates the registered worktree path",
 		"dispatch_wizard.go:discoverLocalRepoRoots":                  "dispatch discovery filters sibling repository candidates",
 		"gitrepo/status.go:insideNestedCheckout":                     "status walking stops at nested checkout boundaries",
+		"plugin_index.go:SyncPluginIndex":                            "plugin index sync checks whether Entire's cache directory contains its clone",
 	}
 	allowedCommonDirQueries := map[string]string{
-		"checkpoint/git_common_dir.go:resolveGitCommonDir":          "checkpoint migrates in GMT-002",
-		"gitdir/gitdir.go:CommonDir":                                "session removes the current-worktree resolver in GMT-003",
-		"gitdir/gitdir.go:CommonDirForWorktree":                     "session removes the explicit-worktree resolver in GMT-003",
-		"session_adopt.go:stateStoreForWorktree":                    "adoption validates an arbitrary source repository in GMT-003",
-		"settings/settings.go:clonePreferencesPathForWorktreeRoot":  "settings migrates in GMT-005",
-		"strategy/common.go:GetGitCommonDir":                        "strategy migrates in GMT-004",
-		"strategy/manual_commit_session.go:gitCommonDirForWorktree": "session routing compares explicit repositories in GMT-004",
-		"strategy/metadata_reconcile.go:loadShallowHashes":          "shallow metadata access migrates in GMT-004",
-		"trail_checkout_worktree.go:gitCommonDirForTrailWorktree":   "trail storage paths migrate in GMT-005",
-		"trail_checkout_worktree.go:validateTrailWorktreeReuse":     "trail reuse validates repository identity in GMT-005",
+		"checkpoint/git_common_dir.go:resolveGitCommonDir":          "checkpoint migrates in the checkpoint split",
+		"gitdir/gitdir.go:CommonDir":                                "session removes the current-worktree resolver in the session split",
+		"gitdir/gitdir.go:CommonDirForWorktree":                     "session removes the explicit-worktree resolver in the session split",
+		"session_adopt.go:stateStoreForWorktree":                    "adoption validates an arbitrary source repository in the session split",
+		"settings/settings.go:clonePreferencesPathForWorktreeRoot":  "settings migrates with the remaining consumers",
+		"strategy/common.go:GetGitCommonDir":                        "strategy migrates in the strategy-and-hooks split",
+		"strategy/manual_commit_session.go:gitCommonDirForWorktree": "session routing migrates in the strategy-and-hooks split",
+		"strategy/metadata_reconcile.go:loadShallowHashes":          "shallow metadata access migrates in the strategy-and-hooks split",
+		"trail_checkout_worktree.go:gitCommonDirForTrailWorktree":   "trail storage paths migrate with the remaining consumers",
+		"trail_checkout_worktree.go:validateTrailWorktreeReuse":     "trail reuse validation migrates with the remaining consumers",
+	}
+	allowedLegacyResolverCalls := map[string]string{
+		"agent/codex/hook_root.go:resolveHookDiscovery": "Codex discovery migrates with the remaining consumers",
+		"agent/codex/hook_root.go:rootOwnsGitDir":       "Codex ownership policy migrates with the remaining consumers",
 	}
 
 	_, thisFile, _, ok := runtime.Caller(0)
@@ -47,6 +52,10 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 	cliRoot := filepath.Dir(filepath.Dir(thisFile))
 	fset := token.NewFileSet()
 	canonicalTokens := 0
+	legacyOwnersSeen := map[string]bool{}
+	policyInspectionsSeen := map[string]bool{}
+	commonDirQueriesSeen := map[string]bool{}
+	legacyResolverCallsSeen := map[string]bool{}
 
 	err := filepath.WalkDir(cliRoot, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -69,6 +78,10 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		dotGitIdentifiers := metadataStringIdentifiers(file, ".git")
+		dotGitIdentifiers["gitDir"] = true
+		gitrepoImports, dotImportedGitrepo := gitrepoImportNames(file)
+		filesystemImports := filesystemImportNames(file)
 		for _, decl := range file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
 			if !ok || fn.Body == nil {
@@ -79,7 +92,7 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 			_, legacyOwner := legacyTraversalOwners[key]
 			_, policyInspection := policyDotGitInspections[key]
 
-			hasDotGitReference := containsMetadataString(fn.Body, ".git") || containsIdentifier(fn.Body, "gitDir")
+			hasDotGitReference := containsMetadataString(fn.Body, ".git") || containsAnyIdentifier(fn.Body, dotGitIdentifiers)
 			ast.Inspect(fn.Body, func(node ast.Node) bool {
 				switch n := node.(type) {
 				case *ast.BasicLit:
@@ -91,7 +104,9 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 						return true
 					}
 					if value == "--git-common-dir" {
-						if _, allowed := allowedCommonDirQueries[key]; !allowed {
+						if _, allowed := allowedCommonDirQueries[key]; allowed {
+							commonDirQueriesSeen[key] = true
+						} else {
 							t.Errorf("%s runs an unaudited --git-common-dir query; use gitrepo.ResolveWorktreeMetadata or document a semantic-query exception", fset.Position(n.Pos()))
 						}
 					}
@@ -102,11 +117,30 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 						canonicalTokens++
 						return true
 					}
-					if !legacyOwner {
+					if legacyOwner {
+						legacyOwnersSeen[key] = true
+					} else {
 						t.Errorf("%s independently parses Git metadata token %q; use gitrepo.ResolveWorktreeMetadata", fset.Position(n.Pos()), value)
 					}
 				case *ast.CallExpr:
-					if !hasDotGitReference || !isOSMetadataInspection(n) || canonicalOwner || legacyOwner || policyInspection {
+					if isLegacyMetadataResolverCall(n, gitrepoImports, dotImportedGitrepo) {
+						if _, allowed := allowedLegacyResolverCalls[key]; allowed {
+							legacyResolverCallsSeen[key] = true
+						} else {
+							t.Errorf("%s calls a legacy Git metadata resolver; use gitrepo.ResolveWorktreeMetadata or document the migration exception", fset.Position(n.Pos()))
+						}
+					}
+					callHasDotGitReference := containsMetadataString(n, ".git") || containsAnyIdentifier(n, dotGitIdentifiers)
+					packageInspection := hasDotGitReference && isPackageFilesystemInspection(n, filesystemImports)
+					if (!callHasDotGitReference && !packageInspection) || !isFilesystemMetadataInspection(n) || canonicalOwner {
+						return true
+					}
+					if legacyOwner {
+						legacyOwnersSeen[key] = true
+						return true
+					}
+					if policyInspection {
+						policyInspectionsSeen[key] = true
 						return true
 					}
 					t.Errorf("%s independently inspects a .git entry; use gitrepo.ResolveWorktreeMetadata or document a narrow policy exception", fset.Position(n.Pos()))
@@ -122,22 +156,184 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 	if canonicalTokens < 2 {
 		t.Fatal("guard found no canonical gitdir/commondir parser tokens")
 	}
+	assertGuardLedgerSeen(t, "legacy traversal owner", legacyTraversalOwners, legacyOwnersSeen)
+	assertGuardLedgerSeen(t, ".git policy inspection", policyDotGitInspections, policyInspectionsSeen)
+	assertGuardLedgerSeen(t, "--git-common-dir query", allowedCommonDirQueries, commonDirQueriesSeen)
+	assertGuardLedgerSeen(t, "legacy resolver call", allowedLegacyResolverCalls, legacyResolverCallsSeen)
 }
 
-func isOSMetadataInspection(call *ast.CallExpr) bool {
+func TestGitMetadataGuardRecognizesBypassForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		source     string
+		wantLegacy bool
+	}{
+		{
+			name:   "rooted filesystem",
+			source: `package probe; import "os"; func inspect(root *os.Root) { _, _ = root.Lstat(".git") }`,
+		},
+		{
+			name:   "package constant",
+			source: `package probe; import "os"; const dotGitName = ".git"; func inspect() { _, _ = os.Stat(dotGitName) }`,
+		},
+		{
+			name:   "readlink",
+			source: `package probe; import "os"; func inspect() { _, _ = os.Readlink(".git") }`,
+		},
+		{
+			name:       "aliased legacy resolver import",
+			source:     `package probe; import repo "github.com/entireio/cli/cmd/entire/cli/gitrepo"; func inspect() { _, _ = repo.ResolveDotGitPath(".") }`,
+			wantLegacy: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "probe.go", tt.source, 0)
+			if err != nil {
+				t.Fatalf("parse probe: %v", err)
+			}
+			identifiers := metadataStringIdentifiers(file, ".git")
+			identifiers["gitDir"] = true
+			imports, dotImported := gitrepoImportNames(file)
+			found := false
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				hasDotGitReference := containsMetadataString(fn.Body, ".git") || containsAnyIdentifier(fn.Body, identifiers)
+				ast.Inspect(fn.Body, func(node ast.Node) bool {
+					call, ok := node.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					if tt.wantLegacy {
+						found = found || isLegacyMetadataResolverCall(call, imports, dotImported)
+					} else {
+						found = found || hasDotGitReference && isFilesystemMetadataInspection(call)
+					}
+					return true
+				})
+			}
+			if !found {
+				t.Fatal("guard did not recognize probe")
+			}
+		})
+	}
+}
+
+func isFilesystemMetadataInspection(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	switch selector.Sel.Name {
+	case "Lstat", "Open", "OpenFile", "ReadDir", "ReadFile", "Readlink", "Stat":
+		return true
+	default:
+		return false
+	}
+}
+
+func metadataStringIdentifiers(file *ast.File, want string) map[string]bool {
+	identifiers := map[string]bool{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, value := range valueSpec.Values {
+				literal, ok := value.(*ast.BasicLit)
+				if !ok || literal.Kind != token.STRING {
+					continue
+				}
+				unquoted, err := strconv.Unquote(literal.Value)
+				if err == nil && unquoted == want && i < len(valueSpec.Names) {
+					identifiers[valueSpec.Names[i].Name] = true
+				}
+			}
+		}
+	}
+	return identifiers
+}
+
+func gitrepoImportNames(file *ast.File) (map[string]bool, bool) {
+	names := map[string]bool{}
+	dotImported := false
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || path != "github.com/entireio/cli/cmd/entire/cli/gitrepo" {
+			continue
+		}
+		switch {
+		case spec.Name == nil:
+			names["gitrepo"] = true
+		case spec.Name.Name == ".":
+			dotImported = true
+		case spec.Name.Name != "_":
+			names[spec.Name.Name] = true
+		}
+	}
+	return names, dotImported
+}
+
+func filesystemImportNames(file *ast.File) map[string]bool {
+	names := map[string]bool{}
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || (path != "os" && path != "io/fs") || (spec.Name != nil && spec.Name.Name == "_") {
+			continue
+		}
+		switch {
+		case spec.Name == nil:
+			names[filepath.Base(path)] = true
+		case spec.Name.Name != ".":
+			names[spec.Name.Name] = true
+		}
+	}
+	return names
+}
+
+func isPackageFilesystemInspection(call *ast.CallExpr, importNames map[string]bool) bool {
 	selector, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return false
 	}
 	pkg, ok := selector.X.(*ast.Ident)
-	if !ok || pkg.Name != "os" {
+	return ok && importNames[pkg.Name]
+}
+
+func isLegacyMetadataResolverCall(call *ast.CallExpr, importNames map[string]bool, dotImported bool) bool {
+	legacyName := func(name string) bool {
+		return name == "ResolveDotGitPath" || name == "ResolveCommonGitPath"
+	}
+	if ident, ok := call.Fun.(*ast.Ident); ok {
+		return dotImported && legacyName(ident.Name)
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !legacyName(selector.Sel.Name) {
 		return false
 	}
-	switch selector.Sel.Name {
-	case "Lstat", "Open", "OpenFile", "ReadDir", "ReadFile", "Stat":
-		return true
-	default:
-		return false
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && importNames[pkg.Name]
+}
+
+func assertGuardLedgerSeen(t *testing.T, label string, ledger map[string]string, seen map[string]bool) {
+	t.Helper()
+	for key, reason := range ledger {
+		if !seen[key] {
+			t.Errorf("documented %s %s (%s) no longer exists; remove or update the exception", label, key, reason)
+		}
 	}
 }
 
@@ -158,11 +354,11 @@ func containsMetadataString(node ast.Node, want string) bool {
 	return found
 }
 
-func containsIdentifier(node ast.Node, want string) bool {
+func containsAnyIdentifier(node ast.Node, want map[string]bool) bool {
 	found := false
 	ast.Inspect(node, func(n ast.Node) bool {
 		ident, ok := n.(*ast.Ident)
-		if ok && ident.Name == want {
+		if ok && want[ident.Name] {
 			found = true
 			return false
 		}

--- a/cmd/entire/cli/gitrepo/metadata_test.go
+++ b/cmd/entire/cli/gitrepo/metadata_test.go
@@ -1,0 +1,581 @@
+package gitrepo
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const windowsOS = "windows"
+
+func TestResolveWorktreeMetadata_RealGitLayouts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ordinary repository", func(t *testing.T) {
+		t.Parallel()
+		root := filepath.Join(t.TempDir(), "ordinary")
+		initMetadataRepo(t, root)
+		assertMetadataMatchesGit(t, root, "")
+	})
+
+	t.Run("conventional linked worktree", func(t *testing.T) {
+		t.Parallel()
+		mainRoot, linkedRoot := conventionalMetadataWorktree(t, "linked")
+		metadata := assertMetadataMatchesGit(t, linkedRoot, "linked")
+		requireSameDirectory(t, filepath.Join(mainRoot, gitDir), metadata.CommonDir)
+		require.Equal(t, "../..\n", readMetadataFile(t, filepath.Join(metadata.GitDir, "commondir")))
+	})
+
+	t.Run("dot-bare worktrees", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		seed := filepath.Join(tmp, "seed")
+		layout := filepath.Join(tmp, "layout")
+		bare := filepath.Join(layout, ".bare")
+		linked := filepath.Join(layout, "dot-bare-linked")
+		initMetadataRepo(t, seed)
+		require.NoError(t, os.MkdirAll(layout, 0o750))
+		runMetadataGit(t, tmp, "clone", "--bare", seed, bare)
+		writeMetadataFile(t, filepath.Join(layout, gitDir), "gitdir: ./.bare\n")
+		runMetadataGit(t, tmp, "--git-dir", bare, "worktree", "add", "-b", "dot-bare-linked", linked)
+
+		metadata := assertMetadataMatchesGit(t, linked, "dot-bare-linked")
+		requireSameDirectory(t, bare, metadata.CommonDir)
+	})
+
+	t.Run("bare-backed linked worktree", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		seed := filepath.Join(tmp, "seed")
+		bare := filepath.Join(tmp, "arbitrary-storage")
+		linked := filepath.Join(tmp, "bare-linked")
+		initMetadataRepo(t, seed)
+		runMetadataGit(t, tmp, "clone", "--bare", seed, bare)
+		runMetadataGit(t, tmp, "--git-dir", bare, "worktree", "add", "-b", "bare-linked", linked)
+
+		metadata := assertMetadataMatchesGit(t, linked, "bare-linked")
+		requireSameDirectory(t, bare, metadata.CommonDir)
+	})
+
+	t.Run("separate Git directory", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		root := filepath.Join(tmp, "checkout")
+		storage := filepath.Join(tmp, "storage")
+		runMetadataGit(t, tmp, "init", "--separate-git-dir", storage, root)
+		configureMetadataRepo(t, root)
+		commitMetadataFile(t, root, "initial.txt", "initial\n")
+
+		metadata := assertMetadataMatchesGit(t, root, "")
+		requireSameDirectory(t, storage, metadata.GitDir)
+		requireSameDirectory(t, storage, metadata.CommonDir)
+	})
+
+	t.Run("ordinary and linked submodules", func(t *testing.T) {
+		t.Parallel()
+		ordinary, linked := metadataSubmoduleWorktrees(t)
+		assertMetadataMatchesGit(t, ordinary, "")
+		assertMetadataMatchesGit(t, linked, "linked-submodule")
+	})
+
+	t.Run("submodule in a linked superproject", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		subject := filepath.Join(tmp, "subject")
+		super := filepath.Join(tmp, "super")
+		linkedSuper := filepath.Join(tmp, "linked-super")
+		initMetadataRepo(t, subject)
+		initMetadataRepo(t, super)
+		runMetadataGit(t, super, "-c", "protocol.file.allow=always", "submodule", "add", subject, "sub")
+		runMetadataGit(t, super, "add", ".gitmodules", "sub")
+		runMetadataGit(t, super, "commit", "--no-gpg-sign", "-m", "add submodule")
+		runMetadataGit(t, super, "worktree", "add", "-b", "linked-super", linkedSuper)
+		runMetadataGit(t, linkedSuper, "-c", "protocol.file.allow=always", "submodule", "update", "--init")
+
+		assertMetadataMatchesGit(t, filepath.Join(linkedSuper, "sub"), "")
+	})
+
+	t.Run("relative gitdir pointer", func(t *testing.T) {
+		t.Parallel()
+		_, linked := conventionalMetadataWorktree(t, "relative-gitdir")
+		metadata := assertMetadataMatchesGit(t, linked, "relative-gitdir")
+		physicalLinked, err := filepath.EvalSymlinks(linked)
+		require.NoError(t, err)
+		relative, err := filepath.Rel(physicalLinked, metadata.GitDir)
+		require.NoError(t, err)
+		writeMetadataFile(t, filepath.Join(linked, gitDir), "gitdir: "+relative+"\n")
+
+		got := assertMetadataMatchesGit(t, linked, "relative-gitdir")
+		require.Equal(t, filepath.Clean(filepath.Join(linked, relative)), got.GitDir)
+	})
+
+	t.Run("symlink-aliased common directory", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == windowsOS {
+			t.Skip("symlink creation requires privileges on some Windows builders")
+		}
+		mainRoot, linked := conventionalMetadataWorktree(t, "aliased")
+		metadata := assertMetadataMatchesGit(t, linked, "aliased")
+		alias := filepath.Join(t.TempDir(), "common-alias")
+		require.NoError(t, os.Symlink(filepath.Join(mainRoot, gitDir), alias))
+		writeMetadataFile(t, filepath.Join(metadata.GitDir, "commondir"), alias+"\n")
+
+		got := assertMetadataMatchesGit(t, linked, "aliased")
+		require.Equal(t, alias, got.CommonDir)
+	})
+
+	t.Run("symlink-aliased worktree root", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == windowsOS {
+			t.Skip("symlink creation requires privileges on some Windows builders")
+		}
+		root := filepath.Join(t.TempDir(), "physical-root")
+		initMetadataRepo(t, root)
+		alias := filepath.Join(t.TempDir(), "root-alias")
+		require.NoError(t, os.Symlink(root, alias))
+
+		metadata, err := ResolveWorktreeMetadata(alias)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(alias, gitDir), metadata.GitDir)
+		require.Equal(t, filepath.Join(alias, gitDir), metadata.CommonDir)
+	})
+
+	t.Run("symlinked .git directory", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == windowsOS {
+			t.Skip("symlink creation requires privileges on some Windows builders")
+		}
+		tmp := t.TempDir()
+		root := filepath.Join(tmp, "checkout")
+		storage := filepath.Join(tmp, "storage")
+		initMetadataRepo(t, root)
+		require.NoError(t, os.Rename(filepath.Join(root, gitDir), storage))
+		require.NoError(t, os.Symlink(storage, filepath.Join(root, gitDir)))
+
+		metadata := assertMetadataMatchesGit(t, root, "")
+		require.Equal(t, filepath.Join(root, gitDir), metadata.GitDir)
+		require.Equal(t, filepath.Join(root, gitDir), metadata.CommonDir)
+	})
+}
+
+func TestResolveWorktreeMetadata_MovedRegistrationPreservesFacts(t *testing.T) {
+	t.Parallel()
+	mainRoot, linked := conventionalMetadataWorktree(t, "moved")
+	before := assertMetadataMatchesGit(t, linked, "moved")
+	moved := filepath.Join(filepath.Dir(linked), "moved-checkout")
+	require.NoError(t, os.Rename(linked, moved))
+
+	metadata, err := ResolveWorktreeMetadata(moved)
+	require.NoError(t, err)
+	require.Equal(t, before.GitDir, metadata.GitDir)
+	requireSameDirectory(t, filepath.Join(mainRoot, gitDir), metadata.CommonDir)
+	require.Equal(t, "moved", metadata.WorktreeID)
+}
+
+func TestResolveWorktreeMetadata_IgnoresGitEnvironment(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	other := filepath.Join(t.TempDir(), "other")
+	initMetadataRepo(t, root)
+	initMetadataRepo(t, other)
+	t.Setenv("GIT_DIR", filepath.Join(other, gitDir))
+	t.Setenv("GIT_WORK_TREE", other)
+	t.Setenv("GIT_COMMON_DIR", filepath.Join(other, gitDir))
+
+	metadata, err := ResolveWorktreeMetadata(root)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(root, gitDir), metadata.GitDir)
+	require.Equal(t, filepath.Join(root, gitDir), metadata.CommonDir)
+}
+
+func TestResolveWorktreeMetadata_StartsNoGitSubprocess(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("fake git uses a POSIX shell script")
+	}
+	root := filepath.Join(t.TempDir(), "root")
+	initMetadataRepo(t, root)
+	fakeBin := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "git-started")
+	writeMetadataFile(t, filepath.Join(fakeBin, "git"), "#!/bin/sh\n: > \"$GIT_METADATA_PROBE\"\nexit 99\n")
+	require.NoError(t, os.Chmod(filepath.Join(fakeBin, "git"), 0o750))
+	t.Setenv("GIT_METADATA_PROBE", marker)
+	t.Setenv("PATH", fakeBin)
+
+	_, err := ResolveWorktreeMetadata(root)
+	require.NoError(t, err)
+	_, err = os.Stat(marker)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestResolveWorktreeMetadata_ObservesMetadataRepair(t *testing.T) {
+	t.Parallel()
+	_, linked := conventionalMetadataWorktree(t, "repair")
+	metadata := assertMetadataMatchesGit(t, linked, "repair")
+	commonFile := filepath.Join(metadata.GitDir, "commondir")
+	writeMetadataFile(t, commonFile, "../missing\n")
+
+	got, err := ResolveWorktreeMetadata(linked)
+	require.Error(t, err)
+	require.Equal(t, WorktreeMetadata{}, got)
+	writeMetadataFile(t, commonFile, "../..\n")
+
+	got, err = ResolveWorktreeMetadata(linked)
+	require.NoError(t, err)
+	require.Equal(t, metadata, got)
+}
+
+func TestResolveWorktreeMetadata_MalformedMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) string
+		want  string
+	}{
+		{
+			name: "missing worktree root",
+			setup: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing")
+			},
+			want: "inspect worktree root",
+		},
+		{
+			name: "worktree root is a file",
+			setup: func(t *testing.T) string {
+				root := filepath.Join(t.TempDir(), "root")
+				writeMetadataFile(t, root, "file\n")
+				return root
+			},
+			want: "worktree root at",
+		},
+		{
+			name: "absent .git",
+			setup: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			want: "worktree Git metadata not found",
+		},
+		{
+			name: "malformed gitdir pointer",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				writeMetadataFile(t, filepath.Join(root, gitDir), "not-a-pointer\n")
+				return root
+			},
+			want: "missing gitdir prefix",
+		},
+		{
+			name: "empty gitdir pointer",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				writeMetadataFile(t, filepath.Join(root, gitDir), "gitdir: \n")
+				return root
+			},
+			want: "empty gitdir value",
+		},
+		{
+			name: "gitdir prefix without space",
+			setup: func(t *testing.T) string {
+				return malformedGitDirMetadata(t, "gitdir:target\n")
+			},
+			want: "missing gitdir prefix",
+		},
+		{
+			name: "gitdir leading whitespace",
+			setup: func(t *testing.T) string {
+				return malformedGitDirMetadata(t, " gitdir: target\n")
+			},
+			want: "missing gitdir prefix",
+		},
+		{
+			name: "gitdir tab separator",
+			setup: func(t *testing.T) string {
+				return malformedGitDirMetadata(t, "gitdir:\ttarget\n")
+			},
+			want: "missing gitdir prefix",
+		},
+		{
+			name: "gitdir trailing whitespace",
+			setup: func(t *testing.T) string {
+				return malformedGitDirMetadata(t, "gitdir: target \n")
+			},
+			want: "inspect Git directory",
+		},
+		{
+			name: "gitdir extra content",
+			setup: func(t *testing.T) string {
+				return malformedGitDirMetadata(t, "gitdir: target\nignored\n")
+			},
+			want: "inspect Git directory",
+		},
+		{
+			name: "dangling .git symlink",
+			setup: func(t *testing.T) string {
+				if runtime.GOOS == windowsOS {
+					t.Skip("symlink creation requires privileges on some Windows builders")
+				}
+				root := t.TempDir()
+				require.NoError(t, os.Symlink("missing", filepath.Join(root, gitDir)))
+				return root
+			},
+			want: "inspect .git entry",
+		},
+		{
+			name: "missing Git directory",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				writeMetadataFile(t, filepath.Join(root, gitDir), "gitdir: missing\n")
+				return root
+			},
+			want: "inspect Git directory",
+		},
+		{
+			name: "Git directory target is a file",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				writeMetadataFile(t, filepath.Join(root, "target"), "file\n")
+				writeMetadataFile(t, filepath.Join(root, gitDir), "gitdir: target\n")
+				return root
+			},
+			want: "Git directory at",
+		},
+		{
+			name: "empty commondir",
+			setup: func(t *testing.T) string {
+				root, perWorktree := malformedLinkedMetadata(t)
+				writeMetadataFile(t, filepath.Join(perWorktree, "commondir"), "\n")
+				return root
+			},
+			want: "empty value",
+		},
+		{
+			name: "commondir leading whitespace",
+			setup: func(t *testing.T) string {
+				return malformedCommonDirMetadata(t, " ../..\n")
+			},
+			want: "inspect common Git directory",
+		},
+		{
+			name: "commondir trailing whitespace",
+			setup: func(t *testing.T) string {
+				return malformedCommonDirMetadata(t, "../.. \n")
+			},
+			want: "inspect common Git directory",
+		},
+		{
+			name: "commondir extra content",
+			setup: func(t *testing.T) string {
+				return malformedCommonDirMetadata(t, "../..\nignored\n")
+			},
+			want: "inspect common Git directory",
+		},
+		{
+			name: "missing common directory",
+			setup: func(t *testing.T) string {
+				root, perWorktree := malformedLinkedMetadata(t)
+				writeMetadataFile(t, filepath.Join(perWorktree, "commondir"), "../missing\n")
+				return root
+			},
+			want: "inspect common Git directory",
+		},
+		{
+			name: "common directory target is a file",
+			setup: func(t *testing.T) string {
+				root, perWorktree := malformedLinkedMetadata(t)
+				writeMetadataFile(t, filepath.Join(filepath.Dir(perWorktree), "common"), "file\n")
+				writeMetadataFile(t, filepath.Join(perWorktree, "commondir"), "../common\n")
+				return root
+			},
+			want: "common Git directory at",
+		},
+		{
+			name: "commondir entry is a directory",
+			setup: func(t *testing.T) string {
+				root, perWorktree := malformedLinkedMetadata(t)
+				require.NoError(t, os.Mkdir(filepath.Join(perWorktree, "commondir"), 0o750))
+				return root
+			},
+			want: "commondir entry",
+		},
+		{
+			name: "symlinked commondir",
+			setup: func(t *testing.T) string {
+				if runtime.GOOS == windowsOS {
+					t.Skip("symlink creation requires privileges on some Windows builders")
+				}
+				root, perWorktree := malformedLinkedMetadata(t)
+				require.NoError(t, os.Symlink("../..", filepath.Join(perWorktree, "commondir")))
+				return root
+			},
+			want: "commondir entry",
+		},
+		{
+			name: "nested registration",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				common := filepath.Join(root, "store")
+				perWorktree := filepath.Join(common, "worktrees", "nested", "id")
+				require.NoError(t, os.MkdirAll(perWorktree, 0o750))
+				writeMetadataFile(t, filepath.Join(root, gitDir), "gitdir: "+perWorktree+"\n")
+				writeMetadataFile(t, filepath.Join(perWorktree, "commondir"), "../../..\n")
+				return root
+			},
+			want: "not an immediate child",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := tt.setup(t)
+			metadata, err := ResolveWorktreeMetadata(root)
+			require.ErrorContains(t, err, tt.want)
+			require.Equal(t, WorktreeMetadata{}, metadata)
+		})
+	}
+}
+
+func TestResolveWorktreeMetadata_RejectsBareRepository(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(t.TempDir(), "bare.git")
+	runMetadataGit(t, filepath.Dir(root), "init", "--bare", root)
+
+	metadata, err := ResolveWorktreeMetadata(root)
+	require.ErrorIs(t, err, ErrWorktreeMetadataNotFound)
+	require.Equal(t, WorktreeMetadata{}, metadata)
+}
+
+func TestErrWorktreeMetadataNotFoundClassification(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveWorktreeMetadata(t.TempDir())
+	require.ErrorIs(t, err, ErrWorktreeMetadataNotFound)
+
+	_, err = ResolveWorktreeMetadata(filepath.Join(t.TempDir(), "missing"))
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrWorktreeMetadataNotFound)
+}
+
+func assertMetadataMatchesGit(t *testing.T, root, wantID string) WorktreeMetadata {
+	t.Helper()
+	metadata, err := ResolveWorktreeMetadata(root)
+	require.NoError(t, err)
+	require.Equal(t, wantID, metadata.WorktreeID)
+	require.True(t, filepath.IsAbs(metadata.GitDir))
+	require.True(t, filepath.IsAbs(metadata.CommonDir))
+	requireSameDirectory(t, metadata.GitDir, runMetadataGit(t, root, "rev-parse", "--absolute-git-dir"))
+	requireSameDirectory(t, metadata.CommonDir, runMetadataGit(t, root, "rev-parse", "--path-format=absolute", "--git-common-dir"))
+	return metadata
+}
+
+func conventionalMetadataWorktree(t *testing.T, name string) (string, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	mainRoot := filepath.Join(tmp, "main")
+	linkedRoot := filepath.Join(tmp, name)
+	initMetadataRepo(t, mainRoot)
+	runMetadataGit(t, mainRoot, "worktree", "add", "-b", name, linkedRoot)
+	return mainRoot, linkedRoot
+}
+
+func metadataSubmoduleWorktrees(t *testing.T) (string, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	subject := filepath.Join(tmp, "subject")
+	super := filepath.Join(tmp, "super")
+	ordinary := filepath.Join(super, "sub")
+	linked := filepath.Join(tmp, "linked-submodule")
+	initMetadataRepo(t, subject)
+	initMetadataRepo(t, super)
+	runMetadataGit(t, super, "-c", "protocol.file.allow=always", "submodule", "add", subject, "sub")
+	runMetadataGit(t, super, "add", ".gitmodules", "sub")
+	runMetadataGit(t, super, "commit", "--no-gpg-sign", "-m", "add submodule")
+	runMetadataGit(t, ordinary, "worktree", "add", "-b", "linked-submodule", linked)
+	return ordinary, linked
+}
+
+func malformedLinkedMetadata(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	perWorktree := filepath.Join(root, "store", "worktrees", "id")
+	require.NoError(t, os.MkdirAll(perWorktree, 0o750))
+	writeMetadataFile(t, filepath.Join(root, gitDir), "gitdir: "+perWorktree+"\n")
+	return root, perWorktree
+}
+
+func malformedGitDirMetadata(t *testing.T, content string) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, "target"), 0o750))
+	writeMetadataFile(t, filepath.Join(root, gitDir), content)
+	return root
+}
+
+func malformedCommonDirMetadata(t *testing.T, content string) string {
+	t.Helper()
+	root, perWorktree := malformedLinkedMetadata(t)
+	writeMetadataFile(t, filepath.Join(perWorktree, "commondir"), content)
+	return root
+}
+
+func initMetadataRepo(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(root, 0o750))
+	runMetadataGit(t, root, "init", "-b", "main")
+	configureMetadataRepo(t, root)
+	commitMetadataFile(t, root, "initial.txt", "initial\n")
+}
+
+func configureMetadataRepo(t *testing.T, root string) {
+	t.Helper()
+	runMetadataGit(t, root, "config", "user.name", "Metadata Test")
+	runMetadataGit(t, root, "config", "user.email", "metadata@example.com")
+	runMetadataGit(t, root, "config", "commit.gpgsign", "false")
+}
+
+func commitMetadataFile(t *testing.T, root, name, content string) {
+	t.Helper()
+	writeMetadataFile(t, filepath.Join(root, name), content)
+	runMetadataGit(t, root, "add", name)
+	runMetadataGit(t, root, "commit", "--no-gpg-sign", "-m", "initial")
+}
+
+func runMetadataGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL="+filepath.Join(t.TempDir(), "global.gitconfig"),
+		"GIT_CONFIG_SYSTEM="+os.DevNull,
+		"GIT_TERMINAL_PROMPT=0",
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %s: %s", strings.Join(args, " "), output)
+	return strings.TrimSpace(string(output))
+}
+
+func requireSameDirectory(t *testing.T, got, want string) {
+	t.Helper()
+	gotInfo, err := os.Stat(got)
+	require.NoError(t, err)
+	wantInfo, err := os.Stat(want)
+	require.NoError(t, err)
+	require.Truef(t, os.SameFile(gotInfo, wantInfo), "%s and %s identify different directories", got, want)
+}
+
+func readMetadataFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func writeMetadataFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}

--- a/cmd/entire/cli/gitrepo/metadata_test.go
+++ b/cmd/entire/cli/gitrepo/metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 )
@@ -528,6 +529,84 @@ func TestResolveWorktreeMetadata_RejectsBareRepository(t *testing.T) {
 	metadata, err := ResolveWorktreeMetadata(root)
 	require.ErrorIs(t, err, ErrWorktreeMetadataNotFound)
 	require.Equal(t, WorktreeMetadata{}, metadata)
+}
+
+// Git refuses an oversized .git file outright ("too large to be a .git file").
+// Reading one unbounded turns a sparse file of near-zero disk size into an
+// allocation the size of its apparent length, and echoing it into the error
+// doubles that, so the cap and the elision are tested together.
+func TestResolveWorktreeMetadata_BoundsPointerFiles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("oversized .git file", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeSparsePointerFile(t, filepath.Join(root, gitDir), 64<<20)
+
+		_, err := ResolveWorktreeMetadata(root)
+		require.ErrorContains(t, err, "too large to be a .git file")
+		require.Less(t, len(err.Error()), 4096, "error must not carry the payload")
+	})
+
+	t.Run("oversized commondir file", func(t *testing.T) {
+		t.Parallel()
+		root, perWorktree := malformedLinkedMetadata(t)
+		writeSparsePointerFile(t, filepath.Join(perWorktree, "commondir"), 64<<20)
+
+		_, err := ResolveWorktreeMetadata(root)
+		require.ErrorContains(t, err, "too large to be a commondir file")
+		require.Less(t, len(err.Error()), 4096, "error must not carry the payload")
+	})
+
+	t.Run("pointer at the cap is still parsed", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		pointer := "gitdir: " + strings.Repeat("a", maxMetadataPointerSize-len("gitdir: ")-1) + "\n"
+		require.Len(t, pointer, maxMetadataPointerSize)
+		writeMetadataFile(t, filepath.Join(root, gitDir), pointer)
+
+		_, err := ResolveWorktreeMetadata(root)
+		// The target does not exist, which is the point: the file was read and
+		// parsed rather than refused for its size.
+		require.ErrorContains(t, err, "inspect Git directory")
+		require.NotErrorIs(t, err, ErrWorktreeMetadataNotFound)
+	})
+
+	t.Run("long pointer path is elided in the error", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeMetadataFile(t, filepath.Join(root, gitDir), "gitdir: "+strings.Repeat("b", 2048)+"\n")
+
+		_, err := ResolveWorktreeMetadata(root)
+		require.ErrorContains(t, err, "bytes elided")
+		require.True(t, utf8.ValidString(err.Error()), "elided error must stay valid UTF-8")
+	})
+}
+
+func TestElideMetadataPath(t *testing.T) {
+	t.Parallel()
+
+	short := strings.Repeat("a", maxMetadataErrorPathLen)
+	require.Equal(t, short, elideMetadataPath(short))
+
+	// Cutting mid-rune would produce an invalid replacement character in the
+	// message, so elision backs up to a boundary.
+	multibyte := strings.Repeat("é", maxMetadataErrorPathLen)
+	elided := elideMetadataPath(multibyte)
+	require.NotEqual(t, multibyte, elided)
+	require.True(t, utf8.ValidString(elided))
+	require.Contains(t, elided, "bytes elided")
+}
+
+func writeSparsePointerFile(t *testing.T, path string, size int64) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, file.Close()) }()
+	_, err = file.WriteString("gitdir: ")
+	require.NoError(t, err)
+	require.NoError(t, file.Truncate(size))
 }
 
 func TestErrWorktreeMetadataNotFoundClassification(t *testing.T) {

--- a/cmd/entire/cli/gitrepo/metadata_test.go
+++ b/cmd/entire/cli/gitrepo/metadata_test.go
@@ -129,6 +129,25 @@ func TestResolveWorktreeMetadata_RealGitLayouts(t *testing.T) {
 		require.Equal(t, alias, got.CommonDir)
 	})
 
+	t.Run("symlink-aliased linked-worktree registration", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == windowsOS {
+			t.Skip("symlink creation requires privileges on some Windows builders")
+		}
+		mainRoot, linked := conventionalMetadataWorktree(t, "registration-alias")
+		metadata := assertMetadataMatchesGit(t, linked, "registration-alias")
+		alias := filepath.Join(t.TempDir(), "registration")
+		require.NoError(t, os.Symlink(metadata.GitDir, alias))
+		writeMetadataFile(t, filepath.Join(linked, gitDir), "gitdir: "+alias+"\n")
+
+		got := assertMetadataMatchesGit(t, linked, "registration-alias")
+		require.Equal(t, alias, got.GitDir)
+		requireSameDirectory(t, filepath.Join(mainRoot, gitDir), got.CommonDir)
+		repo, err := OpenPath(linked)
+		require.NoError(t, err)
+		require.NoError(t, repo.Close())
+	})
+
 	t.Run("symlink-aliased worktree root", func(t *testing.T) {
 		t.Parallel()
 		if runtime.GOOS == windowsOS {
@@ -175,6 +194,17 @@ func TestResolveWorktreeMetadata_MovedRegistrationPreservesFacts(t *testing.T) {
 	require.Equal(t, before.GitDir, metadata.GitDir)
 	requireSameDirectory(t, filepath.Join(mainRoot, gitDir), metadata.CommonDir)
 	require.Equal(t, "moved", metadata.WorktreeID)
+}
+
+func TestResolveWorktreeMetadata_WhitespaceOnlyRoot(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "   ")
+	initMetadataRepo(t, root)
+	t.Chdir(parent)
+
+	metadata, err := ResolveWorktreeMetadata("   ")
+	require.NoError(t, err)
+	requireSameDirectory(t, filepath.Join(root, gitDir), metadata.GitDir)
 }
 
 func TestResolveWorktreeMetadata_IgnoresGitEnvironment(t *testing.T) {
@@ -325,6 +355,18 @@ func TestResolveWorktreeMetadata_MalformedMetadata(t *testing.T) {
 			want: "inspect .git entry",
 		},
 		{
+			name: ".git symlink loop",
+			setup: func(t *testing.T) string {
+				if runtime.GOOS == windowsOS {
+					t.Skip("symlink creation requires privileges on some Windows builders")
+				}
+				root := t.TempDir()
+				require.NoError(t, os.Symlink(gitDir, filepath.Join(root, gitDir)))
+				return root
+			},
+			want: "inspect .git entry",
+		},
+		{
 			name: "missing Git directory",
 			setup: func(t *testing.T) string {
 				root := t.TempDir()
@@ -434,6 +476,9 @@ func TestResolveWorktreeMetadata_MalformedMetadata(t *testing.T) {
 			root := tt.setup(t)
 			metadata, err := ResolveWorktreeMetadata(root)
 			require.ErrorContains(t, err, tt.want)
+			if tt.name != "absent .git" {
+				require.NotErrorIs(t, err, ErrWorktreeMetadataNotFound)
+			}
 			require.Equal(t, WorktreeMetadata{}, metadata)
 		})
 	}

--- a/cmd/entire/cli/gitrepo/metadata_test.go
+++ b/cmd/entire/cli/gitrepo/metadata_test.go
@@ -196,6 +196,42 @@ func TestResolveWorktreeMetadata_MovedRegistrationPreservesFacts(t *testing.T) {
 	require.Equal(t, "moved", metadata.WorktreeID)
 }
 
+func TestResolveWorktreeMetadata_RejectsRegistrationSymlinkEscapingCommonDir(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == windowsOS {
+		t.Skip("symlink creation requires privileges on some Windows builders")
+	}
+
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "worktree")
+	commonDir := filepath.Join(tmp, "common")
+	registrationRoot := filepath.Join(commonDir, "worktrees")
+	plantedRegistration := filepath.Join(tmp, "planted-registration")
+	require.NoError(t, os.MkdirAll(root, 0o750))
+	require.NoError(t, os.MkdirAll(registrationRoot, 0o750))
+	require.NoError(t, os.MkdirAll(plantedRegistration, 0o750))
+	require.NoError(t, os.Symlink(plantedRegistration, filepath.Join(registrationRoot, "escaped")))
+	writeMetadataFile(t, filepath.Join(root, gitDir), "gitdir: "+filepath.Join(registrationRoot, "escaped")+"\n")
+	writeMetadataFile(t, filepath.Join(plantedRegistration, "commondir"), commonDir+"\n")
+
+	metadata, err := ResolveWorktreeMetadata(root)
+	require.ErrorContains(t, err, "not an immediate child")
+	require.Equal(t, WorktreeMetadata{}, metadata)
+
+	repo, err := OpenPath(root)
+	require.ErrorContains(t, err, "resolve worktree metadata")
+	require.ErrorContains(t, err, "not an immediate child")
+	require.Nil(t, repo)
+}
+
+func TestResolveWorktreeMetadata_RequiresExplicitRoot(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := ResolveWorktreeMetadata("")
+	require.EqualError(t, err, "worktree root is required")
+	require.Equal(t, WorktreeMetadata{}, metadata)
+}
+
 func TestResolveWorktreeMetadata_WhitespaceOnlyRoot(t *testing.T) {
 	parent := t.TempDir()
 	root := filepath.Join(parent, "   ")

--- a/cmd/entire/cli/gitrepo/reftable.go
+++ b/cmd/entire/cli/gitrepo/reftable.go
@@ -23,7 +23,7 @@ import (
 // timeout only guards against a wedged git process.
 const reftableGitTimeout = 30 * time.Second
 
-// repoUsesReftable reports whether the repository at the given git directories
+// inspectRepoUsesReftable reports whether the repository at the given git directories
 // stores its references using the reftable backend rather than the classic
 // loose-files + packed-refs layout.
 //
@@ -38,7 +38,7 @@ const reftableGitTimeout = 30 * time.Second
 // `git refs migrate --ref-format=reftable`. Checking the directory avoids
 // parsing config and works for linked worktrees, where the shared stack lives
 // under the common git dir.
-func repoUsesReftable(dotGitPath, commonGitPath string) bool {
+func inspectRepoUsesReftable(dotGitPath, commonGitPath string) (bool, error) {
 	candidates := []string{filepath.Join(dotGitPath, "reftable")}
 	if commonGitPath != "" && commonGitPath != dotGitPath {
 		candidates = append(candidates, filepath.Join(commonGitPath, "reftable"))
@@ -48,11 +48,18 @@ func repoUsesReftable(dotGitPath, commonGitPath string) bool {
 		// symlink in its place is not a genuine reftable stack. Lstat inspects
 		// the entry itself rather than following the link, so a symlink reports
 		// IsDir()==false and is correctly not treated as a reftable repository.
-		if info, err := os.Lstat(dir); err == nil && info.IsDir() {
-			return true
+		info, err := os.Lstat(dir)
+		if err == nil {
+			if info.IsDir() {
+				return true, nil
+			}
+			continue
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return false, fmt.Errorf("inspect reftable directory %s: %w", dir, err)
 		}
 	}
-	return false
+	return false, nil
 }
 
 // reftableStorer adapts a filesystem-backed go-git storage so it can open and

--- a/cmd/entire/cli/gitrepo/reftable_test.go
+++ b/cmd/entire/cli/gitrepo/reftable_test.go
@@ -678,9 +678,21 @@ func TestRepoUsesReftable_Detection(t *testing.T) {
 	t.Parallel()
 
 	reftableRepo, _ := initReftableRepo(t, "a.txt", "a\n")
-	require.True(t, repoUsesReftable(filepath.Join(reftableRepo, ".git"), filepath.Join(reftableRepo, ".git")))
+	usesReftable, err := inspectRepoUsesReftable(filepath.Join(reftableRepo, ".git"), filepath.Join(reftableRepo, ".git"))
+	require.NoError(t, err)
+	require.True(t, usesReftable)
 
 	filesRepo := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(filesRepo, ".git", "refs"), 0o755))
-	require.False(t, repoUsesReftable(filepath.Join(filesRepo, ".git"), filepath.Join(filesRepo, ".git")))
+	usesReftable, err = inspectRepoUsesReftable(filepath.Join(filesRepo, ".git"), filepath.Join(filesRepo, ".git"))
+	require.NoError(t, err)
+	require.False(t, usesReftable)
+}
+
+func TestInspectRepoUsesReftable_ReportsInspectionFailure(t *testing.T) {
+	t.Parallel()
+
+	usesReftable, err := inspectRepoUsesReftable("invalid\x00gitdir", "")
+	require.ErrorContains(t, err, "inspect reftable directory")
+	require.False(t, usesReftable)
 }

--- a/cmd/entire/cli/gitrepo/repository.go
+++ b/cmd/entire/cli/gitrepo/repository.go
@@ -138,6 +138,17 @@ func ResolveCommonGitPath(dotGitPath string) (string, error) {
 	return resolveCommonGitPath(dotGitPath)
 }
 
+// openBareRepository opens a path that carries no worktree metadata.
+//
+// Git never requires core.bare to call a directory bare, and `init --bare`
+// leaves the key unset, so requiring it to be present and true rejects ordinary
+// bare repositories. The case that must still be refused is a separate Git
+// directory, which is a worktree's storage rather than a repository to open on
+// its own, and git writes core.bare = false there explicitly. An explicit false
+// is therefore the discriminator; an absent key is not.
+//
+// PlainOpen supplies the shape check, reporting "repository does not exist" for
+// a directory that only looks like one.
 func openBareRepository(repoRoot string) (*git.Repository, error) {
 	repo, err := git.PlainOpen(repoRoot)
 	if err != nil {
@@ -148,7 +159,7 @@ func openBareRepository(repoRoot string) (*git.Repository, error) {
 		_ = repo.Close()
 		return nil, fmt.Errorf("validate bare repository config: %w", err)
 	}
-	if !config.Core.IsBare {
+	if config.Raw.Section("core").HasOption("bare") && !config.Core.IsBare {
 		_ = repo.Close()
 		return nil, fmt.Errorf("path %s has no worktree metadata and is not a bare repository", repoRoot)
 	}

--- a/cmd/entire/cli/gitrepo/repository.go
+++ b/cmd/entire/cli/gitrepo/repository.go
@@ -78,21 +78,52 @@ func OpenCurrentOrCwd(ctx context.Context) (*git.Repository, error) {
 // OpenPath opens a git repository with object alternates enabled.
 // The caller owns the returned repository and must close it.
 func OpenPath(repoRoot string) (*git.Repository, error) {
-	repo, err := openPathWithAlternates(repoRoot)
+	repoRoot, err := filepath.Abs(repoRoot)
 	if err != nil {
-		if hasAlternates, altErr := hasObjectAlternates(repoRoot); altErr == nil && hasAlternates {
-			return nil, fmt.Errorf("failed to open repository with alternates support: %w", err)
-		}
-
-		// Intentional PlainOpen fallback for unusual layouts that do not use
-		// alternates. Repositories with alternates must not silently downgrade
-		// because PlainOpen cannot read absolute alternate object directories.
-		if fallbackRepo, fallbackErr := git.PlainOpen(repoRoot); fallbackErr == nil {
-			return fallbackRepo, nil
-		}
-		return nil, fmt.Errorf("failed to open repository: %w", err)
+		return nil, fmt.Errorf("resolve repository root: %w", err)
 	}
-	return repo, nil
+	repoRoot = filepath.Clean(repoRoot)
+
+	metadata, err := ResolveWorktreeMetadata(repoRoot)
+	if err != nil {
+		if errors.Is(err, ErrWorktreeMetadataNotFound) {
+			repo, bareErr := openBareRepository(repoRoot)
+			if bareErr == nil {
+				return repo, nil
+			}
+			return nil, fmt.Errorf(
+				"failed to open repository at %s: worktree metadata: %w; bare repository validation: %w",
+				repoRoot,
+				err,
+				bareErr,
+			)
+		}
+		return nil, fmt.Errorf("failed to open repository: resolve worktree metadata: %w", err)
+	}
+
+	repo, err := openWorktreeRepository(repoRoot, metadata)
+	if err == nil {
+		return repo, nil
+	}
+
+	hasAlternates, alternatesErr := hasObjectAlternates(metadata)
+	if alternatesErr != nil {
+		return nil, fmt.Errorf("inspect repository after specialized open failed: %w", alternatesErr)
+	}
+	usesReftable, reftableErr := inspectRepoUsesReftable(metadata.GitDir, metadata.CommonDir)
+	if reftableErr != nil {
+		return nil, fmt.Errorf("inspect repository after specialized open failed: %w", reftableErr)
+	}
+	if hasAlternates || usesReftable {
+		return nil, fmt.Errorf("failed to open repository with specialized storage: %w", err)
+	}
+
+	// PlainOpen is safe only after complete metadata validation and positive
+	// evidence that neither specialized storage feature is present.
+	if fallbackRepo, fallbackErr := git.PlainOpen(repoRoot); fallbackErr == nil {
+		return fallbackRepo, nil
+	}
+	return nil, fmt.Errorf("failed to open repository: %w", err)
 }
 
 // ResolveDotGitPath resolves the .git entry for a worktree without opening the
@@ -107,60 +138,54 @@ func ResolveCommonGitPath(dotGitPath string) (string, error) {
 	return resolveCommonGitPath(dotGitPath)
 }
 
-func hasObjectAlternates(repoRoot string) (bool, error) {
-	repoRoot, err := filepath.Abs(repoRoot)
+func openBareRepository(repoRoot string) (*git.Repository, error) {
+	repo, err := git.PlainOpen(repoRoot)
 	if err != nil {
-		return false, fmt.Errorf("resolve repository root: %w", err)
+		return nil, fmt.Errorf("failed to open repository: %w", err)
 	}
-
-	dotGitPath, err := resolveDotGitPath(repoRoot)
+	config, err := repo.Config()
 	if err != nil {
-		return false, fmt.Errorf("resolve .git path: %w", err)
+		_ = repo.Close()
+		return nil, fmt.Errorf("validate bare repository config: %w", err)
 	}
-
-	commonGitPath, err := resolveCommonGitPath(dotGitPath)
-	if err != nil {
-		return false, fmt.Errorf("resolve common git path: %w", err)
+	if !config.Core.IsBare {
+		_ = repo.Close()
+		return nil, fmt.Errorf("path %s has no worktree metadata and is not a bare repository", repoRoot)
 	}
+	return repo, nil
+}
 
-	candidates := []string{filepath.Join(dotGitPath, "objects", "info", "alternates")}
-	if commonGitPath != "" {
-		candidates = append(candidates, filepath.Join(commonGitPath, "objects", "info", "alternates"))
+func hasObjectAlternates(metadata WorktreeMetadata) (bool, error) {
+	candidates := []string{filepath.Join(metadata.GitDir, "objects", "info", "alternates")}
+	if metadata.CommonDir != metadata.GitDir {
+		candidates = append(candidates, filepath.Join(metadata.CommonDir, "objects", "info", "alternates"))
 	}
 	for _, candidate := range candidates {
-		if _, err := os.Stat(candidate); err == nil {
+		info, err := os.Lstat(candidate)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				if _, err := os.Stat(candidate); err != nil {
+					return false, fmt.Errorf("inspect alternates file: %w", err)
+				}
+			}
 			return true, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return false, fmt.Errorf("stat alternates file: %w", err)
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return false, fmt.Errorf("inspect alternates file: %w", err)
 		}
 	}
 	return false, nil
 }
 
-func openPathWithAlternates(repoRoot string) (*git.Repository, error) {
-	repoRoot, err := filepath.Abs(repoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("resolve repository root: %w", err)
-	}
-
-	dotGitPath, err := resolveDotGitPath(repoRoot)
-	if err != nil {
-		return nil, err
-	}
-
-	commonGitPath, err := resolveCommonGitPath(dotGitPath)
-	if err != nil {
-		return nil, err
-	}
-
+func openWorktreeRepository(repoRoot string, metadata WorktreeMetadata) (*git.Repository, error) {
 	// Wrap the git-dir filesystems so relative alternate object directories are
 	// rewritten to absolute paths on read; go-git cannot follow relative
 	// alternates on its own. The alternates file lives under the common git dir
 	// for linked worktrees, so wrap both.
-	dotGitFS := wrapAlternatesRewrite(osfs.New(dotGitPath, osfs.WithBoundOS()))
+	dotGitFS := wrapAlternatesRewrite(osfs.New(metadata.GitDir, osfs.WithBoundOS()))
 	var commonGitFS billy.Filesystem
-	if commonGitPath != "" {
-		commonGitFS = wrapAlternatesRewrite(osfs.New(commonGitPath, osfs.WithBoundOS()))
+	if metadata.CommonDir != metadata.GitDir {
+		commonGitFS = wrapAlternatesRewrite(osfs.New(metadata.CommonDir, osfs.WithBoundOS()))
 	}
 
 	repositoryFS := dotgit.NewRepositoryFilesystem(dotGitFS, commonGitFS)
@@ -185,8 +210,13 @@ func openPathWithAlternates(repoRoot string) (*git.Repository, error) {
 	// point a plain git.Open(storage, worktreeFS) will handle reftable
 	// repositories directly and this CLI-backed shim is dead weight.
 	worktreeFS := osfs.New(repoRoot, osfs.WithBoundOS())
-	if repoUsesReftable(dotGitPath, commonGitPath) {
-		repo, err := git.Open(newReftableStorer(storage, dotGitPath), worktreeFS)
+	usesReftable, err := inspectRepoUsesReftable(metadata.GitDir, metadata.CommonDir)
+	if err != nil {
+		_ = storage.Close()
+		return nil, err
+	}
+	if usesReftable {
+		repo, err := git.Open(newReftableStorer(storage, metadata.GitDir), worktreeFS)
 		if err != nil {
 			_ = storage.Close()
 			return nil, fmt.Errorf("open reftable repository storage: %w", err)

--- a/cmd/entire/cli/gitrepo/repository_test.go
+++ b/cmd/entire/cli/gitrepo/repository_test.go
@@ -305,6 +305,20 @@ func TestOpenPath_SeparatesBareRepositoriesFromWorktreeMetadata(t *testing.T) {
 		require.NoError(t, repo.Close())
 	})
 
+	t.Run("bare repository without core.bare", func(t *testing.T) {
+		t.Parallel()
+		// git decides bareness from the directory's shape, not from core.bare,
+		// and leaves the key unset in ordinary bare clones. Requiring it here
+		// rejected repositories git opens without complaint.
+		root := filepath.Join(t.TempDir(), "bare.git")
+		runMetadataGit(t, filepath.Dir(root), "init", "--bare", root)
+		runMetadataGit(t, root, "config", "--unset", "core.bare")
+
+		repo, err := OpenPath(root)
+		require.NoError(t, err)
+		require.NoError(t, repo.Close())
+	})
+
 	t.Run("separate Git directory is not a bare repository", func(t *testing.T) {
 		t.Parallel()
 		tmp := t.TempDir()

--- a/cmd/entire/cli/gitrepo/repository_test.go
+++ b/cmd/entire/cli/gitrepo/repository_test.go
@@ -3,6 +3,7 @@ package gitrepo
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -223,14 +224,16 @@ func TestHasObjectAlternates(t *testing.T) {
 		repoDir := t.TempDir()
 		_ = initRepoWithFile(t, repoDir, "root.txt", "root\n")
 
-		hasAlternates, err := hasObjectAlternates(repoDir)
+		metadata, err := ResolveWorktreeMetadata(repoDir)
+		require.NoError(t, err)
+		hasAlternates, err := hasObjectAlternates(metadata)
 		require.NoError(t, err)
 		require.False(t, hasAlternates)
 
 		alternateDir := t.TempDir()
 		writeAlternates(t, repoDir, []string{filepath.Join(alternateDir, gitDir, "objects")})
 
-		hasAlternates, err = hasObjectAlternates(repoDir)
+		hasAlternates, err = hasObjectAlternates(metadata)
 		require.NoError(t, err)
 		require.True(t, hasAlternates)
 	})
@@ -253,9 +256,123 @@ func TestHasObjectAlternates(t *testing.T) {
 		require.NoError(t, os.MkdirAll(infoDir, 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(infoDir, "alternates"), []byte(alternateDir+"\n"), 0o644))
 
-		hasAlternates, err := hasObjectAlternates(worktreeDir)
+		metadata, err := ResolveWorktreeMetadata(worktreeDir)
+		require.NoError(t, err)
+		hasAlternates, err := hasObjectAlternates(metadata)
 		require.NoError(t, err)
 		require.True(t, hasAlternates)
+	})
+}
+
+func TestOpenPath_DoesNotDowngradeMalformedWorktreeMetadata(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeMetadataFile(t, filepath.Join(root, gitDir), "gitdir: missing\n")
+
+	repo, err := OpenPath(root)
+	require.ErrorContains(t, err, "resolve worktree metadata")
+	require.ErrorContains(t, err, "inspect Git directory")
+	require.Nil(t, repo)
+}
+
+func TestOpenPath_DoesNotDowngradeDanglingGitSymlink(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == windowsOS {
+		t.Skip("symlink creation requires privileges on some Windows builders")
+	}
+
+	root := filepath.Join(t.TempDir(), "bare.git")
+	runMetadataGit(t, filepath.Dir(root), "init", "--bare", root)
+	require.NoError(t, os.Symlink("missing", filepath.Join(root, gitDir)))
+
+	repo, err := OpenPath(root)
+	require.ErrorContains(t, err, "resolve worktree metadata")
+	require.ErrorContains(t, err, "inspect .git entry")
+	require.Nil(t, repo)
+}
+
+func TestOpenPath_SeparatesBareRepositoriesFromWorktreeMetadata(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bare repository", func(t *testing.T) {
+		t.Parallel()
+		root := filepath.Join(t.TempDir(), "bare.git")
+		runMetadataGit(t, filepath.Dir(root), "init", "--bare", root)
+
+		repo, err := OpenPath(root)
+		require.NoError(t, err)
+		require.NoError(t, repo.Close())
+	})
+
+	t.Run("separate Git directory is not a bare repository", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		root := filepath.Join(tmp, "checkout")
+		storage := filepath.Join(tmp, "storage")
+		runMetadataGit(t, tmp, "init", "--separate-git-dir", storage, root)
+
+		worktreeRepo, err := OpenPath(root)
+		require.NoError(t, err)
+		require.NoError(t, worktreeRepo.Close())
+
+		storageRepo, err := OpenPath(storage)
+		require.ErrorContains(t, err, "is not a bare repository")
+		require.Nil(t, storageRepo)
+	})
+}
+
+func TestOpenPath_DoesNotDowngradeSpecializedStorageFailures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("alternates inspection failure", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == windowsOS {
+			t.Skip("symlink creation requires privileges on some Windows builders")
+		}
+		root := filepath.Join(t.TempDir(), "repo")
+		initMetadataRepo(t, root)
+		runMetadataGit(t, root, "config", "core.repositoryformatversion", "1")
+		runMetadataGit(t, root, "config", "extensions.unsupported", "true")
+		infoDir := filepath.Join(root, gitDir, "objects", "info")
+		require.NoError(t, os.RemoveAll(infoDir))
+		require.NoError(t, os.Symlink("info", infoDir))
+
+		repo, err := OpenPath(root)
+		require.ErrorContains(t, err, "inspect repository after specialized open failed")
+		require.ErrorContains(t, err, "inspect alternates file")
+		require.Nil(t, repo)
+	})
+
+	t.Run("dangling alternates symlink", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == windowsOS {
+			t.Skip("symlink creation requires privileges on some Windows builders")
+		}
+		root := filepath.Join(t.TempDir(), "repo")
+		initMetadataRepo(t, root)
+		runMetadataGit(t, root, "config", "core.repositoryformatversion", "1")
+		runMetadataGit(t, root, "config", "extensions.unsupported", "true")
+		alternates := filepath.Join(root, gitDir, "objects", "info", "alternates")
+		require.NoError(t, os.Symlink("missing", alternates))
+
+		repo, err := OpenPath(root)
+		require.ErrorContains(t, err, "inspect repository after specialized open failed")
+		require.ErrorContains(t, err, "inspect alternates file")
+		require.Nil(t, repo)
+	})
+
+	t.Run("reftable open failure", func(t *testing.T) {
+		t.Parallel()
+		root := filepath.Join(t.TempDir(), "repo")
+		initMetadataRepo(t, root)
+		runMetadataGit(t, root, "config", "core.repositoryformatversion", "1")
+		runMetadataGit(t, root, "config", "extensions.unsupported", "true")
+		require.NoError(t, os.Mkdir(filepath.Join(root, gitDir, "reftable"), 0o750))
+
+		repo, err := OpenPath(root)
+		require.ErrorContains(t, err, "failed to open repository with specialized storage")
+		require.Nil(t, repo)
 	})
 }
 


### PR DESCRIPTION
Refs #2190.

PR #2190 moved every Git metadata consumer at once. The review exposed two separate jobs: define one owner for the metadata, then migrate its callers.

This is split part 1. It adds the resolver and changes only repository opening. Checkpoint, session, strategy, hooks, and other consumers stay unchanged here.

## Files and ownership

Three production files and four test files change. All paths below are relative to `cmd/entire/cli/gitrepo/`.

| File | Before | After |
| --- | --- | --- |
| `metadata.go` | No file | Resolves the three metadata facts |
| `repository.go` | Opening rediscovered paths | Resolves and passes metadata |
| `reftable.go` | Errors looked like absence | Returns inspection errors |
| `metadata_guard_test.go` | No guard | Blocks new duplicate traversal |
| `metadata_test.go` | No resolver tests | Covers real and broken layouts |
| `repository_test.go` | Tested the old path | Covers fallback and failures |
| `reftable_test.go` | Tested boolean detection | Covers inspection errors |

The call path changes like this:

```text
Before

OpenPath
  ├── resolve .git and commondir while opening
  ├── resolve them again while checking alternates
  └── fall back without one validated metadata result

After

OpenPath
  └── ResolveWorktreeMetadata
        ├── GitDir
        ├── CommonDir
        └── WorktreeID
              │
              ├── repository storage
              ├── alternates inspection
              └── reftable inspection
```

## One resolver for three facts

`gitrepo.ResolveWorktreeMetadata` resolves an explicit worktree root into:

- `GitDir`
- `CommonDir`
- `WorktreeID`

The resolver takes a worktree root. It does not discover one from CWD, read Git environment variables, run Git, cache results, or choose a caller's policy.

Resolution is all-or-error. Malformed or unreadable metadata stops the open.

`gitrepo.OpenPath` now resolves metadata once and passes those facts into repository opening, object-alternates detection, and reftable inspection.

A bare-repository open is tried only when worktree metadata does not exist.

## Symlinks and `..` keep their filesystem meaning

Lexically cleaning a path through a symlink can change where `..` leads. The resolver checks filesystem identity before it returns a cleaned path.

Linked-worktree registrations may use physical aliases. They must still resolve to an immediate child of `CommonDir/worktrees`.

Inspection errors now reach the caller. They no longer mean "feature absent." This applies to reftable inspection and malformed `.git` layouts.

## Fixes a hang that is already released

`OpenPath` on `main` identifies a `.git` entry by reading it: `os.Stat`, then `os.ReadFile`. That works for a directory or a regular file. For three other entry types the read never finishes.

| `.git` is | `main` | This PR |
| --- | --- | --- |
| A FIFO with no writer | Blocks until a writer opens it | Refused on type |
| A symlink to such a FIFO | Blocks until a writer opens it | Refused on type |
| A symlink to `/dev/zero` | Reads forever, memory grows | Refused on type |

The resolver checks the type first. It opens only a directory or a regular file, and refuses anything else by name.

None of these arrive by clone. Git refuses a `.git` path component in a tree at any depth, so each one needs local write access to the worktree. This is a robustness fix, not a vulnerability.

## `gitdir:` strictness now matches Git

The legacy parser accepted pointer files that Git rejects. It cut the prefix at `gitdir:` instead of `gitdir: `, then trimmed whitespace from the remainder. That let `gitdir:target`, ` gitdir: target`, and `gitdir:\ttarget` all resolve. Git requires the single space and trims nothing.
The fixture covers seven `.git` pointer spellings. The new resolver agrees with Git on all seven. The legacy parser agreed on three.
This changes behavior. A `.git` file that worked only because Entire was more permissive than Git now fails, and every other Git tool was already failing it.

## Stop new duplicate traversal

A source guard scans production Go across the repository. It rejects new `.git`, `gitdir:`, and `commondir` traversal outside `gitrepo.ResolveWorktreeMetadata`.
The guard lists the existing callers that later PRs must migrate:

- checkpoint metadata
- session metadata
- strategy and hooks
- remaining product consumers

The exception list records each function and the one `git rev-parse` flag it may use. If that function starts using another metadata flag, the guard fails. The test also fails when a listed exception no longer exists.

A temporary multi-file repository test runs the complete scanner. It proves that the scanner follows a package constant into another file, scans production code under `internal/`, and ignores a parameter named `gitDir`.

Positive controls cover rooted filesystem APIs, package constants, `Readlink`, aliased imports, and legacy resolver calls.

## Verification

- `mise run check`
  - formatting passed
  - lint passed with 0 issues
  - race-enabled unit and integration tests passed
  - Vogon canary passed 56/56
  - external deterministic canary passed 4/4
- `git diff main --check`
- Real Git fixtures cover ordinary, linked, bare, separate-Git-dir, submodule, symlink-alias, moved-registration, alternates, and reftable layouts.
- On the seven `.git` pointer spellings in the fixture, the new resolver matches Git on 7/7. The legacy parser matched 3/7.
- Broken fixtures verify fail-closed repository opening and typed absence.

No paid real-agent E2E tests were run.

## Deliberately not included

Checkpoint, session, strategy, hooks, and other product consumers still use their existing paths. Separate PRs will migrate them without mixing their error and fallback policies into this resolver change. The last migration will remove the legacy resolvers.

