### PR TITLE
Harden executable resolution across the CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1236,6 +1236,21 @@ every directory override it reads — `ENTIRE_PLUGIN_DIR`, `XDG_DATA_HOME`,
 two to `osroot` and to `main.go`'s `PATH` restore. Those backstops hold, but
 they state the invariant two layers from where it is decided.
 
+**The OPF `command` is the deliberate exception, and stays one.**
+`redaction.openai_privacy_filter.command` becomes `argv[0]` of an
+`exec.CommandContext` in `redact/opf.go` with no `cmd.Dir` and no absoluteness
+check, so `"command": "./tools/opf"` resolves against the pre-push process's
+working directory. That is allowed because the field is not repo-supplied: the
+ownership gate above honors it only from an untracked, index-and-HEAD-verified
+`.entire/settings.local.json`, so a relative path there is the developer's own
+choice about their own machine, and a bare name is still covered by
+`exec.Command`'s `ErrDot` re-check. The scanners are the opposite case — they
+resolve names nobody chose, out of a `$PATH` the repository can reach — which
+is why the rule is theirs and not this field's. Do not "finish the job" by
+rejecting a relative OPF `command`: it would break the GUI-git-client setups
+the explicit `command` exists to serve, without closing anything the trust gate
+leaves open.
+
 #### Invoking Commands on Windows - Never Put a Dynamic Value on a cmd.exe Line
 
 **When Entire performs the exec itself, do not go through `cmd.exe`.** Pass the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1208,6 +1208,34 @@ relPath := paths.ToRelativePath("/repo/api/file.ts", repoRoot)  // returns "api/
 
 Test case in `state_test.go`: `TestFilterAndNormalizePaths_SiblingDirectories` documents this bug pattern.
 
+#### Executable Resolution - Absolute Paths Only
+
+Two rules, each with exactly one implementation, because Go's own protections
+do not reach far enough on their own.
+
+**Every `$PATH` scanner goes through `execx.PathScanDirs()`** (`execx/pathscan.go`),
+which returns only absolute entries. `exec.LookPath` reports `ErrDot` for a
+match found through a "." entry and `exec.Command` re-checks a separator-free
+`Path`, but neither protection reaches a scanner that resolves by
+`filepath.Glob`: a globbed match never passes through `LookPath`, and it arrives
+with separators in it. The external-agent scanner
+(`agent/external/discovery.go`) is exactly that shape and *executes* what it
+finds, so a relative entry would make a file committed to the caller's
+repository a binary Entire runs. `findInaccessiblePlugin` (`plugin.go`) carries
+the same rule; they are one helper because two copies is how they drifted.
+
+**`external.Agent.run` refuses a non-absolute `binaryPath` before spawning.**
+`run` sets `cmd.Dir` to the worktree root and `os/exec` resolves a relative
+`Path` against `Dir`, so the file `registerExternalAgent` statted is not
+necessarily the file that executes. The check lives at the exec, not at the
+caller, so it also covers the exported `New`.
+
+`pluginParentDir` (`plugin_store.go`) applies the same absoluteness rule to
+every directory override it reads — `ENTIRE_PLUGIN_DIR`, `XDG_DATA_HOME`,
+`LOCALAPPDATA` — via `requireAbsPluginParent`, rather than leaving the platform
+two to `osroot` and to `main.go`'s `PATH` restore. Those backstops hold, but
+they state the invariant two layers from where it is decided.
+
 #### Invoking Commands on Windows - Never Put a Dynamic Value on a cmd.exe Line
 
 **When Entire performs the exec itself, do not go through `cmd.exe`.** Pass the
@@ -1372,7 +1400,25 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
 - **Scanner engine selection is a settings-only, fail-closed choice**: `redaction.betterleaks.enabled` (default `true`) and `redaction.goredact.enabled` (default `false`) pick which pattern-matching engine(s) feed layer 2 of `detectAllLayers` (`redact.ConfigureScanners`, `redact/scanners.go`). Both keys are honored from committed `.entire/settings.json` only — a `settings.local.json` copy is ignored with a logged warning, because the choice affects everyone who reads the repo's checkpoints, not just the developer who set it. `validateScannerSettings` fails settings load with `settings.ErrScannerConfig` when both engines are disabled. If goredact is the sole enabled engine and its scan fails at runtime, `redact.ErrScannerDegraded` propagates out of `JSONLBytes`/`JSONLBytesWithPrivacyFilter`; every checkpoint-write call site (`checkpoint/ephemeral.go`, `checkpoint/persistent.go`, `strategy/manual_commit_hooks.go`) must `errors.Is` for it and fail the write rather than fall back to under-scanned content. See `docs/security-and-privacy.md` for user-facing details.
 - **OPF (OpenAI Privacy Filter) runs at pre-push, not post-commit**: when `redaction.openai_privacy_filter.enabled` is true, the PrePush hook re-redacts unpushed commits with the OPF 9th layer, builds new commits carrying an `Entire-OPF-Applied: true` trailer, and updates the local refs before pushing. Per-commit condensation stays on the fast 8-layer pipeline. **Both backends are covered, by two rewrites sharing one policy**: `manual_commit_opf_rewrite.go` walks unpushed `entire/checkpoints/v1` commits bounded by the remote tip and CAS-updates the branch; `manual_commit_opf_refs.go` walks the push queue and, per queued ref, rewrites every unpushed commit — stopping at the first commit already carrying the trailer, which makes the trailer its own watermark (steady state stops at the tip's parent) and is bounded by the shared `BootstrapTooLargeError` cap for repos that enable OPF late. Blob policy, byte caps, the single batched shell-out, and the error taxonomy are shared; only discovery and ref update differ. **Fail-closed differs by backend on purpose**: git-branch aborts the user's push, while git-refs withholds the (separately-pushed) checkpoint refs and leaves them queued, so nothing under-redacted ships without blocking the user's own push. See `docs/security-and-privacy.md` for the full flow, including divergence detection, bootstrap caps, and CAS-on-conflict semantics.
 - **OPF's `command` is a trust boundary, not a setting**: `redaction.openai_privacy_filter.command` becomes `argv[0]` of an exec during pre-push, and `.entire/settings.json` is version-controlled — so reading it from the project file would let a pull request execute code on every developer who pushes (the prompt is no defense: it never names the command, `prompt_default: "always"` skips it, and non-TTY pushes auto-run). `settings.enforceOPFCommandTrust` (`settings/opf_command_trust.go`) honors `command` only from `.entire/settings.local.json`, and only when that file is untracked in **both** the index and `HEAD` — the filename is not the check, because `.gitignore` does not apply to an already-tracked path. The probe goes through go-git (`gitrepo.OpenPath`), not the git CLI, and is memoized per process: shelling out cost ~15 subprocesses per hook (`settings.Load` is uncached and runs several times per hook) and would fail verification wherever `git` is off `$PATH` — the GUI-git-client population that most needs an explicit `command`. **Two depths**: the layer check reads the index only, because a PR-delivered file is always in the index of a clone that checks it out, and checkout cannot produce a file absent from the index; the `command` check also reads HEAD. That split matters because HEAD is the expensive half — measured 8.3ms → 2.5ms per hook process in this repo, and 39ms → 11ms on reftable, where `gitrepo` routes reference reads back through the git CLI. The cost falls on everyone with a `settings.local.json`, not just OPF users, so keep it off the HEAD path. Rejection is a downgrade to the documented `$PATH` default plus a warning, never a hard error; verification failure (no repo, git missing) counts as untrusted. Do not add other exec-bearing fields to the project settings file without the same gate.
-- **A tracked `.entire/settings.local.json` is ignored wholesale**: the local layer's premise is that it is per-clone and per-developer (it is gitignored, `entire enable --local` writes it, and `CheckpointRemoteIsLocalOnly` treats presence there as proof the developer chose it). `.gitignore` does not apply to an already-tracked path, so a committed one arrives by cloning and would override project settings for everyone. `loadMergedSettings` drops the layer when the file is **proven** tracked, records `EntireSettings.LocalLayerRejection()`, and the redaction consumer prints it with the `git rm --cached` fix. It never errors — one committed file must not brick `status`/`doctor`. Two deliberately opposite failure directions, expressed as the three-state `localTrust` (`localUnverifiable` is the zero value so a forgotten assignment fails safe): an *unverifiable* repo keeps the layer (losing all local settings is worse than the risk) but still drops the exec-bearing OPF `command` (being wrong means running someone else's binary); *no* repository counts as proof of locality. `CheckpointRemoteIsLocalOnly` reads the raw file outside the loader, so it repeats the check itself.
+- **`external_agents` is the second exec-bearing setting, gated the same way**:
+  it enables the `$PATH` scan that globs for `entire-agent-*` binaries and runs
+  each one's `info` subcommand, so a committed `{"external_agents": true}` would
+  let a pull request turn on execution of whatever binary it could get onto a
+  developer's `$PATH` — the `enforceOPFCommandTrust` rationale verbatim, minus
+  even a prompt. `settings.enforceExternalAgentsTrust`
+  (`settings/external_agents_trust.go`) honors it only from a
+  `classifyLocalSettingsDeep`-verified `.entire/settings.local.json`, reusing
+  the OPF gate's helpers; only a `true` value is gated, since `false` grants
+  nothing. Rejection is a downgrade recorded on
+  `EntireSettings.ExternalAgentsRejection()`, surfaced by `entire status` and by
+  `external.DiscoverAndRegister` — without it, a refused grant and a setting the
+  user never wrote look identical (no agent appears). **Consequence for every
+  write site**: the auto-enable that fires when a user picks an external agent
+  must go through `enableExternalAgentsLocally` (`setup_external_agents.go`),
+  which raw-writes the single key to the local file whatever `--local`/`--project`
+  said about the rest — writing it into the project file produces a setting the
+  user can read back and that never takes effect.
+- **A tracked `.entire/settings.local.json` is ignored wholesale**: the local layer's premise is that it is per-clone and per-developer (it is gitignored, `entire enable --local` writes it, and `CheckpointRemoteIsLocalOnly` treats presence there as proof the developer chose it). `.gitignore` does not apply to an already-tracked path, so a committed one arrives by cloning and would override project settings for everyone. `loadMergedSettings` drops the layer when the file is **proven** tracked, records `EntireSettings.LocalLayerRejection()`, and the redaction consumer prints it with the `git rm --cached` fix. It never errors — one committed file must not brick `status`/`doctor`. Two deliberately opposite failure directions, expressed as the three-state `localTrust` (`localUnverifiable` is the zero value so a forgotten assignment fails safe): an *unverifiable* repo keeps the layer (losing all local settings is worse than the risk) but still drops the exec-bearing settings, OPF `command` and `external_agents` (being wrong there means running someone else's binary); *no* repository counts as proof of locality. `CheckpointRemoteIsLocalOnly` reads the raw file outside the loader, so it repeats the check itself.
 - Safe to use on main/master since it never modifies commit history
 
 #### Key Files

--- a/cmd/entire/cli/agent/external/discovery.go
+++ b/cmd/entire/cli/agent/external/discovery.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/execx"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
@@ -37,11 +39,41 @@ var (
 // Errors during discovery are logged but do not prevent other agents from loading.
 // Discovery is skipped when the external_agents setting is not enabled.
 func DiscoverAndRegister(ctx context.Context) {
-	if !settings.IsExternalAgentsEnabled(ctx) {
+	// settings.Load directly rather than settings.IsExternalAgentsEnabled: the
+	// disabled path needs the same object again to report a refused grant, and
+	// Load is uncached and already runs several times per hook.
+	s, err := settings.Load(ctx)
+	if err != nil {
+		logging.Debug(ctx, "external agent discovery skipped (settings unreadable)",
+			slog.String("error", err.Error()))
+		return
+	}
+	if !s.ExternalAgents {
+		reportExternalAgentsRejection(ctx, s)
 		logging.Debug(ctx, "external agent discovery disabled (external_agents not enabled in settings)")
 		return
 	}
 	discoverAndRegister(ctx)
+}
+
+// reportExternalAgentsRejection tells the user when discovery is off because
+// the loader refused an external_agents grant rather than because they never
+// set one. The two look identical from here — no agent appears — and the fix
+// (move the setting into an untracked .entire/settings.local.json) is not
+// guessable from the symptom. The loader records rather than logs, so this is
+// the first place that can say anything.
+func reportExternalAgentsRejection(ctx context.Context, s *settings.EntireSettings) {
+	reason, rejected := s.ExternalAgentsRejection()
+	if !rejected {
+		return
+	}
+	logging.Warn(ctx, "ignoring external_agents",
+		slog.String("reason", reason),
+		slog.String("remediation", "set external_agents in "+settings.EntireSettingsLocalFile+", untracked"))
+	if interactive.IsTerminalWriter(os.Stderr) {
+		fmt.Fprintf(os.Stderr, "[entire] ignoring external_agents (%s); move it to %s and keep that file out of version control\n",
+			reason, settings.EntireSettingsLocalFile)
+	}
 }
 
 // DiscoverAndRegisterAlways is like DiscoverAndRegister but bypasses the
@@ -134,8 +166,14 @@ func discoverAndRegister(ctx context.Context) {
 	discoveryCtx, cancel := context.WithTimeout(ctx, discoveryTimeout)
 	defer cancel()
 
-	pathEnv := os.Getenv("PATH")
-	if pathEnv == "" {
+	// execx.PathScanDirs, not a bare $PATH split: this scanner resolves by
+	// filepath.Glob, so a match never passes through exec.LookPath (no ErrDot)
+	// and arrives with separators in it (so exec.Command's own re-check does
+	// not apply either). Dropping non-absolute entries at the source is the
+	// only thing standing between a file committed to the user's repository
+	// and a binary this function executes to ask for its info.
+	scanDirs := execx.PathScanDirs()
+	if len(scanDirs) == 0 {
 		return
 	}
 
@@ -146,7 +184,7 @@ func discoverAndRegister(ctx context.Context) {
 	}
 
 	seen := make(map[string]bool) // deduplicate binaries across PATH dirs
-	for _, dir := range filepath.SplitList(pathEnv) {
+	for _, dir := range scanDirs {
 		if discoveryCanceled(ctx, discoveryCtx) {
 			logging.Debug(ctx, "external agent discovery timed out")
 			return

--- a/cmd/entire/cli/agent/external/discovery_test.go
+++ b/cmd/entire/cli/agent/external/discovery_test.go
@@ -50,8 +50,15 @@ func makeInfoJSON(name string) string {
 // NOTE: Tests in this file modify process-global state (os.Setenv, os.Chdir, agent registry)
 // and therefore cannot use t.Parallel().
 
-// externalAgentsRepo writes .entire/settings.json with the given external_agents
-// value and returns a context that names the directory as the worktree root.
+// externalAgentsRepo writes .entire/settings.local.json with the given
+// external_agents value and returns a context that names the directory as the
+// worktree root.
+//
+// The LOCAL file, because external_agents grants execution of every
+// entire-agent-* binary on $PATH and settings.Load honors that grant nowhere
+// else (settings.enforceExternalAgentsTrust). There is no repository here, so
+// nothing can have arrived by cloning and the file verifies as this clone's
+// own.
 //
 // The context is what makes this deterministic. settings.Load short-circuits on
 // a worktree root carried in the context and never consults entiredir's anchor,
@@ -77,9 +84,12 @@ func externalAgentsRepo(t *testing.T, enabled bool) context.Context {
 	if err := os.MkdirAll(entireDir, 0o755); err != nil {
 		t.Fatalf("create .entire: %v", err)
 	}
-	body := fmt.Sprintf(`{"enabled":true,"external_agents":%t}`, enabled)
-	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(body), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"enabled":true}`), 0o644); err != nil {
 		t.Fatalf("write settings: %v", err)
+	}
+	body := fmt.Sprintf(`{"external_agents":%t}`, enabled)
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.local.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write local settings: %v", err)
 	}
 	t.Chdir(tmpDir)
 	return settings.WithWorktreeRoot(context.Background(), tmpDir)
@@ -720,5 +730,129 @@ func TestDiscoverAndRegisterNamedAlways_ReportsCallerDeadlineExpiredDuringLookup
 	err := DiscoverAndRegisterNamedAlways(caller, name)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("DiscoverAndRegisterNamedAlways() error = %v, want context deadline exceeded", err)
+	}
+}
+
+// TestDiscoverAndRegister_SkipsRelativePATHEntry pins the rule the scanner
+// cannot get from Go: a globbed match never passes through exec.LookPath, so
+// nothing else refuses a binary reached through a relative $PATH entry. The
+// planted binary must not run at all, which is what the marker file checks —
+// "did not register" alone would also pass if it ran and merely failed.
+func TestDiscoverAndRegister_SkipsRelativePATHEntry(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	ctx := enableExternalAgents(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	relDir := "planted"
+	if err := os.MkdirAll(filepath.Join(cwd, relDir), 0o755); err != nil {
+		t.Fatalf("create planted dir: %v", err)
+	}
+	marker := filepath.Join(cwd, "planted-ran")
+	planted := "disc-relative"
+	// `: >` is a shell builtin: PATH is reduced to the fixture dirs, so an
+	// external `touch` would not resolve and the marker would never appear.
+	script := "#!/bin/sh\n: > " + marker + "\n" + mockInfoScript(makeInfoJSON(planted))
+	if err := os.WriteFile(filepath.Join(cwd, relDir, binaryPrefix+planted), []byte(script), 0o755); err != nil {
+		t.Fatalf("write planted binary: %v", err)
+	}
+
+	// Control: an absolute entry proves the scan actually ran.
+	control := "disc-absolute"
+	controlDir := setupDiscoveryDir(t, control, makeInfoJSON(control))
+	t.Setenv("PATH", relDir+string(os.PathListSeparator)+controlDir)
+
+	DiscoverAndRegister(ctx)
+
+	if _, err := agent.Get(types.AgentName(control)); err != nil {
+		t.Fatalf("control agent %q should have registered, so the scan ran: %v", control, err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("planted binary was executed (marker stat err = %v), want it never spawned", err)
+	}
+	if _, err := agent.Get(types.AgentName(planted)); err == nil {
+		t.Errorf("agent %q from a relative $PATH entry was registered, want it skipped", planted)
+	}
+}
+
+// TestDiscoverAndRegisterNamedAlways_RejectsRelativeLookPathResult covers the
+// named lookup, which resolves through exec.LookPath rather than a glob.
+// LookPath reports ErrDot for a bare "." entry but happily returns
+// "sub/entire-agent-x" for a relative entry that names a subdirectory.
+func TestDiscoverAndRegisterNamedAlways_RejectsRelativeLookPathResult(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	relDir := "planted"
+	if err := os.MkdirAll(filepath.Join(dir, relDir), 0o755); err != nil {
+		t.Fatalf("create planted dir: %v", err)
+	}
+	marker := filepath.Join(dir, "planted-ran")
+	name := "named-relative"
+	script := "#!/bin/sh\n: > " + marker + "\n" + mockInfoScript(makeInfoJSON(name))
+	if err := os.WriteFile(filepath.Join(dir, relDir, binaryPrefix+name), []byte(script), 0o755); err != nil {
+		t.Fatalf("write planted binary: %v", err)
+	}
+	t.Setenv("PATH", relDir)
+
+	err := DiscoverAndRegisterNamedAlways(context.Background(), types.AgentName(name))
+
+	if err == nil {
+		t.Fatalf("DiscoverAndRegisterNamedAlways succeeded for a relative $PATH entry, want refusal")
+	}
+	if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("planted binary was executed (marker stat err = %v), want it never spawned", statErr)
+	}
+	if _, getErr := agent.Get(types.AgentName(name)); getErr == nil {
+		t.Errorf("agent %q was registered from a relative $PATH entry, want it skipped", name)
+	}
+}
+
+// TestDiscoverAndRegister_ProjectSettingsGrantDoesNotRunBinaries is the
+// end-to-end half of the settings trust gate: a grant in the committed
+// .entire/settings.json is attacker-deliverable through a pull request, and
+// the consequence it must not have is *execution*, not merely registration.
+func TestDiscoverAndRegister_ProjectSettingsGrantDoesNotRunBinaries(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	tmpDir := t.TempDir()
+	t.Cleanup(osroot.ResetShared)
+	entireDir := filepath.Join(tmpDir, ".entire")
+	if err := os.MkdirAll(entireDir, 0o755); err != nil {
+		t.Fatalf("create .entire: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"),
+		[]byte(`{"enabled":true,"external_agents":true}`), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	t.Chdir(tmpDir)
+	ctx := settings.WithWorktreeRoot(context.Background(), tmpDir)
+
+	marker := filepath.Join(tmpDir, "planted-ran")
+	name := "disc-project-grant"
+	dir := t.TempDir()
+	script := "#!/bin/sh\n: > " + marker + "\n" + mockInfoScript(makeInfoJSON(name))
+	if err := os.WriteFile(filepath.Join(dir, binaryPrefix+name), []byte(script), 0o755); err != nil {
+		t.Fatalf("write mock binary: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	DiscoverAndRegister(ctx)
+
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("binary was executed (marker stat err = %v) on a project-file grant, want no scan at all", err)
+	}
+	if _, err := agent.Get(types.AgentName(name)); err == nil {
+		t.Errorf("agent %q registered from a project-file grant, want it refused", name)
 	}
 }

--- a/cmd/entire/cli/agent/external/external.go
+++ b/cmd/entire/cli/agent/external/external.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -435,6 +436,22 @@ func (e *Agent) CalculateTotalTokenUsage(transcriptData []byte, fromOffset int, 
 // If stdin is non-nil it is piped to the process. On non-zero exit, stderr is
 // included in the returned error.
 func (e *Agent) run(ctx context.Context, stdin []byte, args ...string) ([]byte, error) {
+	// binaryPath must be absolute, and the check belongs here rather than at
+	// the caller. run sets cmd.Dir to the worktree root below, and os/exec
+	// resolves a relative Path against Dir — so the file registerExternalAgent
+	// statted (relative to ITS working directory) is not necessarily the file
+	// that executes. Anchoring on an absolute path makes validation and
+	// execution name the same file.
+	//
+	// Go refuses only part of this on its own: exec.Command re-checks a
+	// separator-free name through LookPath and reports ErrDot, but a relative
+	// path WITH a separator ("./x", "sub/x") gets no such treatment. New is
+	// exported, so this is also the only guarantee a caller outside the
+	// scanner has.
+	if !filepath.IsAbs(e.binaryPath) {
+		return nil, fmt.Errorf("%s: refusing to run external agent binary %q: path is not absolute", args[0], e.binaryPath)
+	}
+
 	// Apply a default timeout when the caller hasn't set a deadline, so a hung
 	// external binary can't block the CLI (or git hooks) indefinitely.
 	if _, ok := ctx.Deadline(); !ok {

--- a/cmd/entire/cli/agent/external/external.go
+++ b/cmd/entire/cli/agent/external/external.go
@@ -436,6 +436,14 @@ func (e *Agent) CalculateTotalTokenUsage(transcriptData []byte, fromOffset int, 
 // If stdin is non-nil it is piped to the process. On non-zero exit, stderr is
 // included in the returned error.
 func (e *Agent) run(ctx context.Context, stdin []byte, args ...string) ([]byte, error) {
+	// Every error below labels its message with the subcommand, args[0], so an
+	// empty slice panics on the way to reporting the real failure rather than
+	// returning it. run is variadic and New is exported, so the callers are not
+	// only this package's own.
+	if len(args) == 0 {
+		return nil, fmt.Errorf("refusing to run external agent binary %q: no subcommand given", e.binaryPath)
+	}
+
 	// binaryPath must be absolute, and the check belongs here rather than at
 	// the caller. run sets cmd.Dir to the worktree root below, and os/exec
 	// resolves a relative Path against Dir — so the file registerExternalAgent

--- a/cmd/entire/cli/agent/external/external_test.go
+++ b/cmd/entire/cli/agent/external/external_test.go
@@ -1002,3 +1002,63 @@ func hooksInstalledNow(t *testing.T, ag interface {
 	}
 	return installed
 }
+
+// TestNew_RefusesRelativeBinaryPath pins that validation and execution refer
+// to the same file. run sets cmd.Dir to the worktree root and os/exec resolves
+// a relative Path against Dir, so a caller that stats "./x" in one directory
+// can spawn a different "./x" — the guarantee has to be anchored on an
+// absolute path, and it has to hold for the exported constructor, not only
+// for binaries the scanner produced.
+func TestNew_RefusesRelativeBinaryPath(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	marker := filepath.Join(dir, "planted-ran")
+	// A relative path WITH a separator. exec.Command's own re-check only
+	// covers separator-free names, so this is the shape that still resolves.
+	relPath := "." + string(filepath.Separator) + binaryPrefix + "planted"
+	// `: >` is a shell builtin, so the marker does not depend on $PATH.
+	script := "#!/bin/sh\n: > " + marker + "\n" + mockInfoScript(makeInfoJSON("planted"))
+	if err := os.WriteFile(filepath.Join(dir, binaryPrefix+"planted"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write planted binary: %v", err)
+	}
+
+	ea, err := New(context.Background(), relPath)
+
+	if err == nil {
+		t.Fatalf("New(%q) succeeded, want refusal", relPath)
+	}
+	if ea != nil {
+		t.Errorf("New returned agent %v alongside an error, want nil", ea)
+	}
+	if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("planted binary was executed (marker stat err = %v), want it never spawned", statErr)
+	}
+}
+
+func TestAgentRun_RefusesRelativeBinaryPath(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	marker := filepath.Join(dir, "planted-ran")
+	relPath := "." + string(filepath.Separator) + binaryPrefix + "planted"
+	script := "#!/bin/sh\n: > " + marker + "\n" + mockInfoScript(makeInfoJSON("planted"))
+	if err := os.WriteFile(filepath.Join(dir, binaryPrefix+"planted"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write planted binary: %v", err)
+	}
+
+	ea := &Agent{binaryPath: relPath}
+
+	if _, err := ea.run(context.Background(), nil, "info"); err == nil {
+		t.Fatalf("run succeeded with a relative binaryPath, want refusal")
+	}
+	if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("planted binary was executed (marker stat err = %v), want it never spawned", statErr)
+	}
+}

--- a/cmd/entire/cli/agent/external/external_test.go
+++ b/cmd/entire/cli/agent/external/external_test.go
@@ -1062,3 +1062,25 @@ func TestAgentRun_RefusesRelativeBinaryPath(t *testing.T) {
 		t.Errorf("planted binary was executed (marker stat err = %v), want it never spawned", statErr)
 	}
 }
+
+// TestAgentRun_NoArgs pins that run reports the caller's mistake instead of
+// panicking on it. run is variadic and every error path it takes labels the
+// message with args[0], so a zero-arg call indexes an empty slice before any
+// of those paths can return. New is exported, so the reachable set is not
+// limited to this package's own call sites.
+func TestAgentRun_NoArgs(t *testing.T) {
+	t.Parallel()
+
+	// An absolute path, so the empty-args check is what has to fire rather
+	// than the absoluteness refusal above it.
+	ea := &Agent{binaryPath: filepath.Join(t.TempDir(), binaryPrefix+"noargs")}
+
+	out, err := ea.run(context.Background(), nil)
+
+	if err == nil {
+		t.Fatal("run with no args succeeded, want an error")
+	}
+	if out != nil {
+		t.Errorf("run returned %q alongside an error, want nil", out)
+	}
+}

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -99,7 +99,8 @@ Pass --skills to declare which skills were actually run; omit to
 attach a review without a declared skills list.
 
 Works with any registered agent, including external agents enabled via
-external_agents in settings. Run 'entire agent list' to see the full list.
+external_agents in .entire/settings.local.json (that file only, and only
+when it is untracked). Run 'entire agent list' to see the full list.
 
 If --agent doesn't locate a transcript, Entire auto-detects the agent from
 the transcript and prints the detected agent name.`,

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -2089,11 +2089,12 @@ func TestAttach_DiscoversExternalAgents(t *testing.T) {
 
 	setupAttachTestRepo(t)
 
-	// Overwrite settings to enable external_agents (enableEntire writes the
-	// file without it).
+	// Enable external_agents. It goes in the local file: the setting grants
+	// execution of entire-agent-* binaries on $PATH, so the loader honors it
+	// only from an untracked local override.
 	cwd := mustGetwd(t)
-	settingsPath := filepath.Join(cwd, ".entire", "settings.json")
-	if err := os.WriteFile(settingsPath, []byte(`{"enabled":true,"external_agents":true}`), 0o600); err != nil {
+	settingsPath := filepath.Join(cwd, ".entire", "settings.local.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"external_agents":true}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/entire/cli/execx/pathscan.go
+++ b/cmd/entire/cli/execx/pathscan.go
@@ -1,0 +1,36 @@
+package execx
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// PathScanDirs returns the $PATH entries that may be scanned for executables:
+// absolute directories only, in $PATH order.
+//
+// Every scanner in the CLI must go through this rather than splitting $PATH
+// itself. A relative entry resolves against the process's working directory,
+// which for a git hook or an agent-invoked command is whatever directory the
+// caller happened to be in — usually a repository someone else wrote. A file
+// committed to that repository would then be a binary Entire executes.
+//
+// Go's own resolver already refuses the worst case: exec.LookPath returns
+// ErrDot for a match found through a "." entry, and exec.Command re-checks a
+// separator-free Path. Neither protection reaches a scanner that resolves by
+// filepath.Glob, because a globbed match arrives as a path WITH separators and
+// never passes through LookPath at all. Dropping the entry at the source is
+// what makes the rule hold for every scanner, whatever it resolves with.
+//
+// Empty entries are dropped for the same reason: POSIX reads "" as the current
+// directory, so it is the "." case spelled differently.
+func PathScanDirs() []string {
+	entries := filepath.SplitList(os.Getenv("PATH"))
+	dirs := make([]string, 0, len(entries))
+	for _, dir := range entries {
+		if !filepath.IsAbs(dir) {
+			continue
+		}
+		dirs = append(dirs, dir)
+	}
+	return dirs
+}

--- a/cmd/entire/cli/execx/pathscan_test.go
+++ b/cmd/entire/cli/execx/pathscan_test.go
@@ -1,0 +1,65 @@
+package execx
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// These tests set PATH, which is process-global, so they cannot be parallel.
+
+func join(dirs ...string) string {
+	return strings.Join(dirs, string(os.PathListSeparator))
+}
+
+func abs(t *testing.T, parts ...string) string {
+	t.Helper()
+	root := "/"
+	if runtime.GOOS == "windows" {
+		root = `C:\`
+	}
+	return filepath.Join(append([]string{root}, parts...)...)
+}
+
+func TestPathScanDirs_DropsRelativeEntries(t *testing.T) {
+	good := abs(t, "usr", "bin")
+	t.Setenv("PATH", join("relative/bin", good, "./dot", "..", "sub"))
+
+	got := PathScanDirs()
+
+	if len(got) != 1 || got[0] != good {
+		t.Fatalf("PathScanDirs() = %q, want exactly [%q]", got, good)
+	}
+}
+
+func TestPathScanDirs_DropsEmptyEntries(t *testing.T) {
+	good := abs(t, "usr", "bin")
+	t.Setenv("PATH", join("", good, ""))
+
+	got := PathScanDirs()
+
+	if len(got) != 1 || got[0] != good {
+		t.Fatalf("PathScanDirs() = %q, want exactly [%q]", got, good)
+	}
+}
+
+func TestPathScanDirs_KeepsAbsoluteEntriesInOrder(t *testing.T) {
+	first, second := abs(t, "a"), abs(t, "b")
+	t.Setenv("PATH", join(first, second))
+
+	got := PathScanDirs()
+
+	if len(got) != 2 || got[0] != first || got[1] != second {
+		t.Fatalf("PathScanDirs() = %q, want [%q %q]", got, first, second)
+	}
+}
+
+func TestPathScanDirs_EmptyPATH(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	if got := PathScanDirs(); len(got) != 0 {
+		t.Fatalf("PathScanDirs() = %q, want empty", got)
+	}
+}

--- a/cmd/entire/cli/explain_summary_provider.go
+++ b/cmd/entire/cli/explain_summary_provider.go
@@ -20,17 +20,33 @@ import (
 )
 
 var (
-	loadSummarySettings             = LoadEntireSettings
-	loadSummarySettingsFromFile     = settings.LoadFromFile
-	saveLocalSummarySettings        = SaveEntireSettingsLocal
-	getSummaryAgent                 = agent.Get
-	listRegisteredAgents            = agent.List
-	isSummaryCLIAvailable           = agent.IsSummaryCLIAvailable
-	discoverSummaryProviders        = external.DiscoverAndRegister
-	discoverSummaryProvidersAlways  = external.DiscoverAndRegisterAlways
-	discoverDispatchSummaryProvider = external.DiscoverAndRegisterNamedAlways
-	canPromptForSummaryProvider     = interactive.CanPromptInteractively
-	promptSummaryProvider           = promptForSummaryProvider
+	loadSummarySettings            = LoadEntireSettings
+	loadSummarySettingsFromFile    = settings.LoadFromFile
+	saveLocalSummarySettings       = SaveEntireSettingsLocal
+	getSummaryAgent                = agent.Get
+	listRegisteredAgents           = agent.List
+	isSummaryCLIAvailable          = agent.IsSummaryCLIAvailable
+	discoverSummaryProviders       = external.DiscoverAndRegister
+	discoverSummaryProvidersAlways = external.DiscoverAndRegisterAlways
+	discoverNamedSummaryProvider   = external.DiscoverAndRegisterNamedAlways
+	canPromptForSummaryProvider    = interactive.CanPromptInteractively
+	promptSummaryProvider          = promptForSummaryProvider
+)
+
+// summarySelectionOrigin records who chose a summary provider. It gates the
+// external_agents grant, which is repo-wide rather than scoped to the chosen
+// provider: it turns on the $PATH sweep that executes every entire-agent-*
+// binary from then on. Installing a plugin is consent to "this plugin exists",
+// and picking it in the prompt is consent to run plugins generally, but a code
+// path that selected the only candidate (or the first of several on a headless
+// run) has no such consent behind it.
+type summarySelectionOrigin int
+
+const (
+	// selectionAutomatic is a provider the resolver picked on its own.
+	selectionAutomatic summarySelectionOrigin = iota
+	// selectionByUser is a provider a human picked at the prompt.
+	selectionByUser
 )
 
 type checkpointSummaryProvider struct {
@@ -54,7 +70,7 @@ func resolveDispatchSummaryProvider(ctx context.Context, w io.Writer, override s
 
 	providerName := types.AgentName(override)
 	if _, err := getSummaryAgent(providerName); err != nil {
-		if err := discoverDispatchSummaryProvider(ctx, providerName); err != nil {
+		if err := discoverNamedSummaryProvider(ctx, providerName); err != nil {
 			return nil, err
 		}
 	}
@@ -81,9 +97,11 @@ func resolveCheckpointSummaryProvider(ctx context.Context, w io.Writer) (*checkp
 
 	// Use the always-variant so installed external plugins surface in the
 	// picker even when external_agents is currently off. Installation
-	// (placing entire-agent-* on $PATH) is the user's opt-in to "this
-	// plugin exists"; selecting it in the picker is when external_agents
-	// flips on (handled by persistSummaryProviderSelection).
+	// (placing entire-agent-* on $PATH) is the user's opt-in to "this plugin
+	// exists", and picking it at the prompt is the opt-in to running plugins
+	// generally, which is the only thing that flips external_agents. The
+	// non-interactive branches below reach this same list without a prompt, so
+	// they select a provider but grant nothing. See summarySelectionOrigin.
 	discoverSummaryProvidersAlways(ctx)
 	candidates := listEnabledSummaryProviders(ctx)
 
@@ -91,17 +109,17 @@ func resolveCheckpointSummaryProvider(ctx context.Context, w io.Writer) (*checkp
 	case 0:
 		return nil, errors.New("no summary-capable provider is available; install claude, codex, gemini, pi, cursor, or copilot, install an external entire-agent-* plugin that declares text_generator, or set summary_generation.provider in settings")
 	case 1:
-		return autoSelectSummaryProvider(ctx, w, candidates[0].Name, "non-interactive auto-select: single installed provider")
+		return autoSelectSummaryProvider(ctx, w, candidates[0].Name, "non-interactive auto-select: single installed provider", selectionAutomatic)
 	default:
 		if !canPromptForSummaryProvider() {
-			return autoSelectSummaryProvider(ctx, w, candidates[0].Name, "non-interactive auto-select: first detected of multiple")
+			return autoSelectSummaryProvider(ctx, w, candidates[0].Name, "non-interactive auto-select: first detected of multiple", selectionAutomatic)
 		}
 
 		selected, err := promptSummaryProvider(candidates)
 		if err != nil {
 			return nil, err
 		}
-		provider, err := autoSelectSummaryProvider(ctx, w, selected, "interactive prompt selection")
+		provider, err := autoSelectSummaryProvider(ctx, w, selected, "interactive prompt selection", selectionByUser)
 		if err != nil {
 			return nil, err
 		}
@@ -110,31 +128,50 @@ func resolveCheckpointSummaryProvider(ctx context.Context, w io.Writer) (*checkp
 	}
 }
 
+// discoverSummaryProviderIfMissing resolves a configured provider name that is
+// not registered yet.
+//
+// Named, never the sweep. The name arrives from summary_generation.provider,
+// which is honored from the COMMITTED .entire/settings.json, so routing it
+// through DiscoverAndRegisterAlways would let a pull request turn one settings
+// line into "glob every absolute $PATH directory and run every
+// entire-agent-* binary's info subcommand" on whoever pulls it. The named
+// lookup returns immediately for a built-in and touches exactly one binary
+// otherwise, so the ordinary case costs nothing either.
+//
+// The error is dropped for the reason discoverNamedExternalAgent gives: the
+// caller reports an unresolvable provider a few lines later, in terms of the
+// provider the user named rather than of the plugin protocol.
 func discoverSummaryProviderIfMissing(ctx context.Context, name types.AgentName) {
 	if _, err := getSummaryAgent(name); err == nil {
 		return
 	}
-	discoverSummaryProvidersAlways(ctx)
+	//nolint:errcheck,gosec // see doc comment: ensureSummaryProviderPresent reports it
+	discoverNamedSummaryProvider(ctx, name)
 }
 
 // autoSelectSummaryProvider builds a provider for an auto-selected candidate
 // (single-installed or non-interactive-first-of-many) and persists the choice
 // so subsequent runs don't re-decide. Persistence failure is surfaced as a
 // warning — not an error — because the selection is still usable in-process.
-func autoSelectSummaryProvider(ctx context.Context, w io.Writer, name types.AgentName, reason string) (*checkpointSummaryProvider, error) {
+func autoSelectSummaryProvider(ctx context.Context, w io.Writer, name types.AgentName, reason string, origin summarySelectionOrigin) (*checkpointSummaryProvider, error) {
 	logging.Info(ctx, reason, "provider", string(name))
 	provider, err := buildCheckpointSummaryProvider(name, "")
 	if err != nil {
 		return nil, err
 	}
-	flagFlipped, saveErr := persistSummaryProviderSelection(ctx, provider.Name, provider.Model)
+	flagFlipped, saveErr := persistSummaryProviderSelection(ctx, provider.Name, provider.Model, origin)
 	if saveErr != nil {
 		logging.Warn(ctx, "failed to save summary provider selection, continuing without persistence",
 			"error", saveErr.Error())
 		fmt.Fprintf(w, "Warning: could not save provider selection: %v\nUse `entire configure --summarize-provider %s` to set it manually.\n", saveErr, provider.Name)
 	}
+	// Verified, not assumed: persistSummaryProviderSelection writes the grant
+	// into settings.local.json, and a tracked one is dropped wholesale on the
+	// next load. Announcing the flip without reading it back is the same false
+	// claim enableExternalAgentsLocally now avoids.
 	if flagFlipped {
-		fmt.Fprintln(w, externalAgentsAutoEnabledNotice)
+		reportExternalAgentsGrant(w, verifyExternalAgentsGrant(ctx))
 	}
 	return provider, nil
 }
@@ -264,7 +301,7 @@ func validateSummaryProvider(provider string) error {
 // plugin can actually run; in that case it returns flagFlipped=true so the
 // caller can surface a one-time notice. The flag is written to local because
 // the provider choice is already machine-specific (depends on $PATH).
-func persistSummaryProviderSelection(ctx context.Context, provider types.AgentName, model string) (flagFlipped bool, err error) {
+func persistSummaryProviderSelection(ctx context.Context, provider types.AgentName, model string, origin summarySelectionOrigin) (flagFlipped bool, err error) {
 	targetFileAbs, err := paths.AbsPath(ctx, settings.EntireSettingsLocalFile)
 	if err != nil {
 		targetFileAbs = settings.EntireSettingsLocalFile
@@ -279,9 +316,17 @@ func persistSummaryProviderSelection(ctx context.Context, provider types.AgentNa
 	}
 	s.SummaryGeneration.SetProvider(string(provider), model)
 
-	if ag, getErr := getSummaryAgent(provider); getErr == nil && external.IsExternal(ag) && !s.ExternalAgents {
-		s.ExternalAgents = true
-		flagFlipped = true
+	// Only a human's pick grants external_agents. The provider name is
+	// persisted either way — it decides nothing on its own, and it is what
+	// stops the next run re-deciding. An automatically chosen external
+	// provider keeps working without the grant, because
+	// discoverSummaryProviderIfMissing resolves a configured name through the
+	// named ungated lookup rather than through the sweep the grant enables.
+	if origin == selectionByUser {
+		if ag, getErr := getSummaryAgent(provider); getErr == nil && external.IsExternal(ag) && !s.ExternalAgents {
+			s.ExternalAgents = true
+			flagFlipped = true
+		}
 	}
 
 	if err := saveLocalSummarySettings(ctx, s); err != nil {

--- a/cmd/entire/cli/explain_summary_provider_test.go
+++ b/cmd/entire/cli/explain_summary_provider_test.go
@@ -166,14 +166,14 @@ func TestResolveDispatchSummaryProvider_ExplicitCodexUsesDefaultModelWithoutPers
 	originalSave := saveLocalSummarySettings
 	originalGet := getSummaryAgent
 	originalCLI := isSummaryCLIAvailable
-	originalDiscover := discoverDispatchSummaryProvider
+	originalDiscover := discoverNamedSummaryProvider
 	t.Cleanup(func() {
 		loadSummarySettings = originalLoad
 		loadSummarySettingsFromFile = originalLoadFile
 		saveLocalSummarySettings = originalSave
 		getSummaryAgent = originalGet
 		isSummaryCLIAvailable = originalCLI
-		discoverDispatchSummaryProvider = originalDiscover
+		discoverNamedSummaryProvider = originalDiscover
 	})
 
 	loadSummarySettings = func(context.Context) (*settings.EntireSettings, error) {
@@ -197,7 +197,7 @@ func TestResolveDispatchSummaryProvider_ExplicitCodexUsesDefaultModelWithoutPers
 	isSummaryCLIAvailable = func(name types.AgentName) bool {
 		return name == agent.AgentNameCodex
 	}
-	discoverDispatchSummaryProvider = func(context.Context, types.AgentName) error {
+	discoverNamedSummaryProvider = func(context.Context, types.AgentName) error {
 		t.Fatal("registered explicit provider should not trigger external discovery")
 		return nil
 	}
@@ -346,16 +346,16 @@ func TestResolveDispatchSummaryProvider_PropagatesDiscoveryDeadline(t *testing.T
 	providerName := types.AgentName("external-discovery-deadline")
 
 	originalGet := getSummaryAgent
-	originalDiscover := discoverDispatchSummaryProvider
+	originalDiscover := discoverNamedSummaryProvider
 	t.Cleanup(func() {
 		getSummaryAgent = originalGet
-		discoverDispatchSummaryProvider = originalDiscover
+		discoverNamedSummaryProvider = originalDiscover
 	})
 
 	getSummaryAgent = func(types.AgentName) (agent.Agent, error) {
 		return nil, errors.New("not registered")
 	}
-	discoverDispatchSummaryProvider = func(context.Context, types.AgentName) error {
+	discoverNamedSummaryProvider = func(context.Context, types.AgentName) error {
 		return fmt.Errorf("discovering external agent %q: %w", providerName, context.DeadlineExceeded)
 	}
 
@@ -373,16 +373,16 @@ func TestResolveDispatchSummaryProvider_PropagatesDiscoveryCancellation(t *testi
 	providerName := types.AgentName("external-discovery-canceled")
 
 	originalGet := getSummaryAgent
-	originalDiscover := discoverDispatchSummaryProvider
+	originalDiscover := discoverNamedSummaryProvider
 	t.Cleanup(func() {
 		getSummaryAgent = originalGet
-		discoverDispatchSummaryProvider = originalDiscover
+		discoverNamedSummaryProvider = originalDiscover
 	})
 
 	getSummaryAgent = func(types.AgentName) (agent.Agent, error) {
 		return nil, errors.New("not registered")
 	}
-	discoverDispatchSummaryProvider = func(context.Context, types.AgentName) error {
+	discoverNamedSummaryProvider = func(context.Context, types.AgentName) error {
 		return fmt.Errorf("discovering external agent %q: %w", providerName, context.Canceled)
 	}
 
@@ -401,16 +401,16 @@ func TestResolveDispatchSummaryProvider_PropagatesInvalidExternalInfo(t *testing
 	infoErr := errors.New("invalid helper info")
 
 	originalGet := getSummaryAgent
-	originalDiscover := discoverDispatchSummaryProvider
+	originalDiscover := discoverNamedSummaryProvider
 	t.Cleanup(func() {
 		getSummaryAgent = originalGet
-		discoverDispatchSummaryProvider = originalDiscover
+		discoverNamedSummaryProvider = originalDiscover
 	})
 
 	getSummaryAgent = func(types.AgentName) (agent.Agent, error) {
 		return nil, errors.New("not registered")
 	}
-	discoverDispatchSummaryProvider = func(context.Context, types.AgentName) error {
+	discoverNamedSummaryProvider = func(context.Context, types.AgentName) error {
 		return fmt.Errorf("loading info for external agent %q: info: invalid JSON: %w", providerName, infoErr)
 	}
 
@@ -431,16 +431,16 @@ func TestResolveDispatchSummaryProvider_MissingExternalKeepsUnknownProviderError
 	providerName := types.AgentName("external-discovery-missing")
 
 	originalGet := getSummaryAgent
-	originalDiscover := discoverDispatchSummaryProvider
+	originalDiscover := discoverNamedSummaryProvider
 	t.Cleanup(func() {
 		getSummaryAgent = originalGet
-		discoverDispatchSummaryProvider = originalDiscover
+		discoverNamedSummaryProvider = originalDiscover
 	})
 
 	getSummaryAgent = func(types.AgentName) (agent.Agent, error) {
 		return nil, errors.New("not registered")
 	}
-	discoverDispatchSummaryProvider = func(context.Context, types.AgentName) error { return nil }
+	discoverNamedSummaryProvider = func(context.Context, types.AgentName) error { return nil }
 
 	_, err := resolveDispatchSummaryProvider(context.Background(), &bytes.Buffer{}, string(providerName))
 	if err == nil || !strings.Contains(err.Error(), "unknown summary provider") {
@@ -490,11 +490,11 @@ func TestResolveDispatchSummaryProvider_ExplicitValidationErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			originalGet := getSummaryAgent
 			originalCLI := isSummaryCLIAvailable
-			originalDiscover := discoverDispatchSummaryProvider
+			originalDiscover := discoverNamedSummaryProvider
 			t.Cleanup(func() {
 				getSummaryAgent = originalGet
 				isSummaryCLIAvailable = originalCLI
-				discoverDispatchSummaryProvider = originalDiscover
+				discoverNamedSummaryProvider = originalDiscover
 			})
 
 			getSummaryAgent = func(types.AgentName) (agent.Agent, error) {
@@ -504,7 +504,7 @@ func TestResolveDispatchSummaryProvider_ExplicitValidationErrors(t *testing.T) {
 				return tt.agent, nil
 			}
 			isSummaryCLIAvailable = func(types.AgentName) bool { return tt.available }
-			discoverDispatchSummaryProvider = func(context.Context, types.AgentName) error { return nil }
+			discoverNamedSummaryProvider = func(context.Context, types.AgentName) error { return nil }
 
 			_, err := resolveDispatchSummaryProvider(context.Background(), &bytes.Buffer{}, tt.override)
 			if err == nil {
@@ -858,7 +858,7 @@ func TestPersistSummaryProviderSelection_ExternalFlipsFlagAndReturnsSignal(t *te
 	// Discover so getSummaryAgent returns a wrapped external (the type IsExternal recognizes).
 	discoverSummaryProvidersAlways(ctx)
 
-	flagFlipped, err := persistSummaryProviderSelection(ctx, types.AgentName(providerName), "")
+	flagFlipped, err := persistSummaryProviderSelection(ctx, types.AgentName(providerName), "", selectionByUser)
 	if err != nil {
 		t.Fatalf("persistSummaryProviderSelection() error = %v", err)
 	}
@@ -892,7 +892,7 @@ func TestPersistSummaryProviderSelection_BuiltInDoesNotFlipFlag(t *testing.T) {
 		t.Fatalf("write settings: %v", err)
 	}
 
-	flagFlipped, err := persistSummaryProviderSelection(ctx, agent.AgentNameClaudeCode, "")
+	flagFlipped, err := persistSummaryProviderSelection(ctx, agent.AgentNameClaudeCode, "", selectionByUser)
 	if err != nil {
 		t.Fatalf("persistSummaryProviderSelection() error = %v", err)
 	}
@@ -934,11 +934,136 @@ func TestPersistSummaryProviderSelection_ExternalAlreadyEnabledNoSignal(t *testi
 
 	discoverSummaryProvidersAlways(ctx)
 
-	flagFlipped, err := persistSummaryProviderSelection(ctx, types.AgentName(providerName), "")
+	flagFlipped, err := persistSummaryProviderSelection(ctx, types.AgentName(providerName), "", selectionByUser)
 	if err != nil {
 		t.Fatalf("persistSummaryProviderSelection() error = %v", err)
 	}
 	if flagFlipped {
 		t.Fatal("expected flagFlipped=false when external_agents was already enabled")
+	}
+}
+
+// TestResolveCheckpointSummaryProvider_ConfiguredProviderUsesNamedDiscovery
+// pins that a configured-but-unregistered provider is resolved by NAME rather
+// than by the ungated sweep.
+//
+// summary_generation.provider is honored from the committed
+// .entire/settings.json, so a name that arrives there must not be able to
+// trigger DiscoverAndRegisterAlways, which globs every absolute $PATH
+// directory and executes every entire-agent-* binary's "info" subcommand. The
+// named lookup returns immediately for a built-in and touches exactly one
+// binary otherwise.
+func TestResolveCheckpointSummaryProvider_ConfiguredProviderUsesNamedDiscovery(t *testing.T) {
+	// Cannot use t.Parallel(): mutates package-level resolution seams.
+	ctx := context.Background()
+	const configuredName = types.AgentName("external-configured-provider")
+	stub := &stubTextAgent{name: configuredName, kind: agent.AgentTypeClaudeCode}
+
+	originalLoad := loadSummarySettings
+	originalGet := getSummaryAgent
+	originalCLI := isSummaryCLIAvailable
+	originalSweep := discoverSummaryProvidersAlways
+	originalNamed := discoverNamedSummaryProvider
+	t.Cleanup(func() {
+		loadSummarySettings = originalLoad
+		getSummaryAgent = originalGet
+		isSummaryCLIAvailable = originalCLI
+		discoverSummaryProvidersAlways = originalSweep
+		discoverNamedSummaryProvider = originalNamed
+	})
+
+	loadSummarySettings = func(context.Context) (*settings.EntireSettings, error) {
+		return &settings.EntireSettings{SummaryGeneration: &settings.SummaryGenerationSettings{
+			Provider: string(configuredName),
+		}}, nil
+	}
+	// Unregistered until the named discovery runs, which is what makes
+	// discoverSummaryProviderIfMissing reach for discovery at all.
+	registered := false
+	getSummaryAgent = func(name types.AgentName) (agent.Agent, error) {
+		if !registered {
+			return nil, fmt.Errorf("agent %q not registered", name)
+		}
+		return stub, nil
+	}
+	isSummaryCLIAvailable = func(types.AgentName) bool { return true }
+	discoverSummaryProvidersAlways = func(context.Context) {
+		t.Fatal("a configured provider name must not trigger the ungated $PATH sweep")
+	}
+	namedCalls := 0
+	discoverNamedSummaryProvider = func(_ context.Context, name types.AgentName) error {
+		namedCalls++
+		if name != configuredName {
+			t.Fatalf("named discovery for %q, want %q", name, configuredName)
+		}
+		registered = true
+		return nil
+	}
+
+	provider, err := resolveCheckpointSummaryProvider(ctx, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("resolveCheckpointSummaryProvider() error = %v", err)
+	}
+	if provider.Name != configuredName {
+		t.Fatalf("provider.Name = %q, want %q", provider.Name, configuredName)
+	}
+	if namedCalls != 1 {
+		t.Fatalf("named discovery called %d times, want exactly 1", namedCalls)
+	}
+}
+
+// TestPersistSummaryProviderSelection_AutoSelectDoesNotGrantExternalAgents
+// pins that the repo-wide external_agents grant needs a human.
+//
+// The non-interactive branches of resolveCheckpointSummaryProvider auto-select
+// (single candidate, or first-of-many with no TTY) and used to persist the
+// grant on the way through. That grant is not scoped to the chosen provider:
+// it turns on the $PATH sweep that runs every entire-agent-* binary from then
+// on, so it must not be minted by a code path where nobody chose anything. The
+// chosen provider still resolves on later runs without it, through the named
+// ungated lookup in discoverSummaryProviderIfMissing.
+func TestPersistSummaryProviderSelection_AutoSelectDoesNotGrantExternalAgents(t *testing.T) {
+	// Cannot use t.Parallel(): mutates the package-level agent registry via discovery.
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	t.Chdir(tmpDir)
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755); err != nil {
+		t.Fatalf("mkdir .entire: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".entire", "settings.json"), []byte(`{"enabled":true}`), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	const providerName = "external-summary-autoselect"
+	externalDir := t.TempDir()
+	writeExternalSummaryAgentBinary(t, externalDir, providerName)
+	t.Setenv("PATH", externalDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	discoverSummaryProvidersAlways(ctx)
+
+	flagFlipped, err := persistSummaryProviderSelection(ctx, types.AgentName(providerName), "", selectionAutomatic)
+	if err != nil {
+		t.Fatalf("persistSummaryProviderSelection() error = %v", err)
+	}
+	if flagFlipped {
+		t.Error("an automatic selection must not flip external_agents")
+	}
+
+	s, err := settings.LoadFromFile(filepath.Join(tmpDir, ".entire", "settings.local.json"))
+	if err != nil {
+		t.Fatalf("LoadFromFile() error = %v", err)
+	}
+	if s.ExternalAgents {
+		t.Error("external_agents granted without a human choosing the provider")
+	}
+	// The provider choice itself is still worth persisting: it is what keeps
+	// the next run from re-deciding, and it grants nothing on its own.
+	if s.SummaryGeneration == nil || s.SummaryGeneration.Provider != providerName {
+		t.Fatalf("provider not persisted; got %+v", s.SummaryGeneration)
 	}
 }

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -971,7 +971,14 @@ func TestMaybeCompactExternalTranscriptForSummary_RedactsExternalOutput(t *testi
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(tmpDir, ".entire", "settings.json"),
-		[]byte(`{"enabled":true,"external_agents":true}`),
+		[]byte(`{"enabled":true}`),
+		0o644,
+	))
+	// external_agents lives in the local file: it grants execution of
+	// entire-agent-* binaries on $PATH, so the loader honors it only there.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, ".entire", "settings.local.json"),
+		[]byte(`{"external_agents":true}`),
 		0o644,
 	))
 
@@ -2203,7 +2210,14 @@ func setupExternalTranscriptExplainRepo(t *testing.T) (*git.Repository, string) 
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(tmpDir, ".entire", "settings.json"),
-		[]byte(`{"enabled":true,"external_agents":true}`),
+		[]byte(`{"enabled":true}`),
+		0o644,
+	))
+	// external_agents lives in the local file: it grants execution of
+	// entire-agent-* binaries on $PATH, so the loader honors it only there.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, ".entire", "settings.local.json"),
+		[]byte(`{"external_agents":true}`),
 		0o644,
 	))
 

--- a/cmd/entire/cli/hooks_git_cmd_test.go
+++ b/cmd/entire/cli/hooks_git_cmd_test.go
@@ -131,14 +131,20 @@ func TestHooksGitCmd_DiscoverExternalAgents_WhenEnabled(t *testing.T) {
 	// Reset global state before the test
 	gitHooksDisabled = false
 
-	// Create .entire/settings.json with enabled: true and external_agents: true
+	// Create .entire/settings.json with enabled: true, and external_agents in
+	// the local file — the only place the loader honors that grant, since it
+	// enables execution of entire-agent-* binaries found on $PATH.
 	entireDir := filepath.Join(tmpDir, paths.EntireDir)
 	if err := os.MkdirAll(entireDir, 0o755); err != nil {
 		t.Fatalf("failed to create .entire directory: %v", err)
 	}
 	settingsFile := filepath.Join(entireDir, "settings.json")
-	if err := os.WriteFile(settingsFile, []byte(`{"enabled":true,"external_agents":true}`), 0o644); err != nil {
+	if err := os.WriteFile(settingsFile, []byte(`{"enabled":true}`), 0o644); err != nil {
 		t.Fatalf("failed to write settings file: %v", err)
+	}
+	localSettingsFile := filepath.Join(entireDir, "settings.local.json")
+	if err := os.WriteFile(localSettingsFile, []byte(`{"external_agents":true}`), 0o644); err != nil {
+		t.Fatalf("failed to write local settings file: %v", err)
 	}
 
 	// Create a mock external agent binary in a temp PATH directory.

--- a/cmd/entire/cli/plugin.go
+++ b/cmd/entire/cli/plugin.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
+	"github.com/entireio/cli/cmd/entire/cli/execx"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
@@ -127,28 +128,21 @@ func resolvePlugin(rootCmd *cobra.Command, args []string) (binPath string, plugi
 // indicates the file exists but lacks the executable bit (or the
 // equivalent platform-specific accessibility).
 //
-// Only ABSOLUTE PATH entries are scanned. A relative entry (including bare
-// "." and the empty string, which POSIX treats as the current directory) is
-// skipped outright, even if it points at a real, inaccessible file. That
-// mirrors exec.LookPath's own refusal: when LookPath finds a binary via a
-// relative PATH entry it deliberately returns exec.ErrDot rather than
-// resolving it — the fix for the classic "dot in PATH" RCE class, where a
-// planted binary in an untrusted working directory silently executes with
-// the user's privileges. LookPath's error does not distinguish ErrDot from
-// a genuine "exists but not executable" case, so if this function re-walked
-// relative entries too, it would blindly re-find and return the exact
-// binary LookPath just correctly refused — and the caller (runPlugin) execs
-// it via a path that contains a separator, which bypasses Go's exec.Command
-// ErrDot re-check (that only fires for a bare name with no separator). Do
-// not remove this filter without also making resolvePlugin ErrDot-aware
-// some other way.
+// The scan goes through execx.PathScanDirs, not a bare split: the rule that
+// only absolute entries are scanned is shared with the external-agent
+// scanner, and two copies of it is how they drifted apart in the first place.
+// The rule matters especially here, because this function runs only after
+// LookPath has failed. LookPath's error does not distinguish exec.ErrDot (its
+// refusal to resolve a match found through a relative PATH entry) from a
+// genuine "exists but not executable", so a scan that re-walked relative
+// entries would blindly re-find the exact binary LookPath just correctly
+// refused. runPlugin then execs it via a path containing a separator, which
+// bypasses exec.Command's own ErrDot re-check, since that only fires for a
+// bare name with no separator.
 func findInaccessiblePlugin(filename string) (string, bool) {
-	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
-		if dir == "" || !filepath.IsAbs(dir) {
-			continue
-		}
+	for _, dir := range execx.PathScanDirs() {
 		candidate := filepath.Join(dir, filename)
-		info, err := os.Stat(candidate) //nolint:gosec // PATH entries are user-trusted; scanning them is the point.
+		info, err := os.Stat(candidate)
 		if err != nil || info.IsDir() {
 			continue
 		}

--- a/cmd/entire/cli/plugin_store.go
+++ b/cmd/entire/cli/plugin_store.go
@@ -48,6 +48,28 @@ const (
 	pluginManagedSubDir = "plugins"
 )
 
+// requireAbsPluginParent rejects a non-absolute directory override.
+//
+// A relative value resolves against the process's working directory at
+// startup — typically inside the user's repository — which is the wrong place
+// for managed plugin storage, and it is storage whose bin subdirectory main.go
+// prepends to $PATH. Every override reaching pluginParentDir gets this check,
+// not just ENTIRE_PLUGIN_DIR: XDG_DATA_HOME and LOCALAPPDATA were joined
+// unchecked and left for osroot (which refuses the root open) and for main.go
+// (which restores $PATH) to notice. Those backstops hold today, but they state
+// the invariant two layers away from where it is decided, and each answers a
+// question of its own rather than this one.
+//
+// Rejecting is louder than falling through to the platform default: a
+// misconfigured override is a user error worth surfacing, not something to
+// paper over with a different directory than the one they asked for.
+func requireAbsPluginParent(name, value string) error {
+	if !filepath.IsAbs(value) {
+		return fmt.Errorf("%s must be an absolute path, got %q", name, value)
+	}
+	return nil
+}
+
 // pluginParentDir returns the per-user directory that holds the managed
 // plugin storage. Resolution, in order:
 //
@@ -63,20 +85,17 @@ const (
 // degenerate environment with $LOCALAPPDATA or $XDG_DATA_HOME but no home
 // still returns a usable path.
 func pluginParentDir() (string, error) {
-	// ENTIRE_PLUGIN_DIR must be absolute. A relative value would resolve
-	// against the user's CWD at startup — typically inside their repo —
-	// which is the wrong place for managed plugin storage. Reject loudly
-	// rather than silently falling through to the platform default, since
-	// a misconfigured override is almost certainly a user error worth
-	// surfacing.
 	if v := os.Getenv(pluginEnvPluginDir); v != "" {
-		if !filepath.IsAbs(v) {
-			return "", fmt.Errorf("%s must be an absolute path, got %q", pluginEnvPluginDir, v)
+		if err := requireAbsPluginParent(pluginEnvPluginDir, v); err != nil {
+			return "", err
 		}
 		return v, nil
 	}
 	if runtime.GOOS == windowsGOOS {
 		if appData := os.Getenv("LOCALAPPDATA"); appData != "" {
+			if err := requireAbsPluginParent("LOCALAPPDATA", appData); err != nil {
+				return "", err
+			}
 			return filepath.Join(appData, pluginManagedTopDir, pluginManagedSubDir), nil
 		}
 		home, err := os.UserHomeDir()
@@ -86,6 +105,9 @@ func pluginParentDir() (string, error) {
 		return filepath.Join(home, "AppData", "Local", pluginManagedTopDir, pluginManagedSubDir), nil
 	}
 	if v := os.Getenv("XDG_DATA_HOME"); v != "" {
+		if err := requireAbsPluginParent("XDG_DATA_HOME", v); err != nil {
+			return "", err
+		}
 		return filepath.Join(v, pluginManagedTopDir, pluginManagedSubDir), nil
 	}
 	home, err := os.UserHomeDir()

--- a/cmd/entire/cli/plugin_store_test.go
+++ b/cmd/entire/cli/plugin_store_test.go
@@ -540,3 +540,23 @@ func TestInstallPluginFromPath_AtomicForceReplace(t *testing.T) { //nolint:paral
 		t.Errorf("dest missing after force replace: %v", err)
 	}
 }
+
+// TestPluginParentDir_RejectsRelativePlatformOverride pins the invariant at
+// the place it is defined. ENTIRE_PLUGIN_DIR has always been checked; the
+// platform variables were joined unchecked and left to osroot and to main.go's
+// PATH restore to notice. Downstream backstops answer a different question and
+// answer it far from the cause.
+func TestPluginParentDir_RejectsRelativePlatformOverride(t *testing.T) { //nolint:paralleltest // mutates env
+	t.Setenv(pluginEnvPluginDir, "")
+	varName := "XDG_DATA_HOME"
+	if runtime.GOOS == windowsGOOS {
+		varName = "LOCALAPPDATA"
+	}
+	for _, value := range []string{"data-relative", "."} {
+		t.Setenv(varName, value)
+		got, err := pluginParentDir()
+		if err == nil {
+			t.Errorf("pluginParentDir with %s=%q = %q, nil error; want error", varName, value, got)
+		}
+	}
+}

--- a/cmd/entire/cli/plugin_test.go
+++ b/cmd/entire/cli/plugin_test.go
@@ -308,3 +308,23 @@ func equalStrings(a, b []string) bool {
 	}
 	return true
 }
+
+// TestFindInaccessiblePlugin_SkipsRelativePATHEntry pins that the fallback
+// scan honours the same absolute-only rule as every other $PATH scanner: a
+// file in a repository the user happens to be standing in is not a plugin.
+func TestFindInaccessiblePlugin_SkipsRelativePATHEntry(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	relDir := "planted"
+	if err := os.MkdirAll(filepath.Join(dir, relDir), 0o755); err != nil {
+		t.Fatalf("create planted dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, relDir, "entire-planted"), []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatalf("write planted file: %v", err)
+	}
+	t.Setenv("PATH", relDir)
+
+	if got, found := findInaccessiblePlugin("entire-planted"); found {
+		t.Errorf("findInaccessiblePlugin found %q via a relative $PATH entry, want no match", got)
+	}
+}

--- a/cmd/entire/cli/settings/external_agents_trust.go
+++ b/cmd/entire/cli/settings/external_agents_trust.go
@@ -1,0 +1,78 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// externalAgentsRejectionNotLocal and ...NotVerified explain why an
+// external_agents grant was dropped. They mirror the OPF command's reasons
+// because the hazard is the same one: a JSON settings diff that grants
+// execution does not read as executable to a reviewer.
+const (
+	externalAgentsRejectionNotLocal   = "it did not come from .entire/settings.local.json"
+	externalAgentsRejectionUnverified = "the local settings file could not be verified as untracked"
+)
+
+// enforceExternalAgentsTrust drops external_agents unless it came from a local
+// file positively verified as this developer's own.
+//
+// external_agents is not a preference. It turns on the $PATH scan that globs
+// for entire-agent-* binaries and runs each one's "info" subcommand, and it
+// keeps running them for every hook thereafter. Honoring it from the
+// version-controlled .entire/settings.json would let an ordinary pull request
+// pair `{"external_agents": true}` with a binary committed next to it (or
+// merely present on a shared machine's $PATH) and get it executed on every
+// developer who pulls. The reasoning in enforceOPFCommandTrust applies
+// unchanged: one line of JSON is a poor place to hide an exec grant, and there
+// is no prompt in front of this one at all.
+//
+// localData is the raw local-file bytes, nil when the file is absent or its
+// layer was dropped as tracked. The deep (index AND HEAD) check is used and
+// localOwn is required: like the OPF command and unlike the layer as a whole,
+// an unverifiable repository fails CLOSED, because being wrong means running
+// someone else's binary rather than losing a preference.
+//
+// Rejection is a downgrade, never an error. Discovery simply does not run, and
+// the user's own agents are unaffected — the interactive setup flows call
+// DiscoverAndRegisterAlways and reach external plugins regardless, so the
+// remedy stays available from the command that needs it.
+func enforceExternalAgentsTrust(ctx context.Context, s *EntireSettings, localSettingsPath string, localData []byte) {
+	// Only a true value grants anything, so only a true value is gated.
+	// Warning about a false one would be noise about a privilege nobody asked
+	// for.
+	if s == nil || !s.ExternalAgents {
+		return
+	}
+
+	var reason string
+	switch {
+	case !localSetsExternalAgents(localData):
+		reason = externalAgentsRejectionNotLocal
+	case classifyLocalSettingsDeep(ctx, localSettingsPath) != localOwn:
+		reason = externalAgentsRejectionUnverified
+	default:
+		return
+	}
+
+	// Recorded rather than logged, for the reasons in enforceOPFCommandTrust:
+	// the loader runs while the log level is still being resolved, and a line
+	// in .entire/logs is not a signal the user sees.
+	s.externalAgentsRejection = reason
+	s.ExternalAgents = false
+}
+
+// localSetsExternalAgents reports whether the local override file explicitly
+// sets external_agents.
+//
+// Presence of the key is what matters, not the merged value: both files may
+// set true, and comparing effective values after the merge would credit the
+// project layer for the local file's grant. A malformed local file yields
+// false, the safe direction — the merge reports the parse error separately.
+func localSetsExternalAgents(data []byte) bool {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+	return rawHasKey(raw, "external_agents")
+}

--- a/cmd/entire/cli/settings/external_agents_trust_test.go
+++ b/cmd/entire/cli/settings/external_agents_trust_test.go
@@ -1,0 +1,148 @@
+package settings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// loadedExternalAgents runs the real merge path and reports the effective
+// setting plus its rejection, if any.
+func loadedExternalAgents(t *testing.T, projectPath, localPath string) (bool, string, bool) {
+	t.Helper()
+	s, err := loadMergedSettings(t.Context(), projectPath, "", localPath)
+	require.NoError(t, err)
+	reason, rejected := s.ExternalAgentsRejection()
+	return s.ExternalAgents, reason, rejected
+}
+
+// external_agents turns on $PATH scanning and execution of entire-agent-*
+// binaries. Delivered through the version-controlled project file it is an
+// ordinary-looking JSON diff that grants exec, so it must not take effect.
+func TestExternalAgentsTrust_ProjectSettingIsIgnored(t *testing.T) {
+	t.Parallel()
+	_, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true,"external_agents":true}`)
+
+	enabled, reason, rejected := loadedExternalAgents(t, project, local)
+
+	assert.False(t, enabled, "external_agents from the committed project file must be dropped")
+	assert.True(t, rejected, "the rejection must be reportable to the consumer")
+	assert.Contains(t, reason, "settings.local.json", "the reason names where the setting must live")
+}
+
+func TestExternalAgentsTrust_UntrackedLocalSettingIsHonored(t *testing.T) {
+	t.Parallel()
+	_, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true}`)
+	writeSettingsFile(t, local, `{"external_agents":true}`)
+
+	enabled, _, rejected := loadedExternalAgents(t, project, local)
+
+	assert.True(t, enabled, "an untracked local override is developer-owned and must be honored")
+	assert.False(t, rejected, "a trusted setting must not be reported as rejected")
+}
+
+func TestExternalAgentsTrust_StagedLocalFileIsIgnored(t *testing.T) {
+	t.Parallel()
+	root, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true}`)
+	writeSettingsFile(t, local, `{"external_agents":true}`)
+
+	testutil.RunGit(t, root, "add", "-f", EntireSettingsLocalFile)
+
+	s, err := loadMergedSettings(t.Context(), project, "", local)
+	require.NoError(t, err)
+
+	assert.False(t, s.ExternalAgents, "a local file tracked in the index must not be trusted")
+	// The whole layer is already dropped here, so the user's signal is the
+	// layer rejection: reporting the grant separately would say the same
+	// thing twice about one file.
+	assert.NotEmpty(t, s.LocalLayerRejection(), "the tracked layer must still be reported")
+	_, rejected := s.ExternalAgentsRejection()
+	assert.False(t, rejected, "the layer rejection already names the file and the fix")
+}
+
+func TestExternalAgentsTrust_CommittedThenUnstagedIsIgnored(t *testing.T) {
+	t.Parallel()
+	root, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true}`)
+	writeSettingsFile(t, local, `{"external_agents":true}`)
+
+	testutil.RunGit(t, root, "add", "-f", EntireSettingsLocalFile)
+	testutil.RunGit(t, root, "commit", "-m", "carry local settings")
+	testutil.RunGit(t, root, "rm", "--cached", EntireSettingsLocalFile)
+
+	enabled, _, _ := loadedExternalAgents(t, project, local)
+
+	assert.False(t, enabled, "content still reachable from HEAD must not be trusted")
+}
+
+// With no repository there is nothing to have cloned the file from, so it is
+// definitively this developer's own.
+func TestExternalAgentsTrust_OutsideGitRepoHonorsLocal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o755))
+	project := filepath.Join(dir, EntireSettingsFile)
+	local := filepath.Join(dir, EntireSettingsLocalFile)
+	writeSettingsFile(t, project, `{"enabled":true}`)
+	writeSettingsFile(t, local, `{"external_agents":true}`)
+
+	enabled, _, rejected := loadedExternalAgents(t, project, local)
+
+	assert.True(t, enabled, "with no repository the local file cannot have arrived by cloning")
+	assert.False(t, rejected, "no rejection when there is nothing to distrust")
+}
+
+// Same divergence as the OPF command: an unreadable repository keeps the
+// layer but fails closed on the exec-granting setting.
+func TestExternalAgentsTrust_UnverifiableRepoKeepsLayerDropsSetting(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755)) // present but not a repo
+	project := filepath.Join(dir, EntireSettingsFile)
+	local := filepath.Join(dir, EntireSettingsLocalFile)
+	writeSettingsFile(t, project, `{"enabled":true}`)
+	writeSettingsFile(t, local, `{"external_agents":true,"commit_linking":"always"}`)
+
+	s, err := loadMergedSettings(t.Context(), project, "", local)
+	require.NoError(t, err)
+
+	assert.False(t, s.ExternalAgents, "an unverifiable repo must not grant PATH execution")
+	assert.Equal(t, "always", s.CommitLinking, "unrelated local settings must survive")
+	assert.Empty(t, s.LocalLayerRejection(), "the layer itself was kept")
+}
+
+// A local file that says nothing about external_agents does not vouch for a
+// project file that does.
+func TestExternalAgentsTrust_LocalFileWithoutSettingDoesNotVouch(t *testing.T) {
+	t.Parallel()
+	_, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true,"external_agents":true}`)
+	writeSettingsFile(t, local, `{"commit_linking":"always"}`)
+
+	enabled, _, rejected := loadedExternalAgents(t, project, local)
+
+	assert.False(t, enabled, "presence of an unrelated local file is not consent")
+	assert.True(t, rejected, "the rejection must be reportable")
+}
+
+// Off is the default and grants nothing, so there is nothing to gate: a
+// project file that leaves it off must not produce a rejection notice.
+func TestExternalAgentsTrust_DisabledSettingIsNotRejected(t *testing.T) {
+	t.Parallel()
+	_, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true,"external_agents":false}`)
+
+	enabled, _, rejected := loadedExternalAgents(t, project, local)
+
+	assert.False(t, enabled)
+	assert.False(t, rejected, "a setting that grants nothing needs no warning")
+}

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -82,6 +82,12 @@ type EntireSettings struct {
 	// Unexported so it never serializes. Surfaced via LocalLayerRejection.
 	localLayerRejection string
 
+	// externalAgentsRejection records why an external_agents grant was
+	// dropped by the trust gate, for the consumer to report. Unexported so it
+	// never serializes — a rejected grant must not be written back to disk as
+	// if the user had turned it off. See enforceExternalAgentsTrust.
+	externalAgentsRejection string
+
 	// Enabled indicates whether Entire is active. When false, CLI commands
 	// show a disabled message and hooks exit silently. Defaults to true.
 	Enabled bool `json:"enabled"`
@@ -149,6 +155,13 @@ type EntireSettings struct {
 
 	// ExternalAgents enables discovery and registration of external agent
 	// plugins (entire-agent-* binaries on $PATH). Defaults to false.
+	//
+	// Discovery executes what it finds, so Load() honors a true value only
+	// when it is developer-owned — set in an untracked
+	// .entire/settings.local.json — and resets it to false otherwise. See
+	// enforceExternalAgentsTrust. Readers that obtain settings by any route
+	// other than Load() (LoadFromFile, LoadFromBytes) get the ungated value
+	// and must not scan $PATH on it.
 	ExternalAgents bool `json:"external_agents,omitempty"`
 
 	// AsyncMirrorRequests selects the mirror creation route.
@@ -512,6 +525,17 @@ func (s *EntireSettings) LocalLayerRejection() string {
 	return s.localLayerRejection
 }
 
+// ExternalAgentsRejection reports why Load dropped an external_agents grant as
+// untrusted, and whether a rejection happened. Callers that would otherwise
+// scan $PATH should surface it — it is the only signal that a setting the user
+// can see in their settings file is not in effect.
+func (s *EntireSettings) ExternalAgentsRejection() (reason string, rejected bool) {
+	if s == nil || s.externalAgentsRejection == "" {
+		return "", false
+	}
+	return s.externalAgentsRejection, true
+}
+
 // InvestigateConfig returns the configured investigate config. Returns nil
 // when no configuration is present; callers should check IsZero (or guard
 // for nil) to decide whether configuration is present.
@@ -675,8 +699,11 @@ func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs
 	}
 
 	// openai_privacy_filter.command is executed, so it is honored only from a
-	// local file positively verified as this developer's own.
+	// local file positively verified as this developer's own. external_agents
+	// grants execution of every entire-agent-* binary on $PATH, so it gets the
+	// same gate.
 	enforceOPFCommandTrust(ctx, settings, localSettingsFileAbs, localData)
+	enforceExternalAgentsTrust(ctx, settings, localSettingsFileAbs, localData)
 
 	// Re-validate after merge. Individual files are validated by loadFromFile,
 	// but mergeJSON patches fields independently and can produce combinations

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -590,9 +590,16 @@ func TestLoad_ExternalAgentsField(t *testing.T) {
 		t.Fatalf("failed to create .entire directory: %v", err)
 	}
 
+	// The local file, not settings.json: external_agents grants execution of
+	// entire-agent-* binaries on $PATH, so it is honored only from an
+	// untracked local override. See enforceExternalAgentsTrust.
 	settingsFile := filepath.Join(entireDir, "settings.json")
-	if err := os.WriteFile(settingsFile, []byte(`{"enabled": true, "external_agents": true}`), 0o644); err != nil {
+	if err := os.WriteFile(settingsFile, []byte(`{"enabled": true}`), 0o644); err != nil {
 		t.Fatalf("failed to write settings file: %v", err)
+	}
+	localFile := filepath.Join(entireDir, "settings.local.json")
+	if err := os.WriteFile(localFile, []byte(`{"external_agents": true}`), 0o644); err != nil {
+		t.Fatalf("failed to write local settings file: %v", err)
 	}
 
 	testutil.InitRepo(t, tmpDir)

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -270,10 +270,11 @@ func updateSummaryGenerationSettings(ctx context.Context, w io.Writer, provider,
 	// agents were on while the next load did not honor them. The other three
 	// grant sites in this file order it this way for the same reason.
 	if grantExternalAgents {
-		if err := enableExternalAgentsLocally(ctx); err != nil {
+		grant, err := enableExternalAgentsLocally(ctx)
+		if err != nil {
 			return err
 		}
-		fmt.Fprintln(w, externalAgentsAutoEnabledNotice)
+		reportExternalAgentsGrant(w, grant)
 	}
 
 	fmt.Fprintf(w, "✓ Settings updated (%s)\n", configDisplay)
@@ -666,8 +667,11 @@ func applyAgentChanges(ctx context.Context, w io.Writer, selectedAgentNames []st
 	for _, ag := range append(successfullyAddedAgents, successfullyReinstalledAgents...) {
 		if external.IsExternal(ag) {
 			if !settings.IsExternalAgentsEnabled(ctx) {
-				if saveErr := enableExternalAgentsLocally(ctx); saveErr != nil {
+				grant, saveErr := enableExternalAgentsLocally(ctx)
+				if saveErr != nil {
 					errs = append(errs, saveErr)
+				} else {
+					warnIneffectiveExternalAgentsGrant(w, grant)
 				}
 			}
 			break
@@ -1342,9 +1346,11 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 	// Written separately from the target above: the grant is honored only
 	// from the local file, and the target here may be the project one.
 	if externalAgentSelected {
-		if err := enableExternalAgentsLocally(ctx); err != nil {
+		grant, err := enableExternalAgentsLocally(ctx)
+		if err != nil {
 			return err
 		}
+		warnIneffectiveExternalAgentsGrant(w, grant)
 	}
 
 	// Use settings values (merged from existing config + flags) for hook installation
@@ -2036,9 +2042,11 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 	// honors the grant only from the local file and this target may be the
 	// project one. See enableExternalAgentsLocally.
 	if external.IsExternal(ag) {
-		if err := enableExternalAgentsLocally(ctx); err != nil {
+		grant, err := enableExternalAgentsLocally(ctx)
+		if err != nil {
 			return err
 		}
+		warnIneffectiveExternalAgentsGrant(w, grant)
 	}
 
 	// Hook installation decisions need the merged view across both settings

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -207,8 +207,12 @@ func updateSummaryGenerationSettings(ctx context.Context, w io.Writer, provider,
 	}
 
 	if provider != "" {
-		// Make external agents on $PATH resolvable for --summarize-provider.
-		external.DiscoverAndRegisterAlways(ctx)
+		// Make the NAMED external agent resolvable for --summarize-provider.
+		// Named, not the whole sweep: the user identified one provider, and a
+		// full scan would execute every entire-agent-* binary on $PATH in a
+		// repo that may never have opted into external agents. The named
+		// lookup returns immediately when the provider is a built-in.
+		discoverNamedExternalAgent(ctx, types.AgentName(provider))
 	}
 
 	targetFile, configDisplay := settingsTargetFile(ctx, opts.UseLocalSettings, opts.UseProjectSettings)
@@ -230,8 +234,12 @@ func updateSummaryGenerationSettings(ctx context.Context, w io.Writer, provider,
 			return err
 		}
 		if ag, getErr := getSummaryAgent(types.AgentName(provider)); getErr == nil && external.IsExternal(ag) {
-			if !s.ExternalAgents {
-				s.ExternalAgents = true
+			// Written to the local file rather than into s, which may be
+			// headed for the project file. See enableExternalAgentsLocally.
+			if !settings.IsExternalAgentsEnabled(ctx) {
+				if err := enableExternalAgentsLocally(ctx); err != nil {
+					return err
+				}
 				fmt.Fprintln(w, externalAgentsAutoEnabledNotice)
 			}
 		}
@@ -472,9 +480,15 @@ func runManageAgents(ctx context.Context, w io.Writer, opts EnableOptions, selec
 	if selectFn == nil && !interactive.CanPromptInteractively() {
 		if opts.SearchSkill || opts.AgentHelpSkill {
 			if len(installedNames) > 0 {
-				external.DiscoverAndRegisterAlways(ctx)
+				// Named lookups over the agents already installed here, not a
+				// full sweep: this branch is non-interactive, so there is no
+				// picker to populate and no reason to execute binaries for
+				// agents this repo never enabled. Each call is a no-op for a
+				// built-in, and errors are dropped — applyAgentChanges reports
+				// an agent it cannot resolve.
 				selectedAgentNames := make([]string, 0, len(installedNames))
 				for _, name := range installedNames {
+					discoverNamedExternalAgent(ctx, name)
 					selectedAgentNames = append(selectedAgentNames, string(name))
 				}
 				return applyAgentChanges(ctx, w, selectedAgentNames, installedNames, opts)
@@ -636,22 +650,14 @@ func applyAgentChanges(ctx context.Context, w io.Writer, selectedAgentNames []st
 	}
 
 	// Auto-enable external_agents setting if any new agent is external.
+	// Always into the local file, whatever opts said about the rest of this
+	// write: the loader honors the grant nowhere else. See
+	// enableExternalAgentsLocally.
 	for _, ag := range append(successfullyAddedAgents, successfullyReinstalledAgents...) {
 		if external.IsExternal(ag) {
-			s, loadErr := LoadEntireSettings(ctx)
-			if loadErr != nil {
-				s = &EntireSettings{}
-			}
-			if !s.ExternalAgents {
-				s.ExternalAgents = true
-				var saveErr error
-				if opts.UseLocalSettings {
-					saveErr = SaveEntireSettingsLocal(ctx, s)
-				} else {
-					saveErr = SaveEntireSettings(ctx, s)
-				}
-				if saveErr != nil {
-					errs = append(errs, fmt.Errorf("failed to save external_agents setting: %w", saveErr))
+			if !settings.IsExternalAgentsEnabled(ctx) {
+				if saveErr := enableExternalAgentsLocally(ctx); saveErr != nil {
+					errs = append(errs, saveErr)
 				}
 			}
 			break
@@ -875,10 +881,17 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 				return err
 			}
 
-			// Discover external agent plugins early so --agent can find them.
-			// Use DiscoverAndRegisterAlways so that --agent works on fresh repos
-			// where the external_agents setting hasn't been persisted yet.
-			external.DiscoverAndRegisterAlways(ctx)
+			// Discover the external agent --agent names, so it works on fresh
+			// repos where the external_agents setting has not been persisted
+			// yet. Only that one: without --agent this falls through to
+			// runEnableOnConfiguredRepo or runSetupFlow, which each run the
+			// full ungated scan for the agent picker they show. Scanning here
+			// too would execute every entire-agent-* binary on $PATH for a
+			// bare `entire enable`. The error is dropped so an unresolvable
+			// name is reported by the agent.Get below, in the user's terms.
+			if agentName != "" {
+				discoverNamedExternalAgent(ctx, types.AgentName(agentName))
+			}
 
 			// Non-interactive mode if --agent flag is provided
 			if cmd.Flags().Changed(agentFlagName) && agentName == "" {
@@ -1277,10 +1290,13 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 		settings.AbsoluteGitHookPath = true
 	}
 
-	// Auto-enable external_agents if any selected agent is external.
+	// Auto-enable external_agents if any selected agent is external. Deferred
+	// to a separate local-file write below rather than set on this struct,
+	// which may be headed for the project file where the grant is inert.
+	externalAgentSelected := false
 	for _, ag := range agents {
 		if external.IsExternal(ag) {
-			settings.ExternalAgents = true
+			externalAgentSelected = true
 			break
 		}
 	}
@@ -1311,6 +1327,14 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 	}
 	if err := saveSettings(); err != nil {
 		return fmt.Errorf("failed to save settings: %w", err)
+	}
+
+	// Written separately from the target above: the grant is honored only
+	// from the local file, and the target here may be the project one.
+	if externalAgentSelected {
+		if err := enableExternalAgentsLocally(ctx); err != nil {
+			return err
+		}
 	}
 
 	// Use settings values (merged from existing config + flags) for hook installation
@@ -1974,11 +1998,6 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 		targetSettings.AbsoluteGitHookPath = true
 	}
 
-	// Auto-enable external_agents setting if the agent is external.
-	if external.IsExternal(ag) {
-		targetSettings.ExternalAgents = true
-	}
-
 	opts.applyStrategyOptions(targetSettings)
 
 	// Checkpoint storage backend: an explicit --checkpoint-backend wins; first
@@ -2000,6 +2019,16 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 
 	if err := saveEnabledState(ctx, targetSettings, targetFile == EntireSettingsFile); err != nil {
 		return fmt.Errorf("failed to save settings: %w", err)
+	}
+
+	// Auto-enable external_agents if the agent is external. A separate write,
+	// after the one above and never onto targetSettings, because the loader
+	// honors the grant only from the local file and this target may be the
+	// project one. See enableExternalAgentsLocally.
+	if external.IsExternal(ag) {
+		if err := enableExternalAgentsLocally(ctx); err != nil {
+			return err
+		}
 	}
 
 	// Hook installation decisions need the merged view across both settings

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -229,19 +229,13 @@ func updateSummaryGenerationSettings(ctx context.Context, w io.Writer, provider,
 		s.SummaryGeneration = &settings.SummaryGenerationSettings{}
 	}
 
+	grantExternalAgents := false
 	if provider != "" {
 		if err := validateSummaryProvider(provider); err != nil {
 			return err
 		}
 		if ag, getErr := getSummaryAgent(types.AgentName(provider)); getErr == nil && external.IsExternal(ag) {
-			// Written to the local file rather than into s, which may be
-			// headed for the project file. See enableExternalAgentsLocally.
-			if !settings.IsExternalAgentsEnabled(ctx) {
-				if err := enableExternalAgentsLocally(ctx); err != nil {
-					return err
-				}
-				fmt.Fprintln(w, externalAgentsAutoEnabledNotice)
-			}
+			grantExternalAgents = !settings.IsExternalAgentsEnabled(ctx)
 		}
 	}
 	if model != "" && provider == "" && s.SummaryGeneration.Provider == "" {
@@ -264,6 +258,22 @@ func updateSummaryGenerationSettings(ctx context.Context, w io.Writer, provider,
 		if err := SaveEntireSettings(ctx, s); err != nil {
 			return fmt.Errorf("failed to save settings: %w", err)
 		}
+	}
+
+	// After the save above, never before, and never onto s. The grant is a raw
+	// read-modify-write of the local file, because the loader honors it only
+	// from there (see enableExternalAgentsLocally) and s may be headed for the
+	// project file. When the target IS the local file, the two writes touch the
+	// same file: granting first meant the struct save rewrote it from an s
+	// whose ExternalAgents is still false, and the field is omitempty, so the
+	// key was dropped rather than written back. The user was told external
+	// agents were on while the next load did not honor them. The other three
+	// grant sites in this file order it this way for the same reason.
+	if grantExternalAgents {
+		if err := enableExternalAgentsLocally(ctx); err != nil {
+			return err
+		}
+		fmt.Fprintln(w, externalAgentsAutoEnabledNotice)
 	}
 
 	fmt.Fprintf(w, "✓ Settings updated (%s)\n", configDisplay)

--- a/cmd/entire/cli/setup_external_agents.go
+++ b/cmd/entire/cli/setup_external_agents.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/external"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// discoverNamedExternalAgent resolves one external agent binary by name,
+// bypassing the external_agents setting.
+//
+// Named rather than the full ungated sweep, wherever the caller already knows
+// which agent it wants: DiscoverAndRegisterAlways globs every $PATH directory
+// and executes every entire-agent-* binary it finds, in repositories that may
+// never have opted into external agents at all. The named lookup returns
+// immediately for a built-in, so passing an ordinary agent name costs nothing.
+//
+// The error is deliberately dropped. Every call site reports an unresolvable
+// agent a few lines later in its own terms — validateSummaryProvider,
+// applyAgentChanges, agent.Get plus printWrongAgentError — and surfacing this
+// one instead would replace a message about the agent the user named with one
+// about the plugin protocol.
+func discoverNamedExternalAgent(ctx context.Context, name types.AgentName) {
+	//nolint:errcheck,gosec // see doc comment: the caller reports the failure
+	external.DiscoverAndRegisterNamedAlways(ctx, name)
+}
+
+// enableExternalAgentsLocally turns external_agents on in
+// .entire/settings.local.json.
+//
+// Always the local file, whatever --local/--project said about the rest of the
+// write. external_agents grants execution of entire-agent-* binaries found on
+// $PATH, and settings.Load honors that grant only from an untracked local file
+// (see settings.enforceExternalAgentsTrust). Writing it to the project file
+// would produce a setting the user can read back but that never takes effect:
+// the plugin they just chose would silently stop being discovered on the next
+// command.
+//
+// The choice is machine-specific anyway — it depends on what is on this
+// developer's $PATH — so the local file is where it belonged before the trust
+// gate existed too. persistSummaryProviderSelection already reasoned its way
+// to the same place.
+//
+// Raw read-modify-write, not a struct save: the merged struct carries the
+// project file's fields as well, so writing it into the local file would copy
+// everyone's settings into this developer's overrides. Same rule as
+// setEnabledRaw.
+func enableExternalAgentsLocally(ctx context.Context) error {
+	path, raw, _, err := settings.LoadLocalRaw(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load local settings: %w", err)
+	}
+	raw["external_agents"] = json.RawMessage("true")
+	if err := settings.SaveLocalRaw(path, raw); err != nil {
+		return fmt.Errorf("failed to save external_agents setting: %w", err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/setup_external_agents.go
+++ b/cmd/entire/cli/setup_external_agents.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
@@ -49,14 +50,81 @@ func discoverNamedExternalAgent(ctx context.Context, name types.AgentName) {
 // project file's fields as well, so writing it into the local file would copy
 // everyone's settings into this developer's overrides. Same rule as
 // setEnabledRaw.
-func enableExternalAgentsLocally(ctx context.Context) error {
+//
+// The write is verified rather than assumed. A tracked settings.local.json makes
+// loadMergedSettings drop the whole local layer, so the key lands somewhere the
+// loader will never read, and the usual rejection channel stays silent about it:
+// enforceExternalAgentsTrust returns early on !s.ExternalAgents, which is the
+// very state a dropped layer produces. Without the read-back the caller prints
+// "external agents are now enabled" over a grant that does nothing.
+func enableExternalAgentsLocally(ctx context.Context) (externalAgentsGrant, error) {
 	path, raw, _, err := settings.LoadLocalRaw(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to load local settings: %w", err)
+		return externalAgentsGrant{}, fmt.Errorf("failed to load local settings: %w", err)
 	}
 	raw["external_agents"] = json.RawMessage("true")
 	if err := settings.SaveLocalRaw(path, raw); err != nil {
-		return fmt.Errorf("failed to save external_agents setting: %w", err)
+		return externalAgentsGrant{}, fmt.Errorf("failed to save external_agents setting: %w", err)
 	}
-	return nil
+	return verifyExternalAgentsGrant(ctx), nil
+}
+
+// externalAgentsGrant is what a grant write actually achieved, as opposed to
+// what it attempted.
+type externalAgentsGrant struct {
+	// Effective reports that a fresh load honors the grant.
+	Effective bool
+	// Reason explains an ineffective grant in the user's terms. Empty when
+	// Effective.
+	Reason string
+}
+
+// verifyExternalAgentsGrant re-loads settings and reports whether the grant is
+// honored, preferring whichever rejection channel actually recorded something.
+//
+// Two different mechanisms can swallow the grant and they record in different
+// places: an unverifiable repository keeps the local layer but drops
+// external_agents specifically (ExternalAgentsRejection), while a tracked local
+// file drops the layer wholesale before the gate ever sees the key
+// (LocalLayerRejection). Neither is guaranteed to be set, so there is a
+// last-resort phrasing rather than an empty reason.
+func verifyExternalAgentsGrant(ctx context.Context) externalAgentsGrant {
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return externalAgentsGrant{Reason: fmt.Sprintf("settings could not be re-read to confirm it (%v)", err)}
+	}
+	if s.ExternalAgents {
+		return externalAgentsGrant{Effective: true}
+	}
+	if reason, rejected := s.ExternalAgentsRejection(); rejected {
+		return externalAgentsGrant{Reason: reason}
+	}
+	if reason := s.LocalLayerRejection(); reason != "" {
+		return externalAgentsGrant{Reason: reason}
+	}
+	return externalAgentsGrant{Reason: "the setting is not honored from " + settings.EntireSettingsLocalFile + " in this repository"}
+}
+
+// reportExternalAgentsGrant tells the user what the grant did. Never an error:
+// a committed settings.local.json must not fail the command the user asked
+// for, and the agent they chose still works for the rest of this run.
+func reportExternalAgentsGrant(w io.Writer, grant externalAgentsGrant) {
+	if grant.Effective {
+		fmt.Fprintln(w, externalAgentsAutoEnabledNotice)
+		return
+	}
+	warnIneffectiveExternalAgentsGrant(w, grant)
+}
+
+// warnIneffectiveExternalAgentsGrant is the half of the report that the grant
+// sites which never announced success still need. Silent on success, because
+// those sites treat a working grant as an implementation detail of "the agent
+// you picked now works", and only a grant that did NOT take effect is news.
+func warnIneffectiveExternalAgentsGrant(w io.Writer, grant externalAgentsGrant) {
+	if grant.Effective {
+		return
+	}
+	fmt.Fprintf(w, "Warning: external agents could not be enabled: %s.\n"+
+		"  If %s is tracked by git, run `git rm --cached %s` and keep it out of version control.\n",
+		grant.Reason, settings.EntireSettingsLocalFile, settings.EntireSettingsLocalFile)
 }

--- a/cmd/entire/cli/setup_external_agents_test.go
+++ b/cmd/entire/cli/setup_external_agents_test.go
@@ -30,19 +30,75 @@ func TestEnableExternalAgentsLocally_TakesEffect(t *testing.T) { //nolint:parall
 	}
 	t.Chdir(dir)
 
-	if err := enableExternalAgentsLocally(t.Context()); err != nil {
+	grant, err := enableExternalAgentsLocally(t.Context())
+	if err != nil {
 		t.Fatalf("enableExternalAgentsLocally: %v", err)
+	}
+	if !grant.Effective {
+		t.Errorf("grant reported ineffective (%s), want it honored in an untracked local file", grant.Reason)
+	}
+
+	loaded, err := settings.Load(t.Context())
+	if err != nil {
+		t.Fatalf("load settings: %v", err)
+	}
+	if !loaded.ExternalAgents {
+		reason, _ := loaded.ExternalAgentsRejection()
+		t.Errorf("external_agents did not take effect (rejection: %q)", reason)
+	}
+	if loaded.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want the existing local setting preserved", loaded.LogLevel)
+	}
+}
+
+// TestEnableExternalAgentsLocally_TrackedLocalFile_ReportsIneffective covers
+// the second route to the symptom commit 51d062a34 fixed: the write succeeds,
+// but the grant it wrote can never be read.
+//
+// A TRACKED .entire/settings.local.json makes loadMergedSettings drop the whole
+// local layer, so the key lands in a file the loader ignores. Worse, the gate
+// that would normally record a rejection never runs: enforceExternalAgentsTrust
+// returns early on !s.ExternalAgents, which is exactly the state a dropped
+// layer produces. So nothing anywhere says external_agents is inert, while the
+// caller prints a notice saying it is on.
+func TestEnableExternalAgentsLocally_TrackedLocalFile_ReportsIneffective(t *testing.T) { //nolint:paralleltest // t.Chdir
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	entireDir := filepath.Join(dir, ".entire")
+	if err := os.MkdirAll(entireDir, 0o755); err != nil {
+		t.Fatalf("create .entire: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"),
+		[]byte(`{"enabled":true}`), 0o644); err != nil {
+		t.Fatalf("write project settings: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.local.json"),
+		[]byte(`{"log_level":"debug"}`), 0o644); err != nil {
+		t.Fatalf("write local settings: %v", err)
+	}
+	// -f because .entire/settings.local.json is gitignored; committing it
+	// anyway is precisely the state this guards against.
+	testutil.GitAddForce(t, dir, ".entire/settings.local.json")
+	testutil.GitCommit(t, dir, "track local settings")
+	t.Chdir(dir)
+
+	grant, err := enableExternalAgentsLocally(t.Context())
+	if err != nil {
+		t.Fatalf("enableExternalAgentsLocally: %v", err)
+	}
+
+	if grant.Effective {
+		t.Error("grant reported effective, but a tracked local file is never read back")
+	}
+	if grant.Reason == "" {
+		t.Error("an ineffective grant must carry a reason the caller can show the user")
 	}
 
 	s, err := settings.Load(t.Context())
 	if err != nil {
 		t.Fatalf("load settings: %v", err)
 	}
-	if !s.ExternalAgents {
-		reason, _ := s.ExternalAgentsRejection()
-		t.Errorf("external_agents did not take effect (rejection: %q)", reason)
-	}
-	if s.LogLevel != "debug" {
-		t.Errorf("LogLevel = %q, want the existing local setting preserved", s.LogLevel)
+	if s.ExternalAgents {
+		t.Fatal("precondition failed: tracked local layer should not be honored")
 	}
 }

--- a/cmd/entire/cli/setup_external_agents_test.go
+++ b/cmd/entire/cli/setup_external_agents_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// The auto-enable that fires when a user picks an external agent has to land
+// somewhere the loader will honor. Written into the version-controlled
+// .entire/settings.json it is dropped on the next load, so the agent the user
+// just chose silently stops being discovered.
+func TestEnableExternalAgentsLocally_TakesEffect(t *testing.T) { //nolint:paralleltest // t.Chdir
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	entireDir := filepath.Join(dir, ".entire")
+	if err := os.MkdirAll(entireDir, 0o755); err != nil {
+		t.Fatalf("create .entire: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"),
+		[]byte(`{"enabled":true}`), 0o644); err != nil {
+		t.Fatalf("write project settings: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.local.json"),
+		[]byte(`{"log_level":"debug"}`), 0o644); err != nil {
+		t.Fatalf("write local settings: %v", err)
+	}
+	t.Chdir(dir)
+
+	if err := enableExternalAgentsLocally(t.Context()); err != nil {
+		t.Fatalf("enableExternalAgentsLocally: %v", err)
+	}
+
+	s, err := settings.Load(t.Context())
+	if err != nil {
+		t.Fatalf("load settings: %v", err)
+	}
+	if !s.ExternalAgents {
+		reason, _ := s.ExternalAgentsRejection()
+		t.Errorf("external_agents did not take effect (rejection: %q)", reason)
+	}
+	if s.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want the existing local setting preserved", s.LogLevel)
+	}
+}

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -1337,7 +1337,10 @@ func installExternalAgentPluginForUninstall(t *testing.T, agentName string, hook
 	}
 
 	setupTestRepo(t)
-	writeSettings(t, `{"enabled":true,"external_agents":true}`)
+	writeSettings(t, testSettingsEnabled)
+	// external_agents goes in the local file — the only layer the loader
+	// honors it from, since it grants execution of entire-agent-* binaries.
+	writeLocalSettings(t, `{"external_agents":true}`)
 
 	externalDir := t.TempDir()
 	writeExternalAgentBinaryEx(t, externalDir, agentName, hooksInstalled)
@@ -4384,8 +4387,16 @@ func TestConfigureCmd_SummarizeProvider_ExternalEnablesExternalAgents(t *testing
 	if s.SummaryGeneration.Provider != provider {
 		t.Fatalf("summary provider = %q, want %q", s.SummaryGeneration.Provider, provider)
 	}
-	if !s.ExternalAgents {
-		t.Fatal("external summary provider should enable external_agents")
+	if s.ExternalAgents {
+		t.Fatal("external_agents must not be written to the project file, where the loader ignores it")
+	}
+	effective, err := settings.Load(t.Context())
+	if err != nil {
+		t.Fatalf("failed to load merged settings: %v", err)
+	}
+	if !effective.ExternalAgents {
+		reason, _ := effective.ExternalAgentsRejection()
+		t.Fatalf("external summary provider should enable external_agents (rejection: %q)", reason)
 	}
 	if !strings.Contains(stdout.String(), externalAgentsAutoEnabledNotice) {
 		t.Fatalf("expected notice surfacing the external_agents flip, got stdout:\n%s", stdout.String())
@@ -4398,7 +4409,10 @@ func TestConfigureCmd_SummarizeProvider_ExternalAlreadyEnabled_NoNotice(t *testi
 	}
 
 	setupTestRepo(t)
-	writeSettings(t, `{"enabled": true, "external_agents": true}`)
+	writeSettings(t, testSettingsEnabled)
+	// The local file is the only place the loader honors external_agents, so
+	// it is the only place "already enabled" can be expressed.
+	writeLocalSettings(t, `{"external_agents": true}`)
 
 	const provider = "external-summary-already-on"
 	externalDir := t.TempDir()

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -5116,3 +5116,92 @@ func TestPluginUninstallCommand_QuotesRepoRoot(t *testing.T) {
 		t.Errorf("a single quote in the path must be escaped, got:\n%s", got)
 	}
 }
+
+// TestConfigureCmd_SummarizeProvider_ExternalLocalTarget_GrantSurvives covers
+// the case where the summary settings and the external_agents grant land in
+// the SAME file. The grant is a raw read-modify-write of the local file, so a
+// struct save that happens afterwards rewrites that file from a struct whose
+// ExternalAgents is still false — and the field is omitempty, so the key is
+// dropped rather than written as false. The user is told external agents were
+// enabled, and the very next load does not honor the setting.
+func TestConfigureCmd_SummarizeProvider_ExternalLocalTarget_GrantSurvives(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+
+	const provider = "external-summary-local-target"
+	externalDir := t.TempDir()
+	writeExternalSummaryAgentBinary(t, externalDir, provider)
+	t.Setenv("PATH", externalDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cmd := newSetupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--local", "--summarize-provider", provider})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("configure --local --summarize-provider external failed: %v", err)
+	}
+
+	local, err := settings.LoadFromFile(EntireSettingsLocalFile)
+	if err != nil {
+		t.Fatalf("failed to load local settings: %v", err)
+	}
+	if local.SummaryGeneration == nil || local.SummaryGeneration.Provider != provider {
+		t.Fatalf("local summary provider = %+v, want %q", local.SummaryGeneration, provider)
+	}
+
+	effective, err := settings.Load(t.Context())
+	if err != nil {
+		t.Fatalf("failed to load merged settings: %v", err)
+	}
+	if !effective.ExternalAgents {
+		reason, _ := effective.ExternalAgentsRejection()
+		t.Fatalf("external_agents grant did not survive the settings save (rejection: %q); stdout:\n%s",
+			reason, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), externalAgentsAutoEnabledNotice) {
+		t.Fatalf("expected notice surfacing the external_agents flip, got stdout:\n%s", stdout.String())
+	}
+}
+
+// TestConfigureCmd_SummarizeProvider_ExternalLocalOnlyRepo_GrantSurvives is the
+// same collision reached without --local: in a repo that has only
+// settings.local.json, settingsTargetFile resolves there on its own.
+func TestConfigureCmd_SummarizeProvider_ExternalLocalOnlyRepo_GrantSurvives(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	setupTestRepo(t)
+	writeLocalSettings(t, testSettingsEnabled)
+
+	const provider = "external-summary-local-only"
+	externalDir := t.TempDir()
+	writeExternalSummaryAgentBinary(t, externalDir, provider)
+	t.Setenv("PATH", externalDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cmd := newSetupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--summarize-provider", provider})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("configure --summarize-provider external failed: %v", err)
+	}
+
+	effective, err := settings.Load(t.Context())
+	if err != nil {
+		t.Fatalf("failed to load merged settings: %v", err)
+	}
+	if !effective.ExternalAgents {
+		reason, _ := effective.ExternalAgentsRejection()
+		t.Fatalf("external_agents grant did not survive the settings save (rejection: %q); stdout:\n%s",
+			reason, stdout.String())
+	}
+}

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -139,6 +139,14 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 		fmt.Fprintln(w, formatSettingsStatus("Project", projectSettings, sty))
 	}
 
+	// An external_agents grant the loader refused. The user can see the
+	// setting in their file and has no other way to learn it is inert:
+	// discovery simply does not run, and the agent never appears.
+	if reason, rejected := effectiveSettings.ExternalAgentsRejection(); rejected {
+		fmt.Fprintf(w, "  external_agents is ignored: %s\n  move it to %s, and keep that file out of version control\n",
+			reason, settings.EntireSettingsLocalFile)
+	}
+
 	// Show local settings if it exists. LoadFromFile is ungated, so this
 	// renders the file's own contents — say so when the loader ignored them,
 	// or the display contradicts the settings actually in effect.

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/redact"
 
@@ -2690,5 +2691,38 @@ func TestRunStatusJSON_CheckpointSync_AbsentWhenNoRemotes(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "checkpoint_sync_remote") {
 		t.Errorf("omitempty should drop empty checkpoint sync fields, got: %s", stdout.String())
+	}
+}
+
+// A user who wrote external_agents into .entire/settings.json sees it there
+// and has no other way to learn it is not in effect: discovery just does not
+// happen, and the agent simply never appears. Detailed status renders the
+// files, so it is where the discrepancy has to be named.
+func TestRunStatusDetailed_ReportsRejectedExternalAgents(t *testing.T) { //nolint:paralleltest // t.Chdir
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	entireDir := filepath.Join(dir, ".entire")
+	if err := os.MkdirAll(entireDir, 0o755); err != nil {
+		t.Fatalf("create .entire: %v", err)
+	}
+	projectPath := filepath.Join(entireDir, "settings.json")
+	if err := os.WriteFile(projectPath, []byte(`{"enabled":true,"external_agents":true}`), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	t.Chdir(dir)
+
+	var out bytes.Buffer
+	sty := statusStyles{colorEnabled: false, width: 80}
+	if err := runStatusDetailed(t.Context(), &out, sty, projectPath,
+		filepath.Join(entireDir, "settings.local.json"), true, false); err != nil {
+		t.Fatalf("runStatusDetailed: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "external_agents") {
+		t.Errorf("status does not mention external_agents:\n%s", got)
+	}
+	if !strings.Contains(got, settings.EntireSettingsLocalFile) {
+		t.Errorf("status does not name where the setting must live:\n%s", got)
 	}
 }

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -113,7 +113,14 @@ func TestBuildSummaryGenerator_ExternalProvider(t *testing.T) { //nolint:paralle
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, ".entire", "settings.json"),
-		[]byte(`{"enabled":true,"external_agents":true,"summary_generation":{"provider":"`+provider+`","model":"test-model"}}`),
+		[]byte(`{"enabled":true,"summary_generation":{"provider":"`+provider+`","model":"test-model"}}`),
+		0o644,
+	))
+	// external_agents lives in the local file: it grants execution of
+	// entire-agent-* binaries on $PATH, so the loader honors it only there.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".entire", "settings.local.json"),
+		[]byte(`{"external_agents":true}`),
 		0o644,
 	))
 

--- a/docs/architecture/external-agent-protocol.md
+++ b/docs/architecture/external-agent-protocol.md
@@ -8,6 +8,11 @@ The Entire CLI supports external agent plugins — standalone binaries that impl
 
 The CLI discovers external agents by scanning `$PATH` for executables matching the pattern `entire-agent-<name>`. For example, `entire-agent-cursor` would register as the "cursor" agent.
 
+Two rules bound that scan, both because discovery *executes* what it finds (it calls each binary's `info` subcommand):
+
+- It is off unless `external_agents` is set in an untracked `.entire/settings.local.json`. The committed `.entire/settings.json` cannot grant it — see [Why `external_agents` is local-only](../security-and-privacy.md#why-external_agents-is-local-only). Interactive setup flows scan regardless, so you can still pick a plugin before the setting exists.
+- Only absolute `$PATH` entries are scanned. A relative entry resolves against the working directory, which for a git hook is whatever repository invoked it.
+
 - Binaries whose `<name>` conflicts with an already-registered built-in agent are skipped.
 - Discovery runs once during CLI initialization (before building the hooks command tree).
 - The binary must be executable and respond to the `info` subcommand.

--- a/docs/architecture/external-commands.md
+++ b/docs/architecture/external-commands.md
@@ -264,7 +264,7 @@ Once allowlisted, `cli_plugin_executed` events for that command will flow throug
 | | External Commands | [Agent Protocol](external-agent-protocol.md) |
 |---|---|---|
 | **Binary name pattern** | `entire-<name>` | `entire-agent-<name>` |
-| **Discovery** | Lazy, on first non-built-in arg | Lazy at command entry, gated by `external_agents` setting (setup flows bypass the gate via `DiscoverAndRegisterAlways`) |
+| **Discovery** | Lazy, on first non-built-in arg | Lazy at command entry, gated by the `external_agents` setting, which is honored only from an untracked `.entire/settings.local.json` (setup flows bypass the gate via `DiscoverAndRegisterAlways` / `DiscoverAndRegisterNamedAlways`) |
 | **Communication** | Process exec; stdio passthrough | Subcommand protocol; JSON over stdin/stdout |
 | **Versioning** | None | `ENTIRE_PROTOCOL_VERSION` envelope |
 | **Lifecycle integration** | None | Full (sessions, checkpoints, hooks, transcripts) |

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -554,6 +554,32 @@ Opt out via any one of:
 - `"telemetry": false` in `.entire/settings.json` or `.entire/settings.local.json`.
 - `ENTIRE_TELEMETRY_OPTOUT=1` in the environment.
 
+## Why `external_agents` is local-only
+
+`external_agents` turns on the `$PATH` scan that looks for `entire-agent-*`
+binaries and runs each one's `info` subcommand, then keeps running the ones it
+registered for every hook thereafter. It is an execution grant, not a
+preference, so it is honored under exactly the same rule as the OPF
+[`command`](#why-command-is-local-only): only from `.entire/settings.local.json`,
+and only when that file is untracked in both the index and `HEAD`. Reading it
+from the committed `.entire/settings.json` would let an ordinary pull request
+turn on execution of whatever `entire-agent-*` binary it could get onto a
+developer's `$PATH`, and — as with `command` — one line of JSON does not read as
+executable to a reviewer. There is no prompt in front of this one at all.
+
+Rejection is a downgrade, never an error: discovery simply does not run.
+`entire status` names the setting and where it has to move, and the same reason
+is logged. The interactive setup flows (`entire enable`, `entire configure`,
+`entire agent add`, `entire plugin uninstall`) reach external agents regardless
+of the setting, so the remedy stays available from the commands that need it —
+and when one of them enables an external agent for you, it writes the setting to
+`.entire/settings.local.json`, which is where it takes effect.
+
+Every `$PATH` scanner in the CLI also drops non-absolute entries. A relative
+entry resolves against the process's working directory, which for a git hook is
+whatever repository the caller was standing in, so a file committed to that
+repository would otherwise be a binary Entire executes.
+
 ## Reporting a vulnerability
 
 For vulnerability disclosure, see [SECURITY.md](../SECURITY.md) at the repo root: email `security@entire.io`, expect acknowledgment within 48 hours and resolution of criticals within 90 days.
@@ -561,4 +587,4 @@ For vulnerability disclosure, see [SECURITY.md](../SECURITY.md) at the repo root
 ## Related
 
 - [Checkpoint commit signing](architecture/checkpoint-signing.md) — best-effort GPG/SSH signing of checkpoint commits, opt-out via `sign_checkpoint_commits: false`.
-- External agent plugins are arbitrary executables on `$PATH` invoked by the CLI; only install plugins you trust.
+- External agent plugins are arbitrary executables on `$PATH` invoked by the CLI; only install plugins you trust. Discovery is off unless you turn it on in `.entire/settings.local.json` — see [Why `external_agents` is local-only](#why-external_agents-is-local-only).

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -90,12 +90,29 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 
 	// External agents need external_agents enabled in settings before enable,
 	// so the CLI can discover the agent binary via PATH during DiscoverAndRegister.
+	//
+	// The grant goes in settings.local.json: it enables execution of
+	// entire-agent-* binaries found on $PATH, so the loader honors it only
+	// from an untracked local file. Nothing commits this one — the repo has
+	// its initial commit already — so it verifies as this clone's own.
+	//
+	// An empty settings.json goes alongside it, and is load-bearing rather
+	// than decorative. `entire enable` picks its target file by asking
+	// whether project settings already exist, so a repo carrying only a local
+	// file would send enable's own write there too and never create
+	// settings.json — which PatchSettings below then cannot find. Creating
+	// both keeps the target resolution exactly where it was when this fixture
+	// wrote the grant into settings.json.
 	if ea, ok := agent.(agents.ExternalAgent); ok && ea.IsExternalAgent() {
 		entireDir := filepath.Join(dir, ".entire")
 		if err := os.MkdirAll(entireDir, 0o755); err != nil {
 			t.Fatalf("create .entire for external agent: %v", err)
 		}
 		if err := os.WriteFile(filepath.Join(entireDir, "settings.json"),
+			[]byte("{}\n"), 0o644); err != nil {
+			t.Fatalf("write project settings: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(entireDir, "settings.local.json"),
 			[]byte("{\"external_agents\": true}\n"), 0o644); err != nil {
 			t.Fatalf("write external_agents setting: %v", err)
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1236
<!-- entire-trail-link-end -->

Every $PATH scanner now goes through execx.PathScanDirs(), which returns only absolute entries. Go's own protections do not reach the external-agent scanner: it resolves by filepath.Glob, so a match never passes exec.LookPath (no ErrDot) and it carries separators, so exec.Command's re-check does not apply either -- and discovery executes what it finds. findInaccessiblePlugin carried the same rule separately, which is how the two drifted; one helper keeps them aligned.

external.Agent.run refuses a non-absolute binaryPath before spawning. run sets cmd.Dir to the worktree root and os/exec resolves a relative Path against Dir, so the file registerExternalAgent statted is not necessarily the file that executes. The check sits at the exec, so it also covers the exported New.

external_agents joins openai_privacy_filter.command under the settings trust gate: honored only from a verified-untracked .entire/settings.local.json, a downgrade rather than an error, with the reason surfaced by entire status and by DiscoverAndRegister. It grants execution of every entire-agent-* binary on $PATH, and a committed one-line JSON diff does not read as executable to a reviewer. Every auto-enable therefore writes the key to the local file through enableExternalAgentsLocally: writing it to the project file would produce a setting the user can read back and that never takes effect.

Auditing the six DiscoverAndRegisterAlways call sites -- runSetupFlow, detectOrSelectAgent and runUninstall genuinely need the ungated sweep; --summarize-provider, the non-interactive skill install, and enable's --agent path already knew which agent they wanted and are now named lookups.

pluginParentDir applies its absoluteness rule to XDG_DATA_HOME and LOCALAPPDATA as well, rather than leaving those to osroot and to main.go's PATH restore two layers away from where the invariant is decided.

Regression tests assert behaviour rather than error text: each planted binary writes a marker file, and the tests assert it never appears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication-adjacent execution policy: PATH scanning, external agent spawning, and settings that gate arbitrary binary execution—misconfiguration or a bug could break discovery/plugins or leave a path to unintended exec.
> 
> **Overview**
> This PR tightens **who can cause Entire to execute binaries** and **which paths count as on `$PATH`**.
> 
> **Absolute `$PATH` only:** New `execx.PathScanDirs()` centralizes scanning so relative or empty `$PATH` entries are dropped. External-agent discovery and plugin fallback scanning (`findInaccessiblePlugin`) use it instead of splitting `$PATH` directly, closing glob/LookPath gaps where repo-local files could run during hooks.
> 
> **External agent execution:** `external.Agent.run` (and `New`) refuse non-absolute `binaryPath` before spawn, since `cmd.Dir` is the worktree and relative paths would not match what discovery stat’d.
> 
> **`external_agents` as a trust boundary:** Settings load applies `enforceExternalAgentsTrust` (mirroring OPF `command`): `true` is honored only from an untracked `.entire/settings.local.json`. Rejected grants are recorded and surfaced via `entire status` and discovery warnings. Auto-enable paths write through `enableExternalAgentsLocally` with read-back verification so project-file writes or tracked local files cannot silently look “on” while doing nothing.
> 
> **Fewer ungated sweeps:** Summary/configure/enable flows use **named** external discovery where only one agent is needed; full `$PATH` sweeps stay for flows that genuinely need the picker. Non-interactive summary auto-select no longer flips `external_agents` without a human pick.
> 
> **Plugin dirs:** `pluginParentDir` rejects relative `XDG_DATA_HOME` / `LOCALAPPDATA` overrides, not only `ENTIRE_PLUGIN_DIR`.
> 
> Docs (`CLAUDE.md`, security/architecture) and regression tests (marker files proving binaries never run) accompany the behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a35d4d9797e73816ac14fa539d42e7e815edd9b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->