### PR TITLE
fix(auth): say what auth use --context NAME did instead of "received 0"

### DIFF
--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/internal/entireclient/contexts"
@@ -36,7 +37,7 @@ func newAuthUseCmd() *cobra.Command {
 			"Activity/search/dispatch take their host from ENTIRE_API_BASE_URL; trail\n" +
 			"commands route to the repository's owning cell. The selected context\n" +
 			"supplies the identity.",
-		Args:              cobra.ExactArgs(1),
+		Args:              authUseArgs,
 		ValidArgsFunction: completeContextNames,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := auth.SetCurrentContext(args[0]); err != nil {
@@ -46,6 +47,36 @@ func newAuthUseCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// authUseArgs validates `auth use <context>`, and treats the one mistake this
+// command's shape invites as its own case: `entire auth use --context NAME`.
+//
+// The two spellings mean nearly opposite things. `auth use` takes the context
+// as a positional and writes it to contexts.json for every later command,
+// while the global `--context` selects a login for the current invocation only
+// — and on `auth use` it selects nothing at all, since switching the active
+// context authenticates against nothing. So the flag reads like the obvious
+// way to name a context and is not: cobra binds NAME to the flag, no
+// positional is left, and cobra.ExactArgs(1) answers "accepts 1 arg(s),
+// received 0" about an argument the user plainly did type. Nothing is
+// switched, which the generic message also fails to say.
+//
+// The check is scoped to the zero-positional case on purpose. With a
+// positional present the flag is a harmless no-op, and rejecting it would
+// break anyone whose shell alias passes `--context` to every entire command.
+func authUseArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		if f := cmd.Flags().Lookup("context"); f != nil && f.Changed {
+			if name := strings.TrimSpace(f.Value.String()); name != "" {
+				return fmt.Errorf("--context %s acts as that login for one command; it does not switch the active context.\n"+
+					"To switch, name the context as an argument:\n\n  entire auth use %s", name, name)
+			}
+		}
+	}
+	// Cobra's arg-count message, returned verbatim: main.isPositionalArgError
+	// keys on its "arg(s)" to print this command's usage alongside it.
+	return cobra.ExactArgs(1)(cmd, args)
 }
 
 // completeContextNames is the ValidArgsFunction for commands taking a single

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -301,3 +301,103 @@ func TestPromoteNextLogin(t *testing.T) {
 		t.Fatalf("expected a context to be promoted to current (current=%q, err=%v)", current, err)
 	}
 }
+
+// authUseTestRoot builds the smallest tree that reproduces the flag collision:
+// a root carrying the global --context flag, with `auth use` under it. It is
+// deliberately not NewRootCmd(), whose PersistentPreRunE would validate
+// .entire and open a logger for an argument-parsing test.
+//
+// Parsing --context writes contexts.SetFlagOverride process-wide, so callers
+// must not be parallel; SetFlagOverrideForTest restores the prior selection.
+func authUseTestRoot(t *testing.T) *cobra.Command {
+	t.Helper()
+	contexts.SetFlagOverrideForTest(t, "")
+
+	var out bytes.Buffer
+	root := &cobra.Command{Use: "entire", SilenceErrors: true, SilenceUsage: true}
+	addContextFlag(root)
+	authCmd := &cobra.Command{Use: "auth"}
+	authCmd.AddCommand(newAuthUseCmd())
+	root.AddCommand(authCmd)
+	root.SetOut(&out)
+	root.SetErr(&out)
+	return root
+}
+
+// TestAuthUse_ContextFlagInsteadOfArgument pins the fix for the misleading
+// error: `entire auth use --context NAME` binds NAME to the global --context
+// flag, leaving no positional, and cobra's ExactArgs(1) then reported
+// "accepts 1 arg(s), received 0" about an argument the user did type. The
+// message must name the flag, say it does not switch, and show the working
+// command.
+func TestAuthUse_ContextFlagInsteadOfArgument(t *testing.T) {
+	root := authUseTestRoot(t)
+	root.SetArgs([]string{"auth", "use", "--context", "eu.auth.entire.io"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected an error: --context does not switch the active context")
+	}
+	msg := err.Error()
+	for _, want := range []string{"--context", "does not switch", "entire auth use eu.auth.entire.io"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message is missing %q:\n%s", want, msg)
+		}
+	}
+	// main.isPositionalArgError keys on "arg(s)" to decide whether to dump the
+	// command's usage. This message explains itself, so it must not match.
+	if strings.Contains(msg, "arg(s)") {
+		t.Errorf("message would be treated as a cobra arg-count error and buried under usage:\n%s", msg)
+	}
+}
+
+// TestAuthUse_MissingArgumentKeepsArgCountError pins the other half: with no
+// --context in play, a bare `entire auth use` is a plain arg-count mistake and
+// must keep cobra's message, so main.go still shows the command's usage.
+func TestAuthUse_MissingArgumentKeepsArgCountError(t *testing.T) {
+	root := authUseTestRoot(t)
+	root.SetArgs([]string{"auth", "use"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected an error: auth use takes a context name")
+	}
+	if !strings.Contains(err.Error(), "arg(s)") {
+		t.Errorf("want cobra's arg-count error so usage is shown, got:\n%s", err)
+	}
+}
+
+// TestAuthUse_BlankContextFlagKeepsArgCountError covers `--context "  "`, which
+// names no context: there is nothing to suggest, so the generic arg-count
+// error is the honest answer.
+func TestAuthUse_BlankContextFlagKeepsArgCountError(t *testing.T) {
+	root := authUseTestRoot(t)
+	root.SetArgs([]string{"auth", "use", "--context", "  "})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected an error: auth use takes a context name")
+	}
+	if !strings.Contains(err.Error(), "arg(s)") {
+		t.Errorf("want cobra's arg-count error, got:\n%s", err)
+	}
+}
+
+// TestAuthUseArgs_AcceptsNamedContextAlongsideFlag pins that the new check is
+// scoped to the zero-positional case. `entire --context X auth use Y` still
+// validates: --context does nothing on a command that only writes
+// contexts.json, but rejecting it would break anyone whose shell alias always
+// passes it.
+func TestAuthUseArgs_AcceptsNamedContextAlongsideFlag(t *testing.T) {
+	root := authUseTestRoot(t)
+	use, _, err := root.Find([]string{"auth", "use"})
+	if err != nil {
+		t.Fatalf("find auth use: %v", err)
+	}
+	if err := use.ParseFlags([]string{"--context", "eu.auth.entire.io"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := use.Args(use, []string{"us.auth.entire.io"}); err != nil {
+		t.Errorf("want the named context accepted, got: %v", err)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1263
<!-- entire-trail-link-end -->

This draft pull request was opened by [Entire](https://entire.io) after CI was requested for the linked trail. Feel free to edit the title or body — the link above is what keeps the trail and PR connected.

<!-- entire-shadow-pr -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only argument validation and error text for `auth use`; no auth, persistence, or network behavior changes beyond clearer failures.
> 
> **Overview**
> **`entire auth use`** now uses a custom argument validator instead of plain `cobra.ExactArgs(1)` so a common mistake gets a clear error instead of *accepts 1 arg(s), received 0*.
> 
> When someone runs **`entire auth use --context NAME`** with no positional, the CLI explains that **`--context`** only applies identity for a single invocation and does **not** persistently switch the active login, and shows the correct form: **`entire auth use NAME`**. The custom message deliberately avoids Cobra’s *arg(s)* wording so **`main`** does not treat it as a positional-arg error and dump usage on top.
> 
> Bare **`entire auth use`**, whitespace-only **`--context`**, and **`entire --context X auth use Y`** (positional present) still behave as before—generic arg-count errors or normal validation. Tests cover the new message, usage behavior, and the alias-friendly flag+positional case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092aa8def881b3772e9d850f796a106dd835e299. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->