### PR TITLE
fix: point investigate/review error hints at entire agent add

### DIFF
--- a/cmd/entire/cli/investigate/cmd.go
+++ b/cmd/entire/cli/investigate/cmd.go
@@ -869,7 +869,7 @@ func verifyAgentsLaunchable(ctx context.Context, agents []string, deps Deps) err
 			return fmt.Errorf("agent %q is not launchable (spawner missing)", name)
 		}
 		if _, ok := installedSet[name]; !ok {
-			return fmt.Errorf("agent %q is not launchable (run `entire configure --agent %s` first)", name, name)
+			return fmt.Errorf("agent %q is not launchable (run `entire agent add %s` first)", name, name)
 		}
 	}
 	return nil

--- a/cmd/entire/cli/investigate/cmd_test.go
+++ b/cmd/entire/cli/investigate/cmd_test.go
@@ -451,8 +451,11 @@ func TestNewCommand_FreshRunRejectsAgentWithoutHooks(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when configured agent has no hooks")
 	}
-	if !strings.Contains(errBuf.String(), "entire configure --agent") {
-		t.Errorf("stderr should hint at `entire configure --agent`, got: %s", errBuf.String())
+	if !strings.Contains(errBuf.String(), "entire agent add") {
+		t.Errorf("stderr should hint at `entire agent add`, got: %s", errBuf.String())
+	}
+	if strings.Contains(errBuf.String(), "configure --agent") {
+		t.Errorf("stderr should NOT hint at the stale `configure --agent` flag, got: %s", errBuf.String())
 	}
 }
 

--- a/cmd/entire/cli/investigate/picker.go
+++ b/cmd/entire/cli/investigate/picker.go
@@ -141,7 +141,7 @@ func RunInvestigateConfigPicker(
 	if len(eligible) == 0 {
 		return nil, errors.New(
 			"no launchable agents with hooks installed; " +
-				"run `entire configure --agent <name>` for one of: " +
+				"run `entire agent add <name>` for one of: " +
 				"claude-code, codex, gemini-cli",
 		)
 	}

--- a/cmd/entire/cli/investigate/picker_test.go
+++ b/cmd/entire/cli/investigate/picker_test.go
@@ -29,6 +29,12 @@ func TestRunInvestigateConfigPicker_NoEligibleAgents(t *testing.T) {
 	if !strings.Contains(err.Error(), "no launchable agents") {
 		t.Errorf("error should mention launchability, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "entire agent add") {
+		t.Errorf("error should hint at `entire agent add`, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "configure --agent") {
+		t.Errorf("error should NOT hint at the stale `configure --agent` flag, got: %v", err)
+	}
 }
 
 // TestRunInvestigateConfigPicker_FiltersNonInstalled verifies that an

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -546,7 +546,7 @@ func runReviewListAgents(ctx context.Context, cmd *cobra.Command, profileOverrid
 				cfg := profile.Agents[worker]
 				status := reviewHooksInstalledStatus
 				if _, ok := installedSet[reviewAgentName(worker, cfg)]; !ok {
-					status = "hooks NOT installed; run `entire configure --agent " + reviewAgentName(worker, cfg) + "`"
+					status = "hooks NOT installed; run `entire agent add " + reviewAgentName(worker, cfg) + "`"
 				}
 				fmt.Fprintf(out, "  %s: %s\n", reviewWorkerLabel(worker, cfg), status)
 			}
@@ -560,7 +560,7 @@ func runReviewListAgents(ctx context.Context, cmd *cobra.Command, profileOverrid
 	catalog := availableReviewAgents(installed, deps.ReviewerFor)
 	fmt.Fprintln(out, "No review profile configured yet. Available review agents:")
 	for _, e := range catalog {
-		status := "not installed; run `entire configure --agent " + e.Name + "`"
+		status := "not installed; run `entire agent add " + e.Name + "`"
 		if e.Installed {
 			status = reviewHooksInstalledStatus
 		}
@@ -601,10 +601,10 @@ func availableReviewAgents(installed []types.AgentName, reviewerFor func(string)
 func printReviewConfigCatalog(out io.Writer, profileName string, catalog []reviewAgentCatalogEntry, s *settings.EntireSettings) {
 	fmt.Fprintln(out, "Available review agents:")
 	if len(catalog) == 0 {
-		fmt.Fprintln(out, "  (none; install one with `entire configure --agent claude-code`)")
+		fmt.Fprintln(out, "  (none; install one with `entire agent add claude-code`)")
 	}
 	for _, e := range catalog {
-		status := "not installed; run `entire configure --agent " + e.Name + "`"
+		status := "not installed; run `entire agent add " + e.Name + "`"
 		if e.Installed {
 			status = reviewHooksInstalledStatus
 		}
@@ -932,7 +932,7 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride, modelOver
 
 	if missing := missingInstalledProfileAgents(profile.Agents, installed); len(missing) > 0 {
 		cmd.SilenceUsage = true
-		err := fmt.Errorf("hooks are not installed for review profile %q agent(s): %s; run `entire configure --agent <name>` first, or edit the profile", profileName, strings.Join(missing, ", "))
+		err := fmt.Errorf("hooks are not installed for review profile %q agent(s): %s; run `entire agent add <name>` first, or edit the profile", profileName, strings.Join(missing, ", "))
 		fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
 		return silentErr(err)
 	}
@@ -1056,7 +1056,7 @@ func runSingleAgentPath(
 	if !found {
 		cmd.SilenceUsage = true
 		fmt.Fprintf(cmd.ErrOrStderr(),
-			"Hooks are not installed for %q. Run `entire configure --agent %s` first, "+
+			"Hooks are not installed for %q. Run `entire agent add %s` first, "+
 				"or remove %q from review settings.\n",
 			agentName, agentName, displayName)
 		return silentErr(fmt.Errorf("hooks not installed for %s", agentName))

--- a/cmd/entire/cli/review/cmd_test.go
+++ b/cmd/entire/cli/review/cmd_test.go
@@ -103,10 +103,13 @@ func TestReviewCmd_ListAgents(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"claude-code", "codex", "--agent"} {
+	for _, want := range []string{"claude-code", "codex", "--agent", "entire agent add"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("--agents output missing %q:\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "configure --agent") {
+		t.Errorf("--agents output should NOT hint at the stale `configure --agent` flag:\n%s", out)
 	}
 }
 
@@ -252,6 +255,12 @@ func TestRunReview_MissingHooksAborts(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "hooks are not installed") {
 		t.Errorf("expected 'hooks are not installed' in stderr, got: %s", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "entire agent add") {
+		t.Errorf("expected 'entire agent add' hint in stderr, got: %s", errBuf.String())
+	}
+	if strings.Contains(errBuf.String(), "configure --agent") {
+		t.Errorf("stderr should NOT hint at the stale `configure --agent` flag, got: %s", errBuf.String())
 	}
 
 	_, ok, readErr := review.ReadPendingReviewMarker(context.Background())
@@ -482,6 +491,12 @@ func TestRunReview_FlagOverrideMustBeEligibleAgent(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "Hooks are not installed") {
 		t.Errorf("stderr should mention 'Hooks are not installed', got: %s", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "entire agent add") {
+		t.Errorf("stderr should hint at `entire agent add`, got: %s", errBuf.String())
+	}
+	if strings.Contains(errBuf.String(), "configure --agent") {
+		t.Errorf("stderr should NOT hint at the stale `configure --agent` flag, got: %s", errBuf.String())
 	}
 }
 

--- a/cmd/entire/cli/review/picker.go
+++ b/cmd/entire/cli/review/picker.go
@@ -102,7 +102,7 @@ func RunReviewGuidedSetup(
 
 	launchable := launchableInstalledAgentNames(installed, reviewerFor)
 	if len(launchable) == 0 {
-		return "", settings.ReviewProfileConfig{}, errors.New("no agents with review runner adapters and hooks installed; run `entire configure --agent claude-code`, `entire configure --agent codex`, `entire configure --agent gemini`, or `entire configure --agent pi`")
+		return "", settings.ReviewProfileConfig{}, errors.New("no agents with review runner adapters and hooks installed; run `entire agent add claude-code`, `entire agent add codex`, `entire agent add gemini`, or `entire agent add pi`")
 	}
 
 	profileName = strings.TrimSpace(profileName)
@@ -759,7 +759,7 @@ func RunReviewProfileConfigPicker(ctx context.Context, out io.Writer, getInstall
 	if len(installed) == 0 {
 		return errors.New(
 			"no agents with hooks installed; " +
-				"run 'entire configure --agent <name>' to install hooks for one, " +
+				"run 'entire agent add <name>' to install hooks for one, " +
 				"or 'entire enable' to set up the repo",
 		)
 	}

--- a/cmd/entire/cli/review/picker_internal_test.go
+++ b/cmd/entire/cli/review/picker_internal_test.go
@@ -1,9 +1,14 @@
 package review
 
 import (
+	"bytes"
 	"context"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
 
 func TestSlotActionOptionsOnlyModelRemoveCancel(t *testing.T) {
@@ -62,5 +67,58 @@ func TestReviewModelSelectOptionsPreservesCurrentCustomModel(t *testing.T) {
 	}
 	if !values[reviewModelCustomSentinel] {
 		t.Fatal("custom model option missing")
+	}
+}
+
+// noReviewerFor never matches any agent to a review-runner adapter, so every
+// installed agent is filtered out of launchableInstalledAgentNames.
+func noReviewerFor(string) reviewtypes.AgentReviewer { return nil }
+
+// TestRunReviewGuidedSetup_NoLaunchableAgentsHintsAgentAdd calls the real
+// guided-setup entry point (picker.go) with no launchable agents and asserts
+// the error hints at `entire agent add`, not the stale `entire configure
+// --agent` flag (issue #2249).
+func TestRunReviewGuidedSetup_NoLaunchableAgentsHintsAgentAdd(t *testing.T) {
+	t.Parallel()
+	_, _, err := RunReviewGuidedSetup(
+		context.Background(),
+		&bytes.Buffer{},
+		[]types.AgentName{"claude-code"},
+		noReviewerFor,
+		"",
+		false, // firstRun=false: skips the interactive confirm form
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error when no agents are launchable")
+	}
+	if !strings.Contains(err.Error(), "entire agent add") {
+		t.Errorf("error should hint at `entire agent add`, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "configure --agent") {
+		t.Errorf("error should NOT hint at the stale `configure --agent` flag, got: %v", err)
+	}
+}
+
+// TestDefaultReviewProfileForInstalledAgents_NoneInstalledHintsAgentAdd calls
+// the real default-profile builder (profile.go) with no installed agents and
+// asserts the error hints at `entire agent add`, not the stale `entire
+// configure --agent` flag (issue #2249).
+func TestDefaultReviewProfileForInstalledAgents_NoneInstalledHintsAgentAdd(t *testing.T) {
+	t.Parallel()
+	_, err := defaultReviewProfileForInstalledAgents(
+		context.Background(),
+		"",
+		nil, // installed
+		noReviewerFor,
+	)
+	if err == nil {
+		t.Fatal("expected error when no agents are installed")
+	}
+	if !strings.Contains(err.Error(), "entire agent add") {
+		t.Errorf("error should hint at `entire agent add`, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "configure --agent") {
+		t.Errorf("error should NOT hint at the stale `configure --agent` flag, got: %v", err)
 	}
 }

--- a/cmd/entire/cli/review/picker_test.go
+++ b/cmd/entire/cli/review/picker_test.go
@@ -1,12 +1,14 @@
 package review_test
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/skilldiscovery"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/review"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
@@ -246,5 +248,28 @@ func TestBuildReviewPickerFields_SingleBuiltinDefaultsSelectedAndRenders(t *test
 	field.Focus()
 	if got := field.View(); !strings.Contains(got, "/review") {
 		t.Fatalf("single built-in option did not render:\n%s", got)
+	}
+}
+
+// TestRunReviewProfileConfigPicker_NoInstalledAgentsHintsAgentAdd calls the
+// real `entire review --configure` entry point (picker.go) with no agents
+// installed and asserts the error hints at `entire agent add`, not the stale
+// `entire configure --agent` flag (issue #2249).
+func TestRunReviewProfileConfigPicker_NoInstalledAgentsHintsAgentAdd(t *testing.T) {
+	t.Parallel()
+	err := review.RunReviewProfileConfigPicker(
+		context.Background(),
+		&strings.Builder{},
+		func(_ context.Context) []types.AgentName { return nil },
+		"",
+	)
+	if err == nil {
+		t.Fatal("expected error when no agents have hooks installed")
+	}
+	if !strings.Contains(err.Error(), "entire agent add") {
+		t.Errorf("error should hint at `entire agent add`, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "configure --agent") {
+		t.Errorf("error should NOT hint at the stale `configure --agent` flag, got: %v", err)
 	}
 }

--- a/cmd/entire/cli/review/profile.go
+++ b/cmd/entire/cli/review/profile.go
@@ -351,7 +351,7 @@ func defaultReviewProfileForInstalledAgents(
 		agents[name] = cfg
 	}
 	if len(agents) == 0 {
-		return settings.ReviewProfileConfig{}, errors.New("no agents with review runner adapters and hooks installed; run `entire configure --agent claude-code`, `entire configure --agent codex`, `entire configure --agent gemini`, or `entire configure --agent pi`")
+		return settings.ReviewProfileConfig{}, errors.New("no agents with review runner adapters and hooks installed; run `entire agent add claude-code`, `entire agent add codex`, `entire agent add gemini`, or `entire agent add pi`")
 	}
 	profile := settings.ReviewProfileConfig{
 		Task:   profileTask(profileName, settings.ReviewProfileConfig{}),


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1242
<!-- entire-trail-link-end -->

## Summary
- \`entire investigate\`/\`entire review\` error messages told users to run a nonexistent \`entire configure --agent <name>\` flag. Replaced all 11 instances across 5 files with the correct \`entire agent add <name>\`.

## Evidence
- Repo-wide grep before/after: 11 lines / 17 substring occurrences of \`configure --agent\` in production code → 0.
- 8 tests added/extended, each calling the real error-producing function (not a hardcoded string comparison) and asserting the message names \`entire agent add\` and never the stale flag.
- Proved the tests have teeth: reverted one line back to the stale string and reran — test fails as expected, restored and passes.

## Test plan
- \`go test -race ./cmd/entire/cli/investigate/... ./cmd/entire/cli/review/...\` — all green.
- \`mise run fmt\` clean, \`mise run lint\` — 0 issues.

Fixes #2249