### PR TITLE
fix(gitrepo): keep symbolic ref errors non-retryable

### DIFF
--- a/cmd/entire/cli/gitrepo/ref_cas.go
+++ b/cmd/entire/cli/gitrepo/ref_cas.go
@@ -47,10 +47,12 @@ func CompareAndSwapRef(
 		return errors.Join(err, tx.abort())
 	}
 	if symbolic {
-		return errors.Join(
-			fmt.Errorf("ref %s points to %s: %w", refName, target, ErrRefSymbolic),
-			tx.abort(),
-		)
+		symbolicErr := fmt.Errorf("ref %s points to %s: %w", refName, target, ErrRefSymbolic)
+		if abortErr := tx.abort(); abortErr != nil {
+			// Cleanup diagnostics must not make symbolic-ref rejection retryable.
+			return fmt.Errorf("%w (abort transaction: %s)", symbolicErr, abortErr.Error())
+		}
+		return symbolicErr
 	}
 	return tx.commit()
 }

--- a/cmd/entire/cli/gitrepo/ref_cas_test.go
+++ b/cmd/entire/cli/gitrepo/ref_cas_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -86,6 +87,40 @@ func TestCompareAndSwapRef_RejectsSymbolicRef(t *testing.T) {
 			)
 			require.NoError(t, err)
 			require.Equal(t, replacement, strings.TrimSpace(gitenv.Run(t, repoDir, "rev-parse", refName.String())))
+		})
+	}
+}
+
+func TestCompareAndSwapRef_SymbolicRefAbortFailure(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("abort failure injection requires POSIX signals")
+	}
+	for _, backend := range refCASBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			t.Parallel()
+			repoDir, initial, replacement := backend.init(t)
+			hooksDir := t.TempDir()
+			// Fail the owned Git process after it releases the prepared ref lock.
+			hook := `#!/bin/sh
+if [ "$1" = aborted ]; then
+    echo 'fatal: cannot lock references' >&2
+    kill -TERM "$PPID"
+fi
+`
+			require.NoError(t, os.WriteFile(filepath.Join(hooksDir, "reference-transaction"), []byte(hook), 0o755))
+			gitenv.Run(t, repoDir, "config", "core.hooksPath", hooksDir)
+
+			err := CompareAndSwapRef(t.Context(), repoDir, plumbing.HEAD, plumbing.NewHash(initial), plumbing.NewHash(replacement))
+			require.ErrorIs(t, err, ErrRefSymbolic)
+			require.ErrorContains(t, err, "cannot lock references", "retain the abort failure diagnosis")
+			require.NotErrorIs(t, err, ErrRefLocked, "cleanup must not make symbolic-ref rejection retryable")
+			require.NotErrorIs(t, err, ErrRefCASConflict)
+			require.Equal(t, "refs/heads/main", strings.TrimSpace(gitenv.Run(t, repoDir, "symbolic-ref", "HEAD")))
+			require.Equal(t, replacement, strings.TrimSpace(gitenv.Run(t, repoDir, "rev-parse", "HEAD")))
+
+			require.NoError(t, CompareAndSwapRef(t.Context(), repoDir, plumbing.NewBranchReferenceName("main"), plumbing.NewHash(initial), plumbing.NewHash(replacement)))
+			require.Equal(t, initial, strings.TrimSpace(gitenv.Run(t, repoDir, "rev-parse", "HEAD")))
 		})
 	}
 }


### PR DESCRIPTION
Follow-up to [the final review of #2211](https://github.com/entireio/cli/pull/2211#pullrequestreview-5125910758).

A symbolic-ref rejection from `CompareAndSwapRef` could also match `ErrRefLocked` if aborting the prepared transaction failed with lock contention. This change keeps the rejection's error identity and preserves the cleanup failure as diagnostic text.

## The bug

The helper prepares a native Git transaction before checking whether the target is symbolic, so the ref cannot change between inspection and update. If the target is symbolic, it rejects the update and aborts the transaction.

Previously, `errors.Join(symbolicErr, tx.abort())` exposed both failures through `errors.Is`. A lock error during cleanup therefore made a permanent rejection look retryable to a caller checking `ErrRefLocked`.

The current checkpoint callers already check `ErrRefSymbolic` before retrying. The reported 16 retries are prevented there; the remaining problem is that the helper requires callers to know which of its two error classifications takes priority.

## The fix

Wrap only the symbolic-ref rejection. If abort fails, append its message without wrapping that error. The transaction still gets aborted, and the cleanup diagnosis remains visible, but it cannot add a retryable sentinel to the returned error.

## Verification

The regression exercises real Git transactions on both files and reftable repositories. A temporary repository's abort hook emits a lock-error diagnostic and terminates its owning Git process, forcing the cleanup failure. Both backends fail the regression before the fix.

After the fix, the test verifies that the error matches `ErrRefSymbolic` but neither retry sentinel, retains the cleanup diagnostic, preserves symbolic `HEAD` and its target commit, and permits a subsequent direct-ref update. The signal-based fault injection is skipped on Windows.

- The focused regression passed three consecutive runs with race detection.
- `mise run check` passed: formatting, lint, race-enabled unit and integration tests, 56 Vogon canaries, and 4 Roger canaries.
- Pre-push `mise run lint` passed with zero issues.
