### PR TITLE
fix: address open code-scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches:
       - main
+
+# Least privilege: every job here only reads the repository. The `test` gate job
+# below needs nothing at all and drops even this.
+permissions:
+  contents: read
+
 jobs:
   test-core:
     runs-on: ubuntu-latest
@@ -87,6 +93,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
       - test-core
       - test-integration

--- a/.github/workflows/e2e-checkpoint-store.yml
+++ b/.github/workflows/e2e-checkpoint-store.yml
@@ -27,6 +27,10 @@ on:
           - git-branch
           - git-refs
 
+# Deny by default: matrix-setup needs no token at all, and the job that does
+# declares exactly what it uses.
+permissions: {}
+
 jobs:
   # Build the agent matrix dynamically: a single selected agent, or all of them
   # when the input is left empty.

--- a/.github/workflows/e2e-isolated.yml
+++ b/.github/workflows/e2e-isolated.yml
@@ -14,6 +14,11 @@ on:
         required: true
         default: "TestInteractiveMultiStep"
 
+# Least privilege: the single job only checks out the repository. The agent API
+# keys it needs are repository secrets, not GITHUB_TOKEN scopes.
+permissions:
+  contents: read
+
 jobs:
   e2e-isolated:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -13,6 +13,12 @@ concurrency:
   group: e2e-windows-tests
   cancel-in-progress: true
 
+# Least privilege: this job only checks out the repository. Called via
+# `workflow_call` from e2e.yml, whose calling job must therefore grant at least
+# `contents: read` — a reusable workflow can never hold more than its caller.
+permissions:
+  contents: read
+
 jobs:
   e2e-windows:
     runs-on: windows-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,10 @@ concurrency:
   group: e2e-tests
   cancel-in-progress: true
 
+# Deny by default: matrix-setup needs no token at all, and the three jobs that
+# do need one declare exactly what they use.
+permissions: {}
+
 jobs:
   # Build the matrix dynamically so workflow_dispatch can select a single agent.
   matrix-setup:
@@ -165,10 +169,14 @@ jobs:
 
   e2e-windows:
     uses: ./.github/workflows/e2e-windows.yml
+    permissions:
+      contents: read
     secrets: inherit
 
   notify-slack:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
     needs: [e2e-tests, e2e-windows]
     if: ${{ always() && (needs.e2e-tests.result == 'failure' || needs.e2e-windows.result == 'failure') && github.event_name == 'push' }}
     steps:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
 
+# The reusable workflow checks out this repository and hands the token to
+# mise-action, so it needs read access and nothing more.
+permissions:
+  contents: read
+
 jobs:
   check-licenses:
     uses: entireio/shared/.github/workflows/license-check-reusable.yml@6e5ecde24c20a17b4146250287307718987b7317 # main

--- a/cmd/entire/cli/transcript/compact/copilot.go
+++ b/cmd/entire/cli/transcript/compact/copilot.go
@@ -149,6 +149,10 @@ func copilotAssistantLine(base transcriptLine, line copilotLine) *transcriptLine
 		return nil
 	}
 
+	// Capacity hint only: the +1 is the optional text block. It cannot
+	// overflow — a []copilotToolRequest (56B elements) can never reach
+	// MaxInt entries, so CodeQL's go/allocation-size-overflow here is
+	// unreachable.
 	content := make([]map[string]json.RawMessage, 0, 1+len(data.ToolReqs))
 	if data.Content != "" {
 		tb, err := json.Marshal(transcript.ContentTypeText)

--- a/cmd/entire/cli/transcript/compact/gemini.go
+++ b/cmd/entire/cli/transcript/compact/gemini.go
@@ -152,6 +152,9 @@ func emitGeminiUser(result *[]byte, base transcriptLine, msg geminiMessage, ts j
 // emitGeminiAssistant produces a single assistant line. The content array
 // contains text blocks (from content field) and tool_use blocks (from toolCalls).
 func emitGeminiAssistant(result *[]byte, base transcriptLine, msg geminiMessage, ts json.RawMessage) {
+	// Capacity hint only: the +1 is the optional text block. It cannot
+	// overflow — a []geminiToolCall (96B elements) can never reach MaxInt
+	// entries, so CodeQL's go/allocation-size-overflow here is unreachable.
 	content := make([]map[string]json.RawMessage, 0, 1+len(msg.ToolCalls))
 
 	if contentText := geminiContentText(msg.Content); contentText != "" {

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -1192,7 +1192,10 @@ func tokenStreamHasDuplicateKeys(dec *json.Decoder) bool {
 					return true
 				}
 				if len(seenSlice) == duplicateKeySliceThreshold {
-					seenMap = make(map[string]struct{}, len(seenSlice)+1)
+					// Sized from the constant, not len(seenSlice): they are equal
+					// on this branch, and the spilled keys plus k are exactly
+					// what the map has to hold.
+					seenMap = make(map[string]struct{}, duplicateKeySliceThreshold+1)
 					for _, seenKey := range seenSlice {
 						seenMap[seenKey] = struct{}{}
 					}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1293
<!-- entire-trail-link-end -->

CodeQL default setup was enabled on this repo this morning (`actions`, `go`, `js/ts`, `python`; threat model `remote`), and its first scan opened 16 alerts. This closes all of them.

## `actions/missing-workflow-permissions` × 13

Six workflows ran with GitHub's default `GITHUB_TOKEN` scopes because neither the workflow nor the job declared a `permissions` block. Every job now has an explicit least-privilege set, derived from what the job actually does rather than from a blanket default:

| Workflow | Choice | Why |
| --- | --- | --- |
| `ci.yml` | workflow `contents: read`; `test` job `{}` | Five jobs only check out; no job in the file touches the token. The `test` gate job reads only `needs.*.result`. |
| `e2e-isolated.yml` | workflow `contents: read` | Single job, checkout only. Its agent API keys are repository secrets, not token scopes. |
| `license-check.yml` | workflow `contents: read` | The reusable workflow checks this repo out and hands the token to mise-action. |
| `e2e-windows.yml` | workflow `contents: read` | Checkout only. |
| `e2e.yml` | workflow `{}`; per-job grants | `matrix-setup` only writes `$GITHUB_OUTPUT`. `notify-slack` gets `actions: read`. The `e2e-windows` caller gets `contents: read`. `e2e-tests` keeps its existing block. |
| `e2e-checkpoint-store.yml` | workflow `{}` | `matrix-setup` needs nothing; the other job already declared its scopes. |

Two of these deserve a second look from a reviewer:

- **`e2e.yml` `notify-slack` → `actions: read` only.** It calls `gh api repos/{repo}/actions/runs/{id}/jobs`, which is documented as needing just the Actions read permission; Slack is reached through an incoming webhook, so it needs no repository read. The same-named job in `nightly-e2e.yml` only posts to the webhook and correctly sits at `{}` today, which is what confirmed the two jobs genuinely differ. If this turns out to need `contents: read` too, the failure mode is silent loss of e2e failure notifications on `main`, so it is worth a sanity check on the first `main` push.
- **`e2e-windows.yml` is reached via `workflow_call` from `e2e.yml`.** A reusable workflow can never hold more than its caller, so the calling job grants `contents: read` to match what the called workflow now declares. Without that pairing the Windows leg would fail at checkout.

Verified by parsing all 15 workflows and printing each job's effective permissions — every file is valid YAML and no job is left implicit. The untouched workflows (`e2e-checkpoints-v2.yml`, `nightly-e2e.yml`) already declared theirs per-job, which is why they were never flagged.

## `go/allocation-size-overflow` × 3

All three are unreachable, but they split two ways.

**Fixed in code** — `redact/redact.go` sized a map from `len(seenSlice)+1` on the one branch where `len(seenSlice) == duplicateKeySliceThreshold`, so the value is always 17. It now sizes from the constant, which is what the code meant; the alert goes away as a side effect of saying it plainly.

**Dismissed as false positives** — the two transcript compactors use `make([]T, 0, 1+len(slice))` as a capacity hint. That can only overflow at `len == math.MaxInt`, which for these element types (`geminiToolCall` 96B, `copilotToolRequest` 56B, both measured) would need ~10²⁰ bytes of backing array — far past Go's `maxAlloc`, so `json.Unmarshal` cannot produce it. Dropping the `+1` would clear the alert but costs a realloc per assistant line carrying text, and every other reformulation keeps the same flagged arithmetic. So the reason is recorded at each call site, so nobody "fixes" the hint away later, and alerts #30/#31 are dismissed with that reasoning.

## Verification

- `mise run fmt && mise run lint` — clean (0 issues)
- `GOOS=windows go vet ./...` — clean (`test:ci` compiles host-only, so this is the cross-OS guard)
- `mise run test:ci` — green: 91 packages plus both canary legs (56 and 4 tests)

No behaviour changes: the Go diff is one constant substitution plus three comments.

The 13 Actions alerts stay open until CodeQL re-scans `main`; `codeql-actions.yml` runs on this PR since it touches `.github/workflows/**`, so the analysis result is visible here first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI permission tightening could break checkout or Slack failure classification if scopes are wrong; Go changes are comments plus one equivalent map capacity constant.
> 
> **Overview**
> Closes **16 CodeQL alerts** from new default scanning—mostly **explicit least-privilege `permissions`** on six GitHub Actions workflows, plus small Go tweaks for **`go/allocation-size-overflow`**.
> 
> **Actions:** Workflows that relied on the default `GITHUB_TOKEN` scopes now declare what each job actually needs—e.g. **`ci.yml`** uses workflow **`contents: read`** and the aggregate **`test`** gate job uses **`permissions: {}`**; **`e2e.yml`** defaults to deny-all at workflow level and grants **`contents: read`** on the **`e2e-windows`** reusable call and **`actions: read`** on **`notify-slack`** (for `gh api` job listing); checkout-only flows get **`contents: read`** or **`{}`** where no token is used.
> 
> **Go:** In **`redact/redact.go`**, duplicate-key detection sizes the spill-over map with **`duplicateKeySliceThreshold+1`** instead of **`len(seenSlice)+1`** on the threshold branch (same effective size, satisfies CodeQL). **`copilot.go`** and **`gemini.go`** keep the `1+len(tools)` slice capacity hint and add comments that overflow is unreachable so future “fixes” do not drop the hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e15fbc7c924188bf207b6b4c84b837475c5e355. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->