### PR TITLE
fix: fall back to transformedContent/reasoningText when Copilot CLI content is empty

### DIFF
--- a/cmd/entire/cli/agent/copilotcli/AGENT.md
+++ b/cmd/entire/cli/agent/copilotcli/AGENT.md
@@ -129,8 +129,8 @@ Position = line count (JSONL format). Use `agent.ChunkJSONL()` / `agent.Reassemb
 The `TranscriptAnalyzer` interface is implemented for Copilot CLI, providing:
 - `GetTranscriptPosition` — counts JSONL lines (lightweight, no JSON parsing)
 - `ExtractModifiedFilesFromOffset` — collects `filePaths` from `tool.execution_complete` events after a given line offset
-- `ExtractPrompts` — collects `content` from `user.message` events
-- `ExtractSummary` — returns the `content` of the last `assistant.message` event
+- `ExtractPrompts` — collects `content` from `user.message` events, falling back to `transformedContent` (with injected `<current_datetime>`/`<reminder>` wrapper blocks stripped) when `content` is empty (some sessions emit it empty — issue #1070)
+- `ExtractSummary` — returns the `content` of the last `assistant.message` event, falling back to `reasoningText` when `content` is empty (issue #1070)
 
 ## Session State Directory
 

--- a/cmd/entire/cli/agent/copilotcli/transcript.go
+++ b/cmd/entire/cli/agent/copilotcli/transcript.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -37,12 +39,36 @@ const (
 
 // userMessageData is the data payload for user.message events.
 // IMPORTANT: The field is "content", not "message" — verified from real Copilot JSONL.
+// TransformedContent carries the same user text wrapped with Copilot's own
+// injected context (a <current_datetime> block and, in some sessions, a
+// <reminder> block). Some Copilot CLI sessions emit an empty "content" with
+// the real text only in "transformedContent" — see
+// https://github.com/entireio/cli/issues/1070.
 type userMessageData struct {
-	Content string `json:"content"`
+	Content            string `json:"content"`
+	TransformedContent string `json:"transformedContent"`
 }
 
+// assistantMessageData is the data payload for assistant.message events.
+// ReasoningText carries the model's reasoning-summary text. Some Copilot CLI
+// sessions emit an empty "content" with the real displayable text only in
+// "reasoningText" — see https://github.com/entireio/cli/issues/1070.
 type assistantMessageData struct {
-	Content string `json:"content"`
+	Content       string `json:"content"`
+	ReasoningText string `json:"reasoningText"`
+}
+
+// copilotWrapperNoiseRe matches the <current_datetime>...</current_datetime>
+// and <reminder>...</reminder> blocks Copilot CLI injects around the user's
+// literal input in transformedContent. These are Copilot-internal context,
+// never something the user typed, so they are stripped before the fallback
+// content is used as a displayable prompt.
+var copilotWrapperNoiseRe = regexp.MustCompile(`(?s)<current_datetime>.*?</current_datetime>|<reminder>.*?</reminder>`)
+
+// stripCopilotWrapperNoise removes Copilot CLI's injected wrapper blocks from
+// transformedContent and trims the whitespace left behind.
+func stripCopilotWrapperNoise(s string) string {
+	return strings.TrimSpace(copilotWrapperNoiseRe.ReplaceAllString(s, ""))
 }
 
 // modelChangeData is the data payload for session.model_change events.
@@ -148,6 +174,8 @@ func extractModifiedFilesFromEvents(events []copilotEvent) []string {
 }
 
 // extractPromptsFromEvents collects content from user.message events.
+// Falls back to transformedContent (with Copilot's injected wrapper noise
+// stripped) when content is empty — see https://github.com/entireio/cli/issues/1070.
 func extractPromptsFromEvents(events []copilotEvent) []string {
 	var prompts []string
 
@@ -161,8 +189,13 @@ func extractPromptsFromEvents(events []copilotEvent) []string {
 			continue
 		}
 
-		if data.Content != "" {
-			prompts = append(prompts, data.Content)
+		content := data.Content
+		if content == "" {
+			content = stripCopilotWrapperNoise(data.TransformedContent)
+		}
+
+		if content != "" {
+			prompts = append(prompts, content)
 		}
 	}
 
@@ -191,10 +224,16 @@ func lastEventField[T any](events []copilotEvent, eventType string, extract func
 	return ""
 }
 
-// extractSummaryFromEvents returns the content of the last assistant.message event.
+// extractSummaryFromEvents returns the content of the last assistant.message
+// event, falling back to reasoningText when content is empty — see
+// https://github.com/entireio/cli/issues/1070.
 func extractSummaryFromEvents(events []copilotEvent) string {
-	return lastEventField(events, eventTypeAssistantMsg,
-		func(d assistantMessageData) string { return d.Content })
+	return lastEventField(events, eventTypeAssistantMsg, func(d assistantMessageData) string {
+		if d.Content != "" {
+			return d.Content
+		}
+		return d.ReasoningText
+	})
 }
 
 // extractModelFromEvents returns the model from transcript events.

--- a/cmd/entire/cli/agent/copilotcli/transcript_test.go
+++ b/cmd/entire/cli/agent/copilotcli/transcript_test.go
@@ -591,6 +591,104 @@ func TestExtractModelFromTranscript_MultipleModelChanges(t *testing.T) {
 	}
 }
 
+// --- Empty-content fallback tests (issue #1070) ---
+//
+// Real Copilot CLI transcripts sometimes carry an empty primary "content"
+// field on user.message/assistant.message events, with the actual
+// displayable text only in "transformedContent"/"reasoningText". These
+// fixture lines are lifted verbatim (or minimally adapted per the bug
+// report's exact scenario) from a real captured Copilot CLI transcript at
+// cmd/entire/cli/transcript/compact/testdata/copilot_full.jsonl.
+
+// realAssistantMessageEmptyContentWithReasoningText is copied verbatim from
+// cmd/entire/cli/transcript/compact/testdata/copilot_full.jsonl line 7 — a
+// real Copilot CLI event where data.content == "" but data.reasoningText
+// carries the assistant's actual text.
+const realAssistantMessageEmptyContentWithReasoningText = `{"type":"assistant.message","data":{"messageId":"c1034751-6d32-4f2d-9e58-c45256f6ff36","content":"","toolRequests":[{"toolCallId":"tooluse_gL87PW7YXBczERPrjWHDL7","name":"report_intent","arguments":{"intent":"Creating test-copilot dir"},"type":"function"}],"interactionId":"66af33da-0016-4501-af7f-8794b02deebe","reasoningOpaque":"REDACTED","reasoningText":"Simple task - create a directory and an markdown file inside it.","outputTokens":166},"id":"114790bb-2a27-4401-8fa0-6f55dd6b00b7","timestamp":"2026-04-07T21:07:54.868Z","parentId":"79c3da58-60c4-484d-a9b3-c051ba17ff72"}`
+
+// realUserMessageEmptyContentWithTransformedContent adapts the real event at
+// copilot_full.jsonl line 5 to the exact scenario the bug report describes:
+// data.content == "" with the real text (plus Copilot's injected
+// <current_datetime>/<reminder> wrapper noise) only in
+// data.transformedContent. Schema and wrapper text are unmodified from the
+// real capture; only "content" was blanked to reproduce the reported bug.
+const realUserMessageEmptyContentWithTransformedContent = `{"type":"user.message","data":{"content":"","transformedContent":"<current_datetime>2026-04-07T21:07:50.689Z</current_datetime>\n\nCreate a dir that is called \"test-copilot\" and make an md file stating the dir is for testing copilot\n\n<reminder>\n<sql_tables>No tables currently exist. Default tables (todos, todo_deps) will be created automatically when you first use the SQL tool.</sql_tables>\n</reminder>","attachments":[],"interactionId":"66af33da-0016-4501-af7f-8794b02deebe"},"id":"a1dd969c-0848-4ab4-8580-5b9a89944113","timestamp":"2026-04-07T21:07:50.689Z","parentId":"6fa871dd-d972-4543-a7e0-edca28cf3ee0"}`
+
+func TestExtractPromptsFromEvents_FallsBackToTransformedContent(t *testing.T) {
+	t.Parallel()
+
+	content := realUserMessageEmptyContentWithTransformedContent + "\n"
+	events, err := parseEventsFromBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	prompts := extractPromptsFromEvents(events)
+	t.Logf("extractPromptsFromEvents() real output: %#v", prompts)
+
+	want := "Create a dir that is called \"test-copilot\" and make an md file stating the dir is for testing copilot"
+	if len(prompts) != 1 {
+		t.Fatalf("expected 1 recovered prompt from transformedContent fallback, got %d: %#v", len(prompts), prompts)
+	}
+	if prompts[0] != want {
+		t.Errorf("prompts[0] = %q, want %q (wrapper noise must be stripped)", prompts[0], want)
+	}
+}
+
+func TestExtractPromptsFromEvents_RegressionNormalContentUnaffected(t *testing.T) {
+	t.Parallel()
+
+	// Regression guard: a normally-populated content field must still be
+	// used as-is and must NOT be affected by the transformedContent fallback
+	// path, even when transformedContent is also present (as real Copilot
+	// CLI events always send it).
+	line := `{"type":"user.message","data":{"content":"hello","transformedContent":"<current_datetime>2026-04-07T21:07:50.689Z</current_datetime>\n\nhello","attachments":[]},"id":"1","timestamp":"2026-03-03T00:00:00Z","parentId":""}`
+	events, err := parseEventsFromBytes([]byte(line + "\n"))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	prompts := extractPromptsFromEvents(events)
+	if len(prompts) != 1 || prompts[0] != "hello" {
+		t.Fatalf("expected unchanged prompt %q, got %#v", "hello", prompts)
+	}
+}
+
+func TestExtractSummaryFromEvents_FallsBackToReasoningText(t *testing.T) {
+	t.Parallel()
+
+	content := realAssistantMessageEmptyContentWithReasoningText + "\n"
+	events, err := parseEventsFromBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	summary := extractSummaryFromEvents(events)
+	t.Logf("extractSummaryFromEvents() real output: %q", summary)
+
+	want := "Simple task - create a directory and an markdown file inside it."
+	if summary != want {
+		t.Errorf("extractSummaryFromEvents() = %q, want %q (reasoningText fallback)", summary, want)
+	}
+}
+
+func TestExtractSummaryFromEvents_RegressionContentTakesPrecedenceOverReasoningText(t *testing.T) {
+	t.Parallel()
+
+	// Regression guard: when content IS populated, it must still win over
+	// reasoningText, even if both are present.
+	line := `{"type":"assistant.message","data":{"content":"Done!","reasoningText":"internal reasoning, should not surface"},"id":"1","timestamp":"2026-03-03T00:00:00Z","parentId":""}`
+	events, err := parseEventsFromBytes([]byte(line + "\n"))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	summary := extractSummaryFromEvents(events)
+	if summary != "Done!" {
+		t.Errorf("extractSummaryFromEvents() = %q, want %q (content takes precedence)", summary, "Done!")
+	}
+}
+
 func TestExtractModelFromEvents(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1246
<!-- entire-trail-link-end -->

## Summary
- Copilot CLI sessions captured checkpoints fine, but the transcript detail view was empty/incomplete: Entire's extraction only read the primary \`content\` field of user/assistant message events, with no fallback for when Copilot CLI populates \`transformedContent\`/\`reasoningText\` instead.
- Prompts now fall back to \`transformedContent\` (stripped of Copilot's injected wrapper blocks); summaries fall back to \`reasoningText\`. Populated \`content\` still always wins.

## Evidence
- Real fixture lifted from an actual captured Copilot CLI transcript.
- Before: \`extractPromptsFromEvents\` → \`nil\`, \`extractSummaryFromEvents\` → \`""\`.
- After: real recovered prompt/summary text, verbatim.
- Regression guards confirm normal (content-populated) case is unaffected.

## Test plan
- \`go test ./cmd/entire/cli/agent/copilotcli/... -race -count=1\` — 164/164 pass.
- \`mise run fmt\`/\`mise run lint\` clean.

Note: the compacted-transcript builder (\`transcript/compact/copilot.go\`) had the same class of bug — that's fixed separately in a follow-up PR.

Fixes #1070