### PR TITLE
perf: reduce transcript and repeated-secret scan allocations

### DIFF
--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -2750,7 +2750,7 @@ func readTranscriptFromTree(ctx context.Context, tree *FetchingTree, agentType t
 			chunkFiles = append([]string{paths.TranscriptFileName}, chunkFiles...)
 		}
 
-		var chunks [][]byte
+		chunks := make([][]byte, 0, len(chunkFiles))
 		for _, chunkFile := range chunkFiles {
 			file, err := tree.File(chunkFile)
 			if err != nil {
@@ -2760,7 +2760,7 @@ func readTranscriptFromTree(ctx context.Context, tree *FetchingTree, agentType t
 				)
 				continue
 			}
-			content, err := file.Contents()
+			content, err := readTranscriptFile(file)
 			if err != nil {
 				logging.Warn(ctx, "failed to read transcript chunk contents",
 					slog.String("chunk_file", chunkFile),
@@ -2768,7 +2768,7 @@ func readTranscriptFromTree(ctx context.Context, tree *FetchingTree, agentType t
 				)
 				continue
 			}
-			chunks = append(chunks, []byte(content))
+			chunks = append(chunks, content)
 		}
 
 		if len(chunks) > 0 {
@@ -2782,19 +2782,46 @@ func readTranscriptFromTree(ctx context.Context, tree *FetchingTree, agentType t
 
 	// Fall back to reading base file (non-chunked or backwards compatibility)
 	if file, err := tree.File(paths.TranscriptFileName); err == nil {
-		if content, err := file.Contents(); err == nil {
-			return []byte(content), nil
+		if content, err := readTranscriptFile(file); err == nil {
+			return content, nil
 		}
 	}
 
 	// Try legacy filename
 	if file, err := tree.File(paths.TranscriptFileNameLegacy); err == nil {
-		if content, err := file.Contents(); err == nil {
-			return []byte(content), nil
+		if content, err := readTranscriptFile(file); err == nil {
+			return content, nil
 		}
 	}
 
 	return nil, nil
+}
+
+// readTranscriptFile keeps large transcript blobs as bytes throughout the read.
+// File.Contents grows a buffer and copies it to a string, which callers then
+// copy back to bytes. Reserve the known blob size plus ReadFrom's minimum
+// spare capacity so its final EOF probe does not double the whole buffer.
+func readTranscriptFile(file *object.File) (content []byte, err error) {
+	reader, err := file.Reader()
+	if err != nil {
+		return nil, fmt.Errorf("open transcript blob: %w", err)
+	}
+	defer func() {
+		if closeErr := reader.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close transcript blob: %w", closeErr)
+		}
+	}()
+
+	var buf bytes.Buffer
+	// Use a bounded size hint for normal chunks; larger legacy blobs still
+	// use incremental buffer growth.
+	if file.Size >= 0 && file.Size <= agent.MaxChunkSize {
+		buf.Grow(int(file.Size) + bytes.MinRead)
+	}
+	if _, err := buf.ReadFrom(reader); err != nil {
+		return nil, fmt.Errorf("read transcript blob: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 func transcriptBlobHashesFromTreeEntries(entries []object.TreeEntry) []plumbing.Hash {

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -2813,9 +2813,9 @@ func readTranscriptFile(file *object.File) (content []byte, err error) {
 	}()
 
 	var buf bytes.Buffer
-	// Use a bounded size hint for normal chunks; larger legacy blobs still
-	// use incremental buffer growth.
-	if file.Size >= 0 && file.Size <= agent.MaxChunkSize {
+	// Shadow transcripts can exceed MaxChunkSize without being chunked. Bound
+	// only the upfront allocation hint at 1 GiB; larger blobs still grow incrementally.
+	if file.Size >= 0 && file.Size <= 1<<30 {
 		buf.Grow(int(file.Size) + bytes.MinRead)
 	}
 	if _, err := buf.ReadFrom(reader); err != nil {

--- a/cmd/entire/cli/checkpoint/transcript_read_test.go
+++ b/cmd/entire/cli/checkpoint/transcript_read_test.go
@@ -1,0 +1,87 @@
+package checkpoint
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/storage/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadTranscriptFromTreeFormats(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		files map[string][]byte
+		want  []byte
+	}{
+		{name: "base", files: map[string][]byte{"full.jsonl": []byte("first\nsecond\n")}, want: []byte("first\nsecond\n")},
+		{name: "legacy", files: map[string][]byte{paths.TranscriptFileNameLegacy: []byte("legacy\n")}, want: []byte("legacy\n")},
+		{name: "empty", files: map[string][]byte{"full.jsonl": {}}, want: []byte{}},
+		{name: "absent", files: map[string][]byte{}, want: nil},
+		{
+			name: "chunk order",
+			files: map[string][]byte{
+				"full.jsonl":     []byte("zero"),
+				"full.jsonl.010": []byte("ten"),
+				"full.jsonl.002": []byte("two"),
+				"full.jsonl.001": []byte("one"),
+			},
+			want: []byte("zero\none\ntwo\nten"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			repo, err := git.Init(memory.NewStorage(), nil)
+			require.NoError(t, err)
+			tree := transcriptReadFixture(t, repo, tc.files)
+			got, err := readTranscriptFromTree(t.Context(), NewFetchingTree(t.Context(), tree, repo.Storer, nil), "")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func BenchmarkReadTranscriptFromTree(b *testing.B) {
+	for _, size := range []int{1 << 20, 8 << 20} {
+		b.Run(fmt.Sprintf("%dMiB", size>>20), func(b *testing.B) {
+			// In-memory objects isolate transcript decoding and allocation costs
+			// from filesystem cache state; tree and blob lookup are still real.
+			repo, err := git.Init(memory.NewStorage(), nil)
+			require.NoError(b, err)
+			payload := bytes.Repeat([]byte("x"), size)
+			tree := transcriptReadFixture(b, repo, map[string][]byte{paths.TranscriptFileName: payload})
+			ft := NewFetchingTree(b.Context(), tree, repo.Storer, nil)
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			for b.Loop() {
+				got, readErr := readTranscriptFromTree(b.Context(), ft, "")
+				if readErr != nil || !bytes.Equal(got, payload) {
+					b.Fatalf("transcript differs: size=%d, error=%v", len(got), readErr)
+				}
+			}
+		})
+	}
+}
+
+func transcriptReadFixture(t testing.TB, repo *git.Repository, files map[string][]byte) *object.Tree {
+	t.Helper()
+	entries := make([]object.TreeEntry, 0, len(files))
+	for name, content := range files {
+		hash, err := CreateBlobFromContent(repo, content)
+		require.NoError(t, err)
+		entries = append(entries, object.TreeEntry{Name: name, Mode: filemode.Regular, Hash: hash})
+	}
+	sortTreeEntries(entries)
+	hash, err := storeTree(repo, entries)
+	require.NoError(t, err)
+	tree, err := repo.TreeObject(hash)
+	require.NoError(t, err)
+	return tree
+}

--- a/cmd/entire/cli/checkpoint/transcript_read_test.go
+++ b/cmd/entire/cli/checkpoint/transcript_read_test.go
@@ -21,17 +21,19 @@ func TestReadTranscriptFromTreeFormats(t *testing.T) {
 		files map[string][]byte
 		want  []byte
 	}{
-		{name: "base", files: map[string][]byte{"full.jsonl": []byte("first\nsecond\n")}, want: []byte("first\nsecond\n")},
+		{name: "base", files: map[string][]byte{paths.TranscriptFileName: []byte("first\nsecond\n")}, want: []byte("first\nsecond\n")},
 		{name: "legacy", files: map[string][]byte{paths.TranscriptFileNameLegacy: []byte("legacy\n")}, want: []byte("legacy\n")},
-		{name: "empty", files: map[string][]byte{"full.jsonl": {}}, want: []byte{}},
+		// A present empty transcript must remain non-nil: ephemeral reads use
+		// nil to decide whether to fall through to their legacy read path.
+		{name: "empty", files: map[string][]byte{paths.TranscriptFileName: {}}, want: []byte{}},
 		{name: "absent", files: map[string][]byte{}, want: nil},
 		{
 			name: "chunk order",
 			files: map[string][]byte{
-				"full.jsonl":     []byte("zero"),
-				"full.jsonl.010": []byte("ten"),
-				"full.jsonl.002": []byte("two"),
-				"full.jsonl.001": []byte("one"),
+				paths.TranscriptFileName:          []byte("zero"),
+				paths.TranscriptFileName + ".010": []byte("ten"),
+				paths.TranscriptFileName + ".002": []byte("two"),
+				paths.TranscriptFileName + ".001": []byte("one"),
 			},
 			want: []byte("zero\none\ntwo\nten"),
 		},
@@ -49,7 +51,8 @@ func TestReadTranscriptFromTreeFormats(t *testing.T) {
 }
 
 func BenchmarkReadTranscriptFromTree(b *testing.B) {
-	for _, size := range []int{1 << 20, 8 << 20} {
+	// The 64 MiB case covers unchunked shadow transcripts above MaxChunkSize.
+	for _, size := range []int{1 << 20, 8 << 20, 64 << 20} {
 		b.Run(fmt.Sprintf("%dMiB", size>>20), func(b *testing.B) {
 			// In-memory objects isolate transcript decoding and allocation costs
 			// from filesystem cache state; tree and blob lookup are still real.

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -213,6 +213,7 @@ func detectAllLayers(s string) []taggedRegion {
 	// via ConfigureScanners; betterleaks-only when unconfigured).
 	if getScanners().betterleaks {
 		if d := getDetector(); d != nil {
+			seenSecrets := make(map[string]struct{})
 			for _, f := range d.DetectString(s) {
 				// Placeholder-valued findings (changeme, secret_here, mask runs)
 				// stay visible — but only on an exact match: splitting a greedy
@@ -220,6 +221,13 @@ func detectAllLayers(s string) []taggedRegion {
 				if isPlaceholderSecretValue(f.Secret) {
 					continue
 				}
+				// A finding reports one occurrence, but the search below already
+				// covers every copy of its secret. Repeated findings must not
+				// rescan the input and accumulate quadratically many regions.
+				if _, seen := seenSecrets[f.Secret]; seen {
+					continue
+				}
+				seenSecrets[f.Secret] = struct{}{}
 				searchFrom := 0
 				for {
 					idx := strings.Index(s[searchFrom:], f.Secret)

--- a/redact/redact_bench_test.go
+++ b/redact/redact_bench_test.go
@@ -14,6 +14,25 @@ QyNTUxOQAAACB7ZlJ8tkWCKdRJRGF1BngP3bkNbz8bMF6Yl5xLJp9m1QAAAJj2M3UO9jN1
 DgAAAAtzc2gtZWQyNTUxOQAAACB7ZlJ8tkWCKdRJRGF1BngP3bkNbz8bMF6Yl5xLJp9m1QA
 AAEAGZmFrZS1rZXktZm9yLXJlZGFjdGlvbi1iZW5jaG1hcmstb25seQECAwQF`)
 
+// Repeated credentials can occur in captured tool output, such as request logs.
+// Each matching scanner finding must not trigger another whole-input scan for
+// all copies of the same secret.
+func BenchmarkRedactStringRepeatedSecret(b *testing.B) {
+	for _, repeats := range []int{1, 10, 100, 1000} {
+		b.Run(fmt.Sprintf("Occurrences%d", repeats), func(b *testing.B) {
+			input := strings.Repeat("request key=AKIAYRWQG5EJLPZLBYNP completed\n", repeats)
+			want := strings.Repeat("request key=REDACTED completed\n", repeats)
+			b.ReportAllocs()
+			b.SetBytes(int64(len(input)))
+			for b.Loop() {
+				if got := String(input); got != want {
+					b.Fatal("redacted output did not match expected request log")
+				}
+			}
+		})
+	}
+}
+
 // BenchmarkRedactJSONLBytes gives us a stable redaction performance baseline.
 //
 // To compare against a base ref:

--- a/redact/redact_bench_test.go
+++ b/redact/redact_bench_test.go
@@ -16,7 +16,10 @@ AAEAGZmFrZS1rZXktZm9yLXJlZGFjdGlvbi1iZW5jaG1hcmstb25seQECAwQF`)
 
 // Repeated credentials can occur in captured tool output, such as request logs.
 // Each matching scanner finding must not trigger another whole-input scan for
-// all copies of the same secret.
+// all copies of the same secret within one String call. Parsed JSONL is redacted
+// per string field, so repeated values in separate fields or lines are not deduped.
+// Compare benchmark results manually against a base ref; CI does not enforce
+// a performance baseline.
 func BenchmarkRedactStringRepeatedSecret(b *testing.B) {
 	for _, repeats := range []int{1, 10, 100, 1000} {
 		b.Run(fmt.Sprintf("Occurrences%d", repeats), func(b *testing.B) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1241
<!-- entire-trail-link-end -->

## Summary

- Search each distinct betterleaks finding value once per `String` call, avoiding duplicate whole-input searches and duplicate regions. For valid JSONL, this benefit is within one string field, such as a large tool result containing repeated request-log entries; equal values in separate fields or lines are not deduplicated together.
- Read transcript blobs directly into a size-reserved byte buffer instead of copying through `File.Contents()` strings; preallocate the chunk slice as well. The size hint covers both normal chunks and current unchunked shadow transcripts, up to a 1 GiB sanity ceiling. Above that, reads retain incremental growth. This ceiling is an allocation hint limit, not a read-size limit.
- Preserve transcript bytes, fallback behavior, and redaction output. Each duplicate finding previously generated the same unlabeled regions; eliminating duplicate work does not change output, so no `configFingerprintVersion` bump is needed. No API or configuration changes.
- Keep characterization coverage for base, legacy, present-empty, absent, and numerically ordered chunked transcripts. The present-empty result must remain non-nil because ephemeral reads use nil to select the legacy fallback. Use filename constants consistently.

## Benchmarks

Original before/after medians from five runs with `-benchtime=500ms -benchmem`, Go 1.26.6 on darwin/arm64 (Apple M5 Pro):

| Workload | Time before → after | Allocated bytes before → after |
|---|---:|---:|
| 1,000 repeated credentials in one String call | 175.428 → 116.936 ms | 292.007 → 119.687 MB |
| 1 MiB transcript read | 380.988 → 69.679 µs | 6,291,204 → 1,057,024 |
| 8 MiB transcript read | 1,233.019 → 414.637 µs | 50,331,431 → 8,397,057 |

The existing ClaudeFull2 fixture was effectively unchanged (167.462 → 163.730 ms).

Soph's review identified that the original 50 MB hint ceiling excluded current unchunked shadow transcripts. The new 64 MiB benchmark exercises that case. Fresh A/B medians comparing the previous PR implementation (`caf73c69b`) with the amendment, using the same new benchmark, Go 1.26.6, Apple M5 Pro, `GOMAXPROCS=4`, `-benchtime=20x -count=3 -benchmem`:

| 64 MiB transcript | Previous PR | Amendment |
|---|---:|---:|
| Time | 6.299 ms | 2.952 ms |
| Allocated bytes | 268,435,280 | 67,117,320 |
| Allocations | 24 | 6 |

That is approximately 75% fewer allocated bytes. The 1 MiB and 8 MiB allocation counts remain unchanged. These benchmarks use real in-memory Git objects to isolate read/allocation costs; they are not end-to-end CLI speedup, peak-RSS, or production-frequency claims. The frequency of transcripts above 50 MB has not been measured here.

Benchmark output assertions check correctness. Performance comparisons are manual against a base ref; CI does not enforce an allocation or timing baseline.

```sh
go test ./redact -run '^$' -bench '^BenchmarkRedactStringRepeatedSecret$/Occurrences1000$' -benchtime=500ms -count=5 -benchmem
GOMAXPROCS=4 go test ./cmd/entire/cli/checkpoint -run '^TestReadTranscriptFromTreeFormats$' -bench '^BenchmarkReadTranscriptFromTree$' -benchtime=20x -count=3 -benchmem
```

## Scope

`agent.ReassembleJSONL` pre-sizing, image-asset reads, and direct legacy fallback reads remain separate follow-ups, as requested in review.

## Validation

- [x] Same-benchmark A/B for 1 MiB, 8 MiB, and 64 MiB; three runs per side.
- [x] `TestReadTranscriptFromTreeFormats` and focused redaction checks.
- [x] `mise run check`: formatting, lint (0 issues), race-enabled unit/integration suite, and deterministic Vogon/Roger-Roger canaries; exit 0 in 241.96 seconds.
- [x] `golangci-lint config verify` separately passed. Its online schema fetch was blocked inside the otherwise network-restricted full-check run; the actual lint analysis passed there.
- [x] Independent read-only review and `git diff --check`.

Vogon reports 56/56 and Roger-Roger 4/4; raw Vogon output includes four expected agent-specific skips. Reassembly and image-read follow-ups were not implemented.
