### PR TITLE
fix(e2e): stop paying opencode's per-directory plugin install ~40 times a run

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,6 +143,18 @@ jobs:
             mise run test:e2e --agent ${{ matrix.agent }}
           fi
 
+      # opencode writes nothing to stdout or stderr while it stalls during
+      # startup, so a hung `opencode run` reaches us as an empty-output SIGKILL
+      # naming no cause — which is exactly how the 2026-09-03 red streak looked
+      # from the artifacts. Its own log dir is the only record of what it was
+      # waiting on, so fold it into the artifact tree. Best-effort: a leg that
+      # never got as far as writing logs must not fail here.
+      - name: Collect opencode logs
+        if: always() && matrix.agent == 'opencode'
+        run: |
+          mkdir -p e2e/artifacts/opencode-logs
+          cp -R "$HOME/.local/share/opencode/log/." e2e/artifacts/opencode-logs/ || true
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/e2e/agents/agent.go
+++ b/e2e/agents/agent.go
@@ -63,6 +63,17 @@ type ExternalAgent interface {
 	IsExternalAgent() bool
 }
 
+// RepoSeeder is implemented by an agent that needs files planted in a fresh
+// test repo before it first runs there. SetupRepo calls SeedRepo once the repo
+// exists and `entire enable` has written the agent's own config into it.
+//
+// Seeding is best-effort by contract: an agent that cannot seed should return
+// nil and leave the repo alone, so the tests degrade to whatever the agent does
+// for itself rather than failing on setup.
+type RepoSeeder interface {
+	SeedRepo(dir string) error
+}
+
 var registry []Agent
 var gates = map[string]chan struct{}{}
 

--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -54,21 +54,37 @@ func (a *openCodeAgent) IsTransientError(out Output, _ error) bool {
 	return false
 }
 
+// openCodeWarmupBudget bounds a single warmup attempt. It sits far above the
+// cost of the trivial model round-trip on purpose: the warmup's job is to pay
+// opencode's first-run costs (per-directory dependency install, DB migration)
+// once and serially, before ~40 tests start in parallel, so a budget that kills
+// the attempt part-way leaves that work half-done for every test that follows.
+// It was 30s until 2026-09-04, when opencode's startup latency stepped from
+// ~10s to over 30s and the warmup began being killed on every CI run.
+const openCodeWarmupBudget = 90 * time.Second
+
 func (a *openCodeAgent) Bootstrap() error {
 	// opencode has first-run DB migration + node_modules resolution that
 	// races with parallel test execution (upstream issue #6935).
 	// Run a trivial prompt to force full initialization before tests.
+	//
+	// Each attempt's duration is reported whether it succeeds or not: this is
+	// the only serial, uncontended measurement of opencode startup we take, so
+	// it is the cheapest place to see a step change in it from the CI log.
 	for i := range 3 {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		start := time.Now()
+		ctx, cancel := context.WithTimeout(context.Background(), openCodeWarmupBudget)
 		cmd := exec.CommandContext(ctx, a.Binary(), "run", "--model", a.model, "say hi")
 		cmd.Env = os.Environ()
 		out, err := cmd.CombinedOutput()
 		cancel()
+		elapsed := time.Since(start).Round(time.Millisecond)
 		if err == nil {
+			fmt.Fprintf(os.Stderr, "opencode warmup succeeded on attempt %d in %s\n", i+1, elapsed)
 			return nil
 		}
 		if i < 2 {
-			fmt.Fprintf(os.Stderr, "opencode warmup attempt %d failed: %s\n%s\n", i+1, err, out)
+			fmt.Fprintf(os.Stderr, "opencode warmup attempt %d failed after %s: %s\n%s\n", i+1, elapsed, err, out)
 			time.Sleep(5 * time.Second)
 		}
 	}

--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -54,28 +56,89 @@ func (a *openCodeAgent) IsTransientError(out Output, _ error) bool {
 	return false
 }
 
-// openCodeWarmupBudget bounds a single warmup attempt. It sits far above the
-// cost of the trivial model round-trip on purpose: the warmup's job is to pay
-// opencode's first-run costs (per-directory dependency install, DB migration)
-// once and serially, before ~40 tests start in parallel, so a budget that kills
-// the attempt part-way leaves that work half-done for every test that follows.
-// It was 30s until 2026-09-04, when opencode's startup latency stepped from
-// ~10s to over 30s and the warmup began being killed on every CI run.
-const openCodeWarmupBudget = 90 * time.Second
+const (
+	// openCodeWarmupBudget bounds a single warmup attempt. It sits far above
+	// the cost of the trivial model round-trip on purpose: the warmup's job is
+	// to pay opencode's remaining first-run costs (global DB migration) once and
+	// serially, before ~40 tests start in parallel, so a budget that kills the
+	// attempt part-way leaves that work half-done for every test that follows.
+	openCodeWarmupBudget = 90 * time.Second
+
+	// openCodeDepsBudget bounds the plugin dependency install. It is generous
+	// against a measured ~3s because a cold npm cache on a CI runner is a very
+	// different machine from a developer's, and the cost of overrunning it is
+	// only that we fall back to opencode installing per-directory itself.
+	openCodeDepsBudget = 5 * time.Minute
+
+	// openCodePluginPkg is the package opencode pins into a project's generated
+	// .opencode/package.json. It pins the version of the RUNNING BINARY, not a
+	// range, so the tree has to be rebuilt on every opencode upgrade.
+	openCodePluginPkg = "@opencode-ai/plugin"
+
+	// openCodeSeedGitignore mirrors the .gitignore opencode writes into
+	// .opencode itself. It names its own file, so everything we plant — the
+	// .gitignore included — stays invisible to git. That matters here beyond
+	// tidiness: these repos are the subject of checkpoint assertions, and an
+	// untracked 61MB tree in the working set would change what the CLI sees.
+	openCodeSeedGitignore = "node_modules\npackage.json\npackage-lock.json\nbun.lock\n.gitignore\n"
+)
+
+// openCodeVersionRe matches what `opencode --version` prints. The result names
+// a cache directory, so it is validated rather than trusted.
+var openCodeVersionRe = regexp.MustCompile(`^[0-9][0-9A-Za-z.+-]*$`)
+
+// openCodePluginDeps is the warmed dependency tree built once by Bootstrap and
+// seeded into every test repo by SeedRepo. Empty when it could not be built, in
+// which case seeding is skipped and opencode installs per-directory as usual.
+var openCodePluginDeps string
 
 func (a *openCodeAgent) Bootstrap() error {
-	// opencode has first-run DB migration + node_modules resolution that
-	// races with parallel test execution (upstream issue #6935).
-	// Run a trivial prompt to force full initialization before tests.
+	// Build the dependency tree opencode would otherwise install itself, once,
+	// so SeedRepo can plant it in every test repo.
+	//
+	// Whenever a project directory contains a local plugin file — which
+	// `entire enable` always writes — opencode generates
+	// .opencode/package.json and installs it (27 packages, ~61MB) before it
+	// will finish bootstrapping. That install happens inside a phase that logs
+	// nothing and has no timeout, so a slow one presents as a silent hang with
+	// no output at all; on 2026-09-03 it began exceeding the per-prompt budget
+	// in CI and killed half the suite, with 27 of 53 opencode processes dying
+	// between "loading path=..." and "all LSPs are disabled".
+	//
+	// Doing it here turns ~40 unbounded installs hidden inside the agent into
+	// one bounded step that reports its own failure. It is not a workaround for
+	// a test-only problem: every user gets the same install on first launch per
+	// repo, and again after each opencode upgrade.
+	if deps, err := a.buildPluginDeps(); err != nil {
+		fmt.Fprintf(os.Stderr, "opencode: could not pre-build plugin deps (%v)\n"+
+			"opencode: tests will pay the per-directory install themselves\n", err)
+	} else {
+		openCodePluginDeps = deps
+	}
+
+	// opencode also has a first-run DB migration that races with parallel test
+	// execution (upstream issue #6935). Run a trivial prompt to force the rest
+	// of initialization before tests. It runs in a seeded scratch directory so
+	// it is not itself blocked on the install above.
 	//
 	// Each attempt's duration is reported whether it succeeds or not: this is
 	// the only serial, uncontended measurement of opencode startup we take, so
 	// it is the cheapest place to see a step change in it from the CI log.
+	warmDir, err := os.MkdirTemp("", "opencode-warmup-*")
+	if err != nil {
+		return fmt.Errorf("create opencode warmup dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(warmDir) }()
+	if err := a.SeedRepo(warmDir); err != nil {
+		fmt.Fprintf(os.Stderr, "opencode: could not seed warmup dir: %v\n", err)
+	}
+
 	for i := range 3 {
 		start := time.Now()
 		ctx, cancel := context.WithTimeout(context.Background(), openCodeWarmupBudget)
 		cmd := exec.CommandContext(ctx, a.Binary(), "run", "--model", a.model, "say hi")
-		cmd.Env = os.Environ()
+		cmd.Dir = warmDir
+		cmd.Env = openCodePromptEnv(os.Environ(), warmDir)
 		out, err := cmd.CombinedOutput()
 		cancel()
 		elapsed := time.Since(start).Round(time.Millisecond)
@@ -90,6 +153,97 @@ func (a *openCodeAgent) Bootstrap() error {
 	}
 	// Non-fatal: warmup failure shouldn't block tests entirely.
 	fmt.Fprintln(os.Stderr, "opencode warmup failed after 3 attempts, proceeding anyway")
+	return nil
+}
+
+// buildPluginDeps materialises the .opencode dependency tree once, keyed by
+// opencode version, and returns the directory holding it. See Bootstrap for why.
+func (a *openCodeAgent) buildPluginDeps() (string, error) {
+	version, err := a.version()
+	if err != nil {
+		return "", err
+	}
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user cache dir: %w", err)
+	}
+	// Keyed by version because the pin follows the binary: a tree built for an
+	// older opencode is one opencode will discard and reinstall.
+	dir := filepath.Join(cache, "entire-e2e", "opencode-plugin-deps", version)
+	if _, err := os.Stat(filepath.Join(dir, "node_modules")); err == nil {
+		fmt.Fprintf(os.Stderr, "opencode: reusing plugin deps for %s at %s\n", version, dir)
+		return dir, nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create plugin dep dir %q: %w", dir, err)
+	}
+	pkg := fmt.Sprintf("{\n  \"dependencies\": {\n    %q: %q\n  }\n}\n", openCodePluginPkg, version)
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkg), 0o644); err != nil {
+		return "", fmt.Errorf("write package.json: %w", err)
+	}
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), openCodeDepsBudget)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "npm", "install", "--no-audit", "--no-fund", "--loglevel=error")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("npm install %s@%s: %w\n%s", openCodePluginPkg, version, err, out)
+	}
+	fmt.Fprintf(os.Stderr, "opencode: built plugin deps for %s in %s\n", version, time.Since(start).Round(time.Millisecond))
+	return dir, nil
+}
+
+// version reports the running opencode's version, which is the version its
+// generated package.json will pin.
+func (a *openCodeAgent) version() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, a.Binary(), "--version").Output()
+	if err != nil {
+		return "", fmt.Errorf("opencode --version: %w", err)
+	}
+	version, _, _ := strings.Cut(strings.TrimSpace(string(out)), "\n")
+	version = strings.TrimSpace(version)
+	if !openCodeVersionRe.MatchString(version) {
+		return "", fmt.Errorf("opencode --version printed %q, which is not a version", version)
+	}
+	return version, nil
+}
+
+// SeedRepo plants the pre-built dependency tree in a fresh test repo so
+// opencode's own blocking install never runs there.
+func (a *openCodeAgent) SeedRepo(dir string) error {
+	if openCodePluginDeps == "" {
+		return nil // Bootstrap could not build the tree; leave the repo alone.
+	}
+	target := filepath.Join(dir, ".opencode")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		return fmt.Errorf("create .opencode: %w", err)
+	}
+	for _, name := range []string{"package.json", "package-lock.json"} {
+		data, err := os.ReadFile(filepath.Join(openCodePluginDeps, name))
+		if err != nil {
+			return fmt.Errorf("read seeded %s: %w", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(target, name), data, 0o644); err != nil {
+			return fmt.Errorf("write seeded %s: %w", name, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(target, ".gitignore"), []byte(openCodeSeedGitignore), 0o644); err != nil {
+		return fmt.Errorf("write seeded .gitignore: %w", err)
+	}
+	// node_modules is linked rather than copied: the tree is ~61MB across
+	// thousands of small files and ~40 repos exist at once, so copying it would
+	// cost about what the install we are avoiding costs. opencode reads through
+	// the link and leaves it in place.
+	link := filepath.Join(target, "node_modules")
+	if err := os.Symlink(filepath.Join(openCodePluginDeps, "node_modules"), link); err != nil {
+		// Degrade to opencode installing for itself rather than failing setup —
+		// symlinks are not available unprivileged on every platform.
+		fmt.Fprintf(os.Stderr, "opencode: could not link seeded node_modules (%v); this repo pays the install\n", err)
+		return nil
+	}
 	return nil
 }
 

--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -78,6 +78,10 @@ const (
 	// only that we fall back to opencode installing per-directory itself.
 	openCodeDepsBudget = 5 * time.Minute
 
+	// openCodeDepsAttempts caps how many times a process will try to build the
+	// tree. See openCodePluginDeps for why it is neither 1 nor unbounded.
+	openCodeDepsAttempts = 2
+
 	// openCodePluginPkg is the package opencode pins into a project's generated
 	// .opencode/package.json. It pins the version of the RUNNING BINARY, not a
 	// range, so the tree has to be rebuilt on every opencode upgrade.
@@ -101,8 +105,8 @@ const (
 // a directory, so it is validated rather than trusted.
 var openCodeVersionRe = regexp.MustCompile(`^[0-9][0-9A-Za-z.+-]*$`)
 
-// openCodePluginDeps resolves the pre-built dependency tree, building it at most
-// once per process.
+// openCodePluginDeps resolves the pre-built dependency tree, building it on
+// first use.
 //
 // It resolves rather than reading something Bootstrap stashed, because Bootstrap
 // and SetupRepo run in DIFFERENT PROCESSES: `go run ./e2e/bootstrap`, then
@@ -110,7 +114,35 @@ var openCodeVersionRe = regexp.MustCompile(`^[0-9][0-9A-Za-z.+-]*$`)
 // test process, and because seeding degrades quietly that failure looks like
 // success — bootstrap reports a fast warmup while every test still pays the
 // install. That is exactly what run 33865617639 did.
-var openCodePluginDeps = sync.OnceValues(buildPluginDeps)
+//
+// A success is cached for the life of the process; a failure is retried, but at
+// most openCodeDepsAttempts times in total. Both bounds matter. Caching the
+// error — which is what sync.OnceValues does — lets one transient npm blip on
+// the very first call disable seeding for every repo in the run, reinstating the
+// concurrent-install storm this exists to prevent, for the whole run rather than
+// one attempt. Retrying without a cap is the opposite failure: ~40 installs when
+// npm is simply absent. The mutex is held across the build, so attempts are
+// serial and callers queue behind the one in flight either way.
+func openCodePluginDeps() (string, error) {
+	openCodeDeps.mu.Lock()
+	defer openCodeDeps.mu.Unlock()
+	if openCodeDeps.dir != "" {
+		return openCodeDeps.dir, nil
+	}
+	if openCodeDeps.attempts >= openCodeDepsAttempts {
+		return "", openCodeDeps.err
+	}
+	openCodeDeps.attempts++
+	openCodeDeps.dir, openCodeDeps.err = buildPluginDeps()
+	return openCodeDeps.dir, openCodeDeps.err
+}
+
+var openCodeDeps struct {
+	mu       sync.Mutex
+	dir      string
+	err      error
+	attempts int
+}
 
 // openCodeDepsDir names the shared tree for one opencode version.
 //

--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -32,7 +33,7 @@ func init() {
 }
 
 func (a *openCodeAgent) Name() string               { return "opencode" }
-func (a *openCodeAgent) Binary() string             { return "opencode" }
+func (a *openCodeAgent) Binary() string             { return openCodeBinary }
 func (a *openCodeAgent) EntireAgent() string        { return "opencode" }
 func (a *openCodeAgent) PromptPattern() string      { return `(Ask anything|▣)` }
 func (a *openCodeAgent) TimeoutMultiplier() float64 { return 2.0 }
@@ -75,6 +76,10 @@ const (
 	// range, so the tree has to be rebuilt on every opencode upgrade.
 	openCodePluginPkg = "@opencode-ai/plugin"
 
+	// openCodeBinary is the executable name, also used before an agent instance
+	// exists (the dependency tree is resolved from package scope).
+	openCodeBinary = "opencode"
+
 	// openCodeSeedGitignore mirrors the .gitignore opencode writes into
 	// .opencode itself. It names its own file, so everything we plant — the
 	// .gitignore included — stays invisible to git. That matters here beyond
@@ -84,13 +89,33 @@ const (
 )
 
 // openCodeVersionRe matches what `opencode --version` prints. The result names
-// a cache directory, so it is validated rather than trusted.
+// a directory, so it is validated rather than trusted.
 var openCodeVersionRe = regexp.MustCompile(`^[0-9][0-9A-Za-z.+-]*$`)
 
-// openCodePluginDeps is the warmed dependency tree built once by Bootstrap and
-// seeded into every test repo by SeedRepo. Empty when it could not be built, in
-// which case seeding is skipped and opencode installs per-directory as usual.
-var openCodePluginDeps string
+// openCodePluginDeps resolves the pre-built dependency tree, building it at most
+// once per process.
+//
+// It resolves rather than reading something Bootstrap stashed, because Bootstrap
+// and SetupRepo run in DIFFERENT PROCESSES: `go run ./e2e/bootstrap`, then
+// `go test ./e2e/tests`. A package variable set by Bootstrap is empty in the
+// test process, and because seeding degrades quietly that failure looks like
+// success — bootstrap reports a fast warmup while every test still pays the
+// install. That is exactly what run 33865617639 did.
+var openCodePluginDeps = sync.OnceValues(buildPluginDeps)
+
+// openCodeDepsDir names the shared tree for one opencode version.
+//
+// Deliberately not under os.UserCacheDir(): the e2e TestMain points
+// XDG_CACHE_HOME at the artifact directory, so a tree built there would both
+// miss the one Bootstrap built — different process, different cache dir — and
+// be uploaded as a ~61MB CI artifact. os.TempDir() is stable across both
+// processes, which is the whole requirement.
+//
+// Keyed by version because opencode pins the plugin to its own binary version,
+// so a tree built for an older opencode is one it would discard and reinstall.
+func openCodeDepsDir(version string) string {
+	return filepath.Join(os.TempDir(), "entire-e2e-opencode-deps-"+version)
+}
 
 func (a *openCodeAgent) Bootstrap() error {
 	// Build the dependency tree opencode would otherwise install itself, once,
@@ -106,14 +131,19 @@ func (a *openCodeAgent) Bootstrap() error {
 	// between "loading path=..." and "all LSPs are disabled".
 	//
 	// Doing it here turns ~40 unbounded installs hidden inside the agent into
-	// one bounded step that reports its own failure. It is not a workaround for
-	// a test-only problem: every user gets the same install on first launch per
-	// repo, and again after each opencode upgrade.
-	if deps, err := a.buildPluginDeps(); err != nil {
+	// one bounded step that reports its own failure.
+	//
+	// Not a test-only problem. opencode forks that install for every config
+	// directory that exists (ConfigPaths.directories) and blocks on all of them
+	// whenever any plugin is configured (plugin/index.ts: `if (plugins.length)
+	// yield* config.waitForDependencies()`). So a repo pays it once it has both
+	// a project-local .opencode directory and a plugin configured anywhere,
+	// global or project — and `entire enable` supplies both.
+	if deps, err := openCodePluginDeps(); err != nil {
 		fmt.Fprintf(os.Stderr, "opencode: could not pre-build plugin deps (%v)\n"+
 			"opencode: tests will pay the per-directory install themselves\n", err)
 	} else {
-		openCodePluginDeps = deps
+		fmt.Fprintf(os.Stderr, "opencode: plugin deps ready at %s\n", deps)
 	}
 
 	// opencode also has a first-run DB migration that races with parallel test
@@ -156,50 +186,61 @@ func (a *openCodeAgent) Bootstrap() error {
 	return nil
 }
 
-// buildPluginDeps materialises the .opencode dependency tree once, keyed by
-// opencode version, and returns the directory holding it. See Bootstrap for why.
-func (a *openCodeAgent) buildPluginDeps() (string, error) {
-	version, err := a.version()
+// buildPluginDeps materialises the .opencode dependency tree once and returns
+// the directory holding it. See Bootstrap for why it exists.
+func buildPluginDeps() (string, error) {
+	version, err := openCodeVersion()
 	if err != nil {
 		return "", err
 	}
-	cache, err := os.UserCacheDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve user cache dir: %w", err)
-	}
-	// Keyed by version because the pin follows the binary: a tree built for an
-	// older opencode is one opencode will discard and reinstall.
-	dir := filepath.Join(cache, "entire-e2e", "opencode-plugin-deps", version)
+	dir := openCodeDepsDir(version)
 	if _, err := os.Stat(filepath.Join(dir, "node_modules")); err == nil {
-		fmt.Fprintf(os.Stderr, "opencode: reusing plugin deps for %s at %s\n", version, dir)
 		return dir, nil
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", fmt.Errorf("create plugin dep dir %q: %w", dir, err)
+
+	// Built in a staging directory and renamed into place, so a reader never
+	// sees a half-installed tree. Bootstrap normally wins this race and the test
+	// process takes the Stat above; if bootstrap was skipped, a loser here
+	// adopts the winner's tree rather than failing.
+	staging, err := os.MkdirTemp(os.TempDir(), "entire-e2e-opencode-deps-*")
+	if err != nil {
+		return "", fmt.Errorf("create staging dir: %w", err)
 	}
+	defer func() { _ = os.RemoveAll(staging) }() // no-op once renamed away
 	pkg := fmt.Sprintf("{\n  \"dependencies\": {\n    %q: %q\n  }\n}\n", openCodePluginPkg, version)
-	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkg), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(staging, "package.json"), []byte(pkg), 0o644); err != nil {
 		return "", fmt.Errorf("write package.json: %w", err)
 	}
 
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), openCodeDepsBudget)
 	defer cancel()
+	// The npm CLI, deliberately: opencode installs the same tree with
+	// @npmcli/arborist in-process, which measured 5m00s against npm's 3s for an
+	// identical result. Using npm here is the point of doing it ourselves.
 	cmd := exec.CommandContext(ctx, "npm", "install", "--no-audit", "--no-fund", "--loglevel=error")
-	cmd.Dir = dir
+	cmd.Dir = staging
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("npm install %s@%s: %w\n%s", openCodePluginPkg, version, err, out)
 	}
-	fmt.Fprintf(os.Stderr, "opencode: built plugin deps for %s in %s\n", version, time.Since(start).Round(time.Millisecond))
+	elapsed := time.Since(start).Round(time.Millisecond)
+
+	if err := os.Rename(staging, dir); err != nil {
+		if _, statErr := os.Stat(filepath.Join(dir, "node_modules")); statErr == nil {
+			return dir, nil // lost the race; the winner's tree is equivalent
+		}
+		return "", fmt.Errorf("publish plugin deps to %q: %w", dir, err)
+	}
+	fmt.Fprintf(os.Stderr, "opencode: built plugin deps for %s in %s at %s\n", version, elapsed, dir)
 	return dir, nil
 }
 
-// version reports the running opencode's version, which is the version its
-// generated package.json will pin.
-func (a *openCodeAgent) version() (string, error) {
+// openCodeVersion reports the running opencode's version, which is the version
+// its generated package.json will pin.
+func openCodeVersion() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, a.Binary(), "--version").Output()
+	out, err := exec.CommandContext(ctx, openCodeBinary, "--version").Output()
 	if err != nil {
 		return "", fmt.Errorf("opencode --version: %w", err)
 	}
@@ -214,15 +255,18 @@ func (a *openCodeAgent) version() (string, error) {
 // SeedRepo plants the pre-built dependency tree in a fresh test repo so
 // opencode's own blocking install never runs there.
 func (a *openCodeAgent) SeedRepo(dir string) error {
-	if openCodePluginDeps == "" {
-		return nil // Bootstrap could not build the tree; leave the repo alone.
+	deps, err := openCodePluginDeps()
+	if err != nil {
+		// Leave the repo alone and let opencode install for itself.
+		fmt.Fprintf(os.Stderr, "opencode: no pre-built plugin deps (%v); %s pays the install\n", err, dir)
+		return nil
 	}
 	target := filepath.Join(dir, ".opencode")
 	if err := os.MkdirAll(target, 0o755); err != nil {
 		return fmt.Errorf("create .opencode: %w", err)
 	}
 	for _, name := range []string{"package.json", "package-lock.json"} {
-		data, err := os.ReadFile(filepath.Join(openCodePluginDeps, name))
+		data, err := os.ReadFile(filepath.Join(deps, name))
 		if err != nil {
 			return fmt.Errorf("read seeded %s: %w", name, err)
 		}
@@ -238,7 +282,7 @@ func (a *openCodeAgent) SeedRepo(dir string) error {
 	// cost about what the install we are avoiding costs. opencode reads through
 	// the link and leaves it in place.
 	link := filepath.Join(target, "node_modules")
-	if err := os.Symlink(filepath.Join(openCodePluginDeps, "node_modules"), link); err != nil {
+	if err := os.Symlink(filepath.Join(deps, "node_modules"), link); err != nil {
 		// Degrade to opencode installing for itself rather than failing setup —
 		// symlinks are not available unprivileged on every platform.
 		fmt.Fprintf(os.Stderr, "opencode: could not link seeded node_modules (%v); this repo pays the install\n", err)

--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -22,7 +22,7 @@ func init() {
 	if env := os.Getenv("E2E_AGENT"); env != "" && env != "opencode" {
 		return
 	}
-	if _, err := exec.LookPath("opencode"); err != nil {
+	if _, err := exec.LookPath(openCodeBinary); err != nil {
 		return
 	}
 	model := os.Getenv("E2E_OPENCODE_MODEL")
@@ -65,6 +65,13 @@ const (
 	// attempt part-way leaves that work half-done for every test that follows.
 	openCodeWarmupBudget = 90 * time.Second
 
+	// openCodeWarmupRetryBudget bounds attempts after the first. Only attempt 1
+	// can be paying opencode's genuine first-run costs, so retrying at the full
+	// budget just multiplies the wait before we give up and let the tests run
+	// anyway: 3 x 90s is over four minutes of blocked CI on the exact path this
+	// warmup exists to survive.
+	openCodeWarmupRetryBudget = 30 * time.Second
+
 	// openCodeDepsBudget bounds the plugin dependency install. It is generous
 	// against a measured ~3s because a cold npm cache on a CI runner is a very
 	// different machine from a developer's, and the cost of overrunning it is
@@ -76,8 +83,10 @@ const (
 	// range, so the tree has to be rebuilt on every opencode upgrade.
 	openCodePluginPkg = "@opencode-ai/plugin"
 
-	// openCodeBinary is the executable name, also used before an agent instance
-	// exists (the dependency tree is resolved from package scope).
+	// openCodeBinary is the executable name. It is a constant because the
+	// dependency tree is resolved from package scope, before any agent instance
+	// exists. Name()/EntireAgent() return the agent id and keep their own
+	// literals — the two happen to coincide.
 	openCodeBinary = "opencode"
 
 	// openCodeSeedGitignore mirrors the .gitignore opencode writes into
@@ -139,13 +148,11 @@ func (a *openCodeAgent) Bootstrap() error {
 	// yield* config.waitForDependencies()`). So a repo pays it once it has both
 	// a project-local .opencode directory and a plugin configured anywhere,
 	// global or project — and `entire enable` supplies both.
-	if deps, err := openCodePluginDeps(); err != nil {
-		fmt.Fprintf(os.Stderr, "opencode: could not pre-build plugin deps (%v)\n"+
-			"opencode: tests will pay the per-directory install themselves\n", err)
-	} else {
-		fmt.Fprintf(os.Stderr, "opencode: plugin deps ready at %s\n", deps)
-	}
-
+	//
+	// The build is triggered by the SeedRepo call below rather than here:
+	// buildPluginDeps reports the build and SeedRepo reports a failure, so an
+	// explicit call would only print a third message about the same event.
+	//
 	// opencode also has a first-run DB migration that races with parallel test
 	// execution (upstream issue #6935). Run a trivial prompt to force the rest
 	// of initialization before tests. It runs in a seeded scratch directory so
@@ -164,20 +171,23 @@ func (a *openCodeAgent) Bootstrap() error {
 	}
 
 	for i := range 3 {
+		budget := openCodeWarmupBudget
+		if i > 0 {
+			budget = openCodeWarmupRetryBudget
+		}
 		start := time.Now()
-		ctx, cancel := context.WithTimeout(context.Background(), openCodeWarmupBudget)
-		cmd := exec.CommandContext(ctx, a.Binary(), "run", "--model", a.model, "say hi")
-		cmd.Dir = warmDir
-		cmd.Env = openCodePromptEnv(os.Environ(), warmDir)
-		out, err := cmd.CombinedOutput()
-		cancel()
+		// Through RunPrompt so the warmup child is set up exactly like a test's.
+		// The difference is not cosmetic: openCodePromptEnv forces PWD, without
+		// which opencode resolves a different project root and never loads the
+		// plugin — a warmup that skipped it would warm the wrong directory.
+		out, err := a.RunPrompt(context.Background(), warmDir, "say hi", WithPromptTimeout(budget))
 		elapsed := time.Since(start).Round(time.Millisecond)
 		if err == nil {
 			fmt.Fprintf(os.Stderr, "opencode warmup succeeded on attempt %d in %s\n", i+1, elapsed)
 			return nil
 		}
 		if i < 2 {
-			fmt.Fprintf(os.Stderr, "opencode warmup attempt %d failed after %s: %s\n%s\n", i+1, elapsed, err, out)
+			fmt.Fprintf(os.Stderr, "opencode warmup attempt %d failed after %s: %s\n%s%s\n", i+1, elapsed, err, out.Stdout, out.Stderr)
 			time.Sleep(5 * time.Second)
 		}
 	}
@@ -252,9 +262,23 @@ func openCodeVersion() (string, error) {
 	return version, nil
 }
 
-// SeedRepo plants the pre-built dependency tree in a fresh test repo so
-// opencode's own blocking install never runs there.
+// SeedRepo prepares a directory opencode is about to run in: its config file,
+// plus the pre-built dependency tree so opencode's own blocking install never
+// runs there.
 func (a *openCodeAgent) SeedRepo(dir string) error {
+	// Written before the tree is resolved, so a repo still gets a usable config
+	// when the pre-build failed and opencode falls back to installing for itself.
+	//
+	// opencode's non-interactive mode auto-rejects the external_directory
+	// permission, since there is no user to prompt.
+	cfg := `{"$schema": "https://opencode.ai/config.json", "permission": {"external_directory": "allow"}}`
+	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
+		cfg = fmt.Sprintf(`{"$schema": "https://opencode.ai/config.json", "permission": {"external_directory": "allow"}, "provider": {"anthropic": {"options": {"apiKey": %q}}}}`, key)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "opencode.json"), []byte(cfg+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write opencode.json: %w", err)
+	}
+
 	deps, err := openCodePluginDeps()
 	if err != nil {
 		// Leave the repo alone and let opencode install for itself.
@@ -282,10 +306,11 @@ func (a *openCodeAgent) SeedRepo(dir string) error {
 	// cost about what the install we are avoiding costs. opencode reads through
 	// the link and leaves it in place.
 	link := filepath.Join(target, "node_modules")
-	if err := os.Symlink(filepath.Join(deps, "node_modules"), link); err != nil {
-		// Degrade to opencode installing for itself rather than failing setup —
-		// symlinks are not available unprivileged on every platform.
-		fmt.Fprintf(os.Stderr, "opencode: could not link seeded node_modules (%v); this repo pays the install\n", err)
+	if err := linkFile(filepath.Join(deps, "node_modules"), link); err != nil {
+		// Degrade to opencode installing for itself rather than failing setup.
+		// linkFile copies on Windows, which cannot copy a directory, so that
+		// platform lands here by design.
+		fmt.Fprintf(os.Stderr, "opencode: could not link seeded node_modules (%v); %s pays the install\n", err, dir)
 		return nil
 	}
 	return nil

--- a/e2e/agents/opencode_seed_test.go
+++ b/e2e/agents/opencode_seed_test.go
@@ -1,0 +1,64 @@
+package agents
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestOpenCodeSeedRepoPlantsDeps runs SeedRepo the way SetupRepo does: from a
+// process that never called Bootstrap.
+//
+// That is the whole point of the test. Bootstrap runs in `go run ./e2e/bootstrap`
+// and SetupRepo in `go test ./e2e/tests`, so an implementation that hands the
+// dependency tree between them through a package variable seeds nothing — and
+// seeding degrades quietly, so the suite reports a fast bootstrap while every
+// test still pays opencode's ~61MB per-directory install (run 33865617639).
+func TestOpenCodeSeedRepoPlantsDeps(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("opencode"); err != nil {
+		t.Skip("opencode not installed")
+	}
+	if _, err := exec.LookPath("npm"); err != nil {
+		t.Skip("npm not installed")
+	}
+
+	dir := t.TempDir()
+	agent := &openCodeAgent{model: "test"}
+	if err := agent.SeedRepo(dir); err != nil {
+		t.Fatalf("SeedRepo: %v", err)
+	}
+
+	// node_modules is the one that matters: opencode reinstalls without it.
+	link := filepath.Join(dir, ".opencode", "node_modules")
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("node_modules is not a symlink into the shared tree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "@opencode-ai", "plugin")); err != nil {
+		t.Fatalf("linked tree does not contain %s: %v", openCodePluginPkg, err)
+	}
+
+	for _, name := range []string{"package.json", "package-lock.json", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(dir, ".opencode", name)); err != nil {
+			t.Errorf("seeded %s missing: %v", name, err)
+		}
+	}
+
+	// Everything planted must be invisible to git: these repos are the subject
+	// of checkpoint assertions, and an untracked 61MB tree in the working set
+	// would change what the CLI sees. The .gitignore names itself for that
+	// reason, so a shortened list is a real regression rather than a detail.
+	ignored, err := os.ReadFile(filepath.Join(dir, ".opencode", ".gitignore"))
+	if err != nil {
+		t.Fatalf("read seeded .gitignore: %v", err)
+	}
+	for _, want := range []string{"node_modules", "package.json", "package-lock.json", ".gitignore"} {
+		if !slices.Contains(strings.Split(string(ignored), "\n"), want) {
+			t.Errorf("seeded .gitignore does not ignore %q:\n%s", want, ignored)
+		}
+	}
+}

--- a/e2e/agents/opencode_seed_test.go
+++ b/e2e/agents/opencode_seed_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -33,13 +34,25 @@ func TestOpenCodeSeedRepoPlantsDeps(t *testing.T) {
 	}
 
 	// node_modules is the one that matters: opencode reinstalls without it.
+	//
+	// Windows asserts the documented degradation instead. linkFile copies there
+	// rather than linking, and a copy cannot be a 61MB directory, so SeedRepo
+	// warns and leaves the repo to opencode. Everything else it plants is
+	// platform-independent, which is why this branches instead of excluding the
+	// whole test — the cross-process resolution above is what it exists to pin.
 	link := filepath.Join(dir, ".opencode", "node_modules")
-	target, err := os.Readlink(link)
-	if err != nil {
-		t.Fatalf("node_modules is not a symlink into the shared tree: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(target, "@opencode-ai", "plugin")); err != nil {
-		t.Fatalf("linked tree does not contain %s: %v", openCodePluginPkg, err)
+	if runtime.GOOS == "windows" {
+		if _, err := os.Lstat(link); !os.IsNotExist(err) {
+			t.Errorf("expected SeedRepo to degrade without node_modules on windows, got err=%v", err)
+		}
+	} else {
+		target, err := os.Readlink(link)
+		if err != nil {
+			t.Fatalf("node_modules is not a symlink into the shared tree: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(target, "@opencode-ai", "plugin")); err != nil {
+			t.Fatalf("linked tree does not contain %s: %v", openCodePluginPkg, err)
+		}
 	}
 
 	for _, name := range []string{"package.json", "package-lock.json", "opencode.json"} {

--- a/e2e/agents/opencode_seed_test.go
+++ b/e2e/agents/opencode_seed_test.go
@@ -19,7 +19,7 @@ import (
 // test still pays opencode's ~61MB per-directory install (run 33865617639).
 func TestOpenCodeSeedRepoPlantsDeps(t *testing.T) {
 	t.Parallel()
-	if _, err := exec.LookPath("opencode"); err != nil {
+	if _, err := exec.LookPath(openCodeBinary); err != nil {
 		t.Skip("opencode not installed")
 	}
 	if _, err := exec.LookPath("npm"); err != nil {
@@ -42,8 +42,12 @@ func TestOpenCodeSeedRepoPlantsDeps(t *testing.T) {
 		t.Fatalf("linked tree does not contain %s: %v", openCodePluginPkg, err)
 	}
 
-	for _, name := range []string{"package.json", "package-lock.json", ".gitignore"} {
-		if _, err := os.Stat(filepath.Join(dir, ".opencode", name)); err != nil {
+	for _, name := range []string{"package.json", "package-lock.json", "opencode.json"} {
+		at := filepath.Join(dir, ".opencode", name)
+		if name == "opencode.json" {
+			at = filepath.Join(dir, name) // opencode's config sits at the root
+		}
+		if _, err := os.Stat(at); err != nil {
 			t.Errorf("seeded %s missing: %v", name, err)
 		}
 	}
@@ -56,8 +60,9 @@ func TestOpenCodeSeedRepoPlantsDeps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read seeded .gitignore: %v", err)
 	}
+	lines := strings.Split(string(ignored), "\n")
 	for _, want := range []string{"node_modules", "package.json", "package-lock.json", ".gitignore"} {
-		if !slices.Contains(strings.Split(string(ignored), "\n"), want) {
+		if !slices.Contains(lines, want) {
 			t.Errorf("seeded .gitignore does not ignore %q:\n%s", want, ignored)
 		}
 	}

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -144,6 +144,16 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 		}
 	}
 
+	// Agents that need files planted before their first run in a repo get them
+	// here — after `entire enable` has written the agent's own config, so a
+	// seed can sit alongside it. opencode uses this to receive a pre-built
+	// .opencode dependency tree instead of installing one itself on the clock.
+	if seeder, ok := agent.(agents.RepoSeeder); ok {
+		if err := seeder.SeedRepo(dir); err != nil {
+			t.Fatalf("seed repo for %s: %v", agent.Name(), err)
+		}
+	}
+
 	// Create artifact dir eagerly so console.log is written to disk
 	// incrementally. Even if the test is killed by a global timeout,
 	// partial output survives.

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -132,22 +132,12 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 		}
 	}
 
-	// OpenCode's non-interactive mode auto-rejects external_directory permission
-	// since there's no user to prompt. Write a config to allow it.
-	if agent.Name() == "opencode" {
-		cfg := `{"$schema": "https://opencode.ai/config.json", "permission": {"external_directory": "allow"}}`
-		if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
-			cfg = fmt.Sprintf(`{"$schema": "https://opencode.ai/config.json", "permission": {"external_directory": "allow"}, "provider": {"anthropic": {"options": {"apiKey": %q}}}}`, key)
-		}
-		if err := os.WriteFile(filepath.Join(dir, "opencode.json"), []byte(cfg+"\n"), 0o644); err != nil {
-			t.Fatalf("write opencode.json: %v", err)
-		}
-	}
-
 	// Agents that need files planted before their first run in a repo get them
 	// here — after `entire enable` has written the agent's own config, so a
-	// seed can sit alongside it. opencode uses this to receive a pre-built
-	// .opencode dependency tree instead of installing one itself on the clock.
+	// seed can sit alongside it. opencode uses this for its config file and for
+	// a pre-built .opencode dependency tree it would otherwise install on the
+	// clock; keeping both in the agent is why this is an interface rather than
+	// another arm of the name switch above.
 	if seeder, ok := agent.(agents.RepoSeeder); ok {
 		if err := seeder.SeedRepo(dir); err != nil {
 			t.Fatalf("seed repo for %s: %v", agent.Name(), err)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1238
<!-- entire-trail-link-end -->

## What

The `e2e-tests (opencode)` leg went red on main from 2026-09-03 22:10 UTC and stayed red. This makes it green again: [run 33867981097](https://github.com/entireio/cli/actions/runs/33867981097) — **all 56 tests passed**, `Run E2E Tests` 469s (it was 1266s and failing).

## Why it was failing

Every failure was `agent failed: signal: killed` at the 120s prompt budget, with **zero assertion failures** and completely empty stdout and stderr. Nothing in the artifacts named a cause, because opencode prints nothing while it stalls.

It was not a gradual degradation. The single-process bootstrap warmup was 9–15s for all 32 preceding runs, then 40s+ on every run after. Not ours, and not opencode's code either: same opencode version (1.18.27) on both sides of the boundary, same runner image, only trail-routing commits in our repo, the claude-code leg sharing the same API key got *faster*, our own hook perf was *better* in the red runs, and opencode's install path has one commit since Aug 25 (on 08-27).

What changed is that a cost which was always pathological stopped fitting in the budgets.

## The mechanism

From opencode's source at 1.18.27: `ConfigPaths.directories` returns the global config dir plus every existing `.opencode` directory walking up from cwd. `config.ts:452` forks a background `@opencode-ai/plugin` install for **each** of them. `plugin/index.ts:184` — `if (plugins.length) yield* config.waitForDependencies()` — then blocks on all of them, and `waitForDependencies` joins the fibers with **no timeout** and logs nothing.

So a repo pays a 27-package, ~61MB install once it has both a project-local `.opencode` directory and a plugin configured anywhere, global or project. `entire enable` supplies both by writing `.opencode/plugins/entire.ts`. Every test gets a fresh repo, so we were paying it ~40 times in parallel.

It is also much worse than an npm install sounds: `npm.ts:81` runs `@npmcli/arborist`'s `reify()` in-process rather than the npm CLI. Measured on one machine, identical 27-package result: **arborist 5m00.9s at 1% CPU, `npm install` 3s**.

## What this does

1. **Collect opencode's logs** into the artifact tree. This is what made the diagnosis possible at all, and it is the piece worth keeping regardless of the rest.
2. **Pre-build the dependency tree once** with the npm CLI and seed it into each test repo through a new `RepoSeeder` hook on `SetupRepo`. `node_modules` is symlinked, not copied — 61MB across thousands of small files times ~40 live repos would cost about what it saves. The seed also writes opencode's own `.gitignore`, which names its own file, so nothing planted is visible to git; these repos are the subject of checkpoint assertions.
3. **Raise the warmup budget** and report each attempt's duration, so the one serial, uncontended measurement of opencode startup is visible in the CI log rather than only in a downloaded artifact.

Every step degrades to today's behaviour instead of failing: no npm, an unparseable version, or a platform without unprivileged symlinks all leave the repo alone and let opencode install for itself.

## Verification

Don't read the pass count alone — parse the newly-collected `opencode-logs/opencode.log` for the gap between the last `loading path=` line and the next event. That is the install window.

| | broken | fixed |
| --- | --- | --- |
| median gap | 23.5s | **0.15s** |
| p90 | 57.5s | 0.24s |
| killed inside it | 31 of 53 | 6 of 60 |

The 6 remaining are processes ended by test teardown, not stalls — with a 0.35s max gap there is nothing left to stall on.

## Worth knowing

One intermediate revision here looked fixed and was not: `Bootstrap` runs in `go run ./e2e/bootstrap` and `SetupRepo` in `go test ./e2e/tests`, two processes, so handing the tree between them via a package variable seeded nothing. Because seeding degrades quietly, the bootstrap log reported success while 31 of 53 processes still stalled. The tree is now resolved per-process, and `TestOpenCodeSeedRepoPlantsDeps` runs `SeedRepo` from a process that never called `Bootstrap` — the shape of that bug.

## Not in scope

The same install hits real users under the same two conditions. Moving Entire's plugin to `~/.config/opencode/plugins/` would make it a one-time global cost instead of per-repo, at the price of loading in every project including ones where Entire was never enabled — a design call, not a refactor. Upstream: anomalyco/opencode#47212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches only E2E/CI paths but adds cross-process caching, npm installs, and symlink semantics where quiet fallback could mask regressions.
> 
> **Overview**
> Fixes opencode E2E timeouts caused by **~40 parallel, silent `@opencode-ai/plugin` installs** (~61MB each) after `entire enable` adds a project plugin.
> 
> Adds a **`RepoSeeder`** hook so agents can plant files post-`entire enable`; opencode **`SeedRepo`** now writes `opencode.json`, copies pinned `package.json` / lockfile into `.opencode`, symlinks a **shared `node_modules` tree** built once per process via **`npm install`** (version-keyed under `os.TempDir()`), and mirrors opencode’s `.gitignore` so seeded blobs don’t affect checkpoint/git assertions. **`Bootstrap`** warms up in a seeded scratch dir through **`RunPrompt`** with longer first-attempt budgets and per-attempt timing logs.
> 
> **CI** copies `~/.local/share/opencode/log` into artifacts on the opencode matrix leg. **`TestOpenCodeSeedRepoPlantsDeps`** asserts seeding works from the test process without relying on bootstrap-only state.
> 
> OpenCode-specific setup was removed from **`SetupRepo`** in favor of the seeder interface; failures to pre-build or link deps **degrade** to opencode’s own install rather than failing setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b055dcbde6c9d8228fb2faaf0034484e2dd9e50b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->