### PR TITLE
Revert "Top-level 'entire clone' command"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,12 +111,9 @@ in stable releases, always runnable): `tokens`, `import`, `review`,
 
 Top-level lifecycle and standalone commands: `enable`, `disable`, `status`,
 `login`, `logout`, `clean`, `version`, `dispatch`, `activity`, `help`,
-`configure`, `agent-help`, `api`, `search`, `clone`. `search` is the canonical
+`configure`, `agent-help`, `api`, `search`. `search` is the canonical
 spelling (visible in every build, grouped with Sessions & Checkpoints);
-`checkpoint search` stays a working alias of the same command. `clone` is
-likewise the canonical top-level spelling (in its own Repositories group —
-it's a git content operation, deliberately out of the `repo` group's
-control-plane scope); `repo clone` stays a working alias of the same command.
+`checkpoint search` stays a working alias of the same command.
 
 `api` is an authenticated passthrough to Entire's HTTP APIs (gh-style): it
 attaches the right bearer and dials the right host so callers don't plumb auth

--- a/cmd/entire/cli/agent_help_cmd.go
+++ b/cmd/entire/cli/agent_help_cmd.go
@@ -164,7 +164,6 @@ var agentHelpClassification = map[string]agentHelpFacts{
 	"agent":       {agentHelpAudienceUserOwned, false},
 	"auth":        {agentHelpAudienceUserOwned, false},
 	"clean":       {agentHelpAudienceUserOwned, false},
-	"clone":       {agentHelpAudienceUserOwned, false},
 	"configure":   {agentHelpAudienceUserOwned, false},
 	"disable":     {agentHelpAudienceUserOwned, false},
 	"enable":      {agentHelpAudienceUserOwned, false},

--- a/cmd/entire/cli/entiredir_guard_test.go
+++ b/cmd/entire/cli/entiredir_guard_test.go
@@ -41,7 +41,6 @@ var entireDirCheckExemptions = map[string]string{
 	"entire org":        "control-plane only",
 	"entire project":    "control-plane only",
 	"entire repo":       "control-plane only; git content operations are out of scope",
-	"entire clone":      "clones into a new directory; runs outside any repo",
 	"entire grant":      "control-plane only",
 	"entire api":        "authenticated passthrough; no local state",
 	"entire plugin":     "managed installs live under the per-user dirs",

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -183,12 +183,12 @@ func newRepoCloneCmd() *cobra.Command {
 			"A full `entire://` URL already names the cluster, so it's passed straight " +
 			"through to `git clone` with no lookup (and --cluster is ignored). The " +
 			"optional [target-dir] is passed through to `git clone` either way.",
-		Example: "  entire clone /et/project/example\n" +
-			"  entire clone project/example\n" +
-			"  entire clone /gh/entirehq/entire-api\n" +
-			"  entire clone /gh/entirehq/entire-api ./entire-api\n" +
-			"  entire clone /gh/entirehq/entire-api --cluster aws-us-east-2.entire.io\n" +
-			"  entire clone entire://aws-us-east-2.entire.io/gh/entirehq/entire-api",
+		Example: "  entire repo clone /et/project/example\n" +
+			"  entire repo clone project/example\n" +
+			"  entire repo clone /gh/entirehq/entire-api\n" +
+			"  entire repo clone /gh/entirehq/entire-api ./entire-api\n" +
+			"  entire repo clone /gh/entirehq/entire-api --cluster aws-us-east-2.entire.io\n" +
+			"  entire repo clone entire://aws-us-east-2.entire.io/gh/entirehq/entire-api",
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
@@ -293,13 +293,6 @@ func newRepoCloneCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&cluster, "cluster", "", "Cluster host to clone from when the repo is mirrored on more than one (may belong to another auth context)")
-	return cmd
-}
-
-// `repo clone`, registered at root.
-func newTopLevelCloneCmd() *cobra.Command {
-	cmd := newRepoCloneCmd()
-	addControlPlaneFlags(cmd)
 	return cmd
 }
 

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -40,7 +40,6 @@ Environment Variables:
 const (
 	groupSetup        = "setup"
 	groupSessions     = "sessions"
-	groupRepos        = "repositories"
 	groupAccount      = "account"
 	groupControlPlane = "controlplane"
 )
@@ -162,7 +161,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddGroup(
 		&cobra.Group{ID: groupSetup, Title: "Entire Setup:"},
 		&cobra.Group{ID: groupSessions, Title: "Sessions & Checkpoints:"},
-		&cobra.Group{ID: groupRepos, Title: "Repositories:"},
 		&cobra.Group{ID: groupAccount, Title: "Account:"},
 		&cobra.Group{ID: groupControlPlane, Title: "Control Plane:"},
 	)
@@ -198,10 +196,9 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(inGroup(newDispatchCmd(), groupSessions))
 	cmd.AddCommand(inGroup(newActivityCmd(), groupSessions))
 	cmd.AddCommand(inGroup(newRecapCmd(), groupSessions))
-	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newAPICmd(), groupControlPlane)))    // authenticated passthrough to core/cell APIs
-	cmd.AddCommand(newAgentHelpCmd(cmd))                                                 // visible: agents on transports without context injection discover it via `entire help`
-	cmd.AddCommand(inGroup(newSearchCmd(), groupSessions))                               // 'search' — canonical top-level spelling; 'checkpoint search' stays a working alias
-	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newTopLevelCloneCmd(), groupRepos))) // 'clone' — canonical top-level spelling; 'repo clone' stays a working alias
+	cmd.AddCommand(exemptFromEntireDirCheck(inGroup(newAPICmd(), groupControlPlane))) // authenticated passthrough to core/cell APIs
+	cmd.AddCommand(newAgentHelpCmd(cmd))                                              // visible: agents on transports without context injection discover it via `entire help`
+	cmd.AddCommand(inGroup(newSearchCmd(), groupSessions))                            // 'search' — canonical top-level spelling; 'checkpoint search' stays a working alias
 
 	// Experimental labs commands (listed via `entire labs`; not deprecation shortcuts).
 	experimental.Register(cmd, newExpertsCmd()) // 'experts' (experimental); agent/workflow provenance

--- a/cmd/entire/cli/root_test.go
+++ b/cmd/entire/cli/root_test.go
@@ -300,7 +300,6 @@ func TestRoot_VisibleCommandsAreGrouped(t *testing.T) {
 		"org":        groupControlPlane,
 		"project":    groupControlPlane,
 		"repo":       groupControlPlane,
-		"clone":      groupRepos,
 		"grant":      groupControlPlane,
 		"api":        groupControlPlane,
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1228
<!-- entire-trail-link-end -->

Reverts entireio/cli#2208

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI and help text only; clone behavior stays on `entire repo clone` with no auth or data-path changes.
> 
> **Overview**
> Reverts the top-level **`entire clone`** entry point so cloning is only exposed as **`entire repo clone`** again (undoing the prior promotion in #2208).
> 
> **CLI surface:** Unregisters the root `clone` command and drops the **Repositories** help group from `root.go`. **`repo_clone.go`** examples now show `entire repo clone …` and **`newTopLevelCloneCmd`** is removed.
> 
> **Docs & agent/help:** **`CLAUDE.md`** no longer lists `clone` among top-level commands or describes canonical `entire clone` vs `repo clone`. **`agent_help_cmd.go`** drops the `clone` classification entry.
> 
> **Tests:** **`root_test.go`** no longer expects a grouped top-level `clone`; **`entiredir_guard_test.go`** removes the `entire clone` `.entire` check exemption (clone is no longer a separate root command).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5d7d6ba32dc507e03e5b6ddd8e4de990929763a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->