### PR TITLE
Compare carry-forward hashes with Equal, not ==

### DIFF
--- a/cmd/entire/cli/checkpointpolicy/remote.go
+++ b/cmd/entire/cli/checkpointpolicy/remote.go
@@ -101,7 +101,7 @@ func SyncFrom(ctx context.Context, repo *git.Repository, targets []Target) (Stat
 	if !remoteFound {
 		return local, nil
 	}
-	if local.Hash == baseline.Hash {
+	if local.Hash.Equal(baseline.Hash) {
 		return baseline, nil
 	}
 
@@ -187,7 +187,7 @@ func findRemoteBaseline(ctx context.Context, repo *git.Repository, targets []Tar
 		if !remoteState.Exists {
 			continue
 		}
-		if local.Hash == remoteState.Hash {
+		if local.Hash.Equal(remoteState.Hash) {
 			baseline := local
 			baseline.Source = SourceRemote
 			baseline.RemoteHash = remoteState.Hash
@@ -281,7 +281,7 @@ func isAncestorOf(ctx context.Context, repo *git.Repository, ancestor, target pl
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("checkpoint policy ancestry context: %w", err)
 		}
-		if commit.Hash == ancestor {
+		if commit.Hash.Equal(ancestor) {
 			found = true
 			return errStopTraversal
 		}

--- a/cmd/entire/cli/checkpointpolicy/update.go
+++ b/cmd/entire/cli/checkpointpolicy/update.go
@@ -58,7 +58,7 @@ func updateBaseline(ctx context.Context, repo *git.Repository, target Target) (S
 	if err != nil {
 		return State{}, err
 	}
-	if !remoteFound || local.Hash == baseline.Hash {
+	if !remoteFound || local.Hash.Equal(baseline.Hash) {
 		return baseline, nil
 	}
 	if local.Hash.IsZero() {

--- a/cmd/entire/cli/gitrepo/gitstatus_guard_test.go
+++ b/cmd/entire/cli/gitrepo/gitstatus_guard_test.go
@@ -114,6 +114,17 @@ type safeGitDiffCall struct {
 // Matching only the line containing "diff" is intentional: a wrapped argv
 // separates that line from exec.Command, so requiring an invocation marker
 // would make the guard silently miss exactly the call it exists to prevent.
+//
+// That is the opposite trade-off from TestGitStatusCallSitesPassNoOptionalLocks
+// 100 lines up, which keeps the gitInvocationMarkers filter, and the difference
+// is deliberate rather than an oversight. There, wrapping separates the flag
+// from the word "status", so a miss shows up as a false positive — loud, and
+// safe. Here the marker sits on the exec.Command line and "diff" on the argv
+// line, so wrapping would separate the marker instead and the miss would be
+// silent. The false-positive direction was chosen knowingly: an unrelated
+// "diff" literal (a JSON tag, a map key, a subcommand name) will fail this
+// guard, and the remedy is an allowlist entry whose reason says it is not a
+// worktree-comparing invocation, which the error text points at.
 var safeGitDiffCalls = []safeGitDiffCall{
 	{
 		path:     "cmd/entire/cli/experts_cmd.go",

--- a/cmd/entire/cli/gitrepo/hash_compare_guard_test.go
+++ b/cmd/entire/cli/gitrepo/hash_compare_guard_test.go
@@ -27,15 +27,27 @@ import (
 // distinguish the two operators: a call site reverted to == stays green. The
 // convention can only be enforced where it is written.
 //
+// The pattern covers a .Hash field or a .Hash() method call (Reference.Hash()
+// returns one) on EITHER side of the operator. The first version of this guard
+// matched only the left-hand side and so missed `stagedHash == shadowFile.Hash`
+// in content_overlap.go — in the file the guard was written for. Widening it
+// turned up five more in strategy/, so "the left-hand shape is all of them" was
+// not a small error.
+//
 // Two limitations, both deliberate:
 //
-//   - It catches the `.Hash ==` shape, which is every occurrence in this
-//     repository today. Two local variables of type plumbing.Hash compared
-//     directly (`if a == b`) need type information a textual guard does not
-//     have.
+//   - Two local variables compared directly (`if a == b`, neither spelled
+//     `.Hash`) need type information a textual guard does not have. That shape
+//     has no occurrences today, but unlike the ones above it cannot be ruled
+//     out by grepping.
 //   - It skips _test.go, matching the two sibling guards in this package. Note
 //     that assert.Equal on two hashes compares the format field too, via
 //     reflect.DeepEqual.
+//
+// Do not reach for \b or \s to tighten the pattern: git grep -E is POSIX ERE
+// and supports neither, so it matches NOTHING and the guard reports a clean
+// tree. Verified here — `\.Hash\b` found 0 lines in a file where `\.Hash`
+// found 20.
 //
 // A second family, `== plumbing.ZeroHash`, is NOT covered here and is not the
 // same severity: a 64-char zero hash carries format "sha256", so it is
@@ -51,7 +63,8 @@ func TestHashComparisonsUseEqual(t *testing.T) {
 
 	// A literal space rather than \s: git grep -E silently matches nothing for
 	// the shorthand classes, so a pattern using one reports a clean tree.
-	out := testutil.GitGrepGuard(t, root, "-n", "-E", "--", `\.Hash (==|!=) `,
+	const hashComparison = `(\.Hash(\(\))? (==|!=) )|((==|!=) [A-Za-z_][A-Za-z0-9_.]*\.Hash(\(\))?)`
+	out := testutil.GitGrepGuard(t, root, "-n", "-E", "--", hashComparison,
 		"--", ":(glob)cmd/**/*.go", ":(glob)internal/**/*.go")
 
 	var checked int
@@ -77,7 +90,7 @@ func TestHashComparisonsUseEqual(t *testing.T) {
 	// guards: this one exists to keep the count at zero. Prove the pattern
 	// still works instead, so a detection regression cannot masquerade as
 	// success.
-	probe := testutil.GitGrepGuard(t, root, "-n", "-E", "--", `\.Hash (==|!=) `,
+	probe := testutil.GitGrepGuard(t, root, "-n", "-E", "--", hashComparison,
 		"--", ":(glob)cmd/**/*_test.go")
 	if strings.TrimSpace(probe) == "" {
 		t.Error("guard matched nothing in non-test or test sources; the detection pattern has gone stale")

--- a/cmd/entire/cli/gitrepo/hash_compare_guard_test.go
+++ b/cmd/entire/cli/gitrepo/hash_compare_guard_test.go
@@ -1,0 +1,85 @@
+package gitrepo_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// TestHashComparisonsUseEqual fails the build on a plumbing.Hash compared with
+// == or != rather than .Equal.
+//
+// plumbing.Hash is a struct carrying an object-format field alongside its
+// bytes, so == compares that field and .Equal (bytes.Equal over the array
+// alone) does not.
+//
+// At the pinned go-git the two cannot disagree, and that is worth stating
+// plainly so nobody "proves" this guard unnecessary by observing it: every
+// public constructor leaves the format unset for a 40-char hash and stamps
+// "sha256" only on a 64-char one — NewHash, FromHex, ResetBySize and
+// Hasher.Sum were each checked — so two hashes of the same object in one
+// repository always carry the same format. That is a property of the
+// dependency, pinned at an alpha, not of this code.
+//
+// It is also why this is a source guard and not a test. The mismatch is
+// unconstructible through go-git's public API, so no behavioural test can
+// distinguish the two operators: a call site reverted to == stays green. The
+// convention can only be enforced where it is written.
+//
+// Two limitations, both deliberate:
+//
+//   - It catches the `.Hash ==` shape, which is every occurrence in this
+//     repository today. Two local variables of type plumbing.Hash compared
+//     directly (`if a == b`) need type information a textual guard does not
+//     have.
+//   - It skips _test.go, matching the two sibling guards in this package. Note
+//     that assert.Equal on two hashes compares the format field too, via
+//     reflect.DeepEqual.
+//
+// A second family, `== plumbing.ZeroHash`, is NOT covered here and is not the
+// same severity: a 64-char zero hash carries format "sha256", so it is
+// != ZeroHash while IsZero() reports true. That one is reachable in a sha256
+// repository and is tracked as its own fix rather than folded in here.
+func TestHashComparisonsUseEqual(t *testing.T) {
+	t.Parallel()
+
+	root, found := testutil.GitGrepGuardRepoRoot(t)
+	if !found {
+		return
+	}
+
+	// A literal space rather than \s: git grep -E silently matches nothing for
+	// the shorthand classes, so a pattern using one reports a clean tree.
+	out := testutil.GitGrepGuard(t, root, "-n", "-E", "--", `\.Hash (==|!=) `,
+		"--", ":(glob)cmd/**/*.go", ":(glob)internal/**/*.go")
+
+	var checked int
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		path, _, ok := strings.Cut(line, ":")
+		if !ok || !strings.HasSuffix(path, ".go") {
+			t.Fatalf("cannot parse git grep output; expected `path:line:content`, got:\n  %s", line)
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		checked++
+		t.Errorf("plumbing.Hash compared with == or !=; use .Equal:\n  %s\n"+
+			"== also compares the object-format field, which .Equal ignores.", line)
+	}
+	if checked > 0 {
+		return
+	}
+	// Zero matches is the expected steady state here, unlike the sibling
+	// guards: this one exists to keep the count at zero. Prove the pattern
+	// still works instead, so a detection regression cannot masquerade as
+	// success.
+	probe := testutil.GitGrepGuard(t, root, "-n", "-E", "--", `\.Hash (==|!=) `,
+		"--", ":(glob)cmd/**/*_test.go")
+	if strings.TrimSpace(probe) == "" {
+		t.Error("guard matched nothing in non-test or test sources; the detection pattern has gone stale")
+	}
+}

--- a/cmd/entire/cli/gitrepo/worktree_hash.go
+++ b/cmd/entire/cli/gitrepo/worktree_hash.go
@@ -107,6 +107,13 @@ func hashWorktreeFileBatch(ctx context.Context, worktreeRoot string, paths []str
 // including room for fixed arguments and os/exec quoting. Unix limits are much
 // larger. A single repository-relative path can exceed the budget and is sent
 // alone; filesystem path limits still keep that command bounded.
+//
+// The batching is not scaffolding for a missing --stdin-paths: hash-object has
+// no -z, so --stdin-paths is newline-delimited only, and a path containing a
+// newline is a legal Git path that it splits into two nonexistent ones
+// (`printf 'we\nird.txt\n' | git hash-object --stdin-paths` fails, while
+// `git hash-object -- $'we\nird.txt'` succeeds). Argv is the correct form here,
+// not the fussier one. Filters apply either way, so that is not the reason.
 const gitHashObjectPathBudget = 8 * 1024
 
 func chunkPaths(paths []string, budget int) [][]string {

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -680,7 +680,7 @@ func findCheckpointInHistory(start *object.Commit, stopAt *plumbing.Hash) *branc
 	current := start
 	for current != nil && totalChecked < maxCommits {
 		// Stop if we've reached the boundary
-		if stopAt != nil && current.Hash == *stopAt {
+		if stopAt != nil && current.Hash.Equal(*stopAt) {
 			break
 		}
 

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -756,7 +756,7 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 	}
 
 	if localExists {
-		if remoteRef != nil && localRef.Hash() != remoteRef.Hash() {
+		if remoteRef != nil && !localRef.Hash().Equal(remoteRef.Hash()) {
 			// Local and remote exist but differ — determine relationship
 			hasData, checkErr := metadataBranchHasData(repo, localRef)
 			if checkErr != nil {

--- a/cmd/entire/cli/strategy/content_overlap.go
+++ b/cmd/entire/cli/strategy/content_overlap.go
@@ -165,7 +165,7 @@ func filesOverlapWithContent(ctx context.Context, repo *git.Repository, shadowBr
 		}
 
 		// Compare by hash (blob hash) - exact content match required for new files
-		if headFile.Hash == shadowFile.Hash {
+		if headFile.Hash.Equal(shadowFile.Hash) {
 			logging.Debug(logCtx, "filesOverlapWithContent: new file content match found",
 				slog.String("file", filePath),
 				slog.String("hash", headFile.Hash.String()),
@@ -494,7 +494,7 @@ func filesWithRemainingAgentChanges(
 			continue
 		}
 
-		if commitFile.Hash == shadowFile.Hash {
+		if commitFile.Hash.Equal(shadowFile.Hash) {
 			logging.Debug(logCtx, "filesWithRemainingAgentChanges: content fully committed",
 				slog.String("file", filePath),
 			)

--- a/cmd/entire/cli/strategy/content_overlap.go
+++ b/cmd/entire/cli/strategy/content_overlap.go
@@ -533,7 +533,13 @@ func filesWithRemainingAgentChanges(
 	for _, candidate := range candidates {
 		workingTreeClean := false
 		if worktreeHash, ok := worktreeHashes[candidate.path]; ok {
-			workingTreeClean = worktreeHash == candidate.commitHash
+			// Equal, not ==: plumbing.Hash carries an object-format field
+			// alongside its bytes, and `==` compares that field too. FromHex
+			// leaves it unset for a 40-char hash while stamping SHA256 on a
+			// 64-char one, so `==` only works while the tree decoder happens to
+			// agree. If it ever stamped "sha1", every candidate would read dirty
+			// and the phantom carry-forward would return with no test failing.
+			workingTreeClean = worktreeHash.Equal(candidate.commitHash)
 		} else if worktreeRoot != "" {
 			workingTreeClean = workingTreeMatchesBlob(worktreeRoot, candidate.path, candidate.commitMode, candidate.commitHash)
 		}

--- a/cmd/entire/cli/strategy/content_overlap.go
+++ b/cmd/entire/cli/strategy/content_overlap.go
@@ -282,7 +282,7 @@ func stagedFilesOverlapWithContent(ctx context.Context, repo *git.Repository, sh
 		}
 
 		// Compare hashes - exact match means file is unchanged
-		if stagedHash == shadowFile.Hash {
+		if stagedHash.Equal(shadowFile.Hash) {
 			logging.Debug(logCtx, "stagedFilesOverlapWithContent: new file content match found",
 				slog.String("file", stagedPath),
 				slog.String("hash", stagedHash.String()),

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -814,7 +814,7 @@ func atomicSetV1Ref(ctx context.Context, repo *git.Repository, expectedOld, newH
 		return nil
 	}
 	if errors.Is(err, gitrepo.ErrRefCASConflict) {
-		if cur, refErr := repo.Reference(refName, true); refErr == nil && cur.Hash() != expectedOld {
+		if cur, refErr := repo.Reference(refName, true); refErr == nil && !cur.Hash().Equal(expectedOld) {
 			return &V1RefMovedError{Expected: expectedOld, Actual: cur.Hash()}
 		}
 	}

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -519,7 +519,7 @@ func listUnpushedV1Commits(repo *git.Repository, localTip, remoteTip plumbing.Ha
 
 	var unpushed []*object.Commit
 	if walkErr := iter.ForEach(func(c *object.Commit) error {
-		if !remoteTip.IsZero() && c.Hash == remoteTip {
+		if !remoteTip.IsZero() && c.Hash.Equal(remoteTip) {
 			return errStop
 		}
 		unpushed = append(unpushed, c)

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -140,7 +140,7 @@ func hasUnpushedBranchRef(repo *git.Repository, remoteName string, localHash plu
 
 	// If local and remote point to same commit, nothing to sync
 	// This is the only case where we skip - any difference needs handling
-	return localHash != remoteRef.Hash()
+	return !localHash.Equal(remoteRef.Hash())
 }
 
 func displayPushTarget(target string) string {
@@ -549,7 +549,7 @@ func fetchAndRebaseRefCommon(ctx context.Context, target string, ref plumbing.Re
 	}
 
 	// If local is already at or behind remote, fast-forward
-	if localRef.Hash() == remoteRef.Hash() {
+	if localRef.Hash().Equal(remoteRef.Hash()) {
 		return advance(remoteRef.Hash())
 	}
 
@@ -564,7 +564,7 @@ func fetchAndRebaseRefCommon(ctx context.Context, target string, ref plumbing.Re
 	}
 
 	// If local is ancestor of remote (merge base == local), fast-forward to remote
-	if mergeBase == localRef.Hash() {
+	if mergeBase.Equal(localRef.Hash()) {
 		if err := advance(remoteRef.Hash()); err != nil {
 			return fmt.Errorf("failed to fast-forward ref: %w", err)
 		}


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/1305

Follow-up to #2336. Three review findings on trail 1277 were resolved after that branch merged, so the resolutions are on the trail but the code never landed. One is a behaviour fix; two record decisions reviewers arrived at independently.

## `==` → `.Equal` on `plumbing.Hash`

`filesWithRemainingAgentChanges` compared the clean-filtered worktree hash against the commit blob hash with `==`. `plumbing.Hash` is a struct carrying an object-format field alongside its bytes, and `==` compares that field too:

```go
type ObjectID struct {
	hash   [format.SHA256Size]byte
	format format.ObjectFormat // "" | "sha1" | "sha256"
}

func (s ObjectID) Equal(in ObjectID) bool { return bytes.Equal(s.hash[:], in.hash[:]) }
```

`FromHex` stamps `sha256` on a 64-char hash and leaves the field unset on a 40-char one, so `==` holds only while go-git's tree decoder makes the same choice. Probed against the pinned `v6.0.0-alpha.5.0.20260812155443`:

```
sha1(default)  tree.format=""       fromHex.format=""       ==:true  Equal:true
sha256         tree.format="sha256" fromHex.format="sha256" ==:true  Equal:true
```

So it works today, by coincidence. If a decoder ever stamped `"sha1"` while `FromHex` kept leaving it unset, every candidate would compare dirty, the phantom carry-forward #2336 fixed would come back, and nothing would fail — no test pins the format field. `.Equal` ignores it by construction and is already what the fallback branch three lines down uses.

This cannot be pinned by a test, and the second commit says so in the guard's own doc comment. `NewHash`, `FromHex`, `ResetBySize` and `Hasher.Sum` were each probed against the pinned version and all leave the format unset for a 40-char hash, so the mismatch is unconstructible through go-git's public API and a call site reverted to `==` stays green whatever is asserted. `TestFilesWithRemainingAgentChanges_AutocrlfNormalizedWorkingTree` does *not* cover it — it passes with either operator. `TestHashComparisonsUseEqual` enforces the convention at the source instead, and was verified by reverting `content_overlap.go:497` and watching it fail.

## All eight sites, not one

The first commit changed only the line the original finding named and left seven others, one of them 45 lines above it in the same function — a comment explaining why `==` is wrong sitting just below a `==` doing the same thing. All eight now use `.Equal`, including `checkpointpolicy/remote.go:284`, which the review pass missed:

```
content_overlap.go:168            headFile.Hash  == shadowFile.Hash
content_overlap.go:497            commitFile.Hash == shadowFile.Hash
checkpointpolicy/remote.go:104    local.Hash     == baseline.Hash
checkpointpolicy/remote.go:190    local.Hash     == remoteState.Hash
checkpointpolicy/remote.go:284    commit.Hash    == ancestor
checkpointpolicy/update.go:61     local.Hash     == baseline.Hash
resume.go:683                     current.Hash   == *stopAt
manual_commit_opf_rewrite.go:522  c.Hash         == remoteTip
```

None of these was broken: at the pinned go-git two hashes of the same object in one repository always carry the same format, so `==` could not diverge from `.Equal` at any of them. This is hardening against a dependency change, pinned at an alpha, not a bug fix.

## Why argv rather than `--stdin-paths`

`--stdin-paths` is the first simplification a reader of `HashWorktreeFiles` reaches for, and it would delete `chunkPaths`, its test and the argv budget. It is wrong, and the file did not say so. `hash-object` has no `-z`, so `--stdin-paths` is newline-delimited only, and a newline is legal in a Git path:

```
$ printf 'we\nird.txt\n' | git hash-object --stdin-paths
fatal: could not open 'we' for reading: No such file or directory
$ git hash-object -- $'we\nird.txt'
587be6b4c3f93f93c489c0111bba5596147a26cb
```

Argv is the more correct form, not the fussier one. (`--stdin-paths` does apply clean filters, so that half is not the reason.)

## Why the diff guard drops the marker filter

`TestGitWorktreeDiffCallSitesDoNotRefreshTheIndex` greps a bare `"diff"`, while `TestGitStatusCallSitesPassNoOptionalLocks` 100 lines above it filters candidates through `gitInvocationMarkers` and documents the wrapped-argv miss as the safe direction. That looks like an oversight and is not: the failure direction inverts between them. For `status` the wrap separates the *flag* from the word, so a miss is a loud false positive; for `diff` the marker sits on the `exec.Command` line and the word on the argv line, so a wrap would separate the *marker* and the miss would be silent — which is exactly how the first version of this guard passed against the very file it was written to reject. The false-positive cost of dropping the filter (an unrelated `"diff"` literal failing the build) was accepted knowingly, and the error text already names the remedy.

## Testing

`mise run check` — fmt, lint, unit, integration and the Vogon canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
