### PR TITLE
Partial revert: auto-select the sole login a host accepts

### DIFF
--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -213,8 +213,8 @@ type cellSubject struct {
 // `--jurisdiction` mints a token for the caller's SELECTED environment, so with
 // (say) a partial.to context active it must mint a partial.to token even though
 // the data host defaults to entire.io. Discovery keys off api.BaseURL(), so it
-// would fail outright — clusterdiscovery.requireActiveContext validates the
-// active context against *that* host's trusted issuers and errors when they
+// would fail outright — clusterdiscovery.selectLoginContext validates the
+// selected context against *that* host's trusted issuers and errors when they
 // don't match, which for this command is the wrong question to ask: the target
 // jurisdiction comes from the flag, not from the default data host.
 // NewEntireAPICellClient is a different case — it dials the data plane — so it

--- a/cmd/entire/cli/auth/control_plane_test.go
+++ b/cmd/entire/cli/auth/control_plane_test.go
@@ -97,7 +97,7 @@ func TestResolveControlPlaneTargetForCluster_DialsClusterCoreNotActive(t *testin
 	}
 
 	// Stub cluster discovery so the test doesn't hit the network: the cluster
-	// resolves to the prod context (what /.well-known + requireActiveContext would
+	// resolves to the prod context (what /.well-known + selectLoginContext would
 	// yield), NOT the active partial context.
 	prev := resolveContextForCluster
 	resolveContextForCluster = func(_ context.Context, _, _, host string, _ *http.Client, _ clusterdiscovery.DebugFunc) (*contexts.Context, error) {

--- a/cmd/entire/cli/auth/data_api.go
+++ b/cmd/entire/cli/auth/data_api.go
@@ -65,7 +65,7 @@ func SetResolveContextForAPIForTest(t interface{ Helper() }, fn resolveContextFu
 // A host that doesn't advertise discovery (unreachable / 404 / 503 /
 // malformed) is an error — without it we can't know which login servers the
 // host trusts, and guessing risks presenting a token to a host that doesn't
-// accept that core (see clusterdiscovery.requireActiveContext).
+// accept that core (see clusterdiscovery.selectLoginContext).
 //
 // Callers that honour --insecure-http-auth must call EnableInsecureHTTP before
 // invoking this (as they already do); the per-context refresh reads that

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -308,11 +308,43 @@ func makeTestJWT(t *testing.T, aud string) string {
 	return header + "." + payload + "." + enc.EncodeToString([]byte("sig"))
 }
 
+// testClusterHost is the cluster name the ENTIRE_TOKEN tests dial. It shares
+// entire.io with the cores they advertise, which the same-site gate on
+// discovery requires; the TLS test server itself answers on 127.0.0.1, so
+// pinnedClient rewrites the dial while the URL the code sees keeps this name.
+const testClusterHost = "cluster.entire.io"
+
+// pinnedClient returns srv.Client() with every request redirected to srv,
+// whatever host the URL names. TLS still verifies against 127.0.0.1, which
+// the httptest certificate covers.
+func pinnedClient(t *testing.T, srv *httptest.Server) *http.Client {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	c := srv.Client()
+	c.Transport = pinnedTransport{base: c.Transport, scheme: u.Scheme, host: u.Host}
+	return c
+}
+
+type pinnedTransport struct {
+	base   http.RoundTripper
+	scheme string
+	host   string
+}
+
+func (p pinnedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = p.scheme
+	req.URL.Host = p.host
+	return p.base.RoundTrip(req)
+}
+
 // wellKnownServer serves /.well-known/entire-cluster.json advertising the
 // given cores, jurisdiction audience, and jurisdiction core over TLS,
-// returning the server and the host:port to use as clusterHost. An empty
-// audience models a cluster predating jurisdiction-token git auth.
-func wellKnownServer(t *testing.T, cores []string, jurisdictionAudience, jurisdictionCoreURL string) (*httptest.Server, string) {
+// returning a client pinned to it and testClusterHost to use as clusterHost.
+// An empty audience models a cluster predating jurisdiction-token git auth.
+func wellKnownServer(t *testing.T, cores []string, jurisdictionAudience, jurisdictionCoreURL string) (*http.Client, string) {
 	t.Helper()
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/.well-known/entire-cluster.json" {
@@ -329,22 +361,18 @@ func wellKnownServer(t *testing.T, cores []string, jurisdictionAudience, jurisdi
 		_ = json.NewEncoder(w).Encode(body) //nolint:errcheck // best-effort in test stub
 	}))
 	t.Cleanup(srv.Close)
-	u, err := url.Parse(srv.URL)
-	if err != nil {
-		t.Fatalf("parse server URL: %v", err)
-	}
-	return srv, u.Host
+	return pinnedClient(t, srv), testClusterHost
 }
 
 func TestResolveEnvTokenCreds_TrustedAudSucceeds(t *testing.T) {
 	t.Parallel()
 	const core = "https://core.us.entire.io"
 	const audience = "https://us.entire.io"
-	srv, clusterHost := wellKnownServer(t, []string{core}, audience, core)
+	client, clusterHost := wellKnownServer(t, []string{core}, audience, core)
 	envToken := makeTestJWT(t, core)
 
 	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), envToken, clusterHost, t.TempDir(), srv.Client(),
+		t.Context(), envToken, clusterHost, t.TempDir(), client,
 	)
 	if err != nil {
 		t.Fatalf("expected trusted aud to succeed, got: %v", err)
@@ -364,11 +392,11 @@ func TestResolveEnvTokenCreds_CrossJurisdictionTokenUsesBearer(t *testing.T) {
 	// sibling core passes the trust gate and is used directly as the bearer.
 	const tokenCore = "https://core.eu.entire.io"
 	const jurisdictionCore = "https://core.us.entire.io"
-	srv, clusterHost := wellKnownServer(t, []string{tokenCore, jurisdictionCore}, "https://us.entire.io", jurisdictionCore)
+	client, clusterHost := wellKnownServer(t, []string{tokenCore, jurisdictionCore}, "https://us.entire.io", jurisdictionCore)
 	envToken := makeTestJWT(t, tokenCore)
 
 	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), envToken, clusterHost, t.TempDir(), srv.Client(),
+		t.Context(), envToken, clusterHost, t.TempDir(), client,
 	)
 	if err != nil {
 		t.Fatalf("cross-jurisdiction token must resolve, got: %v", err)
@@ -385,11 +413,11 @@ func TestResolveEnvTokenCreds_CrossJurisdictionTokenUsesBearer(t *testing.T) {
 func TestResolveEnvTokenCreds_DoesNotRequireJurisdictionAudience(t *testing.T) {
 	t.Parallel()
 	const core = "https://core.us.entire.io"
-	srv, clusterHost := wellKnownServer(t, []string{core}, "", "")
+	client, clusterHost := wellKnownServer(t, []string{core}, "", "")
 	envToken := makeTestJWT(t, core)
 
 	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), envToken, clusterHost, t.TempDir(), srv.Client(),
+		t.Context(), envToken, clusterHost, t.TempDir(), client,
 	)
 	if err != nil {
 		t.Fatalf("resolve direct bearer without jurisdiction audience: %v", err)
@@ -499,10 +527,10 @@ func TestResolveEnvTokenCreds_UntrustedAudAborts(t *testing.T) {
 	t.Parallel()
 	// The cluster advertises only core.us; the token's aud points elsewhere.
 	// The gate must abort before building creds (i.e. before any exchange).
-	srv, clusterHost := wellKnownServer(t, []string{"https://core.us.entire.io"}, "https://us.entire.io", "https://core.us.entire.io")
+	client, clusterHost := wellKnownServer(t, []string{"https://core.us.entire.io"}, "https://us.entire.io", "https://core.us.entire.io")
 
 	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, "https://attacker.example.com"), clusterHost, t.TempDir(), srv.Client(),
+		t.Context(), makeTestJWT(t, "https://attacker.example.com"), clusterHost, t.TempDir(), client,
 	)
 	if err == nil {
 		t.Fatal("expected untrusted aud to be rejected")
@@ -519,16 +547,44 @@ func TestResolveEnvTokenCreds_EmptyAdvertisedCoresAborts(t *testing.T) {
 	t.Parallel()
 	// Discovery succeeds (HTTP 200) but advertises no cores. With nothing to
 	// trust, the gate must fail closed rather than trusting the token's aud.
-	srv, clusterHost := wellKnownServer(t, []string{}, "https://us.entire.io", "https://core.us.entire.io")
+	client, clusterHost := wellKnownServer(t, []string{}, "https://us.entire.io", "https://core.us.entire.io")
 
 	creds, _, err := resolveEnvTokenCreds(
-		t.Context(), makeTestJWT(t, "https://core.us.entire.io"), clusterHost, t.TempDir(), srv.Client(),
+		t.Context(), makeTestJWT(t, "https://core.us.entire.io"), clusterHost, t.TempDir(), client,
 	)
 	if err == nil {
 		t.Fatal("expected empty advertised core set to be rejected")
 	}
 	if creds != nil {
 		t.Fatal("expected nil creds when no cores are advertised")
+	}
+}
+
+func TestResolveEnvTokenCreds_CrossSiteCoresAbort(t *testing.T) {
+	t.Parallel()
+	// A cluster under one domain advertising a core under another is the
+	// shape of a token-stealing cluster: the token's aud WOULD match the
+	// advertised list, so coreTrusted alone would hand it over. The same-site
+	// gate on discovery must refuse first, naming both sides.
+	const foreignCore = "https://core.us.evil.example"
+	client, clusterHost := wellKnownServer(t, []string{foreignCore}, "https://us.entire.io", foreignCore)
+
+	creds, _, err := resolveEnvTokenCreds(
+		t.Context(), makeTestJWT(t, foreignCore), clusterHost, t.TempDir(), client,
+	)
+	if err == nil {
+		t.Fatal("expected a cross-site core to be refused")
+	}
+	if creds != nil {
+		t.Fatal("expected nil creds when a cross-site core is advertised")
+	}
+	for _, want := range []string{"cluster " + testClusterHost, foreignCore, "outside entire.io", "refusing"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q must contain %q", err.Error(), want)
+		}
+	}
+	if strings.Contains(err.Error(), "not a trusted login server") {
+		t.Fatal("the same-site gate must refuse before the aud comparison runs")
 	}
 }
 

--- a/docs/architecture/upstream-host-resolution.md
+++ b/docs/architecture/upstream-host-resolution.md
@@ -200,13 +200,20 @@ would end one session server-side while deleting another's local credentials.
 Two tiers sit underneath, in `clusterdiscovery.selectLoginContext`, and they
 apply only when the identity came from `current_context` (or there is none):
 
-- exactly one saved login is eligible → **use it**, and say so on stderr
-  (`Using context 'foo'.`, via `clusterdiscovery.autoSelectNoticeW`). Someone
-  with logins in two federations can clone from either without retargeting
-  every shell on the machine, and acting as a login they did not choose is
-  never silent. Stderr, never stdout: this resolves inside
-  `git-remote-entire`, where stdout is the remote-helper protocol. Nothing is
-  printed when the selected identity acts, nor on any error.
+- exactly one saved login is eligible **and the host is under `entire.io`,
+  `partial.to`, or `localhost`** (`clusterdiscovery.autoSelectSites` — prod,
+  staging, local dev; hardcoded, no setting or env override) → **use it**, and
+  say so on stderr (`Using context 'foo'.`, via
+  `clusterdiscovery.autoSelectNoticeW`). Someone with logins in two federations
+  can clone from either without retargeting every shell on the machine, and
+  acting as a login they did not choose is never silent. Stderr, never stdout:
+  this resolves inside `git-remote-entire`, where stdout is the remote-helper
+  protocol. Nothing is printed when the selected identity acts, nor on any
+  error. For any other host — a self-hosted `git.acme.com` advertising
+  `auth.acme.com` — the sole eligible login is *named*, not used: the "does not
+  accept your active login … These saved logins can authenticate it" error
+  below, so the user selects it with `auth use` or `--context`. The allowlist
+  gates only the choice made *for* the user, never one they made.
 - several are eligible → an ambiguity error naming them, sorted
   (`clusterdiscovery.ambiguousContextError`). Picking one would make the acting
   identity depend on what else happens to be stored.

--- a/docs/architecture/upstream-host-resolution.md
+++ b/docs/architecture/upstream-host-resolution.md
@@ -218,6 +218,34 @@ the failure the override exists to prevent.
 Multiple saved logins are fully supported — `auth contexts`, `auth use`, and
 `logout --all-contexts` are unchanged.
 
+### The advertised issuers must be the host's own
+
+Eligibility is decided by the host's `/.well-known` document, and the eligible
+login's JWT is then handed to that host: `git-remote-entire` sends it as the
+bearer (`cmd/git-remote-entire/main.go`, `resolveCreds`), and the data-API path
+presents the refreshed login token the same way. Nothing else asks whether the
+host is *entitled* to that token. So a hostile cluster `evil.com` that advertises
+`https://foo.auth.entire.io` in `core_urls` would be handed a real entire.io
+login token — through every tier above, explicit or automatic, and through
+`ENTIRE_TOKEN`, whose `aud` is compared against that same list.
+
+`clusterdiscovery.requireSameSiteIssuers` closes this: every entry in `core_urls`
+(git) or `trusted_issuers` (data API) must share the host's registrable domain
+(eTLD+1, via `registrableDomain` — `foo.auth.entire.io` and `git.entire.io` are
+both `entire.io`; `evil.co.uk` is not `acme.co.uk`; IP literals and `localhost`
+match only themselves). It runs in `resolveCachedCores` on **every entry handed
+out** — fresh cache, stale fallback, and a live fetch *before* it is cached — so
+one check covers all three callers and a cores entry planted in the on-disk cache
+is refused on read rather than trusted for a TTL.
+
+A mismatch is a hard error naming both sides
+(`cluster evil.com advertises login server https://foo.auth.entire.io outside
+evil.com; refusing`), never a silent filter: an emptied list would fall through to
+the `entire login --server …` hint and send the user to log in against the host
+that lied. `login_url` is outside the gate — it is display-only and never
+eligible (`clusterdiscovery.Response.LoginURL`); `jurisdiction_core_url` is
+carried but dialled by no caller today, so it is not gated either.
+
 Because "not logged in" is actively misleading for a user who *is* logged in,
 just to another federation, the error distinguishes what the user can do about
 it. Two independent facts pick the message

--- a/docs/architecture/upstream-host-resolution.md
+++ b/docs/architecture/upstream-host-resolution.md
@@ -149,12 +149,13 @@ Resolution (`auth.ResolveDataAPIToken`):
 
 The selection rule differs from the control plane (where the active context is
 *always* used because there's no host to match): here a host **is** matched, so
-the active context is used only when the host trusts its core.
+the active context is used only when the host trusts its core, and otherwise the
+sole saved login it does trust is (see [Account selection](#account-selection)).
 
 Key files: `cmd/entire/cli/auth/data_api.go` (`ResolveDataAPIToken`),
 `cmd/entire/cli/auth/refresh.go` (`RefreshedLoginToken`),
 `internal/entireclient/clusterdiscovery/api_discovery.go` (`DiscoverAPI`,
-`ResolveContextForAPI`, sharing `requireActiveContext` *and* the cores cache with
+`ResolveContextForAPI`, sharing `selectLoginContext` *and* the cores cache with
 the cluster path), `internal/entireclient/discovery/cluster_cores.go`
 (`LoadAPICores`/`ModifyAPICores`). Seams:
 `NewAuthenticatedAPIClient` (activity/trail/search-completion),
@@ -166,10 +167,12 @@ the cluster path), `internal/entireclient/discovery/cluster_cores.go`
 One rule, everywhere a host is matched — git clusters, the data API,
 cluster-addressed control-plane commands, and entire-api cell routing
 (`auth/cell_data_api.go`'s `resolveStoredCellSubject`): **the identity is the one
-the user selected, or the command fails.** `/.well-known` decides only whether
-that identity is *accepted*, never which one is *chosen*.
+the user selected; failing that, the only saved login the host accepts.**
+`/.well-known` decides which identities are *accepted*; it picks one only when
+exactly one fits.
 
-Selection resolves in one place, `contexts.File.Active`, with this precedence:
+The user's selection resolves in one place, `contexts.File.Active`, with this
+precedence:
 
 | Source | Scope | Use it for |
 | --- | --- | --- |
@@ -194,16 +197,22 @@ status` reports it, `auth contexts` marks it, and `logout` revokes and deletes
 *that* login. Resolving the removal target separately from the revocation target
 would end one session server-side while deleting another's local credentials.
 
-Two implicit tiers used to sit underneath — "the sole eligible context", and an
-ambiguity error when several were eligible. Both are gone. They made the acting
-identity depend on what else happened to be stored, so adding a second login
-could silently change which account a command ran as, and the same command could
-act as different identities on two machines. For "whose credentials is this
-running under?", a predictable error beats a convenient guess.
+Two tiers sit underneath, in `clusterdiscovery.selectLoginContext`, and they
+apply only when the identity came from `current_context` (or there is none):
 
-Multiple saved logins are still fully supported — `auth contexts`, `auth use`,
-and `logout --all-contexts` are unchanged. What changed is that switching is
-always explicit.
+- exactly one saved login is eligible → **use it**, and say so on stderr
+  (`Using context 'foo'.`). Someone with logins in two federations can clone
+  from either without retargeting every shell on the machine.
+- several are eligible → an ambiguity error naming them, sorted
+  (`clusterdiscovery.ambiguousContextError`). Picking one would make the acting
+  identity depend on what else happens to be stored.
+
+An **explicit** `--context`/`$ENTIRE_CONTEXT` never falls through to either: the
+user asked for that identity by name, so acting as another behind their back is
+the failure the override exists to prevent.
+
+Multiple saved logins are fully supported — `auth contexts`, `auth use`, and
+`logout --all-contexts` are unchanged.
 
 Because "not logged in" is actively misleading for a user who *is* logged in,
 just to another federation, the error distinguishes what the user can do about
@@ -219,8 +228,11 @@ exists, and whether any saved login is eligible.
 | no | no | the login hint, plus the trusted servers and `entire login --server <url>` |
 
 The two no-identity rows must not use the "does not accept your active login"
-phrasing — there is no active login to reject, and a dangling `current_context`
-lands there.
+phrasing — there is no active login to reject.
+
+The two "a saved login is eligible" rows are now reached only by an explicit
+override the host rejected: with no override, an eligible saved login is
+auto-selected or reported as ambiguous before rendering gets a say.
 
 "Points at the switch" also tracks the source: an identity that came from
 `--context` is fixed by changing that argument, not by `entire auth use`, which
@@ -232,6 +244,6 @@ default server, which for a resource in another federation reproduces the same
 failure.
 
 Key file: `internal/entireclient/clusterdiscovery/resolve.go`
-(`requireActiveContext` — the single home for this policy, plus
-`contextEligible`, the one eligibility predicate shared by the accept decision
-and the candidate list).
+(`selectLoginContext` — the single home for this policy, plus `contextEligible`,
+the one eligibility predicate shared by the accept decision, the auto-selection
+candidates, and the candidate list reported on failure).

--- a/docs/architecture/upstream-host-resolution.md
+++ b/docs/architecture/upstream-host-resolution.md
@@ -201,8 +201,12 @@ Two tiers sit underneath, in `clusterdiscovery.selectLoginContext`, and they
 apply only when the identity came from `current_context` (or there is none):
 
 - exactly one saved login is eligible → **use it**, and say so on stderr
-  (`Using context 'foo'.`). Someone with logins in two federations can clone
-  from either without retargeting every shell on the machine.
+  (`Using context 'foo'.`, via `clusterdiscovery.autoSelectNoticeW`). Someone
+  with logins in two federations can clone from either without retargeting
+  every shell on the machine, and acting as a login they did not choose is
+  never silent. Stderr, never stdout: this resolves inside
+  `git-remote-entire`, where stdout is the remote-helper protocol. Nothing is
+  printed when the selected identity acts, nor on any error.
 - several are eligible → an ambiguity error naming them, sorted
   (`clusterdiscovery.ambiguousContextError`). Picking one would make the acting
   identity depend on what else happens to be stored.

--- a/internal/entireclient/clusterdiscovery/api_discovery.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery.go
@@ -116,5 +116,5 @@ func ResolveContextForAPI(ctx context.Context, configDir, cacheDir, apiHost stri
 	}
 	// The data-API well-known advertises no login server, so the hint falls
 	// back to naming the issuers it trusts.
-	return selectLoginContext(f, "API host "+apiHost, loginTargets{coreURLs: trustedIssuers}, debugf)
+	return selectLoginContext(f, "API host "+apiHost, apiHost, loginTargets{coreURLs: trustedIssuers}, debugf)
 }

--- a/internal/entireclient/clusterdiscovery/api_discovery.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery.go
@@ -86,9 +86,9 @@ func resolveAPICores(ctx context.Context, cacheDir, apiHost string, httpClient *
 // ResolveContextForAPI picks the local login context to authenticate data-API
 // calls against apiHost.
 //
-// It mirrors ResolveContextForCluster, sharing requireActiveContext: the active
-// context is used when its CoreURL is among the API's trusted issuers, and
-// anything else is an error. It sources those issuers from
+// It mirrors ResolveContextForCluster, sharing selectLoginContext: the selected
+// context is used when its CoreURL is among the API's trusted issuers, else the
+// sole saved login that is. It sources those issuers from
 // /.well-known/entire-api.json (cached in api_discovery.json, long TTL,
 // re-fetched on expiry with stale fallback) instead of entire-cluster.json.
 // The caller exchanges the active context's token for the data host origin
@@ -116,5 +116,5 @@ func ResolveContextForAPI(ctx context.Context, configDir, cacheDir, apiHost stri
 	}
 	// The data-API well-known advertises no login server, so the hint falls
 	// back to naming the issuers it trusts.
-	return requireActiveContext(f, "API host "+apiHost, loginTargets{coreURLs: trustedIssuers}, debugf)
+	return selectLoginContext(f, "API host "+apiHost, loginTargets{coreURLs: trustedIssuers}, debugf)
 }

--- a/internal/entireclient/clusterdiscovery/api_discovery.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery.go
@@ -68,7 +68,7 @@ func DiscoverAPI(ctx context.Context, apiHost string, c *http.Client, debugf Deb
 // reuse the cores cache (different file). Cold failures stay folded under
 // ErrDiscoveryUnavailable (from DiscoverAPI) for the caller to surface.
 func resolveAPICores(ctx context.Context, cacheDir, apiHost string, httpClient *http.Client, debugf DebugFunc) ([]string, error) {
-	entry, err := resolveCachedCores(cacheDir, apiHost, "api host", false,
+	entry, err := resolveCachedCores(cacheDir, apiHost, "API host", false,
 		discovery.LoadAPICores, discovery.ModifyAPICores,
 		func() (discovery.CoresEntry, error) {
 			body, err := DiscoverAPI(ctx, apiHost, httpClient, debugf)

--- a/internal/entireclient/clusterdiscovery/api_discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery_test.go
@@ -168,11 +168,10 @@ func TestResolveContextForAPI(t *testing.T) {
 		assert.Equal(t, "me@us-partial", c.Name)
 	})
 
-	// The `ENTIRE_API_BASE_URL=https://partial.to entire activity` case. It used
-	// to resolve silently to the sole eligible staging login; an env var
-	// changing which account a command runs as is the ambiguity the active
-	// context exists to remove, so it is now an error that names the switch.
-	t.Run("unrelated active context errors naming the eligible login", func(t *testing.T) {
+	// The `ENTIRE_API_BASE_URL=https://partial.to entire activity` case: the
+	// active login is on a core this host doesn't trust, and exactly one saved
+	// login is, so that one acts.
+	t.Run("unrelated active context falls back to the sole eligible login", func(t *testing.T) {
 		t.Parallel()
 		srv := httptest.NewServer(apiHandler(t, "https://us.auth.partial.to", "https://eu.auth.partial.to"))
 		defer srv.Close()
@@ -186,11 +185,9 @@ func TestResolveContextForAPI(t *testing.T) {
 			},
 		}))
 
-		_, err := ResolveContextForAPI(t.Context(), configDir, t.TempDir(), "partial.to", hostPinningClient(t, srv), t.Logf)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "API host partial.to does not accept your active login")
-		assert.Contains(t, err.Error(), "me@staging", "name the login that would work")
-		assert.Contains(t, err.Error(), "entire auth use")
+		c, err := ResolveContextForAPI(t.Context(), configDir, t.TempDir(), "partial.to", hostPinningClient(t, srv), t.Logf)
+		require.NoError(t, err)
+		assert.Equal(t, "me@staging", c.Name)
 	})
 
 	t.Run("no eligible context → login hint naming the API host's servers", func(t *testing.T) {
@@ -213,9 +210,9 @@ func TestResolveContextForAPI(t *testing.T) {
 		assert.Contains(t, err.Error(), "entire login --server")
 	})
 
-	// Two eligible contexts are no longer "ambiguous" — the resolver never
-	// picks, so both are simply offered, sorted.
-	t.Run("several eligible contexts are all offered", func(t *testing.T) {
+	// Two eligible contexts leave nothing to auto-select: the resolver refuses to
+	// guess which account acts, and names both, sorted.
+	t.Run("several eligible contexts are ambiguous", func(t *testing.T) {
 		t.Parallel()
 		srv := httptest.NewServer(apiHandler(t, "https://us.auth.partial.to"))
 		defer srv.Close()
@@ -232,7 +229,7 @@ func TestResolveContextForAPI(t *testing.T) {
 
 		_, err := ResolveContextForAPI(t.Context(), configDir, t.TempDir(), "partial.to", hostPinningClient(t, srv), t.Logf)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "API host partial.to")
+		assert.Contains(t, err.Error(), "multiple login contexts can authenticate against API host partial.to")
 		assert.Contains(t, err.Error(), "alice@partial, bob@partial", "sorted, not in stored order")
 	})
 

--- a/internal/entireclient/clusterdiscovery/discovery.go
+++ b/internal/entireclient/clusterdiscovery/discovery.go
@@ -48,7 +48,9 @@ type Response struct {
 	//
 	// Never a member of CoreURLs, and never eligible to be: the apex issues
 	// no tokens, so no login can carry it as an issuer. It answers "what do
-	// I type", not "whose tokens are accepted".
+	// I type", not "whose tokens are accepted". For the same reason it is
+	// outside requireSameSiteIssuers' gate: no token is ever sent because
+	// of it, only a URL shown in a hint.
 	LoginURL string `json:"login_url"`
 }
 

--- a/internal/entireclient/clusterdiscovery/issuer_domain.go
+++ b/internal/entireclient/clusterdiscovery/issuer_domain.go
@@ -1,0 +1,77 @@
+package clusterdiscovery
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// registrableDomain returns the registrable domain (eTLD+1) of host — the
+// part one organisation controls — so two hosts can be compared for "same
+// operator": foo.auth.entire.io → entire.io, royalcanin.partial.to →
+// partial.to, whatever.evil.com → evil.com. It is NOT "the last two labels":
+// evil.co.uk → evil.co.uk, which is what stops evil.co.uk from matching
+// acme.co.uk.
+//
+// A port is ignored, and the result is case-folded through
+// normalizeClusterHost so it never disagrees with the cache key. Hosts with no
+// registrable domain match only themselves: IP literals, single-label names
+// (localhost), and bare public suffixes (co.uk), for which
+// publicsuffix.EffectiveTLDPlusOne returns an error.
+func registrableDomain(host string) string {
+	host = normalizeClusterHost(host)
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	// An IPv6 literal without a port keeps its brackets past SplitHostPort.
+	host = strings.TrimSuffix(strings.Trim(host, "[]"), ".")
+	if net.ParseIP(host) != nil || !strings.Contains(host, ".") {
+		return host
+	}
+	domain, err := publicsuffix.EffectiveTLDPlusOne(host)
+	if err != nil {
+		return host
+	}
+	return domain
+}
+
+// requireSameSiteIssuers rejects an advertised issuer list that reaches outside
+// the resource's own registrable domain.
+//
+// SECURITY: this is the trust boundary on discovery. The resource's
+// /.well-known document decides which saved logins are eligible, and the
+// selected login's JWT is then sent to the resource as the bearer
+// (git-remote-entire), or refreshed and presented to it (data API). Nothing
+// checks that the resource is entitled to that token. So a hostile
+// cluster evil.com advertising `https://foo.auth.entire.io` in core_urls
+// would be handed a real entire.io login token — through every selection
+// tier, explicit or automatic — and through ENTIRE_TOKEN, whose aud is
+// compared against this same list. Requiring every issuer to share the
+// resource's registrable domain means a host can only ever be sent a token
+// minted by its own operator.
+//
+// A mismatch is a hard error naming both sides, never a silent filter: an
+// emptied list would fall through to the `entire login --server …` hint and
+// send the user to log in against the very host that lied. An entry that is
+// not a URL with a host fails the same way — it can match no login and is
+// evidence of a malformed document, not a login server.
+//
+// label and host are the resource ("cluster", "evil.com"); coreURLs is its
+// advertised core_urls (git) or trusted_issuers (data API).
+func requireSameSiteIssuers(label, host string, coreURLs []string) error {
+	site := registrableDomain(host)
+	for _, coreURL := range coreURLs {
+		u, err := url.Parse(strings.TrimSpace(coreURL))
+		if err != nil || u.Host == "" {
+			return fmt.Errorf("%s %s advertises unusable login server %q; refusing", label, host, coreURL)
+		}
+		if registrableDomain(u.Host) != site {
+			return fmt.Errorf("%s %s advertises login server %s outside %s; refusing",
+				label, host, normalizeCoreURL(coreURL), site)
+		}
+	}
+	return nil
+}

--- a/internal/entireclient/clusterdiscovery/issuer_domain_test.go
+++ b/internal/entireclient/clusterdiscovery/issuer_domain_test.go
@@ -1,0 +1,170 @@
+package clusterdiscovery
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/discovery"
+)
+
+func TestRegistrableDomain(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"foo.auth.entire.io":         "entire.io",
+		"whatever.evil.com":          "evil.com",
+		"royalcanin.partial.to":      "partial.to",
+		"AWS-EU-Central-1.Entire.IO": "entire.io",
+		"entire.io":                  "entire.io",
+		// A port is not part of the domain.
+		"localhost:8080":     "localhost",
+		"127.0.0.1:9000":     "127.0.0.1",
+		"auth.acme.com:8443": "acme.com",
+		// No registrable domain: match only themselves.
+		"localhost":  "localhost",
+		"127.0.0.1":  "127.0.0.1",
+		"[::1]:9000": "::1",
+		"[::1]":      "::1",
+		"::1":        "::1",
+		// eTLD+1, not "last two labels": co.uk is a public suffix.
+		"evil.co.uk":       "evil.co.uk",
+		"www.acme.co.uk":   "acme.co.uk",
+		"co.uk":            "co.uk",
+		"trailing.dot.io.": "dot.io",
+	}
+	for host, want := range cases {
+		assert.Equal(t, want, registrableDomain(host), "registrableDomain(%q)", host)
+	}
+	assert.NotEqual(t, registrableDomain("evil.co.uk"), registrableDomain("acme.co.uk"),
+		"two registrants under one public suffix must not compare equal")
+}
+
+func TestRequireSameSiteIssuers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same site passes, across regions, ports, and schemes", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, requireSameSiteIssuers("cluster", "aws-eu-central-1.entire.io",
+			[]string{"https://eu.auth.entire.io", " https://us.auth.entire.io/ "}))
+		require.NoError(t, requireSameSiteIssuers("cluster", "localhost:8080", []string{"http://localhost:9000"}))
+		require.NoError(t, requireSameSiteIssuers("cluster", "127.0.0.1:8080", []string{"http://127.0.0.1:9000"}))
+		require.NoError(t, requireSameSiteIssuers("cluster", "git.acme.com", []string{"https://auth.acme.com"}))
+	})
+
+	t.Run("one foreign entry refuses the whole list, naming both sides", func(t *testing.T) {
+		t.Parallel()
+		err := requireSameSiteIssuers("cluster", "evil.com",
+			[]string{"https://auth.evil.com", "https://foo.auth.entire.io"})
+		require.Error(t, err)
+		assert.Equal(t, "cluster evil.com advertises login server https://foo.auth.entire.io outside evil.com; refusing", err.Error())
+	})
+
+	t.Run("public suffix is not a shared site", func(t *testing.T) {
+		t.Parallel()
+		require.Error(t, requireSameSiteIssuers("cluster", "evil.co.uk", []string{"https://auth.acme.co.uk"}))
+	})
+
+	t.Run("IP literals match exactly", func(t *testing.T) {
+		t.Parallel()
+		require.Error(t, requireSameSiteIssuers("cluster", "127.0.0.1:8080", []string{"http://localhost:9000"}))
+	})
+
+	t.Run("an entry with no host is refused rather than skipped", func(t *testing.T) {
+		t.Parallel()
+		err := requireSameSiteIssuers("API host", "partial.to", []string{"https://us.auth.partial.to", ""})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `API host partial.to advertises unusable login server ""`)
+	})
+}
+
+// TestResolve_ForeignIssuerIsRefused: the threat this gate exists for. A
+// cluster the user did not log into advertises a real entire.io core, so a
+// saved entire.io login IS eligible by the issuer match alone — and its JWT is
+// what git-remote-entire would send the cluster as the bearer. Discovery must
+// refuse before any selection tier runs, and must not send the user off to log
+// in against the lying host.
+func TestResolve_ForeignIssuerIsRefused(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(coresHandler(t, nil, "https://foo.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod",
+		Contexts:       []*contexts.Context{{Name: "prod", CoreURL: "https://foo.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"}},
+	}))
+
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "git.evil.com", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	assert.Equal(t, "cluster git.evil.com advertises login server https://foo.auth.entire.io outside evil.com; refusing", err.Error())
+	assert.NotContains(t, err.Error(), "entire login")
+}
+
+// The data-API path shares the gate: an API host's trusted_issuers must be its
+// own.
+func TestResolveContextForAPI_ForeignIssuerIsRefused(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(apiHandler(t, "https://us.auth.partial.to"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	partialContexts(t, configDir)
+
+	_, err := ResolveContextForAPI(t.Context(), configDir, t.TempDir(), "api.evil.com", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	assert.Equal(t, "API host api.evil.com advertises login server https://us.auth.partial.to outside evil.com; refusing", err.Error())
+	require.NotErrorIs(t, err, ErrDiscoveryUnavailable, "a refusal is not a fallback case")
+}
+
+// TestResolve_PoisonedCacheIsRefusedOnRead: the gate runs on the entry handed
+// out, not only on the fetch, so a cores entry planted in cluster_cores.json is
+// rejected without a network round-trip rather than trusted for its TTL.
+func TestResolve_PoisonedCacheIsRefusedOnRead(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	require.NoError(t, discovery.ModifyClusterCores(cacheDir, func(c discovery.ClusterCoresCache) error {
+		c.SetEntry("git.evil.com", discovery.CoresEntry{
+			CoreURLs:             []string{"https://foo.auth.entire.io"},
+			JurisdictionAudience: "https://eu.entire.io",
+			FetchedAt:            time.Now(),
+		})
+		return nil
+	}))
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod",
+		Contexts:       []*contexts.Context{{Name: "prod", CoreURL: "https://foo.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"}},
+	}))
+
+	// deadPinningClient: any fetch fails, so a refusal proves the cached entry
+	// was inspected and rejected, not re-fetched.
+	_, err := ResolveContextForCluster(t.Context(), configDir, cacheDir, "git.evil.com", deadPinningClient(t), t.Logf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside evil.com; refusing")
+	require.NotErrorIs(t, err, ErrUnreachable, "the cache entry must be refused before any fetch is attempted")
+}
+
+// TestResolve_ForeignIssuerIsNeverCached: a refused document must not land in
+// the cache, or the next call would read it back and refuse it again for a
+// different reason than the one that matters.
+func TestResolve_ForeignIssuerIsNeverCached(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(coresHandler(t, nil, "https://foo.auth.entire.io"))
+	defer srv.Close()
+	cacheDir := t.TempDir()
+
+	_, err := ResolveContextForCluster(t.Context(), t.TempDir(), cacheDir, "git.evil.com", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+
+	cache, err := discovery.LoadClusterCores(cacheDir)
+	require.NoError(t, err)
+	if cache != nil {
+		_, _, ok := cache.GetEntry("git.evil.com")
+		assert.False(t, ok, "a refused discovery document must not be cached")
+	}
+}

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -135,7 +135,18 @@ func normalizeClusterHost(clusterHost string) string {
 // live fetch fails, so a brief outage doesn't break a host whose cores we
 // already knew. load/modify select the cache file; discover wraps the
 // host-specific /.well-known fetch (and any host-specific error formatting);
-// label names the resource in debug output ("cluster" / "api host").
+// label names the resource in debug output and in the same-site refusal
+// ("cluster" / "API host").
+//
+// Every entry handed out — fresh from the cache, the stale fallback, or just
+// fetched — first passes requireSameSiteIssuers, and a fetched one passes it
+// BEFORE it is cached. Gating here rather than at the fetch is what makes one
+// check cover the git-cluster, data-API, and ENTIRE_TOKEN paths, and it is
+// why a cores entry poisoned on disk (a hand-edited or planted cache file) is
+// rejected on read instead of trusted for a TTL. Gating the fetch as well
+// keeps a hostile document from ever landing in the cache. Only CoreURLs is
+// gated: LoginURL is display-only and never eligible (see Response.LoginURL),
+// and JurisdictionCoreURL is carried but dialled by no caller today.
 //
 // requireAudience marks callers that cannot proceed without the entry's
 // jurisdiction audience (both git auth paths). For them, an entry
@@ -173,6 +184,9 @@ func resolveCachedCores(
 			preAudience := requireAudience && entry.JurisdictionAudience == ""
 			outdated := entry.SchemaVersion < discovery.CoresSchemaVersion
 			if fresh && !preAudience && !outdated {
+				if err := requireSameSiteIssuers(label, host, entry.CoreURLs); err != nil {
+					return nil, err
+				}
 				debugf("%s %s cores from cache: %v", label, host, entry.CoreURLs)
 				return entry, nil
 			}
@@ -185,9 +199,15 @@ func resolveCachedCores(
 	fetched, err := discover()
 	if err != nil {
 		if stale != nil && (!requireAudience || stale.JurisdictionAudience != "") {
+			if gateErr := requireSameSiteIssuers(label, host, stale.CoreURLs); gateErr != nil {
+				return nil, gateErr
+			}
 			debugf("%s discovery for %s failed (%v); falling back to stale cached cores %v", label, host, err, stale.CoreURLs)
 			return stale, nil
 		}
+		return nil, err
+	}
+	if err := requireSameSiteIssuers(label, host, fetched.CoreURLs); err != nil {
 		return nil, err
 	}
 

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -27,9 +27,10 @@ import (
 //
 //   - Which of the user's accounts to use — whichever the user selected, via
 //     `--context`/$ENTIRE_CONTEXT for one invocation or the stored
-//     current_context otherwise, and nothing else. The cluster's cores only
-//     decide whether that identity is accepted; see requireActiveContext for
-//     the policy and why it has no fallback tiers.
+//     current_context otherwise, else the sole saved login the cluster's cores
+//     accept. Recomputed every call from the live contexts, never persisted,
+//     so a user with several accounts is never silently pinned to one. See
+//     selectLoginContext for the tiers.
 //
 // In particular we never fall back to an active context whose core does NOT
 // front the cluster: the cluster would reject the exchanged token as "unknown
@@ -88,7 +89,7 @@ func resolveClusterAuth(ctx context.Context, configDir, cacheDir, clusterHost st
 		return nil, err
 	}
 
-	selected, err := requireActiveContext(f, "cluster "+clusterHost,
+	selected, err := selectLoginContext(f, "cluster "+clusterHost,
 		loginTargets{coreURLs: entry.CoreURLs, loginURL: entry.LoginURL}, debugf)
 	if err != nil {
 		return nil, err
@@ -232,28 +233,30 @@ type noAuthContextError struct {
 func (e *noAuthContextError) Error() string { return e.message }
 func (e *noAuthContextError) Unwrap() error { return ErrNoAuthContext }
 
-// requireActiveContext resolves the login context for a resource from the ACTIVE
-// context alone, and is the one place the CLI's account-selection policy lives.
-// subject is a noun phrase identifying the resource ("cluster nyc.entire.io" /
-// "API host partial.to") used in messages, so the same rule serves the
-// git-cluster, data-API, and cell resolvers.
+// selectLoginContext resolves the login context for a resource, and is the one
+// place the CLI's account-selection policy lives. subject is a noun phrase
+// identifying the resource ("cluster nyc.entire.io" / "API host partial.to")
+// used in messages, so the same rule serves the git-cluster, data-API, and cell
+// resolvers.
 //
-// The policy: the user decides which identity acts — `--context` or
-// $ENTIRE_CONTEXT for one invocation, else `entire auth use` for the stored
-// default. A resource's advertised issuers decide only whether that identity is
-// *accepted*, never which one is *chosen*. So this validates, it does not
-// choose — hence the name.
+// The tiers, in order:
 //
-// Two implicit tiers used to sit underneath: "the sole eligible context", and an
-// ambiguity error when several were eligible. Both are gone, because they made
-// the acting identity depend on what *else* happened to be stored — adding a
-// second login could silently change which account a command ran as, and the
-// same command could act as different identities on two machines. For a question
-// as consequential as "whose credentials is this running under?", a predictable
-// error beats a convenient guess.
+//  1. An explicit `--context`/$ENTIRE_CONTEXT selection, when the resource
+//     accepts it. A saved-but-untrusted one is a hard error that never falls
+//     through: the user named that identity, so quietly acting as another is
+//     the very failure the override exists to prevent.
+//  2. The stored current_context, when the resource accepts it. `entire auth
+//     use <name>` is the lever for every resource that context's core fronts.
+//  3. Otherwise the sole saved login the resource accepts. Someone holding
+//     logins in two federations should be able to clone from either without
+//     first retargeting every shell on the machine.
+//  4. Otherwise, when several fit, ambiguousContextError — we refuse to guess
+//     which account acts.
+//
+// Anything left over is a failure renderUnusableActiveContext explains.
 //
 // See docs/architecture/upstream-host-resolution.md#account-selection.
-func requireActiveContext(f *contexts.File, subject string, t loginTargets, debugf DebugFunc) (*contexts.Context, error) {
+func selectLoginContext(f *contexts.File, subject string, t loginTargets, debugf DebugFunc) (*contexts.Context, error) {
 	// An explicit --context/$ENTIRE_CONTEXT naming no saved login fails here,
 	// before any eligibility talk: "that context doesn't exist" and "that context
 	// isn't trusted here" are different mistakes with different fixes.
@@ -269,11 +272,32 @@ func requireActiveContext(f *contexts.File, subject string, t loginTargets, debu
 		debugf("%s -> %s (%s) is not trusted here", subject, describeSelection(sel), sel.Context.CoreURL)
 	}
 	eligible := eligibleContexts(f, t.coreURLs)
+	// Auto-selection is for an identity the user did not name. An explicit
+	// override the resource rejects falls straight through to the message that
+	// blames the flag.
+	if !sel.Explicit() {
+		if len(eligible) == 1 {
+			debugf("%s -> sole eligible context %s", subject, eligible[0].Name)
+			return eligible[0], nil
+		}
+		if len(eligible) > 1 {
+			return nil, ambiguousContextError(subject, eligible)
+		}
+	}
 	message := renderUnusableActiveContext(subject, sel, eligible, t)
 	if sel.Context == nil && len(eligible) == 0 {
 		return nil, &noAuthContextError{message: message}
 	}
 	return nil, errors.New(message)
+}
+
+// ambiguousContextError reports that several saved logins fit and none was
+// chosen. Auto-selection settles a single candidate only: picking among several
+// would make the acting identity depend on what else happens to be stored, so
+// the user picks. Names are sorted, so the message is stable across saves.
+func ambiguousContextError(subject string, eligible []*contexts.Context) error {
+	return fmt.Errorf("multiple login contexts can authenticate against %s (%s); choose one with `entire auth use <context>` and re-run",
+		subject, strings.Join(contextNames(eligible), ", "))
 }
 
 // describeSelection labels a resolved identity for debug output, naming the
@@ -323,11 +347,11 @@ func normalizeCoreURL(coreURL string) string {
 	return strings.TrimRight(strings.TrimSpace(coreURL), "/")
 }
 
-// eligibleContexts returns the saved contexts this resource would accept, for
-// reporting only — requireActiveContext never picks from it. Filtering f.Contexts
-// once (rather than iterating coreURLs and collecting per-issuer matches) makes
-// duplicates structurally impossible, so no de-duplication is needed even when a
-// resource advertises the same core twice.
+// eligibleContexts returns the saved contexts this resource would accept: the
+// auto-selection candidates, and the set reported when selection fails.
+// Filtering f.Contexts once (rather than iterating coreURLs and collecting
+// per-issuer matches) makes duplicates structurally impossible, so no
+// de-duplication is needed even when a resource advertises the same core twice.
 func eligibleContexts(f *contexts.File, coreURLs []string) []*contexts.Context {
 	var out []*contexts.Context
 	for _, c := range f.Contexts {
@@ -353,6 +377,11 @@ func eligibleContexts(f *contexts.File, coreURLs []string) []*contexts.Context {
 // The remedy also tracks where the identity came from: someone who passed
 // `--context` needs to change that argument, not run `auth use`, which would
 // leave the flag still overriding it on the next run.
+//
+// selectLoginContext reaches this only where auto-selection cannot apply: an
+// explicit override the resource rejected, or no eligible saved login at all.
+// The rest of the matrix stays because this renders "no identity is available"
+// as a whole, and it is exercised directly.
 //
 // Returns a string, matching renderLoginHint and leaving the single errors.New
 // to the caller.

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
 
@@ -247,9 +249,10 @@ func (e *noAuthContextError) Unwrap() error { return ErrNoAuthContext }
 //     the very failure the override exists to prevent.
 //  2. The stored current_context, when the resource accepts it. `entire auth
 //     use <name>` is the lever for every resource that context's core fronts.
-//  3. Otherwise the sole saved login the resource accepts. Someone holding
-//     logins in two federations should be able to clone from either without
-//     first retargeting every shell on the machine.
+//  3. Otherwise the sole saved login the resource accepts, announced on
+//     autoSelectNoticeW. Someone holding logins in two federations should be
+//     able to clone from either without first retargeting every shell on the
+//     machine.
 //  4. Otherwise, when several fit, ambiguousContextError — we refuse to guess
 //     which account acts.
 //
@@ -278,6 +281,9 @@ func selectLoginContext(f *contexts.File, subject string, t loginTargets, debugf
 	if !sel.Explicit() {
 		if len(eligible) == 1 {
 			debugf("%s -> sole eligible context %s", subject, eligible[0].Name)
+			// Tier 2 already returned if the stored default fit, so the login
+			// acting here is never the one the user set. Say which it is.
+			fmt.Fprintf(autoSelectNoticeW, "Using context '%s'.\n", eligible[0].Name)
 			return eligible[0], nil
 		}
 		if len(eligible) > 1 {
@@ -290,6 +296,16 @@ func selectLoginContext(f *contexts.File, subject string, t loginTargets, debugf
 	}
 	return nil, errors.New(message)
 }
+
+// autoSelectNoticeW receives the line naming the login selectLoginContext
+// auto-selected. Package-level so tests can capture it, matching
+// tokenstore.loosePermsWarnW; production always writes to stderr.
+//
+// Stderr, never stdout: this resolves inside git-remote-entire, where stdout
+// carries the git remote-helper protocol and one stray line breaks the
+// transfer, and inside git hooks. Errors are ignored for the same reason the
+// other stderr notices ignore them — a failed notice must not fail the command.
+var autoSelectNoticeW io.Writer = os.Stderr
 
 // ambiguousContextError reports that several saved logins fit and none was
 // chosen. Auto-selection settles a single candidate only: picking among several

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -91,7 +91,7 @@ func resolveClusterAuth(ctx context.Context, configDir, cacheDir, clusterHost st
 		return nil, err
 	}
 
-	selected, err := selectLoginContext(f, "cluster "+clusterHost,
+	selected, err := selectLoginContext(f, "cluster "+clusterHost, clusterHost,
 		loginTargets{coreURLs: entry.CoreURLs, loginURL: entry.LoginURL}, debugf)
 	if err != nil {
 		return nil, err
@@ -270,16 +270,22 @@ func (e *noAuthContextError) Unwrap() error { return ErrNoAuthContext }
 //  2. The stored current_context, when the resource accepts it. `entire auth
 //     use <name>` is the lever for every resource that context's core fronts.
 //  3. Otherwise the sole saved login the resource accepts, announced on
-//     autoSelectNoticeW. Someone holding logins in two federations should be
-//     able to clone from either without first retargeting every shell on the
-//     machine.
+//     autoSelectNoticeW — for a host under autoSelectSites only. Someone
+//     holding logins in two federations should be able to clone from either
+//     without first retargeting every shell on the machine.
 //  4. Otherwise, when several fit, ambiguousContextError — we refuse to guess
 //     which account acts.
 //
-// Anything left over is a failure renderUnusableActiveContext explains.
+// Anything left over is a failure renderUnusableActiveContext explains — which
+// for a host outside autoSelectSites names the login that would work, so the
+// user selects it explicitly.
+//
+// host is the resource's own hostname (the cluster or API host the well-known
+// document came from), which tier 3 checks against autoSelectSites; subject is
+// the noun phrase built from it for messages.
 //
 // See docs/architecture/upstream-host-resolution.md#account-selection.
-func selectLoginContext(f *contexts.File, subject string, t loginTargets, debugf DebugFunc) (*contexts.Context, error) {
+func selectLoginContext(f *contexts.File, subject, host string, t loginTargets, debugf DebugFunc) (*contexts.Context, error) {
 	// An explicit --context/$ENTIRE_CONTEXT naming no saved login fails here,
 	// before any eligibility talk: "that context doesn't exist" and "that context
 	// isn't trusted here" are different mistakes with different fixes.
@@ -299,7 +305,10 @@ func selectLoginContext(f *contexts.File, subject string, t loginTargets, debugf
 	// override the resource rejects falls straight through to the message that
 	// blames the flag.
 	if !sel.Explicit() {
-		if len(eligible) == 1 {
+		if len(eligible) == 1 && !autoSelectAllowed(host) {
+			debugf("%s -> sole eligible context %s not auto-selected: %s is not an Entire site", subject, eligible[0].Name, host)
+		}
+		if len(eligible) == 1 && autoSelectAllowed(host) {
 			debugf("%s -> sole eligible context %s", subject, eligible[0].Name)
 			// Tier 2 already returned if the stored default fit, so the login
 			// acting here is never the one the user set. Say which it is.
@@ -315,6 +324,25 @@ func selectLoginContext(f *contexts.File, subject string, t loginTargets, debugf
 		return nil, &noAuthContextError{message: message}
 	}
 	return nil, errors.New(message)
+}
+
+// autoSelectSites are the registrable domains whose hosts may have a login
+// chosen FOR the user (tier 3 of selectLoginContext): Entire's own production,
+// staging, and local-dev federations. Hardcoded on purpose — no setting, no
+// environment override — because the list is the answer to "which operators
+// do we trust enough to pick a credential for without being asked?", and a
+// knob that widened it would be set by exactly the party that benefits.
+//
+// Any other host — a self-hosted git.acme.com advertising auth.acme.com, say —
+// still passes requireSameSiteIssuers and still works when its login is the
+// stored default or named with --context/$ENTIRE_CONTEXT. It just never
+// auto-selects: the user is told which saved login would work and switches
+// explicitly.
+var autoSelectSites = []string{"entire.io", "partial.to", "localhost"}
+
+// autoSelectAllowed reports whether host is under one of autoSelectSites.
+func autoSelectAllowed(host string) bool {
+	return slices.Contains(autoSelectSites, registrableDomain(host))
 }
 
 // autoSelectNoticeW receives the line naming the login selectLoginContext

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -276,7 +276,7 @@ func TestResolve_ContextWithoutCoreURLIsNeverEligible(t *testing.T) {
 		CurrentContext: "blank",
 		Contexts:       []*contexts.Context{{Name: "blank", Handle: "paul", KeychainService: "kc:blank"}},
 	}
-	_, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{""}}, t.Logf)
+	_, err := selectLoginContext(f, "cluster c.entire.io", "c.entire.io", loginTargets{coreURLs: []string{""}}, t.Logf)
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "These saved logins can authenticate it",
 		"a context rejected by the accept check must not be offered as a candidate")
@@ -292,7 +292,7 @@ func TestResolve_EligibilityIgnoresWhitespaceAndTrailingSlash(t *testing.T) {
 		CurrentContext: "eu",
 		Contexts:       []*contexts.Context{{Name: "eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:eu"}},
 	}
-	c, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{" https://eu.auth.entire.io/ "}}, t.Logf)
+	c, err := selectLoginContext(f, "cluster c.entire.io", "c.entire.io", loginTargets{coreURLs: []string{" https://eu.auth.entire.io/ "}}, t.Logf)
 	require.NoError(t, err)
 	assert.Equal(t, "eu", c.Name)
 }
@@ -696,12 +696,12 @@ func TestResolve_NilStoredContextDoesNotPanic(t *testing.T) {
 	}
 
 	// Empty coreURLs is the case the old loop shape never dereferenced at all.
-	_, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{}, t.Logf)
+	_, err := selectLoginContext(f, "cluster c.entire.io", "c.entire.io", loginTargets{}, t.Logf)
 	require.Error(t, err)
 
 	// And with a matching core, the nil entry must be skipped while the real one
 	// is auto-selected.
-	c, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{"https://eu.auth.entire.io"}}, t.Logf)
+	c, err := selectLoginContext(f, "cluster c.entire.io", "c.entire.io", loginTargets{coreURLs: []string{"https://eu.auth.entire.io"}}, t.Logf)
 	require.NoError(t, err)
 	assert.Equal(t, "prod-eu", c.Name, "the valid entry is still the sole candidate")
 }
@@ -717,7 +717,7 @@ func TestResolve_NilStoredContextIsSelectable(t *testing.T) {
 			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
 		},
 	}
-	c, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{"https://eu.auth.entire.io"}}, t.Logf)
+	c, err := selectLoginContext(f, "cluster c.entire.io", "c.entire.io", loginTargets{coreURLs: []string{"https://eu.auth.entire.io"}}, t.Logf)
 	require.NoError(t, err)
 	assert.Equal(t, "prod-eu", c.Name)
 }
@@ -837,5 +837,91 @@ func TestAutoSelectNoticeWriter_DefaultsToStderr(t *testing.T) {
 	f, ok := autoSelectNoticeW.(*os.File)
 	if !ok || f.Fd() != uintptr(syscall.Stderr) {
 		t.Fatalf("autoSelectNoticeW default = %T, want the process stderr", autoSelectNoticeW)
+	}
+}
+
+// TestResolve_AutoSelectionOnlyForEntireSites: a self-hosted cluster passes the
+// same-site gate (auth.acme.com is acme.com's own), and a single saved acme.com
+// login is eligible — but acme.com is not a site we choose credentials for
+// unasked. The user is told which login works and switches explicitly; the
+// stored default and --context are unaffected.
+//
+// Swaps the process-wide override and the package-global writer, so no
+// t.Parallel.
+func TestResolve_AutoSelectionOnlyForEntireSites(t *testing.T) {
+	srv := httptest.NewServer(coresHandler(t, nil, "https://auth.acme.com"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod",
+		Contexts: []*contexts.Context{
+			{Name: "prod", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+			{Name: "acme", CoreURL: "https://auth.acme.com", Handle: "paul", KeychainService: "kc:acme"},
+		},
+	}))
+
+	buf := captureAutoSelectNotice(t)
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "git.acme.com", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err, "acme is the sole eligible login, and must still not be chosen unasked")
+	assert.Contains(t, err.Error(), `cluster git.acme.com does not accept your active login "prod"`)
+	assert.Contains(t, err.Error(), "These saved logins can authenticate it: acme")
+	assert.Contains(t, err.Error(), "entire auth use")
+	assert.Empty(t, buf.String(), "nothing was selected, so nothing is announced")
+
+	// Named explicitly, the same login works — the allowlist gates only the
+	// choice made for the user, never the one they made.
+	contexts.SetFlagOverrideForTest(t, "acme")
+	c, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "git.acme.com", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "acme", c.Name)
+	assert.Empty(t, buf.String())
+}
+
+// TestResolve_AutoSelectionFiresForEachEntireSite: the three federations on the
+// allowlist, including the motivating case (active login on entire.io, cluster
+// on partial.to) and local dev on a port.
+//
+// Swaps the package-global writer, so no t.Parallel.
+func TestResolve_AutoSelectionFiresForEachEntireSite(t *testing.T) {
+	cases := []struct {
+		clusterHost, core, want string
+	}{
+		{"royalcanin.partial.to", "https://eu.auth.partial.to", "eu-staging"},
+		{"aws-eu-central-1.entire.io", "https://eu.auth.entire.io", "prod-eu"},
+		{"localhost:8080", "http://localhost:9000", "dev"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.clusterHost, func(t *testing.T) {
+			srv := httptest.NewServer(coresHandler(t, nil, tc.core))
+			defer srv.Close()
+
+			configDir := t.TempDir()
+			require.NoError(t, contexts.Save(configDir, &contexts.File{
+				CurrentContext: "au",
+				Contexts: []*contexts.Context{
+					{Name: "au", CoreURL: "https://au.auth.entire.io", Handle: "paul", KeychainService: "kc:au"},
+					{Name: "eu-staging", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:eu-staging"},
+					{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod-eu"},
+					{Name: "dev", CoreURL: "http://localhost:9000", Handle: "paul", KeychainService: "kc:dev"},
+				},
+			}))
+
+			buf := captureAutoSelectNotice(t)
+			c, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), tc.clusterHost, hostPinningClient(t, srv), t.Logf)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, c.Name)
+			assert.Equal(t, "Using context '"+tc.want+"'.\n", buf.String())
+		})
+	}
+}
+
+func TestAutoSelectAllowed(t *testing.T) {
+	t.Parallel()
+	for _, host := range []string{"aws-eu-central-1.entire.io", "royalcanin.partial.to", "localhost", "localhost:8080", "Entire.IO"} {
+		assert.True(t, autoSelectAllowed(host), host)
+	}
+	for _, host := range []string{"git.acme.com", "entire.io.evil.com", "127.0.0.1", "notentire.io", "partial.to.attacker.net"} {
+		assert.False(t, autoSelectAllowed(host), host)
 	}
 }

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -56,12 +56,11 @@ func TestResolve_ActiveContextWinsWhenEligible(t *testing.T) {
 	assert.Equal(t, "bob@eu", c.Name, "active eligible context must win over other same-core accounts")
 }
 
-// TestResolve_UnrelatedActiveContextErrorsNamingEligibleLogin: the active
-// context is on an unrelated core while exactly one saved context is eligible.
-// The old resolver silently used that sole eligible context; we now refuse to
-// substitute an identity the user didn't select, and name it instead so the
-// switch is one obvious command.
-func TestResolve_UnrelatedActiveContextErrorsNamingEligibleLogin(t *testing.T) {
+// TestResolve_UnrelatedActiveContextUsesSoleEligibleLogin: the active context is
+// on an unrelated core while exactly one saved context is eligible, so that one
+// is used. Someone holding logins in two federations can clone from either
+// without first retargeting every shell on the machine with `auth use`.
+func TestResolve_UnrelatedActiveContextUsesSoleEligibleLogin(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
 	defer srv.Close()
@@ -75,22 +74,15 @@ func TestResolve_UnrelatedActiveContextErrorsNamingEligibleLogin(t *testing.T) {
 		},
 	}))
 
-	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not accept your active login")
-	assert.Contains(t, err.Error(), `"paul@unrelated"`, "the message must name the active login, or the mismatch is invisible")
-	assert.Contains(t, err.Error(), "https://eu.auth.partial.to", "and the core it belongs to")
-	assert.Contains(t, err.Error(), "prod-eu", "and the saved login that would work")
-	assert.Contains(t, err.Error(), "entire auth use")
-	// A local switch is the fix here, so don't send the user through a login flow.
-	assert.NotContains(t, err.Error(), "entire login")
+	c, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c.Name, "the sole login the cluster trusts is the only possible answer")
 }
 
-// TestResolve_UnrelatedActiveContextNamesAllEligibleLogins: what used to be the
-// "ambiguous" case is now the same case as a single candidate — the resolver
-// never picks, so two eligible contexts are simply two names to offer. Sorted,
-// so the message is stable across saves.
-func TestResolve_UnrelatedActiveContextNamesAllEligibleLogins(t *testing.T) {
+// TestResolve_SeveralEligibleLoginsAreAmbiguous: auto-selection settles a single
+// candidate only. With two, picking one would make the acting identity depend on
+// what else happens to be stored, so the resolver names both, sorted, and stops.
+func TestResolve_SeveralEligibleLoginsAreAmbiguous(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(coresHandler(t, nil, "https://core-us.entire.io"))
 	defer srv.Close()
@@ -107,6 +99,7 @@ func TestResolve_UnrelatedActiveContextNamesAllEligibleLogins(t *testing.T) {
 
 	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "cluster1.entire.io", hostPinningClient(t, srv), t.Logf)
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple login contexts can authenticate against cluster cluster1.entire.io")
 	assert.Contains(t, err.Error(), "admin@core-us, alice@core-us", "candidates must be listed in sorted order")
 	assert.Contains(t, err.Error(), "entire auth use")
 }
@@ -243,10 +236,10 @@ func TestResolve_NoActiveContextReturnsLoginHint(t *testing.T) {
 	assert.NotContains(t, err.Error(), "does not accept your active login")
 }
 
-// TestResolve_DanglingCurrentContextIsNotAnIdentity: current_context naming a
-// context that no longer exists must not resolve to some other saved login. The
-// saved login is offered, not used.
-func TestResolve_DanglingCurrentContextIsNotAnIdentity(t *testing.T) {
+// TestResolve_DanglingCurrentContextFallsBackToSoleEligibleLogin: current_context
+// naming a context that no longer exists is not an identity, so selection falls
+// through to the sole saved login the cluster trusts rather than dead-ending.
+func TestResolve_DanglingCurrentContextFallsBackToSoleEligibleLogin(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
 	defer srv.Close()
@@ -259,10 +252,9 @@ func TestResolve_DanglingCurrentContextIsNotAnIdentity(t *testing.T) {
 		},
 	}))
 
-	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "prod-eu", "offer the eligible login")
-	assert.Contains(t, err.Error(), "entire auth use")
+	c, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c.Name)
 }
 
 // TestResolve_ContextWithoutCoreURLIsNeverEligible: a context carrying no
@@ -281,7 +273,7 @@ func TestResolve_ContextWithoutCoreURLIsNeverEligible(t *testing.T) {
 		CurrentContext: "blank",
 		Contexts:       []*contexts.Context{{Name: "blank", Handle: "paul", KeychainService: "kc:blank"}},
 	}
-	_, err := requireActiveContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{""}}, t.Logf)
+	_, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{""}}, t.Logf)
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "These saved logins can authenticate it",
 		"a context rejected by the accept check must not be offered as a candidate")
@@ -297,7 +289,7 @@ func TestResolve_EligibilityIgnoresWhitespaceAndTrailingSlash(t *testing.T) {
 		CurrentContext: "eu",
 		Contexts:       []*contexts.Context{{Name: "eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:eu"}},
 	}
-	c, err := requireActiveContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{" https://eu.auth.entire.io/ "}}, t.Logf)
+	c, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{" https://eu.auth.entire.io/ "}}, t.Logf)
 	require.NoError(t, err)
 	assert.Equal(t, "eu", c.Name)
 }
@@ -629,9 +621,13 @@ func TestResolve_ContextOverrideSelectsWithoutMutatingState(t *testing.T) {
 		"an override must not persist; that is what distinguishes it from `auth use`")
 }
 
-// TestResolve_IneligibleOverrideBlamesTheFlagNotTheStoredDefault: when the
-// explicitly named context isn't trusted, telling the user to run `auth use`
-// sends them to change the wrong thing — the flag would still override it.
+// TestResolve_IneligibleOverrideBlamesTheFlagNotTheStoredDefault: an explicitly
+// named context the resource rejects is a hard error, never a fall-through to
+// the sole eligible login — the user asked for that identity by name, so acting
+// as another behind their back is the failure the override exists to prevent.
+//
+// And telling them to run `auth use` sends them to change the wrong thing: the
+// flag would still override it on the next run.
 func TestResolve_IneligibleOverrideBlamesTheFlagNotTheStoredDefault(t *testing.T) {
 	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
 	defer srv.Close()
@@ -647,7 +643,7 @@ func TestResolve_IneligibleOverrideBlamesTheFlagNotTheStoredDefault(t *testing.T
 
 	contexts.SetFlagOverrideForTest(t, "staging")
 	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
-	require.Error(t, err)
+	require.Error(t, err, "prod-eu is the sole eligible login, and must still not be substituted")
 	assert.Contains(t, err.Error(), "the login selected by --context")
 	assert.Contains(t, err.Error(), "prod-eu", "offer the login that would work")
 	assert.Contains(t, err.Error(), "--context <context>")
@@ -684,9 +680,8 @@ func TestResolve_UnknownOverrideFailsBeforeEligibility(t *testing.T) {
 // git-remote-entire during `git push`, where a panic is the worst outcome
 // available.
 //
-// The failure path is the exposed one: eligibleContexts walks every stored entry
-// to build the candidate list, so the nil is reached even though no context can
-// possibly match.
+// eligibleContexts walks every stored entry to build the candidate list, so the
+// nil is reached both when nothing can match and when the real entry is picked.
 func TestResolve_NilStoredContextDoesNotPanic(t *testing.T) {
 	t.Parallel()
 	f := &contexts.File{
@@ -698,14 +693,14 @@ func TestResolve_NilStoredContextDoesNotPanic(t *testing.T) {
 	}
 
 	// Empty coreURLs is the case the old loop shape never dereferenced at all.
-	_, err := requireActiveContext(f, "cluster c.entire.io", loginTargets{}, t.Logf)
+	_, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{}, t.Logf)
 	require.Error(t, err)
 
 	// And with a matching core, the nil entry must be skipped while the real one
-	// is still offered.
-	_, err = requireActiveContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{"https://eu.auth.entire.io"}}, t.Logf)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "prod-eu", "the valid entry is still a candidate")
+	// is auto-selected.
+	c, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{"https://eu.auth.entire.io"}}, t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c.Name, "the valid entry is still the sole candidate")
 }
 
 // A nil entry must also not panic the selection itself, which resolves through
@@ -719,7 +714,7 @@ func TestResolve_NilStoredContextIsSelectable(t *testing.T) {
 			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
 		},
 	}
-	c, err := requireActiveContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{"https://eu.auth.entire.io"}}, t.Logf)
+	c, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{"https://eu.auth.entire.io"}}, t.Logf)
 	require.NoError(t, err)
 	assert.Equal(t, "prod-eu", c.Name)
 }

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -1,10 +1,13 @@
 package clusterdiscovery
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -717,4 +720,122 @@ func TestResolve_NilStoredContextIsSelectable(t *testing.T) {
 	c, err := selectLoginContext(f, "cluster c.entire.io", loginTargets{coreURLs: []string{"https://eu.auth.entire.io"}}, t.Logf)
 	require.NoError(t, err)
 	assert.Equal(t, "prod-eu", c.Name)
+}
+
+// captureAutoSelectNotice redirects the auto-selection notice into a buffer for
+// one test. Callers MUST NOT call t.Parallel: the writer is package-global.
+func captureAutoSelectNotice(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := autoSelectNoticeW
+	autoSelectNoticeW = &buf
+	t.Cleanup(func() { autoSelectNoticeW = prev })
+	return &buf
+}
+
+// TestResolve_AutoSelectionIsAnnounced: acting as a login the user did not
+// choose is exactly the surprise the tier was removed over, so it is never
+// silent. The identity the user did choose is not announced — that is the
+// expected case, and a line on every command would be noise.
+//
+// Swaps the package-global writer, so no t.Parallel.
+func TestResolve_AutoSelectionIsAnnounced(t *testing.T) {
+	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "paul@unrelated",
+		Contexts: []*contexts.Context{
+			{Name: "paul@unrelated", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:unrelated"},
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}))
+
+	buf := captureAutoSelectNotice(t)
+	c, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c.Name)
+	assert.Equal(t, "Using context 'prod-eu'.\n", buf.String())
+
+	// The stored default now fits, so nothing is auto-selected and nothing is said.
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod-eu",
+		Contexts: []*contexts.Context{
+			{Name: "paul@unrelated", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:unrelated"},
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}))
+	buf.Reset()
+	_, err = ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "the active context acting is not news")
+}
+
+// TestResolve_ExplicitSelectionIsNotAnnounced: the user named the identity on
+// this very command, so repeating it back is noise — and nothing was chosen for
+// them, which is the only thing the notice reports.
+//
+// Swaps the process-wide override and the package-global writer, so no t.Parallel.
+func TestResolve_ExplicitSelectionIsNotAnnounced(t *testing.T) {
+	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "paul@unrelated",
+		Contexts: []*contexts.Context{
+			{Name: "paul@unrelated", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:unrelated"},
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}))
+
+	buf := captureAutoSelectNotice(t)
+	contexts.SetFlagOverrideForTest(t, "prod-eu")
+	c, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c.Name)
+	assert.Empty(t, buf.String())
+}
+
+// TestResolve_NoNoticeOnFailure: an error already explains itself, and a
+// "Using context" line above one would name a login that never acted.
+//
+// Swaps the package-global writer, so no t.Parallel.
+func TestResolve_NoNoticeOnFailure(t *testing.T) {
+	srv := httptest.NewServer(coresHandler(t, nil, "https://core-us.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "paul@unrelated",
+		Contexts: []*contexts.Context{
+			{Name: "alice@core-us", CoreURL: "https://core-us.entire.io", Handle: "alice", KeychainService: "kc:alice"},
+			{Name: "admin@core-us", CoreURL: "https://core-us.entire.io", Handle: "admin", KeychainService: "kc:admin"},
+			{Name: "paul@unrelated", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:unrelated"},
+		},
+	}))
+
+	buf := captureAutoSelectNotice(t)
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "cluster1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	assert.Empty(t, buf.String())
+}
+
+// TestAutoSelectNoticeWriter_DefaultsToStderr: the notice must never reach
+// stdout, which carries the git remote-helper protocol inside
+// git-remote-entire. Changing the default to io.Discard would delete the
+// feature in production while the suite above stays green.
+//
+// Pinned by descriptor rather than pointer equality with os.Stderr: under
+// `go test -json` the testing package replaces the os.Stderr variable after
+// package init, so the value captured at init no longer compares equal even
+// though it is the process's real stderr. A buffer still fails this.
+//
+// Not parallel: reads the package-global writer that the tests above swap.
+func TestAutoSelectNoticeWriter_DefaultsToStderr(t *testing.T) {
+	f, ok := autoSelectNoticeW.(*os.File)
+	if !ok || f.Fd() != uintptr(syscall.Stderr) {
+		t.Fatalf("autoSelectNoticeW default = %T, want the process stderr", autoSelectNoticeW)
+	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1227
<!-- entire-trail-link-end -->

## Why

With two saved logins and the active one on the wrong federation, git against the other one dead-ended:

```
$ git clone entire://royalcanin.partial.to/et/dogfooding/canary
fatal: cluster royalcanin.partial.to does not accept your active login
```

...even though exactly one saved login could authenticate it, and the error said so. Partial revert of https://github.com/entireio/cli/pull/1982.

## What

Restores the two tiers under the active context: **sole eligible saved login → use it**; several eligible → ambiguity error naming them. It now says which one acted, on stderr:

```
Using context 'eu.auth.partial.to'.
```

`--context` / `$ENTIRE_CONTEXT` are untouched, and an explicit one the host rejects stays a hard error — you asked for that identity by name. Nothing else from https://github.com/entireio/cli/pull/1982 is reverted.

# Security

**The hole.** `git-remote-entire` sends your login JWT as the bearer to the cluster. Which saved login it sends is decided by the cluster's own `/.well-known/entire-cluster.json`: the `core_urls` list names the login servers it accepts. That is self-reported. A hostile host can advertise a login server it does not own:

```
$ git clone entire://anything.evil.com/x/y
# evil.com serves: {"core_urls": ["https://au.auth.entire.io"]}
```

...and the CLI hands evil.com a real `au.auth.entire.io` token. This predates this PR and applies to every selection tier — explicit `--context`, the active context, and `ENTIRE_TOKEN` — not just the restored auto-select. Auto-select widens the blast radius because the attacker no longer needs the victim's *active* login to be the one they name; any saved login will do.

**Mitigation 1 — same-domain gate (all tiers, all paths).** Every advertised login server must share the target host's registrable domain (eTLD+1 via `golang.org/x/net/publicsuffix`, so `evil.co.uk` cannot match `acme.co.uk`). `evil.com` may only nominate `*.evil.com`. A mismatch is a hard error naming both hosts, never a silent filter. Enforced where the discovery result is read, so it covers the git cluster path, the data-API path, `ENTIRE_TOKEN`, and a poisoned cache entry.

**Mitigation 2 — auto-select allowlist (auto-select tier only).** A saved login is auto-selected only when the target's registrable domain is one of `entire.io`, `partial.to`, `localhost`. Hardcoded. Anything else gets today's "switch with `entire auth use`" error. Explicit and active-context selection are not gated by this — a self-hosted cluster that passes mitigation 1 still works when you name the login.

**This allowlist is an interim solution.** We are not inventing an extensible trust mechanism until a self-hosted deployment needs auto-select. If and when that happens, it gets designed properly rather than bolted on here.

## Verification

`golangci-lint run ./...` clean; `mise run test:ci` green except `osroot.TestRootBasesAreTrusted`, which fails identically on `origin/main`. Output in comments below. Both live clusters were checked against the new rules by hand:

| cluster | `core_urls` eTLD+1 | same-domain gate | auto-select allowlist |
| --- | --- | --- | --- |
| `aws-ap-southeast-2.entire.io` | `entire.io` | pass | pass |
| `eukanuba.partial.to` | `partial.to` | pass | pass |
