### PR TITLE
fix(strategy): stop condensation from resetting session token totals

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1190,10 +1190,6 @@ func sessionStateBackfillTokenUsage(ctx context.Context, ag agent.Agent, agentTy
 		return checkpointUsage
 	}
 
-	if checkpointUsage != nil && checkpointUsage.InputTokens > 0 {
-		return checkpointUsage
-	}
-
 	return nil
 }
 

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1178,7 +1178,11 @@ func applyBackfilledSessionTokenUsage(ctx context.Context, ag agent.Agent, state
 // sessionStateBackfillTokenUsage returns the best session-level token usage to
 // persist in session state after condensation.
 func sessionStateBackfillTokenUsage(ctx context.Context, ag agent.Agent, agentType types.AgentType, transcript []byte, checkpointUsage *agent.TokenUsage) *agent.TokenUsage {
-	if agentType == agent.AgentTypeCopilotCLI && len(transcript) > 0 {
+	if agentType != agent.AgentTypeCopilotCLI {
+		return nil
+	}
+
+	if len(transcript) > 0 {
 		fullSessionUsage := agent.CalculateTokenUsage(ctx, ag, transcript, 0, "")
 		if hasTokenUsageData(fullSessionUsage) {
 			return fullSessionUsage
@@ -1186,7 +1190,7 @@ func sessionStateBackfillTokenUsage(ctx context.Context, ag agent.Agent, agentTy
 		logging.Debug(ctx, "copilot-cli: full-session token read produced no data, falling back to checkpoint usage")
 	}
 
-	if agentType == agent.AgentTypeCopilotCLI && hasTokenUsageData(checkpointUsage) {
+	if hasTokenUsageData(checkpointUsage) {
 		return checkpointUsage
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -258,6 +258,83 @@ func TestCountTranscriptItems_CursorEmpty(t *testing.T) {
 	}
 }
 
+func TestNonCopilotCondensationPreservesSessionTokenUsage(t *testing.T) {
+	t.Parallel()
+
+	sessionUsage := &agent.TokenUsage{
+		InputTokens:         10_000,
+		OutputTokens:        999,
+		CacheReadTokens:     2_000,
+		CacheCreationTokens: 500,
+		APICallCount:        42,
+	}
+	state := &SessionState{
+		SessionID:  "s1",
+		AgentType:  agent.AgentTypeClaudeCode,
+		TokenUsage: sessionUsage,
+	}
+	checkpointUsage := &agent.TokenUsage{
+		InputTokens:         100,
+		OutputTokens:        10,
+		CacheReadTokens:     20,
+		CacheCreationTokens: 5,
+		APICallCount:        1,
+	}
+
+	applyBackfilledSessionTokenUsage(t.Context(), nil, state, nil, checkpointUsage)
+
+	require.Equal(t, sessionUsage, state.TokenUsage)
+}
+
+func TestCondenseSessionByID_NonCopilotPreservesSessionTokenUsage(t *testing.T) { //nolint:paralleltest // uses t.Chdir
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	s := &ManualCommitStrategy{}
+	sessionID := "non-copilot-token-usage"
+	metadataDir := ".entire/metadata/" + sessionID
+	metadataDirAbs := filepath.Join(dir, metadataDir)
+	require.NoError(t, os.MkdirAll(metadataDirAbs, 0o755))
+
+	transcript := strings.Join([]string{
+		`{"type":"human","uuid":"u1","message":{"content":"hello"}}`,
+		`{"type":"assistant","uuid":"u2","message":{"id":"msg_001","usage":{"input_tokens":100,"output_tokens":10}}}`,
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(metadataDirAbs, paths.TranscriptFileName), []byte(transcript), 0o644,
+	))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("agent content"), 0o644))
+
+	sessionUsage := &agent.TokenUsage{
+		InputTokens:         10_000,
+		OutputTokens:        999,
+		CacheReadTokens:     2_000,
+		CacheCreationTokens: 500,
+		APICallCount:        42,
+	}
+	require.NoError(t, s.SaveStep(t.Context(), StepContext{
+		SessionID:     sessionID,
+		ModifiedFiles: []string{"test.txt"},
+		MetadataDir:   metadataDir,
+		CommitMessage: "Checkpoint 1",
+		AuthorName:    "Test",
+		AuthorEmail:   "test@test.com",
+		AgentType:     agent.AgentTypeClaudeCode,
+		TokenUsage:    sessionUsage,
+	}))
+
+	state, err := s.loadSessionState(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.Equal(t, sessionUsage, state.TokenUsage)
+
+	require.NoError(t, s.CondenseSessionByID(t.Context(), sessionID))
+
+	state, err = s.loadSessionState(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.Equal(t, sessionUsage, state.TokenUsage)
+	require.Nil(t, state.CheckpointTokenUsage)
+}
+
 func TestSessionStateBackfillTokenUsage_CopilotUsesZeroInputSessionAggregate(t *testing.T) {
 	t.Parallel()
 
@@ -282,6 +359,21 @@ func TestSessionStateBackfillTokenUsage_CopilotUsesZeroInputSessionAggregate(t *
 	require.Equal(t, 20, backfillUsage.CacheReadTokens)
 	require.Equal(t, 10, backfillUsage.CacheCreationTokens)
 	require.Equal(t, 3, backfillUsage.APICallCount)
+}
+
+func TestSessionStateBackfillTokenUsage_CopilotFallsBackToCheckpointUsage(t *testing.T) {
+	t.Parallel()
+
+	checkpointUsage := &agent.TokenUsage{
+		OutputTokens: 25,
+		APICallCount: 1,
+	}
+
+	backfillUsage := sessionStateBackfillTokenUsage(
+		t.Context(), nil, agent.AgentTypeCopilotCLI, nil, checkpointUsage,
+	)
+
+	require.Same(t, checkpointUsage, backfillUsage)
 }
 
 func TestSessionStateBackfillModel_PiReadsModelFromTranscript(t *testing.T) {

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -286,6 +286,24 @@ func TestNonCopilotCondensationPreservesSessionTokenUsage(t *testing.T) {
 	require.Equal(t, sessionUsage, state.TokenUsage)
 }
 
+func TestNonCopilotCondensationDoesNotPromoteCheckpointUsage(t *testing.T) {
+	t.Parallel()
+
+	state := &SessionState{
+		SessionID: "s1",
+		AgentType: agent.AgentTypeClaudeCode,
+	}
+	checkpointUsage := &agent.TokenUsage{
+		InputTokens:  100,
+		OutputTokens: 10,
+		APICallCount: 1,
+	}
+
+	applyBackfilledSessionTokenUsage(t.Context(), nil, state, nil, checkpointUsage)
+
+	require.Nil(t, state.TokenUsage)
+}
+
 func TestCondenseSessionByID_NonCopilotPreservesSessionTokenUsage(t *testing.T) { //nolint:paralleltest // uses t.Chdir
 	dir := setupGitRepo(t)
 	t.Chdir(dir)
@@ -374,6 +392,37 @@ func TestSessionStateBackfillTokenUsage_CopilotFallsBackToCheckpointUsage(t *tes
 	)
 
 	require.Same(t, checkpointUsage, backfillUsage)
+}
+
+func TestApplyBackfilledSessionTokenUsage_CopilotPreservesSubagentTotal(t *testing.T) {
+	t.Parallel()
+
+	checkpointUsage := &agent.TokenUsage{
+		OutputTokens: 25,
+		APICallCount: 1,
+	}
+	state := &SessionState{
+		AgentType: agent.AgentTypeCopilotCLI,
+		TokenUsage: &agent.TokenUsage{
+			InputTokens: 1_000,
+			SubagentTokens: &agent.TokenUsage{
+				InputTokens:  200,
+				OutputTokens: 50,
+				APICallCount: 2,
+			},
+		},
+	}
+
+	applyBackfilledSessionTokenUsage(t.Context(), nil, state, nil, checkpointUsage)
+
+	require.Equal(t, 25, state.TokenUsage.OutputTokens)
+	require.Equal(t, 1, state.TokenUsage.APICallCount)
+	require.Equal(t, &agent.TokenUsage{
+		InputTokens:  200,
+		OutputTokens: 50,
+		APICallCount: 2,
+	}, state.TokenUsage.SubagentTokens)
+	require.Nil(t, checkpointUsage.SubagentTokens)
 }
 
 func TestSessionStateBackfillModel_PiReadsModelFromTranscript(t *testing.T) {

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -310,18 +310,14 @@ func TestCondenseSessionByID_NonCopilotPreservesSessionTokenUsage(t *testing.T) 
 
 	s := &ManualCommitStrategy{}
 	sessionID := "non-copilot-token-usage"
-	metadataDir := ".entire/metadata/" + sessionID
-	metadataDirAbs := filepath.Join(dir, metadataDir)
-	require.NoError(t, os.MkdirAll(metadataDirAbs, 0o755))
+	metadataDir := paths.SessionMetadataDirFromSessionID(sessionID)
 
 	transcript := strings.Join([]string{
 		`{"type":"human","uuid":"u1","message":{"content":"hello"}}`,
 		`{"type":"assistant","uuid":"u2","message":{"id":"msg_001","usage":{"input_tokens":100,"output_tokens":10}}}`,
 	}, "\n") + "\n"
-	require.NoError(t, os.WriteFile(
-		filepath.Join(metadataDirAbs, paths.TranscriptFileName), []byte(transcript), 0o644,
-	))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("agent content"), 0o644))
+	testutil.WriteFile(t, dir, filepath.Join(metadataDir, paths.TranscriptFileName), transcript)
+	testutil.WriteFile(t, dir, "test.txt", "agent content")
 
 	sessionUsage := &agent.TokenUsage{
 		InputTokens:         10_000,

--- a/cmd/entire/cli/strategy/subagent_tokens_test.go
+++ b/cmd/entire/cli/strategy/subagent_tokens_test.go
@@ -518,9 +518,6 @@ func TestCalculateLiveTranscriptTokenUsage_RescopesSubagentCumulativeTotal(t *te
 	require.Equal(t, 200, state.TokenUsage.SubagentTokens.InputTokens,
 		"session state must retain the cumulative snapshot for the next baseline")
 
-	applyBackfilledSessionTokenUsage(t.Context(), ag, state, mainTranscript, usage)
-	require.Equal(t, 200, state.TokenUsage.SubagentTokens.InputTokens,
-		"main-token backfill must not replace the cumulative snapshot with the checkpoint delta")
 	state.RebaselineSubagentTokens()
 	require.NoError(t, os.WriteFile(subagentPath, []byte(`{"type":"assistant","uuid":"a-sub","message":{"id":"msg_sub","type":"message","role":"assistant","content":[{"type":"text","text":"done"}],"usage":{"input_tokens":260,"output_tokens":35}}}
 `), 0o644))
@@ -627,15 +624,8 @@ func TestCondenseSessionByID_CapturesSubagentBaselineViaRealResetPath(t *testing
 	metadataDir := ".entire/metadata/" + sessionID
 	metadataDirAbs := filepath.Join(dir, metadataDir)
 	require.NoError(t, os.MkdirAll(metadataDirAbs, 0o755))
-	// The assistant line carries real usage data (message.id + usage). Real
-	// Claude Code transcripts always do, which makes sessionStateBackfillTokenUsage
-	// fire during condensation (its InputTokens > 0 branch) and overwrite
-	// state.TokenUsage with the transcript-recomputed value — which is computed
-	// with subagentsDir="" and therefore drops SubagentTokens. This is what makes
-	// this test guard the REAL condensation path: without preserving the
-	// cumulative subagent total across the backfill, resetCheckpointWindow would
-	// snapshot a nil baseline and the next checkpoint would re-report the full
-	// cumulative subagent total (finding 019f5ebf-a57e).
+	// Checkpoint-scoped transcript usage must not replace the cumulative session
+	// total here, so the reset can retain the subagent baseline.
 	transcript := `{"type":"human","message":{"content":"do the thing"}}
 {"type":"assistant","uuid":"a1","message":{"id":"m1","usage":{"input_tokens":300,"output_tokens":150}}}
 `
@@ -715,11 +705,8 @@ func TestCondenseSessionByID_CapturesSubagentBaselineViaRealResetPath(t *testing
 	require.Equal(t, 60, summary.TokenUsage.SubagentTokens.OutputTokens)
 }
 
-// TestWithSubagentTokensFrom_DoesNotMutateInput guards the copy semantics directly.
-// The condensation tests cannot: applyBackfilledSessionTokenUsage already hands back
-// a copy on that path, so a mutate-in-place implementation passes them. Mutating
-// would overwrite the session-wide cumulative with a window delta and make
-// resetCheckpointWindow snapshot a too-small baseline for the next window.
+// Session and checkpoint token snapshots can share pointers, so replacement must
+// not mutate either input.
 func TestSubagentCoverageSurvivesBackfill(t *testing.T) {
 	t.Parallel()
 	incomplete := false


### PR DESCRIPTION
Fixes #2368

Trail: [#5: Preserve session-wide token totals during condensation](https://entire.io/gh/MuskanPaliwal/cli/trails/5)

`SessionState.TokenUsage` is the running total shown by `entire status` and `entire session tokens`. `sessionData.TokenUsage` serves a different purpose: it contains only the usage since the previous checkpoint.

During condensation, the checkpoint value was passed to `sessionStateBackfillTokenUsage`. Its final branch accepted that value for every agent when input tokens were present. `applyBackfilledSessionTokenUsage` then stored it as the session total.

As a result, a session with 10,000 cumulative input tokens could appear to have used only the 100 tokens recorded since its latest checkpoint. Later turns accumulated from that smaller value, leaving the total permanently undercounted.

## Keep cumulative and checkpoint usage separate

This change removes the agent-agnostic checkpoint fallback.

Non-Copilot agents now retain the cumulative token total collected through their lifecycle hooks. Checkpoint metadata continues to record the smaller checkpoint-window value.

Copilot CLI keeps both existing backfill paths. Its authoritative `session.shutdown` record can arrive after lifecycle hooks return, so condensation still:

1. Recomputes the full-session total from the transcript when available.
2. Falls back to checkpoint usage when a full-session aggregate is unavailable.

If a non-Copilot agent has no cumulative hook data, the CLI now reports no session-wide total. This is deliberate: a missing total is more accurate than presenting one checkpoint’s usage as the total for the entire session.

## Verification

The regression test models a session with 10,000 cumulative input tokens and a 100-token checkpoint. With the previous behavior, `CondenseSessionByID` saved 100 as the session total. With this change, the total remains 10,000 after the state is reloaded from disk.

Additional tests cover both Copilot backfill paths.

Checks completed:

- Focused token-usage regression tests
- Strategy package tests
- Relevant status and session-token command tests
- Full `mise run check`, including formatting, linting, race-enabled tests, integration tests, and deterministic E2E canaries
