### PR TITLE
Accept /et/<project>/<repo> paths in every repo-ref command

### DIFF
--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -308,7 +308,7 @@ func newRepoGetCmd() *cobra.Command {
 	var project string
 	cmd := &cobra.Command{
 		Use:   "get <repo>",
-		Short: "Show a repository by name or ULID",
+		Short: "Show a repository by /et/<project>/<repo> path, name, or ULID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCoreObject(cmd, repoDetailColumns, repoDetailRow, func(ctx context.Context, c *coreapi.Client) (*coreapi.Repo, error) {
@@ -329,7 +329,7 @@ func newRepoDeleteCmd() *cobra.Command {
 	var project string
 	cmd := &cobra.Command{
 		Use:   "delete <repo>",
-		Short: "Delete a repository by name or ULID",
+		Short: "Delete a repository by /et/<project>/<repo> path, name, or ULID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runControlPlaneDelete(cmd, "repo", args[0],
@@ -450,7 +450,8 @@ func newRepoVisibilitySetCmd() *cobra.Command {
 
 // bindRepoProjectFlag wires the shared --project scope used to resolve a repo
 // addressed by name (a repo name is unique only within its project). Ignored
-// when the repo arg is already a ULID.
+// when the repo arg is already a ULID; checked for agreement when it is a
+// /et/<project>/<repo> path, which names its own project.
 func bindRepoProjectFlag(cmd *cobra.Command, project *string) {
-	cmd.Flags().StringVar(project, "project", "", "Owning project (name or ULID); required when <repo> is a name")
+	cmd.Flags().StringVar(project, "project", "", "Owning project (name or ULID); required when <repo> is a bare name")
 }

--- a/cmd/entire/cli/resolveref.go
+++ b/cmd/entire/cli/resolveref.go
@@ -208,33 +208,91 @@ func resolveProjectRef(ctx context.Context, c projectRefClient, ref string) (str
 }
 
 // resolveRepoRef turns a repo reference into its ULID. A ULID passes through.
-// A name requires a project scope (projectRef, itself a name or ULID) because
-// repo names are unique only within a project: the repo is resolved via the
-// server's case-insensitive by-name lookup, scoped to that project. Like the
-// org/project endpoints, a name-filtered list returns the single match under the
-// response's singular `repo` field (the plural `repos` is only populated for an
-// unfiltered page) — reading `repos` here was the COR-699 bug.
+// A native path ref (`/et/<project>/<repo>`, the `path` the API returns and
+// `repo clone` accepts) carries its own project scope. A bare name requires a
+// project scope (projectRef, itself a name or ULID) because repo names are
+// unique only within a project. Either way the repo is resolved via the
+// server's case-insensitive by-name lookup, scoped to that project.
+//
+// Repo names can never contain '/' (see nativeRepoRe), so any slash-bearing
+// ref is dispatched to the path grammar and never sent to the by-name lookup —
+// and per #2252 a ref must name its forge: a bare `<a>/<b>` is refused with a
+// suggestion rather than read as native, and a `/gh/` mirror ref is refused
+// rather than read as a name.
 func resolveRepoRef(ctx context.Context, c repoRefClient, ref, projectRef string) (string, error) {
 	if looksLikeULID(ref) {
 		return ref, nil
 	}
+	if strings.Contains(trimRefPrefix(ref), "/") {
+		return resolveRepoPathRef(ctx, c, ref, projectRef)
+	}
 	if projectRef == "" {
-		return "", fmt.Errorf("repo %q is a name; pass --project <name|ULID> to resolve it, or use a repo ULID", ref)
+		return "", fmt.Errorf("repo %q is a name; pass --project <name|ULID> to resolve it, use its /%s/<project>/<repo> path, or a repo ULID", ref, nativeCloneForge)
 	}
 	projID, err := resolveProjectRef(ctx, c, projectRef)
 	if err != nil {
 		return "", err
 	}
-	out, err := c.ListProjectRepos(ctx, coreapi.ListProjectReposParams{ProjectId: projID, Name: coreapi.NewOptString(ref)})
+	return resolveRepoInProject(ctx, c, ref, projID)
+}
+
+// resolveRepoPathRef resolves a slash-bearing repo ref: the native
+// `/et/<project>/<repo>` path (leading slash optional, `.git` suffix dropped —
+// parseNativeCloneRef owns that grammar). The ref names its own project, so a
+// --project given alongside it is checked for agreement rather than trusted or
+// ignored: a name compares case-insensitively (the server matches lower(name)
+// and project names are globally unique), a ULID against the resolved project
+// id — neither costs an extra round trip.
+func resolveRepoPathRef(ctx context.Context, c repoRefClient, ref, projectRef string) (string, error) {
+	if declaresForge(ref, mirrorCloneForge) {
+		return "", fmt.Errorf("repo %q is a GitHub mirror ref; this command addresses Entire-native repos — manage mirrors with `entire repo mirror`", ref)
+	}
+	project, repoName, parseErr := parseNativeCloneRef(ref)
+	if parseErr != nil {
+		if declaresForge(ref, nativeCloneForge) {
+			return "", fmt.Errorf("invalid repo ref %q: %w", ref, parseErr)
+		}
+		// A bare <a>/<b> names no forge (#2252): suggest the native reading when
+		// it would parse, instead of guessing it or 404ing a by-name lookup that
+		// can never match a slash-bearing name.
+		native := "/" + nativeCloneForge + "/" + trimRefPrefix(ref)
+		if _, _, err := parseNativeCloneRef(native); err == nil {
+			return "", fmt.Errorf("repo ref %q must name its forge — did you mean %s?", ref, native)
+		}
+		return "", fmt.Errorf("invalid repo ref %q: expected /%s/<project>/<repo>, a repo name with --project, or a repo ULID", ref, nativeCloneForge)
+	}
+	if projectRef != "" && !looksLikeULID(projectRef) && !strings.EqualFold(projectRef, project) {
+		return "", projectMismatchErr(projectRef, project, ref)
+	}
+	projID, err := resolveProjectRef(ctx, c, project)
+	if err != nil {
+		return "", err
+	}
+	if projectRef != "" && looksLikeULID(projectRef) && !strings.EqualFold(projectRef, projID) {
+		return "", projectMismatchErr(projectRef, project, ref)
+	}
+	return resolveRepoInProject(ctx, c, repoName, projID)
+}
+
+func projectMismatchErr(projectRef, project, ref string) error {
+	return fmt.Errorf("supplied --project %q does not match the project %q named in %q", projectRef, project, ref)
+}
+
+// resolveRepoInProject resolves a repo name inside an already-resolved project
+// ULID. Like the org/project endpoints, a name-filtered list returns the single
+// match under the response's singular `repo` field (the plural `repos` is only
+// populated for an unfiltered page) — reading `repos` here was the COR-699 bug.
+func resolveRepoInProject(ctx context.Context, c repoRefClient, name, projID string) (string, error) {
+	out, err := c.ListProjectRepos(ctx, coreapi.ListProjectReposParams{ProjectId: projID, Name: coreapi.NewOptString(name)})
 	if err != nil {
 		if isCoreNotFound(err) {
-			return "", noRepoNamedErr(ref)
+			return "", noRepoNamedErr(name)
 		}
 		return "", fmt.Errorf("list project repos: %w", err)
 	}
 	repo, ok := out.Repo.Get()
 	if !ok {
-		return "", noRepoNamedErr(ref)
+		return "", noRepoNamedErr(name)
 	}
 	return repo.ID, nil
 }

--- a/cmd/entire/cli/resolveref.go
+++ b/cmd/entire/cli/resolveref.go
@@ -223,7 +223,11 @@ func resolveRepoRef(ctx context.Context, c repoRefClient, ref, projectRef string
 	if looksLikeULID(ref) {
 		return ref, nil
 	}
-	if strings.Contains(trimRefPrefix(ref), "/") {
+	// Dispatch on the ref as given, not on trimRefPrefix's output: trimming
+	// first would let `/web` (leading slash, one segment) slip through to the
+	// by-name lookup with the slash still in it — a guaranteed server 404,
+	// since names can never contain '/'.
+	if strings.Contains(strings.TrimSpace(ref), "/") {
 		return resolveRepoPathRef(ctx, c, ref, projectRef)
 	}
 	if projectRef == "" {

--- a/cmd/entire/cli/resolveref_test.go
+++ b/cmd/entire/cli/resolveref_test.go
@@ -244,6 +244,145 @@ func TestResolveRepoRef(t *testing.T) {
 	})
 }
 
+// TestResolveRepoRef_NativePath covers the /et/<project>/<repo> path grammar
+// (COR-1632): the path the API returns and `repo clone` accepts resolves in
+// every repo-ref command, --project alongside it is checked for agreement, and
+// the #2252 rule holds at the resolver — no ref is read as a forge it did not
+// name, and no slash-bearing ref reaches the by-name lookup.
+func TestResolveRepoRef_NativePath(t *testing.T) {
+	t.Parallel()
+	const ulidRepoWeb = "0123456789ABCDEFGHJKMNPQR5"
+
+	// nativePathHandler serves the two lookups a /et/widgets/web ref makes:
+	// GET /projects?name=widgets and GET /projects/{id}/repos?name=web. It
+	// also records the repo name the server was asked for, so tests can pin
+	// server-side filtering and the .git trim.
+	nativePathHandler := func(t *testing.T, gotRepoName *string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/repos") {
+				*gotRepoName = r.URL.Query().Get("name")
+				if err := printJSON(w, &coreapi.ListProjectReposOutputBody{Repo: coreapi.NewOptRepo(coreapi.Repo{ID: ulidRepoWeb, Name: "web"})}); err != nil {
+					t.Errorf("encode repo: %v", err)
+				}
+				return
+			}
+			if err := printJSON(w, &coreapi.ListProjectsOutputBody{Project: coreapi.NewOptProject(coreapi.Project{ID: ulidProjectWidgets, Name: "widgets", OwnerId: ulidOrgAcme, OwnerType: coreapi.ProjectOwnerTypeOrg})}); err != nil {
+				t.Errorf("encode project: %v", err)
+			}
+		}
+	}
+
+	t.Run("native /et/ path resolves via its embedded project", func(t *testing.T) {
+		t.Parallel()
+		for _, ref := range []string{"/et/widgets/web", "et/widgets/web", "/et/widgets/web.git"} {
+			t.Run(ref, func(t *testing.T) {
+				t.Parallel()
+				var gotRepoName string
+				c, calls := resolveTestClient(t, nativePathHandler(t, &gotRepoName))
+				got, err := resolveRepoRef(context.Background(), c, ref, "")
+				if err != nil {
+					t.Fatalf("resolveRepoRef(%q): %v", ref, err)
+				}
+				if got != ulidRepoWeb {
+					t.Errorf("resolveRepoRef = %q, want web id", got)
+				}
+				if gotRepoName != "web" {
+					t.Errorf("server received repo name=%q, want %q", gotRepoName, "web")
+				}
+				if n := calls.Load(); n != 2 {
+					t.Errorf("path ref made %d HTTP calls, want 2 (project + repo lookup)", n)
+				}
+			})
+		}
+	})
+
+	t.Run("--project agreeing with the path is allowed", func(t *testing.T) {
+		t.Parallel()
+		// A name compares case-insensitively (the server matches lower(name));
+		// a ULID compares against the resolved project id.
+		for _, project := range []string{"widgets", "WIDGETS", ulidProjectWidgets} {
+			t.Run(project, func(t *testing.T) {
+				t.Parallel()
+				var gotRepoName string
+				c, _ := resolveTestClient(t, nativePathHandler(t, &gotRepoName))
+				got, err := resolveRepoRef(context.Background(), c, "/et/widgets/web", project)
+				if err != nil {
+					t.Fatalf("resolveRepoRef with --project %q: %v", project, err)
+				}
+				if got != ulidRepoWeb {
+					t.Errorf("resolveRepoRef = %q, want web id", got)
+				}
+			})
+		}
+	})
+
+	t.Run("--project name disagreeing with the path is rejected before any call", func(t *testing.T) {
+		t.Parallel()
+		c, calls := resolveTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			t.Error("unexpected HTTP call for a mismatched --project name")
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := resolveRepoRef(context.Background(), c, "/et/widgets/web", "gadgets")
+		if err == nil || !strings.Contains(err.Error(), "does not match") {
+			t.Errorf("mismatched --project: err = %v, want a \"does not match\" error", err)
+		}
+		if n := calls.Load(); n != 0 {
+			t.Errorf("mismatched --project name made %d HTTP calls, want 0", n)
+		}
+	})
+
+	t.Run("--project ULID disagreeing with the path is rejected", func(t *testing.T) {
+		t.Parallel()
+		var gotRepoName string
+		c, _ := resolveTestClient(t, nativePathHandler(t, &gotRepoName))
+		_, err := resolveRepoRef(context.Background(), c, "/et/widgets/web", ulidOrgGlobex)
+		if err == nil || !strings.Contains(err.Error(), "does not match") {
+			t.Errorf("mismatched --project ULID: err = %v, want a \"does not match\" error", err)
+		}
+		if gotRepoName != "" {
+			t.Error("repo lookup must not run when --project disagrees with the path")
+		}
+	})
+
+	// The remaining subtests pin the #2252 rule at the resolver: no ref is ever
+	// read as a forge it did not name, and no slash-bearing ref reaches the
+	// by-name lookup.
+	refuseLocally := func(t *testing.T, ref, wantErr string) {
+		t.Helper()
+		c, calls := resolveTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			t.Errorf("unexpected HTTP call for ref %q", ref)
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := resolveRepoRef(context.Background(), c, ref, "")
+		if err == nil || !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("resolveRepoRef(%q): err = %v, want it to contain %q", ref, err, wantErr)
+		}
+		if n := calls.Load(); n != 0 {
+			t.Errorf("ref %q made %d HTTP calls, want 0", ref, n)
+		}
+	}
+
+	t.Run("a /gh/ mirror ref is refused, never read as a name", func(t *testing.T) {
+		t.Parallel()
+		refuseLocally(t, "/gh/entirehq/entire-api", "entire repo mirror")
+	})
+
+	t.Run("a bare pair names no forge and is refused with the /et/ suggestion", func(t *testing.T) {
+		t.Parallel()
+		refuseLocally(t, "widgets/web", "/et/widgets/web")
+	})
+
+	t.Run("a malformed /et/ ref keeps the native parser's reason", func(t *testing.T) {
+		t.Parallel()
+		refuseLocally(t, "/et/widgets", "<repo>")
+	})
+
+	t.Run("a slash-bearing ref matching no grammar lists the accepted shapes", func(t *testing.T) {
+		t.Parallel()
+		refuseLocally(t, "a/b/c/d", "/et/<project>/<repo>")
+	})
+}
+
 func TestResolveAccountRef(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/resolveref_test.go
+++ b/cmd/entire/cli/resolveref_test.go
@@ -379,7 +379,12 @@ func TestResolveRepoRef_NativePath(t *testing.T) {
 
 	t.Run("a slash-bearing ref matching no grammar lists the accepted shapes", func(t *testing.T) {
 		t.Parallel()
-		refuseLocally(t, "a/b/c/d", "/et/<project>/<repo>")
+		// "/web" pins that dispatch reads the ref as given: trimming the leading
+		// slash first would send it to the by-name lookup slash and all — a
+		// guaranteed 404, since names can never contain '/'.
+		for _, ref := range []string{"a/b/c/d", "/web", "web/"} {
+			refuseLocally(t, ref, "/et/<project>/<repo>")
+		}
 	})
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1313
<!-- entire-trail-link-end -->

Fixes [COR-1632](https://linear.app/entirehq/issue/COR-1632/cli-repo-get-rejects-the-etprojectrepo-path-that-repo-clone-requires).

## Why

The API identifies an Entire-native repository with a path such as `/et/<project>/<repo>`, and `entire repo clone` already accepts that form. Other commands that resolve repository references treated the same value as a bare repository name, so copying `path` from an API or `repo get` response into another command failed with a misleading error.

## What changed

Extend the shared `resolveRepoRef` path so these commands accept native repository paths:

- `repo get` and `repo delete`
- `repo visibility get/set`
- `repo protection list/add/remove`
- `grant repo add/list/remove`

Native paths reuse the existing clone-reference parser, including optional leading-slash handling, `.git` suffix trimming, and project/repository name validation. Resolution uses the project embedded in the path and then performs the existing project-scoped repository lookup.

The resolver continues to require explicit forge identity:

- A bare `<project>/<repo>` pair is rejected rather than assumed to be native. It receives a `/et/...` suggestion only when that interpretation is valid; otherwise the error lists the accepted reference forms.
- A `/gh/<owner>/<repo>` mirror reference is rejected locally with a pointer to `entire repo mirror`.
- Any malformed slash-bearing reference is rejected locally instead of reaching the repository-name lookup.

When `--project` accompanies a native path, it is checked against the project named by the path. Project names compare case-insensitively; project ULIDs compare against the resolved project ID. A mismatch fails before repository lookup, which is especially important for mutating commands such as `repo delete`.

The `repo get`/`repo delete` help text and the shared `--project` flag description now document the path form and clarify that `--project` is required only for bare repository names.

## Validation

- `TestResolveRepoRef_NativePath` covers paths with and without a leading slash, `.git` trimming, matching and mismatching `--project` values, mirror refs, forge-less pairs, malformed native refs, and malformed slash-bearing refs.
- Local-only refusal cases assert that no HTTP request is made.
- GitHub lint and test checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
