### PR TITLE
fix(status): report disabled checkpoint pushing

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -55,6 +55,38 @@ func FetchURL(ctx context.Context, opts ...FetchURLOptions) (string, error) {
 	return url, err
 }
 
+// ReadsDedicatedStore reports whether checkpoint READS resolve to the
+// configured dedicated checkpoint_remote.
+//
+// leadReadRemote contributes an IDENTITY to the ownership vote, and nothing
+// else: when a checkpoint_remote is configured the URL is always derived from
+// origin, which is why FetchURLOptions.LeadReadRemote says the dedicated path
+// "ignores it entirely". Pass the elected sync remote so the vote sees the
+// same fork-shaped identity the push side sees.
+//
+// The read counterpart of PushURL's enabled bit, and deliberately a separate
+// question: both require every identity to be owned by the checkpoint repo's
+// owner, but the push identity set is origin plus the elected remote's PUSH
+// URLs while the fetch set is origin plus leadReadRemote's FETCH URL — so a
+// remote whose two URLs have different owners is eligible on one side and not
+// the other. A caller reporting where checkpoints COME FROM must ask this
+// one; PushURL answers where they would GO.
+//
+// False covers every reason reads do not land on the configured store, not
+// only an inherited one: no checkpoint_remote configured, ownership not
+// confirmed, unreadable settings, an origin URL that will not parse, or a
+// protocol that maps to no checkpoint URL and no provider host. A caller that
+// needs to explain WHY cannot read it off this bool; the reasons are logged
+// where they are decided.
+//
+// Local-only, like FetchURL: git config and settings reads, no dialing. An
+// error means no read URL resolves at all — distinct from false, which means
+// reads resolve somewhere else.
+func ReadsDedicatedStore(ctx context.Context, leadReadRemote string) (bool, error) {
+	_, authoritative, err := fetchURLAuthoritative(ctx, FetchURLOptions{LeadReadRemote: leadReadRemote})
+	return authoritative, err
+}
+
 // fetchURLAuthoritative is FetchURL plus whether the returned URL is
 // authoritative for checkpoint refs. It is false exactly when a
 // checkpoint_remote IS configured (or cannot be determined) but resolution

--- a/cmd/entire/cli/integration_test/multi_pushurl_test.go
+++ b/cmd/entire/cli/integration_test/multi_pushurl_test.go
@@ -406,37 +406,6 @@ func TestMultiPushURL_DestinationNoteSurfaces(t *testing.T) {
 			want:   []string{"2 remotes", "single elected remote", "entire status"},
 			absent: []string{"follow whichever remote", "always looks at origin"},
 		},
-		{
-			// The note tells the user to run `entire status` for the elected
-			// destination, and describes where a push delivers checkpoints —
-			// both of which read as promises when push_sessions is false and
-			// nothing is pushed at all. The ambiguity is still real (it is
-			// what re-enabling pushing runs into), so the note is qualified
-			// rather than suppressed — and the caveat points at status for
-			// the read source instead of claiming the URLs listed here are
-			// it, since those are push URLs and reads use the fetch URL.
-			name: "several remotes, pushing disabled",
-			setup: func(env *TestEnv) {
-				env.SetupNamedBareRemote("backup")
-				env.PatchSettings(map[string]any{
-					"strategy_options": map[string]any{"push_sessions": false},
-				})
-			},
-			want: []string{
-				// One string proving the note still renders its body; the
-				// case above already covers that body in full.
-				"single elected remote",
-				"Automatic checkpoint pushing is disabled (push_sessions=false)",
-				// Substrings must not straddle the note's line wrapping.
-				"they would go if you re-enabled it",
-			},
-			absent: []string{
-				"checkpoints are waiting for it",
-				// The URLs listed here are push URLs; reads use the fetch
-				// URL, so this note must not present them as the read source.
-				"where they are read from today",
-			},
-		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/entire/cli/integration_test/multi_pushurl_test.go
+++ b/cmd/entire/cli/integration_test/multi_pushurl_test.go
@@ -423,11 +423,12 @@ func TestMultiPushURL_DestinationNoteSurfaces(t *testing.T) {
 				})
 			},
 			want: []string{
-				"2 remotes", "single elected remote", "entire status",
+				// One string proving the note still renders its body; the
+				// case above already covers that body in full.
+				"single elected remote",
 				"Automatic checkpoint pushing is disabled (push_sessions=false)",
 				// Substrings must not straddle the note's line wrapping.
 				"they would go if you re-enabled it",
-				"checkpoints are read from meanwhile",
 			},
 			absent: []string{
 				"checkpoints are waiting for it",

--- a/cmd/entire/cli/integration_test/multi_pushurl_test.go
+++ b/cmd/entire/cli/integration_test/multi_pushurl_test.go
@@ -410,9 +410,11 @@ func TestMultiPushURL_DestinationNoteSurfaces(t *testing.T) {
 			// The note tells the user to run `entire status` for the elected
 			// destination, and describes where a push delivers checkpoints —
 			// both of which read as promises when push_sessions is false and
-			// nothing is pushed at all. The note still applies (the
-			// destination decides where checkpoints are READ from), so it is
-			// qualified rather than suppressed.
+			// nothing is pushed at all. The ambiguity is still real (it is
+			// what re-enabling pushing runs into), so the note is qualified
+			// rather than suppressed — and the caveat points at status for
+			// the read source instead of claiming the URLs listed here are
+			// it, since those are push URLs and reads use the fetch URL.
 			name: "several remotes, pushing disabled",
 			setup: func(env *TestEnv) {
 				env.SetupNamedBareRemote("backup")
@@ -423,9 +425,16 @@ func TestMultiPushURL_DestinationNoteSurfaces(t *testing.T) {
 			want: []string{
 				"2 remotes", "single elected remote", "entire status",
 				"Automatic checkpoint pushing is disabled (push_sessions=false)",
+				// Substrings must not straddle the note's line wrapping.
+				"they would go if you re-enabled it",
+				"checkpoints are read from meanwhile",
+			},
+			absent: []string{
+				"checkpoints are waiting for it",
+				// The URLs listed here are push URLs; reads use the fetch
+				// URL, so this note must not present them as the read source.
 				"where they are read from today",
 			},
-			absent: []string{"checkpoints are waiting for it"},
 		},
 	}
 

--- a/cmd/entire/cli/integration_test/multi_pushurl_test.go
+++ b/cmd/entire/cli/integration_test/multi_pushurl_test.go
@@ -406,6 +406,27 @@ func TestMultiPushURL_DestinationNoteSurfaces(t *testing.T) {
 			want:   []string{"2 remotes", "single elected remote", "entire status"},
 			absent: []string{"follow whichever remote", "always looks at origin"},
 		},
+		{
+			// The note tells the user to run `entire status` for the elected
+			// destination, and describes where a push delivers checkpoints —
+			// both of which read as promises when push_sessions is false and
+			// nothing is pushed at all. The note still applies (the
+			// destination decides where checkpoints are READ from), so it is
+			// qualified rather than suppressed.
+			name: "several remotes, pushing disabled",
+			setup: func(env *TestEnv) {
+				env.SetupNamedBareRemote("backup")
+				env.PatchSettings(map[string]any{
+					"strategy_options": map[string]any{"push_sessions": false},
+				})
+			},
+			want: []string{
+				"2 remotes", "single elected remote", "entire status",
+				"Automatic checkpoint pushing is disabled (push_sessions=false)",
+				"where they are read from today",
+			},
+			absent: []string{"checkpoints are waiting for it"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -51,6 +51,12 @@ type remoteTopology struct {
 	// primaryIsRefs reports whether the git-refs backend is active, which
 	// decides what a fanning-out remote means for checkpoints.
 	primaryIsRefs bool
+	// pushDisabled reports that push_sessions is off, which makes every claim
+	// below about where a push delivers checkpoints conditional: nothing is
+	// pushed at all. Read as a caveat on the note, not a reason to suppress
+	// it — the destination still decides where checkpoints are read from, and
+	// it is still what a user pins with checkpoint_remote.
+	pushDisabled bool
 }
 
 // inspectRemoteTopology reads the repo's remotes and checkpoint configuration.
@@ -91,6 +97,11 @@ func inspectRemoteTopology(ctx context.Context) remoteTopology {
 
 	if cpCfg, err := settings.LoadCheckpointsConfig(ctx); err == nil {
 		t.primaryIsRefs = checkpoint.PrimaryIsRefs(cpCfg)
+	}
+	// Best-effort like everything else here: an unreadable settings file reads
+	// as "pushing enabled", which is the note this code has always printed.
+	if s, err := settings.Load(ctx); err == nil {
+		t.pushDisabled = s.IsPushSessionsDisabled()
 	}
 
 	return t
@@ -144,6 +155,15 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 
 	fmt.Fprintln(w, header)
 
+	// Said first, because it qualifies every "pushes to" below. The note is
+	// still worth printing: the destination decides where checkpoints are read
+	// from, and re-enabling pushing is one setting away.
+	if t.pushDisabled {
+		fmt.Fprintln(w, "  Automatic checkpoint pushing is disabled (push_sessions=false), so no")
+		fmt.Fprintln(w, "  checkpoints are pushed anywhere right now. The destination below is where")
+		fmt.Fprintln(w, "  they would go, and where they are read from today.")
+	}
+
 	for _, d := range t.destinations {
 		if !d.fansOut() {
 			continue
@@ -170,8 +190,8 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 		fmt.Fprintf(w, "  This repo has %d remotes (%s).\n", len(names), strings.Join(names, ", "))
 		fmt.Fprintln(w, "    Checkpoints sync to a single elected remote — not to whichever one you")
 		fmt.Fprintln(w, "    push to. A push to any other remote carries your code but no session")
-		fmt.Fprintln(w, "    history. Run `entire status` to see the elected destination and how many")
-		fmt.Fprintln(w, "    checkpoints are waiting for it.")
+		fmt.Fprintln(w, "    history. Run `entire status` to see the elected destination and how much")
+		fmt.Fprintln(w, "    checkpoint data has not reached it.")
 	}
 
 	fmt.Fprintln(w, "  To pin one repository for checkpoints, set checkpoint_remote in")

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -54,8 +54,8 @@ type remoteTopology struct {
 	// pushDisabled reports that push_sessions is off, which makes every claim
 	// below about where a push delivers checkpoints conditional: nothing is
 	// pushed at all. Read as a caveat on the note, not a reason to suppress
-	// it — the destination still decides where checkpoints are read from, and
-	// it is still what a user pins with checkpoint_remote.
+	// it — the ambiguity is still what re-enabling pushing would run into,
+	// and still what a user pins with checkpoint_remote.
 	pushDisabled bool
 }
 
@@ -156,12 +156,20 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 	fmt.Fprintln(w, header)
 
 	// Said first, because it qualifies every "pushes to" below. The note is
-	// still worth printing: the destination decides where checkpoints are read
-	// from, and re-enabling pushing is one setting away.
+	// still worth printing: the ambiguity it describes is what re-enabling
+	// pushing would run into, and it is what checkpoint_remote pins.
+	//
+	// Deliberately silent about where checkpoints are READ from, even though
+	// that is the live question when nothing is pushed: what this note lists
+	// is PUSH URLs, and a fan-out remote's reads use its fetch URL instead
+	// (the git-branch branch below says as much — "only the fetch URL is ever
+	// reconciled"). `entire status` names the read source correctly, as an
+	// elected remote rather than a URL.
 	if t.pushDisabled {
 		fmt.Fprintln(w, "  Automatic checkpoint pushing is disabled (push_sessions=false), so no")
 		fmt.Fprintln(w, "  checkpoints are pushed anywhere right now. The destination below is where")
-		fmt.Fprintln(w, "  they would go, and where they are read from today.")
+		fmt.Fprintln(w, "  they would go if you re-enabled it; `entire status` reports where")
+		fmt.Fprintln(w, "  checkpoints are read from meanwhile.")
 	}
 
 	for _, d := range t.destinations {

--- a/cmd/entire/cli/remote_topology.go
+++ b/cmd/entire/cli/remote_topology.go
@@ -163,13 +163,17 @@ func (t remoteTopology) describeCheckpointDestination(w io.Writer, header string
 	// that is the live question when nothing is pushed: what this note lists
 	// is PUSH URLs, and a fan-out remote's reads use its fetch URL instead
 	// (the git-branch branch below says as much — "only the fetch URL is ever
-	// reconciled"). `entire status` names the read source correctly, as an
-	// elected remote rather than a URL.
+	// reconciled").
+	//
+	// It points at `entire status` for that rather than answering it, and
+	// without promising an answer: status names a read source where it can
+	// establish one, and says so when it cannot — a failed election with a
+	// configured checkpoint_remote resolves to neither.
 	if t.pushDisabled {
 		fmt.Fprintln(w, "  Automatic checkpoint pushing is disabled (push_sessions=false), so no")
 		fmt.Fprintln(w, "  checkpoints are pushed anywhere right now. The destination below is where")
-		fmt.Fprintln(w, "  they would go if you re-enabled it; `entire status` reports where")
-		fmt.Fprintln(w, "  checkpoints are read from meanwhile.")
+		fmt.Fprintln(w, "  they would go if you re-enabled it; for where they are read from today,")
+		fmt.Fprintln(w, "  see `entire status`.")
 	}
 
 	for _, d := range t.destinations {

--- a/cmd/entire/cli/remote_topology_test.go
+++ b/cmd/entire/cli/remote_topology_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// describeCheckpointDestination writes to an io.Writer from a plain struct, so
+// the disabled-pushing caveat needs no repo, no remotes and no CLI run.
+//
+// What it must not do is present the URLs it lists as the read source: they
+// are PUSH urls, and a fan-out remote's reads use its fetch url. It points at
+// `entire status` for that instead, and does not promise status will always
+// have an answer.
+func TestDescribeCheckpointDestination_PushDisabledCaveat(t *testing.T) {
+	t.Parallel()
+	topology := remoteTopology{
+		destinations: []remoteDestination{
+			{name: "backup", pushURLs: []string{"https://github.com/org/backup.git"}},
+			{name: "origin", pushURLs: []string{"https://github.com/org/repo.git"}},
+		},
+	}
+	for _, tc := range []struct {
+		name           string
+		pushDisabled   bool
+		want, unwanted []string
+	}{
+		{
+			name:     "pushing enabled",
+			want:     []string{"2 remotes", "single elected remote"},
+			unwanted: []string{"push_sessions=false"},
+		},
+		{
+			name:         "pushing disabled",
+			pushDisabled: true,
+			want: []string{
+				// The note still renders its body: the ambiguity is what
+				// re-enabling pushing would run into.
+				"single elected remote",
+				"Automatic checkpoint pushing is disabled (push_sessions=false)",
+				"they would go if you re-enabled it",
+			},
+			// "waiting for it" implied a pending push that cannot happen.
+			unwanted: []string{"checkpoints are waiting for it"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			topology := topology
+			topology.pushDisabled = tc.pushDisabled
+			var b strings.Builder
+			topology.describeCheckpointDestination(&b, "Checkpoint destination: REVIEW")
+			for _, want := range tc.want {
+				if !strings.Contains(b.String(), want) {
+					t.Errorf("missing %q:\n%s", want, b.String())
+				}
+			}
+			for _, unwanted := range tc.unwanted {
+				if strings.Contains(b.String(), unwanted) {
+					t.Errorf("must not mention %q:\n%s", unwanted, b.String())
+				}
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -334,10 +334,19 @@ const checkpointSyncSourceDedicated = "dedicated"
 type checkpointSyncInfo struct {
 	// PushDisabled reflects the explicit automatic-push setting, not every
 	// possible reason checkpoint sync might fail.
+	//
+	// It suppresses nothing else in this struct, because nothing else is a
+	// push promise. The elected remote stays the checkpoint READ source
+	// (strategy.CheckpointReadRemotesWithElection never consults
+	// push_sessions), the unpushed count is the only signal that local-only
+	// checkpoint data is accumulating, and the remote-configuration
+	// diagnostics explain read behavior too. Disabling uploads therefore
+	// changes how the renderers PHRASE these fields, not whether they are
+	// populated — see writeCheckpointSyncLines.
 	PushDisabled bool
 	// Remote is the elected git remote name, or the org/repo slug in
-	// dedicated checkpoint_remote mode. Empty when pushing is disabled or
-	// nothing resolved (no remotes configured, or the fail-closed case).
+	// dedicated checkpoint_remote mode. Empty when nothing resolved (no
+	// remotes configured, or the fail-closed case).
 	Remote string
 	// Source is config|observed|default|sole|first (resolver values) or
 	// "dedicated".
@@ -358,8 +367,6 @@ type checkpointSyncInfo struct {
 
 func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
 	info := checkpointSyncInfo{PushDisabled: s.IsPushSessionsDisabled()}
-	// Remote configuration diagnostics also explain checkpoint read behavior.
-	// Disabling uploads suppresses push promises and counts, not these warnings.
 
 	elected, err := strategy.ResolveCheckpointSyncRemote(ctx)
 	if err != nil {
@@ -387,9 +394,6 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 	// PushURL differently than this elected-remote probe does.
 	if cr := s.GetCheckpointRemote(); cr != nil {
 		if _, enabled, purlErr := checkpointremote.PushURL(ctx, elected.Name); purlErr == nil && enabled {
-			if info.PushDisabled {
-				return info
-			}
 			info.Remote = cr.Repo
 			info.Source = checkpointSyncSourceDedicated
 			// The unpushed counter is meaningful here only on the git-refs
@@ -404,11 +408,9 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 		}
 	}
 
-	if !info.PushDisabled {
-		info.Remote = elected.Name
-		info.Source = string(elected.Source)
-		info.Unpushed = countUnpushedCheckpointsForStatus(ctx, elected.Name)
-	}
+	info.Remote = elected.Name
+	info.Source = string(elected.Source)
+	info.Unpushed = countUnpushedCheckpointsForStatus(ctx, elected.Name)
 	// A configured checkpoint_remote that did not enable above is being
 	// ignored. When the ownership check is what rejected it, say so: this is
 	// the one trust-gate rejection a user otherwise experiences only as
@@ -438,30 +440,44 @@ func countUnpushedCheckpointsForStatus(ctx context.Context, remoteName string) i
 	return n
 }
 
-// writeCheckpointSyncLines reports disabled automatic pushing or the checkpoint
-// sync destination (and the unpushed counter, when non-zero) in the enabled status
-// block. With pushing enabled, no remotes configured means no lines.
+// writeCheckpointSyncLines reports the checkpoint sync destination (and the
+// unpushed counter, when non-zero) in the enabled status block, prefixed by the
+// disabled-pushing line when automatic pushing is off. No remotes configured
+// means no destination line either way.
+//
+// Every phrase that promises a push is conditioned on info.PushDisabled: with
+// pushing off the elected remote is still the read source and the counter still
+// reports local-only data, so the lines are reworded rather than dropped —
+// status is the only surface that names either.
 func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *EntireSettings, sty statusStyles) {
 	info := computeCheckpointSyncInfo(ctx, s)
-	switch {
-	case info.PushDisabled:
+	destination := "\n  Checkpoints sync to: "
+	if info.PushDisabled {
 		b.WriteString("\n  Automatic checkpoint pushing: disabled")
 		b.WriteString(sty.render(sty.dim, " (push_sessions=false)"))
-		if info.Err != "" {
-			b.WriteString("\n")
-			b.WriteString(sty.render(sty.yellow, "  ! Checkpoint remote configuration: "+info.Err))
-		}
+		destination = "\n  Checkpoints read from: "
+	}
+	switch {
 	case info.Err != "":
 		b.WriteString("\n")
-		b.WriteString(sty.render(sty.yellow, "  ! Checkpoints NOT syncing: "+info.Err))
+		// A fail-closed election is not a push failure when nothing is being
+		// pushed: name the misconfiguration without claiming a lost sync.
+		if info.PushDisabled {
+			b.WriteString(sty.render(sty.yellow, "  ! Checkpoint remote configuration: "+info.Err))
+		} else {
+			b.WriteString(sty.render(sty.yellow, "  ! Checkpoints NOT syncing: "+info.Err))
+		}
 	case info.Remote == "":
-		return
+		// No remotes configured: nothing resolved, and the diagnostics and
+		// counter below are empty by construction on this path.
 	case info.Source == checkpointSyncSourceDedicated:
-		b.WriteString("\n  Checkpoints sync to: ")
+		b.WriteString(destination)
 		b.WriteString(sty.render(sty.cyan, "dedicated checkpoint remote ("+info.Remote+")"))
 	default:
-		b.WriteString("\n  Checkpoints sync to: ")
+		b.WriteString(destination)
 		b.WriteString(sty.render(sty.cyan, info.Remote))
+		// Both suffixes describe how the remote was ELECTED, which is what
+		// picks the read source too, so they hold with pushing disabled.
 		switch info.Source {
 		case string(strategy.SyncRemoteSourceConfig):
 			b.WriteString(sty.render(sty.dim, " (set by checkpoint_push_remote)"))
@@ -484,12 +500,19 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 // formatUnpushedCheckpointsLine phrases the unpushed counter. Dedicated URL
 // mode has no git remote to name (and only reaches here on the git-refs
 // backend), so it drops the remote-name phrasing.
+//
+// With pushing disabled the count is not pending anything, so it says what the
+// number actually is — local-only checkpoint data, which keeps growing because
+// push_sessions gates pushing and not checkpoint creation.
 func formatUnpushedCheckpointsLine(info checkpointSyncInfo) string {
 	noun := "checkpoints"
 	pronoun := "they sync"
 	if info.Unpushed == 1 {
 		noun = "checkpoint"
 		pronoun = "it syncs"
+	}
+	if info.PushDisabled {
+		return fmt.Sprintf("%d %s stored locally only", info.Unpushed, noun)
 	}
 	if info.Source == checkpointSyncSourceDedicated {
 		return fmt.Sprintf("%d %s not yet pushed", info.Unpushed, noun)
@@ -871,8 +894,13 @@ type statusJSON struct {
 	CodexHooks *codexHooksStatusJSON `json:"codex_hooks,omitempty"`
 	// CheckpointPushDisabled is emitted only when Entire is enabled and the
 	// effective push_sessions setting is false. Its absence does not guarantee
-	// that a push can succeed. Sync destination, error, and count fields are
-	// omitted while pushing is disabled.
+	// that a push can succeed.
+	//
+	// No other field is omitted or suppressed when it is set: read it as
+	// requalifying the fields below rather than removing them.
+	// CheckpointSyncRemote is then the remote checkpoints are READ from,
+	// UnpushedCheckpoints counts checkpoint data held only locally, and the
+	// error and ignored-remote diagnostics apply to reads as well.
 	CheckpointPushDisabled bool `json:"checkpoint_push_disabled,omitempty"`
 	// CheckpointSyncRemote is the elected checkpoint sync remote name, or the
 	// org/repo slug in dedicated checkpoint_remote mode. Deliberately not named

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -357,9 +357,9 @@ type checkpointSyncInfo struct {
 }
 
 func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
-	if s.IsPushSessionsDisabled() {
-		return checkpointSyncInfo{PushDisabled: true}
-	}
+	info := checkpointSyncInfo{PushDisabled: s.IsPushSessionsDisabled()}
+	// Remote configuration diagnostics also explain checkpoint read behavior.
+	// Disabling uploads suppresses push promises and counts, not these warnings.
 
 	elected, err := strategy.ResolveCheckpointSyncRemote(ctx)
 	if err != nil {
@@ -370,10 +370,11 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 		// configured, the gate's dedicated exemption may still sync checkpoint
 		// data even while this fail-closed warning is shown, since there is no
 		// elected remote left to probe PushURL against here.
-		return checkpointSyncInfo{Err: err.Error()}
+		info.Err = err.Error()
+		return info
 	}
 	if elected.Name == "" {
-		return checkpointSyncInfo{} // no remotes configured: show nothing
+		return info // no remotes configured: only report disabled pushing, if set
 	}
 
 	// Dedicated checkpoint_remote mode is reported only when PushURL derives
@@ -386,7 +387,11 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 	// PushURL differently than this elected-remote probe does.
 	if cr := s.GetCheckpointRemote(); cr != nil {
 		if _, enabled, purlErr := checkpointremote.PushURL(ctx, elected.Name); purlErr == nil && enabled {
-			info := checkpointSyncInfo{Remote: cr.Repo, Source: checkpointSyncSourceDedicated}
+			if info.PushDisabled {
+				return info
+			}
+			info.Remote = cr.Repo
+			info.Source = checkpointSyncSourceDedicated
 			// The unpushed counter is meaningful here only on the git-refs
 			// backend (push-queue length is local and accurate). The
 			// git-branch comparison is omitted: pushes to a raw URL update
@@ -399,10 +404,10 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 		}
 	}
 
-	info := checkpointSyncInfo{
-		Remote:   elected.Name,
-		Source:   string(elected.Source),
-		Unpushed: countUnpushedCheckpointsForStatus(ctx, elected.Name),
+	if !info.PushDisabled {
+		info.Remote = elected.Name
+		info.Source = string(elected.Source)
+		info.Unpushed = countUnpushedCheckpointsForStatus(ctx, elected.Name)
 	}
 	// A configured checkpoint_remote that did not enable above is being
 	// ignored. When the ownership check is what rejected it, say so: this is
@@ -440,8 +445,12 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 	info := computeCheckpointSyncInfo(ctx, s)
 	switch {
 	case info.PushDisabled:
-		b.WriteString("\n  Automatic checkpoint pushing: disabled (push_sessions=false)")
-		return
+		b.WriteString("\n  Automatic checkpoint pushing: disabled")
+		b.WriteString(sty.render(sty.dim, " (push_sessions=false)"))
+		if info.Err != "" {
+			b.WriteString("\n")
+			b.WriteString(sty.render(sty.yellow, "  ! Checkpoint remote configuration: "+info.Err))
+		}
 	case info.Err != "":
 		b.WriteString("\n")
 		b.WriteString(sty.render(sty.yellow, "  ! Checkpoints NOT syncing: "+info.Err))

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -336,13 +336,20 @@ type checkpointSyncInfo struct {
 	// possible reason checkpoint sync might fail.
 	//
 	// It suppresses nothing else in this struct, because nothing else is a
-	// push promise. The elected remote stays the checkpoint READ source
-	// (strategy.CheckpointReadRemotesWithElection never consults
-	// push_sessions), the unpushed count is the only signal that checkpoint
-	// data is not reaching the elected destination, and the
-	// remote-configuration diagnostics explain read behavior too. Disabling
-	// uploads therefore changes how the renderers PHRASE these fields, not
-	// whether they are populated — see writeCheckpointSyncLines.
+	// push promise: reads keep working (push_sessions gates only the pre-push
+	// hook), the unpushed count is the only signal that checkpoint data is
+	// not reaching the elected destination, and the remote-configuration
+	// diagnostics explain read behavior too.
+	//
+	// What it does instead is switch the QUESTION these fields answer, from
+	// "where would checkpoints go" to "where do they come from" — so it
+	// changes more than phrasing. With a checkpoint_remote configured, the
+	// verdict behind Remote and Source is then the FETCH side's rather than
+	// the push side's, and in a repo whose two URLs have different owners
+	// that is a different VALUE, not a different wording. (With none
+	// configured both answer the elected remote, and only the wording
+	// differs.) ReadFallback and ReadSourceUnknown exist only while it is
+	// set.
 	PushDisabled bool
 	// Remote is the elected git remote name, or the org/repo slug in
 	// dedicated checkpoint_remote mode. Empty when nothing resolved (no
@@ -353,16 +360,23 @@ type checkpointSyncInfo struct {
 	Source string
 	// Err is the fail-closed misconfiguration message from the resolver.
 	Err string
+	// ReadSourceUnknown reports that the fetch-side probe failed, so nothing
+	// is known about where reads resolve and no read source is named. Set
+	// only while pushing is disabled, where that probe is consulted at all.
+	ReadSourceUnknown bool
 	// ReadFallback is the remote checkpoint READS fall open to when the
 	// election failed, so Err is set and nothing was elected. Deliberately
 	// not folded into Remote: that field means "the elected remote", and on
 	// this path there is none — reporting a fallback there would misstate
 	// checkpoint_sync_remote to JSON consumers.
 	//
-	// Populated only while pushing is disabled, where status is the sole
-	// surface naming the read source. With pushing enabled the headline is
-	// the broken setting and the user's next move is to fix it, so that
-	// output is left as it was.
+	// TWO preconditions, and its absence means whichever did not hold.
+	// Pushing must be disabled — with pushing enabled the headline is the
+	// broken setting and the user's next move is to fix it, so that output is
+	// left as it was. And no checkpoint_remote may be configured, because
+	// reads would then resolve to the dedicated store rather than to any read
+	// candidate, and this field names a git remote. So empty does NOT mean
+	// "reads fall open to nothing".
 	ReadFallback string
 	// Unpushed approximates checkpoints not yet on the sync destination; 0
 	// when none, when counting failed, or when the count would be a lie
@@ -394,7 +408,10 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 		// them. Asked of the resolver rather than reproducing its fallback
 		// rule here; it re-runs the election, which is why this is on the
 		// error path only, and it stays local-only like the rest of status.
-		if info.PushDisabled {
+		// Skipped when a checkpoint_remote is configured: reads may resolve
+		// to the dedicated store instead of to any read candidate, and this
+		// field names a git remote, so it has nothing true to say there.
+		if info.PushDisabled && s.GetCheckpointRemote() == nil {
 			info.ReadFallback = strategy.LeadCheckpointReadRemote(ctx)
 		}
 		return info
@@ -403,16 +420,46 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 		return info // no remotes configured: only report disabled pushing, if set
 	}
 
-	// Dedicated checkpoint_remote mode is reported only when PushURL derives
-	// an eligible URL for the elected remote, mirroring the pre-push
-	// exemption (ps.hasCheckpointURL); otherwise the gate applies normal
-	// single-remote sync, so status reports that instead. PushURL is
-	// local-only; never call resolvePushSettings here — its follow-up
-	// metadata fetch dials, and status must stay network-free.
+	// Dedicated checkpoint_remote mode is reported only when the direction
+	// this line describes actually resolves to it; otherwise the gate applies
+	// normal single-remote sync, so status reports that instead.
+	//
+	// Which direction that is depends on push_sessions, and the two are
+	// separate questions. With pushing enabled the line names a push
+	// destination, so PushURL decides, mirroring the pre-push exemption
+	// (ps.hasCheckpointURL). With pushing disabled it names a READ source,
+	// which is the fetch side's call over a different ownership identity set
+	// — origin plus the candidate's FETCH url, not its push urls — so a
+	// remote whose two urls have different owners is eligible on one side
+	// only, and asking the wrong side reports a store reads do not use.
+	//
+	// Both probes are local-only; never call resolvePushSettings here — its
+	// follow-up metadata fetch dials, and status must stay network-free.
 	// Accepted divergence: a real push to a different named remote may derive
 	// PushURL differently than this elected-remote probe does.
 	if cr := s.GetCheckpointRemote(); cr != nil {
-		if _, enabled, purlErr := checkpointremote.PushURL(ctx, elected.Name); purlErr == nil && enabled {
+		dedicated := false
+		if info.PushDisabled {
+			authoritative, fetchErr := checkpointremote.ReadsDedicatedStore(ctx, elected.Name)
+			if fetchErr != nil {
+				// Not the same as false. False means reads resolve somewhere
+				// else (so the elected remote is the answer); an error means
+				// no read URL resolves at all — reachable with a configured
+				// checkpoint_remote and no remote named origin. Falling soft
+				// to the elected remote there would report a working read
+				// source for a repo whose checkpoint reads fail. The push
+				// branch below may fall soft because resolvePushSettings
+				// degrades the same way it does; this one may not.
+				logging.Debug(ctx, "checkpoint read source probe failed; status omits the read source",
+					slog.String("error", fetchErr.Error()))
+				info.ReadSourceUnknown = true
+				return info
+			}
+			dedicated = authoritative
+		} else if _, enabled, purlErr := checkpointremote.PushURL(ctx, elected.Name); purlErr == nil {
+			dedicated = enabled
+		}
+		if dedicated {
 			info.Remote = cr.Repo
 			info.Source = checkpointSyncSourceDedicated
 			// The unpushed counter is meaningful here only on the git-refs
@@ -438,10 +485,23 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 	// (origin + push URLs of the elected remote), while a fetch votes with its
 	// read candidate, so a push-only owner mismatch shows "not in use" here
 	// even though a lead-less fetch still resolves the checkpoint remote.
-	if s.GetCheckpointRemote() != nil {
+	if cr := s.GetCheckpointRemote(); cr != nil {
 		if repo, reason, inherited := checkpointremote.InheritedCheckpointRemote(ctx, s, elected.Name); inherited {
 			info.IgnoredRemote = repo
 			info.IgnoredReason = reason
+		} else if info.PushDisabled {
+			// That verdict votes with the push identity set, so it accepts a
+			// store the fetch side declined — and with pushing disabled the
+			// fetch side is the one that decided the line above. Without this
+			// the configured store is reported by nothing at all, which is
+			// the silent-ignore the warning exists to prevent.
+			//
+			// No reason is given: the fetch side returns a verdict and not a
+			// cause, and its false covers ownership, an unparseable origin
+			// URL and an unmappable protocol alike, so naming one would be a
+			// guess. The causes are logged where they are decided.
+			info.IgnoredRemote = cr.Repo
+			info.IgnoredReason = "checkpoint reads do not resolve to it (see .entire/logs for the reason)"
 		}
 	}
 	return info
@@ -500,6 +560,9 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 		} else {
 			b.WriteString(sty.render(sty.yellow, "  ! Checkpoints NOT syncing: "+info.Err))
 		}
+	case info.ReadSourceUnknown:
+		b.WriteString("\n")
+		b.WriteString(sty.render(sty.yellow, "  ! Could not determine where checkpoints are read from"))
 	case info.Remote == "":
 		// No remotes configured: nothing resolved, and the diagnostics and
 		// counter below are empty by construction on this path.
@@ -953,10 +1016,18 @@ type statusJSON struct {
 	CheckpointSyncRemote       string `json:"checkpoint_sync_remote,omitempty"`
 	CheckpointSyncRemoteSource string `json:"checkpoint_sync_remote_source,omitempty"` // config|observed|default|sole|first|dedicated
 	CheckpointSyncError        string `json:"checkpoint_sync_error,omitempty"`         // fail-closed message
+	// CheckpointReadSourceUnknown reports that the read-source probe failed,
+	// so no read source could be determined. Emitted only alongside
+	// checkpoint_push_disabled, and checkpoint_sync_remote is then absent
+	// rather than guessed at.
+	CheckpointReadSourceUnknown bool `json:"checkpoint_read_source_unknown,omitempty"`
 	// CheckpointReadFallback is the remote reads fall open to when the
 	// election failed (checkpoint_sync_error is then set and
 	// checkpoint_sync_remote is absent, because nothing was elected). Emitted
-	// only alongside checkpoint_push_disabled.
+	// only alongside checkpoint_push_disabled AND only when no
+	// checkpoint_remote is configured — with one configured, reads may
+	// resolve to the dedicated store instead, so absence here does not mean
+	// reads fall open to nothing.
 	CheckpointReadFallback string `json:"checkpoint_read_fallback,omitempty"`
 	UnpushedCheckpoints    int    `json:"unpushed_checkpoints,omitempty"`
 	// CheckpointRemoteIgnored/-Reason report a configured checkpoint_remote the
@@ -1053,6 +1124,7 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		result.CheckpointSyncRemoteSource = syncInfo.Source
 		result.CheckpointSyncError = syncInfo.Err
 		result.CheckpointReadFallback = syncInfo.ReadFallback
+		result.CheckpointReadSourceUnknown = syncInfo.ReadSourceUnknown
 		result.UnpushedCheckpoints = syncInfo.Unpushed
 		result.CheckpointRemoteIgnored = syncInfo.IgnoredRemote
 		result.CheckpointRemoteIgnoredReason = syncInfo.IgnoredReason

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -352,8 +352,11 @@ type checkpointSyncInfo struct {
 	// set.
 	PushDisabled bool
 	// Remote is the elected git remote name, or the org/repo slug in
-	// dedicated checkpoint_remote mode. Empty when nothing resolved (no
-	// remotes configured, or the fail-closed case).
+	// dedicated checkpoint_remote mode. Empty when nothing resolved: no
+	// remotes configured, or the fail-closed case — except that with pushing
+	// disabled a failed election can still leave the dedicated slug here,
+	// since reads fail open and the store may serve them with nothing
+	// elected.
 	Remote string
 	// Source is config|observed|default|sole|first (resolver values) or
 	// "dedicated".
@@ -373,10 +376,11 @@ type checkpointSyncInfo struct {
 	// TWO preconditions, and its absence means whichever did not hold.
 	// Pushing must be disabled — with pushing enabled the headline is the
 	// broken setting and the user's next move is to fix it, so that output is
-	// left as it was. And no checkpoint_remote may be configured, because
-	// reads would then resolve to the dedicated store rather than to any read
-	// candidate, and this field names a git remote. So empty does NOT mean
-	// "reads fall open to nothing".
+	// left as it was. And the dedicated store must not be what serves reads:
+	// a configured checkpoint_remote the fetch side confirms is reported
+	// through Remote/Source instead (this field names a git remote), and a
+	// failed probe through ReadSourceUnknown. So empty does NOT mean "reads
+	// fall open to nothing".
 	ReadFallback string
 	// Unpushed approximates checkpoints not yet on the sync destination; 0
 	// when none, when counting failed, or when the count would be a lie
@@ -388,6 +392,46 @@ type checkpointSyncInfo struct {
 	// where a user finds out why — the hooks only log the rejection.
 	IgnoredRemote string
 	IgnoredReason string
+}
+
+// resolveDedicatedReadSource records where checkpoint READS land when the
+// configured checkpoint_remote is what serves them. Used by both paths that
+// name a read source, so the two cannot answer the question differently — the
+// asymmetry between them is what this function exists to remove.
+//
+// lead is the read candidate whose FETCH url joins origin in the ownership
+// vote: the elected remote, or "" when the election failed and reads fall
+// open to origin alone.
+//
+// Reports whether it settled the answer — the dedicated store serves reads
+// (Remote/Source), or the probe failed so nothing is known
+// (ReadSourceUnknown). False means reads resolve to the caller's own
+// candidate, which the caller names.
+func resolveDedicatedReadSource(ctx context.Context, s *EntireSettings, lead string, info *checkpointSyncInfo) bool {
+	cr := s.GetCheckpointRemote()
+	if cr == nil {
+		return false
+	}
+	authoritative, err := checkpointremote.ReadsDedicatedStore(ctx, lead)
+	switch {
+	case err != nil:
+		// Not the same as false. False means reads resolve somewhere else,
+		// so the caller's candidate is the answer; an error means no read URL
+		// resolves at all — reachable with a configured checkpoint_remote and
+		// no remote named origin, since the dedicated derivation is from
+		// origin. Naming a candidate there would report a working read source
+		// for a repo whose checkpoint reads fail.
+		logging.Debug(ctx, "checkpoint read source probe failed; status omits the read source",
+			slog.String("error", err.Error()))
+		info.ReadSourceUnknown = true
+		return true
+	case authoritative:
+		info.Remote = cr.Repo
+		info.Source = checkpointSyncSourceDedicated
+		return true
+	default:
+		return false
+	}
 }
 
 func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
@@ -404,14 +448,13 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 		// elected remote left to probe PushURL against here.
 		info.Err = err.Error()
 		// Reads fail OPEN where the election failed closed (see
-		// strategy.CheckpointReadRemotes), so something may still be serving
-		// them. Asked of the resolver rather than reproducing its fallback
-		// rule here; it re-runs the election, which is why this is on the
-		// error path only, and it stays local-only like the rest of status.
-		// Skipped when a checkpoint_remote is configured: reads may resolve
-		// to the dedicated store instead of to any read candidate, and this
-		// field names a git remote, so it has nothing true to say there.
-		if info.PushDisabled && s.GetCheckpointRemote() == nil {
+		// strategy.CheckpointReadRemotes), so something is probably still
+		// serving them: the dedicated store when one is configured and the
+		// fetch side owns it, otherwise the fail-open candidate. Each is
+		// asked of its own resolver rather than reproduced here. Both re-run
+		// the election, which is why this is on the error path only, and both
+		// stay local-only like the rest of status.
+		if info.PushDisabled && !resolveDedicatedReadSource(ctx, s, "", &info) {
 			info.ReadFallback = strategy.LeadCheckpointReadRemote(ctx)
 		}
 		return info
@@ -440,23 +483,17 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 	if cr := s.GetCheckpointRemote(); cr != nil {
 		dedicated := false
 		if info.PushDisabled {
-			authoritative, fetchErr := checkpointremote.ReadsDedicatedStore(ctx, elected.Name)
-			if fetchErr != nil {
-				// Not the same as false. False means reads resolve somewhere
-				// else (so the elected remote is the answer); an error means
-				// no read URL resolves at all — reachable with a configured
-				// checkpoint_remote and no remote named origin. Falling soft
-				// to the elected remote there would report a working read
-				// source for a repo whose checkpoint reads fail. The push
-				// branch below may fall soft because resolvePushSettings
-				// degrades the same way it does; this one may not.
-				logging.Debug(ctx, "checkpoint read source probe failed; status omits the read source",
-					slog.String("error", fetchErr.Error()))
-				info.ReadSourceUnknown = true
-				return info
+			if resolveDedicatedReadSource(ctx, s, elected.Name, &info) {
+				if info.ReadSourceUnknown {
+					return info
+				}
+				dedicated = true
 			}
-			dedicated = authoritative
 		} else if _, enabled, purlErr := checkpointremote.PushURL(ctx, elected.Name); purlErr == nil {
+			// The push side may fall soft to the elected remote because
+			// resolvePushSettings degrades the same way; the read side may
+			// not, which is why the helper above distinguishes error from
+			// false and this branch does not need to.
 			dedicated = enabled
 		}
 		if dedicated {
@@ -542,34 +579,28 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 		// not claim exclusivity — "read from", never "only".
 		destination = "\n  Checkpoints read from: "
 	}
-	switch {
-	case info.Err != "":
+	// The misconfiguration warning is emitted independently of the read
+	// source below, not as one arm of the same switch: with pushing disabled
+	// a failed election does not stop reads, so the two can both have
+	// something to say and one must not shadow the other.
+	if info.Err != "" {
 		b.WriteString("\n")
 		// A fail-closed election is not a push failure when nothing is being
 		// pushed: name the misconfiguration without claiming a lost sync.
 		if info.PushDisabled {
 			b.WriteString(sty.render(sty.yellow, "  ! Checkpoint remote configuration: "+info.Err))
-			// Same label as the resolved case — to the reader it is one
-			// question, "where do checkpoints come from" — with the suffix
-			// saying this one was not chosen, it was fallen back to.
-			if info.ReadFallback != "" {
-				b.WriteString(destination)
-				b.WriteString(sty.render(sty.cyan, info.ReadFallback))
-				b.WriteString(sty.render(sty.dim, " (fallback; nothing was elected)"))
-			}
 		} else {
 			b.WriteString(sty.render(sty.yellow, "  ! Checkpoints NOT syncing: "+info.Err))
 		}
+	}
+	switch {
 	case info.ReadSourceUnknown:
 		b.WriteString("\n")
 		b.WriteString(sty.render(sty.yellow, "  ! Could not determine where checkpoints are read from"))
-	case info.Remote == "":
-		// No remotes configured: nothing resolved, and the diagnostics and
-		// counter below are empty by construction on this path.
 	case info.Source == checkpointSyncSourceDedicated:
 		b.WriteString(destination)
 		b.WriteString(sty.render(sty.cyan, "dedicated checkpoint remote ("+info.Remote+")"))
-	default:
+	case info.Remote != "":
 		b.WriteString(destination)
 		b.WriteString(sty.render(sty.cyan, info.Remote))
 		// Both suffixes describe how the remote was ELECTED, which is what
@@ -580,6 +611,13 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 		case string(strategy.SyncRemoteSourceObserved):
 			b.WriteString(sty.render(sty.dim, " (follows your branch's push destination)"))
 		}
+	case info.ReadFallback != "":
+		// Same label as a resolved read source — to the reader it is one
+		// question, "where do checkpoints come from" — with the suffix
+		// saying this one was not chosen, it was fallen back to.
+		b.WriteString(destination)
+		b.WriteString(sty.render(sty.cyan, info.ReadFallback))
+		b.WriteString(sty.render(sty.dim, " (fallback; nothing was elected)"))
 	}
 	if info.IgnoredRemote != "" {
 		b.WriteString("\n")
@@ -1022,12 +1060,12 @@ type statusJSON struct {
 	// rather than guessed at.
 	CheckpointReadSourceUnknown bool `json:"checkpoint_read_source_unknown,omitempty"`
 	// CheckpointReadFallback is the remote reads fall open to when the
-	// election failed (checkpoint_sync_error is then set and
-	// checkpoint_sync_remote is absent, because nothing was elected). Emitted
-	// only alongside checkpoint_push_disabled AND only when no
-	// checkpoint_remote is configured — with one configured, reads may
-	// resolve to the dedicated store instead, so absence here does not mean
-	// reads fall open to nothing.
+	// election failed, so checkpoint_sync_error is set. Emitted only
+	// alongside checkpoint_push_disabled, and only when the dedicated store
+	// is not what serves reads — if it is, checkpoint_sync_remote carries it
+	// (with source "dedicated") even though nothing was elected, and a failed
+	// probe sets checkpoint_read_source_unknown instead. Absence here does
+	// not mean reads fall open to nothing.
 	CheckpointReadFallback string `json:"checkpoint_read_fallback,omitempty"`
 	UnpushedCheckpoints    int    `json:"unpushed_checkpoints,omitempty"`
 	// CheckpointRemoteIgnored/-Reason report a configured checkpoint_remote the

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -353,6 +353,17 @@ type checkpointSyncInfo struct {
 	Source string
 	// Err is the fail-closed misconfiguration message from the resolver.
 	Err string
+	// ReadFallback is the remote checkpoint READS fall open to when the
+	// election failed, so Err is set and nothing was elected. Deliberately
+	// not folded into Remote: that field means "the elected remote", and on
+	// this path there is none — reporting a fallback there would misstate
+	// checkpoint_sync_remote to JSON consumers.
+	//
+	// Populated only while pushing is disabled, where status is the sole
+	// surface naming the read source. With pushing enabled the headline is
+	// the broken setting and the user's next move is to fix it, so that
+	// output is left as it was.
+	ReadFallback string
 	// Unpushed approximates checkpoints not yet on the sync destination; 0
 	// when none, when counting failed, or when the count would be a lie
 	// (dedicated URL mode on the git-branch backend).
@@ -378,6 +389,14 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 		// data even while this fail-closed warning is shown, since there is no
 		// elected remote left to probe PushURL against here.
 		info.Err = err.Error()
+		// Reads fail OPEN where the election failed closed (see
+		// strategy.CheckpointReadRemotes), so something may still be serving
+		// them. Asked of the resolver rather than reproducing its fallback
+		// rule here; it re-runs the election, which is why this is on the
+		// error path only, and it stays local-only like the rest of status.
+		if info.PushDisabled {
+			info.ReadFallback = strategy.LeadCheckpointReadRemote(ctx)
+		}
 		return info
 	}
 	if elected.Name == "" {
@@ -470,6 +489,14 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 		// pushed: name the misconfiguration without claiming a lost sync.
 		if info.PushDisabled {
 			b.WriteString(sty.render(sty.yellow, "  ! Checkpoint remote configuration: "+info.Err))
+			// Same label as the resolved case — to the reader it is one
+			// question, "where do checkpoints come from" — with the suffix
+			// saying this one was not chosen, it was fallen back to.
+			if info.ReadFallback != "" {
+				b.WriteString(destination)
+				b.WriteString(sty.render(sty.cyan, info.ReadFallback))
+				b.WriteString(sty.render(sty.dim, " (fallback; nothing was elected)"))
+			}
 		} else {
 			b.WriteString(sty.render(sty.yellow, "  ! Checkpoints NOT syncing: "+info.Err))
 		}
@@ -926,7 +953,12 @@ type statusJSON struct {
 	CheckpointSyncRemote       string `json:"checkpoint_sync_remote,omitempty"`
 	CheckpointSyncRemoteSource string `json:"checkpoint_sync_remote_source,omitempty"` // config|observed|default|sole|first|dedicated
 	CheckpointSyncError        string `json:"checkpoint_sync_error,omitempty"`         // fail-closed message
-	UnpushedCheckpoints        int    `json:"unpushed_checkpoints,omitempty"`
+	// CheckpointReadFallback is the remote reads fall open to when the
+	// election failed (checkpoint_sync_error is then set and
+	// checkpoint_sync_remote is absent, because nothing was elected). Emitted
+	// only alongside checkpoint_push_disabled.
+	CheckpointReadFallback string `json:"checkpoint_read_fallback,omitempty"`
+	UnpushedCheckpoints    int    `json:"unpushed_checkpoints,omitempty"`
 	// CheckpointRemoteIgnored/-Reason report a configured checkpoint_remote the
 	// ownership check rejected as inherited with the clone (reads and pushes
 	// fall back to the elected remote). Mirrors the text path's warning line.
@@ -1020,6 +1052,7 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		result.CheckpointSyncRemote = syncInfo.Remote
 		result.CheckpointSyncRemoteSource = syncInfo.Source
 		result.CheckpointSyncError = syncInfo.Err
+		result.CheckpointReadFallback = syncInfo.ReadFallback
 		result.UnpushedCheckpoints = syncInfo.Unpushed
 		result.CheckpointRemoteIgnored = syncInfo.IgnoredRemote
 		result.CheckpointRemoteIgnoredReason = syncInfo.IgnoredReason

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -338,11 +338,11 @@ type checkpointSyncInfo struct {
 	// It suppresses nothing else in this struct, because nothing else is a
 	// push promise. The elected remote stays the checkpoint READ source
 	// (strategy.CheckpointReadRemotesWithElection never consults
-	// push_sessions), the unpushed count is the only signal that local-only
-	// checkpoint data is accumulating, and the remote-configuration
-	// diagnostics explain read behavior too. Disabling uploads therefore
-	// changes how the renderers PHRASE these fields, not whether they are
-	// populated — see writeCheckpointSyncLines.
+	// push_sessions), the unpushed count is the only signal that checkpoint
+	// data is not reaching the elected destination, and the
+	// remote-configuration diagnostics explain read behavior too. Disabling
+	// uploads therefore changes how the renderers PHRASE these fields, not
+	// whether they are populated — see writeCheckpointSyncLines.
 	PushDisabled bool
 	// Remote is the elected git remote name, or the org/repo slug in
 	// dedicated checkpoint_remote mode. Empty when nothing resolved (no
@@ -455,6 +455,12 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 	if info.PushDisabled {
 		b.WriteString("\n  Automatic checkpoint pushing: disabled")
 		b.WriteString(sty.render(sty.dim, " (push_sessions=false)"))
+		// Names the remote reads resolve to FIRST, not the whole chain:
+		// CheckpointReadRemotes also appends origin as a legacy tier when it
+		// is configured and is not already the elected remote. Rendering the
+		// chain would mean either restating its rule here (which then drifts
+		// from the resolver) or a second election call, and the label does
+		// not claim exclusivity — "read from", never "only".
 		destination = "\n  Checkpoints read from: "
 	}
 	switch {
@@ -501,9 +507,16 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 // mode has no git remote to name (and only reaches here on the git-refs
 // backend), so it drops the remote-name phrasing.
 //
-// With pushing disabled the count is not pending anything, so it says what the
-// number actually is — local-only checkpoint data, which keeps growing because
-// push_sessions gates pushing and not checkpoint creation.
+// With pushing disabled the count is not pending anything, so the future tense
+// goes — but the phrasing must not overclaim in the other direction either.
+// Unpushed is measured against the ELECTED destination only (a tracking-ref
+// comparison on git-branch, the push queue on git-refs), which says nothing
+// about whether these checkpoints reached some other remote earlier; the read
+// chain's legacy origin tier is exactly that case, and stale tracking state
+// over-reports too. So it says what the number supports — not on that one
+// destination — and never that the data exists nowhere else. Getting this
+// backwards would falsely reassure someone asking whether checkpoint data has
+// left the machine.
 func formatUnpushedCheckpointsLine(info checkpointSyncInfo) string {
 	noun := "checkpoints"
 	pronoun := "they sync"
@@ -512,7 +525,10 @@ func formatUnpushedCheckpointsLine(info checkpointSyncInfo) string {
 		pronoun = "it syncs"
 	}
 	if info.PushDisabled {
-		return fmt.Sprintf("%d %s stored locally only", info.Unpushed, noun)
+		if info.Source == checkpointSyncSourceDedicated {
+			return fmt.Sprintf("%d %s not pushed to the checkpoint remote", info.Unpushed, noun)
+		}
+		return fmt.Sprintf("%d %s not on %s", info.Unpushed, noun, info.Remote)
 	}
 	if info.Source == checkpointSyncSourceDedicated {
 		return fmt.Sprintf("%d %s not yet pushed", info.Unpushed, noun)
@@ -898,9 +914,11 @@ type statusJSON struct {
 	//
 	// No other field is omitted or suppressed when it is set: read it as
 	// requalifying the fields below rather than removing them.
-	// CheckpointSyncRemote is then the remote checkpoints are READ from,
-	// UnpushedCheckpoints counts checkpoint data held only locally, and the
-	// error and ignored-remote diagnostics apply to reads as well.
+	// CheckpointSyncRemote is then the remote checkpoints are READ from, and
+	// the error and ignored-remote diagnostics apply to reads as well.
+	// UnpushedCheckpoints keeps its own meaning either way: checkpoints not
+	// present on THAT destination, which is not a claim that they exist
+	// nowhere else.
 	CheckpointPushDisabled bool `json:"checkpoint_push_disabled,omitempty"`
 	// CheckpointSyncRemote is the elected checkpoint sync remote name, or the
 	// org/repo slug in dedicated checkpoint_remote mode. Deliberately not named

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -332,9 +332,12 @@ const checkpointSyncSourceDedicated = "dedicated"
 // drift. Everything here reads local state only (settings, .git/config, local
 // refs, the push queue) — status must stay network-free.
 type checkpointSyncInfo struct {
+	// PushDisabled reflects the explicit automatic-push setting, not every
+	// possible reason checkpoint sync might fail.
+	PushDisabled bool
 	// Remote is the elected git remote name, or the org/repo slug in
-	// dedicated checkpoint_remote mode. Empty when nothing resolved (no
-	// remotes configured, or the fail-closed case).
+	// dedicated checkpoint_remote mode. Empty when pushing is disabled or
+	// nothing resolved (no remotes configured, or the fail-closed case).
 	Remote string
 	// Source is config|observed|default|sole|first (resolver values) or
 	// "dedicated".
@@ -354,6 +357,10 @@ type checkpointSyncInfo struct {
 }
 
 func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
+	if s.IsPushSessionsDisabled() {
+		return checkpointSyncInfo{PushDisabled: true}
+	}
+
 	elected, err := strategy.ResolveCheckpointSyncRemote(ctx)
 	if err != nil {
 		// Fail-closed: checkpoint_push_remote names a remote that does not
@@ -426,13 +433,15 @@ func countUnpushedCheckpointsForStatus(ctx context.Context, remoteName string) i
 	return n
 }
 
-// writeCheckpointSyncLines appends the checkpoint sync destination line (and
-// the unpushed counter, when non-zero) to the enabled status block. Rendered
-// whenever something resolved: an elected remote, a dedicated store, or the
-// fail-closed misconfiguration. No remotes configured -> no lines.
+// writeCheckpointSyncLines reports disabled automatic pushing or the checkpoint
+// sync destination (and the unpushed counter, when non-zero) in the enabled status
+// block. With pushing enabled, no remotes configured means no lines.
 func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *EntireSettings, sty statusStyles) {
 	info := computeCheckpointSyncInfo(ctx, s)
 	switch {
+	case info.PushDisabled:
+		b.WriteString("\n  Automatic checkpoint pushing: disabled (push_sessions=false)")
+		return
 	case info.Err != "":
 		b.WriteString("\n")
 		b.WriteString(sty.render(sty.yellow, "  ! Checkpoints NOT syncing: "+info.Err))
@@ -851,6 +860,11 @@ type statusJSON struct {
 	// CodexHooks reports effective discovery/trust warnings separately from
 	// current-checkout installation and freshness semantics.
 	CodexHooks *codexHooksStatusJSON `json:"codex_hooks,omitempty"`
+	// CheckpointPushDisabled is emitted only when Entire is enabled and the
+	// effective push_sessions setting is false. Its absence does not guarantee
+	// that a push can succeed. Sync destination, error, and count fields are
+	// omitted while pushing is disabled.
+	CheckpointPushDisabled bool `json:"checkpoint_push_disabled,omitempty"`
 	// CheckpointSyncRemote is the elected checkpoint sync remote name, or the
 	// org/repo slug in dedicated checkpoint_remote mode. Deliberately not named
 	// checkpoint_remote, which is the existing GitHub-coupled setting.
@@ -947,6 +961,7 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		// Same computation as the text path (writeCheckpointSyncLines);
 		// empty fields drop out via omitempty when nothing resolved.
 		syncInfo := computeCheckpointSyncInfo(ctx, s)
+		result.CheckpointPushDisabled = syncInfo.PushDisabled
 		result.CheckpointSyncRemote = syncInfo.Remote
 		result.CheckpointSyncRemoteSource = syncInfo.Source
 		result.CheckpointSyncError = syncInfo.Err

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/entireio/cli/redact"
 
 	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
@@ -2287,6 +2288,208 @@ func TestRunStatus_PrintsBothReviewAndInvestigation(t *testing.T) {
 }
 
 // --- Checkpoint sync visibility (single-remote gate observability) ---
+
+func TestRunStatus_CheckpointPushDisabled(t *testing.T) {
+	testCheckpointPushDisabledFork(t, false)
+}
+
+func TestRunStatusJSON_CheckpointPushDisabled(t *testing.T) {
+	testCheckpointPushDisabledFork(t, true)
+}
+
+func testCheckpointPushDisabledFork(t *testing.T, jsonOutput bool) {
+	t.Helper()
+	// setupTestRepo changes CWD and git-config isolation changes process env.
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	writeSettings(t, `{"enabled":true,"strategy_options":{"push_sessions":false,"checkpoint_push_remote":"fork"}}`)
+	testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
+	testutil.AddRemote(t, ".", "fork", "https://github.com/user/repo.git")
+	head := checkpointSyncTestCommit(t, "a.txt", "one")
+	testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
+	assertCheckpointPushDisabledStatus(t, jsonOutput, false)
+}
+
+func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool) {
+	t.Helper()
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, detailed, jsonOutput); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+	t.Logf("status output:\n%s", stdout.String())
+	if jsonOutput {
+		var result map[string]json.RawMessage
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		for _, key := range []string{"enabled", "checkpoint_push_disabled"} {
+			raw, exists := result[key]
+			if !exists {
+				t.Errorf("missing %s", key)
+				continue
+			}
+			var value bool
+			if err := json.Unmarshal(raw, &value); err != nil || !value {
+				t.Errorf("%s = %s, want true (decode error: %v)", key, raw, err)
+			}
+		}
+		for _, key := range []string{"checkpoint_sync_remote", "checkpoint_sync_remote_source", "checkpoint_sync_error", "unpushed_checkpoints", "checkpoint_remote_ignored", "checkpoint_remote_ignored_reason"} {
+			if value, exists := result[key]; exists {
+				t.Errorf("disabled pushing must omit %s, got %s", key, value)
+			}
+		}
+		return
+	}
+	if !strings.Contains(stdout.String(), "Automatic checkpoint pushing: disabled (push_sessions=false)") {
+		t.Error("missing automatic checkpoint pushing disabled message")
+	}
+	for _, unwanted := range []string{"Checkpoints sync to:", "Checkpoints NOT syncing:", "not yet", "next 'git push", "is not in use:"} {
+		if strings.Contains(stdout.String(), unwanted) {
+			t.Errorf("disabled pushing must not show %q", unwanted)
+		}
+	}
+}
+
+func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
+	// These subtests mutate CWD and environment and cannot run in parallel.
+	for _, backend := range []string{"git-branch", "git-refs"} {
+		for _, tc := range []struct {
+			name    string
+			options string
+			origin  string
+		}{
+			{"origin", "", "https://github.com/org/repo.git"},
+			{"explicit_fork", `,"checkpoint_push_remote":"fork"`, "https://github.com/org/repo.git"},
+			{"dedicated", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/org/repo.git"},
+			{"inherited_dedicated_rejected", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/other/repo.git"},
+			{"no_remotes", "", ""},
+			{"missing_configured_remote", `,"checkpoint_push_remote":"gone"`, "https://github.com/org/repo.git"},
+		} {
+			t.Run(backend+"/"+tc.name, func(t *testing.T) {
+				testutil.IsolateGitConfigEnv(t)
+				setupTestRepo(t)
+				writeSettings(t, `{"enabled":true,"strategy_options":{"push_sessions":false`+tc.options+`},"checkpoints":{"primary":{"type":"`+backend+`"}}}`)
+				if tc.origin != "" {
+					testutil.AddRemote(t, ".", "origin", tc.origin)
+				}
+				if tc.name == "explicit_fork" {
+					testutil.AddRemote(t, ".", "fork", "https://github.com/user/repo.git")
+				}
+				head := checkpointSyncTestCommit(t, "a.txt", "one")
+				testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
+				cwd, err := os.Getwd()
+				if err != nil {
+					t.Fatal(err)
+				}
+				queue := checkpoint.NewPushQueue(filepath.Join(cwd, ".git"))
+				if backend == "git-refs" {
+					for _, ref := range []string{"refs/entire/checkpoints/aa/bb0000000001", "refs/entire/checkpoints/aa/bb0000000002"} {
+						if err := queue.Enqueue(plumbing.ReferenceName(ref)); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+				before, err := queue.Peek()
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, jsonOutput := range []bool{false, true} {
+					assertCheckpointPushDisabledStatus(t, jsonOutput, false)
+					after, err := queue.Peek()
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !slices.Equal(before, after) {
+						t.Errorf("status changed pending queue: before=%v after=%v", before, after)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestRunStatus_CheckpointPushDisabledSettingsPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		shared   string
+		local    string
+		disabled bool
+	}{
+		{"local_false_overrides_shared_true", `{"enabled":true,"strategy_options":{"push_sessions":true}}`, `{"strategy_options":{"push_sessions":false}}`, true},
+		{"local_true_overrides_shared_false", `{"enabled":true,"strategy_options":{"push_sessions":false}}`, `{"strategy_options":{"push_sessions":true}}`, false},
+		{"absent", `{"enabled":true}`, "", false},
+		{"explicit_true", `{"enabled":true,"strategy_options":{"push_sessions":true}}`, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.IsolateGitConfigEnv(t)
+			setupTestRepo(t)
+			writeSettings(t, tc.shared)
+			if tc.local != "" {
+				testutil.WriteFile(t, ".", ".entire/settings.local.json", tc.local)
+			}
+			testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
+			head := checkpointSyncTestCommit(t, "a.txt", "one")
+			testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
+			for _, jsonOutput := range []bool{false, true} {
+				if tc.disabled {
+					assertCheckpointPushDisabledStatus(t, jsonOutput, true)
+					continue
+				}
+				var stdout bytes.Buffer
+				if err := runStatus(context.Background(), &stdout, false, jsonOutput); err != nil {
+					t.Fatal(err)
+				}
+				if jsonOutput {
+					var result map[string]json.RawMessage
+					if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+						t.Fatal(err)
+					}
+					if _, exists := result["checkpoint_push_disabled"]; exists {
+						t.Errorf("enabled pushing must omit checkpoint_push_disabled: %s", stdout.String())
+					}
+					if string(result["checkpoint_sync_remote"]) != `"origin"` || string(result["checkpoint_sync_remote_source"]) != `"default"` || string(result["unpushed_checkpoints"]) != "1" {
+						t.Errorf("enabled pushing lost existing destination/counter fields: %s", stdout.String())
+					}
+				} else if strings.Contains(stdout.String(), "Automatic checkpoint pushing:") || !strings.Contains(stdout.String(), "Checkpoints sync to: origin") || !strings.Contains(stdout.String(), "next 'git push origin'") {
+					t.Errorf("enabled pushing changed existing output: %s", stdout.String())
+				}
+			}
+		})
+	}
+}
+
+func TestRunStatus_CheckpointPushDisabledAbsentWithoutEnabledEntire(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		settings string
+	}{
+		{"entire_disabled", `{"enabled":false,"strategy_options":{"push_sessions":false}}`},
+		{"not_set_up", ""},
+		{"invalid_settings", `{"enabled":true,"strategy_options":{"push_sessions":false},`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.IsolateGitConfigEnv(t)
+			setupTestRepo(t)
+			if tc.settings != "" {
+				writeSettings(t, tc.settings)
+			}
+			for _, jsonOutput := range []bool{false, true} {
+				var stdout bytes.Buffer
+				err := runStatus(context.Background(), &stdout, false, jsonOutput)
+				if tc.name == "invalid_settings" && !jsonOutput {
+					if err == nil || !strings.Contains(err.Error(), "failed to load settings") {
+						t.Fatalf("invalid text settings error = %v", err)
+					}
+				} else if err != nil {
+					t.Fatal(err)
+				}
+				if strings.Contains(stdout.String(), "checkpoint_push_disabled") || strings.Contains(stdout.String(), "Automatic checkpoint pushing:") {
+					t.Errorf("inactive Entire must omit disabled-pushing status: %s", stdout.String())
+				}
+			}
+		})
+	}
+}
 
 // checkpointSyncTestCommit creates a commit in the cwd test repo and returns
 // its hash. setupTestRepo leaves the repo without commits, and both the v1

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2333,7 +2334,7 @@ func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool)
 				t.Errorf("%s = %s, want true (decode error: %v)", key, raw, err)
 			}
 		}
-		for _, key := range []string{"checkpoint_sync_remote", "checkpoint_sync_remote_source", "checkpoint_sync_error", "unpushed_checkpoints", "checkpoint_remote_ignored", "checkpoint_remote_ignored_reason"} {
+		for _, key := range []string{"checkpoint_sync_remote", "checkpoint_sync_remote_source", "unpushed_checkpoints"} {
 			if value, exists := result[key]; exists {
 				t.Errorf("disabled pushing must omit %s, got %s", key, value)
 			}
@@ -2343,7 +2344,7 @@ func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool)
 	if !strings.Contains(stdout.String(), "Automatic checkpoint pushing: disabled (push_sessions=false)") {
 		t.Error("missing automatic checkpoint pushing disabled message")
 	}
-	for _, unwanted := range []string{"Checkpoints sync to:", "Checkpoints NOT syncing:", "not yet", "next 'git push", "is not in use:"} {
+	for _, unwanted := range []string{"Checkpoints sync to:", "Checkpoints NOT syncing:", "not yet", "next 'git push"} {
 		if strings.Contains(stdout.String(), unwanted) {
 			t.Errorf("disabled pushing must not show %q", unwanted)
 		}
@@ -2393,6 +2394,17 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				s, err := LoadEntireSettings(t.Context())
+				if err != nil {
+					t.Fatal(err)
+				}
+				info := computeCheckpointSyncInfo(t.Context(), s)
+				if (info.Err != "") != (tc.name == "missing_configured_remote") || (info.IgnoredRemote != "") != (tc.name == "inherited_dedicated_rejected") {
+					t.Errorf("unexpected remote diagnostics: %+v", info)
+				}
+				if !info.PushDisabled || info.Remote != "" || info.Source != "" || info.Unpushed != 0 {
+					t.Errorf("disabled pushing must preserve diagnostics without push destination/count: %+v", info)
+				}
 				for _, jsonOutput := range []bool{false, true} {
 					assertCheckpointPushDisabledStatus(t, jsonOutput, false)
 					after, err := queue.Peek()
@@ -2402,6 +2414,67 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 					if !slices.Equal(before, after) {
 						t.Errorf("status changed pending queue: before=%v after=%v", before, after)
 					}
+				}
+			})
+		}
+	}
+}
+
+// Not parallel: setupTestRepo changes CWD and isolates process environment.
+func TestRunStatus_CheckpointDiagnosticsWithPushDisabled(t *testing.T) {
+	for _, disabled := range []bool{false, true} {
+		for _, tc := range []struct {
+			name, options, key, text string
+		}{
+			{"inherited", `"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "checkpoint_remote_ignored", "org/checkpoints"},
+			{"missing", `"checkpoint_push_remote":"gone"`, "checkpoint_sync_error", `checkpoint_push_remote "gone"`},
+		} {
+			label := "pushing_enabled/" + tc.name
+			pushSetting := strconv.FormatBool(!disabled)
+			if disabled {
+				label = "pushing_disabled/" + tc.name
+			}
+			t.Run(label, func(t *testing.T) {
+				testutil.IsolateGitConfigEnv(t)
+				setupTestRepo(t)
+				writeSettings(t, `{"enabled":true,"strategy_options":{"push_sessions":`+pushSetting+`,`+tc.options+`}}`)
+				testutil.AddRemote(t, ".", "origin", "https://github.com/other/repo.git")
+				for _, mode := range []struct {
+					name           string
+					detailed, json bool
+				}{{"text", false, false}, {"detailed", true, false}, {"json", false, true}} {
+					t.Run(mode.name, func(t *testing.T) {
+						var out bytes.Buffer
+						if err := runStatus(t.Context(), &out, mode.detailed, mode.json); err != nil {
+							t.Fatal(err)
+						}
+						if mode.json {
+							var result map[string]json.RawMessage
+							if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+								t.Fatal(err)
+							}
+							var diagnostic string
+							if err := json.Unmarshal(result[tc.key], &diagnostic); err != nil || !strings.Contains(diagnostic, tc.text) {
+								t.Errorf("missing %s diagnostic: %s", tc.key, out.String())
+							}
+							if tc.name == "inherited" && !strings.Contains(string(result["checkpoint_remote_ignored_reason"]), "differs from checkpoint owner") {
+								t.Errorf("missing rejection reason: %s", out.String())
+							}
+							if disabled {
+								var pushDisabled bool
+								if err := json.Unmarshal(result["checkpoint_push_disabled"], &pushDisabled); err != nil || !pushDisabled {
+									t.Errorf("missing disabled flag: %s", out.String())
+								}
+							}
+							return
+						}
+						if !strings.Contains(out.String(), tc.text) || (tc.name == "inherited" && !strings.Contains(out.String(), "is not in use:")) {
+							t.Errorf("missing remote diagnostic: %s", out.String())
+						}
+						if disabled && (!strings.Contains(out.String(), "Automatic checkpoint pushing: disabled") || strings.Contains(out.String(), "Checkpoints NOT syncing:")) {
+							t.Errorf("diagnostic must coexist with disabled pushing, not claim a push failure: %s", out.String())
+						}
+					})
 				}
 			})
 		}
@@ -2432,7 +2505,9 @@ func TestRunStatus_CheckpointPushDisabledSettingsPrecedence(t *testing.T) {
 			testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
 			for _, jsonOutput := range []bool{false, true} {
 				if tc.disabled {
-					assertCheckpointPushDisabledStatus(t, jsonOutput, true)
+					// --detailed and --json are mutually exclusive: only text
+					// exercises the detailed settings view.
+					assertCheckpointPushDisabledStatus(t, jsonOutput, !jsonOutput)
 					continue
 				}
 				var stdout bytes.Buffer

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -2370,7 +2370,7 @@ func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool,
 }
 
 // Not parallel: setupTestRepo changes CWD and isolates process environment.
-func TestRunStatus_CheckpointPushDisabledNamesReadSourceAndLocalCount(t *testing.T) {
+func TestRunStatus_CheckpointPushDisabledNamesReadSourceAndCount(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, `{"enabled":true,"strategy_options":{"push_sessions":false}}`)
@@ -2380,17 +2380,25 @@ func TestRunStatus_CheckpointPushDisabledNamesReadSourceAndLocalCount(t *testing
 
 	// With pushing off, status is the only surface naming where checkpoint
 	// reads resolve (CheckpointReadRemotesWithElection never consults
-	// push_sessions) and the only one reporting that checkpoint data is
-	// piling up locally — push_sessions gates pushing, not checkpoint
+	// push_sessions) and the only one reporting that checkpoint data is not
+	// reaching the destination — push_sessions gates pushing, not checkpoint
 	// creation. Both must be phrased without promising a push.
 	var text bytes.Buffer
 	if err := runStatus(t.Context(), &text, false, false); err != nil {
 		t.Fatal(err)
 	}
 	t.Logf("status output:\n%s", text.String())
-	for _, want := range []string{"Checkpoints read from: origin", "1 checkpoint stored locally only"} {
+	for _, want := range []string{"Checkpoints read from: origin", "1 checkpoint not on origin"} {
 		if !strings.Contains(text.String(), want) {
 			t.Errorf("missing %q: %s", want, text.String())
+		}
+	}
+	// The count compares against the elected destination only, so it must not
+	// be phrased as proof the data exists nowhere else — a false reassurance
+	// about checkpoint data having left the machine.
+	for _, unwanted := range []string{"stored locally only", "local only", "only locally"} {
+		if strings.Contains(text.String(), unwanted) {
+			t.Errorf("count must not claim local-only storage (%q): %s", unwanted, text.String())
 		}
 	}
 
@@ -2403,7 +2411,7 @@ func TestRunStatus_CheckpointPushDisabledNamesReadSourceAndLocalCount(t *testing
 		t.Fatal(err)
 	}
 	if string(result["checkpoint_sync_remote"]) != `"origin"` || string(result["unpushed_checkpoints"]) != "1" {
-		t.Errorf("disabled pushing dropped read destination or local-only count: %s", jsonOut.String())
+		t.Errorf("disabled pushing dropped read destination or unpushed count: %s", jsonOut.String())
 	}
 }
 
@@ -2467,8 +2475,8 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 				if !info.PushDisabled || info.Remote != tc.wantRemote || info.Source != tc.wantSource {
 					t.Errorf("disabled pushing must still resolve the read destination %q/%q: %+v", tc.wantRemote, tc.wantSource, info)
 				}
-				// The counter is the only signal that local-only checkpoint
-				// data is accumulating, so it survives disabled pushing
+				// The counter is the only signal that checkpoint data is not
+				// reaching the destination, so it survives disabled pushing
 				// wherever it is meaningful at all. Dedicated URL mode on
 				// git-branch has no tracking ref to compare against and stays
 				// uncounted, as it does with pushing enabled.

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -2290,6 +2290,11 @@ func TestRunStatus_PrintsBothReviewAndInvestigation(t *testing.T) {
 
 // --- Checkpoint sync visibility (single-remote gate observability) ---
 
+// originRemoteName is the primary remote these fixtures create. Named rather
+// than repeated: it is also the remote the checkpoint election defaults to and
+// the read chain's legacy tier, so the string carries meaning here.
+const originRemoteName = "origin"
+
 func TestRunStatus_CheckpointPushDisabled(t *testing.T) {
 	testCheckpointPushDisabledFork(t, false)
 }
@@ -2304,7 +2309,7 @@ func testCheckpointPushDisabledFork(t *testing.T, jsonOutput bool) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, `{"enabled":true,"strategy_options":{"push_sessions":false,"checkpoint_push_remote":"fork"}}`)
-	testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
+	testutil.AddRemote(t, ".", originRemoteName, "https://github.com/org/repo.git")
 	testutil.AddRemote(t, ".", "fork", "https://github.com/user/repo.git")
 	head := checkpointSyncTestCommit(t, "a.txt", "one")
 	testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
@@ -2422,23 +2427,83 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 			// wantFallback is the remote reads fall OPEN to when the election
 			// failed closed, reported instead of (never alongside) wantRemote.
 			wantFallback string
+			// fork is the fetch URL of a second remote named "fork" ("" = none);
+			// forkPush overrides its push URL, so the two can have different
+			// owners and the push- and fetch-side ownership votes disagree.
+			fork     string
+			forkPush string
+			// originName renames the primary remote ("" = "origin"). A
+			// configured checkpoint_remote with no origin makes the read
+			// probe fail outright, which is not the same as it resolving
+			// elsewhere.
+			originName string
+			// wantReadUnknown pins that the probe failure is what suppressed
+			// the read source, rather than the row passing because nothing
+			// resolved for some other reason.
+			wantReadUnknown bool
 		}{
-			{"origin", "", "https://github.com/org/repo.git", "origin", "default", ""},
-			{"explicit_fork", `,"checkpoint_push_remote":"fork"`, "https://github.com/org/repo.git", "fork", "config", ""},
-			{"dedicated", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/org/repo.git", "org/checkpoints", checkpointSyncSourceDedicated, ""},
-			{"inherited_dedicated_rejected", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/other/repo.git", "origin", "default", ""},
-			{"no_remotes", "", "", "", "", ""},
-			{"missing_configured_remote", `,"checkpoint_push_remote":"gone"`, "https://github.com/org/repo.git", "", "", "origin"},
+			{name: "origin", origin: "https://github.com/org/repo.git", wantRemote: "origin", wantSource: "default"},
+			{
+				name: "explicit_fork", options: `,"checkpoint_push_remote":"fork"`,
+				origin: "https://github.com/org/repo.git", fork: "https://github.com/user/repo.git",
+				wantRemote: "fork", wantSource: "config",
+			},
+			{
+				name: "dedicated", options: `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`,
+				origin:     "https://github.com/org/repo.git",
+				wantRemote: "org/checkpoints", wantSource: checkpointSyncSourceDedicated,
+			},
+			{
+				name: "inherited_dedicated_rejected", options: `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`,
+				origin:     "https://github.com/other/repo.git",
+				wantRemote: "origin", wantSource: "default",
+			},
+			{name: "no_remotes"},
+			{
+				name: "missing_configured_remote", options: `,"checkpoint_push_remote":"gone"`,
+				origin: "https://github.com/org/repo.git", wantFallback: "origin",
+			},
+			// Push- and fetch-side ownership disagree. Both require EVERY
+			// identity to be owned by the checkpoint repo's owner, but over
+			// different sets: origin plus fork's PUSH urls (all "org", so the
+			// push side certifies the dedicated store) versus origin plus
+			// fork's FETCH url ("other", so the fetch side rejects it). With
+			// pushing disabled the line names a read source, so the fetch
+			// side decides and the elected remote is reported; deciding it
+			// with PushURL named a store reads never use.
+			{
+				name:    "dedicated_rejected_by_fetch_owner",
+				options: `,"checkpoint_push_remote":"fork","checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`,
+				origin:  "https://github.com/org/repo.git",
+				fork:    "https://github.com/other/fork.git", forkPush: "https://github.com/org/fork.git",
+				wantRemote: "fork", wantSource: "config",
+			},
+			// The read probe cannot resolve any URL (a configured
+			// checkpoint_remote derives from origin, and there is none), so
+			// no read source is named rather than the sole remote being
+			// reported as one while reads fail.
+			{
+				name: "dedicated_without_origin", options: `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`,
+				origin: "https://github.com/org/repo.git", originName: "upstream",
+				wantReadUnknown: true,
+			},
 		} {
 			t.Run(backend+"/"+tc.name, func(t *testing.T) {
 				testutil.IsolateGitConfigEnv(t)
 				setupTestRepo(t)
 				writeSettings(t, `{"enabled":true,"strategy_options":{"push_sessions":false`+tc.options+`},"checkpoints":{"primary":{"type":"`+backend+`"}}}`)
 				if tc.origin != "" {
-					testutil.AddRemote(t, ".", "origin", tc.origin)
+					name := tc.originName
+					if name == "" {
+						name = originRemoteName
+					}
+					testutil.AddRemote(t, ".", name, tc.origin)
 				}
-				if tc.name == "explicit_fork" {
-					testutil.AddRemote(t, ".", "fork", "https://github.com/user/repo.git")
+				if tc.fork != "" {
+					testutil.AddRemote(t, ".", "fork", tc.fork)
+					if tc.forkPush != "" {
+						testutil.RunGit(t, ".", "remote", "set-url", "--push", "fork", tc.forkPush)
+					}
 				}
 				head := checkpointSyncTestCommit(t, "a.txt", "one")
 				testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
@@ -2463,7 +2528,17 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 					t.Fatal(err)
 				}
 				info := computeCheckpointSyncInfo(t.Context(), s)
-				if (info.Err != "") != (tc.name == "missing_configured_remote") || (info.IgnoredRemote != "") != (tc.name == "inherited_dedicated_rejected") {
+				// Both rejections report "not in use", by different routes:
+				// the origin-owner row through the push-side verdict, the
+				// fetch-rejected row through the read-side branch that exists
+				// because that verdict ACCEPTS it. Without the second, a
+				// configured store that serves no reads is reported by
+				// nothing. (Not the divergence documented as accepted on
+				// InheritedCheckpointRemote — that one is the opposite
+				// direction, a warning where a lead-less fetch still resolves
+				// the store.)
+				wantIgnored := tc.name == "inherited_dedicated_rejected" || tc.name == "dedicated_rejected_by_fetch_owner"
+				if (info.Err != "") != (tc.name == "missing_configured_remote") || (info.IgnoredRemote != "") != wantIgnored {
 					t.Errorf("unexpected remote diagnostics: %+v", info)
 				}
 				if !info.PushDisabled || info.Remote != tc.wantRemote || info.Source != tc.wantSource {
@@ -2474,6 +2549,9 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 				// means "elected" and has nothing to name here.
 				if info.ReadFallback != tc.wantFallback {
 					t.Errorf("read fallback = %q, want %q: %+v", info.ReadFallback, tc.wantFallback, info)
+				}
+				if info.ReadSourceUnknown != tc.wantReadUnknown {
+					t.Errorf("read source unknown = %v, want %v: %+v", info.ReadSourceUnknown, tc.wantReadUnknown, info)
 				}
 				// The counter is the only signal that checkpoint data is not
 				// reaching the destination, so it survives disabled pushing
@@ -2518,7 +2596,7 @@ func TestRunStatus_CheckpointDiagnosticsWithPushDisabled(t *testing.T) {
 				testutil.IsolateGitConfigEnv(t)
 				setupTestRepo(t)
 				writeSettings(t, `{"enabled":true,"strategy_options":{"push_sessions":`+pushSetting+`,`+tc.options+`}}`)
-				testutil.AddRemote(t, ".", "origin", "https://github.com/other/repo.git")
+				testutil.AddRemote(t, ".", originRemoteName, "https://github.com/other/repo.git")
 				for _, mode := range []struct {
 					name           string
 					detailed, json bool
@@ -2580,7 +2658,7 @@ func TestRunStatus_CheckpointPushDisabledSettingsPrecedence(t *testing.T) {
 			if tc.local != "" {
 				testutil.WriteFile(t, ".", ".entire/settings.local.json", tc.local)
 			}
-			testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
+			testutil.AddRemote(t, ".", originRemoteName, "https://github.com/org/repo.git")
 			head := checkpointSyncTestCommit(t, "a.txt", "one")
 			testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
 			for _, jsonOutput := range []bool{false, true} {
@@ -2827,7 +2905,7 @@ func TestRunStatus_CheckpointSyncDedicated_GitBranch_NoCounter(t *testing.T) {
 	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`)
 	// Same owner ("org") as checkpoint_remote and a parseable GitHub URL, so
 	// PushURL derivation succeeds locally and dedicated mode is verified.
-	testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
+	testutil.AddRemote(t, ".", originRemoteName, "https://github.com/org/repo.git")
 	head := checkpointSyncTestCommit(t, "a.txt", "one")
 	// A local v1 branch exists, but in dedicated URL mode on the git-branch
 	// backend the tracking-ref comparison would permanently read "all
@@ -2852,7 +2930,7 @@ func TestRunStatus_CheckpointSyncDedicated_GitRefs_QueueCounter(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}, "checkpoints": {"primary": {"type": "git-refs"}}}`)
-	testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
+	testutil.AddRemote(t, ".", originRemoteName, "https://github.com/org/repo.git")
 	checkpointSyncTestCommit(t, "a.txt", "one")
 
 	cwd, err := os.Getwd()
@@ -2947,7 +3025,7 @@ func TestRunStatusJSON_CheckpointSync_Dedicated(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`)
-	testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
+	testutil.AddRemote(t, ".", originRemoteName, "https://github.com/org/repo.git")
 
 	var stdout bytes.Buffer
 	if err := runStatus(context.Background(), &stdout, false, true); err != nil {
@@ -2979,7 +3057,7 @@ func TestRunStatus_CheckpointSyncDedicated_IneligibleFallsBackToElected(t *testi
 	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`)
 	// Remote owner "other" != checkpoint_remote owner "org": fork detection
 	// rejects the dedicated store at push time.
-	testutil.AddRemote(t, ".", "origin", "https://github.com/other/repo.git")
+	testutil.AddRemote(t, ".", originRemoteName, "https://github.com/other/repo.git")
 	checkpointSyncTestCommit(t, "a.txt", "one")
 	second := checkpointSyncTestCommit(t, "b.txt", "two")
 	testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, second)
@@ -3007,7 +3085,7 @@ func TestRunStatusJSON_CheckpointSync_DedicatedIneligible(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`)
-	testutil.AddRemote(t, ".", "origin", "https://github.com/other/repo.git")
+	testutil.AddRemote(t, ".", originRemoteName, "https://github.com/other/repo.git")
 
 	var stdout bytes.Buffer
 	if err := runStatus(context.Background(), &stdout, false, true); err != nil {

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -2308,10 +2308,13 @@ func testCheckpointPushDisabledFork(t *testing.T, jsonOutput bool) {
 	testutil.AddRemote(t, ".", "fork", "https://github.com/user/repo.git")
 	head := checkpointSyncTestCommit(t, "a.txt", "one")
 	testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
-	assertCheckpointPushDisabledStatus(t, jsonOutput, false)
+	assertCheckpointPushDisabledStatus(t, jsonOutput, false, "fork")
 }
 
-func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool) {
+// assertCheckpointPushDisabledStatus asserts the disabled-pushing report:
+// wantRemote is the checkpoint read destination status must still name ("" when
+// nothing resolved), and no phrasing may survive that promises a push.
+func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool, wantRemote string) {
 	t.Helper()
 	var stdout bytes.Buffer
 	if err := runStatus(context.Background(), &stdout, detailed, jsonOutput); err != nil {
@@ -2334,10 +2337,19 @@ func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool)
 				t.Errorf("%s = %s, want true (decode error: %v)", key, raw, err)
 			}
 		}
-		for _, key := range []string{"checkpoint_sync_remote", "checkpoint_sync_remote_source", "unpushed_checkpoints"} {
-			if value, exists := result[key]; exists {
-				t.Errorf("disabled pushing must omit %s, got %s", key, value)
+		// The elected remote is still the read source, so the destination
+		// fields stay populated; only the phrasing around them changes.
+		gotRemote := ""
+		if raw, exists := result["checkpoint_sync_remote"]; exists {
+			if err := json.Unmarshal(raw, &gotRemote); err != nil {
+				t.Fatalf("checkpoint_sync_remote decode error = %v", err)
 			}
+		}
+		if gotRemote != wantRemote {
+			t.Errorf("checkpoint_sync_remote = %q, want %q: %s", gotRemote, wantRemote, stdout.String())
+		}
+		if _, exists := result["checkpoint_sync_remote_source"]; exists != (wantRemote != "") {
+			t.Errorf("checkpoint_sync_remote_source presence = %v, want %v: %s", exists, wantRemote != "", stdout.String())
 		}
 		return
 	}
@@ -2349,6 +2361,50 @@ func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool)
 			t.Errorf("disabled pushing must not show %q", unwanted)
 		}
 	}
+	if wantRemote != "" && !strings.Contains(stdout.String(), "Checkpoints read from: ") {
+		t.Errorf("disabled pushing must still name the read destination %q: %s", wantRemote, stdout.String())
+	}
+	if wantRemote == "" && strings.Contains(stdout.String(), "Checkpoints read from: ") {
+		t.Errorf("nothing resolved, so no read destination may be named: %s", stdout.String())
+	}
+}
+
+// Not parallel: setupTestRepo changes CWD and isolates process environment.
+func TestRunStatus_CheckpointPushDisabledNamesReadSourceAndLocalCount(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	writeSettings(t, `{"enabled":true,"strategy_options":{"push_sessions":false}}`)
+	testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
+	head := checkpointSyncTestCommit(t, "a.txt", "one")
+	testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
+
+	// With pushing off, status is the only surface naming where checkpoint
+	// reads resolve (CheckpointReadRemotesWithElection never consults
+	// push_sessions) and the only one reporting that checkpoint data is
+	// piling up locally — push_sessions gates pushing, not checkpoint
+	// creation. Both must be phrased without promising a push.
+	var text bytes.Buffer
+	if err := runStatus(t.Context(), &text, false, false); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("status output:\n%s", text.String())
+	for _, want := range []string{"Checkpoints read from: origin", "1 checkpoint stored locally only"} {
+		if !strings.Contains(text.String(), want) {
+			t.Errorf("missing %q: %s", want, text.String())
+		}
+	}
+
+	var jsonOut bytes.Buffer
+	if err := runStatus(t.Context(), &jsonOut, false, true); err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(jsonOut.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if string(result["checkpoint_sync_remote"]) != `"origin"` || string(result["unpushed_checkpoints"]) != "1" {
+		t.Errorf("disabled pushing dropped read destination or local-only count: %s", jsonOut.String())
+	}
 }
 
 func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
@@ -2358,13 +2414,19 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 			name    string
 			options string
 			origin  string
+			// wantRemote is the read destination status must still report with
+			// pushing disabled; wantSource is its provenance ("" when nothing
+			// resolved). Populating them is the point: the elected remote stays
+			// the checkpoint read source when push_sessions is false.
+			wantRemote string
+			wantSource string
 		}{
-			{"origin", "", "https://github.com/org/repo.git"},
-			{"explicit_fork", `,"checkpoint_push_remote":"fork"`, "https://github.com/org/repo.git"},
-			{"dedicated", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/org/repo.git"},
-			{"inherited_dedicated_rejected", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/other/repo.git"},
-			{"no_remotes", "", ""},
-			{"missing_configured_remote", `,"checkpoint_push_remote":"gone"`, "https://github.com/org/repo.git"},
+			{"origin", "", "https://github.com/org/repo.git", "origin", "default"},
+			{"explicit_fork", `,"checkpoint_push_remote":"fork"`, "https://github.com/org/repo.git", "fork", "config"},
+			{"dedicated", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/org/repo.git", "org/checkpoints", checkpointSyncSourceDedicated},
+			{"inherited_dedicated_rejected", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/other/repo.git", "origin", "default"},
+			{"no_remotes", "", "", "", ""},
+			{"missing_configured_remote", `,"checkpoint_push_remote":"gone"`, "https://github.com/org/repo.git", "", ""},
 		} {
 			t.Run(backend+"/"+tc.name, func(t *testing.T) {
 				testutil.IsolateGitConfigEnv(t)
@@ -2402,11 +2464,21 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 				if (info.Err != "") != (tc.name == "missing_configured_remote") || (info.IgnoredRemote != "") != (tc.name == "inherited_dedicated_rejected") {
 					t.Errorf("unexpected remote diagnostics: %+v", info)
 				}
-				if !info.PushDisabled || info.Remote != "" || info.Source != "" || info.Unpushed != 0 {
-					t.Errorf("disabled pushing must preserve diagnostics without push destination/count: %+v", info)
+				if !info.PushDisabled || info.Remote != tc.wantRemote || info.Source != tc.wantSource {
+					t.Errorf("disabled pushing must still resolve the read destination %q/%q: %+v", tc.wantRemote, tc.wantSource, info)
+				}
+				// The counter is the only signal that local-only checkpoint
+				// data is accumulating, so it survives disabled pushing
+				// wherever it is meaningful at all. Dedicated URL mode on
+				// git-branch has no tracking ref to compare against and stays
+				// uncounted, as it does with pushing enabled.
+				wantCount := tc.wantRemote != "" &&
+					(tc.wantSource != checkpointSyncSourceDedicated || backend != "git-branch")
+				if (info.Unpushed > 0) != wantCount {
+					t.Errorf("unpushed count = %d, want counted: %v (%+v)", info.Unpushed, wantCount, info)
 				}
 				for _, jsonOutput := range []bool{false, true} {
-					assertCheckpointPushDisabledStatus(t, jsonOutput, false)
+					assertCheckpointPushDisabledStatus(t, jsonOutput, false, tc.wantRemote)
 					after, err := queue.Peek()
 					if err != nil {
 						t.Fatal(err)
@@ -2507,7 +2579,7 @@ func TestRunStatus_CheckpointPushDisabledSettingsPrecedence(t *testing.T) {
 				if tc.disabled {
 					// --detailed and --json are mutually exclusive: only text
 					// exercises the detailed settings view.
-					assertCheckpointPushDisabledStatus(t, jsonOutput, !jsonOutput)
+					assertCheckpointPushDisabledStatus(t, jsonOutput, !jsonOutput, "origin")
 					continue
 				}
 				var stdout bytes.Buffer

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -2308,13 +2308,15 @@ func testCheckpointPushDisabledFork(t *testing.T, jsonOutput bool) {
 	testutil.AddRemote(t, ".", "fork", "https://github.com/user/repo.git")
 	head := checkpointSyncTestCommit(t, "a.txt", "one")
 	testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
-	assertCheckpointPushDisabledStatus(t, jsonOutput, false, "fork")
+	assertCheckpointPushDisabledStatus(t, jsonOutput, false, "fork", "")
 }
 
 // assertCheckpointPushDisabledStatus asserts the disabled-pushing report:
-// wantRemote is the checkpoint read destination status must still name ("" when
-// nothing resolved), and no phrasing may survive that promises a push.
-func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool, wantRemote string) {
+// wantRemote is the elected read destination status must still name, wantFallback
+// the remote reads fall open to when the election failed instead (at most one is
+// set; both "" means nothing resolved), and no phrasing may survive that
+// promises a push.
+func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool, wantRemote, wantFallback string) {
 	t.Helper()
 	var stdout bytes.Buffer
 	if err := runStatus(context.Background(), &stdout, detailed, jsonOutput); err != nil {
@@ -2338,19 +2340,19 @@ func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool,
 			}
 		}
 		// The elected remote is still the read source, so the destination
-		// fields stay populated; only the phrasing around them changes.
-		gotRemote := ""
-		if raw, exists := result["checkpoint_sync_remote"]; exists {
-			if err := json.Unmarshal(raw, &gotRemote); err != nil {
-				t.Fatalf("checkpoint_sync_remote decode error = %v", err)
+		// field stays populated; only the phrasing around it changes. A
+		// fail-open read source is reported separately, because nothing was
+		// elected — checkpoint_sync_remote must stay absent for it.
+		wantJSON := func(key, want string) {
+			if want != "" {
+				want = `"` + want + `"`
+			}
+			if got := string(result[key]); got != want {
+				t.Errorf("%s = %s, want %s: %s", key, got, want, stdout.String())
 			}
 		}
-		if gotRemote != wantRemote {
-			t.Errorf("checkpoint_sync_remote = %q, want %q: %s", gotRemote, wantRemote, stdout.String())
-		}
-		if _, exists := result["checkpoint_sync_remote_source"]; exists != (wantRemote != "") {
-			t.Errorf("checkpoint_sync_remote_source presence = %v, want %v: %s", exists, wantRemote != "", stdout.String())
-		}
+		wantJSON("checkpoint_sync_remote", wantRemote)
+		wantJSON("checkpoint_read_fallback", wantFallback)
 		return
 	}
 	if !strings.Contains(stdout.String(), "Automatic checkpoint pushing: disabled (push_sessions=false)") {
@@ -2361,57 +2363,46 @@ func assertCheckpointPushDisabledStatus(t *testing.T, jsonOutput, detailed bool,
 			t.Errorf("disabled pushing must not show %q", unwanted)
 		}
 	}
-	if wantRemote != "" && !strings.Contains(stdout.String(), "Checkpoints read from: ") {
-		t.Errorf("disabled pushing must still name the read destination %q: %s", wantRemote, stdout.String())
+	named := wantRemote + wantFallback
+	if named != "" && !strings.Contains(stdout.String(), "Checkpoints read from: ") {
+		t.Errorf("disabled pushing must still name the read source %q: %s", named, stdout.String())
 	}
-	if wantRemote == "" && strings.Contains(stdout.String(), "Checkpoints read from: ") {
-		t.Errorf("nothing resolved, so no read destination may be named: %s", stdout.String())
+	if named == "" && strings.Contains(stdout.String(), "Checkpoints read from: ") {
+		t.Errorf("nothing resolved, so no read source may be named: %s", stdout.String())
+	}
+	if (wantFallback != "") != strings.Contains(stdout.String(), "(fallback; nothing was elected)") {
+		t.Errorf("fallback suffix must appear only for a failed election (want fallback %q): %s", wantFallback, stdout.String())
 	}
 }
 
-// Not parallel: setupTestRepo changes CWD and isolates process environment.
-func TestRunStatus_CheckpointPushDisabledNamesReadSourceAndCount(t *testing.T) {
-	testutil.IsolateGitConfigEnv(t)
-	setupTestRepo(t)
-	writeSettings(t, `{"enabled":true,"strategy_options":{"push_sessions":false}}`)
-	testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
-	head := checkpointSyncTestCommit(t, "a.txt", "one")
-	testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
-
-	// With pushing off, status is the only surface naming where checkpoint
-	// reads resolve (CheckpointReadRemotesWithElection never consults
-	// push_sessions) and the only one reporting that checkpoint data is not
-	// reaching the destination — push_sessions gates pushing, not checkpoint
-	// creation. Both must be phrased without promising a push.
-	var text bytes.Buffer
-	if err := runStatus(t.Context(), &text, false, false); err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("status output:\n%s", text.String())
-	for _, want := range []string{"Checkpoints read from: origin", "1 checkpoint not on origin"} {
-		if !strings.Contains(text.String(), want) {
-			t.Errorf("missing %q: %s", want, text.String())
-		}
-	}
-	// The count compares against the elected destination only, so it must not
-	// be phrased as proof the data exists nowhere else — a false reassurance
-	// about checkpoint data having left the machine.
-	for _, unwanted := range []string{"stored locally only", "local only", "only locally"} {
-		if strings.Contains(text.String(), unwanted) {
-			t.Errorf("count must not claim local-only storage (%q): %s", unwanted, text.String())
-		}
-	}
-
-	var jsonOut bytes.Buffer
-	if err := runStatus(t.Context(), &jsonOut, false, true); err != nil {
-		t.Fatal(err)
-	}
-	var result map[string]json.RawMessage
-	if err := json.Unmarshal(jsonOut.Bytes(), &result); err != nil {
-		t.Fatal(err)
-	}
-	if string(result["checkpoint_sync_remote"]) != `"origin"` || string(result["unpushed_checkpoints"]) != "1" {
-		t.Errorf("disabled pushing dropped read destination or unpushed count: %s", jsonOut.String())
+// formatUnpushedCheckpointsLine is pure, so its four branches are pinned here
+// rather than through a repo fixture. What the counter must never say with
+// pushing disabled is that the data is local-only: Unpushed compares against
+// the elected destination alone, so it cannot establish that checkpoints exist
+// nowhere else, and claiming otherwise would falsely reassure someone asking
+// whether checkpoint data has left their machine.
+func TestFormatUnpushedCheckpointsLine(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		info checkpointSyncInfo
+		want string
+	}{
+		{"pushing_enabled", checkpointSyncInfo{Remote: "origin", Source: "default", Unpushed: 2},
+			"2 checkpoints not yet on origin — they sync with your next 'git push origin'"},
+		{"pushing_enabled_dedicated", checkpointSyncInfo{Remote: "org/cp", Source: checkpointSyncSourceDedicated, Unpushed: 2},
+			"2 checkpoints not yet pushed"},
+		{"pushing_disabled", checkpointSyncInfo{PushDisabled: true, Remote: "origin", Source: "default", Unpushed: 1},
+			"1 checkpoint not on origin"},
+		{"pushing_disabled_dedicated", checkpointSyncInfo{PushDisabled: true, Remote: "org/cp", Source: checkpointSyncSourceDedicated, Unpushed: 2},
+			"2 checkpoints not pushed to the checkpoint remote"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := formatUnpushedCheckpointsLine(tc.info); got != tc.want {
+				t.Errorf("formatUnpushedCheckpointsLine() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -2428,13 +2419,16 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 			// the checkpoint read source when push_sessions is false.
 			wantRemote string
 			wantSource string
+			// wantFallback is the remote reads fall OPEN to when the election
+			// failed closed, reported instead of (never alongside) wantRemote.
+			wantFallback string
 		}{
-			{"origin", "", "https://github.com/org/repo.git", "origin", "default"},
-			{"explicit_fork", `,"checkpoint_push_remote":"fork"`, "https://github.com/org/repo.git", "fork", "config"},
-			{"dedicated", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/org/repo.git", "org/checkpoints", checkpointSyncSourceDedicated},
-			{"inherited_dedicated_rejected", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/other/repo.git", "origin", "default"},
-			{"no_remotes", "", "", "", ""},
-			{"missing_configured_remote", `,"checkpoint_push_remote":"gone"`, "https://github.com/org/repo.git", "", ""},
+			{"origin", "", "https://github.com/org/repo.git", "origin", "default", ""},
+			{"explicit_fork", `,"checkpoint_push_remote":"fork"`, "https://github.com/org/repo.git", "fork", "config", ""},
+			{"dedicated", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/org/repo.git", "org/checkpoints", checkpointSyncSourceDedicated, ""},
+			{"inherited_dedicated_rejected", `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`, "https://github.com/other/repo.git", "origin", "default", ""},
+			{"no_remotes", "", "", "", "", ""},
+			{"missing_configured_remote", `,"checkpoint_push_remote":"gone"`, "https://github.com/org/repo.git", "", "", "origin"},
 		} {
 			t.Run(backend+"/"+tc.name, func(t *testing.T) {
 				testutil.IsolateGitConfigEnv(t)
@@ -2475,6 +2469,12 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 				if !info.PushDisabled || info.Remote != tc.wantRemote || info.Source != tc.wantSource {
 					t.Errorf("disabled pushing must still resolve the read destination %q/%q: %+v", tc.wantRemote, tc.wantSource, info)
 				}
+				// Reads fail open where the election failed closed, so the
+				// fallback is reported — but never through Remote, which
+				// means "elected" and has nothing to name here.
+				if info.ReadFallback != tc.wantFallback {
+					t.Errorf("read fallback = %q, want %q: %+v", info.ReadFallback, tc.wantFallback, info)
+				}
 				// The counter is the only signal that checkpoint data is not
 				// reaching the destination, so it survives disabled pushing
 				// wherever it is meaningful at all. Dedicated URL mode on
@@ -2486,7 +2486,7 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 					t.Errorf("unpushed count = %d, want counted: %v (%+v)", info.Unpushed, wantCount, info)
 				}
 				for _, jsonOutput := range []bool{false, true} {
-					assertCheckpointPushDisabledStatus(t, jsonOutput, false, tc.wantRemote)
+					assertCheckpointPushDisabledStatus(t, jsonOutput, false, tc.wantRemote, tc.wantFallback)
 					after, err := queue.Peek()
 					if err != nil {
 						t.Fatal(err)
@@ -2587,7 +2587,7 @@ func TestRunStatus_CheckpointPushDisabledSettingsPrecedence(t *testing.T) {
 				if tc.disabled {
 					// --detailed and --json are mutually exclusive: only text
 					// exercises the detailed settings view.
-					assertCheckpointPushDisabledStatus(t, jsonOutput, !jsonOutput, "origin")
+					assertCheckpointPushDisabledStatus(t, jsonOutput, !jsonOutput, "origin", "")
 					continue
 				}
 				var stdout bytes.Buffer

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -2441,6 +2441,12 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 			// the read source, rather than the row passing because nothing
 			// resolved for some other reason.
 			wantReadUnknown bool
+			// wantErr is the fail-closed election, and wantIgnored the
+			// "checkpoint_remote not in use" warning. Stated per row rather
+			// than matched on tc.name: several rows now reach each, and name
+			// matching silently mis-expects every row added afterwards.
+			wantErr     bool
+			wantIgnored bool
 		}{
 			{name: "origin", origin: "https://github.com/org/repo.git", wantRemote: "origin", wantSource: "default"},
 			{
@@ -2456,12 +2462,12 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 			{
 				name: "inherited_dedicated_rejected", options: `,"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`,
 				origin:     "https://github.com/other/repo.git",
-				wantRemote: "origin", wantSource: "default",
+				wantRemote: "origin", wantSource: "default", wantIgnored: true,
 			},
 			{name: "no_remotes"},
 			{
 				name: "missing_configured_remote", options: `,"checkpoint_push_remote":"gone"`,
-				origin: "https://github.com/org/repo.git", wantFallback: "origin",
+				origin: "https://github.com/org/repo.git", wantFallback: "origin", wantErr: true,
 			},
 			// Push- and fetch-side ownership disagree. Both require EVERY
 			// identity to be owned by the checkpoint repo's owner, but over
@@ -2476,7 +2482,26 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 				options: `,"checkpoint_push_remote":"fork","checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`,
 				origin:  "https://github.com/org/repo.git",
 				fork:    "https://github.com/other/fork.git", forkPush: "https://github.com/org/fork.git",
-				wantRemote: "fork", wantSource: "config",
+				wantRemote: "fork", wantSource: "config", wantIgnored: true,
+			},
+			// A failed election does not stop reads: they fail open, so the
+			// dedicated store still serves them when the fetch side owns it,
+			// and status reports it rather than nothing. The elected-remote
+			// fields carry it — nothing was elected, but "dedicated" was
+			// never an election — so wantFallback stays empty.
+			{
+				name:       "missing_configured_remote_with_dedicated",
+				options:    `,"checkpoint_push_remote":"gone","checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`,
+				origin:     "https://github.com/org/repo.git",
+				wantRemote: "org/checkpoints", wantSource: checkpointSyncSourceDedicated, wantErr: true,
+			},
+			// Same, but the fetch side does not own the store, so reads land
+			// on the fail-open candidate and that is what is reported.
+			{
+				name:         "missing_configured_remote_with_disowned_dedicated",
+				options:      `,"checkpoint_push_remote":"gone","checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`,
+				origin:       "https://github.com/other/repo.git",
+				wantFallback: "origin", wantErr: true,
 			},
 			// The read probe cannot resolve any URL (a configured
 			// checkpoint_remote derives from origin, and there is none), so
@@ -2528,17 +2553,15 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 					t.Fatal(err)
 				}
 				info := computeCheckpointSyncInfo(t.Context(), s)
-				// Both rejections report "not in use", by different routes:
-				// the origin-owner row through the push-side verdict, the
-				// fetch-rejected row through the read-side branch that exists
-				// because that verdict ACCEPTS it. Without the second, a
-				// configured store that serves no reads is reported by
-				// nothing. (Not the divergence documented as accepted on
-				// InheritedCheckpointRemote — that one is the opposite
-				// direction, a warning where a lead-less fetch still resolves
-				// the store.)
-				wantIgnored := tc.name == "inherited_dedicated_rejected" || tc.name == "dedicated_rejected_by_fetch_owner"
-				if (info.Err != "") != (tc.name == "missing_configured_remote") || (info.IgnoredRemote != "") != wantIgnored {
+				// The two "not in use" rows reach that warning by different
+				// routes: the origin-owner row through the push-side verdict,
+				// the fetch-rejected row through the read-side branch that
+				// exists because that verdict ACCEPTS what the fetch side
+				// declines. Without the second, a configured store serving no
+				// reads is reported by nothing. (Not the divergence
+				// documented as accepted on InheritedCheckpointRemote — that
+				// one is the opposite direction.)
+				if (info.Err != "") != tc.wantErr || (info.IgnoredRemote != "") != tc.wantIgnored {
 					t.Errorf("unexpected remote diagnostics: %+v", info)
 				}
 				if !info.PushDisabled || info.Remote != tc.wantRemote || info.Source != tc.wantSource {
@@ -2558,7 +2581,10 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 				// wherever it is meaningful at all. Dedicated URL mode on
 				// git-branch has no tracking ref to compare against and stays
 				// uncounted, as it does with pushing enabled.
-				wantCount := tc.wantRemote != "" &&
+				// The fail-closed path returns before counting: with no
+				// election there is no destination to count against, even
+				// when the dedicated store still serves reads.
+				wantCount := !tc.wantErr && tc.wantRemote != "" &&
 					(tc.wantSource != checkpointSyncSourceDedicated || backend != "git-branch")
 				if (info.Unpushed > 0) != wantCount {
 					t.Errorf("unpushed count = %d, want counted: %v (%+v)", info.Unpushed, wantCount, info)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1278
<!-- entire-trail-link-end -->

## Summary

`entire status` could claim checkpoints sync to a remote and promise delivery on the next Git push even when `strategy_options.push_sessions` was false. The push path already respected the setting; this fixes reporting only.

- Use the existing merged-settings check in the shared status computation before remote resolution and pending-count reporting.
- Show `Automatic checkpoint pushing: disabled (push_sessions=false)` in text/detailed status.
- Emit `checkpoint_push_disabled: true` in JSON and omit active sync destination/error/count fields while disabled. The new field is omitted otherwise; absence does not guarantee that a push can succeed.
- Preserve enabled behavior, checkpoint capture, remote selection, and push implementation.

## Verification

- Regression failed before the fix and passed afterward for explicit non-origin `fork`.
- Status tests cover both checkpoint backends, default/fork/dedicated destinations, absent/invalid remotes, inherited settings, local overrides, and queue preservation.
- Real compiled CLI smoke test: 13 temporary-repository scenarios, 39 text/detailed/JSON invocations passed, with no remote pushes or user configuration changes.
- Independent spec and code-quality reviews found no actionable issues.

- `TMPDIR=/private/tmp mise run check` passed: unit/integration tests with race detection, lint, and all 60 deterministic canaries. The canonical temp path avoids existing macOS `/var` versus `/private/var` symlink-test failures; no unrelated tests were modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting-only change in status output; push and capture paths are unchanged. Low risk aside from scripts that assumed sync fields always appear when remotes exist.
> 
> **Overview**
> Fixes **`entire status`** so it no longer implies checkpoints will sync on the next `git push` when **`strategy_options.push_sessions`** is false. Push behavior was already gated; only reporting changed.
> 
> Shared **`computeCheckpointSyncInfo`** now short-circuits on **`IsPushSessionsDisabled()`** before remote resolution or unpushed counts. **Text** status shows `Automatic checkpoint pushing: disabled (push_sessions=false)` instead of sync destination / counter lines. **`entire status --json`** adds **`checkpoint_push_disabled: true`** when Entire is enabled and pushing is off, and omits sync remote, error, and unpushed fields in that case.
> 
> Adds regression tests for text and JSON across checkpoint backends, remotes (origin, fork, dedicated, misconfigured), local vs shared settings precedence, and cases where Entire is not active—plus asserts status does not mutate the push queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd08c498c5f93f59debe4460c88f9f51228c3a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->