### PR TITLE
fix(hooks): register Entire with Lefthook instead of owning its hook files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
   test-windows:
     runs-on: windows-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -86,9 +86,19 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+      # Lefthook owns .git/hooks/* and runs Entire's hooks as `scripts` with a
+      # bash runner, which is the one part of that integration Windows can
+      # break. Installing the real binary is what makes
+      # TestLefthookDeliversEntireOnWindows a test rather than a skip;
+      # ENTIRE_TEST_REQUIRE_LEFTHOOK turns a failed install into a failure
+      # instead of a silent pass.
+      - name: Install lefthook
+        run: go install github.com/evilmartians/lefthook/v2@v2.1.10
       # Real-Windows tests must include Windows or MSYS in their top-level
       # test name so this job selects them without running POSIX-only harnesses.
       - name: Windows unit tests
+        env:
+          ENTIRE_TEST_REQUIRE_LEFTHOOK: "1"
         run: go test ./cmd/entire/cli/... -run '(Windows|MSYS)' -count=1 -v
 
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1931,6 +1931,35 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
 - `cleanup.go` - Cleanup discovery/deletion for shadow branches, session states, and checkpoint metadata
 - `session_state.go` - Package-level session state functions
 - `hooks.go` - Git hook installation
+- `lefthook.go` - Lefthook integration. Lefthook is the one hook manager that
+  does not just overwrite `.git/hooks/*` at install time but **reclaims every
+  hook file at the top of each run**, so Entire's turn-start self-heal always
+  loses the race: the file is taken back by the `pre-commit` of the very commit
+  being made. Owning the files is therefore not a fix, and Entire instead
+  registers with Lefthook itself — `entire-lefthook.yml` (Entire's own config,
+  declaring a script per hook), an `extends:` entry in `lefthook-local.yml`
+  pointing at it, and the scripts under `.lefthook-local/<hook>/entire.sh`.
+  Lefthook resolves `extends` at **run time**, so this needs no `lefthook
+  install`. Load-bearing details: Lefthook *scripts* receive the hook's `$@`
+  (pre-push needs the remote and URL) while *commands* do not, so Entire uses
+  scripts; `lefthook-local.yml` shadows `lefthook-local.toml`, so Entire
+  refuses to create it beside a non-YAML local config
+  (`ErrLefthookLocalConfigUnwritable`) and keeps the native hooks instead; the
+  local config is edited as a `yaml.Node` so comments and key order survive;
+  artifacts are per-clone and generated, so they are ignored via
+  `.git/info/exclude` rather than the user's `.gitignore`; and every file
+  Entire did not write is backed up rather than replaced. `CheckHookDelivery`
+  is the single question `entire status` and `entire doctor` ask — in a
+  Lefthook repo it is answered by the registration, not by `.git/hooks/*`.
+  **Who owns the hook file** follows from that: once Lefthook dispatches
+  Entire, Entire owning the file too would run every hook twice, so
+  `installSkipsHook` leaves any hook carrying Lefthook's launcher alone and
+  `reconcileHookFiles` moves a launcher Entire had displaced back over its own
+  hook (and clears the `<hook>.old` backups that otherwise make every later
+  Lefthook sync fail, #1349). A hook Lefthook has *not* taken over is still
+  installed natively — in a repo where nobody ran `lefthook install`, Entire's
+  own hooks are the only delivery there is. This is also why `EnsureSetup`
+  runs the Lefthook step *before* the native install.
 
 Note: `checkpoint/configloader.go` overrides go-git's default config loader with a symlink-following `billy.Basic` (`osSymlinkFS`) — go-git's default reads config via `os.Root`, which rejects absolute symlinks in any path component (e.g. a `~/.config` managed by a dotfile tool), silently dropping global config so author identity fell back to "Unknown" and signing was skipped.
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -669,6 +669,12 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 		if _, err := strategy.EnsureLefthookIntegration(ctx, false); err != nil {
 			return fmt.Errorf("register Entire with Lefthook: %w", err)
 		}
+		// Registering is not enough when Lefthook has no hook file for a hook
+		// — git runs nothing there. The native install fills exactly those
+		// gaps: it skips every path Lefthook already owns.
+		if _, err := strategy.ReinstallGitHooks(ctx); err != nil {
+			return fmt.Errorf("install git hooks alongside Lefthook: %w", err)
+		}
 		fmt.Fprintln(w, "  ✓ Re-registered")
 		return nil
 	}

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -637,7 +637,7 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 	// their contents say nothing about whether Entire runs. Every other
 	// manager only overwrites at install time, so for those the hook files
 	// remain the answer and the check below is the right one.
-	delivery := strategy.CheckHookDelivery(ctx, false)
+	delivery := strategy.CheckHookDelivery(ctx)
 	if delivery.Declined != "" {
 		// Entire's own hooks are the arrangement here, so the checks below are
 		// the right ones — but say why Lefthook is not carrying it, since
@@ -652,7 +652,7 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 			// launcher, so every hook runs Entire twice — gets straightened
 			// out. Delivery reads OK in that state, so it needs asking for.
 			if force {
-				if _, err := strategy.EnsureLefthookIntegration(ctx, false); err != nil {
+				if _, err := strategy.EnsureLefthookIntegration(ctx); err != nil {
 					return fmt.Errorf("reconcile %s hooks: %w", delivery.Manager, err)
 				}
 			}
@@ -666,7 +666,7 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 			fmt.Fprintln(w, "  Run `entire doctor --force` to apply it.")
 			return nil
 		}
-		if _, err := strategy.EnsureLefthookIntegration(ctx, false); err != nil {
+		if _, err := strategy.EnsureLefthookIntegration(ctx); err != nil {
 			return fmt.Errorf("register Entire with Lefthook: %w", err)
 		}
 		// Registering is not enough when Lefthook has no hook file for a hook

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -632,6 +632,39 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 	ctx := cmd.Context()
 	w := cmd.OutOrStdout()
 
+	// A Lefthook repo is judged on Entire's registration with Lefthook, not on
+	// .git/hooks/*: Lefthook owns those files and rewrites them constantly, so
+	// their contents say nothing about whether Entire runs. Every other
+	// manager only overwrites at install time, so for those the hook files
+	// remain the answer and the check below is the right one.
+	if delivery := strategy.CheckHookDelivery(ctx, false); delivery.Manager == strategy.LefthookManagerName {
+		if delivery.OK {
+			// --force also reconciles .git/hooks/*, which is where a repo left
+			// mid-fight — Entire's own hook chaining to Lefthook's displaced
+			// launcher, so every hook runs Entire twice — gets straightened
+			// out. Delivery reads OK in that state, so it needs asking for.
+			if force {
+				if _, err := strategy.EnsureLefthookIntegration(ctx, false); err != nil {
+					return fmt.Errorf("reconcile %s hooks: %w", delivery.Manager, err)
+				}
+			}
+			fmt.Fprintf(w, "✓ Git hooks: OK (via %s)\n", delivery.Manager)
+			return nil
+		}
+		fmt.Fprintf(w, "Git hooks: NOT DELIVERING (%s)\n", delivery.Manager)
+		fmt.Fprintf(w, "  %s\n", delivery.Reason)
+		fmt.Fprintln(w, "  Fix: re-register Entire in Lefthook's configuration.")
+		if !force {
+			fmt.Fprintln(w, "  Run `entire doctor --force` to apply it.")
+			return nil
+		}
+		if _, err := strategy.EnsureLefthookIntegration(ctx, false); err != nil {
+			return fmt.Errorf("register Entire with Lefthook: %w", err)
+		}
+		fmt.Fprintln(w, "  ✓ Re-registered")
+		return nil
+	}
+
 	switch strategy.CheckGitHookState(ctx) {
 	case strategy.GitHooksCurrent:
 		fmt.Fprintln(w, "✓ Git hooks: OK")

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -637,7 +637,15 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 	// their contents say nothing about whether Entire runs. Every other
 	// manager only overwrites at install time, so for those the hook files
 	// remain the answer and the check below is the right one.
-	if delivery := strategy.CheckHookDelivery(ctx, false); delivery.Manager == strategy.LefthookManagerName {
+	delivery := strategy.CheckHookDelivery(ctx, false)
+	if delivery.Declined != "" {
+		// Entire's own hooks are the arrangement here, so the checks below are
+		// the right ones — but say why Lefthook is not carrying it, since
+		// otherwise a Lefthook repo silently looks like any other.
+		fmt.Fprintf(w, "Note: Entire is not registered in Lefthook's config (%s is not YAML,\n", delivery.Declined)
+		fmt.Fprintln(w, "  and Entire will not shadow it). Entire's own Git hooks are used instead.")
+	}
+	if delivery.Manager == strategy.LefthookManagerName {
 		if delivery.OK {
 			// --force also reconciles .git/hooks/*, which is where a repo left
 			// mid-fight — Entire's own hook chaining to Lefthook's displaced

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -642,8 +642,8 @@ func checkGitHooks(cmd *cobra.Command, force bool) error {
 		// Entire's own hooks are the arrangement here, so the checks below are
 		// the right ones — but say why Lefthook is not carrying it, since
 		// otherwise a Lefthook repo silently looks like any other.
-		fmt.Fprintf(w, "Note: Entire is not registered in Lefthook's config (%s is not YAML,\n", delivery.Declined)
-		fmt.Fprintln(w, "  and Entire will not shadow it). Entire's own Git hooks are used instead.")
+		fmt.Fprintf(w, "Note: Entire is not registered in Lefthook's config (%s,\n", delivery.Declined)
+		fmt.Fprintln(w, "  and Entire will not modify it). Entire's own Git hooks are used instead.")
 	}
 	if delivery.Manager == strategy.LefthookManagerName {
 		if delivery.OK {

--- a/cmd/entire/cli/settings/opf_command_trust.go
+++ b/cmd/entire/cli/settings/opf_command_trust.go
@@ -158,6 +158,24 @@ const (
 	localOwn                            // verified not versioned, or no repository to clone from
 )
 
+// PathIsTracked reports whether a repo-relative path is carried by the
+// repository — present in the index of any clone that checks it out.
+//
+// Exported so callers outside this package do not hand-roll the probe: two
+// commits' worth of correctness lives in it that an open-coded index scan
+// does not get. `pathsEqualFold` rather than an exact compare, because on a
+// case-insensitive volume a differently-cased path is the same file; a
+// missing repository is a definitive "not tracked" rather than a failure;
+// an error means "could not determine" and must not be read as a negative;
+// and the answer is memoized, since trackedness cannot change inside one
+// short-lived hook process.
+//
+// Index-only, matching classifyLocalSettings: the question is whether the
+// repository carries the file, and HEAD costs more than it answers here.
+func PathIsTracked(ctx context.Context, repoRoot, relPath string) (bool, error) {
+	return pathIsVersioned(ctx, repoRoot, relPath, false)
+}
+
 // classifyLocalSettings checks the git index only.
 //
 // The index is what a delivered attack shows up in: a pull request that
@@ -185,7 +203,10 @@ func classifyLocalSettingsDeep(ctx context.Context, path string) localTrust {
 }
 
 func classify(ctx context.Context, path string, deep bool) localTrust {
-	switch versioned, err := localSettingsIsVersioned(ctx, path, deep); {
+	// The settings file is always <worktree>/.entire/settings.local.json, so
+	// its root is two levels up. Callers that know their root pass it
+	// directly through PathIsTracked.
+	switch versioned, err := pathIsVersioned(ctx, filepath.Dir(filepath.Dir(path)), EntireSettingsLocalFile, deep); {
 	case err != nil:
 		return localUnverifiable
 	case versioned:
@@ -199,7 +220,8 @@ func classify(ctx context.Context, path string, deep bool) localTrust {
 // subsumes the shallow one, but they are asked by different callers and only
 // the rare OPF path pays for HEAD.
 type probeKey struct {
-	path string
+	root string
+	rel  string
 	deep bool
 }
 
@@ -230,13 +252,13 @@ func ClearVersionedPathCache() {
 	clear(versionedPaths)
 }
 
-// localSettingsIsVersioned reports whether the local settings file is tracked
-// in the index, and with deep set, whether it is also present in HEAD.
+// pathIsVersioned reports whether a repo-relative path is tracked in the
+// index, and with deep set, whether it is also present in HEAD.
 //
 // An error means "could not determine" (unreadable repository, unreadable
 // index) and callers must treat it as untrusted rather than as a negative.
-func localSettingsIsVersioned(ctx context.Context, path string, deep bool) (bool, error) {
-	key := probeKey{path: path, deep: deep}
+func pathIsVersioned(ctx context.Context, repoRoot, rel string, deep bool) (bool, error) {
+	key := probeKey{root: repoRoot, rel: rel, deep: deep}
 
 	versionedPathsMu.Lock()
 	cached, ok := versionedPaths[key]
@@ -245,7 +267,7 @@ func localSettingsIsVersioned(ctx context.Context, path string, deep bool) (bool
 		return cached, nil
 	}
 
-	versioned, err := probeLocalSettingsIsVersioned(ctx, path, deep)
+	versioned, err := probePathIsVersioned(ctx, repoRoot, rel, deep)
 	if err != nil {
 		return false, err
 	}
@@ -271,12 +293,12 @@ func localSettingsIsVersioned(ctx context.Context, path string, deep bool) (bool
 // the grandparent would name the wrong directory. It holds today because
 // readConfined can only have succeeded on the relative form when the working
 // directory IS the worktree root.
-func probeLocalSettingsIsVersioned(ctx context.Context, path string, deep bool) (bool, error) {
+func probePathIsVersioned(ctx context.Context, repoRoot, rel string, deep bool) (bool, error) {
 	if err := ctx.Err(); err != nil {
-		return false, fmt.Errorf("verify %s: %w", EntireSettingsLocalFile, err)
+		return false, fmt.Errorf("verify %s: %w", rel, err)
 	}
 
-	repo, err := gitrepo.OpenPath(filepath.Dir(filepath.Dir(path)))
+	repo, err := gitrepo.OpenPath(repoRoot)
 	if err != nil {
 		// No repository at all (no .git). A file cannot have arrived by
 		// cloning when there is nothing to clone, so this is a definitive
@@ -296,7 +318,7 @@ func probeLocalSettingsIsVersioned(ctx context.Context, path string, deep bool) 
 		return false, fmt.Errorf("read index: %w", err)
 	}
 	for _, entry := range idx.Entries {
-		if pathsEqualFold(entry.Name, EntireSettingsLocalFile) {
+		if pathsEqualFold(entry.Name, rel) {
 			return true, nil
 		}
 	}
@@ -321,7 +343,7 @@ func probeLocalSettingsIsVersioned(ctx context.Context, path string, deep bool) 
 	if err != nil {
 		return false, fmt.Errorf("read HEAD tree: %w", err)
 	}
-	return treeHasPathFold(tree, strings.Split(EntireSettingsLocalFile, "/"))
+	return treeHasPathFold(tree, strings.Split(rel, "/"))
 }
 
 // pathsEqualFold reports whether two repo-relative git paths can name the same

--- a/cmd/entire/cli/settings/opf_command_trust_test.go
+++ b/cmd/entire/cli/settings/opf_command_trust_test.go
@@ -234,18 +234,18 @@ func TestPathIsVersioned_MemoizesWithinProcess(t *testing.T) {
 	root, _, local := newOPFRepo(t)
 	writeSettingsFile(t, local, localOPFSettings(attackerCommand))
 
-	first, err := localSettingsIsVersioned(t.Context(), local, true)
+	first, err := pathIsVersioned(t.Context(), filepath.Dir(filepath.Dir(local)), EntireSettingsLocalFile, true)
 	require.NoError(t, err)
 	require.False(t, first, "file is untracked to begin with")
 
 	testutil.RunGit(t, root, "add", "-f", EntireSettingsLocalFile)
 
-	second, err := localSettingsIsVersioned(t.Context(), local, true)
+	second, err := pathIsVersioned(t.Context(), filepath.Dir(filepath.Dir(local)), EntireSettingsLocalFile, true)
 	require.NoError(t, err)
 	assert.False(t, second, "result is cached for the process lifetime")
 
 	ClearVersionedPathCache()
-	third, err := localSettingsIsVersioned(t.Context(), local, true)
+	third, err := pathIsVersioned(t.Context(), filepath.Dir(filepath.Dir(local)), EntireSettingsLocalFile, true)
 	require.NoError(t, err)
 	assert.True(t, third, "the reset seam must drop the cached verdict")
 }
@@ -263,7 +263,7 @@ func TestPathIsVersioned_NoGitBinaryRequired(t *testing.T) {
 
 	t.Setenv("PATH", "")
 
-	versioned, err := probeLocalSettingsIsVersioned(t.Context(), local, true)
+	versioned, err := probePathIsVersioned(t.Context(), filepath.Dir(filepath.Dir(local)), EntireSettingsLocalFile, true)
 	require.NoError(t, err, "probe must not depend on the git binary")
 	assert.True(t, versioned, "committed file must still be detected")
 }
@@ -284,12 +284,12 @@ func TestPathIsVersioned_LinkedWorktreeUsesOwnIndex(t *testing.T) {
 	local := filepath.Join(wt, EntireSettingsLocalFile)
 	require.NoError(t, os.WriteFile(local, []byte(localOPFSettings(trustedCommand)), 0o644))
 
-	versioned, err := probeLocalSettingsIsVersioned(t.Context(), local, true)
+	versioned, err := probePathIsVersioned(t.Context(), filepath.Dir(filepath.Dir(local)), EntireSettingsLocalFile, true)
 	require.NoError(t, err)
 	assert.False(t, versioned, "untracked in the linked worktree")
 
 	testutil.RunGit(t, wt, "add", "-f", EntireSettingsLocalFile)
-	versioned, err = probeLocalSettingsIsVersioned(t.Context(), local, true)
+	versioned, err = probePathIsVersioned(t.Context(), filepath.Dir(filepath.Dir(local)), EntireSettingsLocalFile, true)
 	require.NoError(t, err)
 	assert.True(t, versioned, "must read the linked worktree's own index")
 }
@@ -316,7 +316,7 @@ func TestPathIsVersioned_ReftableRepo(t *testing.T) {
 	testutil.RunGit(t, root, "commit", "-m", "carry")
 	testutil.RunGit(t, root, "rm", "--cached", EntireSettingsLocalFile)
 
-	versioned, err := probeLocalSettingsIsVersioned(t.Context(), local, true)
+	versioned, err := probePathIsVersioned(t.Context(), filepath.Dir(filepath.Dir(local)), EntireSettingsLocalFile, true)
 	require.NoError(t, err, "reftable repo must be verifiable")
 	assert.True(t, versioned, "HEAD lookup must work on reftable")
 }
@@ -528,8 +528,7 @@ func TestPathIsVersioned_DecoySiblingDoesNotMaskRealEntry(t *testing.T) {
 			commitIndexAndClear(t, root, tc.decoy, EntireSettingsLocalFile)
 
 			ClearVersionedPathCache()
-			got, err := probeLocalSettingsIsVersioned(
-				t.Context(), filepath.Join(root, EntireSettingsLocalFile), true)
+			got, err := probePathIsVersioned(t.Context(), root, EntireSettingsLocalFile, true)
 			require.NoError(t, err)
 			assert.True(t, got, "the real entry must be found past the earlier-sorting decoy")
 		})
@@ -554,8 +553,7 @@ func TestPathIsVersioned_Win32TrailingCharVariantsAreTracked(t *testing.T) {
 			stageBlobAt(t, root, variant)
 
 			ClearVersionedPathCache()
-			got, err := probeLocalSettingsIsVersioned(
-				t.Context(), filepath.Join(root, EntireSettingsLocalFile), false)
+			got, err := probePathIsVersioned(t.Context(), root, EntireSettingsLocalFile, false)
 			require.NoError(t, err)
 			assert.True(t, got, "a Win32-equivalent committed name must count as tracked")
 		})

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -2664,6 +2664,15 @@ func uninstallGitHooks(ctx context.Context, p *uninstallPrinter) bool {
 		p.warnUnder("failed to remove git hooks: %v", err)
 		return false
 	}
+	// The Lefthook registration is separate from the hook files, so uninstall
+	// has to take both. Only artifacts carrying Entire's marker are removed.
+	lefthookRemoved, err := strategy.RemoveLefthookIntegration(ctx)
+	if err != nil {
+		p.stepFailed("Failed to remove the Lefthook integration")
+		p.warnUnder("failed to remove the Lefthook integration: %v", err)
+		return false
+	}
+	removed += lefthookRemoved
 	if removed > 0 {
 		p.step("Removed git hooks (%d)", removed)
 	} else {

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -1082,6 +1082,9 @@ type statusJSON struct {
 	HooksDeliver       bool   `json:"hooks_deliver"`
 	HooksManager       string `json:"hooks_manager,omitempty"`
 	HooksDeliverReason string `json:"hooks_deliver_reason,omitempty"`
+	// HooksLefthookDeclined names a Lefthook local config Entire will not
+	// write to, which is why Lefthook is not the one delivering.
+	HooksLefthookDeclined string `json:"hooks_lefthook_declined,omitempty"`
 	// CheckpointReadSourceUnknown reports that the read-source probe failed,
 	// so no read source could be determined. Emitted only alongside
 	// checkpoint_push_disabled, and checkpoint_sync_remote is then absent
@@ -1193,6 +1196,7 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		result.HooksDeliver = delivery.OK
 		result.HooksManager = delivery.Manager
 		result.HooksDeliverReason = delivery.Reason
+		result.HooksLefthookDeclined = delivery.Declined
 		result.CheckpointReadFallback = syncInfo.ReadFallback
 		result.CheckpointReadSourceUnknown = syncInfo.ReadSourceUnknown
 		result.UnpushedCheckpoints = syncInfo.Unpushed

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -247,6 +247,7 @@ func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statu
 	// Where checkpoint data syncs (the single elected remote), and how many
 	// checkpoints have not reached it yet. Local-only computation.
 	if s.Enabled {
+		writeHookDeliveryLine(ctx, &b, s, sty)
 		writeCheckpointSyncLines(ctx, &b, s, sty)
 	}
 
@@ -554,6 +555,26 @@ func countUnpushedCheckpointsForStatus(ctx context.Context, remoteName string) i
 		return 0
 	}
 	return n
+}
+
+// writeHookDeliveryLine reports whether Entire's hooks will fire.
+//
+// Without it status named a checkpoint destination while no hook existed to
+// reach it, which is issue #2264. The destination line below is still shown —
+// it is true, and status is the only place it appears — but this line above it
+// removes the claim that delivery is working.
+func writeHookDeliveryLine(ctx context.Context, b *strings.Builder, s *EntireSettings, sty statusStyles) {
+	delivery := strategy.CheckHookDelivery(ctx, s.AbsoluteGitHookPath)
+	b.WriteString("\n")
+	switch {
+	case delivery.OK && delivery.Manager != "":
+		b.WriteString(sty.render(sty.dim, "  Git hooks · via "+delivery.Manager))
+	case delivery.OK:
+		b.WriteString(sty.render(sty.dim, "  Git hooks · installed"))
+	default:
+		b.WriteString(sty.render(sty.yellow, "  ! Checkpoints are NOT being captured: "+delivery.Reason))
+		b.WriteString(sty.render(sty.dim, " · run 'entire doctor'"))
+	}
 }
 
 // writeCheckpointSyncLines reports the checkpoint sync destination (and the
@@ -1054,6 +1075,13 @@ type statusJSON struct {
 	CheckpointSyncRemote       string `json:"checkpoint_sync_remote,omitempty"`
 	CheckpointSyncRemoteSource string `json:"checkpoint_sync_remote_source,omitempty"` // config|observed|default|sole|first|dedicated
 	CheckpointSyncError        string `json:"checkpoint_sync_error,omitempty"`         // fail-closed message
+	// HooksDeliver reports whether Entire's Git hooks will actually fire, and
+	// HooksManager names the hook manager that owns the files when one does.
+	// Without these, status could report a destination while nothing would
+	// reach it (#2264).
+	HooksDeliver       bool   `json:"hooks_deliver"`
+	HooksManager       string `json:"hooks_manager,omitempty"`
+	HooksDeliverReason string `json:"hooks_deliver_reason,omitempty"`
 	// CheckpointReadSourceUnknown reports that the read-source probe failed,
 	// so no read source could be determined. Emitted only alongside
 	// checkpoint_push_disabled, and checkpoint_sync_remote is then absent
@@ -1161,6 +1189,10 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		result.CheckpointSyncRemote = syncInfo.Remote
 		result.CheckpointSyncRemoteSource = syncInfo.Source
 		result.CheckpointSyncError = syncInfo.Err
+		delivery := strategy.CheckHookDelivery(ctx, s.AbsoluteGitHookPath)
+		result.HooksDeliver = delivery.OK
+		result.HooksManager = delivery.Manager
+		result.HooksDeliverReason = delivery.Reason
 		result.CheckpointReadFallback = syncInfo.ReadFallback
 		result.CheckpointReadSourceUnknown = syncInfo.ReadSourceUnknown
 		result.UnpushedCheckpoints = syncInfo.Unpushed

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -247,7 +247,7 @@ func formatSettingsStatusShort(ctx context.Context, s *EntireSettings, sty statu
 	// Where checkpoint data syncs (the single elected remote), and how many
 	// checkpoints have not reached it yet. Local-only computation.
 	if s.Enabled {
-		writeHookDeliveryLine(ctx, &b, s, sty)
+		writeHookDeliveryLine(ctx, &b, sty)
 		writeCheckpointSyncLines(ctx, &b, s, sty)
 	}
 
@@ -563,8 +563,8 @@ func countUnpushedCheckpointsForStatus(ctx context.Context, remoteName string) i
 // reach it, which is issue #2264. The destination line below is still shown —
 // it is true, and status is the only place it appears — but this line above it
 // removes the claim that delivery is working.
-func writeHookDeliveryLine(ctx context.Context, b *strings.Builder, s *EntireSettings, sty statusStyles) {
-	delivery := strategy.CheckHookDelivery(ctx, s.AbsoluteGitHookPath)
+func writeHookDeliveryLine(ctx context.Context, b *strings.Builder, sty statusStyles) {
+	delivery := strategy.CheckHookDelivery(ctx)
 	b.WriteString("\n")
 	switch {
 	case delivery.OK && delivery.Manager != "":
@@ -1192,7 +1192,7 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		result.CheckpointSyncRemote = syncInfo.Remote
 		result.CheckpointSyncRemoteSource = syncInfo.Source
 		result.CheckpointSyncError = syncInfo.Err
-		delivery := strategy.CheckHookDelivery(ctx, s.AbsoluteGitHookPath)
+		delivery := strategy.CheckHookDelivery(ctx)
 		result.HooksDeliver = delivery.OK
 		result.HooksManager = delivery.Manager
 		result.HooksDeliverReason = delivery.Reason

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/redact"
 
@@ -3186,5 +3187,54 @@ func TestRunStatusDetailed_ReportsRejectedExternalAgents(t *testing.T) { //nolin
 	}
 	if !strings.Contains(got, settings.EntireSettingsLocalFile) {
 		t.Errorf("status does not name where the setting must live:\n%s", got)
+	}
+}
+
+// #2264: status named a checkpoint destination while no hook existed to reach
+// it. The delivery line is the answer, and in a Lefthook repo it must be
+// judged on Entire's registration rather than on .git/hooks/*, which Lefthook
+// owns and rewrites.
+func TestRunStatus_HookDeliveryLine(t *testing.T) {
+	testutil.IsolateGitConfigEnv(t)
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+	if err := os.WriteFile("lefthook.yml", []byte("pre-commit: {}\n"), 0o644); err != nil {
+		t.Fatalf("write lefthook.yml: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+	if out := stdout.String(); !strings.Contains(out, "Checkpoints are NOT being captured") {
+		t.Errorf("unregistered Lefthook repo must warn, got:\n%s", out)
+	}
+
+	if _, err := strategy.EnsureLefthookIntegration(context.Background(), false); err != nil {
+		t.Fatalf("EnsureLefthookIntegration() error = %v", err)
+	}
+
+	stdout.Reset()
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Git hooks · via Lefthook") {
+		t.Errorf("registered Lefthook repo must report delivery, got:\n%s", out)
+	}
+	if strings.Contains(out, "NOT being captured") {
+		t.Errorf("registered Lefthook repo must not warn, got:\n%s", out)
+	}
+
+	var jsonOut bytes.Buffer
+	if err := runStatusJSON(context.Background(), &jsonOut); err != nil {
+		t.Fatalf("runStatusJSON() error = %v", err)
+	}
+	var got statusJSON
+	if err := json.Unmarshal(jsonOut.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal status JSON: %v", err)
+	}
+	if !got.HooksDeliver || got.HooksManager != "Lefthook" || got.HooksDeliverReason != "" {
+		t.Errorf("hooks fields = %+v, want delivering via Lefthook: %s", got, jsonOut.String())
 	}
 }

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -3213,6 +3213,13 @@ func TestRunStatus_HookDeliveryLine(t *testing.T) {
 	if _, err := strategy.EnsureLefthookIntegration(context.Background(), false); err != nil {
 		t.Fatalf("EnsureLefthookIntegration() error = %v", err)
 	}
+	// Registering is not delivery on its own: git runs a hook only if the file
+	// exists, and Lefthook creates one per hook it knew about at its last
+	// install. The native install fills the paths Lefthook has not taken.
+	if _, err := strategy.ReinstallGitHooks(context.Background()); err != nil {
+		t.Fatalf("ReinstallGitHooks() error = %v", err)
+	}
+	strategy.ClearHooksDirCache()
 
 	stdout.Reset()
 	if err := runStatus(context.Background(), &stdout, false, false); err != nil {

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -3210,7 +3210,7 @@ func TestRunStatus_HookDeliveryLine(t *testing.T) {
 		t.Errorf("unregistered Lefthook repo must warn, got:\n%s", out)
 	}
 
-	if _, err := strategy.EnsureLefthookIntegration(context.Background(), false); err != nil {
+	if _, err := strategy.EnsureLefthookIntegration(context.Background()); err != nil {
 		t.Fatalf("EnsureLefthookIntegration() error = %v", err)
 	}
 	// Registering is not delivery on its own: git runs a hook only if the file

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -111,6 +111,15 @@ func EnsureSetup(ctx context.Context) error {
 		return fmt.Errorf("failed to ensure primary metadata ref: %w", err)
 	}
 
+	// Lefthook first, because whether Lefthook runs Entire from its own config
+	// decides which hook files Entire should own — see installSkipsHook. Owning
+	// .git/hooks/* is no fix in a Lefthook repo anyway: Lefthook takes those
+	// files back at the top of its next run, which is typically the pre-commit
+	// of the very commit being made.
+	if err := ensureLefthookIntegrationIfManaged(ctx); err != nil {
+		return err
+	}
+
 	// Install generic hooks (they delegate to strategy at runtime)
 	if !IsGitHookInstalled(ctx) {
 		if _, err := ReinstallGitHooks(ctx); err != nil {
@@ -1807,4 +1816,34 @@ func prepareTranscriptIfNeeded(ctx context.Context, ag agent.Agent, transcriptPa
 		// Transcript may not be available yet (e.g., agent not installed).
 		_ = preparer.PrepareTranscript(ctx, transcriptPath) //nolint:errcheck // Best-effort in hook path
 	}
+}
+
+// ensureLefthookIntegrationIfManaged installs or repairs Entire's Lefthook
+// registration when this repository is Lefthook-managed. A repo that declines
+// the integration (a non-YAML local config Entire will not shadow) keeps the
+// native hooks and is not an error.
+//
+// An already-current integration still reconciles the hook files, because
+// that is where a repo left mid-fight — Entire's hook chaining to Lefthook's
+// displaced launcher, running Entire twice — gets straightened out.
+func ensureLefthookIntegrationIfManaged(ctx context.Context) error {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil || !LefthookManaged(repoRoot) {
+		return nil //nolint:nilerr // not a Lefthook repo: nothing to do
+	}
+	absolute := hookSettingsFromConfig(ctx)
+	current, err := LefthookIntegrationCurrent(ctx, absolute)
+	if err != nil {
+		return nil //nolint:nilerr // inspection failure falls back to native hooks
+	}
+	if current {
+		return reconcileHookFiles(ctx, repoRoot)
+	}
+	if _, err := EnsureLefthookIntegration(ctx, absolute); err != nil {
+		if errors.Is(err, ErrLefthookLocalConfigUnwritable) {
+			return nil
+		}
+		return fmt.Errorf("failed to register Entire with Lefthook: %w", err)
+	}
+	return nil
 }

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -1837,7 +1837,7 @@ func ensureLefthookIntegrationIfManaged(ctx context.Context) error {
 		return nil //nolint:nilerr // inspection failure falls back to native hooks
 	}
 	if current {
-		return reconcileHookFiles(ctx, repoRoot)
+		return reconcileHookFiles(ctx)
 	}
 	if _, err := EnsureLefthookIntegration(ctx, absolute); err != nil {
 		if errors.Is(err, ErrLefthookLocalConfigUnwritable) {

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -1831,15 +1831,14 @@ func ensureLefthookIntegrationIfManaged(ctx context.Context) error {
 	if err != nil || !LefthookManaged(repoRoot) {
 		return nil //nolint:nilerr // not a Lefthook repo: nothing to do
 	}
-	absolute := hookSettingsFromConfig(ctx)
-	current, err := LefthookIntegrationCurrent(ctx, absolute)
+	current, err := LefthookIntegrationCurrent(ctx)
 	if err != nil {
 		return nil //nolint:nilerr // inspection failure falls back to native hooks
 	}
 	if current {
 		return reconcileHookFiles(ctx)
 	}
-	if _, err := EnsureLefthookIntegration(ctx, absolute); err != nil {
+	if _, err := EnsureLefthookIntegration(ctx); err != nil {
 		// Both refusals are decisions about the user's repository, not
 		// failures: the native hooks stay and status/doctor report why.
 		if errors.Is(err, ErrLefthookLocalConfigUnwritable) || errors.Is(err, ErrLefthookLocalConfigTracked) {

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -1840,7 +1840,9 @@ func ensureLefthookIntegrationIfManaged(ctx context.Context) error {
 		return reconcileHookFiles(ctx)
 	}
 	if _, err := EnsureLefthookIntegration(ctx, absolute); err != nil {
-		if errors.Is(err, ErrLefthookLocalConfigUnwritable) {
+		// Both refusals are decisions about the user's repository, not
+		// failures: the native hooks stay and status/doctor report why.
+		if errors.Is(err, ErrLefthookLocalConfigUnwritable) || errors.Is(err, ErrLefthookLocalConfigTracked) {
 			return nil
 		}
 		return fmt.Errorf("failed to register Entire with Lefthook: %w", err)

--- a/cmd/entire/cli/strategy/hook_managers.go
+++ b/cmd/entire/cli/strategy/hook_managers.go
@@ -13,28 +13,33 @@ import (
 
 // hookManager describes an external hook manager detected in a repository.
 type hookManager struct {
-	Name            string // "Husky", "Lefthook", "pre-commit", "Overcommit"
-	ConfigPath      string // relative path that triggered detection (e.g., ".husky/")
-	OverwritesHooks bool   // true if the tool will overwrite Entire's hooks on reinstall
+	Name       string // "Husky", "Lefthook", "pre-commit", "Overcommit", "hk"
+	ConfigPath string // relative path that triggered detection (e.g., ".husky/")
 }
 
 // detectHookManagers checks the repository root for known hook manager config
 // files/directories. Detection is filesystem-only (os.Stat, no file reads).
+//
+// Every manager listed here overwrites Entire's hooks when it installs them —
+// verified against pre-commit 4.6.2 ("Use -f to use only pre-commit", which
+// saves a .pre-commit.legacy copy), Overcommit 0.73.0 ("Moving old hooks"), and
+// hk 1.58.1. What makes Lefthook different, and what EnsureLefthookIntegration
+// exists for, is that it also reclaims .git/hooks/* at the top of every later
+// run, so reinstalling on the next agent turn never wins the race.
 func detectHookManagers(repoRoot string) []hookManager {
 	var managers []hookManager
 
 	checks := []hookManager{
-		{"Husky", ".husky/", true},
-		{"pre-commit", ".pre-commit-config.yaml", false},
-		{"Overcommit", ".overcommit.yml", false},
+		{"Husky", ".husky/"},
+		{"pre-commit", ".pre-commit-config.yaml"},
+		{"Overcommit", ".overcommit.yml"},
 	}
 
 	// Lefthook supports {.,}lefthook{,-local}.{yml,yaml,json,toml}
 	for _, prefix := range []string{"", "."} {
 		for _, variant := range []string{"", "-local"} {
 			for _, ext := range []string{"yml", "yaml", "json", "toml"} {
-				name := prefix + "lefthook" + variant + "." + ext
-				checks = append(checks, hookManager{"Lefthook", name, false})
+				checks = append(checks, hookManager{LefthookManagerName, prefix + "lefthook" + variant + "." + ext})
 			}
 		}
 	}
@@ -42,8 +47,7 @@ func detectHookManagers(repoRoot string) []hookManager {
 	// hk supports {.config/,}hk{,.local}.pkl
 	for _, dir := range []string{"", ".config/"} {
 		for _, variant := range []string{"", ".local"} {
-			name := dir + "hk" + variant + ".pkl"
-			checks = append(checks, hookManager{"hk", name, false})
+			checks = append(checks, hookManager{"hk", dir + "hk" + variant + ".pkl"})
 		}
 	}
 
@@ -71,34 +75,36 @@ func hookManagerWarning(managers []hookManager, cmdPrefix string) string {
 
 	var b strings.Builder
 
-	specs := buildHookSpecs(cmdPrefix)
-
 	for _, m := range managers {
-		if m.OverwritesHooks {
-			fmt.Fprintf(&b, "Warning: %s detected (%s)\n", m.Name, m.ConfigPath)
-			fmt.Fprintf(&b, "\n")
+		switch m.Name {
+		case LefthookManagerName:
+			// Entire registers itself in Lefthook's own config, so Lefthook's
+			// regenerations no longer remove it and there is nothing for the
+			// user to do. See EnsureLefthookIntegration.
+			fmt.Fprintf(&b, "Note: %s detected (%s)\n\n", m.Name, m.ConfigPath)
+			fmt.Fprintf(&b, "  %s regenerates Git hooks whenever its config changes or it runs.\n", m.Name)
+			fmt.Fprintf(&b, "  Entire registers itself in %s's own configuration instead of owning\n", m.Name)
+			fmt.Fprintf(&b, "  the hook files, so those regenerations no longer remove it.\n")
+			fmt.Fprintf(&b, "  No action needed.\n\n")
+		case "Husky":
+			// Husky's hooks are hand-editable shell scripts it does not
+			// rewrite, so the durable fix is to add Entire's line to them.
+			fmt.Fprintf(&b, "Warning: %s detected (%s)\n\n", m.Name, m.ConfigPath)
 			fmt.Fprintf(&b, "  %s may overwrite hooks installed by Entire on npm install.\n", m.Name)
-			fmt.Fprintf(&b, "  To make Entire hooks permanent, add these lines to your %s hook files:\n", m.Name)
-			fmt.Fprintf(&b, "\n")
-
-			// Use the config path as the hook directory prefix for hook files.
-			// For Husky, this is typically ".husky/" where hook scripts are stored.
-			hookDir := m.ConfigPath
-
-			for _, spec := range specs {
+			fmt.Fprintf(&b, "  To make Entire hooks permanent, add these lines to your %s hook files:\n\n", m.Name)
+			for _, spec := range buildHookSpecs(cmdPrefix) {
 				cmdLine := extractCommandLine(spec.content)
 				if cmdLine == "" {
 					continue
 				}
-				fmt.Fprintf(&b, "    %s%s:\n", hookDir, spec.name)
-				fmt.Fprintf(&b, "      %s\n", cmdLine)
-				fmt.Fprintf(&b, "\n")
+				fmt.Fprintf(&b, "    %s%s:\n", m.ConfigPath, spec.name)
+				fmt.Fprintf(&b, "      %s\n\n", cmdLine)
 			}
-		} else {
-			fmt.Fprintf(&b, "Note: %s detected (%s)\n", m.Name, m.ConfigPath)
-			fmt.Fprintf(&b, "\n")
-			fmt.Fprintf(&b, "  If %s reinstalls hooks, run 'entire enable' to restore Entire's hooks.\n", m.Name)
-			fmt.Fprintf(&b, "\n")
+		default:
+			fmt.Fprintf(&b, "Warning: %s detected (%s)\n\n", m.Name, m.ConfigPath)
+			fmt.Fprintf(&b, "  %s overwrites Entire's hooks when it installs its own.\n", m.Name)
+			fmt.Fprintf(&b, "  Entire reinstalls them on the next agent turn, but a commit made in\n")
+			fmt.Fprintf(&b, "  between is not captured. Run 'entire enable' to restore them now.\n\n")
 		}
 	}
 

--- a/cmd/entire/cli/strategy/hook_managers.go
+++ b/cmd/entire/cli/strategy/hook_managers.go
@@ -67,8 +67,10 @@ func detectHookManagers(repoRoot string) []hookManager {
 }
 
 // hookManagerWarning builds a warning string for detected hook managers.
-// cmdPrefix is the CLI command prefix (e.g., "entire" or an absolute binary path).
-func hookManagerWarning(managers []hookManager, cmdPrefix string) string {
+// cmdPrefix is the CLI command prefix (e.g., "entire" or an absolute binary
+// path); declined is the phrase from declinedLefthookLocalConfig, empty when
+// Entire is able to register with Lefthook.
+func hookManagerWarning(managers []hookManager, cmdPrefix, declined string) string {
 	if len(managers) == 0 {
 		return ""
 	}
@@ -78,6 +80,18 @@ func hookManagerWarning(managers []hookManager, cmdPrefix string) string {
 	for _, m := range managers {
 		switch m.Name {
 		case LefthookManagerName:
+			if declined != "" {
+				// "No action needed" is true only when Entire can register.
+				// Where it has declined, the repo is on native hooks that
+				// Lefthook reclaims — telling the user otherwise is the false
+				// advice this integration was meant to remove (#2263).
+				fmt.Fprintf(&b, "Warning: %s detected (%s)\n\n", m.Name, m.ConfigPath)
+				fmt.Fprintf(&b, "  Entire could not register in %s's configuration: %s,\n", m.Name, declined)
+				fmt.Fprintf(&b, "  and Entire will not modify it. Entire's own hooks are used instead,\n")
+				fmt.Fprintf(&b, "  and %s reclaims the hooks it manages — Entire reinstalls them on\n", m.Name)
+				fmt.Fprintf(&b, "  the next agent turn, so a commit made in between is not captured.\n\n")
+				break
+			}
 			// Entire registers itself in Lefthook's own config, so Lefthook's
 			// regenerations no longer remove it and there is nothing for the
 			// user to do. See EnsureLefthookIntegration.
@@ -143,7 +157,7 @@ func CheckAndWarnHookManagers(ctx context.Context, w io.Writer, absolutePath boo
 		// Best-effort: hook manager warnings are advisory, skip on resolution failure
 		return
 	}
-	warning := hookManagerWarning(managers, cmdPrefix)
+	warning := hookManagerWarning(managers, cmdPrefix, declinedLefthookLocalConfig(ctx, repoRoot))
 	if warning != "" {
 		fmt.Fprintln(w)
 		fmt.Fprint(w, warning)

--- a/cmd/entire/cli/strategy/hook_managers_test.go
+++ b/cmd/entire/cli/strategy/hook_managers_test.go
@@ -38,9 +38,6 @@ func TestDetectHookManagers_Husky(t *testing.T) {
 	if managers[0].ConfigPath != ".husky/" {
 		t.Errorf("expected .husky/, got %s", managers[0].ConfigPath)
 	}
-	if !managers[0].OverwritesHooks {
-		t.Error("Husky should have OverwritesHooks=true")
-	}
 }
 
 func TestDetectHookManagers_Lefthook(t *testing.T) {
@@ -60,9 +57,6 @@ func TestDetectHookManagers_Lefthook(t *testing.T) {
 	}
 	if managers[0].ConfigPath != "lefthook.yml" {
 		t.Errorf("expected lefthook.yml, got %s", managers[0].ConfigPath)
-	}
-	if managers[0].OverwritesHooks {
-		t.Error("Lefthook should have OverwritesHooks=false")
 	}
 }
 
@@ -165,9 +159,6 @@ func TestDetectHookManagers_PreCommit(t *testing.T) {
 	if managers[0].ConfigPath != ".pre-commit-config.yaml" {
 		t.Errorf("expected .pre-commit-config.yaml, got %s", managers[0].ConfigPath)
 	}
-	if managers[0].OverwritesHooks {
-		t.Error("pre-commit should have OverwritesHooks=false")
-	}
 }
 
 func TestDetectHookManagers_Overcommit(t *testing.T) {
@@ -188,9 +179,6 @@ func TestDetectHookManagers_Overcommit(t *testing.T) {
 	if managers[0].ConfigPath != ".overcommit.yml" {
 		t.Errorf("expected .overcommit.yml, got %s", managers[0].ConfigPath)
 	}
-	if managers[0].OverwritesHooks {
-		t.Error("Overcommit should have OverwritesHooks=false")
-	}
 }
 
 func TestDetectHookManagers_Hk(t *testing.T) {
@@ -210,9 +198,6 @@ func TestDetectHookManagers_Hk(t *testing.T) {
 	}
 	if managers[0].ConfigPath != "hk.pkl" {
 		t.Errorf("expected hk.pkl, got %s", managers[0].ConfigPath)
-	}
-	if managers[0].OverwritesHooks {
-		t.Error("hk should have OverwritesHooks=false")
 	}
 }
 
@@ -314,7 +299,7 @@ func TestHookManagerWarning_Husky(t *testing.T) {
 	t.Parallel()
 
 	managers := []hookManager{
-		{Name: "Husky", ConfigPath: ".husky/", OverwritesHooks: true},
+		{Name: "Husky", ConfigPath: ".husky/"},
 	}
 
 	warning := hookManagerWarning(managers, "entire")
@@ -348,26 +333,52 @@ func TestHookManagerWarning_Husky(t *testing.T) {
 	}
 }
 
-func TestHookManagerWarning_GitHooksManager(t *testing.T) {
+func TestHookManagerWarning_Lefthook(t *testing.T) {
 	t.Parallel()
 
 	managers := []hookManager{
-		{Name: "Lefthook", ConfigPath: "lefthook.yml", OverwritesHooks: false},
+		{Name: "Lefthook", ConfigPath: "lefthook.yml"},
 	}
 
 	warning := hookManagerWarning(managers, "entire")
 
-	// Category B: should be a Note, not a Warning
+	// Lefthook is the one manager Entire integrates with at the config level,
+	// so the message must not ask the user to do anything.
 	if !strings.Contains(warning, "Note: Lefthook detected") {
 		t.Error("warning should contain 'Note: Lefthook detected'")
 	}
-	if !strings.Contains(warning, "run 'entire enable' to restore") {
-		t.Error("warning should mention running 'entire enable'")
+	if !strings.Contains(warning, "No action needed") {
+		t.Error("warning should say no action is needed")
 	}
-
-	// Should NOT contain hook file copy-paste instructions
+	if strings.Contains(warning, "entire enable") {
+		t.Error("warning should not tell the user to re-run entire enable")
+	}
 	if strings.Contains(warning, "prepare-commit-msg:") {
-		t.Error("category B warning should not contain hook file instructions")
+		t.Error("warning should not contain hook file instructions")
+	}
+}
+
+// pre-commit, Overcommit and hk each overwrite Entire's hooks at install time
+// but do not reclaim them afterwards, so the next agent turn repairs it.
+func TestHookManagerWarning_OverwritesAtInstall(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"pre-commit", "Overcommit", "hk"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			warning := hookManagerWarning([]hookManager{{Name: name, ConfigPath: "cfg"}}, "entire")
+
+			if !strings.Contains(warning, "Warning: "+name+" detected") {
+				t.Errorf("warning should name %s, got %q", name, warning)
+			}
+			if !strings.Contains(warning, "next agent turn") {
+				t.Error("warning should say Entire reinstalls on the next agent turn")
+			}
+			if !strings.Contains(warning, "entire enable") {
+				t.Error("warning should offer 'entire enable' to restore now")
+			}
+		})
 	}
 }
 
@@ -389,7 +400,7 @@ func TestHookManagerWarning_AbsolutePathPrefix(t *testing.T) {
 	t.Parallel()
 
 	managers := []hookManager{
-		{Name: "Husky", ConfigPath: ".husky/", OverwritesHooks: true},
+		{Name: "Husky", ConfigPath: ".husky/"},
 	}
 
 	// The prefix is whatever hookCmdPrefix resolved to — bare "entire" or, with
@@ -408,8 +419,8 @@ func TestHookManagerWarning_Multiple(t *testing.T) {
 	t.Parallel()
 
 	managers := []hookManager{
-		{Name: "Husky", ConfigPath: ".husky/", OverwritesHooks: true},
-		{Name: "Lefthook", ConfigPath: "lefthook.yml", OverwritesHooks: false},
+		{Name: "Husky", ConfigPath: ".husky/"},
+		{Name: "Lefthook", ConfigPath: "lefthook.yml"},
 	}
 
 	warning := hookManagerWarning(managers, "entire")

--- a/cmd/entire/cli/strategy/hook_managers_test.go
+++ b/cmd/entire/cli/strategy/hook_managers_test.go
@@ -302,7 +302,7 @@ func TestHookManagerWarning_Husky(t *testing.T) {
 		{Name: "Husky", ConfigPath: ".husky/"},
 	}
 
-	warning := hookManagerWarning(managers, "entire")
+	warning := hookManagerWarning(managers, "entire", "")
 
 	// Should contain all 4 hook file references
 	for _, hook := range gitHookNames {
@@ -340,7 +340,7 @@ func TestHookManagerWarning_Lefthook(t *testing.T) {
 		{Name: "Lefthook", ConfigPath: "lefthook.yml"},
 	}
 
-	warning := hookManagerWarning(managers, "entire")
+	warning := hookManagerWarning(managers, "entire", "")
 
 	// Lefthook is the one manager Entire integrates with at the config level,
 	// so the message must not ask the user to do anything.
@@ -367,7 +367,7 @@ func TestHookManagerWarning_OverwritesAtInstall(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			warning := hookManagerWarning([]hookManager{{Name: name, ConfigPath: "cfg"}}, "entire")
+			warning := hookManagerWarning([]hookManager{{Name: name, ConfigPath: "cfg"}}, "entire", "")
 
 			if !strings.Contains(warning, "Warning: "+name+" detected") {
 				t.Errorf("warning should name %s, got %q", name, warning)
@@ -385,12 +385,12 @@ func TestHookManagerWarning_OverwritesAtInstall(t *testing.T) {
 func TestHookManagerWarning_Empty(t *testing.T) {
 	t.Parallel()
 
-	warning := hookManagerWarning(nil, "entire")
+	warning := hookManagerWarning(nil, "entire", "")
 	if warning != "" {
 		t.Errorf("expected empty string for nil managers, got %q", warning)
 	}
 
-	warning = hookManagerWarning([]hookManager{}, "entire")
+	warning = hookManagerWarning([]hookManager{}, "entire", "")
 	if warning != "" {
 		t.Errorf("expected empty string for empty managers, got %q", warning)
 	}
@@ -408,7 +408,7 @@ func TestHookManagerWarning_AbsolutePathPrefix(t *testing.T) {
 	// warning must quote it verbatim so the command it tells the user to add is
 	// the one Entire actually installs.
 	const prefix = "'/opt/homebrew/bin/entire'"
-	warning := hookManagerWarning(managers, prefix)
+	warning := hookManagerWarning(managers, prefix, "")
 
 	if !strings.Contains(warning, prefix+" hooks git") {
 		t.Errorf("warning should use the resolved command prefix, got %q", warning)
@@ -423,7 +423,7 @@ func TestHookManagerWarning_Multiple(t *testing.T) {
 		{Name: "Lefthook", ConfigPath: "lefthook.yml"},
 	}
 
-	warning := hookManagerWarning(managers, "entire")
+	warning := hookManagerWarning(managers, "entire", "")
 
 	if !strings.Contains(warning, "Warning: Husky detected") {
 		t.Error("should contain Husky warning")
@@ -506,5 +506,29 @@ func TestCheckAndWarnHookManagers_WithHusky(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "Warning: Husky detected") {
 		t.Errorf("expected warning output, got %q", output)
+	}
+}
+
+// "No action needed" is true only where Entire can register. Where it has
+// declined, the repo runs on native hooks that Lefthook reclaims, and saying
+// otherwise is the false advice this integration set out to remove.
+func TestHookManagerWarning_LefthookDeclined(t *testing.T) {
+	t.Parallel()
+
+	managers := []hookManager{{Name: LefthookManagerName, ConfigPath: "lefthook.yml"}}
+	warning := hookManagerWarning(managers, "entire", "lefthook-local.toml is not YAML")
+
+	if strings.Contains(warning, "No action needed") {
+		t.Errorf("a declined registration must not claim there is nothing to do, got:\n%s", warning)
+	}
+	for _, want := range []string{
+		"Warning: Lefthook detected",
+		"lefthook-local.toml is not YAML",
+		"reclaims the hooks it manages",
+		"not captured",
+	} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("warning should explain %q, got:\n%s", want, warning)
+		}
 	}
 }

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -713,8 +713,17 @@ func InstallGitHook(ctx context.Context, silent, absolutePath bool) (int, error)
 	}
 	specs := buildHookSpecs(cmdPrefix)
 	installedCount := 0
+	// In a Lefthook repo the hooks Lefthook owns already run Entire from its
+	// own config; see installSkipsHook.
+	lefthookDelivers := lefthookDeliversHooks(ctx, absolutePath)
+
+	skipped := 0
 
 	for _, spec := range specs {
+		if installSkipsHook(root, spec.name, lefthookDelivers) {
+			skipped++
+			continue
+		}
 		backupName := spec.name + backupSuffix
 		backupExists := hookFileExists(root, backupName)
 
@@ -758,8 +767,14 @@ func InstallGitHook(ctx context.Context, silent, absolutePath bool) (int, error)
 	}
 
 	if !silent {
-		fmt.Println("✓ Installed git hooks (prepare-commit-msg, commit-msg, post-commit, pre-push)")
-		fmt.Println("  Hooks delegate to the current strategy at runtime")
+		// Claiming an install Entire deliberately skipped is the same kind of
+		// false report this integration exists to stop.
+		if skipped == len(specs) {
+			fmt.Printf("✓ Git hooks run through %s (Entire is registered in its config)\n", LefthookManagerName)
+		} else {
+			fmt.Println("✓ Installed git hooks (prepare-commit-msg, commit-msg, post-commit, pre-push)")
+			fmt.Println("  Hooks delegate to the current strategy at runtime")
+		}
 	}
 
 	return installedCount, nil

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -715,7 +715,9 @@ func InstallGitHook(ctx context.Context, silent, absolutePath bool) (int, error)
 	installedCount := 0
 	// In a Lefthook repo the hooks Lefthook owns already run Entire from its
 	// own config; see installSkipsHook.
-	lefthookDelivers := lefthookDeliversHooks(ctx, absolutePath)
+	// Resolved from settings, not from this call's absolutePath: the question
+	// is what the repository's own installed integration says.
+	lefthookDelivers := lefthookDeliversHooks(ctx)
 
 	skipped := 0
 

--- a/cmd/entire/cli/strategy/lefthook.go
+++ b/cmd/entire/cli/strategy/lefthook.go
@@ -33,6 +33,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
 	"gopkg.in/yaml.v3"
 )
@@ -64,6 +65,13 @@ var ErrLefthookLocalConfigUnwritable = errors.New("lefthook local config is not 
 // unlike ErrLefthookLocalConfigUnwritable, which is a deliberate decision not
 // to touch the repo and is handled silently.
 var ErrLefthookArtifactBlocked = errors.New("lefthook artifact path is blocked by an existing backup")
+
+// ErrLefthookLocalConfigTracked reports a local config the repository carries.
+// Lefthook documents lefthook-local.* as personal and gitignored; a tracked
+// one is the team's file, so Entire declines to add its entry rather than
+// modify something shared. Like ErrLefthookLocalConfigUnwritable this is a
+// decision, not a failure, and the native hooks stay.
+var ErrLefthookLocalConfigTracked = errors.New("lefthook local config is tracked by git")
 
 // lefthookLocalConfigNames are the local config names Lefthook reads, in its
 // own precedence order. Writing into anything but the first match present
@@ -122,8 +130,13 @@ func EnsureLefthookIntegration(ctx context.Context, absolutePath bool) (int, err
 	// the point of excluding — and because ensureLefthookIntegrationIfManaged
 	// treats this refusal as a decision rather than a failure, that recurred
 	// on every turn instead of resolving itself.
-	if _, _, err := findLocalConfig(root); err != nil {
+	if name, existing, err := findLocalConfig(root); err != nil {
 		return 0, err
+	} else if existing != nil && !extendsEntryPresent(root) && lefthookLocalConfigTracked(ctx, repoRoot, name) {
+		// Only when the entry would actually be ADDED: a tracked config that
+		// already carries it (committed by the team, or added by hand) is
+		// working as intended, and nothing here writes to it.
+		return 0, fmt.Errorf("%w: %s", ErrLefthookLocalConfigTracked, name)
 	}
 	cmdPrefix, err := hookCmdPrefix(absolutePath)
 	if err != nil {
@@ -818,7 +831,7 @@ func CheckHookDelivery(ctx context.Context, absolutePath bool) HookDelivery {
 		// own hooks are the arrangement in such a repo, so the answer is the
 		// native one. Saying "not registered with Lefthook" here would report
 		// a working repository as broken, forever and with no fix to offer.
-		if declined = declinedLefthookLocalConfig(repoRoot); declined == "" {
+		if declined = declinedLefthookLocalConfig(ctx, repoRoot); declined == "" {
 			return HookDelivery{Manager: LefthookManagerName,
 				Reason: "Entire is not registered with Lefthook, so Lefthook's hooks do not run it."}
 		}
@@ -833,16 +846,42 @@ func CheckHookDelivery(ctx context.Context, absolutePath bool) HookDelivery {
 	return HookDelivery{Reason: "Entire's Git hooks are not installed.", Declined: declined}
 }
 
-// declinedLefthookLocalConfig names the local config Entire refuses to write
-// to, or "" when there is none to refuse.
-func declinedLefthookLocalConfig(repoRoot string) string {
+// declinedLefthookLocalConfig describes the local config Entire refuses to
+// write to, as a phrase naming the file and why — or "" when nothing is being
+// refused. A phrase rather than a name because the two reasons need different
+// remedies and every consumer of HookDelivery.Declined is reporting it to a
+// person.
+func declinedLefthookLocalConfig(ctx context.Context, repoRoot string) string {
 	root, err := worktreedir.OpenAt(repoRoot)
 	if err != nil {
 		return ""
 	}
-	name, _, err := findLocalConfig(root)
-	if errors.Is(err, ErrLefthookLocalConfigUnwritable) {
-		return name
+	name, existing, err := findLocalConfig(root)
+	switch {
+	case errors.Is(err, ErrLefthookLocalConfigUnwritable):
+		return name + " is not YAML"
+	case err != nil:
+		return ""
+	case existing != nil && !extendsEntryPresent(root) && lefthookLocalConfigTracked(ctx, repoRoot, name):
+		return name + " is tracked by git"
 	}
 	return ""
+}
+
+// lefthookLocalConfigTracked reports whether the local config is carried by
+// the repository rather than being the per-clone file Lefthook documents.
+//
+// A tracked one is shared with the team, so adding Entire's extends entry to
+// it modifies their file, not the developer's — and a revert followed by a
+// reinstall next turn is a fight Entire should not pick.
+//
+// settings.PathIsTracked rather than an index scan here: that probe carries
+// two commits' worth of correctness an open-coded one does not, in particular
+// comparing paths the way the filesystem would, because on a case-insensitive
+// volume a differently-cased tracked path is the same file. It is consulted
+// only when Entire is about to add the entry, so after a successful install it
+// never runs again.
+func lefthookLocalConfigTracked(ctx context.Context, repoRoot, name string) bool {
+	tracked, err := settings.PathIsTracked(ctx, repoRoot, name)
+	return err == nil && tracked
 }

--- a/cmd/entire/cli/strategy/lefthook.go
+++ b/cmd/entire/cli/strategy/lefthook.go
@@ -642,9 +642,26 @@ func encodeYAML(doc *yaml.Node) ([]byte, error) {
 	return []byte(out.String()), nil
 }
 
-// lefthookLauncherMarker appears in every hook file Lefthook generates. It is
-// how Entire recognises a hook path Lefthook has taken over.
-const lefthookLauncherMarker = "call_lefthook"
+// isLefthookLauncher reports whether a file is the hook Lefthook generates for
+// this hook name.
+//
+// The test is deliberately structural rather than a search for the word
+// "lefthook", because a false positive here is silent and permanent: a hook
+// misread as Lefthook's gets restored over Entire's by reconcileHookFiles and
+// then skipped forever by installSkipsHook, so capture stops for that hook and
+// nothing ever repairs it. Lefthook's template defines a call_lefthook shell
+// function and ends by dispatching THIS hook through it; a hand-written script
+// that merely runs lefthook does neither, and a launcher for a different hook
+// fails the second test.
+func isLefthookLauncher(root *os.Root, name, hook string) bool {
+	data, err := osroot.ReadFileNoFollow(root, name)
+	if err != nil {
+		return false
+	}
+	body := string(data)
+	return strings.Contains(body, "call_lefthook()") &&
+		strings.Contains(body, `call_lefthook run "`+hook+`"`)
+}
 
 // reconcileHookFiles hands .git/hooks/* back to Lefthook and clears the
 // wreckage of the era when the two fought over those files.
@@ -676,7 +693,7 @@ func reconcileHookFiles(ctx context.Context) error {
 	}
 	for _, hook := range gitHookNames {
 		backup := hook + GitHookBackupSuffix
-		if fileContains(root, backup, lefthookLauncherMarker) && fileContains(root, hook, entireHookMarker) {
+		if isLefthookLauncher(root, backup, hook) && fileContains(root, hook, entireHookMarker) {
 			if err := root.Rename(backup, hook); err != nil && !os.IsNotExist(err) {
 				return fmt.Errorf("restore %s: %w", hook, err)
 			}
@@ -708,7 +725,39 @@ func fileContains(root *os.Root, name, marker string) bool {
 // nobody has run `lefthook install` yet, Entire's own hooks are the only
 // delivery there is.
 func installSkipsHook(root *os.Root, hook string, lefthookDelivers bool) bool {
-	return lefthookDelivers && fileContains(root, hook, lefthookLauncherMarker)
+	return lefthookDelivers && isLefthookLauncher(root, hook, hook)
+}
+
+// uncoveredHookPaths names the hooks nothing would run Entire for.
+//
+// Registering with Lefthook is not enough on its own: git runs a hook only if
+// the FILE exists, and Lefthook creates one per hook it knew about when it last
+// installed. Entire's config reaches Lefthook through `extends` at run time, so
+// a repo whose lefthook.yml declares only pre-commit has no file for the other
+// four and nothing dispatches Entire there — while every artifact Entire owns
+// is present and correct. Reporting that as delivering is the same false OK
+// this integration exists to remove, so the check asks the question git asks:
+// is there a file here, and does it lead to Entire?
+func uncoveredHookPaths(ctx context.Context) []string {
+	hooksDir, err := GetHooksDir(ctx)
+	if err != nil {
+		return gitHookNames
+	}
+	root, err := hooksRootForRemoval(hooksDir)
+	if err != nil {
+		return gitHookNames
+	}
+	var uncovered []string
+	for _, hook := range gitHookNames {
+		// Lefthook's launcher reaches Entire through the integration; Entire's
+		// own hook reaches it directly. Anything else — absent, a symlink, or
+		// another tool's script — does not.
+		if isLefthookLauncher(root, hook, hook) || fileContains(root, hook, entireHookMarker) {
+			continue
+		}
+		uncovered = append(uncovered, hook)
+	}
+	return uncovered
 }
 
 // lefthookDeliversHooks reports whether Lefthook will run Entire from its own
@@ -758,6 +807,11 @@ func CheckHookDelivery(ctx context.Context, absolutePath bool) HookDelivery {
 			return HookDelivery{Manager: LefthookManagerName,
 				Reason: fmt.Sprintf("Could not inspect Entire's Lefthook integration: %v", checkErr)}
 		case current:
+			if uncovered := uncoveredHookPaths(ctx); len(uncovered) > 0 {
+				return HookDelivery{Manager: LefthookManagerName,
+					Reason: fmt.Sprintf("Lefthook has no hook file for %s, so nothing runs Entire there.",
+						strings.Join(uncovered, ", "))}
+			}
 			return HookDelivery{OK: true, Manager: LefthookManagerName}
 		}
 		// A declined integration is permanent, not a repair pending: Entire's

--- a/cmd/entire/cli/strategy/lefthook.go
+++ b/cmd/entire/cli/strategy/lefthook.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/entireio/cli/cmd/entire/cli/gitdir"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
@@ -170,7 +171,7 @@ func EnsureLefthookIntegration(ctx context.Context, absolutePath bool) (int, err
 	if _, err := ensureExtendsEntry(root); err != nil {
 		return 0, err
 	}
-	if err := reconcileHookFiles(ctx, repoRoot); err != nil {
+	if err := reconcileHookFiles(ctx); err != nil {
 		return 0, err
 	}
 	return written, nil
@@ -262,15 +263,51 @@ func rewriteExcludeBlock(ctx context.Context, repoRoot, block string) error {
 }
 
 func openGitCommonDir(ctx context.Context, repoRoot string) (*os.Root, error) {
-	commonDir, err := gitdir.CommonDirForWorktree(ctx, repoRoot)
+	commonDir, err := gitCommonDirFor(ctx, repoRoot)
 	if err != nil {
-		return nil, fmt.Errorf("resolve git common dir: %w", err)
+		return nil, err
 	}
 	root, err := gitdir.OpenAt(commonDir)
 	if err != nil {
 		return nil, fmt.Errorf("open git common dir: %w", err)
 	}
 	return root, nil
+}
+
+// gitCommonDirCache memoizes the git common dir per worktree root. Resolving
+// it is a `git rev-parse` subprocess — measured at ~10ms, against ~0.3µs for
+// the root open it feeds — and the exclude check that needs it is part of the
+// currency test, which a single turn-start runs two or three times. A
+// worktree's common dir does not move while the process lives. Only the path
+// is cached; the root itself is already memoized by osroot.Shared, which is
+// also what keeps a handle from outliving a deleted directory here.
+var (
+	gitCommonDirMu    sync.RWMutex
+	gitCommonDirCache = map[string]string{}
+)
+
+func gitCommonDirFor(ctx context.Context, repoRoot string) (string, error) {
+	gitCommonDirMu.RLock()
+	cached, ok := gitCommonDirCache[repoRoot]
+	gitCommonDirMu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+	commonDir, err := gitdir.CommonDirForWorktree(ctx, repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve git common dir: %w", err)
+	}
+	gitCommonDirMu.Lock()
+	gitCommonDirCache[repoRoot] = commonDir
+	gitCommonDirMu.Unlock()
+	return commonDir, nil
+}
+
+// clearGitCommonDirCache exists for tests that reuse a worktree root path.
+func clearGitCommonDirCache() {
+	gitCommonDirMu.Lock()
+	gitCommonDirCache = map[string]string{}
+	gitCommonDirMu.Unlock()
 }
 
 // LefthookIntegrationCurrent reports whether Entire's artifacts are present
@@ -322,7 +359,21 @@ func RemoveLefthookIntegration(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("open worktree: %w", err)
 	}
+	// The extends entry goes first, mirroring the install, which writes it
+	// last: at no point should Lefthook's config name a file that is not
+	// there. Lefthook 2.1.10 tolerates a dangling extends (run, install,
+	// validate and dump all succeed), so this is not repairing a break — it is
+	// declining to depend on another tool's tolerance, and it fails in the
+	// better direction, since giving up here leaves the integration whole
+	// rather than half-deleted.
 	removed := 0
+	dropped, err := removeExtendsEntry(root)
+	if err != nil {
+		return removed, err
+	}
+	if dropped {
+		removed++
+	}
 	for _, hook := range gitHookNames {
 		name := lefthookScriptPath(hook)
 		owned, err := fileIsOwned(root, name)
@@ -338,13 +389,6 @@ func RemoveLefthookIntegration(ctx context.Context) (int, error) {
 		if err := osroot.RemoveNoSymlinks(root, entireLefthookConfig); err != nil && !os.IsNotExist(err) {
 			return removed, fmt.Errorf("remove %s: %w", entireLefthookConfig, err)
 		}
-		removed++
-	}
-	dropped, err := removeExtendsEntry(root)
-	if err != nil {
-		return removed, err
-	}
-	if dropped {
 		removed++
 	}
 	if err := rewriteExcludeBlock(ctx, repoRoot, ""); err != nil {
@@ -618,8 +662,11 @@ const lefthookLauncherMarker = "call_lefthook"
 // every repo the fight has already touched is in exactly that state.
 //
 // Nothing is touched unless its contents prove whose it was.
-func reconcileHookFiles(ctx context.Context, repoRoot string) error {
-	hooksDir, err := getHooksDirInPath(ctx, repoRoot)
+func reconcileHookFiles(ctx context.Context) error {
+	// GetHooksDir rather than the by-path variant: both callers resolved their
+	// worktree root from this same process's directory, and this one is
+	// memoized. The by-path variant is another ~13ms `git rev-parse` per turn.
+	hooksDir, err := GetHooksDir(ctx)
 	if err != nil {
 		return nil //nolint:nilerr // best effort: no hooks dir, nothing to do
 	}

--- a/cmd/entire/cli/strategy/lefthook.go
+++ b/cmd/entire/cli/strategy/lefthook.go
@@ -103,6 +103,13 @@ func LefthookManaged(repoRoot string) bool {
 // EnsureLefthookIntegration registers Entire with Lefthook, returning the
 // number of artifacts written.
 //
+// The hook-command prefix is read from this repository's settings rather than
+// taken as an argument, for the reason ReinstallGitHooks exists: a caller that
+// passes the wrong value does not fail, it silently drops
+// absolute_git_hook_path — and here that means rewriting a working
+// absolute-path install down to a bare `entire`, breaking delivery for the GUI
+// git clients that setting exists to serve. `entire doctor` did exactly that.
+//
 // There is deliberately no rollback. Every write is atomic and content-
 // idempotent, and the entry that activates the integration is written last, so
 // a failure part way through leaves inert files that the next install
@@ -114,7 +121,7 @@ func LefthookManaged(repoRoot string) bool {
 // front, because it is a decision not to touch the repo rather than a failure
 // that will pass, and the exclude entries go in while the paths are still
 // empty, so a partial write is never left unignored.
-func EnsureLefthookIntegration(ctx context.Context, absolutePath bool) (int, error) {
+func EnsureLefthookIntegration(ctx context.Context) (int, error) {
 	repoRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("resolve worktree root: %w", err)
@@ -138,7 +145,7 @@ func EnsureLefthookIntegration(ctx context.Context, absolutePath bool) (int, err
 		// working as intended, and nothing here writes to it.
 		return 0, fmt.Errorf("%w: %s", ErrLefthookLocalConfigTracked, name)
 	}
-	cmdPrefix, err := hookCmdPrefix(absolutePath)
+	cmdPrefix, err := hookCmdPrefix(hookSettingsFromConfig(ctx))
 	if err != nil {
 		return 0, err
 	}
@@ -325,7 +332,8 @@ func clearGitCommonDirCache() {
 
 // LefthookIntegrationCurrent reports whether Entire's artifacts are present
 // and current: its config, the extends entry pointing at it, and every script.
-func LefthookIntegrationCurrent(ctx context.Context, absolutePath bool) (bool, error) {
+// The prefix comes from settings; see EnsureLefthookIntegration.
+func LefthookIntegrationCurrent(ctx context.Context) (bool, error) {
 	repoRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		return false, fmt.Errorf("resolve worktree root: %w", err)
@@ -345,7 +353,7 @@ func LefthookIntegrationCurrent(ctx context.Context, absolutePath bool) (bool, e
 	if !extendsEntryPresent(root) {
 		return false, nil
 	}
-	cmdPrefix, err := hookCmdPrefix(absolutePath)
+	cmdPrefix, err := hookCmdPrefix(hookSettingsFromConfig(ctx))
 	if err != nil {
 		return false, err
 	}
@@ -775,12 +783,12 @@ func uncoveredHookPaths(ctx context.Context) []string {
 
 // lefthookDeliversHooks reports whether Lefthook will run Entire from its own
 // configuration, which is what makes Entire's own hook files redundant.
-func lefthookDeliversHooks(ctx context.Context, absolutePath bool) bool {
+func lefthookDeliversHooks(ctx context.Context) bool {
 	repoRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil || !LefthookManaged(repoRoot) {
 		return false
 	}
-	current, err := LefthookIntegrationCurrent(ctx, absolutePath)
+	current, err := LefthookIntegrationCurrent(ctx)
 	return err == nil && current
 }
 
@@ -807,14 +815,14 @@ type HookDelivery struct {
 // A Lefthook repo is judged on the integration, not on .git/hooks/*: Lefthook
 // owns those files and rewrites them constantly, so their contents say nothing
 // about whether Entire will run.
-func CheckHookDelivery(ctx context.Context, absolutePath bool) HookDelivery {
+func CheckHookDelivery(ctx context.Context) HookDelivery {
 	repoRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		return HookDelivery{Reason: "Could not resolve the repository root."}
 	}
 	declined := ""
 	if LefthookManaged(repoRoot) {
-		current, checkErr := LefthookIntegrationCurrent(ctx, absolutePath)
+		current, checkErr := LefthookIntegrationCurrent(ctx)
 		switch {
 		case checkErr != nil:
 			return HookDelivery{Manager: LefthookManagerName,

--- a/cmd/entire/cli/strategy/lefthook.go
+++ b/cmd/entire/cli/strategy/lefthook.go
@@ -99,6 +99,12 @@ func LefthookManaged(repoRoot string) bool {
 // a failure part way through leaves inert files that the next install
 // overwrites. EnsureSetup runs at every turn start, so "the next install" is a
 // guarantee rather than a hope.
+//
+// That argument only holds for a failure that eventually stops happening, so
+// two things come before the writes: the non-YAML local config is refused up
+// front, because it is a decision not to touch the repo rather than a failure
+// that will pass, and the exclude entries go in while the paths are still
+// empty, so a partial write is never left unignored.
 func EnsureLefthookIntegration(ctx context.Context, absolutePath bool) (int, error) {
 	repoRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
@@ -108,8 +114,26 @@ func EnsureLefthookIntegration(ctx context.Context, absolutePath bool) (int, err
 	if err != nil {
 		return 0, fmt.Errorf("open worktree: %w", err)
 	}
+	// Refuse BEFORE writing anything. Declining to shadow a non-YAML local
+	// config has to mean leaving the repo untouched: the extends entry is what
+	// makes the other artifacts do anything, so writing them first left six
+	// untracked files in the worktree that this same function had not reached
+	// the point of excluding — and because ensureLefthookIntegrationIfManaged
+	// treats this refusal as a decision rather than a failure, that recurred
+	// on every turn instead of resolving itself.
+	if _, _, err := findLocalConfig(root); err != nil {
+		return 0, err
+	}
 	cmdPrefix, err := hookCmdPrefix(absolutePath)
 	if err != nil {
+		return 0, err
+	}
+
+	// Before the writes, not after: a write that fails part way through (a
+	// blocked artifact path, a full disk) otherwise leaves files in the
+	// worktree that nothing has excluded yet, and the entries name paths
+	// rather than existing files, so writing them early costs nothing.
+	if err := excludeArtifacts(ctx, repoRoot); err != nil {
 		return 0, err
 	}
 
@@ -144,9 +168,6 @@ func EnsureLefthookIntegration(ctx context.Context, absolutePath bool) (int, err
 
 	// Last: this is what makes Lefthook load any of the above.
 	if _, err := ensureExtendsEntry(root); err != nil {
-		return 0, err
-	}
-	if err := excludeArtifacts(ctx, repoRoot); err != nil {
 		return 0, err
 	}
 	if err := reconcileHookFiles(ctx, repoRoot); err != nil {
@@ -658,10 +679,15 @@ func lefthookDeliversHooks(ctx context.Context, absolutePath bool) bool {
 type HookDelivery struct {
 	// OK is true when capture and delivery are wired up.
 	OK bool
-	// Manager names the hook manager that owns the hook files, if any.
+	// Manager names the hook manager that delivers Entire, if one does.
 	Manager string
 	// Reason explains a false OK, ready to show a user.
 	Reason string
+	// Declined names the Lefthook local config Entire will not write to, when
+	// that is why Lefthook is not the one delivering. It is set whether or not
+	// OK is true, because it is the answer to "why is Entire not in Lefthook's
+	// config" in a repository whose hooks are working fine without it.
+	Declined string
 }
 
 // CheckHookDelivery reports whether Entire's hooks will fire in this
@@ -677,6 +703,7 @@ func CheckHookDelivery(ctx context.Context, absolutePath bool) HookDelivery {
 	if err != nil {
 		return HookDelivery{Reason: "Could not resolve the repository root."}
 	}
+	declined := ""
 	if LefthookManaged(repoRoot) {
 		current, checkErr := LefthookIntegrationCurrent(ctx, absolutePath)
 		switch {
@@ -685,17 +712,36 @@ func CheckHookDelivery(ctx context.Context, absolutePath bool) HookDelivery {
 				Reason: fmt.Sprintf("Could not inspect Entire's Lefthook integration: %v", checkErr)}
 		case current:
 			return HookDelivery{OK: true, Manager: LefthookManagerName}
-		default:
+		}
+		// A declined integration is permanent, not a repair pending: Entire's
+		// own hooks are the arrangement in such a repo, so the answer is the
+		// native one. Saying "not registered with Lefthook" here would report
+		// a working repository as broken, forever and with no fix to offer.
+		if declined = declinedLefthookLocalConfig(repoRoot); declined == "" {
 			return HookDelivery{Manager: LefthookManagerName,
 				Reason: "Entire is not registered with Lefthook, so Lefthook's hooks do not run it."}
 		}
 	}
 	switch CheckGitHookState(ctx) {
 	case GitHooksCurrent:
-		return HookDelivery{OK: true}
+		return HookDelivery{OK: true, Declined: declined}
 	case GitHooksOutdated:
-		return HookDelivery{Reason: "Entire's Git hooks are outdated."}
+		return HookDelivery{Reason: "Entire's Git hooks are outdated.", Declined: declined}
 	case GitHooksAbsent:
 	}
-	return HookDelivery{Reason: "Entire's Git hooks are not installed."}
+	return HookDelivery{Reason: "Entire's Git hooks are not installed.", Declined: declined}
+}
+
+// declinedLefthookLocalConfig names the local config Entire refuses to write
+// to, or "" when there is none to refuse.
+func declinedLefthookLocalConfig(repoRoot string) string {
+	root, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return ""
+	}
+	name, _, err := findLocalConfig(root)
+	if errors.Is(err, ErrLefthookLocalConfigUnwritable) {
+		return name
+	}
+	return ""
 }

--- a/cmd/entire/cli/strategy/lefthook.go
+++ b/cmd/entire/cli/strategy/lefthook.go
@@ -1,0 +1,701 @@
+package strategy
+
+// Lefthook integration.
+//
+// Lefthook owns .git/hooks/* and regenerates every hook from its config on
+// each run, gated by a checksum of that config. So Entire cannot keep a
+// wrapper there: any lefthook.yml edit, or the `lefthook install -f` that its
+// npm postinstall runs, silently takes the file back. Worse, the reclaim
+// happens at the top of whatever hook fires next — typically the pre-commit of
+// the very commit being made — so repairing at turn start loses the race.
+//
+// The fix is to stop wanting the file. Entire writes a config of its own and
+// registers it with one `extends` entry in Lefthook's local config; Lefthook
+// then invokes Entire's scripts itself. Lefthook resolves `extends` at run
+// time, so the artifacts take effect immediately — no `lefthook install`, no
+// user action — and Lefthook's own config is never touched.
+//
+// Verified against lefthook 2.1.10: a config reached via `extends` can declare
+// `scripts`, those scripts receive git's hook arguments (pre-push gets the
+// remote and its URL), and the whole arrangement survives both
+// `lefthook install -f` and a config edit.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitdir"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// entireLefthookConfig is Entire's own Lefthook config. Entire owns this
+	// file outright, which is what keeps it out of the user's.
+	entireLefthookConfig = "entire-lefthook.yml"
+	// lefthookScriptDir is Lefthook's clone-local script directory, its
+	// default for source_dir_local.
+	lefthookScriptDir = ".lefthook-local"
+	lefthookScript    = "entire.sh"
+	// lefthookOwnedMarker identifies a file as Entire's. Removal and
+	// overwriting both require it: the path is Entire's choice, but the
+	// repository is the user's.
+	lefthookOwnedMarker = "entire-cli-owned:lefthook:v1"
+)
+
+// ErrLefthookLocalConfigUnwritable reports a local config Entire will not
+// edit. Lefthook reads exactly one local config and lefthook-local.yml takes
+// precedence over lefthook-local.toml, so creating the former beside a user's
+// latter would silently stop their hooks running. Entire declines instead and
+// leaves its native hooks in place.
+var ErrLefthookLocalConfigUnwritable = errors.New("lefthook local config is not YAML")
+
+// ErrLefthookArtifactBlocked reports a path Entire cannot claim because an
+// earlier backup is already sitting beside it. Burying that backup would
+// destroy whatever it holds, so the integration stops and says so instead —
+// unlike ErrLefthookLocalConfigUnwritable, which is a deliberate decision not
+// to touch the repo and is handled silently.
+var ErrLefthookArtifactBlocked = errors.New("lefthook artifact path is blocked by an existing backup")
+
+// lefthookLocalConfigNames are the local config names Lefthook reads, in its
+// own precedence order. Writing into anything but the first match present
+// would be a silent no-op.
+var lefthookLocalConfigNames = []string{
+	"lefthook-local.yml", "lefthook-local.yaml",
+	"lefthook-local.json", "lefthook-local.toml",
+	".lefthook-local.yml", ".lefthook-local.yaml",
+	".lefthook-local.json", ".lefthook-local.toml",
+}
+
+// LefthookManaged reports whether this repository is managed by Lefthook.
+//
+// Only a main config counts. A lone lefthook-local.* is deliberately not
+// evidence: Entire creates lefthook-local.yml itself, so trusting it would
+// leave a repo classified as Lefthook-managed after the user removed Lefthook
+// — reporting "via Lefthook" in status while nothing ran Entire at all.
+func LefthookManaged(repoRoot string) bool {
+	for _, prefix := range []string{"", "."} {
+		for _, ext := range []string{"yml", "yaml", "json", "toml"} {
+			if _, err := os.Stat(filepath.Join(repoRoot, prefix+"lefthook."+ext)); err == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// EnsureLefthookIntegration registers Entire with Lefthook, returning the
+// number of artifacts written.
+//
+// There is deliberately no rollback. Every write is atomic and content-
+// idempotent, and the entry that activates the integration is written last, so
+// a failure part way through leaves inert files that the next install
+// overwrites. EnsureSetup runs at every turn start, so "the next install" is a
+// guarantee rather than a hope.
+func EnsureLefthookIntegration(ctx context.Context, absolutePath bool) (int, error) {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("resolve worktree root: %w", err)
+	}
+	root, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return 0, fmt.Errorf("open worktree: %w", err)
+	}
+	cmdPrefix, err := hookCmdPrefix(absolutePath)
+	if err != nil {
+		return 0, err
+	}
+
+	written := 0
+	for _, spec := range buildHookSpecs(cmdPrefix) {
+		name := lefthookScriptPath(spec.name)
+		if err := displaceUnowned(root, name, 0o755); err != nil {
+			return 0, err
+		}
+		if err := osroot.MkdirAllNoSymlink(root, filepath.ToSlash(filepath.Dir(name)), 0o755); err != nil {
+			return 0, fmt.Errorf("create %s: %w", filepath.Dir(name), err)
+		}
+		changed, writeErr := writeHookFile(root, name, renderLefthookScript(spec))
+		if writeErr != nil {
+			return 0, writeErr
+		}
+		if changed {
+			written++
+		}
+	}
+
+	if err := displaceUnowned(root, entireLefthookConfig, 0o644); err != nil {
+		return 0, err
+	}
+	changed, err := writeOwnedConfig(root)
+	if err != nil {
+		return 0, err
+	}
+	if changed {
+		written++
+	}
+
+	// Last: this is what makes Lefthook load any of the above.
+	if _, err := ensureExtendsEntry(root); err != nil {
+		return 0, err
+	}
+	if err := excludeArtifacts(ctx, repoRoot); err != nil {
+		return 0, err
+	}
+	if err := reconcileHookFiles(ctx, repoRoot); err != nil {
+		return 0, err
+	}
+	return written, nil
+}
+
+// artifactsExcluded reports whether the exclude block is in place, which the
+// install treats as part of being current.
+func artifactsExcluded(ctx context.Context, repoRoot string) bool {
+	root, err := openGitCommonDir(ctx, repoRoot)
+	if err != nil {
+		return true // cannot tell; do not churn the install on it
+	}
+	data, err := osroot.ReadFileNoFollow(root, gitExcludePath)
+	return err == nil && strings.Contains(string(data), lefthookExcludeBlock())
+}
+
+// lefthookExcludeBlock is the exact text excludeArtifacts writes, so
+// artifactsExcluded tests for what an install would produce and any future
+// change to the entries repairs itself on the next turn.
+func lefthookExcludeBlock() string {
+	// lefthook-local.yml is included because Entire creates it when absent and
+	// Lefthook documents it as a personal, uncommitted file. An exclude entry
+	// only affects untracked paths, so a repository that does commit it is
+	// unaffected by this.
+	return excludeBlockBegin +
+		"/" + entireLefthookConfig + "\n" +
+		"/" + lefthookScriptDir + "/\n" +
+		"/" + lefthookLocalConfigNames[0] + "\n" +
+		excludeBlockEnd
+}
+
+const (
+	// LefthookManagerName is how Lefthook is named in user-facing output and
+	// in HookDelivery.Manager; lefthookExtendsKey is Lefthook's own config key
+	// for pulling in another config file at run time.
+	LefthookManagerName = "Lefthook"
+	lefthookExtendsKey  = "extends"
+
+	gitExcludePath    = "info/exclude"
+	excludeBlockBegin = "# " + lefthookOwnedMarker + " begin\n"
+	excludeBlockEnd   = "# " + lefthookOwnedMarker + " end\n"
+)
+
+// excludeArtifacts adds Entire's generated files to the clone-local
+// .git/info/exclude. They are generated and per-clone, so they do not belong
+// in the user's .gitignore — and left unignored they make a dirty worktree the
+// normal state in every Lefthook repo, which eventually gets Entire's
+// integration files committed by an agent that sees them in git status.
+func excludeArtifacts(ctx context.Context, repoRoot string) error {
+	return rewriteExcludeBlock(ctx, repoRoot, lefthookExcludeBlock())
+}
+
+// rewriteExcludeBlock replaces Entire's marked block in .git/info/exclude with
+// block, which is empty on uninstall. Failing to open the git dir is not an
+// error: ignoring these files is a convenience, not part of the integration.
+func rewriteExcludeBlock(ctx context.Context, repoRoot, block string) error {
+	root, err := openGitCommonDir(ctx, repoRoot)
+	if err != nil {
+		return nil //nolint:nilerr // best effort: ignoring is a convenience
+	}
+	existing, err := osroot.ReadFileNoFollow(root, gitExcludePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read git exclude: %w", err)
+	}
+	body := string(existing)
+	if block != "" && strings.Contains(body, block) {
+		return nil
+	}
+	// Replace a previous block rather than appending a second one.
+	if i := strings.Index(body, excludeBlockBegin); i >= 0 {
+		if j := strings.Index(body[i:], excludeBlockEnd); j >= 0 {
+			body = body[:i] + body[i+j+len(excludeBlockEnd):]
+		} else {
+			return nil // an unterminated block is not ours to guess at
+		}
+	} else if block == "" {
+		return nil
+	}
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	if err := osroot.MkdirAllNoSymlink(root, "info", 0o755); err != nil {
+		return fmt.Errorf("create info dir: %w", err)
+	}
+	if err := jsonutil.WriteFileAtomicIn(root, gitExcludePath, []byte(body+block), 0o644); err != nil {
+		return fmt.Errorf("write git exclude: %w", err)
+	}
+	return nil
+}
+
+func openGitCommonDir(ctx context.Context, repoRoot string) (*os.Root, error) {
+	commonDir, err := gitdir.CommonDirForWorktree(ctx, repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve git common dir: %w", err)
+	}
+	root, err := gitdir.OpenAt(commonDir)
+	if err != nil {
+		return nil, fmt.Errorf("open git common dir: %w", err)
+	}
+	return root, nil
+}
+
+// LefthookIntegrationCurrent reports whether Entire's artifacts are present
+// and current: its config, the extends entry pointing at it, and every script.
+func LefthookIntegrationCurrent(ctx context.Context, absolutePath bool) (bool, error) {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return false, fmt.Errorf("resolve worktree root: %w", err)
+	}
+	root, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return false, fmt.Errorf("open worktree: %w", err)
+	}
+	want, err := renderOwnedConfig()
+	if err != nil {
+		return false, err
+	}
+	data, err := osroot.ReadFileNoFollow(root, entireLefthookConfig)
+	if err != nil || string(data) != want {
+		return false, nil //nolint:nilerr // a missing or stale config is "not current", not a failure
+	}
+	if !extendsEntryPresent(root) {
+		return false, nil
+	}
+	cmdPrefix, err := hookCmdPrefix(absolutePath)
+	if err != nil {
+		return false, err
+	}
+	for _, spec := range buildHookSpecs(cmdPrefix) {
+		content, err := osroot.ReadFileNoFollow(root, lefthookScriptPath(spec.name))
+		if err != nil || string(content) != renderLefthookScript(spec) {
+			return false, nil //nolint:nilerr // same: stale, not broken
+		}
+	}
+	// The exclude entry counts as part of the install. Without it every
+	// Lefthook worktree reads as dirty, and a repo that predates this check
+	// needs a repair pass to pick it up.
+	return artifactsExcluded(ctx, repoRoot), nil
+}
+
+// RemoveLefthookIntegration removes Entire's artifacts, returning the number
+// removed. Files without Entire's marker are left alone.
+func RemoveLefthookIntegration(ctx context.Context) (int, error) {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("resolve worktree root: %w", err)
+	}
+	root, err := worktreedir.OpenAt(repoRoot)
+	if err != nil {
+		return 0, fmt.Errorf("open worktree: %w", err)
+	}
+	removed := 0
+	for _, hook := range gitHookNames {
+		name := lefthookScriptPath(hook)
+		owned, err := fileIsOwned(root, name)
+		if err != nil || !owned {
+			continue // unreadable or not ours: leave it
+		}
+		if err := osroot.RemoveNoSymlinks(root, name); err != nil && !os.IsNotExist(err) {
+			return removed, fmt.Errorf("remove %s: %w", name, err)
+		}
+		removed++
+	}
+	if owned, ownErr := fileIsOwned(root, entireLefthookConfig); ownErr == nil && owned {
+		if err := osroot.RemoveNoSymlinks(root, entireLefthookConfig); err != nil && !os.IsNotExist(err) {
+			return removed, fmt.Errorf("remove %s: %w", entireLefthookConfig, err)
+		}
+		removed++
+	}
+	dropped, err := removeExtendsEntry(root)
+	if err != nil {
+		return removed, err
+	}
+	if dropped {
+		removed++
+	}
+	if err := rewriteExcludeBlock(ctx, repoRoot, ""); err != nil {
+		return removed, err
+	}
+	// Prune the directories the scripts lived in. RemoveNoSymlinks fails on a
+	// non-empty directory, which is exactly the guard wanted: anything the
+	// user put there keeps its parent alive.
+	for _, hook := range gitHookNames {
+		//nolint:errcheck // a non-empty directory is meant to survive
+		_ = osroot.RemoveNoSymlinks(root, filepath.ToSlash(filepath.Join(lefthookScriptDir, hook)))
+	}
+	//nolint:errcheck // same
+	_ = osroot.RemoveNoSymlinks(root, lefthookScriptDir)
+	return removed, nil
+}
+
+func lefthookScriptPath(hook string) string {
+	return filepath.ToSlash(filepath.Join(lefthookScriptDir, hook, lefthookScript))
+}
+
+// renderLefthookScript is the native hook body with Entire's marker swapped
+// for the Lefthook-owned one, so ownership is checkable and the two kinds of
+// artifact are never confused for each other.
+func renderLefthookScript(spec hookSpec) string {
+	return strings.Replace(spec.content,
+		"# "+entireHookMarker+"\n", "# "+lefthookOwnedMarker+"\n", 1)
+}
+
+func renderOwnedConfig() (string, error) {
+	hooks := map[string]any{}
+	for _, hook := range gitHookNames {
+		hooks[hook] = map[string]any{
+			"scripts": map[string]any{lefthookScript: map[string]any{"runner": "bash"}},
+		}
+	}
+	hooks["source_dir_local"] = lefthookScriptDir
+	out, err := yaml.Marshal(hooks)
+	if err != nil {
+		return "", fmt.Errorf("render %s: %w", entireLefthookConfig, err)
+	}
+	return "# " + lefthookOwnedMarker + "\n" +
+		"# Managed by Entire. Remove the extends entry in your Lefthook local\n" +
+		"# config to detach; edits here are overwritten.\n" + string(out), nil
+}
+
+func writeOwnedConfig(root *os.Root) (bool, error) {
+	content, err := renderOwnedConfig()
+	if err != nil {
+		return false, err
+	}
+	existing, readErr := osroot.ReadFileNoFollow(root, entireLefthookConfig)
+	if readErr == nil && string(existing) == content {
+		return false, nil
+	}
+	if err := jsonutil.WriteFileAtomicIn(root, entireLefthookConfig, []byte(content), 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", entireLefthookConfig, err)
+	}
+	return true, nil
+}
+
+func fileIsOwned(root *os.Root, name string) (bool, error) {
+	data, err := osroot.ReadFileNoFollow(root, name)
+	if err != nil {
+		return false, err //nolint:wrapcheck // callers only test the bool
+	}
+	return strings.Contains(string(data), lefthookOwnedMarker), nil
+}
+
+// displaceUnowned moves a file Entire did not write aside to <name>.pre-entire
+// before Entire claims the path, and refuses rather than bury an earlier
+// backup. Corruption destroys the marker, so without this a damaged script
+// would read as a foreign file and could never be repaired.
+func displaceUnowned(root *os.Root, name string, mode os.FileMode) error {
+	data, err := osroot.ReadFileNoFollow(root, name)
+	if err != nil || strings.Contains(string(data), lefthookOwnedMarker) {
+		return nil //nolint:nilerr // absent or ours: nothing to displace
+	}
+	backup := name + GitHookBackupSuffix
+	if _, err := osroot.ReadFileNoFollow(root, backup); err == nil {
+		return fmt.Errorf("%w: %s already exists; remove it to let Entire reinstall %s",
+			ErrLefthookArtifactBlocked, backup, name)
+	}
+	if err := jsonutil.WriteFileAtomicIn(root, backup, data, mode); err != nil {
+		return fmt.Errorf("back up %s: %w", name, err)
+	}
+	return nil
+}
+
+// findLocalConfig returns the local config Lefthook actually reads, its
+// contents, and whether Entire may write to it.
+func findLocalConfig(root *os.Root) (name string, data []byte, err error) {
+	for _, candidate := range lefthookLocalConfigNames {
+		body, readErr := osroot.ReadFileNoFollow(root, candidate)
+		if readErr != nil {
+			continue
+		}
+		if !strings.HasSuffix(candidate, ".yml") && !strings.HasSuffix(candidate, ".yaml") {
+			return candidate, body, fmt.Errorf("%w: %s", ErrLefthookLocalConfigUnwritable, candidate)
+		}
+		return candidate, body, nil
+	}
+	return lefthookLocalConfigNames[0], nil, nil
+}
+
+// ensureExtendsEntry adds one entry to the local config's `extends` sequence,
+// preserving everything else including comments. Returns the config written.
+func ensureExtendsEntry(root *os.Root) (string, error) {
+	name, existing, err := findLocalConfig(root)
+	if err != nil {
+		return name, err
+	}
+	doc, seq, err := extendsSequence(existing)
+	if err != nil {
+		return name, fmt.Errorf("%s: %w", name, err)
+	}
+	for _, item := range seq.Content {
+		if item.Value == entireLefthookConfig {
+			return name, nil
+		}
+	}
+	seq.Content = append(seq.Content, &yaml.Node{
+		Kind: yaml.ScalarNode, Tag: "!!str", Value: entireLefthookConfig,
+		LineComment: lefthookOwnedMarker,
+	})
+	out, err := encodeYAML(doc)
+	if err != nil {
+		return name, fmt.Errorf("%s: %w", name, err)
+	}
+	if err := jsonutil.WriteFileAtomicIn(root, name, out, 0o644); err != nil {
+		return name, fmt.Errorf("write %s: %w", name, err)
+	}
+	return name, nil
+}
+
+// extendsEntryPresent reports whether the local config already pulls in
+// Entire's config. An unwritable, absent or unparseable config has no entry.
+func extendsEntryPresent(root *os.Root) bool {
+	_, existing, err := findLocalConfig(root)
+	if err != nil || existing == nil {
+		return false
+	}
+	_, seq, err := extendsSequence(existing)
+	if err != nil {
+		return false
+	}
+	for _, item := range seq.Content {
+		if item.Value == entireLefthookConfig {
+			return true
+		}
+	}
+	return false
+}
+
+func removeExtendsEntry(root *os.Root) (bool, error) {
+	name, existing, err := findLocalConfig(root)
+	if err != nil || existing == nil {
+		return false, nil //nolint:nilerr // nothing of ours to remove
+	}
+	doc, seq, err := extendsSequence(existing)
+	if err != nil {
+		return false, nil //nolint:nilerr // unparseable: not our entry
+	}
+	kept := make([]*yaml.Node, 0, len(seq.Content))
+	changed := false
+	for _, item := range seq.Content {
+		if item.Value == entireLefthookConfig {
+			changed = true
+			continue
+		}
+		kept = append(kept, item)
+	}
+	if !changed {
+		return false, nil
+	}
+	seq.Content = kept
+	mapping := doc.Content[0]
+	if len(kept) == 0 {
+		for i := 0; i+1 < len(mapping.Content); i += 2 {
+			if mapping.Content[i].Value == lefthookExtendsKey {
+				mapping.Content = append(mapping.Content[:i], mapping.Content[i+2:]...)
+				break
+			}
+		}
+	}
+	// A file that held nothing but our entry is ours to delete.
+	if len(mapping.Content) == 0 {
+		if err := osroot.RemoveNoSymlinks(root, name); err != nil && !os.IsNotExist(err) {
+			return false, fmt.Errorf("remove %s: %w", name, err)
+		}
+		return true, nil
+	}
+	out, err := encodeYAML(doc)
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", name, err)
+	}
+	if err := jsonutil.WriteFileAtomicIn(root, name, out, 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", name, err)
+	}
+	return true, nil
+}
+
+// extendsSequence returns the document and its `extends` sequence, creating
+// the key when absent. Kept as yaml.Node rather than a struct because the
+// user's comments and key order must survive the round trip.
+func extendsSequence(existing []byte) (*yaml.Node, *yaml.Node, error) {
+	doc := &yaml.Node{}
+	if len(strings.TrimSpace(string(existing))) == 0 {
+		doc.Kind = yaml.DocumentNode
+		doc.Content = []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}
+	} else if err := yaml.Unmarshal(existing, doc); err != nil {
+		return nil, nil, fmt.Errorf("parse: %w", err)
+	}
+	if len(doc.Content) != 1 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, nil, errors.New("parse: top level must be a mapping")
+	}
+	mapping := doc.Content[0]
+	found := -1
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value != lefthookExtendsKey {
+			continue
+		}
+		if found >= 0 {
+			return nil, nil, errors.New("duplicate extends key")
+		}
+		found = i
+	}
+	if found >= 0 {
+		seq := mapping.Content[found+1]
+		if seq.Kind != yaml.SequenceNode {
+			return nil, nil, errors.New("extends must be a sequence")
+		}
+		return doc, seq, nil
+	}
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: lefthookExtendsKey}, seq)
+	return doc, seq, nil
+}
+
+func encodeYAML(doc *yaml.Node) ([]byte, error) {
+	var out strings.Builder
+	enc := yaml.NewEncoder(&out)
+	enc.SetIndent(2)
+	if err := enc.Encode(doc); err != nil {
+		return nil, fmt.Errorf("encode: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("encode: %w", err)
+	}
+	return []byte(out.String()), nil
+}
+
+// lefthookLauncherMarker appears in every hook file Lefthook generates. It is
+// how Entire recognises a hook path Lefthook has taken over.
+const lefthookLauncherMarker = "call_lefthook"
+
+// reconcileHookFiles hands .git/hooks/* back to Lefthook and clears the
+// wreckage of the era when the two fought over those files.
+//
+// Once Entire is registered in Lefthook's config, Lefthook's own hook runs
+// Entire. Entire owning the hook file as well means the hook runs Entire
+// TWICE — its own copy, then Lefthook's launcher via the chain call — so where
+// Lefthook's launcher is sitting in Entire's backup it is moved back over
+// Entire's hook. installSkipsHook then leaves that path alone.
+//
+// The <hook>.old files are not merely untidy: Lefthook refuses to move a hook
+// aside when its backup already exists, and reports "could not replace the
+// hook: can't rename pre-push to pre-push.old - file already exists" on every
+// sync until it is gone. That error outlives this fix unless cleared, and
+// every repo the fight has already touched is in exactly that state.
+//
+// Nothing is touched unless its contents prove whose it was.
+func reconcileHookFiles(ctx context.Context, repoRoot string) error {
+	hooksDir, err := getHooksDirInPath(ctx, repoRoot)
+	if err != nil {
+		return nil //nolint:nilerr // best effort: no hooks dir, nothing to do
+	}
+	root, err := hooksRootForRemoval(hooksDir)
+	if err != nil {
+		return nil //nolint:nilerr // same
+	}
+	for _, hook := range gitHookNames {
+		backup := hook + GitHookBackupSuffix
+		if fileContains(root, backup, lefthookLauncherMarker) && fileContains(root, hook, entireHookMarker) {
+			if err := root.Rename(backup, hook); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("restore %s: %w", hook, err)
+			}
+			continue
+		}
+		// What Lefthook displaced, back when Entire owned the file.
+		stale := hook + ".old"
+		if !fileContains(root, stale, entireHookMarker) {
+			continue
+		}
+		if err := osroot.RemoveNoSymlinks(root, stale); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove stale backup %s: %w", stale, err)
+		}
+	}
+	return nil
+}
+
+func fileContains(root *os.Root, name, marker string) bool {
+	data, err := osroot.ReadFileNoFollow(root, name)
+	return err == nil && strings.Contains(string(data), marker)
+}
+
+// installSkipsHook reports whether InstallGitHook should leave a hook file
+// alone because Lefthook owns it and already dispatches Entire from its own
+// config. Writing Entire's hook over Lefthook's launcher would both run Entire
+// twice and stop the user's own Lefthook commands until Lefthook's next sync.
+//
+// A hook Lefthook has not taken over is installed normally: in a repo where
+// nobody has run `lefthook install` yet, Entire's own hooks are the only
+// delivery there is.
+func installSkipsHook(root *os.Root, hook string, lefthookDelivers bool) bool {
+	return lefthookDelivers && fileContains(root, hook, lefthookLauncherMarker)
+}
+
+// lefthookDeliversHooks reports whether Lefthook will run Entire from its own
+// configuration, which is what makes Entire's own hook files redundant.
+func lefthookDeliversHooks(ctx context.Context, absolutePath bool) bool {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil || !LefthookManaged(repoRoot) {
+		return false
+	}
+	current, err := LefthookIntegrationCurrent(ctx, absolutePath)
+	return err == nil && current
+}
+
+// HookDelivery describes whether Entire's Git hooks will actually fire.
+type HookDelivery struct {
+	// OK is true when capture and delivery are wired up.
+	OK bool
+	// Manager names the hook manager that owns the hook files, if any.
+	Manager string
+	// Reason explains a false OK, ready to show a user.
+	Reason string
+}
+
+// CheckHookDelivery reports whether Entire's hooks will fire in this
+// repository. This is the question `entire status` was answering wrongly in
+// #2264: it reported a checkpoint destination while no hook existed to reach
+// it. There is no network access and no mutation.
+//
+// A Lefthook repo is judged on the integration, not on .git/hooks/*: Lefthook
+// owns those files and rewrites them constantly, so their contents say nothing
+// about whether Entire will run.
+func CheckHookDelivery(ctx context.Context, absolutePath bool) HookDelivery {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return HookDelivery{Reason: "Could not resolve the repository root."}
+	}
+	if LefthookManaged(repoRoot) {
+		current, checkErr := LefthookIntegrationCurrent(ctx, absolutePath)
+		switch {
+		case checkErr != nil:
+			return HookDelivery{Manager: LefthookManagerName,
+				Reason: fmt.Sprintf("Could not inspect Entire's Lefthook integration: %v", checkErr)}
+		case current:
+			return HookDelivery{OK: true, Manager: LefthookManagerName}
+		default:
+			return HookDelivery{Manager: LefthookManagerName,
+				Reason: "Entire is not registered with Lefthook, so Lefthook's hooks do not run it."}
+		}
+	}
+	switch CheckGitHookState(ctx) {
+	case GitHooksCurrent:
+		return HookDelivery{OK: true}
+	case GitHooksOutdated:
+		return HookDelivery{Reason: "Entire's Git hooks are outdated."}
+	case GitHooksAbsent:
+	}
+	return HookDelivery{Reason: "Entire's Git hooks are not installed."}
+}

--- a/cmd/entire/cli/strategy/lefthook_test.go
+++ b/cmd/entire/cli/strategy/lefthook_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
 	"github.com/stretchr/testify/require"
 )
 
@@ -228,7 +229,7 @@ func TestEnsureLefthookIntegration_ReconcilesHookFiles(t *testing.T) {
 	hooksDir := filepath.Join(dir, ".git", "hooks")
 	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
 
-	launcher := []byte("#!/bin/sh\ncall_lefthook run \"pre-push\" \"$@\"\n")
+	launcher := lefthookLauncher("pre-push")
 	entireHook := []byte("#!/bin/sh\n# " + entireHookMarker + "\nentire hooks git pre-push \"$1\"\n")
 	write := func(name string, body []byte) {
 		require.NoError(t, os.WriteFile(filepath.Join(hooksDir, name), body, 0o755))
@@ -277,21 +278,51 @@ func TestEnsureLefthookIntegration_ReconcilesHookFiles(t *testing.T) {
 		"a hook Lefthook has not taken over is still Entire's to install")
 }
 
-// Delivery is judged on the integration in a Lefthook repo, because Lefthook
-// owns .git/hooks/* and rewrites them constantly.
+// Delivery in a Lefthook repo is judged on the integration rather than on the
+// contents of .git/hooks/*, which Lefthook owns and rewrites — but it still
+// takes a hook FILE to exist, because that is what git runs. Lefthook creates
+// one per hook it knew about at its last install, so a repo whose lefthook.yml
+// declares only pre-commit has none for the rest, and every artifact Entire
+// owns can be present and correct while nothing dispatches Entire at all.
 func TestCheckHookDelivery_Lefthook(t *testing.T) {
-	newLefthookRepo(t, "")
+	dir := newLefthookRepo(t, "")
 	got := CheckHookDelivery(t.Context(), false)
 	require.False(t, got.OK, "not registered yet")
-	require.Equal(t, "Lefthook", got.Manager)
+	require.Equal(t, LefthookManagerName, got.Manager)
 	require.NotEmpty(t, got.Reason)
 
 	_, err := EnsureLefthookIntegration(t.Context(), false)
 	require.NoError(t, err)
+
+	// Registered, but no hook file exists for any hook yet.
 	got = CheckHookDelivery(t.Context(), false)
-	require.True(t, got.OK)
-	require.Equal(t, "Lefthook", got.Manager)
+	require.False(t, got.OK, "a registration nothing triggers is not delivery")
+	require.Equal(t, LefthookManagerName, got.Manager)
+	for _, hook := range gitHookNames {
+		require.Contains(t, got.Reason, hook)
+	}
+
+	// Lefthook owns one hook; Entire's own hooks cover the rest. Both reach
+	// Entire, so both count.
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(hooksDir, "pre-commit"), lefthookLauncher("pre-commit"), 0o755))
+	ClearHooksDirCache()
+	_, err = ReinstallGitHooks(t.Context())
+	require.NoError(t, err)
+	ClearHooksDirCache()
+
+	got = CheckHookDelivery(t.Context(), false)
+	require.True(t, got.OK, "reason: %s", got.Reason)
+	require.Equal(t, LefthookManagerName, got.Manager)
 	require.Empty(t, got.Reason)
+
+	// A hook file that belongs to neither is not delivery either.
+	require.NoError(t, os.WriteFile(filepath.Join(hooksDir, "pre-push"),
+		[]byte("#!/bin/sh\necho someone else\n"), 0o755))
+	got = CheckHookDelivery(t.Context(), false)
+	require.False(t, got.OK)
+	require.Contains(t, got.Reason, "pre-push")
 }
 
 // In a repo with no hook manager, delivery is the native hook state.
@@ -428,8 +459,7 @@ func TestInstallGitHook_ReportsLefthookDeliveryInsteadOfAFalseInstall(t *testing
 	hooksDir := filepath.Join(dir, ".git", "hooks")
 	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
 	for _, hook := range gitHookNames {
-		require.NoError(t, os.WriteFile(filepath.Join(hooksDir, hook),
-			[]byte("#!/bin/sh\ncall_lefthook run \""+hook+"\" \"$@\"\n"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(hooksDir, hook), lefthookLauncher(hook), 0o755))
 	}
 	ClearHooksDirCache()
 
@@ -479,4 +509,48 @@ func TestCheckHookDelivery_DeclinedLefthookConfigFallsBackToNativeHooks(t *testi
 	require.True(t, got.OK, "Entire's own hooks deliver here")
 	require.Empty(t, got.Manager)
 	require.Equal(t, "lefthook-local.toml", got.Declined, "and the reason why is still reported")
+}
+
+// lefthookLauncher is shaped like the hook Lefthook 2.1.10 generates: a
+// call_lefthook shell function, then a dispatch of this hook through it.
+func lefthookLauncher(hook string) []byte {
+	return []byte("#!/bin/sh\n" +
+		"if [ \"$LEFTHOOK\" = \"0\" ]; then\n  exit 0\nfi\n" +
+		"call_lefthook()\n{\n  lefthook \"$@\"\n}\n\n" +
+		"call_lefthook run \"" + hook + "\" \"$@\"\n")
+}
+
+// Misreading a hook as Lefthook's is silent and permanent — reconcileHookFiles
+// restores it over Entire's and installSkipsHook then skips it forever — so
+// recognition is structural, not a search for the word "lefthook".
+func TestIsLefthookLauncher(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := worktreedir.OpenAt(dir)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name string
+		body []byte
+		want bool
+	}{
+		{"lefthook's own launcher", lefthookLauncher("pre-push"), true},
+		{"a launcher for another hook", lefthookLauncher("pre-commit"), false},
+		{"a hand-written hook that runs lefthook",
+			[]byte("#!/bin/sh\n# call_lefthook when staged\nexec lefthook run pre-push \"$@\"\n"), false},
+		{"a hook that only names the function",
+			[]byte("#!/bin/sh\ncall_lefthook run \"pre-push\" \"$@\"\n"), false},
+		{"Entire's own hook", []byte("#!/bin/sh\n# " + entireHookMarker + "\nentire hooks git pre-push\n"), false},
+		{"absent", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			name := "hook-" + strings.ReplaceAll(tc.name, " ", "-")
+			if tc.body != nil {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, name), tc.body, 0o755))
+			}
+			require.Equal(t, tc.want, isLefthookLauncher(root, name, "pre-push"))
+		})
+	}
 }

--- a/cmd/entire/cli/strategy/lefthook_test.go
+++ b/cmd/entire/cli/strategy/lefthook_test.go
@@ -1,0 +1,428 @@
+package strategy
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// newLefthookRepo is an isolated repository that looks Lefthook-managed.
+// mainConfig names its Lefthook config; empty means lefthook.yml.
+func newLefthookRepo(t *testing.T, mainConfig string) string {
+	t.Helper()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	if mainConfig == "" {
+		mainConfig = "lefthook.yml"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, mainConfig), []byte("pre-commit: {}\n"), 0o644))
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	return dir
+}
+
+// Install writes Entire's own config, one extends entry, and a script per
+// hook — and nothing into Lefthook's own config.
+func TestEnsureLefthookIntegration(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	mainBefore, err := os.ReadFile(filepath.Join(dir, "lefthook.yml"))
+	require.NoError(t, err)
+
+	written, err := EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	require.Positive(t, written)
+
+	owned, err := os.ReadFile(filepath.Join(dir, entireLefthookConfig))
+	require.NoError(t, err)
+	require.Contains(t, string(owned), lefthookOwnedMarker)
+	require.Contains(t, string(owned), "source_dir_local: "+lefthookScriptDir)
+
+	local, err := os.ReadFile(filepath.Join(dir, "lefthook-local.yml"))
+	require.NoError(t, err)
+	require.Contains(t, string(local), entireLefthookConfig)
+	require.Equal(t, 1, strings.Count(string(local), entireLefthookConfig))
+
+	for _, hook := range gitHookNames {
+		script, err := os.ReadFile(filepath.Join(dir, lefthookScriptPath(hook)))
+		require.NoError(t, err, hook)
+		require.Contains(t, string(script), lefthookOwnedMarker, hook)
+		require.Contains(t, string(script), "hooks git "+hook, hook)
+		info, err := os.Stat(filepath.Join(dir, lefthookScriptPath(hook)))
+		require.NoError(t, err)
+		require.NotZero(t, info.Mode().Perm()&0o111, "%s must be executable", hook)
+	}
+
+	mainAfter, err := os.ReadFile(filepath.Join(dir, "lefthook.yml"))
+	require.NoError(t, err)
+	require.Equal(t, mainBefore, mainAfter, "Lefthook's own config must not be touched")
+
+	current, err := LefthookIntegrationCurrent(t.Context(), false)
+	require.NoError(t, err)
+	require.True(t, current)
+
+	// Repeat installs are no-ops.
+	written, err = EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	require.Zero(t, written)
+}
+
+// Entire never reads Lefthook's main config, so its format and location are
+// irrelevant — .toml and .config/ repos work like any other.
+func TestEnsureLefthookIntegration_MainConfigFormatIsIrrelevant(t *testing.T) {
+	for _, name := range []string{"lefthook.toml", "lefthook.json", ".lefthook.yaml"} {
+		t.Run(name, func(t *testing.T) {
+			newLefthookRepo(t, name)
+			_, err := EnsureLefthookIntegration(t.Context(), false)
+			require.NoError(t, err)
+			current, err := LefthookIntegrationCurrent(t.Context(), false)
+			require.NoError(t, err)
+			require.True(t, current)
+		})
+	}
+}
+
+// The extends entry goes into the user's local config without disturbing it.
+func TestEnsureLefthookIntegration_PreservesLocalConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name, local string
+		want        []string
+	}{
+		{"existing content", "# keep me\npre-commit:\n  commands:\n    mine:\n      run: true\n",
+			[]string{"# keep me", "mine"}},
+		{"existing extends", "extends:\n  - user.yml\n", []string{"user.yml"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := newLefthookRepo(t, "")
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "lefthook-local.yml"), []byte(tc.local), 0o644))
+			_, err := EnsureLefthookIntegration(t.Context(), false)
+			require.NoError(t, err)
+
+			got, err := os.ReadFile(filepath.Join(dir, "lefthook-local.yml"))
+			require.NoError(t, err)
+			require.Contains(t, string(got), entireLefthookConfig)
+			for _, want := range tc.want {
+				require.Contains(t, string(got), want)
+			}
+		})
+	}
+}
+
+// lefthook-local.yml takes precedence over lefthook-local.toml, so creating
+// the former beside a user's latter would silently stop their hooks running.
+func TestEnsureLefthookIntegration_RefusesToShadowANonYAMLLocalConfig(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	tomlPath := filepath.Join(dir, "lefthook-local.toml")
+	original := []byte("[pre-commit.commands.mine]\nrun = \"true\"\n")
+	require.NoError(t, os.WriteFile(tomlPath, original, 0o644))
+
+	_, err := EnsureLefthookIntegration(t.Context(), false)
+	require.ErrorIs(t, err, ErrLefthookLocalConfigUnwritable)
+
+	after, err := os.ReadFile(tomlPath)
+	require.NoError(t, err)
+	require.Equal(t, original, after)
+	_, statErr := os.Stat(filepath.Join(dir, "lefthook-local.yml"))
+	require.True(t, os.IsNotExist(statErr), "must not create a shadowing lefthook-local.yml")
+}
+
+// A file Entire did not write is displaced, never destroyed. Corruption
+// destroys the marker, so a damaged script would otherwise read as foreign and
+// could never be repaired.
+func TestEnsureLefthookIntegration_DisplacesUnownedFiles(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	scriptPath := filepath.Join(dir, lefthookScriptPath("pre-push"))
+	require.NoError(t, os.MkdirAll(filepath.Dir(scriptPath), 0o755))
+	theirs := []byte("#!/bin/sh\necho mine\n")
+	require.NoError(t, os.WriteFile(scriptPath, theirs, 0o755))
+	configPath := filepath.Join(dir, entireLefthookConfig)
+	theirConfig := []byte("# not Entire's\nkey: value\n")
+	require.NoError(t, os.WriteFile(configPath, theirConfig, 0o644))
+
+	_, err := EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+
+	backup, err := os.ReadFile(scriptPath + GitHookBackupSuffix)
+	require.NoError(t, err, "the displaced script must be kept")
+	require.Equal(t, theirs, backup)
+	backup, err = os.ReadFile(configPath + GitHookBackupSuffix)
+	require.NoError(t, err, "the displaced config must be kept")
+	require.Equal(t, theirConfig, backup)
+
+	current, err := LefthookIntegrationCurrent(t.Context(), false)
+	require.NoError(t, err)
+	require.True(t, current, "and Entire's own artifacts installed over them")
+}
+
+// Uninstall takes only what Entire wrote.
+func TestRemoveLefthookIntegration(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	localPath := filepath.Join(dir, "lefthook-local.yml")
+	require.NoError(t, os.WriteFile(localPath, []byte("pre-commit:\n  commands:\n    mine:\n      run: true\n"), 0o644))
+	_, err := EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+
+	removed, err := RemoveLefthookIntegration(t.Context())
+	require.NoError(t, err)
+	require.Positive(t, removed)
+
+	_, statErr := os.Stat(filepath.Join(dir, entireLefthookConfig))
+	require.True(t, os.IsNotExist(statErr))
+	local, err := os.ReadFile(localPath)
+	require.NoError(t, err, "the user's local config must survive")
+	require.NotContains(t, string(local), entireLefthookConfig)
+	require.Contains(t, string(local), "mine")
+
+	current, err := LefthookIntegrationCurrent(t.Context(), false)
+	require.NoError(t, err)
+	require.False(t, current)
+}
+
+// A foreign file at Entire's config path is not Entire's to delete.
+func TestRemoveLefthookIntegration_LeavesForeignFiles(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	configPath := filepath.Join(dir, entireLefthookConfig)
+	theirs := []byte("# not Entire's\nkey: value\n")
+	require.NoError(t, os.WriteFile(configPath, theirs, 0o644))
+
+	_, err := RemoveLefthookIntegration(t.Context())
+	require.NoError(t, err)
+	after, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.Equal(t, theirs, after)
+}
+
+// Two kinds of wreckage from the era when Entire and Lefthook fought over
+// .git/hooks/*: Entire's hook chaining to Lefthook's displaced launcher (which
+// runs Entire twice now that Lefthook dispatches it), and the <hook>.old
+// backups that make Lefthook fail every later sync (#1349).
+func TestEnsureLefthookIntegration_ReconcilesHookFiles(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+	launcher := []byte("#!/bin/sh\ncall_lefthook run \"pre-push\" \"$@\"\n")
+	entireHook := []byte("#!/bin/sh\n# " + entireHookMarker + "\nentire hooks git pre-push \"$1\"\n")
+	write := func(name string, body []byte) {
+		require.NoError(t, os.WriteFile(filepath.Join(hooksDir, name), body, 0o755))
+	}
+	write("pre-push", entireHook)
+	write("pre-push"+GitHookBackupSuffix, launcher)
+	write("commit-msg.old", entireHook)
+	// Another tool's backup, and a foreign hook Entire displaced: neither is
+	// Entire's to touch.
+	theirs := []byte("#!/bin/sh\necho someone else\n")
+	write("post-commit.old", theirs)
+	write("post-rewrite"+GitHookBackupSuffix, theirs)
+
+	_, err := EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(hooksDir, "pre-push"))
+	require.NoError(t, err)
+	require.Equal(t, launcher, got, "Lefthook's launcher must be restored over Entire's hook")
+	_, statErr := os.Stat(filepath.Join(hooksDir, "pre-push"+GitHookBackupSuffix))
+	require.True(t, os.IsNotExist(statErr), "the backup is consumed by the restore")
+
+	_, statErr = os.Stat(filepath.Join(hooksDir, "commit-msg.old"))
+	require.True(t, os.IsNotExist(statErr), "Entire's stale wrapper backup must be cleared")
+
+	for name, want := range map[string][]byte{
+		"post-commit.old":                    theirs,
+		"post-rewrite" + GitHookBackupSuffix: theirs,
+	} {
+		got, err := os.ReadFile(filepath.Join(hooksDir, name))
+		require.NoError(t, err, name)
+		require.Equal(t, want, got, "%s belongs to someone else", name)
+	}
+
+	// And the native install leaves the yielded hook alone rather than
+	// clobbering the launcher and running Entire twice.
+	ClearHooksDirCache()
+	_, err = ReinstallGitHooks(t.Context())
+	require.NoError(t, err)
+	got, err = os.ReadFile(filepath.Join(hooksDir, "pre-push"))
+	require.NoError(t, err)
+	require.Equal(t, launcher, got, "InstallGitHook must skip a hook Lefthook owns")
+	got, err = os.ReadFile(filepath.Join(hooksDir, "post-commit"))
+	require.NoError(t, err)
+	require.Contains(t, string(got), entireHookMarker,
+		"a hook Lefthook has not taken over is still Entire's to install")
+}
+
+// Delivery is judged on the integration in a Lefthook repo, because Lefthook
+// owns .git/hooks/* and rewrites them constantly.
+func TestCheckHookDelivery_Lefthook(t *testing.T) {
+	newLefthookRepo(t, "")
+	got := CheckHookDelivery(t.Context(), false)
+	require.False(t, got.OK, "not registered yet")
+	require.Equal(t, "Lefthook", got.Manager)
+	require.NotEmpty(t, got.Reason)
+
+	_, err := EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	got = CheckHookDelivery(t.Context(), false)
+	require.True(t, got.OK)
+	require.Equal(t, "Lefthook", got.Manager)
+	require.Empty(t, got.Reason)
+}
+
+// In a repo with no hook manager, delivery is the native hook state.
+func TestCheckHookDelivery_Native(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	ClearHooksDirCache()
+
+	got := CheckHookDelivery(t.Context(), false)
+	require.False(t, got.OK)
+	require.Empty(t, got.Manager)
+
+	if _, err := ReinstallGitHooks(t.Context()); err != nil {
+		t.Fatalf("ReinstallGitHooks: %v", err)
+	}
+	ClearHooksDirCache()
+	got = CheckHookDelivery(t.Context(), false)
+	require.True(t, got.OK)
+	require.Empty(t, got.Manager)
+}
+
+// Entire's artifacts are generated and per-clone, so they go in
+// .git/info/exclude rather than the user's .gitignore — and a stale block from
+// an earlier version is rewritten rather than appended to.
+func TestEnsureLefthookIntegration_ExcludesArtifacts(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	excludePath := filepath.Join(dir, ".git", "info", "exclude")
+	require.NoError(t, os.MkdirAll(filepath.Dir(excludePath), 0o755))
+	require.NoError(t, os.WriteFile(excludePath,
+		[]byte("# user's own\n/scratch\n"+excludeBlockBegin+"/stale-entry\n"+excludeBlockEnd), 0o644))
+
+	_, err := EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(excludePath)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "/scratch", "the user's own entries must survive")
+	require.NotContains(t, string(got), "/stale-entry", "the previous block must be replaced")
+	require.Equal(t, 1, strings.Count(string(got), excludeBlockBegin), "exactly one block")
+	for _, entry := range []string{
+		"/" + entireLefthookConfig,
+		"/" + lefthookScriptDir + "/",
+		"/" + lefthookLocalConfigNames[0],
+	} {
+		require.Contains(t, string(got), entry+"\n")
+	}
+
+	// An install that predates an entry is not "current", so it repairs itself.
+	require.NoError(t, os.WriteFile(excludePath,
+		[]byte(excludeBlockBegin+"/"+entireLefthookConfig+"\n"+excludeBlockEnd), 0o644))
+	current, err := LefthookIntegrationCurrent(t.Context(), false)
+	require.NoError(t, err)
+	require.False(t, current, "a partial exclude block must trigger a repair")
+
+	_, err = EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	current, err = LefthookIntegrationCurrent(t.Context(), false)
+	require.NoError(t, err)
+	require.True(t, current)
+
+	// Uninstall takes the block back out and leaves the user's entries.
+	_, err = RemoveLefthookIntegration(t.Context())
+	require.NoError(t, err)
+	got, err = os.ReadFile(excludePath)
+	require.NoError(t, err)
+	require.NotContains(t, string(got), excludeBlockBegin)
+	require.NotContains(t, string(got), entireLefthookConfig)
+
+	// And the script directory it created, since nothing else is in it.
+	_, statErr := os.Stat(filepath.Join(dir, lefthookScriptDir))
+	require.True(t, os.IsNotExist(statErr), "the empty script dir must be pruned")
+}
+
+// Entire creates lefthook-local.yml itself, so it must never be the thing that
+// makes a repo look Lefthook-managed — otherwise removing Lefthook leaves
+// status claiming delivery "via Lefthook" with nothing running Entire.
+func TestLefthookManaged(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		file string
+		want bool
+	}{
+		{"lefthook.yml", true},
+		{".lefthook.yaml", true},
+		{"lefthook.toml", true},
+		{"lefthook-local.yml", false},
+		{".lefthook-local.toml", false},
+		{"package.json", false},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, tc.file), []byte(""), 0o644))
+			require.Equal(t, tc.want, LefthookManaged(dir))
+		})
+	}
+}
+
+// Entire will not bury an existing backup to claim a path: that backup is the
+// only copy of whatever was displaced before.
+func TestEnsureLefthookIntegration_RefusesToBuryABackup(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	scriptPath := filepath.Join(dir, lefthookScriptPath("pre-push"))
+	require.NoError(t, os.MkdirAll(filepath.Dir(scriptPath), 0o755))
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\necho newer\n"), 0o755))
+	older := []byte("#!/bin/sh\necho older\n")
+	require.NoError(t, os.WriteFile(scriptPath+GitHookBackupSuffix, older, 0o755))
+
+	_, err := EnsureLefthookIntegration(t.Context(), false)
+	require.ErrorIs(t, err, ErrLefthookArtifactBlocked)
+
+	got, err := os.ReadFile(scriptPath + GitHookBackupSuffix)
+	require.NoError(t, err)
+	require.Equal(t, older, got, "the existing backup must be untouched")
+}
+
+// A visible install that installed nothing must not claim otherwise.
+func TestInstallGitHook_ReportsLefthookDeliveryInsteadOfAFalseInstall(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	_, err := EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	for _, hook := range gitHookNames {
+		require.NoError(t, os.WriteFile(filepath.Join(hooksDir, hook),
+			[]byte("#!/bin/sh\ncall_lefthook run \""+hook+"\" \"$@\"\n"), 0o755))
+	}
+	ClearHooksDirCache()
+
+	out := captureStdout(t, func() {
+		_, err := InstallGitHook(t.Context(), false, false)
+		require.NoError(t, err)
+	})
+	require.Contains(t, out, "run through Lefthook")
+	require.NotContains(t, out, "Installed git hooks")
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	saved := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = saved }()
+	fn()
+	require.NoError(t, w.Close())
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(data)
+}

--- a/cmd/entire/cli/strategy/lefthook_test.go
+++ b/cmd/entire/cli/strategy/lefthook_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,9 @@ func newLefthookRepo(t *testing.T, mainConfig string) string {
 		paths.ClearWorktreeRootCache()
 		ClearHooksDirCache()
 		clearGitCommonDirCache()
+		// PathIsTracked memoizes per (root, path) for the process, and these
+		// tests change a file's tracked state inside one.
+		settings.ClearVersionedPathCache()
 		// osroot.Shared memoizes a *os.Root per directory, and an open handle
 		// keeps Windows from deleting the directory under it — t.TempDir's
 		// own cleanup then fails with "used by another process" on .git.
@@ -503,7 +507,7 @@ func TestCheckHookDelivery_DeclinedLefthookConfigFallsBackToNativeHooks(t *testi
 	got := CheckHookDelivery(t.Context(), false)
 	require.False(t, got.OK, "no hooks installed yet")
 	require.Empty(t, got.Manager, "Lefthook is not the one delivering")
-	require.Equal(t, "lefthook-local.toml", got.Declined)
+	require.Equal(t, "lefthook-local.toml is not YAML", got.Declined)
 	require.Contains(t, got.Reason, "not installed", "the reason must be the native one")
 
 	_, err := ReinstallGitHooks(t.Context())
@@ -513,7 +517,7 @@ func TestCheckHookDelivery_DeclinedLefthookConfigFallsBackToNativeHooks(t *testi
 	got = CheckHookDelivery(t.Context(), false)
 	require.True(t, got.OK, "Entire's own hooks deliver here")
 	require.Empty(t, got.Manager)
-	require.Equal(t, "lefthook-local.toml", got.Declined, "and the reason why is still reported")
+	require.Equal(t, "lefthook-local.toml is not YAML", got.Declined, "and the reason why is still reported")
 }
 
 // lefthookLauncher is shaped like the hook Lefthook 2.1.10 generates: a
@@ -558,4 +562,39 @@ func TestIsLefthookLauncher(t *testing.T) {
 			require.Equal(t, tc.want, isLefthookLauncher(root, name, "pre-push"))
 		})
 	}
+}
+
+// Lefthook documents lefthook-local.* as personal and gitignored. A tracked
+// one is the team's file: adding Entire's entry modifies something shared, and
+// a developer who reverts it gets it back next turn. Entire declines instead —
+// but only when it would actually add the entry, so a config that already
+// carries it (committed, or added by hand) is honoured.
+func TestEnsureLefthookIntegration_TrackedLocalConfig(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	localPath := filepath.Join(dir, "lefthook-local.yml")
+	original := []byte("pre-commit:\n  commands:\n    ours:\n      run: true\n")
+	require.NoError(t, os.WriteFile(localPath, original, 0o644))
+	testutil.GitAdd(t, dir, "lefthook-local.yml")
+	testutil.GitCommit(t, dir, "team config")
+
+	_, err := EnsureLefthookIntegration(t.Context(), false)
+	require.ErrorIs(t, err, ErrLefthookLocalConfigTracked)
+
+	after, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+	require.Equal(t, original, after, "a tracked config must not be modified")
+
+	got := CheckHookDelivery(t.Context(), false)
+	require.Empty(t, got.Manager, "Lefthook is not the one delivering")
+	require.Equal(t, "lefthook-local.yml is tracked by git", got.Declined)
+
+	// Once the entry is there — committed by the team, or added by hand —
+	// Entire has nothing to write and the integration proceeds.
+	require.NoError(t, os.WriteFile(localPath,
+		append([]byte("extends:\n  - "+entireLefthookConfig+"\n"), original...), 0o644))
+	_, err = EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	current, err := LefthookIntegrationCurrent(t.Context(), false)
+	require.NoError(t, err)
+	require.True(t, current)
 }

--- a/cmd/entire/cli/strategy/lefthook_test.go
+++ b/cmd/entire/cli/strategy/lefthook_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/worktreedir"
@@ -27,14 +28,18 @@ func newLefthookRepo(t *testing.T, mainConfig string) string {
 	// Both caches are process-global and keyed by the directory this test just
 	// left, so a stale entry would point the hooks-dir and common-dir lookups
 	// at another test's repository.
-	paths.ClearWorktreeRootCache()
-	ClearHooksDirCache()
-	clearGitCommonDirCache()
-	t.Cleanup(func() {
+	reset := func() {
 		paths.ClearWorktreeRootCache()
 		ClearHooksDirCache()
 		clearGitCommonDirCache()
-	})
+		// osroot.Shared memoizes a *os.Root per directory, and an open handle
+		// keeps Windows from deleting the directory under it — t.TempDir's
+		// own cleanup then fails with "used by another process" on .git.
+		// Registered after t.TempDir, so LIFO runs this first.
+		osroot.ResetShared()
+	}
+	reset()
+	t.Cleanup(reset)
 	return dir
 }
 

--- a/cmd/entire/cli/strategy/lefthook_test.go
+++ b/cmd/entire/cli/strategy/lefthook_test.go
@@ -23,8 +23,17 @@ func newLefthookRepo(t *testing.T, mainConfig string) string {
 	}
 	require.NoError(t, os.WriteFile(filepath.Join(dir, mainConfig), []byte("pre-commit: {}\n"), 0o644))
 	t.Chdir(dir)
+	// Both caches are process-global and keyed by the directory this test just
+	// left, so a stale entry would point the hooks-dir and common-dir lookups
+	// at another test's repository.
 	paths.ClearWorktreeRootCache()
-	t.Cleanup(paths.ClearWorktreeRootCache)
+	ClearHooksDirCache()
+	clearGitCommonDirCache()
+	t.Cleanup(func() {
+		paths.ClearWorktreeRootCache()
+		ClearHooksDirCache()
+		clearGitCommonDirCache()
+	})
 	return dir
 }
 

--- a/cmd/entire/cli/strategy/lefthook_test.go
+++ b/cmd/entire/cli/strategy/lefthook_test.go
@@ -128,8 +128,20 @@ func TestEnsureLefthookIntegration_RefusesToShadowANonYAMLLocalConfig(t *testing
 	after, err := os.ReadFile(tomlPath)
 	require.NoError(t, err)
 	require.Equal(t, original, after)
-	_, statErr := os.Stat(filepath.Join(dir, "lefthook-local.yml"))
-	require.True(t, os.IsNotExist(statErr), "must not create a shadowing lefthook-local.yml")
+
+	// Declining must leave the repo untouched. Writing the artifacts first and
+	// only then failing left them untracked and un-excluded — and the refusal
+	// is a decision rather than a transient failure, so every turn rewrote
+	// them and none of them ever reached excludeArtifacts.
+	for _, path := range []string{
+		"lefthook-local.yml",
+		entireLefthookConfig,
+		lefthookScriptDir,
+		lefthookScriptPath("pre-push"),
+	} {
+		_, statErr := os.Stat(filepath.Join(dir, path))
+		require.True(t, os.IsNotExist(statErr), "%s must not be created", path)
+	}
 }
 
 // A file Entire did not write is displaced, never destroyed. Corruption
@@ -389,6 +401,13 @@ func TestEnsureLefthookIntegration_RefusesToBuryABackup(t *testing.T) {
 	got, err := os.ReadFile(scriptPath + GitHookBackupSuffix)
 	require.NoError(t, err)
 	require.Equal(t, older, got, "the existing backup must be untouched")
+
+	// This failure stops the install part way through, so whatever it did
+	// manage to write must already be excluded.
+	exclude, err := os.ReadFile(filepath.Join(dir, ".git", "info", "exclude"))
+	require.NoError(t, err)
+	require.Contains(t, string(exclude), lefthookExcludeBlock(),
+		"a partial install must not leave unignored artifacts")
 }
 
 // A visible install that installed nothing must not claim otherwise.
@@ -425,4 +444,30 @@ func captureStdout(t *testing.T, fn func()) string {
 	data, err := io.ReadAll(r)
 	require.NoError(t, err)
 	return string(data)
+}
+
+// A repo whose local config Entire will not write to is a permanent
+// arrangement, not a repair pending: Entire's own hooks deliver there, so
+// reporting "not registered with Lefthook" would call a working repository
+// broken forever with no fix to offer.
+func TestCheckHookDelivery_DeclinedLefthookConfigFallsBackToNativeHooks(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lefthook-local.toml"),
+		[]byte("[pre-commit.commands.mine]\nrun = \"true\"\n"), 0o644))
+	ClearHooksDirCache()
+
+	got := CheckHookDelivery(t.Context(), false)
+	require.False(t, got.OK, "no hooks installed yet")
+	require.Empty(t, got.Manager, "Lefthook is not the one delivering")
+	require.Equal(t, "lefthook-local.toml", got.Declined)
+	require.Contains(t, got.Reason, "not installed", "the reason must be the native one")
+
+	_, err := ReinstallGitHooks(t.Context())
+	require.NoError(t, err)
+	ClearHooksDirCache()
+
+	got = CheckHookDelivery(t.Context(), false)
+	require.True(t, got.OK, "Entire's own hooks deliver here")
+	require.Empty(t, got.Manager)
+	require.Equal(t, "lefthook-local.toml", got.Declined, "and the reason why is still reported")
 }

--- a/cmd/entire/cli/strategy/lefthook_test.go
+++ b/cmd/entire/cli/strategy/lefthook_test.go
@@ -54,7 +54,7 @@ func TestEnsureLefthookIntegration(t *testing.T) {
 	mainBefore, err := os.ReadFile(filepath.Join(dir, "lefthook.yml"))
 	require.NoError(t, err)
 
-	written, err := EnsureLefthookIntegration(t.Context(), false)
+	written, err := EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
 	require.Positive(t, written)
 
@@ -82,12 +82,12 @@ func TestEnsureLefthookIntegration(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mainBefore, mainAfter, "Lefthook's own config must not be touched")
 
-	current, err := LefthookIntegrationCurrent(t.Context(), false)
+	current, err := LefthookIntegrationCurrent(t.Context())
 	require.NoError(t, err)
 	require.True(t, current)
 
 	// Repeat installs are no-ops.
-	written, err = EnsureLefthookIntegration(t.Context(), false)
+	written, err = EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
 	require.Zero(t, written)
 }
@@ -98,9 +98,9 @@ func TestEnsureLefthookIntegration_MainConfigFormatIsIrrelevant(t *testing.T) {
 	for _, name := range []string{"lefthook.toml", "lefthook.json", ".lefthook.yaml"} {
 		t.Run(name, func(t *testing.T) {
 			newLefthookRepo(t, name)
-			_, err := EnsureLefthookIntegration(t.Context(), false)
+			_, err := EnsureLefthookIntegration(t.Context())
 			require.NoError(t, err)
-			current, err := LefthookIntegrationCurrent(t.Context(), false)
+			current, err := LefthookIntegrationCurrent(t.Context())
 			require.NoError(t, err)
 			require.True(t, current)
 		})
@@ -120,7 +120,7 @@ func TestEnsureLefthookIntegration_PreservesLocalConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := newLefthookRepo(t, "")
 			require.NoError(t, os.WriteFile(filepath.Join(dir, "lefthook-local.yml"), []byte(tc.local), 0o644))
-			_, err := EnsureLefthookIntegration(t.Context(), false)
+			_, err := EnsureLefthookIntegration(t.Context())
 			require.NoError(t, err)
 
 			got, err := os.ReadFile(filepath.Join(dir, "lefthook-local.yml"))
@@ -141,7 +141,7 @@ func TestEnsureLefthookIntegration_RefusesToShadowANonYAMLLocalConfig(t *testing
 	original := []byte("[pre-commit.commands.mine]\nrun = \"true\"\n")
 	require.NoError(t, os.WriteFile(tomlPath, original, 0o644))
 
-	_, err := EnsureLefthookIntegration(t.Context(), false)
+	_, err := EnsureLefthookIntegration(t.Context())
 	require.ErrorIs(t, err, ErrLefthookLocalConfigUnwritable)
 
 	after, err := os.ReadFile(tomlPath)
@@ -176,7 +176,7 @@ func TestEnsureLefthookIntegration_DisplacesUnownedFiles(t *testing.T) {
 	theirConfig := []byte("# not Entire's\nkey: value\n")
 	require.NoError(t, os.WriteFile(configPath, theirConfig, 0o644))
 
-	_, err := EnsureLefthookIntegration(t.Context(), false)
+	_, err := EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
 
 	backup, err := os.ReadFile(scriptPath + GitHookBackupSuffix)
@@ -186,7 +186,7 @@ func TestEnsureLefthookIntegration_DisplacesUnownedFiles(t *testing.T) {
 	require.NoError(t, err, "the displaced config must be kept")
 	require.Equal(t, theirConfig, backup)
 
-	current, err := LefthookIntegrationCurrent(t.Context(), false)
+	current, err := LefthookIntegrationCurrent(t.Context())
 	require.NoError(t, err)
 	require.True(t, current, "and Entire's own artifacts installed over them")
 }
@@ -196,7 +196,7 @@ func TestRemoveLefthookIntegration(t *testing.T) {
 	dir := newLefthookRepo(t, "")
 	localPath := filepath.Join(dir, "lefthook-local.yml")
 	require.NoError(t, os.WriteFile(localPath, []byte("pre-commit:\n  commands:\n    mine:\n      run: true\n"), 0o644))
-	_, err := EnsureLefthookIntegration(t.Context(), false)
+	_, err := EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
 
 	removed, err := RemoveLefthookIntegration(t.Context())
@@ -210,7 +210,7 @@ func TestRemoveLefthookIntegration(t *testing.T) {
 	require.NotContains(t, string(local), entireLefthookConfig)
 	require.Contains(t, string(local), "mine")
 
-	current, err := LefthookIntegrationCurrent(t.Context(), false)
+	current, err := LefthookIntegrationCurrent(t.Context())
 	require.NoError(t, err)
 	require.False(t, current)
 }
@@ -252,7 +252,7 @@ func TestEnsureLefthookIntegration_ReconcilesHookFiles(t *testing.T) {
 	write("post-commit.old", theirs)
 	write("post-rewrite"+GitHookBackupSuffix, theirs)
 
-	_, err := EnsureLefthookIntegration(t.Context(), false)
+	_, err := EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
 
 	got, err := os.ReadFile(filepath.Join(hooksDir, "pre-push"))
@@ -295,16 +295,16 @@ func TestEnsureLefthookIntegration_ReconcilesHookFiles(t *testing.T) {
 // owns can be present and correct while nothing dispatches Entire at all.
 func TestCheckHookDelivery_Lefthook(t *testing.T) {
 	dir := newLefthookRepo(t, "")
-	got := CheckHookDelivery(t.Context(), false)
+	got := CheckHookDelivery(t.Context())
 	require.False(t, got.OK, "not registered yet")
 	require.Equal(t, LefthookManagerName, got.Manager)
 	require.NotEmpty(t, got.Reason)
 
-	_, err := EnsureLefthookIntegration(t.Context(), false)
+	_, err := EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
 
 	// Registered, but no hook file exists for any hook yet.
-	got = CheckHookDelivery(t.Context(), false)
+	got = CheckHookDelivery(t.Context())
 	require.False(t, got.OK, "a registration nothing triggers is not delivery")
 	require.Equal(t, LefthookManagerName, got.Manager)
 	for _, hook := range gitHookNames {
@@ -321,7 +321,7 @@ func TestCheckHookDelivery_Lefthook(t *testing.T) {
 	require.NoError(t, err)
 	ClearHooksDirCache()
 
-	got = CheckHookDelivery(t.Context(), false)
+	got = CheckHookDelivery(t.Context())
 	require.True(t, got.OK, "reason: %s", got.Reason)
 	require.Equal(t, LefthookManagerName, got.Manager)
 	require.Empty(t, got.Reason)
@@ -329,7 +329,7 @@ func TestCheckHookDelivery_Lefthook(t *testing.T) {
 	// A hook file that belongs to neither is not delivery either.
 	require.NoError(t, os.WriteFile(filepath.Join(hooksDir, "pre-push"),
 		[]byte("#!/bin/sh\necho someone else\n"), 0o755))
-	got = CheckHookDelivery(t.Context(), false)
+	got = CheckHookDelivery(t.Context())
 	require.False(t, got.OK)
 	require.Contains(t, got.Reason, "pre-push")
 }
@@ -343,7 +343,7 @@ func TestCheckHookDelivery_Native(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 	ClearHooksDirCache()
 
-	got := CheckHookDelivery(t.Context(), false)
+	got := CheckHookDelivery(t.Context())
 	require.False(t, got.OK)
 	require.Empty(t, got.Manager)
 
@@ -351,7 +351,7 @@ func TestCheckHookDelivery_Native(t *testing.T) {
 		t.Fatalf("ReinstallGitHooks: %v", err)
 	}
 	ClearHooksDirCache()
-	got = CheckHookDelivery(t.Context(), false)
+	got = CheckHookDelivery(t.Context())
 	require.True(t, got.OK)
 	require.Empty(t, got.Manager)
 }
@@ -366,7 +366,7 @@ func TestEnsureLefthookIntegration_ExcludesArtifacts(t *testing.T) {
 	require.NoError(t, os.WriteFile(excludePath,
 		[]byte("# user's own\n/scratch\n"+excludeBlockBegin+"/stale-entry\n"+excludeBlockEnd), 0o644))
 
-	_, err := EnsureLefthookIntegration(t.Context(), false)
+	_, err := EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
 
 	got, err := os.ReadFile(excludePath)
@@ -385,13 +385,13 @@ func TestEnsureLefthookIntegration_ExcludesArtifacts(t *testing.T) {
 	// An install that predates an entry is not "current", so it repairs itself.
 	require.NoError(t, os.WriteFile(excludePath,
 		[]byte(excludeBlockBegin+"/"+entireLefthookConfig+"\n"+excludeBlockEnd), 0o644))
-	current, err := LefthookIntegrationCurrent(t.Context(), false)
+	current, err := LefthookIntegrationCurrent(t.Context())
 	require.NoError(t, err)
 	require.False(t, current, "a partial exclude block must trigger a repair")
 
-	_, err = EnsureLefthookIntegration(t.Context(), false)
+	_, err = EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
-	current, err = LefthookIntegrationCurrent(t.Context(), false)
+	current, err = LefthookIntegrationCurrent(t.Context())
 	require.NoError(t, err)
 	require.True(t, current)
 
@@ -444,7 +444,7 @@ func TestEnsureLefthookIntegration_RefusesToBuryABackup(t *testing.T) {
 	older := []byte("#!/bin/sh\necho older\n")
 	require.NoError(t, os.WriteFile(scriptPath+GitHookBackupSuffix, older, 0o755))
 
-	_, err := EnsureLefthookIntegration(t.Context(), false)
+	_, err := EnsureLefthookIntegration(t.Context())
 	require.ErrorIs(t, err, ErrLefthookArtifactBlocked)
 
 	got, err := os.ReadFile(scriptPath + GitHookBackupSuffix)
@@ -462,7 +462,7 @@ func TestEnsureLefthookIntegration_RefusesToBuryABackup(t *testing.T) {
 // A visible install that installed nothing must not claim otherwise.
 func TestInstallGitHook_ReportsLefthookDeliveryInsteadOfAFalseInstall(t *testing.T) {
 	dir := newLefthookRepo(t, "")
-	_, err := EnsureLefthookIntegration(t.Context(), false)
+	_, err := EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
 
 	hooksDir := filepath.Join(dir, ".git", "hooks")
@@ -504,7 +504,7 @@ func TestCheckHookDelivery_DeclinedLefthookConfigFallsBackToNativeHooks(t *testi
 		[]byte("[pre-commit.commands.mine]\nrun = \"true\"\n"), 0o644))
 	ClearHooksDirCache()
 
-	got := CheckHookDelivery(t.Context(), false)
+	got := CheckHookDelivery(t.Context())
 	require.False(t, got.OK, "no hooks installed yet")
 	require.Empty(t, got.Manager, "Lefthook is not the one delivering")
 	require.Equal(t, "lefthook-local.toml is not YAML", got.Declined)
@@ -514,7 +514,7 @@ func TestCheckHookDelivery_DeclinedLefthookConfigFallsBackToNativeHooks(t *testi
 	require.NoError(t, err)
 	ClearHooksDirCache()
 
-	got = CheckHookDelivery(t.Context(), false)
+	got = CheckHookDelivery(t.Context())
 	require.True(t, got.OK, "Entire's own hooks deliver here")
 	require.Empty(t, got.Manager)
 	require.Equal(t, "lefthook-local.toml is not YAML", got.Declined, "and the reason why is still reported")
@@ -577,14 +577,14 @@ func TestEnsureLefthookIntegration_TrackedLocalConfig(t *testing.T) {
 	testutil.GitAdd(t, dir, "lefthook-local.yml")
 	testutil.GitCommit(t, dir, "team config")
 
-	_, err := EnsureLefthookIntegration(t.Context(), false)
+	_, err := EnsureLefthookIntegration(t.Context())
 	require.ErrorIs(t, err, ErrLefthookLocalConfigTracked)
 
 	after, err := os.ReadFile(localPath)
 	require.NoError(t, err)
 	require.Equal(t, original, after, "a tracked config must not be modified")
 
-	got := CheckHookDelivery(t.Context(), false)
+	got := CheckHookDelivery(t.Context())
 	require.Empty(t, got.Manager, "Lefthook is not the one delivering")
 	require.Equal(t, "lefthook-local.yml is tracked by git", got.Declined)
 
@@ -592,9 +592,44 @@ func TestEnsureLefthookIntegration_TrackedLocalConfig(t *testing.T) {
 	// Entire has nothing to write and the integration proceeds.
 	require.NoError(t, os.WriteFile(localPath,
 		append([]byte("extends:\n  - "+entireLefthookConfig+"\n"), original...), 0o644))
-	_, err = EnsureLefthookIntegration(t.Context(), false)
+	_, err = EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
-	current, err := LefthookIntegrationCurrent(t.Context(), false)
+	current, err := LefthookIntegrationCurrent(t.Context())
 	require.NoError(t, err)
 	require.True(t, current)
+}
+
+// A repo configured with absolute_git_hook_path must survive every entry
+// point. doctor called these with a hardcoded false, so it reported a working
+// install as NOT DELIVERING and then --force rewrote the scripts down to a
+// bare `entire` — breaking delivery for the GUI git clients that setting
+// exists to serve. The prefix now comes from settings, so no caller can
+// choose it wrongly.
+func TestLefthookIntegration_HonoursAbsoluteGitHookPath(t *testing.T) {
+	dir := newLefthookRepo(t, "")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".entire", "settings.json"),
+		[]byte(`{"enabled": true, "absolute_git_hook_path": true}`), 0o644))
+
+	_, err := EnsureLefthookIntegration(t.Context())
+	require.NoError(t, err)
+
+	script, err := os.ReadFile(filepath.Join(dir, lefthookScriptPath("pre-push")))
+	require.NoError(t, err)
+	require.NotContains(t, string(script), "if command -v entire >",
+		"an absolute-path repo must not get the bare command form: %s", script)
+
+	current, err := LefthookIntegrationCurrent(t.Context())
+	require.NoError(t, err)
+	require.True(t, current, "the install must read as current, not as needing repair")
+
+	got := CheckHookDelivery(t.Context())
+	require.Equal(t, LefthookManagerName, got.Manager)
+
+	// The repair path must not rewrite it into the bare form either.
+	_, err = EnsureLefthookIntegration(t.Context())
+	require.NoError(t, err)
+	after, err := os.ReadFile(filepath.Join(dir, lefthookScriptPath("pre-push")))
+	require.NoError(t, err)
+	require.Equal(t, script, after, "a second install must not downgrade the command")
 }

--- a/cmd/entire/cli/strategy/lefthook_windows_runner_test.go
+++ b/cmd/entire/cli/strategy/lefthook_windows_runner_test.go
@@ -1,0 +1,131 @@
+package strategy
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLefthookScriptRunsUnderItsRunnerOnWindows exercises the one assumption
+// in the Lefthook integration that does not hold by construction.
+//
+// Entire's hooks reach Lefthook as `scripts` declared with `runner: bash`, so
+// Lefthook resolves bash through PATH and spawns it with the script. Every
+// other artifact is a file Entire writes and reads itself, but this step is
+// Lefthook executing a POSIX script on a platform whose shell is not POSIX —
+// and if bash does not resolve, or the script does not run under it, Entire
+// silently stops capturing in every Lefthook repo on Windows.
+//
+// The name carries "Windows" because that is how ci.yml selects the tests the
+// windows-latest job runs. It runs everywhere, which is what makes a failure
+// on Windows alone meaningful rather than a missing harness.
+//
+// Scope worth stating: passing proves bash is resolvable and the script runs
+// under it on the machine running the test. A GitHub Windows runner ships Git
+// for Windows with bash on PATH; a developer who installed Git with the
+// "from cmd only" option may not, and this test cannot speak for that machine.
+func TestLefthookScriptRunsUnderItsRunnerOnWindows(t *testing.T) {
+	t.Parallel()
+
+	bash, err := exec.LookPath("bash")
+	require.NoErrorf(t, err, "lefthook spawns the declared runner through PATH, "+
+		"so no bash on %s means Entire's hooks never run in a Lefthook repo there", runtime.GOOS)
+
+	dir := t.TempDir()
+
+	// A stand-in for the entire binary, so the script's `command -v entire`
+	// guard is satisfied and the arguments it forwards can be observed.
+	record := filepath.Join(dir, "args.txt")
+	stub := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> " + shellQuote(record) + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "entire"), []byte(stub), 0o755))
+
+	var prePush hookSpec
+	for _, spec := range buildHookSpecs("entire") {
+		if spec.name == "pre-push" {
+			prePush = spec
+		}
+	}
+	require.NotEmpty(t, prePush.name, "pre-push spec")
+	script := filepath.Join(dir, lefthookScript)
+	require.NoError(t, os.WriteFile(script, []byte(renderLefthookScript(prePush)), 0o755))
+
+	// Exactly what Lefthook does: the runner, the script, and the hook's own
+	// arguments — pre-push gets the remote and its URL.
+	cmd := exec.CommandContext(t.Context(), bash, lefthookScript, "origin", "https://example.com/x.git")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "running Entire's Lefthook script under bash: %s", out)
+
+	got, err := os.ReadFile(record)
+	require.NoError(t, err, "the script did not reach the entire binary: %s", out)
+	require.Equal(t, "hooks git pre-push origin", strings.TrimSpace(string(got)),
+		"the hook's arguments must survive the runner")
+}
+
+// requireLefthookEnv names the variable CI sets so a lefthook that failed to
+// install is a failure rather than a silent skip.
+const requireLefthookEnv = "ENTIRE_TEST_REQUIRE_LEFTHOOK"
+
+// TestLefthookDeliversEntireOnWindows is the whole chain with the real
+// Lefthook binary: git runs Lefthook's generated hook, Lefthook resolves
+// Entire's config through `extends`, and spawns Entire's script with the
+// hook's arguments. Nothing here is stubbed except the entire binary itself.
+//
+// It carries "Windows" in its name so ci.yml's windows-latest job selects it;
+// that job installs lefthook and sets ENTIRE_TEST_REQUIRE_LEFTHOOK, so a
+// missing binary there fails instead of skipping. Elsewhere it runs whenever
+// lefthook happens to be on PATH.
+func TestLefthookDeliversEntireOnWindows(t *testing.T) {
+	lefthook, err := exec.LookPath("lefthook")
+	if err != nil {
+		if os.Getenv(requireLefthookEnv) != "" {
+			t.Fatalf("%s is set but lefthook is not on PATH: %v", requireLefthookEnv, err)
+		}
+		t.Skip("lefthook not installed")
+	}
+
+	dir := newLefthookRepo(t, "")
+	binDir := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	record := filepath.Join(binDir, "args.txt")
+	// hookCmdPrefix resolves to a bare "entire", so a stub on PATH stands in.
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "entire"),
+		[]byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> "+shellQuote(record)+"\n"), 0o755))
+
+	env := append(os.Environ(), "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	run := func(name string, args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(t.Context(), name, args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "%s %v: %s", name, args, out)
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hi\n"), 0o644))
+	run("git", "add", "a.txt")
+	run("git", "commit", "-m", "init", "--no-verify")
+
+	_, err = EnsureLefthookIntegration(t.Context(), false)
+	require.NoError(t, err)
+	// Lefthook only generates a hook file per hook it knows about, and it
+	// learns Entire's from the extends entry written above.
+	run(lefthook, "install")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hi\nthere\n"), 0o644))
+	run("git", "add", "a.txt")
+	run("git", "commit", "-m", "captured")
+
+	got, err := os.ReadFile(record)
+	require.NoError(t, err, "Lefthook never reached Entire")
+	lines := strings.Fields(strings.ReplaceAll(strings.TrimSpace(string(got)), "\n", " "))
+	for _, hook := range []string{"prepare-commit-msg", "commit-msg", "post-commit"} {
+		require.Containsf(t, lines, hook, "Lefthook did not dispatch %s to Entire: %q", hook, got)
+	}
+}

--- a/cmd/entire/cli/strategy/lefthook_windows_runner_test.go
+++ b/cmd/entire/cli/strategy/lefthook_windows_runner_test.go
@@ -40,8 +40,11 @@ func TestLefthookScriptRunsUnderItsRunnerOnWindows(t *testing.T) {
 
 	// A stand-in for the entire binary, so the script's `command -v entire`
 	// guard is satisfied and the arguments it forwards can be observed.
+	// ToSlash because the path is interpolated into a shell script: bash keeps
+	// backslashes literal inside single quotes, so a Windows path would be a
+	// mangled filename rather than a directory walk.
 	record := filepath.Join(dir, "args.txt")
-	stub := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> " + shellQuote(record) + "\n"
+	stub := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> " + shellQuote(filepath.ToSlash(record)) + "\n"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "entire"), []byte(stub), 0o755))
 
 	var prePush hookSpec
@@ -96,7 +99,7 @@ func TestLefthookDeliversEntireOnWindows(t *testing.T) {
 	record := filepath.Join(binDir, "args.txt")
 	// hookCmdPrefix resolves to a bare "entire", so a stub on PATH stands in.
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, "entire"),
-		[]byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> "+shellQuote(record)+"\n"), 0o755))
+		[]byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> "+shellQuote(filepath.ToSlash(record))+"\n"), 0o755))
 
 	env := append(os.Environ(), "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	run := func(name string, args ...string) {

--- a/cmd/entire/cli/strategy/lefthook_windows_runner_test.go
+++ b/cmd/entire/cli/strategy/lefthook_windows_runner_test.go
@@ -115,7 +115,7 @@ func TestLefthookDeliversEntireOnWindows(t *testing.T) {
 	run("git", "add", "a.txt")
 	run("git", "commit", "-m", "init", "--no-verify")
 
-	_, err = EnsureLefthookIntegration(t.Context(), false)
+	_, err = EnsureLefthookIntegration(t.Context())
 	require.NoError(t, err)
 	// Lefthook only generates a hook file per hook it knows about, and it
 	// learns Entire's from the extends entry written above.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1314
<!-- entire-trail-link-end -->

## The bug

Lefthook regenerates **every** file in `.git/hooks` from its own config, gated by a checksum of that config — and it does so at the top of whatever hook fires next, typically the `pre-commit` of the very commit being made. Entire's turn-start self-heal (`EnsureSetup` → reinstall if not installed) therefore always loses the race:

- `lefthook install -f` (what Lefthook's own npm postinstall runs) takes the hook back;
- so does any `lefthook.yml` edit, via the checksum;
- and the reclaim lands *during* the commit, not in some window before the next agent turn.

The user-visible symptom is #2264: `entire status` names a checkpoint destination while no hook exists to reach it. #1349 is the second-order damage — once Entire and Lefthook have fought over a hook, `<hook>.old` is left behind and Lefthook then fails **every** later sync with `can't rename pre-push to pre-push.old - file already exists`.

## The fix

Stop wanting the file.

| Artifact | Purpose |
| --- | --- |
| `entire-lefthook.yml` | Entire's own Lefthook config, declaring a script per hook |
| `extends:` entry in `lefthook-local.yml` | the one line that makes Lefthook load it |
| `.lefthook-local/<hook>/entire.sh` | the hook bodies, run by Lefthook |

Lefthook resolves `extends` at **run time**, so this takes effect with no `lefthook install` and no user action, and Lefthook's own config is never touched.

Hook-file ownership follows from that. Once Lefthook dispatches Entire, Entire owning the file *too* runs every hook twice (its own copy, then Lefthook's launcher via the chain call — measured: 2× `prepare-commit-msg`, `commit-msg`, `post-commit` per commit). So:

- the native install **skips** any hook carrying Lefthook's launcher;
- `reconcileHookFiles` moves a launcher Entire had displaced back over its own hook, and clears the `<hook>.old` backups behind #1349;
- a hook Lefthook has **not** taken over is still installed natively — in a repo where nobody ran `lefthook install`, Entire's own hooks are the only delivery there is.

`CheckHookDelivery` is now the single question `entire status` and `entire doctor` ask, and in a Lefthook repo it is answered by the registration rather than by `.git/hooks/*`.

## Also corrected

`detectHookManagers` was wrong in both directions and gave users false advice:

- **pre-commit 4.6.2, Overcommit 0.73.0, hk 1.58.1** all overwrite Entire's hooks when they install (verified — pre-commit prints "Use -f to use only pre-commit" and saves `.pre-commit.legacy`; Overcommit moves old hooks aside). They were all flagged as harmless.
- **Lefthook** now needs no user action at all, so telling people to re-run `entire enable` is wrong. Only Lefthook reclaims continuously, which is why only Lefthook gets a config integration.

## Safety

- Every file Entire did not write is backed up to `<name>.pre-entire`, never destroyed; an existing backup is never buried (`ErrLefthookArtifactBlocked`).
- `lefthook-local.yml` **shadows** `lefthook-local.toml`, so Entire refuses to create it beside a non-YAML local config (`ErrLefthookLocalConfigUnwritable`) and keeps its native hooks instead.
- The local config is edited as a `yaml.Node`, so comments and key order survive.
- Uninstall removes only artifacts carrying Entire's marker, takes the exclude block back out, and prunes the (empty) script directories.
- Artifacts are generated and per-clone, so they are ignored via `.git/info/exclude`, not the user's `.gitignore`. A partial block from an older version repairs itself.

## Verification

Against real **lefthook 2.1.10** with the real `entire` binary:

- hooks dispatch **exactly once** per commit (`prepare-commit-msg`, `commit-msg`, `post-commit` — 1 each), and the user's own Lefthook commands still run;
- the mid-fight state (Entire's hook chaining to Lefthook's displaced launcher) was reproduced, measured at 2× per hook, and reconciled back to 1× by `entire doctor --force`;
- `entire status` reports `Git hooks · via Lefthook`;
- on a fresh repo all three artifacts are ignored and the worktree is clean;
- `mise run check` passes. The two `dedicated_rejected_by_fetch_owner` subtests in `TestRunStatus_CheckpointPushDisabledDestinations` fail identically on `origin/main` (e8780c3ef) — pre-existing, from #2337.

## Size

+1,413 / −60 — roughly 890 production, 490 test, 30 docs. This replaces the Lefthook half of #2343 (+6,807) and supersedes draft #2365 (+5,025).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Git hooks are installed and diagnosed across Lefthook and native paths; mistakes could miss checkpoint capture or double-run hooks, but behavior is heavily tested and fails closed on ambiguous local config.
> 
> **Overview**
> Adds **first-class Lefthook integration** so checkpoint hooks survive Lefthook reclaiming `.git/hooks/*` on every run (#2264, #1349). Instead of reinstalling native wrappers, Entire writes `entire-lefthook.yml`, hook scripts under `.lefthook-local/`, and an `extends:` entry in `lefthook-local.yml` (YAML-only; refuses to shadow `lefthook-local.toml`). Native install **skips** hooks Lefthook already owns, **reconciles** double-dispatch and stale `<hook>.old` backups, and ignores generated files via `.git/info/exclude`.
> 
> **`CheckHookDelivery`** is now what **`entire status`** (human + JSON: `hooks_deliver`, `hooks_manager`) and **`entire doctor`** use—Lefthook repos are judged on registration, not hook file contents. Doctor can re-register or reconcile with `--force`. Uninstall removes Lefthook artifacts as well as native hooks. **`EnsureSetup`** runs Lefthook registration before native install.
> 
> Hook-manager detection warnings are corrected: Lefthook gets a “no action” note; pre-commit, Overcommit, and hk are warned as install-time overwriters (not harmless).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a36c3e0cb40be35c3b3e93a93081d2aa2d5739b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->