### PR TITLE
fix(gitrepo): strip inherited `GIT_COMMON_DIR`

### DIFF
--- a/cmd/entire/cli/gitrepo/env.go
+++ b/cmd/entire/cli/gitrepo/env.go
@@ -5,27 +5,28 @@ import (
 	"strings"
 )
 
-// repoOverrideEnvVars are git's repo-selector environment variables. Git
-// exports them to its hooks, and they take precedence over a child process's
-// working directory — so `exec.Command("git", ...)` with cmd.Dir set still
-// resolves the *hook's* repository, not the directory named, and
-// GIT_INDEX_FILE redirects index reads and writes to a different file
-// entirely.
+// Inherited repository selectors can redirect Git even when cmd.Dir is explicit.
+// GIT_COMMON_DIR redirects shared repository data, including configuration;
+// GIT_INDEX_FILE redirects index reads and writes.
 var repoOverrideEnvVars = []string{
 	"GIT_DIR=",
+	"GIT_COMMON_DIR=",
 	"GIT_WORK_TREE=",
 	"GIT_INDEX_FILE=",
 }
 
 // EnvWithoutRepoOverrides returns the current environment minus git's
-// repo-selector variables (GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE), so a git
-// subprocess resolves its repository from cmd.Dir as the call site intends.
+// repo-selector variables (GIT_DIR, GIT_COMMON_DIR, GIT_WORK_TREE, GIT_INDEX_FILE),
+// so a git subprocess resolves its repository from cmd.Dir as the call site intends.
 //
-// Use this for any git subprocess that can run inside a git hook and that
-// names its target with cmd.Dir or `-C`. Inheriting these variables makes the
+// Use this for git subprocesses that must resolve their target independently
+// of the enclosing hook, using cmd.Dir or `-C`. Inheriting these variables makes the
 // child silently operate on the hook's repository instead: `git -C <other>
 // rev-parse` reports the hook's repo, and an index-touching command reads and
 // writes whatever GIT_INDEX_FILE names.
+//
+// Commands inspecting the commit being prepared must retain Git's temporary
+// GIT_INDEX_FILE rather than use this helper.
 //
 // Deliberately not applied to user-invoked commands that operate on the
 // current directory (`entire status`, `entire doctor`, `entire review`): there

--- a/cmd/entire/cli/gitrepo/env_isolation_test.go
+++ b/cmd/entire/cli/gitrepo/env_isolation_test.go
@@ -1,0 +1,35 @@
+package gitrepo_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvWithoutRepoOverrides_IsolatesRepositoryConfig(t *testing.T) {
+	// Cannot run in parallel: Git selectors are process-global.
+	target, decoy := t.TempDir(), t.TempDir()
+	testutil.InitRepo(t, target)
+	testutil.InitRepo(t, decoy)
+	targetHooks := filepath.Join(target, "target-hooks")
+	decoyHooks := filepath.Join(decoy, "decoy-hooks")
+	testutil.RunGit(t, target, "config", "core.hooksPath", targetHooks)
+	testutil.RunGit(t, decoy, "config", "core.hooksPath", decoyHooks)
+
+	t.Setenv("GIT_DIR", filepath.Join(decoy, ".git"))
+	t.Setenv("GIT_COMMON_DIR", filepath.Join(decoy, ".git"))
+	t.Setenv("GIT_WORK_TREE", decoy)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(decoy, ".git", "index"))
+
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "--git-path", "hooks")
+	cmd.Dir = target
+	cmd.Env = gitrepo.EnvWithoutRepoOverrides()
+	output, err := cmd.Output()
+	require.NoError(t, err)
+	require.Equal(t, targetHooks, strings.TrimSpace(string(output)))
+}

--- a/cmd/entire/cli/gitrepo/env_test.go
+++ b/cmd/entire/cli/gitrepo/env_test.go
@@ -9,13 +9,14 @@ import (
 func TestEnvWithoutRepoOverrides_StripsRepoSelectors(t *testing.T) {
 	// Cannot be parallel: t.Setenv is process-global.
 	t.Setenv("GIT_DIR", "/decoy/.git")
+	t.Setenv("GIT_COMMON_DIR", "/decoy/.git")
 	t.Setenv("GIT_WORK_TREE", "/decoy")
 	t.Setenv("GIT_INDEX_FILE", "/decoy/.git/index")
 	t.Setenv("ENTIRE_ENV_TEST_KEEP", "keep-me")
 
 	env := EnvWithoutRepoOverrides()
 
-	for _, banned := range []string{"GIT_DIR=", "GIT_WORK_TREE=", "GIT_INDEX_FILE="} {
+	for _, banned := range []string{"GIT_DIR=", "GIT_COMMON_DIR=", "GIT_WORK_TREE=", "GIT_INDEX_FILE="} {
 		if slices.ContainsFunc(env, func(kv string) bool { return strings.HasPrefix(kv, banned) }) {
 			t.Errorf("EnvWithoutRepoOverrides kept %s", strings.TrimSuffix(banned, "="))
 		}


### PR DESCRIPTION
Follow-up to the [findings recorded in split-four PR #2305](https://github.com/entireio/cli/pull/2305#user-content-findings-while-working-on-this-pr), where this existing helper limitation was left out of the refactor.

`gitrepo.EnvWithoutRepoOverrides()` removes `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE`, but leaves `GIT_COMMON_DIR`. A Git command explicitly targeting repository A can therefore read shared Git data from repository B. Setting `cmd.Dir` or passing `git -C` does not clear the inherited override.

A regression test reproduces this with two isolated repositories, each with a different `core.hooksPath`. It points the repository environment variables at B, then runs `git rev-parse --git-path hooks` in A using the helper. Before the fix, the command succeeds but returns B's hooks path. After the fix, it returns A's path.

This adds `GIT_COMMON_DIR` to the existing filter. It affects only commands already using the helper. The helper's comments also clarify that commands inspecting the commit being prepared must retain Git's temporary index.

The reproduction deliberately supplies the environment variable. No incident during normal use has been confirmed.

## Verification

- The exact regression command failed before the fix and passes afterward: `go test ./cmd/entire/cli/gitrepo -run TestEnvWithoutRepoOverrides -count=1`.
- Full `gitrepo`, `checkpoint`, and `strategy` package tests passed with `-count=1`.
- `mise run check` passed on the full rerun, including race-enabled unit/integration tests, 56 Vogon canaries, and 4 external deterministic canaries.
- A separate `mise run lint` after formatting passed with zero issues. `git diff --check` passed.

The first full check failed `TestHooksGitCmd_DiscoverExternalAgents_WhenEnabled` and `TestExternalCommand_SigintReachesPlugin`. Both passed on a focused rerun and in the subsequent full check, without code changes. No paid real-agent E2E tests ran.
