### PR TITLE
Exclude pre-existing tracked changes from session attribution

### DIFF
--- a/cmd/entire/cli/attribution_baseline_test.go
+++ b/cmd/entire/cli/attribution_baseline_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackedAttributionBaseline(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	testutil.InitRepo(t, dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	ctx := context.Background()
+	for _, name := range []string{"dirty", "deleted", "clean", "new-delete"} {
+		require.NoError(t, os.WriteFile(name, []byte("original\n"), 0o644))
+	}
+	testutil.GitAdd(t, dir, ".")
+	testutil.GitCommit(t, dir, "baseline")
+	require.NoError(t, os.WriteFile("dirty", []byte("prior edit\n"), 0o644))
+	require.NoError(t, os.Remove("deleted"))
+	require.NoError(t, os.WriteFile("staged", []byte("prior staged addition\n"), 0o644))
+	testutil.GitAdd(t, dir, "staged")
+	require.NoError(t, CapturePrePromptState(ctx, claudecode.NewClaudeCodeAgent(), "attribution-test", ""))
+	before, err := LoadPrePromptState(ctx, "attribution-test")
+	require.NoError(t, err)
+	require.NotNil(t, before.TrackedBaseline)
+	changes, err := DetectFileChanges(ctx, before.PreUntrackedFiles())
+	require.NoError(t, err)
+	excludeUnchangedTracked(ctx, changes, before.TrackedBaseline)
+	require.Empty(t, changes.Modified, "read-only turn must not claim prior edits or staged additions")
+	require.Empty(t, changes.Deleted, "read-only turn must not claim prior deletions")
+	require.NoError(t, os.WriteFile("dirty", []byte("this turn edits an already dirty file\n"), 0o644))
+	require.NoError(t, os.WriteFile("clean", []byte("this turn edits a clean file\n"), 0o644))
+	require.NoError(t, os.Remove("new-delete"))
+	changes, err = DetectFileChanges(ctx, before.PreUntrackedFiles())
+	require.NoError(t, err)
+	excludeUnchangedTracked(ctx, changes, before.TrackedBaseline)
+	require.ElementsMatch(t, []string{"dirty", "clean"}, changes.Modified)
+	require.Equal(t, []string{"new-delete"}, changes.Deleted)
+	require.NoError(t, CapturePreTaskState(ctx, "task-attribution"))
+	task, err := LoadPreTaskState(ctx, "task-attribution")
+	require.NoError(t, err)
+	require.Equal(t, captureTrackedBaseline(ctx), task.TrackedBaseline)
+	require.FileExists(t, filepath.Join(dir, "dirty"))
+}
+
+func TestTrackedAttributionMissingBaseline(t *testing.T) {
+	changes := &FileChanges{Modified: []string{"unproven"}, Deleted: []string{"unproven"}, New: []string{"new"}}
+	excludeUnchangedTracked(context.Background(), changes, nil)
+	require.Empty(t, changes.Modified)
+	require.Empty(t, changes.Deleted)
+	require.Equal(t, []string{"new"}, changes.New)
+}

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -930,6 +930,7 @@ func handleLifecycleTurnEnd(ctx context.Context, ag agent.Agent, event *agent.Ev
 	// persisted at turn end reflects the whole turn, not just this walk.
 	captureDegraded := preState != nil && preState.UntrackedScanSkipped
 	changes, err := DetectFileChanges(ctx, preUntrackedFiles)
+	excludeUnchangedTracked(ctx, changes, preState.trackedBaseline())
 	if err != nil {
 		captureDegraded = captureDegraded || errors.Is(err, gitrepo.ErrStatusBudgetExceeded)
 		logStatusDegrade(logCtx, "failed to compute file changes", err)
@@ -1620,6 +1621,7 @@ func completeSubagentTaskRecord(logCtx context.Context, ag agent.Agent, event *a
 		}
 		var changesErr error
 		changes, changesErr = DetectFileChanges(logCtx, preUntrackedFiles)
+		excludeUnchangedTracked(logCtx, changes, preState.trackedBaseline())
 		if changesErr != nil {
 			logStatusDegrade(logCtx, "failed to compute file changes", changesErr)
 		}

--- a/cmd/entire/cli/state.go
+++ b/cmd/entire/cli/state.go
@@ -2,13 +2,16 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -21,15 +24,17 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
+	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
 
 	"github.com/go-git/go-git/v6"
 )
 
 // PrePromptState stores the state captured before a user prompt
 type PrePromptState struct {
-	SessionID      string   `json:"session_id"`
-	Timestamp      string   `json:"timestamp"`
-	UntrackedFiles []string `json:"untracked_files"`
+	SessionID       string            `json:"session_id"`
+	Timestamp       string            `json:"timestamp"`
+	UntrackedFiles  []string          `json:"untracked_files"`
+	TrackedBaseline map[string]string `json:"tracked_baseline"`
 
 	// UntrackedScanSkipped records that the pre-prompt untracked scan failed
 	// (e.g. the status walk breached its wall-clock budget). Turn-end must
@@ -145,6 +150,7 @@ func CapturePrePromptState(ctx context.Context, ag agent.Agent, sessionID, sessi
 		SessionID:            sessionID,
 		Timestamp:            time.Now().UTC().Format(time.RFC3339),
 		UntrackedFiles:       untrackedFiles,
+		TrackedBaseline:      captureTrackedBaseline(ctx),
 		UntrackedScanSkipped: scanSkipped,
 		TranscriptOffset:     transcriptOffset,
 	}
@@ -523,9 +529,10 @@ func getUntrackedFilesForState(ctx context.Context) ([]string, error) {
 
 // PreTaskState stores the state captured before a task execution
 type PreTaskState struct {
-	ToolUseID      string   `json:"tool_use_id"`
-	Timestamp      string   `json:"timestamp"`
-	UntrackedFiles []string `json:"untracked_files"`
+	ToolUseID       string            `json:"tool_use_id"`
+	Timestamp       string            `json:"timestamp"`
+	UntrackedFiles  []string          `json:"untracked_files"`
+	TrackedBaseline map[string]string `json:"tracked_baseline"`
 
 	// UntrackedScanSkipped mirrors PrePromptState.UntrackedScanSkipped for the
 	// subagent path: when set, subagent-end must skip new-file detection.
@@ -571,6 +578,7 @@ func CapturePreTaskState(ctx context.Context, toolUseID string) error {
 		ToolUseID:            toolUseID,
 		Timestamp:            time.Now().UTC().Format(time.RFC3339),
 		UntrackedFiles:       untrackedFiles,
+		TrackedBaseline:      captureTrackedBaseline(ctx),
 		UntrackedScanSkipped: scanSkipped,
 	}
 
@@ -714,4 +722,97 @@ func GetNextCheckpointSequence(ctx context.Context, sessionID, taskToolUseID str
 	}
 
 	return count + 1
+}
+
+func trackedFingerprints(ctx context.Context, files []string) map[string]string {
+	result := make(map[string]string, len(files))
+	root, err := worktreedir.Open(ctx)
+	if err != nil {
+		return result
+	}
+	for _, name := range files {
+		if ctx.Err() != nil {
+			break
+		}
+		info, err := root.Lstat(name)
+		if errors.Is(err, fs.ErrNotExist) {
+			result[name] = "missing"
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := root.Readlink(name)
+			if err == nil {
+				result[name] = "link:" + target
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		f, err := osroot.OpenNoFollow(root, name)
+		if err != nil {
+			continue
+		}
+		hash := sha256.New()
+		_, err = io.Copy(hash, f)
+		_ = f.Close()
+		if err == nil {
+			result[name] = fmt.Sprintf("%o:%x", info.Mode().Perm()&0o111, hash.Sum(nil))
+		}
+	}
+	return result
+}
+
+func captureTrackedBaseline(ctx context.Context) map[string]string {
+	changes, err := DetectFileChanges(ctx, []string{})
+	if err != nil {
+		return nil
+	}
+	files := append(slices.Clone(changes.Modified), changes.Deleted...)
+	fingerprints := trackedFingerprints(ctx, files)
+	for _, name := range files {
+		if _, ok := fingerprints[name]; !ok {
+			fingerprints[name] = "unknown"
+		}
+	}
+	return fingerprints
+}
+
+func excludeUnchangedTracked(ctx context.Context, changes *FileChanges, baseline map[string]string) {
+	if changes == nil {
+		return
+	}
+	if baseline == nil {
+		changes.Modified = nil
+		changes.Deleted = nil
+		return
+	}
+	current := trackedFingerprints(ctx, append(slices.Clone(changes.Modified), changes.Deleted...))
+	unchanged := func(name string) bool {
+		before, existed := baseline[name]
+		if !existed {
+			return false
+		}
+		after, readable := current[name]
+		return !readable || before == "unknown" || before == after
+	}
+	changes.Modified = slices.DeleteFunc(changes.Modified, unchanged)
+	changes.Deleted = slices.DeleteFunc(changes.Deleted, unchanged)
+}
+
+func (s *PrePromptState) trackedBaseline() map[string]string {
+	if s == nil {
+		return nil
+	}
+	return s.TrackedBaseline
+}
+
+func (s *PreTaskState) trackedBaseline() map[string]string {
+	if s == nil {
+		return nil
+	}
+	return s.TrackedBaseline
 }


### PR DESCRIPTION
A read-only agent turn in an already-dirty checkout currently inherits every tracked modification/deletion through the Git-status fallback in `handleLifecycleTurnEnd`. In a real Codex reproduction, reading one line of `AGENTS.md` attributed 13 pre-existing dirty paths to the session.

Capture tracked dirty-file fingerprints at prompt/task start and filter unchanged paths out of the Git-status fallback at completion. Explicit transcript edit evidence remains independent of this filter. Further edits to an already-dirty file remain detectable. Missing or unreadable baseline evidence does not become positive attribution. This applies to both parent turns and subagent task captures.

Regression coverage includes unchanged prior modifications, staged additions, prior deletions, new edits to both clean and dirty files, new deletions, task baseline persistence, and missing baselines. The rebuilt CLI was also tested through the real Codex/Entire hooks in the same dirty checkout: transcript captured, session ended, zero attributed files.

Validation:
- Focused attribution/state tests passed.
- `mise run fmt` followed by `mise run lint`: passed, zero lint issues.
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 mise run test:ci`: passed all unit/integration/race packages and all four external-agent E2E canaries. Git configuration was isolated to keep host-global hooks out of the fixtures.

This removes pre-existing tracked-file attribution; it does not establish causal ownership of concurrent changes made inside the same worktree. Fingerprinting adds reads of dirty tracked files at turn/task boundaries. No historical checkpoint rewriting is included.
