### PR TITLE
fix(strategy): prevent shadow cleanup with malformed session state

### DIFF
--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -1083,8 +1083,20 @@ func (s *StateStore) RemoveAll() error {
 	return nil
 }
 
-// List returns all session states.
+// List returns all loadable session states, skipping individual files that
+// cannot be read or decoded.
 func (s *StateStore) List(ctx context.Context) ([]*State, error) {
+	return s.list(ctx, false)
+}
+
+// ListStrict returns all session states and fails if any state file cannot be
+// loaded. Destructive callers should use this method when an incomplete result
+// could cause them to remove data that an omitted session still needs.
+func (s *StateStore) ListStrict(ctx context.Context) ([]*State, error) {
+	return s.list(ctx, true)
+}
+
+func (s *StateStore) list(ctx context.Context, strict bool) ([]*State, error) {
 	root, err := s.dirRoot()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open session state directory: %w", err)
@@ -1109,6 +1121,9 @@ func (s *StateStore) List(ctx context.Context) ([]*State, error) {
 		sessionID := strings.TrimSuffix(entry.Name(), ".json")
 		state, err := s.Load(ctx, sessionID)
 		if err != nil {
+			if strict {
+				return nil, fmt.Errorf("failed to load session state %q: %w", sessionID, err)
+			}
 			continue // Skip corrupted state files
 		}
 		if state == nil {

--- a/cmd/entire/cli/session/state_test.go
+++ b/cmd/entire/cli/session/state_test.go
@@ -524,6 +524,25 @@ func TestStateStore_List_SkipsMalformedState(t *testing.T) {
 	assert.Equal(t, valid.SessionID, states[0].SessionID)
 }
 
+// Not parallel: resets the process-global gitdir roots.
+func TestStateStore_ListStrict_RejectsMalformedState(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "entire-sessions")
+	t.Cleanup(gitdir.Reset)
+	require.NoError(t, os.MkdirAll(stateDir, 0o750))
+	store := NewStateStoreWithDir(stateDir)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(stateDir, "malformed-session.json"),
+		[]byte(`{"session_id":`),
+		0o600,
+	))
+
+	states, err := store.ListStrict(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, states)
+	assert.Contains(t, err.Error(), `failed to load session state "malformed-session"`)
+}
+
 func TestStateStore_Load_TraversalResistant(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/session/state_test.go
+++ b/cmd/entire/cli/session/state_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitdir"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/stretchr/testify/assert"
@@ -495,6 +496,32 @@ func TestStateStore_List_DeletesStaleSession(t *testing.T) {
 	// Active session file should still exist
 	_, err = os.Stat(filepath.Join(stateDir, "active-session.json"))
 	assert.NoError(t, err, "active session file should still exist")
+}
+
+// Not parallel: resets the process-global gitdir roots.
+func TestStateStore_List_SkipsMalformedState(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "entire-sessions")
+	t.Cleanup(gitdir.Reset)
+	require.NoError(t, os.MkdirAll(stateDir, 0o750))
+	store := NewStateStoreWithDir(stateDir)
+	ctx := context.Background()
+
+	valid := &State{
+		SessionID:  "valid-session",
+		BaseCommit: "abc123",
+		StartedAt:  time.Now(),
+	}
+	require.NoError(t, store.Save(ctx, valid))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(stateDir, "malformed-session.json"),
+		[]byte(`{"session_id":`),
+		0o600,
+	))
+
+	states, err := store.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	assert.Equal(t, valid.SessionID, states[0].SessionID)
 }
 
 func TestStateStore_Load_TraversalResistant(t *testing.T) {

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -219,6 +219,8 @@ func listShadowBranchHeads(ctx context.Context) (map[string]plumbing.Hash, error
 //     shadow branch contents have been copied to committed metadata.
 //   - Multiple sessions can share the same shadow branch (same base
 //     commit + worktree); ALL must satisfy the criteria above.
+//   - Fails closed before deletion if a complete session-state inventory
+//     cannot be loaded.
 //   - Shadow branches with no associated session state are deleted
 //     (no session to lose data from).
 func CleanupPushedShadowBranches(ctx context.Context) (int, error) {
@@ -230,7 +232,7 @@ func CleanupPushedShadowBranches(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 
-	states, err := ListSessionStates(ctx)
+	states, err := listSessionStatesStrict(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("list session states: %w", err)
 	}
@@ -283,6 +285,7 @@ func CleanupPushedShadowBranches(ctx context.Context) (int, error) {
 // the same check is repeated here as a second, independent gate rather than
 // relying solely on the caller's filtering, since this function is the one
 // place that actually deletes a ref with no human confirmation.
+// A failed session-state recheck also preserves the branch.
 func DeleteShadowBranchesIfUnchanged(ctx context.Context, branches map[string]plumbing.Hash) (deleted []string, failed []string) {
 	if len(branches) == 0 {
 		return []string{}, []string{}
@@ -333,7 +336,7 @@ func protectedShadowBranchForSession(s *SessionState) (string, bool) {
 }
 
 func shadowBranchProtectedByCurrentState(ctx context.Context, branch string) (bool, error) {
-	states, err := ListSessionStates(ctx)
+	states, err := listSessionStatesStrict(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/entire/cli/strategy/cleanup_pushed_shadow_test.go
+++ b/cmd/entire/cli/strategy/cleanup_pushed_shadow_test.go
@@ -2,10 +2,13 @@ package strategy
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/gitdir"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/go-git/go-git/v6"
@@ -26,6 +29,7 @@ type shadowCleanupEnv struct {
 func newShadowCleanupEnv(t *testing.T) *shadowCleanupEnv {
 	t.Helper()
 	dir := t.TempDir()
+	t.Cleanup(gitdir.Reset)
 	testutil.InitRepo(t, dir)
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
@@ -70,6 +74,17 @@ func (e *shadowCleanupEnv) addSessionState(sessionID, baseCommit, worktreeID str
 		TurnCheckpointIDs: pendingCheckpoints,
 	}
 	require.NoError(e.t, SaveSessionState(context.Background(), state))
+}
+
+func (e *shadowCleanupEnv) corruptSessionState(sessionID string) {
+	e.t.Helper()
+	stateDir, err := getSessionStateDir(context.Background())
+	require.NoError(e.t, err)
+	require.NoError(e.t, os.WriteFile(
+		filepath.Join(stateDir, sessionID+".json"),
+		[]byte(`{"session_id":`),
+		0o600,
+	))
 }
 
 func (e *shadowCleanupEnv) branchExists(name string) bool {
@@ -175,6 +190,36 @@ func TestCleanupPushedShadowBranches_NoBranches_NoOp(t *testing.T) {
 	deleted, err := CleanupPushedShadowBranches(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 0, deleted)
+}
+
+func TestCleanupPushedShadowBranches_MalformedStateFailsClosed(t *testing.T) {
+	env := newShadowCleanupEnv(t)
+	ctx := context.Background()
+
+	const sessionID = "malformed-session"
+	shadow := env.addShadowBranch(env.baseHash.String(), "worktree-a")
+	env.addSessionState(sessionID, env.baseHash.String(), "worktree-a", nil, nil, false)
+	env.corruptSessionState(sessionID)
+
+	deleted, err := CleanupPushedShadowBranches(ctx)
+	require.ErrorContains(t, err, `failed to load session state "malformed-session"`)
+	require.Zero(t, deleted)
+	require.True(t, env.branchExists(shadow), "cleanup must preserve the shadow branch")
+}
+
+func TestDeleteShadowBranchesIfUnchanged_MalformedStatePreservesBranch(t *testing.T) {
+	env := newShadowCleanupEnv(t)
+	ctx := context.Background()
+
+	const sessionID = "malformed-session"
+	shadow := env.addShadowBranch(env.baseHash.String(), "worktree-a")
+	env.addSessionState(sessionID, env.baseHash.String(), "worktree-a", nil, nil, false)
+	env.corruptSessionState(sessionID)
+
+	deleted, failed := DeleteShadowBranchesIfUnchanged(ctx, map[string]plumbing.Hash{shadow: env.baseHash})
+	require.Empty(t, deleted)
+	require.Equal(t, []string{shadow}, failed)
+	require.True(t, env.branchExists(shadow), "recheck must preserve the shadow branch")
 }
 
 func TestDeleteShadowBranchesIfUnchanged_PreservesMovedBranch(t *testing.T) {

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -161,12 +161,25 @@ func SaveSessionState(ctx context.Context, state *SessionState) error {
 // ListSessionStates returns all session states from the state directory.
 // This is a package-level function that doesn't require a specific strategy instance.
 func ListSessionStates(ctx context.Context) ([]*SessionState, error) {
+	return listSessionStates(ctx, false)
+}
+
+func listSessionStatesStrict(ctx context.Context) ([]*SessionState, error) {
+	return listSessionStates(ctx, true)
+}
+
+func listSessionStates(ctx context.Context, strict bool) ([]*SessionState, error) {
 	store, err := session.NewStateStore(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create state store: %w", err)
 	}
 
-	states, err := store.List(ctx)
+	var states []*SessionState
+	if strict {
+		states, err = store.ListStrict(ctx)
+	} else {
+		states, err = store.List(ctx)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to list session states: %w", err)
 	}

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -303,6 +303,11 @@ makes the comparison false forever and the session silently stops condensing.
 - Deleted after condensation to `entire/checkpoints/v1`
 - Reset if orphaned (no session state file exists)
 
+Observational session listings are best-effort and may skip an unreadable state
+file. Unattended post-push cleanup uses a strict inventory instead: if any state
+cannot be loaded, cleanup aborts without deleting shadow branches because it
+cannot prove they are orphaned.
+
 ### Task Records (Subagent Work)
 
 A subagent invocation (Claude Code's Task tool) is captured through a durable


### PR DESCRIPTION
## Summary

- keep `StateStore.List` tolerant for observational callers
- add `StateStore.ListStrict` for operations requiring a complete inventory
- make both unattended shadow-cleanup paths fail closed when any session state cannot be loaded
- document the cleanup safety contract

When persisted session state is malformed, cleanup now aborts instead of potentially deleting a still-needed shadow ref.

Closes #2350

## Testing

- `go test ./cmd/entire/cli/session -run 'TestStateStore_List_(SkipsMalformedState|Strict_RejectsMalformedState)$' -count=1`
- `go test ./cmd/entire/cli/strategy -run 'Test(CleanupPushedShadowBranches_MalformedStateFailsClosed|DeleteShadowBranchesIfUnchanged_MalformedStatePreservesBranch)$' -count=1`
- `go vet ./cmd/entire/cli/session ./cmd/entire/cli/strategy`
- repository-wide formatting, module-tidiness, policy, and ShellCheck verification

Full Windows package runs still encounter existing temporary-directory lock failures reproduced unchanged on `origin/main`.