### PR TITLE
fix: detect empty-tree commits and stop condensing over them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1165,6 +1165,85 @@ without rewriting", which is false, and it would have grown the number of
 index-rewriting call sites from one to eleven. That is why the guard test exists
 rather than a comment.
 
+#### An Empty Index Is Not the Same as a Missing One
+
+**A missing `.git/index` must never be read as an empty index.** Git does
+exactly that — ENOENT, and only ENOENT, yields an empty in-core index — and
+go-git v6 does too (`storage/filesystem.IndexStorage.Index` returns a zero-entry
+index on `os.ErrNotExist`, in both its cache-stat and its file-open branch). That
+single conflation is what turns the race above into a commit that deletes every
+tracked file, with exit code 0 and no warning. Neither implementation will ever
+raise it for us, so `gitrepo.IndexRecordsNoEntries` (`gitrepo/emptyindex.go`) is
+the reader that keeps the two facts apart: a missing file comes back as
+`os.ErrNotExist`, and only a header that positively records zero entries comes
+back as empty. It reads the 12-byte header rather than decoding the index,
+because it runs on every commit, and it reports a split index (`link` extension,
+entries in `.git/sharedindex.<hash>`) as *not* empty.
+
+**Two guards ride on it, both read-only, neither able to fail a commit**
+(`warnOnEmptyIndexCommit` / `warnOnEmptyTreeCommit`, both in `hooks_git_cmd.go`):
+
+- `prepare-commit-msg` compares the index git is committing from — `$GIT_INDEX_FILE`,
+  which git exports to the commit hooks — against HEAD, and warns *before* the
+  commit object exists. By the time that hook runs the file is authoritative and
+  the check is free of any remaining TOCTOU. Git reads the index in
+  `prepare_index()` and **re-reads it after the `pre-commit` hook** — so a
+  `pre-commit` hook that stages a file does change the commit, and "read once
+  before any hook" is wrong — but from there on the commit's tree is written
+  from that in-core copy, and nothing after `prepare-commit-msg` can move it:
+  restoring a good index from a `commit-msg` hook was measured and the empty
+  tree was still committed. Measured values of `$GIT_INDEX_FILE`, identical in
+  `prepare-commit-msg` and `commit-msg`: `.git/index` (relative) for a plain
+  staged commit, `--amend`, and `--allow-empty`; `.git/index.lock` for
+  `commit -a`; `.git/next-index-<pid>.lock` for `commit -m msg -- <path>`; and
+  always **absolute** in a linked worktree, which is what makes the
+  relative-path join safe (a relative `.git/index` where `.git` is a *file*
+  never occurs). For an ordinary `git commit`, `prepare_index` has already
+  renamed its refreshed copy over `.git/index` by hook time, so comparing
+  `$GIT_INDEX_FILE` against `.git/index` proves nothing — HEAD and the worktree
+  are the comparison that works.
+- `post-commit` asks the same question of HEAD, and **returns before the strategy
+  runs at all**. That skip is the part that is not merely advisory: condensing
+  against such a commit deletes the shadow branch, marks the session condensed,
+  and advances `BaseCommit` onto a commit the user is about to remove with `git
+  reset --mixed HEAD~1`, so the recovery leaves the session's pending checkpoint
+  data consumed by a commit that no longer exists. Measured against the
+  unguarded binary through the real hook: `should_condense: true`, "session
+  condensed", "shadow branch deleted".
+
+**The signature is two facts together: the commit records no files, and the files
+it removes are still on disk.** Either alone is ordinary — someone who deletes
+every tracked file means it, and a repository can legitimately hold nothing. Only
+the pair says the index was read as empty when it was not. `git rm -r --cached .`
+followed by a commit produces the same pair and is warned about too; the message
+says so in its last line, and warning is all it does. The worktree probe is
+bounded (`hazardSurvivorScanLimit`) so it cannot scale with repository size on
+the per-commit path, and the tree names go through the `worktreedir` root because
+they may have come from a remote.
+
+Output goes to **stdout**: the installed `prepare-commit-msg` and `post-commit`
+hooks send stderr to `/dev/null` so a hook failure can never mix into a user's
+git output, and git neither reads nor interprets a git hook's stdout. Both hooks
+still record the hazard at ERROR in `.entire/logs`, for the case where there is
+no terminal at all.
+
+Detection is deliberately all this does. Entire cannot prevent the corruption —
+by the time any hook runs, git has already read the index — and the hooks are
+installed `2>/dev/null || true` precisely so Entire can never abort a user's
+commit. Reversing that contract is a product decision, not a bug fix. What these
+guards remove is the silence, and the second loss that silence used to cause.
+
+**Two known consequences, both deliberate.** `prepare-commit-msg` warns and
+*still stamps* the `Entire-Checkpoint` trailer, and `post-commit` then skips, so
+the empty-tree commit carries a checkpoint ID nothing condensed. On the
+prescribed recovery that commit disappears and the trailer with it; it only
+persists for a user who keeps the commit, and suppressing the stamp would mean
+making `PrepareCommitMsg` conditional on a hazard the user may be about to
+ignore. And the surviving-path probe stops after `hazardSurvivorScanLimit`
+entries in tree order, so a commit whose first 512 tracked paths are all absent
+from disk while a later one survives is not warned about — the bound is what
+keeps the probe off the critical path in a large repository.
+
 #### go-git v5 Bugs - Use CLI Instead
 
 **Do NOT use go-git v5 for `checkout` or `reset --hard` operations.**

--- a/cmd/entire/cli/gitrepo/emptyindex.go
+++ b/cmd/entire/cli/gitrepo/emptyindex.go
@@ -1,0 +1,416 @@
+package gitrepo
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
+	"github.com/go-git/go-git/v6/plumbing/object"
+)
+
+// Empty-index / empty-tree detection: the last line of defence for issue #2111.
+//
+// Git treats a `.git/index` that cannot be opened because it does not exist —
+// ENOENT, and ONLY ENOENT; every other errno calls die_errno — as an *empty*
+// index. A `git commit` that reads the index in that state records the empty
+// tree, exits 0, and prints no warning: a commit that deletes every tracked
+// file. go-git v6 has the same rule (storage/filesystem.IndexStorage.Index
+// returns a zero-entry index on os.ErrNotExist), so neither implementation will
+// ever raise this for us.
+//
+// The window opens whenever some process replaces `.git/index` by rename while
+// another reads it, on a filesystem where rename-over-existing is not atomic
+// against a concurrent lookup — Docker Desktop / virtiofs / gRPC-FUSE bind
+// mounts, i.e. devcontainers, measured at 9.9% of opens during continuous
+// replacement versus 0 on ext4. Entire stopped contributing one such write in
+// #2143 (`git status` without --no-optional-locks), but the writers Entire does
+// not control — the user's own `git status`, another tool's, a file watcher's,
+// N agents each running their own hooks — keep the window open. Detection is
+// what is left.
+//
+// Everything here is read-only. It never blocks a commit, never rewrites an
+// index, and never returns an error to a hook: the contract that Entire cannot
+// fail a user's commit is unchanged. What it removes is the silence.
+
+const (
+	// indexSignature is the 4-byte magic at the start of a git index file.
+	indexSignature = "DIRC"
+
+	// indexHeaderLen is the fixed header: signature, version, entry count,
+	// each 4 bytes big-endian.
+	indexHeaderLen = 12
+
+	// indexLinkExtension marks a split index. Its entries live in a shared
+	// index file, so a zero entry count in this file says nothing about how
+	// much is staged. Extensions begin immediately after the header when the
+	// entry count is zero, which is the only case this file needs to read.
+	indexLinkExtension = "link"
+
+	// hazardSurvivorSample is how many still-present paths the warning names.
+	hazardSurvivorSample = 3
+
+	// hazardSurvivorScanLimit bounds the tree walk that looks for a surviving
+	// path. A commit that really does delete every tracked file finds nothing,
+	// and this runs on the per-commit hook path, so the walk must not scale
+	// with repository size. If the first hazardSurvivorScanLimit tracked paths
+	// are all gone from disk, the deletion is taken to be real.
+	hazardSurvivorScanLimit = 512
+)
+
+// ErrNotAnIndexFile reports that a file named as a git index does not carry the
+// index format's header. Distinct from "the index is empty": nothing is known
+// about what is staged, so no caller may draw a conclusion from it.
+var ErrNotAnIndexFile = errors.New("not a git index file")
+
+// IndexRecordsNoEntries reports whether the git index file at path records zero
+// entries.
+//
+// It reads the 12-byte header rather than decoding the index: this runs on
+// every commit, and the answer needed is a count. A missing file is NOT
+// reported as empty — that is precisely the conflation this package exists to
+// break — it is returned as the os.ErrNotExist it is, for the caller to treat
+// as "unknown".
+//
+// A split index (`link` extension) reports false: its entries live in a shared
+// index file, so a zero count here is not an empty index.
+func IndexRecordsNoEntries(path string) (bool, error) {
+	// Stat before open, and require a regular file. An index that is a FIFO, a
+	// socket or a device is not an index, and opening a FIFO with no writer
+	// blocks forever — this runs on a commit hook, has no deadline of its own,
+	// and exists for the filesystem class that hangs. An allowlist, not a list
+	// of known-bad types. Stat, not Lstat: git follows a symlinked index, so
+	// this resolves the link and judges what it points at. A path swapped
+	// between the stat and the open is not defended against here — nothing git
+	// or any tool does produces it, and git opens the same path first.
+	info, err := os.Stat(path) //nolint:gosec // path comes from GIT_INDEX_FILE or the resolved git dir
+	if err != nil {
+		return false, err //nolint:wrapcheck // callers distinguish os.ErrNotExist and add their own context
+	}
+	if !info.Mode().IsRegular() {
+		return false, fmt.Errorf("index at %s is a %s: %w", path, describeIndexMode(info.Mode()), ErrNotAnIndexFile)
+	}
+
+	f, err := os.Open(path) //nolint:gosec // path comes from GIT_INDEX_FILE or the resolved git dir
+	if err != nil {
+		return false, err //nolint:wrapcheck // callers distinguish os.ErrNotExist and add their own context
+	}
+	defer f.Close()
+
+	// A short header is a malformed index; anything else is an I/O failure and
+	// keeps its own error, so a caller's log says which of the two happened.
+	var header [indexHeaderLen]byte
+	if _, err := io.ReadFull(f, header[:]); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return false, fmt.Errorf("index %s is shorter than its header: %w", path, ErrNotAnIndexFile)
+		}
+		return false, fmt.Errorf("read index header of %s: %w", path, err)
+	}
+	if string(header[0:4]) != indexSignature {
+		return false, fmt.Errorf("index header of %s: %w", path, ErrNotAnIndexFile)
+	}
+	if version := binary.BigEndian.Uint32(header[4:8]); version < 2 || version > 4 {
+		return false, fmt.Errorf("index version %d in %s: %w", version, path, ErrNotAnIndexFile)
+	}
+	if binary.BigEndian.Uint32(header[8:12]) > 0 {
+		return false, nil
+	}
+
+	// Zero entries. With no entries to skip, any extension block starts at the
+	// end of the header, so one more 4-byte read settles whether this is a
+	// split index. A short read here means there are no extensions, only the
+	// trailing checksum — a genuinely empty index.
+	//
+	// Only the FIRST extension is inspected, which is sound because git writes
+	// `link` first (write_split_index in read-cache.c) and measured across
+	// every zero-entry index git 2.54 produces the four bytes are `link`,
+	// `TREE`, or trailing checksum bytes. A future git that reorders extensions
+	// would make this over-report empty, i.e. warn where it should not — the
+	// direction that costs a message rather than a miss.
+	var extension [4]byte
+	if _, err := io.ReadFull(f, extension[:]); err == nil && string(extension[:]) == indexLinkExtension {
+		return false, nil
+	}
+	return true, nil
+}
+
+// describeIndexMode names a non-regular index for the message that refuses it.
+func describeIndexMode(mode os.FileMode) string {
+	switch {
+	case mode.IsDir():
+		return "directory"
+	case mode&os.ModeNamedPipe != 0:
+		return "named pipe"
+	case mode&os.ModeSocket != 0:
+		return "socket"
+	case mode&os.ModeDevice != 0:
+		return "device"
+	default:
+		return mode.Type().String()
+	}
+}
+
+// hazardPhase says whether the commit that records no files is still being
+// prepared or has already been written.
+type hazardPhase int
+
+const (
+	hazardBeforeCommit hazardPhase = iota
+	hazardAfterCommit
+)
+
+// EmptyTreeHazard is a commit that records no files at all while the files it
+// removes are still present in the worktree.
+//
+// The two halves are what make it a hazard rather than an intention: a user who
+// means to stop tracking everything has usually deleted the files too, and a
+// user who means to delete the files has deleted them. Files on disk and no
+// files in the commit is the signature of the index having been read as empty
+// when it was not.
+type EmptyTreeHazard struct {
+	phase hazardPhase
+
+	// Commit is the abbreviated hash of the offending commit, empty before the
+	// commit exists.
+	Commit string
+
+	// SurvivingPaths are up to hazardSurvivorSample paths the commit removes
+	// that are still present in the worktree.
+	SurvivingPaths []string
+}
+
+// DetectEmptyIndexHazard reports the hazard from inside a commit hook, before
+// the commit object exists, or nil when there is nothing to report.
+//
+// indexPath must be the index git is committing from — the value git exports as
+// GIT_INDEX_FILE to pre-commit, prepare-commit-msg and commit-msg. That file is
+// authoritative by the time prepare-commit-msg runs: git reads the index in
+// prepare_index(), re-reads it after the pre-commit hook (so a pre-commit hook
+// that stages a file does affect the commit — measured), and from there on
+// writes the commit's tree from that in-core copy. Nothing after
+// prepare-commit-msg can change it: restoring a good index from a commit-msg
+// hook was tried and the empty tree was still committed. So there is no
+// time-of-check/time-of-use gap left between what this sees and what lands.
+//
+// The 12-byte index-header read comes first and the repository is opened only
+// if it says zero entries, so a normal commit pays one open(2) and a 16-byte
+// read for this.
+//
+// Fails silent in every direction it cannot resolve: no index path, an
+// unreadable index, an unopenable repository, an unborn or unreadable HEAD, a
+// HEAD that records no files of its own. Each of those means the check cannot
+// conclude anything, and this runs on a path that must never make noise it
+// cannot justify.
+func DetectEmptyIndexHazard(ctx context.Context, worktreeRoot, indexPath string) *EmptyTreeHazard {
+	logCtx := logging.WithComponent(ctx, "checkpoint")
+
+	if indexPath == "" || worktreeRoot == "" {
+		return nil
+	}
+	if !filepath.IsAbs(indexPath) {
+		// Git runs hooks from the top of the worktree and names the index
+		// relative to it.
+		indexPath = filepath.Join(worktreeRoot, indexPath)
+	}
+
+	empty, err := IndexRecordsNoEntries(indexPath)
+	if err != nil {
+		logging.Debug(logCtx, "empty-index guard: index not readable, skipping",
+			slog.String("index", indexPath),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	if !empty {
+		return nil
+	}
+
+	repo, err := OpenPath(worktreeRoot)
+	if err != nil {
+		logging.Debug(logCtx, "empty-index guard: repository not openable, skipping",
+			slog.String("worktree_root", worktreeRoot),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	defer repo.Close()
+
+	head, err := repo.Head()
+	if err != nil {
+		// Unborn HEAD: the first commit of a repository legitimately starts
+		// from an empty index.
+		return nil
+	}
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		return nil
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return nil
+	}
+
+	surviving := survivingPaths(worktreeRoot, tree)
+	if len(surviving) == 0 {
+		return nil
+	}
+	return &EmptyTreeHazard{phase: hazardBeforeCommit, SurvivingPaths: surviving}
+}
+
+// DetectEmptyTreeCommitHazard reports the hazard from the post-commit hook,
+// after the commit has been written, or nil when there is nothing to report.
+//
+// This is the second net rather than a duplicate of the first: it catches a
+// commit written by a path that runs no prepare-commit-msg hook at all, and it
+// is the point at which Entire can still decline to act on the commit.
+func DetectEmptyTreeCommitHazard(_ context.Context, worktreeRoot string, commit *object.Commit) *EmptyTreeHazard {
+	if commit == nil {
+		return nil
+	}
+	tree, err := commit.Tree()
+	if err != nil || len(tree.Entries) > 0 {
+		return nil
+	}
+	// A root commit that records no files removes nothing.
+	if commit.NumParents() == 0 {
+		return nil
+	}
+	parent, err := commit.Parent(0)
+	if err != nil {
+		return nil
+	}
+	parentTree, err := parent.Tree()
+	if err != nil || len(parentTree.Entries) == 0 {
+		return nil
+	}
+
+	surviving := survivingPaths(worktreeRoot, parentTree)
+	if len(surviving) == 0 {
+		return nil
+	}
+	return &EmptyTreeHazard{
+		phase:          hazardAfterCommit,
+		Commit:         shortHash(commit.Hash.String()),
+		SurvivingPaths: surviving,
+	}
+}
+
+// survivingPaths returns up to hazardSurvivorSample paths from tree that still
+// exist in the worktree, scanning at most hazardSurvivorScanLimit entries.
+//
+// The names come from a git tree, which may have been fetched from a remote, so
+// they are resolved through the worktreedir root rather than joined onto the
+// worktree path — the rule for every read of a working file named by something
+// other than Entire.
+//
+// Lstat, not Stat: the question is whether a path is still present, and a
+// dangling symlink is present.
+func survivingPaths(worktreeRoot string, tree *object.Tree) []string {
+	if worktreeRoot == "" || tree == nil {
+		return nil
+	}
+	root, err := worktreedir.OpenAt(worktreeRoot)
+	if err != nil {
+		return nil
+	}
+
+	found := make([]string, 0, hazardSurvivorSample)
+	scanned := 0
+	files := tree.Files()
+	defer files.Close()
+	for {
+		file, err := files.Next()
+		if err != nil {
+			break
+		}
+		scanned++
+		if scanned > hazardSurvivorScanLimit {
+			break
+		}
+		name, err := worktreedir.Name(worktreeRoot, file.Name)
+		if err != nil {
+			continue
+		}
+		if _, err := root.Lstat(name); err == nil {
+			found = append(found, file.Name)
+			if len(found) == hazardSurvivorSample {
+				break
+			}
+		}
+	}
+	return found
+}
+
+func shortHash(hash string) string {
+	const abbrev = 7
+	if len(hash) > abbrev {
+		return hash[:abbrev]
+	}
+	return hash
+}
+
+// Message renders the warning shown to the user.
+//
+// Both phases can fire for one commit — prepare-commit-msg then post-commit —
+// so only the first carries the explanation; the second is the receipt, and
+// says what Entire did about it. Both name the recovery, because either may be
+// the only one a given commit path reaches.
+func (h *EmptyTreeHazard) Message() string {
+	var b strings.Builder
+	paths := strings.Join(h.SurvivingPaths, ", ")
+
+	switch h.phase {
+	case hazardBeforeCommit:
+		b.WriteString("\nEntire: WARNING - this commit is about to record an EMPTY tree.\n")
+		b.WriteString("  Git read an empty index, so this commit deletes every tracked file - yet\n")
+		b.WriteString("  those files are still here: " + paths + "\n")
+		b.WriteString("  A concurrent git process can replace .git/index while git reads it, and git\n")
+		b.WriteString("  treats an index it cannot find as an empty one: silently, exit code 0. Seen\n")
+		b.WriteString("  on Docker Desktop / virtiofs / gRPC-FUSE bind mounts, i.e. dev containers.\n")
+	case hazardAfterCommit:
+		b.WriteString("\nEntire: WARNING - the commit you just made (" + h.Commit + ") records an EMPTY tree.\n")
+		b.WriteString("  It deletes every file its parent tracked, yet those files are still here:\n")
+		b.WriteString("  " + paths + "\n")
+		b.WriteString("  Entire has left this session's checkpoints alone so the undo below is clean.\n")
+	}
+
+	b.WriteString("  Undo it:  git reset --mixed HEAD~1      Prevent it:  GIT_OPTIONAL_LOCKS=0\n")
+	b.WriteString("  Meant to stop tracking every file? Then nothing is wrong - carry on.\n\n")
+
+	return b.String()
+}
+
+// Report writes the warning where the user will see it and records it in the
+// log.
+//
+// Stdout, not stderr: the prepare-commit-msg and post-commit hooks Entire
+// installs redirect stderr to /dev/null so a hook failure can never mix into a
+// user's git output, and git neither reads nor interprets a git hook's stdout.
+// A hook that has no terminal at all (a GUI client, CI, an agent subprocess)
+// still leaves the record in the log.
+func (h *EmptyTreeHazard) Report(ctx context.Context, out io.Writer) {
+	logging.Error(logging.WithComponent(ctx, "checkpoint"),
+		"empty-tree commit detected: git read the index as empty while tracked files are present",
+		slog.String("phase", h.phaseName()),
+		slog.String("commit", h.Commit),
+		slog.Any("surviving_paths", h.SurvivingPaths),
+	)
+	if out == nil {
+		return
+	}
+	fmt.Fprint(out, h.Message())
+}
+
+func (h *EmptyTreeHazard) phaseName() string {
+	if h.phase == hazardAfterCommit {
+		return "after-commit"
+	}
+	return "before-commit"
+}

--- a/cmd/entire/cli/gitrepo/emptyindex_fifo_unix_test.go
+++ b/cmd/entire/cli/gitrepo/emptyindex_fifo_unix_test.go
@@ -1,0 +1,54 @@
+//go:build unix
+
+package gitrepo
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestIndexRecordsNoEntries_RefusesAFifoWithoutBlocking pins the reason the
+// reader stats before it opens. Opening a FIFO with no writer blocks until one
+// arrives, and this code has no deadline of its own, runs inside a commit hook,
+// and exists for the filesystem class that hangs — so a named pipe where the
+// index should be has to be refused, not opened.
+func TestIndexRecordsNoEntries_RefusesAFifoWithoutBlocking(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "index")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+
+	type result struct {
+		empty bool
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		empty, err := IndexRecordsNoEntries(path)
+		done <- result{empty, err}
+	}()
+
+	select {
+	case got := <-done:
+		if !errors.Is(got.err, ErrNotAnIndexFile) {
+			t.Fatalf("want ErrNotAnIndexFile for a FIFO, got %v", got.err)
+		}
+		if got.empty {
+			t.Fatal("a FIFO was reported as an empty index")
+		}
+	case <-time.After(5 * time.Second):
+		// The goroutine is stuck in open(2) and cannot be reclaimed; a real
+		// hook process would be stuck the same way, which is the bug.
+		t.Fatal("IndexRecordsNoEntries blocked on a FIFO instead of refusing it")
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("the FIFO should be untouched: %v", err)
+	}
+}

--- a/cmd/entire/cli/gitrepo/emptyindex_test.go
+++ b/cmd/entire/cli/gitrepo/emptyindex_test.go
@@ -1,0 +1,422 @@
+package gitrepo
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil/gitenv"
+)
+
+// initEmptyIndexRepo builds a real git repository with three tracked files and
+// one commit, using the real git binary under isolated config. Real git is the
+// point of these tests: the failure being guarded against is a behaviour of
+// git's own index reader, so nothing short of the binary reproduces it.
+func initEmptyIndexRepo(t *testing.T) string {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	gitenv.Run(t, repoDir, "init", "-q", ".")
+	gitenv.Run(t, repoDir, "config", "user.name", "Test User")
+	gitenv.Run(t, repoDir, "config", "user.email", "test@example.com")
+	gitenv.Run(t, repoDir, "config", "commit.gpgsign", "false")
+
+	if err := os.MkdirAll(filepath.Join(repoDir, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	for path, content := range map[string]string{
+		"one.txt":       "one\n",
+		"two.txt":       "two\n",
+		"sub/three.txt": "three\n",
+	} {
+		if err := os.WriteFile(filepath.Join(repoDir, filepath.FromSlash(path)), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	gitenv.Run(t, repoDir, "add", "-A")
+	gitenv.Run(t, repoDir, "commit", "-qm", "initial")
+	return repoDir
+}
+
+func indexPathOf(repoDir string) string {
+	return filepath.Join(repoDir, ".git", "index")
+}
+
+// The hazard probe: a real git hook cannot call into this package, so it
+// re-executes the test binary, which runs the guard in-process against the
+// index git handed the hook and prints the verdict.
+const (
+	hazardProbeEnabledEnv = "ENTIRE_TEST_HAZARD_PROBE"
+	hazardProbeRepoEnv    = "ENTIRE_TEST_HAZARD_REPO"
+	hazardProbeQuiet      = "HAZARD-PROBE-QUIET"
+	hazardProbeNoIndexEnv = "HAZARD-PROBE-NO-GIT-INDEX-FILE"
+)
+
+// TestHazardProbeHelper is not a test. It is the body of the prepare-commit-msg
+// hook that TestEmptyIndexCommitDestroysStagedWork installs: git runs the test
+// binary, which lands here, evaluates the pre-commit guard at the one moment
+// that answers the real question, and prints what a user would have been shown.
+func TestHazardProbeHelper(t *testing.T) {
+	if os.Getenv(hazardProbeEnabledEnv) == "" {
+		t.Skip("hook body, not a test")
+	}
+	if os.Getenv("GIT_INDEX_FILE") == "" {
+		t.Log(hazardProbeNoIndexEnv)
+		return
+	}
+	hazard := DetectEmptyIndexHazard(t.Context(), os.Getenv(hazardProbeRepoEnv), os.Getenv("GIT_INDEX_FILE"))
+	if hazard == nil {
+		t.Log(hazardProbeQuiet)
+		return
+	}
+	t.Log(hazard.Message())
+}
+
+func TestIndexRecordsNoEntries_PopulatedIndexIsNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initEmptyIndexRepo(t)
+
+	empty, err := IndexRecordsNoEntries(indexPathOf(repoDir))
+	if err != nil {
+		t.Fatalf("IndexRecordsNoEntries: %v", err)
+	}
+	if empty {
+		t.Fatal("an index holding three staged entries was reported empty")
+	}
+}
+
+func TestIndexRecordsNoEntries_EmptiedIndexIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initEmptyIndexRepo(t)
+	// The one way a user genuinely empties the index while keeping the files.
+	gitenv.Run(t, repoDir, "rm", "-r", "--cached", "-q", ".")
+
+	empty, err := IndexRecordsNoEntries(indexPathOf(repoDir))
+	if err != nil {
+		t.Fatalf("IndexRecordsNoEntries: %v", err)
+	}
+	if !empty {
+		t.Fatal("an index git emptied with rm --cached was not reported empty")
+	}
+}
+
+// TestIndexRecordsNoEntries_MissingIndexIsNotReportedEmpty pins the conflation
+// this whole file exists to break. Git and go-git both answer "empty index" for
+// a `.git/index` that is not there; this reader answers os.ErrNotExist, because
+// "the file is gone" and "nothing is staged" are different facts and only one
+// of them justifies committing an empty tree.
+func TestIndexRecordsNoEntries_MissingIndexIsNotReportedEmpty(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initEmptyIndexRepo(t)
+	if err := os.Remove(indexPathOf(repoDir)); err != nil {
+		t.Fatalf("remove index: %v", err)
+	}
+
+	empty, err := IndexRecordsNoEntries(indexPathOf(repoDir))
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("want os.ErrNotExist for a missing index, got %v", err)
+	}
+	if empty {
+		t.Fatal("a missing index was reported as an empty index — the #2111 conflation")
+	}
+}
+
+func TestIndexRecordsNoEntries_RejectsNonIndexFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "not-an-index")
+	if err := os.WriteFile(path, []byte("this is not a git index at all"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := IndexRecordsNoEntries(path); !errors.Is(err, ErrNotAnIndexFile) {
+		t.Fatalf("want ErrNotAnIndexFile, got %v", err)
+	}
+
+	if _, err := IndexRecordsNoEntries(dir); !errors.Is(err, ErrNotAnIndexFile) {
+		t.Fatalf("want ErrNotAnIndexFile for a directory, got %v", err)
+	}
+
+	short := filepath.Join(dir, "truncated")
+	if err := os.WriteFile(short, []byte("DIRC"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := IndexRecordsNoEntries(short); !errors.Is(err, ErrNotAnIndexFile) {
+		t.Fatalf("want ErrNotAnIndexFile for a truncated header, got %v", err)
+	}
+}
+
+// TestIndexRecordsNoEntries_SplitIndexIsNotEmpty covers the one shape where a
+// zero entry count does not mean an empty index: a split index keeps its
+// entries in .git/sharedindex.<hash>.
+func TestIndexRecordsNoEntries_SplitIndexIsNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index")
+
+	header := make([]byte, 0, 20)
+	header = append(header, []byte("DIRC")...)
+	header = binary.BigEndian.AppendUint32(header, 2) // version
+	header = binary.BigEndian.AppendUint32(header, 0) // entry count
+	header = append(header, []byte("link")...)        // split-index extension
+	header = append(header, 0, 0, 0, 0)               // extension length
+	if err := os.WriteFile(path, header, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	empty, err := IndexRecordsNoEntries(path)
+	if err != nil {
+		t.Fatalf("IndexRecordsNoEntries: %v", err)
+	}
+	if empty {
+		t.Fatal("a split index was reported empty; its entries live in the shared index")
+	}
+}
+
+// TestEmptyIndexCommitDestroysStagedWork is the bug, end to end, with the real
+// git binary: staged work is lost, every tracked file is deleted by the commit,
+// git exits 0 and says nothing — and the guard sees all of it, both before the
+// commit exists and after.
+//
+// Removing `.git/index` outright is a deterministic stand-in for the race in
+// #2111: on a virtiofs / gRPC-FUSE bind mount a concurrent rename over the
+// index makes a reader observe ENOENT for a file that exists. Git's reaction to
+// ENOENT is the failure, and it is identical either way — an empty in-core
+// index — so this reproduces the consequence without needing the filesystem.
+func TestEmptyIndexCommitDestroysStagedWork(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initEmptyIndexRepo(t)
+
+	const userWork = "WORK THE USER MUST NOT LOSE\n"
+	if err := os.WriteFile(filepath.Join(repoDir, "one.txt"), []byte("one\n"+userWork), 0o644); err != nil {
+		t.Fatalf("write one.txt: %v", err)
+	}
+	gitenv.Run(t, repoDir, "add", "one.txt")
+	if staged := gitenv.Run(t, repoDir, "diff", "--cached", "--name-only"); !strings.Contains(staged, "one.txt") {
+		t.Fatalf("one.txt was not staged, got %q", staged)
+	}
+
+	// Run the pre-commit guard from a real prepare-commit-msg hook, at the
+	// moment git runs it, over the index git handed the hook. Evaluating it
+	// after the commit would be a different question: by then HEAD is the
+	// empty-tree commit and there is nothing left to compare against.
+	probeOutput := filepath.Join(t.TempDir(), "probe-output")
+	hookPath := filepath.Join(repoDir, ".git", "hooks", "prepare-commit-msg")
+	hook := "#!/bin/sh\n" +
+		hazardProbeEnabledEnv + "=1 " + hazardProbeRepoEnv + "=" + repoDir + " " +
+		os.Args[0] + " -test.run='^TestHazardProbeHelper$' -test.v > " + probeOutput + " 2>&1\n" +
+		"exit 0\n"
+	if err := os.WriteFile(hookPath, []byte(hook), 0o755); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+
+	// The window: git is about to read an index that is not there.
+	if err := os.Remove(indexPathOf(repoDir)); err != nil {
+		t.Fatalf("remove index: %v", err)
+	}
+
+	// Real git, real commit. It succeeds, which is the whole problem.
+	gitenv.Run(t, repoDir, "commit", "-qm", "record the user's work")
+
+	// The damage, stated three ways.
+	if tracked := strings.TrimSpace(gitenv.Run(t, repoDir, "ls-tree", "-r", "--name-only", "HEAD")); tracked != "" {
+		t.Fatalf("expected the commit to record no files at all, got:\n%s", tracked)
+	}
+	if shown := gitenv.Run(t, repoDir, "show", "--stat", "--oneline", "HEAD"); !strings.Contains(shown, "3 files changed") {
+		t.Fatalf("expected the commit to delete all three tracked files, got:\n%s", shown)
+	}
+	onDisk, err := os.ReadFile(filepath.Join(repoDir, "one.txt"))
+	if err != nil || !strings.Contains(string(onDisk), userWork) {
+		t.Fatalf("the user's work should still be on disk: %v / %q", err, onDisk)
+	}
+
+	// What the guard said, in the hook, before the commit existed.
+	probe, err := os.ReadFile(probeOutput)
+	if err != nil {
+		t.Fatalf("the prepare-commit-msg hook did not run: %v", err)
+	}
+	if strings.Contains(string(probe), hazardProbeNoIndexEnv) {
+		t.Fatalf("git did not export GIT_INDEX_FILE to the commit hook:\n%s", probe)
+	}
+	if strings.Contains(string(probe), hazardProbeQuiet) {
+		t.Fatalf("pre-commit guard missed an index git read as empty while tracked files were present:\n%s", probe)
+	}
+	if !strings.Contains(string(probe), "is about to record an EMPTY tree") {
+		t.Fatalf("pre-commit guard did not warn:\n%s", probe)
+	}
+	for _, want := range []string{"one.txt", "git reset --mixed HEAD~1"} {
+		if !strings.Contains(string(probe), want) {
+			t.Fatalf("pre-commit warning does not mention %q:\n%s", want, probe)
+		}
+	}
+	t.Logf("pre-commit guard, from inside the real hook:\n%s", probe)
+
+	repo, err := OpenPath(repoDir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		t.Fatalf("commit object: %v", err)
+	}
+	after := DetectEmptyTreeCommitHazard(t.Context(), repoDir, commit)
+	if after == nil {
+		t.Fatal("post-commit guard missed a commit whose tree is empty while its parent's files are on disk")
+	}
+	for _, want := range []string{"EMPTY tree", "git reset --mixed HEAD~1", "GIT_OPTIONAL_LOCKS=0"} {
+		if !strings.Contains(after.Message(), want) {
+			t.Fatalf("warning does not mention %q:\n%s", want, after.Message())
+		}
+	}
+
+	// The recovery the warning prescribes has to actually work.
+	gitenv.Run(t, repoDir, "reset", "--mixed", "HEAD~1")
+	restored := gitenv.Run(t, repoDir, "ls-tree", "-r", "--name-only", "HEAD")
+	for _, path := range []string{"one.txt", "two.txt", "sub/three.txt"} {
+		if !strings.Contains(restored, path) {
+			t.Fatalf("git reset --mixed HEAD~1 did not restore %s:\n%s", path, restored)
+		}
+	}
+	recoveredWork, err := os.ReadFile(filepath.Join(repoDir, "one.txt"))
+	if err != nil || !strings.Contains(string(recoveredWork), userWork) {
+		t.Fatalf("the user's work did not survive recovery: %v / %q", err, recoveredWork)
+	}
+}
+
+func TestDetectEmptyIndexHazard_QuietOnAHealthyCommit(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initEmptyIndexRepo(t)
+	if err := os.WriteFile(filepath.Join(repoDir, "two.txt"), []byte("two\nmore\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	gitenv.Run(t, repoDir, "add", "two.txt")
+
+	if hazard := DetectEmptyIndexHazard(t.Context(), repoDir, indexPathOf(repoDir)); hazard != nil {
+		t.Fatalf("a normal staged commit was flagged:\n%s", hazard.Message())
+	}
+}
+
+func TestDetectEmptyIndexHazard_QuietWithoutAnIndexPath(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initEmptyIndexRepo(t)
+	if hazard := DetectEmptyIndexHazard(t.Context(), repoDir, ""); hazard != nil {
+		t.Fatal("guard fired with no index path to read")
+	}
+	if hazard := DetectEmptyIndexHazard(t.Context(), "", indexPathOf(repoDir)); hazard != nil {
+		t.Fatal("guard fired with no worktree root to check against")
+	}
+}
+
+// TestDetectEmptyIndexHazard_QuietWhenTheFilesAreGoneToo is the intent case:
+// someone who deleted every tracked file is committing exactly what they meant
+// to, and must not be warned.
+func TestDetectEmptyIndexHazard_QuietWhenTheFilesAreGoneToo(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initEmptyIndexRepo(t)
+	gitenv.Run(t, repoDir, "rm", "-r", "-q", ".")
+
+	empty, err := IndexRecordsNoEntries(indexPathOf(repoDir))
+	if err != nil || !empty {
+		t.Fatalf("git rm -r . should leave an empty index: %v / %v", empty, err)
+	}
+	if hazard := DetectEmptyIndexHazard(t.Context(), repoDir, indexPathOf(repoDir)); hazard != nil {
+		t.Fatalf("a deliberate delete-everything commit was flagged:\n%s", hazard.Message())
+	}
+}
+
+func TestDetectEmptyTreeCommitHazard_QuietCases(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initEmptyIndexRepo(t)
+	repo, err := OpenPath(repoDir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	rootCommit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		t.Fatalf("commit object: %v", err)
+	}
+
+	if hazard := DetectEmptyTreeCommitHazard(t.Context(), repoDir, nil); hazard != nil {
+		t.Fatal("guard fired on a nil commit")
+	}
+	if hazard := DetectEmptyTreeCommitHazard(t.Context(), repoDir, rootCommit); hazard != nil {
+		t.Fatalf("guard fired on an ordinary commit:\n%s", hazard.Message())
+	}
+
+	// A root commit that records nothing removes nothing.
+	emptyRoot := t.TempDir()
+	gitenv.Run(t, emptyRoot, "init", "-q", ".")
+	gitenv.Run(t, emptyRoot, "config", "user.name", "Test User")
+	gitenv.Run(t, emptyRoot, "config", "user.email", "test@example.com")
+	gitenv.Run(t, emptyRoot, "config", "commit.gpgsign", "false")
+	gitenv.Run(t, emptyRoot, "commit", "-q", "--allow-empty", "-m", "root")
+
+	emptyRepo, err := OpenPath(emptyRoot)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer emptyRepo.Close()
+	emptyHead, err := emptyRepo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	emptyCommit, err := emptyRepo.CommitObject(emptyHead.Hash())
+	if err != nil {
+		t.Fatalf("commit object: %v", err)
+	}
+	if hazard := DetectEmptyTreeCommitHazard(t.Context(), emptyRoot, emptyCommit); hazard != nil {
+		t.Fatalf("guard fired on an empty root commit:\n%s", hazard.Message())
+	}
+}
+
+// TestDetectEmptyTreeCommitHazard_QuietWhenTheFilesAreGoneToo is the
+// post-commit counterpart of the intent case above.
+func TestDetectEmptyTreeCommitHazard_QuietWhenTheFilesAreGoneToo(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initEmptyIndexRepo(t)
+	gitenv.Run(t, repoDir, "rm", "-r", "-q", ".")
+	gitenv.Run(t, repoDir, "commit", "-qm", "remove everything, on purpose")
+
+	repo, err := OpenPath(repoDir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		t.Fatalf("commit object: %v", err)
+	}
+
+	if hazard := DetectEmptyTreeCommitHazard(t.Context(), repoDir, commit); hazard != nil {
+		t.Fatalf("a deliberate delete-everything commit was flagged:\n%s", hazard.Message())
+	}
+}

--- a/cmd/entire/cli/hooks_git_cmd.go
+++ b/cmd/entire/cli/hooks_git_cmd.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/telemetry"
@@ -211,6 +213,13 @@ func newHooksGitPrepareCommitMsgCmd() *cobra.Command {
 			defer g.span.End()
 			g.logInvoked(slog.String("source", source))
 
+			// Ahead of the checkpoint-policy gate on purpose. The guard reads
+			// nothing Entire owns and draws no conclusion that depends on the
+			// checkpoint policy — it compares the index git is committing from
+			// against HEAD — and it is the last moment at which the user can be
+			// told before the commit deletes their tracked files.
+			warnOnEmptyIndexCommit(g.ctx, cmd.OutOrStdout())
+
 			if g.skipUnsupportedCheckpointPolicy() {
 				return nil
 			}
@@ -261,6 +270,17 @@ func newHooksGitPostCommitCmd() *cobra.Command {
 			g := newGitHookContext(cmd.Context(), "post-commit")
 			defer g.span.End()
 			g.logInvoked()
+
+			// The prepare-commit-msg guard from the other side of the commit,
+			// and the one place Entire can still decline to act on it. Ahead of
+			// the checkpoint-policy gate for the same reason as its twin: the
+			// question it answers — does HEAD record no files while those files
+			// are still on disk — is about the user's commit and depends on no
+			// Entire state, and a repo whose policy this binary must not act on
+			// still wants to hear that its commit deleted everything.
+			if warnOnEmptyTreeCommit(g.ctx, cmd.OutOrStdout()) {
+				return nil
+			}
 
 			if g.skipUnsupportedCheckpointPolicy() {
 				return nil
@@ -341,4 +361,76 @@ func newHooksGitPrePushCmd() *cobra.Command {
 			return fmt.Errorf("pre-push: %w", hookErr)
 		},
 	}
+}
+
+// warnOnEmptyIndexCommit tells the user, before the commit object exists, that
+// the commit git is preparing records no files while those files are still on
+// disk — the signature of git having read `.git/index` as missing and therefore
+// empty (issue #2111).
+//
+// Read-only and silent by default: the detector reads the index header first
+// and opens the repository only if it says zero entries, so a normal commit
+// pays one open(2) and a 16-byte read on top of a worktree-root resolution the
+// rest of this hook process performs anyway (paths.WorktreeRoot caches per
+// working directory). Measured at +0.1ms per invocation. It cannot fail the
+// hook — every unresolvable step returns without a word, because a guard that
+// guesses is worse than no guard.
+func warnOnEmptyIndexCommit(ctx context.Context, out io.Writer) {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return
+	}
+	// GIT_INDEX_FILE is the index git is committing from. Git exports it to
+	// pre-commit, prepare-commit-msg and commit-msg, and by the time this hook
+	// runs it is authoritative: git re-reads the index after pre-commit and
+	// then writes the commit's tree from that in-core copy, so nothing after
+	// this point can change what lands.
+	hazard := gitrepo.DetectEmptyIndexHazard(ctx, worktreeRoot, os.Getenv("GIT_INDEX_FILE"))
+	if hazard == nil {
+		return
+	}
+	hazard.Report(ctx, out)
+}
+
+// warnOnEmptyTreeCommit reports whether the commit at HEAD records no files at
+// all while the files it removes are still in the worktree — the aftermath of
+// the same condition warnOnEmptyIndexCommit catches before the fact (#2111) —
+// warning the user when it does.
+//
+// A true return stops the whole post-commit hook. That is the point: condensing
+// against such a commit deletes shadow branches and marks the session condensed
+// on the strength of a commit the user is about to undo with `git reset --mixed
+// HEAD~1`, and advances BaseCommit onto a commit that is about to stop
+// existing. Skipping costs nothing on the other reading of the same evidence —
+// someone deliberately untracking every file gets condensed on their next
+// commit instead.
+//
+// Two hooks warn about one commit, so the messages differ: the pre-commit one
+// carries the explanation, this one the receipt.
+func warnOnEmptyTreeCommit(ctx context.Context, out io.Writer) bool {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return false
+	}
+	repo, err := gitrepo.OpenCurrent(ctx)
+	if err != nil {
+		return false
+	}
+	defer repo.Close()
+
+	head, err := repo.Head()
+	if err != nil {
+		return false
+	}
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		return false
+	}
+
+	hazard := gitrepo.DetectEmptyTreeCommitHazard(ctx, worktreeRoot, commit)
+	if hazard == nil {
+		return false
+	}
+	hazard.Report(ctx, out)
+	return true
 }

--- a/cmd/entire/cli/integration_test/empty_tree_commit_test.go
+++ b/cmd/entire/cli/integration_test/empty_tree_commit_test.go
@@ -1,0 +1,198 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostCommitHook_EmptyTreeCommit_LeavesCheckpointsAlone covers the #2111
+// aftermath through the real post-commit hook.
+//
+// A commit whose tree is empty while the files it removes are still on disk is
+// what git writes when it reads `.git/index` as missing — ENOENT is silently
+// treated as an empty index — and the user's recovery is `git reset --mixed
+// HEAD~1`. Entire must not condense against such a commit: condensing deletes
+// the shadow branch, marks the session condensed, and advances BaseCommit onto
+// a commit that is about to stop existing, so the recovery leaves the session's
+// pending checkpoint data consumed by a commit that no longer exists.
+//
+// Verified RED against the unguarded binary: `should_condense: true`, "session
+// condensed", "shadow branch deleted".
+func TestPostCommitHook_EmptyTreeCommit_LeavesCheckpointsAlone(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	sess := env.NewSession()
+
+	require.NoError(t, env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(
+		sess.ID, "Create file A", sess.TranscriptPath))
+
+	env.WriteFile("fileA.go", pkgFuncA)
+	sess.CreateTranscript("Create file A", []FileChange{{Path: "fileA.go", Content: pkgFuncA}})
+	require.NoError(t, env.SimulateStop(sess.ID, sess.TranscriptPath))
+
+	// A second turn start puts the session back into ACTIVE, the phase in which
+	// post-commit condenses immediately — the state a mid-turn commit lands in,
+	// and the one where an empty-tree commit costs the session its shadow
+	// branch. Without the guard, this hook logs "session condensed" and "shadow
+	// branch deleted" for the commit below.
+	require.NoError(t, env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(
+		sess.ID, "Now commit it", sess.TranscriptPath))
+
+	shadowBranch := env.GetShadowBranchName()
+	require.True(t, env.BranchExists(shadowBranch),
+		"the session must have shadow-branch content for the hook to be able to lose")
+	// The v1 branch already exists from session setup, so the signal that
+	// condensation ran is its tip moving, not its existence.
+	v1Before := branchHash(t, env, paths.MetadataBranchName)
+
+	// The corrupt commit, with a checkpoint trailer so the unguarded hook would
+	// have every reason to condense against it. The worktree is untouched —
+	// files on disk plus no files in the commit is the whole signature.
+	commitEmptyTreeWithTrailer(t, env, "a1b2c3d4e5f6")
+	require.True(t, env.FileExists("fileA.go"), "the files must still be on disk")
+
+	cmd := exec.CommandContext(t.Context(), getTestBinary(), "hooks", "git", "post-commit")
+	cmd.Dir = env.RepoDir
+	cmd.Env = append(testutil.GitIsolatedEnv(),
+		"ENTIRE_TEST_CLAUDE_PROJECT_DIR="+env.ClaudeProjectDir)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "the hook must not fail the user's commit:\n%s", out)
+	t.Logf("post-commit hook output:\n%s", out)
+
+	require.Contains(t, string(out), "records an EMPTY tree",
+		"the hook must say what happened")
+	require.Contains(t, string(out), "git reset --mixed HEAD~1",
+		"the hook must name the recovery")
+
+	require.True(t, env.BranchExists(shadowBranch),
+		"shadow branch must survive: the user is about to reset this commit away")
+	require.Equal(t, v1Before, branchHash(t, env, paths.MetadataBranchName),
+		"nothing may be condensed onto entire/checkpoints/v1 for an empty-tree commit")
+}
+
+// branchHash returns the branch tip, or "" when the branch does not exist.
+func branchHash(t *testing.T, env *TestEnv, branch string) string {
+	t.Helper()
+
+	repo, err := git.PlainOpen(env.RepoDir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	ref, err := repo.Reference(plumbing.NewBranchReferenceName(branch), true)
+	if err != nil {
+		return ""
+	}
+	return ref.Hash().String()
+}
+
+// commitEmptyTreeWithTrailer moves HEAD to a new commit whose tree is the empty
+// tree, the shape git writes when it reads the index as empty. Built through
+// plumbing because no porcelain path produces it without also deleting the
+// files from the worktree, and their presence on disk is half the signature.
+func commitEmptyTreeWithTrailer(t *testing.T, env *TestEnv, checkpointIDStr string) {
+	t.Helper()
+
+	repo, err := git.PlainOpen(env.RepoDir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	treeObj := repo.Storer.NewEncodedObject()
+	require.NoError(t, (&object.Tree{}).Encode(treeObj))
+	emptyTree, err := repo.Storer.SetEncodedObject(treeObj)
+	require.NoError(t, err)
+
+	sig := object.Signature{Name: "Test User", Email: "test@example.com", When: time.Now()}
+	commit := &object.Commit{
+		Author:       sig,
+		Committer:    sig,
+		Message:      "record the user's work\n\n" + trailers.CheckpointTrailerKey + ": " + id.MustCheckpointID(checkpointIDStr).String() + "\n",
+		TreeHash:     emptyTree,
+		ParentHashes: []plumbing.Hash{head.Hash()},
+	}
+	commitObj := repo.Storer.NewEncodedObject()
+	require.NoError(t, commit.Encode(commitObj))
+	hash, err := repo.Storer.SetEncodedObject(commitObj)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(head.Name(), hash)))
+}
+
+// TestPrepareCommitMsgHook_EmptyIndex_WarnsBeforeTheCommit covers the #2111
+// guard on the near side of the commit, through the real prepare-commit-msg
+// hook of the real binary.
+//
+// It exists because the wiring is the part that can silently disappear: a
+// mutation deleting the guard's call from the hook's RunE left the unit tests,
+// the cli package tests, and the whole integration suite green. Testing the
+// detector is not testing the hook.
+//
+// The index here records zero entries while every tracked file is still on
+// disk — the state git leaves behind when it reads `.git/index` as missing —
+// produced with real git so the bytes are the ones git writes.
+func TestPrepareCommitMsgHook_EmptyIndex_WarnsBeforeTheCommit(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	testutil.RunGit(t, env.RepoDir, "rm", "-r", "--cached", "-q", ".")
+	require.True(t, env.FileExists("README.md"), "the tracked files must still be on disk")
+
+	out := runPrepareCommitMsgHook(t, env)
+	require.Contains(t, out, "is about to record an EMPTY tree",
+		"the hook must warn before the commit object exists")
+	require.Contains(t, out, "git reset --mixed HEAD~1",
+		"the hook must name the recovery")
+}
+
+// TestPrepareCommitMsgHook_PopulatedIndex_IsSilent is the other half: the guard
+// must not announce itself on an ordinary commit.
+func TestPrepareCommitMsgHook_PopulatedIndex_IsSilent(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	env.WriteFile("fileA.go", pkgFuncA)
+	env.GitAdd("fileA.go")
+
+	require.NotContains(t, runPrepareCommitMsgHook(t, env), "EMPTY tree",
+		"an ordinary staged commit must produce no warning")
+}
+
+// runPrepareCommitMsgHook invokes the real binary as git would, including the
+// GIT_INDEX_FILE git exports to its commit hooks — the relative `.git/index`
+// measured from real commits — and fails the test if the hook errors, since a
+// git hook of Entire's may never fail a user's commit.
+func runPrepareCommitMsgHook(t *testing.T, env *TestEnv) string {
+	t.Helper()
+
+	msgFile := filepath.Join(env.RepoDir, ".git", "COMMIT_EDITMSG")
+	require.NoError(t, os.WriteFile(msgFile, []byte("record the user's work\n"), 0o644))
+
+	cmd := exec.CommandContext(t.Context(), getTestBinary(),
+		"hooks", "git", "prepare-commit-msg", msgFile, "message")
+	cmd.Dir = env.RepoDir
+	cmd.Env = append(testutil.GitIsolatedEnv(),
+		"ENTIRE_TEST_CLAUDE_PROJECT_DIR="+env.ClaudeProjectDir,
+		"GIT_INDEX_FILE=.git/index")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "the hook must not fail the user's commit:\n%s", out)
+	t.Logf("prepare-commit-msg hook output:\n%s", out)
+	return string(out)
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1253
<!-- entire-trail-link-end -->

## Summary

The root corruption is git's own bug, not Entire's, and cannot be prevented from a hook: git (and go-git v6, independently) treats a missing \`.git/index\` (ENOENT) as an empty in-core index, and \`git status\` renames a fresh index over the real one as a side effect — so any concurrent process running \`git status\` at the wrong moment can cause a commit to record an empty tree. The previously-merged mitigation (#2143) already scrubs Entire's own \`git status\` calls, but by the time any hook runs, git has already read the index — prevention was never available from here, only detection.

**A second, previously-unknown data-loss bug was found while investigating, and that one is Entire's, and is fixed here**: when an empty-tree commit happens, Entire's \`post-commit\` hook still ran condensation on it — consuming the session's pending checkpoint data. So even if a user notices and runs \`git reset --mixed HEAD~1\` to recover, the checkpoint data backing that work was already gone. \`post-commit\` now detects an empty-tree commit and skips condensation entirely; \`prepare-commit-msg\` warns before the commit lands, naming the recovery command and \`GIT_OPTIONAL_LOCKS=0\`.

## Evidence
- Real repro against a binary built from \`origin/main\`: staged files silently committed as an empty tree, exit 0, files still on disk — confirmed with real git, not simulated.
- Same repro on this branch: both warnings fire, naming the exact recovery steps.
- New \`gitrepo.IndexRecordsNoEntries\` distinguishes "missing" from "genuinely empty" (only a positively-parsed zero-entry header counts), refuses non-regular files (stats before opening — a FIFO at the index path would otherwise block \`open(2)\` forever), and works on sha256 repos (verified against their different empty-tree hash).
- **Mutation-tested**: 9 deliberate mutations (removing the post-commit skip, removing the prepare-commit-msg wiring, removing the stat-before-open, etc.) each turn a passing test red, proving the tests aren't vacuous.
- Adversarial review pass found and fixed 5 issues before this PR (a coverage gap where deleting the hook wiring left everything green, the FIFO-blocking hazard, a dangling-trailer edge case documented as accepted, an errno-masking bug, and a factually-incorrect code comment) — see commit body for the full list.

## Test plan
- \`mise run fmt\` clean, \`mise run lint\` 0 issues, \`go vet\` clean under default/integration/e2e tags.
- \`mise run test\`: 10,719 passed, 9 skipped. \`mise run test:integration\`: 565 passed, 3 skipped. \`mise run test:e2e:canary\`: 56 vogon + 4 roger-roger passed (free).
- \`-race\` clean on \`gitrepo\`, \`cli\`, \`strategy\`.
- \`mise run check\`/\`test:ci\` intentionally not run here (executes real agents with live model calls) — everything else it covers was run individually.
- Perf cost measured: +0.1ms per hook invocation.

## Remaining risk (documented, not hidden)
- The corruption itself cannot be prevented from a hook — user-side mitigation is \`GIT_OPTIONAL_LOCKS=0\`, now named in the warning message.
- One accepted false positive: \`git rm -r --cached .\` then commit warns twice and skips post-commit condensation; the next ordinary commit condenses normally (verified).
- A kept (not reset) empty-tree commit still carries an unclaimed checkpoint trailer — documented, not suppressed, since suppressing it would make the warning conditional on a hazard the user may choose to ignore.

## Side findings for a maintainer (out of scope here, not fixed in this PR)
- \`strategy/manual_commit_hooks.go\`'s \`getStagedFiles\` runs \`git diff --cached\` without \`gitrepo.EnvWithoutRepoOverrides()\` inside prepare-commit-msg, violating the rule this repo adopted after #2143 (~15 call sites share the gap). Consequence is a wrong condensation decision, not data loss.
- go-git's ENOENT-as-empty-index behavior is now documented but not defended against in a few of Entire's own readers (\`content_overlap.go\`, \`settings/opf_command_trust.go\`, \`gitrepo.Status\`) — no destructive consumer currently, but \`IndexRecordsNoEntries\` is there to route them through if someone wants to close this fully.

Refs #2111