### PR TITLE
fix(status): pin the aligned ownership vote in the push-disabled status test

### DIFF
--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -471,10 +471,12 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 	// separate questions. With pushing enabled the line names a push
 	// destination, so PushURL decides, mirroring the pre-push exemption
 	// (ps.hasCheckpointURL). With pushing disabled it names a READ source,
-	// which is the fetch side's call over a different ownership identity set
-	// — origin plus the candidate's FETCH url, not its push urls — so a
-	// remote whose two urls have different owners is eligible on one side
-	// only, and asking the wrong side reports a store reads do not use.
+	// which is the fetch side's call. Both sides vote ownership over the same
+	// identity set — origin plus the candidate's PUSH urls, never its fetch
+	// url, so reads land where writes went — but the read side can still
+	// decline a store for reasons the push side does not consider (an origin
+	// URL that will not parse, a protocol with no checkpoint mapping), so
+	// asking the wrong side can report a store reads do not use.
 	//
 	// Both probes are local-only; never call resolvePushSettings here — its
 	// follow-up metadata fetch dials, and status must stay network-free.
@@ -527,16 +529,18 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 			info.IgnoredRemote = repo
 			info.IgnoredReason = reason
 		} else if info.PushDisabled {
-			// That verdict votes with the push identity set, so it accepts a
-			// store the fetch side declined — and with pushing disabled the
-			// fetch side is the one that decided the line above. Without this
-			// the configured store is reported by nothing at all, which is
-			// the silent-ignore the warning exists to prevent.
+			// That verdict is ownership only, so it accepts a store the fetch
+			// side declined for another reason (an unparseable origin URL, an
+			// unmappable protocol) — and with pushing disabled the fetch side
+			// is the one that decided the line above. Without this the
+			// configured store is reported by nothing at all, which is the
+			// silent-ignore the warning exists to prevent. Ownership itself
+			// cannot split the two: both vote over origin plus the
+			// candidate's push urls.
 			//
 			// No reason is given: the fetch side returns a verdict and not a
-			// cause, and its false covers ownership, an unparseable origin
-			// URL and an unmappable protocol alike, so naming one would be a
-			// guess. The causes are logged where they are decided.
+			// cause, so naming one would be a guess. The causes are logged
+			// where they are decided.
 			info.IgnoredRemote = cr.Repo
 			info.IgnoredReason = "checkpoint reads do not resolve to it (see .entire/logs for the reason)"
 		}

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -399,8 +399,9 @@ type checkpointSyncInfo struct {
 // name a read source, so the two cannot answer the question differently — the
 // asymmetry between them is what this function exists to remove.
 //
-// lead is the read candidate whose FETCH url joins origin in the ownership
-// vote: the elected remote, or "" when the election failed and reads fall
+// lead is the read candidate whose PUSH urls join origin in the ownership
+// vote (the same identity set the push side uses, so reads land where writes
+// went): the elected remote, or "" when the election failed and reads fall
 // open to origin alone.
 //
 // Reports whether it settled the answer — the dedicated store serves reads
@@ -520,10 +521,11 @@ func computeCheckpointSyncInfo(ctx context.Context, s *EntireSettings) checkpoin
 	// ignored. When the ownership check is what rejected it, say so: this is
 	// the one trust-gate rejection a user otherwise experiences only as
 	// checkpoints vanishing. Local-only, like everything else here.
-	// Accepted divergence: this verdict votes with the push identity set
-	// (origin + push URLs of the elected remote), while a fetch votes with its
-	// read candidate, so a push-only owner mismatch shows "not in use" here
-	// even though a lead-less fetch still resolves the checkpoint remote.
+	// Accepted divergence: this verdict votes on origin plus the elected
+	// remote's push URLs, and so does a fetch that names a read candidate —
+	// but a fetch with NO candidate votes on origin alone, so a mismatch that
+	// lives only in the elected remote's push URL shows "not in use" here
+	// even though such a lead-less fetch still resolves the checkpoint remote.
 	if cr := s.GetCheckpointRemote(); cr != nil {
 		if repo, reason, inherited := checkpointremote.InheritedCheckpointRemote(ctx, s, elected.Name); inherited {
 			info.IgnoredRemote = repo

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -2469,19 +2469,32 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 				name: "missing_configured_remote", options: `,"checkpoint_push_remote":"gone"`,
 				origin: "https://github.com/org/repo.git", wantFallback: "origin", wantErr: true,
 			},
-			// Push- and fetch-side ownership disagree. Both require EVERY
-			// identity to be owned by the checkpoint repo's owner, but over
-			// different sets: origin plus fork's PUSH urls (all "org", so the
-			// push side certifies the dedicated store) versus origin plus
-			// fork's FETCH url ("other", so the fetch side rejects it). With
-			// pushing disabled the line names a read source, so the fetch
-			// side decides and the elected remote is reported; deciding it
-			// with PushURL named a store reads never use.
+			// The candidate's fetch and push urls have different owners. Both
+			// ownership votes — push side (InheritedCheckpointRemote) and
+			// read side (ReadsDedicatedStore) — require EVERY identity to be
+			// owned by the checkpoint repo's owner over the SAME set: origin
+			// plus the candidate's PUSH urls. Its FETCH url is deliberately
+			// not a vote: reads must land where writes went, and writes are
+			// decided by push urls (#2342). So a candidate fetching from
+			// another owner but pushing to the store's owner is accepted on
+			// both sides, and the dedicated store is the read source ...
 			{
-				name:    "dedicated_rejected_by_fetch_owner",
+				name:    "dedicated_accepted_by_push_owner",
 				options: `,"checkpoint_push_remote":"fork","checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`,
 				origin:  "https://github.com/org/repo.git",
 				fork:    "https://github.com/other/fork.git", forkPush: "https://github.com/org/fork.git",
+				wantRemote: "org/checkpoints", wantSource: checkpointSyncSourceDedicated,
+			},
+			// ... while one fetching from the store's owner but pushing
+			// elsewhere is rejected on both, so the elected remote is the
+			// read source and the configured store is reported as not in use.
+			// Before the votes were aligned this row's mirror image passed on
+			// the push side and failed on the read side.
+			{
+				name:    "dedicated_rejected_by_push_owner",
+				options: `,"checkpoint_push_remote":"fork","checkpoint_remote":{"provider":"github","repo":"org/checkpoints"}`,
+				origin:  "https://github.com/org/repo.git",
+				fork:    "https://github.com/org/fork.git", forkPush: "https://github.com/other/fork.git",
 				wantRemote: "fork", wantSource: "config", wantIgnored: true,
 			},
 			// A failed election does not stop reads: they fail open, so the
@@ -2553,14 +2566,12 @@ func TestRunStatus_CheckpointPushDisabledDestinations(t *testing.T) {
 					t.Fatal(err)
 				}
 				info := computeCheckpointSyncInfo(t.Context(), s)
-				// The two "not in use" rows reach that warning by different
-				// routes: the origin-owner row through the push-side verdict,
-				// the fetch-rejected row through the read-side branch that
-				// exists because that verdict ACCEPTS what the fetch side
-				// declines. Without the second, a configured store serving no
-				// reads is reported by nothing. (Not the divergence
-				// documented as accepted on InheritedCheckpointRemote — that
-				// one is the opposite direction.)
+				// Both "not in use" rows reach that warning through the
+				// push-side verdict, which votes on the same identity set as
+				// the read side. The read-side branch behind it covers the
+				// non-ownership reasons reads can decline a store (an origin
+				// URL that will not parse, a protocol with no checkpoint
+				// mapping), none of which this table stages.
 				if (info.Err != "") != tc.wantErr || (info.IgnoredRemote != "") != tc.wantIgnored {
 					t.Errorf("unexpected remote diagnostics: %+v", info)
 				}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1315
<!-- entire-trail-link-end -->

## Summary

Main's `Tests` workflow has been red since #2342 merged on top of #2337: `TestRunStatus_CheckpointPushDisabledDestinations/{git-branch,git-refs}/dedicated_rejected_by_fetch_owner` fails at every commit from e8780c3ef onward and passes at its parent.

- #2337 added a row asserting the read-side ownership vote counts the elected candidate's **fetch** URL while the push side counts its **push** URLs, so a `fork` fetching from `other` but pushing to `org` had writes accept the dedicated store and reads reject it.
- #2342 (`adc64ce65`, "align the fetch-side ownership vote with the push side") deliberately made both votes use origin plus the candidate's push URLs, so reads land where writes went. That row now correctly resolves to the dedicated store.

This PR updates the test to the new semantics rather than reverting either change:

- Replaces `dedicated_rejected_by_fetch_owner` with two rows pinning the aligned vote in both directions: `dedicated_accepted_by_push_owner` (fetch `other`, push `org` → dedicated store) and `dedicated_rejected_by_push_owner` (fetch `org`, push `other` → elected remote, store reported as not in use).
- Rewrites the two `status.go` comments that still described the asymmetric vote. The read-side "not in use" branch is kept: `ReadsDedicatedStore` can still decline for non-ownership reasons (unparseable origin URL, unmappable protocol) that the push-side verdict never considers.

No behaviour change.

## Test plan

- [x] `go test ./cmd/entire/cli/ -run 'Status|CheckpointSync|Topology|Doctor'` passes
- [x] `mise run lint:go` — 0 issues
- [ ] CI `Tests` workflow green on this branch

Once merged, #2078 and #2361 (currently failing only on this test) go green after merging main again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and test-only updates; no production logic changes.
> 
> **Overview**
> Fixes CI breakage after **#2342** aligned push- and read-side **checkpoint_remote** ownership checks: both now vote over **origin plus the candidate’s push URLs** (not the fetch URL), so reads match where writes go.
> 
> **Tests:** Replaces the obsolete `dedicated_rejected_by_fetch_owner` table row with **`dedicated_accepted_by_push_owner`** (fetch from another owner, push to the store owner → dedicated read source) and **`dedicated_rejected_by_push_owner`** (the mirror case → elected remote + “not in use” warning). Updates inline comments in the push-disabled destination test to match.
> 
> **Docs in code:** Rewrites `computeCheckpointSyncInfo` comments in `status.go` to describe the shared identity set and to clarify that the push-disabled “not in use” branch still covers **non-ownership** read declines (unparseable origin, unmappable protocol).
> 
> **No runtime behavior change** — expectations and commentary only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbaa7e7d2beb86643926865e0f351e2d8239e112. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->