### PR TITLE
refactor(session): use canonical Git metadata resolution (split part 3)

### DIFF
--- a/cmd/entire/cli/session/metadata_resolution_test.go
+++ b/cmd/entire/cli/session/metadata_resolution_test.go
@@ -1,0 +1,219 @@
+package session
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateStoreConstructionGitSubprocesses(t *testing.T) {
+	// CWD, discovery caches, and Trace2 configuration are process-global.
+	for _, tc := range []struct {
+		name         string
+		explicitRoot bool
+		warmRoot     bool
+	}{
+		{name: "cwd"},
+		{name: "discovered_root", warmRoot: true},
+		{name: "explicit_root", explicitRoot: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			testutil.InitRepo(t, root)
+			t.Chdir(root)
+			paths.ClearWorktreeRootCache()
+			ClearGitCommonDirCache()
+			t.Cleanup(paths.ClearWorktreeRootCache)
+			t.Cleanup(ClearGitCommonDirCache)
+			ctx := context.Background()
+			if tc.warmRoot {
+				_, err := paths.WorktreeRoot(ctx)
+				require.NoError(t, err)
+			}
+			tracePath := filepath.Join(t.TempDir(), "git-trace.jsonl")
+			t.Setenv("GIT_TRACE2_EVENT", tracePath)
+
+			var store *StateStore
+			var err error
+			if tc.explicitRoot {
+				store, err = NewStateStoreForWorktree(ctx, root)
+			} else {
+				store, err = NewStateStore(ctx)
+			}
+			require.NoError(t, err)
+			require.NotNil(t, store)
+			commands := sessionTraceCommands(t, tracePath)
+			t.Logf("constructor Git subprocesses: %v", commands)
+			var want [][]string
+			if !tc.explicitRoot && !tc.warmRoot {
+				want = [][]string{{"rev-parse", "--show-toplevel"}}
+			}
+			require.Equal(t, want, commands)
+
+			testutil.RunGit(t, root, "rev-parse", "--git-common-dir")
+			observed := sessionTraceCommands(t, tracePath)
+			require.Equal(t, append(commands, []string{"rev-parse", "--git-common-dir"}), observed,
+				"the positive control must record an additional real Git process")
+		})
+	}
+}
+
+func TestStateStoreFromCWDObservesMetadataDamageAndRepair(t *testing.T) {
+	// CWD and the worktree-root cache are process-global.
+	root := t.TempDir()
+	testutil.InitRepo(t, root)
+	t.Chdir(root)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	ctx := context.Background()
+	store, err := NewStateStore(ctx)
+	require.NoError(t, err)
+	state := &State{SessionID: "cwd-repair-session", Kind: KindImported}
+	require.NoError(t, store.Save(ctx, state))
+
+	commonFile := filepath.Join(root, ".git", "commondir")
+	require.NoError(t, os.WriteFile(commonFile, []byte("missing\n"), 0o600))
+	store, err = NewStateStore(ctx)
+	require.Error(t, err)
+	require.Nil(t, store)
+
+	require.NoError(t, os.Remove(commonFile))
+	store, err = NewStateStore(ctx)
+	require.NoError(t, err)
+	loaded, err := store.Load(ctx, state.SessionID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.Equal(t, state.SessionID, loaded.SessionID)
+}
+
+func TestStateStoreForLinkedWorktreeSharesSessionStorage(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	mainRoot := filepath.Join(tmp, "main")
+	linkedRoot := filepath.Join(tmp, "linked")
+	testutil.InitRepo(t, mainRoot)
+	testutil.WriteFile(t, mainRoot, "initial.txt", "initial\n")
+	testutil.GitAdd(t, mainRoot, "initial.txt")
+	testutil.GitCommit(t, mainRoot, "initial")
+	testutil.RunGit(t, mainRoot, "worktree", "add", "-b", "linked", linkedRoot)
+
+	ctx := context.Background()
+	linkedStore, err := NewStateStoreForWorktree(ctx, linkedRoot)
+	require.NoError(t, err)
+	state := &State{SessionID: "shared-session", Kind: KindImported}
+	require.NoError(t, linkedStore.Save(ctx, state))
+
+	mainStore, err := NewStateStoreForWorktree(ctx, mainRoot)
+	require.NoError(t, err)
+	loaded, err := mainStore.Load(ctx, state.SessionID)
+	require.NoError(t, err)
+	require.Equal(t, state.SessionID, loaded.SessionID)
+	require.FileExists(t, filepath.Join(mainRoot, ".git", SessionStateDirName, state.SessionID+".json"))
+	require.NoError(t, mainStore.Clear(ctx, state.SessionID))
+	loaded, err = linkedStore.Load(ctx, state.SessionID)
+	require.NoError(t, err)
+	require.Nil(t, loaded)
+}
+
+func TestStateStoreForWorktreeRejectsBrokenMetadataAndObservesRepair(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	testutil.InitRepo(t, root)
+	ctx := context.Background()
+	store, err := NewStateStoreForWorktree(ctx, root)
+	require.NoError(t, err)
+	state := &State{SessionID: "repair-session", Kind: KindImported}
+	require.NoError(t, store.Save(ctx, state))
+
+	commonFile := filepath.Join(root, ".git", "commondir")
+	require.NoError(t, os.WriteFile(commonFile, []byte("missing\n"), 0o600))
+	store, err = NewStateStoreForWorktree(ctx, root)
+	require.Error(t, err)
+	require.Nil(t, store)
+
+	require.NoError(t, os.Remove(commonFile))
+	store, err = NewStateStoreForWorktree(ctx, root)
+	require.NoError(t, err)
+	loaded, err := store.Load(ctx, state.SessionID)
+	require.NoError(t, err)
+	require.Equal(t, state.SessionID, loaded.SessionID)
+}
+
+func TestStateStoreForWorktreeRejectsInvalidRoots(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"empty", "missing", "not_a_directory", "absent_metadata", "malformed_metadata"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			switch name {
+			case "empty":
+				root = ""
+			case "missing":
+				root = filepath.Join(root, "missing")
+			case "not_a_directory":
+				root = filepath.Join(root, "file")
+				require.NoError(t, os.WriteFile(root, nil, 0o600))
+			case "malformed_metadata":
+				require.NoError(t, os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir:"), 0o600))
+			}
+			store, err := NewStateStoreForWorktree(context.Background(), root)
+			require.Error(t, err)
+			require.Nil(t, store)
+		})
+	}
+}
+
+func TestStateStoreForWorktreeIgnoresRepositoryOverrides(t *testing.T) {
+	// Repository override variables are process-global.
+	root := t.TempDir()
+	other := t.TempDir()
+	testutil.InitRepo(t, root)
+	testutil.InitRepo(t, other)
+	t.Setenv("GIT_DIR", filepath.Join(other, ".git"))
+	t.Setenv("GIT_COMMON_DIR", filepath.Join(other, ".git"))
+	t.Setenv("GIT_WORK_TREE", other)
+
+	ctx := context.Background()
+	store, err := NewStateStoreForWorktree(ctx, root)
+	require.NoError(t, err)
+	state := &State{SessionID: "explicit-repository", Kind: KindImported}
+	require.NoError(t, store.Save(ctx, state))
+	require.FileExists(t, filepath.Join(root, ".git", SessionStateDirName, state.SessionID+".json"))
+	require.NoDirExists(t, filepath.Join(other, ".git", SessionStateDirName),
+		"inherited Git selectors must not redirect the session write")
+}
+
+func sessionTraceCommands(t *testing.T, tracePath string) [][]string {
+	t.Helper()
+	file, err := os.Open(tracePath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	require.NoError(t, err)
+	defer file.Close()
+	var commands [][]string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		var event struct {
+			Event string   `json:"event"`
+			Argv  []string `json:"argv"`
+		}
+		require.NoError(t, json.Unmarshal(scanner.Bytes(), &event))
+		if event.Event == "start" {
+			require.NotEmpty(t, event.Argv)
+			commands = append(commands, event.Argv[1:])
+		}
+	}
+	require.NoError(t, scanner.Err())
+	return commands
+}

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -16,9 +16,11 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/gitdir"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/proclive"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
 )
@@ -853,14 +855,11 @@ func (s *StateStore) name(file string) string {
 // NewStateStore creates a new state store.
 // Uses the git common dir to store session state (shared across worktrees).
 func NewStateStore(ctx context.Context) (*StateStore, error) {
-	commonDir, err := gitdir.CommonDir(ctx)
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get git common dir: %w", err)
+		return nil, fmt.Errorf("resolve worktree root for session state: %w", err)
 	}
-	if err := ensureTestIsolatedStateDir(commonDir); err != nil {
-		return nil, err
-	}
-	return newStateStoreAt(commonDir), nil
+	return NewStateStoreForWorktree(ctx, worktreeRoot)
 }
 
 // NewStateStoreForWorktree returns the state store for the repository at
@@ -869,24 +868,18 @@ func NewStateStore(ctx context.Context) (*StateStore, error) {
 // the CWD-resolved NewStateStore writes session state into whatever repo the
 // process happens to run in, which is how test fixtures once leaked into a
 // developer's real .git/entire-sessions and hijacked commit linking.
-func NewStateStoreForWorktree(ctx context.Context, worktreeRoot string) (*StateStore, error) {
-	// An empty root would silently degrade to the process CWD (cmd.Dir = ""),
-	// reproducing exactly the accidental-repo leak this constructor exists to
-	// prevent.
+func NewStateStoreForWorktree(_ context.Context, worktreeRoot string) (*StateStore, error) {
 	if worktreeRoot == "" {
 		return nil, errors.New("worktree root required to scope the session state store")
 	}
-	commonDir, err := gitdir.CommonDirForWorktree(ctx, worktreeRoot)
+	metadata, err := gitrepo.ResolveWorktreeMetadata(worktreeRoot)
 	if err != nil {
 		return nil, fmt.Errorf("resolve git common dir for %s: %w", worktreeRoot, err)
 	}
-	// Same go-test guard as NewStateStore: an explicit root computed from the
-	// process CWD in a non-isolated test is just as accidental as the CWD
-	// itself.
-	if err := ensureTestIsolatedStateDir(commonDir); err != nil {
+	if err := ensureTestIsolatedStateDir(metadata.CommonDir); err != nil {
 		return nil, err
 	}
-	return newStateStoreAt(commonDir), nil
+	return newStateStoreAt(metadata.CommonDir), nil
 }
 
 // ensureTestIsolatedStateDir fails loud when `go test` code reaches a
@@ -900,11 +893,6 @@ func NewStateStoreForWorktree(ctx context.Context, worktreeRoot string) (*StateS
 func ensureTestIsolatedStateDir(commonDir string) error {
 	if !testing.Testing() {
 		return nil
-	}
-	// getGitCommonDir can return a cwd-relative ".git"; the temp-root
-	// comparison needs the absolute location.
-	if abs, err := filepath.Abs(commonDir); err == nil {
-		commonDir = abs
 	}
 	if underTempRoot(commonDir) {
 		return nil

--- a/cmd/entire/cli/session_adopt.go
+++ b/cmd/entire/cli/session_adopt.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
@@ -132,9 +133,9 @@ func adoptFromExternalSessionStore(
 	sessionID string,
 	opts adoptOptions,
 ) (*session.State, []string, error) {
-	sourceWorktreeID, worktreeIDErr := paths.GetWorktreeID(sourceWorktree)
-	if worktreeIDErr != nil {
-		sourceWorktreeID = ""
+	sourceWorktreeID := ""
+	if metadata, err := gitrepo.ResolveWorktreeMetadata(sourceWorktree); err == nil {
+		sourceWorktreeID = metadata.WorktreeID
 	}
 
 	var adopted *session.State
@@ -222,9 +223,9 @@ func adoptFromSameSessionStore(ctx context.Context, sourceWorktree string, sourc
 		return nil, nil, fmt.Errorf("session %s is already tracked in this repo; rerun with --force to replace it", sourceState.SessionID)
 	}
 
-	sourceWorktreeID, worktreeIDErr := paths.GetWorktreeID(sourceWorktree)
-	if worktreeIDErr != nil {
-		sourceWorktreeID = ""
+	sourceWorktreeID := ""
+	if metadata, err := gitrepo.ResolveWorktreeMetadata(sourceWorktree); err == nil {
+		sourceWorktreeID = metadata.WorktreeID
 	}
 
 	var adopted *session.State
@@ -310,9 +311,9 @@ func stateStoreForWorktree(ctx context.Context, worktreePath string) (*session.S
 }
 
 func selectAdoptSourceSession(ctx context.Context, store *session.StateStore, sourceWorktree, sessionID string) (*session.State, error) {
-	sourceWorktreeID, worktreeIDErr := paths.GetWorktreeID(sourceWorktree)
-	if worktreeIDErr != nil {
-		sourceWorktreeID = ""
+	sourceWorktreeID := ""
+	if metadata, err := gitrepo.ResolveWorktreeMetadata(sourceWorktree); err == nil {
+		sourceWorktreeID = metadata.WorktreeID
 	}
 	if sessionID != "" {
 		sourceState, err := store.Load(ctx, sessionID)
@@ -428,7 +429,7 @@ func buildAdoptedSessionState(ctx context.Context, source *session.State) (*sess
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve current worktree root: %w", err)
 	}
-	worktreeID, err := paths.GetWorktreeID(worktreeRoot)
+	metadata, err := gitrepo.ResolveWorktreeMetadata(worktreeRoot)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve current worktree ID: %w", err)
 	}
@@ -457,7 +458,7 @@ func buildAdoptedSessionState(ctx context.Context, source *session.State) (*sess
 	adopted.BaseCommit = head.Hash().String()
 	adopted.RealignAttributionBase(head.Hash().String())
 	adopted.WorktreePath = worktreeRoot
-	adopted.WorktreeID = worktreeID
+	adopted.WorktreeID = metadata.WorktreeID
 	adopted.AdoptedIntoWorktreePath = ""
 	adopted.AdoptedIntoWorktreeID = ""
 	adopted.Branch = branch

--- a/cmd/entire/cli/session_adopt_metadata_test.go
+++ b/cmd/entire/cli/session_adopt_metadata_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdoptStoreRequiresGitRepositoryValidation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".git"), 0o750))
+	_, err := gitrepo.ResolveWorktreeMetadata(root)
+	require.NoError(t, err, "directory metadata alone does not establish a Git repository")
+	store, _, _, err := stateStoreForWorktree(context.Background(), root)
+	require.ErrorContains(t, err, "resolve source git directory")
+	require.Nil(t, store, "adoption must retain Git's semantic validation")
+}
+
+func TestAdoptSourceMetadataFailureFallsBackToWorktreePath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	testutil.InitRepo(t, root)
+	ctx := context.Background()
+	store, err := session.NewStateStoreForWorktree(ctx, root)
+	require.NoError(t, err)
+	state := &session.State{
+		SessionID:    "source-path-fallback",
+		Phase:        session.PhaseActive,
+		StartedAt:    time.Now(),
+		WorktreePath: root,
+	}
+	require.NoError(t, store.Save(ctx, state))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".git", "commondir"), []byte("missing\n"), 0o600))
+	_, err = gitrepo.ResolveWorktreeMetadata(root)
+	require.Error(t, err)
+	selected, err := selectAdoptSourceSession(ctx, store, root, state.SessionID)
+	require.NoError(t, err)
+	require.Equal(t, state.SessionID, selected.SessionID)
+}
+
+func TestBuildAdoptedStateUsesBareBackedWorktreeMetadata(t *testing.T) {
+	// buildAdoptedSessionState discovers its target from CWD.
+	tmp := t.TempDir()
+	seed := filepath.Join(tmp, "seed")
+	storage := filepath.Join(tmp, "storage")
+	linked := filepath.Join(tmp, "target")
+	testutil.InitRepo(t, seed)
+	testutil.WriteFile(t, seed, "initial.txt", "initial\n")
+	testutil.GitAdd(t, seed, "initial.txt")
+	testutil.GitCommit(t, seed, "initial")
+	testutil.RunGit(t, tmp, "clone", "--bare", seed, storage)
+	testutil.RunGit(t, tmp, "--git-dir", storage, "worktree", "add", "-b", "target", linked)
+	t.Chdir(linked)
+
+	state, _, err := buildAdoptedSessionState(context.Background(), &session.State{SessionID: "bare-adoption"})
+	require.NoError(t, err)
+	require.Equal(t, "target", state.WorktreeID)
+	require.Equal(t, testutil.GetHeadHash(t, seed), state.BaseCommit)
+}

--- a/cmd/entire/cli/session_sweep.go
+++ b/cmd/entire/cli/session_sweep.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/execx"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -177,10 +178,10 @@ func countSweepableZombies(states []*session.State, now time.Time) int {
 // spawnDetachedSessionSweepProcess.
 var sweepSpawn = spawnDetachedSessionSweepProcess
 
-// sweepGitCommonDir is the repository-scope seam used by
+// sweepWorktreeMetadata is the repository-scope seam used by
 // maybeSpawnSessionSweep. Swapped in tests to prove a throttle-key failure
 // fails closed without depending on a malformed repository fixture.
-var sweepGitCommonDir = session.GetGitCommonDir
+var sweepWorktreeMetadata = gitrepo.ResolveWorktreeMetadata
 
 // spawnDetachedSessionSweepProcess starts `entire __sweep_sessions` as a
 // detached child so the sweep's repo work can't add latency to the
@@ -228,7 +229,7 @@ func maybeSpawnSessionSweep(ctx context.Context) {
 			slog.String("error", err.Error()))
 		return
 	}
-	commonDir, err := sweepGitCommonDir(ctx)
+	metadata, err := sweepWorktreeMetadata(root)
 	if err != nil {
 		logging.Debug(logCtx, "skipping sweep spawn: could not resolve git common dir",
 			slog.String("error", err.Error()))
@@ -248,7 +249,7 @@ func maybeSpawnSessionSweep(ctx context.Context) {
 	if n == 0 {
 		return
 	}
-	if sweepRecentlySpawned(commonDir, time.Now()) {
+	if sweepRecentlySpawned(metadata.CommonDir, time.Now()) {
 		return
 	}
 	sweepSpawn(root)

--- a/cmd/entire/cli/session_sweep_test.go
+++ b/cmd/entire/cli/session_sweep_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/proclive"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
@@ -338,14 +339,14 @@ func TestMaybeSpawnSessionSweep_SeamAndThrottle(t *testing.T) {
 	var spawns atomic.Int32
 	var gotRoot atomic.Value
 	prevSpawn := sweepSpawn
-	prevGitCommonDir := sweepGitCommonDir
+	prevMetadata := sweepWorktreeMetadata
 	sweepSpawn = func(worktreeRoot string) {
 		spawns.Add(1)
 		gotRoot.Store(worktreeRoot)
 	}
 	t.Cleanup(func() {
 		sweepSpawn = prevSpawn
-		sweepGitCommonDir = prevGitCommonDir
+		sweepWorktreeMetadata = prevMetadata
 	})
 
 	// No zombies: no spawn (and no throttle marker written — the throttle is
@@ -366,12 +367,21 @@ func TestMaybeSpawnSessionSweep_SeamAndThrottle(t *testing.T) {
 
 	// A common-dir failure means there is no safe repository-wide throttle key.
 	// Fail closed rather than forking an unbounded child on every session start.
-	sweepGitCommonDir = func(context.Context) (string, error) {
-		return "", errors.New("common dir unavailable")
+	wantRoot, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	sweepWorktreeMetadata = func(root string) (gitrepo.WorktreeMetadata, error) {
+		require.Equal(t, wantRoot, root, "metadata resolution must use the discovered worktree root")
+		return gitrepo.WorktreeMetadata{}, errors.New("common dir unavailable")
 	}
 	maybeSpawnSessionSweep(ctx)
 	assert.Equal(t, int32(0), spawns.Load(), "common-dir failure must not spawn a sweep")
-	sweepGitCommonDir = prevGitCommonDir
+	sweepWorktreeMetadata = prevMetadata
+
+	commonFile := filepath.Join(dir, ".git", "commondir")
+	require.NoError(t, os.WriteFile(commonFile, []byte("missing\n"), 0o600))
+	maybeSpawnSessionSweep(ctx)
+	assert.Equal(t, int32(0), spawns.Load(), "broken metadata must not spawn a sweep")
+	require.NoError(t, os.Remove(commonFile))
 
 	// Zombie present: exactly one spawn, with the worktree root.
 	maybeSpawnSessionSweep(ctx)
@@ -379,8 +389,6 @@ func TestMaybeSpawnSessionSweep_SeamAndThrottle(t *testing.T) {
 	got, okRoot := gotRoot.Load().(string)
 	require.True(t, okRoot, "seam must have been handed a worktree root")
 	require.NotEmpty(t, got)
-	wantRoot, err := filepath.EvalSymlinks(dir)
-	require.NoError(t, err)
 	gotEval, err := filepath.EvalSymlinks(got)
 	require.NoError(t, err)
 	assert.Equal(t, wantRoot, gotEval, "sweep must be spawned from the worktree root")


### PR DESCRIPTION
Part 3 of #2190's [agreed split](https://github.com/entireio/cli/pull/2190#issuecomment-5499945525), following the merged canonical resolver in #2241 and checkpoint migration in #2254.

Session construction, adoption, and sweep still use separate paths to resolve Git metadata. This PR moves those consumers to `gitrepo.ResolveWorktreeMetadata`, so the canonical resolver supplies the common directory and worktree ID while each caller keeps its own storage and failure policy.

## Session-store construction

Previously, constructing a session store ran `git rev-parse --git-common-dir` even when the caller already knew the worktree root. The CWD constructor also used a cached common-directory result, which could hide metadata damage after an earlier successful lookup.

`NewStateStore` now discovers the root through `paths.WorktreeRoot` and delegates to `NewStateStoreForWorktree`. The explicit-root constructor resolves `WorktreeMetadata.CommonDir` directly. Known-root construction therefore starts no Git subprocesses, and each construction checks the current metadata without adding another cache.

For example, if `commondir` is changed to point at a missing directory after a successful construction, the next construction fails. Repairing the metadata makes construction succeed again and preserves access to the saved session. Inherited `GIT_DIR`, `GIT_COMMON_DIR`, and `GIT_WORK_TREE` values also cannot redirect an explicitly scoped store into another repository.

The common directory still feeds the existing rooted store. Linked worktrees share session files, and empty-root rejection, test isolation, no-follow I/O, atomic writes, and locking remain in place.

## Adoption and sweep

Adoption uses the canonical resolver for source and target worktree IDs. This removes its dependency on the legacy parser's expected directory names. A linked worktree backed by a bare repository named `storage`, for example, can now resolve its ID from `storage/worktrees/<id>`.

The source and target retain different failure policies. If source metadata cannot resolve, adoption can still match the session by its recorded worktree path. If target metadata cannot resolve, adoption stops before saving the adopted state. The combined Git query in `stateStoreForWorktree` stays because it validates an arbitrary user-supplied repository; a directory that merely contains an empty `.git` folder must still be rejected. Source-retirement rollback remains unchanged.

Sweep now resolves metadata from the worktree root it has already discovered. If that fails, it skips spawning. On success, it uses the common directory for the existing repository-wide throttle, so session starts in different worktrees continue to share the same throttle marker.

## Why the legacy APIs and cache remain

`session.GetGitCommonDir`, the cache-clearing API, and `gitdir`'s common-directory resolver/cache still serve strategy and other consumers outside this slice. Removing them now would require migrating those callers too. Their deletion waits until those callers have migrated and been verified.

This PR is limited to three production files and their tests. The ownership guard remains active. Rooted-handle lifetime and the strategy/session-lock migration stay with their existing owners.

## Verification

- `mise run lint`: passed with zero issues.
- `mise run test`: passed, 10,670 tests reported with 8 skipped.
- `mise run test:integration`: passed on a standalone rerun, 562 tests reported with 3 skipped. The initial run alongside the unit suite timed out waiting for the external-command SIGINT test plugin to start.
- Full session, agent-import, and canonical-resolver package tests, plus adoption and sweep tests: passed.
- `git diff upstream/main...HEAD --check`: passed.

Focused tests cover linked-worktree save/load/clear, invalid roots, metadata damage and repair, inherited Git variables, adoption validation and source-path fallback, bare-backed worktree IDs, and sweep failure/throttle behavior. Existing tests exercise rooted storage, symlink refusal, and adoption rollback.

Selected new tests were also run against the old production code through a temporary Go overlay. They failed for the expected cached-metadata, repository-override, worktree-ID, and subprocess-count differences, and passed on this branch.

Real Git Trace2 events show constructor subprocess counts:

| Construction path | Before | After |
| --- | --- | --- |
| Cold CWD | 1 common-directory query | 1 root-discovery query |
| Root already discovered | 1 | 0 |
| Explicit root | 1 | 0 |

The Trace2 test includes a positive control that launches Git and checks that an additional event is recorded. These measurements cover store construction, not total hook latency.

