### PR TITLE
test(versioncheck): pin brew-before-mise probe precedence

### DIFF
--- a/cmd/entire/cli/versioncheck/fixture_test.go
+++ b/cmd/entire/cli/versioncheck/fixture_test.go
@@ -23,6 +23,10 @@ func newAutoUpdateFixture(t *testing.T) *autoUpdateFixture {
 	t.Setenv(envKillSwitch, "")
 	// Force interactive mode on by default; individual tests can opt out.
 	t.Setenv("ENTIRE_TEST_TTY", "1")
+	// Every fixture user drives UpdateCommandForCurrentBinary through an exec
+	// path, so none of them wants the host's install roots deciding which
+	// probe claims it.
+	isolateMiseInstallEnv(t)
 
 	f := &autoUpdateFixture{chooseValue: autoUpdateActionUpdate}
 

--- a/cmd/entire/cli/versioncheck/fixture_test.go
+++ b/cmd/entire/cli/versioncheck/fixture_test.go
@@ -23,10 +23,6 @@ func newAutoUpdateFixture(t *testing.T) *autoUpdateFixture {
 	t.Setenv(envKillSwitch, "")
 	// Force interactive mode on by default; individual tests can opt out.
 	t.Setenv("ENTIRE_TEST_TTY", "1")
-	// Every fixture user drives UpdateCommandForCurrentBinary through an exec
-	// path, so none of them wants the host's install roots deciding which
-	// probe claims it.
-	isolateMiseInstallEnv(t)
 
 	f := &autoUpdateFixture{chooseValue: autoUpdateActionUpdate}
 
@@ -82,20 +78,4 @@ func assertPrintOnly(t *testing.T, f *autoUpdateFixture, action AutoUpdateAction
 	if !strings.Contains(out, "  "+wantCmd) {
 		t.Errorf("manual hint missing installer command %q: %q", wantCmd, out)
 	}
-}
-
-// isolateMiseInstallEnv clears the mise install roots so a relocated mise on
-// the host cannot claim a test's exec path. MISE_INSTALLS_DIR is the only
-// probe variable whose value becomes a root verbatim — MISE_DATA_DIR gets
-// "installs" appended and Scoop's four get "apps", and that mandatory extra
-// segment is what stops them prefixing an arbitrary path. So the rows most
-// exposed are the ones asserting that NO probe matched, and the variable that
-// hijacks them is this one.
-//
-// Lives here, untagged, because both platforms need it: the unix table test
-// calls it directly and isolateWindowsInstallEnv wraps it.
-func isolateMiseInstallEnv(t *testing.T) {
-	t.Helper()
-	t.Setenv("MISE_INSTALLS_DIR", "")
-	t.Setenv("MISE_DATA_DIR", "")
 }

--- a/cmd/entire/cli/versioncheck/global_test.go
+++ b/cmd/entire/cli/versioncheck/global_test.go
@@ -1,0 +1,35 @@
+package versioncheck
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain clears the install roots the probes read from the environment, so
+// no test in this package inherits the developer's own mise or Scoop layout.
+//
+// It is a package-wide default rather than a per-test helper because forgetting
+// it is silent and the failure blames the code under test: every probe root is
+// a `strings.HasPrefix` match, and MISE_INSTALLS_DIR is the one variable used
+// verbatim (miseRoots returns it unchanged, while MISE_DATA_DIR gains
+// `installs` and Scoop's inputs gain `apps`), so a developer with it set to
+// something broad like /opt makes a probe claim exec paths the test never
+// meant it to. The rows that break are the ones asserting a *specific* probe
+// or the fallback — and they break only on that developer's machine, never in
+// CI, which sets none of these.
+//
+// XDG_CONFIG_HOME and USERPROFILE deliberately stay out of here: Scoop's
+// config.json is read through them and several tests write one, so those need
+// a per-test temp dir. isolateWindowsInstallEnv owns that.
+//
+// os.Setenv rather than t.Setenv because TestMain has no *testing.T; a test
+// wanting a specific root still overrides this baseline with t.Setenv, which
+// restores it afterwards.
+func TestMain(m *testing.M) {
+	for _, key := range []string{"MISE_INSTALLS_DIR", "MISE_DATA_DIR", "SCOOP", "SCOOP_GLOBAL"} {
+		if err := os.Setenv(key, ""); err != nil {
+			panic("versioncheck tests: clearing " + key + ": " + err.Error())
+		}
+	}
+	os.Exit(m.Run())
+}

--- a/cmd/entire/cli/versioncheck/versioncheck_unix.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix.go
@@ -26,6 +26,10 @@ var brewProbe = installProbe{
 	command: brewUpgradeCommand,
 }
 
+// installProbes order is load-bearing: UpdateCommandForCurrentBinary returns
+// the FIRST match, and roots match by prefix, so a mise root wide enough to
+// cover a brew path would claim it if it came first. Pinned by
+// TestUnixBrewBeatsAMiseRootCoveringTheSamePath.
 var installProbes = []installProbe{brewProbe, miseProbe}
 
 func fallbackInstallCommand(_, currentVersion string) string {

--- a/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
@@ -201,6 +201,7 @@ func TestCheckAndNotify_InstallerFailureKeepsCacheFresh(t *testing.T) {
 	// Simulate an interactive user who accepts the upgrade prompt, and an
 	// installer that fails (e.g. brew upgrade blew up mid-run).
 	t.Setenv("ENTIRE_TEST_TTY", "1")
+	isolateMiseInstallEnv(t)
 	setExecutablePath(t, brewCaskPath)
 
 	origChoose := chooseUpdate
@@ -236,5 +237,33 @@ func TestCheckAndNotify_InstallerFailureKeepsCacheFresh(t *testing.T) {
 	}
 	if time.Since(cache.LastCheckTime) > time.Minute {
 		t.Errorf("cache LastCheckTime not fresh after installer failure: %v", cache.LastCheckTime)
+	}
+}
+
+// TestUnixBrewBeatsAMiseRootCoveringTheSamePath pins probe precedence, which
+// is a product invariant and not only a test-support one: a developer can have
+// entire installed by brew *and* mise relocated somewhere broad enough to
+// cover the cask path (MISE_INSTALLS_DIR is the one probe variable used
+// verbatim, so `/opt` is enough), and that user must be told to run brew.
+// installProbes orders brewProbe first and brewProbe matches a cask path by
+// marker, so mise cannot claim it however wide its root is.
+//
+// Asserting the precondition matters as much as the outcome. Without it, a
+// change that stopped mise matching at all would leave this test passing while
+// no longer testing precedence.
+func TestUnixBrewBeatsAMiseRootCoveringTheSamePath(t *testing.T) {
+	t.Setenv("MISE_INSTALLS_DIR", "/opt")
+	t.Setenv("MISE_DATA_DIR", "")
+
+	norm := normalizePath(brewCaskPath)
+	if !miseProbe.matches(norm) {
+		t.Fatalf("precondition: miseProbe should also match %q under MISE_INSTALLS_DIR=/opt; "+
+			"without a contending probe this test no longer pins precedence", norm)
+	}
+
+	setExecutablePath(t, brewCaskPath)
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != brewUpgradeCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q; brew must be probed before mise",
+			got, brewUpgradeCmd)
 	}
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
@@ -74,7 +74,6 @@ func TestUpdateCommandForCurrentBinary_Unix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			isolateMiseInstallEnv(t)
 			setExecutable(t, tt.execPath)
 
 			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {
@@ -201,7 +200,6 @@ func TestCheckAndNotify_InstallerFailureKeepsCacheFresh(t *testing.T) {
 	// Simulate an interactive user who accepts the upgrade prompt, and an
 	// installer that fails (e.g. brew upgrade blew up mid-run).
 	t.Setenv("ENTIRE_TEST_TTY", "1")
-	isolateMiseInstallEnv(t)
 	setExecutablePath(t, brewCaskPath)
 
 	origChoose := chooseUpdate
@@ -244,16 +242,11 @@ func TestCheckAndNotify_InstallerFailureKeepsCacheFresh(t *testing.T) {
 // is a product invariant and not only a test-support one: a developer can have
 // entire installed by brew *and* mise relocated somewhere broad enough to
 // cover the cask path (MISE_INSTALLS_DIR is the one probe variable used
-// verbatim, so `/opt` is enough), and that user must be told to run brew.
+// verbatim, so /opt is enough), and that user must be told to run brew.
 // installProbes orders brewProbe first and brewProbe matches a cask path by
 // marker, so mise cannot claim it however wide its root is.
-//
-// Asserting the precondition matters as much as the outcome. Without it, a
-// change that stopped mise matching at all would leave this test passing while
-// no longer testing precedence.
 func TestUnixBrewBeatsAMiseRootCoveringTheSamePath(t *testing.T) {
 	t.Setenv("MISE_INSTALLS_DIR", "/opt")
-	t.Setenv("MISE_DATA_DIR", "")
 
 	norm := normalizePath(brewCaskPath)
 	if !miseProbe.matches(norm) {

--- a/cmd/entire/cli/versioncheck/versioncheck_windows.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows.go
@@ -146,6 +146,10 @@ var scoopProbe = installProbe{
 	command: scoopUpgradeCommand,
 }
 
+// installProbes order is load-bearing: UpdateCommandForCurrentBinary returns
+// the FIRST match, and roots match by prefix, so a mise root wide enough to
+// cover a Scoop path would claim it if it came first. Pinned by
+// TestWindowsScoopBeatsAMiseRootCoveringTheSamePath.
 var installProbes = []installProbe{scoopProbe, miseProbe}
 
 // fallbackInstallCommand names the running binary's directory with

--- a/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_windows_test.go
@@ -117,17 +117,16 @@ func TestWindowsUpdateCommandWithoutExecPathOmitsInstallDir(t *testing.T) {
 	}
 }
 
-// isolateWindowsInstallEnv points every install-root lookup the probes make —
-// Scoop's env vars and config.json, mise's env vars — at an empty temp dir, so
-// a relocated Scoop or mise on the host cannot claim a test's exec path.
+// isolateWindowsInstallEnv redirects Scoop's config.json lookup at an empty
+// temp dir, so a relocated Scoop root recorded there cannot claim a test's
+// exec path. The install-root env vars are already cleared package-wide by
+// TestMain; this covers only what needs to be per-test, and returns the dir so
+// a test can plant a config.json of its own.
 func isolateWindowsInstallEnv(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	t.Setenv("USERPROFILE", dir)
-	t.Setenv("SCOOP", "")
-	t.Setenv("SCOOP_GLOBAL", "")
-	isolateMiseInstallEnv(t)
 	return dir
 }
 
@@ -227,5 +226,29 @@ func TestWindowsUpdateCommandShell(t *testing.T) {
 
 	if got := UpdateCommandShell(); got != "PowerShell" {
 		t.Errorf("UpdateCommandShell() = %q, want %q", got, "PowerShell")
+	}
+}
+
+// TestWindowsScoopBeatsAMiseRootCoveringTheSamePath is the Windows half of
+// TestUnixBrewBeatsAMiseRootCoveringTheSamePath: installProbes puts scoopProbe
+// first, and it matches a Scoop apps path by marker, so a MISE_INSTALLS_DIR
+// wide enough to cover the same path cannot claim it. Worth pinning separately
+// rather than inferring from the unix test, because scoopProbe matches through
+// two mechanisms (its own roots as well as the marker) where brewProbe has
+// markers only.
+func TestWindowsScoopBeatsAMiseRootCoveringTheSamePath(t *testing.T) {
+	isolateWindowsInstallEnv(t)
+	t.Setenv("MISE_INSTALLS_DIR", `C:\Users\test\scoop`)
+
+	norm := normalizePath(scoopEntireExecutablePath)
+	if !miseProbe.matches(norm) {
+		t.Fatalf("precondition: miseProbe should also match %q under a covering MISE_INSTALLS_DIR; "+
+			"without a contending probe this test no longer pins precedence", norm)
+	}
+
+	setExecutablePath(t, scoopEntireExecutablePath)
+	if got := UpdateCommandForCurrentBinary("1.0.0"); got != scoopUpdateCmd {
+		t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q; scoop must be probed before mise",
+			got, scoopUpdateCmd)
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1258
<!-- entire-trail-link-end -->

Follow-up to #2309, from a finding on its trail. Test-only — no production code changes.

## The finding was wrong

It claimed the three `CheckAndNotify` tests moved in #2309 fail when a developer has `MISE_INSTALLS_DIR` set to a path that also covers `brewCaskPath` (it suggested `/opt`), because the mise probe would then match and `f.lastCmdStr` would be `miseUpgradeCmd`. Medium, confidence 0.95.

The premise is right; the conclusion is not. `UpdateCommandForCurrentBinary` returns the **first** matching probe, and `installProbes` orders `brewProbe` ahead of `miseProbe`. `brewProbe` matches a cask path by *marker* (`strings.Contains` on `/Caskroom/`, `/opt/homebrew/`), which no environment variable can switch off. Both probes match; brew is returned:

```
miseProbe.matches("/opt/homebrew/Caskroom/entire/1.0.0/entire") = true   <- the premise
brewProbe.matches("/opt/homebrew/Caskroom/entire/1.0.0/entire") = true   <- matched first, by marker
UpdateCommandForCurrentBinary() = "brew upgrade --yes entire"
```

Checked against every `MISE_INSTALLS_DIR` worth trying — `/opt`, `/opt/homebrew`, `/opt/homebrew/Caskroom`, `/home`, `/home/user`, and the pathological `/` — plus `MISE_DATA_DIR`. All pass. The other two tests aren't reachable at all: the mise test's path contains `/mise/installs/`, miseProbe's own marker, so it matches regardless of env and *wants* mise; and `InstallerFailureKeepsCacheFresh` asserts only the `Try again later running:` hint and cache freshness, never which command.

The comparison to 73a3d39 doesn't hold either. That fixed the two table rows whose expectation is the **fallback** — where by definition no probe matched, so precedence couldn't rescue them, which is exactly why the env leak reached them. Here precedence does rescue it.

## What it did surface

Precedence is load-bearing and nothing pinned it. That's a product invariant, not just test scaffolding: a user can have entire installed by brew *and* mise relocated under a broad root, and that user must be told to run `brew upgrade`. Reordering `installProbes` would silently change the advice, and would break those tests only on the developer boxes that happen to set the variable — the worst way to find out.

So this PR pins it. The test asserts the **precondition** as well as the outcome, because without a contending probe it would keep passing while testing nothing. Verified by mutation:

| Mutation | Caught by |
| --- | --- |
| `installProbes` reordered to `{miseProbe, brewProbe}` | outcome: `= "mise upgrade entire", want "brew upgrade --yes entire"` |
| `miseRoots` stops reading `MISE_INSTALLS_DIR` | precondition: `without a contending probe this test no longer pins precedence` |

It also makes clean probe roots the package's default, in a new `global_test.go` `TestMain` that clears the four probe root variables before `m.Run()` — the pattern `cmd/entire/cli/{,checkpoint/,strategy/}global_test.go` already use for keeping host state out of a package's tests. That retires `isolateMiseInstallEnv` and all four of its call sites; `isolateWindowsInstallEnv` keeps only the part that has to be per-test, the temp dir Scoop's `config.json` is read through.

A default rather than a helper because enumeration had already missed sites twice. On merged `main` — *after* #2309's per-test isolation — three subtests still fail under a hostile root:

```
MISE_INSTALLS_DIR=/ go test ./cmd/entire/cli/versioncheck/
--- FAIL: TestMaybeAutoUpdate_AllInstallers_PromptReceivesCorrectCommand/unknown_curl_bash
--- FAIL: TestMaybeAutoUpdate_AllInstallers_HappyPathRunsInstaller/unknown_curl_bash
--- FAIL: TestMaybeAutoUpdate_AllInstallers_KillSwitchPrintsManualHint/unknown_curl_bash
```

Both commits here fix those (the first via the fixture, the second via `TestMain`), so this is not an argument that one beats the other — it is evidence that hand-listing the exposed call sites kept coming up short, which is the case for a default that cannot be forgotten.

`installProbes` now also states at both declarations that order is load-bearing, naming the test that pins it, and the Windows leg gets the precedence test the unix leg had — the mechanism is platform-independent but the proof does not transfer, since `scoopProbe` matches through its own roots as well as a marker where `brewProbe` has markers only.

Scope call worth naming: `XDG_CONFIG_HOME`/`USERPROFILE` stay per-test rather than joining `TestMain`. `scoopRoots` appends `apps` to every input including `config.json`'s `root_path`, so a leaked Scoop root cannot prefix an arbitrary path — the same mandatory-extra-segment property that made `MISE_INSTALLS_DIR`, used verbatim, the dangerous one. The split follows the mechanism, not convenience.

## Verification

`mise run lint` 0 issues, `mise run test:ci` fully green, `GOOS=windows go vet ./...` clean, and the package passes under `MISE_INSTALLS_DIR=/opt`, `/` and `/usr/local` plus `MISE_DATA_DIR=/usr`. Both mutations stay caught: flipping `installProbes` fails on the outcome, stopping mise matching fails on the precondition. The Windows precedence test is reasoned through but not executed locally — darwin cannot run it, and `normalizeInstallRoot` rejects a drive-letter path as non-absolute there — so CI's `test-windows` job is its first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to versioncheck tests; install probe behavior in production is unchanged.
> 
> **Overview**
> **Test-only** follow-up: no production changes.
> 
> Adds **`TestUnixBrewBeatsAMiseRootCoveringTheSamePath`**, which locks the product rule that when both Homebrew and mise would match the same executable (e.g. brew cask under `/opt/homebrew/...` with `MISE_INSTALLS_DIR=/opt`), **`UpdateCommandForCurrentBinary` must return the brew upgrade command**. The test checks that mise still matches first (precondition) so reordering or disabling mise matching cannot pass silently.
> 
> **Hermetic fixtures:** **`isolateMiseInstallEnv`** is now called from **`newAutoUpdateFixture`** and from **`TestCheckAndNotify_InstallerFailureKeepsCacheFresh`**, so auto-update tests no longer depend on the developer’s mise env when resolving install commands—while precedence is asserted in the dedicated test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea58175ec2cd9474163162d9e5cd3d719782bcb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
