### PR TITLE
cursor: install the cmd.exe hook wrappers on Windows, and tolerate a BOM on hook input

### DIFF
--- a/cmd/entire/cli/agent/cursor/hooks.go
+++ b/cmd/entire/cli/agent/cursor/hooks.go
@@ -62,6 +62,52 @@ func cursorHookConfig(ctx context.Context) (*agent.HookConfigFile, error) {
 	return agent.OpenHookConfig(worktreeRoot, (&CursorAgent{}).HookConfigRelPath()) //nolint:wrapcheck // agent.HookConfigFile already names the file in its error
 }
 
+// hookCommandPrefix is what every hook command Entire writes for Cursor begins
+// with; the verb is one of the HookName* constants.
+const hookCommandPrefix = "entire hooks cursor "
+
+// silentHookCommand wraps one hook verb in the silent production wrapper for
+// this host.
+//
+// Cursor runs every hook command through **PowerShell** on Windows — not
+// cmd.exe. Read out of the shipped builds (Cursor IDE 3.19.19 win32/x64, and
+// the native cursor-agent CLI windows/x64 2026.09.08-6caf4ff), the spawn is
+// `<pwsh|powershell> [-NoProfile -NonInteractive -ExecutionPolicy Bypass] -c
+// "$OutputEncoding = [System.Text.Encoding]::UTF8; Get-Content -LiteralPath
+// '<tmp>\cursor-hook-payload-*.json' -Raw | & { $input | <command> }"`, with the
+// stored command inserted verbatim. Both Windows runners read the same
+// .cursor/hooks.json, and both compose that identically.
+//
+// So the sh wrapper is not mangled the way droid's is: PowerShell single quotes
+// are literal, and the whole script reaches sh as one argument. It fails for a
+// different reason — `sh` has to resolve in the PATH of the PowerShell child
+// Cursor spawns, and agent.UseWindowsProductionHooks probes for sh in the
+// `entire enable` process instead. Git for Windows installs sh.exe under
+// …\Git\usr\bin and …\Git\bin, neither of which is on the machine PATH (only
+// …\Git\cmd is), while MSYS translates PATH for native children — so running
+// `entire enable` from Git Bash passes the probe and writes a wrapper Cursor
+// cannot run. That is issue #1424's reported environment (Windows 11 + Git
+// Bash), and no stronger probe COMMAND fixes it, because the probe is measuring
+// the wrong process. Hence agent.HookHostIsWindows rather than the probe.
+//
+// The failure is invisible rather than swallowed: a CommandNotFoundException
+// raised inside `& { $input | … }` does not set powershell.exe's exit code, so
+// Cursor sees exit 0 and has no error to report. The same command standalone
+// exits 1. TestWindowsWrappers_CursorComposition asserts this on a real Windows
+// runner — the sh-wrapper subtest is exactly this case.
+//
+// This moves the PATH dependency rather than removing it — the wrapper opens
+// with `where.exe entire`, so it needs `entire` on the child's PATH, which every
+// documented install method satisfies and Git for Windows' sh does not.
+//
+// Not fixed by any wrapper: the cursor-agent CLI picks a bash shell executor
+// whenever MSYSTEM is set (i.e. started from Git Bash) while still composing the
+// PowerShell script above, so hooks cannot run there at all. That is Cursor's to
+// fix, and it does not affect the IDE.
+func silentHookCommand(verb string, useWindows bool) string {
+	return agent.WrapProductionSilentHookCommandForOS(hookCommandPrefix+verb, useWindows)
+}
+
 // InstallHooks installs Cursor hooks in .cursor/hooks.json.
 // If force is true, removes existing Entire hooks before installing.
 // Returns the number of hooks installed.
@@ -120,33 +166,24 @@ func (c *CursorAgent) InstallHooks(ctx context.Context, force bool) (int, error)
 		subagentStop = removeEntireHooks(subagentStop)
 	}
 
-	// Define hook commands
-	const cmdPrefix = "entire hooks cursor "
-
-	// Cursor spawns hook commands through the native OS shell (cmd.exe on
-	// Windows), so a `sh -c '…'` wrapper silently fails to launch on a
-	// Windows host without a working POSIX sh — no hook fires and, because
-	// this is the *silent* wrapper, no error surfaces (issue #1424).
-	// UseWindowsProductionHooks probes for a runnable sh and only swaps in
-	// the native cmd.exe wrapper when one is absent, so this is a no-op on
-	// hosts (incl. all non-Windows) where the sh wrapper already works.
-	useWindowsHooks := agent.UseWindowsProductionHooks(ctx)
-	sessionStartCmd := agent.WrapProductionSilentHookCommandForOS(cmdPrefix+HookNameSessionStart, useWindowsHooks)
-	sessionEndCmd := agent.WrapProductionSilentHookCommandForOS(cmdPrefix+HookNameSessionEnd, useWindowsHooks)
-	beforeSubmitPromptCmd := agent.WrapProductionSilentHookCommandForOS(cmdPrefix+HookNameBeforeSubmitPrompt, useWindowsHooks)
-	stopCmd := agent.WrapProductionSilentHookCommandForOS(cmdPrefix+HookNameStop, useWindowsHooks)
-	preCompactCmd := agent.WrapProductionSilentHookCommandForOS(cmdPrefix+HookNamePreCompact, useWindowsHooks)
-	subagentStartCmd := agent.WrapProductionSilentHookCommandForOS(cmdPrefix+HookNameSubagentStart, useWindowsHooks)
-	subagentEndCmd := agent.WrapProductionSilentHookCommandForOS(cmdPrefix+HookNameSubagentStop, useWindowsHooks)
+	// Define hook commands. See silentHookCommand for why the host alone
+	// decides the wrapper.
+	useWindowsHooks := agent.HookHostIsWindows()
+	sessionStartCmd := silentHookCommand(HookNameSessionStart, useWindowsHooks)
+	sessionEndCmd := silentHookCommand(HookNameSessionEnd, useWindowsHooks)
+	beforeSubmitPromptCmd := silentHookCommand(HookNameBeforeSubmitPrompt, useWindowsHooks)
+	stopCmd := silentHookCommand(HookNameStop, useWindowsHooks)
+	preCompactCmd := silentHookCommand(HookNamePreCompact, useWindowsHooks)
+	subagentStartCmd := silentHookCommand(HookNameSubagentStart, useWindowsHooks)
+	subagentEndCmd := silentHookCommand(HookNameSubagentStop, useWindowsHooks)
 
 	count := 0
 
 	// Sync each hook to its desired command. syncEntireHook replaces any
 	// stale-form Entire hook (e.g. an sh-wrapped entry from a previous install)
-	// with the current command even without --force, so a wrapper-form change —
-	// notably the sh↔cmd.exe migration driven by UseWindowsProductionHooks when
-	// a Windows host gains or loses a working POSIX sh — cleanly replaces rather
-	// than leaving a dead duplicate entry that could double-fire (issue #1424).
+	// with the current command even without --force, so the sh→cmd.exe migration
+	// on an already-enabled Windows repo cleanly replaces rather than leaving a
+	// dead duplicate entry that could double-fire (issue #1424).
 	staleDropped := false
 	var dropped bool
 	sessionStart, count, dropped = syncEntireHook(sessionStart, sessionStartCmd, count)

--- a/cmd/entire/cli/agent/cursor/hooks_test.go
+++ b/cmd/entire/cli/agent/cursor/hooks_test.go
@@ -58,78 +58,68 @@ func TestInstallHooks_FreshInstall(t *testing.T) {
 	}
 
 	// Verify commands
-	assertEntryCommand(t, hooksFile.Hooks.Stop, agent.WrapProductionSilentHookCommand("entire hooks cursor stop"))
-	assertEntryCommand(t, hooksFile.Hooks.SessionStart, agent.WrapProductionSilentHookCommand("entire hooks cursor session-start"))
-	assertEntryCommand(t, hooksFile.Hooks.BeforeSubmitPrompt, agent.WrapProductionSilentHookCommand("entire hooks cursor before-submit-prompt"))
-	assertEntryCommand(t, hooksFile.Hooks.PreCompact, agent.WrapProductionSilentHookCommand("entire hooks cursor pre-compact"))
-	assertEntryCommand(t, hooksFile.Hooks.SubagentStart, agent.WrapProductionSilentHookCommand("entire hooks cursor subagent-start"))
-	assertEntryCommand(t, hooksFile.Hooks.SubagentStop, agent.WrapProductionSilentHookCommand("entire hooks cursor subagent-stop"))
+	assertEntryCommand(t, hooksFile.Hooks.Stop, cursorHookCommand(HookNameStop))
+	assertEntryCommand(t, hooksFile.Hooks.SessionStart, cursorHookCommand(HookNameSessionStart))
+	assertEntryCommand(t, hooksFile.Hooks.BeforeSubmitPrompt, cursorHookCommand(HookNameBeforeSubmitPrompt))
+	assertEntryCommand(t, hooksFile.Hooks.PreCompact, cursorHookCommand(HookNamePreCompact))
+	assertEntryCommand(t, hooksFile.Hooks.SubagentStart, cursorHookCommand(HookNameSubagentStart))
+	assertEntryCommand(t, hooksFile.Hooks.SubagentStop, cursorHookCommand(HookNameSubagentStop))
 }
 
-// TestInstallHooks_WindowsProbeSuccessKeepsShWrappers verifies that on a
-// Windows host where a POSIX sh is runnable, Cursor keeps the sh-based wrappers
-// (parity with non-Windows). Mutates the shared probe, so no t.Parallel().
-func TestInstallHooks_WindowsProbeSuccessKeepsShWrappers(t *testing.T) {
-	t.Cleanup(agent.SetWindowsHookProbeForTesting("windows", func(context.Context, string) bool {
-		return true // sh works
-	}))
+// TestInstallHooks_WindowsInstallsCmdWrappersWhateverTheProbeSays is the
+// regression test for the gate change: on a Windows host Cursor installs the
+// native cmd.exe wrappers, and a runnable POSIX sh does not change that.
+//
+// The probe is driven both ways precisely because its answer must not matter.
+// It reports whether sh runs in THIS process; the hook runs in a PowerShell
+// Cursor spawns, whose PATH is a different thing entirely — see
+// silentHookCommand. Mutates the shared probe, so no t.Parallel().
+func TestInstallHooks_WindowsInstallsCmdWrappersWhateverTheProbeSays(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		shWorks bool
+	}{
+		{"sh runs in this process", true},
+		{"no runnable sh", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(agent.SetWindowsHookProbeForTesting("windows", func(context.Context, string) bool {
+				return tc.shWorks
+			}))
 
-	tempDir := t.TempDir()
-	// Installing hooks anchors a process-wide os.Root on the worktree root
-	// (worktreedir.OpenAt -> osroot.Shared), which is never closed. Windows
-	// cannot remove a directory while a handle to it is open, so the registry
-	// must be closed before t.TempDir's RemoveAll — t.Cleanup is LIFO, and
-	// TempDir registered its removal first, so this runs before it.
-	t.Cleanup(osroot.ResetShared)
-	t.Chdir(tempDir)
+			tempDir := t.TempDir()
+			// Installing hooks anchors a process-wide os.Root on the worktree root
+			// (worktreedir.OpenAt -> osroot.Shared), which is never closed. Windows
+			// cannot remove a directory while a handle to it is open, so the registry
+			// must be closed before t.TempDir's RemoveAll — t.Cleanup is LIFO, and
+			// TempDir registered its removal first, so this runs before it.
+			t.Cleanup(osroot.ResetShared)
+			t.Chdir(tempDir)
 
-	ag := &CursorAgent{}
-	if _, err := ag.InstallHooks(context.Background(), false); err != nil {
-		t.Fatalf("InstallHooks() error = %v", err)
+			ag := &CursorAgent{}
+			if _, err := ag.InstallHooks(context.Background(), false); err != nil {
+				t.Fatalf("InstallHooks() error = %v", err)
+			}
+
+			hooksFile := readHooksFile(t, tempDir)
+			assertEntryCommand(t, hooksFile.Hooks.SessionStart, cursorWindowsHookCommand(HookNameSessionStart))
+			assertEntryCommand(t, hooksFile.Hooks.Stop, cursorWindowsHookCommand(HookNameStop))
+			assertEntryCommand(t, hooksFile.Hooks.SubagentStop, cursorWindowsHookCommand(HookNameSubagentStop))
+		})
 	}
-
-	hooksFile := readHooksFile(t, tempDir)
-	assertEntryCommand(t, hooksFile.Hooks.SessionStart, agent.WrapProductionSilentHookCommand("entire hooks cursor session-start"))
-	assertEntryCommand(t, hooksFile.Hooks.Stop, agent.WrapProductionSilentHookCommand("entire hooks cursor stop"))
 }
 
-// TestInstallHooks_WindowsProbeFailureUsesCmdWrappers verifies that on a Windows
-// host with no runnable POSIX sh, Cursor installs the native cmd.exe wrappers so
-// hooks actually fire (issue #1424). Mutates the shared probe, so no t.Parallel().
-func TestInstallHooks_WindowsProbeFailureUsesCmdWrappers(t *testing.T) {
-	t.Cleanup(agent.SetWindowsHookProbeForTesting("windows", func(context.Context, string) bool {
-		return false // no working sh
-	}))
-
-	tempDir := t.TempDir()
-	// Installing hooks anchors a process-wide os.Root on the worktree root
-	// (worktreedir.OpenAt -> osroot.Shared), which is never closed. Windows
-	// cannot remove a directory while a handle to it is open, so the registry
-	// must be closed before t.TempDir's RemoveAll — t.Cleanup is LIFO, and
-	// TempDir registered its removal first, so this runs before it.
-	t.Cleanup(osroot.ResetShared)
-	t.Chdir(tempDir)
-
-	ag := &CursorAgent{}
-	if _, err := ag.InstallHooks(context.Background(), false); err != nil {
-		t.Fatalf("InstallHooks() error = %v", err)
-	}
-
-	hooksFile := readHooksFile(t, tempDir)
-	assertEntryCommand(t, hooksFile.Hooks.SessionStart, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor session-start"))
-	assertEntryCommand(t, hooksFile.Hooks.Stop, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor stop"))
-	assertEntryCommand(t, hooksFile.Hooks.SubagentStop, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor subagent-stop"))
-}
-
-// TestInstallHooks_WindowsProbeFlipMigratesCleanly verifies that when a host's
-// sh availability changes between installs, a non-force reinstall REPLACES the
-// stale sh-wrapped hooks with cmd.exe ones rather than leaving both (which would
-// double-fire). Mirrors the codex migration test. Mutates the shared probe, so
-// no t.Parallel().
-func TestInstallHooks_WindowsProbeFlipMigratesCleanly(t *testing.T) {
-	shWorks := true
-	t.Cleanup(agent.SetWindowsHookProbeForTesting("windows", func(context.Context, string) bool {
-		return shWorks
+// TestInstallHooks_WindowsMigratesShWrappers verifies that a repo enabled
+// before this change — carrying sh-wrapped hooks — is migrated by a non-force
+// reinstall on a Windows host, rather than gaining a second entry beside the
+// stale one. Two entries for one hook type double-fire, which is why the count
+// is asserted per type and not just the command.
+//
+// The sh config is seeded by installing as a non-Windows host, which is exactly
+// what wrote it. Mutates the shared probe, so no t.Parallel().
+func TestInstallHooks_WindowsMigratesShWrappers(t *testing.T) {
+	t.Cleanup(agent.SetWindowsHookProbeForTesting("linux", func(context.Context, string) bool {
+		return true
 	}))
 
 	tempDir := t.TempDir()
@@ -142,13 +132,18 @@ func TestInstallHooks_WindowsProbeFlipMigratesCleanly(t *testing.T) {
 	t.Chdir(tempDir)
 	ag := &CursorAgent{}
 
-	// First install with a working sh → sh-based wrappers.
+	// Seed the sh-wrapped config an earlier version installed.
 	if _, err := ag.InstallHooks(context.Background(), false); err != nil {
-		t.Fatalf("first InstallHooks() error = %v", err)
+		t.Fatalf("seed InstallHooks() error = %v", err)
 	}
+	assertEntryCommand(t, readHooksFile(t, tempDir).Hooks.Stop,
+		agent.WrapProductionSilentHookCommand("entire hooks cursor "+HookNameStop))
 
-	// sh stops working; reinstall WITHOUT force.
-	shWorks = false
+	// Same repo, now on a Windows host; reinstall WITHOUT force.
+	restore := agent.SetWindowsHookProbeForTesting("windows", func(context.Context, string) bool {
+		return true
+	})
+	t.Cleanup(restore)
 	if _, err := ag.InstallHooks(context.Background(), false); err != nil {
 		t.Fatalf("second InstallHooks() error = %v", err)
 	}
@@ -161,7 +156,7 @@ func TestInstallHooks_WindowsProbeFlipMigratesCleanly(t *testing.T) {
 	if len(hooksFile.Hooks.SessionStart) != 1 {
 		t.Errorf("SessionStart hooks = %d after wrapper migration, want 1 (no duplicate)", len(hooksFile.Hooks.SessionStart))
 	}
-	assertEntryCommand(t, hooksFile.Hooks.Stop, agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor stop"))
+	assertEntryCommand(t, hooksFile.Hooks.Stop, cursorWindowsHookCommand(HookNameStop))
 
 	// No sh-based Entire wrapper may survive the migration.
 	data, err := os.ReadFile(filepath.Join(tempDir, ".cursor", HooksFileName))
@@ -345,14 +340,14 @@ func TestInstallHooks_PreservesExistingHooks(t *testing.T) {
 		t.Errorf("Stop hooks = %d, want 2 (user + entire)", len(hooksFile.Hooks.Stop))
 	}
 	assertEntryCommand(t, hooksFile.Hooks.Stop, "echo user hook")
-	assertEntryCommand(t, hooksFile.Hooks.Stop, agent.WrapProductionSilentHookCommand("entire hooks cursor stop"))
+	assertEntryCommand(t, hooksFile.Hooks.Stop, cursorHookCommand(HookNameStop))
 
 	// SubagentStop should have user Write hook + Entire hook
 	if len(hooksFile.Hooks.SubagentStop) != 2 {
 		t.Errorf("SubagentStop hooks = %d, want 2 (user Write + Entire)", len(hooksFile.Hooks.SubagentStop))
 	}
 	assertEntryWithMatcher(t, hooksFile.Hooks.SubagentStop, "Write", "echo file written")
-	assertEntryCommand(t, hooksFile.Hooks.SubagentStop, agent.WrapProductionSilentHookCommand("entire hooks cursor subagent-stop"))
+	assertEntryCommand(t, hooksFile.Hooks.SubagentStop, cursorHookCommand(HookNameSubagentStop))
 }
 
 func TestInstallHooks_ReplacesLegacyLocalDevHook(t *testing.T) {
@@ -363,7 +358,7 @@ func TestInstallHooks_ReplacesLegacyLocalDevHook(t *testing.T) {
 
 	testutil.AssertLegacyHookReplaced(t,
 		filepath.Join(tempDir, ".cursor", HooksFileName),
-		agent.WrapProductionSilentHookCommandForOS("entire hooks cursor stop", agent.UseWindowsProductionHooks(ctx)),
+		cursorHookCommand(HookNameStop),
 		testutil.LegacyLocalDevCommand("hooks cursor stop"),
 		func() {
 			if _, err := ag.InstallHooks(ctx, false); err != nil {
@@ -441,7 +436,7 @@ func TestInstallHooks_PreservesUnknownFields(t *testing.T) {
 		t.Errorf("stop hooks = %d, want 2 (user + entire)", len(stopHooks))
 	}
 	assertEntryCommand(t, stopHooks, "echo user stop")
-	assertEntryCommand(t, stopHooks, agent.WrapProductionSilentHookCommand("entire hooks cursor stop"))
+	assertEntryCommand(t, stopHooks, cursorHookCommand(HookNameStop))
 }
 
 func TestUninstallHooks_PreservesUnknownFields(t *testing.T) {
@@ -553,6 +548,22 @@ func writeHooksFile(t *testing.T, tempDir string, hooksFile CursorHooksFile) {
 	}
 }
 
+// cursorHookCommand is the silent hook command InstallHooks writes on THIS
+// host. Assertions use it so the suite passes on a Windows host, where the
+// installed wrapper is the cmd.exe one.
+func cursorHookCommand(verb string) string {
+	return silentHookCommand(verb, agent.HookHostIsWindows())
+}
+
+// cursorWindowsHookCommand states the Windows wrapper outright rather than
+// delegating to silentHookCommand. It is the only assertion pinning the
+// `entire hooks cursor <verb>` prefix and every verb: cursorHookCommand asks
+// the implementation what it writes, so it cannot catch the prefix changing.
+// Do not collapse the two.
+func cursorWindowsHookCommand(verb string) string {
+	return agent.WrapWindowsProductionSilentHookCommand("entire hooks cursor " + verb)
+}
+
 func assertEntryCommand(t *testing.T, entries []CursorHookEntry, command string) {
 	t.Helper()
 	for _, entry := range entries {
@@ -583,7 +594,7 @@ func TestInstallHooks_DropsLegacyHookAlongsideCurrent(t *testing.T) {
 	ag := &CursorAgent{}
 
 	configPath := filepath.Join(tempDir, ".cursor", HooksFileName)
-	current := agent.WrapProductionSilentHookCommandForOS("entire hooks cursor stop", agent.UseWindowsProductionHooks(ctx))
+	current := cursorHookCommand(HookNameStop)
 	legacy := testutil.LegacyLocalDevCommand("hooks cursor stop")
 
 	testutil.AssertStaleHookDroppedAlongsideCurrent(t, configPath, current, legacy,
@@ -617,6 +628,14 @@ func TestInstallHooks_DropsLegacyHookAlongsideCurrent(t *testing.T) {
 // InstallHooks writes. A stale committed config is how the pi extension ended up
 // invoking a launcher script that had been deleted.
 func TestCommittedDogfoodHooksIsCurrent(t *testing.T) {
+	// The committed file can only carry one wrapper form, and it carries the sh
+	// one — correct for this repo's own CI, which runs on Linux and macOS. On a
+	// Windows host InstallHooks writes the cmd.exe form, so the comparison would
+	// fail on a difference that is the intended behaviour. Codex has the same
+	// condition for the same reason.
+	if agent.HookHostIsWindows() {
+		t.Skip("committed .cursor/hooks.json holds the sh wrappers; a Windows host installs the cmd.exe ones")
+	}
 	testutil.AssertCommittedDogfoodConfigStable(t, ".cursor/hooks.json", func(t *testing.T, dir string) (int, error) {
 		t.Helper()
 		t.Chdir(dir)

--- a/cmd/entire/cli/agent/event.go
+++ b/cmd/entire/cli/agent/event.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -217,9 +219,14 @@ func ReadHookInputRaw(stdin io.Reader) (json.RawMessage, error) {
 }
 
 // ReadHookInputRawLimited is ReadHookInputRaw with a ceiling of limit bytes on
-// the JSON value (limit < 0 means unlimited). It is used at the external/plugin
-// boundary to bound an untrusted payload — without reintroducing the EOF-wait
-// hang, since the streaming decoder still returns on the first complete value.
+// the payload read from stdin, a leading BOM included (limit < 0 means
+// unlimited). It is used at the external/plugin boundary to bound an untrusted
+// payload — without reintroducing the EOF-wait hang, since the streaming
+// decoder still returns on the first complete value.
+//
+// The ceiling is the outermost wrapper, so the buffered reader skipUTF8BOM adds
+// fills through it: its read-ahead is then bounded by limit rather than by its
+// own buffer size, which is larger than plausible ceilings.
 func ReadHookInputRawLimited(stdin io.Reader, limit int64) (json.RawMessage, error) {
 	// If stdin is an interactive terminal there is no payload coming at all: the
 	// command was run by hand, or the agent left the console attached instead of
@@ -234,7 +241,7 @@ func ReadHookInputRawLimited(stdin io.Reader, limit int64) (json.RawMessage, err
 		r = io.LimitReader(stdin, limit)
 	}
 	var raw json.RawMessage
-	if err := json.NewDecoder(r).Decode(&raw); err != nil {
+	if err := json.NewDecoder(skipUTF8BOM(r)).Decode(&raw); err != nil {
 		if errors.Is(err, io.EOF) {
 			return nil, errors.New("empty hook input")
 		}
@@ -249,4 +256,56 @@ func ReadHookInputRawLimited(stdin io.Reader, limit int64) (json.RawMessage, err
 func StdinLooksInteractive(r io.Reader) bool {
 	f, ok := r.(*os.File)
 	return ok && term.IsTerminal(int(f.Fd())) //nolint:gosec // G115: uintptr->int is safe for fd
+}
+
+// utf8BOM is the UTF-8 serialization of U+FEFF. JSON may not begin with it and
+// Go's decoder does not skip it, so a payload carrying one fails to parse as
+// `invalid character 'ï' looking for beginning of value`.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// skipUTF8BOM returns a reader positioned past any UTF-8 BOMs at the head of r.
+//
+// A hook payload acquires one when the agent pipes it through Windows
+// PowerShell. Cursor runs every hook command as
+// `$OutputEncoding = [System.Text.Encoding]::UTF8; … | & { $input | <command> }`,
+// and under Windows PowerShell 5.1 that encoder carries a 3-byte preamble which
+// is written ahead of the JSON — the default $OutputEncoding there is ASCII,
+// which is why Cursor sets it at all. Measured on Windows 11 / PowerShell 5.1:
+// that line alone adds one BOM at any console codepage, and a UTF-8 console
+// codepage adds a second independently, so both stack. Hence a loop rather than
+// one strip. It terminates when the input does, and the untrusted boundary
+// bounds the input with ReadHookInputRawLimited's ceiling.
+//
+// Each strip is gated on a ONE-byte peek. Peek(3) blocks until three bytes
+// arrive or the reader fails, so peeking three unconditionally would give a
+// runner that writes a short-but-complete payload and holds the pipe open the
+// very hang this reader exists to avoid (issue #1398). No JSON document legally
+// begins with 0xEF, so only input that is already malformed reaches the wider
+// peek.
+//
+// The gate bounds that hang to valid payloads, and does not abolish it: input
+// that is nothing but a BOM used to fail instantly on its first byte, and now
+// leaves the decoder with nothing to read until the writer closes or the host
+// kills the hook. That is the price of stripping at all — a single strip pays it
+// too — and it is only ever paid by input that was already malformed.
+//
+// Every exit is the same one, and reader errors are deliberately not
+// propagated: an empty or failing reader is handed to the decoder untouched, so
+// it still produces the io.EOF that callers report as "empty hook input" rather
+// than a bufio-shaped error in its place.
+func skipUTF8BOM(r io.Reader) io.Reader {
+	br := bufio.NewReader(r)
+	for {
+		first, err := br.Peek(1)
+		if err != nil || first[0] != utf8BOM[0] {
+			return br
+		}
+		head, err := br.Peek(len(utf8BOM))
+		if err != nil || !bytes.Equal(head, utf8BOM) {
+			return br
+		}
+		if _, err := br.Discard(len(utf8BOM)); err != nil {
+			return br
+		}
+	}
 }

--- a/cmd/entire/cli/agent/event_test.go
+++ b/cmd/entire/cli/agent/event_test.go
@@ -57,30 +57,89 @@ func TestReadAndParseHookInput_ReturnsBeforeEOF(t *testing.T) {
 // TestReadAndParseHookInput_ReturnsBeforeEOF: the size-bounded raw reader must
 // also return on the first complete JSON value without waiting for stdin close
 // (issue #1398).
+//
+// The shorter-than-a-BOM case additionally pins the one-byte gate in
+// skipUTF8BOM: such a payload returns only because the BOM check peeks one byte
+// before it peeks three. An unconditional Peek(3) blocks here.
+//
+// The claim is scoped to VALID payloads. A payload that is only a BOM does now
+// block until the writer closes, because stripping it leaves the decoder
+// nothing to read; see skipUTF8BOM.
 func TestReadHookInputRawLimited_ReturnsBeforeEOF(t *testing.T) {
 	t.Parallel()
 
-	pr, pw := io.Pipe()
-	go func() {
-		if _, err := pw.Write([]byte(`{"session_file":"/t.jsonl"}`)); err != nil {
-			_ = pw.CloseWithError(err)
-		}
-		// No Close(): the write end stays open, so EOF never arrives.
-	}()
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{"complete value", `{"session_file":"/t.jsonl"}`},
+		{"shorter than a BOM", `{}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	done := make(chan error, 1)
-	go func() {
-		_, err := ReadHookInputRawLimited(pr, 10*1024*1024)
-		done <- err
-	}()
+			pr, pw := io.Pipe()
+			go func() {
+				if _, err := pw.Write([]byte(tc.payload)); err != nil {
+					_ = pw.CloseWithError(err)
+				}
+				// No Close(): the write end stays open, so EOF never arrives.
+			}()
 
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("ReadHookInputRawLimited blocked waiting for EOF — regression of #1398")
+			done := make(chan error, 1)
+			go func() {
+				_, err := ReadHookInputRawLimited(pr, 10*1024*1024)
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("ReadHookInputRawLimited blocked waiting for EOF — regression of #1398")
+			}
+		})
+	}
+}
+
+// TestReadAndParseHookInput_SkipsUTF8BOM covers the payload shape Cursor
+// delivers on Windows: PowerShell 5.1 writes a BOM ahead of the JSON and a
+// trailing CRLF after it, and Go's decoder rejects the BOM as
+// `invalid character 'ï' looking for beginning of value`.
+//
+// Both BOM counts are measured, not hypothetical. The hook command's own
+// `$OutputEncoding = [System.Text.Encoding]::UTF8` adds one at any console
+// codepage; a UTF-8 console codepage adds a second, independently. So the
+// stacked shape is what a cp65001 box actually sends.
+func TestReadAndParseHookInput_SkipsUTF8BOM(t *testing.T) {
+	t.Parallel()
+
+	const bom = "\xef\xbb\xbf"
+	const payload = `{"session_id":"abc","transcript_path":"/t.jsonl"}`
+
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{"one BOM", bom + payload + "\r\n"},
+		{"stacked BOMs", bom + bom + payload + "\r\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ReadAndParseHookInput[hookInput](strings.NewReader(tc.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.SessionID != "abc" {
+				t.Fatalf("session_id = %q, want %q", got.SessionID, "abc")
+			}
+			if got.TranscriptPath != "/t.jsonl" {
+				t.Fatalf("transcript_path = %q, want %q", got.TranscriptPath, "/t.jsonl")
+			}
+		})
 	}
 }
 

--- a/cmd/entire/cli/agent/hook_command.go
+++ b/cmd/entire/cli/agent/hook_command.go
@@ -378,26 +378,37 @@ func defaultSHHookWrapperWorks(ctx context.Context, command string) bool {
 // HookHostIsWindows reports whether hook commands will run on a Windows host,
 // without asking whether a POSIX sh is reachable there.
 //
-// It is the predicate for an agent that hands every hook command to cmd.exe on
-// Windows whatever else is installed. Factory Droid is one: its Windows build
-// runs each hook command as an argument of cmd.exe, while its macOS/Linux
-// build runs the same string under sh. For such an agent
-// UseWindowsProductionHooks answers the wrong question — its probe only
-// establishes that `sh -c 'exit 0'` runs, and that command carries no cmd.exe
-// metacharacters, so a host with Git Bash reports success while the real sh
-// wrapper, which is full of `>` and `&`, is still cut apart by cmd.exe before
-// any sh sees it.
+// It is the predicate for an agent whose Windows hook runner the sh wrapper
+// cannot survive, and two independent mechanisms put an agent in that group.
+// Both were established by reading the shipped per-platform binaries; neither
+// is detectable by a probe run from this process.
 //
-// Codex and Cursor keep UseWindowsProductionHooks, but do NOT read that as
-// "their runners are different". WrapWindowsProductionSilentHookCommand's own
-// doc, runWindowsWrapper in hook_command_exec_windows_test.go, and cursor's
-// InstallHooks all describe those runners as going through cmd.exe too. What
-// separates them is only evidence: Codex demonstrably passes the Windows
-// nightly with the sh wrapper installed, so whatever its composition does, the
-// wrapper survives it. Cursor has no such evidence — it is excluded from the
-// Windows matrix (no tmux) — so it may well have this same defect. Establish
-// that the way it was established here, by reading the runner, before changing
-// its gate.
+// The first is the shell mangling the wrapper. Factory Droid's Windows build
+// runs each hook command as an argument of cmd.exe, while its macOS/Linux build
+// runs the same string under sh. cmd.exe reads the sh wrapper's `>` and `&` as
+// its own redirections and separators, so the line is cut apart before any sh
+// sees it.
+//
+// The second is the wrapper's own dependency not being reachable where the hook
+// actually runs. Cursor spawns hooks through PowerShell, which passes the sh
+// wrapper through intact — single quotes are literal there — and then cannot
+// resolve `sh`, because Git for Windows keeps sh.exe off the machine PATH. See
+// cursor's silentHookCommand.
+//
+// In both cases UseWindowsProductionHooks answers a question that is not the
+// one being asked. Its probe establishes that `sh -c 'exit 0'` runs in THIS
+// process: a command carrying no cmd.exe metacharacters, resolved against this
+// process's PATH. So a host with Git Bash reports success while droid's real
+// wrapper is still cut apart, and `entire enable` run from Git Bash reports
+// success while Cursor's PowerShell child cannot find sh at all. The general
+// statement is that we cannot vouch for the environment of the process the
+// agent runs the hook in, so a probe of ours is not evidence about it.
+//
+// Codex keeps UseWindowsProductionHooks, and on evidence rather than on a
+// belief about its composition: it demonstrably passes the Windows nightly with
+// the sh wrapper installed, so whatever its runner does, the wrapper survives
+// it. Establish the same before changing any remaining gate — by reading the
+// runner, which is how both mechanisms above were found.
 func HookHostIsWindows() bool {
 	return hookCommandOS == hookWrapperOSWindows
 }

--- a/cmd/entire/cli/agent/hook_command.go
+++ b/cmd/entire/cli/agent/hook_command.go
@@ -375,6 +375,33 @@ func defaultSHHookWrapperWorks(ctx context.Context, command string) bool {
 	return cmd.Run() == nil
 }
 
+// HookHostIsWindows reports whether hook commands will run on a Windows host,
+// without asking whether a POSIX sh is reachable there.
+//
+// It is the predicate for an agent that hands every hook command to cmd.exe on
+// Windows whatever else is installed. Factory Droid is one: its Windows build
+// runs each hook command as an argument of cmd.exe, while its macOS/Linux
+// build runs the same string under sh. For such an agent
+// UseWindowsProductionHooks answers the wrong question — its probe only
+// establishes that `sh -c 'exit 0'` runs, and that command carries no cmd.exe
+// metacharacters, so a host with Git Bash reports success while the real sh
+// wrapper, which is full of `>` and `&`, is still cut apart by cmd.exe before
+// any sh sees it.
+//
+// Codex and Cursor keep UseWindowsProductionHooks, but do NOT read that as
+// "their runners are different". WrapWindowsProductionSilentHookCommand's own
+// doc, runWindowsWrapper in hook_command_exec_windows_test.go, and cursor's
+// InstallHooks all describe those runners as going through cmd.exe too. What
+// separates them is only evidence: Codex demonstrably passes the Windows
+// nightly with the sh wrapper installed, so whatever its composition does, the
+// wrapper survives it. Cursor has no such evidence — it is excluded from the
+// Windows matrix (no tmux) — so it may well have this same defect. Establish
+// that the way it was established here, by reading the runner, before changing
+// its gate.
+func HookHostIsWindows() bool {
+	return hookCommandOS == hookWrapperOSWindows
+}
+
 // WrapProductionSilentHookCommandForOS picks the sh-based or native Windows
 // silent wrapper based on useWindows (typically from UseWindowsProductionHooks).
 func WrapProductionSilentHookCommandForOS(command string, useWindows bool) string {

--- a/cmd/entire/cli/agent/hook_command_exec_windows_test.go
+++ b/cmd/entire/cli/agent/hook_command_exec_windows_test.go
@@ -12,27 +12,152 @@ import (
 	"testing"
 )
 
+// windowsSystemRoot is %SystemRoot%, with the conventional fallback for the
+// (unexpected) case of it being unset.
+func windowsSystemRoot() string {
+	if sysRoot := os.Getenv("SystemRoot"); sysRoot != "" {
+		return sysRoot
+	}
+	return `C:\Windows`
+}
+
+// windowsPowerShellPath is the absolute path to Windows PowerShell 5.1.
+//
+// It is resolved absolutely rather than through exec.LookPath because
+// powershell.exe is NOT in System32: it lives in
+// System32\WindowsPowerShell\v1.0, a separate directory that Windows ships on
+// the default PATH and that setWrapperPATH deliberately scrubs away. Cursor's
+// own resolver spells this path out as its last tier for the same reason.
+//
+// Resolving it absolutely is what lets the scrub stay tight. A PowerShell child
+// does not need itself on PATH, and the scrub's whole job is keeping a stray
+// `entire` or `sh` out of the case under test, which adding directories back
+// would work against.
+func windowsPowerShellPath(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(windowsSystemRoot(), "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Windows PowerShell not found at %s: %v", path, err)
+	}
+	return path
+}
+
+// setWrapperPATH scrubs PATH down to System32 — which supplies cmd.exe,
+// where.exe, findstr.exe and powershell.exe — plus, when entirePresent, a
+// directory holding an `entire.bat` with the given body. Nothing else is on
+// PATH, so an `entire` installed on the host machine cannot leak into the
+// "absent" case, and neither can an `sh` from Git for Windows.
+//
+// Returns the stub directory, or "" when entirePresent is false.
+func setWrapperPATH(t *testing.T, entirePresent bool, stubBody string) string {
+	t.Helper()
+
+	pathEntries := []string{filepath.Join(windowsSystemRoot(), "System32")}
+	stubDir := ""
+	if entirePresent {
+		stubDir = t.TempDir()
+		if err := os.WriteFile(filepath.Join(stubDir, "entire.bat"), []byte(stubBody), 0o700); err != nil {
+			t.Fatalf("write entire stub: %v", err)
+		}
+		pathEntries = append([]string{stubDir}, pathEntries...)
+	}
+	t.Setenv("PATH", strings.Join(pathEntries, ";"))
+	return stubDir
+}
+
+// cursorHookScript is Cursor's Windows hook script, verbatim. Read out of the
+// shipped builds — Cursor IDE 3.19.19 win32/x64 and the native cursor-agent CLI
+// windows/x64 2026.09.08-6caf4ff, which compose it identically, as do IDE
+// 3.15.19 and 3.11.19. The stored command is inserted with no quoting of
+// Cursor's own.
+func cursorHookScript(payloadPath, wrapper string) string {
+	return `$OutputEncoding = [System.Text.Encoding]::UTF8; Get-Content -LiteralPath '` +
+		payloadPath + `' -Raw | & { $input | ` + wrapper + ` }`
+}
+
+// runCursorWrapper runs a wrapper the way Cursor's Windows hook runner does:
+// PowerShell, with the JSON payload written to a temp file and piped into the
+// wrapped command's stdin.
+//
+// It cannot share runWrapperCmdLine. That builds a cmd.exe command line via
+// SysProcAttr.CmdLine because cmd.exe does not follow the standard argv
+// unquoting rules; Cursor spawns PowerShell with a real argv, so the ordinary
+// exec.Command path is the faithful model. And Cursor is the only runner that
+// delivers the payload on the wrapped command's stdin, which is what stdinSeen
+// exists to check — a wrapper can run and still starve the hook of its input.
+//
+// The shell is Windows PowerShell 5.1, pinned by construction: the runner names
+// its absolute path (see windowsPowerShellPath) rather than resolving whatever
+// a runner happens to have. Cursor prefers pwsh when it is on PATH, so that
+// branch of its resolution chain is NOT exercised here — see the PR's Not
+// covered. 5.1 is the interesting one anyway: it is where the payload acquires
+// a BOM.
+func runCursorWrapper(t *testing.T, wrapper string, entirePresent bool) (stdout, stderr, argvSeen, stdinSeen string, code int) {
+	t.Helper()
+
+	recordDir := t.TempDir()
+	ranPath := filepath.Join(recordDir, "ran.txt")
+	stdinPath := filepath.Join(recordDir, "stdin.txt")
+	// findstr /R "^" copies stdin through; `more` pages and can rewrite it.
+	stub := "@echo off\r\n" +
+		`echo ARGS:%*>> "` + ranPath + `"` + "\r\n" +
+		`findstr /R "^" >> "` + stdinPath + `"` + "\r\n" +
+		"exit /b 0\r\n"
+	setWrapperPATH(t, entirePresent, stub)
+
+	payloadPath := filepath.Join(recordDir, "payload.json")
+	if err := os.WriteFile(payloadPath, []byte(cursorHookPayload), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	shell := windowsPowerShellPath(t)
+
+	runDir := t.TempDir() // clean CWD so `where` can't find a stray entire next to us
+	cmd := exec.CommandContext(t.Context(), shell,
+		"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+		"-c", cursorHookScript(payloadPath, wrapper))
+	cmd.Dir = runDir
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	code = 0
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("run cursor wrapper: %v", err)
+		}
+		code = exitErr.ExitCode()
+	}
+	return outBuf.String(), errBuf.String(), readIfExists(t, ranPath), readIfExists(t, stdinPath), code
+}
+
+// readIfExists returns a file's contents, or "" when it was never created.
+func readIfExists(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temp path
+	if errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// cursorHookPayload stands in for a Cursor hook's JSON payload. It must survive
+// to the wrapped command's stdin intact enough to be found by substring: under
+// Windows PowerShell 5.1 the pipe prepends a UTF-8 BOM and appends a CRLF, so
+// an equality check would fail on the transport rather than on the wrapper.
+const cursorHookPayload = `{"hook_event_name":"stop","conversation_id":"ENTIRE_PAYLOAD_MARKER"}`
+
 // runWindowsWrapper mirrors Codex's Windows command runner: cmd.exe /C followed
 // by the raw, quoted hook command. SysProcAttr.CmdLine is required because
 // cmd.exe does not use the standard Windows argv unquoting rules.
 func runWindowsWrapper(t *testing.T, wrapper string, entirePresent bool) (string, string, int) {
 	t.Helper()
 
-	sysRoot := os.Getenv("SystemRoot")
-	if sysRoot == "" {
-		sysRoot = `C:\Windows`
-	}
-	// System32 supplies cmd.exe and where.exe; nothing else is on PATH so an
-	// `entire` installed on the host machine can't leak into the "absent" case.
-	pathEntries := []string{filepath.Join(sysRoot, "System32")}
-	if entirePresent {
-		stubDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(stubDir, "entire.bat"), []byte("@exit /b 0\r\n"), 0o700); err != nil {
-			t.Fatalf("write entire stub: %v", err)
-		}
-		pathEntries = append([]string{stubDir}, pathEntries...)
-	}
-	t.Setenv("PATH", strings.Join(pathEntries, ";"))
+	setWrapperPATH(t, entirePresent, "@exit /b 0\r\n")
 
 	runDir := t.TempDir()
 	cmdPath, err := exec.LookPath("cmd.exe")
@@ -139,6 +264,60 @@ func TestWindowsWrappers_Execution(t *testing.T) {
 		}
 		if code != 7 {
 			t.Fatalf("expected wrapped command exit code 7 to propagate, got %d; stderr=%q", code, stderr)
+		}
+	})
+}
+
+// TestWindowsWrappers_CursorComposition runs the wrappers through Cursor's own
+// Windows hook runner — PowerShell, not cmd.exe — and is why cursor installs
+// the native wrapper on every Windows host rather than on a probe's say-so.
+//
+// The sh subtest is the defect: with no `sh` reachable, the sh wrapper does not
+// launch, nothing tells anyone, and the exit code is 0. Cursor reads that as a
+// successful hook.
+func TestWindowsWrappers_CursorComposition(t *testing.T) {
+	// No t.Parallel(): t.Setenv("PATH") forbids it.
+
+	t.Run("cmd wrapper/present runs the command and delivers the payload", func(t *testing.T) {
+		out, stderr, argv, stdin, code := runCursorWrapper(
+			t, WrapWindowsProductionSilentHookCommand("entire hooks cursor stop"), true)
+		if argv == "" {
+			t.Fatalf("wrapped command never ran; stdout=%q stderr=%q", out, stderr)
+		}
+		if !strings.Contains(argv, "hooks cursor stop") {
+			t.Errorf("argv = %q, want it to carry `hooks cursor stop`", argv)
+		}
+		if !strings.Contains(stdin, "ENTIRE_PAYLOAD_MARKER") {
+			t.Errorf("hook payload never reached stdin; got %q (stderr=%q)", stdin, stderr)
+		}
+		if code != 0 {
+			t.Errorf("expected exit 0, got %d; stderr=%q", code, stderr)
+		}
+	})
+
+	t.Run("cmd wrapper/absent skips the command and exits 0", func(t *testing.T) {
+		out, stderr, argv, _, code := runCursorWrapper(
+			t, WrapWindowsProductionSilentHookCommand("entire hooks cursor stop"), false)
+		if argv != "" {
+			t.Fatalf("wrapped command must NOT run when entire absent; argv=%q stdout=%q", argv, out)
+		}
+		if code != 0 {
+			t.Errorf("expected exit 0 when entire absent, got %d; stderr=%q", code, stderr)
+		}
+	})
+
+	// The reason for the gate change. `entire` IS present here; only `sh` is
+	// missing, which is the state of a default Windows box — Git for Windows
+	// keeps sh.exe in …\Git\usr\bin and …\Git\bin, neither on the machine
+	// PATH. The hook simply never runs, and exit 0 means Cursor cannot tell.
+	t.Run("sh wrapper/no sh reachable runs nothing and still exits 0", func(t *testing.T) {
+		out, stderr, argv, _, code := runCursorWrapper(
+			t, WrapProductionSilentHookCommand("entire hooks cursor stop"), true)
+		if argv != "" {
+			t.Fatalf("sh wrapper ran the command with no sh on PATH; argv=%q", argv)
+		}
+		if code != 0 {
+			t.Errorf("expected the failure to be invisible (exit 0), got %d; stdout=%q stderr=%q", code, out, stderr)
 		}
 	})
 }


### PR DESCRIPTION
Makes Cursor hooks fire on Windows, so sessions and checkpoints get recorded there. Fixes #1424.

Two things stopped them: the wrapper Entire installs cannot run under Cursor's PowerShell hook runner, and the payload arrives with a UTF-8 BOM our JSON decode rejects. Both fixed here; the BOM fix is at the shared chokepoint, so it covers every agent.

Trail: https://entire.io/gh/entireio/cli/trails/1291

🤖 Generated with [Claude Code](https://claude.com/claude-code)
