### PR TITLE
fix(strategy): require fetch URLs for checkpoint sync remote election

### DIFF
--- a/cmd/entire/cli/integration_test/checkpoint_sync_remote_test.go
+++ b/cmd/entire/cli/integration_test/checkpoint_sync_remote_test.go
@@ -304,6 +304,46 @@ func TestCheckpointSyncRemote_TrackedPushCapturesElection(t *testing.T) {
 	})
 }
 
+// TestCheckpointSyncRemote_PushURLOnlyRemoteCannotCaptureElection verifies
+// that capture and election use the same fetch-URL eligibility rule. Git treats
+// a pushurl-only entry as a configured push target, but checkpoint sync cannot
+// read or reconcile from it, so a push there must carry no checkpoint data and
+// must not make the destination sticky.
+func TestCheckpointSyncRemote_PushURLOnlyRemoteCannotCaptureElection(t *testing.T) {
+	t.Parallel()
+	ForEachBackend(t, func(t *testing.T, backend string) {
+		env := NewFeatureBranchEnv(t)
+		env.CheckpointStore = backend
+
+		bareOrigin := env.SetupBareRemote()
+		barePushOnly := env.SetupNamedBareRemote("pushonly")
+		testutil.RunGit(t, env.RepoDir, "config", "remote.pushonly.pushurl", barePushOnly)
+		testutil.RunGit(t, env.RepoDir, "config", "--unset-all", "remote.pushonly.url")
+		env.setGitConfigBaseline()
+
+		checkpointID := createCheckpointedCommit(t, env, "Add capture guard", "guard.go", "package guard", "Add capture guard")
+
+		env.RunPrePush("pushonly")
+		if env.CheckpointsPresentOnRemote(barePushOnly) {
+			t.Error("a pushurl-only remote must not receive checkpoint data")
+		}
+		if got := capturedSyncRemotesOnDisk(t, env); got != nil {
+			t.Errorf("a pushurl-only remote must not capture the election, got %v", got)
+		}
+		if env.usingGitRefs() && queuedCheckpointRefCount(t, env) == 0 {
+			t.Error("push queue should be preserved after the ineligible push")
+		}
+
+		env.RunPrePush("origin")
+		if !env.CheckpointExistsOnRemote(bareOrigin, checkpointID) {
+			t.Errorf("checkpoint %s should remain available to the elected origin", checkpointID)
+		}
+		if env.usingGitRefs() && queuedCheckpointRefCount(t, env) != 0 {
+			t.Error("push queue should drain after pushing to origin")
+		}
+	})
+}
+
 // TestCheckpointSyncRemote_DeferredPushDoesNotCaptureElection covers the
 // gate-to-delivery gap on the most likely first push there is: the user adds a
 // brand-new empty fork and pushes their branch to it for the first time. That

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -356,8 +356,8 @@ type checkpointSyncInfo struct {
 func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpointSyncInfo {
 	elected, err := strategy.ResolveCheckpointSyncRemote(ctx)
 	if err != nil {
-		// Fail-closed: checkpoint_push_remote names a remote that does not
-		// exist. The pre-push gate is silently skipping checkpoint sync, so
+		// Fail-closed: election could not confirm a usable checkpoint sync
+		// remote. The pre-push gate is silently skipping checkpoint sync, so
 		// status is the user's signal.
 		// Accepted divergence: if a structured checkpoint_remote is also
 		// configured, the gate's dedicated exemption may still sync checkpoint

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -2366,24 +2367,43 @@ func TestRunStatus_CheckpointSyncDestination_CapturedAnnotated(t *testing.T) {
 
 func TestRunStatus_CheckpointSyncFailClosed(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
-	setupTestRepo(t)
-	writeSettings(t, `{"enabled": true, "strategy_options": {"checkpoint_push_remote": "gone"}}`)
-	testutil.AddRemote(t, ".", "origin", "https://example.com/origin.git")
 
-	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
-		t.Fatalf("runStatus() error = %v", err)
-	}
+	for _, tt := range []struct {
+		name        string
+		remote      string
+		pushurlOnly bool
+		wantReason  string
+	}{
+		{name: "missing remote", remote: "gone"},
+		{name: "pushurl-only remote", remote: "pushonly", pushurlOnly: true, wantReason: "fetch URL"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setupTestRepo(t)
+			writeSettings(t, fmt.Sprintf(`{"enabled": true, "strategy_options": {"checkpoint_push_remote": %q}}`, tt.remote))
+			testutil.AddRemote(t, ".", "origin", "https://example.com/origin.git")
+			if tt.pushurlOnly {
+				testutil.RunGit(t, ".", "config", "remote."+tt.remote+".pushurl", "https://example.com/pushonly.git")
+			}
 
-	out := stdout.String()
-	if !strings.Contains(out, "Checkpoints NOT syncing:") {
-		t.Errorf("expected fail-closed warning line, got:\n%s", out)
-	}
-	if !strings.Contains(out, `"gone"`) {
-		t.Errorf("fail-closed line should name the misconfigured remote, got:\n%s", out)
-	}
-	if strings.Contains(out, "Checkpoints sync to:") {
-		t.Errorf("fail-closed status must not also print a destination line, got:\n%s", out)
+			var stdout bytes.Buffer
+			if err := runStatus(context.Background(), &stdout, false, false); err != nil {
+				t.Fatalf("runStatus() error = %v", err)
+			}
+
+			out := stdout.String()
+			if !strings.Contains(out, "Checkpoints NOT syncing:") {
+				t.Errorf("expected fail-closed warning line, got:\n%s", out)
+			}
+			if !strings.Contains(out, fmt.Sprintf("%q", tt.remote)) {
+				t.Errorf("fail-closed line should name remote %q, got:\n%s", tt.remote, out)
+			}
+			if tt.wantReason != "" && !strings.Contains(out, tt.wantReason) {
+				t.Errorf("fail-closed line should contain %q, got:\n%s", tt.wantReason, out)
+			}
+			if strings.Contains(out, "Checkpoints sync to:") {
+				t.Errorf("fail-closed status must not also print a destination line, got:\n%s", out)
+			}
+		})
 	}
 }
 

--- a/cmd/entire/cli/strategy/checkpoint_sync_capture.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_capture.go
@@ -102,7 +102,7 @@ func saveCapturedSyncRemote(ctx context.Context, name string) error {
 // the write idempotent — "first capture sticks" is decided when the state lands,
 // not when it was proposed.
 func pendingCaptureCheckpointSyncRemote(ctx context.Context, pushRemote string) bool {
-	if !isConfiguredRemote(ctx, pushRemote) {
+	if !hasConfiguredFetchURL(configuredRemotesInConfigOrder(ctx), pushRemote) {
 		return false
 	}
 	root, err := capturedSyncRemotesRoot(ctx)

--- a/cmd/entire/cli/strategy/checkpoint_sync_capture.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_capture.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/gitdir"
@@ -102,7 +103,7 @@ func saveCapturedSyncRemote(ctx context.Context, name string) error {
 // the write idempotent — "first capture sticks" is decided when the state lands,
 // not when it was proposed.
 func pendingCaptureCheckpointSyncRemote(ctx context.Context, pushRemote string) bool {
-	if !hasConfiguredFetchURL(configuredRemotesInConfigOrder(ctx), pushRemote) {
+	if !slices.Contains(configuredRemotesInConfigOrder(ctx), pushRemote) {
 		return false
 	}
 	root, err := capturedSyncRemotesRoot(ctx)

--- a/cmd/entire/cli/strategy/checkpoint_sync_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_remote.go
@@ -81,9 +81,9 @@ func ResolveCheckpointSyncRemote(ctx context.Context) (CheckpointSyncRemote, err
 	}
 	// Every tier elects from the same fetchable set. `git remote get-url`
 	// accepts a pushurl-only entry even though reads and reconciliation cannot.
-	remotes := configuredRemotesInConfigOrder(ctx)
+	fetchRemotes := configuredRemotesInConfigOrder(ctx)
 	if name := s.GetCheckpointPushRemote(); name != "" {
-		if !hasConfiguredFetchURL(remotes, name) {
+		if !slices.Contains(fetchRemotes, name) {
 			return CheckpointSyncRemote{}, fmt.Errorf(
 				"checkpoint_push_remote %q has no configured fetch URL; checkpoint sync disabled until fixed", name)
 		}
@@ -94,7 +94,7 @@ func ResolveCheckpointSyncRemote(ctx context.Context) (CheckpointSyncRemote, err
 	// is automatic state, so a captured remote that is no longer fetchable
 	// falls through to the default tiers instead of disabling sync.
 	for _, name := range loadCapturedSyncRemotes(ctx) {
-		if hasConfiguredFetchURL(remotes, name) {
+		if slices.Contains(fetchRemotes, name) {
 			return CheckpointSyncRemote{Name: name, Source: SyncRemoteSourceObserved}, nil
 		}
 		logging.Debug(ctx, "captured checkpoint sync remote has no configured fetch URL; falling through",
@@ -102,14 +102,14 @@ func ResolveCheckpointSyncRemote(ctx context.Context) (CheckpointSyncRemote, err
 	}
 
 	switch {
-	case len(remotes) == 0:
+	case len(fetchRemotes) == 0:
 		return CheckpointSyncRemote{}, nil
-	case hasConfiguredFetchURL(remotes, "origin"):
+	case slices.Contains(fetchRemotes, "origin"):
 		return CheckpointSyncRemote{Name: "origin", Source: SyncRemoteSourceDefault}, nil
-	case len(remotes) == 1:
-		return CheckpointSyncRemote{Name: remotes[0], Source: SyncRemoteSourceSole}, nil
+	case len(fetchRemotes) == 1:
+		return CheckpointSyncRemote{Name: fetchRemotes[0], Source: SyncRemoteSourceSole}, nil
 	default:
-		return CheckpointSyncRemote{Name: remotes[0], Source: SyncRemoteSourceFirst}, nil
+		return CheckpointSyncRemote{Name: fetchRemotes[0], Source: SyncRemoteSourceFirst}, nil
 	}
 }
 
@@ -159,7 +159,7 @@ func checkpointSyncAllowedForRemote(ctx context.Context, pushRemote, pendingCapt
 // fact, and committing it to the tracked settings.json would fail-close
 // checkpoint sync for every teammate whose clone lacks that remote name.
 func hintGatedCheckpointSync(ctx context.Context, pushRemote string) {
-	if !hasConfiguredFetchURL(configuredRemotesInConfigOrder(ctx), pushRemote) {
+	if !slices.Contains(configuredRemotesInConfigOrder(ctx), pushRemote) {
 		return
 	}
 	syncRemote, err := ResolveCheckpointSyncRemote(ctx)
@@ -211,10 +211,6 @@ func hintGatedCheckpointSync(ctx context.Context, pushRemote string) {
 		slog.Int("unpushed_checkpoints", count),
 		slog.String("checkpoint_sync_remote", syncRemote.Name),
 		slog.String("push_remote", pushRemote))
-}
-
-func hasConfiguredFetchURL(remotes []string, name string) bool {
-	return slices.Contains(remotes, name)
 }
 
 // configuredRemotesInConfigOrder lists remote names in .git/config section

--- a/cmd/entire/cli/strategy/checkpoint_sync_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_remote.go
@@ -83,7 +83,7 @@ func ResolveCheckpointSyncRemote(ctx context.Context) (CheckpointSyncRemote, err
 	// accepts a pushurl-only entry even though reads and reconciliation cannot.
 	remotes := configuredRemotesInConfigOrder(ctx)
 	if name := s.GetCheckpointPushRemote(); name != "" {
-		if !slices.Contains(remotes, name) {
+		if !hasConfiguredFetchURL(remotes, name) {
 			return CheckpointSyncRemote{}, fmt.Errorf(
 				"checkpoint_push_remote %q has no configured fetch URL; checkpoint sync disabled until fixed", name)
 		}
@@ -94,7 +94,7 @@ func ResolveCheckpointSyncRemote(ctx context.Context) (CheckpointSyncRemote, err
 	// is automatic state, so a captured remote that is no longer fetchable
 	// falls through to the default tiers instead of disabling sync.
 	for _, name := range loadCapturedSyncRemotes(ctx) {
-		if slices.Contains(remotes, name) {
+		if hasConfiguredFetchURL(remotes, name) {
 			return CheckpointSyncRemote{Name: name, Source: SyncRemoteSourceObserved}, nil
 		}
 		logging.Debug(ctx, "captured checkpoint sync remote has no configured fetch URL; falling through",
@@ -104,7 +104,7 @@ func ResolveCheckpointSyncRemote(ctx context.Context) (CheckpointSyncRemote, err
 	switch {
 	case len(remotes) == 0:
 		return CheckpointSyncRemote{}, nil
-	case slices.Contains(remotes, "origin"):
+	case hasConfiguredFetchURL(remotes, "origin"):
 		return CheckpointSyncRemote{Name: "origin", Source: SyncRemoteSourceDefault}, nil
 	case len(remotes) == 1:
 		return CheckpointSyncRemote{Name: remotes[0], Source: SyncRemoteSourceSole}, nil
@@ -159,7 +159,7 @@ func checkpointSyncAllowedForRemote(ctx context.Context, pushRemote, pendingCapt
 // fact, and committing it to the tracked settings.json would fail-close
 // checkpoint sync for every teammate whose clone lacks that remote name.
 func hintGatedCheckpointSync(ctx context.Context, pushRemote string) {
-	if !slices.Contains(configuredRemotesInConfigOrder(ctx), pushRemote) {
+	if !hasConfiguredFetchURL(configuredRemotesInConfigOrder(ctx), pushRemote) {
 		return
 	}
 	syncRemote, err := ResolveCheckpointSyncRemote(ctx)
@@ -211,6 +211,10 @@ func hintGatedCheckpointSync(ctx context.Context, pushRemote string) {
 		slog.Int("unpushed_checkpoints", count),
 		slog.String("checkpoint_sync_remote", syncRemote.Name),
 		slog.String("push_remote", pushRemote))
+}
+
+func hasConfiguredFetchURL(remotes []string, name string) bool {
+	return slices.Contains(remotes, name)
 }
 
 // configuredRemotesInConfigOrder lists remote names in .git/config section

--- a/cmd/entire/cli/strategy/checkpoint_sync_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_remote.go
@@ -149,17 +149,17 @@ func checkpointSyncAllowedForRemote(ctx context.Context, pushRemote, pendingCapt
 // until the elected remote happens to be pushed.
 //
 // Stays quiet unless every condition holds: the push target is a configured
-// remote (checkpoint_push_remote takes a remote name, so a raw-URL push has
-// no actionable suggestion), the election succeeded AND was automatic (an
-// explicit checkpoint_push_remote is a decision already made, and the
-// fail-closed misconfigured case logs a warning through the gate itself), and
-// checkpoints are actually waiting. Fully local — no network.
+// remote with a fetch URL (checkpoint_push_remote must name one), the election
+// succeeded AND was automatic (an explicit checkpoint_push_remote is a
+// decision already made, and the fail-closed misconfigured case logs a warning
+// through the gate itself), and checkpoints are actually waiting. Fully local
+// — no network.
 //
 // The hint names .entire/settings.local.json: a remote name is a per-clone
 // fact, and committing it to the tracked settings.json would fail-close
 // checkpoint sync for every teammate whose clone lacks that remote name.
 func hintGatedCheckpointSync(ctx context.Context, pushRemote string) {
-	if !isConfiguredRemote(ctx, pushRemote) {
+	if !slices.Contains(configuredRemotesInConfigOrder(ctx), pushRemote) {
 		return
 	}
 	syncRemote, err := ResolveCheckpointSyncRemote(ctx)

--- a/cmd/entire/cli/strategy/checkpoint_sync_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_remote.go
@@ -42,12 +42,12 @@ type CheckpointSyncRemote struct {
 
 // ResolveCheckpointSyncRemote elects the one configured git remote that
 // checkpoint data syncs to. Pure local lookup — no network. Precedence:
-// checkpoint_push_remote setting (fail-closed if the named remote does not
-// exist), then the captured election (evidence-elected by a past push that
-// agreed with the branch's declared push destination; fail-soft if that
-// remote is gone), then "origin", then the sole remote, then the first remote
-// in .git/config order. It knows nothing about the checkpoint_remote URL
-// feature; callers exempt that case themselves.
+// checkpoint_push_remote setting (fail-closed if the named remote has no
+// fetch URL), then the captured election (evidence-elected by a past push that
+// agreed with the branch's declared push destination; fail-soft if that remote
+// is no longer fetchable), then "origin", then the sole remote, then the first
+// remote in .git/config order. It knows nothing about the checkpoint_remote
+// URL feature; callers exempt that case themselves.
 //
 // Deliberately NOT keyed on the branch's tracking config alone
 // (branch.<name>.pushRemote / remote.pushDefault / branch.<name>.remote).
@@ -79,26 +79,28 @@ func ResolveCheckpointSyncRemote(ctx context.Context) (CheckpointSyncRemote, err
 	if err != nil {
 		return CheckpointSyncRemote{}, fmt.Errorf("cannot read settings to resolve the checkpoint sync remote: %w", err)
 	}
+	// Every tier elects from the same fetchable set. `git remote get-url`
+	// accepts a pushurl-only entry even though reads and reconciliation cannot.
+	remotes := configuredRemotesInConfigOrder(ctx)
 	if name := s.GetCheckpointPushRemote(); name != "" {
-		if !isConfiguredRemote(ctx, name) {
+		if !slices.Contains(remotes, name) {
 			return CheckpointSyncRemote{}, fmt.Errorf(
-				"checkpoint_push_remote %q is not a configured git remote; checkpoint sync disabled until fixed", name)
+				"checkpoint_push_remote %q has no configured fetch URL; checkpoint sync disabled until fixed", name)
 		}
 		return CheckpointSyncRemote{Name: name, Source: SyncRemoteSourceConfig}, nil
 	}
 
 	// Captured tier: fail-soft, unlike the explicit setting above — capture
-	// is automatic state, so a captured remote that was since renamed or
-	// removed falls through to the default tiers instead of disabling sync.
+	// is automatic state, so a captured remote that is no longer fetchable
+	// falls through to the default tiers instead of disabling sync.
 	for _, name := range loadCapturedSyncRemotes(ctx) {
-		if isConfiguredRemote(ctx, name) {
+		if slices.Contains(remotes, name) {
 			return CheckpointSyncRemote{Name: name, Source: SyncRemoteSourceObserved}, nil
 		}
-		logging.Debug(ctx, "captured checkpoint sync remote is not configured; falling through",
+		logging.Debug(ctx, "captured checkpoint sync remote has no configured fetch URL; falling through",
 			slog.String("remote", name))
 	}
 
-	remotes := configuredRemotesInConfigOrder(ctx)
 	switch {
 	case len(remotes) == 0:
 		return CheckpointSyncRemote{}, nil

--- a/cmd/entire/cli/strategy/checkpoint_sync_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_remote_test.go
@@ -535,6 +535,18 @@ func TestHintGatedCheckpointSync(t *testing.T) {
 		assert.Empty(t, buf.String(), "checkpoint_push_remote takes a remote name; a URL push has no actionable hint")
 	})
 
+	t.Run("pushurl-only remote stays silent", func(t *testing.T) {
+		dir := initHintRepo(t, false)
+		testutil.RunGit(t, dir, "config", "remote.pushonly.pushurl", "https://example.com/pushonly.git")
+		setGitConfig(t, dir, "remote.pushDefault", "pushonly")
+		t.Chdir(dir)
+		buf := captureStderrWriter(t)
+
+		hintGatedCheckpointSync(ctx, "pushonly")
+
+		assert.Empty(t, buf.String(), "the hint must not recommend a remote that checkpoint sync cannot read from")
+	})
+
 	t.Run("failed election stays silent", func(t *testing.T) {
 		dir := initHintRepo(t, true)
 		testutil.WriteCheckpointPushRemoteSetting(t, dir, "gone")

--- a/cmd/entire/cli/strategy/checkpoint_sync_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_remote_test.go
@@ -72,6 +72,29 @@ func TestResolveCheckpointSyncRemote_ConfigSettingMissingRemote_FailsClosed(t *t
 }
 
 // Not parallel: uses t.Chdir()
+func TestResolveCheckpointSyncRemote_ConfigSettingPushurlOnlyRemote_FailsClosed(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+
+	testutil.AddRemote(t, tmpDir, "origin", "https://example.com/origin.git")
+	testutil.RunGit(t, tmpDir, "config", "remote.pushonly.pushurl", "https://example.com/pushonly.git")
+	testutil.WriteCheckpointPushRemoteSetting(t, tmpDir, "pushonly")
+
+	t.Chdir(tmpDir)
+
+	got, err := ResolveCheckpointSyncRemote(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pushonly")
+	assert.Contains(t, err.Error(), "fetch URL")
+	assert.Empty(t, got.Name)
+}
+
+// Not parallel: uses t.Chdir()
 func TestResolveCheckpointSyncRemote_DefaultsToOrigin(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	ctx := context.Background()
@@ -563,6 +586,17 @@ func TestResolveCheckpointSyncRemote_CapturedTier(t *testing.T) {
 		dir := newCaptureTestRepo(t)
 		t.Chdir(dir)
 		require.NoError(t, saveCapturedSyncRemote(ctx, "gone"))
+
+		got, err := ResolveCheckpointSyncRemote(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, CheckpointSyncRemote{Name: "origin", Source: SyncRemoteSourceDefault}, got)
+	})
+
+	t.Run("captured pushurl-only remote falls through to origin", func(t *testing.T) {
+		dir := newCaptureTestRepo(t)
+		testutil.RunGit(t, dir, "config", "remote.pushonly.pushurl", "https://example.com/pushonly.git")
+		t.Chdir(dir)
+		require.NoError(t, saveCapturedSyncRemote(ctx, "pushonly"))
 
 		got, err := ResolveCheckpointSyncRemote(ctx)
 		require.NoError(t, err)

--- a/cmd/entire/cli/strategy/checkpoint_sync_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_remote_test.go
@@ -51,47 +51,38 @@ func TestResolveCheckpointSyncRemote_ConfigSetting(t *testing.T) {
 }
 
 // Not parallel: uses t.Chdir()
-func TestResolveCheckpointSyncRemote_ConfigSettingMissingRemote_FailsClosed(t *testing.T) {
+func TestResolveCheckpointSyncRemote_ConfigSettingInvalidRemote_FailsClosed(t *testing.T) {
 	testutil.IsolateGitConfigEnv(t)
 	ctx := context.Background()
-	tmpDir := t.TempDir()
-	testutil.InitRepo(t, tmpDir)
-	testutil.WriteFile(t, tmpDir, "f.txt", "init")
-	testutil.GitAdd(t, tmpDir, "f.txt")
-	testutil.GitCommit(t, tmpDir, "init")
 
-	testutil.AddRemote(t, tmpDir, "origin", "https://example.com/origin.git")
-	testutil.WriteCheckpointPushRemoteSetting(t, tmpDir, "gone")
+	for _, tt := range []struct {
+		name    string
+		remote  string
+		pushURL string
+	}{
+		{name: "missing remote", remote: "gone"},
+		{name: "pushurl-only remote", remote: "pushonly", pushURL: "https://example.com/pushonly.git"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			testutil.InitRepo(t, tmpDir)
+			testutil.WriteFile(t, tmpDir, "f.txt", "init")
+			testutil.GitAdd(t, tmpDir, "f.txt")
+			testutil.GitCommit(t, tmpDir, "init")
+			testutil.AddRemote(t, tmpDir, "origin", "https://example.com/origin.git")
+			if tt.pushURL != "" {
+				testutil.RunGit(t, tmpDir, "config", "remote."+tt.remote+".pushurl", tt.pushURL)
+			}
+			testutil.WriteCheckpointPushRemoteSetting(t, tmpDir, tt.remote)
+			t.Chdir(tmpDir)
 
-	t.Chdir(tmpDir)
-
-	got, err := ResolveCheckpointSyncRemote(ctx)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "gone")
-	assert.Empty(t, got.Name)
-}
-
-// Not parallel: uses t.Chdir()
-func TestResolveCheckpointSyncRemote_ConfigSettingPushurlOnlyRemote_FailsClosed(t *testing.T) {
-	testutil.IsolateGitConfigEnv(t)
-	ctx := context.Background()
-	tmpDir := t.TempDir()
-	testutil.InitRepo(t, tmpDir)
-	testutil.WriteFile(t, tmpDir, "f.txt", "init")
-	testutil.GitAdd(t, tmpDir, "f.txt")
-	testutil.GitCommit(t, tmpDir, "init")
-
-	testutil.AddRemote(t, tmpDir, "origin", "https://example.com/origin.git")
-	testutil.RunGit(t, tmpDir, "config", "remote.pushonly.pushurl", "https://example.com/pushonly.git")
-	testutil.WriteCheckpointPushRemoteSetting(t, tmpDir, "pushonly")
-
-	t.Chdir(tmpDir)
-
-	got, err := ResolveCheckpointSyncRemote(ctx)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "pushonly")
-	assert.Contains(t, err.Error(), "fetch URL")
-	assert.Empty(t, got.Name)
+			got, err := ResolveCheckpointSyncRemote(ctx)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.remote)
+			assert.Contains(t, err.Error(), "fetch URL")
+			assert.Empty(t, got.Name)
+		})
+	}
 }
 
 // Not parallel: uses t.Chdir()

--- a/cmd/entire/cli/strategy/checkpoint_sync_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_sync_remote_test.go
@@ -758,6 +758,17 @@ func TestCaptureCheckpointSyncRemote(t *testing.T) {
 		assert.Equal(t, []string{"fork"}, loadCapturedSyncRemotes(ctx))
 	})
 
+	t.Run("pushurl-only remote cannot capture", func(t *testing.T) {
+		dir := newCaptureTestRepo(t)
+		testutil.RunGit(t, dir, "config", "remote.pushonly.pushurl", "https://example.com/pushonly.git")
+		setGitConfig(t, dir, "remote.pushDefault", "pushonly")
+		t.Chdir(dir)
+
+		assert.False(t, pendingCaptureCheckpointSyncRemote(ctx, "pushonly"),
+			"capture must use the same fetch-URL eligibility rule as election")
+		assert.Empty(t, loadCapturedSyncRemotes(ctx))
+	})
+
 	t.Run("raw URL push never captures", func(t *testing.T) {
 		dir := newCaptureTestRepo(t)
 		setGitConfig(t, dir, "branch."+currentBranchName(t, dir)+".remote", "fork")


### PR DESCRIPTION
Closes #2360

Trail: https://entire.io/gh/MuskanPaliwal/cli/trails/4

A Git remote can be configured with only a `pushurl` and no fetch URL. Such a remote can receive pushes, but Entire cannot read checkpoint history or reconcile checkpoint state from it.

`ResolveCheckpointSyncRemote` previously treated this configuration inconsistently:

- Explicit and previously captured remote selections were validated with `git remote get-url`.
- Git reports success for a pushurl-only remote—even returning the remote name when no fetch URL exists.
- Automatic election used `remote.*.url` entries and therefore correctly excluded the same remote.

This allowed an explicit `checkpoint_push_remote` to select a destination that automatic election considered unusable. `entire status` then presented that remote as the active checkpoint destination even though checkpoint reads and reconciliation could not work against it.

## Use one eligibility rule throughout election

Remote election now builds the set of remotes with configured fetch URLs once and uses that set for every election tier.

The behavior differs deliberately based on who owns the selection:

| Election source | Previous behavior | New behavior |
| --- | --- | --- |
| Explicit `checkpoint_push_remote` | Elected a pushurl-only remote | Fails closed and explains that the remote has no fetch URL |
| Captured automatic selection | Re-elected a pushurl-only remote | Discards the stale selection and falls through to normal defaults |
| Automatic default election | Already excluded pushurl-only remotes | Unchanged |
| Gated-sync hint | Could recommend a pushurl-only remote | Stays silent because the suggested destination would be unusable |

An explicit setting fails closed because it represents a user decision that should be corrected rather than silently replaced. Captured state remains fail-soft because it was produced automatically and may become stale when remotes are renamed or reconfigured.

## Status and diagnostics

When the explicit remote has no fetch URL, `entire status` now:

- Reports that checkpoints are not syncing.
- Names the invalid remote.
- Explains that it lacks a configured fetch URL.
- Does not also print a misleading `Checkpoints sync to:` destination.

The gated-sync hint uses the same fetchability rule, ensuring it never recommends a destination that checkpoint sync cannot read from.

## Regression coverage

The new tests construct real isolated Git repositories with:

```ini
[remote "pushonly"]
    pushurl = https://example.com/pushonly.git
```

and deliberately omit `remote.pushonly.url`.

They verify that:

- An explicit pushurl-only remote fails closed.
- The error names the remote and its missing fetch URL.
- A captured pushurl-only remote falls back to `origin`.
- Status reports the failure without advertising a sync destination.
- The gated-sync hint remains silent for the unusable remote.

## Verification

The following checks passed:

- `go test ./cmd/entire/cli/strategy -run '^TestHintGatedCheckpointSync$'`
- `go test ./cmd/entire/cli/strategy`
- `mise run check`
  - formatting
  - lint
  - race-enabled unit and integration tests
  - Vogon E2E canary
  - Roger Roger E2E canary
- `mise run lint`
