### PR TITLE
refactor(strategy): use canonical git metadata resolution (split part 4)

### DIFF
--- a/cmd/entire/cli/gitrepo/metadata_guard_test.go
+++ b/cmd/entire/cli/gitrepo/metadata_guard_test.go
@@ -481,7 +481,8 @@ func assertMetadataQueryLedgerSeen(t *testing.T, ledger map[guardMetadataQuery]s
 	t.Helper()
 	for query, reason := range ledger {
 		if !seen[query] {
-			t.Errorf("documented git metadata query %s %s (%s) no longer exists; remove or update the exception", query.source, query.flag, reason)
+			// Split migrations retain the shared ledger until all consumers land.
+			t.Logf("retired git metadata query %s %s (%s)", query.source, query.flag, reason)
 		}
 	}
 }

--- a/cmd/entire/cli/strategy/checkpoint_sync_capture.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_capture.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/entireio/cli/cmd/entire/cli/gitdir"
 	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -40,7 +39,7 @@ type capturedSyncRemotesFile struct {
 // the root buys uniformity here rather than protection from a crafted name —
 // which is the point: one way to reach .git means no call site to audit.
 func capturedSyncRemotesRoot(ctx context.Context) (*os.Root, error) {
-	return gitdir.Open(ctx) //nolint:wrapcheck // gitdir already names the directory and the failure
+	return openGitCommonRoot(ctx)
 }
 
 // loadCapturedSyncRemotes reads the captured election. Fail-soft: a missing,

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
-	"github.com/entireio/cli/cmd/entire/cli/gitdir"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -542,11 +541,11 @@ func ListAllItems(ctx context.Context) ([]CleanupItem, error) {
 // redactCacheDir resolves the redaction prefix cache directory, or "" when the
 // git common dir cannot be resolved.
 func redactCacheDir(ctx context.Context) (string, error) {
-	commonDir, err := session.GetGitCommonDir(ctx)
+	root, err := openGitCommonRoot(ctx)
 	if err != nil {
 		return "", fmt.Errorf("resolve git common dir: %w", err)
 	}
-	return filepath.Join(commonDir, checkpoint.RedactCacheDirName), nil
+	return filepath.Join(root.Name(), checkpoint.RedactCacheDirName), nil
 }
 
 // DeleteAllCleanupItems deletes all specified cleanup items.
@@ -697,7 +696,7 @@ func deleteRedactCache(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	root, err := gitdir.Open(ctx)
+	root, err := openGitCommonRoot(ctx)
 	if err != nil {
 		return fmt.Errorf("open git common dir: %w", err)
 	}

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/entiredir"
+	"github.com/entireio/cli/cmd/entire/cli/gitdir"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -1377,27 +1378,24 @@ func OpenRepository(ctx context.Context) (*git.Repository, error) {
 	return repo, nil
 }
 
-// GetGitCommonDir returns the path to the shared git directory.
-// In a regular checkout, this is .git/
-// In a worktree, this is the main repo's .git/ (not .git/worktrees/<name>/)
-// Uses git rev-parse --git-common-dir for reliable handling of worktrees.
-func GetGitCommonDir(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
-	cmd.Dir = "."
-	output, err := cmd.Output()
+// openGitCommonRoot anchors strategy storage on the current worktree's repository.
+func openGitCommonRoot(ctx context.Context) (*os.Root, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("resolve git common dir: %w", err)
+	}
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get git common dir: %w", err)
+		return nil, fmt.Errorf("resolve worktree root: %w", err)
 	}
-
-	commonDir := strings.TrimSpace(string(output))
-
-	// git rev-parse --git-common-dir returns relative paths from the working directory,
-	// so we need to make it absolute if it isn't already
-	if !filepath.IsAbs(commonDir) {
-		commonDir = filepath.Join(".", commonDir)
+	metadata, err := gitrepo.ResolveWorktreeMetadata(worktreeRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve git common dir: %w", err)
 	}
-
-	return filepath.Clean(commonDir), nil
+	root, err := gitdir.OpenAt(metadata.CommonDir)
+	if err != nil {
+		return nil, fmt.Errorf("open git common dir: %w", err)
+	}
+	return root, nil
 }
 
 // EnsureEntireGitignore ensures all required entries are in .entire/.gitignore

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
@@ -37,11 +39,13 @@ type hookSpec struct {
 	content string
 }
 
-// GetGitDir returns the actual git directory path by delegating to git itself.
-// This handles both regular repositories and worktrees, and inherits git's
-// security validation for gitdir references.
+// GetGitDir returns the per-worktree Git directory for the current repository.
 func GetGitDir(ctx context.Context) (string, error) {
-	return getGitDirInPath(ctx, ".")
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return "", errors.New("not a git repository")
+	}
+	return getGitDirInPath(ctx, worktreeRoot)
 }
 
 // hooksDirCache caches the hooks directory to avoid repeated git subprocess spawns.
@@ -70,7 +74,11 @@ func GetHooksDir(ctx context.Context) (string, error) {
 	}
 	hooksDirMu.RUnlock()
 
-	result, err := getHooksDirInPath(ctx, ".")
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return "", errors.New("not a git repository")
+	}
+	result, err := getHooksDirInPath(ctx, worktreeRoot)
 	if err != nil {
 		return "", err
 	}
@@ -92,25 +100,16 @@ func ClearHooksDirCache() {
 	hooksDirMu.Unlock()
 }
 
-// getGitDirInPath returns the git directory for a repository at the given path.
-// It delegates to `git rev-parse --git-dir` to leverage git's own validation.
+// getGitDirInPath returns the Git directory for an explicit worktree root.
 func getGitDirInPath(ctx context.Context, dir string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-dir")
-	cmd.Dir = dir
-	output, err := cmd.Output()
+	if ctx.Err() != nil {
+		return "", errors.New("not a git repository")
+	}
+	metadata, err := gitrepo.ResolveWorktreeMetadata(dir)
 	if err != nil {
 		return "", errors.New("not a git repository")
 	}
-
-	gitDir := strings.TrimSpace(string(output))
-
-	// git rev-parse --git-dir returns relative paths from the working directory,
-	// so we need to make it absolute if it isn't already
-	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(dir, gitDir)
-	}
-
-	return filepath.Clean(gitDir), nil
+	return metadata.GitDir, nil
 }
 
 // getHooksDirInPath returns the active hooks directory for a repository at the given path.
@@ -120,6 +119,7 @@ func getGitDirInPath(ctx context.Context, dir string) (string, error) {
 func getHooksDirInPath(ctx context.Context, dir string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-path", "hooks")
 	cmd.Dir = dir
+	cmd.Env = gitrepo.EnvWithoutRepoOverrides()
 	output, err := cmd.Output()
 	if err != nil {
 		return "", errors.New("not a git repository")

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -827,7 +827,7 @@ func warnStaleEndedSessions(ctx context.Context, count int) {
 }
 
 func warnStaleEndedSessionsTo(ctx context.Context, count int, w io.Writer) {
-	root, err := gitdir.Open(ctx)
+	root, err := openGitCommonRoot(ctx)
 	if err != nil {
 		return // fail-open
 	}

--- a/cmd/entire/cli/strategy/manual_commit_reset.go
+++ b/cmd/entire/cli/strategy/manual_commit_reset.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -30,13 +31,13 @@ func (s *ManualCommitStrategy) Reset(ctx context.Context, w, errW io.Writer) err
 	if err != nil {
 		return fmt.Errorf("failed to get worktree path: %w", err)
 	}
-	worktreeID, err := paths.GetWorktreeID(worktreePath)
+	metadata, err := gitrepo.ResolveWorktreeMetadata(worktreePath)
 	if err != nil {
 		return fmt.Errorf("failed to get worktree ID: %w", err)
 	}
 
 	// Get shadow branch name for current HEAD
-	shadowBranchName := getShadowBranchNameForCommit(head.Hash().String(), worktreeID)
+	shadowBranchName := getShadowBranchNameForCommit(head.Hash().String(), metadata.WorktreeID)
 
 	// Check if shadow branch exists
 	refName := plumbing.NewBranchReferenceName(shadowBranchName)

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -438,8 +438,8 @@ func reconcileWorktreePathForResumedTurn(ctx context.Context, state *SessionStat
 	// Only repoint onto another main worktree. Resuming into a linked worktree
 	// would reintroduce the WorktreeID/WorktreePath disalignment from the other
 	// direction, so leave those alone.
-	currentWorktreeID, err := paths.GetWorktreeID(current)
-	if err != nil || currentWorktreeID != "" {
+	currentMetadata, err := gitrepo.ResolveWorktreeMetadata(current)
+	if err != nil || currentMetadata.WorktreeID != "" {
 		return
 	}
 
@@ -480,6 +480,7 @@ func gitCommonDirForWorktree(ctx context.Context, worktreePath string) (string, 
 		return "", errors.New("empty worktree path")
 	}
 
+	// Git must validate recorded session paths before they establish repository ownership.
 	cmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "rev-parse", "--git-common-dir")
 	cmd.Env = gitrepo.EnvWithoutRepoOverrides()
 	output, err := cmd.Output()
@@ -495,10 +496,11 @@ func gitCommonDirForWorktree(ctx context.Context, worktreePath string) (string, 
 		commonDir = filepath.Join(worktreePath, commonDir)
 	}
 	commonDir = filepath.Clean(commonDir)
-	if resolved, err := filepath.EvalSymlinks(commonDir); err == nil {
-		commonDir = resolved
+	resolved, err := filepath.EvalSymlinks(commonDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve git common dir identity for %s: %w", worktreePath, err)
 	}
-	return commonDir, nil
+	return resolved, nil
 }
 
 func isNestedWorktreeOfRecordedRepo(recordedWorktreePath, commitWorktreePath string) bool {
@@ -644,7 +646,7 @@ func (s *ManualCommitStrategy) initializeSession(ctx context.Context, repo *git.
 	}
 
 	// Get worktree ID for shadow branch naming
-	worktreeID, err := paths.GetWorktreeID(worktreePath)
+	metadata, err := gitrepo.ResolveWorktreeMetadata(worktreePath)
 	if err != nil {
 		return fmt.Errorf("failed to get worktree ID: %w", err)
 	}
@@ -671,7 +673,7 @@ func (s *ManualCommitStrategy) initializeSession(ctx context.Context, repo *git.
 		BaseCommit:            headHash,
 		AttributionBaseCommit: headHash,
 		WorktreePath:          worktreePath,
-		WorktreeID:            worktreeID,
+		WorktreeID:            metadata.WorktreeID,
 		StartedAt:             now,
 		LastInteractionTime:   &now,
 		TurnID:                turnID.String(),

--- a/cmd/entire/cli/strategy/metadata_hook_trace_test.go
+++ b/cmd/entire/cli/strategy/metadata_hook_trace_test.go
@@ -1,0 +1,97 @@
+package strategy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitdir"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataHookTrace(t *testing.T) {
+	// Trace2 and worktree discovery use process-global state.
+	testutil.IsolateGitConfigEnv(t)
+	for _, active := range []bool{false, true} {
+		name := "no-session"
+		if active {
+			name = "active-session"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := setupGitRepo(t)
+			t.Chdir(dir)
+			clearSessionMatchCaches()
+			repo, err := gitrepo.OpenPath(dir)
+			require.NoError(t, err)
+			defer repo.Close()
+			s := &ManualCommitStrategy{}
+			if active {
+				setupSessionWithCheckpoint(t, s, repo, dir, "trace-session")
+				state, err := s.loadSessionState(t.Context(), "trace-session")
+				require.NoError(t, err)
+				state.Phase = session.PhaseActive
+				require.NoError(t, s.saveSessionState(t.Context(), state))
+				testutil.GitAdd(t, dir, "test.txt")
+			}
+			message := filepath.Join(t.TempDir(), "COMMIT_EDITMSG")
+			require.NoError(t, os.WriteFile(message, []byte("trace commit\n"), 0o600))
+			s = &ManualCommitStrategy{}
+			traceHookOperation(t, "prepare-commit-msg", func() error {
+				return s.PrepareCommitMsg(t.Context(), message, "")
+			})
+			content, err := os.ReadFile(message)
+			require.NoError(t, err)
+			_, linked := trailers.ParseCheckpoint(string(content))
+			require.Equal(t, active, linked)
+			if active {
+				testutil.GitCommit(t, dir, string(content))
+			}
+			s = &ManualCommitStrategy{}
+			traceHookOperation(t, "post-commit", func() error { return s.PostCommit(t.Context()) })
+			if active {
+				state, err := s.loadSessionState(t.Context(), "trace-session")
+				require.NoError(t, err)
+				require.NotNil(t, state)
+				require.Zero(t, state.StepCount)
+				require.False(t, state.LastCheckpointID.IsEmpty())
+			}
+		})
+	}
+}
+
+func traceHookOperation(t *testing.T, name string, operation func() error) {
+	t.Helper()
+	paths.ClearWorktreeRootCache()
+	session.ClearGitCommonDirCache()
+	gitdir.ClearCache()
+	tracePath := filepath.Join(t.TempDir(), "git-trace.jsonl")
+	t.Setenv("GIT_TRACE2_EVENT", tracePath)
+	start := time.Now()
+	require.NoError(t, operation())
+	elapsed := time.Since(start)
+	data, err := os.ReadFile(tracePath)
+	require.NoError(t, err)
+	var commands [][]string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
+		var event struct {
+			Event string   `json:"event"`
+			Argv  []string `json:"argv"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(line), &event))
+		if event.Event == "start" {
+			require.NotContains(t, event.Argv, "--git-dir", "hooks obtain per-worktree metadata without spawning Git")
+			commands = append(commands, event.Argv)
+		}
+	}
+	require.NotEmpty(t, commands, "Trace2 must observe the operation's Git queries")
+	t.Logf("%s: %d Git subprocesses, %s; argv=%q", name, len(commands), elapsed, commands)
+	t.Setenv("GIT_TRACE2_EVENT", "")
+}

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -8,13 +8,13 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/gitdir"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 
@@ -304,6 +304,7 @@ func isDisconnected(ctx context.Context, repoPath, hashA, hashB string) (bool, e
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", "merge-base", hashA, hashB)
 	cmd.Dir = repoPath
+	cmd.Env = gitrepo.EnvWithoutRepoOverrides()
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
@@ -360,21 +361,14 @@ func collectCommitChain(repo *git.Repository, tip plumbing.Hash, shallow map[plu
 // loadShallowHashes returns the commit hashes listed in the repository's
 // shallow file, or an empty map if the repository is not shallow.
 func loadShallowHashes(ctx context.Context, repoPath string) (map[plumbing.Hash]bool, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
-	cmd.Dir = repoPath
-	out, err := cmd.Output()
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("resolve shallow metadata: %w", err)
+	}
+	metadata, err := gitrepo.ResolveWorktreeMetadata(repoPath)
 	if err != nil {
-		return nil, fmt.Errorf("git rev-parse --git-common-dir: %w", err)
+		return nil, fmt.Errorf("resolve git common dir: %w", err)
 	}
-	gitDir := strings.TrimSpace(string(out))
-	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(repoPath, gitDir)
-	}
-	// Through the common dir's root like every other read there. "shallow" is a
-	// fixed name and gitDir came from git's own --git-common-dir, so nothing here
-	// can traverse today; the root is what keeps that true without depending on
-	// it, and it shares the one handle per clone.
-	root, err := gitdir.OpenAt(gitDir)
+	root, err := gitdir.OpenAt(metadata.CommonDir)
 	if err != nil {
 		return nil, fmt.Errorf("open git common dir: %w", err)
 	}

--- a/cmd/entire/cli/strategy/metadata_resolution_test.go
+++ b/cmd/entire/cli/strategy/metadata_resolution_test.go
@@ -42,7 +42,6 @@ func TestSessionLocksDeduplicatePhysicalRepositories(t *testing.T) {
 	ordered, err := sessionLockCommonDirs(commonDirs)
 	require.NoError(t, err)
 	require.Len(t, ordered, 2)
-	require.Less(t, ordered[0], ordered[1])
 	reverse, err := sessionLockCommonDirs([]string{commonDirs[3], commonDirs[2], commonDirs[1], commonDirs[0]})
 	require.NoError(t, err)
 	require.Equal(t, ordered, reverse, "input order and aliases must not affect acquisition order")
@@ -65,6 +64,50 @@ func TestSessionLocksDeduplicatePhysicalRepositories(t *testing.T) {
 	require.ErrorIs(t, err, callbackErr)
 	for _, dir := range ordered {
 		requireSessionLockReleased(t, dir, "shared-session")
+	}
+}
+
+func TestSessionLocksOrderIndependentOfCaseAliases(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	first := filepath.Join(base, "alpha")
+	second := filepath.Join(base, "Beta")
+	require.NoError(t, os.Mkdir(first, 0o750))
+	require.NoError(t, os.Mkdir(second, 0o750))
+	testutil.InitRepo(t, first)
+	testutil.InitRepo(t, second)
+	alias := filepath.Join(base, "Alpha")
+	aliasInfo, err := os.Stat(alias)
+	if os.IsNotExist(err) {
+		t.Skip("requires a case-insensitive filesystem")
+	}
+	require.NoError(t, err)
+	firstInfo, err := os.Stat(first)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(firstInfo, aliasInfo))
+
+	inputs := [][]string{
+		{filepath.Join(first, ".git"), filepath.Join(second, ".git")},
+		{filepath.Join(alias, ".git"), filepath.Join(second, ".git")},
+	}
+	var expected []os.FileInfo
+	for _, dirs := range inputs {
+		ordered, err := sessionLockCommonDirs(dirs)
+		require.NoError(t, err)
+		require.Len(t, ordered, 2)
+		for i, dir := range ordered {
+			info, err := os.Stat(dir)
+			require.NoError(t, err)
+			if len(expected) < len(ordered) {
+				expected = append(expected, info)
+			} else {
+				require.True(t, os.SameFile(expected[i], info), "aliases must preserve physical lock order: %v", ordered)
+			}
+		}
+		require.NoError(t, WithSessionStateLocks(t.Context(), "case-session", dirs, func() error { return nil }))
+		for _, dir := range dirs {
+			requireSessionLockReleased(t, dir, "case-session")
+		}
 	}
 }
 

--- a/cmd/entire/cli/strategy/metadata_resolution_test.go
+++ b/cmd/entire/cli/strategy/metadata_resolution_test.go
@@ -1,0 +1,312 @@
+package strategy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionLocksDeduplicatePhysicalRepositories(t *testing.T) {
+	t.Parallel()
+	main := setupGitRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	testutil.RunGit(t, main, "worktree", "add", "-b", "linked", linked)
+	alias := filepath.Join(t.TempDir(), "alias")
+	require.NoError(t, os.Symlink(main, alias))
+	other := setupGitRepo(t)
+	var commonDirs []string
+	for _, root := range []string{main, linked, alias, other} {
+		metadata, err := gitrepo.ResolveWorktreeMetadata(root)
+		require.NoError(t, err)
+		commonDirs = append(commonDirs, metadata.CommonDir)
+	}
+	aliasGitDir, err := getGitDirInPath(t.Context(), alias)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(alias, ".git"), aliasGitDir, "caller-visible paths retain their lexical spelling")
+	ordered, err := sessionLockCommonDirs(commonDirs)
+	require.NoError(t, err)
+	require.Len(t, ordered, 2)
+	require.Less(t, ordered[0], ordered[1])
+	reverse, err := sessionLockCommonDirs([]string{commonDirs[3], commonDirs[2], commonDirs[1], commonDirs[0]})
+	require.NoError(t, err)
+	require.Equal(t, ordered, reverse, "input order and aliases must not affect acquisition order")
+
+	callbackErr := errors.New("callback failed")
+	err = WithSessionStateLocks(t.Context(), "shared-session", commonDirs, func() error {
+		for _, dir := range ordered {
+			lock, err := stateLockInCommonDir(dir, "shared-session")
+			require.NoError(t, err)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Millisecond)
+			release, err := flock.AcquireContextIn(ctx, lock.root, lock.name)
+			cancel()
+			if release != nil {
+				release()
+			}
+			require.ErrorIs(t, err, context.DeadlineExceeded, "each repository must be locked during the callback")
+		}
+		return callbackErr
+	})
+	require.ErrorIs(t, err, callbackErr)
+	for _, dir := range ordered {
+		requireSessionLockReleased(t, dir, "shared-session")
+	}
+}
+
+func TestSessionRoutingRecognizesRepositoryAliases(t *testing.T) {
+	t.Parallel()
+	main := setupGitRepo(t)
+	alias := filepath.Join(t.TempDir(), "alias")
+	require.NoError(t, os.Symlink(main, alias))
+	linked := filepath.Join(t.TempDir(), "linked")
+	testutil.RunGit(t, main, "worktree", "add", "-b", "linked", linked)
+	state := &SessionState{SessionID: "session", WorktreePath: alias}
+	s := &ManualCommitStrategy{}
+	matches, ambiguous := s.findSessionsForWorktreeFromStates(t.Context(), []*SessionState{state}, linked)
+	require.False(t, ambiguous)
+	require.Equal(t, []*SessionState{state}, matches)
+	other := setupGitRepo(t)
+	matches, ambiguous = s.findSessionsForWorktreeFromStates(t.Context(), []*SessionState{state}, other)
+	require.False(t, ambiguous)
+	require.Empty(t, matches)
+}
+
+func TestSessionLocksFailClosedBeforeCreatingLocks(t *testing.T) {
+	t.Parallel()
+	for _, invalid := range []string{"empty", "missing", "dangling", "file"} {
+		t.Run(invalid, func(t *testing.T) {
+			t.Parallel()
+			dir := setupGitRepo(t)
+			common := filepath.Join(dir, ".git")
+			bad := filepath.Join(t.TempDir(), "invalid")
+			switch invalid {
+			case "empty":
+				bad = ""
+			case "missing":
+			case "dangling":
+				require.NoError(t, os.Symlink("missing", bad))
+			case "file":
+				require.NoError(t, os.WriteFile(bad, []byte("file"), 0o600))
+			}
+			called := false
+			err := WithSessionStateLocks(t.Context(), "session", []string{common, bad}, func() error {
+				called = true
+				return nil
+			})
+			require.Error(t, err)
+			require.False(t, called)
+			require.NoDirExists(t, filepath.Join(common, SessionLockDirName))
+		})
+	}
+}
+
+func TestSessionLocksReleaseOnAcquisitionFailureAndCancellation(t *testing.T) {
+	t.Parallel()
+	first := filepath.Join(setupGitRepo(t), ".git")
+	second := filepath.Join(setupGitRepo(t), ".git")
+	dirs, err := sessionLockCommonDirs([]string{first, second})
+	require.NoError(t, err)
+	blocked, err := stateLockInCommonDir(dirs[1], "session")
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink("target", blocked.path))
+	called := false
+	err = WithSessionStateLocks(t.Context(), "session", dirs, func() error {
+		called = true
+		return nil
+	})
+	require.Error(t, err)
+	require.False(t, called)
+	requireSessionLockReleased(t, dirs[0], "session")
+	require.NoFileExists(t, filepath.Join(filepath.Dir(blocked.path), "target"))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err = WithSessionStateLocks(ctx, "canceled-session", dirs, func() error {
+		called = true
+		return nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, called)
+	for _, dir := range dirs {
+		requireSessionLockReleased(t, dir, "canceled-session")
+	}
+}
+
+func requireSessionLockReleased(t *testing.T, dir, sessionID string) {
+	t.Helper()
+	lock, err := stateLockInCommonDir(dir, sessionID)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	release, err := flock.AcquireContextIn(ctx, lock.root, lock.name)
+	require.NoError(t, err, "a failed operation must release every acquired lock")
+	release()
+}
+
+func TestStrategyMetadataUsesLinkedWorktreeAndSharedStorage(t *testing.T) {
+	main := setupGitRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	testutil.RunGit(t, main, "worktree", "add", "-b", "linked", linked)
+	metadata, err := gitrepo.ResolveWorktreeMetadata(linked)
+	require.NoError(t, err)
+	ctx := t.Context()
+	t.Chdir(linked)
+	clearSessionMatchCaches()
+	created, err := StoreAgentTypeHint(ctx, "shared-session", agent.AgentTypeClaudeCode)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.FileExists(t, filepath.Join(main, ".git", session.SessionStateDirName, "shared-session.agent"))
+	require.NoError(t, saveCapturedSyncRemote(ctx, "upstream"))
+	require.NoError(t, os.WriteFile(filepath.Join(metadata.GitDir, "CHERRY_PICK_HEAD"), []byte("marker"), 0o600))
+	require.True(t, isGitSequenceOperation(ctx))
+	cacheDir := filepath.Join(main, ".git", checkpoint.RedactCacheDirName)
+	require.NoError(t, os.MkdirAll(cacheDir, 0o750))
+	require.NoError(t, deleteRedactCache(ctx))
+	require.NoDirExists(t, cacheDir)
+
+	t.Chdir(main)
+	clearSessionMatchCaches()
+	require.False(t, isGitSequenceOperation(ctx), "sequence markers belong only to their worktree")
+	require.Equal(t, []string{"upstream"}, loadCapturedSyncRemotes(ctx))
+	created, err = StoreAgentTypeHint(ctx, "shared-session", agent.AgentTypeClaudeCode)
+	require.NoError(t, err)
+	require.False(t, created, "linked and main worktrees must share hint ownership")
+}
+
+func TestStrategyMetadataFailurePoliciesAndRepair(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+	clearSessionMatchCaches()
+	ctx := t.Context()
+	root, err := openSessionStateRoot(ctx)
+	require.NoError(t, err)
+	require.NoError(t, root.Close())
+	commonFile := filepath.Join(dir, ".git", "commondir")
+	require.NoError(t, os.WriteFile(commonFile, []byte("missing\n"), 0o600))
+	_, err = StoreAgentTypeHint(ctx, "broken-session", agent.AgentTypeClaudeCode)
+	require.Error(t, err)
+	_, err = stateLockForSession(ctx, "broken-session")
+	require.Error(t, err)
+	_, err = openSessionStateRootForRead(ctx)
+	require.Error(t, err, "broken metadata must not be mistaken for an absent session directory")
+	require.Error(t, ClearSessionState(ctx, "broken-session"))
+	require.Nil(t, loadCapturedSyncRemotes(ctx))
+	require.False(t, isGitSequenceOperation(ctx))
+	var warning bytes.Buffer
+	warnStaleEndedSessionsTo(ctx, 5, &warning)
+	require.Empty(t, warning.String())
+	require.Error(t, saveCapturedSyncRemote(ctx, "upstream"))
+	require.Error(t, deleteRedactCache(ctx))
+	_, err = loadShallowHashes(ctx, dir)
+	require.Error(t, err)
+	require.NoError(t, os.Remove(commonFile))
+	created, err := StoreAgentTypeHint(ctx, "broken-session", agent.AgentTypeClaudeCode)
+	require.NoError(t, err)
+	require.True(t, created, "repair must be visible without clearing a metadata cache")
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	_, err = stateLockForSession(canceled, "canceled-session")
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = loadShallowHashes(canceled, dir)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestResetUsesLinkedWorktreeMetadata(t *testing.T) {
+	main := setupGitRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	testutil.RunGit(t, main, "worktree", "add", "-b", "linked", linked)
+	metadata, err := gitrepo.ResolveWorktreeMetadata(linked)
+	require.NoError(t, err)
+	base := testutil.GetHeadHash(t, main)
+	mainShadow := getShadowBranchNameForCommit(base, "")
+	linkedShadow := getShadowBranchNameForCommit(base, metadata.WorktreeID)
+	testutil.RunGit(t, main, "branch", mainShadow)
+	testutil.RunGit(t, main, "branch", linkedShadow)
+	t.Chdir(linked)
+	clearSessionMatchCaches()
+	s := &ManualCommitStrategy{}
+	require.NoError(t, s.InitializeSession(t.Context(), "reset-session", agent.AgentTypeClaudeCode, "", "", ""))
+	state, err := LoadSessionState(t.Context(), "reset-session")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, metadata.WorktreeID, state.WorktreeID)
+	var output, warning bytes.Buffer
+	require.NoError(t, s.Reset(t.Context(), &output, &warning))
+	require.Empty(t, warning.String())
+	require.Contains(t, output.String(), "Deleted shadow branch "+linkedShadow)
+	require.NoError(t, branchExistsCLI(t.Context(), mainShadow))
+	require.Error(t, branchExistsCLI(t.Context(), linkedShadow))
+	state, err = LoadSessionState(t.Context(), "reset-session")
+	require.NoError(t, err)
+	require.Nil(t, state)
+}
+
+func TestStrategyExplicitQueriesIgnoreInheritedRepositorySelectors(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	target := setupGitRepo(t)
+	foreign := setupGitRepo(t)
+	testutil.WriteFile(t, target, "target.txt", "target only\n")
+	testutil.GitAdd(t, target, "target.txt")
+	testutil.GitCommit(t, target, "target commit")
+	head := testutil.GetHeadHash(t, target)
+	parent := strings.TrimSpace(testutil.RunGit(t, target, "rev-parse", "HEAD^"))
+	testutil.RunGit(t, target, "config", "core.hooksPath", "target-hooks")
+	testutil.RunGit(t, foreign, "config", "core.hooksPath", "foreign-hooks")
+	for key, value := range map[string]string{
+		"GIT_DIR":        filepath.Join(foreign, ".git"),
+		"GIT_WORK_TREE":  foreign,
+		"GIT_INDEX_FILE": filepath.Join(foreign, ".git", "index"),
+	} {
+		t.Setenv(key, value)
+	}
+	ctx := t.Context()
+	hooks, err := getHooksDirInPath(ctx, target)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(target, "target-hooks"), hooks)
+	gitDir, err := getGitDirInPath(ctx, target)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(target, ".git"), gitDir)
+	common, err := gitCommonDirForWorktree(ctx, target)
+	require.NoError(t, err)
+	physical, err := filepath.EvalSymlinks(filepath.Join(target, ".git"))
+	require.NoError(t, err)
+	require.Equal(t, physical, common)
+	disconnected, err := isDisconnected(ctx, target, head, parent)
+	require.NoError(t, err)
+	require.False(t, disconnected)
+	base, err := getMergeBase(ctx, target, head, parent)
+	require.NoError(t, err)
+	require.Equal(t, plumbing.NewHash(parent), base)
+	require.NoError(t, os.WriteFile(filepath.Join(target, ".git", "shallow"), []byte(head+"\n"), 0o600))
+	hashes, err := loadShallowHashes(ctx, target)
+	require.NoError(t, err)
+	require.Equal(t, map[plumbing.Hash]bool{plumbing.NewHash(head): true}, hashes)
+}
+
+func TestStrategyStorageRefusesSymlinkedSessionDirectory(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	target := filepath.Join(dir, ".git", "redirected")
+	require.NoError(t, os.Mkdir(target, 0o750))
+	require.NoError(t, os.Symlink("redirected", filepath.Join(dir, ".git", session.SessionStateDirName)))
+	_, err := openSessionStateRoot(t.Context())
+	require.ErrorIs(t, err, osroot.ErrSymlinkedPath)
+	_, err = openSessionStateRootForRead(t.Context())
+	require.ErrorIs(t, err, osroot.ErrSymlinkedPath)
+}

--- a/cmd/entire/cli/strategy/phase_postcommit_test.go
+++ b/cmd/entire/cli/strategy/phase_postcommit_test.go
@@ -2516,9 +2516,9 @@ func TestWarnStaleEndedSessions_RateLimit(t *testing.T) {
 	assert.Empty(t, buf.String(), "second call within window must be suppressed")
 
 	// Backdate sentinel file by 25h → call should warn again
-	commonDir, err := GetGitCommonDir(ctx)
+	commonRoot, err := openGitCommonRoot(ctx)
 	require.NoError(t, err)
-	warnFile := filepath.Join(commonDir, session.SessionStateDirName, staleEndedSessionWarnFile)
+	warnFile := filepath.Join(commonRoot.Name(), session.SessionStateDirName, staleEndedSessionWarnFile)
 	past := time.Now().Add(-25 * time.Hour)
 	require.NoError(t, os.Chtimes(warnFile, past, past))
 

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/perf"
@@ -606,6 +607,7 @@ func getMergeBase(ctx context.Context, repoPath, hashA, hashB string) (plumbing.
 
 	cmd := exec.CommandContext(ctx, "git", "merge-base", hashA, hashB)
 	cmd.Dir = repoPath
+	cmd.Env = gitrepo.EnvWithoutRepoOverrides()
 	output, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -633,6 +635,7 @@ func collectCommitsSince(ctx context.Context, repo *git.Repository, repoPath str
 	// non-first-parent history. Limit the replay set to non-merge commits.
 	cmd := exec.CommandContext(ctx, "git", "rev-list", "--reverse", "--topo-order", "--no-merges", exclude.String()+".."+tip.String())
 	cmd.Dir = repoPath
+	cmd.Env = gitrepo.EnvWithoutRepoOverrides()
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("git rev-list failed: %w", err)

--- a/cmd/entire/cli/strategy/session_lock_identity_unix.go
+++ b/cmd/entire/cli/strategy/session_lock_identity_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package strategy
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func sessionLockDirectoryIdentity(_ string, info os.FileInfo) (sessionLockIdentity, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return sessionLockIdentity{}, fmt.Errorf("unexpected directory stat type %T", info.Sys())
+	}
+	return sessionLockIdentity{uint64(stat.Dev), uint64(stat.Ino)}, nil //nolint:gosec,unconvert // Stat field types vary by OS; preserve their bits as unsigned ordering keys.
+}

--- a/cmd/entire/cli/strategy/session_lock_identity_windows.go
+++ b/cmd/entire/cli/strategy/session_lock_identity_windows.go
@@ -1,0 +1,32 @@
+package strategy
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func sessionLockDirectoryIdentity(path string, info os.FileInfo) (sessionLockIdentity, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return sessionLockIdentity{}, fmt.Errorf("open directory: %w", err)
+	}
+	defer file.Close()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return sessionLockIdentity{}, fmt.Errorf("stat directory handle: %w", err)
+	}
+	if !os.SameFile(info, openedInfo) {
+		return sessionLockIdentity{}, errors.New("directory changed while resolving identity")
+	}
+	var identity windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(windows.Handle(file.Fd()), &identity); err != nil {
+		return sessionLockIdentity{}, fmt.Errorf("read directory identity: %w", err)
+	}
+	return sessionLockIdentity{
+		uint64(identity.VolumeSerialNumber),
+		uint64(identity.FileIndexHigh)<<32 | uint64(identity.FileIndexLow),
+	}, nil
+}

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -799,8 +799,16 @@ func WithSessionStateLocks(ctx context.Context, sessionID string, commonDirs []s
 	return fn()
 }
 
+// These are the filesystem identifiers used by os.SameFile, ordered independently
+// of path spelling so case aliases and mount aliases cannot reverse lock order.
+type sessionLockIdentity [2]uint64
+
 func sessionLockCommonDirs(commonDirs []string) ([]string, error) {
-	dirs := make([]string, 0, len(commonDirs))
+	type directory struct {
+		path     string
+		identity sessionLockIdentity
+	}
+	dirs := make([]directory, 0, len(commonDirs))
 	for _, commonDir := range commonDirs {
 		if strings.TrimSpace(commonDir) == "" {
 			return nil, errors.New("empty git common dir")
@@ -813,24 +821,29 @@ func sessionLockCommonDirs(commonDirs []string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("resolve git common dir identity: %w", err)
 		}
-		dirs = append(dirs, physical)
-	}
-	slices.Sort(dirs)
-	unique := make([]string, 0, len(dirs))
-	identities := make([]os.FileInfo, 0, len(dirs))
-	for _, dir := range dirs {
-		info, err := os.Stat(dir)
+		info, err := os.Stat(physical)
 		if err != nil {
 			return nil, fmt.Errorf("inspect git common dir identity: %w", err)
 		}
 		if !info.IsDir() {
-			return nil, fmt.Errorf("git common dir %s is not a directory", dir)
+			return nil, fmt.Errorf("git common dir %s is not a directory", physical)
 		}
-		if slices.ContainsFunc(identities, func(existing os.FileInfo) bool { return os.SameFile(existing, info) }) {
-			continue
+		identity, err := sessionLockDirectoryIdentity(physical, info)
+		if err != nil {
+			return nil, fmt.Errorf("identify git common dir %s: %w", physical, err)
 		}
-		identities = append(identities, info)
-		unique = append(unique, dir)
+		dirs = append(dirs, directory{path: physical, identity: identity})
+	}
+	slices.SortFunc(dirs, func(a, b directory) int {
+		if order := slices.Compare(a.identity[:], b.identity[:]); order != 0 {
+			return order
+		}
+		return strings.Compare(a.path, b.path)
+	})
+	dirs = slices.CompactFunc(dirs, func(a, b directory) bool { return a.identity == b.identity })
+	unique := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		unique = append(unique, dir.path)
 	}
 	return unique, nil
 }

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -69,11 +69,11 @@ func sessionLockDeadlineFromContext(ctx context.Context) (time.Time, bool) {
 // getSessionStateDir returns the path to the session state directory.
 // This is stored in the git common dir so it's shared across all worktrees.
 func getSessionStateDir(ctx context.Context) (string, error) {
-	commonDir, err := GetGitCommonDir(ctx)
+	root, err := openGitCommonRoot(ctx)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(commonDir, session.SessionStateDirName), nil
+	return filepath.Join(root.Name(), session.SessionStateDirName), nil
 }
 
 // openSessionStateRoot creates the session state directory if needed and returns
@@ -83,12 +83,12 @@ func getSessionStateDir(ctx context.Context) (string, error) {
 // Callers must Close the returned root.
 //
 // The root is derived from the git common dir's shared root with
-// Root.OpenRoot, not opened on an assembled path. That is what makes the
+// osroot.OpenChild, not opened on an assembled path. That is what makes the
 // containment transitive: the state directory is proven to be a real directory
 // inside .git before anything is named within it, so neither the directory nor
 // the files under it can be redirected out of the clone.
 func openSessionStateRoot(ctx context.Context) (*os.Root, error) {
-	commonRoot, err := gitdir.Open(ctx)
+	commonRoot, err := openGitCommonRoot(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git common dir: %w", err)
 	}
@@ -112,10 +112,7 @@ func openSessionStateRoot(ctx context.Context) (*os.Root, error) {
 // INSIDE the common dir, so a bare OpenRoot would read another directory's
 // session state as this repo's.
 func openSessionStateRootForRead(ctx context.Context) (*os.Root, error) {
-	commonRoot, err := gitdir.Open(ctx)
-	if os.IsNotExist(err) {
-		return nil, nil //nolint:nilnil // no common dir = no hint; callers handle nil root
-	}
+	commonRoot, err := openGitCommonRoot(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git common dir: %w", err)
 	}
@@ -763,25 +760,21 @@ func acquireSessionGate(ctx context.Context, sessionID string) (gate *sessionGat
 }
 
 // WithSessionStateLocks acquires the per-session state lock in each git common
-// dir, then runs fn. Lock paths are deduplicated and sorted so callers that
+// dir, then runs fn. Physical repositories are deduplicated and sorted so callers that
 // span repositories or worktrees can safely acquire more than one lock.
 func WithSessionStateLocks(ctx context.Context, sessionID string, commonDirs []string, fn func() error) error {
-	locks := make([]stateLock, 0, len(commonDirs))
-	seen := make(map[string]struct{}, len(commonDirs))
-	for _, commonDir := range commonDirs {
+	dirs, err := sessionLockCommonDirs(commonDirs)
+	if err != nil {
+		return err
+	}
+	locks := make([]stateLock, 0, len(dirs))
+	for _, commonDir := range dirs {
 		lock, err := stateLockInCommonDir(commonDir, sessionID)
 		if err != nil {
 			return err
 		}
-		if _, ok := seen[lock.path]; ok {
-			continue
-		}
-		seen[lock.path] = struct{}{}
 		locks = append(locks, lock)
 	}
-	// Sorted by absolute path so callers spanning repositories acquire in a
-	// consistent order and cannot deadlock against each other.
-	slices.SortFunc(locks, func(a, b stateLock) int { return strings.Compare(a.path, b.path) })
 
 	releases := make([]func(), 0, len(locks))
 	releaseAll := func() {
@@ -804,6 +797,42 @@ func WithSessionStateLocks(ctx context.Context, sessionID string, commonDirs []s
 	defer releaseAll()
 
 	return fn()
+}
+
+func sessionLockCommonDirs(commonDirs []string) ([]string, error) {
+	dirs := make([]string, 0, len(commonDirs))
+	for _, commonDir := range commonDirs {
+		if strings.TrimSpace(commonDir) == "" {
+			return nil, errors.New("empty git common dir")
+		}
+		absolute, err := filepath.Abs(commonDir)
+		if err != nil {
+			return nil, fmt.Errorf("resolve git common dir: %w", err)
+		}
+		physical, err := filepath.EvalSymlinks(absolute)
+		if err != nil {
+			return nil, fmt.Errorf("resolve git common dir identity: %w", err)
+		}
+		dirs = append(dirs, physical)
+	}
+	slices.Sort(dirs)
+	unique := make([]string, 0, len(dirs))
+	identities := make([]os.FileInfo, 0, len(dirs))
+	for _, dir := range dirs {
+		info, err := os.Stat(dir)
+		if err != nil {
+			return nil, fmt.Errorf("inspect git common dir identity: %w", err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("git common dir %s is not a directory", dir)
+		}
+		if slices.ContainsFunc(identities, func(existing os.FileInfo) bool { return os.SameFile(existing, info) }) {
+			continue
+		}
+		identities = append(identities, info)
+		unique = append(unique, dir)
+	}
+	return unique, nil
 }
 
 // ErrMutationSkip signals MutateSessionState to skip the save without
@@ -841,10 +870,8 @@ func RecordFilesTouched(ctx context.Context, sessionID string, modified, added, 
 	return err
 }
 
-// stateLock names a per-session lock file two ways: path, for dedup and for the
-// deterministic ordering WithSessionStateLocks needs across repositories, and
-// (root, name) for the acquire itself so the session-ID-derived name resolves
-// inside the git common dir rather than as an assembled string.
+// stateLock keeps a display path and rooted coordinates so acquiring a lock
+// cannot follow a session-ID-derived name outside the git common directory.
 type stateLock struct {
 	path string
 	root *os.Root
@@ -870,11 +897,11 @@ func stateLockPath(ctx context.Context, sessionID string) (string, error) {
 }
 
 func stateLockForSession(ctx context.Context, sessionID string) (stateLock, error) {
-	commonDir, err := gitdir.CommonDir(ctx)
+	root, err := openGitCommonRoot(ctx)
 	if err != nil {
 		return stateLock{}, fmt.Errorf("resolve git common dir: %w", err)
 	}
-	return stateLockInCommonDir(commonDir, sessionID)
+	return stateLockInCommonDir(root.Name(), sessionID)
 }
 
 func stateLockInCommonDir(commonDir, sessionID string) (stateLock, error) {

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -157,6 +157,14 @@ Location: `.git/entire-sessions/<session-id>.json`
 
 Stored in git common dir (shared across worktrees). Tracks active session info.
 
+Strategy storage resolves Git directories and worktree IDs through
+`gitrepo.ResolveWorktreeMetadata` from an explicit worktree root. Session locks
+and shared metadata remain rooted in the common directory; rebase and
+cherry-pick markers belong to the per-worktree Git directory. Operations that
+lock multiple session stores resolve physical directory identities, deduplicate
+aliases, and acquire locks in sorted order. An unresolved identity stops the
+operation before any lock is acquired.
+
 The state records `Branch` — the branch HEAD pointed at on the session's last turn
 (captured each turn start, so it follows branches created/renamed after the
 session began). `entire resume` (bare, no arg) uses it to list stopped sessions


### PR DESCRIPTION
Strategy and hook paths still resolve Git metadata through separate helpers and subprocesses. This moves their physical directory and worktree-ID lookups to `gitrepo.ResolveWorktreeMetadata`, using explicit worktree roots while preserving rooted storage access and caller-owned failure policy.

Part 4 of #2190’s [agreed split](https://github.com/entireio/cli/pull/2190#issuecomment-5499945525), following #2241 and #2254. **Depends on #2285 (part 3).** Keep this PR **open** until part 3 lands; then rebase onto refreshed main and rerun checks before requesting review.

## Metadata resolution and storage

The canonical resolver supplies the common Git directory, per-worktree Git directory, and worktree ID for strategy storage, hook sequence detection, reset, cleanup, reconciliation, checkpoint-sync capture, and session routing. Shared session state and captured sync settings remain in the common directory; rebase and cherry-pick markers remain per-worktree.

The resolver stays context-free, option-free, cache-free, subprocess-free, and all-or-error. Strategy retains discovery and error policy. Reads, writes, and locks continue through the existing rooted/no-follow storage primitives. Git queries that validate repository membership or inspect configuration/history remain; explicitly targeted queries use the existing `EnvWithoutRepoOverrides` helper.

## Consistent locking across aliases

Multi-store session operations resolve every directory identity before creating or acquiring locks. They deduplicate and order repositories by filesystem identity: device/inode on Unix and volume/file index on Windows, matching the identifiers used by `os.SameFile`.

Path sorting alone is insufficient on a case-insensitive filesystem. For example, callers using `alpha` and `Alpha` can order the same repository differently relative to `Beta`, then each block on the other caller’s first lock. Identity ordering makes both callers choose the same physical order. Rooted lock acquisition, cancellation behavior, and reverse-order release are preserved.

## Scope of deletion

`strategy.GetGitCommonDir` is removed after migrating its callers. Shared session/gitdir resolver and cache APIs, `paths.GetWorktreeID`, and the old gitrepo composition APIs remain for the remaining consumers and final cleanup. Settings, status, Codex, trail, and unrelated consumers are outside this slice.

The shared migration ledger entries remain unchanged. Retired query entries now log diagnostics so the intermediate migration passes; unlisted queries and independent traversal still fail the guard. Final strict ledger cleanup belongs to part 5.

## Verification

- `mise run check`: passed in 279.46 seconds, including formatting, zero-issue lint, race-enabled unit/integration tests, Vogon 56/56, and the external deterministic canary 4/4.
- A subsequent pre-push `mise run lint` passed.
- `mise run dup`: completed with 908 repository-wide advisory findings; none involve the four files in the lock-ordering fix.
- `git diff --check`: passed.
- Windows amd64 strategy tests cross-compiled successfully; Windows runtime testing was not performed.
- The case-alias ordering regression failed before the fix and passes afterward on macOS. The original temporary reproduction also passes. Other focused tests assert real lock contention and release, invalid identities before lock creation, lexical path preservation, shared-worktree storage, metadata damage/repair, linked-worktree reset, supported conflicting Git selectors, and no-follow refusal.
- No paid real-agent E2E tests ran.

Independent Trace2 runs against parent `3dbdf8b83` and the migration measured complete strategy methods with fresh strategy instances and cleared discovery caches:

| Operation | Parent | After |
| --- | ---: | ---: |
| PrepareCommitMsg, no session | 4 | 3 |
| PrepareCommitMsg, active session | 3 | 2 |
| PostCommit, no session | 2 | 2 |
| PostCommit, active condensation | 13 | 12 |

These count Git subprocesses within the strategy methods, not full Cobra startup, and do not establish latency improvements.

## Findings while working on this PR

While testing repository isolation, I found that `gitrepo.EnvWithoutRepoOverrides()` removes `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE`, but leaves `GIT_COMMON_DIR`.

I reproduced the failure with two isolated repositories, each with a different `core.hooksPath`. With `GIT_COMMON_DIR` pointing to repository B, a Git subprocess targeting repository A and using the helper returned B's hooks path. The command succeeded without reporting an error.

Adding `GIT_COMMON_DIR` to the filter makes the same query return A's hooks path. A local follow-up fix includes tests for variable removal and the real Git query.

This omission already exists on `main` and is excluded from this refactor. The reproduction deliberately supplied the environment variable; I have not confirmed an incident during normal use.

## Separate existing limitations

Multi-store lock acquisition retains its existing unbounded wait behavior; cancellation while blocked is not newly made interruptible here.
