### PR TITLE
Fix Lefthook overwrite detection and remediation guidance

### DIFF
--- a/cmd/entire/cli/strategy/hook_managers.go
+++ b/cmd/entire/cli/strategy/hook_managers.go
@@ -34,7 +34,7 @@ func detectHookManagers(repoRoot string) []hookManager {
 		for _, variant := range []string{"", "-local"} {
 			for _, ext := range []string{"yml", "yaml", "json", "toml"} {
 				name := prefix + "lefthook" + variant + "." + ext
-				checks = append(checks, hookManager{"Lefthook", name, false})
+				checks = append(checks, hookManager{"Lefthook", name, true})
 			}
 		}
 	}
@@ -78,6 +78,10 @@ func hookManagerWarning(managers []hookManager, cmdPrefix string) string {
 			fmt.Fprintf(&b, "Warning: %s detected (%s)\n", m.Name, m.ConfigPath)
 			fmt.Fprintf(&b, "\n")
 			fmt.Fprintf(&b, "  %s may overwrite hooks installed by Entire on npm install.\n", m.Name)
+			if m.Name == "Lefthook" {
+				writeLefthookWarning(&b, specs, m.ConfigPath)
+				continue
+			}
 			fmt.Fprintf(&b, "  To make Entire hooks permanent, add these lines to your %s hook files:\n", m.Name)
 			fmt.Fprintf(&b, "\n")
 
@@ -103,6 +107,37 @@ func hookManagerWarning(managers []hookManager, cmdPrefix string) string {
 	}
 
 	return b.String()
+}
+
+func writeLefthookWarning(b *strings.Builder, specs []hookSpec, configPath string) {
+	fmt.Fprintln(b, "  To make Entire hooks permanent, add each command as a Lefthook script:")
+	fmt.Fprintln(b, "  scripts receive Git's hook arguments; do not use Lefthook commands for these entries.")
+	fmt.Fprintln(b, "  The paths below use Lefthook's default source_dir (.lefthook/); use your configured source_dir if different.")
+	fmt.Fprintln(b)
+
+	for _, spec := range specs {
+		cmdLine := extractCommandLine(spec.content)
+		if cmdLine == "" {
+			continue
+		}
+		if spec.name == "pre-push" {
+			cmdLine = strings.Replace(cmdLine, `pre-push "$1"`, `pre-push "$@"`, 1)
+		}
+		fmt.Fprintf(b, "    <source_dir>/%s/entire.sh:\n", spec.name)
+		fmt.Fprintf(b, "      %s\n\n", cmdLine)
+	}
+
+	fmt.Fprintf(b, "  Wire each script in %s (YAML shape shown; use the equivalent syntax for JSON/TOML):\n", configPath)
+	fmt.Fprintln(b)
+	for _, spec := range specs {
+		fmt.Fprintf(b, "    %s:\n      scripts:\n        \"entire.sh\":\n          runner: bash\n", spec.name)
+		if spec.name == "pre-push" {
+			fmt.Fprintln(b, "          use_stdin: true")
+		}
+		fmt.Fprintln(b)
+	}
+	fmt.Fprintln(b, "  Keep these script files and config entries committed so npm install or lefthook install -f does not remove Entire's hooks.")
+	fmt.Fprintln(b)
 }
 
 // extractCommandLine returns the first non-shebang, non-comment, non-empty line

--- a/cmd/entire/cli/strategy/hook_managers_test.go
+++ b/cmd/entire/cli/strategy/hook_managers_test.go
@@ -61,8 +61,8 @@ func TestDetectHookManagers_Lefthook(t *testing.T) {
 	if managers[0].ConfigPath != "lefthook.yml" {
 		t.Errorf("expected lefthook.yml, got %s", managers[0].ConfigPath)
 	}
-	if managers[0].OverwritesHooks {
-		t.Error("Lefthook should have OverwritesHooks=false")
+	if !managers[0].OverwritesHooks {
+		t.Error("Lefthook should have OverwritesHooks=true")
 	}
 }
 
@@ -348,26 +348,53 @@ func TestHookManagerWarning_Husky(t *testing.T) {
 	}
 }
 
-func TestHookManagerWarning_GitHooksManager(t *testing.T) {
+func TestHookManagerWarning_Lefthook(t *testing.T) {
 	t.Parallel()
 
 	managers := []hookManager{
-		{Name: "Lefthook", ConfigPath: "lefthook.yml", OverwritesHooks: false},
+		{Name: "Lefthook", ConfigPath: "lefthook.yml", OverwritesHooks: true},
 	}
 
 	warning := hookManagerWarning(managers, "entire")
 
-	// Category B: should be a Note, not a Warning
-	if !strings.Contains(warning, "Note: Lefthook detected") {
-		t.Error("warning should contain 'Note: Lefthook detected'")
+	if !strings.Contains(warning, "Warning: Lefthook detected") {
+		t.Error("warning should contain 'Warning: Lefthook detected'")
 	}
-	if !strings.Contains(warning, "run 'entire enable' to restore") {
-		t.Error("warning should mention running 'entire enable'")
+	if !strings.Contains(warning, "scripts receive Git's hook arguments") {
+		t.Error("warning should explain that Lefthook scripts receive hook arguments")
 	}
+	if !strings.Contains(warning, "<source_dir>/pre-push/entire.sh") {
+		t.Error("warning should use Lefthook's script layout")
+	}
+	if !strings.Contains(warning, `pre-push "$@"`) {
+		t.Error("pre-push script should preserve all Git hook arguments")
+	}
+	if strings.Contains(warning, "lefthook.ymlpre-push") {
+		t.Error("warning should not concatenate the config file with hook names")
+	}
+	if !strings.Contains(warning, "Wire each script in lefthook.yml") {
+		t.Error("warning should name the detected Lefthook config")
+	}
+	if !strings.Contains(warning, "configured source_dir") {
+		t.Error("warning should account for custom Lefthook source directories")
+	}
+	if strings.Contains(warning, "Note: Lefthook detected") {
+		t.Error("Lefthook should use warning-level messaging")
+	}
+}
 
-	// Should NOT contain hook file copy-paste instructions
-	if strings.Contains(warning, "prepare-commit-msg:") {
-		t.Error("category B warning should not contain hook file instructions")
+func TestHookManagerWarning_LefthookConfigPath(t *testing.T) {
+	t.Parallel()
+
+	warning := hookManagerWarning([]hookManager{
+		{Name: "Lefthook", ConfigPath: ".lefthook.toml", OverwritesHooks: true},
+	}, "entire")
+
+	if !strings.Contains(warning, "Wire each script in .lefthook.toml") {
+		t.Error("warning should name the detected config format and path")
+	}
+	if !strings.Contains(warning, "equivalent syntax for JSON/TOML") {
+		t.Error("warning should identify the displayed config syntax")
 	}
 }
 
@@ -409,7 +436,7 @@ func TestHookManagerWarning_Multiple(t *testing.T) {
 
 	managers := []hookManager{
 		{Name: "Husky", ConfigPath: ".husky/", OverwritesHooks: true},
-		{Name: "Lefthook", ConfigPath: "lefthook.yml", OverwritesHooks: false},
+		{Name: "Lefthook", ConfigPath: "lefthook.yml", OverwritesHooks: true},
 	}
 
 	warning := hookManagerWarning(managers, "entire")
@@ -417,8 +444,8 @@ func TestHookManagerWarning_Multiple(t *testing.T) {
 	if !strings.Contains(warning, "Warning: Husky detected") {
 		t.Error("should contain Husky warning")
 	}
-	if !strings.Contains(warning, "Note: Lefthook detected") {
-		t.Error("should contain Lefthook note")
+	if !strings.Contains(warning, "Warning: Lefthook detected") {
+		t.Error("should contain Lefthook warning")
 	}
 }
 


### PR DESCRIPTION
 ## Summary

  - Classify Lefthook as a hook manager that can overwrite Entire hooks.
  - Add Lefthook-specific remediation guidance using scripts.
  - Preserve Git hook arguments, including `pre-push` arguments and stdin.
  - Avoid invalid hook paths such as `lefthook.ymlpre-push`.
  - Reference the detected Lefthook config path.
  - Account for custom Lefthook `source_dir` values.
  - Add focused regression tests.

  ## Validation

  ```text
  go test ./cmd/entire/cli/strategy -run 'TestHookManagerWarning_(Lefthook|Husky|Multiple)$|
  TestHookManagerWarning_LefthookConfigPath' -count=1
  ```

  Fixes #2263