### PR TITLE
git-remote-entire: delete the wrong-cluster hint, which cannot fire

### DIFF
--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -20,21 +20,17 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
-	"regexp"
 	"runtime"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
-
-	"github.com/entireio/auth-go/sts"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
@@ -151,7 +147,7 @@ func run(args []string) int {
 
 	helperStart := time.Now()
 	if err := githelper.Run(ctx, proxy, protocolVersion, os.Stdin, os.Stdout); err != nil {
-		fmt.Fprint(os.Stderr, fatalMessage(err, parsedURL))
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 		return 128
 	}
 	debuglog.Printf("timing: helper-session dur_ms=%d", time.Since(helperStart).Milliseconds())
@@ -226,41 +222,6 @@ func setAuthWithProvider(provider credentialProvider) transport.SetAuthFunc {
 		req.Header.Set("Authorization", "Bearer "+token)
 		return nil
 	}
-}
-
-// wrongClusterRe extracts the host that actually serves the repo from the
-// data plane's `invalid_target` error_description (RFC 8693). The data plane
-// emits this when the audience host doesn't host the repo but a sibling
-// cluster does, naming the correct host so we can point the user at it. The
-// phrasing is "… it lives on \"<host>\" …"; anchoring on "lives on" keeps the
-// match tied to this specific, actionable case rather than other
-// invalid_target variants (e.g. a suspended mirror).
-var wrongClusterRe = regexp.MustCompile(`lives on "([^"]+)"`)
-
-// fatalMessage renders the stderr "fatal: …" line for a transfer error. When
-// the failure is the data plane reporting that the repo lives on a different
-// cluster, it special-cases the raw OAuth chain into an actionable message
-// naming the correct host (and the corrected entire:// URL). Everything else
-// falls back to the verbatim error.
-func fatalMessage(err error, parsedURL *url.URL) string {
-	var oe *sts.ExchangeError
-	if errors.As(err, &oe) && oe.Code == "invalid_target" {
-		if m := wrongClusterRe.FindStringSubmatch(oe.Description); m != nil {
-			host := m[1]
-			// Copy the URL the user typed and swap only the host, so any
-			// escaped path (RawPath) or query stays byte-identical to what
-			// they originally ran.
-			correctedURL := *parsedURL
-			correctedURL.Scheme = "entire"
-			correctedURL.Host = host
-			correctedURL.User = nil
-			corrected := correctedURL.String()
-			return fmt.Sprintf("fatal: this repository is not hosted on %s; it lives on %s.\n"+
-				"Re-run against the correct host, e.g.:\n\n    git clone %s\n",
-				parsedURL.Host, host, corrected)
-		}
-	}
-	return fmt.Sprintf("fatal: %v\n", err)
 }
 
 // missingClusterHostMessage renders the stderr "fatal: …" line for an entire://

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/entireio/auth-go/sts"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 )
 
@@ -113,60 +111,6 @@ func TestGitActionFromRequest(t *testing.T) {
 			req := httptest.NewRequestWithContext(context.Background(), tc.method, "https://host"+tc.path+"?"+tc.query, nil)
 			if got := gitActionFromRequest(req); got != tc.want {
 				t.Fatalf("gitActionFromRequest(%s %s?%s) = %q, want %q", tc.method, tc.path, tc.query, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestFatalMessage(t *testing.T) {
-	t.Parallel()
-	parsedURL := &url.URL{Scheme: "entire", Host: "aws-us-east-2.entire.io", Path: "/et/paul/dogbark"}
-	wrongCluster := &sts.ExchangeError{
-		StatusCode:  http.StatusBadRequest,
-		Code:        "invalid_target",
-		Description: `audience host "aws-us-east-2.entire.io" does not host this repo; it lives on "aws-eu-central-1.entire.io" — re-target the request there`,
-	}
-	tests := []struct {
-		name        string
-		err         error
-		contains    []string
-		notContains []string
-	}{
-		{
-			name: "wrong cluster names correct host and URL",
-			// Wrapped to mirror production: the ExchangeError surfaces buried under
-			// several fmt.Errorf layers, so errors.As must dig it out.
-			err: fmt.Errorf("stateless-connect v2 info/refs: fetching info/refs from entry domain: repo-scoped token exchange: oauth token exchange: %w", wrongCluster),
-			contains: []string{
-				"aws-eu-central-1.entire.io",
-				"git clone entire://aws-eu-central-1.entire.io/et/paul/dogbark",
-			},
-			notContains: []string{"HTTP 400", "invalid_target"},
-		},
-		{
-			name:     "invalid_target without lives-on hint falls back",
-			err:      &sts.ExchangeError{StatusCode: http.StatusBadRequest, Code: "invalid_target", Description: "no servable mirror"},
-			contains: []string{"fatal:", "no servable mirror"},
-		},
-		{
-			name:     "unrelated error falls back verbatim",
-			err:      errors.New("connection refused"),
-			contains: []string{"fatal: connection refused"},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			got := fatalMessage(tc.err, parsedURL)
-			for _, sub := range tc.contains {
-				if !strings.Contains(got, sub) {
-					t.Errorf("fatalMessage() = %q, missing %q", got, sub)
-				}
-			}
-			for _, sub := range tc.notContains {
-				if strings.Contains(got, sub) {
-					t.Errorf("fatalMessage() = %q, should not contain %q", got, sub)
-				}
 			}
 		})
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1311
<!-- entire-trail-link-end -->

## Why

`fatalMessage` special-cased an RFC 8693 `invalid_target` error whose `error_description` named the cluster actually serving the repo, turning it into an actionable message plus a corrected clone command:

```
fatal: this repository is not hosted on aws-us-east-2.entire.io; it lives on aws-eu-central-1.entire.io.
Re-run against the correct host, e.g.:

    git clone entire://aws-eu-central-1.entire.io/et/paul/dogbark
```

**Nothing can produce that error any more, and nothing has since July 2026.** The helper no longer performs a token exchange — it presents a jurisdiction token as a bearer — so no `invalid_target` ever reaches it. The branch compiles, its test passes, and it cannot run.

Found by a trail finding on #2261 (`01M27VJ2Y7VS`), which I verified rather than took on faith.

## Measured, not reasoned

Cloning a single-placement repo from the wrong cluster, against a helper built from `main`:

```
$ git clone entire://aws-eu-central-1.entire.io/gh/entireio/cli-perf-benchmarks
fatal: stateless-connect v2 info/refs: Repository not found
```

`ENTIRE_DEBUG` on the same run, showing the wire:

```
GET /gh/entireio/cli-perf-benchmarks/info/refs?service=git-upload-pack HTTP/1.1
HTTP/1.1 404 Not Found
Repository not found
```

A plain 404 with a four-word body. No `invalid_target`, no `error_description`, nothing naming the correct host.

**Control:** the same repo on its own cluster (`aws-us-east-2`), same credentials, clones fine. So that 404 is genuinely the wrong-cluster response, not an access or existence failure.

## How it got this way

| | |
| --- | --- |
| 06-30 00:31 | #1575 opened — written against a `main` where the repo-scoped exchange existed |
| 07-03 **05:17** | #1621 merged — jurisdiction tokens, *"No repo-scoped fallback"* |
| 07-03 **11:22** | #1575 merged — the hint lands, its producer already gone six hours earlier |
| 07-04 08:38 | #1622 merged — `ENTIRE_TOKEN` CI path migrated too |

#1621 and #1575 are the same author's, three days apart. They share no file, so nothing conflicted and nothing flagged it. For about 21 hours the hint could still fire for `ENTIRE_TOKEN` users — CI runners, the population least likely to hand-type a cluster host. On the interactive path it was built for, it never worked in `main` at all.

The coupling was semantic: an error-formatting branch depending on a call still being made. #1621 was a good change — it cut `git ls-remote` from ~1050ms to ~350ms by removing a per-command exchange. The exchange was pure overhead, except that one error path had taken a dependency on its failure mode.

## Why the test didn't catch it

`TestFatalMessage` built the `invalid_target` error itself:

```go
wrongCluster := &sts.ExchangeError{Code: "invalid_target", Description: `… it lives on "…" …`}
```

That verifies the formatting perfectly and can never observe that the input has no producer. A test constructing its own input cannot detect a missing producer — which is how a dead branch survived green CI for two months. Its wrapper string even names `repo-scoped token exchange`, a path deleted in July: an accurate fossil of how the code used to work.

## What this does and does not do

**Does:** remove code that cannot run — `fatalMessage`, `wrongClusterRe`, `TestFatalMessage`, and four imports that existed only to serve them.

**Does not:** restore the feature. That is not repairable here — the 404 carries no information about where the repo lives, and no client-side matcher can invent it. It needs the data plane to say so on that response. Worth noting the helper already looks for an `X-Entire-Replicas` header there and logs its absence, so the mechanism may be partly built; filed as a follow-up.

Worth stating plainly: the current UX is worse than the raw error the original PR was fixing. That JSON blob was ugly but it *contained the answer*. `Repository not found` is tidy and tells you nothing. Deleting this branch doesn't cause that — the branch has been inert throughout — but it shouldn't be read as the problem being solved.

## On inlining

`fatalMessage` reduced to a single `Sprintf` with one caller, so it is inlined rather than kept as a seam. If the hint returns it will match a 404 body, not an OAuth error, so the seam would be speculative and the wrong shape. Happy to keep the named function if a reviewer prefers.

## Verification

Rebuilt the helper with the branch deleted and re-ran the wrong-cluster clone: **stderr is byte-identical**. That is the point of the change — if the branch had ever fired, deleting it would alter output.

`mise run test:ci` green (90 packages, 0 failures), `golangci-lint` 0 issues, `GOOS=windows go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal and simpler stderr formatting only; no auth or transport logic changes.
> 
> **Overview**
> Removes **dead error-handling** in `git-remote-entire` that tried to turn OAuth `invalid_target` responses (with a “lives on \<host\>” description) into a friendly fatal message and suggested `git clone entire://…` URL. That path depended on repo-scoped token exchange, which the helper no longer performs after jurisdiction-token bearer auth.
> 
> **`githelper.Run` failures** now always print `fatal: %v` on stderr instead of going through `fatalMessage`. Also drops `wrongClusterRe`, the `sts`/`errors`/`regexp` imports, and **`TestFatalMessage`**.
> 
> Behavior for real wrong-cluster clones is unchanged in practice: users still see the generic transfer error (e.g. “Repository not found”), not the old hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e8e8b3d13ee698e2ee9d00c445f63a09d4509fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->