### PR TITLE
fix(trail): add support for native repos

### DIFF
--- a/cmd/entire/cli/agent_help_cmd.go
+++ b/cmd/entire/cli/agent_help_cmd.go
@@ -351,7 +351,7 @@ func refreshAgentHelpTrailsEnabledCacheIfStaleForScope(ctx context.Context, scop
 	if !scope.Supported {
 		return saveTrailsEnabledForScope(ctx, scope, false, time.Now())
 	}
-	client, notOnboarded, err := trailsCellClient(ctx, false, scope.Owner+"/"+scope.Repo)
+	client, notOnboarded, err := trailsCellClient(ctx, false, scope.Forge, scope.Owner, scope.Repo)
 	if notOnboarded {
 		// Definitive negative: cache it for trailEnablementCacheTTL rather than
 		// falling into the short refresh-failure backoff, which would re-pay the

--- a/cmd/entire/cli/agent_help_cmd_test.go
+++ b/cmd/entire/cli/agent_help_cmd_test.go
@@ -19,12 +19,6 @@ import (
 
 const agentHelpTestRepo = "gh/acme/app"
 
-// testTrailCellRoutedFullName is the "owner/repo" fullName the entire-api
-// cell-routed client (trailRefreshAPIClient) is expected to receive when a
-// repo-scoped trails probe routes correctly through it, shared by the tests
-// covering the two legacy-BFF-routing fixes.
-const testTrailCellRoutedFullName = "acme/widget"
-
 // commandNames returns the Use-name of each command, for assertions.
 func commandNames(cmds []*cobra.Command) []string {
 	names := make([]string, 0, len(cmds))
@@ -230,10 +224,10 @@ func TestRefreshAgentHelpTrailsEnabledCacheIfStaleForScope_RoutesThroughRepoCell
 	t.Chdir(t.TempDir())
 
 	previous := trailRefreshAPIClient
-	var gotFullName string
+	var gotForge, gotOwner, gotRepo string
 	wantErr := errors.New("cell client unavailable")
-	trailRefreshAPIClient = func(_ context.Context, _ bool, fullName string) (*api.Client, error) {
-		gotFullName = fullName
+	trailRefreshAPIClient = func(_ context.Context, _ bool, forge, owner, repo string) (*api.Client, error) {
+		gotForge, gotOwner, gotRepo = forge, owner, repo
 		return nil, wantErr
 	}
 	t.Cleanup(func() { trailRefreshAPIClient = previous })
@@ -242,16 +236,16 @@ func TestRefreshAgentHelpTrailsEnabledCacheIfStaleForScope_RoutesThroughRepoCell
 		Forge:     "gh",
 		Owner:     "acme",
 		Repo:      "widget",
-		RepoKey:   trailEnablementRepoKey("gh", "acme", "widget"),
 		APIBase:   api.BaseURL(),
 		AuthKey:   "test-auth-key",
 		Supported: true,
 	}
+	scope.RepoKey = trailEnablementRepoKey(scope.Forge, scope.Owner, scope.Repo)
 
 	err := refreshAgentHelpTrailsEnabledCacheIfStaleForScope(t.Context(), scope)
 
-	if gotFullName != testTrailCellRoutedFullName {
-		t.Fatalf("trailRefreshAPIClient fullName = %q, want %s", gotFullName, testTrailCellRoutedFullName)
+	if gotForge != scope.Forge || gotOwner != scope.Owner || gotRepo != scope.Repo {
+		t.Fatalf("trailRefreshAPIClient repo = (%q,%q,%q), want (gh,acme,widget)", gotForge, gotOwner, gotRepo)
 	}
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("err = %v, want %v", err, wantErr)
@@ -272,7 +266,7 @@ func TestRefreshAgentHelpTrailsEnabledCacheIfStaleForScope_NotOnboardedSavesDisa
 	runGitInDir(t, ".", "remote", "add", "origin", "https://github.com/acme/widget.git")
 
 	previous := trailRefreshAPIClient
-	trailRefreshAPIClient = func(context.Context, bool, string) (*api.Client, error) {
+	trailRefreshAPIClient = func(context.Context, bool, string, string, string) (*api.Client, error) {
 		return nil, fmt.Errorf("resolve the Entire cell for acme/widget: %w", errRepoNotOnboarded)
 	}
 	t.Cleanup(func() { trailRefreshAPIClient = previous })

--- a/cmd/entire/cli/api_client.go
+++ b/cmd/entire/cli/api_client.go
@@ -72,11 +72,11 @@ func NewAuthenticatedEntireAPICellClient(ctx context.Context, insecureHTTP bool,
 	return auth.NewEntireAPICellClient(ctx, insecureHTTP, target) //nolint:wrapcheck // pass through contextual auth errors
 }
 
-// newTrailAPIClient dials the entire-api cell that owns the repository and
-// returns the processing placement ID used by repo-addressed trail reads. It is
-// a package seam so tests can substitute a client pointed at a stub server.
-var newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, fullName string) (*api.Client, string, error) {
-	placement, err := resolveRepoCellPlacementByFullName(ctx, fullName)
+// newTrailAPIClient dials the entire-api cell that owns the forge-qualified
+// repository and returns its repo_id for repo-addressed trail reads. It is a
+// package seam so tests can substitute a client pointed at a stub server.
+var newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, forge, owner, repo string) (*api.Client, string, error) {
+	placement, err := resolveTrailRepoCellPlacement(ctx, forge, owner, repo)
 	if err != nil {
 		return nil, "", err
 	}

--- a/cmd/entire/cli/api_client.go
+++ b/cmd/entire/cli/api_client.go
@@ -72,17 +72,22 @@ func NewAuthenticatedEntireAPICellClient(ctx context.Context, insecureHTTP bool,
 	return auth.NewEntireAPICellClient(ctx, insecureHTTP, target) //nolint:wrapcheck // pass through contextual auth errors
 }
 
-// newTrailAPIClient dials the entire-api cell that owns the repository. It is a
-// package seam so tests can substitute a client pointed at a stub server.
-var newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, fullName string) (*api.Client, error) {
-	client, err := NewAuthenticatedEntireAPICellClient(ctx, insecureHTTP, fullName)
+// newTrailAPIClient dials the entire-api cell that owns the repository and
+// returns the processing placement ID used by repo-addressed trail reads. It is
+// a package seam so tests can substitute a client pointed at a stub server.
+var newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, fullName string) (*api.Client, string, error) {
+	placement, err := resolveRepoCellPlacementByFullName(ctx, fullName)
+	if err != nil {
+		return nil, "", err
+	}
+	client, err := auth.NewEntireAPICellClient(ctx, insecureHTTP, placement.Target)
 	if errors.Is(err, clusterdiscovery.ErrNoAuthContext) {
 		// Preserve cluster discovery's detailed host/context hint while restoring
 		// the sentinel trail commands use for the standard login UX.
-		return nil, fmt.Errorf("%w: %w", auth.ErrNotLoggedIn, err)
+		return nil, "", fmt.Errorf("%w: %w", auth.ErrNotLoggedIn, err)
 	}
 	if err != nil {
-		return nil, err
+		return nil, "", err //nolint:wrapcheck // auth client returns contextual, user-facing errors
 	}
-	return client, nil
+	return client, placement.RepoID, nil
 }

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -91,15 +91,23 @@ func resolveRepoCellTarget(ctx context.Context, fullName, ulid string) (*auth.Ce
 		return target, nil
 	}
 
-	owner, repo, ok := strings.Cut(strings.TrimSpace(fullName), "/")
-	if !ok || owner == "" || repo == "" {
-		return nil, fmt.Errorf("invalid repo %q: expected owner/repo", fullName)
-	}
-	placement, err := resolveRepoCellPlacement(ctx, owner, repo)
+	placement, err := resolveRepoCellPlacementByFullName(ctx, fullName)
 	if err != nil {
 		return nil, err
 	}
 	return placement.Target, nil
+}
+
+// resolveRepoCellPlacementByFullName parses an owner/repo name and resolves
+// the processing placement. Keeping this boundary shared ensures callers that
+// need both the cell and repo ID make exactly the same placement choice as
+// callers that need only the cell.
+func resolveRepoCellPlacementByFullName(ctx context.Context, fullName string) (repoCellPlacement, error) {
+	owner, repo, ok := strings.Cut(strings.TrimSpace(fullName), "/")
+	if !ok || owner == "" || repo == "" {
+		return repoCellPlacement{}, fmt.Errorf("invalid repo %q: expected owner/repo", fullName)
+	}
+	return resolveRepoCellPlacement(ctx, owner, repo)
 }
 
 // cellTargetForClusterHost maps a known cluster host to a cell apiUrl +

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -42,9 +42,20 @@ type cellCoreClient interface {
 	ListRepos(ctx context.Context, params coreapi.ListReposParams) (*coreapi.ListReposOutputBody, error)
 }
 
+type nativeRepoCellCoreClient interface {
+	nativeRepoResolverClient
+	ListClusters(ctx context.Context) (*coreapi.ListClustersOutputBody, error)
+	ListRepos(ctx context.Context, params coreapi.ListReposParams) (*coreapi.ListReposOutputBody, error)
+}
+
 // newCellCoreClient builds the control-plane client used for cell resolution.
 // Swapped in tests.
 var newCellCoreClient = func() (cellCoreClient, error) { return coreapi.New() }
+
+// newNativeRepoCellCoreClient adds the project-scoped name lookup surface
+// needed for /et/ repository identities. Kept separate from cellCoreClient so
+// cached GitHub index clients do not need unrelated native lookup methods.
+var newNativeRepoCellCoreClient = func() (nativeRepoCellCoreClient, error) { return coreapi.New() }
 
 // resolveRepoCellTarget resolves the entire-api cell that HOSTS the given
 // repo, plus that cell's jurisdiction, so a repo-scoped call (trails, experts)
@@ -268,16 +279,58 @@ func lookupRepoIndexEntry(ctx context.Context, c cellCoreClient, fullName string
 	return entry, nil
 }
 
-// repoCellPlacement is a repo's processing placement: the id entire-api keys
-// repo-scoped routes on, paired with the cell that actually holds it.
+// repoCellPlacement is the identity entire-api keys repo-scoped routes on,
+// paired with the cell that actually holds it. For a GitHub mirror RepoID is
+// the processing placement ID; for an Entire-native repo it is core Repo.ID.
 type repoCellPlacement struct {
-	// RepoID is the placement id (coreapi.RepoPlacement.ID), which entire-api
-	// uses as its repo_id — verified identical to the id the old
-	// mirrors-based lookup used (coreapi.Mirror.MirrorId) for the same
-	// placement.
+	// RepoID is the value entire-api uses as repo_id. For GitHub mirrors this is
+	// coreapi.RepoPlacement.ID (verified identical to the legacy
+	// coreapi.Mirror.MirrorId); for native repos it is coreapi.Repo.ID.
 	RepoID string
-	// Target is the cell hosting THIS placement.
+	// Target is the cell hosting this repo identity.
 	Target *auth.CellTarget
+}
+
+// resolveTrailRepoCellPlacement keeps the forge namespace in repository
+// identity resolution. A native /et/<project>/<repo> and a legacy
+// /gh/<owner>/<repo> can have the same two trailing path segments but are
+// different repositories with different repo IDs and, potentially, cells.
+func resolveTrailRepoCellPlacement(ctx context.Context, forge, owner, repo string) (repoCellPlacement, error) {
+	if forge == nativeCloneForge {
+		return resolveNativeRepoCellPlacement(ctx, owner, repo)
+	}
+	return resolveRepoCellPlacement(ctx, owner, repo)
+}
+
+// resolveNativeRepoCellPlacement resolves /et/<project>/<repo> through the
+// native project-scoped repo lookup, then maps the repo's home cluster to its
+// entire-api cell. It deliberately never consults the forge-blind repos index:
+// that index can select a same-named /gh/ mirror instead.
+func resolveNativeRepoCellPlacement(ctx context.Context, project, repoName string) (repoCellPlacement, error) {
+	ctx, cancel := context.WithTimeout(ctx, requiredCellResolveTimeout)
+	defer cancel()
+
+	c, err := newNativeRepoCellCoreClient()
+	if err != nil {
+		return repoCellPlacement{}, fmt.Errorf("control plane unavailable: %w", err)
+	}
+	repo, err := resolveNativeRepo(ctx, c, project, repoName)
+	if err != nil {
+		return repoCellPlacement{}, cellPlacementError(ctx, project+"/"+repoName, fmt.Errorf("resolve native repo %s/%s: %w", project, repoName, err))
+	}
+	repoID := strings.TrimSpace(repo.ID)
+	if repoID == "" {
+		return repoCellPlacement{}, fmt.Errorf("resolve native repo %s/%s: repo has no id", project, repoName)
+	}
+	clusterHost := strings.TrimSpace(repo.ClusterHost.Or(""))
+	if clusterHost == "" {
+		return repoCellPlacement{}, fmt.Errorf("resolve the Entire cell for %s/%s: repo has no cluster host", project, repoName)
+	}
+	target, err := cellTargetForClusterHost(ctx, c, clusterHost)
+	if err != nil {
+		return repoCellPlacement{}, cellPlacementError(ctx, repoID, fmt.Errorf("resolve the Entire cell for %s/%s: %w", project, repoName, err))
+	}
+	return repoCellPlacement{RepoID: repoID, Target: target}, nil
 }
 
 // resolveRepoCellPlacement resolves a GitHub repo to its processing

--- a/cmd/entire/cli/cell_target.go
+++ b/cmd/entire/cli/cell_target.go
@@ -197,6 +197,13 @@ func cellTargetFromCluster(cluster coreapi.Cluster) (*auth.CellTarget, error) {
 // consumer caches under a TTL, so a completed onboarding self-heals.
 var errRepoNotOnboarded = errors.New("repo is not onboarded to Entire")
 
+// repoNotOnboardedError tags a definitive repository-placement miss without
+// replacing its actionable user-facing message.
+type repoNotOnboardedError struct{ inner error }
+
+func (e *repoNotOnboardedError) Error() string   { return e.inner.Error() }
+func (e *repoNotOnboardedError) Unwrap() []error { return []error{e.inner, errRepoNotOnboarded} }
+
 // resolveProcessingPlacement resolves fullName's PROCESSING placement — the
 // placement id and cell entire-api and the control plane treat as
 // authoritative for repo-scoped data (trails, experts, checkpoint/explain),
@@ -316,6 +323,9 @@ func resolveNativeRepoCellPlacement(ctx context.Context, project, repoName strin
 	}
 	repo, err := resolveNativeRepo(ctx, c, project, repoName)
 	if err != nil {
+		if errors.Is(err, errNamedRefNotFound) {
+			err = &repoNotOnboardedError{inner: err}
+		}
 		return repoCellPlacement{}, cellPlacementError(ctx, project+"/"+repoName, fmt.Errorf("resolve native repo %s/%s: %w", project, repoName, err))
 	}
 	repoID := strings.TrimSpace(repo.ID)
@@ -324,7 +334,7 @@ func resolveNativeRepoCellPlacement(ctx context.Context, project, repoName strin
 	}
 	clusterHost := strings.TrimSpace(repo.ClusterHost.Or(""))
 	if clusterHost == "" {
-		return repoCellPlacement{}, fmt.Errorf("resolve the Entire cell for %s/%s: repo has no cluster host", project, repoName)
+		return repoCellPlacement{}, &repoNotOnboardedError{inner: fmt.Errorf("resolve the Entire cell for %s/%s: repo has no cluster host", project, repoName)}
 	}
 	target, err := cellTargetForClusterHost(ctx, c, clusterHost)
 	if err != nil {

--- a/cmd/entire/cli/cell_target_test.go
+++ b/cmd/entire/cli/cell_target_test.go
@@ -79,12 +79,16 @@ func TestMatchClusterBySlug(t *testing.T) {
 // fakeCellCore is a stub control plane for resolveRepoCellTarget /
 // resolveRepoCellPlacement tests.
 type fakeCellCore struct {
-	repo        *coreapi.Repo
-	repoErr     error
-	clusters    []coreapi.Cluster
-	clustersErr error
-	repos       *coreapi.ListReposOutputBody
-	reposErr    error
+	repo         *coreapi.Repo
+	repoErr      error
+	projects     *coreapi.ListProjectsOutputBody
+	projectsErr  error
+	projectRepos *coreapi.ListProjectReposOutputBody
+	projectErr   error
+	clusters     []coreapi.Cluster
+	clustersErr  error
+	repos        *coreapi.ListReposOutputBody
+	reposErr     error
 	// blockUntilCtxDone makes ListRepos and GetRepo hang until the caller's
 	// deadline fires, standing in for a reachable-but-slow control plane —
 	// both, so the owner/repo and ULID paths can each be tested. Off by
@@ -114,6 +118,32 @@ func (f *fakeCellCore) GetRepo(ctx context.Context, _ coreapi.GetRepoParams) (*c
 	return f.repo, f.repoErr
 }
 
+func (f *fakeCellCore) ListProjects(ctx context.Context, _ coreapi.ListProjectsParams) (*coreapi.ListProjectsOutputBody, error) {
+	if err := f.waitIfBlocking(ctx); err != nil {
+		return nil, err
+	}
+	if f.projectsErr != nil {
+		return nil, f.projectsErr
+	}
+	if f.projects != nil {
+		return f.projects, nil
+	}
+	return &coreapi.ListProjectsOutputBody{}, nil
+}
+
+func (f *fakeCellCore) ListProjectRepos(ctx context.Context, _ coreapi.ListProjectReposParams) (*coreapi.ListProjectReposOutputBody, error) {
+	if err := f.waitIfBlocking(ctx); err != nil {
+		return nil, err
+	}
+	if f.projectErr != nil {
+		return nil, f.projectErr
+	}
+	if f.projectRepos != nil {
+		return f.projectRepos, nil
+	}
+	return &coreapi.ListProjectReposOutputBody{}, nil
+}
+
 func (f *fakeCellCore) ListClusters(context.Context) (*coreapi.ListClustersOutputBody, error) {
 	if f.clustersErr != nil {
 		return nil, f.clustersErr
@@ -140,8 +170,49 @@ func (f *fakeCellCore) ListRepos(ctx context.Context, params coreapi.ListReposPa
 func withFakeCellCore(t *testing.T, f *fakeCellCore) {
 	t.Helper()
 	prev := newCellCoreClient
+	prevNative := newNativeRepoCellCoreClient
 	newCellCoreClient = func() (cellCoreClient, error) { return f, nil }
-	t.Cleanup(func() { newCellCoreClient = prev })
+	newNativeRepoCellCoreClient = func() (nativeRepoCellCoreClient, error) { return f, nil }
+	t.Cleanup(func() {
+		newCellCoreClient = prev
+		newNativeRepoCellCoreClient = prevNative
+	})
+}
+
+func TestResolveTrailRepoCellPlacement_NativeDoesNotSelectSameNamedGitHubMirror(t *testing.T) {
+	const (
+		projectID  = "01NATIVEPROJECT00000000000"
+		nativeID   = "01NATIVEREPOSITORY00000000"
+		legacyGHID = "01LEGACYGHMIRROR000000000"
+	)
+	withFakeCellCore(t, &fakeCellCore{
+		projects: &coreapi.ListProjectsOutputBody{Project: coreapi.NewOptProject(coreapi.Project{
+			ID: projectID, Name: "entirehq",
+		})},
+		projectRepos: &coreapi.ListProjectReposOutputBody{Repo: coreapi.NewOptRepo(coreapi.Repo{
+			ID: nativeID, Name: "marvin", OwningProjectId: projectID,
+		})},
+		repo: &coreapi.Repo{
+			ID: nativeID, Name: "marvin", OwningProjectId: projectID,
+			ClusterHost: coreapi.NewOptString("eu.entire.io"),
+		},
+		clusters: euClusters(),
+		// This is the forge-blind match the old implementation selected. The
+		// native resolver must never consult it.
+		repos: reposOutput(repoIndexFixture("entirehq/marvin", legacyGHID,
+			placementFixture{id: legacyGHID, slug: usClusterSlug})),
+	})
+
+	got, err := resolveTrailRepoCellPlacement(t.Context(), nativeCloneForge, "entirehq", "marvin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RepoID != nativeID {
+		t.Fatalf("RepoID = %q, want native repo ID %q (not legacy mirror %q)", got.RepoID, nativeID, legacyGHID)
+	}
+	if got.Target.BaseURL != euCellAPIURL || got.Target.Jurisdiction != "eu" {
+		t.Fatalf("Target = %+v, want EU native repo cell", got.Target)
+	}
 }
 
 // euClusters is keyed by PublicUrl host, the join the ULID path uses

--- a/cmd/entire/cli/cell_target_test.go
+++ b/cmd/entire/cli/cell_target_test.go
@@ -215,6 +215,63 @@ func TestResolveTrailRepoCellPlacement_NativeDoesNotSelectSameNamedGitHubMirror(
 	}
 }
 
+func TestResolveNativeRepoCellPlacement_ClassifiesDefinitiveMisses(t *testing.T) {
+	const (
+		projectID = "01NATIVEPROJECT00000000000"
+		repoID    = "01NATIVEREPOSITORY00000000"
+	)
+	project := &coreapi.ListProjectsOutputBody{Project: coreapi.NewOptProject(coreapi.Project{ID: projectID, Name: "entirehq"})}
+	projectRepo := &coreapi.ListProjectReposOutputBody{Repo: coreapi.NewOptRepo(coreapi.Repo{ID: repoID, Name: "marvin", OwningProjectId: projectID})}
+
+	tests := []struct {
+		name               string
+		core               *fakeCellCore
+		wantNotOnboarded   bool
+		wantMessageSnippet string
+	}{
+		{
+			name:               "project does not exist",
+			core:               &fakeCellCore{},
+			wantNotOnboarded:   true,
+			wantMessageSnippet: "no project named",
+		},
+		{
+			name:               "repo does not exist in project",
+			core:               &fakeCellCore{projects: project},
+			wantNotOnboarded:   true,
+			wantMessageSnippet: "no repo named",
+		},
+		{
+			name:               "repo has no cluster host",
+			core:               &fakeCellCore{projects: project, projectRepos: projectRepo, repo: &coreapi.Repo{ID: repoID, Name: "marvin", OwningProjectId: projectID}},
+			wantNotOnboarded:   true,
+			wantMessageSnippet: "repo has no cluster host",
+		},
+		{
+			name:               "control plane failure remains retryable",
+			core:               &fakeCellCore{projectsErr: errors.New("core unavailable")},
+			wantNotOnboarded:   false,
+			wantMessageSnippet: "core unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withFakeCellCore(t, tt.core)
+			_, err := resolveNativeRepoCellPlacement(t.Context(), "entirehq", "marvin")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := errors.Is(err, errRepoNotOnboarded); got != tt.wantNotOnboarded {
+				t.Fatalf("errors.Is(err, errRepoNotOnboarded) = %v, want %v (err: %v)", got, tt.wantNotOnboarded, err)
+			}
+			if !strings.Contains(err.Error(), tt.wantMessageSnippet) {
+				t.Fatalf("error = %q, want substring %q", err, tt.wantMessageSnippet)
+			}
+		})
+	}
+}
+
 // euClusters is keyed by PublicUrl host, the join the ULID path uses
 // (cellTargetForClusterHost / matchClusterByHost).
 func euClusters() []coreapi.Cluster {

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -2768,7 +2768,7 @@ func TestRunTrailEnablementRefresh_NotOnboardedSavesDisabledCache(t *testing.T) 
 	runGitInDir(t, ".", "remote", "add", "origin", "https://github.com/entirehq/example.git")
 
 	prevClient := trailRefreshAPIClient
-	trailRefreshAPIClient = func(context.Context, bool, string) (*api.Client, error) {
+	trailRefreshAPIClient = func(context.Context, bool, string, string, string) (*api.Client, error) {
 		return nil, fmt.Errorf("resolve the Entire cell for entirehq/example: %w", errRepoNotOnboarded)
 	}
 	t.Cleanup(func() { trailRefreshAPIClient = prevClient })
@@ -2831,7 +2831,7 @@ func TestNewRefreshTrailEnablementCmd_APIFailureExitsZero(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	prevClient := trailRefreshAPIClient
-	trailRefreshAPIClient = func(context.Context, bool, string) (*api.Client, error) {
+	trailRefreshAPIClient = func(context.Context, bool, string, string, string) (*api.Client, error) {
 		return api.NewClientWithBaseURL("test-token", srv.URL), nil
 	}
 	t.Cleanup(func() { trailRefreshAPIClient = prevClient })

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -137,6 +137,25 @@ func parseNativeCloneRef(ref string) (project, repo string, err error) {
 	return project, repo, nil
 }
 
+type nativeRepoResolverClient interface {
+	repoRefClient
+	GetRepo(ctx context.Context, params coreapi.GetRepoParams) (*coreapi.Repo, error)
+}
+
+// resolveNativeRepo performs the canonical /et/<project>/<repo> identity
+// lookup shared by clone and repo-scoped data commands.
+func resolveNativeRepo(ctx context.Context, c nativeRepoResolverClient, project, repoName string) (*coreapi.Repo, error) {
+	repoID, err := resolveRepoRef(ctx, c, repoName, project)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := c.GetRepo(ctx, coreapi.GetRepoParams{RepoId: repoID})
+	if err != nil {
+		return nil, fmt.Errorf("get repo: %w", err)
+	}
+	return repo, nil
+}
+
 // resolveNativeCloneURL resolves an Entire-native repo (by project and repo
 // name) to its entire:// clone URL: name → ULID via the project-scoped lookup,
 // then GetRepo — the one call that returns both clusterHost and path. The URL
@@ -144,13 +163,9 @@ func parseNativeCloneRef(ref string) (project, repo string, err error) {
 // user's ref. repoName arrives with any `.git` suffix already dropped by the
 // parser (see gitDirSuffix).
 func resolveNativeCloneURL(ctx context.Context, c *coreapi.Client, project, repoName string) (string, error) {
-	repoID, err := resolveRepoRef(ctx, c, repoName, project)
+	repo, err := resolveNativeRepo(ctx, c, project, repoName)
 	if err != nil {
 		return "", err
-	}
-	repo, err := c.GetRepo(ctx, coreapi.GetRepoParams{RepoId: repoID})
-	if err != nil {
-		return "", fmt.Errorf("get repo: %w", err)
 	}
 	cloneURL := repoRemoteURL(*repo)
 	if cloneURL == "" {

--- a/cmd/entire/cli/resolveref.go
+++ b/cmd/entire/cli/resolveref.go
@@ -27,6 +27,19 @@ import (
 // the checkpoint hosting provider — same string, unrelated concern.)
 const providerGitHub = "github"
 
+// projectRefClient and repoRefClient are the narrow control-plane surfaces the
+// name resolvers need. Keeping the helpers on interfaces lets repo-scoped
+// callers resolve a native /et/<project>/<repo> identity with the same client
+// they use to locate its home cell.
+type projectRefClient interface {
+	ListProjects(ctx context.Context, params coreapi.ListProjectsParams) (*coreapi.ListProjectsOutputBody, error)
+}
+
+type repoRefClient interface {
+	projectRefClient
+	ListProjectRepos(ctx context.Context, params coreapi.ListProjectReposParams) (*coreapi.ListProjectReposOutputBody, error)
+}
+
 // looksLikeULID reports whether s has the shape of a ULID: 26 characters drawn
 // from Crockford base32 (digits plus uppercase letters, excluding I, L, O, U).
 // The check is shape-only and case-insensitive on the alphabet; it never hits
@@ -158,7 +171,7 @@ func parseQualifiedHandle(ref string) (provider, handle string, err error) {
 // ULID is returned unchanged; a name is resolved via the server's
 // case-insensitive by-name lookup (the same call `entire project list --name`
 // uses). Project names are globally unique, so a name maps to at most one project.
-func resolveProjectRef(ctx context.Context, c *coreapi.Client, ref string) (string, error) {
+func resolveProjectRef(ctx context.Context, c projectRefClient, ref string) (string, error) {
 	if looksLikeULID(ref) {
 		return ref, nil
 	}
@@ -167,7 +180,7 @@ func resolveProjectRef(ctx context.Context, c *coreapi.Client, ref string) (stri
 		if isCoreNotFound(err) {
 			return "", noProjectNamedErr(ref)
 		}
-		return "", err
+		return "", fmt.Errorf("list projects: %w", err)
 	}
 	project, ok := out.Project.Get()
 	if !ok {
@@ -183,7 +196,7 @@ func resolveProjectRef(ctx context.Context, c *coreapi.Client, ref string) (stri
 // org/project endpoints, a name-filtered list returns the single match under the
 // response's singular `repo` field (the plural `repos` is only populated for an
 // unfiltered page) — reading `repos` here was the COR-699 bug.
-func resolveRepoRef(ctx context.Context, c *coreapi.Client, ref, projectRef string) (string, error) {
+func resolveRepoRef(ctx context.Context, c repoRefClient, ref, projectRef string) (string, error) {
 	if looksLikeULID(ref) {
 		return ref, nil
 	}
@@ -199,7 +212,7 @@ func resolveRepoRef(ctx context.Context, c *coreapi.Client, ref, projectRef stri
 		if isCoreNotFound(err) {
 			return "", noRepoNamedErr(ref)
 		}
-		return "", err
+		return "", fmt.Errorf("list project repos: %w", err)
 	}
 	repo, ok := out.Repo.Get()
 	if !ok {

--- a/cmd/entire/cli/resolveref.go
+++ b/cmd/entire/cli/resolveref.go
@@ -225,12 +225,21 @@ func noOrgNamedErr(name string) error {
 	return fmt.Errorf("no org named %q (run `entire org list` to see names, or pass a ULID)", name)
 }
 
+var errNamedRefNotFound = errors.New("named reference not found")
+
+// namedRefNotFoundError preserves the actionable user-facing message while
+// allowing repository-routing callers to classify a definitive lookup miss.
+type namedRefNotFoundError struct{ message string }
+
+func (e *namedRefNotFoundError) Error() string { return e.message }
+func (e *namedRefNotFoundError) Unwrap() error { return errNamedRefNotFound }
+
 func noProjectNamedErr(name string) error {
-	return fmt.Errorf("no project named %q (run `entire project list` to see names, or pass a ULID)", name)
+	return &namedRefNotFoundError{message: fmt.Sprintf("no project named %q (run `entire project list` to see names, or pass a ULID)", name)}
 }
 
 func noRepoNamedErr(name string) error {
-	return fmt.Errorf("no repo named %q in that project (run `entire repo list <project>` to see names, or pass a ULID)", name)
+	return &namedRefNotFoundError{message: fmt.Sprintf("no repo named %q in that project (run `entire repo list <project>` to see names, or pass a ULID)", name)}
 }
 
 // resolvedRefLabel formats a reference for a success message so it always

--- a/cmd/entire/cli/review_bridge.go
+++ b/cmd/entire/cli/review_bridge.go
@@ -63,8 +63,8 @@ func postReviewToTrail(ctx context.Context, out io.Writer, profileName, verdict 
 		fmt.Fprintln(out, "Nothing to report, so nothing was posted to the trail.")
 		return nil
 	}
-	return runAuthenticatedTrailAPI(ctx, out, false, "", func(ctx context.Context, client *api.Client) error {
-		target, err := resolveTrailReviewTarget(ctx, client, "", "", "")
+	return runAuthenticatedTrailAPI(ctx, out, false, "", func(ctx context.Context, client *api.Client, repoID string) error {
+		target, err := resolveTrailReviewTarget(ctx, client, repoID, "", "", "")
 		if err != nil {
 			return err
 		}

--- a/cmd/entire/cli/review_target.go
+++ b/cmd/entire/cli/review_target.go
@@ -36,8 +36,12 @@ func prepareReviewTarget(ctx context.Context, out, errOut io.Writer, selector st
 		if normalizeErr != nil {
 			return cliReview.TargetWorktree{}, normalizeErr
 		}
-		err = runAuthenticatedTrailAPI(ctx, errOut, false, "", func(ctx context.Context, client *api.Client) error {
-			found, findErr := resolveTrailBySelector(ctx, client, forge, owner, repo, normalized, "")
+		err = runAuthenticatedTrailAPI(ctx, errOut, false, "", func(ctx context.Context, client *api.Client, repoID string) error {
+			basePath, pathErr := trailRepoBasePath(forge, owner, repo, repoID)
+			if pathErr != nil {
+				return pathErr
+			}
+			found, findErr := resolveTrailBySelectorAtPath(ctx, client, basePath, forge, owner, repo, normalized, "")
 			if findErr != nil {
 				return findErr
 			}

--- a/cmd/entire/cli/runner_gather.go
+++ b/cmd/entire/cli/runner_gather.go
@@ -296,7 +296,7 @@ func gatherCheckpoints(ctx context.Context) string {
 
 func gatherTrails(ctx context.Context, errW io.Writer, limit int, insecureHTTP bool) string {
 	var out strings.Builder
-	err := runAuthenticatedTrailAPIWithRepoID(ctx, errW, insecureHTTP, "", func(ctx context.Context, client *api.Client, repoID string) error {
+	err := runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, "", func(ctx context.Context, client *api.Client, repoID string) error {
 		forge, owner, repo, err := resolveTrailRemote(ctx)
 		if err != nil {
 			return err
@@ -326,7 +326,7 @@ func gatherTrails(ctx context.Context, errW io.Writer, limit int, insecureHTTP b
 			scanned = scanned[:tuneMaxTrailsForFindings]
 		}
 		for i := range scanned {
-			client.SetTrailRoute(scanned[i].ID, trailNumberPath(forge, owner, repo, scanned[i].Number))
+			client.SetTrailRoute(scanned[i].ID, trailNumberPathForBase(basePath, scanned[i].Number))
 			comments, err := fetchAllTrailReviewComments(ctx, client, scanned[i].ID, trailReviewSummaryOptions())
 			if err != nil {
 				fetchFailures++

--- a/cmd/entire/cli/runner_gather.go
+++ b/cmd/entire/cli/runner_gather.go
@@ -301,7 +301,7 @@ func gatherTrails(ctx context.Context, errW io.Writer, limit int, insecureHTTP b
 		if err != nil {
 			return err
 		}
-		basePath, err := trailListBasePath(forge, owner, repo, repoID)
+		basePath, err := trailRepoBasePath(forge, owner, repo, repoID)
 		if err != nil {
 			return err
 		}

--- a/cmd/entire/cli/runner_gather.go
+++ b/cmd/entire/cli/runner_gather.go
@@ -296,12 +296,16 @@ func gatherCheckpoints(ctx context.Context) string {
 
 func gatherTrails(ctx context.Context, errW io.Writer, limit int, insecureHTTP bool) string {
 	var out strings.Builder
-	err := runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, "", func(ctx context.Context, client *api.Client) error {
+	err := runAuthenticatedTrailAPIWithRepoID(ctx, errW, insecureHTTP, "", func(ctx context.Context, client *api.Client, repoID string) error {
 		forge, owner, repo, err := resolveTrailRemote(ctx)
 		if err != nil {
 			return err
 		}
-		resources, _, err := listTrailResources(ctx, client, forge, owner, repo, nil, "", limit)
+		basePath, err := trailListBasePath(forge, owner, repo, repoID)
+		if err != nil {
+			return err
+		}
+		resources, _, err := listTrailResources(ctx, client, basePath, nil, "", limit)
 		if err != nil {
 			return err
 		}

--- a/cmd/entire/cli/runner_gather_test.go
+++ b/cmd/entire/cli/runner_gather_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// Not parallel: swaps newTrailAPIClient and changes the process working directory.
+func TestGatherTrailsUsesNativeRepoBaseForFindings(t *testing.T) {
+	const basePath = "/api/v1/repos/native-repo-id/trails"
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.RunGit(t, repoDir, "remote", "add", "origin", "entire://aws-us-east-2.entire.io/et/entirehq/marvin")
+	t.Chdir(repoDir)
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case basePath:
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{Trails: []api.TrailResource{{ID: "native-trail", Number: 3}}}); err != nil {
+				t.Errorf("encode trail list response: %v", err)
+			}
+		case basePath + "/3/reviews/comments":
+			if err := json.NewEncoder(w).Encode(api.TrailReviewCommentsResponse{Comments: []api.TrailReviewComment{{ID: "finding-1", Status: trailReviewStatusOpen}}}); err != nil {
+				t.Errorf("encode findings response: %v", err)
+			}
+		default:
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	previous := newTrailAPIClient
+	newTrailAPIClient = func(context.Context, bool, string, string, string) (*api.Client, string, error) {
+		return api.NewClientWithBaseURL("token", srv.URL), "native-repo-id", nil
+	}
+	t.Cleanup(func() { newTrailAPIClient = previous })
+
+	got := gatherTrails(t.Context(), io.Discard, 10, false)
+	if !strings.Contains(got, "1 past review findings") {
+		t.Fatalf("gatherTrails output = %q, want one finding", got)
+	}
+	if len(paths) != 2 || paths[0] != basePath || paths[1] != basePath+"/3/reviews/comments" {
+		t.Fatalf("request paths = %v, want native list and findings routes", paths)
+	}
+}

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1057,7 +1057,7 @@ func probeAndCacheTrailsEnablement(ctx context.Context, insecureHTTPAuth bool, i
 	probeCtx, cancel := context.WithTimeout(ctx, enableTrailsProbeBudget)
 	defer cancel()
 
-	client, notOnboarded, err := trailsCellClient(probeCtx, insecureHTTPAuth, info.Owner+"/"+info.Repo)
+	client, notOnboarded, err := trailsCellClient(probeCtx, insecureHTTPAuth, info.Forge, info.Owner, info.Repo)
 	if notOnboarded {
 		if saveErr := saveTrailsEnabledForRemote(ctx, info.Forge, info.Owner, info.Repo, false); saveErr != nil {
 			logging.Debug(ctx, "failed to cache trails enablement", "error", saveErr)

--- a/cmd/entire/cli/setup_report_enabled_test.go
+++ b/cmd/entire/cli/setup_report_enabled_test.go
@@ -27,10 +27,10 @@ func TestProbeAndCacheTrailsEnablement_RoutesThroughRepoCell(t *testing.T) {
 	t.Chdir(t.TempDir())
 
 	previous := trailRefreshAPIClient
-	var gotFullName string
+	var gotForge, gotOwner, gotRepo string
 	wantErr := errors.New("cell client unavailable")
-	trailRefreshAPIClient = func(_ context.Context, _ bool, fullName string) (*api.Client, error) {
-		gotFullName = fullName
+	trailRefreshAPIClient = func(_ context.Context, _ bool, forge, owner, repo string) (*api.Client, error) {
+		gotForge, gotOwner, gotRepo = forge, owner, repo
 		return nil, wantErr
 	}
 	t.Cleanup(func() { trailRefreshAPIClient = previous })
@@ -38,8 +38,8 @@ func TestProbeAndCacheTrailsEnablement_RoutesThroughRepoCell(t *testing.T) {
 	info := &gitremote.Info{Forge: "gh", Owner: "acme", Repo: "widget"}
 	probeAndCacheTrailsEnablement(t.Context(), false, info)
 
-	if gotFullName != testTrailCellRoutedFullName {
-		t.Fatalf("trailRefreshAPIClient fullName = %q, want %s", gotFullName, testTrailCellRoutedFullName)
+	if gotForge+"/"+gotOwner+"/"+gotRepo != "gh/acme/widget" {
+		t.Fatalf("trailRefreshAPIClient repo = (%q,%q,%q), want (gh,acme,widget)", gotForge, gotOwner, gotRepo)
 	}
 }
 
@@ -58,7 +58,7 @@ func TestProbeAndCacheTrailsEnablement_CachesEnabledDecision(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	previous := trailRefreshAPIClient
-	trailRefreshAPIClient = func(_ context.Context, _ bool, _ string) (*api.Client, error) {
+	trailRefreshAPIClient = func(_ context.Context, _ bool, _, _, _ string) (*api.Client, error) {
 		return api.NewClientWithBaseURL("tok", srv.URL), nil
 	}
 	t.Cleanup(func() { trailRefreshAPIClient = previous })
@@ -93,7 +93,7 @@ func TestProbeAndCacheTrailsEnablement_NotOnboardedSavesDisabledCache(t *testing
 	t.Chdir(repoDir)
 
 	previous := trailRefreshAPIClient
-	trailRefreshAPIClient = func(context.Context, bool, string) (*api.Client, error) {
+	trailRefreshAPIClient = func(context.Context, bool, string, string, string) (*api.Client, error) {
 		return nil, fmt.Errorf("resolve the Entire cell for acme/widget: %w", errRepoNotOnboarded)
 	}
 	t.Cleanup(func() { trailRefreshAPIClient = previous })
@@ -125,7 +125,7 @@ func TestProbeAndCacheTrailsEnablement_AppliesItsOwnBudget(t *testing.T) {
 	previous := trailRefreshAPIClient
 	var deadline time.Time
 	var hasDeadline bool
-	trailRefreshAPIClient = func(ctx context.Context, _ bool, _ string) (*api.Client, error) {
+	trailRefreshAPIClient = func(ctx context.Context, _ bool, _, _, _ string) (*api.Client, error) {
 		deadline, hasDeadline = ctx.Deadline()
 		return nil, errors.New("stop before any network call")
 	}
@@ -157,7 +157,7 @@ func TestProbeAndCacheTrailsEnablement_CachesEvenWhenTheParentIsDone(t *testing.
 	t.Chdir(repoDir)
 
 	previous := trailRefreshAPIClient
-	trailRefreshAPIClient = func(context.Context, bool, string) (*api.Client, error) {
+	trailRefreshAPIClient = func(context.Context, bool, string, string, string) (*api.Client, error) {
 		return nil, fmt.Errorf("resolve the Entire cell for acme/widget: %w", errRepoNotOnboarded)
 	}
 	t.Cleanup(func() { trailRefreshAPIClient = previous })

--- a/cmd/entire/cli/trail_approval_cmd.go
+++ b/cmd/entire/cli/trail_approval_cmd.go
@@ -13,8 +13,8 @@ import (
 )
 
 // trailApprovalsPath builds the approvals collection path for a trail number.
-func trailApprovalsPath(forge, owner, repo string, number int) string {
-	return trailNumberPath(forge, owner, repo, number) + "/approvals"
+func trailApprovalsPath(basePath string, number int) string {
+	return trailNumberPathForBase(basePath, number) + "/approvals"
 }
 
 // buildApprovalRequest validates and constructs an approval request. A
@@ -32,19 +32,15 @@ func buildApprovalRequest(event, message string) (api.TrailApprovalRequest, erro
 // the current branch (or --branch), and requires it to have a number (the
 // number-keyed subresource endpoints — approvals, threads — reject a trail
 // without one).
-func resolveNumberedTrail(ctx context.Context, client *api.Client, repoOverride, selector, branch string) (*api.TrailResource, string, string, string, error) {
-	forge, owner, repoName, err := resolveTrailRepoOrRemote(ctx, repoOverride)
+func resolveNumberedTrailAtPath(ctx context.Context, client *api.Client, basePath, forge, owner, repoName, selector, branch string) (*api.TrailResource, error) {
+	found, err := resolveTrailBySelectorAtPath(ctx, client, basePath, forge, owner, repoName, selector, branch)
 	if err != nil {
-		return nil, "", "", "", err
-	}
-	found, err := resolveTrailBySelector(ctx, client, forge, owner, repoName, selector, branch)
-	if err != nil {
-		return nil, "", "", "", err
+		return nil, err
 	}
 	if found.Number <= 0 {
-		return nil, "", "", "", errors.New("trail has no number yet")
+		return nil, errors.New("trail has no number yet")
 	}
-	return found, forge, owner, repoName, nil
+	return found, nil
 }
 
 // selectorFromArgs returns the first positional arg, mirroring `trail show`.
@@ -64,12 +60,20 @@ func submitTrailApproval(ctx context.Context, w, errW io.Writer, insecureHTTP bo
 		return err
 	}
 	// Auth/not-logged-in messages go to stderr; w carries command output only.
-	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, repoOverride, func(ctx context.Context, client *api.Client) error {
-		found, forge, owner, repoName, err := resolveNumberedTrail(ctx, client, repoOverride, selector, branch)
+	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, repoOverride, func(ctx context.Context, client *api.Client, repoID string) error {
+		forge, owner, repoName, err := resolveTrailRepoOrRemote(ctx, repoOverride)
 		if err != nil {
 			return err
 		}
-		resp, err := client.Post(ctx, trailApprovalsPath(forge, owner, repoName, found.Number), req)
+		basePath, err := trailRepoBasePath(forge, owner, repoName, repoID)
+		if err != nil {
+			return err
+		}
+		found, err := resolveNumberedTrailAtPath(ctx, client, basePath, forge, owner, repoName, selector, branch)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Post(ctx, trailApprovalsPath(basePath, found.Number), req)
 		if err != nil {
 			return fmt.Errorf("failed to submit approval: %w", err)
 		}
@@ -157,12 +161,20 @@ func runTrailApprovals(ctx context.Context, w, errW io.Writer, insecureHTTP bool
 		return errors.New("pass a trail selector or --branch, not both")
 	}
 	// Auth/not-logged-in messages go to stderr; w carries command output only.
-	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, repoOverride, func(ctx context.Context, client *api.Client) error {
-		found, forge, owner, repoName, err := resolveNumberedTrail(ctx, client, repoOverride, selector, branch)
+	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, repoOverride, func(ctx context.Context, client *api.Client, repoID string) error {
+		forge, owner, repoName, err := resolveTrailRepoOrRemote(ctx, repoOverride)
 		if err != nil {
 			return err
 		}
-		resp, err := client.Get(ctx, trailApprovalsPath(forge, owner, repoName, found.Number))
+		basePath, err := trailRepoBasePath(forge, owner, repoName, repoID)
+		if err != nil {
+			return err
+		}
+		found, err := resolveNumberedTrailAtPath(ctx, client, basePath, forge, owner, repoName, selector, branch)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Get(ctx, trailApprovalsPath(basePath, found.Number))
 		if err != nil {
 			return fmt.Errorf("failed to list approvals: %w", err)
 		}

--- a/cmd/entire/cli/trail_approval_cmd_test.go
+++ b/cmd/entire/cli/trail_approval_cmd_test.go
@@ -36,9 +36,10 @@ func TestBuildApprovalRequestApproveAllowsEmptyMessage(t *testing.T) {
 
 func TestTrailApprovalsPath(t *testing.T) {
 	t.Parallel()
-	got := trailApprovalsPath("gh", "acme", "widgets", 7)
-	if !strings.HasSuffix(got, "/7/approvals") {
-		t.Fatalf("path = %q, want .../7/approvals suffix", got)
+	const basePath = "/api/v1/repos/native-repo-id/trails"
+	got := trailApprovalsPath(basePath, 7)
+	if got != basePath+"/7/approvals" {
+		t.Fatalf("path = %q, want %q", got, basePath+"/7/approvals")
 	}
 }
 

--- a/cmd/entire/cli/trail_cell_client_test.go
+++ b/cmd/entire/cli/trail_cell_client_test.go
@@ -33,7 +33,7 @@ func TestTrailsCellClient_Contract(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			previous := trailRefreshAPIClient
-			trailRefreshAPIClient = func(context.Context, bool, string) (*api.Client, error) {
+			trailRefreshAPIClient = func(context.Context, bool, string, string, string) (*api.Client, error) {
 				if tc.clientErr != nil {
 					return nil, tc.clientErr
 				}
@@ -41,7 +41,7 @@ func TestTrailsCellClient_Contract(t *testing.T) {
 			}
 			t.Cleanup(func() { trailRefreshAPIClient = previous })
 
-			client, notOnboarded, err := trailsCellClient(context.Background(), false, "acme/widget")
+			client, notOnboarded, err := trailsCellClient(context.Background(), false, "gh", "acme", "widget")
 
 			if notOnboarded != tc.wantNotOnboard {
 				t.Errorf("notOnboarded = %v, want %v", notOnboarded, tc.wantNotOnboard)

--- a/cmd/entire/cli/trail_checkout_cmd_test.go
+++ b/cmd/entire/cli/trail_checkout_cmd_test.go
@@ -47,7 +47,7 @@ func TestResolveTrailBySelector_FindsBySelector(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			found, err := resolveTrailBySelector(context.Background(), client, "gh", "acme", "repo", tc.selector, "")
+			found, err := resolveTrailBySelectorAtPath(context.Background(), client, trailTestBasePath, "gh", "acme", "repo", tc.selector, "")
 			if err != nil {
 				t.Fatalf("resolveTrailBySelector: %v", err)
 			}
@@ -69,7 +69,7 @@ func TestResolveTrailBySelector_NotFoundIsAnError(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	found, err := resolveTrailBySelector(context.Background(), client, "gh", "acme", "repo", "does-not-exist", "")
+	found, err := resolveTrailBySelectorAtPath(context.Background(), client, trailTestBasePath, "gh", "acme", "repo", "does-not-exist", "")
 	if err == nil {
 		t.Fatalf("expected error for missing trail, got found = %#v", found)
 	}

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -203,20 +203,24 @@ Otherwise, <trail> may be a trail number, id, or branch in the target repo.`,
 
 // runTrailShow shows one trail, defaulting to the current branch's trail.
 func runTrailShow(ctx context.Context, w, errW io.Writer, opts trailShowOptions) error {
-	return runAuthenticatedTrailAPI(ctx, errW, opts.InsecureHTTP, opts.Repo, func(ctx context.Context, client *api.Client) error {
+	return runAuthenticatedTrailAPIWithRepoID(ctx, errW, opts.InsecureHTTP, opts.Repo, func(ctx context.Context, client *api.Client, repoID string) error {
 		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, opts.Repo)
 		if err != nil {
 			return err
 		}
-		return runTrailShowWithClient(ctx, w, errW, client, forge, owner, repo, opts)
+		basePath, err := trailRepoBasePath(forge, owner, repo, repoID)
+		if err != nil {
+			return err
+		}
+		return runTrailShowWithClientAtPath(ctx, w, errW, client, basePath, forge, owner, repo, opts)
 	})
 }
 
-// runTrailShowWithClient renders one trail once the repo and API client are
-// resolved. Warnings go to errW, so --json keeps stdout parseable even when the
-// best-effort description fetch fails.
-func runTrailShowWithClient(ctx context.Context, w, errW io.Writer, client *api.Client, forge, owner, repo string, opts trailShowOptions) error {
-	found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, opts.Selector, opts.Branch)
+// runTrailShowWithClientAtPath renders one trail once the repo route and API
+// client are resolved. Warnings go to errW, so --json keeps stdout parseable
+// even when the best-effort description fetch fails.
+func runTrailShowWithClientAtPath(ctx context.Context, w, errW io.Writer, client *api.Client, basePath, forge, owner, repo string, opts trailShowOptions) error {
+	found, err := resolveTrailBySelectorAtPath(ctx, client, basePath, forge, owner, repo, opts.Selector, opts.Branch)
 	if err != nil {
 		return err
 	}
@@ -244,7 +248,7 @@ func runTrailShowWithClient(ctx context.Context, w, errW io.Writer, client *api.
 			bodyText = snapshot
 		}
 	case found.Number > 0:
-		if bt, _, derr := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number); derr == nil {
+		if bt, _, derr := fetchTrailDescriptionAtPath(ctx, client, basePath, found.Number); derr == nil {
 			// A successful fetch means we authoritatively consulted the
 			// description, but it only supersedes the seeded list body when
 			// it actually carries text: an older/partial server that omits
@@ -285,13 +289,17 @@ func runTrailShowWithClient(ctx context.Context, w, errW io.Writer, client *api.
 // trail. It returns an actionable error (never a nil trail with a nil error)
 // when nothing matches, so callers can rely on a non-nil result.
 func resolveTrailBySelector(ctx context.Context, client *api.Client, forge, owner, repo, selector, branchOverride string) (*api.TrailResource, error) {
+	return resolveTrailBySelectorAtPath(ctx, client, trailsBasePath(forge, owner, repo), forge, owner, repo, selector, branchOverride)
+}
+
+func resolveTrailBySelectorAtPath(ctx context.Context, client *api.Client, basePath, forge, owner, repo, selector, branchOverride string) (*api.TrailResource, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
 		branch, err := resolveTrailBranch(ctx, branchOverride)
 		if err != nil {
 			return nil, fmt.Errorf("no trail selector given and current branch is unknown: %w\nhint: run 'entire trail list --status any' or pass a trail number, id, or branch", err)
 		}
-		found, err := findTrailByBranch(ctx, client, forge, owner, repo, branch)
+		found, err := findTrailByBranchAtPath(ctx, client, basePath, branch)
 		if err != nil {
 			return nil, err
 		}
@@ -300,7 +308,7 @@ func resolveTrailBySelector(ctx context.Context, client *api.Client, forge, owne
 		}
 		return found, nil
 	}
-	found, err := findTrailBySelector(ctx, client, forge, owner, repo, selector)
+	found, err := findTrailBySelectorAtPath(ctx, client, basePath, selector)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +443,11 @@ func trailWebURL(base, forge, owner, repo string, number int) string {
 // needs, so it is unaffected by the shape of sibling fields like
 // `checkpoints`/`thread`.
 func fetchTrailDescription(ctx context.Context, client *api.Client, forge, owner, repo string, number int) (string, string, error) {
-	resp, err := client.Get(ctx, trailNumberPath(forge, owner, repo, number))
+	return fetchTrailDescriptionAtPath(ctx, client, trailsBasePath(forge, owner, repo), number)
+}
+
+func fetchTrailDescriptionAtPath(ctx context.Context, client *api.Client, basePath string, number int) (string, string, error) {
+	resp, err := client.Get(ctx, trailNumberPathForBase(basePath, number))
 	if err != nil {
 		return "", "", fmt.Errorf("failed to fetch trail detail: %w", err)
 	}
@@ -523,7 +535,7 @@ func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Cli
 	// many pages as needed for --limit. Author login is filtered client-side:
 	// the new backend's author query is account-ID based, while the CLI's public
 	// flag has always accepted GitHub logins.
-	basePath, err := trailListBasePath(forge, owner, repo, repoID)
+	basePath, err := trailRepoBasePath(forge, owner, repo, repoID)
 	if err != nil {
 		return err
 	}
@@ -1236,10 +1248,10 @@ func newTrailCreateRequest(title, body, branch, base, statusStr, typeStr, priori
 // (and no etag) plus the error so the caller can warn (mirroring
 // runTrailShow); an empty detail body (older/partial server) falls back to the
 // list body with no error.
-func resolveTrailUpdateBody(ctx context.Context, client *api.Client, forge, owner, repo string, found *api.TrailResource) (body, etag string, err error) {
+func resolveTrailUpdateBodyAtPath(ctx context.Context, client *api.Client, basePath string, found *api.TrailResource) (body, etag string, err error) {
 	body = found.Body
 	if found.Number > 0 {
-		bt, et, ferr := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number)
+		bt, et, ferr := fetchTrailDescriptionAtPath(ctx, client, basePath, found.Number)
 		if ferr != nil {
 			return body, "", ferr
 		}
@@ -1327,18 +1339,22 @@ type trailUpdateInputs struct {
 }
 
 func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, inputs trailUpdateInputs) error {
-	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, inputs.Repo, func(ctx context.Context, client *api.Client) error {
+	return runAuthenticatedTrailAPIWithRepoID(ctx, errW, insecureHTTP, inputs.Repo, func(ctx context.Context, client *api.Client, repoID string) error {
 		forge, owner, repoName, err := resolveTrailRepoOrRemote(ctx, inputs.Repo)
 		if err != nil {
 			return err
 		}
-		return runTrailUpdateWithClient(ctx, w, errW, client, forge, owner, repoName, inputs)
+		basePath, err := trailRepoBasePath(forge, owner, repoName, repoID)
+		if err != nil {
+			return err
+		}
+		return runTrailUpdateWithClientAtPath(ctx, w, errW, client, basePath, inputs)
 	})
 }
 
-// runTrailUpdateWithClient applies a trail update once the repo and API client
-// are resolved.
-func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *api.Client, forge, owner, repoName string, inputs trailUpdateInputs) error {
+// runTrailUpdateWithClientAtPath applies a trail update once the repo route and
+// API client are resolved.
+func runTrailUpdateWithClientAtPath(ctx context.Context, w, errW io.Writer, client *api.Client, basePath string, inputs trailUpdateInputs) error {
 	// Determine branch.
 	branch := inputs.Branch
 	if branch == "" {
@@ -1350,7 +1366,7 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 	}
 
 	// Find the trail by branch.
-	found, err := findTrailByBranch(ctx, client, forge, owner, repoName, branch)
+	found, err := findTrailByBranchAtPath(ctx, client, basePath, branch)
 	if err != nil {
 		return err
 	}
@@ -1387,7 +1403,7 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 		// the form prefills with the current text and change detection below
 		// compares against the real server value. Warn on a fetch failure so
 		// a blank baseline doesn't silently overwrite an unseen description.
-		seedBody, seedETag, bodyErr := resolveTrailUpdateBody(ctx, client, forge, owner, repoName, found)
+		seedBody, seedETag, bodyErr := resolveTrailUpdateBodyAtPath(ctx, client, basePath, found)
 		if bodyErr != nil {
 			fmt.Fprintf(errW, "Warning: could not load current trail body: %v\n", bodyErr)
 		}
@@ -1457,7 +1473,7 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 	if found.Number <= 0 {
 		return fmt.Errorf("trail for branch %q has no number yet; cannot update", branch)
 	}
-	path := trailNumberPath(forge, owner, repoName, found.Number)
+	path := trailNumberPathForBase(basePath, found.Number)
 
 	// Metadata and description live on different routes, so an update touching
 	// both sends two requests. They are not atomic: if the metadata PATCH lands
@@ -1491,14 +1507,14 @@ func runTrailUpdateWithClient(ctx context.Context, w, errW io.Writer, client *ap
 		// fallback rather than failing the whole command — but say so, since
 		// this is the unattended path most likely to run without anyone
 		// watching for a silently downgraded conflict check.
-		if _, etag, ferr := fetchTrailDescription(ctx, client, forge, owner, repoName, found.Number); ferr != nil {
+		if _, etag, ferr := fetchTrailDescriptionAtPath(ctx, client, basePath, found.Number); ferr != nil {
 			fmt.Fprintf(errW, "Warning: could not verify trail body is unchanged (%v); writing without conflict detection\n", ferr)
 		} else {
 			bodyETag = etag
 		}
 	}
 	if inputs.BodyChanged {
-		if err := sendTrailBody(ctx, client, trailBodyPath(forge, owner, repoName, found.Number), body, bodyETag, inputs.Overwrite); err != nil {
+		if err := sendTrailBody(ctx, client, trailBodyPathForBase(basePath, found.Number), body, bodyETag, inputs.Overwrite); err != nil {
 			if hasMeta {
 				return fmt.Errorf("trail metadata was updated, but the body update failed (the metadata change already applied; retry only the --body change): %w", err)
 			}
@@ -1880,8 +1896,12 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 	ctx := cmd.Context()
 	w := cmd.OutOrStdout()
 
-	return runAuthenticatedTrailAPI(ctx, cmd.ErrOrStderr(), trailInsecureHTTP(cmd), trailRepoFlag(cmd), func(ctx context.Context, client *api.Client) error {
+	return runAuthenticatedTrailAPIWithRepoID(ctx, cmd.ErrOrStderr(), trailInsecureHTTP(cmd), trailRepoFlag(cmd), func(ctx context.Context, client *api.Client, repoID string) error {
 		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, trailRepoFlag(cmd))
+		if err != nil {
+			return err
+		}
+		basePath, err := trailRepoBasePath(forge, owner, repo, repoID)
 		if err != nil {
 			return err
 		}
@@ -1897,7 +1917,7 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 					return fmt.Errorf("failed to determine current branch: %w", err)
 				}
 			}
-			found, ferr := findTrailByBranch(ctx, client, forge, owner, repo, branch)
+			found, ferr := findTrailByBranchAtPath(ctx, client, basePath, branch)
 			if ferr != nil {
 				return ferr
 			}
@@ -1909,7 +1929,7 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 			}
 			number = found.Number
 			title = found.Title
-		} else if found, ferr := findTrailByNumber(ctx, client, forge, owner, repo, number); ferr == nil && found != nil {
+		} else if found, ferr := findTrailByNumberAtPath(ctx, client, basePath, number); ferr == nil && found != nil {
 			title = found.Title
 		}
 
@@ -1921,7 +1941,7 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 			return nil
 		}
 
-		if err := deleteTrailByNumber(ctx, client, forge, owner, repo, number); err != nil {
+		if err := deleteTrailByNumberAtPath(ctx, client, basePath, number); err != nil {
 			return err
 		}
 
@@ -1933,7 +1953,11 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 // deleteTrailByNumber deletes a trail; entire-api answers 204 No Content, so any
 // 2xx is a successful delete and the body is not read.
 func deleteTrailByNumber(ctx context.Context, client *api.Client, forge, owner, repo string, number int) error {
-	resp, err := client.Delete(ctx, trailNumberPath(forge, owner, repo, number))
+	return deleteTrailByNumberAtPath(ctx, client, trailsBasePath(forge, owner, repo), number)
+}
+
+func deleteTrailByNumberAtPath(ctx context.Context, client *api.Client, basePath string, number int) error {
+	resp, err := client.Delete(ctx, trailNumberPathForBase(basePath, number))
 	if err != nil {
 		return fmt.Errorf("failed to delete trail: %w", err)
 	}
@@ -2080,17 +2104,21 @@ func runTrailCreateInteractive(title, body, branch, statusStr *string, noBranch 
 
 // findTrailByBranch looks up a trail by branch name via the list API.
 func findTrailBySelector(ctx context.Context, client *api.Client, forge, owner, repo, selector string) (*api.TrailResource, error) {
+	return findTrailBySelectorAtPath(ctx, client, trailsBasePath(forge, owner, repo), selector)
+}
+
+func findTrailBySelectorAtPath(ctx context.Context, client *api.Client, basePath, selector string) (*api.TrailResource, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
 		return nil, nil //nolint:nilnil // empty selector means not found for this helper
 	}
 	if n, ok := parseTrailNumberSelector(selector); ok {
-		found, err := findTrailByNumber(ctx, client, forge, owner, repo, n)
+		found, err := findTrailByNumberAtPath(ctx, client, basePath, n)
 		if err != nil || found != nil {
 			return found, err
 		}
 	}
-	return findTrail(ctx, client, forge, owner, repo, func(t api.TrailResource) bool {
+	return findTrailAtPath(ctx, client, basePath, func(t api.TrailResource) bool {
 		return t.ID == selector || t.Branch == selector
 	})
 }
@@ -2104,7 +2132,11 @@ func parseTrailNumberSelector(selector string) (int, bool) {
 }
 
 func findTrailByBranch(ctx context.Context, client *api.Client, forge, owner, repo, branch string) (*api.TrailResource, error) {
-	return findTrail(ctx, client, forge, owner, repo, func(t api.TrailResource) bool {
+	return findTrailByBranchAtPath(ctx, client, trailsBasePath(forge, owner, repo), branch)
+}
+
+func findTrailByBranchAtPath(ctx context.Context, client *api.Client, basePath, branch string) (*api.TrailResource, error) {
+	return findTrailAtPath(ctx, client, basePath, func(t api.TrailResource) bool {
 		return t.Branch == branch
 	})
 }
@@ -2112,7 +2144,11 @@ func findTrailByBranch(ctx context.Context, client *api.Client, forge, owner, re
 // findTrailByNumber looks up a trail by numeric identifier through entire-api's
 // direct number route, so it never has to scan the list pages.
 func findTrailByNumber(ctx context.Context, client *api.Client, forge, owner, repo string, number int) (*api.TrailResource, error) {
-	resp, err := client.Get(ctx, trailNumberPath(forge, owner, repo, number))
+	return findTrailByNumberAtPath(ctx, client, trailsBasePath(forge, owner, repo), number)
+}
+
+func findTrailByNumberAtPath(ctx context.Context, client *api.Client, basePath string, number int) (*api.TrailResource, error) {
+	resp, err := client.Get(ctx, trailNumberPathForBase(basePath, number))
 	if err != nil {
 		return nil, fmt.Errorf("get trail %d: %w", number, err)
 	}
@@ -2136,13 +2172,13 @@ func findTrailByNumber(ctx context.Context, client *api.Client, forge, owner, re
 	return &found, nil
 }
 
-func findTrail(ctx context.Context, client *api.Client, forge, owner, repo string, match func(api.TrailResource) bool) (*api.TrailResource, error) {
+func findTrailAtPath(ctx context.Context, client *api.Client, basePath string, match func(api.TrailResource) bool) (*api.TrailResource, error) {
 	// Walk bounded opaque-cursor pages so selector lookups do not silently miss
 	// trails beyond the first entire-api page.
 	pageToken := ""
 	seenTokens := map[string]bool{}
 	for range trailFindMaxPages {
-		resp, err := client.Get(ctx, trailsBasePath(forge, owner, repo)+trailListPageQuery(nil, trailListServerMaxLimit, pageToken))
+		resp, err := client.Get(ctx, basePath+trailListPageQuery(nil, trailListServerMaxLimit, pageToken))
 		if err != nil {
 			return nil, fmt.Errorf("list trails: %w", err)
 		}
@@ -2185,17 +2221,17 @@ func trailsBasePath(forge, owner, repo string) string {
 	return fmt.Sprintf("/api/v1/trails/%s/%s/%s", url.PathEscape(forge), url.PathEscape(owner), url.PathEscape(repo))
 }
 
-// trailListBasePath selects the repo-addressed read route for Entire-native
+// trailRepoBasePath selects the repo-addressed route for Entire-native
 // repositories. The host-addressed API deliberately cannot resolve et repos by
 // name because the cell's full_name index has no forge discriminator; the
-// opaque placement ID is unambiguous. GitHub repos retain the legacy route.
-func trailListBasePath(forge, owner, repo, repoID string) (string, error) {
+// opaque repo ID is unambiguous. GitHub repos retain the legacy route.
+func trailRepoBasePath(forge, owner, repo, repoID string) (string, error) {
 	if forge != nativeCloneForge {
 		return trailsBasePath(forge, owner, repo), nil
 	}
 	repoID = strings.TrimSpace(repoID)
 	if repoID == "" {
-		return "", errors.New("cannot list trails for an Entire-native repo without its repo ID")
+		return "", errors.New("cannot access trails for an Entire-native repo without its repo ID")
 	}
 	return "/api/v1/repos/" + url.PathEscape(repoID) + "/trails", nil
 }
@@ -2204,14 +2240,17 @@ func trailListBasePath(forge, owner, repo, repoID string) (string, error) {
 // number (e.g. "/api/v1/trails/gh/acme/repo/575"). The server validates an
 // integer here and rejects the trail UUID, so callers must pass Number, not ID.
 func trailNumberPath(forge, owner, repo string, number int) string {
-	return trailsBasePath(forge, owner, repo) + "/" + strconv.Itoa(number)
+	return trailNumberPathForBase(trailsBasePath(forge, owner, repo), number)
 }
 
-// trailBodyPath returns the route that writes a trail's description
-// (e.g. "/api/v1/trails/gh/acme/repo/575/body"). It is the only route that does;
-// see api.TrailBodyRequest.
-func trailBodyPath(forge, owner, repo string, number int) string {
-	return trailNumberPath(forge, owner, repo, number) + "/body"
+func trailNumberPathForBase(basePath string, number int) string {
+	return basePath + "/" + strconv.Itoa(number)
+}
+
+// trailBodyPathForBase returns the route that writes a trail's description. It
+// is the only route that does; see api.TrailBodyRequest.
+func trailBodyPathForBase(basePath string, number int) string {
+	return trailNumberPathForBase(basePath, number) + "/body"
 }
 
 // resolveTrailRemote resolves the origin remote and ensures the forge is

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1011,7 +1011,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr, ty
 	if err != nil {
 		return err
 	}
-	client, _, err := newTrailAPIClient(ctx, trailInsecureHTTP(cmd), owner+"/"+repoName)
+	client, _, err := newTrailAPIClient(ctx, trailInsecureHTTP(cmd), forge, owner, repoName)
 	if err != nil {
 		return renderDataAPIAuthError(ctx, cmd.ErrOrStderr(), owner+"/"+repoName, err)
 	}

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -490,8 +490,8 @@ func runTrailListAll(ctx context.Context, w, errW io.Writer, opts trailListOptio
 	if err != nil {
 		return err
 	}
-	return runAuthenticatedTrailAPI(ctx, errW, opts.InsecureHTTP, opts.Repo, func(ctx context.Context, client *api.Client) error {
-		return runTrailListAllWithClient(ctx, w, client, opts, statusFilters)
+	return runAuthenticatedTrailAPIWithRepoID(ctx, errW, opts.InsecureHTTP, opts.Repo, func(ctx context.Context, client *api.Client, repoID string) error {
+		return runTrailListAllWithClient(ctx, w, client, repoID, opts, statusFilters)
 	})
 }
 
@@ -502,7 +502,7 @@ func validateTrailListOptions(opts trailListOptions) ([]trail.Status, error) {
 	return parseTrailStatusFilter(opts.Status)
 }
 
-func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Client, opts trailListOptions, statusFilters []trail.Status) error {
+func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Client, repoID string, opts trailListOptions, statusFilters []trail.Status) error {
 	authorFilter := opts.Author
 	currentUserLogin := ""
 	if authorFilter == trailListAuthorMe {
@@ -523,7 +523,11 @@ func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Cli
 	// many pages as needed for --limit. Author login is filtered client-side:
 	// the new backend's author query is account-ID based, while the CLI's public
 	// flag has always accepted GitHub logins.
-	resources, totalMatched, err := listTrailResources(ctx, client, forge, owner, repo, statusFilters, authorFilter, opts.Limit)
+	basePath, err := trailListBasePath(forge, owner, repo, repoID)
+	if err != nil {
+		return err
+	}
+	resources, totalMatched, err := listTrailResources(ctx, client, basePath, statusFilters, authorFilter, opts.Limit)
 	if err != nil {
 		return err
 	}
@@ -561,7 +565,7 @@ func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Cli
 	return nil
 }
 
-func listTrailResources(ctx context.Context, client *api.Client, forge, owner, repo string, statuses []trail.Status, author string, limit int) ([]api.TrailResource, int, error) {
+func listTrailResources(ctx context.Context, client *api.Client, basePath string, statuses []trail.Status, author string, limit int) ([]api.TrailResource, int, error) {
 	if limit <= 0 {
 		return nil, 0, errors.New("limit must be greater than 0")
 	}
@@ -574,7 +578,7 @@ func listTrailResources(ctx context.Context, client *api.Client, forge, owner, r
 		if author == "" && limit-len(items) < pageSize {
 			pageSize = limit - len(items)
 		}
-		resp, err := client.Get(ctx, trailsBasePath(forge, owner, repo)+trailListPageQuery(statuses, pageSize, pageToken))
+		resp, err := client.Get(ctx, basePath+trailListPageQuery(statuses, pageSize, pageToken))
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to list trails: %w", err)
 		}
@@ -1007,7 +1011,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr, ty
 	if err != nil {
 		return err
 	}
-	client, err := newTrailAPIClient(ctx, trailInsecureHTTP(cmd), owner+"/"+repoName)
+	client, _, err := newTrailAPIClient(ctx, trailInsecureHTTP(cmd), owner+"/"+repoName)
 	if err != nil {
 		return renderDataAPIAuthError(ctx, cmd.ErrOrStderr(), owner+"/"+repoName, err)
 	}
@@ -2179,6 +2183,21 @@ func findTrail(ctx context.Context, client *api.Client, forge, owner, repo strin
 // (e.g., "/api/v1/trails/gh/org/repo").
 func trailsBasePath(forge, owner, repo string) string {
 	return fmt.Sprintf("/api/v1/trails/%s/%s/%s", url.PathEscape(forge), url.PathEscape(owner), url.PathEscape(repo))
+}
+
+// trailListBasePath selects the repo-addressed read route for Entire-native
+// repositories. The host-addressed API deliberately cannot resolve et repos by
+// name because the cell's full_name index has no forge discriminator; the
+// opaque placement ID is unambiguous. GitHub repos retain the legacy route.
+func trailListBasePath(forge, owner, repo, repoID string) (string, error) {
+	if forge != nativeCloneForge {
+		return trailsBasePath(forge, owner, repo), nil
+	}
+	repoID = strings.TrimSpace(repoID)
+	if repoID == "" {
+		return "", errors.New("cannot list trails for an Entire-native repo without its repo ID")
+	}
+	return "/api/v1/repos/" + url.PathEscape(repoID) + "/trails", nil
 }
 
 // trailNumberPath returns the single-trail API path keyed by integer trail

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -2253,23 +2253,17 @@ func trailBodyPathForBase(basePath string, number int) string {
 	return trailNumberPathForBase(basePath, number) + "/body"
 }
 
-// resolveTrailRemote resolves the origin remote and ensures the forge is
-// known to the trails API. Without this guard, an unmapped host (e.g.
-// gitlab.com, or a misconfigured entire:// URL with no forge prefix)
-// produces a malformed `/api/v1/trails//owner/repo` path that the server
-// rejects with an opaque error instead of a clear "unsupported forge" one.
-// A native (`et`) remote is refused for a different reason — the API takes the
-// token but cannot resolve it; see errTrailsNativeUnsupported.
+// resolveTrailRemote resolves the origin remote and ensures the forge is known
+// to the trails API. Without this guard, an unmapped host (e.g. gitlab.com, or
+// a misconfigured entire:// URL with no forge prefix) cannot select a valid
+// repo-scoped trail route and would fail later with an opaque API error.
 func resolveTrailRemote(ctx context.Context) (forge, owner, repo string, err error) {
 	forge, owner, repo, err = gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to resolve repository: %w", err)
 	}
 	if forge == "" {
-		return "", "", "", errors.New("origin remote is not on a forge supported by Entire trails (supported: github.com)")
-	}
-	if forge == nativeCloneForge {
-		return "", "", "", fmt.Errorf("origin remote is the Entire-native repo %s/%s: %w", owner, repo, errTrailsNativeUnsupported)
+		return "", "", "", errors.New("origin remote is not on a forge supported by Entire trails (supported: github.com and Entire-native remotes)")
 	}
 	return forge, owner, repo, nil
 }
@@ -2338,29 +2332,8 @@ func resolveTrailPushRemote(ctx context.Context, branch string) (string, error) 
 // triple. It accepts the canonical "forge/owner/repo" form (e.g. gh/acme/app)
 // as well as a full clone URL (https://, git@, or entire://) that gitremote
 // can parse. A trailing ".git" on the repo is stripped.
-// errTrailsNativeUnsupported is why the trail API cannot serve a native repo.
-// entire-api admits {gh, et} in the path (validTrailsHosts) but resolves {gh}
-// alone (resolvableTrailsHosts), because full_name rows carry no forge host and
-// every resolvable row today is a GitHub mirror — so a native ref collapses
-// into the same existence-hiding 404 as a permission denial, and refusing
-// locally is the only way the user hears the real reason.
-//
-// It is a shared sentinel because a forge reaches the trail API two ways —
-// named in --repo, or inferred from the origin remote — and the inferred one is
-// the common path: gating only the argument left a developer standing in a
-// native clone getting the 404 this exists to prevent. Both wrappers below must
-// go together when entire-api gains forge-scoped naming.
-var errTrailsNativeUnsupported = errors.New("trails are not available for Entire-native repos yet; they need a GitHub mirror (gh/<owner>/<repo>)")
-
 func parseTrailRepoArg(raw string) (forge, owner, repo string, err error) {
-	forge, owner, repo, err = parseTrailRepoShape(raw)
-	if err != nil {
-		return "", "", "", err
-	}
-	if forge == nativeCloneForge {
-		return "", "", "", fmt.Errorf("invalid --repo %q: %w", raw, errTrailsNativeUnsupported)
-	}
-	return forge, owner, repo, nil
+	return parseTrailRepoShape(raw)
 }
 
 // parseTrailRepoShape parses the two spellings --repo accepts — a bare
@@ -2391,7 +2364,7 @@ func parseTrailRepoShape(raw string) (forge, owner, repo string, err error) {
 		return "", "", "", fmt.Errorf("invalid --repo %q: %w", raw, perr)
 	}
 	if info.Forge == "" {
-		return "", "", "", fmt.Errorf("invalid --repo %q: unsupported forge host (supported: github.com)", raw)
+		return "", "", "", fmt.Errorf("invalid --repo %q: unsupported forge host (supported: github.com and Entire-native remotes)", raw)
 	}
 	return info.Forge, info.Owner, info.Repo, nil
 }

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -203,7 +203,7 @@ Otherwise, <trail> may be a trail number, id, or branch in the target repo.`,
 
 // runTrailShow shows one trail, defaulting to the current branch's trail.
 func runTrailShow(ctx context.Context, w, errW io.Writer, opts trailShowOptions) error {
-	return runAuthenticatedTrailAPIWithRepoID(ctx, errW, opts.InsecureHTTP, opts.Repo, func(ctx context.Context, client *api.Client, repoID string) error {
+	return runAuthenticatedTrailAPI(ctx, errW, opts.InsecureHTTP, opts.Repo, func(ctx context.Context, client *api.Client, repoID string) error {
 		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, opts.Repo)
 		if err != nil {
 			return err
@@ -284,14 +284,10 @@ func runTrailShowWithClientAtPath(ctx context.Context, w, errW io.Writer, client
 	return nil
 }
 
-// resolveTrailBySelector resolves a trail by an optional selector (trail
+// resolveTrailBySelectorAtPath resolves a trail by an optional selector (trail
 // number, id, or branch). An empty selector falls back to the current branch's
 // trail. It returns an actionable error (never a nil trail with a nil error)
 // when nothing matches, so callers can rely on a non-nil result.
-func resolveTrailBySelector(ctx context.Context, client *api.Client, forge, owner, repo, selector, branchOverride string) (*api.TrailResource, error) {
-	return resolveTrailBySelectorAtPath(ctx, client, trailsBasePath(forge, owner, repo), forge, owner, repo, selector, branchOverride)
-}
-
 func resolveTrailBySelectorAtPath(ctx context.Context, client *api.Client, basePath, forge, owner, repo, selector, branchOverride string) (*api.TrailResource, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
@@ -436,16 +432,12 @@ func trailWebURL(base, forge, owner, repo string, number int) string {
 	return strings.TrimRight(base, "/") + "/" + forge + "/" + owner + "/" + repo + "/trails/" + strconv.Itoa(number)
 }
 
-// fetchTrailDescription fetches a trail's rendered description text
+// fetchTrailDescriptionAtPath fetches a trail's rendered description text
 // (`trail.body_document.text_snapshot`) and its etag, which the list endpoint
 // omits, by integer number. It returns only the description and etag — the
 // list result already supplies the metadata — and decodes only the fields it
 // needs, so it is unaffected by the shape of sibling fields like
 // `checkpoints`/`thread`.
-func fetchTrailDescription(ctx context.Context, client *api.Client, forge, owner, repo string, number int) (string, string, error) {
-	return fetchTrailDescriptionAtPath(ctx, client, trailsBasePath(forge, owner, repo), number)
-}
-
 func fetchTrailDescriptionAtPath(ctx context.Context, client *api.Client, basePath string, number int) (string, string, error) {
 	resp, err := client.Get(ctx, trailNumberPathForBase(basePath, number))
 	if err != nil {
@@ -502,7 +494,7 @@ func runTrailListAll(ctx context.Context, w, errW io.Writer, opts trailListOptio
 	if err != nil {
 		return err
 	}
-	return runAuthenticatedTrailAPIWithRepoID(ctx, errW, opts.InsecureHTTP, opts.Repo, func(ctx context.Context, client *api.Client, repoID string) error {
+	return runAuthenticatedTrailAPI(ctx, errW, opts.InsecureHTTP, opts.Repo, func(ctx context.Context, client *api.Client, repoID string) error {
 		return runTrailListAllWithClient(ctx, w, client, repoID, opts, statusFilters)
 	})
 }
@@ -1023,9 +1015,13 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr, ty
 	if err != nil {
 		return err
 	}
-	client, _, err := newTrailAPIClient(ctx, trailInsecureHTTP(cmd), forge, owner, repoName)
+	client, repoID, err := newTrailAPIClient(ctx, trailInsecureHTTP(cmd), forge, owner, repoName)
 	if err != nil {
 		return renderDataAPIAuthError(ctx, cmd.ErrOrStderr(), owner+"/"+repoName, err)
+	}
+	basePath, err := trailRepoBasePath(forge, owner, repoName, repoID)
+	if err != nil {
+		return err
 	}
 
 	pushRemote, err := resolveTrailPushRemote(ctx, branch)
@@ -1038,7 +1034,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr, ty
 		return err
 	}
 
-	createResp, err := postTrailCreate(ctx, client, forge, owner, repoName, title, body, branch, base, statusStr, strings.TrimSpace(typeStr), strings.TrimSpace(priorityStr), assignees)
+	createResp, err := postTrailCreate(ctx, client, basePath, forge, owner, repoName, title, body, branch, base, statusStr, strings.TrimSpace(typeStr), strings.TrimSpace(priorityStr), assignees)
 	if err != nil {
 		cleanupCreatedTrailBranch(ctx, repo, pushRemote, branch, branchState.LocalCreated, branchState.RemotePushed, errW)
 		return err
@@ -1171,9 +1167,9 @@ func ensureTrailCreateBranchExists(ctx context.Context, w io.Writer, repo *git.R
 	return nil
 }
 
-func postTrailCreate(ctx context.Context, client *api.Client, forge, owner, repoName, title, body, branch, base, statusStr, typeStr, priorityStr string, assignees []string) (api.TrailCreateResponse, error) {
+func postTrailCreate(ctx context.Context, client *api.Client, basePath, forge, owner, repoName, title, body, branch, base, statusStr, typeStr, priorityStr string, assignees []string) (api.TrailCreateResponse, error) {
 	createReq := newTrailCreateRequest(title, body, branch, base, statusStr, typeStr, priorityStr, assignees)
-	resp, err := client.Post(ctx, trailsBasePath(forge, owner, repoName), createReq)
+	resp, err := client.Post(ctx, basePath, createReq)
 	if err != nil {
 		noteTrailCommandEnablement(ctx, client, err)
 		return api.TrailCreateResponse{}, fmt.Errorf("failed to create trail: %w", err)
@@ -1339,7 +1335,7 @@ type trailUpdateInputs struct {
 }
 
 func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, inputs trailUpdateInputs) error {
-	return runAuthenticatedTrailAPIWithRepoID(ctx, errW, insecureHTTP, inputs.Repo, func(ctx context.Context, client *api.Client, repoID string) error {
+	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, inputs.Repo, func(ctx context.Context, client *api.Client, repoID string) error {
 		forge, owner, repoName, err := resolveTrailRepoOrRemote(ctx, inputs.Repo)
 		if err != nil {
 			return err
@@ -1783,13 +1779,17 @@ type trailCheckoutOptions struct {
 func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector string, opts trailCheckoutOptions) error {
 	// checkout rejects --repo (it operates on the local clone), so the enablement
 	// cache always tracks the local origin here.
-	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, "", func(ctx context.Context, client *api.Client) error {
+	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, "", func(ctx context.Context, client *api.Client, repoID string) error {
 		forge, owner, repo, err := resolveTrailRemote(ctx)
 		if err != nil {
 			return err
 		}
+		basePath, err := trailRepoBasePath(forge, owner, repo, repoID)
+		if err != nil {
+			return err
+		}
 
-		found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, selector, "")
+		found, err := resolveTrailBySelectorAtPath(ctx, client, basePath, forge, owner, repo, selector, "")
 		if err != nil {
 			return err
 		}
@@ -1896,7 +1896,7 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 	ctx := cmd.Context()
 	w := cmd.OutOrStdout()
 
-	return runAuthenticatedTrailAPIWithRepoID(ctx, cmd.ErrOrStderr(), trailInsecureHTTP(cmd), trailRepoFlag(cmd), func(ctx context.Context, client *api.Client, repoID string) error {
+	return runAuthenticatedTrailAPI(ctx, cmd.ErrOrStderr(), trailInsecureHTTP(cmd), trailRepoFlag(cmd), func(ctx context.Context, client *api.Client, repoID string) error {
 		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, trailRepoFlag(cmd))
 		if err != nil {
 			return err
@@ -1950,12 +1950,8 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 	})
 }
 
-// deleteTrailByNumber deletes a trail; entire-api answers 204 No Content, so any
-// 2xx is a successful delete and the body is not read.
-func deleteTrailByNumber(ctx context.Context, client *api.Client, forge, owner, repo string, number int) error {
-	return deleteTrailByNumberAtPath(ctx, client, trailsBasePath(forge, owner, repo), number)
-}
-
+// deleteTrailByNumberAtPath deletes a trail; entire-api answers 204 No Content,
+// so any 2xx is a successful delete and the body is not read.
 func deleteTrailByNumberAtPath(ctx context.Context, client *api.Client, basePath string, number int) error {
 	resp, err := client.Delete(ctx, trailNumberPathForBase(basePath, number))
 	if err != nil {
@@ -2102,11 +2098,6 @@ func runTrailCreateInteractive(title, body, branch, statusStr *string, noBranch 
 	return nil
 }
 
-// findTrailByBranch looks up a trail by branch name via the list API.
-func findTrailBySelector(ctx context.Context, client *api.Client, forge, owner, repo, selector string) (*api.TrailResource, error) {
-	return findTrailBySelectorAtPath(ctx, client, trailsBasePath(forge, owner, repo), selector)
-}
-
 func findTrailBySelectorAtPath(ctx context.Context, client *api.Client, basePath, selector string) (*api.TrailResource, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
@@ -2131,22 +2122,15 @@ func parseTrailNumberSelector(selector string) (int, bool) {
 	return n, true
 }
 
-func findTrailByBranch(ctx context.Context, client *api.Client, forge, owner, repo, branch string) (*api.TrailResource, error) {
-	return findTrailByBranchAtPath(ctx, client, trailsBasePath(forge, owner, repo), branch)
-}
-
+// findTrailByBranchAtPath looks up a trail by branch name via the list API.
 func findTrailByBranchAtPath(ctx context.Context, client *api.Client, basePath, branch string) (*api.TrailResource, error) {
 	return findTrailAtPath(ctx, client, basePath, func(t api.TrailResource) bool {
 		return t.Branch == branch
 	})
 }
 
-// findTrailByNumber looks up a trail by numeric identifier through entire-api's
-// direct number route, so it never has to scan the list pages.
-func findTrailByNumber(ctx context.Context, client *api.Client, forge, owner, repo string, number int) (*api.TrailResource, error) {
-	return findTrailByNumberAtPath(ctx, client, trailsBasePath(forge, owner, repo), number)
-}
-
+// findTrailByNumberAtPath looks up a trail by numeric identifier through
+// entire-api's direct number route, so it never has to scan the list pages.
 func findTrailByNumberAtPath(ctx context.Context, client *api.Client, basePath string, number int) (*api.TrailResource, error) {
 	resp, err := client.Get(ctx, trailNumberPathForBase(basePath, number))
 	if err != nil {
@@ -2236,13 +2220,9 @@ func trailRepoBasePath(forge, owner, repo, repoID string) (string, error) {
 	return "/api/v1/repos/" + url.PathEscape(repoID) + "/trails", nil
 }
 
-// trailNumberPath returns the single-trail API path keyed by integer trail
-// number (e.g. "/api/v1/trails/gh/acme/repo/575"). The server validates an
-// integer here and rejects the trail UUID, so callers must pass Number, not ID.
-func trailNumberPath(forge, owner, repo string, number int) string {
-	return trailNumberPathForBase(trailsBasePath(forge, owner, repo), number)
-}
-
+// trailNumberPathForBase returns the single-trail API path keyed by integer
+// trail number. The server validates an integer here and rejects the trail UUID,
+// so callers must pass Number, not ID.
 func trailNumberPathForBase(basePath string, number int) string {
 	return basePath + "/" + strconv.Itoa(number)
 }

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -59,6 +59,30 @@ func TestNewTrailCreateRequestUsesLinkBranchAction(t *testing.T) {
 	}, req)
 }
 
+// Not parallel: changes the process working directory for the enablement-cache write.
+func TestPostTrailCreateUsesNativeRepoBasePath(t *testing.T) {
+	const basePath = "/api/v1/repos/native-repo-id/trails"
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		if err := json.NewEncoder(w).Encode(api.TrailCreateResponse{Trail: api.TrailResource{ID: "native-trail", Number: 4}}); err != nil {
+			t.Errorf("encode trail create response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := postTrailCreate(t.Context(), api.NewClientWithBaseURL("token", srv.URL), basePath,
+		"et", "entirehq", "marvin", "Native trail", "", "feature/native", "main", "open", "", "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, basePath, gotPath)
+}
+
 func TestNewTrailCreateRequestCanBeBranchless(t *testing.T) {
 	req := newTrailCreateRequest("title", "body", "", "main", "open", "", "", nil)
 
@@ -530,7 +554,7 @@ func TestTrailPathsFromNativeRepoBase(t *testing.T) {
 
 func TestTrailNumberPath(t *testing.T) {
 	t.Parallel()
-	got := trailNumberPath("gh", "acme", "repo", 575)
+	got := trailNumberPathForBase(trailsBasePath("gh", "acme", "repo"), 575)
 	want := "/api/v1/trails/gh/acme/repo/575"
 	if got != want {
 		t.Fatalf("trailNumberPath = %q, want %q", got, want)
@@ -647,7 +671,7 @@ func TestFetchTrailDescription_ReadsNestedBodyDocument(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	bodyText, _, err := fetchTrailDescription(t.Context(), client, "gh", "acme", "repo", 777)
+	bodyText, _, err := fetchTrailDescriptionAtPath(t.Context(), client, trailsBasePath("gh", "acme", "repo"), 777)
 	if err != nil {
 		t.Fatalf("fetchTrailDescription: %v", err)
 	}
@@ -869,7 +893,7 @@ func TestDeleteTrailByNumber(t *testing.T) {
 		defer srv.Close()
 
 		client := api.NewClientWithBaseURL("tok", srv.URL)
-		if err := deleteTrailByNumber(t.Context(), client, "gh", "acme", "repo", 575); err != nil {
+		if err := deleteTrailByNumberAtPath(t.Context(), client, trailsBasePath("gh", "acme", "repo"), 575); err != nil {
 			t.Fatalf("deleteTrailByNumber: %v", err)
 		}
 		if gotMethod != http.MethodDelete {
@@ -907,7 +931,7 @@ func TestDeleteTrailByNumber(t *testing.T) {
 		defer srv.Close()
 
 		client := api.NewClientWithBaseURL("tok", srv.URL)
-		if err := deleteTrailByNumber(t.Context(), client, "gh", "acme", "repo", 999); err == nil {
+		if err := deleteTrailByNumberAtPath(t.Context(), client, trailsBasePath("gh", "acme", "repo"), 999); err == nil {
 			t.Fatal("expected error for 404, got nil")
 		}
 	})
@@ -1184,7 +1208,7 @@ func TestFindTrailByNumberUsesDirectEntireAPIRoute(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	found, err := findTrailByNumber(t.Context(), client, "gh", "acme", "repo", trailNumber)
+	found, err := findTrailByNumberAtPath(t.Context(), client, trailsBasePath("gh", "acme", "repo"), trailNumber)
 	if err != nil {
 		t.Fatalf("findTrailByNumber: %v", err)
 	}
@@ -1237,7 +1261,7 @@ func TestFindTrailByNumberTreatsIdentitylessBodyAsNotFound(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			found, err := findTrailByNumber(t.Context(), api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", 575)
+			found, err := findTrailByNumberAtPath(t.Context(), api.NewClientWithBaseURL("tok", srv.URL), trailsBasePath("gh", "acme", "repo"), 575)
 			if err != nil {
 				t.Fatalf("findTrailByNumber: %v", err)
 			}
@@ -1275,7 +1299,7 @@ func TestFindTrailPaginatesPastServerMax(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	found, err := findTrailByBranch(context.Background(), client, "gh", "acme", "repo", "target")
+	found, err := findTrailByBranchAtPath(context.Background(), client, trailsBasePath("gh", "acme", "repo"), "target")
 	if err != nil {
 		t.Fatalf("findTrailByBranch: %v", err)
 	}
@@ -1314,7 +1338,7 @@ func TestFindTrailPaginatesToTheEndOfItsBudget(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	found, err := findTrailByBranch(t.Context(), client, "gh", "acme", "repo", "target")
+	found, err := findTrailByBranchAtPath(t.Context(), client, trailsBasePath("gh", "acme", "repo"), "target")
 	if err != nil {
 		t.Fatalf("findTrailByBranch: %v", err)
 	}
@@ -1343,7 +1367,7 @@ func TestFindTrailStopsWhenServerRepeatsUnpaginatedFullPage(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	found, err := findTrailByBranch(context.Background(), client, "gh", "acme", "repo", "target")
+	found, err := findTrailByBranchAtPath(context.Background(), client, trailsBasePath("gh", "acme", "repo"), "target")
 	if err != nil {
 		t.Fatalf("findTrailByBranch: %v", err)
 	}
@@ -1373,7 +1397,7 @@ func TestFindTrailStopsAtMaxPagesWithoutTotal(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	found, err := findTrailByBranch(context.Background(), client, "gh", "acme", "repo", "target")
+	found, err := findTrailByBranchAtPath(context.Background(), client, trailsBasePath("gh", "acme", "repo"), "target")
 	if err != nil {
 		t.Fatalf("findTrailByBranch: %v", err)
 	}

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -207,7 +207,7 @@ func TestRunTrailCreateInteractiveBranchlessSkipsBranchPrompt(t *testing.T) {
 func TestRunTrailCreateBranchlessHappyPath(t *testing.T) {
 	// No t.Parallel: uses t.Chdir plus auth/tokenstore package-level test seams.
 	prevTrailClient := newTrailAPIClient
-	newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, _ string) (*api.Client, string, error) {
+	newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, _, _, _ string) (*api.Client, string, error) {
 		client, err := NewAuthenticatedAPIClient(ctx, insecureHTTP)
 		return client, trailTestRepoID, err
 	}
@@ -387,7 +387,7 @@ func gitBranchExistsTrailTest(t *testing.T, repoDir, branch string) bool {
 func TestRunTrailListAll_PrintsLoginHintWhenNotLoggedIn(t *testing.T) {
 	// No t.Parallel: SetResolveContextForAPIForTest and
 	prevTrailClient := newTrailAPIClient
-	newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, _ string) (*api.Client, string, error) {
+	newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, _, _, _ string) (*api.Client, string, error) {
 		client, err := NewAuthenticatedAPIClient(ctx, insecureHTTP)
 		return client, trailTestRepoID, err
 	}

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -497,28 +497,35 @@ func TestTrailsBasePath(t *testing.T) {
 	}
 }
 
-func TestTrailListBasePath(t *testing.T) {
+func TestTrailRepoBasePath(t *testing.T) {
 	t.Parallel()
 
 	t.Run("GitHub keeps host-addressed route", func(t *testing.T) {
 		t.Parallel()
-		got, err := trailListBasePath("gh", "acme", "repo", "placement-id")
+		got, err := trailRepoBasePath("gh", "acme", "repo", "placement-id")
 		require.NoError(t, err)
 		require.Equal(t, "/api/v1/trails/gh/acme/repo", got)
 	})
 
 	t.Run("Entire-native uses repo ID route", func(t *testing.T) {
 		t.Parallel()
-		got, err := trailListBasePath("et", "acme", "repo", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+		got, err := trailRepoBasePath("et", "acme", "repo", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
 		require.NoError(t, err)
 		require.Equal(t, "/api/v1/repos/01ARZ3NDEKTSV4RRFFQ69G5FAV/trails", got)
 	})
 
 	t.Run("Entire-native requires repo ID", func(t *testing.T) {
 		t.Parallel()
-		_, err := trailListBasePath("et", "acme", "repo", "")
-		require.EqualError(t, err, "cannot list trails for an Entire-native repo without its repo ID")
+		_, err := trailRepoBasePath("et", "acme", "repo", "")
+		require.EqualError(t, err, "cannot access trails for an Entire-native repo without its repo ID")
 	})
+}
+
+func TestTrailPathsFromNativeRepoBase(t *testing.T) {
+	t.Parallel()
+	const basePath = "/api/v1/repos/native-repo-id/trails"
+	require.Equal(t, basePath+"/575", trailNumberPathForBase(basePath, 575))
+	require.Equal(t, basePath+"/575/body", trailBodyPathForBase(basePath, 575))
 }
 
 func TestTrailNumberPath(t *testing.T) {
@@ -665,7 +672,7 @@ func TestResolveTrailUpdateBody_PrefersDetailSnapshot(t *testing.T) {
 	// The list resource omits the description, so found.Body is empty. The
 	// seed must come from the detail endpoint, not the empty list body.
 	found := &api.TrailResource{Number: 42, Body: ""}
-	body, etag, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	body, etag, err := resolveTrailUpdateBodyAtPath(t.Context(), client, trailTestBasePath, found)
 	if err != nil {
 		t.Fatalf("resolveTrailUpdateBody: %v", err)
 	}
@@ -693,7 +700,7 @@ func TestResolveTrailUpdateBody_ReturnsETagEvenWhenSnapshotEmpty(t *testing.T) {
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
 	found := &api.TrailResource{Number: 42, Body: trailTestListBody}
-	body, etag, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	body, etag, err := resolveTrailUpdateBodyAtPath(t.Context(), client, trailTestBasePath, found)
 	if err != nil {
 		t.Fatalf("resolveTrailUpdateBody: %v", err)
 	}
@@ -718,7 +725,7 @@ func TestResolveTrailUpdateBody_FallsBackToListBody(t *testing.T) {
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
 	found := &api.TrailResource{Number: 42, Body: trailTestListBody}
-	body, etag, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	body, etag, err := resolveTrailUpdateBodyAtPath(t.Context(), client, trailTestBasePath, found)
 	if err != nil {
 		t.Fatalf("resolveTrailUpdateBody: %v", err)
 	}
@@ -741,7 +748,7 @@ func TestResolveTrailUpdateBody_ReturnsErrorOnFetchFailure(t *testing.T) {
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
 	found := &api.TrailResource{Number: 42, Body: trailTestListBody}
-	body, etag, err := resolveTrailUpdateBody(t.Context(), client, "gh", "acme", "repo", found)
+	body, etag, err := resolveTrailUpdateBodyAtPath(t.Context(), client, trailTestBasePath, found)
 	if err == nil {
 		t.Fatal("expected error on fetch failure, got nil")
 	}
@@ -871,6 +878,22 @@ func TestDeleteTrailByNumber(t *testing.T) {
 		if want := "/api/v1/trails/gh/acme/repo/575"; gotPath != want {
 			t.Fatalf("path = %q, want %q (integer number, not UUID)", gotPath, want)
 		}
+	})
+
+	t.Run("deletes Entire-native trail via repo ID path", func(t *testing.T) {
+		t.Parallel()
+		const basePath = "/api/v1/repos/native-repo-id/trails"
+		var gotMethod, gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod, gotPath = r.Method, r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		t.Cleanup(srv.Close)
+
+		err := deleteTrailByNumberAtPath(t.Context(), api.NewClientWithBaseURL("tok", srv.URL), basePath, 3)
+		require.NoError(t, err)
+		require.Equal(t, http.MethodDelete, gotMethod)
+		require.Equal(t, basePath+"/3", gotPath)
 	})
 
 	t.Run("surfaces a non-2xx status", func(t *testing.T) {
@@ -1170,6 +1193,30 @@ func TestFindTrailByNumberUsesDirectEntireAPIRoute(t *testing.T) {
 	}
 }
 
+func TestFindTrailByNumberAtPathUsesNativeRepoIDRoute(t *testing.T) {
+	t.Parallel()
+	const (
+		basePath    = "/api/v1/repos/native-repo-id/trails"
+		trailNumber = 3
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != basePath+"/3" || r.URL.RawQuery != "" {
+			t.Errorf("request = %s?%s, want %s/3 with no query", r.URL.Path, r.URL.RawQuery, basePath)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(api.TrailResource{ID: "native-trail", Number: trailNumber}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	found, err := findTrailByNumberAtPath(t.Context(), api.NewClientWithBaseURL("tok", srv.URL), basePath, trailNumber)
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	require.Equal(t, "native-trail", found.ID)
+}
+
 // A 2xx whose body carries no trail identity is "not found", not a trail whose
 // every field is zero. Selector callers act on `found != nil`, so returning a
 // phantom would make `trail show <number>` render an empty trail instead of
@@ -1386,7 +1433,7 @@ func TestRunTrailUpdateClearsDescriptionWithEmptyBody(t *testing.T) {
 	defer srv.Close()
 
 	var out bytes.Buffer
-	err := runTrailUpdateWithClient(t.Context(), &out, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+	err := runTrailUpdateWithClientAtPath(t.Context(), &out, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, trailUpdateInputs{
 		Branch:      "feature/x",
 		Body:        "",
 		BodyChanged: true,
@@ -1397,6 +1444,41 @@ func TestRunTrailUpdateClearsDescriptionWithEmptyBody(t *testing.T) {
 	defer mu.Unlock()
 	require.Equal(t, map[string]any{"markdown": "", "overwrite": true}, put)
 	require.Contains(t, out.String(), "Updated trail for branch feature/x")
+}
+
+func TestRunTrailUpdateWithClientAtPathUsesNativeRepoIDRoutes(t *testing.T) {
+	t.Parallel()
+	const basePath = "/api/v1/repos/native-repo-id/trails"
+	var methods, paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method)
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == basePath:
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{Trails: []api.TrailResource{{
+				ID: "native-trail", Number: 3, Branch: "feature/native", Title: "Before",
+			}}}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
+		case r.Method == http.MethodPatch && r.URL.Path == basePath+"/3":
+			if err := json.NewEncoder(w).Encode(api.TrailResource{ID: "native-trail", Number: 3}); err != nil {
+				t.Errorf("encode update response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var out bytes.Buffer
+	err := runTrailUpdateWithClientAtPath(t.Context(), &out, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), basePath, trailUpdateInputs{
+		Branch: "feature/native", Title: "After", TitleChanged: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{http.MethodGet, http.MethodPatch}, methods)
+	require.Equal(t, []string{basePath, basePath + "/3"}, paths)
 }
 
 func TestValidateTrailUpdateFieldsRejectsEmptyTitle(t *testing.T) {
@@ -1708,7 +1790,7 @@ func TestRunTrailListAndShowJSONPreserveBranchState(t *testing.T) {
 			require.NoError(t, err)
 
 			var showOut, showErr bytes.Buffer
-			err = runTrailShowWithClient(t.Context(), &showOut, &showErr, client, "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
+			err = runTrailShowWithClientAtPath(t.Context(), &showOut, &showErr, client, trailTestBasePath, "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
 			require.NoError(t, err)
 			require.Empty(t, showErr.String())
 
@@ -1757,7 +1839,7 @@ func TestRunTrailShowJSONEmitsOneTrailObject(t *testing.T) {
 	srv := trailShowTestServer(t, resource, "detail body", 0)
 
 	var out, errOut bytes.Buffer
-	err := runTrailShowWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
+	err := runTrailShowWithClientAtPath(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
 
 	require.NoError(t, err)
 	require.Empty(t, errOut.String())
@@ -1784,6 +1866,42 @@ func TestRunTrailShowJSONEmitsOneTrailObject(t *testing.T) {
 	// Human-only decoration must not leak into the data.
 	require.NotContains(t, out.String(), noTrailDescription)
 	require.NotContains(t, out.String(), "Trail: ")
+}
+
+func TestRunTrailShowWithClientAtPathUsesNativeRepoIDRoutes(t *testing.T) {
+	t.Parallel()
+	const basePath = "/api/v1/repos/native-repo-id/trails"
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case basePath:
+			if err := json.NewEncoder(w).Encode(api.TrailListResponse{Trails: []api.TrailResource{{
+				ID: "native-trail", Number: 3, Branch: "feature/native", Title: "Native trail",
+			}}}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
+		case basePath + "/3":
+			if err := json.NewEncoder(w).Encode(api.TrailResource{
+				ID: "native-trail", Number: 3, Branch: "feature/native",
+				BodyDocument: &api.TrailBodyDocument{TextSnapshot: "native body"},
+			}); err != nil {
+				t.Errorf("encode detail response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var out, errOut bytes.Buffer
+	err := runTrailShowWithClientAtPath(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), basePath,
+		"et", "entirehq", "marvin", trailShowOptions{Selector: "feature/native", JSON: true})
+	require.NoError(t, err)
+	require.Empty(t, errOut.String())
+	require.Equal(t, []string{basePath, basePath + "/3"}, paths)
 }
 
 // A numeric selector resolves through the detail route, which already returns
@@ -1813,7 +1931,7 @@ func TestRunTrailShowNumericSelectorFetchesDetailOnce(t *testing.T) {
 	defer srv.Close()
 
 	var out, errOut bytes.Buffer
-	err := runTrailShowWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
+	err := runTrailShowWithClientAtPath(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
 
 	require.NoError(t, err)
 	require.Empty(t, errOut.String())
@@ -1830,7 +1948,7 @@ func TestRunTrailShowJSONLeavesBodyEmptyWithoutDescription(t *testing.T) {
 	srv := trailShowTestServer(t, api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x", Status: string(trail.StatusOpen)}, "", 0)
 
 	var out, errOut bytes.Buffer
-	err := runTrailShowWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
+	err := runTrailShowWithClientAtPath(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, "gh", "acme", "repo", trailShowOptions{Selector: "7", JSON: true})
 
 	require.NoError(t, err)
 	require.Empty(t, errOut.String())
@@ -1849,7 +1967,7 @@ func TestRunTrailShowJSONKeepsStdoutParseableWhenDescriptionFetchFails(t *testin
 	srv := trailShowTestServer(t, api.TrailResource{ID: "trl_1", Number: 7, Branch: "feature/x", Title: "T", Body: trailTestListBody, Status: string(trail.StatusOpen)}, "", http.StatusInternalServerError)
 
 	var out, errOut bytes.Buffer
-	err := runTrailShowWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailShowOptions{Selector: "feature/x", JSON: true})
+	err := runTrailShowWithClientAtPath(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, "gh", "acme", "repo", trailShowOptions{Selector: "feature/x", JSON: true})
 
 	require.NoError(t, err)
 	require.Contains(t, errOut.String(), "could not load trail description")
@@ -1868,7 +1986,7 @@ func TestRunTrailShowTextStillRendersTheHumanView(t *testing.T) {
 	}, "detail body", 0)
 
 	var out, errOut bytes.Buffer
-	err := runTrailShowWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailShowOptions{Selector: "7"})
+	err := runTrailShowWithClientAtPath(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, "gh", "acme", "repo", trailShowOptions{Selector: "7"})
 
 	require.NoError(t, err)
 	require.Empty(t, errOut.String())
@@ -2247,7 +2365,7 @@ func TestRunTrailUpdateSendsTitleAsPatchAndBodyAsPut(t *testing.T) {
 	defer srv.Close()
 
 	var out, errOut bytes.Buffer
-	err := runTrailUpdateWithClient(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+	err := runTrailUpdateWithClientAtPath(t.Context(), &out, &errOut, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, trailUpdateInputs{
 		Branch:       "feature/x",
 		Title:        "new title",
 		TitleChanged: true,
@@ -2296,7 +2414,7 @@ func TestRunTrailUpdateReportsNoChangesWhenNothingWasSent(t *testing.T) {
 	// assignee slice: it clears noFlags, and buildTrailUpdateRequest still
 	// returns an empty request — the same state the split has to refuse to
 	// report as a success.
-	err := runTrailUpdateWithClient(t.Context(), &out, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+	err := runTrailUpdateWithClientAtPath(t.Context(), &out, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, trailUpdateInputs{
 		Branch:      "feature/x",
 		AssigneeAdd: []string{},
 	})
@@ -2343,7 +2461,7 @@ func TestRunTrailUpdateReportsAppliedMetadataWhenBodyWriteFails(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := runTrailUpdateWithClient(t.Context(), io.Discard, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+	err := runTrailUpdateWithClientAtPath(t.Context(), io.Discard, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, trailUpdateInputs{
 		Branch:       "feature/x",
 		Title:        "new title",
 		TitleChanged: true,
@@ -2528,7 +2646,7 @@ func TestRunTrailUpdateWithClient_EtagThreadsToIfMatch(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := runTrailUpdateWithClient(t.Context(), io.Discard, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+	err := runTrailUpdateWithClientAtPath(t.Context(), io.Discard, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, trailUpdateInputs{
 		Branch:      "feature/x",
 		Body:        "new body",
 		BodyChanged: true,
@@ -2576,7 +2694,7 @@ func TestRunTrailUpdateWithClient_OverwriteFlagSkipsEtagFetch(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := runTrailUpdateWithClient(t.Context(), io.Discard, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+	err := runTrailUpdateWithClientAtPath(t.Context(), io.Discard, io.Discard, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, trailUpdateInputs{
 		Branch:      "feature/x",
 		Body:        "new body",
 		BodyChanged: true,
@@ -2630,7 +2748,7 @@ func TestRunTrailUpdateWithClient_EtagFetchFailureWarnsAndFallsBackToOverwrite(t
 	defer srv.Close()
 
 	var errBuf bytes.Buffer
-	err := runTrailUpdateWithClient(t.Context(), io.Discard, &errBuf, api.NewClientWithBaseURL("tok", srv.URL), "gh", "acme", "repo", trailUpdateInputs{
+	err := runTrailUpdateWithClientAtPath(t.Context(), io.Discard, &errBuf, api.NewClientWithBaseURL("tok", srv.URL), trailTestBasePath, trailUpdateInputs{
 		Branch:      "feature/x",
 		Body:        "new body",
 		BodyChanged: true,

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -38,6 +38,7 @@ import (
 const (
 	trailListTestAuthorAlice = "alice"
 	trailListTestAuthorBob   = "bob"
+	trailTestRepoID          = "repo-id"
 	// trailTestBasePath is the trails endpoint for the gh/acme/repo fixture.
 	trailTestBasePath = "/api/v1/trails/gh/acme/repo"
 	// trailTestListBody is the stand-in list-resource body used across the
@@ -206,8 +207,9 @@ func TestRunTrailCreateInteractiveBranchlessSkipsBranchPrompt(t *testing.T) {
 func TestRunTrailCreateBranchlessHappyPath(t *testing.T) {
 	// No t.Parallel: uses t.Chdir plus auth/tokenstore package-level test seams.
 	prevTrailClient := newTrailAPIClient
-	newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, _ string) (*api.Client, error) {
-		return NewAuthenticatedAPIClient(ctx, insecureHTTP)
+	newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, _ string) (*api.Client, string, error) {
+		client, err := NewAuthenticatedAPIClient(ctx, insecureHTTP)
+		return client, trailTestRepoID, err
 	}
 	t.Cleanup(func() { newTrailAPIClient = prevTrailClient })
 	var gotCreate map[string]any
@@ -385,8 +387,9 @@ func gitBranchExistsTrailTest(t *testing.T, repoDir, branch string) bool {
 func TestRunTrailListAll_PrintsLoginHintWhenNotLoggedIn(t *testing.T) {
 	// No t.Parallel: SetResolveContextForAPIForTest and
 	prevTrailClient := newTrailAPIClient
-	newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, _ string) (*api.Client, error) {
-		return NewAuthenticatedAPIClient(ctx, insecureHTTP)
+	newTrailAPIClient = func(ctx context.Context, insecureHTTP bool, _ string) (*api.Client, string, error) {
+		client, err := NewAuthenticatedAPIClient(ctx, insecureHTTP)
+		return client, trailTestRepoID, err
 	}
 	t.Cleanup(func() { newTrailAPIClient = prevTrailClient })
 	//
@@ -492,6 +495,30 @@ func TestTrailsBasePath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTrailListBasePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GitHub keeps host-addressed route", func(t *testing.T) {
+		t.Parallel()
+		got, err := trailListBasePath("gh", "acme", "repo", "placement-id")
+		require.NoError(t, err)
+		require.Equal(t, "/api/v1/trails/gh/acme/repo", got)
+	})
+
+	t.Run("Entire-native uses repo ID route", func(t *testing.T) {
+		t.Parallel()
+		got, err := trailListBasePath("et", "acme", "repo", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+		require.NoError(t, err)
+		require.Equal(t, "/api/v1/repos/01ARZ3NDEKTSV4RRFFQ69G5FAV/trails", got)
+	})
+
+	t.Run("Entire-native requires repo ID", func(t *testing.T) {
+		t.Parallel()
+		_, err := trailListBasePath("et", "acme", "repo", "")
+		require.EqualError(t, err, "cannot list trails for an Entire-native repo without its repo ID")
+	})
 }
 
 func TestTrailNumberPath(t *testing.T) {
@@ -1016,7 +1043,7 @@ func TestTrailListPageQueryCapsPageSizeAtServerMax(t *testing.T) {
 func TestListTrailResourcesRejectsNonPositiveLimit(t *testing.T) {
 	t.Parallel()
 	for _, limit := range []int{0, -1} {
-		_, _, err := listTrailResources(t.Context(), nil, "gh", "acme", "repo", nil, "", limit)
+		_, _, err := listTrailResources(t.Context(), nil, trailsBasePath("gh", "acme", "repo"), nil, "", limit)
 		if err == nil || err.Error() != "limit must be greater than 0" {
 			t.Fatalf("limit %d error = %v, want limit validation error", limit, err)
 		}
@@ -1034,7 +1061,7 @@ func TestRunTrailListAllPrintsNoServerLimitNote(t *testing.T) {
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
 	var out bytes.Buffer
-	err := runTrailListAllWithClient(t.Context(), &out, client, trailListOptions{
+	err := runTrailListAllWithClient(t.Context(), &out, client, "", trailListOptions{
 		Repo: "gh/acme/repo", Limit: 500,
 	}, []trail.Status{trail.StatusOpen})
 	if err != nil {
@@ -1049,6 +1076,24 @@ func TestRunTrailListAllPrintsNoServerLimitNote(t *testing.T) {
 	if strings.Contains(out.String(), "feature/former") {
 		t.Fatalf("human output contains original branch:\n%s", out.String())
 	}
+}
+
+func TestRunTrailListAllWithClientNativeUsesRepoIDRoute(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = fmt.Fprint(w, `{"items":[],"totalCount":0}`)
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	err := runTrailListAllWithClient(t.Context(), io.Discard, client, "01ARZ3NDEKTSV4RRFFQ69G5FAV", trailListOptions{
+		Repo: "entire://aws-us-east-2.entire.io/et/entirehq/marvin", Limit: 10,
+	}, []trail.Status{trail.StatusOpen})
+	require.NoError(t, err)
+	require.Equal(t, "/api/v1/repos/01ARZ3NDEKTSV4RRFFQ69G5FAV/trails", gotPath)
 }
 
 func TestListTrailResourcesStopsWhenAuthorLimitIsSatisfied(t *testing.T) {
@@ -1078,7 +1123,7 @@ func TestListTrailResourcesStopsWhenAuthorLimitIsSatisfied(t *testing.T) {
 	defer srv.Close()
 	client := api.NewClientWithBaseURL("tok", srv.URL)
 
-	items, total, err := listTrailResources(t.Context(), client, "gh", "acme", "repo", nil, login, 5)
+	items, total, err := listTrailResources(t.Context(), client, trailsBasePath("gh", "acme", "repo"), nil, login, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1657,7 +1702,7 @@ func TestRunTrailListAndShowJSONPreserveBranchState(t *testing.T) {
 			client := api.NewClientWithBaseURL("tok", srv.URL)
 
 			var listOut bytes.Buffer
-			err := runTrailListAllWithClient(t.Context(), &listOut, client, trailListOptions{
+			err := runTrailListAllWithClient(t.Context(), &listOut, client, "", trailListOptions{
 				Repo: "gh/acme/repo", Limit: 10, JSON: true,
 			}, nil)
 			require.NoError(t, err)

--- a/cmd/entire/cli/trail_collaboration_cmd_test.go
+++ b/cmd/entire/cli/trail_collaboration_cmd_test.go
@@ -40,16 +40,17 @@ func TestPrintTrailThreadDetail_ShowsMessageIDs(t *testing.T) {
 
 func TestTrailThreadPathBuilders(t *testing.T) {
 	t.Parallel()
-	if got := trailThreadsPath("gh", "acme", "widgets", 7); !strings.HasSuffix(got, "/7/threads") {
+	const basePath = "/api/v1/repos/native-repo-id/trails"
+	if got := trailThreadsPath(basePath, 7); got != basePath+"/7/threads" {
 		t.Errorf("threads path = %q", got)
 	}
-	if got := trailThreadPath("gh", "acme", "widgets", 7, "th1"); !strings.HasSuffix(got, "/7/threads/th1") {
+	if got := trailThreadPath(basePath, 7, "th1"); got != basePath+"/7/threads/th1" {
 		t.Errorf("thread path = %q", got)
 	}
-	if got := trailThreadMessagesPath("gh", "acme", "widgets", 7, "th1"); !strings.HasSuffix(got, "/threads/th1/messages") {
+	if got := trailThreadMessagesPath(basePath, 7, "th1"); got != basePath+"/7/threads/th1/messages" {
 		t.Errorf("messages path = %q", got)
 	}
-	if got := trailThreadMessagePath("gh", "acme", "widgets", 7, "th1", "m1"); !strings.HasSuffix(got, "/threads/th1/messages/m1") {
+	if got := trailThreadMessagePath(basePath, 7, "th1", "m1"); got != basePath+"/7/threads/th1/messages/m1" {
 		t.Errorf("message path = %q", got)
 	}
 }

--- a/cmd/entire/cli/trail_comment_cmd.go
+++ b/cmd/entire/cli/trail_comment_cmd.go
@@ -18,20 +18,20 @@ import (
 )
 
 // Thread subresource path builders (keyed by trail number).
-func trailThreadsPath(forge, owner, repo string, number int) string {
-	return trailNumberPath(forge, owner, repo, number) + "/threads"
+func trailThreadsPath(basePath string, number int) string {
+	return trailNumberPathForBase(basePath, number) + "/threads"
 }
 
-func trailThreadPath(forge, owner, repo string, number int, threadID string) string {
-	return trailThreadsPath(forge, owner, repo, number) + "/" + threadID
+func trailThreadPath(basePath string, number int, threadID string) string {
+	return trailThreadsPath(basePath, number) + "/" + threadID
 }
 
-func trailThreadMessagesPath(forge, owner, repo string, number int, threadID string) string {
-	return trailThreadPath(forge, owner, repo, number, threadID) + "/messages"
+func trailThreadMessagesPath(basePath string, number int, threadID string) string {
+	return trailThreadPath(basePath, number, threadID) + "/messages"
 }
 
-func trailThreadMessagePath(forge, owner, repo string, number int, threadID, messageID string) string {
-	return trailThreadMessagesPath(forge, owner, repo, number, threadID) + "/" + messageID
+func trailThreadMessagePath(basePath string, number int, threadID, messageID string) string {
+	return trailThreadMessagesPath(basePath, number, threadID) + "/" + messageID
 }
 
 // trailSubcommandSelector reads the subtree's persistent --trail flag.
@@ -43,7 +43,7 @@ func trailSubcommandSelector(cmd *cobra.Command) string {
 // withNumberedTrail resolves a numbered trail (by --trail selector or current
 // branch / --branch) and invokes fn inside an authenticated API context. It
 // centralizes the resolution boilerplate for the comment subtree.
-func withNumberedTrail(cmd *cobra.Command, fn func(ctx context.Context, client *api.Client, found *api.TrailResource, forge, owner, repo string) error) error {
+func withNumberedTrail(cmd *cobra.Command, fn func(ctx context.Context, client *api.Client, found *api.TrailResource, basePath string) error) error {
 	repoOverride := trailRepoFlag(cmd)
 	selector := trailSubcommandSelector(cmd)
 	branch := trailBranchFlag(cmd)
@@ -54,12 +54,20 @@ func withNumberedTrail(cmd *cobra.Command, fn func(ctx context.Context, client *
 		return err
 	}
 	// Auth/not-logged-in messages go to stderr; w carries command output only.
-	return runAuthenticatedTrailAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), repoOverride, func(ctx context.Context, client *api.Client) error {
-		found, forge, owner, repo, err := resolveNumberedTrail(ctx, client, repoOverride, selector, branch)
+	return runAuthenticatedTrailAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), repoOverride, func(ctx context.Context, client *api.Client, repoID string) error {
+		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
 		if err != nil {
 			return err
 		}
-		return fn(ctx, client, found, forge, owner, repo)
+		basePath, err := trailRepoBasePath(forge, owner, repo, repoID)
+		if err != nil {
+			return err
+		}
+		found, err := resolveNumberedTrailAtPath(ctx, client, basePath, forge, owner, repo, selector, branch)
+		if err != nil {
+			return err
+		}
+		return fn(ctx, client, found, basePath)
 	})
 }
 
@@ -95,8 +103,8 @@ func newTrailCommentListCmd() *cobra.Command {
 		Short: "List discussion threads on a trail",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, forge, owner, repo string) error {
-				items, err := fetchAllTrailThreads(ctx, client, trailThreadsPath(forge, owner, repo, found.Number))
+			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, basePath string) error {
+				items, err := fetchAllTrailThreads(ctx, client, trailThreadsPath(basePath, found.Number))
 				if err != nil {
 					return err
 				}
@@ -193,8 +201,8 @@ func newTrailCommentShowCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			threadID := args[0]
-			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, forge, owner, repo string) error {
-				resp, err := client.Get(ctx, trailThreadPath(forge, owner, repo, found.Number, threadID))
+			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, basePath string) error {
+				resp, err := client.Get(ctx, trailThreadPath(basePath, found.Number, threadID))
 				if err != nil {
 					return fmt.Errorf("failed to fetch thread: %w", err)
 				}
@@ -252,9 +260,9 @@ func newTrailCommentAddCmd() *cobra.Command {
 			if strings.TrimSpace(body) == "" {
 				return errors.New("--body is required")
 			}
-			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, forge, owner, repo string) error {
+			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, basePath string) error {
 				req := api.TrailThreadCreateRequest{Title: strings.TrimSpace(title), Body: body}
-				resp, err := client.Post(ctx, trailThreadsPath(forge, owner, repo, found.Number), req)
+				resp, err := client.Post(ctx, trailThreadsPath(basePath, found.Number), req)
 				if err != nil {
 					return fmt.Errorf("failed to create thread: %w", err)
 				}
@@ -290,12 +298,12 @@ func newTrailCommentReplyCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			threadID := args[0]
-			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, forge, owner, repo string) error {
+			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, basePath string) error {
 				if strings.TrimSpace(body) == "" {
 					return errors.New("--body is required")
 				}
 				req := api.TrailThreadMessageRequest{Body: body}
-				resp, err := client.Post(ctx, trailThreadMessagesPath(forge, owner, repo, found.Number, threadID), req)
+				resp, err := client.Post(ctx, trailThreadMessagesPath(basePath, found.Number, threadID), req)
 				if err != nil {
 					return fmt.Errorf("failed to reply: %w", err)
 				}
@@ -325,12 +333,12 @@ func newTrailCommentEditCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			threadID, messageID := args[0], args[1]
-			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, forge, owner, repo string) error {
+			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, basePath string) error {
 				if strings.TrimSpace(body) == "" {
 					return errors.New("--body is required")
 				}
 				req := api.TrailThreadMessageRequest{Body: body}
-				resp, err := client.Patch(ctx, trailThreadMessagePath(forge, owner, repo, found.Number, threadID, messageID), req)
+				resp, err := client.Patch(ctx, trailThreadMessagePath(basePath, found.Number, threadID, messageID), req)
 				if err != nil {
 					return fmt.Errorf("failed to edit message: %w", err)
 				}
@@ -379,8 +387,8 @@ func newTrailCommentDeleteCmd() *cobra.Command {
 					return nil
 				}
 			}
-			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, forge, owner, repo string) error {
-				resp, err := client.Delete(ctx, trailThreadMessagePath(forge, owner, repo, found.Number, threadID, messageID))
+			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, basePath string) error {
+				resp, err := client.Delete(ctx, trailThreadMessagePath(basePath, found.Number, threadID, messageID))
 				if err != nil {
 					return fmt.Errorf("failed to delete message: %w", err)
 				}
@@ -404,9 +412,9 @@ func newTrailCommentResolveCmd(use string, resolved bool, shortVerb, successVerb
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			threadID := args[0]
-			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, forge, owner, repo string) error {
+			return withNumberedTrail(cmd, func(ctx context.Context, client *api.Client, found *api.TrailResource, basePath string) error {
 				req := api.TrailThreadUpdateRequest{Resolved: &resolved}
-				resp, err := client.Patch(ctx, trailThreadPath(forge, owner, repo, found.Number, threadID), req)
+				resp, err := client.Patch(ctx, trailThreadPath(basePath, found.Number, threadID), req)
 				if err != nil {
 					return fmt.Errorf("failed to update thread: %w", err)
 				}

--- a/cmd/entire/cli/trail_context_cache.go
+++ b/cmd/entire/cli/trail_context_cache.go
@@ -291,8 +291,8 @@ func refreshTrailsEnabledCacheIfStaleForScope(ctx context.Context, scope trailEn
 // data-API/BFF client: the BFF does not proxy /api/v1/trails/... for bearer
 // callers (COR-666), so probing it via the generic client silently misreads a
 // supported repo as disabled.
-var trailRefreshAPIClient = func(ctx context.Context, insecureHTTP bool, fullName string) (*api.Client, error) {
-	client, _, err := newTrailAPIClient(ctx, insecureHTTP, fullName)
+var trailRefreshAPIClient = func(ctx context.Context, insecureHTTP bool, forge, owner, repo string) (*api.Client, error) {
+	client, _, err := newTrailAPIClient(ctx, insecureHTTP, forge, owner, repo)
 	return client, err
 }
 
@@ -311,8 +311,8 @@ var trailRefreshAPIClient = func(ctx context.Context, insecureHTTP bool, fullNam
 // a caller can log it without having to know which of the two it got. When
 // notOnboarded is true, err is the sentinel-wrapping error, kept for logging;
 // callers must act on notOnboarded, not propagate err.
-func trailsCellClient(ctx context.Context, insecureHTTP bool, ownerRepo string) (client *api.Client, notOnboarded bool, err error) {
-	client, err = trailRefreshAPIClient(ctx, insecureHTTP, ownerRepo)
+func trailsCellClient(ctx context.Context, insecureHTTP bool, forge, owner, repo string) (client *api.Client, notOnboarded bool, err error) {
+	client, err = trailRefreshAPIClient(ctx, insecureHTTP, forge, owner, repo)
 	switch {
 	case err == nil:
 		return client, false, nil
@@ -353,7 +353,7 @@ func runTrailEnablementRefresh(ctx context.Context) error {
 		}
 		return nil
 	}
-	client, notOnboarded, err := trailsCellClient(ctx, false, scope.Owner+"/"+scope.Repo)
+	client, notOnboarded, err := trailsCellClient(ctx, false, scope.Forge, scope.Owner, scope.Repo)
 	if notOnboarded {
 		// A definitive, permanent negative: without this, every SessionStart
 		// re-forks a refresh child for this repo forever (see
@@ -566,11 +566,11 @@ func runAuthenticatedTrailAPI(ctx context.Context, errW io.Writer, insecureHTTP 
 // to repo-addressed read callers. Most trail operations remain host-addressed
 // and should use runAuthenticatedTrailAPI instead.
 func runAuthenticatedTrailAPIWithRepoID(ctx context.Context, errW io.Writer, insecureHTTP bool, repoOverride string, fn func(context.Context, *api.Client, string) error) error {
-	_, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
+	forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
 	if err != nil {
 		return err
 	}
-	client, repoID, err := newTrailAPIClient(ctx, insecureHTTP, owner+"/"+repo)
+	client, repoID, err := newTrailAPIClient(ctx, insecureHTTP, forge, owner, repo)
 	if err != nil {
 		return renderDataAPIAuthError(ctx, errW, owner+"/"+repo, err)
 	}

--- a/cmd/entire/cli/trail_context_cache.go
+++ b/cmd/entire/cli/trail_context_cache.go
@@ -553,19 +553,11 @@ func noteTrailCommandEnablement(ctx context.Context, client *api.Client, command
 }
 
 // runAuthenticatedTrailAPI runs fn against the entire-api cell that owns the
-// target repository. repoOverride is the raw --repo flag: when non-empty the
-// local clone's enablement cache is skipped because the result belongs to a
-// different repository.
-func runAuthenticatedTrailAPI(ctx context.Context, errW io.Writer, insecureHTTP bool, repoOverride string, fn func(context.Context, *api.Client) error) error {
-	return runAuthenticatedTrailAPIWithRepoID(ctx, errW, insecureHTTP, repoOverride, func(ctx context.Context, client *api.Client, _ string) error {
-		return fn(ctx, client)
-	})
-}
-
-// runAuthenticatedTrailAPIWithRepoID also exposes the processing placement ID
-// to repo-addressed read callers. Most trail operations remain host-addressed
-// and should use runAuthenticatedTrailAPI instead.
-func runAuthenticatedTrailAPIWithRepoID(ctx context.Context, errW io.Writer, insecureHTTP bool, repoOverride string, fn func(context.Context, *api.Client, string) error) error {
+// target repository and exposes the repo ID needed to address native trail
+// routes. repoOverride is the raw --repo flag: when non-empty the local clone's
+// enablement cache is skipped because the result belongs to a different
+// repository.
+func runAuthenticatedTrailAPI(ctx context.Context, errW io.Writer, insecureHTTP bool, repoOverride string, fn func(context.Context, *api.Client, string) error) error {
 	forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
 	if err != nil {
 		return err

--- a/cmd/entire/cli/trail_context_cache.go
+++ b/cmd/entire/cli/trail_context_cache.go
@@ -292,7 +292,8 @@ func refreshTrailsEnabledCacheIfStaleForScope(ctx context.Context, scope trailEn
 // callers (COR-666), so probing it via the generic client silently misreads a
 // supported repo as disabled.
 var trailRefreshAPIClient = func(ctx context.Context, insecureHTTP bool, fullName string) (*api.Client, error) {
-	return newTrailAPIClient(ctx, insecureHTTP, fullName)
+	client, _, err := newTrailAPIClient(ctx, insecureHTTP, fullName)
+	return client, err
 }
 
 // trailsCellClient resolves the entire-api cell client for ownerRepo via
@@ -556,15 +557,24 @@ func noteTrailCommandEnablement(ctx context.Context, client *api.Client, command
 // local clone's enablement cache is skipped because the result belongs to a
 // different repository.
 func runAuthenticatedTrailAPI(ctx context.Context, errW io.Writer, insecureHTTP bool, repoOverride string, fn func(context.Context, *api.Client) error) error {
+	return runAuthenticatedTrailAPIWithRepoID(ctx, errW, insecureHTTP, repoOverride, func(ctx context.Context, client *api.Client, _ string) error {
+		return fn(ctx, client)
+	})
+}
+
+// runAuthenticatedTrailAPIWithRepoID also exposes the processing placement ID
+// to repo-addressed read callers. Most trail operations remain host-addressed
+// and should use runAuthenticatedTrailAPI instead.
+func runAuthenticatedTrailAPIWithRepoID(ctx context.Context, errW io.Writer, insecureHTTP bool, repoOverride string, fn func(context.Context, *api.Client, string) error) error {
 	_, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
 	if err != nil {
 		return err
 	}
-	client, err := newTrailAPIClient(ctx, insecureHTTP, owner+"/"+repo)
+	client, repoID, err := newTrailAPIClient(ctx, insecureHTTP, owner+"/"+repo)
 	if err != nil {
 		return renderDataAPIAuthError(ctx, errW, owner+"/"+repo, err)
 	}
-	err = fn(ctx, client)
+	err = fn(ctx, client, repoID)
 	if repoOverride == "" {
 		noteTrailCommandEnablement(ctx, client, err)
 	}

--- a/cmd/entire/cli/trail_repo_flag_test.go
+++ b/cmd/entire/cli/trail_repo_flag_test.go
@@ -123,7 +123,7 @@ func TestRunAuthenticatedTrailAPIRoutesByForgeQualifiedRepo(t *testing.T) {
 	t.Cleanup(func() { newTrailAPIClient = previous })
 
 	called := false
-	err := runAuthenticatedTrailAPIWithRepoID(t.Context(), io.Discard, false, "entire://cell.example/et/acme/app", func(_ context.Context, _ *api.Client, repoID string) error {
+	err := runAuthenticatedTrailAPI(t.Context(), io.Discard, false, "entire://cell.example/et/acme/app", func(_ context.Context, _ *api.Client, repoID string) error {
 		called = true
 		if repoID != trailTestRepoID {
 			t.Fatalf("repoID=%q, want %s", repoID, trailTestRepoID)

--- a/cmd/entire/cli/trail_repo_flag_test.go
+++ b/cmd/entire/cli/trail_repo_flag_test.go
@@ -144,18 +144,18 @@ func TestResolveTrailRepoOrRemote_OverrideSkipsGit(t *testing.T) {
 	}
 }
 
-func TestRunAuthenticatedTrailAPIRoutesByRepo(t *testing.T) {
+func TestRunAuthenticatedTrailAPIRoutesByForgeQualifiedRepo(t *testing.T) {
 	// newTrailAPIClient is a package seam, so this test must not run in parallel.
 	previous := newTrailAPIClient
-	var gotFullName string
-	newTrailAPIClient = func(_ context.Context, _ bool, fullName string) (*api.Client, string, error) {
-		gotFullName = fullName
+	var gotForge, gotOwner, gotRepo string
+	newTrailAPIClient = func(_ context.Context, _ bool, forge, owner, repo string) (*api.Client, string, error) {
+		gotForge, gotOwner, gotRepo = forge, owner, repo
 		return api.NewClientWithBaseURL("token", "https://cell.example"), trailTestRepoID, nil
 	}
 	t.Cleanup(func() { newTrailAPIClient = previous })
 
 	called := false
-	err := runAuthenticatedTrailAPIWithRepoID(t.Context(), io.Discard, false, "gh/acme/app", func(_ context.Context, _ *api.Client, repoID string) error {
+	err := runAuthenticatedTrailAPIWithRepoID(t.Context(), io.Discard, false, "entire://cell.example/et/acme/app", func(_ context.Context, _ *api.Client, repoID string) error {
 		called = true
 		if repoID != trailTestRepoID {
 			t.Fatalf("repoID=%q, want %s", repoID, trailTestRepoID)
@@ -165,8 +165,8 @@ func TestRunAuthenticatedTrailAPIRoutesByRepo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !called || gotFullName != "acme/app" {
-		t.Fatalf("called=%v fullName=%q, want true and acme/app", called, gotFullName)
+	if !called || strings.Join([]string{gotForge, gotOwner, gotRepo}, "/") != "et/acme/app" {
+		t.Fatalf("called=%v repo=(%q,%q,%q), want true and (et,acme,app)", called, gotForge, gotOwner, gotRepo)
 	}
 }
 

--- a/cmd/entire/cli/trail_repo_flag_test.go
+++ b/cmd/entire/cli/trail_repo_flag_test.go
@@ -148,15 +148,18 @@ func TestRunAuthenticatedTrailAPIRoutesByRepo(t *testing.T) {
 	// newTrailAPIClient is a package seam, so this test must not run in parallel.
 	previous := newTrailAPIClient
 	var gotFullName string
-	newTrailAPIClient = func(_ context.Context, _ bool, fullName string) (*api.Client, error) {
+	newTrailAPIClient = func(_ context.Context, _ bool, fullName string) (*api.Client, string, error) {
 		gotFullName = fullName
-		return api.NewClientWithBaseURL("token", "https://cell.example"), nil
+		return api.NewClientWithBaseURL("token", "https://cell.example"), trailTestRepoID, nil
 	}
 	t.Cleanup(func() { newTrailAPIClient = previous })
 
 	called := false
-	err := runAuthenticatedTrailAPI(t.Context(), io.Discard, false, "gh/acme/app", func(_ context.Context, _ *api.Client) error {
+	err := runAuthenticatedTrailAPIWithRepoID(t.Context(), io.Discard, false, "gh/acme/app", func(_ context.Context, _ *api.Client, repoID string) error {
 		called = true
+		if repoID != trailTestRepoID {
+			t.Fatalf("repoID=%q, want %s", repoID, trailTestRepoID)
+		}
 		return nil
 	})
 	if err != nil {

--- a/cmd/entire/cli/trail_repo_flag_test.go
+++ b/cmd/entire/cli/trail_repo_flag_test.go
@@ -13,17 +13,16 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
-// TestTrailForgeRefusalCoversBothEntryPoints is the F1 regression: a forge
-// reaches the trail API two ways — named in --repo, or inferred from origin —
-// and only the argument was gated, so a developer standing in a native clone
-// got the existence-hiding 404 the check exists to prevent. The inferred path
-// is the common one.
+// TestTrailNativeForgeCoversBothEntryPoints ensures a native repo reaches the
+// repo-ID-addressed trail path whether it is named in --repo or inferred from
+// origin. The inferred path is the common one.
 //
 // Not parallel: chdirs into a temp repo.
-func TestTrailForgeRefusalCoversBothEntryPoints(t *testing.T) {
+func TestTrailNativeForgeCoversBothEntryPoints(t *testing.T) {
 	t.Run("named in --repo", func(t *testing.T) {
-		_, _, _, err := parseTrailRepoArg("et/paul/dogbark")
-		require.ErrorIs(t, err, errTrailsNativeUnsupported)
+		forge, owner, repo, err := parseTrailRepoArg("et/paul/dogbark")
+		require.NoError(t, err)
+		require.Equal(t, []string{"et", "paul", "dogbark"}, []string{forge, owner, repo})
 	})
 
 	t.Run("inferred from a native origin remote", func(t *testing.T) {
@@ -31,8 +30,9 @@ func TestTrailForgeRefusalCoversBothEntryPoints(t *testing.T) {
 		testutil.InitRepo(t, dir)
 		testutil.RunGit(t, dir, "remote", "add", "origin", "entire://aws-us-east-2.entire.io/et/paul/dogbark")
 		t.Chdir(dir)
-		_, _, _, err := resolveTrailRemote(t.Context())
-		require.ErrorIs(t, err, errTrailsNativeUnsupported)
+		forge, owner, repo, err := resolveTrailRemote(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, []string{"et", "paul", "dogbark"}, []string{forge, owner, repo})
 	})
 
 	t.Run("a mirror origin remote still resolves", func(t *testing.T) {
@@ -46,35 +46,6 @@ func TestTrailForgeRefusalCoversBothEntryPoints(t *testing.T) {
 		require.Equal(t, "entireio", owner)
 		require.Equal(t, "cli", repo)
 	})
-}
-
-// TestParseTrailRepoArg_NativeForgeReason pins WHY a native ref is refused.
-// Before this, `et` fell into the unknown-forge branch and was answered with
-// `"et" is not a supported forge id` plus a suggested github.com URL for a
-// repo that does not live on GitHub — two false statements. The reason is the
-// trails API's, not the forge token's.
-func TestParseTrailRepoArg_NativeForgeReason(t *testing.T) {
-	t.Parallel()
-	for _, raw := range []string{"et/paul/dogbark", "entire://host/et/paul/dogbark"} {
-		t.Run(raw, func(t *testing.T) {
-			t.Parallel()
-			_, _, _, err := parseTrailRepoArg(raw)
-			if err == nil {
-				t.Fatalf("parseTrailRepoArg(%q): want error", raw)
-			}
-			msg := err.Error()
-			for _, want := range []string{"Entire-native", "gh/<owner>/<repo>"} {
-				if !strings.Contains(msg, want) {
-					t.Errorf("parseTrailRepoArg(%q) = %q, missing %q", raw, msg, want)
-				}
-			}
-			for _, unwanted := range []string{"not a supported forge id", "https://github.com/paul/dogbark"} {
-				if strings.Contains(msg, unwanted) {
-					t.Errorf("parseTrailRepoArg(%q) = %q, should not contain %q", raw, msg, unwanted)
-				}
-			}
-		})
-	}
 }
 
 func TestParseTrailRepoArg(t *testing.T) {
@@ -102,11 +73,8 @@ func TestParseTrailRepoArg(t *testing.T) {
 		{name: "bare host instead of forge id", raw: "github.com/acme/app", wantErr: true},
 		{name: "bare unsupported forge host", raw: "gitlab.com/acme/app", wantErr: true},
 		{name: "unknown short forge id", raw: "zz/acme/app", wantErr: true},
-		// `et` IS a forge token (gitremote.IsForgePathToken) and entire-api's
-		// validTrailsHosts admits it, but resolvableTrailsHosts is {gh} alone,
-		// so it can only ever 404 — both spellings are refused locally instead.
-		{name: "native forge is refused", raw: "et/paul/dogbark", wantErr: true},
-		{name: "native forge in a URL is refused too", raw: "entire://host/et/paul/dogbark", wantErr: true},
+		{name: "native forge", raw: "et/paul/dogbark", wantForge: "et", wantOwner: "paul", wantRepo: "dogbark"},
+		{name: "native forge in a URL", raw: "entire://host/et/paul/dogbark", wantForge: "et", wantOwner: "paul", wantRepo: "dogbark"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/entire/cli/trail_resume_cmd.go
+++ b/cmd/entire/cli/trail_resume_cmd.go
@@ -201,7 +201,7 @@ func validateTrailResumeOptions(opts trailResumeOptions) error {
 }
 
 func runTrailResume(cmd *cobra.Command, opts trailResumeOptions) error {
-	return runAuthenticatedTrailAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), "", func(ctx context.Context, client *api.Client) error {
+	return runAuthenticatedTrailAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), "", func(ctx context.Context, client *api.Client, repoID string) error {
 		forge, owner, repo, err := resolveTrailRemote(ctx)
 		if err != nil {
 			return err
@@ -218,7 +218,11 @@ func runTrailResume(cmd *cobra.Command, opts trailResumeOptions) error {
 			forge, owner, repo = expectedRepo.Forge, expectedRepo.Owner, expectedRepo.Repo
 		}
 
-		found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, opts.Selector, opts.ExpectedBranch)
+		basePath, err := trailRepoBasePath(forge, owner, repo, repoID)
+		if err != nil {
+			return err
+		}
+		found, err := resolveTrailBySelectorAtPath(ctx, client, basePath, forge, owner, repo, opts.Selector, opts.ExpectedBranch)
 		if err != nil {
 			return err
 		}
@@ -236,7 +240,7 @@ func runTrailResume(cmd *cobra.Command, opts trailResumeOptions) error {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not load trail checkpoint sessions: %s\n", sessionsUnavailable)
 		}
 
-		client.SetTrailRoute(found.ID, trailNumberPath(forge, owner, repo, found.Number))
+		client.SetTrailRoute(found.ID, trailNumberPathForBase(basePath, found.Number))
 		findings, findingsErr := loadTrailResumeFindingsContext(ctx, client, found.ID)
 		if findingsErr != nil {
 			findings.Unavailable = findingsErr.Error()

--- a/cmd/entire/cli/trail_review_cmd.go
+++ b/cmd/entire/cli/trail_review_cmd.go
@@ -488,10 +488,10 @@ func authenticatedTrailReviewTarget(cmd *cobra.Command, selector string) (*api.C
 	}
 	var target trailReviewTarget
 	var resolvedClient *api.Client
-	err := runAuthenticatedTrailAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), repoOverride, func(ctx context.Context, client *api.Client) error {
+	err := runAuthenticatedTrailAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), repoOverride, func(ctx context.Context, client *api.Client, repoID string) error {
 		var err error
 		resolvedClient = client
-		target, err = resolveTrailReviewTarget(ctx, client, selector, repoOverride, branchOverride)
+		target, err = resolveTrailReviewTarget(ctx, client, repoID, selector, repoOverride, branchOverride)
 		return err
 	})
 	if err != nil {
@@ -500,8 +500,12 @@ func authenticatedTrailReviewTarget(cmd *cobra.Command, selector string) (*api.C
 	return resolvedClient, target, nil
 }
 
-func resolveTrailReviewTarget(ctx context.Context, client *api.Client, selector, repoOverride, branchOverride string) (trailReviewTarget, error) {
+func resolveTrailReviewTarget(ctx context.Context, client *api.Client, repoID, selector, repoOverride, branchOverride string) (trailReviewTarget, error) {
 	host, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
+	if err != nil {
+		return trailReviewTarget{}, err
+	}
+	basePath, err := trailRepoBasePath(host, owner, repo, repoID)
 	if err != nil {
 		return trailReviewTarget{}, err
 	}
@@ -509,7 +513,7 @@ func resolveTrailReviewTarget(ctx context.Context, client *api.Client, selector,
 	selector = strings.TrimSpace(selector)
 	var found *api.TrailResource
 	if selector != "" {
-		found, err = findTrailBySelector(ctx, client, host, owner, repo, selector)
+		found, err = findTrailBySelectorAtPath(ctx, client, basePath, selector)
 		if err != nil {
 			return trailReviewTarget{}, err
 		}
@@ -521,7 +525,7 @@ func resolveTrailReviewTarget(ctx context.Context, client *api.Client, selector,
 		if branchErr != nil {
 			return trailReviewTarget{}, fmt.Errorf("%w: no trail selector given and current branch is unknown: %w\nhint: run 'entire trail list --status any' or pass --trail <number|id|branch>", errTrailReviewDefaultTargetNotFound, branchErr)
 		}
-		found, err = findTrailByBranch(ctx, client, host, owner, repo, branch)
+		found, err = findTrailByBranchAtPath(ctx, client, basePath, branch)
 		if err != nil {
 			return trailReviewTarget{}, err
 		}
@@ -539,7 +543,7 @@ func resolveTrailReviewTarget(ctx context.Context, client *api.Client, selector,
 	// public routes are repo/number addressed. Register that translation once
 	// when the target is resolved so findings, snapshots, and SSE all hit the
 	// owning cell's native route.
-	client.SetTrailRoute(found.ID, trailNumberPath(host, owner, repo, found.Number))
+	client.SetTrailRoute(found.ID, trailNumberPathForBase(basePath, found.Number))
 	return trailReviewTarget{Host: host, Owner: owner, Repo: repo, Trail: *found}, nil
 }
 

--- a/cmd/entire/cli/trail_review_cmd_test.go
+++ b/cmd/entire/cli/trail_review_cmd_test.go
@@ -82,12 +82,52 @@ func TestResolveTrailReviewTargetRejectsUnsupportedForge(t *testing.T) {
 	testutil.RunGit(t, repoDir, "remote", "add", "origin", "git@gitlab.com:acme/my-app.git")
 	t.Chdir(repoDir)
 
-	_, err := resolveTrailReviewTarget(context.Background(), api.NewClient("tok"), "", "", "")
+	_, err := resolveTrailReviewTarget(context.Background(), api.NewClient("tok"), "", "", "", "")
 	if err == nil {
 		t.Fatal("expected error for gitlab.com origin, got nil")
 	}
 	if !strings.Contains(err.Error(), "not on a forge supported by Entire trails") {
 		t.Fatalf("error message does not mention unsupported forge: %v", err)
+	}
+}
+
+// Not parallel: uses t.Chdir() to resolve a native origin remote.
+func TestResolveTrailReviewTargetUsesNativeRepoBasePath(t *testing.T) {
+	const basePath = "/api/v1/repos/native-repo-id/trails"
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.RunGit(t, repoDir, "remote", "add", "origin", "entire://aws-us-east-2.entire.io/et/entirehq/marvin")
+	t.Chdir(repoDir)
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case basePath + "/3":
+			if err := json.NewEncoder(w).Encode(api.TrailResource{ID: "native-trail", Number: 3, Branch: "feature/native"}); err != nil {
+				t.Errorf("encode trail response: %v", err)
+			}
+		case basePath + "/3/reviews/comments":
+			if err := json.NewEncoder(w).Encode(api.TrailReviewCommentsResponse{}); err != nil {
+				t.Errorf("encode findings response: %v", err)
+			}
+		default:
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClientWithBaseURL("token", srv.URL)
+	target, err := resolveTrailReviewTarget(t.Context(), client, "native-repo-id", "3", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fetchAllTrailReviewComments(t.Context(), client, target.Trail.ID, trailReviewSummaryOptions()); err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 2 || paths[0] != basePath+"/3" || paths[1] != basePath+"/3/reviews/comments" {
+		t.Fatalf("request paths = %v, want native detail and findings routes", paths)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1224
<!-- entire-trail-link-end -->

## Problem

Entire-native remotes use `/et/<project>/<repo>`, but trail API client resolution discarded the forge and looked up only `<owner>/<repo>`. When a legacy GitHub mirror has the same name—as with `entirehq/marvin`—the CLI can select the `/gh/` repository's placement and trails instead.

Native repositories also cannot be resolved reliably through the name-addressed cell route. They need to be resolved through their project-scoped repository identity and queried by repository ID.

## Changes

- preserve the `gh` versus `et` forge namespace throughout trail repository resolution
- resolve Entire-native repositories through the native project and repository lookup, using the resulting repository ULID and home cell
- use `/api/v1/repos/{repo_id}/trails` as the base route for native repositories
- retain `/api/v1/trails/gh/{owner}/{repo}` for GitHub-backed repositories
- derive trail lookup, detail, body, metadata update, and delete paths from the selected repository base route
- add collision coverage for same-named `/et/` and `/gh/` repositories

## Command coverage

This change migrates the affected paths for:

- `entire trail list`
- `entire trail show`, including number, selector, and default/current-branch lookup
- `entire trail update`, including metadata and body updates
- `entire trail delete`, including number and branch lookup
- runner trail gathering

## Test plan

- `mise run check`
- `mise run lint`
- read-only production `trail list` smoke test against `entire://aws-us-east-2.entire.io/et/entirehq/marvin` returned exactly its 3 native trails
- read-only production `trail show 3 --json` smoke test returned Marvin native trail 3 with an `/et/entirehq/marvin` URL
- update and delete routes verified with local HTTP fixtures only; no production mutations performed

## Tracking

- [ENT-2195](https://linear.app/entirehq/issue/ENT-2195/cli-entire-trail-commands-dont-support-native-repos)
