### PR TITLE
test: resolve temp dirs before comparing them against git-resolved paths

### DIFF
--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -1910,7 +1910,11 @@ func TestCheckAgentDirSymlinks_ScansBeneathAVouchedLink(t *testing.T) {
 	if err := os.Symlink(t.TempDir(), filepath.Join(dest, "skills")); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
-	agent.SetVouchedSymlinkedDirs(dir, []string{claudeDirName})
+	// git rev-parse --show-toplevel (what checkAgentDirSymlinks reads) resolves
+	// symlinks, so on macOS the vouch must be keyed on the resolved path.
+	vouchRoot, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	agent.SetVouchedSymlinkedDirs(vouchRoot, []string{claudeDirName})
 
 	cmd, stdout := newTestCmd(t)
 	checkAgentDirSymlinks(cmd)
@@ -1937,7 +1941,11 @@ func TestCheckAgentDirSymlinks_VouchedLinkWithCleanTargetReportsOnlyTheLink(t *t
 	if err := os.Symlink(dest, filepath.Join(dir, claudeDirName)); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
-	agent.SetVouchedSymlinkedDirs(dir, []string{claudeDirName})
+	// git rev-parse --show-toplevel (what checkAgentDirSymlinks reads) resolves
+	// symlinks, so on macOS the vouch must be keyed on the resolved path.
+	vouchRoot, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	agent.SetVouchedSymlinkedDirs(vouchRoot, []string{claudeDirName})
 
 	cmd, stdout := newTestCmd(t)
 	checkAgentDirSymlinks(cmd)

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -2088,7 +2088,10 @@ func TestRemoveGitHook_LeavesAnUnreadableHookAndItsBackup(t *testing.T) {
 func TestSymlinkedHooksDirError_RemedyIsPasteable(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	// symlinkedHooksDirError resolves its target, so the expectation has to be
+	// composed from the resolved temp dir (/private/var/... on macOS).
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
 	realHooks := filepath.Join(dir, "real-hooks")
 	require.NoError(t, os.MkdirAll(realHooks, 0o750))
 	link := filepath.Join(dir, "hooks")
@@ -2147,7 +2150,8 @@ func TestSymlinkedHooksDirError_UsesTheQuotedCommand(t *testing.T) {
 		t.Skip("POSIX quoting")
 	}
 
-	dir := t.TempDir()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
 	realHooks := filepath.Join(dir, "real hooks")
 	require.NoError(t, os.MkdirAll(realHooks, 0o750))
 	link := filepath.Join(dir, "hooks")


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1280
<!-- entire-trail-link-end -->

Four tests fail on every macOS dev machine and pass on Linux CI. On macOS `/var` is a symlink to `/private/var`, so `t.TempDir()` hands back a path the code under test never uses — both resolve symlinks before producing the value the test compares against. They are red on clean `origin/main`, verified by running each on a worktree with no diff against it, so this is not a regression from any open branch.

The two pairs fail for **different reasons**, and only the first is the "expectation composed from `t.TempDir()`" case that this class is usually described as.

## Pair 1 — composed expectation (`strategy/hooks_test.go`)

`TestSymlinkedHooksDirError_RemedyIsPasteable`, `TestSymlinkedHooksDirError_UsesTheQuotedCommand`

`symlinkedHooksDirError` resolves its target and emits `/private/var/...`, while the expectation is built with `filepath.Join(t.TempDir(), ...)` and says `/var/...`. Resolving the temp dir before composing settles it.

## Pair 2 — the vouch key never matches (`doctor_test.go`)

`TestCheckAgentDirSymlinks_ScansBeneathAVouchedLink`, `TestCheckAgentDirSymlinks_VouchedLinkWithCleanTargetReportsOnlyTheLink`

These compose no path expectation at all — they assert on the literals `"FOLLOWING SYMLINKS"`, `".claude/skills"` and `"SYMLINKS PRESENT"`. They fail because the test vouches with a raw `t.TempDir()` (`/var/...`) while `checkAgentDirSymlinks` reads `paths.WorktreeRoot` → `git rev-parse --show-toplevel` (`/private/var/...`). `agent.keyFor` canonicalizes separators and Windows case but deliberately not symlinks, so the keys never match, `VouchedSymlinkedDirs` returns nothing, and doctor reports the vouched link as a fault. Keying the vouch on the resolved root is the fix — resolving an expectation would change nothing here.

## No production path is affected

`keyFor`'s comment justifies skipping `EvalSymlinks` on the premise that "both producers reach this through git's `--show-toplevel`, which has already resolved them." That premise holds. I checked every production producer of the vouch root — all six `settings.WithWorktreeRoot` call sites plus `applyVouchedAgentDirs` — and each is `paths.WorktreeRoot` or `getRepoPath(repo)`. Only the tests broke the contract, so this is a test-side fix and `keyFor` is left alone.

Worth flagging for whoever touches `keyFor` next: pair 2's symptom — a verified grant silently ignored, indistinguishable from an absent grant — is exactly what `keyFor`'s own comment says the Windows separator bug caused. macOS reproduced it on a different spelling axis (symlink resolution rather than separator), and these two tests are the only guard on that contract outside Linux CI. While they are red locally they guard nothing on the machines most likely to hit it.

## Verification

`mise run fmt` (no changes), `mise run lint` (0 issues), `mise run test` (10,987 tests, 8 skipped, all green), plus `cmd/entire/cli` and `cmd/entire/cli/strategy` run in full individually, and `GOOS=windows`/`GOOS=linux go vet ./cmd/entire/cli/...` clean since the change lands in code paths that are not OS-guarded. Before: all four fail on macOS. After: all four pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only path canonicalization fixes; no runtime or production behavior is modified.
> 
> **Overview**
> Fixes **four macOS-only test failures** caused by `/var` vs `/private/var` symlink canonicalization. Production code already uses git-resolved paths (`git rev-parse --show-toplevel`, resolved hooks targets); tests were not.
> 
> In **`doctor_test.go`**, vouched symlink allowlist setup now keys `SetVouchedSymlinkedDirs` with `filepath.EvalSymlinks(dir)` so it matches what `checkAgentDirSymlinks` reads from the worktree root—otherwise vouches were silently ignored and doctor reported faults on allowed links.
> 
> In **`hooks_test.go`**, symlinked-hooks error remedy tests build expectations from an **EvalSymlinks**-resolved temp dir so asserted `git config core.hooksPath …` strings match what `symlinkedHooksDirError` emits.
> 
> **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 341c449b1a509052c1f1a27f32b90b213df424f2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->