### PR TITLE
feat: support a generic git provider for --checkpoint-remote

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -131,6 +131,14 @@ func fetchURLAuthoritative(ctx context.Context, opts ...FetchURLOptions) (string
 		return originURL, true, nil
 	}
 
+	if isGenericRemoteConfig(config) {
+		// Generic provider (settings.CheckpointProviderGit): the checkpoint
+		// remote names an explicit git URL rather than an owner/repo pair
+		// resolved against a provider's fixed host, so there is nothing to
+		// derive from origin's protocol/host — always fetch from it verbatim.
+		return config.URL, true, nil
+	}
+
 	if withToken {
 		host, ok := providerHost(config.Provider)
 		if ok {
@@ -247,11 +255,18 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 			return "", false, fmt.Errorf("no push URL found: %w", fallbackErr)
 		}
 		logging.Warn(ctx, "checkpoint-remote: ignoring checkpoint_remote that appears to belong to another owner; pushing checkpoints to the push remote instead",
-			slog.String("checkpoint_repo", config.Repo),
+			slog.String("checkpoint_repo", config.Target()),
 			slog.String("reason", reason),
 			slog.String("hint", "if this checkpoint repo is yours, configure checkpoint_remote in .entire/settings.local.json"),
 		)
 		return fallbackURL, false, nil
+	}
+
+	if isGenericRemoteConfig(config) {
+		// Generic provider (settings.CheckpointProviderGit): push straight to
+		// the configured URL — no protocol/host derivation from the push
+		// remote applies, since the user supplied the exact destination.
+		return config.URL, true, nil
 	}
 
 	pushInfo, err := ParseURL(pushRemoteURL)
@@ -616,6 +631,16 @@ func deriveTokenOriginURL(originURL string) (string, bool) {
 		hostPort = info.HostPort()
 	}
 	return fmt.Sprintf("https://%s/%s/%s.git", hostPort, info.Owner, info.Repo), true
+}
+
+// isGenericRemoteConfig reports whether config names an explicit git remote
+// URL (settings.CheckpointProviderGit) rather than an owner/repo pair resolved
+// against a provider's fixed host. config.URL is populated only for that
+// provider — settings.GetCheckpointRemote never sets it for any other — so
+// checking it directly is equivalent to checking the provider string and
+// avoids duplicating the "git" literal here.
+func isGenericRemoteConfig(config *settings.CheckpointRemoteConfig) bool {
+	return config != nil && config.URL != ""
 }
 
 func providerHost(provider string) (string, bool) {

--- a/cmd/entire/cli/checkpoint/remote/util_test.go
+++ b/cmd/entire/cli/checkpoint/remote/util_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -653,6 +654,172 @@ func TestPushURL_EntireOriginDerivesMirrorURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGenericGitProvider_FetchAndPushURLResolveToConfiguredURL covers issue
+// #2033's core ask: a "git" provider checkpoint_remote naming an explicit
+// self-hosted-shaped URL (rather than github's owner/repo-against-a-fixed-host
+// shorthand) must resolve, via the real FetchURL/PushURL production code, to
+// exactly that URL — regardless of origin's own protocol/host, since there is
+// nothing to derive; the URL is already the destination.
+func TestGenericGitProvider_FetchAndPushURLResolveToConfiguredURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		originURL  string
+		pushRemote string
+	}{
+		{
+			name:       "https origin, generic checkpoint url unaffected",
+			originURL:  "https://github.com/acme/app.git",
+			pushRemote: "origin",
+		},
+		{
+			name:       "ssh origin, generic checkpoint url still unaffected (no protocol derivation applies)",
+			originURL:  "git@github.com:acme/app.git",
+			pushRemote: "origin",
+		},
+		{
+			name:       "no origin at all, generic checkpoint url still resolves",
+			pushRemote: "upstream",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkpointRepoDir := t.TempDir()
+			initBareRepo(t, checkpointRepoDir)
+			checkpointURL := fileURL(checkpointRepoDir)
+
+			repoDir := t.TempDir()
+			testutil.InitRepo(t, repoDir)
+			if tt.originURL != "" {
+				runGit(t, repoDir, "remote", "add", "origin", tt.originURL)
+			}
+			if tt.pushRemote != "origin" {
+				// A distinct real bare repo as the push remote, so this case
+				// also covers "no origin remote at all" realistically rather
+				// than pushing to a URL that doesn't exist.
+				pushRemoteDir := t.TempDir()
+				initBareRepo(t, pushRemoteDir)
+				runGit(t, repoDir, "remote", "add", tt.pushRemote, fileURL(pushRemoteDir))
+			}
+
+			settingsJSON := `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"git","url":"` + checkpointURL + `"}}}`
+			writeSettings(t, repoDir, settingsJSON)
+			t.Chdir(repoDir)
+
+			gotFetch, err := FetchURL(context.Background())
+			if err != nil {
+				t.Fatalf("FetchURL() error = %v", err)
+			}
+			if gotFetch != checkpointURL {
+				t.Fatalf("FetchURL() = %q, want %q", gotFetch, checkpointURL)
+			}
+
+			gotPush, enabled, err := PushURL(context.Background(), tt.pushRemote)
+			if err != nil {
+				t.Fatalf("PushURL() error = %v", err)
+			}
+			if !enabled {
+				t.Fatal("PushURL() enabled = false, want true for a configured generic checkpoint remote")
+			}
+			if gotPush != checkpointURL {
+				t.Fatalf("PushURL() = %q, want %q", gotPush, checkpointURL)
+			}
+		})
+	}
+}
+
+// TestGenericGitProvider_RealPushFetchCycle is the strong-bonus case: it
+// doesn't stop at URL derivation — it runs a REAL `git push` to the URL
+// PushURL derives for a generic "git" provider checkpoint_remote (a real
+// local bare repo, not a mock), then a REAL `git fetch` of that same ref back
+// via the URL FetchURL derives, and asserts the fetched commit is byte-for-byte
+// the one pushed. This exercises the actual production PushURL/FetchURL
+// resolution feeding real git subprocesses, end to end.
+func TestGenericGitProvider_RealPushFetchCycle(t *testing.T) {
+	checkpointRepoDir := t.TempDir()
+	initBareRepo(t, checkpointRepoDir)
+	checkpointURL := fileURL(checkpointRepoDir)
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/acme/app.git")
+
+	settingsJSON := `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"git","url":"` + checkpointURL + `"}}}`
+	writeSettings(t, repoDir, settingsJSON)
+	t.Chdir(repoDir)
+
+	// Create a real commit to push — this stands in for a condensed
+	// checkpoint commit on entire/checkpoints/v1 in production.
+	if err := os.WriteFile(filepath.Join(repoDir, "checkpoint-payload.txt"), []byte("session transcript content\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	runGit(t, repoDir, "add", "checkpoint-payload.txt")
+	runGit(t, repoDir, "commit", "-m", "checkpoint commit")
+	localSHA := strings.TrimSpace(runGitOutput(t, repoDir, "rev-parse", "HEAD"))
+
+	// Resolve the push URL through the real production code path.
+	pushURL, enabled, err := PushURL(context.Background(), "origin")
+	if err != nil {
+		t.Fatalf("PushURL() error = %v", err)
+	}
+	if !enabled {
+		t.Fatal("PushURL() enabled = false, want true")
+	}
+	if pushURL != checkpointURL {
+		t.Fatalf("PushURL() = %q, want %q", pushURL, checkpointURL)
+	}
+
+	// Real push to the real bare repo at the resolved URL.
+	runGit(t, repoDir, "push", pushURL, "HEAD:refs/heads/entire/checkpoints/v1")
+
+	// Verify directly against the bare repo (independent of this package's
+	// own fetch code) that the exact commit landed.
+	remoteSHA := strings.TrimSpace(runGitOutput(t, checkpointRepoDir, "rev-parse", "refs/heads/entire/checkpoints/v1"))
+	if remoteSHA != localSHA {
+		t.Fatalf("pushed commit = %q, want %q", remoteSHA, localSHA)
+	}
+
+	// Now resolve the fetch URL through the real production code path (a
+	// fresh clone, simulating a machine that has never seen this checkpoint
+	// history) and fetch it back.
+	cloneDir := t.TempDir()
+	testutil.InitRepo(t, cloneDir)
+	runGit(t, cloneDir, "remote", "add", "origin", "https://github.com/acme/app.git")
+	writeSettings(t, cloneDir, settingsJSON)
+	t.Chdir(cloneDir)
+
+	fetchURL, err := FetchURL(context.Background())
+	if err != nil {
+		t.Fatalf("FetchURL() error = %v", err)
+	}
+	if fetchURL != checkpointURL {
+		t.Fatalf("FetchURL() = %q, want %q", fetchURL, checkpointURL)
+	}
+
+	runGit(t, cloneDir, "fetch", fetchURL, "refs/heads/entire/checkpoints/v1:refs/remotes/checkpoint/v1")
+	fetchedSHA := strings.TrimSpace(runGitOutput(t, cloneDir, "rev-parse", "refs/remotes/checkpoint/v1"))
+	if fetchedSHA != localSHA {
+		t.Fatalf("fetched commit = %q, want %q", fetchedSHA, localSHA)
+	}
+
+	// And the fetched blob content really is the pushed transcript payload.
+	out := runGitOutput(t, cloneDir, "show", "refs/remotes/checkpoint/v1:checkpoint-payload.txt")
+	if out != "session transcript content\n" {
+		t.Fatalf("fetched file content = %q, want %q", out, "session transcript content\n")
+	}
+}
+
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\nOutput: %s", args, err, out)
+	}
+	return string(out)
 }
 
 func TestPushURL_ErrorsWhenNoCheckpointRemoteAndOriginMissing(t *testing.T) {

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/entiredir"
 	"github.com/entireio/cli/cmd/entire/cli/gitdir"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -1822,21 +1823,55 @@ func (s *EntireSettings) IsSummarizeEnabled() bool {
 	return enabled
 }
 
+// CheckpointProviderGit is the generic checkpoint_remote provider: instead of
+// an owner/repo pair resolved against a provider's hardcoded host (github,
+// gitlab), it carries an explicit git remote URL, so checkpoint storage can
+// target a self-hosted server (Gitea, GitLab CE/EE, a bare git repo over
+// SSH/HTTPS) rather than only github.com/gitlab.com. See setup.go's
+// checkpointProviderGit (the same string, kept as an independent constant
+// there per this repo's convention for provider identifiers, e.g.
+// resolveref.go's providerGitHub next to setup.go's checkpointProviderGitHub).
+const CheckpointProviderGit = "git"
+
 // CheckpointRemoteConfig holds the structured checkpoint remote configuration.
-// Stored in strategy_options.checkpoint_remote as {"provider": "github", "repo": "org/repo"}.
+// Stored in strategy_options.checkpoint_remote as either
+// {"provider": "github", "repo": "org/repo"} (owner/repo shorthand, resolved
+// against the provider's fixed host) or, for the generic CheckpointProviderGit
+// provider, {"provider": "git", "url": "https://git.example.com/org/repo.git"}
+// (an explicit remote URL, for self-hosted git servers).
 type CheckpointRemoteConfig struct {
-	Provider string // e.g., "github"
-	Repo     string // e.g., "org/checkpoints-repo"
+	Provider string // e.g., "github", "git"
+	Repo     string // e.g., "org/checkpoints-repo" (owner/repo-shorthand providers only)
+	URL      string // e.g., "https://git.example.com/org/checkpoints-repo.git" (CheckpointProviderGit only)
 }
 
 // Owner returns the owner portion of the repo field (before the slash).
-// Returns empty string if the repo field doesn't contain a slash.
+// Returns empty string if the repo field doesn't contain a slash — which is
+// always true for the generic CheckpointProviderGit provider, since it has no
+// Repo field at all (only URL). That deliberately matches how a malformed
+// owner/repo field is already handled: checkpointRemoteIsInherited treats an
+// undeterminable owner as "skip the ownership check" rather than blocking on
+// it, because comparing an owner across two potentially unrelated hosts (the
+// origin's forge vs. an arbitrary self-hosted checkpoint server) is not a
+// meaningful signal the way it is when both live on the same forge.
 func (c *CheckpointRemoteConfig) Owner() string {
 	parts := strings.SplitN(c.Repo, "/", 2)
 	if len(parts) < 2 {
 		return ""
 	}
 	return parts[0]
+}
+
+// Target returns the display-friendly checkpoint destination: Repo for
+// owner/repo-shorthand providers, or URL for the generic CheckpointProviderGit
+// provider's explicit remote URL. Used wherever the configured checkpoint
+// remote is shown to the user or logged, so a generic config never renders
+// as an empty string.
+func (c *CheckpointRemoteConfig) Target() string {
+	if c.Repo != "" {
+		return c.Repo
+	}
+	return c.URL
 }
 
 // HasCheckpointRemoteKey reports whether a checkpoint_remote entry exists in
@@ -1881,7 +1916,11 @@ func CheckpointRemoteIsLocalOnly(ctx context.Context) bool {
 }
 
 // GetCheckpointRemote returns the configured checkpoint remote.
-// Expects a structured object: {"provider": "github", "repo": "org/repo"}.
+// Expects a structured object: either {"provider": "github", "repo": "org/repo"}
+// (owner/repo shorthand), or, for CheckpointProviderGit, {"provider": "git",
+// "url": "https://git.example.com/org/repo.git"} (explicit remote URL,
+// validated the same way any other explicit git remote URL in this codebase
+// is: gitremote.ParseURL, the shared SSH/HTTPS remote-URL parser).
 // Returns nil if not configured, wrong type, or missing required fields.
 func (s *EntireSettings) GetCheckpointRemote() *CheckpointRemoteConfig {
 	if s.StrategyOptions == nil {
@@ -1896,8 +1935,21 @@ func (s *EntireSettings) GetCheckpointRemote() *CheckpointRemoteConfig {
 		return nil
 	}
 	provider, providerOK := m["provider"].(string)
+	if !providerOK || provider == "" {
+		return nil
+	}
+	if provider == CheckpointProviderGit {
+		rawURL, urlOK := m["url"].(string)
+		if !urlOK || rawURL == "" {
+			return nil
+		}
+		if _, err := gitremote.ParseURL(rawURL); err != nil {
+			return nil
+		}
+		return &CheckpointRemoteConfig{Provider: provider, URL: rawURL}
+	}
 	repo, repoOK := m["repo"].(string)
-	if !providerOK || !repoOK || provider == "" || repo == "" {
+	if !repoOK || repo == "" {
 		return nil
 	}
 	if !strings.Contains(repo, "/") {

--- a/cmd/entire/cli/settings/settings_checkpoint_remote_test.go
+++ b/cmd/entire/cli/settings/settings_checkpoint_remote_test.go
@@ -84,6 +84,112 @@ func TestGetCheckpointRemote_RepoWithoutSlash(t *testing.T) {
 	assert.Nil(t, s.GetCheckpointRemote())
 }
 
+func TestGetCheckpointRemote_StructuredGenericGit(t *testing.T) {
+	t.Parallel()
+
+	s := &EntireSettings{
+		StrategyOptions: map[string]any{
+			"checkpoint_remote": map[string]any{
+				"provider": "git",
+				"url":      "https://vc.hub.msg.team/org/checkpoints-repo.git",
+			},
+		},
+	}
+	config := s.GetCheckpointRemote()
+	require.NotNil(t, config)
+	assert.Equal(t, "git", config.Provider)
+	assert.Equal(t, "https://vc.hub.msg.team/org/checkpoints-repo.git", config.URL)
+	assert.Empty(t, config.Repo)
+}
+
+func TestGetCheckpointRemote_GenericGitSSHURL(t *testing.T) {
+	t.Parallel()
+
+	s := &EntireSettings{
+		StrategyOptions: map[string]any{
+			"checkpoint_remote": map[string]any{
+				"provider": "git",
+				"url":      "git@git.example.com:org/checkpoints-repo.git",
+			},
+		},
+	}
+	config := s.GetCheckpointRemote()
+	require.NotNil(t, config)
+	assert.Equal(t, "git@git.example.com:org/checkpoints-repo.git", config.URL)
+}
+
+func TestGetCheckpointRemote_GenericGitMissingURL(t *testing.T) {
+	t.Parallel()
+
+	s := &EntireSettings{
+		StrategyOptions: map[string]any{
+			"checkpoint_remote": map[string]any{
+				"provider": "git",
+			},
+		},
+	}
+	assert.Nil(t, s.GetCheckpointRemote())
+}
+
+func TestGetCheckpointRemote_GenericGitInvalidURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"",
+		"not a url",
+		"justahost", // no scheme, no owner/repo path
+		"https://",  // no host, no path
+	}
+	for _, rawURL := range tests {
+		t.Run(rawURL, func(t *testing.T) {
+			t.Parallel()
+			s := &EntireSettings{
+				StrategyOptions: map[string]any{
+					"checkpoint_remote": map[string]any{
+						"provider": "git",
+						"url":      rawURL,
+					},
+				},
+			}
+			assert.Nil(t, s.GetCheckpointRemote(), "url %q should be rejected", rawURL)
+		})
+	}
+}
+
+func TestGetCheckpointRemote_JSONRoundTrip_GenericGit(t *testing.T) {
+	tmpDir := t.TempDir()
+	entireDir := filepath.Join(tmpDir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	testutil.InitRepo(t, tmpDir)
+
+	settingsJSON := `{
+		"enabled": true,
+		"strategy_options": {
+			"checkpoint_remote": {
+				"provider": "git",
+				"url": "https://vc.hub.msg.team/org/checkpoints-repo.git"
+			}
+		}
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644))
+
+	t.Chdir(tmpDir)
+
+	s, err := Load(context.Background())
+	require.NoError(t, err)
+	config := s.GetCheckpointRemote()
+	require.NotNil(t, config)
+	assert.Equal(t, "git", config.Provider)
+	assert.Equal(t, "https://vc.hub.msg.team/org/checkpoints-repo.git", config.URL)
+}
+
+func TestCheckpointRemoteConfig_Target(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "org/checkpoints", (&CheckpointRemoteConfig{Provider: "github", Repo: "org/checkpoints"}).Target())
+	assert.Equal(t, "https://git.example.com/org/checkpoints.git", (&CheckpointRemoteConfig{Provider: "git", URL: "https://git.example.com/org/checkpoints.git"}).Target())
+}
+
 func TestGetCheckpointRemote_LegacyStringIgnored(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -58,6 +58,16 @@ const (
 	flagAgentHelpSkill       = "agent-help-skill"
 	flagImportHistory        = "import-history"
 	checkpointProviderGitHub = "github"
+	// checkpointProviderGit is the generic --checkpoint-remote provider: the
+	// value after the colon is a full git remote URL (e.g.
+	// git:https://git.example.com/org/checkpoints-repo.git) rather than an
+	// owner/repo pair resolved against a hardcoded host, so checkpoint storage
+	// can target a self-hosted git server (Gitea, GitLab CE/EE, a plain bare
+	// repo over SSH/HTTPS). Kept as its own constant, matching this repo's
+	// convention of one provider-identifier constant per file/concern rather
+	// than a shared enum (see settings.CheckpointProviderGit, the same string
+	// used by settings.GetCheckpointRemote).
+	checkpointProviderGit = "git"
 )
 
 // externalAgentsAutoEnabledNotice is printed when picking an external summary
@@ -103,17 +113,23 @@ func (opts *EnableOptions) applyStrategyOptions(settings *EntireSettings) {
 		settings.StrategyOptions["push_sessions"] = false
 	}
 	if opts.CheckpointRemote != "" {
-		provider, repo, err := parseCheckpointRemoteFlag(opts.CheckpointRemote)
+		provider, target, err := parseCheckpointRemoteFlag(opts.CheckpointRemote)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: invalid --checkpoint-remote format: %v\n", err)
 		} else {
 			if settings.StrategyOptions == nil {
 				settings.StrategyOptions = make(map[string]interface{})
 			}
-			settings.StrategyOptions["checkpoint_remote"] = map[string]any{
-				"provider": provider,
-				"repo":     repo,
+			checkpointRemote := map[string]any{"provider": provider}
+			if provider == checkpointProviderGit {
+				// Generic provider: target is a full remote URL, stored under
+				// its own key so it's never mistaken for the owner/repo
+				// shorthand the other providers use.
+				checkpointRemote["url"] = target
+			} else {
+				checkpointRemote["repo"] = target
 			}
+			settings.StrategyOptions["checkpoint_remote"] = checkpointRemote
 		}
 	}
 }
@@ -388,30 +404,46 @@ func saveSettingsToTarget(ctx context.Context, s *EntireSettings, targetFile str
 	}
 }
 
-// parseCheckpointRemoteFlag parses a "provider:owner/repo" string into its components.
-// Supported providers: "github".
-func parseCheckpointRemoteFlag(value string) (provider, repo string, err error) {
+// parseCheckpointRemoteFlag parses a "provider:target" string into its
+// components. For checkpointProviderGitHub, target must be "owner/repo"
+// (e.g. github:org/checkpoints-repo). For checkpointProviderGit, target is an
+// explicit git remote URL (e.g. git:https://git.example.com/org/checkpoints-repo.git
+// or git:git@git.example.com:org/checkpoints-repo.git) — the shorthand for a
+// self-hosted git server (Gitea, GitLab CE/EE, a bare git repo over SSH/HTTPS)
+// that doesn't live on a provider with a hardcoded host.
+//
+// Splitting on the first colon only (strings.SplitN(value, ":", 2)) is what
+// makes this safe for a URL target: a git:// or https:// scheme separator, or
+// an SSH host:path separator, never gets mistaken for the provider delimiter.
+//
+// Supported providers: "github", "git".
+func parseCheckpointRemoteFlag(value string) (provider, target string, err error) {
 	parts := strings.SplitN(value, ":", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("expected format provider:owner/repo (e.g., github:org/checkpoints-repo), got %q", value)
+		return "", "", fmt.Errorf("expected format provider:owner/repo (e.g., github:org/checkpoints-repo) or %s:<url> (e.g., %s:https://git.example.com/org/checkpoints-repo.git), got %q", checkpointProviderGit, checkpointProviderGit, value)
 	}
 
 	provider = parts[0]
-	repo = parts[1]
+	target = parts[1]
 
 	switch provider {
 	case checkpointProviderGitHub:
-		// valid
+		repoParts := strings.SplitN(target, "/", 2)
+		if len(repoParts) != 2 || repoParts[0] == "" || repoParts[1] == "" {
+			return "", "", fmt.Errorf("repo must be in owner/name format, got %q", target)
+		}
+		return provider, target, nil
+	case checkpointProviderGit:
+		// Validated the same way any other explicit git remote URL in this
+		// codebase is validated (gitremote.ParseURL, the shared SSH/HTTPS
+		// remote-URL parser) rather than a bespoke check.
+		if _, parseErr := gitremote.ParseURL(target); parseErr != nil {
+			return "", "", fmt.Errorf("invalid %s remote URL %q: %w", checkpointProviderGit, target, parseErr)
+		}
+		return provider, target, nil
 	default:
-		return "", "", fmt.Errorf("unsupported provider %q (supported: %s)", provider, checkpointProviderGitHub)
+		return "", "", fmt.Errorf("unsupported provider %q (supported: %s, %s)", provider, checkpointProviderGitHub, checkpointProviderGit)
 	}
-
-	repoParts := strings.SplitN(repo, "/", 2)
-	if len(repoParts) != 2 || repoParts[0] == "" || repoParts[1] == "" {
-		return "", "", fmt.Errorf("repo must be in owner/name format, got %q", repo)
-	}
-
-	return provider, repo, nil
 }
 
 // runSetupFlow runs the first-time setup flow (agent selection + hooks + settings).
@@ -792,7 +824,7 @@ Examples:
 	cmd.Flags().BoolVar(&opts.UseProjectSettings, "project", false, "Write settings to .entire/settings.json even if it already exists")
 	cmd.Flags().BoolVarP(&opts.ForceHooks, flagForce, "f", false, "Reinstall the Entire git hook")
 	cmd.Flags().BoolVar(&opts.SkipPushSessions, flagSkipPushSessions, false, "Disable automatic pushing of session logs on git push")
-	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
+	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo), or git:<url> for a self-hosted git server (e.g., git:https://git.example.com/org/checkpoints-repo.git)")
 	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", checkpointBackendFlagUsage)
 	cmd.Flags().StringVar(&summarizeProvider, flagSummarizeAgent, "", "Set the provider used by explain --generate (e.g., claude-code, codex, gemini, pi, cursor, copilot-cli)")
 	cmd.Flags().StringVar(&summarizeModel, flagSummarizeModel, "", "Set the model hint used by explain --generate")
@@ -957,7 +989,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	cmd.Flags().StringVar(&agentName, agentFlagName, "", "Agent to set up hooks for (e.g., "+strings.Join(agent.StringList(), ", ")+"; external agents on $PATH are also available). Enables non-interactive mode.")
 	cmd.Flags().BoolVarP(&opts.ForceHooks, flagForce, "f", false, "Force reinstall hooks (removes existing Entire hooks first)")
 	cmd.Flags().BoolVar(&opts.SkipPushSessions, flagSkipPushSessions, false, "Disable automatic pushing of session logs on git push")
-	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
+	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo), or git:<url> for a self-hosted git server (e.g., git:https://git.example.com/org/checkpoints-repo.git)")
 	cmd.Flags().StringVar(&opts.CheckpointBackend, flagCheckpointBackend, "", checkpointBackendFlagUsage)
 	cmd.Flags().BoolVar(&opts.Telemetry, flagTelemetry, true, "Enable anonymous usage analytics")
 	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/agent/vogon"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	checkpointremote "github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -4023,6 +4024,178 @@ func TestDetectOrSelectAgent_ReRun_EmptySelection_ReturnsError(t *testing.T) {
 }
 
 // Tests for configure --checkpoint-remote
+
+// TestParseCheckpointRemoteFlag exercises the real parser directly (issue
+// #2033): the github:owner/repo shorthand must keep working unchanged, and
+// the new git:<url> generic-provider form must validate the URL the same way
+// any other explicit git remote URL in this codebase is validated
+// (gitremote.ParseURL).
+func TestParseCheckpointRemoteFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		value        string
+		wantProvider string
+		wantTarget   string
+		wantErr      string // substring expected in the error, "" means no error
+	}{
+		{
+			name:         "github shorthand unchanged",
+			value:        "github:org/checkpoints-repo",
+			wantProvider: "github",
+			wantTarget:   "org/checkpoints-repo",
+		},
+		{
+			name:    "github shorthand still rejects a bare name without owner",
+			value:   "github:just-a-name",
+			wantErr: "owner/name format",
+		},
+		{
+			name:         "generic git provider with https url",
+			value:        "git:https://vc.hub.msg.team/org/checkpoints-repo.git",
+			wantProvider: "git",
+			wantTarget:   "https://vc.hub.msg.team/org/checkpoints-repo.git",
+		},
+		{
+			name:         "generic git provider with scp-style ssh url (colon inside target)",
+			value:        "git:git@vc.hub.msg.team:org/checkpoints-repo.git",
+			wantProvider: "git",
+			wantTarget:   "git@vc.hub.msg.team:org/checkpoints-repo.git",
+		},
+		{
+			name:    "generic git provider rejects an unparseable url",
+			value:   "git:not-a-url",
+			wantErr: "invalid git remote URL",
+		},
+		{
+			name:    "the issue's literal repro: a bare url with no provider prefix is still rejected",
+			value:   "https://vc.hub.msg.team/org/checkpoints-repo.git",
+			wantErr: `unsupported provider "https"`,
+		},
+		{
+			name:    "unsupported provider names both supported providers",
+			value:   "bitbucket:org/repo",
+			wantErr: "supported: github, git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			provider, target, err := parseCheckpointRemoteFlag(tt.value)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parseCheckpointRemoteFlag(%q) error = nil, want error containing %q", tt.value, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("parseCheckpointRemoteFlag(%q) error = %q, want it to contain %q", tt.value, err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCheckpointRemoteFlag(%q) unexpected error = %v", tt.value, err)
+			}
+			if provider != tt.wantProvider || target != tt.wantTarget {
+				t.Fatalf("parseCheckpointRemoteFlag(%q) = (%q, %q), want (%q, %q)", tt.value, provider, target, tt.wantProvider, tt.wantTarget)
+			}
+		})
+	}
+}
+
+// initBareRepoForTest creates a real local bare git repository via the real
+// `git init --bare` binary (not a mock) and returns its file:// URL, suitable
+// as a --checkpoint-remote git:<url> target.
+func initBareRepoForTest(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", "init", "--bare", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare %s failed: %v\n%s", dir, err, out)
+	}
+	return "file://" + filepath.ToSlash(dir)
+}
+
+func TestConfigureCmd_CheckpointRemote_GenericGitProvider_UpdatesProjectSettings(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+
+	bareRepoDir := filepath.Join(t.TempDir(), "checkpoints-repo.git")
+	remoteURL := initBareRepoForTest(t, bareRepoDir)
+
+	cmd := newSetupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--checkpoint-remote", "git:" + remoteURL})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("configure --checkpoint-remote git:<url> failed: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Settings updated") {
+		t.Errorf("expected 'Settings updated' output, got: %s", stdout.String())
+	}
+
+	s, err := settings.LoadFromFile(EntireSettingsFile)
+	if err != nil {
+		t.Fatalf("failed to load settings: %v", err)
+	}
+	remote := s.GetCheckpointRemote()
+	if remote == nil {
+		t.Fatal("expected checkpoint_remote to be set")
+	}
+	if remote.Provider != "git" {
+		t.Errorf("Provider = %q, want %q", remote.Provider, "git")
+	}
+	if remote.URL != remoteURL {
+		t.Errorf("URL = %q, want %q", remote.URL, remoteURL)
+	}
+	if remote.Repo != "" {
+		t.Errorf("Repo = %q, want empty for the generic provider", remote.Repo)
+	}
+
+	// Real end-to-end sanity check: with an origin remote present (as any
+	// real repo would have), the stored config resolves via remote.PushURL —
+	// the real production code path, not a mock — to exactly the real bare
+	// repo's URL. See util_test.go in checkpoint/remote for a full real
+	// push/fetch cycle against this same kind of URL.
+	runGit(t, ".", "remote", "add", "origin", "https://github.com/acme/app.git")
+	got, enabled, err := checkpointremote.PushURL(context.Background(), "origin")
+	if err != nil {
+		t.Fatalf("PushURL() error = %v", err)
+	}
+	if !enabled {
+		t.Fatal("PushURL() enabled = false, want true for a configured generic checkpoint remote")
+	}
+	if got != remoteURL {
+		t.Fatalf("PushURL() = %q, want %q", got, remoteURL)
+	}
+}
+
+func TestConfigureCmd_CheckpointRemote_GenericGitProvider_InvalidURLRejected(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+
+	cmd := newSetupCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--checkpoint-remote", "git:not-a-url"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid git:<url> --checkpoint-remote")
+	}
+	if !strings.Contains(err.Error(), "invalid git remote URL") {
+		t.Errorf("expected 'invalid git remote URL' in error, got: %v", err)
+	}
+
+	// Nothing should have been written since validation happens before I/O.
+	if s, err := settings.LoadFromFile(EntireSettingsFile); err == nil {
+		if s.GetCheckpointRemote() != nil {
+			t.Error("checkpoint_remote should not be set after a rejected --checkpoint-remote")
+		}
+	}
+}
 
 func TestConfigureCmd_CheckpointRemote_UpdatesProjectSettings(t *testing.T) {
 	setupTestRepo(t)

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -352,7 +352,7 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 	// PushURL differently than this elected-remote probe does.
 	if cr := s.GetCheckpointRemote(); cr != nil {
 		if _, enabled, purlErr := checkpointremote.PushURL(ctx, elected.Name); purlErr == nil && enabled {
-			info := checkpointSyncInfo{Remote: cr.Repo, Source: checkpointSyncSourceDedicated}
+			info := checkpointSyncInfo{Remote: cr.Target(), Source: checkpointSyncSourceDedicated}
 			// The unpushed counter is meaningful here only on the git-refs
 			// backend (push-queue length is local and accurate). The
 			// git-branch comparison is omitted: pushes to a raw URL update

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -94,7 +94,7 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 	if err != nil {
 		logging.Warn(ctx, "checkpoint-remote: could not derive URL from push remote",
 			slog.String("remote", pushRemoteName),
-			slog.String("repo", config.Repo),
+			slog.String("repo", config.Target()),
 			slog.String("error", err.Error()),
 		)
 		return ps
@@ -296,19 +296,27 @@ func resolveCheckpointFetchURL(ctx context.Context, worktreeRoot string) (string
 	}
 	if !urlTargetsCheckpointRepo(url, config) {
 		logging.Debug(ctx, "checkpoint-remote: fetch URL did not resolve to the configured checkpoint repo; not adopting from origin",
-			slog.String("repo", config.Repo))
+			slog.String("repo", config.Target()))
 		return "", false
 	}
 	return url, true
 }
 
 // urlTargetsCheckpointRepo reports whether url points at the configured checkpoint
-// repository (host-agnostic, case-insensitive owner/repo match). It distinguishes a
-// derived checkpoint URL from remote.FetchURL's origin fallback, which targets the
-// origin repository instead. A same-repo checkpoint_remote (origin == checkpoint
-// repo) still matches, which is correct: adopting from that URL is adopting the
-// checkpoint repo.
+// repository. For the generic settings.CheckpointProviderGit provider, config has
+// no owner/repo to compare — remote.FetchURL/PushURL return config.URL verbatim
+// for that provider (see remote.isGenericRemoteConfig), so an exact URL match
+// (modulo a trailing ".git") is the correct — and only possible — comparison.
+// For owner/repo-shorthand providers this is a host-agnostic, case-insensitive
+// owner/repo match, distinguishing a derived checkpoint URL from
+// remote.FetchURL's origin fallback, which targets the origin repository
+// instead. A same-repo checkpoint_remote (origin == checkpoint repo) still
+// matches, which is correct: adopting from that URL is adopting the checkpoint
+// repo.
 func urlTargetsCheckpointRepo(url string, config *settings.CheckpointRemoteConfig) bool {
+	if config.URL != "" {
+		return strings.EqualFold(strings.TrimSuffix(url, ".git"), strings.TrimSuffix(config.URL, ".git"))
+	}
 	info, err := remote.ParseURL(url)
 	if err != nil || info.Owner == "" || info.Repo == "" {
 		return false

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -1088,6 +1088,38 @@ func TestURLTargetsCheckpointRepo(t *testing.T) {
 	}
 }
 
+// TestURLTargetsCheckpointRepo_GenericGitProvider covers the generic
+// settings.CheckpointProviderGit provider (issue #2033): config carries an
+// explicit URL rather than an owner/repo pair, so the comparison must be an
+// exact URL match (modulo a trailing ".git") rather than an owner/repo one —
+// there is no owner/repo to compare, and remote.FetchURL/PushURL return the
+// configured URL verbatim for this provider (see remote.isGenericRemoteConfig).
+func TestURLTargetsCheckpointRepo_GenericGitProvider(t *testing.T) {
+	t.Parallel()
+
+	config := &settings.CheckpointRemoteConfig{Provider: "git", URL: "https://git.example.com/org/checkpoints-repo.git"}
+
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"exact match", "https://git.example.com/org/checkpoints-repo.git", true},
+		{"case-insensitive match", "HTTPS://GIT.EXAMPLE.COM/org/checkpoints-repo.git", true},
+		{"trailing .git normalized on both sides", "https://git.example.com/org/checkpoints-repo", true},
+		{"different host", "https://github.com/org/checkpoints-repo.git", false},
+		{"different path", "https://git.example.com/other/checkpoints-repo.git", false},
+		{"origin fallback (a completely different URL)", "https://github.com/acme/app.git", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, urlTargetsCheckpointRepo(tt.url, config))
+		})
+	}
+}
+
 // TestEnsurePrimaryRef_CheckpointRemoteTakesPrecedenceOverOrigin verifies issue
 // #1374: when a checkpoint_remote is configured, EnsurePrimaryRef adopts its branch
 // even when a stale origin/entire/checkpoints/v1 tracking ref is present. Origin is


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1251
<!-- entire-trail-link-end -->

## Summary
- \`--checkpoint-remote\` (and the \`.entire/settings.json\` \`checkpoint_remote\` config) only accepted \`{"provider":"github","repo":"owner/repo"}\` — no way to point checkpoint storage at a self-hosted git server (Gitea, GitLab CE, a bare git server).
- Adds an additive \`"provider":"git"\` option that accepts an explicit remote URL (\`--checkpoint-remote git:<url>\`) instead of an owner/repo pair resolved against a hardcoded \`github.com\` template. The existing \`github:owner/repo\` shorthand is completely unchanged.

## Evidence
- Real validation/URL-construction functions, not hand-mocked.
- Before: \`parseCheckpointRemoteFlag("git:https://vc.example/org/repo.git")\` → \`unsupported provider "git"\`.
- After: accepted, resolves to the exact URL. \`entire configure --checkpoint-remote git:<url>\` against a real local bare repo verified end-to-end.
- **Full real push/fetch cycle exercised** against a real bare git repo with the new provider (not just validation) — real commit pushed via \`PushURL()\`, verified on the bare repo directly, then fetched back into a fresh clone via \`FetchURL()\`, SHA and blob content verified to match.
- Existing github-shorthand path verified unchanged (regression test).

## Test plan
- \`go test -race\` across \`cmd/entire/cli/...\` (69 packages incl. settings, checkpoint/remote, strategy) — all pass.
- \`mise run fmt\`/\`mise run lint\` clean.

## Known limitation
\`Owner()\` returns \`""\` for the generic provider (no \`Repo\` field), so the fork-ownership guard is a no-op there — same as today's malformed-repo case, and cross-host owner comparison is meaningless anyway since the checkpoint host differs from the origin host by design. Flagged, not fixed, as out of scope for this PR.

Fixes #2033