### PR TITLE
test(versioncheck): isolate the install-probe env and tag the unix-only tests

### DIFF
--- a/cmd/entire/cli/versioncheck/fixture_test.go
+++ b/cmd/entire/cli/versioncheck/fixture_test.go
@@ -79,3 +79,19 @@ func assertPrintOnly(t *testing.T, f *autoUpdateFixture, action AutoUpdateAction
 		t.Errorf("manual hint missing installer command %q: %q", wantCmd, out)
 	}
 }
+
+// isolateMiseInstallEnv clears the mise install roots so a relocated mise on
+// the host cannot claim a test's exec path. MISE_INSTALLS_DIR is the only
+// probe variable whose value becomes a root verbatim — MISE_DATA_DIR gets
+// "installs" appended and Scoop's four get "apps", and that mandatory extra
+// segment is what stops them prefixing an arbitrary path. So the rows most
+// exposed are the ones asserting that NO probe matched, and the variable that
+// hijacks them is this one.
+//
+// Lives here, untagged, because both platforms need it: the unix table test
+// calls it directly and isolateWindowsInstallEnv wraps it.
+func isolateMiseInstallEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("MISE_INSTALLS_DIR", "")
+	t.Setenv("MISE_DATA_DIR", "")
+}

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -342,11 +340,6 @@ func TestParseGitHubRelease(t *testing.T) {
 	}
 }
 
-// brewUpgradeCmd is the install command produced for any brew-installed
-// binary on a stable channel. Hoisted to a const so tests can reference
-// it without tripping goconst on repeated string literals.
-const brewUpgradeCmd = "brew upgrade --yes entire"
-
 // brewCaskPath is a brew-installed binary; tests that do not care about the
 // install manager use it.
 const brewCaskPath = "/opt/homebrew/Caskroom/entire/1.0.0/entire"
@@ -514,57 +507,6 @@ func TestCheckAndNotify_PrintsNotificationWhenOutdated(t *testing.T) {
 	}
 }
 
-func TestCheckAndNotify_BrewSkipUntilNextVersionCachesLatest(t *testing.T) {
-	server := newVersionServer(t, "v2.0.0")
-	cmd, _ := setupCheckAndNotifyTest(t, server.URL)
-	f := newAutoUpdateFixture(t)
-	setExecutablePath(t, brewCaskPath)
-	f.chooseValue = autoUpdateActionSkipUntilNextVersion
-
-	CheckAndNotify(context.Background(), cmd.OutOrStdout(), "1.0.0")
-
-	if f.installCalls != 0 {
-		t.Fatalf("installer called %d times, want 0", f.installCalls)
-	}
-	cache, err := loadCache()
-	if err != nil {
-		t.Fatalf("loadCache() error = %v", err)
-	}
-	if cache.SkippedVersion != "v2.0.0" {
-		t.Errorf("SkippedVersion = %q, want v2.0.0", cache.SkippedVersion)
-	}
-	if f.lastCmdStr != brewUpgradeCmd {
-		t.Errorf("prompt got cmd %q, want %q", f.lastCmdStr, brewUpgradeCmd)
-	}
-}
-
-// TestCheckAndNotify_MiseSkipUntilNextVersionCachesLatest verifies the
-// skip-until-next-version persistence works for non-brew installers too.
-// The cache flow is installer-agnostic; this locks that contract in.
-func TestCheckAndNotify_MiseSkipUntilNextVersionCachesLatest(t *testing.T) {
-	server := newVersionServer(t, "v2.0.0")
-	cmd, _ := setupCheckAndNotifyTest(t, server.URL)
-	f := newAutoUpdateFixture(t)
-	setExecutablePath(t, miseExecutablePath)
-	f.chooseValue = autoUpdateActionSkipUntilNextVersion
-
-	CheckAndNotify(context.Background(), cmd.OutOrStdout(), "1.0.0")
-
-	if f.installCalls != 0 {
-		t.Fatalf("installer called %d times, want 0", f.installCalls)
-	}
-	cache, err := loadCache()
-	if err != nil {
-		t.Fatalf("loadCache() error = %v", err)
-	}
-	if cache.SkippedVersion != "v2.0.0" {
-		t.Errorf("SkippedVersion = %q, want v2.0.0", cache.SkippedVersion)
-	}
-	if f.lastCmdStr != miseUpgradeCmd {
-		t.Errorf("prompt got cmd %q, want %q", f.lastCmdStr, miseUpgradeCmd)
-	}
-}
-
 func TestCheckAndNotify_SkipsVersionMarkedSkipped(t *testing.T) {
 	server := newVersionServer(t, "v2.0.0")
 	cmd, buf := setupCheckAndNotifyTest(t, server.URL)
@@ -593,51 +535,6 @@ func TestCheckAndNotify_NoNotificationWhenUpToDate(t *testing.T) {
 
 	if buf.Len() != 0 {
 		t.Errorf("expected no output when up to date, got %q", buf.String())
-	}
-}
-
-func TestCheckAndNotify_InstallerFailureKeepsCacheFresh(t *testing.T) {
-	server := newVersionServer(t, "v2.0.0")
-	cmd, buf := setupCheckAndNotifyTest(t, server.URL)
-
-	// Simulate an interactive user who accepts the upgrade prompt, and an
-	// installer that fails (e.g. brew upgrade blew up mid-run).
-	t.Setenv("ENTIRE_TEST_TTY", "1")
-	setExecutablePath(t, brewCaskPath)
-
-	origChoose := chooseUpdate
-	chooseUpdate = func(_ context.Context, _, _, _ string) (AutoUpdateAction, error) {
-		return autoUpdateActionUpdate, nil
-	}
-	t.Cleanup(func() { chooseUpdate = origChoose })
-
-	origRun := runInstaller
-	runInstaller = func(_ context.Context, _ string) error { return errors.New("boom") }
-	t.Cleanup(func() { runInstaller = origRun })
-
-	origIsTerminalOut := isTerminalOut
-	isTerminalOut = func(_ io.Writer) bool { return true }
-	t.Cleanup(func() { isTerminalOut = origIsTerminalOut })
-
-	CheckAndNotify(context.Background(), cmd.OutOrStdout(), "1.0.0")
-
-	// User sees the failure message with a manual-retry hint.
-	if !strings.Contains(buf.String(), "Try again later running:") {
-		t.Errorf("missing retry hint in output: %q", buf.String())
-	}
-
-	// Cache must remain bumped: we don't want to re-prompt every invocation
-	// while the upstream issue is still in place. The user already has the
-	// hint with the exact command to run manually.
-	cache, err := loadCache()
-	if err != nil {
-		t.Fatalf("loadCache() error = %v", err)
-	}
-	if cache.LastCheckTime.IsZero() {
-		t.Errorf("cache LastCheckTime was reset after installer failure; want fresh bump")
-	}
-	if time.Since(cache.LastCheckTime) > time.Minute {
-		t.Errorf("cache LastCheckTime not fresh after installer failure: %v", cache.LastCheckTime)
 	}
 }
 

--- a/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
@@ -66,6 +66,7 @@ func TestUpdateCommandForCurrentBinary_Unix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			isolateMiseInstallEnv(t)
 			setExecutable(t, tt.execPath)
 
 			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {

--- a/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
@@ -3,15 +3,23 @@
 package versioncheck
 
 import (
+	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // plainBinPath is a POSIX install under no recognized install manager.
 const plainBinPath = "/usr/local/bin/entire"
+
+// brewUpgradeCmd is the install command produced for any brew-installed
+// binary on a stable channel. Hoisted to a const so tests can reference
+// it without tripping goconst on repeated string literals.
+const brewUpgradeCmd = "brew upgrade --yes entire"
 
 func TestUpdateCommandForCurrentBinary_Unix(t *testing.T) {
 	tests := []struct {
@@ -132,5 +140,101 @@ func TestUpdateCommandShell_Unix(t *testing.T) {
 
 	if got := UpdateCommandShell(); got != "" {
 		t.Errorf("UpdateCommandShell() = %q, want %q", got, "")
+	}
+}
+
+func TestCheckAndNotify_BrewSkipUntilNextVersionCachesLatest(t *testing.T) {
+	server := newVersionServer(t, "v2.0.0")
+	cmd, _ := setupCheckAndNotifyTest(t, server.URL)
+	f := newAutoUpdateFixture(t)
+	setExecutablePath(t, brewCaskPath)
+	f.chooseValue = autoUpdateActionSkipUntilNextVersion
+
+	CheckAndNotify(context.Background(), cmd.OutOrStdout(), "1.0.0")
+
+	if f.installCalls != 0 {
+		t.Fatalf("installer called %d times, want 0", f.installCalls)
+	}
+	cache, err := loadCache()
+	if err != nil {
+		t.Fatalf("loadCache() error = %v", err)
+	}
+	if cache.SkippedVersion != "v2.0.0" {
+		t.Errorf("SkippedVersion = %q, want v2.0.0", cache.SkippedVersion)
+	}
+	if f.lastCmdStr != brewUpgradeCmd {
+		t.Errorf("prompt got cmd %q, want %q", f.lastCmdStr, brewUpgradeCmd)
+	}
+}
+
+// TestCheckAndNotify_MiseSkipUntilNextVersionCachesLatest verifies the
+// skip-until-next-version persistence works for non-brew installers too.
+// The cache flow is installer-agnostic; this locks that contract in.
+func TestCheckAndNotify_MiseSkipUntilNextVersionCachesLatest(t *testing.T) {
+	server := newVersionServer(t, "v2.0.0")
+	cmd, _ := setupCheckAndNotifyTest(t, server.URL)
+	f := newAutoUpdateFixture(t)
+	setExecutablePath(t, miseExecutablePath)
+	f.chooseValue = autoUpdateActionSkipUntilNextVersion
+
+	CheckAndNotify(context.Background(), cmd.OutOrStdout(), "1.0.0")
+
+	if f.installCalls != 0 {
+		t.Fatalf("installer called %d times, want 0", f.installCalls)
+	}
+	cache, err := loadCache()
+	if err != nil {
+		t.Fatalf("loadCache() error = %v", err)
+	}
+	if cache.SkippedVersion != "v2.0.0" {
+		t.Errorf("SkippedVersion = %q, want v2.0.0", cache.SkippedVersion)
+	}
+	if f.lastCmdStr != miseUpgradeCmd {
+		t.Errorf("prompt got cmd %q, want %q", f.lastCmdStr, miseUpgradeCmd)
+	}
+}
+
+func TestCheckAndNotify_InstallerFailureKeepsCacheFresh(t *testing.T) {
+	server := newVersionServer(t, "v2.0.0")
+	cmd, buf := setupCheckAndNotifyTest(t, server.URL)
+
+	// Simulate an interactive user who accepts the upgrade prompt, and an
+	// installer that fails (e.g. brew upgrade blew up mid-run).
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+	setExecutablePath(t, brewCaskPath)
+
+	origChoose := chooseUpdate
+	chooseUpdate = func(_ context.Context, _, _, _ string) (AutoUpdateAction, error) {
+		return autoUpdateActionUpdate, nil
+	}
+	t.Cleanup(func() { chooseUpdate = origChoose })
+
+	origRun := runInstaller
+	runInstaller = func(_ context.Context, _ string) error { return errors.New("boom") }
+	t.Cleanup(func() { runInstaller = origRun })
+
+	origIsTerminalOut := isTerminalOut
+	isTerminalOut = func(_ io.Writer) bool { return true }
+	t.Cleanup(func() { isTerminalOut = origIsTerminalOut })
+
+	CheckAndNotify(context.Background(), cmd.OutOrStdout(), "1.0.0")
+
+	// User sees the failure message with a manual-retry hint.
+	if !strings.Contains(buf.String(), "Try again later running:") {
+		t.Errorf("missing retry hint in output: %q", buf.String())
+	}
+
+	// Cache must remain bumped: we don't want to re-prompt every invocation
+	// while the upstream issue is still in place. The user already has the
+	// hint with the exact command to run manually.
+	cache, err := loadCache()
+	if err != nil {
+		t.Fatalf("loadCache() error = %v", err)
+	}
+	if cache.LastCheckTime.IsZero() {
+		t.Errorf("cache LastCheckTime was reset after installer failure; want fresh bump")
+	}
+	if time.Since(cache.LastCheckTime) > time.Minute {
+		t.Errorf("cache LastCheckTime not fresh after installer failure: %v", cache.LastCheckTime)
 	}
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -127,8 +127,7 @@ func isolateWindowsInstallEnv(t *testing.T) string {
 	t.Setenv("USERPROFILE", dir)
 	t.Setenv("SCOOP", "")
 	t.Setenv("SCOOP_GLOBAL", "")
-	t.Setenv("MISE_INSTALLS_DIR", "")
-	t.Setenv("MISE_DATA_DIR", "")
+	isolateMiseInstallEnv(t)
 	return dir
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1257
<!-- entire-trail-link-end -->

Two test-hygiene items found reviewing #2217, which merged while this was being written — so this targets `main` rather than stacking. Test-only: no production code changes.

## 1. The unix table test read the host's mise roots

`isolateWindowsInstallEnv` clears `MISE_INSTALLS_DIR` and `MISE_DATA_DIR`, but it lives in `versioncheck_windows_test.go`, so the unix table test never got the fix:

```
MISE_INSTALLS_DIR=/usr/local go test ./cmd/entire/cli/versioncheck/ -run TestUpdateCommandForCurrentBinary_Unix
--- FAIL: .../unknown_path_stable_falls_back_to_stable_curl_command
    UpdateCommandForCurrentBinary() = "mise upgrade entire", want "curl -fsSL https://entire.io/install.sh | bash"
--- FAIL: .../unknown_path_nightly_falls_back_to_nightly_curl_command
```

`MISE_INSTALLS_DIR` is the only probe variable whose value becomes a root verbatim — `miseRoots` returns it as-is, while `MISE_DATA_DIR` gets `installs` appended and `scoopRoots` appends `apps` to all four of its inputs. That mandatory extra segment is what stops the others prefixing an arbitrary path, and it is also why no value of `SCOOP` could reproduce the Windows half of the finding this fell out of: `SCOOP=C:\tools` yields the root `c:/tools/apps/`, which does not prefix `c:/tools/cli/entire.exe`.

So the exposed rows are exactly the two whose expectation is the *fallback* — the ones asserting that no probe matched — and one variable reaches them. The brew rows are immune by probe order, and the `executable error` row returns before the probe loop.

Fix: the two `Setenv` calls move into an untagged `isolateMiseInstallEnv` that both platforms share, with `isolateWindowsInstallEnv` wrapping it and adding Scoop's, so the pair cannot drift again.

| Env | Before | After |
| --- | --- | --- |
| `MISE_INSTALLS_DIR=/usr/local` | 2 rows FAIL | pass |
| `MISE_DATA_DIR=/usr` | pass (needs an `installs/` segment) | pass |
| `MISE_INSTALLS_DIR=usr/local` | pass (`normalizeInstallRoot` rejects relative) | pass |

CI is unaffected either way — no runner sets these. It is the developer-box run that lies, with a message pointing at the code under test and no hint that the environment caused it.

## 2. Three `CheckAndNotify` tests were untagged but unix-only

`TestCheckAndNotify_BrewSkipUntilNextVersionCachesLatest`, `..._MiseSkipUntilNextVersionCachesLatest` and `..._InstallerFailureKeepsCacheFresh` all assert what happens *after* `maybeAutoUpdate` reaches the prompt — that `chooseUpdate`'s answer lands in the cache as `SkippedVersion`, or that the `Try again later running:` hint prints. On Windows `maybeAutoUpdate` returns `autoUpdateActionSkip` before any of that, so all three fail on a Windows host. Confirmed by building the package with `installerAutoRuns` flipped to `false`.

CI cannot see it: `test-windows` selects by name (`-run '(Windows|MSYS)'`) and none of these match. The previous escape hatch was the `goos` variable seam and its `pinNonWindowsGOOS` helper, which #2217 removed — correctly — leaving these three as the callers it did not follow up. A build tag is now the only way to express what they need.

They move to `versioncheck_unix_test.go` alongside the existing unix-only `CheckAndNotify` coverage, and `brewUpgradeCmd` goes with them since brew is a unix-only probe here. `brewCaskPath` stays untagged: `TestCheckAndNotify_SkipsVersionMarkedSkipped` still uses it and is genuinely platform-agnostic, because `CheckAndNotify` returns on the skipped version before any installer is consulted.

Verified with `go list` that the Windows test build now contains only `autoupdate_windows_test.go`, `fixture_test.go`, `versioncheck_test.go` and `versioncheck_windows_test.go`.

## Known gap, deliberately not closed here

Nothing asserts the *Windows* side of the same contract — that `CheckAndNotify` does not cache a skip there, which is the deliberate "the nudge returns every 24h until they update" behaviour `maybeAutoUpdate` documents. That wants a new windows-tagged test rather than a moved one, so it is out of scope.

## Verification

`mise run lint` 0 issues, `mise run test:ci` fully green, `GOOS=windows go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test layout and environment isolation; no runtime version-check or auto-update logic changes.
> 
> **Overview**
> **Test-only** hardening for `versioncheck`: no production behavior changes.
> 
> Adds shared **`isolateMiseInstallEnv`** (clears `MISE_INSTALLS_DIR` / `MISE_DATA_DIR`) so host mise roots cannot make “unknown path → curl install” cases look like `mise upgrade`. The Unix `UpdateCommandForCurrentBinary` table calls it in each subtest; **`isolateWindowsInstallEnv`** now delegates to the same helper instead of duplicating those `Setenv` calls.
> 
> Moves three **`CheckAndNotify`** tests that depend on interactive auto-update (skip-until-next-version caching and installer-failure retry hint) into **`versioncheck_unix_test.go`** under the `unix` build tag, because on Windows `installerAutoRuns` is false and `maybeAutoUpdate` bails out before those paths run. **`brewUpgradeCmd`** moves with them; shared `versioncheck_test.go` drops the duplicated tests and unused imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfef5abe041c13d3327baa3e568eaa3961875798. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->