### PR TITLE
feat: differentiated per-hook timeouts, replacing the flat 30s cap

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -434,6 +434,34 @@ type SessionEndBudgeter interface {
 	SessionEndBudget() time.Duration
 }
 
+// HookTimeoutProvider is implemented by agents that need a hook event's
+// timeout to differ from the flat default DispatchLifecycleEvent otherwise
+// applies to every event (see HookTimeoutFor). SessionEndBudgeter above is
+// the existing precedent for this exact shape — a per-event override,
+// because only that one event's host enforces a hard budget of its own; this
+// generalizes the same idea from "one hard-coded event" to any event an
+// agent has real evidence for, instead of leaving every hook at one flat
+// number regardless of what it actually does (GitHub issue #2115).
+//
+// Codex is the motivating implementation: it already writes a different
+// declared timeout into .codex/hooks.json for its SessionEnd hook
+// (SessionEndTimeoutSec) than for every other event (defaultHookTimeoutSec).
+// HookTimeout exposes that same distinction through one generic interface so
+// it is resolved the same way (HookTimeoutFor) wherever a timeout decision is
+// made, rather than each agent package inventing its own lookup.
+type HookTimeoutProvider interface {
+	Agent
+
+	// HookTimeout returns the declared timeout for the named hook event, in
+	// the agent's own hook-verb spelling (e.g. Codex's HookNameSessionEnd,
+	// "session-end" — the same string ParseHookEvent and the `entire hooks
+	// <agent> <verb>` subcommand use, not a display name). A non-positive
+	// return means "no override for this event — use DefaultHookTimeout()."
+	// Implement an override only for events backed by real evidence; do not
+	// special-case every event just because the interface exists.
+	HookTimeout(hookName string) time.Duration
+}
+
 // RestoredSessionPathResolver is implemented by agents that need a
 // transcript-specific path when Entire reconstructs a session from checkpoint
 // metadata. This is used for restored sessions only; live sessions still use

--- a/cmd/entire/cli/agent/capabilities.go
+++ b/cmd/entire/cli/agent/capabilities.go
@@ -1,5 +1,7 @@
 package agent
 
+import "time"
+
 // CapabilityDeclarer is implemented by agents that declare their capabilities
 // at registration time (e.g., external plugin agents). The As* helper functions
 // below use this interface to gate capability access: an agent must both implement
@@ -244,4 +246,48 @@ func AsToolInvocationScanner(ag Agent) (ToolInvocationScanner, bool) {
 // field when an external agent has a host that clamps its session-end hook.
 func AsSessionEndBudgeter(ag Agent) (SessionEndBudgeter, bool) {
 	return builtinCapability[SessionEndBudgeter](ag)
+}
+
+// AsHookTimeoutProvider returns the agent as HookTimeoutProvider if it
+// implements the interface. Built-in only, matching AsSessionEndBudgeter
+// above: widen with a DeclaredCaps field if an external agent ever needs it.
+func AsHookTimeoutProvider(ag Agent) (HookTimeoutProvider, bool) {
+	return builtinCapability[HookTimeoutProvider](ag)
+}
+
+// defaultHookTimeout is the flat timeout applied to a hook event when no
+// agent overrides it (HookTimeoutFor). A var rather than a const so tests can
+// shrink it instead of waiting out a real 30s — see
+// SetDefaultHookTimeoutForTesting. 30s is the historical flat cap this
+// mechanism generalizes away from (GitHub issue #2115); it is left unchanged
+// as the default for every event with no evidence-backed override, matching
+// Codex's own defaultHookTimeoutSec (cmd/entire/cli/agent/codex/hooks.go).
+var defaultHookTimeout = 30 * time.Second //nolint:gochecknoglobals // overridable for testing, same pattern as external.defaultRunTimeout
+
+// DefaultHookTimeout returns the flat per-hook-event timeout applied when no
+// agent overrides it for the given event via HookTimeoutProvider.
+func DefaultHookTimeout() time.Duration { return defaultHookTimeout }
+
+// SetDefaultHookTimeoutForTesting overrides DefaultHookTimeout for the
+// duration of a test and returns a restore func. Callers must defer the
+// restore so the real 30s default is never left mutated across tests — this
+// is process-global state, so parallel tests must not call it concurrently.
+func SetDefaultHookTimeoutForTesting(d time.Duration) func() {
+	prev := defaultHookTimeout
+	defaultHookTimeout = d
+	return func() { defaultHookTimeout = prev }
+}
+
+// HookTimeoutFor resolves the timeout that should apply to hookName for ag:
+// ag's own HookTimeoutProvider override when it returns a positive duration,
+// else DefaultHookTimeout(). Callers should always resolve through this
+// rather than reading DefaultHookTimeout() directly, so an agent's override
+// is never accidentally bypassed.
+func HookTimeoutFor(ag Agent, hookName string) time.Duration {
+	if provider, ok := AsHookTimeoutProvider(ag); ok {
+		if d := provider.HookTimeout(hookName); d > 0 {
+			return d
+		}
+	}
+	return DefaultHookTimeout()
 }

--- a/cmd/entire/cli/agent/capabilities_test.go
+++ b/cmd/entire/cli/agent/capabilities_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/stretchr/testify/require"
 )
 
 // --- Mock types for testing ---
@@ -123,6 +125,23 @@ type mockBuiltinPromptAgent struct {
 
 func (m *mockBuiltinPromptAgent) ExtractPrompts(string, int) ([]string, error) {
 	return []string{"test prompt"}, nil
+}
+
+// mockHookTimeoutAgent is a built-in agent that implements HookTimeoutProvider
+// but NOT CapabilityDeclarer, mirroring how CodexAgent implements it: an
+// override for one named event, zero (no override) for everything else.
+type mockHookTimeoutAgent struct {
+	mockBaseAgent
+
+	overrideEvent string
+	overrideValue time.Duration
+}
+
+func (m *mockHookTimeoutAgent) HookTimeout(hookName string) time.Duration {
+	if hookName == m.overrideEvent {
+		return m.overrideValue
+	}
+	return 0
 }
 
 // --- Tests ---
@@ -492,4 +511,72 @@ func TestAsStreamingTextGenerator(t *testing.T) {
 			t.Error("expected false when capability declared false")
 		}
 	})
+}
+
+func TestAsHookTimeoutProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not implemented", func(t *testing.T) {
+		t.Parallel()
+		_, ok := AsHookTimeoutProvider(&mockBaseAgent{})
+		if ok {
+			t.Error("expected false for agent not implementing HookTimeoutProvider")
+		}
+	})
+
+	t.Run("builtin agent", func(t *testing.T) {
+		t.Parallel()
+		ag := &mockHookTimeoutAgent{overrideEvent: "stop", overrideValue: 5 * time.Second}
+		htp, ok := AsHookTimeoutProvider(ag)
+		if !ok || htp == nil {
+			t.Error("expected true for built-in agent implementing HookTimeoutProvider")
+		}
+	})
+}
+
+// TestHookTimeoutFor is REQUIREMENT 2 from the differentiated-hook-timeout
+// task: an agent implementing HookTimeoutProvider gets its own declared value
+// honored for the event it overrides, and every other agent/event still
+// resolves to the flat default — proving the mechanism differentiates
+// without silently applying an override everywhere.
+//
+// Not parallel: it mutates the process-global default via
+// SetDefaultHookTimeoutForTesting.
+func TestHookTimeoutFor(t *testing.T) {
+	restore := SetDefaultHookTimeoutForTesting(7 * time.Second)
+	defer restore()
+
+	t.Run("agent without the capability always gets the default", func(t *testing.T) {
+		ag := &mockBaseAgent{}
+		require.Equal(t, DefaultHookTimeout(), HookTimeoutFor(ag, "stop"))
+		require.Equal(t, DefaultHookTimeout(), HookTimeoutFor(ag, "session-end"))
+	})
+
+	t.Run("agent with the capability gets its own value for the overridden event", func(t *testing.T) {
+		ag := &mockHookTimeoutAgent{overrideEvent: "session-end", overrideValue: 3 * time.Second}
+
+		require.Equal(t, 3*time.Second, HookTimeoutFor(ag, "session-end"),
+			"the overridden event must get the agent's own value, not the default")
+		require.Equal(t, DefaultHookTimeout(), HookTimeoutFor(ag, "stop"),
+			"an event the agent does not override must still fall back to the default")
+	})
+
+	t.Run("a non-positive override falls back to the default rather than disabling the timeout", func(t *testing.T) {
+		ag := &mockHookTimeoutAgent{overrideEvent: "stop", overrideValue: 0}
+		require.Equal(t, DefaultHookTimeout(), HookTimeoutFor(ag, "stop"))
+	})
+}
+
+// TestSetDefaultHookTimeoutForTesting pins the test seam DefaultHookTimeout
+// needs: production's flat default is 30s (matching Codex's own
+// defaultHookTimeoutSec), and nothing should have to wait out a real 30s to
+// exercise the timeout mechanism.
+func TestSetDefaultHookTimeoutForTesting(t *testing.T) {
+	require.Equal(t, 30*time.Second, DefaultHookTimeout(), "production default must stay 30s")
+
+	restore := SetDefaultHookTimeoutForTesting(50 * time.Millisecond)
+	require.Equal(t, 50*time.Millisecond, DefaultHookTimeout())
+
+	restore()
+	require.Equal(t, 30*time.Second, DefaultHookTimeout(), "restore must put the real default back")
 }

--- a/cmd/entire/cli/agent/codex/lifecycle.go
+++ b/cmd/entire/cli/agent/codex/lifecycle.go
@@ -20,6 +20,7 @@ var (
 	_ agent.HookResponseWriter       = (*CodexAgent)(nil)
 	_ agent.ContextInjector          = (*CodexAgent)(nil)
 	_ agent.SessionEndBudgeter       = (*CodexAgent)(nil)
+	_ agent.HookTimeoutProvider      = (*CodexAgent)(nil)
 )
 
 // OwnsEffectiveHookDiagnostics keeps Codex's discovered-file state out of the
@@ -107,6 +108,24 @@ const sessionEndBudget = 2 * time.Second
 // SessionEndBudget implements agent.SessionEndBudgeter. Codex runs SessionEnd
 // inside its shutdown sequence under a hard cap; see the interface docs.
 func (c *CodexAgent) SessionEndBudget() time.Duration { return sessionEndBudget }
+
+// HookTimeout implements agent.HookTimeoutProvider. SessionEnd is the one
+// event with an evidence-backed override today — Codex clamps it to
+// SessionEndTimeoutSec regardless of what hooks.json declares, so returning
+// anything else there would just be wrong. Every other event returns 0 (no
+// override): GitHub issues #1137 and #957 report Codex hooks repeatedly
+// hitting the flat 30s cap, but neither pins a specific replacement number,
+// and #2115's own proposed per-hook values are explicitly hedged ("one
+// developer's corpus... under-sampled"). Guessing a new number into
+// production is worse than leaving proven-safe events at
+// agent.DefaultHookTimeout() until a maintainer has real data to tune with —
+// this method is where that tuning lands once it exists.
+func (c *CodexAgent) HookTimeout(hookName string) time.Duration {
+	if hookName == HookNameSessionEnd {
+		return time.Duration(SessionEndTimeoutSec) * time.Second
+	}
+	return 0
+}
 
 // ParseHookEvent translates a Codex hook into a normalized lifecycle Event.
 // Returns nil if the hook has no lifecycle significance.

--- a/cmd/entire/cli/agent/codex/lifecycle_test.go
+++ b/cmd/entire/cli/agent/codex/lifecycle_test.go
@@ -119,6 +119,38 @@ func TestCodexAgent_SessionEndBudgetFitsConfiguredTimeout(t *testing.T) {
 		"budget must leave at least 1s for wrapper + binary startup, which Codex's clock counts and Entire's does not")
 }
 
+// TestCodexAgent_HookTimeoutHonorsSessionEndOverride pins the one
+// evidence-backed override this method makes: SessionEnd gets Codex's own
+// clamp (SessionEndTimeoutSec), never the flat default, and every other event
+// falls through to agent.DefaultHookTimeout() unchanged — see GitHub issues
+// #2115/#1137/#957 for why new numbers for the other events are deliberately
+// not guessed here.
+func TestCodexAgent_HookTimeoutHonorsSessionEndOverride(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+
+	require.Equal(t, time.Duration(SessionEndTimeoutSec)*time.Second, ag.HookTimeout(HookNameSessionEnd))
+
+	for _, hookName := range []string{
+		HookNameSessionStart, HookNameUserPromptSubmit, HookNameStop,
+		HookNamePostToolUse, HookNameSubagentStart, HookNameSubagentStop,
+	} {
+		require.Zerof(t, ag.HookTimeout(hookName), "hook %q must have no override yet", hookName)
+	}
+}
+
+// TestDefaultHookTimeoutSecMatchesGenericDefault guards against the flat
+// default drifting apart across the two places it is spelled: the int
+// seconds value hooks.json needs (defaultHookTimeoutSec) and the
+// time.Duration the generic dispatch-time mechanism reads
+// (agent.DefaultHookTimeout()). They are independent literals on purpose
+// (different packages, different types) rather than one deriving the other,
+// so nothing enforces this except this test.
+func TestDefaultHookTimeoutSecMatchesGenericDefault(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, defaultHookTimeoutSec, int(agent.DefaultHookTimeout()/time.Second))
+}
+
 func TestParseHookEvent_UserPromptSubmit(t *testing.T) {
 	t.Parallel()
 	ag := &CodexAgent{}

--- a/cmd/entire/cli/hook_registry.go
+++ b/cmd/entire/cli/hook_registry.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
@@ -91,6 +92,62 @@ func getHookType(hookName string) string {
 		return "tool"
 	default:
 		return "agent"
+	}
+}
+
+// ErrHookTimedOut reports that a hook handler was abandoned because it ran
+// past the timeout agent.HookTimeoutFor declared for it. Before this, that
+// declared value was purely nominal for every agent except Codex: nothing on
+// our side watched it, so a stuck or slow handler either ran unbounded
+// in-process or waited on an external host's own kill (Codex's hooks.json
+// timeout, which prints "hook timed out after Ns" itself — see GitHub
+// issues #1137/#957) with no record on our side of which case it was. This
+// gives every agent the same self-imposed backstop, and gives it a distinct,
+// logged failure mode rather than silence (#2115: "the cap is doing
+// telemetry's job").
+var ErrHookTimedOut = errors.New("hook exceeded its configured timeout")
+
+// runHookWithTimeout runs fn under the timeout agent.HookTimeoutFor resolves
+// for (ag, hookName), mirroring the goroutine/timer/select shape
+// gitrepo.StatusWithBudget already uses for the same kind of problem (a
+// blocking in-process call with no ctx-polling of its own). fn's goroutine is
+// not killed on timeout — a synchronous call cannot be forced to stop the way
+// an external host kills a subprocess — but this hook's own process is about
+// to exit right after its RunE returns, so an abandoned fn dies with it
+// moments later; returning early just stops this process from silently
+// absorbing a wait nothing is watching, and logs it distinctly so a stuck
+// hook leaves real evidence instead of nothing.
+func runHookWithTimeout(ctx context.Context, ag agent.Agent, hookName string, fn func() error) error {
+	timeout := agent.HookTimeoutFor(ag, hookName)
+	if timeout <= 0 {
+		return fn()
+	}
+
+	resultCh := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				resultCh <- fmt.Errorf("hook handler panicked: %v", r)
+			}
+		}()
+		resultCh <- fn()
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-resultCh:
+		return err
+	case <-timer.C:
+		elapsed := time.Since(start).Round(time.Millisecond)
+		logging.Warn(logging.WithComponent(ctx, "hooks"),
+			"hook exceeded its configured timeout",
+			slog.String("hook", hookName),
+			slog.Duration("elapsed", elapsed),
+			slog.Duration("timeout", timeout))
+		return fmt.Errorf("hook %q abandoned after %s (timeout %s): %w",
+			hookName, elapsed, timeout, ErrHookTimedOut)
 	}
 }
 
@@ -207,10 +264,14 @@ func executeAgentHook(cmd *cobra.Command, agentName types.AgentName, hookName st
 
 	if event != nil {
 		// Lifecycle event — use the generic dispatcher
-		hookErr = DispatchLifecycleEvent(ctx, ag, event)
+		hookErr = runHookWithTimeout(ctx, ag, hookName, func() error {
+			return DispatchLifecycleEvent(ctx, ag, event)
+		})
 	} else if claudePostTodoCheckpointHook {
 		// PostTodo is Claude-specific: creates incremental checkpoints during subagent execution
-		hookErr = handleClaudeCodePostTodo(ctx)
+		hookErr = runHookWithTimeout(ctx, ag, hookName, func() error {
+			return handleClaudeCodePostTodo(ctx)
+		})
 	}
 	// Other pass-through hooks (nil event, no special handling) are no-ops
 

--- a/cmd/entire/cli/hook_registry_test.go
+++ b/cmd/entire/cli/hook_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -686,6 +687,131 @@ func TestHookCommand_SetsCurrentHookAgentName(t *testing.T) {
 	if currentHookAgentName != "" {
 		t.Errorf("after handler: currentHookAgentName = %q, want empty", currentHookAgentName)
 	}
+}
+
+// mockHookTimeoutAwareAgent wraps mockLifecycleAgent (lifecycle_test.go) and
+// additionally implements agent.HookTimeoutProvider, for exercising
+// runHookWithTimeout's override path without needing a real agent's hook
+// config machinery.
+type mockHookTimeoutAwareAgent struct {
+	mockLifecycleAgent
+
+	overrideEvent string
+	overrideValue time.Duration
+}
+
+var _ agent.HookTimeoutProvider = (*mockHookTimeoutAwareAgent)(nil)
+
+func (m *mockHookTimeoutAwareAgent) HookTimeout(hookName string) time.Duration {
+	if hookName == m.overrideEvent {
+		return m.overrideValue
+	}
+	return 0
+}
+
+// sleepHandler returns a hook handler stub that blocks for d then succeeds.
+func sleepHandler(d time.Duration) func() error {
+	return func() error {
+		time.Sleep(d)
+		return nil
+	}
+}
+
+// TestRunHookWithTimeout_CutsOffAtTheFlatDefault is REQUIREMENT 1 from the
+// differentiated-hook-timeout task (GitHub #2115, #1137, #957): today's flat
+// timeout must actually cut a slow hook handler off, uniformly, for an agent
+// that does not implement agent.HookTimeoutProvider — not just be a number
+// nobody enforces. Before runHookWithTimeout existed, the declared 30s value
+// was enforced only externally (Codex's own hooks.json kill; see #1137/#957's
+// "hook timed out after 30s" reports) — nothing on our side watched it for
+// any agent, including this one. agent.SetDefaultHookTimeoutForTesting is the
+// test seam that makes this provable without waiting out a real 30s.
+//
+// Not parallel across the whole test: it mutates the process-global default.
+func TestRunHookWithTimeout_CutsOffAtTheFlatDefault(t *testing.T) {
+	restore := agent.SetDefaultHookTimeoutForTesting(30 * time.Millisecond)
+	defer restore()
+
+	ag := &mockLifecycleAgent{name: agent.AgentNameClaudeCode}
+
+	// Two different hook names prove "flat" — the same default cuts off both,
+	// because this agent has no per-event override at all.
+	for _, hookName := range []string{"stop", "session-start"} {
+		t.Run(hookName, func(t *testing.T) {
+			start := time.Now()
+			err := runHookWithTimeout(context.Background(), ag, hookName, sleepHandler(300*time.Millisecond))
+			elapsed := time.Since(start)
+
+			require.ErrorIsf(t, err, ErrHookTimedOut,
+				"hook %q: a handler slower than the flat default must be reported as timed out", hookName)
+			require.Lessf(t, elapsed, 200*time.Millisecond,
+				"hook %q: expected the 30ms flat default to cut a 300ms handler off, took %s", hookName, elapsed)
+		})
+	}
+}
+
+// TestRunHookWithTimeout_HonorsAgentOverride is REQUIREMENT 2: an agent
+// implementing agent.HookTimeoutProvider gets its OWN declared value for the
+// event it overrides — even one longer than the flat default, so the
+// handler completes instead of being cut off — while an event it does not
+// override still falls back to the same flat default as any other agent.
+func TestRunHookWithTimeout_HonorsAgentOverride(t *testing.T) {
+	restore := agent.SetDefaultHookTimeoutForTesting(30 * time.Millisecond)
+	defer restore()
+
+	ag := &mockHookTimeoutAwareAgent{
+		mockLifecycleAgent: mockLifecycleAgent{name: agent.AgentNameClaudeCode},
+		overrideEvent:      "session-end",
+		overrideValue:      300 * time.Millisecond,
+	}
+
+	t.Run("overridden event gets its own longer budget and completes", func(t *testing.T) {
+		err := runHookWithTimeout(context.Background(), ag, "session-end", sleepHandler(100*time.Millisecond))
+		require.NoError(t, err,
+			"a 100ms handler must fit inside the agent's 300ms override for this event, not the 30ms default")
+	})
+
+	t.Run("non-overridden event on the same agent still uses the flat default", func(t *testing.T) {
+		err := runHookWithTimeout(context.Background(), ag, "stop", sleepHandler(100*time.Millisecond))
+		require.ErrorIs(t, err, ErrHookTimedOut,
+			"an event this agent does not override must still be cut off at the 30ms default")
+	})
+}
+
+// TestRunHookWithTimeout_LogsExceededTimeoutDistinctly is REQUIREMENT 3: a
+// hook that exceeds its declared timeout must leave a distinct, identifiable
+// log line — not just a generic error, and not folded into perf's unrelated
+// fixed slow-span threshold. This is #2115's core complaint ("the cap is
+// doing telemetry's job") made false: an exceeded timeout is now visible in
+// .entire/logs even for agents no external host kills.
+func TestRunHookWithTimeout_LogsExceededTimeoutDistinctly(t *testing.T) {
+	restore := agent.SetDefaultHookTimeoutForTesting(30 * time.Millisecond)
+	defer restore()
+
+	var buf bytes.Buffer
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(prevDefault)
+
+	ag := &mockLifecycleAgent{name: agent.AgentNameClaudeCode}
+	err := runHookWithTimeout(context.Background(), ag, "stop", sleepHandler(300*time.Millisecond))
+	require.ErrorIs(t, err, ErrHookTimedOut)
+
+	found := false
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry), "log line must be valid JSON: %s", line)
+		if entry["msg"] != "hook exceeded its configured timeout" {
+			continue
+		}
+		found = true
+		require.Equal(t, "WARN", entry["level"], "an exceeded timeout must be distinctly visible, not DEBUG-only")
+		require.Equal(t, "stop", entry["hook"])
+		require.Contains(t, entry, "elapsed")
+		require.Contains(t, entry, "timeout")
+	}
+	require.Truef(t, found,
+		"expected a distinct 'hook exceeded its configured timeout' log line, got:\n%s", buf.String())
 }
 
 // writeTestSessionState creates a session state file in .git/entire-sessions/ for testing.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1252
<!-- entire-trail-link-end -->

## Summary
- A flat 30-second hook timeout applied to every agent/hook combination. #2115 argued this is wrong in both directions and proposed differentiation like the existing SessionEnd=3s budgeter precedent; #1137/#957 report repeated real timeouts (Codex hooks externally enforce this same 30s and kill the process, matching their symptoms exactly).
- This PR builds the **mechanism**, not new guessed values: a new optional \`agent.HookTimeoutProvider\` capability (mirroring the existing \`SessionEndBudgeter\` pattern exactly), resolved via \`agent.HookTimeoutFor(agent, hookName)\` — an agent can override the timeout per hook name; everyone else stays at the current 30s default, unchanged.
- Extended the one existing proven precedent (Codex's SessionEnd=3s) through the new interface rather than inventing new per-event numbers for #2115's own proposal (pre-push→120s etc.) — that issue explicitly hedges those values as "one developer's corpus, under-sampled." A maintainer with real telemetry can tune specific values later using this mechanism.
- Also added the visibility fix #2115 specifically asked for: a hook that exceeds its timeout now logs a distinct "hook exceeded its configured timeout" warning (previously only visible as an external Codex-side kill with no corresponding internal signal).

## Evidence
- Real timeout enforcement (\`runHookWithTimeout\`, goroutine/timer/select, mirrors the existing \`gitrepo.StatusWithBudget\` idiom) now wraps every agent's hook dispatch, not just Codex's process-level kill.
- Tests: cutoff at the flat default confirmed real; agent-specific override honored; timeout-exceeded case distinctly logged; Codex's SessionEnd override still resolves correctly through the new interface.

## Test plan
- \`go test ./cmd/entire/cli/... ./perf/... -race -count=1\` — all ~85 packages ok.
- \`mise run fmt\`/\`mise run lint\` clean.

This is the shared mechanism, not a complete resolution of every symptom in all three issues (e.g. #1137's separate Claude Code transcript-sentinel latency is untouched).

Refs #2115, Refs #1137, Refs #957