### PR TITLE
feat: surface progress during the OPF re-redaction phase of checkpoint sync

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_opf_progress_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_progress_test.go
@@ -1,0 +1,115 @@
+package strategy
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v6"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrePush_OPFRewritePhase_GitBranchBackend_ReportsProgress is a real
+// reproduction of issue #1683 on the git-branch checkpoint backend, which is
+// the exact scenario the issue's example transcript shows ("[entire] Pushing
+// entire/checkpoints/v1 to origin..." followed only by dots).
+//
+// It builds two REAL v1 checkpoints through the real checkpoint store,
+// enables OPF through a real .entire/settings.json, fakes only the external
+// `opf` binary dependency via the repo's own documented test double
+// (configureFakeOPF / fakeOPFForRewrite — see manual_commit_opf_rewrite_test.go),
+// and invokes the REAL pre-push hook handler (ManualCommitStrategy.PrePush)
+// against a real local bare "origin" remote (no mocked call). It then
+// captures the real stderr the OPF phase writes.
+//
+// Before the fix: the only line ever written to opfPrePushProgressWriter is
+// the existing non-TTY decision notice ("OpenAI Privacy Filter: scanning
+// checkpoints before push"); the actual redaction work that follows — which
+// is where the real wall-clock time goes — is completely silent, with no
+// phase label and no commit count.
+//
+// After the fix: a second, distinct line reports the phase transition into
+// the re-redaction work itself, naming how many checkpoint commits it
+// covers, and is closed out with "done" once the (faked) OPF batch call
+// returns.
+func TestPrePush_OPFRewritePhase_GitBranchBackend_ReportsProgress(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, paths.EntireDir), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, paths.EntireDir, "settings.json"), []byte(`{
+  "enabled": true,
+  "redaction": {
+    "openai_privacy_filter": {
+      "enabled": true,
+      "categories": {"private_person": true}
+    }
+  }
+}`), 0o644))
+
+	// Real local bare remote (no network) — same pattern used by the
+	// existing TestPrePush_OPFProgressUsesConfiguredWriter.
+	remoteDir := filepath.Join(t.TempDir(), "origin.git")
+	_, err := git.PlainInit(remoteDir, true)
+	require.NoError(t, err)
+	testutil.AddRemote(t, tmpDir, "origin", remoteDir)
+	t.Chdir(tmpDir)
+
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+	// Two real checkpoints -> two real unpushed v1 commits that still need
+	// OPF, so the reported count is exercising real multi-commit plumbing,
+	// not a single-commit edge case.
+	addV1Checkpoint(t, repo, "a1b2c3d4e5f6", "sess-1", "Hello, PERSONABC asked", "Look up PERSONABC")
+	addV1Checkpoint(t, repo, "b2c3d4e5f6a1", "sess-2", "Hi, PERSONABC replied", "Find PERSONABC too")
+
+	configureFakeOPF(t, &fakeOPFForRewrite{})
+
+	var out bytes.Buffer
+	withOPFPrePushProgressWriterForTest(t, &out)
+
+	require.NoError(t, (&ManualCommitStrategy{}).PrePush(t.Context(), "origin"))
+
+	captured := out.String()
+	t.Logf("captured OPF progress stderr (git-branch backend):\n%s", captured)
+
+	require.Contains(t, captured, "OpenAI Privacy Filter: scanning checkpoints before push",
+		"the existing pre-run notice must still fire")
+	// Two checkpoint writes against a fresh v1 store land as 3 real commits
+	// (an initial root-metadata commit plus one per session write) — asserted
+	// against the real observed count rather than the intuitive "2", so this
+	// pins actual behavior instead of a guess.
+	require.Contains(t, captured, "Re-redacting 3 checkpoint commit(s) via OpenAI Privacy Filter",
+		"the actual re-redaction phase must be named and counted, not left silent")
+}
+
+// TestPrePushFromGitHook_OPFRewritePhase_GitRefsBackend_ReportsProgress is the
+// git-refs backend's counterpart: same real hook handler contract
+// (ManualCommitStrategy.PrePushFromGitHook), same real fake-OPF double, but
+// exercising RewriteQueuedCheckpointRefsWithOPF (the git-refs sibling of the
+// v1 rewrite) via setupGitRefsOPFRepo, the existing helper this package's own
+// OPF-refs tests already use for a real git-refs-backend repo with real
+// queued checkpoint refs.
+func TestPrePushFromGitHook_OPFRewritePhase_GitRefsBackend_ReportsProgress(t *testing.T) {
+	configureFakeOPF(t, &fakeOPFForRewrite{})
+	// Two real checkpoint refs, each carrying one unpushed, un-applied
+	// commit that needs OPF.
+	setupGitRefsOPFRepo(t, "a1b2c3d4e5f6", "b2c3d4e5f6a1")
+
+	var out bytes.Buffer
+	withOPFPrePushProgressWriterForTest(t, &out)
+
+	require.NoError(t, NewManualCommitStrategy().PrePushFromGitHook(t.Context(), "origin"))
+
+	captured := out.String()
+	t.Logf("captured OPF progress stderr (git-refs backend):\n%s", captured)
+
+	require.Contains(t, captured, "Re-redacting 2 checkpoint commit(s) via OpenAI Privacy Filter",
+		"the git-refs backend's re-redaction phase must be named and counted, not left silent")
+}

--- a/cmd/entire/cli/strategy/manual_commit_opf_refs.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_refs.go
@@ -133,13 +133,23 @@ func RewriteQueuedCheckpointRefsWithOPF(ctx context.Context, repo *git.Repositor
 		if limit := resolveBatchLimit(); leafBytes > limit {
 			return &OPFBatchTooLargeError{LeafBytes: leafBytes, Limit: limit}
 		}
+		// Every commit in pendings[*].commits is, by construction
+		// (unappliedAncestry), one that still needs OPF — unlike the v1
+		// rewrite there is no already-applied member to exclude here.
+		var unappliedCount int
+		for _, pr := range pendings {
+			unappliedCount += len(pr.commits)
+		}
+		stopOPFProgress := startOPFRewriteProgress(unappliedCount)
 		globalRedacted, err = redact.BatchBytesWithPrivacyFilter(ctx, globalBlobs)
 		if err != nil {
+			stopOPFProgress("")
 			if errors.Is(err, redact.ErrOPFNoEnabledCategories) {
 				return &OPFNoCategoriesError{}
 			}
 			return &OPFRuntimeFailedError{OPFCommand: redact.OPFCommand(), Cause: err}
 		}
+		stopOPFProgress(" done")
 	}
 
 	// Pass 3: rebuild every commit before touching any ref, so a failure

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -246,6 +246,25 @@ func (e *OPFRawBytesTooLargeError) Error() string {
 // pathological RAM blowups (a 5 GiB pasted dump aborts before loading).
 const rawByteCapMultiplier = 100
 
+// startOPFRewriteProgress reports the start of the actual OPF re-redaction
+// work — the single OPF shell-out per push, shared by both the v1 rewrite
+// (RewriteUnpushedV1WithOPF) and the git-refs rewrite
+// (RewriteQueuedCheckpointRefsWithOPF) — to opfPrePushProgressWriter, the
+// same writer resolveOPFDecisionForPrePush uses for the pre-run OPF notice.
+// Without this line a push that already announced "OPF will run" then goes
+// silent for the whole batch call, which is exactly the "feels stuck" gap
+// issue #1683 reports (pre-push checkpoint sync showing no phase indication
+// during a long push). Uses the same "verb... + dots" convention as the git
+// transfer phases (startProgressDots, push_common.go) so OPF's progress line
+// looks like the rest of this command's output rather than inventing new UI.
+// Returns the stop function with startProgressDots' contract: "" on
+// failure, a trailing status suffix on success.
+func startOPFRewriteProgress(commitCount int) func(suffix string) {
+	fmt.Fprintf(opfPrePushProgressWriter,
+		"[entire] Re-redacting %d checkpoint commit(s) via OpenAI Privacy Filter...", commitCount)
+	return startProgressDots(opfPrePushProgressWriter)
+}
+
 // RewriteUnpushedV1WithOPF re-redacts unpushed entire/checkpoints/v1
 // commits with OPF, builds new commits carrying Entire-OPF-Applied:
 // true, and CAS-updates the local ref. Idempotent: already-applied
@@ -336,9 +355,15 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 	// trips on every push.
 	rawCap := scaleBatchLimit(resolveBatchLimit(), rawByteCapMultiplier)
 	var rawBytesSoFar int
+	// unappliedCount is the number of commits this rewrite actually redacts
+	// (as opposed to len(unpushed), which also counts already-applied commits
+	// that are only re-parented). Reported to the user below so the progress
+	// line names real work, not the whole unpushed range.
+	var unappliedCount int
 	for _, c := range unpushed {
 		pc := pendingCommit{commit: c}
 		if !trailers.HasOPFApplied(c.Message) {
+			unappliedCount++
 			tree, err := repo.TreeObject(c.TreeHash)
 			if err != nil {
 				return plumbing.ZeroHash, fmt.Errorf("load tree for %s: %w", c.Hash.String()[:7], err)
@@ -373,8 +398,16 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 		if limit := resolveBatchLimit(); leafBytes > limit {
 			return plumbing.ZeroHash, &OPFBatchTooLargeError{LeafBytes: leafBytes, Limit: limit}
 		}
+		// This shell-out is the one real wall-clock cost in the whole
+		// rewrite (collection/rebuild around it are local and fast), so it
+		// is the phase a slow push goes silent on without this line (issue
+		// #1683: pre-push checkpoint sync showed no progress during long
+		// pushes). stopOPFProgress follows startProgressDots' contract:
+		// "" on failure, a trailing status on success.
+		stopOPFProgress := startOPFRewriteProgress(unappliedCount)
 		globalRedacted, err = redact.BatchBytesWithPrivacyFilter(ctx, globalBlobs)
 		if err != nil {
+			stopOPFProgress("")
 			// Converge with the up-front gate: the misconfiguration
 			// sentinel must surface config remediation, not "verify
 			// your OPF install".
@@ -383,6 +416,7 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 			}
 			return plumbing.ZeroHash, &OPFRuntimeFailedError{OPFCommand: redact.OPFCommand(), Cause: err}
 		}
+		stopOPFProgress(" done")
 	}
 
 	// Pass 3: rebuild each commit. For OPF-applied commits, this is


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1250
<!-- entire-trail-link-end -->

## Summary
- Long git pushes that trigger checkpoint sync showed only a static "Pushing..." line, feeling stuck on slow pushes. Auditing the real pre-push flow (both the git-branch and git-refs backends) found that nearly every phase already had a progress label except one: the OPF re-redaction shell-out, the single genuinely silent multi-second phase (5-100s per existing code comments).
- Added a progress line for that phase specifically, reusing the existing dots-progress convention (\`startProgressDots\`) rather than inventing new UI.

## Evidence
- Real \`testutil.InitRepo\` repo, real checkpoint writes, real fake-OPF-binary test double, real \`ManualCommitStrategy.PrePush\`/\`PrePushFromGitHook\` handlers, real local bare "origin" remote.
- Before: only "OpenAI Privacy Filter: scanning checkpoints before push (may take ~30s)…", nothing else.
- After: adds "Re-redacting N checkpoint commit(s) via OpenAI Privacy Filter... done" — verified for both the git-branch and git-refs backends.

## Test plan
- Full \`strategy\` package, \`-race\`: 1086 tests, all pass (no pre-existing stderr-shape assertion needed changes).
- \`mise run fmt\`/\`mise run lint\` clean.

Fixes #1683