### PR TITLE
flock: revalidate lock file inode after acquire

### DIFF
--- a/cmd/entire/cli/internal/flock/flock_unix.go
+++ b/cmd/entire/cli/internal/flock/flock_unix.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
 )
 
 // pollInterval is how often the bounded AcquireContext path retries a
@@ -22,8 +24,8 @@ const pollInterval = 25 * time.Millisecond
 // Acquire takes an exclusive advisory lock on path, creating the file if
 // needed. The returned release closes the file, which drops the flock.
 // Callers must invoke release exactly once. The lock file persists between
-// runs — flock state is held by the file descriptor, not by the inode on
-// disk — so the lockfile contents are immaterial.
+// runs - flock state is held by the file descriptor, not by the inode on
+// disk - so the lockfile contents are immaterial.
 //
 // Acquire blocks indefinitely until the lock is available. Use AcquireContext
 // with a deadline to bound the wait.
@@ -39,11 +41,15 @@ func Acquire(path string) (release func(), err error) {
 // (turn-start) bound their wait and degrade gracefully instead of stalling
 // behind a long-running lock holder (e.g. checkpoint condensation).
 func AcquireContext(ctx context.Context, path string) (release func(), err error) {
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec // caller is responsible for path validation
-	if err != nil {
-		return nil, fmt.Errorf("open flock: %w", err)
-	}
-	return lockFile(ctx, f)
+	return lockFile(ctx, func() (*os.File, error) {
+		f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec // caller is responsible for path validation
+		if err != nil {
+			return nil, err //nolint:wrapcheck // lockFile wraps opener errors once
+		}
+		return f, nil
+	}, func(f *os.File) (bool, error) {
+		return holdsCurrentPathInode(f, path)
+	})
 }
 
 // AcquireIn is Acquire for a lock file named inside root. It is the form the
@@ -56,46 +62,118 @@ func AcquireIn(root *os.Root, name string) (release func(), err error) {
 
 // AcquireContextIn is AcquireContext for a lock file named inside root.
 func AcquireContextIn(ctx context.Context, root *os.Root, name string) (release func(), err error) {
-	f, err := openLockFileIn(root, name)
-	if err != nil {
-		return nil, fmt.Errorf("open flock: %w", err)
-	}
-	return lockFile(ctx, f)
+	return lockFile(ctx, func() (*os.File, error) {
+		return openLockFileIn(root, name)
+	}, func(f *os.File) (bool, error) {
+		return holdsCurrentRootInode(f, root, name)
+	})
 }
 
 // lockFile holds the locking logic shared by the path- and root-based entry
-// points, which differ only in how the file was opened.
-func lockFile(ctx context.Context, f *os.File) (release func(), err error) {
-	// Fast path: no deadline -> block in the kernel exactly like the historical
-	// Acquire. This preserves behavior (and efficiency) for callers that must
-	// wait as long as it takes, such as turn-end checkpoint condensation.
+// points, which differ only in how the file is opened and revalidated.
+func lockFile(ctx context.Context, open func() (*os.File, error), holdsCurrent func(*os.File) (bool, error)) (release func(), err error) {
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil { //nolint:gosec // file descriptors are non-negative; standard Go pattern for syscall.Flock
+		for range 3 {
+			f, err := open()
+			if err != nil {
+				return nil, fmt.Errorf("open flock: %w", err)
+			}
+			if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil { //nolint:gosec // file descriptors are non-negative; standard Go pattern for syscall.Flock
+				_ = f.Close()
+				return nil, fmt.Errorf("flock: %w", err)
+			}
+			current, err := holdsCurrent(f)
+			if err != nil {
+				_ = f.Close()
+				return nil, err
+			}
+			if current {
+				return func() { _ = f.Close() }, nil
+			}
 			_ = f.Close()
-			return nil, fmt.Errorf("flock: %w", err)
 		}
-		return func() { _ = f.Close() }, nil
+		return nil, errors.New("flock path changed while acquiring lock")
 	}
 
-	// Bounded path: poll a non-blocking lock until acquired or ctx is done.
+	staleInodeRetries := 0
 	for {
+		f, err := open()
+		if err != nil {
+			return nil, fmt.Errorf("open flock: %w", err)
+		}
 		lockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB) //nolint:gosec // see above
 		if lockErr == nil {
-			return func() { _ = f.Close() }, nil
-		}
-		if !errors.Is(lockErr, syscall.EWOULDBLOCK) {
+			current, err := holdsCurrent(f)
+			if err != nil {
+				_ = f.Close()
+				return nil, err
+			}
+			if current {
+				return func() { _ = f.Close() }, nil
+			}
 			_ = f.Close()
-			return nil, fmt.Errorf("flock: %w", lockErr)
-		}
-		if err := ctx.Err(); err != nil {
+			staleInodeRetries++
+			if staleInodeRetries >= 3 {
+				return nil, errors.New("flock path changed while acquiring lock")
+			}
+		} else {
 			_ = f.Close()
-			return nil, fmt.Errorf("flock: %w", err)
+			if !errors.Is(lockErr, syscall.EWOULDBLOCK) {
+				return nil, fmt.Errorf("flock: %w", lockErr)
+			}
 		}
-		select {
-		case <-ctx.Done():
-			_ = f.Close()
-			return nil, fmt.Errorf("flock: %w", ctx.Err())
-		case <-time.After(pollInterval):
+		if err := waitForRetry(ctx); err != nil {
+			return nil, err
 		}
 	}
+}
+
+func waitForRetry(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("flock: %w", err)
+	}
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("flock: %w", ctx.Err())
+	case <-time.After(pollInterval):
+		return nil
+	}
+}
+
+func holdsCurrentPathInode(f *os.File, path string) (bool, error) {
+	pathInfo, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat flock path: %w", err)
+	}
+	return sameInode(f, pathInfo, "path")
+}
+
+func holdsCurrentRootInode(f *os.File, root *os.Root, name string) (bool, error) {
+	pathInfo, err := osroot.LstatNoSymlinks(root, name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat flock root path: %w", err)
+	}
+	return sameInode(f, pathInfo, "root path")
+}
+
+func sameInode(f *os.File, pathInfo os.FileInfo, label string) (bool, error) {
+	heldInfo, err := f.Stat()
+	if err != nil {
+		return false, fmt.Errorf("stat flock fd: %w", err)
+	}
+	held, ok := heldInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, fmt.Errorf("stat flock fd: unexpected stat type %T", heldInfo.Sys())
+	}
+	current, ok := pathInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, fmt.Errorf("stat flock %s: unexpected stat type %T", label, pathInfo.Sys())
+	}
+	return held.Dev == current.Dev && held.Ino == current.Ino, nil
 }

--- a/cmd/entire/cli/internal/flock/flock_unix_test.go
+++ b/cmd/entire/cli/internal/flock/flock_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -19,8 +20,8 @@ func TestAcquireRevalidatesReplacedLockFileInode(t *testing.T) {
 		func(time.Duration) (func(), error) {
 			return Acquire(path)
 		},
-		func() error {
-			return os.Remove(path)
+		func() (func(), error) {
+			return installLockedReplacement(path)
 		},
 	)
 }
@@ -42,8 +43,8 @@ func TestAcquireContextRevalidatesReplacedLockFileInode(t *testing.T) {
 				cancel()
 			}, nil
 		},
-		func() error {
-			return os.Remove(path)
+		func() (func(), error) {
+			return installLockedReplacement(path)
 		},
 	)
 }
@@ -63,8 +64,8 @@ func TestAcquireInRevalidatesReplacedLockFileInode(t *testing.T) {
 		func(time.Duration) (func(), error) {
 			return AcquireIn(root, name)
 		},
-		func() error {
-			return os.Remove(filepath.Join(dir, name))
+		func() (func(), error) {
+			return installLockedReplacement(filepath.Join(dir, name))
 		},
 	)
 }
@@ -93,8 +94,8 @@ func TestAcquireContextInRevalidatesReplacedLockFileInode(t *testing.T) {
 				cancel()
 			}, nil
 		},
-		func() error {
-			return os.Remove(filepath.Join(dir, name))
+		func() (func(), error) {
+			return installLockedReplacement(filepath.Join(dir, name))
 		},
 	)
 }
@@ -126,6 +127,32 @@ func TestLockFileStaleInodeRetryHonorsContextDeadline(t *testing.T) {
 	}
 }
 
+// installLockedReplacement unlinks whatever lock file is at path and installs a
+// fresh one, already flocked, in a single rename.
+//
+// The obvious version of this - unlink, then acquire - is racy against the
+// polling acquire paths. Their next poll re-opens with O_CREATE, so the waiter
+// under test can create the replacement itself, lock it, revalidate it clean
+// and return holding it, leaving the caller here to block on that inode until
+// its own deadline. Renaming an already-locked file over the name leaves no
+// moment at which the name exists unlocked, so the waiter can only ever find it
+// held.
+func installLockedReplacement(path string) (release func(), err error) {
+	f, err := os.OpenFile(path+".replacement", os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if err := os.Rename(path+".replacement", path); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return func() { _ = f.Close() }, nil
+}
+
 func openPathLockFile(t *testing.T, path string) func() (*os.File, error) {
 	t.Helper()
 
@@ -134,7 +161,7 @@ func openPathLockFile(t *testing.T, path string) func() (*os.File, error) {
 	}
 }
 
-func testRevalidatesReplacedLockFileInode(t *testing.T, acquire func(time.Duration) (func(), error), removeLockFile func() error) {
+func testRevalidatesReplacedLockFileInode(t *testing.T, acquire func(time.Duration) (func(), error), replaceLockFile func() (func(), error)) {
 	t.Helper()
 
 	releaseOld, err := acquire(2 * time.Second)
@@ -154,13 +181,9 @@ func testRevalidatesReplacedLockFileInode(t *testing.T, acquire func(time.Durati
 	}()
 
 	time.Sleep(50 * time.Millisecond)
-	if err := removeLockFile(); err != nil {
-		t.Fatalf("remove old lock path: %v", err)
-	}
-
-	releaseNew, err := acquire(2 * time.Second)
+	releaseNew, err := replaceLockFile()
 	if err != nil {
-		t.Fatalf("Acquire new lock: %v", err)
+		t.Fatalf("replace lock file: %v", err)
 	}
 
 	releaseOld()

--- a/cmd/entire/cli/internal/flock/flock_unix_test.go
+++ b/cmd/entire/cli/internal/flock/flock_unix_test.go
@@ -1,0 +1,187 @@
+//go:build unix
+
+package flock
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAcquireRevalidatesReplacedLockFileInode(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "resource.lock")
+	testRevalidatesReplacedLockFileInode(t,
+		func(time.Duration) (func(), error) {
+			return Acquire(path)
+		},
+		func() error {
+			return os.Remove(path)
+		},
+	)
+}
+
+func TestAcquireContextRevalidatesReplacedLockFileInode(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "resource.lock")
+	testRevalidatesReplacedLockFileInode(t,
+		func(timeout time.Duration) (func(), error) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			release, err := AcquireContext(ctx, path)
+			if err != nil {
+				cancel()
+				return nil, err
+			}
+			return func() {
+				release()
+				cancel()
+			}, nil
+		},
+		func() error {
+			return os.Remove(path)
+		},
+	)
+}
+
+func TestAcquireInRevalidatesReplacedLockFileInode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir) //nolint:noinlineerr // test fixture: the root's base is the temp dir itself
+	if err != nil {
+		t.Fatalf("OpenRoot() error = %v", err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+
+	name := "resource.lock"
+	testRevalidatesReplacedLockFileInode(t,
+		func(time.Duration) (func(), error) {
+			return AcquireIn(root, name)
+		},
+		func() error {
+			return os.Remove(filepath.Join(dir, name))
+		},
+	)
+}
+
+func TestAcquireContextInRevalidatesReplacedLockFileInode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir) //nolint:noinlineerr // test fixture: the root's base is the temp dir itself
+	if err != nil {
+		t.Fatalf("OpenRoot() error = %v", err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+
+	name := "resource.lock"
+	testRevalidatesReplacedLockFileInode(t,
+		func(timeout time.Duration) (func(), error) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			release, err := AcquireContextIn(ctx, root, name)
+			if err != nil {
+				cancel()
+				return nil, err
+			}
+			return func() {
+				release()
+				cancel()
+			}, nil
+		},
+		func() error {
+			return os.Remove(filepath.Join(dir, name))
+		},
+	)
+}
+
+func TestLockFileStaleInodeRetryIsBounded(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "resource.lock")
+	_, err := lockFile(context.Background(), openPathLockFile(t, path), func(*os.File) (bool, error) {
+		return false, nil
+	})
+	if err == nil {
+		t.Fatal("lockFile() error = nil, want stale inode retry failure")
+	}
+}
+
+func TestLockFileStaleInodeRetryHonorsContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "resource.lock")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+
+	_, err := lockFile(ctx, openPathLockFile(t, path), func(*os.File) (bool, error) {
+		return false, nil
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("lockFile() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func openPathLockFile(t *testing.T, path string) func() (*os.File, error) {
+	t.Helper()
+
+	return func() (*os.File, error) {
+		return os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	}
+}
+
+func testRevalidatesReplacedLockFileInode(t *testing.T, acquire func(time.Duration) (func(), error), removeLockFile func() error) {
+	t.Helper()
+
+	releaseOld, err := acquire(2 * time.Second)
+	if err != nil {
+		t.Fatalf("Acquire old lock: %v", err)
+	}
+
+	waiter := make(chan func(), 1)
+	errs := make(chan error, 1)
+	go func() {
+		release, err := acquire(2 * time.Second)
+		if err != nil {
+			errs <- err
+			return
+		}
+		waiter <- release
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if err := removeLockFile(); err != nil {
+		t.Fatalf("remove old lock path: %v", err)
+	}
+
+	releaseNew, err := acquire(2 * time.Second)
+	if err != nil {
+		t.Fatalf("Acquire new lock: %v", err)
+	}
+
+	releaseOld()
+
+	select {
+	case release := <-waiter:
+		release()
+		t.Fatal("waiter acquired the unlinked inode while the current lock file was held")
+	case err := <-errs:
+		t.Fatalf("waiter failed: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	releaseNew()
+
+	select {
+	case release := <-waiter:
+		release()
+	case err := <-errs:
+		t.Fatalf("waiter failed: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter did not acquire after current lock was released")
+	}
+}

--- a/cmd/entire/cli/internal/flock/openlock.go
+++ b/cmd/entire/cli/internal/flock/openlock.go
@@ -30,9 +30,15 @@ import (
 // Splitting create-or-open into an exclusive create plus a plain open avoids
 // the broken path entirely, and is deterministic rather than a retry: measured
 // 0 failures in 6000 racing opens where the single-call form failed 4806 times.
-// The loop covers only the vanishingly rare case of the file being removed
-// between the two steps. Lock files are never unlinked (see ClearSessionState),
-// so in practice it runs once.
+// The loop covers two events, which are the same event seen a moment apart:
+// the file removed between the two steps, and the file replaced between an
+// open and its post-open validation (osroot.ErrReplacedDuringOpen). In both,
+// the name stopped pointing at the file we were opening. Neither is fatal
+// here, because the caller wants whichever file now holds the name, and
+// AcquireContextIn revalidates the inode after locking it anyway.
+//
+// No caller unlinks a lock file today (see ClearSessionState), so in practice
+// the loop runs once.
 //
 // Both steps go through osroot.OpenFileNoFollow rather than root.OpenFile. An
 // os.Root refuses a symlink that escapes it but follows one pointing elsewhere
@@ -51,6 +57,11 @@ func openLockFileIn(root *os.Root, name string) (*os.File, error) {
 		if err == nil {
 			return f, nil
 		}
+		if errors.Is(err, osroot.ErrReplacedDuringOpen) {
+			// Replaced between the open and its validation; retry against
+			// whatever now holds the name.
+			continue
+		}
 		if !errors.Is(err, fs.ErrExist) {
 			return nil, err //nolint:wrapcheck // AcquireContextIn wraps this; wrapping twice would bury the cause
 		}
@@ -58,6 +69,9 @@ func openLockFileIn(root *os.Root, name string) (*os.File, error) {
 		f, err = osroot.OpenFileNoFollow(root, name, os.O_RDWR, 0)
 		if err == nil {
 			return f, nil
+		}
+		if errors.Is(err, osroot.ErrReplacedDuringOpen) {
+			continue
 		}
 		if !errors.Is(err, fs.ErrNotExist) {
 			return nil, err //nolint:wrapcheck // AcquireContextIn wraps this; wrapping twice would bury the cause

--- a/cmd/entire/cli/osroot/osroot.go
+++ b/cmd/entire/cli/osroot/osroot.go
@@ -141,7 +141,7 @@ func validateOpenedFile(root *os.Root, name string, f *os.File) error {
 		return err //nolint:wrapcheck // preserve original error classification
 	}
 	if !os.SameFile(pathInfo, openedInfo) {
-		return fmt.Errorf("%s changed while it was being opened", name)
+		return fmt.Errorf("%s changed while it was being opened: %w", name, ErrReplacedDuringOpen)
 	}
 	return nil
 }
@@ -224,6 +224,16 @@ func ReadDirNoSymlinks(root *os.Root, name string) ([]os.DirEntry, error) {
 // ErrSymlinkedPath reports a symlink where a real path component was required.
 // Callers match it with errors.Is.
 var ErrSymlinkedPath = errors.New("path component is a symlink")
+
+// ErrReplacedDuringOpen reports that name resolved to one file when it was
+// opened and a different one by the time the open was validated: something
+// replaced it in between. Callers match it with errors.Is.
+//
+// It is a race, not a refusal. A caller contending for a file that is expected
+// to be replaced under it - a lock file being reaped and recreated - can retry
+// against the new file. A caller that expected a stable name should treat it as
+// the failure it is.
+var ErrReplacedDuringOpen = errors.New("file was replaced while it was being opened")
 
 // MkdirAllNoSymlink is MkdirAll with one added refusal: if any component of
 // name already exists as a symlink, it returns an error wrapping


### PR DESCRIPTION
## Summary

Adds inode revalidation to the Unix flock implementation after a lock is acquired. If the locked file descriptor no longer matches the current lock-file name, the lock is released and acquisition retries against the current file.

This covers:

- `Acquire`
- `AcquireContext`
- `AcquireIn`
- `AcquireContextIn`
- blocking `LOCK_EX`
- polling `LOCK_NB`

The path-based open error is wrapped so wrapcheck is satisfied.

## Tests

```bash
GOCACHE=/private/tmp/entire-go-build-cache go test ./cmd/entire/cli/internal/flock
GOCACHE=/private/tmp/entire-go-build-cache go build ./cmd/entire
git diff --check
```
