### PR TITLE
fix(clean): reap accumulated ref/shadow lock files

### DIFF
--- a/cmd/entire/cli/checkpoint/persistent_ref_update.go
+++ b/cmd/entire/cli/checkpoint/persistent_ref_update.go
@@ -44,9 +44,12 @@ func casUpdateRef(ctx context.Context, repoRoot string, refName plumbing.Referen
 	return fmt.Errorf("git update-ref %s: %s: %w", refName, strings.TrimSpace(out), err)
 }
 
-// persistentRefLockDirName is the persistent-ref lock directory inside the git
-// common dir, alongside shadowLockDirName.
-const persistentRefLockDirName = "entire-persistent-ref-locks"
+// PersistentRefLockDirName is the persistent-ref lock directory inside the git
+// common dir, alongside ShadowLockDirName. Under the git-refs backend this
+// accrues one file per checkpoint ref and nothing supersedes them, so it is
+// exported for `entire clean` to reclaim: a file is safe to remove once no
+// process holds its flock, and the next ref update recreates it.
+const PersistentRefLockDirName = "entire-persistent-ref-locks"
 
 // persistentRefLock returns the git common dir's root and the per-ref lock
 // file's name inside it, mirroring shadowBranchLock. Ref names are escaped
@@ -63,11 +66,11 @@ func persistentRefLock(commonDir string, refName plumbing.ReferenceName) (*os.Ro
 	if err != nil {
 		return nil, "", fmt.Errorf("open git common dir: %w", err)
 	}
-	if err := osroot.MkdirAllNoSymlink(root, persistentRefLockDirName, 0o750); err != nil {
+	if err := osroot.MkdirAllNoSymlink(root, PersistentRefLockDirName, 0o750); err != nil {
 		return nil, "", fmt.Errorf("create persistent ref lock directory: %w", err)
 	}
 	safe := strings.NewReplacer("/", "_", "\\", "_", ":", "_").Replace(refName.String())
-	return root, persistentRefLockDirName + "/" + safe + ".lock", nil
+	return root, PersistentRefLockDirName + "/" + safe + ".lock", nil
 }
 
 func withPersistentRefFlock(ctx context.Context, commonDir string, refName plumbing.ReferenceName, fn func() error) error {

--- a/cmd/entire/cli/checkpoint/shadow_ref.go
+++ b/cmd/entire/cli/checkpoint/shadow_ref.go
@@ -86,15 +86,18 @@ func shadowBranchLock(commonDir, branchName string) (*os.Root, string, error) {
 	if err != nil {
 		return nil, "", fmt.Errorf("open git common dir: %w", err)
 	}
-	if err := osroot.MkdirAllNoSymlink(root, shadowLockDirName, 0o750); err != nil {
+	if err := osroot.MkdirAllNoSymlink(root, ShadowLockDirName, 0o750); err != nil {
 		return nil, "", fmt.Errorf("create shadow lock directory: %w", err)
 	}
 	safe := strings.ReplaceAll(branchName, "/", "_")
-	return root, shadowLockDirName + "/" + safe + ".lock", nil
+	return root, ShadowLockDirName + "/" + safe + ".lock", nil
 }
 
-// shadowLockDirName is the shadow-branch lock directory inside the git common dir.
-const shadowLockDirName = "entire-shadow-locks"
+// ShadowLockDirName is the shadow-branch lock directory inside the git common
+// dir. Exported so `entire clean` can reclaim its lock files: a file is safe to
+// remove once no process holds its flock, and the next shadow-branch write
+// recreates it.
+const ShadowLockDirName = "entire-shadow-locks"
 
 // withShadowBranchFlock acquires the per-shadow-branch flock, runs fn, and
 // releases the flock. Serializes all WriteTemporary callers that target the

--- a/cmd/entire/cli/clean.go
+++ b/cmd/entire/cli/clean.go
@@ -345,7 +345,7 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 	}
 
 	// Group items by type for display
-	var branches, states, checkpoints, redactCaches []strategy.CleanupItem
+	var branches, states, checkpoints, redactCaches, refLocks []strategy.CleanupItem
 	for _, item := range items {
 		switch item.Type {
 		case strategy.CleanupTypeShadowBranch:
@@ -356,6 +356,8 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 			checkpoints = append(checkpoints, item)
 		case strategy.CleanupTypeRedactCache:
 			redactCaches = append(redactCaches, item)
+		case strategy.CleanupTypeRefLock:
+			refLocks = append(refLocks, item)
 		}
 	}
 
@@ -368,6 +370,7 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 		printSection(w, "Session states", cleanupItemIDs(states))
 		printSection(w, "Checkpoint metadata", cleanupItemIDs(checkpoints))
 		printSection(w, "Redaction cache", cleanupItemIDs(redactCaches))
+		printSection(w, "Lock directories", cleanupItemIDs(refLocks))
 		printSection(w, "Temp files", tempFiles)
 		printSection(w, "Stray agent temp files", orphanTemps)
 		printUnscannedNote(w, unscanned)
@@ -409,8 +412,8 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 	failedTempFiles = append(failedTempFiles, failedOrphans...)
 
 	// Report results
-	totalDeleted := len(result.ShadowBranches) + len(result.SessionStates) + len(result.Checkpoints) + len(deletedTempFiles)
-	totalFailed := len(result.FailedBranches) + len(result.FailedStates) + len(result.FailedCheckpoints) + len(failedTempFiles)
+	totalDeleted := len(result.ShadowBranches) + len(result.SessionStates) + len(result.Checkpoints) + len(result.RefLocks) + len(deletedTempFiles)
+	totalFailed := len(result.FailedBranches) + len(result.FailedStates) + len(result.FailedCheckpoints) + len(result.FailedRefLocks) + len(failedTempFiles)
 
 	if totalDeleted > 0 {
 		fmt.Fprintf(w, "✓ Deleted %d %s:\n", totalDeleted, itemWord(totalDeleted))
@@ -418,6 +421,7 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 		printResultSection(w, "Shadow branches", result.ShadowBranches)
 		printResultSection(w, "Session states", result.SessionStates)
 		printResultSection(w, "Checkpoints", result.Checkpoints)
+		printResultSection(w, "Lock directories", result.RefLocks)
 
 		printResultSection(w, "Temp files", deletedTempFiles)
 		printResultSection(w, "Stray agent temp files", deletedOrphans)
@@ -430,6 +434,7 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 		printResultSection(errW, "Shadow branches", result.FailedBranches)
 		printResultSection(errW, "Session states", result.FailedStates)
 		printResultSection(errW, "Checkpoints", result.FailedCheckpoints)
+		printResultSection(errW, "Lock directories", result.FailedRefLocks)
 
 		if len(failedTempFiles) > 0 {
 			fmt.Fprintf(errW, "\nTemp files:\n")

--- a/cmd/entire/cli/clean_test.go
+++ b/cmd/entire/cli/clean_test.go
@@ -818,6 +818,31 @@ func TestRunCleanAllWithItems_MixedTypes_Preview(t *testing.T) {
 	}
 }
 
+func TestRunCleanAllWithItems_RefLock_Preview(t *testing.T) {
+	setupCleanTestRepo(t)
+
+	items := []strategy.CleanupItem{
+		{Type: strategy.CleanupTypeRefLock, ID: "entire-persistent-ref-locks", Reason: "clean all"},
+	}
+
+	cmd, stdout, _ := newTestCleanCmd(t)
+	err := runCleanAllWithItems(cmd.Context(), cmd, false, true, items, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("runCleanAllWithItems() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Lock directories") {
+		t.Errorf("Expected 'Lock directories' section, got: %s", output)
+	}
+	if !strings.Contains(output, "entire-persistent-ref-locks") {
+		t.Errorf("Expected the lock directory name in the preview, got: %s", output)
+	}
+	if !strings.Contains(output, "Found 1 item to clean") {
+		t.Errorf("Expected 'Found 1 item to clean', got: %s", output)
+	}
+}
+
 // --- Flag validation tests ---
 
 func TestCleanCmd_MutuallyExclusiveFlags(t *testing.T) {

--- a/cmd/entire/cli/internal/flock/flock_test.go
+++ b/cmd/entire/cli/internal/flock/flock_test.go
@@ -39,6 +39,71 @@ func TestAcquireIn_CreatesTheLockFileAndReleases(t *testing.T) {
 	release()
 }
 
+func TestTryAcquireIn_TakesAnUncontendedLock(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir) //nolint:noinlineerr // test fixture: the root's base is the temp dir itself
+	if err != nil {
+		t.Fatalf("OpenRoot() error = %v", err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+
+	release, ok, err := TryAcquireIn(root, "state.lock")
+	if err != nil {
+		t.Fatalf("TryAcquireIn() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("TryAcquireIn() ok = false, want true for an uncontended lock")
+	}
+	release()
+
+	if _, err := os.Lstat(filepath.Join(dir, "state.lock")); err != nil {
+		t.Fatalf("lock file should exist after acquire: %v", err)
+	}
+}
+
+// TryAcquireIn must report a held lock immediately rather than queueing behind
+// it -- that is the whole reason it exists. flock is per-open-file-description,
+// so a second open in this same process contends exactly as another process
+// would (see openlock.go).
+func TestTryAcquireIn_ReportsAHeldLockWithoutBlocking(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir) //nolint:noinlineerr // test fixture: the root's base is the temp dir itself
+	if err != nil {
+		t.Fatalf("OpenRoot() error = %v", err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+
+	held, err := AcquireIn(root, "state.lock")
+	if err != nil {
+		t.Fatalf("AcquireIn() error = %v", err)
+	}
+
+	release, ok, err := TryAcquireIn(root, "state.lock")
+	if err != nil {
+		t.Fatalf("TryAcquireIn() error = %v, want nil for a held lock", err)
+	}
+	if ok {
+		release()
+		held()
+		t.Fatal("TryAcquireIn() ok = true, want false while the lock is held")
+	}
+
+	held() // drop it; the next probe must now succeed
+
+	release, ok, err = TryAcquireIn(root, "state.lock")
+	if err != nil {
+		t.Fatalf("TryAcquireIn() after release error = %v", err)
+	}
+	if !ok {
+		t.Fatal("TryAcquireIn() ok = false after the holder released")
+	}
+	release()
+}
+
 // A lock file is opened O_RDWR and its contents are immaterial, so following a
 // link here would not leak anything by itself. It is refused because os.Root
 // stops only the links that escape it, and every other opener in this tree

--- a/cmd/entire/cli/internal/flock/flock_unix.go
+++ b/cmd/entire/cli/internal/flock/flock_unix.go
@@ -63,6 +63,22 @@ func AcquireContextIn(ctx context.Context, root *os.Root, name string) (release 
 	return lockFile(ctx, f)
 }
 
+// tryLockFile takes a single non-blocking LOCK_EX and never waits. EWOULDBLOCK
+// means another open file description holds the lock (ok=false, err=nil); any
+// other flock error is a real failure. On success the returned release closes
+// the file, which drops the lock.
+func tryLockFile(f *os.File) (release func(), ok bool, err error) {
+	lockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB) //nolint:gosec // file descriptors are non-negative; standard Go pattern for syscall.Flock
+	if lockErr == nil {
+		return func() { _ = f.Close() }, true, nil
+	}
+	_ = f.Close()
+	if errors.Is(lockErr, syscall.EWOULDBLOCK) {
+		return nil, false, nil
+	}
+	return nil, false, fmt.Errorf("flock: %w", lockErr)
+}
+
 // lockFile holds the locking logic shared by the path- and root-based entry
 // points, which differ only in how the file was opened.
 func lockFile(ctx context.Context, f *os.File) (release func(), err error) {

--- a/cmd/entire/cli/internal/flock/flock_windows.go
+++ b/cmd/entire/cli/internal/flock/flock_windows.go
@@ -53,6 +53,27 @@ func AcquireContextIn(ctx context.Context, root *os.Root, name string) (release 
 	return lockFile(ctx, f)
 }
 
+// tryLockFile takes a single fail-immediately exclusive lock and never waits. A
+// held lock is reported as ERROR_LOCK_VIOLATION / ERROR_IO_PENDING (ok=false,
+// err=nil), mirroring the unix EWOULDBLOCK case; any other error is a real
+// failure. On success the returned release unlocks and closes the file.
+func tryLockFile(f *os.File) (release func(), ok bool, err error) {
+	overlapped := new(windows.Overlapped)
+	lockErr := windows.LockFileEx(windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, overlapped)
+	if lockErr == nil {
+		return func() {
+			_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, overlapped)
+			_ = f.Close()
+		}, true, nil
+	}
+	_ = f.Close()
+	if errors.Is(lockErr, windows.ERROR_LOCK_VIOLATION) || errors.Is(lockErr, windows.ERROR_IO_PENDING) {
+		return nil, false, nil
+	}
+	return nil, false, fmt.Errorf("lock flock: %w", lockErr)
+}
+
 // lockFile holds the locking logic shared by the path- and root-based entry
 // points, which differ only in how the file was opened.
 func lockFile(ctx context.Context, f *os.File) (release func(), err error) {

--- a/cmd/entire/cli/internal/flock/openlock.go
+++ b/cmd/entire/cli/internal/flock/openlock.go
@@ -2,6 +2,7 @@ package flock
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 
@@ -43,6 +44,25 @@ import (
 // is here so that stays true if a worktree-anchored caller is ever added, since
 // the worktree is the one tree a checkout does control. It keeps the two-step
 // split intact, so the macOS behaviour above is unaffected.
+// TryAcquireIn attempts a single non-blocking exclusive lock on the file named
+// by name inside root, creating it if needed. It never waits: ok reports
+// whether the lock was taken. When ok is true the caller owns the lock and must
+// call release exactly once; when ok is false another holder has it and release
+// is nil. A non-nil err means the attempt could not be made at all -- the file
+// could not be opened, or the lock syscall failed for a reason other than
+// contention -- and is distinct from an uncontended miss.
+//
+// It exists for reapers that must only probe a lock, never queue behind it:
+// `entire clean` removing stale <git-common-dir>/entire-*-locks/ files, where a
+// held lock means "leave it" rather than "wait".
+func TryAcquireIn(root *os.Root, name string) (release func(), ok bool, err error) {
+	f, err := openLockFileIn(root, name)
+	if err != nil {
+		return nil, false, fmt.Errorf("open flock: %w", err)
+	}
+	return tryLockFile(f)
+}
+
 func openLockFileIn(root *os.Root, name string) (*os.File, error) {
 	var err error
 	for range 3 {

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -2,7 +2,9 @@ package strategy
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -14,7 +16,9 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/gitdir"
+	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 
@@ -33,6 +37,10 @@ const (
 	// Purely derived data -- it is rebuilt on the next checkpoint -- so it is
 	// removed wholesale rather than per entry.
 	CleanupTypeRedactCache CleanupType = "redact-cache"
+	// CleanupTypeRefLock is a git-common-dir lock directory (entire-*-locks/).
+	// Its entries are advisory flock files that nothing else reclaims; cleanup
+	// removes the ones no live process holds and leaves the rest.
+	CleanupTypeRefLock CleanupType = "ref-lock"
 )
 
 // CleanupItem represents an item that can be cleaned up.
@@ -48,10 +56,12 @@ type CleanupResult struct {
 	ShadowBranches    []string // Deleted shadow branches
 	SessionStates     []string // Deleted session state files
 	Checkpoints       []string // Deleted checkpoint metadata
+	RefLocks          []string // Reaped lock directories (entire-*-locks/)
 	FailedBranches    []string // Shadow branches that failed to delete
 	FailedStates      []string // Session states that failed to delete
 	FailedCheckpoints []string // Checkpoints that failed to delete
 	FailedRedactCache []string // Redaction caches that failed to delete
+	FailedRefLocks    []string // Lock directories that could not be read
 }
 
 // shadowBranchPattern matches shadow branch names in both old and new formats:
@@ -536,7 +546,105 @@ func ListAllItems(ctx context.Context) ([]CleanupItem, error) {
 		}
 	}
 
+	// The git-common-dir lock directories accrue one advisory flock file per ref
+	// or shadow branch and nothing else reclaims them -- entire-persistent-ref-locks
+	// grows monotonically under the git-refs backend. List a directory only when
+	// it exists and holds at least one entry; the deleter removes just the files
+	// no process is currently holding.
+	if root, gitErr := gitdir.Open(ctx); gitErr == nil {
+		for _, dir := range lockDirNames() {
+			entries, readErr := osroot.ReadDirNoSymlinks(root, dir)
+			if readErr != nil || len(entries) == 0 {
+				continue
+			}
+			cleanupItems = append(cleanupItems, CleanupItem{
+				Type:   CleanupTypeRefLock,
+				ID:     dir,
+				Reason: "clean all",
+			})
+		}
+	}
+
 	return cleanupItems, nil
+}
+
+// lockDirNames are the git-common-dir lock directories whose per-file flock
+// files nothing else reclaims. A file is safe to remove once no live process
+// holds its flock, and the directory's creator recreates it on the next write.
+func lockDirNames() []string {
+	return []string{
+		checkpoint.PersistentRefLockDirName,
+		checkpoint.ShadowLockDirName,
+	}
+}
+
+// reapLockDirs removes the advisory flock files that no process is holding from
+// each named git-common-dir lock directory, and the directory itself once it is
+// empty. A directory is reported reaped when its pass completed (whether or not
+// some files were held back) or was already gone, and failed when the git
+// common dir or the directory listing could not be read.
+//
+// A file whose flock is currently held -- a live process mid-write -- is left
+// in place. The removal holds the flock across the unlink so no new holder can
+// slip in first; the residual window (a process that opened the path just
+// before the unlink can lock a stale inode while a newcomer locks a fresh one)
+// is inherent to unlinking a lock file and is bounded by this running only
+// under the explicitly user-invoked `entire clean --all`.
+func reapLockDirs(ctx context.Context, dirs []string) (reaped, failed []string) {
+	root, gitErr := gitdir.Open(ctx)
+	if gitErr != nil {
+		return nil, dirs
+	}
+	logCtx := logging.WithComponent(ctx, "cleanup")
+
+	for _, dir := range dirs {
+		entries, readErr := osroot.ReadDirNoSymlinks(root, dir)
+		if errors.Is(readErr, fs.ErrNotExist) {
+			reaped = append(reaped, dir)
+			continue
+		}
+		if readErr != nil {
+			failed = append(failed, dir)
+			continue
+		}
+
+		var removed, held int
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".lock") {
+				held++ // an unexpected entry: keep the directory
+				continue
+			}
+			name := dir + "/" + e.Name()
+			release, ok, tryErr := flock.TryAcquireIn(root, name)
+			if tryErr != nil || !ok {
+				held++
+				continue
+			}
+			rmErr := osroot.RemoveNoSymlinks(root, name)
+			release()
+			if rmErr != nil {
+				held++
+				continue
+			}
+			removed++
+		}
+
+		// Drop the directory only when it is now empty. Remove (not RemoveAll)
+		// fails closed on a non-empty directory, so the guard is belt-and-braces;
+		// a failure here is not worth failing the reap over.
+		if held == 0 {
+			if rmErr := osroot.Remove(root, dir); rmErr != nil {
+				logging.Debug(logCtx, "could not remove emptied lock directory",
+					slog.String("dir", dir), slog.String("error", rmErr.Error()))
+			}
+		}
+		logging.Debug(logCtx, "reaped lock directory",
+			slog.String("dir", dir),
+			slog.Int("removed", removed),
+			slog.Int("held", held))
+		reaped = append(reaped, dir)
+	}
+	return reaped, failed
 }
 
 // redactCacheDir resolves the redaction prefix cache directory, or "" when the
@@ -562,7 +670,7 @@ func DeleteAllCleanupItems(ctx context.Context, items []CleanupItem) (*CleanupRe
 	}
 
 	// Group items by type
-	var branches, states, checkpoints, redactCaches []string
+	var branches, states, checkpoints, redactCaches, refLocks []string
 	for _, item := range items {
 		switch item.Type {
 		case CleanupTypeShadowBranch:
@@ -571,6 +679,8 @@ func DeleteAllCleanupItems(ctx context.Context, items []CleanupItem) (*CleanupRe
 			states = append(states, item.ID)
 		case CleanupTypeRedactCache:
 			redactCaches = append(redactCaches, item.ID)
+		case CleanupTypeRefLock:
+			refLocks = append(refLocks, item.ID)
 		case CleanupTypeCheckpoint:
 			checkpoints = append(checkpoints, item.ID)
 		}
@@ -588,6 +698,27 @@ func DeleteAllCleanupItems(ctx context.Context, items []CleanupItem) (*CleanupRe
 			result.RedactCaches = redactCaches
 			logging.Info(logCtx, "deleted redaction cache",
 				slog.String("type", string(CleanupTypeRedactCache)))
+		}
+	}
+
+	// Reap the unheld flock files in each listed lock directory. A held lock
+	// means a live process is mid-write, so that file stays; like the redaction
+	// cache, a listing failure is recorded but never blocks the rest.
+	if len(refLocks) > 0 {
+		reaped, failed := reapLockDirs(ctx, refLocks)
+		result.RefLocks = reaped
+		result.FailedRefLocks = failed
+		for _, id := range reaped {
+			logging.Info(logCtx, "reaped lock directory",
+				slog.String("type", string(CleanupTypeRefLock)),
+				slog.String("id", id),
+				slog.String("reason", reasonMap[id]))
+		}
+		for _, id := range failed {
+			logging.Warn(logCtx, "failed to reap lock directory",
+				slog.String("type", string(CleanupTypeRefLock)),
+				slog.String("id", id),
+				slog.String("reason", reasonMap[id]))
 		}
 	}
 
@@ -673,16 +804,18 @@ func DeleteAllCleanupItems(ctx context.Context, items []CleanupItem) (*CleanupRe
 	}
 
 	// Log summary
-	totalDeleted := len(result.ShadowBranches) + len(result.SessionStates) + len(result.Checkpoints)
-	totalFailed := len(result.FailedBranches) + len(result.FailedStates) + len(result.FailedCheckpoints)
+	totalDeleted := len(result.ShadowBranches) + len(result.SessionStates) + len(result.Checkpoints) + len(result.RefLocks)
+	totalFailed := len(result.FailedBranches) + len(result.FailedStates) + len(result.FailedCheckpoints) + len(result.FailedRefLocks)
 	if totalDeleted > 0 || totalFailed > 0 {
 		logging.Info(logCtx, "cleanup completed",
 			slog.Int("deleted_branches", len(result.ShadowBranches)),
 			slog.Int("deleted_session_states", len(result.SessionStates)),
 			slog.Int("deleted_checkpoints", len(result.Checkpoints)),
+			slog.Int("reaped_lock_dirs", len(result.RefLocks)),
 			slog.Int("failed_branches", len(result.FailedBranches)),
 			slog.Int("failed_session_states", len(result.FailedStates)),
 			slog.Int("failed_checkpoints", len(result.FailedCheckpoints)),
+			slog.Int("failed_lock_dirs", len(result.FailedRefLocks)),
 		)
 	}
 

--- a/cmd/entire/cli/strategy/cleanup_ref_locks_test.go
+++ b/cmd/entire/cli/strategy/cleanup_ref_locks_test.go
@@ -1,0 +1,129 @@
+package strategy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+// lockDir returns <git-common-dir>/<name>, creating it.
+func lockDir(ctx context.Context, t *testing.T, name string) string {
+	t.Helper()
+	commonDir, err := session.GetGitCommonDir(ctx)
+	require.NoError(t, err)
+	dir := filepath.Join(commonDir, name)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	return dir
+}
+
+// TestRefLocks_AbsentDirsAreNotListed keeps `entire clean --all` quiet when a
+// repo has never taken a checkpoint lock -- an empty or missing lock directory
+// is nothing to offer.
+//
+// Not parallel: t.Chdir sets process-global state.
+func TestRefLocks_AbsentDirsAreNotListed(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+
+	items, err := ListAllItems(context.Background())
+	require.NoError(t, err)
+	require.NotContains(t, cleanupItemTypes(items), CleanupTypeRefLock,
+		"no lock directory exists, so none must be listed")
+}
+
+// TestRefLocks_UnheldFilesAreReapedByCleanAll covers the growth path from the
+// issue: entire-persistent-ref-locks accrues one file per checkpoint ref and
+// nothing else removes them.
+//
+// Not parallel: t.Chdir sets process-global state.
+func TestRefLocks_UnheldFilesAreReapedByCleanAll(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+
+	ctx := context.Background()
+	dir := lockDir(ctx, t, checkpoint.PersistentRefLockDirName)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "refs_entire_checkpoints_v1.lock"), nil, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "refs_entire_checkpoints_shard_0.lock"), nil, 0o600))
+
+	items, err := ListAllItems(ctx)
+	require.NoError(t, err)
+	require.Contains(t, cleanupItemTypes(items), CleanupTypeRefLock,
+		"a populated lock directory must be listed for cleanup")
+
+	result, err := DeleteAllCleanupItems(ctx, items)
+	require.NoError(t, err)
+	require.Contains(t, result.RefLocks, checkpoint.PersistentRefLockDirName)
+	require.Empty(t, result.FailedRefLocks)
+	require.NoDirExists(t, dir, "an emptied lock directory is removed with its files")
+}
+
+// TestRefLocks_HeldFileSurvivesReap is the invariant that makes this safe to
+// run while agents are working: a lock whose flock is currently held belongs to
+// a live writer and must be left alone, even as its unheld siblings are reaped.
+//
+// Not parallel: t.Chdir sets process-global state.
+func TestRefLocks_HeldFileSurvivesReap(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+
+	ctx := context.Background()
+	dir := lockDir(ctx, t, checkpoint.ShadowLockDirName)
+	heldPath := filepath.Join(dir, "entire_abc1234-def567.lock")
+	unheldPath := filepath.Join(dir, "entire_0000000-000000.lock")
+	require.NoError(t, os.WriteFile(heldPath, nil, 0o600))
+	require.NoError(t, os.WriteFile(unheldPath, nil, 0o600))
+
+	release, err := flock.Acquire(heldPath)
+	require.NoError(t, err)
+	defer release()
+
+	items, err := ListAllItems(ctx)
+	require.NoError(t, err)
+
+	result, err := DeleteAllCleanupItems(ctx, items)
+	require.NoError(t, err)
+	require.Contains(t, result.RefLocks, checkpoint.ShadowLockDirName)
+	require.Empty(t, result.FailedRefLocks)
+
+	require.FileExists(t, heldPath, "a held lock file must survive the reap")
+	require.NoFileExists(t, unheldPath, "an unheld sibling is still reaped")
+	require.DirExists(t, dir, "the directory stays while it still holds a live lock")
+}
+
+// TestReapLockDirs_MissingDirIsNotAnError keeps the reap idempotent: a
+// directory already gone (reaped by an earlier run, or never created) reports
+// as reaped, not failed.
+//
+// Not parallel: t.Chdir sets process-global state.
+func TestReapLockDirs_MissingDirIsNotAnError(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+
+	reaped, failed := reapLockDirs(context.Background(), lockDirNames())
+	require.ElementsMatch(t, lockDirNames(), reaped)
+	require.Empty(t, failed)
+}


### PR DESCRIPTION
Closes #2197.

Two design questions from my [claim comment](https://github.com/entireio/cli/issues/2197#issuecomment-5553909120) are still open — flagged at the bottom rather than blocking on them. Happy to adjust the diff either way.

## Problem

`persistentRefLock` creates one flock file per checkpoint ref under `<git-common-dir>/entire-persistent-ref-locks/` and nothing ever removes them, so the directory grows monotonically with checkpoint count. `entire-shadow-locks/` has the same shape (bounded by branch activity, but equally unreaped). `strategy/cleanup.go` had no reference to either, so `entire clean` never reclaimed them.

## Change

Wired both into `entire clean --all`, mirroring the existing `CleanupTypeRedactCache` precedent for a git-common-dir directory that would otherwise leak.

- **`internal/flock`**: added `TryAcquireIn` — a one-shot non-blocking probe. There was only the blocking `Acquire`/`AcquireIn` and the deadline-polling `AcquireContext`/`AcquireContextIn`; a reaper must not queue behind a lock it's only testing. Contention returns `ok=false` with a nil error, distinct from a real failure.
- **`checkpoint`**: exported `ShadowLockDirName` / `PersistentRefLockDirName` (as `RedactCacheDirName` already is).
- **`strategy/cleanup.go`**: `CleanupTypeRefLock`, `lockDirNames()`, `reapLockDirs()`. A lock file is removed only when `TryAcquireIn` succeeds (no live holder); the flock is held across the unlink so no new holder slips in first, and the directory is dropped once empty. A held file is left in place. `CleanupResult` gains `RefLocks` / `FailedRefLocks`.
- **`cli/clean.go`**: preview / result / failure sections and count totals.

## Tests

- `flock`: uncontended acquire; held-lock reported without blocking, then success after release.
- `strategy`: absent dirs not listed; unheld files reaped and the emptied dir removed; **a held file survives while an unheld sibling in the same dir is still reaped and the dir is kept**; `reapLockDirs` on missing dirs reports reaped, not failed.
- `cli/clean.go`: the `--all` preview shows a "Lock directories" section.

`mise run fmt && mise run lint && mise run test` all green.

## Note on a pre-existing asymmetry

`redactCaches` currently shows in the `--all` preview but is not in the result summary or `totalDeleted`. I wired `refLocks` into both, otherwise a lock-only cleanup would print "Deleted 0 items". Left the redact-cache side alone to keep scope tight.

## Open questions

1. **Unlink race.** `openlock.go` documents that the code relies on lock files never being unlinked. Reaping them opens a narrow window: a process that opened the path just before the unlink can lock a stale inode while a newcomer locks a fresh one. I've bounded it — reap only under the explicitly user-invoked `clean --all`, hold the flock across the unlink, treat the residual window as self-healing since the next writer recreates the file — and documented it on `reapLockDirs` the way `openlock.go` documents its own tradeoff. Is that acceptable, or do you want a stricter scheme?
2. **Scope.** `entire-session-locks/` (`strategy.SessionLockDirName`) has the same shape — session states get reaped, their lock files don't. Add it to `lockDirNames()` in this PR, or keep to the two directories named in the issue?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
