### PR TITLE
perf(redact): bound duplicate-key scan cost

### DIFF
--- a/redact/jsonl_splice_verify_test.go
+++ b/redact/jsonl_splice_verify_test.go
@@ -1,6 +1,7 @@
 package redact
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -129,6 +130,24 @@ func TestJSONLContent_SingleJSONValueDuplicateKeyIsRebuilt(t *testing.T) {
 	got, err := JSONLContent(content)
 	require.NoError(t, err)
 	assert.NotContains(t, got, highEntropySecret)
+}
+
+func TestJSONLContent_RedactsSecretShadowedByPreMigrationDuplicateKey(t *testing.T) {
+	t.Parallel()
+
+	fields := []string{`"k0":"` + highEntropySecret + `"`}
+	for i := 1; i < 25; i++ {
+		fields = append(fields, fmt.Sprintf(`"k%d":"filler %d"`, i, i))
+	}
+	assert.False(t, hasDuplicateJSONKeys("{"+strings.Join(fields, ",")+"}"))
+
+	fields = append(fields, `"k0":"safe"`)
+	line := "{" + strings.Join(fields, ",") + "}"
+
+	got, err := JSONLContent(line)
+	require.NoError(t, err)
+	assert.NotContains(t, got, highEntropySecret)
+	assert.Contains(t, got, `"k0":"safe"`)
 }
 
 func TestJSONLContent_RedactsNULAmbiguousReplacementPairs(t *testing.T) {

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -1152,10 +1152,13 @@ func hasDuplicateJSONKeys(s string) bool {
 }
 
 // tokenStreamHasDuplicateKeys consumes exactly one JSON value from dec,
-// recursing through containers. Per-object keys are compared through a small
-// slice rather than a map: transcript objects carry a handful of keys, and a
-// map allocation per object would be paid on every parsed line.
+// recursing through containers. Per-object keys stay in a small slice until an
+// object exceeds duplicateKeySliceThreshold: transcript objects usually carry
+// only a handful of keys, so allocating a map for every object would tax every
+// parsed line, while a slice alone becomes quadratic for wide tool output.
 func tokenStreamHasDuplicateKeys(dec *json.Decoder) bool {
+	const duplicateKeySliceThreshold = 16
+
 	t, err := dec.Token()
 	if err != nil {
 		return false
@@ -1166,7 +1169,10 @@ func tokenStreamHasDuplicateKeys(dec *json.Decoder) bool {
 	}
 	switch d {
 	case '{':
-		var seen []string
+		var (
+			seenSlice []string
+			seenMap   map[string]struct{}
+		)
 		for dec.More() {
 			kt, err := dec.Token()
 			if err != nil {
@@ -1176,10 +1182,26 @@ func tokenStreamHasDuplicateKeys(dec *json.Decoder) bool {
 			if !ok {
 				return false
 			}
-			if slices.Contains(seen, k) {
-				return true
+			if seenMap != nil {
+				if _, duplicate := seenMap[k]; duplicate {
+					return true
+				}
+				seenMap[k] = struct{}{}
+			} else {
+				if slices.Contains(seenSlice, k) {
+					return true
+				}
+				if len(seenSlice) == duplicateKeySliceThreshold {
+					seenMap = make(map[string]struct{}, len(seenSlice)+1)
+					for _, seenKey := range seenSlice {
+						seenMap[seenKey] = struct{}{}
+					}
+					seenMap[k] = struct{}{}
+					seenSlice = nil
+				} else {
+					seenSlice = append(seenSlice, k)
+				}
 			}
-			seen = append(seen, k)
 			if tokenStreamHasDuplicateKeys(dec) {
 				return true
 			}

--- a/redact/redact_bench_test.go
+++ b/redact/redact_bench_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -30,6 +31,30 @@ func BenchmarkRedactStringRepeatedSecret(b *testing.B) {
 			for b.Loop() {
 				if got := String(input); got != want {
 					b.Fatal("redacted output did not match expected request log")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkJSONLContent_WideObject pins duplicate-key scanning across object
+// widths. Wide objects occur in tool results such as npm ls output, coverage
+// reports, and flattened configuration dumps. Null values deliberately isolate
+// key scanning from the per-string regex layers; the existing JSONL benchmarks
+// cover realistic string-heavy redaction throughput.
+func BenchmarkJSONLContent_WideObject(b *testing.B) {
+	for _, keys := range []int{200, 2_000, 8_000} {
+		b.Run(fmt.Sprintf("Keys%d", keys), func(b *testing.B) {
+			input := generateBenchmarkWideObject(keys)
+			b.ReportAllocs()
+			b.SetBytes(int64(len(input)))
+			for b.Loop() {
+				got, err := JSONLContent(input)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if got != input {
+					b.Fatal("redaction changed secret-free input")
 				}
 			}
 		})
@@ -92,6 +117,22 @@ func BenchmarkRedactJSONLBytes(b *testing.B) {
 			}
 		})
 	}
+}
+
+func generateBenchmarkWideObject(keys int) string {
+	var out strings.Builder
+	out.Grow(keys * 20)
+	out.WriteByte('{')
+	for i := range keys {
+		if i > 0 {
+			out.WriteByte(',')
+		}
+		out.WriteString(`"key_`)
+		out.WriteString(strconv.Itoa(i))
+		out.WriteString(`":null`)
+	}
+	out.WriteByte('}')
+	return out.String()
 }
 
 func readBenchmarkFixture(b *testing.B, path string) []byte {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1288
<!-- entire-trail-link-end -->

## Summary

- keep duplicate-key detection allocation-light for ordinary JSON objects by retaining the slice path through 16 keys
- lazily migrate all seen keys to a map for wide objects, removing the quadratic tail introduced by #2321
- add end-to-end coverage for both migration correctness directions: no false positive for a unique wide object, and no missed pre-migration duplicate that could expose a shadowed secret
- add committed 200 / 2,000 / 8,000-key benchmarks, with null values deliberately isolating key-scan scaling

The duplicate-key scan remains unconditional. `encoding/json` drops shadowed values even when no replacement is collected, so gating the scan would reopen the leak for the roughly 6% common-case saving.

## Performance

The regression that prompted this follow-up made a 50,000-key object take 1.53s instead of 0.16s (9.5x). With the hybrid set, benchmark throughput stays flat as object width grows.

## Validation

- `mise run fmt`
- `mise run lint`
- `mise run test:ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path duplicate-key detection used before structural rebuild; incorrect migration logic could miss duplicates and leak shadowed secrets in certified JSONL output.
> 
> **Overview**
> **Bounds duplicate-key scan cost** for JSONL redaction while keeping the scan unconditional on every parsed line/object.
> 
> `tokenStreamHasDuplicateKeys` now tracks object keys in a slice for the first **16** unique keys, then **lazily promotes** to a `map` so wide tool-output objects (thousands of keys) avoid the quadratic `slices.Contains` tail from the prior slice-only approach. Small transcript objects stay allocation-light.
> 
> Adds **`TestJSONLContent_RedactsSecretShadowedByPreMigrationDuplicateKey`** to ensure a duplicate that appears only after the slice path would have filled still forces structural rebuild and strips a shadowed high-entropy secret. Adds **`BenchmarkJSONLContent_WideObject`** (200 / 2k / 8k null-valued keys) to pin scaling of key scanning separate from string redaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dbecb9c00784eb3b422e6ea043d5a37b346b0b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->