### PR TITLE
Recommendations v2 (PR 5a): three noisy rules deleted, the rest cite their rows

### DIFF
--- a/cmd/entire/cli/checkpoint_tokens.go
+++ b/cmd/entire/cli/checkpoint_tokens.go
@@ -298,12 +298,11 @@ func buildCheckpointTokensReport(cpID id.CheckpointID, summary *checkpoint.Check
 	if summary != nil {
 		checkpointCount = summary.CheckpointsCount
 	}
-	report.Recommendations = append(report.Recommendations, recommendationRules(tokenRecommendationSignals{
-		Tokens:          report.Tokens,
-		Context:         report.Context,
-		TurnCount:       turnCount,
-		CheckpointCount: checkpointCount,
-	})...)
+	report.Recommendations = append(report.Recommendations, recommendationRules(
+		sessionTokenRecommendationSignals(
+			report.Tokens, report.Classes, report.Context,
+			turnCount, checkpointCount,
+		))...)
 	return report
 }
 

--- a/cmd/entire/cli/checkpoint_tokens.go
+++ b/cmd/entire/cli/checkpoint_tokens.go
@@ -649,7 +649,7 @@ func writeCheckpointTokensText(w io.Writer, report checkpointTokensReport) {
 	writeTokenClasses(w, report.Classes, subagentTotalOf(report.Tokens))
 	writeCheckpointTokenComparison(w, report.Comparison)
 	if len(report.Recommendations) > 0 {
-		writeTokenRecommendations(w, report.Recommendations)
+		writeTokenRecommendations(w, report.Recommendations, tokenRecommendationDisplayLimit)
 	}
 	writeTokenContributors(w, report.Contributors, report.Context,
 		subagentShareFitsBlock(report.Classes, subagentTotalOf(report.Tokens)))

--- a/cmd/entire/cli/checkpoint_tokens.go
+++ b/cmd/entire/cli/checkpoint_tokens.go
@@ -242,7 +242,7 @@ func buildCheckpointTokensReport(cpID id.CheckpointID, summary *checkpoint.Check
 	} else {
 		report.Limitations = append(report.Limitations, "No token usage recorded for this checkpoint.")
 		report.Recommendations = append(report.Recommendations, sessionTokensRecommendation{
-			ID:       "no-token-data",
+			ID:       recNoTokenData,
 			Severity: "low",
 			Message:  "Token usage is unavailable for this checkpoint; the agent may not expose token data yet, or this checkpoint predates token tracking.",
 			Signals:  []string{"missing_token_usage"},
@@ -677,7 +677,7 @@ func writeCheckpointTokensAgentBrief(w io.Writer, report checkpointTokensReport)
 
 func checkpointAgentBriefNextAction(report checkpointTokensReport) string {
 	sessionReport := checkpointAgentBriefSessionReport(report)
-	if hasTokenRecommendation(sessionReport, "no-token-data") {
+	if hasTokenRecommendation(sessionReport, recNoTokenData) {
 		return "Do not spend extra commands on token optimization for this checkpoint. Continue with the task and capture a newer checkpoint before rechecking tokens."
 	}
 	if action, ok := agentBriefOptimizationAction(sessionReport); ok {

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -497,9 +497,23 @@ func recommendationRules(signals tokenRecommendationSignals) []sessionTokensReco
 
 	hotspot := cacheReadHotspot(signals.Tokens)
 	if signals.Tokens != nil && signals.Tokens.APICalls >= recommendationHighAPICalls {
-		message := fmt.Sprintf("API call count is high for one session: %d calls. Batch the next diagnosis and reduce iterative calls.", signals.Tokens.APICalls)
+		message := fmt.Sprintf(
+			"%d API calls for one session. Batch the next diagnosis and reduce iterative calls.",
+			signals.Tokens.APICalls)
 		if hotspot {
-			message = fmt.Sprintf("Large context was replayed across %d API calls; batch the next diagnosis and reduce iterative tool calls.", signals.Tokens.APICalls)
+			// Every figure here is one the usage line prints: the call count,
+			// the per-call average, and the cache-read class total. An earlier
+			// version divided cache read by the call count, which reads as the
+			// replay cost per call but appears in no row — the usage line's
+			// Per call is the whole total divided by calls. A recommendation
+			// that cites a number the reader cannot find is the thing this
+			// change exists to stop.
+			message = fmt.Sprintf(
+				"%d API calls at about %s each, of which %s was replayed cached context. Batch the next diagnosis: each further call replays the context again.",
+				signals.Tokens.APICalls,
+				formatTokenCount(signals.Tokens.Total/signals.Tokens.APICalls),
+				formatTokenCount(signals.Tokens.CacheRead),
+			)
 		}
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       recAPICallAmplification,
@@ -511,9 +525,17 @@ func recommendationRules(signals tokenRecommendationSignals) []sessionTokensReco
 	if signals.Tokens != nil && tokenShareAtLeastOneTenth(signals.Tokens.SubagentTotal, signals.Tokens.Total) {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       recSubagentHeavy,
-			Severity: "medium",
-			Message:  "Scope subagent tasks tightly; give each subagent a narrow objective and expected output.",
-			Signals:  []string{"subagent_tokens"},
+			Severity: trailReviewSeverityMedium,
+			Message: fmt.Sprintf(
+				"Subagents used %s of %s tokens (%s). Give each a narrower objective and expected output.",
+				formatTokenCount(signals.Tokens.SubagentTotal),
+				formatTokenCount(signals.Tokens.Total),
+				// The row's own share, through the row's own formatter, so the
+				// two strings match rather than merely agreeing to a rounding.
+				formatSharePercent(signals.Tokens.SubagentTotal,
+					roundedPercent(signals.Tokens.SubagentTotal, signals.Tokens.Total)),
+			),
+			Signals: []string{"subagent_tokens"},
 		})
 	}
 	if signals.Context != nil && signals.Context.Percent >= recommendationHighContextPercent {
@@ -800,6 +822,14 @@ func writeTokenUsageSectionWithTitle(w io.Writer, title string, tokens *sessionT
 			"Cache write: " + formatTokenCount(tokens.CacheWrite),
 			"Output: " + formatTokenCount(tokens.Output),
 			fmt.Sprintf("API calls: %d", tokens.APICalls),
+		}
+		// Per call is what makes the API-call recommendation citable: it quotes
+		// this figure, and a number a recommendation cites has to be visible in
+		// a row above it. It is an average, so the message it feeds says only
+		// that a further call replays the context again — the marginal call
+		// costs the current context, which is larger in a growing session.
+		if tokens.APICalls > 0 {
+			parts = append(parts, "Per call: "+formatTokenCount(tokens.Total/tokens.APICalls))
 		}
 		fmt.Fprintf(w, "  %s\n", strings.Join(parts, " | "))
 	} else {

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math/bits"
+	"slices"
 	"strings"
 	"time"
 
@@ -570,7 +571,7 @@ func writeSessionTokensText(w io.Writer, report sessionTokensReport) {
 	writeTokenUsageSection(w, report.Tokens)
 	writeTokenClasses(w, report.Classes, subagentTotalOf(report.Tokens))
 	if len(report.Recommendations) > 0 {
-		writeTokenRecommendations(w, report.Recommendations)
+		writeTokenRecommendations(w, report.Recommendations, tokenRecommendationDisplayLimit)
 	}
 
 	writeTokenContributors(w, report.Contributors, report.Context,
@@ -689,10 +690,70 @@ func hasTokenRecommendation(report sessionTokensReport, id string) bool {
 	return false
 }
 
-func writeTokenRecommendations(w io.Writer, recs []sessionTokensRecommendation) {
+// tokenRecommendationDisplayLimit is how many recommendations a report
+// prints. Two, because a list long enough to skim is a list nobody reads: the
+// pre-PR-5a report printed up to seven and 35% of real checkpoints got three
+// or more.
+//
+// tokenRecommendationNoLimit renders every recommendation. `tokens profile`
+// uses it: its rules are a different shape (they count recurrence across many
+// checkpoints rather than describing one session) and revisiting them is PR
+// 6's, so this change deliberately leaves that command's output alone.
+const (
+	tokenRecommendationDisplayLimit = 2
+	tokenRecommendationNoLimit      = 0
+)
+
+// recommendationSeverityRank orders the display. Unknown severities sort last
+// rather than first, so a typo demotes a line instead of promoting it.
+func recommendationSeverityRank(severity string) int {
+	// These are the package's existing severity strings (declared in
+	// trail_review_cmd.go); recommendations and trail findings share the
+	// vocabulary, so this reuses the constants rather than re-spelling them.
+	switch severity {
+	case trailReviewSeverityHigh:
+		return 0
+	case trailReviewSeverityMedium:
+		return 1
+	case trailReviewSeverityLow:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// writeTokenRecommendations renders at most limit recommendations, highest
+// severity first.
+//
+// The cap is applied HERE and never to report.Recommendations, because
+// agentBriefOptimizationAction and agentBriefSignals both read that slice:
+// truncating it would silently change an agent's next action and shorten its
+// diagnostic list as a side effect of a display choice. --json keeps the full
+// list for the same reason — it is the machine-readable surface, not the one
+// being decluttered.
+func writeTokenRecommendations(w io.Writer, recs []sessionTokensRecommendation, limit int) {
+	if len(recs) == 0 {
+		return
+	}
+	ordered := slices.Clone(recs)
+	slices.SortStableFunc(ordered, func(a, b sessionTokensRecommendation) int {
+		return recommendationSeverityRank(a.Severity) - recommendationSeverityRank(b.Severity)
+	})
+	// The limit trims noise, never a serious finding: every high-severity
+	// recommendation is kept even if that exceeds the limit, and the cap
+	// applies only to what follows. Capping by position alone would let two
+	// medium lines hide a high one on the day three fire at once.
+	if limit > 0 && len(ordered) > limit {
+		keep := limit
+		for keep < len(ordered) && ordered[keep].Severity == trailReviewSeverityHigh {
+			keep++
+		}
+		ordered = ordered[:keep]
+	}
+
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Recommendations")
-	for _, rec := range recs {
+	for _, rec := range ordered {
 		fmt.Fprintf(w, "- %s\n", rec.Message)
 	}
 }

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -721,7 +721,7 @@ func agentBriefSignals(report sessionTokensReport) []string {
 	if hasTokenRecommendation(report, recLongSession) {
 		signals = append(signals, "Session has crossed a long-session or checkpoint boundary.")
 	}
-	if hasTokenRecommendation(report, "no-token-data") {
+	if hasTokenRecommendation(report, recNoTokenData) {
 		signals = append([]string{"Token usage is unavailable for this session."}, signals...)
 	}
 	if len(signals) == 0 && report.Tokens != nil {

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -72,10 +72,38 @@ type sessionTokensRecommendation struct {
 }
 
 type tokenRecommendationSignals struct {
-	Tokens          *sessionTokensUsage
+	Tokens *sessionTokensUsage
+	// Classes is the billing-class breakdown the report renders above the
+	// recommendations. A rule quotes figures from it rather than recomputing
+	// them, so every number in a recommendation appears in a row the reader can
+	// find. It also carries the capability signals a rule needs before firing:
+	// Priced says whether cost shares mean anything, and a class's CostZero
+	// says the provider bills none of it — which is a property of the model's
+	// price family, not of the agent. Nil when the report has no breakdown.
+	Classes         *tokenClassBreakdown
 	Context         *sessionTokensContext
 	TurnCount       int
 	CheckpointCount int
+}
+
+// sessionTokenRecommendationSignals builds the rule input. Both `session
+// tokens` and `checkpoint tokens` go through it so the two cannot drift in
+// what they hand the rules — a rule that silently sees no Classes on one
+// command would quietly stop citing rows there.
+func sessionTokenRecommendationSignals(
+	tokens *sessionTokensUsage,
+	classes *tokenClassBreakdown,
+	contextInfo *sessionTokensContext,
+	turnCount int,
+	checkpointCount int,
+) tokenRecommendationSignals {
+	return tokenRecommendationSignals{
+		Tokens:          tokens,
+		Classes:         classes,
+		Context:         contextInfo,
+		TurnCount:       turnCount,
+		CheckpointCount: checkpointCount,
+	}
 }
 
 // Recommendation thresholds are coarse diagnostics for clear token hotspots, not a cost model or quality verdict.
@@ -271,12 +299,11 @@ func buildSessionTokensReport(state *strategy.SessionState, status string) sessi
 		})
 	}
 
-	report.Recommendations = append(report.Recommendations, recommendationRules(tokenRecommendationSignals{
-		Tokens:          report.Tokens,
-		Context:         report.Context,
-		TurnCount:       state.SessionTurnCount,
-		CheckpointCount: state.StepCount,
-	})...)
+	report.Recommendations = append(report.Recommendations, recommendationRules(
+		sessionTokenRecommendationSignals(
+			report.Tokens, report.Classes, report.Context,
+			state.SessionTurnCount, state.StepCount,
+		))...)
 	return report
 }
 

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -231,7 +231,7 @@ func buildSessionTokensReport(state *strategy.SessionState, status string) sessi
 	} else {
 		report.Limitations = append(report.Limitations, "No token usage recorded for this session.")
 		report.Recommendations = append(report.Recommendations, sessionTokensRecommendation{
-			ID:       "no-token-data",
+			ID:       recNoTokenData,
 			Severity: "low",
 			Message:  "Token usage is unavailable for this session; the agent may not expose token data yet, or no checkpoint has captured it.",
 			Signals:  []string{"missing_token_usage"},
@@ -436,32 +436,45 @@ func roundedPercent(value, total int) int {
 	return int(quotient)
 }
 
+// Recommendation IDs. These are matched by string in several places
+// (the agent brief, its signal list, tests), so a deletion compiles clean and
+// every stale reference silently goes false. Naming them makes the next
+// deletion a build failure instead.
+const (
+	recAPICallAmplification = "api-call-amplification"
+	recSubagentHeavy        = "subagent-heavy"
+	recHighContextPressure  = "high-context-pressure"
+	recLongSession          = "long-session"
+	recNoTokenData          = "no-token-data"
+)
+
+// cacheReadHotspot reports whether replayed context dominates this session.
+//
+// It is deliberately NOT a recommendation. Measured over 135 distinct
+// committed checkpoints it was true of 91%, and the spec's own calibration
+// says why: cache read is the largest class in ~90% of sessions, so on its own
+// it describes the baseline rather than a finding. It survives as a qualifier
+// because two things still need it — the API-call message, which asserts
+// replay, and the agent brief's next action, which must not change just
+// because a printed recommendation was removed.
+func cacheReadHotspot(tokens *sessionTokensUsage) bool {
+	if tokens == nil || tokens.CacheRead <= 0 {
+		return false
+	}
+	return tokenPercent(tokens.CacheRead, topLevelSessionTokenTotal(tokens)) >= recommendationHighCacheReadPercent
+}
+
 func recommendationRules(signals tokenRecommendationSignals) []sessionTokensRecommendation {
 	var recs []sessionTokensRecommendation
 
-	cacheReadHotspot := false
-	if signals.Tokens != nil && signals.Tokens.CacheRead > 0 {
-		cacheReadPercent := tokenPercent(signals.Tokens.CacheRead, topLevelSessionTokenTotal(signals.Tokens))
-		if cacheReadPercent >= recommendationHighCacheReadPercent {
-			cacheReadHotspot = true
-			recs = append(recs, sessionTokensRecommendation{
-				ID:       "context-replay-hotspot",
-				Severity: "high",
-				Message: fmt.Sprintf(
-					"Cache/context replay is %s of token volume; reduce unnecessary follow-up calls in this large-context session.",
-					formatPercent(cacheReadPercent),
-				),
-				Signals: []string{"cache_read_tokens"},
-			})
-		}
-	}
+	hotspot := cacheReadHotspot(signals.Tokens)
 	if signals.Tokens != nil && signals.Tokens.APICalls >= recommendationHighAPICalls {
 		message := fmt.Sprintf("API call count is high for one session: %d calls. Batch the next diagnosis and reduce iterative calls.", signals.Tokens.APICalls)
-		if cacheReadHotspot {
+		if hotspot {
 			message = fmt.Sprintf("Large context was replayed across %d API calls; batch the next diagnosis and reduce iterative tool calls.", signals.Tokens.APICalls)
 		}
 		recs = append(recs, sessionTokensRecommendation{
-			ID:       "api-call-amplification",
+			ID:       recAPICallAmplification,
 			Severity: "medium",
 			Message:  message,
 			Signals:  []string{"api_call_count"},
@@ -469,49 +482,23 @@ func recommendationRules(signals tokenRecommendationSignals) []sessionTokensReco
 	}
 	if signals.Tokens != nil && tokenShareAtLeastOneTenth(signals.Tokens.SubagentTotal, signals.Tokens.Total) {
 		recs = append(recs, sessionTokensRecommendation{
-			ID:       "subagent-heavy",
+			ID:       recSubagentHeavy,
 			Severity: "medium",
 			Message:  "Scope subagent tasks tightly; give each subagent a narrow objective and expected output.",
 			Signals:  []string{"subagent_tokens"},
 		})
 	}
-	if signals.Tokens != nil && signals.Tokens.Total > 0 &&
-		tokenClassPressure(signals.Tokens.CacheWrite, signals.Tokens.Total, 5000, 10, 50_000) {
-		recs = append(recs, sessionTokensRecommendation{
-			ID:       "cache-write-pressure",
-			Severity: "medium",
-			Message:  "Cache write is elevated; avoid broad new context and narrow the next read before continuing.",
-			Signals:  []string{"cache_write_tokens"},
-		})
-	}
-	if signals.Tokens != nil && signals.Tokens.Total > 0 &&
-		tokenClassPressure(signals.Tokens.Output, signals.Tokens.Total, 3000, 2, 10_000) {
-		recs = append(recs, sessionTokensRecommendation{
-			ID:       "output-pressure",
-			Severity: "medium",
-			Message:  "Output tokens are elevated; keep the next answer tight and avoid restating evidence.",
-			Signals:  []string{"output_tokens"},
-		})
-	}
 	if signals.Context != nil && signals.Context.Percent >= recommendationHighContextPercent {
 		recs = append(recs, sessionTokensRecommendation{
-			ID:       "high-context-pressure",
+			ID:       recHighContextPressure,
 			Severity: "medium",
 			Message:  fmt.Sprintf("Context pressure is %d%% of the window; preserve only relevant context before continuing.", signals.Context.Percent),
 			Signals:  []string{"context_tokens"},
 		})
 	}
-	if cacheReadHotspot && signals.Tokens != nil && signals.Tokens.APICalls >= recommendationHighAPICalls {
-		recs = append(recs, sessionTokensRecommendation{
-			ID:       "summarize-before-boundary",
-			Severity: "low",
-			Message:  "Compact or restart after summarizing this investigation; do not discard useful findings just because cache read is high.",
-			Signals:  []string{"cache_read_tokens", "api_call_count"},
-		})
-	}
 	if signals.TurnCount >= recommendationLongSessionTurns || signals.CheckpointCount >= recommendationLongSessionCheckpoints {
 		recs = append(recs, sessionTokensRecommendation{
-			ID:       "long-session",
+			ID:       recLongSession,
 			Severity: "low",
 			Message:  "Compact or restart after summarizing the useful findings if older context is no longer needed.",
 			Signals:  []string{"turn_count", "checkpoint_count"},
@@ -526,16 +513,6 @@ func tokenShareAtLeastOneTenth(part, total int) bool {
 		return false
 	}
 	return part >= (total-1)/recommendationSubagentShareDenominator+1
-}
-
-func tokenClassPressure(value, total, minTokens int, minPercent float64, highTokens int) bool {
-	if value <= 0 || total <= 0 {
-		return false
-	}
-	if value >= highTokens {
-		return true
-	}
-	return value >= minTokens && tokenPercent(value, total) >= minPercent
 }
 
 func tokenPercent(value, total int) float64 {
@@ -646,7 +623,7 @@ func formatAPICalls(count int) string {
 }
 
 func agentBriefNextAction(report sessionTokensReport) string {
-	if hasTokenRecommendation(report, "no-token-data") {
+	if hasTokenRecommendation(report, recNoTokenData) {
 		return "Token usage is not available yet. Use this as a context check, not a spend diagnosis; continue after the next checkpoint captures usage."
 	}
 	if action, ok := agentBriefOptimizationAction(report); ok {
@@ -656,27 +633,21 @@ func agentBriefNextAction(report sessionTokensReport) string {
 }
 
 func agentBriefOptimizationAction(report sessionTokensReport) (string, bool) {
+	// The replay arm keys on the usage itself, not on a recommendation. PR 5a
+	// stopped printing context-replay-hotspot because it fired on 91% of real
+	// checkpoints, but the brief returns exactly one next action and always
+	// returned something here; letting a recommendation deletion silently
+	// change the agent's instruction is the coupling Decision 7 rejects.
 	switch {
-	case (hasTokenRecommendation(report, "cache-write-pressure") || hasTokenRecommendation(report, "output-pressure")) &&
-		(hasTokenRecommendation(report, "context-replay-hotspot") || hasTokenRecommendation(report, "api-call-amplification")):
+	case hasTokenRecommendation(report, recAPICallAmplification):
 		return agentBriefCostProxyBatchAction, true
-	case hasTokenRecommendation(report, "cache-write-pressure") && hasTokenRecommendation(report, "output-pressure"):
-		return agentBriefCostProxyBatchAction, true
-	case hasTokenRecommendation(report, "cache-write-pressure"):
-		return "Use at most 3 batched reads and avoid broad new context until you have one narrowed hypothesis.", true
-	case hasTokenRecommendation(report, "output-pressure"):
-		return "Keep the next answer tight; cite only necessary evidence and avoid restating prior context.", true
-	case hasTokenRecommendation(report, "context-replay-hotspot") && hasTokenRecommendation(report, "api-call-amplification"):
-		return agentBriefCostProxyBatchAction, true
-	case hasTokenRecommendation(report, "api-call-amplification"):
-		return agentBriefCostProxyBatchAction, true
-	case hasTokenRecommendation(report, "context-replay-hotspot"):
+	case cacheReadHotspot(report.Tokens):
 		return "Use at most 2 focused reads only if a named file or test can change the answer; otherwise answer now. Avoid broad grep, broad diffs, and broad tests.", true
-	case hasTokenRecommendation(report, "subagent-heavy"):
+	case hasTokenRecommendation(report, recSubagentHeavy):
 		return "Do not launch broad subagents. Use one narrowly scoped check with a concrete expected output.", true
-	case hasTokenRecommendation(report, "high-context-pressure"):
+	case hasTokenRecommendation(report, recHighContextPressure):
 		return "Preserve useful findings, then answer with at most 2 focused reads if more evidence is required.", true
-	case hasTokenRecommendation(report, "long-session"):
+	case hasTokenRecommendation(report, recLongSession):
 		return "Summarize useful findings and stop unless one focused read can change the answer.", true
 	default:
 		return "", false
@@ -685,25 +656,19 @@ func agentBriefOptimizationAction(report sessionTokensReport) (string, bool) {
 
 func agentBriefSignals(report sessionTokensReport) []string {
 	var signals []string
-	if hasTokenRecommendation(report, "context-replay-hotspot") {
+	if cacheReadHotspot(report.Tokens) {
 		signals = append(signals, "Cache/context replay dominates token volume.")
 	}
-	if hasTokenRecommendation(report, "api-call-amplification") {
+	if hasTokenRecommendation(report, recAPICallAmplification) {
 		signals = append(signals, "API call count is high for one session.")
 	}
-	if hasTokenRecommendation(report, "cache-write-pressure") {
-		signals = append(signals, "Cache write/new context pressure is elevated.")
-	}
-	if hasTokenRecommendation(report, "output-pressure") {
-		signals = append(signals, "Output pressure is elevated.")
-	}
-	if hasTokenRecommendation(report, "subagent-heavy") {
+	if hasTokenRecommendation(report, recSubagentHeavy) {
 		signals = append(signals, "Subagent usage is a meaningful part of total tokens.")
 	}
-	if hasTokenRecommendation(report, "high-context-pressure") {
+	if hasTokenRecommendation(report, recHighContextPressure) {
 		signals = append(signals, "Context pressure is high.")
 	}
-	if hasTokenRecommendation(report, "long-session") {
+	if hasTokenRecommendation(report, recLongSession) {
 		signals = append(signals, "Session has crossed a long-session or checkpoint boundary.")
 	}
 	if hasTokenRecommendation(report, "no-token-data") {

--- a/cmd/entire/cli/session_tokens_classes_test.go
+++ b/cmd/entire/cli/session_tokens_classes_test.go
@@ -367,12 +367,15 @@ func TestSessionTokens_SubagentFigureAppearsOnlyOnce(t *testing.T) {
 	writeSessionTokensText(&buf, buildSessionTokensReport(state, "active"))
 	out := buf.String()
 
-	// "ubagents" (plural) and not "ubagent": with this fixture the
-	// subagent-heavy recommendation also fires and says "Scope subagent tasks
-	// tightly…" — singular. Matching the plural counts the figure's labels only.
-	// Do not "fix" this to "ubagent"; it will start counting the advice line.
-	if n := strings.Count(out, "ubagents"); n != 1 {
-		t.Errorf("the subagent figure must appear exactly once in the text, found %d mentions:\n%s", n, out)
+	// Count the FIGURE'S ROW, not the word. This used to count occurrences of
+	// "ubagents" on the premise that the recommendation said "subagent"
+	// singular, which stopped being true when PR 5a made recommendations quote
+	// the rows they cite: the subagent-heavy line now legitimately repeats this
+	// figure, and repeating it is the point — a reader must be able to find the
+	// cited number above. What must still hold is that the breakdown prints the
+	// row exactly once, which is the double-count this test was written for.
+	if n := strings.Count(out, "Of the total, subagents used"); n != 1 {
+		t.Errorf("the subagent row must appear exactly once in the text, found %d:\n%s", n, out)
 	}
 }
 

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -1077,7 +1077,7 @@ func TestTokensCmd_TextOutputWithRecommendations(t *testing.T) {
 		"Of the total, subagents used",
 		"Context pressure: 85% of 10k tokens",
 		"Recommendations",
-		"Scope subagent tasks tightly",
+		"Subagents used ",
 		"Context pressure is 85% of the window",
 		// long-session is low severity, so the two-line display cap trims it
 		// behind the medium-severity lines above. Asserted in
@@ -1706,7 +1706,7 @@ func TestTokensCmd_PrioritizesContextReplayHotspot(t *testing.T) {
 	out := stdout.String()
 	checks := []string{
 		"Recommendations",
-		"Large context was replayed across 70 API calls",
+		"70 API calls at about ",
 		"Token usage",
 		"Total:  6.2M tokens",
 		"Cache read: 6.1M",
@@ -1905,7 +1905,7 @@ func TestCheckpointTokensCmd_TextOutputWithRealCheckpointShape(t *testing.T) {
 		"Agent:      Claude Code",
 		"Branch:     e2e-triage-fix",
 		"Recommendations",
-		"Large context was replayed across 70 API calls",
+		"70 API calls at about ",
 		"Token usage",
 		"Total:  6.2M tokens",
 		"Cache read: 6.1M",
@@ -3724,5 +3724,88 @@ func TestRecommendationSignalsBuilderIsTheOnlyPath(t *testing.T) {
 		if strings.Contains(string(src), "recommendationRules(tokenRecommendationSignals{") {
 			t.Errorf("%s builds a raw signals literal, bypassing the builder", f)
 		}
+	}
+}
+
+// TestRecommendationsQuoteFiguresFromTheRowsAbove is the bar this PR exists to
+// meet: a recommendation names a contributor and every number it cites appears
+// in a row the reader can find, formatted by the same helper that row uses.
+// Recomputing a percentage is the failure mode — the classes block prints an
+// int percent with a "<1%" case, so a float recomputation renders "87.6%"
+// under a row that says "88%".
+func TestRecommendationsQuoteFiguresFromTheRowsAbove(t *testing.T) {
+	t.Parallel()
+
+	tokens := &sessionTokensUsage{
+		Total:         286_344_584,
+		CacheRead:     269_400_000,
+		Output:        1_000_000,
+		APICalls:      509,
+		SubagentTotal: 29_099_852,
+	}
+	classes := &tokenClassBreakdown{
+		CacheRead: tokenClassShare{Tokens: 269_400_000, VolumePercent: 94},
+		Output:    tokenClassShare{Tokens: 1_000_000, VolumePercent: 1},
+		Total:     286_344_584,
+	}
+
+	recs := recommendationRules(sessionTokenRecommendationSignals(tokens, classes, nil, 0, 0))
+
+	byID := map[string]string{}
+	for _, rec := range recs {
+		byID[rec.ID] = rec.Message
+	}
+
+	apiCall, ok := byID[recAPICallAmplification]
+	if !ok {
+		t.Fatalf("expected api-call-amplification, got %+v", recs)
+	}
+	// Every figure must be one the usage line prints: the call count, the
+	// per-call average (total/calls, which is what "Per call" shows), and the
+	// cache-read class total. Dividing cache read by the call count reads
+	// plausibly but appears in no row.
+	for _, want := range []string{
+		"509",
+		formatTokenCount(286_344_584 / 509),
+		formatTokenCount(269_400_000),
+	} {
+		if !strings.Contains(apiCall, want) {
+			t.Errorf("api-call message must quote %q, got %q", want, apiCall)
+		}
+	}
+	if strings.Contains(apiCall, formatTokenCount(269_400_000/509)) {
+		t.Errorf("api-call message cites a per-call replay figure that no row prints: %q", apiCall)
+	}
+
+	subagent, ok := byID[recSubagentHeavy]
+	if !ok {
+		t.Fatalf("expected subagent-heavy, got %+v", recs)
+	}
+	// The share must be the row's own, via the row's formatter.
+	wantShare := formatSharePercent(29_099_852, roundedPercent(29_099_852, classes.Total))
+	for _, want := range []string{formatTokenCount(29_099_852), formatTokenCount(286_344_584), wantShare} {
+		if !strings.Contains(subagent, want) {
+			t.Errorf("subagent message must quote %q, got %q", want, subagent)
+		}
+	}
+}
+
+// TestUsageLineCarriesPerCall pins the row that makes the API-call
+// recommendation citable. Without it the message quotes a quotient that
+// appears nowhere.
+func TestUsageLineCarriesPerCall(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	writeTokenUsageSection(&out, &sessionTokensUsage{Total: 1_000_000, CacheRead: 900_000, APICalls: 50})
+	if !strings.Contains(out.String(), "Per call: "+formatTokenCount(1_000_000/50)) {
+		t.Errorf("expected a per-call figure in the usage line, got:\n%s", out.String())
+	}
+
+	// No calls recorded means no quotient to print.
+	out.Reset()
+	writeTokenUsageSection(&out, &sessionTokensUsage{Total: 1000, APICalls: 0})
+	if strings.Contains(out.String(), "Per call") {
+		t.Errorf("expected no per-call figure without API calls, got:\n%s", out.String())
 	}
 }

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -3652,3 +3652,77 @@ func TestTokenRecommendationsNeverTrimAHighSeverityLine(t *testing.T) {
 		}
 	}
 }
+
+// TestRecommendationSignalsCarryTheClassRows pins that the rules can reach the
+// billing-class breakdown PR 1 renders. Without it a recommendation cannot
+// quote a figure the reader can find in a row above it, which is the whole
+// bar for a good recommendation.
+func TestRecommendationSignalsCarryTheClassRows(t *testing.T) {
+	t.Parallel()
+
+	classes := &tokenClassBreakdown{
+		CacheRead: tokenClassShare{Tokens: 9_000_000, VolumePercent: 90},
+		Output:    tokenClassShare{Tokens: 100_000, VolumePercent: 1},
+		Total:     10_000_000,
+		Priced:    true,
+	}
+	signals := tokenRecommendationSignals{
+		Tokens:  &sessionTokensUsage{Total: 10_000_000, CacheRead: 9_000_000, APICalls: 60},
+		Classes: classes,
+	}
+
+	if signals.Tokens == nil || signals.Tokens.CacheRead != 9_000_000 {
+		t.Fatalf("expected the usage totals to reach the rules, got %+v", signals.Tokens)
+	}
+	if signals.Classes.CacheRead.VolumePercent != 90 {
+		t.Fatalf("expected the cache-read row to reach the rules, got %+v", signals.Classes)
+	}
+	// Decision 4: capability is a property of the price family, not the agent.
+	if !signals.Classes.Priced {
+		t.Fatal("expected the priced flag to reach the rules")
+	}
+}
+
+// TestRecommendationSignalsBuilderIsTheOnlyPath pins that both commands build
+// their rule input through one function. Guarding the constructor is what
+// keeps `session tokens` and `checkpoint tokens` from drifting in what they
+// hand the rules; that the call sites actually pass report.Classes is proven
+// end to end by the citation tests, which run through both commands.
+func TestRecommendationSignalsBuilderIsTheOnlyPath(t *testing.T) {
+	t.Parallel()
+
+	classes := &tokenClassBreakdown{
+		CacheRead: tokenClassShare{Tokens: 900, VolumePercent: 90},
+		Total:     1000,
+	}
+	signals := sessionTokenRecommendationSignals(
+		&sessionTokensUsage{Total: 1000, CacheRead: 900, APICalls: 60},
+		classes,
+		&sessionTokensContext{Percent: 50},
+		7, 3,
+	)
+
+	if signals.Classes != classes {
+		t.Error("builder dropped the class breakdown")
+	}
+	if signals.Context == nil || signals.Context.Percent != 50 {
+		t.Error("builder dropped the context row")
+	}
+	if signals.TurnCount != 7 || signals.CheckpointCount != 3 {
+		t.Errorf("builder dropped the counts: %+v", signals)
+	}
+
+	// Both production call sites must go through it.
+	for _, f := range []string{"session_tokens.go", "checkpoint_tokens.go"} {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		if !strings.Contains(string(src), "sessionTokenRecommendationSignals(") {
+			t.Errorf("%s does not build its signals through the shared builder", f)
+		}
+		if strings.Contains(string(src), "recommendationRules(tokenRecommendationSignals{") {
+			t.Errorf("%s builds a raw signals literal, bypassing the builder", f)
+		}
+	}
+}

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -1079,7 +1079,9 @@ func TestTokensCmd_TextOutputWithRecommendations(t *testing.T) {
 		"Recommendations",
 		"Scope subagent tasks tightly",
 		"Context pressure is 85% of the window",
-		"Compact or restart after summarizing the useful findings",
+		// long-session is low severity, so the two-line display cap trims it
+		// behind the medium-severity lines above. Asserted in
+		// TestTokenRecommendationsAreCappedAtTwo.
 	}
 	for _, check := range checks {
 		if !strings.Contains(out, check) {
@@ -3550,4 +3552,103 @@ func TestAgentBriefSurvivesRuleDeletion(t *testing.T) {
 			t.Errorf("expected no next action, got %q", action)
 		}
 	})
+}
+
+// TestTokenRecommendationsAreCappedAtTwo pins the cap and its blast radius.
+// The cap lives at the render layer, never on report.Recommendations: the
+// agent brief picks its next action and builds its signal list from that
+// slice, so truncating it would change what an agent is told as a side effect
+// of a display decision.
+func TestTokenRecommendationsAreCappedAtTwo(t *testing.T) {
+	t.Parallel()
+
+	// Four rules fire at once: api-call-amplification and subagent-heavy
+	// (medium), high-context-pressure (medium), long-session (low).
+	tokens := &sessionTokensUsage{
+		Total:         10_000_000,
+		CacheRead:     9_000_000,
+		Output:        100_000,
+		APICalls:      60,
+		SubagentTotal: 2_000_000,
+	}
+	signals := tokenRecommendationSignals{
+		Tokens:    tokens,
+		Context:   &sessionTokensContext{Tokens: 90, WindowSize: 100, Percent: 90},
+		TurnCount: 40,
+	}
+	recs := recommendationRules(signals)
+	if len(recs) < 3 {
+		t.Fatalf("fixture should fire at least three rules, got %+v", recs)
+	}
+
+	var out bytes.Buffer
+	writeTokenRecommendations(&out, recs, tokenRecommendationDisplayLimit)
+
+	printed := 0
+	for _, line := range strings.Split(out.String(), "\n") {
+		if strings.HasPrefix(line, "- ") {
+			printed++
+		}
+	}
+	if printed != 2 {
+		t.Errorf("expected 2 rendered recommendations, got %d:\n%s", printed, out.String())
+	}
+
+	// Severity first: a low-severity rule must not displace a medium one.
+	if strings.Contains(out.String(), "Compact or restart") {
+		t.Errorf("low-severity long-session displaced a medium rule:\n%s", out.String())
+	}
+
+	// The brief still sees every rule.
+	report := sessionTokensReport{SessionID: "capped", Tokens: tokens, Recommendations: recs}
+	if got := len(agentBriefSignals(report)); got < 3 {
+		t.Errorf("cap leaked into the agent brief: %d signals, want all of them", got)
+	}
+}
+
+// TestTokenRecommendationsSectionIsSilentWhenEmpty pins that a normal session
+// renders no section at all, which the spec calls the correct output.
+func TestTokenRecommendationsSectionIsSilentWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	tokens := &sessionTokensUsage{Total: 50_000, CacheWrite: 6_000, Output: 3_500, APICalls: 4}
+	recs := recommendationRules(tokenRecommendationSignals{Tokens: tokens})
+	if len(recs) != 0 {
+		t.Fatalf("expected an unremarkable session to fire nothing, got %+v", recs)
+	}
+
+	var out bytes.Buffer
+	writeSessionTokensText(&out, sessionTokensReport{SessionID: "quiet", Tokens: tokens, Recommendations: recs})
+	if strings.Contains(out.String(), "Recommendations") {
+		t.Errorf("expected no Recommendations section, got:\n%s", out.String())
+	}
+}
+
+// TestTokenRecommendationsNeverTrimAHighSeverityLine pins that the display
+// limit removes noise, not findings: three high-severity recommendations all
+// render even though the limit is two.
+func TestTokenRecommendationsNeverTrimAHighSeverityLine(t *testing.T) {
+	t.Parallel()
+
+	recs := []sessionTokensRecommendation{
+		{ID: "a", Severity: "high", Message: "high one"},
+		{ID: "b", Severity: "high", Message: "high two"},
+		{ID: "c", Severity: "high", Message: "high three"},
+		{ID: "d", Severity: "medium", Message: "medium one"},
+		{ID: "e", Severity: "low", Message: "low one"},
+	}
+
+	var out bytes.Buffer
+	writeTokenRecommendations(&out, recs, tokenRecommendationDisplayLimit)
+
+	for _, want := range []string{"high one", "high two", "high three"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("expected %q to survive the cap, got:\n%s", want, out.String())
+		}
+	}
+	for _, notWant := range []string{"medium one", "low one"} {
+		if strings.Contains(out.String(), notWant) {
+			t.Errorf("expected %q to be trimmed, got:\n%s", notWant, out.String())
+		}
+	}
 }

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -1116,34 +1116,6 @@ func TestRecommendationRulesSubagentHeavyAvoidsOverflow(t *testing.T) {
 	t.Fatalf("expected subagent-heavy recommendation, got %+v", recs)
 }
 
-func TestRecommendationRulesCacheReplayUsesTopLevelTokenTotal(t *testing.T) {
-	t.Parallel()
-
-	recs := recommendationRules(tokenRecommendationSignals{
-		Tokens: &sessionTokensUsage{
-			Total:         10000,
-			Input:         100,
-			CacheRead:     800,
-			CacheWrite:    50,
-			Output:        50,
-			APICalls:      20,
-			SubagentTotal: 9000,
-		},
-	})
-
-	var ids []string
-	for _, rec := range recs {
-		ids = append(ids, rec.ID)
-	}
-
-	expected := []string{"context-replay-hotspot", "summarize-before-boundary"}
-	for _, id := range expected {
-		if !slices.Contains(ids, id) {
-			t.Fatalf("expected %s recommendation in %+v", id, recs)
-		}
-	}
-}
-
 func TestRecommendationThresholdsDocumentCurrentHeuristics(t *testing.T) {
 	t.Parallel()
 
@@ -1288,52 +1260,6 @@ func reportHasSessionRecommendation(report sessionTokensReport, id string) bool 
 	return false
 }
 
-func TestRecommendationRules_CacheWritePressure(t *testing.T) {
-	t.Parallel()
-
-	recs := recommendationRules(tokenRecommendationSignals{
-		Tokens: &sessionTokensUsage{
-			Total:      50_000,
-			CacheWrite: 6_000,
-		},
-	})
-
-	if !recommendationsIncludeID(recs, "cache-write-pressure") {
-		t.Fatalf("expected cache-write-pressure recommendation, got %+v", recs)
-	}
-}
-
-func TestRecommendationRules_OutputPressure(t *testing.T) {
-	t.Parallel()
-
-	recs := recommendationRules(tokenRecommendationSignals{
-		Tokens: &sessionTokensUsage{
-			Total:  100_000,
-			Output: 3_500,
-		},
-	})
-
-	if !recommendationsIncludeID(recs, "output-pressure") {
-		t.Fatalf("expected output-pressure recommendation, got %+v", recs)
-	}
-}
-
-func TestRecommendationRules_OutputPressureWithLargeCacheReplay(t *testing.T) {
-	t.Parallel()
-
-	recs := recommendationRules(tokenRecommendationSignals{
-		Tokens: &sessionTokensUsage{
-			Total:     10_000_000,
-			CacheRead: 9_800_000,
-			Output:    100_000,
-		},
-	})
-
-	if !recommendationsIncludeID(recs, "output-pressure") {
-		t.Fatalf("expected output-pressure recommendation for high absolute output, got %+v", recs)
-	}
-}
-
 func recommendationsIncludeID(recs []sessionTokensRecommendation, id string) bool {
 	for _, rec := range recs {
 		if rec.ID == id {
@@ -1382,8 +1308,6 @@ func TestTokensCmd_AgentBriefPrioritizesNextAction(t *testing.T) {
 		"Signals:",
 		"- Cache/context replay dominates token volume.",
 		"- API call count is high for one session.",
-		"- Cache write/new context pressure is elevated.",
-		"- Output pressure is elevated.",
 	}
 	for _, check := range checks {
 		if !strings.Contains(out, check) {
@@ -1564,12 +1488,7 @@ func TestSessionTokensAgentBriefClassAwareCostProxy(t *testing.T) {
 	checks := []string{
 		"Session token brief",
 		"Session: test-cost-proxy-brief",
-		"Use at most 3 batched reads",
-		"Avoid broad grep, broad diffs, broad tests",
-		"otherwise answer now",
-		"keep the answer tight",
-		"- Cache write/new context pressure is elevated.",
-		"- Output pressure is elevated.",
+		"No high-signal token risk detected from captured usage.",
 	}
 	for _, check := range checks {
 		if !strings.Contains(out, check) {
@@ -1600,12 +1519,7 @@ func TestCheckpointTokensAgentBriefClassAwareCostProxy(t *testing.T) {
 	checks := []string{
 		"Checkpoint token brief",
 		"Checkpoint: c05e500cafe0",
-		"Use at most 3 batched reads",
-		"Avoid broad grep, broad diffs, broad tests",
-		"otherwise answer now",
-		"keep the answer tight",
-		"- Cache write/new context pressure is elevated.",
-		"- Output pressure is elevated.",
+		"No high-signal token risk detected from captured usage.",
 	}
 	for _, check := range checks {
 		if !strings.Contains(out, check) {
@@ -1634,12 +1548,9 @@ func TestCheckpointTokensAgentBriefCombinesOutputAndReplayPressure(t *testing.T)
 
 	out := stdout.String()
 	checks := []string{
-		"Use at most 3 batched reads",
-		"Avoid broad grep, broad diffs, broad tests",
-		"keep the answer tight",
+		"Use at most 3 batched reads before answering.",
 		"- Cache/context replay dominates token volume.",
 		"- API call count is high for one session.",
-		"- Output pressure is elevated.",
 	}
 	for _, check := range checks {
 		if !strings.Contains(out, check) {
@@ -1793,9 +1704,7 @@ func TestTokensCmd_PrioritizesContextReplayHotspot(t *testing.T) {
 	out := stdout.String()
 	checks := []string{
 		"Recommendations",
-		"Cache/context replay is 97.4% of token volume",
 		"Large context was replayed across 70 API calls",
-		"Compact or restart after summarizing this investigation",
 		"Token usage",
 		"Total:  6.2M tokens",
 		"Cache read: 6.1M",
@@ -1994,7 +1903,6 @@ func TestCheckpointTokensCmd_TextOutputWithRealCheckpointShape(t *testing.T) {
 		"Agent:      Claude Code",
 		"Branch:     e2e-triage-fix",
 		"Recommendations",
-		"Cache/context replay is 97.4% of token volume",
 		"Large context was replayed across 70 API calls",
 		"Token usage",
 		"Total:  6.2M tokens",
@@ -2169,8 +2077,6 @@ func TestCheckpointTokensCmd_AgentBriefGivesOperationalBudget(t *testing.T) {
 		"Signals:",
 		"- Cache/context replay dominates token volume.",
 		"- API call count is high for one session.",
-		"- Cache write/new context pressure is elevated.",
-		"- Output pressure is elevated.",
 	}
 	for _, check := range checks {
 		if !strings.Contains(out, check) {
@@ -3508,4 +3414,140 @@ func TestTokensCmd_PrefersTheCallersSession(t *testing.T) {
 	if strings.Contains(out, "test-tokens-decoy") {
 		t.Fatalf("expected the more recent decoy session to be ignored, got:\n%s", out)
 	}
+}
+
+// TestRecommendationRules_NoiseRulesAreGone pins the three rules deleted in
+// PR 5a. Each fired on a clear majority of real checkpoints, so it described
+// the baseline rather than a finding: measured over 135 distinct committed
+// checkpoints, context-replay-hotspot 91%, output-pressure 39%,
+// cache-write-pressure 31%. summarize-before-boundary goes with the hotspot
+// because its condition requires it.
+func TestRecommendationRules_NoiseRulesAreGone(t *testing.T) {
+	t.Parallel()
+
+	// A session that fires every one of them under the old rules: cache read
+	// dominant, output and cache write both over their absolute gates, and
+	// enough calls for the boundary rule.
+	recs := recommendationRules(tokenRecommendationSignals{
+		Tokens: &sessionTokensUsage{
+			Total:      1_000_000,
+			CacheRead:  900_000,
+			CacheWrite: 60_000,
+			Output:     20_000,
+			APICalls:   50,
+		},
+	})
+
+	for _, id := range []string{
+		"context-replay-hotspot",
+		"cache-write-pressure",
+		"output-pressure",
+		"summarize-before-boundary",
+	} {
+		if recommendationsIncludeID(recs, id) {
+			t.Errorf("rule %q should have been deleted, still fires: %+v", id, recs)
+		}
+	}
+
+	// The surviving rule still fires on the same input, and its message must
+	// carry the replay framing that cacheReadHotspot gates — deleting the
+	// recommendation must not delete the qualifier.
+	if !recommendationsIncludeID(recs, "api-call-amplification") {
+		t.Fatalf("api-call-amplification should still fire, got %+v", recs)
+	}
+}
+
+func TestCacheReadHotspotUsesTopLevelTokenTotal(t *testing.T) {
+	t.Parallel()
+
+	// context-replay-hotspot was deleted in PR 5a, but the invariant it pinned
+	// outlives it: the share is measured against the top-level total, not one
+	// inflated by nested subagent tokens. Against the raw Total this session
+	// reads as 8% cache read; against the top-level total it is 80%.
+	tokens := &sessionTokensUsage{
+		Total:         10000,
+		Input:         100,
+		CacheRead:     800,
+		CacheWrite:    50,
+		Output:        50,
+		APICalls:      20,
+		SubagentTotal: 9000,
+	}
+
+	if !cacheReadHotspot(tokens) {
+		t.Fatalf("expected cache read to dominate the top-level total, got %d of %d",
+			tokens.CacheRead, topLevelSessionTokenTotal(tokens))
+	}
+}
+
+// TestAgentBriefSurvivesRuleDeletion pins the two ways deleting the three
+// noisy rules changes the agent brief. Both are deliberate; neither is
+// asserted anywhere else, and without these a later edit could reverse them
+// silently, because hasTokenRecommendation matches by string and a stale
+// reference just goes false instead of failing the build.
+func TestAgentBriefSurvivesRuleDeletion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("replay still drives the next action without its recommendation", func(t *testing.T) {
+		t.Parallel()
+
+		// Replay dominates but the call count is below the api-call gate. This
+		// is the ~61% case: before PR 5a the context-replay-hotspot arm answered
+		// it. That recommendation is gone, so the arm now keys on the usage
+		// itself — an agent must not lose its instruction because a printed
+		// line was removed.
+		tokens := &sessionTokensUsage{
+			Total:     10_000_000,
+			CacheRead: 9_800_000,
+			Output:    100_000,
+			APICalls:  5,
+		}
+		report := sessionTokensReport{
+			SessionID:       "replay-without-calls",
+			Tokens:          tokens,
+			Recommendations: recommendationRules(tokenRecommendationSignals{Tokens: tokens}),
+		}
+
+		if recommendationsIncludeID(report.Recommendations, "context-replay-hotspot") {
+			t.Fatalf("context-replay-hotspot should not be a recommendation: %+v", report.Recommendations)
+		}
+
+		action, ok := agentBriefOptimizationAction(report)
+		if !ok {
+			t.Fatal("expected a next action for a replay-dominated session")
+		}
+		if !strings.Contains(action, "Avoid broad grep") {
+			t.Errorf("expected the replay action, got %q", action)
+		}
+		if !slices.Contains(agentBriefSignals(report), "Cache/context replay dominates token volume.") {
+			t.Errorf("expected the replay signal, got %v", agentBriefSignals(report))
+		}
+	})
+
+	t.Run("an unremarkable session now yields no action at all", func(t *testing.T) {
+		t.Parallel()
+
+		// 50k total, 6k cache write, 3.5k output, 4 calls. This used to be told
+		// "use at most 3 batched reads" by the cache-write arm — advice from a
+		// rule that fired on 31% of real checkpoints. Silence is the fix, not a
+		// regression.
+		tokens := &sessionTokensUsage{
+			Total:      50_000,
+			CacheWrite: 6_000,
+			Output:     3_500,
+			APICalls:   4,
+		}
+		report := sessionTokensReport{
+			SessionID:       "unremarkable",
+			Tokens:          tokens,
+			Recommendations: recommendationRules(tokenRecommendationSignals{Tokens: tokens}),
+		}
+
+		if len(report.Recommendations) != 0 {
+			t.Errorf("expected no recommendations, got %+v", report.Recommendations)
+		}
+		if action, ok := agentBriefOptimizationAction(report); ok {
+			t.Errorf("expected no next action, got %q", action)
+		}
+	})
 }

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -42,8 +42,8 @@ type tokensProfileSignalDefinition struct {
 
 var tokensProfileSignalDefinitions = []tokensProfileSignalDefinition{
 	{id: profileSignalReplayHotspot, label: "Cache/context replay hotspot"},
-	{id: "api-call-amplification", label: "API call amplification"},
-	{id: "subagent-heavy", label: "Subagent-heavy sessions"},
+	{id: profileSignalAPICallAmplify, label: "API call amplification"},
+	{id: profileSignalSubagentHeavy, label: "Subagent-heavy sessions"},
 	{id: "missing-token-data", label: "Missing token data"},
 }
 
@@ -56,7 +56,11 @@ const tokensProfileUsageScopeCheckpointObserved = "checkpoint_observed"
 // someone who sees a matching string. `tokens profile`'s thresholds (its
 // api-call signal still fires at >= 20, where the shared rules now use >= 40)
 // are PR 6's to revisit.
-const profileSignalReplayHotspot = "context-replay-hotspot"
+const (
+	profileSignalReplayHotspot  = "context-replay-hotspot"
+	profileSignalAPICallAmplify = "api-call-amplification"
+	profileSignalSubagentHeavy  = "subagent-heavy"
+)
 
 func newTokensGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -234,10 +238,10 @@ func addTokensProfileTokenSignals(signals map[string]*tokensProfileSignal, check
 		addTokensProfileSignal(signals, profileSignalReplayHotspot, checkpointID, denominator)
 	}
 	if tokens.APICalls >= 20 {
-		addTokensProfileSignal(signals, "api-call-amplification", checkpointID, denominator)
+		addTokensProfileSignal(signals, profileSignalAPICallAmplify, checkpointID, denominator)
 	}
 	if tokenShareAtLeastOneTenth(tokens.SubagentTotal, tokens.Total) {
-		addTokensProfileSignal(signals, "subagent-heavy", checkpointID, denominator)
+		addTokensProfileSignal(signals, profileSignalSubagentHeavy, checkpointID, denominator)
 	}
 }
 
@@ -292,7 +296,7 @@ func tokensProfileRecommendations(report tokensProfileReport) []sessionTokensRec
 	}
 
 	if tokensProfileSignalCount(report.Signals, profileSignalReplayHotspot) > 0 ||
-		tokensProfileSignalCount(report.Signals, "api-call-amplification") > 0 {
+		tokensProfileSignalCount(report.Signals, profileSignalAPICallAmplify) > 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "search-before-reinvestigation",
 			Severity: "high",
@@ -300,7 +304,7 @@ func tokensProfileRecommendations(report tokensProfileReport) []sessionTokensRec
 			Signals:  []string{"cache_read_tokens", "api_call_count"},
 		})
 	}
-	if tokensProfileSignalCount(report.Signals, "api-call-amplification") > 0 {
+	if tokensProfileSignalCount(report.Signals, profileSignalAPICallAmplify) > 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "batch-diagnostics",
 			Severity: "medium",
@@ -316,7 +320,7 @@ func tokensProfileRecommendations(report tokensProfileReport) []sessionTokensRec
 			Signals:  []string{"cache_read_tokens"},
 		})
 	}
-	if tokensProfileSignalCount(report.Signals, "subagent-heavy") > 0 {
+	if tokensProfileSignalCount(report.Signals, profileSignalSubagentHeavy) > 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "scope-subagents",
 			Severity: "medium",

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -391,7 +391,7 @@ func writeTokensProfileText(w io.Writer, report tokensProfileReport) {
 	writeTokenUsageSectionWithTitle(w, "Checkpoint-observed token usage", report.Tokens)
 	writeTokensProfileSignals(w, report.Signals)
 	if len(report.Recommendations) > 0 {
-		writeTokenRecommendations(w, report.Recommendations)
+		writeTokenRecommendations(w, report.Recommendations, tokenRecommendationNoLimit)
 	}
 	writeTokenLimitations(w, report.Limitations)
 }

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -41,13 +41,22 @@ type tokensProfileSignalDefinition struct {
 }
 
 var tokensProfileSignalDefinitions = []tokensProfileSignalDefinition{
-	{id: "context-replay-hotspot", label: "Cache/context replay hotspot"},
+	{id: profileSignalReplayHotspot, label: "Cache/context replay hotspot"},
 	{id: "api-call-amplification", label: "API call amplification"},
 	{id: "subagent-heavy", label: "Subagent-heavy sessions"},
 	{id: "missing-token-data", label: "Missing token data"},
 }
 
 const tokensProfileUsageScopeCheckpointObserved = "checkpoint_observed"
+
+// profileSignalReplayHotspot is `tokens profile`'s OWN signal id. It is
+// deliberately not the recommendation rule of the same spelling, which PR 5a
+// deleted: this one counts recurrence across checkpoints through independent
+// machinery. Naming it separately keeps the two from being "unified" later by
+// someone who sees a matching string. `tokens profile`'s thresholds (its
+// api-call signal still fires at >= 20, where the shared rules now use >= 40)
+// are PR 6's to revisit.
+const profileSignalReplayHotspot = "context-replay-hotspot"
 
 func newTokensGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -222,7 +231,7 @@ func addTokensProfileTokenSignals(signals map[string]*tokensProfileSignal, check
 	}
 	topLevelTotal := topLevelSessionTokenTotal(tokens)
 	if topLevelTotal > 0 && tokenPercent(tokens.CacheRead, topLevelTotal) >= recommendationHighCacheReadPercent {
-		addTokensProfileSignal(signals, "context-replay-hotspot", checkpointID, denominator)
+		addTokensProfileSignal(signals, profileSignalReplayHotspot, checkpointID, denominator)
 	}
 	if tokens.APICalls >= 20 {
 		addTokensProfileSignal(signals, "api-call-amplification", checkpointID, denominator)
@@ -282,7 +291,7 @@ func tokensProfileRecommendations(report tokensProfileReport) []sessionTokensRec
 		}}
 	}
 
-	if tokensProfileSignalCount(report.Signals, "context-replay-hotspot") > 0 ||
+	if tokensProfileSignalCount(report.Signals, profileSignalReplayHotspot) > 0 ||
 		tokensProfileSignalCount(report.Signals, "api-call-amplification") > 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "search-before-reinvestigation",
@@ -299,7 +308,7 @@ func tokensProfileRecommendations(report tokensProfileReport) []sessionTokensRec
 			Signals:  []string{"api_call_count"},
 		})
 	}
-	if tokensProfileSignalCount(report.Signals, "context-replay-hotspot") > 0 {
+	if tokensProfileSignalCount(report.Signals, profileSignalReplayHotspot) > 0 {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "preserve-then-compact",
 			Severity: "medium",


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1317
<!-- entire-trail-link-end -->

Task 1–4 of `docs/superpowers/plans/2026-09-11-pr5-recommendations-v2.md`.

**This PR: +616/-222. Cumulative across the stack (PR1+PR2+this vs `main`): +63158/-13182.**

## What changed

`entire checkpoint tokens` on a real 286.3M-token checkpoint printed **seven** recommendations, two of which said the same thing and none of which named a number a reader could find. It now prints two:

```
Token usage
Total:  286.3M tokens
  Input: 110.2k | Cache read: 269.4M | Cache write: 16M | Output: 824.2k | API calls: 509 | Per call: 562.6k

How it was billed
  ...
  Of the total, subagents used        29.1M      10%

Recommendations
- 509 API calls at about 562.6k each, of which 269.4M was replayed cached context.
  Batch the next diagnosis: each further call replays the context again.
- Subagents used 29.1M of 286.3M tokens (10%). Give each a narrower objective and expected output.
```

Every figure traces to a row above it.

## Why these rules

Measured over **135 distinct committed checkpoints** (a sweep of three clones, rule conditions re-derived from source and cross-checked against the IDs the binary emitted):

| rule | fired on | |
|---|---|---|
| `context-replay-hotspot` | **91%** | deleted |
| `output-pressure` | 39% | deleted |
| `cache-write-pressure` | 31% | deleted |
| `summarize-before-boundary` | 30% | deleted (needs the hotspot) |

A rule firing on most sessions describes the baseline. The spec says so for the first: cache read is the largest class in ~90% of checkpoints (96% here), and no threshold rescues it — at a 97% share it still fires on 62%.

Checkpoints printing **nothing: 0% → 75%**. Printing three or more: **35% → 0%**.

The spec's own figures for the two rules it names are 64%/65% over 4,442 checkpoints; this corpus gives 39%/31%. Different corpus, same conclusion — cite the measured number, not mine, if you re-run it.

## Deliberate decisions a reviewer should check

- **`cacheReadHotspot` survives as a qualifier, not a recommendation.** It still selects the API-call message's replay wording.
- **The agent brief's replay arm now keys on usage, not the deleted rule.** On the ~61% of checkpoints where replay dominates but the call count doesn't, deleting the rule would otherwise have silently changed an agent's next action to "no high-signal risk detected". Pinned by `TestAgentBriefSurvivesRuleDeletion`.
- **The cap is at the render layer, never on `report.Recommendations`** — the brief picks its action and builds its signals from that slice. `--json` keeps the full list.
- **A high-severity line is never trimmed.** The limit applies only below the last high one.
- **`tokens profile` is untouched** (passes no limit). Its rules count recurrence across checkpoints, it aggregates many agents, and one of its rules always prints. Its own `api-call-amplification` signal still fires at ≥20 where these now use ≥40 — that divergence is **PR 6's**, and is called out in the code.
- **Rule IDs are typed constants.** `hasTokenRecommendation` matches by string, so a deletion compiles clean and stale references go silently false.

## Behaviour changes worth disagreeing with

1. A 50k session with 6k cache write and 4 API calls used to be told *"use at most 3 batched reads and avoid broad new context"*. It now says nothing. That advice came from a rule firing on 31% of real checkpoints.
2. `TestSessionTokens_SubagentFigureAppearsOnlyOnce` counted occurrences of `"ubagents"` and carried a "do not fix this" comment. Its premise — that the advice line says "subagent" singular — expired here: a recommendation citing a row necessarily repeats its number. It now counts the row itself, so the double-count it guarded is still caught.

## Two mistakes caught by running the command, not the suite

- The message first divided cache read by the call count. That reads as replay-per-call and appears in **no row** — the usage line's `Per call` is total over calls. The test asserted the wrong number and passed. It now asserts that figure is absent.
- *"each extra call costs another full replay"* cited an average to describe the marginal call, which is larger in a growing session.

## Not in this PR

- **Recalibrating the surviving thresholds and the unpriced-report fallback** (plan Decisions 5, 6). The corpus is 124 Claude Code, 10 Codex, 1 Pi and **zero Gemini or OpenCode** — the agents the spec says differ most. Doing per-agent gating on that data would be guessing.
- **Add-to-memory** — spec Open Decision 3 ("print-the-line or Entire writes it") is unconfirmed.
- **`tokens profile`** — dated conflict resolved in the spec on 2026-09-11: it belongs to PR 6.

## Stack

`main` → `tokens` (#2155) → `pr1-token-class-breakdown` (#2210) → `pr2-session-tokens-block` (#2269) → **this**. Retarget to `main` once the stack lands. Spec Rule 4 (off `main`, not stacked) is deviated from because this edits the same functions #2210 and #2269 rewrote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible CLI guidance and agent-brief next actions for session/checkpoint token reports; logic is well-tested but alters when optimization advice appears (many sessions now print nothing).
> 
> **Overview**
> **Token recommendations v2** trims noise from `session tokens` and `checkpoint tokens` while making the advice that remains traceable to printed numbers.
> 
> **Rules removed** as baseline noise (e.g. `context-replay-hotspot` on ~91% of checkpoints): `context-replay-hotspot`, `cache-write-pressure`, `output-pressure`, and `summarize-before-boundary`. **`cacheReadHotspot`** stays as a non-printed qualifier for API-call wording and agent-brief logic so deleting a line does not silently change next actions.
> 
> **Surviving messages** cite rows above them: API-call advice uses call count, **Per call** (new on the usage line), and cache-read total; subagent-heavy quotes token totals and share via the same formatters as the billed block. **`sessionTokenRecommendationSignals`** unifies rule input for both commands and passes **`Classes`**. Recommendation IDs are **named constants** (`recNoTokenData`, etc.).
> 
> **Display** shows at most **two** recommendations (severity-sorted; all **high** kept), only in text rendering—**`report.Recommendations`**, **`--json`**, and the agent brief still see the full set. **`tokens profile`** keeps unlimited recommendations and a separate **`profileSignalReplayHotspot`** id.
> 
> Tests lock in cap behavior, citation invariants, brief behavior after rule deletion, and removed rules staying gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3592887b0eb385afafc6039dadaba90d17ed23ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->