### PR TITLE
fix(checkpoints): trust only final trailer blocks for mutations

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -649,7 +649,7 @@ func suggestFetchCommand(ctx context.Context, refspec string) string {
 }
 
 func resolveCheckpointID(ctx context.Context, headCommit *object.Commit) (id.CheckpointID, bool) {
-	existing := trailers.ParseAllCheckpoints(headCommit.Message)
+	existing := trailers.ParseAllCheckpointsFromFinalTrailerBlock(headCommit.Message)
 	if len(existing) > 0 {
 		return existing[len(existing)-1], true
 	}
@@ -934,7 +934,7 @@ func promptAmendCommit(ctx context.Context, w io.Writer, headCommit *object.Comm
 	subject := strings.SplitN(headCommit.Message, "\n", 2)[0]
 
 	// Skip amending if this exact checkpoint ID is already in the commit.
-	for _, existing := range trailers.ParseAllCheckpoints(headCommit.Message) {
+	for _, existing := range trailers.ParseAllCheckpointsFromFinalTrailerBlock(headCommit.Message) {
 		if existing.String() == checkpointIDStr {
 			fmt.Fprintf(w, "Commit %s already has Entire-Checkpoint: %s\n", shortHash, checkpointIDStr)
 			return nil

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAttach_MissingSessionID(t *testing.T) {
@@ -2019,34 +2019,66 @@ func TestAttach_NonInteractivePrintsTrailerForManualPaste(t *testing.T) {
 }
 
 func TestAttachIgnoresCheckpointShapedBodyText(t *testing.T) {
-	t.Parallel()
+	testAttachDoesNotReuseUnauthorizedCheckpoint(t,
+		"Subject\n\nEntire-Checkpoint: a1b2c3d4e5f6\n\nSigned-off-by: Test User <test@example.com>\n")
+}
 
-	forgedID := "a1b2c3d4e5f6"
-	headCommit := &object.Commit{
-		Hash:    plumbing.NewHash("0123456789abcdef0123456789abcdef01234567"),
-		Message: "Subject\n\nEntire-Checkpoint: " + forgedID + "\n\nSigned-off-by: Test User <test@example.com>\n",
-	}
+func TestAttachIgnoresIndentedCheckpoint(t *testing.T) {
+	testAttachDoesNotReuseUnauthorizedCheckpoint(t,
+		"Subject\n\n  Entire-Checkpoint: a1b2c3d4e5f6\n")
+}
 
-	cpID, reused := resolveCheckpointID(context.Background(), headCommit)
-	t.Logf("message=%q resolved checkpoint=%v reused=%v", headCommit.Message, cpID, reused)
-	if reused {
-		t.Fatal("resolveCheckpointID() reused checkpoint-shaped body text")
-	}
-	if cpID.IsEmpty() || cpID.String() == forgedID {
-		t.Fatalf("resolveCheckpointID() = %v, want a newly generated checkpoint", cpID)
-	}
+func testAttachDoesNotReuseUnauthorizedCheckpoint(t *testing.T, commitMessage string) {
+	t.Helper()
+	setupAttachTestRepo(t)
+	ctx := context.Background()
+	const forgedID = "a1b2c3d4e5f6"
+	forgedCheckpointID := id.MustCheckpointID(forgedID)
+
+	repo, err := git.PlainOpen(mustGetwd(t))
+	require.NoError(t, err)
+	store := cpkg.NewGitStore(repo, cpkg.DefaultV1Refs())
+	require.NoError(t, store.Write(ctx, cpkg.Session{
+		CheckpointID: forgedCheckpointID,
+		SessionID:    "unrelated-session",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("unrelated transcript\n")),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+	}))
+
+	repoDir := mustGetwd(t)
+	testutil.WriteFile(t, repoDir, "forged.txt", "forged")
+	testutil.GitAdd(t, repoDir, "forged.txt")
+	testutil.GitCommit(t, repoDir, commitMessage)
+
+	const attachedSessionID = "test-attach-unauthorized-checkpoint"
+	setupClaudeTranscript(t, attachedSessionID, `{"type":"user","message":{"role":"user","content":"hello"},"uuid":"u1"}
+{"type":"assistant","message":{"role":"assistant","content":"hi"},"uuid":"a1"}
+`)
 
 	var out bytes.Buffer
-	if err := promptAmendCommit(context.Background(), &out, headCommit, forgedID, false); err != nil {
-		t.Fatalf("promptAmendCommit() error = %v", err)
-	}
-	t.Logf("prompt output=%q", out.String())
-	if strings.Contains(out.String(), "already has Entire-Checkpoint") {
-		t.Fatalf("promptAmendCommit() treated body text as an existing trailer:\n%s", out.String())
-	}
-	if !strings.Contains(out.String(), "Copy to your commit message to attach") {
-		t.Fatalf("promptAmendCommit() output = %q, want manual attach instructions", out.String())
-	}
+	require.NoError(t, runAttach(ctx, &out, &out, attachedSessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}))
+
+	stateStore, err := session.NewStateStore(ctx)
+	require.NoError(t, err)
+	state, err := stateStore.Load(ctx, attachedSessionID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.NotEqual(t, forgedCheckpointID, state.LastCheckpointID,
+		"unauthorized checkpoint text must not select the write target")
+
+	forgedSummary, err := store.Read(ctx, forgedCheckpointID)
+	require.NoError(t, err)
+	require.NotNil(t, forgedSummary)
+	require.Len(t, forgedSummary.Sessions, 1)
+	forgedContent, err := store.ReadSessionContent(ctx, forgedCheckpointID, 0)
+	require.NoError(t, err)
+	require.Equal(t, "unrelated-session", forgedContent.Metadata.SessionID)
+
+	attachedContent, err := store.ReadSessionContent(ctx, state.LastCheckpointID, 0)
+	require.NoError(t, err)
+	require.Equal(t, attachedSessionID, attachedContent.Metadata.SessionID)
 }
 
 // setupAttachTestRepo creates a temp git repo with one commit and enables Entire.

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
 func TestAttach_MissingSessionID(t *testing.T) {
@@ -2014,6 +2015,37 @@ func TestAttach_NonInteractivePrintsTrailerForManualPaste(t *testing.T) {
 	re := regexp.MustCompile(`Entire-Checkpoint: ` + id.CheckpointPattern)
 	if !re.MatchString(out.String()) {
 		t.Errorf("expected Entire-Checkpoint trailer for manual paste, got:\n%s", out.String())
+	}
+}
+
+func TestAttachIgnoresCheckpointShapedBodyText(t *testing.T) {
+	t.Parallel()
+
+	forgedID := "a1b2c3d4e5f6"
+	headCommit := &object.Commit{
+		Hash:    plumbing.NewHash("0123456789abcdef0123456789abcdef01234567"),
+		Message: "Subject\n\nEntire-Checkpoint: " + forgedID + "\n\nSigned-off-by: Test User <test@example.com>\n",
+	}
+
+	cpID, reused := resolveCheckpointID(context.Background(), headCommit)
+	t.Logf("message=%q resolved checkpoint=%v reused=%v", headCommit.Message, cpID, reused)
+	if reused {
+		t.Fatal("resolveCheckpointID() reused checkpoint-shaped body text")
+	}
+	if cpID.IsEmpty() || cpID.String() == forgedID {
+		t.Fatalf("resolveCheckpointID() = %v, want a newly generated checkpoint", cpID)
+	}
+
+	var out bytes.Buffer
+	if err := promptAmendCommit(context.Background(), &out, headCommit, forgedID, false); err != nil {
+		t.Fatalf("promptAmendCommit() error = %v", err)
+	}
+	t.Logf("prompt output=%q", out.String())
+	if strings.Contains(out.String(), "already has Entire-Checkpoint") {
+		t.Fatalf("promptAmendCommit() treated body text as an existing trailer:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Copy to your commit message to attach") {
+		t.Fatalf("promptAmendCommit() output = %q, want manual attach instructions", out.String())
 	}
 }
 

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -614,7 +614,7 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 	if commitErr != nil {
 		return fmt.Errorf("failed to get commit %s: %w", abbreviateCommitHash(lookup.repo, hash), commitErr)
 	}
-	cpID, hasCheckpoint := trailers.ParseCheckpoint(commit.Message)
+	cpID, hasCheckpoint := parseCheckpointForExplainCommit(commit.Message, generate)
 	if !hasCheckpoint {
 		// Side-effect modes must error — silently succeeding would leave
 		// scripts unable to distinguish "done" from "didn't happen".
@@ -2990,8 +2990,10 @@ func runExplainCommit(ctx context.Context, w, errW io.Writer, commitRef string, 
 		return fmt.Errorf("failed to get commit: %w", err)
 	}
 
-	// Extract Entire-Checkpoint trailer
-	checkpointID, hasCheckpoint := trailers.ParseCheckpoint(commit.Message)
+	// Generating a summary mutates checkpoint storage, so it requires an
+	// authorizing trailer in Git's final trailer block. Read-only explanation
+	// keeps whole-message discovery for squash-merge history.
+	checkpointID, hasCheckpoint := parseCheckpointForExplainCommit(commit.Message, generate)
 	if !hasCheckpoint {
 		// Side-effect modes must error so scripts can distinguish "done"
 		// from "didn't happen"; read-only modes print a friendly message.
@@ -3005,6 +3007,13 @@ func runExplainCommit(ctx context.Context, w, errW io.Writer, commitRef string, 
 	// Delegate to checkpoint detail view, forwarding the full flag set so
 	// --generate / --raw-transcript / --force work via --commit as well.
 	return runExplainCheckpoint(ctx, w, errW, checkpointID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll, summaryTimeoutSeconds)
+}
+
+func parseCheckpointForExplainCommit(message string, generate bool) (id.CheckpointID, bool) {
+	if generate {
+		return trailers.ParseCheckpointFromFinalTrailerBlock(message)
+	}
+	return trailers.ParseCheckpoint(message)
 }
 
 // pagerLookupEnv is overridable for tests so pager env-gate behavior can be

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -442,6 +442,62 @@ func TestRunExplainAuto_CommitRefWithCheckpointTrailer(t *testing.T) {
 	require.Contains(t, out.String(), cpID.String(), "expected checkpoint header resolved via trailer")
 }
 
+func TestExplainGenerateRejectsCheckpointShapedCommitBody(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	repoDir := wt.Filesystem().Root()
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "forged.txt"), []byte("forged"), 0o644))
+	_, err = wt.Add("forged.txt")
+	require.NoError(t, err)
+	commitHash, err := wt.Commit(
+		"Implement feature\n\nEntire-Checkpoint: deadbeefcafe\n\nSigned-off-by: Test User <test@example.com>\n",
+		&git.CommitOptions{Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()}},
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		run  func(io.Writer, io.Writer) error
+	}{
+		{
+			name: "explicit commit flag",
+			run: func(out, errOut io.Writer) error {
+				return runExplainCommit(context.Background(), out, errOut, commitHash.String(), true, false, false, false, true, true, false, 0)
+			},
+		},
+		{
+			name: "positional commit fallback",
+			run: func(out, errOut io.Writer) error {
+				return runExplainAuto(context.Background(), out, errOut, commitHash.String(), true, false, false, false, true, true, false, 0)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			err := tt.run(&out, &errOut)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "has no Entire-Checkpoint trailer")
+			require.NotContains(t, err.Error(), "deadbeefcafe",
+				"a body-selected checkpoint must not reach the summary write path")
+		})
+	}
+}
+
+func TestParseCheckpointForExplainCommitPreservesReadOnlyDiscovery(t *testing.T) {
+	t.Parallel()
+	message := "Subject\n\nEntire-Checkpoint: deadbeefcafe\n\nSigned-off-by: Test User <test@example.com>\n"
+
+	cpID, found := parseCheckpointForExplainCommit(message, false)
+	require.True(t, found)
+	require.Equal(t, "deadbeefcafe", cpID.String())
+
+	_, found = parseCheckpointForExplainCommit(message, true)
+	require.False(t, found, "summary generation requires final-block authority")
+}
+
 // TestRunExplainAuto_CommitWithoutTrailer covers the trailer-less commit
 // dispatch: read-only modes print a friendly message and exit 0, while
 // --generate / --raw-transcript must error so scripts can distinguish

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -148,8 +148,7 @@ func (s *ManualCommitStrategy) CommitMsg(_ context.Context, commitMsgFile string
 
 	message := string(content)
 
-	// Check if our trailer is present (ParseCheckpoint validates format, so found==true means valid)
-	if _, found := trailers.ParseCheckpoint(message); !found {
+	if _, found := parseCheckpointFromCommitMessageFile(message); !found {
 		// No trailer, nothing to do
 		return nil
 	}
@@ -286,6 +285,19 @@ func stripCheckpointTrailer(message string) string {
 		}
 	}
 	return strings.Join(result, "\n")
+}
+
+func parseCheckpointFromCommitMessageFile(message string) (id.CheckpointID, bool) {
+	lines := strings.Split(strings.TrimRight(message, "\n"), "\n")
+	i := len(lines) - 1
+	for i >= 0 {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			break
+		}
+		i--
+	}
+	return trailers.ParseCheckpointFromFinalTrailerBlock(strings.Join(lines[:i+1], "\n"))
 }
 
 // isGitSequenceOperation checks if git is currently in the middle of a rebase,
@@ -432,8 +444,7 @@ func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFi
 
 	message := string(content)
 
-	// Check if trailer already exists (ParseCheckpoint validates format, so found==true means valid)
-	if existingCpID, found := trailers.ParseCheckpoint(message); found {
+	if existingCpID, found := parseCheckpointFromCommitMessageFile(message); found {
 		readCommitMessageSpan.End()
 		// Trailer already exists (e.g., amend) - keep it
 		logging.Debug(logCtx, "prepare-commit-msg: trailer already exists",
@@ -550,7 +561,7 @@ func (s *ManualCommitStrategy) handleAmendCommitMsg(ctx context.Context, commitM
 	message := string(content)
 
 	// If message already has a trailer, keep it unchanged
-	if existingCpID, found := trailers.ParseCheckpoint(message); found {
+	if existingCpID, found := parseCheckpointFromCommitMessageFile(message); found {
 		logging.Debug(logCtx, "prepare-commit-msg: amend preserves existing trailer",
 			slog.String("strategy", "manual-commit"),
 			slog.String("checkpoint_id", existingCpID.String()),
@@ -932,8 +943,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 		return nil
 	}
 
-	// Check if commit has checkpoint trailer (ParseCheckpoint validates format)
-	checkpointID, found := trailers.ParseCheckpoint(commit.Message)
+	checkpointID, found := trailers.ParseCheckpointFromFinalTrailerBlock(commit.Message)
 	openRepoSpan.End()
 
 	if !found {
@@ -2393,7 +2403,7 @@ func (s *ManualCommitStrategy) addTrailerForAgentCommit(logCtx context.Context, 
 	message := string(content)
 
 	// Don't add if trailer already exists
-	if _, found := trailers.ParseCheckpoint(message); found {
+	if _, found := parseCheckpointFromCommitMessageFile(message); found {
 		return nil
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -47,6 +47,8 @@ import (
 // ttyResult represents the outcome of a TTY confirmation prompt.
 type ttyResult int
 
+const commitMessageSourceMessage = "message"
+
 const (
 	ttyResultLink       ttyResult = iota // Link: add the checkpoint trailer
 	ttyResultSkip                        // Skip: don't add the trailer
@@ -140,21 +142,26 @@ func saveCommitLinkingAlways(ctx context.Context) error {
 // If the message contains only our trailer (no actual user content), strip it
 // so git will abort the commit due to empty message.
 
-func (s *ManualCommitStrategy) CommitMsg(_ context.Context, commitMsgFile string) error { //nolint:unparam // error return is part of the hook contract; callers check it
+func (s *ManualCommitStrategy) CommitMsg(ctx context.Context, commitMsgFile string) error { //nolint:unparam // hook interface requires an error result
 	content, err := os.ReadFile(commitMsgFile) //nolint:gosec // Path comes from git hook
 	if err != nil {
 		return nil //nolint:nilerr // Hook must be silent on failure
 	}
 
 	message := string(content)
+	messageForValidation := message
+	commentPrefix := gitCommentPrefix(ctx, message)
+	if strings.Contains(message, commentPrefix+" Remove the Entire-Checkpoint trailer above") {
+		messageForValidation = stripGitCommentLines(message, commentPrefix)
+	}
 
-	if _, found := parseCheckpointFromCommitMessageFile(message); !found {
+	if _, found := trailers.ParseCheckpointFromFinalTrailerBlock(messageForValidation); !found {
 		// No trailer, nothing to do
 		return nil
 	}
 
 	// Check if there's any user content (non-comment, non-trailer lines)
-	if !hasUserContent(message) {
+	if !hasUserContent(messageForValidation) {
 		// No user content - strip the trailer so git aborts
 		message = stripCheckpointTrailer(message)
 		if err := os.WriteFile(commitMsgFile, []byte(message), 0o600); err != nil {
@@ -287,17 +294,60 @@ func stripCheckpointTrailer(message string) string {
 	return strings.Join(result, "\n")
 }
 
-func parseCheckpointFromCommitMessageFile(message string) (id.CheckpointID, bool) {
-	lines := strings.Split(strings.TrimRight(message, "\n"), "\n")
-	i := len(lines) - 1
-	for i >= 0 {
-		trimmed := strings.TrimSpace(lines[i])
-		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
-			break
-		}
-		i--
+func parseCheckpointFromCommitMessageFile(ctx context.Context, message, source string) (id.CheckpointID, bool) {
+	if source != commitMessageSourceMessage {
+		message = cleanPreparedCommitMessage(message, source, gitCommentPrefix(ctx, message))
 	}
-	return trailers.ParseCheckpointFromFinalTrailerBlock(strings.Join(lines[:i+1], "\n"))
+	return trailers.ParseCheckpointFromFinalTrailerBlock(message)
+}
+
+func cleanPreparedCommitMessage(message, source, commentPrefix string) string {
+	if source == commitMessageSourceMessage {
+		return message
+	}
+	return stripGitCommentLines(message, commentPrefix)
+}
+
+func stripGitCommentLines(message, commentPrefix string) string {
+	if commentPrefix == "" {
+		return message
+	}
+	lines := strings.Split(message, "\n")
+	kept := lines[:0]
+	for _, line := range lines {
+		if !strings.HasPrefix(line, commentPrefix) {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+func gitCommentPrefix(ctx context.Context, message string) string {
+	prefix := gitConfigValue(ctx, "core.commentString")
+	if prefix == "" {
+		prefix = gitConfigValue(ctx, "core.commentChar")
+	}
+	if prefix == "" {
+		prefix = "#"
+	}
+	if prefix != "auto" {
+		return prefix
+	}
+
+	for _, candidate := range "#;@!$%^&|:" {
+		candidatePrefix := string(candidate)
+		available := true
+		for _, line := range strings.Split(message, "\n") {
+			if strings.HasPrefix(line, candidatePrefix) {
+				available = false
+				break
+			}
+		}
+		if available {
+			return candidatePrefix
+		}
+	}
+	return "#"
 }
 
 // isGitSequenceOperation checks if git is currently in the middle of a rebase,
@@ -444,7 +494,7 @@ func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFi
 
 	message := string(content)
 
-	if existingCpID, found := parseCheckpointFromCommitMessageFile(message); found {
+	if existingCpID, found := parseCheckpointFromCommitMessageFile(ctx, message, source); found {
 		readCommitMessageSpan.End()
 		// Trailer already exists (e.g., amend) - keep it
 		logging.Debug(logCtx, "prepare-commit-msg: trailer already exists",
@@ -490,7 +540,7 @@ func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFi
 	// NOTE: TTY confirmation (askConfirmTTY) is intentionally NOT wrapped in a span
 	// because it blocks on user input and would skew timing.
 	switch source {
-	case "message":
+	case commitMessageSourceMessage:
 		// Using -m or -F: behavior depends on TTY availability and commit_linking setting
 		switch {
 		case !interactive.CanPromptInteractively():
@@ -527,7 +577,7 @@ func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFi
 		}
 	default:
 		// Normal editor flow: add trailer with explanatory comment (will be stripped by git)
-		message = addCheckpointTrailerWithComment(message, checkpointID, string(agentType), displayPrompt)
+		message = addCheckpointTrailerWithComment(message, checkpointID, string(agentType), displayPrompt, gitCommentPrefix(ctx, message))
 	}
 
 	logging.Info(logCtx, "prepare-commit-msg: trailer added",
@@ -559,9 +609,14 @@ func (s *ManualCommitStrategy) handleAmendCommitMsg(ctx context.Context, commitM
 	}
 
 	message := string(content)
+	repo, repoErr := OpenRepository(ctx)
+	if repoErr != nil {
+		return nil
+	}
+	defer repo.Close()
 
 	// If message already has a trailer, keep it unchanged
-	if existingCpID, found := parseCheckpointFromCommitMessageFile(message); found {
+	if existingCpID, found := parseCheckpointFromCommitMessageFile(ctx, message, "commit"); found {
 		logging.Debug(logCtx, "prepare-commit-msg: amend preserves existing trailer",
 			slog.String("strategy", "manual-commit"),
 			slog.String("checkpoint_id", existingCpID.String()),
@@ -584,11 +639,6 @@ func (s *ManualCommitStrategy) handleAmendCommitMsg(ctx context.Context, commitM
 	// We need to match sessions whose BaseCommit equals HEAD (the commit being amended
 	// was created from this base). This prevents stale sessions from injecting
 	// unrelated checkpoint IDs.
-	repo, repoErr := OpenRepository(ctx)
-	if repoErr != nil {
-		return nil
-	}
-	defer repo.Close()
 	head, headErr := repo.Head()
 	if headErr != nil {
 		return nil
@@ -2403,7 +2453,7 @@ func (s *ManualCommitStrategy) addTrailerForAgentCommit(logCtx context.Context, 
 	message := string(content)
 
 	// Don't add if trailer already exists
-	if _, found := parseCheckpointFromCommitMessageFile(message); found {
+	if _, found := parseCheckpointFromCommitMessageFile(logCtx, message, source); found {
 		return nil
 	}
 
@@ -2445,23 +2495,23 @@ func addCheckpointTrailer(message string, checkpointID id.CheckpointID) string {
 // The trailer is placed above the git comment block but below the user's message area,
 // with a comment explaining that the user can remove it if they don't want to link the commit
 // to the agent session. If prompt is non-empty, it's shown as context.
-func addCheckpointTrailerWithComment(message string, checkpointID id.CheckpointID, agentName, prompt string) string {
+func addCheckpointTrailerWithComment(message string, checkpointID id.CheckpointID, agentName, prompt, commentPrefix string) string {
 	trailer := trailers.CheckpointTrailerKey + ": " + checkpointID.String()
 	commentLines := []string{
-		"# Remove the Entire-Checkpoint trailer above if you don't want to link this commit to " + agentName + " session context.",
+		commentPrefix + " Remove the Entire-Checkpoint trailer above if you don't want to link this commit to " + agentName + " session context.",
 	}
 	if prompt != "" {
-		commentLines = append(commentLines, "# Last Prompt: "+prompt)
+		commentLines = append(commentLines, commentPrefix+" Last Prompt: "+prompt)
 	}
-	commentLines = append(commentLines, "# The trailer will be added to your next commit based on this branch.")
+	commentLines = append(commentLines, commentPrefix+" The trailer will be added to your next commit based on this branch.")
 	comment := strings.Join(commentLines, "\n")
 
 	lines := strings.Split(message, "\n")
 
-	// Find where the git comment block starts (first # line)
+	// Find where the git comment block starts.
 	commentStart := -1
 	for i, line := range lines {
-		if strings.HasPrefix(line, "#") {
+		if strings.HasPrefix(line, commentPrefix) {
 			commentStart = i
 			break
 		}

--- a/cmd/entire/cli/strategy/manual_commit_migration.go
+++ b/cmd/entire/cli/strategy/manual_commit_migration.go
@@ -56,8 +56,8 @@ func (s *ManualCommitStrategy) migrateShadowBranchIfNeeded(ctx context.Context, 
 	// Cherry-picking a checkpoint commit creates a new SHA with the same
 	// message; firing reconcile in that case would drop the pinned
 	// AttributionBaseCommit and corrupt attribution for uncondensed work.
-	// Legacy state files without LastCheckpointCommitHash fall back to
-	// trailer-only matching for backward compatibility.
+	// Legacy state files without LastCheckpointCommitHash require the same
+	// final-block evidence as every other mutation path.
 	if !state.LastCheckpointID.IsEmpty() {
 		shaMismatch := state.LastCheckpointCommitHash != "" && state.LastCheckpointCommitHash != currentHead
 		if shaMismatch {
@@ -69,7 +69,7 @@ func (s *ManualCommitStrategy) migrateShadowBranchIfNeeded(ctx context.Context, 
 		} else {
 			headCommit, commitErr := repo.CommitObject(head.Hash())
 			if commitErr == nil {
-				for _, cpID := range trailers.ParseAllCheckpoints(headCommit.Message) {
+				for _, cpID := range trailers.ParseAllCheckpointsFromFinalTrailerBlock(headCommit.Message) {
 					if cpID.String() == state.LastCheckpointID.String() {
 						state.BaseCommit = currentHead
 						state.RealignAttributionBase(currentHead)

--- a/cmd/entire/cli/strategy/manual_commit_migration_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_migration_test.go
@@ -209,6 +209,35 @@ func TestMigrateShadowBranch_DifferentTrailerFromSameSession(t *testing.T) {
 	assert.Equal(t, initHash, state.AttributionBaseCommit, "AttributionBaseCommit should stay pinned (migrate, not reconcile)")
 }
 
+func TestMigrateShadowBranch_LegacyStateDoesNotReconcileBodyCheckpoint(t *testing.T) {
+	dir, initHash := setupMigrationRepo(t)
+	t.Chdir(dir)
+
+	cpID := checkpointID.MustCheckpointID("abc123def456")
+	testutil.WriteFile(t, dir, "file.txt", "content")
+	testutil.GitAdd(t, dir, "file.txt")
+	testutil.GitCommit(t, dir, "squash message\n\nEntire-Checkpoint: abc123def456\n\nBody continues.\n\nEntire-Checkpoint: 111111222222")
+	headHash := testutil.GetHeadHash(t, dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	state := &SessionState{
+		SessionID:             "legacy-session",
+		BaseCommit:            initHash,
+		AttributionBaseCommit: initHash,
+		LastCheckpointID:      cpID,
+		// Legacy state deliberately has no LastCheckpointCommitHash.
+	}
+
+	changed, reconciled, err := (&ManualCommitStrategy{}).migrateShadowBranchIfNeeded(context.Background(), repo, state)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.False(t, reconciled)
+	require.Equal(t, headHash, state.BaseCommit)
+	require.Equal(t, initHash, state.AttributionBaseCommit,
+		"checkpoint-shaped body text must not authorize attribution realignment")
+}
+
 // TestMigrateShadowBranch_EmptyLastCheckpointID verifies that when the session
 // has never been condensed (LastCheckpointID is empty), the reconcile guard is
 // skipped and the migrate path fires.

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -819,7 +819,7 @@ func TestAddCheckpointTrailerWithComment_HasComment(t *testing.T) {
 	// Test that addCheckpointTrailerWithComment includes the explanatory comment
 	message := "Test commit message\n"
 
-	result := addCheckpointTrailerWithComment(message, testTrailerCheckpointID, "Claude Code", "add password hashing")
+	result := addCheckpointTrailerWithComment(message, testTrailerCheckpointID, "Claude Code", "add password hashing", "#")
 
 	// Should contain the trailer
 	if !strings.Contains(result, trailers.CheckpointTrailerKey+": "+testTrailerCheckpointID.String()) {
@@ -851,7 +851,7 @@ func TestAddCheckpointTrailerWithComment_NoPrompt(t *testing.T) {
 	// Test that addCheckpointTrailerWithComment works without a prompt
 	message := "Test commit message\n"
 
-	result := addCheckpointTrailerWithComment(message, testTrailerCheckpointID, "Claude Code", "")
+	result := addCheckpointTrailerWithComment(message, testTrailerCheckpointID, "Claude Code", "", "#")
 
 	// Should contain the trailer
 	if !strings.Contains(result, trailers.CheckpointTrailerKey+": "+testTrailerCheckpointID.String()) {
@@ -869,17 +869,74 @@ func TestAddCheckpointTrailerWithComment_NoPrompt(t *testing.T) {
 	}
 }
 
-func TestParseCheckpointFromCommitMessageFileSkipsTrailingComments(t *testing.T) {
+func TestGitCommentPrefixUsesEffectiveRepositoryConfig(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+	testutil.RunGit(t, dir, "config", "core.commentChar", ";")
+	require.Equal(t, ";", gitCommentPrefix(context.Background(), "Message\n"))
+	cpID, found := parseCheckpointFromCommitMessageFile(context.Background(),
+		"Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\n; git status\n", "")
+	require.True(t, found)
+	require.Equal(t, "a1b2c3d4e5f6", cpID.String())
+
+	testutil.RunGit(t, dir, "config", "core.commentString", "//")
+	require.Equal(t, "//", gitCommentPrefix(context.Background(), "Message\n"),
+		"core.commentString takes precedence over core.commentChar")
+
+	result := addCheckpointTrailerWithComment("Message\n// git status\n", testTrailerCheckpointID, "Claude Code", "", "//")
+	require.Contains(t, result, "// Remove the Entire-Checkpoint")
+	require.NotContains(t, result, "# Remove the Entire-Checkpoint")
+}
+
+func TestGitCommentPrefixAutoAvoidsExistingLinePrefix(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+	testutil.RunGit(t, dir, "config", "core.commentChar", "auto")
+
+	require.Equal(t, ";", gitCommentPrefix(context.Background(), "Message\n# user content\n"))
+}
+
+func TestCleanPreparedCommitMessageFollowsGitCommentCleanup(t *testing.T) {
 	t.Parallel()
 
-	message := "Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\n# Entire explanation\n\n# git status\n"
-	cpID, found := parseCheckpointFromCommitMessageFile(message)
-	t.Logf("message=%q parsed=%v found=%v", message, cpID, found)
-	if !found {
-		t.Fatal("parseCheckpointFromCommitMessageFile() did not find the trailer above comments")
+	tests := []struct {
+		name          string
+		message       string
+		source        string
+		commentPrefix string
+		wantFound     bool
+	}{
+		{
+			name:          "editor removes default comments",
+			message:       "Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\n# Entire explanation\n\n# git status\n",
+			commentPrefix: "#",
+			wantFound:     true,
+		},
+		{
+			name:          "message source preserves hash content",
+			message:       "Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\n# user content from -m or -F\n",
+			source:        "message",
+			commentPrefix: "#",
+			wantFound:     false,
+		},
+		{
+			name:          "editor removes configured comments",
+			message:       "Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\n; Entire explanation\n\n; git status\n",
+			commentPrefix: ";",
+			wantFound:     true,
+		},
 	}
-	if cpID.String() != "a1b2c3d4e5f6" {
-		t.Errorf("parseCheckpointFromCommitMessageFile() = %v, want a1b2c3d4e5f6", cpID)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cleaned := cleanPreparedCommitMessage(tt.message, tt.source, tt.commentPrefix)
+			cpID, found := trailers.ParseCheckpointFromFinalTrailerBlock(cleaned)
+			require.Equal(t, tt.wantFound, found)
+			if tt.wantFound {
+				require.Equal(t, "a1b2c3d4e5f6", cpID.String())
+			}
+		})
 	}
 }
 

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -869,6 +869,20 @@ func TestAddCheckpointTrailerWithComment_NoPrompt(t *testing.T) {
 	}
 }
 
+func TestParseCheckpointFromCommitMessageFileSkipsTrailingComments(t *testing.T) {
+	t.Parallel()
+
+	message := "Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\n# Entire explanation\n\n# git status\n"
+	cpID, found := parseCheckpointFromCommitMessageFile(message)
+	t.Logf("message=%q parsed=%v found=%v", message, cpID, found)
+	if !found {
+		t.Fatal("parseCheckpointFromCommitMessageFile() did not find the trailer above comments")
+	}
+	if cpID.String() != "a1b2c3d4e5f6" {
+		t.Errorf("parseCheckpointFromCommitMessageFile() = %v, want a1b2c3d4e5f6", cpID)
+	}
+}
+
 func TestAddCheckpointTrailer_ConventionalCommitSubject(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/strategy/manual_commit_worktree_session_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_worktree_session_test.go
@@ -44,6 +44,31 @@ func TestManualCommitStrategy_FindSessionsForWorktree_MatchesParentSessionFromNe
 }
 
 func TestManualCommitStrategy_PrepareCommitMsg_AddsTrailerForParentSessionFromNestedWorktree(t *testing.T) {
+	content := prepareParentSessionCommitMessage(t, "smoke commit\n")
+
+	cpID, found := trailers.ParseCheckpointFromFinalTrailerBlock(content)
+	require.True(t, found, "prepare-commit-msg should add a checkpoint trailer from the parent-recorded session")
+	require.False(t, cpID.IsEmpty())
+}
+
+func TestManualCommitStrategy_PrepareCommitMsg_IgnoresCheckpointShapedBodyText(t *testing.T) {
+	forgedID := "a1b2c3d4e5f6"
+	content := prepareParentSessionCommitMessage(t, "smoke commit\n\nEntire-Checkpoint: "+forgedID+"\n\nSigned-off-by: Test User <test@example.com>\n")
+
+	cpID, found := trailers.ParseCheckpointFromFinalTrailerBlock(content)
+	t.Logf("prepared message=%q final checkpoint=%v found=%v", content, cpID, found)
+	require.True(t, found, "prepare-commit-msg should stamp a final checkpoint trailer")
+	require.NotEqual(t, forgedID, cpID.String(), "body text must not choose the checkpoint that receives session data")
+
+	discovered := trailers.ParseAllCheckpoints(content)
+	require.Len(t, discovered, 2, "historical discovery should retain squash-compatible whole-message parsing")
+	require.Equal(t, forgedID, discovered[0].String())
+	require.Equal(t, cpID, discovered[1])
+}
+
+func prepareParentSessionCommitMessage(t *testing.T, initialMessage string) string {
+	t.Helper()
+
 	testutil.IsolateGitConfigEnv(t)
 	ctx := context.Background()
 	mainDir := setupSessionMatchRepo(t)
@@ -63,16 +88,14 @@ func TestManualCommitStrategy_PrepareCommitMsg_AddsTrailerForParentSessionFromNe
 	clearSessionMatchCaches()
 
 	commitMsgFile := filepath.Join(worktreeDir, "COMMIT_EDITMSG")
-	require.NoError(t, os.WriteFile(commitMsgFile, []byte("smoke commit\n"), 0o600))
+	require.NoError(t, os.WriteFile(commitMsgFile, []byte(initialMessage), 0o600))
 
 	hook := &ManualCommitStrategy{}
 	require.NoError(t, hook.PrepareCommitMsg(ctx, commitMsgFile, "message"))
 
 	content, err := os.ReadFile(commitMsgFile)
 	require.NoError(t, err)
-	cpID, found := trailers.ParseCheckpoint(string(content))
-	require.True(t, found, "prepare-commit-msg should add a checkpoint trailer from the parent-recorded session")
-	require.False(t, cpID.IsEmpty())
+	return string(content)
 }
 
 func TestManualCommitStrategy_FindSessionsForWorktree_MatchesUniqueSiblingByCommonDir(t *testing.T) {

--- a/cmd/entire/cli/strategy/phase_postcommit_test.go
+++ b/cmd/entire/cli/strategy/phase_postcommit_test.go
@@ -72,6 +72,41 @@ func TestPostCommit_ActiveSession_CondensesImmediately(t *testing.T) {
 		"StepCount should be reset after immediate condensation")
 }
 
+func TestPostCommit_IndentedCheckpointDoesNotAuthorizeCondensation(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	s := &ManualCommitStrategy{}
+	sessionID := "test-postcommit-indented-trailer"
+	setupSessionWithCheckpoint(t, s, repo, dir, sessionID)
+
+	state, err := s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	state.Phase = session.PhaseActive
+	require.NoError(t, s.saveSessionState(context.Background(), state))
+	originalStepCount := state.StepCount
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("agent modified content"), 0o644))
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("test.txt")
+	require.NoError(t, err)
+	_, err = wt.Commit("test commit\n\n  Entire-Checkpoint: a1b2c3d4e5f6\n", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, s.PostCommit(context.Background()))
+	state, err = s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Equal(t, originalStepCount, state.StepCount,
+		"an indented checkpoint-shaped line must not authorize condensation")
+	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.Error(t, err, "no persistent checkpoint should be written")
+}
+
 // TestPostCommit_ReviewSession_PinnedToSingleCheckpoint verifies that a
 // read-only review session is marked terminal once it has been condensed into a
 // checkpoint, so PostCommit stops re-attaching it to every later commit in the

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -103,7 +103,9 @@ func ParseSession(commitMessage string) (string, bool) {
 	return "", false
 }
 
-// ParseCheckpoint extracts the checkpoint ID from a commit message.
+// ParseCheckpoint discovers the first checkpoint ID anywhere in a commit
+// message. It supports squash history; callers must not treat the result as a
+// trusted trailer when deciding whether to create, reuse, or mutate a checkpoint.
 // Returns the CheckpointID and true if found, empty ID and false otherwise.
 func ParseCheckpoint(commitMessage string) (checkpointID.CheckpointID, bool) {
 	matches := checkpointTrailerRegex.FindStringSubmatch(commitMessage)
@@ -117,10 +119,12 @@ func ParseCheckpoint(commitMessage string) (checkpointID.CheckpointID, bool) {
 	return checkpointID.EmptyCheckpointID, false
 }
 
-// ParseAllCheckpoints extracts all checkpoint IDs from a commit message.
+// ParseAllCheckpoints discovers all checkpoint IDs in a commit message.
 // Returns a slice of CheckpointIDs (may be empty if none found).
 // Duplicate IDs are deduplicated while preserving order.
 // This is useful for squash merge commits that contain multiple Entire-Checkpoint trailers.
+// The results are discovery candidates, not proof that the final trailer block
+// authorized checkpoint mutation or reuse.
 func ParseAllCheckpoints(commitMessage string) []checkpointID.CheckpointID {
 	matches := checkpointTrailerRegex.FindAllStringSubmatch(commitMessage, -1)
 	if len(matches) == 0 {
@@ -139,6 +143,45 @@ func ParseAllCheckpoints(commitMessage string) []checkpointID.CheckpointID {
 				}
 			}
 		}
+	}
+	return ids
+}
+
+// ParseCheckpointFromFinalTrailerBlock extracts the first checkpoint ID from
+// the final trailer block. Commit body text is not considered.
+func ParseCheckpointFromFinalTrailerBlock(commitMessage string) (checkpointID.CheckpointID, bool) {
+	ids := ParseAllCheckpointsFromFinalTrailerBlock(commitMessage)
+	if len(ids) == 0 {
+		return checkpointID.EmptyCheckpointID, false
+	}
+	return ids[0], true
+}
+
+// ParseAllCheckpointsFromFinalTrailerBlock extracts checkpoint IDs from the
+// final trailer block, deduplicating them while preserving order.
+func ParseAllCheckpointsFromFinalTrailerBlock(commitMessage string) []checkpointID.CheckpointID {
+	lines := finalTrailerBlock(commitMessage)
+	if len(lines) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	ids := make([]checkpointID.CheckpointID, 0, len(lines))
+	for _, line := range lines {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok || key != CheckpointTrailerKey {
+			continue
+		}
+		idStr := strings.TrimSpace(value)
+		if seen[idStr] {
+			continue
+		}
+		cpID, err := checkpointID.NewCheckpointID(idStr)
+		if err != nil {
+			continue
+		}
+		seen[idStr] = true
+		ids = append(ids, cpID)
 	}
 	return ids
 }

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -168,7 +168,7 @@ func ParseAllCheckpointsFromFinalTrailerBlock(commitMessage string) []checkpoint
 	seen := make(map[string]bool)
 	ids := make([]checkpointID.CheckpointID, 0, len(lines))
 	for _, line := range lines {
-		key, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+		key, value, ok := strings.Cut(line, ":")
 		if !ok || key != CheckpointTrailerKey {
 			continue
 		}
@@ -291,7 +291,6 @@ func AppendCheckpointTrailer(message, checkpointID string) string {
 // "yes, applied."
 func HasOPFApplied(commitMessage string) bool {
 	for _, line := range finalTrailerBlock(commitMessage) {
-		line = strings.TrimSpace(line)
 		key, value, ok := strings.Cut(line, ":")
 		if !ok || key != OPFAppliedTrailerKey {
 			continue
@@ -314,15 +313,25 @@ func finalTrailerBlock(message string) []string {
 		i--
 	}
 	end := i + 1
-	for i >= 0 && IsTrailerLine(strings.TrimSpace(lines[i])) {
+	for i >= 0 && strings.TrimSpace(lines[i]) != "" {
 		i--
 	}
 	start := i + 1
 	if start == end {
 		return nil
 	}
-	if i >= 0 && strings.TrimSpace(lines[i]) != "" {
-		return nil
+
+	seenTrailer := false
+	for _, line := range lines[start:end] {
+		switch {
+		case IsTrailerLine(line):
+			seenTrailer = true
+		case seenTrailer && (strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")):
+			// Git treats an indented line after a trailer as a continuation
+			// of that trailer's value, never as a new trailer.
+		default:
+			return nil
+		}
 	}
 	return lines[start:end]
 }

--- a/cmd/entire/cli/trailers/trailers_test.go
+++ b/cmd/entire/cli/trailers/trailers_test.go
@@ -61,6 +61,8 @@ func TestIsTrailerLine(t *testing.T) {
 	}{
 		{"Signed-off-by: User <user@example.com>", true},
 		{"Entire-Checkpoint: abc123def456", true},
+		{"  Entire-Checkpoint: abc123def456", false},
+		{"\tEntire-Checkpoint: abc123def456", false},
 		{"not a trailer", false},
 		{"error: connection refused", true}, // "error" is a valid trailer key format
 		{"", false},
@@ -367,6 +369,26 @@ func TestParseAllCheckpointsFromFinalTrailerBlock(t *testing.T) {
 		{
 			name:    "checkpoint key embedded in another trailer value ignored",
 			message: "Message\n\nNotes: Entire-Checkpoint: a1b2c3d4e5f6\n",
+			want:    nil,
+		},
+		{
+			name:    "indented checkpoint is not a trailer",
+			message: "Message\n\n  Entire-Checkpoint: a1b2c3d4e5f6\n",
+			want:    nil,
+		},
+		{
+			name:    "tab-indented checkpoint is not a trailer",
+			message: "Message\n\n\tEntire-Checkpoint: a1b2c3d4e5f6\n",
+			want:    nil,
+		},
+		{
+			name:    "continuation after checkpoint remains in trailer block",
+			message: "Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\n continuation text\nSigned-off-by: Test User <test@example.com>\n",
+			want:    []string{"a1b2c3d4e5f6"},
+		},
+		{
+			name:    "continuation of another trailer does not become checkpoint",
+			message: "Message\n\nNotes: details\n  Entire-Checkpoint: a1b2c3d4e5f6\n",
 			want:    nil,
 		},
 	}

--- a/cmd/entire/cli/trailers/trailers_test.go
+++ b/cmd/entire/cli/trailers/trailers_test.go
@@ -268,6 +268,8 @@ func TestParseAllCheckpoints(t *testing.T) {
 }
 
 func TestParseCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		message   string
@@ -326,6 +328,8 @@ func TestParseCheckpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			gotID, gotFound := ParseCheckpoint(tt.message)
 			if gotFound != tt.wantFound {
 				t.Errorf("ParseCheckpoint() found = %v, want %v", gotFound, tt.wantFound)
@@ -334,6 +338,68 @@ func TestParseCheckpoint(t *testing.T) {
 				t.Errorf("ParseCheckpoint() id = %v, want %v", gotID.String(), tt.wantID)
 			}
 		})
+	}
+}
+
+func TestParseAllCheckpointsFromFinalTrailerBlock(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		message string
+		want    []string
+	}{
+		{
+			name:    "checkpoint-shaped body line ignored",
+			message: "Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\n\nSigned-off-by: Test User <test@example.com>\n",
+			want:    nil,
+		},
+		{
+			name:    "final trailer accepted after checkpoint-shaped body line",
+			message: "Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\n\nBody continues here.\n\nEntire-Checkpoint: b2c3d4e5f6a1\n",
+			want:    []string{"b2c3d4e5f6a1"},
+		},
+		{
+			name:    "multiple final checkpoint trailers",
+			message: "Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\nEntire-Checkpoint: b2c3d4e5f6a1\nEntire-Checkpoint: a1b2c3d4e5f6\n",
+			want:    []string{"a1b2c3d4e5f6", "b2c3d4e5f6a1"},
+		},
+		{
+			name:    "checkpoint key embedded in another trailer value ignored",
+			message: "Message\n\nNotes: Entire-Checkpoint: a1b2c3d4e5f6\n",
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseAllCheckpointsFromFinalTrailerBlock(tt.message)
+			t.Logf("message=%q parsed=%v", tt.message, got)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseAllCheckpointsFromFinalTrailerBlock() = %v, want %v", got, tt.want)
+			}
+			for i, wantID := range tt.want {
+				if got[i].String() != wantID {
+					t.Errorf("ParseAllCheckpointsFromFinalTrailerBlock()[%d] = %v, want %v", i, got[i], wantID)
+				}
+			}
+		})
+	}
+}
+
+func TestParseCheckpointFromFinalTrailerBlockReturnsFirst(t *testing.T) {
+	t.Parallel()
+
+	message := "Message\n\nEntire-Checkpoint: a1b2c3d4e5f6\nEntire-Checkpoint: b2c3d4e5f6a1\n"
+	got, found := ParseCheckpointFromFinalTrailerBlock(message)
+	t.Logf("message=%q parsed=%v found=%v", message, got, found)
+	if !found {
+		t.Fatal("ParseCheckpointFromFinalTrailerBlock() did not find a checkpoint")
+	}
+	if got.String() != "a1b2c3d4e5f6" {
+		t.Errorf("ParseCheckpointFromFinalTrailerBlock() = %v, want a1b2c3d4e5f6", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #2255 

PR #2168 prevents untrusted commit subjects from forging Entire trailers, but deliberately leaves commit-body handling to a separate change. Mutation paths still treated an `Entire-Checkpoint` line anywhere in a commit message as authority to select an existing checkpoint.

That allowed checkpoint-shaped body text to redirect PostCommit condensation, session attachment, generated explanations, or legacy migration. At the same time, read-only history discovery must continue recognizing embedded trailers from squash merges.

## Make the trailer block the mutation boundary

This change adds strict final-trailer-block parsing and uses it wherever a checkpoint may be created, reused, reconciled, or modified:

- commit preparation and amendment
- PostCommit condensation
- session attachment
- `checkpoint explain --generate`
- legacy session migration

Whole-message parsing remains available for read-only checkpoint discovery, preserving squash-merge history behavior.

The strict parser follows Git trailer structure: leading whitespace cannot turn body text into a trailer, while indented continuation lines remain supported.

Commit-message cleanup now also follows Git configuration. Editor flows honor `core.commentString`, `core.commentChar`, and `auto`; messages supplied through `-m` or `-F` preserve comment-prefixed user content.

## Verification

- `mise run lint` — 0 issues
- `mise run test` — 10,375 passed, 8 skipped
- `mise run test:integration` — 562 passed, 5 skipped
- `mise run test:ci` — passed, including Vogon and Roger-Roger canaries
- `git diff upstream/main...HEAD --check`

Regression tests exercise the durable PostCommit and attach boundaries, generated explanation paths, legacy migration, Git comment configuration, indented pseudo-trailers, continuation lines, and preserved squash-history discovery.