### PR TITLE
fix: make checkpoint status reflect hook health

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -409,6 +409,25 @@ type HookResponseWriter interface {
 	WriteHookResponse(message string) error
 }
 
+// StandaloneHookResponseWriter identifies an agent whose user-visible hook
+// response cannot share the same native payload as model context injection.
+// The lifecycle dispatcher emits the warning through WriteHookResponse and
+// retries context injection on a later warning-free turn.
+type StandaloneHookResponseWriter interface {
+	HookResponseWriter
+	RequiresStandaloneHookResponse()
+}
+
+// AsStandaloneHookResponseWriter returns ag when its native protocol requires
+// a standalone user-visible hook response.
+func AsStandaloneHookResponseWriter(ag Agent) (StandaloneHookResponseWriter, bool) {
+	if ag == nil {
+		return nil, false
+	}
+	writer, ok := ag.(StandaloneHookResponseWriter)
+	return writer, ok
+}
+
 // SessionEndBudgeter is implemented by agents whose host enforces a hard
 // wall-clock budget on the session-end hook, because it runs inside the agent's
 // own shutdown sequence rather than between turns.

--- a/cmd/entire/cli/agent/geminicli/lifecycle.go
+++ b/cmd/entire/cli/agent/geminicli/lifecycle.go
@@ -13,10 +13,11 @@ import (
 
 // Compile-time interface assertions for new interfaces.
 var (
-	_ agent.TranscriptAnalyzer = (*GeminiCLIAgent)(nil)
-	_ agent.TokenCalculator    = (*GeminiCLIAgent)(nil)
-	_ agent.HookResponseWriter = (*GeminiCLIAgent)(nil)
-	_ agent.ContextInjector    = (*GeminiCLIAgent)(nil)
+	_ agent.TranscriptAnalyzer           = (*GeminiCLIAgent)(nil)
+	_ agent.TokenCalculator              = (*GeminiCLIAgent)(nil)
+	_ agent.HookResponseWriter           = (*GeminiCLIAgent)(nil)
+	_ agent.StandaloneHookResponseWriter = (*GeminiCLIAgent)(nil)
+	_ agent.ContextInjector              = (*GeminiCLIAgent)(nil)
 )
 
 // WriteHookResponse outputs a hook response message as plain text to stdout.
@@ -37,6 +38,10 @@ func (g *GeminiCLIAgent) WriteHookResponse(message string) error {
 	}
 	return nil
 }
+
+// RequiresStandaloneHookResponse preserves Gemini's plain-text response path;
+// JSON systemMessage is displayed twice by Gemini CLI.
+func (g *GeminiCLIAgent) RequiresStandaloneHookResponse() {}
 
 // InjectionEvent reports that Gemini injects model context at TurnStart (its
 // BeforeAgent hook). Gemini CLI's hook runner merges

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -622,12 +622,13 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 	ctx := cmd.Context()
 	w := cmd.OutOrStdout()
 
-	switch strategy.CheckGitHookState(ctx) {
-	case strategy.GitHooksCurrent:
+	health := strategy.CheckGitHookIntegration(ctx)
+	switch health.State {
+	case strategy.GitHookIntegrationCurrent:
 		fmt.Fprintln(w, "✓ Git hooks: OK")
 		return nil
 
-	case strategy.GitHooksAbsent:
+	case strategy.GitHookIntegrationAbsent:
 		// Missing hooks are only a problem where Entire was actually set up.
 		// doctor runs in any git repo, so treating this as actionable would let
 		// `entire doctor --force` install hooks into — and back up the existing
@@ -645,13 +646,17 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 		fmt.Fprintln(w, "Git hooks: NOT INSTALLED")
 		fmt.Fprintln(w, "  Commits in this repository are not captured as checkpoints.")
 
-	case strategy.GitHooksOutdated:
-		// Actionable whatever the settings say: a hook carrying Entire's marker
-		// means this repo opted in at some point, and a stale one is actively
-		// broken rather than merely missing.
+	case strategy.GitHookIntegrationOutdated:
 		fmt.Fprintln(w, "Git hooks: OUT OF DATE")
-		fmt.Fprintln(w, "  A hook still runs Entire from the working tree instead of the installed")
-		fmt.Fprintln(w, "  binary. This can reject `git push`, because the path it names is gone.")
+		fmt.Fprintf(w, "  %s\n", health.Reason)
+
+	case strategy.GitHookIntegrationDegraded:
+		fmt.Fprintln(w, "Git hooks: DEGRADED")
+		fmt.Fprintf(w, "  %s\n", health.Reason)
+
+	case strategy.GitHookIntegrationError:
+		fmt.Fprintln(w, "Git hooks: ERROR")
+		fmt.Fprintf(w, "  %s\n", health.Reason)
 	}
 	fmt.Fprintln(w, "  Fix: reinstall the managed git hooks (any non-Entire hook is backed up).")
 
@@ -672,7 +677,11 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 		}
 	}
 
-	if _, err := strategy.ReinstallGitHooks(ctx); err != nil {
+	hookSettings, err := settings.Load(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load hook settings: %w", err)
+	}
+	if _, err := strategy.EnsureGitHookIntegration(ctx, hookSettings.AbsoluteGitHookPath); err != nil {
 		return fmt.Errorf("failed to reinstall git hooks: %w", err)
 	}
 	fmt.Fprintln(w, "  ✓ Fixed: git hooks reinstalled")

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -44,6 +44,33 @@ func newTestCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
 	return cmd, &stdout
 }
 
+func TestDoctorGitHooksUsesSharedDegradedHealth(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+	_, err := strategy.EnsureGitHookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte("pre_commit: {}\n"), 0o644))
+	require.Equal(t, strategy.GitHookIntegrationDegraded, strategy.CheckGitHookIntegration(t.Context()).State)
+
+	cmd, stdout := newTestCmd(t)
+	require.NoError(t, checkGitHooks(cmd, false))
+	require.Contains(t, stdout.String(), "Git hooks: DEGRADED")
+	require.NotContains(t, stdout.String(), "Git hooks: OK")
+}
+
+func TestDoctorGitHooksOutdatedUsesManagerAwareReason(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte("pre-commit: {}\n"), 0o644))
+	health := strategy.CheckGitHookIntegration(t.Context())
+	require.Equal(t, strategy.GitHookIntegrationOutdated, health.State)
+
+	cmd, stdout := newTestCmd(t)
+	require.NoError(t, checkGitHooks(cmd, false))
+	require.Contains(t, stdout.String(), health.Reason)
+	require.NotContains(t, stdout.String(), "working tree")
+}
+
 // testBaseCommit is a fake commit hash used across classifySession tests.
 const testBaseCommit = "abcdef1234567890abcdef1234567890abcdef12"
 

--- a/cmd/entire/cli/hooks_git_cmd.go
+++ b/cmd/entire/cli/hooks_git_cmd.go
@@ -300,9 +300,9 @@ func newHooksGitPostRewriteCmd() *cobra.Command {
 
 func newHooksGitPrePushCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "pre-push <remote>",
+		Use:   "pre-push <remote> [remote-url]",
 		Short: "Handle pre-push git hook",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.RangeArgs(1, 2),
 		// SilenceUsage/Errors so non-zero exits from privacy-critical
 		// failures (OPF rewrite errors) print only the error message,
 		// not cobra's usage banner. The error message itself already

--- a/cmd/entire/cli/hooks_git_cmd.go
+++ b/cmd/entire/cli/hooks_git_cmd.go
@@ -316,6 +316,10 @@ func newHooksGitPrePushCmd() *cobra.Command {
 			}
 
 			remote := args[0]
+			// Git's hook ABI also supplies args[1], the URL for this invocation.
+			// Routing intentionally stays remote-name based: checkpoint ownership
+			// evaluates every configured push URL for that remote, and the
+			// git-branch backend follows Git's multi-push-URL fan-out semantics.
 
 			g := newGitHookContext(cmd.Context(), "pre-push")
 			defer g.span.End()

--- a/cmd/entire/cli/integration_test/hook_overwrite_test.go
+++ b/cmd/entire/cli/integration_test/hook_overwrite_test.go
@@ -3,115 +3,54 @@
 package integration
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/entireio/cli/cmd/entire/cli/strategy"
-	"github.com/stretchr/testify/assert"
+	"github.com/entireio/cli/cmd/entire/cli/execx"
 	"github.com/stretchr/testify/require"
 )
 
-// TestHookOverwrite_MidTurnWipe_NextPromptRecovers simulates the scenario from
-// https://github.com/entireio/cli/issues/784:
-//
-// Flow:
-//  1. Prompt 1: agent creates files, commits via hooks → checkpoint trailer ✓
-//  2. Mid-turn: third-party tool (husky/lefthook) overwrites git hooks
-//  3. Agent commits again (no hooks fire) → NO trailer
-//  4. Prompt 2 starts (user-prompt-submit) → EnsureSetup reinstalls hooks
-//  5. Agent commits via hooks → checkpoint trailer ✓ (hooks restored)
-//
-// The key insight: GitCommitWithShadowHooks invokes the binary directly (simulating
-// working hooks), while GitAdd+GitCommit uses go-git without hooks (simulating
-// overwritten hooks where `entire` is never called).
-func TestHookOverwrite_MidTurnWipe_NextPromptRecovers(t *testing.T) {
+// TestHookOverwrite_LefthookRefreshKeepsCurrentCommitCovered pins the manager
+// integration contract: once Entire has published its Lefthook-local scripts,
+// a Lefthook refresh may replace the shared native wrappers and the very next
+// commit still reaches Entire. Recovery must not wait for another agent prompt.
+func TestHookOverwrite_LefthookRefreshKeepsCurrentCommitCovered(t *testing.T) {
 	t.Parallel()
 
 	env := NewFeatureBranchEnv(t)
-	hooksDir := filepath.Join(env.RepoDir, ".git", "hooks")
+	writeLefthookConfig(t, env.RepoDir)
+	env.RunCLI("enable", "--absolute-git-hook-path")
 
 	sess := env.NewSession()
-
-	// === Prompt 1: normal flow, hooks work ===
-	err := env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(
-		sess.ID, "Create files A and B", sess.TranscriptPath)
-	require.NoError(t, err)
+	require.NoError(t, env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(
+		sess.ID, "Create files A and B", sess.TranscriptPath))
 
 	env.WriteFile("fileA.go", pkgFuncA)
 	env.WriteFile("fileB.go", pkgFuncB)
-
 	sess.CreateTranscript("Create files A and B", []FileChange{
 		{Path: "fileA.go", Content: pkgFuncA},
 		{Path: "fileB.go", Content: pkgFuncB},
 	})
 
-	// First commit — hooks are intact, binary is invoked → trailer added
-	env.GitCommitWithShadowHooks("Add file A", "fileA.go")
-	cpID1 := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
-	require.NotEmpty(t, cpID1, "first commit should have checkpoint trailer")
+	env.GitCommitWithShadowHooksAsAgent("Add file A", "fileA.go")
+	require.NotEmpty(t, env.GetCheckpointIDFromCommitMessage(env.GetHeadHash()))
 
-	// === Simulate husky/lefthook overwriting hooks mid-turn ===
-	// This is what happens when an agent runs `npm install` and husky's
-	// `prepare` lifecycle script reinstalls its own hooks.
-	for _, hookName := range strategy.ManagedGitHookNames() {
-		hookPath := filepath.Join(hooksDir, hookName)
-		huskyContent := "#!/bin/sh\n# husky - do not edit\n. \"$(dirname \"$0\")/_/husky.sh\"\n"
-		err := os.WriteFile(hookPath, []byte(huskyContent), 0o755)
-		require.NoError(t, err)
-	}
-
-	// Verify hooks are overwritten
-	require.False(t, strategy.IsGitHookInstalledInDir(t.Context(), env.RepoDir),
-		"hooks should be detected as overwritten")
-
-	// Second commit — hooks are gone, use plain go-git commit (no binary invoked).
-	// This simulates the real-world situation after husky/lefthook has overwritten
-	// our hooks: a commit is made where git would run a third-party hook that does
-	// not call `entire`, so from Entire's perspective no hooks run and no trailer
-	// is added.
+	// Simulate `lefthook install` refreshing every shared hook between commits.
+	installSimulatedLefthookHooks(t, env.RepoDir)
 	env.GitAdd("fileB.go")
-	env.GitCommit("Add file B")
-	cpID2 := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
-	assert.Empty(t, cpID2,
-		"second commit should NOT have trailer (hooks were overwritten, entire never called)")
+	cmd := execx.NonInteractive(context.Background(), "git", "commit", "-m", "Add file B")
+	cmd.Dir = env.RepoDir
+	cmd.Env = env.cliEnv()
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "%s", out)
 
-	// End prompt 1
-	err = env.SimulateStop(sess.ID, sess.TranscriptPath)
-	require.NoError(t, err)
-
-	// === Prompt 2: same session, next turn — EnsureSetup should reinstall hooks ===
-
-	env.WriteFile("fileC.go", "package main\n\nfunc C() {}\n")
-
-	sess.CreateTranscript("Create file C", []FileChange{
-		{Path: "fileC.go", Content: "package main\n\nfunc C() {}\n"},
-	})
-
-	err = env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(
-		sess.ID, "Create file C", sess.TranscriptPath)
-	require.NoError(t, err)
-
-	// Verify hooks were reinstalled by EnsureSetup
-	require.True(t, strategy.IsGitHookInstalledInDir(t.Context(), env.RepoDir),
-		"hooks should be reinstalled by EnsureSetup at prompt 2 start")
-
-	// Verify overwritten hooks were backed up (chaining preserved)
-	for _, hookName := range strategy.ManagedGitHookNames() {
-		backupPath := filepath.Join(hooksDir, hookName+".pre-entire")
-		_, err := os.Stat(backupPath)
-		require.NoError(t, err, "backup %s.pre-entire should exist after reinstall", hookName)
-	}
-
-	// Third commit — hooks restored, agent commits (no TTY) → trailer added via fast path
-	env.GitCommitWithShadowHooksAsAgent("Add file C", "fileC.go")
-	cpID3 := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
-	assert.NotEmpty(t, cpID3,
-		"third commit should have trailer (hooks reinstalled by prompt 2)")
-
-	// Checkpoint IDs should be distinct
-	if cpID3 != "" {
-		assert.NotEqual(t, cpID1, cpID3,
-			"checkpoint IDs from prompt 1 and prompt 2 should be distinct")
+	require.NotEmpty(t, env.GetCheckpointIDFromCommitMessage(env.GetHeadHash()),
+		"the commit immediately after Lefthook refresh must retain Entire behavior")
+	for _, hook := range []string{"prepare-commit-msg", "commit-msg", "post-commit", "post-rewrite", "pre-push"} {
+		data, readErr := os.ReadFile(filepath.Join(env.RepoDir, ".git", "hooks", hook))
+		require.NoError(t, readErr)
+		require.Contains(t, string(data), "lefthook generated wrapper")
 	}
 }

--- a/cmd/entire/cli/integration_test/hook_overwrite_test.go
+++ b/cmd/entire/cli/integration_test/hook_overwrite_test.go
@@ -42,7 +42,11 @@ func TestHookOverwrite_LefthookRefreshKeepsCurrentCommitCovered(t *testing.T) {
 	env.GitAdd("fileB.go")
 	cmd := execx.NonInteractive(context.Background(), "git", "commit", "-m", "Add file B")
 	cmd.Dir = env.RepoDir
-	cmd.Env = env.cliEnv()
+	// A real Claude Code shell publishes its session ID to git and every hook
+	// below it. Keep this test focused on durable Lefthook delivery instead of
+	// relying on the platform-specific process-ancestry fallback to identify the
+	// simulated agent session.
+	cmd.Env = append(env.cliEnv(), "CLAUDE_CODE_SESSION_ID="+sess.ID)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", out)
 

--- a/cmd/entire/cli/integration_test/hook_overwrite_test.go
+++ b/cmd/entire/cli/integration_test/hook_overwrite_test.go
@@ -42,11 +42,10 @@ func TestHookOverwrite_LefthookRefreshKeepsCurrentCommitCovered(t *testing.T) {
 	env.GitAdd("fileB.go")
 	cmd := execx.NonInteractive(context.Background(), "git", "commit", "-m", "Add file B")
 	cmd.Dir = env.RepoDir
-	// A real Claude Code shell publishes its session ID to git and every hook
-	// below it. Keep this test focused on durable Lefthook delivery instead of
-	// relying on the platform-specific process-ancestry fallback to identify the
-	// simulated agent session.
-	cmd.Env = append(env.cliEnv(), "CLAUDE_CODE_SESSION_ID="+sess.ID)
+	// The runner may disable repository hooks globally with LEFTHOOK=0. This
+	// scenario specifically exercises an active Lefthook refresh, so declare
+	// that precondition instead of inheriting the runner's ambient opt-out.
+	cmd.Env = append(env.cliEnv(), "LEFTHOOK=1")
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", out)
 

--- a/cmd/entire/cli/integration_test/hook_overwrite_test.go
+++ b/cmd/entire/cli/integration_test/hook_overwrite_test.go
@@ -22,6 +22,10 @@ func TestHookOverwrite_LefthookRefreshKeepsCurrentCommitCovered(t *testing.T) {
 	env := NewFeatureBranchEnv(t)
 	writeLefthookConfig(t, env.RepoDir)
 	env.RunCLI("enable", "--absolute-git-hook-path")
+	installedScript, err := os.ReadFile(filepath.Join(env.RepoDir, ".lefthook-local", "prepare-commit-msg", "entire.sh"))
+	require.NoError(t, err)
+	require.Contains(t, string(installedScript), getTestBinary(),
+		"--absolute-git-hook-path must keep manager-owned hooks independent of PATH")
 
 	sess := env.NewSession()
 	require.NoError(t, env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(
@@ -45,26 +49,11 @@ func TestHookOverwrite_LefthookRefreshKeepsCurrentCommitCovered(t *testing.T) {
 	// The runner may disable repository hooks globally with LEFTHOOK=0. This
 	// scenario specifically exercises an active Lefthook refresh, so declare
 	// that precondition instead of inheriting the runner's ambient opt-out.
-	cmd.Env = append(env.cliEnv(), "LEFTHOOK=1", "LEFTHOOK_VERBOSE=1", "ENTIRE_LOG_LEVEL=debug")
+	cmd.Env = append(env.cliEnv(), "LEFTHOOK=1")
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", out)
 
 	checkpointID := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
-	if checkpointID == "" {
-		t.Logf("git commit output:\n%s", out)
-		for _, name := range []string{
-			".git/hooks/prepare-commit-msg",
-			".lefthook-local/prepare-commit-msg/entire.sh",
-			"lefthook-local.yml",
-			filepath.Join(".git", "entire-sessions", sess.ID+".json"),
-			filepath.Join(".entire", "logs", "entire.log"),
-		} {
-			data, readErr := os.ReadFile(filepath.Join(env.RepoDir, name))
-			t.Logf("diagnostic %s (err=%v):\n%s", name, readErr, data)
-		}
-		statusOut, statusErr := env.RunCLIWithError("status", "--json")
-		t.Logf("diagnostic status --json (err=%v):\n%s", statusErr, statusOut)
-	}
 	require.NotEmpty(t, checkpointID,
 		"the commit immediately after Lefthook refresh must retain Entire behavior")
 	for _, hook := range []string{"prepare-commit-msg", "commit-msg", "post-commit", "post-rewrite", "pre-push"} {

--- a/cmd/entire/cli/integration_test/hook_overwrite_test.go
+++ b/cmd/entire/cli/integration_test/hook_overwrite_test.go
@@ -45,11 +45,27 @@ func TestHookOverwrite_LefthookRefreshKeepsCurrentCommitCovered(t *testing.T) {
 	// The runner may disable repository hooks globally with LEFTHOOK=0. This
 	// scenario specifically exercises an active Lefthook refresh, so declare
 	// that precondition instead of inheriting the runner's ambient opt-out.
-	cmd.Env = append(env.cliEnv(), "LEFTHOOK=1")
+	cmd.Env = append(env.cliEnv(), "LEFTHOOK=1", "LEFTHOOK_VERBOSE=1", "ENTIRE_LOG_LEVEL=debug")
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", out)
 
-	require.NotEmpty(t, env.GetCheckpointIDFromCommitMessage(env.GetHeadHash()),
+	checkpointID := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
+	if checkpointID == "" {
+		t.Logf("git commit output:\n%s", out)
+		for _, name := range []string{
+			".git/hooks/prepare-commit-msg",
+			".lefthook-local/prepare-commit-msg/entire.sh",
+			"lefthook-local.yml",
+			filepath.Join(".git", "entire-sessions", sess.ID+".json"),
+			filepath.Join(".entire", "logs", "entire.log"),
+		} {
+			data, readErr := os.ReadFile(filepath.Join(env.RepoDir, name))
+			t.Logf("diagnostic %s (err=%v):\n%s", name, readErr, data)
+		}
+		statusOut, statusErr := env.RunCLIWithError("status", "--json")
+		t.Logf("diagnostic status --json (err=%v):\n%s", statusErr, statusOut)
+	}
+	require.NotEmpty(t, checkpointID,
 		"the commit immediately after Lefthook refresh must retain Entire behavior")
 	for _, hook := range []string{"prepare-commit-msg", "commit-msg", "post-commit", "post-rewrite", "pre-push"} {
 		data, readErr := os.ReadFile(filepath.Join(env.RepoDir, ".git", "hooks", hook))

--- a/cmd/entire/cli/integration_test/hook_repair_test.go
+++ b/cmd/entire/cli/integration_test/hook_repair_test.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/execx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookRepair_UserEditWarnsOnAgentTurn(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+	hookPath := filepath.Join(env.RepoDir, ".git", "hooks", "pre-push")
+	original, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	edited := []byte(string(original) + "echo custom-validation\n")
+	require.NoError(t, os.WriteFile(hookPath, edited, 0o755))
+	sess := env.NewSession()
+	input, err := json.Marshal(map[string]string{
+		"session_id": sess.ID, "transcript_path": sess.TranscriptPath, "prompt": "Inspect repository",
+	})
+	require.NoError(t, err)
+	cmd := execx.NonInteractive(t.Context(), getTestBinary(), "hooks", "claude-code", "user-prompt-submit")
+	cmd.Dir = env.RepoDir
+	cmd.Env = env.cliEnv()
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	var response struct {
+		SystemMessage string `json:"systemMessage"`
+	}
+	require.NoError(t, json.Unmarshal(out, &response))
+	require.Contains(t, response.SystemMessage, "Git hook integration is outdated")
+	require.Contains(t, response.SystemMessage, "entire doctor")
+	after, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	require.Equal(t, edited, after)
+	status := env.RunCLI("status")
+	require.Contains(t, status, "Checkpoint sync blocked")
+	require.Contains(t, status, "pre-push")
+	require.Contains(t, status, "left it unchanged")
+}
+
+func TestHookRepair_NativePermissionStatusAndRecovery(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not use Unix executable bits")
+	}
+	env := NewRepoWithCommit(t)
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+	hookPath := filepath.Join(env.RepoDir, ".git", "hooks", "pre-push")
+	require.NoError(t, os.Chmod(hookPath, 0o644))
+	status := env.RunCLI("status")
+	require.Contains(t, status, "Checkpoint sync blocked")
+	require.Contains(t, status, "not executable")
+	info, err := os.Stat(hookPath)
+	require.NoError(t, err)
+	require.Zero(t, info.Mode().Perm()&0o111, "status must remain read-only")
+	sess := env.NewSession()
+	require.NoError(t, env.SimulateUserPromptSubmit(sess.ID))
+	info, err = os.Stat(hookPath)
+	require.NoError(t, err)
+	require.NotZero(t, info.Mode().Perm()&0o111)
+	require.NotContains(t, env.RunCLI("status"), "Checkpoint sync blocked")
+}

--- a/cmd/entire/cli/integration_test/hooks_test.go
+++ b/cmd/entire/cli/integration_test/hooks_test.go
@@ -4,11 +4,13 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHookRunner_SimulateUserPromptSubmit(t *testing.T) {
@@ -321,6 +323,26 @@ func TestUserPromptSubmit_ReinstallsOverwrittenHooks(t *testing.T) {
 			t.Errorf("backup hook %s.pre-entire should exist", hookName)
 		}
 	}
+}
+
+func TestHookRepairWarningUsesAgentResponseAndFailsOpen(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	require.NoError(t, os.WriteFile(filepath.Join(env.RepoDir, "lefthook.yml"), []byte("pre-commit: {}\n"), 0o644))
+	conflict := "pre-push:\n  scripts:\n    entire.sh:\n      runner: custom\n"
+	require.NoError(t, os.WriteFile(filepath.Join(env.RepoDir, "lefthook-local.yml"), []byte(conflict), 0o644))
+
+	input, err := json.Marshal(map[string]string{
+		"session_id": "hook-repair-warning", "transcript_path": "", "prompt": "private prompt text",
+	})
+	require.NoError(t, err)
+	runner := NewHookRunner(env.RepoDir, env.ClaudeProjectDir, t)
+	out := runner.runHookWithOutput("user-prompt-submit", input)
+	require.NoError(t, out.Err, string(out.Stderr))
+	require.Contains(t, string(out.Stdout), "Lefthook")
+	require.Contains(t, string(out.Stdout), "outdated")
+	require.Contains(t, string(out.Stdout), "entire doctor")
+	require.NotContains(t, string(out.Stdout), "private prompt text")
 }
 
 // TestUserPromptSubmit_ReinstallsDeletedHooks verifies that EnsureSetup reinstalls

--- a/cmd/entire/cli/integration_test/lefthook_integration_test.go
+++ b/cmd/entire/cli/integration_test/lefthook_integration_test.go
@@ -1,0 +1,239 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/execx"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/stretchr/testify/require"
+)
+
+const validLefthookConfig = "pre-commit: {}\n"
+
+func TestLefthookAlreadyActiveThenEntireEnablePreservesEveryHook(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	writeLefthookConfig(t, env.RepoDir)
+	installSimulatedLefthookHooks(t, env.RepoDir)
+
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+	assertEveryLefthookDispatch(t, env, env.RepoDir)
+}
+
+func TestEntireNativeHooksThenLefthookRefreshPreservesEveryHook(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+	for _, hook := range strategy.ManagedGitHookNames() {
+		data, err := os.ReadFile(filepath.Join(env.RepoDir, ".git", "hooks", hook))
+		require.NoError(t, err)
+		require.Contains(t, string(data), "Entire CLI hooks")
+	}
+	// Exercise the native wrappers before any manager config exists. The helper
+	// allocates a fresh fake-Entire log on each call, so these counts cannot be
+	// satisfied by the post-refresh dispatch below.
+	assertEveryLefthookDispatch(t, env, env.RepoDir)
+
+	// Lefthook is introduced after Entire. The next setup pass publishes the
+	// durable local integration before Lefthook refreshes its shared wrappers.
+	writeLefthookConfig(t, env.RepoDir)
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+	installSimulatedLefthookHooks(t, env.RepoDir)
+
+	assertEveryLefthookDispatch(t, env, env.RepoDir)
+}
+
+func TestLefthookIntegrationIsWorktreeLocalWithSharedHooks(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	writeLefthookConfig(t, env.RepoDir)
+	installSimulatedLefthookHooks(t, env.RepoDir)
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+
+	linked := filepath.Join(t.TempDir(), "linked")
+	cmd := exec.CommandContext(t.Context(), "git", "worktree", "add", "-b", "feature/linked-lefthook", linked)
+	cmd.Dir = env.RepoDir
+	cmd.Env = env.cliEnv()
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	writeLefthookConfig(t, linked)
+	runCLIAt(t, env, linked, "enable", "--agent", agentClaudeCode, "--telemetry=false")
+
+	for _, root := range []string{env.RepoDir, linked} {
+		data, readErr := os.ReadFile(filepath.Join(root, "lefthook-local.yml"))
+		require.NoError(t, readErr, root)
+		require.Contains(t, string(data), "entire-cli-owned:lefthook:v1", root)
+		for _, hook := range strategy.ManagedGitHookNames() {
+			_, statErr := os.Stat(filepath.Join(root, ".lefthook-local", hook, "entire.sh"))
+			require.NoError(t, statErr, "%s in %s", hook, root)
+		}
+	}
+
+	mainHook := gitPath(t, env, env.RepoDir, "hooks/pre-push")
+	linkedHook := gitPath(t, env, linked, "hooks/pre-push")
+	require.Equal(t, mainHook, linkedHook, "linked worktree must retain the effective shared hook path")
+	assertEveryLefthookDispatch(t, env, linked)
+}
+
+func TestUninstallLefthookIntegrationRollsBackObstructionAndRetries(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	writeLefthookConfig(t, env.RepoDir)
+	installSimulatedLefthookHooks(t, env.RepoDir)
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+
+	obstruction := filepath.Join(env.RepoDir, ".lefthook-local", "pre-push", "entire.sh")
+	require.NoError(t, os.Remove(obstruction))
+	require.NoError(t, os.Mkdir(obstruction, 0o755))
+
+	out, err := env.RunCLIWithError("disable", "--uninstall", "--force")
+	require.Error(t, err, out)
+	require.Contains(t, out, "inspect owned Lefthook script pre-push")
+	data, readErr := os.ReadFile(filepath.Join(env.RepoDir, "lefthook-local.yml"))
+	require.NoError(t, readErr)
+	require.Contains(t, string(data), "entire-cli-owned:lefthook:v1", "failed removal must restore earlier mutations")
+	_, statErr := os.Stat(filepath.Join(env.RepoDir, ".lefthook-local", "prepare-commit-msg", "entire.sh"))
+	require.NoError(t, statErr, "failed removal must restore already-removed scripts")
+
+	require.NoError(t, os.Remove(obstruction))
+	env.RunCLI("disable", "--uninstall", "--force")
+	assertNoOwnedLefthookArtifacts(t, env.RepoDir)
+	for _, hook := range strategy.ManagedGitHookNames() {
+		data, hookErr := os.ReadFile(filepath.Join(env.RepoDir, ".git", "hooks", hook))
+		require.NoError(t, hookErr)
+		require.Contains(t, string(data), "lefthook", "uninstall must retain manager-owned wrapper %s", hook)
+	}
+}
+
+func writeLefthookConfig(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "lefthook.yml"), []byte(validLefthookConfig), 0o644))
+}
+
+func installSimulatedLefthookHooks(t *testing.T, repoRoot string) {
+	t.Helper()
+	hooksDir := filepath.Join(repoRoot, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	for _, hook := range strategy.ManagedGitHookNames() {
+		content := fmt.Sprintf(`#!/bin/sh
+
+if [ "$LEFTHOOK_VERBOSE" = "1" -o "$LEFTHOOK_VERBOSE" = "true" ]; then
+  set -x
+fi
+
+if [ "$LEFTHOOK" = "0" ]; then
+  exit 0
+fi
+
+# lefthook generated wrapper
+call_lefthook()
+{
+  shift
+  hook="$1"
+  shift
+  exec "$PWD/.lefthook-local/$hook/entire.sh" "$@"
+}
+
+call_lefthook run "%s" "$@"
+`, hook)
+		require.NoError(t, os.WriteFile(filepath.Join(hooksDir, hook), []byte(content), 0o755))
+	}
+}
+
+func assertEveryLefthookDispatch(t *testing.T, env *TestEnv, worktree string) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	logBase := filepath.Join(t.TempDir(), "hook")
+	fake := `#!/bin/sh
+hook="$3"
+printf '%s\n' "$@" > "$ENTIRE_HOOK_LOG.$hook.args"
+cat > "$ENTIRE_HOOK_LOG.$hook.stdin"
+printf 'call\n' >> "$ENTIRE_HOOK_LOG.$hook.calls"
+if [ "$hook" = pre-push ]; then exit "${ENTIRE_PRE_PUSH_EXIT:-0}"; fi
+`
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "entire"), []byte(fake), 0o755))
+
+	msg := filepath.Join(worktree, ".git", "COMMIT_EDITMSG")
+	cases := []struct {
+		name      string
+		args      []string
+		stdin     string
+		wantArgs  []string
+		wantStdin string
+		wantExit  bool
+	}{
+		{name: "prepare-commit-msg", args: []string{msg, "message"}, wantArgs: []string{"hooks", "git", "prepare-commit-msg", msg, "message"}},
+		{name: "commit-msg", args: []string{msg}, wantArgs: []string{"hooks", "git", "commit-msg", msg}},
+		{name: "post-commit", wantArgs: []string{"hooks", "git", "post-commit"}},
+		{name: "post-rewrite", args: []string{"amend"}, stdin: "old new\n", wantArgs: []string{"hooks", "git", "post-rewrite", "amend"}, wantStdin: "old new\n"},
+		{name: "pre-push", args: []string{"origin", "https://example.test/repo.git"}, wantArgs: []string{"hooks", "git", "pre-push", "origin", "https://example.test/repo.git"}, wantExit: true},
+	}
+	for _, tc := range cases {
+		script := gitPath(t, env, worktree, "hooks/"+tc.name)
+		cmd := execx.NonInteractive(context.Background(), script, tc.args...)
+		cmd.Dir = worktree
+		cmd.Env = append(env.cliEnv(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"), "ENTIRE_HOOK_LOG="+logBase, "ENTIRE_PRE_PUSH_EXIT=23")
+		cmd.Stdin = strings.NewReader(tc.stdin)
+		out, err := cmd.CombinedOutput()
+		if tc.wantExit {
+			require.Error(t, err, "%s must propagate the Entire pre-push block; output=%s", tc.name, out)
+			var exitErr *exec.ExitError
+			require.ErrorAs(t, err, &exitErr)
+			require.Equal(t, 23, exitErr.ExitCode())
+		} else {
+			require.NoError(t, err, "%s output=%s", tc.name, out)
+		}
+		require.Equal(t, tc.wantArgs, readLines(t, logBase+"."+tc.name+".args"), tc.name)
+		require.Equal(t, []string{"call"}, readLines(t, logBase+"."+tc.name+".calls"), "%s must run fake Entire exactly once", tc.name)
+		stdin, readErr := os.ReadFile(logBase + "." + tc.name + ".stdin")
+		require.NoError(t, readErr)
+		require.Equal(t, tc.wantStdin, string(stdin), tc.name)
+	}
+}
+
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+}
+
+func gitPath(t *testing.T, env *TestEnv, dir, path string) string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "--path-format=absolute", "--git-path", path)
+	cmd.Dir = dir
+	cmd.Env = env.cliEnv()
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	return strings.TrimSpace(string(out))
+}
+
+func runCLIAt(t *testing.T, env *TestEnv, dir string, args ...string) {
+	t.Helper()
+	cmd := execx.NonInteractive(context.Background(), getTestBinary(), args...)
+	cmd.Dir = dir
+	cmd.Env = env.cliEnv()
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "%s", out)
+}
+
+func assertNoOwnedLefthookArtifacts(t *testing.T, repoRoot string) {
+	t.Helper()
+	if data, err := os.ReadFile(filepath.Join(repoRoot, "lefthook-local.yml")); err == nil {
+		require.NotContains(t, string(data), "entire-cli-owned:lefthook:v1")
+	} else {
+		require.ErrorIs(t, err, os.ErrNotExist)
+	}
+	for _, hook := range strategy.ManagedGitHookNames() {
+		_, err := os.Stat(filepath.Join(repoRoot, ".lefthook-local", hook, "entire.sh"))
+		require.ErrorIs(t, err, os.ErrNotExist, hook)
+	}
+}

--- a/cmd/entire/cli/integration_test/local_dev_migration_test.go
+++ b/cmd/entire/cli/integration_test/local_dev_migration_test.go
@@ -141,9 +141,20 @@ func pushWithHooksExpectingResult(env *TestEnv, remote, refSpec string) (string,
 
 	cmd := execx.NonInteractive(env.T.Context(), "git", "push", remote, refSpec)
 	cmd.Dir = env.RepoDir
-	cmd.Env = env.cliEnv()
+	cmd.Env = prependPath(env.cliEnv(), filepath.Dir(getTestBinary()))
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+func prependPath(env []string, dir string) []string {
+	result := append([]string(nil), env...)
+	for i, value := range result {
+		if strings.HasPrefix(value, "PATH=") {
+			result[i] = "PATH=" + dir + string(os.PathListSeparator) + strings.TrimPrefix(value, "PATH=")
+			return result
+		}
+	}
+	return append(result, "PATH="+dir)
 }
 
 // seedLegacyGitHooks writes every managed hook in a legacy shape, including

--- a/cmd/entire/cli/integration_test/status_health_test.go
+++ b/cmd/entire/cli/integration_test/status_health_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusIssue2264ReportsBlockedSyncWithoutHooks(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	env.SetupEmptyNamedBareRemote("origin")
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+	for _, hook := range strategy.ManagedGitHookNames() {
+		require.NoError(t, os.Remove(filepath.Join(env.RepoDir, ".git", "hooks", hook)))
+	}
+
+	text := env.RunCLI("status")
+	require.NotContains(t, text, "Checkpoints sync to:")
+	require.Contains(t, text, "Checkpoint sync blocked")
+	require.Contains(t, text, "not installed")
+
+	var got struct {
+		CheckpointSyncState  string `json:"checkpoint_sync_state"`
+		CheckpointSyncRemote string `json:"checkpoint_sync_remote"`
+		GitHooks             struct {
+			Mode  string `json:"mode"`
+			State string `json:"state"`
+		} `json:"git_hooks"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(env.RunCLI("status", "--json")), &got))
+	require.Equal(t, "blocked", got.CheckpointSyncState)
+	require.Equal(t, "origin", got.CheckpointSyncRemote)
+	require.Equal(t, "native", got.GitHooks.Mode)
+	require.Equal(t, "absent", got.GitHooks.State)
+}
+
+func TestStatusHookHealthReadySubprocessContract(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	env.SetupEmptyNamedBareRemote("origin")
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+
+	text := env.RunCLI("status")
+	require.True(t, strings.Contains(text, "Checkpoints sync to:") || strings.Contains(text, "Checkpoint sync ready"), text)
+	var got struct {
+		CheckpointSyncState string `json:"checkpoint_sync_state"`
+		GitHooks            struct {
+			State string `json:"state"`
+		} `json:"git_hooks"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(env.RunCLI("status", "--json")), &got))
+	require.Equal(t, "ready", got.CheckpointSyncState)
+	require.Equal(t, "current", got.GitHooks.State)
+}
+
+func TestStatusMultipleSessionsPreservedAcrossWorktrees(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+	linked := filepath.Join(t.TempDir(), "linked")
+	testutil.RunGit(t, env.RepoDir, "worktree", "add", "-b", "status-linked", linked)
+
+	store := session.NewStateStoreWithDir(filepath.Join(env.RepoDir, ".git", session.SessionStateDirName))
+	lastActive := time.Now().UTC().Add(-time.Minute)
+	for _, state := range []*session.State{
+		{SessionID: "same-agent-main", WorktreeID: "main", WorktreePath: env.RepoDir, Branch: "main", StartedAt: lastActive.Add(-time.Hour), LastInteractionTime: &lastActive, Phase: session.PhaseActive, AgentType: types.AgentType(agentClaudeCode)},
+		{SessionID: "same-agent-linked", WorktreeID: "linked", WorktreePath: linked, Branch: "status-linked", StartedAt: lastActive.Add(-2 * time.Hour), LastInteractionTime: &lastActive, Phase: session.PhaseActive, AgentType: types.AgentType(agentClaudeCode)},
+	} {
+		require.NoError(t, store.Save(t.Context(), state))
+	}
+
+	var got struct {
+		ActiveSessions []struct {
+			SessionID    string `json:"session_id"`
+			WorktreePath string `json:"worktree_path"`
+		} `json:"active_sessions"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(env.RunCLI("status", "--json")), &got))
+	require.Len(t, got.ActiveSessions, 2)
+	require.Equal(t, []string{"same-agent-linked", "same-agent-main"}, []string{got.ActiveSessions[0].SessionID, got.ActiveSessions[1].SessionID})
+	require.ElementsMatch(t, []string{linked, env.RepoDir}, []string{got.ActiveSessions[0].WorktreePath, got.ActiveSessions[1].WorktreePath})
+}
+
+func TestStatusReadOnlyPreservesDeadOwnerStateAndTranscript(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+	env.RunCLI("enable", "--agent", agentClaudeCode, "--telemetry=false")
+	transcriptPath := filepath.Join(env.RepoDir, "status-read-only.jsonl")
+	require.NoError(t, os.WriteFile(transcriptPath, []byte("unchanged\n"), 0o600))
+	store := session.NewStateStoreWithDir(filepath.Join(env.RepoDir, ".git", session.SessionStateDirName))
+	lastActive := time.Now().UTC().Add(-time.Minute)
+	state := &session.State{
+		SessionID: "dead-owner-status", WorktreeID: "main", WorktreePath: env.RepoDir, Branch: "main",
+		StartedAt: lastActive.Add(-time.Hour), LastInteractionTime: &lastActive,
+		Phase: session.PhaseActive, AgentType: types.AgentType(agentClaudeCode),
+		Owner: &proclive.Identity{PID: os.Getpid(), Start: "not-this-process"}, TranscriptPath: transcriptPath,
+	}
+	require.NoError(t, store.Save(t.Context(), state))
+	statePath := filepath.Join(env.RepoDir, ".git", session.SessionStateDirName, state.SessionID+".json")
+	beforeState, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+	beforeStateInfo, err := os.Stat(statePath)
+	require.NoError(t, err)
+	beforeTranscript, err := os.ReadFile(transcriptPath)
+	require.NoError(t, err)
+	beforeTranscriptInfo, err := os.Stat(transcriptPath)
+	require.NoError(t, err)
+
+	text := env.RunCLI("status")
+	jsonStatus := env.RunCLI("status", "--json")
+	require.Contains(t, text, "dead-owner-status")
+	require.Contains(t, text, "exited")
+	require.Contains(t, jsonStatus, `"status":"exited"`)
+	afterState, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+	afterStateInfo, err := os.Stat(statePath)
+	require.NoError(t, err)
+	afterTranscript, err := os.ReadFile(transcriptPath)
+	require.NoError(t, err)
+	afterTranscriptInfo, err := os.Stat(transcriptPath)
+	require.NoError(t, err)
+	require.Equal(t, beforeState, afterState)
+	require.Equal(t, beforeStateInfo.ModTime(), afterStateInfo.ModTime())
+	require.Equal(t, beforeTranscript, afterTranscript)
+	require.Equal(t, beforeTranscriptInfo.ModTime(), afterTranscriptInfo.ModTime())
+}

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -175,15 +175,17 @@ func repairLifecycleHookHealth(
 ) lifecycleHookHealthClaim {
 	repairErr := ops.repair(ctx)
 	health := ops.check(ctx)
-	if repairErr != nil && health.State == strategy.GitHookIntegrationCurrent {
-		health.State = strategy.GitHookIntegrationError
-		health.ReasonCode = "hook_repair_failed"
+	if health.State == strategy.GitHookIntegrationCurrent {
+		if err := strategy.RecordHookHealthRecovery(ctx, sessionID, lifecycleHookHealthFingerprint(health)); err != nil && !errors.Is(err, strategy.ErrStateNotFound) {
+			logging.Warn(ctx, "failed to record recovered hook health warning",
+				slog.String("session_id", sessionID))
+		}
 	}
 	if repairErr != nil || health.State != strategy.GitHookIntegrationCurrent {
 		// Do not log repairErr or health.Reason here: setup errors can include
 		// repository content. Stable classification fields are sufficient for
 		// diagnosis without leaking prompts, files, or commit messages.
-		logging.Warn(ctx, "git hook integration repair incomplete",
+		logging.Warn(ctx, "lifecycle setup or git hook integration repair incomplete",
 			slog.String("session_id", sessionID),
 			slog.String("mode", string(health.Mode)),
 			slog.String("state", string(health.State)),

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -9,6 +9,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -131,6 +132,90 @@ func DispatchLifecycleEvent(ctx context.Context, ag agent.Agent, event *agent.Ev
 const retiredDenyRuleWarning = "\n  A retired Entire permission rule in this repo is causing repeated" +
 	"\n  approval prompts. Run 'entire doctor' to remove it."
 
+type lifecycleHookHealthOps struct {
+	check  func(context.Context) strategy.GitHookIntegrationHealth
+	repair func(context.Context) error
+}
+
+type lifecycleHookHealthClaim struct {
+	message     string
+	fingerprint string
+	claimed     bool
+}
+
+var defaultLifecycleHookHealthOps = lifecycleHookHealthOps{
+	check:  strategy.CheckGitHookIntegration,
+	repair: strategy.EnsureSetup,
+}
+
+func lifecycleHookHealthFingerprint(health strategy.GitHookIntegrationHealth) string {
+	data, err := json.Marshal([4]string{string(health.Mode), string(health.State), health.Manager, health.ReasonCode})
+	if err != nil {
+		return "" // [4]string is always JSON-encodable; retain fail-open behavior if that changes.
+	}
+	return string(data)
+}
+
+func lifecycleHookHealthWarning(health strategy.GitHookIntegrationHealth) string {
+	if health.State == strategy.GitHookIntegrationCurrent {
+		return ""
+	}
+	owner := string(health.Mode)
+	if health.Manager != "" {
+		owner += "/" + health.Manager
+	}
+	return fmt.Sprintf("Entire's Git hook integration is %s (%s). Run 'entire doctor' to diagnose and repair it.", health.State, owner)
+}
+
+func repairLifecycleHookHealth(
+	ctx context.Context,
+	ag agent.Agent,
+	sessionID string,
+	ops lifecycleHookHealthOps,
+) lifecycleHookHealthClaim {
+	repairErr := ops.repair(ctx)
+	health := ops.check(ctx)
+	if repairErr != nil && health.State == strategy.GitHookIntegrationCurrent {
+		health.State = strategy.GitHookIntegrationError
+		health.ReasonCode = "hook_repair_failed"
+	}
+	if repairErr != nil || health.State != strategy.GitHookIntegrationCurrent {
+		// Do not log repairErr or health.Reason here: setup errors can include
+		// repository content. Stable classification fields are sufficient for
+		// diagnosis without leaking prompts, files, or commit messages.
+		logging.Warn(ctx, "git hook integration repair incomplete",
+			slog.String("session_id", sessionID),
+			slog.String("mode", string(health.Mode)),
+			slog.String("state", string(health.State)),
+			slog.String("manager", health.Manager),
+			slog.String("reason_code", health.ReasonCode))
+	}
+	warning := lifecycleHookHealthWarning(health)
+	if warning == "" {
+		return lifecycleHookHealthClaim{}
+	}
+	if _, ok := agent.AsHookResponseWriter(ag); !ok {
+		return lifecycleHookHealthClaim{}
+	}
+	fingerprint := lifecycleHookHealthFingerprint(health)
+	claimed, err := strategy.ClaimHookHealthWarning(ctx, sessionID, fingerprint)
+	if err != nil {
+		// Claim failures fail open: show the warning without persisting a
+		// suppression marker. A later turn can retry the atomic claim.
+		logging.Warn(ctx, "failed to claim hook health warning",
+			slog.String("session_id", sessionID),
+			slog.String("mode", string(health.Mode)),
+			slog.String("state", string(health.State)),
+			slog.String("manager", health.Manager),
+			slog.String("reason_code", health.ReasonCode))
+		return lifecycleHookHealthClaim{message: warning}
+	}
+	if !claimed {
+		return lifecycleHookHealthClaim{}
+	}
+	return lifecycleHookHealthClaim{message: warning, fingerprint: fingerprint, claimed: true}
+}
+
 // handleLifecycleSessionStart handles session start: shows banner, checks concurrent sessions,
 // fires state machine transition.
 func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *agent.Event) error {
@@ -231,6 +316,11 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 	// agent-help banner pointer so it survives the override — banner-only agents
 	// (Factory Droid) have no other in-session channel for it.
 	message = finalizeSessionStartBanner(message, event.ResponseMessage, ag.Name())
+	hookHealth := defaultLifecycleHookHealthOps.check(ctx)
+	hookHealthWarning := lifecycleHookHealthWarning(hookHealth)
+	if hookHealthWarning != "" {
+		message += "\n  " + hookHealthWarning
+	}
 	if writer, ok := agent.AsHookResponseWriter(ag); ok {
 		bannerFirst, bErr := strategy.ClaimSessionStartBanner(ctx, event.SessionID)
 		if bErr != nil {
@@ -244,6 +334,16 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 				hookResponseSpan.RecordError(err)
 				hookResponseSpan.End()
 				return fmt.Errorf("failed to write hook response: %w", err)
+			}
+			if hookHealthWarning != "" {
+				if err := strategy.StoreHookHealthWarningHint(ctx, event.SessionID, lifecycleHookHealthFingerprint(hookHealth)); err != nil {
+					logging.Warn(logCtx, "failed to store hook health warning hint",
+						slog.String("session_id", event.SessionID),
+						slog.String("mode", string(hookHealth.Mode)),
+						slog.String("state", string(hookHealth.State)),
+						slog.String("manager", hookHealth.Manager),
+						slog.String("reason_code", hookHealth.ReasonCode))
+				}
 			}
 		}
 	}
@@ -484,14 +584,12 @@ func entireTrailContextInjection(scope trailEnablementScope) string {
 	return b.String()
 }
 
-// emitContextInjection writes ag's native context-injection payload to stdout
-// when ag injects at event.Type, trails are enabled for the repo on the API,
-// and this session has not been injected yet. Best-effort: an injection failure
-// never fails the hook.
-func emitContextInjection(ctx context.Context, ag agent.Agent, event *agent.Event) {
+// renderContextInjection prepares ag's native context-injection payload when
+// trails are enabled and this session has not been injected yet.
+func renderContextInjection(ctx context.Context, ag agent.Agent, event *agent.Event) []byte {
 	injector, ok := agent.AsContextInjector(ag)
 	if !ok || injector.InjectionEvent() != event.Type || event.SessionID == "" {
-		return
+		return nil
 	}
 	logCtx := logging.WithAgent(logging.WithComponent(ctx, "lifecycle"), ag.Name())
 
@@ -500,7 +598,7 @@ func emitContextInjection(ctx context.Context, ag agent.Agent, event *agent.Even
 	if scopeErr != nil {
 		logging.Warn(logCtx, "failed to load trails scope hint",
 			slog.String("error", scopeErr.Error()))
-		return
+		return nil
 	}
 	decision := trailEnablementCacheUnknown
 	mutated := false
@@ -528,29 +626,109 @@ func emitContextInjection(ctx context.Context, ag agent.Agent, event *agent.Even
 	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to record context injection decision",
 			slog.String("error", mutErr.Error()))
-		return
+		return nil
 	}
 	// Only proceed after the state mutation was persisted. If saving the updated
 	// state failed, mutErr was non-nil above and we returned without injecting,
 	// leaving a later turn free to retry safely.
 	won := mutErr == nil && mutated
 	if !won || decision != trailEnablementCacheEnabled {
-		return
+		return nil
 	}
 
 	payload, err := injector.RenderContextInjection(agent.ContextInjection{Text: entireTrailContextInjection(scope)})
 	if err != nil {
 		logging.Warn(logCtx, "failed to render context injection",
 			slog.String("error", err.Error()))
-		return
+		return nil
 	}
-	if len(payload) == 0 {
-		return
+	return payload
+}
+
+// mergeTurnStartHookResponse adds a user-visible systemMessage to a native
+// JSON context-injection payload. Claude Code and Codex require one JSON value
+// on stdout; emitting HookResponseWriter output separately would concatenate
+// two values and make the response invalid.
+func mergeTurnStartHookResponse(payload []byte, message string) ([]byte, error) {
+	var response map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return nil, fmt.Errorf("decode native hook response: %w", err)
 	}
-	if _, err := os.Stdout.Write(payload); err != nil {
+	encoded, err := json.Marshal(message)
+	if err != nil {
+		return nil, fmt.Errorf("encode hook warning: %w", err)
+	}
+	response["systemMessage"] = encoded
+	combined, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("encode combined hook response: %w", err)
+	}
+	return append(combined, '\n'), nil
+}
+
+// emitTurnStartOutput writes at most one native response. It returns whether
+// the hook-health warning reached stdout so callers can roll back a claim on
+// output failure.
+func emitTurnStartOutput(ctx context.Context, ag agent.Agent, event *agent.Event, warning string) bool {
+	payload := renderContextInjection(ctx, ag, event)
+	return emitPreparedTurnStartOutput(ctx, ag, event, payload, warning)
+}
+
+func emitPreparedTurnStartOutput(ctx context.Context, ag agent.Agent, event *agent.Event, payload []byte, warning string) bool {
+	logCtx := logging.WithAgent(logging.WithComponent(ctx, "lifecycle"), ag.Name())
+	if len(payload) > 0 && warning != "" {
+		if writer, standalone := agent.AsStandaloneHookResponseWriter(ag); standalone {
+			if err := writer.WriteHookResponse(warning); err != nil {
+				logging.Warn(logCtx, "failed to write standalone turn-start warning",
+					slog.String("session_id", event.SessionID))
+				return false
+			}
+			// Gemini cannot carry additionalContext beside its plain-text warning.
+			// Undo the decision claimed while rendering so a later warning-free
+			// turn can inject the context instead of losing it permanently.
+			if err := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
+				if !state.ContextInjectionDecided {
+					return strategy.ErrMutationSkip
+				}
+				state.ContextInjectionDecided = false
+				return nil
+			}); err != nil && !errors.Is(err, strategy.ErrStateNotFound) {
+				logging.Warn(logCtx, "failed to defer context injection",
+					slog.String("session_id", event.SessionID))
+			}
+			return true
+		}
+		combined, err := mergeTurnStartHookResponse(payload, warning)
+		if err != nil {
+			logging.Warn(logCtx, "failed to combine turn-start hook response")
+			return false
+		}
+		if _, err := os.Stdout.Write(combined); err != nil {
+			logging.Warn(logCtx, "failed to write combined turn-start response")
+			return false
+		}
+		return true
+	}
+	if len(payload) > 0 {
+		if _, err := os.Stdout.Write(payload); err != nil {
+			logging.Warn(logCtx, "failed to write context injection",
+				slog.String("error", err.Error()))
+		}
+		return false
+	}
+	if warning == "" {
+		return false
+	}
+	writer, ok := agent.AsHookResponseWriter(ag)
+	if !ok {
+		return false
+	}
+	if err := writer.WriteHookResponse(warning); err != nil {
 		logging.Warn(logCtx, "failed to write context injection",
-			slog.String("error", err.Error()))
+			slog.String("session_id", event.SessionID))
+		return false
 	}
+	return true
 }
 
 // turnStartSessionLockWait bounds how long the TurnStart hook waits for the
@@ -597,10 +775,17 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 	// it before CapturePrePromptState: the snapshot should describe the tree the
 	// agent starts from, not one setup is about to change.
 	_, setupSpan := perf.Start(ctx, "ensure_setup")
-	if err := strategy.EnsureSetup(ctx); err != nil {
-		logging.Warn(logCtx, "failed to ensure strategy setup",
-			slog.String("error", err.Error()))
-	}
+	hookHealthClaim := repairLifecycleHookHealth(logCtx, ag, sessionID, defaultLifecycleHookHealthOps)
+	hookHealthEmitted := false
+	defer func() {
+		if !hookHealthClaim.claimed || hookHealthEmitted {
+			return
+		}
+		if err := strategy.RollbackHookHealthWarningClaim(ctx, sessionID, hookHealthClaim.fingerprint); err != nil {
+			logging.Warn(logCtx, "failed to roll back hook health warning claim",
+				slog.String("session_id", sessionID))
+		}
+	}()
 	setupSpan.End()
 
 	// Capture pre-prompt state (including transcript position via TranscriptAnalyzer)
@@ -641,6 +826,10 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 	if err := strat.InitializeSession(ctx, sessionID, ag.Type(), event.SessionRef, event.Prompt, event.Model); err != nil {
 		logging.Warn(logCtx, "failed to initialize session state",
 			slog.String("error", err.Error()))
+	}
+	if err := strategy.TransferHookHealthWarningHint(ctx, sessionID); err != nil && !errors.Is(err, strategy.ErrStateNotFound) {
+		logging.Warn(logCtx, "failed to transfer hook health warning hint",
+			slog.String("session_id", sessionID))
 	}
 
 	// Best-effort: adopt ENTIRE_REVIEW_* / ENTIRE_INVESTIGATE_* env vars set
@@ -699,7 +888,7 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 
 	// Inject Entire's model-facing context (once per session) for agents whose
 	// transport supports it at TurnStart (e.g. Pi). Extension reads stdout.
-	emitContextInjection(ctx, ag, event)
+	hookHealthEmitted = emitTurnStartOutput(ctx, ag, event, hookHealthClaim.message)
 
 	return nil
 }

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,12 +24,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
+	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
 	"github.com/entireio/cli/cmd/entire/cli/agent/opencode"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/entiredir"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/investigate"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/review"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -475,6 +482,231 @@ func newMockHookResponseAgent() *mockHookResponseAgent {
 			agentType: "Mock HRW Agent",
 		},
 	}
+}
+
+func TestLifecycleHookHealthWarningUsesStableFingerprintAndSafeCopy(t *testing.T) {
+	t.Parallel()
+	health := strategy.GitHookIntegrationHealth{
+		Mode: strategy.GitHookIntegrationLefthook, State: strategy.GitHookIntegrationError,
+		Manager: "Lefthook", ReasonCode: "owned_entry_conflict", Reason: "secret prompt and commit message",
+	}
+	warning := lifecycleHookHealthWarning(health)
+	require.Contains(t, warning, "Lefthook")
+	require.Contains(t, warning, "error")
+	require.Contains(t, warning, "entire doctor")
+	require.NotContains(t, warning, health.Reason)
+
+	first := lifecycleHookHealthFingerprint(health)
+	health.Reason = "different free-form copy"
+	require.Equal(t, first, lifecycleHookHealthFingerprint(health))
+	health.ReasonCode = "different_code"
+	require.NotEqual(t, first, lifecycleHookHealthFingerprint(health))
+}
+
+func TestLifecycleHookHealthRepairWarnsOnceThenAgainWhenFingerprintChanges(t *testing.T) {
+	setupStopTestRepo(t)
+	ctx := context.Background()
+	const sessionID = "hook-health-dedup"
+	ag := newMockHookResponseAgent()
+	repairs := 0
+	health := strategy.GitHookIntegrationHealth{
+		Mode: strategy.GitHookIntegrationLefthook, State: strategy.GitHookIntegrationError,
+		Manager: "Lefthook", ReasonCode: "conflict",
+	}
+	ops := lifecycleHookHealthOps{
+		repair: func(context.Context) error { repairs++; return errors.New("sensitive repair detail") },
+		check:  func(context.Context) strategy.GitHookIntegrationHealth { return health },
+	}
+	logCtx := logging.WithComponent(ctx, "test")
+
+	claim := repairLifecycleHookHealth(logCtx, ag, sessionID, ops)
+	require.Equal(t, 1, repairs)
+	require.Contains(t, claim.message, "entire doctor")
+	_, found, err := strategy.LoadHookHealthWarningHint(ctx, sessionID)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	claim = repairLifecycleHookHealth(logCtx, ag, sessionID, ops)
+	require.Equal(t, 2, repairs, "repair is attempted on every turn")
+	require.Empty(t, claim.message, "same fingerprint is warned only once")
+
+	health.ReasonCode = "changed-conflict"
+	claim = repairLifecycleHookHealth(logCtx, ag, sessionID, ops)
+	require.Equal(t, 3, repairs)
+	require.Contains(t, claim.message, "entire doctor", "changed failures warn again")
+}
+
+func TestTurnStartHookHealthWarningMergesWithNativeContextAsOneJSONValue(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		ag   agent.Agent
+	}{
+		{name: "claude-code", ag: &claudecode.ClaudeCodeAgent{}},
+		{name: "codex", ag: &codex.CodexAgent{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			injector, ok := agent.AsContextInjector(tc.ag)
+			require.True(t, ok)
+			payload, err := injector.RenderContextInjection(agent.ContextInjection{Text: "trail context"})
+			require.NoError(t, err)
+
+			combined, err := mergeTurnStartHookResponse(payload, "repair hooks")
+			require.NoError(t, err)
+			dec := json.NewDecoder(strings.NewReader(string(combined)))
+			var got struct {
+				SystemMessage      string `json:"systemMessage"`
+				HookSpecificOutput struct {
+					AdditionalContext string `json:"additionalContext"`
+				} `json:"hookSpecificOutput"`
+			}
+			require.NoError(t, dec.Decode(&got))
+			require.Equal(t, "repair hooks", got.SystemMessage)
+			require.Equal(t, "trail context", got.HookSpecificOutput.AdditionalContext)
+			var extra any
+			require.ErrorIs(t, dec.Decode(&extra), io.EOF, "stdout payload must contain exactly one JSON value")
+		})
+	}
+}
+
+func TestGeminiTurnStartHookHealthWarningUsesOnePlainTextResponseAndRetriesContext(t *testing.T) {
+	setupStopTestRepo(t)
+	const sessionID = "gemini-health-context-collision"
+	require.NoError(t, strategy.SaveSessionState(t.Context(), &strategy.SessionState{
+		SessionID: sessionID, BaseCommit: "abc", StartedAt: time.Now(), ContextInjectionDecided: true,
+	}))
+	event := &agent.Event{Type: agent.TurnStart, SessionID: sessionID}
+	ag := &geminicli.GeminiCLIAgent{}
+	payload, err := ag.RenderContextInjection(agent.ContextInjection{Text: "trail context"})
+	require.NoError(t, err)
+
+	out := captureLifecycleStdout(t, func() {
+		require.True(t, emitPreparedTurnStartOutput(t.Context(), ag, event, payload, "repair hooks"))
+	})
+	require.Equal(t, "repair hooks\n", out)
+	require.False(t, strings.HasPrefix(strings.TrimSpace(out), "{"), "Gemini JSON systemMessage double-displays")
+
+	state, err := strategy.LoadSessionState(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.False(t, state.ContextInjectionDecided, "deferred additionalContext must retry on the next warning-free turn")
+}
+
+func captureLifecycleStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	original := os.Stdout
+	os.Stdout = w
+	done := make(chan []byte, 1)
+	go func() {
+		data, _ := io.ReadAll(r) //nolint:errcheck // assertion below checks emitted bytes
+		done <- data
+	}()
+	fn()
+	require.NoError(t, w.Close())
+	os.Stdout = original
+	data := <-done
+	require.NoError(t, r.Close())
+	return string(data)
+}
+
+func TestLifecycleHookHealthStructuredLogExcludesSensitiveDetails(t *testing.T) {
+	setupStopTestRepo(t)
+	repoDir, err := os.Getwd()
+	require.NoError(t, err)
+	logger, err := logging.New(logging.Config{Root: entiredir.OpenerAt(repoDir), Dir: logging.LogsName})
+	require.NoError(t, err)
+	ctx := logging.WithLogger(context.Background(), logger)
+	const secret = "prompt-content-commit-secret"
+	health := strategy.GitHookIntegrationHealth{
+		Mode: strategy.GitHookIntegrationLefthook, State: strategy.GitHookIntegrationError,
+		Manager: "Lefthook", ReasonCode: "conflict", Reason: "reason contains " + secret,
+	}
+	repairLifecycleHookHealth(logging.WithComponent(ctx, "test"), newMockHookResponseAgent(), "privacy-session", lifecycleHookHealthOps{
+		repair: func(context.Context) error { return errors.New("repair contains " + secret) },
+		check:  func(context.Context) strategy.GitHookIntegrationHealth { return health },
+	})
+	require.NoError(t, logger.Close())
+	data, err := os.ReadFile(filepath.Join(repoDir, logging.LogsDir, logging.LogFileName))
+	require.NoError(t, err)
+	require.NotContains(t, string(data), secret)
+	require.NotContains(t, string(data), health.Reason)
+	require.Contains(t, string(data), `"reason_code":"conflict"`)
+}
+
+func TestLifecycleHookHealthConcurrentTurnStartsReturnOneWarning(t *testing.T) {
+	setupStopTestRepo(t)
+	const sessionID = "hook-health-turn-start-race"
+	health := strategy.GitHookIntegrationHealth{
+		Mode: strategy.GitHookIntegrationLefthook, State: strategy.GitHookIntegrationError,
+		Manager: "Lefthook", ReasonCode: "conflict",
+	}
+	ops := lifecycleHookHealthOps{
+		repair: func(context.Context) error { return errors.New("still broken") },
+		check:  func(context.Context) strategy.GitHookIntegrationHealth { return health },
+	}
+	const callers = 12
+	start := make(chan struct{})
+	claims := make(chan lifecycleHookHealthClaim, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			claims <- repairLifecycleHookHealth(context.Background(), newMockHookResponseAgent(), sessionID, ops)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(claims)
+	warnings := 0
+	for claim := range claims {
+		if claim.message != "" {
+			warnings++
+		}
+	}
+	require.Equal(t, 1, warnings)
+}
+
+func TestLifecycleHookHealthHintPrecedesPersistedState(t *testing.T) {
+	setupStopTestRepo(t)
+	ctx := context.Background()
+	const sessionID = "hook-health-precedence"
+	require.NoError(t, strategy.SaveSessionState(ctx, &strategy.SessionState{
+		SessionID: sessionID, BaseCommit: "abc", StartedAt: time.Now(), LastHookHealthWarning: "state-value",
+	}))
+	const hint = `["lefthook","error","Lefthook","newer"]`
+	require.NoError(t, strategy.StoreHookHealthWarningHint(ctx, sessionID, hint))
+	claimed, err := strategy.ClaimHookHealthWarning(ctx, sessionID, hint)
+	require.NoError(t, err)
+	require.False(t, claimed, "pending hint takes precedence over the older persisted state")
+}
+
+func TestLifecycleSessionStartHookHealthWarningAndHealthySilence(t *testing.T) {
+	setupStopTestRepo(t)
+	ctx := context.Background()
+
+	unhealthy := newMockHookResponseAgent()
+	require.NoError(t, handleLifecycleSessionStart(ctx, unhealthy, &agent.Event{
+		Type: agent.SessionStart, SessionID: "hook-health-unhealthy", Timestamp: time.Now(),
+	}))
+	require.Contains(t, unhealthy.lastMessage, "entire doctor")
+	_, found, err := strategy.LoadHookHealthWarningHint(ctx, "hook-health-unhealthy")
+	require.NoError(t, err)
+	require.True(t, found, "emitted banner warning must persist its fingerprint hint")
+
+	_, err = strategy.EnsureGitHookIntegration(ctx, false)
+	require.NoError(t, err)
+	healthy := newMockHookResponseAgent()
+	require.NoError(t, handleLifecycleSessionStart(ctx, healthy, &agent.Event{
+		Type: agent.SessionStart, SessionID: "hook-health-healthy", Timestamp: time.Now(),
+	}))
+	require.NotContains(t, healthy.lastMessage, "Git hook integration")
+	_, found, err = strategy.LoadHookHealthWarningHint(ctx, "hook-health-healthy")
+	require.NoError(t, err)
+	require.False(t, found, "healthy banner must not create a warning hint")
 }
 
 // TestHandleLifecycleSessionStart_StoresAgentTypeHint verifies the

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -536,6 +536,42 @@ func TestLifecycleHookHealthRepairWarnsOnceThenAgainWhenFingerprintChanges(t *te
 	require.Contains(t, claim.message, "entire doctor", "changed failures warn again")
 }
 
+func TestLifecycleHookHealthRecoveryClearsWarningSuppression(t *testing.T) {
+	setupStopTestRepo(t)
+	ctx := context.Background()
+	const sessionID = "hook-health-recovery"
+	const fingerprint = `["lefthook","error","Lefthook","conflict"]`
+	require.NoError(t, strategy.SaveSessionState(ctx, &strategy.SessionState{
+		SessionID: sessionID, BaseCommit: "abc", StartedAt: time.Now(), LastHookHealthWarning: fingerprint,
+	}))
+	require.NoError(t, strategy.StoreHookHealthWarningHint(ctx, sessionID, fingerprint))
+
+	health := strategy.GitHookIntegrationHealth{
+		Mode: strategy.GitHookIntegrationNative, State: strategy.GitHookIntegrationCurrent,
+	}
+	ops := lifecycleHookHealthOps{
+		repair: func(context.Context) error { return errors.New("unrelated setup failure") },
+		check:  func(context.Context) strategy.GitHookIntegrationHealth { return health },
+	}
+	claim := repairLifecycleHookHealth(ctx, newMockHookResponseAgent(), sessionID, ops)
+	require.Empty(t, claim.message, "current hooks must not be reported broken by an unrelated setup failure")
+
+	_, found, err := strategy.LoadHookHealthWarningHint(ctx, sessionID)
+	require.NoError(t, err)
+	require.False(t, found, "recovery must consume the pre-state warning hint")
+	state, err := strategy.LoadSessionState(ctx, sessionID)
+	require.NoError(t, err)
+	require.NotEqual(t, fingerprint, state.LastHookHealthWarning,
+		"recovery must replace the unhealthy durable warning suppression")
+
+	health = strategy.GitHookIntegrationHealth{
+		Mode: strategy.GitHookIntegrationLefthook, State: strategy.GitHookIntegrationError,
+		Manager: "Lefthook", ReasonCode: "conflict",
+	}
+	claim = repairLifecycleHookHealth(ctx, newMockHookResponseAgent(), sessionID, ops)
+	require.Contains(t, claim.message, "entire doctor", "the same failure must warn if it recurs after recovery")
+}
+
 func TestTurnStartHookHealthWarningMergesWithNativeContextAsOneJSONValue(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {

--- a/cmd/entire/cli/osroot/rootbase_guard_test.go
+++ b/cmd/entire/cli/osroot/rootbase_guard_test.go
@@ -45,16 +45,17 @@ var allowedRootBases = map[string]string{
 
 	// Trees with their own resolver, anchored at the boundary between what
 	// Entire owns and what it does not.
-	"cmd/entire/cli/agent/session_store.go":      "the agent's own GetSessionDir (opened per operation, not memoized)",
-	"cmd/entire/cli/agent/vouched_dirs.go":       "worktree root, or a symlinked agent directory the user vouched for in settings.local.json, resolved",
-	"cmd/entire/cli/strategy/hooks.go":           "git rev-parse --git-path hooks; core.hooksPath can name a directory no other anchor covers",
-	"cmd/entire/cli/plugin_store.go":             "pluginParentDir()",
-	"cmd/entire/cli/plugin_index.go":             "the per-index cache dir, opened at the clone it contains",
-	"cmd/entire/cli/plugin_install_remote.go":    "a staging dir this process just created",
-	"cmd/entire/cli/plugin_fetch.go":             "the staging dir its caller created",
-	"cmd/entire/cli/utils.go":                    "one of worktree root / home / temp, chosen by containment",
-	"internal/entireclient/contexts/contexts.go": "the caller's config dir, not the contexts file's parent",
-	"internal/entireclient/discovery/cache.go":   "the caller's cache dir, not the cache file's parent",
+	"cmd/entire/cli/agent/session_store.go":                   "the agent's own GetSessionDir (opened per operation, not memoized)",
+	"cmd/entire/cli/agent/vouched_dirs.go":                    "worktree root, or a symlinked agent directory the user vouched for in settings.local.json, resolved",
+	"cmd/entire/cli/strategy/hooks.go":                        "git rev-parse --git-path hooks; core.hooksPath can name a directory no other anchor covers",
+	"cmd/entire/cli/strategy/hook_integration_transaction.go": "the fixed filesystem volume root; core.hooksPath can resolve outside both the worktree and git common directory",
+	"cmd/entire/cli/plugin_store.go":                          "pluginParentDir()",
+	"cmd/entire/cli/plugin_index.go":                          "the per-index cache dir, opened at the clone it contains",
+	"cmd/entire/cli/plugin_install_remote.go":                 "a staging dir this process just created",
+	"cmd/entire/cli/plugin_fetch.go":                          "the staging dir its caller created",
+	"cmd/entire/cli/utils.go":                                 "one of worktree root / home / temp, chosen by containment",
+	"internal/entireclient/contexts/contexts.go":              "the caller's config dir, not the contexts file's parent",
+	"internal/entireclient/discovery/cache.go":                "the caller's cache dir, not the cache file's parent",
 
 	// The two deliberate exceptions, both on a path the CALLER named, where
 	// the file's parent IS the caller's choice and no other base exists. Each

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -217,6 +217,11 @@ type State struct {
 	// warning by `entire status`.
 	CaptureDegradedAt *time.Time `json:"capture_degraded_at,omitempty"`
 
+	// LastHookHealthWarning is the stable health fingerprint most recently
+	// shown to this session. Human-readable warning copy is deliberately not
+	// persisted so copy changes do not cause repeated warnings.
+	LastHookHealthWarning string `json:"last_hook_health_warning,omitempty"`
+
 	// StepCount is the number of checkpoints/steps created in this session.
 	// JSON tag kept as "checkpoint_count" for backward compatibility with existing state files.
 	StepCount int `json:"checkpoint_count"`
@@ -950,6 +955,12 @@ func NewStateStoreWithDir(stateDir string) *StateStore {
 // Returns (nil, nil) when session file doesn't exist or session is stale (not an error condition).
 // Stale sessions (ended longer than StaleSessionThreshold ago) are automatically deleted.
 func (s *StateStore) Load(ctx context.Context, sessionID string) (*State, error) {
+	return s.load(ctx, sessionID, true)
+}
+
+// load reads one session. When deleteStale is false, stale records are omitted
+// without performing the best-effort cleanup used by ordinary store reads.
+func (s *StateStore) load(ctx context.Context, sessionID string, deleteStale bool) (*State, error) {
 	// Validate session ID to prevent path traversal
 	if err := validation.ValidateSessionID(sessionID); err != nil {
 		return nil, fmt.Errorf("invalid session ID: %w", err)
@@ -980,6 +991,9 @@ func (s *StateStore) Load(ctx context.Context, sessionID string) (*State, error)
 	state.NormalizeAfterLoad(ctx)
 
 	if state.IsStale() {
+		if !deleteStale {
+			return &state, nil
+		}
 		logCtx := logging.WithComponent(ctx, "session")
 		logging.Debug(logCtx, "deleting stale session state",
 			slog.String("session_id", sessionID),
@@ -1085,6 +1099,17 @@ func (s *StateStore) RemoveAll() error {
 
 // List returns all session states.
 func (s *StateStore) List(ctx context.Context) ([]*State, error) {
+	return s.list(ctx, true)
+}
+
+// ListReadOnly returns every persisted session without deleting or hiding stale
+// records. Passive surfaces such as status derive display state without letting
+// observation change repository state.
+func (s *StateStore) ListReadOnly(ctx context.Context) ([]*State, error) {
+	return s.list(ctx, false)
+}
+
+func (s *StateStore) list(ctx context.Context, deleteStale bool) ([]*State, error) {
 	root, err := s.dirRoot()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open session state directory: %w", err)
@@ -1107,7 +1132,7 @@ func (s *StateStore) List(ctx context.Context) ([]*State, error) {
 		}
 
 		sessionID := strings.TrimSuffix(entry.Name(), ".json")
-		state, err := s.Load(ctx, sessionID)
+		state, err := s.load(ctx, sessionID, deleteStale)
 		if err != nil {
 			continue // Skip corrupted state files
 		}

--- a/cmd/entire/cli/session/state_test.go
+++ b/cmd/entire/cli/session/state_test.go
@@ -265,6 +265,33 @@ func TestState_NormalizeAfterLoad_JSONRoundTrip(t *testing.T) {
 	}
 }
 
+func TestState_LastHookHealthWarningRoundTrip(t *testing.T) {
+	t.Parallel()
+	want := `["lefthook","error","Lefthook","owned_entry_conflict"]`
+	data, err := json.Marshal(&State{SessionID: "hook-health", LastHookHealthWarning: want})
+	require.NoError(t, err)
+	var got State
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, want, got.LastHookHealthWarning)
+}
+
+func TestStateStoreListReadOnlyRetainsStaleActiveAndIdleSessions(t *testing.T) {
+	t.Parallel()
+	store := NewStateStoreWithDir(filepath.Join(t.TempDir(), SessionStateDirName))
+	old := time.Now().Add(-2 * StaleSessionThreshold)
+	for _, state := range []*State{
+		{SessionID: "stale-active", StartedAt: old, LastInteractionTime: &old, Phase: PhaseActive},
+		{SessionID: "stale-idle", StartedAt: old, LastInteractionTime: &old, Phase: PhaseIdle},
+	} {
+		require.NoError(t, store.Save(t.Context(), state))
+	}
+
+	got, err := store.ListReadOnly(t.Context())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, []string{"stale-active", "stale-idle"}, []string{got[0].SessionID, got[1].SessionID})
+}
+
 func TestState_IsStale(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -342,7 +342,7 @@ func updateGlobalSettings(ctx context.Context, cmd *cobra.Command, w io.Writer, 
 	}
 
 	if cmd.Flags().Changed(flagForce) || cmd.Flags().Changed(flagAbsoluteGitHookPath) {
-		if _, err := strategy.InstallGitHook(ctx, true, s.AbsoluteGitHookPath); err != nil {
+		if _, err := strategy.EnsureGitHookIntegration(ctx, s.AbsoluteGitHookPath); err != nil {
 			return fmt.Errorf("failed to reinstall git hook: %w", err)
 		}
 		strategy.CheckAndWarnHookManagers(ctx, w, s.AbsoluteGitHookPath)
@@ -1355,7 +1355,7 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 
 	// Use settings values (merged from existing config + flags) for hook installation
 	// This ensures re-running `entire enable` without flags preserves existing settings
-	if _, err := strategy.InstallGitHook(ctx, true, settings.AbsoluteGitHookPath); err != nil {
+	if _, err := strategy.EnsureGitHookIntegration(ctx, settings.AbsoluteGitHookPath); err != nil {
 		return fmt.Errorf("failed to install git hooks: %w", err)
 	}
 	strategy.CheckAndWarnHookManagers(ctx, w, settings.AbsoluteGitHookPath)
@@ -2064,7 +2064,7 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 	}
 	hookAbsoluteGitHookPath := mergedSettings.AbsoluteGitHookPath || opts.AbsoluteGitHookPath
 
-	if _, err := strategy.InstallGitHook(ctx, true, hookAbsoluteGitHookPath); err != nil {
+	if _, err := strategy.EnsureGitHookIntegration(ctx, hookAbsoluteGitHookPath); err != nil {
 		return fmt.Errorf("failed to install git hooks: %w", err)
 	}
 	strategy.CheckAndWarnHookManagers(ctx, w, hookAbsoluteGitHookPath)
@@ -2556,10 +2556,10 @@ func runUninstall(ctx context.Context, w, errW io.Writer, force bool) error {
 	// Gather counts for display
 	sessionStateCount := countSessionStates(ctx)
 	shadowBranchCount := countShadowBranches(ctx)
-	// AnyGitHookInstalled, not IsGitHookInstalled: a hook left by an older
-	// version is stale but still ours, and uninstall must still offer to remove
-	// it rather than reporting that Entire is not installed here.
-	gitHooksInstalled := strategy.AnyGitHookInstalled(ctx)
+	// Inspect every supported integration, not only current native wrappers: a
+	// stale hook or Lefthook artifact is still ours, and uninstall must remain
+	// discoverable after a partial run has already removed .entire.
+	gitHooksInstalled := strategy.AnyGitHookIntegrationInstalled(ctx)
 	// One sweep, threaded onwards: each external plugin costs a subprocess to ask,
 	// and the removal below must act on exactly what the summary showed.
 	agHookState := getAgentHookState(ctx)
@@ -2623,7 +2623,7 @@ func runUninstall(ctx context.Context, w, errW io.Writer, force bool) error {
 // Failures render in the same shape as a failed agent-hook removal: a red ✗
 // headline naming the step, with the reason nested beneath it.
 func uninstallGitHooks(ctx context.Context, p *uninstallPrinter) bool {
-	removed, err := strategy.RemoveGitHook(ctx)
+	removed, err := strategy.RemoveGitHookIntegration(ctx)
 	if err != nil {
 		p.stepFailed("Failed to remove git hooks")
 		p.warnUnder("failed to remove git hooks: %v", err)

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1186,6 +1186,11 @@ func runEnableOnConfiguredRepo(ctx context.Context, cmd *cobra.Command, opts Ena
 				return err
 			}
 		}
+		if hasGlobalSettingsFlags(cmd) {
+			if err := updateGlobalSettings(ctx, cmd, w, opts); err != nil {
+				return err
+			}
+		}
 		if enableNeedsAgentManagement(cmd) {
 			var selectFn func(available []string) ([]string, error)
 			if opts.Yes {

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -430,13 +430,17 @@ func checkpointStorageLabel(backend string) string {
 func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings, checkpointBackend string) checkpointSyncInfo {
 	elected, err := strategy.ResolveCheckpointSyncRemote(ctx)
 	if err != nil {
-		// Fail-closed: checkpoint_push_remote names a remote that does not
-		// exist. The pre-push gate is silently skipping checkpoint sync, so
-		// status is the user's signal.
-		// Accepted divergence: if a structured checkpoint_remote is also
-		// configured, the gate's dedicated exemption may still sync checkpoint
-		// data even while this fail-closed warning is shown, since there is no
-		// elected remote left to probe PushURL against here.
+		// A dedicated checkpoint remote is exempt from elected-remote gating in
+		// pre-push. Probe configured remotes before failing closed so a stale explicit
+		// checkpoint_push_remote cannot make status contradict that working
+		// delivery path.
+		for _, remoteName := range configuredRemoteNamesForStatus(ctx) {
+			if info, ok := dedicatedCheckpointSyncInfo(ctx, s, checkpointBackend, remoteName); ok {
+				return info
+			}
+		}
+		// No dedicated route is available: checkpoint_push_remote names a
+		// remote that does not exist, so pre-push cannot elect a destination.
 		return checkpointSyncInfo{Err: err.Error()}
 	}
 	if elected.Name == "" {
@@ -451,19 +455,8 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings, checkpoin
 	// metadata fetch dials, and status must stay network-free.
 	// Accepted divergence: a real push to a different named remote may derive
 	// PushURL differently than this elected-remote probe does.
-	if cr := s.GetCheckpointRemote(); cr != nil {
-		if _, enabled, purlErr := checkpointremote.PushURL(ctx, elected.Name); purlErr == nil && enabled {
-			info := checkpointSyncInfo{Remote: cr.Repo, Source: checkpointSyncSourceDedicated}
-			// The unpushed counter is meaningful here only on the git-refs
-			// backend (push-queue length is local and accurate). The
-			// git-branch comparison is omitted: pushes to a raw URL update
-			// no remote-tracking ref, so it would permanently read "all
-			// unpushed".
-			if checkpointBackend == checkpoint.BackendTypeGitRefs {
-				info.Unpushed = countUnpushedCheckpointsForStatus(ctx, "")
-			}
-			return info
-		}
+	if info, ok := dedicatedCheckpointSyncInfo(ctx, s, checkpointBackend, elected.Name); ok {
+		return info
 	}
 
 	info := checkpointSyncInfo{
@@ -486,6 +479,48 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings, checkpoin
 		}
 	}
 	return info
+}
+
+func configuredRemoteNamesForStatus(ctx context.Context) []string {
+	repo, err := strategy.OpenRepository(ctx)
+	if err != nil {
+		return nil
+	}
+	defer repo.Close()
+	remotes, err := repo.Remotes()
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(remotes))
+	for _, remote := range remotes {
+		if config := remote.Config(); config != nil && config.Name != "" {
+			names = append(names, config.Name)
+		}
+	}
+	return names
+}
+
+func dedicatedCheckpointSyncInfo(
+	ctx context.Context,
+	s *EntireSettings,
+	checkpointBackend string,
+	pushRemote string,
+) (checkpointSyncInfo, bool) {
+	cr := s.GetCheckpointRemote()
+	if cr == nil {
+		return checkpointSyncInfo{}, false
+	}
+	if _, enabled, err := checkpointremote.PushURL(ctx, pushRemote); err != nil || !enabled {
+		return checkpointSyncInfo{}, false
+	}
+	info := checkpointSyncInfo{Remote: cr.Repo, Source: checkpointSyncSourceDedicated}
+	// The push-queue length is locally accurate for git refs. A raw-URL push
+	// updates no remote-tracking ref, so the git-branch comparison would
+	// permanently report every checkpoint as unpushed.
+	if checkpointBackend == checkpoint.BackendTypeGitRefs {
+		info.Unpushed = countUnpushedCheckpointsForStatus(ctx, "")
+	}
+	return info, true
 }
 
 // countUnpushedCheckpointsForStatus counts best-effort: status must never fail

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -91,15 +91,20 @@ func runStatus(ctx context.Context, w io.Writer, detailed, jsonOutput bool) erro
 		return runStatusDetailed(ctx, w, sty, settingsPath, localSettingsPath, projectExists, localExists)
 	}
 
-	// Short output: just show the effective/merged state
+	// Build the operational snapshot once, then render it. Text and JSON use
+	// this same constructor so health, storage, and destination cannot drift.
 	s, err := LoadEntireSettings(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to load settings: %w", err)
 	}
+	snapshot, err := buildStatusSnapshot(ctx, s)
+	if err != nil {
+		return err
+	}
 
-	fmt.Fprintln(w, formatSettingsStatusShort(ctx, s, sty))
+	fmt.Fprintln(w, formatSettingsStatusShort(ctx, snapshot, sty))
 	if s.Enabled {
-		writeActiveSessions(ctx, w, sty)
+		writeActiveSessionsSnapshot(ctx, w, sty, snapshot.Sessions)
 	}
 	writeAgentHelpHint(w, sty)
 
@@ -127,7 +132,11 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 	if err != nil {
 		return fmt.Errorf("failed to load settings: %w", err)
 	}
-	fmt.Fprintln(w, formatSettingsStatusShort(ctx, effectiveSettings, sty))
+	snapshot, err := buildStatusSnapshot(ctx, effectiveSettings)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(w, formatSettingsStatusShort(ctx, snapshot, sty))
 	fmt.Fprintln(w) // blank line
 
 	// Show project settings if it exists
@@ -187,7 +196,7 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 	}
 
 	if effectiveSettings.Enabled {
-		writeActiveSessions(ctx, w, sty)
+		writeActiveSessionsSnapshot(ctx, w, sty, snapshot.Sessions)
 	}
 	writeAgentHelpHint(w, sty)
 
@@ -197,8 +206,9 @@ func runStatusDetailed(ctx context.Context, w io.Writer, sty statusStyles, setti
 // formatSettingsStatusShort formats a short settings status line.
 // Output format: "● Enabled · branch main" or "○ Disabled · branch main"
 // (the branch segment is appended whenever it can be resolved).
-func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statusStyles) string {
+func formatSettingsStatusShort(ctx context.Context, snapshot *statusSnapshot, sty statusStyles) string {
 	var b strings.Builder
+	s := snapshot.Settings
 
 	if s.Enabled {
 		b.WriteString(sty.render(sty.green, "●"))
@@ -247,7 +257,7 @@ func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statu
 	// Where checkpoint data syncs (the single elected remote), and how many
 	// checkpoints have not reached it yet. Local-only computation.
 	if s.Enabled {
-		writeCheckpointSyncLines(ctx, &b, s, sty)
+		writeCheckpointStatusLines(&b, snapshot, sty)
 	}
 
 	if s.Enabled {
@@ -353,7 +363,71 @@ type checkpointSyncInfo struct {
 	IgnoredReason string
 }
 
-func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
+type statusSnapshot struct {
+	Settings                 *EntireSettings
+	GitHooks                 strategy.GitHookIntegrationHealth
+	CheckpointSync           checkpointSyncInfo
+	CheckpointSyncState      string
+	CheckpointStorageBackend string
+	Sessions                 []statusSession
+}
+
+const (
+	checkpointSyncStateReady    = "ready"
+	checkpointSyncStateDegraded = "degraded"
+	checkpointSyncStateBlocked  = "blocked"
+)
+
+func buildStatusSnapshot(ctx context.Context, s *EntireSettings) (*statusSnapshot, error) {
+	checkpointConfig, err := settings.LoadCheckpointsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load checkpoint storage configuration: %w", err)
+	}
+	backend := checkpoint.BackendTypeGitBranch
+	if checkpointConfig != nil {
+		backend = checkpointConfig.Primary.Type
+	}
+	hooks := strategy.CheckGitHookIntegration(ctx)
+	syncInfo := computeCheckpointSyncInfo(ctx, s, backend)
+	sessions := collectStatusSessions(ctx)
+	return &statusSnapshot{
+		Settings:                 s,
+		GitHooks:                 hooks,
+		CheckpointSync:           syncInfo,
+		CheckpointSyncState:      checkpointSyncState(hooks.State, syncInfo.Err),
+		CheckpointStorageBackend: backend,
+		Sessions:                 sessions,
+	}, nil
+}
+
+func checkpointSyncState(hookState strategy.GitHookIntegrationState, syncErr string) string {
+	if syncErr != "" {
+		return checkpointSyncStateBlocked
+	}
+	switch hookState {
+	case strategy.GitHookIntegrationCurrent:
+		return checkpointSyncStateReady
+	case strategy.GitHookIntegrationDegraded:
+		return checkpointSyncStateDegraded
+	case strategy.GitHookIntegrationOutdated, strategy.GitHookIntegrationAbsent, strategy.GitHookIntegrationError:
+		return checkpointSyncStateBlocked
+	default:
+		return checkpointSyncStateBlocked
+	}
+}
+
+func checkpointStorageLabel(backend string) string {
+	switch backend {
+	case checkpoint.BackendTypeGitBranch:
+		return "Git branch"
+	case checkpoint.BackendTypeGitRefs:
+		return "Git refs"
+	default:
+		return backend
+	}
+}
+
+func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings, checkpointBackend string) checkpointSyncInfo {
 	elected, err := strategy.ResolveCheckpointSyncRemote(ctx)
 	if err != nil {
 		// Fail-closed: checkpoint_push_remote names a remote that does not
@@ -385,7 +459,7 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 			// git-branch comparison is omitted: pushes to a raw URL update
 			// no remote-tracking ref, so it would permanently read "all
 			// unpushed".
-			if cpCfg, cfgErr := settings.LoadCheckpointsConfig(ctx); cfgErr == nil && checkpoint.PrimaryIsRefs(cpCfg) {
+			if checkpointBackend == checkpoint.BackendTypeGitRefs {
 				info.Unpushed = countUnpushedCheckpointsForStatus(ctx, "")
 			}
 			return info
@@ -426,16 +500,64 @@ func countUnpushedCheckpointsForStatus(ctx context.Context, remoteName string) i
 	return n
 }
 
-// writeCheckpointSyncLines appends the checkpoint sync destination line (and
-// the unpushed counter, when non-zero) to the enabled status block. Rendered
-// whenever something resolved: an elected remote, a dedicated store, or the
-// fail-closed misconfiguration. No remotes configured -> no lines.
-func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *EntireSettings, sty statusStyles) {
-	info := computeCheckpointSyncInfo(ctx, s)
-	switch {
-	case info.Err != "":
+// writeCheckpointStatusLines appends the local checkpoint storage, Git-hook
+// health, sync readiness, and (when safe to claim) the destination and unpushed
+// counter to the enabled status block.
+func writeCheckpointStatusLines(b *strings.Builder, snapshot *statusSnapshot, sty statusStyles) {
+	info := snapshot.CheckpointSync
+	b.WriteString("\n")
+	b.WriteString(sty.render(sty.dim, "  Checkpoint storage · "))
+	b.WriteString(checkpointStorageLabel(snapshot.CheckpointStorageBackend))
+
+	b.WriteString("\n")
+	hookSummary := fmt.Sprintf("Git hooks · %s (%s)", snapshot.GitHooks.State, snapshot.GitHooks.Mode)
+	if snapshot.GitHooks.State == strategy.GitHookIntegrationCurrent {
+		b.WriteString(sty.render(sty.dim, "  "+hookSummary))
+	} else {
+		b.WriteString(sty.render(sty.yellow, "  ! "+hookSummary))
+		if snapshot.GitHooks.Reason != "" {
+			b.WriteString(": ")
+			b.WriteString(snapshot.GitHooks.Reason)
+		}
+	}
+
+	if info.Err != "" {
 		b.WriteString("\n")
 		b.WriteString(sty.render(sty.yellow, "  ! Checkpoints NOT syncing: "+info.Err))
+		if snapshot.GitHooks.State == strategy.GitHookIntegrationCurrent {
+			return
+		}
+	}
+	switch {
+	case snapshot.CheckpointSyncState == checkpointSyncStateBlocked:
+		b.WriteString("\n")
+		b.WriteString(sty.render(sty.yellow, "  ! Checkpoint sync blocked"))
+		if info.Remote != "" {
+			b.WriteString(": destination ")
+			b.WriteString(sty.render(sty.cyan, info.Remote))
+			b.WriteString(" is configured, but ")
+		} else {
+			b.WriteString(": ")
+		}
+		reason := snapshot.GitHooks.Reason
+		if reason == "" {
+			reason = fmt.Sprintf("Git hook integration is %s.", snapshot.GitHooks.State)
+		}
+		b.WriteString(reason)
+		b.WriteString(sty.render(sty.dim, " · run 'entire doctor'"))
+		return
+	case snapshot.CheckpointSyncState == checkpointSyncStateDegraded:
+		b.WriteString("\n")
+		b.WriteString(sty.render(sty.yellow, "  ! Checkpoint sync degraded"))
+		if info.Remote != "" {
+			b.WriteString(": currently configured for ")
+			b.WriteString(sty.render(sty.cyan, info.Remote))
+		}
+		if snapshot.GitHooks.Reason != "" {
+			b.WriteString("; ")
+			b.WriteString(snapshot.GitHooks.Reason)
+		}
+		return
 	case info.Remote == "":
 		return
 	case info.Source == checkpointSyncSourceDedicated:
@@ -501,50 +623,70 @@ func formatRelativeDuration(d time.Duration) string {
 	}
 }
 
-// worktreeGroup groups sessions by worktree path for display.
-type worktreeGroup struct {
-	path     string
-	branch   string
-	sessions []*session.State
-}
-
 const (
 	unknownPlaceholder  = "(unknown)"
 	detachedHEADDisplay = "HEAD"
 )
 
-// writeActiveSessions writes active session information grouped by worktree.
-func writeActiveSessions(ctx context.Context, w io.Writer, sty statusStyles) {
+type statusSession struct {
+	State        *session.State
+	WorktreePath string
+	Branch       string
+	LastActiveAt time.Time
+}
+
+func collectStatusSessions(ctx context.Context) []statusSession {
 	store, err := session.NewStateStore(ctx)
 	if err != nil {
-		return
+		return nil
 	}
-
-	states, err := store.List(ctx)
-	if err != nil || len(states) == 0 {
-		return
+	states, err := store.ListReadOnly(ctx)
+	if err != nil {
+		return nil
 	}
-
-	// Finalize any non-ended session whose agent process has exited without a
-	// SessionStop hook firing, so it doesn't linger as "active" until the
-	// inactivity timeout. The sweep marks them ended in place, so the filter
-	// below drops them.
-	if n := finalizeExitedSessions(ctx, states, time.Now().Add(interactiveSweepCondenseBudget)); n > 0 {
-		fmt.Fprintln(w, sty.render(sty.dim, fmt.Sprintf("Finalized %d exited session(s) (agent process gone).", n)))
-	}
-
-	// Filter to active sessions only, per session.State.IsEnded — the same rule
-	// `entire session stop` filters on, so status can't advertise a session that
-	// stop then refuses to list. EndedAt alone is not it: `entire session attach`
-	// sets Phase to ended without stamping EndedAt.
-	var active []*session.State
-	for _, s := range states {
-		if !s.IsEnded() {
-			active = append(active, s)
+	result := make([]statusSession, 0, len(states))
+	for _, state := range states {
+		if state.IsEnded() {
+			continue
 		}
+		worktreePath := state.WorktreePath
+		branch := state.Branch
+		if branch == "" && worktreePath != "" {
+			branch = resolveWorktreeBranch(ctx, worktreePath)
+		}
+		lastActive := state.StartedAt
+		if state.LastInteractionTime != nil {
+			lastActive = *state.LastInteractionTime
+		}
+		result = append(result, statusSession{
+			State:        state,
+			WorktreePath: worktreePath,
+			Branch:       branch,
+			LastActiveAt: lastActive,
+		})
 	}
-	if len(active) == 0 {
+	sort.Slice(result, func(i, j int) bool {
+		if !result[i].LastActiveAt.Equal(result[j].LastActiveAt) {
+			return result[i].LastActiveAt.After(result[j].LastActiveAt)
+		}
+		return result[i].State.SessionID < result[j].State.SessionID
+	})
+	return result
+}
+
+// writeActiveSessions retains the direct rendering seam used by focused tests.
+// Production status commands pass the already-collected snapshot instead.
+func writeActiveSessions(ctx context.Context, w io.Writer, sty statusStyles) {
+	writeActiveSessionsSnapshot(ctx, w, sty, collectStatusSessions(ctx))
+}
+
+func writeActiveSessionsSnapshot(ctx context.Context, w io.Writer, sty statusStyles, sessions []statusSession) {
+	if len(sessions) == 0 {
 		return
+	}
+	active := make([]*session.State, 0, len(sessions))
+	for _, item := range sessions {
+		active = append(active, item.State)
 	}
 
 	repoRoot, head, headErr := currentHeadLinkage(ctx)
@@ -553,121 +695,91 @@ func writeActiveSessions(ctx context.Context, w io.Writer, sty statusStyles) {
 		divergenceWarnings = computeSessionDivergenceWarnings(repoRoot, active, head)
 	}
 
-	// Group by worktree path
-	groups := make(map[string]*worktreeGroup)
-	for _, s := range active {
-		wp := s.WorktreePath
-		if wp == "" {
-			wp = unknownPlaceholder
-		}
-		g, ok := groups[wp]
-		if !ok {
-			g = &worktreeGroup{path: wp}
-			groups[wp] = g
-		}
-		g.sessions = append(g.sessions, s)
-	}
-
-	// Resolve branch names for each worktree (skip for unknown paths)
-	for _, g := range groups {
-		if g.path != unknownPlaceholder {
-			g.branch = resolveWorktreeBranch(ctx, g.path)
-		}
-	}
-
-	// Sort groups: alphabetical by path
-	sortedGroups := make([]*worktreeGroup, 0, len(groups))
-	for _, g := range groups {
-		sortedGroups = append(sortedGroups, g)
-	}
-	sort.Slice(sortedGroups, func(i, j int) bool {
-		return sortedGroups[i].path < sortedGroups[j].path
-	})
-
-	// Sort sessions within each group by StartedAt (newest first)
-	for _, g := range sortedGroups {
-		sort.Slice(g.sessions, func(i, j int) bool {
-			return g.sessions[i].StartedAt.After(g.sessions[j].StartedAt)
-		})
-	}
-
 	// Track aggregate totals
 	var totalSessions int
 
 	fmt.Fprintln(w)
 	printedHeader := false
-	for _, g := range sortedGroups {
+	for _, item := range sessions {
 		if !printedHeader {
 			fmt.Fprintln(w, sty.sectionRule("Active Sessions", sty.width))
 			fmt.Fprintln(w)
 			printedHeader = true
 		}
 
-		for _, st := range g.sessions {
-			totalSessions++
+		st := item.State
+		totalSessions++
 
-			agentLabel := string(st.AgentType)
-			if agentLabel == "" {
-				agentLabel = unknownPlaceholder
-			}
-
-			// Line 1: Agent (model) · sessionID
-			if st.ModelName != "" {
-				fmt.Fprintf(w, "%s %s %s %s\n",
-					sty.render(sty.agent, agentLabel),
-					sty.render(sty.dim, "("+st.ModelName+")"),
-					sty.render(sty.dim, "·"),
-					st.SessionID)
-			} else {
-				fmt.Fprintf(w, "%s %s %s\n",
-					sty.render(sty.agent, agentLabel),
-					sty.render(sty.dim, "·"),
-					st.SessionID)
-			}
-
-			// Line 2: > "first prompt" (chevron + quoted, truncated)
-			if st.LastPrompt != "" {
-				prompt := stringutil.TruncateRunes(st.LastPrompt, 60, "...")
-				fmt.Fprintf(w, "%s \"%s\"\n", sty.render(sty.dim, ">"), prompt)
-			}
-
-			// Line 3: stats line — started Xd ago · active now · files N · tokens X.Xk
-			var stats []string
-			stats = append(stats, "started "+timeAgo(st.StartedAt))
-
-			if st.LastInteractionTime != nil && st.LastInteractionTime.Sub(st.StartedAt) > time.Minute {
-				stats = append(stats, activeTimeDisplay(st.LastInteractionTime))
-			}
-
-			if t := totalTokens(st.TokenUsage); t > 0 {
-				stats = append(stats, "tokens "+formatTokenCount(t))
-			}
-
-			statsLine := strings.Join(stats, sty.render(sty.dim, " · "))
-			switch {
-			case st.OwnerExited():
-				// Agent process is gone but the session couldn't be finalized
-				// above (e.g. condense/transition error); flag it explicitly.
-				fmt.Fprintf(w, "%s %s %s\n", sty.render(sty.dim, statsLine),
-					sty.render(sty.dim, "·"),
-					sty.render(sty.yellow, "exited")+" (run 'entire doctor')")
-			case st.IsStuckActive():
-				fmt.Fprintf(w, "%s %s %s\n", sty.render(sty.dim, statsLine),
-					sty.render(sty.dim, "·"),
-					sty.render(sty.yellow, "stale")+" (run 'entire doctor')")
-			default:
-				fmt.Fprintln(w, sty.render(sty.dim, statsLine))
-			}
-			if warning := divergenceWarnings[st.SessionID]; warning != "" {
-				fmt.Fprintf(w, "%s %s\n", sty.render(sty.yellow, "!"), sty.render(sty.yellow, warning))
-			}
-			if st.CaptureDegradedAt != nil {
-				warning := fmt.Sprintf("capture degraded %s: status scan over budget; new-file detection skipped (see 'entire doctor logs')",
-					timeAgo(*st.CaptureDegradedAt))
-				fmt.Fprintf(w, "%s %s\n", sty.render(sty.yellow, "!"), sty.render(sty.yellow, warning))
-			}
-			fmt.Fprintln(w)
+		agentLabel := string(st.AgentType)
+		if agentLabel == "" {
+			agentLabel = unknownPlaceholder
 		}
+
+		// Line 1: Agent (model) · sessionID
+		if st.ModelName != "" {
+			fmt.Fprintf(w, "%s %s %s %s\n",
+				sty.render(sty.agent, agentLabel),
+				sty.render(sty.dim, "("+st.ModelName+")"),
+				sty.render(sty.dim, "·"),
+				st.SessionID)
+		} else {
+			fmt.Fprintf(w, "%s %s %s\n",
+				sty.render(sty.agent, agentLabel),
+				sty.render(sty.dim, "·"),
+				st.SessionID)
+		}
+		worktreePath := item.WorktreePath
+		if worktreePath == "" {
+			worktreePath = unknownPlaceholder
+		}
+		location := "worktree " + worktreePath
+		if item.Branch != "" {
+			location += " · branch " + item.Branch
+		}
+		fmt.Fprintln(w, sty.render(sty.dim, location))
+
+		// Line 2: > "first prompt" (chevron + quoted, truncated)
+		if st.LastPrompt != "" {
+			prompt := stringutil.TruncateRunes(st.LastPrompt, 60, "...")
+			fmt.Fprintf(w, "%s \"%s\"\n", sty.render(sty.dim, ">"), prompt)
+		}
+
+		// Line 3: stats line — started Xd ago · active now · files N · tokens X.Xk
+		var stats []string
+		stats = append(stats, "started "+timeAgo(st.StartedAt))
+
+		if st.LastInteractionTime != nil && st.LastInteractionTime.Sub(st.StartedAt) > time.Minute {
+			stats = append(stats, activeTimeDisplay(st.LastInteractionTime))
+		}
+
+		if t := totalTokens(st.TokenUsage); t > 0 {
+			stats = append(stats, "tokens "+formatTokenCount(t))
+		}
+
+		statsLine := strings.Join(stats, sty.render(sty.dim, " · "))
+		switch {
+		case st.OwnerExited():
+			// Agent process is gone but the session couldn't be finalized
+			// above (e.g. condense/transition error); flag it explicitly.
+			fmt.Fprintf(w, "%s %s %s\n", sty.render(sty.dim, statsLine),
+				sty.render(sty.dim, "·"),
+				sty.render(sty.yellow, "exited")+" (run 'entire doctor')")
+		case st.IsStuckActive():
+			fmt.Fprintf(w, "%s %s %s\n", sty.render(sty.dim, statsLine),
+				sty.render(sty.dim, "·"),
+				sty.render(sty.yellow, "stale")+" (run 'entire doctor')")
+		default:
+			fmt.Fprintln(w, sty.render(sty.dim, statsLine))
+		}
+		if warning := divergenceWarnings[st.SessionID]; warning != "" {
+			fmt.Fprintf(w, "%s %s\n", sty.render(sty.yellow, "!"), sty.render(sty.yellow, warning))
+		}
+		if st.CaptureDegradedAt != nil {
+			warning := fmt.Sprintf("capture degraded %s: status scan over budget; new-file detection skipped (see 'entire doctor logs')",
+				timeAgo(*st.CaptureDegradedAt))
+			fmt.Fprintf(w, "%s %s\n", sty.render(sty.yellow, "!"), sty.render(sty.yellow, warning))
+		}
+		fmt.Fprintln(w)
 	}
 
 	// Footer: horizontal rule + session count
@@ -854,10 +966,13 @@ type statusJSON struct {
 	// CheckpointSyncRemote is the elected checkpoint sync remote name, or the
 	// org/repo slug in dedicated checkpoint_remote mode. Deliberately not named
 	// checkpoint_remote, which is the existing GitHub-coupled setting.
-	CheckpointSyncRemote       string `json:"checkpoint_sync_remote,omitempty"`
-	CheckpointSyncRemoteSource string `json:"checkpoint_sync_remote_source,omitempty"` // config|observed|default|sole|first|dedicated
-	CheckpointSyncError        string `json:"checkpoint_sync_error,omitempty"`         // fail-closed message
-	UnpushedCheckpoints        int    `json:"unpushed_checkpoints,omitempty"`
+	CheckpointSyncRemote       string                            `json:"checkpoint_sync_remote,omitempty"`
+	CheckpointSyncRemoteSource string                            `json:"checkpoint_sync_remote_source,omitempty"` // config|observed|default|sole|first|dedicated
+	CheckpointSyncError        string                            `json:"checkpoint_sync_error,omitempty"`         // fail-closed message
+	CheckpointSyncState        string                            `json:"checkpoint_sync_state"`
+	GitHooks                   strategy.GitHookIntegrationHealth `json:"git_hooks"`
+	CheckpointStorageBackend   string                            `json:"checkpoint_storage_backend"`
+	UnpushedCheckpoints        int                               `json:"unpushed_checkpoints,omitempty"`
 	// CheckpointRemoteIgnored/-Reason report a configured checkpoint_remote the
 	// ownership check rejected as inherited with the clone (reads and pushes
 	// fall back to the elected remote). Mirrors the text path's warning line.
@@ -894,9 +1009,15 @@ func codexHooksStatusFromIssue(issue *codexHookIssue) *codexHooksStatusJSON {
 }
 
 type sessionBriefJSON struct {
-	Agent  string `json:"agent"`
-	Model  string `json:"model,omitempty"`
-	Status string `json:"status"`
+	Agent        string     `json:"agent"`
+	Model        string     `json:"model,omitempty"`
+	Status       string     `json:"status"`
+	SessionID    string     `json:"session_id"`
+	WorktreeID   string     `json:"worktree_id,omitempty"`
+	WorktreePath string     `json:"worktree_path,omitempty"`
+	Branch       string     `json:"branch,omitempty"`
+	StartedAt    *time.Time `json:"started_at,omitempty"`
+	LastActiveAt *time.Time `json:"last_active_at,omitempty"`
 	// CaptureDegraded reports that a session for this agent last turned with a
 	// status scan over budget, so new-file detection was skipped.
 	CaptureDegraded bool `json:"capture_degraded,omitempty"`
@@ -925,11 +1046,19 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		return writeJSON(statusJSON{Error: fmt.Sprintf("failed to load settings: %v", err)})
 	}
 
+	snapshot, err := buildStatusSnapshot(ctx, s)
+	if err != nil {
+		return writeJSON(statusJSON{Error: err.Error()})
+	}
+
 	result := statusJSON{
-		Enabled:        s.Enabled,
-		Agents:         []string{},
-		ActiveSessions: []sessionBriefJSON{},
-		AgentHelp:      agentHelpCommand,
+		Enabled:                  s.Enabled,
+		Agents:                   []string{},
+		ActiveSessions:           []sessionBriefJSON{},
+		AgentHelp:                agentHelpCommand,
+		CheckpointSyncState:      snapshot.CheckpointSyncState,
+		GitHooks:                 snapshot.GitHooks,
+		CheckpointStorageBackend: snapshot.CheckpointStorageBackend,
 	}
 
 	if s.Enabled {
@@ -944,9 +1073,9 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		}
 		result.CodexHooks = codexHooksStatusFromIssue(inspectCodexHookIssue(ctx))
 
-		// Same computation as the text path (writeCheckpointSyncLines);
-		// empty fields drop out via omitempty when nothing resolved.
-		syncInfo := computeCheckpointSyncInfo(ctx, s)
+		// Same snapshot as the text path; empty legacy destination fields drop
+		// out via omitempty when nothing resolved.
+		syncInfo := snapshot.CheckpointSync
 		result.CheckpointSyncRemote = syncInfo.Remote
 		result.CheckpointSyncRemoteSource = syncInfo.Source
 		result.CheckpointSyncError = syncInfo.Err
@@ -954,55 +1083,31 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		result.CheckpointRemoteIgnored = syncInfo.IgnoredRemote
 		result.CheckpointRemoteIgnoredReason = syncInfo.IgnoredReason
 
-		if store, err := session.NewStateStore(ctx); err == nil {
-			if states, err := store.List(ctx); err == nil {
-				// Finalize sessions whose agent has exited (matches the human
-				// status path) so --json doesn't leave them orphaned or
-				// report them under active_sessions.
-				finalizeExitedSessions(ctx, states, time.Now().Add(interactiveSweepCondenseBudget))
-				// Deduplicate by agent: one entry per agent, "active" wins over "idle".
-				type agentEntry struct {
-					brief    sessionBriefJSON
-					isActive bool
-				}
-				byAgent := make(map[string]*agentEntry)
-				for _, st := range states {
-					if st.IsEnded() {
-						continue
-					}
-					agent := string(st.AgentType)
-					if agent == "" {
-						agent = unknownPlaceholder
-					}
-					active := st.Phase == session.PhaseActive
-					if existing, ok := byAgent[agent]; ok {
-						if active && !existing.isActive {
-							existing.brief.Model = st.ModelName
-							existing.brief.Status = sessionStatusLabel(st)
-							existing.isActive = true
-						}
-						// Degradation is sticky across the dedupe: any degraded
-						// session for this agent must not be hidden by a healthy one.
-						existing.brief.CaptureDegraded = existing.brief.CaptureDegraded || st.CaptureDegradedAt != nil
-					} else {
-						byAgent[agent] = &agentEntry{
-							brief: sessionBriefJSON{
-								Agent:           agent,
-								Model:           st.ModelName,
-								Status:          sessionStatusLabel(st),
-								CaptureDegraded: st.CaptureDegradedAt != nil,
-							},
-							isActive: active,
-						}
-					}
-				}
-				for _, e := range byAgent {
-					result.ActiveSessions = append(result.ActiveSessions, e.brief)
-				}
-				sort.Slice(result.ActiveSessions, func(i, j int) bool {
-					return result.ActiveSessions[i].Agent < result.ActiveSessions[j].Agent
-				})
+		for _, item := range snapshot.Sessions {
+			st := item.State
+			agentName := string(st.AgentType)
+			if agentName == "" {
+				agentName = unknownPlaceholder
 			}
+			brief := sessionBriefJSON{
+				Agent:           agentName,
+				Model:           st.ModelName,
+				Status:          sessionStatusLabel(st),
+				SessionID:       st.SessionID,
+				WorktreeID:      st.WorktreeID,
+				WorktreePath:    item.WorktreePath,
+				Branch:          item.Branch,
+				CaptureDegraded: st.CaptureDegradedAt != nil,
+			}
+			if !st.StartedAt.IsZero() {
+				startedAt := st.StartedAt
+				brief.StartedAt = &startedAt
+			}
+			if !item.LastActiveAt.IsZero() {
+				lastActiveAt := item.LastActiveAt
+				brief.LastActiveAt = &lastActiveAt
+			}
+			result.ActiveSessions = append(result.ActiveSessions, brief)
 		}
 	}
 

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -20,13 +20,16 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/redact"
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveWorktreeBranch_RegularRepo(t *testing.T) {
@@ -1246,7 +1249,7 @@ func TestFormatSettingsStatusShort_Enabled(t *testing.T) {
 		Enabled: true,
 	}
 
-	result := formatSettingsStatusShort(context.Background(), s, sty)
+	result := formatSettingsStatusShort(context.Background(), &statusSnapshot{Settings: s}, sty)
 
 	if !strings.Contains(result, "●") {
 		t.Errorf("Enabled status should have green dot, got: %q", result)
@@ -1264,7 +1267,7 @@ func TestFormatSettingsStatusShort_Disabled(t *testing.T) {
 		Enabled: false,
 	}
 
-	result := formatSettingsStatusShort(context.Background(), s, sty)
+	result := formatSettingsStatusShort(context.Background(), &statusSnapshot{Settings: s}, sty)
 
 	if !strings.Contains(result, "○") {
 		t.Errorf("Disabled status should have open dot, got: %q", result)
@@ -2131,7 +2134,7 @@ func TestRunStatusJSON_WithActiveSessions(t *testing.T) {
 	}
 }
 
-func TestRunStatusJSON_DeduplicatesSessions(t *testing.T) {
+func TestRunStatusJSON_ReturnsEverySession(t *testing.T) {
 	setupTestRepo(t)
 	writeSettings(t, testSettingsEnabled)
 
@@ -2181,18 +2184,20 @@ func TestRunStatusJSON_DeduplicatesSessions(t *testing.T) {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 
-	if len(result.ActiveSessions) != 1 {
-		t.Fatalf("Expected 1 deduplicated session, got %d", len(result.ActiveSessions))
+	if len(result.ActiveSessions) != 3 {
+		t.Fatalf("Expected all 3 sessions, got %d", len(result.ActiveSessions))
 	}
-	s := result.ActiveSessions[0]
-	if s.Agent != "Codex" {
-		t.Errorf("Expected agent='Codex', got %q", s.Agent)
-	}
-	if s.Status != "active" {
-		t.Errorf("Expected status='active' (active wins over idle), got %q", s.Status)
-	}
-	if s.Model != "codex-mini" {
-		t.Errorf("Expected model='codex-mini' from active session, got %q", s.Model)
+	for i, want := range []struct {
+		id, status, model string
+	}{
+		{id: "codex-active", status: "active", model: "codex-mini"},
+		{id: "codex-idle-2", status: "idle"},
+		{id: "codex-idle-1", status: "idle"},
+	} {
+		got := result.ActiveSessions[i]
+		if got.Agent != "Codex" || got.SessionID != want.id || got.Status != want.status || got.Model != want.model {
+			t.Errorf("active_sessions[%d] = %+v, want agent Codex, id/status/model %+v", i, got, want)
+		}
 	}
 }
 
@@ -2299,10 +2304,18 @@ func checkpointSyncTestCommit(t *testing.T, name, content string) string {
 	return testutil.GetHeadHash(t, ".")
 }
 
+func installStatusGitHooks(t *testing.T) {
+	t.Helper()
+	if _, err := strategy.EnsureGitHookIntegration(t.Context(), false); err != nil {
+		t.Fatalf("install status Git hooks: %v", err)
+	}
+}
+
 func TestRunStatus_CheckpointSyncDestination_Origin(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, testSettingsEnabled)
+	installStatusGitHooks(t)
 	testutil.AddRemote(t, ".", "origin", "https://example.com/origin.git")
 	testutil.AddRemote(t, ".", "publish", "https://example.com/publish.git")
 
@@ -2327,6 +2340,7 @@ func TestRunStatus_CheckpointSyncDestination_ConfigAnnotated(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_push_remote": "private"}}`)
+	installStatusGitHooks(t)
 	testutil.AddRemote(t, ".", "origin", "https://example.com/origin.git")
 	testutil.AddRemote(t, ".", "private", "https://example.com/private.git")
 
@@ -2345,6 +2359,7 @@ func TestRunStatus_CheckpointSyncDestination_CapturedAnnotated(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, testSettingsEnabled)
+	installStatusGitHooks(t)
 	testutil.AddRemote(t, ".", "origin", "https://example.com/origin.git")
 	testutil.AddRemote(t, ".", "fork", "https://example.com/fork.git")
 	// A captured election (evidence-elected by a past tracked push) must be
@@ -2422,6 +2437,7 @@ func TestRunStatus_CheckpointSyncCounter_GitBranchAhead(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, testSettingsEnabled)
+	installStatusGitHooks(t)
 	testutil.AddRemote(t, ".", "origin", "https://example.com/origin.git")
 	checkpointSyncTestCommit(t, "a.txt", "one")
 	second := checkpointSyncTestCommit(t, "b.txt", "two")
@@ -2444,6 +2460,7 @@ func TestRunStatus_CheckpointSyncCounterOmitted_WhenSynced(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, testSettingsEnabled)
+	installStatusGitHooks(t)
 	testutil.AddRemote(t, ".", "origin", "https://example.com/origin.git")
 	head := checkpointSyncTestCommit(t, "a.txt", "one")
 	testutil.GitUpdateRef(t, ".", "refs/heads/"+paths.MetadataBranchName, head)
@@ -2467,6 +2484,7 @@ func TestRunStatus_CheckpointSyncDedicated_GitBranch_NoCounter(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`)
+	installStatusGitHooks(t)
 	// Same owner ("org") as checkpoint_remote and a parseable GitHub URL, so
 	// PushURL derivation succeeds locally and dedicated mode is verified.
 	testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
@@ -2494,6 +2512,7 @@ func TestRunStatus_CheckpointSyncDedicated_GitRefs_QueueCounter(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}, "checkpoints": {"primary": {"type": "git-refs"}}}`)
+	installStatusGitHooks(t)
 	testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
 	checkpointSyncTestCommit(t, "a.txt", "one")
 
@@ -2545,11 +2564,11 @@ func TestRunStatusJSON_CheckpointSync_Elected(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
-	if result.CheckpointSyncRemote != "origin" {
-		t.Errorf("checkpoint_sync_remote = %q, want %q", result.CheckpointSyncRemote, "origin")
+	if result.CheckpointSyncRemote != defaultMirrorRemote {
+		t.Errorf("checkpoint_sync_remote = %q, want %q", result.CheckpointSyncRemote, defaultMirrorRemote)
 	}
-	if result.CheckpointSyncRemoteSource != "default" {
-		t.Errorf("checkpoint_sync_remote_source = %q, want %q", result.CheckpointSyncRemoteSource, "default")
+	if result.CheckpointSyncRemoteSource != string(strategy.SyncRemoteSourceDefault) {
+		t.Errorf("checkpoint_sync_remote_source = %q, want %q", result.CheckpointSyncRemoteSource, strategy.SyncRemoteSourceDefault)
 	}
 	if result.CheckpointSyncError != "" {
 		t.Errorf("checkpoint_sync_error should be empty, got %q", result.CheckpointSyncError)
@@ -2619,6 +2638,7 @@ func TestRunStatus_CheckpointSyncDedicated_IneligibleFallsBackToElected(t *testi
 	testutil.IsolateGitConfigEnv(t)
 	setupTestRepo(t)
 	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`)
+	installStatusGitHooks(t)
 	// Remote owner "other" != checkpoint_remote owner "org": fork detection
 	// rejects the dedicated store at push time.
 	testutil.AddRemote(t, ".", "origin", "https://github.com/other/repo.git")
@@ -2660,11 +2680,11 @@ func TestRunStatusJSON_CheckpointSync_DedicatedIneligible(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
-	if result.CheckpointSyncRemote != "origin" {
-		t.Errorf("checkpoint_sync_remote = %q, want the elected remote %q", result.CheckpointSyncRemote, "origin")
+	if result.CheckpointSyncRemote != defaultMirrorRemote {
+		t.Errorf("checkpoint_sync_remote = %q, want the elected remote %q", result.CheckpointSyncRemote, defaultMirrorRemote)
 	}
-	if result.CheckpointSyncRemoteSource != "default" {
-		t.Errorf("checkpoint_sync_remote_source = %q, want %q (not dedicated)", result.CheckpointSyncRemoteSource, "default")
+	if result.CheckpointSyncRemoteSource != string(strategy.SyncRemoteSourceDefault) {
+		t.Errorf("checkpoint_sync_remote_source = %q, want %q (not dedicated)", result.CheckpointSyncRemoteSource, strategy.SyncRemoteSourceDefault)
 	}
 	if result.CheckpointSyncError != "" {
 		t.Errorf("checkpoint_sync_error should be empty, got %q", result.CheckpointSyncError)
@@ -2724,5 +2744,440 @@ func TestRunStatusDetailed_ReportsRejectedExternalAgents(t *testing.T) { //nolin
 	}
 	if !strings.Contains(got, settings.EntireSettingsLocalFile) {
 		t.Errorf("status does not name where the setting must live:\n%s", got)
+	}
+}
+
+func TestStatusCheckpointSyncBlockedWhenGitHooksAbsent(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+	testutil.AddRemote(t, ".", "origin", "https://example.com/origin.git")
+
+	var textOut bytes.Buffer
+	if err := runStatus(context.Background(), &textOut, false, false); err != nil {
+		t.Fatalf("runStatus(text) error = %v", err)
+	}
+	text := textOut.String()
+	if strings.Contains(text, "Checkpoints sync to:") {
+		t.Fatalf("absent hooks must not promise active sync:\n%s", text)
+	}
+	for _, want := range []string{"Checkpoint sync blocked", "Git hooks", "not installed", "entire doctor"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("blocked status missing %q:\n%s", want, text)
+		}
+	}
+
+	var jsonOut bytes.Buffer
+	if err := runStatus(context.Background(), &jsonOut, false, true); err != nil {
+		t.Fatalf("runStatus(json) error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(jsonOut.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["checkpoint_sync_remote"] != defaultMirrorRemote || got["checkpoint_sync_remote_source"] != string(strategy.SyncRemoteSourceDefault) {
+		t.Errorf("legacy destination fields changed: %#v", got)
+	}
+	if got["checkpoint_sync_state"] != checkpointSyncStateBlocked {
+		t.Errorf("checkpoint_sync_state = %#v, want blocked", got["checkpoint_sync_state"])
+	}
+	hooks, ok := got["git_hooks"].(map[string]any)
+	if !ok || hooks["mode"] != "native" || hooks["state"] != "absent" {
+		t.Errorf("git_hooks = %#v, want native/absent", got["git_hooks"])
+	}
+}
+
+func TestStatusShowsSyncResolutionErrorAndBlockedHookHealth(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	writeSettings(t, `{"enabled":true,"strategy_options":{"checkpoint_push_remote":"missing"}}`)
+	testutil.AddRemote(t, ".", "origin", "https://example.com/origin.git")
+
+	var out bytes.Buffer
+	require.NoError(t, runStatus(t.Context(), &out, false, false))
+	text := out.String()
+	require.Contains(t, text, "Checkpoints NOT syncing")
+	require.Contains(t, text, "Checkpoint sync blocked")
+	require.Contains(t, text, "not installed")
+	require.Contains(t, text, "entire doctor")
+}
+
+func TestStatusJSONPreservesEmptyWorktreePath(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+	installStatusGitHooks(t)
+	store, err := session.NewStateStore(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, store.Save(t.Context(), &session.State{
+		SessionID: "legacy-no-worktree", StartedAt: time.Now(), Phase: session.PhaseActive,
+	}))
+
+	var out bytes.Buffer
+	require.NoError(t, runStatus(t.Context(), &out, false, true))
+	var got statusJSON
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got.ActiveSessions, 1)
+	require.Empty(t, got.ActiveSessions[0].WorktreePath)
+}
+
+func TestStatusCheckpointStorageAndDedicatedDestinationAreIndependent(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	writeSettings(t, `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}},"checkpoints":{"primary":{"type":"git-refs"}}}`)
+	testutil.AddRemote(t, ".", "origin", "https://github.com/org/repo.git")
+	if _, err := strategy.EnsureGitHookIntegration(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+
+	var textOut bytes.Buffer
+	if err := runStatus(context.Background(), &textOut, false, false); err != nil {
+		t.Fatal(err)
+	}
+	text := textOut.String()
+	if !strings.Contains(text, "Checkpoint storage") || !strings.Contains(text, "Git refs") {
+		t.Errorf("text missing effective storage backend:\n%s", text)
+	}
+	if !strings.Contains(text, "Checkpoints sync to: dedicated checkpoint remote (org/checkpoints)") {
+		t.Errorf("text missing independent dedicated destination:\n%s", text)
+	}
+
+	var jsonOut bytes.Buffer
+	if err := runStatus(context.Background(), &jsonOut, false, true); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(jsonOut.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["checkpoint_storage_backend"] != "git-refs" || got["checkpoint_sync_remote"] != "org/checkpoints" {
+		t.Errorf("storage and destination not reported independently: %#v", got)
+	}
+	if got["checkpoint_sync_state"] != checkpointSyncStateReady {
+		t.Errorf("checkpoint_sync_state = %#v, want ready", got["checkpoint_sync_state"])
+	}
+}
+
+func TestCheckpointSyncStateMapsGitHookHealth(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		state strategy.GitHookIntegrationState
+		want  string
+	}{
+		{state: strategy.GitHookIntegrationCurrent, want: checkpointSyncStateReady},
+		{state: strategy.GitHookIntegrationDegraded, want: checkpointSyncStateDegraded},
+		{state: strategy.GitHookIntegrationOutdated, want: checkpointSyncStateBlocked},
+		{state: strategy.GitHookIntegrationAbsent, want: checkpointSyncStateBlocked},
+		{state: strategy.GitHookIntegrationError, want: checkpointSyncStateBlocked},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			t.Parallel()
+			if got := checkpointSyncState(tt.state, ""); got != tt.want {
+				t.Errorf("checkpointSyncState(%q) = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatusSnapshotMapsObservedGitHookHealth(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupHooks func(t *testing.T, repoDir string)
+		wantHook   strategy.GitHookIntegrationState
+		wantSync   string
+	}{
+		{
+			name: "healthy native",
+			setupHooks: func(t *testing.T, _ string) {
+				installStatusGitHooks(t)
+			},
+			wantHook: strategy.GitHookIntegrationCurrent,
+			wantSync: checkpointSyncStateReady,
+		},
+		{
+			name: "working native bridge awaiting Lefthook migration",
+			setupHooks: func(t *testing.T, repoDir string) {
+				installStatusGitHooks(t)
+				if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte("pre_commit: {}\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantHook: strategy.GitHookIntegrationDegraded,
+			wantSync: checkpointSyncStateDegraded,
+		},
+		{
+			name: "healthy Lefthook",
+			setupHooks: func(t *testing.T, repoDir string) {
+				if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte("pre_commit: {}\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				hooksDir := filepath.Join(repoDir, ".git", "hooks")
+				if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				for _, hook := range strategy.ManagedGitHookNames() {
+					if err := os.WriteFile(filepath.Join(hooksDir, hook), []byte(statusLefthookWrapper(hook)), 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if _, err := strategy.EnsureGitHookIntegration(t.Context(), false); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantHook: strategy.GitHookIntegrationCurrent,
+			wantSync: checkpointSyncStateReady,
+		},
+		{
+			name: "Lefthook without durable artifacts",
+			setupHooks: func(t *testing.T, repoDir string) {
+				if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte("pre_commit: {}\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantHook: strategy.GitHookIntegrationOutdated,
+			wantSync: checkpointSyncStateBlocked,
+		},
+		{
+			name: "Lefthook inspection error",
+			setupHooks: func(t *testing.T, repoDir string) {
+				if err := os.Mkdir(filepath.Join(repoDir, "lefthook.yml"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantHook: strategy.GitHookIntegrationError,
+			wantSync: checkpointSyncStateBlocked,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.IsolateGitConfigEnv(t)
+			repoDir := setupTestRepo(t)
+			writeSettings(t, testSettingsEnabled)
+			testutil.AddRemote(t, ".", "origin", "https://example.com/origin.git")
+			tt.setupHooks(t, repoDir)
+			s, err := LoadEntireSettings(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			snapshot, err := buildStatusSnapshot(t.Context(), s)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if snapshot.GitHooks.State != tt.wantHook || snapshot.CheckpointSyncState != tt.wantSync {
+				t.Errorf("health/sync = %s/%s, want %s/%s", snapshot.GitHooks.State, snapshot.CheckpointSyncState, tt.wantHook, tt.wantSync)
+			}
+		})
+	}
+}
+
+func statusLefthookWrapper(hook string) string {
+	return "#!/bin/sh\n\n" +
+		"if [ \"$LEFTHOOK_VERBOSE\" = \"1\" -o \"$LEFTHOOK_VERBOSE\" = \"true\" ]; then\n  set -x\nfi\n\n" +
+		"if [ \"$LEFTHOOK\" = \"0\" ]; then\n  exit 0\nfi\n\n" +
+		"call_lefthook()\n{\n  lefthook \"$@\"\n}\n\n" +
+		"call_lefthook run \"" + hook + "\" \"$@\"\n"
+}
+
+func TestStatusCheckpointStorageUsesEffectiveLocalOverride(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	writeSettings(t, `{"enabled":true,"checkpoints":{"primary":{"type":"git-branch"}}}`)
+	if err := os.WriteFile(EntireSettingsLocalFile, []byte(`{"checkpoints":{"primary":{"type":"git-refs"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	installStatusGitHooks(t)
+
+	var textOut bytes.Buffer
+	if err := runStatus(context.Background(), &textOut, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(textOut.String(), "Checkpoint storage · Git refs") {
+		t.Errorf("text status did not use effective local backend override:\n%s", textOut.String())
+	}
+
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, false, true); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["checkpoint_storage_backend"] != "git-refs" {
+		t.Errorf("checkpoint_storage_backend = %#v, want effective local git-refs override", got["checkpoint_storage_backend"])
+	}
+}
+
+func TestStatusMultipleSessionsAreCompleteAndDeterministic(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	repoDir := setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+	installStatusGitHooks(t)
+
+	store, err := session.NewStateStore(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	newest := time.Now().UTC().Add(-time.Minute)
+	oldest := newest.Add(-time.Minute)
+	states := []*session.State{
+		{SessionID: "same-b", WorktreeID: "wt-b", WorktreePath: filepath.Join(repoDir, "wt-b"), Branch: "feature-b", StartedAt: oldest.Add(-time.Hour), LastInteractionTime: &newest, Phase: session.PhaseActive, AgentType: agent.AgentTypeClaudeCode},
+		{SessionID: "other-c", WorktreeID: "wt-c", WorktreePath: filepath.Join(repoDir, "wt-c"), Branch: "feature-c", StartedAt: oldest.Add(-2 * time.Hour), LastInteractionTime: &oldest, Phase: session.PhaseIdle, AgentType: agent.AgentTypeCursor},
+		{SessionID: "same-a", WorktreeID: "wt-a", WorktreePath: filepath.Join(repoDir, "wt-a"), Branch: "feature-a", StartedAt: oldest.Add(-3 * time.Hour), LastInteractionTime: &newest, Phase: session.PhaseActive, AgentType: agent.AgentTypeClaudeCode},
+	}
+	for _, state := range states {
+		if err := store.Save(t.Context(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var textOut bytes.Buffer
+	if err := runStatus(t.Context(), &textOut, false, false); err != nil {
+		t.Fatal(err)
+	}
+	text := textOut.String()
+	indices := []int{strings.Index(text, "same-a"), strings.Index(text, "same-b"), strings.Index(text, "other-c")}
+	if indices[0] < 0 || indices[1] <= indices[0] || indices[2] <= indices[1] {
+		t.Fatalf("text sessions not sorted by last-active desc then ID asc: %v\n%s", indices, text)
+	}
+	for _, want := range []string{filepath.Join(repoDir, "wt-a"), filepath.Join(repoDir, "wt-b"), filepath.Join(repoDir, "wt-c"), "feature-a", "feature-b", "feature-c"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("text status missing session worktree identity %q:\n%s", want, text)
+		}
+	}
+
+	var jsonOut bytes.Buffer
+	if err := runStatus(t.Context(), &jsonOut, false, true); err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		ActiveSessions []struct {
+			SessionID    string     `json:"session_id"`
+			WorktreeID   string     `json:"worktree_id"`
+			WorktreePath string     `json:"worktree_path"`
+			Branch       string     `json:"branch"`
+			StartedAt    time.Time  `json:"started_at"`
+			LastActiveAt *time.Time `json:"last_active_at"`
+		} `json:"active_sessions"`
+	}
+	if err := json.Unmarshal(jsonOut.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.ActiveSessions) != 3 {
+		t.Fatalf("active_sessions length = %d, want 3: %s", len(got.ActiveSessions), jsonOut.String())
+	}
+	for i, want := range []string{"same-a", "same-b", "other-c"} {
+		if got.ActiveSessions[i].SessionID != want {
+			t.Fatalf("active_sessions[%d].session_id = %q, want %q", i, got.ActiveSessions[i].SessionID, want)
+		}
+		if got.ActiveSessions[i].WorktreeID == "" || got.ActiveSessions[i].WorktreePath == "" || got.ActiveSessions[i].Branch == "" || got.ActiveSessions[i].StartedAt.IsZero() || got.ActiveSessions[i].LastActiveAt == nil {
+			t.Errorf("active_sessions[%d] missing identity/timestamps: %+v", i, got.ActiveSessions[i])
+		}
+	}
+}
+
+func TestStatusReadOnlyKeepsDeadOwnerSessionAndArtifacts(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	repoDir := setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+	installStatusGitHooks(t)
+
+	transcriptPath := filepath.Join(repoDir, "dead-owner-transcript.jsonl")
+	if err := os.WriteFile(transcriptPath, []byte("unchanged transcript\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStateStore(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	lastActive := time.Now().UTC().Add(-time.Minute)
+	state := &session.State{
+		SessionID: "dead-owner", WorktreeID: "main", WorktreePath: repoDir, Branch: "main",
+		StartedAt: lastActive.Add(-time.Hour), LastInteractionTime: &lastActive,
+		Phase: session.PhaseActive, AgentType: agent.AgentTypeClaudeCode,
+		Owner: &proclive.Identity{PID: os.Getpid(), Start: "not-this-process"}, TranscriptPath: transcriptPath,
+	}
+	if err := store.Save(t.Context(), state); err != nil {
+		t.Fatal(err)
+	}
+	staleEndedAt := time.Now().UTC().Add(-8 * 24 * time.Hour)
+	staleEnded := &session.State{
+		SessionID: "stale-ended", StartedAt: staleEndedAt, EndedAt: &staleEndedAt, Phase: session.PhaseEnded,
+	}
+	if err := store.Save(t.Context(), staleEnded); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(repoDir, ".git", session.SessionStateDirName, state.SessionID+".json")
+	staleEndedPath := filepath.Join(repoDir, ".git", session.SessionStateDirName, staleEnded.SessionID+".json")
+	beforeStaleEnded, err := os.ReadFile(staleEndedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeState, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeStateInfo, err := os.Stat(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeTranscript, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeTranscriptInfo, err := os.Stat(transcriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var textOut, jsonOut bytes.Buffer
+	if err := runStatus(t.Context(), &textOut, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := runStatus(t.Context(), &jsonOut, false, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(textOut.String(), "dead-owner") || !strings.Contains(textOut.String(), "exited") {
+		t.Fatalf("text status omitted derived exited session:\n%s", textOut.String())
+	}
+	var got struct {
+		ActiveSessions []sessionBriefJSON `json:"active_sessions"`
+	}
+	if err := json.Unmarshal(jsonOut.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.ActiveSessions) != 1 || got.ActiveSessions[0].SessionID != state.SessionID || got.ActiveSessions[0].Status != "exited" {
+		t.Fatalf("JSON status omitted derived exited session: %s", jsonOut.String())
+	}
+
+	afterState, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterStateInfo, err := os.Stat(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterTranscript, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterTranscriptInfo, err := os.Stat(transcriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(beforeState, afterState) || !beforeStateInfo.ModTime().Equal(afterStateInfo.ModTime()) {
+		t.Error("status mutated dead-owner session state")
+	}
+	if !bytes.Equal(beforeTranscript, afterTranscript) || !beforeTranscriptInfo.ModTime().Equal(afterTranscriptInfo.ModTime()) {
+		t.Error("status mutated dead-owner transcript")
+	}
+	afterStaleEnded, err := os.ReadFile(staleEndedPath)
+	if err != nil {
+		t.Fatalf("status deleted stale ended session during a passive read: %v", err)
+	}
+	if !bytes.Equal(beforeStaleEnded, afterStaleEnded) {
+		t.Error("status mutated stale ended session state")
 	}
 }

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -2630,6 +2630,24 @@ func TestRunStatusJSON_CheckpointSync_Dedicated(t *testing.T) {
 	}
 }
 
+func TestRunStatusJSON_CheckpointSync_DedicatedOverridesMissingElectedRemote(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_push_remote": "gone", "checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`)
+	testutil.AddRemote(t, ".", "publish", "https://github.com/org/repo.git")
+	installStatusGitHooks(t)
+
+	var stdout bytes.Buffer
+	require.NoError(t, runStatus(context.Background(), &stdout, false, true))
+
+	var result statusJSON
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	require.Equal(t, "org/checkpoints", result.CheckpointSyncRemote)
+	require.Equal(t, checkpointSyncSourceDedicated, result.CheckpointSyncRemoteSource)
+	require.Empty(t, result.CheckpointSyncError)
+	require.Equal(t, checkpointSyncStateReady, result.CheckpointSyncState)
+}
+
 // Dedicated mode is reported only when PushURL derivation succeeds (the same
 // condition the pre-push gate's exemption uses). An owner mismatch between the
 // elected remote and checkpoint_remote makes derivation fall back, so the next

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -111,11 +111,11 @@ func EnsureSetup(ctx context.Context) error {
 		return fmt.Errorf("failed to ensure primary metadata ref: %w", err)
 	}
 
-	// Install generic hooks (they delegate to strategy at runtime)
-	if !IsGitHookInstalled(ctx) {
-		if _, err := ReinstallGitHooks(ctx); err != nil {
-			return fmt.Errorf("failed to install git hooks: %w", err)
-		}
+	// Install or heal the durable integration selected by the repository's hook
+	// manager. The coordinator is idempotent, so the hook hot path can repair a
+	// manager refresh immediately.
+	if _, err := EnsureGitHookIntegration(ctx, hookSettingsFromConfig(ctx)); err != nil {
+		return fmt.Errorf("failed to install git hooks: %w", err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/strategy/hook_integration.go
+++ b/cmd/entire/cli/strategy/hook_integration.go
@@ -1,0 +1,208 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
+)
+
+// GitHookIntegrationMode identifies who owns the durable Git hook integration.
+type GitHookIntegrationMode string
+
+const (
+	GitHookIntegrationNative   GitHookIntegrationMode = "native"
+	GitHookIntegrationLefthook GitHookIntegrationMode = "lefthook"
+)
+
+// GitHookIntegrationState describes whether the selected integration currently
+// delivers every Entire Git hook and can be inspected safely.
+type GitHookIntegrationState string
+
+const (
+	GitHookIntegrationCurrent  GitHookIntegrationState = "current"
+	GitHookIntegrationDegraded GitHookIntegrationState = "degraded"
+	GitHookIntegrationOutdated GitHookIntegrationState = "outdated"
+	GitHookIntegrationAbsent   GitHookIntegrationState = "absent"
+	GitHookIntegrationError    GitHookIntegrationState = "error"
+)
+
+// GitHookIntegrationHealth is the shared, user-facing health contract for Git
+// hook installation. ReasonCode is stable for machine comparisons; Reason is
+// explanatory copy and may evolve independently.
+type GitHookIntegrationHealth struct {
+	Mode       GitHookIntegrationMode  `json:"mode"`
+	State      GitHookIntegrationState `json:"state"`
+	Manager    string                  `json:"manager,omitempty"`
+	ReasonCode string                  `json:"reason_code,omitempty"`
+	Reason     string                  `json:"reason,omitempty"`
+}
+
+const (
+	nativeHooksAbsentReasonCode   = "native_hooks_absent"
+	nativeHooksOutdatedReasonCode = "native_hooks_outdated"
+	nativeHooksErrorReasonCode    = "native_hooks_inspection_error"
+)
+
+// CheckGitHookIntegration reports the effective Git hook integration health for
+// the current repository.
+func CheckGitHookIntegration(ctx context.Context) GitHookIntegrationHealth {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return nativeHookInspectionError(err)
+	}
+
+	return checkGitHookIntegrationInDir(ctx, repoRoot)
+}
+
+func checkGitHookIntegrationInDir(ctx context.Context, repoRoot string) GitHookIntegrationHealth {
+	managers, detectionErr := detectHookManagersForIntegration(repoRoot)
+	if detectionErr != nil {
+		var managerErr *hookManagerDetectionError
+		if errors.As(detectionErr, &managerErr) {
+			mode := GitHookIntegrationNative
+			if managerErr.manager.IntegrationKind == hookManagerIntegrationLefthook {
+				mode = GitHookIntegrationLefthook
+			}
+			return GitHookIntegrationHealth{
+				Mode:       mode,
+				State:      GitHookIntegrationError,
+				Manager:    managerErr.manager.Name,
+				ReasonCode: "hook_manager_detection_error",
+				Reason:     fmt.Sprintf("Could not detect hook-manager ownership safely: %v", detectionErr),
+			}
+		}
+		return nativeHookInspectionError(detectionErr)
+	}
+	manager, selected, selectionErr := selectLefthookIntegrationManager(managers)
+	if selectionErr != nil {
+		nativeState, nativeErr := inspectNativeHookIntegration(ctx, repoRoot)
+		if nativeErr == nil && nativeState == GitHooksCurrent {
+			return GitHookIntegrationHealth{
+				Mode:       GitHookIntegrationNative,
+				State:      GitHookIntegrationDegraded,
+				ReasonCode: "hook_manager_ambiguous",
+				Reason:     fmt.Sprintf("Entire's native Git hooks work, but hook-manager ownership is ambiguous: %v", selectionErr),
+			}
+		}
+		return GitHookIntegrationHealth{
+			Mode:       GitHookIntegrationNative,
+			State:      GitHookIntegrationError,
+			ReasonCode: "hook_manager_ambiguous_no_native",
+			Reason:     fmt.Sprintf("Hook-manager ownership is ambiguous and no working native integration is available: %v", selectionErr),
+		}
+	}
+	if selected {
+		root, err := worktreedir.OpenAt(repoRoot)
+		if err != nil {
+			return lefthookInspectionError(manager, err)
+		}
+		if err := validateLefthookMainConfig(root, manager); err != nil {
+			return lefthookInspectionError(manager, err)
+		}
+		configCtx := settings.WithWorktreeRoot(ctx, repoRoot)
+		cmdPrefix, err := hookCmdPrefix(hookSettingsFromConfig(configCtx))
+		if err != nil {
+			return lefthookInspectionError(manager, err)
+		}
+		current, err := inspectLefthookArtifacts(root, cmdPrefix)
+		if err != nil {
+			return lefthookInspectionError(manager, err)
+		}
+		if current {
+			activeCurrent, activeErr := inspectActiveHookDelivery(ctx, repoRoot)
+			if activeErr != nil {
+				return lefthookInspectionError(manager, activeErr)
+			}
+			if !activeCurrent {
+				return GitHookIntegrationHealth{
+					Mode:       GitHookIntegrationLefthook,
+					State:      GitHookIntegrationOutdated,
+					Manager:    manager.Name,
+					ReasonCode: "lefthook_active_hooks_outdated",
+					Reason:     "Entire's Lefthook artifacts are current, but one or more active Git hooks do not invoke Entire.",
+				}
+			}
+			return GitHookIntegrationHealth{
+				Mode:    GitHookIntegrationLefthook,
+				State:   GitHookIntegrationCurrent,
+				Manager: manager.Name,
+			}
+		}
+		nativeState, nativeErr := inspectNativeHookIntegration(ctx, repoRoot)
+		if nativeErr == nil && nativeState == GitHooksCurrent {
+			return GitHookIntegrationHealth{
+				Mode:       GitHookIntegrationLefthook,
+				State:      GitHookIntegrationDegraded,
+				Manager:    manager.Name,
+				ReasonCode: "lefthook_native_bridge",
+				Reason:     "Entire's native Git hooks are working while the Lefthook integration awaits migration.",
+			}
+		}
+		return GitHookIntegrationHealth{
+			Mode:       GitHookIntegrationLefthook,
+			State:      GitHookIntegrationOutdated,
+			Manager:    manager.Name,
+			ReasonCode: "lefthook_artifacts_outdated",
+			Reason:     "Entire's Lefthook artifacts are missing or outdated.",
+		}
+	}
+
+	nativeState, err := inspectNativeHookIntegration(ctx, repoRoot)
+	if err != nil {
+		return nativeHookInspectionError(err)
+	}
+
+	switch nativeState {
+	case GitHooksCurrent:
+		return GitHookIntegrationHealth{
+			Mode:  GitHookIntegrationNative,
+			State: GitHookIntegrationCurrent,
+		}
+	case GitHooksOutdated:
+		return GitHookIntegrationHealth{
+			Mode:       GitHookIntegrationNative,
+			State:      GitHookIntegrationOutdated,
+			ReasonCode: nativeHooksOutdatedReasonCode,
+			Reason:     "Entire Git hooks were installed by an older CLI version.",
+		}
+	case GitHooksAbsent:
+		return GitHookIntegrationHealth{
+			Mode:       GitHookIntegrationNative,
+			State:      GitHookIntegrationAbsent,
+			ReasonCode: nativeHooksAbsentReasonCode,
+			Reason:     "Entire Git hooks are not installed.",
+		}
+	}
+	return nativeHookInspectionError(fmt.Errorf("unknown native Git hook state %d", nativeState))
+}
+
+func inspectNativeHookIntegration(ctx context.Context, repoRoot string) (GitHookState, error) {
+	hooksDir, err := getHooksDirInPath(ctx, repoRoot)
+	if err != nil {
+		return GitHooksAbsent, err
+	}
+	return inspectGitHookStateInHooksDir(hooksDir)
+}
+
+func lefthookInspectionError(manager hookManager, err error) GitHookIntegrationHealth {
+	return GitHookIntegrationHealth{
+		Mode:       GitHookIntegrationLefthook,
+		State:      GitHookIntegrationError,
+		Manager:    manager.Name,
+		ReasonCode: "lefthook_inspection_error",
+		Reason:     fmt.Sprintf("Could not inspect Entire's Lefthook integration: %v", err),
+	}
+}
+
+func nativeHookInspectionError(err error) GitHookIntegrationHealth {
+	return GitHookIntegrationHealth{
+		Mode:       GitHookIntegrationNative,
+		State:      GitHookIntegrationError,
+		ReasonCode: nativeHooksErrorReasonCode,
+		Reason:     fmt.Sprintf("Could not inspect Entire Git hooks: %v", err),
+	}
+}

--- a/cmd/entire/cli/strategy/hook_integration.go
+++ b/cmd/entire/cli/strategy/hook_integration.go
@@ -101,6 +101,9 @@ func checkGitHookIntegrationInDir(ctx context.Context, repoRoot string) GitHookI
 			return lefthookInspectionError(manager, err)
 		}
 		if err := validateLefthookMainConfig(root, manager); err != nil {
+			if errors.Is(err, errLefthookUnsupportedLayout) {
+				return unsupportedLefthookLayoutHealth(ctx, repoRoot, manager, err)
+			}
 			return lefthookInspectionError(manager, err)
 		}
 		configCtx := settings.WithWorktreeRoot(ctx, repoRoot)
@@ -178,6 +181,25 @@ func checkGitHookIntegrationInDir(ctx context.Context, repoRoot string) GitHookI
 		}
 	}
 	return nativeHookInspectionError(fmt.Errorf("unknown native Git hook state %d", nativeState))
+}
+
+func unsupportedLefthookLayoutHealth(
+	ctx context.Context,
+	repoRoot string,
+	manager hookManager,
+	validationErr error,
+) GitHookIntegrationHealth {
+	nativeState, nativeErr := inspectNativeHookIntegration(ctx, repoRoot)
+	if nativeErr == nil && nativeState == GitHooksCurrent {
+		return GitHookIntegrationHealth{
+			Mode:       GitHookIntegrationLefthook,
+			State:      GitHookIntegrationDegraded,
+			Manager:    manager.Name,
+			ReasonCode: "lefthook_unsupported_native_bridge",
+			Reason:     fmt.Sprintf("Entire's native Git hooks work, but this Lefthook layout cannot be integrated safely: %v", validationErr),
+		}
+	}
+	return lefthookInspectionError(manager, validationErr)
 }
 
 func inspectNativeHookIntegration(ctx context.Context, repoRoot string) (GitHookState, error) {

--- a/cmd/entire/cli/strategy/hook_integration.go
+++ b/cmd/entire/cli/strategy/hook_integration.go
@@ -95,6 +95,18 @@ func checkGitHookIntegrationInDir(ctx context.Context, repoRoot string) GitHookI
 			Reason:     fmt.Sprintf("Hook-manager ownership is ambiguous and no working native integration is available: %v", selectionErr),
 		}
 	}
+	if err := checkNativeHookRepairInDir(ctx, repoRoot); err != nil {
+		health := nativeHookInspectionError(err)
+		if selected {
+			health.Mode = GitHookIntegrationLefthook
+			health.Manager = manager.Name
+		}
+		if errors.Is(err, errModifiedNativeHook) {
+			health.State = GitHookIntegrationOutdated
+			health.ReasonCode = "native_hooks_modified"
+		}
+		return health
+	}
 	if selected {
 		root, err := worktreedir.OpenAt(repoRoot)
 		if err != nil {
@@ -170,7 +182,7 @@ func checkGitHookIntegrationInDir(ctx context.Context, repoRoot string) GitHookI
 			Mode:       GitHookIntegrationNative,
 			State:      GitHookIntegrationOutdated,
 			ReasonCode: nativeHooksOutdatedReasonCode,
-			Reason:     "Entire Git hooks were installed by an older CLI version.",
+			Reason:     "Entire Git hooks are outdated or not executable.",
 		}
 	case GitHooksAbsent:
 		return GitHookIntegrationHealth{

--- a/cmd/entire/cli/strategy/hook_integration_test.go
+++ b/cmd/entire/cli/strategy/hook_integration_test.go
@@ -68,7 +68,7 @@ func TestCheckGitHookIntegration(t *testing.T) {
 				Mode:       GitHookIntegrationNative,
 				State:      GitHookIntegrationOutdated,
 				ReasonCode: "native_hooks_outdated",
-				Reason:     "Entire Git hooks were installed by an older CLI version.",
+				Reason:     "Entire Git hooks are outdated or not executable.",
 			},
 		},
 	}

--- a/cmd/entire/cli/strategy/hook_integration_test.go
+++ b/cmd/entire/cli/strategy/hook_integration_test.go
@@ -1,6 +1,7 @@
 package strategy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
@@ -303,6 +305,42 @@ func TestEnsureGitHookIntegration_SupportsDottedRootYAMLConfigs(t *testing.T) {
 			}
 			if got := CheckGitHookIntegration(t.Context()); got.Mode != GitHookIntegrationLefthook || got.State != GitHookIntegrationCurrent {
 				t.Errorf("health for %s = %+v, want current Lefthook", name, got)
+			}
+		})
+	}
+}
+
+func TestEnsureGitHookIntegration_UnsupportedLefthookLayoutKeepsNativeDelivery(t *testing.T) {
+	for _, configName := range []string{"lefthook.toml", "lefthook.jsonc", ".config/lefthook.yml"} {
+		t.Run(configName, func(t *testing.T) {
+			repoDir := t.TempDir()
+			testutil.InitRepo(t, repoDir)
+			clearGlobalHooksPath(t, repoDir)
+			configPath := filepath.Join(repoDir, configName)
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			original := []byte("user-owned config\n")
+			if err := os.WriteFile(configPath, original, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(repoDir)
+			paths.ClearWorktreeRootCache()
+			t.Cleanup(paths.ClearWorktreeRootCache)
+
+			if _, err := EnsureGitHookIntegration(t.Context(), false); err != nil {
+				t.Fatalf("EnsureGitHookIntegration() for %s error = %v", configName, err)
+			}
+			got := CheckGitHookIntegration(t.Context())
+			if got.Mode != GitHookIntegrationLefthook || got.State != GitHookIntegrationDegraded || got.ReasonCode != "lefthook_unsupported_native_bridge" {
+				t.Fatalf("health = %+v, want degraded unsupported-layout native bridge", got)
+			}
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(data, original) {
+				t.Fatalf("unsupported config was modified: got %q, want %q", data, original)
 			}
 		})
 	}

--- a/cmd/entire/cli/strategy/hook_integration_test.go
+++ b/cmd/entire/cli/strategy/hook_integration_test.go
@@ -1,0 +1,905 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+func TestCheckGitHookIntegration(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, hooksDir string)
+		want  GitHookIntegrationHealth
+	}{
+		{
+			name:  "no hooks uses absent native integration",
+			setup: func(*testing.T, string) {},
+			want: GitHookIntegrationHealth{
+				Mode:       GitHookIntegrationNative,
+				State:      GitHookIntegrationAbsent,
+				ReasonCode: "native_hooks_absent",
+				Reason:     "Entire Git hooks are not installed.",
+			},
+		},
+		{
+			name: "detected Lefthook without artifacts is outdated",
+			setup: func(t *testing.T, hooksDir string) {
+				repoDir := filepath.Dir(filepath.Dir(hooksDir))
+				if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: GitHookIntegrationHealth{
+				Mode:       GitHookIntegrationLefthook,
+				State:      GitHookIntegrationOutdated,
+				Manager:    lefthookManagerName,
+				ReasonCode: "lefthook_artifacts_outdated",
+				Reason:     "Entire's Lefthook artifacts are missing or outdated.",
+			},
+		},
+		{
+			name: "current wrappers use current native integration",
+			setup: func(t *testing.T, hooksDir string) {
+				writeCurrentManagedHooks(t, hooksDir)
+			},
+			want: GitHookIntegrationHealth{
+				Mode:  GitHookIntegrationNative,
+				State: GitHookIntegrationCurrent,
+			},
+		},
+		{
+			name: "one stale wrapper uses outdated native integration",
+			setup: func(t *testing.T, hooksDir string) {
+				writeCurrentManagedHooks(t, hooksDir)
+				legacy := "#!/bin/sh\n# " + entireHookMarker + "\n./scripts/entire-dev hooks git pre-push\n"
+				if err := os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte(legacy), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: GitHookIntegrationHealth{
+				Mode:       GitHookIntegrationNative,
+				State:      GitHookIntegrationOutdated,
+				ReasonCode: "native_hooks_outdated",
+				Reason:     "Entire Git hooks were installed by an older CLI version.",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			testutil.InitRepo(t, repoDir)
+			clearGlobalHooksPath(t, repoDir)
+			hooksDir := filepath.Join(repoDir, ".git", "hooks")
+			if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			tt.setup(t, hooksDir)
+			t.Chdir(repoDir)
+
+			got := CheckGitHookIntegration(context.Background())
+			if got != tt.want {
+				t.Errorf("CheckGitHookIntegration() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckGitHookIntegration_Lefthook(t *testing.T) {
+	setup := func(t *testing.T) (string, string) {
+		t.Helper()
+		repoDir := t.TempDir()
+		testutil.InitRepo(t, repoDir)
+		clearGlobalHooksPath(t, repoDir)
+		if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		hooksDir := filepath.Join(repoDir, ".git", "hooks")
+		if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(repoDir)
+		return repoDir, hooksDir
+	}
+
+	t.Run("current manager owned hooks", func(t *testing.T) {
+		repoDir, hooksDir := setup(t)
+		if _, err := installLefthookFiles(t.Context(), false); err != nil {
+			t.Fatal(err)
+		}
+		writeRealLefthookHooks(t, hooksDir)
+		got := checkGitHookIntegrationInDir(t.Context(), repoDir)
+		if got.Mode != GitHookIntegrationLefthook || got.State != GitHookIntegrationCurrent || got.Manager != lefthookManagerName {
+			t.Errorf("health = %+v, want current Lefthook", got)
+		}
+	})
+
+	t.Run("current native bridge needs migration", func(t *testing.T) {
+		repoDir, hooksDir := setup(t)
+		writeCurrentManagedHooks(t, hooksDir)
+		got := checkGitHookIntegrationInDir(t.Context(), repoDir)
+		if got.Mode != GitHookIntegrationLefthook || got.State != GitHookIntegrationDegraded || got.ReasonCode != "lefthook_native_bridge" {
+			t.Errorf("health = %+v, want degraded Lefthook bridge", got)
+		}
+	})
+
+	t.Run("ambiguity with working native hooks is degraded native", func(t *testing.T) {
+		repoDir, hooksDir := setup(t)
+		writeCurrentManagedHooks(t, hooksDir)
+		if err := os.WriteFile(filepath.Join(repoDir, ".lefthook.yaml"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got := checkGitHookIntegrationInDir(t.Context(), repoDir)
+		if got.Mode != GitHookIntegrationNative || got.State != GitHookIntegrationDegraded || got.ReasonCode != "hook_manager_ambiguous" {
+			t.Errorf("health = %+v, want degraded native", got)
+		}
+	})
+
+	t.Run("outdated artifacts", func(t *testing.T) {
+		repoDir, _ := setup(t)
+		if _, err := installLefthookFiles(t.Context(), false); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(repoDir, ".lefthook-local", "pre-push", lefthookScriptName), []byte("# stale\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		got := checkGitHookIntegrationInDir(t.Context(), repoDir)
+		if got.Mode != GitHookIntegrationLefthook || got.State != GitHookIntegrationOutdated || got.ReasonCode != "lefthook_artifacts_outdated" {
+			t.Errorf("health = %+v, want outdated Lefthook", got)
+		}
+	})
+
+	t.Run("non executable artifact is outdated", func(t *testing.T) {
+		repoDir, _ := setup(t)
+		if _, err := installLefthookFiles(t.Context(), false); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(filepath.Join(repoDir, ".lefthook-local", "pre-push", lefthookScriptName), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got := checkGitHookIntegrationInDir(t.Context(), repoDir)
+		if got.Mode != GitHookIntegrationLefthook || got.State != GitHookIntegrationOutdated {
+			t.Errorf("health = %+v, want outdated Lefthook", got)
+		}
+	})
+
+	t.Run("ambiguity without native hooks is error", func(t *testing.T) {
+		repoDir, _ := setup(t)
+		if err := os.WriteFile(filepath.Join(repoDir, ".lefthook.yaml"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got := checkGitHookIntegrationInDir(t.Context(), repoDir)
+		if got.Mode != GitHookIntegrationNative || got.State != GitHookIntegrationError || got.ReasonCode != "hook_manager_ambiguous_no_native" {
+			t.Errorf("health = %+v, want ambiguity error", got)
+		}
+	})
+}
+
+func TestLegacyGitHookStateRemainsNativeOnlyWithCurrentLefthook(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	if _, err := installLefthookFiles(t.Context(), false); err != nil {
+		t.Fatal(err)
+	}
+	writeRealLefthookHooks(t, filepath.Join(repoDir, ".git", "hooks"))
+
+	health := CheckGitHookIntegration(t.Context())
+	if health.Mode != GitHookIntegrationLefthook || health.State != GitHookIntegrationCurrent {
+		t.Fatalf("CheckGitHookIntegration() = %+v, want current Lefthook", health)
+	}
+	if got := CheckGitHookState(t.Context()); got != GitHooksAbsent {
+		t.Errorf("CheckGitHookState() = %v, want native-only GitHooksAbsent", got)
+	}
+	if got := CheckGitHookStateInDir(t.Context(), repoDir); got != GitHooksAbsent {
+		t.Errorf("CheckGitHookStateInDir() = %v, want native-only GitHooksAbsent", got)
+	}
+}
+
+func TestCheckGitHookIntegration_InspectionError(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCurrentManagedHooks(t, hooksDir)
+
+	brokenHook := filepath.Join(hooksDir, "pre-push")
+	if err := os.Remove(brokenHook); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(brokenHook, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+
+	got := CheckGitHookIntegration(context.Background())
+	if got.Mode != GitHookIntegrationNative {
+		t.Errorf("Mode = %q, want %q", got.Mode, GitHookIntegrationNative)
+	}
+	if got.State != GitHookIntegrationError {
+		t.Errorf("State = %q, want %q", got.State, GitHookIntegrationError)
+	}
+	if got.ReasonCode != "native_hooks_inspection_error" {
+		t.Errorf("ReasonCode = %q, want native_hooks_inspection_error", got.ReasonCode)
+	}
+	if !strings.Contains(got.Reason, "pre-push") {
+		t.Errorf("Reason = %q, want managed hook path", got.Reason)
+	}
+	if legacy := CheckGitHookState(context.Background()); legacy != GitHooksAbsent {
+		t.Errorf("CheckGitHookState() = %v, want GitHooksAbsent compatibility mapping", legacy)
+	}
+}
+
+func TestCheckGitHookIntegration_MarkerOnlyNativeHookIsNotCurrent(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCurrentManagedHooks(t, hooksDir)
+	markerOnly := "#!/bin/sh\n# " + entireHookMarker + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte(markerOnly), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+
+	if got := CheckGitHookIntegration(t.Context()); got.State == GitHookIntegrationCurrent {
+		t.Errorf("health = %+v, marker-only native hook must not be current", got)
+	}
+}
+
+func TestCheckGitHookIntegration_MarkerOnlyLefthookBridgeIsNotCurrent(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte("pre_commit: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	writeRealLefthookHooks(t, hooksDir)
+	t.Chdir(repoDir)
+	if _, err := installLefthookFiles(t.Context(), false); err != nil {
+		t.Fatal(err)
+	}
+	markerOnly := "#!/bin/sh\n# " + entireHookMarker + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte(markerOnly), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := CheckGitHookIntegration(t.Context()); got.State == GitHookIntegrationCurrent {
+		t.Errorf("health = %+v, marker-only bridge must not deliver Entire", got)
+	}
+}
+
+func TestEnsureGitHookIntegration_SupportsDottedRootYAMLConfigs(t *testing.T) {
+	for _, name := range []string{".lefthook.yml", ".lefthook.yaml"} {
+		t.Run(name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			testutil.InitRepo(t, repoDir)
+			clearGlobalHooksPath(t, repoDir)
+			if err := os.WriteFile(filepath.Join(repoDir, name), []byte("pre_commit: {}\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(repoDir)
+			ClearHooksDirCache()
+
+			if _, err := EnsureGitHookIntegration(t.Context(), false); err != nil {
+				t.Fatalf("EnsureGitHookIntegration() for %s error = %v", name, err)
+			}
+			if got := CheckGitHookIntegration(t.Context()); got.Mode != GitHookIntegrationLefthook || got.State != GitHookIntegrationCurrent {
+				t.Errorf("health for %s = %+v, want current Lefthook", name, got)
+			}
+		})
+	}
+}
+
+func TestCheckGitHookIntegration_ManagerCandidateDetectionError(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, ".husky"), []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+
+	got := CheckGitHookIntegration(t.Context())
+	if got.State != GitHookIntegrationError {
+		t.Errorf("State = %q, want %q", got.State, GitHookIntegrationError)
+	}
+	if got.ReasonCode != "hook_manager_detection_error" {
+		t.Errorf("ReasonCode = %q, want hook_manager_detection_error", got.ReasonCode)
+	}
+	if !strings.Contains(got.Reason, "Could not detect hook-manager ownership safely") {
+		t.Errorf("Reason = %q, want generic manager detection wording", got.Reason)
+	}
+}
+
+func TestCheckGitHookStateCompatibilityMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		state GitHookIntegrationState
+		want  GitHookState
+	}{
+		{state: GitHookIntegrationCurrent, want: GitHooksCurrent},
+		{state: GitHookIntegrationOutdated, want: GitHooksOutdated},
+		{state: GitHookIntegrationDegraded, want: GitHooksAbsent},
+		{state: GitHookIntegrationError, want: GitHooksAbsent},
+	}
+
+	for _, tt := range tests {
+		if got := legacyGitHookState(GitHookIntegrationHealth{State: tt.state}); got != tt.want {
+			t.Errorf("legacyGitHookState(%q) = %v, want %v", tt.state, got, tt.want)
+		}
+	}
+}
+
+func TestEnsureGitHookIntegration_InstallsLefthookArtifacts(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte("pre_commit:\n  commands:\n    lint:\n      run: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+
+	written, err := EnsureGitHookIntegration(t.Context(), false)
+	if err != nil {
+		t.Fatalf("EnsureGitHookIntegration() error = %v", err)
+	}
+	if written == 0 {
+		t.Fatal("EnsureGitHookIntegration() should write Lefthook artifacts")
+	}
+	if got := CheckGitHookIntegration(t.Context()); got.Mode != GitHookIntegrationLefthook || got.State != GitHookIntegrationCurrent {
+		t.Errorf("health = %+v, want current Lefthook", got)
+	}
+}
+
+func TestEnsureGitHookIntegration_LefthookWithoutActiveHooksInstallsNativeBridge(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte("pre_commit: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+
+	if _, err := EnsureGitHookIntegration(t.Context(), false); err != nil {
+		t.Fatalf("EnsureGitHookIntegration() error = %v", err)
+	}
+	for _, hook := range gitHookNames {
+		data, err := os.ReadFile(filepath.Join(repoDir, ".git", "hooks", hook))
+		if err != nil {
+			t.Fatalf("active %s hook missing: %v", hook, err)
+		}
+		if !strings.Contains(string(data), entireHookMarker) {
+			t.Errorf("active %s hook does not contain Entire native bridge", hook)
+		}
+	}
+	if got := CheckGitHookIntegration(t.Context()); got.State != GitHookIntegrationCurrent {
+		t.Errorf("health = %+v, want current only after active bridges exist", got)
+	}
+}
+
+func TestEnsureGitHookIntegration_RestoresProvenSavedLefthookHook(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	saved := realLefthookWrapper("pre-push")
+	if err := os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte(saved), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	if _, err := InstallGitHook(t.Context(), true, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureGitHookIntegration(t.Context(), false); err != nil {
+		t.Fatalf("EnsureGitHookIntegration() error = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(hooksDir, "pre-push"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != saved {
+		t.Errorf("active hook = %q, want saved Lefthook hook", got)
+	}
+	if _, err := os.Stat(filepath.Join(hooksDir, "pre-push"+backupSuffix)); !os.IsNotExist(err) {
+		t.Errorf("saved hook backup still exists, stat error = %v", err)
+	}
+}
+
+func TestEnsureGitHookIntegration_DoesNotRestoreNoOpSavedLefthookHook(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	saved := noOpLefthookWrapper("pre-push")
+	if err := os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte(saved), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	if _, err := InstallGitHook(t.Context(), true, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureGitHookIntegration(t.Context(), false); err != nil {
+		t.Fatalf("EnsureGitHookIntegration() error = %v", err)
+	}
+	active, err := os.ReadFile(filepath.Join(hooksDir, "pre-push"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(active), entireHookMarker) {
+		t.Errorf("no-op saved hook replaced the active Entire bridge:\n%s", active)
+	}
+	backup, err := os.ReadFile(filepath.Join(hooksDir, "pre-push"+backupSuffix))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(backup) != saved {
+		t.Errorf("saved no-op hook changed = %q, want %q", backup, saved)
+	}
+}
+
+func TestCheckGitHookIntegration_NoOpLefthookWrappersAreNotCurrent(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	if _, err := EnsureGitHookIntegration(t.Context(), false); err != nil {
+		t.Fatal(err)
+	}
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	for _, hook := range gitHookNames {
+		if err := os.WriteFile(filepath.Join(hooksDir, hook), []byte(noOpLefthookWrapper(hook)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := CheckGitHookIntegration(t.Context()); got.State == GitHookIntegrationCurrent {
+		t.Errorf("health = %+v, no-op Lefthook wrappers must not be current", got)
+	}
+}
+
+func TestRemoveGitHookIntegration_PreservesUnrelatedLefthookContent(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	mainConfig := "# keep me\npre_commit:\n  commands:\n    lint:\n      run: true\n"
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte(mainConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	if _, err := EnsureGitHookIntegration(t.Context(), false); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := RemoveGitHookIntegration(t.Context())
+	if err != nil {
+		t.Fatalf("RemoveGitHookIntegration() error = %v", err)
+	}
+	if removed == 0 {
+		t.Fatal("RemoveGitHookIntegration() should remove owned artifacts")
+	}
+	data, err := os.ReadFile(filepath.Join(repoDir, "lefthook.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != mainConfig {
+		t.Errorf("main config changed = %q", data)
+	}
+	local, err := os.ReadFile(filepath.Join(repoDir, lefthookLocalConfigName))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(local), lefthookOwnedMarker) {
+		t.Errorf("local config retains Entire-owned entries: %s", local)
+	}
+}
+
+func TestLefthookIntegration_RoundTripPreservesCompatibleUserSourceDirLocal(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	localPath := filepath.Join(repoDir, lefthookLocalConfigName)
+	const userConfig = "# user config\nsource_dir_local: .lefthook-local # user-selected shared directory\nuser_key: keep-me\n"
+	if err := os.WriteFile(localPath, []byte(userConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+
+	if _, err := EnsureGitHookIntegration(t.Context(), false); err != nil {
+		t.Fatalf("EnsureGitHookIntegration() error = %v", err)
+	}
+	installed, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installedRoot, err := parseYAMLMapping(installed, lefthookLocalConfigName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceValue, found, duplicate := mappingValueCount(installedRoot, "source_dir_local")
+	sourceKey := mappingKey(installedRoot, "source_dir_local")
+	if !found || duplicate || sourceValue == nil {
+		t.Fatalf("installed source_dir_local = found %v duplicate %v value %#v", found, duplicate, sourceValue)
+	}
+	if sourceValue.Value != lefthookLocalDir {
+		t.Fatalf("installed source_dir_local = %q, want %q", sourceValue.Value, lefthookLocalDir)
+	}
+	if lefthookNodeOwned(sourceKey, sourceValue) {
+		t.Fatal("install claimed the compatible user source_dir_local")
+	}
+	if !strings.Contains(string(installed), "# user-selected shared directory") {
+		t.Errorf("install lost user source_dir_local comment:\n%s", installed)
+	}
+
+	if _, err := RemoveGitHookIntegration(t.Context()); err != nil {
+		t.Fatalf("RemoveGitHookIntegration() error = %v", err)
+	}
+	uninstalled, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"source_dir_local: .lefthook-local", "# user-selected shared directory", "user_key: keep-me"} {
+		if !strings.Contains(string(uninstalled), want) {
+			t.Errorf("uninstall lost %q:\n%s", want, uninstalled)
+		}
+	}
+	if strings.Contains(string(uninstalled), lefthookOwnedMarker) {
+		t.Errorf("uninstall retained Entire-owned YAML:\n%s", uninstalled)
+	}
+}
+
+func TestRemoveGitHookIntegration_RollsBackAfterOwnedScriptObstruction(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	if _, err := EnsureGitHookIntegration(t.Context(), false); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(repoDir, lefthookLocalConfigName)
+	excludePath := filepath.Join(repoDir, ".git", "info", "exclude")
+	wantConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantExclude, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obstruction := filepath.Join(repoDir, filepath.FromSlash(lefthookScriptPath("pre-push")))
+	if err := os.Remove(obstruction); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(obstruction, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RemoveGitHookIntegration(t.Context()); err == nil {
+		t.Fatal("RemoveGitHookIntegration() should fail on an owned script directory obstruction")
+	} else if !strings.Contains(err.Error(), "inspect owned Lefthook script pre-push") {
+		t.Fatalf("RemoveGitHookIntegration() error = %v, want failure after staged config changes", err)
+	}
+	if got, err := os.ReadFile(configPath); err != nil || string(got) != string(wantConfig) {
+		t.Errorf("local config not rolled back: got %q err %v", got, err)
+	}
+	if got, err := os.ReadFile(excludePath); err != nil || string(got) != string(wantExclude) {
+		t.Errorf("exclude not rolled back: got %q err %v", got, err)
+	}
+
+	if err := os.Remove(obstruction); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RemoveGitHookIntegration(t.Context()); err != nil {
+		t.Fatalf("retry RemoveGitHookIntegration() error = %v", err)
+	}
+}
+
+func TestEnsureGitHookIntegration_FinalVerificationRollbackRestoresBytesAndMode(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(repoDir, lefthookLocalConfigName)
+	want := []byte("# user local config\npre_commit:\n  commands:\n    lint:\n      run: true\n")
+	if err := os.WriteFile(configPath, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	hookIntegrationFault = func(stage, _ string) error {
+		if stage == "final-verification" {
+			return errors.New("injected verification failure")
+		}
+		return nil
+	}
+	t.Cleanup(func() { hookIntegrationFault = nil })
+
+	if _, err := EnsureGitHookIntegration(t.Context(), false); err == nil {
+		t.Fatal("EnsureGitHookIntegration() should report injected verification failure")
+	}
+	got, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("config bytes = %q, want %q", got, want)
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotMode := info.Mode().Perm(); gotMode != 0o600 {
+		t.Errorf("config mode = %o, want 600", gotMode)
+	}
+}
+
+func TestEnsureGitHookIntegration_VerifiesArtifactsBeforeSavedHookRestore(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte("pre_commit: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte(realLefthookWrapper("pre-push")), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	if _, err := InstallGitHook(t.Context(), true, false); err != nil {
+		t.Fatal(err)
+	}
+	restoreObserved := false
+	hookIntegrationFault = func(stage, _ string) error {
+		if stage == "saved-hook-restore" {
+			restoreObserved = true
+		}
+		if stage == "artifact-verification" {
+			return errors.New("injected artifact verification failure")
+		}
+		return nil
+	}
+	t.Cleanup(func() { hookIntegrationFault = nil })
+
+	if _, err := EnsureGitHookIntegration(t.Context(), false); err == nil {
+		t.Fatal("EnsureGitHookIntegration() should report artifact verification failure")
+	}
+	if restoreObserved {
+		t.Fatal("saved-hook restoration ran before artifact verification succeeded")
+	}
+}
+
+func TestLefthookGeneratedHookProvenance(t *testing.T) {
+	t.Parallel()
+	if !looksLikeLefthookHook([]byte(realLefthookWrapper("pre-push")), "pre-push") {
+		t.Fatal("real Lefthook v2.1.12 wrapper should be recognized")
+	}
+	mentionOnly := []byte("#!/bin/sh\n# custom hook mentioning lefthook\nexit 0\n")
+	if looksLikeLefthookHook(mentionOnly, "pre-push") {
+		t.Fatal("arbitrary mention of Lefthook must not prove generated-hook provenance")
+	}
+	if looksLikeLefthookHook([]byte(noOpLefthookWrapper("pre-push")), "pre-push") {
+		t.Fatal("a shaped wrapper whose call_lefthook body is a no-op must not prove delivery")
+	}
+}
+
+func noOpLefthookWrapper(hook string) string {
+	return "#!/bin/sh\n\n" +
+		"if [ \"$LEFTHOOK_VERBOSE\" = \"1\" -o \"$LEFTHOOK_VERBOSE\" = \"true\" ]; then\n  set -x\nfi\n\n" +
+		"if [ \"$LEFTHOOK\" = \"0\" ]; then\n  exit 0\nfi\n\n" +
+		"call_lefthook()\n{\n  :\n}\n\n" +
+		"call_lefthook run \"" + hook + "\" \"$@\"\n"
+}
+
+func realLefthookWrapper(hook string) string {
+	return "#!/bin/sh\n\n" +
+		"if [ \"$LEFTHOOK_VERBOSE\" = \"1\" -o \"$LEFTHOOK_VERBOSE\" = \"true\" ]; then\n  set -x\nfi\n\n" +
+		"if [ \"$LEFTHOOK\" = \"0\" ]; then\n  exit 0\nfi\n\n" +
+		"call_lefthook()\n{\n  lefthook \"$@\"\n}\n\n" +
+		"call_lefthook run \"" + hook + "\" \"$@\"\n"
+}
+
+func writeRealLefthookHooks(t *testing.T, hooksDir string) {
+	t.Helper()
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, hook := range gitHookNames {
+		if err := os.WriteFile(filepath.Join(hooksDir, hook), []byte(realLefthookWrapper(hook)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestRemoveGitHookIntegration_RejectsSymlinkedLefthookRoot(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	external := t.TempDir()
+	externalScript := filepath.Join(external, "pre-push", lefthookScriptName)
+	if err := os.MkdirAll(filepath.Dir(externalScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := "#!/bin/sh\n# " + lefthookOwnedMarker + "\nexit 0\n"
+	if err := os.WriteFile(externalScript, []byte(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(repoDir, lefthookLocalDir)); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+
+	if _, err := RemoveGitHookIntegration(t.Context()); err == nil {
+		t.Fatal("RemoveGitHookIntegration() should reject symlinked Lefthook root")
+	}
+	got, err := os.ReadFile(externalScript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("external script changed = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveGitHookIntegration_RejectsSymlinkedHookSubdirectory(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	external := t.TempDir()
+	externalScript := filepath.Join(external, lefthookScriptName)
+	want := "#!/bin/sh\n# " + lefthookOwnedMarker + "\nexit 0\n"
+	if err := os.WriteFile(externalScript, []byte(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	localRoot := filepath.Join(repoDir, lefthookLocalDir)
+	if err := os.Mkdir(localRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(localRoot, "pre-push")); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+
+	if _, err := RemoveGitHookIntegration(t.Context()); err == nil {
+		t.Fatal("RemoveGitHookIntegration() should reject symlinked hook subdirectory")
+	}
+	got, err := os.ReadFile(externalScript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("external script changed = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveGitHookIntegration_RejectsSymlinkedEffectiveHooksDirectory(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	testutil.RunGit(t, repoDir, "config", "core.hooksPath", "managed-hooks")
+	external := t.TempDir()
+	externalHook := filepath.Join(external, "pre-push")
+	want := "#!/bin/sh\n# " + entireHookMarker + "\nexit 0\n"
+	if err := os.WriteFile(externalHook, []byte(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(repoDir, "managed-hooks")); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	ClearHooksDirCache()
+
+	if _, err := RemoveGitHookIntegration(t.Context()); err == nil {
+		t.Fatal("RemoveGitHookIntegration() should reject a symlinked effective hooks directory")
+	}
+	got, err := os.ReadFile(externalHook)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("external native hook changed = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveGitHookIntegration_RejectsSymlinkedNativeHookAndBackup(t *testing.T) {
+	for _, leaf := range []string{"pre-push", "pre-push" + backupSuffix} {
+		t.Run(leaf, func(t *testing.T) {
+			repoDir := t.TempDir()
+			testutil.InitRepo(t, repoDir)
+			clearGlobalHooksPath(t, repoDir)
+			if err := os.MkdirAll(filepath.Join(repoDir, ".git", "hooks"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			external := filepath.Join(t.TempDir(), "external-hook")
+			want := "#!/bin/sh\n# " + entireHookMarker + "\nexit 0\n"
+			if err := os.WriteFile(external, []byte(want), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(external, filepath.Join(repoDir, ".git", "hooks", leaf)); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(repoDir)
+			ClearHooksDirCache()
+
+			if _, err := RemoveGitHookIntegration(t.Context()); err == nil {
+				t.Fatalf("RemoveGitHookIntegration() should reject symlinked %s", leaf)
+			}
+			got, err := os.ReadFile(external)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != want {
+				t.Errorf("external hook changed = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestGitHookIntegrationIgnoresOwnershipMarkerInUnrelatedYAML(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	want := []byte("user_setting: value # " + lefthookOwnedMarker + "\n")
+	if err := os.WriteFile(filepath.Join(repoDir, lefthookLocalConfigName), want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+
+	if AnyGitHookIntegrationInstalled(t.Context()) {
+		t.Fatal("unrelated YAML marker must not claim Entire ownership")
+	}
+	if _, err := RemoveGitHookIntegration(t.Context()); err != nil {
+		t.Fatalf("RemoveGitHookIntegration() error = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(repoDir, lefthookLocalConfigName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("unrelated YAML changed = %q, want %q", got, want)
+	}
+}

--- a/cmd/entire/cli/strategy/hook_integration_transaction.go
+++ b/cmd/entire/cli/strategy/hook_integration_transaction.go
@@ -1,0 +1,675 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitdir"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
+)
+
+// hookIntegrationFault is a package-local test seam for failures at transaction
+// boundaries. Production leaves it nil.
+var hookIntegrationFault func(stage, path string) error
+
+type hookIntegrationSnapshot struct {
+	path   string
+	root   *os.Root
+	name   string
+	data   []byte
+	mode   os.FileMode
+	exists bool
+	dir    bool
+}
+
+type effectiveHooksRoot struct {
+	root   *os.Root
+	prefix string
+	path   string
+}
+
+func (hooks effectiveHooksRoot) name(hook string) string {
+	if hooks.prefix == "." || hooks.prefix == "" {
+		return hook
+	}
+	return filepath.ToSlash(filepath.Join(hooks.prefix, hook))
+}
+
+func openEffectiveHooksRoot(ctx context.Context, repoRoot string) (effectiveHooksRoot, error) {
+	hooksDir, err := getHooksDirInPath(ctx, repoRoot)
+	if err != nil {
+		return effectiveHooksRoot{}, err
+	}
+	commonDir, err := gitdir.CommonDirForWorktree(ctx, repoRoot)
+	if err != nil {
+		return effectiveHooksRoot{}, fmt.Errorf("resolve git common directory: %w", err)
+	}
+	anchors := []struct {
+		path string
+		root *os.Root
+	}{
+		{path: repoRoot},
+		{path: commonDir},
+	}
+	anchors[0].root, err = worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return effectiveHooksRoot{}, fmt.Errorf("open worktree: %w", err)
+	}
+	anchors[1].root, err = gitdir.OpenAt(commonDir)
+	if err != nil {
+		return effectiveHooksRoot{}, fmt.Errorf("open git common directory: %w", err)
+	}
+	hooksComparePath := hooksDir
+	if resolved, resolveErr := filepath.EvalSymlinks(filepath.Dir(hooksDir)); resolveErr == nil {
+		hooksComparePath = filepath.Join(resolved, filepath.Base(hooksDir))
+	}
+	for _, anchor := range anchors {
+		anchorComparePath := anchor.path
+		if resolved, resolveErr := filepath.EvalSymlinks(anchor.path); resolveErr == nil {
+			anchorComparePath = resolved
+		}
+		rel, relErr := filepath.Rel(anchorComparePath, hooksComparePath)
+		if relErr == nil && filepath.IsLocal(rel) {
+			return validateEffectiveHooksRoot(effectiveHooksRoot{root: anchor.root, prefix: filepath.ToSlash(rel), path: hooksDir})
+		}
+	}
+	volume := filepath.VolumeName(hooksDir)
+	fsRootPath := volume + string(os.PathSeparator)
+	// A configured core.hooksPath may live outside both repository anchors. The
+	// fixed root of its filesystem volume is trusted independently of that
+	// configured path; hooksDir remains a checked local name beneath the root.
+	fsRoot, err := osroot.Shared(fsRootPath)
+	if err != nil {
+		return effectiveHooksRoot{}, fmt.Errorf("open filesystem root for hooks: %w", err)
+	}
+	rel, err := filepath.Rel(fsRootPath, hooksDir)
+	if err != nil || !filepath.IsLocal(rel) {
+		return effectiveHooksRoot{}, fmt.Errorf("effective hooks path %s cannot be safely anchored", hooksDir)
+	}
+	return validateEffectiveHooksRoot(effectiveHooksRoot{root: fsRoot, prefix: filepath.ToSlash(rel), path: hooksDir})
+}
+
+func validateEffectiveHooksRoot(hooks effectiveHooksRoot) (effectiveHooksRoot, error) {
+	info, err := osroot.LstatNoSymlinks(hooks.root, hooks.prefix)
+	if os.IsNotExist(err) {
+		return hooks, nil
+	}
+	if err != nil {
+		return effectiveHooksRoot{}, fmt.Errorf("inspect effective hooks directory %s: %w", hooks.path, err)
+	}
+	if !info.IsDir() {
+		return effectiveHooksRoot{}, fmt.Errorf("effective hooks path %s is not a real directory", hooks.path)
+	}
+	return hooks, nil
+}
+
+// EnsureGitHookIntegration installs the durable integration selected by the
+// repository's hook manager. It never executes a hook manager binary.
+func EnsureGitHookIntegration(ctx context.Context, absolutePath bool) (int, error) {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("resolve worktree root: %w", err)
+	}
+	managers, err := detectHookManagersForIntegration(repoRoot)
+	if err != nil {
+		return 0, err
+	}
+	_, lefthook, err := selectLefthookIntegrationManager(managers)
+	if err != nil {
+		return 0, err
+	}
+	snapshots, err := snapshotHookIntegration(ctx, repoRoot)
+	if err != nil {
+		return 0, err
+	}
+	fail := func(primary error) (int, error) {
+		return 0, errors.Join(primary, restoreHookIntegrationSnapshots(snapshots))
+	}
+
+	if !lefthook {
+		written, installErr := InstallGitHook(ctx, true, absolutePath)
+		if installErr != nil {
+			return fail(installErr)
+		}
+		if err := integrationFault("final-verification", "native"); err != nil {
+			return fail(err)
+		}
+		health := CheckGitHookIntegration(ctx)
+		if health.Mode != GitHookIntegrationNative || health.State != GitHookIntegrationCurrent {
+			return fail(fmt.Errorf("native Git hook integration verification failed: %s", health.Reason))
+		}
+		return written, nil
+	}
+
+	written, err := installLefthookFilesAt(ctx, repoRoot, absolutePath, func(name string) error {
+		return integrationFault("rename", name)
+	})
+	if err != nil {
+		return fail(err)
+	}
+	root, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return fail(fmt.Errorf("open worktree for Lefthook verification: %w", err))
+	}
+	cmdPrefix, err := hookCmdPrefix(absolutePath)
+	if err != nil {
+		return fail(err)
+	}
+	artifactsCurrent, err := inspectLefthookArtifacts(root, cmdPrefix)
+	if err != nil {
+		return fail(fmt.Errorf("verify Lefthook artifacts: %w", err))
+	}
+	if !artifactsCurrent {
+		return fail(errors.New("verify Lefthook artifacts: installed artifacts are not current"))
+	}
+	if err := integrationFault("artifact-verification", "lefthook"); err != nil {
+		return fail(err)
+	}
+	activeCurrent, err := inspectActiveHookDelivery(ctx, repoRoot)
+	if err != nil {
+		return fail(fmt.Errorf("inspect active Git hook delivery: %w", err))
+	}
+	if !activeCurrent {
+		nativeWritten, installErr := InstallGitHook(ctx, true, absolutePath)
+		if installErr != nil {
+			return fail(installErr)
+		}
+		written += nativeWritten
+	}
+	if err := restoreProvenLefthookBridges(ctx, absolutePath); err != nil {
+		return fail(err)
+	}
+	if err := integrationFault("final-verification", "lefthook"); err != nil {
+		return fail(err)
+	}
+	health := CheckGitHookIntegration(ctx)
+	if health.Mode != GitHookIntegrationLefthook || health.State != GitHookIntegrationCurrent {
+		return fail(fmt.Errorf("lefthook integration verification failed: %s", health.Reason))
+	}
+	return written, nil
+}
+
+func inspectActiveHookDelivery(ctx context.Context, repoRoot string) (bool, error) {
+	hooks, err := openEffectiveHooksRoot(ctx, repoRoot)
+	if err != nil {
+		return false, err
+	}
+	for _, hook := range gitHookNames {
+		data, info, readErr := readOptionalRegular(hooks.root, hooks.name(hook))
+		if readErr != nil {
+			return false, readErr
+		}
+		if data == nil || info.Mode().Perm()&0o111 == 0 {
+			return false, nil
+		}
+		content := string(data)
+		nativeCurrent := currentNativeHookContent(content, hook)
+		if !nativeCurrent && !looksLikeLefthookHook(data, hook) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func restoreProvenLefthookBridges(ctx context.Context, absolutePath bool) error {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve worktree root: %w", err)
+	}
+	hooks, err := openEffectiveHooksRoot(ctx, repoRoot)
+	if err != nil {
+		return err
+	}
+	cmdPrefix, err := hookCmdPrefix(absolutePath)
+	if err != nil {
+		return err
+	}
+	for _, spec := range buildHookSpecs(cmdPrefix) {
+		hookName := hooks.name(spec.name)
+		backupName := hookName + backupSuffix
+		active, _, activeErr := readOptionalRegular(hooks.root, hookName)
+		backup, _, backupErr := readOptionalRegular(hooks.root, backupName)
+		if activeErr != nil || backupErr != nil || active == nil || backup == nil || string(active) != generateChainedContent(spec.content, spec.name) {
+			continue
+		}
+		if !looksLikeLefthookHook(backup, spec.name) {
+			continue
+		}
+		if err := integrationFault("saved-hook-restore", spec.name); err != nil {
+			return err
+		}
+		parent, leaf, closeParent, err := osroot.OpenParentNoSymlinks(hooks.root, hookName)
+		if err != nil {
+			return fmt.Errorf("open effective hooks directory for %s: %w", spec.name, err)
+		}
+		err = parent.Rename(leaf+backupSuffix, leaf)
+		closeParent()
+		if err != nil {
+			return fmt.Errorf("restore saved Lefthook %s hook: %w", spec.name, err)
+		}
+	}
+	return nil
+}
+
+func looksLikeLefthookHook(data []byte, hook string) bool {
+	content := string(data)
+	const prefix = `#!/bin/sh
+
+if [ "$LEFTHOOK_VERBOSE" = "1" -o "$LEFTHOOK_VERBOSE" = "true" ]; then
+  set -x
+fi
+
+if [ "$LEFTHOOK" = "0" ]; then
+  exit 0
+fi
+
+call_lefthook()
+{
+`
+	suffix := "}\n\ncall_lefthook run \"" + hook + "\" \"$@\"\n"
+	prefixWithGeneratedComment := strings.Replace(prefix, "\ncall_lefthook()", "\n# lefthook generated wrapper\ncall_lefthook()", 1)
+	matchedPrefix := prefix
+	if !strings.HasPrefix(content, matchedPrefix) {
+		matchedPrefix = prefixWithGeneratedComment
+	}
+	if !strings.HasPrefix(content, matchedPrefix) || !strings.HasSuffix(content, suffix) {
+		return false
+	}
+	body := strings.TrimSuffix(strings.TrimPrefix(content, matchedPrefix), suffix)
+	return knownLefthookV2Body(body) || knownDirectEntireLefthookBody(body, hook)
+}
+
+func knownLefthookV2Body(body string) bool {
+	if body == "  lefthook \"$@\"\n" {
+		return true
+	}
+	const installedBranchPrefix = `  if test -n "$LEFTHOOK_BIN"
+  then
+    "$LEFTHOOK_BIN" "$@"
+  elif lefthook -h >/dev/null 2>&1
+  then
+    lefthook "$@"
+  elif `
+	const installedProbeSuffix = ` -h >/dev/null 2>&1
+  then
+    `
+	if !strings.HasPrefix(body, installedBranchPrefix) {
+		return false
+	}
+	remainder := strings.TrimPrefix(body, installedBranchPrefix)
+	probeEnd := strings.Index(remainder, installedProbeSuffix)
+	if probeEnd <= 0 {
+		return false
+	}
+	installedPath := remainder[:probeEnd]
+	if !filepath.IsAbs(installedPath) || strings.ContainsAny(installedPath, "\n\r\t") {
+		return false
+	}
+	const generatedTail = ` "$@"
+  else
+    dir="$(git rev-parse --show-toplevel)"
+    osArch=$(uname | tr '[:upper:]' '[:lower:]')
+    cpuArch=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/x64/')
+    if test -f "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook"
+    then
+      "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/lefthook/bin/index.js"
+    then
+      "$dir/node_modules/lefthook/bin/index.js" "$@"
+    elif go tool lefthook -h >/dev/null 2>&1
+    then
+      go tool lefthook "$@"
+    elif bundle exec lefthook -h >/dev/null 2>&1
+    then
+      bundle exec lefthook "$@"
+    elif yarn lefthook -h >/dev/null 2>&1
+    then
+      yarn lefthook "$@"
+    elif pnpm lefthook -h >/dev/null 2>&1
+    then
+      pnpm lefthook "$@"
+    elif swift package lefthook >/dev/null 2>&1
+    then
+      swift package --build-path .build/lefthook --disable-sandbox lefthook "$@"
+    elif command -v mint >/dev/null 2>&1
+    then
+      mint run csjones/lefthook-plugin "$@"
+    elif uv run lefthook -h >/dev/null 2>&1
+    then
+      uv run lefthook "$@"
+    elif mise exec -- lefthook -h >/dev/null 2>&1
+    then
+      mise exec -- lefthook "$@"
+    elif devbox run lefthook -h >/dev/null 2>&1
+    then
+      devbox run lefthook "$@"
+    else
+      echo "Can't find lefthook in PATH"
+    fi
+  fi
+`
+	want := installedPath + installedProbeSuffix + installedPath + generatedTail
+	return remainder == want
+}
+
+func knownDirectEntireLefthookBody(body, hook string) bool {
+	const integrationLauncher = "  shift\n  hook=\"$1\"\n  shift\n  exec \"$PWD/.lefthook-local/$hook/entire.sh\" \"$@\"\n"
+	e2eLauncher := "  shift 2\n  sh \".lefthook-local/" + hook + "/entire.sh\" \"$@\"\n"
+	return body == integrationLauncher || body == e2eLauncher
+}
+
+// RemoveGitHookIntegration removes only artifacts whose exact ownership marker
+// proves they belong to Entire, together with the legacy native wrappers.
+func RemoveGitHookIntegration(ctx context.Context) (int, error) {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("resolve worktree root: %w", err)
+	}
+	snapshots, err := snapshotHookIntegration(ctx, repoRoot)
+	if err != nil {
+		return 0, err
+	}
+	fail := func(primary error) (int, error) {
+		return 0, errors.Join(primary, restoreHookIntegrationSnapshots(snapshots))
+	}
+	removed, err := removeOwnedLefthookArtifacts(ctx, repoRoot)
+	if err != nil {
+		return fail(err)
+	}
+	nativeRemoved, err := removeNativeGitHooksSafe(ctx, repoRoot)
+	if err != nil {
+		return fail(err)
+	}
+	if err := integrationFault("final-verification", "remove"); err != nil {
+		return fail(err)
+	}
+	if err := verifyGitHookIntegrationRemoved(ctx, repoRoot); err != nil {
+		return fail(err)
+	}
+	return removed + nativeRemoved, nil
+}
+
+func removeNativeGitHooksSafe(ctx context.Context, repoRoot string) (int, error) {
+	hooks, err := openEffectiveHooksRoot(ctx, repoRoot)
+	if err != nil {
+		return 0, err
+	}
+	removed := 0
+	for _, hook := range gitHookNames {
+		hookName := hooks.name(hook)
+		backupName := hookName + backupSuffix
+		active, _, activeErr := readOptionalRegular(hooks.root, hookName)
+		if activeErr != nil {
+			return 0, fmt.Errorf("inspect native %s hook: %w", hook, activeErr)
+		}
+		backup, _, backupErr := readOptionalRegular(hooks.root, backupName)
+		if backupErr != nil {
+			return 0, fmt.Errorf("inspect native %s backup: %w", hook, backupErr)
+		}
+		hookIsOurs := active != nil && strings.Contains(string(active), entireHookMarker)
+		if active != nil && !hookIsOurs && backup != nil {
+			fmt.Fprintf(os.Stderr, "[entire] Warning: %s was modified since install; backup %s%s left in place\n", hook, hook, backupSuffix)
+			continue
+		}
+		if backup != nil && (active == nil || hookIsOurs) {
+			parent, leaf, closeParent, openErr := osroot.OpenParentNoSymlinks(hooks.root, hookName)
+			if openErr != nil {
+				return 0, fmt.Errorf("open effective hooks directory for %s: %w", hook, openErr)
+			}
+			renameErr := parent.Rename(leaf+backupSuffix, leaf)
+			closeParent()
+			if renameErr != nil {
+				return 0, fmt.Errorf("restore %s%s: %w", hook, backupSuffix, renameErr)
+			}
+			if hookIsOurs {
+				removed++
+			}
+			continue
+		}
+		if hookIsOurs {
+			if removeErr := osroot.RemoveNoSymlinks(hooks.root, hookName); removeErr != nil {
+				return 0, fmt.Errorf("remove native %s hook: %w", hook, removeErr)
+			}
+			removed++
+		}
+	}
+	return removed, nil
+}
+
+// AnyGitHookIntegrationInstalled reports whether any native or Lefthook-owned
+// Entire hook artifact remains. Uninstall uses this after a partial run has
+// already removed .entire, so it cannot rely on enabled settings for discovery.
+func AnyGitHookIntegrationInstalled(ctx context.Context) bool {
+	if AnyGitHookInstalled(ctx) {
+		return true
+	}
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return false
+	}
+	root, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return false
+	}
+	if data, _, readErr := readOptionalRegular(root, lefthookLocalConfigName); readErr == nil && data != nil {
+		owned, ownershipErr := hasOwnedLefthookConfigEntries(data)
+		if ownershipErr == nil && owned {
+			return true
+		}
+	}
+	for _, hook := range gitHookNames {
+		data, _, readErr := readOptionalRegular(root, lefthookScriptPath(hook))
+		if readErr == nil && lefthookScriptOwned(string(data)) {
+			return true
+		}
+	}
+	return false
+}
+
+func verifyGitHookIntegrationRemoved(ctx context.Context, repoRoot string) error {
+	root, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return fmt.Errorf("open worktree: %w", err)
+	}
+	if data, _, err := readOptionalRegular(root, lefthookLocalConfigName); err == nil && data != nil {
+		owned, ownershipErr := hasOwnedLefthookConfigEntries(data)
+		if ownershipErr != nil {
+			return fmt.Errorf("verify %s ownership: %w", lefthookLocalConfigName, ownershipErr)
+		}
+		if owned {
+			return errors.New("lefthook local config still contains Entire-owned entries")
+		}
+	} else if err != nil {
+		return fmt.Errorf("verify %s removal: %w", lefthookLocalConfigName, err)
+	}
+	for _, hook := range gitHookNames {
+		if data, _, err := readOptionalRegular(root, lefthookScriptPath(hook)); err == nil && data != nil {
+			if lefthookScriptOwned(string(data)) {
+				return fmt.Errorf("owned Lefthook script %s remains", hook)
+			}
+		} else if err != nil {
+			return fmt.Errorf("verify Lefthook script %s removal: %w", hook, err)
+		}
+	}
+	hooks, err := openEffectiveHooksRoot(ctx, repoRoot)
+	if err != nil {
+		return err
+	}
+	for _, hook := range gitHookNames {
+		if data, _, readErr := readOptionalRegular(hooks.root, hooks.name(hook)); readErr == nil && data != nil {
+			if strings.Contains(string(data), entireHookMarker) {
+				return fmt.Errorf("native Entire hook %s remains", hook)
+			}
+		} else if readErr != nil {
+			return fmt.Errorf("verify native hook %s removal: %w", hook, readErr)
+		}
+	}
+	return nil
+}
+
+func removeOwnedLefthookArtifacts(ctx context.Context, repoRoot string) (int, error) {
+	removed := 0
+	root, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return 0, fmt.Errorf("open worktree: %w", err)
+	}
+	if data, info, err := readOptionalRegular(root, lefthookLocalConfigName); err == nil && data != nil {
+		updated, changed, updateErr := removeOwnedLefthookConfig(data)
+		if updateErr != nil {
+			return 0, updateErr
+		}
+		if changed {
+			if err := integrationFault("write", lefthookLocalConfigName); err != nil {
+				return 0, err
+			}
+			if len(strings.TrimSpace(string(updated))) == 0 || string(updated) == "{}\n" {
+				if err := osroot.RemoveNoSymlinks(root, lefthookLocalConfigName); err != nil {
+					return 0, fmt.Errorf("remove %s: %w", lefthookLocalConfigName, err)
+				}
+			} else if err := jsonutil.WriteFileAtomicIn(root, lefthookLocalConfigName, updated, info.Mode().Perm()); err != nil {
+				return 0, fmt.Errorf("write %s: %w", lefthookLocalConfigName, err)
+			}
+			removed++
+		}
+	} else if err != nil {
+		return 0, fmt.Errorf("read %s: %w", lefthookLocalConfigName, err)
+	}
+	for _, hook := range gitHookNames {
+		name := lefthookScriptPath(hook)
+		data, _, err := readOptionalRegular(root, name)
+		if err != nil {
+			return 0, fmt.Errorf("inspect owned Lefthook script %s: %w", hook, err)
+		}
+		if data == nil {
+			continue
+		}
+		if !lefthookScriptOwned(string(data)) {
+			continue
+		}
+		if err := osroot.RemoveNoSymlinks(root, name); err != nil {
+			return 0, fmt.Errorf("remove owned Lefthook script %s: %w", hook, err)
+		}
+		removed++
+	}
+	commonDir, err := gitdir.CommonDirForWorktree(ctx, repoRoot)
+	if err != nil {
+		return 0, fmt.Errorf("resolve git common directory: %w", err)
+	}
+	gitRoot, err := gitdir.OpenAt(commonDir)
+	if err != nil {
+		return 0, fmt.Errorf("open git common directory: %w", err)
+	}
+	if data, info, readErr := readOptionalRegular(gitRoot, "info/exclude"); readErr == nil && data != nil {
+		updated := removeLefthookExcludeLines(data)
+		if string(updated) != string(data) {
+			if err := jsonutil.WriteFileAtomicIn(gitRoot, "info/exclude", updated, info.Mode().Perm()); err != nil {
+				return 0, fmt.Errorf("write git exclude: %w", err)
+			}
+		}
+	} else if readErr != nil {
+		return 0, fmt.Errorf("read git exclude: %w", readErr)
+	}
+	return removed, nil
+}
+
+func removeLefthookExcludeLines(data []byte) []byte {
+	return []byte(strings.Replace(string(data), lefthookExcludeBlock(), "", 1))
+}
+
+func snapshotHookIntegration(ctx context.Context, repoRoot string) ([]hookIntegrationSnapshot, error) {
+	commonDir, err := gitdir.CommonDirForWorktree(ctx, repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve git common directory: %w", err)
+	}
+	hooks, err := openEffectiveHooksRoot(ctx, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	workRoot, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open worktree: %w", err)
+	}
+	gitRoot, err := gitdir.OpenAt(commonDir)
+	if err != nil {
+		return nil, fmt.Errorf("open git common directory: %w", err)
+	}
+	snapshots := []hookIntegrationSnapshot{
+		{path: filepath.Join(repoRoot, lefthookLocalConfigName), root: workRoot, name: lefthookLocalConfigName},
+		{path: filepath.Join(commonDir, "info", "exclude"), root: gitRoot, name: "info/exclude"},
+	}
+	for _, hook := range gitHookNames {
+		snapshots = append(snapshots,
+			hookIntegrationSnapshot{path: filepath.Join(repoRoot, filepath.FromSlash(lefthookScriptPath(hook))), root: workRoot, name: lefthookScriptPath(hook)},
+			hookIntegrationSnapshot{path: filepath.Join(hooks.path, hook), root: hooks.root, name: hooks.name(hook)},
+			hookIntegrationSnapshot{path: filepath.Join(hooks.path, hook) + backupSuffix, root: hooks.root, name: hooks.name(hook) + backupSuffix},
+		)
+	}
+	for i := range snapshots {
+		snapshot := &snapshots[i]
+		info, statErr := osroot.LstatNoSymlinks(snapshot.root, snapshot.name)
+		if os.IsNotExist(statErr) {
+			continue
+		}
+		if statErr != nil {
+			return nil, fmt.Errorf("inspect transaction path %s: %w", snapshot.path, statErr)
+		}
+		if info.IsDir() {
+			snapshot.mode, snapshot.exists, snapshot.dir = info.Mode().Perm(), true, true
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("transaction path %s is not a regular file", snapshot.path)
+		}
+		data, readErr := osroot.ReadFileNoFollow(snapshot.root, snapshot.name)
+		if readErr != nil {
+			return nil, fmt.Errorf("read transaction path %s: %w", snapshot.path, readErr)
+		}
+		snapshot.data, snapshot.mode, snapshot.exists = data, info.Mode().Perm(), true
+	}
+	return snapshots, nil
+}
+
+func restoreHookIntegrationSnapshots(snapshots []hookIntegrationSnapshot) error {
+	var errs []error
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		snapshot := snapshots[i]
+		if snapshot.dir {
+			// Artifact operations reject directories at file paths without
+			// modifying them, so the captured obstruction is already restored.
+			continue
+		}
+		if snapshot.exists {
+			if err := jsonutil.WriteFileAtomicIn(snapshot.root, snapshot.name, snapshot.data, snapshot.mode); err != nil {
+				errs = append(errs, fmt.Errorf("restore %s: %w", snapshot.path, err))
+			}
+			continue
+		}
+		if err := osroot.RemoveNoSymlinks(snapshot.root, snapshot.name); err != nil {
+			errs = append(errs, fmt.Errorf("remove newly-created %s: %w", snapshot.path, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func integrationFault(stage, path string) error {
+	if hookIntegrationFault == nil {
+		return nil
+	}
+	if err := hookIntegrationFault(stage, path); err != nil {
+		return fmt.Errorf("hook integration %s failure at %s: %w", stage, path, err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/strategy/hook_integration_transaction.go
+++ b/cmd/entire/cli/strategy/hook_integration_transaction.go
@@ -125,6 +125,9 @@ func EnsureGitHookIntegration(ctx context.Context, absolutePath bool) (int, erro
 	if err != nil {
 		return 0, err
 	}
+	if err := checkNativeHookRepairInDir(ctx, repoRoot); err != nil {
+		return 0, err
+	}
 	snapshots, err := snapshotHookIntegration(ctx, repoRoot)
 	if err != nil {
 		return 0, err

--- a/cmd/entire/cli/strategy/hook_integration_transaction.go
+++ b/cmd/entire/cli/strategy/hook_integration_transaction.go
@@ -121,7 +121,7 @@ func EnsureGitHookIntegration(ctx context.Context, absolutePath bool) (int, erro
 	if err != nil {
 		return 0, err
 	}
-	_, lefthook, err := selectLefthookIntegrationManager(managers)
+	manager, lefthook, err := selectLefthookIntegrationManager(managers)
 	if err != nil {
 		return 0, err
 	}
@@ -131,6 +131,27 @@ func EnsureGitHookIntegration(ctx context.Context, absolutePath bool) (int, erro
 	}
 	fail := func(primary error) (int, error) {
 		return 0, errors.Join(primary, restoreHookIntegrationSnapshots(snapshots))
+	}
+	if lefthook {
+		root, openErr := worktreedir.OpenAt(repoRoot)
+		if openErr != nil {
+			return fail(fmt.Errorf("open worktree for Lefthook validation: %w", openErr))
+		}
+		validationErr := validateLefthookMainConfig(root, manager)
+		if errors.Is(validationErr, errLefthookUnsupportedLayout) {
+			written, installErr := InstallGitHook(ctx, true, absolutePath)
+			if installErr != nil {
+				return fail(installErr)
+			}
+			health := CheckGitHookIntegration(ctx)
+			if health.Mode != GitHookIntegrationLefthook || health.State != GitHookIntegrationDegraded || health.ReasonCode != "lefthook_unsupported_native_bridge" {
+				return fail(fmt.Errorf("unsupported Lefthook native fallback verification failed: %s", health.Reason))
+			}
+			return written, nil
+		}
+		if validationErr != nil {
+			return fail(validationErr)
+		}
 	}
 
 	if !lefthook {

--- a/cmd/entire/cli/strategy/hook_managers.go
+++ b/cmd/entire/cli/strategy/hook_managers.go
@@ -13,10 +13,20 @@ import (
 
 // hookManager describes an external hook manager detected in a repository.
 type hookManager struct {
-	Name            string // "Husky", "Lefthook", "pre-commit", "Overcommit"
-	ConfigPath      string // relative path that triggered detection (e.g., ".husky/")
-	OverwritesHooks bool   // true if the tool will overwrite Entire's hooks on reinstall
+	Name            string                     // "Husky", "Lefthook", "pre-commit", "Overcommit"
+	ConfigPath      string                     // relative path that triggered detection (e.g., ".husky/")
+	OverwritesHooks bool                       // true if the tool will overwrite Entire's hooks on reinstall
+	IntegrationKind hookManagerIntegrationKind // how Entire can integrate with the manager
 }
+
+type hookManagerIntegrationKind string
+
+const (
+	hookManagerIntegrationNone          hookManagerIntegrationKind = ""
+	hookManagerIntegrationHookDirectory hookManagerIntegrationKind = "hook-directory"
+	hookManagerIntegrationLefthook      hookManagerIntegrationKind = "lefthook"
+	lefthookManagerName                                            = "Lefthook"
+)
 
 // detectHookManagers checks the repository root for known hook manager config
 // files/directories. Detection is filesystem-only (os.Stat, no file reads).
@@ -24,26 +34,28 @@ func detectHookManagers(repoRoot string) []hookManager {
 	var managers []hookManager
 
 	checks := []hookManager{
-		{"Husky", ".husky/", true},
-		{"pre-commit", ".pre-commit-config.yaml", false},
-		{"Overcommit", ".overcommit.yml", false},
+		{Name: "Husky", ConfigPath: ".husky/", OverwritesHooks: true, IntegrationKind: hookManagerIntegrationHookDirectory},
+		{Name: "pre-commit", ConfigPath: ".pre-commit-config.yaml", IntegrationKind: hookManagerIntegrationNone},
+		{Name: "Overcommit", ConfigPath: ".overcommit.yml", IntegrationKind: hookManagerIntegrationNone},
 	}
 
-	// Lefthook supports {.,}lefthook{,-local}.{yml,yaml,json,toml}
-	for _, prefix := range []string{"", "."} {
-		for _, variant := range []string{"", "-local"} {
-			for _, ext := range []string{"yml", "yaml", "json", "toml"} {
-				name := prefix + "lefthook" + variant + "." + ext
-				checks = append(checks, hookManager{"Lefthook", name, false})
-			}
-		}
+	// Lefthook supports root, dotted-root, and .config variants in YAML,
+	// JSON/JSONC, and TOML. Keep advisory detection broad even when the safe
+	// local integration rejects a format or location it cannot own.
+	for _, name := range append(append([]string{}, lefthookMainConfigNames...), lefthookLocalConfigNames...) {
+		checks = append(checks, hookManager{
+			Name:            lefthookManagerName,
+			ConfigPath:      name,
+			OverwritesHooks: true,
+			IntegrationKind: hookManagerIntegrationLefthook,
+		})
 	}
 
 	// hk supports {.config/,}hk{,.local}.pkl
 	for _, dir := range []string{"", ".config/"} {
 		for _, variant := range []string{"", ".local"} {
 			name := dir + "hk" + variant + ".pkl"
-			checks = append(checks, hookManager{"hk", name, false})
+			checks = append(checks, hookManager{Name: "hk", ConfigPath: name, IntegrationKind: hookManagerIntegrationNone})
 		}
 	}
 
@@ -77,6 +89,12 @@ func hookManagerWarning(managers []hookManager, cmdPrefix string) string {
 		if m.OverwritesHooks {
 			fmt.Fprintf(&b, "Warning: %s detected (%s)\n", m.Name, m.ConfigPath)
 			fmt.Fprintf(&b, "\n")
+			if m.IntegrationKind != hookManagerIntegrationHookDirectory {
+				fmt.Fprintf(&b, "  %s may overwrite hooks installed by Entire when it installs or refreshes hooks.\n", m.Name)
+				fmt.Fprintf(&b, "  If %s reinstalls hooks, run 'entire enable' to restore Entire's hooks.\n", m.Name)
+				fmt.Fprintf(&b, "\n")
+				continue
+			}
 			fmt.Fprintf(&b, "  %s may overwrite hooks installed by Entire on npm install.\n", m.Name)
 			fmt.Fprintf(&b, "  To make Entire hooks permanent, add these lines to your %s hook files:\n", m.Name)
 			fmt.Fprintf(&b, "\n")

--- a/cmd/entire/cli/strategy/hook_managers_test.go
+++ b/cmd/entire/cli/strategy/hook_managers_test.go
@@ -55,14 +55,17 @@ func TestDetectHookManagers_Lefthook(t *testing.T) {
 	if len(managers) != 1 {
 		t.Fatalf("expected 1 manager, got %d", len(managers))
 	}
-	if managers[0].Name != "Lefthook" { //nolint:goconst // test assertion, not a magic string
+	if managers[0].Name != lefthookManagerName {
 		t.Errorf("expected Lefthook, got %s", managers[0].Name)
 	}
 	if managers[0].ConfigPath != "lefthook.yml" {
 		t.Errorf("expected lefthook.yml, got %s", managers[0].ConfigPath)
 	}
-	if managers[0].OverwritesHooks {
-		t.Error("Lefthook should have OverwritesHooks=false")
+	if !managers[0].OverwritesHooks {
+		t.Error("Lefthook should have OverwritesHooks=true")
+	}
+	if managers[0].IntegrationKind != hookManagerIntegrationLefthook {
+		t.Errorf("Lefthook integration kind = %q, want %q", managers[0].IntegrationKind, hookManagerIntegrationLefthook)
 	}
 }
 
@@ -78,7 +81,7 @@ func TestDetectHookManagers_LefthookDotPrefix(t *testing.T) {
 	if len(managers) != 1 {
 		t.Fatalf("expected 1 manager, got %d", len(managers))
 	}
-	if managers[0].Name != "Lefthook" {
+	if managers[0].Name != lefthookManagerName {
 		t.Errorf("expected Lefthook, got %s", managers[0].Name)
 	}
 	if managers[0].ConfigPath != ".lefthook.yml" {
@@ -98,7 +101,7 @@ func TestDetectHookManagers_LefthookToml(t *testing.T) {
 	if len(managers) != 1 {
 		t.Fatalf("expected 1 manager, got %d", len(managers))
 	}
-	if managers[0].Name != "Lefthook" {
+	if managers[0].Name != lefthookManagerName {
 		t.Errorf("expected Lefthook, got %s", managers[0].Name)
 	}
 	if managers[0].ConfigPath != "lefthook.toml" {
@@ -118,7 +121,7 @@ func TestDetectHookManagers_LefthookLocal(t *testing.T) {
 	if len(managers) != 1 {
 		t.Fatalf("expected 1 manager, got %d", len(managers))
 	}
-	if managers[0].Name != "Lefthook" {
+	if managers[0].Name != lefthookManagerName {
 		t.Errorf("expected Lefthook, got %s", managers[0].Name)
 	}
 	if managers[0].ConfigPath != "lefthook-local.yml" {
@@ -142,7 +145,7 @@ func TestDetectHookManagers_LefthookDedup(t *testing.T) {
 	if len(managers) != 1 {
 		t.Fatalf("expected 1 manager (dedup), got %d", len(managers))
 	}
-	if managers[0].Name != "Lefthook" {
+	if managers[0].Name != lefthookManagerName {
 		t.Errorf("expected Lefthook, got %s", managers[0].Name)
 	}
 }
@@ -314,7 +317,12 @@ func TestHookManagerWarning_Husky(t *testing.T) {
 	t.Parallel()
 
 	managers := []hookManager{
-		{Name: "Husky", ConfigPath: ".husky/", OverwritesHooks: true},
+		{
+			Name:            "Husky",
+			ConfigPath:      ".husky/",
+			OverwritesHooks: true,
+			IntegrationKind: hookManagerIntegrationHookDirectory,
+		},
 	}
 
 	warning := hookManagerWarning(managers, "entire")
@@ -352,14 +360,18 @@ func TestHookManagerWarning_GitHooksManager(t *testing.T) {
 	t.Parallel()
 
 	managers := []hookManager{
-		{Name: "Lefthook", ConfigPath: "lefthook.yml", OverwritesHooks: false},
+		{
+			Name:            lefthookManagerName,
+			ConfigPath:      "lefthook.yml",
+			OverwritesHooks: true,
+			IntegrationKind: hookManagerIntegrationLefthook,
+		},
 	}
 
 	warning := hookManagerWarning(managers, "entire")
 
-	// Category B: should be a Note, not a Warning
-	if !strings.Contains(warning, "Note: Lefthook detected") {
-		t.Error("warning should contain 'Note: Lefthook detected'")
+	if !strings.Contains(warning, "Warning: Lefthook detected") {
+		t.Error("warning should contain 'Warning: Lefthook detected'")
 	}
 	if !strings.Contains(warning, "run 'entire enable' to restore") {
 		t.Error("warning should mention running 'entire enable'")
@@ -367,7 +379,10 @@ func TestHookManagerWarning_GitHooksManager(t *testing.T) {
 
 	// Should NOT contain hook file copy-paste instructions
 	if strings.Contains(warning, "prepare-commit-msg:") {
-		t.Error("category B warning should not contain hook file instructions")
+		t.Error("Lefthook warning should not treat its config file as a hook directory")
+	}
+	if strings.Contains(warning, "lefthook.ymlprepare-commit-msg") {
+		t.Error("Lefthook config path must not be presented as a hook directory")
 	}
 }
 
@@ -389,7 +404,12 @@ func TestHookManagerWarning_AbsolutePathPrefix(t *testing.T) {
 	t.Parallel()
 
 	managers := []hookManager{
-		{Name: "Husky", ConfigPath: ".husky/", OverwritesHooks: true},
+		{
+			Name:            "Husky",
+			ConfigPath:      ".husky/",
+			OverwritesHooks: true,
+			IntegrationKind: hookManagerIntegrationHookDirectory,
+		},
 	}
 
 	// The prefix is whatever hookCmdPrefix resolved to — bare "entire" or, with
@@ -408,8 +428,18 @@ func TestHookManagerWarning_Multiple(t *testing.T) {
 	t.Parallel()
 
 	managers := []hookManager{
-		{Name: "Husky", ConfigPath: ".husky/", OverwritesHooks: true},
-		{Name: "Lefthook", ConfigPath: "lefthook.yml", OverwritesHooks: false},
+		{
+			Name:            "Husky",
+			ConfigPath:      ".husky/",
+			OverwritesHooks: true,
+			IntegrationKind: hookManagerIntegrationHookDirectory,
+		},
+		{
+			Name:            lefthookManagerName,
+			ConfigPath:      "lefthook.yml",
+			OverwritesHooks: true,
+			IntegrationKind: hookManagerIntegrationLefthook,
+		},
 	}
 
 	warning := hookManagerWarning(managers, "entire")
@@ -417,8 +447,8 @@ func TestHookManagerWarning_Multiple(t *testing.T) {
 	if !strings.Contains(warning, "Warning: Husky detected") {
 		t.Error("should contain Husky warning")
 	}
-	if !strings.Contains(warning, "Note: Lefthook detected") {
-		t.Error("should contain Lefthook note")
+	if !strings.Contains(warning, "Warning: Lefthook detected") {
+		t.Error("should contain Lefthook warning")
 	}
 }
 

--- a/cmd/entire/cli/strategy/hook_repair.go
+++ b/cmd/entire/cli/strategy/hook_repair.go
@@ -1,0 +1,81 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
+)
+
+var errModifiedNativeHook = errors.New("unrecognized content in Entire-marked Git hook")
+
+// Preflight every hook before writing any of them. A marker establishes that
+// Entire participated, not that every command in the file belongs to Entire.
+func checkNativeHookRepair(root *os.Root) error {
+	for _, hook := range gitHookNames {
+		data, err := osroot.ReadFileNoFollow(root, hook)
+		if os.IsNotExist(err) || errors.Is(err, osroot.ErrSymlinkedPath) {
+			continue // Missing/foreign hooks retain the installer's backup policy.
+		}
+		if err != nil {
+			return unclassifiableHookError(root.Name(), hook, err)
+		}
+		content := string(data)
+		if strings.Contains(content, entireHookMarker) && !recognizedNativeHookContent(content, hook) {
+			return fmt.Errorf("%w: %s. Entire left it unchanged. Preserve your custom commands outside the Entire-managed hook, then run 'entire doctor' to reinstall it", errModifiedNativeHook, hook)
+		}
+	}
+	return nil
+}
+
+func checkNativeHookRepairInDir(ctx context.Context, repoRoot string) error {
+	hooksDir, err := getHooksDirInPath(ctx, repoRoot)
+	if err != nil {
+		return err
+	}
+	root, err := hooksRootForRemoval(hooksDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return checkNativeHookRepair(root)
+}
+
+// Only complete known templates are safe to migrate. Unknown historical
+// variants deliberately require user attention rather than risking user edits.
+func recognizedNativeHookContent(content, hook string) bool {
+	const prePush = "pre-push"
+	if currentNativeHookContent(content, hook) {
+		return true
+	}
+	// The preceding release passed only the remote name to pre-push.
+	if hook == prePush && currentNativeHookContent(strings.Replace(content, `pre-push "$1"`, `pre-push "$1" "$2"`, 1), hook) {
+		return true
+	}
+	args := map[string]string{
+		"prepare-commit-msg": `"$1" "$2" 2>/dev/null`,
+		"commit-msg":         `"$1"`,
+		"post-commit":        `2>/dev/null`,
+		"post-rewrite":       `"$1" 2>/dev/null`,
+		prePush:              `"$1"`,
+	}
+	// These are the two retired local-development launcher formats. Match the
+	// whole file (including an optional generated backup chain), never merely
+	// the invocation line: user additions around a legacy command matter too.
+	for _, command := range []string{
+		"./scripts/entire-dev hooks git " + hook,
+		"./scripts/entire-dev hooks git " + hook + " " + args[hook],
+		"go run ./cmd/entire/main.go hooks git " + hook + " " + args[hook] + " || true",
+	} {
+		base := "#!/bin/sh\n# " + entireHookMarker + "\n" + command + "\n"
+		if content == base || content == generateChainedContent(base, hook) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/strategy/hook_repair_test.go
+++ b/cmd/entire/cli/strategy/hook_repair_test.go
@@ -1,0 +1,115 @@
+package strategy
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func hookRepairRepo(t *testing.T) (string, string) {
+	t.Helper()
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	t.Chdir(repoDir)
+	_, err := EnsureGitHookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	return repoDir, filepath.Join(repoDir, ".git", "hooks")
+}
+
+// These tests change CWD because the repair API resolves the current repository.
+func TestHookRepair_PreservesUserEdits(t *testing.T) {
+	for _, manager := range []string{"native", "lefthook"} {
+		for _, position := range []string{"before", "after"} {
+			t.Run(manager+"/"+position, func(t *testing.T) {
+				repoDir, hooksDir := hookRepairRepo(t)
+				if manager == "lefthook" {
+					require.NoError(t, os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644))
+				}
+				hookPath := filepath.Join(hooksDir, "pre-push")
+				original, err := os.ReadFile(hookPath)
+				require.NoError(t, err)
+				edited := string(original) + "echo user-validation\n"
+				if position == "before" {
+					edited = strings.Replace(string(original), "#!/bin/sh\n", "#!/bin/sh\necho user-validation\n", 1)
+				}
+				require.NoError(t, os.WriteFile(hookPath, []byte(edited), 0o755))
+				for range 2 {
+					_, err := EnsureGitHookIntegration(t.Context(), false)
+					require.Error(t, err, "repair must refuse a user-edited hook")
+					require.Contains(t, err.Error(), "pre-push")
+					after, err := os.ReadFile(hookPath)
+					require.NoError(t, err)
+					require.Equal(t, edited, string(after))
+					require.NoFileExists(t, hookPath+backupSuffix)
+					health := CheckGitHookIntegration(t.Context())
+					require.NotEqual(t, GitHookIntegrationCurrent, health.State)
+					require.Contains(t, health.Reason, "pre-push")
+				}
+			})
+		}
+	}
+}
+
+func TestHookRepair_NativePermissions(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("Windows does not use Unix executable bits")
+	}
+	_, hooksDir := hookRepairRepo(t)
+	hookPath := filepath.Join(hooksDir, "pre-push")
+	require.NoError(t, os.Chmod(hookPath, 0o644))
+	require.NotEqual(t, GitHookIntegrationCurrent, CheckGitHookIntegration(t.Context()).State)
+	written, err := EnsureGitHookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	info, err := os.Stat(hookPath)
+	require.NoError(t, err)
+	require.NotZero(t, info.Mode().Perm()&0o111)
+	require.Equal(t, GitHookIntegrationCurrent, CheckGitHookIntegration(t.Context()).State)
+	written, err = EnsureGitHookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	require.Zero(t, written)
+}
+
+func TestHookRepair_PreviousGeneratedPrePush(t *testing.T) {
+	_, hooksDir := hookRepairRepo(t)
+	hookPath := filepath.Join(hooksDir, "pre-push")
+	current, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	previous := strings.Replace(string(current), `pre-push "$1" "$2"`, `pre-push "$1"`, 1)
+	require.NotEqual(t, string(current), previous)
+	require.NoError(t, os.WriteFile(hookPath, []byte(previous), 0o755))
+	_, err = EnsureGitHookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	after, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	require.Equal(t, string(current), string(after))
+}
+
+func TestHookRepair_PreflightsBeforeChangingHooks(t *testing.T) {
+	_, hooksDir := hookRepairRepo(t)
+	// An earlier hook needs migration, but a later hook contains a user edit.
+	// Even direct installer callers must not partially update the hook set.
+	first := filepath.Join(hooksDir, "prepare-commit-msg")
+	legacy := "#!/bin/sh\n# Entire CLI hooks\n./scripts/entire-dev hooks git prepare-commit-msg\n"
+	require.NoError(t, os.WriteFile(first, []byte(legacy), 0o755))
+	last := filepath.Join(hooksDir, "pre-push")
+	original, err := os.ReadFile(last)
+	require.NoError(t, err)
+	edited := string(original) + "echo user-validation\n"
+	require.NoError(t, os.WriteFile(last, []byte(edited), 0o755))
+	backup := "#!/bin/sh\necho existing-backup\n"
+	require.NoError(t, os.WriteFile(last+backupSuffix, []byte(backup), 0o755))
+	_, err = InstallGitHook(t.Context(), true, false)
+	require.Error(t, err)
+	for path, expected := range map[string]string{first: legacy, last: edited, last + backupSuffix: backup} {
+		actual, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, expected, string(actual))
+	}
+}

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -516,6 +516,13 @@ func inspectGitHookStateInHooksDir(hooksDir string) (GitHookState, error) {
 		if !strings.Contains(content, entireHookMarker) {
 			return GitHooksAbsent, nil
 		}
+		info, err := osroot.LstatNoSymlinks(root, hook)
+		if err != nil {
+			return GitHooksAbsent, fmt.Errorf("inspect Git hook %s permissions: %w", hook, err)
+		}
+		if runtime.GOOS != goosWindows && info.Mode().Perm()&0o111 == 0 {
+			outdated = true
+		}
 		if !currentNativeHookContent(content, hook) {
 			outdated = true
 		}
@@ -728,6 +735,9 @@ func InstallGitHook(ctx context.Context, silent, absolutePath bool) (int, error)
 	if err != nil {
 		return 0, err
 	}
+	if err := checkNativeHookRepair(root); err != nil {
+		return 0, err
+	}
 	specs := buildHookSpecs(cmdPrefix)
 	installedCount := 0
 
@@ -795,7 +805,13 @@ func writeHookFile(root *os.Root, name, content string) (bool, error) {
 	// Check if file already exists with same content
 	existing, err := osroot.ReadFileNoFollow(root, name)
 	if err == nil && string(existing) == content {
-		return false, nil // Already up to date
+		info, statErr := osroot.LstatNoSymlinks(root, name)
+		if statErr != nil {
+			return false, fmt.Errorf("inspect hook %s permissions: %w", name, statErr)
+		}
+		if runtime.GOOS == goosWindows || info.Mode().Perm()&0o111 != 0 {
+			return false, nil // Already up to date, including execution permissions.
+		}
 	}
 
 	// Git hooks must be executable (0o755)

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -20,6 +20,7 @@ import (
 
 // Hook marker used to identify Entire CLI hooks
 const entireHookMarker = "Entire CLI hooks"
+const postRewriteHookName = "post-rewrite"
 
 // GitHookBackupSuffix is what InstallGitHook moves a pre-existing hook to
 // before writing its own. Exported so diagnostics elsewhere can name the file
@@ -414,7 +415,9 @@ const (
 	GitHooksOutdated
 )
 
-// CheckGitHookState reports the state of the active hooks directory.
+// CheckGitHookState reports the legacy native-hook state. Existing setup,
+// doctor, and removal callers stay native-only until their manager-aware
+// migration is wired separately.
 func CheckGitHookState(ctx context.Context) GitHookState {
 	hooksDir, err := GetHooksDir(ctx)
 	if err != nil {
@@ -423,14 +426,25 @@ func CheckGitHookState(ctx context.Context) GitHookState {
 	return gitHookStateInHooksDir(hooksDir)
 }
 
-// CheckGitHookStateInDir reports the state for a specific repo directory, for
-// callers that must not depend on the working directory.
+// CheckGitHookStateInDir reports the legacy native-hook state for repoDir.
 func CheckGitHookStateInDir(ctx context.Context, repoDir string) GitHookState {
 	hooksDir, err := getHooksDirInPath(ctx, repoDir)
 	if err != nil {
 		return GitHooksAbsent
 	}
 	return gitHookStateInHooksDir(hooksDir)
+}
+
+func legacyGitHookState(health GitHookIntegrationHealth) GitHookState {
+	switch health.State {
+	case GitHookIntegrationCurrent:
+		return GitHooksCurrent
+	case GitHookIntegrationOutdated:
+		return GitHooksOutdated
+	case GitHookIntegrationDegraded, GitHookIntegrationAbsent, GitHookIntegrationError:
+		return GitHooksAbsent
+	}
+	return GitHooksAbsent
 }
 
 // IsGitHookInstalled reports whether a CURRENT set of Entire git hooks is
@@ -454,32 +468,6 @@ func AnyGitHookInstalled(ctx context.Context) bool {
 	return CheckGitHookState(ctx) != GitHooksAbsent
 }
 
-// ReinstallGitHooks rewrites the managed git hooks using this repo's hook
-// settings — the same pair EnsureSetup runs, exported so callers outside this
-// package cannot open-code it and silently drop absolute_git_hook_path.
-func ReinstallGitHooks(ctx context.Context) (int, error) {
-	return InstallGitHook(ctx, true, hookSettingsFromConfig(ctx))
-}
-
-// legacyGitHookLaunchers are the markers of a git hook that runs Entire from the
-// working tree instead of the installed binary — the two shapes local-dev mode
-// wrote over time. Retained for DETECTION ONLY: a hook naming either must be
-// treated as needing reinstallation.
-//
-// Such a hook is actively broken, not merely outdated. It carries
-// entireHookMarker, so a marker-only check reports it as installed and nothing
-// ever replaces it. `scripts/entire-dev` no longer exists, and `go run` on a
-// single file cannot build a package split across several — so both fail, and a
-// repo-relative prefix gets no availability guard to swallow it. pre-push
-// deliberately propagates exit codes, so the older of these forms was one
-// missing `|| true` away from rejecting every `git push`.
-//
-// Matching these two rather than "anything unexpected" is deliberate: neither
-// can appear in a hook this version generates (which emits only bare `entire` or
-// a quoted absolute path), and they are the same forms the agents match in their
-// entireHookPrefixes.
-var legacyGitHookLaunchers = []string{"scripts/entire-dev", "go run "}
-
 // bareEntireHookCmd is the default hook command prefix: the entire binary
 // resolved through PATH at hook runtime.
 const bareEntireHookCmd = "entire"
@@ -489,13 +477,28 @@ const bareEntireHookCmd = "entire"
 // Current, which is what makes EnsureSetup reinstall it rather than leaving a
 // broken hook in place forever.
 func gitHookStateInHooksDir(hooksDir string) GitHookState {
+	state, err := inspectGitHookStateInHooksDir(hooksDir)
+	if err != nil {
+		return GitHooksAbsent
+	}
+	return state
+}
+
+// inspectGitHookStateInHooksDir preserves the legacy classification while also
+// returning failures that prevent the integration health API from making a
+// trustworthy assessment. Missing hooks are an inspected Absent state; other
+// read failures mean inspection itself failed.
+func inspectGitHookStateInHooksDir(hooksDir string) (GitHookState, error) {
 	// ForRemoval: this is a read, and reporting GitHooksAbsent for a symlinked
 	// hooks directory is what sent EnsureSetup to InstallGitHook on every agent
 	// turn, to fail on a refusal only `entire enable` should ever hit. Seeing
 	// through the link reports what is actually installed there.
 	root, err := hooksRootForRemoval(hooksDir)
 	if err != nil {
-		return GitHooksAbsent
+		if errors.Is(err, os.ErrNotExist) {
+			return GitHooksAbsent, nil
+		}
+		return GitHooksAbsent, err
 	}
 	outdated := false
 	for _, hook := range gitHookNames {
@@ -504,44 +507,62 @@ func gitHookStateInHooksDir(hooksDir string) GitHookState {
 		// InstallGitHook, which backs the link up and chains to it.
 		data, err := osroot.ReadFileNoFollow(root, hook)
 		if err != nil {
-			return GitHooksAbsent
+			if errors.Is(err, os.ErrNotExist) {
+				return GitHooksAbsent, nil
+			}
+			return GitHooksAbsent, fmt.Errorf("read Git hook %s: %w", filepath.Join(hooksDir, hook), err)
 		}
 		content := string(data)
 		if !strings.Contains(content, entireHookMarker) {
-			return GitHooksAbsent
+			return GitHooksAbsent, nil
 		}
-		if entireHookLineRunsFromWorkingTree(content) {
+		if !currentNativeHookContent(content, hook) {
 			outdated = true
 		}
 	}
 	if outdated {
-		return GitHooksOutdated
+		return GitHooksOutdated, nil
 	}
-	return GitHooksCurrent
+	return GitHooksCurrent, nil
 }
 
-// entireHookLineRunsFromWorkingTree reports whether the hook's OWN Entire
-// invocation names a legacy launcher.
-//
-// Scoped to the invocation line, not the whole file. A user may hand-edit a hook
-// Entire installed to append their own steps, and one of those steps containing
-// `go run ` must not make the file read as ours-but-stale: InstallGitHook only
-// backs up a hook that does NOT carry entireHookMarker, so a hand-edited hook is
-// rewritten with no backup and a false positive here would silently discard their
-// additions. Every generated invocation contains `hooks git `, so keying on that
-// line separates Entire's command from anything around it.
-func entireHookLineRunsFromWorkingTree(content string) bool {
+func currentNativeHookContent(content, hook string) bool {
+	commandNeedle := " hooks git " + hook
 	for line := range strings.SplitSeq(content, "\n") {
-		if !strings.Contains(line, "hooks git ") {
+		commandAt := strings.Index(line, commandNeedle)
+		if commandAt < 0 {
 			continue
 		}
-		for _, launcher := range legacyGitHookLaunchers {
-			if strings.Contains(line, launcher) {
-				return true
+		thenAt := strings.LastIndex(line[:commandAt], "then ")
+		if thenAt < 0 {
+			continue
+		}
+		cmdPrefix := line[thenAt+len("then ") : commandAt]
+		if !validNativeHookCommandPrefix(cmdPrefix) {
+			continue
+		}
+		for _, spec := range buildHookSpecs(cmdPrefix) {
+			if spec.name != hook {
+				continue
 			}
+			return content == spec.content || content == generateChainedContent(spec.content, hook)
 		}
 	}
 	return false
+}
+
+func validNativeHookCommandPrefix(prefix string) bool {
+	if prefix == bareEntireHookCmd {
+		return true
+	}
+	if len(prefix) < 2 || prefix[0] != '\'' || prefix[len(prefix)-1] != '\'' {
+		return false
+	}
+	path := strings.ReplaceAll(prefix[1:len(prefix)-1], `'"'"'`, `'`)
+	if shellQuote(path) != prefix {
+		return false
+	}
+	return filepath.IsAbs(path) || isWindowsAbsoluteHookCommand(prefix)
 }
 
 // buildHookSpecs returns the hook specifications for all managed hooks.
@@ -568,7 +589,7 @@ func buildHookSpecs(cmdPrefix string) []hookSpec {
 	// the user opted into by enabling OPF. Users hit by unrelated
 	// bugs can `ENTIRE_OPF=no git push` for a one-off bypass while
 	// the bug is fixed.
-	prePushCmd := gitHookCommand(cmdPrefix, `pre-push "$1"`, false)
+	prePushCmd := gitHookCommand(cmdPrefix, `pre-push "$1" "$2"`, false)
 
 	return []hookSpec{
 		{
@@ -858,7 +879,7 @@ func RemoveGitHook(ctx context.Context) (int, error) {
 // generateChainedContent appends a chain call to the base hook content,
 // so the pre-existing hook (backed up to .pre-entire) is called after our hook.
 func generateChainedContent(baseContent, hookName string) string {
-	if hookName == "post-rewrite" {
+	if hookName == postRewriteHookName {
 		return generatePostRewriteChainedContent(baseContent)
 	}
 

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -627,6 +627,40 @@ func TestCheckGitHookState(t *testing.T) {
 		}
 	})
 
+	t.Run("an exact generated chain is Current", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeCurrentManagedHooks(t, dir)
+		for _, spec := range buildHookSpecs(bareEntireHookCmd) {
+			if spec.name != "pre-push" {
+				continue
+			}
+			if err := os.WriteFile(filepath.Join(dir, spec.name), []byte(generateChainedContent(spec.content, spec.name)), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if got := gitHookStateInHooksDir(dir); got != GitHooksCurrent {
+			t.Errorf("current generated chain = %v, want GitHooksCurrent", got)
+		}
+	})
+
+	t.Run("a generated-shaped arbitrary command is Outdated", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeCurrentManagedHooks(t, dir)
+		for _, spec := range buildHookSpecs("false") {
+			if spec.name != "pre-push" {
+				continue
+			}
+			if err := os.WriteFile(filepath.Join(dir, spec.name), []byte(spec.content), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if got := gitHookStateInHooksDir(dir); got != GitHooksOutdated {
+			t.Errorf("arbitrary command wrapper = %v, want GitHooksOutdated", got)
+		}
+	})
+
 	t.Run("a single legacy hook makes the set Outdated", func(t *testing.T) {
 		t.Parallel()
 		for _, legacy := range []string{
@@ -646,15 +680,10 @@ func TestCheckGitHookState(t *testing.T) {
 	})
 }
 
-// TestCheckGitHookState_UserAdditionsAreNotDrift pins that a hook Entire
-// installed and the user then hand-edited is not classified as stale just because
-// one of their own lines mentions `go run` or the old launcher path.
-//
-// The classification decides whether EnsureSetup rewrites the file, and
-// InstallGitHook only backs up a hook that does NOT carry entireHookMarker — so a
-// hand-edited hook is overwritten with no backup. A whole-file substring match
-// would therefore silently discard the user's additions.
-func TestCheckGitHookState_UserAdditionsAreNotDrift(t *testing.T) {
+// TestCheckGitHookState_UserAdditionsAreDrift pins that only exact generated
+// wrappers count as current. User additions make an Entire-marked hook stale;
+// they must not make arbitrary marker-bearing content look executable.
+func TestCheckGitHookState_UserAdditionsAreDrift(t *testing.T) {
 	t.Parallel()
 
 	for _, userLine := range []string{
@@ -670,8 +699,8 @@ func TestCheckGitHookState_UserAdditionsAreNotDrift(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if got := gitHookStateInHooksDir(dir); got != GitHooksCurrent {
-			t.Errorf("a hook whose own Entire line is current must read Current despite the user line %q, got %v", userLine, got)
+		if got := gitHookStateInHooksDir(dir); got != GitHooksOutdated {
+			t.Errorf("a modified Entire hook with user line %q = %v, want GitHooksOutdated", userLine, got)
 		}
 	}
 }
@@ -700,9 +729,8 @@ func TestCheckGitHookState_LegacyEntireLineIsStillDrift(t *testing.T) {
 // installs. Tests that need a variant overwrite an individual hook afterwards.
 func writeCurrentManagedHooks(t *testing.T, dir string) {
 	t.Helper()
-	for _, hook := range gitHookNames {
-		content := "#!/bin/sh\n# " + entireHookMarker + "\nentire hooks git " + hook + "\n"
-		if err := os.WriteFile(filepath.Join(dir, hook), []byte(content), 0o755); err != nil {
+	for _, spec := range buildHookSpecs(bareEntireHookCmd) {
+		if err := os.WriteFile(filepath.Join(dir, spec.name), []byte(spec.content), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cmd/entire/cli/strategy/lefthook_artifacts.go
+++ b/cmd/entire/cli/strategy/lefthook_artifacts.go
@@ -1,0 +1,247 @@
+package strategy
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"gopkg.in/yaml.v3"
+)
+
+func renderLefthookScript(spec hookSpec) string {
+	nativeMarker := "# " + entireHookMarker + "\n"
+	lefthookMarker := "# " + lefthookOwnedMarker + "\n"
+	content := strings.Replace(spec.content, nativeMarker, lefthookMarker, 1)
+	commandNeedle := " hooks git " + spec.name
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, commandNeedle) {
+			continue
+		}
+		elseAt := strings.LastIndex(line, "; else ")
+		if elseAt < 0 || !strings.HasSuffix(line, "; fi") {
+			continue
+		}
+		warning := "[entire] Entire CLI is unavailable; skipping " + spec.name + " hook."
+		lines[i] = line[:elseAt] + "; else printf '%s\\n' " + shellQuote(warning) + " >&2 || :; fi"
+		break
+	}
+	return strings.Join(lines, "\n")
+}
+
+func lefthookScriptOwned(content string) bool {
+	want := "# " + lefthookOwnedMarker
+	for line := range strings.SplitSeq(content, "\n") {
+		if line == want {
+			return true
+		}
+	}
+	return false
+}
+
+func inspectLefthookArtifacts(root *os.Root, cmdPrefix string) (bool, error) {
+	data, _, err := readOptionalRegular(root, lefthookLocalConfigName)
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", lefthookLocalConfigName, err)
+	}
+	if data == nil {
+		return false, nil
+	}
+	config, err := parseYAMLMapping(data, lefthookLocalConfigName)
+	if err != nil {
+		return false, err
+	}
+	if current, sourceErr := inspectOwnedLefthookSourceDir(config); sourceErr != nil || !current {
+		return current, sourceErr
+	}
+
+	for _, spec := range buildHookSpecs(cmdPrefix) {
+		entry, owned, found, entryErr := findLefthookScriptEntry(config, spec.name)
+		if entryErr != nil {
+			return false, entryErr
+		}
+		if !found {
+			return false, nil
+		}
+		if !owned {
+			return false, fmt.Errorf("%s: %w", spec.name, ErrLefthookOwnedEntryConflict)
+		}
+		if !lefthookEntryCurrent(entry, spec.name) {
+			return false, nil
+		}
+
+		scriptName := lefthookScriptPath(spec.name)
+		content, info, readErr := readOptionalRegular(root, scriptName)
+		if readErr != nil {
+			return false, fmt.Errorf("read %s: %w", scriptName, readErr)
+		}
+		if content == nil || string(content) != renderLefthookScript(spec) ||
+			!lefthookScriptOwned(string(content)) || info.Mode().Perm()&0o111 == 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func inspectOwnedLefthookSourceDir(root *yaml.Node) (bool, error) {
+	value, found, duplicate := mappingValueCount(root, "source_dir_local")
+	if duplicate {
+		return false, errors.New("duplicate source_dir_local setting")
+	}
+	if !found {
+		return false, nil
+	}
+	// A compatible unowned value may predate Entire. The owned hook nodes and
+	// scripts prove Entire's participation without claiming this user setting.
+	return value.Kind == yaml.ScalarNode && value.Value == lefthookLocalDir, nil
+}
+
+func hasOwnedLefthookConfigEntries(data []byte) (bool, error) {
+	root, err := parseYAMLMapping(data, lefthookLocalConfigName)
+	if err != nil {
+		return false, err
+	}
+	if value, found, duplicate := mappingValueCount(root, "source_dir_local"); duplicate {
+		return false, errors.New("duplicate source_dir_local setting")
+	} else if found {
+		key := mappingKey(root, "source_dir_local")
+		if key != nil && lefthookNodeOwned(key, value) {
+			return true, nil
+		}
+	}
+	for _, hook := range gitHookNames {
+		_, owned, found, findErr := findLefthookScriptEntry(root, hook)
+		if findErr != nil {
+			return false, findErr
+		}
+		if found && owned {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func findLefthookScriptEntry(root *yaml.Node, hook string) (*yaml.Node, bool, bool, error) {
+	hookNode, found, duplicate := mappingValueCount(root, hook)
+	if duplicate {
+		return nil, false, false, fmt.Errorf("duplicate %s mapping", hook)
+	}
+	if !found || hookNode.Kind != yaml.MappingNode {
+		return nil, false, false, nil
+	}
+	scripts, found, duplicate := mappingValueCount(hookNode, "scripts")
+	if duplicate {
+		return nil, false, false, fmt.Errorf("duplicate scripts mapping in %s", hook)
+	}
+	if !found || scripts.Kind != yaml.MappingNode {
+		return nil, false, false, nil
+	}
+	var key, value *yaml.Node
+	for i := 0; i+1 < len(scripts.Content); i += 2 {
+		if scripts.Content[i].Value != lefthookScriptName {
+			continue
+		}
+		if key != nil {
+			return nil, false, false, fmt.Errorf("duplicate %s in %s scripts", lefthookScriptName, hook)
+		}
+		key, value = scripts.Content[i], scripts.Content[i+1]
+	}
+	if key == nil {
+		return nil, false, false, nil
+	}
+	return value, lefthookNodeOwned(key, value), true, nil
+}
+
+func mappingValue(parent *yaml.Node, key string) (*yaml.Node, bool) {
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if parent.Content[i].Value == key {
+			return parent.Content[i+1], true
+		}
+	}
+	return nil, false
+}
+
+func mappingKey(parent *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if parent.Content[i].Value == key {
+			return parent.Content[i]
+		}
+	}
+	return nil
+}
+
+func lefthookRunnerIsBash(entry *yaml.Node) bool {
+	if entry.Kind != yaml.MappingNode {
+		return false
+	}
+	runner, ok := mappingValue(entry, "runner")
+	return ok && runner.Kind == yaml.ScalarNode && runner.Value == "bash"
+}
+
+func lefthookEntryCurrent(entry *yaml.Node, hook string) bool {
+	if !lefthookRunnerIsBash(entry) {
+		return false
+	}
+	useStdin, found, duplicate := mappingValueCount(entry, "use_stdin")
+	if duplicate {
+		return false
+	}
+	if hook == postRewriteHookName {
+		return found && useStdin.Kind == yaml.ScalarNode && useStdin.Tag == "!!bool" && useStdin.Value == "true"
+	}
+	return !found
+}
+
+func mergeLefthookInfoExclude(existing []byte) []byte {
+	content := string(existing)
+	if content != "" && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	block := lefthookExcludeBlock()
+	if strings.Contains(content, block) {
+		return []byte(content)
+	}
+	return []byte(content + block)
+}
+
+func lefthookExcludeBlock() string {
+	const begin = "# entire-cli-owned:lefthook:v1 begin\n"
+	const end = "# entire-cli-owned:lefthook:v1 end\n"
+	entries := []string{"/" + lefthookLocalConfigName}
+	for _, hook := range gitHookNames {
+		entries = append(entries, "/"+filepath.ToSlash(filepath.Join(lefthookLocalDir, hook, lefthookScriptName)))
+	}
+	var block strings.Builder
+	block.WriteString(begin)
+	for _, entry := range entries {
+		block.WriteString(entry)
+		block.WriteByte('\n')
+	}
+	block.WriteString(end)
+	return block.String()
+}
+
+func lefthookScriptPath(hook string) string {
+	return filepath.ToSlash(filepath.Join(lefthookLocalDir, hook, lefthookScriptName))
+}
+
+func readOptionalRegular(root *os.Root, name string) ([]byte, os.FileInfo, error) {
+	info, err := osroot.LstatNoSymlinks(root, name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("lstat %s: %w", name, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("%s is not a regular file", name)
+	}
+	data, err := osroot.ReadFileNoFollow(root, name)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s without following links: %w", name, err)
+	}
+	return data, info, nil
+}

--- a/cmd/entire/cli/strategy/lefthook_detection.go
+++ b/cmd/entire/cli/strategy/lefthook_detection.go
@@ -1,0 +1,235 @@
+package strategy
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
+	"gopkg.in/yaml.v3"
+)
+
+func lefthookConfigNames(local bool) []string {
+	variant := ""
+	if local {
+		variant = "-local"
+	}
+	names := make([]string, 0, 15)
+	for _, prefix := range []string{"", ".", ".config/"} {
+		for _, ext := range []string{"yml", "yaml", "json", "jsonc", "toml"} {
+			names = append(names, prefix+"lefthook"+variant+"."+ext)
+		}
+	}
+	return names
+}
+
+// detectHookManagersForIntegration retains every Lefthook variant. The general
+// warning detector intentionally deduplicates managers, but integration safety
+// depends on distinguishing one main config from two competing main configs.
+func detectHookManagersForIntegration(repoRoot string) ([]hookManager, error) {
+	root, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open worktree: %w", err)
+	}
+	checks := []hookManager{
+		{Name: "Husky", ConfigPath: ".husky/", OverwritesHooks: true, IntegrationKind: hookManagerIntegrationHookDirectory},
+		{Name: "pre-commit", ConfigPath: ".pre-commit-config.yaml"},
+		{Name: "Overcommit", ConfigPath: ".overcommit.yml"},
+		{Name: "hk", ConfigPath: "hk.pkl"},
+		{Name: "hk", ConfigPath: "hk.local.pkl"},
+		{Name: "hk", ConfigPath: ".config/hk.pkl"},
+		{Name: "hk", ConfigPath: ".config/hk.local.pkl"},
+	}
+	managers := make([]hookManager, 0, len(checks)+2)
+	seen := make(map[string]bool)
+	for _, manager := range checks {
+		name := strings.TrimSuffix(manager.ConfigPath, "/")
+		info, statErr := osroot.LstatNoSymlinks(root, name)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				continue
+			}
+			return nil, &hookManagerDetectionError{manager: manager, err: fmt.Errorf("inspect hook manager candidate %s: %w", manager.ConfigPath, statErr)}
+		}
+		wantDir := manager.IntegrationKind == hookManagerIntegrationHookDirectory
+		if wantDir != info.IsDir() || (!wantDir && !info.Mode().IsRegular()) {
+			return nil, &hookManagerDetectionError{manager: manager, err: fmt.Errorf("hook manager candidate %s has an unsupported file type", manager.ConfigPath)}
+		}
+		if !seen[manager.Name] {
+			seen[manager.Name] = true
+			managers = append(managers, manager)
+		}
+	}
+	for _, name := range append(append([]string{}, lefthookMainConfigNames...), lefthookLocalConfigNames...) {
+		info, statErr := osroot.LstatNoSymlinks(root, name)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				continue
+			}
+			return nil, &hookManagerDetectionError{manager: hookManager{Name: lefthookManagerName, ConfigPath: name, OverwritesHooks: true, IntegrationKind: hookManagerIntegrationLefthook}, err: fmt.Errorf("inspect Lefthook config candidate %s: %w", name, statErr)}
+		}
+		if !info.Mode().IsRegular() {
+			return nil, &hookManagerDetectionError{manager: hookManager{Name: lefthookManagerName, ConfigPath: name, OverwritesHooks: true, IntegrationKind: hookManagerIntegrationLefthook}, err: fmt.Errorf("lefthook config candidate %s is not a regular file", name)}
+		}
+		managers = append(managers, hookManager{
+			Name:            lefthookManagerName,
+			ConfigPath:      name,
+			OverwritesHooks: true,
+			IntegrationKind: hookManagerIntegrationLefthook,
+		})
+	}
+	return managers, nil
+}
+
+func validateLefthookMainConfig(root *os.Root, manager hookManager) error {
+	name := manager.ConfigPath
+	if strings.HasPrefix(name, ".") && name != ".lefthook.yml" && name != ".lefthook.yaml" {
+		return fmt.Errorf("safe Entire Lefthook integration inspection does not support config location %s", name)
+	}
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == ".toml" || ext == ".jsonc" {
+		return fmt.Errorf("lefthook config format %s is unsupported for safe source-directory inspection", ext)
+	}
+	data, err := osroot.ReadFileNoFollow(root, name)
+	if err != nil {
+		return fmt.Errorf("read Lefthook main config %s: %w", name, err)
+	}
+	document, err := parseYAMLMapping(data, name)
+	if err != nil {
+		return err
+	}
+	if _, found, duplicate := mappingValueCount(document, "extends"); found || duplicate {
+		return errors.New("lefthook extends are unsupported for safe source-directory inspection")
+	}
+	if _, found, duplicate := mappingValueCount(document, "remotes"); found || duplicate {
+		return errors.New("lefthook remotes are unsupported for safe source-directory inspection")
+	}
+	sourceDir, err := lefthookScalarSetting(document, "source_dir", ".lefthook")
+	if err != nil {
+		return err
+	}
+	sourceDirLocal, err := lefthookScalarSetting(document, "source_dir_local", lefthookLocalDir)
+	if err != nil {
+		return err
+	}
+	if sourceDirLocal != lefthookLocalDir {
+		return fmt.Errorf("main config source_dir_local %q conflicts with Entire's %q", sourceDirLocal, lefthookLocalDir)
+	}
+	sourceDir, err = cleanLefthookSourceDir(sourceDir)
+	if err != nil {
+		return err
+	}
+	if sourceDir == lefthookLocalDir {
+		return errors.New("lefthook source_dir collides with Entire's source_dir_local")
+	}
+	for _, hook := range gitHookNames {
+		name := filepath.ToSlash(filepath.Join(sourceDir, hook, lefthookScriptName))
+		_, statErr := osroot.LstatNoSymlinks(root, name)
+		if statErr == nil {
+			return fmt.Errorf("lefthook source_dir already contains managed script name %s", name)
+		}
+		if !os.IsNotExist(statErr) {
+			return fmt.Errorf("inspect Lefthook source script %s: %w", name, statErr)
+		}
+	}
+	return nil
+}
+
+func parseYAMLMapping(data []byte, name string) (*yaml.Node, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}, nil
+	}
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", name, err)
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse %s: top level must be a mapping", name)
+	}
+	return document.Content[0], nil
+}
+
+func mappingValueCount(parent *yaml.Node, key string) (value *yaml.Node, found, duplicate bool) {
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if parent.Content[i].Value != key {
+			continue
+		}
+		if found {
+			return nil, true, true
+		}
+		value, found = parent.Content[i+1], true
+	}
+	return value, found, false
+}
+
+func lefthookScalarSetting(root *yaml.Node, key, fallback string) (string, error) {
+	value, found, duplicate := mappingValueCount(root, key)
+	if duplicate {
+		return "", fmt.Errorf("duplicate Lefthook %s setting", key)
+	}
+	if !found {
+		return fallback, nil
+	}
+	if value.Kind != yaml.ScalarNode || value.Tag != "!!str" {
+		return "", fmt.Errorf("lefthook %s must be a string", key)
+	}
+	return value.Value, nil
+}
+
+func cleanLefthookSourceDir(value string) (string, error) {
+	if value == "" || filepath.IsAbs(value) || filepath.VolumeName(value) != "" {
+		return "", fmt.Errorf("lefthook source_dir %q must be a repository-relative directory", value)
+	}
+	cleaned := filepath.ToSlash(filepath.Clean(filepath.FromSlash(value)))
+	if cleaned == "." || strings.HasPrefix(cleaned, "../") || cleaned == ".." {
+		return "", fmt.Errorf("lefthook source_dir %q must stay beneath the repository", value)
+	}
+	return strings.TrimSuffix(cleaned, "/"), nil
+}
+
+func selectLefthookIntegrationManager(managers []hookManager) (hookManager, bool, error) {
+	var mains, locals []hookManager
+	for _, manager := range managers {
+		if manager.IntegrationKind == hookManagerIntegrationLefthook {
+			if containsString(lefthookMainConfigNames, manager.ConfigPath) {
+				mains = append(mains, manager)
+			} else if containsString(lefthookLocalConfigNames, manager.ConfigPath) {
+				locals = append(locals, manager)
+			}
+		}
+	}
+
+	if len(mains) == 0 {
+		if len(locals) > 0 {
+			return hookManager{}, false, fmt.Errorf("%w: Lefthook has a local config but no main config", ErrLefthookAmbiguous)
+		}
+		return hookManager{}, false, nil
+	}
+	if len(mains) != 1 {
+		return hookManager{}, false, fmt.Errorf("%w: found %d main configs", ErrLefthookAmbiguous, len(mains))
+	}
+	for _, local := range locals {
+		if local.ConfigPath != lefthookLocalConfigName {
+			return hookManager{}, false, fmt.Errorf("%w: alternate local config %s", ErrLefthookAmbiguous, local.ConfigPath)
+		}
+	}
+	for _, manager := range managers {
+		if manager.IntegrationKind != hookManagerIntegrationLefthook && manager.OverwritesHooks {
+			return hookManager{}, false, fmt.Errorf("%w: %s also owns Git hooks", ErrLefthookAmbiguous, manager.Name)
+		}
+	}
+	return mains[0], true, nil
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/strategy/lefthook_detection.go
+++ b/cmd/entire/cli/strategy/lefthook_detection.go
@@ -88,11 +88,11 @@ func detectHookManagersForIntegration(repoRoot string) ([]hookManager, error) {
 func validateLefthookMainConfig(root *os.Root, manager hookManager) error {
 	name := manager.ConfigPath
 	if strings.HasPrefix(name, ".") && name != ".lefthook.yml" && name != ".lefthook.yaml" {
-		return fmt.Errorf("safe Entire Lefthook integration inspection does not support config location %s", name)
+		return fmt.Errorf("%w: safe Entire Lefthook integration inspection does not support config location %s", errLefthookUnsupportedLayout, name)
 	}
 	ext := strings.ToLower(filepath.Ext(name))
 	if ext == ".toml" || ext == ".jsonc" {
-		return fmt.Errorf("lefthook config format %s is unsupported for safe source-directory inspection", ext)
+		return fmt.Errorf("%w: lefthook config format %s is unsupported for safe source-directory inspection", errLefthookUnsupportedLayout, ext)
 	}
 	data, err := osroot.ReadFileNoFollow(root, name)
 	if err != nil {

--- a/cmd/entire/cli/strategy/lefthook_integration.go
+++ b/cmd/entire/cli/strategy/lefthook_integration.go
@@ -1,0 +1,27 @@
+package strategy
+
+import "errors"
+
+const (
+	lefthookLocalConfigName = "lefthook-local.yml"
+	lefthookLocalDir        = ".lefthook-local"
+	lefthookScriptName      = "entire.sh"
+	lefthookOwnedMarker     = "entire-cli-owned:lefthook:v1"
+)
+
+var (
+	ErrLefthookAmbiguous          = errors.New("ambiguous Lefthook configuration")
+	ErrLefthookOwnedEntryConflict = errors.New("lefthook entire.sh entry is not owned by Entire")
+	errLefthookFileUnchanged      = errors.New("lefthook artifact is unchanged")
+)
+
+var lefthookMainConfigNames = lefthookConfigNames(false)
+var lefthookLocalConfigNames = lefthookConfigNames(true)
+
+type hookManagerDetectionError struct {
+	manager hookManager
+	err     error
+}
+
+func (e *hookManagerDetectionError) Error() string { return e.err.Error() }
+func (e *hookManagerDetectionError) Unwrap() error { return e.err }

--- a/cmd/entire/cli/strategy/lefthook_integration.go
+++ b/cmd/entire/cli/strategy/lefthook_integration.go
@@ -12,6 +12,7 @@ const (
 var (
 	ErrLefthookAmbiguous          = errors.New("ambiguous Lefthook configuration")
 	ErrLefthookOwnedEntryConflict = errors.New("lefthook entire.sh entry is not owned by Entire")
+	errLefthookUnsupportedLayout  = errors.New("unsupported Lefthook integration layout")
 	errLefthookFileUnchanged      = errors.New("lefthook artifact is unchanged")
 )
 

--- a/cmd/entire/cli/strategy/lefthook_integration_security_test.go
+++ b/cmd/entire/cli/strategy/lefthook_integration_security_test.go
@@ -1,0 +1,416 @@
+package strategy
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMergeLefthookLocalConfigOwnsSourceDirAndPostRewriteStdin(t *testing.T) {
+	t.Parallel()
+	merged, err := mergeLefthookLocalConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document yaml.Node
+	if err := yaml.Unmarshal(merged, &document); err != nil {
+		t.Fatal(err)
+	}
+	root := document.Content[0]
+	sourceKey, sourceValue := testYAMLPair(t, root, "source_dir_local")
+	if sourceValue.Value != lefthookLocalDir || !lefthookNodeOwned(sourceKey, sourceValue) {
+		t.Errorf("source_dir_local = value %q owned %v, want %q with marker\n%s", sourceValue.Value, lefthookNodeOwned(sourceKey, sourceValue), lefthookLocalDir, merged)
+	}
+	postRewrite := testLefthookEntry(t, root, "post-rewrite")
+	_, useStdin := testYAMLPair(t, postRewrite, "use_stdin")
+	if useStdin.Value != "true" {
+		t.Errorf("post-rewrite use_stdin = %q, want true", useStdin.Value)
+	}
+	prePush := testLefthookEntry(t, root, "pre-push")
+	if _, ok := mappingValue(prePush, "use_stdin"); ok {
+		t.Error("pre-push must not claim stdin because Entire's handler does not read it")
+	}
+}
+
+func TestMergeLefthookLocalConfigRejectsConflictingSourceDirLocal(t *testing.T) {
+	t.Parallel()
+	input := []byte("source_dir_local: user-hooks\n# keep me\n")
+	before := bytes.Clone(input)
+	_, err := mergeLefthookLocalConfig(input)
+	if !errors.Is(err, ErrLefthookOwnedEntryConflict) {
+		t.Fatalf("error = %v, want ErrLefthookOwnedEntryConflict", err)
+	}
+	if !bytes.Equal(input, before) {
+		t.Errorf("input mutated\nbefore=%q\nafter=%q", before, input)
+	}
+}
+
+func TestSetOwnedLefthookSourceDirPreservesCompatibleUnownedSettingAndComments(t *testing.T) {
+	t.Parallel()
+	key := &yaml.Node{Kind: yaml.ScalarNode, Value: "source_dir_local", HeadComment: "user head", LineComment: "user line", FootComment: "user foot"}
+	value := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: lefthookLocalDir, HeadComment: "value head", LineComment: "value line", FootComment: "value foot"}
+	root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{key, value}}
+	if err := setOwnedLefthookSourceDir(root); err != nil {
+		t.Fatalf("setOwnedLefthookSourceDir() error = %v", err)
+	}
+	if lefthookNodeOwned(key, value) {
+		t.Fatal("compatible user source_dir_local was claimed by Entire")
+	}
+	if key.HeadComment != "user head" || key.LineComment != "user line" || key.FootComment != "user foot" ||
+		value.HeadComment != "value head" || value.LineComment != "value line" || value.FootComment != "value foot" {
+		t.Errorf("user comments changed: key=%+v value=%+v", key, value)
+	}
+}
+
+func TestMergeLefthookLocalConfigRejectsDuplicateManagedMappings(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "managed hook", input: "pre-push: {}\npre-push: {}\n"},
+		{name: "scripts", input: "pre-push:\n  scripts: {}\n  scripts: {}\n"},
+		{name: "source dir local", input: "source_dir_local: .lefthook-local\nsource_dir_local: .lefthook-local\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := mergeLefthookLocalConfig([]byte(tt.input)); err == nil {
+				t.Fatal("expected duplicate mapping error")
+			}
+		})
+	}
+}
+
+func TestInstallLefthookFilesRejectsSymlinkEscapes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink assertions require Unix test privileges")
+	}
+
+	t.Run("local config leaf", func(t *testing.T) {
+		repoDir := newLefthookTestRepo(t)
+		external := filepath.Join(t.TempDir(), "external.yml")
+		original := []byte("external: unchanged\n")
+		if err := os.WriteFile(external, original, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(external, filepath.Join(repoDir, lefthookLocalConfigName)); err != nil {
+			t.Fatal(err)
+		}
+		_, err := installLefthookFiles(t.Context(), false)
+		if err == nil {
+			t.Fatal("expected symlink rejection")
+		}
+		assertFileBytes(t, external, original)
+	})
+
+	t.Run("script parent", func(t *testing.T) {
+		repoDir := newLefthookTestRepo(t)
+		externalDir := t.TempDir()
+		sentinel := filepath.Join(externalDir, "sentinel")
+		original := []byte("external unchanged\n")
+		if err := os.WriteFile(sentinel, original, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(filepath.Join(repoDir, lefthookLocalDir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(externalDir, filepath.Join(repoDir, lefthookLocalDir, "prepare-commit-msg")); err != nil {
+			t.Fatal(err)
+		}
+		_, err := installLefthookFiles(t.Context(), false)
+		if err == nil {
+			t.Fatal("expected symlinked parent rejection")
+		}
+		assertFileBytes(t, sentinel, original)
+		if _, statErr := os.Lstat(filepath.Join(externalDir, lefthookScriptName)); !os.IsNotExist(statErr) {
+			t.Errorf("external script was created through symlink: %v", statErr)
+		}
+		if _, statErr := os.Lstat(filepath.Join(repoDir, lefthookLocalConfigName)); !os.IsNotExist(statErr) {
+			t.Errorf("activating config exists after failure: %v", statErr)
+		}
+		merged, mergeErr := mergeLefthookLocalConfig(nil)
+		if mergeErr != nil {
+			t.Fatal(mergeErr)
+		}
+		if writeErr := os.WriteFile(filepath.Join(repoDir, lefthookLocalConfigName), merged, 0o644); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+		if health := CheckGitHookIntegration(t.Context()); health.State != GitHookIntegrationError {
+			t.Errorf("health = %+v, want error for symlinked script parent", health)
+		}
+	})
+
+	t.Run("git info parent", func(t *testing.T) {
+		repoDir := newLefthookTestRepo(t)
+		infoDir := filepath.Join(repoDir, ".git", "info")
+		if err := os.RemoveAll(infoDir); err != nil {
+			t.Fatal(err)
+		}
+		externalDir := t.TempDir()
+		externalExclude := filepath.Join(externalDir, "exclude")
+		original := []byte("external-only\n")
+		if err := os.WriteFile(externalExclude, original, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(externalDir, infoDir); err != nil {
+			t.Fatal(err)
+		}
+		_, err := installLefthookFiles(t.Context(), false)
+		if err == nil {
+			t.Fatal("expected symlinked git info rejection")
+		}
+		assertFileBytes(t, externalExclude, original)
+		if _, statErr := os.Lstat(filepath.Join(repoDir, lefthookLocalConfigName)); !os.IsNotExist(statErr) {
+			t.Errorf("activating config exists after failure: %v", statErr)
+		}
+	})
+}
+
+func TestInstallLefthookFilesRollsBackPublishedArtifacts(t *testing.T) {
+	repoDir := newLefthookTestRepo(t)
+	if _, err := installLefthookFiles(t.Context(), false); err != nil {
+		t.Fatal(err)
+	}
+	pathsToSnapshot := []string{lefthookLocalConfigName, filepath.Join(".git", "info", "exclude")}
+	for _, hook := range gitHookNames {
+		path := filepath.Join(lefthookLocalDir, hook, lefthookScriptName)
+		pathsToSnapshot = append(pathsToSnapshot, path)
+		fullPath := filepath.Join(repoDir, path)
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, append(data, []byte("# stale\n")...), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	configPath := filepath.Join(repoDir, lefthookLocalConfigName)
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config = bytes.Replace(config, []byte("runner: bash"), []byte("runner: stale"), 1)
+	if err := os.WriteFile(configPath, config, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	before := snapshotTestFiles(t, repoDir, pathsToSnapshot)
+	publishes := 0
+	failPublish := func(string) error {
+		publishes++
+		if publishes == 3 {
+			return errors.New("injected publish failure")
+		}
+		return nil
+	}
+	if _, err := installLefthookFilesAt(t.Context(), repoDir, false, failPublish); err == nil {
+		t.Fatal("expected injected publish failure")
+	}
+	after := snapshotTestFiles(t, repoDir, pathsToSnapshot)
+	for path, want := range before {
+		got := after[path]
+		if !bytes.Equal(got.data, want.data) || got.mode != want.mode {
+			t.Errorf("%s changed after rollback: got mode %v bytes %q, want mode %v bytes %q", path, got.mode, got.data, want.mode, want.data)
+		}
+	}
+	if matches, err := filepath.Glob(filepath.Join(repoDir, ".lefthook-local", "**", "*.tmp")); err != nil || len(matches) != 0 {
+		t.Errorf("staged temp artifacts remain: %v, err=%v", matches, err)
+	}
+}
+
+func TestValidateLefthookMainConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		configName string
+		config     string
+		asDir      bool
+		setup      func(t *testing.T, repoDir string)
+	}{
+		{name: "malformed", configName: "lefthook.yml", config: "pre-push: [\n"},
+		{name: "directory", configName: "lefthook.yml", asDir: true},
+		{name: "custom local source", configName: "lefthook.yml", config: "source_dir_local: custom-local\n"},
+		{name: "source dirs collide", configName: "lefthook.yml", config: "source_dir: .lefthook-local\n"},
+		{name: "unsupported toml", configName: "lefthook.toml", config: "source_dir = '.lefthook'\n"},
+		{
+			name:       "managed script collides in source dir",
+			configName: "lefthook.yml",
+			config:     "source_dir: custom-hooks\n",
+			setup: func(t *testing.T, repoDir string) {
+				t.Helper()
+				dir := filepath.Join(repoDir, "custom-hooks", "pre-push")
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, lefthookScriptName), []byte("user\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			testutil.InitRepo(t, repoDir)
+			path := filepath.Join(repoDir, tt.configName)
+			if tt.asDir {
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(path, []byte(tt.config), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if tt.setup != nil {
+				tt.setup(t, repoDir)
+			}
+			t.Chdir(repoDir)
+			paths.ClearWorktreeRootCache()
+			t.Cleanup(paths.ClearWorktreeRootCache)
+			if _, err := installLefthookFiles(t.Context(), false); err == nil {
+				t.Fatal("expected main config validation error")
+			}
+			health := CheckGitHookIntegration(t.Context())
+			if health.State == GitHookIntegrationCurrent {
+				t.Errorf("health = %+v, must not be current", health)
+			}
+			if tt.asDir && (health.Mode != GitHookIntegrationLefthook || health.State != GitHookIntegrationError || health.ReasonCode != "hook_manager_detection_error") {
+				t.Errorf("directory candidate health = %+v, want Lefthook manager-detection error", health)
+			}
+		})
+	}
+}
+
+func TestDetectHookManagersForIntegrationPropagatesIOErrors(t *testing.T) {
+	t.Parallel()
+	repoDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoDir, ".config"), []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := detectHookManagersForIntegration(repoDir); err == nil {
+		t.Fatal("expected non-not-exist detection error")
+	}
+}
+
+func testYAMLPair(t *testing.T, mapping *yaml.Node, key string) (*yaml.Node, *yaml.Node) {
+	t.Helper()
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i], mapping.Content[i+1]
+		}
+	}
+	t.Fatalf("missing YAML key %q", key)
+	return nil, nil
+}
+
+func testLefthookEntry(t *testing.T, root *yaml.Node, hook string) *yaml.Node {
+	t.Helper()
+	_, hookNode := testYAMLPair(t, root, hook)
+	_, scripts := testYAMLPair(t, hookNode, "scripts")
+	_, entry := testYAMLPair(t, scripts, lefthookScriptName)
+	return entry
+}
+
+func newLefthookTestRepo(t *testing.T) string {
+	t.Helper()
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	return repoDir
+}
+
+func assertFileBytes(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("%s = %q, want %q", path, got, want)
+	}
+}
+
+type testFileSnapshot struct {
+	data []byte
+	mode os.FileMode
+}
+
+func snapshotTestFiles(t *testing.T, root string, names []string) map[string]testFileSnapshot {
+	t.Helper()
+	result := make(map[string]testFileSnapshot, len(names))
+	for _, name := range names {
+		path := filepath.Join(root, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result[name] = testFileSnapshot{data: data, mode: info.Mode().Perm()}
+	}
+	return result
+}
+
+func TestLefthookOptionalBinarySmoke(t *testing.T) {
+	binary := os.Getenv("LEFTHOOK_TEST_BINARY")
+	if binary == "" {
+		t.Skip("set LEFTHOOK_TEST_BINARY to run the real Lefthook stdin smoke test")
+	}
+	if !filepath.IsAbs(binary) || strings.TrimSpace(binary) != binary {
+		t.Fatalf("LEFTHOOK_TEST_BINARY must be a clean absolute path, got %q", binary)
+	}
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatal(err)
+	}
+	repoDir := newLefthookTestRepo(t)
+	if _, err := installLefthookFiles(t.Context(), false); err != nil {
+		t.Fatal(err)
+	}
+	fakeBin := t.TempDir()
+	output := filepath.Join(t.TempDir(), "stdin")
+	fakeEntire := filepath.Join(fakeBin, "entire")
+	fake := "#!/bin/sh\nif [ \"$1\" = hooks ] && [ \"$2\" = git ] && [ \"$3\" = post-rewrite ]; then cat > \"$LEFTHOOK_SMOKE_OUTPUT\"; fi\n"
+	if err := os.WriteFile(fakeEntire, []byte(fake), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	install := exec.CommandContext(t.Context(), binary, "install", "post-rewrite")
+	install.Dir = repoDir
+	install.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if out, err := install.CombinedOutput(); err != nil {
+		t.Fatalf("lefthook install: %v\n%s", err, out)
+	}
+	hookPath := filepath.Join(repoDir, ".git", "hooks", "post-rewrite")
+	generated, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !looksLikeLefthookHook(generated, "post-rewrite") {
+		t.Fatal("pinned Lefthook v2 launcher was not recognized as an active hook")
+	}
+	hook := exec.CommandContext(t.Context(), hookPath, "rebase")
+	hook.Dir = repoDir
+	hook.Stdin = strings.NewReader("old new\n")
+	hook.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"LEFTHOOK_SMOKE_OUTPUT="+output,
+	)
+	if out, err := hook.CombinedOutput(); err != nil {
+		t.Fatalf("generated post-rewrite hook: %v\n%s", err, out)
+	}
+	assertFileBytes(t, output, []byte("old new\n"))
+}

--- a/cmd/entire/cli/strategy/lefthook_integration_test.go
+++ b/cmd/entire/cli/strategy/lefthook_integration_test.go
@@ -1,0 +1,406 @@
+package strategy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMergeLefthookLocalConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates config and all marked script entries", func(t *testing.T) {
+		t.Parallel()
+		got, err := mergeLefthookLocalConfig(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, hook := range gitHookNames {
+			want := hook + ":"
+			if !bytes.Contains(got, []byte(want)) {
+				t.Errorf("config missing %q", want)
+			}
+		}
+		if gotCount := bytes.Count(got, []byte(lefthookOwnedMarker)); gotCount != len(gitHookNames)+1 {
+			t.Errorf("marker count = %d, want %d\n%s", gotCount, len(gitHookNames)+1, got)
+		}
+		var document yaml.Node
+		if err := yaml.Unmarshal(got, &document); err != nil {
+			t.Fatalf("generated YAML is invalid: %v", err)
+		}
+	})
+
+	t.Run("preserves unrelated nodes comments and order", func(t *testing.T) {
+		t.Parallel()
+		input := []byte("# top comment\npre_commit:\n  commands:\n    lint:\n      run: mise run lint # inline\nprepare-commit-msg:\n  scripts:\n    user.sh:\n      runner: bash\npost_merge:\n  commands: {}\n")
+		got, err := mergeLefthookLocalConfig(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(got)
+		for _, preserved := range []string{"# top comment", "lint:", "mise run lint", "# inline", "user.sh:", "post_merge:"} {
+			if !strings.Contains(text, preserved) {
+				t.Errorf("merged config lost %q\n%s", preserved, text)
+			}
+		}
+		if strings.Index(text, "pre_commit:") > strings.Index(text, "prepare-commit-msg:") || strings.Index(text, "prepare-commit-msg:") > strings.Index(text, "post_merge:") {
+			t.Errorf("existing top-level ordering changed\n%s", text)
+		}
+	})
+
+	t.Run("replaces only marked entry", func(t *testing.T) {
+		t.Parallel()
+		input := []byte("pre-push:\n  scripts:\n    user.sh:\n      runner: zsh\n    entire.sh: # " + lefthookOwnedMarker + "\n      runner: stale\n")
+		got, err := mergeLefthookLocalConfig(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(got)
+		if !strings.Contains(text, "user.sh:") || !strings.Contains(text, "runner: zsh") {
+			t.Fatalf("user entry was not preserved\n%s", text)
+		}
+		if strings.Contains(text, "runner: stale") || !strings.Contains(text, "runner: bash") {
+			t.Fatalf("owned entry was not replaced\n%s", text)
+		}
+		gotAgain, err := mergeLefthookLocalConfig(got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, gotAgain) {
+			t.Errorf("merge is not idempotent\nfirst:\n%s\nsecond:\n%s", got, gotAgain)
+		}
+	})
+
+	t.Run("rejects user owned entire script", func(t *testing.T) {
+		t.Parallel()
+		_, err := mergeLefthookLocalConfig([]byte("pre-push:\n  scripts:\n    entire.sh:\n      runner: custom\n"))
+		if !errors.Is(err, ErrLefthookOwnedEntryConflict) {
+			t.Fatalf("error = %v, want ErrLefthookOwnedEntryConflict", err)
+		}
+	})
+
+	t.Run("broad native marker text does not grant ownership", func(t *testing.T) {
+		t.Parallel()
+		input := []byte("pre-push:\n  scripts:\n    entire.sh: # user note about Entire CLI hooks\n      runner: custom\n")
+		before := bytes.Clone(input)
+		_, err := mergeLefthookLocalConfig(input)
+		if !errors.Is(err, ErrLefthookOwnedEntryConflict) {
+			t.Fatalf("error = %v, want ErrLefthookOwnedEntryConflict", err)
+		}
+		if !bytes.Equal(input, before) {
+			t.Errorf("conflicting user config was mutated\nbefore:\n%s\nafter:\n%s", before, input)
+		}
+	})
+
+	t.Run("rejects duplicate entire script keys", func(t *testing.T) {
+		t.Parallel()
+		input := []byte("pre-push:\n  scripts:\n    entire.sh: # " + lefthookOwnedMarker + "\n      runner: bash\n    entire.sh:\n      runner: custom\n")
+		_, err := mergeLefthookLocalConfig(input)
+		if !errors.Is(err, ErrLefthookOwnedEntryConflict) {
+			t.Fatalf("error = %v, want ErrLefthookOwnedEntryConflict", err)
+		}
+	})
+
+	t.Run("rejects malformed YAML", func(t *testing.T) {
+		t.Parallel()
+		if _, err := mergeLefthookLocalConfig([]byte("pre-push: [\n")); err == nil {
+			t.Fatal("expected malformed YAML error")
+		}
+	})
+}
+
+func TestRenderLefthookScript(t *testing.T) {
+	t.Parallel()
+	for _, spec := range buildHookSpecs("entire") {
+		t.Run(spec.name, func(t *testing.T) {
+			t.Parallel()
+			got := renderLefthookScript(spec)
+			if !strings.Contains(got, "# "+lefthookOwnedMarker+"\n") {
+				t.Errorf("renderLefthookScript() missing exact ownership marker\n%s", got)
+			}
+			if !strings.Contains(got, wantLefthookMissingEntireWarning(spec.name)) {
+				t.Errorf("renderLefthookScript() missing warning for %s\n%s", spec.name, got)
+			}
+		})
+	}
+}
+
+func TestInstallLefthookFiles(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	clearGlobalHooksPath(t, repoDir)
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git", "info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, ".git", "info", "exclude"), []byte("# user patterns\n*.scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), []byte("pre_commit:\n  commands:\n    lint:\n      run: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	session.ClearGitCommonDirCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Cleanup(session.ClearGitCommonDirCache)
+	excludePath := filepath.Join(repoDir, ".git", "info", "exclude")
+	excludeBefore, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := installLefthookFiles(context.Background(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != 6 {
+		t.Errorf("written = %d, want 6 (config plus five scripts)", written)
+	}
+	for _, hook := range gitHookNames {
+		path := filepath.Join(repoDir, ".lefthook-local", hook, lefthookScriptName)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("stat %s: %v", path, err)
+			continue
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("%s mode = %v, want executable", path, info.Mode())
+		}
+	}
+	exclude, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasPrefix(exclude, excludeBefore) {
+		t.Errorf("existing user exclude patterns changed\nbefore:\n%s\nafter:\n%s", excludeBefore, exclude)
+	}
+	if count := strings.Count(string(exclude), "/"+lefthookLocalConfigName); count != 1 {
+		t.Errorf("exclude count for config = %d, want 1\n%s", count, exclude)
+	}
+	for _, hook := range gitHookNames {
+		want := "/.lefthook-local/" + hook + "/" + lefthookScriptName
+		if count := strings.Count(string(exclude), want); count != 1 {
+			t.Errorf("exclude count for %q = %d, want 1\n%s", want, count, exclude)
+		}
+	}
+
+	written, err = installLefthookFiles(context.Background(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != 0 {
+		t.Errorf("second written = %d, want 0", written)
+	}
+	configPath := filepath.Join(repoDir, lefthookLocalConfigName)
+	configBefore, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configInfoBefore, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publishes := 0
+	written, err = installLefthookFilesAt(t.Context(), repoDir, false, func(string) error {
+		publishes++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != 0 || publishes != 0 {
+		t.Errorf("no-op reinstall = written %d, publish callbacks %d; want both zero", written, publishes)
+	}
+	configAfter, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configInfoAfter, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(configAfter, configBefore) || configInfoAfter.Mode() != configInfoBefore.Mode() ||
+		!configInfoAfter.ModTime().Equal(configInfoBefore.ModTime()) || !os.SameFile(configInfoBefore, configInfoAfter) {
+		t.Errorf("no-op reinstall replaced or changed config: same bytes=%v mode before/after=%v/%v mtime before/after=%v/%v same file=%v",
+			bytes.Equal(configAfter, configBefore), configInfoBefore.Mode(), configInfoAfter.Mode(), configInfoBefore.ModTime(), configInfoAfter.ModTime(), os.SameFile(configInfoBefore, configInfoAfter))
+	}
+}
+
+func TestInstallLefthookFilesRejectsAlternateLocalConfig(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, ".lefthook-local.yaml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	_, err := installLefthookFiles(context.Background(), false)
+	if !errors.Is(err, ErrLefthookAmbiguous) {
+		t.Fatalf("error = %v, want ErrLefthookAmbiguous", err)
+	}
+}
+
+func TestInstallLefthookFilesRejectsBroadMarkerScriptConflict(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "lefthook.yml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scriptDir := filepath.Join(repoDir, lefthookLocalDir, "pre-push")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(scriptDir, lefthookScriptName)
+	userScript := []byte("#!/bin/sh\n# user documentation mentions Entire CLI hooks\necho user\n")
+	if err := os.WriteFile(scriptPath, userScript, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	_, err := installLefthookFiles(t.Context(), false)
+	if !errors.Is(err, ErrLefthookOwnedEntryConflict) {
+		t.Fatalf("error = %v, want ErrLefthookOwnedEntryConflict", err)
+	}
+	after, readErr := os.ReadFile(scriptPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(after, userScript) {
+		t.Errorf("conflicting user script was overwritten\nbefore:\n%s\nafter:\n%s", userScript, after)
+	}
+}
+
+func TestLefthookScriptRuntimeSemantics(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	record := filepath.Join(dir, "record")
+	fake := "#!/bin/sh\nprintf '<%s>\\n' \"$@\" >> \"$ENTIRE_TEST_RECORD\"\n/bin/cat >> \"$ENTIRE_TEST_RECORD\"\nexit \"${ENTIRE_TEST_EXIT:-0}\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "entire"), []byte(fake), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode := ""
+	run := func(t *testing.T, hook string, stdin string, args ...string) (string, error) {
+		t.Helper()
+		spec := findHookSpec(t, buildHookSpecs("entire"), hook)
+		path := filepath.Join(dir, hook+".sh")
+		if err := os.WriteFile(path, []byte(renderLefthookScript(spec)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.CommandContext(t.Context(), path, args...)
+		cmd.Env = append(os.Environ(), "PATH="+binDir, "ENTIRE_TEST_RECORD="+record, "ENTIRE_TEST_EXIT="+exitCode)
+		cmd.Stdin = strings.NewReader(stdin)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		return stderr.String(), err
+	}
+
+	if _, err := run(t, "prepare-commit-msg", "", "message file", "commit"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run(t, "post-rewrite", "old new\n", "rebase"); err != nil {
+		t.Fatal(err)
+	}
+	recorded, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(recorded)
+	if !strings.Contains(text, "<hooks>\n<git>\n<prepare-commit-msg>\n<message file>\n<commit>") ||
+		!strings.Contains(text, "<hooks>\n<git>\n<post-rewrite>\n<rebase>\nold new") {
+		t.Errorf("argv/stdin not forwarded\n%s", text)
+	}
+	exitCode = "17"
+	if _, err := run(t, "post-commit", ""); err != nil {
+		t.Errorf("capture hook did not fail open: %v", err)
+	}
+	if _, err := run(t, "pre-push", "", "origin"); err == nil {
+		t.Error("pre-push swallowed Entire failure")
+	}
+	exitCode = ""
+
+	if err := os.Remove(filepath.Join(binDir, "entire")); err != nil {
+		t.Fatal(err)
+	}
+	for _, hook := range gitHookNames {
+		stderr, err := run(t, hook, "", "argument")
+		if err != nil {
+			t.Errorf("%s missing binary did not fail open: %v", hook, err)
+		}
+		if !strings.Contains(stderr, wantLefthookMissingEntireWarning(hook)) {
+			t.Errorf("%s missing binary warning: stderr=%q", hook, stderr)
+		}
+	}
+}
+
+func wantLefthookMissingEntireWarning(hook string) string {
+	return "[entire] Entire CLI is unavailable; skipping " + hook + " hook."
+}
+
+func TestSelectLefthookIntegrationManager(t *testing.T) {
+	t.Parallel()
+	lefthook := func(path string) hookManager {
+		return hookManager{Name: lefthookManagerName, ConfigPath: path, OverwritesHooks: true, IntegrationKind: hookManagerIntegrationLefthook}
+	}
+	tests := []struct {
+		name     string
+		managers []hookManager
+		wantOK   bool
+		wantErr  bool
+	}{
+		{name: "exactly one main", managers: []hookManager{lefthook("lefthook.yml")}, wantOK: true},
+		{name: "multiple main variants", managers: []hookManager{lefthook("lefthook.yml"), lefthook(".lefthook.yaml")}, wantErr: true},
+		{name: "local only", managers: []hookManager{lefthook("lefthook-local.yml")}, wantErr: true},
+		{name: "alternate local", managers: []hookManager{lefthook("lefthook.yml"), lefthook(".lefthook-local.yml")}, wantErr: true},
+		{name: "with non overwriting manager", managers: []hookManager{lefthook("lefthook.yml"), {Name: "pre-commit"}}, wantOK: true},
+		{name: "with Husky", managers: []hookManager{lefthook("lefthook.yml"), {Name: "Husky", OverwritesHooks: true}}, wantErr: true},
+		{name: "with another overwriting manager", managers: []hookManager{lefthook("lefthook.yml"), {Name: "custom", OverwritesHooks: true}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, ok, err := selectLefthookIntegrationManager(tt.managers)
+			if ok != tt.wantOK || (err != nil) != tt.wantErr {
+				t.Errorf("select = ok %v err %v, want ok %v err %v", ok, err, tt.wantOK, tt.wantErr)
+			}
+			if tt.wantErr && !errors.Is(err, ErrLefthookAmbiguous) {
+				t.Errorf("error = %v, want ErrLefthookAmbiguous", err)
+			}
+		})
+	}
+}
+
+func TestLefthookExcludeOwnershipPreservesPreexistingExactRules(t *testing.T) {
+	t.Parallel()
+	preexisting := []byte("# user rules\n/lefthook-local.yml\n/.lefthook-local/pre-push/entire.sh\n")
+	installed := mergeLefthookInfoExclude(preexisting)
+	if bytes.Count(installed, []byte("/lefthook-local.yml\n")) != 2 {
+		t.Fatalf("installed exclude should retain user rule and add owned rule block:\n%s", installed)
+	}
+	removed := removeLefthookExcludeLines(installed)
+	if string(removed) != string(preexisting) {
+		t.Errorf("uninstall exclude = %q, want original %q", removed, preexisting)
+	}
+}

--- a/cmd/entire/cli/strategy/lefthook_transaction.go
+++ b/cmd/entire/cli/strategy/lefthook_transaction.go
@@ -1,0 +1,380 @@
+package strategy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitdir"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
+)
+
+func installLefthookFiles(ctx context.Context, absolutePath bool) (int, error) { //nolint:unparam // Task 3 wires the settings-selected true path.
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("resolve worktree root: %w", err)
+	}
+	return installLefthookFilesAt(ctx, repoRoot, absolutePath, nil)
+}
+
+func installLefthookFilesAt(ctx context.Context, repoRoot string, absolutePath bool, beforePublish func(string) error) (int, error) {
+	root, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return 0, fmt.Errorf("open worktree: %w", err)
+	}
+	managers, detectErr := detectHookManagersForIntegration(repoRoot)
+	if detectErr != nil {
+		return 0, detectErr
+	}
+	manager, ok, selectErr := selectLefthookIntegrationManager(managers)
+	if selectErr != nil {
+		return 0, selectErr
+	}
+	if !ok {
+		return 0, errors.New("lefthook main config not found")
+	}
+	if err := validateLefthookMainConfig(root, manager); err != nil {
+		return 0, err
+	}
+
+	existing, _, err := readOptionalRegular(root, lefthookLocalConfigName)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", lefthookLocalConfigName, err)
+	}
+	merged, err := mergeLefthookLocalConfig(existing)
+	if err != nil {
+		return 0, err
+	}
+
+	cmdPrefix, err := hookCmdPrefix(absolutePath)
+	if err != nil {
+		return 0, err
+	}
+	specs := buildHookSpecs(cmdPrefix)
+	for _, spec := range specs {
+		name := lefthookScriptPath(spec.name)
+		current, _, readErr := readOptionalRegular(root, name)
+		if readErr != nil {
+			return 0, fmt.Errorf("read %s: %w", name, readErr)
+		}
+		if current != nil && !lefthookScriptOwned(string(current)) {
+			return 0, fmt.Errorf("%w: script path %s already exists", ErrLefthookOwnedEntryConflict, name)
+		}
+	}
+
+	commonDir, err := gitdir.CommonDirForWorktree(ctx, repoRoot)
+	if err != nil {
+		return 0, fmt.Errorf("resolve git common directory: %w", err)
+	}
+	gitRoot, err := gitdir.OpenAt(commonDir)
+	if err != nil {
+		return 0, fmt.Errorf("open git common directory: %w", err)
+	}
+	exclude, _, err := readOptionalRegular(gitRoot, "info/exclude")
+	if err != nil {
+		return 0, fmt.Errorf("read git exclude: %w", err)
+	}
+	mergedExclude := mergeLefthookInfoExclude(exclude)
+
+	createdDirs, gitInfoCreated, err := prepareLefthookDirectories(root, gitRoot, specs)
+	if err != nil {
+		return 0, err
+	}
+	staged, configFile, err := stageLefthookArtifacts(root, gitRoot, specs, mergedExclude, merged)
+	if err != nil {
+		cleanupLefthookDirs(root, createdDirs)
+		cleanupGitInfoDir(gitRoot, gitInfoCreated)
+		return 0, err
+	}
+	if len(staged) == 0 {
+		return 0, nil
+	}
+	defer cleanupStagedLefthookFiles(staged)
+	written, err := publishLefthookTransaction(staged, configFile, beforePublish)
+	if err != nil {
+		cleanupLefthookDirs(root, createdDirs)
+		cleanupGitInfoDir(gitRoot, gitInfoCreated)
+	}
+	return written, err
+}
+
+func prepareLefthookDirectories(root, gitRoot *os.Root, specs []hookSpec) ([]string, bool, error) {
+	created := make([]string, 0, len(specs)+1)
+	dirs := []string{lefthookLocalDir}
+	for _, spec := range specs {
+		dirs = append(dirs, filepath.ToSlash(filepath.Join(lefthookLocalDir, spec.name)))
+	}
+	for _, dir := range dirs {
+		info, err := osroot.LstatNoSymlinks(root, dir)
+		switch {
+		case os.IsNotExist(err):
+			created = append(created, dir)
+		case err != nil:
+			cleanupLefthookDirs(root, created)
+			return nil, false, fmt.Errorf("inspect Lefthook directory %s: %w", dir, err)
+		case !info.IsDir():
+			cleanupLefthookDirs(root, created)
+			return nil, false, fmt.Errorf("%s is not a directory", dir)
+		}
+		if err := osroot.MkdirAllNoSymlink(root, dir, 0o755); err != nil {
+			cleanupLefthookDirs(root, created)
+			return nil, false, fmt.Errorf("create Lefthook directory %s: %w", dir, err)
+		}
+	}
+	gitInfoCreated := false
+	info, err := osroot.LstatNoSymlinks(gitRoot, "info")
+	switch {
+	case os.IsNotExist(err):
+		gitInfoCreated = true
+	case err != nil:
+		cleanupLefthookDirs(root, created)
+		return nil, false, fmt.Errorf("inspect git info directory: %w", err)
+	case !info.IsDir():
+		cleanupLefthookDirs(root, created)
+		return nil, false, errors.New("git info path is not a directory")
+	}
+	if err := osroot.MkdirAllNoSymlink(gitRoot, "info", 0o755); err != nil {
+		cleanupLefthookDirs(root, created)
+		return nil, false, fmt.Errorf("create git info directory: %w", err)
+	}
+	return created, gitInfoCreated, nil
+}
+
+func stageLefthookArtifacts(root, gitRoot *os.Root, specs []hookSpec, exclude, config []byte) ([]*stagedLefthookFile, *stagedLefthookFile, error) {
+	staged := make([]*stagedLefthookFile, 0, len(specs)+2)
+	stage := func(target *os.Root, name string, data []byte, mode os.FileMode, counted, force bool) error {
+		file, err := stageLefthookFile(target, name, data, mode, counted, force)
+		if errors.Is(err, errLefthookFileUnchanged) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		staged = append(staged, file)
+		return nil
+	}
+	for _, spec := range specs {
+		if err := stage(root, lefthookScriptPath(spec.name), []byte(renderLefthookScript(spec)), 0o755, true, false); err != nil {
+			cleanupStagedLefthookFiles(staged)
+			return nil, nil, err
+		}
+	}
+	if err := stage(gitRoot, "info/exclude", exclude, 0o644, false, false); err != nil {
+		cleanupStagedLefthookFiles(staged)
+		return nil, nil, err
+	}
+	configFile, err := stageLefthookFile(root, lefthookLocalConfigName, config, 0o644, true, len(staged) > 0)
+	if errors.Is(err, errLefthookFileUnchanged) {
+		return staged, nil, nil
+	}
+	if err != nil {
+		cleanupStagedLefthookFiles(staged)
+		return nil, nil, err
+	}
+	staged = append(staged, configFile)
+	return staged, configFile, nil
+}
+
+func publishLefthookTransaction(staged []*stagedLefthookFile, config *stagedLefthookFile, beforePublish func(string) error) (int, error) {
+	if err := config.deactivate(); err != nil {
+		return 0, errors.Join(err, rollbackStagedLefthookFiles(staged))
+	}
+	written := 0
+	for _, file := range staged {
+		if beforePublish != nil {
+			if err := beforePublish(file.name); err != nil {
+				return 0, errors.Join(err, rollbackStagedLefthookFiles(staged))
+			}
+		}
+		if err := file.publish(); err != nil {
+			return 0, errors.Join(err, rollbackStagedLefthookFiles(staged))
+		}
+		if file.counted {
+			written++
+		}
+	}
+	if err := config.finishDeactivation(); err != nil {
+		return 0, errors.Join(err, rollbackStagedLefthookFiles(staged))
+	}
+	return written, nil
+}
+
+type stagedLefthookFile struct {
+	parent         *os.Root
+	name           string
+	leaf           string
+	temp           string
+	original       []byte
+	originalMode   os.FileMode
+	originalExists bool
+	published      bool
+	counted        bool
+	closeParent    func()
+	deactivated    string
+}
+
+func stageLefthookFile(root *os.Root, name string, data []byte, mode os.FileMode, counted, force bool) (*stagedLefthookFile, error) {
+	parent, leaf, closeParent, err := osroot.OpenParentNoSymlinks(root, name)
+	if err != nil {
+		return nil, fmt.Errorf("open parent for %s: %w", name, err)
+	}
+	original, info, err := readOptionalRegular(parent, leaf)
+	if err != nil {
+		closeParent()
+		return nil, fmt.Errorf("read existing %s: %w", name, err)
+	}
+	changed := original == nil || !bytes.Equal(original, data) || info.Mode().Perm() != mode.Perm()
+	if !changed && !force {
+		closeParent()
+		return nil, errLefthookFileUnchanged
+	}
+	temp, tempName, err := jsonutil.CreateTempIn(parent, leaf)
+	if err != nil {
+		closeParent()
+		return nil, fmt.Errorf("stage %s: %w", name, err)
+	}
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = temp.Close()
+			_ = parent.Remove(tempName) //nolint:errcheck // best-effort cleanup after a staging failure
+			closeParent()
+		}
+	}()
+	if err := integrationFault("write", name); err != nil {
+		return nil, err
+	}
+	if _, err := temp.Write(data); err != nil {
+		return nil, fmt.Errorf("stage %s: %w", name, err)
+	}
+	if err := temp.Close(); err != nil {
+		return nil, fmt.Errorf("stage %s: %w", name, err)
+	}
+	if err := parent.Chmod(tempName, mode); err != nil {
+		return nil, fmt.Errorf("stage %s: %w", name, err)
+	}
+	removeTemp = false
+	file := &stagedLefthookFile{
+		parent: parent, name: name, leaf: leaf, temp: tempName, original: original,
+		counted: counted && changed, closeParent: closeParent,
+	}
+	if info != nil {
+		file.originalExists = true
+		file.originalMode = info.Mode().Perm()
+	}
+	return file, nil
+}
+
+func (file *stagedLefthookFile) deactivate() error {
+	if !file.originalExists {
+		return nil
+	}
+	placeholder, backupName, err := jsonutil.CreateTempIn(file.parent, file.leaf+".backup")
+	if err != nil {
+		return fmt.Errorf("prepare deactivation of %s: %w", file.name, err)
+	}
+	if err := placeholder.Close(); err != nil {
+		_ = file.parent.Remove(backupName) //nolint:errcheck // best-effort cleanup after closing the placeholder fails
+		return fmt.Errorf("prepare deactivation of %s: %w", file.name, err)
+	}
+	if err := file.parent.Remove(backupName); err != nil {
+		return fmt.Errorf("prepare deactivation of %s: %w", file.name, err)
+	}
+	if err := file.parent.Rename(file.leaf, backupName); err != nil {
+		return fmt.Errorf("deactivate %s: %w", file.name, err)
+	}
+	file.deactivated = backupName
+	return nil
+}
+
+func (file *stagedLefthookFile) finishDeactivation() error {
+	if file.deactivated == "" {
+		return nil
+	}
+	if err := file.parent.Remove(file.deactivated); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove deactivated %s backup: %w", file.name, err)
+	}
+	file.deactivated = ""
+	return nil
+}
+
+func (file *stagedLefthookFile) publish() error {
+	if err := file.parent.Rename(file.temp, file.leaf); err != nil {
+		return fmt.Errorf("publish %s: %w", file.name, err)
+	}
+	file.temp = ""
+	file.published = true
+	return nil
+}
+
+func rollbackStagedLefthookFiles(files []*stagedLefthookFile) error {
+	var rollbackErrs []error
+	for i := len(files) - 1; i >= 0; i-- {
+		file := files[i]
+		if file.deactivated != "" {
+			if file.published {
+				if err := file.parent.Remove(file.leaf); err != nil && !os.IsNotExist(err) {
+					rollbackErrs = append(rollbackErrs, fmt.Errorf("remove published %s: %w", file.name, err))
+				}
+				file.published = false
+			}
+			if err := file.parent.Rename(file.deactivated, file.leaf); err != nil {
+				rollbackErrs = append(rollbackErrs, fmt.Errorf("reactivate %s: %w", file.name, err))
+			} else {
+				file.deactivated = ""
+			}
+			if file.temp != "" {
+				if err := file.parent.Remove(file.temp); err != nil && !os.IsNotExist(err) {
+					rollbackErrs = append(rollbackErrs, fmt.Errorf("remove staged %s: %w", file.name, err))
+				}
+				file.temp = ""
+			}
+			continue
+		}
+		if file.published {
+			if file.originalExists {
+				if err := jsonutil.WriteFileAtomicIn(file.parent, file.leaf, file.original, file.originalMode); err != nil {
+					rollbackErrs = append(rollbackErrs, fmt.Errorf("restore %s: %w", file.name, err))
+				}
+			} else if err := file.parent.Remove(file.leaf); err != nil && !os.IsNotExist(err) {
+				rollbackErrs = append(rollbackErrs, fmt.Errorf("remove %s: %w", file.name, err))
+			}
+			file.published = false
+		}
+		if file.temp != "" {
+			if err := file.parent.Remove(file.temp); err != nil && !os.IsNotExist(err) {
+				rollbackErrs = append(rollbackErrs, fmt.Errorf("remove staged %s: %w", file.name, err))
+			}
+			file.temp = ""
+		}
+	}
+	return errors.Join(rollbackErrs...)
+}
+
+func cleanupStagedLefthookFiles(files []*stagedLefthookFile) {
+	for _, file := range files {
+		if file.temp != "" {
+			_ = file.parent.Remove(file.temp) //nolint:errcheck // best-effort deferred cleanup; rollback reports material failures
+			file.temp = ""
+		}
+		file.closeParent()
+	}
+}
+
+func cleanupLefthookDirs(root *os.Root, dirs []string) {
+	for i := len(dirs) - 1; i >= 0; i-- {
+		_ = root.Remove(dirs[i]) //nolint:errcheck // best-effort cleanup of directories created during a failed transaction
+	}
+}
+
+func cleanupGitInfoDir(root *os.Root, created bool) {
+	if created {
+		_ = root.Remove("info") //nolint:errcheck // best-effort cleanup; non-empty means the directory was not ours to remove
+	}
+}

--- a/cmd/entire/cli/strategy/lefthook_yaml.go
+++ b/cmd/entire/cli/strategy/lefthook_yaml.go
@@ -1,0 +1,208 @@
+package strategy
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func mergeLefthookLocalConfig(existing []byte) ([]byte, error) {
+	document := &yaml.Node{}
+	if len(bytes.TrimSpace(existing)) == 0 {
+		document.Kind = yaml.DocumentNode
+		document.Content = []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}
+	} else if err := yaml.Unmarshal(existing, document); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", lefthookLocalConfigName, err)
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse %s: top level must be a mapping", lefthookLocalConfigName)
+	}
+
+	root := document.Content[0]
+	if err := setOwnedLefthookSourceDir(root); err != nil {
+		return nil, err
+	}
+	for _, hook := range gitHookNames {
+		hookNode, err := ensureMappingValue(root, hook)
+		if err != nil {
+			return nil, err
+		}
+		scriptsNode, err := ensureMappingValue(hookNode, "scripts")
+		if err != nil {
+			return nil, err
+		}
+		if err := setOwnedLefthookScript(scriptsNode, hook); err != nil {
+			return nil, fmt.Errorf("%s: %w", hook, err)
+		}
+	}
+
+	var out bytes.Buffer
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(document); err != nil {
+		return nil, fmt.Errorf("encode %s: %w", lefthookLocalConfigName, err)
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, fmt.Errorf("encode %s: %w", lefthookLocalConfigName, err)
+	}
+	return out.Bytes(), nil
+}
+
+func ensureMappingValue(parent *yaml.Node, key string) (*yaml.Node, error) {
+	foundAt := -1
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if parent.Content[i].Value != key {
+			continue
+		}
+		if foundAt >= 0 {
+			return nil, fmt.Errorf("duplicate %s mapping", key)
+		}
+		foundAt = i
+	}
+	if foundAt >= 0 {
+		value := parent.Content[foundAt+1]
+		if value.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("%s must be a mapping", key)
+		}
+		return value, nil
+	}
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	valueNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	parent.Content = append(parent.Content, keyNode, valueNode)
+	return valueNode, nil
+}
+
+func setOwnedLefthookSourceDir(root *yaml.Node) error {
+	foundAt := -1
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value != "source_dir_local" {
+			continue
+		}
+		if foundAt >= 0 {
+			return errors.New("duplicate source_dir_local setting")
+		}
+		foundAt = i
+	}
+	if foundAt < 0 {
+		key := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "source_dir_local", LineComment: lefthookOwnedMarker}
+		value := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: lefthookLocalDir}
+		root.Content = append([]*yaml.Node{key, value}, root.Content...)
+		return nil
+	}
+	key, value := root.Content[foundAt], root.Content[foundAt+1]
+	owned := lefthookNodeOwned(key, value)
+	if value.Kind != yaml.ScalarNode || value.Value != lefthookLocalDir {
+		if !owned {
+			return fmt.Errorf("source_dir_local: %w", ErrLefthookOwnedEntryConflict)
+		}
+		value.Kind = yaml.ScalarNode
+		value.Tag = "!!str"
+		value.Value = lefthookLocalDir
+	}
+	// A user-selected compatible source directory is sufficient for Entire's
+	// participant config. Do not mark it: ownership would make uninstall remove
+	// a setting the user created independently.
+	return nil
+}
+
+func setOwnedLefthookScript(scripts *yaml.Node, hook string) error {
+	foundAt := -1
+	for i := 0; i+1 < len(scripts.Content); i += 2 {
+		key := scripts.Content[i]
+		if key.Value != lefthookScriptName {
+			continue
+		}
+		if foundAt >= 0 {
+			return ErrLefthookOwnedEntryConflict
+		}
+		foundAt = i
+		value := scripts.Content[i+1]
+		if !lefthookNodeOwned(key, value) {
+			return ErrLefthookOwnedEntryConflict
+		}
+	}
+	if foundAt >= 0 {
+		key := scripts.Content[foundAt]
+		scripts.Content[foundAt+1] = lefthookScriptValue(hook)
+		key.HeadComment = ""
+		key.LineComment = lefthookOwnedMarker
+		key.FootComment = ""
+		return nil
+	}
+	key := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: lefthookScriptName, LineComment: lefthookOwnedMarker}
+	scripts.Content = append(scripts.Content, key, lefthookScriptValue(hook))
+	return nil
+}
+
+func lefthookNodeOwned(key, value *yaml.Node) bool {
+	return exactLefthookYAMLMarker(key.HeadComment) ||
+		exactLefthookYAMLMarker(key.LineComment) ||
+		exactLefthookYAMLMarker(key.FootComment) ||
+		exactLefthookYAMLMarker(value.HeadComment) ||
+		exactLefthookYAMLMarker(value.LineComment) ||
+		exactLefthookYAMLMarker(value.FootComment)
+}
+
+func exactLefthookYAMLMarker(comment string) bool {
+	return comment == lefthookOwnedMarker || comment == "# "+lefthookOwnedMarker
+}
+
+func lefthookScriptValue(hook string) *yaml.Node {
+	content := []*yaml.Node{
+		{Kind: yaml.ScalarNode, Tag: "!!str", Value: "runner"},
+		{Kind: yaml.ScalarNode, Tag: "!!str", Value: "bash"},
+	}
+	if hook == postRewriteHookName {
+		content = append(content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "use_stdin"},
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
+		)
+	}
+	return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map", Content: content}
+}
+
+func removeOwnedLefthookConfig(data []byte) ([]byte, bool, error) {
+	root, err := parseYAMLMapping(data, lefthookLocalConfigName)
+	if err != nil {
+		return nil, false, err
+	}
+	changed := removeOwnedMappingEntry(root, "source_dir_local")
+	for _, hook := range gitHookNames {
+		hookNode, ok := mappingValue(root, hook)
+		if !ok || hookNode.Kind != yaml.MappingNode {
+			continue
+		}
+		scripts, ok := mappingValue(hookNode, "scripts")
+		if !ok || scripts.Kind != yaml.MappingNode {
+			continue
+		}
+		if removeOwnedMappingEntry(scripts, lefthookScriptName) {
+			changed = true
+		}
+	}
+	if !changed {
+		return data, false, nil
+	}
+	var out bytes.Buffer
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(root); err != nil {
+		return nil, false, fmt.Errorf("encode %s: %w", lefthookLocalConfigName, err)
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, false, fmt.Errorf("encode %s: %w", lefthookLocalConfigName, err)
+	}
+	return out.Bytes(), true, nil
+}
+
+func removeOwnedMappingEntry(parent *yaml.Node, name string) bool {
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if parent.Content[i].Value == name && lefthookNodeOwned(parent.Content[i], parent.Content[i+1]) {
+			parent.Content = append(parent.Content[:i], parent.Content[i+2:]...)
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -346,6 +346,8 @@ func LoadModelHint(ctx context.Context, sessionID string) string {
 
 const hookHealthHintSuffix = ".hook-health"
 
+const hookHealthWarningRetryFingerprint = `["","","","retry"]`
+
 // StoreHookHealthWarningHint atomically records the warning fingerprint shown
 // before SessionState exists. The per-session gate serializes it with transfer.
 func StoreHookHealthWarningHint(ctx context.Context, sessionID, fingerprint string) error {
@@ -431,8 +433,10 @@ func ClaimHookHealthWarning(ctx context.Context, sessionID, fingerprint string) 
 }
 
 // RollbackHookHealthWarningClaim makes a claimed warning retryable when its
-// native hook response could not be emitted. It clears only an exact matching
-// claim, leaving any newer fingerprint untouched.
+// native hook response could not be emitted. It replaces only an exact matching
+// claim with a neutral marker, leaving any newer fingerprint untouched. The
+// marker keeps retry fail-open even when stale durable state contains the same
+// fingerprint as the warning whose output failed.
 func RollbackHookHealthWarningClaim(ctx context.Context, sessionID, fingerprint string) error {
 	if err := validation.ValidateSessionID(sessionID); err != nil {
 		return fmt.Errorf("invalid session ID: %w", err)
@@ -451,22 +455,14 @@ func RollbackHookHealthWarningClaim(ctx context.Context, sessionID, fingerprint 
 		if hint != fingerprint {
 			return nil
 		}
-		root, err := openSessionStateRootForRead(ctx)
-		if err != nil || root == nil {
-			return err
-		}
-		defer root.Close()
-		if err := osroot.RemoveNoSymlinks(root, sessionID+hookHealthHintSuffix); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("rollback hook health warning hint: %w", err)
-		}
-		return nil
+		return writeHookHealthWarningHint(ctx, sessionID, hookHealthWarningRetryFingerprint)
 	}
 
 	state, err := LoadSessionState(ctx, sessionID)
 	if err != nil || state == nil || state.LastHookHealthWarning != fingerprint {
 		return err
 	}
-	state.LastHookHealthWarning = ""
+	state.LastHookHealthWarning = hookHealthWarningRetryFingerprint
 	return SaveSessionState(ctx, state)
 }
 
@@ -536,6 +532,46 @@ func TransferHookHealthWarningHint(ctx context.Context, sessionID string) error 
 	defer root.Close()
 	if err := osroot.RemoveNoSymlinks(root, sessionID+hookHealthHintSuffix); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("consume hook health warning hint: %w", err)
+	}
+	return nil
+}
+
+// RecordHookHealthRecovery records a healthy fingerprint so the same unhealthy
+// fingerprint can warn again if it recurs. The hint is a write-ahead marker:
+// it is written before durable state and removed only after that save succeeds,
+// so a partial failure remains fail-open for the next unhealthy claim.
+func RecordHookHealthRecovery(ctx context.Context, sessionID, fingerprint string) error {
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		return fmt.Errorf("invalid session ID: %w", err)
+	}
+	if !validHookHealthWarningFingerprint(fingerprint) {
+		return errors.New("invalid hook health recovery fingerprint")
+	}
+	_, _, release, err := acquireSessionGate(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	if err := writeHookHealthWarningHint(ctx, sessionID, fingerprint); err != nil {
+		return err
+	}
+
+	state, err := LoadSessionState(ctx, sessionID)
+	if err != nil || state == nil {
+		return err
+	}
+	state.LastHookHealthWarning = fingerprint
+	if err := SaveSessionState(ctx, state); err != nil {
+		return err
+	}
+	root, err := openSessionStateRootForRead(ctx)
+	if err != nil || root == nil {
+		return err
+	}
+	defer root.Close()
+	if err := osroot.RemoveNoSymlinks(root, sessionID+hookHealthHintSuffix); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("consume hook health recovery hint: %w", err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -341,6 +342,202 @@ func LoadModelHint(ctx context.Context, sessionID string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(data))
+}
+
+const hookHealthHintSuffix = ".hook-health"
+
+// StoreHookHealthWarningHint atomically records the warning fingerprint shown
+// before SessionState exists. The per-session gate serializes it with transfer.
+func StoreHookHealthWarningHint(ctx context.Context, sessionID, fingerprint string) error {
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		return fmt.Errorf("invalid session ID: %w", err)
+	}
+	if !validHookHealthWarningFingerprint(fingerprint) {
+		return errors.New("invalid hook health warning fingerprint")
+	}
+	_, _, release, err := acquireSessionGate(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return writeHookHealthWarningHint(ctx, sessionID, fingerprint)
+}
+
+func writeHookHealthWarningHint(ctx context.Context, sessionID, fingerprint string) error {
+	root, err := openSessionStateRoot(ctx)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	if err := jsonutil.WriteFileAtomicIn(root, sessionID+hookHealthHintSuffix, []byte(fingerprint), 0o600); err != nil {
+		return fmt.Errorf("failed to write hook health warning hint: %w", err)
+	}
+	return nil
+}
+
+// ClaimHookHealthWarning atomically compares the last emitted health
+// fingerprint and records fingerprint when it changed. The shared session gate
+// makes concurrent TurnStart processes elect exactly one warning writer.
+func ClaimHookHealthWarning(ctx context.Context, sessionID, fingerprint string) (bool, error) {
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		return false, fmt.Errorf("invalid session ID: %w", err)
+	}
+	if !validHookHealthWarningFingerprint(fingerprint) {
+		return false, errors.New("invalid hook health warning fingerprint")
+	}
+	_, _, release, err := acquireSessionGate(ctx, sessionID)
+	if err != nil {
+		return false, err
+	}
+	defer release()
+
+	hint, found, hintErr := LoadHookHealthWarningHint(ctx, sessionID)
+	if hintErr == nil && found {
+		if hint == fingerprint {
+			return false, nil
+		}
+		if err := writeHookHealthWarningHint(ctx, sessionID, fingerprint); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if hintErr != nil {
+		// A malformed hint must fail open. Replacing it under the gate both makes
+		// this warning visible and repairs future comparisons.
+		if err := writeHookHealthWarningHint(ctx, sessionID, fingerprint); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	state, err := LoadSessionState(ctx, sessionID)
+	if err != nil {
+		return false, err
+	}
+	if state == nil {
+		if err := writeHookHealthWarningHint(ctx, sessionID, fingerprint); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if state.LastHookHealthWarning == fingerprint {
+		return false, nil
+	}
+	state.LastHookHealthWarning = fingerprint
+	if err := SaveSessionState(ctx, state); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// RollbackHookHealthWarningClaim makes a claimed warning retryable when its
+// native hook response could not be emitted. It clears only an exact matching
+// claim, leaving any newer fingerprint untouched.
+func RollbackHookHealthWarningClaim(ctx context.Context, sessionID, fingerprint string) error {
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		return fmt.Errorf("invalid session ID: %w", err)
+	}
+	_, _, release, err := acquireSessionGate(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	hint, found, err := LoadHookHealthWarningHint(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	if found {
+		if hint != fingerprint {
+			return nil
+		}
+		root, err := openSessionStateRootForRead(ctx)
+		if err != nil || root == nil {
+			return err
+		}
+		defer root.Close()
+		if err := osroot.RemoveNoSymlinks(root, sessionID+hookHealthHintSuffix); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("rollback hook health warning hint: %w", err)
+		}
+		return nil
+	}
+
+	state, err := LoadSessionState(ctx, sessionID)
+	if err != nil || state == nil || state.LastHookHealthWarning != fingerprint {
+		return err
+	}
+	state.LastHookHealthWarning = ""
+	return SaveSessionState(ctx, state)
+}
+
+// LoadHookHealthWarningHint returns a pending warning fingerprint. Malformed
+// content is an error so lifecycle fails open by warning instead of suppressing.
+func LoadHookHealthWarningHint(ctx context.Context, sessionID string) (string, bool, error) {
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		return "", false, fmt.Errorf("invalid session ID: %w", err)
+	}
+	root, err := openSessionStateRootForRead(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	if root == nil {
+		return "", false, nil
+	}
+	defer root.Close()
+	data, err := osroot.ReadFileNoFollow(root, sessionID+hookHealthHintSuffix)
+	if os.IsNotExist(err) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("read hook health warning hint: %w", err)
+	}
+	fingerprint := strings.TrimSpace(string(data))
+	if !validHookHealthWarningFingerprint(fingerprint) {
+		return "", false, errors.New("invalid hook health warning hint")
+	}
+	return fingerprint, true, nil
+}
+
+func validHookHealthWarningFingerprint(fingerprint string) bool {
+	var fields []string
+	return json.Unmarshal([]byte(fingerprint), &fields) == nil && len(fields) == 4
+}
+
+// TransferHookHealthWarningHint copies a pending pre-state warning into the
+// durable session state and consumes the hint while holding the session gate.
+func TransferHookHealthWarningHint(ctx context.Context, sessionID string) error {
+	_, _, release, err := acquireSessionGate(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	defer release()
+	fingerprint, found, err := LoadHookHealthWarningHint(ctx, sessionID)
+	if err != nil || !found {
+		return err
+	}
+	state, err := LoadSessionState(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return ErrStateNotFound
+	}
+	state.LastHookHealthWarning = fingerprint
+	if err := SaveSessionState(ctx, state); err != nil {
+		return err
+	}
+	root, err := openSessionStateRootForRead(ctx)
+	if err != nil {
+		return err
+	}
+	if root == nil {
+		return nil
+	}
+	defer root.Close()
+	if err := osroot.RemoveNoSymlinks(root, sessionID+hookHealthHintSuffix); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("consume hook health warning hint: %w", err)
+	}
+	return nil
 }
 
 // StoreAgentTypeHint records the agent type that owns a session before

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -436,11 +436,18 @@ func ClaimHookHealthWarning(ctx context.Context, sessionID, fingerprint string) 
 // native hook response could not be emitted. It replaces only an exact matching
 // claim with a neutral marker, leaving any newer fingerprint untouched. The
 // marker keeps retry fail-open even when stale durable state contains the same
-// fingerprint as the warning whose output failed.
+// fingerprint as the warning whose output failed. Cleanup has its own bounded
+// context because the failed turn may already be cancelled or out of lock budget.
 func RollbackHookHealthWarningClaim(ctx context.Context, sessionID, fingerprint string) error {
 	if err := validation.ValidateSessionID(sessionID); err != nil {
 		return fmt.Errorf("invalid session ID: %w", err)
 	}
+	const cleanupBudget = 2 * time.Second
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupBudget)
+	defer cancel()
+	// WithoutCancel preserves context values, including the turn's expired
+	// session-lock deadline. Replace that value as well as the cancellation.
+	ctx = WithSessionLockWait(ctx, cleanupBudget)
 	_, _, release, err := acquireSessionGate(ctx, sessionID)
 	if err != nil {
 		return err

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -13,11 +13,105 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestHookHealthWarningHintStoreLoadTransfer(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	const sessionID = "hook-health-hint"
+	const fingerprint = `["lefthook","error","Lefthook","conflict"]`
+
+	require.NoError(t, StoreHookHealthWarningHint(context.Background(), sessionID, fingerprint))
+	got, found, err := LoadHookHealthWarningHint(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, fingerprint, got)
+
+	require.NoError(t, SaveSessionState(context.Background(), &SessionState{SessionID: sessionID, BaseCommit: "abc", StartedAt: time.Now()}))
+	require.NoError(t, TransferHookHealthWarningHint(context.Background(), sessionID))
+	state, err := LoadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Equal(t, fingerprint, state.LastHookHealthWarning)
+	_, found, err = LoadHookHealthWarningHint(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.False(t, found, "transfer must atomically consume the hint after saving state")
+}
+
+func TestLoadHookHealthWarningHintRejectsCorruptValue(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	root, err := openSessionStateRoot(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, jsonutil.WriteFileAtomicIn(root, "corrupt-hook-health.hook-health", []byte("prompt text"), 0o600))
+	require.NoError(t, root.Close())
+
+	_, found, err := LoadHookHealthWarningHint(context.Background(), "corrupt-hook-health")
+	require.Error(t, err)
+	require.False(t, found)
+}
+
+func TestClaimHookHealthWarningConcurrentSingleWinner(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	const sessionID = "hook-health-concurrent-claim"
+	const fingerprint = `["lefthook","error","Lefthook","conflict"]`
+
+	const callers = 16
+	start := make(chan struct{})
+	results := make(chan bool, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			claimed, err := ClaimHookHealthWarning(context.Background(), sessionID, fingerprint)
+			results <- claimed
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	winners := 0
+	for claimed := range results {
+		if claimed {
+			winners++
+		}
+	}
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, winners, "fingerprint compare and claim must be atomic")
+}
+
+func TestRollbackHookHealthWarningClaimAllowsRetryAfterOutputFailure(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	const sessionID = "hook-health-output-retry"
+	const fingerprint = `["native","error","","repair_failed"]`
+
+	claimed, err := ClaimHookHealthWarning(context.Background(), sessionID, fingerprint)
+	require.NoError(t, err)
+	require.True(t, claimed)
+	require.NoError(t, RollbackHookHealthWarningClaim(context.Background(), sessionID, fingerprint))
+
+	claimed, err = ClaimHookHealthWarning(context.Background(), sessionID, fingerprint)
+	require.NoError(t, err)
+	require.True(t, claimed, "a failed output must leave the warning retryable")
+}
 
 // TestLoadSessionState_PackageLevel tests the package-level LoadSessionState function.
 func TestLoadSessionState_PackageLevel(t *testing.T) {

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -20,6 +20,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRollbackHookHealthWarningClaimAfterCancellation(t *testing.T) {
+	for _, durable := range []bool{false, true} {
+		t.Run(fmt.Sprintf("durable=%t", durable), func(t *testing.T) {
+			dir := t.TempDir()
+			testutil.InitRepo(t, dir)
+			t.Chdir(dir)
+			const sessionID = "cancelled-hook-warning"
+			const fingerprint = `["native","outdated","","native_hooks_modified"]`
+			if durable {
+				require.NoError(t, SaveSessionState(t.Context(), &SessionState{
+					SessionID: sessionID, BaseCommit: "abc", StartedAt: time.Now(),
+				}))
+			}
+			claimed, err := ClaimHookHealthWarning(t.Context(), sessionID, fingerprint)
+			require.NoError(t, err)
+			require.True(t, claimed)
+			ctx, cancel := context.WithCancel(context.WithValue(t.Context(), sessionLockDeadlineKey{}, time.Now().Add(-time.Second)))
+			cancel()
+			// Uncontended flock acquisition succeeds even with a cancelled
+			// context. Brief contention reproduces the actual cleanup failure.
+			lock, err := stateLockForSession(t.Context(), sessionID)
+			require.NoError(t, err)
+			unlock, err := flock.AcquireIn(lock.root, lock.name)
+			require.NoError(t, err)
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(unlock) }
+			timer := time.AfterFunc(50*time.Millisecond, release)
+			t.Cleanup(func() {
+				timer.Stop()
+				release()
+			})
+			require.NoError(t, RollbackHookHealthWarningClaim(ctx, sessionID, fingerprint))
+			claimed, err = ClaimHookHealthWarning(t.Context(), sessionID, fingerprint)
+			require.NoError(t, err)
+			require.True(t, claimed, "a warning that never reached stdout must remain retryable")
+		})
+	}
+}
+
 func TestHookHealthWarningHintStoreLoadTransfer(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -43,6 +43,39 @@ func TestHookHealthWarningHintStoreLoadTransfer(t *testing.T) {
 	require.False(t, found, "transfer must atomically consume the hint after saving state")
 }
 
+func TestRecordHookHealthRecoveryLeavesFailOpenHintWhenStateIsUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	const sessionID = "hook-health-recovery-failure"
+	const unhealthy = `["lefthook","error","Lefthook","conflict"]`
+	const healthy = `["native","current","",""]`
+	require.NoError(t, SaveSessionState(context.Background(), &SessionState{
+		SessionID: sessionID, BaseCommit: "abc", StartedAt: time.Now(), LastHookHealthWarning: unhealthy,
+	}))
+	stateDir, err := getSessionStateDir(context.Background())
+	require.NoError(t, err)
+	statePath := filepath.Join(stateDir, sessionID+".json")
+	durableState, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(statePath, []byte("{"), 0o600))
+
+	require.Error(t, RecordHookHealthRecovery(context.Background(), sessionID, healthy))
+	got, found, err := LoadHookHealthWarningHint(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.True(t, found, "the write-ahead recovery marker must survive a durable-state failure")
+	require.Equal(t, healthy, got)
+
+	claimed, err := ClaimHookHealthWarning(context.Background(), sessionID, unhealthy)
+	require.NoError(t, err)
+	require.True(t, claimed, "the same unhealthy fingerprint must warn after a partial recovery write")
+	require.NoError(t, os.WriteFile(statePath, durableState, 0o600), "model the transient state-read failure recovering")
+	require.NoError(t, RollbackHookHealthWarningClaim(context.Background(), sessionID, unhealthy))
+	claimed, err = ClaimHookHealthWarning(context.Background(), sessionID, unhealthy)
+	require.NoError(t, err)
+	require.True(t, claimed, "failed warning output must remain retryable over stale durable state")
+}
+
 func TestLoadHookHealthWarningHintRejectsCorruptValue(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -455,9 +455,51 @@ The pre-push hook carries checkpoint data only when the push targets the
 elected remote; pushes to any other remote or to a raw URL sync nothing, on
 both the git-branch and git-refs backends (git-refs leaves its push queue
 intact for the next elected-remote push). The dedicated `checkpoint_remote`
-URL mode is exempt — it addresses a separate metadata store directly. `entire
-status` shows the sync destination and how many checkpoints have not reached
-it yet.
+URL mode is exempt — it addresses a separate metadata store directly.
+
+`entire status` reports checkpoint storage and checkpoint sync separately.
+Storage is the effective local backend (`git-branch` or `git-refs`), while the
+sync destination is the elected Git remote or dedicated checkpoint repository;
+one does not override the other. Status describes that destination as active
+only when the Git-hook integration can currently deliver all five checkpoint
+hooks. Text reports blocked or degraded delivery in place, and JSON retains the
+configured destination fields while adding `checkpoint_storage_backend`,
+`checkpoint_sync_state` (`ready`, `degraded`, or `blocked`), and the typed
+`git_hooks` health object.
+
+### Git Hook Delivery and Lefthook
+
+Entire normally owns five native Git wrappers: `prepare-commit-msg`,
+`commit-msg`, `post-commit`, `post-rewrite`, and `pre-push`. Repositories with
+one unambiguous Lefthook main configuration instead receive a clone-local
+participant configuration:
+
+- `lefthook-local.yml` marks the YAML nodes Entire inserts while preserving
+  unrelated local entries and comments;
+- `.lefthook-local/<hook>/entire.sh` contains the generated hook scripts;
+- both paths are ignored through an exact Entire-owned block in
+  `.git/info/exclude`.
+
+Entire never edits the shared Lefthook configuration or runs `lefthook install`.
+Installation is transactional. Until a Lefthook refresh takes ownership of the
+live hooks, Entire keeps native bridge wrappers active; after refresh, Lefthook
+invokes the same clone-local scripts. Uninstall removes only exact
+ownership-marked nodes, scripts, and exclude lines. Ambiguous managers or local
+configuration fail closed without replacing the working integration.
+
+Hook health is shared by setup, lifecycle, doctor, and status. SessionStart
+separately includes unhealthy delivery in its startup banner. TurnStart attempts
+repair; a failed repair remains fail-open for the agent workflow but is reported
+through the agent's native hook-response protocol with an `entire doctor`
+action. For TurnStart repair warnings, a stable failure fingerprint prevents
+repetition within the session and permits a new warning when the condition
+changes. Generated scripts guard binary availability. Every clone-local
+Lefthook script prints a concise missing-binary warning and skips cleanly;
+capture hooks remain fail-open. Native wrappers retain their quieter legacy
+behavior, where only `commit-msg` prints the missing-binary warning. `pre-push`
+also skips cleanly when the binary is absent, but propagates a non-zero exit
+from an available `entire hooks git pre-push` invocation so its blocking
+semantics are retained.
 
 A gated push is not fully silent: when checkpoints are waiting for the
 elected remote, the hook prints a two-line stderr hint naming the elected
@@ -864,6 +906,16 @@ Multiple AI sessions can run concurrently on the same base commit:
 2. **Both proceed** - User can continue; checkpoints interleave on the same shadow branch
 3. **Identification** - Each checkpoint is tagged with its session ID; `checkpoint list --pending` shows the session prompt
 4. **Condensation** - On commit, all sessions are condensed together with archived subfolders
+
+`entire status` is a read-only observer of this state. It does not finalize a
+session, condense a transcript, or rewrite session files when the owning agent
+has exited; the dedicated sweeper and doctor own those mutations. Until that
+cleanup persists an ended phase, status keeps the session in `active_sessions`
+and derives the display state `exited`. Text and JSON use the same complete
+collection, including multiple sessions from the same agent, sorted by most
+recent activity and then session ID. JSON includes session and worktree IDs,
+worktree path, branch, and available start/last-active timestamps so entries
+remain distinguishable.
 
 ### Conflict Handling
 

--- a/e2e/tests/lefthook_durable_test.go
+++ b/e2e/tests/lefthook_durable_test.go
@@ -1,0 +1,110 @@
+//go:build e2e
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/execx"
+	"github.com/entireio/cli/e2e/entire"
+	"github.com/entireio/cli/e2e/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLefthookRefreshKeepsAgentCommitCheckpointed exercises the user-visible
+// failure from issue #2264 end to end: Lefthook takes ownership of every live
+// Git hook after Entire was enabled, but the next commit of real agent work
+// must still be captured without requiring the user to run `entire status`
+// first.
+func TestLefthookRefreshKeepsAgentCommitCheckpointed(t *testing.T) {
+	testutil.ForEachAgent(t, 3*time.Minute, func(t *testing.T, s *testutil.RepoState, ctx context.Context) {
+		lefthookConfig := filepath.Join(s.Dir, "lefthook.yml")
+		require.NoError(t, os.WriteFile(lefthookConfig, []byte("pre-commit: {}\n"), 0o644))
+		s.Git(t, "add", "lefthook.yml")
+		s.Git(t, "commit", "-m", "Configure Lefthook")
+
+		// Re-enable after Lefthook appears so Entire creates its clone-local
+		// configuration and generated scripts while native hooks still bridge
+		// the transition.
+		entire.Enable(t, s.Dir, s.Agent.EntireAgent())
+		s.HeadBefore = testutil.GitOutput(t, s.Dir, "rev-parse", "HEAD")
+		s.CheckpointBefore = testutil.CheckpointState(s.Dir)
+		_, err := s.RunPrompt(t, ctx,
+			"create a markdown file at docs/lefthook-survives.md with a paragraph about hooks surviving. Do not commit the file. Do not ask for confirmation, just make the change. Do not use a worktree.")
+		require.NoError(t, err)
+		testutil.AssertFileExists(t, s.Dir, "docs/lefthook-survives.md")
+
+		// This overwrite is the last action before git add/commit. In particular,
+		// no Entire status or lifecycle command may repair the live hooks between
+		// the simulated Lefthook refresh and the commit under test.
+		hooksDir := testutil.GitOutput(t, s.Dir, "rev-parse", "--git-path", "hooks")
+		if !filepath.IsAbs(hooksDir) {
+			hooksDir = filepath.Join(s.Dir, hooksDir)
+		}
+		for _, hook := range []string{"prepare-commit-msg", "commit-msg", "post-commit", "post-rewrite", "pre-push"} {
+			require.NoError(t, os.WriteFile(
+				filepath.Join(hooksDir, hook),
+				[]byte(simulatedLefthookLauncher(hook)),
+				0o755,
+			))
+		}
+		s.Git(t, "add", "docs/lefthook-survives.md")
+		s.Git(t, "commit", "-m", "Verify Lefthook checkpoint")
+		testutil.AssertNewCommits(t, s, 1)
+		testutil.WaitForCheckpoint(t, s, 30*time.Second)
+		testutil.AssertCheckpointAdvanced(t, s)
+		checkpointID := testutil.AssertHasCheckpointTrailer(t, s.Dir, "HEAD")
+		testutil.AssertCheckpointExists(t, s.Dir, checkpointID)
+		testutil.WaitForNoShadowBranches(t, s.Dir, 10*time.Second)
+
+		// Inspect health only after the commit/checkpoint assertions above. This
+		// proves status observed the durable delivery; it could not have repaired
+		// the commit path being tested.
+		statusCmd := execx.NonInteractive(ctx, entire.BinPath(), "status", "--json")
+		statusCmd.Dir = s.Dir
+		statusOut, err := statusCmd.CombinedOutput()
+		require.NoError(t, err, "entire status --json failed: %s", statusOut)
+		var status struct {
+			CheckpointSyncState string `json:"checkpoint_sync_state"`
+			GitHooks            struct {
+				Mode  string `json:"mode"`
+				State string `json:"state"`
+			} `json:"git_hooks"`
+		}
+		require.NoError(t, json.Unmarshal(statusOut, &status))
+		require.Equal(t, "ready", status.CheckpointSyncState)
+		require.Equal(t, "lefthook", status.GitHooks.Mode)
+		require.Equal(t, "current", status.GitHooks.State)
+	})
+}
+
+// simulatedLefthookLauncher keeps the structure of a Lefthook v2 launcher but
+// dispatches directly to the clone-local script. That makes the test
+// deterministic and validates the same argv/stdin boundary without requiring a
+// separately installed Lefthook binary in every agent E2E environment.
+func simulatedLefthookLauncher(hook string) string {
+	return fmt.Sprintf(`#!/bin/sh
+
+if [ "$LEFTHOOK_VERBOSE" = "1" -o "$LEFTHOOK_VERBOSE" = "true" ]; then
+  set -x
+fi
+
+if [ "$LEFTHOOK" = "0" ]; then
+  exit 0
+fi
+
+call_lefthook()
+{
+  shift 2
+  sh ".lefthook-local/%s/entire.sh" "$@"
+}
+
+call_lefthook run "%s" "$@"
+`, hook, hook)
+}

--- a/redact/betterleaks_env_test.go
+++ b/redact/betterleaks_env_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -28,7 +29,7 @@ go 1.26.2
 
 require github.com/entireio/cli v0.0.0
 
-replace github.com/entireio/cli => ` + filepath.ToSlash(repoRoot) + `
+replace github.com/entireio/cli => ` + strconv.Quote(filepath.ToSlash(repoRoot)) + `
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goMod), 0o644); err != nil {
 		t.Fatalf("write go.mod: %v", err)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1284
<!-- entire-trail-link-end -->

## Problem

Issue #2264 reports that `entire status` says checkpoints sync to `origin` even when Entire git hooks are missing, so capture and push cannot happen. The immediate bug is a false healthy status; the underlying cause in the reproduction is Lefthook overwriting the Entire wrapper during `lefthook install -f` or an npm postinstall.

This PR addresses both layers: it makes status reflect actual hook delivery health, and it installs a durable Lefthook integration so refreshes do not silently remove checkpoint capture. It also emits lifecycle warnings when delivery is unhealthy, so users do not have to remember to run `entire status` to discover a failure. The session-listing and storage-versus-sync changes make the same status snapshot complete and unambiguous.

## Summary

- make native and Lefthook checkpoint-hook installation durable, ownership-aware, and transactional
- surface hook delivery failures proactively and share truthful health diagnostics across status and doctor
- separate storage from sync readiness and keep session reporting complete and read-only

## Verification

- mise run check
- real Codex OAuth E2E: TestLefthookRefreshKeepsAgentCommitCheckpointed
- real Claude Code OAuth E2E: TestLefthookRefreshKeepsAgentCommitCheckpointed
- independent implementation review approved with no remaining actionable findings

Fixes #2264

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Git hooks are installed, repaired, and reported across commits and push; mistakes could miss checkpoints or mislead sync readiness, but behavior is heavily tested and fails open on warnings.
> 
> **Overview**
> This PR makes Git hook health a first-class part of checkpoint capture and sync reporting, with durable **native** and **Lefthook** integrations that survive manager refreshes instead of waiting for the next agent turn.
> 
> **Hook integration:** `CheckGitHookIntegration` / `EnsureGitHookIntegration` / `RemoveGitHookIntegration` replace the older install-only checks. Lefthook repos get owned `lefthook-local` scripts and config; native hooks remain the bridge when wrappers are missing. `entire doctor`, enable/setup, and `EnsureSetup` all heal through the same coordinator and surface **DEGRADED** / manager-specific reasons.
> 
> **Lifecycle:** Turn start runs hook repair, emits a deduplicated `entire doctor` warning (fingerprinted in session state), and folds it into a single stdout payload for Claude/Codex JSON or a standalone plain-text path for Gemini (deferring context injection when both would collide). Session start can append the same warning to the banner.
> 
> **Status & sessions:** Text and JSON share `buildStatusSnapshot` with `checkpoint_sync_state` (`ready` / `degraded` / `blocked`), `git_hooks` health, and storage backend. Sync is not advertised as healthy when hooks are absent or broken. `entire status` lists every active session read-only (no stale cleanup or finalize-on-read) with richer JSON fields. **pre-push** accepts an optional remote URL argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598bc4f0112de79eb3f64705d9f476e62d5bc347. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
