### PR TITLE
fix(explain): name the supported agents for an unusable summary provider

### DIFF
--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -1373,7 +1373,7 @@ func checkSummaryProvider(cmd *cobra.Command) {
 	}
 
 	w := cmd.OutOrStdout()
-	sourceFile, isLocal := summaryProviderSourceLayer(ctx, s.SummaryGeneration.Provider)
+	sourceFile, isLocal := summaryProviderSourceLayer(ctx, s)
 	fmt.Fprintln(w, "Summary provider: UNUSABLE")
 	fmt.Fprintf(w, "  summary_generation.provider is %q in %s, which cannot generate text.\n", name, sourceFile)
 	fmt.Fprintln(w, "  `entire checkpoint explain --generate`, `entire dispatch`, and")
@@ -1409,7 +1409,21 @@ func checkSummaryProvider(cmd *cobra.Command) {
 // applies, so matching on the effective value is enough to identify the source.
 // A read failure or a missing file falls back to the project layer, matching
 // where `configure` would write.
-func summaryProviderSourceLayer(ctx context.Context, effective string) (relPath string, isLocal bool) {
+//
+// LocalLayerRejection is consulted first, and it is not an optimisation: a
+// TRACKED settings.local.json is dropped wholesale by the loader, so its
+// contents are not the effective value however well they match. Reading the
+// file directly cannot see that — it would attribute a provider both files
+// happen to share to the local layer and send the user to edit a file the
+// loader ignores, leaving the project-level fault in place behind a success
+// message. That is the same class of wrong-file advice as the missing --local.
+func summaryProviderSourceLayer(ctx context.Context, merged *settings.EntireSettings) (relPath string, isLocal bool) {
+	if merged == nil || merged.SummaryGeneration == nil {
+		return settings.EntireSettingsFile, false
+	}
+	if merged.LocalLayerRejection() != "" {
+		return settings.EntireSettingsFile, false
+	}
 	localAbs, err := paths.AbsPath(ctx, settings.EntireSettingsLocalFile)
 	if err != nil {
 		return settings.EntireSettingsFile, false
@@ -1420,7 +1434,7 @@ func summaryProviderSourceLayer(ctx context.Context, effective string) (relPath 
 	if err != nil {
 		return settings.EntireSettingsFile, false
 	}
-	if local.SummaryGeneration != nil && local.SummaryGeneration.Provider == effective {
+	if local.SummaryGeneration != nil && local.SummaryGeneration.Provider == merged.SummaryGeneration.Provider {
 		return settings.EntireSettingsLocalFile, true
 	}
 	return settings.EntireSettingsFile, false

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -17,6 +17,7 @@ import (
 	"charm.land/huh/v2"
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/entiredir"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
@@ -168,6 +169,10 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 	// Retired permission rule that makes ordinary commands need approval.
 	// Fixes rather than only reporting: what it removes is a rule Entire wrote.
 	checkRetiredDenyRule(cmd)
+
+	// A configured summary provider that cannot generate text. After the hook
+	// checks: it breaks three commands, not capture, so it is the milder fault.
+	checkSummaryProvider(cmd)
 
 	// Where checkpoints land, when the repo's remotes make that ambiguous.
 	printCheckpointDestinationNote(ctx, cmd.OutOrStdout(), "Checkpoint destination: REVIEW")
@@ -1322,6 +1327,55 @@ func checkRetiredDenyRule(cmd *cobra.Command) {
 			fmt.Fprintln(w, "  The settings file changed — commit or revert it as you prefer.")
 		}
 	}
+}
+
+// checkSummaryProvider reports a configured summary_generation.provider naming
+// a registered agent that cannot generate text. See
+// unsupportedSummaryProviderError for how such a value gets written.
+//
+// Worth a check of its own because nothing else says a word about it: the
+// settings loader validates only model-without-provider, `entire status` never
+// mentions summary generation, and the resolver's error surfaces at
+// `checkpoint explain --generate` / `dispatch` / `runner setup` — commands a
+// user may not run for weeks after the edit, by which time the cause is not in
+// view. Read-only; the remedy is the user's choice of provider, and the value
+// may live in a committed settings.json where a rewrite changes everyone's.
+//
+// Two conditions are deliberately out of scope. An UNREGISTERED name is the
+// external-plugin shape, where telling "not installed" from "installed but the
+// external_agents grant is missing" means running discovery — and doctor must
+// not exec a plugin to write a diagnostic (`entire status` already reports the
+// grant rejection). An off-$PATH binary is machine-local and expected, so the
+// resolver reports it at the point of use instead.
+func checkSummaryProvider(cmd *cobra.Command) {
+	ctx := cmd.Context()
+	s, err := loadSummarySettings(ctx)
+	if err != nil {
+		// Not reported: a settings file that will not load is a louder problem
+		// than this check, and doctor's own PreRunE already reads it.
+		logging.Warn(ctx, "could not load settings for summary provider check",
+			slog.String("error", err.Error()))
+		return
+	}
+	if s.SummaryGeneration == nil || s.SummaryGeneration.Provider == "" {
+		return
+	}
+
+	name := types.AgentName(s.SummaryGeneration.Provider)
+	_, registered, capable := summaryCapableAgent(name)
+	if !registered || capable {
+		return
+	}
+
+	w := cmd.OutOrStdout()
+	fmt.Fprintln(w, "Summary provider: UNUSABLE")
+	fmt.Fprintf(w, "  summary_generation.provider is %q, which cannot generate text.\n", name)
+	fmt.Fprintln(w, "  `entire checkpoint explain --generate`, `entire dispatch`, and")
+	fmt.Fprintln(w, "  `entire runner setup` all fail while it is set.")
+	if capable := summaryCapableProviderNames(); len(capable) > 0 {
+		fmt.Fprintf(w, "  Fix: entire configure --summarize-provider <%s>\n", strings.Join(capable, "|"))
+	}
+	fmt.Fprintln(w, "  No `entire` command writes this value, so it was hand-edited or written by an agent.")
 }
 
 // checkCodexHookTrust reports whether Codex can discover its effective

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -1378,19 +1378,31 @@ func checkSummaryProvider(cmd *cobra.Command) {
 	fmt.Fprintf(w, "  summary_generation.provider is %q in %s, which cannot generate text.\n", name, sourceFile)
 	fmt.Fprintln(w, "  `entire checkpoint explain --generate`, `entire dispatch`, and")
 	fmt.Fprintln(w, "  `entire runner setup` all fail while it is set.")
-	if capable := summaryCapableProviderNames(); len(capable) > 0 {
-		// One runnable command, not a <a|b|c> placeholder: the shell reads < as
-		// a redirect and | as a pipe, so the obvious copy-paste fails. The rest
-		// of the choices go on their own line, where they are data rather than
-		// something the reader is invited to paste.
-		fix := "entire configure --summarize-provider " + capable[0]
+	// The command names an INSTALLED provider, not merely a capable one.
+	// summaryCapableProviderNames is deliberately unfiltered by $PATH — it
+	// answers "what does this field accept" — but a command built from its
+	// first entry is alphabetical, so it says claude-code on a machine with no
+	// claude, and `configure` then rejects it for exactly that. The user this
+	// check fires for is the likeliest to have only one agent installed.
+	installed := listEnabledSummaryProviders(ctx)
+	if len(installed) > 0 {
+		fix := "entire configure --summarize-provider " + string(installed[0].Name)
 		if isLocal {
 			fix += " --local"
 		}
 		fmt.Fprintf(w, "  Fix: %s\n", fix)
-		if len(capable) > 1 {
-			fmt.Fprintf(w, "  Supported: %s\n", strings.Join(capable, ", "))
+	}
+	if capable := summaryCapableProviderNames(); len(capable) > 0 {
+		// The accepted values, listed as data rather than as something to
+		// paste — a <a|b|c> placeholder is not copy-pasteable, since the shell
+		// reads < as a redirect and | as a pipe.
+		line := "  Supported: " + strings.Join(capable, ", ")
+		if len(installed) == 0 {
+			// No Fix line was printed above, so say why rather than leaving the
+			// reader to wonder where the command went.
+			line += " (none installed; install one first)"
 		}
+		fmt.Fprintln(w, line)
 	}
 	fmt.Fprintln(w, "  No `entire` command writes this value, so it was hand-edited or written by an agent.")
 }

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -64,7 +64,12 @@ Checks performed:
      no longer fire, or a committed Pi/OpenCode extension has gone stale).
      Fix by re-running 'entire enable --force'.
 
-  5. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
+  5. Summary provider: warn when summary_generation.provider names a registered
+     agent that cannot generate text (e.g. opencode), which makes
+     'entire checkpoint explain --generate', 'entire dispatch' and
+     'entire runner setup' fail. Reports the file to change; does not rewrite it.
+
+  6. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
 
 A session is considered stuck if:
   - It is in ACTIVE phase with no interaction for over 1 hour
@@ -1368,14 +1373,57 @@ func checkSummaryProvider(cmd *cobra.Command) {
 	}
 
 	w := cmd.OutOrStdout()
+	sourceFile, isLocal := summaryProviderSourceLayer(ctx, s.SummaryGeneration.Provider)
 	fmt.Fprintln(w, "Summary provider: UNUSABLE")
-	fmt.Fprintf(w, "  summary_generation.provider is %q, which cannot generate text.\n", name)
+	fmt.Fprintf(w, "  summary_generation.provider is %q in %s, which cannot generate text.\n", name, sourceFile)
 	fmt.Fprintln(w, "  `entire checkpoint explain --generate`, `entire dispatch`, and")
 	fmt.Fprintln(w, "  `entire runner setup` all fail while it is set.")
 	if capable := summaryCapableProviderNames(); len(capable) > 0 {
-		fmt.Fprintf(w, "  Fix: entire configure --summarize-provider <%s>\n", strings.Join(capable, "|"))
+		// One runnable command, not a <a|b|c> placeholder: the shell reads < as
+		// a redirect and | as a pipe, so the obvious copy-paste fails. The rest
+		// of the choices go on their own line, where they are data rather than
+		// something the reader is invited to paste.
+		fix := "entire configure --summarize-provider " + capable[0]
+		if isLocal {
+			fix += " --local"
+		}
+		fmt.Fprintf(w, "  Fix: %s\n", fix)
+		if len(capable) > 1 {
+			fmt.Fprintf(w, "  Supported: %s\n", strings.Join(capable, ", "))
+		}
 	}
 	fmt.Fprintln(w, "  No `entire` command writes this value, so it was hand-edited or written by an agent.")
+}
+
+// summaryProviderSourceLayer reports which settings file supplies the effective
+// provider, and whether that file is the local layer.
+//
+// The remedy needs it. `entire configure` with no layer flag writes the PROJECT
+// file whenever one exists (settingsTargetFile), so a provider coming from
+// settings.local.json would be "fixed" in the wrong file: the command reports
+// success, the local layer still overrides it, and doctor still reports the
+// fault. Naming the file also answers the question the diagnosis otherwise
+// leaves open — which of two settings files to open.
+//
+// Local wins when it carries the key at all, which is the merge rule the loader
+// applies, so matching on the effective value is enough to identify the source.
+// A read failure or a missing file falls back to the project layer, matching
+// where `configure` would write.
+func summaryProviderSourceLayer(ctx context.Context, effective string) (relPath string, isLocal bool) {
+	localAbs, err := paths.AbsPath(ctx, settings.EntireSettingsLocalFile)
+	if err != nil {
+		return settings.EntireSettingsFile, false
+	}
+	// loadFromFile returns empty settings for a missing file, so absence is
+	// simply "the local layer does not supply it".
+	local, err := loadSummarySettingsFromFile(localAbs)
+	if err != nil {
+		return settings.EntireSettingsFile, false
+	}
+	if local.SummaryGeneration != nil && local.SummaryGeneration.Provider == effective {
+		return settings.EntireSettingsLocalFile, true
+	}
+	return settings.EntireSettingsFile, false
 }
 
 // checkCodexHookTrust reports whether Codex can discover its effective

--- a/cmd/entire/cli/doctor_summary_provider_test.go
+++ b/cmd/entire/cli/doctor_summary_provider_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// stubSummaryProviderSettings points the settings seam at one configured
+// provider ("" for none), against a registry of codex (capable) + opencode
+// (not).
+func stubSummaryProviderSettings(t *testing.T, configured string) {
+	t.Helper()
+
+	stubSummaryRegistry(t, []types.AgentName{"codex", "opencode"}, "codex")
+
+	originalLoad := loadSummarySettings
+	t.Cleanup(func() { loadSummarySettings = originalLoad })
+	loadSummarySettings = func(context.Context) (*settings.EntireSettings, error) {
+		s := &settings.EntireSettings{}
+		if configured != "" {
+			s.SummaryGeneration = &settings.SummaryGenerationSettings{Provider: configured}
+		}
+		return s, nil
+	}
+}
+
+func runCheckSummaryProvider(t *testing.T, configured string) string {
+	t.Helper()
+
+	stubSummaryProviderSettings(t, configured)
+	cmd, out := newTestCmd(t)
+	checkSummaryProvider(cmd)
+	return out.String()
+}
+
+func TestCheckSummaryProvider_ReportsANonCapableProvider(t *testing.T) {
+	// Cannot use t.Parallel(): mutates package-level resolution seams.
+	got := runCheckSummaryProvider(t, "opencode")
+
+	if !strings.Contains(got, "Summary provider: UNUSABLE") {
+		t.Fatalf("no diagnosis printed:\n%s", got)
+	}
+	if !strings.Contains(got, "opencode") {
+		t.Errorf("diagnosis does not name the provider:\n%s", got)
+	}
+	// The remedy must be runnable, not just a statement of the problem.
+	if !strings.Contains(got, "entire configure --summarize-provider") {
+		t.Errorf("diagnosis carries no remedy command:\n%s", got)
+	}
+	if !strings.Contains(got, "codex") {
+		t.Errorf("remedy does not name a usable provider:\n%s", got)
+	}
+}
+
+// Silence is the whole contract for the healthy cases: doctor's output is read
+// as a fault list, so a line about a working setting is noise that trains
+// people to skip the section.
+func TestCheckSummaryProvider_SilentWhenNothingIsWrong(t *testing.T) {
+	// Cannot use t.Parallel(): mutates package-level resolution seams.
+	cases := []struct {
+		name       string
+		configured string
+		why        string
+	}{
+		{
+			name:       "capable provider",
+			configured: "codex",
+			why:        "a working provider is not a fault",
+		},
+		{
+			name: "no provider configured",
+			why:  "the field is optional; absent means the resolver picks one",
+		},
+		{
+			name:       "unregistered provider",
+			configured: "entire-agent-something",
+			why:        "the external-plugin shape; reporting it would need an exec (see the doc comment)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := runCheckSummaryProvider(t, tc.configured); got != "" {
+				t.Errorf("expected silence (%s), got:\n%s", tc.why, got)
+			}
+		})
+	}
+}
+
+// A settings file that will not load is a louder problem, reported elsewhere;
+// this check must not add a second voice for it.
+func TestCheckSummaryProvider_SilentWhenSettingsWillNotLoad(t *testing.T) {
+	// Cannot use t.Parallel(): mutates package-level resolution seams.
+	stubSummaryRegistry(t, []types.AgentName{"codex", "opencode"}, "codex")
+
+	originalLoad := loadSummarySettings
+	t.Cleanup(func() { loadSummarySettings = originalLoad })
+	loadSummarySettings = func(context.Context) (*settings.EntireSettings, error) {
+		return nil, errors.New("boom")
+	}
+
+	cmd, out := newTestCmd(t)
+	checkSummaryProvider(cmd)
+	if out.String() != "" {
+		t.Errorf("expected silence, got:\n%s", out.String())
+	}
+}

--- a/cmd/entire/cli/doctor_summary_provider_test.go
+++ b/cmd/entire/cli/doctor_summary_provider_test.go
@@ -3,11 +3,14 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
 // stubSummaryProviderSettings points the settings seam at one configured
@@ -49,11 +52,15 @@ func TestCheckSummaryProvider_ReportsANonCapableProvider(t *testing.T) {
 		t.Errorf("diagnosis does not name the provider:\n%s", got)
 	}
 	// The remedy must be runnable, not just a statement of the problem.
-	if !strings.Contains(got, "entire configure --summarize-provider") {
-		t.Errorf("diagnosis carries no remedy command:\n%s", got)
+	if !strings.Contains(got, "entire configure --summarize-provider codex") {
+		t.Errorf("diagnosis carries no runnable remedy command:\n%s", got)
 	}
-	if !strings.Contains(got, "codex") {
-		t.Errorf("remedy does not name a usable provider:\n%s", got)
+	// A <a|b|c> placeholder is not copy-pasteable: the shell reads < as a
+	// redirect and | as a pipe, so the obvious paste fails before it runs.
+	for _, meta := range []string{"<", "|", ">"} {
+		if strings.Contains(got, meta) {
+			t.Errorf("diagnosis contains shell metacharacter %q, so it cannot be pasted:\n%s", meta, got)
+		}
 	}
 }
 
@@ -108,5 +115,67 @@ func TestCheckSummaryProvider_SilentWhenSettingsWillNotLoad(t *testing.T) {
 	checkSummaryProvider(cmd)
 	if out.String() != "" {
 		t.Errorf("expected silence, got:\n%s", out.String())
+	}
+}
+
+// The remedy must name the layer `entire configure` would actually write.
+// With no flag it writes the PROJECT file whenever one exists, so a provider
+// coming from settings.local.json needs --local or the "fix" lands in a file
+// the local layer still overrides.
+func TestCheckSummaryProvider_RemedyTargetsTheLayerHoldingTheValue(t *testing.T) {
+	// Cannot use t.Parallel(): t.Chdir and package-level resolution seams.
+	cases := []struct {
+		name      string
+		localFile string
+		wantFile  string
+		wantLocal bool
+	}{
+		{
+			name:      "provider from the project layer",
+			localFile: "",
+			wantFile:  settings.EntireSettingsFile,
+			wantLocal: false,
+		},
+		{
+			name:      "provider from the local layer",
+			localFile: `{"summary_generation":{"provider":"opencode"}}`,
+			wantFile:  settings.EntireSettingsLocalFile,
+			wantLocal: true,
+		},
+		{
+			name:      "local layer exists but supplies a different provider",
+			localFile: `{"summary_generation":{"provider":"codex"}}`,
+			wantFile:  settings.EntireSettingsFile,
+			wantLocal: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			testutil.InitRepo(t, tmpDir)
+			if err := os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if tc.localFile != "" {
+				if err := os.WriteFile(filepath.Join(tmpDir, settings.EntireSettingsLocalFile), []byte(tc.localFile), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Chdir(tmpDir)
+
+			stubSummaryProviderSettings(t, "opencode")
+			cmd, out := newTestCmd(t)
+			checkSummaryProvider(cmd)
+			got := out.String()
+
+			if !strings.Contains(got, tc.wantFile) {
+				t.Errorf("diagnosis does not name %s:\n%s", tc.wantFile, got)
+			}
+			hasLocalFlag := strings.Contains(got, "--local")
+			if hasLocalFlag != tc.wantLocal {
+				t.Errorf("remedy --local = %v, want %v:\n%s", hasLocalFlag, tc.wantLocal, got)
+			}
+		})
 	}
 }

--- a/cmd/entire/cli/doctor_summary_provider_test.go
+++ b/cmd/entire/cli/doctor_summary_provider_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -26,7 +28,16 @@ func stubSummaryProviderSettings(t *testing.T, configured string) {
 	t.Helper()
 
 	isolateRepoForSummaryProviderCheck(t)
+	stubSummaryCLIAvailable(t, "codex")
 	stubSummaryRegistry(t, []types.AgentName{"codex", "opencode"}, "codex")
+	stubSummaryProviderSettingsOnly(t, configured)
+}
+
+// stubSummaryProviderSettingsOnly points the settings seam at one configured
+// provider without touching the registry, availability, or the repo — for
+// tests that set those up themselves.
+func stubSummaryProviderSettingsOnly(t *testing.T, configured string) {
+	t.Helper()
 
 	originalLoad := loadSummarySettings
 	t.Cleanup(func() { loadSummarySettings = originalLoad })
@@ -52,6 +63,17 @@ func isolateRepoForSummaryProviderCheck(t *testing.T) string {
 	}
 	t.Chdir(tmpDir)
 	return tmpDir
+}
+
+// stubSummaryCLIAvailable reports only the named agents as installed.
+func stubSummaryCLIAvailable(t *testing.T, available ...types.AgentName) {
+	t.Helper()
+
+	original := isSummaryCLIAvailable
+	t.Cleanup(func() { isSummaryCLIAvailable = original })
+	isSummaryCLIAvailable = func(name types.AgentName) bool {
+		return slices.Contains(available, name)
+	}
 }
 
 func runCheckSummaryProvider(t *testing.T, configured string) string {
@@ -198,6 +220,10 @@ func TestCheckSummaryProvider_RemedyTargetsTheLayerHoldingTheValue(t *testing.T)
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := isolateRepoForSummaryProviderCheck(t)
+			// Pin availability: the Fix line names an INSTALLED provider, so
+			// without this the assertions depend on which agents the developer
+			// happens to have on $PATH.
+			stubSummaryCLIAvailable(t, agent.AgentNameCodex)
 			testutil.WriteFile(t, tmpDir, settings.EntireSettingsFile, tc.project)
 			if tc.local != "" {
 				testutil.WriteFile(t, tmpDir, settings.EntireSettingsLocalFile, tc.local)
@@ -229,4 +255,53 @@ func TestCheckSummaryProvider_RemedyTargetsTheLayerHoldingTheValue(t *testing.T)
 			}
 		})
 	}
+}
+
+// The Fix command must name a provider that is actually installed. Building it
+// from summaryCapableProviderNames()[0] picks alphabetically — claude-code — so
+// on a machine without claude the suggested command fails `configure`'s own
+// PATH check. An opencode-only user is both the likeliest to see this check and
+// the likeliest to have no claude.
+func TestCheckSummaryProvider_FixNamesAnInstalledProvider(t *testing.T) {
+	// Cannot use t.Parallel(): t.Chdir and package-level resolution seams.
+	t.Run("prefers the installed provider over the alphabetical one", func(t *testing.T) {
+		isolateRepoForSummaryProviderCheck(t)
+		stubSummaryRegistry(t, []types.AgentName{"claude-code", "codex", "opencode"}, "claude-code", "codex")
+		stubSummaryCLIAvailable(t, agent.AgentNameCodex)
+		stubSummaryProviderSettingsOnly(t, "opencode")
+
+		cmd, out := newTestCmd(t)
+		checkSummaryProvider(cmd)
+		got := out.String()
+
+		if !strings.Contains(got, "Fix: entire configure --summarize-provider codex") {
+			t.Errorf("Fix does not name the installed provider:\n%s", got)
+		}
+		if strings.Contains(got, "--summarize-provider claude-code") {
+			t.Errorf("Fix names claude-code, which is not installed:\n%s", got)
+		}
+		// The accepted values are still all of them, installed or not.
+		if !strings.Contains(got, "Supported: claude-code, codex") {
+			t.Errorf("Supported list should carry every accepted value:\n%s", got)
+		}
+	})
+
+	t.Run("says so when nothing capable is installed", func(t *testing.T) {
+		isolateRepoForSummaryProviderCheck(t)
+		stubSummaryRegistry(t, []types.AgentName{"claude-code", "codex", "opencode"}, "claude-code", "codex")
+		stubSummaryCLIAvailable(t) // nothing on PATH
+		stubSummaryProviderSettingsOnly(t, "opencode")
+
+		cmd, out := newTestCmd(t)
+		checkSummaryProvider(cmd)
+		got := out.String()
+
+		// A command that cannot work is worse than no command.
+		if strings.Contains(got, "Fix:") {
+			t.Errorf("suggested a command with no installed provider:\n%s", got)
+		}
+		if !strings.Contains(got, "none installed; install one first") {
+			t.Errorf("does not explain the missing Fix line:\n%s", got)
+		}
+	})
 }

--- a/cmd/entire/cli/doctor_summary_provider_test.go
+++ b/cmd/entire/cli/doctor_summary_provider_test.go
@@ -15,10 +15,17 @@ import (
 
 // stubSummaryProviderSettings points the settings seam at one configured
 // provider ("" for none), against a registry of codex (capable) + opencode
-// (not).
+// (not), inside an isolated repo.
+//
+// The isolation is required, not hygiene: checkSummaryProvider's fault branch
+// calls summaryProviderSourceLayer, which resolves the CURRENT repository and
+// reads its real .entire/settings.local.json. Without a temp repo these tests
+// read the developer's own settings and their output depends on whose machine
+// they run on.
 func stubSummaryProviderSettings(t *testing.T, configured string) {
 	t.Helper()
 
+	isolateRepoForSummaryProviderCheck(t)
 	stubSummaryRegistry(t, []types.AgentName{"codex", "opencode"}, "codex")
 
 	originalLoad := loadSummarySettings
@@ -30,6 +37,21 @@ func stubSummaryProviderSettings(t *testing.T, configured string) {
 		}
 		return s, nil
 	}
+}
+
+// isolateRepoForSummaryProviderCheck creates an empty repo with a .entire
+// directory and points the process at it. Returns the repo root so callers can
+// plant settings layers in it.
+func isolateRepoForSummaryProviderCheck(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmpDir)
+	return tmpDir
 }
 
 func runCheckSummaryProvider(t *testing.T, configured string) string {
@@ -122,59 +144,88 @@ func TestCheckSummaryProvider_SilentWhenSettingsWillNotLoad(t *testing.T) {
 // With no flag it writes the PROJECT file whenever one exists, so a provider
 // coming from settings.local.json needs --local or the "fix" lands in a file
 // the local layer still overrides.
+//
+// Runs against REAL settings loading and the REAL registry rather than the
+// stubs the other tests use. Two reasons: opencode is genuinely incapable, so
+// the registry needs no help; and the tracked-local case cannot be stubbed at
+// all, because localLayerRejection is unexported — only a real Load over a real
+// tracked file produces it.
 func TestCheckSummaryProvider_RemedyTargetsTheLayerHoldingTheValue(t *testing.T) {
-	// Cannot use t.Parallel(): t.Chdir and package-level resolution seams.
+	// Cannot use t.Parallel(): t.Chdir is process-global.
 	cases := []struct {
-		name      string
-		localFile string
-		wantFile  string
-		wantLocal bool
+		name       string
+		project    string
+		local      string
+		trackLocal bool
+		wantFile   string
+		wantLocal  bool
+		why        string
 	}{
 		{
 			name:      "provider from the project layer",
-			localFile: "",
+			project:   `{"enabled":true,"summary_generation":{"provider":"opencode"}}`,
 			wantFile:  settings.EntireSettingsFile,
 			wantLocal: false,
+			why:       "only the project file carries it",
 		},
 		{
 			name:      "provider from the local layer",
-			localFile: `{"summary_generation":{"provider":"opencode"}}`,
+			project:   `{"enabled":true}`,
+			local:     `{"summary_generation":{"provider":"opencode"}}`,
 			wantFile:  settings.EntireSettingsLocalFile,
 			wantLocal: true,
+			why:       "the local layer supplies it, so configure needs --local",
 		},
 		{
-			name:      "local layer exists but supplies a different provider",
-			localFile: `{"summary_generation":{"provider":"codex"}}`,
+			name:      "local layer supplies a different provider",
+			project:   `{"enabled":true,"summary_generation":{"provider":"opencode"}}`,
+			local:     `{"summary_generation":{"provider":"claude-code"}}`,
 			wantFile:  settings.EntireSettingsFile,
 			wantLocal: false,
+			why:       "local wins, so a local claude-code means the fault is not reported at all",
+		},
+		{
+			name:       "tracked local layer is ignored by the loader",
+			project:    `{"enabled":true,"summary_generation":{"provider":"opencode"}}`,
+			local:      `{"summary_generation":{"provider":"opencode"}}`,
+			trackLocal: true,
+			wantFile:   settings.EntireSettingsFile,
+			wantLocal:  false,
+			why:        "a tracked local file is dropped wholesale, so editing it fixes nothing",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir := t.TempDir()
-			testutil.InitRepo(t, tmpDir)
-			if err := os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if tc.localFile != "" {
-				if err := os.WriteFile(filepath.Join(tmpDir, settings.EntireSettingsLocalFile), []byte(tc.localFile), 0o644); err != nil {
-					t.Fatal(err)
+			tmpDir := isolateRepoForSummaryProviderCheck(t)
+			testutil.WriteFile(t, tmpDir, settings.EntireSettingsFile, tc.project)
+			if tc.local != "" {
+				testutil.WriteFile(t, tmpDir, settings.EntireSettingsLocalFile, tc.local)
+				if tc.trackLocal {
+					testutil.GitAdd(t, tmpDir, settings.EntireSettingsLocalFile)
 				}
 			}
-			t.Chdir(tmpDir)
 
-			stubSummaryProviderSettings(t, "opencode")
 			cmd, out := newTestCmd(t)
 			checkSummaryProvider(cmd)
 			got := out.String()
 
-			if !strings.Contains(got, tc.wantFile) {
-				t.Errorf("diagnosis does not name %s:\n%s", tc.wantFile, got)
+			// The third case reports nothing at all (a capable provider wins),
+			// which is itself the correct answer; the rest must diagnose.
+			if tc.name == "local layer supplies a different provider" {
+				if got != "" {
+					t.Fatalf("expected silence (%s), got:\n%s", tc.why, got)
+				}
+				return
 			}
-			hasLocalFlag := strings.Contains(got, "--local")
-			if hasLocalFlag != tc.wantLocal {
-				t.Errorf("remedy --local = %v, want %v:\n%s", hasLocalFlag, tc.wantLocal, got)
+			if !strings.Contains(got, "Summary provider: UNUSABLE") {
+				t.Fatalf("no diagnosis printed (%s):\n%s", tc.why, got)
+			}
+			if !strings.Contains(got, tc.wantFile) {
+				t.Errorf("diagnosis does not name %s (%s):\n%s", tc.wantFile, tc.why, got)
+			}
+			if hasLocal := strings.Contains(got, "--local"); hasLocal != tc.wantLocal {
+				t.Errorf("remedy --local = %v, want %v (%s):\n%s", hasLocal, tc.wantLocal, tc.why, got)
 			}
 		})
 	}

--- a/cmd/entire/cli/explain_summary_provider.go
+++ b/cmd/entire/cli/explain_summary_provider.go
@@ -110,6 +110,12 @@ func resolveCheckpointSummaryProvider(ctx context.Context, w io.Writer) (*checkp
 
 	switch len(candidates) {
 	case 0:
+		// Spelled out rather than derived from summaryCapableProviderNames:
+		// these are BINARY names to install (`claude`, `copilot`), not the
+		// registry names that helper returns (`claude-code`, `copilot-cli`),
+		// and "install claude-code" names nothing you can install. The mapping
+		// lives in isSummaryCLIAvailable; deriving this needs that, not the
+		// name list.
 		return nil, errors.New("no summary-capable provider is available; install claude, codex, gemini, pi, cursor, or copilot, install an external entire-agent-* plugin that declares text_generator, or set summary_generation.provider in settings")
 	case 1:
 		return autoSelectSummaryProvider(ctx, w, candidates[0].Name, "non-interactive auto-select: single installed provider", selectionAutomatic)
@@ -225,11 +231,8 @@ func listEnabledSummaryProviders(_ context.Context) []checkpointSummaryProvider 
 	registered := listRegisteredAgents()
 	providers := make([]checkpointSummaryProvider, 0, len(registered))
 	for _, name := range registered {
-		ag, err := getSummaryAgent(name)
-		if err != nil {
-			continue
-		}
-		if _, ok := agent.AsTextGenerator(ag); !ok {
+		ag, _, capable := summaryCapableAgent(name)
+		if !capable {
 			continue
 		}
 		// Check CLI binary on PATH for built-ins. External agents are already
@@ -243,6 +246,25 @@ func listEnabledSummaryProviders(_ context.Context) []checkpointSummaryProvider 
 		})
 	}
 	return providers
+}
+
+// summaryCapableAgent resolves a provider name to its agent and reports whether
+// that agent can generate text. The one place "is this name a usable summary
+// provider" is decided: the two registry walks, doctor's check, and the error
+// paths all go through it, so the capability predicate cannot drift between
+// them. AsTextGenerator consults CapabilityDeclarer for external agents, which
+// is exactly the part a second inline copy would get wrong.
+//
+// Reports the two failures separately because callers treat them differently:
+// an unregistered name may be an uninstalled plugin, while a registered one
+// that cannot generate text is a settled fault.
+func summaryCapableAgent(name types.AgentName) (ag agent.Agent, registered, capable bool) {
+	ag, err := getSummaryAgent(name)
+	if err != nil {
+		return nil, false, false
+	}
+	_, capable = agent.AsTextGenerator(ag)
+	return ag, true, capable
 }
 
 func isSummaryProviderAvailable(name types.AgentName, ag agent.Agent) bool {
@@ -280,6 +302,58 @@ func buildCheckpointSummaryProvider(name types.AgentName, model string) (*checkp
 	return buildCheckpointSummaryProviderWithEffectiveModel(name, summarize.ResolveModel(name, model))
 }
 
+// summaryCapableProviderNames returns the registered agents that can generate
+// text, which is the set of values summary_generation.provider accepts.
+//
+// Derived from the registry rather than spelled out, so an agent that gains
+// GenerateText needs no second edit here and one that loses it cannot leave a
+// stale name in a user-facing error. The order is agent.List's, which is
+// documented as sorted, so the message is stable without sorting again.
+//
+// Deliberately NOT filtered by $PATH, unlike listEnabledSummaryProviders: this
+// answers "which names does this field accept", and a provider the user has yet
+// to install is still an answer to that. The PATH condition has its own error,
+// which says to install it.
+func summaryCapableProviderNames() []string {
+	registered := listRegisteredAgents()
+	names := make([]string, 0, len(registered))
+	for _, name := range registered {
+		if _, _, capable := summaryCapableAgent(name); capable {
+			names = append(names, string(name))
+		}
+	}
+	return names
+}
+
+// unsupportedSummaryProviderError reports an agent that exists but cannot
+// generate text, naming the providers that would work.
+//
+// The list is the whole point. Every agent name is a valid value for `entire
+// enable --agent`, and summary_generation.provider takes names out of that same
+// registry — so writing the agent you code with into it looks right and is how
+// `opencode` and `factoryai-droid` end up there. The bare sentence said the
+// value was wrong without saying what a right one looks like, and neither
+// `status` nor the settings loader mentions the field at all, so this error is
+// the first and only place a user hears about it.
+//
+// It lists agents rather than pointing at summary_generation.provider, because
+// the value does not always come from there: `configure --summarize-provider`
+// passes a flag, and naming the field would be answering about a file the user
+// did not touch. doctor's check names the field, which is the surface where
+// locating the value is the actual problem.
+//
+// An empty capable set degrades to the bare sentence rather than a dangling
+// "supported agents:" — reachable only with a stubbed registry, since the cli
+// package links every built-in.
+func unsupportedSummaryProviderError(name types.AgentName) error {
+	capable := summaryCapableProviderNames()
+	if len(capable) == 0 {
+		return fmt.Errorf("agent %q does not support summary generation", name)
+	}
+	return fmt.Errorf("agent %q does not support summary generation; supported agents: %s, or an external entire-agent-* plugin that declares text_generator",
+		name, strings.Join(capable, ", "))
+}
+
 func buildCheckpointSummaryProviderWithEffectiveModel(name types.AgentName, effectiveModel string) (*checkpointSummaryProvider, error) {
 	ag, err := getSummaryAgent(name)
 	if err != nil {
@@ -288,7 +362,9 @@ func buildCheckpointSummaryProviderWithEffectiveModel(name types.AgentName, effe
 
 	textGenerator, ok := agent.AsTextGenerator(ag)
 	if !ok {
-		return nil, fmt.Errorf("agent %s does not support summary generation", name)
+		// Backstop: every caller passes a name a gate below already accepted,
+		// so this is unreachable rather than a surface.
+		return nil, unsupportedSummaryProviderError(name)
 	}
 
 	_, streaming := agent.AsStreamingTextGenerator(textGenerator)
@@ -317,7 +393,7 @@ func ensureSummaryProviderPresent(_ context.Context, name types.AgentName) error
 		return fmt.Errorf("unknown summary provider %s: %w", name, err)
 	}
 	if _, ok := agent.AsTextGenerator(ag); !ok {
-		return fmt.Errorf("agent %s does not support summary generation", name)
+		return unsupportedSummaryProviderError(name)
 	}
 	if !isSummaryProviderAvailable(name, ag) {
 		return fmt.Errorf("summary provider %q is configured but its CLI binary is not on PATH; install it or update summary_generation.provider in settings", name)
@@ -332,7 +408,7 @@ func validateSummaryProvider(provider string) error {
 		return fmt.Errorf("unknown summary provider %q: %w", provider, err)
 	}
 	if _, ok := agent.AsTextGenerator(ag); !ok {
-		return fmt.Errorf("agent %q does not support summary generation", provider)
+		return unsupportedSummaryProviderError(name)
 	}
 	if !isSummaryProviderAvailable(name, ag) {
 		return fmt.Errorf("summary provider %q CLI binary is not on PATH; install it or choose another provider", provider)

--- a/cmd/entire/cli/explain_summary_provider_test.go
+++ b/cmd/entire/cli/explain_summary_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1294,5 +1295,92 @@ func TestDiscoverSummaryProviderIfMissing_GrantedExternalIsDiscovered(t *testing
 	}
 	if calls != 1 {
 		t.Fatalf("named discovery called %d times, want exactly 1", calls)
+	}
+}
+
+// stubSummaryRegistry points the resolution seams at a fixed set of agents.
+// capable names get a text generator, the rest get one with the capability
+// stripped, which is the opencode/factoryai-droid shape.
+func stubSummaryRegistry(t *testing.T, all []types.AgentName, capable ...types.AgentName) {
+	t.Helper()
+
+	originalList := listRegisteredAgents
+	originalGet := getSummaryAgent
+	t.Cleanup(func() {
+		listRegisteredAgents = originalList
+		getSummaryAgent = originalGet
+	})
+
+	isCapable := make(map[types.AgentName]bool, len(capable))
+	for _, name := range capable {
+		isCapable[name] = true
+	}
+	listRegisteredAgents = func() []types.AgentName { return all }
+	getSummaryAgent = func(name types.AgentName) (agent.Agent, error) {
+		if !slices.Contains(all, name) {
+			return nil, fmt.Errorf("agent %s not registered", name)
+		}
+		base := &stubTextAgent{name: name, kind: types.AgentType(name)}
+		if isCapable[name] {
+			return base, nil
+		}
+		return &stubNonTextAgent{Agent: base}, nil
+	}
+}
+
+// The list is the reason this error exists: the bare sentence told the user the
+// value was wrong without saying what a right one looks like.
+func TestUnsupportedSummaryProviderError_NamesTheCapableProviders(t *testing.T) {
+	// Cannot use t.Parallel(): mutates package-level resolution seams.
+	stubSummaryRegistry(t,
+		[]types.AgentName{"codex", "gemini", "opencode"},
+		"codex", "gemini")
+
+	err := unsupportedSummaryProviderError("opencode")
+	if err == nil {
+		t.Fatal("expected an error for a non-capable provider")
+	}
+	got := err.Error()
+
+	if !strings.Contains(got, `agent "opencode" does not support summary generation`) {
+		t.Errorf("error does not name the rejected provider: %q", got)
+	}
+	// One assertion covers both halves: the exact list, and that the rejected
+	// provider is absent from it. Counting occurrences in the prose instead
+	// would fail on any rewording that legitimately names the value twice.
+	if !strings.Contains(got, "supported agents: codex, gemini,") {
+		t.Errorf("error does not carry the capable list: %q", got)
+	}
+}
+
+// An empty capable set must not produce a dangling "one of" with nothing after
+// it. Unreachable in the shipped binary, reached by any test that stubs the
+// registry.
+func TestUnsupportedSummaryProviderError_DegradesWithNoCapableProviders(t *testing.T) {
+	// Cannot use t.Parallel(): mutates package-level resolution seams.
+	stubSummaryRegistry(t, []types.AgentName{"opencode"})
+
+	got := unsupportedSummaryProviderError("opencode").Error()
+	if got != `agent "opencode" does not support summary generation` {
+		t.Errorf("unexpected degraded message: %q", got)
+	}
+}
+
+// Pins the accepted values against the registry. This test runs in the cli
+// package, where every built-in agent is registered, so it is the enforced copy
+// of the set README documents — and it fails in both directions: an agent that
+// gains GenerateText without the docs following, and one listed here that
+// quietly loses the capability.
+func TestSummaryCapableProviderNames_MatchesTheBuiltInAgents(t *testing.T) {
+	t.Parallel()
+
+	// opencode and factoryai-droid are deliberately absent: both are registered
+	// agents with no GenerateText, and naming one is the fault this feature reports.
+	want := []string{"claude-code", "codex", "copilot-cli", "cursor", "gemini", "pi"}
+	got := summaryCapableProviderNames()
+	if !slices.Equal(got, want) {
+		t.Errorf("summary-capable providers = %v, want %v\n"+
+			"If an agent gained or lost GenerateText, update this list and README's\n"+
+			"\"cannot generate summaries\" note together.", got, want)
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1297
<!-- entire-trail-link-end -->

## What

`summary_generation.provider` takes names out of the agent registry, and every name in that registry is also a valid `entire enable --agent` value. So writing the agent you code with into it looks right — and for `opencode` and `factoryai-droid`, which are registered agents with no `GenerateText`, the entire diagnosis was:

```
agent opencode does not support summary generation
```

No accepted values, and no pointer to where the value lives. This PR lists the supported agents in that error and teaches `entire doctor` to report the condition.

## Why it is worth a check of its own

Neither writer can produce such a value: `configure --summarize-provider` runs `validateSummaryProvider`, and the picker's candidates come from `listEnabledSummaryProviders`, which is capability-filtered — a filter present since the feature's first commit, so no older release wrote one either. The value therefore always arrives by hand-editing, most plausibly by an agent that reached for the name it knows itself by.

And nothing said a word about it. `SummaryGenerationSettings.Validate` checks only model-without-provider, `entire status` never mentions summary generation, and the resolver's error surfaces at `entire checkpoint explain --generate` / `dispatch` / `runner setup` — commands the user may not run for weeks after the edit, by which time the cause is not in view. In a committed `.entire/settings.json` it breaks for everyone who clones.

## Changes

The three `does not support summary generation` sites now route through `unsupportedSummaryProviderError`, which builds its list from the registry so a stale name cannot outlive the capability:

```
agent "opencode" does not support summary generation; supported agents: claude-code,
codex, copilot-cli, cursor, gemini, pi, or an external entire-agent-* plugin that
declares text_generator
```

The list is deliberately not `$PATH`-filtered, unlike `listEnabledSummaryProviders`: it answers "which names does this field accept", and a provider not yet installed is still an answer to that. The PATH condition keeps its own error, which says to install it. The three sites had also drifted apart on quoting (`%s` vs `%q`); they now agree.

`entire doctor` gains `checkSummaryProvider`:

```
Summary provider: UNUSABLE
  summary_generation.provider is "opencode", which cannot generate text.
  `entire checkpoint explain --generate`, `entire dispatch`, and
  `entire runner setup` all fail while it is set.
  Fix: entire configure --summarize-provider <claude-code|codex|copilot-cli|cursor|gemini|pi>
  No `entire` command writes this value, so it was hand-edited or written by an agent.
```

It reports without fixing: which provider to use is the user's call, and the value may live in a committed file where a rewrite changes everyone's configuration.

Two conditions are deliberately **not** reported, each with its reason at the call site:

- An **unregistered** provider name. That is the external-plugin shape, and telling "plugin not installed" from "installed but the `external_agents` grant is missing" means running discovery, which execs every candidate binary. doctor must not exec a plugin to write a diagnostic, and the grant rejection is already surfaced by `entire status` via `ExternalAgentsRejection`.
- A capable provider whose **binary is off `$PATH`**. Machine-local and expected — a provider configured on another machine, or a project setting for a team that does not all install the same CLI — so it is a fact about this checkout rather than a fault in the repo, and the resolver already reports it actionably at the point of use.

## Product calls for a reviewer

Both are wording/scope judgments rather than mechanics, so move them if you disagree:

- The resolver error lists agents and does **not** name `summary_generation.provider`, because `configure --summarize-provider` reaches it via a flag and naming the field would point at a file the user did not touch. doctor's check does name the field, which is the surface where locating the value is the actual problem. The tradeoff: for `runner setup` / `explain` / `dispatch`, which pass no provider, the error no longer says where the value came from.
- doctor's wording asserts "No `entire` command writes this value". That is true of this tree and of every earlier one I checked, but it is a claim about all of history, so it would go stale if a future write path skipped the capability gate.

## Not in scope

`entire runner setup -y` scaffolds six runner files and *then* resolves the provider, so it exits 1 having already written them, and every retry fails identically until the setting is fixed. `runner_setup.go` deliberately resolves "before the gather" so a failure does not land after seconds of waiting, while a comment ten lines earlier draws the line harder for `--agent`: *"Before the scaffold: a usage error must not leave files behind."* An unusable configured provider is knowable before any write, so it arguably belongs on the same side of that line — but creating the defaults is real work the user asked for, so this is a behaviour change rather than a fix and is left out.

## Testing

`mise run check` (fmt, lint, test:ci) clean. `GOOS=windows go build ./...` clean.

Verified by running the real binary in a scratch repo carrying `{"summary_generation": {"provider": "opencode"}}`, across `runner setup -y`, `configure --summarize-provider opencode`, and `doctor` — including that doctor goes silent once the setting is corrected.

New tests: the error names the capable agents and never re-suggests the rejected one; an empty capable set degrades to the bare sentence instead of a dangling "supported agents:"; doctor reports the fault and stays silent across four healthy shapes (capable provider, no provider, unregistered provider, unloadable settings). Plus `TestSummaryCapableProviderNames_MatchesTheBuiltInAgents`, a guard in the `cli` package (where every built-in is registered) pinning the set to exactly those six and asserting `opencode` and `factoryai-droid` are absent — so the registry and README's "cannot generate summaries" note cannot drift apart silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing diagnostics and error messages only; no changes to auth, persistence semantics beyond clearer errors, or capture paths.
> 
> **Overview**
> Improves diagnosis when `summary_generation.provider` points at a registered agent that cannot generate summaries (e.g. `opencode`), a value that often arrives from hand-editing because it shares the same name list as `entire enable --agent`.
> 
> **Resolver errors** now go through `unsupportedSummaryProviderError`, which lists registry-derived, text-capable agent names (not `$PATH`-filtered) plus a note about external `entire-agent-*` plugins. The same helper unifies quoting at the three previous “does not support summary generation” sites.
> 
> **`entire doctor`** adds `checkSummaryProvider`: it prints **Summary provider: UNUSABLE**, names `summary_generation.provider`, lists affected commands, and suggests `entire configure --summarize-provider <capable names>`. It reports only—no auto-fix—and stays silent for capable providers, missing config, unregistered (external) names, and unloadable settings.
> 
> Tests cover doctor output, error wording, empty-capable degradation, and a guard that built-in summary-capable agents match the expected set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d57c929a6b5f523de769d55ff1cd412937a77f9f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->