### PR TITLE
interactive: treat Cursor and opencode shell tools as non-interactive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,7 +389,14 @@ Tests that spawn the real `entire` or `git` binary need the child to be non-inte
 
 1. `ENTIRE_TEST_TTY=1` → force interactive ON (any other non-empty value → force OFF).
 2. `testing.Testing()` → false. In-process `go test` runs are non-interactive by default; no per-test `t.Setenv("ENTIRE_TEST_TTY", "0")` is needed.
-3. Agent sentinels (`GEMINI_CLI`, `COPILOT_CLI`, `PI_CODING_AGENT`, `GIT_TERMINAL_PROMPT=0`) → false.
+3. Agent sentinels → false. `interactive.agentSubprocessEnvVars` is the single
+   source of truth for the presence-checked ones (`COPILOT_CLI`, `CURSOR_AGENT`,
+   `GEMINI_CLI`, `OPENCODE`, `PI_CODING_AGENT`) — the function reads it and the
+   tests both enumerate and clear it, so adding a vendor is a one-line change.
+   `GIT_TERMINAL_PROMPT=0` stays separate because only that exact value counts.
+   `CLAUDECODE` is deliberately not a sentinel: Claude Code sets it, but adding
+   it withdraws prompts from the largest agent population at once, which is a
+   product decision rather than a detection fix.
 4. `CI=<non-empty-non-false>` → false.
 5. `/dev/tty` probe, plus its terminal mode → a terminal held in raw mode
    (canonical input off) belongs to a full-screen TUI that spawned us, not to a

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -71,18 +71,43 @@ func UnderTest() bool {
 	return testing.Testing() || os.Getenv(EnvTestTTY) != ""
 }
 
+// agentSubprocessEnvVars are vendor-set variables that mark a process spawned
+// by an agent's shell tool or hook runner. Presence alone is the signal —
+// vendors spell the value differently ("1", "true"), so only an empty or unset
+// value means absent.
+//
+// This is the single source of truth for the list: isAgentSubprocessEnv reads
+// it, and the tests both enumerate it and clear it. Adding a name here is the
+// whole change.
+//
+//   - CLAUDECODE is deliberately absent. Claude Code sets it to 1 in its tool
+//     subprocesses, so it could join this list, but doing so withdraws every
+//     interactive prompt from the largest agent population at once. That is a
+//     product call, not a detection fix.
+var agentSubprocessEnvVars = []string{
+	"COPILOT_CLI",     // Copilot CLI hook subprocesses (v0.0.421+)
+	"CURSOR_AGENT",    // cursor-agent shell tool; set alongside CURSOR_CONVERSATION_ID
+	"GEMINI_CLI",      // Gemini CLI shell tool (https://geminicli.com/docs/tools/shell/)
+	"OPENCODE",        // set on opencode's own process, so every child inherits it
+	"PI_CODING_AGENT", // Pi Coding Agent shell tool
+}
+
 // isAgentSubprocessEnv reports whether the env indicates we're running inside
 // an agent subprocess that inherited a TTY but can't respond to prompts:
-//   - GEMINI_CLI=1: Gemini CLI shell tool (https://geminicli.com/docs/tools/shell/)
-//   - COPILOT_CLI=1: Copilot CLI hook subprocesses (v0.0.421+)
-//   - PI_CODING_AGENT=true: Pi Coding Agent shell tool
-//   - GIT_TERMINAL_PROMPT=0: caller (CI, Factory AI Droid, etc.) asked git
-//     to stop prompting; respect it from git-hook context too.
+// either one of agentSubprocessEnvVars is set, or GIT_TERMINAL_PROMPT=0 —
+// the caller (CI, Factory AI Droid, etc.) asked git to stop prompting, and we
+// respect it from git-hook context too.
+//
+// GIT_TERMINAL_PROMPT stays outside the list because its semantics differ: it
+// is a tri-state the user may legitimately set to "1", so only the exact value
+// "0" counts, where the others are presence checks.
 func isAgentSubprocessEnv() bool {
-	return os.Getenv("GEMINI_CLI") != "" ||
-		os.Getenv("COPILOT_CLI") != "" ||
-		os.Getenv("PI_CODING_AGENT") != "" ||
-		os.Getenv("GIT_TERMINAL_PROMPT") == "0"
+	for _, name := range agentSubprocessEnvVars {
+		if os.Getenv(name) != "" {
+			return true
+		}
+	}
+	return os.Getenv("GIT_TERMINAL_PROMPT") == "0"
 }
 
 // IsTerminalReader reports whether r is an *os.File backed by a terminal.

--- a/cmd/entire/cli/interactive/interactive_test.go
+++ b/cmd/entire/cli/interactive/interactive_test.go
@@ -40,20 +40,37 @@ func TestCanPromptInteractively_CIFalseOverride(t *testing.T) {
 	}
 }
 
+// Every name in agentSubprocessEnvVars must be honored. Driving the table off
+// the slice rather than a hand-copied list is what makes adding a sentinel a
+// one-line change that is still covered.
 func TestIsAgentSubprocessEnv(t *testing.T) {
-	cases := []struct {
-		name, key, val string
-	}{
-		{"gemini", "GEMINI_CLI", "1"},
-		{"copilot", "COPILOT_CLI", "1"},
-		{"pi", "PI_CODING_AGENT", "true"},
-		{"git-terminal-prompt-off", "GIT_TERMINAL_PROMPT", "0"},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			t.Setenv(c.key, c.val)
+	for _, name := range agentSubprocessEnvVars {
+		t.Run(name, func(t *testing.T) {
+			clearAgentSubprocessEnv(t)
+			t.Setenv(name, "1")
 			if !isAgentSubprocessEnv() {
-				t.Errorf("isAgentSubprocessEnv() = false; want true when %s=%s", c.key, c.val)
+				t.Errorf("isAgentSubprocessEnv() = false; want true when %s=1", name)
+			}
+		})
+	}
+	t.Run("git-terminal-prompt-off", func(t *testing.T) {
+		clearAgentSubprocessEnv(t)
+		t.Setenv("GIT_TERMINAL_PROMPT", "0")
+		if !isAgentSubprocessEnv() {
+			t.Error("isAgentSubprocessEnv() = false; want true when GIT_TERMINAL_PROMPT=0")
+		}
+	})
+}
+
+// A vendor may spell the value however it likes — pi uses "true", the rest use
+// "1" — so presence is the whole test. Only the git tri-state reads its value.
+func TestIsAgentSubprocessEnv_AnyNonEmptyValueCounts(t *testing.T) {
+	for _, val := range []string{"1", "true", "0", "no"} {
+		t.Run(val, func(t *testing.T) {
+			clearAgentSubprocessEnv(t)
+			t.Setenv("PI_CODING_AGENT", val)
+			if !isAgentSubprocessEnv() {
+				t.Errorf("isAgentSubprocessEnv() = false; want true when PI_CODING_AGENT=%s", val)
 			}
 		})
 	}
@@ -62,15 +79,24 @@ func TestIsAgentSubprocessEnv(t *testing.T) {
 // GIT_TERMINAL_PROMPT only counts when explicitly set to "0". Other values
 // (or absence) shouldn't trigger the guard.
 func TestIsAgentSubprocessEnv_GitTerminalPromptOnIsNotAgent(t *testing.T) {
-	// Clear sibling agent-detection vars so the test is hermetic regardless of
-	// parent environment (e.g. running inside pi, gemini-cli, copilot-cli).
-	t.Setenv("GEMINI_CLI", "")
-	t.Setenv("COPILOT_CLI", "")
-	t.Setenv("PI_CODING_AGENT", "")
+	clearAgentSubprocessEnv(t)
 	t.Setenv("GIT_TERMINAL_PROMPT", "1")
 	if isAgentSubprocessEnv() {
 		t.Error("isAgentSubprocessEnv() = true; want false when GIT_TERMINAL_PROMPT=1")
 	}
+}
+
+// clearAgentSubprocessEnv unsets every sentinel so a test states its own
+// preconditions rather than inheriting them. `mise run test` is routinely run
+// from inside one of these agents, and a sentinel left set by the parent turns
+// the negative assertions into false failures — the reason this clears the
+// slice instead of a hand-listed subset that would rot on the next addition.
+func clearAgentSubprocessEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range agentSubprocessEnvVars {
+		t.Setenv(name, "")
+	}
+	t.Setenv("GIT_TERMINAL_PROMPT", "")
 }
 
 func TestUnderTest_TrueByTestingHarness(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1264
<!-- entire-trail-link-end -->

## What

Adds `CURSOR_AGENT` and `OPENCODE` to the agent sentinels that make `interactive.CanPromptInteractively()` return false, and collapses the sentinel list into one slice.

Cursor's shell tool sets `CURSOR_AGENT=1` in the child env; opencode sets `OPENCODE=1` on its own process, so every child inherits it. Neither was a sentinel, so an `entire` command run by either agent fell through to the `CI` check and the `/dev/tty` probe — and could still put up a prompt nobody is there to answer. Gemini, Copilot CLI and pi have been handled since their integrations landed; these two were simply missed.

## How it was established

Not inferred from names. I ran each agent headless with an `env` dump and diffed against a baseline, and cross-checked the source:

- **opencode** adds exactly three vars — `AGENT=1`, `OPENCODE=1`, `OPENCODE_PID=<pid>` — set at `packages/opencode/src/index.ts:77`. Its V2 core bash tool adds no env of its own (there is an explicit `// TODO: Add plugin shell.env environment augmentation once V2 plugin hooks exist` at `packages/core/src/tool/bash.ts:70`), so the child simply inherits opencode's process env.
- **Cursor**'s bundled shell-tool spawn builds `{CURSOR_AGENT:"1"}` and then conditionally adds `CURSOR_CONVERSATION_ID` and `AGENT_TRANSCRIPTS`. (`cursor-agent` would not authenticate on my machine, so this one is source-derived rather than run — the var is set unconditionally in that spawn path, so I'm confident, but a live confirmation from anyone with a working `cursor-agent` login is welcome.)

## Why the list moved into a slice

It was spelled in four places, and one was a rot trap. `TestIsAgentSubprocessEnv_GitTerminalPromptOnIsNotAgent` hand-cleared three sentinels to stay hermetic "regardless of parent environment (e.g. running inside pi, gemini-cli, copilot-cli)" — so adding a fourth sentinel *without* also adding it to that clear list makes `mise run test` fail for anyone running it from inside the newly-detected agent. Green on CI, red on the contributor's machine.

`agentSubprocessEnvVars` is now the single source of truth: the function iterates it, the positive test enumerates it, and the clear helper unsets it. Adding a vendor is a one-line change that stays covered and stays hermetic. Verified by running the suite with `OPENCODE=1 CURSOR_AGENT=1` set.

## Deliberately not included

- **bare `AGENT`** — opencode sets it, but the name is generic enough that unrelated tooling would trip the guard, and a false positive here silently removes prompts a human wanted.
- **`CLAUDECODE`** — a real Claude Code sentinel, and it would work. Left out because adopting it withdraws every interactive prompt from the largest agent population in one step; that is a product decision, not a detection fix. Called out in a comment so the next reader doesn't think it was an oversight.
- **`GIT_TERMINAL_PROMPT`** stays outside the slice: it is a tri-state where only the exact value `0` counts, while the others are presence checks.

## Behavior change

In Cursor and opencode subprocesses, prompts that previously *might* have appeared (only when a `/dev/tty` was inherited and not held in raw mode) now consistently do not. That is the same treatment the other agents already get, and it is the intended direction — an agent cannot answer a `huh` form.

## Context

Fell out of investigating a report where an agent in a worktree ran `entire session current` to find "its own" session id and then `entire session adopt`. `session current` answers "most recently active session in this store", not "the session calling me", and silently falls back across worktrees. That is the larger fix (a caller-identity resolver built on these env vars plus `proclive` ancestry); this PR is just the low-hanging half that stands on its own.

## Test plan

- `mise run fmt && mise run lint` — clean
- `mise run test:ci` — passes (unit + integration + Vogon canary)
- `GOOS=windows go vet ./cmd/entire/cli/interactive/...` — clean
- `OPENCODE=1 CURSOR_AGENT=1 go test ./cmd/entire/cli/interactive/` — passes, confirming the hermeticity fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change to TTY/prompt gating in the interactive package; behavior narrows prompts in two agent environments and improves test hermeticity without touching auth, data, or git writes.
> 
> **Overview**
> **Cursor** and **opencode** subprocesses now count as agent contexts where `CanPromptInteractively()` returns false, using `CURSOR_AGENT` and `OPENCODE` env sentinels (presence-only, any non-empty value).
> 
> Agent detection is centralized in `agentSubprocessEnvVars`: `isAgentSubprocessEnv()` iterates the slice, tests enumerate and clear it via `clearAgentSubprocessEnv`, and `CLAUDE.md` documents the list. **`GIT_TERMINAL_PROMPT=0`** stays a separate exact-value check; **`CLAUDECODE`** is intentionally excluded (documented as a product choice).
> 
> Net effect: `entire` commands run from Cursor’s shell tool or opencode no longer fall through to `/dev/tty` and risk blocking on huh/confirm prompts agents cannot answer—matching Gemini, Copilot CLI, and Pi.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe7edeb217d9ec64bef4f9f6073939b11401b3e2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->