### PR TITLE
fix: apply personal entire disable across all worktrees of a clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ Personal overrides, gitignored by default:
 }
 ```
 
+A personal `entire disable` (or `entire enable`) applies to every [worktree](#git-worktrees) of your clone, not just the one you run it in: the choice is mirrored into the git common dir so a new `git worktree add` stays disabled instead of coming back enabled from the committed `settings.json`. A worktree you individually re-enable through its own `settings.local.json` keeps that answer.
+
 ### Configuration Options
 
 | Option                                    | Values                                       | Description                                                                       |

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -206,6 +206,15 @@ type EntireSettings struct {
 // same clone see the same preferences. Not committed because the file lives
 // inside .git/.
 type ClonePreferences struct {
+	// Enabled mirrors a personal `entire disable` / `entire enable` (local
+	// scope) choice into the git common dir so it applies to every worktree of
+	// this clone; settings.local.json is per-worktree, so an opt-out written
+	// only there is lost when `git worktree add` creates a checkout without it.
+	// It merges between settings.json and settings.local.json (see Load), so a
+	// worktree re-enabled through its own local file keeps that answer. Pointer
+	// shape distinguishes "no personal choice" (nil) from an explicit false.
+	Enabled *bool `json:"enabled,omitempty"`
+
 	ReviewProfiles       map[string]ReviewProfileConfig `json:"review_profiles,omitempty"`
 	ReviewDefaultProfile string                         `json:"review_default_profile,omitempty"`
 
@@ -1216,6 +1225,11 @@ func clonePreferencesRoot(filePath string) (*os.Root, string, error) {
 func applyClonePreferences(settings *EntireSettings, prefs *ClonePreferences) {
 	if prefs == nil {
 		return
+	}
+	// Clone-wide choice overrides the committed default; settings.local.json
+	// (applied after this in Load) still wins for a worktree with its own value.
+	if prefs.Enabled != nil {
+		settings.Enabled = *prefs.Enabled
 	}
 	if prefs.ReviewProfiles != nil {
 		settings.ReviewProfiles = mergeReviewProfiles(settings.ReviewProfiles, prefs.ReviewProfiles)

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -1298,6 +1298,75 @@ func TestLoad_AppliesClonePreferencesBeforeLocalSettings(t *testing.T) {
 	}
 }
 
+func TestLoad_ClonePreferencesEnabledOverridesProject(t *testing.T) {
+	// The clone-wide "enabled" mirror (git common dir) sits between the
+	// committed settings.json and the per-worktree settings.local.json, so a
+	// personal `entire disable` disables the committed default while a worktree
+	// that re-enabled through its own local file keeps that answer.
+	tests := []struct {
+		name        string
+		preferences string // clone preferences JSON, "" to omit the file
+		local       string // settings.local.json, "" to omit the file
+		wantEnabled bool
+	}{
+		{
+			name:        "clone mirror disables committed default",
+			preferences: `{"enabled": false}`,
+			wantEnabled: false,
+		},
+		{
+			name:        "local re-enable overrides clone mirror",
+			preferences: `{"enabled": false}`,
+			local:       `{"enabled": true}`,
+			wantEnabled: true,
+		},
+		{
+			name:        "no mirror keeps committed default",
+			preferences: `{"review_fix_agent": "clone-agent"}`,
+			wantEnabled: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			testutil.InitRepo(t, tmp)
+			t.Chdir(tmp)
+			session.ClearGitCommonDirCache()
+
+			entireDir := filepath.Join(tmp, ".entire")
+			if err := os.MkdirAll(entireDir, 0o750); err != nil {
+				t.Fatalf("mkdir .entire: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"enabled": true}`), 0o600); err != nil {
+				t.Fatalf("write project settings: %v", err)
+			}
+
+			if tt.preferences != "" {
+				preferencesDir := filepath.Join(tmp, ".git", "entire")
+				if err := os.MkdirAll(preferencesDir, 0o750); err != nil {
+					t.Fatalf("mkdir preferences dir: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(preferencesDir, "preferences.json"), []byte(tt.preferences), 0o600); err != nil {
+					t.Fatalf("write preferences: %v", err)
+				}
+			}
+			if tt.local != "" {
+				if err := os.WriteFile(filepath.Join(entireDir, "settings.local.json"), []byte(tt.local), 0o600); err != nil {
+					t.Fatalf("write local settings: %v", err)
+				}
+			}
+
+			s, err := Load(context.Background())
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if s.Enabled != tt.wantEnabled {
+				t.Fatalf("Enabled = %v, want %v", s.Enabled, tt.wantEnabled)
+			}
+		})
+	}
+}
+
 func TestReviewConfig_IsZero(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1227,8 +1227,13 @@ func runEnableOnConfiguredRepo(ctx context.Context, cmd *cobra.Command, opts Ena
 	// with an explicit --project, so `enable` could not recover that split
 	// state. Only short-circuit when the merged view is enabled AND the target
 	// file is not itself explicitly disabled.
+	//
+	// A clone-wide disable is treated the same way: a worktree whose own local
+	// file says enabled reports enabled in the merge while the clone mirror
+	// still says disabled, so not short-circuiting lets runEnable re-sync the
+	// mirror and recover the clone.
 	enabled, err := IsEnabled(ctx)
-	if err == nil && enabled && !scopeExplicitlyDisabled(ctx, useProject) {
+	if err == nil && enabled && !scopeExplicitlyDisabled(ctx, useProject) && !cloneMirrorDisabled(ctx) {
 		if !usedSetupFlow {
 			fmt.Fprintln(w, "Entire is already enabled.")
 		}
@@ -1525,6 +1530,12 @@ func runDisable(ctx context.Context, w io.Writer, useProjectSettings bool) error
 // view, so a stale local "enabled": false would otherwise keep the repo
 // disabled after a project-scope re-enable.
 //
+// A local-scope write also mirrors the choice into clone preferences (git
+// common dir) so a personal opt-out survives `git worktree add`; the local file
+// alone is per-worktree. A project-scope write re-syncs that mirror only when it
+// already exists, on the same rule as the project -> local sync. See
+// ClonePreferences.Enabled for the merge position.
+//
 // This is the canonical explanation of the merged-vs-scoped write rule that the
 // whole enable/disable surface follows; other sites point here.
 //
@@ -1549,10 +1560,56 @@ func setEnabledFlag(ctx context.Context, enabled, useProjectSettings bool) error
 				return fmt.Errorf("failed to save local settings: %w", err)
 			}
 		}
+		// Re-sync the clone mirror only when it already exists, so a clone that
+		// never chose locally keeps the committed file as its only source.
+		if cloneEnabledMirror(ctx) != nil {
+			if err := setCloneEnabledMirror(ctx, enabled); err != nil {
+				return err
+			}
+		}
 	} else {
 		if err := setEnabledRaw(ctx, settings.LoadLocalRaw, settings.SaveLocalRaw, enabled); err != nil {
 			return fmt.Errorf("failed to save local settings: %w", err)
 		}
+		// Mirror the personal choice so it spans every worktree of this clone.
+		if err := setCloneEnabledMirror(ctx, enabled); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// cloneEnabledMirror returns this clone's mirrored enable/disable choice from
+// clone preferences, or nil when the clone never made one.
+func cloneEnabledMirror(ctx context.Context) *bool {
+	prefs, err := settings.LoadClonePreferences(ctx)
+	if err != nil {
+		return nil
+	}
+	return prefs.Enabled
+}
+
+// cloneMirrorDisabled reports whether the mirror explicitly says disabled. A
+// missing mirror (nil) is not disabled: the committed settings.json governs.
+func cloneMirrorDisabled(ctx context.Context) bool {
+	m := cloneEnabledMirror(ctx)
+	return m != nil && !*m
+}
+
+// setCloneEnabledMirror records the choice in clone preferences so it applies to
+// every worktree. Outside a git repo there is no common dir and nothing to span,
+// so it skips rather than fails — a write error in a real repo still propagates.
+func setCloneEnabledMirror(ctx context.Context, enabled bool) error {
+	if _, err := settings.ClonePreferencesPath(ctx); err != nil {
+		logging.Debug(ctx, "clone preferences path unresolved; skipping enabled mirror", "error", err)
+		return nil
+	}
+	enabledCopy := enabled
+	if err := settings.ModifyClonePreferences(ctx, func(prefs *settings.ClonePreferences) error {
+		prefs.Enabled = &enabledCopy
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to save clone preferences: %w", err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -826,6 +826,82 @@ func TestRunDisable_AlreadyDisabled(t *testing.T) {
 	}
 }
 
+// TestRunDisable_MirrorsToClonePreferences verifies a local-scope disable writes
+// the clone-wide mirror (git common dir), which is what carries the opt-out
+// across worktrees.
+func TestRunDisable_MirrorsToClonePreferences(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+
+	var stdout bytes.Buffer
+	if err := runDisable(context.Background(), &stdout, false); err != nil {
+		t.Fatalf("runDisable() error = %v", err)
+	}
+
+	prefs, err := settings.LoadClonePreferences(context.Background())
+	if err != nil {
+		t.Fatalf("LoadClonePreferences() error = %v", err)
+	}
+	if prefs.Enabled == nil || *prefs.Enabled {
+		t.Fatalf("clone mirror = %v, want explicit false", prefs.Enabled)
+	}
+}
+
+// TestDisable_ReachesLinkedWorktree reproduces the reported bug: a personal
+// disable in one worktree must leave a freshly added worktree disabled, even
+// though the new worktree carries only the committed settings.json.
+func TestDisable_ReachesLinkedWorktree(t *testing.T) {
+	mainDir := setupTestRepo(t)
+	// Commit the enabled project settings so the linked worktree carries them;
+	// git worktree add also needs a HEAD to check out.
+	testutil.WriteFile(t, mainDir, EntireSettingsFile, testSettingsEnabled)
+	testutil.GitAdd(t, mainDir, EntireSettingsFile)
+	testutil.GitCommit(t, mainDir, "enable entire")
+
+	var stdout bytes.Buffer
+	if err := runDisable(context.Background(), &stdout, false); err != nil {
+		t.Fatalf("runDisable() error = %v", err)
+	}
+
+	wtDir := filepath.Join(t.TempDir(), "wt")
+	testutil.RunGit(t, mainDir, "worktree", "add", wtDir, "-b", "feature")
+
+	// The new worktree has no settings.local.json — only the committed
+	// settings.json (enabled) plus the shared clone mirror (disabled).
+	ctx := settings.WithWorktreeRoot(context.Background(), wtDir)
+	s, err := settings.Load(ctx)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if s.Enabled {
+		t.Fatal("linked worktree came back enabled; clone mirror did not reach it")
+	}
+}
+
+// TestEnable_RecoversClonewideDisable checks that a bare `entire enable` flips
+// the clone mirror back on when a worktree's own local file already says
+// enabled — otherwise the next new worktree would come back disabled.
+func TestEnable_RecoversClonewideDisable(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+
+	var stdout bytes.Buffer
+	if err := runDisable(context.Background(), &stdout, false); err != nil {
+		t.Fatalf("runDisable() error = %v", err)
+	}
+	if err := runEnable(context.Background(), &stdout, false); err != nil {
+		t.Fatalf("runEnable() error = %v", err)
+	}
+
+	prefs, err := settings.LoadClonePreferences(context.Background())
+	if err != nil {
+		t.Fatalf("LoadClonePreferences() error = %v", err)
+	}
+	if prefs.Enabled == nil || !*prefs.Enabled {
+		t.Fatalf("clone mirror = %v, want explicit true", prefs.Enabled)
+	}
+}
+
 func TestCheckDisabledGuard(t *testing.T) {
 	setupTestDir(t)
 

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -139,6 +139,12 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 		fmt.Fprintln(w, formatSettingsStatus("Project", projectSettings, sty))
 	}
 
+	// Show the clone-wide enable/disable mirror when set, between Project and
+	// Local to match its merge position and because it spans every worktree.
+	if prefs, err := settings.LoadClonePreferences(ctx); err == nil && prefs.Enabled != nil {
+		fmt.Fprintln(w, formatSettingsStatus("Clone", &EntireSettings{Enabled: *prefs.Enabled}, sty))
+	}
+
 	// An external_agents grant the loader refused. The user can see the
 	// setting in their file and has no other way to learn it is inert:
 	// discovery simply does not run, and the agent never appears.


### PR DESCRIPTION
fixes  #2274


## Problem

We roll Entire out per repository with a committed `.entire/settings.json` (`"enabled": true`) and let individual developers opt out with `entire disable`. That writes `"enabled": false` to `.entire/settings.local.json`, which is gitignored — so it exists only in the worktree it was written in.

Anyone who works with linked worktrees (`git worktree add`, or agents such as Claude Code that create worktrees on their own) gets re-enabled every time a worktree is created: the new checkout carries only the committed `settings.json`, `settings.Load` finds no local override, and every agent hook and git hook starts recording again.

Reproduced on current `main`:

```sh
tmp=$(mktemp -d)
git init -q -b main "$tmp/main" && cd "$tmp/main"
mkdir .entire && printf '{"enabled": true}\n' > .entire/settings.json
printf 'settings.local.json\n' > .entire/.gitignore
git add -A && git commit -qm init

entire disable            # -> Entire is now disabled (.entire/settings.local.json).
git worktree add -q "$tmp/wt" -b feature
cd "$tmp/wt" && entire status --json
# {"enabled":true, ...}   <- expected "enabled":false
```

## Fix

Mirror the local-scope `enabled` choice into clone preferences (`.git/entire/preferences.json`, in the git common dir), which is the layer designed to span worktrees. The merge order becomes `settings.json` → clone preferences → `settings.local.json`, so the per-worktree local file still wins for a worktree individually re-enabled.

- `ClonePreferences` gains `Enabled *bool`; `applyClonePreferences` applies it.
- `entire disable` / `entire enable` (local scope) also write the mirror; `--project` re-syncs it only when it already exists — the same rule the project → local sync already follows.
- The "already enabled" short-circuit in `runEnableOnConfiguredRepo` treats a clone-wide `false` as an explicit disable, so `entire enable` can recover a clone whose own local file says `true`.
- `entire status --detailed` shows a `Clone · enabled|disabled` line between Project and Local.

Backward compatible: the local file is still written, so `IsSetUpAny` and older binaries keep working.

## Known edge

A worktree that carries its own `settings.local.json` with `"enabled": false` keeps that answer until `entire enable` runs there, because the local file is the most specific layer. That matches today's layering and only affects worktrees disabled individually before this change.

## Tests

- `TestLoad_ClonePreferencesEnabledOverridesProject` — merge precedence (clone disables committed default; local re-enable wins; no mirror keeps default).
- `TestRunDisable_MirrorsToClonePreferences` — disable writes the mirror.
- `TestDisable_ReachesLinkedWorktree` — the repro, with a real `git worktree add`.
- `TestEnable_RecoversClonewideDisable` — `enable` flips the mirror back on.

## Verification

- `mise run lint` (go, gofmt, gomod, shellcheck, mise) — 0 issues
- Full unit tests for `settings` and `cli` packages, key cases also under `-race`
- End-to-end repro against a built binary now reports `"enabled":false` in the new worktree
