### PR TITLE
fix(test-repo skill): verify git-refs checkpoint storage, drop removed --strategy flag

### DIFF
--- a/.claude/skills/test-repo/SKILL.md
+++ b/.claude/skills/test-repo/SKILL.md
@@ -83,9 +83,14 @@ Execute these steps in order:
 .claude/skills/test-repo/test-harness.sh verify-commit
 .claude/skills/test-repo/test-harness.sh verify-session-state
 .claude/skills/test-repo/test-harness.sh verify-shadow-branch
+.claude/skills/test-repo/test-harness.sh commit-changes
 .claude/skills/test-repo/test-harness.sh verify-metadata-branch
 .claude/skills/test-repo/test-harness.sh list-pending-checkpoints
 ```
+
+`commit-changes` comes before `verify-metadata-branch` because checkpoints
+condense into the storage on **user commits** — right after `stop-session`
+the work exists only on the shadow branch and as a pending checkpoint.
 
 Expected results:
 
@@ -94,7 +99,7 @@ Expected results:
 | Active branch | Optional Entire-Checkpoint: trailer |
 | Session state | ✓ Exists |
 | Shadow branch | ✓ entire/{hash} |
-| Metadata branch | ✓ entire/checkpoints/v1 |
+| Checkpoint storage | ✓ refs/entire/checkpoints/* (git-refs, the default) — or entire/checkpoints/v1 when settings select the git-branch backend |
 | Pending checkpoints | ✓ At least 1 |
 
 #### 4. Check Listing After Further Changes
@@ -131,6 +136,7 @@ go build -o /tmp/entire-bin ./cmd/entire && \
 .claude/skills/test-repo/test-harness.sh create-files && \
 .claude/skills/test-repo/test-harness.sh create-transcript && \
 .claude/skills/test-repo/test-harness.sh stop-session && \
+.claude/skills/test-repo/test-harness.sh commit-changes && \
 .claude/skills/test-repo/test-harness.sh verify-metadata-branch && \
 .claude/skills/test-repo/test-harness.sh list-pending-checkpoints
 ```
@@ -140,7 +146,10 @@ go build -o /tmp/entire-bin ./cmd/entire && \
 ### Manual-Commit Strategy (default)
 - Active branch commits: **NO modifications** (no commits created by Entire)
 - Shadow branches: `entire/<commit-hash[:7]>` created for checkpoints
-- Metadata: stored on both shadow branches and `entire/checkpoints/v1` branch (condensed on user commits)
+- Metadata: stored on shadow branches and, condensed on user commits, in the
+  checkpoint storage — `refs/entire/checkpoints/<shard>/<ULID>` on the
+  git-refs backend (`enable`'s default) or the `entire/checkpoints/v1` branch
+  on the git-branch backend
 - AllowsMainBranch: **true** (safe on main/master)
 
 ## Additional Testing (Optional)
@@ -180,11 +189,9 @@ For manual-commit, test log condensation:
 git add app.js
 git commit -m "Add greeting function"
 
-# Verify logs condensed to entire/checkpoints/v1
-git show entire/checkpoints/v1 --stat | grep -E "^[0-9a-f]{2}/[0-9a-f]"
-
-# Verify shadow branch still exists
-git branch -a | grep "entire/[0-9a-f]"
+# Verify logs condensed into the checkpoint storage (git-refs default);
+# falls back to the v1 branch on the git-branch backend
+.claude/skills/test-repo/test-harness.sh verify-metadata-branch
 ```
 
 ## Available Claude Code Hooks

--- a/.claude/skills/test-repo/test-harness.sh
+++ b/.claude/skills/test-repo/test-harness.sh
@@ -44,7 +44,8 @@ configure-strategy)
   # Only ignore test-specific dirs in root .gitignore
   printf ".claude-test/\n" >.gitignore
   git add .gitignore
-  "$BIN_PATH" enable --agent claude-code --strategy "$STRATEGY"
+  # manual-commit is the only strategy; enable no longer takes --strategy.
+  "$BIN_PATH" enable --agent claude-code
   git add .entire/settings.json .entire/.gitignore
   git add .claude 2>/dev/null || true
   git commit -m "Configure Entire with $STRATEGY strategy"
@@ -135,14 +136,24 @@ verify-shadow-branch)
   ;;
 
 verify-metadata-branch)
-  echo "==> Verifying metadata branch..."
+  echo "==> Verifying checkpoint storage..."
   cd "$REPO_DIR"
 
-  if git branch -a | grep "entire/checkpoints/v1"; then
-    echo "✓ Metadata branch exists"
+  # `enable` defaults to the git-refs backend: condensed checkpoints live
+  # under refs/entire/checkpoints/<shard>/<ULID>. The entire/checkpoints/v1
+  # branch is the git-branch backend, still valid when settings select it.
+  refs=$(git for-each-ref --format='%(refname)' 'refs/entire/checkpoints/*')
+  if [ -n "$refs" ]; then
+    echo "✓ Checkpoint refs exist (git-refs backend)"
+    echo "$refs" | head -5
+    first_ref=$(echo "$refs" | head -1)
+    git ls-tree -r "$first_ref" --name-only | head -10
+  elif git branch -a | grep "entire/checkpoints/v1"; then
+    echo "✓ Metadata branch exists (git-branch backend)"
     git show entire/checkpoints/v1 --stat | head -20
   else
-    echo "✗ Metadata branch not found"
+    echo "✗ No checkpoint storage found (neither refs/entire/checkpoints/* nor entire/checkpoints/v1)"
+    echo "  Checkpoints condense on user commits — run the commit-changes step first."
     exit 1
   fi
   ;;
@@ -163,6 +174,20 @@ create-changes)
 
   echo "Modified: app.js"
   echo "Created: extra.js"
+  ;;
+
+commit-changes)
+  echo "==> Committing session changes (triggers post-commit condensation)..."
+  cd "$REPO_DIR"
+
+  # The post-commit hook resolves `entire` from PATH; point it at BIN_PATH so
+  # condensation runs the binary under test, not an installed release.
+  mkdir -p "$REPO_DIR/.test-bin"
+  ln -sf "$BIN_PATH" "$REPO_DIR/.test-bin/entire"
+  git add -A
+  PATH="$REPO_DIR/.test-bin:$PATH" git commit -m "Session changes"
+
+  echo "Committed; checkpoints condense into storage on this commit"
   ;;
 
 cleanup)
@@ -193,7 +218,8 @@ info)
   echo "  verify-commit            - Verify active branch commit"
   echo "  verify-session-state     - Verify session state files"
   echo "  verify-shadow-branch     - Verify shadow branch exists"
-  echo "  verify-metadata-branch   - Verify metadata branch exists"
+  echo "  commit-changes           - Commit session changes (condenses checkpoints)"
+  echo "  verify-metadata-branch   - Verify checkpoint storage (refs or v1 branch)"
   echo "  list-pending-checkpoints - List pending (not yet condensed) checkpoints"
   echo "  create-changes           - Create changes on top of the checkpoint"
   echo "  cleanup                  - Clean up test environment"

--- a/.claude/skills/test-repo/test-harness.sh
+++ b/.claude/skills/test-repo/test-harness.sh
@@ -142,7 +142,9 @@ verify-metadata-branch)
   # `enable` defaults to the git-refs backend: condensed checkpoints live
   # under refs/entire/checkpoints/<shard>/<ULID>. The entire/checkpoints/v1
   # branch is the git-branch backend, still valid when settings select it.
-  refs=$(git for-each-ref --format='%(refname)' 'refs/entire/checkpoints/*')
+  # Prefix form, no glob: the refs sit two levels deep and for-each-ref's
+  # '*' does not cross '/', so 'refs/entire/checkpoints/*' matches nothing.
+  refs=$(git for-each-ref --format='%(refname)' 'refs/entire/checkpoints')
   if [ -n "$refs" ]; then
     echo "✓ Checkpoint refs exist (git-refs backend)"
     echo "$refs" | head -5


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1222
<!-- entire-trail-link-end -->

The test-repo skill harness was stale on two era assumptions, found while validating the user-settings work on #2166:

- `configure-strategy` passed `enable --strategy`, a flag that no longer exists (manual-commit is the only strategy) — the harness failed at setup.
- `verify-metadata-branch` asserted the `entire/checkpoints/v1` **branch**, but `enable` defaults to the **git-refs** backend, where a condensed checkpoint lives at `refs/entire/checkpoints/<shard>/<ULID>` — so it failed a perfectly healthy run.

Changes:
- `verify-metadata-branch` checks `refs/entire/checkpoints/*` first and keeps the v1 branch as the fallback for repos whose settings select the git-branch backend. git-refs stays the default and is what gets verified.
- New `commit-changes` step (with a PATH shim so the post-commit hook runs the binary under test), ordered before the storage check: checkpoints condense on **user commits**, so verifying storage right after `stop-session` could never succeed on git-refs.
- SKILL.md expectations/table/snippets updated to match.

Validated end-to-end against a main-built binary: setup → session → stop → commit → verify passes, trailer added by prepare-commit-msg, checkpoint condensed to `refs/entire/checkpoints/9N/01M1HRM8…`. shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the test-repo skill harness and documentation; no production CLI or runtime behavior is modified.
> 
> **Overview**
> Updates the **test-repo** skill and `test-harness.sh` so manual E2E validation matches current CLI behavior instead of failing on setup or storage checks.
> 
> **Harness fixes:** `configure-strategy` now runs `entire enable --agent claude-code` without the removed `--strategy` flag. A new **`commit-changes`** step commits session work with a PATH shim so the post-commit hook runs the binary under test; it is inserted before checkpoint verification because condensation happens on user commits, not immediately after `stop-session`.
> 
> **Verification:** `verify-metadata-branch` (still the step name) now looks for condensed checkpoints under `refs/entire/checkpoints/*` (git-refs, `enable`'s default) and falls back to the `entire/checkpoints/v1` branch when settings use the git-branch backend.
> 
> **Docs:** `SKILL.md` flow tables, one-liner recipe, and manual-commit expectations describe checkpoint storage and ordering accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d6bfa5b1e3c9b3fee09343fab63979e18fbe009. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->