### PR TITLE
Let entire auth use pick a context interactively

### DIFF
--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -568,6 +568,21 @@ func (s authTableStyles) render(style lipgloss.Style, text string) string {
 // sizing each column to its widest (possibly pre-styled) cell. Column widths
 // use lipgloss.Width so ANSI escapes don't inflate the padding.
 func renderAlignedTable(w io.Writer, header []string, rows [][]string) {
+	for _, line := range alignTableLines(header, rows) {
+		fmt.Fprintln(w, line)
+	}
+}
+
+// alignTableLines lays header and rows out in left-aligned columns and returns
+// one string per line, header first, with no trailing newline.
+//
+// Separate from renderAlignedTable because the context picker needs the same
+// columns as strings rather than written out: huh takes each row as an option
+// label and the header as the field description, so there is no writer to
+// render into. Trailing padding is trimmed, which matters there — huh styles
+// the whole label, so padding on the end would widen the selected row's
+// highlight past its text.
+func alignTableLines(header []string, rows [][]string) []string {
 	widths := make([]int, len(header))
 	for i, h := range header {
 		widths[i] = lipgloss.Width(h)
@@ -580,25 +595,31 @@ func renderAlignedTable(w io.Writer, header []string, rows [][]string) {
 		}
 	}
 
-	writeRow(w, header, widths)
-	for _, row := range rows {
-		writeRow(w, row, widths)
+	lines := make([]string, 0, len(rows)+1)
+	for _, cells := range append([][]string{header}, rows...) {
+		lines = append(lines, rowLine(cells, widths))
 	}
+	return lines
 }
 
-func writeRow(w io.Writer, cells []string, widths []int) {
+func rowLine(cells []string, widths []int) string {
+	var b strings.Builder
 	for i, c := range cells {
-		fmt.Fprint(w, c)
+		b.WriteString(c)
 		if i < len(cells)-1 {
-			fmt.Fprint(w, strings.Repeat(" ", widths[i]-lipgloss.Width(c)+2))
+			b.WriteString(strings.Repeat(" ", widths[i]-lipgloss.Width(c)+2))
 		}
 	}
-	fmt.Fprintln(w)
+	return strings.TrimRight(b.String(), " ")
 }
 
-func fallback(s, alt string) string {
+// orDash renders an empty table cell as placeholderDash, so a column keeps its
+// width and a missing value reads as absent rather than as a blank gap. Shared
+// by the auth, context, and mirror tables — a whitespace-only value counts as
+// empty, since a cell of spaces would silently break column alignment.
+func orDash(s string) string {
 	if strings.TrimSpace(s) == "" {
-		return alt
+		return placeholderDash
 	}
 	return s
 }
@@ -616,7 +637,7 @@ func renderAuthSessionsTable(w io.Writer, sty authTableStyles, sessions []api.Au
 	rows := make([][]string, 0, len(sessions))
 	for _, s := range sessions {
 		rows = append(rows, []string{
-			sty.render(sty.name, fallback(s.Name, placeholderDash)),
+			sty.render(sty.name, orDash(s.Name)),
 			sty.render(sty.value, formatAuthDate(s.CreatedAt)),
 			sty.render(sty.value, formatLastUsed(s.LastUsedAt)),
 			sty.render(sty.value, formatAuthDate(s.ExpiresAt)),

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -109,14 +109,16 @@ func selectContextToUse(cmd *cobra.Command) (string, error) {
 			len(named), named[0].Name, strings.Join(contextNames(named), ", "))
 	}
 
+	header, options := contextPickerTable(named, current)
+
 	// Start the cursor on the context being replaced.
 	selected := current
 	form := NewAccessibleForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Switch the active login context").
-				Description("One context is active at a time; it supplies the identity for every authenticated operation.").
-				Options(contextSelectOptions(named, current)...).
+				Description("One context is active at a time; it supplies the identity for every authenticated operation.\n" + header).
+				Options(options...).
 				Value(&selected),
 		),
 	)
@@ -137,27 +139,49 @@ func selectContextToUse(cmd *cobra.Command) (string, error) {
 	return selected, nil
 }
 
-// contextSelectOptions builds the picker rows, one per saved context, valued by
-// context name and labelled with the handle and login server that tell two
-// similarly-named logins apart. The active one is marked, matching the "*"
-// column in `entire auth contexts`.
-func contextSelectOptions(all []*contexts.Context, current string) []huh.Option[string] {
-	options := make([]huh.Option[string], 0, len(all))
+// contextPickerTable lays the saved contexts out as the same aligned
+// CONTEXT/HANDLE/LOGIN SERVER columns `entire auth contexts` prints, returning
+// the header line and one option per context (valued by name, which is what
+// SetCurrentContext takes).
+//
+// The header is returned separately because it is not selectable: it goes in
+// the field description, above the options. Both are indented by
+// selectOptionIndent so the columns line up with the option text rather than
+// with huh's cursor.
+//
+// The active context is marked "(active)" in a trailing column rather than
+// with the table's leading "*". Two markers in the same place would read as
+// one: huh's "> " cursor already occupies the leading column and it *moves*,
+// while "(active)" states which context is in use — so the row you happen to
+// be sitting on would otherwise look like the current one.
+//
+// Labels carry no styling of their own. huh renders each row through its
+// selected/unselected option style, and a color embedded here would fight
+// that; the table's header/value styles are deliberately left to the
+// non-interactive listing.
+func contextPickerTable(all []*contexts.Context, current string) (string, []huh.Option[string]) {
+	header := []string{"CONTEXT", "HANDLE", "LOGIN SERVER", ""}
+
+	rows := make([][]string, 0, len(all))
 	for _, c := range all {
-		parts := []string{c.Name}
-		if c.Handle != "" {
-			parts = append(parts, c.Handle)
-		}
-		if c.CoreURL != "" {
-			parts = append(parts, c.CoreURL)
-		}
-		label := strings.Join(parts, " · ")
+		marker := ""
 		if c.Name == current {
-			label += " (active)"
+			marker = "(active)"
 		}
-		options = append(options, huh.NewOption(label, c.Name))
+		rows = append(rows, []string{
+			c.Name,
+			orDash(c.Handle),
+			orDash(c.CoreURL),
+			marker,
+		})
 	}
-	return options
+
+	lines := alignTableLines(header, rows)
+	options := make([]huh.Option[string], 0, len(all))
+	for i, c := range all {
+		options = append(options, huh.NewOption(lines[i+1], c.Name))
+	}
+	return selectOptionIndent + lines[0], options
 }
 
 // contextNames lists the context names, for the no-terminal error that points
@@ -249,8 +273,8 @@ func renderContextsTable(w io.Writer, all []*contexts.Context, current string) {
 		rows = append(rows, []string{
 			marker,
 			name,
-			sty.render(sty.value, fallback(c.Handle, placeholderDash)),
-			sty.render(sty.value, fallback(c.CoreURL, placeholderDash)),
+			sty.render(sty.value, orDash(c.Handle)),
+			sty.render(sty.value, orDash(c.CoreURL)),
 		})
 	}
 

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -3,13 +3,17 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strings"
 
+	"charm.land/huh/v2"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/spf13/cobra"
 )
 
-// newAuthUseCmd switches the active login context.
+// newAuthUseCmd switches the active login context, by name or by picking one
+// from the saved contexts.
 //
 // The active context is the preferred identity for both `git clone entire://…`
 // (it authenticates any cluster fronted by its login server) and the
@@ -20,9 +24,12 @@ import (
 // All use the active identity.
 func newAuthUseCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "use <context>",
+		Use:   "use [context]",
 		Short: "Switch the active login context",
 		Long: "Switch the active login context.\n\n" +
+			"With no argument this lists the saved contexts and asks which to switch\n" +
+			"to; pass a name to switch without being asked. One context is active at\n" +
+			"a time.\n\n" +
 			"The active context is the identity for every authenticated operation:\n" +
 			"`git clone entire://…`, the control-plane commands (auth status,\n" +
 			"org/project/repo/grant), and the data-API commands (activity, search,\n" +
@@ -36,16 +43,131 @@ func newAuthUseCmd() *cobra.Command {
 			"Activity/search/dispatch take their host from ENTIRE_API_BASE_URL; trail\n" +
 			"commands route to the repository's owning cell. The selected context\n" +
 			"supplies the identity.",
-		Args:              cobra.ExactArgs(1),
+		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: completeContextNames,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := auth.SetCurrentContext(args[0]); err != nil {
+			var name string
+			if len(args) == 1 {
+				name = args[0]
+			} else {
+				chosen, err := selectContextToUse(cmd)
+				if err != nil {
+					return err
+				}
+				if chosen == "" {
+					// Nothing to switch to (none saved) or the user cancelled;
+					// selectContextToUse has already said which.
+					return nil
+				}
+				name = chosen
+			}
+			if err := auth.SetCurrentContext(name); err != nil {
 				return err //nolint:wrapcheck // already a user-facing message
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Now using context %q.\n", args[0])
+			fmt.Fprintf(cmd.OutOrStdout(), "Now using context %q.\n", name)
 			return nil
 		},
 	}
+}
+
+// selectContextToUse asks which saved context to switch to. It returns the
+// chosen name, or "" when there is nothing to switch to and the reason has
+// already been written for the user.
+//
+// The candidates and the "(active)" marker come from StoredContexts, not
+// Contexts: `use` writes current_context, so the stored pointer is what it
+// replaces, and resolving the effective identity instead would fail outright on
+// a dangling `--context`/$ENTIRE_CONTEXT — one of the situations someone runs
+// this command to get out of.
+func selectContextToUse(cmd *cobra.Command) (string, error) {
+	all, current, err := auth.StoredContexts()
+	if err != nil {
+		return "", err //nolint:wrapcheck // already a user-facing message
+	}
+
+	// A nameless entry can only come from a hand-edited or corrupted
+	// contexts.json; it is not selectable, since SetCurrentContext looks a
+	// context up by name.
+	named := make([]*contexts.Context, 0, len(all))
+	for _, c := range all {
+		if c != nil && c.Name != "" {
+			named = append(named, c)
+		}
+	}
+
+	switch len(named) {
+	case 0:
+		fmt.Fprintln(cmd.OutOrStdout(), "No login contexts. Run 'entire login' to authenticate.")
+		return "", nil
+	case 1:
+		// One saved login is the only answer a picker could give.
+		return named[0].Name, nil
+	}
+
+	if !interactive.CanPromptInteractively() {
+		return "", fmt.Errorf("%d login contexts saved; name one, e.g. `entire auth use %s` (list them with `entire auth contexts`): %s",
+			len(named), named[0].Name, strings.Join(contextNames(named), ", "))
+	}
+
+	// Start the cursor on the context being replaced.
+	selected := current
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Switch the active login context").
+				Description("One context is active at a time; it supplies the identity for every authenticated operation.").
+				Options(contextSelectOptions(named, current)...).
+				Value(&selected),
+		),
+	)
+	if err := form.RunWithContext(cmd.Context()); err != nil {
+		// handleFormCancellation prints "Switch cancelled." and returns nil for a
+		// Ctrl+C / cancelled-context abort; a real form error propagates.
+		if cerr := handleFormCancellation(cmd.ErrOrStderr(), "Switch", err); cerr != nil {
+			return "", cerr
+		}
+		return "", nil
+	}
+	if selected == "" {
+		// The form succeeded but handed back nothing that was on offer. Nothing
+		// has been printed here, so this must NOT be a SilentError — main.go
+		// suppresses those and the command would exit non-zero with no message.
+		return "", fmt.Errorf("no context selected from the %d offered", len(named))
+	}
+	return selected, nil
+}
+
+// contextSelectOptions builds the picker rows, one per saved context, valued by
+// context name and labelled with the handle and login server that tell two
+// similarly-named logins apart. The active one is marked, matching the "*"
+// column in `entire auth contexts`.
+func contextSelectOptions(all []*contexts.Context, current string) []huh.Option[string] {
+	options := make([]huh.Option[string], 0, len(all))
+	for _, c := range all {
+		parts := []string{c.Name}
+		if c.Handle != "" {
+			parts = append(parts, c.Handle)
+		}
+		if c.CoreURL != "" {
+			parts = append(parts, c.CoreURL)
+		}
+		label := strings.Join(parts, " · ")
+		if c.Name == current {
+			label += " (active)"
+		}
+		options = append(options, huh.NewOption(label, c.Name))
+	}
+	return options
+}
+
+// contextNames lists the context names, for the no-terminal error that points
+// at the positional form.
+func contextNames(all []*contexts.Context) []string {
+	out := make([]string, 0, len(all))
+	for _, c := range all {
+		out = append(out, c.Name)
+	}
+	return out
 }
 
 // completeContextNames is the ValidArgsFunction for commands taking a single

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -139,44 +139,20 @@ func selectContextToUse(cmd *cobra.Command) (string, error) {
 	return selected, nil
 }
 
-// contextPickerTable lays the saved contexts out as the same aligned
-// CONTEXT/HANDLE/LOGIN SERVER columns `entire auth contexts` prints, returning
-// the header line and one option per context (valued by name, which is what
-// SetCurrentContext takes).
+// contextPickerTable lays the saved contexts out as the picker's rows: the
+// same table `entire auth contexts` prints, built by contextTableLines, with
+// each row valued by context name (which is what SetCurrentContext takes).
 //
 // The header is returned separately because it is not selectable: it goes in
-// the field description, above the options. Both are indented by
-// selectOptionIndent so the columns line up with the option text rather than
-// with huh's cursor.
+// the field description, above the options, indented by selectOptionIndent so
+// the columns line up with the option text rather than with huh's cursor.
 //
-// The active context is marked "(active)" in a trailing column rather than
-// with the table's leading "*". Two markers in the same place would read as
-// one: huh's "> " cursor already occupies the leading column and it *moves*,
-// while "(active)" states which context is in use — so the row you happen to
-// be sitting on would otherwise look like the current one.
-//
-// Labels carry no styling of their own. huh renders each row through its
-// selected/unselected option style, and a color embedded here would fight
-// that; the table's header/value styles are deliberately left to the
-// non-interactive listing.
+// Rows carry no styling. huh renders each through its selected/unselected
+// option style, and a color embedded here would fight it — so the styles go in
+// unset, which authTableStyles already treats as "render plain text".
 func contextPickerTable(all []*contexts.Context, current string) (string, []huh.Option[string]) {
-	header := []string{"CONTEXT", "HANDLE", "LOGIN SERVER", ""}
+	lines := contextTableLines(authTableStyles{}, all, current)
 
-	rows := make([][]string, 0, len(all))
-	for _, c := range all {
-		marker := ""
-		if c.Name == current {
-			marker = "(active)"
-		}
-		rows = append(rows, []string{
-			c.Name,
-			orDash(c.Handle),
-			orDash(c.CoreURL),
-			marker,
-		})
-	}
-
-	lines := alignTableLines(header, rows)
 	options := make([]huh.Option[string], 0, len(all))
 	for i, c := range all {
 		options = append(options, huh.NewOption(lines[i+1], c.Name))
@@ -248,35 +224,56 @@ func runAuthContexts(w io.Writer) error {
 	return nil
 }
 
-// renderContextsTable prints the saved login contexts as a styled, aligned
-// table with column headers. The active context is flagged with "*" in the
-// leading column. Purely local data — no network, no timestamps — so it
-// reuses the auth-table styles but only the header/name/value/accent slots.
-func renderContextsTable(w io.Writer, all []*contexts.Context, current string) {
-	sty := newAuthTableStyles(w)
+// activeContextMarker flags the context in use. It sits in a trailing column
+// in both the listing and the picker, rather than as a leading "*": huh draws
+// its cursor in the leading column and the cursor *moves*, so a marker there
+// would make whichever row you are sitting on read as the current one. The
+// listing follows the picker so the two render identically, and so the word
+// matches the one shell completion already appends.
+const activeContextMarker = "(active)"
 
+// contextTableLines lays the saved contexts out in aligned CONTEXT / HANDLE /
+// LOGIN SERVER columns, with activeContextMarker in a trailing column on the
+// context in use, and returns the header line followed by one line per
+// context.
+//
+// One function because `entire auth contexts` and the `entire auth use` picker
+// print the same table; they differ only in styling, and sty carries that. An
+// unset authTableStyles renders every cell plain, which is what the picker
+// passes.
+func contextTableLines(sty authTableStyles, all []*contexts.Context, current string) []string {
 	header := []string{
-		"", // active marker
 		sty.render(sty.header, "CONTEXT"),
 		sty.render(sty.header, "HANDLE"),
 		sty.render(sty.header, "LOGIN SERVER"),
+		"", // the marker column heads itself
 	}
 
 	rows := make([][]string, 0, len(all))
 	for _, c := range all {
-		marker := " "
+		marker := ""
 		name := sty.render(sty.value, c.Name)
 		if c.Name == current {
-			marker = sty.render(sty.id, "*")
+			marker = sty.render(sty.id, activeContextMarker)
 			name = sty.render(sty.name, c.Name)
 		}
 		rows = append(rows, []string{
-			marker,
 			name,
 			sty.render(sty.value, orDash(c.Handle)),
 			sty.render(sty.value, orDash(c.CoreURL)),
+			marker,
 		})
 	}
 
-	renderAlignedTable(w, header, rows)
+	return alignTableLines(header, rows)
+}
+
+// renderContextsTable prints the saved login contexts as a styled, aligned
+// table with column headers. Purely local data — no network, no timestamps —
+// so it reuses the auth-table styles but only the header/name/value/accent
+// slots.
+func renderContextsTable(w io.Writer, all []*contexts.Context, current string) {
+	for _, line := range contextTableLines(newAuthTableStyles(w), all, current) {
+		fmt.Fprintln(w, line)
+	}
 }

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -301,3 +301,175 @@ func TestPromoteNextLogin(t *testing.T) {
 		t.Fatalf("expected a context to be promoted to current (current=%q, err=%v)", current, err)
 	}
 }
+
+// setupContextsForUse records one login context per host into an isolated config
+// dir and returns their names in on-disk order. Only the first stays active, so
+// a test can tell the picker's default from whatever was recorded last.
+func setupContextsForUse(t *testing.T, hosts ...string) []string {
+	t.Helper()
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(time.Hour).Unix()
+	names := make([]string, 0, len(hosts))
+	for i, host := range hosts {
+		claims := fmt.Sprintf(`{"iss":"https://%s","handle":"user-%d","exp":%d}`, host, i, exp)
+		name, err := auth.RecordLoginContext(makeContextJWT(t, claims), "", i == 0)
+		if err != nil {
+			t.Fatalf("record %s: %v", host, err)
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+// TestSelectContextToUse_NoContexts pins that a bare `entire auth use` with
+// nothing saved points at login instead of erroring or opening an empty picker.
+func TestSelectContextToUse_NoContexts(t *testing.T) {
+	setupContextsForUse(t)
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	got, err := selectContextToUse(cmd)
+	if err != nil {
+		t.Fatalf("selectContextToUse: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("selected = %q, want no selection", got)
+	}
+	if !strings.Contains(out.String(), "entire login") {
+		t.Fatalf("output = %q, want a hint pointing at 'entire login'", out.String())
+	}
+}
+
+// TestSelectContextToUse_SingleContextNeedsNoPicker pins that one saved login
+// resolves directly — a one-row picker asks a question with one answer, and this
+// is the branch that keeps a bare `auth use` working with no terminal.
+func TestSelectContextToUse_SingleContextNeedsNoPicker(t *testing.T) {
+	names := setupContextsForUse(t, "core-a.example.com")
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	got, err := selectContextToUse(cmd)
+	if err != nil {
+		t.Fatalf("selectContextToUse: %v", err)
+	}
+	if got != names[0] {
+		t.Fatalf("selected = %q, want the only saved context %q", got, names[0])
+	}
+}
+
+// TestSelectContextToUse_NoTerminalNamesThePositional pins the agent-safe
+// fallback: with several logins and no terminal the picker can't render, so the
+// error names every candidate and the non-interactive way to choose one rather
+// than hanging or picking for the user.
+func TestSelectContextToUse_NoTerminalNamesThePositional(t *testing.T) {
+	// interactive.CanPromptInteractively() is false under `go test`, so this
+	// exercises the no-terminal branch without faking a TTY.
+	names := setupContextsForUse(t, "core-a.example.com", "core-b.example.com")
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	got, err := selectContextToUse(cmd)
+	if err == nil {
+		t.Fatalf("selected %q, want an error when the picker can't render", got)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "entire auth use") {
+		t.Fatalf("error = %q, want it to name `entire auth use`", msg)
+	}
+	for _, name := range names {
+		if !strings.Contains(msg, name) {
+			t.Fatalf("error = %q, want it to list candidate %q", msg, name)
+		}
+	}
+}
+
+// TestContextSelectOptions pins the picker rows: one per context, valued by the
+// name SetCurrentContext takes, labelled with the handle and login server that
+// tell similarly-named logins apart, and exactly one marked active.
+func TestContextSelectOptions(t *testing.T) {
+	t.Parallel()
+
+	all := []*contexts.Context{
+		{Name: "prod", Handle: "alice", CoreURL: "https://core-a.example.com"},
+		{Name: "staging", Handle: "bob", CoreURL: "https://core-b.example.com"},
+		{Name: "bare"},
+	}
+
+	options := contextSelectOptions(all, "staging")
+	if len(options) != len(all) {
+		t.Fatalf("options = %d, want one per context (%d)", len(options), len(all))
+	}
+
+	var activeCount int
+	for i, opt := range options {
+		if opt.Value != all[i].Name {
+			t.Errorf("option %d value = %q, want the context name %q", i, opt.Value, all[i].Name)
+		}
+		if !strings.Contains(opt.Key, all[i].Name) {
+			t.Errorf("option %d label = %q, want it to carry the name %q", i, opt.Key, all[i].Name)
+		}
+		if strings.Contains(opt.Key, "(active)") {
+			activeCount++
+			if opt.Value != "staging" {
+				t.Errorf("option %q is marked active, want only staging", opt.Value)
+			}
+		}
+	}
+	if activeCount != 1 {
+		t.Fatalf("want exactly one (active) row, got %d", activeCount)
+	}
+
+	// A context with no handle or login server renders as a bare name — no
+	// dangling separators for the fields it doesn't have.
+	if options[2].Key != "bare" {
+		t.Errorf("label for a handle-less, URL-less context = %q, want %q", options[2].Key, "bare")
+	}
+	if !strings.Contains(options[0].Key, "alice") || !strings.Contains(options[0].Key, "core-a.example.com") {
+		t.Errorf("label = %q, want the handle and login server", options[0].Key)
+	}
+}
+
+// TestAuthUseCmd_ArgsAndSwitch pins the command surface: a name still switches
+// without asking, and the argument is now optional so a bare `entire auth use`
+// reaches the picker instead of failing argument validation.
+func TestAuthUseCmd_ArgsAndSwitch(t *testing.T) {
+	names := setupContextsForUse(t, "core-a.example.com", "core-b.example.com")
+
+	cmd := newAuthUseCmd()
+	if err := cmd.Args(cmd, nil); err != nil {
+		t.Fatalf("Args(no args) = %v, want the picker form to be accepted", err)
+	}
+	if err := cmd.Args(cmd, []string{"a", "b"}); err == nil {
+		t.Error("Args(two args) = nil, want at most one context")
+	}
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{names[1]})
+	if err := cmd.ExecuteContext(t.Context()); err != nil {
+		t.Fatalf("auth use %s: %v", names[1], err)
+	}
+	if !strings.Contains(out.String(), names[1]) {
+		t.Fatalf("output = %q, want confirmation naming %q", out.String(), names[1])
+	}
+	_, current, err := auth.StoredContexts()
+	if err != nil {
+		t.Fatalf("StoredContexts: %v", err)
+	}
+	if current != names[1] {
+		t.Fatalf("current context = %q, want %q", current, names[1])
+	}
+}

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -395,10 +395,10 @@ func TestSelectContextToUse_NoTerminalNamesThePositional(t *testing.T) {
 	}
 }
 
-// TestContextSelectOptions pins the picker rows: one per context, valued by the
-// name SetCurrentContext takes, labelled with the handle and login server that
-// tell similarly-named logins apart, and exactly one marked active.
-func TestContextSelectOptions(t *testing.T) {
+// TestContextPickerTable pins the picker rows: one per context, valued by the
+// name SetCurrentContext takes, carrying the handle and login server that tell
+// similarly-named logins apart, and exactly one marked active.
+func TestContextPickerTable(t *testing.T) {
 	t.Parallel()
 
 	all := []*contexts.Context{
@@ -407,9 +407,15 @@ func TestContextSelectOptions(t *testing.T) {
 		{Name: "bare"},
 	}
 
-	options := contextSelectOptions(all, "staging")
+	header, options := contextPickerTable(all, "staging")
 	if len(options) != len(all) {
 		t.Fatalf("options = %d, want one per context (%d)", len(options), len(all))
+	}
+
+	for _, col := range []string{"CONTEXT", "HANDLE", "LOGIN SERVER"} {
+		if !strings.Contains(header, col) {
+			t.Errorf("header = %q, want column %q (the same ones `auth contexts` prints)", header, col)
+		}
 	}
 
 	var activeCount int
@@ -431,14 +437,73 @@ func TestContextSelectOptions(t *testing.T) {
 		t.Fatalf("want exactly one (active) row, got %d", activeCount)
 	}
 
-	// A context with no handle or login server renders as a bare name — no
-	// dangling separators for the fields it doesn't have.
-	if options[2].Key != "bare" {
-		t.Errorf("label for a handle-less, URL-less context = %q, want %q", options[2].Key, "bare")
+	// Missing handle / login server become the listing's placeholder dash, so
+	// the row keeps its columns instead of collapsing to a bare name.
+	if got := strings.Fields(options[2].Key); len(got) != 3 || got[0] != "bare" || got[1] != placeholderDash || got[2] != placeholderDash {
+		t.Errorf("row for a handle-less, URL-less context = %q, want name plus two %q placeholders", options[2].Key, placeholderDash)
 	}
 	if !strings.Contains(options[0].Key, "alice") || !strings.Contains(options[0].Key, "core-a.example.com") {
-		t.Errorf("label = %q, want the handle and login server", options[0].Key)
+		t.Errorf("row = %q, want the handle and login server", options[0].Key)
 	}
+}
+
+// TestContextPickerTable_ColumnsAlign pins the alignment that makes this a
+// table rather than three fields with spaces between them: every column starts
+// at the same offset in the header and in every row, and the header is
+// indented past huh's cursor so it sits above the option text.
+func TestContextPickerTable_ColumnsAlign(t *testing.T) {
+	t.Parallel()
+
+	all := []*contexts.Context{
+		{Name: "p", Handle: "a-very-long-handle", CoreURL: "https://short"},
+		{Name: "a-very-long-context-name", Handle: "b", CoreURL: "https://a-much-longer-login-server.example.com"},
+		{Name: "mid", Handle: "carol", CoreURL: "https://core.example.com"},
+	}
+
+	header, options := contextPickerTable(all, "mid")
+
+	if !strings.HasPrefix(header, selectOptionIndent+"CONTEXT") {
+		t.Fatalf("header = %q, want it indented by %q so it aligns with the option text", header, selectOptionIndent)
+	}
+
+	// Where each column starts in the header, minus the cursor indent (huh
+	// indents the rows itself). Anchored on the labels rather than on gaps,
+	// because "LOGIN SERVER" contains a space of its own.
+	bare := strings.TrimPrefix(header, selectOptionIndent)
+	want := make([]int, 0, 3)
+	for _, col := range []string{"CONTEXT", "HANDLE", "LOGIN SERVER"} {
+		at := strings.Index(bare, col)
+		if at < 0 {
+			t.Fatalf("header %q is missing column %q", header, col)
+		}
+		want = append(want, at)
+	}
+
+	// Test data has no spaces inside a cell, so a row's columns are its
+	// space-separated runs.
+	for _, opt := range options {
+		got := columnOffsets(opt.Key)
+		if len(got) < 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+			t.Errorf("row %q starts columns at %v, want the header's %v", opt.Key, got, want)
+		}
+	}
+}
+
+// columnOffsets returns the rune index at which each space-separated run in a
+// row begins, which is what has to match the header's column starts.
+func columnOffsets(line string) []int {
+	var offsets []int
+	inGap := true
+	for i, r := range []rune(line) {
+		switch {
+		case r == ' ':
+			inGap = true
+		case inGap:
+			offsets = append(offsets, i)
+			inGap = false
+		}
+	}
+	return offsets
 }
 
 // TestAuthUseCmd_ArgsAndSwitch pins the command surface: a name still switches

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -181,8 +181,8 @@ func TestRunAuthContexts(t *testing.T) {
 			t.Fatalf("listing = %q, want column header %q", got, hdr)
 		}
 	}
-	if !strings.Contains(got, "*") {
-		t.Fatalf("listing = %q, want an active-context marker", got)
+	if !strings.Contains(got, activeContextMarker) {
+		t.Fatalf("listing = %q, want the active context flagged %q", got, activeContextMarker)
 	}
 	if !strings.Contains(got, "core.example.com") {
 		t.Fatalf("listing = %q, want context core.example.com", got)
@@ -485,6 +485,42 @@ func TestContextPickerTable_ColumnsAlign(t *testing.T) {
 		got := columnOffsets(opt.Key)
 		if len(got) < 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
 			t.Errorf("row %q starts columns at %v, want the header's %v", opt.Key, got, want)
+		}
+	}
+}
+
+// TestContextTableMatchesPicker pins what one builder buys: `entire auth
+// contexts` and the `entire auth use` picker print the same table, down to the
+// column widths and the trailing "(active)". A column added to one cannot go
+// missing from the other, and the marker cannot drift back to two spellings.
+// The picker's rows are indented by huh's cursor gutter; nothing else differs.
+func TestContextTableMatchesPicker(t *testing.T) {
+	t.Parallel()
+
+	all := []*contexts.Context{
+		{Name: "prod", Handle: "alice", CoreURL: "https://core-a.example.com"},
+		{Name: "staging", Handle: "bob", CoreURL: "https://a-much-longer-login-server.example.com"},
+		{Name: "bare"},
+	}
+
+	// A bytes.Buffer is not a terminal, so the listing renders unstyled — the
+	// only difference the picker's rows would otherwise have.
+	var listing bytes.Buffer
+	renderContextsTable(&listing, all, "staging")
+	want := strings.Split(strings.TrimRight(listing.String(), "\n"), "\n")
+
+	header, options := contextPickerTable(all, "staging")
+	got := []string{strings.TrimPrefix(header, selectOptionIndent)}
+	for _, opt := range options {
+		got = append(got, opt.Key)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("picker rendered %d lines, listing %d:\npicker:  %q\nlisting: %q", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d:\npicker  = %q\nlisting = %q", i, got[i], want[i])
 		}
 	}
 }

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -217,13 +217,6 @@ func styledHeaders(st statusStyles, headers []string) []string {
 	return out
 }
 
-func orDash(s string) string {
-	if s == "" {
-		return "-"
-	}
-	return s
-}
-
 // visibilityDisplay renders the VISIBILITY cell (and the `get` record's
 // Visibility section): the repo's audience in GitHub's terms, not a yes/no.
 func visibilityDisplay(private bool) string {

--- a/cmd/entire/cli/uiform/uiform.go
+++ b/cmd/entire/cli/uiform/uiform.go
@@ -22,6 +22,16 @@ func IsAccessibleMode() bool {
 	return os.Getenv("ACCESSIBLE") != ""
 }
 
+// SelectOptionIndent is the blank prefix huh reserves for a select's cursor,
+// so text put above the options (a column header in the field description)
+// lines up with the option text instead of with the cursor.
+//
+// It is the width of the SelectSelector string, "> ", which Theme inherits
+// from ThemeBase16 and recolors without changing. A caller that overrides the
+// selector string needs its own indent. TestSelectOptionIndentMatchesSelector
+// pins the two together.
+const SelectOptionIndent = "  "
+
 // Theme returns Entire's standard huh theme: base16 (ANSI 0–15) colors so
 // form prompts respect the user's terminal palette and stay consistent with
 // the rest of the CLI's styling. Derived from huh.ThemeBase16 with a few

--- a/cmd/entire/cli/uiform/uiform_test.go
+++ b/cmd/entire/cli/uiform/uiform_test.go
@@ -9,6 +9,26 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
+// TestSelectOptionIndentMatchesSelector pins SelectOptionIndent to the width
+// of the theme's actual select cursor. A caller uses the indent to put a
+// column header above a select's options; if the selector string ever changes
+// width, the header silently stops lining up with the rows underneath it.
+func TestSelectOptionIndentMatchesSelector(t *testing.T) {
+	t.Parallel()
+
+	for _, isDark := range []bool{true, false} {
+		styles := Theme().Theme(isDark)
+		for name, selector := range map[string]lipgloss.Style{
+			"focused": styles.Focused.SelectSelector,
+			"blurred": styles.Blurred.SelectSelector,
+		} {
+			if got, want := lipgloss.Width(selector.String()), lipgloss.Width(SelectOptionIndent); got != want {
+				t.Errorf("isDark=%v %s selector width = %d, SelectOptionIndent width = %d", isDark, name, got, want)
+			}
+		}
+	}
+}
+
 // TestTheme_BlurredTitlesInheritTerminalForeground guards against the theme
 // pinning base16 foreground colors on blurred (inactive) fields. ThemeBase16
 // copies Focused into Blurred wholesale, so clearing only the Focused variants

--- a/cmd/entire/cli/utils.go
+++ b/cmd/entire/cli/utils.go
@@ -27,6 +27,10 @@ func NewAccessibleForm(groups ...*huh.Group) *huh.Form {
 	return uiform.New(groups...)
 }
 
+// selectOptionIndent aligns text placed above a select's options with the
+// option text. See uiform.SelectOptionIndent.
+const selectOptionIndent = uiform.SelectOptionIndent
+
 // handleFormCancellation handles cancellation from huh form prompts.
 // User abort (Ctrl+C), timeout, and a cancelled/expired context (when the form
 // ran via RunWithContext and the command's context was cancelled) all print a


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1270
<!-- entire-trail-link-end -->

`entire auth use` required the context name as an argument, so switching logins meant running `entire auth contexts` first and copying a name out of it. The argument is now optional.

## What changed

- `entire auth use` (no argument) shows the saved contexts and asks which to switch to. Picking one calls the same `auth.SetCurrentContext` the positional form always did, so one context stays active at a time.
- `entire auth use <name>` is unchanged — no prompt.
- Ctrl+C prints `Switch cancelled.`, exits 0, and leaves `current_context` alone.

The picker uses the same aligned CONTEXT / HANDLE / LOGIN SERVER columns `entire auth contexts` prints. Below, the cursor has been moved down one row so the two markers are on different rows:

```
┃ Switch the active login context
┃ One context is active at a time; it supplies the identity for every authenticated operation.
┃   CONTEXT  HANDLE         LOGIN SERVER
┃   prod     alice          https://core.entire.io
┃   staging  alice-staging  https://core.staging.entire.io  (active)
┃ > local    dev            http://localhost:8080

↑ up • ↓ down • / filter • enter submit
```

`>` is huh's cursor and it moves; `(active)` is a fixed property of one row saying which context is in use. `entire auth contexts` marks the active one with a leading `*`, but that is the column huh draws its cursor in — putting both there would make the row you happen to be sitting on read as the current one, so the marker moved to the end.

Options are single-line strings in huh, so the header cannot be one of them (it would be selectable). It goes in the field description instead, indented by the width of the select cursor so the columns sit above the option text rather than above the cursor.

Under `ACCESSIBLE=1`, huh renders numbered choices and no field description, so the header line is absent there. The columns still align and `(active)` still shows:

```
Switch the active login context
1. prod     alice          https://core.entire.io          (active)
2. staging  alice-staging  https://core.staging.entire.io
3. local    dev            http://localhost:8080
Enter a number between 1 and 3:
```

## Following existing patterns

Modelled on `selectPlacement` in `repo_clone.go` — the picker behind `entire repo clone` and `entire repo mirror use`: resolve directly when there is only one candidate, prompt only when there is a real choice, fail fast with a pointer to the non-interactive form when there is no terminal. Uses `NewAccessibleForm` and `handleFormCancellation` like every other picker.

Three consolidations rather than new copies:

- `alignTableLines` is split out of `renderAlignedTable`, which now calls it. The picker needs the columns as strings rather than written to a writer, so both share one gutter and width implementation. It trims trailing padding, which matters here: huh styles the whole label, so padding would widen the selected row's highlight past its text.
- The indent is `uiform.SelectOptionIndent`, defined beside the theme that sets the selector. `TestSelectOptionIndentMatchesSelector` asserts it equals the real selector width in both light and dark, so a change to the cursor string fails a test instead of quietly misaligning the header.
- `unparam` flagged `fallback(s, alt)` once every caller passed the same placeholder. Collapsing it surfaced an identical `orDash` already in `repo_mirror.go`, same package, so there is now one instead of three. The surviving version trims whitespace — a cell of spaces looks empty but breaks alignment.

Labels carry no styling of their own; huh colors the selected row, and an embedded color would fight it.

## Non-interactive behaviour

Per the agent-safe CLI fallback rule in `CLAUDE.md`, with several logins and no terminal it errors rather than hanging or choosing for anyone, naming every candidate and how to pick one:

```
3 login contexts saved; name one, e.g. `entire auth use prod` (list them with `entire auth contexts`): prod, staging, local
```

The workflow stays completable without a terminal: `entire auth contexts` lists, `entire auth use <name>` selects.

## One decision worth a reviewer's eye

The picker reads `auth.StoredContexts()`, not `auth.Contexts()`. `use` writes `current_context`, so the stored pointer is what it replaces — and `Contexts()` errors outright on a dangling `--context` / `$ENTIRE_CONTEXT`, which is one of the situations you would run this command to get out of.

The tradeoff: when an override is in effect, the `(active)` marker names the stored default rather than the identity currently acting. I left that alone rather than adding an override warning, since the same gap applies to `entire auth use <name>` today and is a separate change.

## Verification

- `mise run fmt && mise run lint` — clean
- `mise run test:ci` — unit + integration + both E2E canaries (56 vogon, 4 roger-roger) pass
- Tests cover the empty, single-context, no-terminal, row-content, column-alignment, and argument-validation paths, plus the selector-width guard
- The interactive path was driven on a pty (normal and `ACCESSIBLE=1`) against an isolated `ENTIRE_CONFIG_DIR`, including the Ctrl+C abort. The frame above was rendered through huh's own `View()`

<!-- entire-shadow-pr -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local CLI UX around reading/writing `contexts.json`; no changes to token refresh, network auth, or server-side behavior.
> 
> **Overview**
> **`entire auth use` no longer requires a context name.** With zero arguments it walks saved logins and switches the active identity; passing a name still switches immediately without prompting.
> 
> When nothing is saved it prints a hint to run **`entire login`**. With one saved context it selects that name directly (so non-TTY runs still work). With multiple contexts and no interactive terminal it fails with an error that lists names and points at **`entire auth use <name>`** instead of hanging. In an interactive terminal it shows a **huh** select (via existing **`NewAccessibleForm`**) whose options are built from **`auth.StoredContexts`**—the on-disk **`current_context`**, not resolved identity—so broken **`--context` / `ENTIRE_CONTEXT` overrides don’t block recovery. Picker labels combine name, handle, and login server and mark **`(active)`**; nameless/corrupt entries are skipped.
> 
> Tests cover empty/single/multi context paths, option formatting, optional-args validation, and positional switching still persisting via **`SetCurrentContext`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3955b25c6f41781fe5bc051c2c526f34291971. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
