### PR TITLE
Report each agent's smoke verdict on its own step

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -195,11 +195,14 @@ jobs:
       # would kill a recovering run and report it as a failure.
       #
       # In each body: `set +e` because GitHub already runs `shell: bash` with
-      # -e, which would end the step before its result row is written. The
-      # `Total: 0` check because a filter matching no test exits 0 with "[no
-      # tests to run]", which would report every agent as passing. Per-agent
-      # E2E_ARTIFACT_DIR because the mise task otherwise derives one shared dir
-      # and later agents overwrite earlier reports.
+      # -e, which would end the step before its result row is written; the
+      # closing `exit "$rc"` then reports the agent's own verdict on its own
+      # step, and the `!cancelled()` gates above are what keep the later agents
+      # running after it fails. The `Total: 0` check because a filter matching
+      # no test exits 0 with "[no tests to run]", which would report every
+      # agent as passing. Per-agent E2E_ARTIFACT_DIR because the mise task
+      # otherwise derives one shared dir and later agents overwrite earlier
+      # reports.
       #
       # E2E_ENTIRE_BIN (job env, set above) is what makes this the *installed*
       # nightly: the mise task skips its build when it is set.
@@ -222,6 +225,7 @@ jobs:
           rc=$?
           grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
+          exit "$rc"
 
       - name: Smoke test opencode
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' opencode ') }}
@@ -240,6 +244,7 @@ jobs:
           rc=$?
           grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
+          exit "$rc"
 
       - name: Smoke test codex
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' codex ') }}
@@ -259,6 +264,7 @@ jobs:
           rc=$?
           grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
+          exit "$rc"
 
       - name: Smoke test cursor-cli
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' cursor-cli ') }}
@@ -277,6 +283,7 @@ jobs:
           rc=$?
           grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
+          exit "$rc"
 
       - name: Smoke test factoryai-droid
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' factoryai-droid ') }}
@@ -297,6 +304,7 @@ jobs:
           rc=$?
           grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
+          exit "$rc"
 
       - name: Smoke test copilot-cli
         if: ${{ !cancelled() && contains(format(' {0} ', env.AGENTS), ' copilot-cli ') }}
@@ -315,6 +323,7 @@ jobs:
           rc=$?
           grep -q '^Total: 0 ' "$ARTIFACT_ROOT/$AGENT/report.txt" 2>/dev/null && rc=1
           echo "$AGENT $rc" >> e2e/artifacts/results.txt
+          exit "$rc"
 
       - name: Summarize
         if: always()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1310
<!-- entire-trail-link-end -->

## Summary

In nightly install smoke run [34583415795](https://github.com/entireio/cli/actions/runs/34583415795) copilot-cli failed on Windows, but its step showed green and only Summarize turned red, so the failing agent was visible only in the step summary table.

Each "Smoke test <agent>" body runs under `set +e`, captures the test's exit code, appends a result row, and ends. The trailing `echo` is the last command, so the step always exits 0. `set +e` predates the per-agent steps: 3830520fe added it when all agents ran in one loop step so one failure would not abort the loop, and f86b1a60c split the loop into steps gated on `!cancelled()` but kept the body verbatim. Nothing ever propagated `rc`.

## Change

Append `exit "$rc"` to each of the six bodies and update the header comment. Later agent steps still run after a failure because they are gated on `!cancelled()`; Summarize and Upload are `always()`; `needs.smoke.result` and the Slack notification are unchanged.

## Verification

actionlint reports only the pre-existing `copilot-requests` permission scope that 1.7.12 does not know yet. The Windows leg keeps failing until #2376 ships in a nightly tag, but the red mark will now land on "Smoke test copilot-cli".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; improves failure visibility without altering test logic or cross-agent orchestration beyond step exit codes.
> 
> **Overview**
> Fixes nightly install smoke so a failing agent’s GitHub Actions step shows **red**, not only the **Summarize** step.
> 
> Each per-agent smoke step already captured the e2e exit code in `rc` and appended to `results.txt`, but the script ended on `echo`, so the step always exited **0**. The change adds **`exit "$rc"`** to all six identical agent bodies and expands the workflow comment to note that **`!cancelled()`** on later steps still runs remaining agents after one fails, while Summarize/artifact upload stay on **`always()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f15fe6926f00b5154984a0666fdde561bed179af. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->