### PR TITLE
fix(test): a leaked goroutine and a colorized git grep, both reporting the wrong cause

### DIFF
--- a/cmd/entire/cli/osroot/rootbase_guard_test.go
+++ b/cmd/entire/cli/osroot/rootbase_guard_test.go
@@ -78,15 +78,33 @@ func TestRootBasesAreTrusted(t *testing.T) {
 
 	var checked int
 	for _, opener := range rootOpeners {
-		grep := exec.Command("git", "grep", "-n", "--fixed-strings", "--", opener, "--", ":(glob)**/*.go") //nolint:noctx // guard test, no cancellation needed
+		// --no-color because this parses git's output: color.ui / color.grep
+		// set to `always` colorizes even into a pipe, and the escapes land
+		// inside the filename field, so every line below fails the .go suffix
+		// check and the guard reports itself stale on a perfectly good tree.
+		// That is not hypothetical -- it was read as a real staleness failure
+		// on main (#2248) before the cause was found.
+		grep := exec.Command("git", "grep", "-n", "--no-color", "--fixed-strings", "--", opener, "--", ":(glob)**/*.go") //nolint:noctx // guard test, no cancellation needed
 		grep.Dir = strings.TrimSpace(string(repoRoot))
 		out, grepErr := grep.Output()
 		if grepErr != nil {
 			t.Fatalf("git grep for %q found nothing, which cannot be right: %v", opener, grepErr)
 		}
 		for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+			if line == "" {
+				continue
+			}
 			file, rest, ok := strings.Cut(line, ":")
-			if !ok || !strings.HasSuffix(file, ".go") || strings.HasSuffix(file, "_test.go") {
+			// The pathspec admits only *.go, so a first field that is not a
+			// .go path means the output is not `path:line:content` at all --
+			// a parse failure, which must not be mistaken for "found nothing".
+			if !ok || !strings.HasSuffix(file, ".go") {
+				t.Fatalf("cannot parse git grep output; expected `path:line:content`, got:\n  %s\n"+
+					"The filename field is unusable, so this test can prove nothing. "+
+					"Check whether git is colorizing into a pipe (color.ui or "+
+					"color.grep set to `always`).", line)
+			}
+			if strings.HasSuffix(file, "_test.go") {
 				continue
 			}
 			// The rule is about opening a root, not about naming one: doc
@@ -128,7 +146,7 @@ func TestRootBasesAreTrusted(t *testing.T) {
 func fileStillOpensARoot(t *testing.T, repoRoot, file string) bool {
 	t.Helper()
 	for _, opener := range rootOpeners {
-		grep := exec.Command("git", "grep", "-q", "--fixed-strings", "--", opener, "--", file) //nolint:noctx // guard test, no cancellation needed
+		grep := exec.Command("git", "grep", "-q", "--no-color", "--fixed-strings", "--", opener, "--", file) //nolint:noctx // guard test, no cancellation needed
 		grep.Dir = repoRoot
 		if grep.Run() == nil {
 			return true

--- a/cmd/entire/cli/strategy/session_lock_notice_test.go
+++ b/cmd/entire/cli/strategy/session_lock_notice_test.go
@@ -213,13 +213,12 @@ func TestClearSessionStateWithProgress_RefusesReentrantClear(t *testing.T) {
 
 	var errBuf syncBuffer
 	returned := make(chan error, 1)
+	frameDone := make(chan error, 1)
 	go func() {
-		if err := MutateSessionState(ctx, sessionID, func(*SessionState) error {
+		frameDone <- MutateSessionState(ctx, sessionID, func(*SessionState) error {
 			returned <- ClearSessionStateWithProgress(ctx, sessionID, &errBuf, 20*time.Millisecond)
 			return nil
-		}); err != nil {
-			t.Errorf("MutateSessionState: %v", err)
-		}
+		})
 	}()
 
 	select {
@@ -232,6 +231,25 @@ func TestClearSessionStateWithProgress_RefusesReentrantClear(t *testing.T) {
 		}
 	case <-time.After(15 * time.Second):
 		t.Fatal("deadlock: the clear ran on a goroutine that did not hold the gate, so it blocked on its own parent's flock")
+	}
+
+	// The clear's result arrives from INSIDE the mutation, so the frame is
+	// still open when the receive above unblocks: it has yet to save and drop
+	// the flock. Reporting the frame's own error from its goroutine and
+	// returning here raced that save against this test's cleanups -- t.Chdir
+	// restores the cwd and t.TempDir deletes the repo, so the save resolves a
+	// different git dir (in CI, the real checkout, which the state store's
+	// test-isolation guard then refuses) and fails. The t.Errorf that reported
+	// it landed on a completed test, which panics the whole package run rather
+	// than failing this one test. Join the frame here instead, and assert on
+	// its error from the test goroutine.
+	select {
+	case err := <-frameDone:
+		if err != nil {
+			t.Fatalf("MutateSessionState: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("MutateSessionState never returned after the refused clear")
 	}
 
 	// And it must not have claimed someone else held the lock.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1234
<!-- entire-trail-link-end -->

Two test-only fixes for failures that report the wrong cause. Neither touches production code.

## 1. `TestClearSessionStateWithProgress_RefusesReentrantClear` leaks its goroutine

Added in #2232, it intermittently panics the whole `strategy` package run in CI:

```
panic: Fail in goroutine after TestClearSessionStateWithProgress_RefusesReentrantClear has completed
...
strategy.TestClearSessionStateWithProgress_RefusesReentrantClear.func1()
    cmd/entire/cli/strategy/session_lock_notice_test.go:221 +0x17c
```

Nothing about the behaviour under test is wrong: the reentrant clear is refused, and every assertion passes.

`returned` is written from *inside* the mutation closure, so when the test's receive unblocks, the outermost `MutateSessionState` frame is still open — it has yet to run `SaveSessionState` and drop the flock (`session_state.go:670`). The test runs its last assertion and returns, and its own cleanups fire in LIFO order: `t.Chdir` restores the cwd, then `t.TempDir` deletes the repo. The still-in-flight save then resolves its state store from the *restored* cwd via `session.NewStateStore` → `gitdir.CommonDir`, which in CI is the real checkout — and `ensureTestIsolatedStateDir` refuses it. The frame returns non-nil, and the `t.Errorf` reporting it lands on a test that has already completed, which `testing` turns into a panic rather than a failure.

Reproduced by replaying the old shape with a `time.Sleep` standing in for the scheduler letting the parent finish first — same panic, and the frame's actual error is:

```
save session state: failed to create state store: session state dir "…/cli/.git/entire-sessions" escapes test isolation; give the test an isolated repo (testutil.InitRepo + t.Chdir) or scope the store explicitly
```

The isolation guard is what makes this loud: without it the leaked frame would have written session state into the CI checkout's real `.git/entire-sessions`.

**Fix:** send the frame's error on its own channel and join it before the test finishes, asserting from the test goroutine so a late failure can never reach `t.Errorf` after completion. The deadlock-regression path is unaffected — there the existing `t.Fatal` fires first and the child stays parked on its own flock, so it never sends.

## 2. `TestRootBasesAreTrusted` fails when git is configured to force color

This one came out of triaging the above. The guard parses `git grep -n` output, and git colorizes into a pipe when `color.ui` or `color.grep` is `always`, so the ANSI escapes land inside the filename field, `strings.HasSuffix(file, ".go")` rejects every line, `checked` stays 0, and the guard accuses its own detection pattern of having gone stale on a perfectly good tree.

That is the failure reported as pre-existing on main in [#2248](https://github.com/entireio/cli/pull/2248#issuecomment-5519425501). It isn't pre-existing — the test passes at the commit named there (`302b6edd5`, an ancestor of this branch) — and it reproduces byte-for-byte, single error line included, under `GIT_CONFIG_KEY_0=color.ui VALUE_0=always`. The single-error shape is itself the tell: `fileStillOpensARoot` uses `git grep -q` and reads only the exit status, so it is immune and reported nothing. Had the pattern really gone stale, all 16 allowlisted files would have failed too, as "no longer opens a root".

**Fix:** `--no-color` on both greps, and a hard failure on an unparsable line instead of silently filtering it. The pathspec admits only `*.go`, so a first field that is not a `.go` path means the output is not `path:line:content` at all — a parse failure, which must not be reported as "found nothing". The new message names colorization as the thing to check:

```
cannot parse git grep output; expected `path:line:content`, got:
  ^[[35mcmd/…/cli_commands_test.go^[[m^[[36m:^[[m^[[32m195^[[m…
The filename field is unusable, so this test can prove nothing. Check whether git is
colorizing into a pipe (color.ui or color.grep set to `always`).
```

Deliberately **not** `gitenv.Isolated()`, which would also keep ambient `GIT_CONFIG_*` out. It drops the user's global config, and this guard is the rare test that runs git against the developer's real checkout rather than a temp repo, so losing a globally-configured `safe.directory` would turn a pass into a hard failure. Of the `grep.*` keys git accepts (`column`, `extendedRegexp`, `fallbackToNoIndex`, `fullName`, `lineNumber`, `patternType`, `threads`) none breaks the parse; color is the only one, and `--no-color` overrides it wherever it is set.

## Verification

- The old reentrant-clear shape, with the delay injected, panics exactly as CI does; the new shape with the same delay passes (5×, `-race`).
- `go test ./cmd/entire/cli/strategy/ -run TestClearSessionState -race -count=20` — ok.
- `./cmd/entire/cli/strategy/` and `./cmd/entire/cli/session/` full packages, `-race` — ok.
- `TestRootBasesAreTrusted` passes plain, under `color.ui=always`, and under `color.grep=always`; dropping `--no-color` under forced color fails with the parse diagnostic rather than the staleness claim.
- `mise run fmt && mise run lint` — 0 issues. `mise run test:ci` — exit 0 (87 packages, 56 canary + 4 external-agent tests).

I checked the rest of the repo for the same goroutine shape (a session-state mutation whose result is observed from inside its own closure on another goroutine). The other goroutine-driven tests — `TestClearSessionStateWithProgress_AnnouncesLockWait`, `TestClearSessionState_SerializesAgainstConcurrentMutation`, `TestMutateSessionState_NestedCallsAreReentrant`, `TestRecordFilesTouched_ParallelMergesAreSerialized` — all already join before returning, so #1 is the only instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
