### PR TITLE
fix(checkpoint): surface git-refs push queue failures

### DIFF
--- a/cmd/entire/cli/checkpoint/refs_store.go
+++ b/cmd/entire/cli/checkpoint/refs_store.go
@@ -196,29 +196,26 @@ func (s *gitRefsStore) refTip(cid id.CheckpointID, ref *plumbing.Reference) (plu
 	return ref.Hash(), tree, nil
 }
 
-// enqueueForPush records refName in the push-discovery queue, logging (never
-// returning) on failure so the local ref write still succeeds.
+// enqueueForPush records refName in the push-discovery queue.
 //
 // The queue is resolved with the cancellation stripped from ctx. By the time we
 // get here the ref is already written locally, and the queue is the ONLY
-// push-discovery mechanism there is — see the
-// pushQueueFileName doc. A ref that misses the queue is never pushed, and the
-// writers above are idempotent, so a re-run skips it as already-present and
-// never re-enqueues it: it stays local-only forever. Queue resolution is now a
-// context-free metadata read, but stripping cancellation here keeps the whole
-// post-ref bookkeeping boundary explicit and prevents a future queue operation
-// from dropping a write that already happened.
-func (s *gitRefsStore) enqueueForPush(ctx context.Context, refName plumbing.ReferenceName) {
+// push-discovery mechanism there is; see the pushQueueFileName doc. A ref that
+// misses the queue is never pushed, so failure is returned as a partial
+// outcome: the checkpoint remains readable locally,
+// but the caller must not treat it as durably queued for publication. Queue
+// resolution is now a context-free metadata read, but stripping cancellation
+// here keeps the whole post-ref bookkeeping boundary explicit and prevents a
+// future queue operation from dropping a write that already happened.
+func (s *gitRefsStore) enqueueForPush(ctx context.Context, refName plumbing.ReferenceName) error {
 	q, err := PushQueueForRepo(context.WithoutCancel(ctx), s.repo)
 	if err != nil {
-		logging.Warn(ctx, "checkpoint: resolve push queue failed; ref not enqueued",
-			slog.String("ref", refName.String()), slog.String("error", err.Error()))
-		return
+		return fmt.Errorf("resolve push queue: %w", err)
 	}
 	if err := q.Enqueue(refName); err != nil {
-		logging.Warn(ctx, "checkpoint: enqueue checkpoint ref for push failed",
-			slog.String("ref", refName.String()), slog.String("error", err.Error()))
+		return fmt.Errorf("enqueue checkpoint ref: %w", err)
 	}
+	return nil
 }
 
 func (s *gitRefsStore) updateCheckpointRef(
@@ -242,7 +239,9 @@ func (s *gitRefsStore) updateCheckpointRef(
 	if err != nil {
 		return err
 	}
-	s.enqueueForPush(ctx, refName)
+	if err := s.enqueueForPush(ctx, refName); err != nil {
+		return fmt.Errorf("checkpoint ref %s was written locally but could not be queued for push: %w", refName, err)
+	}
 	return nil
 }
 

--- a/cmd/entire/cli/checkpoint/refs_store_test.go
+++ b/cmd/entire/cli/checkpoint/refs_store_test.go
@@ -3,6 +3,8 @@ package checkpoint
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	git "github.com/go-git/go-git/v6"
@@ -11,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitdir"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/redact"
 )
@@ -53,6 +56,43 @@ func TestGitRefsStore_WriteEnqueuesForPush(t *testing.T) {
 	refs, err := q.Drain()
 	require.NoError(t, err)
 	assert.Contains(t, refs, mustRefName(t, cid), "a session write should enqueue its checkpoint ref for push")
+}
+
+func TestGitRefsStore_WriteReportsQueueFailureAfterRefUpdate(t *testing.T) {
+	store := newRefsStore(t)
+	t.Cleanup(gitdir.Reset)
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	refName := mustRefName(t, cid)
+
+	_, commonDir, err := repositoryDirs(store.repo)
+	require.NoError(t, err)
+	queuePath := filepath.Join(commonDir, pushQueueFileName)
+	require.NoError(t, os.Mkdir(queuePath, 0o700))
+
+	writeReq := Session{
+		CheckpointID: cid,
+		SessionID:    "sess-1",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("transcript")),
+		AuthorName:   "Test Author",
+		AuthorEmail:  "test@example.com",
+	}
+	err = store.Write(context.Background(), writeReq)
+	require.ErrorContains(t, err, "written locally but could not be queued for push")
+
+	_, refErr := store.repo.Reference(refName, true)
+	require.NoError(t, refErr, "the surfaced partial failure must retain the local checkpoint ref")
+
+	gitdir.Reset()
+	require.NoError(t, os.Remove(queuePath))
+
+	require.NoError(t, store.Write(context.Background(), writeReq),
+		"a later write after the obstruction clears must restore push discovery")
+	queue, err := PushQueueForRepo(context.Background(), store.repo)
+	require.NoError(t, err)
+	queued, err := queue.Peek()
+	require.NoError(t, err)
+	assert.Contains(t, queued, refName)
 }
 
 func TestGitRefsStore_OnDemandRefFetch(t *testing.T) {
@@ -780,7 +820,7 @@ func TestGitRefsStore_EnqueuesAfterCancellationFollowingCAS(t *testing.T) {
 	require.NoError(t, casUpdateRef(ctx, repoRoot, refName, head.Hash(), plumbing.ZeroHash))
 
 	cancel()
-	store.enqueueForPush(ctx, refName)
+	require.NoError(t, store.enqueueForPush(ctx, refName))
 
 	q, err := PushQueueForRepo(context.Background(), store.repo)
 	require.NoError(t, err)

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitdir"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -802,6 +803,77 @@ func setupCondensableSessionWithTranscript(t *testing.T, sessionID string) (*git
 	state, err := s.loadSessionState(context.Background(), sessionID)
 	require.NoError(t, err)
 	return repo, state
+}
+
+func TestCondenseAndUpdateState_QueueFailurePreservesRetryState(t *testing.T) {
+	t.Setenv("ENTIRE_CHECKPOINTS_PRIMARY", "git-refs")
+
+	repo, state := setupCondensableSessionWithTranscript(t, "2026-09-12-push-queue-retry")
+	t.Cleanup(gitdir.Reset)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	repoRoot := worktree.Filesystem().Root()
+	metadata, err := gitrepo.ResolveWorktreeMetadata(repoRoot)
+	require.NoError(t, err)
+
+	queuePath := filepath.Join(metadata.CommonDir, "entire-checkpoint-push-queue.jsonl")
+	require.NoError(t, os.Mkdir(queuePath, 0o700))
+	t.Cleanup(func() {
+		gitdir.Reset()
+		_ = os.RemoveAll(queuePath)
+	})
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+	checkpointID := id.MustCheckpointID("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	shadowBranchName := getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
+	shadowBranchesToDelete := make(map[string]struct{})
+	originalBaseCommit := state.BaseCommit
+	originalStepCount := state.StepCount
+	originalFilesTouched := append([]string(nil), state.FilesTouched...)
+	originalLastCheckpointID := state.LastCheckpointID
+
+	s := &ManualCommitStrategy{}
+	condensed, skillEvents, signal := s.condenseAndUpdateState(
+		context.Background(), repo, checkpointID, state, head, shadowBranchName,
+		shadowBranchesToDelete, nil, condenseOpts{repoDir: repoRoot},
+	)
+
+	assert.False(t, condensed)
+	assert.Nil(t, skillEvents)
+	assert.Nil(t, signal)
+	assert.Empty(t, shadowBranchesToDelete)
+	assert.Equal(t, originalBaseCommit, state.BaseCommit)
+	assert.Equal(t, originalStepCount, state.StepCount)
+	assert.Equal(t, originalFilesTouched, state.FilesTouched)
+	assert.Equal(t, originalLastCheckpointID, state.LastCheckpointID)
+	assert.False(t, state.PromptWindowResetPending)
+
+	refName, err := checkpoint.RefName(checkpointID)
+	require.NoError(t, err)
+	_, err = repo.Reference(refName, true)
+	require.NoError(t, err, "the locally written checkpoint remains readable")
+
+	gitdir.Reset()
+	require.NoError(t, os.Remove(queuePath))
+
+	condensed, _, _ = s.condenseAndUpdateState(
+		context.Background(), repo, checkpointID, state, head, shadowBranchName,
+		shadowBranchesToDelete, nil, condenseOpts{repoDir: repoRoot},
+	)
+	require.True(t, condensed)
+	assert.Contains(t, shadowBranchesToDelete, shadowBranchName)
+	assert.Zero(t, state.StepCount)
+	assert.Empty(t, state.FilesTouched)
+	assert.Equal(t, checkpointID, state.LastCheckpointID)
+	assert.True(t, state.PromptWindowResetPending)
+
+	queue, err := checkpoint.PushQueueForRepo(context.Background(), repo)
+	require.NoError(t, err)
+	queuedRefs, err := queue.Peek()
+	require.NoError(t, err)
+	assert.Contains(t, queuedRefs, refName)
 }
 
 // checkpointTaskFile reads one file from a committed checkpoint's

--- a/docs/architecture/checkpoint-scenarios.md
+++ b/docs/architecture/checkpoint-scenarios.md
@@ -532,8 +532,12 @@ sequenceDiagram
     Note over G: PostCommit hook
     G->>SB: Read accumulated shadow state
     G->>R: Commit checkpoint subtree at refs/.../<shard>/<id>
-    G->>PQ: Enqueue the ref (best-effort)
-    G->>SB: Delete shadow branch
+    G->>PQ: Enqueue the ref
+    alt enqueue succeeds
+        G->>SB: Delete shadow branch
+    else enqueue fails after local ref update
+        G-->>U: Report partial failure; preserve retryable session state
+    end
 
     Note over U: Later...
     U->>G: git push
@@ -550,7 +554,7 @@ sequenceDiagram
 
 ### Key Points
 - Condensation writes one commit per checkpoint under `refs/entire/checkpoints/<shard>/<id>`; there is no shared branch tip to serialize on.
-- Enqueue is best-effort — a checkpoint that lands locally but fails to enqueue is still correct locally and re-enqueues on its next write.
+- A queue failure after the ref update is reported as a partial failure: the checkpoint remains correct and readable locally, retryable session state is preserved, and the next write to that checkpoint re-enqueues it.
 - Pushes are never forced; a diverged ref is recovered by fetch + replay so the remote commit is preserved as an ancestor.
 - Failed or interrupted pushes leave refs queued for the next pre-push — the queue degrades toward "will retry", never toward silent loss.
 - Reads route by ID kind across both backends, so a repo mid-migration reads hex (branch) and ULID (refs) checkpoints transparently.

--- a/docs/architecture/ref-checkpoint-backend.md
+++ b/docs/architecture/ref-checkpoint-backend.md
@@ -74,7 +74,7 @@ Every persistent write (`WriteSession`, and the `Backfill*` operations for trans
 3. **Create a commit** with the current tip as parent (orphan on first write, parented thereafter), so each checkpoint accretes its **own per-checkpoint history**.
 4. **Point the ref at the new commit** (`setRef`) and **enqueue it for push**.
 
-Enqueue is best-effort: a write that lands locally but fails to enqueue must not fail condensation. The ref is still local and correct; only its remote sync is deferred until the next write to the same checkpoint re-enqueues it (see the push queue below).
+Enqueue is required for a successful write result because the queue is the only local source of refs for pre-push. If a ref update succeeds but enqueue fails, the store reports an explicit partial failure. The ref remains local and correct, condensation retains its retryable session state, and a later write to the same checkpoint re-enqueues the ref (see the push queue below).
 
 ## Push and fetch
 


### PR DESCRIPTION
## Summary

- return an explicit partial failure when a git-refs checkpoint is written locally but cannot be added to the push queue
- preserve the local ref and retryable condensation state, then re-enqueue on a later write
- add store-level and condensation-level regressions and update the architecture contract

Closes #2393

## Why this approach

The ref update and queue append cannot be one atomic operation. Rolling back a valid local ref would discard recoverable data, while scanning every local checkpoint ref during pre-push would conflict with the queue's purpose and with fetched-ref semantics. This change therefore makes the partial outcome explicit at the store boundary. The existing fail-soft post-commit caller then preserves session and shadow state so the same checkpoint can be retried safely.

I believe this is the smallest complete fix that fits the current architecture. I would appreciate the maintainers' direction on this approach, and I am happy to adjust it or continue the work under your guidance.

## Verification

- `go test ./cmd/entire/cli/checkpoint ./cmd/entire/cli/strategy -run '^(TestGitRefsStore_WriteReportsQueueFailureAfterRefUpdate|TestCondenseAndUpdateState_QueueFailurePreservesRetryState)$' -count=1`
- `go test ./cmd/entire/cli/checkpoint ./cmd/entire/cli/strategy -run '^$' -count=1`
- `golangci-lint run ./cmd/entire/cli/checkpoint/... ./cmd/entire/cli/strategy/...` (0 issues)
- `git diff --check upstream/main..HEAD`

Broader package test runs on this Windows host encounter existing temporary-repository cleanup failures where `.git` remains locked; the focused regressions and package compilation above pass.

## Session metadata

Codex checkpoint capture was not active for this local Windows linked-worktree session, so no genuine checkpoint trailer was available.