### PR TITLE
fix: give each Pi subagent run a unique session identifier

### DIFF
--- a/cmd/entire/cli/agent/pi/lifecycle.go
+++ b/cmd/entire/cli/agent/pi/lifecycle.go
@@ -414,17 +414,77 @@ func captureTranscript(ctx context.Context, sessionID, piSessionFile string) str
 	return filepath.Join(worktreeRoot, paths.EntireDir, filepath.FromSlash(name))
 }
 
-// extractSessionIDFromPath extracts the UUID from a Pi session filename.
-// Pattern: <timestamp>_<uuid>.jsonl → returns <uuid>
-// Falls back to the basename without extension if the pattern doesn't match.
+// piSubagentLeafBasename is the fixed filename Pi gives every subagent
+// transcript leaf, regardless of which subagent or run produced it — see
+// extractSubagentSessionID.
+const piSubagentLeafBasename = "session"
+
+// extractSessionIDFromPath extracts a stable identifier from a Pi session
+// transcript path.
+//
+// A Pi parent transcript is a flat file named by identity:
+// <timestamp>_<uuid>.jsonl → returns <uuid>.
+//
+// A Pi subagent transcript is nested and named by role instead:
+// .../<subagentID>/run-<n>/session.jsonl. Every subagent run's basename is
+// therefore the literal string "session", so the plain-basename rule below
+// would collapse every concurrent or sequential subagent run onto the same
+// ID and the same staged transcript file (issue #1870 — a checkpoint could
+// end up storing an entirely different subagent's transcript). When the
+// basename is that literal leaf name, extractSubagentSessionID combines the
+// two directory segments above it with the parent session's own UUID into a
+// per-invocation-unique ID instead.
+//
+// Falls back to the basename without extension if neither pattern matches.
 func extractSessionIDFromPath(p string) string {
 	if p == "" {
 		return ""
 	}
 	base := filepath.Base(p)
 	base = strings.TrimSuffix(base, ".jsonl")
+	if base == piSubagentLeafBasename {
+		if id := extractSubagentSessionID(p); id != "" {
+			return id
+		}
+		// Not enough path structure to disambiguate (e.g. a bare
+		// "session.jsonl" with no parent directories) — fall through to the
+		// generic rule below, which reproduces the pre-fix behavior rather
+		// than inventing an ID from nothing.
+	}
 	if i := strings.LastIndex(base, "_"); i >= 0 {
 		return base[i+1:]
 	}
 	return base
+}
+
+// isUsableDirSegment reports whether name is a real, non-degenerate
+// directory-name component — not empty, ".", or an OS path separator, all of
+// which filepath.Base/Dir return once a path runs out of real components.
+func isUsableDirSegment(name string) bool {
+	return name != "" && name != "." && name != string(filepath.Separator)
+}
+
+// extractSubagentSessionID parses Pi's nested subagent transcript shape,
+// .../<parent-dir>/<subagentID>/run-<n>/session.jsonl, and returns a
+// per-invocation-unique identifier combining the parent session's UUID, the
+// subagent ID, and the run number: "<parentUUID>_<subagentID>_run-<n>".
+// Returns "" if p doesn't have at least that much directory structure.
+func extractSubagentSessionID(p string) string {
+	runDir := filepath.Dir(p) // .../<subagentID>/run-<n>
+	runSeg := filepath.Base(runDir)
+	subagentDir := filepath.Dir(runDir) // .../<subagentID>
+	subagentSeg := filepath.Base(subagentDir)
+	parentDir := filepath.Dir(subagentDir) // .../<timestamp>_<uuid>
+	parentSeg := filepath.Base(parentDir)
+
+	if !isUsableDirSegment(runSeg) || !isUsableDirSegment(subagentSeg) || !isUsableDirSegment(parentSeg) {
+		return ""
+	}
+
+	parentID := parentSeg
+	if i := strings.LastIndex(parentSeg, "_"); i >= 0 {
+		parentID = parentSeg[i+1:]
+	}
+
+	return parentID + "_" + subagentSeg + "_" + runSeg
 }

--- a/cmd/entire/cli/agent/pi/lifecycle_test.go
+++ b/cmd/entire/cli/agent/pi/lifecycle_test.go
@@ -194,6 +194,14 @@ func TestExtractSessionIDFromPath(t *testing.T) {
 		"abc-123.jsonl":                             "abc-123",
 		"/tmp/no-underscore-here.jsonl":             "no-underscore-here",
 		"/path/with/multiple_under_scores_id.jsonl": "id",
+		// Pi subagent shape (issue #1870): every subagent leaf is literally
+		// named session.jsonl, so identity comes from the directory segments
+		// above it, not the basename.
+		"/root/2026-07-29T00-36-01-991Z_019fab4c-c147-7b3a-8cc9-9ebd7224663b/71e7c5e8/run-0/session.jsonl": "019fab4c-c147-7b3a-8cc9-9ebd7224663b_71e7c5e8_run-0",
+		"/root/2026-07-29T00-36-01-991Z_019fab4c-c147-7b3a-8cc9-9ebd7224663b/716671d6/run-2/session.jsonl": "019fab4c-c147-7b3a-8cc9-9ebd7224663b_716671d6_run-2",
+		// Too shallow to disambiguate — falls back to the pre-fix basename
+		// behavior rather than inventing an ID from nothing.
+		"session.jsonl": "session",
 	}
 	for in, want := range cases {
 		if got := extractSessionIDFromPath(in); got != want {
@@ -450,4 +458,95 @@ func TestParseHookEvent_SessionlessPayloadIsSkipped(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPiSubagentTranscriptsDoNotCollide reproduces GitHub issue #1870: two
+// distinct Pi subagent runs under the same parent session used to both
+// resolve to the literal session ID "session" (the fixed leaf name Pi gives
+// every subagent transcript: .../<subagentID>/run-<n>/session.jsonl), so
+// their staged captures collided on one destination file and the second
+// write clobbered the first — a checkpoint could end up storing a
+// completely different subagent's transcript than the one it was supposedly
+// capturing. This drives the real production entry point
+// (PiAgent.ParseHookEvent -> extractSessionIDFromPath -> captureTranscript),
+// not a hand-mocked struct, against a realistic on-disk fixture matching the
+// tree from the issue's "Observed" section, and asserts each subagent run
+// now gets its own session ID and its own independently recoverable
+// transcript.
+func TestPiSubagentTranscriptsDoNotCollide(t *testing.T) {
+	// Cannot use t.Parallel — t.Chdir.
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Realistic Pi on-disk layout for one parent session with two live
+	// subagent runs:
+	//   .../2026-07-29T00-36-01-991Z_019fab4c-c147-7b3a-8cc9-9ebd7224663b/
+	//     71e7c5e8/run-0/session.jsonl
+	//     716671d6/run-0/session.jsonl
+	parentDir := filepath.Join(dir, "pi-sessions",
+		"2026-07-29T00-36-01-991Z_019fab4c-c147-7b3a-8cc9-9ebd7224663b")
+	pathA := filepath.Join(parentDir, "71e7c5e8", "run-0", "session.jsonl")
+	pathB := filepath.Join(parentDir, "716671d6", "run-0", "session.jsonl")
+
+	contentA := []byte(`{"type":"message","role":"assistant","content":"subagent A: reviewed auth.go"}` + "\n")
+	contentB := []byte(`{"type":"message","role":"assistant","content":"subagent B: reviewed billing.go"}` + "\n")
+
+	for path, content := range map[string][]byte{pathA: contentA, pathB: contentB} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	a := &PiAgent{}
+	ctx := context.Background()
+
+	payload := func(sessionFile string) string {
+		return `{"type":"agent_end","session_file":"` + filepath.ToSlash(sessionFile) + `"}`
+	}
+
+	evA, err := a.ParseHookEvent(ctx, HookNameAgentEnd, strings.NewReader(payload(pathA)))
+	if err != nil {
+		t.Fatalf("ParseHookEvent(A): %v", err)
+	}
+	evB, err := a.ParseHookEvent(ctx, HookNameAgentEnd, strings.NewReader(payload(pathB)))
+	if err != nil {
+		t.Fatalf("ParseHookEvent(B): %v", err)
+	}
+
+	t.Logf("subagent A -> SessionID=%q SessionRef=%q", evA.SessionID, evA.SessionRef)
+	t.Logf("subagent B -> SessionID=%q SessionRef=%q", evB.SessionID, evB.SessionRef)
+
+	if evA.SessionID == "" || evB.SessionID == "" {
+		t.Fatalf("expected non-empty session IDs, got %q and %q", evA.SessionID, evB.SessionID)
+	}
+	if evA.SessionID == evB.SessionID {
+		t.Fatalf("subagent runs collided on session ID %q (issue #1870)", evA.SessionID)
+	}
+	if evA.SessionRef == "" || evB.SessionRef == "" {
+		t.Fatalf("expected non-empty staged destinations, got %q and %q", evA.SessionRef, evB.SessionRef)
+	}
+	if evA.SessionRef == evB.SessionRef {
+		t.Fatalf("subagent runs staged to the same destination %q (issue #1870)", evA.SessionRef)
+	}
+
+	gotA, err := os.ReadFile(evA.SessionRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotA) != string(contentA) {
+		t.Fatalf("subagent A's staged file = %q, want %q", gotA, contentA)
+	}
+
+	gotB, err := os.ReadFile(evB.SessionRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotB) != string(contentB) {
+		t.Fatalf("subagent B's staged file = %q, want %q", gotB, contentB)
+	}
+
+	t.Logf("FIXED: subagent A's transcript (%s) and subagent B's transcript (%s) are both independently recoverable", evA.SessionRef, evB.SessionRef)
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1245
<!-- entire-trail-link-end -->

## Summary
- Every Pi subagent transcript file is named \`session.jsonl\` regardless of which subagent/run produced it, so the session-ID resolver collapsed every subagent invocation to the literal ID \`"session"\`. Concurrent or sequential subagent runs overwrote each other's staged/archived transcript copy, and a checkpoint could end up storing a different subagent's content than the one it was supposedly capturing.
- Fix derives a unique ID per invocation (\`<parentUUID>_<subagentID>_run-<n>\`) by walking up the real nested directory structure Pi already writes, instead of using the constant leaf filename.
- Forward-only: already-corrupted historical checkpoints aren't retroactively repairable (there's no uncontaminated copy to recover), matching the issue's own note. New captures never collide again.

## Evidence
- Real \`PiAgent.ParseHookEvent\` driven twice with realistic nested fixture paths (no mocks).
- Before: both subagent runs resolve to \`SessionID="session"\`, second overwrites the first — confirmed via real staged-file content check.
- After: distinct IDs, both subagents' transcripts independently recoverable.

## Test plan
- \`go test ./cmd/entire/cli/agent/pi/... -race\` and full \`cmd/entire/cli/...\` — all pass.
- \`mise run fmt\`/\`mise run lint\` clean.

Fixes #1870