### PR TITLE
build: bump Go to 1.27.1 and golangci-lint to 2.13.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,8 +31,26 @@ jobs:
       # So this golangci-lint uses the same config as `mise run lint:go`, but using special sauce to
       # create inline feedback on GitHub's UI.  On local dev, the same issues should be surfaced by
       # mise-tasks/lint/go
+      #
+      # The version is read from mise.toml for the same reason setup-go reads
+      # go.mod above: the two pins must name the same version, and the hardcoded
+      # copy that used to live here is what drifted on the Go 1.27 bump. A 2.11
+      # binary refuses to lint a 1.27 module outright ("the Go language version
+      # (go1.26) used to build golangci-lint is lower than the targeted Go
+      # version"), so this step failed after `mise run lint` had already passed
+      # with the correct version.
+      - name: Resolve golangci-lint version
+        id: golangci
+        run: |
+          version=$(sed -n "s/^golangci-lint = '\(.*\)'$/\1/p" mise.toml)
+          if [ -z "$version" ]; then
+            echo "could not read the golangci-lint version from mise.toml" >&2
+            exit 1
+          fi
+          echo "version=v$version" >> "$GITHUB_OUTPUT"
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: 'v2.11.3'
+          version: ${{ steps.golangci.outputs.version }}
           debug: 'clean'

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -74,6 +74,13 @@ linters:
     - whitespace
     - wrapcheck
   settings:
+    goconst:
+      # golangci-lint 2.13 (goconst upgrade) began scanning composite literals,
+      # which turned map-literal keys and test fixtures into ~2.3k findings that
+      # 2.11 never reported. Both knobs restore the prior scope rather than
+      # adopting a stricter linter as a side effect of a Go toolchain bump.
+      ignore-tests: true
+      ignore-map-keys: true
     gosec:
       excludes:
         - G204 # subprocess with variables is expected for git/opencode CLI wrappers

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -75,10 +75,28 @@ linters:
     - wrapcheck
   settings:
     goconst:
-      # golangci-lint 2.13 (goconst upgrade) began scanning composite literals,
-      # which turned map-literal keys and test fixtures into ~2.3k findings that
-      # 2.11 never reported. Both knobs restore the prior scope rather than
-      # adopting a stricter linter as a side effect of a Go toolchain bump.
+      # golangci-lint 2.13's goconst upgrade began scanning composite literals,
+      # which turned ~2.3k previously-unreported strings into findings. The two
+      # knobs below are NOT equivalent in what they give up:
+      #
+      #   ignore-map-keys restores the prior scope exactly: a map-literal key
+      #   was never reported before 2.13, so nothing is lost.
+      #
+      #   ignore-tests is broader than the 2.13 change and DOES give up
+      #   coverage this repo had. goconst used to lint test logic -- the proof
+      #   is the three //nolint:goconst directives in _test.go files that the
+      #   Go 1.27 bump deleted as unused; they were suppressing real
+      #   comparison/assignment findings under 2.11. Those shapes are no longer
+      #   checked in tests.
+      #
+      # It is accepted anyway because no narrower exclusion exists. goconst
+      # settings are global (there is no per-path variant), the remainder is
+      # 2016 findings across 62 packages so a path-scoped rule would have to
+      # name nearly every one, and the field that looks like the right tool --
+      # exclude-types: [CompositeLit] -- REPLACES the default exclusion set
+      # rather than adding to it, so it re-enables Call findings and takes the
+      # count up to 6255. Revisit if goconst gains per-path settings or fixes
+      # exclude-types.
       ignore-tests: true
       ignore-map-keys: true
     gosec:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ named `<noun>_group.go` and `<noun>_<verb>.go` respectively.
 
 ## Tech Stack
 
-- Language: Go 1.26.x
+- Language: Go 1.27.x (`go.mod` pins the 1.27.1 minimum)
 - Build tool: mise, go modules
 - Linting: golangci-lint
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Please answer these questions in your bug report:
 
 ### Prerequisites
 
-- **Go 1.26.x** - Check with `go version`
+- **Go 1.27.1+** - Check with `go version`. `go.mod` pins the minimum, so an older toolchain fails unless it can download the pinned one (`GOTOOLCHAIN=local` cannot).
 - **mise** - Task runner and version manager. Install with `curl https://mise.run | sh`
 
 ### Clone and Install

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ With Entire, you can:
 - Git
 - macOS, Linux or Windows
 - [Supported agent](#agent-hook-configuration) installed and authenticated
-- Go 1.26+ only if you install with `go install` (the packaged installs bundle their own runtime)
+- Go 1.27.1+ only if you install with `go install` (the packaged installs bundle their own runtime)
 
 ## Quick Start
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -4,7 +4,7 @@
 
 - **Windows 10 1809+** (required for ConPTY support in E2E tests)
 - **Git for Windows** — provides `git.exe` and bundled bash for git hooks
-- **Go 1.26+** — for building from source
+- **Go 1.27.1+** — for building from source
 
 ## Building
 

--- a/cmd/entire/cli/activity_cmd.go
+++ b/cmd/entire/cli/activity_cmd.go
@@ -27,23 +27,40 @@ const (
 	sessionsOverviewLimit = 50
 )
 
+// Canonical agent IDs as /me/activity reports them: the keys of the display
+// map, the values knownAgents normalizes onto, and the render order all draw
+// from this one set.
+const (
+	activityAgentClaude   = "claude"
+	activityAgentGemini   = "gemini"
+	activityAgentAmp      = "amp"
+	activityAgentCodex    = "codex"
+	activityAgentOpencode = "opencode"
+	activityAgentCopilot  = "copilot"
+	activityAgentPi       = "pi"
+	activityAgentCursor   = "cursor"
+	activityAgentDroid    = "droid"
+	activityAgentKiro     = "kiro"
+	activityAgentUnknown  = "unknown"
+)
+
 // knownAgents maps normalized agent strings from the API to display IDs.
 // Used for the commit list, where per-checkpoint agent strings are free-form.
 // The /me/activity endpoint returns already-normalized canonical IDs.
 var knownAgents = map[string]string{
-	"claude":     "claude",
-	"claudecode": "claude",
-	"gemini":     "gemini",
-	"geminicli":  "gemini",
-	"amp":        "amp",
-	"codex":      "codex",
-	"opencode":   "opencode",
-	"copilot":    "copilot",
-	"copilotcli": "copilot",
-	"pi":         "pi",
-	"cursor":     "cursor",
-	"droid":      "droid",
-	"kiro":       "kiro",
+	"claude":     activityAgentClaude,
+	"claudecode": activityAgentClaude,
+	"gemini":     activityAgentGemini,
+	"geminicli":  activityAgentGemini,
+	"amp":        activityAgentAmp,
+	"codex":      activityAgentCodex,
+	"opencode":   activityAgentOpencode,
+	"copilot":    activityAgentCopilot,
+	"copilotcli": activityAgentCopilot,
+	"pi":         activityAgentPi,
+	"cursor":     activityAgentCursor,
+	"droid":      activityAgentDroid,
+	"kiro":       activityAgentKiro,
 }
 
 func newActivityCmd() *cobra.Command {

--- a/cmd/entire/cli/activity_render.go
+++ b/cmd/entire/cli/activity_render.go
@@ -37,7 +37,7 @@ type activityStyles struct {
 // used by other commands. Activity benefits from wide output for bar charts.
 func getFullTerminalWidth(w io.Writer) int {
 	if f, ok := w.(*os.File); ok {
-		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 { //nolint:gosec // G115: uintptr->int is safe for fd
+		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 {
 			return width
 		}
 	}
@@ -45,7 +45,7 @@ func getFullTerminalWidth(w io.Writer) int {
 		if f == nil {
 			continue
 		}
-		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 { //nolint:gosec // G115: uintptr->int is safe for fd
+		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 {
 			return width
 		}
 	}
@@ -108,22 +108,22 @@ type agentDisplay struct {
 // recognizable; lipgloss resolves them to the best representation for the
 // terminal's color profile. The non-brand "unknown" fallback uses muted gray.
 var agentDisplayMap = map[string]agentDisplay{
-	"claude":   {Label: "Claude Code", Color: "#fb923c", Char: '▓'}, // orange-400
-	"gemini":   {Label: "Gemini", Color: "#60a5fa", Char: '▓'},      // blue-400
-	"amp":      {Label: "Amp", Color: "#f87171", Char: '▓'},         // red-400
-	"codex":    {Label: "Codex", Color: "#818cf8", Char: '▓'},       // indigo-400
-	"opencode": {Label: "OpenCode", Color: "#22d3ee", Char: '▓'},    // cyan-400
-	"copilot":  {Label: "Copilot", Color: "#a78bfa", Char: '▓'},     // violet-400
-	"pi":       {Label: "Pi", Color: "#fbbf24", Char: '▓'},          // amber-400
-	"cursor":   {Label: "Cursor", Color: "#38bdf8", Char: '▓'},      // sky-400
-	"droid":    {Label: "Droid", Color: "#f472b6", Char: '▓'},       // pink-400
-	"kiro":     {Label: "Kiro", Color: "#c084fc", Char: '▓'},        // purple-400
-	"unknown":  {Label: "Unknown", Color: palette.Muted, Char: '░'},
+	activityAgentClaude:   {Label: "Claude Code", Color: "#fb923c", Char: '▓'}, // orange-400
+	activityAgentGemini:   {Label: "Gemini", Color: "#60a5fa", Char: '▓'},      // blue-400
+	activityAgentAmp:      {Label: "Amp", Color: "#f87171", Char: '▓'},         // red-400
+	activityAgentCodex:    {Label: "Codex", Color: "#818cf8", Char: '▓'},       // indigo-400
+	activityAgentOpencode: {Label: "OpenCode", Color: "#22d3ee", Char: '▓'},    // cyan-400
+	activityAgentCopilot:  {Label: "Copilot", Color: "#a78bfa", Char: '▓'},     // violet-400
+	activityAgentPi:       {Label: "Pi", Color: "#fbbf24", Char: '▓'},          // amber-400
+	activityAgentCursor:   {Label: "Cursor", Color: "#38bdf8", Char: '▓'},      // sky-400
+	activityAgentDroid:    {Label: "Droid", Color: "#f472b6", Char: '▓'},       // pink-400
+	activityAgentKiro:     {Label: "Kiro", Color: "#c084fc", Char: '▓'},        // purple-400
+	activityAgentUnknown:  {Label: "Unknown", Color: palette.Muted, Char: '░'},
 }
 
 var agentOrder = []string{
-	"claude", "codex", "gemini", "amp", "opencode",
-	"copilot", "pi", "cursor", "droid", "kiro", "unknown",
+	activityAgentClaude, activityAgentCodex, activityAgentGemini, activityAgentAmp, activityAgentOpencode,
+	activityAgentCopilot, activityAgentPi, activityAgentCursor, activityAgentDroid, activityAgentKiro, activityAgentUnknown,
 }
 
 // renderActivityHeader renders the stat cards, contribution heatmap, and repo
@@ -556,7 +556,7 @@ func renderSessionListN(w io.Writer, sty activityStyles, days []sessionDay, maxD
 
 	for _, day := range days[:maxDays] {
 		displayDate := formatCommitDate(day.Date)
-		sessionWord := "sessions"
+		sessionWord := nounSessions
 		if len(day.Sessions) == 1 {
 			sessionWord = strings.TrimSuffix(sessionWord, "s")
 		}

--- a/cmd/entire/cli/agent/agent_test.go
+++ b/cmd/entire/cli/agent/agent_test.go
@@ -135,7 +135,6 @@ func TestHookTypeConstants(t *testing.T) {
 	}
 }
 
-//nolint:govet // testing struct field assignment
 func TestHookInputStructure(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/claudecode/generate.go
+++ b/cmd/entire/cli/agent/claudecode/generate.go
@@ -14,6 +14,13 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 )
 
+// flagOutputFormat selects the CLI's response encoding; modelHaiku is the
+// default model for Entire's own generation calls (fast and cheap).
+const (
+	flagOutputFormat = "--output-format"
+	modelHaiku       = "haiku"
+)
+
 // buildGenerateArgs assembles the claude CLI argv for a --print text-generation
 // call.
 //
@@ -41,7 +48,7 @@ import (
 // without any injection (settingsPath == "").
 func buildGenerateArgs(model, settingsPath string) []string {
 	args := []string{
-		"--print", "--output-format", "json",
+		"--print", flagOutputFormat, "json",
 		"--model", model,
 		"--setting-sources", "",
 	}
@@ -59,7 +66,7 @@ func buildGenerateArgs(model, settingsPath string) []string {
 func buildStreamingGenerateArgs(model, settingsPath string) []string {
 	args := []string{
 		"--print",
-		"--output-format", "stream-json",
+		flagOutputFormat, "stream-json",
 		"--include-partial-messages",
 		"--verbose",
 		"--model", model,
@@ -151,7 +158,7 @@ func readUserAPIKeyHelper() string {
 func (c *ClaudeCodeAgent) GenerateText(ctx context.Context, prompt string, model string) (string, error) {
 	claudePath := "claude"
 	if model == "" {
-		model = "haiku"
+		model = modelHaiku
 	}
 
 	commandRunner := c.CommandRunner

--- a/cmd/entire/cli/agent/claudecode/generate_streaming.go
+++ b/cmd/entire/cli/agent/claudecode/generate_streaming.go
@@ -29,7 +29,7 @@ func (c *ClaudeCodeAgent) GenerateTextStreaming(
 	progress agent.ProgressFn,
 ) (string, error) {
 	if model == "" {
-		model = "haiku"
+		model = modelHaiku
 	}
 
 	commandRunner := c.CommandRunner

--- a/cmd/entire/cli/agent/claudecode/models.go
+++ b/cmd/entire/cli/agent/claudecode/models.go
@@ -15,6 +15,6 @@ func (c *ClaudeCodeAgent) ListModels(_ context.Context) ([]agent.ModelInfo, erro
 	return []agent.ModelInfo{
 		{ID: "opus", Note: "alias — latest Claude Opus"},
 		{ID: "sonnet", Note: "alias — latest Claude Sonnet"},
-		{ID: "haiku", Note: "alias — latest Claude Haiku (fast)"},
+		{ID: modelHaiku, Note: "alias — latest Claude Haiku (fast)"},
 	}, nil
 }

--- a/cmd/entire/cli/agent/claudecode/reviewer.go
+++ b/cmd/entire/cli/agent/claudecode/reviewer.go
@@ -37,7 +37,7 @@ func NewReviewer() *reviewtypes.ReviewerTemplate {
 // Exposed at package level for test inspection of argv and env.
 func buildReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
 	prompt := review.ComposeReviewPrompt(cfg)
-	args := []string{"-p", prompt, "--output-format", "stream-json", "--verbose"}
+	args := []string{"-p", prompt, flagOutputFormat, "stream-json", "--verbose"}
 	args = review.AppendModelFlag(args, cfg.Model)
 	cmd := exec.CommandContext(ctx, "claude", args...)
 	cmd.Env = review.AppendReviewEnv(os.Environ(), "claude-code", cfg, prompt)

--- a/cmd/entire/cli/agent/copilotcli/generate.go
+++ b/cmd/entire/cli/agent/copilotcli/generate.go
@@ -7,6 +7,10 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 )
 
+// flagDenyTool withholds one built-in tool from the generation run; Entire's
+// summaries need no tools at all, so every one it knows about is denied.
+const flagDenyTool = "--deny-tool"
+
 // generateTextArgs is the pinned tool policy for text generation.
 //
 // Summary generation is a text-in text-out call, and its prompt carries
@@ -48,9 +52,9 @@ import (
 // TestGenerateText_PinsMinimalToolSurface pins the argv so a future flag
 // change is a reviewed decision rather than a drive-by edit.
 var generateTextArgs = []string{
-	"--deny-tool", "shell",
-	"--deny-tool", "write",
-	"--deny-tool", "url",
+	flagDenyTool, "shell",
+	flagDenyTool, "write",
+	flagDenyTool, "url",
 	"--no-ask-user",
 	"--no-custom-instructions",
 	"--disable-builtin-mcps",

--- a/cmd/entire/cli/agent/event.go
+++ b/cmd/entire/cli/agent/event.go
@@ -248,5 +248,5 @@ func ReadHookInputRawLimited(stdin io.Reader, limit int64) (json.RawMessage, err
 // instead of blocking on a read that will never complete (issue #1398).
 func StdinLooksInteractive(r io.Reader) bool {
 	f, ok := r.(*os.File)
-	return ok && term.IsTerminal(int(f.Fd())) //nolint:gosec // G115: uintptr->int is safe for fd
+	return ok && term.IsTerminal(int(f.Fd()))
 }

--- a/cmd/entire/cli/agent/session_test.go
+++ b/cmd/entire/cli/agent/session_test.go
@@ -1,4 +1,3 @@
-//nolint:govet // Test file with struct field assignments for completeness
 package agent
 
 import (

--- a/cmd/entire/cli/agent_group.go
+++ b/cmd/entire/cli/agent_group.go
@@ -16,7 +16,7 @@ import (
 // newAgentGroupCmd builds `entire agent`. Replaces `entire configure`.
 func newAgentGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "agent",
+		Use:   cmdAgent,
 		Short: "Manage agent integrations (add, remove, list)",
 		Long: `Manage agent integrations in this repository.
 
@@ -57,7 +57,7 @@ func runAgentMenu(ctx context.Context, w io.Writer) error {
 
 func newAgentListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List installed and available agents",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAgentList(cmd.Context(), cmd.OutOrStdout())

--- a/cmd/entire/cli/agent_help_cmd.go
+++ b/cmd/entire/cli/agent_help_cmd.go
@@ -692,9 +692,9 @@ func renderAgentHelpTop(rootCmd *cobra.Command, repoLine string, trailsEnabled b
 	}
 	// Use an example command that is actually advertised here (trail is gated on
 	// trails being enabled), so we never point at a command the agent can't use.
-	example := "checkpoint"
+	example := cmdCheckpoint
 	if trailsEnabled {
-		example = "trail"
+		example = cmdTrail
 	}
 	fmt.Fprintf(&b, "\nDrill in for exact, currently-installed flags:  entire agent-help <command>  (e.g. entire agent-help %s)\n", example)
 	b.WriteString("Add --json for structured output.\n")

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -215,7 +215,7 @@ func newAuthTokenCmd() *cobra.Command {
 func newAuthStatusCmd() *cobra.Command {
 	var insecureHTTPAuth bool
 	cmd := &cobra.Command{
-		Use:   "status",
+		Use:   cmdStatus,
 		Short: "Show authentication status",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			target, err := resolveAuthStatusTarget(cmd.Context(), auth.Contexts, auth.RefreshedLoginToken)

--- a/cmd/entire/cli/benchutil/benchutil.go
+++ b/cmd/entire/cli/benchutil/benchutil.go
@@ -29,6 +29,12 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
+// Fixture identity for every benchmark repo and commit this package builds.
+const (
+	benchAuthorName  = "Bench User"
+	benchAuthorEmail = "bench@example.com"
+)
+
 // BenchRepo is a fully initialized git repository with Entire configured,
 // ready for checkpoint benchmarks.
 type BenchRepo struct {
@@ -150,8 +156,8 @@ func NewBenchRepo(b *testing.B, opts RepoOpts) *BenchRepo {
 		}
 		headHash, err = wt.Commit(fmt.Sprintf("Commit %d", c+1), &git.CommitOptions{
 			Author: &object.Signature{
-				Name:  "Bench User",
-				Email: "bench@example.com",
+				Name:  benchAuthorName,
+				Email: benchAuthorEmail,
 				When:  time.Now(),
 			},
 		})
@@ -371,8 +377,8 @@ func (br *BenchRepo) SeedShadowBranch(b *testing.B, sessionID string, checkpoint
 			ModifiedFiles:     modified,
 			MetadataDir:       metadataDir,
 			CommitMessage:     fmt.Sprintf("Checkpoint %d", i+1),
-			AuthorName:        "Bench User",
-			AuthorEmail:       "bench@example.com",
+			AuthorName:        benchAuthorName,
+			AuthorEmail:       benchAuthorEmail,
 			IsFirstCheckpoint: i == 0,
 		})
 		if err != nil {
@@ -412,8 +418,8 @@ func (br *BenchRepo) SeedMetadataBranch(b *testing.B, checkpointCount int) {
 			Prompts:          []string{fmt.Sprintf("Implement feature %d", i)},
 			FilesTouched:     files,
 			CheckpointsCount: 3,
-			AuthorName:       "Bench User",
-			AuthorEmail:      "bench@example.com",
+			AuthorName:       benchAuthorName,
+			AuthorEmail:      benchAuthorEmail,
 			Agent:            agent.AgentTypeClaudeCode,
 		})
 		if err != nil {

--- a/cmd/entire/cli/checkpoint/fsstore/fsstore.go
+++ b/cmd/entire/cli/checkpoint/fsstore/fsstore.go
@@ -326,7 +326,7 @@ func metadataFromWriteOptions(opts cp.WriteOptions) cp.Metadata {
 		TurnID:                      opts.TurnID,
 		TranscriptIdentifierAtStart: opts.TranscriptIdentifierAtStart,
 		CheckpointTranscriptStart:   opts.CheckpointTranscriptStart,
-		TranscriptLinesAtStart:      opts.CheckpointTranscriptStart, // git writes both for back-compat
+		TranscriptLinesAtStart:      opts.CheckpointTranscriptStart, //nolint:staticcheck // deliberate: git writes both so older CLIs can still read the metadata
 		TokenUsage:                  opts.TokenUsage,
 		SkillEvents:                 opts.SkillEvents,
 		PromptAttributions:          opts.PromptAttributionsJSON,

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -16,8 +16,6 @@ import (
 // CheckpointID identifies a checkpoint. It comes in two formats: a legacy
 // 12-character lowercase hex ID and a 26-character Crockford base32 ULID (see
 // Kind / CheckpointPattern). It links code commits to their checkpoint metadata.
-//
-//nolint:recvcheck // UnmarshalJSON requires pointer receiver, others use value receiver - standard pattern
 type CheckpointID string
 
 // EmptyCheckpointID represents an unset or invalid checkpoint ID.

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -727,7 +727,7 @@ func (s *treeWriter) writeSessionToSubdirectory(ctx context.Context, opts WriteO
 		TurnID:                      opts.TurnID,
 		TranscriptIdentifierAtStart: opts.TranscriptIdentifierAtStart,
 		CheckpointTranscriptStart:   opts.CheckpointTranscriptStart,
-		TranscriptLinesAtStart:      opts.CheckpointTranscriptStart, // Deprecated: kept for backward compat
+		TranscriptLinesAtStart:      opts.CheckpointTranscriptStart, //nolint:staticcheck // deliberate: written so older CLIs can still read the metadata
 		CompactTranscriptStart:      compactTranscriptStart,
 		TokenUsage:                  opts.TokenUsage,
 		SkillEventsVersion:          skillEventsVersion(opts.SkillEvents),

--- a/cmd/entire/cli/checkpoint_group.go
+++ b/cmd/entire/cli/checkpoint_group.go
@@ -12,8 +12,8 @@ import (
 // registers list/explain/tokens/search/resume as children.
 func newCheckpointGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "checkpoint",
-		Aliases: []string{"cp", "checkpoints"},
+		Use:     cmdCheckpoint,
+		Aliases: []string{"cp", cmdCheckpointsAlias},
 		Short:   "Inspect and search checkpoints",
 		Long: `Operations on checkpoints — the persistent records of agent work tied to commits.
 
@@ -75,7 +75,7 @@ func newCheckpointListCmd() *cobra.Command {
 	var pendingFlag bool
 
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List checkpoints on the current branch",
 		Long: `List checkpoints on the current branch.
 

--- a/cmd/entire/cli/checkpoint_tokens.go
+++ b/cmd/entire/cli/checkpoint_tokens.go
@@ -218,20 +218,20 @@ func buildCheckpointTokensReport(cpID id.CheckpointID, summary *checkpoint.Check
 		report.Tokens = tokens
 		if tokens.SubagentTotal > 0 {
 			report.Contributors = append(report.Contributors, sessionTokensContributor{
-				Kind:       "subagents",
+				Kind:       tokensKindSubagents,
 				Label:      "Subagents",
 				Tokens:     tokens.SubagentTotal,
-				Confidence: "reported",
-				Signals:    []string{"subagent_tokens"},
+				Confidence: tokensConfidenceReported,
+				Signals:    []string{tokensSignalSubagentTokens},
 			})
 		}
 	} else {
 		report.Limitations = append(report.Limitations, "No token usage recorded for this checkpoint.")
 		report.Recommendations = append(report.Recommendations, sessionTokensRecommendation{
 			ID:       "no-token-data",
-			Severity: "low",
+			Severity: tokensSeverityLow,
 			Message:  "Token usage is unavailable for this checkpoint; the agent may not expose token data yet, or this checkpoint predates token tracking.",
-			Signals:  []string{"missing_token_usage"},
+			Signals:  []string{tokensSignalMissingUsage},
 		})
 	}
 	if metadataWarnings > 0 {
@@ -251,11 +251,11 @@ func buildCheckpointTokensReport(cpID id.CheckpointID, summary *checkpoint.Check
 			if contextInfo := buildSessionTokensContext(metrics.ContextTokens, metrics.ContextWindowSize); contextInfo != nil {
 				report.Context = contextInfo
 				report.Contributors = append(report.Contributors, sessionTokensContributor{
-					Kind:       "context_pressure",
+					Kind:       tokensKindContextPressure,
 					Label:      "Context pressure",
 					Percent:    contextInfo.Percent,
-					Confidence: "reported",
-					Signals:    []string{"context_tokens"},
+					Confidence: tokensConfidenceReported,
+					Signals:    []string{tokensSignalContextTokens},
 				})
 			}
 		}
@@ -275,7 +275,7 @@ func buildCheckpointTokensReport(cpID id.CheckpointID, summary *checkpoint.Check
 		report.Contributors = append(report.Contributors, sessionTokensContributor{
 			Kind:       "skills",
 			Label:      "Skills/slash commands: " + strings.Join(labels, ", "),
-			Confidence: "reported",
+			Confidence: tokensConfidenceReported,
 			Signals:    []string{"skill_events"},
 		})
 	}

--- a/cmd/entire/cli/dispatch.go
+++ b/cmd/entire/cli/dispatch.go
@@ -147,7 +147,7 @@ func runDispatchCommand(ctx context.Context, outW io.Writer, opts dispatchpkg.Op
 }
 
 func isTerminalStdin(file *os.File) bool {
-	return term.IsTerminal(int(file.Fd())) //nolint:gosec // G115: uintptr->int is safe for fd
+	return term.IsTerminal(int(file.Fd()))
 }
 
 func shouldRunDispatchWizard(flagCount int, stdinIsTerminal bool, stdoutIsTerminal bool) bool {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1037,7 +1037,7 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store che
 	if content.Metadata.Summary != nil && !force {
 		return renderExplainFailure(errW, "Summary already exists", []explainRow{
 			{Label: "id", Value: checkpointID.String()},
-			{Label: "try", Value: fmt.Sprintf("entire checkpoint explain --generate --force %s", checkpointID)},
+			{Label: explainLabelTry, Value: fmt.Sprintf("entire checkpoint explain --generate --force %s", checkpointID)},
 		}, fmt.Errorf("checkpoint %s already has a summary", checkpointID))
 	}
 
@@ -1257,28 +1257,28 @@ func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, [
 		case claudecode.ClaudeErrorAuth:
 			label := "Claude authentication failed"
 			rows := []explainRow{
-				{Label: "try", Value: "run `claude login` and retry"},
+				{Label: explainLabelTry, Value: "run `claude login` and retry"},
 			}
 			if claudeErr.Message != "" {
-				rows = append([]explainRow{{Label: "message", Value: claudeErr.Message}}, rows...)
+				rows = append([]explainRow{{Label: explainLabelMessage, Value: claudeErr.Message}}, rows...)
 			}
 			return label, rows, fmt.Errorf("Claude authentication failed%s", formatMessageSuffix(claudeErr.Message)) //nolint:staticcheck // ST1005: Claude is a proper noun
 		case claudecode.ClaudeErrorRateLimit:
 			label := "Claude rejected the summary request due to rate limits or quota"
 			rows := []explainRow{
-				{Label: "try", Value: "wait and retry"},
+				{Label: explainLabelTry, Value: "wait and retry"},
 			}
 			if claudeErr.Message != "" {
-				rows = append([]explainRow{{Label: "message", Value: claudeErr.Message}}, rows...)
+				rows = append([]explainRow{{Label: explainLabelMessage, Value: claudeErr.Message}}, rows...)
 			}
 			return label, rows, fmt.Errorf("Claude rejected the summary request due to rate limits or quota%s", formatMessageSuffix(claudeErr.Message)) //nolint:staticcheck // ST1005
 		case claudecode.ClaudeErrorConfig:
 			label := "Claude rejected the summary request"
 			rows := []explainRow{
-				{Label: "try", Value: "check your Claude CLI config and selected model"},
+				{Label: explainLabelTry, Value: "check your Claude CLI config and selected model"},
 			}
 			if claudeErr.Message != "" {
-				rows = append([]explainRow{{Label: "message", Value: claudeErr.Message}}, rows...)
+				rows = append([]explainRow{{Label: explainLabelMessage, Value: claudeErr.Message}}, rows...)
 			}
 			return label, rows, fmt.Errorf("Claude rejected the summary request%s", formatMessageSuffix(claudeErr.Message)) //nolint:staticcheck // ST1005
 		case claudecode.ClaudeErrorCLIMissing:
@@ -1356,33 +1356,33 @@ func timeoutDiagnostic(_ error, attempt *summaryAttempt) (string, []explainRow) 
 		case attempt.phasesReached[agent.PhaseDone]:
 			label = "model finished but the result was not delivered in time"
 			rows = []explainRow{
-				{Label: "cause", Value: "the deadline fired while the finished result was being read"},
-				{Label: "try", Value: "raise --summary-timeout-seconds and retry"},
+				{Label: explainLabelCause, Value: "the deadline fired while the finished result was being read"},
+				{Label: explainLabelTry, Value: "raise --summary-timeout-seconds and retry"},
 			}
 		case attempt.phasesReached[agent.PhaseGenerating], attempt.phasesReached[agent.PhaseFirstToken]:
 			label = "model responded but did not finish"
 			rows = []explainRow{
-				{Label: "cause", Value: "transcript may be too large for the chosen cap, or model is slow"},
-				{Label: "try", Value: "raise --summary-timeout-seconds or pick a faster model"},
+				{Label: explainLabelCause, Value: "transcript may be too large for the chosen cap, or model is slow"},
+				{Label: explainLabelTry, Value: "raise --summary-timeout-seconds or pick a faster model"},
 			}
 		case attempt.phasesReached[agent.PhaseConnecting]:
 			label = "provider sent request but received no response"
 			rows = []explainRow{
-				{Label: "cause", Value: "network/firewall, provider API degraded, or auth check stuck"},
-				{Label: "try", Value: "check connectivity to the provider, then retry"},
+				{Label: explainLabelCause, Value: "network/firewall, provider API degraded, or auth check stuck"},
+				{Label: explainLabelTry, Value: "check connectivity to the provider, then retry"},
 			}
 		default:
 			label = "provider never sent its request"
 			rows = []explainRow{
-				{Label: "cause", Value: "the provider CLI may be stalled before subprocess startup"},
-				{Label: "try", Value: tryRunCLI},
+				{Label: explainLabelCause, Value: "the provider CLI may be stalled before subprocess startup"},
+				{Label: explainLabelTry, Value: tryRunCLI},
 			}
 		}
 		// attempt.streaming is set eagerly when a streaming-capable provider
 		// is selected, so a provider that stalls before its first event lands
 		// here — surface the captured stderr rather than dropping it.
 		if stderr != "" {
-			rows = append(rows, explainRow{Label: "stderr", Value: stderr})
+			rows = append(rows, explainRow{Label: explainLabelStderr, Value: stderr})
 		}
 		return prefix + label, rows
 	}
@@ -1391,21 +1391,21 @@ func timeoutDiagnostic(_ error, attempt *summaryAttempt) (string, []explainRow) 
 
 	if stdoutBytes == 0 {
 		rows := []explainRow{
-			{Label: "cause", Value: "provider CLI produced no output (likely network/auth/CLI path issue)"},
-			{Label: "try", Value: tryRunCLI},
+			{Label: explainLabelCause, Value: "provider CLI produced no output (likely network/auth/CLI path issue)"},
+			{Label: explainLabelTry, Value: tryRunCLI},
 		}
 		if stderr != "" {
-			rows = append(rows, explainRow{Label: "stderr", Value: stderr})
+			rows = append(rows, explainRow{Label: explainLabelStderr, Value: stderr})
 		}
 		return prefix + "provider produced no output", rows
 	}
 
 	rows := []explainRow{
-		{Label: "cause", Value: "provider was generating output but did not finish before cap"},
-		{Label: "try", Value: "raise --summary-timeout-seconds"},
+		{Label: explainLabelCause, Value: "provider was generating output but did not finish before cap"},
+		{Label: explainLabelTry, Value: "raise --summary-timeout-seconds"},
 	}
 	if stderr != "" {
-		rows = append(rows, explainRow{Label: "stderr", Value: stderr})
+		rows = append(rows, explainRow{Label: explainLabelStderr, Value: stderr})
 	}
 	return prefix + "provider was generating output when killed", rows
 }
@@ -1728,7 +1728,7 @@ func explainTemporaryCheckpoint(ctx context.Context, w, errW io.Writer, repo *gi
 
 	label := fmt.Sprintf("Checkpoint %s [temporary]", shortID)
 	rows := []explainRow{
-		{Label: "session", Value: tc.SessionID},
+		{Label: explainLabelSession, Value: tc.SessionID},
 		{Label: "created", Value: tc.Timestamp.Format("2006-01-02 15:04:05")},
 	}
 	sb.WriteString(styles.renderIdentity(label, "", rows))
@@ -3083,7 +3083,7 @@ func outputWithPager(w io.Writer, content string) {
 	// Check if we're writing to stdout and it's a terminal
 	if f, ok := w.(*os.File); ok && f == os.Stdout && interactive.IsTerminalWriter(w) {
 		// Get terminal height
-		_, height, err := term.GetSize(int(f.Fd())) //nolint:gosec // G115: same as above
+		_, height, err := term.GetSize(int(f.Fd()))
 		if err != nil {
 			height = 24 // Default fallback
 		}
@@ -3153,9 +3153,9 @@ func formatBranchCheckpoints(w io.Writer, branchName string, points []strategy.P
 		{Label: "branch", Value: branchName},
 	}
 	if sessionFilter != "" {
-		branchRows = append(branchRows, explainRow{Label: "session", Value: sessionFilter})
+		branchRows = append(branchRows, explainRow{Label: explainLabelSession, Value: sessionFilter})
 	}
-	branchRows = append(branchRows, explainRow{Label: "checkpoints", Value: strconv.Itoa(len(groups))})
+	branchRows = append(branchRows, explainRow{Label: explainLabelCheckpoints, Value: strconv.Itoa(len(groups))})
 
 	sb.WriteString(styles.metadataRows(branchRows))
 	sb.WriteString("\n")

--- a/cmd/entire/cli/grant.go
+++ b/cmd/entire/cli/grant.go
@@ -67,8 +67,8 @@ func newGrantCmd() *cobra.Command {
 // grants, so GRANTEE shows a friendly name (handle/org name) with SOURCE
 // saying where the grant comes from; ID keeps the ULID for revoke.
 var (
-	orgMemberColumns = []string{"ACCOUNT", "ROLE", "STATUS"}
-	grantColumns     = []string{"GRANTEE", "ROLE", "SOURCE", "TYPE", "ID"}
+	orgMemberColumns = []string{"ACCOUNT", colHeaderRole, colHeaderStatus}
+	grantColumns     = []string{"GRANTEE", colHeaderRole, "SOURCE", "TYPE", "ID"}
 )
 
 func orgMemberRow(m coreapi.Membership) []string {
@@ -98,7 +98,7 @@ func granteeName(name coreapi.OptString, granteeID string) string {
 
 func newGrantOrgCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "org",
+		Use:   cmdOrg,
 		Short: "Manage org membership",
 	}
 	cmd.AddCommand(newGrantOrgAddCmd())
@@ -313,6 +313,10 @@ func newGrantProjectRemoveCmd() *cobra.Command {
 	return cmd
 }
 
+// granteeTypeAccount is the only grantee kind the revoke-by-id calls take; the
+// provider-qualified variant has its own endpoint.
+const granteeTypeAccount = "account"
+
 // revokeProjectGrantee revokes a grantee (provider:handle or account ULID) from
 // a resolved project. projectRef is the user's original (pre-resolution) project
 // ref, used only for the success message.
@@ -321,7 +325,7 @@ func revokeProjectGrantee(ctx context.Context, cmd *cobra.Command, c *coreapi.Cl
 		func() error {
 			return c.RevokeProjectAccess(ctx, coreapi.RevokeProjectAccessParams{
 				ProjectId:   projID,
-				GranteeType: "account",
+				GranteeType: granteeTypeAccount,
 				GranteeId:   grantee,
 			})
 		},
@@ -363,7 +367,7 @@ func revokeGrantee(
 
 func newGrantRepoCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "repo",
+		Use:   cmdRepo,
 		Short: "Manage repo access",
 	}
 	cmd.AddCommand(newGrantRepoAddCmd())
@@ -476,7 +480,7 @@ func revokeRepoGrantee(ctx context.Context, cmd *cobra.Command, c *coreapi.Clien
 		func() error {
 			return c.RevokeRepoAccess(ctx, coreapi.RevokeRepoAccessParams{
 				RepoId:      repoID,
-				GranteeType: "account",
+				GranteeType: granteeTypeAccount,
 				GranteeId:   grantee,
 			})
 		},

--- a/cmd/entire/cli/hook_registry.go
+++ b/cmd/entire/cli/hook_registry.go
@@ -77,6 +77,13 @@ func newAgentHooksCmd(agentName types.AgentName, handler agent.HookSupport) *cob
 	return cmd
 }
 
+// Hook categories reported by getHookType.
+const (
+	hookTypeAgent    = "agent"
+	hookTypeTool     = "tool"
+	hookTypeSubagent = "subagent"
+)
+
 // getHookType returns the hook type based on the hook name.
 // Returns "subagent" for task-related hooks (pre-task, post-task, post-todo,
 // subagent-stop), "tool" for tool-related hooks (before-tool, after-tool),
@@ -85,11 +92,11 @@ func getHookType(hookName string) string {
 	switch hookName {
 	case claudecode.HookNamePreTask, claudecode.HookNamePostTask, claudecode.HookNamePostTodo,
 		claudecode.HookNameSubagentStop:
-		return "subagent"
+		return hookTypeSubagent
 	case geminicli.HookNameBeforeTool, geminicli.HookNameAfterTool:
-		return "tool"
+		return hookTypeTool
 	default:
-		return "agent"
+		return hookTypeAgent
 	}
 }
 

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -807,33 +807,33 @@ func (s *FactoryDroidSession) CreateDroidTranscript(prompt string, changes []Fil
 
 	// User message with prompt
 	lines = append(lines, map[string]interface{}{
-		"type": "message",
+		"type": entryTypeMessage,
 		"id":   "m1",
 		"message": map[string]interface{}{
-			"role": "user",
+			"role": roleUser,
 			"content": []map[string]interface{}{
-				{"type": "text", "text": prompt},
+				{"type": blockTypeText, "text": prompt},
 			},
 		},
 	})
 
 	// Assistant message with tool uses
 	assistantContent := []interface{}{
-		map[string]interface{}{"type": "text", "text": "I'll help you with that."},
+		map[string]interface{}{"type": blockTypeText, "text": "I'll help you with that."},
 	}
 	for i, change := range changes {
 		assistantContent = append(assistantContent, map[string]interface{}{
-			"type":  "tool_use",
+			"type":  blockTypeToolUse,
 			"id":    fmt.Sprintf("toolu_%d", i+1),
 			"name":  "Write",
 			"input": map[string]string{"file_path": change.Path, "content": change.Content},
 		})
 	}
 	lines = append(lines, map[string]interface{}{
-		"type": "message",
+		"type": entryTypeMessage,
 		"id":   "m2",
 		"message": map[string]interface{}{
-			"role":    "assistant",
+			"role":    roleAssistant,
 			"content": assistantContent,
 		},
 	})
@@ -842,28 +842,28 @@ func (s *FactoryDroidSession) CreateDroidTranscript(prompt string, changes []Fil
 	toolResultContent := make([]map[string]interface{}, 0, len(changes))
 	for i := range changes {
 		toolResultContent = append(toolResultContent, map[string]interface{}{
-			"type":        "tool_result",
+			"type":        blockTypeToolResult,
 			"tool_use_id": fmt.Sprintf("toolu_%d", i+1),
 			"content":     "Success",
 		})
 	}
 	lines = append(lines, map[string]interface{}{
-		"type": "message",
+		"type": entryTypeMessage,
 		"id":   "m3",
 		"message": map[string]interface{}{
-			"role":    "user",
+			"role":    roleUser,
 			"content": toolResultContent,
 		},
 	})
 
 	// Final assistant message
 	lines = append(lines, map[string]interface{}{
-		"type": "message",
+		"type": entryTypeMessage,
 		"id":   "m4",
 		"message": map[string]interface{}{
-			"role": "assistant",
+			"role": roleAssistant,
 			"content": []map[string]interface{}{
-				{"type": "text", "text": "Done!"},
+				{"type": blockTypeText, "text": "Done!"},
 			},
 		},
 	})
@@ -1096,11 +1096,11 @@ func (s *OpenCodeSession) CreateOpenCodeTranscript(prompt string, changes []File
 	s.messages = append(s.messages, map[string]interface{}{
 		"info": map[string]interface{}{
 			"id":   fmt.Sprintf("msg-%d", s.msgCounter),
-			"role": "user",
+			"role": roleUser,
 			"time": map[string]interface{}{"created": 1708300000 + s.msgCounter},
 		},
 		"parts": []map[string]interface{}{
-			{"type": "text", "text": prompt},
+			{"type": blockTypeText, "text": prompt},
 		},
 	})
 
@@ -1108,7 +1108,7 @@ func (s *OpenCodeSession) CreateOpenCodeTranscript(prompt string, changes []File
 	s.msgCounter++
 	var parts []map[string]interface{}
 	parts = append(parts, map[string]interface{}{
-		"type": "text",
+		"type": blockTypeText,
 		"text": "I'll help you with that.",
 	})
 	for i, change := range changes {
@@ -1124,14 +1124,14 @@ func (s *OpenCodeSession) CreateOpenCodeTranscript(prompt string, changes []File
 		})
 	}
 	parts = append(parts, map[string]interface{}{
-		"type": "text",
+		"type": blockTypeText,
 		"text": "Done!",
 	})
 
 	s.messages = append(s.messages, map[string]interface{}{
 		"info": map[string]interface{}{
 			"id":   fmt.Sprintf("msg-%d", s.msgCounter),
-			"role": "assistant",
+			"role": roleAssistant,
 			"time": map[string]interface{}{
 				"created":   1708300000 + s.msgCounter,
 				"completed": 1708300000 + s.msgCounter + 5,

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -36,6 +36,22 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
+// Fixture git identity used by every repo this harness initializes.
+const (
+	testAuthorName  = "Test User"
+	testAuthorEmail = "test@example.com"
+)
+
+// Values from the agent transcript JSONL wire formats the harness synthesizes.
+const (
+	entryTypeMessage    = "message"
+	roleUser            = "user"
+	roleAssistant       = "assistant"
+	blockTypeText       = "text"
+	blockTypeToolUse    = "tool_use"
+	blockTypeToolResult = "tool_result"
+)
+
 // testBinaryPath holds the path to the CLI binary built once in TestMain.
 // All tests share this binary to avoid repeated builds.
 var testBinaryPath string
@@ -227,8 +243,8 @@ func (env *TestEnv) InitRepo() {
 	if err != nil {
 		env.T.Fatalf("failed to get repo config: %v", err)
 	}
-	cfg.User.Name = "Test User"
-	cfg.User.Email = "test@example.com"
+	cfg.User.Name = testAuthorName
+	cfg.User.Email = testAuthorEmail
 
 	// Disable GPG signing for test commits (prevents failures if user has commit.gpgsign=true globally)
 	if cfg.Raw == nil {
@@ -484,8 +500,8 @@ func (env *TestEnv) GitCommit(message string) {
 
 	_, err = worktree.Commit(message, &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  "Test User",
-			Email: "test@example.com",
+			Name:  testAuthorName,
+			Email: testAuthorEmail,
 			When:  time.Now(),
 		},
 	})
@@ -515,8 +531,8 @@ func (env *TestEnv) GitCommitWithCheckpointID(message, checkpointID string) {
 
 	_, err = worktree.Commit(fullMessage, &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  "Test User",
-			Email: "test@example.com",
+			Name:  testAuthorName,
+			Email: testAuthorEmail,
 			When:  time.Now(),
 		},
 	})
@@ -552,8 +568,8 @@ func (env *TestEnv) GitCommitWithMultipleCheckpoints(message string, checkpointI
 
 	_, err = worktree.Commit(sb.String(), &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  "Test User",
-			Email: "test@example.com",
+			Name:  testAuthorName,
+			Email: testAuthorEmail,
 			When:  time.Now(),
 		},
 	})
@@ -1034,8 +1050,8 @@ func (env *TestEnv) gitCommitWithShadowHooks(message string, simulateTTY bool, f
 
 	_, err = worktree.Commit(string(modifiedMsg), &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  "Test User",
-			Email: "test@example.com",
+			Name:  testAuthorName,
+			Email: testAuthorEmail,
 			When:  time.Now(),
 		},
 	})
@@ -1112,8 +1128,8 @@ func (env *TestEnv) GitCommitAmendWithShadowHooks(message string, files ...strin
 
 	_, err = worktree.Commit(string(modifiedMsg), &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  "Test User",
-			Email: "test@example.com",
+			Name:  testAuthorName,
+			Email: testAuthorEmail,
 			When:  time.Now(),
 		},
 		Amend: true,
@@ -1218,8 +1234,8 @@ func (env *TestEnv) GitCommitWithTrailerRemoved(message string, files ...string)
 
 	_, err = worktree.Commit(cleanedMsg, &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  "Test User",
-			Email: "test@example.com",
+			Name:  testAuthorName,
+			Email: testAuthorEmail,
 			When:  time.Now(),
 		},
 	})
@@ -1293,8 +1309,8 @@ func (env *TestEnv) gitCommitStagedWithShadowHooks(message string, simulateTTY b
 
 	_, err = worktree.Commit(string(modifiedMsg), &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  "Test User",
-			Email: "test@example.com",
+			Name:  testAuthorName,
+			Email: testAuthorEmail,
 			When:  time.Now(),
 		},
 	})
@@ -1823,8 +1839,8 @@ func (env *TestEnv) CloneFrom(bareDir string) *TestEnv {
 
 	// Configure git user (clone doesn't inherit local config from the bare repo)
 	for _, kv := range [][2]string{
-		{"user.name", "Test User"},
-		{"user.email", "test@example.com"},
+		{"user.name", testAuthorName},
+		{"user.email", testAuthorEmail},
 		{"commit.gpgsign", "false"},
 	} {
 		testutil.RunGit(env.T, cloneDir, "config", kv[0], kv[1])

--- a/cmd/entire/cli/integration_test/transcript.go
+++ b/cmd/entire/cli/integration_test/transcript.go
@@ -28,7 +28,7 @@ func NewTranscriptBuilder() *TranscriptBuilder {
 func (b *TranscriptBuilder) AddUserMessage(content string) {
 	b.messages = append(b.messages, map[string]interface{}{
 		"uuid":      fmt.Sprintf("user-%d", len(b.messages)+1),
-		"type":      "user",
+		"type":      roleUser,
 		"message":   map[string]interface{}{"content": content},
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
 	})
@@ -38,10 +38,10 @@ func (b *TranscriptBuilder) AddUserMessage(content string) {
 func (b *TranscriptBuilder) AddAssistantMessage(content string) {
 	b.messages = append(b.messages, map[string]interface{}{
 		"uuid": fmt.Sprintf("asst-%d", len(b.messages)+1),
-		"type": "assistant",
+		"type": roleAssistant,
 		"message": map[string]interface{}{
 			"content": []map[string]interface{}{
-				{"type": "text", "text": content},
+				{"type": blockTypeText, "text": content},
 			},
 		},
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
@@ -55,7 +55,7 @@ func (b *TranscriptBuilder) AddToolUse(toolName, filePath, content string) strin
 	toolUseID := fmt.Sprintf("toolu_%d", b.toolUseCounter)
 
 	toolUse := map[string]interface{}{
-		"type": "tool_use",
+		"type": blockTypeToolUse,
 		"id":   toolUseID,
 		"name": toolName,
 		"input": map[string]interface{}{
@@ -66,7 +66,7 @@ func (b *TranscriptBuilder) AddToolUse(toolName, filePath, content string) strin
 
 	b.messages = append(b.messages, map[string]interface{}{
 		"uuid": fmt.Sprintf("asst-%d", len(b.messages)+1),
-		"type": "assistant",
+		"type": roleAssistant,
 		"message": map[string]interface{}{
 			"content": []interface{}{toolUse},
 		},
@@ -80,11 +80,11 @@ func (b *TranscriptBuilder) AddToolUse(toolName, filePath, content string) strin
 func (b *TranscriptBuilder) AddToolResult(toolUseID string) {
 	b.messages = append(b.messages, map[string]interface{}{
 		"uuid": fmt.Sprintf("user-%d", len(b.messages)+1),
-		"type": "user",
+		"type": roleUser,
 		"message": map[string]interface{}{
 			"content": []map[string]interface{}{
 				{
-					"type":        "tool_result",
+					"type":        blockTypeToolResult,
 					"tool_use_id": toolUseID,
 					"content":     "Success",
 				},
@@ -103,7 +103,7 @@ func (b *TranscriptBuilder) AddTaskToolUse(toolUseID, prompt string) string {
 	}
 
 	toolUse := map[string]interface{}{
-		"type": "tool_use",
+		"type": blockTypeToolUse,
 		"id":   toolUseID,
 		"name": "Task",
 		"input": map[string]interface{}{
@@ -114,7 +114,7 @@ func (b *TranscriptBuilder) AddTaskToolUse(toolUseID, prompt string) string {
 
 	b.messages = append(b.messages, map[string]interface{}{
 		"uuid": fmt.Sprintf("asst-%d", len(b.messages)+1),
-		"type": "assistant",
+		"type": roleAssistant,
 		"message": map[string]interface{}{
 			"content": []interface{}{toolUse},
 		},
@@ -131,11 +131,11 @@ func (b *TranscriptBuilder) AddTaskToolResult(toolUseID, agentID string) string 
 
 	b.messages = append(b.messages, map[string]interface{}{
 		"uuid": uuid,
-		"type": "user",
+		"type": roleUser,
 		"message": map[string]interface{}{
 			"content": []map[string]interface{}{
 				{
-					"type":        "tool_result",
+					"type":        blockTypeToolResult,
 					"tool_use_id": toolUseID,
 					"content":     "agentId: " + agentID,
 				},

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -119,7 +119,7 @@ func IsTerminalReader(r io.Reader) bool {
 	if !ok {
 		return false
 	}
-	return term.IsTerminal(int(f.Fd())) //nolint:gosec // G115: uintptr->int is safe for fd
+	return term.IsTerminal(int(f.Fd()))
 }
 
 // IsTerminalWriter reports whether w is an *os.File backed by a terminal.
@@ -130,7 +130,7 @@ func IsTerminalWriter(w io.Writer) bool {
 	if !ok {
 		return false
 	}
-	return term.IsTerminal(int(f.Fd())) //nolint:gosec // G115: uintptr->int is safe for fd
+	return term.IsTerminal(int(f.Fd()))
 }
 
 // ShouldStyle reports whether ANSI-styled output (color, bold, rendered

--- a/cmd/entire/cli/interactive/rawmode_unix.go
+++ b/cmd/entire/cli/interactive/rawmode_unix.go
@@ -40,7 +40,7 @@ import (
 // rawModeIoctl is the platform's termios read ioctl (rawmode_darwin.go,
 // rawmode_linux.go); rawmode_other.go covers platforms without termios.
 func ttyInRawMode(f *os.File) bool {
-	termios, err := unix.IoctlGetTermios(int(f.Fd()), rawModeIoctl) //nolint:gosec // G115: uintptr->int is safe for fd
+	termios, err := unix.IoctlGetTermios(int(f.Fd()), rawModeIoctl)
 	if err != nil {
 		// Can't tell — fail open so an unexpected ioctl failure never silently
 		// disables prompting. This check may only ever suppress prompts we

--- a/cmd/entire/cli/internal/flock/flock_unix.go
+++ b/cmd/entire/cli/internal/flock/flock_unix.go
@@ -78,7 +78,7 @@ func lockFile(ctx context.Context, open func() (*os.File, error), holdsCurrent f
 			if err != nil {
 				return nil, fmt.Errorf("open flock: %w", err)
 			}
-			if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil { //nolint:gosec // file descriptors are non-negative; standard Go pattern for syscall.Flock
+			if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
 				_ = f.Close()
 				return nil, fmt.Errorf("flock: %w", err)
 			}
@@ -101,7 +101,7 @@ func lockFile(ctx context.Context, open func() (*os.File, error), holdsCurrent f
 		if err != nil {
 			return nil, fmt.Errorf("open flock: %w", err)
 		}
-		lockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB) //nolint:gosec // see above
+		lockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 		if lockErr == nil {
 			current, err := holdsCurrent(f)
 			if err != nil {

--- a/cmd/entire/cli/labs.go
+++ b/cmd/entire/cli/labs.go
@@ -16,7 +16,7 @@ type experimentalCommandInfo struct {
 
 var experimentalCommands = []experimentalCommandInfo{
 	{
-		CommandPath: []string{"review"},
+		CommandPath: []string{cmdReview},
 		Invocation:  "entire review",
 		Summary:     "Run a multi-agent review against the current branch",
 	},
@@ -31,7 +31,7 @@ var experimentalCommands = []experimentalCommandInfo{
 		Summary:     "Import existing Claude Code transcripts as local, read-only history",
 	},
 	{
-		CommandPath: []string{"tokens"},
+		CommandPath: []string{cmdTokens},
 		Invocation:  "entire tokens",
 		Summary:     "Analyze experimental token usage diagnostics",
 	},
@@ -41,7 +41,7 @@ var experimentalCommands = []experimentalCommandInfo{
 		Summary:     "Aggregate token usage across committed checkpoints",
 	},
 	{
-		CommandPath: []string{"session", "tokens"},
+		CommandPath: []string{cmdSession, cmdTokens},
 		Invocation:  "entire session tokens",
 		Summary:     "Show token usage and recommendations for a session",
 	},

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -2196,11 +2196,15 @@ func tryAdoptEnv(ctx context.Context, state *session.State, expectedAgent string
 	spec.apply(ctx, state, envAgent)
 }
 
+// sessionKindLabelReview is the human label for a review session, shared by
+// env adoption and the trail resume summary.
+const sessionKindLabelReview = "review"
+
 // adoptReviewEnv tags the session as a review session when ENTIRE_REVIEW_*
 // env vars are present on the current process.
 func adoptReviewEnv(ctx context.Context, state *session.State, expectedAgent string) {
 	tryAdoptEnv(ctx, state, expectedAgent, envAdoptionSpec{
-		kindLabel:      "review",
+		kindLabel:      sessionKindLabelReview,
 		envSession:     review.EnvSession,
 		envAgent:       review.EnvAgent,
 		envStartingSHA: review.EnvStartingSHA,

--- a/cmd/entire/cli/mcp.go
+++ b/cmd/entire/cli/mcp.go
@@ -61,6 +61,9 @@ type mcpRequest struct {
 	Params  json.RawMessage `json:"params,omitempty"`
 }
 
+// jsonRPCVersion is the only JSON-RPC version this server speaks.
+const jsonRPCVersion = "2.0"
+
 type mcpResponse struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      json.RawMessage `json:"id"`
@@ -91,7 +94,7 @@ func runMCPServer(ctx context.Context, rootCmd *cobra.Command, in io.Reader, out
 
 		var req mcpRequest
 		if err := json.Unmarshal(line, &req); err != nil {
-			if encErr := enc.Encode(mcpResponse{JSONRPC: "2.0", ID: json.RawMessage("null"), Error: &mcpError{Code: -32700, Message: "parse error"}}); encErr != nil {
+			if encErr := enc.Encode(mcpResponse{JSONRPC: jsonRPCVersion, ID: json.RawMessage("null"), Error: &mcpError{Code: -32700, Message: "parse error"}}); encErr != nil {
 				return fmt.Errorf("write mcp parse-error response: %w", encErr)
 			}
 			continue
@@ -100,12 +103,12 @@ func runMCPServer(ctx context.Context, rootCmd *cobra.Command, in io.Reader, out
 		// Reject a parseable-but-invalid request (missing/incorrect jsonrpc version
 		// or empty method) with -32600 before dispatch, per JSON-RPC, rather than
 		// treating it as method-not-found.
-		if req.JSONRPC != "2.0" || req.Method == "" {
+		if req.JSONRPC != jsonRPCVersion || req.Method == "" {
 			id := req.ID
 			if len(id) == 0 {
 				id = json.RawMessage("null")
 			}
-			if encErr := enc.Encode(mcpResponse{JSONRPC: "2.0", ID: id, Error: &mcpError{Code: -32600, Message: "invalid request"}}); encErr != nil {
+			if encErr := enc.Encode(mcpResponse{JSONRPC: jsonRPCVersion, ID: id, Error: &mcpError{Code: -32600, Message: "invalid request"}}); encErr != nil {
 				return fmt.Errorf("write mcp invalid-request response: %w", encErr)
 			}
 			continue
@@ -124,7 +127,7 @@ func runMCPServer(ctx context.Context, rootCmd *cobra.Command, in io.Reader, out
 			continue
 		}
 
-		resp := mcpResponse{JSONRPC: "2.0", ID: req.ID}
+		resp := mcpResponse{JSONRPC: jsonRPCVersion, ID: req.ID}
 		if rpcErr != nil {
 			resp.Error = rpcErr
 		} else {
@@ -138,7 +141,7 @@ func runMCPServer(ctx context.Context, rootCmd *cobra.Command, in io.Reader, out
 		// A single line exceeded maxMCPMessageBytes (the scanner can't resynchronize
 		// past an over-long token) or the read failed; report once and stop.
 		if errors.Is(err, bufio.ErrTooLong) {
-			if encErr := enc.Encode(mcpResponse{JSONRPC: "2.0", ID: json.RawMessage("null"), Error: &mcpError{Code: -32600, Message: "request too large"}}); encErr != nil {
+			if encErr := enc.Encode(mcpResponse{JSONRPC: jsonRPCVersion, ID: json.RawMessage("null"), Error: &mcpError{Code: -32600, Message: "request too large"}}); encErr != nil {
 				return fmt.Errorf("write mcp oversize response: %w", encErr)
 			}
 			return nil

--- a/cmd/entire/cli/mdrender/mdrender.go
+++ b/cmd/entire/cli/mdrender/mdrender.go
@@ -93,7 +93,7 @@ func shouldRender(w io.Writer) bool {
 // Falls back to stdout/stderr probing, then DefaultTerminalWidth.
 func terminalWidth(w io.Writer) int {
 	if f, ok := w.(*os.File); ok {
-		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 { //nolint:gosec // G115: uintptr->int is safe for fd
+		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 {
 			return min(width, DefaultTerminalWidth)
 		}
 	}
@@ -101,7 +101,7 @@ func terminalWidth(w io.Writer) int {
 		if f == nil {
 			continue
 		}
-		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 { //nolint:gosec // G115: uintptr->int is safe for fd
+		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 {
 			return min(width, DefaultTerminalWidth)
 		}
 	}

--- a/cmd/entire/cli/names.go
+++ b/cmd/entire/cli/names.go
@@ -1,0 +1,42 @@
+package cli
+
+// Command and verb names that more than one file spells. Cobra takes these as
+// plain strings, so without a name here a rename means finding every `Use:`,
+// alias and hard-coded command path by hand.
+const (
+	cmdAgent      = "agent"
+	cmdCheckpoint = "checkpoint"
+	cmdCreateName = "create <name>"
+	cmdList       = "list"
+	cmdOrg        = "org"
+	cmdRepo       = "repo"
+	cmdReview     = "review"
+	cmdSession    = "session"
+	cmdStatus     = "status"
+	cmdTokens     = "tokens"
+	cmdTrail      = "trail"
+
+	// Plural aliases, kept beside the names they alias.
+	cmdCheckpointsAlias = "checkpoints"
+	cmdSessionsAlias    = "sessions"
+)
+
+// Column headers shared by the control-plane tables: org, project, repo, grant
+// and the mirror subtree each print several of the same columns.
+const (
+	colHeaderCloneURL = "CLONE URL"
+	colHeaderCluster  = "CLUSTER"
+	colHeaderName     = "NAME"
+	colHeaderRegion   = "REGION"
+	colHeaderRole     = "ROLE"
+	colHeaderStatus   = "STATUS"
+)
+
+// Display nouns selected by a count. Spelled here rather than inline because
+// several commands phrase the same "N thing(s)" line.
+const (
+	nounCheckpoint  = "checkpoint"
+	nounCheckpoints = "checkpoints"
+	nounSession     = "session"
+	nounSessions    = "sessions"
+)

--- a/cmd/entire/cli/org.go
+++ b/cmd/entire/cli/org.go
@@ -13,7 +13,7 @@ import (
 // delete organizations on the Entire control plane.
 func newOrgCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "org",
+		Use:   cmdOrg,
 		Short: "Manage Entire organizations",
 	}
 	addControlPlaneFlags(cmd)
@@ -26,7 +26,7 @@ func newOrgCmd() *cobra.Command {
 
 // orgColumns is the human table/field view of an org, shared by list and
 // any future `org get`.
-var orgColumns = []string{"ID", "NAME", "REGION", "CREATED"}
+var orgColumns = []string{"ID", colHeaderName, colHeaderRegion, "CREATED"}
 
 func orgRow(o coreapi.Org) []string {
 	return []string{o.ID, o.Name, o.Region, o.CreatedAt.Format("2006-01-02")}
@@ -35,7 +35,7 @@ func orgRow(o coreapi.Org) []string {
 func newOrgCreateCmd() *cobra.Command {
 	var region string
 	cmd := &cobra.Command{
-		Use:   "create <name>",
+		Use:   cmdCreateName,
 		Short: "Create an organization",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -59,7 +59,7 @@ func newOrgCreateCmd() *cobra.Command {
 
 func newOrgListCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List organizations you can see",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/entire/cli/plugin_group.go
+++ b/cmd/entire/cli/plugin_group.go
@@ -449,7 +449,7 @@ func warnIfShadowsBuiltin(cmd *cobra.Command, name string) {
 
 func newPluginListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List plugins installed in the managed directory",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runPluginList(cmd.OutOrStdout())

--- a/cmd/entire/cli/project.go
+++ b/cmd/entire/cli/project.go
@@ -25,7 +25,7 @@ func newProjectCmd() *cobra.Command {
 }
 
 // projectColumns is the human table/field view of a project.
-var projectColumns = []string{"ID", "NAME", "OWNER-TYPE", "OWNER", "REGION"}
+var projectColumns = []string{"ID", colHeaderName, "OWNER-TYPE", "OWNER", colHeaderRegion}
 
 func projectRow(p coreapi.Project) []string {
 	return []string{p.ID, p.Name, string(p.OwnerType), p.OwnerId, p.Region}
@@ -38,7 +38,7 @@ func newProjectCreateCmd() *cobra.Command {
 		region    string
 	)
 	cmd := &cobra.Command{
-		Use:   "create <name>",
+		Use:   cmdCreateName,
 		Short: "Create a project under an org or account",
 		Long: "Creates a project owned by an org or an account. --owner is the " +
 			"owning org (name or ULID) or account (github:handle or ULID), and " +
@@ -94,7 +94,7 @@ func newProjectCreateCmd() *cobra.Command {
 func newProjectListCmd() *cobra.Command {
 	var name, org string
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List projects you can see",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -198,14 +198,20 @@ func newProjectDeleteCmd() *cobra.Command {
 	return cmd
 }
 
+// The two owner kinds a project may have, as the --owner-type flag spells them.
+const (
+	ownerTypeOrg     = "org"
+	ownerTypeAccount = "account"
+)
+
 // parseProjectOwnerType maps the --owner-type flag to the generated enum,
 // rejecting anything but org/account at the CLI boundary so the user gets
 // a clear message instead of a server 422.
 func parseProjectOwnerType(s string) (coreapi.CreateProjectInputBodyOwnerType, error) {
 	switch s {
-	case "org":
+	case ownerTypeOrg:
 		return coreapi.CreateProjectInputBodyOwnerTypeOrg, nil
-	case "account":
+	case ownerTypeAccount:
 		return coreapi.CreateProjectInputBodyOwnerTypeAccount, nil
 	default:
 		// Plain error: the create RunE sets SilenceUsage, and main.go

--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -258,7 +258,7 @@ func terminalWidth(w io.Writer) int {
 	if !isatty.IsTerminal(file.Fd()) {
 		return recap.DefaultWidth
 	}
-	width, _, err := term.GetSize(int(file.Fd())) //nolint:gosec // fd values fit in int on supported platforms
+	width, _, err := term.GetSize(int(file.Fd()))
 	if err != nil || width <= 0 {
 		return recap.DefaultWidth
 	}

--- a/cmd/entire/cli/recap_tui.go
+++ b/cmd/entire/cli/recap_tui.go
@@ -261,6 +261,14 @@ func (m recapTUIModel) withViewport() recapTUIModel {
 	return m
 }
 
+// Footer key-hint labels, repeated across the progressively shorter footer
+// variants renderFooter picks between.
+const (
+	recapHintView  = "view"
+	recapHintAgent = "agent"
+	recapHintQuit  = "quit"
+)
+
 func (m recapTUIModel) renderFooter() string {
 	choices := []string{
 		recapFooterLine(m.color, []recapHelpItem{
@@ -268,24 +276,24 @@ func (m recapTUIModel) renderFooter() string {
 			{"w", "week"},
 			{"m", "month"},
 			{"r", "90d"},
-			{"v", "view"},
-			{"a", "agent"},
+			{"v", recapHintView},
+			{"a", recapHintAgent},
 			{"R", "reload"},
-			{"q", "quit"},
+			{"q", recapHintQuit},
 		}),
 		recapFooterLine(m.color, []recapHelpItem{
 			{"d/w/m/r", "range"},
-			{"v", "view"},
-			{"a", "agent"},
-			{"q", "quit"},
+			{"v", recapHintView},
+			{"a", recapHintAgent},
+			{"q", recapHintQuit},
 		}),
 		recapFooterLine(m.color, []recapHelpItem{
 			{"d/w/m/r", "range"},
-			{"v", "view"},
-			{"q", "quit"},
+			{"v", recapHintView},
+			{"q", recapHintQuit},
 		}),
 		recapFooterLine(m.color, []recapHelpItem{
-			{"q", "quit"},
+			{"q", recapHintQuit},
 		}),
 	}
 	for _, choice := range choices {

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -20,7 +20,7 @@ import (
 // operations (log, diff, …) remain intentionally out of scope here.
 func newRepoCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "repo",
+		Use:   cmdRepo,
 		Short: "Manage Entire repositories",
 	}
 	addControlPlaneFlags(cmd)
@@ -36,7 +36,7 @@ func newRepoCmd() *cobra.Command {
 
 // repoColumns is the human table/field view of a repo, shared by list and
 // get. CLUSTER/STATE come from optional fields, shown as "-" when unset.
-var repoColumns = []string{"ID", "NAME", "PROJECT", "CLUSTER", "STATE"}
+var repoColumns = []string{"ID", colHeaderName, "PROJECT", colHeaderCluster, "STATE"}
 
 func repoRow(r coreapi.Repo) []string {
 	return []string{r.ID, r.Name, r.OwningProjectId, r.ClusterHost.Or("-"), r.State.Or("-")}
@@ -128,7 +128,7 @@ func newRepoCreateCmd() *cobra.Command {
 		objectFormat string
 	)
 	cmd := &cobra.Command{
-		Use:   "create <name>",
+		Use:   cmdCreateName,
 		Short: "Create a repository in a project",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -35,11 +35,11 @@ type column struct {
 // so a --sort value needs no quoting; headers stay upper-case display text.
 var (
 	colName       = column{key: "name", header: "NAME (owner/repo)"}
-	colCloneURL   = column{key: "clone-url", header: "CLONE URL"}
+	colCloneURL   = column{key: "clone-url", header: colHeaderCloneURL}
 	colClusters   = column{key: "clusters", header: "CLUSTERS"}
 	colVisibility = column{key: "visibility", header: "VISIBILITY"}
 	colAccess     = column{key: "access", header: "ACCESS"}
-	colStatus     = column{key: "status", header: "STATUS"}
+	colStatus     = column{key: "status", header: colHeaderStatus}
 )
 
 // columnHeaders is the display-header view of a column set, for the table/field
@@ -923,7 +923,7 @@ func newRepoMirrorListCmd() *cobra.Command {
 	var pageToken string
 	var noPager, all bool
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List repos you can see: existing mirrors and GitHub repos you could onboard",
 		Long: "List repos visible from your login in one table: existing mirrors " +
 			"(one row per repo, with the clusters it is mirrored on and the clone " +
@@ -1140,7 +1140,7 @@ func renderRepoDetail(w io.Writer, row repoDirRow) {
 		return
 	}
 
-	headers := styledHeaders(st, []string{"CLUSTER", "CLONE URL", "STATUS"})
+	headers := styledHeaders(st, []string{colHeaderCluster, colHeaderCloneURL, colHeaderStatus})
 	rows := make([][]string, len(row.Placements))
 	for i, p := range row.Placements {
 		cluster, status := p.Cluster, p.Status

--- a/cmd/entire/cli/repo_mirror_collaborators.go
+++ b/cmd/entire/cli/repo_mirror_collaborators.go
@@ -13,7 +13,7 @@ import (
 // collaborator: the display handle, the reader/writer role, and the Entire
 // account ULID (the stable identifier, shown last as the fallback when no
 // handle resolves).
-var mirrorCollaboratorColumns = []string{"HANDLE", "ROLE", "ACCOUNT"}
+var mirrorCollaboratorColumns = []string{"HANDLE", colHeaderRole, "ACCOUNT"}
 
 func mirrorCollaboratorRow(c coreapi.MirrorCollaborator) []string {
 	handle := c.Handle.Or("")

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -292,7 +292,7 @@ type mirrorResult struct {
 	err         error
 }
 
-var mirrorCreateResultColumns = []string{"REPO", "REGION", "STATUS", "CLONE URL"}
+var mirrorCreateResultColumns = []string{"REPO", colHeaderRegion, colHeaderStatus, colHeaderCloneURL}
 
 func mirrorCreateResultRow(r mirrorResult) []string {
 	url := r.cloneURL

--- a/cmd/entire/cli/review/configure_test.go
+++ b/cmd/entire/cli/review/configure_test.go
@@ -325,7 +325,7 @@ func TestBuildConfiguredProfile_PreservesExistingTask(t *testing.T) {
 func TestSelectReviewProfile_LegacyReviewFallback(t *testing.T) {
 	t.Parallel()
 	s := &settings.EntireSettings{
-		Review: map[string]settings.ReviewConfig{
+		Review: map[string]settings.ReviewConfig{ //nolint:staticcheck // exercises the legacy pre-profile fallback on purpose
 			tAgentClaude: {Skills: []string{"/review"}, Model: tModelSonnet},
 		},
 	}
@@ -353,7 +353,7 @@ func TestSelectReviewProfile_ConfiguredProfilesOverrideLegacyReview(t *testing.T
 	t.Parallel()
 	const securityProfile = "security"
 	s := &settings.EntireSettings{
-		Review: map[string]settings.ReviewConfig{
+		Review: map[string]settings.ReviewConfig{ //nolint:staticcheck // exercises the legacy pre-profile fallback on purpose
 			tAgentClaude: {Skills: []string{"/legacy"}},
 		},
 		ReviewProfiles: map[string]settings.ReviewProfileConfig{

--- a/cmd/entire/cli/review/picker.go
+++ b/cmd/entire/cli/review/picker.go
@@ -204,8 +204,8 @@ func promptForReviewFocus(ctx context.Context, current string) (string, string, 
 	picked := DefaultProfileName
 	presets := []struct{ label, value string }{
 		{"General - correctness, regressions, tests", DefaultProfileName},
-		{"Security - auth, injection, secrets", "security"},
-		{"Accessibility - keyboard, screen readers, contrast", "accessibility"},
+		{"Security - auth, injection, secrets", SecurityProfileName},
+		{"Accessibility - keyboard, screen readers, contrast", AccessibilityProfileName},
 	}
 	options := make([]huh.Option[string], 0, len(presets)+1)
 	for _, p := range presets {

--- a/cmd/entire/cli/review/profile.go
+++ b/cmd/entire/cli/review/profile.go
@@ -16,7 +16,14 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/tuiutil"
 )
 
-const DefaultProfileName = "general"
+// Built-in profile names. DefaultProfileName is the profile used when none is
+// named; the other two are the presets the picker offers and profileTask knows
+// a built-in task for.
+const (
+	DefaultProfileName       = "general"
+	SecurityProfileName      = "security"
+	AccessibilityProfileName = "accessibility"
+)
 
 // Review output destinations. ReviewOutputLocal prints the verdict and writes
 // the local review manifest; ReviewOutputTrail additionally posts the verdict
@@ -63,9 +70,9 @@ func profileTask(name string, cfg settings.ReviewProfileConfig) string {
 	switch strings.ToLower(name) {
 	case "", DefaultProfileName:
 		return defaultGeneralTask
-	case "security":
+	case SecurityProfileName:
 		return defaultSecurityTask
-	case "accessibility", "a11y":
+	case AccessibilityProfileName, "a11y":
 		return defaultAccessibilityTask
 	default:
 		return defaultGeneralTask
@@ -398,7 +405,7 @@ func defaultReviewAgentConfig(profileName, agentName string) settings.ReviewConf
 	focus := defaultProfileFocus(profileName)
 	switch agentName {
 	case string(agent.AgentNameClaudeCode):
-		if strings.EqualFold(profileName, "security") {
+		if strings.EqualFold(profileName, SecurityProfileName) {
 			return settings.ReviewConfig{Skills: []string{"/security-review"}}
 		}
 		return settings.ReviewConfig{Skills: []string{"/review"}, Prompt: focus}
@@ -415,9 +422,9 @@ func defaultReviewAgentConfig(profileName, agentName string) settings.ReviewConf
 
 func defaultProfileFocus(profileName string) string {
 	switch strings.ToLower(strings.TrimSpace(profileName)) {
-	case "security":
+	case SecurityProfileName:
 		return "Focus specifically on security issues."
-	case "accessibility", "a11y":
+	case AccessibilityProfileName, "a11y":
 		return "Focus specifically on accessibility issues."
 	default:
 		return ""

--- a/cmd/entire/cli/review/tui_sink.go
+++ b/cmd/entire/cli/review/tui_sink.go
@@ -120,7 +120,7 @@ func terminalMeasurer(output io.Writer) func() (int, int, bool) {
 		return nil
 	}
 	return func() (int, int, bool) {
-		width, height, err := term.GetSize(int(f.Fd())) //nolint:gosec // fd values fit in int on supported platforms
+		width, height, err := term.GetSize(int(f.Fd()))
 		if err != nil || width <= 0 || height <= 0 {
 			return 0, 0, false
 		}

--- a/cmd/entire/cli/runner_gather.go
+++ b/cmd/entire/cli/runner_gather.go
@@ -28,6 +28,7 @@ const (
 )
 
 const (
+	sourceRepo        = "repo"
 	sourceCheckpoint  = "checkpoint"
 	sourceCheckpoints = "checkpoints"
 	sourceTrail       = "trail"
@@ -57,7 +58,7 @@ func parseTuneSources(list []string) (tuneSources, error) {
 			continue
 		case "all":
 			return allTuneSources(), nil
-		case "repo":
+		case sourceRepo:
 			s.repo = true
 		case "pr", "prs", "issue", "issues":
 			s.prs = true

--- a/cmd/entire/cli/session_adopt_test.go
+++ b/cmd/entire/cli/session_adopt_test.go
@@ -961,8 +961,8 @@ func TestSessionAdopt_ResetsSourceCheckpointWindow(t *testing.T) {
 		ContextWindowSize:           200_000,
 		CheckpointTranscriptStart:   2,
 		CheckpointTranscriptSize:    1234,
-		CondensedTranscriptLines:    2,
-		TranscriptLinesAtStart:      2,
+		CondensedTranscriptLines:    2, //nolint:staticcheck // legacy field, asserted so migration keeps working
+		TranscriptLinesAtStart:      2, //nolint:staticcheck // legacy field, asserted so migration keeps working
 		TranscriptIdentifierAtStart: "source-assistant",
 		TurnID:                      "source-turn",
 		TurnCheckpointIDs:           []string{"abc123def456"},
@@ -1086,8 +1086,8 @@ func TestSessionAdopt_ClearsLegacyTranscriptOffsets(t *testing.T) {
 		BaseCommit:                "source-head",
 		WorktreePath:              "/source/repo",
 		CheckpointTranscriptStart: 9,
-		CondensedTranscriptLines:  9,
-		TranscriptLinesAtStart:    9,
+		CondensedTranscriptLines:  9, //nolint:staticcheck // legacy field, asserted so migration keeps working
+		TranscriptLinesAtStart:    9, //nolint:staticcheck // legacy field, asserted so migration keeps working
 	})
 	if err != nil {
 		t.Fatalf("buildAdoptedSessionState failed: %v", err)

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -13,6 +13,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// The token-report vocabulary, shared by `session tokens`, `checkpoint tokens`
+// and `tokens profile`: these strings are part of those commands' --json
+// contract, so they are named once rather than spelled per call site.
+const (
+	tokensKindSubagents       = "subagents"
+	tokensKindContextPressure = "context_pressure"
+
+	tokensConfidenceReported = "reported"
+
+	tokensSignalSubagentTokens  = "subagent_tokens"
+	tokensSignalMissingUsage    = "missing_token_usage"
+	tokensSignalContextTokens   = "context_tokens"
+	tokensSignalCacheReadTokens = "cache_read_tokens"
+	tokensSignalAPICallCount    = "api_call_count"
+
+	tokensSeverityLow    = "low"
+	tokensSeverityMedium = "medium"
+	tokensSeverityHigh   = "high"
+)
+
 type sessionTokensReport struct {
 	SessionID       string                        `json:"session_id"`
 	Agent           string                        `json:"agent"`
@@ -209,31 +229,31 @@ func buildSessionTokensReport(state *strategy.SessionState, status string) sessi
 		report.Tokens = tokens
 		if tokens.SubagentTotal > 0 {
 			report.Contributors = append(report.Contributors, sessionTokensContributor{
-				Kind:       "subagents",
+				Kind:       tokensKindSubagents,
 				Label:      "Subagents",
 				Tokens:     tokens.SubagentTotal,
-				Confidence: "reported",
-				Signals:    []string{"subagent_tokens"},
+				Confidence: tokensConfidenceReported,
+				Signals:    []string{tokensSignalSubagentTokens},
 			})
 		}
 	} else {
 		report.Limitations = append(report.Limitations, "No token usage recorded for this session.")
 		report.Recommendations = append(report.Recommendations, sessionTokensRecommendation{
 			ID:       "no-token-data",
-			Severity: "low",
+			Severity: tokensSeverityLow,
 			Message:  "Token usage is unavailable for this session; the agent may not expose token data yet, or no checkpoint has captured it.",
-			Signals:  []string{"missing_token_usage"},
+			Signals:  []string{tokensSignalMissingUsage},
 		})
 	}
 
 	if contextInfo := buildSessionTokensContext(state.ContextTokens, state.ContextWindowSize); contextInfo != nil {
 		report.Context = contextInfo
 		report.Contributors = append(report.Contributors, sessionTokensContributor{
-			Kind:       "context_pressure",
+			Kind:       tokensKindContextPressure,
 			Label:      "Context pressure",
 			Percent:    contextInfo.Percent,
-			Confidence: "reported",
-			Signals:    []string{"context_tokens"},
+			Confidence: tokensConfidenceReported,
+			Signals:    []string{tokensSignalContextTokens},
 		})
 	}
 
@@ -241,7 +261,7 @@ func buildSessionTokensReport(state *strategy.SessionState, status string) sessi
 		report.Contributors = append(report.Contributors, sessionTokensContributor{
 			Kind:       "skills",
 			Label:      "Skills/slash commands: " + strings.Join(labels, ", "),
-			Confidence: "reported",
+			Confidence: tokensConfidenceReported,
 			Signals:    []string{"skill_events"},
 		})
 	}
@@ -328,12 +348,12 @@ func recommendationRules(signals tokenRecommendationSignals) []sessionTokensReco
 			cacheReadHotspot = true
 			recs = append(recs, sessionTokensRecommendation{
 				ID:       "context-replay-hotspot",
-				Severity: "high",
+				Severity: tokensSeverityHigh,
 				Message: fmt.Sprintf(
 					"Cache/context replay is %s of token volume; reduce unnecessary follow-up calls in this large-context session.",
 					formatPercent(cacheReadPercent),
 				),
-				Signals: []string{"cache_read_tokens"},
+				Signals: []string{tokensSignalCacheReadTokens},
 			})
 		}
 	}
@@ -344,24 +364,24 @@ func recommendationRules(signals tokenRecommendationSignals) []sessionTokensReco
 		}
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "api-call-amplification",
-			Severity: "medium",
+			Severity: tokensSeverityMedium,
 			Message:  message,
-			Signals:  []string{"api_call_count"},
+			Signals:  []string{tokensSignalAPICallCount},
 		})
 	}
 	if signals.Tokens != nil && tokenShareAtLeastOneTenth(signals.Tokens.SubagentTotal, signals.Tokens.Total) {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "subagent-heavy",
-			Severity: "medium",
+			Severity: tokensSeverityMedium,
 			Message:  "Scope subagent tasks tightly; give each subagent a narrow objective and expected output.",
-			Signals:  []string{"subagent_tokens"},
+			Signals:  []string{tokensSignalSubagentTokens},
 		})
 	}
 	if signals.Tokens != nil && signals.Tokens.Total > 0 &&
 		tokenClassPressure(signals.Tokens.CacheWrite, signals.Tokens.Total, 5000, 10, 50_000) {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "cache-write-pressure",
-			Severity: "medium",
+			Severity: tokensSeverityMedium,
 			Message:  "Cache write is elevated; avoid broad new context and narrow the next read before continuing.",
 			Signals:  []string{"cache_write_tokens"},
 		})
@@ -370,7 +390,7 @@ func recommendationRules(signals tokenRecommendationSignals) []sessionTokensReco
 		tokenClassPressure(signals.Tokens.Output, signals.Tokens.Total, 3000, 2, 10_000) {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "output-pressure",
-			Severity: "medium",
+			Severity: tokensSeverityMedium,
 			Message:  "Output tokens are elevated; keep the next answer tight and avoid restating evidence.",
 			Signals:  []string{"output_tokens"},
 		})
@@ -378,23 +398,23 @@ func recommendationRules(signals tokenRecommendationSignals) []sessionTokensReco
 	if signals.Context != nil && signals.Context.Percent >= recommendationHighContextPercent {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "high-context-pressure",
-			Severity: "medium",
+			Severity: tokensSeverityMedium,
 			Message:  fmt.Sprintf("Context pressure is %d%% of the window; preserve only relevant context before continuing.", signals.Context.Percent),
-			Signals:  []string{"context_tokens"},
+			Signals:  []string{tokensSignalContextTokens},
 		})
 	}
 	if cacheReadHotspot && signals.Tokens != nil && signals.Tokens.APICalls >= recommendationHighAPICalls {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "summarize-before-boundary",
-			Severity: "low",
+			Severity: tokensSeverityLow,
 			Message:  "Compact or restart after summarizing this investigation; do not discard useful findings just because cache read is high.",
-			Signals:  []string{"cache_read_tokens", "api_call_count"},
+			Signals:  []string{tokensSignalCacheReadTokens, tokensSignalAPICallCount},
 		})
 	}
 	if signals.TurnCount >= recommendationLongSessionTurns || signals.CheckpointCount >= recommendationLongSessionCheckpoints {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "long-session",
-			Severity: "low",
+			Severity: tokensSeverityLow,
 			Message:  "Compact or restart after summarizing the useful findings if older context is no longer needed.",
 			Signals:  []string{"turn_count", "checkpoint_count"},
 		})
@@ -637,9 +657,9 @@ func writeTokenContributors(w io.Writer, contributors []sessionTokensContributor
 		fmt.Fprintln(w, "Likely contributors")
 		for _, contributor := range contributors {
 			switch contributor.Kind {
-			case "subagents":
+			case tokensKindSubagents:
 				fmt.Fprintf(w, "- %s: %s tokens\n", contributor.Label, formatTokenCount(contributor.Tokens))
-			case "context_pressure":
+			case tokensKindContextPressure:
 				if contextInfo != nil {
 					fmt.Fprintf(w, "- %s: %d%% of %s tokens\n", contributor.Label, contextInfo.Percent, formatTokenCount(contextInfo.WindowSize))
 				}

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -156,8 +156,8 @@ func writeWholeDocumentJSONTranscript(ctx context.Context, w io.Writer, r io.Rea
 
 func newSessionsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "session",
-		Aliases: []string{"sessions"},
+		Use:     cmdSession,
+		Aliases: []string{cmdSessionsAlias},
 		Short:   "Manage agent sessions tracked by Entire",
 		Long: `View and manage agent sessions tracked by Entire.
 
@@ -325,7 +325,7 @@ func newListCmd() *cobra.Command {
 	var jsonFlag bool
 
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List all sessions",
 		Long: `List all sessions tracked by Entire, including ended sessions.
 

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -167,7 +167,7 @@ func TestLoad_AcceptsValidKeys(t *testing.T) {
 	if settings.SummaryGeneration.Provider != "claude-code" {
 		t.Errorf("expected summary_generation.provider 'claude-code', got %q", settings.SummaryGeneration.Provider)
 	}
-	if settings.SummaryGeneration.Model != "sonnet" { //nolint:goconst // test literal
+	if settings.SummaryGeneration.Model != "sonnet" {
 		t.Errorf("expected summary_generation.model 'sonnet', got %q", settings.SummaryGeneration.Model)
 	}
 	if settings.Redaction == nil {

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -38,7 +38,7 @@ func newStatusCmd() *cobra.Command {
 	var jsonFlag bool
 
 	cmd := &cobra.Command{
-		Use:   "status",
+		Use:   cmdStatus,
 		Short: "Show Entire status",
 		Long:  "Show whether Entire is currently enabled or disabled",
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -467,10 +467,10 @@ func writeCheckpointSyncLines(ctx context.Context, b *strings.Builder, s *Entire
 // mode has no git remote to name (and only reaches here on the git-refs
 // backend), so it drops the remote-name phrasing.
 func formatUnpushedCheckpointsLine(info checkpointSyncInfo) string {
-	noun := "checkpoints"
+	noun := nounCheckpoints
 	pronoun := "they sync"
 	if info.Unpushed == 1 {
-		noun = "checkpoint"
+		noun = nounCheckpoint
 		pronoun = "it syncs"
 	}
 	if info.Source == checkpointSyncSourceDedicated {

--- a/cmd/entire/cli/status_style.go
+++ b/cmd/entire/cli/status_style.go
@@ -76,7 +76,7 @@ func shouldUseColor(w io.Writer) bool {
 func getTerminalWidth(w io.Writer) int {
 	// Try the output writer first
 	if f, ok := w.(*os.File); ok {
-		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 { //nolint:gosec // G115: uintptr->int is safe for fd
+		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 {
 			return min(width, 80)
 		}
 	}
@@ -86,7 +86,7 @@ func getTerminalWidth(w io.Writer) int {
 		if f == nil {
 			continue
 		}
-		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 { //nolint:gosec // G115: uintptr->int is safe for fd
+		if width, _, err := term.GetSize(int(f.Fd())); err == nil && width > 0 {
 			return min(width, 80)
 		}
 	}
@@ -118,6 +118,16 @@ func totalTokens(tu *agent.TokenUsage) int {
 	total = saturatingIntAdd(total, totalTokens(tu.SubagentTokens))
 	return total
 }
+
+// Row labels reused across the explain output's diagnostic tables.
+const (
+	explainLabelCause       = "cause"
+	explainLabelCheckpoints = "checkpoints"
+	explainLabelMessage     = "message"
+	explainLabelSession     = "session"
+	explainLabelStderr      = "stderr"
+	explainLabelTry         = "try"
+)
 
 // explainRow is one entry in a metadata block: dim label + plain value.
 type explainRow struct {

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -35,6 +35,10 @@ const (
 	CleanupTypeRedactCache CleanupType = "redact-cache"
 )
 
+// cleanAllReason marks an item discovered by the unfiltered sweep, as opposed
+// to one selected by an orphan or staleness rule.
+const cleanAllReason = "clean all"
+
 // CleanupItem represents an item that can be cleaned up.
 type CleanupItem struct {
 	Type   CleanupType
@@ -501,7 +505,7 @@ func ListAllItems(ctx context.Context) ([]CleanupItem, error) {
 		cleanupItems = append(cleanupItems, CleanupItem{
 			Type:   CleanupTypeShadowBranch,
 			ID:     branch,
-			Reason: "clean all",
+			Reason: cleanAllReason,
 		})
 	}
 
@@ -520,7 +524,7 @@ func ListAllItems(ctx context.Context) ([]CleanupItem, error) {
 		cleanupItems = append(cleanupItems, CleanupItem{
 			Type:   CleanupTypeSessionState,
 			ID:     state.SessionID,
-			Reason: "clean all",
+			Reason: cleanAllReason,
 		})
 	}
 
@@ -531,7 +535,7 @@ func ListAllItems(ctx context.Context) ([]CleanupItem, error) {
 			cleanupItems = append(cleanupItems, CleanupItem{
 				Type:   CleanupTypeRedactCache,
 				ID:     checkpoint.RedactCacheDirName,
-				Reason: "clean all",
+				Reason: cleanAllReason,
 			})
 		}
 	}

--- a/cmd/entire/cli/strategy/hook_managers_test.go
+++ b/cmd/entire/cli/strategy/hook_managers_test.go
@@ -55,7 +55,7 @@ func TestDetectHookManagers_Lefthook(t *testing.T) {
 	if len(managers) != 1 {
 		t.Fatalf("expected 1 manager, got %d", len(managers))
 	}
-	if managers[0].Name != "Lefthook" { //nolint:goconst // test assertion, not a magic string
+	if managers[0].Name != "Lefthook" {
 		t.Errorf("expected Lefthook, got %s", managers[0].Name)
 	}
 	if managers[0].ConfigPath != "lefthook.yml" {

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -34,8 +34,12 @@ const goosWindows = "windows"
 const chainComment = "# Chain: run pre-existing hook"
 const missingEntireGitHookWarning = "[entire] Entire CLI is enabled but not installed or not on PATH. Skipping Entire Git hook; continuing. Installation guide: https://docs.entire.io/cli/installation#installation-methods"
 
+// postRewriteHook is named on its own because the rewrite hook is the one
+// Entire branches on by name (see below).
+const postRewriteHook = "post-rewrite"
+
 // gitHookNames are the git hooks managed by Entire CLI
-var gitHookNames = []string{"prepare-commit-msg", "commit-msg", "post-commit", "post-rewrite", "pre-push"}
+var gitHookNames = []string{"prepare-commit-msg", "commit-msg", "post-commit", postRewriteHook, "pre-push"}
 
 // ManagedGitHookNames returns the list of git hooks managed by Entire CLI.
 // This is useful for tests that need to manipulate hooks.
@@ -595,7 +599,7 @@ func buildHookSpecs(cmdPrefix string) []hookSpec {
 `, entireHookMarker, postCommitCmd),
 		},
 		{
-			name: "post-rewrite",
+			name: postRewriteHook,
 			content: fmt.Sprintf(`#!/bin/sh
 # %s
 # Post-rewrite hook: remap session linkage after amend/rebase rewrites
@@ -858,7 +862,7 @@ func RemoveGitHook(ctx context.Context) (int, error) {
 // generateChainedContent appends a chain call to the base hook content,
 // so the pre-existing hook (backed up to .pre-entire) is called after our hook.
 func generateChainedContent(baseContent, hookName string) string {
-	if hookName == "post-rewrite" {
+	if hookName == postRewriteHook {
 		return generatePostRewriteChainedContent(baseContent)
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -871,7 +871,7 @@ func TestShadowStrategy_PrepareCommitMsg_SkipsSessionWhenContentCheckFails(t *te
 
 func TestAddCheckpointTrailer_NoComment(t *testing.T) {
 	// Test that addCheckpointTrailer adds trailer without any comment lines
-	message := "Test commit message\n" //nolint:goconst // already present in codebase
+	message := "Test commit message\n"
 
 	result := addCheckpointTrailer(message, testTrailerCheckpointID)
 

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -51,7 +51,7 @@ const tokensProfileUsageScopeCheckpointObserved = "checkpoint_observed"
 
 func newTokensGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "tokens",
+		Use:    cmdTokens,
 		Short:  "Analyze token usage across sessions and checkpoints",
 		Hidden: true,
 		Long: `Analyze token usage across sessions and checkpoints.
@@ -276,7 +276,7 @@ func tokensProfileRecommendations(report tokensProfileReport) []sessionTokensRec
 	if report.CheckpointsAnalyzed == 0 {
 		return []sessionTokensRecommendation{{
 			ID:       "no-checkpoints",
-			Severity: "low",
+			Severity: tokensSeverityLow,
 			Message:  "Create checkpoints first; token profiling needs committed checkpoint metadata to identify patterns.",
 			Signals:  []string{"empty_checkpoint_history"},
 		}}
@@ -286,48 +286,48 @@ func tokensProfileRecommendations(report tokensProfileReport) []sessionTokensRec
 		tokensProfileSignalCount(report.Signals, "api-call-amplification") > 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "search-before-reinvestigation",
-			Severity: "high",
+			Severity: tokensSeverityHigh,
 			Message:  "Use `entire search` for prior decisions/checkpoints before broad re-investigation.",
-			Signals:  []string{"cache_read_tokens", "api_call_count"},
+			Signals:  []string{tokensSignalCacheReadTokens, tokensSignalAPICallCount},
 		})
 	}
 	if tokensProfileSignalCount(report.Signals, "api-call-amplification") > 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "batch-diagnostics",
-			Severity: "medium",
+			Severity: tokensSeverityMedium,
 			Message:  "Batch diagnostic reads around one narrowed hypothesis when API call amplification repeats.",
-			Signals:  []string{"api_call_count"},
+			Signals:  []string{tokensSignalAPICallCount},
 		})
 	}
 	if tokensProfileSignalCount(report.Signals, "context-replay-hotspot") > 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "preserve-then-compact",
-			Severity: "medium",
+			Severity: tokensSeverityMedium,
 			Message:  "Summarize useful findings before continuing large-context work; compact or restart only after preserving relevant context.",
-			Signals:  []string{"cache_read_tokens"},
+			Signals:  []string{tokensSignalCacheReadTokens},
 		})
 	}
 	if tokensProfileSignalCount(report.Signals, "subagent-heavy") > 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "scope-subagents",
-			Severity: "medium",
+			Severity: tokensSeverityMedium,
 			Message:  "Scope subagent tasks tightly with a narrow objective and expected output.",
-			Signals:  []string{"subagent_tokens"},
+			Signals:  []string{tokensSignalSubagentTokens},
 		})
 	}
 	if report.MissingTokenData > 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "improve-token-coverage",
-			Severity: "low",
+			Severity: tokensSeverityLow,
 			Message:  "Increase token coverage by using agents and checkpoints that report token usage.",
-			Signals:  []string{"missing_token_usage"},
+			Signals:  []string{tokensSignalMissingUsage},
 		})
 	}
 
 	if len(recs) == 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "no-repeated-hotspots",
-			Severity: "low",
+			Severity: tokensSeverityLow,
 			Message:  "No repeated token hotspots were visible in committed checkpoint metadata.",
 			Signals:  []string{"checkpoint_token_metadata"},
 		})

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -49,7 +49,7 @@ func newTrailCmd() *cobra.Command {
 	var repoOverride string
 
 	cmd := &cobra.Command{
-		Use:    "trail",
+		Use:    cmdTrail,
 		Short:  "Manage trails for your branches",
 		Hidden: true,
 		// Hidden from root help while the surface matures, but advertised to
@@ -470,7 +470,7 @@ func newTrailListCmd() *cobra.Command {
 	var opts trailListOptions
 
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List recent trails",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts.InsecureHTTP = trailInsecureHTTP(cmd)

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -2297,7 +2297,7 @@ func TestTrailUpdateRequestCountsEveryFieldAsMetadata(t *testing.T) {
 			// Fail rather than skip: a skipped subtest passes quietly, so a
 			// non-pointer field would silently retire the guarantee this test
 			// exists to provide, exactly when it starts mattering.
-			require.Equalf(t, reflect.Ptr, field.Type.Kind(),
+			require.Equalf(t, reflect.Pointer, field.Type.Kind(),
 				"field %s is not a pointer; decide its zero/set semantics and extend this test before adding it", field.Name)
 			var req api.TrailUpdateRequest
 			// A pointer to the zero value is still "provided" — that is how a

--- a/cmd/entire/cli/trail_comment_cmd.go
+++ b/cmd/entire/cli/trail_comment_cmd.go
@@ -99,7 +99,7 @@ replies. Code-review comments are managed separately under 'entire trail finding
 func newTrailCommentListCmd() *cobra.Command {
 	var jsonOut, all bool
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List discussion threads on a trail",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/entire/cli/trail_resume_cmd.go
+++ b/cmd/entire/cli/trail_resume_cmd.go
@@ -831,9 +831,9 @@ func printTrailResumeSkippedSessions(w io.Writer, skipped int) {
 	if skipped == 0 {
 		return
 	}
-	label := "session"
+	label := nounSession
 	if skipped != 1 {
-		label = "sessions"
+		label = nounSessions
 	}
 	fmt.Fprintf(w, "    skipped %d checkpoint %s due to read errors\n", skipped, label)
 }
@@ -1000,7 +1000,7 @@ func trailRestoredSessionChoiceLabel(session strategy.RestoredSession, isDefault
 func trailRestoredSessionKindLabel(kind string) string {
 	switch sessionpkg.Kind(kind) {
 	case sessionpkg.KindAgentReview:
-		return "review"
+		return sessionKindLabelReview
 	case sessionpkg.KindAgentInvestigate:
 		return "investigation"
 	case sessionpkg.KindImported:

--- a/cmd/entire/cli/transcript/compact/codex.go
+++ b/cmd/entire/cli/transcript/compact/codex.go
@@ -107,7 +107,7 @@ func compactCodex(content []byte, opts MetadataFields) ([]byte, error) {
 		}
 
 		switch {
-		case p.Type == transcriptTypeMessage && p.Role == "user":
+		case p.Type == transcriptTypeMessage && p.Role == transcript.TypeUser:
 			text := codexUserText(p.Content)
 			if text == "" {
 				continue
@@ -122,7 +122,7 @@ func compactCodex(content []byte, opts MetadataFields) ([]byte, error) {
 			line.Content = contentJSON
 			appendLine(&result, line)
 
-		case p.Type == transcriptTypeMessage && p.Role == "assistant":
+		case p.Type == transcriptTypeMessage && p.Role == transcript.TypeAssistant:
 			text := codexAssistantText(p.Content)
 			if text == "" {
 				continue

--- a/cmd/entire/cli/transcript/compact/compact.go
+++ b/cmd/entire/cli/transcript/compact/compact.go
@@ -46,7 +46,10 @@ func newTranscriptLine(opts MetadataFields) transcriptLine {
 	}
 }
 
-const toolResultStatusError = "error"
+const (
+	toolResultStatusSuccess = "success"
+	toolResultStatusError   = "error"
+)
 
 // toolResultJSON is the compact result object inlined into tool_use blocks.
 type toolResultJSON struct {
@@ -488,7 +491,7 @@ func inlineToolResults(assistant, user parsedEntry) parsedEntry {
 func buildToolResult(tr toolResultEntry) json.RawMessage {
 	r := toolResultJSON{
 		Output:     tr.output,
-		Status:     "success",
+		Status:     toolResultStatusSuccess,
 		MatchCount: tr.matchCount,
 	}
 	if tr.isError {

--- a/cmd/entire/cli/transcript/compact/gemini.go
+++ b/cmd/entire/cli/transcript/compact/gemini.go
@@ -250,9 +250,9 @@ func geminiToolResultCompact(tc geminiToolCall) json.RawMessage {
 
 	r := toolResultJSON{
 		Output: output,
-		Status: "success",
+		Status: toolResultStatusSuccess,
 	}
-	if tc.Status != "" && tc.Status != "success" {
+	if tc.Status != "" && tc.Status != toolResultStatusSuccess {
 		r.Status = toolResultStatusError
 	}
 	b, err := json.Marshal(r)

--- a/cmd/entire/cli/transcript/compact/opencode.go
+++ b/cmd/entire/cli/transcript/compact/opencode.go
@@ -194,7 +194,7 @@ func emitOpenCodeAssistant(result *[]byte, base transcriptLine, msg openCodeMess
 func openCodeToolResult(state map[string]json.RawMessage) json.RawMessage {
 	r := toolResultJSON{
 		Output: unquote(state["output"]),
-		Status: "success",
+		Status: toolResultStatusSuccess,
 	}
 	if s := unquote(state["status"]); s != "" && s != "completed" {
 		r.Status = toolResultStatusError

--- a/cmd/entire/cli/transcript/compact/parse.go
+++ b/cmd/entire/cli/transcript/compact/parse.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/transcript"
 )
 
 type CondensedEntry struct {
@@ -59,7 +61,7 @@ func BuildCondensedEntries(content []byte) ([]CondensedEntry, error) {
 		}
 
 		switch line.Type {
-		case "user":
+		case transcript.TypeUser:
 			var parts []string
 			for _, block := range blocks {
 				var text string
@@ -68,10 +70,10 @@ func BuildCondensedEntries(content []byte) ([]CondensedEntry, error) {
 				}
 			}
 			if len(parts) > 0 {
-				entries = append(entries, CondensedEntry{Type: "user", Content: strings.Join(parts, "\n")})
+				entries = append(entries, CondensedEntry{Type: transcript.TypeUser, Content: strings.Join(parts, "\n")})
 			}
 
-		case "assistant":
+		case transcript.TypeAssistant:
 			for _, block := range blocks {
 				var blockType string
 				if err := json.Unmarshal(block["type"], &blockType); err != nil {
@@ -82,7 +84,7 @@ func BuildCondensedEntries(content []byte) ([]CondensedEntry, error) {
 				case "text":
 					var text string
 					if err := json.Unmarshal(block["text"], &text); err == nil && text != "" {
-						entries = append(entries, CondensedEntry{Type: "assistant", Content: text})
+						entries = append(entries, CondensedEntry{Type: transcript.TypeAssistant, Content: text})
 					}
 				case "tool_use":
 					var toolName string

--- a/cmd/entire/cli/transcript/compact/pi.go
+++ b/cmd/entire/cli/transcript/compact/pi.go
@@ -25,11 +25,6 @@ import (
 // SkipLines, NewScanner) are shared with the pi agent package via
 // cmd/entire/cli/agent/pi/pijsonl so a fix applied here also lands there.
 
-const (
-	piToolResultStatusOK  = "success"
-	piToolResultStatusErr = "error"
-)
-
 // piToolNameMap normalises Pi's lowercase tool names to the title-cased names
 // used elsewhere in Entire's compact format (matching Claude's "Read"/"Write"/"Edit").
 var piToolNameMap = map[string]string{
@@ -299,9 +294,9 @@ func piDecodeResultOutput(raw json.RawMessage) string {
 
 func piResultStatus(isError bool) string {
 	if isError {
-		return piToolResultStatusErr
+		return toolResultStatusError
 	}
-	return piToolResultStatusOK
+	return toolResultStatusSuccess
 }
 
 func piTimestampJSON(ts string) json.RawMessage {

--- a/docs/first-time-contributors.md
+++ b/docs/first-time-contributors.md
@@ -78,7 +78,7 @@ Entire is a Go project managed by `mise`. Three commands and you're set up:
 # Install mise (skip if you already have it)
 curl https://mise.run | sh
 
-# Trust this repo's mise config and install Go 1.26
+# Trust this repo's mise config and install Go 1.27
 mise trust
 mise install
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/entireio/cli
 
-go 1.26.6
+go 1.27.1
 
 require (
 	charm.land/bubbles/v2 v2.2.1
@@ -30,6 +30,7 @@ require (
 	github.com/go-git/x/plugin/objectsigner/program v0.0.0-20260624122410-382b2905c041
 	github.com/gofrs/flock v0.13.1
 	github.com/google/uuid v1.6.0
+	github.com/lastpersonlabs/goredact v0.1.0
 	github.com/mattn/go-isatty v0.0.24
 	github.com/mattn/go-runewidth v0.0.29
 	github.com/muesli/termenv v0.16.0
@@ -49,8 +50,6 @@ require (
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-require github.com/lastpersonlabs/goredact v0.1.0
 
 require (
 	dario.cat/mergo v1.0.2 // indirect

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 # Please also keep the version aligned in the go.mod file
-go = { version = '1.26.6', postinstall = "go install github.com/go-delve/delve/cmd/dlv@latest && go install gotest.tools/gotestsum@latest" }
-golangci-lint = '2.11.3'
+go = { version = '1.27.1', postinstall = "go install github.com/go-delve/delve/cmd/dlv@latest && go install gotest.tools/gotestsum@latest" }
+golangci-lint = '2.13.2'
 shellcheck = 'latest'
 tmux = 'latest'
 "go:github.com/entireio/roger-roger/cmd/roger-roger" = 'latest'


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1295
<!-- entire-trail-link-end -->

Go 1.26.6 → 1.27.1 in `go.mod` and `mise.toml`, kept aligned per the comment there.

## The golangci-lint bump is forced, not optional

2.11.3 refuses to lint a module targeting a newer Go than it was built with, and fails outright rather than degrading:

```
Error: can't load config: the Go language version (go1.26) used to build
golangci-lint is lower than the targeted Go version (1.27.1)
```

2.13.0 is the first release built with go1.27, so 2.13.x is the floor; this takes the latest patch, 2.13.2. The comparison is at minor granularity, which is why a 2.13.x built with go1.27.0 accepts a module targeting 1.27.1.

That bump arrives with three linter behaviour changes. All 160 findings are resolved in code here rather than suppressed.

## goconst: 2457 new findings

2.13's newer goconst started scanning composite literals. Two settings in `.golangci.yaml` restore the prior scope for the 2328 findings that are test fixtures (2235) and map-literal keys — a Go toolchain bump shouldn't also adopt a stricter linter as a side effect, and neither knob loses coverage the repo ever actually had, since 2.11.3 reported zero in both.

The remaining 129 become named constants across 50 files:

- a new `cmd/entire/cli/names.go` — command/verb names, the control-plane table headers shared by `org`/`project`/`repo`/`grant`/`mirror`, and count-dependent display nouns
- a token-report vocabulary block shared by `session tokens`, `checkpoint tokens` and `tokens profile` (these strings are part of those commands' `--json` contract)
- canonical activity agent IDs, explain row labels, hook categories, recap footer hints
- per-package constants in `review`, `claudecode`, `copilotcli`, `benchutil`, `strategy` and `transcript/compact`

Every substitution preserves the string value, so the `--json` contracts and the tests asserting them are untouched.

**Where goconst's advice is deliberately not followed.** Its "such constant already exists" hints point at same-valued constants in unrelated domains — `agentFlagName` (a flag name) for the `agent` *command*, `trailReviewSeverityLow` for a token-pressure *level*, `sourceCheckpoint` (a tune-source enum) for the `checkpoint` command. Reusing those would couple unrelated domains, so each got a correctly-named constant in its own. Two literals stay literals for the same reason: the `gh repo create` and `gh <kind> list` argv in `setup_github.go` and `runner_gather.go` are the *GitHub* CLI's tokens, not Entire's, and both are now single occurrences.

**`exclude-types` is unusable in 2.13.2**, worth knowing before anyone reaches for it as the obvious knob. `exclude-types: [CompositeLit]` makes things *worse* — 6260 findings instead of 2457 — with or without an explicit `ignore-calls: true`. It appears to disable the occurrence filtering rather than suppress reporting.

## nolintlint: 22 dead directives

Newer gosec no longer reports G115 on `int(f.Fd())`, so those `//nolint:gosec` comments were dead. Deleted, along with three `//nolint:govet`/`recvcheck` directives whose linters no longer fire.

## staticcheck SA1019: 8 findings

Targeted `//nolint:staticcheck` with reasons. These are deliberate reads of our own deprecated-for-backward-compat fields (`TranscriptLinesAtStart`, `CondensedTranscriptLines`, the legacy `Review` map), so dropping the usage would break the compatibility they exist for.

## govet: 1 finding

Go 1.27's new `inline` analyzer flags the deprecated `reflect.Ptr` alias in `trail_cmd_test.go`; now `reflect.Pointer`.

## Verification

On go1.27.1 / darwin-arm64:

- build clean; `go vet` clean on darwin, linux **and windows**, and under both the `integration` and `e2e` tags
- all five lint tasks at **0 issues**
- `mise run test:ci` green — 91 packages under `-race` with `-tags=integration`, plus both canary legs (vogon 56/56, roger-roger 4/4)

One flake seen along the way, not a regression: `TestShellOut_BatchSingleInferencePass` failed once with `WaitDelay expired before I/O complete` while a full lint run was competing for CPU. It passes `-count=5` isolated and the whole `redact` package passes twice on an idle machine — its 5s budget starves under load, same class as `TestExternalCommand_SigintReachesPlugin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain and lint-only refactors with string values preserved; no intentional runtime or API behavior changes beyond dependency versions.
> 
> **Overview**
> Bumps **Go to 1.27.1** (`go.mod`, `mise.toml`) and **golangci-lint to 2.13.2**, which is required because older lint releases cannot target newer Go toolchains.
> 
> **Lint fallout is handled in-repo**, not with broad suppressions: `.golangci.yaml` restores prior **goconst** scope (`ignore-tests`, `ignore-map-keys`) after 2.13 started flagging composite literals; remaining duplicate strings become named constants via new **`names.go`** (shared Cobra verbs, table headers, plural nouns), token-report JSON vocabulary, activity agent IDs, and smaller per-package constants. Dead **`//nolint:gosec`** (G115 on `int(f.Fd())`) and a few obsolete govet/recvcheck directives are removed; deliberate deprecated-field usage gets targeted **`staticcheck`** nolint comments; **`reflect.Ptr`** becomes **`reflect.Pointer`** for Go 1.27’s govet.
> 
> Behavior and **`--json` contracts** are unchanged—values are the same strings, only centralized for lint compliance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75b832e4db589cb5c55edd12d3cc2c552ddc727. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->