### PR TITLE
session: resolve the session running the command, not the one that moved last

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -761,6 +761,12 @@ narrower: naming a session ancestry *cannot* rank — one whose owner was never
 recorded (no turn yet), or any session on a platform that cannot introspect
 processes.
 
+`session tokens` preserves this provenance in its JSON `resolution` field and
+in text/agent-brief `Resolved:` lines (omitted for an explicit session ID).
+Ambiguous matches warn on stderr before recommendations are printed. Untracked
+callers reuse `session current`'s diagnostic; JSON and agent-brief modes leave
+stdout empty and exit non-zero rather than emitting a token report.
+
 **`caller-ambiguous` is a third outcome of that tier, and it does not satisfy
 `IsCaller()`.** The rule (`claimsRuledOut`) is that **the winner is believed
 only when no session the environment named could be nearer to us than it is.**
@@ -799,8 +805,8 @@ which states an arbitrary pick as the answer when several untracked claims
 exist. It now says which sessions claim it and that the caller could not be
 determined; the diagnosis survives, the identification does not.
 
-**Tier 4 is why this exists.** `entire session current` used to collapse tiers
-3 and 4 and describe either as "the active session for the current worktree".
+**Tier 3 is why this exists.** `entire session current` used to collapse tiers
+2 and 3 and describe either as "the active session for the current worktree".
 Worktrees share one session store, so in a worktree with no sessions of its own
 it returned a live session belonging to a *different* worktree —
 indistinguishably from a real answer, with that worktree's path in the JSON.
@@ -810,7 +816,7 @@ a wrong ID there mutates a third party's running session. The tier still
 exists, because "what has been happening in this repo" is a real question — it
 just has to say that is what it answered. `SessionResolution.IsCaller()` is the
 gate for anything that *acts* on a session rather than displaying it; only
-tiers 1 and 2 pass.
+tier 1 passes, and then only when it resolves to `caller-env` or `ancestry`.
 
 **`IsCaller()` currently guards nothing, and that is the open half of this
 work.** `session adopt` — the command whose damage motivated the tiering, since

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,9 @@ the commands are always runnable in every build.
   `adopt` moves an active session from another repo or worktree into the current
   worktree and resets target-local checkpoint bookkeeping so future commits link
   to the adopted session from the new location.
+  `current` and a bare `tokens` answer "which session is running this command?"
+  through `strategy.ResolveCallerSession`, not "which state file moved last" —
+  see [Resolving the calling session](#resolving-the-calling-session).
 - `checkpoint` (aliases: `cp`, `checkpoints`): `list`, `explain`, `tokens`, `search`.
   `explain` also takes `--repo <owner/name>`, the drill-down for a cross-repo
   `search` hit: it reads the checkpoint from that repo's entire-api cell over
@@ -730,6 +733,157 @@ group's `PersistentPreRunE` — ahead of doctor's own `PreRunE`, which loads
 redaction settings from `.entire/settings.json`, and ahead of `doctor logs` /
 `doctor bundle`, which read `.entire/logs` — prints the diagnosis, and stops. It
 does not auto-fix: what occupies the path may be someone's data.
+
+### Resolving the calling session
+
+`strategy.ResolveCallerSession` answers "which session is running this
+process?", degrading to "which session is current here?" only when nothing can
+identify the caller. Tiers, strongest first, each reported back as
+`SessionResolution`:
+
+1. **Identification** — the environment and process ancestry ranked
+   *together*, reporting `caller-env`, `ancestry`, or `caller-ambiguous`.
+2. **`worktree`** — the most recently active session recorded in this worktree.
+3. **`other-worktree`** — this worktree has no sessions at all, so the most
+   recent one from anywhere in the shared store.
+
+**Environment and ancestry are one tier, and a nearer owner outranks an
+environment claim.** They were two tiers, environment first, returning on any
+hit — which is wrong for nesting: an inner agent that publishes no ID of its
+own (Gemini CLI, opencode) forwards the OUTER agent's variable straight
+through, so the only claim named the outer session while the inner one sat one
+hop away in our ancestry. The resolver reported the outer session as
+`caller-env` and `IsCaller()` true — "safe to act on" — which is exactly the
+mistake the type exists to prevent. Depth is the only signal that separates
+"Codex ran me" from "Codex ran Gemini ran me", so the nearest owner wins
+wherever ancestry can rank at all. The environment's remaining job is real and
+narrower: naming a session ancestry *cannot* rank — one whose owner was never
+recorded (no turn yet), or any session on a platform that cannot introspect
+processes.
+
+**`caller-ambiguous` is a third outcome of that tier, and it does not satisfy
+`IsCaller()`.** The rule (`claimsRuledOut`) is that **the winner is believed
+only when no session the environment named could be nearer to us than it is.**
+A claim reached our environment, so its agent is certainly somewhere in our
+ancestry; what is unknown is where. A claim we could not place — untracked, so
+no owner to compare, or tracked with no owner recorded yet — therefore sits at
+an unmeasured depth, and unmeasured means possibly nearer. Exactly two
+exemptions: a winner at depth 0 owns our immediate parent, so nothing can be
+nearer; and a claim that IS the winner shadows nothing, which is the ordinary
+single-agent shape.
+
+Three revisions of this rule were wrong in review, each in the same direction —
+overclaiming identification — and the sequence is worth knowing because the
+next attempt will be tempted by the same shortcut:
+
+1. Environment first, returning on any hit. Wrong for nesting: the lone claim
+   named the *outer* session while the inner one sat a hop away in ancestry.
+2. Ambiguous only when several claims went unplaced. Missed the mixed case:
+   only sessions with state enter the ranking, so a tracked outer session won
+   by default while an untracked inner claim was never examined.
+3. Exempting "exactly one claim", on the reasoning that a lone claim has
+   nothing to be nearer than. True of a lone claim that *wins* — and the
+   revision assumed those were the same thing. A claim with no state cannot
+   enter the ranking at all, so a session found purely by ancestry won instead
+   and was reported as identified while the claim naming itself in our own
+   environment went unexamined.
+
+**Do not reintroduce a count-based exemption.** The question is about the
+winner, not about how many claims exist. The reported session is still the most
+useful of the candidates (a tracked one over an ID Entire knows nothing about);
+what the resolution says is whether it was identified or guessed.
+
+**The command must not narrate a guess as a fact either.** `session current`'s
+untracked diagnostic used to say "This command is running inside X session Y",
+which states an arbitrary pick as the answer when several untracked claims
+exist. It now says which sessions claim it and that the caller could not be
+determined; the diagnosis survives, the identification does not.
+
+**Tier 4 is why this exists.** `entire session current` used to collapse tiers
+3 and 4 and describe either as "the active session for the current worktree".
+Worktrees share one session store, so in a worktree with no sessions of its own
+it returned a live session belonging to a *different* worktree —
+indistinguishably from a real answer, with that worktree's path in the JSON.
+Agents read the ID back and fed it to `entire session adopt`, which moves the
+named session into the current worktree and resets its checkpoint bookkeeping:
+a wrong ID there mutates a third party's running session. The tier still
+exists, because "what has been happening in this repo" is a real question — it
+just has to say that is what it answered. `SessionResolution.IsCaller()` is the
+gate for anything that *acts* on a session rather than displaying it; only
+tiers 1 and 2 pass.
+
+**`IsCaller()` currently guards nothing, and that is the open half of this
+work.** `session adopt` — the command whose damage motivated the tiering, since
+it moves a session and resets its checkpoint bookkeeping — does not consult it.
+Its own checks are narrower than a most-recent guess (an explicit `--from`, and
+auto-selection scoped to that worktree's recent adoptable sessions) but none of
+them asks "is this session mine": `sessionBelongsToSourceWorktree` only checks
+that the ID and the worktree agree with each other, which the weak tiers'
+output satisfies by construction. Reaching it does not even need `session
+current`, since `adopt --from <path>` with one recent session there
+auto-adopts. Wiring the guard is a separate change with its own question to
+settle — what "mine" means for a `--from` on another machine, where ancestry
+cannot apply.
+
+**Tier 1 is per-agent and declarative.** An agent implements
+`agent.CallerSessionIdentifier` by naming the variable it publishes
+(`CallerSessionEnvVar`), and the `agent` package does the reading and
+validation — so the ID is checked with `validation.ValidateAgentSessionID` in
+one place (it becomes a path component in `ResolveSessionFile`, so an
+unvalidated one is a traversal sink), and `agent.CallerSessionEnvVars()` can
+enumerate the set. Five agents publish one: Claude Code
+(`CLAUDE_CODE_SESSION_ID`), Codex (`CODEX_SESSION_ID` — the root-session
+identity, *not* `CODEX_THREAD_ID`, which follows forks and subagent threads),
+Cursor (`CURSOR_CONVERSATION_ID`), Copilot CLI
+(`COPILOT_AGENT_SESSION_ID`), and pi (`PI_SESSION_ID`). Each was established
+against the shipped agent rather than inferred, and each resolves to the same
+ID that agent's lifecycle events report — so no translation is needed.
+
+These names are stated in four places (here, each agent's
+`CallerSessionEnvVar`, the static `agent.callerSessionEnvVars`, and
+`callerSessionEnvVarByAgent` in `agent/caller_session_test.go`); **the test
+table is the enforced copy**, so trust it if they ever diverge, and
+`TestCallerSessionEnvVars_MatchesTheRegistry` pins the static list against the
+live registry.
+
+**`CallerSessionEnvVars()` is static rather than registry-derived on purpose**,
+which looks backwards until you see the failure: its consumers are the test
+harnesses that isolate themselves from the developer's real agent session, and
+not every test binary links every agent implementation — the e2e harness links
+eight of the nine, omitting pi. A registry-derived list silently shortens to
+that binary's subset, and a missing name is not an error, it is one variable
+left set, so a real session leaks into the run and surfaces as an unrelated
+assertion failure on one machine. Registration cannot be the source of truth
+for "every name that exists". Worth knowing because a wrong name fails
+silently — it degrades to a weaker tier rather than erroring — and the guard
+test catches a newly capable agent going unlisted, not a vendor renaming a
+variable we already track.
+
+Gemini CLI and opencode publish **nothing**, and that is a finding rather than
+a gap in our table: Gemini passes its session ID to its shell executor for
+background-process bookkeeping but never into the child environment, and
+opencode's shell tool performs no environment augmentation at all. Tier 2 is
+what covers them, which is why it is not optional.
+`TestCallerSessionEnvVar_UnpublishedAgentsStayUnpublished` fails if either
+gains the capability without its variable being pinned.
+
+Two states worth distinguishing, both on tier 1:
+`ResolvedSession.Tracked == false` means the agent named a session Entire holds
+no state for — hooks are not installed, they failed, or the first turn has not
+landed (state is created at turn start). That is a diagnosis, so the ID and
+agent are reported; falling through to a weaker tier would answer a question
+nobody asked with someone else's session.
+
+Several tier-1 claims at once is the normal **nested** case, not a conflict: a
+`codex exec` run from Claude Code's shell tool inherits the outer agent's
+variables through the inner agent's process. Tracked claims are ranked by
+ancestry depth (nearest wins), then by most recent interaction when ancestry
+cannot separate them.
+
+**Tests that touch this must clear the variables**, derived from
+`agent.CallerSessionEnvVars()` rather than hand-listed. `go test` is routinely
+run from inside one of these agents, so a leaked variable makes fixture-based
+assertions pass on CI and fail on a contributor's machine.
 
 ### Settings
 

--- a/cmd/entire/cli/agent/caller_session.go
+++ b/cmd/entire/cli/agent/caller_session.go
@@ -1,0 +1,180 @@
+package agent
+
+import (
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/validation"
+)
+
+// CallerSessionIdentifier is implemented by agents that publish their own
+// session ID into the environment of the processes they spawn — the shell tool
+// an agent runs `entire` from, and any hook or git hook underneath it.
+//
+// It answers a question nothing else can: "which session is running me right
+// now?" Session state is keyed on the agent's session ID, so an agent that
+// hands its ID to its children lets a command identify its caller exactly,
+// rather than inferring one from which state file moved most recently — which
+// is a different question with a different answer whenever more than one
+// session shares a checkpoint store (see strategy.ResolveCallerSession).
+//
+// Not every agent publishes one. Gemini CLI passes its session ID to its shell
+// executor for background-process bookkeeping but never into the child
+// environment, and opencode's shell tool performs no environment augmentation
+// at all; both are absent here on purpose rather than by omission, and callers
+// must degrade rather than assume.
+//
+// Deliberately built-in only, so it has no DeclaredCaps entry: the external
+// agent protocol has no field for it, and an external plugin already receives
+// its session ID through the hook payload it is handed.
+type CallerSessionIdentifier interface {
+	// CallerSessionEnvVar returns the environment variable this agent
+	// publishes its session ID under.
+	//
+	// The agent declares the name and the package does the reading, so
+	// validation happens in exactly one place and the set of names is
+	// enumerable — which is what lets tests clear them all and keeps a future
+	// diagnostic from re-deriving the list.
+	CallerSessionEnvVar() string
+}
+
+// AsCallerSessionIdentifier returns the agent as CallerSessionIdentifier if it
+// implements it. Built-in-only capability, so no DeclaredCaps gate.
+func AsCallerSessionIdentifier(ag Agent) (CallerSessionIdentifier, bool) {
+	return builtinCapability[CallerSessionIdentifier](ag)
+}
+
+// callerSessionAgent pairs an agent with its caller-session capability, so an
+// enumeration resolves both once instead of asserting or re-instantiating per
+// consumer.
+type callerSessionAgent struct {
+	agent Agent
+	ident CallerSessionIdentifier
+}
+
+// callerSessionAgents returns every registered agent that publishes a session
+// ID, in sorted agent-name order.
+//
+// Copies the factories under one read lock and instantiates outside it, the
+// same shape as AllProtectedDirs and its siblings: one lock span per
+// enumeration rather than a List() plus a Get() per agent, so the whole
+// enumeration sees a single consistent registry snapshot.
+func callerSessionAgents() []callerSessionAgent {
+	registryMu.RLock()
+	names := make([]types.AgentName, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	factories := make([]Factory, 0, len(names))
+	for _, name := range names {
+		factories = append(factories, registry[name])
+	}
+	registryMu.RUnlock()
+
+	out := make([]callerSessionAgent, 0, len(factories))
+	for _, factory := range factories {
+		ag := factory()
+		if ident, ok := AsCallerSessionIdentifier(ag); ok {
+			out = append(out, callerSessionAgent{agent: ag, ident: ident})
+		}
+	}
+	return out
+}
+
+// callerSessionEnvVars is every variable name a built-in agent publishes.
+//
+// Static rather than registry-derived, which is the opposite of what it looks
+// like it should be. Its consumers are test harnesses isolating themselves
+// from the developer's real agent session, and not every test binary links
+// every agent implementation — the e2e harness links eight of the nine. A
+// registry-derived list therefore shortens to whatever that particular binary
+// happened to import, **silently**: a missing name is not an error, it is one
+// variable left set, so the developer's own session leaks into the spawned CLI
+// and the failure surfaces as an unrelated assertion on their machine only.
+// Registration cannot be the source of truth for "every name that exists".
+//
+// TestCallerSessionEnvVars_MatchesTheRegistry pins this against the live
+// enumeration inside this package, where every agent IS registered, so the two
+// cannot drift.
+var callerSessionEnvVars = []string{
+	"CLAUDE_CODE_SESSION_ID",
+	"CODEX_SESSION_ID",
+	"COPILOT_AGENT_SESSION_ID",
+	"CURSOR_CONVERSATION_ID",
+	"PI_SESSION_ID",
+}
+
+// CallerSessionEnvVars returns every caller-session variable name a built-in
+// agent publishes, complete regardless of which agents the calling binary
+// links. Use it to clear the set; see callerSessionEnvVars for why it is not
+// derived from the registry.
+func CallerSessionEnvVars() []string {
+	return slices.Clone(callerSessionEnvVars)
+}
+
+// callerSessionEnvVarsFromRegistry enumerates the variable names of the agents
+// registered in THIS binary. Only the guard test uses it — production and test
+// isolation want the complete set above, not this binary's subset.
+func callerSessionEnvVarsFromRegistry() []string {
+	agents := callerSessionAgents()
+	names := make([]string, 0, len(agents))
+	for _, a := range agents {
+		names = append(names, a.ident.CallerSessionEnvVar())
+	}
+	return names
+}
+
+// callerSessionIDFromEnv reads a session ID an agent published under name.
+//
+// The value is validated with validation.ValidateAgentSessionID, and this is
+// not a formality: the ID it returns reaches ResolveSessionFile and becomes a
+// path component, so an unvalidated one read straight out of the environment
+// would be a traversal sink. An ID that fails validation is reported absent —
+// the caller then degrades to a weaker tier, which is the same outcome as the
+// variable never having been set, and strictly better than resolving a path
+// from it.
+func callerSessionIDFromEnv(name string) (string, bool) {
+	id := strings.TrimSpace(os.Getenv(name))
+	if validation.ValidateAgentSessionID(id) != nil {
+		return "", false
+	}
+	return id, true
+}
+
+// CallerSessionCandidate is one agent's claim that it spawned this process.
+//
+// AgentType rather than the registry name, because the only consumer reports
+// it to a user ("running inside Codex session X") and AgentType is the spelling
+// session state and commit trailers already use.
+type CallerSessionCandidate struct {
+	SessionID string
+	AgentType types.AgentType
+}
+
+// CallerSessionCandidates returns every registered agent's claim about which
+// session spawned this process, sorted by agent name so the result is stable.
+//
+// More than one claim is normal rather than a conflict: agents nest, and a
+// `codex exec` started from Claude Code's shell tool sees both agents'
+// variables, since the outer one is inherited through the inner agent's own
+// process. The environment alone cannot say which is nearer, so it does not
+// try — resolving between candidates needs process ancestry, and belongs to
+// the caller that has session state to match against.
+func CallerSessionCandidates() []CallerSessionCandidate {
+	agents := callerSessionAgents()
+	candidates := make([]CallerSessionCandidate, 0, len(agents))
+	for _, a := range agents {
+		id, ok := callerSessionIDFromEnv(a.ident.CallerSessionEnvVar())
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, CallerSessionCandidate{
+			SessionID: id,
+			AgentType: a.agent.Type(),
+		})
+	}
+	return candidates
+}

--- a/cmd/entire/cli/agent/caller_session_test.go
+++ b/cmd/entire/cli/agent/caller_session_test.go
@@ -1,0 +1,194 @@
+package agent
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+)
+
+// callerSessionEnvVarByAgent pins the variable each agent reads. These names
+// are not ours to choose — each is set by a third-party binary we do not
+// control — so a rename here is a behavioural change that silently stops
+// identifying that agent's sessions, with nothing else in the build to notice.
+// Established empirically per vendor; do not "fix" an entry without checking
+// the agent's own shipped behaviour.
+var callerSessionEnvVarByAgent = map[types.AgentName]string{
+	AgentNameClaudeCode: "CLAUDE_CODE_SESSION_ID",
+	AgentNameCodex:      "CODEX_SESSION_ID",
+	AgentNameCursor:     "CURSOR_CONVERSATION_ID",
+	AgentNameCopilotCLI: "COPILOT_AGENT_SESSION_ID",
+	AgentNamePi:         "PI_SESSION_ID",
+}
+
+func TestCallerSessionEnvVar_MatchesTheVendorsName(t *testing.T) {
+	for name, want := range callerSessionEnvVarByAgent {
+		t.Run(string(name), func(t *testing.T) {
+			ag, err := Get(name)
+			if err != nil {
+				t.Fatalf("Get(%q) error = %v", name, err)
+			}
+			ident, ok := AsCallerSessionIdentifier(ag)
+			if !ok {
+				t.Fatalf("%s does not implement CallerSessionIdentifier; it must publish %s", name, want)
+			}
+			if got := ident.CallerSessionEnvVar(); got != want {
+				t.Errorf("CallerSessionEnvVar() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// The agents deliberately WITHOUT the capability are as load-bearing as the
+// ones with it: Gemini CLI passes its session ID only to its own background
+// bookkeeping, and opencode's shell tool augments no environment at all. If
+// either gains the capability without an entry above, this fails and asks for
+// the mapping to be pinned rather than left implicit.
+func TestCallerSessionEnvVar_UnpublishedAgentsStayUnpublished(t *testing.T) {
+	for _, name := range List() {
+		if _, pinned := callerSessionEnvVarByAgent[name]; pinned {
+			continue
+		}
+		ag, err := Get(name)
+		if err != nil {
+			continue
+		}
+		if ident, ok := AsCallerSessionIdentifier(ag); ok {
+			t.Errorf("%s newly implements CallerSessionIdentifier (%s) — add it to callerSessionEnvVarByAgent",
+				name, ident.CallerSessionEnvVar())
+		}
+	}
+}
+
+func TestCallerSessionEnvVars_ListsEveryPublishingAgent(t *testing.T) {
+	got := CallerSessionEnvVars()
+	for name, want := range callerSessionEnvVarByAgent {
+		if !slices.Contains(got, want) {
+			t.Errorf("CallerSessionEnvVars() = %v, missing %s for %s", got, want, name)
+		}
+	}
+}
+
+// The static list and the live registry must agree. This test runs in the one
+// package where every agent is registered, which is exactly why the static
+// list exists: elsewhere the registry enumeration silently returns a subset
+// (the e2e harness links eight of nine agents), and a name missing from a
+// test's isolation set leaks the developer's own session into the run.
+func TestCallerSessionEnvVars_MatchesTheRegistry(t *testing.T) {
+	fromRegistry := callerSessionEnvVarsFromRegistry()
+	slices.Sort(fromRegistry)
+	static := CallerSessionEnvVars()
+	slices.Sort(static)
+	if !slices.Equal(static, fromRegistry) {
+		t.Errorf("callerSessionEnvVars = %v, registry enumerates %v — update the static list", static, fromRegistry)
+	}
+}
+
+// CallerSessionEnvVars must not hand out its backing array: a caller that
+// sorts or truncates the result would corrupt the list for everyone else in
+// the process.
+func TestCallerSessionEnvVars_ReturnsACopy(t *testing.T) {
+	first := CallerSessionEnvVars()
+	if len(first) == 0 {
+		t.Fatal("CallerSessionEnvVars() is empty")
+	}
+	first[0] = "MUTATED"
+	if CallerSessionEnvVars()[0] == "MUTATED" {
+		t.Error("CallerSessionEnvVars() shares its backing array with the package-level list")
+	}
+}
+
+// clearCallerSessionEnv unsets every agent's caller-session variable.
+//
+// `go test` is routinely run from inside one of these agents — this suite's
+// own development happened inside Claude Code, which sets
+// CLAUDE_CODE_SESSION_ID — so without this a test asserting "no candidates"
+// passes on CI and fails on a contributor's machine. Derived from
+// CallerSessionEnvVars() rather than a hand-written list so it cannot rot when
+// an agent is added.
+func clearCallerSessionEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range CallerSessionEnvVars() {
+		t.Setenv(name, "")
+	}
+}
+
+func TestCallerSessionCandidates_ReadsThePublishedID(t *testing.T) {
+	clearCallerSessionEnv(t)
+	t.Setenv("CODEX_SESSION_ID", "01a0800c-91dd-7483-ba76-1df61bb5dd4f")
+
+	got := CallerSessionCandidates()
+	if len(got) != 1 {
+		t.Fatalf("CallerSessionCandidates() = %+v, want exactly 1", got)
+	}
+	if got[0].SessionID != "01a0800c-91dd-7483-ba76-1df61bb5dd4f" {
+		t.Errorf("SessionID = %q, want the value of CODEX_SESSION_ID", got[0].SessionID)
+	}
+	if got[0].AgentType != AgentTypeCodex {
+		t.Errorf("AgentType = %q, want %q", got[0].AgentType, AgentTypeCodex)
+	}
+}
+
+func TestCallerSessionCandidates_NoneWhenNothingPublished(t *testing.T) {
+	clearCallerSessionEnv(t)
+	if got := CallerSessionCandidates(); len(got) != 0 {
+		t.Errorf("CallerSessionCandidates() = %+v, want none", got)
+	}
+}
+
+// Nesting is the normal multi-candidate case, not a conflict: a codex run
+// started from Claude Code's shell tool sees both variables. Both are
+// reported, because only process ancestry can say which is nearer and this
+// layer has no session state to match against.
+func TestCallerSessionCandidates_ReportsEveryNestedClaim(t *testing.T) {
+	clearCallerSessionEnv(t)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "outer-session")
+	t.Setenv("CODEX_SESSION_ID", "inner-session")
+
+	got := CallerSessionCandidates()
+	if len(got) != 2 {
+		t.Fatalf("CallerSessionCandidates() = %+v, want both claims", got)
+	}
+	ids := []string{got[0].SessionID, got[1].SessionID}
+	for _, want := range []string{"outer-session", "inner-session"} {
+		if !slices.Contains(ids, want) {
+			t.Errorf("CallerSessionCandidates() ids = %v, missing %q", ids, want)
+		}
+	}
+}
+
+// An ID out of the environment becomes a path component in
+// ResolveSessionFile, so a value that is not path-safe must read as absent
+// rather than be passed along. Reporting absent degrades to a weaker
+// resolution tier, which is the same outcome as the variable never being set.
+func TestCallerSessionCandidates_RejectsUnsafeIDs(t *testing.T) {
+	for _, id := range []string{
+		"../../../etc/passwd",
+		"a/b",
+		"-rf",
+		"has space",
+		"   ",
+		"semi;colon",
+	} {
+		t.Run(id, func(t *testing.T) {
+			clearCallerSessionEnv(t)
+			t.Setenv("PI_SESSION_ID", id)
+			if got := CallerSessionCandidates(); len(got) != 0 {
+				t.Errorf("CallerSessionCandidates() = %+v for PI_SESSION_ID=%q, want none", got, id)
+			}
+		})
+	}
+}
+
+func TestCallerSessionCandidates_TrimsSurroundingWhitespace(t *testing.T) {
+	clearCallerSessionEnv(t)
+	t.Setenv("PI_SESSION_ID", "  01a08012-ce85-7bc0-8e05-fe0047687581\n")
+
+	got := CallerSessionCandidates()
+	if len(got) != 1 {
+		t.Fatalf("CallerSessionCandidates() = %+v, want exactly 1", got)
+	}
+	if got[0].SessionID != "01a08012-ce85-7bc0-8e05-fe0047687581" {
+		t.Errorf("SessionID = %q, want it trimmed", got[0].SessionID)
+	}
+}

--- a/cmd/entire/cli/agent/claudecode/claude.go
+++ b/cmd/entire/cli/agent/claudecode/claude.go
@@ -312,3 +312,9 @@ func (c *ClaudeCodeAgent) LaunchCmd(ctx context.Context, initialPrompt string) (
 	cmd.Env = os.Environ()
 	return cmd, nil
 }
+
+// CallerSessionEnvVar names the variable holding the session ID Claude Code
+// publishes into the environment of the processes it spawns. A nested session
+// gets its own ID rather than its parent's, so this names the session actually
+// running the caller.
+func (c *ClaudeCodeAgent) CallerSessionEnvVar() string { return "CLAUDE_CODE_SESSION_ID" }

--- a/cmd/entire/cli/agent/codex/codex.go
+++ b/cmd/entire/cli/agent/codex/codex.go
@@ -263,3 +263,12 @@ func findRolloutBySessionID(codexHome, agentSessionID string) string {
 
 	return ""
 }
+
+// CallerSessionEnvVar names the variable holding the session ID Codex
+// publishes into the environment of the processes it spawns.
+//
+// Codex publishes two IDs and this is the root-session identity, shared by
+// every descendant thread — the one session state is keyed on. CODEX_THREAD_ID
+// is deliberately unused: it follows forks and subagent threads, so it names a
+// transcript file rather than a session.
+func (c *CodexAgent) CallerSessionEnvVar() string { return "CODEX_SESSION_ID" }

--- a/cmd/entire/cli/agent/copilotcli/copilotcli.go
+++ b/cmd/entire/cli/agent/copilotcli/copilotcli.go
@@ -176,3 +176,8 @@ func (c *CopilotCLIAgent) ChunkTranscript(_ context.Context, content []byte, max
 func (c *CopilotCLIAgent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
 	return agent.ReassembleJSONL(chunks), nil
 }
+
+// CallerSessionEnvVar names the variable holding the session ID Copilot CLI
+// publishes into the environment of the processes it spawns — the same ID that
+// names the session's directory under Copilot's session-state store.
+func (c *CopilotCLIAgent) CallerSessionEnvVar() string { return "COPILOT_AGENT_SESSION_ID" }

--- a/cmd/entire/cli/agent/cursor/cursor.go
+++ b/cmd/entire/cli/agent/cursor/cursor.go
@@ -261,3 +261,10 @@ func (c *CursorAgent) ChunkTranscript(_ context.Context, content []byte, maxSize
 func (c *CursorAgent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
 	return agent.ReassembleJSONL(chunks), nil
 }
+
+// CallerSessionEnvVar names the variable holding the session ID Cursor
+// publishes into the environment of the processes its shell tool spawns,
+// alongside CURSOR_AGENT. It is the same conversation ID every Cursor
+// lifecycle event reports as its session ID, so it resolves against session
+// state without translation.
+func (c *CursorAgent) CallerSessionEnvVar() string { return "CURSOR_CONVERSATION_ID" }

--- a/cmd/entire/cli/agent/pi/pi.go
+++ b/cmd/entire/cli/agent/pi/pi.go
@@ -279,3 +279,10 @@ func (a *PiAgent) FormatResumeCommand(sessionID string) string {
 	}
 	return "pi --session " + id
 }
+
+// CallerSessionEnvVar names the variable holding the session ID Pi publishes
+// into the environment of the processes it spawns. Pi also publishes
+// PI_SESSION_FILE, the transcript path itself; the ID is preferred because
+// ResolveSessionFile derives the same path from it, keeping one resolution
+// point instead of two.
+func (a *PiAgent) CallerSessionEnvVar() string { return "PI_SESSION_ID" }

--- a/cmd/entire/cli/hooks_git_cmd.go
+++ b/cmd/entire/cli/hooks_git_cmd.go
@@ -128,7 +128,11 @@ func (g *gitHookContext) skipUnreadableCheckpointPolicy(err error) bool {
 // enabled Entire. The check is not repeated here: it costs an uncached
 // settings.Load, and this runs on the per-commit and per-turn paths.
 func withHookSession(ctx context.Context) context.Context {
-	ctx = logging.WithSessionID(ctx, strategy.FindMostRecentSession(ctx))
+	// Resolve the caller rather than the most recent session: a git hook an
+	// agent triggered inherits that agent's session ID in its environment, so
+	// log lines get attributed to the session that actually ran the commit
+	// instead of whichever session in the shared store moved last.
+	ctx = logging.WithSessionID(ctx, strategy.ResolveCallerSession(ctx).SessionID)
 
 	// Hooks are the checkpoint-writing path, so this cannot be left to the root
 	// pre-run: without it only always-on secret scanning would run.

--- a/cmd/entire/cli/hooks_git_cmd_test.go
+++ b/cmd/entire/cli/hooks_git_cmd_test.go
@@ -336,10 +336,14 @@ func TestWithHookSession_StampsTheCallersSessionFromEnv(t *testing.T) {
 	enableEntire(t, tmpDir)
 	entireDir := filepath.Join(tmpDir, paths.EntireDir)
 
-	// The decoy is the most recently active session and is what the old
-	// most-recent behaviour would have stamped.
-	writeTestSessionState(t, tmpDir, "decoy-most-recent")
+	// Write order is load-bearing: writeTestSessionState stamps
+	// LastInteractionTime at call time, so the SECOND state is the most recent
+	// one and is what the fallback tiers would pick. The caller therefore goes
+	// first, leaving the environment claim as the only thing that can select
+	// it — otherwise this test passes with the claim removed and proves
+	// nothing.
 	writeTestSessionState(t, tmpDir, "caller-session-id")
+	writeTestSessionState(t, tmpDir, "decoy-most-recent")
 	t.Setenv("CODEX_SESSION_ID", "caller-session-id")
 
 	l, err := logging.New(logging.Config{Root: entiredir.OpenerAt(tmpDir), Dir: logging.LogsName})

--- a/cmd/entire/cli/hooks_git_cmd_test.go
+++ b/cmd/entire/cli/hooks_git_cmd_test.go
@@ -20,14 +20,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TestWithHookSession_StampsMostRecentSession pins the one thing the hook path
+// TestWithHookSession_StampsResolvedSession pins the one thing the hook path
 // adds over the root prerun: lines logged under the returned context carry the
 // session, which root cannot know without scanning session state on every
-// command.
-func TestWithHookSession_StampsMostRecentSession(t *testing.T) {
+// command. With no agent variable in the environment this is the worktree
+// tier; see the caller-env case below.
+func TestWithHookSession_StampsResolvedSession(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
 	testutil.InitRepo(t, tmpDir)
+	clearCallerSessionEnv(t)
 
 	enableEntire(t, tmpDir)
 	entireDir := filepath.Join(tmpDir, paths.EntireDir)
@@ -318,4 +320,45 @@ func agentHooksCmd(t *testing.T, agentName string) *cobra.Command {
 	}
 	t.Fatalf("no hooks subcommand for %q", agentName)
 	return nil
+}
+
+// A git hook an agent triggered inherits that agent's session ID in its
+// environment, so log lines are attributed to the session that actually ran
+// the commit rather than whichever session in the shared store moved last.
+// Worktrees share one session store, so "last to move" is routinely a
+// different worktree's session.
+func TestWithHookSession_StampsTheCallersSessionFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	testutil.InitRepo(t, tmpDir)
+	clearCallerSessionEnv(t)
+
+	enableEntire(t, tmpDir)
+	entireDir := filepath.Join(tmpDir, paths.EntireDir)
+
+	// The decoy is the most recently active session and is what the old
+	// most-recent behaviour would have stamped.
+	writeTestSessionState(t, tmpDir, "decoy-most-recent")
+	writeTestSessionState(t, tmpDir, "caller-session-id")
+	t.Setenv("CODEX_SESSION_ID", "caller-session-id")
+
+	l, err := logging.New(logging.Config{Root: entiredir.OpenerAt(tmpDir), Dir: logging.LogsName})
+	if err != nil {
+		t.Fatalf("logging.New() error = %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	ctx := withHookSession(logging.WithLogger(context.Background(), l))
+	logging.Warn(ctx, "hook session stamped")
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(entireDir, "logs", "entire.log"))
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	if !strings.Contains(string(content), `"session_id":"caller-session-id"`) {
+		t.Errorf("log line missing the caller's session_id: %s", content)
+	}
 }

--- a/cmd/entire/cli/integration_test/hook_bench_test.go
+++ b/cmd/entire/cli/integration_test/hook_bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkHookSessionStart(b *testing.B) {
 }
 
 // benchSessions scales session state files in .git/entire-sessions/.
-// listAllSessionStates() is called twice: once in FindMostRecentSession (logging init),
+// listAllSessionStates() is called twice: once in ResolveCallerSession (logging init),
 // once in CountOtherActiveSessionsWithCheckpoints. Each call does
 // ReadDir + (ReadFile + JSON unmarshal + repo.Reference) per file.
 func benchSessions(b *testing.B) {

--- a/cmd/entire/cli/integration_test/setup_test.go
+++ b/cmd/entire/cli/integration_test/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
@@ -60,6 +61,25 @@ func TestMain(m *testing.M) {
 	for k, v := range isolation {
 		if err := os.Setenv(k, v); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to set %s: %v\n", k, err)
+			os.RemoveAll(tmpDir)
+			os.Exit(1)
+		}
+	}
+
+	// Unset the agents' caller-session variables, for the same reason as the
+	// config isolation above and with the same mechanism: the developer running
+	// `mise run test:integration` is usually inside an agent, that agent
+	// publishes its session ID into this process's environment, and every
+	// spawned `entire` inherits it — so the binary under test resolves the
+	// developer's real session as its caller and stamps it into hooks that are
+	// supposed to have no session at all. Not covered by the map above because
+	// isolation here means absence, not a redirected path. The list is static
+	// rather than registry-derived precisely so a harness whose binary does
+	// not link every agent still clears every variable — see
+	// agent.callerSessionEnvVars.
+	for _, name := range agent.CallerSessionEnvVars() {
+		if err := os.Unsetenv(name); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to unset %s: %v\n", name, err)
 			os.RemoveAll(tmpDir)
 			os.Exit(1)
 		}

--- a/cmd/entire/cli/session_current.go
+++ b/cmd/entire/cli/session_current.go
@@ -25,8 +25,8 @@ recorded in this worktree, and then to the most recent one anywhere in the
 repository's shared session store.
 
 Those are different answers to different questions, so the output always says
-which one you got — the "Resolved" line, or the "resolution" field under
---json. Only "caller-env" and "ancestry" identify the session running this
+which one you got: the "Resolved" line in text mode, or the "resolution" field
+under --json. Only "caller-env" and "ancestry" identify the session running this
 command; "other-worktree" can be any unrelated session in the store, because
 every worktree of a repository shares one. Check it before acting on the
 session rather than merely displaying it.

--- a/cmd/entire/cli/session_current.go
+++ b/cmd/entire/cli/session_current.go
@@ -15,13 +15,21 @@ func newSessionCurrentCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "current",
-		Short: "Show the active session for the current worktree",
-		Long: `Show the most recently active session for the current worktree.
+		Short: "Show the session running this command, or the most recent one here",
+		Long: `Show the session running this command, or the most recent one in this worktree.
 
-Resolves the session that is writing checkpoints in this directory right now,
-preferring sessions from the current worktree and falling back to the most
-recent session if no state matches this worktree. Equivalent to running
-'sessions info' on the session ID returned by FindMostRecentSession.
+When an agent runs this, it reports that agent's own session: agents publish
+their session ID into the environment of the commands they run, and Entire
+reads it back. Failing that, it falls back to the most recently active session
+recorded in this worktree, and then to the most recent one anywhere in the
+repository's shared session store.
+
+Those are different answers to different questions, so the output always says
+which one you got — the "Resolved" line, or the "resolution" field under
+--json. Only "caller-env" and "ancestry" identify the session running this
+command; "other-worktree" can be any unrelated session in the store, because
+every worktree of a repository shares one. Check it before acting on the
+session rather than merely displaying it.
 
 Output modes:
   Default       Human-readable summary.
@@ -39,23 +47,39 @@ Examples:
 				return errors.New("not a git repository")
 			}
 
-			sessionID := strategy.FindMostRecentSession(ctx)
-			if sessionID == "" {
-				// Machine-readable modes must not emit prose on stdout with a
-				// zero exit — downstream parsers treat stdout as JSON (or raw
-				// transcript bytes) and would choke on the hint text. Report
-				// on stderr and exit non-zero so callers can detect the
-				// no-session case. The human default keeps the stdout hint.
-				if jsonFlag || transcriptFlag {
-					cmd.SilenceUsage = true
-					fmt.Fprintln(cmd.ErrOrStderr(), "No active session found in this worktree.")
-					return NewSilentError(errors.New("no active session found in this worktree"))
-				}
-				fmt.Fprintln(cmd.OutOrStdout(), "No active session found in this worktree.")
-				return nil
+			machineReadable := jsonFlag || transcriptFlag
+			resolved := strategy.ResolveCallerSession(ctx)
+			if !resolved.Found() {
+				return reportNoSessionEnvelope(cmd, machineReadable,
+					errors.New("no active session found in this worktree"),
+					"No active session found in this worktree.")
+			}
+			if !resolved.Tracked {
+				return reportUntrackedCallerSession(cmd, resolved, machineReadable)
+			}
+			// Loud on stderr as well as labelled in the output, for every
+			// resolution that did not identify the caller: these are the
+			// answers that used to be indistinguishable from a real one, and
+			// the ones an agent must not act on.
+			switch resolved.Resolution {
+			case strategy.ResolutionOtherWorktree:
+				fmt.Fprintln(cmd.ErrOrStderr(),
+					"[entire] No session is recorded in this worktree; showing the most recent one from elsewhere in this repository. It is not this command's caller.")
+			case strategy.ResolutionCallerAmbiguous:
+				fmt.Fprintln(cmd.ErrOrStderr(),
+					"[entire] Several agent sessions claim this command and none could be ordered; showing the most plausible. Do not act on it without confirming which session is yours.")
+			case strategy.ResolutionCallerEnv, strategy.ResolutionAncestry:
+				// Identified the caller; the answer needs no caveat.
+			case strategy.ResolutionWorktree:
+				// "The session that has been working here" is what someone
+				// typing this in a terminal already assumes, so saying it adds
+				// noise. It is still labelled in the output and not IsCaller.
+			case strategy.ResolutionNone:
+				// Unreachable: handled by the !Found() branch above. Named so
+				// the exhaustive check forces a decision on a future tier.
 			}
 
-			return runSessionInfo(ctx, cmd, sessionID, sessionOutputModeFromFlags(jsonFlag, transcriptFlag))
+			return runSessionInfo(ctx, cmd, resolved.SessionID, sessionOutputModeFromFlags(jsonFlag, transcriptFlag), resolved.Resolution)
 		},
 	}
 
@@ -63,4 +87,68 @@ Examples:
 	cmd.Flags().BoolVar(&transcriptFlag, "transcript", false, "Stream raw agent transcript bytes to stdout")
 	cmd.MarkFlagsMutuallyExclusive("json", "transcript")
 	return cmd
+}
+
+// reportUntrackedCallerSession handles the case where the agent running us
+// named its session but Entire holds no state for it.
+//
+// This is a diagnosis, not a lookup failure, and it is the reason the resolver
+// reports the ID rather than discarding it: we know which session the caller
+// is in — or, when several agents claim it, that it is one of a named few —
+// and we know Entire is not recording it — hooks are not
+// installed, they failed, or the session's first turn has not landed yet
+// (state is created at turn start). Answering "session not found" would hide
+// the useful half, and falling through to the most-recent tiers would answer a
+// question nobody asked with a session that isn't the caller's.
+//
+// Machine-readable modes exit non-zero for the same reason as the no-session
+// branch above: there is no session envelope to emit, so stdout must stay
+// empty rather than carry prose a parser would choke on.
+func reportUntrackedCallerSession(cmd *cobra.Command, resolved strategy.ResolvedSession, machineReadable bool) error {
+	agentLabel := string(resolved.AgentType)
+	if agentLabel == "" {
+		agentLabel = unknownPlaceholder
+	}
+	// An ambiguous resolution must not be narrated as a fact. With several
+	// claims and no state behind any of them there is nothing to order them
+	// by — no owner to compare, no interaction time — so the reported session
+	// is the first of several, and "This command is running inside X" would
+	// state that arbitrary pick as the answer. The diagnosis (you are inside
+	// an untracked session) survives; the identification does not.
+	if resolved.Resolution == strategy.ResolutionCallerAmbiguous {
+		return reportNoSessionEnvelope(cmd, machineReadable,
+			fmt.Errorf("several untracked agent sessions claim this command, including %s", resolved.SessionID),
+			"Several agent sessions claim this command and Entire has state for none of them, so which one is running it could not be determined.",
+			fmt.Sprintf("One of them is %s session %s. Pass a session ID explicitly rather than relying on this.",
+				agentLabel, resolved.SessionID),
+			"Entire may not be enabled here, or its hooks may not have run yet. Run 'entire status' to check.")
+	}
+	return reportNoSessionEnvelope(cmd, machineReadable,
+		fmt.Errorf("no session state for caller session %s", resolved.SessionID),
+		fmt.Sprintf("This command is running inside %s session %s, but Entire has no session state for it.",
+			agentLabel, resolved.SessionID),
+		"Entire may not be enabled here, its hooks may not have run yet, or this session's first turn has not completed. Run 'entire status' to check.")
+}
+
+// reportNoSessionEnvelope reports that there is no session envelope to emit.
+//
+// Machine-readable modes must not put prose on stdout with a zero exit —
+// downstream parsers treat stdout as JSON (or raw transcript bytes) and would
+// choke on it — so the lines go to stderr and the command exits non-zero,
+// letting a caller detect the case. The human default keeps the lines on
+// stdout and succeeds. Shared because both no-session cases need exactly this
+// shape, and a third would otherwise copy it again.
+func reportNoSessionEnvelope(cmd *cobra.Command, machineReadable bool, sentinel error, lines ...string) error {
+	out := cmd.OutOrStdout()
+	if machineReadable {
+		cmd.SilenceUsage = true
+		out = cmd.ErrOrStderr()
+	}
+	for _, line := range lines {
+		fmt.Fprintln(out, line)
+	}
+	if machineReadable {
+		return NewSilentError(sentinel)
+	}
+	return nil
 }

--- a/cmd/entire/cli/session_current_test.go
+++ b/cmd/entire/cli/session_current_test.go
@@ -390,3 +390,77 @@ func TestSessionCurrent_AmbiguousTrackedWinnerIsLabelledAndWarned(t *testing.T) 
 		t.Errorf("expected a stderr warning about the unordered claims, got: %q", stderr.String())
 	}
 }
+
+// The help promises the output always says which question it answered. The
+// worktree tier is the most common one and used to print no line at all,
+// making that promise false in exactly the case a user hits most.
+func TestSessionCurrent_TextModeLabelsTheWorktreeTier(t *testing.T) {
+	// t.Chdir cannot coexist with t.Parallel; this test mutates process CWD.
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	clearCallerSessionEnv(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	state := &strategy.SessionState{
+		SessionID:           "worktree-tier-session",
+		AgentType:           agent.AgentTypeClaudeCode,
+		WorktreePath:        dir,
+		StartedAt:           now,
+		LastInteractionTime: &now,
+		Phase:               session.PhaseIdle,
+	}
+	if err := strategy.SaveSessionState(context.Background(), state); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	cmd := newSessionCurrentCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Resolved:") {
+		t.Errorf("text mode omitted the resolution the help promises, got: %q", stdout.String())
+	}
+}
+
+// `session info <id>` names its session outright, so there is nothing to
+// explain and the line must stay absent.
+func TestSessionInfo_TextModeHasNoResolutionLine(t *testing.T) {
+	// t.Chdir cannot coexist with t.Parallel; this test mutates process CWD.
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	clearCallerSessionEnv(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	state := &strategy.SessionState{
+		SessionID:           "named-outright",
+		AgentType:           agent.AgentTypeClaudeCode,
+		WorktreePath:        dir,
+		StartedAt:           now,
+		LastInteractionTime: &now,
+		Phase:               session.PhaseIdle,
+	}
+	if err := strategy.SaveSessionState(context.Background(), state); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	cmd := newInfoCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"named-outright"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if strings.Contains(stdout.String(), "Resolved:") {
+		t.Errorf("session info explained a resolution it was handed, got: %q", stdout.String())
+	}
+}

--- a/cmd/entire/cli/session_current_test.go
+++ b/cmd/entire/cli/session_current_test.go
@@ -15,11 +15,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// clearCallerSessionEnv unsets every agent's caller-session variable, derived
+// from the registry so it cannot rot when an agent is added.
+//
+// Without it these tests inherit the session of whichever agent is running
+// `go test` — `session current` would correctly identify that real session and
+// every fixture-based assertion below would fail on a contributor's machine
+// while passing on CI. Tests that want the caller tier set their variable
+// after calling this.
+func clearCallerSessionEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range agent.CallerSessionEnvVars() {
+		t.Setenv(name, "")
+	}
+}
+
 func TestSessionCurrent_NoSessionsPrintsHint(t *testing.T) {
 	// t.Chdir cannot coexist with t.Parallel; this test mutates process CWD.
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	t.Chdir(dir)
+	clearCallerSessionEnv(t)
 
 	cmd := newSessionCurrentCmd()
 	var stdout, stderr bytes.Buffer
@@ -46,6 +62,7 @@ func TestSessionCurrent_JSONNoSessionErrorsWithCleanStdout(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	t.Chdir(dir)
+	clearCallerSessionEnv(t)
 
 	for _, flag := range []string{"--json", "--transcript"} {
 		cmd := newSessionCurrentCmd()
@@ -73,6 +90,7 @@ func TestSessionCurrent_JSONPrintsCurrentSessionInfo(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	t.Chdir(dir)
+	clearCallerSessionEnv(t)
 
 	now := time.Now().UTC().Truncate(time.Second)
 	state := &strategy.SessionState{
@@ -141,3 +159,234 @@ func TestSessionCurrent_NotARepoErrors(t *testing.T) {
 // trivial sanity guard so an accidental return-type change is caught here
 // rather than at the wiring site in sessions.go).
 var _ *cobra.Command = newSessionCurrentCmd()
+
+// The caller tier end to end: an agent's published session ID names the
+// session even though a different one is the most recent thing in the store.
+// This is the reported bug's shape — before the tier, the foreign session came
+// back indistinguishable from a real answer.
+func TestSessionCurrent_JSONIdentifiesTheCallersOwnSession(t *testing.T) {
+	// t.Chdir cannot coexist with t.Parallel; this test mutates process CWD.
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	clearCallerSessionEnv(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	older := now.Add(-2 * time.Hour)
+	mine := &strategy.SessionState{
+		SessionID:           "caller-owned-session",
+		AgentType:           agent.AgentTypeCodex,
+		WorktreePath:        "/some/other/worktree",
+		StartedAt:           older,
+		LastInteractionTime: &older,
+		Phase:               session.PhaseIdle,
+	}
+	theirs := &strategy.SessionState{
+		SessionID:           "most-recent-elsewhere",
+		AgentType:           agent.AgentTypeClaudeCode,
+		WorktreePath:        "/a/third/worktree",
+		StartedAt:           now,
+		LastInteractionTime: &now,
+		Phase:               session.PhaseIdle,
+	}
+	for _, state := range []*strategy.SessionState{mine, theirs} {
+		if err := strategy.SaveSessionState(context.Background(), state); err != nil {
+			t.Fatalf("SaveSessionState(%q): %v", state.SessionID, err)
+		}
+	}
+	t.Setenv("CODEX_SESSION_ID", mine.SessionID)
+
+	cmd := newSessionCurrentCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"--json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", err, stderr.String())
+	}
+
+	var got sessionInfoJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout.String(), err)
+	}
+	if got.SessionID != mine.SessionID {
+		t.Errorf("session_id = %q, want the caller's own %q", got.SessionID, mine.SessionID)
+	}
+	if got.Resolution != string(strategy.ResolutionCallerEnv) {
+		t.Errorf("resolution = %q, want %q", got.Resolution, strategy.ResolutionCallerEnv)
+	}
+}
+
+// The weakest tier stays available but must announce itself on stderr while
+// keeping stdout a clean envelope — an agent parsing stdout needs the
+// "resolution" field, and a human needs the sentence.
+func TestSessionCurrent_CrossWorktreeFallbackIsLabelledAndWarned(t *testing.T) {
+	// t.Chdir cannot coexist with t.Parallel; this test mutates process CWD.
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	clearCallerSessionEnv(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	state := &strategy.SessionState{
+		SessionID:           "only-elsewhere",
+		AgentType:           agent.AgentTypeClaudeCode,
+		WorktreePath:        "/some/other/worktree",
+		StartedAt:           now,
+		LastInteractionTime: &now,
+		Phase:               session.PhaseIdle,
+	}
+	if err := strategy.SaveSessionState(context.Background(), state); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	cmd := newSessionCurrentCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"--json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", err, stderr.String())
+	}
+
+	var got sessionInfoJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout.String(), err)
+	}
+	if got.Resolution != string(strategy.ResolutionOtherWorktree) {
+		t.Errorf("resolution = %q, want %q", got.Resolution, strategy.ResolutionOtherWorktree)
+	}
+	if !strings.Contains(stderr.String(), "not this command's caller") {
+		t.Errorf("expected a stderr warning naming the risk, got: %q", stderr.String())
+	}
+}
+
+// An agent named its session and Entire has no state for it. The command
+// reports that fact — it must not fall through and answer with the unrelated
+// session that happens to be in the store.
+func TestSessionCurrent_UntrackedCallerIsDiagnosedNotSubstituted(t *testing.T) {
+	// t.Chdir cannot coexist with t.Parallel; this test mutates process CWD.
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	clearCallerSessionEnv(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	decoy := &strategy.SessionState{
+		SessionID:           "unrelated-session",
+		AgentType:           agent.AgentTypeClaudeCode,
+		WorktreePath:        dir,
+		StartedAt:           now,
+		LastInteractionTime: &now,
+		Phase:               session.PhaseIdle,
+	}
+	if err := strategy.SaveSessionState(context.Background(), decoy); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+	t.Setenv("PI_SESSION_ID", "no-state-for-me")
+
+	cmd := newSessionCurrentCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", err, stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "no-state-for-me") {
+		t.Errorf("expected the caller's session ID in the output, got: %q", out)
+	}
+	if strings.Contains(out, decoy.SessionID) {
+		t.Errorf("substituted an unrelated session for the untracked caller: %q", out)
+	}
+}
+
+// Several untracked claims must not be narrated as one identified session.
+// The resolver reports the first of them so the diagnosis survives, but the
+// command previously said "This command is running inside X session Y" — an
+// arbitrary pick stated as fact.
+func TestSessionCurrent_UntrackedAmbiguousClaimsAreNotStatedAsFact(t *testing.T) {
+	// t.Chdir cannot coexist with t.Parallel; this test mutates process CWD.
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	clearCallerSessionEnv(t)
+
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "untracked-outer")
+	t.Setenv("CODEX_SESSION_ID", "untracked-inner")
+
+	cmd := newSessionCurrentCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", err, stderr.String())
+	}
+
+	out := stdout.String()
+	if strings.Contains(out, "is running inside") {
+		t.Errorf("stated an arbitrary pick as the caller: %q", out)
+	}
+	if !strings.Contains(out, "could not be determined") {
+		t.Errorf("expected the output to say which session is running it is unknown, got: %q", out)
+	}
+}
+
+// A tracked winner alongside an unplaceable claim is reported with its
+// envelope intact — an agent needs the resolution field — but warned about on
+// stderr, because the pair was never ordered.
+func TestSessionCurrent_AmbiguousTrackedWinnerIsLabelledAndWarned(t *testing.T) {
+	// t.Chdir cannot coexist with t.Parallel; this test mutates process CWD.
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	clearCallerSessionEnv(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	tracked := &strategy.SessionState{
+		SessionID:           "outer-tracked",
+		AgentType:           agent.AgentTypeClaudeCode,
+		WorktreePath:        dir,
+		StartedAt:           now,
+		LastInteractionTime: &now,
+		Phase:               session.PhaseIdle,
+	}
+	if err := strategy.SaveSessionState(context.Background(), tracked); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "outer-tracked")
+	t.Setenv("CODEX_SESSION_ID", "inner-untracked")
+
+	cmd := newSessionCurrentCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"--json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", err, stderr.String())
+	}
+
+	var got sessionInfoJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout.String(), err)
+	}
+	if got.Resolution != string(strategy.ResolutionCallerAmbiguous) {
+		t.Errorf("resolution = %q, want %q", got.Resolution, strategy.ResolutionCallerAmbiguous)
+	}
+	if !strings.Contains(stderr.String(), "could be ordered") {
+		t.Errorf("expected a stderr warning about the unordered claims, got: %q", stderr.String())
+	}
+}

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -121,10 +121,19 @@ optimize next steps."`,
 
 func runSessionTokens(ctx context.Context, cmd *cobra.Command, sessionID string, current, jsonOutput, agentBrief bool) error {
 	if sessionID == "" {
+		// --current pins the answer to this worktree and nothing else, which
+		// is the one thing the resolver deliberately will not do: it prefers
+		// the caller's own session wherever that session lives. Keep the flag
+		// literal, and let the default path identify the caller.
 		if current {
 			sessionID = strategy.FindMostRecentSessionInCurrentWorktree(ctx)
 		} else {
-			sessionID = strategy.FindMostRecentSession(ctx)
+			resolved := strategy.ResolveCallerSession(ctx)
+			sessionID = resolved.SessionID
+			if resolved.Resolution == strategy.ResolutionOtherWorktree {
+				fmt.Fprintln(cmd.ErrOrStderr(),
+					"[entire] No session is recorded in this worktree; reporting the most recent one from elsewhere in this repository. It is not this command's caller.")
+			}
 		}
 		if sessionID == "" {
 			fmt.Fprintln(cmd.OutOrStdout(), "No active session found in this worktree.")

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -19,6 +19,7 @@ type sessionTokensReport struct {
 	Model           string                        `json:"model,omitempty"`
 	Status          string                        `json:"status"`
 	Source          string                        `json:"source"`
+	Resolution      strategy.SessionResolution    `json:"resolution,omitempty"`
 	Tokens          *sessionTokensUsage           `json:"tokens,omitempty"`
 	Context         *sessionTokensContext         `json:"context,omitempty"`
 	Contributors    []sessionTokensContributor    `json:"contributors,omitempty"`
@@ -87,10 +88,12 @@ func newTokensCmd() *cobra.Command {
 		Short: "Show token usage and optimization recommendations for a session",
 		Long: `Show token usage and optimization recommendations for a session.
 
-When no session ID is provided, Entire reports on the most recently active
-session, preferring the current worktree and falling back to the newest session
-if no state matches this worktree. The report uses token and context data Entire
-already captured for the session.
+When no session ID is provided, Entire identifies the caller using agent session
+IDs and process ancestry, falling back to the most recently active session in
+this worktree and then elsewhere in the repository. The report includes how the
+session was resolved; ambiguous and cross-worktree matches also warn on stderr.
+Use --current to select only the current worktree's most recent session.
+The report uses token and context data Entire already captured for the session.
 
 Use --agent-brief when an agent needs compact guidance for the next step, for
 example: "Use Entire token tracking to check how this session is doing and
@@ -120,6 +123,7 @@ optimize next steps."`,
 }
 
 func runSessionTokens(ctx context.Context, cmd *cobra.Command, sessionID string, current, jsonOutput, agentBrief bool) error {
+	resolution := strategy.ResolutionNone
 	if sessionID == "" {
 		// --current pins the answer to this worktree and nothing else, which
 		// is the one thing the resolver deliberately will not do: it prefers
@@ -127,9 +131,18 @@ func runSessionTokens(ctx context.Context, cmd *cobra.Command, sessionID string,
 		// literal, and let the default path identify the caller.
 		if current {
 			sessionID = strategy.FindMostRecentSessionInCurrentWorktree(ctx)
+			resolution = strategy.ResolutionWorktree
 		} else {
 			resolved := strategy.ResolveCallerSession(ctx)
+			if resolved.Found() && !resolved.Tracked {
+				return reportUntrackedCallerSession(cmd, resolved, jsonOutput || agentBrief)
+			}
 			sessionID = resolved.SessionID
+			resolution = resolved.Resolution
+			if resolution == strategy.ResolutionCallerAmbiguous {
+				fmt.Fprintln(cmd.ErrOrStderr(),
+					"[entire] Caller session is ambiguous; these tokens may belong to another session. Confirm the session ID before acting on the recommendations.")
+			}
 			if resolved.Resolution == strategy.ResolutionOtherWorktree {
 				fmt.Fprintln(cmd.ErrOrStderr(),
 					"[entire] No session is recorded in this worktree; reporting the most recent one from elsewhere in this repository. It is not this command's caller.")
@@ -152,6 +165,7 @@ func runSessionTokens(ctx context.Context, cmd *cobra.Command, sessionID string,
 	}
 
 	report := buildSessionTokensReport(state, sessionPhaseLabel(state))
+	report.Resolution = resolution
 	if jsonOutput {
 		return printJSON(cmd.OutOrStdout(), report)
 	}
@@ -446,6 +460,9 @@ func writeSessionTokensText(w io.Writer, report sessionTokensReport) {
 	fmt.Fprintln(w, "Session tokens")
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "Session: %s\n", report.SessionID)
+	if report.Resolution != strategy.ResolutionNone {
+		fmt.Fprintf(w, "Resolved: %s\n", sessionResolutionLabel(report.Resolution))
+	}
 	fmt.Fprintf(w, "Agent:   %s\n", report.Agent)
 	if report.Model != "" {
 		fmt.Fprintf(w, "Model:   %s\n", report.Model)
@@ -464,6 +481,9 @@ func writeSessionTokensText(w io.Writer, report sessionTokensReport) {
 func writeSessionTokensAgentBrief(w io.Writer, report sessionTokensReport) {
 	fmt.Fprintln(w, "Session token brief")
 	fmt.Fprintf(w, "Session: %s\n", report.SessionID)
+	if report.Resolution != strategy.ResolutionNone {
+		fmt.Fprintf(w, "Resolved: %s\n", sessionResolutionLabel(report.Resolution))
+	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, agentBriefUsageLine(report.Tokens))
 	fmt.Fprintln(w)

--- a/cmd/entire/cli/session_tokens_resolution_test.go
+++ b/cmd/entire/cli/session_tokens_resolution_test.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+)
+
+func TestTokensCmd_CallerResolutionOutput(t *testing.T) {
+	// These cases change CWD and environment, so they cannot run in parallel.
+	for _, mode := range []string{"text", "json", "agent-brief"} {
+		t.Run(mode, func(t *testing.T) {
+			for _, scenario := range []string{"untracked", "untracked-ambiguous", "tracked-ambiguous", "caller", "explicit"} {
+				t.Run(scenario, func(t *testing.T) {
+					setupStopTestRepo(t)
+					clearCallerSessionEnv(t)
+					ctx := context.Background()
+					const id = "tokens-resolution-session"
+					untracked := strings.HasPrefix(scenario, "untracked")
+					ambiguous := strings.Contains(scenario, "ambiguous")
+					explicit := scenario == "explicit"
+					if !untracked {
+						state := makeSessionState(id, session.PhaseActive)
+						if err := strategy.SaveSessionState(ctx, state); err != nil {
+							t.Fatalf("SaveSessionState: %v", err)
+						}
+					}
+					t.Setenv("PI_SESSION_ID", id)
+					if ambiguous {
+						t.Setenv("CODEX_SESSION_ID", "another-untracked-session")
+					}
+
+					var args []string
+					if explicit {
+						args = append(args, id)
+					}
+					if mode != "text" {
+						args = append(args, "--"+mode)
+					}
+					cmd := newTokensCmd()
+					var stdout, stderr bytes.Buffer
+					cmd.SetOut(&stdout)
+					cmd.SetErr(&stderr)
+					cmd.SetArgs(args)
+					err := cmd.ExecuteContext(ctx)
+					if untracked {
+						if mode != "text" {
+							if err == nil || stdout.Len() != 0 {
+								t.Fatalf("untracked machine output: err=%v stdout=%q", err, stdout.String())
+							}
+						} else if err != nil {
+							t.Fatalf("untracked text diagnostic: %v", err)
+						}
+						output := stdout.String() + stderr.String()
+						if !strings.Contains(output, "entire status") || strings.Contains(output, "Session not found") {
+							t.Fatalf("missing untracked diagnostic: %s", output)
+						}
+						if ambiguous && (!strings.Contains(output, "could not be determined") || strings.Contains(output, "is running inside")) {
+							t.Fatalf("untracked ambiguity lost: %s", output)
+						}
+						if !ambiguous && !strings.Contains(output, id) {
+							t.Fatalf("diagnostic omitted caller ID: %s", output)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatalf("ExecuteContext: %v", err)
+					}
+					want := strategy.ResolutionCallerEnv
+					if ambiguous {
+						want = strategy.ResolutionCallerAmbiguous
+						if !strings.Contains(stderr.String(), "Confirm the session ID") {
+							t.Fatalf("missing ambiguity warning: %s", stderr.String())
+						}
+					} else if explicit {
+						want = strategy.ResolutionNone
+					}
+					if mode == "json" {
+						var report sessionTokensReport
+						if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+							t.Fatalf("invalid JSON: %v", err)
+						}
+						if report.Resolution != want || report.SessionID != id {
+							t.Fatalf("unexpected report: %+v", report)
+						}
+					} else if want != strategy.ResolutionNone {
+						// Text mode renders the human label, not the enum —
+						// the same label `session current` prints, so one
+						// resolution reads identically wherever it surfaces.
+						// The enum belongs to --json.
+						wantLine := "Resolved: " + sessionResolutionLabel(want)
+						if !strings.Contains(stdout.String(), wantLine) {
+							t.Fatalf("missing %q in %s output: %s", wantLine, mode, stdout.String())
+						}
+						if strings.Contains(stdout.String(), "Resolved: "+string(want)) {
+							t.Fatalf("text output leaked the raw enum: %s", stdout.String())
+						}
+					}
+					if explicit && (strings.Contains(stdout.String(), `"resolution":`) || strings.Contains(stdout.String(), "Resolved:")) {
+						t.Fatalf("explicit selection should omit resolution: %s", stdout.String())
+					}
+				})
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -494,7 +494,7 @@ Examples:
   entire sessions info <session-id> --transcript > session.jsonl`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSessionInfo(cmd.Context(), cmd, args[0], sessionOutputModeFromFlags(jsonFlag, transcriptFlag))
+			return runSessionInfo(cmd.Context(), cmd, args[0], sessionOutputModeFromFlags(jsonFlag, transcriptFlag), strategy.ResolutionNone)
 		},
 	}
 
@@ -516,7 +516,10 @@ func sessionOutputModeFromFlags(jsonFlag, transcriptFlag bool) sessionOutputMode
 	}
 }
 
-func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, mode sessionOutputMode) error {
+// runSessionInfo renders one session. resolution describes how sessionID was
+// arrived at and is reported alongside it; pass strategy.ResolutionNone when
+// the caller named the session outright, as `session info` does.
+func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, mode sessionOutputMode, resolution strategy.SessionResolution) error {
 	state, err := strategy.LoadSessionState(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("failed to load session: %w", err)
@@ -533,9 +536,9 @@ func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, m
 	case sessionOutputTranscript:
 		return writeSessionTranscript(ctx, cmd, state)
 	case sessionOutputJSON:
-		return writeSessionInfoJSON(cmd.OutOrStdout(), state, status)
+		return writeSessionInfoJSON(cmd.OutOrStdout(), state, status, resolution)
 	case sessionOutputText:
-		return writeSessionInfoText(cmd.OutOrStdout(), state, status)
+		return writeSessionInfoText(cmd.OutOrStdout(), state, status, resolution)
 	default:
 		return fmt.Errorf("unknown session output mode: %d", mode)
 	}
@@ -587,6 +590,17 @@ type sessionInfoJSON struct {
 	Tokens         *tokenInfoJSON `json:"tokens,omitempty"`
 	LastPrompt     string         `json:"last_prompt,omitempty"`
 	FilesTouched   []string       `json:"files_touched,omitempty"`
+
+	// Resolution says how this session was picked when the caller did not name
+	// one — see strategy.SessionResolution. Present only for `session
+	// current`, which resolves; `session info <id>` and `session list` were
+	// told which sessions to report, so they omit it.
+	//
+	// A consumer that acts on the session rather than displaying it must check
+	// this: only "caller-env" and "ancestry" identify the calling process's
+	// own session. "other-worktree" in particular can be any unrelated session
+	// in the shared store.
+	Resolution string `json:"resolution,omitempty"`
 }
 
 type tokenInfoJSON struct {
@@ -635,17 +649,22 @@ func buildSessionInfoJSON(state *strategy.SessionState, status string) sessionIn
 	return info
 }
 
-func writeSessionInfoJSON(w io.Writer, state *strategy.SessionState, status string) error {
+func writeSessionInfoJSON(w io.Writer, state *strategy.SessionState, status string, resolution strategy.SessionResolution) error {
+	info := buildSessionInfoJSON(state, status)
+	info.Resolution = string(resolution)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(buildSessionInfoJSON(state, status)); err != nil {
+	if err := enc.Encode(info); err != nil {
 		return fmt.Errorf("failed to encode session info: %w", err)
 	}
 	return nil
 }
 
-func writeSessionInfoText(w io.Writer, state *strategy.SessionState, status string) error {
+func writeSessionInfoText(w io.Writer, state *strategy.SessionState, status string, resolution strategy.SessionResolution) error {
 	fmt.Fprintf(w, "Session %s\n\n", state.SessionID)
+	if label := sessionResolutionLabel(resolution); label != "" {
+		fmt.Fprintf(w, "Resolved:    %s\n", label)
+	}
 
 	agentLabel := string(state.AgentType)
 	if agentLabel == "" {
@@ -900,4 +919,29 @@ func stopSessionAndPrint(ctx context.Context, cmd *cobra.Command, state *strateg
 		fmt.Fprintln(cmd.OutOrStdout(), "  No work recorded.")
 	}
 	return nil
+}
+
+// sessionResolutionLabel renders how a session was resolved, for humans. Empty
+// for a session the caller named outright, and for the plain worktree tier —
+// "the most recent session recorded here" is what someone typing `session
+// current` in a terminal already assumes, so saying it adds noise.
+//
+// The two tiers that are worth a line are the ones that contradict that
+// assumption: an identified caller (better than assumed) and a session from
+// another worktree (weaker than assumed).
+func sessionResolutionLabel(resolution strategy.SessionResolution) string {
+	switch resolution {
+	case strategy.ResolutionCallerEnv:
+		return "your own session, named by the agent running this command"
+	case strategy.ResolutionAncestry:
+		return "your own session, matched by process ancestry"
+	case strategy.ResolutionCallerAmbiguous:
+		return "a guess — several agents claim this command and nothing could order them"
+	case strategy.ResolutionOtherWorktree:
+		return "another worktree's session — this worktree has none of its own"
+	case strategy.ResolutionWorktree, strategy.ResolutionNone:
+		return ""
+	default:
+		return ""
+	}
 }

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -921,14 +921,16 @@ func stopSessionAndPrint(ctx context.Context, cmd *cobra.Command, state *strateg
 	return nil
 }
 
-// sessionResolutionLabel renders how a session was resolved, for humans. Empty
-// for a session the caller named outright, and for the plain worktree tier —
-// "the most recent session recorded here" is what someone typing `session
-// current` in a terminal already assumes, so saying it adds noise.
+// sessionResolutionLabel renders how a session was resolved, for humans.
 //
-// The two tiers that are worth a line are the ones that contradict that
-// assumption: an identified caller (better than assumed) and a session from
-// another worktree (weaker than assumed).
+// Every resolution gets a line except ResolutionNone, which means the caller
+// named the session outright and there is nothing to explain. An earlier
+// revision also returned "" for the plain worktree tier, on the grounds that
+// "the most recent session recorded here" is what someone typing `session
+// current` already assumes — but the command's own help promises the output
+// always says which question it answered, and silently omitting the most
+// common tier made that false. Cheaper to keep the promise than to qualify
+// it.
 func sessionResolutionLabel(resolution strategy.SessionResolution) string {
 	switch resolution {
 	case strategy.ResolutionCallerEnv:
@@ -939,7 +941,9 @@ func sessionResolutionLabel(resolution strategy.SessionResolution) string {
 		return "a guess — several agents claim this command and nothing could order them"
 	case strategy.ResolutionOtherWorktree:
 		return "another worktree's session — this worktree has none of its own"
-	case strategy.ResolutionWorktree, strategy.ResolutionNone:
+	case strategy.ResolutionWorktree:
+		return "the most recently active session recorded in this worktree"
+	case strategy.ResolutionNone:
 		return ""
 	default:
 		return ""

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -1814,6 +1814,7 @@ func TestTokensCmd_PrioritizesContextReplayHotspot(t *testing.T) {
 
 func TestTokensCmd_DefaultsToCurrentSession(t *testing.T) {
 	setupStopTestRepo(t)
+	clearCallerSessionEnv(t)
 
 	ctx := context.Background()
 	repoRoot, err := paths.WorktreeRoot(ctx)
@@ -1859,6 +1860,7 @@ func TestTokensCmd_DefaultsToCurrentSession(t *testing.T) {
 
 func TestTokensCmd_CurrentDoesNotFallbackToOtherWorktree(t *testing.T) {
 	setupStopTestRepo(t)
+	clearCallerSessionEnv(t)
 
 	ctx := context.Background()
 	now := time.Now()
@@ -3343,5 +3345,50 @@ func TestSessionPhaseLabel(t *testing.T) {
 				t.Errorf("sessionPhaseLabel() = %q, want %q", got, tt.expected)
 			}
 		})
+	}
+}
+
+// A bare `session tokens` asks the same "which session am I" question as
+// `session current`, so it resolves the caller too: the agent's own session
+// wins over the most recently active one in the shared store.
+func TestTokensCmd_PrefersTheCallersSession(t *testing.T) {
+	setupStopTestRepo(t)
+	clearCallerSessionEnv(t)
+
+	ctx := context.Background()
+	now := time.Now()
+
+	mine := makeSessionState("test-tokens-caller", session.PhaseActive)
+	mine.WorktreePath = testOtherWorktreePath
+	older := now.Add(-2 * time.Hour)
+	mine.LastInteractionTime = &older
+	mine.TokenUsage = &agent.TokenUsage{InputTokens: 1200}
+
+	decoy := makeSessionState("test-tokens-decoy", session.PhaseActive)
+	decoy.WorktreePath = testOtherWorktreePath
+	decoy.LastInteractionTime = &now
+	decoy.TokenUsage = &agent.TokenUsage{InputTokens: 9999}
+
+	for _, s := range []*strategy.SessionState{mine, decoy} {
+		if err := strategy.SaveSessionState(ctx, s); err != nil {
+			t.Fatalf("SaveSessionState() error = %v", err)
+		}
+	}
+	t.Setenv("PI_SESSION_ID", mine.SessionID)
+
+	cmd := newTokensCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{})
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Session: test-tokens-caller") {
+		t.Fatalf("expected the caller's session, got:\n%s", out)
+	}
+	if strings.Contains(out, "test-tokens-decoy") {
+		t.Fatalf("expected the more recent decoy session to be ignored, got:\n%s", out)
 	}
 }

--- a/cmd/entire/cli/strategy/caller_session.go
+++ b/cmd/entire/cli/strategy/caller_session.go
@@ -1,0 +1,323 @@
+package strategy
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+)
+
+// SessionResolution says how a session was arrived at, so a caller can tell an
+// exact answer from a guess.
+//
+// This exists because the guess is genuinely useful to a human — someone who
+// asks which session is current in a terminal means "the one that has been
+// working here" — and genuinely dangerous to an agent, which means "mine" and
+// may go on to act on the answer. One command can serve both only if it says
+// which question it answered.
+type SessionResolution string
+
+const (
+	// ResolutionCallerEnv means an agent published this session's ID into our
+	// environment and nothing nearer in our process ancestry contradicted it.
+	ResolutionCallerEnv SessionResolution = "caller-env"
+
+	// ResolutionAncestry means this session's recorded owner process is the
+	// nearest such ancestor of ours — its agent spawned us, however
+	// indirectly — and no environment variable named it.
+	//
+	// This outranks a bare environment claim rather than backing it up, which
+	// is the opposite of what it looks like it should do. An environment
+	// variable says only that some ancestor published it, not that the
+	// publisher is our caller: agents nest, and an inner agent that publishes
+	// nothing of its own (Gemini CLI, opencode) passes the OUTER agent's
+	// variable straight through to us. Depth is the only signal that
+	// distinguishes "Codex ran me" from "Codex ran Gemini ran me", so the
+	// nearest owner wins wherever ancestry can rank at all.
+	ResolutionAncestry SessionResolution = "ancestry"
+
+	// ResolutionCallerAmbiguous means we are demonstrably inside an agent
+	// session but cannot say which: several agents claim us and nothing
+	// ordered their claims — no owner recorded on any of them, or a platform
+	// that cannot introspect processes. The reported session is the most
+	// plausible of them and explicitly a guess, so this does NOT satisfy
+	// IsCaller.
+	//
+	// Reported rather than resolved on purpose. Picking one and calling it
+	// "your own session" is the failure this whole type exists to prevent, and
+	// registry order — which is what an arbitrary pick amounts to — carries no
+	// information about who invoked the command.
+	ResolutionCallerAmbiguous SessionResolution = "caller-ambiguous"
+
+	// ResolutionWorktree means nothing identified the caller, and this is the
+	// most recently active session recorded in the current worktree.
+	ResolutionWorktree SessionResolution = "worktree"
+
+	// ResolutionOtherWorktree means the current worktree has no sessions at
+	// all, and this is the most recently active session from somewhere else in
+	// the shared store. Correct for "what has been happening in this repo",
+	// never evidence about the caller — worktrees share one session store, so
+	// this can be any of dozens of unrelated sessions.
+	ResolutionOtherWorktree SessionResolution = "other-worktree"
+
+	// ResolutionNone means no session was found by any tier.
+	ResolutionNone SessionResolution = ""
+)
+
+// IsCaller reports whether the resolution actually identified the calling
+// process's own session, rather than inferring or guessing a plausible one.
+// Gate anything that acts on a session — as opposed to merely displaying it —
+// on this.
+//
+// ResolutionCallerAmbiguous is deliberately excluded even though it means "you
+// are definitely inside an agent session": knowing that is not knowing which.
+func (r SessionResolution) IsCaller() bool {
+	return r == ResolutionCallerEnv || r == ResolutionAncestry
+}
+
+// ResolvedSession is a session plus the provenance of how it was picked.
+type ResolvedSession struct {
+	SessionID  string
+	Resolution SessionResolution
+
+	// AgentType is the agent that claimed the session, set only for
+	// ResolutionCallerEnv — the environment says which agent published the ID
+	// before any state has been loaded, and that is worth reporting even when
+	// Tracked is false.
+	AgentType types.AgentType
+
+	// Tracked reports whether Entire holds session state for SessionID. False
+	// only on the ResolutionCallerEnv tier, where the agent named a session
+	// Entire has not recorded: hooks are not installed, they failed, or the
+	// session's first turn has not happened yet (state is created at turn
+	// start). That combination is a diagnosis worth surfacing rather than an
+	// error — the caller is genuinely in a session, and Entire is genuinely
+	// not tracking it.
+	Tracked bool
+}
+
+// Found reports whether any session was resolved.
+func (r ResolvedSession) Found() bool { return r.SessionID != "" }
+
+// ResolveCallerSession answers "which session is running this process?",
+// falling back to "which session is current here?" when nothing can identify
+// the caller. Tiers, strongest first:
+//
+//  1. Identification — the caller's own environment, its process ancestry, or
+//     both, ranked together by how near the owning process is
+//     (resolveCallerIdentity). Reports caller-env, ancestry, or
+//     caller-ambiguous.
+//  2. The most recently active session recorded in this worktree.
+//  3. The most recently active session anywhere in the shared store.
+//
+// Every tier is reported through Resolution, and the weak ones are not
+// silently interchangeable with identification — which is the whole point.
+// `entire session current` used to collapse tiers 2 and 3 and report either as
+// "the active session for the current worktree", so in a worktree with no
+// sessions of its own it returned a live session belonging to a different
+// worktree, indistinguishably from the real thing. An agent that read that ID
+// back and acted on it operated on someone else's session.
+//
+// Environment and ancestry are ONE tier rather than two, ordered internally.
+// An earlier revision tried the environment first and returned on any hit,
+// which is wrong for the nesting case: an inner agent that publishes no ID of
+// its own passes the outer agent's variable through, so the lone claim named
+// the outer session while the inner one sat in our ancestry one hop away. See
+// ResolutionAncestry.
+func ResolveCallerSession(ctx context.Context) ResolvedSession {
+	states, err := ListSessionStates(ctx)
+	if err != nil {
+		logging.Debug(logging.WithComponent(ctx, "session"),
+			"caller session resolution: cannot list session states",
+			slog.String("error", err.Error()))
+		states = nil
+	}
+
+	if resolved, ok := resolveCallerIdentity(ctx, states); ok {
+		return resolved
+	}
+	if id := mostRecentSessionID(sessionStatesForCurrentWorktree(ctx, states)); id != "" {
+		return ResolvedSession{SessionID: id, Resolution: ResolutionWorktree, Tracked: true}
+	}
+	if id := mostRecentSessionID(states); id != "" {
+		return ResolvedSession{SessionID: id, Resolution: ResolutionOtherWorktree, Tracked: true}
+	}
+	return ResolvedSession{Resolution: ResolutionNone}
+}
+
+// callerCandidate is one session that might be running us, with the evidence
+// for it: whether the environment named it, and how near its owner process is
+// in our ancestry (-1 when it could not be placed there at all).
+type callerCandidate struct {
+	state     *SessionState
+	agentType types.AgentType
+	envNamed  bool
+	depth     int
+}
+
+// resolveCallerIdentity identifies the session running this process from the
+// environment and the process tree together, or reports that it cannot.
+//
+// Both signals are partial in opposite ways, which is why neither can be a
+// separate tier that short-circuits the other. The environment is a positive
+// statement by a vendor, but only that SOME ancestor published it — an inner
+// agent publishing nothing forwards the outer agent's variable verbatim.
+// Ancestry says which owner is nearest, but only for sessions that recorded an
+// owner (turn start), and not at all on a platform that cannot introspect
+// processes. So candidates are gathered from either signal and ranked by
+// depth, with the environment breaking ties depth cannot.
+func resolveCallerIdentity(ctx context.Context, states []*SessionState) (ResolvedSession, bool) {
+	claims := agent.CallerSessionCandidates()
+	claimedBy := make(map[string]types.AgentType, len(claims))
+	for _, claim := range claims {
+		claimedBy[claim.SessionID] = claim.AgentType
+	}
+
+	// Needed whenever anything might be ranked, which is any time we have
+	// either a claim or a state that could carry an owner. Snapshot once:
+	// each call walks the process tree and reads the hostname and boot ID.
+	var ancestry proclive.Ancestry
+	haveAncestry := false
+	if len(claims) > 0 || len(states) > 0 {
+		ancestry, haveAncestry = proclive.CurrentAncestry()
+	}
+
+	var candidates []callerCandidate
+	placedClaims := make(map[string]bool, len(claimedBy))
+	for _, state := range states {
+		if state.Kind.IsImported() || state.AdoptedIntoWorktreePath != "" {
+			continue
+		}
+		agentType, envNamed := claimedBy[state.SessionID]
+		depth := -1
+		if haveAncestry && state.Owner != nil {
+			depth = ancestry.Depth(*state.Owner)
+		}
+		if !envNamed && depth < 0 {
+			continue
+		}
+		if envNamed && depth >= 0 {
+			placedClaims[state.SessionID] = true
+		}
+		if !envNamed {
+			agentType = state.AgentType
+		}
+		candidates = append(candidates, callerCandidate{
+			state: state, agentType: agentType, envNamed: envNamed, depth: depth,
+		})
+	}
+
+	if len(candidates) == 0 {
+		return resolveUntrackedClaims(ctx, claims)
+	}
+
+	best := candidates[0]
+	for _, candidate := range candidates[1:] {
+		if isNearerOwner(candidate.depth, best.depth, candidate.state, best.state) {
+			best = candidate
+		}
+	}
+
+	resolution := ResolutionCallerEnv
+	switch {
+	case !claimsRuledOut(claimedBy, placedClaims, best.state.SessionID, best.depth):
+		resolution = ResolutionCallerAmbiguous
+	case !best.envNamed:
+		resolution = ResolutionAncestry
+	}
+
+	resolved := ResolvedSession{
+		SessionID:  best.state.SessionID,
+		Resolution: resolution,
+		AgentType:  best.agentType,
+		Tracked:    true,
+	}
+	logging.Debug(logging.WithComponent(ctx, "session"),
+		"caller session identified",
+		slog.String("session_id", resolved.SessionID),
+		slog.String("resolution", string(resolution)),
+		slog.String("agent_type", string(resolved.AgentType)),
+		slog.Int("candidates", len(candidates)),
+		slog.Int("env_claims", len(claimedBy)),
+		slog.Int("placed_claims", len(placedClaims)),
+		slog.Int("ancestry_depth", best.depth))
+	return resolved, true
+}
+
+// claimsRuledOut reports whether the winner can be believed: no session the
+// environment named could be nearer to us than it is.
+//
+// A claim reached our environment, so its agent IS somewhere in our ancestry —
+// that much is certain. What is unknown is where. A claim we could not place
+// (untracked, so no owner to compare; or tracked with no owner recorded yet,
+// since the first turn creates it) therefore sits at an unmeasured depth, and
+// unmeasured means "possibly nearer than the winner". Two exemptions, and only
+// two:
+//
+// A winner at depth 0 owns our immediate parent process. Nothing can be nearer
+// than that, so no unplaced claim can shadow it however many there are. Note
+// the exemption claims only that: nothing NEARER. An unplaced claim whose
+// owner happens to be that same parent process — one agent process hosting two
+// sessions after a resume — is equally near and invisible, which is the
+// residual this cannot close. Equal depth is the case recency breaks when both
+// sides are placed; here one side cannot be seen at all.
+//
+// A claim that IS the winner shadows nothing — it is the thing being believed.
+// This is the ordinary single-agent shape: one variable, one session, whose
+// owner may not be recorded yet.
+//
+// An earlier revision exempted "exactly one claim" instead, reasoning that a
+// lone claim has nothing to be nearer than. That is true of a lone claim that
+// WINS, and the revision quietly assumed the two were the same thing. They are
+// not: a claim with no state cannot enter the ranking at all, so a tracked
+// session found purely by ancestry won instead and was reported as the
+// identified caller while the claim that named itself in our own environment
+// went unexamined. Do not reintroduce a count-based exemption; the question is
+// about the winner, not about how many claims there are.
+func claimsRuledOut(claimedBy map[string]types.AgentType, placed map[string]bool, winnerID string, winnerDepth int) bool {
+	if winnerDepth == 0 {
+		return true
+	}
+	for id := range claimedBy {
+		if id != winnerID && !placed[id] {
+			return false
+		}
+	}
+	return true
+}
+
+// resolveUntrackedClaims handles the case where agents claim us but Entire
+// holds state for none of them.
+//
+// The claim is still worth reporting: we are demonstrably inside a session
+// Entire is not recording — hooks not installed, hooks failed, or the first
+// turn not yet landed (state is created at turn start) — and that is a
+// diagnosis, where falling through to the most-recent tiers would answer a
+// question nobody asked with an unrelated session.
+//
+// More than one such claim cannot be ordered at all: with no state there is no
+// owner to compare and no interaction time to fall back on, so any pick is
+// registry order wearing a disguise. Report it ambiguous.
+func resolveUntrackedClaims(ctx context.Context, claims []agent.CallerSessionCandidate) (ResolvedSession, bool) {
+	if len(claims) == 0 {
+		return ResolvedSession{}, false
+	}
+	resolution := ResolutionCallerEnv
+	if len(claims) > 1 {
+		resolution = ResolutionCallerAmbiguous
+	}
+	resolved := ResolvedSession{
+		SessionID:  claims[0].SessionID,
+		Resolution: resolution,
+		AgentType:  claims[0].AgentType,
+	}
+	logging.Debug(logging.WithComponent(ctx, "session"),
+		"caller session claimed but not tracked",
+		slog.String("session_id", resolved.SessionID),
+		slog.String("resolution", string(resolution)),
+		slog.Int("env_claims", len(claims)))
+	return resolved, true
+}

--- a/cmd/entire/cli/strategy/caller_session.go
+++ b/cmd/entire/cli/strategy/caller_session.go
@@ -83,19 +83,30 @@ type ResolvedSession struct {
 	SessionID  string
 	Resolution SessionResolution
 
-	// AgentType is the agent that claimed the session, set only for
-	// ResolutionCallerEnv — the environment says which agent published the ID
-	// before any state has been loaded, and that is worth reporting even when
-	// Tracked is false.
+	// AgentType names the agent the session belongs to, on any resolution the
+	// identification tier produced — from the environment when a claim named
+	// the session, otherwise from the session's own state. Set even when
+	// Tracked is false, which is the case it exists for: the environment
+	// identifies the agent before any state has been loaded, and "you are
+	// inside a Codex session Entire is not recording" is the whole diagnosis.
+	// Empty on the worktree and other-worktree tiers, which report a session
+	// rather than a caller.
 	AgentType types.AgentType
 
-	// Tracked reports whether Entire holds session state for SessionID. False
-	// only on the ResolutionCallerEnv tier, where the agent named a session
-	// Entire has not recorded: hooks are not installed, they failed, or the
-	// session's first turn has not happened yet (state is created at turn
-	// start). That combination is a diagnosis worth surfacing rather than an
-	// error — the caller is genuinely in a session, and Entire is genuinely
-	// not tracking it.
+	// Tracked reports whether Entire holds session state for SessionID.
+	//
+	// False only when the environment named a session Entire has not
+	// recorded — hooks not installed, hooks failed, or the first turn not yet
+	// landed, since state is created at turn start. That reaches the caller as
+	// ResolutionCallerEnv for a single claim or ResolutionCallerAmbiguous for
+	// several, so do NOT test it by comparing Resolution; test this field.
+	//
+	// A diagnosis rather than an error: the caller is genuinely in a session,
+	// and Entire is genuinely not tracking it. Load-bearing for exactly that
+	// reason — `session current` and `session tokens` branch to their
+	// untracked diagnostic on it — so resolveUntrackedClaims assigns it
+	// explicitly rather than leaning on the zero value, matching the
+	// `Tracked: true` its sibling paths write.
 	Tracked bool
 }
 
@@ -313,6 +324,10 @@ func resolveUntrackedClaims(ctx context.Context, claims []agent.CallerSessionCan
 		SessionID:  claims[0].SessionID,
 		Resolution: resolution,
 		AgentType:  claims[0].AgentType,
+		// Explicit, not the zero value: false here is the assertion this
+		// whole function makes, and the flag every untracked diagnostic
+		// branches on. Its sibling paths spell out Tracked: true.
+		Tracked: false,
 	}
 	logging.Debug(logging.WithComponent(ctx, "session"),
 		"caller session claimed but not tracked",

--- a/cmd/entire/cli/strategy/caller_session_test.go
+++ b/cmd/entire/cli/strategy/caller_session_test.go
@@ -1,0 +1,473 @@
+package strategy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// clearCallerSessionEnv unsets every agent's caller-session variable, derived
+// from the registry rather than hand-listed so it cannot rot when an agent is
+// added. Necessary because `go test` is routinely run from inside one of these
+// agents, whose variable would otherwise leak into every case below.
+func clearCallerSessionEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range agent.CallerSessionEnvVars() {
+		t.Setenv(name, "")
+	}
+}
+
+// callerSessionRepo sets up an isolated repo, chdirs into it, and returns the
+// worktree root as git resolves it (symlinks and all, e.g. /var →
+// /private/var on macOS) so a state's WorktreePath can be made to match.
+func callerSessionRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	resolved, err := paths.WorktreeRoot(context.Background())
+	if err != nil {
+		t.Fatalf("paths.WorktreeRoot() error = %v", err)
+	}
+	return resolved
+}
+
+func saveState(t *testing.T, id, worktree string, lastInteraction time.Time) {
+	t.Helper()
+	state := &SessionState{
+		SessionID:           id,
+		BaseCommit:          "abc1234",
+		WorktreePath:        worktree,
+		StartedAt:           lastInteraction,
+		LastInteractionTime: &lastInteraction,
+		Phase:               "idle",
+	}
+	if err := SaveSessionState(context.Background(), state); err != nil {
+		t.Fatalf("SaveSessionState(%q) error = %v", id, err)
+	}
+}
+
+// The reported bug, as a test: an agent asks which session is running it from
+// a worktree that has no sessions of its own. Before the caller tier, the
+// answer was another worktree's live session, indistinguishable from a real
+// one — which is what got fed to `session adopt`.
+func TestResolveCallerSession_PrefersTheCallerOverAnotherWorktreesSession(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	saveState(t, "elsewhere-session", "/some/other/worktree", time.Now())
+	saveState(t, "caller-session", "/a/third/worktree", time.Now().Add(-2*time.Hour))
+	t.Setenv("CODEX_SESSION_ID", "caller-session")
+
+	got := ResolveCallerSession(context.Background())
+	if got.SessionID != "caller-session" {
+		t.Errorf("SessionID = %q, want %q (the caller, not the most recent)", got.SessionID, "caller-session")
+	}
+	if got.Resolution != ResolutionCallerEnv {
+		t.Errorf("Resolution = %q, want %q", got.Resolution, ResolutionCallerEnv)
+	}
+	if !got.Tracked {
+		t.Error("Tracked = false; state was saved for this session")
+	}
+	if !got.Resolution.IsCaller() {
+		t.Error("IsCaller() = false for the caller-env tier")
+	}
+}
+
+func TestResolveCallerSession_FallsBackToThisWorktree(t *testing.T) {
+	clearCallerSessionEnv(t)
+	worktree := callerSessionRepo(t)
+
+	saveState(t, "elsewhere-session", "/some/other/worktree", time.Now())
+	saveState(t, "local-session", worktree, time.Now().Add(-time.Hour))
+
+	got := ResolveCallerSession(context.Background())
+	if got.SessionID != "local-session" {
+		t.Errorf("SessionID = %q, want %q (prefer this worktree over a newer foreign one)", got.SessionID, "local-session")
+	}
+	if got.Resolution != ResolutionWorktree {
+		t.Errorf("Resolution = %q, want %q", got.Resolution, ResolutionWorktree)
+	}
+	if got.Resolution.IsCaller() {
+		t.Error("IsCaller() = true for the worktree tier; it is an inference, not an identification")
+	}
+}
+
+// The weakest tier must still be reachable — it is what a human asking "what
+// has been happening in this repo" wants — but it must announce itself, since
+// nothing about it relates to the caller.
+func TestResolveCallerSession_LabelsTheCrossWorktreeFallback(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	saveState(t, "elsewhere-session", "/some/other/worktree", time.Now())
+
+	got := ResolveCallerSession(context.Background())
+	if got.SessionID != "elsewhere-session" {
+		t.Errorf("SessionID = %q, want %q", got.SessionID, "elsewhere-session")
+	}
+	if got.Resolution != ResolutionOtherWorktree {
+		t.Errorf("Resolution = %q, want %q", got.Resolution, ResolutionOtherWorktree)
+	}
+	if got.Resolution.IsCaller() {
+		t.Error("IsCaller() = true for the other-worktree tier; this is the one an agent must never act on")
+	}
+}
+
+func TestResolveCallerSession_NothingFound(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	got := ResolveCallerSession(context.Background())
+	if got.Found() {
+		t.Errorf("ResolveCallerSession() = %+v, want no session", got)
+	}
+	if got.Resolution != ResolutionNone {
+		t.Errorf("Resolution = %q, want %q", got.Resolution, ResolutionNone)
+	}
+}
+
+// An agent named its session but Entire holds no state for it: hooks are not
+// installed, they failed, or the first turn has not landed. The ID and the
+// agent are still reported, because "you are in session X and Entire is not
+// recording it" is a diagnosis — and crucially it must NOT fall through to a
+// weaker tier and answer with someone else's session.
+func TestResolveCallerSession_ReportsAnUntrackedCallerRatherThanGuessing(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	saveState(t, "elsewhere-session", "/some/other/worktree", time.Now())
+	t.Setenv("CURSOR_CONVERSATION_ID", "untracked-caller")
+
+	got := ResolveCallerSession(context.Background())
+	if got.SessionID != "untracked-caller" {
+		t.Errorf("SessionID = %q, want %q", got.SessionID, "untracked-caller")
+	}
+	if got.Tracked {
+		t.Error("Tracked = true; no state was saved for this session")
+	}
+	if got.Resolution != ResolutionCallerEnv {
+		t.Errorf("Resolution = %q, want %q", got.Resolution, ResolutionCallerEnv)
+	}
+	if got.AgentType == "" {
+		t.Error("AgentType is empty; the environment names the agent even when state is missing")
+	}
+}
+
+// A tracked claim is the one worth REPORTING when the other is untracked — a
+// session Entire holds is more useful than an ID it knows nothing about — but
+// reporting is not identifying. The untracked claim has no recorded owner, so
+// ancestry cannot place it and cannot rule it out as the nearer of the two.
+func TestResolveCallerSession_TrackedClaimIsReportedButStillAmbiguous(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	saveState(t, "inner-session", "/some/other/worktree", time.Now())
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "outer-untracked")
+	t.Setenv("CODEX_SESSION_ID", "inner-session")
+
+	got := ResolveCallerSession(context.Background())
+	if got.SessionID != "inner-session" {
+		t.Errorf("SessionID = %q, want the tracked claim %q", got.SessionID, "inner-session")
+	}
+	if !got.Tracked {
+		t.Error("Tracked = false; the tracked candidate should have been reported")
+	}
+	if got.Resolution != ResolutionCallerAmbiguous {
+		t.Errorf("Resolution = %q, want %q", got.Resolution, ResolutionCallerAmbiguous)
+	}
+}
+
+// Two tracked claims that ancestry cannot order — neither recorded an owner —
+// is not an identification. The most recently active one is still reported as
+// the most plausible guess, but the resolution says it is a guess, so nothing
+// acts on it. Picking one and calling it "your own session" is the failure the
+// whole type exists to prevent.
+func TestResolveCallerSession_UnrankableNestedClaimsAreAmbiguous(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	saveState(t, "outer-session", "/some/other/worktree", time.Now().Add(-time.Hour))
+	saveState(t, "inner-session", "/some/other/worktree", time.Now())
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "outer-session")
+	t.Setenv("CODEX_SESSION_ID", "inner-session")
+
+	got := ResolveCallerSession(context.Background())
+	if got.Resolution != ResolutionCallerAmbiguous {
+		t.Errorf("Resolution = %q, want %q — nothing ordered the two claims", got.Resolution, ResolutionCallerAmbiguous)
+	}
+	if got.Resolution.IsCaller() {
+		t.Error("IsCaller() = true for an unordered pair of claims")
+	}
+	if got.SessionID != "inner-session" {
+		t.Errorf("SessionID = %q, want the most plausible guess %q", got.SessionID, "inner-session")
+	}
+}
+
+// Same rule with no state at all: two untracked claims cannot be ordered by
+// anything — no owner to compare, no interaction time — so a pick would be
+// registry order in disguise.
+func TestResolveCallerSession_UntrackedMultipleClaimsAreAmbiguous(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "untracked-outer")
+	t.Setenv("CODEX_SESSION_ID", "untracked-inner")
+
+	got := ResolveCallerSession(context.Background())
+	if got.Resolution != ResolutionCallerAmbiguous {
+		t.Errorf("Resolution = %q, want %q", got.Resolution, ResolutionCallerAmbiguous)
+	}
+	if got.Tracked {
+		t.Error("Tracked = true; no state was saved for either claim")
+	}
+	if !got.Found() {
+		t.Error("Found() = false; being inside an untracked session is still worth reporting")
+	}
+}
+
+// An unsafe value reads as absent at the agent layer, so the resolver must
+// degrade to a weaker tier rather than carry it — never resolve a path from an
+// ID the environment supplied unchecked.
+func TestResolveCallerSession_IgnoresAnUnsafePublishedID(t *testing.T) {
+	clearCallerSessionEnv(t)
+	worktree := callerSessionRepo(t)
+
+	saveState(t, "local-session", worktree, time.Now())
+	t.Setenv("CODEX_SESSION_ID", "../../../etc/passwd")
+
+	got := ResolveCallerSession(context.Background())
+	if got.SessionID != "local-session" || got.Resolution != ResolutionWorktree {
+		t.Errorf("ResolveCallerSession() = %+v, want the worktree tier", got)
+	}
+}
+
+func TestSessionResolution_IsCaller(t *testing.T) {
+	cases := map[SessionResolution]bool{
+		ResolutionCallerEnv:       true,
+		ResolutionAncestry:        true,
+		ResolutionCallerAmbiguous: false,
+		ResolutionWorktree:        false,
+		ResolutionOtherWorktree:   false,
+		ResolutionNone:            false,
+	}
+	for resolution, want := range cases {
+		if got := resolution.IsCaller(); got != want {
+			t.Errorf("SessionResolution(%q).IsCaller() = %v, want %v", resolution, got, want)
+		}
+	}
+}
+
+// The ancestry tier, exercised with a real identity rather than a fixture:
+// proclive.Chain() is the documented way tests obtain live identities at known
+// depths, so recording chain[0] as a session's owner makes that session
+// genuinely our nearest-ancestor match.
+//
+// This tier is what covers the agents that publish no session ID — Gemini CLI
+// and opencode — so it must not be left to the environment-variable tests.
+func TestResolveCallerSession_MatchesOwnerByProcessAncestry(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	ancestry, ok := proclive.CurrentAncestry()
+	if !ok {
+		t.Skip("platform cannot introspect processes; the ancestry tier is unavailable here by design")
+	}
+	chain := ancestry.Chain()
+	if len(chain) == 0 {
+		t.Skip("no ancestors visible; nothing to match against")
+	}
+	owner := chain[0]
+
+	newer := time.Now()
+	older := newer.Add(-2 * time.Hour)
+	// A newer session elsewhere that ancestry must lose to, so a pass cannot
+	// come from the recency tiers underneath.
+	saveState(t, "newer-elsewhere", "/some/other/worktree", newer)
+
+	owned := &SessionState{
+		SessionID:           "ancestry-owned",
+		BaseCommit:          "abc1234",
+		WorktreePath:        "/a/third/worktree",
+		StartedAt:           older,
+		LastInteractionTime: &older,
+		Phase:               "idle",
+		Owner:               &owner,
+	}
+	if err := SaveSessionState(context.Background(), owned); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	got := ResolveCallerSession(context.Background())
+	if got.SessionID != "ancestry-owned" {
+		t.Errorf("SessionID = %q, want %q (our nearest-ancestor owner)", got.SessionID, "ancestry-owned")
+	}
+	if got.Resolution != ResolutionAncestry {
+		t.Errorf("Resolution = %q, want %q", got.Resolution, ResolutionAncestry)
+	}
+	if !got.Resolution.IsCaller() {
+		t.Error("IsCaller() = false for the ancestry tier")
+	}
+}
+
+// What the environment tier is actually for, now that a nearer owner outranks
+// it: naming a session ancestry cannot rank. A session whose owner was never
+// recorded (no turn has started yet) is invisible to the process walk, and on
+// a platform that cannot introspect at all the walk finds nothing — the
+// published ID is the only evidence there is, and it is good evidence.
+func TestResolveCallerSession_EnvClaimWinsWhenAncestryCannotRank(t *testing.T) {
+	clearCallerSessionEnv(t)
+	worktree := callerSessionRepo(t)
+
+	now := time.Now()
+	// Neither session records an owner, so depth is unresolved for both and
+	// only the environment distinguishes them.
+	saveState(t, "local-session", worktree, now)
+	saveState(t, "env-named", "/some/other/worktree", now.Add(-2*time.Hour))
+	t.Setenv("CODEX_SESSION_ID", "env-named")
+
+	got := ResolveCallerSession(context.Background())
+	if got.SessionID != "env-named" || got.Resolution != ResolutionCallerEnv {
+		t.Errorf("ResolveCallerSession() = %+v, want env-named via caller-env", got)
+	}
+	if !got.Resolution.IsCaller() {
+		t.Error("IsCaller() = false; a single unopposed claim is an identification")
+	}
+}
+
+// An inherited environment ID must not outrank the session that actually
+// spawned us. Codex launching Gemini or opencode is the shape: the inner agent
+// publishes no ID of its own, so CODEX_SESSION_ID survives in our environment
+// through the inner agent's process and is the ONLY env claim — while the
+// inner session's owner is our nearest ancestor. Accepting the lone claim
+// names the outer session and marks it IsCaller, which is precisely the
+// "safe to act on" mistake the tiering exists to prevent.
+func TestResolveCallerSession_InheritedEnvIDLosesToTheNearerOwner(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	ancestry, ok := proclive.CurrentAncestry()
+	if !ok {
+		t.Skip("platform cannot introspect processes; ancestry cannot arbitrate here by design")
+	}
+	chain := ancestry.Chain()
+	if len(chain) == 0 {
+		t.Skip("no ancestors visible; nothing to match against")
+	}
+	// chain[0] is load-bearing: the winner lands at depth 0, our immediate
+	// parent, which is what lets claimsRuledOut believe it despite the
+	// unplaced outer claim. At any greater depth this case is ambiguous
+	// instead — see UnplacedClaimShadowsADistantAncestryWinner.
+	nearest := chain[0]
+
+	now := time.Now()
+	// The outer agent: env-claimed, tracked, but its owner is not in our
+	// ancestry at all — it reached us only by inheritance.
+	saveState(t, "outer-env-claimed", "/some/other/worktree", now)
+	// The inner agent: publishes nothing, but its owner IS our nearest ancestor.
+	inner := &SessionState{
+		SessionID:           "inner-real-caller",
+		BaseCommit:          "abc1234",
+		WorktreePath:        "/a/third/worktree",
+		StartedAt:           now.Add(-2 * time.Hour),
+		LastInteractionTime: ptrTime(now.Add(-2 * time.Hour)),
+		Phase:               "idle",
+		Owner:               &nearest,
+	}
+	if err := SaveSessionState(context.Background(), inner); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+	t.Setenv("CODEX_SESSION_ID", "outer-env-claimed")
+
+	got := ResolveCallerSession(context.Background())
+	if got.SessionID != "inner-real-caller" {
+		t.Errorf("SessionID = %q, want %q — the inherited claim outranked the real caller",
+			got.SessionID, "inner-real-caller")
+	}
+	if got.Resolution != ResolutionAncestry {
+		t.Errorf("Resolution = %q, want %q", got.Resolution, ResolutionAncestry)
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+// Mixed tracked and untracked claims must not resolve to an identification.
+// A tracked outer Claude session launching an as-yet-untracked Codex session
+// leaves both variables set, but only the outer one has state, so only it can
+// enter the ranking — and it then wins by default and is reported as the
+// caller. The inner claim is the likelier caller and nothing ruled it out:
+// an untracked session has no recorded owner, so ancestry cannot place it.
+func TestResolveCallerSession_MixedTrackedAndUntrackedClaimsAreAmbiguous(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	saveState(t, "outer-tracked", "/some/other/worktree", time.Now())
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "outer-tracked")
+	t.Setenv("CODEX_SESSION_ID", "inner-untracked")
+
+	got := ResolveCallerSession(context.Background())
+	if got.Resolution != ResolutionCallerAmbiguous {
+		t.Errorf("Resolution = %q, want %q — an untracked claim cannot be ruled out as nearer",
+			got.Resolution, ResolutionCallerAmbiguous)
+	}
+	if got.Resolution.IsCaller() {
+		t.Error("IsCaller() = true while an unplaceable claim exists")
+	}
+	// The tracked session is still the more useful thing to report.
+	if got.SessionID != "outer-tracked" {
+		t.Errorf("SessionID = %q, want the tracked claim %q", got.SessionID, "outer-tracked")
+	}
+}
+
+// An unplaced claim can shadow an ancestry winner that is not our parent.
+// A tracked opencode session launching an untracked Codex session publishes
+// only CODEX_SESSION_ID: opencode enters the ranking through ancestry, Codex
+// cannot enter at all for want of state, and opencode is then reported as the
+// identified caller. The Codex claim is demonstrably in our ancestry — it put
+// a variable in our environment — at a depth we cannot measure, so it could
+// be the nearer of the two.
+func TestResolveCallerSession_UnplacedClaimShadowsADistantAncestryWinner(t *testing.T) {
+	clearCallerSessionEnv(t)
+	callerSessionRepo(t)
+
+	ancestry, ok := proclive.CurrentAncestry()
+	if !ok {
+		t.Skip("platform cannot introspect processes; ancestry cannot arbitrate here by design")
+	}
+	chain := ancestry.Chain()
+	if len(chain) < 2 {
+		t.Skip("need an ancestor beyond our parent: depth 0 is decisive on its own")
+	}
+	// Deliberately NOT chain[0]: an owner that is our immediate parent cannot
+	// be shadowed, and that case is covered separately.
+	distant := chain[1]
+
+	now := time.Now()
+	owned := &SessionState{
+		SessionID:           "opencode-outer",
+		BaseCommit:          "abc1234",
+		WorktreePath:        "/some/other/worktree",
+		StartedAt:           now,
+		LastInteractionTime: &now,
+		Phase:               "idle",
+		Owner:               &distant,
+	}
+	if err := SaveSessionState(context.Background(), owned); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+	t.Setenv("CODEX_SESSION_ID", "codex-inner-untracked")
+
+	got := ResolveCallerSession(context.Background())
+	if got.Resolution != ResolutionCallerAmbiguous {
+		t.Errorf("Resolution = %q, want %q — an unmeasurable claim could sit nearer than depth %d",
+			got.Resolution, ResolutionCallerAmbiguous, 1)
+	}
+	if got.Resolution.IsCaller() {
+		t.Error("IsCaller() = true while an unplaced claim could be nearer")
+	}
+}

--- a/cmd/entire/cli/strategy/session_identity.go
+++ b/cmd/entire/cli/strategy/session_identity.go
@@ -82,11 +82,27 @@ func linkingSetContains(states []*SessionState, id string) bool {
 // file per session in the shared store, so a per-candidate walk would repeat
 // the hostname/boot/proc reads dozens of times per commit.
 func (s *ManualCommitStrategy) findSessionByCommitAncestry(ctx context.Context, states []*SessionState) *SessionState {
-	// requireWorktreePath: a commit is attributed in order to condense and
-	// link it, and both need somewhere to do that. Caller resolution asks only
-	// "whose process am I", so it does not require one — see
-	// nearestSessionByOwnerAncestry.
-	best, _ := nearestSessionByOwnerAncestry(states, true)
+	ancestry, ok := proclive.CurrentAncestry()
+	if !ok {
+		return nil
+	}
+	var best *SessionState
+	bestDepth := -1
+	for _, state := range states {
+		// WorktreePath is required here and NOT by caller resolution: a commit
+		// is attributed in order to condense and link it, and both need
+		// somewhere to do that, while resolving a caller only names a session.
+		if state.Owner == nil || state.WorktreePath == "" || state.Kind.IsImported() || state.AdoptedIntoWorktreePath != "" {
+			continue
+		}
+		depth := ancestry.Depth(*state.Owner)
+		if depth < 0 {
+			continue
+		}
+		if best == nil || isNearerOwner(depth, bestDepth, state, best) {
+			best, bestDepth = state, depth
+		}
+	}
 	if best != nil {
 		logging.Debug(logging.WithComponent(ctx, "checkpoint"),
 			"commit attributed to session by process ancestry",
@@ -98,62 +114,33 @@ func (s *ManualCommitStrategy) findSessionByCommitAncestry(ctx context.Context, 
 	return best
 }
 
-// nearestSessionByOwnerAncestry returns the session whose recorded owner
-// process is the nearest ancestor of this one, with its ancestry depth, or
-// (nil, -1) when none is.
-//
-// The one implementation of "which session's agent spawned us", shared by
-// commit attribution (findSessionByCommitAncestry) and caller resolution
-// (sessionIDByOwnerAncestry). They had a loop each, differing only in one
-// guard, which is how the tie-break and the imported/adopted exclusions —
-// invariants documented at length above and both easy to get subtly wrong —
-// came to be independently editable in two places.
-//
-// The owner fingerprint carries host, boot and start-time guards, so a
-// recycled PID or an identity recorded on another machine cannot match, and
-// nearest-ancestor-wins resolves nesting. Returns (nil, -1) on platforms that
-// cannot introspect processes (Windows), which is why every caller needs a
-// weaker fallback.
-//
-// requireWorktreePath is the sole difference between the two callers, and it
-// is a real semantic one rather than an accident: attribution mutates
-// worktree-coupled state and so needs a worktree recorded, while caller
-// resolution only names a session.
-func nearestSessionByOwnerAncestry(states []*SessionState, requireWorktreePath bool) (*SessionState, int) {
-	ancestry, ok := proclive.CurrentAncestry()
-	if !ok {
-		return nil, -1
-	}
-	var best *SessionState
-	bestDepth := -1
-	for _, state := range states {
-		if state.Owner == nil || state.Kind.IsImported() || state.AdoptedIntoWorktreePath != "" {
-			continue
-		}
-		if requireWorktreePath && state.WorktreePath == "" {
-			continue
-		}
-		depth := ancestry.Depth(*state.Owner)
-		if depth < 0 {
-			continue
-		}
-		if best == nil || isNearerOwner(depth, bestDepth, state, best) {
-			best, bestDepth = state, depth
-		}
-	}
-	return best, bestDepth
-}
-
 // isNearerOwner reports whether an owner match at depth beats the incumbent at
-// bestDepth: a resolved depth (>= 0) beats an unresolved one, nearer beats
-// farther, and otherwise the more recently interacting session wins.
+// bestDepth. A depth of -1 means the owner could not be placed in our
+// ancestry at all. The contract, for any pair of inputs:
 //
-// Recency only ever breaks a tie WITHIN one depth — the same agent process
-// hosting several sessions over its lifetime, e.g. after a resume — never
-// across depths, where the nearer process is the answer whatever the clocks
-// say. Callers that filter out unresolved depths never reach the last branch;
-// caller resolution does reach it, because a candidate the environment named
-// may have no owner recorded yet.
+//   - exactly one placed — the placed one wins, at any depth;
+//   - both placed — the nearer wins, and an exact tie goes to the more
+//     recently interacting session;
+//   - neither placed — the more recently interacting session wins.
+//
+// Recency therefore only ever breaks a tie between equals, never across
+// depths, where the nearer process is the answer whatever the clocks say. Two
+// equal placed depths means one agent process hosting several sessions over
+// its lifetime, e.g. after a resume. Two unplaced depths means nothing located
+// either, and recency is the last thing left — deliberate rather than a
+// fallthrough, though a caller that treats the result as an identification
+// must not use it (see claimsRuledOut, which is why resolveCallerIdentity
+// reports caller-ambiguous in exactly that case).
+//
+// The one shared piece between commit attribution
+// (findSessionByCommitAncestry, above) and caller resolution
+// (resolveCallerIdentity in caller_session.go). Their loops differ in what
+// they admit as a candidate, so only the comparison is common — an earlier
+// revision extracted the whole loop, which stopped paying for itself the
+// moment caller resolution merged its ancestry pass into the environment one
+// and left the extraction with a single caller. Attribution never passes an
+// unplaced depth today; the contract above holds regardless, so a future
+// caller that does needs no change here.
 func isNearerOwner(depth, bestDepth int, state, best *SessionState) bool {
 	if (depth >= 0) != (bestDepth >= 0) {
 		return depth >= 0

--- a/cmd/entire/cli/strategy/session_identity.go
+++ b/cmd/entire/cli/strategy/session_identity.go
@@ -82,24 +82,11 @@ func linkingSetContains(states []*SessionState, id string) bool {
 // file per session in the shared store, so a per-candidate walk would repeat
 // the hostname/boot/proc reads dozens of times per commit.
 func (s *ManualCommitStrategy) findSessionByCommitAncestry(ctx context.Context, states []*SessionState) *SessionState {
-	ancestry, ok := proclive.CurrentAncestry()
-	if !ok {
-		return nil
-	}
-	var best *SessionState
-	bestDepth := -1
-	for _, state := range states {
-		if state.WorktreePath == "" || state.Kind.IsImported() || state.AdoptedIntoWorktreePath != "" || state.Owner == nil {
-			continue
-		}
-		depth := ancestry.Depth(*state.Owner)
-		if depth < 0 {
-			continue
-		}
-		if best == nil || depth < bestDepth || (depth == bestDepth && interactedAfter(state, best)) {
-			best, bestDepth = state, depth
-		}
-	}
+	// requireWorktreePath: a commit is attributed in order to condense and
+	// link it, and both need somewhere to do that. Caller resolution asks only
+	// "whose process am I", so it does not require one — see
+	// nearestSessionByOwnerAncestry.
+	best, _ := nearestSessionByOwnerAncestry(states, true)
 	if best != nil {
 		logging.Debug(logging.WithComponent(ctx, "checkpoint"),
 			"commit attributed to session by process ancestry",
@@ -109,6 +96,72 @@ func (s *ManualCommitStrategy) findSessionByCommitAncestry(ctx context.Context, 
 		)
 	}
 	return best
+}
+
+// nearestSessionByOwnerAncestry returns the session whose recorded owner
+// process is the nearest ancestor of this one, with its ancestry depth, or
+// (nil, -1) when none is.
+//
+// The one implementation of "which session's agent spawned us", shared by
+// commit attribution (findSessionByCommitAncestry) and caller resolution
+// (sessionIDByOwnerAncestry). They had a loop each, differing only in one
+// guard, which is how the tie-break and the imported/adopted exclusions —
+// invariants documented at length above and both easy to get subtly wrong —
+// came to be independently editable in two places.
+//
+// The owner fingerprint carries host, boot and start-time guards, so a
+// recycled PID or an identity recorded on another machine cannot match, and
+// nearest-ancestor-wins resolves nesting. Returns (nil, -1) on platforms that
+// cannot introspect processes (Windows), which is why every caller needs a
+// weaker fallback.
+//
+// requireWorktreePath is the sole difference between the two callers, and it
+// is a real semantic one rather than an accident: attribution mutates
+// worktree-coupled state and so needs a worktree recorded, while caller
+// resolution only names a session.
+func nearestSessionByOwnerAncestry(states []*SessionState, requireWorktreePath bool) (*SessionState, int) {
+	ancestry, ok := proclive.CurrentAncestry()
+	if !ok {
+		return nil, -1
+	}
+	var best *SessionState
+	bestDepth := -1
+	for _, state := range states {
+		if state.Owner == nil || state.Kind.IsImported() || state.AdoptedIntoWorktreePath != "" {
+			continue
+		}
+		if requireWorktreePath && state.WorktreePath == "" {
+			continue
+		}
+		depth := ancestry.Depth(*state.Owner)
+		if depth < 0 {
+			continue
+		}
+		if best == nil || isNearerOwner(depth, bestDepth, state, best) {
+			best, bestDepth = state, depth
+		}
+	}
+	return best, bestDepth
+}
+
+// isNearerOwner reports whether an owner match at depth beats the incumbent at
+// bestDepth: a resolved depth (>= 0) beats an unresolved one, nearer beats
+// farther, and otherwise the more recently interacting session wins.
+//
+// Recency only ever breaks a tie WITHIN one depth — the same agent process
+// hosting several sessions over its lifetime, e.g. after a resume — never
+// across depths, where the nearer process is the answer whatever the clocks
+// say. Callers that filter out unresolved depths never reach the last branch;
+// caller resolution does reach it, because a candidate the environment named
+// may have no owner recorded yet.
+func isNearerOwner(depth, bestDepth int, state, best *SessionState) bool {
+	if (depth >= 0) != (bestDepth >= 0) {
+		return depth >= 0
+	}
+	if depth >= 0 {
+		return depth < bestDepth || (depth == bestDepth && interactedAfter(state, best))
+	}
+	return interactedAfter(state, best)
 }
 
 // isSessionHomeWorktree reports whether worktreePath — the commit's worktree,

--- a/cmd/entire/cli/strategy/session_identity_test.go
+++ b/cmd/entire/cli/strategy/session_identity_test.go
@@ -501,3 +501,37 @@ func TestFindSessionsForCommitLinking_FallsBackToWorktree(t *testing.T) {
 	assert.Equal(t, "sess-here-fallback", got[0].SessionID,
 		"human commits (no agent ancestry) keep worktree matching")
 }
+
+// isNearerOwner is the shared comparator behind commit attribution and caller
+// resolution, and its contract covers input pairs neither caller produces
+// today. Pinned directly so it stays true for a future one.
+func TestIsNearerOwner_Contract(t *testing.T) {
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
+	stale := &SessionState{SessionID: "stale", LastInteractionTime: &older}
+	fresh := &SessionState{SessionID: "fresh", LastInteractionTime: &newer}
+
+	cases := []struct {
+		name             string
+		depth, bestDepth int
+		state, best      *SessionState
+		want             bool
+	}{
+		{"placed beats unplaced", 3, -1, stale, fresh, true},
+		{"unplaced loses to placed", -1, 3, fresh, stale, false},
+		{"nearer wins", 0, 1, stale, fresh, true},
+		{"farther loses", 2, 1, fresh, stale, false},
+		{"equal depth breaks by recency", 1, 1, fresh, stale, true},
+		{"equal depth keeps the fresher incumbent", 1, 1, stale, fresh, false},
+		{"both unplaced break by recency", -1, -1, fresh, stale, true},
+		{"both unplaced keep the fresher incumbent", -1, -1, stale, fresh, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isNearerOwner(c.depth, c.bestDepth, c.state, c.best); got != c.want {
+				t.Errorf("isNearerOwner(%d, %d, %s, %s) = %v, want %v",
+					c.depth, c.bestDepth, c.state.SessionID, c.best.SessionID, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -173,28 +173,16 @@ func ListSessionStates(ctx context.Context) ([]*SessionState, error) {
 	return states, nil
 }
 
-// FindMostRecentSession returns the session ID of the most recently interacted session
-// (by LastInteractionTime) in the current worktree. Returns empty string if no sessions exist.
-// Scoping to the current worktree prevents cross-worktree pollution in log routing.
-// Falls back to unfiltered search if the worktree path can't be determined.
-func FindMostRecentSession(ctx context.Context) string {
-	states, err := ListSessionStates(ctx)
-	if err != nil || len(states) == 0 {
-		return ""
-	}
-
-	// Scope to current worktree to prevent cross-worktree pollution.
-	if filtered := sessionStatesForCurrentWorktree(ctx, states); len(filtered) > 0 {
-		states = filtered
-		// If no sessions match the worktree, fall back to all sessions.
-	}
-
-	return mostRecentSessionID(states)
-}
-
 // FindMostRecentSessionInCurrentWorktree returns the most recently interacted
-// session from the current worktree only. Unlike FindMostRecentSession, it does
-// not fall back to sessions from other worktrees.
+// session from the current worktree only, never falling back to another
+// worktree's.
+//
+// This is the whole of what it does, deliberately. Anything asking "which
+// session is running me" must go through strategy.ResolveCallerSession, which
+// identifies the caller first and reports which tier answered; a bare
+// most-recent lookup cannot tell "mine" from "whichever moved last", and
+// worktrees share one session store, so guessing there returns an unrelated
+// session that looks exactly like a real answer.
 func FindMostRecentSessionInCurrentWorktree(ctx context.Context) string {
 	states, err := ListSessionStates(ctx)
 	if err != nil || len(states) == 0 {

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
-	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/stretchr/testify/assert"
@@ -443,96 +442,6 @@ func TestManualCommitStrategy_SessionState_UsesPackageFunctions(t *testing.T) {
 
 	if loaded2.SessionID != state2.SessionID {
 		t.Errorf("SessionID = %q, want %q", loaded2.SessionID, state2.SessionID)
-	}
-}
-
-// TestFindMostRecentSession_FiltersByWorktree tests that FindMostRecentSession
-// returns sessions from the current worktree, not from other worktrees.
-func TestFindMostRecentSession_FiltersByWorktree(t *testing.T) {
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-
-	t.Chdir(dir)
-
-	// Get the resolved worktree path (git resolves symlinks, e.g. /var → /private/var on macOS)
-	resolvedDir, err := paths.WorktreeRoot(context.Background())
-	if err != nil {
-		t.Fatalf("paths.WorktreeRoot() error = %v", err)
-	}
-
-	older := time.Now().Add(-1 * time.Hour)
-	newer := time.Now()
-
-	// Session from a different worktree (more recent)
-	otherWorktree := &SessionState{
-		SessionID:           "other-worktree-session",
-		BaseCommit:          "abc1234",
-		WorktreePath:        "/some/other/worktree",
-		StartedAt:           newer,
-		LastInteractionTime: &newer,
-		Phase:               "idle",
-	}
-
-	// Session from current worktree (older)
-	currentWorktree := &SessionState{
-		SessionID:           "current-worktree-session",
-		BaseCommit:          "xyz7890",
-		WorktreePath:        resolvedDir, // matches current worktree
-		StartedAt:           older,
-		LastInteractionTime: &older,
-		Phase:               "idle",
-	}
-
-	if err := SaveSessionState(context.Background(), otherWorktree); err != nil {
-		t.Fatalf("SaveSessionState() error = %v", err)
-	}
-	if err := SaveSessionState(context.Background(), currentWorktree); err != nil {
-		t.Fatalf("SaveSessionState() error = %v", err)
-	}
-
-	// FindMostRecentSession should return the current worktree's session,
-	// not the other worktree's session (even though it's more recent).
-	result := FindMostRecentSession(context.Background())
-	if result != "current-worktree-session" {
-		t.Errorf("FindMostRecentSession(context.Background()) = %q, want %q (should prefer current worktree)",
-			result, "current-worktree-session")
-	}
-}
-
-// TestFindMostRecentSession_FallsBackWhenNoWorktreeMatch tests that
-// FindMostRecentSession falls back to all sessions when none match the current worktree.
-func TestFindMostRecentSession_FallsBackWhenNoWorktreeMatch(t *testing.T) {
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-
-	t.Chdir(dir)
-
-	newer := time.Now()
-
-	// Session from a different worktree only (no sessions for current worktree)
-	otherWorktree := &SessionState{
-		SessionID:           "only-session",
-		BaseCommit:          "abc1234",
-		WorktreePath:        "/some/other/worktree",
-		StartedAt:           newer,
-		LastInteractionTime: &newer,
-		Phase:               "idle",
-	}
-
-	if err := SaveSessionState(context.Background(), otherWorktree); err != nil {
-		t.Fatalf("SaveSessionState() error = %v", err)
-	}
-
-	// Should fall back to the only available session since none match current worktree
-	result := FindMostRecentSession(context.Background())
-	if result != "only-session" {
-		t.Errorf("FindMostRecentSession(context.Background()) = %q, want %q (should fall back when no worktree match)",
-			result, "only-session")
-	}
-
-	// Cleanup
-	if err := os.Remove(dir + "/.git/entire-sessions/only-session.json"); err != nil && !os.IsNotExist(err) {
-		t.Logf("cleanup warning: %v", err)
 	}
 }
 

--- a/e2e/tests/main_test.go
+++ b/e2e/tests/main_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/testutil/gitenv"
 	"github.com/entireio/cli/e2e/agents"
 	"github.com/entireio/cli/e2e/entire"
@@ -41,6 +42,24 @@ func TestMain(m *testing.M) {
 	// fallback cannot protect it).
 	os.Setenv("ENTIRE_CONFIG_DIR", filepath.Join(runDir, "entire-config"))
 	os.Setenv("XDG_CACHE_HOME", filepath.Join(runDir, "entire-cache"))
+
+	// And clear the agents' caller-session variables. E2E is usually run from
+	// inside an agent, which publishes its session ID into this process's
+	// environment; every spawned binary and git hook inherits it, so the
+	// harness's own `entire` invocations would resolve the DEVELOPER's session
+	// as their caller instead of the session the agent under test just
+	// created. Isolation here is absence rather than a redirected path, which
+	// is why it is an Unsetenv loop and not one of the Setenv calls above. The
+	// agent under test still publishes its own variables to its own children,
+	// so nothing under test is weakened.
+	//
+	// CallerSessionEnvVars is deliberately NOT registry-derived: this binary
+	// links eight of the nine agents (pi is absent from its import graph), and
+	// a registry-derived list would silently omit PI_SESSION_ID and leak a
+	// real pi session into the run. See agent.callerSessionEnvVars.
+	for _, name := range agent.CallerSessionEnvVars() {
+		os.Unsetenv(name)
+	}
 
 	// Select the checkpoint storage backend for the whole suite. E2E_CHECKPOINT_STORE
 	// (e.g. "git-refs") maps to the ENTIRE_CHECKPOINTS_PRIMARY override the spawned


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1266
<!-- entire-trail-link-end -->

## Problem

`entire session current` could silently return another worktree’s most recently active session as the caller’s. Agents using that ID with `session adopt` could move an unrelated live session and reset its checkpoint bookkeeping.

## Changes

- Resolve the caller using agent-published session IDs and process ancestry together, accounting for nested agents. Report uncertain matches as `caller-ambiguous` rather than claiming they identify the caller.
- Keep worktree and cross-worktree recency fallbacks, but distinguish them from caller identification. `session current --json` includes `resolution`; cross-worktree and ambiguous results warn on stderr. Untracked callers receive a diagnostic instead of an unrelated session.
- Use the resolver for `session current`, bare `session tokens`, and git-hook log attribution. `session tokens --current` remains worktree-only.
- Validate environment IDs centrally and clear all supported caller-session variables in integration/E2E harnesses, including agents the harness does not import.

## Validation

Focused caller-resolution and command tests pass, covering nesting, ambiguous and untracked claims, ancestry, unsafe IDs, and cross-worktree fallbacks. `git diff --check` passes.

## Follow-up

`IsCaller()` distinguishes identification from a guess, but does not yet guard `session adopt`. Preventing adoption of another caller’s session remains separate work.
