### PR TITLE
fix: harden filesystem and exec boundaries (hooks dir, summary providers, branch names, user dirs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -788,7 +788,7 @@ Don't use `fmt.Print*` for operational messages (checkpoint saves, hook invocati
 
 ### The Root Anchors
 
-Entire does filesystem I/O in seven trees, and each has one package that owns a
+Entire does filesystem I/O in eight trees, and each has one package that owns a
 shared `*os.Root` over it. **Never assemble a path into one of these and hand it
 to `os.ReadFile`/`os.WriteFile`/`os.MkdirAll`/`os.ReadDir`/`filepath.Walk`.**
 
@@ -799,6 +799,7 @@ to `os.ReadFile`/`os.WriteFile`/`os.MkdirAll`/`os.ReadDir`/`filepath.Walk`.**
 | the working tree | `worktreedir` | worktree root |
 | an agent's hook config | `agent.HookConfigFile` | worktree root (`.claude/`, `.cursor/`, `.gemini/`, `.github/hooks/`, `.factory/`, `.codex/`, `.opencode/plugins/`, `.pi/extensions/entire/`) |
 | an agent's session store | `agent.SessionStore` | the agent's own `GetSessionDir` |
+| the active git hooks dir | `strategy.hooksRoot` | `git rev-parse --git-path hooks`, absolutized |
 | per-user config / cache | `userdirs.ConfigRoot` / `CacheRoot` | `$ENTIRE_CONFIG_DIR` else `~/.config/entire`; `$XDG_CACHE_HOME/entire` else `~/.cache/entire` |
 | managed plugin tree | `pluginRoot` (`plugin_store.go`) | `pluginParentDir()` — `$ENTIRE_PLUGIN_DIR`, `%LOCALAPPDATA%`, or `$XDG_DATA_HOME` |
 
@@ -897,6 +898,25 @@ comments at each site say which case applies:
 - An agent's session store is where a hook payload's session ID becomes a path,
   via the agent's own `ResolveSessionFile`. `SessionStore.SessionFile` converts
   the result back to a name inside the store and **rejects** an ID that left it.
+- The git hooks directory holds no untrusted *name* — the five hook filenames are
+  compile-time constants — so it is anchored for the opposite reason: what is at
+  those names arrived from somewhere else. It was the last tree Entire wrote to
+  with bare `os.ReadFile`/`os.WriteFile` on a joined path, so a symlink at
+  `.git/hooks/pre-push` was read through and then *written* through, replacing
+  whatever the link named with a shell script. `hooksRoot` refuses a link at the
+  directory (git's own `--git-path hooks` answer, which `core.hooksPath` can put
+  anywhere, which is why no other anchor reaches it); the four reads go through
+  `osroot.ReadFileNoFollow`; and the write is `jsonutil.WriteFileAtomicIn`,
+  whose rename **replaces** a leaf link rather than following it.
+  `osroot.OpenFileNoFollow` is not the tool for that write — it rejects
+  `O_TRUNC` by design, precisely to push truncating writes onto the rename.
+  A symlinked hook is then classified as *foreign* rather than as absent, so it
+  is backed up to `<hook>.pre-entire` and chained to exactly as a foreign script
+  would be: refusing to read through someone's link must not mean silently
+  discarding it. `doctor`'s `checkGitHookSymlinks` reports both conditions, and
+  it is a separate function from `checkAgentDirSymlinks` because that one scans
+  worktree-relative paths through the worktree root and `core.hooksPath` can
+  name a directory outside the worktree entirely.
 
 **Rules that are load-bearing rather than stylistic:**
 
@@ -992,9 +1012,6 @@ comments at each site say which case applies:
 
 **Deliberately not rooted**, with the reason:
 
-- **`.git/hooks`** — `GetHooksDir` honours `core.hooksPath`, so the directory is
-  often not `.git`-resident at all, and the hook filenames are compile-time
-  constants. No untrusted name to contain.
 - **Global/system git config** — `checkpoint/configloader.go` installs a
   *symlink-following* `billy.Basic` on purpose. `os.Root` documents that
   "symbolic links must not be absolute" unconditionally, so go-git's default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1469,6 +1469,22 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
   which raw-writes the single key to the local file whatever `--local`/`--project`
   said about the rest — writing it into the project file produces a setting the
   user can read back and that never takes effect.
+  **The grant also gates `summary_generation.provider`**, which is the other
+  place a tracked file names a binary to execute: `discoverSummaryProviderIfMissing`
+  resolves an unregistered provider by name, so `{"summary_generation":
+  {"provider": "evil"}}` in a pull request was enough to run
+  `entire-agent-evil info` on whoever pulled it and ran `entire explain`.
+  Resolving by name rather than sweeping `$PATH` bounds the blast radius to one
+  binary; it does not make it zero. The check sits *after* the
+  already-registered early return, so a committed `"provider": "claude-code"`
+  is unaffected — the gate lands only on the external case — and the
+  unresolvable-provider error gains a line naming the grant, since "unknown
+  summary provider" about a plugin that is plainly installed is not actionable.
+  A dedicated `enforceSummaryProviderTrust` beside the other two gates would let
+  a developer name an external provider in their own `settings.local.json`
+  without granting the `$PATH` sweep; that is a real want, but it costs a third
+  settings-layer classification and a third rejection channel, so it waits until
+  someone asks for the combination.
 - **A tracked `.entire/settings.local.json` is ignored wholesale**: the local layer's premise is that it is per-clone and per-developer (it is gitignored, `entire enable --local` writes it, and `CheckpointRemoteIsLocalOnly` treats presence there as proof the developer chose it). `.gitignore` does not apply to an already-tracked path, so a committed one arrives by cloning and would override project settings for everyone. `loadMergedSettings` drops the layer when the file is **proven** tracked, records `EntireSettings.LocalLayerRejection()`, and the redaction consumer prints it with the `git rm --cached` fix. It never errors — one committed file must not brick `status`/`doctor`. Two deliberately opposite failure directions, expressed as the three-state `localTrust` (`localUnverifiable` is the zero value so a forgotten assignment fails safe): an *unverifiable* repo keeps the layer (losing all local settings is worse than the risk) but still drops the exec-bearing settings, OPF `command` and `external_agents` (being wrong there means running someone else's binary); *no* repository counts as proof of locality. `CheckpointRemoteIsLocalOnly` reads the raw file outside the loader, so it repeats the check itself.
 - Safe to use on main/master since it never modifies commit history
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1410,16 +1410,31 @@ Two rules about *where* the check goes, both learned by getting them wrong:
   dropped a `.lock` inside it on the way to reporting the refusal, which is the
   mistake itself. `resolveUserRoot` already had this right; the other two did
   not.
-- **A tree with no root to check at must check for itself.** The token store is
-  the fourth consumer and has no root over the config dir: `fileStore.dir`
-  anchors on the dirname of its own path (one of the two places the root-base
-  rule permits that, since `ENTIRE_TOKEN_STORE_PATH` names a file the caller
-  chose) and reaches it through `filepath.Abs`. So it calls
+- **A root whose base is DERIVED cannot enforce this, so its owner must check
+  for itself.** The token store is the fourth consumer, and it does open a root
+  — the claim that it had none was wrong. `fileStore.dir` anchors on
+  `filepath.Dir` of its own path, one of the two places the root-base rule
+  permits a derived base (`ENTIRE_TOKEN_STORE_PATH` names a file the caller
+  chose), and gets there through `filepath.Abs`. That `Abs` is precisely why the
+  root can never refuse a relative config dir: it launders `./relative-config`
+  into a plausible absolute path *before* the root exists, which is the same
+  laundering removed from `contexts` and `discovery`. So the store calls
   `userdirs.ConfigDirChecked` and carries the error on `fileStore.pathErr`,
-  reported by `dir` and `ensureDir` before any filesystem access. Left out, it
-  put bearer tokens at `./<value>/tokens.json`. An explicit
-  `ENTIRE_TOKEN_STORE_PATH` is deliberately still exempt: the user named that
-  file.
+  reported by `dir` and `ensureDir` ahead of any filesystem access — verified
+  through `Get`/`Set`/`Delete`, not just the resolver. Left out, it put bearer
+  tokens at `./<value>/tokens.json`. An explicit `ENTIRE_TOKEN_STORE_PATH` is
+  deliberately still exempt: the user named that file.
+
+- **Only a USER-supplied override is refused; Entire's own fallback is
+  absolutized.** `userdirs.ownFallbackDir` resolves the home-relative default
+  that `configDir`/`cacheDir` produce when `os.UserHomeDir` fails, because by
+  the time a consumer sees a plain string it can no longer tell a value the user
+  set from one Entire made up — and refusing both was a regression: on a machine
+  with no resolvable home (no `HOME`, an odd container, a service account) every
+  command touching a saved login or a discovery cache began failing with advice
+  about a variable the user had never set. There is nothing for them to fix
+  there, and a cwd-relative directory that works beats a hard failure, so the
+  distinction is drawn in the one place that still has the information.
 
 **The OPF `command` is the deliberate exception, and stays one.**
 `redaction.openai_privacy_filter.command` becomes `argv[0]` of an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1061,6 +1061,18 @@ comments at each site say which case applies:
   path that was neither — leaving an extension pi still discovers. Reading
   either coordinate for both jobs gets one of them wrong.
 
+  **The policy is scoped to the worktree it was loaded for.** It has to be a
+  package global — `settings` may import `agent`, not the reverse, so the
+  package that owns the value pushes it in — and an unscoped global would mean
+  last-load-wins deciding for a process that loads settings for one tree and
+  writes an agent config for another. `SetVouchedSymlinkedDirs` records the
+  root, `AnchorWorktreePath` and the doctor/status reporting compare against it,
+  and a mismatch refuses (degrading to the strict behaviour, never to following
+  another tree's link). This is a different question from why `vouchableDirs` is
+  pinned: that is the set a user MAY name, which must not be widenable at
+  runtime; this is the set a user DID name, which is per-configuration and has
+  to come from somewhere mutable.
+
   Scope notes: vouching for `.claude` does **not** vouch for links inside it,
   since below the anchor everything is a name in a root again; the scaffolds go
   through the same anchor (`openScaffoldTarget`), because a vouched directory
@@ -1416,6 +1428,16 @@ which produced a plausible-looking absolute path out of the exact mistake being
 guarded against. Do not reintroduce it.
 
 Two rules about *where* the check goes, both learned by getting them wrong:
+
+- **Who checks is enforced, not enumerated.** `TestUserDirConsumersAreAudited`
+  requires every caller of `Config()`/`Cache()` to appear in a ledger with the
+  reason it is safe. Two successive doc comments tried to list the consumers
+  instead and both were wrong within a commit or two: the token store slipped
+  past the first (bearer tokens at `./<value>/tokens.json`) and `plugin_index`
+  past the second (an index clone and its lock file in the working directory).
+  Converting a caller to `ConfigDirChecked`/`CacheDirChecked` removes it from
+  the ledger, since it is then safe by construction; the list is meant to
+  shrink.
 
 - **It must precede every `MkdirAll`, not merely every root open.** Checking at
   the root is checking at the READ, and `contexts.FilePath` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -980,6 +980,48 @@ comments at each site say which case applies:
   `HookConfigFile.RemoveDir`, because pi discovers extensions by directory, so
   removing only the file would leave a half-uninstalled extension behind.
 
+  **One escape hatch, and only for these directories.**
+  `allow_symlinked_agent_dirs` in `.entire/settings.local.json` names
+  worktree-relative agent config directories whose symlinks Entire follows
+  instead of refusing, anchoring its root on the resolved target
+  (`agent.AnchorWorktreePath` / `OpenAnchoredRoot`). It exists because a
+  dotfile-managed `.claude` (chezmoi, stow, yadm) is an ordinary setup among
+  exactly the people who run coding agents, and the previous answer was "stop
+  managing it that way".
+
+  Three properties make it a hatch rather than a hole, and all three are load
+  bearing:
+
+  - **A list, not a boolean.** A flag would disable the class; naming a path is
+    the user saying which arrangement is theirs.
+  - **Two independent boundaries.** `enforceSymlinkedAgentDirsTrust` answers
+    "may this FILE grant anything" with the same untracked-and-verified gate as
+    the OPF command and `external_agents` (a repository that could both ship the
+    link and vouch for it is the whole attack). `agent.SetVouchedSymlinkedDirs`
+    then answers "is this PATH one an agent config lives under", against a
+    pinned list plus a structural `neverVouchable` rule, so `.entire` and
+    `.git/hooks` are unspellable *even from a verified local file*.
+  - **Pinned, not derived.** `agent.vouchableDirs` was first derived from
+    `AllHookConfigRelPaths()`, which is wrong twice: that registry is mutable at
+    runtime, so an external plugin could widen what a user may vouch for, and it
+    is empty in a binary that has not imported the agent packages, so the set
+    silently collapsed depending on the caller's import graph.
+    `TestVouchableDirsMatchTheBuiltInAgents` (in the `cli` package, where every
+    built-in agent is registered) fails on drift in both directions.
+
+  Scope notes: vouching for `.claude` does **not** vouch for links inside it,
+  since below the anchor everything is a name in a root again; the scaffolds go
+  through the same anchor (`openScaffoldTarget`), because a vouched directory
+  that hook installation follows and scaffolding refuses leaves `entire enable`
+  half-applied across two directories; and a vouched but *unresolvable* link is
+  an error, not a quiet fall back to refusing. `entire status` prints what is
+  being followed and any rejected entries, and `doctor` reports the link under
+  FOLLOWING SYMLINKS rather than as a fault. `.entire`, the settings files, and
+  the git hooks directory are deliberately excluded — the settings case is
+  circular (a symlinked `settings.local.json` vouching for symlinked settings
+  files authorizes itself) and the hooks case already has git's own
+  `core.hooksPath`.
+
   The config FILE is refused too, not just its parents: the merge READ would
   otherwise pull the link target's contents into
   what Entire then writes, and the write is a rename, which replaces the link

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1048,6 +1048,19 @@ comments at each site say which case applies:
     `TestVouchableDirsMatchTheBuiltInAgents` (in the `cli` package, where every
     built-in agent is registered) fails on drift in both directions.
 
+  **The Entire-owned directory is not vouchable, and `RemoveDir` reads the
+  worktree-relative name.** `.pi/extensions/entire` is the one directory Entire
+  both creates *and* deletes, so it cannot also be a link the user manages;
+  `neverVouchable` refuses any path whose base is `entire`, and the pinned list
+  omits it. `HookConfigFile` therefore carries **two coordinates** — `name`
+  (root-relative, for I/O) and `relName` (worktree-relative, for decisions) —
+  the same split `entiredir.Name` draws. `RemoveDir` decides on `relName` and
+  removes on `name`: deciding on the root-relative name let a vouch for
+  `.pi/extensions/entire` anchor the root *on* that directory, collapse the name
+  to `index.ts`, and refuse with "refusing to remove the worktree root" about a
+  path that was neither — leaving an extension pi still discovers. Reading
+  either coordinate for both jobs gets one of them wrong.
+
   Scope notes: vouching for `.claude` does **not** vouch for links inside it,
   since below the anchor everything is a name in a root again; the scaffolds go
   through the same anchor (`openScaffoldTarget`), because a vouched directory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1038,6 +1038,15 @@ comments at each site say which case applies:
   it by anchoring a root on `filepath.Dir(sessionRef)` — that is the derived
   base the rule above refuses, and it would contain nothing while looking like
   it did.
+
+  `TestTranscriptReadsOnlyShrink` (`agent/transcript_read_guard_test.go`) is a
+  **ratchet** over that set: it pins the per-file count of
+  `os.ReadFile(sessionRef)`-shaped reads and fails the build when one grows or a
+  new file appears, and equally when a listed one goes away without its entry
+  following. Growth is the regression it exists to stop — a new agent
+  integration copies the nearest existing one, so the shape spreads by
+  imitation — and a stale entry is the slower failure, since the count is the
+  only record of how much of the gap is left.
 - **Global/system git config** — see the config-loader bullet above; that is the
   one place rooting is actively wrong.
 - **A directory the caller is about to create, replace, or delete** — creating,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1266,11 +1266,29 @@ the same rule; they are one helper because two copies is how they drifted.
 necessarily the file that executes. The check lives at the exec, not at the
 caller, so it also covers the exported `New`.
 
-`pluginParentDir` (`plugin_store.go`) applies the same absoluteness rule to
-every directory override it reads — `ENTIRE_PLUGIN_DIR`, `XDG_DATA_HOME`,
-`LOCALAPPDATA` — via `requireAbsPluginParent`, rather than leaving the platform
-two to `osroot` and to `main.go`'s `PATH` restore. Those backstops hold, but
-they state the invariant two layers from where it is decided.
+**A per-user directory override must be absolute**, and there is one
+implementation of that rule: `userdirs.RequireAbsoluteOverride`. A relative
+value resolves against the working directory, so the same environment names a
+different directory in every process — usually one inside whatever repository
+the command ran from. It covers all three trees an override can redirect:
+`pluginParentDir` (`ENTIRE_PLUGIN_DIR`, `XDG_DATA_HOME`, `LOCALAPPDATA` — a
+tree whose `bin` subdirectory `main.go` prepends to `$PATH`), and the config and
+cache directories (`ENTIRE_CONFIG_DIR`, `XDG_CACHE_HOME`), which hold the login
+tokens and the discovery caches. Leaving it to `osroot` (which refuses a
+relative root open) and to `main.go`'s `PATH` restore was not wrong, but each
+backstop answers a question of its own, two layers from where this one is
+decided.
+
+Rejecting beats falling through to the platform default: for the config
+directory that default is the developer's REAL `~/.config/entire`, so quietly
+substituting it for a test harness's mistyped override is worse than an error.
+`userdirs.Config()`/`Cache()` cannot report — too many callers only want the
+string — so the refusal lands at every root opened over those directories:
+`userdirs`' own (`resolveUserRoot`, which checks *before* creating anything),
+plus `contexts.configRoot` and `discovery.cacheFile.root`, which open their own.
+Those last two used to launder a relative directory through `filepath.Abs`,
+which produced a plausible-looking absolute path out of the exact mistake being
+guarded against. Do not reintroduce it.
 
 **The OPF `command` is the deliberate exception, and stays one.**
 `redaction.openai_privacy_filter.command` becomes `argv[0]` of an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1343,6 +1343,26 @@ avoid-the-shell side) and `cmd/entire/cli/agent/hook_command.go`
 (`escapeWindowsCMD`, the third-party-exec side). Each doc comment points at the
 other.
 
+**The auto-updater's `sh -c` is a considered exception, and it is enforced
+rather than asserted.** `versioncheck.realRunInstaller` (unix only) runs the
+update command through a shell, which the rule above would otherwise forbid. It
+is allowed because there is no dynamic value in it: on unix
+`UpdateCommandForCurrentBinary` returns one of five compile-time literals, and
+the binary's path and version choose *between* them and never appear *in* them —
+while the shell is load-bearing for the fallback, which is a pipeline
+(`curl … | bash`). The tempting next change is exactly the one that breaks this:
+interpolating a channel or a version into the command.
+`TestUpdateCommandIsAlwaysALiteral` (in `versioncheck_unix_test.go`) drives every
+unix install manager and channel with adversarial paths and versions and fails
+when the result is not a known string. A command that genuinely needs a runtime
+value must be built and run as argv, not added to that set.
+
+Windows is deliberately outside that invariant rather than an exception to it:
+`fallbackInstallCommand` there interpolates the running binary's directory into
+`-InstallDir`, and it is safe to because Windows never *runs* the command —
+`realRunInstaller` is unimplemented there, so the string is only ever printed
+for the user to paste.
+
 ### Control-Plane Core Resolution (which core am I talking to?)
 
 Control-plane commands dial one of three cores: the active context's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -799,7 +799,7 @@ to `os.ReadFile`/`os.WriteFile`/`os.MkdirAll`/`os.ReadDir`/`filepath.Walk`.**
 | the working tree | `worktreedir` | worktree root |
 | an agent's hook config | `agent.HookConfigFile` | worktree root (`.claude/`, `.cursor/`, `.gemini/`, `.github/hooks/`, `.factory/`, `.codex/`, `.opencode/plugins/`, `.pi/extensions/entire/`) |
 | an agent's session store | `agent.SessionStore` | the agent's own `GetSessionDir` |
-| the active git hooks dir | `strategy.hooksRoot` | `git rev-parse --git-path hooks`, absolutized |
+| the active git hooks dir | `strategy.hooksRootForInstall` / `ForRemoval` | `git rev-parse --git-path hooks`, absolutized |
 | per-user config / cache | `userdirs.ConfigRoot` / `CacheRoot` | `$ENTIRE_CONFIG_DIR` else `~/.config/entire`; `$XDG_CACHE_HOME/entire` else `~/.cache/entire` |
 | managed plugin tree | `pluginRoot` (`plugin_store.go`) | `pluginParentDir()` — `$ENTIRE_PLUGIN_DIR`, `%LOCALAPPDATA%`, or `$XDG_DATA_HOME` |
 
@@ -903,8 +903,8 @@ comments at each site say which case applies:
   those names arrived from somewhere else. It was the last tree Entire wrote to
   with bare `os.ReadFile`/`os.WriteFile` on a joined path, so a symlink at
   `.git/hooks/pre-push` was read through and then *written* through, replacing
-  whatever the link named with a shell script. `hooksRoot` refuses a link at the
-  directory (git's own `--git-path hooks` answer, which `core.hooksPath` can put
+  whatever the link named with a shell script. `hooksRootForInstall` refuses a
+  link at the directory (git's own `--git-path hooks` answer, which `core.hooksPath` can put
   anywhere, which is why no other anchor reaches it); the four reads go through
   `osroot.ReadFileNoFollow`; and the write is `jsonutil.WriteFileAtomicIn`,
   whose rename **replaces** a leaf link rather than following it.
@@ -913,7 +913,29 @@ comments at each site say which case applies:
   A symlinked hook is then classified as *foreign* rather than as absent, so it
   is backed up to `<hook>.pre-entire` and chained to exactly as a foreign script
   would be: refusing to read through someone's link must not mean silently
-  discarding it. `doctor`'s `checkGitHookSymlinks` reports both conditions, and
+  discarding it.
+
+  **The directory refusal is install-only, and that asymmetry is load-bearing.**
+  `hooksRootForRemoval` resolves the link and anchors on its target; only
+  `hooksRootForInstall` refuses. Removal deletes files carrying Entire's marker
+  and renames back the backups Entire itself made, so it acts only on files
+  Entire created and the redirect costs nothing. Sharing one function cost a
+  great deal: `entire disable` exited non-zero forever with no other uninstall
+  path, and `gitHookStateInHooksDir` reported `GitHooksAbsent`, which sent
+  `EnsureSetup` to `InstallGitHook` and failed **every agent turn** on the same
+  refusal. A refusal a user can neither act on nor uninstall past is worse than
+  the redirect it declines to follow.
+
+  **A hook that cannot be READ is never replaced.** `classifyExistingHook`
+  identifies absent / ours / foreign positively and returns an error for
+  anything else, because the write is `jsonutil.WriteFileAtomicIn` and
+  `rename(2)` needs no permission on the target at all: a mode-0000 hook was
+  classified "not foreign", got no backup, and was silently destroyed. The
+  in-place truncating write this replaced failed loudly with `EACCES`, so
+  switching to the rename (correct, for symlinks) turned a loud failure into
+  data loss. Removal treats the same case as present-and-not-ours, so a backup
+  is not renamed over it either, and warns rather than erroring so uninstall
+  still finishes. `doctor`'s `checkGitHookSymlinks` reports both conditions, and
   it is a separate function from `checkAgentDirSymlinks` because that one scans
   worktree-relative paths through the worktree root and `core.hooksPath` can
   name a directory outside the worktree entirely.
@@ -1030,7 +1052,8 @@ comments at each site say which case applies:
   largest gap left**, so do not read it as settled. The WRITE half is contained
   — every agent's `WriteSession` goes through `agent.WriteSessionFile` and
   `SessionStore`, which rejects a `SessionRef` outside the agent's session
-  directory — while the eight `os.ReadFile(sessionRef)` reads are not, and the
+  directory — while the `os.ReadFile(sessionRef)` reads are not (the count is
+  pinned per file by `agent.TestTranscriptReadsOnlyShrink`), and the
   read is what pulls transcript content into checkpoints. Closing it is a
   protocol change rather than a refactor, which is why it is scoped separately;
   the shape it wants is `HookInput.RepoPath` plus the same
@@ -1292,12 +1315,30 @@ Rejecting beats falling through to the platform default: for the config
 directory that default is the developer's REAL `~/.config/entire`, so quietly
 substituting it for a test harness's mistyped override is worse than an error.
 `userdirs.Config()`/`Cache()` cannot report — too many callers only want the
-string — so the refusal lands at every root opened over those directories:
-`userdirs`' own (`resolveUserRoot`, which checks *before* creating anything),
-plus `contexts.configRoot` and `discovery.cacheFile.root`, which open their own.
-Those last two used to launder a relative directory through `filepath.Abs`,
+string — so **every consumer that turns one into I/O checks, and there are
+four**: `userdirs`' own roots, `contexts`, `discovery`, and the token store.
+The first three used to launder a relative directory through `filepath.Abs`,
 which produced a plausible-looking absolute path out of the exact mistake being
 guarded against. Do not reintroduce it.
+
+Two rules about *where* the check goes, both learned by getting them wrong:
+
+- **It must precede every `MkdirAll`, not merely every root open.** Checking at
+  the root is checking at the READ, and `contexts.FilePath` and
+  `withCacheFileLock` run several steps earlier: they created `./<value>` and
+  dropped a `.lock` inside it on the way to reporting the refusal, which is the
+  mistake itself. `resolveUserRoot` already had this right; the other two did
+  not.
+- **A tree with no root to check at must check for itself.** The token store is
+  the fourth consumer and has no root over the config dir: `fileStore.dir`
+  anchors on the dirname of its own path (one of the two places the root-base
+  rule permits that, since `ENTIRE_TOKEN_STORE_PATH` names a file the caller
+  chose) and reaches it through `filepath.Abs`. So it calls
+  `userdirs.ConfigDirChecked` and carries the error on `fileStore.pathErr`,
+  reported by `dir` and `ensureDir` before any filesystem access. Left out, it
+  put bearer tokens at `./<value>/tokens.json`. An explicit
+  `ENTIRE_TOKEN_STORE_PATH` is deliberately still exempt: the user named that
+  file.
 
 **The OPF `command` is the deliberate exception, and stays one.**
 `redaction.openai_privacy_filter.command` becomes `argv[0]` of an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,6 +457,45 @@ Before pushing commits or otherwise sending code changes to any remote, run `mis
 - Lint errors → run `mise run lint` and fix issues
 - Test failures → run `mise run test` and fix
 
+### Source-Level Guard Tests
+
+Four tests scan this repo's own source with `git grep` to enforce an invariant
+the compiler cannot: `TestRootBasesAreTrusted` (root bases are trusted paths),
+`TestTranscriptReadsOnlyShrink` (the unconfined transcript-read ratchet),
+`TestGitStatusCallSitesPassNoOptionalLocks`, and
+`TestAllHookConfigRelPaths_CoversEveryWorktreeConfigAgent`.
+
+**They all go through `testutil.GitGrepGuard`, which owns three flags.** Each was
+missing from at least one guard, and the same one was missing from three:
+
+- `--untracked`. `git grep` searches the INDEX. Every one of these guards has
+  "someone just added a file" as its subject, so the file it most needs to see is
+  the one not yet staged. Two failure shapes were worse than a miss: the
+  hook-config guard compares two sets built from the same blind grep, so a new
+  agent package calling `OpenHookConfig` without declaring `HookConfigRelPath`
+  was absent from both and the comparison *passed*; and the root-base guard's
+  staleness half reported a just-added entry as STALE, telling the author to
+  delete the entry that legitimised their new root.
+- `--no-color`. `color.ui`/`color.grep` set to `always` colorizes into a pipe and
+  the escapes land in the **filename** field. True of `-l` too, which looks
+  immune. Guards then either misparse (read as staleness, #2248) or compare
+  garbage to garbage while their "did we match anything" assertion still passes.
+- Repo-selector scrubbing. Git exports `GIT_DIR`/`GIT_WORK_TREE` to hooks and
+  they outrank `cmd.Dir`, so a `go test` under a hook or `git rebase --exec`
+  scanned a different repository. `RunGit`'s isolation does **not** cover this:
+  it filters `GIT_CONFIG_*` only.
+
+Two rules for writing one:
+
+- **A pathspec restricted to `*.go`, so an unparseable path can be fatal.** The
+  `git status` guard passed a bare `cmd internal`, which also matched testdata
+  `.jsonl` and a `.md`, so its non-`.go` branch had to `continue` — and that
+  skip was the only thing between colorized output and a guard that silently
+  checked nothing.
+- **Fail on zero matches.** A detection pattern that goes stale otherwise passes
+  forever. `GitGrepGuard` does this itself; the `checked == 0` tallies are the
+  second half of the same idea.
+
 ### Code Duplication Prevention
 
 Before implementing Go code, use `/go:discover-related` to find existing utilities and patterns that might be reusable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1068,7 +1068,14 @@ comments at each site say which case applies:
   writes an agent config for another. `SetVouchedSymlinkedDirs` records the
   root, `AnchorWorktreePath` and the doctor/status reporting compare against it,
   and a mismatch refuses (degrading to the strict behaviour, never to following
-  another tree's link). This is a different question from why `vouchableDirs` is
+  another tree's link). The key is **canonicalized and typed**
+  (`agent.worktreeKey`, built only by `keyFor`), so a raw path cannot be
+  compared against a stored key — that does not compile. The first version
+  compared plain strings and silently disabled the feature on Windows: readers
+  pass git's `--show-toplevel` (`C:/repo`) while settings derives its root
+  through `entiredir.PathTo`, whose `filepath.Join` rewrites it (`C:\repo`).
+  One directory, two spellings, never equal, and every symptom looked exactly
+  like an absent grant. This is a different question from why `vouchableDirs` is
   pinned: that is the set a user MAY name, which must not be widenable at
   runtime; this is the set a user DID name, which is per-configuration and has
   to come from somewhere mutable.

--- a/cmd/entire/cli/agent/hook_config_file.go
+++ b/cmd/entire/cli/agent/hook_config_file.go
@@ -54,8 +54,18 @@ import (
 // entry — and manages it locally, which is what a dotfile workflow does anyway.
 type HookConfigFile struct {
 	root *os.Root
+	// name is root-relative, for I/O. It is NOT worktree-relative: when a
+	// vouched symlinked agent directory was followed, the root is anchored at
+	// that directory's target and name has lost the components consumed getting
+	// there.
 	name string
-	path string
+	// relName is the worktree-relative name, for every DECISION about the path
+	// as opposed to every access through it. Two coordinates for one file, the
+	// same split entiredir.Name draws, and RemoveDir is why it exists: it
+	// reasons about which directory it is allowed to delete, and doing that on
+	// the root-relative name let anchoring change the answer.
+	relName string
+	path    string
 }
 
 // HookConfigLocator is implemented by an agent whose Entire hook configuration
@@ -105,8 +115,9 @@ func OpenHookConfig(worktreeRoot, relPath string) (*HookConfigFile, error) {
 		return nil, fmt.Errorf("resolve hook config path: %w", err)
 	}
 	return &HookConfigFile{
-		root: root,
-		name: inner,
+		root:    root,
+		name:    inner,
+		relName: name,
 		// The link's own path, not the resolved one. It is what the user typed,
 		// what doctor prints, and what the agents write into their own config,
 		// where following the link is the agent's business and works.
@@ -196,14 +207,35 @@ func (f *HookConfigFile) Remove() error {
 // root and every shared intermediate fails the name test instead, and pi's
 // `.pi/extensions/entire` passes it because Entire is what created it.
 func (f *HookConfigFile) RemoveDir() error {
-	dir := path.Dir(f.name)
-	if dir == "." {
+	// The precondition is decided on the WORKTREE-relative name and the removal
+	// is performed on the root-relative one. Deciding on the root-relative name
+	// was a bug: with a vouched symlink at `.pi/extensions/entire` the root
+	// anchors on that directory's target and the name collapses to `index.ts`,
+	// so path.Dir was "." and uninstall refused with "refusing to remove the
+	// worktree root" -- about a path that was neither. Pi discovers extensions
+	// by directory, so the refusal left one it still loads. The two coordinates
+	// answer different questions and only relName answers this one.
+	relDir := path.Dir(f.relName)
+	if relDir == "." {
 		return fmt.Errorf("remove %s: refusing to remove the worktree root", filepath.Dir(f.path))
 	}
-	if path.Base(dir) != entireOwnedDirName {
+	if path.Base(relDir) != entireOwnedDirName {
 		return fmt.Errorf("remove %s: refusing to remove %q, which Entire did not create; "+
 			"RemoveDir is only for a directory named %q that holds one generated file",
-			filepath.Dir(f.path), path.Base(dir), entireOwnedDirName)
+			filepath.Dir(f.path), path.Base(relDir), entireOwnedDirName)
+	}
+
+	dir := path.Dir(f.name)
+	if dir == "." {
+		// The owned directory IS the anchor, so it cannot be removed through
+		// its own root (see "A directory cannot be created, statted, or removed
+		// through its own root" in CLAUDE.md). Unreachable today, because
+		// neverVouchable refuses a vouch for the Entire-owned directory itself
+		// for exactly this reason. Kept as the honest answer rather than as the
+		// misleading one above, since any future way of anchoring here needs a
+		// real message and not a claim about the worktree root.
+		return fmt.Errorf("remove %s: the directory Entire owns is itself the followed symlink, "+
+			"so it cannot be removed from inside; remove the link by hand", filepath.Dir(f.path))
 	}
 	if err := osroot.RemoveAllNoSymlinks(f.root, dir); err != nil {
 		return fmt.Errorf("remove %s: %w", filepath.Dir(f.path), err)

--- a/cmd/entire/cli/agent/hook_config_file.go
+++ b/cmd/entire/cli/agent/hook_config_file.go
@@ -86,18 +86,31 @@ type HookConfigLocator interface {
 // (".cursor/hooks.json"). The directory does not need to exist: Read reports a
 // missing file the way os.ReadFile does, and Write creates the parents.
 func OpenHookConfig(worktreeRoot, relPath string) (*HookConfigFile, error) {
+	// Validate against the worktree root first, so a relPath that escapes is
+	// rejected before anything is resolved. AnchorWorktreePath re-anchors only
+	// on directories the user vouched for by name, but it should never be the
+	// thing deciding whether the path was well formed.
 	name, err := worktreedir.Name(worktreeRoot, relPath)
 	if err != nil {
 		return nil, fmt.Errorf("resolve hook config path: %w", err)
 	}
-	root, err := worktreedir.OpenAt(worktreeRoot)
+	display := filepath.Join(worktreeRoot, filepath.FromSlash(name))
+
+	// Two bases, one behaviour below. The ordinary case anchors on the worktree
+	// root and every agent directory stays a name inside it, refusable by
+	// MkdirAllNoSymlink. A vouched symlinked directory anchors on its resolved
+	// target instead, and everything below it is still a name inside a root.
+	root, inner, err := OpenAnchoredRoot(worktreeRoot, name)
 	if err != nil {
-		return nil, fmt.Errorf("open worktree root: %w", err)
+		return nil, fmt.Errorf("resolve hook config path: %w", err)
 	}
 	return &HookConfigFile{
 		root: root,
-		name: name,
-		path: filepath.Join(worktreeRoot, filepath.FromSlash(name)),
+		name: inner,
+		// The link's own path, not the resolved one. It is what the user typed,
+		// what doctor prints, and what the agents write into their own config,
+		// where following the link is the agent's business and works.
+		path: display,
 	}, nil
 }
 

--- a/cmd/entire/cli/agent/transcript_read_guard_test.go
+++ b/cmd/entire/cli/agent/transcript_read_guard_test.go
@@ -1,0 +1,121 @@
+package agent_test
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// transcriptReadPattern matches a read of an already-resolved transcript path:
+// ReadTranscript(path) and ReadSession(input) receive a path rather than a repo,
+// so neither can build a SessionStore, and both call straight into os.
+//
+// The two variable names are the whole vocabulary these signatures use. Keying
+// on them rather than on os.ReadFile in general keeps the guard about the
+// transcript-read gap and not about every file the agent packages open.
+const transcriptReadPattern = `os\.(ReadFile|Open)\((sessionRef|transcriptPath)\)`
+
+// unconfinedTranscriptReads is the number of unconfined transcript reads each
+// file is currently allowed, and why the file has any.
+//
+// This is a RATCHET, not an allowlist: the set is expected to shrink to nothing
+// and must never grow. It exists because the rooting of Entire's I/O is
+// knowingly asymmetric here, and the asymmetric half is the one that matters.
+// Every WriteSession goes through agent.WriteSessionFile and SessionStore, which
+// rejects a SessionRef outside the agent's session directory; the reads below
+// have no such boundary, and the read is what pulls transcript content into a
+// checkpoint. Closing the gap needs RepoPath on HookInput — a change to the
+// external-plugin protocol rather than a refactor — which is exactly the kind of
+// work that stalls while the count quietly climbs.
+//
+// Do NOT close a finding here by anchoring a root on filepath.Dir(sessionRef).
+// That puts every component the resolver produced above the root, so it contains
+// nothing while looking like it does. See "The Root Anchors" in CLAUDE.md.
+var unconfinedTranscriptReads = map[string]int{
+	"cmd/entire/cli/agent/claudecode/lifecycle.go":          1,
+	"cmd/entire/cli/agent/codex/codex.go":                   1,
+	"cmd/entire/cli/agent/codex/transcript.go":              1,
+	"cmd/entire/cli/agent/copilotcli/copilotcli.go":         1,
+	"cmd/entire/cli/agent/copilotcli/transcript.go":         3,
+	"cmd/entire/cli/agent/cursor/lifecycle.go":              1,
+	"cmd/entire/cli/agent/cursor/transcript.go":             1,
+	"cmd/entire/cli/agent/factoryaidroid/factoryaidroid.go": 1,
+	"cmd/entire/cli/agent/factoryaidroid/lifecycle.go":      1,
+	"cmd/entire/cli/agent/geminicli/lifecycle.go":           1,
+	"cmd/entire/cli/agent/vogon/vogon.go":                   1,
+
+	// The integration harness reads a transcript it wrote itself, in a temp
+	// repo it built. Listed rather than excluded by path, so that a real read
+	// added under a build tag cannot hide behind the exclusion.
+	"cmd/entire/cli/integration_test/hooks.go": 2,
+}
+
+// TestTranscriptReadsOnlyShrink fails the build when a new unconfined
+// transcript read appears, and when a listed one goes away without the entry
+// following it.
+//
+// Both directions matter. Growth is the regression this exists to stop: a new
+// agent integration copies the nearest existing one, so the shape spreads by
+// imitation and nobody re-derives whether it is safe. A stale entry is the
+// slower failure — a ratchet nobody prunes stops meaning anything, and the
+// count is the only record of how much of the gap is left.
+func TestTranscriptReadsOnlyShrink(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := exec.Command("git", "rev-parse", "--show-toplevel").Output() //nolint:noctx // guard test, no cancellation needed
+	if err != nil {
+		t.Skipf("not in a git checkout: %v", err)
+	}
+
+	// --no-color for the reason rootbase_guard_test.go gives: color.ui set to
+	// `always` colorizes into a pipe, the escapes land in the filename field,
+	// and every line then parses as something this test cannot use.
+	grep := exec.Command("git", "grep", "-c", "--no-color", "-E", "--", transcriptReadPattern, //nolint:noctx // guard test, no cancellation needed
+		"--", ":(glob)cmd/**/*.go", ":(exclude,glob)**/*_test.go")
+	grep.Dir = strings.TrimSpace(string(repoRoot))
+	out, grepErr := grep.Output()
+	if grepErr != nil {
+		t.Fatalf("git grep for %q found nothing, which cannot be right — the pattern has gone stale: %v", transcriptReadPattern, grepErr)
+	}
+
+	found := map[string]int{}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		file, countText, ok := strings.Cut(line, ":")
+		count, convErr := strconv.Atoi(countText)
+		if !ok || !strings.HasSuffix(file, ".go") || convErr != nil {
+			t.Fatalf("cannot parse git grep output; expected `path:count`, got:\n  %s\n"+
+				"The filename field is unusable, so this test can prove nothing. "+
+				"Check whether git is colorizing into a pipe (color.ui or color.grep set to `always`).", line)
+		}
+		found[file] = count
+	}
+	if len(found) == 0 {
+		t.Fatal("guard matched no transcript reads at all; the detection pattern has gone stale and must be re-pointed")
+	}
+
+	for file, count := range found {
+		allowed, listed := unconfinedTranscriptReads[file]
+		if !listed {
+			t.Errorf("%s reads a transcript by path without a containment boundary, and is not on the ratchet.\n"+
+				"Route the read through the agent's SessionStore if you can. If the read genuinely "+
+				"cannot be confined yet, add the file to unconfinedTranscriptReads with the reason — "+
+				"and do NOT anchor a root on filepath.Dir(sessionRef), which contains nothing.", file)
+			continue
+		}
+		if count > allowed {
+			t.Errorf("%s has %d unconfined transcript reads, up from %d. This set may only shrink.", file, count, allowed)
+		}
+		if count < allowed {
+			t.Errorf("%s has %d unconfined transcript reads, down from %d — lower its entry in unconfinedTranscriptReads.", file, count, allowed)
+		}
+	}
+	for file := range unconfinedTranscriptReads {
+		if _, still := found[file]; !still {
+			t.Errorf("%s is on the ratchet but no longer reads a transcript by path; remove the entry.", file)
+		}
+	}
+}

--- a/cmd/entire/cli/agent/transcript_read_guard_test.go
+++ b/cmd/entire/cli/agent/transcript_read_guard_test.go
@@ -1,10 +1,10 @@
 package agent_test
 
 import (
-	"os/exec"
-	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
 // transcriptReadPattern matches a read of an already-resolved transcript path:
@@ -63,35 +63,33 @@ var unconfinedTranscriptReads = map[string]int{
 func TestTranscriptReadsOnlyShrink(t *testing.T) {
 	t.Parallel()
 
-	repoRoot, err := exec.Command("git", "rev-parse", "--show-toplevel").Output() //nolint:noctx // guard test, no cancellation needed
-	if err != nil {
-		t.Skipf("not in a git checkout: %v", err)
+	repoRoot, ok := testutil.GitGrepGuardRepoRoot(t)
+	if !ok {
+		return
 	}
 
-	// --no-color for the reason rootbase_guard_test.go gives: color.ui set to
-	// `always` colorizes into a pipe, the escapes land in the filename field,
-	// and every line then parses as something this test cannot use.
-	grep := exec.Command("git", "grep", "-c", "--no-color", "-E", "--", transcriptReadPattern, //nolint:noctx // guard test, no cancellation needed
+	// -o, not -c: `git grep -c` counts LINES containing a match, so a second
+	// read added to a line that already had one is invisible to the ratchet.
+	// -o emits one output line per MATCH, which is what the counts below mean.
+	//
+	// testutil.GitGrepGuard owns --untracked, --no-color and the repo-selector
+	// scrubbing, and explains why each is load-bearing for a guard like this.
+	out := testutil.GitGrepGuard(t, repoRoot, "-o", "-E", "--", transcriptReadPattern,
 		"--", ":(glob)cmd/**/*.go", ":(exclude,glob)**/*_test.go")
-	grep.Dir = strings.TrimSpace(string(repoRoot))
-	out, grepErr := grep.Output()
-	if grepErr != nil {
-		t.Fatalf("git grep for %q found nothing, which cannot be right — the pattern has gone stale: %v", transcriptReadPattern, grepErr)
-	}
 
+	// One line per match, `path:line:matched-text`, so the tally is of matches.
 	found := map[string]int{}
-	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
 		if line == "" {
 			continue
 		}
-		file, countText, ok := strings.Cut(line, ":")
-		count, convErr := strconv.Atoi(countText)
-		if !ok || !strings.HasSuffix(file, ".go") || convErr != nil {
-			t.Fatalf("cannot parse git grep output; expected `path:count`, got:\n  %s\n"+
+		file, _, ok := strings.Cut(line, ":")
+		if !ok || !strings.HasSuffix(file, ".go") {
+			t.Fatalf("cannot parse git grep output; expected `path:line:match`, got:\n  %s\n"+
 				"The filename field is unusable, so this test can prove nothing. "+
 				"Check whether git is colorizing into a pipe (color.ui or color.grep set to `always`).", line)
 		}
-		found[file] = count
+		found[file]++
 	}
 	if len(found) == 0 {
 		t.Fatal("guard matched no transcript reads at all; the detection pattern has gone stale and must be re-pointed")

--- a/cmd/entire/cli/agent/vouched_dirs.go
+++ b/cmd/entire/cli/agent/vouched_dirs.go
@@ -1,0 +1,257 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
+)
+
+// Vouched agent directories: the one place a symlink Entire would otherwise
+// refuse is followed on purpose.
+//
+// The refusal these opt out of is real and stays the default. A working tree
+// arrives by clone, so a symlink at `.claude` can be something the REPOSITORY
+// chose, and `entire enable` would then create directories and write JSON
+// through it to wherever it points. Nothing about the link says which of those
+// two it is.
+//
+// What tells them apart is not the link. It is who said the link is fine, and
+// where they said it: settings.AllowSymlinkedAgentDirs is honored only from an
+// untracked, index-and-HEAD-verified .entire/settings.local.json, the same gate
+// that guards the OPF command and external_agents. A repository cannot put a
+// path in that list, so following one is always this developer's own decision
+// about their own machine.
+//
+// It exists because the setup is ordinary rather than exotic: dotfile managers
+// (chezmoi, stow, yadm) symlink `.claude` into a repository, and the people
+// running coding agents are the people who use those. Before this, the only
+// answer was to stop managing the directory that way.
+//
+// Deliberately NOT extended to `.entire`, to the settings files, or to the git
+// hooks directory:
+//
+//   - `.entire` holds the redaction settings that decide what may be committed
+//     and pushed. "Follow this link to decide what your transcripts leak" is
+//     not a knob worth having.
+//   - A settings file is where the grant itself would live, so a symlinked
+//     settings.local.json vouching for symlinked settings files would authorize
+//     itself. There is no non-circular place to put that permission.
+//   - The git hooks directory already has this escape hatch, and git owns it:
+//     `git config core.hooksPath <target>` says the same thing without the
+//     link. A second spelling would be ours to keep in step for no gain.
+var (
+	vouchedMu   sync.RWMutex
+	vouchedDirs []string
+)
+
+// SetVouchedSymlinkedDirs installs the set of worktree-relative agent
+// directories whose symlinks may be followed, replacing any previous set, and
+// returns the entries it refused.
+//
+// Refusal is by NAME, against the directories actually derivable from the
+// agents' own hook-config paths (see VouchableSymlinkedDirs). That is what keeps
+// the list from becoming a general "follow symlinks" switch: `.entire`,
+// `.git/hooks`, and anything else that is not an agent's config directory are
+// not spellable here at all, whoever is doing the spelling.
+//
+// The zero value vouches for nothing, so a caller that never configures a
+// policy gets the strict behaviour. That direction is deliberate: forgetting
+// this call costs a refusal the user can act on, where the opposite default
+// would silently follow links nobody approved.
+func SetVouchedSymlinkedDirs(dirs []string) (rejected []string) {
+	vouchable := VouchableSymlinkedDirs()
+	accepted := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		clean := path.Clean(filepath.ToSlash(strings.TrimSpace(d)))
+		clean = strings.TrimSuffix(clean, "/")
+		if clean == "" || !slices.Contains(vouchable, clean) {
+			rejected = append(rejected, d)
+			continue
+		}
+		if !slices.Contains(accepted, clean) {
+			accepted = append(accepted, clean)
+		}
+	}
+
+	vouchedMu.Lock()
+	vouchedDirs = accepted
+	vouchedMu.Unlock()
+	return rejected
+}
+
+// VouchedSymlinkedDirs returns the accepted set, for doctor and status to
+// report what is being followed rather than leaving it invisible.
+func VouchedSymlinkedDirs() []string {
+	vouchedMu.RLock()
+	defer vouchedMu.RUnlock()
+	return slices.Clone(vouchedDirs)
+}
+
+// vouchableDirs is every worktree-relative directory a user may vouch for: each
+// directory component of every BUILT-IN agent's hook-config path.
+//
+// Pinned rather than derived from AllHookConfigRelPaths, which was the first
+// version and was wrong twice over. The registry is MUTABLE at runtime -- an
+// external plugin registers into it -- so deriving would let a plugin widen the
+// set of paths a user can be persuaded to vouch for, which is the opposite of
+// what a boundary is for. And it is EMPTY in any binary that has not imported
+// the agent packages, so the derived set silently refused every legitimate
+// entry depending on the import graph of the caller.
+//
+// Drift is caught rather than trusted: TestVouchableDirsMatchTheBuiltInAgents
+// runs in a binary where every built-in agent IS registered and fails in both
+// directions, so a new agent that forgets this list cannot ship.
+var vouchableDirs = []string{
+	".claude",
+	".codex",
+	".cursor",
+	".factory",
+	".gemini",
+	".github",
+	".github/hooks",
+	".opencode",
+	".opencode/plugins",
+	".pi",
+	".pi/extensions",
+	".pi/extensions/entire",
+}
+
+// VouchableSymlinkedDirs is the set a user may name, with the trees Entire owns
+// removed whatever the list above says.
+//
+// neverVouchable is applied here rather than only trusted to be absent, because
+// this is the last line between a settings file and a followed symlink: if a
+// future agent ever declared a config path under .entire or .git, or the list
+// above were edited carelessly, the structural rule still refuses it. Two cheap
+// checks that must both pass beats one that must never be got wrong.
+func VouchableSymlinkedDirs() []string {
+	out := make([]string, 0, len(vouchableDirs))
+	for _, d := range vouchableDirs {
+		if neverVouchable(d) {
+			continue
+		}
+		out = append(out, d)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// neverVouchable names the trees whose symlink refusals are not negotiable,
+// whoever is asking and however the path is spelled.
+//
+// .entire holds the redaction settings that decide what may be committed, and
+// .git holds the hooks directory, whose escape hatch is core.hooksPath rather
+// than this. Matched as path prefixes so a deeper path cannot slip under.
+func neverVouchable(dir string) bool {
+	for _, owned := range []string{".entire", ".git"} {
+		if dir == owned || strings.HasPrefix(dir, owned+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// isVouched reports whether a worktree-relative directory has been vouched for.
+func isVouched(dir string) bool {
+	vouchedMu.RLock()
+	defer vouchedMu.RUnlock()
+	return slices.Contains(vouchedDirs, dir)
+}
+
+// AnchorWorktreePath resolves the directory to anchor a root on for a
+// worktree-relative path, following a vouched symlinked agent directory and
+// returning the remaining name inside that directory.
+//
+// Walks the path's directory components outside in. A component that is not a
+// symlink stays a NAME inside the current base, which is what keeps the strict
+// open below able to refuse it; a component that IS a symlink is followed only
+// when its accumulated worktree-relative path was vouched for, and re-anchors
+// the walk on the resolved target. An unvouched link is left in the name on
+// purpose, so the caller's own MkdirAllNoSymlink / LstatNoSymlinks refuses it
+// and says which component, exactly as before.
+//
+// followed names the links that were resolved, so callers can report them. It
+// is normally empty.
+//
+// Exported because the skill scaffolds (writeManagedScaffold) write under the
+// same agent directories and must reach the same place. A vouched `.claude`
+// that hook installation follows but scaffolding does not would leave `entire
+// enable` half-applied, with files in two directories.
+func AnchorWorktreePath(worktreeRoot, relPath string) (baseDir, name string, followed []string, err error) {
+	segments := strings.Split(filepath.ToSlash(relPath), "/")
+	baseDir = worktreeRoot
+	onDisk := worktreeRoot
+	vouchName := ""
+	start := 0
+
+	for i := range len(segments) - 1 {
+		onDisk = filepath.Join(onDisk, segments[i])
+		vouchName = path.Join(vouchName, segments[i])
+
+		info, lerr := os.Lstat(onDisk)
+		if lerr != nil || info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		if !isVouched(vouchName) {
+			continue
+		}
+		resolved, rerr := filepath.EvalSymlinks(onDisk)
+		if rerr != nil {
+			// A vouched but unresolvable link is an error rather than a silent
+			// fallback to the strict path: the user said to follow this one, and
+			// "we could not" is a different answer from "we would not".
+			return "", "", nil, &VouchedDirError{Dir: vouchName, Err: rerr}
+		}
+		followed = append(followed, vouchName)
+		baseDir = resolved
+		onDisk = resolved
+		start = i + 1
+	}
+	return baseDir, strings.Join(segments[start:], "/"), followed, nil
+}
+
+// OpenAnchoredRoot resolves relPath through any vouched symlinked agent
+// directory and returns the root to work in plus the name inside it.
+//
+// The single place the anchor for a worktree-relative agent path is chosen, so
+// the hook configs and the skill scaffolds cannot drift onto different bases.
+// The two bases it can return are both trusted: the worktree root, which a
+// resolver produced, and a vouched directory's resolved target, which the user
+// named in a file only they can write.
+func OpenAnchoredRoot(worktreeRoot, relPath string) (*os.Root, string, error) {
+	baseDir, name, _, err := AnchorWorktreePath(worktreeRoot, relPath)
+	if err != nil {
+		return nil, "", err
+	}
+	if baseDir == worktreeRoot {
+		root, openErr := worktreedir.OpenAt(worktreeRoot)
+		if openErr != nil {
+			return nil, "", fmt.Errorf("open worktree root: %w", openErr)
+		}
+		return root, name, nil
+	}
+	root, openErr := osroot.Shared(baseDir)
+	if openErr != nil {
+		return nil, "", fmt.Errorf("open vouched agent directory %s: %w", baseDir, openErr)
+	}
+	return root, name, nil
+}
+
+// VouchedDirError reports a vouched agent directory that could not be resolved.
+type VouchedDirError struct {
+	Dir string
+	Err error
+}
+
+func (e *VouchedDirError) Error() string {
+	return "resolve vouched agent directory " + e.Dir + ": " + e.Err.Error()
+}
+
+func (e *VouchedDirError) Unwrap() error { return e.Err }

--- a/cmd/entire/cli/agent/vouched_dirs.go
+++ b/cmd/entire/cli/agent/vouched_dirs.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -70,8 +71,52 @@ import (
 var (
 	vouchedMu      sync.RWMutex
 	vouchedDirs    []string
-	vouchedForRoot string
+	vouchedForRoot worktreeKey
 )
+
+// worktreeKey is a canonicalized worktree root, and a distinct TYPE so that a
+// raw path cannot be compared against a stored key by accident: assigning or
+// comparing a plain string here does not compile, so every comparison has to go
+// through keyFor.
+//
+// That is not decoration. The first version stored a plain string and compared
+// it directly, which silently disabled the whole feature on Windows: git's
+// `rev-parse --show-toplevel` prints forward slashes (C:/repo), while the
+// settings side reaches the same directory through entiredir.PathTo, whose
+// filepath.Join rewrites it to C:\repo. The two spellings name one directory
+// and compare unequal, so a verified local grant never applied and hook
+// install, scaffolding, doctor and status all went on refusing the link -- with
+// no diagnostic, because "refused" is also what an absent grant looks like.
+type worktreeKey string
+
+// goosWindows is runtime.GOOS on Windows.
+const goosWindows = "windows"
+
+// keyFor canonicalizes a worktree root for comparison.
+//
+// Abs (which also Cleans) settles relative spellings and redundant components;
+// ToSlash settles the separator, which is the one that actually bit; and
+// Windows paths are lowered because the filesystem is case-insensitive there,
+// so two spellings differing only in case are the same directory and must not
+// key differently.
+//
+// Symlinks are deliberately NOT resolved. Both producers reach this through
+// git's --show-toplevel, which has already resolved them, so an EvalSymlinks
+// here would buy nothing and could fail on a tree being torn down.
+func keyFor(worktreeRoot string) worktreeKey {
+	if worktreeRoot == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(worktreeRoot)
+	if err != nil {
+		abs = filepath.Clean(worktreeRoot)
+	}
+	key := filepath.ToSlash(abs)
+	if runtime.GOOS == goosWindows {
+		key = strings.ToLower(key)
+	}
+	return worktreeKey(key)
+}
 
 // SetVouchedSymlinkedDirs installs the set of worktree-relative agent
 // directories whose symlinks may be followed, replacing any previous set, and
@@ -104,7 +149,7 @@ func SetVouchedSymlinkedDirs(worktreeRoot string, dirs []string) (rejected []str
 
 	vouchedMu.Lock()
 	vouchedDirs = accepted
-	vouchedForRoot = worktreeRoot
+	vouchedForRoot = keyFor(worktreeRoot)
 	vouchedMu.Unlock()
 	return rejected
 }
@@ -117,7 +162,7 @@ func SetVouchedSymlinkedDirs(worktreeRoot string, dirs []string) (rejected []str
 func VouchedSymlinkedDirs(worktreeRoot string) []string {
 	vouchedMu.RLock()
 	defer vouchedMu.RUnlock()
-	if vouchedForRoot != worktreeRoot {
+	if vouchedForRoot != keyFor(worktreeRoot) {
 		return nil
 	}
 	return slices.Clone(vouchedDirs)
@@ -223,12 +268,13 @@ func neverVouchable(dir string) bool {
 // isVouched reports whether dir was vouched for IN worktreeRoot.
 //
 // The root comparison is the whole point: a policy loaded for another worktree
-// must not decide anything here. It is a plain string compare on the value the
-// caller was given, which is the same value settings resolved the policy for.
+// must not decide anything here. It compares CANONICAL keys, never the raw
+// strings -- the two sides reach the same directory by different routes and
+// spell it differently on Windows. See worktreeKey.
 func isVouched(worktreeRoot, dir string) bool {
 	vouchedMu.RLock()
 	defer vouchedMu.RUnlock()
-	return vouchedForRoot == worktreeRoot && slices.Contains(vouchedDirs, dir)
+	return vouchedForRoot == keyFor(worktreeRoot) && slices.Contains(vouchedDirs, dir)
 }
 
 // AnchorWorktreePath resolves the directory to anchor a root on for a

--- a/cmd/entire/cli/agent/vouched_dirs.go
+++ b/cmd/entire/cli/agent/vouched_dirs.go
@@ -46,9 +46,31 @@ import (
 //   - The git hooks directory already has this escape hatch, and git owns it:
 //     `git config core.hooksPath <target>` says the same thing without the
 //     link. A second spelling would be ours to keep in step for no gain.
+//
+// The policy is process-global because the import direction forces it:
+// `settings` may import `agent`, `agent` may not import `settings`, so the
+// package that owns the value has to push it in. It is SCOPED to the worktree
+// it was loaded for, which is what keeps that from being a hazard.
+//
+// Without the scope the coupling is real even if nothing exploits it today: a
+// process that loads settings for worktree A and then writes an agent config
+// for worktree B would follow a link A vouched for and B did not, with
+// last-load-wins deciding. AnchorWorktreePath takes a worktreeRoot, so it can
+// simply refuse to apply a policy that was not loaded for that root -- and
+// refusing is the safe direction, since it degrades to the strict behaviour
+// rather than to following someone else's link.
+//
+// It is worth being precise about how this differs from vouchableDirs, which is
+// pinned rather than derived on the argument that a runtime-mutable registry is
+// the wrong thing to build a boundary on. That argument is about the set of
+// paths a user MAY name: it must not be widenable by anything at runtime. This
+// is the set a user DID name, which is per-configuration by nature and has to
+// come from somewhere mutable. The boundary is vouchableDirs; this is the
+// input it filters.
 var (
-	vouchedMu   sync.RWMutex
-	vouchedDirs []string
+	vouchedMu      sync.RWMutex
+	vouchedDirs    []string
+	vouchedForRoot string
 )
 
 // SetVouchedSymlinkedDirs installs the set of worktree-relative agent
@@ -65,7 +87,7 @@ var (
 // policy gets the strict behaviour. That direction is deliberate: forgetting
 // this call costs a refusal the user can act on, where the opposite default
 // would silently follow links nobody approved.
-func SetVouchedSymlinkedDirs(dirs []string) (rejected []string) {
+func SetVouchedSymlinkedDirs(worktreeRoot string, dirs []string) (rejected []string) {
 	vouchable := VouchableSymlinkedDirs()
 	accepted := make([]string, 0, len(dirs))
 	for _, d := range dirs {
@@ -82,16 +104,44 @@ func SetVouchedSymlinkedDirs(dirs []string) (rejected []string) {
 
 	vouchedMu.Lock()
 	vouchedDirs = accepted
+	vouchedForRoot = worktreeRoot
 	vouchedMu.Unlock()
 	return rejected
 }
 
-// VouchedSymlinkedDirs returns the accepted set, for doctor and status to
-// report what is being followed rather than leaving it invisible.
-func VouchedSymlinkedDirs() []string {
+// VouchedSymlinkedDirs returns the accepted set for worktreeRoot, for doctor
+// and status to report what is being followed rather than leaving it invisible.
+//
+// Scoped like the enforcement path, so a report can never name links that are
+// not in fact being followed here.
+func VouchedSymlinkedDirs(worktreeRoot string) []string {
 	vouchedMu.RLock()
 	defer vouchedMu.RUnlock()
+	if vouchedForRoot != worktreeRoot {
+		return nil
+	}
 	return slices.Clone(vouchedDirs)
+}
+
+// FollowedSymlinkedDirs is the subset of the vouched set that is a symlink on
+// disk right now, in worktreeRoot.
+//
+// Distinct from VouchedSymlinkedDirs, which reports the CONFIGURATION. A user
+// may legitimately vouch for `.claude` on a machine where it is an ordinary
+// directory, is absent, or is a dangling link, and in none of those cases is
+// Entire following anything. Saying "Following symlinked agent directories" for
+// a path that is a plain directory is simply false, so the user-facing report
+// asks this instead.
+func FollowedSymlinkedDirs(worktreeRoot string) []string {
+	var out []string
+	for _, dir := range VouchedSymlinkedDirs(worktreeRoot) {
+		info, err := os.Lstat(filepath.Join(worktreeRoot, filepath.FromSlash(dir)))
+		if err != nil || info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		out = append(out, dir)
+	}
+	return out
 }
 
 // vouchableDirs is every worktree-relative directory a user may vouch for: each
@@ -170,11 +220,15 @@ func neverVouchable(dir string) bool {
 	return path.Base(dir) == entireOwnedDirName
 }
 
-// isVouched reports whether a worktree-relative directory has been vouched for.
-func isVouched(dir string) bool {
+// isVouched reports whether dir was vouched for IN worktreeRoot.
+//
+// The root comparison is the whole point: a policy loaded for another worktree
+// must not decide anything here. It is a plain string compare on the value the
+// caller was given, which is the same value settings resolved the policy for.
+func isVouched(worktreeRoot, dir string) bool {
 	vouchedMu.RLock()
 	defer vouchedMu.RUnlock()
-	return slices.Contains(vouchedDirs, dir)
+	return vouchedForRoot == worktreeRoot && slices.Contains(vouchedDirs, dir)
 }
 
 // AnchorWorktreePath resolves the directory to anchor a root on for a
@@ -211,7 +265,7 @@ func AnchorWorktreePath(worktreeRoot, relPath string) (baseDir, name string, fol
 		if lerr != nil || info.Mode()&os.ModeSymlink == 0 {
 			continue
 		}
-		if !isVouched(vouchName) {
+		if !isVouched(worktreeRoot, vouchName) {
 			continue
 		}
 		resolved, rerr := filepath.EvalSymlinks(onDisk)

--- a/cmd/entire/cli/agent/vouched_dirs.go
+++ b/cmd/entire/cli/agent/vouched_dirs.go
@@ -120,7 +120,8 @@ var vouchableDirs = []string{
 	".opencode/plugins",
 	".pi",
 	".pi/extensions",
-	".pi/extensions/entire",
+	// .pi/extensions/entire is deliberately absent, and neverVouchable refuses
+	// it a second time. See that function.
 }
 
 // VouchableSymlinkedDirs is the set a user may name, with the trees Entire owns
@@ -143,19 +144,30 @@ func VouchableSymlinkedDirs() []string {
 	return out
 }
 
-// neverVouchable names the trees whose symlink refusals are not negotiable,
+// neverVouchable names the paths whose symlink refusals are not negotiable,
 // whoever is asking and however the path is spelled.
 //
-// .entire holds the redaction settings that decide what may be committed, and
-// .git holds the hooks directory, whose escape hatch is core.hooksPath rather
-// than this. Matched as path prefixes so a deeper path cannot slip under.
+// Two rules. `.entire` holds the redaction settings that decide what may be
+// committed, and `.git` holds the hooks directory, whose escape hatch is
+// core.hooksPath rather than this one. Matched as path prefixes so a deeper
+// path cannot slip under.
+//
+// And a directory named `entire` is refused wherever it appears, because that
+// is the one directory Entire both CREATES and DELETES: HookConfigFile.RemoveDir
+// removes `.pi/extensions/entire` wholesale on uninstall, since pi discovers
+// extensions by directory and removing only the file leaves one it still loads.
+// A path Entire owns the lifecycle of cannot also be a link the user manages --
+// the two claims are incompatible, and the hatch is for the agent's own
+// directory, not for Entire's scratch space inside it. Vouching for it also
+// anchored the root ON that directory, so RemoveDir had nothing above it to
+// delete from and refused, leaving the extension in place.
 func neverVouchable(dir string) bool {
 	for _, owned := range []string{".entire", ".git"} {
 		if dir == owned || strings.HasPrefix(dir, owned+"/") {
 			return true
 		}
 	}
-	return false
+	return path.Base(dir) == entireOwnedDirName
 }
 
 // isVouched reports whether a worktree-relative directory has been vouched for.

--- a/cmd/entire/cli/agent/vouched_dirs_key_test.go
+++ b/cmd/entire/cli/agent/vouched_dirs_key_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// The policy key must survive the two producers spelling one directory
+// differently. Readers pass paths.WorktreeRoot, which is git's
+// `rev-parse --show-toplevel` verbatim; settings derives its root from
+// entiredir.PathTo, whose filepath.Join re-Cleans the same path. On Windows
+// those differ (C:/repo vs C:\repo) and the plain string compare this replaced
+// silently disabled the whole feature there.
+func TestKeyFor_EquatesSpellingsOfOneDirectory(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	want := keyFor(base)
+
+	// filepath.Join is what the settings side puts the path through.
+	viaJoin := filepath.Dir(filepath.Dir(filepath.Join(base, ".entire", "settings.json")))
+	if got := keyFor(viaJoin); got != want {
+		t.Errorf("keyFor(via filepath.Join) = %q, want %q; the two producers must agree", got, want)
+	}
+
+	for _, spelling := range []string{
+		base + string(filepath.Separator),
+		filepath.Join(base, "."),
+		filepath.Join(base, "sub", ".."),
+	} {
+		if got := keyFor(spelling); got != want {
+			t.Errorf("keyFor(%q) = %q, want %q", spelling, got, want)
+		}
+	}
+}
+
+// Distinct directories must still key distinctly, or the scope is not a scope.
+func TestKeyFor_DistinguishesDifferentDirectories(t *testing.T) {
+	t.Parallel()
+
+	first, second := t.TempDir(), t.TempDir()
+	if keyFor(first) == keyFor(second) {
+		t.Errorf("two different worktrees (%q, %q) produced the same key", first, second)
+	}
+	if keyFor("") != "" {
+		t.Error(`keyFor("") must stay empty so an unset policy cannot match a real root`)
+	}
+}
+
+// Case folding is Windows-only: there two spellings differing in case are one
+// directory, while on Unix they are two.
+func TestKeyFor_CaseHandlingMatchesThePlatform(t *testing.T) {
+	t.Parallel()
+
+	lower, upper := keyFor("/tmp/repo"), keyFor("/tmp/REPO")
+	if runtime.GOOS == goosWindows {
+		if lower != upper {
+			t.Errorf("on Windows /tmp/repo and /tmp/REPO are one directory; got %q vs %q", lower, upper)
+		}
+		return
+	}
+	if lower == upper {
+		t.Errorf("on %s these are different directories; got %q for both", runtime.GOOS, lower)
+	}
+}

--- a/cmd/entire/cli/agent/vouched_dirs_key_windows_test.go
+++ b/cmd/entire/cli/agent/vouched_dirs_key_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package agent
+
+import "testing"
+
+// The exact shapes the two producers emit on Windows. git prints a forward-slash
+// toplevel; filepath.Join rewrites it with backslashes. Comparing them raw is
+// what silently disabled allow_symlinked_agent_dirs on this platform.
+func TestKeyFor_GitToplevelAndJoinedPathAgree(t *testing.T) {
+	t.Parallel()
+
+	fromGit := keyFor(`C:/Users/dev/repo`)
+	fromJoin := keyFor(`C:\Users\dev\repo`)
+	if fromGit != fromJoin {
+		t.Errorf("keyFor(%q) = %q but keyFor(%q) = %q; one directory must produce one key",
+			`C:/Users/dev/repo`, fromGit, `C:\Users\dev\repo`, fromJoin)
+	}
+	if mixedCase := keyFor(`c:\users\dev\REPO`); mixedCase != fromGit {
+		t.Errorf("Windows paths are case-insensitive; got %q, want %q", mixedCase, fromGit)
+	}
+}

--- a/cmd/entire/cli/agent/vouched_dirs_test.go
+++ b/cmd/entire/cli/agent/vouched_dirs_test.go
@@ -1,0 +1,214 @@
+package agent_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
+)
+
+// resetVouched restores the strict default, which is what every other test in
+// the process expects. Not t.Parallel-safe: the policy is process-wide.
+func resetVouched(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs(nil) })
+}
+
+// The name check is the boundary that keeps this from being a general
+// "follow symlinks" switch. It is separate from the trust gate: even a
+// developer's own verified settings.local.json cannot vouch for these.
+func TestSetVouchedSymlinkedDirs_RefusesAnythingButAnAgentConfigDirectory(t *testing.T) {
+	resetVouched(t)
+
+	forbidden := []string{
+		".entire",
+		".entire/metadata",
+		".git/hooks",
+		".git",
+		"..",
+		"/etc",
+		"",
+		".",
+	}
+	rejected := agent.SetVouchedSymlinkedDirs(forbidden)
+	if len(rejected) != len(forbidden) {
+		t.Errorf("rejected %d of %d; every one of these must be unspellable: %v",
+			len(rejected), len(forbidden), rejected)
+	}
+	if got := agent.VouchedSymlinkedDirs(); len(got) != 0 {
+		t.Errorf("vouched = %v, want none accepted", got)
+	}
+}
+
+func TestSetVouchedSymlinkedDirs_AcceptsAgentDirectories(t *testing.T) {
+	resetVouched(t)
+
+	if rejected := agent.SetVouchedSymlinkedDirs([]string{".claude"}); len(rejected) != 0 {
+		t.Fatalf("rejected %v, want .claude accepted", rejected)
+	}
+	if got := agent.VouchedSymlinkedDirs(); !slices.Equal(got, []string{".claude"}) {
+		t.Errorf("vouched = %v, want [.claude]", got)
+	}
+
+	// Replaces rather than accumulates, so a settings change that removes an
+	// entry stops the following in the same process.
+	agent.SetVouchedSymlinkedDirs(nil)
+	if got := agent.VouchedSymlinkedDirs(); len(got) != 0 {
+		t.Errorf("vouched = %v after clearing, want none", got)
+	}
+}
+
+// The structural rule holds independently of the pinned list, so a careless
+// edit to that list still cannot make an Entire-owned tree vouchable.
+// TestVouchableDirsMatchTheBuiltInAgents (cli package) covers drift the other
+// way, where every built-in agent is actually registered.
+func TestVouchableSymlinkedDirs_NeverIncludesAnEntireOwnedTree(t *testing.T) {
+	t.Parallel()
+
+	vouchable := agent.VouchableSymlinkedDirs()
+	for _, forbidden := range []string{".entire", ".entire/metadata", ".git", ".git/hooks"} {
+		if slices.Contains(vouchable, forbidden) {
+			t.Errorf("%s must never be vouchable", forbidden)
+		}
+	}
+	if len(vouchable) == 0 {
+		t.Error("no directory is vouchable at all; the pinned list has gone empty and the hatch is dead")
+	}
+}
+
+// The default is strict, so a caller that never configures a policy behaves
+// exactly as it did before the setting existed.
+func TestOpenHookConfig_StillRefusesAnUnvouchedSymlinkedDir(t *testing.T) {
+	resetVouched(t)
+	agent.SetVouchedSymlinkedDirs(nil)
+
+	worktree := t.TempDir()
+	dest := t.TempDir()
+	if err := os.Symlink(dest, filepath.Join(worktree, ".claude")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cfg, err := agent.OpenHookConfig(worktree, ".claude/settings.json")
+	if err != nil {
+		t.Fatalf("OpenHookConfig() error = %v", err)
+	}
+	if err := cfg.Write([]byte("{}"), 0o600); !isSymlinkRefusal(err) {
+		t.Fatalf("Write() error = %v, want osroot.ErrSymlinkedPath", err)
+	}
+	entries, readErr := os.ReadDir(dest)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("wrote %d entries through an unvouched link", len(entries))
+	}
+}
+
+// And with the entry present, the write lands at the far end. This is the whole
+// point of the hatch: a dotfile-managed .claude keeps working.
+func TestOpenHookConfig_FollowsAVouchedSymlinkedDir(t *testing.T) {
+	resetVouched(t)
+
+	worktree := t.TempDir()
+	dest := t.TempDir()
+	if err := os.Symlink(dest, filepath.Join(worktree, ".claude")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	agent.SetVouchedSymlinkedDirs([]string{".claude"})
+
+	cfg, err := agent.OpenHookConfig(worktree, ".claude/settings.json")
+	if err != nil {
+		t.Fatalf("OpenHookConfig() error = %v", err)
+	}
+	if err := cfg.Write([]byte(`{"ok":true}`), 0o600); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dest, "settings.json"))
+	if err != nil {
+		t.Fatalf("the write did not land at the link's target: %v", err)
+	}
+	if string(got) != `{"ok":true}` {
+		t.Errorf("content = %q", got)
+	}
+
+	// Read and Exists must agree with Write, or callers choose between merging
+	// and overwriting on a different file from the one they then write.
+	if !cfg.Exists() {
+		t.Error("Exists() = false for a file Write just created")
+	}
+	back, err := cfg.Read()
+	if err != nil || string(back) != `{"ok":true}` {
+		t.Errorf("Read() = %q, %v", back, err)
+	}
+
+	// The path stays the one the user recognises. It is what doctor prints and
+	// what agents put in their own config, where following the link is the
+	// agent's business and works.
+	if want := filepath.Join(worktree, ".claude", "settings.json"); cfg.Path() != want {
+		t.Errorf("Path() = %q, want the link's own path %q", cfg.Path(), want)
+	}
+}
+
+// Vouching for one directory does not vouch for links inside it: below the
+// anchor everything is a name in a root again.
+func TestOpenHookConfig_VouchedDirDoesNotVouchForLinksBeneathIt(t *testing.T) {
+	resetVouched(t)
+
+	worktree := t.TempDir()
+	dest := t.TempDir()
+	if err := os.Symlink(dest, filepath.Join(worktree, ".pi")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	elsewhere := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dest, "extensions"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(elsewhere, filepath.Join(dest, "extensions", "entire")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	agent.SetVouchedSymlinkedDirs([]string{".pi"})
+
+	cfg, err := agent.OpenHookConfig(worktree, ".pi/extensions/entire/index.ts")
+	if err != nil {
+		t.Fatalf("OpenHookConfig() error = %v", err)
+	}
+	if err := cfg.Write([]byte("x"), 0o600); !isSymlinkRefusal(err) {
+		t.Fatalf("Write() error = %v, want the inner link refused", err)
+	}
+	entries, readErr := os.ReadDir(elsewhere)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("wrote %d entries through an unvouched inner link", len(entries))
+	}
+}
+
+// A vouched link that cannot be resolved is an error, not a silent fallback to
+// refusing: "we could not follow it" is a different answer from "we would not".
+func TestOpenHookConfig_VouchedButDanglingIsAnError(t *testing.T) {
+	resetVouched(t)
+
+	worktree := t.TempDir()
+	if err := os.Symlink(filepath.Join(t.TempDir(), "nowhere"), filepath.Join(worktree, ".claude")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	agent.SetVouchedSymlinkedDirs([]string{".claude"})
+
+	_, err := agent.OpenHookConfig(worktree, ".claude/settings.json")
+	if err == nil {
+		t.Fatal("OpenHookConfig() = nil error for a vouched but dangling link")
+	}
+	if !strings.Contains(err.Error(), ".claude") {
+		t.Errorf("error = %q, want it to name the directory", err)
+	}
+}
+
+func isSymlinkRefusal(err error) bool {
+	return err != nil && strings.Contains(err.Error(), osroot.ErrSymlinkedPath.Error())
+}

--- a/cmd/entire/cli/agent/vouched_dirs_test.go
+++ b/cmd/entire/cli/agent/vouched_dirs_test.go
@@ -212,3 +212,99 @@ func TestOpenHookConfig_VouchedButDanglingIsAnError(t *testing.T) {
 func isSymlinkRefusal(err error) bool {
 	return err != nil && strings.Contains(err.Error(), osroot.ErrSymlinkedPath.Error())
 }
+
+// The Entire-owned directory is the one directory Entire both creates and
+// deletes, so it cannot also be a link the user manages. Vouching for it was
+// accepted and then broke uninstall: the root anchored ON that directory, so
+// RemoveDir had nothing above it to delete from and refused with "refusing to
+// remove the worktree root" -- about a path that was neither -- leaving the pi
+// extension in place for pi to keep discovering.
+func TestSetVouchedSymlinkedDirs_RefusesTheEntireOwnedDirectory(t *testing.T) {
+	resetVouched(t)
+
+	rejected := agent.SetVouchedSymlinkedDirs([]string{".pi/extensions/entire"})
+	if len(rejected) != 1 {
+		t.Errorf("rejected = %v, want .pi/extensions/entire refused", rejected)
+	}
+	if got := agent.VouchedSymlinkedDirs(); len(got) != 0 {
+		t.Errorf("vouched = %v, want none", got)
+	}
+	if slices.Contains(agent.VouchableSymlinkedDirs(), ".pi/extensions/entire") {
+		t.Error(".pi/extensions/entire must not appear in the vouchable set either")
+	}
+}
+
+// Pi is still served by the hatch, at the levels the user actually owns, and
+// uninstall works through the link. This is the test the coordinate split
+// exists for: the ownership decision comes from the worktree-relative name
+// (whose dir is `.pi/extensions/entire`, base `entire`) while the removal is
+// performed on the root-relative name (`entire`) inside the anchored root.
+// Reading either coordinate for both jobs gets one of them wrong.
+func TestOpenHookConfig_VouchedPiExtensionsInstallsAndUninstalls(t *testing.T) {
+	for _, vouch := range []string{".pi", ".pi/extensions"} {
+		t.Run(vouch, func(t *testing.T) {
+			resetVouched(t)
+
+			worktree := t.TempDir()
+			dest := t.TempDir()
+			linkAt := filepath.Join(worktree, filepath.FromSlash(vouch))
+			if err := os.MkdirAll(filepath.Dir(linkAt), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(dest, linkAt); err != nil {
+				t.Skipf("symlink not supported: %v", err)
+			}
+			agent.SetVouchedSymlinkedDirs([]string{vouch})
+
+			cfg, err := agent.OpenHookConfig(worktree, ".pi/extensions/entire/index.ts")
+			if err != nil {
+				t.Fatalf("OpenHookConfig() error = %v", err)
+			}
+			if err := cfg.Write([]byte("// entire\n"), 0o600); err != nil {
+				t.Fatalf("Write() error = %v", err)
+			}
+			if !cfg.Exists() {
+				t.Fatal("Exists() = false after Write")
+			}
+
+			if err := cfg.RemoveDir(); err != nil {
+				t.Fatalf("RemoveDir() error = %v; pi discovers extensions by directory, so a "+
+					"refused uninstall leaves one it still loads", err)
+			}
+
+			// The generated directory is gone from wherever it landed...
+			if _, serr := os.Lstat(filepath.Join(worktree, ".pi", "extensions", "entire")); serr == nil {
+				t.Error("the entire/ extension directory survived uninstall")
+			}
+			// ...and the user's own linked directory is not deleted with it.
+			if _, serr := os.Lstat(dest); serr != nil {
+				t.Errorf("the vouched link's target must survive uninstall: %v", serr)
+			}
+			if _, serr := os.Lstat(linkAt); serr != nil {
+				t.Errorf("the user's own link at %s must survive uninstall: %v", vouch, serr)
+			}
+		})
+	}
+}
+
+// RemoveDir's precondition still refuses a directory Entire did not create,
+// and says which one, rather than reporting the worktree root.
+func TestRemoveDir_RefusesADirectoryEntireDidNotCreate(t *testing.T) {
+	resetVouched(t)
+
+	worktree := t.TempDir()
+	cfg, err := agent.OpenHookConfig(worktree, ".claude/settings.json")
+	if err != nil {
+		t.Fatalf("OpenHookConfig() error = %v", err)
+	}
+	err = cfg.RemoveDir()
+	if err == nil {
+		t.Fatal("RemoveDir() on .claude = nil error; it would delete the user's own config")
+	}
+	if !strings.Contains(err.Error(), ".claude") {
+		t.Errorf("error = %q, want it to name the directory it refused", err)
+	}
+	if strings.Contains(err.Error(), "worktree root") {
+		t.Errorf("error = %q, must not report the worktree root for a named directory", err)
+	}
+}

--- a/cmd/entire/cli/agent/vouched_dirs_test.go
+++ b/cmd/entire/cli/agent/vouched_dirs_test.go
@@ -15,7 +15,7 @@ import (
 // the process expects. Not t.Parallel-safe: the policy is process-wide.
 func resetVouched(t *testing.T) {
 	t.Helper()
-	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs(nil) })
+	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs("", nil) })
 }
 
 // The name check is the boundary that keeps this from being a general
@@ -34,12 +34,13 @@ func TestSetVouchedSymlinkedDirs_RefusesAnythingButAnAgentConfigDirectory(t *tes
 		"",
 		".",
 	}
-	rejected := agent.SetVouchedSymlinkedDirs(forbidden)
+	worktree := t.TempDir()
+	rejected := agent.SetVouchedSymlinkedDirs(worktree, forbidden)
 	if len(rejected) != len(forbidden) {
 		t.Errorf("rejected %d of %d; every one of these must be unspellable: %v",
 			len(rejected), len(forbidden), rejected)
 	}
-	if got := agent.VouchedSymlinkedDirs(); len(got) != 0 {
+	if got := agent.VouchedSymlinkedDirs(worktree); len(got) != 0 {
 		t.Errorf("vouched = %v, want none accepted", got)
 	}
 }
@@ -47,17 +48,21 @@ func TestSetVouchedSymlinkedDirs_RefusesAnythingButAnAgentConfigDirectory(t *tes
 func TestSetVouchedSymlinkedDirs_AcceptsAgentDirectories(t *testing.T) {
 	resetVouched(t)
 
-	if rejected := agent.SetVouchedSymlinkedDirs([]string{".claude"}); len(rejected) != 0 {
+	root := t.TempDir()
+	if rejected := agent.SetVouchedSymlinkedDirs(root, []string{".claude"}); len(rejected) != 0 {
 		t.Fatalf("rejected %v, want .claude accepted", rejected)
 	}
-	if got := agent.VouchedSymlinkedDirs(); !slices.Equal(got, []string{".claude"}) {
+	if got := agent.VouchedSymlinkedDirs(root); !slices.Equal(got, []string{".claude"}) {
 		t.Errorf("vouched = %v, want [.claude]", got)
+	}
+	if got := agent.VouchedSymlinkedDirs(t.TempDir()); len(got) != 0 {
+		t.Errorf("vouched = %v for another worktree, want none", got)
 	}
 
 	// Replaces rather than accumulates, so a settings change that removes an
 	// entry stops the following in the same process.
-	agent.SetVouchedSymlinkedDirs(nil)
-	if got := agent.VouchedSymlinkedDirs(); len(got) != 0 {
+	agent.SetVouchedSymlinkedDirs(root, nil)
+	if got := agent.VouchedSymlinkedDirs(root); len(got) != 0 {
 		t.Errorf("vouched = %v after clearing, want none", got)
 	}
 }
@@ -84,7 +89,7 @@ func TestVouchableSymlinkedDirs_NeverIncludesAnEntireOwnedTree(t *testing.T) {
 // exactly as it did before the setting existed.
 func TestOpenHookConfig_StillRefusesAnUnvouchedSymlinkedDir(t *testing.T) {
 	resetVouched(t)
-	agent.SetVouchedSymlinkedDirs(nil)
+	agent.SetVouchedSymlinkedDirs("", nil)
 
 	worktree := t.TempDir()
 	dest := t.TempDir()
@@ -118,7 +123,7 @@ func TestOpenHookConfig_FollowsAVouchedSymlinkedDir(t *testing.T) {
 	if err := os.Symlink(dest, filepath.Join(worktree, ".claude")); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
-	agent.SetVouchedSymlinkedDirs([]string{".claude"})
+	agent.SetVouchedSymlinkedDirs(worktree, []string{".claude"})
 
 	cfg, err := agent.OpenHookConfig(worktree, ".claude/settings.json")
 	if err != nil {
@@ -171,7 +176,7 @@ func TestOpenHookConfig_VouchedDirDoesNotVouchForLinksBeneathIt(t *testing.T) {
 	if err := os.Symlink(elsewhere, filepath.Join(dest, "extensions", "entire")); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
-	agent.SetVouchedSymlinkedDirs([]string{".pi"})
+	agent.SetVouchedSymlinkedDirs(worktree, []string{".pi"})
 
 	cfg, err := agent.OpenHookConfig(worktree, ".pi/extensions/entire/index.ts")
 	if err != nil {
@@ -198,7 +203,7 @@ func TestOpenHookConfig_VouchedButDanglingIsAnError(t *testing.T) {
 	if err := os.Symlink(filepath.Join(t.TempDir(), "nowhere"), filepath.Join(worktree, ".claude")); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
-	agent.SetVouchedSymlinkedDirs([]string{".claude"})
+	agent.SetVouchedSymlinkedDirs(worktree, []string{".claude"})
 
 	_, err := agent.OpenHookConfig(worktree, ".claude/settings.json")
 	if err == nil {
@@ -222,11 +227,11 @@ func isSymlinkRefusal(err error) bool {
 func TestSetVouchedSymlinkedDirs_RefusesTheEntireOwnedDirectory(t *testing.T) {
 	resetVouched(t)
 
-	rejected := agent.SetVouchedSymlinkedDirs([]string{".pi/extensions/entire"})
+	rejected := agent.SetVouchedSymlinkedDirs(t.TempDir(), []string{".pi/extensions/entire"})
 	if len(rejected) != 1 {
 		t.Errorf("rejected = %v, want .pi/extensions/entire refused", rejected)
 	}
-	if got := agent.VouchedSymlinkedDirs(); len(got) != 0 {
+	if got := agent.VouchedSymlinkedDirs(""); len(got) != 0 {
 		t.Errorf("vouched = %v, want none", got)
 	}
 	if slices.Contains(agent.VouchableSymlinkedDirs(), ".pi/extensions/entire") {
@@ -254,7 +259,7 @@ func TestOpenHookConfig_VouchedPiExtensionsInstallsAndUninstalls(t *testing.T) {
 			if err := os.Symlink(dest, linkAt); err != nil {
 				t.Skipf("symlink not supported: %v", err)
 			}
-			agent.SetVouchedSymlinkedDirs([]string{vouch})
+			agent.SetVouchedSymlinkedDirs(worktree, []string{vouch})
 
 			cfg, err := agent.OpenHookConfig(worktree, ".pi/extensions/entire/index.ts")
 			if err != nil {
@@ -306,5 +311,76 @@ func TestRemoveDir_RefusesADirectoryEntireDidNotCreate(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "worktree root") {
 		t.Errorf("error = %q, must not report the worktree root for a named directory", err)
+	}
+}
+
+// The policy is a package global because the import direction forces it
+// (settings may import agent, not the reverse), so it is scoped to the worktree
+// it was loaded for. A process that loads settings for one tree and then writes
+// an agent config for another must not follow a link only the first vouched
+// for, and refusing is the safe direction: it degrades to the strict behaviour
+// rather than to following someone else's link.
+func TestOpenHookConfig_VouchIsScopedToItsWorktree(t *testing.T) {
+	resetVouched(t)
+
+	vouchedTree := t.TempDir()
+	otherTree := t.TempDir()
+	dest := t.TempDir()
+	if err := os.Symlink(dest, filepath.Join(otherTree, ".claude")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	// The grant belongs to a different worktree than the one being written.
+	agent.SetVouchedSymlinkedDirs(vouchedTree, []string{".claude"})
+
+	cfg, err := agent.OpenHookConfig(otherTree, ".claude/settings.json")
+	if err != nil {
+		t.Fatalf("OpenHookConfig() error = %v", err)
+	}
+	if err := cfg.Write([]byte("{}"), 0o600); !isSymlinkRefusal(err) {
+		t.Fatalf("Write() error = %v, want the link refused; the grant was for another worktree", err)
+	}
+	entries, readErr := os.ReadDir(dest)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("wrote %d entries through a link vouched for a different worktree", len(entries))
+	}
+}
+
+// "Following symlinked agent directories" must be true when printed. A user may
+// legitimately vouch for a path that is an ordinary directory, absent, or a
+// dangling link on this machine, and in none of those is Entire following
+// anything.
+func TestFollowedSymlinkedDirs_OnlyReportsActualLinks(t *testing.T) {
+	resetVouched(t)
+
+	worktree := t.TempDir()
+	// .claude: vouched and a real link -> followed.
+	if err := os.Symlink(t.TempDir(), filepath.Join(worktree, ".claude")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	// .codex: vouched but an ordinary directory -> not followed.
+	if err := os.MkdirAll(filepath.Join(worktree, ".codex"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// .cursor: vouched but absent -> not followed.
+	// .gemini: vouched but dangling -> not followed (and nothing is written there).
+	if err := os.Symlink(filepath.Join(t.TempDir(), "nowhere"), filepath.Join(worktree, ".gemini")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	agent.SetVouchedSymlinkedDirs(worktree, []string{".claude", ".codex", ".cursor", ".gemini"})
+
+	if got := agent.FollowedSymlinkedDirs(worktree); !slices.Equal(got, []string{".claude", ".gemini"}) {
+		t.Errorf("FollowedSymlinkedDirs() = %v, want only the paths that are symlinks on disk", got)
+	}
+	// The configuration is unchanged; the two answers are different questions.
+	if got := agent.VouchedSymlinkedDirs(worktree); len(got) != 4 {
+		t.Errorf("VouchedSymlinkedDirs() = %v, want the full configured set", got)
+	}
+	if got := agent.FollowedSymlinkedDirs(t.TempDir()); len(got) != 0 {
+		t.Errorf("FollowedSymlinkedDirs() = %v for another worktree, want none", got)
 	}
 }

--- a/cmd/entire/cli/agent_hook_config_guard_test.go
+++ b/cmd/entire/cli/agent_hook_config_guard_test.go
@@ -1,14 +1,13 @@
 package cli
 
 import (
-	"os/exec"
 	"path"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
-	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,23 +26,19 @@ import (
 func TestAllHookConfigRelPaths_CoversEveryWorktreeConfigAgent(t *testing.T) {
 	t.Parallel()
 
-	// Both subprocesses run with git's repo selectors scrubbed. They inherit the
-	// environment, and GIT_DIR / GIT_WORK_TREE take precedence over both the
-	// working directory and grep.Dir — so a `go test` launched from anywhere
-	// that exports them (a `git rebase --exec`, a hook, this CLI's own test
-	// harnesses) resolved some other repository entirely. Measured against a
-	// decoy repo, the unscrubbed version fails with "no agent calls
-	// agent.OpenHookConfig", which is a guard failing for a reason that has
-	// nothing to do with what it guards; a decoy that happened to contain
-	// matching paths would instead have it pass having checked nothing.
-	topLevel := exec.Command("git", "rev-parse", "--show-toplevel") //nolint:noctx // guard test, no cancellation needed
-	topLevel.Env = gitrepo.EnvWithoutRepoOverrides()
-	repoRoot, err := topLevel.Output()
-	if err != nil {
-		t.Skipf("not in a git checkout: %v", err)
+	// Both subprocesses run through testutil.GitGrepGuard, which scrubs git's
+	// repo selectors (GIT_DIR / GIT_WORK_TREE take precedence over cmd.Dir, so a
+	// `go test` launched from a hook or a `git rebase --exec` resolved some other
+	// repository entirely) and passes --untracked and --no-color. The first of
+	// those matters more here than anywhere else: this guard compares two sets
+	// built from the same grep, so a NEW agent package that calls OpenHookConfig
+	// without declaring HookConfigRelPath was invisible on both sides and the
+	// comparison passed — with the file unstaged, which is exactly when someone
+	// is writing a new agent.
+	dir, ok := testutil.GitGrepGuardRepoRoot(t)
+	if !ok {
+		return
 	}
-
-	dir := strings.TrimSpace(string(repoRoot))
 	callers := agentPackagesMatching(t, dir, "agent.OpenHookConfig(")
 	locators := agentPackagesMatching(t, dir, ") HookConfigRelPath() string {")
 
@@ -83,19 +78,27 @@ func TestAllHookConfigRelPaths_CoversEveryWorktreeConfigAgent(t *testing.T) {
 // guard into a comparison of two empty sets.
 func agentPackagesMatching(t *testing.T, repoRoot, needle string) []string {
 	t.Helper()
-	grep := exec.Command("git", "grep", "-l", "--fixed-strings", "--", //nolint:noctx // guard test, no cancellation needed
+	out := testutil.GitGrepGuard(t, repoRoot, "-l", "--fixed-strings", "--",
 		needle, "--", ":(glob)cmd/entire/cli/agent/**/*.go")
-	grep.Dir = repoRoot
-	// Set for the same reason every git subprocess naming its target with
-	// cmd.Dir does: git exports GIT_DIR/GIT_WORK_TREE to hooks, and those take
-	// precedence over cmd.Dir.
-	grep.Env = gitrepo.EnvWithoutRepoOverrides()
-	out, err := grep.Output()
-	require.NoError(t, err, "no agent source matches %q, which cannot be right", needle)
 
 	var pkgs []string
-	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
-		if line == "" || strings.HasSuffix(line, "_test.go") {
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		// A positive .go check, not just a _test.go skip. `git grep -l` emits
+		// nothing but filenames and still colorizes them, so an escape-wrapped
+		// path fails the _test.go suffix test, leaks test files into the set,
+		// and prefixes the package directory — all while the NotEmpty assertion
+		// below still passes and the two sets still compare. --no-color makes
+		// that unreachable; this makes it loud if it ever becomes reachable
+		// again.
+		if !strings.HasSuffix(line, ".go") {
+			t.Fatalf("cannot parse git grep -l output; expected a .go path, got:\n  %s\n"+
+				"The filename field is unusable, so this test can prove nothing. "+
+				"Check whether git is colorizing into a pipe (color.ui or color.grep set to `always`).", line)
+		}
+		if strings.HasSuffix(line, "_test.go") {
 			continue
 		}
 		if dir := path.Dir(line); !slices.Contains(pkgs, dir) {

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -930,12 +930,10 @@ func checkGitHookSymlinks(cmd *cobra.Command) {
 		return
 	}
 
+	// No symlinkReportLimit here: the candidates are the five managed hook
+	// names, so the list cannot run away the way a walk of .entire can.
 	fmt.Fprintln(w, "Git hooks: SYMLINKS PRESENT")
-	for i, name := range links {
-		if i == symlinkReportLimit {
-			fmt.Fprintf(w, "  ... and %d more\n", len(links)-symlinkReportLimit)
-			break
-		}
+	for _, name := range links {
 		full := filepath.Join(hooksDir, name)
 		fmt.Fprintf(w, "  %s -> %s\n", full, readlinkOrUnknown(full))
 	}

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -801,7 +801,7 @@ func checkAgentDirSymlinks(cmd *cobra.Command) {
 		return
 	}
 
-	var links, unreadable, wrongType []string
+	var links, unreadable, wrongType, vouched []string
 	reported := make(map[string]struct{})
 	for _, candidate := range agentSymlinkCheckPaths() {
 		name, outcome := scanForSymlinkedComponent(root, candidate)
@@ -814,6 +814,15 @@ func checkAgentDirSymlinks(cmd *cobra.Command) {
 			continue
 		}
 		reported[name] = struct{}{}
+		// A link the user vouched for in settings.local.json is followed, not
+		// refused, so reporting it as a fault would be wrong twice: it names a
+		// problem that is not one, and it hides the fact that Entire is writing
+		// somewhere other than where the path appears to lead. Reported below in
+		// its own section instead.
+		if outcome == componentScanLinked && slices.Contains(agent.VouchedSymlinkedDirs(), name) {
+			vouched = append(vouched, name)
+			continue
+		}
 		switch outcome {
 		case componentScanUnreadable:
 			unreadable = append(unreadable, name)
@@ -824,6 +833,17 @@ func checkAgentDirSymlinks(cmd *cobra.Command) {
 		case componentScanClean:
 			// Filtered out above; listed so a new outcome fails the build here.
 		}
+	}
+
+	if len(vouched) > 0 {
+		fmt.Fprintln(w, "Agent config directories: FOLLOWING SYMLINKS")
+		printCappedList(w, vouched, func(name string) string {
+			return name + " -> " + readlinkOrUnknownIn(root, name)
+		})
+		fmt.Fprintf(w, "  Allowed by allow_symlinked_agent_dirs in %s. Entire installs hooks and\n",
+			settings.EntireSettingsLocalFile)
+		fmt.Fprintln(w, "  skills at the far end of these links rather than inside the repository.")
+		fmt.Fprintln(w, "  Remove the entry to go back to refusing them.")
 	}
 
 	if len(links) > 0 {

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -809,19 +809,40 @@ func checkAgentDirSymlinks(cmd *cobra.Command) {
 			continue
 		}
 		// Several candidates share a prefix (.claude, .claude/settings.json), so
-		// a symlinked .claude would otherwise be named once per candidate.
-		if _, dup := reported[name]; dup {
-			continue
+		// a symlinked .claude would otherwise be named once per candidate. The
+		// vouched branch below does its own recording, because it has two names
+		// to track: the followed link and whatever it finds beneath it.
+		if outcome != componentScanLinked || !slices.Contains(agent.VouchedSymlinkedDirs(worktreeRoot), name) {
+			if _, dup := reported[name]; dup {
+				continue
+			}
+			reported[name] = struct{}{}
 		}
-		reported[name] = struct{}{}
 		// A link the user vouched for in settings.local.json is followed, not
 		// refused, so reporting it as a fault would be wrong twice: it names a
 		// problem that is not one, and it hides the fact that Entire is writing
 		// somewhere other than where the path appears to lead. Reported below in
 		// its own section instead.
-		if outcome == componentScanLinked && slices.Contains(agent.VouchedSymlinkedDirs(), name) {
-			vouched = append(vouched, name)
-			continue
+		//
+		// And then the scan CONTINUES beneath it. Stopping here reported the one
+		// link that is fine and stayed silent about the one that is not: with
+		// `.claude` vouched and `.claude/skills` a link inside the target,
+		// scaffold installation follows the first and refuses the second, so the
+		// user saw a failed install and a doctor that named only the allowed
+		// link.
+		if outcome == componentScanLinked && slices.Contains(agent.VouchedSymlinkedDirs(worktreeRoot), name) {
+			if _, dup := reported[name]; !dup {
+				reported[name] = struct{}{}
+				vouched = append(vouched, name)
+			}
+			name, outcome = scanBeneathVouchedDir(worktreeRoot, candidate)
+			if outcome == componentScanClean {
+				continue
+			}
+			if _, dup := reported[name]; dup {
+				continue
+			}
+			reported[name] = struct{}{}
 		}
 		switch outcome {
 		case componentScanUnreadable:
@@ -941,7 +962,7 @@ func checkGitHookSymlinks(cmd *cobra.Command) {
 		if resolved {
 			fmt.Fprintln(w, "  Fix: point git at the target directly, which says the same thing without")
 			fmt.Fprintln(w, "  the indirection:")
-			fmt.Fprintf(w, "    git config core.hooksPath %s\n", target)
+			fmt.Fprintf(w, "    %s\n", strategy.HooksPathCommand(target))
 			fmt.Fprintln(w, "  or replace the link with a real directory.")
 		} else {
 			fmt.Fprintln(w, "  Fix: find where the path is set, then point git at a real directory:")
@@ -1061,6 +1082,35 @@ func agentSymlinkCheckPaths() []string {
 
 	slices.Sort(out)
 	return out
+}
+
+// scanBeneathVouchedDir continues the component scan inside a vouched symlinked
+// agent directory, returning what it finds as a worktree-relative name.
+//
+// The outer scan stops at the first symlink, which is the right answer when that
+// link is a fault. When it is one the user vouched for, the components below it
+// are still Entire's to check and still refused by MkdirAllNoSymlink, so the
+// scan has to resume from the link's target. agent.OpenAnchoredRoot is the same
+// resolution the writers use, so doctor reports on exactly the tree they act on.
+//
+// A vouched link that will not resolve is reported unreadable rather than
+// silently dropped: every write through it fails, which is precisely the state
+// worth naming.
+func scanBeneathVouchedDir(worktreeRoot, candidate string) (string, componentScanOutcome) {
+	innerRoot, innerName, err := agent.OpenAnchoredRoot(worktreeRoot, candidate)
+	if err != nil {
+		return candidate, componentScanUnreadable
+	}
+	if innerName == candidate {
+		// Nothing was followed after all, so the outer scan already had it.
+		return "", componentScanClean
+	}
+	found, outcome := scanForSymlinkedComponent(innerRoot, innerName)
+	if outcome == componentScanClean {
+		return "", componentScanClean
+	}
+	prefix := strings.TrimSuffix(candidate, "/"+innerName)
+	return prefix + "/" + found, outcome
 }
 
 // scanForSymlinkedComponent walks name one component at a time and reports the

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -904,15 +904,29 @@ func checkGitHookSymlinks(cmd *cobra.Command) {
 		return // absent or unreadable: checkGitHooks reports what that costs
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		target := readlinkOrUnknown(hooksDir)
 		fmt.Fprintln(w, "Git hooks directory: SYMLINK")
-		fmt.Fprintf(w, "  %s -> %s\n", hooksDir, target)
+		// The resolved target, not os.Readlink's raw contents: a relative link
+		// reads relative to the link's own parent, so pasting it into the
+		// command below sets a path git resolves from somewhere else. When it
+		// cannot be resolved, no command is printed at all -- a remedy the user
+		// pastes must not contain a placeholder.
+		target, resolved := strategy.HooksDirLinkTarget(hooksDir)
+		if resolved {
+			fmt.Fprintf(w, "  %s -> %s\n", hooksDir, target)
+		} else {
+			fmt.Fprintf(w, "  %s -> %s (unresolvable)\n", hooksDir, readlinkOrUnknown(hooksDir))
+		}
 		fmt.Fprintln(w, "  Entire will not install hooks through a link, so its git hooks are not")
-		fmt.Fprintln(w, "  installed and other commands report them as absent rather than blocked.")
-		fmt.Fprintln(w, "  Fix: point git at the target directly, which says the same thing without")
-		fmt.Fprintln(w, "  the indirection:")
-		fmt.Fprintf(w, "    git config core.hooksPath %s\n", target)
-		fmt.Fprintln(w, "  or replace the link with a real directory.")
+		fmt.Fprintln(w, "  installed. Uninstalling still works: `entire disable` follows the link.")
+		if resolved {
+			fmt.Fprintln(w, "  Fix: point git at the target directly, which says the same thing without")
+			fmt.Fprintln(w, "  the indirection:")
+			fmt.Fprintf(w, "    git config core.hooksPath %s\n", target)
+			fmt.Fprintln(w, "  or replace the link with a real directory.")
+		} else {
+			fmt.Fprintln(w, "  Fix: find where the path is set, then point git at a real directory:")
+			fmt.Fprintln(w, "    git config --show-origin --get-all core.hooksPath")
+		}
 		return
 	}
 	if !info.IsDir() {

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -137,6 +137,10 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 
 	ctx := cmd.Context()
 
+	// Ahead of checkGitHooks, which is the check a symlinked hooks directory
+	// makes fail: the cause should be on screen before the failure it explains.
+	checkGitHookSymlinks(cmd)
+
 	// The git hook surface. Checked before the agent hook checks because it is
 	// the more fundamental one: if git hooks are broken, commits are not captured
 	// at all and agent-config drift is noise by comparison.
@@ -865,6 +869,80 @@ func checkAgentDirSymlinks(cmd *cobra.Command) {
 		fmt.Fprintln(w, "  cannot say whether hooks and skills can be installed under them.")
 		fmt.Fprintln(w, "  Fix: check the ownership and permissions of each path above.")
 	}
+}
+
+// checkGitHookSymlinks reports a symlink at the active git hooks directory, or
+// at one of the hooks Entire manages inside it.
+//
+// This needs its own function rather than an agentSymlinkCheckPaths entry, and
+// the reason is the path itself: that list is worktree-relative and scanned
+// through the worktree root, while core.hooksPath can name any directory at all
+// — a shared hooks directory in $HOME is a common setup — and a linked
+// worktree's hooks live in the common dir. Git resolves where the hooks are;
+// this only reports what is sitting there.
+//
+// The two findings differ in severity and so in remedy. A symlinked DIRECTORY
+// stops installation outright: Entire refuses to write hooks through a link, so
+// `entire status` reports them absent with nothing to say why — the same
+// invisible-after-the-fact condition checkAgentDirSymlinks exists for. A
+// symlinked HOOK FILE is not an error at all; it is simply not Entire's, so the
+// next install backs it up and chains to it, and the note is there so the user
+// is not surprised that the path they set up is no longer what git runs first.
+//
+// Read-only in both cases. Replacing a link means deciding what to do with its
+// target, which is not doctor's call.
+func checkGitHookSymlinks(cmd *cobra.Command) {
+	ctx := cmd.Context()
+	w := cmd.OutOrStdout()
+
+	hooksDir, err := strategy.GetHooksDir(ctx)
+	if err != nil {
+		return // no repository: nothing to check
+	}
+	info, err := os.Lstat(hooksDir)
+	if err != nil {
+		return // absent or unreadable: checkGitHooks reports what that costs
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target := readlinkOrUnknown(hooksDir)
+		fmt.Fprintln(w, "Git hooks directory: SYMLINK")
+		fmt.Fprintf(w, "  %s -> %s\n", hooksDir, target)
+		fmt.Fprintln(w, "  Entire will not install hooks through a link, so its git hooks are not")
+		fmt.Fprintln(w, "  installed and other commands report them as absent rather than blocked.")
+		fmt.Fprintln(w, "  Fix: point git at the target directly, which says the same thing without")
+		fmt.Fprintln(w, "  the indirection:")
+		fmt.Fprintf(w, "    git config core.hooksPath %s\n", target)
+		fmt.Fprintln(w, "  or replace the link with a real directory.")
+		return
+	}
+	if !info.IsDir() {
+		return // InstallGitHook's own error covers core.hooksPath=/dev/null
+	}
+
+	var links []string
+	for _, name := range strategy.ManagedGitHookNames() {
+		hookInfo, lerr := os.Lstat(filepath.Join(hooksDir, name))
+		if lerr == nil && hookInfo.Mode()&os.ModeSymlink != 0 {
+			links = append(links, name)
+		}
+	}
+	if len(links) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w, "Git hooks: SYMLINKS PRESENT")
+	for i, name := range links {
+		if i == symlinkReportLimit {
+			fmt.Fprintf(w, "  ... and %d more\n", len(links)-symlinkReportLimit)
+			break
+		}
+		full := filepath.Join(hooksDir, name)
+		fmt.Fprintf(w, "  %s -> %s\n", full, readlinkOrUnknown(full))
+	}
+	fmt.Fprintf(w, "  Entire never installs a hook as a symlink, so these belong to you or to\n"+
+		"  another tool. It does not read or write through them: the next install\n"+
+		"  moves each one to <hook>%s and chains to it, so it still runs, but\n"+
+		"  after Entire's rather than instead of it.\n", strategy.GitHookBackupSuffix)
 }
 
 // componentScanOutcome is what scanForSymlinkedComponent found.

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -1889,3 +1889,61 @@ func TestCheckGitHookSymlinks_SilentOnAPlainHooksDirectory(t *testing.T) {
 
 	assert.Empty(t, stdout.String())
 }
+
+// A vouched link is followed, so the components BENEATH it are the ones that can
+// still block an install. Stopping the scan at the vouched link reported the one
+// path that is fine and said nothing about the one that is not: scaffold
+// installation follows `.claude` and then refuses `.claude/skills`, so the user
+// saw a failed install and a doctor naming only the allowed link.
+func TestCheckAgentDirSymlinks_ScansBeneathAVouchedLink(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Cleanup(osroot.ResetShared)
+	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs("", nil) })
+
+	dest := t.TempDir()
+	if err := os.Symlink(dest, filepath.Join(dir, claudeDirName)); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if err := os.Symlink(t.TempDir(), filepath.Join(dest, "skills")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	agent.SetVouchedSymlinkedDirs(dir, []string{claudeDirName})
+
+	cmd, stdout := newTestCmd(t)
+	checkAgentDirSymlinks(cmd)
+	got := stdout.String()
+
+	assert.Contains(t, got, "FOLLOWING SYMLINKS", "the vouched link is still reported as followed")
+	assert.Contains(t, got, claudeDirName+"/skills",
+		"the nested link that actually blocks installation must be reported too")
+	assert.Contains(t, got, "SYMLINKS PRESENT", "and reported as a fault, not as allowed")
+}
+
+// The common vouched case stays quiet about everything except the link it is
+// following: a clean tree beneath a vouched directory is not a finding.
+func TestCheckAgentDirSymlinks_VouchedLinkWithCleanTargetReportsOnlyTheLink(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Cleanup(osroot.ResetShared)
+	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs("", nil) })
+
+	dest := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dest, "skills"), 0o750))
+	if err := os.Symlink(dest, filepath.Join(dir, claudeDirName)); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	agent.SetVouchedSymlinkedDirs(dir, []string{claudeDirName})
+
+	cmd, stdout := newTestCmd(t)
+	checkAgentDirSymlinks(cmd)
+	got := stdout.String()
+
+	assert.Contains(t, got, "FOLLOWING SYMLINKS")
+	assert.NotContains(t, got, "SYMLINKS PRESENT", "a clean target is not a fault")
+	assert.NotContains(t, got, "NOT READABLE")
+}

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -1811,3 +1811,81 @@ func TestComponentHasExpectedShape(t *testing.T) {
 		}
 	}
 }
+
+// A symlinked hooks directory stops installation, and nothing else says so:
+// every other command reports the hooks as absent. Naming core.hooksPath in the
+// remedy matters because git, not Entire, chose the path.
+func TestCheckGitHookSymlinks_ReportsSymlinkedHooksDirectory(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	strategy.ClearHooksDirCache()
+	t.Cleanup(strategy.ClearHooksDirCache)
+
+	realHooks := filepath.Join(dir, "real-hooks")
+	require.NoError(t, os.MkdirAll(realHooks, 0o750))
+	link := filepath.Join(dir, "linked-hooks")
+	if err := os.Symlink(realHooks, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	testutil.RunGit(t, dir, "config", "core.hooksPath", link)
+
+	cmd, stdout := newTestCmd(t)
+	checkGitHookSymlinks(cmd)
+
+	output := stdout.String()
+	assert.Contains(t, output, "Git hooks directory: SYMLINK")
+	assert.Contains(t, output, realHooks, "the report must say where the link points")
+	assert.Contains(t, output, "core.hooksPath", "and how to point git at the target instead")
+}
+
+// A symlinked hook file is not an error — Entire backs it up and chains to it —
+// but the user should hear that the path they set up is no longer what git runs
+// first.
+func TestCheckGitHookSymlinks_ReportsSymlinkedHookFile(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	strategy.ClearHooksDirCache()
+	t.Cleanup(strategy.ClearHooksDirCache)
+
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o750))
+	testutil.RunGit(t, dir, "config", "core.hooksPath", hooksDir)
+
+	elsewhere := filepath.Join(t.TempDir(), "shared-pre-push")
+	require.NoError(t, os.WriteFile(elsewhere, []byte("#!/bin/sh\n"), 0o700))
+	if err := os.Symlink(elsewhere, filepath.Join(hooksDir, "pre-push")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cmd, stdout := newTestCmd(t)
+	checkGitHookSymlinks(cmd)
+
+	output := stdout.String()
+	assert.Contains(t, output, "Git hooks: SYMLINKS PRESENT")
+	assert.Contains(t, output, elsewhere)
+	assert.Contains(t, output, strategy.GitHookBackupSuffix, "the note must name where the link will end up")
+}
+
+// The common case must stay silent: a doctor section that fires on every healthy
+// repo is one users learn to scroll past.
+func TestCheckGitHookSymlinks_SilentOnAPlainHooksDirectory(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	strategy.ClearHooksDirCache()
+	t.Cleanup(strategy.ClearHooksDirCache)
+
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o750))
+	testutil.RunGit(t, dir, "config", "core.hooksPath", hooksDir)
+
+	cmd, stdout := newTestCmd(t)
+	checkGitHookSymlinks(cmd)
+
+	assert.Empty(t, stdout.String())
+}

--- a/cmd/entire/cli/explain_summary_provider.go
+++ b/cmd/entire/cli/explain_summary_provider.go
@@ -185,6 +185,10 @@ func discoverSummaryProviderIfMissing(ctx context.Context, name types.AgentName)
 // (single-installed or non-interactive-first-of-many) and persists the choice
 // so subsequent runs don't re-decide. Persistence failure is surfaced as a
 // warning — not an error — because the selection is still usable in-process.
+// errSelectionNotPersistable reports a selection that is correct for this run
+// and must not be written down. See persistSummaryProviderSelection.
+var errSelectionNotPersistable = errors.New("selection is valid for this run but would not resolve on the next one")
+
 func autoSelectSummaryProvider(ctx context.Context, w io.Writer, name types.AgentName, reason string, origin summarySelectionOrigin) (*checkpointSummaryProvider, error) {
 	logging.Info(ctx, reason, "provider", string(name))
 	provider, err := buildCheckpointSummaryProvider(name, "")
@@ -192,7 +196,15 @@ func autoSelectSummaryProvider(ctx context.Context, w io.Writer, name types.Agen
 		return nil, err
 	}
 	flagFlipped, saveErr := persistSummaryProviderSelection(ctx, provider.Name, provider.Model, origin)
-	if saveErr != nil {
+	switch {
+	case errors.Is(saveErr, errSelectionNotPersistable):
+		// Not a warning: nothing went wrong and the run is unaffected. Say what
+		// would make the choice stick, since re-selecting it on every run is the
+		// only symptom the user would otherwise see.
+		logging.Info(ctx, "not persisting auto-selected external summary provider without the external_agents grant",
+			"provider", string(provider.Name))
+		fmt.Fprintf(w, "Using %s for this run. To save it as the default, run `entire agent` and pick it: an external plugin needs the external_agents grant, and only your own selection can give it.\n", provider.DisplayName)
+	case saveErr != nil:
 		logging.Warn(ctx, "failed to save summary provider selection, continuing without persistence",
 			"error", saveErr.Error())
 		fmt.Fprintf(w, "Warning: could not save provider selection: %v\nUse `entire configure --summarize-provider %s` to set it manually.\n", saveErr, provider.Name)
@@ -347,17 +359,32 @@ func persistSummaryProviderSelection(ctx context.Context, provider types.AgentNa
 	}
 	s.SummaryGeneration.SetProvider(string(provider), model)
 
-	// Only a human's pick grants external_agents. The provider name is
-	// persisted either way — it decides nothing on its own, and it is what
-	// stops the next run re-deciding. An automatically chosen external
-	// provider keeps working without the grant, because
-	// discoverSummaryProviderIfMissing resolves a configured name through the
-	// named ungated lookup rather than through the sweep the grant enables.
-	if origin == selectionByUser {
-		if ag, getErr := getSummaryAgent(provider); getErr == nil && external.IsExternal(ag) && !s.ExternalAgents {
-			s.ExternalAgents = true
-			flagFlipped = true
+	// Only a human's pick grants external_agents: an automatic selection is no
+	// one's decision to widen a repo-wide execution grant.
+	//
+	// Which leaves the case this returns early on. An external provider chosen
+	// automatically cannot be persisted either, because the name alone no longer
+	// resolves. discoverSummaryProviderIfMissing gates the named lookup on the
+	// grant, so writing `provider: X` without it produces a configuration that
+	// fails on the very next run: Entire breaking itself with its own write. It
+	// did resolve ungated once, which is what the comment that used to sit here
+	// said. Gating that lookup closed a hole and invalidated the claim.
+	//
+	// Writing nothing is not a lost setting. The run in progress already has the
+	// agent registered from discoverSummaryProvidersAlways, so it completes, and
+	// the next run re-discovers and auto-selects the same provider by the same
+	// route. What is lost is only the shortcut of not re-deciding, against a
+	// stored value that would make the command fail.
+	//
+	// This is the rule enableExternalAgentsLocally already follows: do not report
+	// success for a write that cannot take effect. Persisting here is that same
+	// false claim written to disk instead of printed.
+	if ag, getErr := getSummaryAgent(provider); getErr == nil && external.IsExternal(ag) && !s.ExternalAgents {
+		if origin != selectionByUser {
+			return false, errSelectionNotPersistable
 		}
+		s.ExternalAgents = true
+		flagFlipped = true
 	}
 
 	if err := saveLocalSummarySettings(ctx, s); err != nil {

--- a/cmd/entire/cli/explain_summary_provider.go
+++ b/cmd/entire/cli/explain_summary_provider.go
@@ -88,8 +88,11 @@ func resolveCheckpointSummaryProvider(ctx context.Context, w io.Writer) (*checkp
 
 	if s.SummaryGeneration != nil && s.SummaryGeneration.Provider != "" {
 		providerName := types.AgentName(s.SummaryGeneration.Provider)
-		discoverSummaryProviderIfMissing(ctx, providerName)
+		blocked := discoverSummaryProviderIfMissing(ctx, providerName)
 		if err := ensureSummaryProviderPresent(ctx, providerName); err != nil {
+			if blocked {
+				return nil, fmt.Errorf("%w\nIf %s is an external plugin, enable external agents first: `entire agent` and pick it, or set \"external_agents\": true in .entire/settings.local.json", err, providerName)
+			}
 			return nil, err
 		}
 		return buildCheckpointSummaryProvider(providerName, s.SummaryGeneration.Model)
@@ -129,7 +132,9 @@ func resolveCheckpointSummaryProvider(ctx context.Context, w io.Writer) (*checkp
 }
 
 // discoverSummaryProviderIfMissing resolves a configured provider name that is
-// not registered yet.
+// not registered yet. It reports whether it declined to look because external
+// agents are not enabled, so the caller can say so rather than leaving the user
+// with "unknown summary provider" about a plugin that is installed.
 //
 // Named, never the sweep. The name arrives from summary_generation.provider,
 // which is honored from the COMMITTED .entire/settings.json, so routing it
@@ -139,15 +144,41 @@ func resolveCheckpointSummaryProvider(ctx context.Context, w io.Writer) (*checkp
 // lookup returns immediately for a built-in and touches exactly one binary
 // otherwise, so the ordinary case costs nothing either.
 //
-// The error is dropped for the reason discoverNamedExternalAgent gives: the
-// caller reports an unresolvable provider a few lines later, in terms of the
-// provider the user named rather than of the plugin protocol.
-func discoverSummaryProviderIfMissing(ctx context.Context, name types.AgentName) {
+// Named is not sufficient on its own, though, which is what the
+// external_agents check adds: one binary is still one binary, and the name
+// deciding WHICH one still came out of a tracked file. `{"summary_generation":
+// {"provider": "evil"}}` in a pull request is then enough to run
+// `entire-agent-evil info` on everyone who pulls it and runs `entire explain`,
+// with no prompt and no grant — the exact thing enforceExternalAgentsTrust
+// exists to prevent, reached by a path that never consults it.
+//
+// The gate lands only on the external case: the early return above covers every
+// registered agent, so a committed `"provider": "claude-code"` keeps working
+// with external agents off, as it must.
+//
+// The lighter gate rather than a third trust gate beside enforceOPFCommandTrust
+// and enforceExternalAgentsTrust. An enforceSummaryProviderTrust would let a
+// developer name an external provider in their own untracked
+// settings.local.json without granting the $PATH sweep, which is a real if
+// narrow want; it costs another settings-layer classification, another
+// rejection channel for `entire status` to surface, and another gate to keep in
+// step. It becomes worth writing when someone actually asks for that
+// combination -- until then, `entire agent` already offers the plugin, and
+// picking it there is what flips the grant.
+//
+// The discovery error is dropped for the reason discoverNamedExternalAgent
+// gives: the caller reports an unresolvable provider a few lines later, in
+// terms of the provider the user named rather than of the plugin protocol.
+func discoverSummaryProviderIfMissing(ctx context.Context, name types.AgentName) (blockedByExternalAgents bool) {
 	if _, err := getSummaryAgent(name); err == nil {
-		return
+		return false
+	}
+	if !settings.IsExternalAgentsEnabled(ctx) {
+		return true
 	}
 	//nolint:errcheck,gosec // see doc comment: ensureSummaryProviderPresent reports it
 	discoverNamedSummaryProvider(ctx, name)
+	return false
 }
 
 // autoSelectSummaryProvider builds a provider for an auto-selected candidate

--- a/cmd/entire/cli/explain_summary_provider.go
+++ b/cmd/entire/cli/explain_summary_provider.go
@@ -181,14 +181,16 @@ func discoverSummaryProviderIfMissing(ctx context.Context, name types.AgentName)
 	return false
 }
 
-// autoSelectSummaryProvider builds a provider for an auto-selected candidate
-// (single-installed or non-interactive-first-of-many) and persists the choice
-// so subsequent runs don't re-decide. Persistence failure is surfaced as a
-// warning — not an error — because the selection is still usable in-process.
 // errSelectionNotPersistable reports a selection that is correct for this run
 // and must not be written down. See persistSummaryProviderSelection.
 var errSelectionNotPersistable = errors.New("selection is valid for this run but would not resolve on the next one")
 
+// autoSelectSummaryProvider builds a provider for an auto-selected candidate
+// (single-installed or non-interactive-first-of-many) and persists the choice
+// so subsequent runs don't re-decide. Persistence failure is surfaced as a
+// warning — not an error — because the selection is still usable in-process.
+// An external provider chosen without a human is the one case that persists
+// nothing at all; see persistSummaryProviderSelection.
 func autoSelectSummaryProvider(ctx context.Context, w io.Writer, name types.AgentName, reason string, origin summarySelectionOrigin) (*checkpointSummaryProvider, error) {
 	logging.Info(ctx, reason, "provider", string(name))
 	provider, err := buildCheckpointSummaryProvider(name, "")

--- a/cmd/entire/cli/explain_summary_provider_test.go
+++ b/cmd/entire/cli/explain_summary_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1019,17 +1020,23 @@ func TestResolveCheckpointSummaryProvider_ConfiguredProviderUsesNamedDiscovery(t
 	}
 }
 
-// TestPersistSummaryProviderSelection_AutoSelectDoesNotGrantExternalAgents
-// pins that the repo-wide external_agents grant needs a human.
+// TestPersistSummaryProviderSelection_AutoSelectPersistsNothingForAnExternal
+// pins both halves of the automatic case.
 //
-// The non-interactive branches of resolveCheckpointSummaryProvider auto-select
-// (single candidate, or first-of-many with no TTY) and used to persist the
-// grant on the way through. That grant is not scoped to the chosen provider:
-// it turns on the $PATH sweep that runs every entire-agent-* binary from then
-// on, so it must not be minted by a code path where nobody chose anything. The
-// chosen provider still resolves on later runs without it, through the named
-// ungated lookup in discoverSummaryProviderIfMissing.
-func TestPersistSummaryProviderSelection_AutoSelectDoesNotGrantExternalAgents(t *testing.T) {
+// The repo-wide external_agents grant needs a human: the non-interactive
+// branches of resolveCheckpointSummaryProvider auto-select (single candidate,
+// or first-of-many with no TTY) and used to persist the grant on the way
+// through. That grant is not scoped to the chosen provider, it turns on the
+// $PATH sweep that runs every entire-agent-* binary from then on, so it must
+// not be minted by a code path where nobody chose anything.
+//
+// And with the grant withheld, the provider NAME must not be persisted either.
+// It used to be, on the reasoning that it resolved through an ungated named
+// lookup. That lookup is gated now, so the write produced a settings file whose
+// very next read fails with "unknown summary provider" -- Entire breaking
+// itself with its own write. Persisting nothing leaves the working behaviour:
+// the next run re-discovers and auto-selects the same provider.
+func TestPersistSummaryProviderSelection_AutoSelectPersistsNothingForAnExternal(t *testing.T) {
 	// Cannot use t.Parallel(): mutates the package-level agent registry via discovery.
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("sh not available")
@@ -1054,24 +1061,74 @@ func TestPersistSummaryProviderSelection_AutoSelectDoesNotGrantExternalAgents(t 
 	discoverSummaryProvidersAlways(ctx)
 
 	flagFlipped, err := persistSummaryProviderSelection(ctx, types.AgentName(providerName), "", selectionAutomatic)
-	if err != nil {
-		t.Fatalf("persistSummaryProviderSelection() error = %v", err)
+	if !errors.Is(err, errSelectionNotPersistable) {
+		t.Fatalf("persistSummaryProviderSelection() error = %v, want errSelectionNotPersistable", err)
 	}
 	if flagFlipped {
 		t.Error("an automatic selection must not flip external_agents")
 	}
 
-	s, err := settings.LoadFromFile(filepath.Join(tmpDir, ".entire", "settings.local.json"))
+	localFile := filepath.Join(tmpDir, ".entire", "settings.local.json")
+	if _, statErr := os.Stat(localFile); statErr == nil {
+		s, loadErr := settings.LoadFromFile(localFile)
+		if loadErr != nil {
+			t.Fatalf("LoadFromFile() error = %v", loadErr)
+		}
+		if s.ExternalAgents {
+			t.Error("external_agents granted without a human choosing the provider")
+		}
+		if s.SummaryGeneration != nil && s.SummaryGeneration.Provider != "" {
+			t.Errorf("provider %q persisted without the grant that makes it resolvable; "+
+				"the next run reads it back and fails", s.SummaryGeneration.Provider)
+		}
+	}
+}
+
+// The round trip the bug actually produced: auto-select, save, then resolve
+// again from the saved settings. It must not fail on what Entire itself wrote.
+func TestResolveCheckpointSummaryProvider_AutoSelectedExternalSurvivesTheNextRun(t *testing.T) {
+	// Cannot use t.Parallel(): mutates the package-level agent registry via discovery.
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	t.Chdir(tmpDir)
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o750); err != nil {
+		t.Fatalf("mkdir .entire: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".entire", "settings.json"), []byte(`{"enabled":true}`), 0o600); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	const providerName = "external-summary-roundtrip"
+	externalDir := t.TempDir()
+	writeExternalSummaryAgentBinary(t, externalDir, providerName)
+	t.Setenv("PATH", externalDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// The always-variant, which is what the real non-interactive path uses to
+	// build its candidate list: installation is the opt-in to "this plugin
+	// exists", and it is what makes the run in progress work without the grant.
+	discoverSummaryProvidersAlways(ctx)
+
+	var first bytes.Buffer
+	got, err := autoSelectSummaryProvider(ctx, &first, types.AgentName(providerName),
+		"test: non-interactive auto-select", selectionAutomatic)
 	if err != nil {
-		t.Fatalf("LoadFromFile() error = %v", err)
+		t.Fatalf("autoSelectSummaryProvider() error = %v", err)
 	}
-	if s.ExternalAgents {
-		t.Error("external_agents granted without a human choosing the provider")
+	if got.Name != types.AgentName(providerName) {
+		t.Fatalf("provider = %q, want %q", got.Name, providerName)
 	}
-	// The provider choice itself is still worth persisting: it is what keeps
-	// the next run from re-deciding, and it grants nothing on its own.
-	if s.SummaryGeneration == nil || s.SummaryGeneration.Provider != providerName {
-		t.Fatalf("provider not persisted; got %+v", s.SummaryGeneration)
+	if !strings.Contains(first.String(), "entire agent") {
+		t.Errorf("output should say how to make the choice stick, got %q", first.String())
+	}
+
+	// Second run: whatever was written, resolving again must still work.
+	if _, err := resolveCheckpointSummaryProvider(ctx, io.Discard); err != nil {
+		t.Fatalf("second run failed on settings the first run wrote: %v", err)
 	}
 }
 

--- a/cmd/entire/cli/explain_summary_provider_test.go
+++ b/cmd/entire/cli/explain_summary_provider_test.go
@@ -1086,6 +1086,13 @@ func TestPersistSummaryProviderSelection_AutoSelectPersistsNothingForAnExternal(
 
 // The round trip the bug actually produced: auto-select, save, then resolve
 // again from the saved settings. It must not fail on what Entire itself wrote.
+//
+// The second resolution runs with the registry RESTORED to its pre-discovery
+// state, which is what a fresh process actually has. Without that this proves
+// much less than it appears to: the first call leaves the external agent
+// registered process-wide, so a second call in the same process resolves it
+// from memory whether or not anything usable was persisted. The bug is a
+// next-invocation bug, so the test has to be one too.
 func TestResolveCheckpointSummaryProvider_AutoSelectedExternalSurvivesTheNextRun(t *testing.T) {
 	// Cannot use t.Parallel(): mutates the package-level agent registry via discovery.
 	if _, err := exec.LookPath("sh"); err != nil {
@@ -1111,6 +1118,7 @@ func TestResolveCheckpointSummaryProvider_AutoSelectedExternalSurvivesTheNextRun
 	// The always-variant, which is what the real non-interactive path uses to
 	// build its candidate list: installation is the opt-in to "this plugin
 	// exists", and it is what makes the run in progress work without the grant.
+	restore := agent.SnapshotRegistryForTesting()
 	discoverSummaryProvidersAlways(ctx)
 
 	var first bytes.Buffer
@@ -1126,9 +1134,58 @@ func TestResolveCheckpointSummaryProvider_AutoSelectedExternalSurvivesTheNextRun
 		t.Errorf("output should say how to make the choice stick, got %q", first.String())
 	}
 
-	// Second run: whatever was written, resolving again must still work.
+	// A fresh process: the plugin is on $PATH but nothing is registered yet.
+	restore()
+
 	if _, err := resolveCheckpointSummaryProvider(ctx, io.Discard); err != nil {
-		t.Fatalf("second run failed on settings the first run wrote: %v", err)
+		t.Fatalf("a fresh process failed on the settings the first run wrote: %v", err)
+	}
+}
+
+// The negative control for the test above, and the reason not-persisting is the
+// fix rather than a dodge.
+//
+// It writes by hand what the old code wrote by itself -- the provider name with
+// no external_agents grant -- and then resolves as a fresh process would. That
+// configuration is unusable: discoverSummaryProviderIfMissing gates the named
+// lookup on the grant, so the name resolves to nothing and the command fails on
+// something Entire put there. If a future change makes this state reachable
+// again, this test says so.
+func TestResolveCheckpointSummaryProvider_PersistedExternalWithoutTheGrantIsBroken(t *testing.T) {
+	// Cannot use t.Parallel(): mutates the package-level agent registry via discovery.
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	t.Chdir(tmpDir)
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o750); err != nil {
+		t.Fatalf("mkdir .entire: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".entire", "settings.json"), []byte(`{"enabled":true}`), 0o600); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	const providerName = "external-summary-persisted"
+	externalDir := t.TempDir()
+	writeExternalSummaryAgentBinary(t, externalDir, providerName)
+	t.Setenv("PATH", externalDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// What persisting used to produce: the name, and no grant.
+	local := fmt.Sprintf(`{"summary_generation":{"provider":%q}}`, providerName)
+	if err := os.WriteFile(filepath.Join(tmpDir, ".entire", "settings.local.json"), []byte(local), 0o600); err != nil {
+		t.Fatalf("write local settings: %v", err)
+	}
+
+	_, err := resolveCheckpointSummaryProvider(ctx, io.Discard)
+	if err == nil {
+		t.Fatal("a persisted external provider with no grant resolved; the gate is not being applied")
+	}
+	if !strings.Contains(err.Error(), providerName) {
+		t.Errorf("error = %q, want it to name the unresolvable provider", err)
 	}
 }
 

--- a/cmd/entire/cli/explain_summary_provider_test.go
+++ b/cmd/entire/cli/explain_summary_provider_test.go
@@ -803,8 +803,14 @@ func TestResolveCheckpointSummaryProvider_ConfiguredExternalProvider(t *testing.
 	if err := os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755); err != nil {
 		t.Fatalf("mkdir .entire: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(tmpDir, ".entire", "settings.json"), []byte(`{"enabled":true,"external_agents":true,"summary_generation":{"provider":"`+providerName+`","model":"external-model"}}`), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, ".entire", "settings.json"), []byte(`{"enabled":true,"summary_generation":{"provider":"`+providerName+`","model":"external-model"}}`), 0o644); err != nil {
 		t.Fatalf("write settings: %v", err)
+	}
+	// The grant lives in the untracked local layer, which is the only one
+	// settings.enforceExternalAgentsTrust honors — and the only one that lets
+	// the configured name reach discovery at all.
+	if err := os.WriteFile(filepath.Join(tmpDir, ".entire", "settings.local.json"), []byte(`{"external_agents":true}`), 0o644); err != nil {
+		t.Fatalf("write local settings: %v", err)
 	}
 	externalDir := t.TempDir()
 	writeExternalSummaryAgentBinary(t, externalDir, providerName)
@@ -956,6 +962,7 @@ func TestPersistSummaryProviderSelection_ExternalAlreadyEnabledNoSignal(t *testi
 func TestResolveCheckpointSummaryProvider_ConfiguredProviderUsesNamedDiscovery(t *testing.T) {
 	// Cannot use t.Parallel(): mutates package-level resolution seams.
 	ctx := context.Background()
+	grantExternalAgentsLocally(t)
 	const configuredName = types.AgentName("external-configured-provider")
 	stub := &stubTextAgent{name: configuredName, kind: agent.AgentTypeClaudeCode}
 
@@ -1065,5 +1072,113 @@ func TestPersistSummaryProviderSelection_AutoSelectDoesNotGrantExternalAgents(t 
 	// the next run from re-deciding, and it grants nothing on its own.
 	if s.SummaryGeneration == nil || s.SummaryGeneration.Provider != providerName {
 		t.Fatalf("provider not persisted; got %+v", s.SummaryGeneration)
+	}
+}
+
+// grantExternalAgentsLocally puts the test in a repository whose UNTRACKED
+// .entire/settings.local.json enables external agents, which is the only layer
+// settings.enforceExternalAgentsTrust honors.
+func grantExternalAgentsLocally(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".entire"), 0o750); err != nil {
+		t.Fatalf("mkdir .entire: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".entire", "settings.local.json"), []byte(`{"external_agents":true}`), 0o600); err != nil {
+		t.Fatalf("write local settings: %v", err)
+	}
+}
+
+// summary_generation.provider is honored from the COMMITTED
+// .entire/settings.json, so the name deciding which binary to execute can
+// arrive in a pull request. Naming one binary rather than sweeping $PATH is not
+// enough on its own: without the external_agents grant, that one line would run
+// `entire-agent-<name> info` on everyone who pulls it.
+func TestDiscoverSummaryProviderIfMissing_ExternalNeedsTheGrant(t *testing.T) {
+	// Cannot use t.Parallel(): mutates package-level resolution seams.
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	originalGet := getSummaryAgent
+	originalNamed := discoverNamedSummaryProvider
+	t.Cleanup(func() {
+		getSummaryAgent = originalGet
+		discoverNamedSummaryProvider = originalNamed
+	})
+
+	getSummaryAgent = func(name types.AgentName) (agent.Agent, error) {
+		return nil, fmt.Errorf("agent %q not registered", name)
+	}
+	discoverNamedSummaryProvider = func(context.Context, types.AgentName) error {
+		t.Fatal("a committed provider name must not execute a plugin binary without the external_agents grant")
+		return nil
+	}
+
+	if blocked := discoverSummaryProviderIfMissing(context.Background(), "external-ungranted"); !blocked {
+		t.Fatal("discoverSummaryProviderIfMissing() should report that it declined for want of the grant")
+	}
+}
+
+// The gate must land only on the external case. A committed
+// `"provider": "claude-code"` is the ordinary configuration and has nothing to
+// do with plugins, so it must keep working with external agents off.
+func TestDiscoverSummaryProviderIfMissing_RegisteredProviderIsUnaffected(t *testing.T) {
+	// Cannot use t.Parallel(): mutates package-level resolution seams.
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	originalGet := getSummaryAgent
+	originalNamed := discoverNamedSummaryProvider
+	t.Cleanup(func() {
+		getSummaryAgent = originalGet
+		discoverNamedSummaryProvider = originalNamed
+	})
+
+	getSummaryAgent = func(types.AgentName) (agent.Agent, error) {
+		return &stubTextAgent{name: "claude-code", kind: agent.AgentTypeClaudeCode}, nil
+	}
+	discoverNamedSummaryProvider = func(context.Context, types.AgentName) error {
+		t.Fatal("a registered provider must not reach discovery at all")
+		return nil
+	}
+
+	if blocked := discoverSummaryProviderIfMissing(context.Background(), "claude-code"); blocked {
+		t.Fatal("a registered provider must resolve regardless of the external_agents grant")
+	}
+}
+
+// Once granted, the named lookup runs as before.
+func TestDiscoverSummaryProviderIfMissing_GrantedExternalIsDiscovered(t *testing.T) {
+	// Cannot use t.Parallel(): mutates package-level resolution seams.
+	grantExternalAgentsLocally(t)
+
+	originalGet := getSummaryAgent
+	originalNamed := discoverNamedSummaryProvider
+	t.Cleanup(func() {
+		getSummaryAgent = originalGet
+		discoverNamedSummaryProvider = originalNamed
+	})
+
+	getSummaryAgent = func(name types.AgentName) (agent.Agent, error) {
+		return nil, fmt.Errorf("agent %q not registered", name)
+	}
+	calls := 0
+	discoverNamedSummaryProvider = func(_ context.Context, name types.AgentName) error {
+		calls++
+		if name != "external-granted" {
+			t.Fatalf("named discovery for %q, want %q", name, "external-granted")
+		}
+		return nil
+	}
+
+	if blocked := discoverSummaryProviderIfMissing(context.Background(), "external-granted"); blocked {
+		t.Fatal("discoverSummaryProviderIfMissing() should not report a block once the grant is in place")
+	}
+	if calls != 1 {
+		t.Fatalf("named discovery called %d times, want exactly 1", calls)
 	}
 }

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -228,6 +228,15 @@ func HasUncommittedChanges(ctx context.Context) (bool, error) {
 // via git ls-remote in case local refs are stale (e.g., after a fresh clone
 // that didn't fetch all branches).
 func BranchExistsOnRemote(ctx context.Context, branchName string) (bool, error) {
+	// The name reaches `git ls-remote` as an argument and reaches go-git as a
+	// reference name, and every caller takes it from CLI input or from a trail's
+	// metadata. "refs/heads/" in front rules out an option being read as one,
+	// but not a name carrying a newline or a glob, which ls-remote answers for
+	// some other branch entirely.
+	if err := ValidateBranchName(ctx, branchName); err != nil {
+		return false, err
+	}
+
 	repo, err := openRepository(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to open git repository: %w", err)
@@ -259,6 +268,14 @@ func BranchExistsOnRemote(ctx context.Context, branchName string) (bool, error) 
 
 // BranchExistsLocally checks if a local branch exists.
 func BranchExistsLocally(ctx context.Context, branchName string) (bool, error) {
+	// Symmetry with BranchExistsOnRemote is the point: the two are called side
+	// by side on the same name, and a name that is not a branch name should get
+	// the same answer from both rather than "invalid" from one and "no such
+	// branch" from the other.
+	if err := ValidateBranchName(ctx, branchName); err != nil {
+		return false, err
+	}
+
 	repo, err := openRepository(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to open git repository: %w", err)
@@ -276,14 +293,22 @@ func BranchExistsLocally(ctx context.Context, branchName string) (bool, error) {
 	return true, nil
 }
 
-// CheckoutBranch switches to the specified local branch or commit.
+// CheckoutBranch switches to the specified local branch.
 // Uses git CLI instead of go-git to work around go-git v5 bug where Checkout
 // deletes untracked files (see https://github.com/go-git/go-git/issues/970).
 // Should be switched back to go-git once we upgrade to go-git v6
 // Returns an error if the ref doesn't exist or checkout fails.
+//
+// The leading-dash guard it used to carry is the narrowest part of the problem:
+// `git checkout` also reads `--`, a pathspec, and `@{-1}`, and the ref arrives
+// from `entire resume <branch>` and from a trail's branch field. Full
+// validation costs one subprocess on a command a human is waiting on, and it
+// still admits an object id — `check-ref-format --branch` accepts a hex string
+// — so the "or commit" half of the old contract survives even though no caller
+// uses it.
 func CheckoutBranch(ctx context.Context, ref string) error {
-	if strings.HasPrefix(ref, "-") {
-		return fmt.Errorf("checkout failed: invalid ref %q", ref)
+	if err := ValidateBranchName(ctx, ref); err != nil {
+		return fmt.Errorf("checkout failed: %w", err)
 	}
 	cmd := exec.CommandContext(ctx, "git", "checkout", ref)
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -299,18 +299,29 @@ func BranchExistsLocally(ctx context.Context, branchName string) (bool, error) {
 // Should be switched back to go-git once we upgrade to go-git v6
 // Returns an error if the ref doesn't exist or checkout fails.
 //
-// The leading-dash guard it used to carry is the narrowest part of the problem:
-// `git checkout` also reads `--`, a pathspec, and `@{-1}`, and the ref arrives
-// from `entire resume <branch>` and from a trail's branch field. Full
-// validation costs one subprocess on a command a human is waiting on, and it
-// still admits an object id — `check-ref-format --branch` accepts a hex string
-// — so the "or commit" half of the old contract survives even though no caller
-// uses it.
+// Two guards, because neither covers the other.
+//
+// ValidateBranchName replaces a leading-dash check that was the narrowest part
+// of the problem: the ref arrives from `entire resume <branch>` and from a
+// trail's branch field, and `git checkout` also reads `@{-1}` and a name
+// carrying a newline. It still admits an object id, since `check-ref-format
+// --branch` accepts a hex string, so the "or commit" half of the old contract
+// survives even though no caller uses it.
+//
+// The trailing `--` covers what validation cannot, and validation cannot cover
+// it in principle: `git checkout <name>` falls back to treating <name> as a
+// PATHSPEC when no such ref exists, and a filename is very often a perfectly
+// legal branch name. `check-ref-format --branch README.md` exits 0, and
+// `git checkout README.md` in a repo with no such branch then restores that file
+// from the index, discarding the user's edits, and exits 0 -- a silent data loss
+// reported as success. With the `--`, the same call is `fatal: invalid
+// reference: README.md` and exits 128. A branch and a raw commit id both still
+// resolve, so nothing legitimate is lost.
 func CheckoutBranch(ctx context.Context, ref string) error {
 	if err := ValidateBranchName(ctx, ref); err != nil {
 		return fmt.Errorf("checkout failed: %w", err)
 	}
-	cmd := exec.CommandContext(ctx, "git", "checkout", ref)
+	cmd := exec.CommandContext(ctx, "git", "checkout", ref, "--")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("checkout failed: %s: %w", strings.TrimSpace(string(output)), err)
 	}

--- a/cmd/entire/cli/gitrepo/gitstatus_guard_test.go
+++ b/cmd/entire/cli/gitrepo/gitstatus_guard_test.go
@@ -40,17 +40,41 @@ var gitInvocationMarkers = []string{
 func TestGitStatusCallSitesPassNoOptionalLocks(t *testing.T) {
 	t.Parallel()
 
-	root := strings.TrimSpace(testutil.RunGit(t, "", "rev-parse", "--show-toplevel"))
+	root, found := testutil.GitGrepGuardRepoRoot(t)
+	if !found {
+		return
+	}
 
-	// git grep exits non-zero on zero matches, so RunGit failing here means
-	// "found nothing", which cannot be right — see the checked == 0 guard below.
-	out := testutil.RunGit(t, root, "grep", "-n", "--", `"status"`, "--", "cmd", "internal")
+	// GitGrepGuard rather than RunGit: it passes --untracked, so a `git status`
+	// call site in a not-yet-staged file is visible (new call sites arrive in new
+	// files, which is the case this guard exists for), --no-color, and it scrubs
+	// GIT_DIR / GIT_WORK_TREE, which RunGit's env isolation does not — it filters
+	// GIT_CONFIG_* only, so a `go test` under a git hook scanned another
+	// repository. It also fails loudly on zero matches, which is the same
+	// staleness signal as the checked == 0 guard below.
+	// Pathspec narrowed to *.go, which is what lets the parse failure below be
+	// fatal: the bare `cmd internal` it used to pass also matched testdata
+	// .jsonl fixtures and a .md file, so a non-.go first field was an ordinary
+	// result rather than evidence of mangled output, and the skip that filtered
+	// them was also the only thing standing between colorized output and a
+	// guard that silently checked nothing.
+	out := testutil.GitGrepGuard(t, root, "-n", "--", `"status"`,
+		"--", ":(glob)cmd/**/*.go", ":(glob)internal/**/*.go")
 
 	var checked int
 	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
-		path, rest, ok := strings.Cut(line, ":")
-		if !ok || !strings.HasSuffix(path, ".go") {
+		if line == "" {
 			continue
+		}
+		path, rest, ok := strings.Cut(line, ":")
+		// Fatal, not skip. Colorized output puts escapes in the filename field,
+		// so every line failed this check, `checked` stayed 0, and the guard
+		// reported its detection pattern stale — the #2248 misdiagnosis, from a
+		// tree that was perfectly fine.
+		if !ok || !strings.HasSuffix(path, ".go") {
+			t.Fatalf("cannot parse git grep output; expected `path:line:content`, got:\n  %s\n"+
+				"The filename field is unusable, so this test can prove nothing. "+
+				"Check whether git is colorizing into a pipe (color.ui or color.grep set to `always`).", line)
 		}
 		// Test files and fixtures may assert on the unguarded argv shape.
 		if strings.HasSuffix(path, "_test.go") || strings.Contains(path, "/testutil/") {

--- a/cmd/entire/cli/gitrepo/metadata_guard_test.go
+++ b/cmd/entire/cli/gitrepo/metadata_guard_test.go
@@ -40,6 +40,7 @@ func TestGitMetadataTraversalHasCanonicalOwner(t *testing.T) {
 		{source: "session_adopt.go:stateStoreForWorktree", flag: "--git-common-dir"}:                    "adoption validates an arbitrary source repository in the session split",
 		{source: "session_adopt.go:stateStoreForWorktree", flag: "--show-toplevel"}:                     "adoption validates an arbitrary source repository in the session split",
 		{source: "settings/settings.go:clonePreferencesPathForWorktreeRoot", flag: "--git-common-dir"}:  "settings migrates with the remaining consumers",
+		{source: "testutil/gitgrep.go:GitGrepGuardRepoRoot", flag: "--show-toplevel"}:                   "the source-level guard tests scan the checkout they live in, which is the repository git reports and not one resolved from a worktree path",
 		{source: "strategy/common.go:GetGitCommonDir", flag: "--git-common-dir"}:                        "strategy migrates in the strategy-and-hooks split",
 		{source: "strategy/hooks.go:getGitDirInPath", flag: "--git-dir"}:                                "hook directory discovery migrates in the strategy-and-hooks split",
 		{source: "strategy/manual_commit_session.go:gitCommonDirForWorktree", flag: "--git-common-dir"}: "session routing migrates in the strategy-and-hooks split",

--- a/cmd/entire/cli/osroot/rootbase_guard_test.go
+++ b/cmd/entire/cli/osroot/rootbase_guard_test.go
@@ -4,6 +4,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
 // rootOpeners cover both package-level os.OpenRoot and Root.OpenRoot, plus the
@@ -73,26 +75,17 @@ var allowedRootBases = map[string]string{
 func TestRootBasesAreTrusted(t *testing.T) {
 	t.Parallel()
 
-	repoRoot, err := exec.Command("git", "rev-parse", "--show-toplevel").Output() //nolint:noctx // guard test, no cancellation needed
-	if err != nil {
-		t.Skipf("not in a git checkout: %v", err)
+	repoRoot, ok := testutil.GitGrepGuardRepoRoot(t)
+	if !ok {
+		return
 	}
 
 	var checked int
 	for _, opener := range rootOpeners {
-		// --no-color because this parses git's output: color.ui / color.grep
-		// set to `always` colorizes even into a pipe, and the escapes land
-		// inside the filename field, so every line below fails the .go suffix
-		// check and the guard reports itself stale on a perfectly good tree.
-		// That is not hypothetical -- it was read as a real staleness failure
-		// on main (#2248) before the cause was found.
-		grep := exec.Command("git", "grep", "-n", "--no-color", "--fixed-strings", "--", opener, "--", ":(glob)**/*.go") //nolint:noctx // guard test, no cancellation needed
-		grep.Dir = strings.TrimSpace(string(repoRoot))
-		out, grepErr := grep.Output()
-		if grepErr != nil {
-			t.Fatalf("git grep for %q found nothing, which cannot be right: %v", opener, grepErr)
-		}
-		for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		// testutil.GitGrepGuard owns --untracked, --no-color and the repo-selector
+		// scrubbing, and explains why each is load-bearing for a guard like this.
+		out := testutil.GitGrepGuard(t, repoRoot, "-n", "--fixed-strings", "--", opener, "--", ":(glob)**/*.go")
+		for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
 			if line == "" {
 				continue
 			}
@@ -136,7 +129,7 @@ func TestRootBasesAreTrusted(t *testing.T) {
 	}
 
 	for file := range allowedRootBases {
-		if !fileStillOpensARoot(t, strings.TrimSpace(string(repoRoot)), file) {
+		if !fileStillOpensARoot(t, repoRoot, file) {
 			t.Errorf("%s is in allowedRootBases but no longer opens a root; remove the entry", file)
 		}
 	}
@@ -148,8 +141,12 @@ func TestRootBasesAreTrusted(t *testing.T) {
 func fileStillOpensARoot(t *testing.T, repoRoot, file string) bool {
 	t.Helper()
 	for _, opener := range rootOpeners {
-		grep := exec.Command("git", "grep", "-q", "--no-color", "--fixed-strings", "--", opener, "--", file) //nolint:noctx // guard test, no cancellation needed
+		// -q, so this one cannot use GitGrepGuard: a miss is the expected answer
+		// here, not a stale pattern. The flags still have to match it, which is
+		// what makes the shared helper's doc comment the place they are explained.
+		grep := exec.Command("git", "grep", "-q", "--untracked", "--no-color", "--fixed-strings", "--", opener, "--", file) //nolint:noctx // guard test, no cancellation needed
 		grep.Dir = repoRoot
+		grep.Env = testutil.GuardGitEnv()
 		if grep.Run() == nil {
 			return true
 		}

--- a/cmd/entire/cli/osroot/rootbase_guard_test.go
+++ b/cmd/entire/cli/osroot/rootbase_guard_test.go
@@ -44,6 +44,7 @@ var allowedRootBases = map[string]string{
 	// Trees with their own resolver, anchored at the boundary between what
 	// Entire owns and what it does not.
 	"cmd/entire/cli/agent/session_store.go":      "the agent's own GetSessionDir (opened per operation, not memoized)",
+	"cmd/entire/cli/agent/vouched_dirs.go":       "worktree root, or a symlinked agent directory the user vouched for in settings.local.json, resolved",
 	"cmd/entire/cli/strategy/hooks.go":           "git rev-parse --git-path hooks; core.hooksPath can name a directory no other anchor covers",
 	"cmd/entire/cli/plugin_store.go":             "pluginParentDir()",
 	"cmd/entire/cli/plugin_index.go":             "the per-index cache dir, opened at the clone it contains",

--- a/cmd/entire/cli/osroot/rootbase_guard_test.go
+++ b/cmd/entire/cli/osroot/rootbase_guard_test.go
@@ -44,6 +44,7 @@ var allowedRootBases = map[string]string{
 	// Trees with their own resolver, anchored at the boundary between what
 	// Entire owns and what it does not.
 	"cmd/entire/cli/agent/session_store.go":      "the agent's own GetSessionDir (opened per operation, not memoized)",
+	"cmd/entire/cli/strategy/hooks.go":           "git rev-parse --git-path hooks; core.hooksPath can name a directory no other anchor covers",
 	"cmd/entire/cli/plugin_store.go":             "pluginParentDir()",
 	"cmd/entire/cli/plugin_index.go":             "the per-index cache dir, opened at the clone it contains",
 	"cmd/entire/cli/plugin_install_remote.go":    "a staging dir this process just created",

--- a/cmd/entire/cli/plugin_index.go
+++ b/cmd/entire/cli/plugin_index.go
@@ -159,7 +159,16 @@ func resolvePluginIndexURL(flagValue string) string {
 // URL so switching indexes (or per-repo overrides) never serves one
 // catalog's cache for another.
 func pluginIndexCacheDir(indexURL string) (string, error) {
-	cache := userdirs.Cache()
+	// Checked, not the string form. SyncPluginIndex creates the parent directory
+	// and takes a flock beside it before osroot.Shared ever sees the path, so a
+	// relative XDG_CACHE_HOME landed both in the working directory on the way to
+	// reporting itself -- the "creates the thing while reporting the error"
+	// shape already fixed in contexts, discovery and the token store. This was
+	// the fourth instance.
+	cache, err := userdirs.CacheDirChecked()
+	if err != nil {
+		return "", err //nolint:wrapcheck // the error already names the variable and its value
+	}
 	if cache == "" {
 		return "", errors.New("cannot resolve user cache directory")
 	}

--- a/cmd/entire/cli/plugin_store.go
+++ b/cmd/entire/cli/plugin_store.go
@@ -18,6 +18,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
 
 // Managed plugin storage. The kubectl-style dispatcher in plugin.go resolves
@@ -48,28 +49,6 @@ const (
 	pluginManagedSubDir = "plugins"
 )
 
-// requireAbsPluginParent rejects a non-absolute directory override.
-//
-// A relative value resolves against the process's working directory at
-// startup — typically inside the user's repository — which is the wrong place
-// for managed plugin storage, and it is storage whose bin subdirectory main.go
-// prepends to $PATH. Every override reaching pluginParentDir gets this check,
-// not just ENTIRE_PLUGIN_DIR: XDG_DATA_HOME and LOCALAPPDATA were joined
-// unchecked and left for osroot (which refuses the root open) and for main.go
-// (which restores $PATH) to notice. Those backstops hold today, but they state
-// the invariant two layers away from where it is decided, and each answers a
-// question of its own rather than this one.
-//
-// Rejecting is louder than falling through to the platform default: a
-// misconfigured override is a user error worth surfacing, not something to
-// paper over with a different directory than the one they asked for.
-func requireAbsPluginParent(name, value string) error {
-	if !filepath.IsAbs(value) {
-		return fmt.Errorf("%s must be an absolute path, got %q", name, value)
-	}
-	return nil
-}
-
 // pluginParentDir returns the per-user directory that holds the managed
 // plugin storage. Resolution, in order:
 //
@@ -86,15 +65,15 @@ func requireAbsPluginParent(name, value string) error {
 // still returns a usable path.
 func pluginParentDir() (string, error) {
 	if v := os.Getenv(pluginEnvPluginDir); v != "" {
-		if err := requireAbsPluginParent(pluginEnvPluginDir, v); err != nil {
-			return "", err
+		if err := userdirs.RequireAbsoluteOverride(pluginEnvPluginDir, v); err != nil {
+			return "", err //nolint:wrapcheck // the error already names the override and its value
 		}
 		return v, nil
 	}
 	if runtime.GOOS == windowsGOOS {
 		if appData := os.Getenv("LOCALAPPDATA"); appData != "" {
-			if err := requireAbsPluginParent("LOCALAPPDATA", appData); err != nil {
-				return "", err
+			if err := userdirs.RequireAbsoluteOverride("LOCALAPPDATA", appData); err != nil {
+				return "", err //nolint:wrapcheck // the error already names the override and its value
 			}
 			return filepath.Join(appData, pluginManagedTopDir, pluginManagedSubDir), nil
 		}
@@ -105,8 +84,8 @@ func pluginParentDir() (string, error) {
 		return filepath.Join(home, "AppData", "Local", pluginManagedTopDir, pluginManagedSubDir), nil
 	}
 	if v := os.Getenv("XDG_DATA_HOME"); v != "" {
-		if err := requireAbsPluginParent("XDG_DATA_HOME", v); err != nil {
-			return "", err
+		if err := userdirs.RequireAbsoluteOverride("XDG_DATA_HOME", v); err != nil {
+			return "", err //nolint:wrapcheck // the error already names the override and its value
 		}
 		return filepath.Join(v, pluginManagedTopDir, pluginManagedSubDir), nil
 	}

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -236,6 +236,34 @@ func TestCheckoutBranch(t *testing.T) {
 			}
 		})
 	}
+
+	// Validation cannot catch this one, and no amount of tightening it would:
+	// a filename is very often a legal branch name, so `check-ref-format
+	// --branch test.txt` exits 0. Without a trailing `--`, git falls back to
+	// reading the argument as a PATHSPEC, restores the file from the index, and
+	// exits 0 — the user's edits gone, reported as a successful checkout.
+	t.Run("a filename is not silently treated as a pathspec", func(t *testing.T) {
+		if err := CheckoutBranch(context.Background(), "feature"); err != nil {
+			t.Fatalf("setup checkout: %v", err)
+		}
+		const edited = "edited, must survive\n"
+		if err := os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte(edited), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		err := CheckoutBranch(context.Background(), "test.txt")
+		if err == nil {
+			t.Error("CheckoutBranch(\"test.txt\") = nil; a file that is not a ref must not report success")
+		}
+
+		got, readErr := os.ReadFile(filepath.Join(tmpDir, "test.txt"))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if string(got) != edited {
+			t.Errorf("test.txt = %q, want the uncommitted edit intact; git restored it from the index", got)
+		}
+	})
 }
 
 func TestResumeFromCurrentBranch_NoCheckpoint(t *testing.T) {

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -218,17 +219,23 @@ func TestCheckoutBranch(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects ref starting with dash to prevent argument injection", func(t *testing.T) {
-		// "git checkout -b evil" would create a new branch named "evil" instead
-		// of failing, because git interprets "-b" as a flag.
-		err := CheckoutBranch(context.Background(), "-b evil")
-		if err == nil {
-			t.Fatal("CheckoutBranch() should reject refs starting with '-', got nil")
-		}
-		if !strings.Contains(err.Error(), "invalid ref") {
-			t.Errorf("CheckoutBranch() error = %q, want error containing 'invalid ref'", err.Error())
-		}
-	})
+	// A leading dash was the only shape the old guard caught. `git checkout`
+	// reads several others, and the ref reaches here from `entire resume
+	// <branch>` and from a trail's branch field.
+	// Not "@{-1}": `check-ref-format --branch` resolves it to the previous
+	// branch and reports it valid, which is git's own feature rather than
+	// something this guard should override.
+	for _, ref := range []string{"-b evil", "..", "feature/../../etc", "feature\nmore"} {
+		t.Run("rejects "+strconv.Quote(ref), func(t *testing.T) {
+			err := CheckoutBranch(context.Background(), ref)
+			if err == nil {
+				t.Fatalf("CheckoutBranch(%q) should be rejected, got nil", ref)
+			}
+			if !strings.Contains(err.Error(), "invalid branch name") {
+				t.Errorf("CheckoutBranch(%q) error = %q, want error containing 'invalid branch name'", ref, err.Error())
+			}
+		})
+	}
 }
 
 func TestResumeFromCurrentBranch_NoCheckpoint(t *testing.T) {

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -693,6 +693,18 @@ func clonePreferencesPathForWorktreeRoot(ctx context.Context, worktreeRoot strin
 	return filepath.Join(filepath.Clean(commonDir), ClonePreferencesFile), nil
 }
 
+// worktreeRootOfSettingsFile recovers the worktree root a settings path was
+// built from: settingsAbsPaths joins <root>/.entire/<file>, so the root is two
+// levels up. Used only as the KEY the vouched-symlink policy is scoped by, never
+// as a base for I/O, so the derived-path rule in CLAUDE.md does not apply -- an
+// inconsistent key costs a refused symlink, which is the safe direction.
+func worktreeRootOfSettingsFile(settingsFileAbs string) string {
+	if settingsFileAbs == "" {
+		return ""
+	}
+	return filepath.Dir(filepath.Dir(settingsFileAbs))
+}
+
 func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs, localSettingsFileAbs string) (*EntireSettings, error) {
 	// Load base settings
 	settings, err := loadFromFile(settingsFileAbs)
@@ -737,7 +749,7 @@ func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs
 	// config, so it gets the same gate, and then installs the surviving set as
 	// the process-wide policy.
 	enforceSymlinkedAgentDirsTrust(ctx, settings, localSettingsFileAbs, localData)
-	applyVouchedAgentDirs(settings)
+	applyVouchedAgentDirs(settings, worktreeRootOfSettingsFile(settingsFileAbs))
 
 	// Re-validate after merge. Individual files are validated by loadFromFile,
 	// but mergeJSON patches fields independently and can produce combinations

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -82,6 +82,10 @@ type EntireSettings struct {
 	// Unexported so it never serializes. Surfaced via LocalLayerRejection.
 	localLayerRejection string
 
+	// symlinkedAgentDirsRejection records why some or all of
+	// allow_symlinked_agent_dirs was dropped.
+	symlinkedAgentDirsRejection string
+
 	// externalAgentsRejection records why an external_agents grant was
 	// dropped by the trust gate, for the consumer to report. Unexported so it
 	// never serializes — a rejected grant must not be written back to disk as
@@ -163,6 +167,22 @@ type EntireSettings struct {
 	// other than Load() (LoadFromFile, LoadFromBytes) get the ungated value
 	// and must not scan $PATH on it.
 	ExternalAgents bool `json:"external_agents,omitempty"`
+
+	// AllowSymlinkedAgentDirs lists worktree-relative agent config directories
+	// (".claude", ".codex/…") whose symlinks Entire may follow instead of
+	// refusing. Defaults to empty, which is the strict behaviour.
+	//
+	// A list rather than a boolean, on purpose: a flag would disable the whole
+	// class, where naming a path is the user saying which arrangement is theirs.
+	// Entries are checked against the directories actually derivable from the
+	// agents' hook-config paths, so `.entire` and `.git/hooks` cannot be
+	// spelled here at all.
+	//
+	// Following a link means writing where it points, so Load() honors this only
+	// from an untracked .entire/settings.local.json, the same gate as
+	// ExternalAgents. See enforceSymlinkedAgentDirsTrust and
+	// agent.SetVouchedSymlinkedDirs.
+	AllowSymlinkedAgentDirs []string `json:"allow_symlinked_agent_dirs,omitempty"`
 
 	// SummaryGeneration stores provider preferences for explain --generate.
 	// This is separate from strategy_options.summarize, which controls
@@ -532,6 +552,19 @@ func (s *EntireSettings) ExternalAgentsRejection() (reason string, rejected bool
 	return s.externalAgentsRejection, true
 }
 
+// SymlinkedAgentDirsRejection reports why Load dropped some or all of
+// allow_symlinked_agent_dirs, and whether a rejection happened.
+//
+// Surfaced for the same reason as ExternalAgentsRejection: without it, a grant
+// that was refused and a setting the user never wrote look identical from the
+// outside, since both end with Entire refusing the link.
+func (s *EntireSettings) SymlinkedAgentDirsRejection() (reason string, rejected bool) {
+	if s == nil || s.symlinkedAgentDirsRejection == "" {
+		return "", false
+	}
+	return s.symlinkedAgentDirsRejection, true
+}
+
 // InvestigateConfig returns the configured investigate config. Returns nil
 // when no configuration is present; callers should check IsZero (or guard
 // for nil) to decide whether configuration is present.
@@ -700,6 +733,11 @@ func loadMergedSettings(ctx context.Context, settingsFileAbs, preferencesFileAbs
 	// same gate.
 	enforceOPFCommandTrust(ctx, settings, localSettingsFileAbs, localData)
 	enforceExternalAgentsTrust(ctx, settings, localSettingsFileAbs, localData)
+	// allow_symlinked_agent_dirs decides where Entire writes an agent's hook
+	// config, so it gets the same gate, and then installs the surviving set as
+	// the process-wide policy.
+	enforceSymlinkedAgentDirsTrust(ctx, settings, localSettingsFileAbs, localData)
+	applyVouchedAgentDirs(settings)
 
 	// Re-validate after merge. Individual files are validated by loadFromFile,
 	// but mergeJSON patches fields independently and can produce combinations
@@ -1342,6 +1380,29 @@ func mergeScalarFields(settings *EntireSettings, raw map[string]json.RawMessage)
 	if err := mergeRawInt(raw, "summary_timeout_seconds", &settings.SummaryTimeoutSeconds); err != nil {
 		return err
 	}
+	if err := mergeRawStringSlice(raw, "allow_symlinked_agent_dirs", &settings.AllowSymlinkedAgentDirs); err != nil {
+		return err
+	}
+	return nil
+}
+
+// mergeRawStringSlice replaces dst when key is present, rather than appending.
+//
+// Replacement is the only sensible merge for allow_symlinked_agent_dirs: the
+// list is the complete set of directories this developer vouches for, and
+// appending would let the project layer contribute entries to a grant only the
+// local layer is trusted to make. An explicit empty list therefore means
+// "vouch for nothing", which is a thing a user can want to say.
+func mergeRawStringSlice(raw map[string]json.RawMessage, key string, dst *[]string) error {
+	v, ok := raw[key]
+	if !ok {
+		return nil
+	}
+	var parsed []string
+	if err := json.Unmarshal(v, &parsed); err != nil {
+		return fmt.Errorf("parsing %s: %w", key, err)
+	}
+	*dst = parsed
 	return nil
 }
 

--- a/cmd/entire/cli/settings/symlinked_agent_dirs_trust.go
+++ b/cmd/entire/cli/settings/symlinked_agent_dirs_trust.go
@@ -89,18 +89,23 @@ func localSetsSymlinkedAgentDirs(data []byte) bool {
 // process whose settings change mid-run cannot keep following a link the user
 // has since removed from the file.
 //
+// worktreeRoot scopes the policy to the tree these settings came from. The
+// value is the settings file's grandparent, which is exactly what
+// settingsAbsPaths built the path from (<root>/.entire/settings.json), so the
+// key agent stores matches the worktreeRoot OpenHookConfig is later given.
+//
 // The name check inside SetVouchedSymlinkedDirs is a second, different
 // boundary from the trust gate above, and both are needed. The gate answers
 // "may this file grant anything"; the name check answers "is this path one an
 // agent config actually lives in", which is what stops a developer's own local
 // file from vouching for `.entire` or `.git/hooks` -- paths whose refusals are
 // not up for negotiation whoever is asking.
-func applyVouchedAgentDirs(s *EntireSettings) {
+func applyVouchedAgentDirs(s *EntireSettings, worktreeRoot string) {
 	if s == nil {
-		agent.SetVouchedSymlinkedDirs(nil)
+		agent.SetVouchedSymlinkedDirs(worktreeRoot, nil)
 		return
 	}
-	rejected := agent.SetVouchedSymlinkedDirs(s.AllowSymlinkedAgentDirs)
+	rejected := agent.SetVouchedSymlinkedDirs(worktreeRoot, s.AllowSymlinkedAgentDirs)
 	if len(rejected) == 0 {
 		return
 	}

--- a/cmd/entire/cli/settings/symlinked_agent_dirs_trust.go
+++ b/cmd/entire/cli/settings/symlinked_agent_dirs_trust.go
@@ -1,0 +1,122 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// Why allow_symlinked_agent_dirs is dropped. The first two mirror the OPF
+// command's and external_agents' reasons, because the hazard is the same shape:
+// a JSON diff that changes WHERE Entire writes does not read as dangerous.
+const (
+	symlinkedAgentDirsRejectionNotLocal   = "it did not come from .entire/settings.local.json"
+	symlinkedAgentDirsRejectionUnverified = "the local settings file could not be verified as untracked"
+)
+
+// enforceSymlinkedAgentDirsTrust drops allow_symlinked_agent_dirs unless it came
+// from a local file positively verified as this developer's own.
+//
+// The entry it grants is not a preference. `.claude` and its siblings live in
+// the working tree, and a working tree arrives by clone, so a repository that
+// could both ship a symlink at `.claude` AND vouch for it in a tracked settings
+// file would have `entire enable` create directories and write JSON wherever
+// the link pointed. That is the exact attack the refusal exists to stop, so the
+// permission to skip the refusal has to come from somewhere the repository
+// cannot reach.
+//
+// localData is the raw local-file bytes, nil when the file is absent or its
+// layer was dropped as tracked. Like the OPF command and external_agents, the
+// deep (index AND HEAD) check is used and localOwn is required: an unverifiable
+// repository fails CLOSED, because being wrong means writing through someone
+// else's link rather than losing a preference.
+//
+// Rejection is a downgrade, never an error. The link is refused, which is
+// exactly what happens with no setting at all, and the recorded reason is what
+// tells the two apart.
+func enforceSymlinkedAgentDirsTrust(ctx context.Context, s *EntireSettings, localSettingsPath string, localData []byte) {
+	// An empty list grants nothing, so there is nothing to gate and nothing to
+	// warn about.
+	if s == nil || len(s.AllowSymlinkedAgentDirs) == 0 {
+		return
+	}
+
+	var reason string
+	switch {
+	case !localSetsSymlinkedAgentDirs(localData):
+		reason = symlinkedAgentDirsRejectionNotLocal
+	case classifyLocalSettingsDeep(ctx, localSettingsPath) != localOwn:
+		reason = symlinkedAgentDirsRejectionUnverified
+	default:
+		return
+	}
+
+	// Recorded rather than logged, for the reason enforceOPFCommandTrust gives:
+	// the loader runs while the log level is still being resolved, and a line in
+	// .entire/logs is not a signal the user sees.
+	s.symlinkedAgentDirsRejection = reason
+	s.AllowSymlinkedAgentDirs = nil
+}
+
+// localSetsSymlinkedAgentDirs reports whether the local override file
+// explicitly sets allow_symlinked_agent_dirs.
+//
+// Presence of the key, not the merged value, for the reason
+// localSetsExternalAgents gives: both files may set it, and comparing effective
+// values after the merge would credit the project layer for the local file's
+// grant. A malformed local file yields false, the safe direction.
+func localSetsSymlinkedAgentDirs(data []byte) bool {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+	return rawHasKey(raw, "allow_symlinked_agent_dirs")
+}
+
+// applyVouchedAgentDirs installs the surviving set as the process-wide policy
+// and records anything the agent package refused by name.
+//
+// The call lives here because of the import direction: `settings` may import
+// `agent`, and `agent` may not import `settings`, so the package that owns the
+// value is the one that has to push it. Every consumer of the policy reaches it
+// through a settings load first, including the eighteen files that call
+// settings.Load directly and never pass the root pre-run.
+//
+// It runs on EVERY load, including one that produced an empty list, so a
+// process whose settings change mid-run cannot keep following a link the user
+// has since removed from the file.
+//
+// The name check inside SetVouchedSymlinkedDirs is a second, different
+// boundary from the trust gate above, and both are needed. The gate answers
+// "may this file grant anything"; the name check answers "is this path one an
+// agent config actually lives in", which is what stops a developer's own local
+// file from vouching for `.entire` or `.git/hooks` -- paths whose refusals are
+// not up for negotiation whoever is asking.
+func applyVouchedAgentDirs(s *EntireSettings) {
+	if s == nil {
+		agent.SetVouchedSymlinkedDirs(nil)
+		return
+	}
+	rejected := agent.SetVouchedSymlinkedDirs(s.AllowSymlinkedAgentDirs)
+	if len(rejected) == 0 {
+		return
+	}
+	unusable := fmt.Sprintf("%s is not an agent config directory (allowed: %s)",
+		strings.Join(quoteAll(rejected), ", "), strings.Join(agent.VouchableSymlinkedDirs(), ", "))
+	if s.symlinkedAgentDirsRejection == "" {
+		s.symlinkedAgentDirsRejection = unusable
+		return
+	}
+	s.symlinkedAgentDirsRejection += "; " + unusable
+}
+
+func quoteAll(in []string) []string {
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = fmt.Sprintf("%q", v)
+	}
+	return out
+}

--- a/cmd/entire/cli/settings/symlinked_agent_dirs_trust_test.go
+++ b/cmd/entire/cli/settings/symlinked_agent_dirs_trust_test.go
@@ -1,0 +1,114 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// loadedSymlinkedAgentDirs runs the real merge path and reports the effective
+// list plus its rejection, if any.
+//
+// Not t.Parallel-safe, unlike the external_agents tests beside it: the load
+// installs the surviving set as agent's process-wide policy, so two of these
+// running at once would overwrite each other's. The cleanup restores the strict
+// default for everything else in the package.
+func loadedSymlinkedAgentDirs(t *testing.T, projectPath, localPath string) ([]string, string, bool) {
+	t.Helper()
+	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs(nil) })
+	s, err := loadMergedSettings(t.Context(), projectPath, "", localPath)
+	require.NoError(t, err)
+	reason, rejected := s.SymlinkedAgentDirsRejection()
+	return s.AllowSymlinkedAgentDirs, reason, rejected
+}
+
+// The whole point of the gate. A repository that could ship a symlink at
+// .claude AND vouch for it in the committed settings file would have `entire
+// enable` write through it on every developer who cloned.
+func TestSymlinkedAgentDirsTrust_ProjectSettingIsIgnored(t *testing.T) {
+	_, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true,"allow_symlinked_agent_dirs":[".claude"]}`)
+
+	dirs, reason, rejected := loadedSymlinkedAgentDirs(t, project, local)
+
+	assert.Empty(t, dirs, "a grant from the committed project file must be dropped")
+	assert.True(t, rejected, "the rejection must be reportable")
+	assert.Contains(t, reason, "settings.local.json", "the reason names where the setting must live")
+	assert.Empty(t, agent.VouchedSymlinkedDirs(), "and nothing may be vouched for in the agent package")
+}
+
+func TestSymlinkedAgentDirsTrust_UntrackedLocalSettingIsHonored(t *testing.T) {
+	_, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true}`)
+	writeSettingsFile(t, local, `{"allow_symlinked_agent_dirs":[".claude"]}`)
+
+	dirs, _, rejected := loadedSymlinkedAgentDirs(t, project, local)
+
+	assert.Equal(t, []string{".claude"}, dirs, "an untracked local override is developer-owned")
+	assert.False(t, rejected)
+	assert.Equal(t, []string{".claude"}, agent.VouchedSymlinkedDirs(),
+		"the load must install the policy, or the setting is inert")
+}
+
+func TestSymlinkedAgentDirsTrust_StagedLocalFileIsIgnored(t *testing.T) {
+	root, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true}`)
+	writeSettingsFile(t, local, `{"allow_symlinked_agent_dirs":[".claude"]}`)
+
+	testutil.RunGit(t, root, "add", "-f", EntireSettingsLocalFile)
+
+	dirs, _, _ := loadedSymlinkedAgentDirs(t, project, local)
+
+	assert.Empty(t, dirs, "a local file tracked in the index must not be trusted")
+	assert.Empty(t, agent.VouchedSymlinkedDirs())
+}
+
+// The second, independent boundary: the trust gate says whether the FILE may
+// grant, and the name check says whether the PATH is one an agent config lives
+// in. A developer's own verified local file still cannot vouch for .entire.
+func TestSymlinkedAgentDirsTrust_LocalFileStillCannotVouchForEntireDir(t *testing.T) {
+	_, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true}`)
+	writeSettingsFile(t, local, `{"allow_symlinked_agent_dirs":[".entire",".git/hooks",".claude"]}`)
+
+	_, reason, rejected := loadedSymlinkedAgentDirs(t, project, local)
+
+	assert.True(t, rejected, "the unusable entries must be reported, not silently dropped")
+	assert.Contains(t, reason, ".entire")
+	assert.Contains(t, reason, ".git/hooks")
+	assert.Equal(t, []string{".claude"}, agent.VouchedSymlinkedDirs(),
+		"the legitimate entry survives; only the unspellable ones are refused")
+}
+
+// An empty or absent list grants nothing, so it must not produce a warning
+// about a privilege nobody asked for.
+func TestSymlinkedAgentDirsTrust_AbsentSettingIsSilent(t *testing.T) {
+	_, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true}`)
+
+	dirs, reason, rejected := loadedSymlinkedAgentDirs(t, project, local)
+
+	assert.Empty(t, dirs)
+	assert.False(t, rejected, "no setting is not a rejected setting")
+	assert.Empty(t, reason)
+}
+
+// Every load reinstalls the policy, including one that produced nothing, so a
+// process whose settings stop granting cannot keep following the old link.
+func TestSymlinkedAgentDirsTrust_LoadClearsAPreviousGrant(t *testing.T) {
+	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs(nil) })
+	agent.SetVouchedSymlinkedDirs([]string{".claude"})
+	require.NotEmpty(t, agent.VouchedSymlinkedDirs())
+
+	_, project, local := newOPFRepo(t)
+	writeSettingsFile(t, project, `{"enabled":true}`)
+	_, err := loadMergedSettings(t.Context(), project, "", local)
+	require.NoError(t, err)
+
+	assert.Empty(t, agent.VouchedSymlinkedDirs(),
+		"a load with no grant must clear one installed earlier in the process")
+}

--- a/cmd/entire/cli/settings/symlinked_agent_dirs_trust_test.go
+++ b/cmd/entire/cli/settings/symlinked_agent_dirs_trust_test.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,7 +20,7 @@ import (
 // default for everything else in the package.
 func loadedSymlinkedAgentDirs(t *testing.T, projectPath, localPath string) ([]string, string, bool) {
 	t.Helper()
-	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs(nil) })
+	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs("", nil) })
 	s, err := loadMergedSettings(t.Context(), projectPath, "", localPath)
 	require.NoError(t, err)
 	reason, rejected := s.SymlinkedAgentDirsRejection()
@@ -38,7 +39,7 @@ func TestSymlinkedAgentDirsTrust_ProjectSettingIsIgnored(t *testing.T) {
 	assert.Empty(t, dirs, "a grant from the committed project file must be dropped")
 	assert.True(t, rejected, "the rejection must be reportable")
 	assert.Contains(t, reason, "settings.local.json", "the reason names where the setting must live")
-	assert.Empty(t, agent.VouchedSymlinkedDirs(), "and nothing may be vouched for in the agent package")
+	assert.Empty(t, agent.VouchedSymlinkedDirs(filepath.Dir(filepath.Dir(project))), "and nothing may be vouched for in the agent package")
 }
 
 func TestSymlinkedAgentDirsTrust_UntrackedLocalSettingIsHonored(t *testing.T) {
@@ -50,7 +51,7 @@ func TestSymlinkedAgentDirsTrust_UntrackedLocalSettingIsHonored(t *testing.T) {
 
 	assert.Equal(t, []string{".claude"}, dirs, "an untracked local override is developer-owned")
 	assert.False(t, rejected)
-	assert.Equal(t, []string{".claude"}, agent.VouchedSymlinkedDirs(),
+	assert.Equal(t, []string{".claude"}, agent.VouchedSymlinkedDirs(filepath.Dir(filepath.Dir(project))),
 		"the load must install the policy, or the setting is inert")
 }
 
@@ -64,7 +65,7 @@ func TestSymlinkedAgentDirsTrust_StagedLocalFileIsIgnored(t *testing.T) {
 	dirs, _, _ := loadedSymlinkedAgentDirs(t, project, local)
 
 	assert.Empty(t, dirs, "a local file tracked in the index must not be trusted")
-	assert.Empty(t, agent.VouchedSymlinkedDirs())
+	assert.Empty(t, agent.VouchedSymlinkedDirs(filepath.Dir(filepath.Dir(project))))
 }
 
 // The second, independent boundary: the trust gate says whether the FILE may
@@ -80,7 +81,7 @@ func TestSymlinkedAgentDirsTrust_LocalFileStillCannotVouchForEntireDir(t *testin
 	assert.True(t, rejected, "the unusable entries must be reported, not silently dropped")
 	assert.Contains(t, reason, ".entire")
 	assert.Contains(t, reason, ".git/hooks")
-	assert.Equal(t, []string{".claude"}, agent.VouchedSymlinkedDirs(),
+	assert.Equal(t, []string{".claude"}, agent.VouchedSymlinkedDirs(filepath.Dir(filepath.Dir(project))),
 		"the legitimate entry survives; only the unspellable ones are refused")
 }
 
@@ -100,15 +101,38 @@ func TestSymlinkedAgentDirsTrust_AbsentSettingIsSilent(t *testing.T) {
 // Every load reinstalls the policy, including one that produced nothing, so a
 // process whose settings stop granting cannot keep following the old link.
 func TestSymlinkedAgentDirsTrust_LoadClearsAPreviousGrant(t *testing.T) {
-	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs(nil) })
-	agent.SetVouchedSymlinkedDirs([]string{".claude"})
-	require.NotEmpty(t, agent.VouchedSymlinkedDirs())
+	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs("", nil) })
 
 	_, project, local := newOPFRepo(t)
+	root := filepath.Dir(filepath.Dir(project))
+
+	agent.SetVouchedSymlinkedDirs(root, []string{".claude"})
+	require.NotEmpty(t, agent.VouchedSymlinkedDirs(root))
+
 	writeSettingsFile(t, project, `{"enabled":true}`)
 	_, err := loadMergedSettings(t.Context(), project, "", local)
 	require.NoError(t, err)
 
-	assert.Empty(t, agent.VouchedSymlinkedDirs(),
+	assert.Empty(t, agent.VouchedSymlinkedDirs(root),
 		"a load with no grant must clear one installed earlier in the process")
+}
+
+// A policy loaded for one worktree must not decide anything in another. The
+// enforcement path takes a worktreeRoot precisely so last-load-wins cannot
+// follow a link the other tree vouched for, and refusing is the safe direction.
+func TestSymlinkedAgentDirsTrust_PolicyIsScopedToItsWorktree(t *testing.T) {
+	t.Cleanup(func() { agent.SetVouchedSymlinkedDirs("", nil) })
+
+	_, project, local := newOPFRepo(t)
+	root := filepath.Dir(filepath.Dir(project))
+	writeSettingsFile(t, project, `{"enabled":true}`)
+	writeSettingsFile(t, local, `{"allow_symlinked_agent_dirs":[".claude"]}`)
+
+	_, err := loadMergedSettings(t.Context(), project, "", local)
+	require.NoError(t, err)
+	require.Equal(t, []string{".claude"}, agent.VouchedSymlinkedDirs(root),
+		"sanity: the policy is installed for the tree it was loaded for")
+
+	assert.Empty(t, agent.VouchedSymlinkedDirs(t.TempDir()),
+		"another worktree must not inherit this one's grant")
 }

--- a/cmd/entire/cli/setup_agent_help_skill.go
+++ b/cmd/entire/cli/setup_agent_help_skill.go
@@ -55,11 +55,11 @@ func scaffoldAgentHelpSkill(ctx context.Context, ag agent.Agent) (managedScaffol
 		return managedScaffoldResult{}, fmt.Errorf("resolve worktree root: %w", err)
 	}
 
-	root, err := openScaffoldRoot(repoRoot)
+	target, err := openScaffoldTarget(repoRoot, relPath)
 	if err != nil {
 		return managedScaffoldResult{}, err
 	}
-	return writeManagedScaffold(root, relPath, content, isManagedAgentHelpSkill)
+	return writeManagedScaffold(target, content, isManagedAgentHelpSkill)
 }
 
 func isManagedAgentHelpSkill(data []byte) bool {

--- a/cmd/entire/cli/setup_managed_scaffold.go
+++ b/cmd/entire/cli/setup_managed_scaffold.go
@@ -14,7 +14,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
-	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
 )
 
 // managedScaffoldStatus is the outcome of writing an Entire-managed scaffold file
@@ -64,8 +63,8 @@ type managedScaffoldResult struct {
 // the atomic writer pins the real parent for the whole replacement. An
 // unmanaged file at the far end of a link therefore cannot be mistaken for one
 // of ours and rewritten.
-func writeManagedScaffold(root *os.Root, relPath string, content []byte, isManaged func([]byte) bool) (managedScaffoldResult, error) {
-	name := filepath.ToSlash(relPath)
+func writeManagedScaffold(t scaffoldTarget, content []byte, isManaged func([]byte) bool) (managedScaffoldResult, error) {
+	root, name, relPath := t.root, t.name, t.relPath
 	existingData, err := osroot.ReadFileNoFollow(root, name)
 	if err == nil {
 		if !isManaged(existingData) {
@@ -96,18 +95,39 @@ func writeManagedScaffold(root *os.Root, relPath string, content []byte, isManag
 	return managedScaffoldResult{Status: managedScaffoldCreated, RelPath: relPath}, nil
 }
 
-// openScaffoldRoot returns the shared worktree anchor for confined scaffold IO.
+// scaffoldTarget is where one managed scaffold is written: the root to write
+// inside, the name inside that root, and the worktree-relative path to report.
+//
+// name and relPath differ only when the scaffold sits under a symlinked agent
+// directory the user vouched for, in which case the root is anchored at the
+// link's target and name has lost the components consumed getting there.
+// Messages keep naming relPath, which is the path the user recognises.
+type scaffoldTarget struct {
+	root    *os.Root
+	name    string
+	relPath string
+}
+
+// openScaffoldTarget resolves where a scaffold at relPath should be written.
 //
 // It goes through worktreedir rather than opening its own root because the
 // worktree already has exactly one anchor and repoRoot is what a resolver
 // answered. The returned root is owned by the registry and shared with every
 // other reader and writer of this tree, so callers must not close it.
-func openScaffoldRoot(repoRoot string) (*os.Root, error) {
-	root, err := worktreedir.OpenAt(repoRoot)
+//
+// The vouched-directory step is not optional here even though scaffolds are not
+// hook configs: they are written under the SAME agent directories
+// (.claude/skills, .claude/agents, .codex/agents, .gemini/agents), by the same
+// `entire enable`. A vouched `.claude` that hook installation follows and
+// scaffolding refuses would leave enable half-applied, with the hook config at
+// the link's target and the skill nowhere, reporting success for both.
+func openScaffoldTarget(repoRoot, relPath string) (scaffoldTarget, error) {
+	name := filepath.ToSlash(relPath)
+	root, inner, err := agent.OpenAnchoredRoot(repoRoot, name)
 	if err != nil {
-		return nil, fmt.Errorf("open repository root for scaffolding: %w", err)
+		return scaffoldTarget{}, fmt.Errorf("open repository root for scaffolding: %w", err)
 	}
-	return root, nil
+	return scaffoldTarget{root: root, name: inner, relPath: name}, nil
 }
 
 // setupOptionalSkillForNames installs an optional skill (search, agent-help, ...)

--- a/cmd/entire/cli/setup_managed_scaffold_symlink_test.go
+++ b/cmd/entire/cli/setup_managed_scaffold_symlink_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -116,15 +117,50 @@ func TestWriteManagedScaffold_RefusesSymlinkedLeaf(t *testing.T) {
 func TestVouchableDirsMatchTheBuiltInAgents(t *testing.T) {
 	t.Parallel()
 
+	// deliberatelyUnvouchable is the ledger of directories the derivation
+	// produces that must NOT be vouchable, each with its reason. A ledger rather
+	// than a filter reimplementing agent.neverVouchable, so the exclusion has to
+	// be argued for here and cannot quietly grow.
+	deliberatelyUnvouchable := map[string]string{
+		".pi/extensions/entire": "Entire both creates and deletes this directory (HookConfigFile.RemoveDir), " +
+			"so it cannot also be a link the user manages; vouching for it anchored the root ON it and " +
+			"left uninstall with nothing above it to delete from",
+	}
+
 	want := map[string]struct{}{}
 	for _, relPath := range agent.AllHookConfigRelPaths() {
 		dir := path.Dir(filepath.ToSlash(relPath))
 		for dir != "." && dir != "/" && dir != "" {
-			want[dir] = struct{}{}
+			if _, excluded := deliberatelyUnvouchable[dir]; !excluded {
+				want[dir] = struct{}{}
+			}
 			dir = path.Dir(dir)
 		}
 	}
 	require.NotEmpty(t, want, "no built-in agent declares a hook config path; this guard proves nothing")
+
+	// A stale exclusion is its own failure: if the path stops existing, the
+	// entry has outlived its reason.
+	derived := map[string]struct{}{}
+	for _, relPath := range agent.AllHookConfigRelPaths() {
+		dir := path.Dir(filepath.ToSlash(relPath))
+		for dir != "." && dir != "/" && dir != "" {
+			derived[dir] = struct{}{}
+			dir = path.Dir(dir)
+		}
+	}
+	for d, reason := range deliberatelyUnvouchable {
+		if _, still := derived[d]; !still {
+			assert.Failf(t, "stale exclusion",
+				"%s is listed as deliberately unvouchable (%s) but no agent config lives under it "+
+					"any more; remove the entry", d, reason)
+		}
+		if slices.Contains(agent.VouchableSymlinkedDirs(), d) {
+			assert.Failf(t, "exclusion not enforced",
+				"%s is listed as deliberately unvouchable (%s) but agent.VouchableSymlinkedDirs "+
+					"still offers it", d, reason)
+		}
+	}
 
 	got := map[string]struct{}{}
 	for _, d := range agent.VouchableSymlinkedDirs() {

--- a/cmd/entire/cli/setup_managed_scaffold_symlink_test.go
+++ b/cmd/entire/cli/setup_managed_scaffold_symlink_test.go
@@ -2,10 +2,14 @@ package cli
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,11 +40,11 @@ func TestWriteManagedScaffold_RefusesASymlinkedAgentDirectory(t *testing.T) {
 				t.Skipf("symlink not supported: %v", err)
 			}
 
-			root, rootErr := openScaffoldRoot(worktree)
+			rel := filepath.Join(".claude", "skills", "entire", "SKILL.md")
+			st, rootErr := openScaffoldTarget(worktree, rel)
 			require.NoError(t, rootErr)
 
-			rel := filepath.Join(".claude", "skills", "entire", "SKILL.md")
-			_, err := writeManagedScaffold(root, rel, []byte("managed\n"), func([]byte) bool { return true })
+			_, err := writeManagedScaffold(st, []byte("managed\n"), func([]byte) bool { return true })
 			require.ErrorIs(t, err, osroot.ErrSymlinkedPath)
 
 			entries, readErr := os.ReadDir(dest)
@@ -58,12 +62,11 @@ func TestWriteManagedScaffold_CreatesThroughARealDirectory(t *testing.T) {
 	t.Parallel()
 
 	worktree := t.TempDir()
-	root, err := openScaffoldRoot(worktree)
+	rel := filepath.Join(".claude", "skills", "entire", "SKILL.md")
+	st, err := openScaffoldTarget(worktree, rel)
 	require.NoError(t, err)
 
-	rel := filepath.Join(".claude", "skills", "entire", "SKILL.md")
-
-	res, err := writeManagedScaffold(root, rel, []byte("managed\n"), func([]byte) bool { return true })
+	res, err := writeManagedScaffold(st, []byte("managed\n"), func([]byte) bool { return true })
 	require.NoError(t, err)
 	require.Equal(t, managedScaffoldCreated, res.Status)
 
@@ -71,11 +74,11 @@ func TestWriteManagedScaffold_CreatesThroughARealDirectory(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "managed\n", string(got))
 
-	res, err = writeManagedScaffold(root, rel, []byte("managed\n"), func([]byte) bool { return true })
+	res, err = writeManagedScaffold(st, []byte("managed\n"), func([]byte) bool { return true })
 	require.NoError(t, err)
 	require.Equal(t, managedScaffoldUnchanged, res.Status)
 
-	res, err = writeManagedScaffold(root, rel, []byte("changed\n"), func([]byte) bool { return false })
+	res, err = writeManagedScaffold(st, []byte("changed\n"), func([]byte) bool { return false })
 	require.NoError(t, err)
 	require.Equal(t, managedScaffoldSkippedConflict, res.Status)
 }
@@ -86,18 +89,59 @@ func TestWriteManagedScaffold_RefusesSymlinkedLeaf(t *testing.T) {
 	worktree := t.TempDir()
 	rel := filepath.Join(".claude", "skills", "entire", "SKILL.md")
 	require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(worktree, rel)), 0o750))
-	target := filepath.Join(worktree, "victim.md")
-	require.NoError(t, os.WriteFile(target, []byte("managed old\n"), 0o600))
+	victim := filepath.Join(worktree, "victim.md")
+	require.NoError(t, os.WriteFile(victim, []byte("managed old\n"), 0o600))
 	if err := os.Symlink(filepath.Join("..", "..", "..", "victim.md"), filepath.Join(worktree, rel)); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
 
-	root, rootErr := openScaffoldRoot(worktree)
+	st, rootErr := openScaffoldTarget(worktree, rel)
 	require.NoError(t, rootErr)
 
-	_, err := writeManagedScaffold(root, rel, []byte("managed new\n"), func([]byte) bool { return true })
+	_, err := writeManagedScaffold(st, []byte("managed new\n"), func([]byte) bool { return true })
 	require.ErrorIs(t, err, osroot.ErrSymlinkedPath)
-	got, err := os.ReadFile(target)
+	got, err := os.ReadFile(victim)
 	require.NoError(t, err)
 	require.Equal(t, "managed old\n", string(got))
+}
+
+// TestVouchableDirsMatchTheBuiltInAgents pins agent.vouchableDirs against the
+// registry, in the one package where every built-in agent is registered.
+//
+// The list is pinned rather than derived because the registry is mutable at
+// runtime and empty in most test binaries (see its doc comment), which costs
+// the automatic coverage deriving would have given. This is that coverage put
+// back: a new agent whose config directory is missing from the list fails here,
+// and so does an entry left behind by an agent that was removed.
+func TestVouchableDirsMatchTheBuiltInAgents(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]struct{}{}
+	for _, relPath := range agent.AllHookConfigRelPaths() {
+		dir := path.Dir(filepath.ToSlash(relPath))
+		for dir != "." && dir != "/" && dir != "" {
+			want[dir] = struct{}{}
+			dir = path.Dir(dir)
+		}
+	}
+	require.NotEmpty(t, want, "no built-in agent declares a hook config path; this guard proves nothing")
+
+	got := map[string]struct{}{}
+	for _, d := range agent.VouchableSymlinkedDirs() {
+		got[d] = struct{}{}
+	}
+
+	for d := range want {
+		if _, ok := got[d]; !ok {
+			assert.Failf(t, "missing vouchable directory",
+				"%s is a built-in agent's config directory but is not in agent.vouchableDirs; "+
+					"a user with it symlinked has no way to say so", d)
+		}
+	}
+	for d := range got {
+		if _, ok := want[d]; !ok {
+			assert.Failf(t, "stale vouchable directory",
+				"%s is in agent.vouchableDirs but no built-in agent's config lives under it; remove it", d)
+		}
+	}
 }

--- a/cmd/entire/cli/setup_search_skill.go
+++ b/cmd/entire/cli/setup_search_skill.go
@@ -55,11 +55,11 @@ func scaffoldSearchSkill(ctx context.Context, ag agent.Agent) (managedScaffoldRe
 		return managedScaffoldResult{}, fmt.Errorf("resolve worktree root: %w", err)
 	}
 
-	root, err := openScaffoldRoot(repoRoot)
+	target, err := openScaffoldTarget(repoRoot, relPath)
 	if err != nil {
 		return managedScaffoldResult{}, err
 	}
-	result, err := writeManagedScaffold(root, relPath, content, isManagedSearchSkill)
+	result, err := writeManagedScaffold(target, content, isManagedSearchSkill)
 	if err != nil {
 		return result, err
 	}
@@ -68,7 +68,7 @@ func scaffoldSearchSkill(ctx context.Context, ag agent.Agent) (managedScaffoldRe
 	// leaving that behind would have the agent offer both. It is best-effort:
 	// the skill is already installed at this point, so a failed deletion is a
 	// warning on the result, never a failure of the install.
-	removed, cleanupErr := removeLegacySearchSubagent(root, ag.Name())
+	removed, cleanupErr := removeLegacySearchSubagent(repoRoot, ag.Name())
 	if cleanupErr != nil {
 		result.LegacyCleanupWarning = fmt.Sprintf(
 			"failed to remove superseded search subagent %s (%v) — remove it manually",
@@ -113,12 +113,20 @@ func legacySearchSubagentPath(agentName types.AgentName) string {
 // symlink or directory at this path is not ours to delete. The marker check
 // decides which file is eligible. The confinement decides where the deletion
 // may happen at all.
-func removeLegacySearchSubagent(root *os.Root, agentName types.AgentName) (string, error) {
+func removeLegacySearchSubagent(repoRoot string, agentName types.AgentName) (string, error) {
 	relPath := legacySearchSubagentPath(agentName)
 	if relPath == "" {
 		return "", nil
 	}
-	name := filepath.ToSlash(relPath)
+	// The legacy subagent lives under the same agent directory as the skill that
+	// supersedes it (.claude/agents next to .claude/skills), so it has to be
+	// reached through the same anchor. Resolved separately rather than derived
+	// from the skill's target, because the two paths are independent inputs.
+	target, err := openScaffoldTarget(repoRoot, relPath)
+	if err != nil {
+		return "", err
+	}
+	root, name := target.root, target.name
 	info, err := osroot.LstatNoSymlinks(root, name)
 	if errors.Is(err, os.ErrNotExist) {
 		return "", nil

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -147,6 +147,20 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 			reason, settings.EntireSettingsLocalFile)
 	}
 
+	// Same reasoning for allow_symlinked_agent_dirs: a refused grant and a
+	// setting nobody wrote both end in Entire refusing the link, so without
+	// this the two are indistinguishable from the outside.
+	if reason, rejected := effectiveSettings.SymlinkedAgentDirsRejection(); rejected {
+		fmt.Fprintf(w, "  allow_symlinked_agent_dirs is ignored: %s\n  move it to %s, and keep that file out of version control\n",
+			reason, settings.EntireSettingsLocalFile)
+	}
+
+	// And say what IS being followed. A link Entire writes through is worth
+	// stating plainly every time, not only when something is wrong with it.
+	if vouched := agent.VouchedSymlinkedDirs(); len(vouched) > 0 {
+		fmt.Fprintf(w, "  Following symlinked agent directories: %s\n", strings.Join(vouched, ", "))
+	}
+
 	// Show local settings if it exists. LoadFromFile is ungated, so this
 	// renders the file's own contents — say so when the loader ignored them,
 	// or the display contradicts the settings actually in effect.

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -157,8 +157,15 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 
 	// And say what IS being followed. A link Entire writes through is worth
 	// stating plainly every time, not only when something is wrong with it.
-	if vouched := agent.VouchedSymlinkedDirs(); len(vouched) > 0 {
-		fmt.Fprintf(w, "  Following symlinked agent directories: %s\n", strings.Join(vouched, ", "))
+	//
+	// FollowedSymlinkedDirs, not VouchedSymlinkedDirs: the latter is the
+	// configuration, and a vouched path that is an ordinary directory, absent,
+	// or a dangling link is not something Entire is following. Scoped to this
+	// worktree too, so the report can never name links followed somewhere else.
+	if repoRoot, rootErr := paths.WorktreeRoot(ctx); rootErr == nil {
+		if followed := agent.FollowedSymlinkedDirs(repoRoot); len(followed) > 0 {
+			fmt.Fprintf(w, "  Following symlinked agent directories: %s\n", strings.Join(followed, ", "))
+		}
 	}
 
 	// Show local settings if it exists. LoadFromFile is ungated, so this

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -28,6 +28,9 @@ const entireHookMarker = "Entire CLI hooks"
 const GitHookBackupSuffix = ".pre-entire"
 
 const backupSuffix = GitHookBackupSuffix
+
+// goosWindows is runtime.GOOS on Windows.
+const goosWindows = "windows"
 const chainComment = "# Chain: run pre-existing hook"
 const missingEntireGitHookWarning = "[entire] Entire CLI is enabled but not installed or not on PATH. Skipping Entire Git hook; continuing. Installation guide: https://docs.entire.io/cli/installation#installation-methods"
 
@@ -243,6 +246,56 @@ func HooksDirLinkTarget(hooksDir string) (string, bool) {
 	return resolved, true
 }
 
+// HooksPathCommand renders the `git config core.hooksPath <dir>` remedy with dir
+// quoted so the line survives being pasted into a shell.
+//
+// Exported because doctor prints the same remedy, and printing it twice means
+// getting the quoting right twice. A hooks directory containing a space is
+// ordinary -- a macOS "Application Support" path, a Windows "C:\Users\First
+// Last\..." -- and unquoted it produces `git config core.hooksPath /tmp/my
+// hooks dir`, which git rejects with "error: no action specified" because it
+// sees four arguments. The remedy is presented as a command to paste, so it has
+// to be one.
+//
+// Quoted only when it needs to be, so the common clean path stays readable.
+func HooksPathCommand(dir string) string {
+	return "git config core.hooksPath " + shellQuoteForDisplay(dir)
+}
+
+// shellQuoteForDisplay quotes a path for a command line the USER will paste. It
+// is not for building an argv -- nothing here is executed, and a path that
+// reaches an exec goes as a separate argument instead (see CLAUDE.md's
+// "Never Put a Dynamic Value on a cmd.exe Line").
+//
+// The POSIX branch delegates to shellQuote, this file's existing quoter for the
+// #!/bin/sh hooks it generates, rather than repeating the escaping: single
+// quoting is total, since the only character with meaning inside a single-quoted
+// string is the closing quote. Windows shells have no equivalent, so double
+// quotes are used there, which is what cmd.exe and PowerShell both accept for a
+// path.
+//
+// Quoted only when it has to be, so the ordinary path stays readable.
+func shellQuoteForDisplay(s string) string {
+	if s != "" && !strings.ContainsFunc(s, needsShellQuote) {
+		return s
+	}
+	if runtime.GOOS == goosWindows {
+		return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+	}
+	return shellQuote(s)
+}
+
+// needsShellQuote reports a rune that is not safe bare in a shell word. An
+// allowlist, so a character nobody has considered is quoted rather than passed
+// through.
+func needsShellQuote(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return false
+	}
+	return !strings.ContainsRune(`_@%+=:,./-\`, r)
+}
+
 // symlinkedHooksDirError explains a refusal from hooksRootForInstall in terms of
 // the one setting that can produce it.
 //
@@ -266,8 +319,8 @@ func symlinkedHooksDirError(hooksDir string, err error) error {
 	return fmt.Errorf("git resolves the hooks directory to %s, which is a symlink to %s\n"+
 		refusal+
 		"Point git at the target directly instead:\n"+
-		"  git config core.hooksPath %s\n"+
-		"or replace the link with a real directory: %w", abs, target, target, err)
+		"  %s\n"+
+		"or replace the link with a real directory: %w", abs, target, HooksPathCommand(target), err)
 }
 
 // hookClassification is what is sitting at a managed hook's path.

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -20,12 +20,13 @@ import (
 // Hook marker used to identify Entire CLI hooks
 const entireHookMarker = "Entire CLI hooks"
 
-const backupSuffix = ".pre-entire"
+// GitHookBackupSuffix is what InstallGitHook moves a pre-existing hook to
+// before writing its own. Exported so diagnostics elsewhere can name the file
+// the user will find rather than spelling it a second time; backupSuffix is the
+// in-package shorthand for it.
+const GitHookBackupSuffix = ".pre-entire"
 
-// GitHookBackupSuffix is the suffix InstallGitHook moves a pre-existing hook to
-// before writing its own, exported so diagnostics can name the file the user
-// will find rather than spelling it a second time.
-const GitHookBackupSuffix = backupSuffix
+const backupSuffix = GitHookBackupSuffix
 const chainComment = "# Chain: run pre-existing hook"
 const missingEntireGitHookWarning = "[entire] Entire CLI is enabled but not installed or not on PATH. Skipping Entire Git hook; continuing. Installation guide: https://docs.entire.io/cli/installation#installation-methods"
 

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
@@ -19,6 +21,11 @@ import (
 const entireHookMarker = "Entire CLI hooks"
 
 const backupSuffix = ".pre-entire"
+
+// GitHookBackupSuffix is the suffix InstallGitHook moves a pre-existing hook to
+// before writing its own, exported so diagnostics can name the file the user
+// will find rather than spelling it a second time.
+const GitHookBackupSuffix = backupSuffix
 const chainComment = "# Chain: run pre-existing hook"
 const missingEntireGitHookWarning = "[entire] Entire CLI is enabled but not installed or not on PATH. Skipping Entire Git hook; continuing. Installation guide: https://docs.entire.io/cli/installation#installation-methods"
 
@@ -133,6 +140,62 @@ func getHooksDirInPath(ctx context.Context, dir string) (string, error) {
 	return filepath.Clean(hooksDir), nil
 }
 
+// hooksRoot anchors a root at the active hooks directory and refuses a symlink
+// at the directory itself.
+//
+// The base is git's own answer to `git rev-parse --git-path hooks`, which is
+// what makes it a trusted one: core.hooksPath may name any directory, inside
+// the worktree or well outside it, and a linked worktree's hooks live in the
+// common dir. No existing anchor can reach it for that reason, which is also
+// why doctor needs its own check here rather than an agentSymlinkCheckPaths
+// entry.
+//
+// Refusing a link AT the directory is what makes every hook name beneath it a
+// name inside the root, which is the property the reads and the write below
+// rely on. Entire never creates a symlinked hooks directory, so one is either
+// the user's own arrangement -- in which case pointing core.hooksPath at the
+// target says the same thing without the indirection -- or something that
+// redirects every hook Entire installs somewhere it cannot see.
+//
+// A missing directory is returned unwrapped so callers can classify it with
+// os.IsNotExist.
+func hooksRoot(hooksDir string) (*os.Root, error) {
+	abs, err := filepath.Abs(hooksDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve hooks directory %s: %w", hooksDir, err)
+	}
+	info, err := os.Lstat(abs)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // preserve os.IsNotExist classification
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%s: %w", abs, osroot.ErrSymlinkedPath)
+	}
+	return osroot.Shared(abs) //nolint:wrapcheck // preserve os.IsNotExist classification, as the doc comment promises
+}
+
+// symlinkedHooksDirError explains a refusal from hooksRoot in terms of the one
+// setting that can produce it.
+func symlinkedHooksDirError(hooksDir string, err error) error {
+	target, readErr := os.Readlink(hooksDir)
+	if readErr != nil {
+		target = "its target"
+	}
+	return fmt.Errorf("git resolves the hooks directory to %s, which is a symlink to %s\n"+
+		"Entire will not install hooks through a link, because everything it writes there would land somewhere it cannot verify.\n"+
+		"Point git at the target directly instead:\n"+
+		"  git config core.hooksPath %s\n"+
+		"or replace the link with a real directory: %w", hooksDir, target, target, err)
+}
+
+// hookFileExists reports whether name exists directly inside root. It lstats, so
+// a symlink counts as present: a link at a hook path is still something that
+// must not be silently overwritten.
+func hookFileExists(root *os.Root, name string) bool {
+	_, err := root.Lstat(name)
+	return err == nil
+}
+
 // GitHookState describes .git/hooks relative to what InstallGitHook writes today.
 //
 // Deliberately the same vocabulary as agent.HookConfigState: there are two hook
@@ -232,10 +295,16 @@ const bareEntireHookCmd = "entire"
 // Current, which is what makes EnsureSetup reinstall it rather than leaving a
 // broken hook in place forever.
 func gitHookStateInHooksDir(hooksDir string) GitHookState {
+	root, err := hooksRoot(hooksDir)
+	if err != nil {
+		return GitHooksAbsent
+	}
 	outdated := false
 	for _, hook := range gitHookNames {
-		hookPath := filepath.Join(hooksDir, hook)
-		data, err := os.ReadFile(hookPath) //nolint:gosec // Path is constructed from constants
+		// NoFollow: a hook that is a symlink is not one Entire wrote, whatever
+		// is at the far end. Reporting Absent is what sends EnsureSetup to
+		// InstallGitHook, which backs the link up and chains to it.
+		data, err := osroot.ReadFileNoFollow(root, hook)
 		if err != nil {
 			return GitHooksAbsent
 		}
@@ -422,8 +491,18 @@ func InstallGitHook(ctx context.Context, silent, absolutePath bool) (int, error)
 			"then unset it (git config --global --unset core.hooksPath) or override for this repo (git config core.hooksPath .git/hooks) and re-run 'entire enable'", hooksDir)
 	}
 
+	// Creating a directory is an operation on it from the outside, so this stays
+	// a plain os call; the root below is opened on the result.
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil { //nolint:gosec // Git hooks require executable permissions
 		return 0, fmt.Errorf("failed to create hooks directory: %w", err)
+	}
+
+	root, err := hooksRoot(hooksDir)
+	if err != nil {
+		if errors.Is(err, osroot.ErrSymlinkedPath) {
+			return 0, symlinkedHooksDirError(hooksDir, err)
+		}
+		return 0, fmt.Errorf("failed to open hooks directory %s: %w", hooksDir, err)
 	}
 
 	cmdPrefix, err := hookCmdPrefix(absolutePath)
@@ -434,15 +513,20 @@ func InstallGitHook(ctx context.Context, silent, absolutePath bool) (int, error)
 	installedCount := 0
 
 	for _, spec := range specs {
-		hookPath := filepath.Join(hooksDir, spec.name)
-		backupPath := hookPath + backupSuffix
-		backupExists := fileExists(backupPath)
+		backupName := spec.name + backupSuffix
+		backupExists := hookFileExists(root, backupName)
 
-		// Back up existing non-Entire hooks
-		existing, existingErr := os.ReadFile(hookPath) //nolint:gosec // path is controlled
-		if existingErr == nil && !strings.Contains(string(existing), entireHookMarker) {
+		// Back up existing non-Entire hooks. A symlinked hook is one of those:
+		// Entire never installs a link, so it belongs to the user or another
+		// tool. Refusing to read through it must not mean quietly replacing it,
+		// and the rename below preserves the link itself as the backup, which
+		// the generated chain call then invokes exactly as it would a script.
+		existing, existingErr := osroot.ReadFileNoFollow(root, spec.name)
+		foreign := errors.Is(existingErr, osroot.ErrSymlinkedPath) ||
+			(existingErr == nil && !strings.Contains(string(existing), entireHookMarker))
+		if foreign {
 			if !backupExists {
-				if err := os.Rename(hookPath, backupPath); err != nil {
+				if err := root.Rename(spec.name, backupName); err != nil {
 					return installedCount, fmt.Errorf("failed to back up %s: %w", spec.name, err)
 				}
 				fmt.Fprintf(os.Stderr, "[entire] Backed up existing %s to %s%s\n", spec.name, spec.name, backupSuffix)
@@ -458,7 +542,7 @@ func InstallGitHook(ctx context.Context, silent, absolutePath bool) (int, error)
 			content = generateChainedContent(spec.content, spec.name)
 		}
 
-		written, err := writeHookFile(hookPath, content)
+		written, err := writeHookFile(root, spec.name, content)
 		if err != nil {
 			return installedCount, fmt.Errorf("failed to install %s hook: %w", spec.name, err)
 		}
@@ -477,16 +561,23 @@ func InstallGitHook(ctx context.Context, silent, absolutePath bool) (int, error)
 
 // writeHookFile writes a hook file if it doesn't exist or has different content.
 // Returns true if the file was written, false if it already had the same content.
-func writeHookFile(path, content string) (bool, error) {
+//
+// The write is a temp-file-and-rename rather than an in-place truncate, because
+// a rename REPLACES a symlink sitting at the hook path instead of writing
+// through it to whatever it names. (osroot.OpenFileNoFollow is the wrong tool
+// here: it rejects O_TRUNC by design, precisely so that truncating writes go
+// through an atomic rename like this one.) The 0o755 is applied to the temp file
+// before the rename, so the hook lands executable regardless of umask.
+func writeHookFile(root *os.Root, name, content string) (bool, error) {
 	// Check if file already exists with same content
-	existing, err := os.ReadFile(path) //nolint:gosec // path is controlled
+	existing, err := osroot.ReadFileNoFollow(root, name)
 	if err == nil && string(existing) == content {
 		return false, nil // Already up to date
 	}
 
 	// Git hooks must be executable (0o755)
-	if err := os.WriteFile(path, []byte(content), 0o755); err != nil { //nolint:gosec // Git hooks require executable permissions
-		return false, fmt.Errorf("failed to write hook file %s: %w", path, err)
+	if err := jsonutil.WriteFileAtomicIn(root, name, []byte(content), 0o755); err != nil {
+		return false, fmt.Errorf("failed to write hook file %s: %w", name, err)
 	}
 	return true, nil
 }
@@ -500,20 +591,32 @@ func RemoveGitHook(ctx context.Context) (int, error) {
 		return 0, err
 	}
 
+	root, err := hooksRoot(hooksDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil // no hooks directory, so nothing of ours in it
+		}
+		if errors.Is(err, osroot.ErrSymlinkedPath) {
+			return 0, symlinkedHooksDirError(hooksDir, err)
+		}
+		return 0, fmt.Errorf("failed to open hooks directory %s: %w", hooksDir, err)
+	}
+
 	removed := 0
 	var removeErrors []string
 
 	for _, hook := range gitHookNames {
-		hookPath := filepath.Join(hooksDir, hook)
-		backupPath := hookPath + backupSuffix
+		backupName := hook + backupSuffix
 
-		// Remove the hook if it contains our marker
-		data, err := os.ReadFile(hookPath) //nolint:gosec // path is controlled
-		hookIsOurs := err == nil && strings.Contains(string(data), entireHookMarker)
-		hookExists := err == nil
+		// Remove the hook if it contains our marker. A symlink at the path is
+		// present but never ours, so it is left alone and, like any other
+		// foreign hook, blocks the backup from being restored over it.
+		data, readErr := osroot.ReadFileNoFollow(root, hook)
+		hookIsOurs := readErr == nil && strings.Contains(string(data), entireHookMarker)
+		hookExists := readErr == nil || errors.Is(readErr, osroot.ErrSymlinkedPath)
 
 		if hookIsOurs {
-			if err := os.Remove(hookPath); err != nil {
+			if err := osroot.RemoveNoSymlinks(root, hook); err != nil {
 				removeErrors = append(removeErrors, fmt.Sprintf("%s: %v", hook, err))
 				continue
 			}
@@ -521,12 +624,12 @@ func RemoveGitHook(ctx context.Context) (int, error) {
 		}
 
 		// Restore .pre-entire backup if it exists
-		if fileExists(backupPath) {
+		if hookFileExists(root, backupName) {
 			if hookExists && !hookIsOurs {
 				// A non-Entire hook is present — don't overwrite it with the backup
 				fmt.Fprintf(os.Stderr, "[entire] Warning: %s was modified since install; backup %s%s left in place\n", hook, hook, backupSuffix)
 			} else {
-				if err := os.Rename(backupPath, hookPath); err != nil {
+				if err := root.Rename(backupName, hook); err != nil {
 					removeErrors = append(removeErrors, fmt.Sprintf("restore %s%s: %v", hook, backupSuffix, err))
 				}
 			}

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -141,8 +142,18 @@ func getHooksDirInPath(ctx context.Context, dir string) (string, error) {
 	return filepath.Clean(hooksDir), nil
 }
 
-// hooksRoot anchors a root at the active hooks directory and refuses a symlink
-// at the directory itself.
+// absHooksDir absolutizes git's answer for the hooks directory. Both roots
+// below anchor on the result, and every message names it.
+func absHooksDir(hooksDir string) (string, error) {
+	abs, err := filepath.Abs(hooksDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve hooks directory %s: %w", hooksDir, err)
+	}
+	return abs, nil
+}
+
+// hooksRootForInstall anchors a root at the active hooks directory and refuses a
+// symlink at the directory itself.
 //
 // The base is git's own answer to `git rev-parse --git-path hooks`, which is
 // what makes it a trusted one: core.hooksPath may name any directory, inside
@@ -158,12 +169,15 @@ func getHooksDirInPath(ctx context.Context, dir string) (string, error) {
 // target says the same thing without the indirection -- or something that
 // redirects every hook Entire installs somewhere it cannot see.
 //
+// The refusal is INSTALL-ONLY, which hooksRootForRemoval is the other half of.
+// Read that function's comment before widening this one back out.
+//
 // A missing directory is returned unwrapped so callers can classify it with
 // os.IsNotExist.
-func hooksRoot(hooksDir string) (*os.Root, error) {
-	abs, err := filepath.Abs(hooksDir)
+func hooksRootForInstall(hooksDir string) (*os.Root, error) {
+	abs, err := absHooksDir(hooksDir)
 	if err != nil {
-		return nil, fmt.Errorf("resolve hooks directory %s: %w", hooksDir, err)
+		return nil, err
 	}
 	info, err := os.Lstat(abs)
 	if err != nil {
@@ -175,18 +189,144 @@ func hooksRoot(hooksDir string) (*os.Root, error) {
 	return osroot.Shared(abs) //nolint:wrapcheck // preserve os.IsNotExist classification, as the doc comment promises
 }
 
-// symlinkedHooksDirError explains a refusal from hooksRoot in terms of the one
-// setting that can produce it.
+// hooksRootForRemoval anchors a root at the directory a symlinked hooks path
+// points AT, instead of refusing the link the way hooksRootForInstall does.
+//
+// Removal is not the operation the refusal exists to prevent. Installing writes
+// new content through a path it cannot verify; removing deletes files carrying
+// Entire's own marker and renames back the .pre-entire backups Entire itself
+// created. Both act only on files Entire put there, so following the link costs
+// nothing the install-time refusal was protecting.
+//
+// Refusing here instead cost a great deal, which is why this exists. RemoveGitHook
+// and gitHookStateInHooksDir shared hooksRootForInstall, so a symlinked hooks
+// directory made `entire disable` exit non-zero forever -- there is no uninstall
+// path that does not go through this function, so the user could not get out by
+// running Entire at all -- while the detection half reported GitHooksAbsent,
+// which sent EnsureSetup to InstallGitHook and failed every agent turn on the
+// same error. A refusal a user cannot act on and cannot uninstall past is worse
+// than the redirect it declines to follow.
+//
+// EvalSymlinks rather than Readlink: the link may be relative or chained, and
+// the root has to anchor on a real directory. A missing directory is returned
+// unwrapped so callers can classify it with os.IsNotExist.
+func hooksRootForRemoval(hooksDir string) (*os.Root, error) {
+	abs, err := absHooksDir(hooksDir)
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // preserve os.IsNotExist classification
+	}
+	return osroot.Shared(resolved) //nolint:wrapcheck // preserve os.IsNotExist classification
+}
+
+// HooksDirLinkTarget resolves a symlinked hooks directory to the absolute
+// directory it names, reporting false when it cannot be resolved (a dangling
+// link, or one whose target is unreadable).
+//
+// Exported because doctor prints the same remedy, and it must print the same
+// path: os.Readlink returns the link's raw contents, which for a relative link
+// is relative to the link's own parent rather than to anywhere the user's shell
+// will be. Pasting that into `git config core.hooksPath` sets a path git then
+// resolves from somewhere else entirely.
+func HooksDirLinkTarget(hooksDir string) (string, bool) {
+	abs, err := absHooksDir(hooksDir)
+	if err != nil {
+		return "", false
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", false
+	}
+	return resolved, true
+}
+
+// symlinkedHooksDirError explains a refusal from hooksRootForInstall in terms of
+// the one setting that can produce it.
+//
+// The unresolvable branch names no target at all rather than a placeholder: the
+// remedy is a command the user pastes, and `git config core.hooksPath its target`
+// is worse than no command, because it looks like one.
 func symlinkedHooksDirError(hooksDir string, err error) error {
-	target, readErr := os.Readlink(hooksDir)
-	if readErr != nil {
-		target = "its target"
+	const refusal = "Entire will not install hooks through a link, because everything it writes there would land somewhere it cannot verify.\n"
+	abs, absErr := absHooksDir(hooksDir)
+	if absErr != nil {
+		abs = hooksDir
+	}
+	target, ok := HooksDirLinkTarget(hooksDir)
+	if !ok {
+		return fmt.Errorf("git resolves the hooks directory to %s, which is a symlink Entire cannot resolve\n"+
+			refusal+
+			"Find where the path is set, then point git at a real directory:\n"+
+			"  git config --show-origin --get-all core.hooksPath\n"+
+			"%w", abs, err)
 	}
 	return fmt.Errorf("git resolves the hooks directory to %s, which is a symlink to %s\n"+
-		"Entire will not install hooks through a link, because everything it writes there would land somewhere it cannot verify.\n"+
+		refusal+
 		"Point git at the target directly instead:\n"+
 		"  git config core.hooksPath %s\n"+
-		"or replace the link with a real directory: %w", hooksDir, target, target, err)
+		"or replace the link with a real directory: %w", abs, target, target, err)
+}
+
+// hookClassification is what is sitting at a managed hook's path.
+type hookClassification int
+
+const (
+	// hookAbsent: nothing is there.
+	hookAbsent hookClassification = iota
+	// hookOurs: a regular file carrying Entire's marker.
+	hookOurs
+	// hookForeign: something that is not Entire's -- a script another tool or
+	// the user wrote, or a symlink, which Entire never installs.
+	hookForeign
+)
+
+// classifyExistingHook reports what is at name inside root.
+//
+// Every outcome is identified POSITIVELY and an unrecognised read error is
+// returned rather than folded into one of them. That is not style. The previous
+// expression was
+//
+//	foreign := errors.Is(err, osroot.ErrSymlinkedPath) || (err == nil && !hasMarker)
+//
+// which is false for a hook that exists but cannot be READ -- a mode-0600 hook
+// owned by another user, say. "Not foreign" meant no backup, and the write that
+// followed is a temp-file-and-rename, which needs no permission on the target at
+// all: rename(2) only needs the directory writable. So an unreadable hook was
+// silently destroyed. The in-place truncating write this code replaced failed
+// loudly with EACCES and left the file alone, so the atomic write -- correct for
+// refusing to follow a symlink -- turned a loud failure into data loss.
+//
+// The caller must therefore treat a returned error as "something is there and I
+// could not tell what", and write nothing.
+func classifyExistingHook(root *os.Root, name string) (hookClassification, error) {
+	data, err := osroot.ReadFileNoFollow(root, name)
+	switch {
+	case err == nil:
+		if strings.Contains(string(data), entireHookMarker) {
+			return hookOurs, nil
+		}
+		return hookForeign, nil
+	case errors.Is(err, osroot.ErrSymlinkedPath):
+		// Entire never installs a link, so it belongs to the user or another
+		// tool: foreign, and backed up and chained to like any other.
+		return hookForeign, nil
+	case errors.Is(err, fs.ErrNotExist):
+		return hookAbsent, nil
+	default:
+		return hookAbsent, err //nolint:wrapcheck // callers add the hook name and the remedy
+	}
+}
+
+// unclassifiableHookError refuses to replace a hook that could not be read.
+func unclassifiableHookError(hooksDir, name string, err error) error {
+	return fmt.Errorf("cannot read the existing %s hook to tell whether it is Entire's: %w\n"+
+		"Entire will not replace a hook it cannot classify. The install writes by atomic rename, "+
+		"which would replace the file whether or not it is readable, so there would be no backup and no warning.\n"+
+		"Check what is there and fix its permissions, or move it aside yourself:\n"+
+		"  ls -l %s", name, err, filepath.Join(hooksDir, name))
 }
 
 // hookFileExists reports whether name exists directly inside root. It lstats, so
@@ -296,7 +436,11 @@ const bareEntireHookCmd = "entire"
 // Current, which is what makes EnsureSetup reinstall it rather than leaving a
 // broken hook in place forever.
 func gitHookStateInHooksDir(hooksDir string) GitHookState {
-	root, err := hooksRoot(hooksDir)
+	// ForRemoval: this is a read, and reporting GitHooksAbsent for a symlinked
+	// hooks directory is what sent EnsureSetup to InstallGitHook on every agent
+	// turn, to fail on a refusal only `entire enable` should ever hit. Seeing
+	// through the link reports what is actually installed there.
+	root, err := hooksRootForRemoval(hooksDir)
 	if err != nil {
 		return GitHooksAbsent
 	}
@@ -498,7 +642,7 @@ func InstallGitHook(ctx context.Context, silent, absolutePath bool) (int, error)
 		return 0, fmt.Errorf("failed to create hooks directory: %w", err)
 	}
 
-	root, err := hooksRoot(hooksDir)
+	root, err := hooksRootForInstall(hooksDir)
 	if err != nil {
 		if errors.Is(err, osroot.ErrSymlinkedPath) {
 			return 0, symlinkedHooksDirError(hooksDir, err)
@@ -522,10 +666,14 @@ func InstallGitHook(ctx context.Context, silent, absolutePath bool) (int, error)
 		// tool. Refusing to read through it must not mean quietly replacing it,
 		// and the rename below preserves the link itself as the backup, which
 		// the generated chain call then invokes exactly as it would a script.
-		existing, existingErr := osroot.ReadFileNoFollow(root, spec.name)
-		foreign := errors.Is(existingErr, osroot.ErrSymlinkedPath) ||
-			(existingErr == nil && !strings.Contains(string(existing), entireHookMarker))
-		if foreign {
+		//
+		// A hook that cannot be classified at all stops the install for that
+		// hook rather than being treated as absent; see classifyExistingHook.
+		class, classErr := classifyExistingHook(root, spec.name)
+		if classErr != nil {
+			return installedCount, unclassifiableHookError(hooksDir, spec.name, classErr)
+		}
+		if class == hookForeign {
 			if !backupExists {
 				if err := root.Rename(spec.name, backupName); err != nil {
 					return installedCount, fmt.Errorf("failed to back up %s: %w", spec.name, err)
@@ -592,13 +740,13 @@ func RemoveGitHook(ctx context.Context) (int, error) {
 		return 0, err
 	}
 
-	root, err := hooksRoot(hooksDir)
+	// ForRemoval: uninstall must be able to finish on a repo install refused.
+	// See hooksRootForRemoval for why following the link is safe here and not
+	// in InstallGitHook.
+	root, err := hooksRootForRemoval(hooksDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return 0, nil // no hooks directory, so nothing of ours in it
-		}
-		if errors.Is(err, osroot.ErrSymlinkedPath) {
-			return 0, symlinkedHooksDirError(hooksDir, err)
 		}
 		return 0, fmt.Errorf("failed to open hooks directory %s: %w", hooksDir, err)
 	}
@@ -612,9 +760,20 @@ func RemoveGitHook(ctx context.Context) (int, error) {
 		// Remove the hook if it contains our marker. A symlink at the path is
 		// present but never ours, so it is left alone and, like any other
 		// foreign hook, blocks the backup from being restored over it.
-		data, readErr := osroot.ReadFileNoFollow(root, hook)
-		hookIsOurs := readErr == nil && strings.Contains(string(data), entireHookMarker)
-		hookExists := readErr == nil || errors.Is(readErr, osroot.ErrSymlinkedPath)
+		//
+		// A hook that cannot be read is treated as present-and-not-ours, which
+		// is the safe direction on this path too: classifying it as absent let
+		// the backup be renamed OVER it below, destroying it exactly as the
+		// install did. Warn and leave both files alone -- uninstall is cleanup
+		// and must still finish, so this is not an error.
+		class, classErr := classifyExistingHook(root, hook)
+		if classErr != nil {
+			fmt.Fprintf(os.Stderr, "[entire] Warning: cannot read %s to tell whether it is Entire's (%v); leaving it and any %s%s backup in place\n",
+				hook, classErr, hook, backupSuffix)
+			continue
+		}
+		hookIsOurs := class == hookOurs
+		hookExists := class != hookAbsent
 
 		if hookIsOurs {
 			if err := osroot.RemoveNoSymlinks(root, hook); err != nil {

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -11,8 +11,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const goosWindows = "windows"
@@ -1866,4 +1869,118 @@ func TestResolveHookExePath(t *testing.T) {
 			t.Errorf("error should mention symlink resolution, got: %v", err)
 		}
 	})
+}
+
+// A symlinked hook belongs to the user or another tool — Entire never installs
+// one — so it is treated as a foreign hook: backed up and chained to, not read
+// through and not overwritten in place. The link itself becomes the backup, so
+// whatever it pointed at is untouched and still runs.
+func TestInstallGitHook_SymlinkedHookIsBackedUpNotFollowed(t *testing.T) {
+	_, hooksDir := initHooksTestRepo(t)
+	require.NoError(t, os.MkdirAll(hooksDir, 0o750))
+
+	targetDir := t.TempDir()
+	target := filepath.Join(targetDir, "shared-pre-push")
+	const targetContent = "#!/bin/sh\necho shared\n"
+	require.NoError(t, os.WriteFile(target, []byte(targetContent), 0o700))
+
+	hookPath := filepath.Join(hooksDir, "pre-push")
+	if err := os.Symlink(target, hookPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := InstallGitHook(context.Background(), true, false)
+	require.NoError(t, err)
+
+	after, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, targetContent, string(after), "the link's target must not be written through")
+
+	backupInfo, err := os.Lstat(hookPath + backupSuffix)
+	require.NoError(t, err, "the link must be preserved as the backup")
+	assert.NotZero(t, backupInfo.Mode()&os.ModeSymlink, "the backup should still be the link itself")
+
+	installed, err := os.Lstat(hookPath)
+	require.NoError(t, err)
+	assert.Zero(t, installed.Mode()&os.ModeSymlink, "the installed hook must be a real file")
+
+	content, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), entireHookMarker)
+	assert.Contains(t, string(content), "pre-push"+backupSuffix, "the chain call should invoke the preserved link")
+}
+
+// The hooks directory is git's answer to core.hooksPath, and Entire will not
+// write its hooks through a link to somewhere it cannot verify. The error has to
+// name the setting, because nothing else in the message would tell the user
+// where the path came from.
+func TestInstallGitHook_SymlinkedHooksDirIsRefused(t *testing.T) {
+	tmpDir, _ := initHooksTestRepo(t)
+
+	realHooks := filepath.Join(tmpDir, "real-hooks")
+	require.NoError(t, os.MkdirAll(realHooks, 0o750))
+	link := filepath.Join(tmpDir, "linked-hooks")
+	if err := os.Symlink(realHooks, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	testutil.RunGit(t, tmpDir, "config", "core.hooksPath", link)
+	ClearHooksDirCache()
+	t.Cleanup(ClearHooksDirCache)
+
+	_, err := InstallGitHook(context.Background(), true, false)
+	require.Error(t, err)
+	require.ErrorIs(t, err, osroot.ErrSymlinkedPath)
+	assert.Contains(t, err.Error(), "core.hooksPath", "the remedy must name the setting that produced the path")
+
+	entries, readErr := os.ReadDir(realHooks)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "nothing should have been written through the link")
+}
+
+// Absent rather than Current: a symlinked hook is not one we wrote, so reporting
+// it as installed would leave it in place forever. Absent is what sends
+// EnsureSetup to InstallGitHook, which backs it up and chains to it.
+func TestCheckGitHookState_SymlinkedHookIsNotOurs(t *testing.T) {
+	_, hooksDir := initHooksTestRepo(t)
+
+	_, err := InstallGitHook(context.Background(), true, false)
+	require.NoError(t, err)
+	require.Equal(t, GitHooksCurrent, CheckGitHookState(context.Background()))
+
+	hookPath := filepath.Join(hooksDir, "post-commit")
+	ours, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	elsewhere := filepath.Join(t.TempDir(), "post-commit")
+	require.NoError(t, os.WriteFile(elsewhere, ours, 0o700))
+	require.NoError(t, os.Remove(hookPath))
+	if err := os.Symlink(elsewhere, hookPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	assert.Equal(t, GitHooksAbsent, CheckGitHookState(context.Background()),
+		"a link to a file carrying our marker is still not a hook we installed")
+}
+
+// Removal must not follow a link either: the hook at that path is not ours, so
+// it stays, and it blocks a backup from being restored over it.
+func TestRemoveGitHook_LeavesSymlinkedForeignHook(t *testing.T) {
+	_, hooksDir := initHooksTestRepo(t)
+
+	_, err := InstallGitHook(context.Background(), true, false)
+	require.NoError(t, err)
+
+	hookPath := filepath.Join(hooksDir, "post-commit")
+	require.NoError(t, os.Remove(hookPath))
+	elsewhere := filepath.Join(t.TempDir(), "post-commit")
+	require.NoError(t, os.WriteFile(elsewhere, []byte("#!/bin/sh\n"), 0o700))
+	if err := os.Symlink(elsewhere, hookPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err = RemoveGitHook(context.Background())
+	require.NoError(t, err)
+
+	info, err := os.Lstat(hookPath)
+	require.NoError(t, err, "a foreign hook must survive removal")
+	assert.NotZero(t, info.Mode()&os.ModeSymlink)
 }

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -18,8 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const goosWindows = "windows"
-
 // clearGlobalHooksPath overrides any global core.hooksPath setting so that
 // test repos use their default .git/hooks directory. Setting the local value
 // takes precedence over the global one.
@@ -2112,4 +2110,53 @@ func TestSymlinkedHooksDirError_RemedyIsPasteable(t *testing.T) {
 	assert.NotContains(t, msg, "its target", "never emit a command containing a placeholder")
 	assert.Contains(t, msg, "git config --show-origin --get-all core.hooksPath",
 		"with no target to name, point at the command that finds where the path came from")
+}
+
+// The remedy is a command the user pastes, so it has to survive being pasted.
+// A hooks directory containing a space is ordinary, and unquoted it produced
+// `git config core.hooksPath /tmp/my hooks dir`, which git rejects with
+// "error: no action specified" because it sees four arguments.
+func TestHooksPathCommand_QuotesWhatAShellWouldSplit(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == goosWindows {
+		assert.Equal(t, `git config core.hooksPath "C:\Users\First Last\hooks"`,
+			HooksPathCommand(`C:\Users\First Last\hooks`))
+		return
+	}
+
+	// The clean common case stays unquoted and readable.
+	assert.Equal(t, "git config core.hooksPath /home/u/.git-hooks",
+		HooksPathCommand("/home/u/.git-hooks"))
+
+	for _, tc := range []struct{ in, want string }{
+		{"/tmp/my hooks dir", `git config core.hooksPath '/tmp/my hooks dir'`},
+		{"/tmp/a;rm -rf b", `git config core.hooksPath '/tmp/a;rm -rf b'`},
+		{"/tmp/$(id)", `git config core.hooksPath '/tmp/$(id)'`},
+		{"/tmp/it's", `git config core.hooksPath '/tmp/it'\''s'`},
+	} {
+		assert.Equal(t, tc.want, HooksPathCommand(tc.in), "input %q", tc.in)
+	}
+}
+
+// And the error that carries it uses the same rendering, so the two places the
+// remedy is printed cannot disagree.
+func TestSymlinkedHooksDirError_UsesTheQuotedCommand(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == goosWindows {
+		t.Skip("POSIX quoting")
+	}
+
+	dir := t.TempDir()
+	realHooks := filepath.Join(dir, "real hooks")
+	require.NoError(t, os.MkdirAll(realHooks, 0o750))
+	link := filepath.Join(dir, "hooks")
+	if err := os.Symlink(realHooks, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	msg := symlinkedHooksDirError(link, osroot.ErrSymlinkedPath).Error()
+	assert.Contains(t, msg, HooksPathCommand(realHooks))
+	assert.NotContains(t, msg, "core.hooksPath "+realHooks,
+		"the bare unquoted path would be split by the shell the user pastes into")
 }

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -1984,3 +1984,132 @@ func TestRemoveGitHook_LeavesSymlinkedForeignHook(t *testing.T) {
 	require.NoError(t, err, "a foreign hook must survive removal")
 	assert.NotZero(t, info.Mode()&os.ModeSymlink)
 }
+
+// The refusal is install-only. It used to be shared with removal and detection,
+// which left a repo with a symlinked hooks directory unable to uninstall (there
+// is no other uninstall path) and failing EnsureSetup on every agent turn,
+// because detection reported the hooks absent and sent it back to the install
+// that had just refused.
+func TestRemoveGitHook_FinishesThroughASymlinkedHooksDir(t *testing.T) {
+	repoDir, _ := initHooksTestRepo(t)
+
+	_, err := InstallGitHook(context.Background(), true, false)
+	require.NoError(t, err)
+	require.Equal(t, GitHooksCurrent, CheckGitHookState(context.Background()))
+
+	realHooks := filepath.Join(repoDir, ".git", "hooks")
+	link := filepath.Join(repoDir, "linked-hooks")
+	if err := os.Symlink(realHooks, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	testutil.RunGit(t, repoDir, "config", "--local", "core.hooksPath", link)
+	ClearHooksDirCache()
+
+	assert.Equal(t, GitHooksCurrent, CheckGitHookState(context.Background()),
+		"detection must see through the link, or EnsureSetup reinstalls into the refusal on every turn")
+
+	removed, err := RemoveGitHook(context.Background())
+	require.NoError(t, err, "uninstall must be able to finish; there is no other way out")
+	assert.Positive(t, removed)
+	for _, hook := range ManagedGitHookNames() {
+		assert.NoFileExists(t, filepath.Join(realHooks, hook))
+	}
+}
+
+// A hook Entire cannot read is a hook Entire must not replace. The write is an
+// atomic rename, which needs no permission on the target at all, so classifying
+// an unreadable hook as "not foreign" destroyed it with no backup and no
+// warning. The in-place write this replaced failed loudly with EACCES.
+func TestInstallGitHook_RefusesToReplaceAnUnreadableHook(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission bits this test removes")
+	}
+	if runtime.GOOS == goosWindows {
+		t.Skip("unix permission bits")
+	}
+	_, hooksDir := initHooksTestRepo(t)
+
+	const precious = "#!/bin/sh\n# someone else's pre-push\n"
+	hookPath := filepath.Join(hooksDir, "pre-push")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o750))
+	require.NoError(t, os.WriteFile(hookPath, []byte(precious), 0o700))
+	require.NoError(t, os.Chmod(hookPath, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(hookPath, 0o700) }) //nolint:errcheck // best-effort restore for t.TempDir cleanup
+
+	_, err := InstallGitHook(context.Background(), true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pre-push")
+	assert.Contains(t, err.Error(), "cannot read", "the message must name the condition, not just fail")
+
+	require.NoError(t, os.Chmod(hookPath, 0o400))
+	got, readErr := os.ReadFile(hookPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, precious, string(got), "the hook must survive untouched")
+	assert.NoFileExists(t, hookPath+GitHookBackupSuffix, "and no backup should have been invented for it")
+}
+
+// The same hole on the removal side: an unreadable hook classified as absent let
+// the .pre-entire backup be renamed over it.
+func TestRemoveGitHook_LeavesAnUnreadableHookAndItsBackup(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission bits this test removes")
+	}
+	if runtime.GOOS == goosWindows {
+		t.Skip("unix permission bits")
+	}
+	_, hooksDir := initHooksTestRepo(t)
+
+	const precious = "#!/bin/sh\n# someone else's pre-push\n"
+	hookPath := filepath.Join(hooksDir, "pre-push")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o750))
+	require.NoError(t, os.WriteFile(hookPath, []byte(precious), 0o700))
+
+	_, err := InstallGitHook(context.Background(), true, false)
+	require.NoError(t, err)
+	require.FileExists(t, hookPath+GitHookBackupSuffix)
+
+	require.NoError(t, os.Chmod(hookPath, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(hookPath, 0o700) }) //nolint:errcheck // best-effort restore for t.TempDir cleanup
+
+	_, err = RemoveGitHook(context.Background())
+	require.NoError(t, err, "uninstall stays best-effort: an unreadable hook is a warning, not a failure")
+
+	require.NoError(t, os.Chmod(hookPath, 0o400))
+	got, readErr := os.ReadFile(hookPath)
+	require.NoError(t, readErr)
+	assert.NotEqual(t, precious, string(got),
+		"sanity: the file at the hook path is the one install wrote, not the backup")
+	assert.FileExists(t, hookPath+GitHookBackupSuffix,
+		"the backup must not have been renamed over a file we could not classify")
+}
+
+// A remedy the user pastes must be a command that works. os.Readlink returns the
+// link's raw contents, so a relative link produced a path git resolves from
+// somewhere else, and an unreadable one produced the literal
+// `git config core.hooksPath its target`.
+func TestSymlinkedHooksDirError_RemedyIsPasteable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	realHooks := filepath.Join(dir, "real-hooks")
+	require.NoError(t, os.MkdirAll(realHooks, 0o750))
+	link := filepath.Join(dir, "hooks")
+	if err := os.Symlink("real-hooks", link); err != nil { // deliberately relative
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	msg := symlinkedHooksDirError(link, osroot.ErrSymlinkedPath).Error()
+	assert.Contains(t, msg, "git config core.hooksPath "+realHooks,
+		"the remedy must name the resolved absolute target, not the link's raw contents")
+	assert.NotContains(t, msg, "core.hooksPath real-hooks",
+		"a relative target would be resolved by git from a different directory")
+
+	dangling := filepath.Join(dir, "dangling")
+	if err := os.Symlink(filepath.Join(dir, "nowhere"), dangling); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	msg = symlinkedHooksDirError(dangling, osroot.ErrSymlinkedPath).Error()
+	assert.NotContains(t, msg, "its target", "never emit a command containing a placeholder")
+	assert.Contains(t, msg, "git config --show-origin --get-all core.hooksPath",
+		"with no target to name, point at the command that finds where the path came from")
+}

--- a/cmd/entire/cli/testutil/gitenv/gitenv.go
+++ b/cmd/entire/cli/testutil/gitenv/gitenv.go
@@ -162,6 +162,16 @@ func Run(t *testing.T, dir string, args ...string) string {
 	return string(out)
 }
 
+// EmptyConfigOverrides returns the GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM
+// settings Isolated applies, for callers that build their own environment on a
+// different base and still want the caller's git config kept out.
+func EmptyConfigOverrides() []string {
+	return []string{
+		"GIT_CONFIG_GLOBAL=" + emptyConfigPath(),
+		"GIT_CONFIG_SYSTEM=" + emptyConfigPath(),
+	}
+}
+
 func isGitConfigEnv(e string) bool {
 	return strings.HasPrefix(e, "GIT_CONFIG_")
 }

--- a/cmd/entire/cli/testutil/gitgrep.go
+++ b/cmd/entire/cli/testutil/gitgrep.go
@@ -1,0 +1,95 @@
+package testutil
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/testutil/gitenv"
+)
+
+// GitGrepGuard runs `git grep` for a source-level guard test and returns its
+// output, failing the test when the pattern matched nothing.
+//
+// It exists because this repo has four guards that scan their own source with
+// `git grep` — the root-base allowlist, the transcript-read ratchet, the
+// `git status` flag check, and the agent hook-config coverage check — and
+// getting the invocation right is not obvious. Each of the three flags below
+// was missing from at least one of them, and the same bug was found in three:
+// two copies is how they drift, and four is how they drifted.
+//
+// --untracked, because git grep otherwise searches only the INDEX. Every one of
+// these guards has "someone just added a file" as its subject, so the file it
+// most needs to see is the one not yet staged. The hole is worse than a plain
+// miss in two of them: the hook-config guard compares two sets built from the
+// same blind grep, so a new agent missing its locator is invisible on both
+// sides and the comparison passes; and the root-base guard's staleness half
+// reported a just-added entry as STALE, telling the author to delete the entry
+// that legitimises their new root. Ignored files stay excluded, which is right.
+//
+// --no-color, because `color.ui` or `color.grep` set to `always` colorizes even
+// into a pipe, and the escapes land in the FILENAME field. Confirmed for both
+// output shapes: `-n` gives `\e[35mpath\e[m\e[36m:\e[m...`, and `-l` — which
+// looks like it should be immune, being nothing but filenames — gives
+// `\e[35mpath\e[m`. Every one of these guards then either misparses (a `.go`
+// suffix check fails and the guard reports itself stale, which was read as a
+// real staleness failure on main, #2248) or, worse, silently compares garbage
+// to garbage while its "did we match anything" assertion still passes.
+//
+// Repo-selector scrubbing, because git exports GIT_DIR / GIT_WORK_TREE to the
+// hooks it runs and those take precedence over cmd.Dir. A `go test` launched
+// from anywhere that exports them — a `git rebase --exec`, a hook, this CLI's
+// own harnesses — pointed the grep at some other repository. Measured against a
+// decoy repo, an unscrubbed grep returns the decoy's files while cmd.Dir names
+// this one. GIT_CONFIG_* isolation is applied too (gitenv.Isolated), so a
+// developer's global grep settings cannot change the pattern semantics either.
+//
+// args are the caller's own flags, pattern and pathspecs, appended after the
+// three above.
+func GitGrepGuard(t *testing.T, repoRoot string, args ...string) string {
+	t.Helper()
+
+	full := append([]string{"grep", "--untracked", "--no-color"}, args...)
+	cmd := exec.Command("git", full...) //nolint:noctx // guard test, no cancellation needed
+	cmd.Dir = repoRoot
+	cmd.Env = GuardGitEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		// git grep exits non-zero on zero matches, so this is "found nothing",
+		// which for a guard means its detection pattern has gone stale rather
+		// than that the tree is clean.
+		t.Fatalf("git grep %v found nothing, which cannot be right — the detection pattern has gone stale: %v", args, err)
+	}
+	return string(out)
+}
+
+// GitGrepGuardRepoRoot resolves the repository root for a guard test, skipping
+// when there is no checkout to scan.
+func GitGrepGuardRepoRoot(t *testing.T) (string, bool) {
+	t.Helper()
+
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel") //nolint:noctx // guard test, no cancellation needed
+	cmd.Env = GuardGitEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		t.Skipf("not in a git checkout: %v", err)
+		return "", false
+	}
+	return strings.TrimSpace(string(out)), true
+}
+
+// GuardGitEnv drops the repo selectors and the caller's git config, keeping
+// both isolations in one place so the two subprocesses above cannot disagree
+// about which repository they are looking at.
+func GuardGitEnv() []string {
+	scrubbed := gitrepo.EnvWithoutRepoOverrides()
+	var kept []string
+	for _, kv := range scrubbed {
+		if strings.HasPrefix(kv, "GIT_CONFIG_") {
+			continue
+		}
+		kept = append(kept, kv)
+	}
+	return append(kept, gitenv.EmptyConfigOverrides()...)
+}

--- a/cmd/entire/cli/userdirs_consumers_guard_test.go
+++ b/cmd/entire/cli/userdirs_consumers_guard_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// userDirConsumers is every file that calls userdirs.Config() or
+// userdirs.Cache(), with the reason a bad override cannot cause damage there.
+//
+// Those two return a plain string and cannot report a rejected override, so
+// safety is the CALLER's, and it has to arrive before the caller creates a
+// directory, takes a lock, or writes a file. There are only two safe shapes:
+// hand the value straight to a consumer that checks (contexts, discovery, the
+// userdirs roots), or call the *Checked resolver and handle the error.
+//
+// Converting a consumer to the *Checked resolver removes it from this ledger
+// entirely, because it is then safe by construction rather than by argument —
+// plugin_index left the list that way. The list is meant to shrink.
+//
+// A ledger rather than a doc comment because the doc comment was tried twice
+// and was wrong both times within a commit or two. The token store slipped past
+// the first enumeration and put bearer tokens at ./<value>/tokens.json;
+// plugin_index slipped past the second and put an index clone and its lock file
+// in the working directory. Prose cannot fail when someone adds a caller.
+var userDirConsumers = map[string]string{
+	"cmd/entire/cli/auth/cell_data_api.go":        "passes both directories to clusterdiscovery, which reaches contexts and discovery; neither creates before checking",
+	"cmd/entire/cli/auth/context_store.go":        "passes the config dir to contexts.Load/Modify, which check before EnsurePrivateDir",
+	"cmd/entire/cli/auth/contexts.go":             "passes the config dir to contexts.Modify",
+	"cmd/entire/cli/auth/control_plane.go":        "passes both to clusterdiscovery and contexts.Load",
+	"cmd/entire/cli/auth/data_api.go":             "passes both to clusterdiscovery",
+	"cmd/entire/cli/versioncheck/versioncheck.go": "only ever creates through userdirs.ConfigRoot, whose resolveUserRoot checks before creating",
+	"cmd/git-remote-entire/main.go":               "passes both to clusterdiscovery, which reaches contexts and discovery",
+	"internal/remotehelper/replicas/replicas.go":  "passes the cache dir to discovery.LoadCache/ModifyCache, which check before MkdirAll",
+}
+
+// TestUserDirConsumersAreAudited fails the build when a new caller of
+// userdirs.Config() or userdirs.Cache() appears without an entry above, and
+// when an entry outlives the call it describes.
+//
+// It cannot verify that the stated reason is TRUE — that is the reviewer's job,
+// and writing the reason down is what gives them something to check. What it
+// guarantees is that nobody adds a consumer without being asked the question.
+func TestUserDirConsumersAreAudited(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, ok := testutil.GitGrepGuardRepoRoot(t)
+	if !ok {
+		return
+	}
+
+	found := map[string]struct{}{}
+	for _, needle := range []string{"userdirs.Config()", "userdirs.Cache()"} {
+		out := testutil.GitGrepGuard(t, repoRoot, "-l", "--fixed-strings", "--", needle,
+			"--", ":(glob)**/*.go", ":(exclude,glob)**/*_test.go")
+		for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+			if line == "" {
+				continue
+			}
+			if !strings.HasSuffix(line, ".go") {
+				t.Fatalf("cannot parse git grep -l output; expected a .go path, got:\n  %s", line)
+			}
+			// The resolver defines them; it is not a consumer of itself.
+			if strings.HasSuffix(line, "internal/entireclient/userdirs/userdirs.go") {
+				continue
+			}
+			// A mention inside a doc comment is not a call. contexts names
+			// userdirs.Config() when explaining what its base is.
+			if strings.HasSuffix(line, "internal/entireclient/contexts/contexts.go") {
+				continue
+			}
+			found[line] = struct{}{}
+		}
+	}
+	if len(found) == 0 {
+		t.Fatal("guard matched no consumers at all; the detection pattern has gone stale")
+	}
+
+	for file := range found {
+		if _, audited := userDirConsumers[file]; audited {
+			continue
+		}
+		t.Errorf("%s calls userdirs.Config() or userdirs.Cache() but is not in userDirConsumers.\n"+
+			"Those return a plain string and cannot report a rejected override, so this file is "+
+			"responsible for learning about one BEFORE it creates a directory, takes a lock, or "+
+			"writes. Either hand the value straight to a consumer that checks (contexts, "+
+			"discovery, the userdirs roots), or call userdirs.ConfigDirChecked / CacheDirChecked "+
+			"and handle the error — then add an entry saying which.", file)
+	}
+	for file := range userDirConsumers {
+		if _, still := found[file]; !still {
+			t.Errorf("%s is in userDirConsumers but no longer calls userdirs.Config() or "+
+				"userdirs.Cache(); remove the entry", file)
+		}
+	}
+}

--- a/cmd/entire/cli/versioncheck/autoupdate_unix.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_unix.go
@@ -14,6 +14,25 @@ const installerAutoRuns = true
 
 // realRunInstaller shells out to the installer command, streaming stdin/stdout/stderr
 // so password prompts and progress output reach the user.
+//
+// The shell stays, and this is the reason it is allowed to. CLAUDE.md's rule is
+// "never put a dynamic value on a cmd.exe line", and the argument generalises to
+// `sh -c`: Go's argv escaping does not protect a string a shell then re-parses.
+// What makes this call site different is that there IS no dynamic value.
+// UpdateCommandForCurrentBinary returns one of the unix commands' compile-time
+// literals; the running binary's path and version choose BETWEEN them and never
+// appear IN them. And the shell is load-bearing for the fallback, which is a
+// pipeline (`curl … | bash`) — rewriting it as argv would mean re-implementing
+// the pipe here, which is more moving parts than the risk being removed.
+//
+// That reasoning holds only as long as the literals stay literal, and the
+// tempting next change is exactly the one that breaks it: interpolating the
+// channel or the version into the command. So the invariant is enforced rather
+// than asserted — TestUpdateCommandIsAlwaysALiteral drives every unix install
+// manager and channel, including adversarial exec paths and versions, and fails
+// when the result is not one of the known strings. If a future command
+// genuinely needs a runtime value in it, that command must be built and run as
+// argv, not added to the literal set.
 func realRunInstaller(ctx context.Context, cmdStr string) error {
 	c := exec.CommandContext(ctx, "sh", "-c", cmdStr)
 	c.Stdin = os.Stdin

--- a/cmd/entire/cli/versioncheck/versioncheck_unix.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix.go
@@ -32,6 +32,14 @@ var brewProbe = installProbe{
 // TestUnixBrewBeatsAMiseRootCoveringTheSamePath.
 var installProbes = []installProbe{brewProbe, miseProbe}
 
+// Every command this file returns is a compile-time literal, and that is load
+// bearing rather than incidental: realRunInstaller hands the result to `sh -c`.
+// The version and the executable path select among these commands; they must
+// never appear inside one. TestUpdateCommandIsAlwaysALiteral enforces it — a
+// command that needs a runtime value has to be built and run as argv instead.
+// The Windows fallback is deliberately not held to this: it interpolates the
+// install directory, and Windows never runs the installer (realRunInstaller is
+// unimplemented there, so the command is only ever printed).
 func fallbackInstallCommand(_, currentVersion string) string {
 	if isNightly(currentVersion) {
 		return "curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly"

--- a/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_unix_test.go
@@ -260,3 +260,63 @@ func TestUnixBrewBeatsAMiseRootCoveringTheSamePath(t *testing.T) {
 			got, brewUpgradeCmd)
 	}
 }
+
+// knownUpdateCommands is every string UpdateCommandForCurrentBinary may return
+// on unix. It is a closed set on purpose: realRunInstaller hands the result to
+// `sh -c`, and that is only defensible while nothing runtime-derived reaches
+// the string. Windows has no equivalent guard because it has no equivalent
+// exception: realRunInstaller is unimplemented there, so its commands are only
+// ever printed, and its fallback deliberately names the install directory.
+var knownUpdateCommands = map[string]struct{}{
+	brewUpgradeCmd:                      {},
+	"brew upgrade --yes entire@nightly": {},
+	miseUpgradeCmd:                      {},
+	"curl -fsSL https://entire.io/install.sh | bash":                         {},
+	"curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly": {},
+}
+
+// TestUpdateCommandIsAlwaysALiteral is the guard behind realRunInstaller's
+// decision to keep `sh -c`.
+//
+// The version string and the executable path are the only inputs, and today
+// they only select among fixed commands. Interpolating either into the command
+// — the channel into a URL, a package name into a spec — is the change that
+// turns a shell invocation of a constant into a shell invocation of a runtime
+// value, and it would look entirely reasonable in review. The adversarial cases
+// below are not a claim that an attacker controls these inputs; they are there
+// so that a future interpolation shows up as a failing test rather than as a
+// quoting question nobody asks.
+func TestUpdateCommandIsAlwaysALiteral(t *testing.T) {
+	versions := []string{
+		"1.0.0",
+		"1.0.1-nightly.202604101200.abc1234",
+		"",
+		"1.0.0; touch /tmp/pwned",
+		"$(touch /tmp/pwned)",
+		"1.0.0-nightly.`id`",
+	}
+	execPaths := []string{
+		"/opt/homebrew/bin/entire",
+		"/home/linuxbrew/.linuxbrew/bin/entire",
+		"/home/user/.local/share/mise/installs/entire/1.0.0/bin/entire",
+		plainBinPath,
+		"/opt/homebrew/bin/entire; touch /tmp/pwned",
+		"/home/user/.local/share/mise/installs/$(id)/bin/entire",
+	}
+
+	for _, version := range versions {
+		for _, path := range execPaths {
+			original := executablePath
+			executablePath = func() (string, error) { return path, nil }
+			got := UpdateCommandForCurrentBinary(version)
+			executablePath = original
+
+			if _, known := knownUpdateCommands[got]; !known {
+				t.Errorf("UpdateCommandForCurrentBinary(%q) with exec path %q = %q, which is not one of the known literals.\n"+
+					"realRunInstaller passes this to `sh -c`, which is only safe while the command is a "+
+					"compile-time constant. A command that needs a runtime value must be built and run as "+
+					"argv instead of being added to knownUpdateCommands.", version, path, got)
+			}
+		}
+	}
+}

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -73,6 +73,15 @@ const contextsFileName = "contexts.json"
 // The path is for messages and for the flock, which takes one. Reads and writes
 // go through configRoot.
 func FilePath(configDir string) (string, error) {
+	// Before EnsurePrivateDir, not after. configRoot refuses a relative
+	// directory, but it runs at the READ, several steps past this one: by then
+	// EnsurePrivateDir has created ./<value> relative to the working directory
+	// and lockFile has put a .lock inside it. Creating that directory is the
+	// exact mistake the check exists to prevent, so it cannot happen on the way
+	// to reporting it.
+	if err := userdirs.RequireAbsoluteOverride("config dir", configDir); err != nil {
+		return "", err //nolint:wrapcheck // the error already names the directory and its value
+	}
 	if err := userdirs.EnsurePrivateDir(configDir); err != nil {
 		return "", fmt.Errorf("create config dir: %w", err)
 	}

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -248,12 +248,17 @@ func lockFile(path string) (func(), error) {
 // every component the caller resolved above the root, so the root contains
 // exactly one fixed name and enforces nothing. The directory is what the caller
 // actually chose (userdirs.Config(), or $ENTIRE_CONFIG_DIR), so that is the base.
+//
+// A relative configDir is refused rather than absolutized. It arrives from
+// $ENTIRE_CONFIG_DIR (see userdirs.RequireAbsoluteOverride), and resolving it
+// against the working directory would put the login tokens in a different place
+// in every process — usually inside whatever repository the command was run
+// from. filepath.Abs used to launder exactly that into a plausible-looking path.
 func configRoot(configDir string) (*os.Root, string, error) {
-	abs, err := filepath.Abs(configDir)
-	if err != nil {
-		return nil, "", fmt.Errorf("resolve config dir: %w", err)
+	if err := userdirs.RequireAbsoluteOverride("config dir", configDir); err != nil {
+		return nil, "", err //nolint:wrapcheck // the error already names the directory and its value
 	}
-	root, err := osroot.Shared(abs)
+	root, err := osroot.Shared(configDir)
 	if err != nil {
 		return nil, "", fmt.Errorf("open config dir: %w", err)
 	}

--- a/internal/entireclient/contexts/contexts_test.go
+++ b/internal/entireclient/contexts/contexts_test.go
@@ -284,3 +284,29 @@ func TestModify_HoldsLockAcrossLoadAndSave(t *testing.T) {
 		t.Errorf("CurrentContext = %q, want %q (lost updates indicate non-atomic RMW)", got.CurrentContext, strconv.Itoa(n))
 	}
 }
+
+// The roots refuse a relative config dir, but only at the read. FilePath runs
+// several steps earlier and used to create the directory and let lockFile drop a
+// .lock inside it on the way to reporting the refusal, which is the mistake
+// itself: for a CLI run from a repository, ./<value> is inside the repository.
+func TestLoad_RefusesRelativeConfigDirBeforeCreatingIt(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if _, err := contexts.Load("relative-config"); err == nil {
+		t.Fatal("Load() = nil error, want a rejected override")
+	}
+	if _, err := os.Stat("relative-config"); err == nil {
+		t.Error("Load() created the directory it was refusing")
+	}
+}
+
+func TestSave_RefusesRelativeConfigDirBeforeCreatingIt(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := contexts.Save("relative-config", &contexts.File{}); err == nil {
+		t.Fatal("Save() = nil error, want a rejected override")
+	}
+	if _, err := os.Stat("relative-config"); err == nil {
+		t.Error("Save() created the directory it was refusing")
+	}
+}

--- a/internal/entireclient/contexts/contexts_test.go
+++ b/internal/entireclient/contexts/contexts_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -308,5 +309,65 @@ func TestSave_RefusesRelativeConfigDirBeforeCreatingIt(t *testing.T) {
 	}
 	if _, err := os.Stat("relative-config"); err == nil {
 		t.Error("Save() created the directory it was refusing")
+	}
+}
+
+// TestEveryEntryPointRefusesRelativeConfigDirWithoutSideEffects covers all four
+// public entry points, not just the two that had tests.
+//
+// The refusal has to land before EnsurePrivateDir and before lockFile: configRoot
+// refuses a relative directory too, but only at the READ, by which point
+// ./<value> exists with a .lock inside it. For a CLI run from a repository that
+// is a directory inside the repository, which is the mistake the check exists to
+// report, so it must not happen on the way to reporting it.
+func TestEveryEntryPointRefusesRelativeConfigDirWithoutSideEffects(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(dir string) error
+	}{
+		{"FilePath", func(d string) error { _, err := contexts.FilePath(d); return err }},
+		{"Load", func(d string) error { _, err := contexts.Load(d); return err }},
+		{"Save", func(d string) error { return contexts.Save(d, &contexts.File{}) }},
+		{"Modify", func(d string) error {
+			return contexts.Modify(d, func(*contexts.File) (bool, error) { return true, nil })
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cwd := t.TempDir()
+			t.Chdir(cwd)
+
+			err := tc.call("relative-config")
+			if err == nil {
+				t.Fatalf("%s(%q) = nil error, want a rejected override", tc.name, "relative-config")
+			}
+			if !strings.Contains(err.Error(), "absolute") {
+				t.Errorf("%s error = %q, want it to name the absolute-path requirement", tc.name, err)
+			}
+
+			// Nothing at all, not merely no target directory: the lock file is
+			// created beside the target and would land in the cwd too.
+			entries, readErr := os.ReadDir(cwd)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			for _, e := range entries {
+				t.Errorf("%s left %q behind in the working directory", tc.name, e.Name())
+			}
+		})
+	}
+}
+
+// Entire's OWN fallback must stay usable. When os.UserHomeDir fails, configDir
+// returns its home-relative default, and rejecting that alongside a genuine
+// user override broke every command that touches a saved login on a machine
+// with no resolvable home. userdirs absolutizes it instead; this pins that the
+// consumer accepts what the resolver now produces.
+func TestLoad_AcceptsTheResolversOwnFallback(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	dir := filepath.Join(cwd, ".config", "entire")
+	if _, err := contexts.Load(dir); err != nil {
+		t.Fatalf("Load(%q) = %v, want the resolver's own fallback honored", dir, err)
 	}
 }

--- a/internal/entireclient/discovery/cache.go
+++ b/internal/entireclient/discovery/cache.go
@@ -72,6 +72,12 @@ func writeCacheNoLock(f cacheFile, cache ClusterCache) error {
 // withCacheFileLock ensures cacheDir exists, takes the exclusive flock for
 // the named cache file, and runs fn with the file's path.
 func withCacheFileLock(cacheDir, fileName string, fn func(cacheFile) error) error {
+	// Before the MkdirAll, for the reason contexts.FilePath gives: cacheFile.root
+	// refuses a relative directory, but only at the read, by which point this
+	// has already created ./<value> and dropped a .lock in it.
+	if err := userdirs.RequireAbsoluteOverride("cache dir", cacheDir); err != nil {
+		return err //nolint:wrapcheck // the error already names the directory and its value
+	}
 	if err := os.MkdirAll(cacheDir, 0700); err != nil {
 		return fmt.Errorf("create cache dir: %w", err)
 	}

--- a/internal/entireclient/discovery/cache.go
+++ b/internal/entireclient/discovery/cache.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 	"github.com/gofrs/flock"
 )
 
@@ -168,12 +169,14 @@ type cacheFile struct {
 func (f cacheFile) path() string { return filepath.Join(f.dir, f.name) }
 
 // root opens f.dir and returns f's name inside it.
+// A relative f.dir is refused rather than absolutized, for the reason
+// contexts.configRoot gives: it comes from $XDG_CACHE_HOME, and resolving it
+// against the working directory names a different cache in every process.
 func (f cacheFile) root() (*os.Root, string, error) {
-	abs, err := filepath.Abs(f.dir)
-	if err != nil {
-		return nil, "", fmt.Errorf("resolve cache dir: %w", err)
+	if err := userdirs.RequireAbsoluteOverride("cache dir", f.dir); err != nil {
+		return nil, "", err //nolint:wrapcheck // the error already names the directory and its value
 	}
-	root, err := osroot.Shared(abs)
+	root, err := osroot.Shared(f.dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Unwrapped so readCacheBytes can classify a cold cache.

--- a/internal/entireclient/discovery/cache_test.go
+++ b/internal/entireclient/discovery/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -175,5 +176,65 @@ func TestLoadCacheCorruptFile(t *testing.T) {
 	}
 	if len(cache) != 0 {
 		t.Fatal("expected empty cache from corrupt file")
+	}
+}
+
+// The refusal has to land before withCacheFileLock's MkdirAll and before the
+// flock file is created. cacheFile.root refuses a relative directory too, but
+// only at the read, by which point ./<value> exists with a .lock inside it.
+//
+// Both entry points are covered: ModifyCache goes through withCacheFileLock,
+// while LoadCache deliberately bypasses it (an unlocked read) and has to reach
+// the same verdict by its own route. All three cache files (nodes.json,
+// cluster_cores.json, api_discovery.json) funnel through these two helpers.
+func TestCacheEntryPointsRefuseRelativeDirWithoutSideEffects(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(dir string) error
+	}{
+		{"LoadCache", func(d string) error { _, err := LoadCache(d); return err }},
+		{"ModifyCache", func(d string) error {
+			return ModifyCache(d, func(ClusterCache) error { return nil })
+		}},
+		{"ModifyClusterCores", func(d string) error {
+			return ModifyClusterCores(d, func(ClusterCoresCache) error { return nil })
+		}},
+		{"ModifyAPICores", func(d string) error {
+			return ModifyAPICores(d, func(ClusterCoresCache) error { return nil })
+		}},
+		{"LoadClusterCores", func(d string) error { _, err := LoadClusterCores(d); return err }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cwd := t.TempDir()
+			t.Chdir(cwd)
+
+			err := tc.call("relative-cache")
+			if err == nil {
+				t.Fatalf("%s(relative) = nil error, want a rejected override", tc.name)
+			}
+			if !strings.Contains(err.Error(), "absolute") {
+				t.Errorf("%s error = %q, want it to name the absolute-path requirement", tc.name, err)
+			}
+
+			entries, readErr := os.ReadDir(cwd)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			for _, e := range entries {
+				t.Errorf("%s left %q behind in the working directory", tc.name, e.Name())
+			}
+		})
+	}
+}
+
+// The resolver's own home-failure fallback stays usable; see the matching test
+// in the contexts package.
+func TestModifyCache_AcceptsTheResolversOwnFallback(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	dir := filepath.Join(cwd, ".cache", "entire")
+	if err := ModifyCache(dir, func(ClusterCache) error { return nil }); err != nil {
+		t.Fatalf("ModifyCache(%q) = %v, want the resolver's own fallback honored", dir, err)
 	}
 }

--- a/internal/entireclient/tokenstore/file.go
+++ b/internal/entireclient/tokenstore/file.go
@@ -46,6 +46,12 @@ type fileStore struct {
 	// itself: chmod-ing it is a side effect nobody asked for when it works,
 	// and takes down every Get/Set/Delete when it doesn't.
 	ownsDir bool
+	// pathErr is a rejected ENTIRE_CONFIG_DIR override, carried from
+	// resolveBackendLocked because that function cannot return one. Reported by
+	// ensureDir and dir, both of which run before any filesystem access, so a
+	// relative config dir never gets as far as creating a directory or a lock
+	// file. See userdirs.RequireAbsoluteOverride.
+	pathErr error
 	mu      sync.Mutex
 	// warnedLoosePerms dedupes the loose-permissions warning to once per
 	// store instance — effectively once per CLI invocation, since
@@ -78,6 +84,9 @@ type fileStore struct {
 // lock file below is likewise path-based, since gofrs/flock takes a path and its
 // name is a fixed suffix rather than anything derived.
 func (f *fileStore) dir() (*os.Root, string, error) {
+	if f.pathErr != nil {
+		return nil, "", f.pathErr
+	}
 	abs, err := filepath.Abs(f.path)
 	if err != nil {
 		return nil, "", fmt.Errorf("resolving token store path: %w", err)
@@ -125,6 +134,11 @@ func (f *fileStore) withFileLock(fn func() error) error {
 // directory created here is private either way, since it is new and nothing
 // else was using it.
 func (f *fileStore) ensureDir() error {
+	// Before the MkdirAll below, which would otherwise create the rejected
+	// directory on the way to reporting it.
+	if f.pathErr != nil {
+		return f.pathErr
+	}
 	dir := filepath.Dir(f.path)
 	if f.ownsDir {
 		if err := userdirs.EnsurePrivateDir(dir); err != nil {

--- a/internal/entireclient/tokenstore/file_test.go
+++ b/internal/entireclient/tokenstore/file_test.go
@@ -544,3 +544,78 @@ func TestFileBackendPath_ExplicitPathIsNotHeldToTheAbsoluteRule(t *testing.T) {
 		t.Errorf("path = %q, want the value as given", path)
 	}
 }
+
+// probeSecret is the value the relative-config-dir tests round-trip.
+const probeSecret = "secret"
+
+// resetBackendForTesting forces the next Get/Set/Delete to re-resolve the
+// backend from the environment, which is what a fresh process does. The
+// package-level backend is memoized, so without this a test inherits whatever
+// an earlier one resolved.
+func resetBackendForTesting(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		backendMu.Lock()
+		defer backendMu.Unlock()
+		backend = nil
+		resolved = false
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+// The check has to bite through the PUBLIC surface, not just the internal
+// resolver: Get/Set/Delete are what a command calls, and each of them creates
+// the directory, then a .lock, then the token file.
+//
+// The token store does open an os.Root — but on filepath.Dir of its own
+// absolutized path, one of the two bases CLAUDE.md permits to be derived, since
+// ENTIRE_TOKEN_STORE_PATH names a file the caller chose. That filepath.Abs is
+// exactly what stops the root from ever refusing a relative config dir: it
+// launders ./relative-config into a plausible absolute path first. Hence the
+// explicit check rather than relying on the root.
+func TestFileStore_PublicOpsRejectRelativeConfigDirWithoutSideEffects(t *testing.T) {
+	t.Setenv("ENTIRE_TOKEN_STORE", "file")
+	t.Setenv(PathEnvVar, "")
+	t.Setenv("ENTIRE_CONFIG_DIR", "relative-config")
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	resetBackendForTesting(t)
+
+	if err := Set("svc", "user", probeSecret); err == nil {
+		t.Error("Set() succeeded with a relative ENTIRE_CONFIG_DIR")
+	}
+	if _, err := Get("svc", "user"); err == nil {
+		t.Error("Get() succeeded with a relative ENTIRE_CONFIG_DIR")
+	}
+	if err := Delete("svc", "user"); err == nil {
+		t.Error("Delete() succeeded with a relative ENTIRE_CONFIG_DIR")
+	}
+
+	entries, readErr := os.ReadDir(cwd)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	for _, e := range entries {
+		t.Errorf("left %q behind in the working directory; bearer tokens must not land under the cwd", e.Name())
+	}
+}
+
+// An explicit ENTIRE_TOKEN_STORE_PATH is unchanged by the above: the user named
+// that file, which is the same reasoning that exempts it from the root-base
+// rule. A relative ENTIRE_CONFIG_DIR alongside it is simply irrelevant.
+func TestFileStore_ExplicitPathKeepsWorkingWithARelativeConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENTIRE_TOKEN_STORE", "file")
+	t.Setenv("ENTIRE_CONFIG_DIR", "relative-config")
+	t.Setenv(PathEnvVar, filepath.Join(dir, "tokens.json"))
+	resetBackendForTesting(t)
+
+	if err := Set("svc", "user", probeSecret); err != nil {
+		t.Fatalf("Set() with an explicit path = %v", err)
+	}
+	got, err := Get("svc", "user")
+	if err != nil || got != probeSecret {
+		t.Fatalf("Get() = %q, %v; want the explicitly named file honored", got, err)
+	}
+}

--- a/internal/entireclient/tokenstore/file_test.go
+++ b/internal/entireclient/tokenstore/file_test.go
@@ -495,3 +495,52 @@ func TestResolveBackend_OwnsDirOnlyForTheDefaultPath(t *testing.T) {
 		t.Error("custom path: ownsDir = true, want false")
 	}
 }
+
+// The token store is the fourth consumer of userdirs.Config(), and the one with
+// no root to catch a rejected override: fileStore.dir anchors on the dirname of
+// its own path (permitted, since ENTIRE_TOKEN_STORE_PATH names a file the caller
+// chose) and reaches it through filepath.Abs, which launders a relative
+// ENTIRE_CONFIG_DIR into a plausible-looking path. Left unchecked, bearer tokens
+// landed at ./<value>/tokens.json — for a CLI run from a repository, inside the
+// repository.
+func TestFileBackendPath_RejectsRelativeConfigDirWithoutTouchingDisk(t *testing.T) {
+	t.Setenv(PathEnvVar, "")
+	t.Setenv("ENTIRE_CONFIG_DIR", "relative-config")
+	t.Chdir(t.TempDir())
+
+	path, err := fileBackendPathChecked()
+	if err == nil {
+		t.Fatalf("fileBackendPathChecked() = %q, nil; want a rejected override", path)
+	}
+	if !strings.Contains(err.Error(), "ENTIRE_CONFIG_DIR") {
+		t.Errorf("error = %q, want it to name the variable the user has to change", err)
+	}
+
+	// The carried error must stop every operation before it creates anything.
+	s := &fileStore{path: path, pathErr: err, ownsDir: true}
+	if _, getErr := s.Get("svc", "user"); getErr == nil {
+		t.Error("Get() succeeded against a rejected config dir")
+	}
+	if setErr := s.Set("svc", "user", "secret"); setErr == nil {
+		t.Error("Set() succeeded against a rejected config dir")
+	}
+	if _, statErr := os.Stat("relative-config"); statErr == nil {
+		t.Error("the store created the directory it was refusing")
+	}
+}
+
+// An explicit ENTIRE_TOKEN_STORE_PATH is deliberately not held to the rule: it
+// names a file the user chose, the same reasoning that exempts it from the
+// root-base rule in CLAUDE.md.
+func TestFileBackendPath_ExplicitPathIsNotHeldToTheAbsoluteRule(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", "relative-config")
+	t.Setenv(PathEnvVar, "relative-tokens.json")
+
+	path, err := fileBackendPathChecked()
+	if err != nil {
+		t.Fatalf("fileBackendPathChecked() error = %v, want the caller's own path honored", err)
+	}
+	if path != "relative-tokens.json" {
+		t.Errorf("path = %q, want the value as given", path)
+	}
+}

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -122,14 +122,42 @@ func BackendDescription() string {
 	return keyringProviderName()
 }
 
+// tokenStoreFileName is the file backend's name inside the per-user config dir.
+const tokenStoreFileName = "tokens.json"
+
 // FileBackendPath resolves where the file backend stores (or would store)
 // tokens: PathEnvVar when set, else tokens.json in the per-user config
 // directory. Exported so user-facing guidance can name the concrete path.
+//
+// The string form cannot report a rejected override, so it returns the path it
+// would use; fileBackendPathChecked is what the store itself calls.
 func FileBackendPath() string {
+	path, _ := fileBackendPathChecked() //nolint:errcheck // see doc comment: the store reports it
+	return path
+}
+
+// fileBackendPathChecked is FileBackendPath with the override check.
+//
+// The config-directory case is checked here rather than being left to the root
+// that opens it, because there is no such root: fileStore.dir anchors on
+// filepath.Dir of this path (one of the two places CLAUDE.md permits that, since
+// PathEnvVar names a file the caller chose) and reaches it through
+// filepath.Abs. That Abs is exactly the laundering the contexts and discovery
+// roots stopped doing. Without a check here, ENTIRE_CONFIG_DIR=foo silently put
+// bearer tokens at ./foo/tokens.json, which for a CLI run from a repository
+// means inside the repository.
+//
+// PathEnvVar is deliberately NOT checked: it names a file the user chose
+// directly, the same reasoning that exempts it from the root-base rule.
+func fileBackendPathChecked() (string, error) {
 	if path := os.Getenv(PathEnvVar); path != "" {
-		return path
+		return path, nil
 	}
-	return filepath.Join(userdirs.Config(), "tokens.json")
+	dir, err := userdirs.ConfigDirChecked()
+	if err != nil {
+		return filepath.Join(dir, tokenStoreFileName), err
+	}
+	return filepath.Join(dir, tokenStoreFileName), nil
 }
 
 func resolveBackendLocked() store {
@@ -137,7 +165,12 @@ func resolveBackendLocked() store {
 		// Entire owns the directory only when it also picked it: an
 		// explicit PathEnvVar names a location the user chose, and its
 		// mode is theirs to set.
-		return &fileStore{path: FileBackendPath(), ownsDir: os.Getenv(PathEnvVar) == ""}
+		//
+		// pathErr is carried rather than resolved here: this function has no
+		// error return, and swallowing it is what put tokens in the working
+		// directory. Every operation reports it before touching the filesystem.
+		path, pathErr := fileBackendPathChecked()
+		return &fileStore{path: path, pathErr: pathErr, ownsDir: os.Getenv(PathEnvVar) == ""}
 	}
 	// Under `go test`, never fall through to the real OS keyring: a test
 	// that forgets tokenstore.UseFileBackendForTesting would otherwise write

--- a/internal/entireclient/userdirs/userdirs.go
+++ b/internal/entireclient/userdirs/userdirs.go
@@ -98,7 +98,9 @@ func configDir() (string, error) {
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		home = "."
+		// nil error deliberately: a machine with no resolvable home is not a
+		// user error to report, and ownFallbackDir returns something usable.
+		return ownFallbackDir(".config", "entire"), nil //nolint:nilerr // see ownFallbackDir
 	}
 	return filepath.Join(home, ".config", "entire"), nil
 }
@@ -118,8 +120,40 @@ func cacheDir() (string, error) {
 	if dir, ok := testdirs.Dir("cache"); ok {
 		return filepath.Join(dir, "entire"), nil
 	}
-	home, _ := os.UserHomeDir() //nolint:errcheck // best-effort default
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// See configDir: the fallback is usable, so there is nothing to report.
+		return ownFallbackDir(".cache", "entire"), nil //nolint:nilerr // see ownFallbackDir
+	}
 	return filepath.Join(home, ".cache", "entire"), nil
+}
+
+// ownFallbackDir builds the home-relative default for a machine where
+// os.UserHomeDir fails, resolved to an absolute path.
+//
+// The absolutization is the point, and it belongs HERE rather than at each
+// consumer, because this is the only place that still knows the difference
+// between a path the USER set and a path Entire made up. Both resolvers return
+// a plain string, so by the time contexts, discovery or the token store sees
+// one, a relative value looks identical either way -- and those consumers must
+// refuse a relative override, since it names a different directory in every
+// process. Refusing this one too was a regression: on a machine where
+// UserHomeDir fails (no HOME, an odd container, a service account) every
+// command that touched a saved login or a discovery cache started failing with
+// advice about an environment variable the user had never set.
+//
+// Absolutized rather than refused because it is not a user error to report:
+// there is nothing for them to fix, and a cwd-relative directory that at least
+// works beats a hard failure. It resolves against the working directory at
+// call time, which is the same tradeoff openUserRoot documented when it was
+// the only place doing this.
+func ownFallbackDir(parts ...string) string {
+	rel := filepath.Join(parts...)
+	abs, err := filepath.Abs(rel)
+	if err != nil {
+		return rel
+	}
+	return abs
 }
 
 // EnsurePrivateDir creates dir as a private, user-only directory (0700) and,

--- a/internal/entireclient/userdirs/userdirs.go
+++ b/internal/entireclient/userdirs/userdirs.go
@@ -67,13 +67,25 @@ func RequireAbsoluteOverride(name, value string) error {
 // Config returns the per-user config directory.
 //
 // The string form cannot report a rejected override, so it returns whatever was
-// set; every path that turns it into I/O opens a root over it, and both this
-// package's roots (configDir below) and the ones contexts and discovery open
-// for themselves refuse a relative directory. Callers that only display the
-// path are unaffected.
+// set. Every consumer that turns it into I/O is responsible for checking, and
+// there are four: this package's own roots, contexts, discovery, and the token
+// store. The first three open a root that refuses a relative directory; the
+// token store cannot, because it anchors on the dirname of a path the caller may
+// have named itself, so it calls ConfigDirChecked instead. An earlier version of
+// this comment listed only the middle two, and the token store was the one that
+// slipped past: bearer tokens at ./<value>/tokens.json.
+//
+// Callers that only display the path are unaffected.
 func Config() string {
-	dir, _ := configDir() //nolint:errcheck // see doc comment: the roots report it
+	dir, _ := configDir() //nolint:errcheck // see doc comment: the consumers report it
 	return dir
+}
+
+// ConfigDirChecked is Config for a caller that can report a rejected override.
+// It returns the directory in both cases, so a caller building a path for a
+// message still has one.
+func ConfigDirChecked() (string, error) {
+	return configDir()
 }
 
 // configDir is Config with the override check, for the callers that can report.

--- a/internal/entireclient/userdirs/userdirs.go
+++ b/internal/entireclient/userdirs/userdirs.go
@@ -23,31 +23,88 @@ import (
 	"github.com/entireio/cli/internal/testdirs"
 )
 
+// The environment variables that override these directories. Named rather than
+// spelled at each use, because RequireAbsoluteOverride reports them back to the
+// user and the string in the error must be the one they can set.
+const (
+	// EnvConfigDir overrides the per-user config directory.
+	EnvConfigDir = "ENTIRE_CONFIG_DIR"
+	// EnvCacheHome overrides the per-user cache directory's parent.
+	EnvCacheHome = "XDG_CACHE_HOME"
+)
+
+// RequireAbsoluteOverride rejects a non-absolute directory override.
+//
+// A relative value resolves against the process's working directory, so the
+// same environment names a different directory in every process — and, for a
+// tool run from inside a repository, typically names a directory inside it.
+// That is wrong for all three trees this rule covers. The config directory
+// holds bearer tokens (contexts.json and the file token store), the cache
+// directory holds cluster discovery state, and the managed plugin directory
+// holds binaries whose bin subdirectory main.go prepends to $PATH.
+//
+// One helper rather than one rule per tree. Every override gets it, not just
+// the Entire-specific ones: XDG_DATA_HOME, XDG_CACHE_HOME and LOCALAPPDATA were
+// joined unchecked and left for osroot (which refuses a relative root open) and
+// for main.go (which restores $PATH) to notice. Those backstops hold, but each
+// answers a question of its own, two layers from where this one is decided.
+//
+// Rejecting is louder than falling through to the platform default, and that is
+// deliberate: a misconfigured override is a user error worth surfacing, and for
+// the config directory the platform default is the developer's REAL
+// ~/.config/entire — quietly substituting it for a test harness's mistyped
+// override is the one outcome worse than an error.
+func RequireAbsoluteOverride(name, value string) error {
+	if !filepath.IsAbs(value) {
+		return fmt.Errorf("%s must be an absolute path, got %q", name, value)
+	}
+	return nil
+}
+
 // Config returns the per-user config directory.
+//
+// The string form cannot report a rejected override, so it returns whatever was
+// set; every path that turns it into I/O opens a root over it, and both this
+// package's roots (configDir below) and the ones contexts and discovery open
+// for themselves refuse a relative directory. Callers that only display the
+// path are unaffected.
 func Config() string {
-	if dir := os.Getenv("ENTIRE_CONFIG_DIR"); dir != "" {
-		return dir
+	dir, _ := configDir() //nolint:errcheck // see doc comment: the roots report it
+	return dir
+}
+
+// configDir is Config with the override check, for the callers that can report.
+func configDir() (string, error) {
+	if dir := os.Getenv(EnvConfigDir); dir != "" {
+		return dir, RequireAbsoluteOverride(EnvConfigDir, dir)
 	}
 	if dir, ok := testdirs.Dir("config"); ok {
-		return dir
+		return dir, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		home = "."
 	}
-	return filepath.Join(home, ".config", "entire")
+	return filepath.Join(home, ".config", "entire"), nil
 }
 
-// Cache returns the per-user cache directory.
+// Cache returns the per-user cache directory. See Config on the unreported
+// override.
 func Cache() string {
-	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
-		return filepath.Join(xdg, "entire")
+	dir, _ := cacheDir() //nolint:errcheck // see Config's doc comment
+	return dir
+}
+
+// cacheDir is Cache with the override check, for the callers that can report.
+func cacheDir() (string, error) {
+	if xdg := os.Getenv(EnvCacheHome); xdg != "" {
+		return filepath.Join(xdg, "entire"), RequireAbsoluteOverride(EnvCacheHome, xdg)
 	}
 	if dir, ok := testdirs.Dir("cache"); ok {
-		return filepath.Join(dir, "entire")
+		return filepath.Join(dir, "entire"), nil
 	}
 	home, _ := os.UserHomeDir() //nolint:errcheck // best-effort default
-	return filepath.Join(home, ".cache", "entire")
+	return filepath.Join(home, ".cache", "entire"), nil
 }
 
 // EnsurePrivateDir creates dir as a private, user-only directory (0700) and,
@@ -107,33 +164,47 @@ func EnsurePrivateDir(dir string) error {
 // .entire: a command that only looks for a saved login must not leave an
 // ~/.config/entire behind on a machine that has never used one.
 func ConfigRoot() (*os.Root, error) {
-	return openUserRoot(Config(), true)
+	return resolveUserRoot(configDir, true)
 }
 
 // ConfigRootForRead is ConfigRoot without creating the directory. A missing
 // directory is reported unwrapped, so callers classify it with os.IsNotExist.
 func ConfigRootForRead() (*os.Root, error) {
-	return openUserRoot(Config(), false)
+	return resolveUserRoot(configDir, false)
 }
 
 // CacheRoot returns the shared *os.Root over the per-user cache directory,
 // creating it. CacheRootForRead is the same without creation.
 func CacheRoot() (*os.Root, error) {
-	return openUserRoot(Cache(), true)
+	return resolveUserRoot(cacheDir, true)
 }
 
 // CacheRootForRead is CacheRoot without creating the directory.
 func CacheRootForRead() (*os.Root, error) {
-	return openUserRoot(Cache(), false)
+	return resolveUserRoot(cacheDir, false)
+}
+
+// resolveUserRoot fails on a rejected override before any directory is created:
+// creating one under a path that resolves against the cwd is the mistake, so it
+// must not happen on the way to reporting it.
+func resolveUserRoot(resolve func() (string, error), create bool) (*os.Root, error) {
+	dir, err := resolve()
+	if err != nil {
+		return nil, err
+	}
+	return openUserRoot(dir, create)
 }
 
 // openUserRoot absolutizes dir before handing it to the shared registry.
 //
-// Config and Cache can both return a RELATIVE path: when os.UserHomeDir fails
-// they fall back to "." and "" respectively, which join to ".config/entire" and
-// ".cache/entire". A relative root would then mean a different directory
-// depending on where the process happened to be — the same failure the repo
-// anchors exist to remove — so it is resolved once, here.
+// Config and Cache can both return a RELATIVE path even with no override in
+// play: when os.UserHomeDir fails they fall back to "." and "" respectively,
+// which join to ".config/entire" and ".cache/entire". A relative root would then
+// mean a different directory depending on where the process happened to be —
+// the same failure the repo anchors exist to remove — so it is resolved once,
+// here. That fallback is Entire's own, not something the user set, which is why
+// it is absolutized rather than refused the way RequireAbsoluteOverride refuses
+// an override.
 func openUserRoot(dir string, create bool) (*os.Root, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {

--- a/internal/entireclient/userdirs/userdirs.go
+++ b/internal/entireclient/userdirs/userdirs.go
@@ -23,9 +23,7 @@ import (
 	"github.com/entireio/cli/internal/testdirs"
 )
 
-// The environment variables that override these directories. Named rather than
-// spelled at each use, because RequireAbsoluteOverride reports them back to the
-// user and the string in the error must be the one they can set.
+// The environment variables that override these directories.
 const (
 	// EnvConfigDir overrides the per-user config directory.
 	EnvConfigDir = "ENTIRE_CONFIG_DIR"
@@ -54,6 +52,11 @@ const (
 // the config directory the platform default is the developer's REAL
 // ~/.config/entire — quietly substituting it for a test harness's mistyped
 // override is the one outcome worse than an error.
+// name is whatever the message should call the directory. Pass the environment
+// variable where the value plainly came from one, so the reader knows what to
+// change; callers a level down from the variable (contexts, discovery) pass the
+// role instead, because by then the value may equally have come from the
+// platform default.
 func RequireAbsoluteOverride(name, value string) error {
 	if !filepath.IsAbs(value) {
 		return fmt.Errorf("%s must be an absolute path, got %q", name, value)

--- a/internal/entireclient/userdirs/userdirs.go
+++ b/internal/entireclient/userdirs/userdirs.go
@@ -67,13 +67,16 @@ func RequireAbsoluteOverride(name, value string) error {
 // Config returns the per-user config directory.
 //
 // The string form cannot report a rejected override, so it returns whatever was
-// set. Every consumer that turns it into I/O is responsible for checking, and
-// there are four: this package's own roots, contexts, discovery, and the token
-// store. The first three open a root that refuses a relative directory; the
-// token store cannot, because it anchors on the dirname of a path the caller may
-// have named itself, so it calls ConfigDirChecked instead. An earlier version of
-// this comment listed only the middle two, and the token store was the one that
-// slipped past: bearer tokens at ./<value>/tokens.json.
+// set, and every consumer that turns one into I/O is responsible for learning
+// about a bad value BEFORE it creates a directory, takes a lock, or writes.
+//
+// Deliberately NOT a list of those consumers. Two successive revisions of this
+// comment enumerated them and both were wrong within a commit or two -- the
+// token store slipped past the first (bearer tokens at ./<value>/tokens.json)
+// and plugin_index past the second (an index clone and its lock file in the
+// working directory). A comment cannot fail when someone adds a caller.
+// TestUserDirConsumersAreAudited can, and does: every call site of Config() or
+// Cache() must appear in its ledger with the reason it is safe.
 //
 // Callers that only display the path are unaffected.
 func Config() string {
@@ -86,6 +89,16 @@ func Config() string {
 // message still has one.
 func ConfigDirChecked() (string, error) {
 	return configDir()
+}
+
+// CacheDirChecked is Cache for a caller that can report a rejected override.
+//
+// Needed for the same reason as its config twin: a consumer that creates a
+// directory or takes a lock before handing the path to something that opens a
+// root has to learn about a bad override BEFORE it creates anything, and the
+// string form cannot tell it. plugin_index was the consumer that needed it.
+func CacheDirChecked() (string, error) {
+	return cacheDir()
 }
 
 // configDir is Config with the override check, for the callers that can report.

--- a/internal/entireclient/userdirs/userdirs_internal_test.go
+++ b/internal/entireclient/userdirs/userdirs_internal_test.go
@@ -1,0 +1,57 @@
+package userdirs
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Item 5's fix, at the layer that owns the distinction. A user-supplied
+// override that is relative is refused; Entire's own home-failure fallback is
+// absolutized instead, because there is nothing for the user to fix and a
+// cwd-relative directory that works beats a command that does not.
+//
+// ownFallbackDir is exercised directly: os.UserHomeDir cannot be made to fail
+// portably from a test (Windows consults the API, not $HOME) and testdirs
+// intercepts the fallback under `go test` anyway, so the resolver's branch is
+// unreachable in-process. What matters is the property, which is that the
+// fallback it returns is absolute.
+func TestOwnFallbackDir_IsAbsoluteSoConsumersAccept(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	got := ownFallbackDir(".config", "entire")
+	if !filepath.IsAbs(got) {
+		t.Fatalf("ownFallbackDir() = %q, want an absolute path: every consumer refuses a "+
+			"relative directory, and refusing Entire's own fallback broke every command "+
+			"that touches a saved login on a machine with no resolvable home", got)
+	}
+	if want := filepath.Join(cwd, ".config", "entire"); got != want {
+		t.Errorf("ownFallbackDir() = %q, want %q", got, want)
+	}
+	// It must satisfy the very check the consumers apply.
+	if err := RequireAbsoluteOverride("config dir", got); err != nil {
+		t.Errorf("the fallback must pass the consumers' own check, got %v", err)
+	}
+}
+
+// The distinction is not softened: a relative value the USER set is still
+// refused, in both variables.
+func TestRelativeUserOverridesAreStillRefused(t *testing.T) {
+	for _, tc := range []struct{ env, val string }{
+		{EnvConfigDir, "relative-config"},
+		{EnvCacheHome, "relative-cache"},
+	} {
+		t.Run(tc.env, func(t *testing.T) {
+			t.Setenv(tc.env, tc.val)
+			var err error
+			if tc.env == EnvConfigDir {
+				_, err = configDir()
+			} else {
+				_, err = cacheDir()
+			}
+			if err == nil {
+				t.Fatalf("%s=%q was accepted; a user override must be absolute", tc.env, tc.val)
+			}
+		})
+	}
+}

--- a/internal/entireclient/userdirs/userdirs_test.go
+++ b/internal/entireclient/userdirs/userdirs_test.go
@@ -143,3 +143,57 @@ func TestEnsurePrivateDir_PreservesOwnerBitsWhileTightening(t *testing.T) {
 		t.Errorf("mode = %04o, want 0500 (group/other cleared, owner untouched)", got)
 	}
 }
+
+// A relative override resolves against the working directory, so the same
+// environment names a different directory in every process. For the config
+// directory that directory holds bearer tokens, and it is usually inside
+// whatever repository the command was run from.
+func TestRequireAbsoluteOverride(t *testing.T) {
+	t.Parallel()
+
+	abs := "/tmp/absolute"
+	if runtime.GOOS == goosWindows {
+		abs = `C:\tmp\absolute`
+	}
+	if err := userdirs.RequireAbsoluteOverride("ENTIRE_CONFIG_DIR", abs); err != nil {
+		t.Errorf("RequireAbsoluteOverride(%q) = %v, want nil", abs, err)
+	}
+
+	for _, value := range []string{"relative/dir", ".", "", "./cfg"} {
+		err := userdirs.RequireAbsoluteOverride("ENTIRE_CONFIG_DIR", value)
+		if err == nil {
+			t.Errorf("RequireAbsoluteOverride(%q) = nil, want an error", value)
+			continue
+		}
+		// The name has to be the one the user can set, or the message tells
+		// them nothing actionable.
+		if !strings.Contains(err.Error(), "ENTIRE_CONFIG_DIR") {
+			t.Errorf("RequireAbsoluteOverride(%q) error = %q, want it to name the variable", value, err)
+		}
+	}
+}
+
+// The string forms cannot report, so the roots are where the refusal has to
+// land — and it must land before the directory is created, since creating one
+// under a cwd-relative path is the mistake being reported.
+func TestConfigRoot_RefusesRelativeOverride(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", "relative-config")
+
+	if _, err := userdirs.ConfigRoot(); err == nil {
+		t.Fatal("ConfigRoot() = nil error, want a rejected override")
+	}
+	if _, err := os.Stat("relative-config"); err == nil {
+		t.Error("ConfigRoot() created the directory it was refusing")
+	}
+}
+
+func TestCacheRoot_RefusesRelativeOverride(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", "relative-cache")
+
+	if _, err := userdirs.CacheRoot(); err == nil {
+		t.Fatal("CacheRoot() = nil error, want a rejected override")
+	}
+	if _, err := os.Stat("relative-cache"); err == nil {
+		t.Error("CacheRoot() created the directory it was refusing")
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1262
<!-- entire-trail-link-end -->

Five hardening changes at Entire's remaining un-anchored edges, plus two ratchets
that keep the resulting invariants enforced rather than documented. Each commit
stands alone; they are batched because they came out of one review pass.

## Hardening

**Git hook installation is now rooted.** It was the last tree Entire touched with
bare `os.ReadFile`/`os.WriteFile` on a joined path. Installation now anchors a
root on git's own `--git-path hooks` answer (refusing a symlink at the directory
itself), reads through `osroot.ReadFileNoFollow`, and writes via
`jsonutil.WriteFileAtomicIn`, whose rename replaces a leaf link instead of
following it. A symlinked hook is treated as *foreign*: backed up to
`<hook>.pre-entire` and chained to, exactly as a foreign script is. `doctor`
grows `checkGitHookSymlinks`, since a symlinked hooks directory otherwise just
looks like "hooks absent".

**External summary-provider discovery now respects the `external_agents` grant.**
`discoverSummaryProviderIfMissing` resolves an unregistered
`summary_generation.provider` by running `entire-agent-<name> info`; that lookup
is now gated on `settings.IsExternalAgentsEnabled`, consistent with every other
external-plugin exec. The gate sits after the already-registered early return, so
a committed `"provider": "claude-code"` keeps working with external agents off
Two tests that granted the flag from the committed project file — which the trust
gate has never honoured — now grant it from the untracked local layer.

**Branch names are validated in all three helpers that took one on trust.**
`BranchExistsOnRemote`, `BranchExistsLocally` and `CheckoutBranch` now run
`ValidateBranchName`, replacing `CheckoutBranch`'s leading-dash guard, which
covered less than `git checkout` actually reads (`--`, a pathspec, `@{-1}`).
Validating both existence helpers keeps their answers symmetric — they are cal
side by side on the same name.

**One absolute-override rule now covers every per-user directory.**
`userdirs.RequireAbsoluteOverride` replaces the plugin-local copy and extends
rule to `ENTIRE_CONFIG_DIR` and `XDG_CACHE_HOME`, which redirect the config and
cache trees. `Config()`/`Cache()` keep their string signatures, so the refusal
lands at the roots: `resolveUserRoot`, `contexts.configRoot` and
`discovery.cacheFile.root`. The last two no longer run `filepath.Abs` on the
override first. Rejecting beats falling back to the platform default — for the
config directory that default is the developer's real `~/.config/entire`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches git hook install/removal, symlink-following policy, external binary discovery, and checkout behavior—security-sensitive paths where mistakes cause data loss or unintended execution.
> 
> **Overview**
> This PR tightens several filesystem and execution boundaries and adds machinery so those rules stay enforced in CI.
> 
> **Symlinked agent config directories** can be opted into via `allow_symlinked_agent_dirs` in untracked `.entire/settings.local.json`. Settings load applies the same trust gate as `external_agents`, installs a worktree-scoped policy (`SetVouchedSymlinkedDirs` / `OpenAnchoredRoot`), and `HookConfigFile` now separates worktree-relative vs root-relative paths so `RemoveDir` and pi uninstall work when a vouched link is followed. Doctor/status report followed vs refused links and continue scanning beneath vouched dirs.
> 
> **Git hooks** are treated as a rooted tree (install vs removal asymmetry for symlinked hook dirs), with `doctor` reporting symlinked hook directories and managed hook files. **Summary providers**: named external discovery in `discoverSummaryProviderIfMissing` requires the `external_agents` grant; auto-selected externals are not persisted without that grant. **Git checkout/branch helpers** validate branch names consistently and `CheckoutBranch` uses a trailing `--` to avoid silent pathspec restores. **Per-user dir overrides** funnel through `userdirs.RequireAbsoluteOverride` (including plugin index cache).
> 
> **Source guard tests** share `testutil.GitGrepGuard` (`--untracked`, `--no-color`, repo env scrubbing); new/updated guards cover hook-config coverage, transcript-read ratchet, git-status `--no-optional-locks`, and root-base allowlists. **CLAUDE.md** documents these invariants at length.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c35f7606d8396c75d496754e1dfc1bf4ec0a8d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->