### PR TITLE
Gate new complexity in CI via the tools/complexity diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,30 @@ jobs:
       - name: Windows unit tests
         run: go test ./cmd/entire/cli/... -run '(Windows|MSYS)' -count=1 -v
 
+  # Fails only on functions this pull request made new or worse than the merge
+  # base; the repo's ~105 pre-existing violations are exempt. Deliberately not
+  # the gocognit linter: golangci has no per-linter new-only mode, so enabling
+  # it would fail `mise run lint` locally on all of them, and the action's
+  # only-new-issues switch is workflow-wide. See tools/complexity/README.md.
+  complexity-gate:
+    # Pull requests only: the gate diffs against the merge base with the target
+    # branch, and a push to main has no such base to diff against.
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # The merge base is resolved locally, so both sides of the history
+          # have to be present.
+          fetch-depth: 0
+      - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4
+      - name: Complexity gate
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: mise run complexity:gate
+
   test:
     runs-on: ubuntu-latest
     needs:
@@ -93,6 +117,7 @@ jobs:
       - test-codex-hooks
       - test-canary
       - test-windows
+      - complexity-gate
     if: ${{ always() }}
     steps:
       - name: Check dependencies
@@ -102,3 +127,6 @@ jobs:
           [ "${{ needs.test-codex-hooks.result }}" = "success" ]
           [ "${{ needs.test-canary.result }}" = "success" ]
           [ "${{ needs.test-windows.result }}" = "success" ]
+          # "skipped" is the push-to-main and workflow_dispatch case, where the
+          # gate has no merge base and does not run.
+          [ "${{ needs.complexity-gate.result }}" = "success" ] || [ "${{ needs.complexity-gate.result }}" = "skipped" ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,6 +525,10 @@ When duplication is found:
 2. If not, consider extracting the duplicated logic to a shared helper
 3. If duplication is intentional (e.g., test setup), add a `//nolint:dupl` comment with explanation
 
+### Complexity gate
+
+CI's `complexity-gate` job fails a pull request when a function is over cognitive complexity 30 **and** new or worsened against the merge base — never on the 105 pre-existing violations, which is why it is a `tools/complexity` diff rather than the `gocognit` linter (golangci has no per-linter new-only mode, so enabling it would fail `mise run lint` on all of them). Run it locally with `mise run complexity:gate`; the threshold is the gate's `-cognit-warn` flag (`COGNIT_WARN=25 mise run complexity:gate`), not a `.golangci.yaml` setting. A per-feature coverage comparison against `tools/complexity/baseline/<date>/features.csv` also exists, advisory-only and not yet wired into CI — see [tools/complexity/README.md](tools/complexity/README.md).
+
 ## Code Patterns
 
 ### Error Handling

--- a/mise-tasks/complexity/gate
+++ b/mise-tasks/complexity/gate
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#MISE description="Fail on functions this branch made new or worse than the base (cognitive complexity > 30)"
+set -euo pipefail
+
+# The blocking half of the complexity gate, run identically here and in CI
+# (.github/workflows/ci.yml calls this task). It compares the working tree
+# against the merge base with BASE_REF and fails on functions that are both
+# over the threshold and new or worsened; the repo's long tail of pre-existing
+# violations is deliberately exempt. See tools/complexity/README.md.
+#
+# BASE_REF     ref to take the merge base with (default origin/main; CI passes
+#              the pull request's base SHA)
+# COGNIT_WARN  the threshold (default 30)
+
+BASE_REF="${BASE_REF:-origin/main}"
+COGNIT_WARN="${COGNIT_WARN:-30}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! base_sha="$(git merge-base "$BASE_REF" HEAD)"; then
+  echo "error: no merge base between $BASE_REF and HEAD (fetch it first: git fetch origin main)" >&2
+  exit 1
+fi
+# --no-optional-locks per the repo rule: `git status` otherwise rewrites the
+# index, and this can run while an agent's hooks are touching the same repo.
+# Untracked files count as a change, because a new .go file is exactly what
+# this gate exists to look at and `git diff` would not see it.
+if [ "$base_sha" = "$(git rev-parse HEAD)" ] && [ -z "$(git --no-optional-locks status --porcelain)" ]; then
+  echo "complexity gate: working tree is the merge base with $BASE_REF — nothing to compare"
+  exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# `git archive` rather than `git worktree add`: this task is meant to be run
+# from a dirty working tree, and an export leaves no entry in the repo's
+# worktree list to clean up if it is interrupted. The repo has no
+# .gitattributes, so the export is a faithful copy of the tree.
+mkdir -p "$tmpdir/basetree"
+git archive "$base_sha" | tar -x -C "$tmpdir/basetree"
+
+# Both runs use the HEAD version of the tool and of the feature mapping, so
+# cxtool can evolve without a change to it looking like a complexity change.
+cd tools/complexity
+go build -o "$tmpdir/cxtool" .
+go build -o "$tmpdir/gate" ./gate
+
+# No -cover: the diff reads only per-function complexity, and skipping the
+# coverage profiles (and churn, which needs a git dir the export does not
+# have) keeps each run to about a second. cxtool's stderr is left alone — it
+# lists unmapped files there, and swallowing it would swallow its errors too.
+"$tmpdir/cxtool" -root "$tmpdir/basetree" -churn-days '' -out "$tmpdir/base"
+"$tmpdir/cxtool" -root "$repo_root" -churn-days '' -out "$tmpdir/head"
+
+echo "complexity gate: HEAD vs $(git -C "$repo_root" rev-parse --short "$base_sha") (merge base with $BASE_REF)"
+"$tmpdir/gate" -base "$tmpdir/base" -head "$tmpdir/head" -cognit-warn "$COGNIT_WARN"

--- a/tools/complexity/README.md
+++ b/tools/complexity/README.md
@@ -15,7 +15,8 @@ and it in turn skips nested modules when walking the tree.
 | `main.go` | parses every non-test Go file (in parallel); per function LOC, cyclomatic (`fzipp/gocyclo`), cognitive (`uudashr/gocognit`); folds `go test -coverprofile` files in a single streaming pass (merged per block, max count) and `git log --numstat` churn (one git run, bucketed per window); rolls up by `features.json` |
 | `reach/main.go` | builds SSA + a VTA call graph (`golang.org/x/tools/go/callgraph/vta`); every `*cobra.Command`-returning func is a root, plus `<init>` and one `<main:pkg>`; reports exclusive vs shared LOC per root and declarations no root reaches. Its precision policies (`-maxfanout` cutoff for unresolved dynamic calls, closures only via their creator, generic instantiations rolled up to their origin) are documented at the top of the file; `-who <substr>` explains why a symbol is or isn't reached |
 | `dupl/main.go` | rolls a golangci-lint `dupl` JSON report up by feature. golangci reports `Pos.Filename` relative to its **config file's** directory while the path quoted in the issue text is repo-relative, so `-base` (default: the working directory) says what the former resolves against and each path is resolved against whichever base names a file that exists |
-| `internal/cx/` | the one home of the feature mapping (rule matching, rank policy), module-path reading, and CSV writing — shared by all three binaries |
+| `gate/main.go` | the CI check. Reads the CSVs the others write, by header name rather than column position. Blocking mode diffs two `functions.csv` files and fails on functions that are both over `-cognit-warn` and new or worsened; advisory mode compares `features.csv` coverage against a committed baseline and never fails. See "CI gate" below |
+| `internal/cx/` | the one home of the feature mapping (rule matching, rank policy), module-path reading, and CSV writing — shared by all four binaries |
 | `features.json` | path → feature rules, resolved in three ordered steps, first match winning: a rule naming the exact path (so an explicit `_test.go` rule always wins); then, for a test file, its source name (`foo_test.go` → `foo.go`) so tests follow their source; then globs and `dir/` prefixes. Exact paths beat globs regardless of list order — otherwise a broad rule like `setup*.go` silently absorbs a later one naming `setup_import.go`, and the file lands in a plausible wrong feature instead of in `_unmapped`, where nothing reports it. A pattern `path.Match` cannot parse is rejected at load rather than matching nothing. `norank: true` keeps a feature out of rankings and headline totals while still measuring it. Edit this when a command family moves; unmapped files are reported and counted in `report.json` meta |
 | `render.py` | renders the HTML report from `report.json` + `reach.json` + `dupl-by-feature.json`. Its "Reading the numbers" section is snapshot-bound interpretation and says so |
 | `dupl-config.yaml` | golangci config for the duplication scan (same recipe as `mise run dup`) |
@@ -57,6 +58,45 @@ rendered page labels itself from data.
 Outputs: `report.md` (human summary), `features.csv` / `areas.csv` /
 `packages.csv` / `files.csv` / `functions.csv` (diffable tables), `report.json`
 (everything, including meta), `reach.md` / `commands.csv` / `reach.json`.
+
+## CI gate
+
+`gate/` turns these tables into a check. It has two modes with opposite failure semantics, and they are separate invocations for that reason.
+
+### What blocks
+
+The `complexity-gate` job in `.github/workflows/ci.yml` runs on every pull request and fails it when a function is over cognitive complexity 30 **and** is new or worse than at the merge base. A function that is over the threshold and did not move does not fail: the tree has 105 of those, and a gate that fired on all of them would be switched off within a week. The three failing shapes are a function absent from the base tree (so a moved or renamed file counts as entirely new — the identity is file plus function name, since the CSVs carry no stable symbol ID), a function whose base complexity was within the threshold, and a function that grew.
+
+Locally, the same comparison:
+
+```sh
+mise run complexity:gate                          # working tree vs the merge base with origin/main
+BASE_REF=origin/some-branch mise run complexity:gate
+COGNIT_WARN=25 mise run complexity:gate
+```
+
+It builds the head tree's `cxtool` and `gate`, exports the merge-base tree with `git archive`, and runs `cxtool` over both — deliberately with no `-cover` and no churn window, which keeps each run to about a second. Both sides are measured by the *head* version of the tool and of `features.json`, so a change to `cxtool` itself never reads as a change in complexity.
+
+This is deliberately **not** the `gocognit` linter. golangci-lint has no per-linter new-only mode: enabling `gocognit` in `.golangci.yaml` would fail `mise run lint` locally on all 105 pre-existing violations, and the alternative — `only-new-issues: true` on the golangci-lint action — is workflow-wide, so it would silently flip every other linter to new-only in CI as well. The threshold lives in the gate's flags (`-cognit-warn`, `COGNIT_WARN`), not in `.golangci.yaml`.
+
+### What advises
+
+The second mode compares each ranked feature's statement coverage against a committed baseline snapshot and reports drops past a tolerance. It never fails: it exits 0 on a finding, and exits 0 even when it cannot read its inputs (emitting a `::warning::` instead), because the snapshot is one commit's numbers and goes stale as the tree moves — features get renamed, files change hands, suites get resharded.
+
+```sh
+# after taking coverage profiles as in "Run" above
+go run . -root ../.. -cover /tmp/cx/unit.out,/tmp/cx/int.out -out /tmp/cx/all
+go run ./gate -features /tmp/cx/all/features.csv \
+  -baseline baseline/2026-08-31/features.csv -cov-drop 2.0 -min-stmts 300
+```
+
+`-min-stmts` skips small features, whose coverage swings several points on one helper, and unranked features (test infrastructure, generated code) are skipped along with any feature missing from either side or without a coverage figure.
+
+This half is **not wired into CI yet**, and wiring it needs a decision first: the profiles the CI test jobs could produce are not comparable with the committed baseline. `mise run test:ci:core` runs with `-tags=integration -race` over every package but `integration_test`, and the three `test:ci:integration:shard` jobs cover that one package under `-run` filters; the baseline's `cov_pct` column came from the untagged, unraced two-command recipe in "Run" above. Feeding CI's profiles into a comparison against this baseline would report the recipe change as a coverage regression on the first run. The two ways out are to refresh the baseline with the CI recipe (and keep the two in step from then on), or to give the advisory its own non-blocking job that reproduces the documented recipe — which costs a duplicate coverage run but keeps the numbers apples-to-apples and keeps instrumentation off the blocking test path.
+
+### Refreshing the baseline
+
+Refreshing `baseline/<date>/` is manual and meant to be deliberate: it is the reference the coverage advisory measures against, so re-taking it silently accepts whatever has drifted since. Take a new dated directory (following the "Run" recipe, then copying in `report.md`, the four rollup CSVs, `dupl-by-feature.json`, and a `COMMIT` file naming the tree), and say in the pull request what moved and why that is acceptable. The blocking half needs none of this — it always diffs against the merge base, so it cannot go stale.
 
 ## Reading the numbers
 

--- a/tools/complexity/gate/main.go
+++ b/tools/complexity/gate/main.go
@@ -1,0 +1,424 @@
+// gate turns the cxtool tables into a CI check. It has two modes, and they
+// are deliberately separate invocations because their failure semantics are
+// opposites.
+//
+// Complexity diff (blocking):
+//
+//	gate -base out/base -head out/head [-cognit-warn 30]
+//
+// Each directory is a cxtool output directory (it needs only functions.csv).
+// The gate fails when a function in head is over the threshold *and* is new or
+// worse than it was at base. A function that is over the threshold and
+// unchanged does not fail: this repo has a long tail of those, and a gate that
+// fired on them would only ever be switched off.
+//
+// Coverage advisory (never blocking):
+//
+//	gate -features out/head/features.csv -baseline baseline/<date>/features.csv
+//	     [-cov-drop 2.0] [-min-stmts 300]
+//
+// Compares each ranked feature's statement coverage against a committed
+// snapshot and warns on a drop past the tolerance. The snapshot goes stale as
+// the tree moves — features are renamed, files change hands, suites are
+// resharded — so this half reports and never fails. It exits 0 even when it
+// cannot read its inputs, emitting a warning annotation instead, so a stale
+// path in the workflow can never redden a pull request.
+package main
+
+import (
+	"encoding/csv"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"cxtool/internal/cx"
+)
+
+func main() {
+	base := flag.String("base", "", "cxtool output directory for the base tree (holds functions.csv); with -head, runs the blocking complexity diff")
+	head := flag.String("head", "", "cxtool output directory for the head tree (holds functions.csv); with -base, runs the blocking complexity diff")
+	cognitWarn := flag.Int("cognit-warn", 30, "cognitive complexity a function may not exceed once it is new or worsened")
+	features := flag.String("features", "", "features.csv from the head tree; with -baseline, runs the advisory coverage comparison")
+	baseline := flag.String("baseline", "", "committed baseline features.csv to compare against; with -features, runs the advisory coverage comparison")
+	covDrop := flag.Float64("cov-drop", 2.0, "coverage percentage points a feature may lose against the baseline before it is reported")
+	minStmts := flag.Int("min-stmts", 300, "ignore features with fewer than this many statements in the head tree; small features swing on a handful of lines")
+	flag.Usage = usage
+	flag.Parse()
+
+	diff := *base != "" || *head != ""
+	cov := *features != "" || *baseline != ""
+	switch {
+	case diff && cov:
+		cx.Check(errors.New("-base/-head and -features/-baseline are separate modes; run one at a time"))
+	case diff:
+		if *base == "" || *head == "" {
+			cx.Check(errors.New("the complexity diff needs both -base and -head"))
+		}
+		os.Exit(complexityDiff(os.Stdout, *base, *head, *cognitWarn))
+	case cov:
+		if *features == "" || *baseline == "" {
+			cx.Check(errors.New("the coverage advisory needs both -features and -baseline"))
+		}
+		coverageAdvisory(os.Stdout, *features, *baseline, *covDrop, *minStmts)
+	default:
+		flag.Usage()
+		os.Exit(2)
+	}
+}
+
+func usage() {
+	out := flag.CommandLine.Output()
+	fmt.Fprintf(out, `gate — CI gates over the cxtool tables.
+
+Complexity diff (exits 1 on a finding):
+  gate -base <dir> -head <dir> [-cognit-warn N]
+
+    Each <dir> is a cxtool output directory; only functions.csv is read. A
+    function fails the gate when its head cognitive complexity is above
+    -cognit-warn AND it is new (no function of that name in that file at base,
+    so a moved or renamed file counts as entirely new), or its base complexity
+    was within the threshold, or it grew. Pre-existing violations that did not
+    move do not fail.
+
+Coverage advisory (always exits 0):
+  gate -features <features.csv> -baseline <features.csv> [-cov-drop F] [-min-stmts N]
+
+    Reports ranked features whose statement coverage fell more than -cov-drop
+    points below the committed baseline. Advisory because the baseline is a
+    snapshot of one commit and drifts as the tree moves. Unreadable inputs are
+    reported as warnings, not failures.
+
+Flags:
+`)
+	flag.PrintDefaults()
+}
+
+// ---------- complexity diff ----------
+
+// FuncMetric is one functions.csv row, reduced to what the diff compares.
+type FuncMetric struct {
+	File   string
+	Name   string
+	Start  int
+	Cognit int
+}
+
+// key identifies a function across two trees. File plus name is the whole
+// identity available in the CSVs: there are no stable symbol IDs, and line
+// numbers move for reasons that have nothing to do with complexity. The cost
+// is that renaming a file re-reports every over-threshold function in it as
+// new, which is the safe direction for a gate to be wrong in.
+func (f FuncMetric) key() string { return f.File + "\x00" + f.Name }
+
+// Offender is a function the diff gate refuses.
+type Offender struct {
+	FuncMetric
+	Base    int  // base complexity
+	IsNew   bool // no counterpart at base, so Base is meaningless
+	Comment string
+}
+
+// findOffenders returns the functions in head that are over the limit and
+// either absent from base, within the limit at base, or worse than at base.
+//
+// Sorted worst-first, then by file and line, so the annotation order is
+// stable across runs and platforms.
+func findOffenders(base, head []FuncMetric, limit int) []Offender {
+	prev := make(map[string]int, len(base))
+	for _, f := range base {
+		// Duplicate keys cannot arise from a compiling package, but if one
+		// ever does, keeping the highest complexity makes the gate lenient
+		// rather than firing on an ambiguity we cannot resolve.
+		if old, ok := prev[f.key()]; !ok || f.Cognit > old {
+			prev[f.key()] = f.Cognit
+		}
+	}
+	var out []Offender
+	for _, f := range head {
+		if f.Cognit <= limit {
+			continue
+		}
+		was, existed := prev[f.key()]
+		switch {
+		case !existed:
+			out = append(out, Offender{FuncMetric: f, IsNew: true, Comment: "new function"})
+		case was <= limit:
+			out = append(out, Offender{FuncMetric: f, Base: was, Comment: fmt.Sprintf("was %d, within the limit", was)})
+		case f.Cognit > was:
+			out = append(out, Offender{FuncMetric: f, Base: was, Comment: fmt.Sprintf("grew from %d", was)})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.Cognit != b.Cognit {
+			return a.Cognit > b.Cognit
+		}
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Start != b.Start {
+			return a.Start < b.Start
+		}
+		return a.Name < b.Name
+	})
+	return out
+}
+
+// complexityDiff reads both trees, reports, and returns the process exit code.
+func complexityDiff(w io.Writer, baseDir, headDir string, limit int) int {
+	base, err := readFuncs(baseDir)
+	cx.Check(err)
+	head, err := readFuncs(headDir)
+	cx.Check(err)
+
+	offenders := findOffenders(base, head, limit)
+	if len(offenders) == 0 {
+		fmt.Fprintf(w, "complexity gate: no new or worsened function over cognitive complexity %d (%d functions compared against %d)\n", limit, len(head), len(base))
+		return 0
+	}
+
+	for _, o := range offenders {
+		wasNote := strconv.Itoa(o.Base)
+		if o.IsNew {
+			wasNote = "new"
+		}
+		msg := fmt.Sprintf("function %s cognitive complexity %d (limit %d, base %s)", o.Name, o.Cognit, limit, wasNote)
+		fmt.Fprintf(w, "::error file=%s,line=%d::%s\n", escapeProperty(o.File), o.Start, escapeData(msg))
+	}
+
+	fmt.Fprintf(w, "\ncomplexity gate: %d function(s) exceed cognitive complexity %d and are new or worsened:\n\n", len(offenders), limit)
+	for _, o := range offenders {
+		fmt.Fprintf(w, "  %3d  %s:%d  %s  (%s)\n", o.Cognit, o.File, o.Start, o.Name, o.Comment)
+	}
+	fmt.Fprintf(w, "\nSplit the function, or lower its nesting. Pre-existing violations are exempt;\nthis fires only on code this change added or made harder to read.\n")
+	return 1
+}
+
+// ---------- coverage advisory ----------
+
+// FeatureCoverage is one features.csv row, reduced to what the advisory reads.
+type FeatureCoverage struct {
+	Name   string
+	Ranked bool
+	Stmts  int
+	CovPct float64 // -1 when the feature has no statements ("n/a" in the CSV)
+}
+
+// CovRegression is one feature that lost more coverage than the tolerance.
+type CovRegression struct {
+	Feature string
+	Base    float64
+	Head    float64
+	Stmts   int
+}
+
+// findCovRegressions compares ranked features present in both tables. A
+// feature is skipped when it is unranked (test infrastructure and generated
+// code, which the mapping excludes from headline numbers), when either side
+// has no coverage figure, or when the head side is smaller than minStmts —
+// coverage on a small feature swings several points on a single helper.
+func findCovRegressions(baseline, head []FeatureCoverage, drop float64, minStmts int) []CovRegression {
+	was := make(map[string]FeatureCoverage, len(baseline))
+	for _, f := range baseline {
+		was[f.Name] = f
+	}
+	var out []CovRegression
+	for _, f := range head {
+		if !f.Ranked || f.Stmts < minStmts || f.CovPct < 0 {
+			continue
+		}
+		b, ok := was[f.Name]
+		if !ok || b.CovPct < 0 {
+			continue
+		}
+		if f.CovPct < b.CovPct-drop {
+			out = append(out, CovRegression{Feature: f.Name, Base: b.CovPct, Head: f.CovPct, Stmts: f.Stmts})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if la, lb := a.Base-a.Head, b.Base-b.Head; la != lb {
+			return la > lb
+		}
+		return a.Feature < b.Feature
+	})
+	return out
+}
+
+// coverageAdvisory reports and returns nothing: this mode never fails a build,
+// so even a read error is a warning annotation rather than an exit code.
+func coverageAdvisory(w io.Writer, featuresCSV, baselineCSV string, drop float64, minStmts int) {
+	head, err := readFeatures(featuresCSV)
+	if err != nil {
+		warnUnreadable(w, err)
+		return
+	}
+	baseline, err := readFeatures(baselineCSV)
+	if err != nil {
+		warnUnreadable(w, err)
+		return
+	}
+
+	regressions := findCovRegressions(baseline, head, drop, minStmts)
+	if len(regressions) == 0 {
+		fmt.Fprintf(w, "coverage advisory: no ranked feature lost more than %.1f points against %s\n", drop, baselineCSV)
+		return
+	}
+
+	for _, r := range regressions {
+		msg := fmt.Sprintf("feature %s statement coverage %.1f%%, down %.1f points from %.1f%% at the baseline (%d statements)", r.Feature, r.Head, r.Base-r.Head, r.Base, r.Stmts)
+		fmt.Fprintf(w, "::warning::%s\n", escapeData(msg))
+	}
+
+	var md strings.Builder
+	fmt.Fprintf(&md, "### Coverage advisory\n\n")
+	fmt.Fprintf(&md, "%d ranked feature(s) lost more than %.1f points of statement coverage against `%s`. This does not block the build: the baseline is a snapshot of one commit and drifts as the tree moves.\n\n", len(regressions), drop, baselineCSV)
+	fmt.Fprintf(&md, "| feature | baseline | head | delta | statements |\n| --- | --: | --: | --: | --: |\n")
+	for _, r := range regressions {
+		fmt.Fprintf(&md, "| %s | %.1f%% | %.1f%% | -%.1f | %d |\n", r.Feature, r.Base, r.Head, r.Base-r.Head, r.Stmts)
+	}
+	fmt.Fprint(w, md.String())
+	if err := appendStepSummary(md.String()); err != nil {
+		warnUnreadable(w, err)
+	}
+}
+
+func warnUnreadable(w io.Writer, err error) {
+	fmt.Fprintf(w, "::warning::coverage advisory skipped: %s\n", escapeData(err.Error()))
+}
+
+// appendStepSummary appends to the GitHub step summary when running under
+// Actions, and does nothing anywhere else.
+func appendStepSummary(md string) error {
+	p := os.Getenv("GITHUB_STEP_SUMMARY")
+	if p == "" {
+		return nil
+	}
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("step summary: %w", err)
+	}
+	if _, err := io.WriteString(f, "\n"+md); err != nil {
+		f.Close()
+		return fmt.Errorf("step summary: %w", err)
+	}
+	return f.Close()
+}
+
+// ---------- CSV reading ----------
+
+// readCSV returns the rows of a CSV keyed by header name, so a column added or
+// reordered upstream in cxtool does not silently shift the values this gate
+// reads.
+func readCSV(path string, want ...string) ([]map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	r := csv.NewReader(f)
+	rows, err := r.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("%s: empty", path)
+	}
+	idx := map[string]int{}
+	for i, h := range rows[0] {
+		idx[h] = i
+	}
+	for _, h := range want {
+		if _, ok := idx[h]; !ok {
+			return nil, fmt.Errorf("%s: no %q column", path, h)
+		}
+	}
+	out := make([]map[string]string, 0, len(rows)-1)
+	for _, row := range rows[1:] {
+		m := make(map[string]string, len(want))
+		for _, h := range want {
+			if i := idx[h]; i < len(row) {
+				m[h] = row[i]
+			}
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+func readFuncs(dir string) ([]FuncMetric, error) {
+	path := filepath.Join(dir, "functions.csv")
+	rows, err := readCSV(path, "file", "func", "start", "cognit")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]FuncMetric, 0, len(rows))
+	for _, m := range rows {
+		start, err := strconv.Atoi(m["start"])
+		if err != nil {
+			return nil, fmt.Errorf("%s: bad start %q: %w", path, m["start"], err)
+		}
+		cognit, err := strconv.Atoi(m["cognit"])
+		if err != nil {
+			return nil, fmt.Errorf("%s: bad cognit %q: %w", path, m["cognit"], err)
+		}
+		out = append(out, FuncMetric{File: m["file"], Name: m["func"], Start: start, Cognit: cognit})
+	}
+	return out, nil
+}
+
+func readFeatures(path string) ([]FeatureCoverage, error) {
+	rows, err := readCSV(path, "name", "ranked", "stmts", "cov_pct")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]FeatureCoverage, 0, len(rows))
+	for _, m := range rows {
+		stmts, err := strconv.Atoi(m["stmts"])
+		if err != nil {
+			return nil, fmt.Errorf("%s: bad stmts %q: %w", path, m["stmts"], err)
+		}
+		out = append(out, FeatureCoverage{
+			Name:   m["name"],
+			Ranked: m["ranked"] == "true",
+			Stmts:  stmts,
+			CovPct: parsePct(m["cov_pct"]),
+		})
+	}
+	return out, nil
+}
+
+// parsePct mirrors cxtool's pct(), which writes "n/a" for a feature with no
+// statements. Anything unparseable is treated the same way — as no figure —
+// because the advisory's only response to a missing number is to skip.
+func parsePct(s string) float64 {
+	v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return -1
+	}
+	return v
+}
+
+// ---------- annotations ----------
+
+// escapeData and escapeProperty apply GitHub's workflow-command escaping. Our
+// own paths and identifiers do not currently need it; the encoding is applied
+// anyway so a message that one day carries a percent sign or a newline cannot
+// truncate or forge an annotation.
+func escapeData(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	return strings.ReplaceAll(s, "\n", "%0A")
+}
+
+func escapeProperty(s string) string {
+	s = escapeData(s)
+	s = strings.ReplaceAll(s, ":", "%3A")
+	return strings.ReplaceAll(s, ",", "%2C")
+}

--- a/tools/complexity/gate/main_test.go
+++ b/tools/complexity/gate/main_test.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func fn(file, name string, start, cognit int) FuncMetric {
+	return FuncMetric{File: file, Name: name, Start: start, Cognit: cognit}
+}
+
+// TestFindOffenders pins the whole decision table: what the gate fires on, and
+// — the half that decides whether anyone leaves it switched on — what it lets
+// through.
+func TestFindOffenders(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		base  []FuncMetric
+		head  []FuncMetric
+		limit int
+		// want is "file:func=headCognit/base", base being "new" for a
+		// function absent from the base tree.
+		want []string
+	}{
+		{
+			name:  "new function over the limit fails",
+			base:  nil,
+			head:  []FuncMetric{fn("a.go", "F", 10, 31)},
+			limit: 30,
+			want:  []string{"a.go:F=31/new"},
+		},
+		{
+			name:  "new function at the limit passes",
+			head:  []FuncMetric{fn("a.go", "F", 10, 30)},
+			limit: 30,
+		},
+		{
+			name:  "pre-existing violation left alone passes",
+			base:  []FuncMetric{fn("a.go", "F", 10, 80)},
+			head:  []FuncMetric{fn("a.go", "F", 40, 80)},
+			limit: 30,
+		},
+		{
+			name:  "pre-existing violation that grew fails",
+			base:  []FuncMetric{fn("a.go", "F", 10, 80)},
+			head:  []FuncMetric{fn("a.go", "F", 10, 81)},
+			limit: 30,
+			want:  []string{"a.go:F=81/80"},
+		},
+		{
+			name:  "pre-existing violation that shrank but stayed over passes",
+			base:  []FuncMetric{fn("a.go", "F", 10, 80)},
+			head:  []FuncMetric{fn("a.go", "F", 10, 79)},
+			limit: 30,
+		},
+		{
+			name:  "function pushed over the limit fails",
+			base:  []FuncMetric{fn("a.go", "F", 10, 30)},
+			head:  []FuncMetric{fn("a.go", "F", 10, 31)},
+			limit: 30,
+			want:  []string{"a.go:F=31/30"},
+		},
+		{
+			name:  "growth that stays within the limit passes",
+			base:  []FuncMetric{fn("a.go", "F", 10, 3)},
+			head:  []FuncMetric{fn("a.go", "F", 10, 29)},
+			limit: 30,
+		},
+		{
+			name:  "same name in another file is a different function",
+			base:  []FuncMetric{fn("a.go", "F", 10, 80)},
+			head:  []FuncMetric{fn("b.go", "F", 10, 80)},
+			limit: 30,
+			want:  []string{"b.go:F=80/new"},
+		},
+		{
+			name:  "methods are distinguished by receiver",
+			base:  []FuncMetric{fn("a.go", "T.F", 10, 80), fn("a.go", "U.F", 90, 5)},
+			head:  []FuncMetric{fn("a.go", "T.F", 10, 80), fn("a.go", "U.F", 90, 40)},
+			limit: 30,
+			want:  []string{"a.go:U.F=40/5"},
+		},
+		{
+			name:  "a raised limit forgives what a lower one would catch",
+			base:  []FuncMetric{fn("a.go", "F", 10, 30)},
+			head:  []FuncMetric{fn("a.go", "F", 10, 45)},
+			limit: 50,
+		},
+		{
+			name: "worst first, then file, then line",
+			head: []FuncMetric{
+				fn("b.go", "Mid", 5, 40),
+				fn("a.go", "Tie2", 90, 35),
+				fn("a.go", "Tie1", 10, 35),
+				fn("c.go", "Worst", 1, 99),
+			},
+			limit: 30,
+			want:  []string{"c.go:Worst=99/new", "b.go:Mid=40/new", "a.go:Tie1=35/new", "a.go:Tie2=35/new"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := offenderKeys(findOffenders(tc.base, tc.head, tc.limit))
+			if strings.Join(got, " ") != strings.Join(tc.want, " ") {
+				t.Fatalf("findOffenders = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func offenderKeys(offs []Offender) []string {
+	out := make([]string, 0, len(offs))
+	for _, o := range offs {
+		was := "new"
+		if !o.IsNew {
+			was = strconv.Itoa(o.Base)
+		}
+		out = append(out, o.File+":"+o.Name+"="+strconv.Itoa(o.Cognit)+"/"+was)
+	}
+	return out
+}
+
+func feat(name string, ranked bool, stmts int, cov float64) FeatureCoverage {
+	return FeatureCoverage{Name: name, Ranked: ranked, Stmts: stmts, CovPct: cov}
+}
+
+// TestFindCovRegressions pins the advisory's skip rules, which are the whole
+// reason it is advisory: everything it cannot compare fairly it declines to
+// compare at all.
+func TestFindCovRegressions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		baseline  []FeatureCoverage
+		head      []FeatureCoverage
+		drop      float64
+		minStmts  int
+		wantFeats []string
+	}{
+		{
+			name:      "drop past the tolerance is reported",
+			baseline:  []FeatureCoverage{feat("f", true, 500, 80)},
+			head:      []FeatureCoverage{feat("f", true, 500, 77.9)},
+			drop:      2,
+			minStmts:  300,
+			wantFeats: []string{"f"},
+		},
+		{
+			name:     "drop inside the tolerance is not",
+			baseline: []FeatureCoverage{feat("f", true, 500, 80)},
+			head:     []FeatureCoverage{feat("f", true, 500, 78)},
+			drop:     2,
+			minStmts: 300,
+		},
+		{
+			name:     "a gain is not",
+			baseline: []FeatureCoverage{feat("f", true, 500, 80)},
+			head:     []FeatureCoverage{feat("f", true, 500, 91)},
+			drop:     2,
+			minStmts: 300,
+		},
+		{
+			name:     "unranked features are skipped",
+			baseline: []FeatureCoverage{feat("test-infra", false, 500, 80)},
+			head:     []FeatureCoverage{feat("test-infra", false, 500, 10)},
+			drop:     2,
+			minStmts: 300,
+		},
+		{
+			name:     "features under min-stmts are skipped",
+			baseline: []FeatureCoverage{feat("f", true, 500, 80)},
+			head:     []FeatureCoverage{feat("f", true, 299, 10)},
+			drop:     2,
+			minStmts: 300,
+		},
+		{
+			name:     "a feature absent from the baseline is skipped",
+			baseline: nil,
+			head:     []FeatureCoverage{feat("f", true, 500, 10)},
+			drop:     2,
+			minStmts: 300,
+		},
+		{
+			name:     "a feature dropped from head is skipped",
+			baseline: []FeatureCoverage{feat("f", true, 500, 80)},
+			head:     nil,
+			drop:     2,
+			minStmts: 300,
+		},
+		{
+			name:     "n/a on either side is skipped",
+			baseline: []FeatureCoverage{feat("a", true, 500, -1), feat("b", true, 500, 80)},
+			head:     []FeatureCoverage{feat("a", true, 500, 10), feat("b", true, 500, -1)},
+			drop:     2,
+			minStmts: 300,
+		},
+		{
+			// b and d tie on a 10-point drop and are ordered by name; c's
+			// 25 beats a's 20, so the head of the list is not alphabetical.
+			name:      "biggest drop first, then by name",
+			baseline:  []FeatureCoverage{feat("a", true, 500, 80), feat("b", true, 500, 80), feat("c", true, 500, 95), feat("d", true, 500, 80)},
+			head:      []FeatureCoverage{feat("a", true, 500, 60), feat("b", true, 500, 70), feat("c", true, 500, 70), feat("d", true, 500, 70)},
+			drop:      2,
+			minStmts:  300,
+			wantFeats: []string{"c", "a", "b", "d"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got []string
+			for _, r := range findCovRegressions(tc.baseline, tc.head, tc.drop, tc.minStmts) {
+				got = append(got, r.Feature)
+			}
+			if strings.Join(got, " ") != strings.Join(tc.wantFeats, " ") {
+				t.Fatalf("findCovRegressions = %v, want %v", got, tc.wantFeats)
+			}
+		})
+	}
+}
+
+func TestParsePct(t *testing.T) {
+	t.Parallel()
+	for in, want := range map[string]float64{"77.3": 77.3, "0.0": 0, "n/a": -1, "": -1, " 12.5 ": 12.5} {
+		if got := parsePct(in); got != want {
+			t.Errorf("parsePct(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// TestEscapeAnnotation guards the two encodings a workflow command needs; a
+// raw newline in a message would otherwise end the annotation early and let
+// the rest of the text be read as a fresh command.
+func TestEscapeAnnotation(t *testing.T) {
+	t.Parallel()
+	if got, want := escapeData("100% done\nnext"), "100%25 done%0Anext"; got != want {
+		t.Errorf("escapeData = %q, want %q", got, want)
+	}
+	if got, want := escapeProperty("a:b,c.go"), "a%3Ab%2Cc.go"; got != want {
+		t.Errorf("escapeProperty = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1281
<!-- entire-trail-link-end -->

Implements the two CI follow-ups #2194 flagged when `tools/complexity/` landed: gate new complexity so it cannot accumulate silently, and compare per-feature coverage against the committed baseline. The complexity half ships blocking; the coverage half ships as a working, tested mode that is deliberately not wired into CI yet, for a reason measured below.

## 1. Gating new complexity — a cxtool diff, not the gocognit linter

`gate -base <dir> -head <dir>` compares two cxtool output directories and fails only on functions that are over cognitive complexity 30 **and** new or worse than at the merge base. Three shapes fail: a function absent from the base tree, a function whose base complexity was within the threshold, and a function that grew. A function that is over the threshold and did not move does not fail.

That last exemption is the whole design. **This tree has 105 functions over cognitive complexity 30** (of 6,606 total; 250 are over 20, 48 over 40, 17 over 50 — measured with `cd tools/complexity && go run . -root ../.. -out /tmp/cx`, counting `functions.csv` rows). The worst is `newSearchCmd` at 105, then `handleLifecycleTurnEnd` at 83.

**Why not just enable `gocognit` in `.golangci.yaml`.** golangci-lint has no per-linter new-only mode. Enabling `gocognit` would fail `mise run lint` locally on all 105 of those, immediately, with no way to scope the leniency to that one linter. The alternative — `only-new-issues: true` on the golangci-lint action — is workflow-wide, so it would silently flip **every** linter in CI to new-only semantics, which is a much larger change than this one and in the wrong direction. So `.golangci.yaml` and `lint.yml` are untouched, and the threshold lives in the gate's own flags (`-cognit-warn`, `COGNIT_WARN=25 mise run complexity:gate`).

Function identity across the two trees is file plus function name — the whole identity the CSVs carry, since there are no stable symbol IDs and line numbers move for reasons unrelated to complexity. The cost is that renaming a file re-reports every over-threshold function in it as new; that is the safe direction for a gate to be wrong in, and `-h` says so.

CI runs it as a `complexity-gate` job on pull requests only (a push to main has no merge base to diff against; the aggregate `test` job accepts `skipped` for it so main and `workflow_dispatch` stay green). One script serves CI and the developer, so what fails in a PR is exactly what `mise run complexity:gate` fails locally.

**Two deviations from the brief, both deliberate.** The base tree is exported with `git archive` rather than `git worktree add`: the task is meant to be run from a dirty working tree, an export leaves nothing in the repo's worktree list to clean up if it is interrupted, and — the deciding factor — I could actually verify it end to end, whereas the worktree path was unrunnable from this agent's isolated worktree. The repo has no `.gitattributes`, so the export is a faithful copy. And the job sets Go up with `jdx/mise-action` rather than `actions/setup-go` + `go-version-file`, matching the two sibling jobs in `ci.yml` that run mise tasks; `mise.toml` pins the same Go version as `go.mod` and carries a comment saying to keep them aligned.

## 2. Per-feature coverage — advisory, and the CI wiring is the remaining step

`gate -features <head features.csv> -baseline <committed features.csv> -cov-drop 2.0 -min-stmts 300` reports ranked features whose statement coverage fell past the tolerance, as `::warning::` annotations plus a markdown table into `$GITHUB_STEP_SUMMARY`. It exits 0 on a finding, and exits 0 even when it cannot read its inputs (emitting a warning instead of an error), so it can never redden a pull request. Advisory-first because a committed baseline is one commit's numbers and goes stale as the tree moves — features get renamed, files change hands, suites get resharded — and a hard gate on a drifting reference produces false positives that get it switched off. The escalation path is to make it blocking once the numbers have been stable across a few refreshes, at which point the tolerance is the knob to argue about, not the mechanism.

**I stopped short of wiring it into CI, and the reason is comparability rather than diff size.** The brief's plan was to add `-coverprofile` to `test:ci:core` and the three `test:ci:integration:shard` jobs, upload the profiles, and merge them in a dependent job. Reading those tasks: `test:ci:core` runs `go test -tags=integration -race` over every package except `integration_test`, and the shards run that one package under `-run` filters. The committed baseline's `cov_pct` column came from the recipe in `tools/complexity/README.md` — two untagged, unraced `go test -coverprofile -coverpkg=./...` invocations. Those are different measurements of the same tree: `-tags=integration` on the core job pulls in integration-tagged files in ordinary packages that the baseline recipe never compiled. Feeding CI's profiles into a comparison against this baseline would have reported the recipe change as a coverage regression on the very first run, on an unknown number of features — the exact false-positive failure the advisory-first decision exists to avoid — and it would have put `-coverpkg=./...` instrumentation on the critical path of the two blocking test jobs to do it.

So the two ways forward, both written up in the README rather than left as tribal knowledge: refresh the baseline with the CI recipe and keep the two in step from then on, or give the advisory its own non-blocking job that reproduces the documented recipe (a duplicate coverage run, but apples-to-apples numbers and no instrumentation on the blocking path). That is a product call about which recipe is the reference, so I have not made it silently. The mode itself is built, table-driven tested, and documented as runnable locally today.

Refreshing `baseline/<date>/` stays manual and deliberate — it is the reference the advisory measures against, so re-taking it silently accepts whatever has drifted. The blocking half needs none of that: it always diffs against the merge base, so it cannot go stale.

## Gate proof

Base = `origin/main` (exported with `git archive`), head = this branch. Zero offenders, because the 105 pre-existing violations did not move:

```
$ /tmp/gate/cxtool -root /tmp/gate/basetree -churn-days '' -out /tmp/gate/base
$ /tmp/gate/cxtool -root ../..              -churn-days '' -out /tmp/gate/head
$ /tmp/gate/gate -base /tmp/gate/base -head /tmp/gate/head; echo "exit=$?"
complexity gate: no new or worsened function over cognitive complexity 30 (6606 functions compared against 6606)
exit=0
```

Then a throwaway copy of the `origin/main` tree with two synthetic worsenings — a new function planted in `status_style.go`, and extra nesting injected into `writeActiveSessions`, which is already a pre-existing violation at 53 and so proves the "grew" branch rather than the "new" one:

```
$ /tmp/gate/cxtool -root /tmp/gate/worsetree -churn-days '' -out /tmp/gate/worse
$ /tmp/gate/gate -base /tmp/gate/base -head /tmp/gate/worse; echo "exit=$?"
::error file=cmd/entire/cli/status_style.go,line=296::function gateProbeNewFunction cognitive complexity 85 (limit 30, base new)
::error file=cmd/entire/cli/status.go,line=517::function writeActiveSessions cognitive complexity 68 (limit 30, base 53)

complexity gate: 2 function(s) exceed cognitive complexity 30 and are new or worsened:

   85  cmd/entire/cli/status_style.go:296  gateProbeNewFunction  (new function)
   68  cmd/entire/cli/status.go:517  writeActiveSessions  (grew from 53)

Split the function, or lower its nesting. Pre-existing violations are exempt;
this fires only on code this change added or made harder to read.
exit=1
```

And the same worsening through the real entry point, planted in the working tree so the mise task's own merge-base resolution and tree export are exercised (reverted afterwards):

```
$ mise run complexity:gate
complexity gate: HEAD vs 0138471ae (merge base with origin/main)
::error file=cmd/entire/cli/status.go,line=517::function writeActiveSessions cognitive complexity 68 (limit 30, base 53)
...
[complexity:gate] ERROR task failed
```

Advisory mode, against `baseline/2026-08-31/features.csv` with a synthetic head that knocks 6.3 points off one feature and 1.2 off another (the second is inside the tolerance and correctly silent), plus the unreadable-input case:

```
$ GITHUB_STEP_SUMMARY=/tmp/gate/summary.md /tmp/gate/gate -features /tmp/gate/synthetic-features.csv \
    -baseline tools/complexity/baseline/2026-08-31/features.csv; echo "exit=$?"
::warning::feature capture:strategy statement coverage 71.0%25, down 6.3 points from 77.3%25 at the baseline (6661 statements)
### Coverage advisory
...
| capture:strategy | 77.3% | 71.0% | -6.3 | 6661 |
exit=0

$ /tmp/gate/gate -features /tmp/gate/head/features.csv -baseline /tmp/gate/nope.csv; echo "exit=$?"
::warning::coverage advisory skipped: open /tmp/gate/nope.csv: no such file or directory
exit=0
```

(`%25` is GitHub's required escaping for `%` inside a workflow command; it renders as `%` in the PR UI, and the markdown table below it is the human-readable form.)

## Verification

- `cd tools/complexity && gofmt -s -l . && go vet ./... && go test ./... && go build ./...` — all clean. `cxtool/gate` is the second test package in the module, alongside `cxtool/internal/cx`; the comparison logic in both modes is table-driven, and most of the cases assert what must **not** fire.
- From the repo root: `go list ./... | grep -c tools` → `0`, so the nested module still stays out of the CLI's build. `mise run fmt` changed nothing; `mise run lint` → `0 issues` (`lint:go`, `lint:gofmt`, `lint:gomod`, `lint:mise`, `lint:shellcheck` all pass, the last covering the new `mise-tasks/complexity/gate`).
- No root-module Go files are touched — the diff outside `tools/` is one workflow file, one mise task, and two docs — so `mise run test:ci` was not required.
- **Workflow validation:** `actionlint` v1.7.12 (installed for this) passes clean on `.github/workflows/ci.yml`, and so does `origin/main`'s copy, so there is no pre-existing noise being masked. The findings it reports elsewhere in `.github/workflows/` (`e2e*.yml`, `release.yml`) are all pre-existing and untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI, docs, and the nested `tools/complexity` module; no CLI runtime, auth, or data-path code is modified.
> 
> **Overview**
> Adds a **pull-request-only** `complexity-gate` CI job that fails when a function exceeds cognitive complexity 30 **and** is new or worse than the merge base, while leaving ~105 existing over-threshold functions alone. The check uses a new `tools/complexity/gate` binary (diff of `cxtool` `functions.csv` outputs) instead of enabling `gocognit` in golangci-lint, which would fail local lint on all legacy violations.
> 
> **Local/CI entry point:** `mise run complexity:gate` exports the merge-base tree via `git archive`, runs head's `cxtool` on base and working tree, then `gate -base … -head …`. The aggregate `test` job now depends on this job and accepts `skipped` on pushes to main.
> 
> Also ships an **advisory** coverage mode (`gate -features … -baseline …`) with table-driven tests and README/CLAUDE docs; it is **not** wired into CI yet because CI coverage recipes differ from the committed baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1116c727937b1b38db654146a9104778f8c3cf4f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->