### PR TITLE
fix(interactive): restore native Windows prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,12 +399,12 @@ Tests that spawn the real `entire` or `git` binary need the child to be non-inte
    product decision rather than a detection fix.
 4. `CI=<non-empty-non-false>` → false.
 5. Controlling-terminal probe — `/dev/tty` on Unix, `CONIN$` + `CONOUT$` on
-   Windows. On Unix, a terminal held in raw mode (canonical input off) belongs
-   to a full-screen TUI that spawned us, not to a shell we can prompt: TUI git
-   clients (lazygit, gitui, tig) run `git commit` as a child while owning the
-   screen, so the hook inherits a `/dev/tty` it must not prompt on. The mode
-   check fails open when it cannot read the mode. See `interactive/tty_*.go`
-   and `interactive/rawmode_unix.go` for the platform split and rationale.
+   Windows. A terminal held in raw mode (canonical/line input off) belongs to a
+   full-screen TUI that spawned us, not to a shell we can prompt: TUI git clients
+   (lazygit, gitui, tig) run `git commit` as a child while owning the screen, so
+   the hook inherits the same terminal it must not prompt on. The mode check
+   fails open when it cannot read the mode. See `interactive/tty_*.go` and
+   `interactive/rawmode_{unix,windows}.go` for the platform split and rationale.
 
 For subprocesses spawning the real `entire` binary (e2e, integration tests, `entire` calling itself from a hook), prefer `execx.NonInteractive` over env-var plumbing:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,12 +398,13 @@ Tests that spawn the real `entire` or `git` binary need the child to be non-inte
    it withdraws prompts from the largest agent population at once, which is a
    product decision rather than a detection fix.
 4. `CI=<non-empty-non-false>` → false.
-5. `/dev/tty` probe, plus its terminal mode → a terminal held in raw mode
-   (canonical input off) belongs to a full-screen TUI that spawned us, not to a
-   shell we can prompt: TUI git clients (lazygit, gitui, tig) run `git commit`
-   as a child while owning the screen, so the hook inherits a `/dev/tty` it
-   must not prompt on. Fails open when the mode can't be read. See
-   `interactive/rawmode_unix.go` for the rationale.
+5. Controlling-terminal probe — `/dev/tty` on Unix, `CONIN$` + `CONOUT$` on
+   Windows. On Unix, a terminal held in raw mode (canonical input off) belongs
+   to a full-screen TUI that spawned us, not to a shell we can prompt: TUI git
+   clients (lazygit, gitui, tig) run `git commit` as a child while owning the
+   screen, so the hook inherits a `/dev/tty` it must not prompt on. The mode
+   check fails open when it cannot read the mode. See `interactive/tty_*.go`
+   and `interactive/rawmode_unix.go` for the platform split and rationale.
 
 For subprocesses spawning the real `entire` binary (e2e, integration tests, `entire` calling itself from a hook), prefer `execx.NonInteractive` over env-var plumbing:
 
@@ -415,9 +416,9 @@ cmd.Dir = repoDir
 out, err := cmd.CombinedOutput()
 ```
 
-`execx.NonInteractive` puts the child in a new session with no controlling terminal (`Setsid` on Unix, `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows), so the child's `/dev/tty` probe fails naturally. No env var required.
+`execx.NonInteractive` puts the child in a new session with no controlling terminal (`Setsid` on Unix, `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows), so the child's platform terminal probe fails naturally. No env var required.
 
-`interactive.UnderTest()` returns true when `testing.Testing()` or `ENTIRE_TEST_TTY` is set — use it where code needs to skip a real-terminal operation even if `CanPromptInteractively()` returns true (e.g., reading from `/dev/tty` directly inside `askConfirmTTY`).
+`interactive.UnderTest()` returns true when `testing.Testing()` or `ENTIRE_TEST_TTY` is set — use it where code needs to skip a real-terminal operation even if `CanPromptInteractively()` returns true (e.g., opening `interactive.OpenPromptTTY()` directly inside a prompt reader).
 
 ### Linting and Formatting
 
@@ -1027,9 +1028,9 @@ comments at each site say which case applies:
   statting, or removing a directory is an operation on it from the outside, which
   a root over it cannot perform. `setupEntireDirectory`, `removeEntireDirectory`,
   the `MkdirAll` behind each anchor, and the plugin index clone are all this case.
-- **Paths the user named** (`doctor bundle --out`, `api --input`) and the two
-  single fixed files `/dev/tty` and `/proc/<pid>/*`. No boundary exists to
-  enforce.
+- **Paths the user named** (`doctor bundle --out`, `api --input`) and fixed
+  platform files such as `/dev/tty`, `CONIN$`, `CONOUT$`, and `/proc/<pid>/*`.
+  No boundary exists to enforce.
 
 ### Git Operations
 

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -15,7 +15,7 @@ import (
 //   - EnvTestTTY=1 → CanPromptInteractively returns true.
 //   - EnvTestTTY set to any other value → returns false.
 //   - EnvTestTTY unset → real detection via testing.Testing(), agent
-//     sentinels, CI, then /dev/tty probe.
+//     sentinels, CI, then a platform-specific controlling-terminal probe.
 const EnvTestTTY = "ENTIRE_TEST_TTY"
 
 // CanPromptInteractively reports whether interactive confirmation prompts
@@ -30,9 +30,10 @@ const EnvTestTTY = "ENTIRE_TEST_TTY"
 //     Subprocess tests must spawn via execx.NonInteractive (or set EnvTestTTY).
 //  3. Agent sentinels — vendor-set by agent subprocesses.
 //  4. CI=<non-empty-non-false> — de-facto CI convention.
-//  5. /dev/tty probe, plus its terminal mode: a controlling terminal held in
-//     raw mode belongs to a full-screen TUI (lazygit, gitui, tig, …) that
-//     spawned us, not to a shell we can prompt. See rawmode_unix.go.
+//  5. Platform-specific controlling-terminal probe, plus its terminal mode on
+//     platforms that expose one: a terminal held in raw mode belongs to a
+//     full-screen TUI (lazygit, gitui, tig, …) that spawned us, not to a shell
+//     we can prompt. See rawmode_unix.go.
 func CanPromptInteractively() bool {
 	if v := os.Getenv(EnvTestTTY); v != "" {
 		return v == "1"
@@ -52,7 +53,7 @@ func CanPromptInteractively() bool {
 		return false
 	}
 
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	tty, err := OpenPromptTTY()
 	if err != nil {
 		return false
 	}
@@ -60,13 +61,13 @@ func CanPromptInteractively() bool {
 	// Having a controlling terminal isn't enough — a TUI that spawned us holds
 	// that same terminal in raw mode for its own screen and keys. See
 	// rawmode_unix.go.
-	return !ttyInRawMode(tty)
+	return !ttyInRawMode(tty.Input())
 }
 
 // UnderTest reports whether the process is running in a test context — either
 // inside `go test` (testing.Testing()) or with EnvTestTTY explicitly set. Use
-// to skip operations that read from the real terminal (e.g. opening /dev/tty)
-// even when CanPromptInteractively() returns true.
+// to skip operations that read from the real controlling terminal even when
+// CanPromptInteractively() returns true.
 func UnderTest() bool {
 	return testing.Testing() || os.Getenv(EnvTestTTY) != ""
 }

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -26,14 +26,14 @@ const EnvTestTTY = "ENTIRE_TEST_TTY"
 // Precedence (first match wins):
 //  1. EnvTestTTY=1 forces interactive ON; any other non-empty value forces OFF.
 //  2. testing.Testing() — `go test` runs default to OFF so in-process tests
-//     don't hang on developer terminals that happen to have a real /dev/tty.
+//     don't hang on developer terminals that have a real controlling terminal.
 //     Subprocess tests must spawn via execx.NonInteractive (or set EnvTestTTY).
 //  3. Agent sentinels — vendor-set by agent subprocesses.
 //  4. CI=<non-empty-non-false> — de-facto CI convention.
 //  5. Platform-specific controlling-terminal probe, plus its terminal mode on
 //     platforms that expose one: a terminal held in raw mode belongs to a
 //     full-screen TUI (lazygit, gitui, tig, …) that spawned us, not to a shell
-//     we can prompt. See rawmode_unix.go.
+//     we can prompt. See rawmode_unix.go and rawmode_windows.go.
 func CanPromptInteractively() bool {
 	if v := os.Getenv(EnvTestTTY); v != "" {
 		return v == "1"

--- a/cmd/entire/cli/interactive/rawmode_other.go
+++ b/cmd/entire/cli/interactive/rawmode_other.go
@@ -1,13 +1,11 @@
-//go:build !darwin && !linux
+//go:build !darwin && !linux && !windows
 
 package interactive
 
 import "os"
 
-// ttyInRawMode cannot inspect terminal modes on platforms without the unix
-// termios ioctls, so it reports false (fail open — see rawmode_unix.go). Those
-// platforms don't have a /dev/tty for CanPromptInteractively to open either, so
-// this path is not reached in practice.
+// ttyInRawMode cannot inspect terminal modes on these platforms, so it reports
+// false (fail open — see rawmode_unix.go and rawmode_windows.go).
 func ttyInRawMode(_ *os.File) bool {
 	return false
 }

--- a/cmd/entire/cli/interactive/rawmode_windows.go
+++ b/cmd/entire/cli/interactive/rawmode_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package interactive
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// ttyInRawMode reports whether console line input is disabled. Full-screen
+// Windows TUIs disable ENABLE_LINE_INPUT while they own the console, just as
+// Unix TUIs disable ICANON; prompting from a child in that state would race the
+// parent for keys and draw over its screen.
+func ttyInRawMode(f *os.File) bool {
+	var mode uint32
+	if err := windows.GetConsoleMode(windows.Handle(f.Fd()), &mode); err != nil {
+		// Can't tell — fail open, matching the Unix mode probe.
+		return false
+	}
+	return consoleModeInRawMode(mode)
+}
+
+func consoleModeInRawMode(mode uint32) bool {
+	return mode&windows.ENABLE_LINE_INPUT == 0
+}

--- a/cmd/entire/cli/interactive/rawmode_windows_test.go
+++ b/cmd/entire/cli/interactive/rawmode_windows_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package interactive
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestConsoleModeInRawMode(t *testing.T) {
+	t.Parallel()
+
+	if consoleModeInRawMode(windows.ENABLE_LINE_INPUT) {
+		t.Error("line-input console reported as raw")
+	}
+	if !consoleModeInRawMode(0) {
+		t.Error("console without line input reported as canonical")
+	}
+}

--- a/cmd/entire/cli/interactive/tty.go
+++ b/cmd/entire/cli/interactive/tty.go
@@ -1,0 +1,56 @@
+package interactive
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// PromptTTY is the platform's controlling terminal, opened for prompt input and
+// output independently where the platform requires separate handles.
+type PromptTTY struct {
+	in  *os.File
+	out *os.File
+}
+
+// Input returns the terminal input handle. Callers that hand terminal input to
+// a library such as Bubble Tea need the concrete file so it can manage raw mode.
+func (t *PromptTTY) Input() *os.File {
+	return t.in
+}
+
+// Read reads prompt input.
+func (t *PromptTTY) Read(p []byte) (int, error) {
+	n, err := t.in.Read(p)
+	if err != nil {
+		return n, fmt.Errorf("read prompt terminal: %w", err)
+	}
+	return n, nil
+}
+
+// Write writes prompt output.
+func (t *PromptTTY) Write(p []byte) (int, error) {
+	n, err := t.out.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("write prompt terminal: %w", err)
+	}
+	return n, nil
+}
+
+// Close closes the prompt terminal handles.
+func (t *PromptTTY) Close() error {
+	if t.in == t.out {
+		if err := t.in.Close(); err != nil {
+			return fmt.Errorf("close prompt terminal: %w", err)
+		}
+		return nil
+	}
+	var errs []error
+	if err := t.in.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("close prompt terminal input: %w", err))
+	}
+	if err := t.out.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("close prompt terminal output: %w", err))
+	}
+	return errors.Join(errs...)
+}

--- a/cmd/entire/cli/interactive/tty_other.go
+++ b/cmd/entire/cli/interactive/tty_other.go
@@ -1,0 +1,10 @@
+//go:build !unix && !windows
+
+package interactive
+
+import "errors"
+
+// OpenPromptTTY reports that this platform has no supported controlling-terminal device.
+func OpenPromptTTY() (*PromptTTY, error) {
+	return nil, errors.New("prompt terminal is unsupported on this platform")
+}

--- a/cmd/entire/cli/interactive/tty_unix.go
+++ b/cmd/entire/cli/interactive/tty_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package interactive
+
+import (
+	"fmt"
+	"os"
+)
+
+// OpenPromptTTY opens the controlling terminal for interactive prompts.
+func OpenPromptTTY() (*PromptTTY, error) {
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open /dev/tty: %w", err)
+	}
+	return &PromptTTY{in: tty, out: tty}, nil
+}

--- a/cmd/entire/cli/interactive/tty_windows.go
+++ b/cmd/entire/cli/interactive/tty_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package interactive
+
+import (
+	"fmt"
+	"os"
+)
+
+// OpenPromptTTY opens the Windows controlling-console devices for interactive
+// prompts. Windows exposes console input and output through separate handles.
+func OpenPromptTTY() (*PromptTTY, error) {
+	in, err := os.OpenFile("CONIN$", os.O_RDONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open CONIN$: %w", err)
+	}
+	out, err := os.OpenFile("CONOUT$", os.O_WRONLY, 0)
+	if err != nil {
+		_ = in.Close()
+		return nil, fmt.Errorf("open CONOUT$: %w", err)
+	}
+	return &PromptTTY{in: in, out: out}, nil
+}

--- a/cmd/entire/cli/interactive/tty_windows.go
+++ b/cmd/entire/cli/interactive/tty_windows.go
@@ -10,7 +10,9 @@ import (
 // OpenPromptTTY opens the Windows controlling-console devices for interactive
 // prompts. Windows exposes console input and output through separate handles.
 func OpenPromptTTY() (*PromptTTY, error) {
-	in, err := os.OpenFile("CONIN$", os.O_RDONLY, 0)
+	// Bubble Tea switches the input handle into raw mode with SetConsoleMode,
+	// which requires GENERIC_WRITE as well as GENERIC_READ.
+	in, err := os.OpenFile("CONIN$", os.O_RDWR, 0)
 	if err != nil {
 		return nil, fmt.Errorf("open CONIN$: %w", err)
 	}

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -96,13 +96,13 @@ func loginURLKeysAvailable() bool {
 		return false
 	}
 
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	tty, err := interactive.OpenPromptTTY()
 	if err != nil {
 		return false
 	}
 	defer tty.Close()
 
-	return interactive.IsTerminalReader(tty)
+	return interactive.IsTerminalReader(tty.Input())
 }
 
 // copyLoginURL bounds a clipboard write. clipboardWriteFunc takes no context —
@@ -869,26 +869,35 @@ func readLoginURLAction(ctx context.Context, errW io.Writer) (loginURLAction, er
 		return loginURLNone, nil
 	}
 
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	tty, err := interactive.OpenPromptTTY()
 	if err != nil {
 		return loginURLNone, nil //nolint:nilerr // no controlling TTY; continue without key actions
 	}
 
-	return readLoginURLActionFromTTY(ctx, errW, tty)
+	return readLoginURLActionFromTerminal(ctx, errW, tty.Input(), tty.Close)
 }
 
 // readLoginURLActionFromTTY takes ownership of tty. Bubble Tea handles raw mode,
 // escape-sequence decoding, and terminal restoration. If the terminal cannot
 // provide single-key input, disable key actions.
 func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File) (loginURLAction, error) {
+	return readLoginURLActionFromTerminal(ctx, errW, tty, tty.Close)
+}
+
+func readLoginURLActionFromTerminal(
+	ctx context.Context,
+	errW io.Writer,
+	input *os.File,
+	closeTerminal func() error,
+) (loginURLAction, error) {
 	closeTTY := true
 	defer func() {
 		if closeTTY {
-			_ = tty.Close()
+			_ = closeTerminal() //nolint:errcheck // best-effort cleanup after terminal interaction
 		}
 	}()
 
-	if !interactive.IsTerminalReader(tty) {
+	if !interactive.IsTerminalReader(input) {
 		return loginURLNone, nil
 	}
 
@@ -899,7 +908,7 @@ func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File
 
 	program := tea.NewProgram(
 		loginURLActionModel{},
-		tea.WithInput(tty),
+		tea.WithInput(input),
 		tea.WithOutput(io.Discard),
 		tea.WithoutSignalHandler(),
 	)
@@ -916,7 +925,8 @@ func readLoginURLActionFromTTY(ctx context.Context, errW io.Writer, tty *os.File
 	if errors.Is(err, tea.ErrProgramKilled) {
 		// Bubble Tea reports any event-loop error this way, input-stream failures
 		// included, and a killed Run skipped waitForReadLoop — so the reader may
-		// still hold tty. Let process exit reclaim the fd rather than race for it.
+		// still hold the input handle. Let process exit reclaim the terminal
+		// handles rather than race for them.
 		closeTTY = false
 	}
 	if ctx.Err() != nil {

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -53,7 +53,8 @@ const (
 	ttyResultLinkAlways                  // Link and remember: add trailer + save "always" preference
 )
 
-// askConfirmTTY prompts the user via /dev/tty whether to link a commit to session context.
+// askConfirmTTY prompts via the controlling terminal whether to link a commit
+// to session context.
 // This requires a controlling terminal — callers must check
 // interactive.CanPromptInteractively() first and handle the no-TTY case
 // (agent subprocesses, CI) themselves.
@@ -71,10 +72,10 @@ func askConfirmTTY(header string, details []string, prompt string, defaultYes bo
 		return defaultResult
 	}
 
-	// Open /dev/tty for both reading and writing.
-	// This is the controlling terminal, which works even when stdin/stderr are redirected
-	// (e.g., human runs git commit -m where stdin is not a pipe).
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	// Open the controlling terminal for both reading and writing. This works even
+	// when stdin/stderr are redirected (e.g., human runs git commit -m where
+	// stdin is not a pipe).
+	tty, err := interactive.OpenPromptTTY()
 	if err != nil {
 		return defaultResult
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1274
<!-- entire-trail-link-end -->

## Summary

- open the controlling terminal through platform-specific devices (`/dev/tty` on Unix, `CONIN$`/`CONOUT$` on Windows)
- route interactive detection, login key actions, and commit-link confirmation through the shared abstraction
- preserve the Unix raw-terminal guard used to avoid prompting underneath full-screen TUIs

This supersedes #1396.

## Credit

This work originated in #1396 by Bryan Wade (@stale2000), who identified the native Windows gap and proposed using the Windows console devices. Thank you for the investigation and original contribution.

## Testing

- `mise run check`
- `GOOS=windows GOARCH=amd64 go test -c ./cmd/entire/cli/interactive`
- `GOOS=windows GOARCH=amd64 go test -c ./cmd/entire/cli/strategy`
- `GOOS=windows GOARCH=amd64 go test -c ./cmd/entire/cli`

Native Windows terminal interaction was not manually tested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when prompts appear and how login/hook TTY I/O works on Windows and all platforms that use the new abstraction; behavior on Unix is intended to be preserved but regressions in TUI detection or terminal cleanup would affect commit hooks and sign-in UX.
> 
> **Overview**
> **Restores interactive prompts on Windows** by opening the controlling console through **`CONIN$` / `CONOUT$`** instead of Unix-only **`/dev/tty`**, while keeping **`/dev/tty`** on Unix and failing closed on unsupported platforms.
> 
> Adds a shared **`PromptTTY`** wrapper with **`OpenPromptTTY()`** and routes **`CanPromptInteractively()`**, login keyboard actions (Bubble Tea), and commit-link **`askConfirmTTY`** through it. **Unix raw-mode detection** (skip prompts under full-screen TUIs) still runs on the input handle. **Docs** (`CLAUDE.md`) now describe the platform-specific terminal probe and **`CONIN$`/`CONOUT$`** as fixed paths outside **`os.Root`** confinement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b1b7e895740b2216af33fc807e0d298bc23132. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
