### PR TITLE
osroot: refuse a non-regular leaf before opening it (fixes a FIFO hang)

### DIFF
--- a/cmd/entire/cli/osroot/openfifo_unix_test.go
+++ b/cmd/entire/cli/osroot/openfifo_unix_test.go
@@ -1,0 +1,57 @@
+//go:build unix
+
+package osroot_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
+)
+
+// TestOpenNoFollow_RefusesFifoWithoutBlocking is the case the refusal exists
+// for. open(2) on a FIFO with no writer blocks until one arrives, and none of
+// these helpers passes O_NONBLOCK, so before the Lstat gate this call hung the
+// process instead of failing it — `entire doctor` in a repo with a FIFO at
+// .claude/settings.json was unkillable short of SIGINT.
+//
+// The test is written as a race against a timer rather than a plain error
+// assertion, because a regression here does not fail: it hangs, and an
+// unguarded assertion would take the whole package's timeout with it.
+//
+// Unix-only by build constraint rather than a runtime skip: syscall.Mkfifo does
+// not exist on Windows, and a runtime guard still has to compile.
+func TestOpenNoFollow_RefusesFifoWithoutBlocking(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := syscall.Mkfifo(filepath.Join(dir, "settings.json"), 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		_, openErr := osroot.OpenNoFollow(root, "settings.json")
+		done <- openErr
+	}()
+
+	select {
+	case openErr := <-done:
+		if !errors.Is(openErr, osroot.ErrNotRegularFile) {
+			t.Errorf("OpenNoFollow(fifo) error = %v, want ErrNotRegularFile", openErr)
+		}
+	case <-time.After(10 * time.Second):
+		// Deliberately not t.Fatal: the goroutine is still parked in openat and
+		// will stay there, so say what happened and let the process exit.
+		t.Error("OpenNoFollow(fifo) blocked instead of returning; the pre-open type check is gone")
+	}
+}

--- a/cmd/entire/cli/osroot/osroot.go
+++ b/cmd/entire/cli/osroot/osroot.go
@@ -76,6 +76,18 @@ func OpenNoFollow(root *os.Root, name string) (*os.File, error) {
 	if before.Mode()&os.ModeSymlink != 0 {
 		return nil, fmt.Errorf("%s: %w", name, ErrSymlinkedPath)
 	}
+	// Checked BEFORE the open, which is the whole point: open(2) on a FIFO with
+	// no writer blocks until one arrives, and none of these helpers passes
+	// O_NONBLOCK. A named pipe at a path Entire reads therefore hung the process
+	// in openat rather than failing it — `entire doctor` in a repo with a FIFO
+	// at .claude/settings.json was unkillable short of SIGINT.
+	//
+	// A directory is refused here too. io.ReadAll of one already failed a step
+	// later with a platform-dependent errno, and a caller asking for a file
+	// wants the refusal, not an EISDIR from the middle of its read.
+	if err := requireRegularFile(name, before.Mode()); err != nil {
+		return nil, err
+	}
 
 	f, err := parent.Open(leaf)
 	if err != nil {
@@ -126,6 +138,25 @@ func OpenFileNoFollow(root *os.Root, name string, flag int, perm os.FileMode) (*
 		return nil, err
 	}
 	return f, nil
+}
+
+// requireRegularFile rejects anything that is not a regular file.
+//
+// The error names the path and the condition but not the type, deliberately:
+// paths.describeMode already renders one for the .entire scan, and a second
+// copy of that vocabulary in the layer underneath it is how the two drift
+// apart. `ls -l` answers "which kind", and doctor's agent-path scan names it.
+//
+// fs.ModeIrregular is masked out rather than matched: Windows maps every reparse
+// tag it has no category for onto that bit, which lands OneDrive Files
+// On-Demand placeholders there, and a placeholder is a perfectly readable file.
+// The same tolerance the .entire entry scan applies, for the same reason —
+// refusing it would hard-fail every repository inside a synced folder.
+func requireRegularFile(name string, mode fs.FileMode) error {
+	if mode.Type()&^fs.ModeIrregular != 0 {
+		return fmt.Errorf("%s: %w", name, ErrNotRegularFile)
+	}
+	return nil
 }
 
 func validateOpenedFile(root *os.Root, name string, f *os.File) error {
@@ -224,6 +255,15 @@ func ReadDirNoSymlinks(root *os.Root, name string) ([]os.DirEntry, error) {
 // ErrSymlinkedPath reports a symlink where a real path component was required.
 // Callers match it with errors.Is.
 var ErrSymlinkedPath = errors.New("path component is a symlink")
+
+// ErrNotRegularFile reports a directory, FIFO, socket or device where a file was
+// required. Callers match it with errors.Is.
+//
+// Deliberately not classified as os.ErrNotExist, though several callers reach
+// these helpers to decide "is there a config here?": a path occupied by the
+// wrong kind of object is a broken repository, and answering "absent" would
+// have Entire write a fresh file over whatever is there.
+var ErrNotRegularFile = errors.New("path is not a regular file")
 
 // ErrReplacedDuringOpen reports that name resolved to one file when it was
 // opened and a different one by the time the open was validated: something

--- a/cmd/entire/cli/osroot/osroot_test.go
+++ b/cmd/entire/cli/osroot/osroot_test.go
@@ -1,6 +1,7 @@
 package osroot_test
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -729,4 +730,72 @@ func TestRemoveAllNoSymlinks(t *testing.T) {
 		assert.True(t, os.IsNotExist(statErr), "the link is gone")
 		assert.FileExists(t, filepath.Join(outside, "keep"), "its target is not")
 	})
+}
+
+// TestOpenNoFollow_RejectsDirectory pins the portable half of the non-regular
+// refusal. A directory used to open fine and fail a step later, inside the
+// caller's io.ReadAll, with a platform-dependent errno.
+func TestOpenNoFollow_RejectsDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	if _, err := osroot.OpenNoFollow(root, "sub"); !errors.Is(err, osroot.ErrNotRegularFile) {
+		t.Errorf("OpenNoFollow(dir) error = %v, want ErrNotRegularFile", err)
+	}
+	if _, err := osroot.ReadFileNoFollow(root, "sub"); !errors.Is(err, osroot.ErrNotRegularFile) {
+		t.Errorf("ReadFileNoFollow(dir) error = %v, want ErrNotRegularFile", err)
+	}
+}
+
+// A regular file is unaffected — the refusal must not have become a blanket one.
+func TestOpenNoFollow_AllowsRegularFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.json"), []byte(`{"a":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	data, err := osroot.ReadFileNoFollow(root, "f.json")
+	if err != nil {
+		t.Fatalf("ReadFileNoFollow() error = %v", err)
+	}
+	if string(data) != `{"a":1}` {
+		t.Errorf("ReadFileNoFollow() = %q", data)
+	}
+}
+
+// A missing file must still classify as os.ErrNotExist, because callers use that
+// to tell "no config here" from "broken config here".
+func TestOpenNoFollow_MissingStaysNotExist(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	_, err = osroot.ReadFileNoFollow(root, "absent.json")
+	if !os.IsNotExist(err) {
+		t.Errorf("ReadFileNoFollow(absent) error = %v, want os.IsNotExist", err)
+	}
+	if errors.Is(err, osroot.ErrNotRegularFile) {
+		t.Error("an absent file must not report ErrNotRegularFile")
+	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1256
<!-- entire-trail-link-end -->

A named pipe at a path Entire reads hangs the process instead of failing it. In a repo where Entire is not even enabled:

```
mkdir -p .claude && mkfifo .claude/settings.json
entire doctor
# prints "✓ Metadata branches: OK", then blocks in openat. SIGINT only.
```

`open(2)` on a FIFO with no writer blocks until one arrives, and none of the NoFollow helpers passes `O_NONBLOCK`:

```
os.(*Root).Open                 root.go:103
osroot.OpenNoFollow             osroot/osroot.go:80   <- parent.Open, no O_NONBLOCK
agent.(*HookConfigFile).Read    agent/hook_config_file.go:112
claudecode.loadClaudeSettings   claudecode/hooks.go:433
claudecode.CheckHookConfig      claudecode/hooks.go:499
```

## The fix

`OpenNoFollow` already `Lstat`s the leaf to reject a symlink, so the type check goes in the same place and costs nothing. Being **before** the open is the whole point — a post-open check cannot help, because the open is what blocks.

Directories are refused too: `io.ReadAll` of one already failed a step later with a platform-dependent errno, and a caller asking for a file wants the refusal rather than an `EISDIR` from the middle of its read.

Verified end-to-end — same repro, rebuilt binary:

```
WARN claude-code: failed to read settings file
     err=".claude/settings.json: path is not a regular file"
```

## Scope, measured rather than assumed

- **`entire doctor` hangs. `entire status` and `entire agent list` do not** — they reach the config through `Exists` (an `Lstat`), not `Read`. I originally described this as "every command that reads an agent config"; that was wrong, and testing each command is what corrected it.
- **The checkpoint path was never exposed.** `git status --porcelain` does not list a FIFO at all, so the code that reads working files from status output cannot reach one. I assumed the opposite at first and checked.
- **Only a FIFO hangs.** A socket fails with "operation not supported on socket"; a regular file and a char device open fine.
- **It cannot arrive by clone.** Git has no tree mode for a FIFO, so this needs local action — a liveness footgun, not the traversal class the anchor work defends against.

Every read funnels through this helper, so one check covers all nine agents plus `permissions.go`, the plugin manifest, doctor's log readers and the settings loader. No caller wants a non-regular file: the one that reads from a directory listing (`review/manifest.go:737`) already skips `entry.IsDir()`, and the full suite passes unchanged.

## Two deliberate choices

**`ErrNotRegularFile` is not classified as `os.ErrNotExist`.** Several callers reach these helpers to decide "is there a config here?", and answering "absent" for an occupied path would have Entire write a fresh file over whatever is there. A missing file still classifies as before, pinned by a test.

**`fs.ModeIrregular` is masked out rather than matched**, the same tolerance the `.entire` entry scan applies: Windows maps uncategorised reparse tags onto that bit, which lands OneDrive Files On-Demand placeholders there, and a placeholder is a readable file. Refusing it would hard-fail every repository inside a synced folder.

The error names the path and the condition but not the type, on purpose — `paths.describeMode` already renders one for the `.entire` scan, and a second copy of that vocabulary in the layer underneath is how the two drift apart.

## Testing note

The FIFO test races the open against a timer instead of asserting on its error, because a regression here does not *fail* — it hangs, and a plain assertion would take the package's timeout with it. It is Unix-only by build constraint rather than a runtime skip, since `syscall.Mkfifo` does not exist on Windows and a runtime guard still has to compile.

## Relationship to #2290

Follow-up to #2290, which made this condition *reportable* — doctor's agent-path scan now checks the leaf's type instead of passing a FIFO as clean — but a scan cannot stop the hang.

**Independent, but they do share one file.** Both touch `cmd/entire/cli/osroot/osroot.go`: #2290 unwraps an error in `RemoveAllNoSymlinks` (line ~401), this PR adds the sentinel and the check in `OpenNoFollow` (lines ~76-140). Different regions, and I verified git auto-merges them in either order — merging both onto `main` in a scratch worktree produced no conflicts, and the combined tree builds with the whole unit suite passing. Either can land first.

## Verification

`mise run lint` 0 issues, `mise run test:ci` exit 0, and `GOOS=windows|linux|darwin go vet ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes file-open behavior for all agent config reads; behavior change for non-regular paths is intentional but broad, with careful error semantics to avoid overwriting occupied paths.
> 
> **Overview**
> **`OpenNoFollow`** now runs a pre-open **`Lstat`** type check via **`requireRegularFile`**, returning **`ErrNotRegularFile`** for directories, FIFOs, sockets, and devices instead of calling **`open`** (which can block indefinitely on a FIFO with no writer). **`ReadFileNoFollow`** inherits this behavior.
> 
> The new sentinel is **not** treated as **`os.ErrNotExist`** so callers do not treat a wrong-type path as “missing config,” and **`fs.ModeIrregular`** is ignored so Windows OneDrive placeholders stay readable.
> 
> Tests add a Unix FIFO race-with-timeout guard, plus coverage for directory rejection, normal files, and absent paths still reporting not-exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2efcf775abf35015dbf3b415147c3fc42b60a7d0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
