### PR TITLE
Mark the active context the same way in both context tables

### DIFF
--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -139,44 +139,20 @@ func selectContextToUse(cmd *cobra.Command) (string, error) {
 	return selected, nil
 }
 
-// contextPickerTable lays the saved contexts out as the same aligned
-// CONTEXT/HANDLE/LOGIN SERVER columns `entire auth contexts` prints, returning
-// the header line and one option per context (valued by name, which is what
-// SetCurrentContext takes).
+// contextPickerTable lays the saved contexts out as the picker's rows: the
+// same table `entire auth contexts` prints, built by contextTableLines, with
+// each row valued by context name (which is what SetCurrentContext takes).
 //
 // The header is returned separately because it is not selectable: it goes in
-// the field description, above the options. Both are indented by
-// selectOptionIndent so the columns line up with the option text rather than
-// with huh's cursor.
+// the field description, above the options, indented by selectOptionIndent so
+// the columns line up with the option text rather than with huh's cursor.
 //
-// The active context is marked "(active)" in a trailing column rather than
-// with the table's leading "*". Two markers in the same place would read as
-// one: huh's "> " cursor already occupies the leading column and it *moves*,
-// while "(active)" states which context is in use — so the row you happen to
-// be sitting on would otherwise look like the current one.
-//
-// Labels carry no styling of their own. huh renders each row through its
-// selected/unselected option style, and a color embedded here would fight
-// that; the table's header/value styles are deliberately left to the
-// non-interactive listing.
+// Rows carry no styling. huh renders each through its selected/unselected
+// option style, and a color embedded here would fight it — so the styles go in
+// unset, which authTableStyles already treats as "render plain text".
 func contextPickerTable(all []*contexts.Context, current string) (string, []huh.Option[string]) {
-	header := []string{"CONTEXT", "HANDLE", "LOGIN SERVER", ""}
+	lines := contextTableLines(authTableStyles{}, all, current)
 
-	rows := make([][]string, 0, len(all))
-	for _, c := range all {
-		marker := ""
-		if c.Name == current {
-			marker = "(active)"
-		}
-		rows = append(rows, []string{
-			c.Name,
-			orDash(c.Handle),
-			orDash(c.CoreURL),
-			marker,
-		})
-	}
-
-	lines := alignTableLines(header, rows)
 	options := make([]huh.Option[string], 0, len(all))
 	for i, c := range all {
 		options = append(options, huh.NewOption(lines[i+1], c.Name))
@@ -248,35 +224,56 @@ func runAuthContexts(w io.Writer) error {
 	return nil
 }
 
-// renderContextsTable prints the saved login contexts as a styled, aligned
-// table with column headers. The active context is flagged with "*" in the
-// leading column. Purely local data — no network, no timestamps — so it
-// reuses the auth-table styles but only the header/name/value/accent slots.
-func renderContextsTable(w io.Writer, all []*contexts.Context, current string) {
-	sty := newAuthTableStyles(w)
+// activeContextMarker flags the context in use. It sits in a trailing column
+// in both the listing and the picker, rather than as a leading "*": huh draws
+// its cursor in the leading column and the cursor *moves*, so a marker there
+// would make whichever row you are sitting on read as the current one. The
+// listing follows the picker so the two render identically, and so the word
+// matches the one shell completion already appends.
+const activeContextMarker = "(active)"
 
+// contextTableLines lays the saved contexts out in aligned CONTEXT / HANDLE /
+// LOGIN SERVER columns, with activeContextMarker in a trailing column on the
+// context in use, and returns the header line followed by one line per
+// context.
+//
+// One function because `entire auth contexts` and the `entire auth use` picker
+// print the same table; they differ only in styling, and sty carries that. An
+// unset authTableStyles renders every cell plain, which is what the picker
+// passes.
+func contextTableLines(sty authTableStyles, all []*contexts.Context, current string) []string {
 	header := []string{
-		"", // active marker
 		sty.render(sty.header, "CONTEXT"),
 		sty.render(sty.header, "HANDLE"),
 		sty.render(sty.header, "LOGIN SERVER"),
+		"", // the marker column heads itself
 	}
 
 	rows := make([][]string, 0, len(all))
 	for _, c := range all {
-		marker := " "
+		marker := ""
 		name := sty.render(sty.value, c.Name)
 		if c.Name == current {
-			marker = sty.render(sty.id, "*")
+			marker = sty.render(sty.id, activeContextMarker)
 			name = sty.render(sty.name, c.Name)
 		}
 		rows = append(rows, []string{
-			marker,
 			name,
 			sty.render(sty.value, orDash(c.Handle)),
 			sty.render(sty.value, orDash(c.CoreURL)),
+			marker,
 		})
 	}
 
-	renderAlignedTable(w, header, rows)
+	return alignTableLines(header, rows)
+}
+
+// renderContextsTable prints the saved login contexts as a styled, aligned
+// table with column headers. Purely local data — no network, no timestamps —
+// so it reuses the auth-table styles but only the header/name/value/accent
+// slots.
+func renderContextsTable(w io.Writer, all []*contexts.Context, current string) {
+	for _, line := range contextTableLines(newAuthTableStyles(w), all, current) {
+		fmt.Fprintln(w, line)
+	}
 }

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -181,8 +181,8 @@ func TestRunAuthContexts(t *testing.T) {
 			t.Fatalf("listing = %q, want column header %q", got, hdr)
 		}
 	}
-	if !strings.Contains(got, "*") {
-		t.Fatalf("listing = %q, want an active-context marker", got)
+	if !strings.Contains(got, activeContextMarker) {
+		t.Fatalf("listing = %q, want the active context flagged %q", got, activeContextMarker)
 	}
 	if !strings.Contains(got, "core.example.com") {
 		t.Fatalf("listing = %q, want context core.example.com", got)
@@ -485,6 +485,42 @@ func TestContextPickerTable_ColumnsAlign(t *testing.T) {
 		got := columnOffsets(opt.Key)
 		if len(got) < 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
 			t.Errorf("row %q starts columns at %v, want the header's %v", opt.Key, got, want)
+		}
+	}
+}
+
+// TestContextTableMatchesPicker pins what one builder buys: `entire auth
+// contexts` and the `entire auth use` picker print the same table, down to the
+// column widths and the trailing "(active)". A column added to one cannot go
+// missing from the other, and the marker cannot drift back to two spellings.
+// The picker's rows are indented by huh's cursor gutter; nothing else differs.
+func TestContextTableMatchesPicker(t *testing.T) {
+	t.Parallel()
+
+	all := []*contexts.Context{
+		{Name: "prod", Handle: "alice", CoreURL: "https://core-a.example.com"},
+		{Name: "staging", Handle: "bob", CoreURL: "https://a-much-longer-login-server.example.com"},
+		{Name: "bare"},
+	}
+
+	// A bytes.Buffer is not a terminal, so the listing renders unstyled — the
+	// only difference the picker's rows would otherwise have.
+	var listing bytes.Buffer
+	renderContextsTable(&listing, all, "staging")
+	want := strings.Split(strings.TrimRight(listing.String(), "\n"), "\n")
+
+	header, options := contextPickerTable(all, "staging")
+	got := []string{strings.TrimPrefix(header, selectOptionIndent)}
+	for _, opt := range options {
+		got = append(got, opt.Key)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("picker rendered %d lines, listing %d:\npicker:  %q\nlisting: %q", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d:\npicker  = %q\nlisting = %q", i, got[i], want[i])
 		}
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1287
<!-- entire-trail-link-end -->

Stacked on #2326.

`entire auth contexts` flagged the active context with a leading `*` while the `entire auth use` picker (added in #2326) used a trailing `(active)`. Two renderings of the same three columns, disagreeing about where the marker lives and what it says — and shell completion already appends `(active)`, so `*` was the odd one out of the three surfaces.

The listing now follows the picker:

```
$ entire auth contexts                    entire auth use
CONTEXT     HANDLE  LOGIN SERVER            CONTEXT     HANDLE  LOGIN SERVER
entire-io   victor  https://…               entire-io   victor  https://…
staging-eu  -       https://…  (active)   > staging-eu  -       https://…  (active)
local       dev     -                       local       dev     -
```

Identical apart from huh's cursor gutter.

### Why the trailing column

It is what the picker needs: huh draws its cursor in the leading column and the cursor *moves*, so a marker there makes whichever row you are sitting on read as the current one. The listing has no cursor and could keep `*`, but then it stays a second spelling of one fact.

### One table, not two

`contextTableLines` is now the only place these columns are built. Both callers pass an `authTableStyles`, which already renders plain text when color is off, so the picker gets its unstyled rows by passing an unset one rather than keeping its own copy of the column list. `TestContextTableMatchesPicker` compares the two renderings line for line, so a column added to one cannot go missing from the other, and the marker cannot drift back to two spellings.

### Trade-off

Stated because it is real: `*` in a leading column is the convention for this table (`kubectl config get-contexts`, `git branch`) and scans faster down a long list than a word at a ragged right edge, since the marker's start moves with the widest LOGIN SERVER. This is a deliberate choice of consistency across the three surfaces over that convention.

### Verification

`mise run check` (fmt, lint, unit + integration + Vogon canary) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only display and refactor with no auth, persistence, or network behavior changes; regression coverage locks listing and picker parity.
> 
> **Overview**
> **Unifies how the active login context is shown** across `entire auth contexts`, the `entire auth use` picker, and shell completion: the listing no longer uses a leading `*`, and both surfaces now share a trailing **`(active)`** marker via `activeContextMarker`.
> 
> **Refactors table rendering** so one helper, **`contextTableLines`**, builds the aligned CONTEXT / HANDLE / LOGIN SERVER rows (with optional styling through `authTableStyles`). The picker passes an unset style for plain huh rows; the listing uses `newAuthTableStyles(w)` and prints each line. **`contextPickerTable`** drops its duplicate column assembly and calls the shared builder.
> 
> **Tests** assert the listing contains `(active)` instead of `*`, and **`TestContextTableMatchesPicker`** line-compares listing output to picker rows so columns and the marker cannot diverge again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ea807af4ab80a1a7cc6b9e4bc6de8a2c88ba651. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->