### PR TITLE
fix: handle Close on the two writable handles that discarded it

### DIFF
--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -2293,7 +2293,7 @@ func isCompletionConfigured(rcFile string) bool {
 }
 
 // appendShellCompletion adds the completion line to the rc file.
-func appendShellCompletion(rcFile, completionLine string) error {
+func appendShellCompletion(rcFile, completionLine string) (err error) {
 	if err := os.MkdirAll(filepath.Dir(rcFile), 0o700); err != nil {
 		return fmt.Errorf("creating directory: %w", err)
 	}
@@ -2302,10 +2302,17 @@ func appendShellCompletion(rcFile, completionLine string) error {
 	if err != nil {
 		return fmt.Errorf("opening file: %w", err)
 	}
-	defer f.Close()
+	// Close reports a failed flush on a writable handle, so discarding it would
+	// drop the append while this function returned nil — the caller then tells
+	// the user completion is installed when the rc file never received the line.
+	// A write error already in flight is the more specific one, so it wins.
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing file: %w", cerr)
+		}
+	}()
 
-	_, err = f.WriteString("\n" + shellCompletionComment + "\n" + completionLine + "\n")
-	if err != nil {
+	if _, err := f.WriteString("\n" + shellCompletionComment + "\n" + completionLine + "\n"); err != nil {
 		return fmt.Errorf("writing completion: %w", err)
 	}
 	return nil

--- a/e2e/vogon/main.go
+++ b/e2e/vogon/main.go
@@ -705,8 +705,17 @@ func appendTranscriptEntry(path string, entry transcriptEntry) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
-	f.Write(data)
+	// The canary asserts on this transcript, so a partial one invalidates the
+	// run rather than degrading it: every downstream assertion fails with a
+	// message about the wrong thing. Report the real cause instead. Close is
+	// checked because it is where a failed flush surfaces.
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		fatal("writing transcript %s: %v", path, err)
+	}
+	if err := f.Close(); err != nil {
+		fatal("closing transcript %s: %v", path, err)
+	}
 }
 
 func fatal(format string, args ...any) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1296
<!-- entire-trail-link-end -->

Fixes both `go/unhandled-writable-file-close` findings (CWE-252, precision `high`), surfaced by enabling CodeQL's `security-and-quality` suite for Go in #2355.

Both sites did `defer f.Close()` on a handle opened for writing, discarding the error that reports a failed flush — so the write is lost and the code continues as though it succeeded. `golangci-lint` reports neither, so this is coverage we did not previously have.

## The two sites

**`cmd/entire/cli/setup.go:2305`** — `appendShellCompletion` already returns an `error`, so it now reports the close through it via a named return. A write error already in flight is the more specific one and still wins. The consequence of dropping it was concrete rather than theoretical: the caller tells the user shell completion is installed while the rc file never received the line.

**`e2e/vogon/main.go:708`** — `appendTranscriptEntry` writes the transcript the E2E canary asserts on, so a partial transcript invalidates the run rather than degrading it; every downstream assertion then fails with a message about the wrong thing. It calls the existing `fatal` helper, which is the difference between one accurate error and 56 misleading ones.

Two judgement calls there worth a reviewer's eye:

- Its `Write` error was being dropped as well. I check it now on the same reasoning, since a short write is the same silent-truncation problem.
- The pre-existing silent `return` on a failed **open** is deliberately left alone. Making that fatal too is defensible but it is a separate decision, and it would change when the canary fails rather than just what it reports.

## Verification

Verified against CodeQL itself rather than by reading the diff — built a local Go database of this repo with the CodeQL CLI and ran the suite before and after:

| | alerts | `unhandled-writable-file-close` |
| --- | --- | --- |
| before | 4 | 2 |
| after | **2** | **0** |

The 2 remaining are the `go/allocation-size-overflow` false positives already dismissed (`1+len(slice)` capacity hints that cannot overflow).

- `mise run lint` — clean (0 issues)
- `GOOS=windows go vet ./...` — clean
- `go test -tags=integration -race ./...` — 91 packages, no failures
- `mise run test:e2e:canary` — both legs pass (56 and 4 tests), with no `vogon:` output, so the new fatal paths do not fire in a healthy run

Depends on nothing; #2355 is what makes CI surface this class going forward, but this fix stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized I/O error-handling fixes with no changes to auth, security, or core CLI behavior beyond more accurate failure reporting.
> 
> **Overview**
> Addresses CodeQL **`go/unhandled-writable-file-close`** by surfacing flush/close failures on two append-only writable files instead of treating success when the data may never have landed on disk.
> 
> In **`appendShellCompletion`** (`setup.go`), the function now uses a named `error` return and a `defer` that promotes a non-nil **`Close`** error when the write path did not already fail—so setup does not print that shell completion was added when the rc file never got the line.
> 
> In **`appendTranscriptEntry`** (`e2e/vogon/main.go`), **`Write`** and **`Close`** errors now call **`fatal`** with the transcript path, since a partial JSONL transcript makes the canary fail in misleading ways. Failed **open** still returns silently (unchanged scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190b656d6c3ce1d7022f9abb4ecbdbd1c6d63bc4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->